### PR TITLE
[AMD-SMI] Fix BRCM NIC/switch initialization and argument gating

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -88,6 +88,9 @@ class AMDSMICommands(
         self.logger = AMDSMILogger(format=format, destination=destination, helpers=self.helpers)
         self.device_handles = []
         self.device_handles_gpus = []
+        self.device_handles_brcm_nics = []
+        self.device_handles_ainics = []
+        self.device_handles_switchs = []
         self.cpu_handles = []
         self.core_handles = []
         self.node_handle = None
@@ -120,7 +123,7 @@ class AMDSMICommands(
                 )
                 exit_flag = True
 
-        if self.helpers.is_ainic_initialized():
+        if self.helpers.is_ainic_initialized() or self.helpers.is_brcm_nic_initialized():
             try:
                 self.device_handles_brcm_nics = amdsmi_interface.get_nic_handles()
                 self.device_handles_ainics = amdsmi_interface.get_ainic_handles()

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -123,7 +123,11 @@ class AMDSMICommands(
                 )
                 exit_flag = True
 
-        if self.helpers.is_ainic_initialized() or self.helpers.is_brcm_nic_initialized():
+        if (
+            self.helpers.is_ainic_initialized()
+            or self.helpers.is_brcm_nic_initialized()
+            or self.helpers.is_brcm_switch_initialized()
+        ):
             try:
                 self.device_handles_brcm_nics = amdsmi_interface.get_nic_handles()
                 self.device_handles_ainics = amdsmi_interface.get_ainic_handles()

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -96,7 +96,11 @@ class AMDSMICommands:
                 )
                 exit_flag = True
 
-        if self.helpers.is_ainic_initialized() or self.helpers.is_brcm_nic_initialized():
+        if (
+            self.helpers.is_ainic_initialized()
+            or self.helpers.is_brcm_nic_initialized()
+            or self.helpers.is_brcm_switch_initialized()
+        ):
             try:
                 self.device_handles_brcm_nics = amdsmi_interface.get_nic_handles()
                 self.device_handles_ainics = amdsmi_interface.get_ainic_handles()
@@ -6546,7 +6550,12 @@ class AMDSMICommands:
         niccount = 0
         switchcount = 0
 
-        if args.nic == None:
+        # The topology parser conditionally registers --nic / --switch based on
+        # is_brcm_nic_initialized() / is_brcm_switch_initialized(). On hosts
+        # where one is gated off, the corresponding argparse attribute is
+        # absent on the namespace; getattr() guards the unconditional access
+        # below to prevent AttributeError on single-subsystem hosts.
+        if getattr(args, "nic", None) is None:
             args.nic = self.device_handles_brcm_nics
         if not isinstance(args.nic, list):
             args.nic = [args.nic]
@@ -6554,7 +6563,7 @@ class AMDSMICommands:
             is_single_nic_request = True
         niccount = len(args.nic)
 
-        if args.switch is None:
+        if getattr(args, "switch", None) is None:
             args.switch = self.device_handles_switchs
         if not isinstance(args.switch, list):
             args.switch = [args.switch]
@@ -6885,11 +6894,11 @@ class AMDSMICommands:
                 args,
                 multiple_devices,
                 args.gpu,
-                args.nic,
+                getattr(args, "nic", None),
                 args.nic_topo,
                 args.nic_switch,
                 multiple_device_enabled,
-                args.switch,
+                getattr(args, "switch", None),
             )
             return
 

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -61,6 +61,9 @@ class AMDSMICommands:
         self.logger = AMDSMILogger(format=format, destination=destination, helpers=self.helpers)
         self.device_handles = []
         self.device_handles_gpus = []
+        self.device_handles_brcm_nics = []
+        self.device_handles_ainics = []
+        self.device_handles_switchs = []
         self.cpu_handles = []
         self.core_handles = []
         self.node_handle = None
@@ -93,7 +96,7 @@ class AMDSMICommands:
                 )
                 exit_flag = True
 
-        if self.helpers.is_ainic_initialized():
+        if self.helpers.is_ainic_initialized() or self.helpers.is_brcm_nic_initialized():
             try:
                 self.device_handles_brcm_nics = amdsmi_interface.get_nic_handles()
                 self.device_handles_ainics = amdsmi_interface.get_ainic_handles()
@@ -698,7 +701,7 @@ class AMDSMICommands:
         self.logger.output = {}
         self.logger.clear_multiple_devices_output()
 
-        if self.helpers.is_brcm_switch_initialized():
+        if self.helpers.is_brcm_switch_initialized() and args.switch:
             self.list_switch(args, False, switch=args.switch)
 
         self.logger.output = {}
@@ -2483,7 +2486,9 @@ class AMDSMICommands:
         if args.gpu == None:
             args.gpu = self.device_handles
 
-        if self.helpers.is_brcm_nic_initialized() and (args.brcm_nic or brcm_nic):
+        if self.helpers.is_brcm_nic_initialized() and (
+            getattr(args, "brcm_nic", False) or brcm_nic
+        ):
             self.logger.output = {}
             self.logger.clear_multiple_devices_output()
             self.firmware_nic(args, multiple_devices, nic, fw_list)
@@ -5830,7 +5835,9 @@ class AMDSMICommands:
             args.cpu = cpu
         if core:
             args.core = core
-        if self.helpers.is_brcm_nic_initialized() and (args.brcm_nic or brcm_nic):
+        if self.helpers.is_brcm_nic_initialized() and (
+            getattr(args, "brcm_nic", False) or brcm_nic
+        ):
             args.nic_power = args.power
             args.nic_temperature = args.temperature
             args.nic_errors = args.ecc
