### PR TITLE
Remove the comgr deprecated action

### DIFF
--- a/projects/clr/rocclr/device/devprogram.cpp
+++ b/projects/clr/rocclr/device/devprogram.cpp
@@ -303,8 +303,11 @@ bool Program::compileToLLVMBitcode(const amd_comgr_data_set_t compileInputs,
   amd_comgr_status_t status = createAction(langver, options, &action, &hasAction);
 
   if (status == AMD_COMGR_STATUS_SUCCESS) {
-    hasOutput = true;
     status = amd::Comgr::create_data_set(&output);
+  }
+
+  if (status == AMD_COMGR_STATUS_SUCCESS) {
+    hasOutput = true;
   }
 
   // Preprocess the source

--- a/projects/clr/rocclr/device/devprogram.cpp
+++ b/projects/clr/rocclr/device/devprogram.cpp
@@ -295,31 +295,20 @@ bool Program::compileToLLVMBitcode(const amd_comgr_data_set_t compileInputs,
   //  Create the output data set
   amd_comgr_action_info_t action{};
   amd_comgr_data_set_t output{};
-  amd_comgr_data_set_t dataSetPCH{};
   amd_comgr_data_set_t input = compileInputs;
 
   bool hasAction = false;
   bool hasOutput = false;
-  bool hasDataSetPCH = false;
 
   amd_comgr_status_t status = createAction(langver, options, &action, &hasAction);
 
   if (status == AMD_COMGR_STATUS_SUCCESS) {
+    hasOutput = true;
     status = amd::Comgr::create_data_set(&output);
   }
 
-  //  Adding Precompiled Headers
-  if (status == AMD_COMGR_STATUS_SUCCESS) {
-    hasOutput = true;
-    status = amd::Comgr::create_data_set(&dataSetPCH);
-  }
-
   // Preprocess the source
-  // FIXME: This must happen before the precompiled headers are added, as they
-  // do not embed the source text of the header, and so reference paths in the
-  // filesystem which do not exist at runtime.
   if (status == AMD_COMGR_STATUS_SUCCESS) {
-    hasDataSetPCH = true;
 
     if (amdOptions->isDumpFlagSet(amd::option::DUMP_I)) {
       amd_comgr_data_set_t dataSetPreprocessor;
@@ -346,18 +335,7 @@ bool Program::compileToLLVMBitcode(const amd_comgr_data_set_t compileInputs,
     }
   }
 
-  if (!isHIP()) {
-    if (status == AMD_COMGR_STATUS_SUCCESS) {
-      status = amd::Comgr::do_action(AMD_COMGR_ACTION_ADD_PRECOMPILED_HEADERS, action, input,
-                                     dataSetPCH);
-      extractBuildLog(dataSetPCH);
-    }
-
-    // Set input for the next stage
-    input = dataSetPCH;
-  }
-
-  //  Compiling the source codes with precompiled headers or directly compileInputs
+  //  Compiling the source codes
   if (status == AMD_COMGR_STATUS_SUCCESS) {
     if (link_dev_libs) {
       status = amd::Comgr::do_action(AMD_COMGR_ACTION_COMPILE_SOURCE_WITH_DEVICE_LIBS_TO_BC, action,
@@ -379,10 +357,6 @@ bool Program::compileToLLVMBitcode(const amd_comgr_data_set_t compileInputs,
 
   if (hasAction) {
     amd::Comgr::destroy_action_info(action);
-  }
-
-  if (hasDataSetPCH) {
-    amd::Comgr::destroy_data_set(dataSetPCH);
   }
 
   if (hasOutput) {


### PR DESCRIPTION
## Motivation

Remove the comgr deprecated action

## Technical Details

Comgr has deprecated the action and made it a no-op and will be removed in future release.
This shows up as a warning everytime I build CLR. If its a no-op it should be easy to remove.

## JIRA ID

NA

## Test Plan

CLR should build just fine after removing the action.

## Test Result

Build locally with CLR/HIP on, it compiled

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Co-authored-by: Claude <noreply@anthropic.com>