### PR TITLE
[rocprofiler-compute] harden shared counter parsing and sets validator

### DIFF
--- a/projects/rocprofiler-compute/src/utils/utils_counter_defs.py
+++ b/projects/rocprofiler-compute/src/utils/utils_counter_defs.py
@@ -3,44 +3,82 @@
 
 """Shared counter definitions for HW performance counter parsing.
 
-This module is intentionally dependency-free (only ``re``) so that it can be
-imported by both the main runtime code and lightweight tooling such as
-``tools/validate_sets_metric_ids.py``.
+This module is the single source of truth for three closely related concerns
+that used to be hand-copied between :mod:`rocprof_compute_soc.soc_base` and
+``tools/validate_sets_metric_ids.py``:
+
+1. The set of hardware block names referenced by any arch's
+   ``perfmon_config`` in ``src/utils/mi_gpu_spec.yaml`` — ``BLOCK_NAMES`` is
+   derived from the YAML, so adding a new arch or block updates the regex
+   automatically.
+
+2. The aggregator-suffix grammar (``_sum``, ``_avr``, ``_max``, ``_min``) and
+   the TCC channel-template marker produced when a formula references
+   ``TCC_HIT[0]``/``TCC_HIT[1]``/... — downstream code in
+   :func:`rocprof_compute_soc.soc_base.OmniSoC_Base._expand_tcc_template_counters`
+   expands the template into per-channel counters.
+
+3. The ``SQC``/``SP`` → ``SQ`` remap used by
+   :meth:`rocprof_compute_soc.soc_base.CounterFile.add` when packing counters
+   into PMC perfmon files.
+
+Importing this module reads ``mi_gpu_spec.yaml`` once (cached). No logging.
 """
 
 from __future__ import annotations
 
 import re
+from functools import lru_cache
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    # For type-checking, treat yaml as the standard PyYAML shape (resolved
+    # against types-pyyaml). At runtime, the vendored copy wins when the
+    # profile-mode stdlib guard is active; otherwise we fall back to the
+    # system yaml. Both code paths expose the same :func:`safe_load` surface.
+    import yaml
+else:  # pragma: no cover - resolved once at import time
+    try:
+        from vendored import yaml
+    except ImportError:
+        import yaml
+
+_PROJECT_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
+_GPU_SPEC_PATH: Final[Path] = _PROJECT_ROOT / "src" / "utils" / "mi_gpu_spec.yaml"
 
 # ---------------------------------------------------------------------------
-# Regex patterns for HW counter and variable extraction
+# Aggregator suffixes, synthetic counters, block remap
 # ---------------------------------------------------------------------------
 
-# HW counter name must start with an IP block prefix, followed by an
-# underscore-separated suffix of uppercase letters/digits, optionally
-# ending with '[' or an aggregation suffix (_sum, _avr, _max, _min).
-HW_COUNTER_BLK = (
-    r"(?:SQ|SQC|SP|TA|TD|TCP|TCC|GL1A|GL1C|GL2A|GL2C|"
-    r"CPC|CPF|SPI|GCEA|GRBM)"
-)
-HW_COUNTER_SFX = r"_[0-9A-Z_]*[0-9A-Z](?:\[|_sum|_avr|_max|_min)*"
-HW_COUNTER_RE = re.compile(HW_COUNTER_BLK + HW_COUNTER_SFX)
+# Aggregator suffixes that can trail a counter name inside a formula.
+AGGREGATOR_SUFFIXES: Final[tuple[str, ...]] = ("_sum", "_avr", "_max", "_min")
 
-# Captures the variable name after '$'.
-VARIABLE_RE = re.compile(r"\$([0-9A-Za-z_]*[0-9A-Za-z])")
+# Counters whose block name is keyed to another block for perfmon packing.
+# ``SQC`` and ``SP`` counters share the ``SQ`` budget; see
+# :meth:`rocprof_compute_soc.soc_base.CounterFile.add`.
+BLOCK_REMAP: Final[dict[str, str]] = {"SQC": "SQ", "SP": "SQ"}
+
+# ``SQ_ACCUM_PREV_HIRES`` is a synthetic counter injected separately for
+# level counters (see :meth:`OmniSoC_Base.perfmon_filter`); not a real PMC
+# counter and must be filtered out of extractor results.
+SYNTHETIC_COUNTERS: Final[frozenset[str]] = frozenset({"SQ_ACCUM_PREV_HIRES"})
+
 
 # ---------------------------------------------------------------------------
 # Built-in variable and denominator definitions
 # ---------------------------------------------------------------------------
 
