### PR TITLE
clr: redefine DEBUG_HIP_DYNAMIC_QUEUES modes for full HW queue utilization

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -1757,7 +1757,8 @@ device::VirtualDevice* Device::createVirtualDevice(amd::CommandQueue* queue) {
 
   bool profiling = (queue != nullptr) && queue->properties().test(CL_QUEUE_PROFILING_ENABLE);
   bool cooperative = false;
-  bool dedicated_queue = (queue != nullptr) && queue->isDedicatedQueue();
+  bool dedicated_queue = (queue != nullptr) && queue->isDedicatedQueue() &&
+                         (settings().dynamic_queues_ >= 2);
 
   // If amd command queue is null, then it's an internal device queue
   if (queue == nullptr) {

--- a/projects/clr/rocclr/device/rocm/rocsettings.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.cpp
@@ -142,7 +142,7 @@ bool Settings::create(bool fullProfile, const amd::Isa& isa, bool enableXNACK, b
         (gfxStepping == 0 || gfxStepping == 1 || gfxStepping == 2)))) {
     // Enable Barrier Value packet is only for MI2XX/300
     barrier_value_packet_ = true;
-    queue_pipe_dist_ = DEBUG_HIP_DYNAMIC_QUEUES == 2 ? true : false;
+    queue_pipe_dist_ = dynamic_queues_ >= 1;
   }
 
   if (gfxipMajor == 9 && gfxipMinor >= 4) {

--- a/projects/clr/rocclr/device/rocm/rocsettings.hpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.hpp
@@ -34,10 +34,10 @@ class Settings : public device::Settings {
       uint system_scope_signal_ : 1;   //!< HSA signal is visibile to the entire system
       uint fgs_kernel_arg_ : 1;        //!< Use fine grain kernel arg segment
       uint barrier_value_packet_ : 1;  //!< Barrier value packet functionality
-      uint dynamic_queues_ : 2;        //!< Dynamic queues: 0=off, 1=Depth
+      uint dynamic_queues_ : 2;        //!< Dynamic queues: 0=off, 1=Depth, 2=1+dedicated null
       uint blocking_blit_ : 1;         //!< Blit ops can be blocking on CPU
-      uint queue_pipe_dist_ : 1;       //!< MI300 queue pipe distribution (gfx94x)
-      uint ext_dispatch_packet_ : 1;    //!< Uses new ext dispatch packet for all launches
+      uint queue_pipe_dist_ : 1;       //!< gfx94x queue pipe distribution
+      uint ext_dispatch_packet_ : 1;   //!< Uses new ext dispatch packet for all launches
       uint reserved_ : 18;
     };
     uint value_;

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -253,9 +253,9 @@ release(bool, DEBUG_CLR_SYSMEM_POOL, false,                                   \
         "Use sysmem pool implementation in runtime for amd commands")         \
 release(bool, DEBUG_CLR_KERNARG_HDP_FLUSH_WA, false,                          \
         "Toggle kernel arg copy workaround")                                  \
-release(uint, DEBUG_HIP_DYNAMIC_QUEUES, 2,                                    \
-        "Dynamic queue management: 0=off, 1=Queue depth heuristic,"           \
-        "2= Queue Depth + Pipe distribution")                                 \
+release(uint, DEBUG_HIP_DYNAMIC_QUEUES, 1,                                    \
+        "Dynamic queue management: 0=off, 1=Depth heuristic,"                 \
+        " 2=1 + dedicated null-stream queue")                                 \
 release(bool, DEBUG_HIP_IGNORE_STREAM_PRIORITY, false,                        \
         "Ignore priority streams")                                            \
 release(uint, HIP_SKIP_ABORT_ON_GPU_ERROR, true,                              \


### PR DESCRIPTION
Mode 1 now enables depth heuristic without reserving a dedicated HW queue for the null stream, so all GPU_MAX_HW_QUEUES are available to every stream equally. Mode 2 retains the previous default behavior (mode 1 + a dedicated null-stream queue with a 2048 load penalty).

- 0 = off
- 1 = depth heuristic, no dedicated null-stream queue(DEFAULT)
- 2 = 1 + dedicated null-stream queue (previous mode 2 behavior)

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
