### PR TITLE
Update rocprofiler workflows to use latest actions with node 24

### DIFF
--- a/.github/workflows/rocprofiler-compute-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-compute-continuous-integration.yml
@@ -64,7 +64,7 @@ jobs:
       matrix: ${{ steps.generate_matrix.outputs.matrix }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: projects/rocprofiler-compute/.github
 
@@ -106,7 +106,7 @@ jobs:
         --env-file /etc/podinfo/gha-gpu-isolation-settings
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             projects/rocprofiler-compute

--- a/.github/workflows/rocprofiler-compute-formatting.yml
+++ b/.github/workflows/rocprofiler-compute-formatting.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-compute
     - name: Set up Python '3.x'
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-compute
     - name: Install dependencies
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-compute
     - name: Install dependencies
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-compute
     - name: find-bytecode

--- a/.github/workflows/rocprofiler-compute-ghcr.yml
+++ b/.github/workflows/rocprofiler-compute-ghcr.yml
@@ -77,7 +77,7 @@ jobs:
           submodules: recursive
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -120,13 +120,13 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ghcr.io/ROCm/rocprofiler-${{ matrix.system.distro }}
 
       - name: Build CI GFX Container (Does not Push on PR)
         id: docker_build
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           file: projects/rocprofiler-compute/docker/${{ steps.setup_vars_gfx.outputs.docker_file }}
           platforms: linux/amd64
@@ -143,7 +143,7 @@ jobs:
       # Retry a copy of docker_build if Docker build failed due to intermittent failure
       - name: Build CI GFX Container Retry (Does not Push on PR)
         if: steps.docker_build.outcome != 'success'
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           file: projects/rocprofiler-compute/docker/${{ steps.setup_vars_gfx.outputs.docker_file }}
           platforms: linux/amd64

--- a/.github/workflows/rocprofiler-compute-ghcr.yml
+++ b/.github/workflows/rocprofiler-compute-ghcr.yml
@@ -35,7 +35,7 @@ jobs:
       gpu_list: ${{ steps.generate_gpu_list.outputs.gpu_list }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: projects/rocprofiler-compute/docker
 
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           sparse-checkout: projects/rocprofiler-compute
           submodules: recursive

--- a/.github/workflows/rocprofiler-compute-rhel-8.yml
+++ b/.github/workflows/rocprofiler-compute-rhel-8.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Install ROCm Packages
         timeout-minutes: 30
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           retry_wait_seconds: 30
           timeout_minutes: 30

--- a/.github/workflows/rocprofiler-compute-rhel-8.yml
+++ b/.github/workflows/rocprofiler-compute-rhel-8.yml
@@ -90,7 +90,7 @@ jobs:
             yum install -y rocm-dev
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             projects/rocprofiler-compute

--- a/.github/workflows/rocprofiler-compute-rhel-8.yml
+++ b/.github/workflows/rocprofiler-compute-rhel-8.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Install ROCm Packages
         timeout-minutes: 30
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           retry_wait_seconds: 30
           timeout_minutes: 30

--- a/.github/workflows/rocprofiler-compute-tarball.yml
+++ b/.github/workflows/rocprofiler-compute-tarball.yml
@@ -55,7 +55,7 @@ jobs:
             echo "sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
           fi
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             projects/rocprofiler-compute
@@ -96,7 +96,7 @@ jobs:
           cd build
           make package_source
       - name: Archive tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tarball-testing
           path: projects/rocprofiler-compute/build/rocprofiler-compute-*.tar.gz

--- a/.github/workflows/rocprofiler-compute-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-compute-ubuntu-jammy.yml
@@ -52,7 +52,7 @@ jobs:
           apt-get install -y cmake
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             projects/rocprofiler-compute

--- a/.github/workflows/rocprofiler-register-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-register-continuous-integration.yml
@@ -93,7 +93,7 @@ jobs:
         apt update
         apt install -y git
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-register
         submodules: true

--- a/.github/workflows/rocprofiler-sdk-build-ci-docker-images.yml
+++ b/.github/workflows/rocprofiler-sdk-build-ci-docker-images.yml
@@ -37,7 +37,7 @@ jobs:
         gpu: [ 'gfx94X', 'gfx950', 'gfx110X', 'gfx120X' ]
     steps:
       - name: Checkout (shallow)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             projects/rocprofiler-sdk/requirements.txt

--- a/.github/workflows/rocprofiler-sdk-build-ci-docker-images.yml
+++ b/.github/workflows/rocprofiler-sdk-build-ci-docker-images.yml
@@ -60,17 +60,17 @@ jobs:
           echo "tarball=${KEY}" >> $GITHUB_OUTPUT
 
       - name: Login to Docker Hub
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: docker.io
           username: ${{ secrets.ROCPROFILER_AZURE_CI_USER }}
           password: ${{ secrets.ROCPROFILER_AZURE_CI_PASS }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build & Push (to Docker Hub; cache to GHA)
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           file: projects/rocprofiler-sdk/docker/Dockerfile.ci
           platforms: linux/amd64

--- a/.github/workflows/rocprofiler-sdk-code_coverage.yml
+++ b/.github/workflows/rocprofiler-sdk-code_coverage.yml
@@ -106,7 +106,7 @@ jobs:
         echo "ROCm installed to: ${{ env.ROCM_PATH }}"
 
     - name: Clone ROCProfiler SDK & AQLProfile & ROCProfiler Register & ROCR-Runtime
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         sparse-checkout: |
           projects/rocprofiler-sdk
@@ -144,7 +144,7 @@ jobs:
       run: git submodule update --init --recursive --jobs 16
 
     - name: Clone ROCDecode
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         repository: 'ROCm/rocDecode'
         ref: 'release/rocm-rel-7.0'
@@ -152,7 +152,7 @@ jobs:
         path: 'rocDecode'
 
     - name: Clone ROCJPEG
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         repository: 'ROCm/rocJPEG'
         ref: 'release/rocm-rel-7.0'
@@ -518,7 +518,7 @@ jobs:
 
     - name: Archive Code Coverage Data
       if: ${{ github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: code-coverage-details
         path: |

--- a/.github/workflows/rocprofiler-sdk-codeql.yml
+++ b/.github/workflows/rocprofiler-sdk-codeql.yml
@@ -96,7 +96,7 @@ jobs:
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 20 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12
         git config --global --add safe.directory '*'
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: |
           projects/rocprofiler-sdk

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -120,7 +120,7 @@ jobs:
           echo "ROCm installed to: ${{ env.ROCM_PATH }}"
 
       - name: Clone ROCProfiler SDK & AQLProfile & ROCProfiler Register & ROCR-Runtime & Trace Decoder
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             projects/rocprofiler-sdk
@@ -160,7 +160,7 @@ jobs:
         run: git submodule update --init --recursive --jobs 16
 
       - name: Clone ROCDecode
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: 'ROCm/rocDecode'
           ref: 'release/rocm-rel-7.0'
@@ -168,7 +168,7 @@ jobs:
           path: 'rocDecode'
 
       - name: Clone ROCJPEG
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: 'ROCm/rocJPEG'
           ref: 'release/rocm-rel-7.0'
@@ -448,7 +448,7 @@ jobs:
 
       - name: Archive production artifacts
         if: ${{ github.event_name == 'workflow_dispatch' && contains(matrix.system.gpu, env.CORE_EXT_RUNNER) }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: installers-deb
           path: |
@@ -484,7 +484,7 @@ jobs:
       GPU_RUNNER: ${{ matrix.system.gpu }}
     steps:
       - name: Clone ROCProfiler SDK & AQLProfile & ROCProfiler Register & ROCR-Runtime & Trace Decoder
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             projects/rocprofiler-sdk
@@ -753,7 +753,7 @@ jobs:
     - *install_latest_nightly_rocm
 
     - name: Clone ROCProfiler SDK & AQLProfile & ROCProfiler Register & ROCR-Runtime & Trace Decoder
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         sparse-checkout: |
           projects/rocprofiler-sdk

--- a/.github/workflows/rocprofiler-sdk-docs.yml
+++ b/.github/workflows/rocprofiler-sdk-docs.yml
@@ -43,7 +43,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: projects/rocprofiler-sdk
           submodules: true
@@ -110,7 +110,7 @@ jobs:
           echo "PATH=/usr/bin:$PATH" >> "$GITHUB_ENV"
 
       - name: Clone ROCProfiler SDK & HIP/CLR & ROCR-Runtime
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             projects/rocprofiler-sdk

--- a/.github/workflows/rocprofiler-sdk-formatting.yml
+++ b/.github/workflows/rocprofiler-sdk-formatting.yml
@@ -31,7 +31,7 @@ jobs:
       ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-sdk
 
@@ -71,7 +71,7 @@ jobs:
       ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-sdk
 
@@ -118,7 +118,7 @@ jobs:
       ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-sdk
 
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-sdk
 
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-sdk
 

--- a/.github/workflows/rocprofiler-sdk-python.yml
+++ b/.github/workflows/rocprofiler-sdk-python.yml
@@ -41,7 +41,7 @@ jobs:
         python-version: ['3.8', '3.10', '3.12']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-sdk
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/rocprofiler-sdk-restrictions.yml
+++ b/.github/workflows/rocprofiler-sdk-restrictions.yml
@@ -38,7 +38,7 @@ jobs:
       FOLDERS: "source/lib/common source/lib/rocprofiler-sdk source/lib/rocprofiler-sdk-roctx source/lib/output source/lib/rocprofiler-sdk-tool"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/rocprofiler-sdk-rocm_release_compatibility.yml
+++ b/.github/workflows/rocprofiler-sdk-rocm_release_compatibility.yml
@@ -69,7 +69,7 @@ jobs:
         apt-get update
         apt-get install -y git
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install requirements
       timeout-minutes: 10

--- a/.github/workflows/rocprofiler-systems-containers.yml
+++ b/.github/workflows/rocprofiler-systems-containers.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Build CI Container (PR - No Push)
         if: github.event_name == 'pull_request'
         timeout-minutes: 45
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           retry_wait_seconds: 60
           timeout_minutes: 45
@@ -109,7 +109,7 @@ jobs:
       - name: Build Base Container (Push)
         if: github.event_name != 'pull_request'
         timeout-minutes: 45
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           retry_wait_seconds: 60
           timeout_minutes: 45
@@ -172,7 +172,7 @@ jobs:
       - name: Build Base Container (PR - No Push)
         if: github.event_name == 'pull_request'
         timeout-minutes: 45
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           retry_wait_seconds: 60
           timeout_minutes: 45
@@ -188,7 +188,7 @@ jobs:
       - name: Build Base Container (Push)
         if: github.event_name != 'pull_request'
         timeout-minutes: 45
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           retry_wait_seconds: 60
           timeout_minutes: 45

--- a/.github/workflows/rocprofiler-systems-containers.yml
+++ b/.github/workflows/rocprofiler-systems-containers.yml
@@ -83,7 +83,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }}
           password: ${{ secrets.ROCPROF_SYS_DOCKER_TOKEN }}
@@ -164,7 +164,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }}
           password: ${{ secrets.ROCPROF_SYS_DOCKER_TOKEN }}

--- a/.github/workflows/rocprofiler-systems-containers.yml
+++ b/.github/workflows/rocprofiler-systems-containers.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Build CI Container (PR - No Push)
         if: github.event_name == 'pull_request'
         timeout-minutes: 45
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           retry_wait_seconds: 60
           timeout_minutes: 45
@@ -109,7 +109,7 @@ jobs:
       - name: Build Base Container (Push)
         if: github.event_name != 'pull_request'
         timeout-minutes: 45
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           retry_wait_seconds: 60
           timeout_minutes: 45
@@ -172,7 +172,7 @@ jobs:
       - name: Build Base Container (PR - No Push)
         if: github.event_name == 'pull_request'
         timeout-minutes: 45
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           retry_wait_seconds: 60
           timeout_minutes: 45
@@ -188,7 +188,7 @@ jobs:
       - name: Build Base Container (Push)
         if: github.event_name != 'pull_request'
         timeout-minutes: 45
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           retry_wait_seconds: 60
           timeout_minutes: 45

--- a/.github/workflows/rocprofiler-systems-debian.yml
+++ b/.github/workflows/rocprofiler-systems-debian.yml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Install Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25

--- a/.github/workflows/rocprofiler-systems-debian.yml
+++ b/.github/workflows/rocprofiler-systems-debian.yml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Install Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v4
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25

--- a/.github/workflows/rocprofiler-systems-ghcr.yml
+++ b/.github/workflows/rocprofiler-systems-ghcr.yml
@@ -73,7 +73,7 @@ jobs:
           submodules: recursive
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -123,7 +123,7 @@ jobs:
       - name: Build CI GFX Container (Does not Push on PR)
         id: docker_build
         continue-on-error: true
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           file: projects/rocprofiler-systems/docker/${{ steps.setup_vars_gfx.outputs.docker_file }}
           platforms: linux/amd64
@@ -144,7 +144,7 @@ jobs:
       # Retry a copy of docker_build if Docker build failed due to intermittent failure
       - name: Build CI GFX Container Retry (Does not Push on PR)
         if: steps.docker_build.outcome != 'success'
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           file: projects/rocprofiler-systems/docker/${{ steps.setup_vars_gfx.outputs.docker_file }}
           platforms: linux/amd64

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -91,7 +91,7 @@ jobs:
 
     - name: Install ROCm Packages
       timeout-minutes: 30
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         retry_wait_seconds: 30
         timeout_minutes: 30

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -91,7 +91,7 @@ jobs:
 
     - name: Install ROCm Packages
       timeout-minutes: 30
-      uses: nick-fields/retry@v4
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
       with:
         retry_wait_seconds: 30
         timeout_minutes: 30

--- a/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Install Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25
@@ -92,7 +92,7 @@ jobs:
 
     - name: Install ROCm Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25
@@ -279,7 +279,7 @@ jobs:
 
     - name: Install System Dependency Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25
@@ -295,7 +295,7 @@ jobs:
 
     - name: Install ROCm 7.2
       timeout-minutes: 25
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25
@@ -412,7 +412,7 @@ jobs:
 
     - name: Install Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25
@@ -426,7 +426,7 @@ jobs:
 
     - name: Install ROCm Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25

--- a/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Install Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v4
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25
@@ -92,7 +92,7 @@ jobs:
 
     - name: Install ROCm Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v4
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25
@@ -279,7 +279,7 @@ jobs:
 
     - name: Install System Dependency Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v4
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25
@@ -295,7 +295,7 @@ jobs:
 
     - name: Install ROCm 7.2
       timeout-minutes: 25
-      uses: nick-fields/retry@v4
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25
@@ -412,7 +412,7 @@ jobs:
 
     - name: Install Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v4
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25
@@ -426,7 +426,7 @@ jobs:
 
     - name: Install ROCm Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v4
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25

--- a/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Install Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25
@@ -242,7 +242,7 @@ jobs:
 
     - name: Install System Dependency Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25
@@ -258,7 +258,7 @@ jobs:
 
     - name: Install ROCm 7.2
       timeout-minutes: 25
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25

--- a/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Install Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v4
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25
@@ -242,7 +242,7 @@ jobs:
 
     - name: Install System Dependency Packages
       timeout-minutes: 25
-      uses: nick-fields/retry@v4
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25
@@ -258,7 +258,7 @@ jobs:
 
     - name: Install ROCm 7.2
       timeout-minutes: 25
-      uses: nick-fields/retry@v4
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
       with:
         retry_wait_seconds: 30
         timeout_minutes: 25


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Noticed that older versions of Docker actions used Node 20, and Node 20 actions are being deprecated in June.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Update `rocprofiler-*` workflow files to use the latest versions of Docker and GitHub actions (moved to Node 24)
  - `docker/login-action` -> v4.1.0
  - `docker/metadata-action` -> v6.0.0
  - `docker/build-push-action` -> v7.1.0
  - `docker/setup-buildx-action` -> v4.0.0
  - `actions/checkout` -> v6
  - `actions/upload-artifact` -> v7
  - `nick-fields/retry` -> v4

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Ensure no regression issues with action updates, workflows pass

## Test Result

<!-- Briefly summarize test outcomes. -->
TBA

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
