### PR TITLE
[rocprofiler-sdk] Add runtime guards to ROCP_* log macros

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/common/logging.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/logging.hpp
@@ -25,6 +25,7 @@
 #include "lib/common/defines.hpp"
 
 #include <absl/log/check.h>
+#include <absl/log/globals.h>
 #include <absl/log/log.h>
 #include <absl/log/vlog_is_on.h>
 
@@ -52,19 +53,25 @@
 #    define LOG_ASSERT(condition) CHECK(condition)
 #endif
 
+// Runtime-guarded log macros: stream arguments are NOT evaluated when the
+// severity is below the configured minimum log level (absl::MinLogLevel()).
+// LOG_IF uses abseil's ternary short-circuit pattern internally.
 #define ROCP_TRACE   VLOG(ROCP_LOG_LEVEL_TRACE)
-#define ROCP_INFO    LOG(INFO)
-#define ROCP_WARNING LOG(WARNING)
-#define ROCP_ERROR   LOG(ERROR)
+#define ROCP_INFO    LOG_IF(INFO, ::absl::MinLogLevel() <= ::absl::LogSeverityAtLeast::kInfo)
+#define ROCP_WARNING LOG_IF(WARNING, ::absl::MinLogLevel() <= ::absl::LogSeverityAtLeast::kWarning)
+#define ROCP_ERROR   LOG_IF(ERROR, ::absl::MinLogLevel() <= ::absl::LogSeverityAtLeast::kError)
 #define ROCP_FATAL   LOG(FATAL)
 #define ROCP_DFATAL  DLOG(FATAL)
 
-#define ROCP_TRACE_IF(CONDITION)   VLOG_IF(ROCP_LOG_LEVEL_TRACE, (CONDITION))
-#define ROCP_INFO_IF(CONDITION)    LOG_IF(INFO, (CONDITION))
-#define ROCP_WARNING_IF(CONDITION) LOG_IF(WARNING, (CONDITION))
-#define ROCP_ERROR_IF(CONDITION)   LOG_IF(ERROR, (CONDITION))
-#define ROCP_FATAL_IF(CONDITION)   LOG_IF(FATAL, (CONDITION))
-#define ROCP_DFATAL_IF(CONDITION)  DLOG_IF(FATAL, (CONDITION))
+#define ROCP_TRACE_IF(CONDITION) VLOG_IF(ROCP_LOG_LEVEL_TRACE, (CONDITION))
+#define ROCP_INFO_IF(CONDITION)                                                                    \
+    LOG_IF(INFO, ::absl::MinLogLevel() <= ::absl::LogSeverityAtLeast::kInfo && (CONDITION))
+#define ROCP_WARNING_IF(CONDITION)                                                                 \
+    LOG_IF(WARNING, ::absl::MinLogLevel() <= ::absl::LogSeverityAtLeast::kWarning && (CONDITION))
+#define ROCP_ERROR_IF(CONDITION)                                                                   \
+    LOG_IF(ERROR, ::absl::MinLogLevel() <= ::absl::LogSeverityAtLeast::kError && (CONDITION))
+#define ROCP_FATAL_IF(CONDITION)  LOG_IF(FATAL, (CONDITION))
+#define ROCP_DFATAL_IF(CONDITION) DLOG_IF(FATAL, (CONDITION))
 
 #if defined(ROCPROFILER_CI)
 #    define ROCP_CI_LOG_IF(NON_CI_LEVEL, ...) ROCP_FATAL_IF(__VA_ARGS__)


### PR DESCRIPTION
## Summary
- Add runtime log level checks to `ROCP_INFO`, `ROCP_WARNING`, `ROCP_ERROR` and their `_IF` variants
- Prevents evaluation of stream arguments (including `fmt::format` calls) when the severity is below the configured minimum log level
- Uses abseil's `LOG_IF` which internally short-circuits via a ternary pattern, ensuring zero argument evaluation overhead when logging is suppressed
- `ROCP_TRACE` already guards via `VLOG_IS_ON`; `ROCP_FATAL`/`ROCP_DFATAL` are never suppressed

## Test plan
- [ ] CI builds pass across all OS variants
- [ ] Verify log output is unchanged at default log level (WARNING)
- [ ] Verify no output from `ROCP_INFO`/`ROCP_WARNING` when `ROCP_LOG_LEVEL=error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)