### PR TITLE
[rocprofiler-sdk] Use GITHUB_TOKEN for code coverage image upload

### DIFF
--- a/.github/workflows/rocprofiler-sdk-code_coverage.yml
+++ b/.github/workflows/rocprofiler-sdk-code_coverage.yml
@@ -437,7 +437,7 @@ jobs:
         which -a git
         git --version
 
-        ./source/scripts/upload-image-to-github.py --bot --token ${{ secrets.ROCPROFILER_TOKEN }} --files .codecov/{all,tests,samples}.png --output-dir .codecov --name pr-${{ github.event.pull_request.number }}
+        ./source/scripts/upload-image-to-github.py --bot --token ${{ secrets.GITHUB_TOKEN }} --files .codecov/{all,tests,samples}.png --output-dir .codecov --name pr-${{ github.event.pull_request.number }}
 
         echo -e "\n${PWD}:"
         ls -la .
@@ -479,7 +479,7 @@ jobs:
           ${{ steps.generatereport.outputs.CODECOVERAGE_REPORT }}
           </details>
       with:
-        github-token: ${{ secrets.ROCPROFILER_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const commentIdentifier = '<!-- code-coverage-comment-identifier -->'; // Used to identify codecov comment
             const commentBody = process.env.COMMENT_BODY;

--- a/.github/workflows/rocprofiler-sdk-code_coverage.yml
+++ b/.github/workflows/rocprofiler-sdk-code_coverage.yml
@@ -423,7 +423,7 @@ jobs:
     - id: generatereport
       name: Generate Code Coverage Comment
       if: github.event_name == 'pull_request'
-      timeout-minutes: 5
+      timeout-minutes: 10
       working-directory: projects/rocprofiler-sdk
       shell: bash
       run: |
@@ -468,7 +468,7 @@ jobs:
 
     - name: Write Code Coverage Comment
       if: github.event_name == 'pull_request'
-      timeout-minutes: 5
+      timeout-minutes: 10
       uses: actions/github-script@v6
       env:
         COMMENT_BODY: |

--- a/.github/workflows/rocprofiler-sdk-code_coverage.yml
+++ b/.github/workflows/rocprofiler-sdk-code_coverage.yml
@@ -1,8 +1,7 @@
 name: rocprofiler-sdk Code Coverage
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 on:
   workflow_dispatch:
@@ -70,6 +69,9 @@ env:
 jobs:
   code-coverage:
     name: Code Coverage • ${{ matrix.system.gpu }} • ${{ matrix.system.os }}
+    permissions:
+      contents: write
+      pull-requests: write
     strategy:
       # fail-fast: false
       matrix:

--- a/.github/workflows/rocprofiler-sdk-code_coverage.yml
+++ b/.github/workflows/rocprofiler-sdk-code_coverage.yml
@@ -1,7 +1,7 @@
 name: rocprofiler-sdk Code Coverage
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 on:


### PR DESCRIPTION
## Motivation

Updates the `rocprofiler-sdk` code coverage GitHub Actions workflow to stop using a repository secret for image upload/commenting and instead rely on the built-in `GITHUB_TOKEN`.

## Technical Details

- Switch code coverage image upload script to authenticate with `secrets.GITHUB_TOKEN` instead of `secrets.ROCPROFILER_TOKEN`.
- Update `actions/github-script` step to use `secrets.GITHUB_TOKEN` for posting/updating the PR comment.
- Increase timeouts for the report generation and comment posting steps.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
