### PR TITLE
clr: Use same scheduling logic as parent graph for child graph

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -198,6 +198,8 @@ void Graph::ScheduleOneNode(Node start, int stream_id) {
     if (cur->GetType() == hipGraphNodeTypeGraph) {
       auto cgn   = reinterpret_cast<hip::ChildGraphNode*>(cur);
       auto child = cgn->GetChildGraph();
+      // Use same scheduling logic(classic or segment) as parent graph for child graph
+      child->SetSegmentScheduling(use_segment_scheduling_);
       hipError_t status = child->ScheduleNodes();
       (void)status;
       max_streams_ = std::max(max_streams_, child->max_streams_);

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -635,6 +635,8 @@ class Graph {
   std::vector<std::pair<Node, Node>> GetEdges() const;
   /// Returns whether segment scheduling is enabled for this graph
   bool IsSegmentSchedulingEnabled() const { return use_segment_scheduling_; }
+  // Enable or disable segment scheduling for this graph
+  void SetSegmentScheduling(bool segmentScheduling) {use_segment_scheduling_ = segmentScheduling;}
   // returns the original graph ptr if cloned
   const Graph* getOriginalGraph() const { return pOriginalGraph_; }
   // Add user obj resource to graph

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -388,6 +388,9 @@ graph:
   Unit_hipGraphAddChildGraphNode_CmplxNstGrph_MultGPU:
     <<: *level_2
     tags: [multigpu, node]
+  Unit_hipGraphAddChildGraphNode_CmplxGrph_SchedLogic:
+    <<: *level_2
+    tags: [node]
   Unit_hipGraphNodeGetType_Negative:
     <<: *level_2
     tags: [query]

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddChildGraphNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddChildGraphNode.cc
@@ -46,6 +46,9 @@ Functional:
     contains 3 independent kernel nodes and graph3 contains 3 independent
     memcpy d2h nodes. Graph1, graph2 and graph3 are added as child nodes in
     graph4. Graph4 is validated for functionality.
+18. Functional Test to verify that for a complex graph but having
+    non-Complex child graphs, same scheduling logic (classic or segment)
+    is used for main and child graphs
 
 Negative:
 1. Pass nullptr to graph node
@@ -59,6 +62,12 @@ Negative:
 #include <hip_test_kernels.hh>
 
 #define TEST_LOOP_SIZE 50
+
+__global__ void dummy_kernel(float* data) {
+  int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  data[idx] = data[idx] * 2.0f;
+}
+
 /*
 This testcase verifies the negative scenarios of
 hipGraphAddChildGraphNode API
@@ -1119,4 +1128,122 @@ HIP_TEST_CASE(Unit_hipGraphAddChildGraphNode_CmplxNstGrph_MultGPU) {
   delete[] graphExec;
   delete[] streamForGraph;
   delete[] graph;
+}
+
+/**
+ Complex Scenario: This testcase verifies that for a complex graph
+ (with >16 segments and avg# of nodes per segment >8) but having
+ non-Complex child graphs, same scheduling logic (classic or segment)
+ is used for main and child graphs
+ */
+HIP_TEST_CASE(Unit_hipGraphAddChildGraphNode_CmplxGrph_SchedLogic) {
+  // Allocate device memory for dummy operations
+  float* d_data;
+  size_t data_size = 256 * sizeof(float);
+  HIP_CHECK(hipMalloc(&d_data, data_size));
+
+  hipKernelNodeParams params = {};
+  void* args[] = {&d_data};
+  params.func = (void*)dummy_kernel;
+  params.gridDim = dim3(1, 1, 1);
+  params.blockDim = dim3(256, 1, 1);
+  params.sharedMemBytes = 0;
+  params.kernelParams = args;
+  params.extra = nullptr;
+
+  // Create child graphs
+  hipGraph_t child_graph[9];
+  hipGraphNode_t child_graph_node[9];
+  for (int i = 0; i < 9; i++) {
+    HIP_CHECK(hipGraphCreate(&child_graph[i], 0));
+    HIP_CHECK(hipGraphAddKernelNode(&child_graph_node[i], child_graph[i], nullptr, 0, &params));
+  }
+
+  // Create main graph with sequential dependencies
+  hipGraph_t main_graph;
+  HIP_CHECK(hipGraphCreate(&main_graph, 0));
+  hipGraphNode_t main_graph_node[18];
+  hipGraphNode_t deps[1];
+
+  // Kernel node
+  HIP_CHECK(hipGraphAddKernelNode(&main_graph_node[0], main_graph, nullptr, 0, &params));
+  deps[0] = {main_graph_node[0]};
+  HIP_CHECK(hipGraphAddKernelNode(&main_graph_node[1], main_graph, deps, 1, &params));
+
+  // Child graph node
+  deps[0] = {main_graph_node[1]};
+  HIP_CHECK(hipGraphAddChildGraphNode(&main_graph_node[2], main_graph, deps, 1, child_graph[0]));
+
+   // Kernel node
+  deps[0] = {main_graph_node[2]};
+  HIP_CHECK(hipGraphAddKernelNode(&main_graph_node[3], main_graph, deps, 1, &params));
+
+  // Child graph node
+  deps[0] = {main_graph_node[3]};
+  HIP_CHECK(hipGraphAddChildGraphNode(&main_graph_node[4], main_graph, deps, 1, child_graph[1]));
+
+  // Kernel node
+  deps[0] = {main_graph_node[4]};
+  HIP_CHECK(hipGraphAddKernelNode(&main_graph_node[5], main_graph, deps, 1, &params));
+  deps[0] = {main_graph_node[5]};
+  HIP_CHECK(hipGraphAddKernelNode(&main_graph_node[6], main_graph, deps, 1, &params));
+
+  // Child graph node
+  deps[0] = {main_graph_node[6]};
+  HIP_CHECK(hipGraphAddChildGraphNode(&main_graph_node[7], main_graph, deps, 1, child_graph[2]));
+  deps[0] = {main_graph_node[7]};
+  HIP_CHECK(hipGraphAddChildGraphNode(&main_graph_node[8], main_graph, deps, 1, child_graph[3]));
+  deps[0] = {main_graph_node[8]};
+  HIP_CHECK(hipGraphAddChildGraphNode(&main_graph_node[9], main_graph, deps, 1, child_graph[4]));
+
+  // Kernel node
+  deps[0] = {main_graph_node[9]};
+  HIP_CHECK(hipGraphAddKernelNode(&main_graph_node[10], main_graph, deps, 1, &params));
+
+  // Child graph node
+  deps[0] = {main_graph_node[10]};
+  HIP_CHECK(hipGraphAddChildGraphNode(&main_graph_node[11], main_graph, deps, 1, child_graph[5]));
+
+  // Kernel node
+  deps[0] = {main_graph_node[11]};
+  HIP_CHECK(hipGraphAddKernelNode(&main_graph_node[12], main_graph, deps, 1, &params));
+
+  // Child graph node
+  deps[0] = {main_graph_node[12]};
+  HIP_CHECK(hipGraphAddChildGraphNode(&main_graph_node[13], main_graph, deps, 1, child_graph[6]));
+
+  // Kernel node
+  deps[0] = {main_graph_node[13]};
+  HIP_CHECK(hipGraphAddKernelNode(&main_graph_node[14], main_graph, deps, 1, &params));
+
+  // Child graph node
+  deps[0] = {main_graph_node[14]};
+  HIP_CHECK(hipGraphAddChildGraphNode(&main_graph_node[15], main_graph, deps, 1, child_graph[7]));
+  deps[0] = {main_graph_node[15]};
+  HIP_CHECK(hipGraphAddChildGraphNode(&main_graph_node[16], main_graph, deps, 1, child_graph[8]));
+
+  // Kernel node
+  deps[0] = {main_graph_node[16]};
+  HIP_CHECK(hipGraphAddKernelNode(&main_graph_node[17], main_graph, deps, 1, &params));
+
+  // Instantiate the graph
+  hipGraphExec_t graph_exec;
+  HIP_CHECK(hipGraphInstantiate(&graph_exec, main_graph, nullptr, nullptr, 0));
+
+  // Launch graph
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+  HIP_CHECK(hipGraphLaunch(graph_exec, stream)); // shouldn't cause any segfault here
+
+  // Synchronize stream
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  // Cleanup
+  HIP_CHECK(hipGraphExecDestroy(graph_exec));
+  HIP_CHECK(hipGraphDestroy(main_graph));
+  for (int i = 0; i < 9; i++) {
+    HIP_CHECK(hipGraphDestroy(child_graph[i]));
+  }
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipFree(d_data));
 }


### PR DESCRIPTION
## Motivation
https://github.com/ROCm/rocm-systems/pull/1372 had enabled  segment scheduling for Graphs.
For Complex graph (with >16 segments and avg# of nodes per segment >8) but having Non-Complex child graphs, during graph instantiation phase currently it sets to use classic scheduling logic for main graph(being complex) & segment scheduling logic for child graphs (being non-complex).

But during graph launch phase, entire graph is launched only based on main graph's scheduling logic (classic in this case).
This causes segfault in child graph during execution, as member stream_id_ is set to initial value -1.

Ideally after initial analysis of the entire graph (including the child graphs) if  classic scheduling logic is chosen, then even for child graphs classic scheduling logic should be used.

## Technical Details
Adds new member function to set segment scheduling logic flag in Graph.
Uses the function to set same scheduling logic as parent graph for child graphs.
Added a catch test to validate this change.


## JIRA ID

ROCM-20819

## Test Plan
Verified the fix locally by running JAX tests.
Also added a catch test to validate this change.

## Test Result

Both passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
