### PR TITLE
clr: guard Device::tearDown() against calling Hsa::shut_down from the C++ atexit chain

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -550,6 +550,18 @@ void Device::tearDown() {
     return;
   }
 #endif  // _WIN32
+  // Skip Hsa::shut_down() when the C++ atexit chain is tearing the runtime
+  // down. Calling it from the atexit chain forces libhsa-runtime64 to release
+  // its internal arena while other rocclr and libhsa-runtime64 statics (e.g.
+  // Signal::ipcMap_ and the loader's leaked Executables vector) still hold
+  // pointers into that freed memory. Their later destructors UAF onto
+  // main_arena and corrupt adjacent free-bin chunks, which is then detected
+  // by glibc's malloc_consolidate when libgcc's FDE teardown frees a
+  // neighboring chunk. On explicit hsa_init/hsa_shut_down by the application
+  // we still take the call.
+  if (amd::Runtime::isLibraryDetached()) {
+    return;
+  }
   Hsa::shut_down();
 }
 

--- a/projects/clr/rocclr/platform/runtime.cpp
+++ b/projects/clr/rocclr/platform/runtime.cpp
@@ -126,6 +126,14 @@ RuntimeTearDown::~RuntimeTearDown() {
       ClPrint(amd::LOG_DEBUG, amd::LOG_INIT, "~RuntimeTearDown release external object: %p", it);
       it->release();
     }
+    // Mark the library as detached so that any downstream tearDown() path
+    // knows we are running in the C++ atexit chain, not in an explicit
+    // hsa_init/hsa_shut_down call. Device::tearDown() uses this to skip
+    // Hsa::shut_down() during _dl_fini, because the ordering between HSA's
+    // internal cleanup and true-static globals in libhsa-runtime64 (e.g.
+    // Signal::ipcMap_ and the loader's leaked Executables vector) is
+    // undefined and causes intermittent heap corruption at process exit.
+    Runtime::setLibraryDetached();
     Runtime::tearDown();
   }
 #endif


### PR DESCRIPTION

Fixes a class of intermittent `corrupted double-linked list` SIGABRTs at process exit seen across HIP + ONNX Runtime + MIGraphX workloads on ROCm 6.4.x.

### Symptom

`libamdhip64`-using processes abort at teardown with glibc's `malloc_consolidate` detecting a corrupted `main_arena` free-bin chunk. Reproduced most easily with long-running inference sweeps where many subprocesses go through normal init and exit. Detection frames are in `btree_destroy` (libgcc FDE unwind-table teardown) or `numa_bitmask_free` (libnuma atexit), neither of which is the actual culprit.

All application work succeeds; the abort is strictly in the atexit path after `main()` returns. Repro rate varies with workload and allocator but observed up to ~1 in 25 process invocations on a VoxConverse diarization sweep. Full trace and analysis: ROCm/AMDMIGraphX#4792.

### Root cause

`projects/clr/rocclr/platform/runtime.cpp`'s namespace-scope `RuntimeTearDown runtime_tear_down` is a global whose destructor runs via `__cxa_atexit` during `_dl_fini`. That destructor calls `Runtime::tearDown()`, which (on the ROC device path, `projects/clr/rocclr/device/rocm/rocdevice.cpp:640-643`) unconditionally calls `hsa_shut_down()`.

`hsa_shut_down` triggers `libhsa-runtime64`'s `Runtime::Unload`, which aggressively deletes agents, signals, drivers, and loader state. However, several true-static globals in `libhsa-runtime64` outlive that tear-down and hold pointers into the memory it just freed:

- `Signal::ipcLock_` / `Signal::ipcMap_` (`core/runtime/signal.cpp:58-59`), a file-scope `std::unordered_map` whose own destructor runs during libhsa-runtime64's `_dl_fini`. Entries point at `SharedSignal` blocks freed by `SharedSignalPool.clear()` during `Unload`.
- Loader's `Executable::executables` vector (`core/inc/amd_hsa_loader.hpp:425-426`). The loader explicitly leaves these undestroyed (`loader/executable.cpp:174-181`), retaining pointers to `Agent` objects freed by `Runtime::DestroyAgents`.

