### PR TITLE
Fix source line attribution for partial dwarf ranges

### DIFF
--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/cxx/codeobj/code_printing.hpp
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/cxx/codeobj/code_printing.hpp
@@ -174,7 +174,12 @@ public:
             Dwarf_Off next_offset{};
             size_t    header_size{};
 
-            std::map<Dwarf_Addr, std::string>                       line_addrs{};
+            struct LineEntry
+            {
+                Dwarf_Addr  end_addr;
+                std::string text;
+            };
+            std::map<Dwarf_Addr, LineEntry>                         line_addrs{};
             std::unordered_map<Dwarf_Off, std::unique_ptr<DIEInfo>> diemap{};
 
             while(
@@ -197,53 +202,76 @@ public:
                     continue;
                 }
 
-                for(size_t i = 0; i < line_count; ++i)
+                // Each row in the DWARF line table covers [addr, next_row_addr).
+                // The terminator of a contiguous code sequence is a row with the
+                // end_sequence flag set — its address is one past the last
+                // instruction in the sequence. Using the next row's address
+                // (rather than the next *kept* row's address, or codeobj_size)
+                // ensures that ranges never extend across gaps in DWARF
+                // coverage or past the end of an end_sequence boundary.
+                for(size_t i = 0; i + 1 < line_count; ++i)
                 {
-                    Dwarf_Addr  addr;
-                    int         line_number;
-                    Dwarf_Line* line = dwarf_onesrcline(lines, i);
+                    Dwarf_Addr  addr{};
+                    Dwarf_Addr  end_addr{};
+                    int         line_number{};
+                    bool        end_sequence = false;
+                    Dwarf_Line* line         = dwarf_onesrcline(lines, i);
+                    Dwarf_Line* next_line    = dwarf_onesrcline(lines, i + 1);
 
-                    if(line && dwarf_lineaddr(line, &addr) == 0 &&
-                       dwarf_lineno(line, &line_number) == 0 && line_number != 0)
+                    if(line == nullptr || next_line == nullptr) continue;
+                    if(dwarf_lineaddr(line, &addr) != 0) continue;
+                    if(dwarf_lineaddr(next_line, &end_addr) != 0) continue;
+                    if(end_addr <= addr) continue;
+
+                    // Skip end_sequence rows — they only mark the end boundary
+                    // of the previous row, they aren't a real source location.
+                    if(dwarf_lineendsequence(line, &end_sequence) == 0 && end_sequence) continue;
+
+                    // line_number == 0 is a valid DWARF row meaning "this address
+                    // belongs to this source file but has no specific line"
+                    // (typically compiler-synthesized code, prologue/epilogue,
+                    // or optimizer-merged blocks). addr2line renders these as
+                    // "<file>:?" — keep them with the same convention so they
+                    // are not silently dropped.
+                    if(dwarf_lineno(line, &line_number) != 0) continue;
+
+                    const char* src_cstr = dwarf_linesrc(line, nullptr, nullptr);
+                    if(src_cstr == nullptr) continue;
+
+                    std::string src        = src_cstr;
+                    auto        dwarf_line = src + ':';
+                    if(line_number != 0)
+                        dwarf_line += std::to_string(line_number);
+                    else
+                        dwarf_line += '?';
+
+                    std::vector<std::string> call_stack_info{};
+
+                    auto& die_ptr = diemap[dwarf_dieoffset(&die)];
+                    if(die_ptr == nullptr) die_ptr = std::make_unique<DIEInfo>(&die);
+                    die_ptr->getCallStackRecursive(addr, call_stack_info);
+
+                    size_t capacity =
+                        dwarf_line.size() + Instruction::separator.size() * call_stack_info.size();
+                    for(const auto& call : call_stack_info)
+                        capacity += call.size();
+
+                    dwarf_line.reserve(capacity);
+                    for(const auto& call : call_stack_info)
                     {
-                        std::string src        = dwarf_linesrc(line, nullptr, nullptr);
-                        auto        dwarf_line = src + ':' + std::to_string(line_number);
-
-                        std::vector<std::string> call_stack_info{};
-
-                        auto& die_ptr = diemap[dwarf_dieoffset(&die)];
-                        if(die_ptr == nullptr) die_ptr = std::make_unique<DIEInfo>(&die);
-                        die_ptr->getCallStackRecursive(addr, call_stack_info);
-
-                        size_t capacity = dwarf_line.size() +
-                                          Instruction::separator.size() * call_stack_info.size();
-                        for(const auto& call : call_stack_info)
-                            capacity += call.size();
-
-                        dwarf_line.reserve(capacity);
-                        for(const auto& call : call_stack_info)
-                        {
-                            dwarf_line += Instruction::separator;
-                            dwarf_line += call;
-                        }
-                        line_addrs[addr] = std::move(dwarf_line);
+                        dwarf_line += Instruction::separator;
+                        dwarf_line += call;
                     }
+                    line_addrs[addr] = LineEntry{end_addr, std::move(dwarf_line)};
                 }
                 cu_offset = next_offset;
             }
 
-            auto it = line_addrs.begin();
-            if(it != line_addrs.end())
+            for(auto& [addr, entry] : line_addrs)
             {
-                while(std::next(it) != line_addrs.end())
-                {
-                    uint64_t delta   = std::next(it)->first - it->first;
-                    auto     segment = segment::address_range_t{it->first, delta, 0};
-                    m_line_number_map.emplace(segment, std::move(it->second));
-                    it++;
-                }
-                auto segment = segment::address_range_t{it->first, codeobj_size - it->first, 0};
-                m_line_number_map.emplace(segment, std::move(it->second));
+                if(entry.end_addr <= addr) continue;
+                auto segment = segment::address_range_t{addr, entry.end_addr - addr, 0};
+                m_line_number_map.emplace(segment, std::move(entry.text));
             }
         }
 

--- a/projects/rocprofiler-sdk/source/lib/tests/codeobj/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/tests/codeobj/CMakeLists.txt
@@ -12,27 +12,10 @@ target_sources(codeobj-library-tests PRIVATE ${CODEOBJ_LIB_TEST_SOURCES})
 
 set(PKG_TEST_BIN_DIR "${CMAKE_INSTALL_DATAROOTDIR}/${PACKAGE_NAME}/tests/unit-tests/bin")
 