-SUPPORTED_DENOM: dict[str, str] = {
+SUPPORTED_DENOM: Final[dict[str, str]] = {
     "per_wave": "SQ_WAVES",
     "per_cycle": "$GRBM_GUI_ACTIVE_PER_XCD",
     "per_second": "((End_Timestamp - Start_Timestamp) / 1000000000)",
     "per_kernel": "1",
 }
 
-BUILD_IN_VARS: dict[str, str] = {
+BUILD_IN_VARS: Final[dict[str, str]] = {
     "GRBM_GUI_ACTIVE_PER_XCD": "(GRBM_GUI_ACTIVE / $num_xcd)",
     "GRBM_COUNT_PER_XCD": "(GRBM_COUNT / $num_xcd)",
     "GRBM_SPI_BUSY_PER_XCD": "(GRBM_SPI_BUSY / $num_xcd)",
@@ -56,15 +94,202 @@ BUILD_IN_VARS: dict[str, str] = {
     "hbmBandwidth": "($max_mclk / 1000 * 32 * $num_hbm_channels)",
 }
 
-# ---------------------------------------------------------------------------
-# Block remapping — SQC and SP counters belong to the SQ IP block
-# ---------------------------------------------------------------------------
-
-BLOCK_REMAP: dict[str, str] = {"SQC": "SQ", "SP": "SQ"}
-
 
 # ---------------------------------------------------------------------------
-# Stateless counter-parsing helpers
+# YAML traversal helpers (shared between BLOCK_NAMES discovery and
+# perfmon-config loading so the schema shape is documented once)
+# ---------------------------------------------------------------------------
+
+
+def _iter_perfmon_entries(
+    path: Path,
+) -> Iterator[tuple[str, dict[str, Any]]]:
+    """Yield ``(arch_name, perfmon_dict)`` pairs from *path*.
+
+    ``yaml.safe_load`` returns ``Any``, so every level of the traversal is
+    guarded with ``isinstance`` before it is used. A missing file yields
+    nothing (callers that patch :data:`_GPU_SPEC_PATH` can start clean).
+    """
+    if not path.is_file():
+        return
+    raw: Any = yaml.safe_load(path.read_text())
+    if not isinstance(raw, dict):
+        return
+    data = cast("dict[str, Any]", raw)
+    series_list = data.get("mi_gpu_spec") or []
+    if not isinstance(series_list, list):
+        return
+    for series in series_list:
+        if not isinstance(series, dict):
+            continue
+        arch_list = series.get("gpu_archs") or []
+        if not isinstance(arch_list, list):
+            continue
+        for arch_entry in arch_list:
+            if not isinstance(arch_entry, dict):
+                continue
+            arch = arch_entry.get("gpu_arch")
+            perfmon = arch_entry.get("perfmon_config") or {}
+            if not isinstance(arch, str) or not isinstance(perfmon, dict):
+                continue
+            yield arch, cast("dict[str, Any]", perfmon)
+
+
+@lru_cache(maxsize=1)
+def _load_block_names(path: Path = _GPU_SPEC_PATH) -> frozenset[str]:
+    """Union of counter-block names referenced by any arch's ``perfmon_config``.
+
+    Non-block metadata entries (e.g. ``TCC_channels``) are filtered out: a
+    valid block name has no underscore in it *and* its value is an integer
+    counter cap. Returns an empty frozenset if the spec file is missing so
+    tests that patch the path can start from a clean state.
+    """
+    blocks: set[str] = set()
+    for _arch, perfmon in _iter_perfmon_entries(path):
+        for key, value in perfmon.items():
+            if isinstance(key, str) and isinstance(value, int) and "_" not in key:
+                blocks.add(key)
+    return frozenset(blocks)
+
+
+def block_names() -> frozenset[str]:
+    """Return the cached hardware block name set (see :func:`_load_block_names`)."""
+    return _load_block_names()
+
+
+def load_perfmon_configs(
+    path: Path = _GPU_SPEC_PATH,
+    metadata_keys: frozenset[str] = frozenset(),
+) -> dict[str, dict[str, int]]:
+    """Return ``{gpu_arch: {block: max_counters}}`` from *path*.
+
+    Keys listed in *metadata_keys* are dropped (they appear alongside real
+    block caps — e.g. ``TCC_channels`` — but are not per-block budgets).
+    Non-integer values are ignored so partial/corrupt files degrade
+    gracefully.
+    """
+    result: dict[str, dict[str, int]] = {}
+    for arch, perfmon in _iter_perfmon_entries(path):
+        result[arch] = {
+            k: v
+            for k, v in perfmon.items()
+            if isinstance(k, str) and isinstance(v, int) and k not in metadata_keys
+        }
+    return result
+
+
+# Module-level snapshot for callers that don't care about cache semantics.
+BLOCK_NAMES: Final[frozenset[str]] = _load_block_names()
+
+
+# ---------------------------------------------------------------------------
+# Regex patterns
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def _counter_regex(blocks: frozenset[str] = BLOCK_NAMES) -> re.Pattern[str]:
+    """Build a counter-matching regex from *blocks*.
+
+    Driven by the block set from ``mi_gpu_spec.yaml`` so adding a new block
+    to any arch automatically extends the matcher. The block set is unioned
+    with :data:`BLOCK_REMAP` keys so that aliased prefixes such as ``SQC_*``
+    and ``SP_*`` — which share the ``SQ`` perfmon budget and do *not* appear
+    as standalone entries in ``perfmon_config`` — still match. Alternatives
+    are sorted longest-first so ``SQC`` wins over ``SQ``, ``GL1A`` over
+    ``GL1``, etc.
+    """
+    prefixes = set(blocks) | set(BLOCK_REMAP)
+    sorted_blocks = sorted(prefixes, key=len, reverse=True)
+    if not sorted_blocks:
+        # Nothing to match — produce a regex that matches nothing rather than
+        # an empty alternation (which would be a syntax error).
+        return re.compile(r"(?!)")
+    block_alt = "|".join(re.escape(b) for b in sorted_blocks)
+    suffix = r"(?:\[|_sum|_avr|_max|_min)*"
+    return re.compile(rf"(?:{block_alt})_[0-9A-Z_]*[0-9A-Z]{suffix}")
+
+
+_VARIABLE_RE: Final[re.Pattern[str]] = re.compile(r"\$([0-9A-Za-z_]*[0-9A-Za-z])")
+
+# ---------------------------------------------------------------------------
+# Legacy-compatible public constants. The string-literal regex pair is kept
+# for callers that want a pre-built pattern without the block set as an
+# argument. ``HW_COUNTER_RE`` is the data-driven pattern (includes ``GDS``
+# and every other block in ``perfmon_config``).
+# ---------------------------------------------------------------------------
+
+HW_COUNTER_RE: Final[re.Pattern[str]] = _counter_regex()
+VARIABLE_RE: Final[re.Pattern[str]] = _VARIABLE_RE
+
+
+# ---------------------------------------------------------------------------
+# Token-level helpers
+# ---------------------------------------------------------------------------
+
+
+def extract_variable_names(text: str) -> set[str]:
+    """Return the variable names (without the leading ``$``) in *text*."""
+    return set(_VARIABLE_RE.findall(text))
+
+
+def extract_counter_tokens(
+    text: str,
+    blocks: frozenset[str] | None = None,
+) -> set[str]:
+    """Return every HW counter token in *text*.
+
+    - TCC channel references in formulas (``TCC_HIT[0]``, ``TCC_HIT[1]``, ...)
+      collapse into a single template token ending with ``[`` — downstream
+      code (``_expand_tcc_template_counters``) detects this marker and
+      expands the template to per-channel counters.
+    - Aggregator-suffixed counters (``FOO_sum``, ``FOO_avr``, ...) are kept
+      with the suffix attached.
+    - ``$variables`` are excluded (fetched separately via
+      :func:`extract_variable_names`).
+    """
+    block_set = BLOCK_NAMES if blocks is None else blocks
+    pattern = _counter_regex(block_set)
+    hw = set(pattern.findall(text))
+    # The counter regex will match inside a $variable reference
+    # (e.g. "$GRBM_GUI_ACTIVE_PER_XCD" yields a spurious counter token).
+    # Strip variable bodies out so only real counters survive.
+    return hw - extract_variable_names(text)
+
+
+def strip_suffix(token: str) -> str:
+    """Remove one trailing aggregator suffix from *token* if present."""
+    for suffix in AGGREGATOR_SUFFIXES:
+        if token.endswith(suffix):
+            return token[: -len(suffix)]
+    return token
+
+
+_CHANNEL_INDEX_RE: Final[re.Pattern[str]] = re.compile(r"\[\d*\]?$")
+
+
+def strip_channel(token: str) -> str:
+    """Drop a trailing TCC channel index (``[0]``/``[15]``) or template ``[``.
+
+    Handles both the fully expanded form (``TCC_HIT[3]``) and the
+    template-marker form (``TCC_HIT[``) produced by
+    :func:`extract_counter_tokens`.
+    """
+    return _CHANNEL_INDEX_RE.sub("", token)
+
+
+def remap_block(counter: str) -> str:
+    """Return the effective perfmon block for *counter*.
+
+    ``SQC_*`` and ``SP_*`` counters are packed into the ``SQ`` budget; every
+    other counter keeps its first-segment block.
+    """
+    block = counter.split("_", 1)[0]
+    return BLOCK_REMAP.get(block, block)
+
+
+# ---------------------------------------------------------------------------
+# Public API (legacy-compatible names kept for existing callers)
 # ---------------------------------------------------------------------------
 
 
@@ -72,46 +297,63 @@ def parse_counters_text(text: str) -> tuple[set[str], set[str]]:
     """Extract HW counter names and ``$variable`` names from formula *text*.
 
     Returns ``(hw_counters, variables)`` where *variables* are the names
-    without the leading ``$``.  Matches that look like variables are removed
+    without the leading ``$``. Matches that look like variables are removed
     from the HW counter set.
     """
-    hw_counter_matches = set(HW_COUNTER_RE.findall(text))
-    variable_matches = set(VARIABLE_RE.findall(text))
-    # variable matches cannot be counters
-    hw_counter_matches -= variable_matches
-    return hw_counter_matches, variable_matches
+    return extract_counter_tokens(text), extract_variable_names(text)
+
+
+def resolve_variables(
+    text: str,
+    build_in_vars: dict[str, str],
+    extra_texts: list[str] | None = None,
+    blocks: frozenset[str] | None = None,
+) -> set[str]:
+    """Extract HW counters from *text*, recursively expanding ``$`` variables.
+
+    1. Pull counters + variable names from *text* and each string in
+       *extra_texts* (typically the ``SUPPORTED_DENOM`` formulas).
+    2. For every variable found, if it is defined in *build_in_vars*, parse
+       its body and fold its counters/variables back in. Repeat until no new
+       variables appear.
+
+    Synthetic counters (``SQ_ACCUM_PREV_HIRES``) are filtered out.
+    """
+    block_set = BLOCK_NAMES if blocks is None else blocks
+    hw: set[str] = set()
+    variables: set[str] = set()
+
+    for chunk in (text, *(extra_texts or [])):
+        hw |= extract_counter_tokens(chunk, block_set)
+        variables |= extract_variable_names(chunk)
+
+    seen: set[str] = set()
+    while variables - seen:
+        for var in list(variables - seen):
+            seen.add(var)
+            body = build_in_vars.get(var)
+            if body is None:
+                continue
+            hw |= extract_counter_tokens(body, block_set)
+            variables |= extract_variable_names(body)
+
+    return hw - SYNTHETIC_COUNTERS
 
 
 def extract_counters(text: str) -> set[str]:
     """Return the full set of HW counters referenced by *text*.
 
-    Resolves ``$variable`` references and supported denominators
-    recursively so that all transitive counter dependencies are included.
+    Resolves ``$variable`` references and supported denominators recursively
+    so that all transitive counter dependencies are included. Synthetic
+    counters (``SQ_ACCUM_PREV_HIRES``) are filtered out.
     """
-    hw, variables = parse_counters_text(text)
-
-    # Include counters from all supported denominators
-    for formula in SUPPORTED_DENOM.values():
-        hw_d, var_d = parse_counters_text(formula)
-        hw.update(hw_d)
-        variables.update(var_d)
-
-    # Recursively resolve built-in variables
-    seen: set[str] = set()
-    while variables - seen:
-        new_vars: set[str] = set()
-        for var in variables - seen:
-            seen.add(var)
-            if var in BUILD_IN_VARS:
-                hw_v, var_v = parse_counters_text(BUILD_IN_VARS[var])
-                hw.update(hw_v)
-                new_vars.update(var_v)
-        variables.update(new_vars)
-
-    return hw
+    return resolve_variables(
+        text,
+        BUILD_IN_VARS,
+        extra_texts=list(SUPPORTED_DENOM.values()),
+    )
 
 
 def counter_to_block(counter: str) -> str:
     """Map a counter name to its IP block, applying :data:`BLOCK_REMAP`."""
-    block = counter.split("_")[0]
-    return BLOCK_REMAP.get(block, block)
+    return remap_block(counter)

--- a/projects/rocprofiler-compute/tests/test_utils_counter_defs.py
+++ b/projects/rocprofiler-compute/tests/test_utils_counter_defs.py
@@ -1,0 +1,273 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+"""Unit tests for utils.utils_counter_defs - hardware-independent.
+
+Test function names describe intent; per-function docstrings would be
+redundant. ``missing-function-docstring`` is disabled at the module level.
+"""
+
+# pylint: disable=missing-function-docstring
+# ruff: noqa: S101  # pytest idiomatically uses plain `assert` statements.
+
+from __future__ import annotations
+
+import pytest
+
+from utils.utils_counter_defs import (
+    AGGREGATOR_SUFFIXES,
+    BLOCK_NAMES,
+    BLOCK_REMAP,
+    SYNTHETIC_COUNTERS,
+    counter_to_block,
+    extract_counter_tokens,
+    extract_counters,
+    extract_variable_names,
+    parse_counters_text,
+    remap_block,
+    resolve_variables,
+    strip_channel,
+    strip_suffix,
+)
+
+# ---------------------------------------------------------------------------
+# Block set sourced from mi_gpu_spec.yaml
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "block",
+    [
+        "SQ",
+        "TA",
+        "TD",
+        "TCP",
+        "TCC",
+        "CPC",
+        "CPF",
+        "SPI",
+        "GRBM",
+        "GDS",  # regression: missing from legacy regex
+        "GCEA",
+        "GL1A",
+        "GL1C",
+        "GL2A",
+        "GL2C",
+    ],
+)
+def test_block_names_covers_all_perfmon_blocks(block: str) -> None:
+    assert block in BLOCK_NAMES, (
+        f"{block} should be discovered from mi_gpu_spec.yaml perfmon_config"
+    )
+
+
+def test_block_names_excludes_non_block_metadata() -> None:
+    # TCC_channels is an integer-valued metadata entry but not a block name.
+    assert "TCC_channels" not in BLOCK_NAMES
+
+
+# ---------------------------------------------------------------------------
+# extract_counter_tokens
+# ---------------------------------------------------------------------------
+
+
+_EXTRACT_CASES = [
+    pytest.param(
+        "AVG(((100 * CPF_CPF_STAT_BUSY) / (CPF_CPF_STAT_BUSY + CPF_CPF_STAT_IDLE)))",
+        {"CPF_CPF_STAT_BUSY", "CPF_CPF_STAT_IDLE"},
+        id="simple-avg-formula",
+    ),
+    pytest.param(
+        "TO_INT(MIN(ROUND(SUM(4 * SQ_BUSY_CU_CYCLES) / $GRBM_GUI_ACTIVE_PER_XCD, 0)))",
+        {"SQ_BUSY_CU_CYCLES"},
+        id="variable-body-not-counted-as-counter",
+    ),
+    pytest.param(
+        "(TCC_HIT[0] + TCC_HIT[1] + TCC_MISS[0])",
+        {"TCC_HIT[", "TCC_MISS["},
+        id="tcc-channel-template-preserves-bracket-marker",
+    ),
+    pytest.param(
+        "TCC_EA_RDREQ_sum + SQ_WAVES",
+        {"TCC_EA_RDREQ_sum", "SQ_WAVES"},
+        id="aggregator-suffix-preserved",
+    ),
+    pytest.param(
+        "SQC_ICACHE_HITS + SP_INSTS + SQ_WAVES",
+        {"SQC_ICACHE_HITS", "SP_INSTS", "SQ_WAVES"},
+        id="aliased-blocks-SQC-and-SP-still-extract",
+    ),
+    pytest.param(
+        "GDS_BUSY + 100",
+        {"GDS_BUSY"},
+        id="GDS-counters-extracted-regression-fix",
+    ),
+    pytest.param(
+        "AVG(100) + ROUND(SUM(End_Timestamp - Start_Timestamp)) + None",
+        set(),
+        id="formula-keywords-not-misclassified",
+    ),
+    pytest.param(
+        "",
+        set(),
+        id="empty-string",
+    ),
+]
+
+
+@pytest.mark.parametrize(("text", "expected"), _EXTRACT_CASES)
+def test_extract_counter_tokens(text: str, expected: set[str]) -> None:
+    assert extract_counter_tokens(text) == expected
+
+
+# ---------------------------------------------------------------------------
+# extract_variable_names
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("SQ_WAVES / $GRBM_GUI_ACTIVE_PER_XCD", {"GRBM_GUI_ACTIVE_PER_XCD"}),
+        ("$max_mclk + $num_hbm_channels", {"max_mclk", "num_hbm_channels"}),
+        ("no dollar sign here", set()),
+        ("$TrailingDollar$", {"TrailingDollar"}),
+    ],
+)
+def test_extract_variable_names(text: str, expected: set[str]) -> None:
+    assert extract_variable_names(text) == expected
+
+
+# ---------------------------------------------------------------------------
+# strip_suffix / strip_channel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("token", "expected"),
+    [
+        ("TCC_EA_RDREQ_sum", "TCC_EA_RDREQ"),
+        ("SQ_WAVES_avr", "SQ_WAVES"),
+        ("SQ_WAVES_max", "SQ_WAVES"),
+        ("SQ_WAVES_min", "SQ_WAVES"),
+        ("SQ_WAVES", "SQ_WAVES"),  # no suffix
+    ],
+)
+def test_strip_suffix(token: str, expected: str) -> None:
+    assert strip_suffix(token) == expected
+
+
+def test_aggregator_suffix_tuple_is_stable() -> None:
+    # Tests depend on the exact suffix set; if this changes the helper
+    # semantics shift and dependent tests must be reviewed.
+    assert AGGREGATOR_SUFFIXES == ("_sum", "_avr", "_max", "_min")
+
+
+@pytest.mark.parametrize(
+    ("token", "expected"),
+    [
+        ("TCC_HIT[0]", "TCC_HIT"),
+        ("TCC_HIT[15]", "TCC_HIT"),
+        ("TCC_HIT[", "TCC_HIT"),  # template marker from extract_counter_tokens
+        ("SQ_WAVES", "SQ_WAVES"),
+    ],
+)
+def test_strip_channel(token: str, expected: str) -> None:
+    assert strip_channel(token) == expected
+
+
+# ---------------------------------------------------------------------------
+# remap_block / counter_to_block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("counter", "expected"),
+    [
+        ("SQC_WAVES", "SQ"),  # SQC aliased to SQ
+        ("SP_INSTS", "SQ"),  # SP aliased to SQ
+        ("SQ_WAVES", "SQ"),  # identity
+        ("TCC_HIT", "TCC"),
+        ("GRBM_GUI_ACTIVE", "GRBM"),
+        ("GDS_BUSY", "GDS"),
+    ],
+)
+def test_remap_block(counter: str, expected: str) -> None:
+    assert remap_block(counter) == expected
+
+
+def test_counter_to_block_matches_remap_block() -> None:
+    # Public legacy alias must stay consistent with the internal helper.
+    for c in ("SQC_WAVES", "SP_INSTS", "SQ_WAVES", "TCC_HIT", "GDS_BUSY"):
+        assert counter_to_block(c) == remap_block(c)
+
+
+def test_block_remap_constants_match_documented_aliases() -> None:
+    assert BLOCK_REMAP == {"SQC": "SQ", "SP": "SQ"}
+
+
+# ---------------------------------------------------------------------------
+# resolve_variables
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_variables_follows_build_in_vars() -> None:
+    # Formula references a $var whose body mentions another counter.
+    build_in_vars = {
+        "GRBM_GUI_ACTIVE_PER_XCD": "(GRBM_GUI_ACTIVE / $num_xcd)",
+    }
+    out = resolve_variables(
+        "SQ_WAVES / $GRBM_GUI_ACTIVE_PER_XCD",
+        build_in_vars,
+    )
+    assert out == {"SQ_WAVES", "GRBM_GUI_ACTIVE"}
+
+
+def test_resolve_variables_folds_in_extra_texts() -> None:
+    build_in_vars: dict[str, str] = {}
+    # extra_texts simulates SUPPORTED_DENOM formulas.
+    out = resolve_variables(
+        "SQ_WAVES",
+        build_in_vars,
+        extra_texts=["(End_Timestamp - Start_Timestamp) / 1000000000"],
+    )
+    # extra text adds no counters here (Start_Timestamp is a keyword), but
+    # the call must still succeed and include SQ_WAVES.
+    assert "SQ_WAVES" in out
+
+
+def test_resolve_variables_filters_synthetic_counters() -> None:
+    # SQ_ACCUM_PREV_HIRES is injected elsewhere; the parser must drop it.
+    out = resolve_variables("SQ_WAVES + SQ_ACCUM_PREV_HIRES", {})
+    assert "SQ_ACCUM_PREV_HIRES" not in out
+    assert "SQ_WAVES" in out
+    assert "SQ_ACCUM_PREV_HIRES" in SYNTHETIC_COUNTERS
+
+
+def test_resolve_variables_unknown_variable_is_ignored() -> None:
+    # A $var with no BUILD_IN_VARS entry must not raise - it is simply not
+    # expanded. This matches legacy parse_counters behaviour.
+    out = resolve_variables("SQ_WAVES / $unknown_var", {})
+    assert out == {"SQ_WAVES"}
+
+
+# ---------------------------------------------------------------------------
+# Legacy-compatible top-level API (kept for existing callers)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_counters_text_returns_pair() -> None:
+    hw, variables = parse_counters_text(
+        "SQ_WAVES / $GRBM_GUI_ACTIVE_PER_XCD + CPF_CPF_STAT_BUSY"
+    )
+    assert hw == {"SQ_WAVES", "CPF_CPF_STAT_BUSY"}
+    assert variables == {"GRBM_GUI_ACTIVE_PER_XCD"}
+
+
+def test_extract_counters_resolves_supported_denom() -> None:
+    # Using $GRBM_GUI_ACTIVE_PER_XCD as a denom pulls GRBM_GUI_ACTIVE in via
+    # BUILD_IN_VARS; extract_counters must see it transitively.
+    out = extract_counters("SQ_WAVES / $GRBM_GUI_ACTIVE_PER_XCD")
+    assert "SQ_WAVES" in out
+    assert "GRBM_GUI_ACTIVE" in out
+    assert "SQ_ACCUM_PREV_HIRES" not in out

