### PR TITLE
[rocdecode, rocjpeg] added env var doc

### DIFF
--- a/projects/rocdecode/docs/index.rst
+++ b/projects/rocdecode/docs/index.rst
@@ -53,6 +53,7 @@ The rocDecode project is located in https://github.com/ROCm/rocm-systems/tree/de
       * :doc:`The rocDecode software decoder API <./reference/rocDecode-sw-decoder>`
       
     * :doc:`rocDecode logging levels <./reference/rocDecode-logging-control>`
+    * :doc:`rocDecode environment variables <./reference/rocDecode-env-vars>`
     * :doc:`rocDecode codec support and hardware capabilities <./reference/rocDecode-formats-and-architectures>`
     * :doc:`API library <../doxygen/html/files>`
     * :doc:`Functions <../doxygen/html/globals>`

--- a/projects/rocdecode/docs/reference/rocDecode-env-vars.rst
+++ b/projects/rocdecode/docs/reference/rocDecode-env-vars.rst
@@ -1,0 +1,29 @@
+.. meta::
+   :description: rocDecode environment variables
+   :keywords: rocDecode, environment variables, ROCm, AMD
+
+********************************************************************
+rocDecode environment variables
+********************************************************************
+
+The following environment variables affect the rocDecode runtime.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 72
+
+   * - Environment variable
+     - Values
+   * - ``ROCDEC_LOG_LEVEL``
+     - | Sets the maximum severity of log messages during decoding. The log level defines the maximum severity of log messages to output.
+       | ``0``: Output critical messages only (default) 
+       | ``1``: Output critical and error messages
+       | ``2``: Output critical, error and warning messages
+       | ``3``: Output critical, error, warning and info messages
+       | ``4``: Output critical, error, warning, info and debug messages 
+   * - ``ROCR_VISIBLE_DEVICES``
+     - | Takes a comma-separated list of GPU indices. 
+       | When set, the VAAPI decoder path parses this list before it falls back to ``HIP_VISIBLE_DEVICES``. 
+   * - ``HIP_VISIBLE_DEVICES``
+     - | Comma-separated list of GPU indices. Parsed when ``ROCR_VISIBLE_DEVICES`` isn't set.
+

--- a/projects/rocdecode/docs/sphinx/_toc.yml.in
+++ b/projects/rocdecode/docs/sphinx/_toc.yml.in
@@ -58,6 +58,8 @@ subtrees:
         title: Software decoder API
   - file: reference/rocDecode-logging-control.rst
     title: Logging levels 
+  - file: reference/rocDecode-env-vars.rst
+    title: Environment variables
   - file: reference/rocDecode-formats-and-architectures.rst
     title: rocDecode supported codecs and architectures
   - file: doxygen/html/files

--- a/projects/rocjpeg/docs/index.rst
+++ b/projects/rocjpeg/docs/index.rst
@@ -34,6 +34,7 @@ The rocJPEG project is located in https://github.com/ROCm/rocm-systems/tree/deve
 
   .. grid-item-card:: Reference
 
+    * :doc:`rocJPEG environment variables <./reference/rocJPEG-env-vars>`
     * :doc:`rocJPEG subsampling and hardware capabilities <./reference/rocjpeg-formats-and-architectures>`
     * :doc:`rocJPEG API library <../doxygen/html/files>`
     * :doc:`rocJPEG Functions <../doxygen/html/globals>`

--- a/projects/rocjpeg/docs/reference/rocJPEG-env-vars.rst
+++ b/projects/rocjpeg/docs/reference/rocJPEG-env-vars.rst
@@ -1,0 +1,25 @@
+.. meta::
+    :description: rocJPEG environment variables
+    :keywords: rocJPEG, environment variables, ROCm, AMD
+
+********************************************************************
+rocJPEG environment variables
+********************************************************************
+
+The following environment variables affect the rocJPEG runtime.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 72
+
+   * - Environment variable
+     - Values
+   * - ``ROCJPEG_ENABLE_VCN_HW_CSC``
+     -  | ``1``: Enables hardware color-space conversion when there are eight or more JPEG cores and RGB or RGB planar output is in use.
+        | Hardware color-space conversion is off by default regardless of the number of cores. 
+        | Not used for ``CSS_440`` (4:4:0) chroma subsampling even when enabled.
+   * - ``ROCR_VISIBLE_DEVICES``
+     - | Takes a comma-separated list of GPU indices. 
+       | When set, the VAAPI decoder path parses this list before it falls back to ``HIP_VISIBLE_DEVICES``. 
+   * - ``HIP_VISIBLE_DEVICES``
+     - | Comma-separated list of GPU indices. Parsed when ``ROCR_VISIBLE_DEVICES`` isn't set.

--- a/projects/rocjpeg/docs/sphinx/_toc.yml.in
+++ b/projects/rocjpeg/docs/sphinx/_toc.yml.in
@@ -34,6 +34,8 @@ subtrees:
     
 - caption: Reference
   entries:
+  - file: reference/rocJPEG-env-vars.rst
+    title: Environment variables
   - file: reference/rocjpeg-formats-and-architectures.rst
     title: Subsampling and hardware capabilities
   - file: doxygen/html/files


### PR DESCRIPTION
## Motivation
 rocdecode and rocjpeg both needed a list of env vars that affected their runtimes