@@ -5850,7 +5857,9 @@ class AMDSMICommands:
             )
             return
 
-        if self.helpers.is_brcm_switch_initialized() and (args.brcm_switch or brcm_switch):
+        if self.helpers.is_brcm_switch_initialized() and (
+            getattr(args, "brcm_switch", False) or brcm_switch
+        ):
             args.switch_power = args.power
             args.switch_errors = args.ecc
             self.logger.output = {}

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -224,10 +224,20 @@ class AMDSMIHelpers:
         return AMDSMI_INIT_FLAG & amdsmi_interface.amdsmi_wrapper.AMDSMI_INIT_AMD_NICS
 
     def is_brcm_nic_initialized(self):
-        return False
+        if not (AMDSMI_INIT_FLAG & amdsmi_interface.amdsmi_wrapper.AMDSMI_INIT_AMD_NICS):
+            return False
+        try:
+            return len(amdsmi_interface.get_nic_handles()) > 0
+        except amdsmi_interface.AmdSmiLibraryException:
+            return False
 
     def is_brcm_switch_initialized(self):
-        return False
+        if not (AMDSMI_INIT_FLAG & amdsmi_interface.amdsmi_wrapper.AMDSMI_INIT_AMD_NICS):
+            return False
+        try:
+            return len(amdsmi_interface.get_switch_handles()) > 0
+        except amdsmi_interface.AmdSmiLibraryException:
+            return False
 
     def get_rocm_version(self):
         try:
@@ -850,6 +860,7 @@ class AMDSMIHelpers:
                 return False, args.gpu
             else:
                 logging.debug("args.gpu has an empty list")
+                return True, args.gpu
         else:
             return False, args.gpu
 
@@ -890,6 +901,7 @@ class AMDSMIHelpers:
                 return False, args.switch
             else:
                 logging.debug("args.switch has an empty list")
+                return True, args.switch
         else:
             return False, args.switch
 
@@ -930,6 +942,7 @@ class AMDSMIHelpers:
                 return False, args.nic
             else:
                 logging.debug("args.nic has an empty list")
+                return True, args.nic
         else:
             return False, args.nic
 

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -224,20 +224,38 @@ class AMDSMIHelpers:
         return AMDSMI_INIT_FLAG & amdsmi_interface.amdsmi_wrapper.AMDSMI_INIT_AMD_NICS
 
     def is_brcm_nic_initialized(self):
-        if not (AMDSMI_INIT_FLAG & amdsmi_interface.amdsmi_wrapper.AMDSMI_INIT_AMD_NICS):
-            return False
-        try:
-            return len(amdsmi_interface.get_nic_handles()) > 0
-        except amdsmi_interface.AmdSmiLibraryException:
-            return False
+        """Returns True if a Broadcom NIC handle is enumerated.
+
+        The result is cached on first call. The init flag is checked first to
+        short-circuit on systems where no NIC stack was initialized; otherwise
+        a single C-library probe is issued and memoized.
+        """
+        if hasattr(self, "_brcm_nic_initialized_cached"):
+            return self._brcm_nic_initialized_cached
+        result = False
+        if AMDSMI_INIT_FLAG & amdsmi_interface.amdsmi_wrapper.AMDSMI_INIT_AMD_NICS:
+            try:
+                result = len(amdsmi_interface.get_nic_handles()) > 0
+            except amdsmi_interface.AmdSmiLibraryException:
+                result = False
+        self._brcm_nic_initialized_cached = result
+        return result
 
     def is_brcm_switch_initialized(self):
-        if not (AMDSMI_INIT_FLAG & amdsmi_interface.amdsmi_wrapper.AMDSMI_INIT_AMD_NICS):
-            return False
-        try:
-            return len(amdsmi_interface.get_switch_handles()) > 0
-        except amdsmi_interface.AmdSmiLibraryException:
-            return False
+        """Returns True if a Broadcom switch handle is enumerated.
+
+        The result is cached on first call.  See ``is_brcm_nic_initialized``.
+        """
+        if hasattr(self, "_brcm_switch_initialized_cached"):
+            return self._brcm_switch_initialized_cached
+        result = False
+        if AMDSMI_INIT_FLAG & amdsmi_interface.amdsmi_wrapper.AMDSMI_INIT_AMD_NICS:
+            try:
+                result = len(amdsmi_interface.get_switch_handles()) > 0
+            except amdsmi_interface.AmdSmiLibraryException:
+                result = False
+        self._brcm_switch_initialized_cached = result
+        return result
 
     def get_rocm_version(self):
         try:
@@ -983,6 +1001,7 @@ class AMDSMIHelpers:
                 return False, args.nic
             else:
                 logging.debug("args.nic has an empty list")
+                return True, args.nic
         else:
             return False, args.nic
 

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -210,10 +210,20 @@ class AMDSMIHelpers:
         return AMDSMI_INIT_FLAG & amdsmi_interface.amdsmi_wrapper.AMDSMI_INIT_AMD_NICS
 
     def is_brcm_nic_initialized(self):
-        return False
+        if not (AMDSMI_INIT_FLAG & amdsmi_interface.amdsmi_wrapper.AMDSMI_INIT_AMD_NICS):
+            return False
+        try:
+            return len(amdsmi_interface.get_nic_handles()) > 0
+        except amdsmi_interface.AmdSmiLibraryException:
+            return False
 
     def is_brcm_switch_initialized(self):
-        return False
+        if not (AMDSMI_INIT_FLAG & amdsmi_interface.amdsmi_wrapper.AMDSMI_INIT_AMD_NICS):
+            return False
+        try:
+            return len(amdsmi_interface.get_switch_handles()) > 0
+        except amdsmi_interface.AmdSmiLibraryException:
+            return False
 
     def get_rocm_version(self):
         try:
@@ -836,6 +846,7 @@ class AMDSMIHelpers:
                 return False, args.gpu
             else:
                 logging.debug("args.gpu has an empty list")
+                return True, args.gpu
         else:
             return False, args.gpu
 
@@ -876,6 +887,7 @@ class AMDSMIHelpers:
                 return False, args.switch
             else:
                 logging.debug("args.switch has an empty list")
+                return True, args.switch
         else:
             return False, args.switch
 
@@ -916,6 +928,7 @@ class AMDSMIHelpers:
                 return False, args.nic
             else:
                 logging.debug("args.nic has an empty list")
+                return True, args.nic
         else:
             return False, args.nic
 

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -210,20 +210,38 @@ class AMDSMIHelpers:
         return AMDSMI_INIT_FLAG & amdsmi_interface.amdsmi_wrapper.AMDSMI_INIT_AMD_NICS
 
     def is_brcm_nic_initialized(self):
-        if not (AMDSMI_INIT_FLAG & amdsmi_interface.amdsmi_wrapper.AMDSMI_INIT_AMD_NICS):
-            return False
-        try:
-            return len(amdsmi_interface.get_nic_handles()) > 0
-        except amdsmi_interface.AmdSmiLibraryException:
-            return False
+        """Returns True if a Broadcom NIC handle is enumerated.
+
+        The result is cached on first call. The init flag is checked first to
+        short-circuit on systems where no NIC stack was initialized; otherwise
+        a single C-library probe is issued and memoized.
+        """
+        if hasattr(self, "_brcm_nic_initialized_cached"):
+            return self._brcm_nic_initialized_cached
+        result = False
+        if AMDSMI_INIT_FLAG & amdsmi_interface.amdsmi_wrapper.AMDSMI_INIT_AMD_NICS:
+            try:
+                result = len(amdsmi_interface.get_nic_handles()) > 0
+            except amdsmi_interface.AmdSmiLibraryException:
+                result = False
+        self._brcm_nic_initialized_cached = result
+        return result
 
     def is_brcm_switch_initialized(self):
-        if not (AMDSMI_INIT_FLAG & amdsmi_interface.amdsmi_wrapper.AMDSMI_INIT_AMD_NICS):
-            return False
-        try:
-            return len(amdsmi_interface.get_switch_handles()) > 0
-        except amdsmi_interface.AmdSmiLibraryException:
-            return False
+        """Returns True if a Broadcom switch handle is enumerated.
+
+        The result is cached on first call.  See ``is_brcm_nic_initialized``.
+        """
+        if hasattr(self, "_brcm_switch_initialized_cached"):
+            return self._brcm_switch_initialized_cached
+        result = False
+        if AMDSMI_INIT_FLAG & amdsmi_interface.amdsmi_wrapper.AMDSMI_INIT_AMD_NICS:
+            try:
+                result = len(amdsmi_interface.get_switch_handles()) > 0
+            except amdsmi_interface.AmdSmiLibraryException:
+                result = False
+        self._brcm_switch_initialized_cached = result
+        return result
 
     def get_rocm_version(self):
         try:
@@ -969,6 +987,7 @@ class AMDSMIHelpers:
                 return False, args.nic
             else:
                 logging.debug("args.nic has an empty list")
+                return True, args.nic
         else:
             return False, args.nic
 

--- a/projects/amdsmi/amdsmi_cli/amdsmi_init.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_init.py
@@ -96,17 +96,20 @@ def check_amd_ionic_driver():
 def check_brcm_nic_driver():
     """Returns true if bnxt_en is found in the list of initialized modules"""
     status_file = Path("/sys/module/bnxt_en/initstate")
-    if status_file.exists():
-        if status_file.read_text(encoding="ascii").strip() == "live":
-            return True
+    try:
+        if status_file.exists():
+            if status_file.read_text(encoding="ascii").strip() == "live":
+                return True
+    except OSError:
+        return False
     return False
 
 
 def amdsmi_cli_init():
     """Initializes AMDSMI Library for the CLI
 
-    Checks for the presence of the amdgpu, amd_hsmp or hsmp_acpi drivers and initializes the
-    AMD SMI library based on the live drivers found.
+    Probes for the presence of the amdgpu, amd_hsmp/hsmp_acpi, ionic, and bnxt_en
+    drivers and initializes the AMD SMI library based on the live drivers found.
 
     Return:
         init_flag: the flag used to initialize the AMD SMI library without error
@@ -173,7 +176,7 @@ def amdsmi_cli_init():
             or init_flag == 0
         ):
             logging.error(
-                "Drivers not loaded (amdgpu, amd_hsmp, ionic, rdma drivers not found in modules)"
+                "Drivers not loaded (amdgpu, amd_hsmp, ionic, bnxt_en drivers not found in modules)"
             )
             sys.exit(-1)
         else:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_init.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_init.py
@@ -93,6 +93,15 @@ def check_amd_ionic_driver():
     return False
 
 
+def check_brcm_nic_driver():
+    """Returns true if bnxt_en is found in the list of initialized modules"""
+    status_file = Path("/sys/module/bnxt_en/initstate")
+    if status_file.exists():
+        if status_file.read_text(encoding="ascii").strip() == "live":
+            return True
+    return False
+
+
 def amdsmi_cli_init():
     """Initializes AMDSMI Library for the CLI
 
@@ -124,6 +133,9 @@ def amdsmi_cli_init():
         logging.debug("hsmp driver's initstate is live")
     if check_amd_ionic_driver():
         logging.debug("ionic driver's initstate is live")