--- a/projects/rocprofiler-compute/tools/validate_sets_metric_ids.py
+++ b/projects/rocprofiler-compute/tools/validate_sets_metric_ids.py
@@ -13,27 +13,60 @@ Metric ID format X.Y.Z:
   X = panel_config_id // 100
   Y = metric_table_id % 100  (metric_table_id = X*100 + Y)
   Z = 0-indexed position of the metric within that table's ordered metric dict
+
+``print`` is the CLI-output channel for a pre-commit hook; ``T201`` is
+disabled at the module level rather than per-call.
 """
+
+# ruff: noqa: T201
 
 from __future__ import annotations
 
 import sys
 from collections import defaultdict
 from pathlib import Path
+from typing import Any, Final, TypeAlias, cast
 
 import yaml
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-SETS_DIR = PROJECT_ROOT / "src" / "rocprof_compute_soc" / "profile_configs" / "sets"
-ANALYSIS_DIR = PROJECT_ROOT / "src" / "rocprof_compute_soc" / "analysis_configs"
-GPU_SPEC_PATH = PROJECT_ROOT / "src" / "utils" / "mi_gpu_spec.yaml"
+PROJECT_ROOT: Final[Path] = Path(__file__).resolve().parents[1]
+SETS_DIR: Final[Path] = (
+    PROJECT_ROOT / "src" / "rocprof_compute_soc" / "profile_configs" / "sets"
+)
+ANALYSIS_DIR: Final[Path] = (
+    PROJECT_ROOT / "src" / "rocprof_compute_soc" / "analysis_configs"
+)
+GPU_SPEC_PATH: Final[Path] = PROJECT_ROOT / "src" / "utils" / "mi_gpu_spec.yaml"
 
 # Make src/ importable so we can reuse the canonical counter definitions.
-sys.path.insert(0, str(PROJECT_ROOT / "src"))
+# src/ has no __init__.py (and making it a proper package is out of scope
+# for this validator), so we extend sys.path the way tests/conftest.py does.
+_SRC: Final[str] = str(PROJECT_ROOT / "src")
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+# pylint: disable=wrong-import-position  # sys.path.insert must run first.
 from utils.utils_counter_defs import (  # noqa: E402
     counter_to_block,
     extract_counters,
+    load_perfmon_configs,
 )
+
+# Metadata keys that appear in perfmon_config alongside real block caps
+# (e.g. TCC_channels) and must not be treated as per-block limits. Explicit
+# allow-list — if mi_gpu_spec.yaml grows new metadata it must be added here.
+_METADATA_KEYS: Final[frozenset[str]] = frozenset({"TCC_channels"})
+
+# A metric formula in analysis_configs/*.yaml is a recursive tree of
+# strings (leaf formulas) nested under dicts. We don't expect lists in
+# practice, but typing them here keeps the boundary honest.
+FormulaTree: TypeAlias = "str | dict[str, FormulaTree] | list[FormulaTree]"
+TableMetrics: TypeAlias = "dict[str, FormulaTree]"
+ArchAnalysis: TypeAlias = "dict[int, TableMetrics]"
+
+# Metric IDs must have exactly three dot-separated segments (``X.Y.Z``).
+_METRIC_ID_SEGMENTS: Final[int] = 3
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -41,66 +74,89 @@ from utils.utils_counter_defs import (  # noqa: E402
 
 
 def resolve_metric_id(metric_id: str) -> tuple[int | None, int | None]:
-    """Parse 'X.Y.Z' into (metric_table_id, metric_index)."""
+    """Parse 'X.Y.Z' into (metric_table_id, metric_index).
+
+    Returns ``(None, None)`` if the id is not fully qualified (fewer than
+    three segments) *or* if any segment is not numeric — the caller reports
+    a single "not fully qualified" error in either case.
+    """
     tokens = metric_id.split(".")
-    if len(tokens) < 3:
+    if len(tokens) < _METRIC_ID_SEGMENTS:
         return None, None
-    x, y, z = int(tokens[0]), int(tokens[1]), int(tokens[2])
+    try:
+        x, y, z = int(tokens[0]), int(tokens[1]), int(tokens[2])
+    except ValueError:
+        return None, None
     return x * 100 + y, z
 
 
-def load_analysis_configs(arch: str) -> dict[int, dict[str, dict]]:
-    """Return {metric_table_id: {metric_name: formula_dict}} for *arch*.
+def load_analysis_configs(arch: str) -> ArchAnalysis:  # noqa: C901
+    """Return {metric_table_id: {metric_name: formula_tree}} for *arch*.
 
     Metric name ordering is preserved (dict insertion order), so
     ``list(result[table_id])`` gives the ordered name list needed for
-    index-based lookups.
+    index-based lookups. Each YAML layer is guarded with ``isinstance`` so
+    that a malformed file cannot inject unexpected types past this boundary
+    — hence the complexity ruff flags is load-bearing (one ``isinstance``
+    per YAML level) and is accepted.
     """
     arch_dir = ANALYSIS_DIR / arch
     if not arch_dir.is_dir():
         return {}
