### PR TITLE
RCCL: Sync ibv_qp_init_attr_ex and related structs with latest IB verbs provider headers in ibvcore.h

### DIFF
--- a/projects/rccl/src/include/ibvcore.h
+++ b/projects/rccl/src/include/ibvcore.h
@@ -491,6 +491,20 @@ struct ibv_srq_init_attr_ex {
 	struct ibv_cq	       *cq;
 };
 
+/*
+ * Receive Work Queue Indirection Table.
+ * It's used in order to distribute incoming packets between different
+ * Receive Work Queues. Associating Receive WQs with different CPU cores
+ * allows one to workload the traffic between different CPU cores.
+ * The Indirection Table can contain only WQs of type IBV_WQT_RQ.
+*/
+struct ibv_rwq_ind_table {
+	struct ibv_context *context;
+	int ind_tbl_handle;
+	int ind_tbl_num;
+	uint32_t comp_mask;
+};
+
 enum ibv_qp_type {
 	IBV_QPT_RC = 2,
 	IBV_QPT_UC,
@@ -535,6 +549,15 @@ enum ibv_qp_init_attr_mask {
 	IBV_QP_INIT_ATTR_RESERVED	= 1 << 2
 };
 
+struct ibv_rx_hash_conf {
+	/* enum ibv_rx_hash_function_flags */
+	uint8_t    rx_hash_function;
+	uint8_t    rx_hash_key_len;
+	uint8_t    *rx_hash_key;
+	/* enum ibv_rx_hash_fields */
+	uint64_t   rx_hash_fields_mask;
+};
+
 struct ibv_qp_init_attr_ex {
 	void		       *qp_context;
 	struct ibv_cq	       *send_cq;
@@ -547,6 +570,13 @@ struct ibv_qp_init_attr_ex {
 	uint32_t		comp_mask;
 	struct ibv_pd	       *pd;
 	struct ibv_xrcd	       *xrcd;
+	uint32_t    create_flags;
+	uint16_t		max_tso_header;
+	struct ibv_rwq_ind_table       *rwq_ind_tbl;
+	struct ibv_rx_hash_conf    rx_hash_conf;
+	uint32_t		source_qpn;
+	/* See enum ibv_qp_create_send_ops_flags */
+	uint64_t send_ops_flags;
 };
 
 enum ibv_qp_open_attr_mask {

--- a/projects/rccl/src/include/ibvcore.h
+++ b/projects/rccl/src/include/ibvcore.h
@@ -495,7 +495,7 @@ struct ibv_srq_init_attr_ex {
  * Receive Work Queue Indirection Table.
  * It's used in order to distribute incoming packets between different
  * Receive Work Queues. Associating Receive WQs with different CPU cores
- * allows one to workload the traffic between different CPU cores.
+ * allows one to distribute the traffic load across different CPU cores.
  * The Indirection Table can contain only WQs of type IBV_WQT_RQ.
 */
 struct ibv_rwq_ind_table {

--- a/projects/rccl/src/include/ibvcore.h
+++ b/projects/rccl/src/include/ibvcore.h
@@ -573,7 +573,7 @@ struct ibv_qp_init_attr_ex {
 	uint32_t    create_flags;
 	uint16_t		max_tso_header;
 	struct ibv_rwq_ind_table       *rwq_ind_tbl;
-	struct ibv_rx_hash_conf    rx_hash_conf;
+	struct ibv_rx_hash_conf	rx_hash_conf;
 	uint32_t		source_qpn;
 	/* See enum ibv_qp_create_send_ops_flags */
 	uint64_t send_ops_flags;


### PR DESCRIPTION
## Motivation

Brings RCCL's local inline copy of the IB verbs ABI (used for dynamic loading without a hard libibverbs dependency) up to date with the latest upstream libibverbs provider header definitions. Three additions:

1. struct ibv_rwq_ind_table (new struct, after ibv_srq_init_attr_ex) Synced from upstream libibverbs — represents a Receive Work Queue Indirection Table used to distribute incoming packets across multiple RWQs mapped to different CPU cores for RSS load balancing.

2. struct ibv_rx_hash_conf (new struct, before ibv_qp_init_attr_ex) Synced from upstream libibverbs — configures the RSS hash function for a QP: hash algorithm, key length, key bytes, and a bitmask of fields to hash over (e.g., src/dst IP, ports).

3. struct ibv_qp_init_attr_ex extensions (6 new fields appended) Closes the gap between RCCL's local definition and the current upstream ibv_qp_init_attr_ex: adds create_flags, max_tso_header, rwq_ind_tbl, rx_hash_conf, source_qpn, and send_ops_flags.


## Technical Details

With RCCL inline copy of the IB verbs ABI being out of sync with latest verbs header definition, when using latest verbs provider library, the flags in extended(/newer) versions are fails due to improper access leading to out-of-bound access for those typedefinitions.

## JIRA ID


## Test Plan
Run RCCL with and without latest IB verbs and ensured there is no functional impact.


## Test Result
Pass

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
