### PR TITLE
[AMD-SMI] Update power APIs precision

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -88,9 +88,26 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - CLI help text and memory partition change warnings no longer reference `amd-smi reset -r` for driver reloading.
   - Users are now directed to use `sudo modprobe -r amdgpu && sudo modprobe amdgpu` to reload the driver after partition changes.
 
+- **Changed CPU power APIs to return values in milliwatts (mW) for higher precision**.  
+  - Removed lossy integer rounding (`(mW + 500) / 1000`) from 6 CPU power get APIs. Values are now
+    returned in milliwatts directly from the ESMI library, preserving sub-watt precision.
+  - **C API**: Output parameter type remains `uint32_t*`, but the unit changed from watts to milliwatts (mW).
+    - `amdsmi_get_cpu_socket_power`
+    - `amdsmi_get_cpu_socket_power_cap`
+    - `amdsmi_get_cpu_socket_power_cap_max`
+    - `amdsmi_get_cpu_pwr_efficiency_mode` (ppt_limit field)
+    - `amdsmi_get_cpu_core_ccd_power`
+    - `amdsmi_get_cpu_sdps_limit`
+  - **Python API (breaking)**: These functions now return `int` (milliwatts) instead of `str` (e.g., `"240 Watts"`).
+    Callers that parsed the string output must update to handle the numeric return value.
+  - **CLI output**: Power values now display with milliwatt precision (e.g., `240.500 Watts`).
+  - Added missing null-pointer validation for output parameters in `amdsmi_get_cpu_socket_power_cap`
+    and `amdsmi_get_cpu_socket_power_cap_max`.
+  - Updated header documentation to specify milliwatt units for all affected get and set API parameters.
+
 - **Changed power APIs to have consistent output parameter types**.  
   - Modified 6 cpu power API's to have consistent output power types. All set and get API's have uint32_t output values.
-  - Modified get and set API's that had double output types to have uint32_t output types.
+  - Modified get and set API's that had double output types to have uint32_t output types in milliwatts (mW).
     - amdsmi_get_cpu_socket_power(amdsmi_processor_handle processor_handle, uint32_t* ppower);
     - amdsmi_get_cpu_socket_power_cap(amdsmi_processor_handle processor_handle, uint32_t* pcap);
     - amdsmi_get_cpu_socket_power_cap_max(amdsmi_processor_handle processor_handle, uint32_t* pmax);

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -4599,7 +4599,7 @@ class AMDSMICommands:
             try:
                 soc_pow = amdsmi_interface.amdsmi_get_cpu_socket_power(args.cpu)
                 soc_pow = self.helpers.convert_SI_unit(float(soc_pow), self.helpers.SI_Unit.MILLI)
