### PR TITLE
[rocshmem] Enable launching with a variety of MPI/launchers

### DIFF
--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -161,23 +161,60 @@ if (NOT BUILD_TESTS_ONLY)
   #############################################################################
   # PACKAGE DEPENDENCIES
   #############################################################################
-  if (NOT USE_EXTERNAL_MPI STREQUAL "OFF")
-    find_package(MPI)
-  else()
-    message ("-- External MPI detection disabled by user")
-  endif()
-
-  if (MPI_FOUND)
-    set(HAVE_EXTERNAL_MPI ON)
-  else()
+  if (USE_EXTERNAL_MPI STREQUAL "OFF")
+    message(STATUS "External MPI detection disabled by user")
+    # HAVE_EXTERNAL_MPI=OFF is the authoritative gate used throughout the build
+    # (target_link_libraries, DeviceBitcode.cmake, rocshmem_config.h).  We do
+    # NOT unset MPI_* variables here: unset() is scope-local and cannot remove
+    # cache variables or imported targets already created by a parent project's
+    # find_package(MPI).  Relying on HAVE_EXTERNAL_MPI=OFF is both correct and
+    # safe in superproject / submodule configurations.
     set(HAVE_EXTERNAL_MPI OFF)
-    set(BUILD_UNIT_TESTS OFF)
-    set(BUILD_EXAMPLES OFF)
-  endif()
-
-  if (USE_EXTERNAL_MPI STREQUAL "ON")
-    if(NOT HAVE_EXTERNAL_MPI)
-      message(FATAL_ERROR "External MPI support requested but MPI support not found. Build Aborted")
+  else()
+    find_package(MPI)
+    if (MPI_FOUND)
+      if (USE_EXTERNAL_MPI STREQUAL "ON")
+        # Explicit request: always use compile-time MPI link regardless of brand
+        set(HAVE_EXTERNAL_MPI ON)
+        message(STATUS "External MPI linkage forced by user (HAVE_EXTERNAL_MPI=ON)")
+      else()
+        # AUTO mode: Open MPI is already handled via dlopen — no compile-time
+        # link needed.  Only non-Open MPI implementations require it.
+        #
+        # Detect the MPI brand by scanning mpi.h for well-known preprocessor
+        # markers.  This avoids spawning mpiexec (not always installed with the
+        # dev package) and works in cross-compilation environments.
+        #
+        #  Open MPI  : #define OPEN_MPI 1  /  #define OMPI_MAJOR_VERSION …
+        #  MPICH     : #define MPICH_VERSION  /  #define MPICH_NUMVERSION …
+        #              (also used by Intel MPI, MVAPICH, Cray MPI)
+        set(_MPI_IS_OPENMPI OFF)
+        foreach(_inc ${MPI_CXX_INCLUDE_DIRS})
+          if (EXISTS "${_inc}/mpi.h")
+            file(STRINGS "${_inc}/mpi.h" _mpi_header_lines
+                 REGEX "#define (OPEN_MPI|OMPI_MAJOR_VERSION)")
+            if (_mpi_header_lines)
+              set(_MPI_IS_OPENMPI ON)
+            endif()
+            break()
+          endif()
+        endforeach()
+        if (_MPI_IS_OPENMPI)
+          message(STATUS "Found Open MPI — using dlopen path (HAVE_EXTERNAL_MPI=OFF)")
+          set(HAVE_EXTERNAL_MPI OFF)
+        else()
+          message(STATUS "Found non-Open MPI — enabling compile-time MPI linkage (HAVE_EXTERNAL_MPI=ON)")
+          set(HAVE_EXTERNAL_MPI ON)
+        endif()
+        unset(_MPI_IS_OPENMPI)
+        unset(_mpi_header_lines)
+        unset(_inc)
+      endif()
+    else()
+      set(HAVE_EXTERNAL_MPI OFF)
+      set(BUILD_UNIT_TESTS OFF)
+      set(BUILD_EXAMPLES OFF)
+      set(BUILD_FUNCTIONAL_TESTS OFF)
     endif()
   endif()
 

--- a/projects/rocshmem/cmake/DeviceBitcode.cmake
+++ b/projects/rocshmem/cmake/DeviceBitcode.cmake
@@ -71,9 +71,11 @@ if(${ROCM_MAJOR_VERSION} LESS 7)
   list(APPEND BITCODE_COMPILE_FLAGS_BASE -DHIP_ENABLE_WARP_SYNC_BUILTINS=1)
 endif()
 
-# Add MPI include directories — rocshmem_config.h defines HAVE_EXTERNAL_MPI
-# when MPI is found, causing rocshmem_mpi.hpp to #include <mpi.h> transitively.
-if(MPI_CXX_FOUND)
+# Add MPI include directories only when compile-time MPI linkage is active.
+# Gating on HAVE_EXTERNAL_MPI (not MPI_CXX_FOUND) prevents a parent project's
+# find_package(MPI) result from leaking into the device bitcode when
+# USE_EXTERNAL_MPI=OFF or when Open MPI was detected in AUTO mode.
+if(HAVE_EXTERNAL_MPI)
   foreach(mpi_include_dir ${MPI_CXX_INCLUDE_DIRS})
     list(APPEND BITCODE_COMPILE_FLAGS_BASE -I${mpi_include_dir})
   endforeach()