-find_program(
-    CODEOBJ_LLVM_SYMBOLIZER
-    NAMES llvm-symbolizer
-    HINTS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
-    PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
-    PATH_SUFFIXES llvm/bin bin)
-
 target_compile_definitions(
     codeobj-library-tests
     PRIVATE CODEOBJ_BINARY_DIR="${CMAKE_CURRENT_BINARY_DIR}/"
             CODEOBJ_INSTALL_DIR="${CMAKE_INSTALL_PREFIX}/${PKG_TEST_BIN_DIR}/")
-
-if(CODEOBJ_LLVM_SYMBOLIZER)
-    target_compile_definitions(codeobj-library-tests
-                               PRIVATE LLVM_SYMBOLIZER_PATH="${CODEOBJ_LLVM_SYMBOLIZER}")
-else()
-    message(
-        STATUS
-            "llvm-symbolizer not found; codeobj_library.dwarf_matches_llvm_symbolizer test will SKIP."
-        )
-endif()
 
 configure_file(smallkernel.bin smallkernel.bin COPYONLY)
 configure_file(hipcc_output.s hipcc_output.s COPYONLY)

--- a/projects/rocprofiler-sdk/source/lib/tests/codeobj/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/tests/codeobj/CMakeLists.txt
@@ -12,10 +12,27 @@ target_sources(codeobj-library-tests PRIVATE ${CODEOBJ_LIB_TEST_SOURCES})
 
 set(PKG_TEST_BIN_DIR "${CMAKE_INSTALL_DATAROOTDIR}/${PACKAGE_NAME}/tests/unit-tests/bin")
 
+find_program(
+    CODEOBJ_LLVM_SYMBOLIZER
+    NAMES llvm-symbolizer
+    HINTS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+    PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+    PATH_SUFFIXES llvm/bin bin)
+
 target_compile_definitions(
     codeobj-library-tests
     PRIVATE CODEOBJ_BINARY_DIR="${CMAKE_CURRENT_BINARY_DIR}/"
             CODEOBJ_INSTALL_DIR="${CMAKE_INSTALL_PREFIX}/${PKG_TEST_BIN_DIR}/")
+
+if(CODEOBJ_LLVM_SYMBOLIZER)
+    target_compile_definitions(codeobj-library-tests
+                               PRIVATE LLVM_SYMBOLIZER_PATH="${CODEOBJ_LLVM_SYMBOLIZER}")
+else()
+    message(
+        STATUS
+            "llvm-symbolizer not found; codeobj_library.dwarf_matches_llvm_symbolizer test will SKIP."
+        )
+endif()
 
 configure_file(smallkernel.bin smallkernel.bin COPYONLY)
 configure_file(hipcc_output.s hipcc_output.s COPYONLY)

--- a/projects/rocprofiler-sdk/source/lib/tests/codeobj/codeobj_library_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/codeobj/codeobj_library_test.cpp
@@ -385,6 +385,17 @@ canonicalize(std::string_view s)
     return std::string{base} + ':' + std::string{line};
 }
 
+// Read a FILE* to EOF into a string.
+std::string
+slurp(FILE* fp)
+{
+    std::string out;
+    char        buf[4096];
+    while(size_t n = std::fread(buf, 1, sizeof(buf), fp))
+        out.append(buf, n);
+    return out;
+}
+
 // Locate llvm-symbolizer at runtime: $ROCM_PATH, $ROCM_HOME, /opt/rocm, then $PATH.
 // Resolved at runtime rather than configure time because some CI flows (e.g.
 // TheRock) wipe the build dir before tests run, leaving any baked-in absolute
@@ -404,10 +415,7 @@ find_symbolizer()
 
     FILE* pipe = ::popen("command -v llvm-symbolizer 2>/dev/null", "r");
     if(!pipe) return {};
-    char        buf[4096];
-    std::string out;
-    while(size_t n = std::fread(buf, 1, sizeof(buf), pipe))
-        out.append(buf, n);
+    auto out = slurp(pipe);
     ::pclose(pipe);
     while(!out.empty() && (out.back() == '\n' || out.back() == '\r'))
         out.pop_back();
