### PR TITLE
ROCM-21812 - cap the size only for APUs

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -1241,12 +1241,21 @@ bool Device::populateOCLDeviceConstants() {
     }
 
     // For APU systems the SVM aperture can exceed actual physical RAM.
-    const size_t phys_mem = amd::Os::getPhysicalMemSize();
-    const uint apu_mem_percent =
-        ((phys_mem / Mi) > 1536 && IS_WINDOWS) ? 75 : 50;
-    const uint64_t apu_mem_limit = phys_mem * apu_mem_percent / 100;
-    info_.globalMemSize_ = std::min(info_.globalMemSize_,
-                                    static_cast<uint64_t>(apu_mem_limit));
+    // Only apply to integrated/APU devices — dGPUs report real VRAM.
+    // Only cap if reported VRAM exceeds physical RAM (unrealistic SVM aperture).
+    const bool is_apu = hsa_flag_isset64(memory_properties, HSA_AMD_MEMORY_PROPERTY_AGENT_IS_APU);
+    if (is_apu) {
+      const size_t phys_mem = amd::Os::getPhysicalMemSize();
+
+      // Only cap if VRAM > physical RAM (indicates SVM aperture, not real allocation)
+      if (info_.globalMemSize_ > phys_mem) {
+        const uint apu_mem_percent =
+            ((phys_mem / Mi) > 1536 && IS_WINDOWS) ? 75 : 50;
+        const uint64_t apu_mem_limit = phys_mem * apu_mem_percent / 100;
+        info_.globalMemSize_ = std::min(info_.globalMemSize_,
+                                        static_cast<uint64_t>(apu_mem_limit));
+      }
+    }
 
     gpuvm_segment_max_alloc_ =
         uint64_t(info_.globalMemSize_ * std::min(GPU_SINGLE_ALLOC_PERCENT, 100u) / 100u);

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -1761,6 +1761,9 @@ memory:
   Unit_hipMemGetInfo_FreeLessThanTotal:
     <<: *level_2
     tags: [query]
+  Unit_hipMemGetInfo_ConsistencyCheck:
+    <<: *level_2
+    tags: [query]
   Unit_hipFreeImplicitSyncDev:
     <<: *level_2
     # Note: TDR

--- a/projects/hip-tests/catch/unit/memory/hipMemGetInfo.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemGetInfo.cc
@@ -20,3 +20,24 @@ HIP_TEST_CASE(Unit_hipMemGetInfo_FreeLessThanTotal) {
 
   HIP_CHECK(hipFree(A_mem));
 }
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Verify that free memory never exceeds total memory.
+ *  - This is a universal sanity check that catches memory reporting bugs.
+ *  - Prevents regression where free=25.85 GiB > total=15.35 GiB occurred.
+ * Test source
+ * ------------------------
+ *  - unit/memory/hipMemGetInfo.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+HIP_TEST_CASE(Unit_hipMemGetInfo_ConsistencyCheck) {
+  size_t free, total;
+  HIP_CHECK(hipMemGetInfo(&free, &total));
+
+  // Free memory must never exceed total memory
+  REQUIRE(free <= total);
+}


### PR DESCRIPTION
## Motivation

Fix a regression for DGPUs

## Technical Details

 capped VRAM-reported total memory to 50% of host RAM, but free memory still reflected actual VRAM 

## JIRA ID

ROCM-21812

## Test Plan

ROCM-21812 tested with the regression point

## Test Result

passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
