### PR TITLE
[rocshmem] gda/mlx5: remove take_turns logic from AMO functions

### DIFF
--- a/projects/rocshmem/src/gda/bnxt/queue_pair_bnxt.cpp
+++ b/projects/rocshmem/src/gda/bnxt/queue_pair_bnxt.cpp
@@ -289,7 +289,7 @@ __device__ void QueuePair::bnxt_write_rma_wqe(uintptr_t raddr, uintptr_t laddr, 
 }
 
 __device__ void QueuePair::bnxt_post_wqe_rma(int32_t length,
-    uintptr_t laddr, uintptr_t raddr, uint8_t opcode, ActiveWFInfo &wf_info) {
+    uintptr_t laddr, uintptr_t raddr, uint8_t opcode, const ActiveWFInfo& wf_info) {
   if (wf_info.is_pe_group_first) {
     lock(&bnxt_sq.lock);
   }
@@ -388,7 +388,7 @@ __device__ uint32_t QueuePair::bnxt_write_amo_wqe(uintptr_t raddr,
 
 __device__ uint64_t QueuePair::bnxt_post_wqe_amo(uintptr_t raddr,
     uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetching,
-    ActiveWFInfo &wf_info) {
+    const ActiveWFInfo& wf_info) {
   uint32_t atomic_idx = 0;
 
     if (wf_info.is_pe_group_first) {

--- a/projects/rocshmem/src/gda/bnxt/queue_pair_bnxt.cpp
+++ b/projects/rocshmem/src/gda/bnxt/queue_pair_bnxt.cpp
@@ -391,7 +391,7 @@ __device__ uint64_t QueuePair::bnxt_post_wqe_amo(uintptr_t raddr,
     const ActiveWFInfo& wf_info) {
   uint32_t atomic_idx = 0;
 
-    if (wf_info.is_pe_group_first) {
+  if (wf_info.is_pe_group_first) {
     lock(&bnxt_sq.lock);
   }
 

--- a/projects/rocshmem/src/gda/context_gda_device.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device.cpp
@@ -160,7 +160,7 @@ __device__ void GDAContext::quiet() {
   internal_quiet(wf_info);
 }
 
-__device__ void GDAContext::internal_quiet(ActiveWFInfo &wf_info) {
+__device__ void GDAContext::internal_quiet(const ActiveWFInfo& wf_info) {
   for (uint32_t i = 0; i < num_qps; i++) {
     qps[i].quiet(wf_info);
   }
@@ -449,7 +449,7 @@ __device__ uint64_t GDAContext::signal_fetch_wave(const uint64_t *sig_addr) {
 
 // internal functions used by collective operations
 __device__ void GDAContext::internal_putmem(void *dest, const void *source, size_t nelems,
-    int pe, int qp_index, ActiveWFInfo &wf_info) {
+    int pe, int qp_index, const ActiveWFInfo& wf_info) {
   int local_pe{-1};
   if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
@@ -462,7 +462,7 @@ __device__ void GDAContext::internal_putmem(void *dest, const void *source, size
 }
 
 __device__ void GDAContext::internal_getmem(void *dest, const void *source, size_t nelems,
-    int pe, int qp_index, ActiveWFInfo &wf_info) {
+    int pe, int qp_index, const ActiveWFInfo& wf_info) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   int local_pe{-1};
   if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
@@ -476,7 +476,7 @@ __device__ void GDAContext::internal_getmem(void *dest, const void *source, size
 }
 
 __device__ void GDAContext::internal_putmem_wg(void *dest, const void *source,
-    size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info) {
+    size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info) {
   int local_pe{-1};
   if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
@@ -491,7 +491,7 @@ __device__ void GDAContext::internal_putmem_wg(void *dest, const void *source,
 }
 
 __device__ void GDAContext::internal_getmem_wg(void *dest, const void *source,
-    size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info) {
+    size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   int local_pe{-1};
   if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
@@ -507,7 +507,7 @@ __device__ void GDAContext::internal_getmem_wg(void *dest, const void *source,
 }
 
 __device__ void GDAContext::internal_putmem_wave(void *dest, const void *source,
-    size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info) {
+    size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info) {
   int local_pe{-1};
   if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
@@ -522,7 +522,7 @@ __device__ void GDAContext::internal_putmem_wave(void *dest, const void *source,
 }
 
 __device__ void GDAContext::internal_getmem_wave(void *dest, const void *source,
-    size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info) {
+    size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   int local_pe{-1};
   if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
@@ -538,7 +538,7 @@ __device__ void GDAContext::internal_getmem_wave(void *dest, const void *source,
 }
 
 __device__ void GDAContext::internal_putmem_nbi(void *dest, const void *source, size_t nelems,
-    int pe, int qp_index, ActiveWFInfo &wf_info) {
+    int pe, int qp_index, const ActiveWFInfo& wf_info) {
   int local_pe{-1};
   if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
@@ -550,7 +550,7 @@ __device__ void GDAContext::internal_putmem_nbi(void *dest, const void *source, 
 }
 
 __device__ void GDAContext::internal_getmem_nbi(void *dest, const void *source, size_t nelems,
-    int pe, int qp_index, ActiveWFInfo &wf_info) {
+    int pe, int qp_index, const ActiveWFInfo& wf_info) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   int local_pe{-1};
   if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
@@ -563,7 +563,7 @@ __device__ void GDAContext::internal_getmem_nbi(void *dest, const void *source, 
 }
 
 __device__ void GDAContext::internal_putmem_nbi_wg(void *dest, const void *source,
-    size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info) {
+    size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info) {
   int local_pe{-1};
   if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
@@ -577,7 +577,7 @@ __device__ void GDAContext::internal_putmem_nbi_wg(void *dest, const void *sourc
 }
 
 __device__ void GDAContext::internal_getmem_nbi_wg(void *dest, const void *source,
-    size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info) {
+    size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   int local_pe{-1};
   if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
@@ -592,7 +592,7 @@ __device__ void GDAContext::internal_getmem_nbi_wg(void *dest, const void *sourc
 }
 
 __device__ void GDAContext::internal_putmem_nbi_wave(void *dest, const void *source,
-    size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info) {
+    size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info) {
   int local_pe{-1};
   if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
@@ -606,7 +606,7 @@ __device__ void GDAContext::internal_putmem_nbi_wave(void *dest, const void *sou
 }
 
 __device__ void GDAContext::internal_getmem_nbi_wave(void *dest, const void *source,
-    size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info) {
+    size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   int local_pe{-1};
   if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -259,11 +259,11 @@ class GDAContext : public Context {
   template <typename T>
   __device__ void internal_put_broadcast(T *dst, const T *src, int nelems,
       int pe_root, int PE_start, int logPE_stride, int PE_size,
-      ActiveWFInfo &wf_info);  // NOLINT(runtime/int)
+      const ActiveWFInfo& wf_info);  // NOLINT(runtime/int)
 
   template <typename T>
   __device__ void internal_get_broadcast(T *dst, const T *src, int nelems,
-      int pe_root, ActiveWFInfo &wf_info);  // NOLINT(runtime/int)
+      int pe_root, const ActiveWFInfo& wf_info);  // NOLINT(runtime/int)
 
   template <typename T>
   __device__ void fcollect_linear(rocshmem_team_t team, T *dest,
@@ -278,87 +278,87 @@ class GDAContext : public Context {
                                               const T *source, int nelems);
 
   __device__ void internal_sync(int pe, int PE_start, int stride, int PE_size,
-      int64_t *pSync, ActiveWFInfo &wf_info);
+      int64_t *pSync, const ActiveWFInfo& wf_info);
 
   __device__ void internal_sync_wave(int pe, int PE_start, int stride,
-      int PE_size, int64_t *pSync, ActiveWFInfo &wf_info);
+      int PE_size, int64_t *pSync, const ActiveWFInfo& wf_info);
 
   __device__ void internal_sync_wg(int pe, int PE_start, int stride,
-    int PE_size, int64_t *pSync, ActiveWFInfo &wf_info);
+    int PE_size, int64_t *pSync, const ActiveWFInfo& wf_info);
 
   __device__ void internal_direct_barrier(int pe, int PE_start, int stride,
-      int n_pes, int64_t *pSync, ActiveWFInfo &wf_info);
+      int n_pes, int64_t *pSync, const ActiveWFInfo& wf_info);
 
   __device__ void internal_direct_barrier_wg(int pe, int PE_start, int stride,
-      int n_pes, int64_t *pSync, ActiveWFInfo &wf_info);
+      int n_pes, int64_t *pSync, const ActiveWFInfo& wf_info);
 
   __device__ void internal_atomic_barrier(int pe, int PE_start, int stride,
-      int n_pes, int64_t *pSync, ActiveWFInfo &wf_info);
+      int n_pes, int64_t *pSync, const ActiveWFInfo& wf_info);
 
   template <typename T, ROCSHMEM_OP Op>
   __device__ void internal_direct_allreduce(T *dst, const T *src, int nelems,
-      GDATeam *team_obj, ActiveWFInfo &wf_info);
+      GDATeam *team_obj, const ActiveWFInfo& wf_info);
 
   template <typename T, ROCSHMEM_OP Op>
   __device__ void internal_ring_allreduce(T *dst, const T *src, int nelems,
       GDATeam *team_obj, int n_seg, int seg_size, int chunk_size,
-      ActiveWFInfo &wf_info);
+      const ActiveWFInfo& wf_info);
 
   __device__ void internal_putmem(void *dest, const void *source,
-      size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info);
+      size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info);
 
   __device__ void internal_getmem(void *dest, const void *source,
-      size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info);
+      size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info);
 
   __device__ void internal_putmem_wg(void *dest, const void *source,
-      size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info);
+      size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info);
 
   __device__ void internal_getmem_wg(void *dest, const void *source,
-      size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info);
+      size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info);
 
   __device__ void internal_putmem_wave(void *dest, const void *source,
-      size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info);
+      size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info);
 
   __device__ void internal_getmem_wave(void *dest, const void *source,
-      size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info);
+      size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info);
 
   __device__ void internal_putmem_nbi(void *dest, const void *source,
-      size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info);
+      size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info);
 
   __device__ void internal_getmem_nbi(void *dest, const void *source,
-      size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info);
+      size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info);
 
   __device__ void internal_putmem_nbi_wg(void *dest, const void *source,
-      size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info);
+      size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info);
 
   __device__ void internal_getmem_nbi_wg(void *dest, const void *source,
-      size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info);
+      size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info);
 
   __device__ void internal_putmem_nbi_wave(void *dest, const void *source,
-      size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info);
+      size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info);
 
   __device__ void internal_getmem_nbi_wave(void *dest, const void *source,
-      size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info);
+      size_t nelems, int pe, int qp_index, const ActiveWFInfo& wf_info);
 
   __device__
-  void internal_quiet(ActiveWFInfo &wf_info);
+  void internal_quiet(const ActiveWFInfo& wf_info);
 
   template <typename T>
   __device__ void internal_amo_add(void *dst, T value, int pe, int qp_index,
-      ActiveWFInfo &wf_info);
+      const ActiveWFInfo& wf_info);
 
   template <typename T>
   __device__ T internal_amo_fetch_add(void *dst, T value, int pe, int qp_index,
-      ActiveWFInfo &wf_info);
+      const ActiveWFInfo& wf_info);
 
   template <typename T>
   __device__ T internal_amo_swap(void *dst, T value, int pe, int qp_index,
-      ActiveWFInfo &wf_info);
+      const ActiveWFInfo& wf_info);
 
   /**
    * @brief Get the Queue Pair index to use for a given PE
    */
