### PR TITLE
[rocprof-systems]: Fix KFD test logic for SDK version check

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -530,6 +530,28 @@ def pytest_collection_modifyitems(config, items) -> None:
             item.add_marker(skip_julia)
         if "xnack" in item.keywords and not xnack_available:
             item.add_marker(skip_xnack)
+        if "kfd" in item.keywords:
+            min_kfd_sdk = (1, 2, 2)
+            sdk_ver = rocprof_config.rocprofiler_sdk_version
+            if sdk_ver is None:
+                item.add_marker(
+                    pytest.mark.skip(
+                        reason=(
+                            "KFD tests require rocprofiler-sdk >= 1.2.2; version not detected "
+                            "(ensure librocprofiler-sdk is discoverable via ctypes.util.find_library, "
+                            "e.g. LD_LIBRARY_PATH or ROCm library layout)"
+                        )
+                    )
+                )
+            elif sdk_ver < min_kfd_sdk:
+                item.add_marker(
+                    pytest.mark.skip(
+                        reason=(
+                            f"KFD tests require rocprofiler-sdk >= 1.2.2 "
+                            f"(found {'.'.join(map(str, sdk_ver))}; undefined KFD node ID bug)"
+                        )
+                    )
+                )
         if "rocm_min_version" in item.keywords:
             req_version = item.get_closest_marker("rocm_min_version").args[0]
             system_version = rocprof_config.rocm_version
@@ -780,6 +802,12 @@ def _generate_rocprofsys_config_header(config: pytest.Config) -> list[str]:
 
     gpu_info = get_gpu_info()
 
