### PR TITLE
hip-tests: Add level_0 fast mode to reduce emulator runtime

### DIFF
--- a/projects/hip-tests/catch/README.md
+++ b/projects/hip-tests/catch/README.md
@@ -125,7 +125,7 @@ Or use Catch2 tag filters:
 
 ### Writing level-aware tests with `isQuickLevel()`
 
-Tests that are slow in emulation environments can use `isQuickLevel()` to reduce their workload at `level_0` while preserving full coverage at higher levels. This function returns `true` when `HIP_TEST_LEVEL=level_0` is set.
+Tests that are slow in emulation environments can use `isQuickLevel()` to reduce their workload at `level_0` while preserving full coverage at higher levels. This function returns `true` when the active test level is `level_0` (set via `HIP_TEST_LEVEL` environment variable or `[level_0]` Catch2 tag filter).
 
 ```cpp
 #include <hip_test_common.hh>

--- a/projects/hip-tests/catch/README.md
+++ b/projects/hip-tests/catch/README.md
@@ -97,6 +97,66 @@ TEMPLATE_TEST_CASE(Unit_atomicExch_system_Positive_Peer_GPUs, int, float, double
 
 <b>Every newly added test should mandate adding an entry to the configuration file.</b>
 
+## Test Levels and Quick Mode (`level_0`)
+
+Tests are assigned a level in the YAML configuration (`level: 0` through `level: 4`). The level serves two purposes: it controls which tests are **selected** to run (via Catch2 tag filters), and it allows tests to **adjust their behavior** at runtime (e.g., reducing workload at lower levels).
+
+| Level | Use case | Typical runtime |
+|-------|----------|-----------------|
+| `level_0` | Quick smoke tests, emulation environments | Seconds per test |
+| `level_1` | Reserved for future use | — |
+| `level_2` | Standard test suite (default) | Minutes |
+| `level_3` | Reserved for future use | — |
+| `level_4` | Reserved for future use | — |
+
+### Running at a specific level
+
+Use the `HIP_TEST_LEVEL` environment variable:
+
+```bash
+HIP_TEST_LEVEL=level_0 ./MemoryTest1 "Unit_hipMemsetSync"
+```
+
+Or use Catch2 tag filters:
+
+```bash
+./MemoryTest1 "[level_0]"
+```
+
+### Writing level-aware tests with `isQuickLevel()`
+
+Tests that are slow in emulation environments can use `isQuickLevel()` to reduce their workload at `level_0` while preserving full coverage at higher levels. This function returns `true` when `HIP_TEST_LEVEL=level_0` is set.
+
+```cpp
+#include <hip_test_common.hh>
+
+HIP_TEST_CASE(Unit_hipMemsetSync) {
+  size_t N = isQuickLevel() ? 1024 : (1024 * 1024);
+  // ...
+}
+```
+
+#### Guidelines for `isQuickLevel()` trimming
+
+- **Prefer reducing iteration counts and buffer sizes** over skipping code paths, so the same API surface is exercised with less data.
+- **Call `isQuickLevel()` inside the test function**, not in global/static variable initializers. The test level is detected at runtime by the Catch2 listener, which runs after static initialization.
+- **Use reproducible seeds** when tests involve randomization. Log the seed and allow overriding (e.g., via `HIP_TEST_SEED`) so failures can be replayed.
+
+#### Example: reducing a memset size
+
+```cpp
+size_t numH = isQuickLevel() ? 256 : (1024 * 1024);
+size_t numW = isQuickLevel() ? 256 : (1024 * 1024);
+```
+
+#### Example: reducing GENERATE parameters
+
+```cpp
+auto size = GENERATE(isQuickLevel()
+    ? values({64, 256, 1024})
+    : values({64, 256, 1024, 65536, 1048576}));
+```
+
 ## Environment Variables
 - `HT_LOG_ENABLE` : This is for debugging the HIP Test Framework itself. Setting it to 1, all `LogPrintf` will be printed on screen
 

--- a/projects/hip-tests/catch/include/hip_test_common.hh
+++ b/projects/hip-tests/catch/include/hip_test_common.hh
@@ -19,6 +19,7 @@
 #include <cstdlib>
 #include <thread>
 #include "hip_test_features.hh"
+#include "hip_test_params.hh"
 
 #ifdef ENABLE_YAML_TAGS
 #include "hip_test_config.hh"
@@ -39,13 +40,7 @@
  * Use this to reduce test parameters for faster execution.
  */
 inline bool isQuickLevel() {
-  static bool quick = false;
-  static std::once_flag flag;
-  std::call_once(flag, [] {
-    const char* level = std::getenv("HIP_TEST_LEVEL");
-    quick = (level && std::strcmp(level, "level_0") == 0);
-  });
-  return quick;
+  return TestParameterStore::instance().currentTestLevel == "level_0";
 }
 
 #if HT_LINUX

--- a/projects/hip-tests/catch/include/hip_test_common.hh
+++ b/projects/hip-tests/catch/include/hip_test_common.hh
@@ -34,6 +34,20 @@
 #define HIP_TEMPLATE_TEST_CASE(name, ...) TEMPLATE_TEST_CASE(#name, "", __VA_ARGS__)
 #endif
 
+/**
+ * @brief Check if running at quick level (level_0).
+ * Use this to reduce test parameters for faster execution.
+ */
+inline bool isQuickLevel() {
+  static bool quick = false;
+  static std::once_flag flag;
+  std::call_once(flag, [] {
+    const char* level = std::getenv("HIP_TEST_LEVEL");
+    quick = (level && std::strcmp(level, "level_0") == 0);
+  });
+  return quick;
+}
+
 #if HT_LINUX
 #include <sys/resource.h>
 #endif

--- a/projects/hip-tests/catch/include/memcpy1d_tests_common.hh
+++ b/projects/hip-tests/catch/include/memcpy1d_tests_common.hh
@@ -171,9 +171,11 @@ void MemcpyWithDirectionCommonTests(F memcpy_func, const hipStream_t kernel_stre
         std::bind(memcpy_func, _1, _2, _3, hipMemcpyDeviceToHost), kernel_stream);
   }
 
-  SECTION("Device to host with default kind") {
-    MemcpyDeviceToHostShell<should_synchronize>(
-        std::bind(memcpy_func, _1, _2, _3, hipMemcpyDefault), kernel_stream);
+  if (!isQuickLevel()) {
+    SECTION("Device to host with default kind") {
+      MemcpyDeviceToHostShell<should_synchronize>(
+          std::bind(memcpy_func, _1, _2, _3, hipMemcpyDefault), kernel_stream);
+    }
   }
 
   SECTION("Host to device") {
@@ -181,9 +183,11 @@ void MemcpyWithDirectionCommonTests(F memcpy_func, const hipStream_t kernel_stre
         std::bind(memcpy_func, _1, _2, _3, hipMemcpyHostToDevice), kernel_stream);
   }
 
-  SECTION("Host to device with default kind") {
-    MemcpyHostToDeviceShell<should_synchronize>(
-        std::bind(memcpy_func, _1, _2, _3, hipMemcpyDefault), kernel_stream);
+  if (!isQuickLevel()) {
+    SECTION("Host to device with default kind") {
+      MemcpyHostToDeviceShell<should_synchronize>(
+          std::bind(memcpy_func, _1, _2, _3, hipMemcpyDefault), kernel_stream);
+    }
   }
 
   SECTION("Host to host") {
@@ -191,9 +195,11 @@ void MemcpyWithDirectionCommonTests(F memcpy_func, const hipStream_t kernel_stre
         std::bind(memcpy_func, _1, _2, _3, hipMemcpyHostToHost), kernel_stream);
   }
 
-  SECTION("Host to host with default kind") {
-    MemcpyHostToHostShell<should_synchronize>(std::bind(memcpy_func, _1, _2, _3,
-                                              hipMemcpyDefault), kernel_stream);
+  if (!isQuickLevel()) {
+    SECTION("Host to host with default kind") {
+      MemcpyHostToHostShell<should_synchronize>(std::bind(memcpy_func, _1, _2, _3,
+                                                hipMemcpyDefault), kernel_stream);
+    }
   }
 
   SECTION("Device to device") {
@@ -207,14 +213,16 @@ void MemcpyWithDirectionCommonTests(F memcpy_func, const hipStream_t kernel_stre
     }
   }
 
-  SECTION("Device to device with default kind") {
-    SECTION("Peer access enabled") {
-      MemcpyDeviceToDeviceShell<should_synchronize, true>(
-          std::bind(memcpy_func, _1, _2, _3, hipMemcpyDefault), kernel_stream);
-    }
-    SECTION("Peer access disabled") {
-      MemcpyDeviceToDeviceShell<should_synchronize, false>(
-          std::bind(memcpy_func, _1, _2, _3, hipMemcpyDefault), kernel_stream);
+  if (!isQuickLevel()) {
+    SECTION("Device to device with default kind") {
+      SECTION("Peer access enabled") {
+        MemcpyDeviceToDeviceShell<should_synchronize, true>(
+            std::bind(memcpy_func, _1, _2, _3, hipMemcpyDefault), kernel_stream);
+      }
+      SECTION("Peer access disabled") {
+        MemcpyDeviceToDeviceShell<should_synchronize, false>(
+            std::bind(memcpy_func, _1, _2, _3, hipMemcpyDefault), kernel_stream);
+      }
     }
   }
 }

--- a/projects/hip-tests/catch/stress/memory/hipHostMallocStress.cc
+++ b/projects/hip-tests/catch/stress/memory/hipHostMallocStress.cc
@@ -1,21 +1,8 @@
 /*
-Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANNTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER INN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR INN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-*/
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
 
 #include <hip_test_common.hh>
 #include <hip_test_helper.hh>

--- a/projects/hip-tests/catch/stress/memory/hipHostMallocStress.cc
+++ b/projects/hip-tests/catch/stress/memory/hipHostMallocStress.cc
@@ -1,19 +1,45 @@
 /*
- * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
- *
- * SPDX-License-Identifier: MIT
- */
+Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANNTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER INN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR INN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
 
 #include <hip_test_common.hh>
 #include <hip_test_helper.hh>
+#include <hip_test_params.hh>
+
+#include <algorithm>
+#include <iostream>
 
 #define ADDITIONAL_MEMORY_PERCENT 10
+
+namespace {
+constexpr size_t kSmokeAllocCapBytes = 32u * 1024u * 1024u;
+// End-of-buffer memset uses samplesize bytes; keep alloc large enough for non-overlap (AllGpu only).
+constexpr size_t kSmokeAllGpuMinAllocBytes = 4096u;
+}  // namespace
 
 // Stress allocation tests
 // Try to allocate as much memory as possible
 // But since max allocation can fail, we need to try the next value
 
 HIP_TEST_CASE(Stress_hipHostMalloc_MaxAllocation) {
+  const bool smoke =
+      (TestParameterStore::instance().currentTestLevel == "level_0");
+
   size_t devMemAvail{0}, devMemFree{0};
   HIP_CHECK(hipMemGetInfo(&devMemFree, &devMemAvail));
   auto hostMemFree = HipTest::getAvailableSystemMemoryInMB() * 1024 * 1024;  // In bytes
@@ -22,13 +48,21 @@ HIP_TEST_CASE(Stress_hipHostMalloc_MaxAllocation) {
   REQUIRE(hostMemFree > 0);
   // which is the limiter cpu or gpu
   size_t memFree = std::min(devMemFree, hostMemFree);
+  if (smoke) {
+    memFree = std::min(memFree, kSmokeAllocCapBytes);
+    std::cout << "[Stress_hipHostMalloc_MaxAllocation] level_0 cap: " << kSmokeAllocCapBytes
+              << " bytes" << std::endl;
+  }
+  REQUIRE(memFree > 0);
   char* d_ptr{nullptr};
   size_t counter{0};
 
-  INFO("Max Allocation of " << memFree << " bytes!");
+  std::cout << "[Stress_hipHostMalloc_MaxAllocation] Max Allocation of " << memFree << " bytes!"
+            << std::endl;
   while (hipHostMalloc(&d_ptr, memFree) != hipSuccess && memFree > 1) {
     counter++;
-    INFO("Attempt to allocate " << memFree << " bytes out of " << devMemFree << "bytes Failed!");
+    std::cout << "[Stress_hipHostMalloc_MaxAllocation] Attempt to allocate " << memFree
+              << " bytes out of " << devMemFree << " bytes Failed!" << std::endl;
     memFree >>= 1;          // reduce the memory to be allocated by half
     REQUIRE(counter <= 2);  // Make sure that we are atleast able to allocate
     // 1/4th of max memory
@@ -42,8 +76,12 @@ HIP_TEST_CASE(Stress_hipHostMalloc_MaxAllocation) {
 
 // Allocate more memory than total GPU memory in each available GPU.
 // hipHostMalloc should return hipSuccess.
+// Level 0 (smoke / emulator): cap per-device allocation; level 2 keeps full oversubscription.
 
 HIP_TEST_CASE(Stress_hipHostMalloc_MaxAllocation_AllGpu) {
+  const bool smoke =
+      (TestParameterStore::instance().currentTestLevel == "level_0");
+
   char* A = nullptr;
   size_t maxGpuMem = 0, availableMem = 0;
   int count = 0;
@@ -53,6 +91,13 @@ HIP_TEST_CASE(Stress_hipHostMalloc_MaxAllocation_AllGpu) {
     HIP_CHECK(hipSetDevice(dev));
     HIP_CHECK(hipMemGetInfo(&availableMem, &maxGpuMem));
     size_t allocsize = maxGpuMem + ((maxGpuMem * ADDITIONAL_MEMORY_PERCENT) / 100);
+    if (smoke) {
+      allocsize = std::min(allocsize, kSmokeAllocCapBytes);
+      allocsize = std::max(allocsize, kSmokeAllGpuMinAllocBytes);
+      std::cout << "[Stress_hipHostMalloc_MaxAllocation_AllGpu] dev " << dev
+                << " level_0 cap: " << kSmokeAllocCapBytes << " bytes, allocsize: " << allocsize
+                << " bytes" << std::endl;
+    }
     // Get free host In bytes
     size_t hostMemFree = HipTest::getAvailableSystemMemoryInMB() * 1024 * 1024;
     if (allocsize < hostMemFree) {
@@ -66,7 +111,7 @@ HIP_TEST_CASE(Stress_hipHostMalloc_MaxAllocation_AllGpu) {
       HIP_CHECK(hipMemset((A + allocsize - 1 - samplesize), val, samplesize));
       HIP_CHECK(hipHostFree(A));
     } else {
-      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNotEnoughFreeHostMemory);
+      WARN("Skipping test as CPU memory is less than GPU memory");
     }
   }
 }

--- a/projects/hip-tests/catch/stress/memory/hipHostMallocStress.cc
+++ b/projects/hip-tests/catch/stress/memory/hipHostMallocStress.cc
@@ -6,7 +6,6 @@
 
 #include <hip_test_common.hh>
 #include <hip_test_helper.hh>
-#include <hip_test_params.hh>
 
 #include <algorithm>
 #include <iostream>
@@ -14,9 +13,9 @@
 #define ADDITIONAL_MEMORY_PERCENT 10
 
 namespace {
-constexpr size_t kSmokeAllocCapBytes = 32u * 1024u * 1024u;
+constexpr size_t kQuickAllocCapBytes = 32u * 1024u * 1024u;
 // End-of-buffer memset uses samplesize bytes; keep alloc large enough for non-overlap (AllGpu only).
-constexpr size_t kSmokeAllGpuMinAllocBytes = 4096u;
+constexpr size_t kQuickAllGpuMinAllocBytes = 4096u;
 }  // namespace
 
 // Stress allocation tests
@@ -24,9 +23,6 @@ constexpr size_t kSmokeAllGpuMinAllocBytes = 4096u;
 // But since max allocation can fail, we need to try the next value
 
 HIP_TEST_CASE(Stress_hipHostMalloc_MaxAllocation) {
-  const bool smoke =
-      (TestParameterStore::instance().currentTestLevel == "level_0");
-
   size_t devMemAvail{0}, devMemFree{0};
   HIP_CHECK(hipMemGetInfo(&devMemFree, &devMemAvail));
   auto hostMemFree = HipTest::getAvailableSystemMemoryInMB() * 1024 * 1024;  // In bytes
@@ -35,9 +31,9 @@ HIP_TEST_CASE(Stress_hipHostMalloc_MaxAllocation) {
   REQUIRE(hostMemFree > 0);
   // which is the limiter cpu or gpu
   size_t memFree = std::min(devMemFree, hostMemFree);
-  if (smoke) {
-    memFree = std::min(memFree, kSmokeAllocCapBytes);
-    std::cout << "[Stress_hipHostMalloc_MaxAllocation] level_0 cap: " << kSmokeAllocCapBytes
+  if (isQuickLevel()) {
+    memFree = std::min(memFree, kQuickAllocCapBytes);
+    std::cout << "[Stress_hipHostMalloc_MaxAllocation] level_0 cap: " << kQuickAllocCapBytes
               << " bytes" << std::endl;
   }
   REQUIRE(memFree > 0);
@@ -63,12 +59,9 @@ HIP_TEST_CASE(Stress_hipHostMalloc_MaxAllocation) {
 
 // Allocate more memory than total GPU memory in each available GPU.
 // hipHostMalloc should return hipSuccess.
-// Level 0 (smoke / emulator): cap per-device allocation; level 2 keeps full oversubscription.
+// Level 0 (quick level): cap per-device allocation; level 2 keeps full oversubscription.
 
 HIP_TEST_CASE(Stress_hipHostMalloc_MaxAllocation_AllGpu) {
-  const bool smoke =
-      (TestParameterStore::instance().currentTestLevel == "level_0");
-
   char* A = nullptr;
   size_t maxGpuMem = 0, availableMem = 0;
   int count = 0;
@@ -78,11 +71,11 @@ HIP_TEST_CASE(Stress_hipHostMalloc_MaxAllocation_AllGpu) {
     HIP_CHECK(hipSetDevice(dev));
     HIP_CHECK(hipMemGetInfo(&availableMem, &maxGpuMem));
     size_t allocsize = maxGpuMem + ((maxGpuMem * ADDITIONAL_MEMORY_PERCENT) / 100);
-    if (smoke) {
-      allocsize = std::min(allocsize, kSmokeAllocCapBytes);
-      allocsize = std::max(allocsize, kSmokeAllGpuMinAllocBytes);
+    if (isQuickLevel()) {
+      allocsize = std::min(allocsize, kQuickAllocCapBytes);
+      allocsize = std::max(allocsize, kQuickAllGpuMinAllocBytes);
       std::cout << "[Stress_hipHostMalloc_MaxAllocation_AllGpu] dev " << dev
-                << " level_0 cap: " << kSmokeAllocCapBytes << " bytes, allocsize: " << allocsize
+                << " level_0 cap: " << kQuickAllocCapBytes << " bytes, allocsize: " << allocsize
                 << " bytes" << std::endl;
     }
     // Get free host In bytes

--- a/projects/hip-tests/catch/stress/memory/hipHostMallocStress.cc
+++ b/projects/hip-tests/catch/stress/memory/hipHostMallocStress.cc
@@ -91,7 +91,7 @@ HIP_TEST_CASE(Stress_hipHostMalloc_MaxAllocation_AllGpu) {
       HIP_CHECK(hipMemset((A + allocsize - 1 - samplesize), val, samplesize));
       HIP_CHECK(hipHostFree(A));
     } else {
-      WARN("Skipping test as CPU memory is less than GPU memory");
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNotEnoughFreeHostMemory);
     }
   }
 }

--- a/projects/hip-tests/catch/stress/memory/hipMalloc.cc
+++ b/projects/hip-tests/catch/stress/memory/hipMalloc.cc
@@ -1,24 +1,10 @@
 /*
-   Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANNTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INNCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANNY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER INN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR INN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
  */
 
  #include <hip_test_common.hh>
- #include <hip_test_params.hh>
 
  #include <algorithm>
  #include <cstdlib>
@@ -29,20 +15,18 @@
 
 // Stress allocation tests
 // Try to allocate as much memory as possible, backing off gradually on failure.
-// Level 0 (smoke / emulator): cap allocation and host staging; level 2 uses ~95% free VRAM.
+// Level 0 (quick level): cap allocation and host staging; level 2 uses ~95% free VRAM.
 HIP_TEST_CASE(Stress_hipMalloc_HighSizeAlloc) {
   size_t devMemTotal{0}, devMemFree{0};
   HIP_CHECK(hipMemGetInfo(&devMemFree, &devMemTotal));
   REQUIRE(devMemFree > 0);
   REQUIRE(devMemTotal > 0);
 
-  const bool smoke =
-      (TestParameterStore::instance().currentTestLevel == "level_0");
-  constexpr size_t kSmokeAllocCap = 32u * 1024u * 1024u;
+  constexpr size_t kQuickAllocCap = 32u * 1024u * 1024u;
 
   size_t alloc_size = static_cast<size_t>(devMemFree * 0.95);
-  if (smoke) {
-    alloc_size = std::min(alloc_size, kSmokeAllocCap);
+  if (isQuickLevel()) {
+    alloc_size = std::min(alloc_size, kQuickAllocCap);
   }
   alloc_size = std::max(alloc_size, size_t{1});
 
@@ -52,7 +36,7 @@ HIP_TEST_CASE(Stress_hipMalloc_HighSizeAlloc) {
   std::cout << "[Stress_hipMalloc_HighSizeAlloc] Free Mem Available: " << devMemFree
             << " bytes out of " << devMemTotal << " bytes" << std::endl;
   std::cout << "[Stress_hipMalloc_HighSizeAlloc] Target allocation: " << alloc_size << " bytes"
-            << (smoke ? " (level_0 cap)" : "") << std::endl;
+            << (isQuickLevel() ? " (level_0 cap)" : "") << std::endl;
   while (hipMalloc(&d_ptr, alloc_size) != hipSuccess && alloc_size > 1) {
     counter++;
     alloc_size = static_cast<size_t>(alloc_size * 0.95);

--- a/projects/hip-tests/catch/stress/memory/hipMalloc.cc
+++ b/projects/hip-tests/catch/stress/memory/hipMalloc.cc
@@ -1,49 +1,78 @@
 /*
- * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
- *
- * SPDX-License-Identifier: MIT
+   Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANNTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INNCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANNY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER INN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR INN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
  */
 
  #include <hip_test_common.hh>
+ #include <hip_test_params.hh>
 
  #include <algorithm>
  #include <cstdlib>
  #include <ctime>
  #include <execution>
+ #include <iostream>
  #include <memory>
 
 // Stress allocation tests
 // Try to allocate as much memory as possible, backing off gradually on failure.
+// Level 0 (smoke / emulator): cap allocation and host staging; level 2 uses ~95% free VRAM.
 HIP_TEST_CASE(Stress_hipMalloc_HighSizeAlloc) {
   size_t devMemTotal{0}, devMemFree{0};
   HIP_CHECK(hipMemGetInfo(&devMemFree, &devMemTotal));
   REQUIRE(devMemFree > 0);
   REQUIRE(devMemTotal > 0);
 
+  const bool smoke =
+      (TestParameterStore::instance().currentTestLevel == "level_0");
+  constexpr size_t kSmokeAllocCap = 32u * 1024u * 1024u;
+
+  size_t alloc_size = static_cast<size_t>(devMemFree * 0.95);
+  if (smoke) {
+    alloc_size = std::min(alloc_size, kSmokeAllocCap);
+  }
+  alloc_size = std::max(alloc_size, size_t{1});
+
   char* d_ptr{nullptr};
   constexpr size_t kMaxRetries = 10;
   size_t counter{0};
-  // Reserve a small buffer so the runtime can still create queues / contexts
-  devMemFree *= 0.95;
-  INFO("Free Mem Available: " << devMemFree << " bytes out of " << devMemTotal << " bytes!");
-  while (hipMalloc(&d_ptr, devMemFree) != hipSuccess && devMemFree > 1) {
+  std::cout << "[Stress_hipMalloc_HighSizeAlloc] Free Mem Available: " << devMemFree
+            << " bytes out of " << devMemTotal << " bytes" << std::endl;
+  std::cout << "[Stress_hipMalloc_HighSizeAlloc] Target allocation: " << alloc_size << " bytes"
+            << (smoke ? " (level_0 cap)" : "") << std::endl;
+  while (hipMalloc(&d_ptr, alloc_size) != hipSuccess && alloc_size > 1) {
     counter++;
-    devMemFree = static_cast<size_t>(devMemFree * 0.95);  // back off by ~5% each attempt
-    INFO("Attempt to allocate " << devMemFree << " bytes out of " << devMemTotal
-                                << " bytes failed!");
+    alloc_size = static_cast<size_t>(alloc_size * 0.95);
+    std::cout << "[Stress_hipMalloc_HighSizeAlloc] Attempt to allocate " << alloc_size
+              << " bytes out of " << devMemTotal << " bytes failed!" << std::endl;
     REQUIRE(counter <= kMaxRetries);
   }
+  REQUIRE(d_ptr != nullptr);
 
   // Use a random fill value so repeated runs are cache-unfriendly; this helps
   // surface issues that only appear when memory contents differ between runs.
   std::srand(static_cast<unsigned>(std::time(nullptr)));
   unsigned char fill_val = static_cast<unsigned char>(std::rand() % 255 + 1);
-  INFO("Fill value for this run: " << static_cast<int>(fill_val));
+  std::cout << "[Stress_hipMalloc_HighSizeAlloc] Fill value for this run: " << static_cast<int>(fill_val)
+            << std::endl;
 
-   HIP_CHECK(hipMemset(d_ptr, fill_val, devMemFree));
-   auto ptr = std::unique_ptr<unsigned char[]>{new unsigned char[devMemFree]};
-   HIP_CHECK(hipMemcpy(ptr.get(), d_ptr, devMemFree, hipMemcpyDeviceToHost));
-   HIP_CHECK(hipFree(d_ptr));
-   REQUIRE(std::all_of(std::execution::par_unseq, ptr.get(), ptr.get() + devMemFree,
-                        [fill_val](unsigned char n) { return n == fill_val; }));
- }
+  HIP_CHECK(hipMemset(d_ptr, fill_val, alloc_size));
+  auto ptr = std::unique_ptr<unsigned char[]>{new unsigned char[alloc_size]};
+  HIP_CHECK(hipMemcpy(ptr.get(), d_ptr, alloc_size, hipMemcpyDeviceToHost));
+  HIP_CHECK(hipFree(d_ptr));
+  REQUIRE(std::all_of(std::execution::par_unseq, ptr.get(), ptr.get() + alloc_size,
+                       [fill_val](unsigned char n) { return n == fill_val; }));
+}

--- a/projects/hip-tests/catch/stress/memory/hipMemcpyMThreadMSize.cc
+++ b/projects/hip-tests/catch/stress/memory/hipMemcpyMThreadMSize.cc
@@ -8,6 +8,7 @@
 #include <hip_test_kernels.hh>
 #include <hip_test_checkers.hh>
 #include <algorithm>
+#include <cstdlib>
 #include <iostream>
 #include <random>
 #include <type_traits>
@@ -84,7 +85,7 @@ const char* ApiToString(apiToTest api) {
 
 }  // namespace
 
-template <typename TestType> void Memcpy_And_verify(size_t NUM_ELM) {
+template <typename TestType> void Memcpy_And_verify(size_t NUM_ELM, std::mt19937& gen) {
   // level_0 (quick level): skip H2D/D2H/H2DAsync/D2HAsync entirely,
   // and cap async APIs (MemcpyAsync/DtoDAsync) at 64 KiB.
   // All other levels run every API at every size.
@@ -114,8 +115,6 @@ template <typename TestType> void Memcpy_And_verify(size_t NUM_ELM) {
       HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, A_h, B_h, nullptr, false);
       continue;
     }
-    std::random_device rd_seed;
-    std::mt19937 gen(rd_seed());
 
     TestType* A_d[MAX_GPU]{};
     hipStream_t stream[MAX_GPU]{};
@@ -369,6 +368,15 @@ HIP_TEST_CASE(Stress_hipMemcpy_multiDevice_AllAPIs) {
     }
   }
 
+  std::random_device rd;
+  unsigned int seed = rd();
+  const char* seed_env = std::getenv("HIP_TEST_SEED");
+  if (seed_env && seed_env[0] != '\0') {
+    seed = static_cast<unsigned int>(std::atol(seed_env));
+  }
+  std::mt19937 gen(seed);
+  std::cout << "[Stress_hipMemcpy_multiDevice_AllAPIs] seed=" << seed << std::endl;
+
   int step = 0;
   for (size_t NUM_ELM : all_sizes) {
     NUM_ELM = std::max(NUM_ELM, size_t{1});
@@ -380,7 +388,7 @@ HIP_TEST_CASE(Stress_hipMemcpy_multiDevice_AllAPIs) {
     std::cout << "[Stress_hipMemcpy_multiDevice_AllAPIs] " << step << "/" << total_steps
               << " NUM_ELM=" << NUM_ELM << " bytes=" << requested_bytes << std::endl;
     if (requested_bytes <= free) {
-      Memcpy_And_verify<char>(NUM_ELM);
+      Memcpy_And_verify<char>(NUM_ELM, gen);
       HIP_CHECK(hipDeviceSynchronize());
     } else {
       std::cout << "[Stress_hipMemcpy_multiDevice_AllAPIs] skip (need " << requested_bytes

--- a/projects/hip-tests/catch/stress/memory/hipMemcpyMThreadMSize.cc
+++ b/projects/hip-tests/catch/stress/memory/hipMemcpyMThreadMSize.cc
@@ -198,42 +198,18 @@ template <typename TestType> void Memcpy_And_verify(size_t NUM_ELM) {
         break;
       }
       case TEST_MEMCPYASYNC: {
-        // Same pattern as hipMemcpyDtoD: random intra (async H2D/D2H), random peer, P2P async intra→peer.
-        const int intra_dev = RandomDeviceIndex(Available_Gpus, gen);
-        const int peer_dst = RandomPeerDst(intra_dev, Available_Gpus, gen);
-
-        HIP_CHECK(hipSetDevice(intra_dev));
-        HIP_CHECK(hipMalloc(&A_d[intra_dev], NUM_ELM * sizeof(TestType)));
-        HIP_CHECK(hipStreamCreate(&stream[intra_dev]));
-        stream_ok[intra_dev] = true;
-        if (peer_dst >= 0) {
-          HIP_CHECK(hipSetDevice(peer_dst));
-          HIP_CHECK(hipMalloc(&A_d[peer_dst], NUM_ELM * sizeof(TestType)));
-        }
-
-        {
-          const int i = intra_dev;
-          std::cout << "[Stress_hipMemcpy_multiDevice_AllAPIs] hipMemcpyAsync intra dev=" << i
-                    << " bytes=" << (NUM_ELM * sizeof(TestType)) << std::endl;
-          HIP_CHECK(hipSetDevice(i));
-          HIP_CHECK(hipMemcpyAsync(A_d[i], A_h, NUM_ELM * sizeof(TestType), hipMemcpyHostToDevice,
-                                   stream[i]));
-          HIP_CHECK(hipMemcpyAsync(B_h, A_d[i], NUM_ELM * sizeof(TestType), hipMemcpyDeviceToHost,
-                                   stream[i]));
-          HIP_CHECK(hipStreamSynchronize(stream[i]));
-          HipTest::checkTest(A_h, B_h, NUM_ELM);
-        }
-
-        if (peer_dst >= 0) {
-          std::cout << "[Stress_hipMemcpy_multiDevice_AllAPIs] hipMemcpyAsync peer " << intra_dev << "->"
-                    << peer_dst << " bytes=" << (NUM_ELM * sizeof(TestType)) << std::endl;
-          HIP_CHECK(hipSetDevice(peer_dst));
-          HIP_CHECK(hipMemcpyAsync(A_d[peer_dst], A_d[intra_dev], NUM_ELM * sizeof(TestType),
-                                   hipMemcpyDefault, stream[intra_dev]));
-          HIP_CHECK(hipStreamSynchronize(stream[intra_dev]));
-          HIP_CHECK(hipMemcpy(B_h, A_d[peer_dst], NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-          HipTest::checkTest(A_h, B_h, NUM_ELM);
-        }
+        // One random GPU; P2P is covered in TEST_MEMCPYD2DASYNC.
+        const int d = RandomDeviceIndex(Available_Gpus, gen);
+        HIP_CHECK(hipSetDevice(d));
+        HIP_CHECK(hipMalloc(&A_d[d], NUM_ELM * sizeof(TestType)));
+        HIP_CHECK(hipStreamCreate(&stream[d]));
+        stream_ok[d] = true;
+        HIP_CHECK(hipMemcpyAsync(A_d[d], A_h, NUM_ELM * sizeof(TestType), hipMemcpyHostToDevice,
+                                 stream[d]));
+        HIP_CHECK(hipMemcpyAsync(B_h, A_d[d], NUM_ELM * sizeof(TestType), hipMemcpyDeviceToHost,
+                                 stream[d]));
+        HIP_CHECK(hipStreamSynchronize(stream[d]));
+        HipTest::checkTest(A_h, B_h, NUM_ELM);
         break;
       }
       case TEST_MEMCPYH2DASYNC:  // To test hipMemcpyHtoDAsync()

--- a/projects/hip-tests/catch/stress/memory/hipMemcpyMThreadMSize.cc
+++ b/projects/hip-tests/catch/stress/memory/hipMemcpyMThreadMSize.cc
@@ -1,12 +1,30 @@
 /*
- * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
- *
- * SPDX-License-Identifier: MIT
- */
+Copyright (c) 2021 - present Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
 
 #include <hip_test_common.hh>
 #include <hip_test_kernels.hh>
 #include <hip_test_checkers.hh>
+#include <hip_test_params.hh>
+#include <algorithm>
+#include <iostream>
+#include <random>
+#include <type_traits>
 #include <utility>
 #include <vector>
 /*
@@ -29,108 +47,197 @@ enum apiToTest {
   TEST_MEMCPYD2DASYNC
 };
 
-template <typename TestType> void Memcpy_And_verify(int NUM_ELM) {
+namespace {
+
+/** Uniform random int in [0, n); n must be > 0. */
+inline int RandomDeviceIndex(int n, std::mt19937& gen) {
+  return static_cast<int>(std::uniform_int_distribution<int>(0, n - 1)(gen));
+}
+
+/** Pick j != intra with hipDeviceCanAccessPeer(intra, j); random trials, or -1. */
+inline int RandomPeerDst(int intra_dev, int n_gpu, std::mt19937& gen) {
+  if (n_gpu <= 1) {
+    return -1;
+  }
+  constexpr int kMaxTries = 64;
+  for (int t = 0; t < kMaxTries; ++t) {
+    const int j = RandomDeviceIndex(n_gpu, gen);
+    if (j == intra_dev) {
+      continue;
+    }
+    int p = 0;
+    HIP_CHECK(hipDeviceCanAccessPeer(&p, intra_dev, j));
+    if (p) {
+      return j;
+    }
+  }
+  return -1;
+}
+
+const char* ApiToString(apiToTest api) {
+  switch (api) {
+    case TEST_MEMCPY:
+      return "hipMemcpy";
+    case TEST_MEMCPYH2D:
+      return "hipMemcpyHtoD";
+    case TEST_MEMCPYD2H:
+      return "hipMemcpyDtoH";
+    case TEST_MEMCPYD2D:
+      return "hipMemcpyDtoD";
+    case TEST_MEMCPYASYNC:
+      return "hipMemcpyAsync";
+    case TEST_MEMCPYH2DASYNC:
+      return "hipMemcpyHtoDAsync";
+    case TEST_MEMCPYD2HASYNC:
+      return "hipMemcpyDtoHAsync";
+    case TEST_MEMCPYD2DASYNC:
+      return "hipMemcpyDtoDAsync";
+  }
+  return "unknown";
+}
+
+}  // namespace
+
+template <typename TestType> void Memcpy_And_verify(size_t NUM_ELM) {
+  // MEMCPYH2D / DtoH / H2DAsync / DtoHAsync: only run when transfer <= 64 KiB (level_2+). Not run at all for
+  // level_0 smoke. MEMCPY / DtoD (sync): no per-API cap beyond smoke 32 MiB.
+  // level_0 smoke: MemcpyAsync / DtoDAsync only when transfer <= 64 KiB.
+  // Each API uses one randomly chosen GPU (and a second for P2P when applicable); device memory is
+  // allocated only for GPUs used in that iteration.
+  constexpr size_t kNonPrimaryApiMaxBytes = 64u * 1024u;
+  constexpr size_t kSmokeAsyncMaxBytes = 64u * 1024u;
+  const size_t requested_bytes = NUM_ELM * sizeof(TestType);
+  const bool smoke_level =
+      (TestParameterStore::instance().currentTestLevel == "level_0");
+
   TestType *A_h, *B_h;
   for (apiToTest api = TEST_MEMCPY; api <= TEST_MEMCPYD2DASYNC; api = apiToTest(api + 1)) {
+    if (smoke_level && (api == TEST_MEMCPYH2D || api == TEST_MEMCPYD2H || api == TEST_MEMCPYH2DASYNC ||
+                        api == TEST_MEMCPYD2HASYNC)) {
+      continue;
+    }
+    const bool primary_api = (api == TEST_MEMCPY || api == TEST_MEMCPYD2D || api == TEST_MEMCPYASYNC ||
+                              api == TEST_MEMCPYD2DASYNC);
+    if (!primary_api && requested_bytes > kNonPrimaryApiMaxBytes) {
+      continue;
+    }
+    const bool async_api = (api == TEST_MEMCPYASYNC || api == TEST_MEMCPYH2DASYNC ||
+                            api == TEST_MEMCPYD2HASYNC || api == TEST_MEMCPYD2DASYNC);
+    if (smoke_level && async_api && requested_bytes > kSmokeAsyncMaxBytes) {
+      continue;
+    }
+
+    std::cout << "[Stress_hipMemcpy_multiDevice_AllAPIs] api=" << ApiToString(api)
+              << " NUM_ELM=" << NUM_ELM << " bytes=" << requested_bytes << std::endl;
+
     HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &A_h, &B_h, nullptr, NUM_ELM);
     HIP_CHECK(hipGetDeviceCount(&Available_Gpus));
-    TestType* A_d[MAX_GPU];
-    hipStream_t stream[MAX_GPU];
-    for (int i = 0; i < Available_Gpus; ++i) {
-      HIP_CHECK(hipSetDevice(i));
-      HIP_CHECK(hipMalloc(&A_d[i], NUM_ELM * sizeof(TestType)));
-      if (api >= TEST_MEMCPYD2D) {
-        HIP_CHECK(hipStreamCreate(&stream[i]));
-      }
+    if (Available_Gpus <= 0) {
+      HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, A_h, B_h, nullptr, false);
+      continue;
     }
-    HIP_CHECK(hipSetDevice(0));
-    int canAccessPeer = 0;
+    std::random_device rd_seed;
+    std::mt19937 gen(rd_seed());
+
+    TestType* A_d[MAX_GPU]{};
+    hipStream_t stream[MAX_GPU]{};
+    bool stream_ok[MAX_GPU]{};
+
     switch (api) {
       case TEST_MEMCPY: {
-        // To test hipMemcpy()
-        // Copying data from host to individual devices followed by copying
-        // back to host and verifying the data consistency.
-        for (int i = 0; i < Available_Gpus; ++i) {
-          HIP_CHECK(hipMemcpy(A_d[i], A_h, NUM_ELM * sizeof(TestType), hipMemcpyHostToDevice));
-          HIP_CHECK(hipMemcpy(B_h, A_d[i], NUM_ELM * sizeof(TestType), hipMemcpyDeviceToHost));
-          HipTest::checkTest(A_h, B_h, NUM_ELM);
-        }
-        // Device to Device copying for all combinations
-        for (int i = 0; i < Available_Gpus; ++i) {
-          for (int j = i + 1; j < Available_Gpus; ++j) {
-            canAccessPeer = 0;
-            HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, i, j));
-            if (canAccessPeer) {
-              HIP_CHECK(hipMemcpy(A_d[j], A_d[i], NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-              // Copying in reverse dir of above to check if bidirectional
-              // access is happening without any error
-              HIP_CHECK(hipMemcpy(A_d[i], A_d[j], NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-              // Copying data to host to verify the content
-              HIP_CHECK(hipMemcpy(B_h, A_d[j], NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-              HipTest::checkTest(A_h, B_h, NUM_ELM);
-            }
-          }
-        }
+        // One random GPU; P2P is covered in TEST_MEMCPYD2D / ASYNC.
+        const int d = RandomDeviceIndex(Available_Gpus, gen);
+        HIP_CHECK(hipSetDevice(d));
+        HIP_CHECK(hipMalloc(&A_d[d], NUM_ELM * sizeof(TestType)));
+        HIP_CHECK(hipMemcpy(A_d[d], A_h, NUM_ELM * sizeof(TestType), hipMemcpyHostToDevice));
+        HIP_CHECK(hipMemcpy(B_h, A_d[d], NUM_ELM * sizeof(TestType), hipMemcpyDeviceToHost));
+        HipTest::checkTest(A_h, B_h, NUM_ELM);
         break;
       }
       case TEST_MEMCPYH2D:  // To test hipMemcpyHtoD()
       {
-        for (int i = 0; i < Available_Gpus; ++i) {
-          HIP_CHECK(hipMemcpyHtoD(hipDeviceptr_t(A_d[i]), A_h, NUM_ELM * sizeof(TestType)));
-          // Copying data from device to host to check data consistency
-          HIP_CHECK(hipMemcpy(B_h, A_d[i], NUM_ELM * sizeof(TestType), hipMemcpyDeviceToHost));
-          HipTest::checkTest(A_h, B_h, NUM_ELM);
-        }
+        const int d = RandomDeviceIndex(Available_Gpus, gen);
+        HIP_CHECK(hipSetDevice(d));
+        HIP_CHECK(hipMalloc(&A_d[d], NUM_ELM * sizeof(TestType)));
+        HIP_CHECK(hipMemcpyHtoD(hipDeviceptr_t(A_d[d]), A_h, NUM_ELM * sizeof(TestType)));
+        HIP_CHECK(hipMemcpy(B_h, A_d[d], NUM_ELM * sizeof(TestType), hipMemcpyDeviceToHost));
+        HipTest::checkTest(A_h, B_h, NUM_ELM);
         break;
       }
       case TEST_MEMCPYD2H:  // To test hipMemcpyDtoH()--done
       {
-        for (int i = 0; i < Available_Gpus; ++i) {
-          HIP_CHECK(hipMemcpy(A_d[i], A_h, NUM_ELM * sizeof(TestType), hipMemcpyHostToDevice));
-          HIP_CHECK(hipMemcpyDtoH(B_h, hipDeviceptr_t(A_d[i]), NUM_ELM * sizeof(TestType)));
-          HipTest::checkTest(A_h, B_h, NUM_ELM);
-        }
+        const int d = RandomDeviceIndex(Available_Gpus, gen);
+        HIP_CHECK(hipSetDevice(d));
+        HIP_CHECK(hipMalloc(&A_d[d], NUM_ELM * sizeof(TestType)));
+        HIP_CHECK(hipMemcpy(A_d[d], A_h, NUM_ELM * sizeof(TestType), hipMemcpyHostToDevice));
+        HIP_CHECK(hipMemcpyDtoH(B_h, hipDeviceptr_t(A_d[d]), NUM_ELM * sizeof(TestType)));
+        HipTest::checkTest(A_h, B_h, NUM_ELM);
         break;
       }
       case TEST_MEMCPYD2D:  // To test hipMemcpyDtoD()
       {
-        if (Available_Gpus > 1) {
-          // First copy data from H to D and then
-          // from D to D followed by D to H
-          // HIP_CHECK(hipMemcpyHtoD(A_d[0], A_h,
-          // NUM_ELM * sizeof(TestType)));
-          int canAccessPeer = 0;
-          for (int i = 0; i < Available_Gpus; ++i) {
-            for (int j = i + 1; j < Available_Gpus; ++j) {
-              HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, i, j));
-              if (canAccessPeer) {
-                HIP_CHECK(hipMemcpyHtoD(hipDeviceptr_t(A_d[i]), A_h, NUM_ELM * sizeof(TestType)));
-                HIP_CHECK(hipMemcpyDtoD(hipDeviceptr_t(A_d[j]), hipDeviceptr_t(A_d[i]),
-                                        NUM_ELM * sizeof(TestType)));
-                // Copying in direction reverse of above to check if
-                // bidirectional
-                // access is happening without any error
-                HIP_CHECK(hipMemcpyDtoD(hipDeviceptr_t(A_d[i]), hipDeviceptr_t(A_d[j]),
-                                        NUM_ELM * sizeof(TestType)));
-                HIP_CHECK(
-                    hipMemcpy(B_h, A_d[i], NUM_ELM * sizeof(TestType), hipMemcpyDeviceToHost));
-                HipTest::checkTest(A_h, B_h, NUM_ELM);
-              }
-            }
-          }
-        } else {
-          // As DtoD is not possible transfer data from HtH(A_h to B_h)
-          // so as to get through verification step
-          HIP_CHECK(hipMemcpy(B_h, A_h, NUM_ELM * sizeof(TestType), hipMemcpyHostToHost));
+        // Random intra GPU; random peer dst (no full-GPU scan); P2P intra→peer (reuse A_d[intra], no H2D).
+        const int intra_dev = RandomDeviceIndex(Available_Gpus, gen);
+        const int peer_dst = RandomPeerDst(intra_dev, Available_Gpus, gen);
+
+        HIP_CHECK(hipSetDevice(intra_dev));
+        HIP_CHECK(hipMalloc(&A_d[intra_dev], NUM_ELM * sizeof(TestType)));
+        if (peer_dst >= 0) {
+          HIP_CHECK(hipSetDevice(peer_dst));
+          HIP_CHECK(hipMalloc(&A_d[peer_dst], NUM_ELM * sizeof(TestType)));
+        }
+
+        TestType* scratch_d[MAX_GPU]{};
+        HIP_CHECK(hipSetDevice(intra_dev));
+        HIP_CHECK(hipMalloc(&scratch_d[intra_dev], NUM_ELM * sizeof(TestType)));
+
+        {
+          const int i = intra_dev;
+          std::cout << "[Stress_hipMemcpy_multiDevice_AllAPIs] hipMemcpyDtoD intra dev=" << i
+                    << " bytes=" << (NUM_ELM * sizeof(TestType)) << std::endl;
+          HIP_CHECK(hipSetDevice(i));
+          HIP_CHECK(hipMemcpyHtoD(hipDeviceptr_t(A_d[i]), A_h, NUM_ELM * sizeof(TestType)));
+          HIP_CHECK(hipMemcpyDtoD(hipDeviceptr_t(scratch_d[i]), hipDeviceptr_t(A_d[i]),
+                                  NUM_ELM * sizeof(TestType)));
+          HIP_CHECK(hipMemcpyDtoD(hipDeviceptr_t(A_d[i]), hipDeviceptr_t(scratch_d[i]),
+                                  NUM_ELM * sizeof(TestType)));
+          HIP_CHECK(hipMemcpy(B_h, A_d[i], NUM_ELM * sizeof(TestType), hipMemcpyDeviceToHost));
           HipTest::checkTest(A_h, B_h, NUM_ELM);
         }
+
+        if (peer_dst >= 0) {
+          std::cout << "[Stress_hipMemcpy_multiDevice_AllAPIs] hipMemcpyDtoD peer " << intra_dev << "->"
+                    << peer_dst << " bytes=" << (NUM_ELM * sizeof(TestType)) << std::endl;
+          HIP_CHECK(hipSetDevice(peer_dst));
+          HIP_CHECK(hipMemcpyDtoD(hipDeviceptr_t(A_d[peer_dst]), hipDeviceptr_t(A_d[intra_dev]),
+                                  NUM_ELM * sizeof(TestType)));
+          HIP_CHECK(hipMemcpy(B_h, A_d[peer_dst], NUM_ELM * sizeof(TestType), hipMemcpyDeviceToHost));
+          HipTest::checkTest(A_h, B_h, NUM_ELM);
+        }
+
+        HIP_CHECK(hipSetDevice(intra_dev));
+        HIP_CHECK(hipFree(scratch_d[intra_dev]));
         break;
       }
       case TEST_MEMCPYASYNC: {
-        // To test hipMemcpyAsync()
-        // Copying data from host to individual devices followed by copying
-        // back to host and verifying the data consistency.
-        for (int i = 0; i < Available_Gpus; ++i) {
+        // Same pattern as hipMemcpyDtoD: random intra (async H2D/D2H), random peer, P2P async intra→peer.
+        const int intra_dev = RandomDeviceIndex(Available_Gpus, gen);
+        const int peer_dst = RandomPeerDst(intra_dev, Available_Gpus, gen);
+
+        HIP_CHECK(hipSetDevice(intra_dev));
+        HIP_CHECK(hipMalloc(&A_d[intra_dev], NUM_ELM * sizeof(TestType)));
+        HIP_CHECK(hipStreamCreate(&stream[intra_dev]));
+        stream_ok[intra_dev] = true;
+        if (peer_dst >= 0) {
+          HIP_CHECK(hipSetDevice(peer_dst));
+          HIP_CHECK(hipMalloc(&A_d[peer_dst], NUM_ELM * sizeof(TestType)));
+        }
+
+        {
+          const int i = intra_dev;
+          std::cout << "[Stress_hipMemcpy_multiDevice_AllAPIs] hipMemcpyAsync intra dev=" << i
+                    << " bytes=" << (NUM_ELM * sizeof(TestType)) << std::endl;
+          HIP_CHECK(hipSetDevice(i));
           HIP_CHECK(hipMemcpyAsync(A_d[i], A_h, NUM_ELM * sizeof(TestType), hipMemcpyHostToDevice,
                                    stream[i]));
           HIP_CHECK(hipMemcpyAsync(B_h, A_d[i], NUM_ELM * sizeof(TestType), hipMemcpyDeviceToHost,
@@ -138,89 +245,103 @@ template <typename TestType> void Memcpy_And_verify(int NUM_ELM) {
           HIP_CHECK(hipStreamSynchronize(stream[i]));
           HipTest::checkTest(A_h, B_h, NUM_ELM);
         }
-        // Device to Device copying for all combinations
-        for (int i = 0; i < Available_Gpus; ++i) {
-          for (int j = i + 1; j < Available_Gpus; ++j) {
-            canAccessPeer = 0;
-            HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, i, j));
-            if (canAccessPeer) {
-              HIP_CHECK(hipMemcpyAsync(A_d[j], A_d[i], NUM_ELM * sizeof(TestType), hipMemcpyDefault,
-                                       stream[i]));
-              // Copying in direction reverse of above to
-              // check if bidirectional
-              // access is happening without any error
-              HIP_CHECK(hipMemcpyAsync(A_d[i], A_d[j], NUM_ELM * sizeof(TestType), hipMemcpyDefault,
-                                       stream[i]));
-              HIP_CHECK(hipStreamSynchronize(stream[i]));
-              HIP_CHECK(hipMemcpy(B_h, A_d[j], NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-              HipTest::checkTest(A_h, B_h, NUM_ELM);
-            }
-          }
+
+        if (peer_dst >= 0) {
+          std::cout << "[Stress_hipMemcpy_multiDevice_AllAPIs] hipMemcpyAsync peer " << intra_dev << "->"
+                    << peer_dst << " bytes=" << (NUM_ELM * sizeof(TestType)) << std::endl;
+          HIP_CHECK(hipSetDevice(peer_dst));
+          HIP_CHECK(hipMemcpyAsync(A_d[peer_dst], A_d[intra_dev], NUM_ELM * sizeof(TestType),
+                                   hipMemcpyDefault, stream[intra_dev]));
+          HIP_CHECK(hipStreamSynchronize(stream[intra_dev]));
+          HIP_CHECK(hipMemcpy(B_h, A_d[peer_dst], NUM_ELM * sizeof(TestType), hipMemcpyDefault));
+          HipTest::checkTest(A_h, B_h, NUM_ELM);
         }
         break;
       }
       case TEST_MEMCPYH2DASYNC:  // To test hipMemcpyHtoDAsync()
       {
-        for (int i = 0; i < Available_Gpus; ++i) {
-          HIP_CHECK(hipMemcpyHtoDAsync(hipDeviceptr_t(A_d[i]), A_h, NUM_ELM * sizeof(TestType),
-                                       stream[i]));
-          HIP_CHECK(hipStreamSynchronize(stream[i]));
-          // Copying data from device to host to check data consistency
-          HIP_CHECK(hipMemcpy(B_h, A_d[i], NUM_ELM * sizeof(TestType), hipMemcpyDeviceToHost));
-          HipTest::checkTest(A_h, B_h, NUM_ELM);
-        }
+        const int d = RandomDeviceIndex(Available_Gpus, gen);
+        HIP_CHECK(hipSetDevice(d));
+        HIP_CHECK(hipMalloc(&A_d[d], NUM_ELM * sizeof(TestType)));
+        HIP_CHECK(hipStreamCreate(&stream[d]));
+        stream_ok[d] = true;
+        HIP_CHECK(hipMemcpyHtoDAsync(hipDeviceptr_t(A_d[d]), A_h, NUM_ELM * sizeof(TestType),
+                                     stream[d]));
+        HIP_CHECK(hipStreamSynchronize(stream[d]));
+        HIP_CHECK(hipMemcpy(B_h, A_d[d], NUM_ELM * sizeof(TestType), hipMemcpyDeviceToHost));
+        HipTest::checkTest(A_h, B_h, NUM_ELM);
         break;
       }
       case TEST_MEMCPYD2HASYNC:  // To test hipMemcpyDtoHAsync()
       {
-        for (int i = 0; i < Available_Gpus; ++i) {
-          HIP_CHECK(hipMemcpy(A_d[i], A_h, NUM_ELM * sizeof(TestType), hipMemcpyHostToDevice));
-          HIP_CHECK(hipMemcpyDtoHAsync(B_h, hipDeviceptr_t(A_d[i]), NUM_ELM * sizeof(TestType),
-                                       stream[i]));
-          HIP_CHECK(hipStreamSynchronize(stream[i]));
-          HipTest::checkTest(A_h, B_h, NUM_ELM);
-        }
+        const int d = RandomDeviceIndex(Available_Gpus, gen);
+        HIP_CHECK(hipSetDevice(d));
+        HIP_CHECK(hipMalloc(&A_d[d], NUM_ELM * sizeof(TestType)));
+        HIP_CHECK(hipStreamCreate(&stream[d]));
+        stream_ok[d] = true;
+        HIP_CHECK(hipMemcpy(A_d[d], A_h, NUM_ELM * sizeof(TestType), hipMemcpyHostToDevice));
+        HIP_CHECK(hipMemcpyDtoHAsync(B_h, hipDeviceptr_t(A_d[d]), NUM_ELM * sizeof(TestType),
+                                     stream[d]));
+        HIP_CHECK(hipStreamSynchronize(stream[d]));
+        HipTest::checkTest(A_h, B_h, NUM_ELM);
         break;
       }
       case TEST_MEMCPYD2DASYNC:  // To test hipMemcpyDtoDAsync()
       {
-        if (Available_Gpus > 1) {
-          // First copy data from H to D and then from D to D followed by D2H
-          HIP_CHECK(hipMemcpyHtoD(hipDeviceptr_t(A_d[0]), A_h, NUM_ELM * sizeof(TestType)));
-          for (int i = 0; i < Available_Gpus; ++i) {
-            for (int j = i + 1; j < Available_Gpus; ++j) {
-              canAccessPeer = 0;
-              HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, i, j));
-              if (canAccessPeer) {
-                HIP_CHECK(hipSetDevice(j));
-                HIP_CHECK(hipMemcpyDtoDAsync(hipDeviceptr_t(A_d[j]), hipDeviceptr_t(A_d[i]),
-                                             NUM_ELM * sizeof(TestType), stream[i]));
-                // Copying in direction reverse of above to check if
-                // bidirectional
-                // access is happening without any error
-                HIP_CHECK(hipMemcpyDtoDAsync(hipDeviceptr_t(A_d[i]), hipDeviceptr_t(A_d[j]),
-                                             NUM_ELM * sizeof(TestType), stream[i]));
-                HIP_CHECK(hipStreamSynchronize(stream[i]));
-                HIP_CHECK(
-                    hipMemcpy(B_h, A_d[i], NUM_ELM * sizeof(TestType), hipMemcpyDeviceToHost));
-                HipTest::checkTest(A_h, B_h, NUM_ELM);
-              }
-            }
-          }
-        } else {
-          // As DtoD is not possible we will transfer data
-          // from HtH(A_h to B_h)
-          // so as to get through verification step
-          HIP_CHECK(hipMemcpy(B_h, A_h, NUM_ELM * sizeof(TestType), hipMemcpyHostToHost));
+        // Same as sync DtoD: random intra / random peer; allocate only those GPUs.
+        const int intra_dev = RandomDeviceIndex(Available_Gpus, gen);
+        const int peer_dst = RandomPeerDst(intra_dev, Available_Gpus, gen);
+
+        HIP_CHECK(hipSetDevice(intra_dev));
+        HIP_CHECK(hipMalloc(&A_d[intra_dev], NUM_ELM * sizeof(TestType)));
+        HIP_CHECK(hipStreamCreate(&stream[intra_dev]));
+        stream_ok[intra_dev] = true;
+        if (peer_dst >= 0) {
+          HIP_CHECK(hipSetDevice(peer_dst));
+          HIP_CHECK(hipMalloc(&A_d[peer_dst], NUM_ELM * sizeof(TestType)));
+        }
+
+        TestType* scratch_d[MAX_GPU]{};
+        HIP_CHECK(hipSetDevice(intra_dev));
+        HIP_CHECK(hipMalloc(&scratch_d[intra_dev], NUM_ELM * sizeof(TestType)));
+
+        {
+          const int i = intra_dev;
+          std::cout << "[Stress_hipMemcpy_multiDevice_AllAPIs] hipMemcpyDtoDAsync intra dev=" << i
+                    << " bytes=" << (NUM_ELM * sizeof(TestType)) << std::endl;
+          HIP_CHECK(hipSetDevice(i));
+          HIP_CHECK(hipMemcpyHtoD(hipDeviceptr_t(A_d[i]), A_h, NUM_ELM * sizeof(TestType)));
+          HIP_CHECK(hipMemcpyDtoDAsync(hipDeviceptr_t(scratch_d[i]), hipDeviceptr_t(A_d[i]),
+                                       NUM_ELM * sizeof(TestType), stream[i]));
+          HIP_CHECK(hipMemcpyDtoDAsync(hipDeviceptr_t(A_d[i]), hipDeviceptr_t(scratch_d[i]),
+                                       NUM_ELM * sizeof(TestType), stream[i]));
+          HIP_CHECK(hipStreamSynchronize(stream[i]));
+          HIP_CHECK(hipMemcpy(B_h, A_d[i], NUM_ELM * sizeof(TestType), hipMemcpyDeviceToHost));
           HipTest::checkTest(A_h, B_h, NUM_ELM);
         }
+
+        if (peer_dst >= 0) {
+          std::cout << "[Stress_hipMemcpy_multiDevice_AllAPIs] hipMemcpyDtoDAsync peer " << intra_dev
+                    << "->" << peer_dst << " bytes=" << (NUM_ELM * sizeof(TestType)) << std::endl;
+          HIP_CHECK(hipSetDevice(peer_dst));
+          HIP_CHECK(hipMemcpyDtoDAsync(hipDeviceptr_t(A_d[peer_dst]), hipDeviceptr_t(A_d[intra_dev]),
+                                       NUM_ELM * sizeof(TestType), stream[intra_dev]));
+          HIP_CHECK(hipStreamSynchronize(stream[intra_dev]));
+          HIP_CHECK(hipMemcpy(B_h, A_d[peer_dst], NUM_ELM * sizeof(TestType), hipMemcpyDeviceToHost));
+          HipTest::checkTest(A_h, B_h, NUM_ELM);
+        }
+
+        HIP_CHECK(hipSetDevice(intra_dev));
+        HIP_CHECK(hipFree(scratch_d[intra_dev]));
         break;
       }
     }
     for (int i = 0; i < Available_Gpus; ++i) {
-      HIP_CHECK(hipSetDevice(i));
-      HIP_CHECK(hipFree((A_d[i])));
-      if (api >= TEST_MEMCPYD2D) {
+      if (A_d[i]) {
+        HIP_CHECK(hipSetDevice(i));
+        HIP_CHECK(hipFree(A_d[i]));
+      }
+      if (stream_ok[i]) {
         HIP_CHECK(hipStreamDestroy(stream[i]));
       }
     }
@@ -228,13 +349,90 @@ template <typename TestType> void Memcpy_And_verify(int NUM_ELM) {
   }
 }
 
-HIP_TEMPLATE_TEST_CASE(Stress_hipMemcpy_multiDevice_AllAPIs, char, int, size_t, long double) {
-  auto diff_size = GENERATE(1, 5, 10, 100, 1024, 10 * 1024, 100 * 1024, 1024 * 1024,
-                            10 * 1024 * 1024, 100 * 1024 * 1024, 1024 * 1024 * 1024);
+HIP_TEST_CASE(Stress_hipMemcpy_multiDevice_AllAPIs) {
+  constexpr size_t kSmokeMaxBytes = 32u * 1024u * 1024u;
+  // Memcpy_And_verify (smoke): MemcpyAsync / DtoDAsync run only for transfer <= 64 KiB.
+  static constexpr int kNumElmStepsSmoke[] = {
+      1,  3,  7,  15, 31,  33,  63,  65,  255, 257,  1023, 1025,  4095, 4097,
+      8191, 8193,  32767, 32769,  65535, 65537,
+      10 * 1024,
+      100 * 1024,
+      3 * 1024 * 1024,
+      7 * 1024 * 1024,
+      10 * 1024 * 1024,
+  };
+  static constexpr int kNumElmSteps[] = {
+      1,    3,     5,     7,     10,     15,    17,    31,    33,    48,
+      63,   65,    96,    97,    100,    101,   127,   129,   192,   255,
+      257,  511,   513,   768,   1009,   1023,  1025,  1536,  2047,  2049,
+      3072, 4095,  4097,  6144,  8191,   8193,  12288, 16383, 16385, 24576,
+      32767, 32769, 65535, 65537, 
+      10 * 1024,
+      100 * 1024,
+      3 * 1024 * 1024,
+      7 * 1024 * 1024,
+      10 * 1024 * 1024,
+      48 * 1024 * 1024,
+      100 * 1024 * 1024,
+  };
+  // Inclusive exponent range for 2^p elements. char: end=32 → 2^32 B transfer. Wider TestType: end=30 to cap bytes.
+  constexpr int kPow2StartPower = 0;
+  constexpr int kPow2EndPower = 32;
+
+  const bool smoke = (TestParameterStore::instance().currentTestLevel == "level_0");
+
   size_t free = 0, total = 0;
   HIP_CHECK(hipMemGetInfo(&free, &total));
-  if ((diff_size * sizeof(TestType)) <= free) {
-    Memcpy_And_verify<TestType>(diff_size);
-    HIP_CHECK(hipDeviceSynchronize());
+
+  const int* const extra_elm_steps = smoke ? kNumElmStepsSmoke : kNumElmSteps;
+  const size_t extra_elm_count =
+      smoke ? sizeof(kNumElmStepsSmoke) / sizeof(kNumElmStepsSmoke[0])
+            : sizeof(kNumElmSteps) / sizeof(kNumElmSteps[0]);
+
+  std::vector<size_t> all_sizes;
+  all_sizes.reserve((kPow2EndPower - kPow2StartPower + 1) + extra_elm_count);
+  for (int p = kPow2StartPower; p <= kPow2EndPower; ++p) {
+    all_sizes.push_back(1ull << p);
+  }
+  for (size_t e = 0; e < extra_elm_count; ++e) {
+    all_sizes.push_back(static_cast<size_t>(extra_elm_steps[e]));
+  }
+  std::sort(all_sizes.begin(), all_sizes.end());
+  all_sizes.erase(std::unique(all_sizes.begin(), all_sizes.end()), all_sizes.end());
+
+  auto use_size = [&](size_t NUM_ELM) -> bool {
+    NUM_ELM = std::max(NUM_ELM, size_t{1});
+    const size_t requested_bytes = NUM_ELM * sizeof(char);
+    // level_0 smoke: cap all scheduled sizes at 32 MiB (Memcpy_And_verify uses a subset of APIs).
+    if (smoke && requested_bytes > kSmokeMaxBytes) {
+      return false;
+    }
+    return true;
+  };
+
+  int total_steps = 0;
+  for (size_t NUM_ELM : all_sizes) {
+    if (use_size(NUM_ELM)) {
+      ++total_steps;
+    }
+  }
+
+  int step = 0;
+  for (size_t NUM_ELM : all_sizes) {
+    NUM_ELM = std::max(NUM_ELM, size_t{1});
+    if (!use_size(NUM_ELM)) {
+      continue;
+    }
+    ++step;
+    const size_t requested_bytes = NUM_ELM * sizeof(char);
+    std::cout << "[Stress_hipMemcpy_multiDevice_AllAPIs] " << step << "/" << total_steps
+              << " NUM_ELM=" << NUM_ELM << " bytes=" << requested_bytes << std::endl;
+    if (requested_bytes <= free) {
+      Memcpy_And_verify<char>(NUM_ELM);
+      HIP_CHECK(hipDeviceSynchronize());
+    } else {
+      std::cout << "[Stress_hipMemcpy_multiDevice_AllAPIs] skip (need " << requested_bytes
+                << " B, free " << free << " B)" << std::endl;
+    }
   }
 }

--- a/projects/hip-tests/catch/stress/memory/hipMemcpyMThreadMSize.cc
+++ b/projects/hip-tests/catch/stress/memory/hipMemcpyMThreadMSize.cc
@@ -85,12 +85,11 @@ const char* ApiToString(apiToTest api) {
 }  // namespace
 
 template <typename TestType> void Memcpy_And_verify(size_t NUM_ELM) {
-  // MEMCPYH2D / DtoH / H2DAsync / DtoHAsync: only run when transfer <= 64 KiB (level_2+). Not run at all for
-  // level_0 (quick level). MEMCPY / DtoD (sync): no per-API cap beyond quick level 32 MiB.
-  // level_0 (quick level): MemcpyAsync / DtoDAsync only when transfer <= 64 KiB.
+  // level_0 (quick level): skip H2D/D2H/H2DAsync/D2HAsync entirely,
+  // and cap async APIs (MemcpyAsync/DtoDAsync) at 64 KiB.
+  // All other levels run every API at every size.
   // Each API uses one randomly chosen GPU (and a second for P2P when applicable); device memory is
   // allocated only for GPUs used in that iteration.
-  constexpr size_t kNonPrimaryApiMaxBytes = 64u * 1024u;
   constexpr size_t kQuickAsyncMaxBytes = 64u * 1024u;
   const size_t requested_bytes = NUM_ELM * sizeof(TestType);
 
@@ -98,11 +97,6 @@ template <typename TestType> void Memcpy_And_verify(size_t NUM_ELM) {
   for (apiToTest api = TEST_MEMCPY; api <= TEST_MEMCPYD2DASYNC; api = apiToTest(api + 1)) {
     if (isQuickLevel() && (api == TEST_MEMCPYH2D || api == TEST_MEMCPYD2H || api == TEST_MEMCPYH2DASYNC ||
                            api == TEST_MEMCPYD2HASYNC)) {
-      continue;
-    }
-    const bool primary_api = (api == TEST_MEMCPY || api == TEST_MEMCPYD2D || api == TEST_MEMCPYASYNC ||
-                              api == TEST_MEMCPYD2DASYNC);
-    if (!primary_api && requested_bytes > kNonPrimaryApiMaxBytes) {
       continue;
     }
     const bool async_api = (api == TEST_MEMCPYASYNC || api == TEST_MEMCPYH2DASYNC ||

--- a/projects/hip-tests/catch/stress/memory/hipMemcpyMThreadMSize.cc
+++ b/projects/hip-tests/catch/stress/memory/hipMemcpyMThreadMSize.cc
@@ -1,26 +1,12 @@
 /*
-Copyright (c) 2021 - present Advanced Micro Devices, Inc. All rights reserved.
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-*/
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
 
 #include <hip_test_common.hh>
 #include <hip_test_kernels.hh>
 #include <hip_test_checkers.hh>
-#include <hip_test_params.hh>
 #include <algorithm>
 #include <iostream>
 #include <random>
@@ -100,20 +86,18 @@ const char* ApiToString(apiToTest api) {
 
 template <typename TestType> void Memcpy_And_verify(size_t NUM_ELM) {
   // MEMCPYH2D / DtoH / H2DAsync / DtoHAsync: only run when transfer <= 64 KiB (level_2+). Not run at all for
-  // level_0 smoke. MEMCPY / DtoD (sync): no per-API cap beyond smoke 32 MiB.
-  // level_0 smoke: MemcpyAsync / DtoDAsync only when transfer <= 64 KiB.
+  // level_0 (quick level). MEMCPY / DtoD (sync): no per-API cap beyond quick level 32 MiB.
+  // level_0 (quick level): MemcpyAsync / DtoDAsync only when transfer <= 64 KiB.
   // Each API uses one randomly chosen GPU (and a second for P2P when applicable); device memory is
   // allocated only for GPUs used in that iteration.
   constexpr size_t kNonPrimaryApiMaxBytes = 64u * 1024u;
-  constexpr size_t kSmokeAsyncMaxBytes = 64u * 1024u;
+  constexpr size_t kQuickAsyncMaxBytes = 64u * 1024u;
   const size_t requested_bytes = NUM_ELM * sizeof(TestType);
-  const bool smoke_level =
-      (TestParameterStore::instance().currentTestLevel == "level_0");
 
   TestType *A_h, *B_h;
   for (apiToTest api = TEST_MEMCPY; api <= TEST_MEMCPYD2DASYNC; api = apiToTest(api + 1)) {
-    if (smoke_level && (api == TEST_MEMCPYH2D || api == TEST_MEMCPYD2H || api == TEST_MEMCPYH2DASYNC ||
-                        api == TEST_MEMCPYD2HASYNC)) {
+    if (isQuickLevel() && (api == TEST_MEMCPYH2D || api == TEST_MEMCPYD2H || api == TEST_MEMCPYH2DASYNC ||
+                           api == TEST_MEMCPYD2HASYNC)) {
       continue;
     }
     const bool primary_api = (api == TEST_MEMCPY || api == TEST_MEMCPYD2D || api == TEST_MEMCPYASYNC ||
@@ -123,7 +107,7 @@ template <typename TestType> void Memcpy_And_verify(size_t NUM_ELM) {
     }
     const bool async_api = (api == TEST_MEMCPYASYNC || api == TEST_MEMCPYH2DASYNC ||
                             api == TEST_MEMCPYD2HASYNC || api == TEST_MEMCPYD2DASYNC);
-    if (smoke_level && async_api && requested_bytes > kSmokeAsyncMaxBytes) {
+    if (isQuickLevel() && async_api && requested_bytes > kQuickAsyncMaxBytes) {
       continue;
     }
 
@@ -350,9 +334,9 @@ template <typename TestType> void Memcpy_And_verify(size_t NUM_ELM) {
 }
 
 HIP_TEST_CASE(Stress_hipMemcpy_multiDevice_AllAPIs) {
-  constexpr size_t kSmokeMaxBytes = 32u * 1024u * 1024u;
-  // Memcpy_And_verify (smoke): MemcpyAsync / DtoDAsync run only for transfer <= 64 KiB.
-  static constexpr int kNumElmStepsSmoke[] = {
+  constexpr size_t kQuickMaxBytes = 32u * 1024u * 1024u;
+  // Memcpy_And_verify (quick level): MemcpyAsync / DtoDAsync run only for transfer <= 64 KiB.
+  static constexpr int kNumElmStepsQuick[] = {
       1,  3,  7,  15, 31,  33,  63,  65,  255, 257,  1023, 1025,  4095, 4097,
       8191, 8193,  32767, 32769,  65535, 65537,
       10 * 1024,
@@ -379,15 +363,13 @@ HIP_TEST_CASE(Stress_hipMemcpy_multiDevice_AllAPIs) {
   constexpr int kPow2StartPower = 0;
   constexpr int kPow2EndPower = 32;
 
-  const bool smoke = (TestParameterStore::instance().currentTestLevel == "level_0");
-
   size_t free = 0, total = 0;
   HIP_CHECK(hipMemGetInfo(&free, &total));
 
-  const int* const extra_elm_steps = smoke ? kNumElmStepsSmoke : kNumElmSteps;
+  const int* const extra_elm_steps = isQuickLevel() ? kNumElmStepsQuick : kNumElmSteps;
   const size_t extra_elm_count =
-      smoke ? sizeof(kNumElmStepsSmoke) / sizeof(kNumElmStepsSmoke[0])
-            : sizeof(kNumElmSteps) / sizeof(kNumElmSteps[0]);
+      isQuickLevel() ? sizeof(kNumElmStepsQuick) / sizeof(kNumElmStepsQuick[0])
+                     : sizeof(kNumElmSteps) / sizeof(kNumElmSteps[0]);
 
   std::vector<size_t> all_sizes;
   all_sizes.reserve((kPow2EndPower - kPow2StartPower + 1) + extra_elm_count);
@@ -403,8 +385,8 @@ HIP_TEST_CASE(Stress_hipMemcpy_multiDevice_AllAPIs) {
   auto use_size = [&](size_t NUM_ELM) -> bool {
     NUM_ELM = std::max(NUM_ELM, size_t{1});
     const size_t requested_bytes = NUM_ELM * sizeof(char);
-    // level_0 smoke: cap all scheduled sizes at 32 MiB (Memcpy_And_verify uses a subset of APIs).
-    if (smoke && requested_bytes > kSmokeMaxBytes) {
+    // level_0 (quick level): cap all scheduled sizes at 32 MiB (Memcpy_And_verify uses a subset of APIs).
+    if (isQuickLevel() && requested_bytes > kQuickMaxBytes) {
       return false;
     }
     return true;

--- a/projects/hip-tests/catch/unit/deviceLib/deviceAllocation.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/deviceAllocation.cc
@@ -757,7 +757,9 @@ static bool TestAlloc_Load_MultKernels(int test_type, int value) {
  */
 template <typename T> static bool TestMemoryAcrossMulKernelsUsingGraph(int test_type) {
   T *outputVec_d{nullptr}, *outputVec_h{nullptr};
-  size_t arraysize = (BLOCKSIZE * GRIDSIZE);
+  const int gridSize = isQuickLevel() ? 4 : GRIDSIZE;
+  const int blockSize = isQuickLevel() ? 16 : BLOCKSIZE;
+  size_t arraysize = (blockSize * gridSize);
   T data_value = std::numeric_limits<T>::max();
   outputVec_h = reinterpret_cast<T*>(malloc(sizeof(T) * arraysize));
   REQUIRE(outputVec_h != nullptr);
@@ -773,8 +775,8 @@ template <typename T> static bool TestMemoryAcrossMulKernelsUsingGraph(int test_
   hipKernelNodeParams kernelNodeParams1{};
   void* kernelArgs1[] = {reinterpret_cast<void*>(&test_type)};
   kernelNodeParams1.func = reinterpret_cast<void*>(kerAlloc<T>);
-  kernelNodeParams1.gridDim = dim3(GRIDSIZE);
-  kernelNodeParams1.blockDim = dim3(BLOCKSIZE);
+  kernelNodeParams1.gridDim = dim3(gridSize);
+  kernelNodeParams1.blockDim = dim3(blockSize);
   kernelNodeParams1.sharedMemBytes = 0;
   kernelNodeParams1.kernelParams = reinterpret_cast<void**>(kernelArgs1);
   kernelNodeParams1.extra = nullptr;
@@ -784,8 +786,8 @@ template <typename T> static bool TestMemoryAcrossMulKernelsUsingGraph(int test_
   hipKernelNodeParams kernelNodeParams2{};
   void* kernelArgs2[] = {reinterpret_cast<void*>(&data_value)};
   kernelNodeParams2.func = reinterpret_cast<void*>(kerWrite<T>);
-  kernelNodeParams2.gridDim = dim3(GRIDSIZE);
-  kernelNodeParams2.blockDim = dim3(BLOCKSIZE);
+  kernelNodeParams2.gridDim = dim3(gridSize);
+  kernelNodeParams2.blockDim = dim3(blockSize);
   kernelNodeParams2.sharedMemBytes = 0;
   kernelNodeParams2.kernelParams = reinterpret_cast<void**>(kernelArgs2);
   kernelNodeParams2.extra = nullptr;
@@ -795,8 +797,8 @@ template <typename T> static bool TestMemoryAcrossMulKernelsUsingGraph(int test_
   hipKernelNodeParams kernelNodeParams3{};
   void* kernelArgs3[] = {&outputVec_d, reinterpret_cast<void*>(&test_type)};
   kernelNodeParams3.func = reinterpret_cast<void*>(kerFree<T>);
-  kernelNodeParams3.gridDim = dim3(GRIDSIZE);
-  kernelNodeParams3.blockDim = dim3(BLOCKSIZE);
+  kernelNodeParams3.gridDim = dim3(gridSize);
+  kernelNodeParams3.blockDim = dim3(blockSize);
   kernelNodeParams3.sharedMemBytes = 0;
   kernelNodeParams3.kernelParams = reinterpret_cast<void**>(kernelArgs3);
   kernelNodeParams3.extra = nullptr;
@@ -1207,19 +1209,15 @@ HIP_TEST_CASE(Unit_deviceAllocation_Malloc_PerThread_Graph) {
   SECTION("Test char datatype allocation with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<char>(TEST_MALLOC_FREE));
   }
-
   SECTION("Test short datatype allocation with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<int16_t>(TEST_MALLOC_FREE));
   }
-
   SECTION("Test int datatype allocation with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<int32_t>(TEST_MALLOC_FREE));
   }
-
   SECTION("Test float datatype allocation with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<float>(TEST_MALLOC_FREE));
   }
-
   SECTION("Test double datatype allocation with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<double>(TEST_MALLOC_FREE));
   }
@@ -1240,19 +1238,15 @@ HIP_TEST_CASE(Unit_deviceAllocation_New_PerThread_Graph) {
   SECTION("Test char datatype allocation with new") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<char>(TEST_NEW_DELETE));
   }
-
   SECTION("Test short datatype allocation with new") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<int16_t>(TEST_NEW_DELETE));
   }
-
   SECTION("Test int datatype allocation with new") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<int32_t>(TEST_NEW_DELETE));
   }
-
   SECTION("Test float datatype allocation with new") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<float>(TEST_NEW_DELETE));
   }
-
   SECTION("Test double datatype allocation with new") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<double>(TEST_NEW_DELETE));
   }

--- a/projects/hip-tests/catch/unit/deviceLib/deviceAllocation.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/deviceAllocation.cc
@@ -1209,15 +1209,19 @@ HIP_TEST_CASE(Unit_deviceAllocation_Malloc_PerThread_Graph) {
   SECTION("Test char datatype allocation with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<char>(TEST_MALLOC_FREE));
   }
+
   SECTION("Test short datatype allocation with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<int16_t>(TEST_MALLOC_FREE));
   }
+
   SECTION("Test int datatype allocation with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<int32_t>(TEST_MALLOC_FREE));
   }
+
   SECTION("Test float datatype allocation with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<float>(TEST_MALLOC_FREE));
   }
+
   SECTION("Test double datatype allocation with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<double>(TEST_MALLOC_FREE));
   }
@@ -1238,15 +1242,19 @@ HIP_TEST_CASE(Unit_deviceAllocation_New_PerThread_Graph) {
   SECTION("Test char datatype allocation with new") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<char>(TEST_NEW_DELETE));
   }
+
   SECTION("Test short datatype allocation with new") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<int16_t>(TEST_NEW_DELETE));
   }
+
   SECTION("Test int datatype allocation with new") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<int32_t>(TEST_NEW_DELETE));
   }
+
   SECTION("Test float datatype allocation with new") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<float>(TEST_NEW_DELETE));
   }
+
   SECTION("Test double datatype allocation with new") {
     REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<double>(TEST_NEW_DELETE));
   }

--- a/projects/hip-tests/catch/unit/deviceLib/fp16_ops.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp16_ops.cc
@@ -56,7 +56,7 @@ void fp16_arith_cpu(const std::vector<float>& a, const std::vector<float>& b,
 
 HIP_TEST_CASE(Unit_fp16_arith) {
   constexpr size_t num_of_ops = 18;
-  constexpr size_t iters = 100;
+  const size_t iters = isQuickLevel() ? 10 : 100;
   Catch::Generators::RandomFloatingGenerator<float> input1_gen(2.2f, 10.f, /*seed*/ 0x1234);
   constexpr float input2 = 1.1f;
   for (size_t iter = 0; iter < iters; iter++) {
@@ -136,7 +136,7 @@ void fp162_arith_cpu(std::vector<float2>& a, std::vector<float2>& b, std::vector
 
 HIP_TEST_CASE(Unit_fp162_arith) {
   constexpr size_t num_of_ops = 18;
-  constexpr size_t iters = 100;
+  const size_t iters = isQuickLevel() ? 10 : 100;
   Catch::Generators::RandomFloatingGenerator<float> input1_gen(2.2f, 10.f, /* seed */ 0x1234);
   for (size_t iter = 0; iter < iters; iter++) {
     auto input1 = input1_gen.get();

--- a/projects/hip-tests/catch/unit/event/Unit_hipEvent.cc
+++ b/projects/hip-tests/catch/unit/event/Unit_hipEvent.cc
@@ -187,7 +187,7 @@ void runTests(int64_t numElements) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-HIP_TEST_CASE(Unit_hipEvent) { runTests(10000000); }
+HIP_TEST_CASE(Unit_hipEvent) { runTests(isQuickLevel() ? 1000000 : 10000000); }
 
 /**
  * End doxygen group EventTest.

--- a/projects/hip-tests/catch/unit/event/Unit_hipEventElapsedTime.cc
+++ b/projects/hip-tests/catch/unit/event/Unit_hipEventElapsedTime.cc
@@ -149,7 +149,7 @@ HIP_TEST_CASE(Unit_hipEventElapsedTime_NotReady_Negative) {
   // Record start event
   HIP_CHECK(hipEventRecord(start, nullptr));
 
-  LaunchDelayKernel(std::chrono::milliseconds(1000));
+  LaunchDelayKernel(std::chrono::milliseconds(isQuickLevel() ? 100 : 1000));
   // Record stop event
   HIP_CHECK(hipEventRecord(stop, nullptr));
 

--- a/projects/hip-tests/catch/unit/event/Unit_hipEventQuery.cc
+++ b/projects/hip-tests/catch/unit/event/Unit_hipEventQuery.cc
@@ -42,7 +42,7 @@ HIP_TEST_CASE(Unit_hipEventQuery_DifferentDevice) {
   {
     HIP_CHECK(hipSetDevice(0));
     HIP_CHECK(hipEventRecord(event1, stream));
-    LaunchDelayKernel(std::chrono::milliseconds(3000), stream);
+    LaunchDelayKernel(std::chrono::milliseconds(isQuickLevel() ? 100 : 3000), stream);
     HIP_CHECK(hipEventRecord(event2, stream));
 
     HIP_CHECK(hipEventSynchronize(event1));

--- a/projects/hip-tests/catch/unit/event/hipEventCreateWithFlags.cc
+++ b/projects/hip-tests/catch/unit/event/hipEventCreateWithFlags.cc
@@ -10,8 +10,8 @@
 #include <stdlib.h>
 
 constexpr size_t buffer_size = (1024 * 1024);
-static const int test_iteration_hstvismem = isQuickLevel() ? 3 : 5;
-static const int test_iteration_noncohmem = isQuickLevel() ? 5 : 10;
+static int test_iteration_hstvismem() { return isQuickLevel() ? 3 : 5; }
+static int test_iteration_noncohmem() { return isQuickLevel() ? 5 : 10; }
 constexpr int block_size = 512;
 
 // Atomic store required as events are created with special flag hipEventDisableSystemFence [Ref : SWDEV-523177]
@@ -113,13 +113,13 @@ static void testMemCoherency(eSyncToTest test, eMemoryToTest mem, uint32_t flags
   int total_iter = 0;
   if (mem == eMemoryToTest::eHostVisibleMemory) {
     HIP_CHECK(hipMalloc(&buf_d, buffer_size * sizeof(int)));
-    total_iter = test_iteration_hstvismem;
+    total_iter = test_iteration_hstvismem();
   } else if (mem == eMemoryToTest::eNonCoherentHostMemory) {
     HIP_CHECK(hipHostMalloc(&buf_d, buffer_size * sizeof(int), hipHostMallocNonCoherent));
-    total_iter = test_iteration_noncohmem;
+    total_iter = test_iteration_noncohmem();
   } else if (mem == eMemoryToTest::eCoherentHostMemory) {
     HIP_CHECK(hipHostMalloc(&buf_d, buffer_size * sizeof(int), hipHostMallocCoherent));
-    total_iter = test_iteration_noncohmem;
+    total_iter = test_iteration_noncohmem();
   }
   for (int iter = 0; iter < total_iter; iter++) {
     // Inititalize the buffer with random data

--- a/projects/hip-tests/catch/unit/event/hipEventCreateWithFlags.cc
+++ b/projects/hip-tests/catch/unit/event/hipEventCreateWithFlags.cc
@@ -10,8 +10,8 @@
 #include <stdlib.h>
 
 constexpr size_t buffer_size = (1024 * 1024);
-constexpr int test_iteration_hstvismem = 5;
-constexpr int test_iteration_noncohmem = 10;
+static const int test_iteration_hstvismem = isQuickLevel() ? 3 : 5;
+static const int test_iteration_noncohmem = isQuickLevel() ? 5 : 10;
 constexpr int block_size = 512;
 
 // Atomic store required as events are created with special flag hipEventDisableSystemFence [Ref : SWDEV-523177]

--- a/projects/hip-tests/catch/unit/event/hipEventDestroy.cc
+++ b/projects/hip-tests/catch/unit/event/hipEventDestroy.cc
@@ -57,7 +57,8 @@ HIP_TEST_CASE(Unit_hipEventDestroy_Unfinished) {
   HIP_CHECK(hipEventCreate(&event));
 
   float *A_h, *B_h, *C_h;
-  launchVectorAdd(A_h, B_h, C_h, std::chrono::milliseconds(1000));
+  launchVectorAdd(A_h, B_h, C_h,
+                  std::chrono::milliseconds(isQuickLevel() ? 100 : 1000));
 
   HIP_CHECK(hipEventRecord(event));
   HIP_CHECK_ERROR(hipEventQuery(event), hipErrorNotReady);

--- a/projects/hip-tests/catch/unit/graph/hipGraph.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraph.cc
@@ -16,6 +16,7 @@ Testcase Scenarios :
 
 #define THREADS_PER_BLOCK 512
 #define GRAPH_LAUNCH_ITERATIONS 1000
+#define GRAPH_LAUNCH_ITERS_QUICK 10
 
 static __global__ void reduce(float* d_in, double* d_out) {
   int myId = threadIdx.x + blockDim.x * blockIdx.x;
@@ -67,7 +68,7 @@ static void hipWithoutGraphs(float* inputVec_h, float* inputVec_d, double* outpu
   HIP_CHECK(hipEventCreate(&memsetEvent1));
   HIP_CHECK(hipEventCreate(&memsetEvent2));
   auto start = std::chrono::high_resolution_clock::now();
-  for (int i = 0; i < GRAPH_LAUNCH_ITERATIONS; i++) {
+  for (int i = 0, _iters = isQuickLevel() ? GRAPH_LAUNCH_ITERS_QUICK : GRAPH_LAUNCH_ITERATIONS; i < _iters; i++) {
     HIP_CHECK(hipMemcpyAsync(inputVec_d, inputVec_h, sizeof(float) * inputSize, hipMemcpyDefault,
                              stream1));
     HIP_CHECK(hipMemsetAsync(outputVec_d, 0, sizeof(double) * numOfBlocks, stream2));
@@ -152,7 +153,7 @@ static void hipGraphsUsingStreamCapture(float* inputVec_h, float* inputVec_d, do
 
   HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
   auto start1 = std::chrono::high_resolution_clock::now();
-  for (int i = 0; i < GRAPH_LAUNCH_ITERATIONS; i++) {
+  for (int i = 0, _iters = isQuickLevel() ? GRAPH_LAUNCH_ITERS_QUICK : GRAPH_LAUNCH_ITERATIONS; i < _iters; i++) {
     HIP_CHECK(hipGraphLaunch(graphExec, streamForGraph));
   }
   HIP_CHECK(hipStreamSynchronize(streamForGraph));
@@ -258,7 +259,7 @@ static void hipGraphsManual(float* inputVec_h, float* inputVec_d, double* output
       << numNodes);
   HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
   auto start1 = std::chrono::high_resolution_clock::now();
-  for (int i = 0; i < GRAPH_LAUNCH_ITERATIONS; i++) {
+  for (int i = 0, _iters = isQuickLevel() ? GRAPH_LAUNCH_ITERS_QUICK : GRAPH_LAUNCH_ITERATIONS; i < _iters; i++) {
     HIP_CHECK(hipGraphLaunch(graphExec, streamForGraph));
   }
   HIP_CHECK(hipStreamSynchronize(streamForGraph));

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddEventRecordNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddEventRecordNode.cc
@@ -225,7 +225,7 @@ HIP_TEST_CASE(Unit_hipGraphAddEventRecordNode_Functional_WithFlags) {
  * 100 times in a loop.
  */
 HIP_TEST_CASE(Unit_hipGraphAddEventRecordNode_MultipleRun) {
-  validateAddEventRecordNode(false, false, 100);
+  validateAddEventRecordNode(false, false, isQuickLevel() ? 10 : 100);
 }
 
 /**

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddEventWaitNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddEventWaitNode.cc
@@ -211,7 +211,7 @@ HIP_TEST_CASE(Unit_hipGraphAddEventWaitNode_MultGraphMultStrmDependency) {
  * Scenario 3
  */
 HIP_TEST_CASE(Unit_hipGraphAddEventWaitNode_MultipleRun) {
-  validate_hipGraphAddEventWaitNode_internodedep(0, 100);
+  validate_hipGraphAddEventWaitNode_internodedep(0, isQuickLevel() ? 10 : 100);
 }
 
 /**

--- a/projects/hip-tests/catch/unit/graph/hipGraphAsyncUserObj.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAsyncUserObj.cc
@@ -45,6 +45,8 @@ void threadFunc_dltMemory() {
   HIP_CHECK(hipHostFree(globalPtr));
   setVar = false;
 }
+static int kernelDelayMs() { return isQuickLevel() ? 500 : 5000; }
+
 void destroyPinnedObj(void* ptr) {
   globalPtr = ptr;
   setVar = true;
@@ -59,7 +61,7 @@ void hipUserObjectCreate_int_float_Objects(T* hostArr, T* devArr, void destroyOb
   HIP_CHECK(hipStreamCreate(&stream));
   HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
   HIP_CHECK(hipMemcpyAsync(devArr, hostArr, sizeof(int), hipMemcpyHostToDevice, stream));
-  KernelFn<<<1, 1, 0, stream>>>(devArr, clockrate, isQuickLevel() ? 500 : 5000);
+  KernelFn<<<1, 1, 0, stream>>>(devArr, clockrate, kernelDelayMs());
   HIP_CHECK(hipMemcpyAsync(hostArr, devArr, sizeof(int), hipMemcpyDeviceToHost, stream));
   HIP_CHECK(hipStreamEndCapture(stream, &graph));
   REQUIRE(graph != nullptr);
@@ -164,7 +166,7 @@ HIP_TEST_CASE(Unit_hipGraphUserObj_HostRegister) {
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
   HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
-  KernelFn<<<1, 1, 0, stream>>>(A_d, clockrate, isQuickLevel() ? 500 : 5000);
+  KernelFn<<<1, 1, 0, stream>>>(A_d, clockrate, kernelDelayMs());
   HIP_CHECK(hipStreamEndCapture(stream, &graph));
   REQUIRE(graph != nullptr);
   hipUserObject_t Uobj;
@@ -200,7 +202,7 @@ template <typename T> void hipUserObjectCreate_Struct_Class_Objects(T* Obj_h, T*
   HIP_CHECK(hipStreamCreate(&stream));
   HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
   HIP_CHECK(hipMemcpyAsync(Obj_d, Obj_h, sizeof(BoxStruct), hipMemcpyHostToDevice, stream));
-  StructClassKernelFn<<<1, 1, 0, stream>>>(Obj_d, clockrate, isQuickLevel() ? 500 : 5000);
+  StructClassKernelFn<<<1, 1, 0, stream>>>(Obj_d, clockrate, kernelDelayMs());
   HIP_CHECK(hipMemcpyAsync(Obj_h, Obj_d, sizeof(BoxStruct), hipMemcpyDeviceToHost, stream));
   HIP_CHECK(hipStreamEndCapture(stream, &graph));
   REQUIRE(graph != nullptr);
@@ -295,7 +297,7 @@ HIP_TEST_CASE(Unit_hipGraphUserObj_ClonedGraph) {
   HIP_CHECK(hipStreamCreate(&stream));
   HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
   HIP_CHECK(hipMemcpyAsync(devArr, hostArr, sizeof(int), hipMemcpyHostToDevice, stream));
-  KernelFn<<<1, 1, 0, stream>>>(devArr, clockrate, isQuickLevel() ? 500 : 5000);
+  KernelFn<<<1, 1, 0, stream>>>(devArr, clockrate, kernelDelayMs());
   HIP_CHECK(hipMemcpyAsync(hostArr, devArr, sizeof(int), hipMemcpyDeviceToHost, stream));
   HIP_CHECK(hipStreamEndCapture(stream, &graph));
   REQUIRE(graph != nullptr);
@@ -372,7 +374,7 @@ HIP_TEST_CASE(Unit_hipGraphUserObj_ManualGraph) {
                                     hipMemcpyHostToDevice));
   dependencies.push_back(memcpyNode);
   kNodeParams.func = reinterpret_cast<void*>(ManualGraphKernelFn);
-  int delay = isQuickLevel() ? 500 : 5000;
+  int delay = kernelDelayMs();
   void* kernelArgs[] = {reinterpret_cast<void*>(&devArr), &clockrate, &delay};
   kNodeParams.gridDim = dim3(1);
   kNodeParams.blockDim = dim3(1);

--- a/projects/hip-tests/catch/unit/graph/hipGraphAsyncUserObj.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAsyncUserObj.cc
@@ -23,9 +23,9 @@ std::condition_variable cv;
  *                                 unsigned int flags);`
  * - Create an instance of userObject to manage lifetime of a resource.
  */