-  __device__ __forceinline__ uint32_t get_qp_index(int pe, ActiveWFInfo wf_info);
+  __device__ __forceinline__ uint32_t get_qp_index(int pe, const ActiveWFInfo& wf_info);
 
   //Temporary scratchpad memory used by internal barrier algorithms.
   int64_t *barrier_sync{nullptr};

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -356,6 +356,13 @@ class GDAContext : public Context {
       const ActiveWFInfo& wf_info);
 
   /**
+   * @brief Implement amo_fetch_op using a compare-and-swap loop.
+   * op is a Callable returning T with arguments (T prior_value, T new_value).
+   */
+  template <typename T, typename Op>
+  __device__ T internal_amo_fetch_op(void *dst, T value, int pe, Op op);
+
+  /**
    * @brief Get the Queue Pair index to use for a given PE
    */
   __device__ __forceinline__ uint32_t get_qp_index(int pe, const ActiveWFInfo& wf_info);

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -360,7 +360,8 @@ class GDAContext : public Context {
    * op is a Callable returning T with arguments (T prior_value, T new_value).
    */
   template <typename T, typename Op>
-  __device__ T internal_amo_fetch_op(void *dst, T value, int pe, Op op);
+  __device__ T internal_amo_fetch_op(void *dst, T value, int pe, uint32_t qp_index,
+                                     [[maybe_unused]] const ActiveWFInfo& wf_info, Op&& op);
 
   /**
    * @brief Get the Queue Pair index to use for a given PE

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -29,6 +29,8 @@
 #include "team.hpp"
 #include "queue_pair.hpp"
 
+#include <type_traits>
+
 namespace rocshmem {
 
 class QueuePair;
@@ -354,6 +356,14 @@ class GDAContext : public Context {
   template <typename T>
   __device__ T internal_amo_swap(void *dst, T value, int pe, int qp_index,
       const ActiveWFInfo& wf_info);
+
+  /**
+   * @brief Call callable F with arguments Args... once for each PE-group.
+   * At least one of the arguments must be a reference to (possibly const-qualified) ActiveWFInfo.
+   * The mlx5 provider bypasses the take_turns code and calls F(Args...) directly.
+   */
+  template <typename F, typename... Args>
+  __device__ std::invoke_result_t<F, Args...> internal_amo_take_turns(F&& f, Args&&... args);
 
   /**
    * @brief Implement amo_fetch_op using a compare-and-swap loop.

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -363,14 +363,15 @@ class GDAContext : public Context {
    * The mlx5 provider bypasses the take_turns code and calls F(Args...) directly.
    */
   template <typename F, typename... Args>
-  __device__ std::invoke_result_t<F, Args...> internal_amo_take_turns(F&& f, Args&&... args);
+  __device__ std::invoke_result_t<F, Args...>
+  internal_amo_take_turns(int gda_provider, F&& f, Args&&... args);
 
   /**
    * @brief Implement amo_fetch_op using a compare-and-swap loop.
    * op is a Callable returning T with arguments (T prior_value, T new_value).
    */
   template <typename T, typename Op>
-  __device__ T internal_amo_fetch_op(void *dst, T value, int pe, uint32_t qp_index,
+  __device__ T internal_amo_fetch_op(void *dst, T value, int pe, QueuePair& qp,
                                      [[maybe_unused]] const ActiveWFInfo& wf_info, Op&& op);
 
   /**

--- a/projects/rocshmem/src/gda/context_gda_device_coll.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device_coll.cpp
@@ -31,7 +31,7 @@
 namespace rocshmem {
 
 __device__ void GDAContext::internal_direct_barrier(int pe, int PE_start,
-    int stride, int n_pes, int64_t *pSync, ActiveWFInfo &wf_info) {
+    int stride, int n_pes, int64_t *pSync, const ActiveWFInfo& wf_info) {
   int64_t flag_val{1};
   if (pe == PE_start) {
     // Go through all PE offsets (except current offset = 0)
@@ -71,7 +71,7 @@ __device__ void GDAContext::internal_direct_barrier(int pe, int PE_start,
 }
 
 __device__ void GDAContext::internal_direct_barrier_wg(int pe, int PE_start,
-    int stride, int n_pes, int64_t *pSync, ActiveWFInfo &wf_info) {
+    int stride, int n_pes, int64_t *pSync, const ActiveWFInfo& wf_info) {
   int64_t flag_val{1};
 
   if (pe == PE_start) {
@@ -123,7 +123,7 @@ __device__ void GDAContext::internal_direct_barrier_wg(int pe, int PE_start,
 }
 
 __device__ void GDAContext::internal_atomic_barrier(int pe, int PE_start,
-    int stride, int n_pes, int64_t *pSync, ActiveWFInfo &wf_info) {
+    int stride, int n_pes, int64_t *pSync, const ActiveWFInfo& wf_info) {
   int64_t flag_val{1};
   if (pe == PE_start) {
     wait_until(&pSync[0], ROCSHMEM_CMP_EQ, (int64_t)(n_pes - 1));
@@ -146,7 +146,7 @@ __device__ void GDAContext::internal_atomic_barrier(int pe, int PE_start,
 }
 
 __device__ void GDAContext::internal_sync(int pe, int PE_start, int stride,
-    int PE_size, int64_t *pSync, ActiveWFInfo &wf_info) {
+    int PE_size, int64_t *pSync, const ActiveWFInfo& wf_info) {
   if (PE_size < 64) {
     internal_direct_barrier(pe, PE_start, stride, PE_size, pSync, wf_info);
   } else {
@@ -155,7 +155,7 @@ __device__ void GDAContext::internal_sync(int pe, int PE_start, int stride,
 }
 
 __device__ void GDAContext::internal_sync_wave(int pe, int PE_start,
-    int stride, int PE_size, int64_t *pSync, ActiveWFInfo &wf_info) {
+    int stride, int PE_size, int64_t *pSync, const ActiveWFInfo& wf_info) {
   if (is_thread_zero_in_wave()) {
     if (PE_size < 64) {
       internal_direct_barrier(pe, PE_start, stride, PE_size, pSync, wf_info);
@@ -166,7 +166,7 @@ __device__ void GDAContext::internal_sync_wave(int pe, int PE_start,
 }
 
 __device__ void GDAContext::internal_sync_wg(int pe, int PE_start, int stride,
-    int PE_size, int64_t *pSync, ActiveWFInfo &wf_info) {
+    int PE_size, int64_t *pSync, const ActiveWFInfo& wf_info) {
   __syncthreads();
   if (PE_size < 64) {
     internal_direct_barrier_wg(pe, PE_start, stride, PE_size, pSync, wf_info);

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -99,13 +99,16 @@ __device__ T GDAContext::internal_amo_fetch_op(void *dst, T value, int pe, uint3
                                                Op&& op) {
   static_assert(std::is_invocable_v<Op, T, T>, "Op must be invocable with arguments (T, T)");
   static_assert(std::is_same_v<T, std::invoke_result_t<Op, T, T>>, "Op must return T");
-  static_assert(sizeof(T) == 8, "gda::internal_amo_fetch_op only implemented for 64-bit types");
+  if constexpr (sizeof(T) != 8) {
+    //TODO: support types other than uint64_t
+    LOGD_ERROR_ABORT("gda::internal_amo_fetch_op only implemented for 64-bit types");
+  }
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
 
   /**
-   * Guess that the remote memory is zero by setting condition to zero.
-   * The compare-and-swap loop will execute at least twice if wrong.
-   * It may run additional times if contention on memory location.
+   * Guess that the prior value of the remote memory is zero by initializing prior_val to zero.
+   * The compare-and-swap loop will execute at least twice if this guess is wrong.
+   * It may run additional times if there is contention on the memory location.
    */
   T prior_val = 0;
   T fetch_val = 0;
@@ -120,15 +123,14 @@ __device__ T GDAContext::internal_amo_fetch_op(void *dst, T value, int pe, uint3
 
 template <typename T>
 __device__ void GDAContext::amo_add(void *dst, T value, int pe) {
-  if constexpr (sizeof(T) == 8) {
-    uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-    ActiveWFInfo wf_info{pe};
-    uint32_t qp_index = get_qp_index(pe, wf_info);
-    qps[qp_index].atomic_nofetch(base_heap[pe] + L_offset, value, 0, wf_info);
-  } else {
+  if constexpr (sizeof(T) != 8) {
     //TODO: support types other than uint64_t
     LOGD_ERROR_ABORT("gda:amo_add only implemented for 64-bit types");
   }
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  ActiveWFInfo wf_info{pe};
+  uint32_t qp_index = get_qp_index(pe, wf_info);
+  qps[qp_index].atomic_nofetch(base_heap[pe] + L_offset, value, 0, wf_info);
 }
 
 template <typename T>
@@ -138,28 +140,26 @@ __device__ void GDAContext::amo_set(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ T GDAContext::amo_swap(void *dst, T value, int pe) {
-  if constexpr (sizeof(T) == 8) {
-    ActiveWFInfo wf_info{pe};
-    uint32_t qp_index = get_qp_index(pe, wf_info);
-    return internal_amo_fetch_op(dst, value, pe, qp_index, wf_info,
-                                 []([[maybe_unused]] T prior_val, T value) { return value; });
-  } else {
+  if constexpr (sizeof(T) != 8) {
     //TODO: support types other than uint64_t
     LOGD_ERROR_ABORT("gda:amo_swap only implemented for 64-bit types");
   }
+  ActiveWFInfo wf_info{pe};
+  uint32_t qp_index = get_qp_index(pe, wf_info);
+  return internal_amo_fetch_op(dst, value, pe, qp_index, wf_info,
+                               []([[maybe_unused]] T prior_val, T value) { return value; });
 }
 
 template <typename T>
 __device__ T GDAContext::amo_fetch_and(void *dst, T value, int pe) {
-  if constexpr (sizeof(T) == 8) {
-    ActiveWFInfo wf_info{pe};
-    uint32_t qp_index = get_qp_index(pe, wf_info);
-    return internal_amo_fetch_op(dst, value, pe, qp_index, wf_info,
-                                 [](T prior_val, T value) { return prior_val & value; });
-  } else {
+  if constexpr (sizeof(T) != 8) {
     //TODO: support types other than uint64_t
     LOGD_ERROR_ABORT("gda:amo_fetch_and only implemented for 64-bit types");
   }
+  ActiveWFInfo wf_info{pe};
+  uint32_t qp_index = get_qp_index(pe, wf_info);
+  return internal_amo_fetch_op(dst, value, pe, qp_index, wf_info,
+                               [](T prior_val, T value) { return prior_val & value; });
 }
 
 template <typename T>
@@ -169,15 +169,14 @@ __device__ void GDAContext::amo_and(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ T GDAContext::amo_fetch_or(void *dst, T value, int pe) {
-  if constexpr (sizeof(T) == 8) {
-    ActiveWFInfo wf_info{pe};
-    uint32_t qp_index = get_qp_index(pe, wf_info);
-    return internal_amo_fetch_op(dst, value, pe, qp_index, wf_info,
-                                 [](T prior_val, T value) { return prior_val | value; });
-  } else {
+  if constexpr (sizeof(T) != 8) {
     //TODO: support types other than uint64_t
     LOGD_ERROR_ABORT("gda:amo_fetch_or only implemented for 64-bit types");
   }
+  ActiveWFInfo wf_info{pe};
+  uint32_t qp_index = get_qp_index(pe, wf_info);
+  return internal_amo_fetch_op(dst, value, pe, qp_index, wf_info,
+                               [](T prior_val, T value) { return prior_val | value; });
 }
 
 template <typename T>
@@ -187,15 +186,14 @@ __device__ void GDAContext::amo_or(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ T GDAContext::amo_fetch_xor(void *dst, T value, int pe) {
-  if constexpr (sizeof(T) == 8) {
-    ActiveWFInfo wf_info{pe};
-    uint32_t qp_index = get_qp_index(pe, wf_info);
-    return internal_amo_fetch_op(dst, value, pe, qp_index, wf_info,
-                                 [](T prior_val, T value) { return prior_val ^ value; });
-  } else {
+  if constexpr (sizeof(T) != 8) {
     //TODO: support types other than uint64_t
     LOGD_ERROR_ABORT("gda:amo_fetch_xor only implemented for 64-bit types");
   }
+  ActiveWFInfo wf_info{pe};
+  uint32_t qp_index = get_qp_index(pe, wf_info);
+  return internal_amo_fetch_op(dst, value, pe, qp_index, wf_info,
+                               [](T prior_val, T value) { return prior_val ^ value; });
 }
 
 template <typename T>
@@ -205,41 +203,38 @@ __device__ void GDAContext::amo_xor(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ void GDAContext::amo_cas(void *dst, T value, T cond, int pe) {
-  if constexpr (sizeof(T) == 8) {
-    uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-    ActiveWFInfo wf_info{pe};
-    uint32_t qp_index = get_qp_index(pe, wf_info);
-    qps[qp_index].atomic_cas_nofetch(base_heap[pe] + L_offset, value, cond, wf_info);
-  } else {
+  if constexpr (sizeof(T) != 8) {
     //TODO: support types other than uint64_t
     LOGD_ERROR_ABORT("gda:amo_cas only implemented for 64-bit types");
   }
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  ActiveWFInfo wf_info{pe};
+  uint32_t qp_index = get_qp_index(pe, wf_info);
+  qps[qp_index].atomic_cas_nofetch(base_heap[pe] + L_offset, value, cond, wf_info);
 }
 
 template <typename T>
 __device__ T GDAContext::amo_fetch_add(void *dst, T value, int pe) {
-  if constexpr (sizeof(T) == 8) {
-    uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-    ActiveWFInfo wf_info{pe};
-    uint32_t qp_index = get_qp_index(pe, wf_info);
-    return qps[qp_index].atomic_fetch(base_heap[pe] + L_offset, value, 0, wf_info);
-  } else {
+  if constexpr (sizeof(T) != 8) {
     //TODO: support types other than uint64_t
     LOGD_ERROR_ABORT("gda:amo_fetch_add only implemented for 64-bit types");
   }
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  ActiveWFInfo wf_info{pe};
+  uint32_t qp_index = get_qp_index(pe, wf_info);
+  return qps[qp_index].atomic_fetch(base_heap[pe] + L_offset, value, 0, wf_info);
 }
 
 template <typename T>
 __device__ T GDAContext::amo_fetch_cas(void *dst, T value, T cond, int pe) {
-  if constexpr (sizeof(T) == 8) {
-    uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-    ActiveWFInfo wf_info{pe};
-    uint32_t qp_index = get_qp_index(pe, wf_info);
-    return qps[qp_index].atomic_cas(base_heap[pe] + L_offset, value, cond, wf_info);
-  } else {
+  if constexpr (sizeof(T) != 8) {
     //TODO: support types other than uint64_t
     LOGD_ERROR_ABORT("gda:amo_fetch_cas only implemented for 64-bit types");
   }
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  ActiveWFInfo wf_info{pe};
+  uint32_t qp_index = get_qp_index(pe, wf_info);
+  return qps[qp_index].atomic_cas(base_heap[pe] + L_offset, value, cond, wf_info);
 }
 
 // Collectives TODO: loosely adapted from IPC, needs review

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -143,7 +143,6 @@ __device__ T GDAContext::amo_swap(void *dst, T value, int pe) {
   } else {
     //TODO: support types other than uint64_t
     LOGD_ERROR_ABORT("gda:amo_swap only implemented for 64-bit types");
-    return T{};
   }
 }
 
@@ -155,7 +154,6 @@ __device__ T GDAContext::amo_fetch_and(void *dst, T value, int pe) {
   } else {
     //TODO: support types other than uint64_t
     LOGD_ERROR_ABORT("gda:amo_fetch_and only implemented for 64-bit types");
-    return T{};
   }
 }
 
@@ -172,7 +170,6 @@ __device__ T GDAContext::amo_fetch_or(void *dst, T value, int pe) {
   } else {
     //TODO: support types other than uint64_t
     LOGD_ERROR_ABORT("gda:amo_fetch_or only implemented for 64-bit types");
-    return T{};
   }
 }
 
@@ -189,7 +186,6 @@ __device__ T GDAContext::amo_fetch_xor(void *dst, T value, int pe) {
   } else {
     //TODO: support types other than uint64_t
     LOGD_ERROR_ABORT("gda:amo_fetch_xor only implemented for 64-bit types");
-    return T{};
   }
 }
 
@@ -221,7 +217,6 @@ __device__ T GDAContext::amo_fetch_add(void *dst, T value, int pe) {
   } else {
     //TODO: support types other than uint64_t
     LOGD_ERROR_ABORT("gda:amo_fetch_add only implemented for 64-bit types");
-    return T{};
   }
 }
 
@@ -235,7 +230,6 @@ __device__ T GDAContext::amo_fetch_cas(void *dst, T value, T cond, int pe) {
   } else {
     //TODO: support types other than uint64_t
     LOGD_ERROR_ABORT("gda:amo_fetch_cas only implemented for 64-bit types");
-    return T{};
   }
 }
 
@@ -912,7 +906,6 @@ __device__ T GDAContext::internal_amo_fetch_add(void *dst, T value, int pe, int 
   if constexpr (sizeof(T) != 8) {
     //TODO: support types other than uint64_t
     LOGD_ERROR_ABORT("gda:internal_amo_fetch_add only implemented for 64-bit types");
-    return T{};
   }
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   return qps[qp_index].atomic_fetch(base_heap[pe] + L_offset, value, 0, wf_info);
@@ -924,7 +917,6 @@ __device__ T GDAContext::internal_amo_swap(void *dst, T value, int pe, int qp_in
   if constexpr (sizeof(T) != 8) {
     //TODO: support types other than uint64_t
     LOGD_ERROR_ABORT("gda:internal_amo_swap only implemented for 64-bit types");
-    return T{};
   }
   /**
    * Guess that the remote memory is zero by setting condition to zero.

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -95,9 +95,9 @@ __device__ void GDAContext::get_nbi(T *dest, const T *source, size_t nelems, int
 // Atomics
 template <typename F, typename... Args>
 __device__ std::invoke_result_t<F, Args...>
-GDAContext::internal_amo_take_turns(F&& f, Args&&... args) {
+GDAContext::internal_amo_take_turns(int gda_provider, F&& f, Args&&... args) {
 #if defined(GDA_MLX5)
-  if (gda_provider_ == GDAProvider::MLX5) {
+  if (gda_provider == GDAProvider::MLX5) {
     return std::forward<F>(f)(std::forward<Args>(args)...);
   } else
 #endif
@@ -112,7 +112,7 @@ GDAContext::internal_amo_take_turns(F&& f, Args&&... args) {
 }
 
 template <typename T, typename Op>
-__device__ T GDAContext::internal_amo_fetch_op(void *dst, T value, int pe, uint32_t qp_index,
+__device__ T GDAContext::internal_amo_fetch_op(void *dst, T value, int pe, QueuePair& qp,
                                                [[maybe_unused]] const ActiveWFInfo& wf_info,
                                                Op&& op) {
   static_assert(std::is_invocable_v<Op, T, T>, "Op must be invocable with arguments (T, T)");
@@ -134,7 +134,7 @@ __device__ T GDAContext::internal_amo_fetch_op(void *dst, T value, int pe, uint3
     ActiveWFInfo loop_wf_info{pe};
     prior_val = fetch_val;
     T desired = op(prior_val, value);
-    fetch_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, desired, prior_val, loop_wf_info);
+    fetch_val = qp.atomic_cas(base_heap[pe] + L_offset, desired, prior_val, loop_wf_info);
   } while (fetch_val != prior_val);
   return fetch_val;
 }
@@ -148,7 +148,8 @@ __device__ void GDAContext::amo_add(void *dst, T value, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   ActiveWFInfo wf_info{pe};
   uint32_t qp_index = get_qp_index(pe, wf_info);
-  internal_amo_take_turns([&qp = qps[qp_index]](auto&&... args) {
+  QueuePair& qp = qps[qp_index];
+  internal_amo_take_turns(qp.gda_provider_, [&qp](auto&&... args) {
       qp.atomic_nofetch(std::forward<decltype(args)>(args)...);
     }, base_heap[pe] + L_offset, value, 0, wf_info);
 }
@@ -166,10 +167,11 @@ __device__ T GDAContext::amo_swap(void *dst, T value, int pe) {
   }
   ActiveWFInfo wf_info{pe};
   uint32_t qp_index = get_qp_index(pe, wf_info);
-  return internal_amo_take_turns([this](auto&&... args) {
+  QueuePair& qp = qps[qp_index];
+  return internal_amo_take_turns(qp.gda_provider_, [this](auto&&... args) {
       return this->internal_amo_fetch_op(std::forward<decltype(args)>(args)...,
                                          []([[maybe_unused]] T prior_val, T value) { return value; });
-    }, dst, value, pe, qp_index, wf_info);
+    }, dst, value, pe, qp, wf_info);
 }
 
 template <typename T>
@@ -180,10 +182,11 @@ __device__ T GDAContext::amo_fetch_and(void *dst, T value, int pe) {
   }
   ActiveWFInfo wf_info{pe};
   uint32_t qp_index = get_qp_index(pe, wf_info);
-  return internal_amo_take_turns([this](auto&&... args) {
+  QueuePair& qp = qps[qp_index];
+  return internal_amo_take_turns(qp.gda_provider_, [this](auto&&... args) {
       return this->internal_amo_fetch_op(std::forward<decltype(args)>(args)...,
                                          [](T prior_val, T value) { return prior_val & value; });
-    }, dst, value, pe, qp_index, wf_info);
+    }, dst, value, pe, qp, wf_info);
 }
 
 template <typename T>
@@ -199,10 +202,11 @@ __device__ T GDAContext::amo_fetch_or(void *dst, T value, int pe) {
   }
   ActiveWFInfo wf_info{pe};
   uint32_t qp_index = get_qp_index(pe, wf_info);
-  return internal_amo_take_turns([this](auto&&... args) {
+  QueuePair& qp = qps[qp_index];
+  return internal_amo_take_turns(qp.gda_provider_, [this](auto&&... args) {
       return this->internal_amo_fetch_op(std::forward<decltype(args)>(args)...,
                                          [](T prior_val, T value) { return prior_val | value; });
-    }, dst, value, pe, qp_index, wf_info);
+    }, dst, value, pe, qp, wf_info);
 }
 
 template <typename T>
@@ -218,10 +222,11 @@ __device__ T GDAContext::amo_fetch_xor(void *dst, T value, int pe) {
   }
   ActiveWFInfo wf_info{pe};
   uint32_t qp_index = get_qp_index(pe, wf_info);
-  return internal_amo_take_turns([this](auto&&... args) {
+  QueuePair& qp = qps[qp_index];
+  return internal_amo_take_turns(qp.gda_provider_, [this](auto&&... args) {
       return this->internal_amo_fetch_op(std::forward<decltype(args)>(args)...,
                                          [](T prior_val, T value) { return prior_val ^ value; });
-    }, dst, value, pe, qp_index, wf_info);
+    }, dst, value, pe, qp, wf_info);
 }
 
 template <typename T>
@@ -238,7 +243,8 @@ __device__ void GDAContext::amo_cas(void *dst, T value, T cond, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   ActiveWFInfo wf_info{pe};
   uint32_t qp_index = get_qp_index(pe, wf_info);
-  internal_amo_take_turns([&qp = qps[qp_index]](auto&&... args) {
+  QueuePair& qp = qps[qp_index];
+  internal_amo_take_turns(qp.gda_provider_, [&qp](auto&&... args) {
       qp.atomic_cas_nofetch(std::forward<decltype(args)>(args)...);
     }, base_heap[pe] + L_offset, value, cond, wf_info);
 }
@@ -252,7 +258,8 @@ __device__ T GDAContext::amo_fetch_add(void *dst, T value, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   ActiveWFInfo wf_info{pe};
   uint32_t qp_index = get_qp_index(pe, wf_info);
-  return internal_amo_take_turns([&qp = qps[qp_index]](auto&&... args) {
+  QueuePair& qp = qps[qp_index];
+  return internal_amo_take_turns(qp.gda_provider_, [&qp](auto&&... args) {
       return qp.atomic_fetch(std::forward<decltype(args)>(args)...);
     }, base_heap[pe] + L_offset, value, 0, wf_info);
 }
@@ -266,7 +273,8 @@ __device__ T GDAContext::amo_fetch_cas(void *dst, T value, T cond, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   ActiveWFInfo wf_info{pe};
   uint32_t qp_index = get_qp_index(pe, wf_info);
-  return internal_amo_take_turns([&qp = qps[qp_index]](auto&&... args) {
+  QueuePair& qp = qps[qp_index];
+  return internal_amo_take_turns(qp.gda_provider_, [&qp](auto&&... args) {
       return qp.atomic_cas(std::forward<decltype(args)>(args)...);
     }, base_heap[pe] + L_offset, value, cond, wf_info);
 }
@@ -935,7 +943,8 @@ __device__ void GDAContext::internal_amo_add(void *dst, T value, int pe, int qp_
     LOGD_ERROR_ABORT("gda:internal_amo_add only implemented for 64-bit types");
   }
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  internal_amo_take_turns([&qp = qps[qp_index]](auto&&... args) {
+  QueuePair& qp = qps[qp_index];
+  internal_amo_take_turns(qp.gda_provider_, [&qp](auto&&... args) {
       qp.atomic_nofetch(std::forward<decltype(args)>(args)...);
     }, base_heap[pe] + L_offset, value, 0, wf_info);
 }
@@ -948,7 +957,8 @@ __device__ T GDAContext::internal_amo_fetch_add(void *dst, T value, int pe, int 
     LOGD_ERROR_ABORT("gda:internal_amo_fetch_add only implemented for 64-bit types");
   }
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  return internal_amo_take_turns([&qp = qps[qp_index]](auto&&... args) {
+  QueuePair& qp = qps[qp_index];
+  return internal_amo_take_turns(qp.gda_provider_, [&qp](auto&&... args) {
       return qp.atomic_fetch(std::forward<decltype(args)>(args)...);
     }, base_heap[pe] + L_offset, value, 0, wf_info);
 }
@@ -960,10 +970,11 @@ __device__ T GDAContext::internal_amo_swap(void *dst, T value, int pe, int qp_in
     //TODO: support types other than uint64_t
     LOGD_ERROR_ABORT("gda:internal_amo_swap only implemented for 64-bit types");
   }
-  return internal_amo_take_turns([this](auto&&... args) {
+  QueuePair& qp = qps[qp_index];
+  return internal_amo_take_turns(qp.gda_provider_, [this](auto&&... args) {
       return this->internal_amo_fetch_op(std::forward<decltype(args)>(args)...,
                                          []([[maybe_unused]] T prior_val, T value) { return value; });
-    }, dst, value, pe, qp_index, wf_info);
+    }, dst, value, pe, qp, wf_info);
 }
 
 /******************************************************************************

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -38,6 +38,7 @@
 
 #include <hip/hip_runtime.h>
 #include <type_traits>
+#include <utility>
 
 namespace rocshmem {
 
@@ -93,13 +94,13 @@ __device__ void GDAContext::get_nbi(T *dest, const T *source, size_t nelems, int
 
 // Atomics
 template <typename T, typename Op>
-__device__ T GDAContext::internal_amo_fetch_op(void *dst, T value, int pe, Op op) {
+__device__ T GDAContext::internal_amo_fetch_op(void *dst, T value, int pe, uint32_t qp_index,
+                                               [[maybe_unused]] const ActiveWFInfo& wf_info,
+                                               Op&& op) {
   static_assert(std::is_invocable_v<Op, T, T>, "Op must be invocable with arguments (T, T)");
   static_assert(std::is_same_v<T, std::invoke_result_t<Op, T, T>>, "Op must return T");
   static_assert(sizeof(T) == 8, "gda::internal_amo_fetch_op only implemented for 64-bit types");
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  ActiveWFInfo wf_info{pe};
-  uint32_t qp_index = get_qp_index(pe, wf_info);
 
   /**
    * Guess that the remote memory is zero by setting condition to zero.
@@ -111,8 +112,8 @@ __device__ T GDAContext::internal_amo_fetch_op(void *dst, T value, int pe, Op op
   do {
     ActiveWFInfo loop_wf_info{pe};
     prior_val = fetch_val;
-    T desired_val = op(prior_val, value);
-    fetch_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, desired_val, prior_val, loop_wf_info);
+    T desired = std::forward<Op>(op)(prior_val, value);
+    fetch_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, desired, prior_val, loop_wf_info);
   } while (fetch_val != prior_val);
   return fetch_val;
 }
@@ -138,7 +139,9 @@ __device__ void GDAContext::amo_set(void *dst, T value, int pe) {
 template <typename T>
 __device__ T GDAContext::amo_swap(void *dst, T value, int pe) {
   if constexpr (sizeof(T) == 8) {
-    return internal_amo_fetch_op(dst, value, pe,
+    ActiveWFInfo wf_info{pe};
+    uint32_t qp_index = get_qp_index(pe, wf_info);
+    return internal_amo_fetch_op(dst, value, pe, qp_index, wf_info,
                                  []([[maybe_unused]] T prior_val, T value) { return value; });
   } else {
     //TODO: support types other than uint64_t
@@ -149,7 +152,9 @@ __device__ T GDAContext::amo_swap(void *dst, T value, int pe) {
 template <typename T>
 __device__ T GDAContext::amo_fetch_and(void *dst, T value, int pe) {
   if constexpr (sizeof(T) == 8) {
-    return internal_amo_fetch_op(dst, value, pe,
+    ActiveWFInfo wf_info{pe};
+    uint32_t qp_index = get_qp_index(pe, wf_info);
+    return internal_amo_fetch_op(dst, value, pe, qp_index, wf_info,
                                  [](T prior_val, T value) { return prior_val & value; });
   } else {
     //TODO: support types other than uint64_t
@@ -165,7 +170,9 @@ __device__ void GDAContext::amo_and(void *dst, T value, int pe) {
 template <typename T>
 __device__ T GDAContext::amo_fetch_or(void *dst, T value, int pe) {
   if constexpr (sizeof(T) == 8) {
-    return internal_amo_fetch_op(dst, value, pe,
+    ActiveWFInfo wf_info{pe};
+    uint32_t qp_index = get_qp_index(pe, wf_info);
+    return internal_amo_fetch_op(dst, value, pe, qp_index, wf_info,
                                  [](T prior_val, T value) { return prior_val | value; });
   } else {
     //TODO: support types other than uint64_t
@@ -181,7 +188,9 @@ __device__ void GDAContext::amo_or(void *dst, T value, int pe) {
 template <typename T>
 __device__ T GDAContext::amo_fetch_xor(void *dst, T value, int pe) {
   if constexpr (sizeof(T) == 8) {
-    return internal_amo_fetch_op(dst, value, pe,
+    ActiveWFInfo wf_info{pe};
+    uint32_t qp_index = get_qp_index(pe, wf_info);
+    return internal_amo_fetch_op(dst, value, pe, qp_index, wf_info,
                                  [](T prior_val, T value) { return prior_val ^ value; });
   } else {
     //TODO: support types other than uint64_t
@@ -918,21 +927,8 @@ __device__ T GDAContext::internal_amo_swap(void *dst, T value, int pe, int qp_in
     //TODO: support types other than uint64_t
     LOGD_ERROR_ABORT("gda:internal_amo_swap only implemented for 64-bit types");
   }
-  /**
-   * Guess that the remote memory is zero by setting condition to zero.
-   * The compare-and-swap loop will execute at least twice if wrong.
-   * It may run additional times if contention on memory location.
-   */
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  T prior_val = 0;
-  T fetch_val = 0;
-  do {
-    ActiveWFInfo loop_wf_info{pe};
-    prior_val = fetch_val;
-    T desired_val = value;
-    fetch_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, desired_val, prior_val, loop_wf_info);
-  } while (fetch_val != prior_val);
-  return fetch_val;
+  return internal_amo_fetch_op(dst, value, pe, qp_index, wf_info,
+                               []([[maybe_unused]] T prior_val, T value) { return value; });
 }
 
 /******************************************************************************

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -38,6 +38,7 @@
 
 #include <hip/hip_runtime.h>
 #include <type_traits>
+#include <utility>
 
 namespace rocshmem {
 
@@ -92,6 +93,24 @@ __device__ void GDAContext::get_nbi(T *dest, const T *source, size_t nelems, int
 }
 
 // Atomics
+template <typename F, typename... Args>
+__device__ std::invoke_result_t<F, Args...>
+GDAContext::internal_amo_take_turns(F&& f, Args&&... args) {
+#if defined(GDA_MLX5)
+  if (gda_provider_ == GDAProvider::MLX5) {
+    return std::forward<F>(f)(std::forward<Args>(args)...);
+  } else
+#endif
+  {
+    // determine whether ActiveWFInfo argument is a const or non-const reference
+    constexpr bool is_arg_const = std::disjunction_v<std::is_same<const ActiveWFInfo&, Args>...>;
+    using wf_info_arg_t = std::conditional_t<is_arg_const, const ActiveWFInfo&, ActiveWFInfo&>;
+    // get the ActiveWFInfo argument so we can call F once for each PE-group
+    const ActiveWFInfo& wf_info = get_arg<wf_info_arg_t>(std::forward<Args>(args)...);
+    return wf_info.for_each_pe_group(std::forward<F>(f), std::forward<Args>(args)...);
+  }
+}
+
 template <typename T, typename Op>
 __device__ T GDAContext::internal_amo_fetch_op(void *dst, T value, int pe, uint32_t qp_index,
                                                [[maybe_unused]] const ActiveWFInfo& wf_info,
@@ -129,7 +148,9 @@ __device__ void GDAContext::amo_add(void *dst, T value, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   ActiveWFInfo wf_info{pe};
   uint32_t qp_index = get_qp_index(pe, wf_info);
-  qps[qp_index].atomic_nofetch(base_heap[pe] + L_offset, value, 0, wf_info);
+  internal_amo_take_turns([&qp = qps[qp_index]](auto&&... args) {
+      qp.atomic_nofetch(std::forward<decltype(args)>(args)...);
+    }, base_heap[pe] + L_offset, value, 0, wf_info);
 }
 
 template <typename T>
@@ -145,8 +166,10 @@ __device__ T GDAContext::amo_swap(void *dst, T value, int pe) {
   }
   ActiveWFInfo wf_info{pe};
   uint32_t qp_index = get_qp_index(pe, wf_info);
-  return internal_amo_fetch_op(dst, value, pe, qp_index, wf_info,
-                               []([[maybe_unused]] T prior_val, T value) { return value; });
+  return internal_amo_take_turns([this](auto&&... args) {
+      return this->internal_amo_fetch_op(std::forward<decltype(args)>(args)...,
+                                         []([[maybe_unused]] T prior_val, T value) { return value; });
+    }, dst, value, pe, qp_index, wf_info);
 }
 
 template <typename T>
@@ -157,8 +180,10 @@ __device__ T GDAContext::amo_fetch_and(void *dst, T value, int pe) {
   }
   ActiveWFInfo wf_info{pe};
   uint32_t qp_index = get_qp_index(pe, wf_info);
-  return internal_amo_fetch_op(dst, value, pe, qp_index, wf_info,
-                               [](T prior_val, T value) { return prior_val & value; });
+  return internal_amo_take_turns([this](auto&&... args) {
+      return this->internal_amo_fetch_op(std::forward<decltype(args)>(args)...,
+                                         [](T prior_val, T value) { return prior_val & value; });
+    }, dst, value, pe, qp_index, wf_info);
 }
 
 template <typename T>
@@ -174,8 +199,10 @@ __device__ T GDAContext::amo_fetch_or(void *dst, T value, int pe) {
   }
   ActiveWFInfo wf_info{pe};
   uint32_t qp_index = get_qp_index(pe, wf_info);
-  return internal_amo_fetch_op(dst, value, pe, qp_index, wf_info,
-                               [](T prior_val, T value) { return prior_val | value; });
+  return internal_amo_take_turns([this](auto&&... args) {
+      return this->internal_amo_fetch_op(std::forward<decltype(args)>(args)...,
+                                         [](T prior_val, T value) { return prior_val | value; });
+    }, dst, value, pe, qp_index, wf_info);
 }
 
 template <typename T>
@@ -191,8 +218,10 @@ __device__ T GDAContext::amo_fetch_xor(void *dst, T value, int pe) {
   }
   ActiveWFInfo wf_info{pe};
   uint32_t qp_index = get_qp_index(pe, wf_info);
-  return internal_amo_fetch_op(dst, value, pe, qp_index, wf_info,
-                               [](T prior_val, T value) { return prior_val ^ value; });
+  return internal_amo_take_turns([this](auto&&... args) {
+      return this->internal_amo_fetch_op(std::forward<decltype(args)>(args)...,
+                                         [](T prior_val, T value) { return prior_val ^ value; });
+    }, dst, value, pe, qp_index, wf_info);
 }
 
 template <typename T>
@@ -209,7 +238,9 @@ __device__ void GDAContext::amo_cas(void *dst, T value, T cond, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   ActiveWFInfo wf_info{pe};
   uint32_t qp_index = get_qp_index(pe, wf_info);
-  qps[qp_index].atomic_cas_nofetch(base_heap[pe] + L_offset, value, cond, wf_info);
+  internal_amo_take_turns([&qp = qps[qp_index]](auto&&... args) {
+      qp.atomic_cas_nofetch(std::forward<decltype(args)>(args)...);
+    }, base_heap[pe] + L_offset, value, cond, wf_info);
 }
 
 template <typename T>
@@ -221,7 +252,9 @@ __device__ T GDAContext::amo_fetch_add(void *dst, T value, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   ActiveWFInfo wf_info{pe};
   uint32_t qp_index = get_qp_index(pe, wf_info);
-  return qps[qp_index].atomic_fetch(base_heap[pe] + L_offset, value, 0, wf_info);
+  return internal_amo_take_turns([&qp = qps[qp_index]](auto&&... args) {
+      return qp.atomic_fetch(std::forward<decltype(args)>(args)...);
+    }, base_heap[pe] + L_offset, value, 0, wf_info);
 }
 
 template <typename T>
@@ -233,7 +266,9 @@ __device__ T GDAContext::amo_fetch_cas(void *dst, T value, T cond, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   ActiveWFInfo wf_info{pe};
   uint32_t qp_index = get_qp_index(pe, wf_info);
-  return qps[qp_index].atomic_cas(base_heap[pe] + L_offset, value, cond, wf_info);
+  return internal_amo_take_turns([&qp = qps[qp_index]](auto&&... args) {
+      return qp.atomic_cas(std::forward<decltype(args)>(args)...);
+    }, base_heap[pe] + L_offset, value, cond, wf_info);
 }
 
 // Collectives TODO: loosely adapted from IPC, needs review
@@ -900,7 +935,9 @@ __device__ void GDAContext::internal_amo_add(void *dst, T value, int pe, int qp_
     LOGD_ERROR_ABORT("gda:internal_amo_add only implemented for 64-bit types");
   }
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  qps[qp_index].atomic_nofetch(base_heap[pe] + L_offset, value, 0, wf_info);
+  internal_amo_take_turns([&qp = qps[qp_index]](auto&&... args) {
+      qp.atomic_nofetch(std::forward<decltype(args)>(args)...);
+    }, base_heap[pe] + L_offset, value, 0, wf_info);
 }
 
 template <typename T>
@@ -911,7 +948,9 @@ __device__ T GDAContext::internal_amo_fetch_add(void *dst, T value, int pe, int 
     LOGD_ERROR_ABORT("gda:internal_amo_fetch_add only implemented for 64-bit types");
   }
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  return qps[qp_index].atomic_fetch(base_heap[pe] + L_offset, value, 0, wf_info);
+  return internal_amo_take_turns([&qp = qps[qp_index]](auto&&... args) {
+      return qp.atomic_fetch(std::forward<decltype(args)>(args)...);
+    }, base_heap[pe] + L_offset, value, 0, wf_info);
 }
 
 template <typename T>
@@ -921,8 +960,10 @@ __device__ T GDAContext::internal_amo_swap(void *dst, T value, int pe, int qp_in
     //TODO: support types other than uint64_t
     LOGD_ERROR_ABORT("gda:internal_amo_swap only implemented for 64-bit types");
   }
-  return internal_amo_fetch_op(dst, value, pe, qp_index, wf_info,
-                               []([[maybe_unused]] T prior_val, T value) { return value; });
+  return internal_amo_take_turns([this](auto&&... args) {
+      return this->internal_amo_fetch_op(std::forward<decltype(args)>(args)...,
+                                         []([[maybe_unused]] T prior_val, T value) { return value; });
+    }, dst, value, pe, qp_index, wf_info);
 }
 
 /******************************************************************************

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -37,6 +37,7 @@
 #include "backend_gda.hpp"
 
 #include <hip/hip_runtime.h>
+#include <type_traits>
 
 namespace rocshmem {
 
@@ -91,22 +92,41 @@ __device__ void GDAContext::get_nbi(T *dest, const T *source, size_t nelems, int
 }
 
 // Atomics
+template <typename T, typename Op>
+__device__ T GDAContext::internal_amo_fetch_op(void *dst, T value, int pe, Op op) {
+  static_assert(std::is_invocable_v<Op, T, T>, "Op must be invocable with arguments (T, T)");
+  static_assert(std::is_same_v<T, std::invoke_result_t<Op, T, T>>, "Op must return T");
+  static_assert(sizeof(T) == 8, "gda::internal_amo_fetch_op only implemented for 64-bit types");
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  ActiveWFInfo wf_info{pe};
+  uint32_t qp_index = get_qp_index(pe, wf_info);
+
+  /**
+   * Guess that the remote memory is zero by setting condition to zero.
+   * The compare-and-swap loop will execute at least twice if wrong.
+   * It may run additional times if contention on memory location.
+   */
+  T prior_val = 0;
+  T fetch_val = 0;
+  do {
+    ActiveWFInfo loop_wf_info{pe};
+    prior_val = fetch_val;
+    T desired_val = op(prior_val, value);
+    fetch_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, desired_val, prior_val, loop_wf_info);
+  } while (fetch_val != prior_val);
+  return fetch_val;
+}
+
 template <typename T>
 __device__ void GDAContext::amo_add(void *dst, T value, int pe) {
-  if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_add not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  ActiveWFInfo wf_info(pe);
-  int qp_index = get_qp_index(pe, wf_info);
-  bool need_turn {true};
-  uint64_t turns = __ballot(need_turn);
-  while (turns) {
-    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
-    int pe_turn = __shfl(pe, lane);
-    if (pe_turn == pe) {
-      qps[qp_index].atomic_nofetch(base_heap[pe] + L_offset, value, 0, wf_info);
-      need_turn = false;
-    }
-    turns = __ballot(need_turn);
+  if constexpr (sizeof(T) == 8) {
+    uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+    ActiveWFInfo wf_info{pe};
+    uint32_t qp_index = get_qp_index(pe, wf_info);
+    qps[qp_index].atomic_nofetch(base_heap[pe] + L_offset, value, 0, wf_info);
+  } else {
+    //TODO: support types other than uint64_t
+    LOGD_ERROR_ABORT("gda:amo_add only implemented for 64-bit types");
   }
 }
 
@@ -117,67 +137,26 @@ __device__ void GDAContext::amo_set(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ T GDAContext::amo_swap(void *dst, T value, int pe) {
-  if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_set not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  ActiveWFInfo wf_info(pe);
-  int qp_index = get_qp_index(pe, wf_info);
-  bool need_turn {true};
-  uint64_t turns = __ballot(need_turn);
-  T ret_val;
-  T cond = 0;
-  while (turns) {
-    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
-    int pe_turn = __shfl(pe, lane);
-    if (pe_turn == pe) {
-      /**
-       * Guess that the remote memory is zero by setting condition to zero.
-       * The compare-and-swap loop will execute at least twice if wrong.
-       * It may run additional times if contention on memory location.
-       */
-      while (true) {
-        ActiveWFInfo wf_info{pe};
-        ret_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, value, cond, wf_info);
-        if (ret_val == cond) {
-          break;
-        }
-        cond = ret_val;
-      }
-      need_turn = false;
-    }
-    turns = __ballot(need_turn);
+  if constexpr (sizeof(T) == 8) {
+    return internal_amo_fetch_op(dst, value, pe,
+                                 []([[maybe_unused]] T prior_val, T value) { return value; });
+  } else {
+    //TODO: support types other than uint64_t
+    LOGD_ERROR_ABORT("gda:amo_swap only implemented for 64-bit types");
+    return T{};
   }
-  return ret_val;
 }
 
 template <typename T>
 __device__ T GDAContext::amo_fetch_and(void *dst, T value, int pe) {
-  if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_fetch_and not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  ActiveWFInfo wf_info(pe);
-  int qp_index = get_qp_index(pe, wf_info);
-  bool need_turn {true};
-  uint64_t turns = __ballot(need_turn);
-  T ret_val;
-  T cond = 0;
-  T desired_val = cond & value;
-  while (turns) {
-    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
-    int pe_turn = __shfl(pe, lane);
-    if (pe_turn == pe) {
-      while (true) {
-        ActiveWFInfo wf_info{pe};
-        ret_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, desired_val, cond, wf_info);
-        if (ret_val == cond) {
-          break;
-        }
-        cond = ret_val;
-        desired_val = ret_val & value;
-      }
-      need_turn = false;
-    }
-    turns = __ballot(need_turn);
+  if constexpr (sizeof(T) == 8) {
+    return internal_amo_fetch_op(dst, value, pe,
+                                 [](T prior_val, T value) { return prior_val & value; });
+  } else {
+    //TODO: support types other than uint64_t
+    LOGD_ERROR_ABORT("gda:amo_fetch_and only implemented for 64-bit types");
+    return T{};
   }
-  return ret_val;
 }
 
 template <typename T>
@@ -187,33 +166,14 @@ __device__ void GDAContext::amo_and(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ T GDAContext::amo_fetch_or(void *dst, T value, int pe) {
-  if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_fetch_or not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  ActiveWFInfo wf_info(pe);
-  int qp_index = get_qp_index(pe, wf_info);
-  bool need_turn {true};
-  uint64_t turns = __ballot(need_turn);
-  T ret_val;
-  T cond = 0;
-  T desired_val = cond | value;
-  while (turns) {
-    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
-    int pe_turn = __shfl(pe, lane);
-    if (pe_turn == pe) {
-      while (true) {
-        ActiveWFInfo wf_info{pe};
-        ret_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, desired_val, cond, wf_info);
-        if (ret_val == cond) {
-          break;
-        }
-        cond = ret_val;
-        desired_val = ret_val | value;
-      }
-      need_turn = false;
-    }
-    turns = __ballot(need_turn);
+  if constexpr (sizeof(T) == 8) {
+    return internal_amo_fetch_op(dst, value, pe,
+                                 [](T prior_val, T value) { return prior_val | value; });
+  } else {
+    //TODO: support types other than uint64_t
+    LOGD_ERROR_ABORT("gda:amo_fetch_or only implemented for 64-bit types");
+    return T{};
   }
-  return ret_val;
 }
 
 template <typename T>
@@ -223,33 +183,14 @@ __device__ void GDAContext::amo_or(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ T GDAContext::amo_fetch_xor(void *dst, T value, int pe) {
-  if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_fetch_xor not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  ActiveWFInfo wf_info(pe);
-  int qp_index = get_qp_index(pe, wf_info);
-  bool need_turn {true};
-  uint64_t turns = __ballot(need_turn);
-  T ret_val;
-  T cond = 0;
-  T desired_val = cond ^ value;
-  while (turns) {
-    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
-    int pe_turn = __shfl(pe, lane);
-    if (pe_turn == pe) {
-      while (true) {
-        ActiveWFInfo wf_info{pe};
-        ret_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, desired_val, cond, wf_info);
-        if (ret_val == cond) {
-          break;
-        }
-        cond = ret_val;
-        desired_val = ret_val ^ value;
-      }
-      need_turn = false;
-    }
-    turns = __ballot(need_turn);
+  if constexpr (sizeof(T) == 8) {
+    return internal_amo_fetch_op(dst, value, pe,
+                                 [](T prior_val, T value) { return prior_val ^ value; });
+  } else {
+    //TODO: support types other than uint64_t
+    LOGD_ERROR_ABORT("gda:amo_fetch_xor only implemented for 64-bit types");
+    return T{};
   }
-  return ret_val;
 }
 
 template <typename T>
@@ -259,63 +200,43 @@ __device__ void GDAContext::amo_xor(void *dst, T value, int pe) {
 
 template <typename T>
 __device__ void GDAContext::amo_cas(void *dst, T value, T cond, int pe) {
-  if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_cas not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  ActiveWFInfo wf_info(pe);
-  int qp_index = get_qp_index(pe, wf_info);
-  bool need_turn {true};
-  uint64_t turns = __ballot(need_turn);
-  while (turns) {
-    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
-    int pe_turn = __shfl(pe, lane);
-    if (pe_turn == pe) {
-      qps[qp_index].atomic_cas_nofetch(base_heap[pe] + L_offset, value, cond, wf_info);
-      need_turn = false;
-    }
-    turns = __ballot(need_turn);
+  if constexpr (sizeof(T) == 8) {
+    uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+    ActiveWFInfo wf_info{pe};
+    uint32_t qp_index = get_qp_index(pe, wf_info);
+    qps[qp_index].atomic_cas_nofetch(base_heap[pe] + L_offset, value, cond, wf_info);
+  } else {
+    //TODO: support types other than uint64_t
+    LOGD_ERROR_ABORT("gda:amo_cas only implemented for 64-bit types");
   }
 }
 
 template <typename T>
 __device__ T GDAContext::amo_fetch_add(void *dst, T value, int pe) {
-  if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_fadd not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  ActiveWFInfo wf_info(pe);
-  int qp_index = get_qp_index(pe, wf_info);
-  T ret_val = 0;
-  bool need_turn {true};
-  uint64_t turns = __ballot(need_turn);
-  while (turns) {
-    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
-    int pe_turn = __shfl(pe, lane);
-    if (pe_turn == pe) {
-      ret_val =  qps[qp_index].atomic_fetch(base_heap[pe] + L_offset, value, 0, wf_info);
-      need_turn = false;
-    }
-    turns = __ballot(need_turn);
+  if constexpr (sizeof(T) == 8) {
+    uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+    ActiveWFInfo wf_info{pe};
+    uint32_t qp_index = get_qp_index(pe, wf_info);
+    return qps[qp_index].atomic_fetch(base_heap[pe] + L_offset, value, 0, wf_info);
+  } else {
+    //TODO: support types other than uint64_t
+    LOGD_ERROR_ABORT("gda:amo_fetch_add only implemented for 64-bit types");
+    return T{};
   }
-  return ret_val;
 }
 
 template <typename T>
 __device__ T GDAContext::amo_fetch_cas(void *dst, T value, T cond, int pe) {
-  if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_fcas not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  ActiveWFInfo wf_info(pe);
-  int qp_index = get_qp_index(pe, wf_info);
-  bool need_turn {true};
-  uint64_t turns = __ballot(need_turn);
-  T ret_val;
-  while (turns) {
-    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
-    int pe_turn = __shfl(pe, lane);
-    if (pe_turn == pe) {
-      ret_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, value, cond, wf_info);
-      need_turn = false;
-    }
-    turns = __ballot(need_turn);
+  if constexpr (sizeof(T) == 8) {
+    uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+    ActiveWFInfo wf_info{pe};
+    uint32_t qp_index = get_qp_index(pe, wf_info);
+    return qps[qp_index].atomic_cas(base_heap[pe] + L_offset, value, cond, wf_info);
+  } else {
+    //TODO: support types other than uint64_t
+    LOGD_ERROR_ABORT("gda:amo_fetch_cas only implemented for 64-bit types");
+    return T{};
   }
-  return ret_val;
 }
 
 // Collectives TODO: loosely adapted from IPC, needs review
@@ -975,74 +896,51 @@ GDA_CONTEXT_PUT_SIGNAL_DEF(_wave)
 
 // Internal functions used by collective and signal operations
 template <typename T>
-__device__ void GDAContext::internal_amo_add(void *dst, T value, int pe,
-    int qp_index, const ActiveWFInfo& wf_info) {
-  if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_add not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  bool need_turn {true};
-  uint64_t turns = __ballot(need_turn);
-  while (turns) {
-    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
-    int pe_turn = __shfl(pe, lane);
-    if (pe_turn == pe) {
-      qps[qp_index].atomic_nofetch(base_heap[pe] + L_offset, value, 0, wf_info);
-      need_turn = false;
-    }
-    turns = __ballot(need_turn);
+__device__ void GDAContext::internal_amo_add(void *dst, T value, int pe, int qp_index,
+                                             const ActiveWFInfo& wf_info) {
+  if constexpr (sizeof(T) != 8) {
+    //TODO: support types other than uint64_t
+    LOGD_ERROR_ABORT("gda:internal_amo_add only implemented for 64-bit types");
   }
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  qps[qp_index].atomic_nofetch(base_heap[pe] + L_offset, value, 0, wf_info);
 }
 
 template <typename T>
-__device__ T GDAContext::internal_amo_fetch_add(void *dst, T value, int pe,
-    int qp_index, const ActiveWFInfo& wf_info) {
-  if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_fadd not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  T ret_val = 0;
-  bool need_turn {true};
-  uint64_t turns = __ballot(need_turn);
-  while (turns) {
-    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
-    int pe_turn = __shfl(pe, lane);
-    if (pe_turn == pe) {
-      ret_val =  qps[qp_index].atomic_fetch(base_heap[pe] + L_offset, value, 0, wf_info);
-      need_turn = false;
-    }
-    turns = __ballot(need_turn);
+__device__ T GDAContext::internal_amo_fetch_add(void *dst, T value, int pe, int qp_index,
+                                                const ActiveWFInfo& wf_info) {
+  if constexpr (sizeof(T) != 8) {
+    //TODO: support types other than uint64_t
+    LOGD_ERROR_ABORT("gda:internal_amo_fetch_add only implemented for 64-bit types");
+    return T{};
   }
-  return ret_val;
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  return qps[qp_index].atomic_fetch(base_heap[pe] + L_offset, value, 0, wf_info);
 }
 
 template <typename T>
-__device__ T GDAContext::internal_amo_swap(void *dst, T value, int pe,
-    int qp_index, const ActiveWFInfo& wf_info) {
-  if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_set not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
-  bool need_turn {true};
-  uint64_t turns = __ballot(need_turn);
-  T ret_val;
-  T cond = 0;
-  while (turns) {
-    uint8_t lane = __ffsll((unsigned long long)turns) - 1;
-    int pe_turn = __shfl(pe, lane);
-    if (pe_turn == pe) {
-      /**
-       * Guess that the remote memory is zero by setting condition to zero.
-       * The compare-and-swap loop will execute at least twice if wrong.
-       * It may run additional times if contention on memory location.
-       */
-      while (true) {
-        ActiveWFInfo wf_info{pe};
-        ret_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, value, cond, wf_info);
-        if (ret_val == cond) {
-          break;
-        }
-        cond = ret_val;
-      }
-      need_turn = false;
-    }
-    turns = __ballot(need_turn);
+__device__ T GDAContext::internal_amo_swap(void *dst, T value, int pe, int qp_index,
+                                           [[maybe_unused]] const ActiveWFInfo& wf_info) {
+  if constexpr (sizeof(T) != 8) {
+    //TODO: support types other than uint64_t
+    LOGD_ERROR_ABORT("gda:internal_amo_swap only implemented for 64-bit types");
+    return T{};
   }
-  return ret_val;
+  /**
+   * Guess that the remote memory is zero by setting condition to zero.
+   * The compare-and-swap loop will execute at least twice if wrong.
+   * It may run additional times if contention on memory location.
+   */
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  T prior_val = 0;
+  T fetch_val = 0;
+  do {
+    ActiveWFInfo loop_wf_info{pe};
+    prior_val = fetch_val;
+    T desired_val = value;
+    fetch_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, desired_val, prior_val, loop_wf_info);
+  } while (fetch_val != prior_val);
+  return fetch_val;
 }
 
 /******************************************************************************

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -38,7 +38,6 @@
 
 #include <hip/hip_runtime.h>
 #include <type_traits>
-#include <utility>
 
 namespace rocshmem {
 
@@ -115,7 +114,7 @@ __device__ T GDAContext::internal_amo_fetch_op(void *dst, T value, int pe, uint3
   do {
     ActiveWFInfo loop_wf_info{pe};
     prior_val = fetch_val;
-    T desired = std::forward<Op>(op)(prior_val, value);
+    T desired = op(prior_val, value);
     fetch_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, desired, prior_val, loop_wf_info);
   } while (fetch_val != prior_val);
   return fetch_val;

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -134,8 +134,12 @@ __device__ T GDAContext::amo_swap(void *dst, T value, int pe) {
        * The compare-and-swap loop will execute at least twice if wrong.
        * It may run additional times if contention on memory location.
        */
-      while (wf_info.update(pe), (ret_val = qps[qp_index].atomic_cas(
-             base_heap[pe] + L_offset, value, cond, wf_info)) != cond) {
+      while (true) {
+        ActiveWFInfo wf_info{pe};
+        ret_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, value, cond, wf_info);
+        if (ret_val == cond) {
+          break;
+        }
         cond = ret_val;
       }
       need_turn = false;
@@ -160,8 +164,12 @@ __device__ T GDAContext::amo_fetch_and(void *dst, T value, int pe) {
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      while (wf_info.update(pe), (ret_val = qps[qp_index].atomic_cas(
-             base_heap[pe] + L_offset, desired_val, cond, wf_info)) != cond) {
+      while (true) {
+        ActiveWFInfo wf_info{pe};
+        ret_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, desired_val, cond, wf_info);
+        if (ret_val == cond) {
+          break;
+        }
         cond = ret_val;
         desired_val = ret_val & value;
       }
@@ -192,8 +200,12 @@ __device__ T GDAContext::amo_fetch_or(void *dst, T value, int pe) {
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      while (wf_info.update(pe), (ret_val = qps[qp_index].atomic_cas(
-             base_heap[pe] + L_offset, desired_val, cond, wf_info)) != cond) {
+      while (true) {
+        ActiveWFInfo wf_info{pe};
+        ret_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, desired_val, cond, wf_info);
+        if (ret_val == cond) {
+          break;
+        }
         cond = ret_val;
         desired_val = ret_val | value;
       }
@@ -224,8 +236,12 @@ __device__ T GDAContext::amo_fetch_xor(void *dst, T value, int pe) {
     uint8_t lane = __ffsll((unsigned long long)turns) - 1;
     int pe_turn = __shfl(pe, lane);
     if (pe_turn == pe) {
-      while (wf_info.update(pe), (ret_val = qps[qp_index].atomic_cas(
-             base_heap[pe] + L_offset, desired_val, cond, wf_info)) != cond) {
+      while (true) {
+        ActiveWFInfo wf_info{pe};
+        ret_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, desired_val, cond, wf_info);
+        if (ret_val == cond) {
+          break;
+        }
         cond = ret_val;
         desired_val = ret_val ^ value;
       }
@@ -313,7 +329,7 @@ __device__ void gda_compute_reduce(T *src, T *dst, int size, int wg_id, int wg_s
 
 template <typename T, ROCSHMEM_OP Op>
 __device__ void GDAContext::internal_direct_allreduce(T *dst, const T *src,
-    int nelems, GDATeam *team_obj, ActiveWFInfo &wf_info) {  // NOLINT(runtime/int)
+    int nelems, GDATeam *team_obj, const ActiveWFInfo& wf_info) {  // NOLINT(runtime/int)
 
   int stride = team_obj->tinfo_wrt_world->stride;
   int PE_start = team_obj->tinfo_wrt_world->pe_start;
@@ -430,7 +446,7 @@ __device__ void GDAContext::internal_direct_allreduce(T *dst, const T *src,
 template <typename T, ROCSHMEM_OP Op>
 __device__ void GDAContext::internal_ring_allreduce(T *dst, const T *src,
     int nelems, GDATeam *team_obj,  // NOLINT(runtime/int)
-    int n_seg, int seg_size, int chunk_size, ActiveWFInfo &wf_info) {
+    int n_seg, int seg_size, int chunk_size, const ActiveWFInfo& wf_info) {
 
   int PE_size = team_obj->tinfo_wrt_world->size;
   long *pSync = team_obj->reduce_pSync;
@@ -573,7 +589,7 @@ __device__ int GDAContext::reduce(rocshmem_team_t team, T *dest,
 template <typename T>
 __device__ void GDAContext::internal_put_broadcast(T *dst, const T *src,
     int nelems, int pe_root, int pe_start, int stride, int pe_size,
-    ActiveWFInfo &wf_info) {  // NOLINT(runtime/int)
+    const ActiveWFInfo& wf_info) {  // NOLINT(runtime/int)
   if (my_pe == pe_root) {
     int finish = pe_start + stride * pe_size;
     for (int i = pe_start; i < finish; i += stride) {
@@ -586,7 +602,7 @@ __device__ void GDAContext::internal_put_broadcast(T *dst, const T *src,
 
 template <typename T>
 __device__ void GDAContext::internal_get_broadcast(T *dst, const T *src,
-    int nelems, int pe_root, ActiveWFInfo &wf_info) {  // NOLINT(runtime/int)
+    int nelems, int pe_root, const ActiveWFInfo& wf_info) {  // NOLINT(runtime/int)
   if (my_pe != pe_root) {
     internal_getmem_wg(dst, src, nelems * sizeof(T), pe_root, pe_root, wf_info);
   }
@@ -960,7 +976,7 @@ GDA_CONTEXT_PUT_SIGNAL_DEF(_wave)
 // Internal functions used by collective and signal operations
 template <typename T>
 __device__ void GDAContext::internal_amo_add(void *dst, T value, int pe,
-    int qp_index, ActiveWFInfo &wf_info) {
+    int qp_index, const ActiveWFInfo& wf_info) {
   if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_add not implemented for non-64bit types"); }//TODO:support for non-uint64t
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   bool need_turn {true};
@@ -978,7 +994,7 @@ __device__ void GDAContext::internal_amo_add(void *dst, T value, int pe,
 
 template <typename T>
 __device__ T GDAContext::internal_amo_fetch_add(void *dst, T value, int pe,
-    int qp_index, ActiveWFInfo &wf_info) {
+    int qp_index, const ActiveWFInfo& wf_info) {
   if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_fadd not implemented for non-64bit types"); }//TODO:support for non-uint64t
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   T ret_val = 0;
@@ -998,7 +1014,7 @@ __device__ T GDAContext::internal_amo_fetch_add(void *dst, T value, int pe,
 
 template <typename T>
 __device__ T GDAContext::internal_amo_swap(void *dst, T value, int pe,
-    int qp_index, ActiveWFInfo &wf_info) {
+    int qp_index, const ActiveWFInfo& wf_info) {
   if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_set not implemented for non-64bit types"); }//TODO:support for non-uint64t
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
   bool need_turn {true};
@@ -1014,8 +1030,12 @@ __device__ T GDAContext::internal_amo_swap(void *dst, T value, int pe,
        * The compare-and-swap loop will execute at least twice if wrong.
        * It may run additional times if contention on memory location.
        */
-      while (wf_info.update(pe), (ret_val = qps[qp_index].atomic_cas(
-             base_heap[pe] + L_offset, value, cond, wf_info)) != cond) {
+      while (true) {
+        ActiveWFInfo wf_info{pe};
+        ret_val = qps[qp_index].atomic_cas(base_heap[pe] + L_offset, value, cond, wf_info);
+        if (ret_val == cond) {
+          break;
+        }
         cond = ret_val;
       }
       need_turn = false;
@@ -1055,12 +1075,10 @@ __device__ T GDAContext::internal_amo_swap(void *dst, T value, int pe,
  *    - QP[i,j]             →  i-th QP of PE j
  *    - **[ QP2,2 ]**       →  The 3rd QP (QP index 2) of PE2
  */
-__device__ __forceinline__ uint32_t GDAContext::get_qp_index(int pe,
-    ActiveWFInfo wf_info) {
-
+__device__ __forceinline__ uint32_t GDAContext::get_qp_index(int pe, const ActiveWFInfo& wf_info) {
   uint32_t qp_index   {0};
 
-  if(wf_info.pe_group_logical_lane_id == 0) {
+  if (wf_info.is_pe_group_first) {
     // Only the leader lane updates the counter (Does it require atomics?)
     // uint32_t local_qp_counter = __hip_atomic_fetch_add(&qp_counter[pe], 1,
     //                                        __ATOMIC_RELAXED,

--- a/projects/rocshmem/src/gda/ionic/queue_pair_ionic.cpp
+++ b/projects/rocshmem/src/gda/ionic/queue_pair_ionic.cpp
@@ -30,7 +30,7 @@
 
 namespace rocshmem {
 
-__device__ uint32_t QueuePair::reserve_sq(ActiveWFInfo &wf_info,
+__device__ uint32_t QueuePair::reserve_sq(const ActiveWFInfo& wf_info,
     uint32_t num_wqes) {
   uint32_t my_sq_prod = 0;
 
@@ -75,7 +75,7 @@ __device__ uint32_t QueuePair::commit_sq_single(uint32_t my_sq_prod, [[maybe_unu
   return dbprod;
 }
 
-__device__ uint32_t QueuePair::commit_sq(ActiveWFInfo &wf_info,
+__device__ uint32_t QueuePair::commit_sq(const ActiveWFInfo& wf_info,
     uint32_t my_sq_prod, [[maybe_unused]] uint32_t my_sq_pos,
     uint32_t num_wqes) {
   uint32_t dbprod = my_sq_prod + num_wqes;
@@ -155,7 +155,7 @@ __device__ void QueuePair::poll_wave_cqes(uint64_t activemask) {
   sq_msn = msn;
 }
 
-__device__ void QueuePair::ionic_quiet_internal_ccqe(ActiveWFInfo &wf_info,
+__device__ void QueuePair::ionic_quiet_internal_ccqe(const ActiveWFInfo& wf_info,
     uint32_t cons) {
   if (!wf_info.is_pe_group_first) {
     return;
@@ -220,7 +220,7 @@ __device__ void QueuePair::ionic_quiet_internal_ccqe_single(uint32_t cons) {
   }
 }
 
-__device__ void QueuePair::ionic_quiet_internal(ActiveWFInfo &wf_info, uint32_t cons) {
+__device__ void QueuePair::ionic_quiet_internal(const ActiveWFInfo& wf_info, uint32_t cons) {
   uint32_t greed = 10;
 
   if (!cq_mask) {
@@ -280,7 +280,7 @@ __device__ void QueuePair::ionic_ring_doorbell_single(uint32_t pos) {
   __atomic_store_n(&sq_dbreg[8 * __lane_id()], sq_dbval | (sq_mask & pos), __ATOMIC_SEQ_CST);
 }
 
-__device__ void QueuePair::ionic_quiet(ActiveWFInfo &wf_info) {
+__device__ void QueuePair::ionic_quiet(const ActiveWFInfo& wf_info) {
   ionic_quiet_internal(wf_info, sq_prod);
 }
 
@@ -289,7 +289,7 @@ __device__ void QueuePair::ionic_quiet_single() {
 }
 
 __device__ void QueuePair::ionic_post_wqe_rma(int32_t size, uintptr_t laddr,
-    uintptr_t raddr, uint8_t opcode, ActiveWFInfo &wf_info) {
+    uintptr_t raddr, uint8_t opcode, const ActiveWFInfo& wf_info) {
   uint32_t num_wqes = 1;
   if (wf_info.scope == ThreadScope::thread) {
     num_wqes = wf_info.num_pe_group_lanes;
@@ -400,7 +400,7 @@ __device__ void QueuePair::ionic_post_wqe_rma_single(int32_t size,
 
 __device__ uint64_t QueuePair::ionic_post_wqe_amo([[maybe_unused]] int32_t size, uintptr_t raddr,
     uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
-    bool fetching, ActiveWFInfo &wf_info) {
+    bool fetching, const ActiveWFInfo& wf_info) {
   uint32_t num_wqes = wf_info.num_pe_group_lanes;
   uint32_t my_sq_prod = reserve_sq(wf_info, num_wqes);
   uint32_t my_sq_pos = my_sq_prod + wf_info.pe_group_logical_lane_id;

--- a/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
@@ -259,7 +259,7 @@ __device__ void QueuePair::mlx5_quiet_single() {
 
 // can be called with all active lanes using any number of different QPs, don't assume anything
 __device__ void QueuePair::mlx5_post_wqe_rma(int32_t length, uintptr_t laddr, uintptr_t raddr,
-                                             uint8_t opcode, ActiveWFInfo &wf_info) {
+                                             uint8_t opcode, const ActiveWFInfo& wf_info) {
   if (wf_info.is_pe_group_last) {
     // get SQ lock
     acquire_lock(&mlx5_sq.lock);
@@ -333,7 +333,7 @@ __device__ void QueuePair::mlx5_post_wqe_rma_single(int32_t length, uintptr_t la
 __device__ uint64_t QueuePair::mlx5_post_wqe_amo([[maybe_unused]] int32_t length,
                                                  uintptr_t raddr, uint8_t opcode,
                                                  int64_t atomic_data, int64_t atomic_cmp,
-                                                 bool fetching, ActiveWFInfo &wf_info) {
+                                                 bool fetching, const ActiveWFInfo& wf_info) {
   if (wf_info.is_pe_group_last) {
     // get SQ lock
     acquire_lock(&mlx5_sq.lock);

--- a/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
@@ -260,6 +260,8 @@ __device__ void QueuePair::mlx5_quiet_single() {
 // can be called with all active lanes using any number of different QPs, don't assume anything
 __device__ void QueuePair::mlx5_post_wqe_rma(int32_t length, uintptr_t laddr, uintptr_t raddr,
                                              uint8_t opcode, const ActiveWFInfo& wf_info) {
+  /* since the leader needs to write the first 8 bytes of the LAST WQE to the
+   * doorbell register, it's easier if the LAST thread is the leader */
   if (wf_info.is_pe_group_last) {
     // get SQ lock
     acquire_lock(&mlx5_sq.lock);
@@ -334,6 +336,8 @@ __device__ uint64_t QueuePair::mlx5_post_wqe_amo([[maybe_unused]] int32_t length
                                                  uintptr_t raddr, uint8_t opcode,
                                                  int64_t atomic_data, int64_t atomic_cmp,
                                                  bool fetching, const ActiveWFInfo& wf_info) {
+  /* since the leader needs to write the first 8 bytes of the LAST WQE to the
+   * doorbell register, it's easier if the LAST thread is the leader */
   if (wf_info.is_pe_group_last) {
     // get SQ lock
     acquire_lock(&mlx5_sq.lock);

--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -142,7 +142,7 @@ __device__ uint64_t QueuePair::get_same_qp_lane_mask() {
  ************************ PROVIDER-SPECIFIC HELPERS ***************************
  *****************************************************************************/
 __device__ void QueuePair::post_wqe_rma([[maybe_unused]] int pe, int32_t size, uintptr_t laddr,
-    uintptr_t raddr, uint8_t opcode, ActiveWFInfo &wf_info) {
+    uintptr_t raddr, uint8_t opcode, const ActiveWFInfo& wf_info) {
   switch (gda_provider_) {
 #if defined(GDA_IONIC)
   case GDAProvider::IONIC:
@@ -189,7 +189,7 @@ __device__ void QueuePair::post_wqe_rma_single([[maybe_unused]] int32_t size, ui
 
 __device__ uint64_t QueuePair::post_wqe_amo([[maybe_unused]] int32_t size, uintptr_t raddr,
     uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
-    bool fetching, ActiveWFInfo &wf_info) {
+    bool fetching, const ActiveWFInfo& wf_info) {
   switch (gda_provider_) {
 #if defined(GDA_IONIC)
   case GDAProvider::IONIC:
@@ -234,7 +234,7 @@ __device__ uint64_t QueuePair::post_wqe_amo_single(uintptr_t raddr,
   }
 }
 
-__device__ void QueuePair::quiet([[maybe_unused]] ActiveWFInfo &wf_info) {
+__device__ void QueuePair::quiet([[maybe_unused]] const ActiveWFInfo& wf_info) {
   if(wf_info.is_pe_group_first) {
       switch (gda_provider_) {
     #if defined(GDA_IONIC)
@@ -284,7 +284,7 @@ __device__ void QueuePair::quiet_single() {
  ****************************** SHMEM INTERFACE *******************************
  *****************************************************************************/
 __device__ void QueuePair::put_nbi(void *dest, const void *source,
-    size_t nelems, int pe, ActiveWFInfo &wf_info) {
+    size_t nelems, int pe, const ActiveWFInfo& wf_info) {
   uintptr_t src = reinterpret_cast<uintptr_t>(source);
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
   post_wqe_rma(pe, nelems, src, dst, gda_op_rdma_write, wf_info);
@@ -305,35 +305,35 @@ __device__ void QueuePair::get_nbi_single(void *dest, const void *source, size_t
 }
 
 __device__ void QueuePair::get_nbi(void *dest, const void *source,
-    size_t nelems, int pe, ActiveWFInfo &wf_info) {
+    size_t nelems, int pe, const ActiveWFInfo& wf_info) {
   uintptr_t src = reinterpret_cast<uintptr_t>(source);
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
   post_wqe_rma(pe, nelems, dst, src, gda_op_rdma_read, wf_info);
 }
 
 __device__ int64_t QueuePair::atomic_cas(void *dest, int64_t atomic_data,
-    int64_t atomic_cmp, ActiveWFInfo &wf_info) {
+    int64_t atomic_cmp, const ActiveWFInfo& wf_info) {
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
   return post_wqe_amo(sizeof(int64_t), dst, gda_op_atomic_cs, atomic_data,
                       atomic_cmp, true, wf_info);
 }
 
 __device__ int64_t QueuePair::atomic_cas_nofetch(void *dest,
-    int64_t atomic_data, int64_t atomic_cmp, ActiveWFInfo &wf_info) {
+    int64_t atomic_data, int64_t atomic_cmp, const ActiveWFInfo& wf_info) {
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
   return post_wqe_amo(sizeof(int64_t), dst, gda_op_atomic_cs, atomic_data,
                       atomic_cmp, false, wf_info);
 }
 
 __device__ int64_t QueuePair::atomic_fetch(void *dest, int64_t atomic_data,
-    int64_t atomic_cmp, ActiveWFInfo &wf_info) {
+    int64_t atomic_cmp, const ActiveWFInfo& wf_info) {
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
   return post_wqe_amo(sizeof(int64_t), dst, gda_op_atomic_fa, atomic_data,
                       atomic_cmp, true, wf_info);
 }
 
 __device__ void QueuePair::atomic_nofetch(void *dest, int64_t atomic_data,
-    int64_t atomic_cmp, ActiveWFInfo &wf_info) {
+    int64_t atomic_cmp, const ActiveWFInfo& wf_info) {
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
   post_wqe_amo(sizeof(int64_t), dst, gda_op_atomic_fa, atomic_data,
                atomic_cmp, false, wf_info);

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -49,6 +49,8 @@
 #include "memory/hip_allocator.hpp"
 
 #include <map>
+#include <type_traits>
+#include <utility>
 
 namespace rocshmem {
 
@@ -117,7 +119,7 @@ class ActiveWFInfo {
     is_pe_group_last  = (pe_group_logical_lane_id == num_pe_group_lanes - 1);
   }
 
-  __device__ void printInfo() {
+  __device__ void printInfo() const {
     printf("PE: %d, Scope: %d, activemask: %llx, "
            "pe_group_mask: %llx, num_pe_group_lanes: %d, "
            "thread_id: %u, pe_group_logical_lane_id: %d, "
@@ -128,6 +130,34 @@ class ActiveWFInfo {
            threadIdx.x, pe_group_logical_lane_id,
            static_cast<int>(is_pe_group_first), pe_group_first_phys_lane_id,
            static_cast<int>(is_pe_group_last), pe_group_last_phys_lane_id);
+  }
+
+  template <typename F, typename... Args>
+  __device__ std::invoke_result_t<F, Args...> for_each_pe_group(F&& f, Args&&... args) const {
+    // need a dummy return value local for when F returns void
+    constexpr bool is_void_return = std::is_same_v<std::invoke_result_t<F, Args...>, void>;
+    using R = std::conditional_t<is_void_return, int, std::invoke_result_t<F, Args...>>;
+    [[maybe_unused]] R ret_val;
+
+    bool need_turn = true;
+    uint64_t turns = __ballot(need_turn);
+    while (turns) {
+      int first_lane = get_first_active_lane_id(turns);
+      int pe_turn = __shfl(pe, first_lane);
+      if (pe_turn == pe) {
+        // only executed once, so perfect forwarding via std::forward<T>() is safe
+        if constexpr (is_void_return) {
+          std::forward<F>(f)(std::forward<Args>(args)...);
+        } else {
+          ret_val = std::forward<F>(f)(std::forward<Args>(args)...);
+        }
+        need_turn = false;
+      }
+      turns = __ballot(need_turn);
+    }
+    if constexpr (!is_void_return) {
+      return ret_val;
+    }
   }
 };
 

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -55,6 +55,7 @@
 namespace rocshmem {
 
 class GDABackend;
+class GDAContext;
 
 struct user_buf_info_t {
   uintptr_t addr;
@@ -164,6 +165,7 @@ class ActiveWFInfo {
 class QueuePair {
  public:
   friend GDABackend;
+  friend GDAContext;
 
   /**
    * @brief Constructor.

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -117,21 +117,6 @@ class ActiveWFInfo {
     is_pe_group_last  = (pe_group_logical_lane_id == num_pe_group_lanes - 1);
   }
 
-  // used in CAS based atomic operations at thread scope
-  __device__ void update(int _pe, ThreadScope _scope = ThreadScope::thread) {
-    // Get active lane mask
-    activemask          = get_active_lane_mask();
-    pe_group_mask       = __match_any_sync(activemask, pe);
-    num_pe_group_lanes  = get_active_lane_count(pe_group_mask);
-    pe_group_logical_lane_id = get_active_lane_num(pe_group_mask);
-    pe_group_first_phys_lane_id = get_first_active_lane_id(pe_group_mask);
-    pe_group_last_phys_lane_id  = get_last_active_lane_id(pe_group_mask);
-    is_pe_group_first   = (pe_group_logical_lane_id == 0);
-    is_pe_group_last    = (pe_group_logical_lane_id == num_pe_group_lanes - 1);
-    scope               = _scope;
-    pe                  = _pe;
-  }
-
   __device__ void printInfo() {
     printf("PE: %d, Scope: %d, activemask: %llx, "
            "pe_group_mask: %llx, num_pe_group_lanes: %d, "
@@ -170,7 +155,7 @@ class QueuePair {
    * @param[in] wf_info Wavefront information.
    */
   __device__ void put_nbi(void *dest, const void *source, size_t nelems,
-      int pe, ActiveWFInfo &wf_info);
+      int pe, const ActiveWFInfo& wf_info);
 
   __device__ void put_nbi_single(void *dest, const void *source, size_t nelems,
       bool ring_db);
@@ -185,7 +170,7 @@ class QueuePair {
    * @param[in] wf_info Wavefront information.
    */
   __device__ void get_nbi(void *dest, const void *source, size_t nelems,
-      int pe, ActiveWFInfo &wf_info);
+      int pe, const ActiveWFInfo& wf_info);
 
   __device__ void get_nbi_single(void *dest, const void *source, size_t nelems,
       bool ring_db);
@@ -194,7 +179,7 @@ class QueuePair {
    * @brief Empty all completions from the completion queue.
    * @param[in] wf_info Wavefront information.
    */
-  __device__ void quiet(ActiveWFInfo &wf_info);
+  __device__ void quiet(const ActiveWFInfo& wf_info);
 
   __device__ void quiet_single();
 
@@ -202,7 +187,7 @@ class QueuePair {
    * @brief Empty all completions from the completion queue.
    * @param[in] wf_info Wavefront information.
    */
-  __device__ void quiet_scope(ActiveWFInfo &wf_info);
+  __device__ void quiet_scope(const ActiveWFInfo& wf_info);
 
   /**
    * @brief Create and enqueue an atomic fetch work queue entry (wqe).
@@ -215,7 +200,7 @@ class QueuePair {
    * @return An atomic value
    */
   __device__ int64_t atomic_fetch(void *dest, int64_t value, int64_t cond,
-      ActiveWFInfo &wf_info);
+      const ActiveWFInfo& wf_info);
 
   /**
    * @brief Create and enqueue an atomic fetch work queue entry (wqe).
@@ -226,7 +211,7 @@ class QueuePair {
    * @param[in] wf_info Wavefront information.
    */
   __device__ void atomic_nofetch(void *dest, int64_t value, int64_t cond,
-      ActiveWFInfo &wf_info);
+      const ActiveWFInfo& wf_info);
 
   __device__ void atomic_nofetch_single(void *dest, int64_t value);
 
@@ -241,7 +226,7 @@ class QueuePair {
    * @return An atomic value
    */
   __device__ int64_t atomic_cas(void *dest, int64_t atomic_data,
-      int64_t atomic_cmp, ActiveWFInfo &wf_info);
+      int64_t atomic_cmp, const ActiveWFInfo& wf_info);
 
   /**
    * @brief Create and enqueue an atomic cas work queue entry (wqe).
@@ -252,7 +237,7 @@ class QueuePair {
    * @param[in] wf_info Wavefront information.
    */
   __device__ int64_t atomic_cas_nofetch(void *dest, int64_t atomic_data,
-      int64_t atomic_cmp, ActiveWFInfo &wf_info);
+      int64_t atomic_cmp, const ActiveWFInfo& wf_info);
 
   uintptr_t base_heap = 0;
   size_t base_heap_size = 0;
@@ -272,7 +257,7 @@ class QueuePair {
   __device__ __attribute__((noinline)) uint64_t
   post_wqe_amo(int32_t size, uintptr_t raddr, uint8_t opcode,
       int64_t atomic_data, int64_t atomic_cmp, bool fetch,
-      ActiveWFInfo &wf_info);
+      const ActiveWFInfo& wf_info);
 
   __device__ __attribute__((noinline)) uint64_t post_wqe_amo_single(uintptr_t raddr,
       uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetching);
@@ -289,7 +274,7 @@ class QueuePair {
    */
   __device__ __attribute__((noinline)) void
   post_wqe_rma(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr,
-      uint8_t opcode, ActiveWFInfo &wf_info);
+      uint8_t opcode, const ActiveWFInfo& wf_info);
 
   __device__ __attribute__((noinline)) void
   post_wqe_rma_single(int32_t size, uintptr_t laddr, uintptr_t raddr,
@@ -298,12 +283,12 @@ class QueuePair {
 #if defined(GDA_MLX5)
   __device__ uint64_t mlx5_post_wqe_amo(int32_t size, uintptr_t raddr,
       uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetch,
-      ActiveWFInfo &wf_info);
+      const ActiveWFInfo& wf_info);
   __device__ uint64_t mlx5_post_wqe_amo_single(int32_t size, uintptr_t raddr,
       uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
       bool fetch);
   __device__ void mlx5_post_wqe_rma(int32_t size, uintptr_t laddr,
-      uintptr_t raddr, uint8_t opcode, ActiveWFInfo &wf_info);
+      uintptr_t raddr, uint8_t opcode, const ActiveWFInfo& wf_info);
   __device__ void mlx5_post_wqe_rma_single(int32_t size, uintptr_t laddr,
       uintptr_t raddr, uint8_t opcode, bool ring_db);
   __device__ void mlx5_quiet();
@@ -320,10 +305,10 @@ class QueuePair {
       int64_t atomic_data, int64_t atomic_cmp, bool fetching);
   __device__ uint64_t bnxt_post_wqe_amo(uintptr_t raddr, uint8_t opcode,
       int64_t atomic_data, int64_t atomic_cmp, bool fetching,
-      ActiveWFInfo &wf_info);
+      const ActiveWFInfo& wf_info);
 
   __device__ void bnxt_post_wqe_rma(int32_t size, uintptr_t laddr,
-      uintptr_t raddr, uint8_t opcode, ActiveWFInfo &wf_info);
+      uintptr_t raddr, uint8_t opcode, const ActiveWFInfo& wf_info);
 
   __device__ void bnxt_post_wqe_rma_single(int32_t size, uintptr_t laddr,
       uintptr_t raddr, uint8_t opcode, bool ring_db);
@@ -333,15 +318,15 @@ class QueuePair {
 #if defined(GDA_IONIC)
   __device__ uint64_t ionic_post_wqe_amo(int32_t size, uintptr_t raddr,
       uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetch,
-      ActiveWFInfo &wf_info);
+      const ActiveWFInfo& wf_info);
   __device__ uint64_t ionic_post_wqe_amo_single(int32_t size,
       uintptr_t raddr, uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
       bool fetch);
   __device__ void ionic_post_wqe_rma(int32_t size, uintptr_t laddr,
-      uintptr_t raddr, uint8_t opcode, ActiveWFInfo &wf_info);
+      uintptr_t raddr, uint8_t opcode, const ActiveWFInfo& wf_info);
   __device__ void ionic_post_wqe_rma_single(int32_t size,
       uintptr_t laddr, uintptr_t raddr, uint8_t opcode);
-  __device__ void ionic_quiet(ActiveWFInfo &wf_info);
+  __device__ void ionic_quiet(const ActiveWFInfo& wf_info);
   __device__ void ionic_quiet_single();
 #endif
 
@@ -410,7 +395,7 @@ class QueuePair {
    * @param num_wqes number of sq wqes to reserve for this wave.
    * @return position of my_tid=0's wqe.
    */
-  __device__ uint32_t reserve_sq(ActiveWFInfo &wf_info, uint32_t num_wqes);
+  __device__ uint32_t reserve_sq(const ActiveWFInfo& wf_info, uint32_t num_wqes);
   __device__ uint32_t reserve_sq_single(uint32_t num_wqes);
 
   /**
@@ -421,7 +406,7 @@ class QueuePair {
    * @param wqe this thread's wqe.
    * @return doorbell producer index.
    */
-  __device__ uint32_t commit_sq(ActiveWFInfo &wf_info, uint32_t my_sq_prod,
+  __device__ uint32_t commit_sq(const ActiveWFInfo& wf_info, uint32_t my_sq_prod,
       uint32_t my_sq_pos, uint32_t num_wqes);
   __device__ uint32_t commit_sq_single(uint32_t my_sq_prod, uint32_t my_sq_pos,
       uint32_t num_wqes);
@@ -438,7 +423,7 @@ class QueuePair {
    * @param cons wait for sq_msn to catch up to this position.
    */
   __device__ __attribute__((noinline))
-  void ionic_quiet_internal_ccqe(ActiveWFInfo &wf_info, uint32_t cons);
+  void ionic_quiet_internal_ccqe(const ActiveWFInfo& wf_info, uint32_t cons);
   __device__ __attribute__((noinline))
   void ionic_quiet_internal_ccqe_single(uint32_t cons);
 
@@ -448,7 +433,7 @@ class QueuePair {
    * @param cons wait for sq_msn to catch up to this position.
    */
   __device__ __attribute__((noinline))
-  void ionic_quiet_internal(ActiveWFInfo &wf_info, uint32_t cons);
+  void ionic_quiet_internal(const ActiveWFInfo& wf_info, uint32_t cons);
 
   /* GDAProvider::IONIC END */
 

--- a/projects/rocshmem/src/log.hpp
+++ b/projects/rocshmem/src/log.hpp
@@ -126,6 +126,7 @@ namespace rocshmem {
         __VA_OPT__(__VA_ARGS__,)                                              \
         __func__, __FILE__, __LINE__);                                        \
   abort();                                                                    \
+  __builtin_unreachable();                                                    \
 } while (0)
 
 #define LOG_WARN(fmt, ...) do {                                               \
@@ -259,6 +260,7 @@ void dprintf(const char* fmt, const Args&... args) {
         : "E%04dw%04ut%04u " fmt "\t" __FILE__ ":%d\n",                       \
         __VA_OPT__(__VA_ARGS__,) __LINE__);                                   \
   abort();                                                                    \
+  __builtin_unreachable();                                                    \
 } while (0)
 
 #ifdef BUILD_DEBUG_DEVICE

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -510,6 +510,18 @@ int rocm_init();
 
 void rocm_memory_lock_to_fine_grain(void* ptr, size_t size, void** gpu_ptr, int gpu_id);
 
+// Return the first argument with the same type as T, forwarded as the same value category.
+template <typename T, typename Arg, typename... Rest>
+[[maybe_unused]] static inline constexpr auto&& get_arg(Arg&& arg, Rest&&... rest) {
+  if constexpr (std::is_same_v<T, Arg>) {
+    return std::forward<Arg>(arg);
+  } else {
+    static_assert(sizeof...(Rest) > 0, "type not found in argument list");
+    using GetArgT = decltype(get_arg<T>(std::forward<Rest>(rest)...));
+    return std::forward<GetArgT>(get_arg<T>(std::forward<Rest>(rest)...));
+  }
+}
+
 }  // namespace rocshmem
 
 #endif  // LIBRARY_SRC_UTIL_HPP_

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -29,8 +29,10 @@
 #include <hsa/hsa.h>
 #include <hsa/hsa_ext_amd.h>
 
-#include <cstdio>
 #include <cassert>
+#include <cstdio>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)


### PR DESCRIPTION
## Motivation

`take_turns` logic has been remove from other code paths; remove it from GDA AMO functions as well. Currently only enabled for the mlx5 provider.

## Technical Details

* Add `ActiveWFInfo::for_each_pe_group<F, Args...>` non-static member function that calls the input Callable once for each PE-group; this implements the "take turns" waterfall loop logic in a generic fashion.
* [util] Add `get_arg<T, Args...>` free function that returns the first argument with type T.
* Add `GDAContext::internal_amo_take_turns<F, Args...>` non-static member function that either:
  * [mlx5] calls the input Callable directly, or
  * [bnxt, ionic] dispatches the input Callable through `ActiveWFInfo::for_each_pe_group`.
* Remove direct use of "take turns" waterfall loop logic from all AMO functions, replacing it with calls to `GDAContext::internal_amo_take_turns`.
* Add `GDAContext::internal_amo_fetch_op<T, Op>` non-static member function that generically implements `amo_fetch_<op>` using a compare-and-swap loop.
* Implement `amo_swap`, `amo_fetch_and`, `amo_fetch_or`, and `amo_fetch_xor` using `internal_amo_fetch_op`.
* Pass `wf_info` as `const ActiveWFInfo&`.
* Remove `ActiveWFInfo::update`.

## JIRA ID

~~AIROCSHMEM-233~~
AIROCSHMEM-404
AIROCSHMEM-405
AIROCSHMEM-406

## Test Plan

Validate AMO, collective, and flood functional tests on ionic, bnxt, and mlx5
Validate DeepEP on ionic, bnxt, and mlx5

## Test Result

- AMOs
  - [ ] ionic
  - [x] bnxt
  - [x] mlx5
- Collectives
  - [ ] ionic
  - [x] bnxt
  - [x] mlx5
- Flood
  - [ ] ionic
  - [x] bnxt
  - [x] mlx5
- DeepEP
  - [ ] ionic
  - [ ] bnxt
  - [x] mlx5

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
