### PR TITLE
Remove the queue from a set of active queues only when last enqueued command is cleared

### DIFF
--- a/projects/clr/rocclr/platform/commandqueue.cpp
+++ b/projects/clr/rocclr/platform/commandqueue.cpp
@@ -219,11 +219,11 @@ void HostQueue::finish(bool cpu_wait) {
     // Runtime can clear the last command only if no other submissions occured
     // during finish()
     if (command == lastEnqueueCommand_) {
-      device_.removeFromActiveQueues(this);
       // Under Windows runtime can't destroy objects in the callback thread.
       // Also runtime should force interrupt before any destroy. Hence, if it was just gpu wait,
       // then keep the lastEnqueueCommand_ for the interrupt handling.
       if (IS_LINUX || cpu_wait || GPU_ENABLE_PAL != 0) {
+        device_.removeFromActiveQueues(this);
         lastEnqueueCommand_->release();
         lastEnqueueCommand_ = nullptr;
       }

--- a/projects/clr/rocclr/platform/commandqueue.hpp
+++ b/projects/clr/rocclr/platform/commandqueue.hpp
@@ -269,6 +269,9 @@ class HostQueue : public CommandQueue {
     // Release the last command in the batch
     if (lastEnqueueCommand_ != nullptr) {
       lastEnqueueCommand_->release();
+      if (GPU_ENABLE_PAL == 0) {
+        device_.addToActiveQueues(this);
+      }
     } else {
       // The queue becomes active. Add it to the set of activeQueues.
       device_.addToActiveQueues(this);

--- a/projects/clr/rocclr/platform/commandqueue.hpp
+++ b/projects/clr/rocclr/platform/commandqueue.hpp
@@ -269,9 +269,6 @@ class HostQueue : public CommandQueue {
     // Release the last command in the batch
     if (lastEnqueueCommand_ != nullptr) {
       lastEnqueueCommand_->release();
-      if (GPU_ENABLE_PAL == 0) {
-        device_.addToActiveQueues(this);
-      }
     } else {
       // The queue becomes active. Add it to the set of activeQueues.
       device_.addToActiveQueues(this);


### PR DESCRIPTION
## Motivation

Unit_hipMultiThreadStreams1_AsyncAsync fails when GPU_ENABLE_PAL=0. In HostQueue::finish(), lastEnqueueCommand_ is preserved, but the queue is still removed from activeQueues. When the next command is enqueued, the queue is not added back to activeQueues because lastEnqueueCommand_ is still non-null, which prevents the null stream from implicitly synchronizing with that queue.

## Technical Details

This change removes the queue from the set of active queues only when last enqueued command is cleared.

## JIRA ID

ROCM-20999

## Test Plan

Run Unit_hipMultiThreadStreams1_AsyncAsync 100x.

## Test Result

All iterations passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
