### PR TITLE
[ROCM-1553] GPU metrics v1.9 support with new attributes

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -3,6 +3,29 @@
 Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/projects/amdsmi](https://rocm.docs.amd.com/projects/amdsmi/en/latest/).
 
 ***All information listed below is for reference and subject to change.***
+## amd_smi_lib for ROCm 7.13.0
+
+### Added
+
+- **Added support for GPU metrics v1.9 new fields**.  
+  - Added new temperature fields to `amdsmi_gpu_metrics_t`:
+    - `temperature_hbm_stacks` — per-stack HBM temperatures (°C)
+    - `temperature_mid` — per-MID temperatures (°C)
+    - `temperature_aid` — per-AID temperatures (°C)
+    - `temperature_xcd` — per-XCC compute die temperatures (°C)
+  - Added new per-die clock fields to `amdsmi_gpu_metrics_t`:
+    - `current_uclk_aid` — per-AID uclk (MHz)
+    - `current_socclks_mid` — per-MID SOC clock (MHz)
+  - Added new constants:
+    - `AMDSMI_MAX_NUM_HBM_STACKS` (12)
+    - `AMDSMI_MAX_NUM_AID` (2)
+    - `AMDSMI_MAX_NUM_MID` (2)
+    - `AMDSMI_MAX_NUM_CLKS_PER_AID` (2)
+    - `AMDSMI_MAX_NUM_CLKS_PER_MID` (2)
+
+### Changed
+
+- **Renamed `lc_perf_other_end_recovery` to `lc_perf_other_end_recovery_count` in `amd-smi metric` CLI output for unification**.  
 
 ## amd_smi_lib for ROCm 7.13.0
 

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -3,6 +3,7 @@
 Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/projects/amdsmi](https://rocm.docs.amd.com/projects/amdsmi/en/latest/).
 
 ***All information listed below is for reference and subject to change.***
+
 ## amd_smi_lib for ROCm 7.13.0
 
 ### Added
@@ -22,14 +23,6 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
     - `AMDSMI_MAX_NUM_MID` (2)
     - `AMDSMI_MAX_NUM_CLKS_PER_AID` (2)
     - `AMDSMI_MAX_NUM_CLKS_PER_MID` (2)
-
-### Changed
-
-- **Renamed `lc_perf_other_end_recovery` to `lc_perf_other_end_recovery_count` in `amd-smi metric` CLI output for unification**.  
-
-## amd_smi_lib for ROCm 7.13.0
-
-### Added
 
 - **Added VRAM and GTT tuning interface**.  
   - New `amd-smi static --mem-carveout` to view VRAM carveout options.
@@ -84,6 +77,8 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - Process `cu_occupancy` is now initialized to `INVALID` instead of zero, so `amd-smi process` displays `N/A` rather than a misleading `0%` when the sysfs file is not accessible.
 
 ### Changed
+
+- **Renamed `lc_perf_other_end_recovery` to `lc_perf_other_end_recovery_count` in `amd-smi metric` CLI output for unification**.  
 
 - **Removed references to deprecated `amd-smi reset -r`**.  
   - CLI help text and memory partition change warnings no longer reference `amd-smi reset -r` for driver reloading.

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -3018,7 +3018,7 @@ class AMDSMICommands:
                     "current_bandwidth_sent": "N/A",
                     "current_bandwidth_received": "N/A",
                     "max_packet_size": "N/A",
-                    "lc_perf_other_end_recovery": "N/A",
+                    "lc_perf_other_end_recovery_count": "N/A",
                 }
 
                 try:
@@ -3054,7 +3054,7 @@ class AMDSMICommands:
                     pcie_dict["replay_roll_over_count"] = pcie_metric["pcie_replay_roll_over_count"]
                     pcie_dict["nak_received_count"] = pcie_metric["pcie_nak_received_count"]
                     pcie_dict["nak_sent_count"] = pcie_metric["pcie_nak_sent_count"]
-                    pcie_dict["lc_perf_other_end_recovery"] = pcie_metric[
+                    pcie_dict["lc_perf_other_end_recovery_count"] = pcie_metric[
                         "pcie_lc_perf_other_end_recovery_count"
                     ]
 
@@ -3315,6 +3315,9 @@ class AMDSMICommands:
                     "deep_sleep": "N/A",
                 }
 
+                clocks["uclk_aid"] = "N/A"
+                clocks["socclks_mid"] = "N/A"
+
                 clock_unit = "MHz"
 
                 # Populate clock values from gpu_metrics_info
@@ -3409,6 +3412,30 @@ class AMDSMICommands:
                         )
                 except KeyError as e:
                     logging.debug("Failed to get current_socclk for gpu %s | %s", gpu_id, e)
+
+                try:
+                    current_uclk_aid = gpu_metric.get("current_uclk_aid", "N/A")
+                    if current_uclk_aid != "N/A":
+                        clocks["uclk_aid"] = {
+                            f"AID_{index}": self.helpers.unit_format(self.logger, clk, clock_unit)
+                            if clk != "N/A"
+                            else "N/A"
+                            for index, clk in enumerate(current_uclk_aid)
+                        }
+                except Exception as e:
+                    logging.debug("Failed to get current_uclk_aid for gpu %s | %s", gpu_id, e)
+
+                try:
+                    current_socclks_mid = gpu_metric.get("current_socclks_mid", "N/A")
+                    if current_socclks_mid != "N/A":
+                        clocks["socclks_mid"] = {
+                            f"MID_{index}": self.helpers.unit_format(self.logger, clk, clock_unit)
+                            if clk != "N/A"
+                            else "N/A"
+                            for index, clk in enumerate(current_socclks_mid)
+                        }
+                except Exception as e:
+                    logging.debug("Failed to get current_socclks_mid for gpu %s | %s", gpu_id, e)
 
                 # Populate the max and min clock values from sysfs.
                 # Min and Max values are per clock type, not per clock engine.