--- a/projects/rocshmem/docs/api/init.rst
+++ b/projects/rocshmem/docs/api/init.rst
@@ -24,6 +24,39 @@ you must select the device that this PE is associated to by calling
 <https://rocm.docs.amd.com/projects/HIP/en/docs-6.0.0/doxygen/html/group___device.html#ga43c1e7f15925eeb762195ccb5e063eae>`_.
 
 .. WARNING::
+   The following two overloads are deprecated. Use :cpp:func:`rocshmem_init_attr`
+   with the ``ROCSHMEM_INIT_WITH_MPI_COMM`` flag instead.
+
+.. cpp:function:: [[deprecated]] __host__ void rocshmem_init(MPI_Comm comm)
+
+  :param comm: MPI communicator to use. If ``MPI_COMM_NULL``, ``MPI_COMM_WORLD`` is used.
+  :returns: None.
+
+**Description:**
+This routine initializes the rocSHMEM library using the provided MPI communicator.
+
+.. note::
+
+   This overload is only declared when ``<mpi.h>`` is included **before**
+   ``<rocshmem/rocshmem.hpp>``.
+
+.. cpp:function:: [[deprecated]] __host__ int rocshmem_init_thread(int requested, int *provided, MPI_Comm comm)
+
+  :param requested: Requested thread mode (from ``rocshmem_thread_ops``).
+  :param provided:  Thread mode selected by the runtime. May differ from ``requested``.
+  :param comm:      MPI communicator to use. If ``MPI_COMM_NULL``, ``MPI_COMM_WORLD`` is used.
+  :returns int:     Returns ``0`` on success; otherwise, returns a nonzero value.
+
+**Description:**
+This routine initializes the rocSHMEM library with thread support negotiation,
+using the provided MPI communicator.
+
+.. note::
+
+   This overload is only declared when ``<mpi.h>`` is included **before**
+   ``<rocshmem/rocshmem.hpp>``.
+
+.. WARNING::
    Routine `rocshmem_wg_init` has been deprecated.
 
 .. cpp:function:: [[deprecated]] __device__ void rocshmem_wg_init(void)

