### PR TITLE
[RDC][AMD-SMI][ROCM-SMI] Drop POST_BUILD strip on shared libs

### DIFF
--- a/projects/amdsmi/goamdsmi_shim/CMakeLists.txt
+++ b/projects/amdsmi/goamdsmi_shim/CMakeLists.txt
@@ -97,11 +97,6 @@ target_link_libraries(${GOAMDSMI_SHIM_TARGET} -L${AMDSMI_DIR}/lib64)
 set_property(TARGET ${GOAMDSMI_SHIM_TARGET} PROPERTY SOVERSION "${VERSION_MAJOR}")
 set_property(TARGET ${GOAMDSMI_SHIM_TARGET} PROPERTY VERSION "${SO_VERSION_STRING}")
 
-## If the library is a release, strip the target library
-if("${CMAKE_BUILD_TYPE}" STREQUAL Release)
-    add_custom_command(TARGET ${GOAMDSMI_SHIM_TARGET} POST_BUILD COMMAND ${CMAKE_STRIP} lib${GOAMDSMI_SHIM_TARGET}.so)
-endif()
-
 set(go_amd_smi_install_headers smiwrapper/goamdsmi.h smiwrapper/amdsmi_go_shim.h)
 
 ## Add the install directives for the runtime library.

--- a/projects/amdsmi/rocm_smi/CMakeLists.txt
+++ b/projects/amdsmi/rocm_smi/CMakeLists.txt
@@ -66,14 +66,3 @@ target_include_directories(
 ## Set the VERSION and SOVERSION values
 set_property(TARGET ${ROCM_SMI_TARGET} PROPERTY SOVERSION "${VERSION_MAJOR}")
 set_property(TARGET ${ROCM_SMI_TARGET} PROPERTY VERSION "${SO_VERSION_STRING}")
-
-## If the library is a release, strip the target library
-if("${CMAKE_BUILD_TYPE}" STREQUAL Release)
-    if(${BUILD_SHARED_LIBS}) #stripping only for .so
-        add_custom_command(
-            TARGET ${ROCM_SMI_TARGET}
-            POST_BUILD
-            COMMAND ${CMAKE_STRIP} lib${ROCM_SMI_TARGET}.so.${SO_VERSION_STRING}
-        )
-    endif()
-endif()

--- a/projects/amdsmi/src/CMakeLists.txt
+++ b/projects/amdsmi/src/CMakeLists.txt
@@ -184,19 +184,6 @@ endif()
 set_property(TARGET ${AMD_SMI} PROPERTY SOVERSION "${MAJOR}")
 set_property(TARGET ${AMD_SMI} PROPERTY VERSION "${SO_VERSION_STRING}")
 
-## If the library is a release, strip the target library
-if("${CMAKE_BUILD_TYPE}" STREQUAL Release)
-    if(BUILD_BOTH_LIBS OR BUILD_SHARED_LIBS)
-        if(TARGET ${AMD_SMI})
-            add_custom_command(
-                TARGET ${AMD_SMI}
-                POST_BUILD
-                COMMAND ${CMAKE_STRIP} lib${AMD_SMI}.so.${SO_VERSION_STRING}
-            )
-        endif()
-    endif()
-endif()
-
 ## Add the install directives for the runtime library.
 set(_INSTALL_TARGETS ${AMD_SMI} amdsminic)
 if(BUILD_BOTH_LIBS)

--- a/projects/rdc/rdc_libs/bootstrap/CMakeLists.txt
+++ b/projects/rdc/rdc_libs/bootstrap/CMakeLists.txt
@@ -52,12 +52,3 @@ set_target_properties(
     ${BOOTSTRAP_LIB}
     PROPERTIES INSTALL_RPATH "\$ORIGIN:\$ORIGIN/rdc" THEROCK_NO_INSTALL_RPATH TRUE
 )
-
-# If the library is a release, strip the target library
-if("${CMAKE_BUILD_TYPE}" STREQUAL Release)
-    add_custom_command(
-        TARGET ${BOOTSTRAP_LIB}
-        POST_BUILD
-        COMMAND ${CMAKE_STRIP} ${BOOTSTRAP_LIB_COMPONENT}.so
-    )
-endif()

--- a/projects/rdc/rdc_libs/rdc/CMakeLists.txt
+++ b/projects/rdc/rdc_libs/rdc/CMakeLists.txt
@@ -82,10 +82,5 @@ set_property(TARGET ${RDC_LIB} PROPERTY SOVERSION "${VERSION_MAJOR}")
 set_property(TARGET ${RDC_LIB} PROPERTY VERSION "${SO_VERSION_STRING}")
 set_target_properties(${RDC_LIB} PROPERTIES INSTALL_RPATH "\$ORIGIN")
 
-# If the library is a release, strip the target library
-if("${CMAKE_BUILD_TYPE}" STREQUAL Release)
-    add_custom_command(TARGET ${RDC_LIB} POST_BUILD COMMAND ${CMAKE_STRIP} ${RDC_LIB_COMPONENT}.so)
-endif()
-
 # pass ROCM_DIR to compiler
 target_compile_definitions(${RDC_LIB} PRIVATE ROCM_DIR="${ROCM_DIR}")

--- a/projects/rdc/rdc_libs/rdc_client/CMakeLists.txt
+++ b/projects/rdc/rdc_libs/rdc_client/CMakeLists.txt
@@ -41,11 +41,3 @@ target_include_directories(
 # Set the VERSION and SOVERSION values
 set_property(TARGET ${RDCCLIENT_LIB} PROPERTY SOVERSION "${VERSION_MAJOR}")
 set_property(TARGET ${RDCCLIENT_LIB} PROPERTY VERSION "${SO_VERSION_STRING}")
-
-if("${CMAKE_BUILD_TYPE}" STREQUAL Release)
-    add_custom_command(
-        TARGET ${RDCCLIENT_LIB}
-        POST_BUILD
-        COMMAND ${CMAKE_STRIP} ${RDCCLIENT_LIB_COMPONENT}.so
-    )
-endif()

--- a/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/CMakeLists.txt
+++ b/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/CMakeLists.txt
@@ -59,13 +59,4 @@ if(BUILD_PROFILER)
     # Set the VERSION and SOVERSION values
     set_property(TARGET ${RDC_ROCP_LIB} PROPERTY SOVERSION "${VERSION_MAJOR}")
     set_property(TARGET ${RDC_ROCP_LIB} PROPERTY VERSION "${SO_VERSION_STRING}")
-
-    # If the library is a release, strip the target library
-    if("${CMAKE_BUILD_TYPE}" STREQUAL Release)
-        add_custom_command(
-            TARGET ${RDC_ROCP_LIB}
-            POST_BUILD
-            COMMAND ${CMAKE_STRIP} ${RDC_ROCP_LIB_COMPONENT}.so
-        )
-    endif()
 endif()

--- a/projects/rdc/rdc_libs/rdc_modules/rdc_rocr/CMakeLists.txt
+++ b/projects/rdc/rdc_libs/rdc_modules/rdc_rocr/CMakeLists.txt
@@ -68,13 +68,4 @@ if(BUILD_RUNTIME)
     # Set the VERSION and SOVERSION values
     set_property(TARGET ${RDC_ROCR_LIB} PROPERTY SOVERSION "${VERSION_MAJOR}")
     set_property(TARGET ${RDC_ROCR_LIB} PROPERTY VERSION "${SO_VERSION_STRING}")
-
-    # If the library is a release, strip the target library
-    if("${CMAKE_BUILD_TYPE}" STREQUAL Release)
-        add_custom_command(
-            TARGET ${RDC_ROCR_LIB}
-            POST_BUILD
-            COMMAND ${CMAKE_STRIP} ${RDC_ROCR_LIB_COMPONENT}.so
-        )
-    endif()
 endif()

--- a/projects/rdc/rdc_libs/rdc_modules/rdc_rvs/CMakeLists.txt
+++ b/projects/rdc/rdc_libs/rdc_modules/rdc_rvs/CMakeLists.txt
@@ -62,15 +62,6 @@ if(BUILD_RVS)
     set_property(TARGET ${RDC_RVS_LIB} PROPERTY SOVERSION "${VERSION_MAJOR}")
     set_property(TARGET ${RDC_RVS_LIB} PROPERTY VERSION "${SO_VERSION_STRING}")
 
-    # If the library is a release, strip the target library
-    if("${CMAKE_BUILD_TYPE}" STREQUAL Release)
-        add_custom_command(
-            TARGET ${RDC_RVS_LIB}
-            POST_BUILD
-            COMMAND ${CMAKE_STRIP} ${RDC_RVS_LIB_COMPONENT}.so
-        )
-    endif()
-
     # Install RVS config files into /opt/rocm/share/rdc/conf/rvs/
     install(
         DIRECTORY "${SRC_DIR}/conf/"

--- a/projects/rocm-smi-lib/oam/CMakeLists.txt
+++ b/projects/rocm-smi-lib/oam/CMakeLists.txt
@@ -85,17 +85,6 @@ target_include_directories(
 set_property(TARGET ${OAM_TARGET} PROPERTY SOVERSION "${VERSION_MAJOR}")
 set_property(TARGET ${OAM_TARGET} PROPERTY VERSION "${SO_VERSION_STRING}")
 
-## If the library is a release, strip the target library
-if("${CMAKE_BUILD_TYPE}" STREQUAL Release)
-    if(${BUILD_SHARED_LIBS}) #striping only for .so
-        add_custom_command(
-            TARGET ${OAM_TARGET}
-            POST_BUILD
-            COMMAND ${CMAKE_STRIP} lib${OAM_TARGET}.so
-        )
-    endif()
-endif()
-
 target_include_directories(
     ${OAM_TARGET}
     PUBLIC

--- a/projects/rocm-smi-lib/rocm_smi/CMakeLists.txt
+++ b/projects/rocm-smi-lib/rocm_smi/CMakeLists.txt
@@ -103,17 +103,6 @@ target_include_directories(
 set_property(TARGET ${ROCM_SMI_TARGET} PROPERTY SOVERSION "${VERSION_MAJOR}")
 set_property(TARGET ${ROCM_SMI_TARGET} PROPERTY VERSION "${SO_VERSION_STRING}")
 
-## If the library is a release, strip the target library
-if("${CMAKE_BUILD_TYPE}" STREQUAL Release)
-    if(${BUILD_SHARED_LIBS}) #stripping only for .so
-        add_custom_command(
-            TARGET ${ROCM_SMI_TARGET}
-            POST_BUILD
-            COMMAND ${CMAKE_STRIP} lib${ROCM_SMI_TARGET}.so.${SO_VERSION_STRING}
-        )
-    endif()
-endif()
-
 #file reorganization changes
 #rocm_smi.py moved to libexec/rocm_smi. so creating rocm-smi symlink
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)


### PR DESCRIPTION
Defer stripping to packagers and TheRock's THEROCK_SPLIT_DEBUG_INFO. Fixes
SONAME-symlink corruption under llvm-strip (https://github.com/ROCm/TheRock/issues/4640)
