### PR TITLE
[RO regs 1/2] Client read-only registers

### DIFF
--- a/projects/rocdbgapi/src/architecture.cpp
+++ b/projects/rocdbgapi/src/architecture.cpp
@@ -304,6 +304,7 @@ public:
   const void *register_read_only_mask (amdgpu_regnum_t regnum) const override;
   amd_dbgapi_register_properties_t
   register_properties (amdgpu_regnum_t regnum) const override;
+  bool register_is_client_readonly (amdgpu_regnum_t regnum) const override;
 
   bool is_pseudo_register_available (const wave_t &wave,
                                      amdgpu_regnum_t regnum) const override;
@@ -2130,9 +2131,10 @@ amd_dbgapi_register_properties_t
 amdgcn_architecture_t::register_properties (amdgpu_regnum_t regnum) const
 {
   amd_dbgapi_register_properties_t properties
-    = register_read_only_mask (regnum) != nullptr
-        ? AMD_DBGAPI_REGISTER_PROPERTY_READONLY_BITS
-        : AMD_DBGAPI_REGISTER_PROPERTY_NONE;
+    = ((register_read_only_mask (regnum) != nullptr
+        || register_is_client_readonly (regnum))
+       ? AMD_DBGAPI_REGISTER_PROPERTY_READONLY_BITS
+       : AMD_DBGAPI_REGISTER_PROPERTY_NONE);
 
   /* Writing to the vcc register may change the status.vccz bit.  */
   if (regnum == amdgpu_regnum_t::pseudo_status)
@@ -2155,6 +2157,24 @@ amdgcn_architecture_t::register_properties (amdgpu_regnum_t regnum) const
     properties |= AMD_DBGAPI_REGISTER_PROPERTY_INVALIDATE_VOLATILE;
 
   return properties;
+}
+
+bool
+amdgcn_architecture_t::register_is_client_readonly (
+  amdgpu_regnum_t regnum) const
+{
+  if (amdgpu_regnum_t::first_ttmp <= regnum
+      && regnum <= amdgpu_regnum_t::last_ttmp)
+    return true;
+  switch (regnum)
+    {
+    case amdgpu_regnum_t::flat_scratch:
+    case amdgpu_regnum_t::pseudo_status:
+    case amdgpu_regnum_t::trapsts:
+      return true;
+    default:
+      return false;
+    }
 }
 
 bool
@@ -6339,6 +6359,8 @@ protected:
   amd_dbgapi_register_properties_t
   register_properties (amdgpu_regnum_t regnum) const override;
 
+  bool register_is_client_readonly (amdgpu_regnum_t regnum) const override;
+
   bool is_pseudo_register_available (const wave_t &wave,
                                      amdgpu_regnum_t regnum) const override;
 
@@ -6967,6 +6989,21 @@ gfx12_architecture_t::register_properties (amdgpu_regnum_t regnum) const
     properties |= AMD_DBGAPI_REGISTER_PROPERTY_VOLATILE;
 
   return properties;
+}
+
+bool
+gfx12_architecture_t::register_is_client_readonly (
+  amdgpu_regnum_t regnum) const
+{
+  switch (regnum)
+    {
+    case amdgpu_regnum_t::excp_flag_priv:
+    case amdgpu_regnum_t::pseudo_state_priv:
+    case amdgpu_regnum_t::trap_ctrl:
+      return true;
+    default:
+      return gfx11_architecture_t::register_is_client_readonly (regnum);
+    }
 }
 
 bool

--- a/projects/rocdbgapi/src/architecture.h
+++ b/projects/rocdbgapi/src/architecture.h
@@ -432,6 +432,12 @@ public:
   register_properties (amdgpu_regnum_t regnum) const
     = 0;
 
+  /* Returns true if REGNUM is exposed to the client as a read-only
+     register (while internally we do write to it).  This is
+     typically, though not limited to, client-visible registers which
+     can only be written with PRIV=1.  */
+  virtual bool register_is_client_readonly (amdgpu_regnum_t regnum) const = 0;
+
   std::set<amdgpu_regnum_t> register_set () const;
   bool is_register_available (amdgpu_regnum_t regnum) const;
 

