### PR TITLE
[AMD-SMI] Switch to stdint.h for GO binding support

### DIFF
--- a/projects/amdsmi/goamdsmi.go
+++ b/projects/amdsmi/goamdsmi.go
@@ -26,7 +26,7 @@ package goamdsmi
 /*
 #cgo CFLAGS: -Wall -I/opt/rocm/include
 #cgo LDFLAGS: -L/opt/rocm/lib -L/opt/rocm/lib64 -lgoamdsmi_shim64 -Wl,--unresolved-symbols=ignore-in-object-files
-#include <cstdint>
+#include <stdint.h>
 #include <amdsmi_go_shim.h>
 */
 import "C"


### PR DESCRIPTION
## Motivation

Resolves https://github.com/ROCm/rocm-systems/issues/5195.

## Technical Details

https://github.com/ROCm/rocm-systems/commit/924a06d1e16cae0ecee07f519ff2bbe254bb9f72 broke go bindings by switching to `cstdint`. Reverting back to `stdint.h` resolve this.

## JIRA ID

N/A

## Test Plan

- Build a sample `main.go` test file with `go build`.

## Test Result

- Prior to the patch, builds fails with 
```
/home/rocm/go/pkg/mod/github.com/!r!o!cm/amdsmi@v0.0.0-20251117222445-a044536b8d69/goamdsmi.go:29:10: fatal error: cstdint: No such file or directory
   29 | #include <cstdint>
      |          ^~~~~~~~~
compilation terminated.
```
- Post patch, build is successful.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
