### PR TITLE
[CUID] Added hardware fingerprint fallback to search PCIE VSEC section

### DIFF
--- a/projects/cuid/lib/src/cuid_gpu.cc
+++ b/projects/cuid/lib/src/cuid_gpu.cc
@@ -267,7 +267,7 @@ CuidGpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
     fingerprint = 0;
     return AMDCUID_STATUS_UNSUPPORTED;
   }
-  return AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
 amdcuid_status_t CuidGpu::get_primary_cuid(amdcuid_primary_id &id) const {

--- a/projects/cuid/lib/src/cuid_gpu.cc
+++ b/projects/cuid/lib/src/cuid_gpu.cc
@@ -248,9 +248,9 @@ CuidGpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
       }
     }
 
-    uint8_t fingerprint_size = 8;
-    uint8_t *fingerprint_buffer = new uint8_t[fingerprint_size];
-    status = PciUtil::read_pci_config_space(m_info.bdf, fingerprint_buffer,
+    const uint8_t fingerprint_size = 8;
+    uint8_t fingerprint_bytes[fingerprint_size] = {0};
+    status = PciUtil::read_pci_config_space(m_info.bdf, fingerprint_bytes,
                                             fingerprint_size, offset);
     if (status != AMDCUID_STATUS_SUCCESS) {
       fingerprint = 0;
@@ -258,7 +258,7 @@ CuidGpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
     }
     // pcie config file is little endian, so need to convert to big endian
     uint64_t fingerprint_value = 0;
-    std::memcpy(&fingerprint_value, fingerprint_buffer,
+    std::memcpy(&fingerprint_value, fingerprint_bytes,
                 sizeof(fingerprint_value));
     fingerprint = PciUtil::le64_to_be64(fingerprint_value);
   } else {

--- a/projects/cuid/lib/src/cuid_gpu.cc
+++ b/projects/cuid/lib/src/cuid_gpu.cc
@@ -244,7 +244,7 @@ CuidGpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
       status = PciUtil::get_pci_vsec_cap_offset(m_info.bdf, offset);
       if (status != AMDCUID_STATUS_SUCCESS) {
         fingerprint = 0;
-        return status;
+        return AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND;
       }
     }
 
@@ -254,20 +254,20 @@ CuidGpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
                                             fingerprint_size, offset);
     if (status != AMDCUID_STATUS_SUCCESS) {
       fingerprint = 0;
-      delete[] fingerprint_buffer;
       return status;
     }
     // pcie config file is little endian, so need to convert to big endian
-    fingerprint = PciUtil::le64_to_be64(
-        *reinterpret_cast<uint64_t *>(fingerprint_buffer));
-    delete[] fingerprint_buffer;
+    uint64_t fingerprint_value = 0;
+    std::memcpy(&fingerprint_value, fingerprint_buffer,
+                sizeof(fingerprint_value));
+    fingerprint = PciUtil::le64_to_be64(fingerprint_value);
   } else {
     // partitioned device without unique_id file or pci config cannot get
     // fingerprint
     fingerprint = 0;
     return AMDCUID_STATUS_UNSUPPORTED;
   }
-  return AMDCUID_STATUS_SUCCESS;
+  return AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND;
 }
 
 amdcuid_status_t CuidGpu::get_primary_cuid(amdcuid_primary_id &id) const {

--- a/projects/cuid/lib/src/cuid_gpu.cc
+++ b/projects/cuid/lib/src/cuid_gpu.cc
@@ -234,12 +234,18 @@ CuidGpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
       return AMDCUID_STATUS_UNSUPPORTED;
     }
   } else if (m_info.header.fields.gpu.unit_id == 0) {
-    // attempt to get fingerprint through PCI Config Space if not a partition
+    // attempt to get fingerprint through PCI Config Space if not a VF
     uint16_t offset = 0;
     amdcuid_status_t status =
-        PciUtil::get_pci_cap_offset(m_info.bdf, 0x03, offset);
+        PciUtil::get_pci_dsn_cap_offset(m_info.bdf, offset);
     if (status != AMDCUID_STATUS_SUCCESS) {
-      return status;
+      // attempt to get fingerprint through VSEC fallback if DSN capability is
+      // not found
+      status = PciUtil::get_pci_vsec_cap_offset(m_info.bdf, offset);
+      if (status != AMDCUID_STATUS_SUCCESS) {
+        fingerprint = 0;
+        return status;
+      }
     }
 
     uint8_t fingerprint_size = 8;
@@ -256,7 +262,8 @@ CuidGpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
         *reinterpret_cast<uint64_t *>(fingerprint_buffer));
     delete[] fingerprint_buffer;
   } else {
-    // partitioned device without unique_id file cannot get fingerprint
+    // partitioned device without unique_id file or pci config cannot get
+    // fingerprint
     fingerprint = 0;
     return AMDCUID_STATUS_UNSUPPORTED;
   }

--- a/projects/cuid/lib/src/cuid_nic.cc
+++ b/projects/cuid/lib/src/cuid_nic.cc
@@ -52,10 +52,10 @@ amdcuid_status_t CuidNic::discover(std::vector<DevicePtr> &nics) {
       nics.emplace_back(std::make_shared<CuidNic>(info));
     }
   }
+  closedir(dir);
   if (nics.size() == 0)
     return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 
-  closedir(dir);
   return AMDCUID_STATUS_SUCCESS;
 }
 

--- a/projects/cuid/lib/src/cuid_nic.cc
+++ b/projects/cuid/lib/src/cuid_nic.cc
@@ -166,8 +166,10 @@ CuidNic::get_hardware_fingerprint(uint64_t &fingerprint) const {
     status = PciUtil::read_pci_config_space(m_info.bdf, fingerprint_bytes,
                                             fingerprint_size, offset);
     if (status == AMDCUID_STATUS_SUCCESS) {
-      fingerprint = PciUtil::le64_to_be64(
-          *reinterpret_cast<uint64_t *>(fingerprint_bytes));
+      uint64_t fingerprint_value = 0;
+      std::memcpy(&fingerprint_value, fingerprint_bytes,
+                  sizeof(fingerprint_bytes));
+      fingerprint = PciUtil::le64_to_be64(fingerprint_value);
       return AMDCUID_STATUS_SUCCESS;
     }
   }
@@ -185,7 +187,9 @@ CuidNic::get_hardware_fingerprint(uint64_t &fingerprint) const {
     sscanf(mac_address.c_str(), "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &mac_bytes[0],
            &mac_bytes[1], &mac_bytes[2], &mac_bytes[3], &mac_bytes[4],
            &mac_bytes[5]);
-    fingerprint = *reinterpret_cast<uint64_t *>(mac_bytes);
+    uint64_t mac_fingerprint = 0;
+    std::memcpy(&mac_fingerprint, mac_bytes, sizeof(mac_bytes));
+    fingerprint = mac_fingerprint;
     return AMDCUID_STATUS_SUCCESS;
   }
 

