### PR TITLE
Revert "[CLR][HIP][NFCI] Simplify variable usage in hipLaunchKernelGGL"

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
@@ -67,9 +67,6 @@ size_t amd_dbgapi_get_build_id();
 #include <cmath>
 #include <cstdint>
 #include <tuple>
-#include <array>
-#include <utility>
-#include <type_traits>
 #else
 #include <math.h>
 #include <stdint.h>
@@ -168,14 +165,15 @@ __host__ inline void* __get_dynamicgroupbaseptr() { return nullptr; }
 
 typedef int hipLaunchParm;
 
-template <typename... Formals, typename... Actuals>
-std::tuple<Formals...> validateArgsCountType(void (*kernel)(Formals...),
-                                             Actuals... actuals) {
-  static_assert(sizeof...(Formals) == sizeof...(Actuals), "Argument Count Mismatch");
-  return {std::move(actuals)...};
-}
+template <std::size_t n, typename... Ts,
+          typename std::enable_if<n == sizeof...(Ts)>::type* = nullptr>
+void pArgs(const std::tuple<Ts...>&, void*) {}
 
-template <typename T> constexpr bool validateArgType() {
+template <std::size_t n, typename... Ts,
+          typename std::enable_if<n != sizeof...(Ts)>::type* = nullptr>
+void pArgs(const std::tuple<Ts...>& formals, void** _vargs) {
+  using T = typename std::tuple_element<n, std::tuple<Ts...>>::type;
+
   static_assert(!std::is_reference<T>{},
                 "A __global__ function cannot have a reference as one of its "
                 "arguments.");
@@ -184,38 +182,30 @@ template <typename T> constexpr bool validateArgType() {
                 "Only TriviallyCopyable types can be arguments to a __global__ "
                 "function");
 #endif
-  return !std::is_reference<T>{} && std::is_trivially_copyable<T>{};
+  _vargs[n] = const_cast<void*>(reinterpret_cast<const void*>(&std::get<n>(formals)));
+  return pArgs<n + 1>(formals, _vargs);
 }
 
-template <typename... Ts> constexpr bool validateArgs(void (*)(Ts...)) {
-  return (validateArgType<Ts>() && ... && true);
-}
-
-template <typename... Ts, size_t... Is>
-std::array<void*, sizeof...(Ts)> pArgs(std::tuple<Ts...>& formals,
-                                       __hip_internal::index_sequence<Is...>) {
-  return {(static_cast<void*>(&std::get<Is>(formals)))...};
-}
-
-template <typename... Ts> std::array<void*, sizeof...(Ts)> pArgs(std::tuple<Ts...>& formals) {
-  return pArgs(formals, __hip_internal::make_index_sequence<sizeof...(Ts)>());
+template <typename... Formals, typename... Actuals>
+std::tuple<Formals...> validateArgsCountType(void (*kernel)(Formals...),
+                                             std::tuple<Actuals...>(actuals)) {
+  static_assert(sizeof...(Formals) == sizeof...(Actuals), "Argument Count Mismatch");
+  std::tuple<Formals...> to_formals{std::move(actuals)};
+  return to_formals;
 }
 
 #if defined(HIP_TEMPLATE_KERNEL_LAUNCH)
 template <typename... Args, typename F = void (*)(Args...)>
 void hipLaunchKernelGGL(F kernel, const dim3& numBlocks, const dim3& dimBlocks,
                         std::uint32_t sharedMemBytes, hipStream_t stream, Args... args) {
-  validateArgs(kernel);
-  auto k = reinterpret_cast<void*>(kernel);
+  constexpr size_t count = sizeof...(Args);
+  auto tup_ = std::tuple<Args...>{args...};
+  auto tup = validateArgsCountType(kernel, tup_);
+  void* _Args[count];
+  pArgs<0>(tup, _Args);
 
-  if constexpr (std::is_same_v<F, void (*)(Args...)>) {
-    std::array<void*, sizeof...(Args)> ptrArgsArr{static_cast<void*>(&args)...};
-    hipLaunchKernel(k, numBlocks, dimBlocks, ptrArgsArr.data(), sharedMemBytes, stream);
-  } else {
-    auto formals = validateArgsCountType(kernel, args...);
-    auto ptrArgsArr = pArgs(formals);
-    hipLaunchKernel(k, numBlocks, dimBlocks, ptrArgsArr.data(), sharedMemBytes, stream);
-  }
+  auto k = reinterpret_cast<void*>(kernel);
+  hipLaunchKernel(k, numBlocks, dimBlocks, _Args, sharedMemBytes, stream);
 }
 #else
 #define hipLaunchKernelGGLInternal(kernelName, numBlocks, numThreads, memPerBlock, streamId, ...)  \

--- a/projects/hip/include/hip/hip_ext.h
+++ b/projects/hip/include/hip/hip_ext.h
@@ -10,7 +10,6 @@
 #if defined(__cplusplus)
 #include <tuple>
 #include <type_traits>
-#include <array>
 #endif
 /** @addtogroup Execution Execution Control
  *  @{
@@ -127,19 +126,15 @@ inline void hipExtLaunchKernelGGL(F kernel, const dim3& numBlocks, const dim3& d
                                   std::uint32_t sharedMemBytes, hipStream_t stream,
                                   hipEvent_t startEvent, hipEvent_t stopEvent, std::uint32_t flags,
                                   Args... args) {
-  validateArgs(kernel);
-  auto k = reinterpret_cast<void*>(kernel);
+  constexpr size_t count = sizeof...(Args);
+  auto tup_ = std::tuple<Args...>{args...};
+  auto tup = validateArgsCountType(kernel, tup_);
+  void* _Args[count];
+  pArgs<0>(tup, _Args);
 
-  if constexpr (std::is_same_v<F, void (*)(Args...)>) {
-    std::array<void*, sizeof...(Args)> ptrArgsArr{static_cast<void*>(&args)...};
-    hipExtLaunchKernel(k, numBlocks, dimBlocks, ptrArgsArr.data(), sharedMemBytes, stream,
-                       startEvent, stopEvent, (int)flags);
-  } else {
-    auto formals = validateArgsCountType(kernel, args...);
-    auto ptrArgsArr = pArgs(formals);
-    hipExtLaunchKernel(k, numBlocks, dimBlocks, ptrArgsArr.data(), sharedMemBytes, stream,
-                       startEvent, stopEvent, (int)flags);
-  }
+  auto k = reinterpret_cast<void*>(kernel);
+  hipExtLaunchKernel(k, numBlocks, dimBlocks, _Args, sharedMemBytes, stream, startEvent, stopEvent,
+                     (int)flags);
 }
 
 #endif  // defined(__cplusplus)


### PR DESCRIPTION
## Motivation

Reverts ROCm/rocm-systems#4185 due to the use of C++17 features in headers intended to be usable with C++11.

## Technical Details

Revert due to failure seen in building a sample. Need more time to investigate why its failing but for now we revert to unblock.

## JIRA ID

NA

## Test Plan

NA

## Test Result

NA

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.