### PR TITLE
[rccl] Gate multi-node Direct AllGather on PXN enablement

### DIFF
--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -418,6 +418,12 @@ bool rcclUseAllGatherDirect(struct ncclComm* comm, size_t& msgSize) {
     return false;
   }
 
+  // Multi-node Direct AllGather requires PXN
+  if (comm->nNodes > 1 && ncclPxnDisable(comm) != 0) {
+    INFO(NCCL_INIT, "RCCL DIRECT ALLGATHER disabled on multi-node due to PXN being disabled.");
+    return false;
+  }
+
   // Check if user explicitly set threshold
   static int userThresholdInput = -2;
   if (userThresholdInput == -2) {


### PR DESCRIPTION
Guard rcclUseAllGatherDirect() so that multi-node runs require PXN, matching the existing gate in rcclUseReduceScatterDirect(). Single-node behavior is unchanged.

## Motivation

This PR gates Direct AllGather on PXN enablement for multi-node runs to prevent these failures, applying uniformly across all NIC type

## Technical Details

Added a PXN enablement check in rcclUseAllGatherDirect() (src/rccl_wrap.cc). When running multi-node (comm->nNodes > 1), the function now calls ncclPxnDisable(comm) and returns false if PXN is disabled, falling back to the regular AllGather path. This mirrors the existing PXN gate already present in rcclUseReduceScatterDirect(). Single-node behavior is unchanged.

## JIRA ID

Resolves AICOMRCCL-891

## Test Plan

[ ] - Verify Direct AllGather is disabled on multi-node when NCCL_PXN_DISABLE=1 (or PXN is otherwise not enabled)
[ ] - Verify Direct AllGather still activates on multi-node when PXN is enabled
[ ] - Verify single-node Direct AllGather is unaffected regardless of PXN setting

## Test Result



## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