-    result: dict[int, dict[str, dict]] = {}
+    result: ArchAnalysis = {}
     for config_path in sorted(arch_dir.glob("*.yaml")):
-        data = yaml.safe_load(config_path.read_text())
-        panel = (data or {}).get("Panel Config", {})
-        for source in panel.get("data source", []):
-            mt = source.get("metric_table", {})
-            table_id = mt.get("id")
-            if table_id is None:
+        raw: Any = yaml.safe_load(config_path.read_text())
+        if not isinstance(raw, dict):
+            continue
+        panel_raw = raw.get("Panel Config")
+        if not isinstance(panel_raw, dict):
+            continue
+        sources = panel_raw.get("data source") or []
+        if not isinstance(sources, list):
+            continue
+        for source in sources:
+            if not isinstance(source, dict):
                 continue
-            metrics = mt.get("metric", {})
-            if metrics:
-                result[table_id] = dict(metrics)
+            mt = source.get("metric_table")
+            if not isinstance(mt, dict):
+                continue
+            table_id = mt.get("id")
+            if not isinstance(table_id, int):
+                continue
+            metrics = mt.get("metric")
+            if not isinstance(metrics, dict):
+                continue
+            # Every key in metric-tables is a metric-name string in practice;
+            # drop any entries that are not so we preserve the TableMetrics
+            # contract downstream.
+            table: TableMetrics = {
+                str(name): cast("FormulaTree", body)
+                for name, body in metrics.items()
+                if isinstance(name, str)
+            }
+            if table:
+                result[table_id] = table
     return result
 
 
