### PR TITLE
[rocshmem] gda/mlx5: SQ depth is always power of 2, use bitwise modulo

### DIFF
--- a/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.hpp
+++ b/projects/rocshmem/src/gda/mlx5/provider_gda_mlx5.hpp
@@ -274,11 +274,12 @@ struct gda_mlx5_device_sq : public gda_mlx5_device_queue<gda_mlx5_wqe> {
   uint64_t post;
   uint32_t lock;
   uint16_t depth;
+  uint16_t depth_mask;
 
   __host__ inline gda_mlx5_device_sq(gda_mlx5_wqe* buf, __be32* dbrec,
                                      gda_mlx5_doorbell* db, uint16_t depth)
     : gda_mlx5_device_queue{buf, dbrec},
-      db{db}, post{0}, lock{0}, depth{depth} { }
+      db{db}, post{0}, lock{0}, depth{depth}, depth_mask{static_cast<uint16_t>(depth - 1)} { }
 
   __host__ inline gda_mlx5_device_sq() : gda_mlx5_device_sq{nullptr, nullptr, nullptr, 0} { }
 

--- a/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
@@ -71,6 +71,11 @@ __device__ static inline uint16_t mlx5_wqe_idx(const gda_mlx5_device_sq& sq, uin
   return static_cast<uint16_t>(sq.post + lane_id);
 }
 
+__device__ static inline uint16_t mlx5_sq_idx(const gda_mlx5_device_sq& sq, uint16_t wqe_idx) {
+  // sq.depth is a power of 2, so just mask off everything above that
+  return wqe_idx & sq.depth_mask;
+}
+
 __device__ void QueuePair::mlx5_ring_doorbell(uint64_t sq_post, const gda_mlx5_wqe& wqe) {
   // sq_wqebb_counter is the least significant bits of the post counter
   uint16_t sq_wqebb_counter = static_cast<uint16_t>(sq_post);
@@ -269,7 +274,7 @@ __device__ void QueuePair::mlx5_post_wqe_rma(int32_t length, uintptr_t laddr,
 
   // wqe_idx is the logical WQE id that wraps at 0xFFFF, sq_idx is the index into the actual SQ
   uint16_t wqe_idx = mlx5_wqe_idx(mlx5_sq, wf_info.pe_group_logical_lane_id);
-  uint16_t sq_idx = wqe_idx % mlx5_sq.depth;
+  uint16_t sq_idx = mlx5_sq_idx(mlx5_sq, wqe_idx);
 
   // can we inline the data into the WQE?
   bool send_inline = gda_mlx5_wqe_rma::can_inline(opcode, length, inline_threshold);
@@ -301,7 +306,7 @@ __device__ void QueuePair::mlx5_post_wqe_rma_single(int32_t length,
 
   // wqe_idx is the logical WQE id that wraps at 0xFFFF, sq_idx is the index into the actual SQ
   uint16_t wqe_idx = mlx5_wqe_idx(mlx5_sq, 0);
-  uint16_t sq_idx = wqe_idx % mlx5_sq.depth;
+  uint16_t sq_idx = mlx5_sq_idx(mlx5_sq, wqe_idx);
 
   // can we inline the data into the WQE?
   bool send_inline = gda_mlx5_wqe_rma::can_inline(opcode, length, inline_threshold);
@@ -353,7 +358,7 @@ __device__ uint64_t QueuePair::mlx5_post_wqe_amo([[maybe_unused]] int32_t length
 
   // wqe_idx is the logical WQE id that wraps at 0xFFFF, sq_idx is the index into the actual SQ
   uint16_t wqe_idx = mlx5_wqe_idx(mlx5_sq, wf_info.pe_group_logical_lane_id);
-  uint16_t sq_idx = wqe_idx % mlx5_sq.depth;
+  uint16_t sq_idx = mlx5_sq_idx(mlx5_sq, wqe_idx);
 
   // construct the WQE on the stack
   gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, MLX5_WQE_CTRL_CQ_UPDATE,
@@ -402,7 +407,7 @@ __device__ uint64_t QueuePair::mlx5_post_wqe_amo_single([[maybe_unused]] int32_t
 
   // wqe_idx is the logical WQE id that wraps at 0xFFFF, sq_idx is the index into the actual SQ
   uint16_t wqe_idx = mlx5_wqe_idx(mlx5_sq, 0);
-  uint16_t sq_idx = wqe_idx % mlx5_sq.depth;
+  uint16_t sq_idx = mlx5_sq_idx(mlx5_sq, wqe_idx);
 
   // construct the WQE on the stack
   gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, MLX5_WQE_CTRL_CQ_UPDATE,


### PR DESCRIPTION
## Motivation

The SQ depth is required to be a power of 2 by mlx5 hardware requirements; this is enforced by the QP initialization code. However, the compiler can have difficulty inferring that the SQ depth is always a power of 2; this results in expensive division operations rather than bitwise AND when computing the SQ index. These divisions have shown up as hot spots in profiling.

## Technical Details

* Add field `gda_mlx5_device_sq::depth_mask`, initialized to `depth - 1`
* Add inline helper function `mlx5_sq_idx` that returns `wqe_idx & mlx5_sq.depth_mask`
* Replace `uint16_t sq_idx = wqe_idx % mlx5_sq.depth` by calls to `mlx5_sq_idx(mlx5_sq, wqe_idx)`

## JIRA ID
AIROCSHMEM-379

## Test Plan

GDA functional tests on CX7 RoCE

## Test Result

- [ ] All tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
