### PR TITLE
ROCM-21025 - cooperative launch negative test fails on perfect-cube ASIC configs

### DIFF
--- a/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernel.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernel.cc
@@ -148,7 +148,13 @@ HIP_TEST_CASE(Unit_hipLaunchCooperativeKernel_Negative_Parameters) {
                                                            reinterpret_cast<void*>(kernel), 1, 0));
     const unsigned int multiproc_count =
         GetDeviceAttribute(hipDeviceAttributeMultiprocessorCount, 0);
-    const unsigned int dim = std::ceil(std::cbrt(max_blocks * multiproc_count));
+    unsigned int dim = std::ceil(std::cbrt(max_blocks * multiproc_count));
+    // When the product is a perfect cube, dim^3 == limit (not exceeding it).
+    // Bump dim to guarantee we exceed the cooperative launch block limit.
+    if (static_cast<unsigned long long>(dim) * dim * dim <=
+        static_cast<unsigned long long>(max_blocks) * multiproc_count) {
+      dim++;
+    }
     HIP_CHECK_ERROR(hipLaunchCooperativeKernel(reinterpret_cast<void*>(kernel), dim3{dim, dim, dim},
                                                dim3{1, 1, 1}, nullptr, 0, nullptr),
                     hipErrorCooperativeLaunchTooLarge);


### PR DESCRIPTION
## Motivation

Fix `Unit_hipLaunchCooperativeKernel_Negative_Parameters` failure on gfx1150.

## Technical Details

The test computes `dim = ceil(cbrt(max_blocks * multiproc_count))` and expects `dim^3` to exceed the cooperative launch limit. On gfx1150 the product is `512 = 8^3` (a perfect cube), so `dim^3 == 512` equals the limit rather than exceeding it. The API correctly returns `hipSuccess`; the test expectation is wrong.

The fix bumps `dim` by 1 when `dim^3 <= product`, matching the pattern in `hip_module_launch_kernel_common.hh`.

## JIRA ID

Resolves ROCM-21025

## Test Plan

Verified with a standalone reproducer on gfx1150 and gfx1032 that the fixed logic correctly exceeds the limit and returns `hipErrorCooperativeLaunchTooLarge`, and is a no-op on ASICs where the product is not a perfect cube.

## Test Result

Pass on gfx1150 (Strix Point) and gfx1032 (Navi 23).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.