### PR TITLE
ROCM-2903 - Default DEBUG_HIP_MEM_POOL_VMHEAP to IS_LINUX

### DIFF
--- a/projects/clr/hipamd/src/hip_mempool_impl.hpp
+++ b/projects/clr/hipamd/src/hip_mempool_impl.hpp
@@ -225,7 +225,8 @@ class MemoryPool : public amd::ReferenceCountedObject, amd::VmHeapArray {
     }
     state_.interprocess_ = properties_.handleTypes != hipMemHandleTypeNone;
     // Check if VM heap can be enabled
-    if (DEBUG_HIP_MEM_POOL_VMHEAP && !state_.phys_mem_ && !state_.interprocess_) {
+    if (DEBUG_HIP_MEM_POOL_VMHEAP && AMD_DIRECT_DISPATCH &&
+        !state_.phys_mem_ && !state_.interprocess_) {
       state_.use_vm_heap_ = true;
       busy_heap_.EnableVmHeap();
       free_heap_.EnableVmHeap();

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -190,7 +190,7 @@ release(bool, HIP_MEM_POOL_SUPPORT, true,                                     \
         "Enables memory pool support in HIP")                                 \
 release(bool, HIP_MEM_POOL_USE_VM, true,                                      \
         "Enables memory pool support in HIP")                                 \
-release(bool, DEBUG_HIP_MEM_POOL_VMHEAP, IS_LINUX,                            \
+release(bool, DEBUG_HIP_MEM_POOL_VMHEAP, true,                                \
         "Enables virtual memory for memory pools")                            \
 release(bool, PAL_HIP_IPC_FLAG, true,                                         \
         "Enable interprocess flag for device allocation in PAL HIP")          \

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -190,7 +190,7 @@ release(bool, HIP_MEM_POOL_SUPPORT, true,                                     \
         "Enables memory pool support in HIP")                                 \
 release(bool, HIP_MEM_POOL_USE_VM, true,                                      \
         "Enables memory pool support in HIP")                                 \
-release(bool, DEBUG_HIP_MEM_POOL_VMHEAP, true,                                \
+release(bool, DEBUG_HIP_MEM_POOL_VMHEAP, IS_LINUX,                            \
         "Enables virtual memory for memory pools")                            \
 release(bool, PAL_HIP_IPC_FLAG, true,                                         \
         "Enable interprocess flag for device allocation in PAL HIP")          \


### PR DESCRIPTION
## Motivation

rocBLAS graph tests hang on Windows 11 after sustained stream-ordered allocation / free / trim cycles (~500-1000 cycles in). The hang is in the VM heap path: awaitCompletion on the synchronous VirtualMapCommand blocks indefinitely with the GPU event never signaling, leaving the command stuck in CL_SUBMITTED.

## Technical Details

Default DEBUG_HIP_MEM_POOL_VMHEAP to IS_LINUX so that allocations on Windows are routed through SvmBuffer::malloc / free instead of VirtualMapCommand. This is a temporary workaround until the ROCR/HSA backend becomes the default on Windows, which brings direct dispatch and avoids this path entirely.

## JIRA ID

ROCM-2903

## Test Plan

Run rocblas-test *graph* filter on Navi3x / Windows 11; verify the hang is resolved.

## Test Result

Confirmed on W7900 (gfx1100) + Windows 11: PAL previously hung at trmv_graph_test_f32_r_U_N_N_128_2_1; with this change all 1637 graph tests pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