+        init_flag |= amdsmi_interface.AmdSmiInitFlags.INIT_AMD_NICS
+    if check_brcm_nic_driver():
+        logging.debug("bnxt_en driver's initstate is live")
         init_flag |= amdsmi_interface.AmdSmiInitFlags.INIT_AMD_NICS
 
     _INIT_TIMEOUT_SEC = 60

--- a/projects/amdsmi/amdsmi_cli/amdsmi_init.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_init.py
@@ -95,17 +95,20 @@ def check_amd_ionic_driver():
 def check_brcm_nic_driver():
     """Returns true if bnxt_en is found in the list of initialized modules"""
     status_file = Path("/sys/module/bnxt_en/initstate")
-    if status_file.exists():
-        if status_file.read_text(encoding="ascii").strip() == "live":
-            return True
+    try:
+        if status_file.exists():
+            if status_file.read_text(encoding="ascii").strip() == "live":
+                return True
+    except OSError:
+        return False
     return False
 
 
 def amdsmi_cli_init():
     """Initializes AMDSMI Library for the CLI
 
-    Checks for the presence of the amdgpu, amd_hsmp or hsmp_acpi drivers and initializes the
-    AMD SMI library based on the live drivers found.
+    Probes for the presence of the amdgpu, amd_hsmp/hsmp_acpi, ionic, and bnxt_en
+    drivers and initializes the AMD SMI library based on the live drivers found.
 
     Return:
         init_flag: the flag used to initialize the AMD SMI library without error
@@ -145,7 +148,7 @@ def amdsmi_cli_init():
             or init_flag == 0
         ):
             logging.error(
-                "Drivers not loaded (amdgpu, amd_hsmp, ionic, rdma drivers not found in modules)"
+                "Drivers not loaded (amdgpu, amd_hsmp, ionic, bnxt_en drivers not found in modules)"
             )
             sys.exit(-1)
         else:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_init.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_init.py
@@ -92,6 +92,15 @@ def check_amd_ionic_driver():
     return False
 
 
+def check_brcm_nic_driver():
+    """Returns true if bnxt_en is found in the list of initialized modules"""
+    status_file = Path("/sys/module/bnxt_en/initstate")
+    if status_file.exists():
+        if status_file.read_text(encoding="ascii").strip() == "live":
+            return True
+    return False
+
+
 def amdsmi_cli_init():
     """Initializes AMDSMI Library for the CLI
 
@@ -115,6 +124,9 @@ def amdsmi_cli_init():
         logging.debug("hsmp driver's initstate is live")
     if check_amd_ionic_driver():
         logging.debug("ionic driver's initstate is live")
+        init_flag |= amdsmi_interface.AmdSmiInitFlags.INIT_AMD_NICS
+    if check_brcm_nic_driver():
+        logging.debug("bnxt_en driver's initstate is live")
         init_flag |= amdsmi_interface.AmdSmiInitFlags.INIT_AMD_NICS
 
     try:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -137,10 +137,13 @@ class AMDSMIParser(argparse.ArgumentParser):
         # Get choices based on driver initialized
         if self.helpers.is_amdgpu_initialized():
             self.gpu_choices, self.gpu_choices_str = self.helpers.get_gpu_choices()
-            self.switch_choices, self.switch_choices_str = self.helpers.get_switch_choices()
         else:
             self.gpu_choices = {}
             self.gpu_choices_str = ""
+
+        if self.helpers.is_brcm_switch_initialized():
+            self.switch_choices, self.switch_choices_str = self.helpers.get_switch_choices()
+        else:
             self.switch_choices = {}
             self.switch_choices_str = ""
 
@@ -1739,8 +1742,6 @@ class AMDSMIParser(argparse.ArgumentParser):
 
         # Add Universal Arguments
         self._add_device_arguments(firmware_parser, required=False)
-        if self.helpers.is_brcm_nic_initialized():
-            self._add_brcm_nic_device_arguments(firmware_parser, nicMandatory=True, required=False)
         self._add_command_modifiers(firmware_parser)
 
     def _add_bad_pages_parser(self, subparsers: argparse._SubParsersAction, func):
@@ -2206,6 +2207,20 @@ class AMDSMIParser(argparse.ArgumentParser):
                 action="store_true",
                 required=False,
                 help=core_eff_floor_limit_help,
+            )
+
+        # Add BRCM NIC/Switch Arguments
+        if self.helpers.is_brcm_nic_initialized():
+            metric_parser.add_argument(
+                "-nic", "--brcm_nic", action="store_true", required=False, help=nic_metric_help
+            )
+        if self.helpers.is_brcm_switch_initialized():
+            metric_parser.add_argument(
+                "-switch",
+                "--brcm_switch",
+                action="store_true",
+                required=False,
+                help=switch_metric_help,
             )
 
         # Add Universal Arguments & watch Args
@@ -3077,7 +3092,6 @@ class AMDSMIParser(argparse.ArgumentParser):
         monitor_parser.add_argument(
             "-q", "--process", action="store_true", required=False, help=process_help
         )