@@ -3651,12 +3678,74 @@ class AMDSMICommands:
                     "edge": temperature_edge_current,
                     "hotspot": temperature_hotspot_current,
                     "mem": temperature_vram_current,
+                    "hbm_stacks": gpu_metric.get("temperature_hbm_stacks", "N/A"),
+                    "mid": gpu_metric.get("temperature_mid", "N/A"),
+                    "aid": gpu_metric.get("temperature_aid", "N/A"),
+                    "xcd": "N/A",
                 }
+
+                if temperatures["hbm_stacks"] != "N/A":
+                    temperatures["hbm_stacks"] = list(temperatures["hbm_stacks"])
+                if temperatures["mid"] != "N/A":
+                    temperatures["mid"] = list(temperatures["mid"])
+                if temperatures["aid"] != "N/A":
+                    temperatures["aid"] = list(temperatures["aid"])
+
+                if num_partition != "N/A":
+                    xcp_temp_xcd = gpu_metric.get("xcp_stats.temperature_xcd", "N/A")
+                    if xcp_temp_xcd != "N/A":
+                        available_partition = min(num_partition, len(xcp_temp_xcd))
+                        temperatures["xcd"] = {
+                            f"XCP_{current_xcp}": xcp_temp_xcd[current_xcp]
+                            for current_xcp in range(available_partition)
+                        }
 
                 temp_unit_human_readable = "\N{DEGREE SIGN}C"
                 temp_unit_json = "C"
                 for temperature_key, temperature_value in temperatures.items():
