### PR TITLE
Add atomicAdd for half and bfloat

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
@@ -1896,8 +1896,50 @@ __BF16_DEVICE_STATIC__ __hip_bfloat162 h2trunc(const __hip_bfloat162 h) {
 }
 
 /**
+ * \ingroup HIP_INTRINSIC_BFLOAT16_MATH
+ * \brief Atomic add bfloat16
+ */
+inline __device__ __hip_bfloat16 atomicAdd(__hip_bfloat16* address, __hip_bfloat16 value) {
+  static_assert(sizeof(__hip_bfloat16_raw) == sizeof(unsigned short));
+  union u_hold {
+    __hip_bfloat16_raw h;
+    unsigned short s;
+  };
+  u_hold old_val, new_val;
+  old_val.s =
+      __hip_atomic_load((unsigned short*)address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+  do {
+    new_val.h = __hadd(old_val.h, value);
+  } while (!__hip_atomic_compare_exchange_strong((unsigned short*)address, &old_val.s, new_val.s,
+                                                 __ATOMIC_RELAXED, __ATOMIC_RELAXED,
+                                                 __HIP_MEMORY_SCOPE_AGENT));
+  return __hip_bfloat16{old_val.h};
+}
+
+/**
  * \ingroup HIP_INTRINSIC_BFLOAT162_MATH
  * \brief Atomic add bfloat162
+ */
+__BF16_DEVICE_STATIC__ __hip_bfloat162 atomicAdd(__hip_bfloat162* address, __hip_bfloat162 value) {
+  static_assert(sizeof(unsigned int) == sizeof(__hip_bfloat162_raw));
+  union u_hold {
+    __hip_bfloat162_raw h2r;
+    unsigned int u32;
+  };
+  u_hold old_val, new_val;
+  old_val.u32 =
+      __hip_atomic_load((unsigned int*)address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+  do {
+    new_val.h2r = __hadd2(old_val.h2r, value);
+  } while (!__hip_atomic_compare_exchange_strong((unsigned int*)address, &old_val.u32, new_val.u32,
+                                                 __ATOMIC_RELAXED, __ATOMIC_RELAXED,
+                                                 __HIP_MEMORY_SCOPE_AGENT));
+  return __hip_bfloat162{old_val.h2r};
+}
+
+/**
+ * \ingroup HIP_INTRINSIC_BFLOAT162_MATH
+ * \brief Unsafe Atomic add bfloat162
  */
 __BF16_DEVICE_STATIC__ __hip_bfloat162 unsafeAtomicAdd(__hip_bfloat162* address,
                                                        __hip_bfloat162 value) {

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
@@ -1900,8 +1900,8 @@ __BF16_DEVICE_STATIC__ __hip_bfloat162 h2trunc(const __hip_bfloat162 h) {
  * \brief Atomic add bfloat16
  */
 inline __device__ __hip_bfloat16 atomicAdd(__hip_bfloat16* address, __hip_bfloat16 value) {
-  return static_cast<__hip_bfloat16>(
-      __atomic_fetch_add((__bf16*)address, static_cast<__bf16>(value), __ATOMIC_SEQ_CST));
+  return static_cast<__hip_bfloat16>(__scoped_atomic_fetch_add(
+      (__bf16*)address, static_cast<__bf16>(value), __ATOMIC_ACQ_REL, __MEMORY_SCOPE_DEVICE));
 }
 
 /**
@@ -1918,12 +1918,13 @@ __BF16_DEVICE_STATIC__ __hip_bfloat162 atomicAdd(__hip_bfloat162* address, __hip
   } expected, desired;
 
   unsigned int* atomic_ptr = (unsigned int*)address;
-  expected.u32 = __atomic_load_n(atomic_ptr, __ATOMIC_RELAXED);
+  expected.u32 = __scoped_atomic_load_n(atomic_ptr, __ATOMIC_RELAXED, __MEMORY_SCOPE_DEVICE);
 
   do {
     desired.vec = expected.vec + static_cast<__bf16_2>(value);
-  } while (!__atomic_compare_exchange_n(atomic_ptr, &expected.u32, desired.u32, 0, __ATOMIC_ACQ_REL,
-                                        __ATOMIC_ACQUIRE));
+  } while (!__scoped_atomic_compare_exchange_n(atomic_ptr, &expected.u32, desired.u32, 0,
+                                               __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE,
+                                               __MEMORY_SCOPE_DEVICE));
   return static_cast<__hip_bfloat162>(expected.vec);
 }
 

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
@@ -1900,20 +1900,8 @@ __BF16_DEVICE_STATIC__ __hip_bfloat162 h2trunc(const __hip_bfloat162 h) {
  * \brief Atomic add bfloat16
  */
 inline __device__ __hip_bfloat16 atomicAdd(__hip_bfloat16* address, __hip_bfloat16 value) {
-  static_assert(sizeof(__hip_bfloat16_raw) == sizeof(unsigned short));
-  union u_hold {
-    __hip_bfloat16_raw h;
-    unsigned short s;
-  };
-  u_hold old_val, new_val;
-  old_val.s =
-      __hip_atomic_load((unsigned short*)address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
-  do {
-    new_val.h = __hadd(old_val.h, value);
-  } while (!__hip_atomic_compare_exchange_strong((unsigned short*)address, &old_val.s, new_val.s,
-                                                 __ATOMIC_RELAXED, __ATOMIC_RELAXED,
-                                                 __HIP_MEMORY_SCOPE_AGENT));
-  return __hip_bfloat16{old_val.h};
+  return static_cast<__hip_bfloat16>(
+      __atomic_fetch_add((__bf16*)address, static_cast<__bf16>(value), __ATOMIC_SEQ_CST));
 }
 
 /**
@@ -1921,20 +1909,22 @@ inline __device__ __hip_bfloat16 atomicAdd(__hip_bfloat16* address, __hip_bfloat
  * \brief Atomic add bfloat162
  */
 __BF16_DEVICE_STATIC__ __hip_bfloat162 atomicAdd(__hip_bfloat162* address, __hip_bfloat162 value) {
-  static_assert(sizeof(unsigned int) == sizeof(__hip_bfloat162_raw));
-  union u_hold {
-    __hip_bfloat162_raw h2r;
+  typedef __bf16 __bf16_2 __attribute__((ext_vector_type(2)));
+  static_assert(sizeof(__bf16_2) == sizeof(unsigned int));
+
+  union {
+    __bf16_2 vec;
     unsigned int u32;
-  };
-  u_hold old_val, new_val;
-  old_val.u32 =
-      __hip_atomic_load((unsigned int*)address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+  } expected, desired;
+
+  unsigned int* atomic_ptr = (unsigned int*)address;
+  expected.u32 = __atomic_load_n(atomic_ptr, __ATOMIC_RELAXED);
+
   do {
-    new_val.h2r = __hadd2(old_val.h2r, value);
-  } while (!__hip_atomic_compare_exchange_strong((unsigned int*)address, &old_val.u32, new_val.u32,
-                                                 __ATOMIC_RELAXED, __ATOMIC_RELAXED,
-                                                 __HIP_MEMORY_SCOPE_AGENT));
-  return __hip_bfloat162{old_val.h2r};
+    desired.vec = expected.vec + static_cast<__bf16_2>(value);
+  } while (!__atomic_compare_exchange_n(atomic_ptr, &expected.u32, desired.u32, 0, __ATOMIC_ACQ_REL,
+                                        __ATOMIC_ACQUIRE));
+  return static_cast<__hip_bfloat162>(expected.vec);
 }
 
 /**

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp16.h
@@ -867,38 +867,25 @@ inline __HOST_DEVICE__ __half2 __h2div(__half2 x, __half2 y) {
 // Device specific functions
 #if defined(__clang__) && defined(__HIP__)
 inline __device__ __half atomicAdd(__half* const address, const __half value) {
-  static_assert(sizeof(__half) == sizeof(unsigned short));
-  union u_hold {
-    __half_raw h;
-    unsigned short s;
-  };
-  u_hold old_val, new_val;
-  old_val.s = __hip_atomic_load((unsigned short*)address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
-  do {
-    __half temp = __hadd(__half{old_val.h}, value);
-    new_val.h = static_cast<__half_raw>(temp);
-  } while (!__hip_atomic_compare_exchange_strong((unsigned short*)address, &old_val.s, new_val.s,
-                                                 __ATOMIC_RELAXED, __ATOMIC_RELAXED,
-                                                 __HIP_MEMORY_SCOPE_SYSTEM));
-  return __half{old_val.h};
+  return static_cast<__half>(
+      __atomic_fetch_add((_Float16*)address, static_cast<_Float16>(value), __ATOMIC_SEQ_CST));
 }
 
 inline __device__ __half2 atomicAdd(__half2* const address, const __half2 value) {
-  static_assert(sizeof(__half2_raw) == sizeof(unsigned int));
-  union u_hold {
-    __half2_raw h2r;
+  static_assert(sizeof(_Float16_2) == sizeof(unsigned int));
+  union {
+    _Float16_2 vec;
     unsigned int u32;
-  };
-  u_hold old_val, new_val;
-  old_val.u32 =
-      __hip_atomic_load((unsigned int*)address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+  } expected, desired;
+
+  unsigned int* atomic_ptr = (unsigned int*)address;
+  expected.u32 = __atomic_load_n(atomic_ptr, __ATOMIC_RELAXED);
+
   do {
-    __half2 temp = __hadd2(__half2{old_val.h2r}, value);
-    new_val.h2r = static_cast<__half2_raw>(temp);
-  } while (!__hip_atomic_compare_exchange_strong((unsigned int*)address, &old_val.u32, new_val.u32,
-                                                 __ATOMIC_RELAXED, __ATOMIC_RELAXED,
-                                                 __HIP_MEMORY_SCOPE_SYSTEM));
-  return __half2{old_val.h2r};
+    desired.vec = expected.vec + static_cast<_Float16_2>(value);
+  } while (!__atomic_compare_exchange_n(atomic_ptr, &expected.u32, desired.u32, 0, __ATOMIC_ACQ_REL,
+                                        __ATOMIC_ACQUIRE));
+  return static_cast<__half2>(expected.vec);
 }
 
 inline __device__ __half2 unsafeAtomicAdd(__half2* address, __half2 value) {

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp16.h
@@ -867,8 +867,8 @@ inline __HOST_DEVICE__ __half2 __h2div(__half2 x, __half2 y) {
 // Device specific functions
 #if defined(__clang__) && defined(__HIP__)
 inline __device__ __half atomicAdd(__half* const address, const __half value) {
-  return static_cast<__half>(
-      __atomic_fetch_add((_Float16*)address, static_cast<_Float16>(value), __ATOMIC_SEQ_CST));
+  return static_cast<__half>(__scoped_atomic_fetch_add(
+      (_Float16*)address, static_cast<_Float16>(value), __ATOMIC_ACQ_REL, __MEMORY_SCOPE_DEVICE));
 }
 
 inline __device__ __half2 atomicAdd(__half2* const address, const __half2 value) {
@@ -879,12 +879,13 @@ inline __device__ __half2 atomicAdd(__half2* const address, const __half2 value)
   } expected, desired;
 
   unsigned int* atomic_ptr = (unsigned int*)address;
-  expected.u32 = __atomic_load_n(atomic_ptr, __ATOMIC_RELAXED);
+  expected.u32 = __scoped_atomic_load_n(atomic_ptr, __ATOMIC_RELAXED, __MEMORY_SCOPE_DEVICE);
 
   do {
     desired.vec = expected.vec + static_cast<_Float16_2>(value);
-  } while (!__atomic_compare_exchange_n(atomic_ptr, &expected.u32, desired.u32, 0, __ATOMIC_ACQ_REL,
-                                        __ATOMIC_ACQUIRE));
+  } while (!__scoped_atomic_compare_exchange_n(atomic_ptr, &expected.u32, desired.u32, 0,
+                                               __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE,
+                                               __MEMORY_SCOPE_DEVICE));
   return static_cast<__half2>(expected.vec);
 }
 

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp16.h
@@ -867,8 +867,9 @@ inline __HOST_DEVICE__ __half2 __h2div(__half2 x, __half2 y) {
 // Device specific functions
 #if defined(__clang__) && defined(__HIP__)
 inline __device__ __half atomicAdd(__half* const address, const __half value) {
-  return static_cast<__half>(__scoped_atomic_fetch_add(
-      (_Float16*)address, static_cast<_Float16>(value), __ATOMIC_ACQ_REL, __MEMORY_SCOPE_DEVICE));
+  return static_cast<__half>(__scoped_atomic_fetch_add((_Float16*)address,
+                                                       static_cast<__half_raw>(value).data,
+                                                       __ATOMIC_ACQ_REL, __MEMORY_SCOPE_DEVICE));
 }
 
 inline __device__ __half2 atomicAdd(__half2* const address, const __half2 value) {

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp16.h
@@ -867,9 +867,9 @@ inline __HOST_DEVICE__ __half2 __h2div(__half2 x, __half2 y) {
 // Device specific functions
 #if defined(__clang__) && defined(__HIP__)
 inline __device__ __half atomicAdd(__half* const address, const __half value) {
-  return static_cast<__half>(__scoped_atomic_fetch_add((_Float16*)address,
-                                                       static_cast<__half_raw>(value).data,
-                                                       __ATOMIC_ACQ_REL, __MEMORY_SCOPE_DEVICE));
+  return __half_raw{__scoped_atomic_fetch_add((_Float16*)address,
+                                              static_cast<__half_raw>(value).data,
+                                              __ATOMIC_ACQ_REL, __MEMORY_SCOPE_DEVICE)};
 }
 
 inline __device__ __half2 atomicAdd(__half2* const address, const __half2 value) {

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp16.h
@@ -864,8 +864,43 @@ inline __HOST_DEVICE__ __half2 __h2div(__half2 x, __half2 y) {
   return __half2{static_cast<__half2_raw>(x).data / static_cast<__half2_raw>(y).data};
 }
 
-// Atomic
+// Device specific functions
 #if defined(__clang__) && defined(__HIP__)
+inline __device__ __half atomicAdd(__half* const address, const __half value) {
+  static_assert(sizeof(__half) == sizeof(unsigned short));
+  union u_hold {
+    __half_raw h;
+    unsigned short s;
+  };
+  u_hold old_val, new_val;
+  old_val.s = __hip_atomic_load((unsigned short*)address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+  do {
+    __half temp = __hadd(__half{old_val.h}, value);
+    new_val.h = static_cast<__half_raw>(temp);
+  } while (!__hip_atomic_compare_exchange_strong((unsigned short*)address, &old_val.s, new_val.s,
+                                                 __ATOMIC_RELAXED, __ATOMIC_RELAXED,
+                                                 __HIP_MEMORY_SCOPE_SYSTEM));
+  return __half{old_val.h};
+}
+
+inline __device__ __half2 atomicAdd(__half2* const address, const __half2 value) {
+  static_assert(sizeof(__half2_raw) == sizeof(unsigned int));
+  union u_hold {
+    __half2_raw h2r;
+    unsigned int u32;
+  };
+  u_hold old_val, new_val;
+  old_val.u32 =
+      __hip_atomic_load((unsigned int*)address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+  do {
+    __half2 temp = __hadd2(__half2{old_val.h2r}, value);
+    new_val.h2r = static_cast<__half2_raw>(temp);
+  } while (!__hip_atomic_compare_exchange_strong((unsigned int*)address, &old_val.u32, new_val.u32,
+                                                 __ATOMIC_RELAXED, __ATOMIC_RELAXED,
+                                                 __HIP_MEMORY_SCOPE_SYSTEM));
+  return __half2{old_val.h2r};
+}
+
 inline __device__ __half2 unsafeAtomicAdd(__half2* address, __half2 value) {
 #if __has_builtin(__builtin_amdgcn_flat_atomic_fadd_v2f16)
   // The api expects an ext_vector_type of half
@@ -894,6 +929,7 @@ inline __device__ __half2 unsafeAtomicAdd(__half2* address, __half2 value) {
   return old_val.h2r;
 #endif
 }
+
 inline __device__ __half unsafeAtomicAdd(__half* address, __half value) {
   static_assert(sizeof(unsigned short int) == sizeof(__half_raw));
   unsigned short int* address_as_short = reinterpret_cast<unsigned short int*>(address);

--- a/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
@@ -299,6 +299,12 @@ deviceLib:
   Unit_half_min_max_host:
     <<: *level_2
     tags: [types]
+  Unit_bf16_atomic_add:
+    <<: *level_2
+    tags: [atomics, types]
+  Unit_fp16_atomic_add:
+    <<: *level_2
+    tags: [atomics, types]
   Unit_fp8_ocp_bool_host:
     <<: *level_2
     tags: [types]

--- a/projects/hip-tests/catch/unit/deviceLib/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/deviceLib/CMakeLists.txt
@@ -42,8 +42,6 @@ set(TEST_SRC
     hipTestDeviceDouble.cc
     hipTestHost.cc
     hadd.cc
-    bfloat16_atomic_test.cc
-    fp16_atomic_test.cc
 )
 if(HIP_PLATFORM MATCHES "nvidia")
   set_source_files_properties(hipTestHost.cc PROPERTIES COMPILE_OPTIONS "--expt-relaxed-constexpr")
@@ -75,6 +73,8 @@ set(AMD_TEST_SRC
     fp6_ocp.cc
     fp4_ocp.cc
     memcpy_async.cc
+    bfloat16_atomic_test.cc
+    fp16_atomic_test.cc
 )
 
 set(AMD_ARCH_SPEC_TEST_SRC

--- a/projects/hip-tests/catch/unit/deviceLib/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/deviceLib/CMakeLists.txt
@@ -42,6 +42,8 @@ set(TEST_SRC
     hipTestDeviceDouble.cc
     hipTestHost.cc
     hadd.cc
+    bfloat16_atomic_test.cc
+    fp16_atomic_test.cc
 )
 if(HIP_PLATFORM MATCHES "nvidia")
   set_source_files_properties(hipTestHost.cc PROPERTIES COMPILE_OPTIONS "--expt-relaxed-constexpr")

--- a/projects/hip-tests/catch/unit/deviceLib/bfloat16_atomic_test.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/bfloat16_atomic_test.cc
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip_test_common.hh>
+#include <hip/hip_bf16.h>
+
+static __global__ void bf16_atomic_add_kernel(__hip_bfloat16* result, float* values, size_t size) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < size) {
+    atomicAdd(result, __float2bfloat16(values[i]));
+  }
+}
+
+static __global__ void bf162_atomic_add_kernel(__hip_bfloat162* result, float2* values,
+                                               size_t size) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < size) {
+    atomicAdd(result, __float22bfloat162_rn(values[i]));
+  }
+}
+
+HIP_TEST_CASE(Unit_bf16_atomic_add) {
+  SECTION("bf16 atomic add") {
+    constexpr size_t num_threads = 256;
+    constexpr size_t num_blocks = 4;
+    constexpr size_t total_threads = num_threads * num_blocks;
+
+    std::vector<float> h_values(total_threads);
+    for (size_t i = 0; i < total_threads; i++) {
+      h_values[i] = 1.0f;  // Each thread adds 1.0
+    }
+
+    float* d_values;
+    __hip_bfloat16* d_result;
+    HIP_CHECK(hipMalloc(&d_values, sizeof(float) * total_threads));
+    HIP_CHECK(hipMalloc(&d_result, sizeof(__hip_bfloat16)));
+
+    HIP_CHECK(
+        hipMemcpy(d_values, h_values.data(), sizeof(float) * total_threads, hipMemcpyHostToDevice));
+
+    __hip_bfloat16 zero = __float2bfloat16(0.0f);
+    HIP_CHECK(hipMemcpy(d_result, &zero, sizeof(__hip_bfloat16), hipMemcpyHostToDevice));
+
+    bf16_atomic_add_kernel<<<num_blocks, num_threads>>>(d_result, d_values, total_threads);
+    HIP_CHECK(hipDeviceSynchronize());
+
+    __hip_bfloat16 h_result;
+    HIP_CHECK(hipMemcpy(&h_result, d_result, sizeof(__hip_bfloat16), hipMemcpyDeviceToHost));
+
+    float expected = static_cast<float>(total_threads);
+    float actual = __bfloat162float(h_result);
+
+    INFO("Expected: " << expected << " Actual: " << actual);
+    // Allow small error due to bfloat16 precision
+    REQUIRE(std::fabs(actual - expected) / expected < 0.01f);
+
+    HIP_CHECK(hipFree(d_values));
+    HIP_CHECK(hipFree(d_result));
+  }
+
+  SECTION("bf162 atomic add") {
+    constexpr size_t num_threads = 256;
+    constexpr size_t num_blocks = 4;
+    constexpr size_t total_threads = num_threads * num_blocks;
+
+    std::vector<float2> h_values(total_threads);
+    for (size_t i = 0; i < total_threads; i++) {
+      h_values[i] = float2{1.0f, 2.0f};  // Each thread adds (1.0, 2.0)
+    }
+
+    float2* d_values;
+    __hip_bfloat162* d_result;
+    HIP_CHECK(hipMalloc(&d_values, sizeof(float2) * total_threads));
+    HIP_CHECK(hipMalloc(&d_result, sizeof(__hip_bfloat162)));
+
+    HIP_CHECK(hipMemcpy(d_values, h_values.data(), sizeof(float2) * total_threads,
+                        hipMemcpyHostToDevice));
+
+    __hip_bfloat162 zero = __float22bfloat162_rn(float2{0.0f, 0.0f});
+    HIP_CHECK(hipMemcpy(d_result, &zero, sizeof(__hip_bfloat162), hipMemcpyHostToDevice));
+
+    bf162_atomic_add_kernel<<<num_blocks, num_threads>>>(d_result, d_values, total_threads);
+    HIP_CHECK(hipDeviceSynchronize());
+
+    __hip_bfloat162 h_result;
+    HIP_CHECK(hipMemcpy(&h_result, d_result, sizeof(__hip_bfloat162), hipMemcpyDeviceToHost));
+
+    float2 expected =
+        float2{static_cast<float>(total_threads), static_cast<float>(total_threads * 2)};
+    float2 actual = __bfloat1622float2(h_result);
+
+    INFO("Expected: (" << expected.x << ", " << expected.y << ") Actual: (" << actual.x << ", "
+                       << actual.y << ")");
+    REQUIRE(std::fabs(actual.x - expected.x) / expected.x < 0.01f);
+    REQUIRE(std::fabs(actual.y - expected.y) / expected.y < 0.01f);
+
+    HIP_CHECK(hipFree(d_values));
+    HIP_CHECK(hipFree(d_result));
+  }
+}

--- a/projects/hip-tests/catch/unit/deviceLib/bfloat16_atomic_test.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/bfloat16_atomic_test.cc
@@ -24,7 +24,7 @@ static __global__ void bf162_atomic_add_kernel(__hip_bfloat162* result, float2* 
 
 HIP_TEST_CASE(Unit_bf16_atomic_add) {
   SECTION("bf16 atomic add") {
-    constexpr size_t num_threads = 256;
+    constexpr size_t num_threads = 32;
     constexpr size_t num_blocks = 4;
     constexpr size_t total_threads = num_threads * num_blocks;
 
@@ -62,7 +62,7 @@ HIP_TEST_CASE(Unit_bf16_atomic_add) {
   }
 
   SECTION("bf162 atomic add") {
-    constexpr size_t num_threads = 256;
+    constexpr size_t num_threads = 32;
     constexpr size_t num_blocks = 4;
     constexpr size_t total_threads = num_threads * num_blocks;
 

--- a/projects/hip-tests/catch/unit/deviceLib/fp16_atomic_test.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp16_atomic_test.cc
@@ -39,8 +39,8 @@ HIP_TEST_CASE(Unit_fp16_atomic_add) {
     HIP_CHECK(hipMalloc(&d_values, sizeof(float) * total_threads));
     HIP_CHECK(hipMalloc(&d_result, sizeof(__half)));
 
-    HIP_CHECK(hipMemcpy(d_values, h_values.data(), sizeof(float) * total_threads,
-                        hipMemcpyHostToDevice));
+    HIP_CHECK(
+        hipMemcpy(d_values, h_values.data(), sizeof(float) * total_threads, hipMemcpyHostToDevice));
 
     __half zero = __float2half_rn(0.0f);
     HIP_CHECK(hipMemcpy(d_result, &zero, sizeof(__half), hipMemcpyHostToDevice));
@@ -89,7 +89,8 @@ HIP_TEST_CASE(Unit_fp16_atomic_add) {
     __half2 h_result;
     HIP_CHECK(hipMemcpy(&h_result, d_result, sizeof(__half2), hipMemcpyDeviceToHost));
 
-    float2 expected = float2{static_cast<float>(total_threads), static_cast<float>(total_threads * 2)};
+    float2 expected =
+        float2{static_cast<float>(total_threads), static_cast<float>(total_threads * 2)};
     float2 actual = __half22float2(h_result);
 
     INFO("Expected: (" << expected.x << ", " << expected.y << ") Actual: (" << actual.x << ", "
@@ -102,7 +103,7 @@ HIP_TEST_CASE(Unit_fp16_atomic_add) {
   }
 
   SECTION("fp16 atomic add - concurrent stress test") {
-    constexpr size_t num_threads = 1024;
+    constexpr size_t num_threads = 256;
     constexpr size_t num_blocks = 16;
     constexpr size_t total_threads = num_threads * num_blocks;
 
@@ -118,8 +119,8 @@ HIP_TEST_CASE(Unit_fp16_atomic_add) {
     HIP_CHECK(hipMalloc(&d_values, sizeof(float) * total_threads));
     HIP_CHECK(hipMalloc(&d_result, sizeof(__half)));
 
-    HIP_CHECK(hipMemcpy(d_values, h_values.data(), sizeof(float) * total_threads,
-                        hipMemcpyHostToDevice));
+    HIP_CHECK(
+        hipMemcpy(d_values, h_values.data(), sizeof(float) * total_threads, hipMemcpyHostToDevice));
 
     __half zero = __float2half_rn(0.0f);
     HIP_CHECK(hipMemcpy(d_result, &zero, sizeof(__half), hipMemcpyHostToDevice));

--- a/projects/hip-tests/catch/unit/deviceLib/fp16_atomic_test.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp16_atomic_test.cc
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip/hip_fp16.h>
+
+#include <cmath>
+#include <hip_test_common.hh>
+
+static __global__ void fp16_atomic_add_kernel(__half* result, float* values, size_t size) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < size) {
+    atomicAdd(result, __float2half_rn(values[i]));
+  }
+}
+
+static __global__ void fp162_atomic_add_kernel(__half2* result, float2* values, size_t size) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < size) {
+    atomicAdd(result, __float22half2_rn(values[i]));
+  }
+}
+
+HIP_TEST_CASE(Unit_fp16_atomic_add) {
+  SECTION("fp16 atomic add") {
+    constexpr size_t num_threads = 256;
+    constexpr size_t num_blocks = 4;
+    constexpr size_t total_threads = num_threads * num_blocks;
+
+    std::vector<float> h_values(total_threads);
+    for (size_t i = 0; i < total_threads; i++) {
+      h_values[i] = 1.0f;  // Each thread adds 1.0
+    }
+
+    float* d_values;
+    __half* d_result;
+    HIP_CHECK(hipMalloc(&d_values, sizeof(float) * total_threads));
+    HIP_CHECK(hipMalloc(&d_result, sizeof(__half)));
+
+    HIP_CHECK(hipMemcpy(d_values, h_values.data(), sizeof(float) * total_threads,
+                        hipMemcpyHostToDevice));
+
+    __half zero = __float2half_rn(0.0f);
+    HIP_CHECK(hipMemcpy(d_result, &zero, sizeof(__half), hipMemcpyHostToDevice));
+
+    fp16_atomic_add_kernel<<<num_blocks, num_threads>>>(d_result, d_values, total_threads);
+    HIP_CHECK(hipDeviceSynchronize());
+
+    __half h_result;
+    HIP_CHECK(hipMemcpy(&h_result, d_result, sizeof(__half), hipMemcpyDeviceToHost));
+
+    float expected = static_cast<float>(total_threads);
+    float actual = __half2float(h_result);
+
+    INFO("Expected: " << expected << " Actual: " << actual);
+    // Allow small error due to fp16 precision (10 bits mantissa)
+    REQUIRE(std::fabs(actual - expected) / expected < 0.01f);
+
+    HIP_CHECK(hipFree(d_values));
+    HIP_CHECK(hipFree(d_result));
+  }
+
+  SECTION("fp162 atomic add") {
+    constexpr size_t num_threads = 256;
+    constexpr size_t num_blocks = 4;
+    constexpr size_t total_threads = num_threads * num_blocks;
+
+    std::vector<float2> h_values(total_threads);
+    for (size_t i = 0; i < total_threads; i++) {
+      h_values[i] = float2{1.0f, 2.0f};  // Each thread adds (1.0, 2.0)
+    }
+
+    float2* d_values;
+    __half2* d_result;
+    HIP_CHECK(hipMalloc(&d_values, sizeof(float2) * total_threads));
+    HIP_CHECK(hipMalloc(&d_result, sizeof(__half2)));
+
+    HIP_CHECK(hipMemcpy(d_values, h_values.data(), sizeof(float2) * total_threads,
+                        hipMemcpyHostToDevice));
+
+    __half2 zero = __float22half2_rn(float2{0.0f, 0.0f});
+    HIP_CHECK(hipMemcpy(d_result, &zero, sizeof(__half2), hipMemcpyHostToDevice));
+
+    fp162_atomic_add_kernel<<<num_blocks, num_threads>>>(d_result, d_values, total_threads);
+    HIP_CHECK(hipDeviceSynchronize());
+
+    __half2 h_result;
+    HIP_CHECK(hipMemcpy(&h_result, d_result, sizeof(__half2), hipMemcpyDeviceToHost));
+
+    float2 expected = float2{static_cast<float>(total_threads), static_cast<float>(total_threads * 2)};
+    float2 actual = __half22float2(h_result);
+
+    INFO("Expected: (" << expected.x << ", " << expected.y << ") Actual: (" << actual.x << ", "
+                       << actual.y << ")");
+    REQUIRE(std::fabs(actual.x - expected.x) / expected.x < 0.01f);
+    REQUIRE(std::fabs(actual.y - expected.y) / expected.y < 0.01f);
+
+    HIP_CHECK(hipFree(d_values));
+    HIP_CHECK(hipFree(d_result));
+  }
+
+  SECTION("fp16 atomic add - concurrent stress test") {
+    constexpr size_t num_threads = 1024;
+    constexpr size_t num_blocks = 16;
+    constexpr size_t total_threads = num_threads * num_blocks;
+
+    std::vector<float> h_values(total_threads);
+    float sum_expected = 0.0f;
+    for (size_t i = 0; i < total_threads; i++) {
+      h_values[i] = static_cast<float>(i % 10) * 0.5f;
+      sum_expected += h_values[i];
+    }
+
+    float* d_values;
+    __half* d_result;
+    HIP_CHECK(hipMalloc(&d_values, sizeof(float) * total_threads));
+    HIP_CHECK(hipMalloc(&d_result, sizeof(__half)));
+
+    HIP_CHECK(hipMemcpy(d_values, h_values.data(), sizeof(float) * total_threads,
+                        hipMemcpyHostToDevice));
+
+    __half zero = __float2half_rn(0.0f);
+    HIP_CHECK(hipMemcpy(d_result, &zero, sizeof(__half), hipMemcpyHostToDevice));
+
+    fp16_atomic_add_kernel<<<num_blocks, num_threads>>>(d_result, d_values, total_threads);
+    HIP_CHECK(hipDeviceSynchronize());
+
+    __half h_result;
+    HIP_CHECK(hipMemcpy(&h_result, d_result, sizeof(__half), hipMemcpyDeviceToHost));
+
+    float actual = __half2float(h_result);
+
+    INFO("Expected: " << sum_expected << " Actual: " << actual);
+    // Higher tolerance for large sums due to accumulated rounding
+    REQUIRE(std::fabs(actual - sum_expected) / sum_expected < 0.05f);
+
+    HIP_CHECK(hipFree(d_values));
+    HIP_CHECK(hipFree(d_result));
+  }
+}


### PR DESCRIPTION
## Motivation

Add `atomicAdd` for half and bfloat types along with its tests

## Technical Details

Implement `atomicAdd` using Load/CAS. Also add tests for it.

## JIRA ID

NA

## Test Plan

Add new tests for the new APIs.

## Test Result

Tests are passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Co-authored-by: Claude <noreply@anthropic.com>