### PR TITLE
[rocSHMEM] Fix a warning when building config gda_ionic

### DIFF
--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -153,7 +153,7 @@ __device__ void QueuePair::post_wqe_rma([[maybe_unused]] int pe, int32_t size, u
 }
 
 __device__ void QueuePair::post_wqe_rma_single([[maybe_unused]] int32_t size, uintptr_t laddr,
-    uintptr_t raddr, uint8_t opcode, bool ring_db) {
+    uintptr_t raddr, uint8_t opcode, [[maybe_unused]] bool ring_db) {
   switch (gda_provider_) {
 #if defined(GDA_IONIC)
   case GDAProvider::IONIC:


### PR DESCRIPTION
## Motivation

Fix warnings

## Technical Details

missing a [[maybe-unused]] in gda_ionic configuration.

## JIRA ID

AIROCSHMEM-300