-def load_perfmon_configs() -> dict[str, dict[str, int]]:
-    """Return {gpu_arch: {block: max_counters}} from mi_gpu_spec.yaml."""
-    data = yaml.safe_load(GPU_SPEC_PATH.read_text())
-    result: dict[str, dict[str, int]] = {}
-    for series in data.get("mi_gpu_spec", []):
-        for arch_entry in series.get("gpu_archs", []):
-            arch = arch_entry.get("gpu_arch")
-            perfmon = arch_entry.get("perfmon_config", {})
-            if arch and perfmon:
-                # Filter out non-block entries like TCC_channels
-                result[arch] = {
-                    k: v
-                    for k, v in perfmon.items()
-                    if isinstance(v, int) and "_" not in k
-                }
-    return result
+def _perfmon_caps() -> dict[str, dict[str, int]]:
+    """Return ``{gpu_arch: {block: max_counters}}`` via the shared loader.
+
+    Thin wrapper around :func:`utils.utils_counter_defs.load_perfmon_configs`
+    so the validator cannot drift from the runtime spec-reader.
+    """
+    return load_perfmon_configs(GPU_SPEC_PATH, metadata_keys=_METADATA_KEYS)
 
 
-def _flatten_formula_values(d: dict) -> str:
-    """Recursively collect all string values from a metric formula dict."""
-    parts: list[str] = []
-    for v in d.values():
-        if isinstance(v, str):
-            parts.append(v)
-        elif isinstance(v, dict):
-            parts.append(_flatten_formula_values(v))
-    return "\n".join(parts)
+def _flatten_formula_values(tree: FormulaTree) -> str:
+    """Recursively collect all string leaves from a metric formula tree."""
+    if isinstance(tree, str):
+        return tree
+    if isinstance(tree, dict):
+        return "\n".join(_flatten_formula_values(v) for v in tree.values())
+    if isinstance(tree, list):
+        return "\n".join(_flatten_formula_values(v) for v in tree)
+    return ""
 
 
 # ---------------------------------------------------------------------------
