### PR TITLE
[rocDecode] Merge debug logging into the new logging mechanism.

### DIFF
--- a/projects/rocdecode/CHANGELOG.md
+++ b/projects/rocdecode/CHANGELOG.md
@@ -20,6 +20,7 @@ Full documentation for rocDecode is available at [https://rocm.docs.amd.com/proj
 * Logging improvement: Added duration to function exit logs and optimized log message formatting to reduce runtime overhead.
 * Logging improvement: Merged all logger instances into one global instance.
 * Logging improvement: Unified logging format in utility classes with core library logging format.
+* Logging improvement: Moved debug logging from a compile-time switch to the runtime logger level controlled by ROCDEC_LOG_LEVEL (debug = 4).
 * Feature: support for user set output surface format.
 
 ## rocDecode 1.7.0 for ROCm 7.2.1

--- a/projects/rocdecode/src/commons.h
+++ b/projects/rocdecode/src/commons.h
@@ -34,13 +34,8 @@ THE SOFTWARE.
 #include <stdint.h>
 #include <sys/syscall.h>
 
-#if DBGINFO
 #define MSG(X) std::clog << X << std::endl;
 #define MSG_NO_NEWLINE(X) std::clog << X;
-#else
-#define MSG(X) ;
-#define MSG_NO_NEWLINE(X) ;
-#endif
 
 #define ROCDEC_TOSTR(X) std::to_string(X)
 #define ROCDEC_STR(X) std::string(X)

--- a/projects/rocdecode/src/parser/av1_parser.cpp
+++ b/projects/rocdecode/src/parser/av1_parser.cpp
@@ -62,6 +62,7 @@ rocDecStatus Av1VideoParser::UnInitialize() {
 rocDecStatus Av1VideoParser::ParseVideoData(RocdecSourceDataPacket *p_data) {
     FunctionEntryLog(g_rocdec_logger);
     if (p_data->payload && p_data->payload_size) {
+        DebugLog(g_rocdec_logger, ROCDEC_STR("Parsing picture ") + ROCDEC_TOSTR(pic_count_) + ROCDEC_STR(" with payload size ") + ROCDEC_TOSTR(p_data->payload_size) + ROCDEC_STR(" bytes ..."));
         curr_pts_ = p_data->pts;
         if (ParsePictureData(p_data->payload, p_data->payload_size) != PARSER_OK) {
             ErrorLog(g_rocdec_logger, "Error occurred in picture data parsing.");
@@ -501,9 +502,9 @@ ParserResult Av1VideoParser::SendPicForDecode() {
     }
     dec_pic_params_.slice_params.av1 = tile_param_list_.data();
 
-#if DBGINFO
-    PrintVaapiParams();
-#endif // DBGINFO
+    if (g_rocdec_logger.GetLogLevel() >= kRocDecLogDebug) {
+        PrintVaapiParams();
+    }
 
     if (pfn_decode_picture_cb_(parser_params_.user_data, &dec_pic_params_) == 0) {
         ErrorLog(g_rocdec_logger, "Decode error occurred.");
@@ -604,9 +605,9 @@ ParserResult Av1VideoParser::DecodeFrameWrapup() {
         // For show_existing_frame = 0 case, post processing filtering is done in HW
         UpdateRefFrames();
     }
-#if DBGINFO
-    PrintDpb();
-#endif // DBGINFO
+    if (g_rocdec_logger.GetLogLevel() >= kRocDecLogDebug) {
+        PrintDpb();
+    }
 
     // Output decoded pictures from DPB if any are ready
     if (pfn_display_picture_cb_ && num_output_pics_ > 0) {
@@ -2573,7 +2574,6 @@ ParserResult Av1VideoParser::FilmGrainParams(const uint8_t *p_stream, size_t &of
     return PARSER_OK;
 }
 
-#if DBGINFO
 void Av1VideoParser::PrintVaapiParams() {
     int i, j;
     MSG("=======================");
@@ -2853,4 +2853,3 @@ void Av1VideoParser::PrintDpb() {
         MSG("");
     }
 }
-#endif // DBGINFO

--- a/projects/rocdecode/src/parser/av1_parser.h
+++ b/projects/rocdecode/src/parser/av1_parser.h
@@ -654,12 +654,10 @@ protected:
         return (v << 1) - m + extra_bit;
     }
 
-#if DBGINFO
     /*! \brief Function to log VAAPI parameters
      */
     void PrintVaapiParams();
     /*! \brief Function to log DPB and decode/display buffer pool info
      */
     void PrintDpb();
-#endif // DBGINFO
 };

--- a/projects/rocdecode/src/parser/avc_parser.cpp
+++ b/projects/rocdecode/src/parser/avc_parser.cpp
@@ -69,6 +69,7 @@ rocDecStatus AvcVideoParser::UnInitialize() {
 rocDecStatus AvcVideoParser::ParseVideoData(RocdecSourceDataPacket *p_data) {
     FunctionEntryLog(g_rocdec_logger);
     if (p_data->payload && p_data->payload_size) {
+        DebugLog(g_rocdec_logger, ROCDEC_STR("Parsing picture ") + ROCDEC_TOSTR(pic_count_) + ROCDEC_STR(" with payload size ") + ROCDEC_TOSTR(p_data->payload_size) + ROCDEC_STR(" bytes ..."));
         curr_pts_ = p_data->pts;
         if (ParsePictureData(p_data->payload, p_data->payload_size) != PARSER_OK) {
             ErrorLog(g_rocdec_logger, ROCDEC_STR("Parser failed!"));
@@ -735,9 +736,9 @@ ParserResult AvcVideoParser::SendPicForDecode() {
         }
     }
 
-#if DBGINFO
-    PrintVappiBufInfo();
-#endif // DBGINFO
+    if (g_rocdec_logger.GetLogLevel() >= kRocDecLogDebug) {
+        PrintVappiBufInfo();
+    }
 
     if (pfn_decode_picture_cb_(parser_params_.user_data, &dec_pic_params_) == 0) {
         ErrorLog(g_rocdec_logger, "Decode error occurred.");
@@ -1046,9 +1047,9 @@ ParserResult AvcVideoParser::ParseSps(uint8_t *p_stream, size_t size) {
 
     p_sps->is_received = 1;  // confirm SPS with seq_parameter_set_id received (but not activated)
 
-#if DBGINFO
-    PrintSps(p_sps);
-#endif // DBGINFO
+    if (g_rocdec_logger.GetLogLevel() >= kRocDecLogDebug) {
+        PrintSps(p_sps);
+    }
     FunctionExitLog(g_rocdec_logger);
     return PARSER_OK;
 }
@@ -1230,9 +1231,9 @@ ParserResult AvcVideoParser::ParsePps(uint8_t *p_stream, size_t stream_size_in_b
 
     p_pps->is_received = 1;  // confirm PPS with pic_parameter_set_id received (but not activated)
 
-#if DBGINFO
-    PrintPps(p_pps);
-#endif // DBGINFO
+    if (g_rocdec_logger.GetLogLevel() >= kRocDecLogDebug) {
+        PrintPps(p_pps);
+    }
     FunctionExitLog(g_rocdec_logger);
     return PARSER_OK;
 }
@@ -1589,9 +1590,9 @@ ParserResult AvcVideoParser::ParseSliceHeader(uint8_t *p_stream, size_t stream_s
         p_slice_header->slice_group_change_cycle = Parser::ReadBits(p_stream, offset, size);
     }
 
-#if DBGINFO
-    PrintSliceHeader(p_slice_header);
-#endif // DBGINFO
+    if (g_rocdec_logger.GetLogLevel() >= kRocDecLogDebug) {
+        PrintSliceHeader(p_slice_header);
+    }
     FunctionExitLog(g_rocdec_logger);
     return PARSER_OK;
 }
@@ -3273,9 +3274,9 @@ ParserResult AvcVideoParser::InsertCurrPicIntoDpb() {
         return PARSER_FAIL;
     }
 
-#if DBGINFO
-    PrintDpb();
-#endif // DBGINFO
+    if (g_rocdec_logger.GetLogLevel() >= kRocDecLogDebug) {
+        PrintDpb();
+    }
     return PARSER_OK;
 }
 
@@ -3310,7 +3311,6 @@ ParserResult AvcVideoParser::FlushDpb() {
     return PARSER_OK;
 }
 
-#if DBGINFO
 void AvcVideoParser::PrintSps(AvcSeqParameterSet *p_sps) {
     uint32_t i, j;
     
@@ -3601,4 +3601,3 @@ void AvcVideoParser::PrintVappiBufInfo() {
         MSG("");
     }
 }
-#endif // DBGINFO

--- a/projects/rocdecode/src/parser/avc_parser.h
+++ b/projects/rocdecode/src/parser/avc_parser.h
@@ -292,7 +292,6 @@ protected:
      */
     ParserResult FlushDpb();
 
-#if DBGINFO
     /*! \brief Function to log out parsed SPS content for debug.
     */
     void PrintSps(AvcSeqParameterSet *p_sps);
@@ -312,5 +311,4 @@ protected:
     /*! \brief Function to log out buffer info in VAAPI decode params
      */
     void PrintVappiBufInfo();
-#endif // DBGINFO
 };

--- a/projects/rocdecode/src/parser/hevc_parser.cpp
+++ b/projects/rocdecode/src/parser/hevc_parser.cpp
@@ -67,6 +67,7 @@ rocDecStatus HevcVideoParser::UnInitialize() {
 rocDecStatus HevcVideoParser::ParseVideoData(RocdecSourceDataPacket *p_data) {
     FunctionEntryLog(g_rocdec_logger);
     if (p_data->payload && p_data->payload_size) {
+        DebugLog(g_rocdec_logger, ROCDEC_STR("Parsing picture ") + ROCDEC_TOSTR(pic_count_) + ROCDEC_STR(" with payload size ") + ROCDEC_TOSTR(p_data->payload_size) + ROCDEC_STR(" bytes ..."));
         curr_pts_ = p_data->pts;
         if (ParsePictureData(p_data->payload, p_data->payload_size) != PARSER_OK) {
             ErrorLog(g_rocdec_logger, ROCDEC_STR("Parser failed!"));
@@ -541,9 +542,9 @@ int HevcVideoParser::SendPicForDecode() {
         }
     }
 
-#if DBGINFO
-    PrintVappiBufInfo();
-#endif // DBGINFO
+    if (g_rocdec_logger.GetLogLevel() >= kRocDecLogDebug) {
+        PrintVappiBufInfo();
+    }
 
     if (pfn_decode_picture_cb_(parser_params_.user_data, &dec_pic_params_) == 0) {
         ErrorLog(g_rocdec_logger, "Decode error occurred.");
@@ -698,9 +699,9 @@ ParserResult HevcVideoParser::ParsePictureData(const uint8_t* p_stream, uint32_t
                             return PARSER_FAIL;
                         }
 
-#if DBGINFO
-                        PrintDpb();
-#endif // DBGINFO
+                        if (g_rocdec_logger.GetLogLevel() >= kRocDecLogDebug) {
+                            PrintDpb();
+                        }
                     }
                     num_slices_++;
                     break;
@@ -1343,9 +1344,9 @@ ParserResult HevcVideoParser::ParseVps(uint8_t *nalu, size_t size) {
     p_vps->vps_extension_flag = Parser::GetBit(nalu, offset);
     p_vps->is_received = 1;
 
-#if DBGINFO
-    PrintVps(p_vps);
-#endif // DBGINFO
+    if (g_rocdec_logger.GetLogLevel() >= kRocDecLogDebug) {
+        PrintVps(p_vps);
+    }
     FunctionExitLog(g_rocdec_logger);
     return PARSER_OK;
 }
@@ -1522,9 +1523,9 @@ ParserResult HevcVideoParser::ParseSps(uint8_t *nalu, size_t size) {
     sps_ptr->sps_extension_flag = Parser::GetBit(nalu, offset);
     sps_ptr->is_received = 1;
 
-#if DBGINFO
-    PrintSps(sps_ptr);
-#endif // DBGINFO
+    if (g_rocdec_logger.GetLogLevel() >= kRocDecLogDebug) {
+        PrintSps(sps_ptr);
+    }
     FunctionExitLog(g_rocdec_logger);
     return PARSER_OK;
 }
@@ -1668,9 +1669,9 @@ ParserResult HevcVideoParser::ParsePps(uint8_t *nalu, size_t size) {
     }
 
     pps_ptr->is_received = 1;
-#if DBGINFO
-    PrintPps(pps_ptr);
-#endif // DBGINFO
+    if (g_rocdec_logger.GetLogLevel() >= kRocDecLogDebug) {
+        PrintPps(pps_ptr);
+    }
     FunctionExitLog(g_rocdec_logger);
     return PARSER_OK;
 }
@@ -2037,9 +2038,9 @@ ParserResult HevcVideoParser::ParseSliceHeader(uint8_t *nalu, size_t size, HevcS
     }
 #endif
 
-#if DBGINFO
-    PrintSliceSegHeader(p_slice_header);
-#endif // DBGINFO
+    if (g_rocdec_logger.GetLogLevel() >= kRocDecLogDebug) {
+        PrintSliceSegHeader(p_slice_header);
+    }
 
     FunctionExitLog(g_rocdec_logger);
     return PARSER_OK;
@@ -2542,7 +2543,6 @@ int HevcVideoParser::BumpPicFromDpb() {
     return PARSER_OK;
 }
 
-#if DBGINFO
 void HevcVideoParser::PrintVps(HevcVideoParamSet *vps_ptr) {
     MSG("=== hevc_video_parameter_set_t ===");
     MSG("vps_video_parameter_set_id               = " <<  vps_ptr->vps_video_parameter_set_id);
@@ -3000,4 +3000,3 @@ void HevcVideoParser::PrintVappiBufInfo() {
         MSG("");
     }
 }
-#endif // DBGINFO

--- a/projects/rocdecode/src/parser/hevc_parser.h
+++ b/projects/rocdecode/src/parser/hevc_parser.h
@@ -327,7 +327,6 @@ protected:
      */
     ParserResult ParsePictureData(const uint8_t* p_stream, uint32_t pic_data_size);
 
-#if DBGINFO
     void PrintVps(HevcVideoParamSet *vps_ptr);
     void PrintSps(HevcSeqParamSet *sps_ptr);
     void PrintPps(HevcPicParamSet *pps_ptr);
@@ -336,7 +335,6 @@ protected:
     void PrintLtRefInfo(HevcLongTermRps *lt_info_ptr);
     void PrintDpb();
     void PrintVappiBufInfo();
-#endif // DBGINFO
 
 private:
     /*! \brief Callback function to notify decoder about new SPS.

--- a/projects/rocdecode/src/parser/vp9_parser.cpp
+++ b/projects/rocdecode/src/parser/vp9_parser.cpp
@@ -68,6 +68,7 @@ rocDecStatus Vp9VideoParser::UnInitialize() {
 rocDecStatus Vp9VideoParser::ParseVideoData(RocdecSourceDataPacket *p_data) {
     FunctionEntryLog(g_rocdec_logger);
     if (p_data->payload && p_data->payload_size) {
+        DebugLog(g_rocdec_logger, ROCDEC_STR("Parsing picture ") + ROCDEC_TOSTR(pic_count_) + ROCDEC_STR(" with payload size ") + ROCDEC_TOSTR(p_data->payload_size) + ROCDEC_STR(" bytes ..."));
         curr_pts_ = p_data->pts;
         if (ParsePictureData(p_data->payload, p_data->payload_size) != PARSER_OK) {
             ErrorLog(g_rocdec_logger, "Error occurred in ParsePictureData().");
@@ -130,9 +131,9 @@ ParserResult Vp9VideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
                         return PARSER_OUT_OF_RANGE;
                     }
                 }
-        #if DBGINFO
-                PrintDpb();
-        #endif // DBGINFO
+                if (g_rocdec_logger.GetLogLevel() >= kRocDecLogDebug) {
+                    PrintDpb();
+                }
             } else {
                 pic_stream_data_ptr_ = pic_data_ptr;
                 pic_stream_data_size_ = frame_sizes_[frame_index];
@@ -148,9 +149,9 @@ ParserResult Vp9VideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
                     ErrorLog(g_rocdec_logger, ROCDEC_STR("Failed to decode!"));
                     return ret;
                 }
-        #if DBGINFO
-                PrintDpb();
-        #endif // DBGINFO
+                if (g_rocdec_logger.GetLogLevel() >= kRocDecLogDebug) {
+                    PrintDpb();
+                }
                 // Output decoded pictures from DPB if any are ready
                 if (pfn_display_picture_cb_ && num_output_pics_ > 0) {
                     if ((ret = OutputDecodedPictures(false)) != PARSER_OK) {
@@ -343,9 +344,9 @@ ParserResult Vp9VideoParser::SendPicForDecode() {
     }
     dec_pic_params_.slice_params.vp9 = p_tile_params;
 
-#if DBGINFO
-    PrintVaapiParams();
-#endif // DBGINFO
+    if (g_rocdec_logger.GetLogLevel() >= kRocDecLogDebug) {
+        PrintVaapiParams();
+    }
 
     if (pfn_decode_picture_cb_(parser_params_.user_data, &dec_pic_params_) == 0) {
         ErrorLog(g_rocdec_logger, "Decode error occurred.");
@@ -1080,7 +1081,6 @@ void Vp9VideoParser::LoopFilterFrameInit(Vp9UncompressedHeader *p_uncomp_header)
     }
 }
 
-#if DBGINFO
 void Vp9VideoParser::PrintVaapiParams() {
     int i;
     MSG("=======================");
@@ -1205,4 +1205,3 @@ void Vp9VideoParser::PrintDpb() {
         MSG("");
     }
 }
-#endif // DBGINFO

--- a/projects/rocdecode/src/parser/vp9_parser.h
+++ b/projects/rocdecode/src/parser/vp9_parser.h
@@ -300,12 +300,10 @@ protected:
         return sign ? -u_value : u_value;
     }
 
-#if DBGINFO
     /*! \brief Function to log VAAPI parameters
      */
     void PrintVaapiParams();
     /*! \brief Function to log DPB and decode/display buffer pool info
      */
     void PrintDpb();
-#endif // DBGINFO
 };


### PR DESCRIPTION
## Motivation

This PR merges debug logging into the new logging mechanism.

## Technical Details

- rocDecode debug message was a compile option. 
- Now debug logging can be enabled by setting env var ROCDEC_LOG_LEVEL to 4 . This helps issue triage on the release builds.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Run CTests and decode conformance tests to catch any regressions.
Run rocdecdecode samples to verify user set output.

## Test Result
All CTests and conformance tests pass. Example summary of the test results:

CTests:
    Start 1: video_decodeRaw-HEVC
1/6 Test #1: video_decodeRaw-HEVC .............   Passed    2.10 sec
    Start 2: video_decodeRaw-AVC
2/6 Test #2: video_decodeRaw-AVC ..............   Passed    1.96 sec
    Start 3: video_decodeRaw-AV1
3/6 Test #3: video_decodeRaw-AV1 ..............   Passed    2.03 sec
    Start 4: video_decodeRaw-VP9
4/6 Test #4: video_decodeRaw-VP9 ..............   Passed    2.05 sec
    Start 5: rocdec_Decode-HEVC
5/6 Test #5: rocdec_Decode-HEVC ...............   Passed    0.91 sec
    Start 6: rocDecode_Negative_API_Tests
6/6 Test #6: rocDecode_Negative_API_Tests .....   Passed    0.73 sec

Conformance tests:

AVC conformance test:
Conformance test completed on the 127 streams:

The number of passing streams is 127
The number of failing streams is 0
The number of streams that did not finish decoding is 0

HEVC conformance test:
Conformance test completed on the 135 streams:

The number of passing streams is 135
The number of failing streams is 0
The number of streams that did not finish decoding is 0

AV1 conformance test:
Conformance test completed on the 162 streams:

The number of passing streams is 162
The number of failing streams is 0
The number of streams that did not finish decoding is 0

VP9 conformance test:
Conformance test completed on the 108 streams:

The number of passing streams is 108
The number of failing streams is 0
The number of streams that did not finish decoding is 0

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
