### PR TITLE
[codespell] Fix spelling errors in `docs`, `shared`, and `test` dirs

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -23,7 +23,7 @@ This document is to detail the various continuous integration (CI) systems that 
 
 ### Overview <a id="az-overview"></a>
 
-The ROCm Azure Pipelines CI (also known as External CI) is a public-facing CI system that builds and tests against latest public source code. It encompasses almost all of the ROCm stack, typically pulling source code from the `develop` or `amd-staging` branch on a component's GitHub repository. The CI's main source is publically available at [ROCm/ROCm/.azuredevops](https://github.com/ROCm/ROCm/tree/develop/.azuredevops).
+The ROCm Azure Pipelines CI (also known as External CI) is a public-facing CI system that builds and tests against latest public source code. It encompasses almost all of the ROCm stack, typically pulling source code from the `develop` or `amd-staging` branch on a component's GitHub repository. The CI's main source is publicly available at [ROCm/ROCm/.azuredevops](https://github.com/ROCm/ROCm/tree/develop/.azuredevops).
 
 See the [Azure super-repo dashboard](https://dev.azure.com/ROCm-CI/ROCm-CI/_build?definitionScope=%5Csuper-repo) for a full list of pipelines running in the super-repo.
 

--- a/shared/amdgpu-windows-interop/hsail-compiler/lib/loaders/elf/elf.cpp
+++ b/shared/amdgpu-windows-interop/hsail-compiler/lib/loaders/elf/elf.cpp
@@ -30,7 +30,7 @@ using namespace oclelfutils;
 #endif
 
 /*
-   Opague data type definition.
+   Opaque data type definition.
 */
 struct symbol_handle {
   union {
@@ -1076,7 +1076,7 @@ OclElf::addSectionData (
 /*
    getShdrNdx() returns an index to the .shstrtab in 'outNdx' for "name" if it
    is in .shstrtab (outNdx == 0 means it is not in .shstrtab). It return true if
-   it is successful; return false if en error occured.
+   it is successful; return false if en error occurred.
    */
   bool
 OclElf::getShstrtabNdx(Elf64_Word& outNdx, const char* name)

--- a/shared/amdgpu-windows-interop/hsail-compiler/lib/loaders/elf/elf.hpp
+++ b/shared/amdgpu-windows-interop/hsail-compiler/lib/loaders/elf/elf.hpp
@@ -352,7 +352,7 @@ private:
      */
     bool InitElf ();
 
-    // Wraper for creating a section header and Elf_Data
+    // Wrapper for creating a section header and Elf_Data
     bool createShdr (
         oclElfSections id,
         Elf_Scn*&      scn,

--- a/shared/amdgpu-windows-interop/hsail-compiler/lib/loaders/elf/elf_utils.hpp
+++ b/shared/amdgpu-windows-interop/hsail-compiler/lib/loaders/elf/elf_utils.hpp
@@ -26,7 +26,7 @@ namespace amd {
 class OclElfErr
 {
 public:
-    // Temperary buffer for copying from file to file
+    // Temporary buffer for copying from file to file
     uint8_t* _copyBuffer;   // Initialized first time it is used
 
 private:

--- a/shared/amdgpu-windows-interop/hsail-compiler/lib/loaders/elf/utils/common/_elftc.h
+++ b/shared/amdgpu-windows-interop/hsail-compiler/lib/loaders/elf/utils/common/_elftc.h
@@ -27,7 +27,7 @@
  */
 
 /**
- ** Miscellanous definitions needed by multiple components.
+ ** Miscellaneous definitions needed by multiple components.
  **/
 
 #ifndef	_ELFTC_H

--- a/shared/amdgpu-windows-interop/hsail-compiler/lib/loaders/elf/utils/common/elfdefinitions.h
+++ b/shared/amdgpu-windows-interop/hsail-compiler/lib/loaders/elf/utils/common/elfdefinitions.h
@@ -273,7 +273,7 @@ _ELF_DEFINE_DT(DT_MIPS_DELTA_RELOC, 0x7000001BUL,			\
 _ELF_DEFINE_DT(DT_MIPS_DELTA_RELOC_NO, 0x7000001CUL,			\
 	"number of entries in DT_MIPS_DELTA_RELOC")			\
 _ELF_DEFINE_DT(DT_MIPS_DELTA_SYM,   0x7000001DUL,			\
-	"Delta symbols refered by Delta relocations")			\
+	"Delta symbols referred by Delta relocations")			\
 _ELF_DEFINE_DT(DT_MIPS_DELTA_SYM_NO, 0x7000001EUL,			\
 	"number of entries in DT_MIPS_DELTA_SYM")			\
 _ELF_DEFINE_DT(DT_MIPS_DELTA_CLASSSYM, 0x70000020UL,			\
@@ -1262,7 +1262,7 @@ _ELF_DEFINE_STV(STV_INTERNAL,        1,		\
 _ELF_DEFINE_STV(STV_HIDDEN,          2,		\
 	"hidden from other components")		\
 _ELF_DEFINE_STV(STV_PROTECTED,       3,		\
-	"local references are not preemptable")
+	"local references are not preemptible")
 
 #undef	_ELF_DEFINE_STV
 #define	_ELF_DEFINE_STV(N, V, DESCR)	N = V ,
@@ -1276,7 +1276,7 @@ enum {
  */
 #define	_ELF_DEFINE_SYMBOL_FLAGS()		\
 _ELF_DEFINE_SYF(SYMINFO_FLG_DIRECT,	0x01,	\
-	"directly assocated reference")		\
+	"directly associated reference")		\
 _ELF_DEFINE_SYF(SYMINFO_FLG_COPY,	0x04,	\
 	"definition by copy-relocation")	\
 _ELF_DEFINE_SYF(SYMINFO_FLG_LAZYLOAD,	0x08,	\
@@ -2181,7 +2181,7 @@ _ELF_DEFINE_ODK(ODK_HWOR,       8,      "hardware OR patch applied")	\
 _ELF_DEFINE_ODK(ODK_GP_GROUP,   9,					\
 	"GP group to use for text/data sections")			\
 _ELF_DEFINE_ODK(ODK_IDENT,      10,     "ID information")		\
-_ELF_DEFINE_ODK(ODK_PAGESIZE,   11,     "page size infomation")
+_ELF_DEFINE_ODK(ODK_PAGESIZE,   11,     "page size information")
 
 #undef	_ELF_DEFINE_ODK
 #define	_ELF_DEFINE_ODK(N, V, DESCR)	N = V ,

--- a/shared/amdgpu-windows-interop/hsail-compiler/lib/loaders/elf/utils/libelf/elf_strptr.c
+++ b/shared/amdgpu-windows-interop/hsail-compiler/lib/loaders/elf/utils/libelf/elf_strptr.c
@@ -89,7 +89,7 @@ elf_strptr(Elf *e, size_t scndx, size_t offset)
 		}
 	} else {
 		/*
-		 * Otherwise, the `d_off' members are not useable and
+		 * Otherwise, the `d_off' members are not usable and
 		 * we need to compute offsets ourselves, taking into
 		 * account 'holes' in coverage of the section introduced
 		 * by alignment requirements.

--- a/shared/amdgpu-windows-interop/hsail-compiler/lib/loaders/elf/utils/libelf/elf_update.c
+++ b/shared/amdgpu-windows-interop/hsail-compiler/lib/loaders/elf/utils/libelf/elf_update.c
@@ -650,7 +650,7 @@ _libelf_resync_elf(Elf *e, struct _Elf_Extent_List *extents)
     /*
      * If we are a read only elf that has not had its
      * headers loaded, or a read/write elf that is not
-     * based on a file descripter and had its headers
+     * based on a file descriptor and had its headers
      * loaded, then lets load the headers.
      * If the loading of the headers fails, return -1.
      */

--- a/shared/amdgpu-windows-interop/pal/inc/core/pal.h
+++ b/shared/amdgpu-windows-interop/pal/inc/core/pal.h
@@ -117,7 +117,7 @@ constexpr uint64 InternalApiPsoHash       = UINT64_MAX;  ///< Default Hash for P
 /// Device::GetProperties, returned in DeviceProperties.engineProperties[].
 enum EngineType : uint32
 {
-    /// Corresponds to the graphics hardware engine (a.k.a. graphcis ring a.k.a 3D).
+    /// Corresponds to the graphics hardware engine (a.k.a. graphics ring a.k.a 3D).
     EngineTypeUniversal,
 
     /// Corresponds to asynchronous compute engines (ACE).
@@ -451,7 +451,7 @@ struct DirectCaptureInfo
             uint32 preflip              :  1;  ///< Requires pre-flip primary access
             uint32 postflip             :  1;  ///< Requires post-flip primary access. A DirectCapture resource cannot
                                                ///  have pre-flip and post-flip access at the same time
-            uint32 accessDesktop        :  1;  ///< Requires acces to the desktop
+            uint32 accessDesktop        :  1;  ///< Requires access to the desktop
             uint32 shared               :  1;  ///< This resource will be shared between APIs
             uint32 frameGenRatio        :  4;  ///< Frame generation ratio
             uint32 paceGeneratedFrame   :  1;  ///< Requires pacing the generated frames

--- a/shared/amdgpu-windows-interop/pal/inc/core/palCmdBuffer.h
+++ b/shared/amdgpu-windows-interop/pal/inc/core/palCmdBuffer.h
@@ -616,7 +616,7 @@ union TessDistributionFactors
         /// increments the accumulator for the Patch distribution factor.
         uint32 donutDistributionFactor : 5;
         /// Used when the distribution mode is TRAPEZOID for quad and tri domain types. The number of donuts in the patch
-        /// are compared against this value to detemine whether this donut gets split up into trapezoids (needs the patch to
+        /// are compared against this value to determine whether this donut gets split up into trapezoids (needs the patch to
         /// be in donut mode). A value of 0 or 1 will be treated as 2. The innermost donut is never allowed to be broken
         /// into trapezoids.
         uint32 trapDistributionFactor  : 3;
@@ -1472,7 +1472,7 @@ struct DrawIndirectArgs
     uint32 instanceCount;  ///< Number of instances to draw.
     uint32 firstVertex;    ///< Starting index value for the draw.  Indices passed to the vertex shader will range from
                            ///  firstVertex to firstVertex + vertexCount - 1.
-    uint32 firstInstance;  ///< Starting instance for the draw.  Instace IDs passed to the vertex shader will range from
+    uint32 firstInstance;  ///< Starting instance for the draw.  Instance IDs passed to the vertex shader will range from
                            ///  firstInstance to firstInstance + instanceCount - 1.
 };
 
@@ -1491,7 +1491,7 @@ struct DrawIndexedIndirectArgs
     uint32 firstIndex;     ///< Starting index buffer slot for the draw.
     int32  vertexOffset;   ///< Offset added to the index fetched from the index buffer before it is passed to the
                            ///  vertex shader.
-    uint32 firstInstance;  ///< Starting instance for the draw.  Instace IDs passed to the vertex shader will range from
+    uint32 firstInstance;  ///< Starting instance for the draw.  Instance IDs passed to the vertex shader will range from
                            ///  firstInstance to firstInstance + instanceCount - 1.
 };
 
@@ -1586,7 +1586,7 @@ enum class VrsCombiner : uint32
     Count
 };
 
-/// Structure for defining paramters to the CmdSetPerDrawVrsRate function.
+/// Structure for defining parameters to the CmdSetPerDrawVrsRate function.
 struct VrsRateParams
 {
     /// The shading rate to be bound to the render state.
@@ -1610,7 +1610,7 @@ struct VrsRateParams
     } flags;              ///< Flags controlling VRS rate parameters
 };
 
-/// Structure for defininig paramters to the CmdSetVrsCenterState function.
+/// Structure for defininig parameters to the CmdSetVrsCenterState function.
 struct VrsCenterState
 {
     /// The offset is scaled by the coarse pixel size and then added to the center location
@@ -1789,7 +1789,7 @@ typedef void (PAL_STDCALL *CmdDispatchAqlFunc)(
 /// @see ICmdBuffer::CmdSetInputAssemblyState
 struct InputAssemblyStateParams
 {
-    PrimitiveTopology topology;                     ///< Defines how vertices should be interpretted and rendered by
+    PrimitiveTopology topology;                     ///< Defines how vertices should be interpreted and rendered by
                                                     ///  the graphics pipeline.
     uint8             patchControlPoints;           ///< # of control points per patch. [0-32] valid. Should be set to
                                                     ///  0 by clients if topology is not PrimitiveTopology::Patch.
@@ -1849,7 +1849,7 @@ struct LineStippleStateParams
     uint32 lineStippleScale; ///< Line stipple repeat factor.
 };
 
-/// Specifies paramters for setting up depth bias. Depth Bias is used to ensure a primitive can properly be displayed
+/// Specifies parameters for setting up depth bias. Depth Bias is used to ensure a primitive can properly be displayed
 /// (without Z fighting) in front (or behind) of the previously rendered co-planar primitive.  This is useful for decal
 /// or shadow rendering.
 /// @see ICmdBuffer::CmdSetDepthBiasState
@@ -1942,7 +1942,7 @@ constexpr uint32 NumHiSPretests = 2;
 /// or via an app profile in the client layer. For example, if the application 1) clears stencil, 2) does a pass to
 /// write stencil, 3) then does a final pass that masks rendering based on the stencil value being > 0, ideally we
 /// would choose a pretest of func=Greater, mask=0xFF, and value=0 so that #2 would update the stencil image with
-/// per-tile data that lets #3 be accelerated at maximum effeciency.
+/// per-tile data that lets #3 be accelerated at maximum efficiency.
 ///
 /// In absence of app-specific knowledge, the following algorithm may be a good generic approach:
 /// 1. When the stencil image is cleared, set pretest #0 to func=Equal, mask=0xFF, and value set to the clear value.
@@ -2019,10 +2019,10 @@ struct ViewportParams
     DepthRange depthRange;              ///< Specifies the target range of Z values
     DepthClamp userDepthClamp;          ///< Specifies the clamp range of Z values for DepthClampMode::UserDefined.
     // Define viewports array at the end of the structure as it is common to only access the first N from the CPU.
-    Viewport   viewports[MaxViewports]; ///< Array of desciptors for each viewport.
+    Viewport   viewports[MaxViewports]; ///< Array of descriptors for each viewport.
 };
 
-/// Specifies the parameters for specifing the scissor rectangle.
+/// Specifies the parameters for specifying the scissor rectangle.
 struct ScissorRectParams
 {
     uint32 count;                   ///< Number of scissor rectangles.
@@ -2115,7 +2115,7 @@ enum ComputeStateFlags : uint32
     ComputeStatePipelineAndUserData = 0x1, ///< Selects the bound compute pipeline, all non-indirect user data, and all
                                            ///  kernel arguments (if applicable). Note that the current user data will
                                            ///  be invalidated on CmdSaveComputeState.
-    ComputeStateBorderColorPalette  = 0x2, ///< Selects the bound border color pallete that affects compute pipelines.
+    ComputeStateBorderColorPalette  = 0x2, ///< Selects the bound border color palette that affects compute pipelines.
     ComputeStateAllState            = 0x3, ///< Selects all state
     ComputeStateTreatAsBlt          = 0x4, ///< This compute state counts towards PipelineStageBlt.
     ComputeStateAllFlags            = 0x7, ///< Selects all possible options
@@ -2125,9 +2125,9 @@ enum ComputeStateFlags : uint32
 };
 
 /// Provides dynamic command buffer flags during submission
-/// The following flags are used for Frame Pacing when delay time is configured to be caculated by KMD.
+/// The following flags are used for Frame Pacing when delay time is configured to be calculated by KMD.
 /// (Currently DX clients require this).
-/// For clients that do not need Frame Pacing with KMD caculated delay time, they can ignore these flags:
+/// For clients that do not need Frame Pacing with KMD calculated delay time, they can ignore these flags:
 ///
 /// - frameBegin and frameEnd : Client's presenting queue should track its present state,
 ///   and set frameBegin flag on the first command buffer after present,
@@ -2159,7 +2159,7 @@ struct CmdBufInfo
             uint32 preflip                 : 1;  ///< This command buffer has pre-flip access to DirectCapture resource
             uint32 postflip                : 1;  ///< This command buffer has post-flip access to DirectCapture resource
             uint32 privateFlip             : 1;  ///< Need to flip to a private primary surface for DirectCapture feature
-            uint32 vpBltExecuted           : 1;  ///< This command buffer comtains VP Blt work.
+            uint32 vpBltExecuted           : 1;  ///< This command buffer contains VP Blt work.
             uint32 disableDccRejected      : 1;  ///< Reject KMD's DisableDcc request to avoid writing to front buffer.
             uint32 noFlip                  : 1;  ///< No flip when DirectCapture access submission completes
             uint32 frameGenIndex           : 4;  ///< Index of the DirectCapture feature generated frames
@@ -2315,7 +2315,7 @@ struct ScaledCopyInfo
     ImageRotation                   rotation;       ///< Rotation option between two images.
     const ColorKey*                 pColorKey;      ///< Color key value.
     const Rect*                     pScissorRect;   ///< Scissor test rectangle.
-    ScaledCopyFlags                 flags;          ///< Copy flags, identifies the type of blt to peform.
+    ScaledCopyFlags                 flags;          ///< Copy flags, identifies the type of blt to perform.
 };
 
 /// Input structure to @ref ICmdBuffer::CmdGenerateMipmaps. Specifies parameters needed to execute CmdGenerateMipmaps.
@@ -2539,13 +2539,13 @@ public:
 
     /// Sets the shading rate in the command buffer along with the state of the various combiners.
     ///
-    /// @param [in] rateParams     Nwe VRS shading rate parameters to be bound.
+    /// @param [in] rateParams     New VRS shading rate parameters to be bound.
     virtual void CmdSetPerDrawVrsRate(
         const VrsRateParams&  rateParams) = 0;
 
     /// Setup parameters regarding how pixel center will be evaluated with VRS.
     ///
-    /// @param [in] centerState     Nwe VRS parameters to be bound that control how pixel center is defined.
+    /// @param [in] centerState     New VRS parameters to be bound that control how pixel center is defined.
     virtual void CmdSetVrsCenterState(
         const VrsCenterState&  centerState) = 0;
 
@@ -3288,7 +3288,7 @@ public:
     /// - PipelineStage:  @ref PipelineStageBlt
     /// - CacheCoherency: @ref CoherCopySrc for the source and @ref CoherCopyDst for the destination.
     ///
-    /// @param [in] srcGpuVirtAddr  GPU memory vitrual address where the source regions are located.
+    /// @param [in] srcGpuVirtAddr  GPU memory virtual address where the source regions are located.
     /// @param [in] dstGpuVirtAddr  GPU memory virtual address where the destination regions are located.
     /// @param [in] regionCount     Number of regions to copy; size of the pRegions array.
     /// @param [in] pRegions        Array of copy regions, each entry specifynig a source offset, destination offset,
@@ -3447,7 +3447,7 @@ public:
     /// - CacheCoherency: @ref CoherCopySrc for the source and @ref CoherCopyDst for the destination.
     /// - ImageLayout:    @ref LayoutCopyDst
     ///
-    /// @param [in] srcGpuVirtAddr GPU memory vitrual address where the source regions are located.
+    /// @param [in] srcGpuVirtAddr GPU memory virtual address where the source regions are located.
     /// @param [in] dstImage       Image where destination data will be written.
     /// @param [in] dstImageLayout Current allowed usages and engines for the destination image.  These masks must
     ///                            include LayoutCopyDst and the ImageLayoutEngineFlags corresponding to the engine
@@ -3519,7 +3519,7 @@ public:
     /// @param [in] srcImageLayout Current allowed usages and engines for the source image.  These masks must
     ///                            include LayoutCopySrc and the ImageLayoutEngineFlags corresponding to the engine
     ///                            this function is being called on.
-    /// @param [in] dstGpuVirtAddr GPU memory vitrual address where the destination data will be written.
+    /// @param [in] dstGpuVirtAddr GPU memory virtual address where the destination data will be written.
     /// @param [in] regionCount    Number of regions to copy; size of the pRegions array.
     /// @param [in] pRegions       Array of copy regions, each entry specifying a destination offset, a source
     ///                            subresource, source x/y/z offset, and copy size in the x/y/z dimensions.
@@ -3776,7 +3776,7 @@ public:
     /// equal than 8 bytes, CmdWriteImmediate() is preferred.
     ///
     /// @param [in] dstGpuMemory  GPU memory object to be updated.
-    /// @param [in] dstOffset     Byte offset into the GPU memory object to be udpated.  Must be a multiple of 4.
+    /// @param [in] dstOffset     Byte offset into the GPU memory object to be updated.  Must be a multiple of 4.
     /// @param [in] dataSize      Amount of data to write, in bytes.  Must be a multiple of 4.
     /// @param [in] pData         Pointer to host data to be copied into the GPU memory.
     virtual void CmdUpdateMemory(
@@ -4575,7 +4575,7 @@ public:
     /// Stalls a command buffer execution based on a condition that compares an immediate value with value coming from a
     /// GPU memory location.
     ///
-    /// The client (or application) is expected to transiton the memory to proper state before calling this function.
+    /// The client (or application) is expected to transition the memory to proper state before calling this function.
     /// The memory location for the condition must be 4-byte aligned.
     /// This function requires use of the following barrier flags on @ref gpuVirtAddr:
     /// - PipelineStage:  @ref PipelineStagePostPrefetch
@@ -4668,7 +4668,7 @@ public:
     /// normal IPerfExperiment buffer so we need a special command to get the data.
     ///
     /// The bulk of the implementation for this is done by the KMD. They are in charge of starting and stopping the
-    /// trace as well as all of the register programming. When KMD recieves a dfSpmTraceEnd bit from a CmdBufInfo
+    /// trace as well as all of the register programming. When KMD receives a dfSpmTraceEnd bit from a CmdBufInfo
     /// flag, they will wait for the command buffer to be completely idle before stopping the trace. Therefore, a
     /// CmdEndPerfExperiment call does not stop this particular sample, the end of a command buffer with a
     /// dfSpmTraceEnd does. This means that calling CmdCopyDfSpmTraceData in the same command buffer as
@@ -4925,7 +4925,7 @@ public:
         uint32 sizeInDwords,
         bool reserveInNewChunk) = 0;
 
-    /// Ensure data is commited the command buffer and unused space is reclaimed.
+    /// Ensure data is committed to the command buffer and unused space is reclaimed.
     /// This method is only supported on command buffers for the following queue types:
     ///
     /// @param [in] pCmdSpace  Pointer to the next unused dword in the command buffer.
@@ -5129,16 +5129,16 @@ public:
 
     /// Get the number of bytes required by CreateTrackedCmdLocationArray.
     ///
-    /// @detail The value returned here accomdates the full number of TrackedCmdLocationArray's to be
+    /// @detail The value returned here accommodates the full number of TrackedCmdLocationArray's to be
     ///         created, from a single contiguous allocation.
-    ///         If allocation has not yet occured, (GetNumTrackingArrays() == 0).
+    ///         If allocation has not yet occurred, (GetNumTrackingArrays() == 0).
     ///         If (GetTrackedCmdLocationArraySizeInBytes() > 0) &&  (GetNumTrackingArrays() == 0)
     ///         this ICmdBuffer supports TrackedCmdLocationArray's, but has not yet allocated them
     ///         If (GetTrackedCmdLocationArraySizeInBytes() == 0), this ICmdBuffer does not support
     ///         TrackedCmdLocationArray's
     ///
     /// @returns 0 if TrackedCmdLocationArray's are not supported
-    ///         The total number of bytes required requied by CreateTrackedCmdLocationArray otherwise.
+    ///         The total number of bytes required by CreateTrackedCmdLocationArray otherwise.
     virtual uint32 GetTrackedCmdLocationArraySizeInBytes() const = 0;
 
     /// Uses the memory pMemory to initialize GetNumTrackingArrays() TrackedCmdLocationArray's on this
@@ -5283,7 +5283,7 @@ public:
     ///     Result::Unsupported     if the implementation of ICmdBuffer does not support tracking
     ///     Result::ErrorInvalidPointer if there was an error encountered determining the cmdList correlation
     ///                             requested. This is likely to be an out-of-memory situation.
-    ///     Result::AlreadyExists   if registering clientId occured multiple times. This should only occur for
+    ///     Result::AlreadyExists   if registering clientId occurred multiple times. This should only occur for
     ///                             race conditions, if the code calling TrackClientEvent is not threadsafe
     virtual Result TrackClientEvent(
         uint64 clientId,

--- a/shared/amdgpu-windows-interop/pal/inc/core/palDeveloperHooks.h
+++ b/shared/amdgpu-windows-interop/pal/inc/core/palDeveloperHooks.h
@@ -201,7 +201,7 @@ struct BarrierOperations
             uint16 eosTsPsDone                    : 1;  ///< Issue an end-of-pixel-shader event that can be waited on.
             uint16 eosTsCsDone                    : 1;  ///< Issue an end-of-compute-shader event that can be waited on
             uint16 waitOnTs                       : 1;  ///< Wait on an timestamp event (EOP or EOS) at the ME.
-                                                        ///  Which event is not necesarily specified here, though any
+                                                        ///  Which event is not necessarily specified here, though any
                                                         ///  that are specified here would be waited on.
             uint16 reserved                       : 7;  ///< Reserved for future use.
         };

--- a/shared/amdgpu-windows-interop/pal/inc/core/palDevice.h
+++ b/shared/amdgpu-windows-interop/pal/inc/core/palDevice.h
@@ -152,7 +152,7 @@ constexpr uint32 MaxPixelPackerPerSe = 4;
 /// Defines host flags for Semaphore/Fence Array wait
 enum HostWaitFlags : uint32
 {
-    HostWaitAny                = 0x1,  ///< if set this bit, return after any signle semaphore/fence in the array has
+    HostWaitAny                = 0x1,  ///< if set this bit, return after any single semaphore/fence in the array has
                                        ///  completed. if not set, wait for completion of all semaphores/fences in the
                                        ///  array before returning.
 };
@@ -545,7 +545,7 @@ enum TemporalHintsMrtBehavior : uint8
 {
     TemporalHintsDynamicRt = 0x0, ///< Enable Dynamic RT Temporal hints. PAL chooses NT vs RT based on heuristics.
     TemporalHintsStaticRt  = 0x1, ///< Regular temporal for both near and far read/write caches.
-    TemporalHintsStaticNt  = 0x2, ///< Non-temporal (re-use not expected) for both near and far read/write caches.
+    TemporalHintsStaticNt  = 0x2, ///< Non-temporal (reuse not expected) for both near and far read/write caches.
 };
 
 /// Client-controllable behavior for Gfx12-specific software workaround to HiSZ hardware bug.
@@ -739,8 +739,8 @@ struct PalPublicSettings
     /// the ACE.
     bool disableExecuteIndirectAceOffload;
 
-    /// Value to initialize metadata for DCC surfaces to, if they are compressable. This has no effect on non-DCC
-    /// images. Images whose initial layout is not compressable are only affected if this is "forced".
+    /// Value to initialize metadata for DCC surfaces to, if they are compressible. This has no effect on non-DCC
+    /// images. Images whose initial layout is not compressible are only affected if this is "forced".
     ///  0x00 - Uncompressed (default)
     ///  0x01 - Opaque Black
     ///  0x02 - Opaque White
@@ -1257,7 +1257,7 @@ struct DeviceProperties
                 uint32 supportHostMappedForeignMemory   :  1;
 
                 /// Indicates whether specifying memory references at Submit time is supported. If not supported
-                /// all memory references must be manged via IDevice or IQueue AddGpuMemoryReferences()
+                /// all memory references must be managed via IDevice or IQueue AddGpuMemoryReferences()
                 uint32 supportPerSubmitMemRefs          :  1;
 
                 /// Indicates support for GPU virtual addresses that are visible to all devices.
@@ -1275,7 +1275,7 @@ struct DeviceProperties
                 /// (DMA-capable) I/O bus to the main memory.
                 uint32 iommuv2Support                   :  1;
 
-                /// Indiciates that the platform supports automatic GPU memory priority management.
+                /// Indicates that the platform supports automatic GPU memory priority management.
                 uint32 autoPrioritySupport              :  1;
 
                 /// Indicates KMD has enabled HBCC(High Bandwidth Cache Controller) page migration support.  This means
@@ -1751,7 +1751,7 @@ struct DeviceProperties
 #endif
 
 #if defined(_WIN32)
-        bool   supportArbitaryPrtMapUnmap;  ///< Support arbitary prt map unmap operation.
+        bool   supportArbitaryPrtMapUnmap;  ///< Support arbitrary prt map unmap operation.
 #endif
 
         uint32                     umdFpsCapFrameRate;   ///< The frame rate of the UMD FPS CAP
@@ -1838,7 +1838,7 @@ struct PrivateScreenNotifyInfo
                                                   ///  calls callback pfnOnTopology.
     TopologyChangeNotificationFunc pfnOnTopology; ///< Pointer to client provided function. PAL should call this when
                                                   ///  the topology change happens and let the client handle the change.
-    DestroyNotificationFunc        pfnOnDestroy;  ///< Pointer to client provdided function. PAL should call this when
+    DestroyNotificationFunc        pfnOnDestroy;  ///< Pointer to client provided function. PAL should call this when
                                                   ///  a private screen object is to be destroyed. The pOwner data is
                                                   ///  passed at @ref IPrivateScreen::BindOwner() time.
 };
@@ -2028,7 +2028,7 @@ struct GpuMemoryHeapProperties
     gpusize physicalSize;                  ///< Physical size of the heap in bytes
 };
 
-/// Reports properties of a specific GPU block required for interpretting performance experiment data from that block.
+/// Reports properties of a specific GPU block required for interpreting performance experiment data from that block.
 /// See @ref PerfExperimentProperties.
 struct GpuBlockPerfProperties
 {
@@ -2199,7 +2199,7 @@ enum class CompressionMode : uint32
     ReadEnableWriteDisable = 2,  ///< Support reading compressed data, but force any writes to be uncompressed (keeping
                                  ///  physical metadata consistent).
     ReadBypassWriteDisable = 3,  ///< Bypass physical metadata on reads (assume decompressed), all writes will be
-                                 ///  uncompressed and will write physical metatdata marking updated blocks as being
+                                 ///  uncompressed and will write physical metadata marking updated blocks as being
                                  ///  uncompressed. This mode is intended to handle placed resources that do not
                                  ///  want compression in memory allocations that have distributed compression enabled.
                                  ///  WARNING: Using this mode to read compressed data will result in corruption.
@@ -2698,7 +2698,7 @@ enum class WorkstationStereoMode : uint32
     Count,
 };
 
-/// Specifies output arguments for IDevice::GetPrimaryInfo(), returning capabilitiy information for a display in
+/// Specifies output arguments for IDevice::GetPrimaryInfo(), returning capability information for a display in
 /// a particular mode.
 struct GetPrimaryInfoOutput
 {
@@ -3003,7 +3003,7 @@ struct FlglState
         struct
         {
             uint32 genLockEnabled    : 1;   ///< True if genlock is currently enabled. Genlock is a system-wide setting
-                                            ///< in CCC. Genlock provides a singal source (which is used in framelock)
+                                            ///< in CCC. Genlock provides a signal source (which is used in framelock)
             uint32 frameLockEnabled  : 1;   ///< True if (KMD) framelock is currently enabled.
                                             ///< Framelock is the mechanism to sync all presents in multiple adapters.
             uint32 isTimingMaster    : 1;   ///< True if the display being driven by the current adapter is the timing
@@ -3090,7 +3090,7 @@ struct GlSyncConfig
     uint32 framelockCntlVector; ///< Vector of Framelock control bits. GlSyncFrameLockCntl*
     uint32 signalSource;        ///< Source of sync signal. Can be House Sync, RJ45 Port or GPUPort.
                                 ///  GlSyncSignalSource* or GPUPort Index
-    uint8  sampleRate;          ///< Number of VSyncs per sample. 0 - no sampling, syncronized by singal VSync.
+    uint8  sampleRate;          ///< Number of VSyncs per sample. 0 - no sampling, synchronized by signal VSync.
     uint8  syncField;           ///< Sync to Field 1 or to both Fields when input signal is interlaced.
                                 ///  GlSyncSyncField*
     uint8  triggerEdge;         ///< Which edge should be used as trigger. GlSyncTriggerEdge*
@@ -3380,7 +3380,7 @@ public:
     /// settings and build up the device for further use. If the client doesn't call this function, it will be called
     /// automatically when IPlatform::Destroy() is called or when devices are re-enumerated.
     ///
-    /// This function provides clients with a way to return devices to a trival state, one in which they have no
+    /// This function provides clients with a way to return devices to a trivial state, one in which they have no
     /// lingering OS or kernel driver dependencies. If a client pairs external state (e.g., an OS handle) with their
     /// devices they may be required to call this function when they destroy their API device objects.
     ///
@@ -3434,7 +3434,7 @@ public:
     ///
     /// @returns Success if the heap properties were successfully queried and returned in info[].  Otherwise, one of the
     ///          following errors may be returned:
-    ///          + ErrorUnknown if an unexpected internal error occured.
+    ///          + ErrorUnknown if an unexpected internal error occurred.
     virtual Result GetGpuMemoryHeapProperties(
         GpuMemoryHeapProperties info[GpuHeapCount]) const = 0;
 
@@ -3562,7 +3562,7 @@ public:
     /// @returns Success if the display modes were successfully queried and the results were reported in
     ///          pStereoModeCount/pStereoModeList.  Otherwise, one of the following errors may be returned:
     ///          + Unsupported if stereo mode is not supported, or the stereo modes can't be queried.
-    ///          + ErrorOutOfMemory if temp memeory allocation failed.
+    ///          + ErrorOutOfMemory if temp memory allocation failed.
     virtual Result GetStereoDisplayModes(
         uint32*                   pStereoModeCount,
         StereoDisplayModeOutput*  pStereoModeList) const = 0;
@@ -3594,7 +3594,7 @@ public:
     ///
     /// @param [in] pGpuMemory    The dst GPU memory reference which will be marked as 10 bits format.
     ///
-    /// @returns Success if the KMD has been sucessfully notified.
+    /// @returns Success if the KMD has been successfully notified.
     virtual Result RequestKmdReinterpretAs10Bit(
         const IGpuMemory* pGpuMemory) const = 0;
 
@@ -3668,7 +3668,7 @@ public:
     ///                                     vidPnSrcId is valid.
     ///
     /// @returns Success if the metadata controls on the given vidPnSrcId was successfully polled.
-    ///          Otherwise, one of the following erros may be returned:
+    ///          Otherwise, one of the following errors may be returned:
     ///          + ErrorInvalidValue if vidPnSrcId is invalid (out of range)
     ///          + ErrorUnavailable if no implementation on current platform or if metadata shared buffer is null.
     virtual Result PollFullScreenFrameMetadataControl(
@@ -3835,7 +3835,7 @@ public:
     /// @param [in] wsiPlatform               WSI Platform the request supposed to send to
     /// @param [in] visualId                  Requested visual information which may not needed for some wsiPlatforms
     ///
-    /// @returns Success if the request is supported. Otherwise, one of the following erros may be returned:
+    /// @returns Success if the request is supported. Otherwise, one of the following errors may be returned:
     ///         + Unsupported
     virtual Result DeterminePresentationSupported(
         OsDisplayHandle      hDisplay,
@@ -4668,7 +4668,7 @@ public:
     /// The SRD can be created in either system memory or pre-mapped GPU memory.  If updating GPU memory, the client
     /// must ensure there are no GPU accesses of this memory in flight before calling this method.
     ///
-    /// The generated sampler SRD controlls execution of sample instructions in a shader, and should be setup as
+    /// The generated sampler SRD controls execution of sample instructions in a shader, and should be setup as
     /// described in @ref SamplerInfo.  The client should put the resulting SRD in an appropriate location based on the
     /// shader resource mapping specified by the bound pipeline, either directly in user data
     /// (ICmdBuffer::CmdSetUserData()) or a table in GPU memory indirectly referenced by user data.
@@ -4845,7 +4845,7 @@ public:
     ///
     /// @param [in]  createInfo Library creation parameters including ELF code object and other items.
     /// @param [out] pResult    The validation result if pResult is non-null.  This argument can be null to avoid the
-    ///                         additonal validation.
+    ///                         additional validation.
     ///
     /// @returns Size, in bytes, of system memory required for an IShaderLibrary object with the specified properties.
     ///          A return value of zero indicates the createInfo was invalid.
@@ -5098,7 +5098,7 @@ public:
     ///
     /// @returns Success if the NT handle was successfully opened.  Otherwise, one of
     ///          the following errors may be returned:
-    ///          + ErrorInvalidValue if the name or attributes is invaild.
+    ///          + ErrorInvalidValue if the name or attributes is invalid.
     virtual Result OpenExternalHandleFromName(
         const ExternalHandleInfo& handleInfo,
         OsExternalHandle*         pHandle) = 0;
@@ -5137,7 +5137,7 @@ public:
         void*                  pPlacementAddr,
         IFence**               ppFence) const = 0;
 
-    /// Opens a fence wihich was shared by another Device.
+    /// Opens a fence which was shared by another Device.
     ///
     /// @param  [in] openInfo         A reference to FenceOpenInfo, the handle is used if it's not null, or the
     ///                               event is opened via name.
@@ -5342,7 +5342,7 @@ public:
     /// private screens. If the id of an enumerated private screen already exists, it is treated as unchanged. The EDID
     /// array and display index are used to generate MD5 hash code.
     ///
-    /// @param [out]  pNumScreens  Pointer to the number of private sceens, note that this number does not mean first
+    /// @param [out]  pNumScreens  Pointer to the number of private screens, note that this number does not mean first
     ///                            *pNumScreens elements in ppScreens are valid but just a hint that total *pNumScreens
     ///                            out of MaxPrivateScreens are valid.
     /// @param [out]  ppScreens    Pointer to the array of private screens. The client must pass in the pointer to an
@@ -5548,7 +5548,7 @@ public:
     ///
     /// @returns Success if query returns with success. Otherwise, one of the following errors may returned:
     ///          + ErrorUnknown if an unexpected internal error occurs.
-    ///          + ErrorInvalidPointer if pGlSyncConfig is null poiter.
+    ///          + ErrorInvalidPointer if pGlSyncConfig is null pointer.
     virtual Result FlglGetSyncConfiguration(
         GlSyncConfig* pGlSyncConfig) const  = 0;
 
@@ -5677,7 +5677,7 @@ public:
     /// re-querythe attached screens and they will find a new one in the list that is pretend, but they can use it just
     /// like a normal display.
     ///
-    /// @param [in]  virtualDisplayInfo   Virtual display creation infomation.
+    /// @param [in]  virtualDisplayInfo   Virtual display creation information.
     /// @param [out] pScreenTargetId      The screen target ID returned by KMD
     ///
     /// @returns Success if the call succeeded.
@@ -5707,7 +5707,7 @@ public:
 
     /// Determines if hardware accelerated stereo rendering can be enabled for given graphic pipeline.
     /// If hardware accelerate stereo rendering can be enabled, client doesn't need to do shader patching
-    /// which includes translating view id intrinsic to user data slot, outputing render target
+    /// which includes translating view id intrinsic to user data slot, outputting render target
     /// array index and viewport array index in shader closest to scan converter.
     ///
     /// @param [in]  viewInstancingInfo  Graphic pipeline view instancing information.
@@ -5818,7 +5818,7 @@ public:
     /// @return Result::Success             if successful
     ///         Result::Unsupported         if feature is not supported
     ///         Result::AlreadyExists       if there is already a CmdDisassembly::ICmdBufferReporting
-    ///                                         registered with this devide
+    ///                                         registered with this device
     ///         Result::ErrorInvalidValue   if pInterface == nullptr
     ///
     virtual Result RegisterCmdReportingInterface(

--- a/shared/amdgpu-windows-interop/pal/inc/core/palFormat.h
+++ b/shared/amdgpu-windows-interop/pal/inc/core/palFormat.h
@@ -277,7 +277,7 @@ enum class ChNumFormat : Util::uint32
                                         ///  channels respectively. Image views can use the { Y8X8_Y8Z8, Unorm } format
                                         ///  where the Y0,X0,Y1,Z0 channels are mapped to the Y0,V0,Y1,U0 channels.
     YV12                     = 0xA2,    ///< YVU 4:2:0 planar format, with 8 bits per luma and chroma sample.  The Y
-                                        ///  plane is first, containg a uint8 per sample.  Next is the V plane and the U
+                                        ///  plane is first, containing a uint8 per sample.  Next is the V plane and the U
                                         ///  plane, both of which have a uint8 per sample.  Valid Image view formats are
                                         ///  { X8, Unorm } and { X8, Uint }.  Each view only has access to one of the Y,
                                         ///  V, or U planes.
@@ -308,7 +308,7 @@ enum class ChNumFormat : Util::uint32
     P010                     = 0xA7,    ///< YUV 4:2:0 planar format, with 10 bits per luma and chroma sample.  This is
                                         ///  identical to @ref ChNumFormat::P016, except that the lowest 6 bits of each
                                         ///  luma and chroma sample are ignored. This allows the source data to be
-                                        ///  interpreted as either P016 or P010 interchangably.
+                                        ///  interpreted as either P016 or P010 interchangeably.
     P210                     = 0xA8,    ///< YUV 4:2:2 planar format, with 10 bits per luma and chroma sample. This is
                                         ///  similar to @ref ChNumFormat::P010, except that the UV planes are sub-sampled
                                         ///  only in the horizontal direction, but still by a factor of 2 so the UV plane

--- a/shared/amdgpu-windows-interop/pal/inc/core/palFormatInfo.h
+++ b/shared/amdgpu-windows-interop/pal/inc/core/palFormatInfo.h
@@ -108,7 +108,7 @@ static constexpr uint32 CompressedEtcBlockDim = 4;
 extern const FormatInfo FormatInfoTable[static_cast<size_t>(ChNumFormat::Count)];
 
 /// Convert a floating-point representation of a color value in RGBA order to the appropriate bit representation for
-/// each channel based on the specified format. Swizzling is enabled by default to maintain backwards compatability.
+/// each channel based on the specified format. Swizzling is enabled by default to maintain backwards compatibility.
 /// There will be no swizzling functionality going forwards.
 extern void ConvertColor(
     SwizzledFormat format,
@@ -124,7 +124,7 @@ extern void ConvertYuvColor(
     uint32*        pColorOut);
 
 /// Packs a clear color value in RGBA order to a single element of the provided format and stores it in the
-/// memory provided. Swizzling is enabled by default to maintain backwards compatability. There will be
+/// memory provided. Swizzling is enabled by default to maintain backwards compatibility. There will be
 /// no swizzling functionality going forwards.
 extern void PackRawClearColor(
     SwizzledFormat format,

--- a/shared/amdgpu-windows-interop/pal/inc/core/palGpuMemory.h
+++ b/shared/amdgpu-windows-interop/pal/inc/core/palGpuMemory.h
@@ -77,7 +77,7 @@ enum class GpuMemPriorityOffset : uint32
     Count
 };
 
-/// Speicfies access mode for unmapped pages in a virtual Gpu Memory.
+/// Specifies access mode for unmapped pages in a virtual GPU memory.
 enum class VirtualGpuMemAccessMode : uint32
 {
     Undefined = 0x0, ///< Used in situations where no special accessMode needed.
@@ -293,9 +293,9 @@ struct GpuMemoryCreateInfo
                                            ///  This GPU memory will be permanently considered a typed buffer.
 
     VirtualGpuMemAccessMode virtualAccessMode; ///< Access mode for virtual GPU memory's unmapped pages, WDDM only.
-    gpusize                 surfaceBusAddr;    ///< Surface bus address of Bus Addresable Memory.
+    gpusize                 surfaceBusAddr;    ///< Surface bus address of Bus Addressable Memory.
                                                ///  Only valid when GpuMemoryCreateFlags::sdiExternal is set.
-    gpusize                 markerBusAddr;     ///< Marker bus address of Bus Addresable Memory. The client can:
+    gpusize                 markerBusAddr;     ///< Marker bus address of Bus Addressable Memory. The client can:
                                                ///  1. Write to marker
                                                ///  2. Let GPU wait until a value is written to marker before issuing
                                                ///     the next command.
@@ -404,7 +404,7 @@ struct ExternalGpuMemoryOpenInfo
     } flags;                        ///< External Gpu memory open info flags.
 };
 
-/// The fundemental information that describes a GPU memory object that is stored directly in each IGpuMemory.
+/// The fundamental information that describes a GPU memory object that is stored directly in each IGpuMemory.
 /// It can be accessed without a virtual call via IGpuMemory::Desc().
 struct GpuMemoryDesc
 {
@@ -554,7 +554,7 @@ struct GpuMemoryExportInfo
  * @see IDevice::OpenExternalSharedGpuMemory
  *
  *
- * All of these kinds of GPU memory are assigned a set of fundemental properties specified in GpuMemoryDesc which are
+ * All of these kinds of GPU memory are assigned a set of fundamental properties specified in GpuMemoryDesc which are
  * either specified by the client or by PAL.  There are specific rules these properties must follow; those rules are
  * documented here to avoid duplication.  Violating these rules will cause the device's corresponding "get size"
  * functions to return an error code, the create/open functions may not validate their arguments.
@@ -651,7 +651,7 @@ public:
     virtual OsExternalHandle ExportExternalHandle(const GpuMemoryExportInfo& exportInfo) const = 0;
 #endif
 
-    /// Returns a structure containing some fundemental information that describes this GPU memory object.
+    /// Returns a structure containing some fundamental information that describes this GPU memory object.
     ///
     /// @returns A reference to this allocation's GpuMemoryDesc.
     const GpuMemoryDesc& Desc() const { return m_desc; }

--- a/shared/amdgpu-windows-interop/pal/inc/core/palImage.h
+++ b/shared/amdgpu-windows-interop/pal/inc/core/palImage.h
@@ -125,7 +125,7 @@ enum class MetadataSharingLevel : uint32
 /// Specifies the type of PRT map image being created.
 enum class PrtMapType : uint32
 {
-    None            = 0, ///< This is not an auxillary image used for PRT plus functionality.
+    None            = 0, ///< This is not an auxiliary image used for PRT plus functionality.
     Residency       = 1, ///< Image data is really a low-resolution map containing the finest populated LOD
                          ///  for a particular UV space region.
     SamplingStatus  = 2, ///< Indicates the validity of a given tile on a per-mip level basis.
@@ -203,7 +203,7 @@ union ImageCreateFlags
         uint32 sampleLocsAlwaysKnown   :  1; ///< Sample pattern is always known in client driver for MSAA depth image.
 #if PAL_CLIENT_INTERFACE_MAJOR_VERSION < 963
         uint32 fullResolveDstOnly      :  1; ///< Indicates any ICmdBuffer::CmdResolveImage using this image as a
-                                             ///  desination will overwrite the entire image (width and height of
+                                             ///  designation will overwrite the entire image (width and height of
                                              ///  resolve region is same as width and height of resolve dst).
 #else
         uint32 reserved963             :  1;
@@ -621,7 +621,7 @@ struct ImageLayout
 /**
 ****************************************************************************************************
 * @brief
-*   Enumerates swizzle modes useable on any supported GPU.
+*   Enumerates swizzle modes usable on any supported GPU.
 * @note
 * For details please check _AddrSwizzleMode
 *

--- a/shared/amdgpu-windows-interop/pal/inc/core/palLib.h
+++ b/shared/amdgpu-windows-interop/pal/inc/core/palLib.h
@@ -478,7 +478,7 @@ inline Result PAL_STDCALL GetGpuInfoForAsicRevision(
  *
  * After a successful call to CreatePlatform(), the client should call @ref IPlatform::EnumerateDevices() in order to
  * get a list of supported devices attached to the system.  This function returns an array of @ref IDevice objects
- * which are used by the client to query properties of the devicess and eventually execute work on those devices.
+ * which are used by the client to query properties of the devices and eventually execute work on those devices.
  * IPlatform::EnumerateDevices() is not available to util-only clients (PAL_BUILD_CORE=0).
  *
  * The client may re-enumerate devices at any time by calling IPlatform::EnumerateDevices().  The client must make sure

--- a/shared/amdgpu-windows-interop/pal/inc/core/palPerfExperiment.h
+++ b/shared/amdgpu-windows-interop/pal/inc/core/palPerfExperiment.h
@@ -519,7 +519,7 @@ public:
     virtual Result GetGlobalCounterLayout(
         GlobalCounterLayout* pLayout) const = 0;
 
-    /// Addes the specified thread trace to be recorded as part of this perf experiment.
+    /// Adds the specified thread trace to be recorded as part of this perf experiment.
     ///
     /// @param [in] traceInfo Specifies what type of trace to record, which block instance to trace, and options, etc.
     ///

--- a/shared/amdgpu-windows-interop/pal/inc/core/palPipeline.h
+++ b/shared/amdgpu-windows-interop/pal/inc/core/palPipeline.h
@@ -241,7 +241,7 @@ union PipelineCreateFlags
     {
         uint32 clientInternal        :  1; ///< Internal pipeline not created by the application.
         uint32 reverseWorkgroupOrder :  1; ///< Indicates that any Dispatch using this pipeline should execute in
-                                           ///  reverse workgroup order. This superceeds the flag on the CommandBuffer
+                                           ///  reverse workgroup order. This supersedes the flag on the CommandBuffer
                                            ///  (dispatchPingPongWalk) - always forcing reverse workgroup order! This
                                            ///  is a best effort as not all implementations or Queues may support this.
         uint32 reserved              : 30; ///< Reserved for future use.
@@ -249,7 +249,7 @@ union PipelineCreateFlags
     uint32 u32All;                         ///< Flags packed as 32-bit uint.
 };
 
-/// Constant definining the max number of view instance count that is supported.
+/// Constant defining the max number of view instance count that is supported.
 constexpr uint32 MaxViewInstanceCount = 6;
 
 /// Specifies graphic pipeline view instancing state.
@@ -322,7 +322,7 @@ struct ComputePipelineCreateInfo
     Extent3d threadsPerGroup;
     TriState groupLaunchGuarantee; ///< Force the group launch guarantee mechanism on or off. This feature will throttle
                                    ///  issuing of low priority waves when it detects too many higher priority waves are
-                                   ///  failing to schedule due to resource contraints.
+                                   ///  failing to schedule due to resource constraints.
 
     const char* pKernelName; ///< When create pipeline with hsa ELF binary of multiple kernels, need to set one
                              ///  kernel to create the pipeline. null means only one kernel in ELF binary.
@@ -471,7 +471,7 @@ struct GraphicsPipelineCreateInfo
 
     TriState groupLaunchGuarantee; ///< Force the group launch guarantee mechanism on or off. This feature will throttle
                                    ///  issuing of low priority waves when it detects too many higher priority waves are
-                                   ///  failing to schedule due to resource contraints.
+                                   ///  failing to schedule due to resource constraints.
     bool     noForceReZ;           ///< Disables the ability for PAL to force ReZ modes outside of what was chosen by
                                    ///  the compiler for this pipeline.
 };
@@ -759,7 +759,7 @@ public:
     ///                                 size of the disassembly string in ShaderStats::isaSizeInBytes. Else reports 0.
     /// @returns Success if the stats were successfully obtained for this shader, including the shader disassembly size.
     ///          +ErrorUnavailable if a wrong shader stage for this pipeline was specified, or if some internal error
-    ///                           occured.
+    ///                           occurred.
     virtual Result GetShaderStats(
         ShaderType   shaderType,
         ShaderStats* pShaderStats,

--- a/shared/amdgpu-windows-interop/pal/inc/core/palQueue.h
+++ b/shared/amdgpu-windows-interop/pal/inc/core/palQueue.h
@@ -355,7 +355,7 @@ struct PresentSwapChainInfo
     PresentMode presentMode;    ///< Chooses between windowed and fullscreen present.
     IImage*     pSrcImage;      ///< The image to be presented.
     ISwapChain* pSwapChain;     ///< The swap chain associated with the source image.
-    uint32      imageIndex;     ///< The index of the source image within the swap chain. Owership of this image
+    uint32      imageIndex;     ///< The index of the source image within the swap chain. Ownership of this image
                                 ///  index will be released back to the swap chain if this call succeeds.
     uint32      rectangleCount; ///< Number of valid rectangles in the pRectangles array.
     uint32      syncInterval;   ///< Applicable only when syncIntervalOverride is set
@@ -571,7 +571,7 @@ public:
     /// the presentable image index, eventually deadlocking the swap chain.
     ///
     /// Overall support for direct presents can be queried at platform creation time via supportNonSwapChainPresents
-    /// in @ref PlatformProperties.  Support for particular present modes is specifed via supportedDirectPresentModes
+    /// in @ref PlatformProperties.  Support for particular present modes is specified via supportedDirectPresentModes
     /// in @ref DeviceProperties.
     ///
     /// @note  Any images specified in presentInfo must be made resident before calling this function.

--- a/shared/amdgpu-windows-interop/pal/inc/core/palQueueSemaphore.h
+++ b/shared/amdgpu-windows-interop/pal/inc/core/palQueueSemaphore.h
@@ -142,7 +142,7 @@ struct QueueSemaphoreExportInfo
             uint32 isReference        :  1;   ///< If set, then the semaphore exporting a handle that reference the
                                               ///< same sync object in the kernel.  Otherwise, the object is copied
                                               ///< to the new Semaphore.
-            uint32 reserved           : 31;   ///< Resevered for future use.
+            uint32 reserved           : 31;   ///< Reserved for future use.
         };
         uint32 u32All;                        ///< Flags packed as 32-bit uint.
     } flags;                                  ///< External queue semaphore export flags.

--- a/shared/amdgpu-windows-interop/pal/inc/core/palShaderLibrary.h
+++ b/shared/amdgpu-windows-interop/pal/inc/core/palShaderLibrary.h
@@ -220,7 +220,7 @@ public:
     ///                                 size of the disassembly string in ShaderStats::isaSizeInBytes. Else reports 0.
     /// @returns Success if the stats were successfully obtained for this shader, including the shader disassembly size.
     ///          +ErrorUnavailable if a wrong shader stage for this pipeline was specified, or if some internal error
-    ///                           occured.
+    ///                           occurred.
     virtual Result GetShaderFunctionStats(
         Util::StringView<char> shaderExportName,
         ShaderLibStats*        pShaderStats) const = 0;

--- a/shared/amdgpu-windows-interop/pal/inc/gpuUtil/palGpaSession.h
+++ b/shared/amdgpu-windows-interop/pal/inc/gpuUtil/palGpaSession.h
@@ -96,7 +96,7 @@ enum class UpdateSampleTraceMode : Pal::uint32
                                 ///  active sample.
 };
 
-/// Specifies basic type of sample to perfom - either a normal set of "global" perf counters, or a trace consisting
+/// Specifies basic type of sample to perform - either a normal set of "global" perf counters, or a trace consisting
 /// of SQ thread trace and/or streaming performance counters.
 enum class GpaSampleType : Pal::uint32
 {
@@ -481,7 +481,7 @@ struct QueueTimingsTraceInfo
 *       written, are allocated from internal pools managed by the session.
 *     - A session is moved from the _building_ state to the _complete_ state by calling End().
 *     - The application will submit all command buffers referenced by the session.
-*     - The session is confirmed as _ready_, either using standard PAL fences to confirm all assocated submission have
+*     - The session is confirmed as _ready_, either using standard PAL fences to confirm all associated submission have
 *       completed, or by polling IsReady() on the session.
 *     - Results for all samples in the session can be queried via GetResults().
 *     - Reset() should be called once results have been gathered and before building a new session.  Resources are

--- a/shared/amdgpu-windows-interop/pal/inc/gpuUtil/palTraceSession.h
+++ b/shared/amdgpu-windows-interop/pal/inc/gpuUtil/palTraceSession.h
@@ -432,7 +432,7 @@ public:
 
     /// Initialize the trace session before requesting a trace.
     ///
-    /// @returns Success if initalization was successful, or ErrorUnknown upon failure.
+    /// @returns Success if initialization was successful, or ErrorUnknown upon failure.
     Pal::Result Init();
 
     /// Returns whether tracing has been formally enabled via UberTrace or not.
@@ -738,9 +738,9 @@ public:
         return m_pConfigData;
     }
 
-    /// Indicates if a cancel-trace signal has been received and that a cancelation is in progress.
+    /// Indicates if a cancel-trace signal has been received and that a cancellation is in progress.
     ///
-    /// @return true if a cancelation is in progress.
+    /// @return true if a cancellation is in progress.
     bool IsCancelingTrace() const { return m_cancelingTrace; }
 
     /// Register a function to be called when the Trace Session state changes.
@@ -804,9 +804,9 @@ private:
     rdfStream*          m_pCurrentStream;    // Active RDF stream for writing chunks
     Pal::int32          m_currentChunkIndex; // The current chunk index of the RDF stream
     bool                m_tracingEnabled;    // Flag indicating UberTrace tracing is enabled tool-side
-    void*               m_pConfigData;       // Buffer containing the cached trace configurationn
+    void*               m_pConfigData;       // Buffer containing the cached trace configuration
     size_t              m_configDataSize;    // Size of the cached trace config buffer
-    bool                m_cancelingTrace;    // Indicates that a cancel signal has been received and trace cancelation
+    bool                m_cancelingTrace;    // Indicates that a cancel signal has been received and trace cancellation
                                              // is in progress.
 
     Util::Mutex         m_stateChangeCallbackLock; // RW lock for state change callbacks

--- a/shared/amdgpu-windows-interop/pal/inc/util/palAutoBuffer.h
+++ b/shared/amdgpu-windows-interop/pal/inc/util/palAutoBuffer.h
@@ -105,7 +105,7 @@ public:
     {
         if (m_pBuffer != reinterpret_cast<Item*>(m_localBuffer))
         {
-            // Destory dynamically allocated array, by destroying its objects and freeing memory.
+            // Destroy dynamically allocated array, by destroying its objects and freeing memory.
             PAL_SAFE_DELETE_ARRAY(m_pBuffer, m_pAllocator);
         }
         else if (!std::is_trivial<Item>::value)

--- a/shared/amdgpu-windows-interop/pal/inc/util/palBuddyAllocator.h
+++ b/shared/amdgpu-windows-interop/pal/inc/util/palBuddyAllocator.h
@@ -110,7 +110,7 @@ public:
     /// Returns the size of the largest allocation that can be suballocated with this buddy allocator.
     gpusize MaximumAllocationSize() const;
 
-    /// Claims (doesn't allocate) some memory, used to quickly determine if a pool of memory has availible memory.
+    /// Claims (doesn't allocate) some memory, used to quickly determine if a pool of memory has available memory.
     /// Doesn't affect internal state unless Result::Success is returned
     ///
     /// @param [in]  size           The size of the requested suballocation.
@@ -119,7 +119,7 @@ public:
     /// @returns Success if there is enough memory in this buddyAllocator to allocate the requested size of memory,
     ///          @ref ErrorOutOfGpuMemory if there is not enough memory
     ///
-    /// @warning Unless this is called to test availible memory before every call to Allocate, then the results will not
+    /// @warning Unless this is called to test available memory before every call to Allocate, then the results will not
     ///          be valid.
     Result ClaimGpuMemory(
         gpusize size,

--- a/shared/amdgpu-windows-interop/pal/inc/util/palBuddyAllocatorImpl.h
+++ b/shared/amdgpu-windows-interop/pal/inc/util/palBuddyAllocatorImpl.h
@@ -300,7 +300,7 @@ Result BuddyAllocator<Allocator>::GetNextFreeBlock(
 
 // =====================================================================================================================
 // Frees the memory at the given offset, if it's buddy is also free, merges the two and recursively calls this again.
-// This doesn't need any internal locks because Free accquires an exclusive lock on the entire allocator (freeLock), and
+// This doesn't need any internal locks because Free acquires an exclusive lock on the entire allocator (freeLock), and
 // the lock on the m_pNumFreeList.  These locks could potentially be more fine grained, however freeing and allocating
 // don't typically happen at the same time, and Freeing is already much faster than allocating.
 template <typename Allocator>
@@ -363,7 +363,7 @@ Result BuddyAllocator<Allocator>::FreeBlock(
     return result;
 }
 // =====================================================================================================================
-// Frees a suballocated block making it available for future re-use.
+// Frees a suballocated block making it available for future reuse.
 template <typename Allocator>
 void BuddyAllocator<Allocator>::Free(
     gpusize offset,
@@ -445,7 +445,7 @@ Result BuddyAllocator<Allocator>::ClaimGpuMemory(
 // =====================================================================================================================
 // Used to search through pools before claiming memory to find the one that will fragment the least.  pKval will have
 // be the highest level needed to be split up for this pool, so the pool with the lowest value will be best.  Can NOT
-// guarantee the memory will still be availible by the time this thread calls ClaimGpuMemory.
+// guarantee the memory will still be available by the time this thread calls ClaimGpuMemory.
 template <typename Allocator>
 Result BuddyAllocator<Allocator>::CheckIfOpenMemory(
     gpusize size,

--- a/shared/amdgpu-windows-interop/pal/inc/util/palDbgPrint.h
+++ b/shared/amdgpu-windows-interop/pal/inc/util/palDbgPrint.h
@@ -266,11 +266,11 @@ extern size_t EncodeAsFilename(
 
 /// Generate a log filename.
 ///
-/// @param [inout] pFilenameBuffer   Buffer to hold the filename.
-/// @param         maxSize           Max size of the pFilenameBuffer.
-/// @param         nextPost          The next write position.
-/// @param [in]    pExt              The filename extension.
-/// @param         logDuplicate      Log duplicate objects.
+/// @param [in,out] pFilenameBuffer   Buffer to hold the filename.
+/// @param          maxSize           Max size of the pFilenameBuffer.
+/// @param          nextPost          The next write position.
+/// @param [in]     pExt              The filename extension.
+/// @param          logDuplicate      Log duplicate objects.
 extern void GenLogFilename(
     char*             pFilenameBuffer,
     size_t            maxSize,

--- a/shared/amdgpu-windows-interop/pal/inc/util/palEvent.h
+++ b/shared/amdgpu-windows-interop/pal/inc/util/palEvent.h
@@ -93,13 +93,13 @@ public:
     /// Changes the event state to _set_
     ///
     /// @returns Success unless the Event has not been initialized yet (@ref ErrorUnavailable) or an unexpected internal
-    ///          error occured when calling the OS (ErrorUnknown).
+    ///          error occurred when calling the OS (ErrorUnknown).
     Result Set() const;
 
     /// Changes the event state to _reset_.
     ///
     /// @returns Success unless the Event has not been initialized yet (ErrorUnavailable) or an unexpected
-    ///         internal error occured when calling the OS (ErrorUnknown).
+    ///         internal error occurred when calling the OS (ErrorUnknown).
     Result Reset() const;
 
     /// Waits for the event to enter the _set_ state before returning control to the caller.  The event will change to
@@ -133,8 +133,8 @@ public:
 private:
     EventHandle m_hEvent;      // OS-specific event handle.
     bool        m_isReference; // If true, the event is a global sharing object handle (not a duplicate) which is
-                               // imported from external, so it can't be closed in the currect destructor, and can only
-                               // be closed by the creater.
+                               // imported from external, so it can't be closed in the current destructor, and can only
+                               // be closed by the creator.
 
     PAL_DISALLOW_COPY_AND_ASSIGN(Event);
 };

--- a/shared/amdgpu-windows-interop/pal/inc/util/palFile.h
+++ b/shared/amdgpu-windows-interop/pal/inc/util/palFile.h
@@ -54,14 +54,14 @@
 namespace Util
 {
 #if defined(_WIN32)
-/// Wide-character of the platform's prefered path separator.
+/// Wide-character of the platform's preferred path separator.
 static constexpr wchar_t PathSepW = L'\\';
-/// Narrow-character of the platform's prefered path separator.
+/// Narrow-character of the platform's preferred path separator.
 static constexpr  char   PathSep = '\\';
 #else
-/// Wide-character of the platform's prefered path separator.
+/// Wide-character of the platform's preferred path separator.
 static constexpr wchar_t PathSepW = L'/';
-/// Narrow-character of the platform's prefered path separator.
+/// Narrow-character of the platform's preferred path separator.
 static constexpr  char   PathSep = '/';
 #endif
 

--- a/shared/amdgpu-windows-interop/pal/inc/util/palHashBaseImpl.h
+++ b/shared/amdgpu-windows-interop/pal/inc/util/palHashBaseImpl.h
@@ -695,7 +695,7 @@ Result HashBase<Key, Entry, Allocator, HashFunc, EqualFunc, AllocFunc, GroupSize
 }
 
 // =====================================================================================================================
-// Returns pointer to the next group of the spcified group.
+// Returns pointer to the next group of the specified group.
 template<
     typename Key,
     typename Entry,

--- a/shared/amdgpu-windows-interop/pal/inc/util/palMutex.h
+++ b/shared/amdgpu-windows-interop/pal/inc/util/palMutex.h
@@ -145,7 +145,7 @@ public:
     /// Defines RWLockData as a Windows RWLOCK
     typedef SRWLOCK RWLockData;
     RWLock() noexcept : m_osRWLock {} { InitializeSRWLock(&m_osRWLock); }
-    ~RWLock() noexcept { /* No Win32 destory function */ };
+    ~RWLock() noexcept { /* No Win32 destroy function */ };
 #else
     /// Defines RWLockData as a unix pthread_rwlock_t
     typedef pthread_rwlock_t  RWLockData;

--- a/shared/amdgpu-windows-interop/pal/inc/util/palStringUtil.h
+++ b/shared/amdgpu-windows-interop/pal/inc/util/palStringUtil.h
@@ -122,7 +122,7 @@ extern void CopyUtf16String(
 /// @param [in]  dstSize    The length of pDst in bytes.
 /// @param [in]  pBuffer    The arbitrary data blob to turn into a string.
 /// @param [in]  bufferSize The length of pBuffer in bytes.
-/// @param [in]  blockSize  How many bytes to combine into one hexidecimal big endian string.
+/// @param [in]  blockSize  How many bytes to combine into one hexadecimal big endian string.
 ///
 /// @returns The number of bytes from pBuffer that were formatted into pDst.
 extern size_t BytesToStr(

--- a/shared/amdgpu-windows-interop/pal/inc/util/palSysUtil.h
+++ b/shared/amdgpu-windows-interop/pal/inc/util/palSysUtil.h
@@ -182,7 +182,7 @@ enum class KeyCode : uint32
 /// Enum to identify possible configurations
 enum class CpuType : uint32
 {
-    Unknown         = 0,                       ///< No capabilites set
+    Unknown         = 0,                       ///< No capabilities set
     AmdK5           = (CpuVendorAmd + 0),      ///< No MMX, no cmov, no 3DNow
     AmdK6           = (CpuVendorAmd + 1),      ///< No MMX, no cmov, 3DNow (models 6 and 7)
     AmdK6_2         = (CpuVendorAmd + 2),      ///< MMX, no cmov, 3DNow (model 8, no HW WC but not part of cpuid)
@@ -197,7 +197,7 @@ enum class CpuType : uint32
     AmdFamily15h    = (CpuVendorAmd + 11),     ///< Family 15h - Orochi, Trinity, Komodo, Kaveri, Basilisk
     AmdFamily16h    = (CpuVendorAmd + 12),     ///< Family 16h - Kabini
     AmdRyzen        = (CpuVendorAmd + 13),     ///< Ryzen
-    IntelOld        = (CpuVendorIntel + 0),    ///< Inidicate cpu type befor Intel Pentium III
+    IntelOld        = (CpuVendorIntel + 0),    ///< Indicate cpu type before Intel Pentium III
     IntelP3         = (CpuVendorIntel + 1),    ///< Generic Pentium III
     IntelP3Model7   = (CpuVendorIntel + 2),    ///< PIII-7, PIII Xeon-7
     IntelP3Model8   = (CpuVendorIntel + 3),    ///< PIII-8, PIII Xeon-8, Celeron-8
@@ -237,7 +237,7 @@ struct SystemInfo
 ///
 /// @param errno_in Value from 'errno' (or functions that return errno_t)
 ///
-/// @returns Relevent Result value for the given errno-- never Success.
+/// @returns Relevant Result value for the given errno-- never Success.
 inline Result ConvertErrno(
     int32 errnoIn)
 {
@@ -308,7 +308,7 @@ extern Result HResultToPal(HRESULT hr);
 ///
 /// @param errno_in System error code from 'GetLastError'
 ///
-/// @returns Relevent Result value for the given system error code.
+/// @returns Relevant Result value for the given system error code.
 inline Result ConvertWinError(
     uint32 winError)
 {

--- a/shared/amdgpu-windows-interop/pal/inc/util/palUtil.h
+++ b/shared/amdgpu-windows-interop/pal/inc/util/palUtil.h
@@ -483,7 +483,7 @@ enum class Result : int32
     /// The returned results were incomplete.
     ErrorIncompleteResults                  = -(0x00000060),
 
-    /// The display mode is imcompatible with framebuffer or CRTC.
+    /// The display mode is incompatible with framebuffer or CRTC.
     ErrorIncompatibleDisplayMode            = -(0x00000061),
 
     /// Implicit fullscreen exclusive mode is not safe because the specified window size doesn't match the

--- a/shared/amdgpu-windows-interop/pal/inc/util/palVector.h
+++ b/shared/amdgpu-windows-interop/pal/inc/util/palVector.h
@@ -149,7 +149,7 @@ public:
     /// Increases maximum capacity to the number of elements in the vector, plus the specified increment amount.
     /// Equivalent to this->Reserve(this->NumElements() + amount);
     ///
-    /// @param [in] amount Number of items beyond the current element count to increas the capacity to.
+    /// @param [in] amount Number of items beyond the current element count to increase the capacity to.
     ///
     /// @returns Result ErrorOutOfMemory if the operation failed.
     Result Grow(uint32 amount) { return Reserve(NumElements() + amount); }

--- a/shared/amdgpu-windows-interop/pal/shared/devdriver/shared/legacy/core/inc/ddcPlatform.h
+++ b/shared/amdgpu-windows-interop/pal/shared/devdriver/shared/legacy/core/inc/ddcPlatform.h
@@ -140,7 +140,7 @@ typedef void (*ThreadFunction)(void* pThreadParameter);
     #error "DD_DEBUG_BREAK not defined by platform!"
 #endif
 
-// This only exists for 32bit Windows to specificy callbacks as __stdcall.
+// This only exists for 32bit Windows to specify callbacks as __stdcall.
 #if !defined(DD_APIENTRY)
     #define DD_APIENTRY
 #endif

--- a/shared/amdgpu-windows-interop/pal/shared/devdriver/shared/legacy/core/inc/ddcTemplate.h
+++ b/shared/amdgpu-windows-interop/pal/shared/devdriver/shared/legacy/core/inc/ddcTemplate.h
@@ -144,7 +144,7 @@ namespace DevDriver
             return ret;
         }
 
-        /// Rounds the specified uint 'value' up to the nearest power of 2. Constexpr varient.
+        /// Rounds the specified uint 'value' up to the nearest power of 2. Constexpr variant.
         ///
         /// @returns Power of 2 padded value.
         template<typename T>
@@ -153,7 +153,7 @@ namespace DevDriver
             return (padded < value) ? _ConstPow2Pad(value, padded << 1) : padded;
         }
 
-        /// Rounds the specified uint 'value' up to the nearest power of 2. Constexpr varient.
+        /// Rounds the specified uint 'value' up to the nearest power of 2. Constexpr variant.
         ///
         /// @returns Power of 2 padded value.
         template<typename T>

--- a/shared/amdgpu-windows-interop/pal/shared/devdriver/shared/legacy/inc/ddUriInterface.h
+++ b/shared/amdgpu-windows-interop/pal/shared/devdriver/shared/legacy/inc/ddUriInterface.h
@@ -277,7 +277,7 @@ namespace DevDriver
         virtual Result HandleRequest(IURIRequestContext* pContext) = 0;
 
         // Determines the size limit for post data requests for the client request.  By default services
-        // will not accept any post data.  The pArguments paramter must remain non-const because the
+        // will not accept any post data.  The pArguments parameter must remain non-const because the
         // service may need to manipulate it for further processing.
         virtual size_t QueryPostSizeLimit(char* pArguments) const
         {

--- a/shared/amdgpu-windows-interop/pal/shared/devdriver/shared/legacy/inc/gpuopen.h
+++ b/shared/amdgpu-windows-interop/pal/shared/devdriver/shared/legacy/inc/gpuopen.h
@@ -144,7 +144,7 @@
 *| 5.0     | Update network protocol to allow specifying status flags at registration time, and add system message.   |
 *|         | to indicate when a driver has been halted. Additionally, this changes the format of the client           |
 *|         | registration packets so as to better detect version mismatch. It also fixes the ClientManangement typo.  |
-*| 4.0     | Refactor interface so as to better delineate between system protcols/client protocols, as well as add    |
+*| 4.0     | Refactor interface so as to better delineate between system protocols/client protocols, as well as add   |
 *|         | ability to query protocol availability. Requires version bump, so also formally deprecated               |
 *|         | Result::Timeout and ClientStatusFlags::ProfilingEnabled, as well as moved entire SessionProtocol         |
 *|         | namespace out of the public headers.                                                                     |

--- a/shared/amdgpu-windows-interop/pal/shared/devdriver/shared/legacy/inc/util/sharedptr.h
+++ b/shared/amdgpu-windows-interop/pal/shared/devdriver/shared/legacy/inc/util/sharedptr.h
@@ -223,14 +223,14 @@ namespace DevDriver
             return Get();
         }
 
-        // Templated comparison operator. Allows comparing shared pointer objects so long as U is convertable to T.
+        // Templated comparison operator. Allows comparing shared pointer objects so long as U is convertible to T.
         template <typename U, typename = typename Platform::EnableIf<Platform::IsConvertible<U*, T*>::Value>::Type>
         bool operator== (const SharedPointer< U >&right) const
         {
             return m_pObject == right.m_pObject;
         }
 
-        // Templated comparison operator. Allows comparing shared pointer objects so long as U is convertable to T.
+        // Templated comparison operator. Allows comparing shared pointer objects so long as U is convertible to T.
         template <typename U, typename = typename Platform::EnableIf<Platform::IsConvertible<U*, T*>::Value>::Type>
         bool operator!= (const SharedPointer< U >&right) const
         {

--- a/shared/amdgpu-windows-interop/pal/shared/devdriver/shared/legacy/inc/util/string.h
+++ b/shared/amdgpu-windows-interop/pal/shared/devdriver/shared/legacy/inc/util/string.h
@@ -31,7 +31,7 @@
 namespace DevDriver
 {
 // A String class that stores the string inline with a compile-time maximum size.
-// This class facilitiates passing bounded sized C Strings around without dynamic allocation. It has POD semantics
+// This class facilitates passing bounded sized C Strings around without dynamic allocation. It has POD semantics
 // when copied or passed by value into functions, and can be stored in a vector.
 template<size_t FixedSize>
 class FixedString

--- a/shared/amdgpu-windows-interop/pal/shared/devdriver/shared/legacy/inc/util/vector.h
+++ b/shared/amdgpu-windows-interop/pal/shared/devdriver/shared/legacy/inc/util/vector.h
@@ -479,7 +479,7 @@ namespace DevDriver
         // Disallow copy construct.
         Vector(Vector& rhs) = delete;
 
-        // This indirection fixes the warning comparision of a constant with another constant. This should be
+        // This indirection fixes the warning comparison of a constant with another constant. This should be
         // replace with `if constexpr` once AMDLog upgrades to support C++17.
         constexpr bool is_type_trivial()
         {

--- a/shared/amdgpu-windows-interop/pal/shared/inc/trackedCmdLocation.h
+++ b/shared/amdgpu-windows-interop/pal/shared/inc/trackedCmdLocation.h
@@ -145,7 +145,7 @@ struct TrackedCmdLocation
 };
 
 // =====================================================================================================================
-/// @brief  Helper funcion to obtain DeltaInDwords from TrackedCmdLocation
+/// @brief  Helper function to obtain DeltaInDwords from TrackedCmdLocation
 ///
 /// @detail m_correlateInternal.m_deltaInDWords is only used when m_mode == TrackedCmdLocationMode::Delta
 ///             And describes a TrackedCmdLocationMode::Before, TrackedCmdLocationMode::After pair
@@ -173,7 +173,7 @@ constexpr uint64_t TrackedCmdLocationGetDeltaInDwords(
 }
 
 // =====================================================================================================================
-/// @brief  Helper funcion to convert DeltaInDwords from TrackedCmdLocation to "InBytes"
+/// @brief  Helper function to convert DeltaInDwords from TrackedCmdLocation to "InBytes"
 ///
 /// @returns 0 in m_mode != TrackedCmdLocationMode::Delta
 ///         m_correlateInternal.m_deltaInDWords * sizeof(DWORD) otherwise - where DWORD is uint32_t

--- a/shared/amdgpu-windows-interop/sc/HSAIL/ext/libamdhsacode/amd_hsa_code.cpp
+++ b/shared/amdgpu-windows-interop/sc/HSAIL/ext/libamdhsacode/amd_hsa_code.cpp
@@ -759,7 +759,7 @@ namespace code {
         switch (img->EClass()) {
         case ELFCLASS64:
           // There is no e_machine and/or OS ABI for R600 so rely on checking
-          // the ELFCLASS to determin if AMDGCN verses R600. AMDHSA always uses
+          // the ELFCLASS to determine if AMDGCN verses R600. AMDHSA always uses
           // ELFCLASS64 and R600 always uses ELFCLASS32.
           isa_name += "amdgcn";
           break;

--- a/shared/amdgpu-windows-interop/sc/HSAIL/ext/loader/executable.cpp
+++ b/shared/amdgpu-windows-interop/sc/HSAIL/ext/loader/executable.cpp
@@ -1495,7 +1495,7 @@ hsa_status_t ExecutableImpl::LoadDefinitionSymbol(hsa_agent_t agent,
     sym->GetSection()->getData(sym->SectionOffset(), &kd, sizeof(kd));
 
     uint32_t kernarg_segment_size = kd.kernarg_size; // FIXME: If 0 then the compiler is not specifying the size.
-    uint32_t kernarg_segment_alignment = 16;         // FIXME: Use the minumum HSA required alignment.
+    uint32_t kernarg_segment_alignment = 16;         // FIXME: Use the minimum HSA required alignment.
     uint32_t group_segment_size = kd.group_segment_fixed_size;
     uint32_t private_segment_size = kd.private_segment_fixed_size;
     bool is_dynamic_callstack = AMDHSA_BITS_GET(

--- a/shared/amdgpu-windows-interop/sc/HSAIL/include/amd_hsa_elf.h
+++ b/shared/amdgpu-windows-interop/sc/HSAIL/include/amd_hsa_elf.h
@@ -51,7 +51,7 @@
 // AMD GPU Specific ELF Header Enumeration Values.
 //
 // Values are copied from LLVM BinaryFormat/ELF.h . This file also contains
-// code object V1 defintions which are not part of the LLVM header. Code object
+// code object V1 definitions which are not part of the LLVM header. Code object
 // V1 was only supported by the Finalizer which is now deprecated and removed.
 //
 // TODO: Deprecate and remove V1 support and replace this header with using the

--- a/shared/amdgpu-windows-interop/sc/HSAIL/include/amd_hsa_program.hpp
+++ b/shared/amdgpu-windows-interop/sc/HSAIL/include/amd_hsa_program.hpp
@@ -92,7 +92,7 @@ public:
   /// @param[in] size Requested deallocation size in bytes.
   virtual void CodeObjectFree(void *ptr, size_t size) = 0;
 
-  /// @brief Invoked when AMD HSA Finalizer and Program needs to reprot message or error
+  /// @brief Invoked when AMD HSA Finalizer and Program needs to report message or error
   ///
   /// @param[in] str Message to report.
   virtual void ReportMessage(const std::string& str) = 0;

--- a/shared/amdgpu-windows-interop/sc/HSAIL/include/hsa.h
+++ b/shared/amdgpu-windows-interop/sc/HSAIL/include/hsa.h
@@ -826,7 +826,7 @@ typedef enum {
    */
   HSA_AGENT_INFO_FEATURE = 2,
   /**
-   * @deprecated Query ::HSA_ISA_INFO_MACHINE_MODELS for a given intruction set
+   * @deprecated Query ::HSA_ISA_INFO_MACHINE_MODELS for a given instruction set
    * architecture supported by the agent instead.  If more than one ISA is
    * supported by the agent, the returned value corresponds to the first ISA
    * enumerated by ::hsa_agent_iterate_isas.
@@ -836,7 +836,7 @@ typedef enum {
    */
   HSA_AGENT_INFO_MACHINE_MODEL = 3,
   /**
-   * @deprecated Query ::HSA_ISA_INFO_PROFILES for a given intruction set
+   * @deprecated Query ::HSA_ISA_INFO_PROFILES for a given instruction set
    * architecture supported by the agent instead.  If more than one ISA is
    * supported by the agent, the returned value corresponds to the first ISA
    * enumerated by ::hsa_agent_iterate_isas.
@@ -847,7 +847,7 @@ typedef enum {
   HSA_AGENT_INFO_PROFILE = 4,
   /**
    * @deprecated Query ::HSA_ISA_INFO_DEFAULT_FLOAT_ROUNDING_MODES for a given
-   * intruction set architecture supported by the agent instead.  If more than
+   * instruction set architecture supported by the agent instead.  If more than
    * one ISA is supported by the agent, the returned value corresponds to the
    * first ISA enumerated by ::hsa_agent_iterate_isas.
    *
@@ -858,7 +858,7 @@ typedef enum {
   HSA_AGENT_INFO_DEFAULT_FLOAT_ROUNDING_MODE = 5,
   /**
    * @deprecated Query ::HSA_ISA_INFO_BASE_PROFILE_DEFAULT_FLOAT_ROUNDING_MODES
-   * for a given intruction set architecture supported by the agent instead.  If
+   * for a given instruction set architecture supported by the agent instead.  If
    * more than one ISA is supported by the agent, the returned value corresponds
    * to the first ISA enumerated by ::hsa_agent_iterate_isas.
    *
@@ -870,7 +870,7 @@ typedef enum {
    */
   HSA_AGENT_INFO_BASE_PROFILE_DEFAULT_FLOAT_ROUNDING_MODES = 23,
   /**
-   * @deprecated Query ::HSA_ISA_INFO_FAST_F16_OPERATION for a given intruction
+   * @deprecated Query ::HSA_ISA_INFO_FAST_F16_OPERATION for a given instruction
    * set architecture supported by the agent instead.  If more than one ISA is
    * supported by the agent, the returned value corresponds to the first ISA
    * enumerated by ::hsa_agent_iterate_isas.
@@ -883,7 +883,7 @@ typedef enum {
   HSA_AGENT_INFO_FAST_F16_OPERATION = 24,
   /**
    * @deprecated Query ::HSA_WAVEFRONT_INFO_SIZE for a given wavefront and
-   * intruction set architecture supported by the agent instead.  If more than
+   * instruction set architecture supported by the agent instead.  If more than
    * one ISA is supported by the agent, the returned value corresponds to the
    * first ISA enumerated by ::hsa_agent_iterate_isas and the first wavefront
    * enumerated by ::hsa_isa_iterate_wavefronts for that ISA.
@@ -894,7 +894,7 @@ typedef enum {
    */
   HSA_AGENT_INFO_WAVEFRONT_SIZE = 6,
   /**
-   * @deprecated Query ::HSA_ISA_INFO_WORKGROUP_MAX_DIM for a given intruction
+   * @deprecated Query ::HSA_ISA_INFO_WORKGROUP_MAX_DIM for a given instruction
    * set architecture supported by the agent instead.  If more than one ISA is
    * supported by the agent, the returned value corresponds to the first ISA
    * enumerated by ::hsa_agent_iterate_isas.
@@ -907,7 +907,7 @@ typedef enum {
    */
   HSA_AGENT_INFO_WORKGROUP_MAX_DIM = 7,
   /**
-   * @deprecated Query ::HSA_ISA_INFO_WORKGROUP_MAX_SIZE for a given intruction
+   * @deprecated Query ::HSA_ISA_INFO_WORKGROUP_MAX_SIZE for a given instruction
    * set architecture supported by the agent instead.  If more than one ISA is
    * supported by the agent, the returned value corresponds to the first ISA
    * enumerated by ::hsa_agent_iterate_isas.
@@ -918,7 +918,7 @@ typedef enum {
    */
   HSA_AGENT_INFO_WORKGROUP_MAX_SIZE = 8,
   /**
-   * @deprecated Query ::HSA_ISA_INFO_GRID_MAX_DIM for a given intruction set
+   * @deprecated Query ::HSA_ISA_INFO_GRID_MAX_DIM for a given instruction set
    * architecture supported by the agent instead.
    *
    * Maximum number of work-items of each dimension of a grid. Each maximum must
@@ -930,7 +930,7 @@ typedef enum {
    */
   HSA_AGENT_INFO_GRID_MAX_DIM = 9,
   /**
-   * @deprecated Query ::HSA_ISA_INFO_GRID_MAX_SIZE for a given intruction set
+   * @deprecated Query ::HSA_ISA_INFO_GRID_MAX_SIZE for a given instruction set
    * architecture supported by the agent instead.  If more than one ISA is
    * supported by the agent, the returned value corresponds to the first ISA
    * enumerated by ::hsa_agent_iterate_isas.
@@ -941,7 +941,7 @@ typedef enum {
    */
   HSA_AGENT_INFO_GRID_MAX_SIZE = 10,
   /**
-   * @deprecated Query ::HSA_ISA_INFO_FBARRIER_MAX_SIZE for a given intruction
+   * @deprecated Query ::HSA_ISA_INFO_FBARRIER_MAX_SIZE for a given instruction
    * set architecture supported by the agent instead.  If more than one ISA is
    * supported by the agent, the returned value corresponds to the first ISA
    * enumerated by ::hsa_agent_iterate_isas.
@@ -1117,7 +1117,7 @@ typedef enum {
 } hsa_exception_policy_t;
 
 /**
- * @deprecated Use ::hsa_isa_get_exception_policies for a given intruction set
+ * @deprecated Use ::hsa_isa_get_exception_policies for a given instruction set
  * architecture supported by the agent instead. If more than one ISA is
  * supported by the agent, this function uses the first value returned by
  * ::hsa_agent_iterate_isas.
@@ -3215,7 +3215,7 @@ typedef enum {
   /**
    * Updates to memory in this region can be performed by a single agent at
    * a time. If a different agent in the system is allowed to access the
-   * region, the application must explicitely invoke ::hsa_memory_assign_agent
+   * region, the application must explicitly invoke ::hsa_memory_assign_agent
    * in order to transfer ownership to that agent for a particular buffer.
    */
   HSA_REGION_GLOBAL_FLAG_COARSE_GRAINED = 4
@@ -3426,7 +3426,7 @@ hsa_status_t HSA_API hsa_memory_copy(
  * @brief Change the ownership of a global, coarse-grained buffer.
  *
  * @details The contents of a coarse-grained buffer are visible to an agent
- * only after ownership has been explicitely transferred to that agent. Once the
+ * only after ownership has been explicitly transferred to that agent. Once the
  * operation completes, the previous owner cannot longer access the data in the
  * buffer.
  *

--- a/shared/amdgpu-windows-interop/sc/HSAIL/include/hsa_ven_amd_loader.h
+++ b/shared/amdgpu-windows-interop/sc/HSAIL/include/hsa_ven_amd_loader.h
@@ -236,7 +236,7 @@ hsa_status_t hsa_ven_amd_loader_query_segment_descriptors(
  * @retval HSA_STATUS_ERROR_NOT_INITIALIZED Runtime is not initialized.
  *
  * @retval HSA_STATUS_ERROR_INVALID_ARGUMENT The input is invalid or there
- * is no exectuable found for this kernel code object.
+ * is no executable found for this kernel code object.
  */
 hsa_status_t hsa_ven_amd_loader_query_executable(
   const void *device_address,
@@ -348,7 +348,7 @@ typedef enum hsa_ven_amd_loader_loaded_code_object_info_e {
    * The signed byte address difference of the memory address at which the code
    * object is loaded minus the virtual address specified in the code object
    * that is loaded. The value of this attribute is only defined if the
-   * executable in which the code object is loaded is froozen. The type of this
+   * executable in which the code object is loaded is frozen. The type of this
    * attribute is ::int64_t.
    */
   HSA_VEN_AMD_LOADER_LOADED_CODE_OBJECT_INFO_LOAD_DELTA = 8,
@@ -357,14 +357,14 @@ typedef enum hsa_ven_amd_loader_loaded_code_object_info_e {
    * base address of the allocation for the lowest addressed segment of the code
    * object that is loaded. Note that any non-loaded segments before the first
    * loaded segment are ignored. The value of this attribute is only defined if
-   * the executable in which the code object is loaded is froozen. The type of
+   * the executable in which the code object is loaded is frozen. The type of
    * this attribute is ::uint64_t.
    */
   HSA_VEN_AMD_LOADER_LOADED_CODE_OBJECT_INFO_LOAD_BASE = 9,
   /**
    * The byte size of the loaded code objects contiguous memory allocation. The
    * value of this attribute is only defined if the executable in which the code
-   * object is loaded is froozen. The type of this attribute is ::uint64_t.
+   * object is loaded is frozen. The type of this attribute is ::uint64_t.
    */
   HSA_VEN_AMD_LOADER_LOADED_CODE_OBJECT_INFO_LOAD_SIZE = 10,
   /**
@@ -391,7 +391,7 @@ typedef enum hsa_ven_amd_loader_loaded_code_object_info_e {
    *
    * ``file_path`` is the file's path specified as a URI encoded UTF-8 string.
    * In URI encoding, every character that is not in the regular expression
-   * ``[a-zA-Z0-9/_.~-]`` is encoded as two uppercase hexidecimal digits
+   * ``[a-zA-Z0-9/_.~-]`` is encoded as two uppercase hexadecimal digits
    * proceeded by "%".  Directories in the path are separated by "/".
    *
    * ``offset`` is a 0-based byte offset to the start of the code object.  For a

--- a/shared/kpack/docs/multi_arch_packaging_with_kpack.md
+++ b/shared/kpack/docs/multi_arch_packaging_with_kpack.md
@@ -1558,7 +1558,7 @@ rocm-blas-gfx120X_8.0.0_amd64.deb
   - Provides: rocm-blas-device-code
 ```
 
-Again, this is simplified for illustration. Details will be worked out by the implementors.
+Again, this is simplified for illustration. Details will be worked out by the implementers.
 
 **Installation Workflow**:
 

--- a/test/therock/test_hiptests.py
+++ b/test/therock/test_hiptests.py
@@ -95,7 +95,7 @@ def get_asan_lib_path():
 
 def copy_dlls_exe_path():
     if platform.system() == "Windows":
-        # hip and comgr dlls need to be copied to the same folder as exectuable
+        # hip and comgr dlls need to be copied to the same folder as executable
         dlls_pattern = [
             "amdhip64*.dll",
             "amd_comgr*.dll",


### PR DESCRIPTION
Comments and strings only - no code changes otherwise. Changes made manually by a human, not AI.

## Motivation

We should fix spelling errors in our code. `codespell` can help with this.

## Technical Details

Ran this command over the `docs`, `shared`, and `test` directories:

`codespell --skip=*.kpm -L=hsa,HSA,Synopsys,VALU,LOD,Uscaled,pEvent,VAs,Inactivate,aranges <dir>`