+    sdk_version = (
+        ".".join(map(str, rocprof_config.rocprofiler_sdk_version))
+        if rocprof_config.rocprofiler_sdk_version
+        else "Not found"
+    )
+
     if rocprof_config.rocm_path:
         # Rocm version
         rocm_version = (
@@ -824,6 +852,7 @@ def _generate_rocprofsys_config_header(config: pytest.Config) -> list[str]:
         "Test Configuration:",
         "=" * 70,
         f"  ROCm version:         {rocm_version}",
+        f"  rocprofiler-sdk:      {sdk_version}",
         f"  ROCm path:            {rocprof_config.rocm_path}",
         f"  Is installed:         {rocprof_config.is_installed}",
         f"  Output dir:           {rocprof_config.test_output_dir}",

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/__init__.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/__init__.py
@@ -15,6 +15,7 @@ from .config import (
     RocprofsysConfig,
     discover_install_config,
     discover_build_config,
+    get_rocprofiler_sdk_version,
 )
 
 from .runners import (
@@ -53,6 +54,7 @@ __all__ = [
     "RocprofsysConfig",
     "discover_build_config",
     "discover_install_config",
+    "get_rocprofiler_sdk_version",
     # Runners
     "TestResult",
     "BaselineRunner",
@@ -78,4 +80,5 @@ __all__ = [
     "lookup_gpu_category",
     "get_target_gpu_arch",
     "get_offload_extractor",
+    "get_xnack_support",
 ]

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/config.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/config.py
@@ -40,6 +40,7 @@ class RocprofsysConfig:
         - mpiexec: Path to MPI launcher executable
         - julia: Path to Julia executable
         - rocm_version: Tuple of (major, minor, patch) of the installed ROCm version
+        - rocprofiler_sdk_version: Parsed rocprofiler-sdk version (else None)
         - is_installed: Whether this is an installed configuration
         - python_versions: List of python versions available
         - python_executables: List of python executables available
@@ -64,6 +65,7 @@ class RocprofsysConfig:
     julia: Optional[Path] = None
     is_installed: bool = False
     rocm_version: Optional[tuple[int, int, int]] = None
+    rocprofiler_sdk_version: Optional[tuple[int, int, int]] = None
     python_versions: Optional[list[str]] = None
     python_executables: Optional[list[str]] = None
     python_module_path: Optional[Path] = None
@@ -359,6 +361,49 @@ def _get_rocm_version() -> Optional[tuple[int, int, int]]:
     return None
 
 
+def get_rocprofiler_sdk_version() -> Optional[tuple[int, int, int]]:
+    """Installed rocprofiler-sdk version via ``rocprofiler_get_version()`` (ctypes + find_library).
+    Returns ``None`` when ``find_library`` cannot locate the SDK, ``CDLL`` fails, or the call does
+    not succeed (pytest gates skip instead of failing collection).
+    """
+    import ctypes
+    from ctypes.util import find_library
+
+    lib_path = find_library("rocprofiler-sdk")
+    if not lib_path:
+        return None
+
+    try:
+        lib = ctypes.CDLL(lib_path)
+    except OSError:
+        return None
+
+    lib.rocprofiler_get_version.argtypes = [
+        ctypes.POINTER(ctypes.c_uint32),
+        ctypes.POINTER(ctypes.c_uint32),
+        ctypes.POINTER(ctypes.c_uint32),
+    ]
+    lib.rocprofiler_get_version.restype = ctypes.c_int
+
+    major = ctypes.c_uint32()
+    minor = ctypes.c_uint32()
+    patch = ctypes.c_uint32()
+
+    try:
+        result = lib.rocprofiler_get_version(
+            ctypes.byref(major),
+            ctypes.byref(minor),
+            ctypes.byref(patch),
+        )
+    except OSError:
+        return None
+
+    if result != 0:
+        return None
+
+    return (int(major.value), int(minor.value), int(patch.value))
+
+
 def _find_mpiexec() -> Optional[Path]:
     """Find MPI launcher executable."""
     for candidate in ["mpiexec", "mpirun"]:
@@ -617,6 +662,7 @@ def discover_install_config(
         mpiexec=mpiexec,
         julia=_find_julia(),
         rocm_version=_get_rocm_version(),
+        rocprofiler_sdk_version=get_rocprofiler_sdk_version(),
         is_installed=True,
         python_versions=found_python_versions,
         python_executables=found_python_executables,
@@ -712,6 +758,7 @@ def discover_build_config(
         mpiexec=mpiexec,
         julia=_find_julia(),
         rocm_version=_get_rocm_version(),
+        rocprofiler_sdk_version=get_rocprofiler_sdk_version(),
         is_installed=False,
         python_versions=found_python_versions,
         python_executables=found_python_executables,

--- a/projects/rocprofiler-systems/tests/pytest/test_hpc.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_hpc.py
@@ -47,15 +47,6 @@ def hpc_hip_environment() -> dict[str, str]:
 
 
 @pytest.fixture
-def kfd_rules(validation_rules_dir) -> list[Path]:
-    """Get validation rules for KFD event tests."""
-    rules_dir = validation_rules_dir / "kfd"
-    return [
-        rules_dir / "kfd-rules.json",
-    ]
-
-
-@pytest.fixture
 def matrix_exponential_rules(validation_rules_dir) -> list[Path]:
     """Get validation rules for matrix exponential tests."""
     rules_dir = validation_rules_dir / "hpc" / "matrix-exponential"
@@ -88,9 +79,9 @@ class TestJacobi(RocprofsysTest):
     @pytest.mark.xnack
     @pytest.mark.rocpd("hpc_openmp_environment")
     @pytest.mark.parametrize("mode", ["sys_run"])
-    def test_usm(self, mode, hpc_openmp_environment, gpu_info, kfd_rules):
+    def test_usm(self, mode, hpc_openmp_environment, gpu_info):
         env = hpc_openmp_environment.copy()
-        env["ROCPROFSYS_ROCM_DOMAINS"] = "hip_api,kernel_dispatch,memory_copy,kfd_events"
+        env["ROCPROFSYS_ROCM_DOMAINS"] = "hip_api,kernel_dispatch,memory_copy"
         env["ROCPROFSYS_TRACE_LEGACY"] = "ON"
         env["HSA_XNACK"] = "1"
         env["ROCPROFSYS_USE_AMD_SMI"] = "OFF"
@@ -139,22 +130,6 @@ class TestJacobi(RocprofsysTest):
                 counts=[1],
                 depths=[1],
             )
-
-        # Validate KFD events in perfetto trace
-        self.assert_perfetto(
-            result,
-            subtest_name="Perfetto KFD event validation",
-            categories=["rocm_kfd_page_fault", "rocm_kfd_page_migrate", "rocm_kfd_queue"],
-            label_substrings=["PAGE_FAULT", "PAGE_MIGRATE", "QUEUE_EVICT"],
-            print_output=True,
-        )
-
-        # Validate KFD events in rocpd database
-        self.assert_rocpd(
-            result,
-            subtest_name="ROCpd KFD event validation",
-            rules_files=kfd_rules,
-        )
 
     @pytest.mark.openmp
     @pytest.mark.roctx

--- a/projects/rocprofiler-systems/tests/rocprof-sys-kfd-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-kfd-tests.cmake
@@ -28,8 +28,9 @@ if(NOT _XNACK_SUPPORTED)
     return()
 endif()
 
-# ROCprofiker-SDK version < 1.2.1 does not handle KFD_IOCTL_SVM_LOCATION_UNDEFINED
+# ROCprofiker-SDK version <= 1.2.1 does not handle KFD_IOCTL_SVM_LOCATION_UNDEFINED
 # node IDs (0xFFFFFFFF), causing a fatal crash in the SDK's KFD parsing thread.
+# Require rocprofiler-sdk >= 1.2.2 where this is fixed with PR https://github.com/ROCm/rocm-systems/pull/340
 if(rocprofiler-sdk_VERSION VERSION_LESS "1.2.2")
     rocprofiler_systems_message(
         WARNING


### PR DESCRIPTION
## Motivation

ROCProfiler-SDK before 1.2.2 can crash when parsing KFD traffic that uses undefined node IDs (KFD_IOCTL_SVM_LOCATION_UNDEFINED). Align CTest and pytest so KFD-focused tests run only where the fixed SDK is present.

Fixed in https://github.com/ROCm/rocm-systems/pull/340

## Technical Details

- `rocprof-sys-kfd-tests.cmake`: Comments updated; gate unchanged (rocprofiler-sdk_VERSION VERSION_LESS "1.2.2" → skips KFD unified-memory tests when SDK < 1.2.2).
- `tests/pytest/rocprofsys/config.py`: RocprofsysConfig gains rocprofiler_sdk_version; get_rocprofiler_sdk_version() loads librocprofiler-sdk via ctypes.util.find_library and calls rocprofiler_get_version → (major, minor, patch) or None on failure (no raise, so pytest collection survives).
- `tests/pytest/conftest.py`: Items with kfd marker skip if version is None or &lt; (1, 2, 2); --show-config prints detected rocprofiler-sdk version.
- `tests/pytest/test_hpc.py`: test_usm drops kfd_events from domains and removes Perfetto/ROCpd KFD assertions (and the kfd_rules fixture).
- `tests/pytest/rocprofsys/__init__.py`: Exports get_rocprofiler_sdk_version; restores get_xnack_support in __all__.

## JIRA ID

AIPROFSYST-419

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
