### PR TITLE
[static lib 1/2] Fix building dbgapi as a static library

### DIFF
--- a/projects/rocdbgapi/CMakeLists.txt
+++ b/projects/rocdbgapi/CMakeLists.txt
@@ -119,6 +119,15 @@ else()
   endif()
 endif()
 
+# Define this before amd-dbgapi.h is generated.  amd-dbgapi.h.in uses
+# this to define the right export/import decorators in amd-dbgapi.h
+# for clients to use.
+if(NOT BUILD_SHARED_LIBS)
+  set(AMD_DBGAPI_STATIC_LIB "1")
+else()
+  set(AMD_DBGAPI_STATIC_LIB "0")
+endif()
+
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/amd-dbgapi.h.in
   ${CMAKE_CURRENT_BINARY_DIR}/include/amd-dbgapi/amd-dbgapi.h @ONLY)

--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -508,15 +508,19 @@
 # endif
 #endif /* !defined (AMD_DBGAPI_IMPORT_DECORATOR) */
 
-#define AMD_DBGAPI_EXPORT AMD_DBGAPI_EXPORT_DECORATOR AMD_DBGAPI_CALL
-#define AMD_DBGAPI_IMPORT AMD_DBGAPI_IMPORT_DECORATOR AMD_DBGAPI_CALL
+/* True if dbgapi was built as a static library.  */
+#define AMD_DBGAPI_STATIC_LIB @AMD_DBGAPI_STATIC_LIB@
 
 #if !defined(AMD_DBGAPI)
-#if defined(AMD_DBGAPI_EXPORTS)
-#define AMD_DBGAPI AMD_DBGAPI_EXPORT
-#else /* !defined (AMD_DBGAPI_EXPORTS) */
-#define AMD_DBGAPI AMD_DBGAPI_IMPORT
-#endif /* !defined (AMD_DBGAPI_EXPORTS) */
+# if AMD_DBGAPI_STATIC_LIB
+#  define AMD_DBGAPI AMD_DBGAPI_CALL
+# else
+#  if defined(AMD_DBGAPI_EXPORTS)
+#   define AMD_DBGAPI AMD_DBGAPI_EXPORT_DECORATOR AMD_DBGAPI_CALL
+#  else
+#   define AMD_DBGAPI AMD_DBGAPI_IMPORT_DECORATOR AMD_DBGAPI_CALL
+#  endif
+# endif
 #endif /* !defined (AMD_DBGAPI) */
 
 /* By default, MSVC reports 199711L (C++98) for the __cplusplus macro,


### PR DESCRIPTION
Since 4bfddf5494 ("dbgapi/win32: __declspec(dllexport) instead of
--version-script"), building dbgapi as a static library on Windows
fails with errors such as:

.../rocm-dbgapi/src/initialization.cpp:41:1: error: function 'amd_dbgapi_status_t amd_dbgapi_initialize(amd_dbgapi_callbacks_s*)' definition is marked dllimport
41 | amd_dbgapi_initialize (struct amd_dbgapi_callbacks_s *callbacks)
| ^~~~~~~~~~~~~~~~~~~~~

The symbols end up "marked dllimport" because with:

set_target_properties(amd-dbgapi PROPERTIES
...
DEFINE_SYMBOL "AMD_DBGAPI_EXPORTS"
...

... DEFINE_SYMBOL is a CMake convenience that only applies when (and
while) building a shared library.  When BUILD_SHARED_LIBS is OFF,
DEFINE_SYMBOL does nothing.  So AMD_DBGAPI_EXPORTS ends up not defined
in amd-dbgapi.h, which results in AMD_DBGAPI mapping to
AMD_DBGAPI_IMPORT, here, in amd-dbgapi.h.in:

#define AMD_DBGAPI AMD_DBGAPI_IMPORT

AMD_DBGAPI_IMPORT in turn is unconditionally defined to
__declspec(dllimport) on Windows.

So there are two issues:

- The dbgapi build itself is treated as importing symbols (as a
consumer) instead of exporting them (as a producer).

- The import/export decorations are applied even when dbgapi is built
as a static library, where they should not be used at all.

Fix this by teaching amd-dbgapi.h about whether dbgapi was built as a
static or shared library.  Since the header is generated, define
AMD_DBGAPI_STATIC_LIB (0 or 1) at configure time and use it to skip
using import/export decorations.

This also ensures that clients, including those which do not use CMake
(e.g. GDB), automatically see consistent definitions without needing
to know how dbgapi was built.

Change-Id: I31c8c947791551cc4e20218826561c1d242f298d

---

**Stack**:
- #5213
- #5155 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*