### PR TITLE
[rocprofiler-systems] filter VCN/JPEG sentinel values during metric collection

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
@@ -138,7 +138,7 @@ emit_xcp_array_metrics(uint32_t device_id, size_t ts, const char* metric_name,
     for(size_t i = 0; i < data.size(); ++i)
     {
         const auto value = data[i];
-        if(value == std::numeric_limits<uint16_t>::max()) continue;
+        if(value == pmc::collectors::gpu::METRIC_VALUE_NOT_SUPPORTED_16) continue;
 
         std::string track_name;
         if(xcp_idx.has_value())

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.cpp
@@ -386,6 +386,8 @@ rocpd_processor_t::handle([[maybe_unused]] const gpu_pmc_sample& _gpu_pmc)
             const auto& arr = get_array(m.xcp_stats[xcp]);
             for(size_t i = 0; i < arr.size(); ++i)
             {
+                if(arr[i] == pmc::collectors::gpu::METRIC_VALUE_NOT_SUPPORTED_16)
+                    continue;
                 auto name = format_name(static_cast<int>(xcp), static_cast<int>(i));
                 insert_metric(true, name.c_str(), name.c_str(), arr[i]);
             }
@@ -410,6 +412,8 @@ rocpd_processor_t::handle([[maybe_unused]] const gpu_pmc_sample& _gpu_pmc)
         if(!is_enabled) return;
         for(size_t i = 0; i < arr.size(); ++i)
         {
+            if(arr[i] == pmc::collectors::gpu::METRIC_VALUE_NOT_SUPPORTED_16) continue;
+
             auto suffix     = "_" + std::to_string(i);
             auto pmc_name   = std::string(base_name) + suffix;
             auto track_name = pmc_name;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/tests/test_device.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/tests/test_device.cpp
@@ -2524,4 +2524,119 @@ TEST_F(DeviceTest, sdma_delta_computation)
 }
 #endif
 
+/**
+ * Verify that sentinel values (0xFFFF) in per-XCP vcn_busy arrays
+ * are preserved during collection — filtering happens at the processor layer.
+ */
+TEST_F(DeviceTest, vcn_busy_collection_preserves_sentinels)
+{
+    amdsmi_gpu_metrics_t metrics = CreateSentinelMetrics();
+
+    metrics.xcp_stats[0].vcn_busy[0] = 80;
+
+    EXPECT_CALL(*mock_driver, get_metrics_info(test_handle, _))
+        .Times(AtLeast(1))
+        .WillRepeatedly(DoAll(SetArgPointee<1>(metrics), Return(AMDSMI_STATUS_SUCCESS)));
+
+    uint64_t sentinel_mem = 0xFFFFFFFFFFFFFFFFULL;
+    EXPECT_CALL(*mock_driver, get_memory_usage(test_handle, AMDSMI_MEM_TYPE_VRAM, _))
+        .Times(AtLeast(1))
+        .WillRepeatedly(
+            DoAll(SetArgPointee<2>(sentinel_mem), Return(AMDSMI_STATUS_SUCCESS)));
+
+    SetupSDMAExpectations(mock_driver, test_handle);
+
+    device<MockDriver> dev(mock_driver, test_handle, test_processor_type, test_index);
+
+    EXPECT_TRUE(dev.get_supported_metrics().bits.vcn_busy);
+
+    auto collected =
+        dev.get_gpu_metrics(enabled_metrics{ .value = 0xFFFF }, 1000000000ULL);
+
+    EXPECT_EQ(collected.xcp_stats[0].vcn_busy[0], 80U);
+    for(size_t vcn = 1; vcn < AMDSMI_MAX_NUM_VCN; ++vcn)
+    {
+        EXPECT_EQ(collected.xcp_stats[0].vcn_busy[vcn], METRIC_VALUE_NOT_SUPPORTED_16)
+            << "Sentinel in vcn_busy[" << vcn
+            << "] must be preserved for processor-layer filtering";
+    }
+}
+
+/**
+ * Verify that sentinel values (0xFFFF) in device-level vcn_activity
+ * array are preserved during collection — filtering happens at the processor layer.
+ */
+TEST_F(DeviceTest, vcn_activity_device_level_preserves_sentinels)
+{
+    amdsmi_gpu_metrics_t metrics = CreateSentinelMetrics();
+
+    metrics.vcn_activity[0] = 42;
+
+    EXPECT_CALL(*mock_driver, get_metrics_info(test_handle, _))
+        .Times(AtLeast(1))
+        .WillRepeatedly(DoAll(SetArgPointee<1>(metrics), Return(AMDSMI_STATUS_SUCCESS)));
+
+    uint64_t sentinel_mem = 0xFFFFFFFFFFFFFFFFULL;
+    EXPECT_CALL(*mock_driver, get_memory_usage(test_handle, AMDSMI_MEM_TYPE_VRAM, _))
+        .Times(AtLeast(1))
+        .WillRepeatedly(
+            DoAll(SetArgPointee<2>(sentinel_mem), Return(AMDSMI_STATUS_SUCCESS)));
+
+    SetupSDMAExpectations(mock_driver, test_handle);
+
+    device<MockDriver> dev(mock_driver, test_handle, test_processor_type, test_index);
+
+    EXPECT_TRUE(dev.get_supported_metrics().bits.vcn_activity);
+    EXPECT_FALSE(dev.get_supported_metrics().bits.vcn_busy);
+
+    auto collected =
+        dev.get_gpu_metrics(enabled_metrics{ .value = 0xFFFF }, 1000000000ULL);
+
+    EXPECT_EQ(collected.vcn_activity[0], 42U);
+    for(size_t i = 1; i < AMDSMI_MAX_NUM_VCN; ++i)
+    {
+        EXPECT_EQ(collected.vcn_activity[i], METRIC_VALUE_NOT_SUPPORTED_16)
+            << "Sentinel in vcn_activity[" << i
+            << "] must be preserved for processor-layer filtering";
+    }
+}
+
+/**
+ * Verify that sentinel values in per-XCP jpeg_busy arrays
+ * are preserved during collection — filtering happens at the processor layer.
+ */
+TEST_F(DeviceTest, jpeg_busy_collection_preserves_sentinels)
+{
+    amdsmi_gpu_metrics_t metrics = CreateSentinelMetrics();
+
+    metrics.xcp_stats[0].jpeg_busy[0] = 60;
+
+    EXPECT_CALL(*mock_driver, get_metrics_info(test_handle, _))
+        .Times(AtLeast(1))
+        .WillRepeatedly(DoAll(SetArgPointee<1>(metrics), Return(AMDSMI_STATUS_SUCCESS)));
+
+    uint64_t sentinel_mem = 0xFFFFFFFFFFFFFFFFULL;
+    EXPECT_CALL(*mock_driver, get_memory_usage(test_handle, AMDSMI_MEM_TYPE_VRAM, _))
+        .Times(AtLeast(1))
+        .WillRepeatedly(
+            DoAll(SetArgPointee<2>(sentinel_mem), Return(AMDSMI_STATUS_SUCCESS)));
+
+    SetupSDMAExpectations(mock_driver, test_handle);
+
+    device<MockDriver> dev(mock_driver, test_handle, test_processor_type, test_index);
+
+    EXPECT_TRUE(dev.get_supported_metrics().bits.jpeg_busy);
+
+    auto collected =
+        dev.get_gpu_metrics(enabled_metrics{ .value = 0xFFFF }, 1000000000ULL);
+
+    EXPECT_EQ(collected.xcp_stats[0].jpeg_busy[0], 60U);
+    for(size_t jpeg = 1; jpeg < ROCPROFSYS_AMDSMI_JPEG_ENGINE_COUNT; ++jpeg)
+    {
+        EXPECT_EQ(collected.xcp_stats[0].jpeg_busy[jpeg], METRIC_VALUE_NOT_SUPPORTED_16)
+            << "Sentinel in jpeg_busy[" << jpeg
+            << "] must be preserved for processor-layer filtering";
+    }
+}
+
 }  // namespace rocprofsys::pmc::collectors::gpu::testing

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/types.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/types.hpp
@@ -19,7 +19,8 @@ namespace collectors
 namespace gpu
 {
 
-// Sentinel value used by AMD SMI to indicate unsupported/unavailable 64-bit metrics
+// Sentinel values used by AMD SMI to indicate unsupported/unavailable metrics
+constexpr uint16_t METRIC_VALUE_NOT_SUPPORTED_16 = 0xffff;
 constexpr uint64_t METRIC_VALUE_NOT_SUPPORTED_64 = 0xffffffffffffffff;
 
 /**


### PR DESCRIPTION
## Motivation

When only some VCN/JPEG engines are present on a GPU, the AMD SMI `vcn_activity`/`jpeg_activity` arrays contain `0xFFFF` sentinel values for absent engines. These sentinel values were being passed through to Perfetto and RocPD output as `65535`, appearing as bogus `device_vcn_activity_1`, `_2`, `_3` metrics.

## Technical Details

**Root cause:** `collect_xcp_metrics()` in `device.hpp` used `std::copy` to blindly copy the entire `vcn_activity[4]` array from AMD SMI, including sentinel values for non-existent engines. Downstream output paths (RocPD) also lacked sentinel filtering. 

## JIRA ID

## Test Plan
- [x] Full build succeeds
- [x] Manual validation: profiled `videodecode` with `ROCPROFSYS_AMD_SMI_METRICS=vcn_activity,jpeg_activity` — only valid VCN engine 0 appears in Perfetto trace, zero `65535` values found

## Test Result
Before:
<img width="2053" height="328" alt="image" src="https://github.com/user-attachments/assets/d7687d60-01df-4209-b40d-774598d1cbe0" />

After the fix:
<img width="2058" height="159" alt="image" src="https://github.com/user-attachments/assets/199f8c20-b06b-469d-90e1-433847ca54bc" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