--- a/projects/rocshmem/examples/util.h
+++ b/projects/rocshmem/examples/util.h
@@ -56,13 +56,16 @@
 }
 
 [[maybe_unused]] static int get_launcher_local_rank() {
-    char *local_rank_str = nullptr;
-
-    local_rank_str = getenv("OMPI_COMM_WORLD_LOCAL_RANK");
-    if (nullptr != local_rank_str) {
-        return atoi(local_rank_str);
+    // Check launcher-specific env vars in priority order
+    for (const char* var : {"OMPI_COMM_WORLD_LOCAL_RANK",  // Open MPI / prterun
+                             "SLURM_LOCALID",               // SLURM
+                             "FLUX_TASK_LOCAL_ID",          // Flux
+                             "PMIX_LOCAL_RANK",             // PMIx / MPICH
+                             "PBS_O_TASKNUM",               // PBS/Torque
+                             "LOCAL_RANK"}) {               // torchrun / generic
+        const char* v = getenv(var);
+        if (v) return atoi(v);
     }
-
     return -1;
 }
 

--- a/projects/rocshmem/include/rocshmem/rocshmem.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem.hpp
@@ -60,9 +60,12 @@ constexpr char VERSION[] = "3.3.0";
 /******************************************************************************
  **************************** HOST INTERFACE **********************************
  *****************************************************************************/
-#if defined(HAVE_EXTERNAL_MPI)
+#if defined(MPI_VERSION)
 /**
  * @brief Initialize the rocSHMEM runtime and underlying transport layer.
+ *
+ * @note This declaration is only available when @c <mpi.h> is included
+ *       before @c <rocshmem/rocshmem.hpp>.
  *
  * @param[in] comm      MPI Communicator that rocSHMEM will be using
  *                      If MPI_COMM_NULL, rocSHMEM will be using MPI_COMM_WORLD
@@ -126,10 +129,13 @@ __host__ int rocshmem_hipmodule_init(hipModule_t module, hipStream_t stream = nu
 __host__ void* rocshmem_ptr(const void *dest, int pe);
 __device__ ATTR_NO_INLINE void* rocshmem_ptr(const void *dest, int pe);
 
-#if defined(HAVE_EXTERNAL_MPI)
+#if defined(MPI_VERSION)
 /**
  * @brief Initialize the rocSHMEM runtime and underlying transport layer
  *        with an attempt to enable the requested thread support.
+ *
+ * @note This declaration is only available when @c <mpi.h> is included
+ *       before @c <rocshmem/rocshmem.hpp>.
  *
  * @param[in] requested Requested thread mode (from rocshmem_thread_ops)
  *                      for host-facing functions.

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -129,6 +129,156 @@ declare -A TEST_NUMBERS=(
   ["device_bitcode"]="93"
 )
 
+###############################################################################
+# Launcher detection helpers
+###############################################################################
+
+# Returns the launcher family for the given binary:
+#   ompi_like   — Open MPI, prterun (PRRTE), paratool (PBS/OMPI wrapper)
+#   slurm       — srun
+#   mpich_like  — MPICH, Intel MPI, MVAPICH, and any unrecognised mpirun/mpiexec
+#   flux        — Flux
+#   torch       — torchrun
+# For mpirun/mpiexec the brand is inferred from --version output.
+launcher_family() {
+  local launcher="$1"
+  case "$launcher" in
+    prterun|paratool) echo "ompi_like";  return ;;
+    srun)             echo "slurm";      return ;;
+    flux)             echo "flux";       return ;;
+    torchrun)         echo "torch";      return ;;
+  esac
+  # For mpirun/mpiexec (and unknowns) probe --version to determine brand.
+  local ver
+  ver=$("$launcher" --version 2>&1 || true)
+  if echo "$ver" | grep -qi "open.mpi\|openmpi"; then
+    echo "ompi_like"
+  elif echo "$ver" | grep -qi "mpich\|hydra"; then
+    echo "mpich_like"
+  else
+    echo "mpich_like"   # safe default: fewer flags, env inherited
+  fi
+}
+
+# Detect which MPI launcher to use.  Priority:
+#   1. $LAUNCHER env var (user override)
+#   2. Job-scheduler env markers (SLURM_JOB_ID, FLUX_JOB_ID, PBS_JOBID)
+#   3. First launcher found in PATH
+detect_launcher() {
+  if [[ -n "$LAUNCHER" ]]; then
+    echo "$LAUNCHER"
+    return
+  fi
+  if [[ -n "$SLURM_JOB_ID" ]]; then
+    echo "srun"
+    return
+  fi
+  if [[ -n "$FLUX_JOB_ID" ]]; then
+    echo "flux"
+    return
+  fi
+  if [[ -n "$PBS_JOBID" ]]; then
+    command -v mpiexec &>/dev/null && echo "mpiexec" || echo "mpirun"
+    return
+  fi
+  for candidate in mpirun mpiexec prterun paratool torchrun; do
+    command -v "$candidate" &>/dev/null && { echo "$candidate"; return; }
+  done
+  echo "mpirun"
+}
+
+# Populate the array named by $3 with the full launcher command for $n ranks.
+# Switches on the launcher family so the actual launcher binary ($launcher) is
+# always used verbatim — only the surrounding flags depend on the family.
+#
+# Env vars are injected via a POSIX `env VAR=val` prefix captured at call time,
+# with no side-effects on the parent shell across test runs.
+# OMPI-like launchers additionally receive each var via -x VAR=val so that MPI
+# task slots inherit them even when spawned via a separate daemon.
+build_launcher_cmd() {
+  local launcher="$1"
+  local n="$2"
+  local -n _blc_out=$3
+
+  local family
+  family=$(launcher_family "$launcher")
+
+  # Env preamble shared by all families — values captured at call time.
+  local -a _env
+  _env=( env
+         "UCX_ROCM_IPC_SIGPOOL_MAX_ELEMS=16384"
+         "ROCSHMEM_HEAP_SIZE=$HEAP_SIZE"
+         "ROCSHMEM_MAX_NUM_CONTEXTS=$ROCSHMEM_MAX_NUM_CONTEXTS"
+       )
+  [[ -n "$ROCSHMEM_TEST_USE_DEFAULT_STREAM" ]] && _env+=( "ROCSHMEM_TEST_USE_DEFAULT_STREAM=$ROCSHMEM_TEST_USE_DEFAULT_STREAM" )
+  [[ -n "$ROCSHMEM_TEST_UUID" ]] && _env+=( "ROCSHMEM_TEST_UUID=$ROCSHMEM_TEST_UUID" )
+
+  case "$family" in
+    ompi_like)
+      # prterun, paratool, and Open MPI mpirun/mpiexec all accept -mca/-x flags.
+      # Pass env vars explicitly via -x VAR=val so task slots inherit them.
+      _blc_out=( "${_env[@]}"
+                 "$launcher"
+                 -n "$n"
+                 -mca pml "${OMPI_MCA_pml:-ucx}"
+                 -mca osc "${OMPI_MCA_osc:-ucx}"
+                 -x "ROCSHMEM_MAX_NUM_CONTEXTS=$ROCSHMEM_MAX_NUM_CONTEXTS"
+                 -x "UCX_ROCM_IPC_SIGPOOL_MAX_ELEMS=16384"
+                 -x "ROCSHMEM_HEAP_SIZE=$HEAP_SIZE"
+                 ${ROCSHMEM_TEST_USE_DEFAULT_STREAM:+-x "ROCSHMEM_TEST_USE_DEFAULT_STREAM=$ROCSHMEM_TEST_USE_DEFAULT_STREAM"}
+                 ${ROCSHMEM_TEST_UUID:+-x "ROCSHMEM_TEST_UUID=$ROCSHMEM_TEST_UUID"}
+                 ${TIMEOUT:+--timeout "$TIMEOUT"}
+                 ${HOSTFILE:+--hostfile "$HOSTFILE"}
+                 --map-by numa
+               )
+      ;;
+    slurm)
+      _blc_out=( "${_env[@]}" "$launcher"
+                 -n "$n"
+                 ${HOSTFILE:+--nodelist "$HOSTFILE"}
+                 ${TIMEOUT:+--time "$((TIMEOUT/60+1))"}
+               )
+      ;;
+    mpich_like)
+      _blc_out=( "${_env[@]}" "$launcher" -n "$n" ${HOSTFILE:+-f "$HOSTFILE"} )
+      ;;
+    flux)
+      # Flux manages node selection via its scheduler; hostfiles are not accepted.
+      if [[ -n "$HOSTFILE" ]]; then
+        echo "Warning: HOSTFILE is set but flux does not accept a hostfile; ignoring." >&2
+      fi
+      _blc_out=( "${_env[@]}" "$launcher" run -n "$n" ${TIMEOUT:+--time="${TIMEOUT}s"} )
+      ;;
+    torch)
+      # torchrun maps processes as nproc_per_node × nnodes; set
+      # TORCHRUN_NPROC_PER_NODE to match the number of GPUs per node.
+      # Multi-node rendezvous: set TORCHRUN_RDZV_ENDPOINT (host:port reachable
+      # from all nodes) and TORCHRUN_RDZV_ID; when HOSTFILE is set the first
+      # line is used as the rendezvous host.
+      local nproc="${TORCHRUN_NPROC_PER_NODE:-1}"
+      local nnodes=$(( (n + nproc - 1) / nproc ))
+      local rdzv_endpoint="${TORCHRUN_RDZV_ENDPOINT:-}"
+      if [[ -z "$rdzv_endpoint" && -n "$HOSTFILE" ]]; then
+        local _head_node
+        _head_node=$(head -n1 "$HOSTFILE")
+        rdzv_endpoint="${_head_node}:29400"
+      fi
+      rdzv_endpoint="${rdzv_endpoint:-localhost:29400}"
+      local rdzv_id="${TORCHRUN_RDZV_ID:-rocshmem-$$}"
+      _blc_out=( "${_env[@]}" "$launcher"
+                 --nproc-per-node "$nproc"
+                 --nnodes "$nnodes"
+                 --rdzv-backend c10d
+                 --rdzv-endpoint "$rdzv_endpoint"
+                 --rdzv-id "$rdzv_id"
+               )
+      ;;
+    *)
+      _blc_out=( "${_env[@]}" "$launcher" -n "$n" ${HOSTFILE:+--hostfile "$HOSTFILE"} )
+      ;;
+  esac
+}
+
 ExecTest() {
   TEST_NAME=$1
   NUM_RANKS=$2
@@ -166,34 +316,12 @@ ExecTest() {
     ROCSHMEM_MAX_NUM_CONTEXTS=$NUM_WG
   fi
 
-  # MPI Parameters
-  LAUNCHER=mpirun
-
-  if [[ "" != "$ROCSHMEM_TEST_USE_DEFAULT_STREAM" ]]
-  then
-    OPTIONS+=" -x ROCSHMEM_TEST_USE_DEFAULT_STREAM=$ROCSHMEM_TEST_USE_DEFAULT_STREAM"
-  fi
-
-  if [[ "" != "$HOSTFILE" ]]
-  then
-    OPTIONS+=" --hostfile $HOSTFILE"
-  fi
-
-  # Build command as an array to avoid command injection with eval
+  # Detect launcher, resolve its family, and build the command array.
+  local LAUNCHER_BIN LAUNCHER_FAMILY
+  LAUNCHER_BIN=$(detect_launcher)
+  LAUNCHER_FAMILY=$(launcher_family "$LAUNCHER_BIN")
   local -a cmd
-  cmd=( "$LAUNCHER"
-        -n "$NUM_RANKS"
-        -mca pml "${OMPI_MCA_pml:-ucx}"
-        -mca osc "${OMPI_MCA_osc:-ucx}"
-        -x "ROCSHMEM_MAX_NUM_CONTEXTS=$ROCSHMEM_MAX_NUM_CONTEXTS"
-        -x "UCX_ROCM_IPC_SIGPOOL_MAX_ELEMS=16384"
-        -x "ROCSHMEM_HEAP_SIZE=$HEAP_SIZE"
-        ${ROCSHMEM_TEST_USE_DEFAULT_STREAM:+-x "ROCSHMEM_TEST_USE_DEFAULT_STREAM=$ROCSHMEM_TEST_USE_DEFAULT_STREAM"}
-        ${ROCSHMEM_TEST_UUID:+-x "ROCSHMEM_TEST_UUID=$ROCSHMEM_TEST_UUID"}
-        ${TIMEOUT:+--timeout "$TIMEOUT"}
-        ${HOSTFILE:+--hostfile "$HOSTFILE"}
-        --map-by numa
-      )
+  build_launcher_cmd "$LAUNCHER_BIN" "$NUM_RANKS" cmd
   # Construct Test Command
   TEST_LOG_NAME="$TEST_NAME"_n"$NUM_RANKS"_w"$NUM_WG"_z"$NUM_THREADS"
   cmd+=( "$APP" -a "$TEST_NUM" -w "$NUM_WG" -z "$NUM_THREADS" ${NOVERIF:+-noverif} )
@@ -207,8 +335,9 @@ ExecTest() {
     fi
     TEST_LOG_NAME+=_"$MAX_MSG_SIZE"B
   fi
-  # Create a human-readable representation of the command for logging purposes
-  CMD="${cmd[@]}"
+  # Create a shell-quoted representation of the full command for the log header,
+  # including the env VAR=val prefix so the logged line is copy-pasteable.
+  CMD="$(printf '%q ' "${cmd[@]}")"
 
   # Determine log file name based on whether this is a retry
   if [ $IS_RETRY -eq 1 ]; then
@@ -222,7 +351,36 @@ ExecTest() {
   # Run Test
   if [ $NUM_GPUS -ge $NUM_RANKS ] || [[ "" != "$HOSTFILE" ]]; then
     echo "# $CMD >> $LOG_FILE" >"$LOG_FILE"
-    "${cmd[@]}" >>"$LOG_FILE" 2>&1
+    if [[ "$LAUNCHER_FAMILY" == "torch" && -n "$HOSTFILE" ]]; then
+      # torchrun does not SSH to remote hosts itself.  Launch one torchrun
+      # process per host in parallel then wait for all of them.
+      # Requirements: torchrun and the test binary must be in PATH on each host;
+      # the rendezvous port (default 29400) must be open between nodes.
+      # Pre-quote the full command once for use in both branches below.
+      local _cmd_str
+      _cmd_str="$(printf '%q ' "${cmd[@]}")"
+      if command -v pdsh &>/dev/null; then
+        # pdsh fans out to all hosts in parallel; ^FILE reads one host per line.
+        # -N suppresses the per-line hostname prefix so the log is clean.
+        pdsh -N -w ^"$HOSTFILE" bash -c "$_cmd_str" >>"$LOG_FILE" 2>&1
+      else
+        # Fallback: background SSH per host; collect worst exit code.
+        local -a _pids=()
+        local _host _ssh_rc=0
+        while IFS= read -r _host; do
+          [[ -z "$_host" ]] && continue
+          ssh "$_host" "$_cmd_str" >>"$LOG_FILE" 2>&1 &
+          _pids+=($!)
+        done < "$HOSTFILE"
+        for _pid in "${_pids[@]}"; do
+          wait "$_pid" || _ssh_rc=$?
+        done
+        # Propagate worst exit code to $? for the check below.
+        (( _ssh_rc == 0 ))
+      fi
+    else
+      "${cmd[@]}" >>"$LOG_FILE" 2>&1
+    fi
   else
     echo "Skip:   $TEST_LOG_NAME ($NUM_RANKS greater than $NUM_GPUS)"
   fi

--- a/projects/rocshmem/scripts/unit_tests/driver.sh
+++ b/projects/rocshmem/scripts/unit_tests/driver.sh
@@ -54,15 +54,88 @@ timestamp=$(date "+%Y-%m-%d-%H:%M:%S")
 log_file="unit_tests_${timestamp}.log"
 mpi_timeout=$((20 * 60)) # 20 minutes in seconds
 
-# Function to execute mpirun command
+###############################################################################
+# Launcher detection helpers
+###############################################################################
+
+# Returns the launcher family: ompi_like, slurm, mpich_like, flux, torch.
+# For mpirun/mpiexec the brand is inferred from --version output.
+launcher_family() {
+  local launcher="$1"
+  case "$launcher" in
+    prterun|paratool) echo "ompi_like";  return ;;
+    srun)             echo "slurm";      return ;;
+    flux)             echo "flux";       return ;;
+    torchrun)         echo "torch";      return ;;
+  esac
+  local ver
+  ver=$("$launcher" --version 2>&1 || true)
+  if echo "$ver" | grep -qi "open.mpi\|openmpi"; then echo "ompi_like"
+  elif echo "$ver" | grep -qi "mpich\|hydra"; then echo "mpich_like"
+  else echo "mpich_like"; fi
+}
+
+# Detect which MPI launcher to use.
+detect_launcher() {
+  if [[ -n "$LAUNCHER" ]]; then echo "$LAUNCHER"; return; fi
+  if [[ -n "$SLURM_JOB_ID" ]]; then echo "srun"; return; fi
+  if [[ -n "$FLUX_JOB_ID"  ]]; then echo "flux"; return; fi
+  if [[ -n "$PBS_JOBID"    ]]; then
+    command -v mpiexec &>/dev/null && echo "mpiexec" || echo "mpirun"
+    return
+  fi
+  for candidate in mpirun mpiexec prterun paratool torchrun; do
+    command -v "$candidate" &>/dev/null && { echo "$candidate"; return; }
+  done
+  echo "mpirun"
+}
+
+# Function to execute the test under the detected launcher
 function run_mpirun {
     local np=$1
     local gtest_filter=$2
-    cmd_str="mpirun -np $np --timeout $mpi_timeout $binary_name --gtest_filter=$gtest_filter >> $log_file 2>&1"
-    echo $cmd_str
-    eval $cmd_str
 
-    # Test if mpirun failed
+    local launcher family
+    launcher=$(detect_launcher)
+    family=$(launcher_family "$launcher")
+
+    # Env preamble: POSIX `env VAR=val` captures values at call time,
+    # no side effects on the parent shell between test runs.
+    local -a _env
+    _env=( env "UCX_ROCM_IPC_SIGPOOL_MAX_ELEMS=16384" )
+    [[ -n "$ROCSHMEM_TEST_UUID" ]] && _env+=( "ROCSHMEM_TEST_UUID=$ROCSHMEM_TEST_UUID" )
+
+    local -a cmd
+    case "$family" in
+      ompi_like)
+        cmd=( "${_env[@]}" "$launcher" -n "$np" --timeout "$mpi_timeout" )
+        ;;
+      slurm)
+        cmd=( "${_env[@]}" "$launcher" -n "$np" --time "$((mpi_timeout/60+1))" )
+        ;;
+      flux)
+        cmd=( "${_env[@]}" "$launcher" run -n "$np" --time="${mpi_timeout}s" )
+        ;;
+      torch)
+        local nproc="${TORCHRUN_NPROC_PER_NODE:-1}"
+        local nnodes=$(( (np + nproc - 1) / nproc ))
+        cmd=( "${_env[@]}" "$launcher" --nproc-per-node "$nproc" --nnodes "$nnodes" )
+        ;;
+      mpich_like|*)
+        cmd=( "${_env[@]}" "$launcher" -n "$np" )
+        ;;
+    esac
+
+    cmd+=( "$binary_name" "--gtest_filter=$gtest_filter" )
+
+    # Log the full shell-quoted command (including env VAR=val prefix) so it
+    # is visible in the log and can be copy-pasted for manual reproduction.
+    local cmd_str
+    cmd_str="$(printf '%q ' "${cmd[@]}")"
+    echo "$cmd_str"
+    "${cmd[@]}" >> "$log_file" 2>&1
+
+    # Test if the launcher failed
     if [ $? -ne 0 ]
     then
         echo "FAILED: $cmd_str" >&2

--- a/projects/rocshmem/src/mpi_instance.cpp
+++ b/projects/rocshmem/src/mpi_instance.cpp
@@ -95,6 +95,20 @@ int MPIInstance::mpilib_dl_init() {
   DLSYM_HELPER(mpilib_ftable_, MPI_, mpilib_handle_, Fetch_and_op);
 
 #if !defined(HAVE_EXTERNAL_MPI)
+  // Probe one sentinel symbol to confirm the runtime library is Open MPI.
+  // MPICH and other implementations do not export ompi_* globals.
+  // Close and null the handle: ompi_symbols_ is unpopulated so any call
+  // that uses MPI_COMM_WORLD / MPI_INT / … would dereference a null pointer.
+  // Callers that receive MPILIB_INCOMPATIBLE must not invoke any MPI operation.
+  if (!dlsym(mpilib_handle_, "ompi_mpi_comm_world")) {
+    LOG_WARN("libmpi.so is not Open MPI (ompi_mpi_comm_world not found).\n"
+             "  The runtime MPI library is likely MPICH or similar.\n"
+             "  Features and backends that require Open MPI ABI will not load.\n"
+             "");
+    dlclose(mpilib_handle_);
+    mpilib_handle_ = nullptr;
+    return MPIInstance::MPILIB_INCOMPATIBLE;
+  }
   DLSYM_VAR_HELPER(ompi_symbols_, mpilib_handle_, ompi_mpi_comm_world);
   DLSYM_VAR_HELPER(ompi_symbols_, mpilib_handle_, ompi_mpi_comm_null);
   DLSYM_VAR_HELPER(ompi_symbols_, mpilib_handle_, ompi_mpi_datatype_null);

--- a/projects/rocshmem/src/mpi_instance.hpp
+++ b/projects/rocshmem/src/mpi_instance.hpp
@@ -97,6 +97,15 @@ extern struct mpilib_funcs_t mpilib_ftable_;
 class MPIInstance {
   public:
     /**
+     * @brief Return value for mpilib_dl_init() when libmpi.so loaded successfully
+     *        but is not Open MPI ABI (e.g. MPICH, Intel MPI).
+     *        Internal to the library — not part of the public API.
+     *        Backends that require Open MPI will return ROCSHMEM_ERROR from
+     *        backend_can_run(); backends that do not (IPC, GDA) can continue.
+     */
+    static constexpr int MPILIB_INCOMPATIBLE = 2;
+
+    /**
      * @brief Primary constructor
      */
     MPIInstance(MPI_Comm comm);

--- a/projects/rocshmem/src/reverse_offload/backend_ro.cpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.cpp
@@ -141,8 +141,23 @@ int ROBackend::backend_can_run() {
     LOG_TRACE("Could not open libmpi.so");
     return ROCSHMEM_ERROR;
   }
-  //TODO dlsym MPI_Get_library_version and verify compat when HAVE_EXTERNAL_MPI is undef
+#if !defined(HAVE_EXTERNAL_MPI)
+  // When built without a compile-time MPI link, rocSHMEM assumes Open MPI ABI
+  // for all MPI handle constants (MPI_COMM_WORLD, MPI_INT, …).  Probe one
+  // sentinel symbol to confirm the runtime library is actually Open MPI.
+  bool is_ompi = (dlsym(handle, "ompi_mpi_comm_world") != nullptr);
   dlclose(handle);
+  if (!is_ompi) {
+    LOG_WARN("libmpi.so is not Open MPI (ompi_mpi_comm_world not found).\n"
+             "  the RO backend has been built against the Open MPI ABI and cannot run with this MPI library.\n"
+             "");
+    return ROCSHMEM_ERROR;
+  }
+#else
+  // HAVE_EXTERNAL_MPI=ON: the MPI library was verified at link time.
+  // Trust the linker — no runtime brand check needed.
+  dlclose(handle);
+#endif
   return ROCSHMEM_SUCCESS;
 }
 

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -176,9 +176,13 @@ static void setFilesLimit() {
 
   int ret;
   ret = MPIInstance::mpilib_dl_init();
-  if (ret != ROCSHMEM_SUCCESS) {
+  if (ret == MPIInstance::MPILIB_INCOMPATIBLE) {
+    LOG_ERROR_EXIT("MPI library loaded at runtime is not Open MPI but rocSHMEM is compiled for the Open MPI ABI.\n"
+                   "  This initialization method of rocSHMEM requires the MPI library to be loaded at runtime.\n"
+                   "  ");
+  } else if (ret != ROCSHMEM_SUCCESS) {
     LOG_ERROR_EXIT("Could not initialize the MPI library.\n"
-                   "  This initialization method of rocSHMEM requires MPI library to be loaded at runtime.\n"
+                   "  This initialization method of rocSHMEM requires the MPI library to be loaded at runtime.\n"
                    "  ");
   }
 
@@ -246,7 +250,11 @@ static void setFilesLimit() {
 
   int ret;
   ret = MPIInstance::mpilib_dl_init();
-  if (ret != ROCSHMEM_SUCCESS) {
+  if (ret == MPIInstance::MPILIB_INCOMPATIBLE) {
+    LOG_ERROR_EXIT("MPI library loaded at runtime is not Open MPI but rocSHMEM is compiled for the Open MPI ABI.\n"
+                   "  This initialization method of rocSHMEM requires the MPI library to be loaded at runtime.\n"
+                   "  ");
+  } else if (ret != ROCSHMEM_SUCCESS) {
     LOG_ERROR_EXIT("Could not initialize the MPI library.\n"
                    "  This initialization method of rocSHMEM requires MPI library to be loaded at runtime.\n"
                    "  ");
@@ -432,15 +440,17 @@ static void setFilesLimit() {
   return ROCSHMEM_SUCCESS;
 }
 
-#if defined(HAVE_EXTERNAL_MPI)
 [[maybe_unused]] __host__ void rocshmem_init(MPI_Comm comm) {
   library_init(comm);
 }
-#endif
 
 [[maybe_unused]] __host__ void rocshmem_init() {
   auto ret = MPIInstance::mpilib_dl_init();
-  if (ret != ROCSHMEM_SUCCESS) {
+  if (ret == MPIInstance::MPILIB_INCOMPATIBLE) {
+    LOG_ERROR_EXIT("MPI library loaded at runtime is not Open MPI but rocSHMEM is compiled for the Open MPI ABI.\n"
+                   "  This initialization method of rocSHMEM requires the MPI library to be loaded at runtime.\n"
+                   "  ");
+  } else if (ret != ROCSHMEM_SUCCESS) {
     LOG_ERROR_EXIT("Could not initialize the MPI library.\n"
                    "  This initialization method of rocSHMEM requires the MPI library to be loaded at runtime."
                    "  ");
@@ -448,7 +458,6 @@ static void setFilesLimit() {
   library_init(MPI_COMM_WORLD);
 }
 
-#if defined(HAVE_EXTERNAL_MPI)
 [[maybe_unused]] __host__ int rocshmem_init_thread(
     [[maybe_unused]] int required, int *provided, MPI_Comm comm) {
   if (comm == static_cast<MPI_Comm>(0) || comm == MPI_COMM_NULL) {
@@ -459,7 +468,6 @@ static void setFilesLimit() {
 
   return ROCSHMEM_SUCCESS;
 }
-#endif
 
 [[maybe_unused]] __host__ int rocshmem_my_pe() {
   if (backend != nullptr) {

--- a/projects/rocshmem/tests/functional_tests/test_driver.cpp
+++ b/projects/rocshmem/tests/functional_tests/test_driver.cpp
@@ -137,12 +137,30 @@ int main(int argc, char *argv[]) {
   /***
    * Select a GPU
    */
-  char* ompi_local_rank = getenv("OMPI_COMM_WORLD_LOCAL_RANK");
-  if (nullptr == ompi_local_rank) {
-    printf("Could not determine local rank, use Open MPI `mpiexec`\n");
+  // Determine the node-local GPU rank from the job launcher's env vars
+  auto get_local_rank = []() -> int {
+    for (const char* var : {"OMPI_COMM_WORLD_LOCAL_RANK",  // Open MPI / prterun
+                             "SLURM_LOCALID",               // SLURM
+                             "FLUX_TASK_LOCAL_ID",          // Flux
+                             "PMIX_LOCAL_RANK",             // PMIx / MPICH
+                             "PBS_O_TASKNUM",               // PBS/Torque
+                             "LOCAL_RANK"}) {               // torchrun / generic
+      const char* v = getenv(var);
+      if (v) return atoi(v);
+    }
+    return -1;
+  };
+  int local_rank = get_local_rank();
+  if (local_rank < 0) {
+    fprintf(stderr,
+        "Could not determine local GPU rank.\n"
+        "Supported env vars: OMPI_COMM_WORLD_LOCAL_RANK (Open MPI/prterun), "
+        "SLURM_LOCALID (SLURM), FLUX_TASK_LOCAL_ID (Flux), "
+        "PMIX_LOCAL_RANK (PMIx/MPICH), PBS_O_TASKNUM (PBS/Torque), "
+        "LOCAL_RANK (torchrun)\n");
     abort();
   }
-  CHECK_HIP(hipSetDevice(atoi(ompi_local_rank)));
+  CHECK_HIP(hipSetDevice(local_rank));
 
   /**
    * Must initialize rocshmem to access arguments needed by the tester.

--- a/projects/rocshmem/tests/unit_tests/ipc_impl_simple_coarse_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/ipc_impl_simple_coarse_gtest.hpp
@@ -30,7 +30,6 @@
 #include <numeric>
 #include <tuple>
 
-#include <mpi.h>
 #include "../src/memory/symmetric_heap.hpp"
 #include "../src/ipc_policy.hpp"
 

--- a/projects/rocshmem/tests/unit_tests/ipc_impl_simple_fine_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/ipc_impl_simple_fine_gtest.hpp
@@ -28,7 +28,6 @@
 #include "gtest/gtest.h"
 
 #include <numeric>
-#include <mpi.h>
 
 #include "../src/atomic.hpp"
 #include "../src/ipc_policy.hpp"

--- a/projects/rocshmem/tests/unit_tests/ipc_impl_tiled_fine_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/ipc_impl_tiled_fine_gtest.hpp
@@ -28,7 +28,6 @@
 #include "gtest/gtest.h"
 
 #include <numeric>
-#include <mpi.h>
 
 #include "../src/atomic.hpp"
 #include "../src/ipc_policy.hpp"
@@ -194,7 +193,7 @@ class IPCImplTiledFine : public ::testing::TestWithParam<std::tuple<int, int, in
         ipc_impl_.ipcHostStop();
         delete heap_mem_;
         MPIInstance::mpilib_dl_close();
-	delete mpi_;
+        delete mpi_;
     }
 
     void launch(FN_T1 f, const dim3 grid, const dim3 block, int* src, int* dest, size_t bytes, TestType test) {


### PR DESCRIPTION
## Motivation

Parts of rocshmem are specific to Open MPI, while Open MPI remains the only validated variant, add support for other MPIs as well. 
Also requested by contacts at labs. 

## Technical Details

testers and examples can run with non-Open MPI mpiexec/srun/flux/prte/pbs/... 

## JIRA ID

AIROCSHMEM-154

## Test Plan

* [ ] The rock still builds
* [x] All configurations tested for EXTERNAL_MPI=AUTO/ON/OFF with/without MPI_ROOT set
* [ ] compile and run with mpich derivatives

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
