### PR TITLE
Update TheRock reference to (a3e68276)

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 702d15844f84a3a8401a24185bd4131008f0e640 # 2026-04-16 commit
+          ref: a3e68276d1c2e7d6ad240f7b2b2f0091dd1ee72f # 2026-04-20 commit
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 702d15844f84a3a8401a24185bd4131008f0e640 # 2026-04-16 commit
+          ref: a3e68276d1c2e7d6ad240f7b2b2f0091dd1ee72f # 2026-04-20 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 702d15844f84a3a8401a24185bd4131008f0e640 # 2026-04-16 commit
+          ref: a3e68276d1c2e7d6ad240f7b2b2f0091dd1ee72f # 2026-04-20 commit
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 702d15844f84a3a8401a24185bd4131008f0e640 # 2026-04-16 commit
+          ref: a3e68276d1c2e7d6ad240f7b2b2f0091dd1ee72f # 2026-04-20 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-rccl-test-packages-single-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-single-node.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 702d15844f84a3a8401a24185bd4131008f0e640 # 2026-04-16 commit
+          ref: a3e68276d1c2e7d6ad240f7b2b2f0091dd1ee72f # 2026-04-20 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 702d15844f84a3a8401a24185bd4131008f0e640 # 2026-04-16 commit
+          ref: a3e68276d1c2e7d6ad240f7b2b2f0091dd1ee72f # 2026-04-20 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 702d15844f84a3a8401a24185bd4131008f0e640 # 2026-04-16 commit
+          ref: a3e68276d1c2e7d6ad240f7b2b2f0091dd1ee72f # 2026-04-20 commit
 
       - name: Setting up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0


### PR DESCRIPTION
## Motivation

Bump TheRock ref from `702d158` (2026-04-16) to `a3e68276` (2026-04-20).

Used as a bisection signal to determine whether the CI failures observed on rocm-systems#4211 are caused by the TheRock ref change itself or by the code changes in that PR. If this PR exhibits the same Linux build / Windows shard 4 failures, the failures are not specific to #4211's code.

## Technical Details

Standard ref bump applied to the same 7 workflow files updated by #5117:
- `.github/workflows/therock-ci-linux.yml`
- `.github/workflows/therock-ci-windows.yml`
- `.github/workflows/therock-rccl-ci-linux.yml`
- `.github/workflows/therock-rccl-test-packages-multi-node.yml`
- `.github/workflows/therock-rccl-test-packages-single-node.yml`
- `.github/workflows/therock-test-component.yml`
- `.github/workflows/therock-test-packages.yml`

`a3e68276` is the merge commit of ROCm/TheRock#4535.

## JIRA ID

N/A

## Test Plan

CI run only.

## Test Result

To be filled in after CI runs.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.