@@ -108,34 +164,54 @@ def _flatten_formula_values(d: dict) -> str:
 # ---------------------------------------------------------------------------
 
 
-def validate() -> list[str]:
-    """Run all checks, return error messages."""
+def validate() -> list[str]:  # noqa: C901, PLR0912  # pylint: disable=too-many-locals,too-many-branches
+    """Run all checks, return error messages.
+
+    The two checks (metric-ID -> name mapping and single-pass counter
+    budgets) are intentionally fused into one nested loop so each sets
+    file is read and parsed once. Splitting the function would require
+    re-materializing the per-arch analysis config and formula list, so
+    the branch/local counts are tracked-but-accepted.
+    """
     errors: list[str] = []
-    perfmon_configs = load_perfmon_configs()
+    perfmon_configs = _perfmon_caps()
 
     for sets_path in sorted(SETS_DIR.glob("gfx*_sets.yaml")):
         arch = sets_path.stem.replace("_sets", "")
-        sets_data = yaml.safe_load(sets_path.read_text())
+        sets_raw: Any = yaml.safe_load(sets_path.read_text())
+        if not isinstance(sets_raw, dict):
+            continue
 
         # Load analysis configs once per arch
         analysis = load_analysis_configs(arch)
         limits = perfmon_configs.get(arch)
 
