### PR TITLE
[rocprof-sys][gfx1250] Add gfx1250 test support

### DIFF
--- a/projects/rocprofiler-systems/cmake/MacroUtilities.cmake
+++ b/projects/rocprofiler-systems/cmake/MacroUtilities.cmake
@@ -546,7 +546,8 @@ function(ROCPROFILER_SYSTEMS_PRINT_ENABLED_FEATURES)
                     )
                 else()
                     string(
-                        REGEX REPLACE "^${PROJECT_NAME}_USE_"
+                        REGEX REPLACE
+                        "^${PROJECT_NAME}_USE_"
                         ""
                         _feature_tmp
                         "${_feature}"

--- a/projects/rocprofiler-systems/cmake/MacroUtilities.cmake
+++ b/projects/rocprofiler-systems/cmake/MacroUtilities.cmake
@@ -546,8 +546,7 @@ function(ROCPROFILER_SYSTEMS_PRINT_ENABLED_FEATURES)
                     )
                 else()
                     string(
-                        REGEX REPLACE
-                        "^${PROJECT_NAME}_USE_"
+                        REGEX REPLACE "^${PROJECT_NAME}_USE_"
                         ""
                         _feature_tmp
                         "${_feature}"
@@ -1195,6 +1194,7 @@ function(ROCPROFILER_SYSTEMS_LOOKUP_GFX _TARGET _OUTPUT_LIST)
         "gfx90a"
         "gfx942"
         "gfx950"
+        "gfx1250"
     )
 
     # Also includes PRO GPUs

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/gpu.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/gpu.py
@@ -31,6 +31,11 @@ class GPUInfo:
     categories: set[str]
 
     @property
+    def _is_gfx1250(self) -> bool:
+        """Check if the GPU is MI450 (gfx1250)."""
+        return "gfx1250" in self.architectures
+
+    @property
     def _is_mi300_or_later(self) -> bool:
         """Check if the GPU is a MI300 or later."""
         for arch in self.architectures:
@@ -41,16 +46,18 @@ class GPUInfo:
     @property
     def rocm_events_for_test(self) -> str:
         """Get appropriate ROCm events for testing based on architecture."""
-        mi300_or_later = self._is_mi300_or_later
-        if mi300_or_later:
+        if self._is_gfx1250:
+            return "GRBM_COUNT,SQ_WAVES:device=0"
+        if self._is_mi300_or_later:
             return "GRBM_COUNT,SQ_WAVES,SQ_INSTS_VALU,TA_TA_BUSY"
         return "SQ_WAVES"
 
     @property
     def counter_names(self) -> list[str]:
         """Get counter names for validation based on architecture"""
-        mi300_or_later = self._is_mi300_or_later
-        if mi300_or_later:
+        if self._is_gfx1250:
+            return ["GRBM_COUNT", "SQ_WAVES"]
+        if self._is_mi300_or_later:
             return ["GRBM_COUNT", "SQ_WAVES", "SQ_INSTS_VALU", "TA_TA_BUSY"]
         return ["SQ_WAVES"]
 
@@ -159,6 +166,7 @@ def lookup_gpu_category(
         "gfx90a",
         "gfx942",
         "gfx950",
+        "gfx1250",
     ]
 
     # Also includes PRO GPUs

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/transpose/amd-smi-rules-gfx1250.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/transpose/amd-smi-rules-gfx1250.json
@@ -1,0 +1,85 @@
+{
+    "required_tables": [
+        {
+            "min_rows": 4,
+            "name_prefix": "rocpd_info_pmc_",
+            "required_columns": [
+                "agent_id",
+                "target_arch",
+                "name",
+                "symbol",
+                "description",
+                "units",
+                "value_type"
+            ],
+            "validation_queries": [
+                {
+                    "comparison": "greater_than",
+                    "description": "Check for amd-smi monitoring categories",
+                    "error_message": "Found none of the amd-smi categories",
+                    "expected_result": 4,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE target_arch is 'GPU'"
+                }
+            ]
+        },
+        {
+            "min_rows": 200,
+            "name_prefix": "rocpd_pmc_event_",
+            "required_columns": [
+                "event_id",
+                "pmc_id",
+                "value"
+            ],
+            "validation_queries": [
+                {
+                    "comparison": "greater_than",
+                    "description": "Check for amd-smi GFX busy samples",
+                    "error_message": "Less than expected number of captured amd-smi gfx-busy samples!",
+                    "expected_result": 10,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_busy_gfx'",
+                    "requires": "gfx_activity"
+                },
+                {
+                    "comparison": "greater_than",
+                    "description": "Check for amd-smi UMC busy samples",
+                    "error_message": "Less than expected number of captured amd-smi umc-busy samples!",
+                    "expected_result": 10,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_busy_umc'",
+                    "requires": "umc_activity"
+                },
+                {
+                    "comparison": "greater_than",
+                    "description": "Check for amd-smi MM busy samples",
+                    "error_message": "Less than expected number of captured amd-smi mm-busy samples!",
+                    "expected_result": 10,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_busy_mm'",
+                    "requires": "mm_activity"
+                },
+                {
+                    "comparison": "greater_than",
+                    "description": "Check for amd-smi monitoring GPU temperature",
+                    "error_message": "Less than expected number of captured amd-smi-temperature samples!",
+                    "expected_result": 10,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_temp'",
+                    "requires": "temp"
+                },
+                {
+                    "comparison": "greater_than",
+                    "description": "Check for amd-smi monitoring GPU power consumption",
+                    "error_message": "Less than expected number of captured amd-smi-power samples!",
+                    "expected_result": 10,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_power'",
+                    "requires": "power"
+                },
+                {
+                    "comparison": "greater_than",
+                    "description": "Check for amd-smi monitoring GPU memory usage",
+                    "error_message": "Less than expected number of captured amd-smi-memory-usage samples!",
+                    "expected_result": 10,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_memory_usage'",
+                    "requires": "mem_usage"
+                }
+            ]
+        }
+    ]
+}