-template <typename T> __global__ void KernelFn(T* Ad, int clockrate, int WaitSecs) {
+template <typename T> __global__ void KernelFn(T* Ad, int clockrate, int WaitMs) {
   uint64_t num_cycles = (uint64_t)clockrate;
-  num_cycles = num_cycles * 1000 * WaitSecs;
+  num_cycles = num_cycles * WaitMs;
   uint64_t start = clock64(), cycles = 0;
   while (cycles < num_cycles) {
     cycles = clock64() - start;
@@ -59,7 +59,7 @@ void hipUserObjectCreate_int_float_Objects(T* hostArr, T* devArr, void destroyOb
   HIP_CHECK(hipStreamCreate(&stream));
   HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
   HIP_CHECK(hipMemcpyAsync(devArr, hostArr, sizeof(int), hipMemcpyHostToDevice, stream));
-  KernelFn<<<1, 1, 0, stream>>>(devArr, clockrate, 5);
+  KernelFn<<<1, 1, 0, stream>>>(devArr, clockrate, isQuickLevel() ? 500 : 5000);
   HIP_CHECK(hipMemcpyAsync(hostArr, devArr, sizeof(int), hipMemcpyDeviceToHost, stream));
   HIP_CHECK(hipStreamEndCapture(stream, &graph));
   REQUIRE(graph != nullptr);
@@ -164,7 +164,7 @@ HIP_TEST_CASE(Unit_hipGraphUserObj_HostRegister) {
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
   HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
-  KernelFn<<<1, 1, 0, stream>>>(A_d, clockrate, 5);
+  KernelFn<<<1, 1, 0, stream>>>(A_d, clockrate, isQuickLevel() ? 500 : 5000);
   HIP_CHECK(hipStreamEndCapture(stream, &graph));
   REQUIRE(graph != nullptr);
   hipUserObject_t Uobj;
@@ -183,9 +183,9 @@ HIP_TEST_CASE(Unit_hipGraphUserObj_HostRegister) {
   HIP_CHECK(hipStreamDestroy(stream));
   HIP_CHECK(hipHostUnregister(A_h));
 }
-template <typename T> __global__ void StructClassKernelFn(T* Obj, int clockrate, int WaitSecs) {
+template <typename T> __global__ void StructClassKernelFn(T* Obj, int clockrate, int WaitMs) {
   uint64_t num_cycles = (uint64_t)clockrate;
-  num_cycles = num_cycles * 1000 * WaitSecs;
+  num_cycles = num_cycles * WaitMs;
   uint64_t start = clock64(), cycles = 0;
   while (cycles < num_cycles) {
     cycles = clock64() - start;
@@ -200,7 +200,7 @@ template <typename T> void hipUserObjectCreate_Struct_Class_Objects(T* Obj_h, T*
   HIP_CHECK(hipStreamCreate(&stream));
   HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
   HIP_CHECK(hipMemcpyAsync(Obj_d, Obj_h, sizeof(BoxStruct), hipMemcpyHostToDevice, stream));
-  StructClassKernelFn<<<1, 1, 0, stream>>>(Obj_d, clockrate, 5);
+  StructClassKernelFn<<<1, 1, 0, stream>>>(Obj_d, clockrate, isQuickLevel() ? 500 : 5000);
   HIP_CHECK(hipMemcpyAsync(Obj_h, Obj_d, sizeof(BoxStruct), hipMemcpyDeviceToHost, stream));
   HIP_CHECK(hipStreamEndCapture(stream, &graph));
   REQUIRE(graph != nullptr);
@@ -295,7 +295,7 @@ HIP_TEST_CASE(Unit_hipGraphUserObj_ClonedGraph) {
   HIP_CHECK(hipStreamCreate(&stream));
   HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
   HIP_CHECK(hipMemcpyAsync(devArr, hostArr, sizeof(int), hipMemcpyHostToDevice, stream));
-  KernelFn<<<1, 1, 0, stream>>>(devArr, clockrate, 5);
+  KernelFn<<<1, 1, 0, stream>>>(devArr, clockrate, isQuickLevel() ? 500 : 5000);
   HIP_CHECK(hipMemcpyAsync(hostArr, devArr, sizeof(int), hipMemcpyDeviceToHost, stream));
   HIP_CHECK(hipStreamEndCapture(stream, &graph));
   REQUIRE(graph != nullptr);
@@ -325,9 +325,9 @@ HIP_TEST_CASE(Unit_hipGraphUserObj_ClonedGraph) {
   HIP_CHECK(hipStreamDestroy(stream));
   HIP_CHECK(hipFree(devArr));
 }
-__global__ void ManualGraphKernelFn(int* Ad, int clockrate, int WaitSecs) {
+__global__ void ManualGraphKernelFn(int* Ad, int clockrate, int WaitMs) {
   uint64_t num_cycles = (uint64_t)clockrate;
-  num_cycles = num_cycles * 1000 * WaitSecs;
+  num_cycles = num_cycles * WaitMs;
   uint64_t start = clock64(), cycles = 0;
   while (cycles < num_cycles) {
     cycles = clock64() - start;
@@ -372,7 +372,7 @@ HIP_TEST_CASE(Unit_hipGraphUserObj_ManualGraph) {
                                     hipMemcpyHostToDevice));
   dependencies.push_back(memcpyNode);
   kNodeParams.func = reinterpret_cast<void*>(ManualGraphKernelFn);
-  int delay = 5;
+  int delay = isQuickLevel() ? 500 : 5000;
   void* kernelArgs[] = {reinterpret_cast<void*>(&devArr), &clockrate, &delay};
   kNodeParams.gridDim = dim3(1);
   kNodeParams.blockDim = dim3(1);

--- a/projects/hip-tests/catch/unit/graph/hipSimpleGraphWithKernel.cc
+++ b/projects/hip-tests/catch/unit/graph/hipSimpleGraphWithKernel.cc
@@ -61,8 +61,9 @@ static void hipTestWithGraph() {
   HIP_CHECK(hipStreamEndCapture(stream, &graph));
   HIP_CHECK(hipGraphInstantiate(&instance, graph, nullptr, nullptr, 0));
 
+  const int nstep = isQuickLevel() ? 10 : NSTEP;
   auto start1 = std::chrono::high_resolution_clock::now();
-  for (int istep = 0; istep < NSTEP; istep++) {
+  for (int istep = 0; istep < nstep; istep++) {
     HIP_CHECK(hipGraphLaunch(instance, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
   }
@@ -115,8 +116,9 @@ static void hipTestWithoutGraph() {
   HIP_CHECK(hipMemcpy(in_d, in_h, N * sizeof(float), hipMemcpyHostToDevice));
 
   // start CPU wallclock timer
+  const int nstep2 = isQuickLevel() ? 10 : NSTEP;
   auto start = std::chrono::high_resolution_clock::now();
-  for (int istep = 0; istep < NSTEP; istep++) {
+  for (int istep = 0; istep < nstep2; istep++) {
     for (int ikrnl = 0; ikrnl < NKERNEL; ikrnl++) {
       simpleKernel<<<dim3(N / 512, 1, 1), dim3(512, 1, 1), 0, stream>>>(out_d, in_d);
     }

--- a/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture.cc
@@ -69,9 +69,11 @@ class eventQuery {
   hipError_t result_status = hipSuccess;
 };
 
+static size_t captureN() { return isQuickLevel() ? 10000 : 1000000; }
+
 template <typename T, typename F>
 void captureStreamAndLaunchGraph(F graphFunc, hipStreamCaptureMode mode, hipStream_t stream) {
-  const size_t N = isQuickLevel() ? 10000 : 1000000;
+  const size_t N = captureN();
   size_t Nbytes = N * sizeof(T);
 
   hipGraph_t graph{nullptr};
@@ -311,7 +313,7 @@ static void colligatedStrmCapture(const hipStream_t& stream1, const hipStream_t&
 /* Local function for colligated stream capture functionality
  */
 static void colligatedStrmCaptureFunc(const hipStream_t& stream1, const hipStream_t& stream2) {
-  const size_t N = isQuickLevel() ? 10000 : 1000000;
+  const size_t N = captureN();
   size_t Nbytes = N * sizeof(int);
 
   hipGraph_t graph1{nullptr}, graph2{nullptr};
@@ -379,7 +381,7 @@ static void threadStrmCaptureFunc(hipStream_t stream, int* A_h, int* A_d, int* B
 /* Local Function for multithreaded tests
  */
 static void multithreadedTest(hipStreamCaptureMode mode) {
-  const size_t N = isQuickLevel() ? 10000 : 1000000;
+  const size_t N = captureN();
   size_t Nbytes = N * sizeof(int);
 
   hipGraph_t graph1{nullptr}, graph2{nullptr};

--- a/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture.cc
@@ -71,7 +71,7 @@ class eventQuery {
 
 template <typename T, typename F>
 void captureStreamAndLaunchGraph(F graphFunc, hipStreamCaptureMode mode, hipStream_t stream) {
-  constexpr size_t N = 1000000;
+  const size_t N = isQuickLevel() ? 10000 : 1000000;
   size_t Nbytes = N * sizeof(T);
 
   hipGraph_t graph{nullptr};
@@ -311,7 +311,7 @@ static void colligatedStrmCapture(const hipStream_t& stream1, const hipStream_t&
 /* Local function for colligated stream capture functionality
  */
 static void colligatedStrmCaptureFunc(const hipStream_t& stream1, const hipStream_t& stream2) {
-  constexpr size_t N = 1000000;
+  const size_t N = isQuickLevel() ? 10000 : 1000000;
   size_t Nbytes = N * sizeof(int);
 
   hipGraph_t graph1{nullptr}, graph2{nullptr};
@@ -379,7 +379,7 @@ static void threadStrmCaptureFunc(hipStream_t stream, int* A_h, int* A_d, int* B
 /* Local Function for multithreaded tests
  */
 static void multithreadedTest(hipStreamCaptureMode mode) {
-  constexpr size_t N = 1000000;
+  const size_t N = isQuickLevel() ? 10000 : 1000000;
   size_t Nbytes = N * sizeof(int);
 
   hipGraph_t graph1{nullptr}, graph2{nullptr};

--- a/projects/hip-tests/catch/unit/graph/hipStreamEndCapture.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamEndCapture.cc
@@ -9,6 +9,8 @@
 
 #include "stream_capture_common.hh"
 
+static size_t captureN() { return isQuickLevel() ? 10000 : 1000000; }
+
 /**
  * @addtogroup hipStreamEndCapture hipStreamEndCapture
  * @{
@@ -65,7 +67,7 @@ HIP_TEST_CASE(Unit_hipStreamEndCapture_Negative_Parameters) {
  */
 HIP_TEST_CASE(Unit_hipStreamEndCapture_Positive_GraphDestroy) {
   hipGraph_t graph{nullptr};
-  const size_t N = isQuickLevel() ? 10000 : 1000000;
+  const size_t N = captureN();
   size_t Nbytes = N * sizeof(float);
 
   LinearAllocGuard<float> A_h(LinearAllocs::malloc, Nbytes);
@@ -104,7 +106,7 @@ static void thread_func_neg(hipStream_t stream, hipGraph_t graph) {
  *    - HIP_VERSION >= 5.2
  */
 HIP_TEST_CASE(Unit_hipStreamEndCapture_Negative_Thread) {
-  const size_t N = isQuickLevel() ? 10000 : 1000000;
+  const size_t N = captureN();
   size_t Nbytes = N * sizeof(float);
 
   LinearAllocGuard<float> A_h(LinearAllocs::malloc, Nbytes);
@@ -148,7 +150,7 @@ static void thread_func_pos(hipStream_t stream, hipGraph_t* graph) {
  *    - HIP_VERSION >= 5.2
  */
 HIP_TEST_CASE(Unit_hipStreamEndCapture_Positive_Thread) {
-  const size_t N = isQuickLevel() ? 10000 : 1000000;
+  const size_t N = captureN();
   size_t Nbytes = N * sizeof(float);
 
   LinearAllocGuard<float> A_h(LinearAllocs::malloc, Nbytes);

--- a/projects/hip-tests/catch/unit/graph/hipStreamEndCapture.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamEndCapture.cc
@@ -65,7 +65,7 @@ HIP_TEST_CASE(Unit_hipStreamEndCapture_Negative_Parameters) {
  */
 HIP_TEST_CASE(Unit_hipStreamEndCapture_Positive_GraphDestroy) {
   hipGraph_t graph{nullptr};
-  constexpr size_t N = 1000000;
+  const size_t N = isQuickLevel() ? 10000 : 1000000;
   size_t Nbytes = N * sizeof(float);
 
   LinearAllocGuard<float> A_h(LinearAllocs::malloc, Nbytes);
@@ -104,7 +104,7 @@ static void thread_func_neg(hipStream_t stream, hipGraph_t graph) {
  *    - HIP_VERSION >= 5.2
  */
 HIP_TEST_CASE(Unit_hipStreamEndCapture_Negative_Thread) {
-  constexpr size_t N = 1000000;
+  const size_t N = isQuickLevel() ? 10000 : 1000000;
   size_t Nbytes = N * sizeof(float);
 
   LinearAllocGuard<float> A_h(LinearAllocs::malloc, Nbytes);
@@ -148,7 +148,7 @@ static void thread_func_pos(hipStream_t stream, hipGraph_t* graph) {
  *    - HIP_VERSION >= 5.2
  */
 HIP_TEST_CASE(Unit_hipStreamEndCapture_Positive_Thread) {
-  constexpr size_t N = 1000000;
+  const size_t N = isQuickLevel() ? 10000 : 1000000;
   size_t Nbytes = N * sizeof(float);
 
   LinearAllocGuard<float> A_h(LinearAllocs::malloc, Nbytes);

--- a/projects/hip-tests/catch/unit/graph/hipStreamIsCapturing.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamIsCapturing.cc
@@ -9,6 +9,8 @@
 
 #include "stream_capture_common.hh"
 
+static size_t captureN() { return isQuickLevel() ? 10000 : 1000000; }
+
 /**
  * @addtogroup hipStreamIsCapturing hipStreamIsCapturing
  * @{
@@ -74,7 +76,7 @@ HIP_TEST_CASE(Unit_hipStreamIsCapturing_Positive_Basic) {
 }
 
 void checkStreamCaptureStatus(hipStreamCaptureMode mode, hipStream_t stream) {
-  const size_t N = isQuickLevel() ? 10000 : 1000000;
+  const size_t N = captureN();
 
   hipStreamCaptureStatus cStatus;
   size_t Nbytes = N * sizeof(float);
@@ -162,7 +164,7 @@ static void thread_func(hipStream_t stream) {
  *    - HIP_VERSION >= 5.2
  */
 HIP_TEST_CASE(Unit_hipStreamIsCapturing_Positive_Thread) {
-  const size_t N = isQuickLevel() ? 10000 : 1000000;
+  const size_t N = captureN();
   size_t Nbytes = N * sizeof(float);
 
   hipGraph_t graph{nullptr};

--- a/projects/hip-tests/catch/unit/graph/hipStreamIsCapturing.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamIsCapturing.cc
@@ -74,7 +74,7 @@ HIP_TEST_CASE(Unit_hipStreamIsCapturing_Positive_Basic) {
 }
 
 void checkStreamCaptureStatus(hipStreamCaptureMode mode, hipStream_t stream) {
-  constexpr size_t N = 1000000;
+  const size_t N = isQuickLevel() ? 10000 : 1000000;
 
   hipStreamCaptureStatus cStatus;
   size_t Nbytes = N * sizeof(float);
@@ -162,7 +162,7 @@ static void thread_func(hipStream_t stream) {
  *    - HIP_VERSION >= 5.2
  */
 HIP_TEST_CASE(Unit_hipStreamIsCapturing_Positive_Thread) {
-  constexpr size_t N = 1000000;
+  const size_t N = isQuickLevel() ? 10000 : 1000000;
   size_t Nbytes = N * sizeof(float);
 
   hipGraph_t graph{nullptr};

--- a/projects/hip-tests/catch/unit/kernel/hipExtLaunchKernelGGLBasic.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipExtLaunchKernelGGLBasic.cc
@@ -108,7 +108,7 @@ arguments
 
 HIP_TEST_CASE(Unit_hipExtLaunchKernelGGL) {
   SECTION("test run") {
-    size_t N = 4 * 1024 * 1024;
+    size_t N = isQuickLevel() ? 100 * 1024 : 4 * 1024 * 1024;
     test(N);
   }
   SECTION("testStruct run") { testStruct(); }

--- a/projects/hip-tests/catch/unit/kernel/hipGridLaunch.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipGridLaunch.cc
@@ -93,7 +93,7 @@ int test_triple_chevron(size_t N) {
  */
 
 HIP_TEST_CASE(Unit_hipGridLaunch) {
-  size_t N = 4 * 1024 * 1024;
+  size_t N = isQuickLevel() ? 100 * 1024 : 4 * 1024 * 1024;
   SECTION("Test test_gl2") { test_gl2(N); }
 
 #if __HIP__

--- a/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
@@ -642,14 +642,15 @@ HIP_TEST_CASE(Unit_hipHostRegister_Memcpy) {
   Bh = reinterpret_cast<int*>(malloc(sizeBytes));
   HIP_CHECK(hipMalloc(&Bd, sizeBytes));
 
-  REQUIRE(LEN > OFFSET);
+  const size_t offset = isQuickLevel() ? 32 : OFFSET;
+  REQUIRE(LEN > offset);
   if (mem_type) {
-    for (size_t i = 0; i < OFFSET; i++) {
+    for (size_t i = 0; i < offset; i++) {
       doMemCopy<int>(LEN, i, A, Bh, Bd, true /*internalRegister*/);
     }
   } else {
     HIP_CHECK(hipHostRegister(A, sizeBytes, 0));
-    for (size_t i = 0; i < OFFSET; i++) {
+    for (size_t i = 0; i < offset; i++) {
       doMemCopy<int>(LEN, i, A, Bh, Bd, false /*internalRegister*/);
     }
     HIP_CHECK(hipHostUnregister(A));

--- a/projects/hip-tests/catch/unit/memory/hipMallocManaged.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocManaged.cc
@@ -74,39 +74,40 @@ HIP_TEST_CASE(Unit_hipMallocManaged_Advanced) {
     return;
   }
 
+  const size_t N = isQuickLevel() ? (512 * 1024 / sizeof(float)) : numElements;
   float *A, *B, *C;
 
-  HIP_CHECK(hipMallocManaged(&A, numElements * sizeof(float)));
-  HIP_CHECK(hipMallocManaged(&B, numElements * sizeof(float)));
-  HIP_CHECK(hipMallocManaged(&C, numElements * sizeof(float)));
-  HipTest::setDefaultData(numElements, A, B, C);
+  HIP_CHECK(hipMallocManaged(&A, N * sizeof(float)));
+  HIP_CHECK(hipMallocManaged(&B, N * sizeof(float)));
+  HIP_CHECK(hipMallocManaged(&C, N * sizeof(float)));
+  HipTest::setDefaultData(N, A, B, C);
 
   hipDevice_t device = hipCpuDeviceId;
 
-  HIP_CHECK(hipMemAdvise(A, numElements * sizeof(float), hipMemAdviseSetReadMostly, device));
-  HIP_CHECK(hipMemPrefetchAsync(A, numElements * sizeof(float), 0));
-  HIP_CHECK(hipMemPrefetchAsync(B, numElements * sizeof(float), 0));
+  HIP_CHECK(hipMemAdvise(A, N * sizeof(float), hipMemAdviseSetReadMostly, device));
+  HIP_CHECK(hipMemPrefetchAsync(A, N * sizeof(float), 0));
+  HIP_CHECK(hipMemPrefetchAsync(B, N * sizeof(float), 0));
   HIP_CHECK(hipDeviceSynchronize());
   HIP_CHECK(hipMemRangeGetAttribute(&device, sizeof(device),
                                     hipMemRangeAttributeLastPrefetchLocation, A,
-                                    numElements * sizeof(float)));
+                                    N * sizeof(float)));
   if (device != 0) {
     INFO("hipMemRangeGetAttribute error, device = " << device);
   }
   uint32_t read_only = 0xf;
   HIP_CHECK(hipMemRangeGetAttribute(&read_only, sizeof(read_only), hipMemRangeAttributeReadMostly,
-                                    A, numElements * sizeof(float)));
+                                    A, N * sizeof(float)));
   if (read_only != 1) {
     SUCCEED("hipMemRangeGetAttribute error, read_only = " << read_only);
   }
 
-  unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, numElements);
+  unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, N);
   hipEvent_t event0, event1;
   HIP_CHECK(hipEventCreate(&event0));
   HIP_CHECK(hipEventCreate(&event1));
   HIP_CHECK(hipEventRecord(event0, 0));
   hipLaunchKernelGGL(HipTest::vectorADD, dim3(blocks), dim3(threadsPerBlock), 0, 0,
-                     static_cast<const float*>(A), static_cast<const float*>(B), C, numElements);
+                     static_cast<const float*>(A), static_cast<const float*>(B), C, N);
   HIP_CHECK(hipGetLastError());
   HIP_CHECK(hipEventRecord(event1, 0));
   HIP_CHECK(hipDeviceSynchronize());
@@ -114,17 +115,17 @@ HIP_TEST_CASE(Unit_hipMallocManaged_Advanced) {
   HIP_CHECK(hipEventElapsedTime(&time, event0, event1));
   printf("Time %.3f ms\n", time);
   float maxError = 0.0f;
-  HIP_CHECK(hipMemPrefetchAsync(B, numElements * sizeof(float), hipCpuDeviceId));
+  HIP_CHECK(hipMemPrefetchAsync(B, N * sizeof(float), hipCpuDeviceId));
   HIP_CHECK(hipDeviceSynchronize());
   device = 0;
   HIP_CHECK(hipMemRangeGetAttribute(&device, sizeof(device),
                                     hipMemRangeAttributeLastPrefetchLocation, A,
-                                    numElements * sizeof(float)));
+                                    N * sizeof(float)));
   if (device != hipCpuDeviceId) {
     SUCCEED("hipMemRangeGetAttribute error device = " << device);
   }
 
-  for (size_t i = 0; i < numElements; i++) {
+  for (size_t i = 0; i < N; i++) {
     maxError = fmax(maxError, fabs(B[i] - 3.0f));
   }
   HIP_CHECK(hipFree(A));

--- a/projects/hip-tests/catch/unit/memory/hipMallocMngdMultiThread.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocMngdMultiThread.cc
@@ -351,7 +351,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MGpuMThread) {
     return;
   }
 
-  int InitVal = 123, *Hmm1 = NULL, NumElms = 4096 * 4;
+  int InitVal = 123, *Hmm1 = NULL, NumElms = isQuickLevel() ? 4096 : 4096 * 4;
   HIP_CHECK(hipMallocManaged(&Hmm1, (NumElms * sizeof(int))));
   for (int i = 0; i < NumElms; ++i) {
     Hmm1[i] = InitVal;
@@ -388,7 +388,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MultiKrnlComnHmm) {
 
   IfTestPassed = true;
 
-  int InitVal = 123, *Hmm = NULL, NumElms = 1024 * 4, TotThrds = 2;
+  int InitVal = 123, *Hmm = NULL, NumElms = isQuickLevel() ? 4096 : 1024 * 4, TotThrds = 2;
   int HmmMem2 = 0, *HstPtr = nullptr;  //  to indicate the thread that
   //  hipMalloc() memory has to be used
   HstPtr = reinterpret_cast<int*>(new int[NumElms]);
@@ -422,7 +422,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MultiKrnlComnMalloc) {
   }
 
   IfTestPassed = true;
-  int InitVal = 123, *Dptr = NULL, NumElms = 4096 * 8, TotThrds = 2;
+  int InitVal = 123, *Dptr = NULL, NumElms = isQuickLevel() ? 4096 : 4096 * 8, TotThrds = 2;
   int* HstPtr = reinterpret_cast<int*>(new int[NumElms]);
   HIP_CHECK(hipMalloc(&Dptr, (NumElms * sizeof(int))));
   for (int i = 0; i < NumElms; ++i) {
@@ -454,7 +454,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MultiThrdMultiStrm) {
 
   IfTestPassed = true;
 
-  int NumElms = 4096 * 4;
+  int NumElms = isQuickLevel() ? 4096 : 4096 * 4;
   int *Hmm1 = NULL, TotlThrds = 4, InitVal = 123;
   int HmmMem = 1;  //  to indicate the thread that Hmm memory need to be
   //  used inside it
@@ -487,7 +487,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_TwoKrnlsComnHmmMem) {
   }
 
   IfTestPassed = true;
-  int InitVal = 123, *Dptr = NULL, NumElms = 4096 * 4, TotThrds = 2;
+  int InitVal = 123, *Dptr = NULL, NumElms = isQuickLevel() ? 4096 : 4096 * 4, TotThrds = 2;
   int* HstPtr = reinterpret_cast<int*>(new int[NumElms]);
   HIP_CHECK(hipMalloc(&Dptr, (NumElms * sizeof(int))));
   for (int i = 0; i < NumElms; ++i) {

--- a/projects/hip-tests/catch/unit/memory/hipMallocPitch.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocPitch.cc
@@ -5,6 +5,7 @@
  */
 
 #include <hip_test_common.hh>
+#include <algorithm>
 #include <initializer_list>
 #include <memory>
 #include "hip/driver_types.h"
@@ -105,7 +106,10 @@ hipExtent generateExtent(AllocationApi api) {
   hipExtent extent;
   if (api == AllocationApi::hipMalloc3D) {
     auto& extents3D = ExtentGenerator::getInstance().extents3D;
-    extent = GENERATE_REF(from_range(extents3D.begin(), extents3D.end()));
+    // At level_0: 4 edge cases + 4 random = 8 extents (vs 24 normally)
+    auto end3D = isQuickLevel() ? extents3D.begin() + std::min(extents3D.size(), size_t(8))
+                                : extents3D.end();
+    extent = GENERATE_REF(from_range(extents3D.begin(), end3D));
   } else {
     auto& extents2D = ExtentGenerator::getInstance().extents2D;
     extent = GENERATE_REF(from_range(extents2D.begin(), extents2D.end()));

--- a/projects/hip-tests/catch/unit/memory/hipMemCoherencyTst.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemCoherencyTst.cc
@@ -25,6 +25,9 @@ __global__ void CoherentTst(int* ptr) {  // ptr was set to 1
   atomicAdd_system(ptr, 1);              // now ptr is 2
   while (atomicCAS_system(ptr, 3, 4) != 3) {
     // wait till ptr is updated to 3 in host, then change it to 4
+#if HT_AMD
+    __builtin_amdgcn_s_sleep(100);
+#endif
   }
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolExportToShareableHandle.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolExportToShareableHandle.cc
@@ -18,8 +18,8 @@
 #include "mempool_common.hh"
 #include <hip_test_process.hh>
 
-static const int DATA_SIZE = isQuickLevel() ? 128 * 1024 : 1024 * 1024;
-static const size_t byte_size = DATA_SIZE * sizeof(int);
+static int DATA_SIZE() { return isQuickLevel() ? 128 * 1024 : 1024 * 1024; }
+static size_t byte_size() { return DATA_SIZE() * sizeof(int); }
 
 /**
  Kernel to perform Square of input data.
@@ -34,7 +34,7 @@ static __global__ void square_kernel(int* Buff) {
  Fill with input and expected output data.
  */
 static void fill_data(std::vector<int>& A_h, std::vector<int>& B_h, std::vector<int>& C_h) {
-  for (int i = 0; i < DATA_SIZE; i++) {
+  for (int i = 0; i < DATA_SIZE(); i++) {
     A_h[i] = i % 1024;
     B_h[i] = 0;
     C_h[i] = A_h[i] * A_h[i];
@@ -57,7 +57,7 @@ static void fill_data(std::vector<int>& A_h, std::vector<int>& B_h, std::vector<
 HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_SameProc) {
   hipMemPoolPtrExportData ptrExp;
   hipShareableHdl sharedHandle;
-  std::vector<int> A_h(DATA_SIZE), B_h(DATA_SIZE), C_h(DATA_SIZE);
+  std::vector<int> A_h(DATA_SIZE()), B_h(DATA_SIZE()), C_h(DATA_SIZE());
   fill_data(A_h, B_h, C_h);
   hipMemPoolProps pool_props{};
   hipMemPool_t mempool, mempoolImp;
@@ -77,8 +77,8 @@ HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_SameProc) {
   HIP_CHECK(hipMemPoolCreate(&mempool, &pool_props));
   // Allocate device memory from mempool
   int* A_d;
-  HIP_CHECK(hipMallocFromPoolAsync(reinterpret_cast<void**>(&A_d), byte_size, mempool, stream));
-  HIP_CHECK(hipMemcpyAsync(A_d, A_h.data(), byte_size, hipMemcpyHostToDevice, stream));
+  HIP_CHECK(hipMallocFromPoolAsync(reinterpret_cast<void**>(&A_d), byte_size(), mempool, stream));
+  HIP_CHECK(hipMemcpyAsync(A_d, A_h.data(), byte_size(), hipMemcpyHostToDevice, stream));
   HIP_CHECK(hipStreamSynchronize(stream));
   // Export mempool
   HIP_CHECK(hipMemPoolExportToShareableHandle(&sharedHandle, mempool,
@@ -91,9 +91,9 @@ HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_SameProc) {
   // Import and use pointer
   void* ptrImp;
   HIP_CHECK(hipMemPoolImportPointer(&ptrImp, mempoolImp, &ptrExp));
-  square_kernel<<<dim3(DATA_SIZE / THREADS_PER_BLOCK), dim3(THREADS_PER_BLOCK), 0, stream>>>(
+  square_kernel<<<dim3(DATA_SIZE() / THREADS_PER_BLOCK), dim3(THREADS_PER_BLOCK), 0, stream>>>(
       (int*)ptrImp);
-  HIP_CHECK(hipMemcpyAsync(B_h.data(), ptrImp, byte_size, hipMemcpyDeviceToHost, stream));
+  HIP_CHECK(hipMemcpyAsync(B_h.data(), ptrImp, byte_size(), hipMemcpyDeviceToHost, stream));
   HIP_CHECK(hipStreamSynchronize(stream));
   REQUIRE(true == std::equal(B_h.begin(), B_h.end(), C_h.data()));
   HIP_CHECK(hipFree(ptrImp));
@@ -121,7 +121,7 @@ HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_SameProc) {
  *    - HIP_VERSION >= 6.2
  */
 HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_ChldUseHdl) {
-  std::vector<int> A_h(DATA_SIZE), B_h(DATA_SIZE), C_h(DATA_SIZE);
+  std::vector<int> A_h(DATA_SIZE()), B_h(DATA_SIZE()), C_h(DATA_SIZE());
   fill_data(A_h, B_h, C_h);
   int fd[2], fdSig[2];
   REQUIRE(pipe(fd) == 0);
@@ -151,7 +151,7 @@ HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_ChldUseHdl) {
     // Import and use pointer
     void* ptrImp;
     HIP_CHECK(hipMemPoolImportPointer(&ptrImp, mempoolImp, &ptrExp));
-    square_kernel<<<dim3(DATA_SIZE / THREADS_PER_BLOCK), dim3(THREADS_PER_BLOCK), 0, 0>>>(
+    square_kernel<<<dim3(DATA_SIZE() / THREADS_PER_BLOCK), dim3(THREADS_PER_BLOCK), 0, 0>>>(
         (int*)ptrImp);
     HIP_CHECK(hipStreamSynchronize(0));
     // Import and use pointer
@@ -180,8 +180,8 @@ HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_ChldUseHdl) {
     hipStream_t stream;
     HIP_CHECK(hipStreamCreate(&stream));
     int* A_d;
-    HIP_CHECK(hipMallocFromPoolAsync(reinterpret_cast<void**>(&A_d), byte_size, mempool, stream));
-    HIP_CHECK(hipMemcpyAsync(A_d, A_h.data(), byte_size, hipMemcpyHostToDevice, stream));
+    HIP_CHECK(hipMallocFromPoolAsync(reinterpret_cast<void**>(&A_d), byte_size(), mempool, stream));
+    HIP_CHECK(hipMemcpyAsync(A_d, A_h.data(), byte_size(), hipMemcpyHostToDevice, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
     hipMemPoolPtrExportData ptrExp;
     // Export A_d
@@ -198,7 +198,7 @@ HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_ChldUseHdl) {
     int status;
     REQUIRE(wait(&status) >= 0);
     REQUIRE(status == 0);
-    HIP_CHECK(hipMemcpyAsync(B_h.data(), A_d, byte_size, hipMemcpyDeviceToHost, stream));
+    HIP_CHECK(hipMemcpyAsync(B_h.data(), A_d, byte_size(), hipMemcpyDeviceToHost, stream));
     // Free all resources
     HIP_CHECK(hipFreeAsync(reinterpret_cast<void*>(A_d), stream));
     HIP_CHECK(hipStreamSynchronize(stream));
@@ -331,7 +331,7 @@ HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_ChldCheckAccess) {
  *    - HIP_VERSION >= 6.2
  */
 HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_GrndChldUseHdl) {
-  std::vector<int> A_h(DATA_SIZE), B_h(DATA_SIZE), C_h(DATA_SIZE);
+  std::vector<int> A_h(DATA_SIZE()), B_h(DATA_SIZE()), C_h(DATA_SIZE());
   fill_data(A_h, B_h, C_h);
   int fd[2], fdSig[2], fdpid[2];
   REQUIRE(pipe(fd) == 0);
@@ -363,7 +363,7 @@ HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_GrndChldUseHdl) {
       // Import and use pointer
       void* ptrImp;
       HIP_CHECK(hipMemPoolImportPointer(&ptrImp, mempoolImp, &ptrExp));
-      square_kernel<<<dim3(DATA_SIZE / THREADS_PER_BLOCK), dim3(THREADS_PER_BLOCK), 0, 0>>>(
+      square_kernel<<<dim3(DATA_SIZE() / THREADS_PER_BLOCK), dim3(THREADS_PER_BLOCK), 0, 0>>>(
           (int*)ptrImp);
       HIP_CHECK(hipStreamSynchronize(0));
       REQUIRE(close(fd[0]) == 0);
@@ -403,8 +403,8 @@ HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_GrndChldUseHdl) {
     hipStream_t stream;
     HIP_CHECK(hipStreamCreate(&stream));
     int* A_d;
-    HIP_CHECK(hipMallocFromPoolAsync(reinterpret_cast<void**>(&A_d), byte_size, mempool, stream));
-    HIP_CHECK(hipMemcpyAsync(A_d, A_h.data(), byte_size, hipMemcpyHostToDevice, stream));
+    HIP_CHECK(hipMallocFromPoolAsync(reinterpret_cast<void**>(&A_d), byte_size(), mempool, stream));
+    HIP_CHECK(hipMemcpyAsync(A_d, A_h.data(), byte_size(), hipMemcpyHostToDevice, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
     hipMemPoolPtrExportData ptrExp;
     // Export A_d
@@ -422,7 +422,7 @@ HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_GrndChldUseHdl) {
     int status;
     REQUIRE(wait(&status) >= 0);
     REQUIRE(status == 0);
-    HIP_CHECK(hipMemcpyAsync(B_h.data(), A_d, byte_size, hipMemcpyDeviceToHost, stream));
+    HIP_CHECK(hipMemcpyAsync(B_h.data(), A_d, byte_size(), hipMemcpyDeviceToHost, stream));
     // Free all resources
     HIP_CHECK(hipFreeAsync(reinterpret_cast<void*>(A_d), stream));
     HIP_CHECK(hipStreamSynchronize(stream));
@@ -486,11 +486,11 @@ HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_multiproc) {
   HIP_CHECK(hipStreamCreate(&stream));
 
   int* A_d;
-  HIP_CHECK(hipMallocFromPoolAsync(reinterpret_cast<void**>(&A_d), byte_size, mempool, stream));
+  HIP_CHECK(hipMallocFromPoolAsync(reinterpret_cast<void**>(&A_d), byte_size(), mempool, stream));
 
-  std::vector<int> A_h(DATA_SIZE);
-  for (int i = 0; i < DATA_SIZE; i++) A_h[i] = i % 1024;
-  HIP_CHECK(hipMemcpyAsync(A_d, A_h.data(), byte_size, hipMemcpyHostToDevice, stream));
+  std::vector<int> A_h(DATA_SIZE());
+  for (int i = 0; i < DATA_SIZE(); i++) A_h[i] = i % 1024;
+  HIP_CHECK(hipMemcpyAsync(A_d, A_h.data(), byte_size(), hipMemcpyHostToDevice, stream));
   HIP_CHECK(hipStreamSynchronize(stream));
 
   hipShareableHdl sharedHandle;
@@ -530,10 +530,10 @@ HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_multiproc) {
   int exitCode = child.wait();
   REQUIRE(exitCode == 0);
 
-  std::vector<int> B_h(DATA_SIZE);
-  HIP_CHECK(hipMemcpyAsync(B_h.data(), A_d, byte_size, hipMemcpyDeviceToHost, stream));
+  std::vector<int> B_h(DATA_SIZE());
+  HIP_CHECK(hipMemcpyAsync(B_h.data(), A_d, byte_size(), hipMemcpyDeviceToHost, stream));
   HIP_CHECK(hipStreamSynchronize(stream));
-  for (int i = 0; i < DATA_SIZE; i++) {
+  for (int i = 0; i < DATA_SIZE(); i++) {
     REQUIRE(B_h[i] == (A_h[i] * A_h[i]));
   }
 
@@ -602,7 +602,7 @@ HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_multiproc_child) {
   void *ptrImp;
   HIP_CHECK(hipMemPoolImportPointer(&ptrImp, mempoolImp, &ptrExp));
 
-  square_kernel<<<dim3(DATA_SIZE / THREADS_PER_BLOCK), dim3(THREADS_PER_BLOCK), 0, 0>>>(
+  square_kernel<<<dim3(DATA_SIZE() / THREADS_PER_BLOCK), dim3(THREADS_PER_BLOCK), 0, 0>>>(
       (int *)ptrImp);
   HIP_CHECK(hipStreamSynchronize(0));
 

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolExportToShareableHandle.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolExportToShareableHandle.cc
@@ -18,8 +18,8 @@
 #include "mempool_common.hh"
 #include <hip_test_process.hh>
 
-constexpr int DATA_SIZE = 1024 * 1024;
-constexpr size_t byte_size = DATA_SIZE * sizeof(int);
+static const int DATA_SIZE = isQuickLevel() ? 128 * 1024 : 1024 * 1024;
+static const size_t byte_size = DATA_SIZE * sizeof(int);
 
 /**
  Kernel to perform Square of input data.

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolExportToShareableHandle.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolExportToShareableHandle.cc
@@ -18,7 +18,10 @@
 #include "mempool_common.hh"
 #include <hip_test_process.hh>
 
-static int DATA_SIZE() { return isQuickLevel() ? 128 * 1024 : 1024 * 1024; }
+static int DATA_SIZE() {
+  static const int val = isQuickLevel() ? 128 * 1024 : 1024 * 1024;
+  return val;
+}
 static size_t byte_size() { return DATA_SIZE() * sizeof(int); }
 
 /**

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolTrimTo.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolTrimTo.cc
@@ -190,7 +190,7 @@ HIP_TEST_CASE(Unit_hipMemPoolTrimTo_VaryingMinBytesToHold) {
       // create a stream
       hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
-  constexpr int N = 1 << 20;
+  const int N = isQuickLevel() ? (1 << 12) : (1 << 20);
   REQUIRE(true == checkhipMemPoolTrimTo(stream, N));
   HIP_CHECK(hipStreamDestroy(stream));
 }
@@ -206,7 +206,7 @@ HIP_TEST_CASE(Unit_hipMemPoolTrimTo_VaryingMinBytesToHold) {
  *    - HIP_VERSION >= 6.2
  */
 HIP_TEST_CASE(Unit_hipMemPoolTrimTo_MGpuVaryingMinBytesToHold) {
-  constexpr int N = 1 << 20;
+  const int N = isQuickLevel() ? (1 << 12) : (1 << 20);
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync.cc
@@ -16,7 +16,9 @@ HIP_TEST_CASE(Unit_hipMemcpy2DAsync_Positive_Basic) {
 
   constexpr bool async = true;
 
-  const auto stream_type = GENERATE(Streams::nullstream, Streams::perThread, Streams::created);
+  const auto stream_type = isQuickLevel()
+      ? Streams::created
+      : GENERATE(Streams::nullstream, Streams::perThread, Streams::created);
   const StreamGuard stream_guard(stream_type);
   const hipStream_t stream = stream_guard.stream();
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAllApiNegative.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAllApiNegative.cc
@@ -16,7 +16,10 @@ This testfile verifies the following scenarios of all hipMemcpy API
 3. Null check scenario
 */
 
-static auto NUM_ELM() { return isQuickLevel() ? 1024 : 1024 * 1024; }
+static auto NUM_ELM() {
+  static const auto val = isQuickLevel() ? 1024 : 1024 * 1024;
+  return val;
+}
 
 
 /*This testcase verifies the negative scenarios of hipMemcpy APIs

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAllApiNegative.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAllApiNegative.cc
@@ -16,7 +16,7 @@ This testfile verifies the following scenarios of all hipMemcpy API
 3. Null check scenario
 */
 
-static const auto NUM_ELM = isQuickLevel() ? 1024 : 1024 * 1024;
+static auto NUM_ELM() { return isQuickLevel() ? 1024 : 1024 * 1024; }
 
 
 /*This testcase verifies the negative scenarios of hipMemcpy APIs
@@ -26,64 +26,64 @@ HIP_TEST_CASE(Unit_hipMemcpy_Negative) {
   float *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr};
   float *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr};
   HIP_CHECK(hipSetDevice(0));
-  HipTest::initArrays<float>(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, NUM_ELM * sizeof(float));
+  HipTest::initArrays<float>(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, NUM_ELM() * sizeof(float));
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
   SECTION("Pass nullptr to destination pointer for all Memcpy APIs") {
-    REQUIRE(hipMemcpy(nullptr, A_d, NUM_ELM * sizeof(float), hipMemcpyDefault) != hipSuccess);
-    REQUIRE(hipMemcpyAsync(nullptr, A_h, NUM_ELM * sizeof(float), hipMemcpyDefault, stream) !=
+    REQUIRE(hipMemcpy(nullptr, A_d, NUM_ELM() * sizeof(float), hipMemcpyDefault) != hipSuccess);
+    REQUIRE(hipMemcpyAsync(nullptr, A_h, NUM_ELM() * sizeof(float), hipMemcpyDefault, stream) !=
             hipSuccess);
-    REQUIRE(hipMemcpyHtoD(hipDeviceptr_t(nullptr), A_h, NUM_ELM * sizeof(float)) != hipSuccess);
-    REQUIRE(hipMemcpyHtoDAsync(hipDeviceptr_t(nullptr), A_h, NUM_ELM * sizeof(float), stream) !=
+    REQUIRE(hipMemcpyHtoD(hipDeviceptr_t(nullptr), A_h, NUM_ELM() * sizeof(float)) != hipSuccess);
+    REQUIRE(hipMemcpyHtoDAsync(hipDeviceptr_t(nullptr), A_h, NUM_ELM() * sizeof(float), stream) !=
             hipSuccess);
-    REQUIRE(hipMemcpyDtoH(nullptr, hipDeviceptr_t(A_d), NUM_ELM * sizeof(float)) != hipSuccess);
-    REQUIRE(hipMemcpyDtoHAsync(nullptr, hipDeviceptr_t(A_d), NUM_ELM * sizeof(float), stream) !=
+    REQUIRE(hipMemcpyDtoH(nullptr, hipDeviceptr_t(A_d), NUM_ELM() * sizeof(float)) != hipSuccess);
+    REQUIRE(hipMemcpyDtoHAsync(nullptr, hipDeviceptr_t(A_d), NUM_ELM() * sizeof(float), stream) !=
             hipSuccess);
-    REQUIRE(hipMemcpyDtoD(hipDeviceptr_t(nullptr), hipDeviceptr_t(A_d), NUM_ELM * sizeof(float)) !=
+    REQUIRE(hipMemcpyDtoD(hipDeviceptr_t(nullptr), hipDeviceptr_t(A_d), NUM_ELM() * sizeof(float)) !=
             hipSuccess);
     REQUIRE(hipMemcpyDtoDAsync(hipDeviceptr_t(nullptr), hipDeviceptr_t(A_d),
-                               NUM_ELM * sizeof(float), stream) != hipSuccess);
+                               NUM_ELM() * sizeof(float), stream) != hipSuccess);
   }
 
   SECTION("Passing nullptr to source pointer") {
-    REQUIRE(hipMemcpy(A_h, nullptr, NUM_ELM * sizeof(float), hipMemcpyDefault) != hipSuccess);
-    REQUIRE(hipMemcpyAsync(A_d, nullptr, NUM_ELM * sizeof(float), hipMemcpyDefault, stream) !=
+    REQUIRE(hipMemcpy(A_h, nullptr, NUM_ELM() * sizeof(float), hipMemcpyDefault) != hipSuccess);
+    REQUIRE(hipMemcpyAsync(A_d, nullptr, NUM_ELM() * sizeof(float), hipMemcpyDefault, stream) !=
             hipSuccess);
-    REQUIRE(hipMemcpyHtoD(hipDeviceptr_t(A_d), nullptr, NUM_ELM * sizeof(float)) != hipSuccess);
-    REQUIRE(hipMemcpyHtoDAsync(hipDeviceptr_t(A_d), nullptr, NUM_ELM * sizeof(float), stream) !=
+    REQUIRE(hipMemcpyHtoD(hipDeviceptr_t(A_d), nullptr, NUM_ELM() * sizeof(float)) != hipSuccess);
+    REQUIRE(hipMemcpyHtoDAsync(hipDeviceptr_t(A_d), nullptr, NUM_ELM() * sizeof(float), stream) !=
             hipSuccess);
-    REQUIRE(hipMemcpyDtoH(A_h, hipDeviceptr_t(nullptr), NUM_ELM * sizeof(float)) != hipSuccess);
-    REQUIRE(hipMemcpyDtoHAsync(A_h, hipDeviceptr_t(nullptr), NUM_ELM * sizeof(float), stream) !=
+    REQUIRE(hipMemcpyDtoH(A_h, hipDeviceptr_t(nullptr), NUM_ELM() * sizeof(float)) != hipSuccess);
+    REQUIRE(hipMemcpyDtoHAsync(A_h, hipDeviceptr_t(nullptr), NUM_ELM() * sizeof(float), stream) !=
             hipSuccess);
-    REQUIRE(hipMemcpyDtoD(hipDeviceptr_t(A_d), hipDeviceptr_t(nullptr), NUM_ELM * sizeof(float)) !=
+    REQUIRE(hipMemcpyDtoD(hipDeviceptr_t(A_d), hipDeviceptr_t(nullptr), NUM_ELM() * sizeof(float)) !=
             hipSuccess);
     REQUIRE(hipMemcpyDtoDAsync(hipDeviceptr_t(A_d), hipDeviceptr_t(nullptr),
-                               NUM_ELM * sizeof(float), stream) != hipSuccess);
+                               NUM_ELM() * sizeof(float), stream) != hipSuccess);
   }
 
   SECTION("Passing nullptr to both source and dest pointer") {
-    REQUIRE(hipMemcpy(nullptr, nullptr, NUM_ELM * sizeof(float), hipMemcpyDefault) != hipSuccess);
-    REQUIRE(hipMemcpyAsync(nullptr, nullptr, NUM_ELM * sizeof(float), hipMemcpyDefault, stream) !=
+    REQUIRE(hipMemcpy(nullptr, nullptr, NUM_ELM() * sizeof(float), hipMemcpyDefault) != hipSuccess);
+    REQUIRE(hipMemcpyAsync(nullptr, nullptr, NUM_ELM() * sizeof(float), hipMemcpyDefault, stream) !=
             hipSuccess);
-    REQUIRE(hipMemcpyHtoD(hipDeviceptr_t(nullptr), nullptr, NUM_ELM * sizeof(float)) != hipSuccess);
-    REQUIRE(hipMemcpyHtoDAsync(hipDeviceptr_t(nullptr), nullptr, NUM_ELM * sizeof(float), stream) !=
+    REQUIRE(hipMemcpyHtoD(hipDeviceptr_t(nullptr), nullptr, NUM_ELM() * sizeof(float)) != hipSuccess);
+    REQUIRE(hipMemcpyHtoDAsync(hipDeviceptr_t(nullptr), nullptr, NUM_ELM() * sizeof(float), stream) !=
             hipSuccess);
-    REQUIRE(hipMemcpyDtoH(nullptr, hipDeviceptr_t(nullptr), NUM_ELM * sizeof(float)) != hipSuccess);
-    REQUIRE(hipMemcpyDtoHAsync(nullptr, hipDeviceptr_t(nullptr), NUM_ELM * sizeof(float), stream) !=
+    REQUIRE(hipMemcpyDtoH(nullptr, hipDeviceptr_t(nullptr), NUM_ELM() * sizeof(float)) != hipSuccess);
+    REQUIRE(hipMemcpyDtoHAsync(nullptr, hipDeviceptr_t(nullptr), NUM_ELM() * sizeof(float), stream) !=
             hipSuccess);
     REQUIRE(hipMemcpyDtoD(hipDeviceptr_t(nullptr), hipDeviceptr_t(nullptr),
-                          NUM_ELM * sizeof(float)) != hipSuccess);
+                          NUM_ELM() * sizeof(float)) != hipSuccess);
     REQUIRE(hipMemcpyDtoDAsync(hipDeviceptr_t(nullptr), hipDeviceptr_t(nullptr),
-                               NUM_ELM * sizeof(float), stream) != hipSuccess);
+                               NUM_ELM() * sizeof(float), stream) != hipSuccess);
   }
 
   SECTION("Passing same pointers") {
-    HIP_CHECK(hipMemcpy(A_d, A_d, (NUM_ELM / 2) * sizeof(float), hipMemcpyDefault));
-    HIP_CHECK(hipMemcpy(A_h, A_h, (NUM_ELM / 2) * sizeof(float), hipMemcpyDefault));
-    HIP_CHECK(hipMemcpyAsync(A_d, A_d, (NUM_ELM / 2) * sizeof(float), hipMemcpyDefault, stream));
-    HIP_CHECK(hipMemcpyAsync(A_h, A_h, (NUM_ELM / 2) * sizeof(float), hipMemcpyDefault, stream));
-    HIP_CHECK(hipMemcpyDtoD(hipDeviceptr_t(A_d), hipDeviceptr_t(A_d), NUM_ELM * sizeof(float)));
-    HIP_CHECK(hipMemcpyDtoDAsync(hipDeviceptr_t(A_d), hipDeviceptr_t(A_d), NUM_ELM * sizeof(float),
+    HIP_CHECK(hipMemcpy(A_d, A_d, (NUM_ELM() / 2) * sizeof(float), hipMemcpyDefault));
+    HIP_CHECK(hipMemcpy(A_h, A_h, (NUM_ELM() / 2) * sizeof(float), hipMemcpyDefault));
+    HIP_CHECK(hipMemcpyAsync(A_d, A_d, (NUM_ELM() / 2) * sizeof(float), hipMemcpyDefault, stream));
+    HIP_CHECK(hipMemcpyAsync(A_h, A_h, (NUM_ELM() / 2) * sizeof(float), hipMemcpyDefault, stream));
+    HIP_CHECK(hipMemcpyDtoD(hipDeviceptr_t(A_d), hipDeviceptr_t(A_d), NUM_ELM() * sizeof(float)));
+    HIP_CHECK(hipMemcpyDtoDAsync(hipDeviceptr_t(A_d), hipDeviceptr_t(A_d), NUM_ELM() * sizeof(float),
                                  stream));
   }
 
@@ -99,54 +99,54 @@ HIP_TEST_CASE(Unit_hipMemcpy_NullCheck) {
   float *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr};
   float *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr};
   HIP_CHECK(hipSetDevice(0));
-  HipTest::initArrays<float>(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, NUM_ELM * sizeof(float));
+  HipTest::initArrays<float>(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, NUM_ELM() * sizeof(float));
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
-  HIP_CHECK(hipMemcpy(A_d, C_h, NUM_ELM * sizeof(float), hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(A_d, C_h, NUM_ELM() * sizeof(float), hipMemcpyHostToDevice));
 
   SECTION("hipMemcpyHtoD API null size check") {
     REQUIRE(hipMemcpyHtoD(hipDeviceptr_t(A_d), A_h, 0) == hipSuccess);
-    HIP_CHECK(hipMemcpy(B_h, A_d, NUM_ELM * sizeof(float), hipMemcpyDeviceToHost));
-    HipTest::checkTest(C_h, B_h, NUM_ELM);
+    HIP_CHECK(hipMemcpy(B_h, A_d, NUM_ELM() * sizeof(float), hipMemcpyDeviceToHost));
+    HipTest::checkTest(C_h, B_h, NUM_ELM());
   }
 
   SECTION("hipMemcpyHtoDAsync API null size check") {
     HIP_CHECK(hipMemcpyHtoDAsync(hipDeviceptr_t(A_d), A_h, 0, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
-    HIP_CHECK(hipMemcpy(B_h, A_d, NUM_ELM * sizeof(float), hipMemcpyDeviceToHost));
-    HipTest::checkTest(C_h, B_h, NUM_ELM);
+    HIP_CHECK(hipMemcpy(B_h, A_d, NUM_ELM() * sizeof(float), hipMemcpyDeviceToHost));
+    HipTest::checkTest(C_h, B_h, NUM_ELM());
   }
   SECTION("hipMemcpy API null size check") {
     HIP_CHECK(hipMemcpy(A_d, B_h, 0, hipMemcpyDefault));
-    HIP_CHECK(hipMemcpy(B_h, A_d, NUM_ELM * sizeof(float), hipMemcpyDeviceToHost));
-    HipTest::checkTest(C_h, B_h, NUM_ELM);
+    HIP_CHECK(hipMemcpy(B_h, A_d, NUM_ELM() * sizeof(float), hipMemcpyDeviceToHost));
+    HipTest::checkTest(C_h, B_h, NUM_ELM());
   }
   SECTION("hipMemcpyAsync API null size check") {
     HIP_CHECK(hipMemcpyAsync(A_d, B_h, 0, hipMemcpyDefault, stream));
-    HIP_CHECK(hipMemcpy(B_h, A_d, NUM_ELM * sizeof(float), hipMemcpyDeviceToHost));
-    HipTest::checkTest(C_h, B_h, NUM_ELM);
+    HIP_CHECK(hipMemcpy(B_h, A_d, NUM_ELM() * sizeof(float), hipMemcpyDeviceToHost));
+    HipTest::checkTest(C_h, B_h, NUM_ELM());
   }
   SECTION("hipMemcpyDtoH API null size check") {
     HIP_CHECK(hipMemcpyDtoH(C_h, hipDeviceptr_t(A_d), 0));
-    HIP_CHECK(hipMemcpy(B_h, A_d, NUM_ELM * sizeof(float), hipMemcpyDeviceToHost));
-    HipTest::checkTest(C_h, B_h, NUM_ELM);
+    HIP_CHECK(hipMemcpy(B_h, A_d, NUM_ELM() * sizeof(float), hipMemcpyDeviceToHost));
+    HipTest::checkTest(C_h, B_h, NUM_ELM());
   }
   SECTION("hipMemcpyDtoHAsync API null size check") {
     HIP_CHECK(hipMemcpyDtoHAsync(C_h, hipDeviceptr_t(A_d), 0, stream));
-    HIP_CHECK(hipMemcpy(B_h, A_d, NUM_ELM * sizeof(float), hipMemcpyDeviceToHost));
-    HipTest::checkTest(C_h, B_h, NUM_ELM);
+    HIP_CHECK(hipMemcpy(B_h, A_d, NUM_ELM() * sizeof(float), hipMemcpyDeviceToHost));
+    HipTest::checkTest(C_h, B_h, NUM_ELM());
   }
   SECTION("hipMemcpyDtoD API null size check") {
-    HIP_CHECK(hipMemcpy(C_d, A_h, NUM_ELM * sizeof(float), hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(C_d, A_h, NUM_ELM() * sizeof(float), hipMemcpyHostToDevice));
     HIP_CHECK(hipMemcpyDtoD(hipDeviceptr_t(C_d), hipDeviceptr_t(A_d), 0));
-    HIP_CHECK(hipMemcpy(B_h, C_d, NUM_ELM * sizeof(float), hipMemcpyDeviceToHost));
-    HipTest::checkTest(A_h, B_h, NUM_ELM);
+    HIP_CHECK(hipMemcpy(B_h, C_d, NUM_ELM() * sizeof(float), hipMemcpyDeviceToHost));
+    HipTest::checkTest(A_h, B_h, NUM_ELM());
   }
   SECTION("hipMemcpyDtoDAsync API null size check") {
-    HIP_CHECK(hipMemcpy(C_d, A_h, NUM_ELM * sizeof(float), hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(C_d, A_h, NUM_ELM() * sizeof(float), hipMemcpyHostToDevice));
     HIP_CHECK(hipMemcpyDtoDAsync(hipDeviceptr_t(C_d), hipDeviceptr_t(A_d), 0, stream));
-    HIP_CHECK(hipMemcpy(B_h, C_d, NUM_ELM * sizeof(float), hipMemcpyDeviceToHost));
-    HipTest::checkTest(A_h, B_h, NUM_ELM);
+    HIP_CHECK(hipMemcpy(B_h, C_d, NUM_ELM() * sizeof(float), hipMemcpyDeviceToHost));
+    HipTest::checkTest(A_h, B_h, NUM_ELM());
   }
 
   HipTest::freeArrays<float>(A_d, B_d, C_d, A_h, B_h, C_h, false);
@@ -162,64 +162,64 @@ HIP_TEST_CASE(Unit_hipMemcpy_HalfMemCopy) {
   float *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr};
   float *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr};
   HIP_CHECK(hipSetDevice(0));
-  HipTest::initArrays<float>(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, NUM_ELM * sizeof(float));
+  HipTest::initArrays<float>(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, NUM_ELM() * sizeof(float));
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
 
   SECTION("hipMemcpyHtoD half memory copy") {
-    HIP_CHECK(hipMemcpyHtoD(hipDeviceptr_t(A_d), A_h, (NUM_ELM * sizeof(float)) / 2));
-    HIP_CHECK(hipMemcpy(B_h, A_d, (NUM_ELM * sizeof(float)) / 2, hipMemcpyDeviceToHost));
-    HipTest::checkTest(A_h, B_h, NUM_ELM / 2);
+    HIP_CHECK(hipMemcpyHtoD(hipDeviceptr_t(A_d), A_h, (NUM_ELM() * sizeof(float)) / 2));
+    HIP_CHECK(hipMemcpy(B_h, A_d, (NUM_ELM() * sizeof(float)) / 2, hipMemcpyDeviceToHost));
+    HipTest::checkTest(A_h, B_h, NUM_ELM() / 2);
   }
 
   SECTION("hipMemcpyHtoDAsync half memory copy") {
-    HIP_CHECK(hipMemcpyHtoDAsync(hipDeviceptr_t(A_d), A_h, (NUM_ELM * sizeof(float)) / 2, stream));
+    HIP_CHECK(hipMemcpyHtoDAsync(hipDeviceptr_t(A_d), A_h, (NUM_ELM() * sizeof(float)) / 2, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
-    HIP_CHECK(hipMemcpy(B_h, A_d, (NUM_ELM * sizeof(float)) / 2, hipMemcpyDeviceToHost));
-    HipTest::checkTest(A_h, B_h, NUM_ELM / 2);
+    HIP_CHECK(hipMemcpy(B_h, A_d, (NUM_ELM() * sizeof(float)) / 2, hipMemcpyDeviceToHost));
+    HipTest::checkTest(A_h, B_h, NUM_ELM() / 2);
   }
 
   SECTION("hipMemcpyDtoH half memory copy") {
-    HIP_CHECK(hipMemcpyHtoD(hipDeviceptr_t(A_d), A_h, (NUM_ELM * sizeof(float))));
-    HIP_CHECK(hipMemcpyDtoH(B_h, hipDeviceptr_t(A_d), (NUM_ELM * sizeof(float)) / 2));
-    HipTest::checkTest(A_h, B_h, NUM_ELM / 2);
+    HIP_CHECK(hipMemcpyHtoD(hipDeviceptr_t(A_d), A_h, (NUM_ELM() * sizeof(float))));
+    HIP_CHECK(hipMemcpyDtoH(B_h, hipDeviceptr_t(A_d), (NUM_ELM() * sizeof(float)) / 2));
+    HipTest::checkTest(A_h, B_h, NUM_ELM() / 2);
   }
 
   SECTION("hipMemcpyDtoHAsync half memory copy") {
-    HIP_CHECK(hipMemcpyHtoD(hipDeviceptr_t(A_d), A_h, (NUM_ELM * sizeof(float))));
-    HIP_CHECK(hipMemcpyDtoHAsync(B_h, hipDeviceptr_t(A_d), (NUM_ELM * sizeof(float)) / 2, stream));
+    HIP_CHECK(hipMemcpyHtoD(hipDeviceptr_t(A_d), A_h, (NUM_ELM() * sizeof(float))));
+    HIP_CHECK(hipMemcpyDtoHAsync(B_h, hipDeviceptr_t(A_d), (NUM_ELM() * sizeof(float)) / 2, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
-    HipTest::checkTest(A_h, B_h, NUM_ELM / 2);
+    HipTest::checkTest(A_h, B_h, NUM_ELM() / 2);
   }
 
   SECTION("hipMemcpyDtoD half memory copy") {
-    HIP_CHECK(hipMemcpyHtoD(hipDeviceptr_t(A_d), A_h, (NUM_ELM * sizeof(float)) / 2));
+    HIP_CHECK(hipMemcpyHtoD(hipDeviceptr_t(A_d), A_h, (NUM_ELM() * sizeof(float)) / 2));
     HIP_CHECK(
-        hipMemcpyDtoD(hipDeviceptr_t(B_d), hipDeviceptr_t(A_d), (NUM_ELM * sizeof(float)) / 2));
-    HIP_CHECK(hipMemcpy(B_h, B_d, (NUM_ELM * sizeof(float)) / 2, hipMemcpyDeviceToHost));
-    HipTest::checkTest(A_h, B_h, NUM_ELM / 2);
+        hipMemcpyDtoD(hipDeviceptr_t(B_d), hipDeviceptr_t(A_d), (NUM_ELM() * sizeof(float)) / 2));
+    HIP_CHECK(hipMemcpy(B_h, B_d, (NUM_ELM() * sizeof(float)) / 2, hipMemcpyDeviceToHost));
+    HipTest::checkTest(A_h, B_h, NUM_ELM() / 2);
   }
 
   SECTION("hipMemcpyDtoDAsync half memory copy") {
-    HIP_CHECK(hipMemcpyHtoD(hipDeviceptr_t(A_d), A_h, (NUM_ELM * sizeof(float)) / 2));
+    HIP_CHECK(hipMemcpyHtoD(hipDeviceptr_t(A_d), A_h, (NUM_ELM() * sizeof(float)) / 2));
     HIP_CHECK(hipMemcpyDtoDAsync(hipDeviceptr_t(B_d), hipDeviceptr_t(A_d),
-                                 (NUM_ELM * sizeof(float)) / 2, stream));
-    HIP_CHECK(hipMemcpy(B_h, B_d, (NUM_ELM * sizeof(float)) / 2, hipMemcpyDeviceToHost));
-    HipTest::checkTest(A_h, B_h, NUM_ELM / 2);
+                                 (NUM_ELM() * sizeof(float)) / 2, stream));
+    HIP_CHECK(hipMemcpy(B_h, B_d, (NUM_ELM() * sizeof(float)) / 2, hipMemcpyDeviceToHost));
+    HipTest::checkTest(A_h, B_h, NUM_ELM() / 2);
   }
 
   SECTION("hipMemcpy half memory copy") {
-    HIP_CHECK(hipMemcpy(A_d, A_h, (NUM_ELM * sizeof(float)), hipMemcpyDefault));
-    HIP_CHECK(hipMemcpy(B_h, A_d, (NUM_ELM / 2) * sizeof(float), hipMemcpyDeviceToHost));
-    HipTest::checkTest(A_h, B_h, NUM_ELM / 2);
+    HIP_CHECK(hipMemcpy(A_d, A_h, (NUM_ELM() * sizeof(float)), hipMemcpyDefault));
+    HIP_CHECK(hipMemcpy(B_h, A_d, (NUM_ELM() / 2) * sizeof(float), hipMemcpyDeviceToHost));
+    HipTest::checkTest(A_h, B_h, NUM_ELM() / 2);
   }
 
   SECTION("hipMemcpyAsync half memory copy") {
-    HIP_CHECK(hipMemcpy(A_d, A_h, (NUM_ELM * sizeof(float)), hipMemcpyDefault));
+    HIP_CHECK(hipMemcpy(A_d, A_h, (NUM_ELM() * sizeof(float)), hipMemcpyDefault));
     HIP_CHECK(
-        hipMemcpyAsync(B_h, A_d, (NUM_ELM / 2) * sizeof(float), hipMemcpyDeviceToHost, stream));
+        hipMemcpyAsync(B_h, A_d, (NUM_ELM() / 2) * sizeof(float), hipMemcpyDeviceToHost, stream));
     HIP_CHECK(hipDeviceSynchronize());
-    HipTest::checkTest(A_h, B_h, NUM_ELM / 2);
+    HipTest::checkTest(A_h, B_h, NUM_ELM() / 2);
   }
   HipTest::freeArrays<float>(A_d, B_d, C_d, A_h, B_h, C_h, false);
   HIP_CHECK(hipStreamDestroy(stream));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAllApiNegative.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAllApiNegative.cc
@@ -16,7 +16,7 @@ This testfile verifies the following scenarios of all hipMemcpy API
 3. Null check scenario
 */
 
-static constexpr auto NUM_ELM{1024 * 1024};
+static const auto NUM_ELM = isQuickLevel() ? 1024 : 1024 * 1024;
 
 
 /*This testcase verifies the negative scenarios of hipMemcpy APIs

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAsync.cc
@@ -12,7 +12,9 @@
 
 HIP_TEST_CASE(Unit_hipMemcpyAsync_Positive_Basic) {
   using namespace std::placeholders;
-  const auto stream_type = GENERATE(Streams::nullstream, Streams::perThread, Streams::created);
+  const auto stream_type = isQuickLevel()
+      ? GENERATE(Streams::created)
+      : GENERATE(Streams::nullstream, Streams::perThread, Streams::created);
   const StreamGuard stream_guard(stream_type);
   const hipStream_t stream = stream_guard.stream();
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy_EdgeCases.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy_EdgeCases.cc
@@ -26,7 +26,10 @@ This testcase verifies following scenarios
 #endif
 
 
-static auto NUM_ELM() { return isQuickLevel() ? 128 * 1024 : 4 * 1024 * 1024; }
+static auto NUM_ELM() {
+  static const auto val = isQuickLevel() ? 128 * 1024 : 4 * 1024 * 1024;
+  return val;
+}
 static unsigned blocksPerCU{6};  // to hide latency
 static unsigned threadsPerBlock{256};
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy_EdgeCases.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy_EdgeCases.cc
@@ -26,7 +26,7 @@ This testcase verifies following scenarios
 #endif
 
 
-static const auto NUM_ELM = isQuickLevel() ? 128 * 1024 : 4 * 1024 * 1024;
+static auto NUM_ELM() { return isQuickLevel() ? 128 * 1024 : 4 * 1024 * 1024; }
 static unsigned blocksPerCU{6};  // to hide latency
 static unsigned threadsPerBlock{256};
 
@@ -336,17 +336,17 @@ template <typename T> void memcpytest2_offsets(size_t maxElem, bool devOffsets, 
 // Create multiple threads to stress multi-thread locking behavior in the
 // allocation/deallocation/tracking logic:
 template <typename T> void multiThread_1(bool serialize, bool usePinnedHost) {
-  DeviceMemory<T> memD(NUM_ELM);
-  HostMemory<T> mem1(NUM_ELM, usePinnedHost);
-  HostMemory<T> mem2(NUM_ELM, usePinnedHost);
+  DeviceMemory<T> memD(NUM_ELM());
+  HostMemory<T> mem1(NUM_ELM(), usePinnedHost);
+  HostMemory<T> mem2(NUM_ELM(), usePinnedHost);
 
-  std::thread t1(memcpytest2<T>, &memD, &mem1, NUM_ELM, 0, 0, 0);
+  std::thread t1(memcpytest2<T>, &memD, &mem1, NUM_ELM(), 0, 0, 0);
   if (serialize) {
     t1.join();
   }
 
 
-  std::thread t2(memcpytest2<T>, &memD, &mem2, NUM_ELM, 0, 0, 0);
+  std::thread t2(memcpytest2<T>, &memD, &mem2, NUM_ELM(), 0, 0, 0);
   if (serialize) {
     t2.join();
   }
@@ -360,25 +360,25 @@ Launches kernel and performs the sum of device variables
 copies the result to host variable and validates the result.
 */
 HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy_KernelLaunch, int, float, double) {
-  size_t Nbytes = NUM_ELM * sizeof(TestType);
+  size_t Nbytes = NUM_ELM() * sizeof(TestType);
 
   TestType *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr};
   TestType *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr};
 
-  HipTest::initArrays(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, NUM_ELM, false);
+  HipTest::initArrays(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, NUM_ELM(), false);
 
   HIP_CHECK(hipMemcpy(A_d, A_h, Nbytes, hipMemcpyHostToDevice));
   HIP_CHECK(hipMemcpy(B_d, B_h, Nbytes, hipMemcpyHostToDevice));
 
   constexpr int threads = 1024;
-  int blocks = NUM_ELM / threads;
+  int blocks = NUM_ELM() / threads;
   hipLaunchKernelGGL(HipTest::vectorADD, blocks, 1024, 0, 0, static_cast<const TestType*>(A_d),
-                     static_cast<const TestType*>(B_d), C_d, NUM_ELM);
+                     static_cast<const TestType*>(B_d), C_d, NUM_ELM());
   HIP_CHECK(hipGetLastError());
   HIP_CHECK(hipMemcpy(C_h, C_d, Nbytes, hipMemcpyDeviceToHost));
 
   HIP_CHECK(hipDeviceSynchronize());
-  HipTest::checkVectorADD(A_h, B_h, C_h, NUM_ELM);
+  HipTest::checkVectorADD(A_h, B_h, C_h, NUM_ELM());
 
   HipTest::freeArrays<TestType>(A_d, B_d, C_d, A_h, B_h, C_h, false);
 }
@@ -397,29 +397,29 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy_H2H_H2D_D2H_H2PinMem, int, float, double) 
   TestType *A_Ph{nullptr}, *B_Ph{nullptr};
   HIP_CHECK(hipSetDevice(0));
   HipTest::initArrays<TestType>(&A_d, &B_d, nullptr, &A_h, &B_h, nullptr,
-                                NUM_ELM * sizeof(TestType));
+                                NUM_ELM() * sizeof(TestType));
   HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &A_Ph, &B_Ph, nullptr,
-                                NUM_ELM * sizeof(TestType), true);
+                                NUM_ELM() * sizeof(TestType), true);
 
   SECTION("H2H, H2PinMem and PinMem2H") {
-    HIP_CHECK(hipMemcpy(B_h, A_h, NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-    HIP_CHECK(hipMemcpy(A_Ph, B_h, NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-    HIP_CHECK(hipMemcpy(B_Ph, A_Ph, NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-    HipTest::checkTest(A_h, B_Ph, NUM_ELM);
+    HIP_CHECK(hipMemcpy(B_h, A_h, NUM_ELM() * sizeof(TestType), hipMemcpyDefault));
+    HIP_CHECK(hipMemcpy(A_Ph, B_h, NUM_ELM() * sizeof(TestType), hipMemcpyDefault));
+    HIP_CHECK(hipMemcpy(B_Ph, A_Ph, NUM_ELM() * sizeof(TestType), hipMemcpyDefault));
+    HipTest::checkTest(A_h, B_Ph, NUM_ELM());
   }
 
   SECTION("H2D-D2D-D2H-SameGPU") {
-    HIP_CHECK(hipMemcpy(A_d, A_h, NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-    HIP_CHECK(hipMemcpy(B_d, A_d, NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-    HIP_CHECK(hipMemcpy(B_h, B_d, NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-    HipTest::checkTest(A_h, B_h, NUM_ELM);
+    HIP_CHECK(hipMemcpy(A_d, A_h, NUM_ELM() * sizeof(TestType), hipMemcpyDefault));
+    HIP_CHECK(hipMemcpy(B_d, A_d, NUM_ELM() * sizeof(TestType), hipMemcpyDefault));
+    HIP_CHECK(hipMemcpy(B_h, B_d, NUM_ELM() * sizeof(TestType), hipMemcpyDefault));
+    HipTest::checkTest(A_h, B_h, NUM_ELM());
   }
 
   SECTION("pH2D-D2D-D2pH-SameGPU") {
-    HIP_CHECK(hipMemcpy(A_d, A_Ph, NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-    HIP_CHECK(hipMemcpy(B_d, A_d, NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-    HIP_CHECK(hipMemcpy(B_Ph, B_d, NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-    HipTest::checkTest(A_Ph, B_Ph, NUM_ELM);
+    HIP_CHECK(hipMemcpy(A_d, A_Ph, NUM_ELM() * sizeof(TestType), hipMemcpyDefault));
+    HIP_CHECK(hipMemcpy(B_d, A_d, NUM_ELM() * sizeof(TestType), hipMemcpyDefault));
+    HIP_CHECK(hipMemcpy(B_Ph, B_d, NUM_ELM() * sizeof(TestType), hipMemcpyDefault));
+    HipTest::checkTest(A_Ph, B_Ph, NUM_ELM());
   }
   SECTION("H2D-D2D-D2H-DeviceContextChange") {
     int deviceCount = 0;
@@ -431,10 +431,10 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy_H2H_H2D_D2H_H2PinMem, int, float, double) 
       HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, 0, 1));
       if (canAccessPeer) {
         HIP_CHECK(hipSetDevice(1));
-        HIP_CHECK(hipMemcpy(A_d, A_h, NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-        HIP_CHECK(hipMemcpy(B_d, A_d, NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-        HIP_CHECK(hipMemcpy(B_h, B_d, NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-        HipTest::checkTest(A_h, B_h, NUM_ELM);
+        HIP_CHECK(hipMemcpy(A_d, A_h, NUM_ELM() * sizeof(TestType), hipMemcpyDefault));
+        HIP_CHECK(hipMemcpy(B_d, A_d, NUM_ELM() * sizeof(TestType), hipMemcpyDefault));
+        HIP_CHECK(hipMemcpy(B_h, B_d, NUM_ELM() * sizeof(TestType), hipMemcpyDefault));
+        HipTest::checkTest(A_h, B_h, NUM_ELM());
       } else {
         WARN("Skipping section: " << HipTest::SkipReason::kPeerAccessUnavailable);
       }
@@ -453,11 +453,11 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy_H2H_H2D_D2H_H2PinMem, int, float, double) 
         HIP_CHECK(hipSetDevice(1));
         TestType* C_d{nullptr};
         HipTest::initArrays<TestType>(nullptr, nullptr, &C_d, nullptr, nullptr, nullptr,
-                                      NUM_ELM * sizeof(TestType));
-        HIP_CHECK(hipMemcpy(A_d, A_h, NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-        HIP_CHECK(hipMemcpy(C_d, A_d, NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-        HIP_CHECK(hipMemcpy(B_h, C_d, NUM_ELM * sizeof(TestType), hipMemcpyDefault));
-        HipTest::checkTest(A_h, B_h, NUM_ELM);
+                                      NUM_ELM() * sizeof(TestType));
+        HIP_CHECK(hipMemcpy(A_d, A_h, NUM_ELM() * sizeof(TestType), hipMemcpyDefault));
+        HIP_CHECK(hipMemcpy(C_d, A_d, NUM_ELM() * sizeof(TestType), hipMemcpyDefault));
+        HIP_CHECK(hipMemcpy(B_h, C_d, NUM_ELM() * sizeof(TestType), hipMemcpyDefault));
+        HipTest::checkTest(A_h, B_h, NUM_ELM());
         HIP_CHECK(hipFree(C_d));
       } else {
         WARN("Skipping section: " << HipTest::SkipReason::kPeerAccessUnavailable);
@@ -499,14 +499,14 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy_PinnedRegMemWithKernelLaunch,
     // 1 refers to pinned Memory
     // 2 refers to register Memory
     int MallocPinType = GENERATE(0, 1);
-    size_t Nbytes = NUM_ELM * sizeof(TestType);
-    unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, NUM_ELM);
+    size_t Nbytes = NUM_ELM() * sizeof(TestType);
+    unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, NUM_ELM());
 
     TestType *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr};
     TestType *X_d{nullptr}, *Y_d{nullptr}, *Z_d{nullptr};
     TestType *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr};
     if (MallocPinType) {
-      HipTest::initArrays(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, NUM_ELM, true);
+      HipTest::initArrays(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, NUM_ELM(), true);
     } else {
       A_h = reinterpret_cast<TestType*>(malloc(Nbytes));
       HIP_CHECK(hipHostRegister(A_h, Nbytes, hipHostRegisterDefault));
@@ -514,18 +514,18 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy_PinnedRegMemWithKernelLaunch,
       HIP_CHECK(hipHostRegister(B_h, Nbytes, hipHostRegisterDefault));
       C_h = reinterpret_cast<TestType*>(malloc(Nbytes));
       HIP_CHECK(hipHostRegister(C_h, Nbytes, hipHostRegisterDefault));
-      HipTest::initArrays<TestType>(&A_d, &B_d, &C_d, nullptr, nullptr, nullptr, NUM_ELM, false);
-      HipTest::setDefaultData<TestType>(NUM_ELM, A_h, B_h, C_h);
+      HipTest::initArrays<TestType>(&A_d, &B_d, &C_d, nullptr, nullptr, nullptr, NUM_ELM(), false);
+      HipTest::setDefaultData<TestType>(NUM_ELM(), A_h, B_h, C_h);
     }
     HIP_CHECK(hipMemcpy(A_d, A_h, Nbytes, hipMemcpyHostToDevice));
     HIP_CHECK(hipMemcpy(B_d, B_h, Nbytes, hipMemcpyHostToDevice));
 
     hipLaunchKernelGGL(HipTest::vectorADD, dim3(blocks), dim3(threadsPerBlock), 0, 0,
                        static_cast<const TestType*>(A_d), static_cast<const TestType*>(B_d), C_d,
-                       NUM_ELM);
+                       NUM_ELM());
     HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipMemcpy(C_h, C_d, Nbytes, hipMemcpyDeviceToHost));
-    HipTest::checkVectorADD(A_h, B_h, C_h, NUM_ELM);
+    HipTest::checkVectorADD(A_h, B_h, C_h, NUM_ELM());
 
     unsigned int seed = time(0);
     HIP_CHECK(hipSetDevice(HipTest::RAND_R(&seed) % (numDevices - 1) + 1));
@@ -533,9 +533,9 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy_PinnedRegMemWithKernelLaunch,
     int device;
     HIP_CHECK(hipGetDevice(&device));
     std::cout << "hipMemcpy is set to happen between device 0 and device " << device << std::endl;
-    HipTest::initArrays<TestType>(&X_d, &Y_d, &Z_d, nullptr, nullptr, nullptr, NUM_ELM, false);
+    HipTest::initArrays<TestType>(&X_d, &Y_d, &Z_d, nullptr, nullptr, nullptr, NUM_ELM(), false);
 
-    for (int j = 0; j < NUM_ELM; j++) {
+    for (int j = 0; j < NUM_ELM(); j++) {
       A_h[j] = 0;
       B_h[j] = 0;
       C_h[j] = 0;
@@ -548,11 +548,11 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy_PinnedRegMemWithKernelLaunch,
 
     hipLaunchKernelGGL(HipTest::vectorADD, dim3(blocks), dim3(threadsPerBlock), 0, 0,
                        static_cast<const TestType*>(X_d), static_cast<const TestType*>(Y_d), Z_d,
-                       NUM_ELM);
+                       NUM_ELM());
     HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipMemcpy(C_h, Z_d, Nbytes, hipMemcpyDeviceToHost));
 
-    HipTest::checkVectorADD(A_h, B_h, C_h, NUM_ELM);
+    HipTest::checkVectorADD(A_h, B_h, C_h, NUM_ELM());
 
     if (MallocPinType) {
       HipTest::freeArrays<TestType>(A_d, B_d, C_d, A_h, B_h, C_h, true);

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy_EdgeCases.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy_EdgeCases.cc
@@ -26,7 +26,7 @@ This testcase verifies following scenarios
 #endif
 
 
-static constexpr auto NUM_ELM{4 * 1024 * 1024};
+static const auto NUM_ELM = isQuickLevel() ? 128 * 1024 : 4 * 1024 * 1024;
 static unsigned blocksPerCU{6};  // to hide latency
 static unsigned threadsPerBlock{256};
 

--- a/projects/hip-tests/catch/unit/memory/hipMemset2DAsyncMultiThreadAndKernel.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemset2DAsyncMultiThreadAndKernel.cc
@@ -126,7 +126,8 @@ HIP_TEST_CASE(Unit_hipMemset2DAsync_MultiThread) {
   int validateCount{};
   hipStream_t stream;
 
-  auto thread_count = HipTest::getHostThreadCount(memPerThread, NUM_THREADS);
+  const int maxThreads = isQuickLevel() ? 4 : NUM_THREADS;
+  auto thread_count = HipTest::getHostThreadCount(memPerThread, maxThreads);
   if (thread_count == 0) {
     WARN("Resources not available for thread creation");
     return;
@@ -148,7 +149,8 @@ HIP_TEST_CASE(Unit_hipMemset2DAsync_MultiThread) {
   HIP_CHECK(hipMemcpy2D(B_d, width, B_h, pitch_B, NUM_W, NUM_H, hipMemcpyHostToDevice));
   HIP_CHECK(hipStreamCreate(&stream));
 
-  for (int i = 0; i < ITER; i++) {
+  const int numIter = isQuickLevel() ? 2 : ITER;
+  for (int i = 0; i < numIter; i++) {
     for (size_t k = 0; k < thread_count; k++) {
       if (k % 2) {
         t[k] = std::thread(queueJobsForhipMemset2DAsync, A_d, A_h, pitch_A, width, stream);
@@ -168,7 +170,7 @@ HIP_TEST_CASE(Unit_hipMemset2DAsync_MultiThread) {
     }
   }
 
-  REQUIRE(static_cast<size_t>(validateCount) == (ITER * elements));
+  REQUIRE(static_cast<size_t>(validateCount) == (numIter * elements));
 
   HIP_CHECK(hipFree(A_d));
   HIP_CHECK(hipFree(B_d));

--- a/projects/hip-tests/catch/unit/memory/hipMemset3D.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemset3D.cc
@@ -131,9 +131,9 @@ HIP_TEST_CASE(Unit_hipMemset3DAsync_capturehipMemset3DAsync) {
   hipGraph_t graph{nullptr};
   hipGraphExec_t graphExec{nullptr};
   int row, col, dep;
-  row = GENERATE(3, 4, 100);
-  col = GENERATE(3, 4, 100);
-  dep = GENERATE(3, 4, 100);
+  row = isQuickLevel() ? GENERATE(3, 100) : GENERATE(3, 4, 100);
+  col = isQuickLevel() ? GENERATE(3, 100) : GENERATE(3, 4, 100);
+  dep = isQuickLevel() ? GENERATE(3, 100) : GENERATE(3, 4, 100);
   hipStream_t stream;
 
   A_h = reinterpret_cast<char*>(malloc(sizeof(char) * row * col * dep));

--- a/projects/hip-tests/catch/unit/memory/hipMemsetSync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetSync.cc
@@ -389,8 +389,7 @@ void runTests(allocType type, memSetType memsetType, MultiDData data, hipStream_
   bool async = GENERATE(true, false);
   CAPTURE(type, memsetType, data.width, data.height, data.depth, stream, async);
   std::pair<T*, T*> aPtr = initMemory<T>(type, memsetType, data);
-  using namespace std::chrono_literals;
-  const std::chrono::duration<uint64_t, std::milli> delay = 100ms;
+  const auto delay = std::chrono::milliseconds(isQuickLevel() ? 10 : 100);
   LaunchDelayKernel(delay, stream);
   memsetCheck(aPtr.first, testValue, memsetType, data, async, stream);
 
@@ -413,7 +412,9 @@ void runTests(allocType type, memSetType memsetType, MultiDData data, hipStream_
 template <typename T>
 static void doMemsetTest(allocType mallocType, memSetType memset_type, MultiDData data) {
   enum StreamType { NULLSTR, CREATEDSTR };
-  auto streamType = GENERATE(NULLSTR, CREATEDSTR);
+  auto streamType = isQuickLevel()
+      ? GENERATE(CREATEDSTR)
+      : GENERATE(NULLSTR, CREATEDSTR);
   hipStream_t stream{nullptr};
 
   if (streamType == CREATEDSTR) HIP_CHECK(hipStreamCreate(&stream));
@@ -455,8 +456,8 @@ HIP_TEST_CASE(Unit_hipMemset2DSync) {
                                   allocType::hostRegisted, allocType::devRegistered);
   memSetType memset_type = memSetType::hipMemset2D;
   MultiDData data;
-  data.width = GENERATE(512, 1024);
-  data.height = GENERATE(512, 1024);
+  data.width = isQuickLevel() ? GENERATE(128, 256) : GENERATE(512, 1024);
+  data.height = isQuickLevel() ? GENERATE(128, 256) : GENERATE(512, 1024);
 
   doMemsetTest<char>(mallocType, memset_type, data);
 }
@@ -466,9 +467,9 @@ HIP_TEST_CASE(Unit_hipMemset3DSync) {
                                   allocType::hostRegisted, allocType::devRegistered);
   memSetType memset_type = memSetType::hipMemset3D;
   MultiDData data;
-  data.width = GENERATE(128, 256);
-  data.height = GENERATE(128, 256);
-  data.depth = GENERATE(128, 256);
+  data.width = isQuickLevel() ? GENERATE(32, 64) : GENERATE(128, 256);
+  data.height = isQuickLevel() ? GENERATE(32, 64) : GENERATE(128, 256);
+  data.depth = isQuickLevel() ? GENERATE(32, 64) : GENERATE(128, 256);
 
   doMemsetTest<char>(mallocType, memset_type, data);
 }

--- a/projects/hip-tests/catch/unit/memory/memcpy2d_tests_common.hh
+++ b/projects/hip-tests/catch/unit/memory/memcpy2d_tests_common.hh
@@ -16,7 +16,8 @@
 
 template <bool should_synchronize, bool unaligned = false, typename F>
 void Memcpy2DDeviceToHostShell(F memcpy_func, const hipStream_t kernel_stream = nullptr) {
-  const auto kind = GENERATE(hipMemcpyDeviceToHost, hipMemcpyDefault);
+  const auto kind =
+      isQuickLevel() ? hipMemcpyDeviceToHost : GENERATE(hipMemcpyDeviceToHost, hipMemcpyDefault);
 
   constexpr size_t cols = 127;
   constexpr size_t rows = 128;
@@ -46,7 +47,8 @@ void Memcpy2DDeviceToHostShell(F memcpy_func, const hipStream_t kernel_stream = 
 
 template <bool should_synchronize, bool enable_peer_access, bool unaligned = false, typename F>
 void Memcpy2DDeviceToDeviceShell(F memcpy_func, const hipStream_t kernel_stream = nullptr) {
-  const auto kind = GENERATE(hipMemcpyDeviceToDevice, hipMemcpyDefault);
+  const auto kind = isQuickLevel() ? hipMemcpyDeviceToDevice
+                                   : GENERATE(hipMemcpyDeviceToDevice, hipMemcpyDefault);
 
   constexpr size_t cols = 127;
   constexpr size_t rows = 128;
@@ -104,7 +106,8 @@ void Memcpy2DDeviceToDeviceShell(F memcpy_func, const hipStream_t kernel_stream 
 
 template <bool should_synchronize, bool unaligned = false, typename F>
 void Memcpy2DHostToDeviceShell(F memcpy_func, const hipStream_t kernel_stream = nullptr) {
-  const auto kind = GENERATE(hipMemcpyHostToDevice, hipMemcpyDefault);
+  const auto kind = isQuickLevel() ? hipMemcpyHostToDevice
+                                   : GENERATE(hipMemcpyHostToDevice, hipMemcpyDefault);
 
   constexpr size_t cols = 127;
   constexpr size_t rows = 128;
@@ -138,7 +141,8 @@ void Memcpy2DHostToDeviceShell(F memcpy_func, const hipStream_t kernel_stream = 
 
 template <bool should_synchronize, typename F>
 void Memcpy2DHostToHostShell(F memcpy_func, const hipStream_t kernel_stream = nullptr) {
-  const auto kind = GENERATE(hipMemcpyHostToHost, hipMemcpyDefault);
+  const auto kind =
+      isQuickLevel() ? hipMemcpyHostToHost : GENERATE(hipMemcpyHostToHost, hipMemcpyDefault);
 
   constexpr size_t cols = 127;
   constexpr size_t rows = 128;

--- a/projects/hip-tests/catch/unit/memory/mempool_common.hh
+++ b/projects/hip-tests/catch/unit/memory/mempool_common.hh
@@ -75,8 +75,9 @@ template <typename T> __global__ void kernel_500ms_gfx11(T* host_res, int clk_ra
 template <typename T> __global__ void notifiedKernel(T* host_res, volatile unsigned int* notified) {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
   host_res[tid] = tid + 1;
-  __threadfence_system();
-  while (*notified == 0) { }
+  if (threadIdx.x == 0) {
+    while (*notified == 0) { }
+  }
 }
 
 template <typename F> void MallocMemPoolAsync_OneAlloc(F malloc_func, const MemPools mempool_type) {

--- a/projects/hip-tests/catch/unit/multiThread/hipMemsetAsyncMultiThread.cc
+++ b/projects/hip-tests/catch/unit/multiThread/hipMemsetAsyncMultiThread.cc
@@ -49,7 +49,7 @@ template <typename Func, typename T> void threadCall(Func f, hipStream_t stream)
 
   T* ptr{nullptr};
   constexpr size_t size = 1024;
-  constexpr size_t iter = 512;
+  const size_t iter = isQuickLevel() ? 8 : 512;
   HIP_CHECK_THREAD(hipMalloc(&ptr, sizeof(T) * size));
   hipEvent_t event{};
   HIP_CHECK_THREAD(hipEventCreate(&event));
@@ -97,7 +97,8 @@ template <typename Func, typename T> void launchThreads(Func f, TestType type) {
                                                    hipStream_t)>::value) &&  // hipMemsetD8Async
                 "Func f should be hipMemsetAsync or hipMemsetD*Async");
 
-  const size_t num_threads = (std::thread::hardware_concurrency() > 8)
+  const size_t num_threads = isQuickLevel() ? 4
+                            : (std::thread::hardware_concurrency() > 8)
                                  ? (((std::thread::hardware_concurrency() / 4) >= 127)
                                         ? 127
                                         : (std::thread::hardware_concurrency() / 4))

--- a/projects/hip-tests/catch/unit/multiThread/hipMultiThreadStreams2.cc
+++ b/projects/hip-tests/catch/unit/multiThread/hipMultiThreadStreams2.cc
@@ -106,7 +106,7 @@ void run(size_t size, hipStream_t stream1, hipStream_t stream2) {
   HIPCHECK(hipFree(Ddd));
 }
 HIP_TEST_CASE(Unit_hipMultiThreadStreams2) {
-  int iterations = 100;
+  int iterations = isQuickLevel() ? 5 : 100;
 
   hipStream_t stream[3];
   for (int i = 0; i < 3; i++) {

--- a/projects/hip-tests/catch/unit/stream/hipLaunchHostFunc.cc
+++ b/projects/hip-tests/catch/unit/stream/hipLaunchHostFunc.cc
@@ -476,7 +476,8 @@ HIP_TEST_CASE(Unit_hipLaunchHostFunc_Graph) {
 
   HIP_CHECK(hipGraphInstantiate(&graphExec, graph, NULL, NULL, 0));
   auto start1 = std::chrono::high_resolution_clock::now();
-  for (int i = 0; i < GRAPH_LAUNCH_ITERATIONS; i++) {
+  const int graphIters = isQuickLevel() ? 10 : GRAPH_LAUNCH_ITERATIONS;
+  for (int i = 0; i < graphIters; i++) {
     HIP_CHECK(hipGraphLaunch(graphExec, streamForGraph));
   }
   HIP_CHECK(hipStreamSynchronize(streamForGraph));

--- a/projects/hip-tests/catch/unit/stream/hipMultiStream.cc
+++ b/projects/hip-tests/catch/unit/stream/hipMultiStream.cc
@@ -29,14 +29,15 @@ HIP_TEST_CASE(Unit_hipMultiStream_sameDevice) {
   hipStream_t streams[num_streams];
   float *data[num_streams], *yd, *xd;
   float y{1.0f}, x{1.0f};
+  const int n = isQuickLevel() ? (1 << 12) : NN;
   HIP_CHECK(hipMalloc((void**)&yd, sizeof(float)));
   HIP_CHECK(hipMalloc((void**)&xd, sizeof(float)));
   HIP_CHECK(hipMemcpy(yd, &y, sizeof(float), hipMemcpyHostToDevice));
   HIP_CHECK(hipMemcpy(xd, &x, sizeof(float), hipMemcpyHostToDevice));
   for (int i = 0; i < num_streams; i++) {
     HIP_CHECK(hipStreamCreate(&streams[i]));
-    HIP_CHECK(hipMalloc(&data[i], NN * sizeof(float)));
-    hipLaunchKernelGGL(kernel, dim3(1), dim3(1), 0, streams[i], data[i], xd, NN);
+    HIP_CHECK(hipMalloc(&data[i], n * sizeof(float)));
+    hipLaunchKernelGGL(kernel, dim3(1), dim3(1), 0, streams[i], data[i], xd, n);
     HIP_CHECK(hipGetLastError());
     hipLaunchKernelGGL(HIP_KERNEL_NAME(nKernel), dim3(1), dim3(1), 0, 0, yd);
     HIP_CHECK(hipGetLastError());
@@ -51,7 +52,7 @@ HIP_TEST_CASE(Unit_hipMultiStream_sameDevice) {
 }
 
 HIP_TEST_CASE(Unit_hipMultiStream_multimeDevice) {
-  constexpr int nLoops = 50000;
+  const int nLoops = isQuickLevel() ? 500 : 50000;
   constexpr int nStreams = 2;
   std::vector<hipStream_t> streams(nStreams);
   int nGpu = 0;

--- a/projects/hip-tests/catch/unit/stream/hipStreamCreateWithFlags.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamCreateWithFlags.cc
@@ -51,7 +51,7 @@ HIP_TEST_CASE(Unit_hipStreamCreateWithFlags_DefaultStreamInteraction) {
   hipStream_t stream{};
   HIP_CHECK(hipStreamCreateWithFlags(&stream, flagUnderTest));
 
-  constexpr auto delay = std::chrono::milliseconds(500);
+  const auto delay = std::chrono::milliseconds(isQuickLevel() ? 100 : 500);
 
   SECTION("default stream waiting for created stream") {
     const hipError_t expectedError =

--- a/projects/hip-tests/catch/unit/stream/hipStreamCreateWithPriority.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamCreateWithPriority.cc
@@ -17,8 +17,14 @@
 #include <vector>
 #include "streamCommon.hh"  // NOLINT
 
-static size_t MEMCPYSIZE1() { return isQuickLevel() ? (100 * 1024) : (64 * 1024 * 1024); }
-static size_t MEMCPYSIZE2() { return isQuickLevel() ? (100 * 1024) : (1024 * 1024); }
+static size_t MEMCPYSIZE1() {
+  static const size_t val = isQuickLevel() ? (100 * 1024) : (64 * 1024 * 1024);
+  return val;
+}
+static size_t MEMCPYSIZE2() {
+  static const size_t val = isQuickLevel() ? (100 * 1024) : (1024 * 1024);
+  return val;
+}
 constexpr size_t NUMITERS = 2;
 constexpr size_t GRIDSIZE = 4096;
 constexpr size_t BLOCKSIZE = 256;

--- a/projects/hip-tests/catch/unit/stream/hipStreamCreateWithPriority.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamCreateWithPriority.cc
@@ -17,8 +17,8 @@
 #include <vector>
 #include "streamCommon.hh"  // NOLINT
 
-constexpr size_t MEMCPYSIZE1 = (64 * 1024 * 1024);
-constexpr size_t MEMCPYSIZE2 = (1024 * 1024);
+static const size_t MEMCPYSIZE1 = isQuickLevel() ? (100 * 1024) : (64 * 1024 * 1024);
+static const size_t MEMCPYSIZE2 = isQuickLevel() ? (100 * 1024) : (1024 * 1024);
 constexpr size_t NUMITERS = 2;
 constexpr size_t GRIDSIZE = 4096;
 constexpr size_t BLOCKSIZE = 256;
@@ -153,7 +153,7 @@ void funcTestsForAllPriorityLevelsWrtNullStrm(unsigned int flags, bool deviceSyn
  * Validate the calculated results.
  */
 void queueTasksInStreams(std::vector<hipStream_t>& stream, size_t arrsize) {
-  constexpr size_t size = MEMCPYSIZE2 * sizeof(int);
+  const size_t size = MEMCPYSIZE2 * sizeof(int);
   constexpr int initVal = 2;
 
   std::vector<int> A_in(MEMCPYSIZE2, initVal);
@@ -165,7 +165,7 @@ void queueTasksInStreams(std::vector<hipStream_t>& stream, size_t arrsize) {
   std::vector<int*> C_d(arrsize, nullptr);
 
   constexpr int threads = 1024;
-  constexpr int blocks = (MEMCPYSIZE2 / threads);
+  const int blocks = (MEMCPYSIZE2 / threads);
 
   for (int i = 0; i < arrsize; i++) {
     HIP_CHECK_THREAD(hipMalloc(&A_d[i], size));

--- a/projects/hip-tests/catch/unit/stream/hipStreamCreateWithPriority.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamCreateWithPriority.cc
@@ -17,8 +17,8 @@
 #include <vector>
 #include "streamCommon.hh"  // NOLINT
 
-static const size_t MEMCPYSIZE1 = isQuickLevel() ? (100 * 1024) : (64 * 1024 * 1024);
-static const size_t MEMCPYSIZE2 = isQuickLevel() ? (100 * 1024) : (1024 * 1024);
+static size_t MEMCPYSIZE1() { return isQuickLevel() ? (100 * 1024) : (64 * 1024 * 1024); }
+static size_t MEMCPYSIZE2() { return isQuickLevel() ? (100 * 1024) : (1024 * 1024); }
 constexpr size_t NUMITERS = 2;
 constexpr size_t GRIDSIZE = 4096;
 constexpr size_t BLOCKSIZE = 256;
@@ -52,7 +52,7 @@ void funcTestsForAllPriorityLevelsWrtNullStrm(unsigned int flags, bool deviceSyn
   int priority;
   int priority_low{};
   int priority_high{};
-  size_t size = MEMCPYSIZE2 * sizeof(int);
+  size_t size = MEMCPYSIZE2() * sizeof(int);
   // Test is to get the Stream Priority Range
   HIP_CHECK(hipDeviceGetStreamPriorityRange(&priority_low, &priority_high));
 
@@ -97,7 +97,7 @@ void funcTestsForAllPriorityLevelsWrtNullStrm(unsigned int flags, bool deviceSyn
   // Initialize host memory
   constexpr int initVal = 2;
   for (int idx = 0; idx < arr_size; idx++) {
-    for (int idy = 0; idy < MEMCPYSIZE2; idy++) {
+    for (int idy = 0; idy < MEMCPYSIZE2(); idy++) {
       A_h[idx][idy] = initVal;
     }
   }
@@ -106,7 +106,7 @@ void funcTestsForAllPriorityLevelsWrtNullStrm(unsigned int flags, bool deviceSyn
   for (int idx = 0; idx < arr_size; idx++) {
     HIP_CHECK(hipMemcpyAsync(A_d[idx], A_h[idx], size, hipMemcpyHostToDevice, stream[idx]));
     hipLaunchKernelGGL((HipTest::vector_square), dim3(GRIDSIZE), dim3(BLOCKSIZE), 0, stream[idx],
-                       A_d[idx], C_d[idx], MEMCPYSIZE2);
+                       A_d[idx], C_d[idx], MEMCPYSIZE2());
     HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipMemcpyAsync(C_h[idx], C_d[idx], size, hipMemcpyDeviceToHost, stream[idx]));
   }
@@ -120,7 +120,7 @@ void funcTestsForAllPriorityLevelsWrtNullStrm(unsigned int flags, bool deviceSyn
     if (!deviceSynchronize) {
       HIP_CHECK(hipStreamSynchronize(stream[idx]));
     }
-    for (int idy = 0; idy < MEMCPYSIZE2; idy++) {
+    for (int idy = 0; idy < MEMCPYSIZE2(); idy++) {
       if (C_h[idx][idy] != A_h[idx][idy] * A_h[idx][idy]) {
         INFO("Data mismatch at idx:" << idx << " idy:" << idy);
         REQUIRE(false);
@@ -153,11 +153,11 @@ void funcTestsForAllPriorityLevelsWrtNullStrm(unsigned int flags, bool deviceSyn
  * Validate the calculated results.
  */
 void queueTasksInStreams(std::vector<hipStream_t>& stream, size_t arrsize) {
-  const size_t size = MEMCPYSIZE2 * sizeof(int);
+  const size_t size = MEMCPYSIZE2() * sizeof(int);
   constexpr int initVal = 2;
 
-  std::vector<int> A_in(MEMCPYSIZE2, initVal);
-  std::vector<int> C_in(MEMCPYSIZE2, 0);
+  std::vector<int> A_in(MEMCPYSIZE2(), initVal);
+  std::vector<int> C_in(MEMCPYSIZE2(), 0);
   std::vector<std::vector<int>> A_h(arrsize, A_in);
   std::vector<std::vector<int>> C_h(arrsize, C_in);
 
@@ -165,7 +165,7 @@ void queueTasksInStreams(std::vector<hipStream_t>& stream, size_t arrsize) {
   std::vector<int*> C_d(arrsize, nullptr);
 
   constexpr int threads = 1024;
-  const int blocks = (MEMCPYSIZE2 / threads);
+  const int blocks = (MEMCPYSIZE2() / threads);
 
   for (int i = 0; i < arrsize; i++) {
     HIP_CHECK_THREAD(hipMalloc(&A_d[i], size));
@@ -176,7 +176,7 @@ void queueTasksInStreams(std::vector<hipStream_t>& stream, size_t arrsize) {
   for (int i = 0; i < arrsize; i++) {
     HIP_CHECK_THREAD(hipMemcpyAsync(A_d[i], A_h[i].data(), size, hipMemcpyHostToDevice, stream[i]));
     hipLaunchKernelGGL((HipTest::vector_square), blocks, threads, 0, stream[i], A_d[i], C_d[i],
-                       MEMCPYSIZE2);
+                       MEMCPYSIZE2());
     HIP_CHECK_THREAD(hipGetLastError());
     HIP_CHECK_THREAD(hipMemcpyAsync(C_h[i].data(), C_d[i], size, hipMemcpyDeviceToHost, stream[i]));
   }
@@ -184,7 +184,7 @@ void queueTasksInStreams(std::vector<hipStream_t>& stream, size_t arrsize) {
   // Validate the output of each queue
   for (int i = 0; i < arrsize; i++) {
     HIP_CHECK_THREAD(hipStreamSynchronize(stream[i]));
-    for (size_t j = 0; j < MEMCPYSIZE2; j++) {
+    for (size_t j = 0; j < MEMCPYSIZE2(); j++) {
       REQUIRE_THREAD(C_h[i][j] == (A_h[i][j] * A_h[i][j]));
     }
   }
@@ -247,7 +247,7 @@ bool runFuncTestsForAllPriorityLevelsMultThread(unsigned int flags) {
 
 
 template <typename T> bool verifyStreamPriorityKernelResults() {
-  size_t size = NUMITERS * MEMCPYSIZE1;
+  size_t size = NUMITERS * MEMCPYSIZE1();
 
 // get the range of priorities available
 #define OP(x)                                                                                      \
@@ -319,12 +319,12 @@ template <typename T> bool verifyStreamPriorityKernelResults() {
 #undef OP
 
   // launch kernels repeatedly on each of the priority streams
-  for (int i = 0; i < static_cast<int>(size); i += MEMCPYSIZE1) {
+  for (int i = 0; i < static_cast<int>(size); i += MEMCPYSIZE1()) {
     int j = i / sizeof(T);
 #define OP(x)                                                                                      \
   if (enable_priority_##x) {                                                                       \
     hipLaunchKernelGGL((memcpy_kernel<T>), dim3(GRIDSIZE), dim3(BLOCKSIZE), 0, stream_##x,         \
-                       dst_d_##x + j, src_d_##x + j, (MEMCPYSIZE1 / sizeof(T)));                   \
+                       dst_d_##x + j, src_d_##x + j, (MEMCPYSIZE1() / sizeof(T)));                   \
     HIP_CHECK(hipGetLastError());                                                                  \
   }
     OP(low)
@@ -384,7 +384,7 @@ template <typename T> bool verifyStreamPriorityKernelResults() {
 #define HIGH_PRIORITY_STREAMCOUNT 2
 #define NORMAL_PRIORITY_STREAMCOUNT 2
 template <typename T> void TestForMultipleStreamWithPriority(void) {
-  size_t size = NUMITERS * MEMCPYSIZE1;
+  size_t size = NUMITERS * MEMCPYSIZE1();
 // get the range of priorities available
 #define OP(x)                                                                                      \
   int priority_##x;                                                                                \
@@ -556,31 +556,31 @@ template <typename T> void TestForMultipleStreamWithPriority(void) {
   }
   // launch kernels repeatedly on each of the low prioritiy stream
   for (int k = 0; k < LOW_PRIORITY_STREAMCOUNT; ++k) {
-    for (size_t i = 0; i < size; i += MEMCPYSIZE1) {
+    for (size_t i = 0; i < size; i += MEMCPYSIZE1()) {
       size_t j = i / sizeof(T);
       if (enable_priority_low) {
         hipLaunchKernelGGL((memcpy_kernel<T>), dim3(GRIDSIZE), dim3(BLOCKSIZE), 0, stream_low[k],
-                           dst_d_low[k] + j, src_d_low[k] + j, (MEMCPYSIZE1 / sizeof(T)));
+                           dst_d_low[k] + j, src_d_low[k] + j, (MEMCPYSIZE1() / sizeof(T)));
       }
     }
   }
   // launch kernels repeatedly on each of the normal prioritiy stream
   for (int k = 0; k < NORMAL_PRIORITY_STREAMCOUNT; ++k) {
-    for (size_t i = 0; i < size; i += MEMCPYSIZE1) {
+    for (size_t i = 0; i < size; i += MEMCPYSIZE1()) {
       size_t j = i / sizeof(T);
       if (enable_priority_normal) {
         hipLaunchKernelGGL((memcpy_kernel<T>), dim3(GRIDSIZE), dim3(BLOCKSIZE), 0, stream_normal[k],
-                           dst_d_normal[k] + j, src_d_normal[k] + j, (MEMCPYSIZE1 / sizeof(T)));
+                           dst_d_normal[k] + j, src_d_normal[k] + j, (MEMCPYSIZE1() / sizeof(T)));
       }
     }
   }
   // launch kernels repeatedly on each of the high prioritiy stream
   for (int k = 0; k < HIGH_PRIORITY_STREAMCOUNT; ++k) {
-    for (size_t i = 0; i < size; i += MEMCPYSIZE1) {
+    for (size_t i = 0; i < size; i += MEMCPYSIZE1()) {
       size_t j = i / sizeof(T);
       if (enable_priority_high) {
         hipLaunchKernelGGL((memcpy_kernel<T>), dim3(GRIDSIZE), dim3(BLOCKSIZE), 0, stream_high[k],
-                           dst_d_high[k] + j, src_d_high[k] + j, (MEMCPYSIZE1 / sizeof(T)));
+                           dst_d_high[k] + j, src_d_high[k] + j, (MEMCPYSIZE1() / sizeof(T)));
       }
     }
   }

--- a/projects/hip-tests/catch/unit/stream/hipStreamDestroy.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamDestroy.cc
@@ -61,7 +61,7 @@ HIP_TEST_CASE(Unit_hipStreamDestroy_WithPendingWork) {
   HIP_CHECK(hipMalloc(&deviceData, sizeof(int) * numDataPoints));
   HIP_CHECK(hipMemset(deviceData, 0, sizeof(int) * numDataPoints));
 
-  LaunchDelayKernel(std::chrono::milliseconds(500), stream);
+  LaunchDelayKernel(std::chrono::milliseconds(isQuickLevel() ? 50 : 500), stream);
   setToOne<<<1, numDataPoints, 0, stream>>>(deviceData, numDataPoints);
   SECTION("Without stream query") { fprintf(stderr, "Without stream query\n"); }
   SECTION("With stream query") {

--- a/projects/hip-tests/catch/unit/stream/hipStreamLegacy_Ext.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamLegacy_Ext.cc
@@ -9,7 +9,10 @@
 #include <utils.hh>
 #include <hip_test_process.hh>
 
-static int getN() { return isQuickLevel() ? (64 * 1024 / sizeof(int)) : 2 * 1024 * 1024; }
+static int getN() {
+  static const int val = isQuickLevel() ? (64 * 1024 / sizeof(int)) : 2 * 1024 * 1024;
+  return val;
+}
 static size_t getNBytes() { return getN() * sizeof(int); }
 
 /**

--- a/projects/hip-tests/catch/unit/stream/hipStreamLegacy_Ext.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamLegacy_Ext.cc
@@ -9,8 +9,8 @@
 #include <utils.hh>
 #include <hip_test_process.hh>
 
-static const int N = isQuickLevel() ? (64 * 1024 / sizeof(int)) : 2 * 1024 * 1024;
-static const size_t NBYTES = N * sizeof(int);
+static int getN() { return isQuickLevel() ? (64 * 1024 / sizeof(int)) : 2 * 1024 * 1024; }
+static size_t getNBytes() { return getN() * sizeof(int); }
 
 /**
  * Local Function to fill the array with given value
@@ -64,27 +64,27 @@ static __global__ void addOneKernel(int* a, int size) {
  *  - HIP_VERSION >= 6.3
  */
 HIP_TEST_CASE(Unit_hipStreamLegacy_WithBlockingStream) {
-  int* hostArrSrc = new int[N];
+  int* hostArrSrc = new int[getN()];
   REQUIRE(hostArrSrc != nullptr);
-  fillHostArray(hostArrSrc, N, 1);
+  fillHostArray(hostArrSrc, getN(), 1);
 
   int* devArr = nullptr;
-  HIP_CHECK(hipMalloc(&devArr, NBYTES));
+  HIP_CHECK(hipMalloc(&devArr, getNBytes()));
   REQUIRE(devArr != nullptr);
-  fillDeviceArray(devArr, N, 2);
+  fillDeviceArray(devArr, getN(), 2);
 
-  int* hostArrDst = new int[N];
+  int* hostArrDst = new int[getN()];
   REQUIRE(hostArrDst != nullptr);
-  fillHostArray(hostArrDst, N, 3);
+  fillHostArray(hostArrDst, getN(), 3);
 
   hipStream_t stream;
   HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamDefault));
 
-  HIP_CHECK(hipMemcpyAsync(devArr, hostArrSrc, NBYTES, hipMemcpyHostToDevice, stream));
-  HIP_CHECK(hipMemcpyAsync(hostArrDst, devArr, NBYTES, hipMemcpyDeviceToHost, hipStreamLegacy));
+  HIP_CHECK(hipMemcpyAsync(devArr, hostArrSrc, getNBytes(), hipMemcpyHostToDevice, stream));
+  HIP_CHECK(hipMemcpyAsync(hostArrDst, devArr, getNBytes(), hipMemcpyDeviceToHost, hipStreamLegacy));
   HIP_CHECK(hipStreamSynchronize(hipStreamLegacy));
 
-  for (int i = 0; i < N; i++) {
+  for (int i = 0; i < getN(); i++) {
     INFO("At index : " << i << " Got value : " << hostArrDst[i] << " Expected value : 1 \n");
     REQUIRE(hostArrDst[i] == 1);
   }
@@ -102,24 +102,24 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_WithBlockingStream) {
  * Task 2 should wait till the execution of task 1.
  */
 void launchFunction(hipStream_t stream) {
-  int* hostArrSrc = new int[N];
+  int* hostArrSrc = new int[getN()];
   REQUIRE_THREAD(hostArrSrc != nullptr);
-  fillHostArray(hostArrSrc, N, 5);
+  fillHostArray(hostArrSrc, getN(), 5);
 
   int* devArr = nullptr;
-  HIP_CHECK_THREAD(hipMalloc(&devArr, NBYTES));
+  HIP_CHECK_THREAD(hipMalloc(&devArr, getNBytes()));
   REQUIRE_THREAD(devArr != nullptr);
-  fillDeviceArray(devArr, N, 6);
+  fillDeviceArray(devArr, getN(), 6);
 
-  int* hostArrDst = new int[N];
+  int* hostArrDst = new int[getN()];
   REQUIRE_THREAD(hostArrDst != nullptr);
-  fillHostArray(hostArrDst, N, 7);
+  fillHostArray(hostArrDst, getN(), 7);
 
-  HIP_CHECK_THREAD(hipMemcpyAsync(devArr, hostArrSrc, NBYTES, hipMemcpyHostToDevice, stream));
-  HIP_CHECK_THREAD(hipMemcpyAsync(hostArrDst, devArr, NBYTES, hipMemcpyDeviceToHost, stream));
+  HIP_CHECK_THREAD(hipMemcpyAsync(devArr, hostArrSrc, getNBytes(), hipMemcpyHostToDevice, stream));
+  HIP_CHECK_THREAD(hipMemcpyAsync(hostArrDst, devArr, getNBytes(), hipMemcpyDeviceToHost, stream));
   HIP_CHECK_THREAD(hipStreamSynchronize(hipStreamLegacy));
 
-  for (int i = 0; i < N; i++) {
+  for (int i = 0; i < getN(); i++) {
     if (hostArrDst[i] != 5) {
       std::cout << "At index : " << i << " Got value : " << hostArrDst[i]
                 << " Expected value : 5 \n"
@@ -194,27 +194,27 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_NegetiveCase) {
  *  - HIP_VERSION >= 6.3
  */
 HIP_TEST_CASE(Unit_hipStreamLegacy_WithNonBlockingStream) {
-  int* hostArrSrc = new int[N];
+  int* hostArrSrc = new int[getN()];
   REQUIRE(hostArrSrc != nullptr);
-  fillHostArray(hostArrSrc, N, 10);
+  fillHostArray(hostArrSrc, getN(), 10);
 
   int* devArr = nullptr;
-  HIP_CHECK(hipMalloc(&devArr, NBYTES));
+  HIP_CHECK(hipMalloc(&devArr, getNBytes()));
   REQUIRE(devArr != nullptr);
-  fillDeviceArray(devArr, N, 11);
+  fillDeviceArray(devArr, getN(), 11);
 
-  int* hostArrDst = new int[N];
+  int* hostArrDst = new int[getN()];
   REQUIRE(hostArrDst != nullptr);
-  fillHostArray(hostArrDst, N, 12);
+  fillHostArray(hostArrDst, getN(), 12);
 
   hipStream_t stream;
   HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
 
-  HIP_CHECK(hipMemcpyAsync(devArr, hostArrSrc, NBYTES, hipMemcpyHostToDevice, stream));
-  HIP_CHECK(hipMemcpyAsync(hostArrDst, devArr, NBYTES, hipMemcpyDeviceToHost, hipStreamLegacy));
+  HIP_CHECK(hipMemcpyAsync(devArr, hostArrSrc, getNBytes(), hipMemcpyHostToDevice, stream));
+  HIP_CHECK(hipMemcpyAsync(hostArrDst, devArr, getNBytes(), hipMemcpyDeviceToHost, hipStreamLegacy));
   HIP_CHECK(hipStreamSynchronize(hipStreamLegacy));
 
-  for (int i = 0; i < N; i++) {
+  for (int i = 0; i < getN(); i++) {
     INFO("At index : " << i << " Got value : " << hostArrDst[i] << " Expected value : 10 or 11 \n");
     REQUIRE(((hostArrDst[i] == 10) || (hostArrDst[i] == 11)));
   }
@@ -241,23 +241,23 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_WithNonBlockingStream) {
  *  - HIP_VERSION >= 6.3
  */
 HIP_TEST_CASE(Unit_hipStreamLegacy_WithStreamPerThread) {
-  int* hostArrSrc = new int[N];
+  int* hostArrSrc = new int[getN()];
   REQUIRE(hostArrSrc != nullptr);
-  fillHostArray(hostArrSrc, N, 15);
+  fillHostArray(hostArrSrc, getN(), 15);
 
   int* devArr = nullptr;
-  HIP_CHECK(hipMalloc(&devArr, NBYTES));
+  HIP_CHECK(hipMalloc(&devArr, getNBytes()));
   REQUIRE(devArr != nullptr);
-  fillDeviceArray(devArr, N, 16);
+  fillDeviceArray(devArr, getN(), 16);
 
-  int* hostArrDst = new int[N];
+  int* hostArrDst = new int[getN()];
   REQUIRE(hostArrDst != nullptr);
 
-  HIP_CHECK(hipMemcpyAsync(devArr, hostArrSrc, NBYTES, hipMemcpyHostToDevice, hipStreamPerThread));
-  HIP_CHECK(hipMemcpyAsync(hostArrDst, devArr, NBYTES, hipMemcpyDeviceToHost, hipStreamLegacy));
+  HIP_CHECK(hipMemcpyAsync(devArr, hostArrSrc, getNBytes(), hipMemcpyHostToDevice, hipStreamPerThread));
+  HIP_CHECK(hipMemcpyAsync(hostArrDst, devArr, getNBytes(), hipMemcpyDeviceToHost, hipStreamLegacy));
   HIP_CHECK(hipStreamSynchronize(hipStreamLegacy));
 
-  for (int i = 0; i < N; i++) {
+  for (int i = 0; i < getN(); i++) {
     INFO("At index : " << i << " Got value : " << hostArrDst[i] << " Expected value : 15 \n");
     REQUIRE(hostArrDst[i] == 15);
   }
@@ -293,24 +293,24 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_MultiDevice) {
   for (int deviceId = 0; deviceId < deviceCount; deviceId++) {
     HIP_CHECK(hipSetDevice(deviceId));
 
-    int* hostArrSrc = new int[N];
+    int* hostArrSrc = new int[getN()];
     REQUIRE(hostArrSrc != nullptr);
-    fillHostArray(hostArrSrc, N, 20);
+    fillHostArray(hostArrSrc, getN(), 20);
 
     int* devArr = nullptr;
-    HIP_CHECK(hipMalloc(&devArr, NBYTES));
+    HIP_CHECK(hipMalloc(&devArr, getNBytes()));
     REQUIRE(devArr != nullptr);
-    fillDeviceArray(devArr, N, 21);
+    fillDeviceArray(devArr, getN(), 21);
 
-    int* hostArrDst = new int[N];
+    int* hostArrDst = new int[getN()];
     REQUIRE(hostArrDst != nullptr);
-    fillHostArray(hostArrDst, N, 22);
+    fillHostArray(hostArrDst, getN(), 22);
 
-    HIP_CHECK(hipMemcpyAsync(devArr, hostArrSrc, NBYTES, hipMemcpyHostToDevice, hipStreamLegacy));
-    HIP_CHECK(hipMemcpyAsync(hostArrDst, devArr, NBYTES, hipMemcpyDeviceToHost, hipStreamLegacy));
+    HIP_CHECK(hipMemcpyAsync(devArr, hostArrSrc, getNBytes(), hipMemcpyHostToDevice, hipStreamLegacy));
+    HIP_CHECK(hipMemcpyAsync(hostArrDst, devArr, getNBytes(), hipMemcpyDeviceToHost, hipStreamLegacy));
     HIP_CHECK(hipStreamSynchronize(hipStreamLegacy));
 
-    for (int i = 0; i < N; i++) {
+    for (int i = 0; i < getN(); i++) {
       INFO("At index : " << i << " Got value : " << hostArrDst[i]
                          << " Expected value : 20 "
                             " For deviceId : "
@@ -338,40 +338,40 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_MultiDevice) {
  *  - HIP_VERSION >= 6.3
  */
 HIP_TEST_CASE(Unit_hipStreamLegacy_H2H_H2D_D2D_D2H_Default) {
-  int* hostArr1 = new int[N];
+  int* hostArr1 = new int[getN()];
   REQUIRE(hostArr1 != nullptr);
-  fillHostArray(hostArr1, N, 30);
+  fillHostArray(hostArr1, getN(), 30);
 
-  int* hostArr2 = new int[N];
+  int* hostArr2 = new int[getN()];
   REQUIRE(hostArr2 != nullptr);
-  fillHostArray(hostArr2, N, 31);
+  fillHostArray(hostArr2, getN(), 31);
 
   int* devArr1 = nullptr;
-  HIP_CHECK(hipMalloc(&devArr1, NBYTES));
+  HIP_CHECK(hipMalloc(&devArr1, getNBytes()));
   REQUIRE(devArr1 != nullptr);
-  fillDeviceArray(devArr1, N, 32);
+  fillDeviceArray(devArr1, getN(), 32);
 
   int* devArr2 = nullptr;
-  HIP_CHECK(hipMalloc(&devArr2, NBYTES));
+  HIP_CHECK(hipMalloc(&devArr2, getNBytes()));
   REQUIRE(devArr2 != nullptr);
-  fillDeviceArray(devArr2, N, 33);
+  fillDeviceArray(devArr2, getN(), 33);
 
-  int* hostArr3 = new int[N];
+  int* hostArr3 = new int[getN()];
   REQUIRE(hostArr3 != nullptr);
-  fillHostArray(hostArr3, N, 34);
+  fillHostArray(hostArr3, getN(), 34);
 
-  int* hostArr4 = new int[N];
+  int* hostArr4 = new int[getN()];
   REQUIRE(hostArr4 != nullptr);
-  fillHostArray(hostArr4, N, 35);
+  fillHostArray(hostArr4, getN(), 35);
 
-  HIP_CHECK(hipMemcpyAsync(hostArr2, hostArr1, NBYTES, hipMemcpyHostToHost, hipStreamLegacy));
-  HIP_CHECK(hipMemcpyAsync(devArr1, hostArr2, NBYTES, hipMemcpyHostToDevice, hipStreamLegacy));
-  HIP_CHECK(hipMemcpyAsync(devArr2, devArr1, NBYTES, hipMemcpyDeviceToDevice, hipStreamLegacy));
-  HIP_CHECK(hipMemcpyAsync(hostArr3, devArr2, NBYTES, hipMemcpyDeviceToHost, hipStreamLegacy));
-  HIP_CHECK(hipMemcpyAsync(hostArr4, hostArr3, NBYTES, hipMemcpyDefault, hipStreamLegacy));
+  HIP_CHECK(hipMemcpyAsync(hostArr2, hostArr1, getNBytes(), hipMemcpyHostToHost, hipStreamLegacy));
+  HIP_CHECK(hipMemcpyAsync(devArr1, hostArr2, getNBytes(), hipMemcpyHostToDevice, hipStreamLegacy));
+  HIP_CHECK(hipMemcpyAsync(devArr2, devArr1, getNBytes(), hipMemcpyDeviceToDevice, hipStreamLegacy));
+  HIP_CHECK(hipMemcpyAsync(hostArr3, devArr2, getNBytes(), hipMemcpyDeviceToHost, hipStreamLegacy));
+  HIP_CHECK(hipMemcpyAsync(hostArr4, hostArr3, getNBytes(), hipMemcpyDefault, hipStreamLegacy));
   HIP_CHECK(hipStreamSynchronize(hipStreamLegacy));
 
-  for (int i = 0; i < N; i++) {
+  for (int i = 0; i < getN(); i++) {
     INFO("At index : " << i << " Got value : " << hostArr4[i] << " Expected value : 30 \n");
     REQUIRE(hostArr4[i] == 30);
   }
@@ -419,64 +419,64 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_MultiDeviceMultiOperation) {
   // Set arrays in device 0
   HIP_CHECK(hipSetDevice(currentDevice));
 
-  int* h1Dev0 = new int[N];
+  int* h1Dev0 = new int[getN()];
   REQUIRE(h1Dev0 != nullptr);
-  fillHostArray(h1Dev0, N, 40);
+  fillHostArray(h1Dev0, getN(), 40);
 
   int* d1Dev0 = nullptr;
-  HIP_CHECK(hipMalloc(&d1Dev0, NBYTES));
+  HIP_CHECK(hipMalloc(&d1Dev0, getNBytes()));
   REQUIRE(d1Dev0 != nullptr);
-  fillDeviceArray(d1Dev0, N, 41);
+  fillDeviceArray(d1Dev0, getN(), 41);
 
   // Set arrays in device 1
   HIP_CHECK(hipSetDevice(peerDevice));
 
   int* d1Dev1 = nullptr;
-  HIP_CHECK(hipMalloc(&d1Dev1, NBYTES));
+  HIP_CHECK(hipMalloc(&d1Dev1, getNBytes()));
   REQUIRE(d1Dev1 != nullptr);
-  fillDeviceArray(d1Dev1, N, 42);
+  fillDeviceArray(d1Dev1, getN(), 42);
 
   int* d2Dev1 = nullptr;
-  HIP_CHECK(hipMalloc(&d2Dev1, NBYTES));
+  HIP_CHECK(hipMalloc(&d2Dev1, getNBytes()));
   REQUIRE(d2Dev1 != nullptr);
-  fillDeviceArray(d2Dev1, N, 43);
+  fillDeviceArray(d2Dev1, getN(), 43);
 
   // Set destination arrays in device 0
   HIP_CHECK(hipSetDevice(currentDevice));
 
   int* d2Dev0 = nullptr;
-  HIP_CHECK(hipMalloc(&d2Dev0, NBYTES));
+  HIP_CHECK(hipMalloc(&d2Dev0, getNBytes()));
   REQUIRE(d2Dev0 != nullptr);
-  fillDeviceArray(d2Dev0, N, 44);
+  fillDeviceArray(d2Dev0, getN(), 44);
 
-  int* h2Dev0 = new int[N];
+  int* h2Dev0 = new int[getN()];
   REQUIRE(h2Dev0 != nullptr);
-  fillHostArray(h2Dev0, N, 45);
+  fillHostArray(h2Dev0, getN(), 45);
 
   // Do operations in current device
   HIP_CHECK(hipSetDevice(currentDevice));
-  HIP_CHECK(hipMemcpyAsync(d1Dev0, h1Dev0, NBYTES, hipMemcpyHostToHost, hipStreamLegacy));
+  HIP_CHECK(hipMemcpyAsync(d1Dev0, h1Dev0, getNBytes(), hipMemcpyHostToHost, hipStreamLegacy));
 
   // Copy from current device to peer device
   HIP_CHECK(hipMemcpyPeerAsync(d1Dev1, peerDevice,     // des
                                d1Dev0, currentDevice,  // src
-                               NBYTES, hipStreamLegacy));
+                               getNBytes(), hipStreamLegacy));
 
   // Do operations in peer device
   HIP_CHECK(hipSetDevice(peerDevice));
-  HIP_CHECK(hipMemcpyAsync(d2Dev1, d1Dev1, NBYTES, hipMemcpyDeviceToDevice, hipStreamLegacy));
+  HIP_CHECK(hipMemcpyAsync(d2Dev1, d1Dev1, getNBytes(), hipMemcpyDeviceToDevice, hipStreamLegacy));
 
   // Copy from peer device to current device
   HIP_CHECK(hipMemcpyPeerAsync(d2Dev0, currentDevice,  // des
                                d2Dev1, peerDevice,     // src
-                               NBYTES, hipStreamLegacy));
+                               getNBytes(), hipStreamLegacy));
 
   // Finally copy daat to hostArr4
   HIP_CHECK(hipSetDevice(currentDevice));
-  HIP_CHECK(hipMemcpyAsync(h2Dev0, d2Dev0, NBYTES, hipMemcpyDeviceToHost, hipStreamLegacy));
+  HIP_CHECK(hipMemcpyAsync(h2Dev0, d2Dev0, getNBytes(), hipMemcpyDeviceToHost, hipStreamLegacy));
   HIP_CHECK(hipStreamSynchronize(hipStreamLegacy));
 
-  for (int i = 0; i < N; i++) {
+  for (int i = 0; i < getN(); i++) {
     INFO("At index : " << i << " Got value : " << h2Dev0[i]
                        << " Expected value : 40/41/42/43/44 \n");
     REQUIRE(h2Dev0[i] != 45);
@@ -499,14 +499,14 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_MultiDeviceMultiOperation) {
  * Local helper function to copy data from host to device
  */
 static void copyFromHostToDevice(int* hostArr, int* devArr) {
-  HIP_CHECK(hipMemcpyAsync(devArr, hostArr, NBYTES, hipMemcpyHostToDevice, hipStreamLegacy));
+  HIP_CHECK(hipMemcpyAsync(devArr, hostArr, getNBytes(), hipMemcpyHostToDevice, hipStreamLegacy));
 }
 
 /*
  * Local helper function to copy data from device to host
  */
 static void copyFromDeviceToHost(int* devArr, int* hostArr) {
-  HIP_CHECK(hipMemcpyAsync(hostArr, devArr, NBYTES, hipMemcpyDeviceToHost, hipStreamLegacy));
+  HIP_CHECK(hipMemcpyAsync(hostArr, devArr, getNBytes(), hipMemcpyDeviceToHost, hipStreamLegacy));
 }
 
 /**
@@ -535,18 +535,18 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_TwoThreadsEachOneDiffOperation) {
     return;
   }
 
-  int* hostArrSrc = new int[N];
+  int* hostArrSrc = new int[getN()];
   REQUIRE(hostArrSrc != nullptr);
-  fillHostArray(hostArrSrc, N, 50);
+  fillHostArray(hostArrSrc, getN(), 50);
 
   int* devArr = nullptr;
-  HIP_CHECK(hipMalloc(&devArr, NBYTES));
+  HIP_CHECK(hipMalloc(&devArr, getNBytes()));
   REQUIRE(devArr != nullptr);
-  fillDeviceArray(devArr, N, 51);
+  fillDeviceArray(devArr, getN(), 51);
 
-  int* hostArrDst = new int[N];
+  int* hostArrDst = new int[getN()];
   REQUIRE(hostArrDst != nullptr);
-  fillHostArray(hostArrDst, N, 52);
+  fillHostArray(hostArrDst, getN(), 52);
 
   std::thread H2D_Thread(copyFromHostToDevice, hostArrSrc, devArr);
   H2D_Thread.join();
@@ -555,7 +555,7 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_TwoThreadsEachOneDiffOperation) {
   D2H_Thread.join();
   HIP_CHECK(hipStreamSynchronize(hipStreamLegacy));
 
-  for (int i = 0; i < N; i++) {
+  for (int i = 0; i < getN(); i++) {
     INFO("At index : " << i << " Got value : " << hostArrDst[i] << " Expected value : 50 \n");
     REQUIRE(hostArrDst[i] == 50);
   }
@@ -591,34 +591,34 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_TwoDevicesEachOneDiffOperation) {
   HIP_CHECK(hipSetDevice(0));
 
   int* devArrDev0 = nullptr;
-  HIP_CHECK(hipMalloc(&devArrDev0, NBYTES));
+  HIP_CHECK(hipMalloc(&devArrDev0, getNBytes()));
   REQUIRE(devArrDev0 != nullptr);
-  fillDeviceArray(devArrDev0, N, 500);
+  fillDeviceArray(devArrDev0, getN(), 500);
 
   // Set arrays in device 1
   HIP_CHECK(hipSetDevice(1));
 
   int* devArrDev1 = nullptr;
-  HIP_CHECK(hipMalloc(&devArrDev1, NBYTES));
+  HIP_CHECK(hipMalloc(&devArrDev1, getNBytes()));
   REQUIRE(devArrDev1 != nullptr);
-  fillDeviceArray(devArrDev1, N, 501);
+  fillDeviceArray(devArrDev1, getN(), 501);
 
-  int* hostArrDst = new int[N];
+  int* hostArrDst = new int[getN()];
   REQUIRE(hostArrDst != nullptr);
-  fillHostArray(hostArrDst, N, 502);
+  fillHostArray(hostArrDst, getN(), 502);
 
   HIP_CHECK(hipSetDevice(0));
 
   HIP_CHECK(hipMemcpyPeerAsync(devArrDev1, 1,  // des
                                devArrDev0, 0,  // src
-                               NBYTES, hipStreamLegacy));
+                               getNBytes(), hipStreamLegacy));
 
   HIP_CHECK(hipSetDevice(1));
 
-  HIP_CHECK(hipMemcpyAsync(hostArrDst, devArrDev1, NBYTES, hipMemcpyDeviceToHost, hipStreamLegacy));
+  HIP_CHECK(hipMemcpyAsync(hostArrDst, devArrDev1, getNBytes(), hipMemcpyDeviceToHost, hipStreamLegacy));
   HIP_CHECK(hipStreamSynchronize(hipStreamLegacy));
 
-  for (int i = 0; i < N; i++) {
+  for (int i = 0; i < getN(); i++) {
     INFO("At index : " << i << " Got value : " << hostArrDst[i]
                        << " Expected value : 500 or 501 \n");
     REQUIRE(((hostArrDst[i] == 500) || (hostArrDst[i] == 501)));
@@ -638,7 +638,7 @@ static void operationsInDev0(int* devArrDev0, int* devArrDev1) {
   HIP_CHECK(hipSetDevice(0));
   HIP_CHECK(hipMemcpyPeerAsync(devArrDev1, 1,  // des
                                devArrDev0, 0,  // src
-                               NBYTES, hipStreamLegacy));
+                               getNBytes(), hipStreamLegacy));
 }
 
 /*
@@ -646,7 +646,7 @@ static void operationsInDev0(int* devArrDev0, int* devArrDev1) {
  */
 static void operationsInDev1(int* devArrDev1, int* hostArrDst) {
   HIP_CHECK(hipSetDevice(1));
-  HIP_CHECK(hipMemcpyAsync(hostArrDst, devArrDev1, NBYTES, hipMemcpyDeviceToHost, hipStreamLegacy));
+  HIP_CHECK(hipMemcpyAsync(hostArrDst, devArrDev1, getNBytes(), hipMemcpyDeviceToHost, hipStreamLegacy));
 }
 
 /**
@@ -676,21 +676,21 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_TwoThreadsInTwoDevicesEachOneDiffOperation) {
   HIP_CHECK(hipSetDevice(0));
 
   int* devArrDev0 = nullptr;
-  HIP_CHECK(hipMalloc(&devArrDev0, NBYTES));
+  HIP_CHECK(hipMalloc(&devArrDev0, getNBytes()));
   REQUIRE(devArrDev0 != nullptr);
-  fillDeviceArray(devArrDev0, N, 999);
+  fillDeviceArray(devArrDev0, getN(), 999);
 
   // Set arrays in device 1
   HIP_CHECK(hipSetDevice(1));
 
   int* devArrDev1 = nullptr;
-  HIP_CHECK(hipMalloc(&devArrDev1, NBYTES));
+  HIP_CHECK(hipMalloc(&devArrDev1, getNBytes()));
   REQUIRE(devArrDev1 != nullptr);
-  fillDeviceArray(devArrDev1, N, 888);
+  fillDeviceArray(devArrDev1, getN(), 888);
 
-  int* hostArrDst = new int[N];
+  int* hostArrDst = new int[getN()];
   REQUIRE(hostArrDst != nullptr);
-  fillHostArray(hostArrDst, N, 777);
+  fillHostArray(hostArrDst, getN(), 777);
 
   HIP_CHECK(hipSetDevice(0));
 
@@ -700,7 +700,7 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_TwoThreadsInTwoDevicesEachOneDiffOperation) {
   dev1Thread.join();
   HIP_CHECK(hipStreamSynchronize(hipStreamLegacy));
 
-  for (int i = 0; i < N; i++) {
+  for (int i = 0; i < getN(); i++) {
     INFO("At index : " << i << " Got value : " << hostArrDst[i]
                        << " Expected value : 999 or 888 \n");
     REQUIRE(((hostArrDst[i] == 999) || (hostArrDst[i] == 888)));
@@ -744,25 +744,25 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_InChildProcess) {
  *  - HIP_VERSION >= 6.3
  */
 HIP_TEST_CASE(Unit_hipStreamLegacy_WithKernel) {
-  int* hostArrSrc = new int[N];
+  int* hostArrSrc = new int[getN()];
   REQUIRE(hostArrSrc != nullptr);
-  fillHostArray(hostArrSrc, N, 1);
+  fillHostArray(hostArrSrc, getN(), 1);
 
   int* devArr = nullptr;
-  HIP_CHECK(hipMalloc(&devArr, NBYTES));
+  HIP_CHECK(hipMalloc(&devArr, getNBytes()));
   REQUIRE(devArr != nullptr);
 
-  int* hostArrDst = new int[N];
+  int* hostArrDst = new int[getN()];
   REQUIRE(hostArrDst != nullptr);
-  fillHostArray(hostArrDst, N, 6);
+  fillHostArray(hostArrDst, getN(), 6);
 
-  HIP_CHECK(hipMemcpyAsync(devArr, hostArrSrc, NBYTES, hipMemcpyHostToDevice, hipStreamLegacy));
-  addOneKernel<<<1, 1, 0, hipStreamLegacy>>>(devArr, N);
-  addOneKernel<<<1, 1, 0, hipStreamLegacy>>>(devArr, N);
-  HIP_CHECK(hipMemcpyAsync(hostArrDst, devArr, NBYTES, hipMemcpyDeviceToHost, hipStreamLegacy));
+  HIP_CHECK(hipMemcpyAsync(devArr, hostArrSrc, getNBytes(), hipMemcpyHostToDevice, hipStreamLegacy));
+  addOneKernel<<<1, 1, 0, hipStreamLegacy>>>(devArr, getN());
+  addOneKernel<<<1, 1, 0, hipStreamLegacy>>>(devArr, getN());
+  HIP_CHECK(hipMemcpyAsync(hostArrDst, devArr, getNBytes(), hipMemcpyDeviceToHost, hipStreamLegacy));
   HIP_CHECK(hipStreamSynchronize(hipStreamLegacy));
 
-  for (int i = 0; i < N; i++) {
+  for (int i = 0; i < getN(); i++) {
     INFO("At index : " << i << " Got value : " << hostArrDst[i] << " Expected value : 3 \n");
     REQUIRE(hostArrDst[i] == 3);
   }
@@ -786,25 +786,25 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_WithKernel) {
  */
 
 HIP_TEST_CASE(Unit_hipStreamLegacy_hipStreamSynchronize) {
-  int* hostArrSrc = new int[N];
+  int* hostArrSrc = new int[getN()];
   REQUIRE(hostArrSrc != nullptr);
-  fillHostArray(hostArrSrc, N, 1);
+  fillHostArray(hostArrSrc, getN(), 1);
 
   int* devArr = nullptr;
-  HIP_CHECK(hipMalloc(&devArr, NBYTES));
+  HIP_CHECK(hipMalloc(&devArr, getNBytes()));
   REQUIRE(devArr != nullptr);
 
-  int* hostArrDst = new int[N];
+  int* hostArrDst = new int[getN()];
   REQUIRE(hostArrDst != nullptr);
-  fillHostArray(hostArrDst, N, 3);
+  fillHostArray(hostArrDst, getN(), 3);
 
-  HIP_CHECK(hipMemcpyAsync(devArr, hostArrSrc, NBYTES, hipMemcpyHostToDevice, hipStreamLegacy));
+  HIP_CHECK(hipMemcpyAsync(devArr, hostArrSrc, getNBytes(), hipMemcpyHostToDevice, hipStreamLegacy));
   HIP_CHECK(hipStreamSynchronize(hipStreamLegacy));
 
-  HIP_CHECK(hipMemcpyAsync(hostArrDst, devArr, NBYTES, hipMemcpyDeviceToHost, hipStreamLegacy));
+  HIP_CHECK(hipMemcpyAsync(hostArrDst, devArr, getNBytes(), hipMemcpyDeviceToHost, hipStreamLegacy));
   HIP_CHECK(hipStreamSynchronize(hipStreamLegacy));
 
-  for (int i = 0; i < N; i++) {
+  for (int i = 0; i < getN(); i++) {
     INFO("At index : " << i << " Got value : " << hostArrDst[i] << " Expected value : 1 \n");
     REQUIRE(hostArrDst[i] == 1);
   }

--- a/projects/hip-tests/catch/unit/stream/hipStreamLegacy_Ext.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamLegacy_Ext.cc
@@ -9,8 +9,8 @@
 #include <utils.hh>
 #include <hip_test_process.hh>
 
-static constexpr int N = 2 * 1024 * 1024;
-static constexpr size_t NBYTES = N * sizeof(int);
+static const int N = isQuickLevel() ? (64 * 1024 / sizeof(int)) : 2 * 1024 * 1024;
+static const size_t NBYTES = N * sizeof(int);
 
 /**
  * Local Function to fill the array with given value

--- a/projects/hip-tests/catch/unit/stream/hipStreamQuery.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamQuery.cc
@@ -60,7 +60,7 @@ HIP_TEST_CASE(Unit_hipStreamQuery_SubmitWorkOnStreamAndQueryNullStream) {
     HIP_CHECK(hipStreamCreate(&stream));
 
     HIP_CHECK(hipStreamQuery(hip::nullStream));
-    LaunchDelayKernel(std::chrono::milliseconds(500), stream);
+    LaunchDelayKernel(std::chrono::milliseconds(isQuickLevel() ? 100 : 500), stream);
     HIP_CHECK_ERROR(hipStreamQuery(hip::nullStream), hipErrorNotReady);
     HIP_CHECK(hipDeviceSynchronize());
 
@@ -75,7 +75,7 @@ HIP_TEST_CASE(Unit_hipStreamQuery_SubmitWorkOnStreamAndQueryNullStream) {
  */
 HIP_TEST_CASE(Unit_hipStreamQuery_NullStreamQuery) {
   HIP_CHECK(hipStreamQuery(hip::nullStream));
-  LaunchDelayKernel(std::chrono::milliseconds(500), hip::nullStream);
+  LaunchDelayKernel(std::chrono::milliseconds(isQuickLevel() ? 100 : 500), hip::nullStream);
   HIP_CHECK_ERROR(hipStreamQuery(hip::nullStream), hipErrorNotReady);
 
   HIP_CHECK(hipStreamSynchronize(hip::nullStream));
@@ -89,7 +89,7 @@ HIP_TEST_CASE(Unit_hipStreamQuery_WithPendingWork) {
   hipStream_t waitingStream{nullptr};
   HIP_CHECK(hipStreamCreate(&waitingStream));
 
-  LaunchDelayKernel(std::chrono::milliseconds(500), waitingStream);
+  LaunchDelayKernel(std::chrono::milliseconds(isQuickLevel() ? 100 : 500), waitingStream);
   HIP_CHECK_ERROR(hipStreamQuery(waitingStream), hipErrorNotReady);
   HIP_CHECK(hipStreamSynchronize(waitingStream));
   HIP_CHECK(hipStreamQuery(waitingStream));

--- a/projects/hip-tests/catch/unit/stream/hipStreamSynchronize.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamSynchronize.cc
@@ -36,7 +36,7 @@ HIP_TEST_CASE(Unit_hipStreamSynchronize_FinishWork) {
     HIP_CHECK(hipStreamCreate(&stream));
   }
 
-  LaunchDelayKernel(std::chrono::milliseconds(500), stream);
+  LaunchDelayKernel(std::chrono::milliseconds(isQuickLevel() ? 50 : 500), stream);
   HIP_CHECK(hipStreamSynchronize(stream));
   HIP_CHECK(hipStreamQuery(stream));
 
@@ -60,7 +60,7 @@ HIP_TEST_CASE(Unit_hipStreamSynchronize_NullStreamSynchronization) {
   }
 
   for (int i = 0; i < totalStreams; ++i) {
-    LaunchDelayKernel(std::chrono::milliseconds(1000), streams[i]);
+    LaunchDelayKernel(std::chrono::milliseconds(isQuickLevel() ? 100 : 1000), streams[i]);
   }
 
   HIP_CHECK_ERROR(hipStreamQuery(hip::nullStream), hipErrorNotReady);
@@ -98,7 +98,7 @@ HIP_TEST_CASE(Unit_hipStreamSynchronize_SynchronizeStreamAndQueryNullStream) {
   HIP_CHECK(hipStreamCreate(&stream2));
 
   LaunchDelayKernel(std::chrono::milliseconds(500), stream1);
-  LaunchDelayKernel(std::chrono::milliseconds(2000), stream2);
+  LaunchDelayKernel(std::chrono::milliseconds(isQuickLevel() ? 100 : 2000), stream2);
 
   SECTION("Do not use NullStream") {}
   SECTION("Submit Kernel to NullStream") {

--- a/projects/hip-tests/catch/unit/stream/hipStreamSynchronize_spt.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamSynchronize_spt.cc
@@ -66,7 +66,7 @@ HIP_TEST_CASE(Unit_hipStreamSynchronize_spt_FinishWork) {
     HIP_CHECK(hipStreamCreate(&stream));
   }
 
-  LaunchDelayKernel(std::chrono::milliseconds(500), stream);
+  LaunchDelayKernel(std::chrono::milliseconds(isQuickLevel() ? 100 : 500), stream);
   HIP_CHECK(hipStreamSynchronize_spt(stream));
   HIP_CHECK(hipStreamQuery(stream));
 
@@ -96,8 +96,8 @@ HIP_TEST_CASE(Unit_hipStreamSynchronize_spt_SynchronizeStreamAndQueryNullStream)
   HIP_CHECK(hipStreamCreate(&stream1));
   HIP_CHECK(hipStreamCreate(&stream2));
 
-  LaunchDelayKernel(std::chrono::milliseconds(500), stream1);
-  LaunchDelayKernel(std::chrono::milliseconds(2000), stream2);
+  LaunchDelayKernel(std::chrono::milliseconds(isQuickLevel() ? 100 : 500), stream1);
+  LaunchDelayKernel(std::chrono::milliseconds(isQuickLevel() ? 400 : 2000), stream2);
   hip::stream::empty_kernel<<<1, 1, 0, hip::nullStream>>>();
 
   HIP_CHECK_ERROR(hipStreamQuery(stream1), hipErrorNotReady);

--- a/projects/hip-tests/catch/unit/stream/hipStreamWaitEvent.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamWaitEvent.cc
@@ -63,7 +63,7 @@ HIP_TEST_CASE(Unit_hipStreamWaitEvent_Default) {
   REQUIRE(stream != nullptr);
   REQUIRE(waitEvent != nullptr);
 
-  LaunchDelayKernel(std::chrono::milliseconds(2000), stream);
+  LaunchDelayKernel(std::chrono::milliseconds(isQuickLevel() ? 100 : 2000), stream);
 
   HIP_CHECK(hipEventRecord(waitEvent, stream));
 


### PR DESCRIPTION
## Motivation
 Reduce hip-tests runtime on emulators at level_0 by gating expensive test parameters with isQuickLevel()
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
  **Optimization strategies:**

  1. Reduce delay kernel durations — GPU busy-wait delays are the dominant emulator cost. Shortened at level_0 while keeping enough for stream/event query tests.
  2. Reduce kernel spin loop overhead — Added sleep instructions to tight atomic spin loops and limited spinning to a single thread per block where possible.
  3. Reduce buffer sizes and element counts — Smaller allocations while keeping enough data for meaningful coverage.
  4. Reduce iteration and loop counts — Stress/soak test loops shortened at level_0, keeping enough iterations for functional correctness.
  5. Reduce grid/block dimensions — Fewer threads where per-thread work (e.g., device malloc) is the bottleneck, rather than dropping test variants.
  6. Reduce GENERATE combinations — Use smaller parameter values instead of dropping entries, preserving combinatorial coverage.
  7. Reduce kernel computation — Shrink serial in-kernel work (e.g., loop counts) instead of removing kernel launches or test sections.

  **Guiding principle**: Prefer reducing how much work each test does over reducing what code paths it covers. All allocation types, stream types, and distinct intrinsics remain tested at every level.

**Testing:** To enable level_0 at runtime set this env variable: **HIP_TEST_LEVEL=level_0**

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
AIRUNTIME-2120
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
Verified that the runtime is reduced on emulator with level_0 for the optimized tests
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Verified that the runtime is reduced on emulator with level_0 for the optimized tests
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