-                    if "N/A" not in str(temperature_value):
+                    if isinstance(temperature_value, list):
+                        if self.logger.is_human_readable_format():
+                            formatted_values = [
+                                f"{value} {temp_unit_human_readable}" if value != "N/A" else "N/A"
+                                for value in temperature_value
+                            ]
+                            temperatures[temperature_key] = "[" + ", ".join(formatted_values) + "]"
+                        if self.logger.is_json_format():
+                            temperatures[temperature_key] = [
+                                {"value": value, "unit": temp_unit_json}
+                                if value != "N/A"
+                                else "N/A"
+                                for value in temperature_value
+                            ]
+                    elif isinstance(temperature_value, dict):
+                        for key, value in temperature_value.items():
+                            if isinstance(value, list):
+                                if self.logger.is_human_readable_format():
+                                    formatted_values = [
+                                        f"{item} {temp_unit_human_readable}"
+                                        if item != "N/A"
+                                        else "N/A"
+                                        for item in value
+                                    ]
+                                    temperature_value[key] = "[" + ", ".join(formatted_values) + "]"
+                                if self.logger.is_json_format():
+                                    temperature_value[key] = [
+                                        {"value": item, "unit": temp_unit_json}
+                                        if item != "N/A"
+                                        else "N/A"
+                                        for item in value
+                                    ]
+                            elif value != "N/A":
+                                if self.logger.is_human_readable_format():
+                                    temperature_value[key] = f"{value} {temp_unit_human_readable}"
+                                if self.logger.is_json_format():
+                                    temperature_value[key] = {
+                                        "value": value,
+                                        "unit": temp_unit_json,
+                                    }
+                    else:
+                        if temperature_value == "N/A":
+                            continue
                         if self.logger.is_human_readable_format():
                             temperatures[temperature_key] = (
                                 f"{temperature_value} {temp_unit_human_readable}"

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -204,6 +204,17 @@ typedef enum {
 #define AMDSMI_MAX_PROFILE_COUNT 16          //!< Maximum profiles supported
 
 /**
+ * @brief Introduced in gpu metrics v1.9+
+ *
+ * @cond @tag{gpu_bm_linux} @endcond
+ */
+#define AMDSMI_MAX_NUM_HBM_STACKS 12   //!< Maximum number of HBM stacks supported
+#define AMDSMI_MAX_NUM_AID 2           //!< Maximum number of AID supported
+#define AMDSMI_MAX_NUM_MID 2           //!< Maximum number of MID supported
+#define AMDSMI_MAX_NUM_CLKS_PER_AID 2  //!< Maximum number of clocks per AID supported
+#define AMDSMI_MAX_NUM_CLKS_PER_MID 2  //!< Maximum number of clocks per MID supported
+
+/**
  * @brief String format
  *
  * @cond @tag{gpu_bm_linux} @tag{host} @tag{guest_windows} @endcond
@@ -2032,6 +2043,11 @@ typedef struct {
   uint64_t gfx_below_host_limit_thm_acc[AMDSMI_MAX_NUM_XCC];
   uint64_t gfx_low_utilization_acc[AMDSMI_MAX_NUM_XCC];
   uint64_t gfx_below_host_limit_total_acc[AMDSMI_MAX_NUM_XCC];
+
+  /**
+   * @brief v1.9 additions
+   */
+  uint16_t temperature_xcd[AMDSMI_MAX_NUM_XCC];
 } amdsmi_gpu_xcp_metrics_t;
 
 /**
@@ -2231,6 +2247,17 @@ typedef struct {
   uint64_t vram_max_bandwidth;  //!< VRAM max bandwidth at max memory clock (GB/s)
 
   uint16_t xgmi_link_status[AMDSMI_MAX_NUM_XGMI_LINKS];  //!< XGMI link status(up/down)
+
+  /**
+   * @brief v1.9 additions
+   */
+  uint16_t
+      temperature_hbm_stacks[AMDSMI_MAX_NUM_HBM_STACKS];  //!< temperature of the HBM stacks in C
+  uint16_t temperature_mid[AMDSMI_MAX_NUM_MID];           //!< temperature of the MID in C
+  uint16_t temperature_aid[AMDSMI_MAX_NUM_AID];           //!< temperature of the AID in C
+
+  uint16_t current_uclk_aid[AMDSMI_MAX_NUM_CLKS_PER_AID];     //!< In MHz
+  uint16_t current_socclks_mid[AMDSMI_MAX_NUM_CLKS_PER_MID];  //!< In MHz
 } amdsmi_gpu_metrics_t;
 
 /**

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -1048,6 +1048,12 @@ def _NA_amdsmi_get_gpu_metrics_info() -> Dict[str, str]:
         "pcie_lc_perf_other_end_recovery": "N/A",
         "vram_max_bandwidth": "N/A",
         "xgmi_link_status": "N/A",
+        "temperature_hbm_stacks": "N/A",
+        "temperature_mid": "N/A",
+        "temperature_aid": "N/A",
+        "current_uclk_aid": "N/A",
+        "current_socclks_mid": "N/A",
+        "xcp_stats.temperature_xcd": "N/A",
     }
     return na_gpu_metrics_info
 
@@ -5803,6 +5809,7 @@ def amdsmi_get_gpu_metrics_info(processor_handle: processor_handle_t) -> Dict[st
         "xcp_stats.gfx_below_host_limit_thm_acc": list(gpu_metrics.xcp_stats),
         "xcp_stats.gfx_low_utilization_acc": list(gpu_metrics.xcp_stats),
         "xcp_stats.gfx_below_host_limit_total_acc": list(gpu_metrics.xcp_stats),
+        "xcp_stats.temperature_xcd": list(gpu_metrics.xcp_stats),
         "pcie_lc_perf_other_end_recovery": _validate_if_max_uint(
             gpu_metrics.pcie_lc_perf_other_end_recovery, MaxUIntegerTypes.UINT32_T
         ),
@@ -5811,6 +5818,21 @@ def amdsmi_get_gpu_metrics_info(processor_handle: processor_handle_t) -> Dict[st
         ),
         "xgmi_link_status": _validate_if_max_uint(
             list(gpu_metrics.xgmi_link_status), MaxUIntegerTypes.UINT16_T
+        ),
+        "temperature_hbm_stacks": _validate_if_max_uint(
+            list(gpu_metrics.temperature_hbm_stacks), MaxUIntegerTypes.UINT16_T
+        ),
+        "temperature_mid": _validate_if_max_uint(
+            list(gpu_metrics.temperature_mid), MaxUIntegerTypes.UINT16_T
+        ),
+        "temperature_aid": _validate_if_max_uint(
+            list(gpu_metrics.temperature_aid), MaxUIntegerTypes.UINT16_T
+        ),
+        "current_uclk_aid": _validate_if_max_uint(
+            list(gpu_metrics.current_uclk_aid), MaxUIntegerTypes.UINT16_T
+        ),
+        "current_socclks_mid": _validate_if_max_uint(
+            list(gpu_metrics.current_socclks_mid), MaxUIntegerTypes.UINT16_T
         ),
     }
 
@@ -5890,6 +5912,13 @@ def amdsmi_get_gpu_metrics_info(processor_handle: processor_handle_t) -> Dict[st
             for val in xcp_metrics.gfx_below_host_limit_total_acc:
                 xcp_detail.append(_validate_if_max_uint(val, MaxUIntegerTypes.UINT64_T))
             gpu_metrics_output["xcp_stats.gfx_below_host_limit_total_acc"][xcp_index] = xcp_detail
+
+    if "xcp_stats.temperature_xcd" in gpu_metrics_output:
+        for xcp_index, xcp_metrics in enumerate(gpu_metrics_output["xcp_stats.temperature_xcd"]):
+            xcp_detail = []
+            for val in xcp_metrics.temperature_xcd:
+                xcp_detail.append(_validate_if_max_uint(val, MaxUIntegerTypes.UINT16_T))
+            gpu_metrics_output["xcp_stats.temperature_xcd"][xcp_index] = xcp_detail
     return gpu_metrics_output
 
 
@@ -6107,6 +6136,7 @@ def amdsmi_get_gpu_partition_metrics_info(processor_handle: processor_handle_t) 
         "xcp_stats.gfx_below_host_limit_thm_acc": list(gpu_metrics.xcp_stats),
         "xcp_stats.gfx_low_utilization_acc": list(gpu_metrics.xcp_stats),
         "xcp_stats.gfx_below_host_limit_total_acc": list(gpu_metrics.xcp_stats),
+        "xcp_stats.temperature_xcd": list(gpu_metrics.xcp_stats),
         "pcie_lc_perf_other_end_recovery": _validate_if_max_uint(
             gpu_metrics.pcie_lc_perf_other_end_recovery, MaxUIntegerTypes.UINT32_T
         ),
@@ -6115,6 +6145,21 @@ def amdsmi_get_gpu_partition_metrics_info(processor_handle: processor_handle_t) 
         ),
         "xgmi_link_status": _validate_if_max_uint(
             list(gpu_metrics.xgmi_link_status), MaxUIntegerTypes.UINT16_T
+        ),
+        "temperature_hbm_stacks": _validate_if_max_uint(
+            list(gpu_metrics.temperature_hbm_stacks), MaxUIntegerTypes.UINT16_T
+        ),
+        "temperature_mid": _validate_if_max_uint(
+            list(gpu_metrics.temperature_mid), MaxUIntegerTypes.UINT16_T
+        ),
+        "temperature_aid": _validate_if_max_uint(
+            list(gpu_metrics.temperature_aid), MaxUIntegerTypes.UINT16_T
+        ),
+        "current_uclk_aid": _validate_if_max_uint(
+            list(gpu_metrics.current_uclk_aid), MaxUIntegerTypes.UINT16_T
+        ),
+        "current_socclks_mid": _validate_if_max_uint(
+            list(gpu_metrics.current_socclks_mid), MaxUIntegerTypes.UINT16_T
         ),
     }
 
@@ -6194,6 +6239,13 @@ def amdsmi_get_gpu_partition_metrics_info(processor_handle: processor_handle_t) 
             for val in xcp_metrics.gfx_below_host_limit_total_acc:
                 xcp_detail.append(_validate_if_max_uint(val, MaxUIntegerTypes.UINT64_T))
             gpu_metrics_output["xcp_stats.gfx_below_host_limit_total_acc"][xcp_index] = xcp_detail
+
+    if "xcp_stats.temperature_xcd" in gpu_metrics_output:
+        for xcp_index, xcp_metrics in enumerate(gpu_metrics_output["xcp_stats.temperature_xcd"]):
+            xcp_detail = []
+            for val in xcp_metrics.temperature_xcd:
+                xcp_detail.append(_validate_if_max_uint(val, MaxUIntegerTypes.UINT16_T))
+            gpu_metrics_output["xcp_stats.temperature_xcd"][xcp_index] = xcp_detail
     return gpu_metrics_output
 
 

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -2115,6 +2115,7 @@ struct_amdsmi_gpu_xcp_metrics_t._fields_ = [
     ('gfx_below_host_limit_thm_acc', ctypes.c_uint64 * 8),
     ('gfx_low_utilization_acc', ctypes.c_uint64 * 8),
     ('gfx_below_host_limit_total_acc', ctypes.c_uint64 * 8),
+    ('temperature_xcd', ctypes.c_uint16 * 8),
 ]
 
 amdsmi_gpu_xcp_metrics_t = struct_amdsmi_gpu_xcp_metrics_t
@@ -2198,6 +2199,11 @@ struct_amdsmi_gpu_metrics_t._fields_ = [
     ('PADDING_5', ctypes.c_ubyte * 4),
     ('vram_max_bandwidth', ctypes.c_uint64),
     ('xgmi_link_status', ctypes.c_uint16 * 8),
+    ('temperature_hbm_stacks', ctypes.c_uint16 * 12),
+    ('temperature_mid', ctypes.c_uint16 * 2),
+    ('temperature_aid', ctypes.c_uint16 * 2),
+    ('current_uclk_aid', ctypes.c_uint16 * 2),
+    ('current_socclks_mid', ctypes.c_uint16 * 2),
 ]
 
 amdsmi_gpu_metrics_t = struct_amdsmi_gpu_metrics_t

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
@@ -1212,6 +1212,39 @@ typedef struct metrics_table_header_t metrics_table_header_t;
 #define RSMI_MAX_NUM_XCP 8
 
 /**
+ * @brief This should match kRSMI_MAX_NUM_HBM_STACKS;
+ * HBM_STACKS - High Bandwidth Memory, HBM stacks provide high
+ * memory bandwidth.
+ */
+#define RSMI_MAX_NUM_HBM_STACKS 12
+
+/**
+ * @brief This should match kRSMI_MAX_NUM_AID;
+ * AID - Active Interposer Die, part of the multi-die GPU
+ * architecture.
+ */
+#define RSMI_MAX_NUM_AID 2
+
+/**
+ * @brief This should match kRSMI_MAX_NUM_MID;
+ * MID - Multimedia IO Die, part of the multi-die GPU
+ * architecture.
+ */
+#define RSMI_MAX_NUM_MID 2
+
+/**
+ * @brief This should match kRSMI_MAX_NUM_CLKS_PER_AID;
+ * CLKS_PER_AID - Maximum number of clocks per AID.
+ */
+#define RSMI_MAX_NUM_CLKS_PER_AID 2
+
+/**
+ * @brief This should match kRSMI_MAX_NUM_CLKS_PER_MID;
+ * CLKS_PER_MID - Maximum number of clocks per MID.
+ */
+#define RSMI_MAX_NUM_CLKS_PER_MID 2
+
+/**
  * @brief The following structures hold the gpu statistics for a device.
  */
 struct amdgpu_xcp_metrics_t {
@@ -1239,6 +1272,11 @@ struct amdgpu_xcp_metrics_t {
   uint64_t gfx_below_host_limit_thm_acc[RSMI_MAX_NUM_XCC];
   uint64_t gfx_low_utilization_acc[RSMI_MAX_NUM_XCC];
   uint64_t gfx_below_host_limit_total_acc[RSMI_MAX_NUM_XCC];
+
+  /**
+   * v1.9 additions
+   */
+  uint16_t temperature_xcd[RSMI_MAX_NUM_XCC];
 };
 
 typedef struct {
@@ -1448,6 +1486,16 @@ typedef struct {
 
   /* XGMI link status(up/down) */
   uint16_t xgmi_link_status[RSMI_MAX_NUM_XGMI_LINKS];
+
+  /*
+   * v1.9 additions
+   */
+  uint16_t temperature_hbm_stacks[RSMI_MAX_NUM_HBM_STACKS];  //!< temperature of the HBM stacks in C
+  uint16_t temperature_mid[RSMI_MAX_NUM_MID];                //!< temperature of the MID in C
+  uint16_t temperature_aid[RSMI_MAX_NUM_AID];                //!< temperature of the AID in C
+
+  uint16_t current_uclk_aid[RSMI_MAX_NUM_CLKS_PER_AID];     //!< In MHz
+  uint16_t current_socclks_mid[RSMI_MAX_NUM_CLKS_PER_MID];  //!< In MHz
 
   /// \endcond
 } rsmi_gpu_metrics_t;

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_dyn_gpu_metrics.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_dyn_gpu_metrics.h
@@ -155,6 +155,10 @@ enum class AMDGpuMetricAttributeId_t {
   GFX_BELOW_HOST_LIMIT_THM_ACC,
   GFX_LOW_UTILIZATION_ACC,
   GFX_BELOW_HOST_LIMIT_TOTAL_ACC,
+  TEMPERATURE_HBM,
+  TEMPERATURE_MID,
+  TEMPERATURE_AID,
+  TEMPERATURE_XCD,
 };
 
 struct AMDGpuDynamicTranslationTextInfo_t {
@@ -253,6 +257,14 @@ static const auto AMDGpuMetricAttributeIdToString = AMDGpuMetricAttributeIdTrans
      {"GFX_LOW_UTILIZATION_ACC", "Accumulator for GFX low utilization"}},
     {AMDGpuMetricAttributeId_t::GFX_BELOW_HOST_LIMIT_TOTAL_ACC,
      {"GFX_BELOW_HOST_LIMIT_TOTAL_ACC", "Total accumulator for GFX below host limit"}},
+    {AMDGpuMetricAttributeId_t::TEMPERATURE_HBM,
+     {"TEMPERATURE_HBM", "Temperature of High Bandwidth Memory"}},
+    {AMDGpuMetricAttributeId_t::TEMPERATURE_MID,
+     {"TEMPERATURE_MID", "MID (Multimedia IO Die) temperature"}},
+    {AMDGpuMetricAttributeId_t::TEMPERATURE_AID,
+     {"TEMPERATURE_AID", "AID (Active Interposer Die) temperature"}},
+    {AMDGpuMetricAttributeId_t::TEMPERATURE_XCD,
+     {"TEMPERATURE_XCD", "XCD (Accelerator Compute Die) temperature"}},
 };
 
 /*
@@ -1073,7 +1085,44 @@ static const auto AMDGpuMetricsBaseSchema = details::AMDGpuMetricSchemaMapType_t
              details::AMDGpuMetricAttributeId_t::GFX_BELOW_HOST_LIMIT_TOTAL_ACC,
              details::AMDGpuMetricAttributeType_t::TYPE_UINT64,
              details::AMDGpuMetricUnitType_t::PERCENT),
-         static_cast<details::AMDGpuMetricAttributeValue_t>(0)}}};
+         static_cast<details::AMDGpuMetricAttributeValue_t>(0)}},
+
+    {details::AMDGpuMetricAttributeId_t::TEMPERATURE_HBM,
+     details::AMDGpuMetricAttributeData_t{
+         details::AMDGpuMetricAttributeInstance_t(
+             "Temperature HBM", "Temperature of High Bandwidth Memory",
+             details::AMDGpuMetricAttributeId_t::TEMPERATURE_HBM,
+             details::AMDGpuMetricAttributeType_t::TYPE_UINT16,
+             details::AMDGpuMetricUnitType_t::CELSIUS),
+         static_cast<details::AMDGpuMetricAttributeValue_t>(0)}},
+
+    {details::AMDGpuMetricAttributeId_t::TEMPERATURE_MID,
+     details::AMDGpuMetricAttributeData_t{
+         details::AMDGpuMetricAttributeInstance_t(
+             "Temperature MID", "MID (Multimedia IO Die) temperature measurement",
+             details::AMDGpuMetricAttributeId_t::TEMPERATURE_MID,
+             details::AMDGpuMetricAttributeType_t::TYPE_UINT16,
+             details::AMDGpuMetricUnitType_t::CELSIUS),
+         static_cast<details::AMDGpuMetricAttributeValue_t>(0)}},
+
+    {details::AMDGpuMetricAttributeId_t::TEMPERATURE_AID,
+     details::AMDGpuMetricAttributeData_t{
+         details::AMDGpuMetricAttributeInstance_t(
+             "Temperature AID", "AID (Active Interposer Die) temperature",
+             details::AMDGpuMetricAttributeId_t::TEMPERATURE_AID,
+             details::AMDGpuMetricAttributeType_t::TYPE_UINT16,
+             details::AMDGpuMetricUnitType_t::CELSIUS),
+         static_cast<details::AMDGpuMetricAttributeValue_t>(0)}},
+
+    {details::AMDGpuMetricAttributeId_t::TEMPERATURE_XCD,
+     details::AMDGpuMetricAttributeData_t{
+         details::AMDGpuMetricAttributeInstance_t(
+             "Temperature XCD", "XCD (Accelerator Compute Die) temperature",
+             details::AMDGpuMetricAttributeId_t::TEMPERATURE_XCD,
+             details::AMDGpuMetricAttributeType_t::TYPE_UINT16,
+             details::AMDGpuMetricUnitType_t::CELSIUS),
+         static_cast<details::AMDGpuMetricAttributeValue_t>(0)}},
+};
 
 using AMDGpuDynamicMetricsOffsetMap_t = std::map<std::uint64_t, std::uint32_t>;
 using AMDGpuDynamicMetricsOffsetIt_t = AMDGpuDynamicMetricsOffsetMap_t::const_iterator;

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_gpu_metrics.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_gpu_metrics.h
@@ -89,6 +89,21 @@ constexpr uint32_t kRSMI_MAX_NUM_XCC = 8;
 //  Note: This *must* match MAX_XCP
 constexpr uint32_t kRSMI_MAX_NUM_XCP = 8;
 
+//  Note: This *must* match MAX_NUM_HBM_STACKS
+constexpr uint32_t kRSMI_MAX_NUM_HBM_STACKS = 12;
+
+//  Note: This *must* match MAX_NUM_AID
+constexpr uint32_t kRSMI_MAX_NUM_AID = 2;
+
+//  Note: This *must* match MAX_NUM_MID
+constexpr uint32_t kRSMI_MAX_NUM_MID = 2;
+
+//  Note: This *must* match MAX_NUM_CLKS_PER_AID
+constexpr uint32_t kRSMI_MAX_NUM_CLKS_PER_AID = 2;
+
+//  Note: This *must* match MAX_NUM_CLKS_PER_MID
+constexpr uint32_t kRSMI_MAX_NUM_CLKS_PER_MID = 2;
+
 struct AMDGpuMetricsHeader_v1_t {
   uint16_t m_structure_size;
   uint8_t m_format_revision;
@@ -133,6 +148,9 @@ struct amdgpu_xcp_metrics_v1_2 {
   uint64_t gfx_below_host_limit_thm_acc[kRSMI_MAX_NUM_XCC];
   uint64_t gfx_low_utilization_acc[kRSMI_MAX_NUM_XCC];
   uint64_t gfx_below_host_limit_total_acc[kRSMI_MAX_NUM_XCC];
+
+  /* v1.9 additions */
+  uint16_t temperature_xcd[kRSMI_MAX_NUM_XCC];
 };
 
 struct AMDGpuMetricsBase_t {
@@ -767,6 +785,9 @@ struct AMDGpuMetrics_v18_Partition_v1_0_t {
   uint64_t m_gfx_below_host_limit_thm_acc[kRSMI_MAX_NUM_XCC];
   uint64_t m_gfx_low_utilization_acc[kRSMI_MAX_NUM_XCC];
   uint64_t m_gfx_below_host_limit_total_acc[kRSMI_MAX_NUM_XCC];
+
+  /* v1.9 additions */
+  uint16_t m_temperature_xcd[kRSMI_MAX_NUM_XCC];
 };
 
 struct AMDGpuMetrics_v18_t {
@@ -1093,6 +1114,10 @@ enum class AMDGpuMetricsUnitType_t : AMDGpuMetricTypeId_t {
   kMetricGfxBelowHostLimitTotalAcc,  // v1.8
   kMetricGfxLowUtilitizationAcc,     // v1.8
 
+  // New temperature unit types
+  kMetricTempMid,  // v1.9+
+  kMetricTempAid,  // v1.9+
+  kMetricTempXcd,  // v1.9+
 };
 using AMDGpuMetricsUnitTypeTranslationTbl_t = std::map<AMDGpuMetricsUnitType_t, std::string>;
 

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_gpu_metrics.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_gpu_metrics.cc
@@ -288,6 +288,11 @@ const AMDGpuMetricsUnitTypeTranslationTbl_t amdgpu_metrics_unit_type_translation
      "GfxBelowHostLimitTotalAcc"},                                                        /* v1.8 */
     {AMDGpuMetricsUnitType_t::kMetricGfxBelowHostLimitPptAcc, "GfxBelowHostLimitPptAcc"}, /* v1.8 */
     {AMDGpuMetricsUnitType_t::kMetricGfxBelowHostLimitThmAcc, "GfxBelowHostLimitThmAcc"}, /* v1.8 */
+
+    // New temperature unit types (v1.9+)
+    {AMDGpuMetricsUnitType_t::kMetricTempMid, "TempMid"}, /* v1.9+ */
+    {AMDGpuMetricsUnitType_t::kMetricTempAid, "TempAid"}, /* v1.9+ */
+    {AMDGpuMetricsUnitType_t::kMetricTempXcd, "TempXcd"}, /* v1.9+ */
 };
 
 AMDGpuMetricVersionFlags_t translate_header_to_flag_version(
@@ -736,6 +741,18 @@ rsmi_status_t GpuMetricsBaseDynamic_t::populate_metrics_dynamic_tbl() {
              AMDGpuMetricsUnitType_t::kMetricHBMThmResidencyAccumulator, "hbm_thm_residency_acc",
              r);
         break;
+      case details::AMDGpuMetricAttributeId_t::TEMPERATURE_HBM:
+        emit(AMDGpuMetricsClassId_t::kGpuMetricTemperature, AMDGpuMetricsUnitType_t::kMetricTempHbm,
+             "temperature_hbm", r);
+        break;
+      case details::AMDGpuMetricAttributeId_t::TEMPERATURE_MID:
+        emit(AMDGpuMetricsClassId_t::kGpuMetricTemperature, AMDGpuMetricsUnitType_t::kMetricTempMid,
+             "temperature_mid", r);
+        break;
+      case details::AMDGpuMetricAttributeId_t::TEMPERATURE_AID:
+        emit(AMDGpuMetricsClassId_t::kGpuMetricTemperature, AMDGpuMetricsUnitType_t::kMetricTempAid,
+             "temperature_aid", r);
+        break;
 
       // XCP stats
       case details::AMDGpuMetricAttributeId_t::GFX_BUSY_INST:
@@ -773,6 +790,10 @@ rsmi_status_t GpuMetricsBaseDynamic_t::populate_metrics_dynamic_tbl() {
         emit(AMDGpuMetricsClassId_t::kGpuMetricXcpStats,
              AMDGpuMetricsUnitType_t::kMetricGfxBelowHostLimitTotalAcc,
              "xcp_stats->gfx_below_host_limit_total_acc", r);
+        break;
+      case details::AMDGpuMetricAttributeId_t::TEMPERATURE_XCD:
+        emit(AMDGpuMetricsClassId_t::kGpuMetricTemperature, AMDGpuMetricsUnitType_t::kMetricTempXcd,
+             "xcp_stats->temperature_xcd", r);
         break;
 
       default:
@@ -1011,6 +1032,11 @@ rsmi_status_t GpuMetricsBase_v18_t::populate_metrics_dynamic_tbl() {
                            m_gpu_metrics_tbl.m_xcp_stats->gfx_low_utilization_acc,
                            "xcp_stats->gfx_low_utilization_acc");
 
+    // GPU metrics v1.9 xcp_stats info
+    populate_metrics_table(
+        AMDGpuMetricsClassId_t::kGpuMetricXcpStats, AMDGpuMetricsUnitType_t::kMetricTempXcd,
+        m_gpu_metrics_tbl.m_xcp_stats->temperature_xcd, "xcp_stats->temperature_xcd");
+
     // PCIE other end recovery counter info
     populate_metrics_table(AMDGpuMetricsClassId_t::kGpuMetricLinkWidthSpeed,
                            AMDGpuMetricsUnitType_t::kMetricPcieLCPerfOtherEndRecov,
@@ -1072,6 +1098,10 @@ rsmi_status_t GpuMetricsBase_v18_t::populate_metrics_dynamic_tbl() {
                            AMDGpuMetricsUnitType_t::kMetricGfxLowUtilitizationAcc,
                            m_gpu_metrics_partition_tbl.m_gfx_low_utilization_acc,
                            "[partition 1.0] gfx_low_utilization_acc");
+    // v1.9
+    populate_metrics_table(
+        AMDGpuMetricsClassId_t::kGpuMetricXcpStats, AMDGpuMetricsUnitType_t::kMetricTempXcd,
+        m_gpu_metrics_partition_tbl.m_temperature_xcd, "xcp_stats->temperature_xcd");
   }
 
   ss << __PRETTY_FUNCTION__ << " | ======= end ======= "
@@ -1888,6 +1918,22 @@ rsmi_status_t init_max_public_gpu_matrics(AMGpuMetricsPublicLatest_t& rsmi_gpu_m
   std::fill(std::begin(rsmi_gpu_metrics.xgmi_link_status),
             std::end(rsmi_gpu_metrics.xgmi_link_status), init_max_uint_types<std::uint16_t>());
 
+  std::fill(std::begin(rsmi_gpu_metrics.temperature_hbm_stacks),
+            std::end(rsmi_gpu_metrics.temperature_hbm_stacks),
+            init_max_uint_types<std::uint16_t>());
+
+  std::fill(std::begin(rsmi_gpu_metrics.temperature_mid),
+            std::end(rsmi_gpu_metrics.temperature_mid), init_max_uint_types<std::uint16_t>());
+
+  std::fill(std::begin(rsmi_gpu_metrics.temperature_aid),
+            std::end(rsmi_gpu_metrics.temperature_aid), init_max_uint_types<std::uint16_t>());
+
+  std::fill(std::begin(rsmi_gpu_metrics.current_uclk_aid),
+            std::end(rsmi_gpu_metrics.current_uclk_aid), init_max_uint_types<std::uint16_t>());
+
+  std::fill(std::begin(rsmi_gpu_metrics.current_socclks_mid),
+            std::end(rsmi_gpu_metrics.current_socclks_mid), init_max_uint_types<std::uint16_t>());
+
   std::fill(std::begin(rsmi_gpu_metrics.temperature_hbm),
             std::end(rsmi_gpu_metrics.temperature_hbm), init_max_uint_types<std::uint16_t>());
 
@@ -1984,6 +2030,8 @@ rsmi_status_t init_max_public_gpu_matrics(AMGpuMetricsPublicLatest_t& rsmi_gpu_m
               init_max_uint_types<std::uint64_t>());
     std::fill(std::begin(row.gfx_below_host_limit_total_acc),
               std::end(row.gfx_below_host_limit_total_acc), init_max_uint_types<std::uint64_t>());
+    std::fill(std::begin(row.temperature_xcd), std::end(row.temperature_xcd),
+              init_max_uint_types<std::uint16_t>());
   }
 
   ss << __PRETTY_FUNCTION__ << " | ======= end ======= "
@@ -2025,6 +2073,7 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBaseDynamic_t::copy_internal_to_externa
     using Dst = std::remove_reference_t<decltype(dst)>;
     using T = std::remove_cv_t<std::remove_extent_t<Dst>>;
     auto v = std::get_if<std::vector<T>>(&r.m_value);
+    if (!v) return;  // Not a vector type, skip
     const std::size_t n = std::min<std::size_t>(v->size(), cap);
     std::copy_n(v->data(), n, dst);
   };
@@ -2149,12 +2198,30 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBaseDynamic_t::copy_internal_to_externa
         break;
       }
 
