### PR TITLE
[rocjitsu] Skip SHT_NOBITS sections when loading ELF code objects

### DIFF
--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.cpp
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.cpp
@@ -234,7 +234,7 @@ void AmdGpuCodeObject::load_sections(std::ifstream &elf_file) {
   }
 
   for (const auto &shdr : section_hdrs) {
-    if (shdr.sh_type == SHT_NULL)
+    if (shdr.sh_type == SHT_NULL || shdr.sh_type == SHT_NOBITS)
       continue;
     if (shdr.sh_name >= shstrtab_data.size())
       continue;

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
@@ -85,6 +85,7 @@ inline constexpr uint32_t SHT_PROGBITS = 1;
 inline constexpr uint32_t SHT_SYMTAB = 2;
 inline constexpr uint32_t SHT_STRTAB = 3;
 inline constexpr uint32_t SHT_NOTE = 7;
+inline constexpr uint32_t SHT_NOBITS = 8;  // ELF spec: section occupies no file space (e.g. .bss)
 inline constexpr uint32_t SHT_DYNSYM = 11;
 
 /// @brief AMDGPU vendor specific notes for Code Object V3.


### PR DESCRIPTION
SHT_NOBITS sections (type 8, e.g. .bss) occupy no space in the ELF file but have a non-zero sh_size. Attempting to read sh_size bytes at sh_offset reads past the intended section data, producing garbage or crashes. Found while loading HIP kernels compiled with amdclang++ — some compilations produce ELFs with .bss sections that triggered invalid reads in the code object loader. Skip SHT_NOBITS sections alongside SHT_NULL during code object loading. Testing: would require an ELF with an SHT_NOBITS section. The existing HIP test kernels may or may not produce one depending on compiler flags. Not added in this commit. See ELF specification, Section Header Table:  https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.sheader.html
