### PR TITLE
Fix division by zero exception

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/signal.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/signal.h
@@ -89,7 +89,7 @@ namespace timer {
 inline timer::fast_clock::duration GetFastTimeout(uint64_t timeout) {
   uint64_t hsa_freq = 0;
   HSA::hsa_system_get_info(HSA_SYSTEM_INFO_TIMESTAMP_FREQUENCY, &hsa_freq);
-  return timer::duration_from_seconds<timer::fast_clock::duration>(
+  return (hsa_freq == 0) ? timer::duration_from_seconds<timer::fast_clock::duration>(0)  : timer::duration_from_seconds<timer::fast_clock::duration>(
       double(timeout) / double(hsa_freq));
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/signal.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/signal.h
@@ -89,7 +89,13 @@ namespace timer {
 inline timer::fast_clock::duration GetFastTimeout(uint64_t timeout) {
   uint64_t hsa_freq = 0;
   HSA::hsa_system_get_info(HSA_SYSTEM_INFO_TIMESTAMP_FREQUENCY, &hsa_freq);
-  return (hsa_freq == 0) ? timer::duration_from_seconds<timer::fast_clock::duration>(0)  : timer::duration_from_seconds<timer::fast_clock::duration>(
+  if (hsa_freq == 0) {
+    if (timeout == UINT64_MAX) {
+      return timer::fast_clock::duration::max();
+    }
+    return timer::duration_from_seconds<timer::fast_clock::duration>(0);
+  }
+  return timer::duration_from_seconds<timer::fast_clock::duration>(
       double(timeout) / double(hsa_freq));
 }
 


### PR DESCRIPTION
## Motivation

[halo-finder-hip](https://github.com/ORNL/HeCBench/tree/master/src/halo-finder-hip) benchmark from HeCBench calls `fesetenv(FE_NOMASK_ENV)` to enable strict floating-point exception trapping (SIGFPE on divide-by-zero, overflow, and invalid operations). When `main()` returns, the HIP/HSA runtime shutdown path (`InterruptSignal::WaitRelaxed` inside `libhsa-runtime64.so`) performs a floating-point operation that triggers SIGFPE under the strict environment, crashing the process with a confusing signal after the benchmark has already completed successfully. The patch fixes the division by zero.

## Technical Details

During runtime shutdown, sys_clock_freq_ becomes 0 (likely cleared during teardown), so when the queue cleanup waits on signals, it queries the timestamp frequency and gets 0, then divides by it.

## JIRA ID

None

## Test Plan

Not familiar to testing in this repo. Open to suggestions. I have a minimal reproducer that I am more than happy to turn into a test when guidance is provided.

## Test Result

Successfully finishes without exceptions thrown or crashes.

## Submission Checklist

- [ x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
