### PR TITLE
[rocprof-sys][gfx1250] Fix transferbench build for gfx1250

### DIFF
--- a/projects/rocprofiler-systems/examples/transferBench/TransferBench.hpp
+++ b/projects/rocprofiler-systems/examples/transferBench/TransferBench.hpp
@@ -561,7 +561,7 @@ operator+=(float4& a, const float4& b)
 // Macro for collecting CU/SM GFX kernel is running on
 #if defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) ||              \
     defined(__gfx1150__) || defined(__gfx1151__) || defined(__gfx1200__) ||              \
-    defined(__gfx1201__)
+    defined(__gfx1201__) || defined(__gfx1250__)
 #    define GetHwId(hwId) hwId = 0
 #elif defined(__NVCC__)
 #    define GetHwId(hwId) asm("mov.u32 %0, %smid;" : "=r"(hwId))


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
TransferBench fails to build on gfx1250 because it falls through to the HW_REG_HW_ID code path, which is not supported on this architecture.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Add gfx1250 to the GetHwId macro guard in TransferBench.hpp so it uses `hwId = 0` instead of the unsupported `s_getreg_b32 hwreg(HW_REG_HW_ID)` instruction.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Build TransferBench with gfx1250 target
- Run transferbench-validation-check on gfx1250

## Test Result

<!-- Briefly summarize test outcomes. -->
Verified on gfx1250 : TransferBench builds successfully.
transferbench-validation-check fails as expected due to single-GPU topology (no XGMI links) - not a code issue.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