+      case details::AMDGpuMetricAttributeId_t::TEMPERATURE_HBM: {
+        assign_vector(out.temperature_hbm_stacks, r, RSMI_MAX_NUM_HBM_STACKS);
+        break;
+      }
+      case details::AMDGpuMetricAttributeId_t::TEMPERATURE_MID: {
+        assign_vector(out.temperature_mid, r, RSMI_MAX_NUM_MID);
+        break;
+      }
+      case details::AMDGpuMetricAttributeId_t::TEMPERATURE_AID: {
+        assign_vector(out.temperature_aid, r, RSMI_MAX_NUM_AID);
+        break;
+      }
+
       // Current clocks (arrays) + uclk (scalar)
       case details::AMDGpuMetricAttributeId_t::CURRENT_GFXCLK: {
         assign_vector(out.current_gfxclks, r, RSMI_MAX_NUM_GFX_CLKS);
         break;
       }
       case details::AMDGpuMetricAttributeId_t::CURRENT_SOCCLK: {
+        auto socclks = std::get_if<std::vector<std::uint16_t>>(&r.m_value);
+        if (socclks && socclks->size() == RSMI_MAX_NUM_CLKS_PER_MID) {
+          assign_vector(out.current_socclks_mid, r, RSMI_MAX_NUM_CLKS_PER_MID);
+          break;
+        }
         assign_vector(out.current_socclks, r, RSMI_MAX_NUM_CLKS);
         break;
       }