-
         if self.helpers.is_brcm_nic_initialized():
             monitor_parser.add_argument(
                 "-nic", "--brcm_nic", action="store_true", required=False, help=nic_monitor_help
@@ -3105,12 +3119,6 @@ class AMDSMIParser(argparse.ArgumentParser):
         # Add Universal Arguments & Watch Args
         self._add_watch_arguments(monitor_parser)
         self._add_device_arguments(monitor_parser, required=False)
-        if self.helpers.is_brcm_nic_initialized():
-            self._add_brcm_nic_device_arguments(monitor_parser, nicMandatory=True, required=False)
-        if self.helpers.is_brcm_switch_initialized():
-            self._add_brcm_switch_device_arguments(
-                monitor_parser, switchMandatory=True, required=False
-            )
         self._add_command_modifiers(monitor_parser)
 
     def _add_xgmi_parser(self, subparsers: argparse._SubParsersAction, func):

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -1364,41 +1364,6 @@ class AMDSMIParser(argparse.ArgumentParser):
                 help=switch_help,
             )
 
-    def _add_brcm_nic_device_arguments(
-        self, subcommand_parser: argparse.ArgumentParser, nicMandatory=False, required=False
-    ):
-        # Device arguments help text
-        nic_help = (
-            f"Select a NIC ID, BDF, or UUID from the possible choices:\n{self.nic_choices_str}"
-        )
-        if nicMandatory:
-            nic_help = f"Select a NIC ID, BDF, or UUID from the possible choices:\n {self.nic_choices_str} Note: -nic, --brcm_nic is mandatory argument for this option.\n"
-        # Mutually Exclusive Args within the subparser
-        device_args = subcommand_parser.add_mutually_exclusive_group(required=required)
-
-        device_args.add_argument(
-            "-N", "--nic", action=self._nic_select(self.nic_choices), nargs="+", help=nic_help
-        )
-
-    def _add_brcm_switch_device_arguments(
-        self, subcommand_parser: argparse.ArgumentParser, switchMandatory=False, required=False
-    ):
-        # Device arguments help text
-        switch_help = f"Select a SWITCH ID, BDF, or UUID from the possible choices:\n{self.switch_choices_str}"
-        if switchMandatory:
-            switch_help = f"Select a SWITCH ID, BDF, or UUID from the possible choices:\n{self.switch_choices_str} Note: -switch, --brcm_switch is mandatory argument for this option.\n"
-
-        # Mutually Exclusive Args within the subparser
-        device_args = subcommand_parser.add_mutually_exclusive_group(required=required)
-
-        device_args.add_argument(
-            "-bs",
-            "--switch",
-            action=self._switch_select(self.switch_choices),
-            nargs="+",
-            help=switch_help,
-        )
-
     def _add_command_modifiers(self, subcommand_parser: argparse.ArgumentParser):
         json_help = "Displays output in JSON format"
         csv_help = "Displays output in CSV format"
@@ -1707,7 +1672,7 @@ class AMDSMIParser(argparse.ArgumentParser):
 
         # Optional arguments help text
         fw_list_help = "All FW list information"
-        nic_firmware_help = "BRCM NIC devices's Firmware attributes"
+        nic_firmware_help = "Broadcom NIC firmware attributes"
         err_records_help = "All error records information"
 
         # Create firmware subparser
@@ -1792,7 +1757,7 @@ class AMDSMIParser(argparse.ArgumentParser):
 
     def _add_metric_parser(self, subparsers: argparse._SubParsersAction, func):
         # Subparser help text
-        metric_help = "Gets metric/performance information about the specified GPU"
+        metric_help = "Gets metric/performance information about the specified GPU, NIC, or switch"
         metric_subcommand_help = f"{self.description}\n\nIf no GPU is specified, returns metric information for all GPUs on the system.\
                                 \nIf no metric argument is provided, all metric information will be displayed."
         metric_optionals_title = "Metric arguments"
@@ -1802,8 +1767,8 @@ class AMDSMIParser(argparse.ArgumentParser):
 
         # Help text for Arguments only Available on Linux Virtual OS and Baremetal platforms
         mem_usage_help = "Memory usage per block"
-        nic_metric_help = "Broadcom NIC's metrics attributes"
-        switch_metric_help = "Broadcom SWITCH's metrics attributes"
+        nic_metric_help = "Broadcom NIC metric attributes"
+        switch_metric_help = "Broadcom switch metric attributes"
 
         # Help text for Arguments only on Hypervisor and Baremetal platforms
         power_help = "Current power usage"
@@ -3034,8 +2999,8 @@ class AMDSMIParser(argparse.ArgumentParser):
         ecc_help = "Monitor ECC single bit, ECC double bit, and PCIe replay error counts"
         mem_usage_help = "Monitor memory usage in MB"
         pcie_bandwidth_help = "Monitor PCIe bandwidth in Mb/s"
-        nic_monitor_help = "BRCM NIC devices's Monitor attributes"
-        switch_monitor_help = "BRCM Switch devices's Monitor attributes"
+        nic_monitor_help = "Broadcom NIC monitor attributes"
+        switch_monitor_help = "Broadcom switch monitor attributes"
         process_help = "Enable Process information table below monitor output;\n    Process Name may require elevated permissions"
         violation_help = "Monitor power and thermal violation status (%%);\n    Only available for MI300 or newer ASICs"
 

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -1357,7 +1357,6 @@ class AMDSMIParser(argparse.ArgumentParser):
         if self.helpers.is_brcm_switch_initialized():
             switch_help = f"Select a SWITCH ID, BDF, or UUID from the possible choices:\n{self.switch_choices_str}"
             device_args.add_argument(
-                "-bs",
                 "--switch",
                 action=self._switch_select(self.switch_choices),
                 nargs="+",
@@ -1696,7 +1695,7 @@ class AMDSMIParser(argparse.ArgumentParser):
         )
         if self.helpers.is_brcm_nic_initialized():
             firmware_parser.add_argument(
-                "-nic", "--brcm_nic", action="store_true", required=False, help=nic_firmware_help
+                "--brcm_nic", action="store_true", required=False, help=nic_firmware_help
             )
 
         # Options to only display on a Hypervisor
