### PR TITLE
Improve logging when incorrect arch is passed

### DIFF
--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -639,7 +639,7 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
       } else {
         // We found neither a compatible code object nor SPIRV
         LogPrintfError(
-            "No compatible code objects with HIP_FORCE_SPIRV_CODEOBJECT: %d. Rebuild the application with option --offload-arch=%s",
+            "No compatible code objects found with HIP_FORCE_SPIRV_CODEOBJECT=%d. Rebuild the application with option --offload-arch=%s",
              HIP_FORCE_SPIRV_CODEOBJECT, device->devices()[0]->isa().targetId());
         break;
       }

--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -639,8 +639,8 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
       } else {
         // We found neither a compatible code object nor SPIRV
         LogPrintfError(
-            "No compatible code objects found for: %s, value of HIP_FORCE_SPIRV_CODEOBJECT: %d",
-            device->devices()[0]->isa().targetId(), HIP_FORCE_SPIRV_CODEOBJECT);
+            "No compatible code objects with HIP_FORCE_SPIRV_CODEOBJECT: %d. Rebuild the application with option --offload-arch=%s",
+             HIP_FORCE_SPIRV_CODEOBJECT, device->devices()[0]->isa().targetId());
         break;
       }
     }


### PR DESCRIPTION
## Motivation
Improve error when incorrect offload-arch is passed. 

## Technical Details
log to help user to rebuild application with correct set of --offload-arch=gfxXXXX

## JIRA ID
ROCM-21851


## Test Plan
build app with incorrect offload-arch and rebuild the app with the instructions provided in the logs

## Test Result


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
