### PR TITLE
[hipFile] Leave some space for libmount / temp files to open file descriptors in state_mt.

### DIFF
--- a/projects/hipfile/test/amd_detail/state_mt.cpp
+++ b/projects/hipfile/test/amd_detail/state_mt.cpp
@@ -399,7 +399,7 @@ main()
         cerr << "RLIMIT_NOFILE (ulimit -n) is to low" << endl;
         exit(EXIT_FAILURE);
     }
-    n_free_files = (nofile.rlim_cur - n_file_reserved) / n_fds_per_registered_file;
+    n_free_files = (nofile.rlim_cur - n_file_reserved) / n_fds_per_registered_file - 2 * N_THREADS;
 
     array<thread, N_THREADS> threads;
 


### PR DESCRIPTION
We're hitting EMFILE in mnt_context_get_mtab and mkstemp when running state_mt.  Reserve two file descriptors per-thread.