When these statics' destructors (or any other post-shut_down code path: tool dtors, rocprofiler callbacks, transitive destructors in rocclr's own remaining globals) touch the dangling state, they either dereference freed memory or free already-freed chunks. The resulting heap corruption lands on an adjacent free-bin chunk's `fd`/`bk` pointers and is detected later when `malloc_consolidate` tries to unlink the corrupt chunk.

Why sanitizers miss it:
- **ASan** uses its own allocator with red zones; the layout change removes the specific adjacency that triggers the bug.
- **UBSan** instruments arithmetic, but this is a destructor doing a legal hashmap or vector operation on already-freed memory.
- **MALLOC_CHECK_ / MALLOC_PERTURB_** similarly alter heap layout enough to mask it.

### Fix

There is an existing `amd::Runtime::LibraryDetached` flag (`projects/clr/rocclr/platform/runtime.hpp:36`, setter at `:58`, definition at `projects/clr/rocclr/platform/runtime.cpp:49`) that is perfectly suited for this case but is not used in the ROC device path. This PR wires it up:

1. `RuntimeTearDown::~RuntimeTearDown()` calls `Runtime::setLibraryDetached()` before `Runtime::tearDown()`, marking the runtime as being torn down from the C++ atexit chain.
2. `Device::tearDown()` on the ROC path checks `Runtime::isLibraryDetached()` and skips `hsa_shut_down` in that case, leaving HSA teardown to libhsa-runtime64's own `_dl_fini` sequence (which handles its own statics correctly when not forcibly shut down mid-process-exit).

Explicit `hsa_init`/`hsa_shut_down` pairs from application code still run normally.

### Validation

Reproducer: a 216-file VoxConverse DEV sweep of speakrs + ONNX Runtime + MIGraphX EP on an RX 9070 (gfx1201, RDNA 4, ROCm 6.4.2, Fedora 43, glibc 2.42).

| Configuration | SIGABRTs | Rate |
|---|---|---|
| Stock ROCm 6.4.2 (initial report) | 1/232 | 0.43% |
| UBSan MIGraphX build | 6/216 | 2.78% |
| MIGraphX-side mitigations (leak-on-exit singletons, RTLD_NODELETE) | 2/90 | 2.22% |
| **This PR (ROCm/clr fix)** | **0/216** | **0.00%** |

Under the null hypothesis that the rate is unchanged from the UBSan baseline (1/36), the probability of 0 crashes in 216 files is `e^(-6) ≈ 0.25%`. We reject the null.

No DER or throughput regression: strict DER 6.84% (identical to pre-fix), 17.71x realtime.

### Environment

- AMD Radeon RX 9070 (RDNA 4, gfx1201)
- Fedora 43, kernel 6.19.11
- ROCm 6.4.2 (Fedora packages)
- glibc 2.42, libgcc 15.2.1
- ONNX Runtime 1.24.2 with MIGraphX EP
- MIGraphX rocm-6.4.x

### Related

- ROCm/AMDMIGraphX#4792, original report with full diagnostic timeline
- ROCm/ROCR-Runtime, the true-static state in `libhsa-runtime64` is independently worth surfacing; this fix avoids triggering it rather than removing it, but a longer-term fix on the HSA side (eager clear of `ipcMap_` in `Runtime::Unload`, explicit cleanup of loader `executables`) would be more robust. Happy to file that separately.

### Testing notes for reviewers

The change is a strict superset of existing behavior: if neither the `LibraryDetached` setter nor the `isLibraryDetached` check were called, the code would behave identically to before. Explicit application `hsa_shut_down` calls are unaffected. The only behavioral change is that at process exit via `_dl_fini`, `hsa_shut_down` is no longer called from this path, which is the intended fix, since calling it from there is what causes the UAF.

No ABI change. No public API change. No performance impact.
