### PR TITLE
[rocprofiler-compute] Update git version in Ubuntu GHCR CI images

### DIFF
--- a/projects/rocprofiler-compute/docker/Dockerfile.ubuntu.ci
+++ b/projects/rocprofiler-compute/docker/Dockerfile.ubuntu.ci
@@ -18,7 +18,8 @@ ENV LIBRARY_PATH="/usr/local/lib:/usr/local/lib64"
 ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64"
 ENV CMAKE_PREFIX_PATH="/usr/local"
 
-RUN apt-get update && \
+RUN sudo add-apt-repository ppa:git-core/ppa && \
+    apt-get update && \
     apt-get dist-upgrade -y && \
     apt-get install -y autoconf autotools-dev bash-completion build-essential bzip2 cmake curl environment-modules git-core gnupg2 gzip libtool locales lsb-release m4 python3-pip unzip wget zip zlib1g-dev && \
     apt-get autoclean && \

--- a/projects/rocprofiler-compute/docker/Dockerfile.ubuntu.ci
+++ b/projects/rocprofiler-compute/docker/Dockerfile.ubuntu.ci
@@ -18,8 +18,11 @@ ENV LIBRARY_PATH="/usr/local/lib:/usr/local/lib64"
 ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64"
 ENV CMAKE_PREFIX_PATH="/usr/local"
 
-RUN sudo add-apt-repository ppa:git-core/ppa && \
-    apt-get update && \
+# Add git-core repository to get latest versions of git
+RUN apt-get install -y software-properties-common && \
+    add-apt-repository ppa:git-core/ppa
+
+RUN apt-get update && \
     apt-get dist-upgrade -y && \
     apt-get install -y autoconf autotools-dev bash-completion build-essential bzip2 cmake curl environment-modules git-core gnupg2 gzip libtool locales lsb-release m4 python3-pip unzip wget zip zlib1g-dev && \
     apt-get autoclean && \

--- a/projects/rocprofiler-compute/docker/Dockerfile.ubuntu.ci
+++ b/projects/rocprofiler-compute/docker/Dockerfile.ubuntu.ci
@@ -19,11 +19,11 @@ ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/local/lib64"
 ENV CMAKE_PREFIX_PATH="/usr/local"
 
 # Add git-core repository to get latest versions of git
-RUN apt-get install -y software-properties-common && \
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
     add-apt-repository ppa:git-core/ppa
 
-RUN apt-get update && \
-    apt-get dist-upgrade -y && \
+RUN apt-get dist-upgrade -y && \
     apt-get install -y autoconf autotools-dev bash-completion build-essential bzip2 cmake curl environment-modules git-core gnupg2 gzip libtool locales lsb-release m4 python3-pip unzip wget zip zlib1g-dev && \
     apt-get autoclean && \
     locale -a


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
#5144 adds some new submodules, and the current CI image is failing to clone the repo with the submodules due to 22.04 using an older version of git.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Update `Dockerfile.ubuntu.ci` to include the git-core ppa repository so we can grab the latest version of git
  - Previous version installed was 2.34.1, which was the latest version available with default ubuntu 22.04 repos

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Ensure Dockers build properly
- Once merged, verify that the updated images are able to pass the checkout step in #5144 checks 

## Test Result

<!-- Briefly summarize test outcomes. -->
TBA

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
