### PR TITLE
kfdtest: Use CopyDwordIsa in Ptrace test

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.cpp
@@ -1561,7 +1561,7 @@ void KFDMemoryTest::PtraceAccessInvisibleVram(int gpuNode) {
     // dstBuffer is cpu accessible gtt memory
     HsaMemoryBuffer dstBuffer(PAGE_SIZE, gpuNode);
 
-    ASSERT_SUCCESS_GPU(m_pAsm->RunAssembleBuf(ScratchCopyDwordIsa, isaBuffer.As<char*>()), gpuNode);
+    ASSERT_SUCCESS_GPU(m_pAsm->RunAssembleBuf(CopyDwordIsa, isaBuffer.As<char*>()), gpuNode);
 
     Dispatch dispatch0(isaBuffer);
     dispatch0.SetArgs(mem0, dstBuffer.As<void*>());


### PR DESCRIPTION
Fix: Switch to CopyDwordIsa, which is simpler and appropriate for this test's purpose (testing ptrace access to invisible VRAM, not scratch memory). This avoids the scratch space conversion logic entirely.

## Motivation
PtraceAccessInvisibleVram test failure due to change in ScratchCopyDwordIsa. This test is better using CopyDwordIsa

## Technical Details


## JIRA ID

ROCM-23360
ROCM-20237

## Test Plan

Able to compile the test and pass the PtraceAccessInvisibleVram test.

## Test Result

Test passed. Since this change only affects PtraceAccessInvisibleVram test. It's safe to test only this sub test case.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
