### PR TITLE
[static lib 2/2] Add missing AMD_DBGAPI_EXPORT_DECORATOR fallback

### DIFF
--- a/projects/rocdbgapi/CMakeLists.txt
+++ b/projects/rocdbgapi/CMakeLists.txt
@@ -119,6 +119,15 @@ else()
   endif()
 endif()
 
+# Define this before amd-dbgapi.h is generated.  amd-dbgapi.h.in uses
+# this to define the right export/import decorators in amd-dbgapi.h
+# for clients to use.
+if(NOT BUILD_SHARED_LIBS)
+  set(AMD_DBGAPI_STATIC_LIB "1")
+else()
+  set(AMD_DBGAPI_STATIC_LIB "0")
+endif()
+
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/amd-dbgapi.h.in
   ${CMAKE_CURRENT_BINARY_DIR}/include/amd-dbgapi/amd-dbgapi.h @ONLY)

--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -508,15 +508,19 @@
 # endif
 #endif /* !defined (AMD_DBGAPI_IMPORT_DECORATOR) */
 
-#define AMD_DBGAPI_EXPORT AMD_DBGAPI_EXPORT_DECORATOR AMD_DBGAPI_CALL
-#define AMD_DBGAPI_IMPORT AMD_DBGAPI_IMPORT_DECORATOR AMD_DBGAPI_CALL
+/* True if dbgapi was built as a static library.  */
+#define AMD_DBGAPI_STATIC_LIB @AMD_DBGAPI_STATIC_LIB@
 
 #if !defined(AMD_DBGAPI)
-#if defined(AMD_DBGAPI_EXPORTS)
-#define AMD_DBGAPI AMD_DBGAPI_EXPORT
-#else /* !defined (AMD_DBGAPI_EXPORTS) */
-#define AMD_DBGAPI AMD_DBGAPI_IMPORT
-#endif /* !defined (AMD_DBGAPI_EXPORTS) */
+# if AMD_DBGAPI_STATIC_LIB
+#  define AMD_DBGAPI AMD_DBGAPI_CALL
+# else
+#  if defined(AMD_DBGAPI_EXPORTS)
+#   define AMD_DBGAPI AMD_DBGAPI_EXPORT_DECORATOR AMD_DBGAPI_CALL
+#  else
+#   define AMD_DBGAPI AMD_DBGAPI_IMPORT_DECORATOR AMD_DBGAPI_CALL
+#  endif
+# endif
 #endif /* !defined (AMD_DBGAPI) */
 
 /* By default, MSVC reports 199711L (C++98) for the __cplusplus macro,

--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -497,6 +497,8 @@
 #  define AMD_DBGAPI_EXPORT_DECORATOR __declspec(dllexport)
 # elif defined(__GNUC__)
 #  define AMD_DBGAPI_EXPORT_DECORATOR __attribute__ ((visibility ("default")))
+# else
+#  define AMD_DBGAPI_EXPORT_DECORATOR
 # endif
 #endif /* !defined (AMD_DBGAPI_EXPORT_DECORATOR) */
 


### PR DESCRIPTION
The AMD_DBGAPI_EXPORT_DECORATOR definition block is missing the
fallback case.  Fix that.

Change-Id: Idcc785b59a48b5cc17c64d4b70e534ba6e912eaf
commit-id:8ab06a04

---

**Stack**:
- #5213 ⬅
- #5155


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*