@@ -427,7 +435,7 @@ find_symbolizer()
  */
 TEST(codeobj_library, dwarf_matches_llvm_symbolizer)
 {
-    namespace fs                = rocprofiler::common::filesystem;
+    namespace fs                   = rocprofiler::common::filesystem;
     constexpr std::string_view sep = disassembly::Instruction::separator;
 
     const std::string symbolizer = find_symbolizer();
@@ -471,9 +479,9 @@ TEST(codeobj_library, dwarf_matches_llvm_symbolizer)
 
     // Feed addresses to llvm-symbolizer via stdin from a tmp file (the test's
     // build dir is read-only in some CI install layouts).
-    std::error_code ec;
-    auto            tmp     = fs::temp_directory_path(ec);
-    std::string     tmpl_str = (ec ? "/tmp" : tmp.string()) + "/codeobj_addrs.XXXXXX";
+    std::error_code   ec;
+    auto              tmp      = fs::temp_directory_path(ec);
+    std::string       tmpl_str = (ec ? "/tmp" : tmp.string()) + "/codeobj_addrs.XXXXXX";
     std::vector<char> tmpl(tmpl_str.begin(), tmpl_str.end());
     tmpl.push_back('\0');
     int fd = ::mkstemp(tmpl.data());
@@ -489,11 +497,8 @@ TEST(codeobj_library, dwarf_matches_llvm_symbolizer)
                       "\" --inlines --output-style=LLVM < \"" + tmpl.data() + "\" 2>&1";
     FILE* pipe = ::popen(cmd.c_str(), "r");
     ASSERT_NE(pipe, nullptr) << "popen: " << ::strerror(errno);
-    std::string raw;
-    char        buf[4096];
-    while(size_t n = std::fread(buf, 1, sizeof(buf), pipe))
-        raw.append(buf, n);
-    int rc = ::pclose(pipe);
+    std::string raw = slurp(pipe);
+    int         rc  = ::pclose(pipe);
     ::unlink(tmpl.data());
     ASSERT_EQ(rc, 0) << "llvm-symbolizer rc=" << rc << " cmd=" << cmd << "\n" << raw;
 
@@ -525,7 +530,8 @@ TEST(codeobj_library, dwarf_matches_llvm_symbolizer)
     // Compare frame-by-frame after canonicalization. Trailing "no info" frames
     // are dropped on both sides so {""} (llvm's "??:0:0") matches our empty.
     auto trim = [](std::vector<std::string>& v) {
-        while(!v.empty() && v.back().empty()) v.pop_back();
+        while(!v.empty() && v.back().empty())
+            v.pop_back();
     };
 
     size_t mismatches = 0;
@@ -535,8 +541,8 @@ TEST(codeobj_library, dwarf_matches_llvm_symbolizer)
         for(size_t pos = 0; pos <= ours[i].size();)
         {
             auto next = ours[i].find(sep, pos);
-            mine.emplace_back(canonicalize(
-                ours[i].substr(pos, next == std::string::npos ? next : next - pos)));
+            mine.emplace_back(
+                canonicalize(ours[i].substr(pos, next == std::string::npos ? next : next - pos)));
             if(next == std::string::npos) break;
             pos = next + sep.size();
         }
@@ -548,7 +554,8 @@ TEST(codeobj_library, dwarf_matches_llvm_symbolizer)
         {
             auto fmt = [](const std::vector<std::string>& v) {
                 std::string s;
-                for(auto& f : v) (s += '[') += f, s += ']';
+                for(auto& f : v)
+                    (s += '[') += f, s += ']';
                 return s;
             };
             ADD_FAILURE() << "addr=0x" << std::hex << addrs[i] << std::dec

--- a/projects/rocprofiler-sdk/source/lib/tests/codeobj/codeobj_library_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/codeobj/codeobj_library_test.cpp
@@ -22,8 +22,11 @@
 
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#include <cstdio>
+#include <cstdlib>
 #include <fstream>
 #include <rocprofiler-sdk/cxx/codeobj/code_printing.hpp>
+#include <sstream>
 #include <string_view>
 #include <vector>
 
@@ -352,4 +355,251 @@ TEST(codeobj_library, inline_annotation)
     EXPECT_GE(max_depth, min_depth)
         << "Deepest inline call stack was " << max_depth << " levels (expected >= " << min_depth
         << "). DWARF inlined subroutine traversal may be broken.";
+}
+
+namespace
+{
+// Strip the trailing ":<col>" off "file:line:col" -> "file:line", and normalize
+// llvm-symbolizer's "no info" rendering ("??:?", "??:0", "<file>:0") to the
+// same convention used by code_printing.hpp ("<file>:?" or empty).
+std::string
+normalize_fileline(std::string_view s)
+{
+    if(s.empty()) return {};
+
+    // strip trailing :col (if present and numeric/?). llvm-symbolizer emits
+    // "file:line:col"; we only carry "file:line", so drop everything after the
+    // last ':' if it is the third colon-delimited field.
+    auto last_colon  = s.rfind(':');
+    auto first_colon = s.find(':');
+    if(last_colon != std::string_view::npos && last_colon != first_colon)
+        s = s.substr(0, last_colon);
+
+    // collapse "??:?" / "??:0" to empty (== our "no info")
+    if(s == "??:?" || s == "??:0") return {};
+
+    // collapse trailing ":0" to ":?" (line 0 in DWARF == "no specific line")
+    if(s.size() >= 2 && s.substr(s.size() - 2) == ":0")
+        return std::string(s.substr(0, s.size() - 2)) + ":?";
+
+    return std::string(s);
+}
+
+// Compare two file:line strings by basename (path component after last '/'),
+// ignoring path-prefix differences across machines/builds.
+bool
+fileline_basename_equal(std::string_view a, std::string_view b)
+{
+    if(a == b) return true;
+    if(a.empty() || b.empty()) return a == b;
+
+    auto basename = [](std::string_view s) {
+        auto colon = s.rfind(':');
+        if(colon == std::string_view::npos) return s;
+        auto path  = s.substr(0, colon);
+        auto slash = path.rfind('/');
+        if(slash == std::string_view::npos) return s;
+        return std::string_view{s.data() + slash + 1, s.size() - slash - 1};
+    };
+
+    return basename(a) == basename(b);
+}
+
+// Split our comment ("file:line -> file:line -> ...") into a list of frames.
+std::vector<std::string>
+split_our_comment(std::string_view comment)
+{
+    std::vector<std::string> out;
+    if(comment.empty()) return out;
+
+    constexpr std::string_view sep = rocprofiler::sdk::codeobj::disassembly::Instruction::separator;
+    size_t                     pos = 0;
+    while(pos <= comment.size())
+    {
+        auto next = comment.find(sep, pos);
+        if(next == std::string_view::npos)
+        {
+            out.emplace_back(comment.substr(pos));
+            break;
+        }
+        out.emplace_back(comment.substr(pos, next - pos));
+        pos = next + sep.size();
+    }
+    return out;
+}
+
+// Run llvm-symbolizer once with all addresses fed on stdin via a tmp file, and
+// return its parsed output: outer vector is one entry per address (in order),
+// inner vector is the inline-chain frames as "file:line" (innermost first),
+// already normalized for "no info" lines.
+std::vector<std::vector<std::string>>
+run_llvm_symbolizer(const std::string&           symbolizer,
+                    const std::string&           obj_path,
+                    const std::vector<uint64_t>& addrs,
+                    const std::string&           tmp_dir)
+{
+    std::vector<std::vector<std::string>> result(addrs.size());
+    if(addrs.empty()) return result;
+
+    std::string addrs_path = tmp_dir + "/codeobj_dwarf_addrs.txt";
+    {
+        std::ofstream addrs_file(addrs_path);
+        if(!addrs_file) return result;
+        for(auto a : addrs)
+            addrs_file << "0x" << std::hex << a << '\n';
+    }
+
+    // --inlines:        emit the inline chain (innermost first)
+    // --output-style=LLVM: default; "func\nfile:line:col\n\n" per address
+    // --demangle=1:     default; we ignore function names anyway
+    std::ostringstream cmd;
+    cmd << '"' << symbolizer << "\" --obj=\"" << obj_path << "\" --inlines --output-style=LLVM < \""
+        << addrs_path << '"';
+
+    std::unique_ptr<FILE, int (*)(FILE*)> pipe(::popen(cmd.str().c_str(), "r"), &::pclose);
+    if(!pipe) return result;
+
+    std::string raw;
+    {
+        char buf[4096];
+        while(size_t n = std::fread(buf, 1, sizeof(buf), pipe.get()))
+            raw.append(buf, n);
+    }
+
+    // Parse: per-address record terminated by an empty line; each record is a
+    // sequence of (function_name, file:line:col) line pairs.
+    std::istringstream is(raw);
+    std::string        line;
+    size_t             addr_idx    = 0;
+    bool               expect_func = true;  // alternates between function-name and file:line:col
+
+    while(std::getline(is, line))
+    {
+        if(addr_idx >= addrs.size()) break;
+        if(line.empty())
+        {
+            ++addr_idx;
+            expect_func = true;
+            continue;
+        }
+        if(expect_func)
+            expect_func = false;  // skip function name line
+        else
+        {
+            result[addr_idx].emplace_back(normalize_fileline(line));
+            expect_func = true;
+        }
+    }
+    return result;
+}
+}  // namespace
+
+/**
+ * Differential test: every 4-byte address inside each kernel symbol must yield
+ * the same source-line / inline-chain attribution from CodeobjDecoderComponent
+ * as it does from llvm-symbolizer.  Both tools parse the same .debug_line in
+ * the same ELF — disagreement is a bug on one side, and llvm-symbolizer has
+ * had years more scrutiny.
+ *
+ * Specifically guards against the bugs the recent line-attribution fix exists
+ * to prevent: ranges spilling past end_sequence rows, and ranges spilling
+ * across gaps in DWARF coverage.
+ *
+ * Skipped at runtime if llvm-symbolizer was not available at configure time.
+ */
+TEST(codeobj_library, dwarf_matches_llvm_symbolizer)
+{
+#ifndef LLVM_SYMBOLIZER_PATH
+    GTEST_SKIP() << "LLVM_SYMBOLIZER_PATH not defined";
+#else
+    const std::string symbolizer = LLVM_SYMBOLIZER_PATH;
+    if(symbolizer.empty()) GTEST_SKIP() << "llvm-symbolizer not found at configure time";
+
+    std::string obj_path = codeobjhelper::get_data_file_path("syncthreads_kernel.bin");
+    ASSERT_FALSE(obj_path.empty()) << "syncthreads_kernel.bin not found";
+
+    std::ifstream file(obj_path, std::ios::binary);
+    using iterator_t = std::istreambuf_iterator<char>;
+    std::vector<char> objdata{iterator_t(file), iterator_t{}};
+    ASSERT_FALSE(objdata.empty());
+
+    CodeobjDecoderComponent comp(objdata.data(), objdata.size());
+    ASSERT_FALSE(comp.m_symbol_map.empty());
+
+    // Walk every instruction in every kernel symbol and collect (vaddr, our-comment).
+    // Stepping by inst->size (rather than the 4-byte AMDGPU minimum) avoids
+    // calling amd_comgr_disassemble_instruction on mid-instruction addresses,
+    // which throws.  Both sides still see the exact same address set, so any
+    // disagreement is a real DWARF-attribution bug.
+    std::vector<uint64_t>    addrs;
+    std::vector<std::string> ours;
+    for(auto& [kaddr, sym] : comp.m_symbol_map)
+    {
+        uint64_t va = kaddr;
+        while(va < kaddr + sym.mem_size)
+        {
+            auto faddr = comp.va2fo(va);
+            if(!faddr) break;
+            std::unique_ptr<disassembly::Instruction> inst;
+            try
+            {
+                inst = comp.disassemble_instruction(*faddr, va);
+            } catch(...)
+            {
+                break;
+            }
+            if(!inst || inst->size == 0) break;
+            addrs.push_back(va);
+            ours.push_back(inst->comment);
+            va += inst->size;
+        }
+    }
+    ASSERT_FALSE(addrs.empty());
+
+    auto theirs = run_llvm_symbolizer(symbolizer, obj_path, addrs, CODEOBJ_BINARY_DIR);
+    ASSERT_EQ(theirs.size(), addrs.size())
+        << "llvm-symbolizer returned a different number of address records";
+
+    size_t mismatches = 0;
+    for(size_t i = 0; i < addrs.size(); ++i)
+    {
+        auto  our_frames   = split_our_comment(ours[i]);
+        auto& their_frames = theirs[i];
+
+        // Both empty == both report "no info" for this address. OK.
+        if(our_frames.empty() && their_frames.empty()) continue;
+
+        bool ok = our_frames.size() == their_frames.size();
+        if(ok)
+        {
+            for(size_t f = 0; f < our_frames.size(); ++f)
+            {
+                if(!fileline_basename_equal(normalize_fileline(our_frames[f]), their_frames[f]))
+                {
+                    ok = false;
+                    break;
+                }
+            }
+        }
+
+        if(!ok && mismatches < 10)
+        {
+            std::ostringstream our_s, their_s;
+            for(auto& f : our_frames)
+                our_s << '[' << f << ']';
+            for(auto& f : their_frames)
+                their_s << '[' << f << ']';
+            ADD_FAILURE() << "addr=0x" << std::hex << addrs[i] << std::dec
+                          << "\n  ours  : " << our_s.str() << "\n  theirs: " << their_s.str();
+            ++mismatches;
+        }
+        else if(!ok)
+        {
+            ++mismatches;
+        }
+    }
+
+    EXPECT_EQ(mismatches, 0u) << mismatches << " of " << addrs.size()
+                              << " addresses disagreed with llvm-symbolizer";
+#endif
 }

--- a/projects/rocprofiler-sdk/source/lib/tests/codeobj/codeobj_library_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/codeobj/codeobj_library_test.cpp
@@ -361,244 +361,95 @@ TEST(codeobj_library, inline_annotation)
 
 namespace
 {
-// Strip the trailing ":<col>" off "file:line:col" -> "file:line", and normalize
-// llvm-symbolizer's "no info" rendering ("??:?", "??:0", "<file>:0") to the
-// same convention used by code_printing.hpp ("<file>:?" or empty).
+// Reduce a "file[:line[:col]]" frame to "basename:line", or "" for "no info".
+// llvm-symbolizer renders "no info" as "??:0:0" / "??:?"; DWARF line 0 is also
+// "no specific line".  Normalizing both sides this way makes path-prefix and
+// column differences across machines/builds irrelevant.
 std::string
-normalize_fileline(std::string_view s)
+canonicalize(std::string_view s)
 {
-    if(s.empty()) return {};
+    if(s.empty() || s == "??:0:0" || s == "??:?" || s == "??:0") return {};
 
-    // strip trailing :col (if present and numeric/?). llvm-symbolizer emits
-    // "file:line:col"; we only carry "file:line", so drop everything after the
-    // last ':' if it is the third colon-delimited field.
-    auto last_colon  = s.rfind(':');
-    auto first_colon = s.find(':');
-    if(last_colon != std::string_view::npos && last_colon != first_colon)
-        s = s.substr(0, last_colon);
+    // Strip optional trailing ":col" (llvm-symbolizer is "file:line:col"; we are "file:line").
+    auto last  = s.rfind(':');
+    auto first = s.find(':');
+    if(last != first && last != std::string_view::npos) s = s.substr(0, last);
 
-    // collapse "??:?" / "??:0" to empty (== our "no info")
-    if(s == "??:?" || s == "??:0") return {};
-
-    // collapse trailing ":0" to ":?" (line 0 in DWARF == "no specific line")
-    if(s.size() >= 2 && s.substr(s.size() - 2) == ":0")
-        return std::string(s.substr(0, s.size() - 2)) + ":?";
-
-    return std::string(s);
+    auto colon = s.rfind(':');
+    if(colon == std::string_view::npos) return std::string{s};
+    auto line = s.substr(colon + 1);
+    if(line == "0" || line == "?") return {};
+    auto path  = s.substr(0, colon);
+    auto slash = path.rfind('/');
+    auto base  = (slash == std::string_view::npos) ? path : path.substr(slash + 1);
+    return std::string{base} + ':' + std::string{line};
 }
 
-// Compare two file:line strings by basename (path component after last '/'),
-// ignoring path-prefix differences across machines/builds.
-bool
-fileline_basename_equal(std::string_view a, std::string_view b)
+// Locate llvm-symbolizer at runtime: $ROCM_PATH, $ROCM_HOME, /opt/rocm, then $PATH.
+// Resolved at runtime rather than configure time because some CI flows (e.g.
+// TheRock) wipe the build dir before tests run, leaving any baked-in absolute
+// path stale.
+std::string
+find_symbolizer()
 {
-    if(a == b) return true;
-    if(a.empty() || b.empty()) return a == b;
-
-    auto basename = [](std::string_view s) {
-        auto colon = s.rfind(':');
-        if(colon == std::string_view::npos) return s;
-        auto path  = s.substr(0, colon);
-        auto slash = path.rfind('/');
-        if(slash == std::string_view::npos) return s;
-        return std::string_view{s.data() + slash + 1, s.size() - slash - 1};
-    };
-
-    return basename(a) == basename(b);
-}
-
-// Split our comment ("file:line -> file:line -> ...") into a list of frames.
-std::vector<std::string>
-split_our_comment(std::string_view comment)
-{
-    std::vector<std::string> out;
-    if(comment.empty()) return out;
-
-    constexpr std::string_view sep = rocprofiler::sdk::codeobj::disassembly::Instruction::separator;
-    size_t                     pos = 0;
-    while(pos <= comment.size())
-    {
-        auto next = comment.find(sep, pos);
-        if(next == std::string_view::npos)
-        {
-            out.emplace_back(comment.substr(pos));
-            break;
-        }
-        out.emplace_back(comment.substr(pos, next - pos));
-        pos = next + sep.size();
-    }
-    return out;
-}
-
-struct SymbolizerResult
-{
-    std::vector<std::vector<std::string>> records;  // one entry per requested address
-    std::string                           error;    // non-empty == hard failure
-};
-
-// Run llvm-symbolizer once with all addresses fed on stdin via a tmp file, and
-// return its parsed output: outer vector is one entry per address (in order),
-// inner vector is the inline-chain frames as "file:line" (innermost first),
-// already normalized for "no info" lines.
-//
-// The address list is written via mkstemp() into the system tmp dir
-// (TMPDIR / std::filesystem::temp_directory_path(), falling back to /tmp).
-// The test's binary dir is read-only in CI builds that run tests from the
-// install tree.  On any failure, fills `error` so the caller fails the test
-// loudly rather than silently treating every address as a mismatch.
-SymbolizerResult
-run_llvm_symbolizer(const std::string&           symbolizer,
-                    const std::string&           obj_path,
-                    const std::vector<uint64_t>& addrs)
-{
-    SymbolizerResult out;
-    out.records.resize(addrs.size());
-    if(addrs.empty()) return out;
-
     namespace fs = rocprofiler::common::filesystem;
-    std::string tmp_dir;
-    {
+    auto exists  = [](const std::string& p) {
         std::error_code ec;
-        auto            p = fs::temp_directory_path(ec);
-        if(!ec && !p.empty())
-            tmp_dir = p.string();
-        else if(const char* env = std::getenv("TMPDIR"); env && *env)
-            tmp_dir = env;
-        else
-            tmp_dir = "/tmp";
-    }
+        return !p.empty() && fs::exists(p, ec) && !ec;
+    };
+    for(const char* env : {"ROCM_PATH", "ROCM_HOME"})
+        if(const char* v = std::getenv(env); v && *v)
+            if(auto p = std::string{v} + "/llvm/bin/llvm-symbolizer"; exists(p)) return p;
+    if(std::string p = "/opt/rocm/llvm/bin/llvm-symbolizer"; exists(p)) return p;
 
-    std::string       tmpl_str = tmp_dir + "/codeobj_dwarf_addrs.XXXXXX";
-    std::vector<char> tmpl(tmpl_str.begin(), tmpl_str.end());
-    tmpl.push_back('\0');
-    int fd = ::mkstemp(tmpl.data());
-    if(fd < 0)
-    {
-        out.error = std::string{"mkstemp("} + tmpl.data() + ") failed: " + ::strerror(errno);
-        return out;
-    }
-    std::string addrs_path = tmpl.data();
-    {
-        FILE* fp = ::fdopen(fd, "w");
-        if(!fp)
-        {
-            out.error = std::string{"fdopen failed: "} + ::strerror(errno);
-            ::close(fd);
-            ::unlink(addrs_path.c_str());
-            return out;
-        }
-        for(auto a : addrs)
-            std::fprintf(fp, "0x%lx\n", static_cast<unsigned long>(a));
-        std::fclose(fp);  // also closes fd
-    }
-
-    // --inlines: emit the inline chain (innermost first)
-    // --output-style=LLVM: "func\nfile:line:col\n\n" per address
-    // 2>&1 so symbolizer-side errors land in our captured output for diagnosis
-    std::ostringstream cmd;
-    cmd << '"' << symbolizer << "\" --obj=\"" << obj_path << "\" --inlines --output-style=LLVM < \""
-        << addrs_path << "\" 2>&1";
-
-    FILE*       raw_pipe = ::popen(cmd.str().c_str(), "r");
-    std::string raw;
-    if(raw_pipe)
-    {
-        char buf[4096];
-        while(size_t n = std::fread(buf, 1, sizeof(buf), raw_pipe))
-            raw.append(buf, n);
-    }
-    int rc = raw_pipe ? ::pclose(raw_pipe) : -1;
-    ::unlink(addrs_path.c_str());
-
-    if(!raw_pipe || rc != 0)
-    {
-        out.error = "llvm-symbolizer invocation failed (rc=" + std::to_string(rc) +
-                    ", cmd=" + cmd.str() + ", output:\n" + raw + ")";
-        return out;
-    }
-    if(raw.empty())
-    {
-        out.error = "llvm-symbolizer produced no output (cmd=" + cmd.str() + ")";
-        return out;
-    }
-
-    // Parse: per-address record terminated by an empty line; each record is a
-    // sequence of (function_name, file:line:col) line pairs.
-    std::istringstream is(raw);
-    std::string        line;
-    size_t             addr_idx    = 0;
-    bool               expect_func = true;  // alternates between function-name and file:line:col
-
-    while(std::getline(is, line))
-    {
-        if(addr_idx >= addrs.size()) break;
-        if(line.empty())
-        {
-            ++addr_idx;
-            expect_func = true;
-            continue;
-        }
-        if(expect_func)
-            expect_func = false;  // skip function name line
-        else
-        {
-            out.records[addr_idx].emplace_back(normalize_fileline(line));
-            expect_func = true;
-        }
-    }
-
-    // If we never crossed a single record terminator, the output didn't match
-    // the expected --output-style=LLVM shape; fail loudly rather than mismatch-spam.
-    if(addr_idx == 0)
-        out.error = "llvm-symbolizer output did not parse as LLVM-style records:\n" + raw;
-
+    FILE* pipe = ::popen("command -v llvm-symbolizer 2>/dev/null", "r");
+    if(!pipe) return {};
+    char        buf[4096];
+    std::string out;
+    while(size_t n = std::fread(buf, 1, sizeof(buf), pipe))
+        out.append(buf, n);
+    ::pclose(pipe);
+    while(!out.empty() && (out.back() == '\n' || out.back() == '\r'))
+        out.pop_back();
     return out;
 }
 }  // namespace
 
 /**
- * Differential test: every 4-byte address inside each kernel symbol must yield
- * the same source-line / inline-chain attribution from CodeobjDecoderComponent
- * as it does from llvm-symbolizer.  Both tools parse the same .debug_line in
- * the same ELF — disagreement is a bug on one side, and llvm-symbolizer has
- * had years more scrutiny.
+ * Differential test: every instruction inside each kernel symbol must yield the
+ * same source-line / inline-chain attribution from CodeobjDecoderComponent as
+ * from llvm-symbolizer.  Both parse the same .debug_line in the same ELF —
+ * disagreement is a bug, and llvm-symbolizer has had years more scrutiny.
  *
- * Specifically guards against the bugs the recent line-attribution fix exists
- * to prevent: ranges spilling past end_sequence rows, and ranges spilling
- * across gaps in DWARF coverage.
- *
- * Skipped at runtime if llvm-symbolizer was not available at configure time.
+ * Guards against the bugs the recent line-attribution fix targets: ranges
+ * spilling past end_sequence rows, and ranges spilling across DWARF gaps.
+ * Skipped if llvm-symbolizer cannot be found at runtime.
  */
 TEST(codeobj_library, dwarf_matches_llvm_symbolizer)
 {
-#ifndef LLVM_SYMBOLIZER_PATH
-    GTEST_SKIP() << "LLVM_SYMBOLIZER_PATH not defined";
-#else
-    const std::string symbolizer = LLVM_SYMBOLIZER_PATH;
-    if(symbolizer.empty()) GTEST_SKIP() << "llvm-symbolizer not found at configure time";
+    namespace fs                = rocprofiler::common::filesystem;
+    constexpr std::string_view sep = disassembly::Instruction::separator;
+
+    const std::string symbolizer = find_symbolizer();
+    if(symbolizer.empty()) GTEST_SKIP() << "llvm-symbolizer not found";
 
     std::string obj_path = codeobjhelper::get_data_file_path("syncthreads_kernel.bin");
     ASSERT_FALSE(obj_path.empty()) << "syncthreads_kernel.bin not found";
 
-    std::ifstream file(obj_path, std::ios::binary);
-    using iterator_t = std::istreambuf_iterator<char>;
-    std::vector<char> objdata{iterator_t(file), iterator_t{}};
-    ASSERT_FALSE(objdata.empty());
+    std::ifstream     in(obj_path, std::ios::binary);
+    std::vector<char> obj{std::istreambuf_iterator<char>(in), {}};
+    ASSERT_FALSE(obj.empty());
 
-    CodeobjDecoderComponent comp(objdata.data(), objdata.size());
+    CodeobjDecoderComponent comp(obj.data(), obj.size());
     ASSERT_FALSE(comp.m_symbol_map.empty());
 
-    // Walk every instruction in every kernel symbol and collect (vaddr, our-comment).
-    // Stepping by inst->size (rather than the 4-byte AMDGPU minimum) avoids
-    // calling amd_comgr_disassemble_instruction on mid-instruction addresses,
-    // which throws.  Both sides still see the exact same address set, so any
-    // disagreement is a real DWARF-attribution bug.
+    // Walk every instruction; step by inst->size so we never feed comgr a
+    // mid-instruction address (which throws). Both sides see the same set.
     std::vector<uint64_t>    addrs;
     std::vector<std::string> ours;
     for(auto& [kaddr, sym] : comp.m_symbol_map)
     {
-        uint64_t va = kaddr;
-        while(va < kaddr + sym.mem_size)
+        for(uint64_t va = kaddr; va < kaddr + sym.mem_size;)
         {
             auto faddr = comp.va2fo(va);
             if(!faddr) break;
@@ -618,51 +469,93 @@ TEST(codeobj_library, dwarf_matches_llvm_symbolizer)
     }
     ASSERT_FALSE(addrs.empty());
 
-    auto theirs = run_llvm_symbolizer(symbolizer, obj_path, addrs);
-    ASSERT_TRUE(theirs.error.empty()) << theirs.error;
-    ASSERT_EQ(theirs.records.size(), addrs.size())
-        << "llvm-symbolizer returned a different number of address records";
+    // Feed addresses to llvm-symbolizer via stdin from a tmp file (the test's
+    // build dir is read-only in some CI install layouts).
+    std::error_code ec;
+    auto            tmp     = fs::temp_directory_path(ec);
+    std::string     tmpl_str = (ec ? "/tmp" : tmp.string()) + "/codeobj_addrs.XXXXXX";
+    std::vector<char> tmpl(tmpl_str.begin(), tmpl_str.end());
+    tmpl.push_back('\0');
+    int fd = ::mkstemp(tmpl.data());
+    ASSERT_GE(fd, 0) << "mkstemp: " << ::strerror(errno);
+    {
+        FILE* fp = ::fdopen(fd, "w");
+        ASSERT_NE(fp, nullptr);
+        for(auto a : addrs)
+            std::fprintf(fp, "0x%lx\n", static_cast<unsigned long>(a));
+        std::fclose(fp);
+    }
+    std::string cmd = '"' + symbolizer + "\" --obj=\"" + obj_path +
+                      "\" --inlines --output-style=LLVM < \"" + tmpl.data() + "\" 2>&1";
+    FILE* pipe = ::popen(cmd.c_str(), "r");
+    ASSERT_NE(pipe, nullptr) << "popen: " << ::strerror(errno);
+    std::string raw;
+    char        buf[4096];
+    while(size_t n = std::fread(buf, 1, sizeof(buf), pipe))
+        raw.append(buf, n);
+    int rc = ::pclose(pipe);
+    ::unlink(tmpl.data());
+    ASSERT_EQ(rc, 0) << "llvm-symbolizer rc=" << rc << " cmd=" << cmd << "\n" << raw;
+
+    // Parse: per-address record terminated by an empty line; each record is
+    // (function_name, file:line:col) line pairs, innermost first.
+    std::vector<std::vector<std::string>> theirs(addrs.size());
+    {
+        std::istringstream is(raw);
+        std::string        line;
+        size_t             i         = 0;
+        bool               want_func = true;
+        while(std::getline(is, line) && i < addrs.size())
+        {
+            if(line.empty())
+            {
+                ++i;
+                want_func = true;
+            }
+            else if(want_func)
+                want_func = false;
+            else
+            {
+                theirs[i].emplace_back(canonicalize(line));
+                want_func = true;
+            }
+        }
+    }
+
+    // Compare frame-by-frame after canonicalization. Trailing "no info" frames
+    // are dropped on both sides so {""} (llvm's "??:0:0") matches our empty.
+    auto trim = [](std::vector<std::string>& v) {
+        while(!v.empty() && v.back().empty()) v.pop_back();
+    };
 
     size_t mismatches = 0;
     for(size_t i = 0; i < addrs.size(); ++i)
     {
-        auto  our_frames   = split_our_comment(ours[i]);
-        auto& their_frames = theirs.records[i];
-
-        // Both empty == both report "no info" for this address. OK.
-        if(our_frames.empty() && their_frames.empty()) continue;
-
-        bool ok = our_frames.size() == their_frames.size();
-        if(ok)
+        std::vector<std::string> mine;
+        for(size_t pos = 0; pos <= ours[i].size();)
         {
-            for(size_t f = 0; f < our_frames.size(); ++f)
-            {
-                if(!fileline_basename_equal(normalize_fileline(our_frames[f]), their_frames[f]))
-                {
-                    ok = false;
-                    break;
-                }
-            }
+            auto next = ours[i].find(sep, pos);
+            mine.emplace_back(canonicalize(
+                ours[i].substr(pos, next == std::string::npos ? next : next - pos)));
+            if(next == std::string::npos) break;
+            pos = next + sep.size();
         }
+        trim(mine);
+        trim(theirs[i]);
+        if(mine == theirs[i]) continue;
 
-        if(!ok && mismatches < 10)
+        if(mismatches++ < 10)
         {
-            std::ostringstream our_s, their_s;
-            for(auto& f : our_frames)
-                our_s << '[' << f << ']';
-            for(auto& f : their_frames)
-                their_s << '[' << f << ']';
+            auto fmt = [](const std::vector<std::string>& v) {
+                std::string s;
+                for(auto& f : v) (s += '[') += f, s += ']';
+                return s;
+            };
             ADD_FAILURE() << "addr=0x" << std::hex << addrs[i] << std::dec
-                          << "\n  ours  : " << our_s.str() << "\n  theirs: " << their_s.str();
-            ++mismatches;
-        }
-        else if(!ok)
-        {
-            ++mismatches;
+                          << "\n  ours  : " << fmt(mine) << "\n  theirs: " << fmt(theirs[i]);
         }
     }
 
     EXPECT_EQ(mismatches, 0u) << mismatches << " of " << addrs.size()
                               << " addresses disagreed with llvm-symbolizer";
-#endif
 }

--- a/projects/rocprofiler-sdk/source/lib/tests/codeobj/codeobj_library_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/codeobj/codeobj_library_test.cpp
@@ -22,8 +22,10 @@
 
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#include <unistd.h>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <rocprofiler-sdk/cxx/codeobj/code_printing.hpp>
 #include <sstream>
@@ -428,42 +430,96 @@ split_our_comment(std::string_view comment)
     return out;
 }
 
+struct SymbolizerResult
+{
+    std::vector<std::vector<std::string>> records;  // one entry per requested address
+    std::string                           error;    // non-empty == hard failure
+};
+
 // Run llvm-symbolizer once with all addresses fed on stdin via a tmp file, and
 // return its parsed output: outer vector is one entry per address (in order),
 // inner vector is the inline-chain frames as "file:line" (innermost first),
 // already normalized for "no info" lines.
-std::vector<std::vector<std::string>>
+//
+// The address list is written via mkstemp() into the system tmp dir
+// (TMPDIR / std::filesystem::temp_directory_path(), falling back to /tmp).
+// The test's binary dir is read-only in CI builds that run tests from the
+// install tree.  On any failure, fills `error` so the caller fails the test
+// loudly rather than silently treating every address as a mismatch.
+SymbolizerResult
 run_llvm_symbolizer(const std::string&           symbolizer,
                     const std::string&           obj_path,
-                    const std::vector<uint64_t>& addrs,
-                    const std::string&           tmp_dir)
+                    const std::vector<uint64_t>& addrs)
 {
-    std::vector<std::vector<std::string>> result(addrs.size());
-    if(addrs.empty()) return result;
+    SymbolizerResult out;
+    out.records.resize(addrs.size());
+    if(addrs.empty()) return out;
 
-    std::string addrs_path = tmp_dir + "/codeobj_dwarf_addrs.txt";
+    namespace fs = rocprofiler::common::filesystem;
+    std::string tmp_dir;
     {
-        std::ofstream addrs_file(addrs_path);
-        if(!addrs_file) return result;
-        for(auto a : addrs)
-            addrs_file << "0x" << std::hex << a << '\n';
+        std::error_code ec;
+        auto            p = fs::temp_directory_path(ec);
+        if(!ec && !p.empty())
+            tmp_dir = p.string();
+        else if(const char* env = std::getenv("TMPDIR"); env && *env)
+            tmp_dir = env;
+        else
+            tmp_dir = "/tmp";
     }
 
-    // --inlines:        emit the inline chain (innermost first)
-    // --output-style=LLVM: default; "func\nfile:line:col\n\n" per address
-    // --demangle=1:     default; we ignore function names anyway
+    std::string       tmpl_str = tmp_dir + "/codeobj_dwarf_addrs.XXXXXX";
+    std::vector<char> tmpl(tmpl_str.begin(), tmpl_str.end());
+    tmpl.push_back('\0');
+    int fd = ::mkstemp(tmpl.data());
+    if(fd < 0)
+    {
+        out.error = std::string{"mkstemp("} + tmpl.data() + ") failed: " + ::strerror(errno);
+        return out;
+    }
+    std::string addrs_path = tmpl.data();
+    {
+        FILE* fp = ::fdopen(fd, "w");
+        if(!fp)
+        {
+            out.error = std::string{"fdopen failed: "} + ::strerror(errno);
+            ::close(fd);
+            ::unlink(addrs_path.c_str());
+            return out;
+        }
+        for(auto a : addrs)
+            std::fprintf(fp, "0x%lx\n", static_cast<unsigned long>(a));
+        std::fclose(fp);  // also closes fd
+    }
+
+    // --inlines: emit the inline chain (innermost first)
+    // --output-style=LLVM: "func\nfile:line:col\n\n" per address
+    // 2>&1 so symbolizer-side errors land in our captured output for diagnosis
     std::ostringstream cmd;
     cmd << '"' << symbolizer << "\" --obj=\"" << obj_path << "\" --inlines --output-style=LLVM < \""
-        << addrs_path << '"';
+        << addrs_path << "\" 2>&1";
 
-    std::unique_ptr<FILE, int (*)(FILE*)> pipe(::popen(cmd.str().c_str(), "r"), &::pclose);
-    if(!pipe) return result;
-
+    FILE*       raw_pipe = ::popen(cmd.str().c_str(), "r");
     std::string raw;
+    if(raw_pipe)
     {
         char buf[4096];
-        while(size_t n = std::fread(buf, 1, sizeof(buf), pipe.get()))
+        while(size_t n = std::fread(buf, 1, sizeof(buf), raw_pipe))
             raw.append(buf, n);
+    }
+    int rc = raw_pipe ? ::pclose(raw_pipe) : -1;
+    ::unlink(addrs_path.c_str());
+
+    if(!raw_pipe || rc != 0)
+    {
+        out.error = "llvm-symbolizer invocation failed (rc=" + std::to_string(rc) +
+                    ", cmd=" + cmd.str() + ", output:\n" + raw + ")";
+        return out;
+    }
+    if(raw.empty())
+    {
+        out.error = "llvm-symbolizer produced no output (cmd=" + cmd.str() + ")";
+        return out;
     }
 
     // Parse: per-address record terminated by an empty line; each record is a
@@ -486,11 +542,17 @@ run_llvm_symbolizer(const std::string&           symbolizer,
             expect_func = false;  // skip function name line
         else
         {
-            result[addr_idx].emplace_back(normalize_fileline(line));
+            out.records[addr_idx].emplace_back(normalize_fileline(line));
             expect_func = true;
         }
     }
-    return result;
+
+    // If we never crossed a single record terminator, the output didn't match
+    // the expected --output-style=LLVM shape; fail loudly rather than mismatch-spam.
+    if(addr_idx == 0)
+        out.error = "llvm-symbolizer output did not parse as LLVM-style records:\n" + raw;
+
+    return out;
 }
 }  // namespace
 