@@ -2177,15 +2176,11 @@ class AMDSMIParser(argparse.ArgumentParser):
         # Add BRCM NIC/Switch Arguments
         if self.helpers.is_brcm_nic_initialized():
             metric_parser.add_argument(
-                "-nic", "--brcm_nic", action="store_true", required=False, help=nic_metric_help
+                "--brcm_nic", action="store_true", required=False, help=nic_metric_help
             )
         if self.helpers.is_brcm_switch_initialized():
             metric_parser.add_argument(
-                "-switch",
-                "--brcm_switch",
-                action="store_true",
-                required=False,
-                help=switch_metric_help,
+                "--brcm_switch", action="store_true", required=False, help=switch_metric_help
             )
 
         # Add Universal Arguments & watch Args
@@ -2375,15 +2370,11 @@ class AMDSMIParser(argparse.ArgumentParser):
         )
         if self.helpers.is_brcm_nic_initialized():
             topology_parser.add_argument(
-                "-nic", "--nic_topo", action="store_true", required=False, help=nic_topo_help
+                "--nic_topo", action="store_true", required=False, help=nic_topo_help
             )
         if self.helpers.is_brcm_switch_initialized():
             topology_parser.add_argument(
-                "-nic_switch",
-                "--nic_switch",
-                action="store_true",
-                required=False,
-                help=nic_shownuma_help,
+                "--nic_switch", action="store_true", required=False, help=nic_shownuma_help
             )
 
     def _add_set_value_parser(self, subparsers: argparse._SubParsersAction, func):
@@ -3059,15 +3050,11 @@ class AMDSMIParser(argparse.ArgumentParser):
         )
         if self.helpers.is_brcm_nic_initialized():
             monitor_parser.add_argument(
-                "-nic", "--brcm_nic", action="store_true", required=False, help=nic_monitor_help
+                "--brcm_nic", action="store_true", required=False, help=nic_monitor_help
             )
         if self.helpers.is_brcm_switch_initialized():
             monitor_parser.add_argument(
-                "-switch",
-                "--brcm_switch",
-                action="store_true",
-                required=False,
-                help=switch_monitor_help,
+                "--brcm_switch", action="store_true", required=False, help=switch_monitor_help
             )
         if not self.helpers.is_virtual_os():
             monitor_parser.add_argument(

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -136,10 +136,13 @@ class AMDSMIParser(argparse.ArgumentParser):
         # Get choices based on driver initialized
         if self.helpers.is_amdgpu_initialized():
             self.gpu_choices, self.gpu_choices_str = self.helpers.get_gpu_choices()
-            self.switch_choices, self.switch_choices_str = self.helpers.get_switch_choices()
         else:
             self.gpu_choices = {}
             self.gpu_choices_str = ""
+
+        if self.helpers.is_brcm_switch_initialized():
+            self.switch_choices, self.switch_choices_str = self.helpers.get_switch_choices()
+        else:
             self.switch_choices = {}
             self.switch_choices_str = ""
 
@@ -1734,8 +1737,6 @@ class AMDSMIParser(argparse.ArgumentParser):
 
         # Add Universal Arguments
         self._add_device_arguments(firmware_parser, required=False)
-        if self.helpers.is_brcm_nic_initialized():
-            self._add_brcm_nic_device_arguments(firmware_parser, nicMandatory=True, required=False)
         self._add_command_modifiers(firmware_parser)
 
     def _add_bad_pages_parser(self, subparsers: argparse._SubParsersAction, func):
@@ -2201,6 +2202,20 @@ class AMDSMIParser(argparse.ArgumentParser):
                 action="store_true",
                 required=False,
                 help=core_eff_floor_limit_help,
+            )
+
+        # Add BRCM NIC/Switch Arguments
+        if self.helpers.is_brcm_nic_initialized():
+            metric_parser.add_argument(
+                "-nic", "--brcm_nic", action="store_true", required=False, help=nic_metric_help
+            )
+        if self.helpers.is_brcm_switch_initialized():
+            metric_parser.add_argument(
+                "-switch",
+                "--brcm_switch",
+                action="store_true",
+                required=False,
+                help=switch_metric_help,
             )
 
         # Add Universal Arguments & watch Args
@@ -3054,7 +3069,6 @@ class AMDSMIParser(argparse.ArgumentParser):
         monitor_parser.add_argument(
             "-q", "--process", action="store_true", required=False, help=process_help
         )
-
         if self.helpers.is_brcm_nic_initialized():
             monitor_parser.add_argument(
                 "-nic", "--brcm_nic", action="store_true", required=False, help=nic_monitor_help
@@ -3075,12 +3089,6 @@ class AMDSMIParser(argparse.ArgumentParser):
         # Add Universal Arguments & Watch Args
         self._add_watch_arguments(monitor_parser)
         self._add_device_arguments(monitor_parser, required=False)
-        if self.helpers.is_brcm_nic_initialized():
-            self._add_brcm_nic_device_arguments(monitor_parser, nicMandatory=True, required=False)
-        if self.helpers.is_brcm_switch_initialized():
-            self._add_brcm_switch_device_arguments(
-                monitor_parser, switchMandatory=True, required=False
-            )
         self._add_command_modifiers(monitor_parser)
 
     def _add_xgmi_parser(self, subparsers: argparse._SubParsersAction, func):

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -1359,41 +1359,6 @@ class AMDSMIParser(argparse.ArgumentParser):
                 help=switch_help,
             )
 