--- a/projects/rocprofiler-systems/tests/rocprof-sys-rocm-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-rocm-tests.cmake
@@ -85,6 +85,9 @@ if(ROCPROFSYS_GFX_TARGETS)
     foreach(arch IN LISTS ROCPROFSYS_GFX_TARGETS)
         rocprofiler_systems_lookup_gfx(${arch} GPU_CATEGORY)
         if("instinct" IN_LIST GPU_CATEGORY)
+            if("${arch}" STREQUAL "gfx1250")
+                set(GFX1250_DETECTED TRUE)
+            endif()
             continue()
         endif()
         set(NAVI_DETECTED TRUE)
@@ -92,7 +95,12 @@ if(ROCPROFSYS_GFX_TARGETS)
     endforeach()
 endif()
 
-if(NAVI_DETECTED)
+if(GFX1250_DETECTED)
+    # gfx1250: SQ_INSTS_VALU and TA_TA_BUSY are unavailable
+    # (SQ_INSTS_VALU missing from aqlprofile defaults, TA block merged into TX)
+    set(ROCPROFSYS_ROCM_EVENTS_TEST "GRBM_COUNT,SQ_WAVES:device=0")
+    set(ROCPROFSYS_COUNTER_NAMES_ARG "GRBM_COUNT" "SQ_WAVES")
+elseif(NAVI_DETECTED)
     set(ROCPROFSYS_ROCM_EVENTS_TEST "SQ_WAVES")
     set(ROCPROFSYS_COUNTER_NAMES_ARG "SQ_WAVES")
 else()
@@ -178,6 +186,16 @@ endforeach()
 #
 # -------------------------------------------------------------------------------------- #
 
+if(GFX1250_DETECTED)
+    set(_AMD_SMI_RULES_FILE
+        "${CMAKE_CURRENT_LIST_DIR}/rocpd-validation-rules/transpose/amd-smi-rules-gfx1250.json"
+    )
+else()
+    set(_AMD_SMI_RULES_FILE
+        "${CMAKE_CURRENT_LIST_DIR}/rocpd-validation-rules/transpose/amd-smi-rules.json"
+    )
+endif()
+
 if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU} AND TEST transpose-sampling)
     set_property(TEST transpose-sampling APPEND PROPERTY LABELS rocpd)
 
@@ -187,7 +205,7 @@ if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU} AND TEST transpose-sampling)
         ARGS --validation-rules
         "${CMAKE_CURRENT_LIST_DIR}/rocpd-validation-rules/transpose/validation-rules.json"
         "${CMAKE_CURRENT_LIST_DIR}/rocpd-validation-rules/default-rules.json"
-        "${CMAKE_CURRENT_LIST_DIR}/rocpd-validation-rules/transpose/amd-smi-rules.json"
+        "${_AMD_SMI_RULES_FILE}"
         "${CMAKE_CURRENT_LIST_DIR}/rocpd-validation-rules/transpose/cpu-metrics-rules.json"
         "${CMAKE_CURRENT_LIST_DIR}/rocpd-validation-rules/transpose/timer-sampling-rules.json"
         "${CMAKE_CURRENT_LIST_DIR}/rocpd-validation-rules/transpose/sdk-metrics-rules.json"


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
gfx1250 is not recognized as an Instinct GPU and lacks appropriate test counter configuration, causing counter collection tests to fail.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
  - Add gfx1250 to Instinct GPU lists in CMake and Python
  - Use GRBM_COUNT and SQ_WAVES counters for gfx1250 (SQ_INSTS_VALU missing from aqlprofile defaults, TA block merged into TX)
  - Add gfx1250-specific amd-smi validation rules with lower thresholds to match its smaller counter set (produces 268 total PMC event rows vs thousands on other Instinct GPUs - "Row count check passed for 'rocpd_pmc_event_6c73444ddb30a14b0df48479c9a45c78': 268 rows (minimum: 200)")
  - Per-metric AMD SMI sample counts (~22 each) observed from CTest output during Day 2 debugging; threshold set to 10 as conservative lower bound.
  
## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
  - Run validate-transpose-sampling-rocpd on gfx1250 to verify amd-smi thresholds
  - Run counter collection tests (transpose-rocprofiler) to verify GRBM_COUNT/SQ_WAVES selection
  
## Test Result

<!-- Briefly summarize test outcomes. -->

Verified on gfx1250: validate-transpose-sampling-rocpd passes with 268 PMC event rows and ~22 samples per metric. Counter collection tests pass with GRBM_COUNT/SQ_WAVES.
```
262/336 Test  #81: validate-transpose-rocprofiler-sampling-rocprof-device-0-GRBM_COUNT.txt-exists ................   Passed    0.00 sec
        Start 111: validate-openmp-target-sampling-perfetto
263/336 Test  #82: validate-transpose-rocprofiler-sampling-rocprof-device-0-SQ_WAVES.txt-exists ..................   Passed    0.00 sec
        Start 112: validate-openmp-target-sampling-rocpd
264/336 Test #112: validate-openmp-target-sampling-rocpd .........................................................   Passed    0.03 sec
        Start 220: validate-annotate-sampling-perfetto
265/336 Test  #87: validate-transpose-sampling-rocpd .............................................................   Passed    0.08 sec
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
