### PR TITLE
[CLR][NFCI] `Event::setStatus` tweaks

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -2231,7 +2231,9 @@ void VirtualGPU::updateCommandsState(amd::Command* list) const {
     }
 
     if (current->status() == CL_SUBMITTED) {
-      current->setStatus(CL_RUNNING, startTimeStamp);
+      if (!amd::IS_HIP || current->profilingInfo().enabled_) {
+        current->setStatus(CL_RUNNING, startTimeStamp);
+      }
       current->setStatus(CL_COMPLETE, endTimeStamp);
     } else if (current->status() != CL_COMPLETE) {
       LogPrintfError("Unexpected command status - %d.", current->status());

--- a/projects/clr/rocclr/platform/command.cpp
+++ b/projects/clr/rocclr/platform/command.cpp
@@ -117,11 +117,12 @@ bool Event::setStatus(int32_t status, uint64_t timeStamp) {
   }
 
   if (amd::IS_HIP) {
-    // HIP API doesn't have any event, associated with a callback. Hence the SW status of
-    // the event is irrelevant, during the actual callback. At the same time HIP API requires
-    // to finish the callback before HIP stream can continue. Hence runtime has to process
-    // the callback first and then update the status.
-    if (callbacks_ != (CallBackEntry*)0) {
+    // HIP API doesn't have any event, associated with a callback and callbacks can only be set for
+    // when all commands in a stream are completed. Hence the SW status of the event is irrelevant,
+    // during the actual callback. At the same time HIP API requires to finish the callback before
+    // HIP stream can continue. Hence runtime has to process the callback first and then update the
+    // status.
+    if (status == CL_COMPLETE && callbacks_ != (CallBackEntry*)0) {
       processCallbacks(status);
     }
     if (!status_.compare_exchange_strong(currentStatus, status, std::memory_order_relaxed)) {
@@ -191,6 +192,8 @@ bool Event::resetStatus(int32_t status) {
 bool Event::setCallback(int32_t status, Event::CallBackFunction callback, void* data,
                         bool blocking) {
   assert(status >= CL_COMPLETE && status <= CL_QUEUED && "Invalid status");
+  assert((status == CL_COMPLETE || !amd::IS_HIP) &&
+         "HIP callbacks can only be set to command full completion");
 
   CallBackEntry* entry = new CallBackEntry(status, callback, data, blocking);
   if (entry == NULL) {


### PR DESCRIPTION
## Motivation

Performance optimizations

## Technical Details

HIP only allows to set callbacks to a situation when all commands in a stream are completed - that allows to by-pass one atomic load (with default sequential consistency memory order) per `setStatus` call. Also, if we enable profiling info, then we can bypass `running` state for HIP, because it is has no other side effects otherwise.

## JIRA ID

N/A

## Test Plan

N/A, this is supposed to be a non-functional change

## Test Result

N/A, this is supposed to be a non-functional change

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