-    def _add_brcm_nic_device_arguments(
-        self, subcommand_parser: argparse.ArgumentParser, nicMandatory=False, required=False
-    ):
-        # Device arguments help text
-        nic_help = (
-            f"Select a NIC ID, BDF, or UUID from the possible choices:\n{self.nic_choices_str}"
-        )
-        if nicMandatory:
-            nic_help = f"Select a NIC ID, BDF, or UUID from the possible choices:\n {self.nic_choices_str} Note: -nic, --brcm_nic is mandatory argument for this option.\n"
-        # Mutually Exclusive Args within the subparser
-        device_args = subcommand_parser.add_mutually_exclusive_group(required=required)
-
-        device_args.add_argument(
-            "-N", "--nic", action=self._nic_select(self.nic_choices), nargs="+", help=nic_help
-        )
-
-    def _add_brcm_switch_device_arguments(
-        self, subcommand_parser: argparse.ArgumentParser, switchMandatory=False, required=False
-    ):
-        # Device arguments help text
-        switch_help = f"Select a SWITCH ID, BDF, or UUID from the possible choices:\n{self.switch_choices_str}"
-        if switchMandatory:
-            switch_help = f"Select a SWITCH ID, BDF, or UUID from the possible choices:\n{self.switch_choices_str} Note: -switch, --brcm_switch is mandatory argument for this option.\n"
-
-        # Mutually Exclusive Args within the subparser
-        device_args = subcommand_parser.add_mutually_exclusive_group(required=required)
-
-        device_args.add_argument(
-            "-bs",
-            "--switch",
-            action=self._switch_select(self.switch_choices),
-            nargs="+",
-            help=switch_help,
-        )
-
     def _add_command_modifiers(self, subcommand_parser: argparse.ArgumentParser):
         json_help = "Displays output in JSON format"
         csv_help = "Displays output in CSV format"
@@ -1702,7 +1667,7 @@ class AMDSMIParser(argparse.ArgumentParser):
 
         # Optional arguments help text
         fw_list_help = "All FW list information"
-        nic_firmware_help = "BRCM NIC devices's Firmware attributes"
+        nic_firmware_help = "Broadcom NIC firmware attributes"
         err_records_help = "All error records information"
 
         # Create firmware subparser
@@ -1787,7 +1752,7 @@ class AMDSMIParser(argparse.ArgumentParser):
 
     def _add_metric_parser(self, subparsers: argparse._SubParsersAction, func):
         # Subparser help text
-        metric_help = "Gets metric/performance information about the specified GPU"
+        metric_help = "Gets metric/performance information about the specified GPU, NIC, or switch"
         metric_subcommand_help = f"{self.description}\n\nIf no GPU is specified, returns metric information for all GPUs on the system.\
                                 \nIf no metric argument is provided, all metric information will be displayed."
         metric_optionals_title = "Metric arguments"
@@ -1797,8 +1762,8 @@ class AMDSMIParser(argparse.ArgumentParser):
 
         # Help text for Arguments only Available on Linux Virtual OS and Baremetal platforms
         mem_usage_help = "Memory usage per block"
-        nic_metric_help = "Broadcom NIC's metrics attributes"
-        switch_metric_help = "Broadcom SWITCH's metrics attributes"
+        nic_metric_help = "Broadcom NIC metric attributes"
+        switch_metric_help = "Broadcom switch metric attributes"
 
         # Help text for Arguments only on Hypervisor and Baremetal platforms
         power_help = "Current power usage"
@@ -3011,8 +2976,8 @@ class AMDSMIParser(argparse.ArgumentParser):
         ecc_help = "Monitor ECC single bit, ECC double bit, and PCIe replay error counts"
         mem_usage_help = "Monitor memory usage in MB"
         pcie_bandwidth_help = "Monitor PCIe bandwidth in Mb/s"
-        nic_monitor_help = "BRCM NIC devices's Monitor attributes"
-        switch_monitor_help = "BRCM Switch devices's Monitor attributes"
+        nic_monitor_help = "Broadcom NIC monitor attributes"
+        switch_monitor_help = "Broadcom switch monitor attributes"
         process_help = "Enable Process information table below monitor output;\n    Process Name may require elevated permissions"
         violation_help = "Monitor power and thermal violation status (%%);\n    Only available for MI300 or newer ASICs"
 

--- a/projects/amdsmi/amdsmi_cli/subcommands/firmware.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/firmware.py
@@ -101,7 +101,9 @@ class FirmwareCommands:
         if args.gpu == None:
             args.gpu = self.device_handles
 
-        if self.helpers.is_brcm_nic_initialized() and (args.brcm_nic or brcm_nic):
+        if self.helpers.is_brcm_nic_initialized() and (
+            getattr(args, "brcm_nic", False) or brcm_nic
+        ):
             self.logger.output = {}
             self.logger.clear_multiple_devices_output()
             self.firmware_nic(args, multiple_devices, nic, fw_list)

--- a/projects/amdsmi/amdsmi_cli/subcommands/list_devices.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/list_devices.py
@@ -427,7 +427,7 @@ class ListDevicesCommands:
         self.logger.output = {}
         self.logger.clear_multiple_devices_output()
 
-        if self.helpers.is_brcm_switch_initialized():
+        if self.helpers.is_brcm_switch_initialized() and args.switch:
             self.list_switch(args, False, switch=args.switch)
 
         self.logger.output = {}

--- a/projects/amdsmi/amdsmi_cli/subcommands/metric.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/metric.py
@@ -3142,7 +3142,9 @@ class MetricCommands:
             args.cpu = cpu
         if core:
             args.core = core