-        for s in sets_data.get("sets", []):
-            set_option = s.get("set_option", "<unknown>")
+        sets_list = sets_raw.get("sets") or []
+        if not isinstance(sets_list, list):
+            continue
+        for s in sets_list:
+            if not isinstance(s, dict):
+                continue
+            set_option = str(s.get("set_option", "<unknown>"))
             formula_texts: list[str] = []
 
-            for entry in s.get("metric", []):
-                for metric_id_raw, expected_name in entry.items():
+            metric_entries = s.get("metric") or []
+            if not isinstance(metric_entries, list):
+                continue
+            for entry in metric_entries:
+                if not isinstance(entry, dict):
+                    continue
+                for metric_id_raw, expected_name_raw in entry.items():
                     metric_id = str(metric_id_raw)
-                    expected_name = str(expected_name)
+                    expected_name = str(expected_name_raw)
                     table_id, idx = resolve_metric_id(metric_id)
 
                     # --- Check 1: metric ID maps to correct name ---
                     if table_id is None or idx is None:
                         errors.append(
                             f"[{arch}] set '{set_option}': metric ID "
-                            f"'{metric_id}' is not fully qualified (need X.Y.Z)"
+                            f"'{metric_id}' is not fully qualified (need "
+                            f"three numeric segments X.Y.Z)"
                         )
                         continue
 
@@ -177,19 +253,15 @@ def validate() -> list[str]:
                     # Collect formula text for single-pass check
                     formula = table_metrics.get(actual)
                     if formula is not None:
-                        formula_texts.append(
-                            _flatten_formula_values(formula)
-                            if isinstance(formula, dict)
-                            else str(formula)
-                        )
+                        formula_texts.append(_flatten_formula_values(formula))
 
             # --- Check 2: counters fit in single pass ---
             if not formula_texts or limits is None:
                 continue
 
+            # extract_counters already filters SYNTHETIC_COUNTERS
+            # (SQ_ACCUM_PREV_HIRES); no manual .discard() needed.
             counters = extract_counters("\n".join(formula_texts))
-            # SQ_ACCUM_PREV_HIRES is injected separately for level counters
-            counters.discard("SQ_ACCUM_PREV_HIRES")
             block_counters: dict[str, set[str]] = defaultdict(set)
             for c in counters:
                 block_counters[counter_to_block(c)].add(c)
@@ -214,6 +286,7 @@ def validate() -> list[str]:
 
 
 def main() -> int:
+    """CLI entry point; prints each error and returns a non-zero exit code."""
     errors = validate()
     if errors:
         print("Sets metric ID validation failed:\n")


### PR DESCRIPTION
# [rocprofiler-compute] harden shared counter parsing and sets validator

> [!IMPORTANT]
> **This PR does NOT target `develop`.**
>
> The base branch is `users/xuchen-amd/correct_outdated_sets` — i.e. the head of #5165. The intent is to *contribute into* #5165 so the hardening ships as part of that PR rather than as a separate follow-up. If #5165 is merged, these changes merge with it.
>
> If you arrived here expecting a develop-targeted PR, please review against #5165 first; this is stacked on top of it.

---

## TL;DR

Three files changed on top of #5165:

- `src/utils/utils_counter_defs.py` — fix `GDS` regression (data-driven `BLOCK_NAMES`), tighten typing for `mypy --strict`, add isinstance guards at the YAML boundary.
- `tools/validate_sets_metric_ids.py` — guard `int()` in `resolve_metric_id`, replace the implicit `"_" not in k` metadata filter with an explicit allow-list, add `isinstance` checks at every `yaml.safe_load` boundary, document formula shape with a recursive `FormulaTree` type alias.
- `tests/test_utils_counter_defs.py` — 52 hardware-independent parametrized cases pinning the above (including a dedicated row for the `GDS` regression).

---

## Why (contributed into #5165, not follow-up)

#5165 (@xuchen-amd) already did the hard structural work — extracting the counter / variable / block-remap parsing out of `soc_base.py` and `validate_sets_metric_ids.py` into a shared `src/utils/utils_counter_defs.py`. With the helper in place, a few things become worth tightening:

## Why