@@ -2167,9 +2234,19 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBaseDynamic_t::copy_internal_to_externa
         break;
       }
 
-      case details::AMDGpuMetricAttributeId_t::CURRENT_UCLK:
+      case details::AMDGpuMetricAttributeId_t::CURRENT_UCLK: {
+        auto uclk = std::get_if<std::vector<std::uint16_t>>(&r.m_value);
+        if (uclk && uclk->size() == RSMI_MAX_NUM_CLKS_PER_AID) {
+          assign_vector(out.current_uclk_aid, r, RSMI_MAX_NUM_CLKS_PER_AID);
+          break;
+        }
+        if (uclk && !uclk->empty()) {
+          out.current_uclk = (*uclk)[0];
+          break;
+        }
         assign_by_type(out.current_uclk, r);
         break;
+      }
 
       case details::AMDGpuMetricAttributeId_t::PCIE_LC_PERF_OTHER_END_RECOVERY:
         assign_by_type(out.pcie_lc_perf_other_end_recovery, r);
@@ -2207,6 +2284,10 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBaseDynamic_t::copy_internal_to_externa
       }
       case details::AMDGpuMetricAttributeId_t::GFX_BELOW_HOST_LIMIT_TOTAL_ACC: {
         assign_vector(out.xcp_stats[0].gfx_below_host_limit_total_acc, r, RSMI_MAX_NUM_XCC);
+        break;
+      }
+      case details::AMDGpuMetricAttributeId_t::TEMPERATURE_XCD: {
+        assign_vector(out.xcp_stats[0].temperature_xcd, r, RSMI_MAX_NUM_XCC);
         break;
       }
 
