### PR TITLE
enable in mem / async logging by default. 

### DIFF
--- a/projects/clr/rocclr/utils/debug.cpp
+++ b/projects/clr/rocclr/utils/debug.cpp
@@ -74,7 +74,9 @@ struct LogEntry {
 class AsyncLogger {
  public:
   AsyncLogger() : buffer_(kBufferSize) {
-    if (AMD_LOG_ASYNC) {
+    bool useAsync = !flagIsDefault(AMD_LOG_ASYNC) ? AMD_LOG_ASYNC
+                                                  : !flagIsDefault(AMD_LOG_LEVEL_FILE);
+    if (useAsync) {
       enable(true);
     }
   }

--- a/projects/clr/rocclr/utils/debug.cpp
+++ b/projects/clr/rocclr/utils/debug.cpp
@@ -74,7 +74,7 @@ struct LogEntry {
 class AsyncLogger {
  public:
   AsyncLogger() : buffer_(kBufferSize) {
-    if (!flagIsDefault(AMD_LOG_ASYNC) && AMD_LOG_ASYNC) {
+    if (flagIsDefault(AMD_LOG_ASYNC) || AMD_LOG_ASYNC) {
       enable(true);
     }
   }

--- a/projects/clr/rocclr/utils/debug.cpp
+++ b/projects/clr/rocclr/utils/debug.cpp
@@ -74,7 +74,7 @@ struct LogEntry {
 class AsyncLogger {
  public:
   AsyncLogger() : buffer_(kBufferSize) {
-    if (flagIsDefault(AMD_LOG_ASYNC) || AMD_LOG_ASYNC) {
+    if (AMD_LOG_ASYNC) {
       enable(true);
     }
   }

--- a/projects/clr/rocclr/utils/flags.cpp
+++ b/projects/clr/rocclr/utils/flags.cpp
@@ -145,7 +145,7 @@ bool Flag::init() {
       }
     }
     // Enable async logging if configured
-    if (!flagIsDefault(AMD_LOG_ASYNC) && AMD_LOG_ASYNC) {
+    if (flagIsDefault(AMD_LOG_ASYNC) || AMD_LOG_ASYNC) {
       EnableAsyncLogging(true);
     }
   }

--- a/projects/clr/rocclr/utils/flags.cpp
+++ b/projects/clr/rocclr/utils/flags.cpp
@@ -144,8 +144,11 @@ bool Flag::init() {
         outFile = fopen(("clr_logs_" + pid + ".txt").c_str(), "a");
       }
     }
-    // Enable async logging if configured
-    if (AMD_LOG_ASYNC) {
+    // Enable async logging: honor explicit AMD_LOG_ASYNC, otherwise auto-enable
+    // only when logging to a file (AMD_LOG_LEVEL_FILE is set).
+    bool useAsync = !flagIsDefault(AMD_LOG_ASYNC) ? AMD_LOG_ASYNC
+                                                  : !flagIsDefault(AMD_LOG_LEVEL_FILE);
+    if (useAsync) {
       EnableAsyncLogging(true);
     }
   }

--- a/projects/clr/rocclr/utils/flags.cpp
+++ b/projects/clr/rocclr/utils/flags.cpp
@@ -145,7 +145,7 @@ bool Flag::init() {
       }
     }
     // Enable async logging if configured
-    if (flagIsDefault(AMD_LOG_ASYNC) || AMD_LOG_ASYNC) {
+    if (AMD_LOG_ASYNC) {
       EnableAsyncLogging(true);
     }
   }

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -18,8 +18,8 @@ release(cstring, AMD_LOG_LEVEL_FILE, "",                                      \
         "Set output file for AMD_LOG_LEVEL, Default is stderr")               \
 release(size_t, AMD_LOG_LEVEL_SIZE, 2048,                                     \
         "The max size of AMD_LOG generated in MB if printed to a file")       \
-release(bool, AMD_LOG_ASYNC, false,                                           \
-        "Enable async logging with in-memory buffer and background thread")   \
+release(bool, AMD_LOG_ASYNC, true,                                            \
+        "Async logging with in-memory buffer and background thread (set 0 to disable)")\
 debug(uint, DEBUG_GPU_FLAGS, 0,                                               \
         "The debug options for GPU device")                                   \
 release(size_t, CQ_THREAD_STACK_SIZE, 256*Ki, /* @todo: that much! */         \


### PR DESCRIPTION
## Motivation

Given async logging is working in local testing, enabled it by default

## Technical Details

Enabled now by default. Can be disabled by AMD_LOG_ASYNC=0

## JIRA ID

enabled implementation of AIRUNTIME-215 by default

## Test Plan

Tested it locally with mslatency test

## Test Result

Test run fine with it enabled by default

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
