### PR TITLE
[ROCM-21475] Fix Violation Status Accumulation Counter

### DIFF
--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_dyn_gpu_metrics.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_dyn_gpu_metrics.h
@@ -743,7 +743,7 @@ static const auto AMDGpuMetricsBaseSchema = details::AMDGpuMetricSchemaMapType_t
          details::AMDGpuMetricAttributeInstance_t(
              "Accumulation Counter", "Counter for accumulated metrics",
              details::AMDGpuMetricAttributeId_t::ACCUMULATION_COUNTER,
-             details::AMDGpuMetricAttributeType_t::TYPE_UINT32,
+             details::AMDGpuMetricAttributeType_t::TYPE_UINT64,
              details::AMDGpuMetricUnitType_t::COUNT_ACCUMULATOR),
          static_cast<details::AMDGpuMetricAttributeValue_t>(0)}},
 

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_dyn_gpu_metrics.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_dyn_gpu_metrics.cc
@@ -74,6 +74,29 @@ static inline rsmi_status_t schema_lookup_instance(AMDGpuMetricAttributeId_t att
   return RSMI_STATUS_NOT_FOUND;
 }
 
+static inline std::string attr_type_to_string(AMDGpuMetricAttributeType_t t) {
+  switch (t) {
+    case AMDGpuMetricAttributeType_t::TYPE_UINT8:
+      return "TYPE_UINT8";
+    case AMDGpuMetricAttributeType_t::TYPE_INT8:
+      return "TYPE_INT8";
+    case AMDGpuMetricAttributeType_t::TYPE_UINT16:
+      return "TYPE_UINT16";
+    case AMDGpuMetricAttributeType_t::TYPE_INT16:
+      return "TYPE_INT16";
+    case AMDGpuMetricAttributeType_t::TYPE_UINT32:
+      return "TYPE_UINT32";
+    case AMDGpuMetricAttributeType_t::TYPE_INT32:
+      return "TYPE_INT32";
+    case AMDGpuMetricAttributeType_t::TYPE_UINT64:
+      return "TYPE_UINT64";
+    case AMDGpuMetricAttributeType_t::TYPE_INT64:
+      return "TYPE_INT64";
+    default:
+      return "UNKNOWN";
+  }
+}
+
 template <class T>
 static inline std::optional<T> read_scalar(Cursor& c) {
   // Ensure we can read safely
@@ -191,12 +214,24 @@ auto AMDGpuDynamicMetrics_t::parse_from_buffer(const std::byte* data, std::size_
     AMDGpuMetricAttributeInstance_t inst{};
     status = schema_lookup_instance(attr_id, attr_type, inst);
     if (status != RSMI_STATUS_SUCCESS) {
+      const auto attr_name = [&]() -> std::string {
+        const auto it = AMDGpuMetricAttributeIdToString.find(attr_id);
+        return (it != AMDGpuMetricAttributeIdToString.end()) ? it->second.m_short_info : "UNKNOWN";
+      }();
+
       ss << __PRETTY_FUNCTION__ << " | Warn: schema lookup miss"
-         << " | Attr ID: "
+         << " | Attr Name: " << attr_name << " | Attr ID: "
          << static_cast<std::underlying_type_t<AMDGpuMetricAttributeId_t>>(attr_id)
-         << " | Attr Type: "
-         << static_cast<std::underlying_type_t<AMDGpuMetricAttributeType_t>>(attr_type)
-         << " | Returning = " << getRSMIStatusString(status) << " |";
+         << " | Attr Type: " << attr_type_to_string(attr_type) << " ("
+         << static_cast<std::underlying_type_t<AMDGpuMetricAttributeType_t>>(attr_type) << ")";
+
+      if (status == RSMI_STATUS_NOT_SUPPORTED) {
+        const auto expected_type = AMDGpuMetricsBaseSchema.at(attr_id).m_instance.m_attribute_type;
+        ss << " | Size mismatch: schema expects " << attr_type_to_string(expected_type) << ", got "
+           << attr_type_to_string(attr_type);
+      }
+
+      ss << " | Returning = " << getRSMIStatusString(status, false) << " |";
       LOG_TRACE(ss);
 
       if (!skip_payload(cur, attr_type, instances)) {


### PR DESCRIPTION
Changes:
- Update UINT32 -> UINT64 for ACCUMULATION_COUNTER
(Latest driver updates)
- Improve dynamic metrics schema miss logs

Signed-off-by: Charis Poag <charis.poag@amd.com>

## Motivation

Driver updated accumulation counter in upcoming releases (`uint32` -> `uint64`)
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

ROCM-21475

## Test Plan

Tested on multiple asics with upcoming driver changes.

Before:
<img width="660" height="687" alt="image" src="https://github.com/user-attachments/assets/8d490e6b-72b9-4538-913e-ba28cfee71d9" />


After:
<img width="2223" height="142" alt="image" src="https://github.com/user-attachments/assets/1f12ec6e-88b7-4f62-a770-074d2d137921" />
<img width="826" height="652" alt="image" src="https://github.com/user-attachments/assets/3f9b2ad5-d91f-4bcc-b331-666a1da4258c" />



## Test Result

Violation status is readable as was in previous releases.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