@@ -2406,6 +2487,8 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v18_t::copy_internal_to_external_m
                     pub_it->gfx_low_utilization_acc);
         std::copy_n(std::begin(priv_it->gfx_below_host_limit_total_acc), RSMI_MAX_NUM_XCC,
                     pub_it->gfx_below_host_limit_total_acc);
+        std::copy_n(std::begin(priv_it->temperature_xcd), RSMI_MAX_NUM_XCC,
+                    pub_it->temperature_xcd);
       }
     } else {
       // Partition Data: /sys/class/drm/renderDXXX/device/xcp/xcp_metrics
@@ -2474,6 +2557,8 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v18_t::copy_internal_to_external_m
                       RSMI_MAX_NUM_XCC, it->gfx_low_utilization_acc);
           std::copy_n(std::begin(m_gpu_metrics_partition_tbl.m_gfx_below_host_limit_total_acc),
                       RSMI_MAX_NUM_XCC, it->gfx_below_host_limit_total_acc);
+          std::copy_n(std::begin(m_gpu_metrics_partition_tbl.m_temperature_xcd), RSMI_MAX_NUM_XCC,
+                      it->temperature_xcd);
         } else {
           break;  // No need to copy for other rows
         }


### PR DESCRIPTION
## Motivation

GPU metrics v1.9 support with new attributes.

## Technical Details

Added support for updated dynamic GPU metrics version 1.9 by introducing new metric attributes based on latest amdgpu header.
Updated python interface and CLI outputs for new gpu_metric fields. Unified CLI output for amdsmi metric.

## JIRA ID

ROCM-1553

## Test Plan

amd-smi CLI, API and amdsmi tests

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
