### PR TITLE
[rocprof-compute] Move intermediate csv deprecation warning to 7.13 upcoming changes

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -48,7 +48,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Upcoming changes
 
-* `--path` and `--subpath` options will be removed as they are already deprecated
+* `--path` and `--subpath` options are deprecated and will be removed in a future release.
 * Intermediate CSV generation (`results_*.csv`) from rocpd databases during profiling is deprecated and will be removed in a future release. The analyze step will read `.db` files directly.
 * `--retain-rocpd-output` is deprecated and will be removed in a future release. `.db` files will be retained by default.
 

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -2,23 +2,6 @@
 
 Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/](https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/).
 
-## Unreleased
-
-### Added
-
-### Changed
-
-### Removed
-
-### Optimized
-
-### Resolved issues
-
-### Upcoming changes
-
-* Intermediate CSV generation (`results_*.csv`) from rocpd databases during profiling is deprecated and will be removed in a future release. The analyze step will read `.db` files directly.
-* `--retain-rocpd-output` is deprecated and will be removed in a future release. `.db` files will be retained by default.
-
 ## ROCm Compute Profiler 3.6.0 for ROCm 7.13.0
 
 ### Added
@@ -66,6 +49,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 ### Upcoming changes
 
 * `--path` and `--subpath` options will be removed as they are already deprecated
+* Intermediate CSV generation (`results_*.csv`) from rocpd databases during profiling is deprecated and will be removed in a future release. The analyze step will read `.db` files directly.
+* `--retain-rocpd-output` is deprecated and will be removed in a future release. `.db` files will be retained by default.
 
 ### Known issues
 


### PR DESCRIPTION
## Motivation

Move deprecation warning out of 'Unreleased' section and move to changes to ROCm 7.13 upcoming changes section instead

## Technical Details

No functional changes

## JIRA ID

N/A

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