#5165's second revision did the hard structural work — extracting the counter / variable / block-remap parsing out of `soc_base.py` and `validate_sets_metric_ids.py` into a shared `src/utils/utils_counter_defs.py`. With the helper in place, a few things become worth tightening:

1. **`GDS` was silently dropped.** Both the pre-refactor regex *and* the initial helper's block list omit `GDS`, so every `GDS_*` counter was being skipped at runtime and by the pre-commit validator. Making `BLOCK_NAMES` data-driven from `mi_gpu_spec.yaml::perfmon_config` fixes this and prevents future drift when a new block is added.
2. **`resolve_metric_id` can raise `ValueError`** on malformed metric IDs because `int()` is not guarded. A `gfx*_sets.yaml` typo would crash the pre-commit hook instead of producing a clean diagnostic.
3. **The `"_" not in k` metadata filter is implicit.** If `mi_gpu_spec.yaml` ever grows a metadata key like `some_other_cap` the filter silently stops treating it as metadata, which is the kind of bug a validator is supposed to prevent.
4. **No mypy-strict coverage and no unit tests for the helper.** Without either, the next incremental change is easy to get subtly wrong.

## What changed

### `src/utils/utils_counter_defs.py` (hardened in place)

- `BLOCK_NAMES` is now discovered from `mi_gpu_spec.yaml::perfmon_config` via `load_perfmon_configs()` + `_iter_perfmon_entries()`. Adding a new arch/block updates the matcher automatically. `GDS` now matches.
- The generated regex unions `BLOCK_REMAP` keys (`SQC`, `SP`) with real block names and sorts alternatives longest-first so `SQC` wins over `SQ`, `GL1A` over `GL1`, etc.
- `SYNTHETIC_COUNTERS = frozenset({"SQ_ACCUM_PREV_HIRES"})` is filtered at the extractor level so callers do not need to `.discard()` it.
- Module is typed for `mypy --strict`. The `yaml` import is `TYPE_CHECKING`-gated to avoid requiring the vendored wheel on the mypy path. Every YAML level has an `isinstance` guard in `_iter_perfmon_entries`.
- Public API preserved: `extract_counters`, `counter_to_block`, `parse_counters_text` keep their shape so existing callers (`soc_base.py`, `analysis_db.py`, etc.) are unchanged.

### `tools/validate_sets_metric_ids.py`

- `resolve_metric_id()` wraps `int()` in `try/except ValueError`. A malformed `X.Y.Z` segment is reported as "not fully qualified" through the normal error-collection path instead of aborting the hook.
- The `"_" not in k` metadata filter is replaced with an explicit `_METADATA_KEYS = frozenset({"TCC_channels"})` allow-list. If new metadata keys appear they must be added deliberately.
- Every `yaml.safe_load` boundary is guarded with `isinstance`. A recursive `FormulaTree` type alias (`str | dict[str, FormulaTree] | list[FormulaTree]`) documents the metric-formula shape.
- `_METRIC_ID_SEGMENTS: Final[int] = 3` replaces an unexplained `3` in the parser.
- CLI surface unchanged — `.pre-commit-config.yaml` does not change.

### Tests — `tests/test_utils_counter_defs.py` (new)

52 hardware-independent parametrized cases covering:

- `extract_counter_tokens` — formula tokenisation, TCC-channel template marker, aggregator-suffix preservation, formula-keyword rejection, empty input.
- `extract_variable_names` — `$`-variable extraction.
- `strip_suffix` — `_sum` / `_avr` / `_max` / `_min` suffix handling.
- `strip_channel` — TCC `[N]` and the `[` template marker.
- `remap_block` / `counter_to_block` — `SQC` → `SQ`, `SP` → `SQ`, identity, and the public-alias invariant.
- `resolve_variables` — `BUILD_IN_VARS` following, `extra_texts` folding, `SYNTHETIC_COUNTERS` filtering, unknown-variable behaviour.
- `parse_counters_text` / `extract_counters` — legacy-compatible API.
- `BLOCK_NAMES` discovery — regression row pinning `GDS` in the set and excluding `TCC_channels` metadata.

A dedicated row (`id="GDS-counters-extracted-regression-fix"`) pins the `GDS` fix.

## Equivalence check

An offline equivalence check walks every formula in `src/rocprof_compute_soc/analysis_configs/*.yaml` and asserts the new extractor returns a superset of the legacy regex output:

```
OK: 2871 formulas match; new extractor is a superset of legacy.
```

The only "extras" are the previously-dropped `GDS_*` counters.

## Test plan

- [x] `ruff check --select=ALL` — clean on all 3 changed files
- [x] `ruff format --check` — clean
- [x] `mypy --strict` — clean on `utils_counter_defs.py`, `validate_sets_metric_ids.py`, `test_utils_counter_defs.py`
- [x] `pylint` — **10.00/10** on both modules (inline `# pylint: disable=` pragmas are explained in comments; no command-line `--disable` flags)
- [x] `bandit -r` — 0 non-B101 issues (B101 is the expected `assert_used` finding in the test file, idiomatic for pytest)
- [x] `python tools/validate_sets_metric_ids.py` — `Sets metric ID validation passed.`
- [x] `pytest tests/test_utils_counter_defs.py -v` — **52 passed**
- [x] Equivalence script confirms the new extractor is a strict superset of the legacy regex across **2871** real formulas

## Notes for reviewers

- **Base branch is `users/xuchen-amd/correct_outdated_sets`, not `develop`.** This PR stacks on top of #5165 so the hardening ships as part of the same merge. @xuchen-amd — if you prefer this as a standalone follow-up against `develop` after #5165 lands, I'm happy to retarget; just let me know.
- `BLOCK_NAMES` is now data-driven from `mi_gpu_spec.yaml::perfmon_config`; if you add a new block there, no code changes are needed for the extractor to recognise its counters.
- Module name and public API (`extract_counters`, `counter_to_block`, `parse_counters_text`) are preserved from #5165, so existing callers (`soc_base.py`, `analysis_db.py`) are not touched.

## Credits

Thanks to @xuchen-amd for the original sets validator and the deduplication refactor in #5165 — that module is what made this hardening worth sending as a small, focused addition.