@@ -556,15 +618,16 @@ TEST(codeobj_library, dwarf_matches_llvm_symbolizer)
     }
     ASSERT_FALSE(addrs.empty());
 
-    auto theirs = run_llvm_symbolizer(symbolizer, obj_path, addrs, CODEOBJ_BINARY_DIR);
-    ASSERT_EQ(theirs.size(), addrs.size())
+    auto theirs = run_llvm_symbolizer(symbolizer, obj_path, addrs);
+    ASSERT_TRUE(theirs.error.empty()) << theirs.error;
+    ASSERT_EQ(theirs.records.size(), addrs.size())
         << "llvm-symbolizer returned a different number of address records";
 
     size_t mismatches = 0;
     for(size_t i = 0; i < addrs.size(); ++i)
     {
         auto  our_frames   = split_our_comment(ours[i]);
-        auto& their_frames = theirs[i];
+        auto& their_frames = theirs.records[i];
 
         // Both empty == both report "no info" for this address. OK.
         if(our_frames.empty() && their_frames.empty()) continue;


### PR DESCRIPTION
## Motivation

When the disassembly is only partially covered by dwarf lineinfo, the profiler assigns the last valid source line to that address.
This is incorrect, instead the profiler needs to check the dwarf address range.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

This PR adds a test to ensure the Codeobj classes generate the same output as llvm-symbolizer.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
