### PR TITLE
[rocSHMEM] remove static amdsmi-loader instance

### DIFF
--- a/projects/rocshmem/src/memfabric/amdsmi_loader.cpp
+++ b/projects/rocshmem/src/memfabric/amdsmi_loader.cpp
@@ -30,8 +30,6 @@
 
 namespace rocshmem {
 
-AmdsmiLoader amdsmi;
-
 AmdsmiLoader::AmdsmiLoader()
     : amdsmi_handle(nullptr),
       init(nullptr),
@@ -59,10 +57,10 @@ AmdsmiLoader::~AmdsmiLoader() {
 }
 
 int AmdsmiLoader::init_function_table() {
-  DLSYM_HELPER(amdsmi, amdsmi_, amdsmi_handle, init);
-  DLSYM_HELPER(amdsmi, amdsmi_, amdsmi_handle, shut_down);
-  DLSYM_HELPER(amdsmi, amdsmi_, amdsmi_handle, get_processor_handle_from_bdf);
-  DLSYM_HELPER(amdsmi, amdsmi_, amdsmi_handle, get_gpu_fabric_info);
+  DLSYM_HELPER((*this), amdsmi_, amdsmi_handle, init);
+  DLSYM_HELPER((*this), amdsmi_, amdsmi_handle, shut_down);
+  DLSYM_HELPER((*this), amdsmi_, amdsmi_handle, get_processor_handle_from_bdf);
+  DLSYM_HELPER((*this), amdsmi_, amdsmi_handle, get_gpu_fabric_info);
   return ROCSHMEM_SUCCESS;
 }
 


### PR DESCRIPTION
## Motivation

the constructor in a static amdsmi-loader instance tried to open the amdsmi lib and dlsym the functions used even if we do not compile with pod-detection. The static instance however not actually required.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