-                static_dict["power_metrics"]["socket power"] = f"{soc_pow:.3f} Watts"
+                static_dict["power_metrics"]["socket power"] = f"{soc_pow:.3f} W"
             except amdsmi_exception.AmdSmiLibraryException as e:
                 static_dict["power_metrics"]["socket power"] = "N/A"
                 logging.debug(
@@ -4611,7 +4611,7 @@ class AMDSMICommands:
                 soc_pwr_limit = self.helpers.convert_SI_unit(
                     float(soc_pwr_limit), self.helpers.SI_Unit.MILLI
                 )
-                static_dict["power_metrics"]["socket power limit"] = f"{soc_pwr_limit:.3f} Watts"
+                static_dict["power_metrics"]["socket power limit"] = f"{soc_pwr_limit:.3f} W"
             except amdsmi_exception.AmdSmiLibraryException as e:
                 static_dict["power_metrics"]["socket power limit"] = "N/A"
                 logging.debug(
@@ -4624,7 +4624,7 @@ class AMDSMICommands:
                     float(soc_max_pwr_limit), self.helpers.SI_Unit.MILLI
                 )
                 static_dict["power_metrics"]["socket max power limit"] = (
-                    f"{soc_max_pwr_limit:.3f} Watts"
+                    f"{soc_max_pwr_limit:.3f} W"
                 )
             except amdsmi_exception.AmdSmiLibraryException as e:
                 static_dict["power_metrics"]["socket max power limit"] = "N/A"
@@ -4764,7 +4764,7 @@ class AMDSMICommands:
                 # Only show util and ppt_limit for modes 4 and 5
                 if mode in [4, 5]:
                     static_dict["pwr_eff_mode"]["util"] = f"{util}%"
-                    static_dict["pwr_eff_mode"]["ppt_limit"] = f"{ppt_limit:.3f} Watts"
+                    static_dict["pwr_eff_mode"]["ppt_limit"] = f"{ppt_limit:.3f} W"
                 else:
                     # For modes 0-3, util and ppt_limit are not displayed
                     pass
@@ -5046,7 +5046,7 @@ class AMDSMICommands:
                 sdps_limit = self.helpers.convert_SI_unit(
                     float(sdps_limit), self.helpers.SI_Unit.MILLI
                 )
-                static_dict["sdps_limit"]["value"] = f"{sdps_limit:.3f} Watts"
+                static_dict["sdps_limit"]["value"] = f"{sdps_limit:.3f} W"
             except amdsmi_exception.AmdSmiLibraryException as e:
                 static_dict["sdps_limit"]["value"] = "N/A"
                 logging.debug(
@@ -5185,7 +5185,7 @@ class AMDSMICommands:
             try:
                 power = amdsmi_interface.amdsmi_get_cpu_core_ccd_power(args.core)
                 power = self.helpers.convert_SI_unit(float(power), self.helpers.SI_Unit.MILLI)
-                static_dict["ccd_power"]["value"] = f"{power:.3f} Watts"
+                static_dict["ccd_power"]["value"] = f"{power:.3f} W"
             except amdsmi_exception.AmdSmiLibraryException as e:
                 static_dict["ccd_power"]["value"] = "N/A"
                 logging.debug(
@@ -7960,7 +7960,7 @@ class AMDSMICommands:
                 if mode in [4, 5]:
                     ppt_limit_watts = updated_ppt_limit / 1000.0  # Convert milliwatts to watts
                     static_dict["pwr_eff_mode"]["util"] = f"{updated_util}%"
-                    static_dict["pwr_eff_mode"]["ppt_limit"] = f"{ppt_limit_watts} Watts"
+                    static_dict["pwr_eff_mode"]["ppt_limit"] = f"{ppt_limit_watts} W"
                 else:
                     # For modes 0-3, util and ppt_limit are not displayed
                     pass
@@ -8262,7 +8262,7 @@ class AMDSMICommands:
                 amdsmi_interface.amdsmi_set_cpu_sdps_limit(args.cpu, args.cpu_sdps_limit[0][0])
                 sdps_limit_watts = float(args.cpu_sdps_limit[0][0]) / 1000
                 static_dict["sdps_limit"]["Response"] = (
-                    f"Set, VALUE: {sdps_limit_watts:.3f} Watts, successful"
+                    f"Set, VALUE: {sdps_limit_watts:.3f} W, successful"
                 )
             except amdsmi_exception.AmdSmiLibraryException as e:
                 static_dict["sdps_limit"]["Response"] = (

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -4598,7 +4598,8 @@ class AMDSMICommands:
             static_dict["power_metrics"] = {}
             try:
                 soc_pow = amdsmi_interface.amdsmi_get_cpu_socket_power(args.cpu)
-                static_dict["power_metrics"]["socket power"] = soc_pow
+                soc_pow = self.helpers.convert_SI_unit(float(soc_pow), self.helpers.SI_Unit.MILLI)
+                static_dict["power_metrics"]["socket power"] = f"{soc_pow:.3f} Watts"
             except amdsmi_exception.AmdSmiLibraryException as e:
                 static_dict["power_metrics"]["socket power"] = "N/A"
                 logging.debug(
@@ -4607,7 +4608,10 @@ class AMDSMICommands:
 
             try:
                 soc_pwr_limit = amdsmi_interface.amdsmi_get_cpu_socket_power_cap(args.cpu)
-                static_dict["power_metrics"]["socket power limit"] = soc_pwr_limit
+                soc_pwr_limit = self.helpers.convert_SI_unit(
+                    float(soc_pwr_limit), self.helpers.SI_Unit.MILLI
+                )
+                static_dict["power_metrics"]["socket power limit"] = f"{soc_pwr_limit:.3f} Watts"
             except amdsmi_exception.AmdSmiLibraryException as e:
                 static_dict["power_metrics"]["socket power limit"] = "N/A"
                 logging.debug(
@@ -4616,7 +4620,12 @@ class AMDSMICommands:
 
             try:
                 soc_max_pwr_limit = amdsmi_interface.amdsmi_get_cpu_socket_power_cap_max(args.cpu)
-                static_dict["power_metrics"]["socket max power limit"] = soc_max_pwr_limit
+                soc_max_pwr_limit = self.helpers.convert_SI_unit(
+                    float(soc_max_pwr_limit), self.helpers.SI_Unit.MILLI
+                )
+                static_dict["power_metrics"]["socket max power limit"] = (
+                    f"{soc_max_pwr_limit:.3f} Watts"
+                )
             except amdsmi_exception.AmdSmiLibraryException as e:
                 static_dict["power_metrics"]["socket max power limit"] = "N/A"
                 logging.debug(
@@ -4745,6 +4754,9 @@ class AMDSMICommands:
                 mode, util, ppt_limit = amdsmi_interface.amdsmi_get_cpu_pwr_efficiency_mode(
                     args.cpu
                 )
+                ppt_limit = self.helpers.convert_SI_unit(
+                    float(ppt_limit), self.helpers.SI_Unit.MILLI
+                )
 
                 # Always show mode
                 static_dict["pwr_eff_mode"]["mode"] = f"{mode}"
@@ -4752,7 +4764,7 @@ class AMDSMICommands:
                 # Only show util and ppt_limit for modes 4 and 5
                 if mode in [4, 5]:
                     static_dict["pwr_eff_mode"]["util"] = f"{util}%"
-                    static_dict["pwr_eff_mode"]["ppt_limit"] = f"{ppt_limit} Watts"
+                    static_dict["pwr_eff_mode"]["ppt_limit"] = f"{ppt_limit:.3f} Watts"
                 else:
                     # For modes 0-3, util and ppt_limit are not displayed
                     pass
@@ -5031,7 +5043,10 @@ class AMDSMICommands:
             static_dict["sdps_limit"] = {}
             try:
                 sdps_limit = amdsmi_interface.amdsmi_get_cpu_sdps_limit(args.cpu)
-                static_dict["sdps_limit"]["value"] = sdps_limit
+                sdps_limit = self.helpers.convert_SI_unit(
+                    float(sdps_limit), self.helpers.SI_Unit.MILLI
+                )
+                static_dict["sdps_limit"]["value"] = f"{sdps_limit:.3f} Watts"
             except amdsmi_exception.AmdSmiLibraryException as e:
                 static_dict["sdps_limit"]["value"] = "N/A"
                 logging.debug(
@@ -5169,7 +5184,8 @@ class AMDSMICommands:
             static_dict["ccd_power"] = {}
             try:
                 power = amdsmi_interface.amdsmi_get_cpu_core_ccd_power(args.core)
-                static_dict["ccd_power"]["value"] = f"{power} Watts"
+                power = self.helpers.convert_SI_unit(float(power), self.helpers.SI_Unit.MILLI)
+                static_dict["ccd_power"]["value"] = f"{power:.3f} Watts"
             except amdsmi_exception.AmdSmiLibraryException as e:
                 static_dict["ccd_power"]["value"] = "N/A"
                 logging.debug(
@@ -7861,14 +7877,16 @@ class AMDSMICommands:
             static_dict["set_pwr_limit"] = {}
             try:
                 soc_max_pwr_limit = amdsmi_interface.amdsmi_get_cpu_socket_power_cap_max(args.cpu)
-                extract_numeric = soc_max_pwr_limit.split()[0]
-                max_power = int(extract_numeric)
-
-                amdsmi_interface.amdsmi_set_cpu_socket_power_cap(args.cpu, args.cpu_pwr_limit[0][0])
+                soc_max_pwr_limit = self.helpers.convert_SI_unit(
+                    float(soc_max_pwr_limit), self.helpers.SI_Unit.MILLI
+                )
+                max_power = int(soc_max_pwr_limit)
                 if args.cpu_pwr_limit[0][0] > max_power:
                     args.cpu_pwr_limit[0][0] = max_power
+
+                amdsmi_interface.amdsmi_set_cpu_socket_power_cap(args.cpu, args.cpu_pwr_limit[0][0])
                 static_dict["set_pwr_limit"]["Response"] = (
-                    f"{args.cpu_pwr_limit[0][0] / 1000:.3f} mW"
+                    f"{args.cpu_pwr_limit[0][0] / 1000:.3f} W"
                 )
             except amdsmi_exception.AmdSmiLibraryException as e:
                 static_dict["set_pwr_limit"]["Response"] = (
@@ -12527,8 +12545,9 @@ class AMDSMICommands:
             # rest of power usage info; Will assume we're always trying to get PPT0 for now
             try:
                 power_cap_info = amdsmi_interface.amdsmi_get_power_cap_info(processor, 0)
+                socket_power_limit = power_cap_info["power_cap"]
                 socket_power_limit = self.helpers.convert_SI_unit(
-                    power_cap_info["power_cap"], AMDSMIHelpers.SI_Unit.MICRO
+                    socket_power_limit, AMDSMIHelpers.SI_Unit.MICRO
                 )
                 power_usage = {"current_power": current_power, "power_limit": socket_power_limit}
             except amdsmi_exception.AmdSmiLibraryException as e:

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -3711,7 +3711,7 @@ amdsmi_status_t amdsmi_get_supported_power_cap(amdsmi_processor_handle processor
  *
  *  @param[in]   processor_handle Cpu socket which to query
  *
- *  @param[out]  ppower - Input buffer to return socket power
+ *  @param[out]  ppower - Input buffer to return socket power in milliwatts (mW)
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
@@ -3727,7 +3727,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_power(amdsmi_processor_handle processor_ha
  *
  *  @param[in]   processor_handle Cpu socket which to query
  *
- *  @param[out]  pcap - Input buffer to return power cap.
+ *  @param[out]  pcap - Input buffer to return power cap in milliwatts (mW)
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
@@ -3743,7 +3743,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_power_cap(amdsmi_processor_handle processo
  *
  *  @param[in]   processor_handle Cpu socket which to query
  *
- *  @param[out]  pmax - Input buffer to return maximum power limit value
+ *  @param[out]  pmax - Input buffer to return maximum power limit value in milliwatts (mW)
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
@@ -3775,7 +3775,7 @@ amdsmi_status_t amdsmi_get_cpu_pwr_svi_telemetry_all_rails(amdsmi_processor_hand
  *
  *  @param[in]  processor_handle Cpu socket which to query
  *
- *  @param[in]  pcap - Input power limit value
+ *  @param[in]  pcap - Input power limit value in milliwatts (mW)
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
@@ -3796,6 +3796,7 @@ amdsmi_status_t amdsmi_set_cpu_socket_power_cap(amdsmi_processor_handle processo
  *  @param[in,out]  utilization - pointer to store utilization for balanced core modes (%)
  *
  *  @param[in,out]  ppt_limit - pointer to PPT (Package Power Tracking) limit value
+ *                              in milliwatts (mW)
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
@@ -3819,7 +3820,8 @@ amdsmi_status_t amdsmi_set_cpu_pwr_efficiency_mode(amdsmi_processor_handle proce
  *
  *  @param[out]  utilization - pointer to store utilization for balanced core modes (%)
  *
- *  @param[out]  ppt_limit - pointer to store PPT (Package Power Tracking) limit value in Watt
+ *  @param[out]  ppt_limit - pointer to store PPT (Package Power Tracking) limit value
+ *                           in milliwatts (mW)
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
@@ -3837,7 +3839,7 @@ amdsmi_status_t amdsmi_get_cpu_pwr_efficiency_mode(amdsmi_processor_handle proce
  *  @platform{cpu_bm}
  *
  *  @param[in]   processor_handle Cpu core which to query
- *  @param[out]  power - Input buffer to store power consumption in watts
+ *  @param[out]  power - Input buffer to store power consumption in milliwatts (mW)
  *
  *   @return ::amdsmi_status_t
  *           ::AMDSMI_STATUS_SUCCESS on successful register read, non-zero on failure
@@ -7827,7 +7829,8 @@ amdsmi_status_t amdsmi_set_cpu_sdps_limit(amdsmi_processor_handle processor_hand
  *  @platform{cpu_bm}
  *
  *  @param[in]   processor_handle Processor handle for which to query the limit
- *  @param[out]  sdps_limit - Input buffer to receive the current SDPS limit value in watts
+ *  @param[out]  sdps_limit - Input buffer to receive the current SDPS limit value in
+ *                            milliwatts (mW)
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -1390,8 +1390,7 @@ def amdsmi_get_cpu_core_ccd_power(processor_handle: processor_handle_t) -> int:
 
     _check_res(amdsmi_wrapper.amdsmi_get_cpu_core_ccd_power(processor_handle, ctypes.byref(power)))
 
-    # In Watt
-    return power.value
+    return power.value  # in mW
 
 
 def amdsmi_get_cpu_socket_energy(processor_handle: processor_handle_t) -> str:
@@ -1501,27 +1500,27 @@ def amdsmi_get_cpu_core_current_freq_limit(processor_handle: processor_handle_t)
     return f"{freq.value} MHz"
 
 
-def amdsmi_get_cpu_socket_power(processor_handle: processor_handle_t) -> str:
+def amdsmi_get_cpu_socket_power(processor_handle: processor_handle_t) -> int:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
     ppower = ctypes.c_uint32()
     _check_res(amdsmi_wrapper.amdsmi_get_cpu_socket_power(processor_handle, ctypes.byref(ppower)))
 
-    return f"{ppower.value} Watts"
+    return ppower.value  # in mW
 
 
-def amdsmi_get_cpu_socket_power_cap(processor_handle: processor_handle_t) -> str:
+def amdsmi_get_cpu_socket_power_cap(processor_handle: processor_handle_t) -> int:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
     pcap = ctypes.c_uint32()
     _check_res(amdsmi_wrapper.amdsmi_get_cpu_socket_power_cap(processor_handle, ctypes.byref(pcap)))
 
-    return f"{pcap.value} Watts"
+    return pcap.value  # in mW
 
 
-def amdsmi_get_cpu_socket_power_cap_max(processor_handle: processor_handle_t) -> str:
+def amdsmi_get_cpu_socket_power_cap_max(processor_handle: processor_handle_t) -> int:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
@@ -1530,7 +1529,7 @@ def amdsmi_get_cpu_socket_power_cap_max(processor_handle: processor_handle_t) ->
         amdsmi_wrapper.amdsmi_get_cpu_socket_power_cap_max(processor_handle, ctypes.byref(pmax))
     )
 
-    return f"{pmax.value} Watts"
+    return pmax.value  # in mW
 
 
 def amdsmi_get_cpu_pwr_svi_telemetry_all_rails(processor_handle: processor_handle_t) -> str:
@@ -2358,15 +2357,14 @@ def amdsmi_set_cpu_sdps_limit(processor_handle: processor_handle_t, sdps_limit: 
     _check_res(amdsmi_wrapper.amdsmi_set_cpu_sdps_limit(processor_handle, sdps_limit_32))
 
 
-def amdsmi_get_cpu_sdps_limit(processor_handle: processor_handle_t) -> str:
+def amdsmi_get_cpu_sdps_limit(processor_handle: processor_handle_t) -> int:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
     sdps_limit = ctypes.c_uint32()
     _check_res(amdsmi_wrapper.amdsmi_get_cpu_sdps_limit(processor_handle, ctypes.byref(sdps_limit)))
 
-    # In Watt
-    return f"{sdps_limit.value} Watts"
+    return sdps_limit.value  # in mW
 
 
 # Get 2's complement of 32 bit unsigned integer

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -6517,8 +6517,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_power(amdsmi_processor_handle processor_ha
 
   AMDSMI_CHECK_INIT();
 
-  if (processor_handle == nullptr) return AMDSMI_STATUS_INVAL;
-  if (ppower == nullptr) return AMDSMI_STATUS_INVAL;
+  if (processor_handle == nullptr || ppower == nullptr) return AMDSMI_STATUS_INVAL;
 
   amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
   if (r != AMDSMI_STATUS_SUCCESS) return r;
@@ -6528,8 +6527,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_power(amdsmi_processor_handle processor_ha
   status = static_cast<amdsmi_status_t>(esmi_socket_power_get(sock_ind, &avg_power));
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
-  // Convert milliwatts to watts
-  *ppower = (avg_power + 500) / 1000;
+  *ppower = avg_power;  // in mW
 
   return AMDSMI_STATUS_SUCCESS;
 }
@@ -6542,7 +6540,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_power_cap(amdsmi_processor_handle processo
 
   AMDSMI_CHECK_INIT();
 
-  if (processor_handle == nullptr) return AMDSMI_STATUS_INVAL;
+  if (processor_handle == nullptr || pcap == nullptr) return AMDSMI_STATUS_INVAL;
 
   amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
   if (r != AMDSMI_STATUS_SUCCESS) return r;
@@ -6552,8 +6550,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_power_cap(amdsmi_processor_handle processo
   status = static_cast<amdsmi_status_t>(esmi_socket_power_cap_get(sock_ind, &p_cap));
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
-  // Convert milliwatts to watts
-  *pcap = (p_cap + 500) / 1000;
+  *pcap = p_cap;  // in mW
 
   return AMDSMI_STATUS_SUCCESS;
 }
@@ -6566,7 +6563,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_power_cap_max(amdsmi_processor_handle proc
 
   AMDSMI_CHECK_INIT();
 
-  if (processor_handle == nullptr) return AMDSMI_STATUS_INVAL;
+  if (processor_handle == nullptr || pmax == nullptr) return AMDSMI_STATUS_INVAL;
 
   amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
   if (r != AMDSMI_STATUS_SUCCESS) return r;
@@ -6576,8 +6573,7 @@ amdsmi_status_t amdsmi_get_cpu_socket_power_cap_max(amdsmi_processor_handle proc
   status = static_cast<amdsmi_status_t>(esmi_socket_power_cap_max_get(sock_ind, &p_max));
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
-  // Convert milliwatts to watts
-  *pmax = (p_max + 500) / 1000;
+  *pmax = p_max;  // in mW
 
   return AMDSMI_STATUS_SUCCESS;
 }
@@ -6698,7 +6694,6 @@ amdsmi_status_t amdsmi_get_cpu_pwr_efficiency_mode(amdsmi_processor_handle proce
   AMDSMI_CHECK_INIT();
 
   if (processor_handle == nullptr) return AMDSMI_STATUS_INVAL;
-
   if (power_efficiency_mode == nullptr || utilization == nullptr || ppt_limit == nullptr)
     return AMDSMI_STATUS_INVAL;
 
@@ -6712,7 +6707,7 @@ amdsmi_status_t amdsmi_get_cpu_pwr_efficiency_mode(amdsmi_processor_handle proce
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
   *power_efficiency_mode = static_cast<uint32_t>(mode_uint8);
-  *ppt_limit = (pptlimit_uint32 + 500) / 1000;
+  *ppt_limit = pptlimit_uint32;  // in mW
 
   return AMDSMI_STATUS_SUCCESS;
 }
@@ -7731,7 +7726,7 @@ amdsmi_status_t amdsmi_get_cpu_core_ccd_power(amdsmi_processor_handle processor_
   status = static_cast<amdsmi_status_t>(esmi_read_ccd_power(core_ind, &power_u32));
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
-  *power = (power_u32 + 500) / 1000;
+  *power = power_u32;  // in mW
   return AMDSMI_STATUS_SUCCESS;
 }
 
@@ -8102,8 +8097,7 @@ amdsmi_status_t amdsmi_get_cpu_sdps_limit(amdsmi_processor_handle processor_hand
   status = static_cast<amdsmi_status_t>(esmi_sdps_limit_get(sock_ind, &sdpslimit_u32));
   if (status != AMDSMI_STATUS_SUCCESS) return amdsmi_errno_to_esmi_status(status);
 
-  // Convert milliwatts to watts
-  *sdps_limit = (sdpslimit_u32 + 500) / 1000;
+  *sdps_limit = sdpslimit_u32;  // in mW
 
   return AMDSMI_STATUS_SUCCESS;
 }

--- a/projects/amdsmi/tests/python_unittest/integration_test.py
+++ b/projects/amdsmi/tests/python_unittest/integration_test.py
@@ -742,10 +742,6 @@ class TestAmdSmiPython(unittest.TestCase):
                 power_cap_max = amdsmi.amdsmi_get_cpu_socket_power_cap_max(cpu)
                 self.common.print(msg, power_cap_max)
                 self.common.check_ret("", "", self.common.PASS)
-
-                # Convert power_cap_max from string that has units to an integer
-                # Ex.  power_cap_max = "500 W"  to   power_cap_max = 500
-                power_cap_max = int(power_cap_max.split()[0])
             except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:
                 if self.common.check_ret(msg, e, self.common.PASS):
                     self.raise_exception = e
@@ -767,7 +763,7 @@ class TestAmdSmiPython(unittest.TestCase):
             # Set cpu socket power back
             msg = f"\t### amdsmi_set_cpu_socket_power_cap(cpu={i}, power_cap={power_cap_orig}):"
             try:
-                ret = amdsmi.amdsmi_set_cpu_socket_power_cap(cpu, int(power_cap_orig.split()[0]))
+                ret = amdsmi.amdsmi_set_cpu_socket_power_cap(cpu, power_cap_orig)
                 self.common.print(msg, ret)
                 self.common.check_ret("", "", self.common.PASS)
             except (amdsmi.AmdSmiLibraryException, amdsmi.AmdSmiParameterException) as e:


### PR DESCRIPTION
## Motivation
The AMD E-SMI (Energy/System Management Interface) library returns all power values in milliwatts. The AMD SMI C library was converting these to whole watts via integer rounding: *ppower = (avg_power + 500) / 1000. This introduced up to ±0.5W of quantization error — acceptable for high-TDP sockets (~0.1% error at 400W) but significant for lower-power CCD/core measurements where relative error grows proportionally.

## Technical Details
C library (amd_smi.cc) — Remove all 6 instances of (val + 500) / 1000 rounding. Pass raw milliwatt uint32_t values from ESMI directly to callers. The output parameter type (uint32_t*) is unchanged — only the semantic unit changes from watts to milliwatts.

Python interface (amdsmi_interface.py) — Return raw int values (milliwatts) instead of formatted strings like "240 Watts". This is a breaking change for 5 functions that previously returned str. The amdsmi_get_cpu_pwr_efficiency_mode tuple already returned raw integers, so it's consistent now.

CLI (amdsmi_commands.py) — Convert mW → W at the display layer using the existing convert_SI_unit(val, SI_Unit.MILLI) helper (which multiplies by 0.001). Format with :.3f for sub-watt precision (e.g., "240.500 Watts").

## Testing
All tests passed:
	amdsmitst
	integration_test.py
	unit_tests.py
	amd-smi: metric --cpu all <--cpu-power-metrics | --cpu-sdps-limit | --core-ccd-power >