--- a/projects/cuid/lib/src/cuid_nic.cc
+++ b/projects/cuid/lib/src/cuid_nic.cc
@@ -201,7 +201,6 @@ amdcuid_status_t CuidNic::get_primary_cuid(amdcuid_primary_id &id) const {
   std::string cuid_file_path = CuidUtilities::priv_cuid_file();
   CuidFile primary_file(cuid_file_path, false);
   primary_file.load();
-  std::vector<CuidFileEntry> entries = primary_file.get_entries();
 
   CuidFileEntry entry;
   amdcuid_status_t status =

--- a/projects/cuid/lib/src/cuid_nic.cc
+++ b/projects/cuid/lib/src/cuid_nic.cc
@@ -21,256 +21,260 @@
  */
 
 #include "cuid_nic.h"
+#include "cuid_file.h"
 #include "cuid_util.h"
 #include "pci_util.h"
-#include "cuid_file.h"
 #include <cstring>
 #include <dirent.h>
+#include <fstream>
+#include <iostream>
+#include <sstream>
 #include <sys/types.h>
 #include <unistd.h>
-#include <cstring>
-#include <fstream>
-#include <sstream>
-#include <iostream>
 
-CuidNic::CuidNic(const amdcuid_nic_info& i)
-    : m_info(i)
-{}
+CuidNic::CuidNic(const amdcuid_nic_info &i) : m_info(i) {}
 
 amdcuid_status_t CuidNic::discover(std::vector<DevicePtr> &nics) {
-    std::string nic_base_path = "/sys/class/net";
-    DIR *dir = opendir(nic_base_path.c_str());
-    if (!dir) return AMDCUID_STATUS_DEVICE_NOT_FOUND;
+  std::string nic_base_path = "/sys/class/net";
+  DIR *dir = opendir(nic_base_path.c_str());
+  if (!dir)
+    return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 
-    struct dirent *entry;
-    while ((entry = readdir(dir)) != NULL) {
-        // grab everything except the loopback device and hidden entries
-        if (strncmp(entry->d_name, "lo", 2) != 0 && entry->d_name[0] != '.') {
-            amdcuid_nic_info info = {};
-            std::string device_path = std::string(nic_base_path) + "/" + entry->d_name + "/device";
-            discover_single(&info, device_path);
+  struct dirent *entry;
+  while ((entry = readdir(dir)) != NULL) {
+    // grab everything except the loopback device and hidden entries
+    if (strncmp(entry->d_name, "lo", 2) != 0 && entry->d_name[0] != '.') {
+      amdcuid_nic_info info = {};
+      std::string device_path =
+          std::string(nic_base_path) + "/" + entry->d_name + "/device";
+      discover_single(&info, device_path);
 
-            nics.emplace_back(std::make_shared<CuidNic>(info));
-        }
+      nics.emplace_back(std::make_shared<CuidNic>(info));
     }
-    if (nics.size() == 0)
-        return AMDCUID_STATUS_DEVICE_NOT_FOUND;
+  }
+  if (nics.size() == 0)
+    return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 
-    closedir(dir);
-    return AMDCUID_STATUS_SUCCESS;
+  closedir(dir);
+  return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::discover_single(amdcuid_nic_info* nic_info, const std::string& device_path) {
-    amdcuid_nic_info info = {};
-    info.header.device_type = AMDCUID_DEVICE_TYPE_NIC;
+amdcuid_status_t CuidNic::discover_single(amdcuid_nic_info *nic_info,
+                                          const std::string &device_path) {
+  amdcuid_nic_info info = {};
+  info.header.device_type = AMDCUID_DEVICE_TYPE_NIC;
 
-    std::string bdf = CuidUtilities::readlink_bdf(device_path);
+  std::string bdf = CuidUtilities::readlink_bdf(device_path);
 
-    std::string vendor = CuidUtilities::read_sysfs_file(device_path + "/vendor");
-    if (vendor.empty() && !bdf.empty()){
-        // if file read fails, attempt to get from pci config
-        uint8_t vendor_id_bytes[2] = {0};
-        const uint16_t offset = 0x0;
-        amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
-        uint16_t vendor_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(vendor_id_bytes));
-        info.header.fields.nic.vendor_id = (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
-    }
-    else
-    {
-        info.header.fields.nic.vendor_id = (uint16_t)strtol(vendor.c_str(), nullptr, 16);
-    }
+  std::string vendor = CuidUtilities::read_sysfs_file(device_path + "/vendor");
+  if (vendor.empty() && !bdf.empty()) {
+    // if file read fails, attempt to get from pci config
+    uint8_t vendor_id_bytes[2] = {0};
+    const uint16_t offset = 0x0;
+    amdcuid_status_t status =
+        PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
+    uint16_t vendor_id_int =
+        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(vendor_id_bytes));
+    info.header.fields.nic.vendor_id =
+        (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
+  } else {
+    info.header.fields.nic.vendor_id =
+        (uint16_t)strtol(vendor.c_str(), nullptr, 16);
+  }
 
-    std::string device = CuidUtilities::read_sysfs_file(device_path + "/device");
-    if (device.empty() && !bdf.empty()){
-        // if file read fails, attempt to get from pci config
-        uint8_t device_id_bytes[2] = {0};
-        const uint16_t offset = 0x2;
-        amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
-        uint16_t device_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(device_id_bytes));
-        info.header.fields.nic.device_id = (status ==  AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
-    }
-    else
-    {
-        info.header.fields.nic.device_id = (uint16_t)strtol(device.c_str(), nullptr, 16);
-    }
+  std::string device = CuidUtilities::read_sysfs_file(device_path + "/device");
+  if (device.empty() && !bdf.empty()) {
+    // if file read fails, attempt to get from pci config
+    uint8_t device_id_bytes[2] = {0};
+    const uint16_t offset = 0x2;
+    amdcuid_status_t status =
+        PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
+    uint16_t device_id_int =
+        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(device_id_bytes));
+    info.header.fields.nic.device_id =
+        (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
+  } else {
+    info.header.fields.nic.device_id =
+        (uint16_t)strtol(device.c_str(), nullptr, 16);
+  }
 
-    std::string pci_class = CuidUtilities::read_sysfs_file(device_path + "/class");
-    uint16_t pci_class_integer = 0;
-    if (pci_class.empty() && !bdf.empty()){
-        // if file read fails, attempt to get from pci config
-        uint8_t class_id_bytes[2] = {0};
-        const uint16_t offset = 0xa;
-        amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
-        uint16_t class_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(class_id_bytes));
-        pci_class_integer = (status ==  AMDCUID_STATUS_SUCCESS) ? class_id_int : 0;
-    }
-    else
-    {
-        // sysfs class file returns 24-bit value (class:subclass:prog_if), shift right by 8
-        // to get 16-bit class:subclass
-        pci_class_integer = (uint16_t)(strtol(pci_class.c_str(), nullptr, 16) >> 8);
-    }
-    info.header.fields.nic.pci_class = pci_class_integer;
+  std::string pci_class =
+      CuidUtilities::read_sysfs_file(device_path + "/class");
+  uint16_t pci_class_integer = 0;
+  if (pci_class.empty() && !bdf.empty()) {
+    // if file read fails, attempt to get from pci config
+    uint8_t class_id_bytes[2] = {0};
+    const uint16_t offset = 0xa;
+    amdcuid_status_t status =
+        PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
+    uint16_t class_id_int =
+        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(class_id_bytes));
+    pci_class_integer = (status == AMDCUID_STATUS_SUCCESS) ? class_id_int : 0;
+  } else {
+    // sysfs class file returns 24-bit value (class:subclass:prog_if), shift
+    // right by 8 to get 16-bit class:subclass
+    pci_class_integer = (uint16_t)(strtol(pci_class.c_str(), nullptr, 16) >> 8);
+  }
+  info.header.fields.nic.pci_class = pci_class_integer;
 
-    std::string revision_id = CuidUtilities::read_sysfs_file(device_path + "/revision");
-    if (revision_id.empty() && !bdf.empty()){
-        // if file read fails, attempt to get from pci config
-        uint8_t revision_id_bytes[2] = {0};
-        const uint16_t offset = 0x8;
-        amdcuid_status_t status = PciUtil::read_pci_config_space(bdf, revision_id_bytes, 2, offset);
-        uint16_t revision_id_int = PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(revision_id_bytes));
-        info.header.fields.nic.revision_id = (status ==  AMDCUID_STATUS_SUCCESS) ? revision_id_int : 0;
-    }
-    else
-    {
-        info.header.fields.nic.revision_id = (uint16_t)strtol(revision_id.c_str(), nullptr, 16);
-    }
-    info.bdf = bdf;
-    std::string full_device_node;
-    size_t last_slash = device_path.rfind('/');
-    if (last_slash != std::string::npos && last_slash > 0) {
-        full_device_node = device_path.substr(0, last_slash);
-    }
-    else {
-        full_device_node = device_path;
-    }
-    info.network_interface = full_device_node;
-    *nic_info = info;
+  std::string revision_id =
+      CuidUtilities::read_sysfs_file(device_path + "/revision");
+  if (revision_id.empty() && !bdf.empty()) {
+    // if file read fails, attempt to get from pci config
+    uint8_t revision_id_bytes[2] = {0};
+    const uint16_t offset = 0x8;
+    amdcuid_status_t status =
+        PciUtil::read_pci_config_space(bdf, revision_id_bytes, 2, offset);
+    uint16_t revision_id_int =
+        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(revision_id_bytes));
+    info.header.fields.nic.revision_id =
+        (status == AMDCUID_STATUS_SUCCESS) ? revision_id_int : 0;
+  } else {
+    info.header.fields.nic.revision_id =
+        (uint16_t)strtol(revision_id.c_str(), nullptr, 16);
+  }
+  info.bdf = bdf;
+  std::string full_device_node;
+  size_t last_slash = device_path.rfind('/');
+  if (last_slash != std::string::npos && last_slash > 0) {
+    full_device_node = device_path.substr(0, last_slash);
+  } else {
+    full_device_node = device_path;
+  }
+  info.network_interface = full_device_node;
+  *nic_info = info;
 
-    return AMDCUID_STATUS_SUCCESS;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::get_hardware_fingerprint(uint64_t& fingerprint) const {
-    if (geteuid() != 0)
-    {
-        return AMDCUID_STATUS_PERMISSION_DENIED;
-    }
+amdcuid_status_t
+CuidNic::get_hardware_fingerprint(uint64_t &fingerprint) const {
+  if (geteuid() != 0) {
+    return AMDCUID_STATUS_PERMISSION_DENIED;
+  }
 
-    uint32_t cap_id = 0x3;
-    uint16_t offset = 0;
-    amdcuid_status_t status = PciUtil::get_pci_cap_offset(m_info.bdf, cap_id, offset);
-    if (status != AMDCUID_STATUS_UNSUPPORTED)
-    {
-        const uint8_t fingerprint_size = 8;
-        uint8_t fingerprint_bytes[fingerprint_size] = {0};
-        status = PciUtil::read_pci_config_space(m_info.bdf, fingerprint_bytes, fingerprint_size, offset);
-        if (status == AMDCUID_STATUS_SUCCESS)
-        {
-            fingerprint = PciUtil::le64_to_be64(*reinterpret_cast<uint64_t*>(fingerprint_bytes));
-            return AMDCUID_STATUS_SUCCESS;
-        }
-    }
-    // TODO: serial ID coudl be found in FRU_ID so should attempt to look there
-    // pci config space file does not exist or read failed, so create fingerprint from MAC address
-    std::string mac_address;
-    status = get_mac_address(mac_address);
-    if (status != AMDCUID_STATUS_SUCCESS)
-    {
-        return status;
-    }
-    if (!mac_address.empty())
-    {
-        // convert MAC address string to bytes
-        uint8_t mac_bytes[6] = {0};
-        sscanf(mac_address.c_str(), "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
-               &mac_bytes[0], &mac_bytes[1], &mac_bytes[2],
-               &mac_bytes[3], &mac_bytes[4], &mac_bytes[5]);
-        fingerprint = *reinterpret_cast<uint64_t*>(mac_bytes);
-        return AMDCUID_STATUS_SUCCESS;
-    }
-
-    return AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND;
-}
-
-amdcuid_status_t CuidNic::get_primary_cuid(amdcuid_primary_id& id) const {
-    if (geteuid() != 0)
-    {
-        return AMDCUID_STATUS_PERMISSION_DENIED;
-    }
-
-    // attempt to read the CUID from the file first
-    std::string cuid_file_path = CuidUtilities::priv_cuid_file();
-    CuidFile primary_file(cuid_file_path, false);
-    primary_file.load();
-    std::vector<CuidFileEntry> entries = primary_file.get_entries();
-
-    CuidFileEntry entry;
-    amdcuid_status_t status =primary_file.find_by_device_node(m_info.network_interface, entry);
+  uint16_t offset = 0;
+  amdcuid_status_t status = PciUtil::get_pci_dsn_cap_offset(m_info.bdf, offset);
+  if (status != AMDCUID_STATUS_SUCCESS) {
+    // attempt to get fingerprint through VSEC fallback if DSN capability is not
+    // found
+    status = PciUtil::get_pci_vsec_cap_offset(m_info.bdf, offset);
+  }
+  if (status == AMDCUID_STATUS_SUCCESS) {
+    const uint8_t fingerprint_size = 8;
+    uint8_t fingerprint_bytes[fingerprint_size] = {0};
+    status = PciUtil::read_pci_config_space(m_info.bdf, fingerprint_bytes,
+                                            fingerprint_size, offset);
     if (status == AMDCUID_STATUS_SUCCESS) {
-        id.UUIDv8_representation = entry.primary_cuid;
-        CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
-        return AMDCUID_STATUS_SUCCESS;
+      fingerprint = PciUtil::le64_to_be64(
+          *reinterpret_cast<uint64_t *>(fingerprint_bytes));
+      return AMDCUID_STATUS_SUCCESS;
     }
-
-    uint64_t fingerprint = 0;
-    status = get_hardware_fingerprint(fingerprint);
-    if (status != AMDCUID_STATUS_SUCCESS) {
-        std::memset(&id, 0, sizeof(id));
-        return status;
-    }
-
-    status = CuidUtilities::generate_primary_cuid(
-        fingerprint, 
-        0, 
-        m_info.header.fields.nic.revision_id,
-        m_info.header.fields.nic.device_id,
-        m_info.header.fields.nic.vendor_id,
-        static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_NIC), 
-        &id);
-    if (status != AMDCUID_STATUS_SUCCESS) {
-        std::memset(&id, 0, sizeof(id));
-        return status;
-    }
-
+  }
+  // TODO: serial ID could be found in FRU_ID so should attempt to look there
+  // pci config space file does not exist or read failed, so create fingerprint
+  // from MAC address
+  std::string mac_address;
+  status = get_mac_address(mac_address);
+  if (status != AMDCUID_STATUS_SUCCESS) {
     return status;
-}
-
-const amdcuid_nic_info& CuidNic::get_info() const {
-    return m_info;
-}
-
-amdcuid_status_t CuidNic::get_vendor_id(uint16_t& vendor_id) const {
-    vendor_id = m_info.header.fields.nic.vendor_id;
+  }
+  if (!mac_address.empty()) {
+    // convert MAC address string to bytes
+    uint8_t mac_bytes[6] = {0};
+    sscanf(mac_address.c_str(), "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &mac_bytes[0],
+           &mac_bytes[1], &mac_bytes[2], &mac_bytes[3], &mac_bytes[4],
+           &mac_bytes[5]);
+    fingerprint = *reinterpret_cast<uint64_t *>(mac_bytes);
     return AMDCUID_STATUS_SUCCESS;
+  }
+
+  return AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND;
 }
 
-amdcuid_status_t CuidNic::get_device_id(uint16_t& device_id) const {
-    device_id = m_info.header.fields.nic.device_id;
+amdcuid_status_t CuidNic::get_primary_cuid(amdcuid_primary_id &id) const {
+  if (geteuid() != 0) {
+    return AMDCUID_STATUS_PERMISSION_DENIED;
+  }
+
+  // attempt to read the CUID from the file first
+  std::string cuid_file_path = CuidUtilities::priv_cuid_file();
+  CuidFile primary_file(cuid_file_path, false);
+  primary_file.load();
+  std::vector<CuidFileEntry> entries = primary_file.get_entries();
+
+  CuidFileEntry entry;
+  amdcuid_status_t status =
+      primary_file.find_by_device_node(m_info.network_interface, entry);
+  if (status == AMDCUID_STATUS_SUCCESS) {
+    id.UUIDv8_representation = entry.primary_cuid;
+    CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
     return AMDCUID_STATUS_SUCCESS;
+  }
+
+  uint64_t fingerprint = 0;
+  status = get_hardware_fingerprint(fingerprint);
+  if (status != AMDCUID_STATUS_SUCCESS) {
+    std::memset(&id, 0, sizeof(id));
+    return status;
+  }
+
+  status = CuidUtilities::generate_primary_cuid(
+      fingerprint, 0, m_info.header.fields.nic.revision_id,
+      m_info.header.fields.nic.device_id, m_info.header.fields.nic.vendor_id,
+      static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_NIC), &id);
+  if (status != AMDCUID_STATUS_SUCCESS) {
+    std::memset(&id, 0, sizeof(id));
+    return status;
+  }
+
+  return status;
 }
 
-amdcuid_status_t CuidNic::get_pci_class(uint16_t& pci_class) const {
-    pci_class = m_info.header.fields.nic.pci_class;
-    return AMDCUID_STATUS_SUCCESS;
+const amdcuid_nic_info &CuidNic::get_info() const { return m_info; }
+
+amdcuid_status_t CuidNic::get_vendor_id(uint16_t &vendor_id) const {
+  vendor_id = m_info.header.fields.nic.vendor_id;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::get_revision_id(uint8_t& revision_id) const {
-    revision_id = m_info.header.fields.nic.revision_id;
-    return AMDCUID_STATUS_SUCCESS;
+amdcuid_status_t CuidNic::get_device_id(uint16_t &device_id) const {
+  device_id = m_info.header.fields.nic.device_id;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::get_bdf(std::string& bdf) const {
-    if (m_info.bdf.empty()) {
-        return AMDCUID_STATUS_UNSUPPORTED;
-    }
-    bdf = m_info.bdf;
-    return AMDCUID_STATUS_SUCCESS;
+amdcuid_status_t CuidNic::get_pci_class(uint16_t &pci_class) const {
+  pci_class = m_info.header.fields.nic.pci_class;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::get_device_path(std::string& path) const {
-    if (m_info.network_interface.empty()) {
-        return AMDCUID_STATUS_UNSUPPORTED;
-    }
-    path = m_info.network_interface;
-    return AMDCUID_STATUS_SUCCESS;
+amdcuid_status_t CuidNic::get_revision_id(uint8_t &revision_id) const {
+  revision_id = m_info.header.fields.nic.revision_id;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNic::get_mac_address(std::string& mac_address) const {
-    std::string mac_path = m_info.network_interface + "/address";
-    mac_address = CuidUtilities::read_sysfs_file(mac_path);
+amdcuid_status_t CuidNic::get_bdf(std::string &bdf) const {
+  if (m_info.bdf.empty()) {
+    return AMDCUID_STATUS_UNSUPPORTED;
+  }
+  bdf = m_info.bdf;
+  return AMDCUID_STATUS_SUCCESS;
+}
 
-    if (mac_address.empty()) {
-        return AMDCUID_STATUS_UNSUPPORTED;
-    }
-    return AMDCUID_STATUS_SUCCESS;
+amdcuid_status_t CuidNic::get_device_path(std::string &path) const {
+  if (m_info.network_interface.empty()) {
+    return AMDCUID_STATUS_UNSUPPORTED;
+  }
+  path = m_info.network_interface;
+  return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t CuidNic::get_mac_address(std::string &mac_address) const {
+  std::string mac_path = m_info.network_interface + "/address";
+  mac_address = CuidUtilities::read_sysfs_file(mac_path);
+
+  if (mac_address.empty()) {
+    return AMDCUID_STATUS_UNSUPPORTED;
+  }
+  return AMDCUID_STATUS_SUCCESS;
 }

--- a/projects/cuid/lib/src/cuid_npu.cc
+++ b/projects/cuid/lib/src/cuid_npu.cc
@@ -39,341 +39,338 @@ static const uint16_t AMD_VENDOR_ID = 0x1022;
 //   0x11 = Signal processing controller (e.g., Strix/Strix Halo NPU 0x1180)
 //   0x12 = Processing accelerators
 static const uint16_t PCI_CLASS_SIGNAL_PROCESSING = 0x1100;
-static const uint16_t PCI_CLASS_PROCESSING_ACCEL  = 0x1200;
+static const uint16_t PCI_CLASS_PROCESSING_ACCEL = 0x1200;
 static const uint16_t PCI_CLASS_BASE_MASK = 0xFF00;
 
-CuidNpu::CuidNpu(const amdcuid_npu_info& i) : m_info(i) {}
+CuidNpu::CuidNpu(const amdcuid_npu_info &i) : m_info(i) {}
 
 // Helper to check if a /sys/class/accel entry name is an accel device
 // (e.g., "accel0", "accel1").
-static bool is_accel_entry(const char* name) {
-    if (strncmp(name, "accel", 5) != 0 || !isdigit(name[5]))
-        return false;
-    for (size_t i = 5; name[i] != '\0'; ++i) {
-        if (!isdigit(name[i]))
-            return false;
-    }
-    return true;
+static bool is_accel_entry(const char *name) {
+  if (strncmp(name, "accel", 5) != 0 || !isdigit(name[5]))
+    return false;
+  for (size_t i = 5; name[i] != '\0'; ++i) {
+    if (!isdigit(name[i]))
+      return false;
+  }
+  return true;
 }
 
 // Discover NPU devices via /sys/class/accel (when amdxdna driver is loaded)
-static amdcuid_status_t discover_via_accel(std::vector<DevicePtr>& npus) {
-    const char* accel_path = "/sys/class/accel";
-    DIR* dir = opendir(accel_path);
-    if (!dir)
-        return AMDCUID_STATUS_UNSUPPORTED;
+static amdcuid_status_t discover_via_accel(std::vector<DevicePtr> &npus) {
+  const char *accel_path = "/sys/class/accel";
+  DIR *dir = opendir(accel_path);
+  if (!dir)
+    return AMDCUID_STATUS_UNSUPPORTED;
 
-    struct dirent* entry;
-    while ((entry = readdir(dir)) != NULL) {
-        if (is_accel_entry(entry->d_name)) {
-            std::string accel_name(entry->d_name);
-            std::string device_path =
-                std::string(accel_path) + "/" + accel_name + "/device";
+  struct dirent *entry;
+  while ((entry = readdir(dir)) != NULL) {
+    if (is_accel_entry(entry->d_name)) {
+      std::string accel_name(entry->d_name);
+      std::string device_path =
+          std::string(accel_path) + "/" + accel_name + "/device";
 
-            // Read vendor to filter for AMD NPU devices only
-            std::string vendor_str =
-                CuidUtilities::read_sysfs_file(device_path + "/vendor");
-            if (vendor_str.empty())
-                continue;
-            uint16_t vendor_id =
-                static_cast<uint16_t>(strtol(vendor_str.c_str(), nullptr, 16));
-            if (vendor_id != AMD_VENDOR_ID)
-                continue;
+      // Read vendor to filter for AMD NPU devices only
+      std::string vendor_str =
+          CuidUtilities::read_sysfs_file(device_path + "/vendor");
+      if (vendor_str.empty())
+        continue;
+      uint16_t vendor_id =
+          static_cast<uint16_t>(strtol(vendor_str.c_str(), nullptr, 16));
+      if (vendor_id != AMD_VENDOR_ID)
+        continue;
 
-            amdcuid_npu_info info = {};
-            amdcuid_status_t status = CuidNpu::discover_single(&info, device_path);
-            if (status != AMDCUID_STATUS_SUCCESS)
-                continue;
+      amdcuid_npu_info info = {};
+      amdcuid_status_t status = CuidNpu::discover_single(&info, device_path);
+      if (status != AMDCUID_STATUS_SUCCESS)
+        continue;
 
-            npus.emplace_back(std::make_shared<CuidNpu>(info));
-        }
+      npus.emplace_back(std::make_shared<CuidNpu>(info));
     }
-    closedir(dir);
+  }
+  closedir(dir);
 
-    return npus.empty() ? AMDCUID_STATUS_UNSUPPORTED : AMDCUID_STATUS_SUCCESS;
+  return npus.empty() ? AMDCUID_STATUS_UNSUPPORTED : AMDCUID_STATUS_SUCCESS;
 }
 
 // Fallback: discover NPU devices by scanning PCI bus for AMD processing
 // accelerator class devices. This handles systems where /sys/class/accel
 // is not populated (e.g., driver not loaded or accel subsystem absent).
-static amdcuid_status_t discover_via_pci_bus(std::vector<DevicePtr>& npus) {
-    const char* pci_path = "/sys/bus/pci/devices";
-    DIR* dir = opendir(pci_path);
-    if (!dir)
-        return AMDCUID_STATUS_UNSUPPORTED;
+static amdcuid_status_t discover_via_pci_bus(std::vector<DevicePtr> &npus) {
+  const char *pci_path = "/sys/bus/pci/devices";
+  DIR *dir = opendir(pci_path);
+  if (!dir)
+    return AMDCUID_STATUS_UNSUPPORTED;
 
-    struct dirent* entry;
-    while ((entry = readdir(dir)) != NULL) {
-        if (entry->d_name[0] == '.')
-            continue;
+  struct dirent *entry;
+  while ((entry = readdir(dir)) != NULL) {
+    if (entry->d_name[0] == '.')
+      continue;
 
-        std::string device_path =
-            std::string(pci_path) + "/" + entry->d_name;
+    std::string device_path = std::string(pci_path) + "/" + entry->d_name;
 
-        std::string vendor_str =
-            CuidUtilities::read_sysfs_file(device_path + "/vendor");
-        if (vendor_str.empty())
-            continue;
-        uint16_t vendor_id =
-            static_cast<uint16_t>(strtol(vendor_str.c_str(), nullptr, 16));
-        if (vendor_id != AMD_VENDOR_ID)
-            continue;
-
-        std::string class_str =
-            CuidUtilities::read_sysfs_file(device_path + "/class");
-        if (class_str.empty())
-            continue;
-        // sysfs class is 24-bit (class:subclass:prog_if), shift to get class:subclass
-        uint16_t pci_class =
-            static_cast<uint16_t>(strtol(class_str.c_str(), nullptr, 16) >> 8);
-        uint16_t base_class = pci_class & PCI_CLASS_BASE_MASK;
-        if (base_class != PCI_CLASS_PROCESSING_ACCEL &&
-            base_class != PCI_CLASS_SIGNAL_PROCESSING)
-            continue;
-
-        amdcuid_npu_info info = {};
-        amdcuid_status_t status = CuidNpu::discover_single(&info, device_path);
-        if (status != AMDCUID_STATUS_SUCCESS)
-            continue;
-
-        npus.emplace_back(std::make_shared<CuidNpu>(info));
-    }
-    closedir(dir);
-
-    return npus.empty() ? AMDCUID_STATUS_UNSUPPORTED : AMDCUID_STATUS_SUCCESS;
-}
-
-amdcuid_status_t CuidNpu::discover(std::vector<DevicePtr>& npus) {
-    // Try /sys/class/accel first (when amdxdna driver is loaded)
-    amdcuid_status_t status = discover_via_accel(npus);
-    if (status == AMDCUID_STATUS_SUCCESS)
-        return status;
-
-    // Fallback: scan PCI bus for processing accelerator class devices
-    return discover_via_pci_bus(npus);
-}
-
-amdcuid_status_t CuidNpu::discover_single(amdcuid_npu_info* npu_info,
-                                           const std::string& device_path) {
-    amdcuid_npu_info info = {};
-    std::string bdf = CuidUtilities::readlink_bdf(device_path);
-
-    std::string vendor =
+    std::string vendor_str =
         CuidUtilities::read_sysfs_file(device_path + "/vendor");
-    if (vendor.empty() && !bdf.empty()) {
-        uint8_t vendor_id_bytes[2] = {0};
-        const uint16_t offset = 0x0;
-        amdcuid_status_t status =
-            PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
-        uint16_t vendor_id_int =
-            PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(vendor_id_bytes));
-        info.header.fields.npu.vendor_id =
-            (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
-    } else {
-        info.header.fields.npu.vendor_id =
-            static_cast<uint16_t>(strtol(vendor.c_str(), nullptr, 16));
-    }
+    if (vendor_str.empty())
+      continue;
+    uint16_t vendor_id =
+        static_cast<uint16_t>(strtol(vendor_str.c_str(), nullptr, 16));
+    if (vendor_id != AMD_VENDOR_ID)
+      continue;
 
-    std::string device =
-        CuidUtilities::read_sysfs_file(device_path + "/device");
-    if (device.empty() && !bdf.empty()) {
-        uint8_t device_id_bytes[2] = {0};
-        const uint16_t offset = 0x2;
-        amdcuid_status_t status =
-            PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
-        uint16_t device_id_int =
-            PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(device_id_bytes));
-        info.header.fields.npu.device_id =
-            (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
-    } else {
-        info.header.fields.npu.device_id =
-            static_cast<uint16_t>(strtol(device.c_str(), nullptr, 16));
-    }
-
-    std::string pci_class =
+    std::string class_str =
         CuidUtilities::read_sysfs_file(device_path + "/class");
-    uint16_t pci_class_integer = 0;
-    if (pci_class.empty() && !bdf.empty()) {
-        uint8_t class_id_bytes[2] = {0};
-        const uint16_t offset = 0xa;
-        amdcuid_status_t status =
-            PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
-        uint16_t class_id_int =
-            PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(class_id_bytes));
-        pci_class_integer =
-            (status == AMDCUID_STATUS_SUCCESS) ? class_id_int : 0;
+    if (class_str.empty())
+      continue;
+    // sysfs class is 24-bit (class:subclass:prog_if), shift to get
+    // class:subclass
+    uint16_t pci_class =
+        static_cast<uint16_t>(strtol(class_str.c_str(), nullptr, 16) >> 8);
+    uint16_t base_class = pci_class & PCI_CLASS_BASE_MASK;
+    if (base_class != PCI_CLASS_PROCESSING_ACCEL &&
+        base_class != PCI_CLASS_SIGNAL_PROCESSING)
+      continue;
+
+    amdcuid_npu_info info = {};
+    amdcuid_status_t status = CuidNpu::discover_single(&info, device_path);
+    if (status != AMDCUID_STATUS_SUCCESS)
+      continue;
+
+    npus.emplace_back(std::make_shared<CuidNpu>(info));
+  }
+  closedir(dir);
+
+  return npus.empty() ? AMDCUID_STATUS_UNSUPPORTED : AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t CuidNpu::discover(std::vector<DevicePtr> &npus) {
+  // Try /sys/class/accel first (when amdxdna driver is loaded)
+  amdcuid_status_t status = discover_via_accel(npus);
+  if (status == AMDCUID_STATUS_SUCCESS)
+    return status;
+
+  // Fallback: scan PCI bus for processing accelerator class devices
+  return discover_via_pci_bus(npus);
+}
+
+amdcuid_status_t CuidNpu::discover_single(amdcuid_npu_info *npu_info,
+                                          const std::string &device_path) {
+  amdcuid_npu_info info = {};
+  std::string bdf = CuidUtilities::readlink_bdf(device_path);
+
+  std::string vendor = CuidUtilities::read_sysfs_file(device_path + "/vendor");
+  if (vendor.empty() && !bdf.empty()) {
+    uint8_t vendor_id_bytes[2] = {0};
+    const uint16_t offset = 0x0;
+    amdcuid_status_t status =
+        PciUtil::read_pci_config_space(bdf, vendor_id_bytes, 2, offset);
+    uint16_t vendor_id_int =
+        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(vendor_id_bytes));
+    info.header.fields.npu.vendor_id =
+        (status == AMDCUID_STATUS_SUCCESS) ? vendor_id_int : 0;
+  } else {
+    info.header.fields.npu.vendor_id =
+        static_cast<uint16_t>(strtol(vendor.c_str(), nullptr, 16));
+  }
+
+  std::string device = CuidUtilities::read_sysfs_file(device_path + "/device");
+  if (device.empty() && !bdf.empty()) {
+    uint8_t device_id_bytes[2] = {0};
+    const uint16_t offset = 0x2;
+    amdcuid_status_t status =
+        PciUtil::read_pci_config_space(bdf, device_id_bytes, 2, offset);
+    uint16_t device_id_int =
+        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(device_id_bytes));
+    info.header.fields.npu.device_id =
+        (status == AMDCUID_STATUS_SUCCESS) ? device_id_int : 0;
+  } else {
+    info.header.fields.npu.device_id =
+        static_cast<uint16_t>(strtol(device.c_str(), nullptr, 16));
+  }
+
+  std::string pci_class =
+      CuidUtilities::read_sysfs_file(device_path + "/class");
+  uint16_t pci_class_integer = 0;
+  if (pci_class.empty() && !bdf.empty()) {
+    uint8_t class_id_bytes[2] = {0};
+    const uint16_t offset = 0xa;
+    amdcuid_status_t status =
+        PciUtil::read_pci_config_space(bdf, class_id_bytes, 2, offset);
+    uint16_t class_id_int =
+        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(class_id_bytes));
+    pci_class_integer = (status == AMDCUID_STATUS_SUCCESS) ? class_id_int : 0;
+  } else {
+    // sysfs class file returns 24-bit value (class:subclass:prog_if),
+    // shift right by 8 to get 16-bit class:subclass
+    pci_class_integer =
+        static_cast<uint16_t>(strtol(pci_class.c_str(), nullptr, 16) >> 8);
+  }
+  info.header.fields.npu.pci_class = pci_class_integer;
+
+  std::string revision_id =
+      CuidUtilities::read_sysfs_file(device_path + "/revision");
+  if (revision_id.empty() && !bdf.empty()) {
+    uint8_t revision_id_bytes[2] = {0};
+    const uint16_t offset = 0x8;
+    amdcuid_status_t status =
+        PciUtil::read_pci_config_space(bdf, revision_id_bytes, 2, offset);
+    uint16_t revision_id_int =
+        PciUtil::le16_to_be16(*reinterpret_cast<uint16_t *>(revision_id_bytes));
+    info.header.fields.npu.revision_id =
+        (status == AMDCUID_STATUS_SUCCESS)
+            ? static_cast<uint8_t>(revision_id_int)
+            : 0;
+  } else {
+    info.header.fields.npu.revision_id =
+        static_cast<uint8_t>(strtol(revision_id.c_str(), nullptr, 16));
+  }
+
+  // Determine the device node path.
+  // If discovered through /sys/class/accel, strip the /device suffix.
+  // If discovered through /sys/bus/pci/devices, try to resolve the accel
+  // node; if that fails, store the PCI device path as-is.
+  std::string full_device_node;
+  if (device_path.find("/sys/class/accel/") != std::string::npos) {
+    size_t last_slash = device_path.rfind('/');
+    if (last_slash != std::string::npos && last_slash > 0) {
+      full_device_node = device_path.substr(0, last_slash);
     } else {
-        // sysfs class file returns 24-bit value (class:subclass:prog_if),
-        // shift right by 8 to get 16-bit class:subclass
-        pci_class_integer =
-            static_cast<uint16_t>(strtol(pci_class.c_str(), nullptr, 16) >> 8);
+      full_device_node = device_path;
     }
-    info.header.fields.npu.pci_class = pci_class_integer;
-
-    std::string revision_id =
-        CuidUtilities::read_sysfs_file(device_path + "/revision");
-    if (revision_id.empty() && !bdf.empty()) {
-        uint8_t revision_id_bytes[2] = {0};
-        const uint16_t offset = 0x8;
-        amdcuid_status_t status =
-            PciUtil::read_pci_config_space(bdf, revision_id_bytes, 2, offset);
-        uint16_t revision_id_int =
-            PciUtil::le16_to_be16(*reinterpret_cast<uint16_t*>(revision_id_bytes));
-        info.header.fields.npu.revision_id =
-            (status == AMDCUID_STATUS_SUCCESS)
-                ? static_cast<uint8_t>(revision_id_int)
-                : 0;
+  } else if (!bdf.empty()) {
+    // Try to resolve /sys/bus/pci/devices/<bdf>/accel/accelN
+    std::string resolved =
+        CuidUtilities::bdf_to_device_path(bdf, AMDCUID_DEVICE_TYPE_NPU);
+    if (!resolved.empty()) {
+      full_device_node = resolved;
     } else {
-        info.header.fields.npu.revision_id =
-            static_cast<uint8_t>(strtol(revision_id.c_str(), nullptr, 16));
+      full_device_node = device_path;
     }
+  } else {
+    full_device_node = device_path;
+  }
 
-    // Determine the device node path.
-    // If discovered through /sys/class/accel, strip the /device suffix.
-    // If discovered through /sys/bus/pci/devices, try to resolve the accel
-    // node; if that fails, store the PCI device path as-is.
-    std::string full_device_node;
-    if (device_path.find("/sys/class/accel/") != std::string::npos) {
-        size_t last_slash = device_path.rfind('/');
-        if (last_slash != std::string::npos && last_slash > 0) {
-            full_device_node = device_path.substr(0, last_slash);
-        } else {
-            full_device_node = device_path;
-        }
-    } else if (!bdf.empty()) {
-        // Try to resolve /sys/bus/pci/devices/<bdf>/accel/accelN
-        std::string resolved =
-            CuidUtilities::bdf_to_device_path(bdf, AMDCUID_DEVICE_TYPE_NPU);
-        if (!resolved.empty()) {
-            full_device_node = resolved;
-        } else {
-            full_device_node = device_path;
-        }
-    } else {
-        full_device_node = device_path;
-    }
+  info.header.device_type = AMDCUID_DEVICE_TYPE_NPU;
+  info.bdf = bdf;
+  info.accel_node = full_device_node;
 
-    info.header.device_type = AMDCUID_DEVICE_TYPE_NPU;
-    info.bdf = bdf;
-    info.accel_node = full_device_node;
+  *npu_info = info;
 
-    *npu_info = info;
-
-    return AMDCUID_STATUS_SUCCESS;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
 amdcuid_status_t
-CuidNpu::get_hardware_fingerprint(uint64_t& fingerprint) const {
-    if (geteuid() != 0) {
-        return AMDCUID_STATUS_PERMISSION_DENIED;
-    }
+CuidNpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
+  if (geteuid() != 0) {
+    return AMDCUID_STATUS_PERMISSION_DENIED;
+  }
 
-    // Attempt to get fingerprint through PCI Config Space DSN capability
-    uint16_t offset = 0;
-    amdcuid_status_t status =
-        PciUtil::get_pci_cap_offset(m_info.bdf, 0x03, offset);
+  // Attempt to get fingerprint through PCI Config Space DSN capability
+  uint16_t offset = 0;
+  amdcuid_status_t status = PciUtil::get_pci_dsn_cap_offset(m_info.bdf, offset);
+  if (status != AMDCUID_STATUS_SUCCESS) {
+    // attempt to get fingerprint through VSEC fallback if DSN capability is not
+    // found
+    status = PciUtil::get_pci_vsec_cap_offset(m_info.bdf, offset);
+    if (status != AMDCUID_STATUS_SUCCESS) {
+      fingerprint = 0;
+      return status;
+    }
+  }
+  if (status == AMDCUID_STATUS_SUCCESS) {
+    const uint8_t fingerprint_size = 8;
+    uint8_t fingerprint_bytes[fingerprint_size] = {0};
+    status = PciUtil::read_pci_config_space(m_info.bdf, fingerprint_bytes,
+                                            fingerprint_size, offset);
     if (status == AMDCUID_STATUS_SUCCESS) {
-        const uint8_t fingerprint_size = 8;
-        uint8_t fingerprint_bytes[fingerprint_size] = {0};
-        status = PciUtil::read_pci_config_space(
-            m_info.bdf, fingerprint_bytes, fingerprint_size, offset);
-        if (status == AMDCUID_STATUS_SUCCESS) {
-            fingerprint = PciUtil::le64_to_be64(
-                *reinterpret_cast<uint64_t*>(fingerprint_bytes));
-            return AMDCUID_STATUS_SUCCESS;
-        }
+      fingerprint = PciUtil::le64_to_be64(
+          *reinterpret_cast<uint64_t *>(fingerprint_bytes));
+      return AMDCUID_STATUS_SUCCESS;
+    } else {
+      fingerprint = 0;
+      delete[] fingerprint_bytes;
+      return status;
     }
+  }
 
-    // If DSN capability is not available, construct a fingerprint from
-    // PCI vendor/device/revision IDs as a fallback. This fingerprint is
-    // not unique per device instance — all NPUs of the same model will
-    // produce the same value. This is acceptable for integrated NPUs
-    // (one per SoC). If discrete NPU parts appear in the future, a
-    // unique identifier source (e.g., fuse ID) will be needed.
-    fingerprint = (static_cast<uint64_t>(m_info.header.fields.npu.vendor_id) << 32) |
-                  (static_cast<uint64_t>(m_info.header.fields.npu.device_id) << 16) |
-                  static_cast<uint64_t>(m_info.header.fields.npu.revision_id);
-    return AMDCUID_STATUS_SUCCESS;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNpu::get_primary_cuid(amdcuid_primary_id& id) const {
-    if (geteuid() != 0) {
-        return AMDCUID_STATUS_PERMISSION_DENIED;
-    }
+amdcuid_status_t CuidNpu::get_primary_cuid(amdcuid_primary_id &id) const {
+  if (geteuid() != 0) {
+    return AMDCUID_STATUS_PERMISSION_DENIED;
+  }
 
-    // Attempt to read the CUID from the file first
-    std::string cuid_file_path = CuidUtilities::priv_cuid_file();
-    CuidFile primary_file(cuid_file_path, false);
-    primary_file.load();
+  // Attempt to read the CUID from the file first
+  std::string cuid_file_path = CuidUtilities::priv_cuid_file();
+  CuidFile primary_file(cuid_file_path, false);
+  primary_file.load();
 
-    CuidFileEntry entry;
-    amdcuid_status_t status =
-        primary_file.find_by_device_node(m_info.accel_node, entry);
-    if (status == AMDCUID_STATUS_SUCCESS) {
-        id.UUIDv8_representation = entry.primary_cuid;
-        CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation,
-                                          id.raw_bits);
-        return AMDCUID_STATUS_SUCCESS;
-    }
+  CuidFileEntry entry;
+  amdcuid_status_t status =
+      primary_file.find_by_device_node(m_info.accel_node, entry);
+  if (status == AMDCUID_STATUS_SUCCESS) {
+    id.UUIDv8_representation = entry.primary_cuid;
+    CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
+    return AMDCUID_STATUS_SUCCESS;
+  }
 
-    // Primary CUID not found in file, so generate it
-    uint64_t fingerprint = 0;
-    status = get_hardware_fingerprint(fingerprint);
-    if (status != AMDCUID_STATUS_SUCCESS) {
-        std::memset(&id, 0, sizeof(id));
-        return status;
-    }
-
-    status = CuidUtilities::generate_primary_cuid(
-        fingerprint,
-        0,  // unit_id: NPUs are not partitioned
-        m_info.header.fields.npu.revision_id,
-        m_info.header.fields.npu.device_id,
-        m_info.header.fields.npu.vendor_id,
-        static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_NPU),
-        &id);
-    if (status != AMDCUID_STATUS_SUCCESS) {
-        std::memset(&id, 0, sizeof(id));
-        return status;
-    }
-
+  // Primary CUID not found in file, so generate it
+  uint64_t fingerprint = 0;
+  status = get_hardware_fingerprint(fingerprint);
+  if (status != AMDCUID_STATUS_SUCCESS) {
+    std::memset(&id, 0, sizeof(id));
     return status;
+  }
+
+  status = CuidUtilities::generate_primary_cuid(
+      fingerprint,
+      0, // unit_id: NPUs are not partitioned
+      m_info.header.fields.npu.revision_id, m_info.header.fields.npu.device_id,
+      m_info.header.fields.npu.vendor_id,
+      static_cast<uint8_t>(AMDCUID_DEVICE_TYPE_NPU), &id);
+  if (status != AMDCUID_STATUS_SUCCESS) {
+    std::memset(&id, 0, sizeof(id));
+    return status;
+  }
+
+  return status;
 }
 
-const amdcuid_npu_info& CuidNpu::get_info() const { return m_info; }
+const amdcuid_npu_info &CuidNpu::get_info() const { return m_info; }
 
-amdcuid_status_t CuidNpu::get_vendor_id(uint16_t& vendor_id) const {
-    vendor_id = m_info.header.fields.npu.vendor_id;
-    return AMDCUID_STATUS_SUCCESS;
+amdcuid_status_t CuidNpu::get_vendor_id(uint16_t &vendor_id) const {
+  vendor_id = m_info.header.fields.npu.vendor_id;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNpu::get_device_id(uint16_t& device_id) const {
-    device_id = m_info.header.fields.npu.device_id;
-    return AMDCUID_STATUS_SUCCESS;
+amdcuid_status_t CuidNpu::get_device_id(uint16_t &device_id) const {
+  device_id = m_info.header.fields.npu.device_id;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNpu::get_pci_class(uint16_t& pci_class) const {
-    pci_class = m_info.header.fields.npu.pci_class;
-    return AMDCUID_STATUS_SUCCESS;
+amdcuid_status_t CuidNpu::get_pci_class(uint16_t &pci_class) const {
+  pci_class = m_info.header.fields.npu.pci_class;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNpu::get_revision_id(uint8_t& revision_id) const {
-    revision_id = m_info.header.fields.npu.revision_id;
-    return AMDCUID_STATUS_SUCCESS;
+amdcuid_status_t CuidNpu::get_revision_id(uint8_t &revision_id) const {
+  revision_id = m_info.header.fields.npu.revision_id;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNpu::get_bdf(std::string& bdf) const {
-    if (m_info.bdf.empty()) {
-        return AMDCUID_STATUS_UNSUPPORTED;
-    }
-    bdf = m_info.bdf;
-    return AMDCUID_STATUS_SUCCESS;
+amdcuid_status_t CuidNpu::get_bdf(std::string &bdf) const {
+  if (m_info.bdf.empty()) {
+    return AMDCUID_STATUS_UNSUPPORTED;
+  }
+  bdf = m_info.bdf;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t CuidNpu::get_device_path(std::string& path) const {
-    if (m_info.accel_node.empty()) {
-        return AMDCUID_STATUS_UNSUPPORTED;
-    }
-    path = m_info.accel_node;
-    return AMDCUID_STATUS_SUCCESS;
+amdcuid_status_t CuidNpu::get_device_path(std::string &path) const {
+  if (m_info.accel_node.empty()) {
+    return AMDCUID_STATUS_UNSUPPORTED;
+  }
+  path = m_info.accel_node;
+  return AMDCUID_STATUS_SUCCESS;
 }

--- a/projects/cuid/lib/src/cuid_npu.cc
+++ b/projects/cuid/lib/src/cuid_npu.cc
@@ -283,12 +283,12 @@ CuidNpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
     status = PciUtil::read_pci_config_space(m_info.bdf, fingerprint_bytes,
                                             fingerprint_size, offset);
     if (status == AMDCUID_STATUS_SUCCESS) {
-      fingerprint = PciUtil::le64_to_be64(
-          *reinterpret_cast<uint64_t *>(fingerprint_bytes));
+      uint64_t fingerprint_value = 0;
+      std::memcpy(&fingerprint_value, fingerprint_bytes, fingerprint_size);
+      fingerprint = PciUtil::le64_to_be64(fingerprint_value);
       return AMDCUID_STATUS_SUCCESS;
     } else {
       fingerprint = 0;
-      delete[] fingerprint_bytes;
       return status;
     }
   }

--- a/projects/cuid/lib/src/cuid_npu.cc
+++ b/projects/cuid/lib/src/cuid_npu.cc
@@ -274,7 +274,7 @@ CuidNpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
     status = PciUtil::get_pci_vsec_cap_offset(m_info.bdf, offset);
     if (status != AMDCUID_STATUS_SUCCESS) {
       fingerprint = 0;
-      return status;
+      return AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND;
     }
   }
   if (status == AMDCUID_STATUS_SUCCESS) {
@@ -293,7 +293,7 @@ CuidNpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
     }
   }
 
-  return AMDCUID_STATUS_SUCCESS;
+  return AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND;
 }
 
 amdcuid_status_t CuidNpu::get_primary_cuid(amdcuid_primary_id &id) const {

--- a/projects/cuid/lib/src/pci_util.cc
+++ b/projects/cuid/lib/src/pci_util.cc
@@ -201,7 +201,11 @@ amdcuid_status_t PciUtil::get_pci_vsec_cap_offset(std::string bdf,
           (static_cast<uint32_t>(config_space[cap_ptr + 7]) << 24);
 
       // if the VSEC has the required length for our fingerprint, return the
-      // offset
+      // offset. Since VSEC ID for serial number/id not typically defined,
+      // we rely on the length field to to simply get enough bytes
+      // for the fingerprint rather than checking an ID field in the VSEC
+      // header. If one is defined in the future, we will add that check here as
+      // well.
       uint16_t vsec_length =
           static_cast<uint16_t>((vsec_header >> 20) & 0x0FFF);
       if (vsec_length >= 8) {

--- a/projects/cuid/lib/src/pci_util.cc
+++ b/projects/cuid/lib/src/pci_util.cc
@@ -49,8 +49,8 @@ uint64_t PciUtil::le64_to_be64(uint64_t value) {
          ((value & 0xFF00000000000000ULL) >> 56);
 }
 
-// function should only work with PCI devices, which so far includes GPUs and
-// NICs. May later include NPU and storage.
+// This function should only work with PCI devices, which currently includes
+// GPUs, NICs, and NPUs. It may later include storage devices as well.
 amdcuid_status_t PciUtil::read_pci_config_space(std::string bdf,
                                                 uint8_t *buffer,
                                                 size_t buffer_size,
@@ -71,26 +71,35 @@ amdcuid_status_t PciUtil::read_pci_config_space(std::string bdf,
   }
 
   config_file.seekg(0, std::ios::end);
-  int length = config_file.tellg();
+  std::ifstream::pos_type length = config_file.tellg();
+  if (length < 0) {
+    config_file.close();
+    return AMDCUID_STATUS_PCI_ERROR;
+  }
   config_file.seekg(0, std::ios::beg);
+  if (!config_file) {
+    config_file.close();
+    return AMDCUID_STATUS_PCI_ERROR;
+  }
+
+  if (static_cast<std::ifstream::pos_type>(offset) + buffer_size > length) {
+    config_file.close();
+    return AMDCUID_STATUS_PCI_ERROR;
+  }
 
   config_file.seekg(offset, std::ios::beg);
+  if (!config_file) {
+    config_file.close();
+    return AMDCUID_STATUS_PCI_ERROR;
+  }
+
   config_file.read(reinterpret_cast<char *>(buffer), buffer_size);
-  int err = errno;
-  if (config_file.bad()) {
+  if (config_file.fail() || static_cast<size_t>(config_file.gcount()) !=
+                                buffer_size) {
     config_file.close();
     return AMDCUID_STATUS_PCI_ERROR;
   }
   return AMDCUID_STATUS_SUCCESS;
-}
-
-// Helper to check if a handle has non-zero bytes
-static bool is_pci_handle_nonzero(const amdcuid_id_t &handle) {
-  for (int i = 0; i < 16; ++i) {
-    if (handle.bytes[i] != 0)
-      return true;
-  }
-  return false;
 }
 
 // iterate capabilities list to find the relevant capability

--- a/projects/cuid/lib/src/pci_util.cc
+++ b/projects/cuid/lib/src/pci_util.cc
@@ -21,123 +21,198 @@
  */
 
 #include "pci_util.h"
-#include "include/amd_cuid.h"
-#include "cuid_util.h"
 #include "cuid_device.h"
 #include "cuid_device_manager.h"
 #include "cuid_gpu.h"
 #include "cuid_nic.h"
+#include "cuid_util.h"
+#include "include/amd_cuid.h"
 #include <cstring>
 #include <fstream>
-#include <sstream>
 #include <iostream>
+#include <sstream>
 #include <unistd.h>
 
 // Endianness conversion functions
 uint16_t PciUtil::le16_to_be16(uint16_t value) {
-    return ((value & 0x00FF) << 8) | ((value & 0xFF00) >> 8);
+  return ((value & 0x00FF) << 8) | ((value & 0xFF00) >> 8);
 }
 
 uint64_t PciUtil::le64_to_be64(uint64_t value) {
-    return ((value & 0x00000000000000FFULL) << 56) |
-           ((value & 0x000000000000FF00ULL) << 40) |
-           ((value & 0x0000000000FF0000ULL) << 24) |
-           ((value & 0x00000000FF000000ULL) << 8)  |
-           ((value & 0x000000FF00000000ULL) >> 8)  |
-           ((value & 0x0000FF0000000000ULL) >> 24) |
-           ((value & 0x00FF000000000000ULL) >> 40) |
-           ((value & 0xFF00000000000000ULL) >> 56);
+  return ((value & 0x00000000000000FFULL) << 56) |
+         ((value & 0x000000000000FF00ULL) << 40) |
+         ((value & 0x0000000000FF0000ULL) << 24) |
+         ((value & 0x00000000FF000000ULL) << 8) |
+         ((value & 0x000000FF00000000ULL) >> 8) |
+         ((value & 0x0000FF0000000000ULL) >> 24) |
+         ((value & 0x00FF000000000000ULL) >> 40) |
+         ((value & 0xFF00000000000000ULL) >> 56);
 }
 
-// function should only work with PCI devices, which so far includes GPUs and NICs. May later include NPU and storage.
-amdcuid_status_t PciUtil::read_pci_config_space(std::string bdf, uint8_t *buffer, size_t buffer_size, uint16_t offset) {
-    if (geteuid() != 0){
-        return AMDCUID_STATUS_PERMISSION_DENIED;
-    }
-    if (bdf.empty() || !buffer || buffer_size == 0) return AMDCUID_STATUS_INVALID_ARGUMENT;
+// function should only work with PCI devices, which so far includes GPUs and
+// NICs. May later include NPU and storage.
+amdcuid_status_t PciUtil::read_pci_config_space(std::string bdf,
+                                                uint8_t *buffer,
+                                                size_t buffer_size,
+                                                uint16_t offset) {
+  if (geteuid() != 0) {
+    return AMDCUID_STATUS_PERMISSION_DENIED;
+  }
+  if (bdf.empty() || !buffer || buffer_size == 0)
+    return AMDCUID_STATUS_INVALID_ARGUMENT;
 
-    std::string pci_config_path = "/sys/bus/pci/devices/" + bdf + "/config";
+  std::string pci_config_path = "/sys/bus/pci/devices/" + bdf + "/config";
 
-    // Read the PCI config space
-    std::ifstream config_file(pci_config_path, std::ios::binary);
-    if (!config_file){
-        config_file.close();
-        return AMDCUID_STATUS_PCI_ERROR;
-    }
+  // Read the PCI config space
+  std::ifstream config_file(pci_config_path, std::ios::binary);
+  if (!config_file) {
+    config_file.close();
+    return AMDCUID_STATUS_PCI_ERROR;
+  }
 
-    config_file.seekg(0, std::ios::end);
-    int length = config_file.tellg();
-    config_file.seekg(0, std::ios::beg);
+  config_file.seekg(0, std::ios::end);
+  int length = config_file.tellg();
+  config_file.seekg(0, std::ios::beg);
 
-    config_file.seekg(offset, std::ios::beg);
-    config_file.read(reinterpret_cast<char*>(buffer), buffer_size);
-    int err = errno;
-    if (config_file.bad())
-    {
-        config_file.close();
-        return AMDCUID_STATUS_PCI_ERROR;
-    }
-    return AMDCUID_STATUS_SUCCESS;
+  config_file.seekg(offset, std::ios::beg);
+  config_file.read(reinterpret_cast<char *>(buffer), buffer_size);
+  int err = errno;
+  if (config_file.bad()) {
+    config_file.close();
+    return AMDCUID_STATUS_PCI_ERROR;
+  }
+  return AMDCUID_STATUS_SUCCESS;
 }
 
 // Helper to check if a handle has non-zero bytes
-static bool is_pci_handle_nonzero(const amdcuid_id_t& handle) {
-    for (int i = 0; i < 16; ++i) {
-        if (handle.bytes[i] != 0) return true;
-    }
-    return false;
+static bool is_pci_handle_nonzero(const amdcuid_id_t &handle) {
+  for (int i = 0; i < 16; ++i) {
+    if (handle.bytes[i] != 0)
+      return true;
+  }
+  return false;
 }
 
 // iterate capabilities list to find the relevant capability
-amdcuid_status_t PciUtil::get_pci_cap_offset(std::string bdf, uint32_t cap_id, uint16_t &offset)
-{
-    if (geteuid() != 0){
-        return AMDCUID_STATUS_PERMISSION_DENIED;
-    }
-    if (bdf.empty()) return AMDCUID_STATUS_INVALID_ARGUMENT;
+amdcuid_status_t PciUtil::get_pci_dsn_cap_offset(std::string bdf,
+                                                 uint16_t &offset) {
+  if (geteuid() != 0) {
+    return AMDCUID_STATUS_PERMISSION_DENIED;
+  }
+  if (bdf.empty())
+    return AMDCUID_STATUS_INVALID_ARGUMENT;
 
-    // Get the whole PCI config space header
-    uint8_t config_space[4096] = {0};
-    amdcuid_status_t status = read_pci_config_space(bdf, config_space, 4096, 0);
-    if (status != AMDCUID_STATUS_SUCCESS)
-    {
-        return status;
-    }
+  // Get the whole PCI config space header
+  uint8_t config_space[4096] = {0};
+  amdcuid_status_t status = read_pci_config_space(bdf, config_space, 4096, 0);
+  if (status != AMDCUID_STATUS_SUCCESS) {
+    return status;
+  }
 
-    // Device Serial Number (cap_id 0x0003) is a PCIe Extended Capability.
-    // Traverse the extended capability list starting at offset 0x100.
-    uint16_t cap_ptr = 0x100;
-    for (size_t hops = 0; hops < 1024; ++hops) {
-        if (cap_ptr < 0x100 || cap_ptr + 3 >= sizeof(config_space)) {
-            return AMDCUID_STATUS_UNSUPPORTED;
-        }
+// Device Serial Number (cap_id 0x0003) is a PCIe Extended Capability.
+#define dsn_cap_id 0x0003 // PCIe DSN capability ID
 
-        uint32_t header =
-            static_cast<uint32_t>(config_space[cap_ptr]) |
-            (static_cast<uint32_t>(config_space[cap_ptr + 1]) << 8) |
-            (static_cast<uint32_t>(config_space[cap_ptr + 2]) << 16) |
-            (static_cast<uint32_t>(config_space[cap_ptr + 3]) << 24);
-
-        uint16_t cap_id_local = static_cast<uint16_t>(header & 0xFFFF);
-        uint16_t next_ptr = static_cast<uint16_t>((header >> 20) & 0x0FFF);
-
-        if (cap_id_local == static_cast<uint16_t>(cap_id)) {
-            offset = cap_ptr + 4;
-            return AMDCUID_STATUS_SUCCESS;
-        }
-
-        // End of list.
-        if (next_ptr == 0) {
-            break;
-        }
-
-        // Guard against malformed/cyclic lists.
-        if (next_ptr == cap_ptr) {
-            break;
-        }
-
-        cap_ptr = next_ptr;
+  // Traverse the extended capability list starting at offset 0x100.
+  uint16_t cap_ptr = 0x100;
+  for (size_t hops = 0; hops < 1024; ++hops) {
+    if (cap_ptr < 0x100 || cap_ptr + 3 >= sizeof(config_space)) {
+      return AMDCUID_STATUS_UNSUPPORTED;
     }
 
-    return AMDCUID_STATUS_UNSUPPORTED;
+    uint32_t header = static_cast<uint32_t>(config_space[cap_ptr]) |
+                      (static_cast<uint32_t>(config_space[cap_ptr + 1]) << 8) |
+                      (static_cast<uint32_t>(config_space[cap_ptr + 2]) << 16) |
+                      (static_cast<uint32_t>(config_space[cap_ptr + 3]) << 24);
+
+    uint16_t cap_id_local = static_cast<uint16_t>(header & 0xFFFF);
+    uint16_t next_ptr = static_cast<uint16_t>((header >> 20) & 0x0FFF);
+
+    if (cap_id_local == static_cast<uint16_t>(dsn_cap_id)) {
+      offset = cap_ptr + 4;
+      return AMDCUID_STATUS_SUCCESS;
+    }
+
+    // End of list.
+    if (next_ptr == 0) {
+      break;
+    }
+
+    // Guard against malformed/cyclic lists.
+    if (next_ptr == cap_ptr) {
+      break;
+    }
+
+    cap_ptr = next_ptr;
+  }
+
+  return AMDCUID_STATUS_UNSUPPORTED;
+}
+
+amdcuid_status_t PciUtil::get_pci_vsec_cap_offset(std::string bdf,
+                                                  uint16_t &offset) {
+  if (geteuid() != 0) {
+    return AMDCUID_STATUS_PERMISSION_DENIED;
+  }
+  if (bdf.empty())
+    return AMDCUID_STATUS_INVALID_ARGUMENT;
+
+  // Get the whole PCI config space header
+  uint8_t config_space[4096] = {0};
+  amdcuid_status_t status = read_pci_config_space(bdf, config_space, 4096, 0);
+  if (status != AMDCUID_STATUS_SUCCESS) {
+    return status;
+  }
+
+  // Vendor-Specific Extended Capability (cap_id 0x000B) is a PCIe Extended
+  // Capability.
+  const uint16_t vsec_cap_id = 0x0b; // PCIe VSEC capability ID
+
+  // Traverse the extended capability list starting at offset 0x100.
+  uint16_t cap_ptr = 0x100;
+  for (size_t hops = 0; hops < 1024; ++hops) {
+    if (cap_ptr < 0x100 || cap_ptr + 3 >= sizeof(config_space)) {
+      return AMDCUID_STATUS_UNSUPPORTED;
+    }
+
+    uint32_t cap_header =
+        static_cast<uint32_t>(config_space[cap_ptr]) |
+        (static_cast<uint32_t>(config_space[cap_ptr + 1]) << 8) |
+        (static_cast<uint32_t>(config_space[cap_ptr + 2]) << 16) |
+        (static_cast<uint32_t>(config_space[cap_ptr + 3]) << 24);
+
+    uint16_t cap_id_local = static_cast<uint16_t>(cap_header & 0xFFFF);
+    uint16_t next_ptr = static_cast<uint16_t>((cap_header >> 20) & 0x0FFF);
+
+    if (cap_id_local == vsec_cap_id) {
+      // check vsec header now for correct fields
+      uint32_t vsec_header =
+          static_cast<uint32_t>(config_space[cap_ptr + 4]) |
+          (static_cast<uint32_t>(config_space[cap_ptr + 5]) << 8) |
+          (static_cast<uint32_t>(config_space[cap_ptr + 6]) << 16) |
+          (static_cast<uint32_t>(config_space[cap_ptr + 7]) << 24);
+
+      // if the VSEC has the required length for our fingerprint, return the
+      // offset
+      uint16_t vsec_length =
+          static_cast<uint16_t>((vsec_header >> 20) & 0x0FFF);
+      if (vsec_length >= 8) {
+        offset = cap_ptr + 8;
+        return AMDCUID_STATUS_SUCCESS;
+      }
+    }
+
+    // End of list.
+    if (next_ptr == 0) {
+      break;
+    }
+
+    // Guard against malformed/cyclic lists.
+    if (next_ptr == cap_ptr) {
+      break;
+    }
+
+    cap_ptr = next_ptr;
+  }
+
+  return AMDCUID_STATUS_UNSUPPORTED;
 }

--- a/projects/cuid/lib/src/pci_util.cc
+++ b/projects/cuid/lib/src/pci_util.cc
@@ -82,7 +82,7 @@ amdcuid_status_t PciUtil::read_pci_config_space(std::string bdf,
     return AMDCUID_STATUS_PCI_ERROR;
   }
 
-  if (static_cast<std::ifstream::pos_type>(offset) + buffer_size > length) {
+  if (static_cast<std::ifstream::pos_type>(offset + buffer_size) > length) {
     config_file.close();
     return AMDCUID_STATUS_PCI_ERROR;
   }
@@ -94,8 +94,8 @@ amdcuid_status_t PciUtil::read_pci_config_space(std::string bdf,
   }
 
   config_file.read(reinterpret_cast<char *>(buffer), buffer_size);
-  if (config_file.fail() || static_cast<size_t>(config_file.gcount()) !=
-                                buffer_size) {
+  if (config_file.fail() ||
+      static_cast<size_t>(config_file.gcount()) != buffer_size) {
     config_file.close();
     return AMDCUID_STATUS_PCI_ERROR;
   }
@@ -118,8 +118,8 @@ amdcuid_status_t PciUtil::get_pci_dsn_cap_offset(std::string bdf,
     return status;
   }
 
-// Device Serial Number (cap_id 0x0003) is a PCIe Extended Capability.
-#define dsn_cap_id 0x0003 // PCIe DSN capability ID
+  // Device Serial Number (cap_id 0x0003) is a PCIe Extended Capability.
+  const uint16_t dsn_cap_id = 0x0003; // PCIe DSN capability ID
 
   // Traverse the extended capability list starting at offset 0x100.
   uint16_t cap_ptr = 0x100;
@@ -179,7 +179,7 @@ amdcuid_status_t PciUtil::get_pci_vsec_cap_offset(std::string bdf,
   // Traverse the extended capability list starting at offset 0x100.
   uint16_t cap_ptr = 0x100;
   for (size_t hops = 0; hops < 1024; ++hops) {
-    if (cap_ptr < 0x100 || cap_ptr + 3 >= sizeof(config_space)) {
+    if (cap_ptr < 0x100 || cap_ptr + 7 >= sizeof(config_space)) {
       return AMDCUID_STATUS_UNSUPPORTED;
     }
 
@@ -210,13 +210,8 @@ amdcuid_status_t PciUtil::get_pci_vsec_cap_offset(std::string bdf,
       }
     }
 
-    // End of list.
-    if (next_ptr == 0) {
-      break;
-    }
-
-    // Guard against malformed/cyclic lists.
-    if (next_ptr == cap_ptr) {
+    // Guard against malformed/cyclic lists or end of list.
+    if (next_ptr == 0 || next_ptr == cap_ptr) {
       break;
     }
 

--- a/projects/cuid/lib/src/pci_util.h
+++ b/projects/cuid/lib/src/pci_util.h
@@ -30,12 +30,18 @@
 
 class PciUtil {
 public:
-    static amdcuid_status_t read_pci_config_space(std::string bdf, uint8_t *buffer, size_t buffer_size, uint16_t offset);
-    static amdcuid_status_t get_pci_cap_offset(std::string bdf, uint32_t cap_id, uint16_t &offset);
+  static amdcuid_status_t read_pci_config_space(std::string bdf,
+                                                uint8_t *buffer,
+                                                size_t buffer_size,
+                                                uint16_t offset);
+  static amdcuid_status_t get_pci_dsn_cap_offset(std::string bdf,
+                                                 uint16_t &offset);
+  static amdcuid_status_t get_pci_vsec_cap_offset(std::string bdf,
+                                                  uint16_t &offset);
 
-    // Endianness conversion utilities
-    static uint16_t le16_to_be16(uint16_t value);
-    static uint64_t le64_to_be64(uint64_t value);
+  // Endianness conversion utilities
+  static uint16_t le16_to_be16(uint16_t value);
+  static uint64_t le64_to_be64(uint64_t value);
 };
 
 #endif // PCI_UTIL_H


### PR DESCRIPTION
## Motivation
CUID design called for adding a fallback capability in addition to searching for DSN in the PCI configuration space. Fallback capability helps to ensure that CUIDs can be produced for a wider range of devices which may not have a DSN defined in the PCI config space.

## Technical Details
Added search through PCIe config space extended capabilities for Vendor Specific section to extract device information for use in creating CUIDs.

## JIRA ID
N/A

## Test Plan
run CUID generation on devices where Vendor Specified section was defined and ensured that hardware fingerprint matched was was shown through a hexdump of the device config space.

## Test Result
confirmed matching hardware fingerprint and successful CUID generation.

## Submission Checklist
N/A