### PR TITLE
Check the size of HsaExternalHandleDesc in DxgAbiCheck for WSL

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
@@ -1574,7 +1574,8 @@ typedef struct _HsaHandleImportFlags {
 typedef struct _HsaStructureSizes {
   HSAuint16 StructureSizes;           // sizeof(HsaStructureSizes) used for check overflow
   HSAuint16 SizeOfHsaNodeProperties;  // sizeof(HsaNodeProperties)
-  HSAuint16 Reserved[6];
+  HSAuint16 SizeOfHsaExternalHandleDesc; // sizeof(HsaExternalHandleDesc)
+  HSAuint16 Reserved[5];
 } HsaStructureSizes;
 #pragma pack(pop, hsakmttypes_h)
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
@@ -631,6 +631,7 @@ LOAD_ERROR:
     HsaStructureSizes sizes = {};
     sizes.StructureSizes = (HSAuint16)sizeof(HsaStructureSizes);
     sizes.SizeOfHsaNodeProperties = (HSAuint16)sizeof(HsaNodeProperties);
+    sizes.SizeOfHsaExternalHandleDesc = (HSAuint16)sizeof(HsaExternalHandleDesc);
 
     if (pfnDxgAbiCheck(&sizes) != HSAKMT_STATUS_SUCCESS) {
       debug_print("DxgAbiCheck failed!\n");


### PR DESCRIPTION
Changes to this variable in ROCR affect ROCDXG tests that depend on it (e.g., IPC-related tests).
To avoid ABI incompatibilities between ROCR and ROCDXG, add this variable to DxgAbiCheck so that versioning can properly gate such changes.