--- a/projects/rocdbgapi/src/register.cpp
+++ b/projects/rocdbgapi/src/register.cpp
@@ -640,6 +640,13 @@ amd_dbgapi_write_register (amd_dbgapi_wave_id_t wave_id,
     if (!wave->is_register_available (*regnum))
       THROW (AMD_DBGAPI_STATUS_ERROR_REGISTER_NOT_AVAILABLE);
 
+    /* Ignore writes to registers we expose to clients as read-only.
+       Note this is not handled at the wave_t::write_register level
+       because internally we do want to write to some of these
+       registers.  */
+    if (wave->architecture ().register_is_client_readonly (*regnum))
+      return AMD_DBGAPI_STATUS_SUCCESS;
+
     wave->write_register (*regnum, offset, value_size, value);
   }
   CATCH (AMD_DBGAPI_STATUS_ERROR_NOT_INITIALIZED,


### PR DESCRIPTION
Currently, if you write to registers that are supposedly read-only
from the client's perspective, dbgapi still accepts the write:

(gdb) p $ttmp4
$1 = 1
(gdb) p $ttmp4 = 2
$2 = 2
(gdb) p $ttmp4
$3 = 2

(gdb) p $status
$4 = [ TRAP_EN VCCZ VALID WAVE64 ]
(gdb) p $status = 0
$5 = [ ]
(gdb) p $status
$6 = [ ]

This is particularly dangerous if the user changes ttmp registers,
which breaks the debug session quite badly.  See example further
below.

architecture_t::register_read_only_mask is not exactly what we need
here.  Some of these registers should be read-only from the client's
perspective, but code internal to dbagpi still wants to be able to
write to them.  ttmps is one such example.

We need a separate "register is read-only from the client's
perspective" register property instead.  I thought of adding a new
amd_dbgapi_register_properties_t flag, but since I'm not proposing
that ROCgdb would make use of the flag, I'm instead proposing to add a
new architecture_t::register_is_client_readonly virtual method.

The change-ttmp-crashes-debug-session example:

(gdb) p $ttmp4
$1 = 1
(gdb) si
0x00007ffff62c1348      24        for (int i = 0; i < 100; i++)
(gdb) p $ttmp4 = 2
$2 = 2
(gdb) si
fatal error: wave_2 not found in queue_2
Backtrace:
#0 0x000074a672f69615 operator()<std::unique_ptr<const amd::dbgapi::architecture_t::cwsr_record_t> > in /home/pedro/rocm/dbgapi/src/src/queue.cpp:272
#1 0x000074a672f74437 __invoke_impl<void, amd::dbgapi::compute_queue_t::update_waves()::<lambda(auto:34)>&, std::unique_ptr<const amd::dbgapi::architecture_t::cwsr_record_t, std::default_delete<const amd::dbgapi::architecture_t::cwsr_record_t> > > in /usr/include/c++/13/bits/invoke.h:61
#2 0x000074a672f73913 __invoke_r<void, amd::dbgapi::compute_queue_t::update_waves()::<lambda(auto:34)>&, std::unique_ptr<const amd::dbgapi::architecture_t::cwsr_record_t, std::default_delete<const amd::dbgapi::architecture_t::cwsr_record_t> > > in /usr/include/c++/13/bits/invoke.h:111
#3 0x000074a672f72a43 _M_invoke in /usr/include/c++/13/bits/std_function.h:290
#4 0x000074a672e56cae std::function<void (std::unique_ptr<amd::dbgapi::architecture_t::cwsr_record_t const, std::default_delete<amd::dbgapi::architecture_t::cwsr_record_t const> >)>::operator()(std::unique_ptr<amd::dbgapi::architecture_t::cwsr_record_t const, std::default_delete<amd::dbgapi::architecture_t::cwsr_record_t const> >) const
#5 0x000074a672e3ac78 amd::dbgapi::gfx10_architecture_t::control_stack_iterate(amd::dbgapi::compute_queue_t&, unsigned int, unsigned int const*, unsigned long, amd::dbgapi::agent_address_t, unsigned long, std::function<void (std::unique_ptr<amd::dbgapi::architecture_t::cwsr_record_t const, std::default_delete<amd::dbgapi::architecture_t::cwsr_record_t const> >)> const&) const in /home/pedro/rocm/dbgapi/src/src/architecture.cpp:5291
#6 0x000074a672f6a2c4 amd::dbgapi::compute_queue_t::update_waves() in /home/pedro/rocm/dbgapi/src/src/queue.cpp:434
#7 0x000074a672f6ab6b amd::dbgapi::compute_queue_t::queue_state_changed() in /home/pedro/rocm/dbgapi/src/src/queue.cpp:537
#8 0x000074a672f6d138 amd::dbgapi::queue_t::set_state(amd::dbgapi::queue_t::state_t) in /home/pedro/rocm/dbgapi/src/src/queue.cpp:1224
#9 0x000074a672f2a7db amd::dbgapi::process_t::suspend_queues(std::vector<amd::dbgapi::queue_t*, std::allocator<amd::dbgapi::queue_t*> > const&, char const*) const in /home/pedro/rocm/dbgapi/src/src/process.cpp:920
#10 0x000074a672f308bf amd::dbgapi::process_t::next_pending_event() in /home/pedro/rocm/dbgapi/src/src/process.cpp:2198
#11 0x000074a672ebbdf4 operator() in /home/pedro/rocm/dbgapi/src/src/event.cpp:290
#12 0x000074a672ebe0ec tracer_closure in /home/pedro/rocm/dbgapi/src/src/logging.h:656
#13 0x000074a672ebd227 enter<amd::dbgapi::detail::parameter_t<amd_dbgapi_process_id_t, (& amd::dbgapi::utils::string_literal<'p', 'r', 'o', 'c', 'e', 's', 's', '_', 'i', 'd'>::value), (amd::dbgapi::detail::parameter_kind_t)0>, amd::dbgapi::detail::parameter_t<amd_dbgapi_event_id_t*, (& amd::dbgapi::utils::string_literal<'e', 'v', 'e', 'n', 't', '_', 'i', 'd'>::value), (amd::dbgapi::detail::parameter_kind_t)0>, amd::dbgapi::detail::parameter_t<amd_dbgapi_event_kind_t*, (& amd::dbgapi::utils::string_literal<'k', 'i', 'n', 'd'>::value), (amd::dbgapi::detail::parameter_kind_t)0>, amd_dbgapi_process_next_pending_event(amd_dbgapi_process_id_t, amd_dbgapi_event_id_t*, amd_dbgapi_event_kind_t*)::<lambda()> > in /home/pedro/rocm/dbgapi/src/src/logging.h:706
#14 0x000074a672ebc1f9 amd_dbgapi_process_next_pending_event in /home/pedro/rocm/dbgapi/src/src/event.cpp:272
#15 0x00006357aedb03b2 process_event_queue in ../../src/gdb/amd-dbgapi-target.c:2260
#16 0x00006357aedb0c66 amd_dbgapi_target::wait(ptid_t, target_waitstatus*, enum_flags<target_wait_flag>) in ../../src/gdb/amd-dbgapi-target.c:2380
#17 0x00006357af5b36a6 target_wait(ptid_t, target_waitstatus*, enum_flags<target_wait_flag>) in ../../src/gdb/target.c:2614
#18 0x00006357af24b887 do_target_wait_1 in ../../src/gdb/infrun.c:4228
#19 0x00006357af24bb07 operator() in ../../src/gdb/infrun.c:4290
#20 0x00006357af24bee4 do_target_wait in ../../src/gdb/infrun.c:4309
#21 0x00006357af24d246 fetch_inferior_event() in ../../src/gdb/infrun.c:4744
#22 0x00006357af21f670 inferior_event_handler(inferior_event_type) in ../../src/gdb/inf-loop.c:42
#23 0x00006357aedaee00 handle_target_event in ../../src/gdb/amd-dbgapi-target.c:1802
#24 0x00006357aee45a45 check_async_event_handlers() in ../../src/gdb/async-event.c:337
#25 0x00006357af8ccb50 gdb_do_one_event(int) in ../../src/gdbsupport/event-loop.cc:220
#26 0x00006357aef4c55a interp::do_one_event(int) in ../../src/gdb/interps.h:90
#27 0x00006357af2f03a5 start_event_loop in ../../src/gdb/main.c:400
#28 0x00006357af2f0595 captured_command_loop in ../../src/gdb/main.c:465
#29 0x00006357af2f225b captured_main in ../../src/gdb/main.c:1373
#30 0x00006357af2f2305 gdb_main(captured_main_args*) in ../../src/gdb/main.c:1392
#31 0x00006357aed118ae main in ../../src/gdb/gdb.c:38
#32 0x000074a67262a1c9 __libc_start_call_main in ../sysdeps/nptl/libc_start_call_main.h:58
#33 0x000074a67262a28a __libc_start_main_impl in ../csu/libc-start.c:360
#34 0x00006357aed11734 _start
#35 0xffffffffffffffff
❌️ next_pending_event failed (A fatal error has occurred)
(gdb)

Change-Id: I64116fa9bdd03e92ebaf552f462e2333e9335e42

---

**Stack**:
- #5212
- #5211 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*