### PR TITLE
[Rocprof-Compute] Blocking the options that are not compatible with torch-trace flags

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -342,6 +342,68 @@ class RocProfCompute:
 
     def handle_analyze_args(self) -> None:
         """Handle analyze-specific argument processing"""
+        args = self.__args
+        torch_operator = args.torch_operator
+        list_torch_operators = args.list_torch_operators
+
+        if torch_operator is not None or list_torch_operators:
+            if args.gui is not None:
+                console_error(
+                    "torch trace",
+                    "--torch-operator and --list-torch-operators are not "
+                    "supported in --gui mode. Please remove --gui or run "
+                    "without the torch-operator flags.",
+                )
+            if args.tui:
+                console_error(
+                    "torch trace",
+                    "--torch-operator and --list-torch-operators are not "
+                    "supported in --tui mode. Please remove --tui or run "
+                    "without the torch-operator flags.",
+                )
+            if args.spatial_multiplexing:
+                console_error(
+                    "torch trace",
+                    "--torch-operator and --list-torch-operators do not yet "
+                    "support multi-node analysis via --spatial-multiplexing. "
+                    "Please remove one of these options.",
+                )
+            if args.output_format != "stdout":
+                console_error(
+                    "torch trace",
+                    "--torch-operator and --list-torch-operators are only "
+                    "supported with --output-format stdout (the default). "
+                    "The matched operator call tree is printed directly to "
+                    "stdout and is not captured in txt, csv, or db output. "
+                    "Remove the --output-format option or drop the "
+                    "torch-operator flags.",
+                )
+
+            if torch_operator is not None:
+                if args.list_stats:
+                    console_warning(
+                        "torch trace",
+                        "--torch-operator is ignored by --list-stats; the "
+                        "full kernel stats table will be shown regardless "
+                        "of the operator filter.",
+                    )
+                if args.list_nodes:
+                    console_warning(
+                        "torch trace",
+                        "--torch-operator is ignored by --list-nodes; the "
+                        "node enumeration does not respect the operator "
+                        "filter.",
+                    )
+                if list_torch_operators:
+                    console_warning(
+                        "torch trace",
+                        "--torch-operator is ignored when "
+                        "--list-torch-operators is used; the full operator "
+                        "tree will be shown. Drop --list-torch-operators to "
+                        "apply the operator filter to the analysis, or drop "
+                        "--torch-operator to list all operators.",
+                    )
+
         # Block all filters during spatial-multiplexing
         if self.__args.spatial_multiplexing:
             self.__args.gpu_id = None

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -167,6 +167,30 @@ class RocProfCompute_Base:
                 "Please remove one of these options."
             )
 
+        if getattr(args, "torch_trace", False):
+            if args.attach_pid:
+                console_error(
+                    "--torch-trace cannot be used with --attach-pid. "
+                    "Torch trace requires injecting ROCTX markers into the "
+                    "workload at launch; already-running processes cannot be "
+                    "instrumented. Please remove one of these options."
+                )
+
+            if args.attach_duration_msec:
+                console_error(
+                    "--torch-trace cannot be used with --attach-duration-msec. "
+                    "--attach-duration-msec only applies to --attach-pid, which "
+                    "is incompatible with --torch-trace. Please remove one of "
+                    "these options."
+                )
+
+            if args.spatial_multiplexing is not None:
+                console_error(
+                    "--torch-trace does not yet support multi-node profiling "
+                    "via --spatial-multiplexing. Please remove one of these "
+                    "options."
+                )
+
         # verify correct formatting for application binary
         args.remaining = args.remaining[1:]
         resolved_exec_path: Optional[Path] = None

--- a/projects/rocprofiler-compute/tests/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/test_profiler_base.py
@@ -23,6 +23,8 @@ def _make_sanitize_args(remaining, torch_trace=False):
         no_native_tool=False,
         iteration_multiplexing=None,
         attach_pid=None,
+        attach_duration_msec=None,
+        spatial_multiplexing=None,
         remaining=["--"] + remaining,
         torch_trace=torch_trace,
     )


### PR DESCRIPTION
## Motivation

Some combinations involving `--torch-trace` and `--torch-operator` / `--list-torch-operators` silently produced empty files or ignored filters with no error or warning. This PR closes those silent-failure paths with explicit hard-blocks where the combination is not supported, and warnings where the combination is reachable but misleading.

## Technical Details

1. `profiler_base.py::sanitize()` — hard-error on **--attach-pid, --attach-duration-msec, --spatial-multiplexing**.
2. `rocprof_compute_base.py::handle_analyze_args()` — hard-error on **--gui, --tui, --output-format {txt,csv,db}, --spatial-multiplexing**; warn on **--list-stats, --list-nodes**, and combining **--torch-operator** with **--list-torch-operators**.

## JIRA ID

AIPROFCOMP-526

## Test Plan

```
#Profile guards (3 hard-blocks) — expect exit 1 + ERROR
rocprof-compute --experimental profile --torch-trace --attach-pid $$ -n flag-tests -- python3 sample/simple_net.py
rocprof-compute --experimental profile --torch-trace --attach-duration-msec 1000 -n flag-tests -- python3 sample/simple_net.py
rocprof-compute --experimental profile --torch-trace --spatial-multiplexing -n flag-tests -- python3 sample/simple_net.py
#Baseline run, works
rocprof-compute --experimental profile --torch-trace -n flag-tests -- python3 sample/simple_net.py
#Analyze guards (4 hard-blocks) — expect exit 1 + ERROR
rocprof-compute --experimental analyze -p workloads/flag-tests/MI300A_A1 --torch-operator 'all' --gui
rocprof-compute --experimental analyze -p workloads/flag-tests/MI300A_A1 --torch-operator 'all' --tui
rocprof-compute --experimental analyze -p workloads/flag-tests/MI300A_A1 --torch-operator 'all' --output-format csv --output-name _t
rocprof-compute --experimental analyze -p workloads/flag-tests/MI300A_A1 --torch-operator 'all' --spatial-multiplexing
#Analyze warnings (3) — expect exit 0 + WARNING + command continues
rocprof-compute --experimental analyze -p workloads/flag-tests/MI300A_A1 --torch-operator 'all' --list-stats
rocprof-compute --experimental analyze -p workloads/flag-tests/MI300A_A1 --torch-operator 'all' --list-nodes
rocprof-compute --experimental analyze -p workloads/flag-tests/MI300A_A1 --torch-operator 'all' --list-torch-operators
#Baseline works
rocprof-compute --experimental analyze -p workloads/flag-tests/MI300A_A1 --torch-operator 'all'

```
## Test Result

The above runs produce the intended results: Errors/warnings for the tweaked flag combinations.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