-        if self.helpers.is_brcm_nic_initialized() and (args.brcm_nic or brcm_nic):
+        if self.helpers.is_brcm_nic_initialized() and (
+            getattr(args, "brcm_nic", False) or brcm_nic
+        ):
             args.nic_power = args.power
             args.nic_temperature = args.temperature
             args.nic_errors = args.ecc
@@ -3162,7 +3164,9 @@ class MetricCommands:
             )
             return
 
-        if self.helpers.is_brcm_switch_initialized() and (args.brcm_switch or brcm_switch):
+        if self.helpers.is_brcm_switch_initialized() and (
+            getattr(args, "brcm_switch", False) or brcm_switch
+        ):
             args.switch_power = args.power
             args.switch_errors = args.ecc
             self.logger.output = {}

--- a/projects/amdsmi/amdsmi_cli/subcommands/topology.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/topology.py
@@ -410,16 +410,21 @@ class TopologyCommands:
             args.nic = nic
         if switch:
             args.switch = switch
-        if (self.helpers.is_brcm_nic_initialized() and (nic_topo or args.nic_topo)) or (
-            self.helpers.is_brcm_switch_initialized() and (nic_switch or args.nic_switch)
+        # nic_topo / nic_switch are only registered on the parser when their
+        # respective subsystem is initialized, so guard every namespace access
+        # with getattr() to stay safe on single-subsystem hosts.
+        nic_topo_req = getattr(args, "nic_topo", False)
+        nic_switch_req = getattr(args, "nic_switch", False)
+        if (self.helpers.is_brcm_nic_initialized() and (nic_topo or nic_topo_req)) or (
+            self.helpers.is_brcm_switch_initialized() and (nic_switch or nic_switch_req)
         ):
             self.topology_nic(
                 args,
                 multiple_devices,
                 args.gpu,
                 getattr(args, "nic", None),
-                args.nic_topo,
-                args.nic_switch,
+                nic_topo_req,
+                nic_switch_req,
                 multiple_device_enabled,
                 getattr(args, "switch", None),
             )

--- a/projects/amdsmi/amdsmi_cli/subcommands/topology.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/topology.py
@@ -73,7 +73,12 @@ class TopologyCommands:
         niccount = 0
         switchcount = 0
 
-        if args.nic == None:
+        # The topology parser conditionally registers --nic / --switch based on
+        # is_brcm_nic_initialized() / is_brcm_switch_initialized(). On hosts
+        # where one is gated off, the corresponding argparse attribute is
+        # absent on the namespace; getattr() guards the unconditional access
+        # below to prevent AttributeError on single-subsystem hosts.
+        if getattr(args, "nic", None) is None:
             args.nic = self.device_handles_brcm_nics
         if not isinstance(args.nic, list):
             args.nic = [args.nic]
@@ -81,7 +86,7 @@ class TopologyCommands:
             is_single_nic_request = True
         niccount = len(args.nic)
 
-        if args.switch is None:
+        if getattr(args, "switch", None) is None:
             args.switch = self.device_handles_switchs
         if not isinstance(args.switch, list):
             args.switch = [args.switch]
@@ -412,11 +417,11 @@ class TopologyCommands:
                 args,
                 multiple_devices,
                 args.gpu,
-                args.nic,
+                getattr(args, "nic", None),
                 args.nic_topo,
                 args.nic_switch,
                 multiple_device_enabled,
-                args.switch,
+                getattr(args, "switch", None),
             )
             return
 

--- a/projects/amdsmi/amdsmi_cli/subcommands/topology.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/topology.py
@@ -66,7 +66,7 @@ class TopologyCommands:
             self.group_check_printed = True
 
         is_single_nic_request = False  # -N option
-        is_single_switch_request = False  # -bs option
+        is_single_switch_request = False  # --switch option
         is_single_gpu_request = False  # -g option
 
         gpucount = 0

--- a/projects/amdsmi/tests/python_unittest/cli_unit_test.py
+++ b/projects/amdsmi/tests/python_unittest/cli_unit_test.py
@@ -761,12 +761,19 @@ class TestAmdSmiCli(unittest.TestCase):
         # Find all available command line args
         cmd_args = []
         found = False
+        subcommand_indent = None
         for line in lines:
             if found:
                 if not line:
                     break
-                items = line.split()
-                cmd_args.append(items[0])
+                leading = len(line) - len(line.lstrip())
+                # Record the indentation of the first subcommand line and only
+                # accept lines at that same level (skip wrapped description text)
+                if subcommand_indent is None:
+                    subcommand_indent = leading
+                if leading == subcommand_indent:
+                    items = line.split()
+                    cmd_args.append(items[0])
                 continue
             if "Descriptions" in line:
                 found = True


### PR DESCRIPTION
- Add check_brcm_nic_driver() for bnxt_en kernel module detection
- Fix is_brcm_nic/switch_initialized() to check actual device handles
  instead of only the init flag (prevents false positives on AINIC-only
  systems)
- Gate --brcm_nic/--brcm_switch args in monitor, metric, firmware,
  topology parsers behind hardware detection
- Move switch_choices from is_amdgpu_initialized to
  is_brcm_switch_initialized guard
- Add missing --brcm_nic/--brcm_switch args to metric parser
- Remove duplicate _add_brcm_nic/switch_device_arguments calls that
  caused argparse conflicts on BRCM systems
- Add default empty lists for device_handles_brcm_nics,
  device_handles_ainics, device_handles_switchs in AMDSMICommands init
- Expand NIC handle init guard to include is_brcm_nic_initialized()
- Use getattr() for safe args.brcm_nic/brcm_switch access in command
  handlers
- Fix handle_gpus/switchs/brcm_nics missing return on empty list branch
- Guard list_switch call against empty switch list
