### PR TITLE
rocr: Fix trap handler regression for gfx120x

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler_gfx12.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler_gfx12.s
@@ -439,7 +439,7 @@
     // Save SCHED_MODE from ttmp1[27:26] into ttmp11[27:26]. We will restore it on exit
     s_andn2_b32         ttmp11, ttmp11, TTMP11_SCHED_MODE_MASK
     s_and_b32           ttmp2,  ttmp1, TTMP1_SCHED_MODE_MASK
-    s_or_b32            ttmp11, ttmp2, TTMP1_SCHED_MODE_MASK
+    s_or_b32            ttmp11, ttmp11, ttmp2
   .endif
   s_mov_b32           ttmp3, 0
 


### PR DESCRIPTION
Recent drop of code for gfx1250 accidentally reverted the following existing fix for gfx120x:

    commit 6c02efa1166665ac94b48268aa5375ed69c99a51
    Author: Lancelot SIX <lancelot.six@amd.com>
    Date:   Thu Feb 12 22:23:33 2026 +0000

        rocr: Fix restoring SCHED_MODE in gfx12 trap handler

        The code to restore SCHED_MODE on exit has an issue and incorrectly
        restores advanced scheduling mode unconditionally.  Fix this and restore
        the expected value.

Reverting this effectively re-introduced the issue.  Re-apply the same fix on top of gfx1250 to restore gfx120x support.