### PR TITLE
Users/marantic amd/argparser refactor

### DIFF
--- a/projects/rocprofiler-systems/source/bin/common/json_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/json_config.cpp
@@ -415,9 +415,9 @@ resolve_schema_config(const nlohmann::json& config)
         resolve_value(result, adv, "max_depth", env_vars::MAX_DEPTH);
         resolve_value(result, adv, "trace_delay_sec", env_vars::TRACE_DELAY);
         resolve_value(result, adv, "trace_duration_sec", env_vars::TRACE_DURATION);
-        resolve_value(result, adv, "verbose", env_vars::VERBOSE);
+        resolve_value(result, adv, "verbose", env_vars::VERBOSE_OUTPUT);
         if(adv.contains("debug"))
-            resolve_enabled(result, adv["debug"], "enabled", env_vars::DEBUG);
+            resolve_enabled(result, adv["debug"], "enabled", env_vars::DEBUG_OUTPUT);
         resolve_value(result, adv, "timemory_components", env_vars::TIMEMORY_COMPONENTS);
         resolve_value(result, adv, "network_interface", env_vars::NETWORK_INTERFACE);
         resolve_value(result, adv, "trace_periods", env_vars::TRACE_PERIODS);
@@ -911,8 +911,8 @@ env_vars_to_json_schema(const std::map<std::string, std::string>& env_map)
                      "random_seed");
 
     // --- Advanced ---
-    export_int_value(config, env_map, env_vars::VERBOSE, "advanced", "verbose");
-    export_enabled(config, env_map, env_vars::DEBUG, "advanced", "debug");
+    export_int_value(config, env_map, env_vars::VERBOSE_OUTPUT, "advanced", "verbose");
+    export_enabled(config, env_map, env_vars::DEBUG_OUTPUT, "advanced", "debug");
     export_int_value(config, env_map, env_vars::MAX_DEPTH, "advanced", "max_depth");
     export_double_value(config, env_map, env_vars::TRACE_DELAY, "advanced",
                         "trace_delay_sec");

--- a/projects/rocprofiler-systems/source/bin/common/tests/test_json_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/tests/test_json_config.cpp
@@ -407,5 +407,5 @@ TEST_F(json_config_test, validate_env_var_constants)
     EXPECT_EQ(rocprofsys::env_vars::USE_MPIP, "ROCPROFSYS_USE_MPIP");
     EXPECT_EQ(rocprofsys::env_vars::OUTPUT_PATH, "ROCPROFSYS_OUTPUT_PATH");
     EXPECT_EQ(rocprofsys::env_vars::USE_CAUSAL, "ROCPROFSYS_USE_CAUSAL");
-    EXPECT_EQ(rocprofsys::env_vars::VERBOSE, "ROCPROFSYS_VERBOSE");
+    EXPECT_EQ(rocprofsys::env_vars::VERBOSE_OUTPUT, "ROCPROFSYS_VERBOSE");
 }

--- a/projects/rocprofiler-systems/source/bin/common/tool_runner.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/tool_runner.cpp
@@ -156,6 +156,7 @@ make_sample_config()
   1. Profile:   rocprof-sys-sample --preset=balanced -- ./app
   2. Analyze:   cat rocprof-sys-output/wall_clock.txt
   3. Visualize: Open rocprof-sys-output/perfetto-trace.proto in ui.perfetto.dev)";
+    cfg.output_prefix  = "ROCPROFSYS: ";
     cfg.force_sampling = true;
     cfg.disable_cputime_on_realtime_only = true;
     cfg.deprecated_flags                 = {

--- a/projects/rocprofiler-systems/source/lib/common/env_vars.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/env_vars.hpp
@@ -52,7 +52,10 @@ constexpr std::string_view SAMPLING_AINICS   = "ROCPROFSYS_SAMPLING_AINICS";
 constexpr std::string_view SAMPLING_TIDS     = "ROCPROFSYS_SAMPLING_TIDS";
 constexpr std::string_view SAMPLING_INCLUDE_INLINES =
     "ROCPROFSYS_SAMPLING_INCLUDE_INLINES";
+constexpr std::string_view SAMPLING_OVERFLOW       = "ROCPROFSYS_SAMPLING_OVERFLOW";
 constexpr std::string_view SAMPLING_OVERFLOW_EVENT = "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT";
+constexpr std::string_view SAMPLING_OVERFLOW_FREQ  = "ROCPROFSYS_SAMPLING_OVERFLOW_FREQ";
+constexpr std::string_view SAMPLING_OVERFLOW_TIDS  = "ROCPROFSYS_SAMPLING_OVERFLOW_TIDS";
 
 // --- Sampling: cputime timer ---
 constexpr std::string_view SAMPLING_CPUTIME       = "ROCPROFSYS_SAMPLING_CPUTIME";
@@ -90,6 +93,10 @@ constexpr std::string_view USE_RCCLP   = "ROCPROFSYS_USE_RCCLP";
 constexpr std::string_view USE_AINIC   = "ROCPROFSYS_USE_AINIC";
 constexpr std::string_view USE_SHMEM   = "ROCPROFSYS_USE_SHMEM";
 constexpr std::string_view USE_UCX     = "ROCPROFSYS_USE_UCX";
+
+// --- MPI ---
+constexpr std::string_view RANK_FILTER_ID     = "ROCPROFSYS_RANK_FILTER_ID";
+constexpr std::string_view RANK_FILTER_OUTPUT = "ROCPROFSYS_RANK_FILTER_OUTPUT";
 
 // --- Output ---
 constexpr std::string_view OUTPUT_PATH   = "ROCPROFSYS_OUTPUT_PATH";
@@ -145,8 +152,8 @@ constexpr std::string_view TRACE_DELAY           = "ROCPROFSYS_TRACE_DELAY";
 constexpr std::string_view TRACE_DURATION        = "ROCPROFSYS_TRACE_DURATION";
 constexpr std::string_view TRACE_PERIODS         = "ROCPROFSYS_TRACE_PERIODS";
 constexpr std::string_view TRACE_PERIOD_CLOCK_ID = "ROCPROFSYS_TRACE_PERIOD_CLOCK_ID";
-constexpr std::string_view VERBOSE               = "ROCPROFSYS_VERBOSE";
-constexpr std::string_view DEBUG                 = "ROCPROFSYS_DEBUG";
+constexpr std::string_view VERBOSE_OUTPUT        = "ROCPROFSYS_VERBOSE";
+constexpr std::string_view DEBUG_OUTPUT          = "ROCPROFSYS_DEBUG";
 // well above the highest verbose threshold (3) so debug mode enables all verbose output
 constexpr int              DEBUG_VERBOSE_BOOST = 8;
 constexpr std::string_view TIMEMORY_COMPONENTS = "ROCPROFSYS_TIMEMORY_COMPONENTS";

--- a/projects/rocprofiler-systems/source/lib/core/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/CMakeLists.txt
@@ -62,6 +62,7 @@ add_library(
 )
 
 target_sources(rocprofiler-systems-core-library PRIVATE ${core_sources} ${core_headers})
+add_subdirectory(argparse)
 add_subdirectory(binary)
 add_subdirectory(components)
 add_subdirectory(containers)

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -206,6 +206,11 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
         _data.env.set(env::USE_AMD_SMI, false);
     }
 
+    // TODO(seam): the BACKEND `-I/-E` flags have runtime-computed choices
+    // (gpu::device_count + MPI/OMPT preprocessor flags decide which backend
+    // tokens are valid). Static flag_descriptor cannot express this without
+    // adding std::function-typed choices fields. Migrate together with the
+    // dynamic-choices follow-up.
     _parser.start_group("BACKEND OPTIONS",
                         "These options control region information captured "
                         "w/o sampling or instrumentation");
@@ -270,31 +275,14 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
     add_group_arguments(_parser, "backend", _data);
     add_group_arguments(_parser, "parallelism", _data, true);
 
-    if(_data.reg.environ_filter("launcher", _data))
-    {
-        _parser
-            .add_argument(
-                { "-l", "--launcher" },
-                "When running MPI jobs, typically the associated '--' for this "
-                "executable should be right before the target executable, e.g. `mpirun "
-                "-n 2 <THIS_EXE> -- <TARGET_EXE> <TARGET_EXE_ARGS...>`. This options "
-                "enables prefixing the entire command (i.e. before `mpirun`, `srun`, "
-                "etc.). Pass the name of the target executable (or a regex for matching "
-                "to the name of the target) as the argument to this option and this "
-                "executable will insert itself a second time in the appropriate "
-                "location, e.g. `<THIS_EXE> --launcher sleep -- mpirun -n 2 sleep 10` is "
-                "equivalent to `mpirun -n 2 <THIS_EXE> -- sleep 10`")
-            .count(1)
-            .dtype("target-exe")
-            .action([&](parser_t& p) {
-                _data.out.launcher = p.get<std::string>("launcher");
-            });
-
-        _data.reg.processed_environs.emplace("launcher");
-    }
+    register_group(_parser, _data, launcher_group());
 
     register_group(_parser, _data, tracing_group());
 
+    // TODO(seam): --trace-clock-id choices are runtime-computed from CLOCK_*
+    // macros via get_clock_id_choices(); flag_descriptor's static choices
+    // field cannot express this. Migrate alongside the dynamic-choices
+    // follow-up (same blocker as `-I/-E` above).
     if(_data.reg.environ_filter("trace_clock_id", _data))
     {
         auto _clock_id_choices = get_clock_id_choices();
@@ -349,6 +337,13 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
     return _data;
 }
 
+// TODO(seam): add_group_arguments / add_extended_arguments below iterate
+// rocprofsys::settings::instance() (returns tim::settings*) and bind directly
+// to tim::vsettings::add_argument(_parser). The descriptor seam does NOT
+// cover this path — these are the long tail of timemory-defined settings
+// auto-exposed as CLI flags. Lifting them needs a settings_to_descriptor()
+// adapter (and a vsettings wrapper) outside this branch's scope. Until then,
+// roughly ~20 flags still bind to the timemory engine through this path.
 parser_data&
 add_group_arguments(parser_t& _parser, const std::string& _group_name, parser_data& _data,
                     bool _add_group)

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #include "argparse.hpp"
+#include "argparse/core_flags.hpp"
+#include "argparse/interpreter.hpp"
 #include "common/environment.hpp"
 #include "common/path.hpp"
 #include "config.hpp"
@@ -77,6 +79,36 @@ update_env(parser_data& _data, std::string_view _env_var, Tp&& _env_val,
                                    _data.env.updated, _data.env.initial);
 }
 
+void
+apply_papi_choice_filter(const std::shared_ptr<tim::vsettings>& setting)
+{
+    if(setting->get_name() != "papi_events") return;
+    auto choices = setting->get_choices();
+    choices.erase(
+        std::remove_if(choices.begin(), choices.end(),
+                       [](const auto& choice) {
+                           return std::regex_search(
+                                      choice, std::regex{ "[A-Za-z0-9]:([A-Za-z_]+)" }) ||
+                                  std::regex_search(choice, std::regex{ "io:::" });
+                       }),
+        choices.end());
+    choices.emplace_back("... run `rocprof-sys-avail -H -c CPU` for full list ...");
+    setting->set_choices(choices);
+}
+
+void
+sort_settings_by_name_length(std::vector<std::shared_ptr<tim::vsettings>>& settings)
+{
+    std::sort(settings.begin(), settings.end(), [](const auto& lhs, const auto& rhs) {
+        const auto& lhs_name = lhs->get_name();
+        const auto& rhs_name = rhs->get_name();
+        if(lhs_name.length() > 4 && rhs_name.length() > 4 &&
+           lhs_name.substr(0, 4) == rhs_name.substr(0, 4))
+            return lhs_name < rhs_name;
+        return lhs_name.length() < rhs_name.length();
+    });
+}
+
 }  // namespace
 
 bool
@@ -150,389 +182,12 @@ add_torch_library_path(parser_data& _data, bool verbose)
 parser_data&
 add_core_arguments(parser_t& _parser, parser_data& _data)
 {
-    const auto* _cputime_desc =
-        R"(Sample based on a CPU-clock timer (default). Accepts zero or more arguments:
-    %{INDENT}%0. Enables sampling based on CPU-clock timer.
-    %{INDENT}%1. Interrupts per second. E.g., 100 == sample every 10 milliseconds of CPU-time.
-    %{INDENT}%2. Delay (in seconds of CPU-clock time). I.e., how long each thread should wait before taking first sample.
-    %{INDENT}%3+ Thread IDs to target for sampling, starting at 0 (the main thread).
-    %{INDENT}%   May be specified as index or range, e.g., '0 2-4' will be interpreted as:
-    %{INDENT}%      sample the main thread (0), do not sample the first child thread but sample the 2nd, 3rd, and 4th child threads)";
-
-    const auto* _realtime_desc =
-        R"(Sample based on a real-clock timer. Accepts zero or more arguments:
-    %{INDENT}%0. Enables sampling based on real-clock timer.
-    %{INDENT}%1. Interrupts per second. E.g., 100 == sample every 10 milliseconds of realtime.
-    %{INDENT}%2. Delay (in seconds of real-clock time). I.e., how long each thread should wait before taking first sample.
-    %{INDENT}%3+ Thread IDs to target for sampling, starting at 0 (the main thread).
-    %{INDENT}%   May be specified as index or range, e.g., '0 2-4' will be interpreted as:
-    %{INDENT}%      sample the main thread (0), do not sample the first child thread but sample the 2nd, 3rd, and 4th child threads
-    %{INDENT}%   When sampling with a real-clock timer, please note that enabling this will cause threads which are typically "idle"
-    %{INDENT}%   to consume more resources since, while idle, the real-clock time increases (and therefore triggers taking samples)
-    %{INDENT}%   whereas the CPU-clock time does not.)";
-
-    const auto* _overflow_desc =
-        R"(Sample based on an overflow event. Accepts zero or more arguments:
-    %{INDENT}%0. Enables sampling based on overflow.
-    %{INDENT}%1. Overflow metric, e.g. PERF_COUNT_HW_INSTRUCTIONS
-    %{INDENT}%2. Overflow value. E.g., if metric == PERF_COUNT_HW_INSTRUCTIONS, then 10000000 == sample every 10,000,000 instructions.
-    %{INDENT}%3+ Thread IDs to target for sampling, starting at 0 (the main thread).
-    %{INDENT}%   May be specified as index or range, e.g., '0 2-4' will be interpreted as:
-    %{INDENT}%      sample the main thread (0), do not sample the first child thread but sample the 2nd, 3rd, and 4th child threads)";
-
-    const auto* _hsa_interrupt_desc =
-        R"(Set the value of the HSA_ENABLE_INTERRUPT environment variable.
-%{INDENT}%  ROCm version 5.2 and older have a bug which will cause a deadlock if a sample is taken while waiting for the signal
-%{INDENT}%  that a kernel completed -- which happens when sampling with a real-clock timer. We require this option to be set to
-%{INDENT}%  when --realtime is specified to make users aware that, while this may fix the bug, it can have a negative impact on
-%{INDENT}%  performance.
-%{INDENT}%  Values:
-%{INDENT}%    0     avoid triggering the bug, potentially at the cost of reduced performance
-%{INDENT}%    1     do not modify how ROCm is notified about kernel completion)";
-
-    const auto* _trace_policy_desc =
-        R"(Policy for new data when the buffer size limit is reached:
-    %{INDENT}%- discard     : new data is ignored
-    %{INDENT}%- ring_buffer : new data overwrites oldest data)";
-
-    _parser.start_group("DEBUG OPTIONS", "");
-
-    if(_data.reg.environ_filter("log_level", _data))
-    {
-        _parser.add_argument({ "--log-level" }, "Log level")
-            .max_count(1)
-            .dtype("string")
-            .choices({ "trace", "debug", "info", "warn", "error", "critical", "off" })
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_LOG_LEVEL",
-                           p.get<std::string>("log-level"));
-            });
-
-        _data.reg.processed_environs.emplace("log_level");
-    }
-
-    if(_data.reg.environ_filter("monochrome", _data))
-    {
-        _parser.add_argument({ "--monochrome" }, "Disable colorized output")
-            .max_count(1)
-            .dtype("bool")
-            .action([&](parser_t& p) {
-                auto _monochrome     = p.get<bool>("monochrome");
-                _data.out.monochrome = _monochrome;
-                p.set_use_color(!_monochrome);
-                update_env(_data, "ROCPROFSYS_MONOCHROME", (_monochrome) ? "1" : "0");
-                update_env(_data, "MONOCHROME", (_monochrome) ? "1" : "0");
-            });
-
-        _data.reg.processed_environs.emplace("monochrome");
-    }
-
-    if(_data.reg.environ_filter("debug", _data))
-    {
-        _parser
-            .add_argument({ "--debug" },
-                          "[DEPRECATED Use --log-level=debug] Debug output")
-            .max_count(1)
-            .action(
-                [&](parser_t&) { update_env(_data, "ROCPROFSYS_LOG_LEVEL", "debug"); });
-
-        _data.reg.processed_environs.emplace("debug");
-    }
-
-    if(_data.reg.environ_filter("verbose", _data))
-    {
-        _parser
-            .add_argument({ "-v", "--verbose" },
-                          "[DEPRECATED Use --log-level=trace] Verbose output")
-            .count(1)
-            .dtype("integral")
-            .action([&](parser_t& p) {
-                auto _v           = p.get<int>("verbose");
-                _data.out.verbose = _v;
-                update_env(_data, "ROCPROFSYS_VERBOSE", _v);
-
-                constexpr std::array<const char*, 5> log_levels = { "off", "info",
-                                                                    "debug", "debug",
-                                                                    "trace" };
-
-                auto index =
-                    std::clamp(_v + 1, 0, static_cast<int>(log_levels.size() - 1));
-                update_env(_data, "ROCPROFSYS_LOG_LEVEL", log_levels[index]);
-            });
-
-        _data.reg.processed_environs.emplace("verbose");
-    }
+    register_group(_parser, _data, debug_group());
 
     add_group_arguments(_parser, "debugging", _data);
     add_group_arguments(_parser, "mode", _data, true);
 
-    _parser.start_group("GENERAL OPTIONS",
-                        "These are options which are ubiquitously applied");
-
-    if(_data.reg.environ_filter("config", _data))
-    {
-        _parser.add_argument({ "-c", "--config" }, "Configuration file")
-            .min_count(1)
-            .dtype("filepath")
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_CONFIG_FILE",
-                           fmt::format("{}", fmt::join(p.get<strvec_t>("config"), ":")));
-            });
-
-        _data.reg.processed_environs.emplace("config");
-        _data.reg.processed_environs.emplace("config_file");
-    }
-
-    if(_data.reg.environ_filter("output", _data))
-    {
-        _parser
-            .add_argument(
-                { "-o", "--output" },
-                "Output path. Accepts 1-2 parameters corresponding to the output "
-                "path and the output prefix")
-            .min_count(1)
-            .max_count(2)
-            .dtype("path [prefix]")
-            .action([&](parser_t& p) {
-                auto _v = p.get<strvec_t>("output");
-                update_env(_data, "ROCPROFSYS_OUTPUT_PATH", _v.at(0));
-                if(_v.size() > 1) update_env(_data, "ROCPROFSYS_OUTPUT_PREFIX", _v.at(1));
-            });
-
-        _data.reg.processed_environs.emplace("output");
-        _data.reg.processed_environs.emplace("output_path");
-        _data.reg.processed_environs.emplace("output_prefix");
-    }
-
-    if(_data.reg.environ_filter("trace", _data))
-    {
-        _parser
-            .add_argument({ "-T", "--trace" },
-                          "Generate a detailed trace (perfetto output)")
-            .max_count(1)
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE", p.get<bool>("trace"));
-            });
-
-        _parser
-            .add_argument({ "-L", "--trace-legacy" },
-                          "Use legacy direct mode for tracing instead of deferred trace "
-                          "generation (higher overhead)")
-            .max_count(1)
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_LEGACY", p.get<bool>("trace-legacy"));
-            });
-
-        _data.reg.processed_environs.emplace("trace");
-        _data.reg.processed_environs.emplace("trace_legacy");
-    }
-
-    if(_data.reg.environ_filter("profile", _data))
-    {
-        _parser
-            .add_argument(
-                { "-P", "--profile" },
-                "Generate a call-stack-based profile (conflicts with --flat-profile)")
-            .max_count(1)
-            .conflicts({ "flat-profile" })
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PROFILE", p.get<bool>("profile"));
-            });
-
-        _data.reg.processed_environs.emplace("profile");
-    }
-
-    if(_data.reg.environ_filter("flat_profile", _data))
-    {
-        _parser
-            .add_argument({ "-F", "--flat-profile" },
-                          "Generate a flat profile (conflicts with --profile)")
-            .max_count(1)
-            .conflicts({ "profile" })
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PROFILE", p.get<bool>("flat-profile"));
-                update_env(_data, "ROCPROFSYS_FLAT_PROFILE", p.get<bool>("flat-profile"));
-            });
-
-        _data.reg.processed_environs.emplace("flat_profile");
-    }
-
-    if(_data.reg.environ_filter("sampling", _data))
-    {
-        _parser
-            .add_argument({ "-S", "--sample" },
-                          "Enable statistical sampling of call-stack")
-            .min_count(0)
-            .max_count(2)
-            .dtype("timer-type")
-            .choices({ "cputime", "realtime" })
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_USE_SAMPLING", true);
-                auto _modes = p.get<strset_t>("sample");
-                if(!_modes.empty())
-                {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_CPUTIME",
-                               _modes.count("cputime") > 0, update_mode::WEAK);
-                    update_env(_data, "ROCPROFSYS_SAMPLING_REALTIME",
-                               _modes.count("realtime") > 0, update_mode::WEAK);
-                }
-            });
-
-        _data.reg.processed_environs.emplace("cpu_freq");
-    }
-
-    if(_data.reg.environ_filter("host", _data))
-    {
-        _parser
-            .add_argument({ "-H", "--host" },
-                          "Enable sampling host-based metrics for the process. E.g. CPU "
-                          "frequency, memory usage, etc.")
-            .max_count(1)
-            .action([&](parser_t& p) {
-                auto _h = p.get<bool>("host");
-                auto _d = p.get<bool>("device");
-                update_env(_data, "ROCPROFSYS_USE_PROCESS_SAMPLING", _h || _d);
-                update_env(_data, "ROCPROFSYS_CPU_FREQ_ENABLED", _h);
-                if(_h) update_env(_data, "ROCPROFSYS_USE_AMD_SMI", _d);
-            });
-
-        _data.reg.processed_environs.emplace("host");
-        _data.reg.processed_environs.emplace("cpu_freq");
-    }
-
-    if(_data.reg.environ_filter("device", _data))
-    {
-        _parser
-            .add_argument(
-                { "-D", "--device" },
-                "Enable sampling device-based metrics for the process. E.g. GPU "
-                "temperature, memory usage, etc.")
-            .max_count(1)
-            .action([&](parser_t& p) {
-                auto _h = p.get<bool>("host");
-                auto _d = p.get<bool>("device");
-                update_env(_data, "ROCPROFSYS_USE_PROCESS_SAMPLING", _h || _d);
-                update_env(_data, "ROCPROFSYS_USE_AMD_SMI", _d);
-                if(_d) update_env(_data, "ROCPROFSYS_CPU_FREQ_ENABLED", _h);
-            });
-
-        _data.reg.processed_environs.emplace("device");
-        _data.reg.processed_environs.emplace("amd_smi");
-    }
-
-    if(_data.reg.environ_filter("wait", _data))
-    {
-        _parser
-            .add_argument(
-                { "-w", "--wait" },
-                "This option is a combination of '--trace-wait' and "
-                "'--sampling-wait'. See the descriptions for those two options.")
-            .count(1)
-            .dtype("seconds")
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_DELAY", p.get<double>("wait"),
-                           update_mode::WEAK);
-                update_env(_data, "ROCPROFSYS_SAMPLING_DELAY", p.get<double>("wait"),
-                           update_mode::WEAK);
-                update_env(_data, "ROCPROFSYS_CAUSAL_DELAY", p.get<double>("wait"),
-                           update_mode::WEAK);
-            });
-
-        _data.reg.processed_environs.emplace("wait");
-    }
-
-    if(_data.reg.environ_filter("duration", _data))
-    {
-        _parser
-            .add_argument(
-                { "-d", "--duration" },
-                "This option is a combination of '--trace-duration' and "
-                "'--sampling-duration'. See the descriptions for those two options.")
-            .count(1)
-            .dtype("seconds")
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_DURATION", p.get<double>("duration"),
-                           update_mode::WEAK);
-                update_env(_data, "ROCPROFSYS_SAMPLING_DURATION",
-                           p.get<double>("duration"), update_mode::WEAK);
-                update_env(_data, "ROCPROFSYS_CAUSAL_DURATION", p.get<double>("duration"),
-                           update_mode::WEAK);
-            });
-
-        _data.reg.processed_environs.emplace("duration");
-    }
-
-    if(_data.reg.environ_filter("periods", _data))
-    {
-        _parser
-            .add_argument({ "--periods" },
-                          "Similar to specifying delay and/or duration except in "
-                          "the form <DELAY>:<DURATION>, <DELAY>:<DURATION>:<REPEAT>, "
-                          "and/or <DELAY>:<DURATION>:<REPEAT>:<CLOCK_ID>")
-            .min_count(1)
-            .dtype("period-spec(s)")
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_PERIODS",
-                           fmt::format("{}", fmt::join(p.get<strvec_t>("periods"), " ")),
-                           update_mode::WEAK);
-            });
-
-        _data.reg.processed_environs.emplace("periods");
-    }
-
-    if(_data.reg.environ_filter("selected_regions", _data))
-    {
-        _parser
-            .add_argument(
-                { "--selected-regions" },
-                "Comma-separated list of roctx region names. When set, only "
-                "activity inside matching roctx regions is traced (matched against "
-                "roctxRangeStartA message)")
-            .count(1)
-            .dtype("string")
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SELECTED_REGIONS",
-                           p.get<std::string>("selected-regions"));
-            });
-
-        _data.reg.processed_environs.emplace("selected_regions");
-    }
-
-    if(_data.reg.environ_filter("rank_filter_id", _data))
-    {
-        _parser
-            .add_argument({ "--rank-filter-id" },
-                          "Sets the name of environment variable to read rank from for "
-                          "MPI output filtering")
-            .max_count(1)
-            .dtype("string")
-            .required({ "rank-filter-output" })
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_RANK_FILTER_ID",
-                           p.get<std::string>("rank-filter-id"));
-            });
-
-        _data.reg.processed_environs.emplace("rank_filter_id");
-    }
-
-    if(_data.reg.environ_filter("rank_filter_output", _data))
-    {
-        _parser
-            .add_argument({ "--rank-filter-output" },
-                          "Ranks for which file output is generated. Values should be "
-                          "separated by commas and can be explicit or ranges, e.g. "
-                          "0,1,5-8. An empty value enables output for all ranks")
-            .max_count(1)
-            .dtype("int and/or range")
-            .action([&](parser_t& p) {
-                update_env(
-                    _data, "ROCPROFSYS_RANK_FILTER_OUTPUT",
-                    fmt::format("{}",
-                                fmt::join(p.get<strvec_t>("rank-filter-output"), ",")));
-            });
-
-        _data.reg.processed_environs.emplace("rank_filter_output");
-    }
+    register_group(_parser, _data, general_group());
 
     strset_t _backend_choices = { "all",        "kokkosp", "mpip", "ompt",
                                   "rcclp",      "amd-smi", "rocm", "mutex-locks",
@@ -644,113 +299,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
         _data.reg.processed_environs.emplace("launcher");
     }
 
-    _parser.start_group("TRACING OPTIONS", "Specific options controlling tracing (i.e. "
-                                           "deterministic measurements of every event)");
-
-    if(_data.reg.environ_filter("trace_file", _data))
-    {
-        _parser
-            .add_argument(
-                { "--trace-file" },
-                "Specify the trace output filename. Relative filepath will be with "
-                "respect to output path and output prefix.")
-            .count(1)
-            .dtype("filepath")
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PERFETTO_FILE",
-                           p.get<std::string>("trace-file"));
-            });
-
-        _data.reg.processed_environs.emplace("trace_file");
-        _data.reg.processed_environs.emplace("perfetto_file");
-    }
-
-    if(_data.reg.environ_filter("trace_buffer_size", _data))
-    {
-        _parser
-            .add_argument({ "--trace-buffer-size" },
-                          "Size limit for the trace output (in KB)")
-            .count(1)
-            .dtype("KB")
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PERFETTO_BUFFER_SIZE_KB",
-                           p.get<std::int64_t>("trace-buffer-size"));
-            });
-
-        _data.reg.processed_environs.emplace("trace_buffer_size");
-        _data.reg.processed_environs.emplace("perfetto_buffer_size_kb");
-    }
-
-    if(_data.reg.environ_filter("trace_fill_policy", _data))
-    {
-        _parser.add_argument({ "--trace-fill-policy" }, _trace_policy_desc)
-            .count(1)
-            .dtype("policy")
-            .choices({ "discard", "ring_buffer" })
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PERFETTO_FILL_POLICY",
-                           p.get<std::string>("trace-fill-policy"));
-            });
-
-        _data.reg.processed_environs.emplace("trace_fill_policy");
-        _data.reg.processed_environs.emplace("perfetto_fill_policy");
-    }
-
-    if(_data.reg.environ_filter("trace_wait", _data))
-    {
-        _parser
-            .add_argument(
-                { "--trace-wait" },
-                "Set the wait time (in seconds) "
-                "before collecting trace and/or profiling data"
-                "(in seconds). By default, the duration is in seconds of realtime "
-                "but that can changed via --trace-clock-id.")
-            .count(1)
-            .dtype("seconds")
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_DELAY", p.get<double>("trace-wait"));
-            });
-
-        _data.reg.processed_environs.emplace("trace_delay");
-    }
-
-    if(_data.reg.environ_filter("trace_duration", _data))
-    {
-        _parser
-            .add_argument(
-                { "--trace-duration" },
-                "Set the duration of the trace and/or profile data collection (in "
-                "seconds). By default, the duration is in seconds of realtime but "
-                "that can changed via --trace-clock-id.")
-            .count(1)
-            .dtype("seconds")
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_DURATION",
-                           p.get<double>("trace-duration"));
-            });
-
-        _data.reg.processed_environs.emplace("trace_duration");
-    }
-
-    if(_data.reg.environ_filter("trace_periods", _data))
-    {
-        _parser
-            .add_argument(
-                { "--trace-periods" },
-                "More powerful version of specifying trace delay and/or duration. Format "
-                "is one or more groups of: <DELAY>:<DURATION>, "
-                "<DELAY>:<DURATION>:<REPEAT>, "
-                "and/or <DELAY>:<DURATION>:<REPEAT>:<CLOCK_ID>.")
-            .min_count(1)
-            .dtype("period-spec(s)")
-            .action([&](parser_t& p) {
-                update_env(
-                    _data, "ROCPROFSYS_TRACE_PERIODS",
-                    fmt::format("{}", fmt::join(p.get<strvec_t>("trace-periods"), ",")));
-            });
-
-        _data.reg.processed_environs.emplace("trace_periods");
-    }
+    register_group(_parser, _data, tracing_group());
 
     if(_data.reg.environ_filter("trace_clock_id", _data))
     {
@@ -780,337 +329,10 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
         _data.reg.processed_environs.emplace("trace_period_clock_id");
     }
 
-    _parser.start_group("PROFILE OPTIONS",
-                        "Specific options controlling profiling (i.e. deterministic "
-                        "measurements which are aggregated into a summary)");
-
-    if(_data.reg.environ_filter("profile_format", _data))
-    {
-        _parser.add_argument({ "--profile-format" }, "Data formats for profiling results")
-            .min_count(1)
-            .max_count(3)
-            .dtype("string")
-            .required({ "profile|flat-profile" })
-            .choices({ "text", "json", "console" })
-            .action([&](parser_t& p) {
-                auto _v = p.get<strset_t>("profile-format");
-                update_env(_data, "ROCPROFSYS_PROFILE", true);
-                if(!_v.empty())
-                {
-                    update_env(_data, "ROCPROFSYS_TEXT_OUTPUT", _v.count("text") != 0);
-                    update_env(_data, "ROCPROFSYS_JSON_OUTPUT", _v.count("json") != 0);
-                    update_env(_data, "ROCPROFSYS_COUT_OUTPUT", _v.count("console") != 0);
-                }
-            });
-
-        _data.reg.processed_environs.emplace("profile_format");
-        _data.reg.processed_environs.emplace("text_output");
-        _data.reg.processed_environs.emplace("json_output");
-        _data.reg.processed_environs.emplace("cout_output");
-    }
-
-    if(_data.reg.environ_filter("profile_diff", _data))
-    {
-        _parser
-            .add_argument(
-                { "--profile-diff" },
-                "Generate a diff output b/t the profile collected and an existing "
-                "profile from another run Accepts 1-2 parameters corresponding to "
-                "the input path and the input prefix")
-            .min_count(1)
-            .max_count(2)
-            .dtype("path [prefix]")
-            .action([&](parser_t& p) {
-                auto _v = p.get<strvec_t>("profile-diff");
-                update_env(_data, "ROCPROFSYS_DIFF_OUTPUT", true);
-                update_env(_data, "ROCPROFSYS_INPUT_PATH", _v.at(0));
-                if(_v.size() > 1) update_env(_data, "ROCPROFSYS_INPUT_PREFIX", _v.at(1));
-            });
-
-        _data.reg.processed_environs.emplace("profile_diff");
-        _data.reg.processed_environs.emplace("diff_output");
-        _data.reg.processed_environs.emplace("input_path");
-        _data.reg.processed_environs.emplace("input_prefix");
-    }
-
-    _parser.start_group(
-        "HOST/DEVICE (PROCESS SAMPLING) OPTIONS",
-        "Process sampling is background measurements for resources available to the "
-        "entire process. These samples are not tied to specific lines/regions of code");
-
-    if(_data.reg.environ_filter("process_freq", _data))
-    {
-        _parser
-            .add_argument({ "--process-freq" },
-                          "Set the default host/device sampling frequency "
-                          "(number of interrupts per second)")
-            .count(1)
-            .dtype("floating-point")
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PROCESS_SAMPLING_FREQ",
-                           p.get<double>("process-freq"));
-            });
-
-        _data.reg.processed_environs.emplace("process_freq");
-        _data.reg.processed_environs.emplace("process_sampling_freq");
-    }
-
-    if(_data.reg.environ_filter("process_wait", _data))
-    {
-        _parser
-            .add_argument({ "--process-wait" }, "Set the default wait time (i.e. delay) "
-                                                "before taking first host/device sample "
-                                                "(in seconds of realtime)")
-            .count(1)
-            .dtype("seconds")
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PROCESS_SAMPLING_DELAY",
-                           p.get<double>("process-wait"));
-            });
-
-        _data.reg.processed_environs.emplace("process_wait");
-        _data.reg.processed_environs.emplace("process_sampling_delay");
-    }
-
-    if(_data.reg.environ_filter("process_duration", _data))
-    {
-        _parser
-            .add_argument(
-                { "--process-duration" },
-                "Set the duration of the host/device sampling (in seconds of realtime)")
-            .count(1)
-            .dtype("seconds")
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_PROCESS_DURATION",
-                           p.get<double>("process-duration"));
-            });
-
-        _data.reg.processed_environs.emplace("process_duration");
-        _data.reg.processed_environs.emplace("process_sampling_duration");
-    }
-
-    if(_data.reg.environ_filter("cpus", _data))
-    {
-        _parser
-            .add_argument(
-                { "--cpus" },
-                "CPU IDs for frequency sampling. Supports integers and/or ranges")
-            .dtype("int and/or range")
-            .required({ "host" })
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_CPUS",
-                           fmt::format("{}", fmt::join(p.get<strvec_t>("cpus"), ",")));
-            });
-
-        _data.reg.processed_environs.emplace("cpus");
-        _data.reg.processed_environs.emplace("sampling_cpus");
-    }
-
-    if(_data.reg.environ_filter("gpus", _data))
-    {
-        _parser
-            .add_argument({ "--gpus" },
-                          "GPU IDs for SMI queries. Supports integers and/or ranges")
-            .dtype("int and/or range")
-            .required({ "device" })
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_GPUS",
-                           fmt::format("{}", fmt::join(p.get<strvec_t>("gpus"), ",")));
-            });
-
-        _data.reg.processed_environs.emplace("gpus");
-        _data.reg.processed_environs.emplace("sampling_gpus");
-    }
-
-    if(_data.reg.environ_filter("ai-nics", _data))
-    {
-        _parser
-            .add_argument({ "--ai-nics" },
-                          "AI NIC IDs for SMI queries. Supports comma-separated list")
-            .dtype("list of strings")
-            .required({ "device" })
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_AINICS",
-                           fmt::format("{}", fmt::join(p.get<strvec_t>("ai-nics"), ",")));
-            });
-
-        _data.reg.processed_environs.emplace("ai-nics");
-        _data.reg.processed_environs.emplace("sampling_ai-nics");
-    }
-
-    _parser.start_group("GENERAL SAMPLING OPTIONS",
-                        "General options for timer-based sampling per-thread");
-
-    if(_data.reg.environ_filter("sampling_freq", _data))
-    {
-        _parser
-            .add_argument({ "-f", "--sampling-freq" },
-                          "Set the default sampling frequency "
-                          "(number of interrupts per second)")
-            .count(1)
-            .dtype("floating-point")
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_FREQ",
-                           p.get<double>("sampling-freq"));
-            });
-
-        _data.reg.processed_environs.emplace("sampling_freq");
-    }
-
-    if(_data.reg.environ_filter("tids", _data))
-    {
-        _parser
-            .add_argument(
-                { "-t", "--tids" },
-                "Specify the default thread IDs for sampling, where 0 (zero) is "
-                "the main thread and each thread created by the target application "
-                "is assigned an atomically incrementing value.")
-            .min_count(1)
-            .dtype("int and/or range")
-            .action([&](parser_t& p) {
-                update_env(
-                    _data, "ROCPROFSYS_SAMPLING_TIDS",
-                    fmt::format(
-                        "{}", fmt::join(p.get<std::vector<std::int64_t>>("tids"), ", ")));
-            });
-
-        _data.reg.processed_environs.emplace("tids");
-        _data.reg.processed_environs.emplace("sampling_tids");
-    }
-
-    if(_data.reg.environ_filter("sampling_wait", _data))
-    {
-        _parser
-            .add_argument(
-                { "--sampling-wait" },
-                "Set the default wait time (i.e. delay) before taking first sample "
-                "(in seconds). This delay time is based on the clock of the sampler, "
-                "i.e., a "
-                "delay of 1 second for CPU-clock sampler may not equal 1 second of "
-                "realtime")
-            .count(1)
-            .dtype("seconds")
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_DELAY",
-                           p.get<double>("sampling-wait"));
-            });
-
-        _data.reg.processed_environs.emplace("sampling_wait");
-        _data.reg.processed_environs.emplace("sampling_delay");
-    }
-
-    if(_data.reg.environ_filter("sampling_duration", _data))
-    {
-        _parser
-            .add_argument(
-                { "--sampling-duration" },
-                "Set the duration of the sampling (in seconds of realtime). I.e., it is "
-                "possible (currently) to set a CPU-clock time delay that exceeds the "
-                "real-time duration... resulting in zero samples being taken")
-            .count(1)
-            .dtype("seconds")
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_DURATION",
-                           p.get<double>("sampling-duration"));
-            });
-
-        _data.reg.processed_environs.emplace("sampling_duration");
-    }
-
-    _parser.start_group(
-        "SAMPLING TIMER OPTIONS",
-        "These options determine the heuristic for deciding when to take a sample");
-
-    if(_data.reg.environ_filter("sampling_cputime", _data))
-    {
-        _parser.add_argument({ "--sample-cputime" }, _cputime_desc)
-            .min_count(0)
-            .dtype("[freq] [delay] [tids...]")
-            .action([&](parser_t& p) {
-                auto _v = p.get<std::deque<std::string>>("sample-cputime");
-                update_env(_data, "ROCPROFSYS_SAMPLING_CPUTIME", true);
-                if(!_v.empty())
-                {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_CPUTIME_FREQ", _v.front());
-                    _v.pop_front();
-                }
-                if(!_v.empty())
-                {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_CPUTIME_DELAY", _v.front());
-                    _v.pop_front();
-                }
-                if(!_v.empty())
-                {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_CPUTIME_TIDS",
-                               fmt::format("{}", fmt::join(_v, ",")));
-                }
-            });
-
-        _data.reg.processed_environs.emplace("sampling_cputime");
-    }
-
-    if(_data.reg.environ_filter("sampling_realtime", _data))
-    {
-        _parser.add_argument({ "--sample-realtime" }, _realtime_desc)
-            .min_count(0)
-            .dtype("[freq] [delay] [tids...]")
-            .action([&](parser_t& p) {
-                auto _v = p.get<std::deque<std::string>>("sample-realtime");
-                update_env(_data, "ROCPROFSYS_SAMPLING_REALTIME", true);
-                if(!_v.empty())
-                {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_REALTIME_FREQ", _v.front());
-                    _v.pop_front();
-                }
-                if(!_v.empty())
-                {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_REALTIME_DELAY", _v.front());
-                    _v.pop_front();
-                }
-                if(!_v.empty())
-                {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_REALTIME_TIDS",
-                               fmt::format("{}", fmt::join(_v, ",")));
-                }
-            });
-
-        _data.reg.processed_environs.emplace("sampling_realtime");
-    }
-
-    if(_data.reg.environ_filter("sampling_overflow", _data))
-    {
-        _parser.add_argument({ "--sample-overflow" }, _overflow_desc)
-            .min_count(0)
-            .dtype("[event] [freq] [tids...]")
-            .action([&](parser_t& p) {
-                auto _v = p.get<std::deque<std::string>>("sample-overflow");
-                update_env(_data, "ROCPROFSYS_SAMPLING_OVERFLOW", true);
-
-                if(!_v.empty())
-                {
-                    if(p.exists("sampling-overflow-event") &&
-                       _v.front() != p.get<std::string>("sampling-overflow-event"))
-                        throw exception<std::runtime_error>(fmt::format(
-                            "'--sample-overflow {} ...' conflicts with "
-                            "'--sampling-overflow-event {}' option",
-                            _v.front(), p.get<std::string>("sampling-overflow-event")));
-                    update_env(_data, "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT", _v.front());
-                    _v.pop_front();
-                }
-                if(!_v.empty())
-                {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_OVERFLOW_FREQ", _v.front());
-                    _v.pop_front();
-                }
-                if(!_v.empty())
-                {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_OVERFLOW_TIDS",
-                               fmt::format("{}", fmt::join(_v, ",")));
-                }
-            });
-
-        _data.reg.processed_environs.emplace("sampling_overflow");
-    }
+    register_group(_parser, _data, profile_group());
+    register_group(_parser, _data, process_sampling_group());
+    register_group(_parser, _data, general_sampling_group());
+    register_group(_parser, _data, sampling_timer_group());
 
     _parser.start_group(
         "ADVANCED SAMPLING OPTIONS",
@@ -1118,43 +340,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
 
     add_group_arguments(_parser, "sampling", _data);
 
-    _parser.start_group("HARDWARE COUNTER OPTIONS", "See also: rocprof-sys-avail -H");
-
-    if(_data.reg.environ_filter("cpu_events", _data))
-    {
-        _parser
-            .add_argument({ "-C", "--cpu-events" },
-                          "Set the CPU hardware counter events to record (ref: "
-                          "`rocprof-sys-avail -H -c CPU`)")
-            .min_count(1)
-            .dtype("[EVENT ...]")
-            .action([&](parser_t& p) {
-                auto _events =
-                    fmt::format("{}", fmt::join(p.get<strvec_t>("cpu-events"), ","));
-                update_env(_data, "ROCPROFSYS_PAPI_EVENTS", _events);
-            });
-
-        _data.reg.processed_environs.emplace("cpu_events");
-        _data.reg.processed_environs.emplace("papi_events");
-    }
-
-    if(_data.reg.environ_filter("gpu_events", _data))
-    {
-        _parser
-            .add_argument({ "-G", "--gpu-events" },
-                          "Set the GPU hardware counter events to record (ref: "
-                          "`rocprof-sys-avail -H -c GPU`)")
-            .min_count(1)
-            .dtype("[EVENT ...]")
-            .action([&](parser_t& p) {
-                auto _events =
-                    fmt::format("{}", fmt::join(p.get<strvec_t>("gpu-events"), ","));
-                update_env(_data, "ROCPROFSYS_ROCM_EVENTS", _events);
-            });
-
-        _data.reg.processed_environs.emplace("gpu_events");
-        _data.reg.processed_environs.emplace("rocm_events");
-    }
+    register_group(_parser, _data, hw_counter_group());
 
     add_group_arguments(_parser, "category", _data, true);
     add_group_arguments(_parser, "io", _data, true);
@@ -1162,35 +348,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
     add_group_arguments(_parser, "timemory", _data, true);
     add_group_arguments(_parser, "rocm", _data, true);
 
-    _parser.start_group("MISCELLANEOUS OPTIONS", "");
-
-    if(_data.reg.environ_filter("inlines", _data))
-    {
-        _parser
-            .add_argument({ "-i", "--inlines" },
-                          "Include inline info in output when available")
-            .max_count(1)
-            .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_INCLUDE_INLINES",
-                           p.get<bool>("inlines"));
-            });
-
-        _data.reg.processed_environs.emplace("inlines");
-        _data.reg.processed_environs.emplace("sampling_include_inlines");
-    }
-
-    if(_data.reg.environ_filter("hsa_interrupt", _data))
-    {
-        _parser.add_argument({ "--hsa-interrupt" }, _hsa_interrupt_desc)
-            .count(1)
-            .dtype("int")
-            .choices({ 0, 1 })
-            .action([&](parser_t& p) {
-                update_env(_data, "HSA_ENABLE_INTERRUPT", p.get<int>("hsa-interrupt"));
-            });
-
-        _data.reg.processed_environs.emplace("hsa_interrupt");
-    }
+    register_group(_parser, _data, misc_group());
 
     _parser.end_group();
 
@@ -1263,33 +421,10 @@ add_group_arguments(parser_t& _parser, const std::string& _group_name, parser_da
 
         itr.second->set_enabled(true);
         _settings.emplace_back(itr.second);
-
-        if(itr.second->get_name() == "papi_events")
-        {
-            auto _choices = itr.second->get_choices();
-            _choices.erase(
-                std::remove_if(_choices.begin(), _choices.end(),
-                               [](const auto& citr) {
-                                   return std::regex_search(
-                                              citr,
-                                              std::regex{ "[A-Za-z0-9]:([A-Za-z_]+)" }) ||
-                                          std::regex_search(citr, std::regex{ "io:::" });
-                               }),
-                _choices.end());
-            _choices.emplace_back(
-                "... run `rocprof-sys-avail -H -c CPU` for full list ...");
-            itr.second->set_choices(_choices);
-        }
+        apply_papi_choice_filter(itr.second);
     }
 
-    std::sort(_settings.begin(), _settings.end(), [](const auto& _lhs, const auto& _rhs) {
-        auto _lhs_v = _lhs->get_name();
-        auto _rhs_v = _rhs->get_name();
-        if(_lhs_v.length() > 4 && _rhs_v.length() > 4 &&
-           _lhs_v.substr(0, 4) == _rhs_v.substr(0, 4))
-            return _lhs_v < _rhs_v;
-        return _lhs_v.length() < _rhs_v.length();
-    });
+    sort_settings_by_name_length(_settings);
 
     if(_add_group)
     {
@@ -1324,23 +459,7 @@ add_extended_arguments(parser_t& _parser, parser_data& _data)
 
         itr.second->set_enabled(true);
         _settings.emplace_back(itr.second);
-
-        if(itr.second->get_name() == "papi_events")
-        {
-            auto _choices = itr.second->get_choices();
-            _choices.erase(
-                std::remove_if(_choices.begin(), _choices.end(),
-                               [](const auto& citr) {
-                                   return std::regex_search(
-                                              citr,
-                                              std::regex{ "[A-Za-z0-9]:([A-Za-z_]+)" }) ||
-                                          std::regex_search(citr, std::regex{ "io:::" });
-                               }),
-                _choices.end());
-            _choices.emplace_back(
-                "... run `rocprof-sys-avail -H -c CPU` for full list ...");
-            itr.second->set_choices(_choices);
-        }
+        apply_papi_choice_filter(itr.second);
 
         for(const auto& citr : itr.second->get_categories())
         {

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -4,6 +4,7 @@
 #include "argparse.hpp"
 #include "argparse/core_flags.hpp"
 #include "argparse/interpreter.hpp"
+#include "common/env_vars.hpp"
 #include "common/environment.hpp"
 #include "common/path.hpp"
 #include "config.hpp"
@@ -29,6 +30,7 @@ namespace
 {
 namespace filepath = ::tim::filepath;
 namespace path     = rocprofsys::common::path;
+namespace env      = rocprofsys::env_vars;
 using rocprofsys::common::remove_env;
 
 auto
@@ -146,10 +148,10 @@ init_parser(parser_data& _data)
         path::realpath(path::get_internal_libpath("librocprof-sys.so").c_str());
 
     auto _libexecpath = path::realpath(path::get_internal_script_path());
-    update_env(_data, "ROCPROFSYS_SCRIPT_PATH", _libexecpath, update_mode::REPLACE);
+    update_env(_data, env::SCRIPT_PATH, _libexecpath, update_mode::REPLACE);
 
     auto _rootpath = path::realpath(path::get_rocprofsys_root());
-    update_env(_data, "ROCPROFSYS_ROOT", _rootpath, update_mode::REPLACE);
+    update_env(_data, env::ROOT, _rootpath, update_mode::REPLACE);
 
     return _data;
 }
@@ -209,7 +211,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
         _backend_choices.erase("amd-smi");
         _backend_choices.erase("rocm");
 
-        update_env(_data, "ROCPROFSYS_USE_AMD_SMI", false);
+        update_env(_data, env::USE_AMD_SMI, false);
     }
 
     _parser.start_group("BACKEND OPTIONS",
@@ -228,14 +230,14 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                 auto _update = [&](const auto& _opt, bool _cond) {
                     if(_cond || _v.count("all") > 0) update_env(_data, _opt, true);
                 };
-                _update("ROCPROFSYS_USE_KOKKOSP", _v.count("kokkosp") > 0);
-                _update("ROCPROFSYS_USE_MPIP", _v.count("mpip") > 0);
-                _update("ROCPROFSYS_USE_OMPT", _v.count("ompt") > 0);
-                _update("ROCPROFSYS_USE_RCCLP", _v.count("rcclp") > 0);
-                _update("ROCPROFSYS_USE_AMD_SMI", _v.count("amd-smi") > 0);
-                _update("ROCPROFSYS_TRACE_THREAD_LOCKS", _v.count("mutex-locks") > 0);
-                _update("ROCPROFSYS_TRACE_THREAD_RW_LOCKS", _v.count("rw-locks") > 0);
-                _update("ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS", _v.count("spin-locks") > 0);
+                _update(env::USE_KOKKOSP, _v.count("kokkosp") > 0);
+                _update(env::USE_MPIP, _v.count("mpip") > 0);
+                _update(env::USE_OMPT, _v.count("ompt") > 0);
+                _update(env::USE_RCCLP, _v.count("rcclp") > 0);
+                _update(env::USE_AMD_SMI, _v.count("amd-smi") > 0);
+                _update(env::TRACE_THREAD_LOCKS, _v.count("mutex-locks") > 0);
+                _update(env::TRACE_THREAD_RW_LOCKS, _v.count("rw-locks") > 0);
+                _update(env::TRACE_THREAD_SPIN_LOCKS, _v.count("spin-locks") > 0);
 
                 if(_v.count("all") > 0 || _v.count("kokkosp") > 0)
                     update_env(_data, "KOKKOS_TOOLS_LIBS", _data.env.omni_libpath,
@@ -257,14 +259,14 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                 auto _update = [&](const auto& _opt, bool _cond) {
                     if(_cond || _v.count("all") > 0) update_env(_data, _opt, false);
                 };
-                _update("ROCPROFSYS_USE_KOKKOSP", _v.count("kokkosp") > 0);
-                _update("ROCPROFSYS_USE_MPIP", _v.count("mpip") > 0);
-                _update("ROCPROFSYS_USE_OMPT", _v.count("ompt") > 0);
-                _update("ROCPROFSYS_USE_RCCLP", _v.count("rcclp") > 0);
-                _update("ROCPROFSYS_USE_AMD_SMI", _v.count("amd-smi") > 0);
-                _update("ROCPROFSYS_TRACE_THREAD_LOCKS", _v.count("mutex-locks") > 0);
-                _update("ROCPROFSYS_TRACE_THREAD_RW_LOCKS", _v.count("rw-locks") > 0);
-                _update("ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS", _v.count("spin-locks") > 0);
+                _update(env::USE_KOKKOSP, _v.count("kokkosp") > 0);
+                _update(env::USE_MPIP, _v.count("mpip") > 0);
+                _update(env::USE_OMPT, _v.count("ompt") > 0);
+                _update(env::USE_RCCLP, _v.count("rcclp") > 0);
+                _update(env::USE_AMD_SMI, _v.count("amd-smi") > 0);
+                _update(env::TRACE_THREAD_LOCKS, _v.count("mutex-locks") > 0);
+                _update(env::TRACE_THREAD_RW_LOCKS, _v.count("rw-locks") > 0);
+                _update(env::TRACE_THREAD_SPIN_LOCKS, _v.count("spin-locks") > 0);
 
                 if(_v.count("all") > 0 || _v.count("kokkosp") > 0)
                     remove_env(_data.env.current, "KOKKOS_TOOLS_LIBS", _data.env.initial);
@@ -319,7 +321,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("clock-id")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_PERIOD_CLOCK_ID",
+                update_env(_data, env::TRACE_PERIOD_CLOCK_ID,
                            p.get<double>("trace-clock-id"));
             })
             .choices(_clock_id_choices.first)

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 #include "argparse.hpp"
+
 #include "argparse/core_flags.hpp"
+#include "argparse/detail/parser_engine.hpp"
 #include "argparse/interpreter.hpp"
 #include "common/env_vars.hpp"
 #include "common/environment.hpp"

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -71,29 +71,19 @@ get_clock_id_choices()
 
 using rocprofsys::common::update_mode;
 
-template <typename Tp>
 void
-update_env(parser_data& _data, std::string_view _env_var, Tp&& _env_val,
-           update_mode _mode = update_mode::REPLACE, std::string_view _join_delim = ":")
+filter_papi_choices(const std::shared_ptr<tim::vsettings>& setting)
 {
-    rocprofsys::common::update_env(_data.env.current, _env_var,
-                                   std::forward<Tp>(_env_val), _mode, _join_delim,
-                                   _data.env.updated, _data.env.initial);
-}
+    static const std::regex prefixed_event{ "[A-Za-z0-9]:([A-Za-z_]+)" };
+    static const std::regex io_event{ "io:::" };
 
-void
-apply_papi_choice_filter(const std::shared_ptr<tim::vsettings>& setting)
-{
-    if(setting->get_name() != "papi_events") return;
     auto choices = setting->get_choices();
-    choices.erase(
-        std::remove_if(choices.begin(), choices.end(),
-                       [](const auto& choice) {
-                           return std::regex_search(
-                                      choice, std::regex{ "[A-Za-z0-9]:([A-Za-z_]+)" }) ||
-                                  std::regex_search(choice, std::regex{ "io:::" });
-                       }),
-        choices.end());
+    choices.erase(std::remove_if(choices.begin(), choices.end(),
+                                 [](const auto& choice) {
+                                     return std::regex_search(choice, prefixed_event) ||
+                                            std::regex_search(choice, io_event);
+                                 }),
+                  choices.end());
     choices.emplace_back("... run `rocprof-sys-avail -H -c CPU` for full list ...");
     setting->set_choices(choices);
 }
@@ -124,13 +114,13 @@ default_setting_filter(vsetting_t* _v, const parser_data& _data)
 bool
 default_environ_filter(std::string_view _v, const parser_data& _data)
 {
-    return (_data.reg.processed_environs.count(_v.data()) == 0);
+    return (_data.reg.processed_environs.count(std::string{ _v }) == 0);
 }
 
 bool
 default_grouping_filter(std::string_view _v, const parser_data& _data)
 {
-    return (_data.reg.processed_groups.count(_v.data()) == 0);
+    return (_data.reg.processed_groups.count(std::string{ _v }) == 0);
 }
 
 parser_data&
@@ -148,10 +138,10 @@ init_parser(parser_data& _data)
         path::realpath(path::get_internal_libpath("librocprof-sys.so").c_str());
 
     auto _libexecpath = path::realpath(path::get_internal_script_path());
-    update_env(_data, env::SCRIPT_PATH, _libexecpath, update_mode::REPLACE);
+    _data.env.set(env::SCRIPT_PATH, _libexecpath, update_mode::REPLACE);
 
     auto _rootpath = path::realpath(path::get_rocprofsys_root());
-    update_env(_data, env::ROOT, _rootpath, update_mode::REPLACE);
+    _data.env.set(env::ROOT, _rootpath, update_mode::REPLACE);
 
     return _data;
 }
@@ -159,7 +149,7 @@ init_parser(parser_data& _data)
 parser_data&
 add_ld_preload(parser_data& _data)
 {
-    update_env(_data, "LD_PRELOAD", _data.env.dl_libpath, update_mode::APPEND);
+    _data.env.set("LD_PRELOAD", _data.env.dl_libpath, update_mode::APPEND);
     return _data;
 }
 
@@ -168,7 +158,7 @@ add_ld_library_path(parser_data& _data)
 {
     auto _libdir = filepath::dirname(_data.env.dl_libpath);
     if(filepath::exists(_libdir))
-        update_env(_data, "LD_LIBRARY_PATH", _libdir, update_mode::APPEND);
+        _data.env.set("LD_LIBRARY_PATH", _libdir, update_mode::APPEND);
     return _data;
 }
 
@@ -211,7 +201,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
         _backend_choices.erase("amd-smi");
         _backend_choices.erase("rocm");
 
-        update_env(_data, env::USE_AMD_SMI, false);
+        _data.env.set(env::USE_AMD_SMI, false);
     }
 
     _parser.start_group("BACKEND OPTIONS",
@@ -228,7 +218,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .action([&](parser_t& p) {
                 auto _v      = p.get<strset_t>("include");
                 auto _update = [&](const auto& _opt, bool _cond) {
-                    if(_cond || _v.count("all") > 0) update_env(_data, _opt, true);
+                    if(_cond || _v.count("all") > 0) _data.env.set(_opt, true);
                 };
                 _update(env::USE_KOKKOSP, _v.count("kokkosp") > 0);
                 _update(env::USE_MPIP, _v.count("mpip") > 0);
@@ -240,8 +230,8 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                 _update(env::TRACE_THREAD_SPIN_LOCKS, _v.count("spin-locks") > 0);
 
                 if(_v.count("all") > 0 || _v.count("kokkosp") > 0)
-                    update_env(_data, "KOKKOS_TOOLS_LIBS", _data.env.omni_libpath,
-                               update_mode::PREPEND);
+                    _data.env.set("KOKKOS_TOOLS_LIBS", _data.env.omni_libpath,
+                                  update_mode::PREPEND);
             });
 
         _data.reg.processed_environs.emplace("include");
@@ -257,7 +247,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .action([&](parser_t& p) {
                 auto _v      = p.get<strset_t>("exclude");
                 auto _update = [&](const auto& _opt, bool _cond) {
-                    if(_cond || _v.count("all") > 0) update_env(_data, _opt, false);
+                    if(_cond || _v.count("all") > 0) _data.env.set(_opt, false);
                 };
                 _update(env::USE_KOKKOSP, _v.count("kokkosp") > 0);
                 _update(env::USE_MPIP, _v.count("mpip") > 0);
@@ -321,8 +311,8 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("clock-id")
             .action([&](parser_t& p) {
-                update_env(_data, env::TRACE_PERIOD_CLOCK_ID,
-                           p.get<double>("trace-clock-id"));
+                _data.env.set(env::TRACE_PERIOD_CLOCK_ID,
+                              p.get<double>("trace-clock-id"));
             })
             .choices(_clock_id_choices.first)
             .choice_aliases(_clock_id_choices.second);
@@ -392,7 +382,7 @@ add_group_arguments(parser_t& _parser, const std::string& _group_name, parser_da
                 if(_value.empty()) _value = fmt::format("{}", p.get<bool>(_name));
                 if(_value.empty())
                     throw exception<std::runtime_error>("Error! no value for " + _name);
-                update_env(_data, itr->get_env_name(), _value);
+                _data.env.set(itr->get_env_name(), _value);
             });
         }
         else
@@ -405,7 +395,7 @@ add_group_arguments(parser_t& _parser, const std::string& _group_name, parser_da
                     if(_value.empty())
                         throw exception<std::runtime_error>("Error! no value for " +
                                                             _name);
-                    update_env(_data, itr->get_env_name(), _value);
+                    _data.env.set(itr->get_env_name(), _value);
                 });
         }
         return true;
@@ -423,7 +413,7 @@ add_group_arguments(parser_t& _parser, const std::string& _group_name, parser_da
 
         itr.second->set_enabled(true);
         _settings.emplace_back(itr.second);
-        apply_papi_choice_filter(itr.second);
+        if(itr.second->get_name() == "papi_events") filter_papi_choices(itr.second);
     }
 
     sort_settings_by_name_length(_settings);
@@ -461,7 +451,7 @@ add_extended_arguments(parser_t& _parser, parser_data& _data)
 
         itr.second->set_enabled(true);
         _settings.emplace_back(itr.second);
-        apply_papi_choice_filter(itr.second);
+        if(itr.second->get_name() == "papi_events") filter_papi_choices(itr.second);
 
         for(const auto& citr : itr.second->get_categories())
         {

--- a/projects/rocprofiler-systems/source/lib/core/argparse.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.hpp
@@ -5,9 +5,6 @@
 
 #include "common/environment.hpp"
 
-#include <timemory/settings/vsettings.hpp>
-#include <timemory/utility/argparse.hpp>
-
 #include <functional>
 #include <set>
 #include <string>
@@ -15,6 +12,20 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+
+// Forward declarations only — the timemory engine lives behind
+// argparse/detail/parser_engine.hpp, included by TUs that need the
+// complete types (interpreter.cpp, core_flags.cpp, parsed_values.cpp,
+// argparse.cpp). Public consumers of this header pay no timemory
+// include cost and bind only to references / pointers.
+namespace tim
+{
+struct vsettings;
+namespace argparse
+{
+struct argument_parser;
+}  // namespace argparse
+}  // namespace tim
 
 namespace rocprofsys
 {

--- a/projects/rocprofiler-systems/source/lib/core/argparse/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+target_sources(
+    rocprofiler-systems-core-library
+    PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/flag_descriptor.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/interpreter.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/interpreter.cpp
+)

--- a/projects/rocprofiler-systems/source/lib/core/argparse/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/CMakeLists.txt
@@ -10,3 +10,7 @@ target_sources(
         ${CMAKE_CURRENT_LIST_DIR}/interpreter.hpp
         ${CMAKE_CURRENT_LIST_DIR}/interpreter.cpp
 )
+
+if(ROCPROFSYS_BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/projects/rocprofiler-systems/source/lib/core/argparse/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/CMakeLists.txt
@@ -1,5 +1,15 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+#
+# TODO(seam): promote to `add_library(rocprofsys-argparse OBJECT ...)` so the
+# timemory dependency is link-localised. Deferred: this layer's headers no
+# longer leak tim:: (verified by validation gate), but argparse.cpp's
+# add_group_arguments / add_extended_arguments still bind tim::vsettings
+# directly. Until the vsettings-driven path is lifted via a
+# settings_to_descriptor adapter (separate follow-up), an OBJECT library
+# here can't actually enforce "no tim in core-library" — it would only
+# guard the small descriptor subset already covered by the source-level
+# detail/parser_engine.hpp boundary.
 
 target_sources(
     rocprofiler-systems-core-library

--- a/projects/rocprofiler-systems/source/lib/core/argparse/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/CMakeLists.txt
@@ -4,6 +4,8 @@
 target_sources(
     rocprofiler-systems-core-library
     PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/core_flags.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/core_flags.hpp
         ${CMAKE_CURRENT_LIST_DIR}/flag_descriptor.hpp
         ${CMAKE_CURRENT_LIST_DIR}/interpreter.hpp
         ${CMAKE_CURRENT_LIST_DIR}/interpreter.cpp

--- a/projects/rocprofiler-systems/source/lib/core/argparse/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/CMakeLists.txt
@@ -6,9 +6,12 @@ target_sources(
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/core_flags.cpp
         ${CMAKE_CURRENT_LIST_DIR}/core_flags.hpp
+        ${CMAKE_CURRENT_LIST_DIR}/detail/parser_engine.hpp
         ${CMAKE_CURRENT_LIST_DIR}/flag_descriptor.hpp
         ${CMAKE_CURRENT_LIST_DIR}/interpreter.hpp
         ${CMAKE_CURRENT_LIST_DIR}/interpreter.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/parsed_values.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/parsed_values.hpp
 )
 
 if(ROCPROFSYS_BUILD_TESTING)

--- a/projects/rocprofiler-systems/source/lib/core/argparse/core_flags.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/core_flags.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <set>
 #include <string>
 #include <vector>
@@ -162,7 +163,7 @@ tids_action(parsed_values& values, parser_data& data)
 {
     // Comma-space joiner is intentional and matches legacy behavior;
     // `--sample-cputime`/`--sample-realtime`/`--sample-overflow` use comma-only.
-    auto tids = values.get<std::vector<int64_t>>("tids");
+    auto tids = values.get<std::vector<std::int64_t>>("tids");
     data.env.set(env::SAMPLING_TIDS, fmt::format("{}", fmt::join(tids, ", ")));
 }
 

--- a/projects/rocprofiler-systems/source/lib/core/argparse/core_flags.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/core_flags.cpp
@@ -1,0 +1,1064 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "core_flags.hpp"
+#include "common/env_vars.hpp"
+#include "exception.hpp"
+#include "flag_descriptor.hpp"
+#include "interpreter.hpp"
+
+#include <spdlog/fmt/fmt.h>
+#include <spdlog/fmt/ranges.h>
+
+#include <algorithm>
+#include <array>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace rocprofsys
+{
+namespace argparse
+{
+namespace
+{
+namespace env = rocprofsys::env_vars;
+using common::update_mode;
+
+constexpr std::string_view CPUTIME_HELP =
+    R"(Sample based on a CPU-clock timer (default). Accepts zero or more arguments:
+    %{INDENT}%0. Enables sampling based on CPU-clock timer.
+    %{INDENT}%1. Interrupts per second. E.g., 100 == sample every 10 milliseconds of CPU-time.
+    %{INDENT}%2. Delay (in seconds of CPU-clock time). I.e., how long each thread should wait before taking first sample.
+    %{INDENT}%3+ Thread IDs to target for sampling, starting at 0 (the main thread).
+    %{INDENT}%   May be specified as index or range, e.g., '0 2-4' will be interpreted as:
+    %{INDENT}%      sample the main thread (0), do not sample the first child thread but sample the 2nd, 3rd, and 4th child threads)";
+
+constexpr std::string_view REALTIME_HELP =
+    R"(Sample based on a real-clock timer. Accepts zero or more arguments:
+    %{INDENT}%0. Enables sampling based on real-clock timer.
+    %{INDENT}%1. Interrupts per second. E.g., 100 == sample every 10 milliseconds of realtime.
+    %{INDENT}%2. Delay (in seconds of real-clock time). I.e., how long each thread should wait before taking first sample.
+    %{INDENT}%3+ Thread IDs to target for sampling, starting at 0 (the main thread).
+    %{INDENT}%   May be specified as index or range, e.g., '0 2-4' will be interpreted as:
+    %{INDENT}%      sample the main thread (0), do not sample the first child thread but sample the 2nd, 3rd, and 4th child threads
+    %{INDENT}%   When sampling with a real-clock timer, please note that enabling this will cause threads which are typically "idle"
+    %{INDENT}%   to consume more resources since, while idle, the real-clock time increases (and therefore triggers taking samples)
+    %{INDENT}%   whereas the CPU-clock time does not.)";
+
+constexpr std::string_view OVERFLOW_HELP =
+    R"(Sample based on an overflow event. Accepts zero or more arguments:
+    %{INDENT}%0. Enables sampling based on overflow.
+    %{INDENT}%1. Overflow metric, e.g. PERF_COUNT_HW_INSTRUCTIONS
+    %{INDENT}%2. Overflow value. E.g., if metric == PERF_COUNT_HW_INSTRUCTIONS, then 10000000 == sample every 10,000,000 instructions.
+    %{INDENT}%3+ Thread IDs to target for sampling, starting at 0 (the main thread).
+    %{INDENT}%   May be specified as index or range, e.g., '0 2-4' will be interpreted as:
+    %{INDENT}%      sample the main thread (0), do not sample the first child thread but sample the 2nd, 3rd, and 4th child threads)";
+
+constexpr std::string_view HSA_INTERRUPT_HELP =
+    R"(Set the value of the HSA_ENABLE_INTERRUPT environment variable.
+%{INDENT}%  ROCm version 5.2 and older have a bug which will cause a deadlock if a sample is taken while waiting for the signal
+%{INDENT}%  that a kernel completed -- which happens when sampling with a real-clock timer. We require this option to be set to
+%{INDENT}%  when --realtime is specified to make users aware that, while this may fix the bug, it can have a negative impact on
+%{INDENT}%  performance.
+%{INDENT}%  Values:
+%{INDENT}%    0     avoid triggering the bug, potentially at the cost of reduced performance
+%{INDENT}%    1     do not modify how ROCm is notified about kernel completion)";
+
+void
+monochrome_action(parser_t& parser, parser_data& data)
+{
+    auto enabled        = parser.get<bool>("monochrome");
+    data.out.monochrome = enabled;
+    parser.set_use_color(!enabled);
+    common::update_env(data.env.current, env::MONOCHROME, enabled ? "1" : "0",
+                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+    common::update_env(data.env.current, "MONOCHROME", enabled ? "1" : "0",
+                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+}
+
+void
+debug_action(parser_t& /*parser*/, parser_data& data)
+{
+    common::update_env(data.env.current, env::LOG_LEVEL, "debug", update_mode::REPLACE,
+                       ":", data.env.updated, data.env.initial);
+}
+
+void
+verbose_action(parser_t& parser, parser_data& data)
+{
+    auto level       = parser.get<int>("verbose");
+    data.out.verbose = level;
+    common::update_env(data.env.current, env::VERBOSE_OUTPUT, level, update_mode::REPLACE,
+                       ":", data.env.updated, data.env.initial);
+    constexpr std::array<const char*, 5> log_levels = { "off", "info", "debug", "debug",
+                                                        "trace" };
+    auto index = std::clamp(level + 1, 0, static_cast<int>(log_levels.size() - 1));
+    common::update_env(data.env.current, env::LOG_LEVEL, log_levels[index],
+                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+}
+
+void
+output_action(parser_t& parser, parser_data& data)
+{
+    auto values = parser.get<std::vector<std::string>>("output");
+    common::update_env(data.env.current, env::OUTPUT_PATH, values.at(0),
+                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+    if(values.size() > 1)
+        common::update_env(data.env.current, env::OUTPUT_PREFIX, values.at(1),
+                           update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+}
+
+void
+sample_action(parser_t& parser, parser_data& data)
+{
+    common::update_env(data.env.current, env::USE_SAMPLING, true, update_mode::REPLACE,
+                       ":", data.env.updated, data.env.initial);
+    auto modes = parser.get<std::set<std::string>>("sample");
+    if(modes.empty()) return;
+    common::update_env(data.env.current, env::SAMPLING_CPUTIME,
+                       modes.count("cputime") > 0, update_mode::WEAK, ":",
+                       data.env.updated, data.env.initial);
+    common::update_env(data.env.current, env::SAMPLING_REALTIME,
+                       modes.count("realtime") > 0, update_mode::WEAK, ":",
+                       data.env.updated, data.env.initial);
+}
+
+void
+host_action(parser_t& parser, parser_data& data)
+{
+    auto host_enabled   = parser.get<bool>("host");
+    auto device_enabled = parser.get<bool>("device");
+    common::update_env(data.env.current, env::USE_PROCESS_SAMPLING,
+                       host_enabled || device_enabled, update_mode::REPLACE, ":",
+                       data.env.updated, data.env.initial);
+    common::update_env(data.env.current, env::CPU_FREQ_ENABLED, host_enabled,
+                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+    if(host_enabled)
+        common::update_env(data.env.current, env::USE_AMD_SMI, device_enabled,
+                           update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+}
+
+void
+device_action(parser_t& parser, parser_data& data)
+{
+    auto host_enabled   = parser.get<bool>("host");
+    auto device_enabled = parser.get<bool>("device");
+    common::update_env(data.env.current, env::USE_PROCESS_SAMPLING,
+                       host_enabled || device_enabled, update_mode::REPLACE, ":",
+                       data.env.updated, data.env.initial);
+    common::update_env(data.env.current, env::USE_AMD_SMI, device_enabled,
+                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+    if(device_enabled)
+        common::update_env(data.env.current, env::CPU_FREQ_ENABLED, host_enabled,
+                           update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+}
+
+const flag_group&
+make_debug_group()
+{
+    static const flag_group group{
+        "DEBUG OPTIONS",
+        "",
+        {
+            flag_descriptor{
+                /* names       */ { "--log-level" },
+                /* help        */ "Log level",
+                /* dtype       */ "string",
+                /* count       */ count_spec::at_most(1),
+                /* kind        */ value_kind::scalar,
+                /* join        */ join_with::none,
+                /* env_vars    */ { env::LOG_LEVEL },
+                /* mode        */ update_mode::REPLACE,
+                /* aliased_env */ {},
+                /* choices     */
+                { "trace", "debug", "info", "warn", "error", "critical", "off" },
+            },
+            flag_descriptor{
+                /* names    */ { "--monochrome" },
+                /* help     */ "Disable colorized output",
+                /* dtype    */ "bool",
+                /* count    */ count_spec::at_most(1),
+                /* kind     */ value_kind::flag,
+                /* join     */ join_with::none,
+                /* env_vars */ {},
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ {},
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ {},
+                /* custom      */ &monochrome_action,
+            },
+            flag_descriptor{
+                /* names    */ { "--debug" },
+                /* help     */ "[DEPRECATED Use --log-level=debug] Debug output",
+                /* dtype    */ {},
+                /* count    */ count_spec::at_most(1),
+                /* kind     */ value_kind::flag,
+                /* join     */ join_with::none,
+                /* env_vars */ {},
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ {},
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ {},
+                /* custom      */ &debug_action,
+            },
+            flag_descriptor{
+                /* names    */ { "-v", "--verbose" },
+                /* help     */ "[DEPRECATED Use --log-level=trace] Verbose output",
+                /* dtype    */ "integral",
+                /* count    */ count_spec::exactly(1),
+                /* kind     */ value_kind::scalar,
+                /* join     */ join_with::none,
+                /* env_vars */ {},
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ {},
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ {},
+                /* custom      */ &verbose_action,
+            },
+        },
+    };
+    return group;
+}
+
+void
+tids_action(parser_t& parser, parser_data& data)
+{
+    auto tids = parser.get<std::vector<int64_t>>("tids");
+    common::update_env(data.env.current, env::SAMPLING_TIDS,
+                       fmt::format("{}", fmt::join(tids, ", ")), update_mode::REPLACE,
+                       ":", data.env.updated, data.env.initial);
+}
+
+void
+consume_sample_args(parser_t& parser, parser_data& data, std::string_view flag_key,
+                    std::string_view enable_env, std::string_view first_env,
+                    std::string_view second_env, std::string_view tail_env,
+                    bool first_conflict_check = false)
+{
+    auto values = parser.get<std::deque<std::string>>(std::string{ flag_key });
+    common::update_env(data.env.current, enable_env, true, update_mode::REPLACE, ":",
+                       data.env.updated, data.env.initial);
+
+    if(!values.empty())
+    {
+        if(first_conflict_check && parser.exists("sampling-overflow-event") &&
+           values.front() != parser.get<std::string>("sampling-overflow-event"))
+        {
+            throw exception<std::runtime_error>(fmt::format(
+                "'--sample-overflow {} ...' conflicts with "
+                "'--sampling-overflow-event {}' option",
+                values.front(), parser.get<std::string>("sampling-overflow-event")));
+        }
+        common::update_env(data.env.current, first_env, values.front(),
+                           update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+        values.pop_front();
+    }
+    if(!values.empty())
+    {
+        common::update_env(data.env.current, second_env, values.front(),
+                           update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+        values.pop_front();
+    }
+    if(!values.empty())
+    {
+        common::update_env(data.env.current, tail_env,
+                           fmt::format("{}", fmt::join(values, ",")),
+                           update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+    }
+}
+
+void
+sample_cputime_action(parser_t& parser, parser_data& data)
+{
+    consume_sample_args(parser, data, "sample-cputime", env::SAMPLING_CPUTIME,
+                        env::SAMPLING_CPUTIME_FREQ, env::SAMPLING_CPUTIME_DELAY,
+                        env::SAMPLING_CPUTIME_TIDS);
+}
+
+void
+sample_realtime_action(parser_t& parser, parser_data& data)
+{
+    consume_sample_args(parser, data, "sample-realtime", env::SAMPLING_REALTIME,
+                        env::SAMPLING_REALTIME_FREQ, env::SAMPLING_REALTIME_DELAY,
+                        env::SAMPLING_REALTIME_TIDS);
+}
+
+void
+sample_overflow_action(parser_t& parser, parser_data& data)
+{
+    consume_sample_args(parser, data, "sample-overflow", env::SAMPLING_OVERFLOW,
+                        env::SAMPLING_OVERFLOW_EVENT, env::SAMPLING_OVERFLOW_FREQ,
+                        env::SAMPLING_OVERFLOW_TIDS, /*first_conflict_check=*/true);
+}
+
+void
+profile_format_action(parser_t& parser, parser_data& data)
+{
+    auto formats = parser.get<std::set<std::string>>("profile-format");
+    common::update_env(data.env.current, env::PROFILE, true, update_mode::REPLACE, ":",
+                       data.env.updated, data.env.initial);
+    if(formats.empty()) return;
+    common::update_env(data.env.current, env::TEXT_OUTPUT, formats.count("text") != 0,
+                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+    common::update_env(data.env.current, env::JSON_OUTPUT, formats.count("json") != 0,
+                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+    common::update_env(data.env.current, env::COUT_OUTPUT, formats.count("console") != 0,
+                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+}
+
+void
+profile_diff_action(parser_t& parser, parser_data& data)
+{
+    auto values = parser.get<std::vector<std::string>>("profile-diff");
+    common::update_env(data.env.current, env::DIFF_OUTPUT, true, update_mode::REPLACE,
+                       ":", data.env.updated, data.env.initial);
+    common::update_env(data.env.current, env::INPUT_PATH, values.at(0),
+                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+    if(values.size() > 1)
+        common::update_env(data.env.current, env::INPUT_PREFIX, values.at(1),
+                           update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+}
+
+const flag_group&
+make_tracing_group()
+{
+    static const flag_group group{
+        "TRACING OPTIONS",
+        "Specific options controlling tracing (i.e. deterministic measurements of "
+        "every event)",
+        {
+            flag_descriptor{
+                /* names    */ { "--trace-file" },
+                /* help     */
+                "Specify the trace output filename. Relative filepath "
+                "will be with respect to output path and output prefix.",
+                /* dtype    */ "filepath",
+                /* count    */ count_spec::exactly(1),
+                /* kind     */ value_kind::scalar,
+                /* join     */ join_with::none,
+                /* env_vars */ { env::PERFETTO_FILE },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "perfetto_file" },
+            },
+            flag_descriptor{
+                /* names    */ { "--trace-buffer-size" },
+                /* help     */ "Size limit for the trace output (in KB)",
+                /* dtype    */ "KB",
+                /* count    */ count_spec::exactly(1),
+                /* kind     */ value_kind::scalar_int,
+                /* join     */ join_with::none,
+                /* env_vars */ { env::PERFETTO_BUFFER_SIZE_KB },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "perfetto_buffer_size_kb" },
+            },
+            flag_descriptor{
+                /* names    */ { "--trace-fill-policy" },
+                /* help     */
+                "Policy for new data when the buffer size limit is "
+                "reached:\n"
+                "    %{INDENT}%- discard     : new data is ignored\n"
+                "    %{INDENT}%- ring_buffer : new data overwrites "
+                "oldest data",
+                /* dtype    */ "policy",
+                /* count    */ count_spec::exactly(1),
+                /* kind     */ value_kind::scalar,
+                /* join     */ join_with::none,
+                /* env_vars */ { env::PERFETTO_FILL_POLICY },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "perfetto_fill_policy" },
+                /* choices     */ { "discard", "ring_buffer" },
+            },
+            flag_descriptor{
+                /* names    */ { "--trace-wait" },
+                /* help     */
+                "Set the wait time (in seconds) before collecting trace "
+                "and/or profiling data(in seconds). By default, the "
+                "duration is in seconds of realtime but that can changed "
+                "via --trace-clock-id.",
+                /* dtype    */ "seconds",
+                /* count    */ count_spec::exactly(1),
+                /* kind     */ value_kind::scalar_double,
+                /* join     */ join_with::none,
+                /* env_vars */ { env::TRACE_DELAY },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ {},
+            },
+            flag_descriptor{
+                /* names    */ { "--trace-duration" },
+                /* help     */
+                "Set the duration of the trace and/or profile data "
+                "collection (in seconds). By default, the duration is in "
+                "seconds of realtime but that can changed via "
+                "--trace-clock-id.",
+                /* dtype    */ "seconds",
+                /* count    */ count_spec::exactly(1),
+                /* kind     */ value_kind::scalar_double,
+                /* join     */ join_with::none,
+                /* env_vars */ { env::TRACE_DURATION },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ {},
+            },
+            flag_descriptor{
+                /* names    */ { "--trace-periods" },
+                /* help     */
+                "More powerful version of specifying trace delay and/or "
+                "duration. Format is one or more groups of: "
+                "<DELAY>:<DURATION>, <DELAY>:<DURATION>:<REPEAT>, and/or "
+                "<DELAY>:<DURATION>:<REPEAT>:<CLOCK_ID>.",
+                /* dtype    */ "period-spec(s)",
+                /* count    */ count_spec::at_least(1),
+                /* kind     */ value_kind::list,
+                /* join     */ join_with::comma,
+                /* env_vars */ { env::TRACE_PERIODS },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ {},
+            },
+        },
+    };
+    return group;
+}
+
+const flag_group&
+make_profile_group()
+{
+    static const flag_group group{
+        "PROFILE OPTIONS",
+        "Specific options controlling profiling (i.e. deterministic measurements "
+        "which are aggregated into a summary)",
+        {
+            flag_descriptor{
+                /* names    */ { "--profile-format" },
+                /* help     */ "Data formats for profiling results",
+                /* dtype    */ "string",
+                /* count    */ count_spec::range(1, 3),
+                /* kind     */ value_kind::list,
+                /* join     */ join_with::none,
+                /* env_vars */ {},
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "text_output", "json_output", "cout_output" },
+                /* choices     */ { "text", "json", "console" },
+                /* conflicts   */ {},
+                /* requires_   */ { "profile|flat-profile" },
+                /* custom      */ &profile_format_action,
+            },
+            flag_descriptor{
+                /* names    */ { "--profile-diff" },
+                /* help     */
+                "Generate a diff output b/t the profile collected and "
+                "an existing profile from another run Accepts 1-2 "
+                "parameters corresponding to the input path and the "
+                "input prefix",
+                /* dtype    */ "path [prefix]",
+                /* count    */ count_spec::range(1, 2),
+                /* kind     */ value_kind::list,
+                /* join     */ join_with::none,
+                /* env_vars */ {},
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "diff_output", "input_path", "input_prefix" },
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ {},
+                /* custom      */ &profile_diff_action,
+            },
+        },
+    };
+    return group;
+}
+
+const flag_group&
+make_process_sampling_group()
+{
+    static const flag_group group{
+        "HOST/DEVICE (PROCESS SAMPLING) OPTIONS",
+        "Process sampling is background measurements for resources available to the "
+        "entire process. These samples are not tied to specific lines/regions of code",
+        {
+            flag_descriptor{
+                /* names    */ { "--process-freq" },
+                /* help     */
+                "Set the default host/device sampling frequency "
+                "(number of interrupts per second)",
+                /* dtype    */ "floating-point",
+                /* count    */ count_spec::exactly(1),
+                /* kind     */ value_kind::scalar_double,
+                /* join     */ join_with::none,
+                /* env_vars */ { env::PROCESS_SAMPLING_FREQ },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "process_sampling_freq" },
+            },
+            flag_descriptor{
+                /* names    */ { "--process-wait" },
+                /* help     */
+                "Set the default wait time (i.e. delay) before taking "
+                "first host/device sample (in seconds of realtime)",
+                /* dtype    */ "seconds",
+                /* count    */ count_spec::exactly(1),
+                /* kind     */ value_kind::scalar_double,
+                /* join     */ join_with::none,
+                /* env_vars */ { env::PROCESS_SAMPLING_DELAY },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "process_sampling_delay" },
+            },
+            flag_descriptor{
+                /* names    */ { "--process-duration" },
+                /* help     */
+                "Set the duration of the host/device sampling (in "
+                "seconds of realtime)",
+                /* dtype    */ "seconds",
+                /* count    */ count_spec::exactly(1),
+                /* kind     */ value_kind::scalar_double,
+                /* join     */ join_with::none,
+                /* env_vars */ { env::SAMPLING_PROCESS_DURATION },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "process_sampling_duration" },
+            },
+            flag_descriptor{
+                /* names    */ { "--cpus" },
+                /* help     */
+                "CPU IDs for frequency sampling. Supports integers "
+                "and/or ranges",
+                /* dtype    */ "int and/or range",
+                /* count    */ {},
+                /* kind     */ value_kind::list,
+                /* join     */ join_with::comma,
+                /* env_vars */ { env::SAMPLING_CPUS },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "sampling_cpus" },
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ { "host" },
+            },
+            flag_descriptor{
+                /* names    */ { "--gpus" },
+                /* help     */
+                "GPU IDs for SMI queries. Supports integers and/or "
+                "ranges",
+                /* dtype    */ "int and/or range",
+                /* count    */ {},
+                /* kind     */ value_kind::list,
+                /* join     */ join_with::comma,
+                /* env_vars */ { env::SAMPLING_GPUS },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "sampling_gpus" },
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ { "device" },
+            },
+            flag_descriptor{
+                /* names    */ { "--ai-nics" },
+                /* help     */
+                "AI NIC IDs for SMI queries. Supports comma-separated "
+                "list",
+                /* dtype    */ "list of strings",
+                /* count    */ {},
+                /* kind     */ value_kind::list,
+                /* join     */ join_with::comma,
+                /* env_vars */ { env::SAMPLING_AINICS },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "sampling_ai-nics" },
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ { "device" },
+            },
+        },
+    };
+    return group;
+}
+
+const flag_group&
+make_general_sampling_group()
+{
+    static const flag_group group{
+        "GENERAL SAMPLING OPTIONS",
+        "General options for timer-based sampling per-thread",
+        {
+            flag_descriptor{
+                /* names    */ { "-f", "--sampling-freq" },
+                /* help     */
+                "Set the default sampling frequency "
+                "(number of interrupts per second)",
+                /* dtype    */ "floating-point",
+                /* count    */ count_spec::exactly(1),
+                /* kind     */ value_kind::scalar_double,
+                /* join     */ join_with::none,
+                /* env_vars */ { env::SAMPLING_FREQ },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ {},
+            },
+            flag_descriptor{
+                /* names    */ { "-t", "--tids" },
+                /* help     */
+                "Specify the default thread IDs for sampling, where 0 "
+                "(zero) is the main thread and each thread created by "
+                "the target application is assigned an atomically "
+                "incrementing value.",
+                /* dtype    */ "int and/or range",
+                /* count    */ count_spec::at_least(1),
+                /* kind     */ value_kind::list,
+                /* join     */ join_with::none,
+                /* env_vars */ {},
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "sampling_tids" },
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ {},
+                /* custom      */ &tids_action,
+            },
+            flag_descriptor{
+                /* names    */ { "--sampling-wait" },
+                /* help     */
+                "Set the default wait time (i.e. delay) before taking "
+                "first sample (in seconds). This delay time is based "
+                "on the clock of the sampler, i.e., a delay of 1 "
+                "second for CPU-clock sampler may not equal 1 second "
+                "of realtime",
+                /* dtype    */ "seconds",
+                /* count    */ count_spec::exactly(1),
+                /* kind     */ value_kind::scalar_double,
+                /* join     */ join_with::none,
+                /* env_vars */ { env::SAMPLING_DELAY },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "sampling_delay" },
+            },
+            flag_descriptor{
+                /* names    */ { "--sampling-duration" },
+                /* help     */
+                "Set the duration of the sampling (in seconds of "
+                "realtime). I.e., it is possible (currently) to set a "
+                "CPU-clock time delay that exceeds the real-time "
+                "duration... resulting in zero samples being taken",
+                /* dtype    */ "seconds",
+                /* count    */ count_spec::exactly(1),
+                /* kind     */ value_kind::scalar_double,
+                /* join     */ join_with::none,
+                /* env_vars */ { env::SAMPLING_DURATION },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ {},
+            },
+        },
+    };
+    return group;
+}
+
+const flag_group&
+make_sampling_timer_group()
+{
+    static const flag_group group{
+        "SAMPLING TIMER OPTIONS",
+        "These options determine the heuristic for deciding when to take a sample",
+        {
+            flag_descriptor{
+                /* names    */ { "--sample-cputime" },
+                /* help     */ CPUTIME_HELP,
+                /* dtype    */ "[freq] [delay] [tids...]",
+                /* count    */ count_spec::at_least(0),
+                /* kind     */ value_kind::list,
+                /* join     */ join_with::none,
+                /* env_vars */ {},
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ {},
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ {},
+                /* custom      */ &sample_cputime_action,
+            },
+            flag_descriptor{
+                /* names    */ { "--sample-realtime" },
+                /* help     */ REALTIME_HELP,
+                /* dtype    */ "[freq] [delay] [tids...]",
+                /* count    */ count_spec::at_least(0),
+                /* kind     */ value_kind::list,
+                /* join     */ join_with::none,
+                /* env_vars */ {},
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ {},
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ {},
+                /* custom      */ &sample_realtime_action,
+            },
+            flag_descriptor{
+                /* names    */ { "--sample-overflow" },
+                /* help     */ OVERFLOW_HELP,
+                /* dtype    */ "[event] [freq] [tids...]",
+                /* count    */ count_spec::at_least(0),
+                /* kind     */ value_kind::list,
+                /* join     */ join_with::none,
+                /* env_vars */ {},
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ {},
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ {},
+                /* custom      */ &sample_overflow_action,
+            },
+        },
+    };
+    return group;
+}
+
+const flag_group&
+make_hw_counter_group()
+{
+    static const flag_group group{
+        "HARDWARE COUNTER OPTIONS",
+        "See also: rocprof-sys-avail -H",
+        {
+            flag_descriptor{
+                /* names    */ { "-C", "--cpu-events" },
+                /* help     */
+                "Set the CPU hardware counter events to record (ref: "
+                "`rocprof-sys-avail -H -c CPU`)",
+                /* dtype    */ "[EVENT ...]",
+                /* count    */ count_spec::at_least(1),
+                /* kind     */ value_kind::list,
+                /* join     */ join_with::comma,
+                /* env_vars */ { env::PAPI_EVENTS },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "papi_events" },
+            },
+            flag_descriptor{
+                /* names    */ { "-G", "--gpu-events" },
+                /* help     */
+                "Set the GPU hardware counter events to record (ref: "
+                "`rocprof-sys-avail -H -c GPU`)",
+                /* dtype    */ "[EVENT ...]",
+                /* count    */ count_spec::at_least(1),
+                /* kind     */ value_kind::list,
+                /* join     */ join_with::comma,
+                /* env_vars */ { env::ROCM_EVENTS },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "rocm_events" },
+            },
+        },
+    };
+    return group;
+}
+
+const flag_group&
+make_misc_group()
+{
+    static const flag_group group{
+        "MISCELLANEOUS OPTIONS",
+        "",
+        {
+            flag_descriptor{
+                /* names    */ { "-i", "--inlines" },
+                /* help     */ "Include inline info in output when available",
+                /* dtype    */ {},
+                /* count    */ count_spec::at_most(1),
+                /* kind     */ value_kind::flag,
+                /* join     */ join_with::none,
+                /* env_vars */ { env::SAMPLING_INCLUDE_INLINES },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "sampling_include_inlines" },
+            },
+            flag_descriptor{
+                /* names    */ { "--hsa-interrupt" },
+                /* help     */ HSA_INTERRUPT_HELP,
+                /* dtype    */ "int",
+                /* count    */ count_spec::exactly(1),
+                /* kind     */ value_kind::scalar_int,
+                /* join     */ join_with::none,
+                /* env_vars */ { "HSA_ENABLE_INTERRUPT" },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ {},
+                /* choices     */ { "0", "1" },
+            },
+        },
+    };
+    return group;
+}
+
+const flag_group&
+make_general_group()
+{
+    static const flag_group group{
+        "GENERAL OPTIONS",
+        "These are options which are ubiquitously applied",
+        {
+            flag_descriptor{
+                /* names       */ { "-c", "--config" },
+                /* help        */ "Configuration file",
+                /* dtype       */ "filepath",
+                /* count       */ count_spec::at_least(1),
+                /* kind        */ value_kind::list,
+                /* join        */ join_with::colon,
+                /* env_vars    */ { env::CONFIG_FILE },
+                /* mode        */ update_mode::REPLACE,
+                /* aliased_env */ { "config_file" },
+            },
+            flag_descriptor{
+                /* names    */ { "-o", "--output" },
+                /* help     */
+                "Output path. Accepts 1-2 parameters corresponding to "
+                "the output path and the output prefix",
+                /* dtype    */ "path [prefix]",
+                /* count    */ count_spec::range(1, 2),
+                /* kind     */ value_kind::list,
+                /* join     */ join_with::none,
+                /* env_vars */ {},
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "output_path", "output_prefix" },
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ {},
+                /* custom      */ &output_action,
+            },
+            flag_descriptor{
+                /* names       */ { "-T", "--trace" },
+                /* help        */ "Generate a detailed trace (perfetto output)",
+                /* dtype       */ {},
+                /* count       */ count_spec::at_most(1),
+                /* kind        */ value_kind::flag,
+                /* join        */ join_with::none,
+                /* env_vars    */ { env::TRACE },
+                /* mode        */ update_mode::REPLACE,
+                /* aliased_env */ {},
+            },
+            flag_descriptor{
+                /* names       */ { "-L", "--trace-legacy" },
+                /* help        */
+                "Use legacy direct mode for tracing instead of "
+                "deferred trace generation (higher overhead)",
+                /* dtype       */ {},
+                /* count       */ count_spec::at_most(1),
+                /* kind        */ value_kind::flag,
+                /* join        */ join_with::none,
+                /* env_vars    */ { env::TRACE_LEGACY },
+                /* mode        */ update_mode::REPLACE,
+                /* aliased_env */ {},
+            },
+            flag_descriptor{
+                /* names       */ { "-P", "--profile" },
+                /* help        */
+                "Generate a call-stack-based profile (conflicts "
+                "with --flat-profile)",
+                /* dtype       */ {},
+                /* count       */ count_spec::at_most(1),
+                /* kind        */ value_kind::flag,
+                /* join        */ join_with::none,
+                /* env_vars    */ { env::PROFILE },
+                /* mode        */ update_mode::REPLACE,
+                /* aliased_env */ {},
+                /* choices     */ {},
+                /* conflicts   */ { "flat-profile" },
+            },
+            flag_descriptor{
+                /* names       */ { "-F", "--flat-profile" },
+                /* help        */ "Generate a flat profile (conflicts with --profile)",
+                /* dtype       */ {},
+                /* count       */ count_spec::at_most(1),
+                /* kind        */ value_kind::flag,
+                /* join        */ join_with::none,
+                /* env_vars    */ { env::PROFILE, env::FLAT_PROFILE },
+                /* mode        */ update_mode::REPLACE,
+                /* aliased_env */ {},
+                /* choices     */ {},
+                /* conflicts   */ { "profile" },
+            },
+            flag_descriptor{
+                /* names    */ { "-S", "--sample" },
+                /* help     */ "Enable statistical sampling of call-stack",
+                /* dtype    */ "timer-type",
+                /* count    */ count_spec::range(0, 2),
+                /* kind     */ value_kind::list,
+                /* join     */ join_with::none,
+                /* env_vars */ {},
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "cpu_freq" },
+                /* choices     */ { "cputime", "realtime" },
+                /* conflicts   */ {},
+                /* requires_   */ {},
+                /* custom      */ &sample_action,
+            },
+            flag_descriptor{
+                /* names    */ { "-H", "--host" },
+                /* help     */
+                "Enable sampling host-based metrics for the process. "
+                "E.g. CPU frequency, memory usage, etc.",
+                /* dtype    */ {},
+                /* count    */ count_spec::at_most(1),
+                /* kind     */ value_kind::flag,
+                /* join     */ join_with::none,
+                /* env_vars */ {},
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "cpu_freq" },
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ {},
+                /* custom      */ &host_action,
+            },
+            flag_descriptor{
+                /* names    */ { "-D", "--device" },
+                /* help     */
+                "Enable sampling device-based metrics for the "
+                "process. E.g. GPU temperature, memory usage, etc.",
+                /* dtype    */ {},
+                /* count    */ count_spec::at_most(1),
+                /* kind     */ value_kind::flag,
+                /* join     */ join_with::none,
+                /* env_vars */ {},
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ { "amd_smi" },
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ {},
+                /* custom      */ &device_action,
+            },
+            flag_descriptor{
+                /* names    */ { "-w", "--wait" },
+                /* help     */
+                "This option is a combination of '--trace-wait' and "
+                "'--sampling-wait'. See the descriptions for those "
+                "two options.",
+                /* dtype    */ "seconds",
+                /* count    */ count_spec::exactly(1),
+                /* kind     */ value_kind::scalar_double,
+                /* join     */ join_with::none,
+                /* env_vars */
+                { env::TRACE_DELAY, env::SAMPLING_DELAY, env::CAUSAL_DELAY },
+                /* mode     */ update_mode::WEAK,
+                /* aliased_env */ {},
+            },
+            flag_descriptor{
+                /* names    */ { "-d", "--duration" },
+                /* help     */
+                "This option is a combination of '--trace-duration' "
+                "and '--sampling-duration'. See the descriptions for "
+                "those two options.",
+                /* dtype    */ "seconds",
+                /* count    */ count_spec::exactly(1),
+                /* kind     */ value_kind::scalar_double,
+                /* join     */ join_with::none,
+                /* env_vars */
+                { env::TRACE_DURATION, env::SAMPLING_DURATION, env::CAUSAL_DURATION },
+                /* mode     */ update_mode::WEAK,
+                /* aliased_env */ {},
+            },
+            flag_descriptor{
+                /* names    */ { "--periods" },
+                /* help     */
+                "Similar to specifying delay and/or duration except "
+                "in the form <DELAY>:<DURATION>, "
+                "<DELAY>:<DURATION>:<REPEAT>, and/or "
+                "<DELAY>:<DURATION>:<REPEAT>:<CLOCK_ID>",
+                /* dtype    */ "period-spec(s)",
+                /* count    */ count_spec::at_least(1),
+                /* kind     */ value_kind::list,
+                /* join     */ join_with::space,
+                /* env_vars */ { env::TRACE_PERIODS },
+                /* mode     */ update_mode::WEAK,
+                /* aliased_env */ {},
+            },
+            flag_descriptor{
+                /* names    */ { "--selected-regions" },
+                /* help     */
+                "Comma-separated list of roctx region names. When "
+                "set, only activity inside matching roctx regions is "
+                "traced (matched against roctxRangeStartA message)",
+                /* dtype    */ "string",
+                /* count    */ count_spec::exactly(1),
+                /* kind     */ value_kind::scalar,
+                /* join     */ join_with::none,
+                /* env_vars */ { env::SELECTED_REGIONS },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ {},
+            },
+            flag_descriptor{
+                /* names    */ { "--rank-filter-id" },
+                /* help     */
+                "Sets the name of environment variable to read rank "
+                "from for MPI output filtering",
+                /* dtype    */ "string",
+                /* count    */ count_spec::at_most(1),
+                /* kind     */ value_kind::scalar,
+                /* join     */ join_with::none,
+                /* env_vars */ { env::RANK_FILTER_ID },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ {},
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ { "rank-filter-output" },
+            },
+            flag_descriptor{
+                /* names    */ { "--rank-filter-output" },
+                /* help     */
+                "Ranks for which file output is generated. Values "
+                "should be separated by commas and can be explicit or "
+                "ranges, e.g. 0,1,5-8. An empty value enables output "
+                "for all ranks",
+                /* dtype    */ "int and/or range",
+                /* count    */ count_spec::at_most(1),
+                /* kind     */ value_kind::list,
+                /* join     */ join_with::comma,
+                /* env_vars */ { env::RANK_FILTER_OUTPUT },
+                /* mode     */ update_mode::REPLACE,
+                /* aliased_env */ {},
+            },
+        },
+    };
+    return group;
+}
+}  // namespace
+
+const flag_group&
+debug_group()
+{
+    return make_debug_group();
+}
+
+const flag_group&
+general_group()
+{
+    return make_general_group();
+}
+
+const flag_group&
+tracing_group()
+{
+    return make_tracing_group();
+}
+
+const flag_group&
+profile_group()
+{
+    return make_profile_group();
+}
+
+const flag_group&
+process_sampling_group()
+{
+    return make_process_sampling_group();
+}
+
+const flag_group&
+general_sampling_group()
+{
+    return make_general_sampling_group();
+}
+
+const flag_group&
+sampling_timer_group()
+{
+    return make_sampling_timer_group();
+}
+
+const flag_group&
+hw_counter_group()
+{
+    return make_hw_counter_group();
+}
+
+const flag_group&
+misc_group()
+{
+    return make_misc_group();
+}
+
+}  // namespace argparse
+}  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/argparse/core_flags.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/core_flags.cpp
@@ -60,6 +60,9 @@ constexpr std::string_view OVERFLOW_HELP =
     %{INDENT}%   May be specified as index or range, e.g., '0 2-4' will be interpreted as:
     %{INDENT}%      sample the main thread (0), do not sample the first child thread but sample the 2nd, 3rd, and 4th child threads)";
 
+constexpr std::string_view LAUNCHER_HELP =
+    R"(When running MPI jobs, typically the associated '--' for this executable should be right before the target executable, e.g. `mpirun -n 2 <THIS_EXE> -- <TARGET_EXE> <TARGET_EXE_ARGS...>`. This options enables prefixing the entire command (i.e. before `mpirun`, `srun`, etc.). Pass the name of the target executable (or a regex for matching to the name of the target) as the argument to this option and this executable will insert itself a second time in the appropriate location, e.g. `<THIS_EXE> --launcher sleep -- mpirun -n 2 sleep 10` is equivalent to `mpirun -n 2 <THIS_EXE> -- sleep 10`)";
+
 constexpr std::string_view HSA_INTERRUPT_HELP =
     R"(Set the value of the HSA_ENABLE_INTERRUPT environment variable.
 %{INDENT}%  ROCm version 5.2 and older have a bug which will cause a deadlock if a sample is taken while waiting for the signal
@@ -249,6 +252,12 @@ profile_diff_action(parsed_values& values, parser_data& data)
     data.env.set(env::DIFF_OUTPUT, true);
     data.env.set(env::INPUT_PATH, paths.at(0));
     if(paths.size() > 1) data.env.set(env::INPUT_PREFIX, paths.at(1));
+}
+
+void
+launcher_action(parsed_values& values, parser_data& data)
+{
+    data.out.launcher = values.get<std::string>("launcher");
 }
 
 }  // namespace
@@ -540,6 +549,33 @@ general_group()
                 /* kind        */ value_kind::list,
                 /* join        */ join_with::comma,
                 /* env_vars    */ { env::RANK_FILTER_OUTPUT },
+            },
+        },
+    };
+    return group;
+}
+
+const flag_group&
+launcher_group()
+{
+    static const flag_group group{
+        "LAUNCHER OPTIONS",
+        "",
+        {
+            flag_descriptor{
+                /* names       */ { "-l", "--launcher" },
+                /* help        */ LAUNCHER_HELP,
+                /* dtype       */ "target-exe",
+                /* count       */ count_spec::exactly(1),
+                /* kind        */ value_kind::scalar,
+                /* join        */ join_with::none,
+                /* env_vars    */ {},
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ {},
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ {},
+                /* custom      */ &launcher_action,
             },
         },
     };

--- a/projects/rocprofiler-systems/source/lib/core/argparse/core_flags.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/core_flags.cpp
@@ -73,11 +73,11 @@ constexpr std::string_view HSA_INTERRUPT_HELP =
 // --- Custom actions: flags whose behavior cannot be expressed as pure data ---
 
 void
-monochrome_action(parser_t& parser, parser_data& data)
+monochrome_action(parsed_values& values, parser_data& data)
 {
-    auto enabled        = parser.get<bool>("monochrome");
+    auto enabled        = values.get<bool>("monochrome");
     data.out.monochrome = enabled;
-    parser.set_use_color(!enabled);
+    values.set_use_color(!enabled);
     data.env.set(env::MONOCHROME, enabled ? "1" : "0");
     // Bare MONOCHROME (non-ROCPROFSYS_) is consumed by other tools; intentionally
     // not in env_vars.hpp because it isn't part of our prefixed namespace.
@@ -85,15 +85,15 @@ monochrome_action(parser_t& parser, parser_data& data)
 }
 
 void
-debug_action(parser_t& /*parser*/, parser_data& data)
+debug_action(parsed_values& /*values*/, parser_data& data)
 {
     data.env.set(env::LOG_LEVEL, "debug");
 }
 
 void
-verbose_action(parser_t& parser, parser_data& data)
+verbose_action(parsed_values& values, parser_data& data)
 {
-    auto level       = parser.get<int>("verbose");
+    auto level       = values.get<int>("verbose");
     data.out.verbose = level;
     data.env.set(env::VERBOSE_OUTPUT, level);
     constexpr std::array<const char*, 5> log_levels = { "off", "info", "debug", "debug",
@@ -103,18 +103,18 @@ verbose_action(parser_t& parser, parser_data& data)
 }
 
 void
-output_action(parser_t& parser, parser_data& data)
+output_action(parsed_values& values, parser_data& data)
 {
-    auto values = parser.get<std::vector<std::string>>("output");
-    data.env.set(env::OUTPUT_PATH, values.at(0));
-    if(values.size() > 1) data.env.set(env::OUTPUT_PREFIX, values.at(1));
+    auto output = values.get<std::vector<std::string>>("output");
+    data.env.set(env::OUTPUT_PATH, output.at(0));
+    if(output.size() > 1) data.env.set(env::OUTPUT_PREFIX, output.at(1));
 }
 
 void
-sample_action(parser_t& parser, parser_data& data)
+sample_action(parsed_values& values, parser_data& data)
 {
     data.env.set(env::USE_SAMPLING, true);
-    auto modes = parser.get<std::set<std::string>>("sample");
+    auto modes = values.get<std::set<std::string>>("sample");
     if(modes.empty()) return;
     data.env.set(env::SAMPLING_CPUTIME, modes.count("cputime") > 0, update_mode::WEAK);
     data.env.set(env::SAMPLING_REALTIME, modes.count("realtime") > 0, update_mode::WEAK);
@@ -141,25 +141,25 @@ apply_host_device(parser_data& data, bool host_enabled, bool device_enabled,
 }
 
 void
-host_action(parser_t& parser, parser_data& data)
+host_action(parsed_values& values, parser_data& data)
 {
-    apply_host_device(data, parser.get<bool>("host"), parser.get<bool>("device"),
+    apply_host_device(data, values.get<bool>("host"), values.get<bool>("device"),
                       /*driving_flag_is_host=*/true);
 }
 
 void
-device_action(parser_t& parser, parser_data& data)
+device_action(parsed_values& values, parser_data& data)
 {
-    apply_host_device(data, parser.get<bool>("host"), parser.get<bool>("device"),
+    apply_host_device(data, values.get<bool>("host"), values.get<bool>("device"),
                       /*driving_flag_is_host=*/false);
 }
 
 void
-tids_action(parser_t& parser, parser_data& data)
+tids_action(parsed_values& values, parser_data& data)
 {
     // Comma-space joiner is intentional and matches legacy behavior;
     // `--sample-cputime`/`--sample-realtime`/`--sample-overflow` use comma-only.
-    auto tids = parser.get<std::vector<int64_t>>("tids");
+    auto tids = values.get<std::vector<int64_t>>("tids");
     data.env.set(env::SAMPLING_TIDS, fmt::format("{}", fmt::join(tids, ", ")));
 }
 
@@ -174,56 +174,57 @@ struct sample_consume_spec
 };
 
 void
-consume_sample_args(parser_t& parser, parser_data& data, const sample_consume_spec& spec)
+consume_sample_args(parsed_values& values, parser_data& data,
+                    const sample_consume_spec& spec)
 {
-    auto values = parser.get<std::deque<std::string>>(std::string{ spec.flag_key });
+    auto args = values.get<std::deque<std::string>>(spec.flag_key);
     data.env.set(spec.enable_env, true);
 
-    if(!values.empty())
+    if(!args.empty())
     {
         if(spec.check_overflow_event_conflict &&
-           parser.exists("sampling-overflow-event") &&
-           values.front() != parser.get<std::string>("sampling-overflow-event"))
+           values.exists("sampling-overflow-event") &&
+           args.front() != values.get<std::string>("sampling-overflow-event"))
         {
             throw exception<std::runtime_error>(fmt::format(
                 "'--sample-overflow {} ...' conflicts with "
                 "'--sampling-overflow-event {}' option",
-                values.front(), parser.get<std::string>("sampling-overflow-event")));
+                args.front(), values.get<std::string>("sampling-overflow-event")));
         }
-        data.env.set(spec.first_env, values.front());
-        values.pop_front();
+        data.env.set(spec.first_env, args.front());
+        args.pop_front();
     }
-    if(!values.empty())
+    if(!args.empty())
     {
-        data.env.set(spec.second_env, values.front());
-        values.pop_front();
+        data.env.set(spec.second_env, args.front());
+        args.pop_front();
     }
-    if(!values.empty())
-        data.env.set(spec.tail_env, fmt::format("{}", fmt::join(values, ",")));
+    if(!args.empty())
+        data.env.set(spec.tail_env, fmt::format("{}", fmt::join(args, ",")));
 }
 
 void
-sample_cputime_action(parser_t& parser, parser_data& data)
+sample_cputime_action(parsed_values& values, parser_data& data)
 {
-    consume_sample_args(parser, data,
+    consume_sample_args(values, data,
                         { "sample-cputime", env::SAMPLING_CPUTIME,
                           env::SAMPLING_CPUTIME_FREQ, env::SAMPLING_CPUTIME_DELAY,
                           env::SAMPLING_CPUTIME_TIDS });
 }
 
 void
-sample_realtime_action(parser_t& parser, parser_data& data)
+sample_realtime_action(parsed_values& values, parser_data& data)
 {
-    consume_sample_args(parser, data,
+    consume_sample_args(values, data,
                         { "sample-realtime", env::SAMPLING_REALTIME,
                           env::SAMPLING_REALTIME_FREQ, env::SAMPLING_REALTIME_DELAY,
                           env::SAMPLING_REALTIME_TIDS });
 }
 
 void
-sample_overflow_action(parser_t& parser, parser_data& data)
+sample_overflow_action(parsed_values& values, parser_data& data)
 {
-    consume_sample_args(parser, data,
+    consume_sample_args(values, data,
                         { "sample-overflow", env::SAMPLING_OVERFLOW,
                           env::SAMPLING_OVERFLOW_EVENT, env::SAMPLING_OVERFLOW_FREQ,
                           env::SAMPLING_OVERFLOW_TIDS,
@@ -231,9 +232,9 @@ sample_overflow_action(parser_t& parser, parser_data& data)
 }
 
 void
-profile_format_action(parser_t& parser, parser_data& data)
+profile_format_action(parsed_values& values, parser_data& data)
 {
-    auto formats = parser.get<std::set<std::string>>("profile-format");
+    auto formats = values.get<std::set<std::string>>("profile-format");
     data.env.set(env::PROFILE, true);
     if(formats.empty()) return;
     data.env.set(env::TEXT_OUTPUT, formats.count("text") != 0);
@@ -242,12 +243,12 @@ profile_format_action(parser_t& parser, parser_data& data)
 }
 
 void
-profile_diff_action(parser_t& parser, parser_data& data)
+profile_diff_action(parsed_values& values, parser_data& data)
 {
-    auto values = parser.get<std::vector<std::string>>("profile-diff");
+    auto paths = values.get<std::vector<std::string>>("profile-diff");
     data.env.set(env::DIFF_OUTPUT, true);
-    data.env.set(env::INPUT_PATH, values.at(0));
-    if(values.size() > 1) data.env.set(env::INPUT_PREFIX, values.at(1));
+    data.env.set(env::INPUT_PATH, paths.at(0));
+    if(paths.size() > 1) data.env.set(env::INPUT_PREFIX, paths.at(1));
 }
 
 }  // namespace

--- a/projects/rocprofiler-systems/source/lib/core/argparse/core_flags.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/core_flags.cpp
@@ -25,6 +25,9 @@ namespace
 namespace env = rocprofsys::env_vars;
 using common::update_mode;
 
+// --- Help text (each used exactly once; kept inline to avoid spreading a
+//     descriptor's literal data across two files) ---
+
 constexpr std::string_view CPUTIME_HELP =
     R"(Sample based on a CPU-clock timer (default). Accepts zero or more arguments:
     %{INDENT}%0. Enables sampling based on CPU-clock timer.
@@ -59,11 +62,13 @@ constexpr std::string_view HSA_INTERRUPT_HELP =
     R"(Set the value of the HSA_ENABLE_INTERRUPT environment variable.
 %{INDENT}%  ROCm version 5.2 and older have a bug which will cause a deadlock if a sample is taken while waiting for the signal
 %{INDENT}%  that a kernel completed -- which happens when sampling with a real-clock timer. We require this option to be set to
-%{INDENT}%  when --realtime is specified to make users aware that, while this may fix the bug, it can have a negative impact on
+%{INDENT}%  when --sample-realtime is specified to make users aware that, while this may fix the bug, it can have a negative impact on
 %{INDENT}%  performance.
 %{INDENT}%  Values:
 %{INDENT}%    0     avoid triggering the bug, potentially at the cost of reduced performance
 %{INDENT}%    1     do not modify how ROCm is notified about kernel completion)";
+
+// --- Custom actions: flags whose behavior cannot be expressed as pure data ---
 
 void
 monochrome_action(parser_t& parser, parser_data& data)
@@ -71,17 +76,16 @@ monochrome_action(parser_t& parser, parser_data& data)
     auto enabled        = parser.get<bool>("monochrome");
     data.out.monochrome = enabled;
     parser.set_use_color(!enabled);
-    common::update_env(data.env.current, env::MONOCHROME, enabled ? "1" : "0",
-                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
-    common::update_env(data.env.current, "MONOCHROME", enabled ? "1" : "0",
-                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+    data.env.set(env::MONOCHROME, enabled ? "1" : "0");
+    // Bare MONOCHROME (non-ROCPROFSYS_) is consumed by other tools; intentionally
+    // not in env_vars.hpp because it isn't part of our prefixed namespace.
+    data.env.set("MONOCHROME", enabled ? "1" : "0");
 }
 
 void
 debug_action(parser_t& /*parser*/, parser_data& data)
 {
-    common::update_env(data.env.current, env::LOG_LEVEL, "debug", update_mode::REPLACE,
-                       ":", data.env.updated, data.env.initial);
+    data.env.set(env::LOG_LEVEL, "debug");
 }
 
 void
@@ -89,73 +93,168 @@ verbose_action(parser_t& parser, parser_data& data)
 {
     auto level       = parser.get<int>("verbose");
     data.out.verbose = level;
-    common::update_env(data.env.current, env::VERBOSE_OUTPUT, level, update_mode::REPLACE,
-                       ":", data.env.updated, data.env.initial);
+    data.env.set(env::VERBOSE_OUTPUT, level);
     constexpr std::array<const char*, 5> log_levels = { "off", "info", "debug", "debug",
                                                         "trace" };
     auto index = std::clamp(level + 1, 0, static_cast<int>(log_levels.size() - 1));
-    common::update_env(data.env.current, env::LOG_LEVEL, log_levels[index],
-                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+    data.env.set(env::LOG_LEVEL, log_levels[index]);
 }
 
 void
 output_action(parser_t& parser, parser_data& data)
 {
     auto values = parser.get<std::vector<std::string>>("output");
-    common::update_env(data.env.current, env::OUTPUT_PATH, values.at(0),
-                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
-    if(values.size() > 1)
-        common::update_env(data.env.current, env::OUTPUT_PREFIX, values.at(1),
-                           update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+    data.env.set(env::OUTPUT_PATH, values.at(0));
+    if(values.size() > 1) data.env.set(env::OUTPUT_PREFIX, values.at(1));
 }
 
 void
 sample_action(parser_t& parser, parser_data& data)
 {
-    common::update_env(data.env.current, env::USE_SAMPLING, true, update_mode::REPLACE,
-                       ":", data.env.updated, data.env.initial);
+    data.env.set(env::USE_SAMPLING, true);
     auto modes = parser.get<std::set<std::string>>("sample");
     if(modes.empty()) return;
-    common::update_env(data.env.current, env::SAMPLING_CPUTIME,
-                       modes.count("cputime") > 0, update_mode::WEAK, ":",
-                       data.env.updated, data.env.initial);
-    common::update_env(data.env.current, env::SAMPLING_REALTIME,
-                       modes.count("realtime") > 0, update_mode::WEAK, ":",
-                       data.env.updated, data.env.initial);
+    data.env.set(env::SAMPLING_CPUTIME, modes.count("cputime") > 0, update_mode::WEAK);
+    data.env.set(env::SAMPLING_REALTIME, modes.count("realtime") > 0, update_mode::WEAK);
+}
+
+// --host and --device share the same three writes but differ in which secondary
+// write is gated by the *primary* flag's enabled state. This asymmetry is
+// inherited from the legacy code; preserved here.
+void
+apply_host_device(parser_data& data, bool host_enabled, bool device_enabled,
+                  bool driving_flag_is_host)
+{
+    data.env.set(env::USE_PROCESS_SAMPLING, host_enabled || device_enabled);
+    if(driving_flag_is_host)
+    {
+        data.env.set(env::CPU_FREQ_ENABLED, host_enabled);
+        if(host_enabled) data.env.set(env::USE_AMD_SMI, device_enabled);
+    }
+    else
+    {
+        data.env.set(env::USE_AMD_SMI, device_enabled);
+        if(device_enabled) data.env.set(env::CPU_FREQ_ENABLED, host_enabled);
+    }
 }
 
 void
 host_action(parser_t& parser, parser_data& data)
 {
-    auto host_enabled   = parser.get<bool>("host");
-    auto device_enabled = parser.get<bool>("device");
-    common::update_env(data.env.current, env::USE_PROCESS_SAMPLING,
-                       host_enabled || device_enabled, update_mode::REPLACE, ":",
-                       data.env.updated, data.env.initial);
-    common::update_env(data.env.current, env::CPU_FREQ_ENABLED, host_enabled,
-                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
-    if(host_enabled)
-        common::update_env(data.env.current, env::USE_AMD_SMI, device_enabled,
-                           update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+    apply_host_device(data, parser.get<bool>("host"), parser.get<bool>("device"),
+                      /*driving_flag_is_host=*/true);
 }
 
 void
 device_action(parser_t& parser, parser_data& data)
 {
-    auto host_enabled   = parser.get<bool>("host");
-    auto device_enabled = parser.get<bool>("device");
-    common::update_env(data.env.current, env::USE_PROCESS_SAMPLING,
-                       host_enabled || device_enabled, update_mode::REPLACE, ":",
-                       data.env.updated, data.env.initial);
-    common::update_env(data.env.current, env::USE_AMD_SMI, device_enabled,
-                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
-    if(device_enabled)
-        common::update_env(data.env.current, env::CPU_FREQ_ENABLED, host_enabled,
-                           update_mode::REPLACE, ":", data.env.updated, data.env.initial);
+    apply_host_device(data, parser.get<bool>("host"), parser.get<bool>("device"),
+                      /*driving_flag_is_host=*/false);
 }
 
+void
+tids_action(parser_t& parser, parser_data& data)
+{
+    // Comma-space joiner is intentional and matches legacy behavior;
+    // `--sample-cputime`/`--sample-realtime`/`--sample-overflow` use comma-only.
+    auto tids = parser.get<std::vector<int64_t>>("tids");
+    data.env.set(env::SAMPLING_TIDS, fmt::format("{}", fmt::join(tids, ", ")));
+}
+
+struct sample_consume_spec
+{
+    std::string_view flag_key;
+    std::string_view enable_env;
+    std::string_view first_env;
+    std::string_view second_env;
+    std::string_view tail_env;
+    bool             check_overflow_event_conflict = false;
+};
+
+void
+consume_sample_args(parser_t& parser, parser_data& data, const sample_consume_spec& spec)
+{
+    auto values = parser.get<std::deque<std::string>>(std::string{ spec.flag_key });
+    data.env.set(spec.enable_env, true);
+
+    if(!values.empty())
+    {
+        if(spec.check_overflow_event_conflict &&
+           parser.exists("sampling-overflow-event") &&
+           values.front() != parser.get<std::string>("sampling-overflow-event"))
+        {
+            throw exception<std::runtime_error>(fmt::format(
+                "'--sample-overflow {} ...' conflicts with "
+                "'--sampling-overflow-event {}' option",
+                values.front(), parser.get<std::string>("sampling-overflow-event")));
+        }
+        data.env.set(spec.first_env, values.front());
+        values.pop_front();
+    }
+    if(!values.empty())
+    {
+        data.env.set(spec.second_env, values.front());
+        values.pop_front();
+    }
+    if(!values.empty())
+        data.env.set(spec.tail_env, fmt::format("{}", fmt::join(values, ",")));
+}
+
+void
+sample_cputime_action(parser_t& parser, parser_data& data)
+{
+    consume_sample_args(parser, data,
+                        { "sample-cputime", env::SAMPLING_CPUTIME,
+                          env::SAMPLING_CPUTIME_FREQ, env::SAMPLING_CPUTIME_DELAY,
+                          env::SAMPLING_CPUTIME_TIDS });
+}
+
+void
+sample_realtime_action(parser_t& parser, parser_data& data)
+{
+    consume_sample_args(parser, data,
+                        { "sample-realtime", env::SAMPLING_REALTIME,
+                          env::SAMPLING_REALTIME_FREQ, env::SAMPLING_REALTIME_DELAY,
+                          env::SAMPLING_REALTIME_TIDS });
+}
+
+void
+sample_overflow_action(parser_t& parser, parser_data& data)
+{
+    consume_sample_args(parser, data,
+                        { "sample-overflow", env::SAMPLING_OVERFLOW,
+                          env::SAMPLING_OVERFLOW_EVENT, env::SAMPLING_OVERFLOW_FREQ,
+                          env::SAMPLING_OVERFLOW_TIDS,
+                          /*check_overflow_event_conflict=*/true });
+}
+
+void
+profile_format_action(parser_t& parser, parser_data& data)
+{
+    auto formats = parser.get<std::set<std::string>>("profile-format");
+    data.env.set(env::PROFILE, true);
+    if(formats.empty()) return;
+    data.env.set(env::TEXT_OUTPUT, formats.count("text") != 0);
+    data.env.set(env::JSON_OUTPUT, formats.count("json") != 0);
+    data.env.set(env::COUT_OUTPUT, formats.count("console") != 0);
+}
+
+void
+profile_diff_action(parser_t& parser, parser_data& data)
+{
+    auto values = parser.get<std::vector<std::string>>("profile-diff");
+    data.env.set(env::DIFF_OUTPUT, true);
+    data.env.set(env::INPUT_PATH, values.at(0));
+    if(values.size() > 1) data.env.set(env::INPUT_PREFIX, values.at(1));
+}
+
+}  // namespace
+
+// --- Group definitions (positional aggregate init; will switch to designated
+//     initializers when project moves to C++20) ---
+
 const flag_group&
-make_debug_group()
+debug_group()
 {
     static const flag_group group{
         "DEBUG OPTIONS",
@@ -170,50 +269,50 @@ make_debug_group()
                 /* join        */ join_with::none,
                 /* env_vars    */ { env::LOG_LEVEL },
                 /* mode        */ update_mode::REPLACE,
-                /* aliased_env */ {},
+                /* dedup_keys  */ {},
                 /* choices     */
                 { "trace", "debug", "info", "warn", "error", "critical", "off" },
             },
             flag_descriptor{
-                /* names    */ { "--monochrome" },
-                /* help     */ "Disable colorized output",
-                /* dtype    */ "bool",
-                /* count    */ count_spec::at_most(1),
-                /* kind     */ value_kind::flag,
-                /* join     */ join_with::none,
-                /* env_vars */ {},
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ {},
+                /* names       */ { "--monochrome" },
+                /* help        */ "Disable colorized output",
+                /* dtype       */ "bool",
+                /* count       */ count_spec::at_most(1),
+                /* kind        */ value_kind::flag,
+                /* join        */ join_with::none,
+                /* env_vars    */ {},
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ {},
                 /* choices     */ {},
                 /* conflicts   */ {},
                 /* requires_   */ {},
                 /* custom      */ &monochrome_action,
             },
             flag_descriptor{
-                /* names    */ { "--debug" },
-                /* help     */ "[DEPRECATED Use --log-level=debug] Debug output",
-                /* dtype    */ {},
-                /* count    */ count_spec::at_most(1),
-                /* kind     */ value_kind::flag,
-                /* join     */ join_with::none,
-                /* env_vars */ {},
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ {},
+                /* names       */ { "--debug" },
+                /* help        */ "[DEPRECATED Use --log-level=debug] Debug output",
+                /* dtype       */ {},
+                /* count       */ count_spec::at_most(1),
+                /* kind        */ value_kind::flag,
+                /* join        */ join_with::none,
+                /* env_vars    */ {},
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ {},
                 /* choices     */ {},
                 /* conflicts   */ {},
                 /* requires_   */ {},
                 /* custom      */ &debug_action,
             },
             flag_descriptor{
-                /* names    */ { "-v", "--verbose" },
-                /* help     */ "[DEPRECATED Use --log-level=trace] Verbose output",
-                /* dtype    */ "integral",
-                /* count    */ count_spec::exactly(1),
-                /* kind     */ value_kind::scalar,
-                /* join     */ join_with::none,
-                /* env_vars */ {},
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ {},
+                /* names       */ { "-v", "--verbose" },
+                /* help        */ "[DEPRECATED Use --log-level=trace] Verbose output",
+                /* dtype       */ "integral",
+                /* count       */ count_spec::exactly(1),
+                /* kind        */ value_kind::scalar,
+                /* join        */ join_with::none,
+                /* env_vars    */ {},
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ {},
                 /* choices     */ {},
                 /* conflicts   */ {},
                 /* requires_   */ {},
@@ -224,558 +323,8 @@ make_debug_group()
     return group;
 }
 
-void
-tids_action(parser_t& parser, parser_data& data)
-{
-    auto tids = parser.get<std::vector<int64_t>>("tids");
-    common::update_env(data.env.current, env::SAMPLING_TIDS,
-                       fmt::format("{}", fmt::join(tids, ", ")), update_mode::REPLACE,
-                       ":", data.env.updated, data.env.initial);
-}
-
-void
-consume_sample_args(parser_t& parser, parser_data& data, std::string_view flag_key,
-                    std::string_view enable_env, std::string_view first_env,
-                    std::string_view second_env, std::string_view tail_env,
-                    bool first_conflict_check = false)
-{
-    auto values = parser.get<std::deque<std::string>>(std::string{ flag_key });
-    common::update_env(data.env.current, enable_env, true, update_mode::REPLACE, ":",
-                       data.env.updated, data.env.initial);
-
-    if(!values.empty())
-    {
-        if(first_conflict_check && parser.exists("sampling-overflow-event") &&
-           values.front() != parser.get<std::string>("sampling-overflow-event"))
-        {
-            throw exception<std::runtime_error>(fmt::format(
-                "'--sample-overflow {} ...' conflicts with "
-                "'--sampling-overflow-event {}' option",
-                values.front(), parser.get<std::string>("sampling-overflow-event")));
-        }
-        common::update_env(data.env.current, first_env, values.front(),
-                           update_mode::REPLACE, ":", data.env.updated, data.env.initial);
-        values.pop_front();
-    }
-    if(!values.empty())
-    {
-        common::update_env(data.env.current, second_env, values.front(),
-                           update_mode::REPLACE, ":", data.env.updated, data.env.initial);
-        values.pop_front();
-    }
-    if(!values.empty())
-    {
-        common::update_env(data.env.current, tail_env,
-                           fmt::format("{}", fmt::join(values, ",")),
-                           update_mode::REPLACE, ":", data.env.updated, data.env.initial);
-    }
-}
-
-void
-sample_cputime_action(parser_t& parser, parser_data& data)
-{
-    consume_sample_args(parser, data, "sample-cputime", env::SAMPLING_CPUTIME,
-                        env::SAMPLING_CPUTIME_FREQ, env::SAMPLING_CPUTIME_DELAY,
-                        env::SAMPLING_CPUTIME_TIDS);
-}
-
-void
-sample_realtime_action(parser_t& parser, parser_data& data)
-{
-    consume_sample_args(parser, data, "sample-realtime", env::SAMPLING_REALTIME,
-                        env::SAMPLING_REALTIME_FREQ, env::SAMPLING_REALTIME_DELAY,
-                        env::SAMPLING_REALTIME_TIDS);
-}
-
-void
-sample_overflow_action(parser_t& parser, parser_data& data)
-{
-    consume_sample_args(parser, data, "sample-overflow", env::SAMPLING_OVERFLOW,
-                        env::SAMPLING_OVERFLOW_EVENT, env::SAMPLING_OVERFLOW_FREQ,
-                        env::SAMPLING_OVERFLOW_TIDS, /*first_conflict_check=*/true);
-}
-
-void
-profile_format_action(parser_t& parser, parser_data& data)
-{
-    auto formats = parser.get<std::set<std::string>>("profile-format");
-    common::update_env(data.env.current, env::PROFILE, true, update_mode::REPLACE, ":",
-                       data.env.updated, data.env.initial);
-    if(formats.empty()) return;
-    common::update_env(data.env.current, env::TEXT_OUTPUT, formats.count("text") != 0,
-                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
-    common::update_env(data.env.current, env::JSON_OUTPUT, formats.count("json") != 0,
-                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
-    common::update_env(data.env.current, env::COUT_OUTPUT, formats.count("console") != 0,
-                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
-}
-
-void
-profile_diff_action(parser_t& parser, parser_data& data)
-{
-    auto values = parser.get<std::vector<std::string>>("profile-diff");
-    common::update_env(data.env.current, env::DIFF_OUTPUT, true, update_mode::REPLACE,
-                       ":", data.env.updated, data.env.initial);
-    common::update_env(data.env.current, env::INPUT_PATH, values.at(0),
-                       update_mode::REPLACE, ":", data.env.updated, data.env.initial);
-    if(values.size() > 1)
-        common::update_env(data.env.current, env::INPUT_PREFIX, values.at(1),
-                           update_mode::REPLACE, ":", data.env.updated, data.env.initial);
-}
-
 const flag_group&
-make_tracing_group()
-{
-    static const flag_group group{
-        "TRACING OPTIONS",
-        "Specific options controlling tracing (i.e. deterministic measurements of "
-        "every event)",
-        {
-            flag_descriptor{
-                /* names    */ { "--trace-file" },
-                /* help     */
-                "Specify the trace output filename. Relative filepath "
-                "will be with respect to output path and output prefix.",
-                /* dtype    */ "filepath",
-                /* count    */ count_spec::exactly(1),
-                /* kind     */ value_kind::scalar,
-                /* join     */ join_with::none,
-                /* env_vars */ { env::PERFETTO_FILE },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "perfetto_file" },
-            },
-            flag_descriptor{
-                /* names    */ { "--trace-buffer-size" },
-                /* help     */ "Size limit for the trace output (in KB)",
-                /* dtype    */ "KB",
-                /* count    */ count_spec::exactly(1),
-                /* kind     */ value_kind::scalar_int,
-                /* join     */ join_with::none,
-                /* env_vars */ { env::PERFETTO_BUFFER_SIZE_KB },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "perfetto_buffer_size_kb" },
-            },
-            flag_descriptor{
-                /* names    */ { "--trace-fill-policy" },
-                /* help     */
-                "Policy for new data when the buffer size limit is "
-                "reached:\n"
-                "    %{INDENT}%- discard     : new data is ignored\n"
-                "    %{INDENT}%- ring_buffer : new data overwrites "
-                "oldest data",
-                /* dtype    */ "policy",
-                /* count    */ count_spec::exactly(1),
-                /* kind     */ value_kind::scalar,
-                /* join     */ join_with::none,
-                /* env_vars */ { env::PERFETTO_FILL_POLICY },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "perfetto_fill_policy" },
-                /* choices     */ { "discard", "ring_buffer" },
-            },
-            flag_descriptor{
-                /* names    */ { "--trace-wait" },
-                /* help     */
-                "Set the wait time (in seconds) before collecting trace "
-                "and/or profiling data(in seconds). By default, the "
-                "duration is in seconds of realtime but that can changed "
-                "via --trace-clock-id.",
-                /* dtype    */ "seconds",
-                /* count    */ count_spec::exactly(1),
-                /* kind     */ value_kind::scalar_double,
-                /* join     */ join_with::none,
-                /* env_vars */ { env::TRACE_DELAY },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ {},
-            },
-            flag_descriptor{
-                /* names    */ { "--trace-duration" },
-                /* help     */
-                "Set the duration of the trace and/or profile data "
-                "collection (in seconds). By default, the duration is in "
-                "seconds of realtime but that can changed via "
-                "--trace-clock-id.",
-                /* dtype    */ "seconds",
-                /* count    */ count_spec::exactly(1),
-                /* kind     */ value_kind::scalar_double,
-                /* join     */ join_with::none,
-                /* env_vars */ { env::TRACE_DURATION },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ {},
-            },
-            flag_descriptor{
-                /* names    */ { "--trace-periods" },
-                /* help     */
-                "More powerful version of specifying trace delay and/or "
-                "duration. Format is one or more groups of: "
-                "<DELAY>:<DURATION>, <DELAY>:<DURATION>:<REPEAT>, and/or "
-                "<DELAY>:<DURATION>:<REPEAT>:<CLOCK_ID>.",
-                /* dtype    */ "period-spec(s)",
-                /* count    */ count_spec::at_least(1),
-                /* kind     */ value_kind::list,
-                /* join     */ join_with::comma,
-                /* env_vars */ { env::TRACE_PERIODS },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ {},
-            },
-        },
-    };
-    return group;
-}
-
-const flag_group&
-make_profile_group()
-{
-    static const flag_group group{
-        "PROFILE OPTIONS",
-        "Specific options controlling profiling (i.e. deterministic measurements "
-        "which are aggregated into a summary)",
-        {
-            flag_descriptor{
-                /* names    */ { "--profile-format" },
-                /* help     */ "Data formats for profiling results",
-                /* dtype    */ "string",
-                /* count    */ count_spec::range(1, 3),
-                /* kind     */ value_kind::list,
-                /* join     */ join_with::none,
-                /* env_vars */ {},
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "text_output", "json_output", "cout_output" },
-                /* choices     */ { "text", "json", "console" },
-                /* conflicts   */ {},
-                /* requires_   */ { "profile|flat-profile" },
-                /* custom      */ &profile_format_action,
-            },
-            flag_descriptor{
-                /* names    */ { "--profile-diff" },
-                /* help     */
-                "Generate a diff output b/t the profile collected and "
-                "an existing profile from another run Accepts 1-2 "
-                "parameters corresponding to the input path and the "
-                "input prefix",
-                /* dtype    */ "path [prefix]",
-                /* count    */ count_spec::range(1, 2),
-                /* kind     */ value_kind::list,
-                /* join     */ join_with::none,
-                /* env_vars */ {},
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "diff_output", "input_path", "input_prefix" },
-                /* choices     */ {},
-                /* conflicts   */ {},
-                /* requires_   */ {},
-                /* custom      */ &profile_diff_action,
-            },
-        },
-    };
-    return group;
-}
-
-const flag_group&
-make_process_sampling_group()
-{
-    static const flag_group group{
-        "HOST/DEVICE (PROCESS SAMPLING) OPTIONS",
-        "Process sampling is background measurements for resources available to the "
-        "entire process. These samples are not tied to specific lines/regions of code",
-        {
-            flag_descriptor{
-                /* names    */ { "--process-freq" },
-                /* help     */
-                "Set the default host/device sampling frequency "
-                "(number of interrupts per second)",
-                /* dtype    */ "floating-point",
-                /* count    */ count_spec::exactly(1),
-                /* kind     */ value_kind::scalar_double,
-                /* join     */ join_with::none,
-                /* env_vars */ { env::PROCESS_SAMPLING_FREQ },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "process_sampling_freq" },
-            },
-            flag_descriptor{
-                /* names    */ { "--process-wait" },
-                /* help     */
-                "Set the default wait time (i.e. delay) before taking "
-                "first host/device sample (in seconds of realtime)",
-                /* dtype    */ "seconds",
-                /* count    */ count_spec::exactly(1),
-                /* kind     */ value_kind::scalar_double,
-                /* join     */ join_with::none,
-                /* env_vars */ { env::PROCESS_SAMPLING_DELAY },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "process_sampling_delay" },
-            },
-            flag_descriptor{
-                /* names    */ { "--process-duration" },
-                /* help     */
-                "Set the duration of the host/device sampling (in "
-                "seconds of realtime)",
-                /* dtype    */ "seconds",
-                /* count    */ count_spec::exactly(1),
-                /* kind     */ value_kind::scalar_double,
-                /* join     */ join_with::none,
-                /* env_vars */ { env::SAMPLING_PROCESS_DURATION },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "process_sampling_duration" },
-            },
-            flag_descriptor{
-                /* names    */ { "--cpus" },
-                /* help     */
-                "CPU IDs for frequency sampling. Supports integers "
-                "and/or ranges",
-                /* dtype    */ "int and/or range",
-                /* count    */ {},
-                /* kind     */ value_kind::list,
-                /* join     */ join_with::comma,
-                /* env_vars */ { env::SAMPLING_CPUS },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "sampling_cpus" },
-                /* choices     */ {},
-                /* conflicts   */ {},
-                /* requires_   */ { "host" },
-            },
-            flag_descriptor{
-                /* names    */ { "--gpus" },
-                /* help     */
-                "GPU IDs for SMI queries. Supports integers and/or "
-                "ranges",
-                /* dtype    */ "int and/or range",
-                /* count    */ {},
-                /* kind     */ value_kind::list,
-                /* join     */ join_with::comma,
-                /* env_vars */ { env::SAMPLING_GPUS },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "sampling_gpus" },
-                /* choices     */ {},
-                /* conflicts   */ {},
-                /* requires_   */ { "device" },
-            },
-            flag_descriptor{
-                /* names    */ { "--ai-nics" },
-                /* help     */
-                "AI NIC IDs for SMI queries. Supports comma-separated "
-                "list",
-                /* dtype    */ "list of strings",
-                /* count    */ {},
-                /* kind     */ value_kind::list,
-                /* join     */ join_with::comma,
-                /* env_vars */ { env::SAMPLING_AINICS },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "sampling_ai-nics" },
-                /* choices     */ {},
-                /* conflicts   */ {},
-                /* requires_   */ { "device" },
-            },
-        },
-    };
-    return group;
-}
-
-const flag_group&
-make_general_sampling_group()
-{
-    static const flag_group group{
-        "GENERAL SAMPLING OPTIONS",
-        "General options for timer-based sampling per-thread",
-        {
-            flag_descriptor{
-                /* names    */ { "-f", "--sampling-freq" },
-                /* help     */
-                "Set the default sampling frequency "
-                "(number of interrupts per second)",
-                /* dtype    */ "floating-point",
-                /* count    */ count_spec::exactly(1),
-                /* kind     */ value_kind::scalar_double,
-                /* join     */ join_with::none,
-                /* env_vars */ { env::SAMPLING_FREQ },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ {},
-            },
-            flag_descriptor{
-                /* names    */ { "-t", "--tids" },
-                /* help     */
-                "Specify the default thread IDs for sampling, where 0 "
-                "(zero) is the main thread and each thread created by "
-                "the target application is assigned an atomically "
-                "incrementing value.",
-                /* dtype    */ "int and/or range",
-                /* count    */ count_spec::at_least(1),
-                /* kind     */ value_kind::list,
-                /* join     */ join_with::none,
-                /* env_vars */ {},
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "sampling_tids" },
-                /* choices     */ {},
-                /* conflicts   */ {},
-                /* requires_   */ {},
-                /* custom      */ &tids_action,
-            },
-            flag_descriptor{
-                /* names    */ { "--sampling-wait" },
-                /* help     */
-                "Set the default wait time (i.e. delay) before taking "
-                "first sample (in seconds). This delay time is based "
-                "on the clock of the sampler, i.e., a delay of 1 "
-                "second for CPU-clock sampler may not equal 1 second "
-                "of realtime",
-                /* dtype    */ "seconds",
-                /* count    */ count_spec::exactly(1),
-                /* kind     */ value_kind::scalar_double,
-                /* join     */ join_with::none,
-                /* env_vars */ { env::SAMPLING_DELAY },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "sampling_delay" },
-            },
-            flag_descriptor{
-                /* names    */ { "--sampling-duration" },
-                /* help     */
-                "Set the duration of the sampling (in seconds of "
-                "realtime). I.e., it is possible (currently) to set a "
-                "CPU-clock time delay that exceeds the real-time "
-                "duration... resulting in zero samples being taken",
-                /* dtype    */ "seconds",
-                /* count    */ count_spec::exactly(1),
-                /* kind     */ value_kind::scalar_double,
-                /* join     */ join_with::none,
-                /* env_vars */ { env::SAMPLING_DURATION },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ {},
-            },
-        },
-    };
-    return group;
-}
-
-const flag_group&
-make_sampling_timer_group()
-{
-    static const flag_group group{
-        "SAMPLING TIMER OPTIONS",
-        "These options determine the heuristic for deciding when to take a sample",
-        {
-            flag_descriptor{
-                /* names    */ { "--sample-cputime" },
-                /* help     */ CPUTIME_HELP,
-                /* dtype    */ "[freq] [delay] [tids...]",
-                /* count    */ count_spec::at_least(0),
-                /* kind     */ value_kind::list,
-                /* join     */ join_with::none,
-                /* env_vars */ {},
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ {},
-                /* choices     */ {},
-                /* conflicts   */ {},
-                /* requires_   */ {},
-                /* custom      */ &sample_cputime_action,
-            },
-            flag_descriptor{
-                /* names    */ { "--sample-realtime" },
-                /* help     */ REALTIME_HELP,
-                /* dtype    */ "[freq] [delay] [tids...]",
-                /* count    */ count_spec::at_least(0),
-                /* kind     */ value_kind::list,
-                /* join     */ join_with::none,
-                /* env_vars */ {},
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ {},
-                /* choices     */ {},
-                /* conflicts   */ {},
-                /* requires_   */ {},
-                /* custom      */ &sample_realtime_action,
-            },
-            flag_descriptor{
-                /* names    */ { "--sample-overflow" },
-                /* help     */ OVERFLOW_HELP,
-                /* dtype    */ "[event] [freq] [tids...]",
-                /* count    */ count_spec::at_least(0),
-                /* kind     */ value_kind::list,
-                /* join     */ join_with::none,
-                /* env_vars */ {},
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ {},
-                /* choices     */ {},
-                /* conflicts   */ {},
-                /* requires_   */ {},
-                /* custom      */ &sample_overflow_action,
-            },
-        },
-    };
-    return group;
-}
-
-const flag_group&
-make_hw_counter_group()
-{
-    static const flag_group group{
-        "HARDWARE COUNTER OPTIONS",
-        "See also: rocprof-sys-avail -H",
-        {
-            flag_descriptor{
-                /* names    */ { "-C", "--cpu-events" },
-                /* help     */
-                "Set the CPU hardware counter events to record (ref: "
-                "`rocprof-sys-avail -H -c CPU`)",
-                /* dtype    */ "[EVENT ...]",
-                /* count    */ count_spec::at_least(1),
-                /* kind     */ value_kind::list,
-                /* join     */ join_with::comma,
-                /* env_vars */ { env::PAPI_EVENTS },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "papi_events" },
-            },
-            flag_descriptor{
-                /* names    */ { "-G", "--gpu-events" },
-                /* help     */
-                "Set the GPU hardware counter events to record (ref: "
-                "`rocprof-sys-avail -H -c GPU`)",
-                /* dtype    */ "[EVENT ...]",
-                /* count    */ count_spec::at_least(1),
-                /* kind     */ value_kind::list,
-                /* join     */ join_with::comma,
-                /* env_vars */ { env::ROCM_EVENTS },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "rocm_events" },
-            },
-        },
-    };
-    return group;
-}
-
-const flag_group&
-make_misc_group()
-{
-    static const flag_group group{
-        "MISCELLANEOUS OPTIONS",
-        "",
-        {
-            flag_descriptor{
-                /* names    */ { "-i", "--inlines" },
-                /* help     */ "Include inline info in output when available",
-                /* dtype    */ {},
-                /* count    */ count_spec::at_most(1),
-                /* kind     */ value_kind::flag,
-                /* join     */ join_with::none,
-                /* env_vars */ { env::SAMPLING_INCLUDE_INLINES },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "sampling_include_inlines" },
-            },
-            flag_descriptor{
-                /* names    */ { "--hsa-interrupt" },
-                /* help     */ HSA_INTERRUPT_HELP,
-                /* dtype    */ "int",
-                /* count    */ count_spec::exactly(1),
-                /* kind     */ value_kind::scalar_int,
-                /* join     */ join_with::none,
-                /* env_vars */ { "HSA_ENABLE_INTERRUPT" },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ {},
-                /* choices     */ { "0", "1" },
-            },
-        },
-    };
-    return group;
-}
-
-const flag_group&
-make_general_group()
+general_group()
 {
     static const flag_group group{
         "GENERAL OPTIONS",
@@ -790,20 +339,20 @@ make_general_group()
                 /* join        */ join_with::colon,
                 /* env_vars    */ { env::CONFIG_FILE },
                 /* mode        */ update_mode::REPLACE,
-                /* aliased_env */ { "config_file" },
+                /* dedup_keys  */ { "config_file" },
             },
             flag_descriptor{
-                /* names    */ { "-o", "--output" },
-                /* help     */
+                /* names       */ { "-o", "--output" },
+                /* help        */
                 "Output path. Accepts 1-2 parameters corresponding to "
                 "the output path and the output prefix",
-                /* dtype    */ "path [prefix]",
-                /* count    */ count_spec::range(1, 2),
-                /* kind     */ value_kind::list,
-                /* join     */ join_with::none,
-                /* env_vars */ {},
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "output_path", "output_prefix" },
+                /* dtype       */ "path [prefix]",
+                /* count       */ count_spec::range(1, 2),
+                /* kind        */ value_kind::list,
+                /* join        */ join_with::none,
+                /* env_vars    */ {},
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "output_path", "output_prefix" },
                 /* choices     */ {},
                 /* conflicts   */ {},
                 /* requires_   */ {},
@@ -817,8 +366,6 @@ make_general_group()
                 /* kind        */ value_kind::flag,
                 /* join        */ join_with::none,
                 /* env_vars    */ { env::TRACE },
-                /* mode        */ update_mode::REPLACE,
-                /* aliased_env */ {},
             },
             flag_descriptor{
                 /* names       */ { "-L", "--trace-legacy" },
@@ -830,8 +377,6 @@ make_general_group()
                 /* kind        */ value_kind::flag,
                 /* join        */ join_with::none,
                 /* env_vars    */ { env::TRACE_LEGACY },
-                /* mode        */ update_mode::REPLACE,
-                /* aliased_env */ {},
             },
             flag_descriptor{
                 /* names       */ { "-P", "--profile" },
@@ -844,7 +389,7 @@ make_general_group()
                 /* join        */ join_with::none,
                 /* env_vars    */ { env::PROFILE },
                 /* mode        */ update_mode::REPLACE,
-                /* aliased_env */ {},
+                /* dedup_keys  */ {},
                 /* choices     */ {},
                 /* conflicts   */ { "flat-profile" },
             },
@@ -857,207 +402,587 @@ make_general_group()
                 /* join        */ join_with::none,
                 /* env_vars    */ { env::PROFILE, env::FLAT_PROFILE },
                 /* mode        */ update_mode::REPLACE,
-                /* aliased_env */ {},
+                /* dedup_keys  */ {},
                 /* choices     */ {},
                 /* conflicts   */ { "profile" },
             },
             flag_descriptor{
-                /* names    */ { "-S", "--sample" },
-                /* help     */ "Enable statistical sampling of call-stack",
-                /* dtype    */ "timer-type",
-                /* count    */ count_spec::range(0, 2),
-                /* kind     */ value_kind::list,
-                /* join     */ join_with::none,
-                /* env_vars */ {},
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "cpu_freq" },
+                /* names       */ { "-S", "--sample" },
+                /* help        */ "Enable statistical sampling of call-stack",
+                /* dtype       */ "timer-type",
+                /* count       */ count_spec::range(0, 2),
+                /* kind        */ value_kind::list,
+                /* join        */ join_with::none,
+                /* env_vars    */ {},
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "cpu_freq" },
                 /* choices     */ { "cputime", "realtime" },
                 /* conflicts   */ {},
                 /* requires_   */ {},
                 /* custom      */ &sample_action,
             },
             flag_descriptor{
-                /* names    */ { "-H", "--host" },
-                /* help     */
+                /* names       */ { "-H", "--host" },
+                /* help        */
                 "Enable sampling host-based metrics for the process. "
                 "E.g. CPU frequency, memory usage, etc.",
-                /* dtype    */ {},
-                /* count    */ count_spec::at_most(1),
-                /* kind     */ value_kind::flag,
-                /* join     */ join_with::none,
-                /* env_vars */ {},
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "cpu_freq" },
+                /* dtype       */ {},
+                /* count       */ count_spec::at_most(1),
+                /* kind        */ value_kind::flag,
+                /* join        */ join_with::none,
+                /* env_vars    */ {},
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "cpu_freq" },
                 /* choices     */ {},
                 /* conflicts   */ {},
                 /* requires_   */ {},
                 /* custom      */ &host_action,
             },
             flag_descriptor{
-                /* names    */ { "-D", "--device" },
-                /* help     */
+                /* names       */ { "-D", "--device" },
+                /* help        */
                 "Enable sampling device-based metrics for the "
                 "process. E.g. GPU temperature, memory usage, etc.",
-                /* dtype    */ {},
-                /* count    */ count_spec::at_most(1),
-                /* kind     */ value_kind::flag,
-                /* join     */ join_with::none,
-                /* env_vars */ {},
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ { "amd_smi" },
+                /* dtype       */ {},
+                /* count       */ count_spec::at_most(1),
+                /* kind        */ value_kind::flag,
+                /* join        */ join_with::none,
+                /* env_vars    */ {},
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "amd_smi" },
                 /* choices     */ {},
                 /* conflicts   */ {},
                 /* requires_   */ {},
                 /* custom      */ &device_action,
             },
             flag_descriptor{
-                /* names    */ { "-w", "--wait" },
-                /* help     */
+                /* names       */ { "-w", "--wait" },
+                /* help        */
                 "This option is a combination of '--trace-wait' and "
                 "'--sampling-wait'. See the descriptions for those "
                 "two options.",
-                /* dtype    */ "seconds",
-                /* count    */ count_spec::exactly(1),
-                /* kind     */ value_kind::scalar_double,
-                /* join     */ join_with::none,
-                /* env_vars */
+                /* dtype       */ "seconds",
+                /* count       */ count_spec::exactly(1),
+                /* kind        */ value_kind::scalar_double,
+                /* join        */ join_with::none,
+                /* env_vars    */
                 { env::TRACE_DELAY, env::SAMPLING_DELAY, env::CAUSAL_DELAY },
-                /* mode     */ update_mode::WEAK,
-                /* aliased_env */ {},
+                /* mode        */ update_mode::WEAK,
             },
             flag_descriptor{
-                /* names    */ { "-d", "--duration" },
-                /* help     */
+                /* names       */ { "-d", "--duration" },
+                /* help        */
                 "This option is a combination of '--trace-duration' "
                 "and '--sampling-duration'. See the descriptions for "
                 "those two options.",
-                /* dtype    */ "seconds",
-                /* count    */ count_spec::exactly(1),
-                /* kind     */ value_kind::scalar_double,
-                /* join     */ join_with::none,
-                /* env_vars */
+                /* dtype       */ "seconds",
+                /* count       */ count_spec::exactly(1),
+                /* kind        */ value_kind::scalar_double,
+                /* join        */ join_with::none,
+                /* env_vars    */
                 { env::TRACE_DURATION, env::SAMPLING_DURATION, env::CAUSAL_DURATION },
-                /* mode     */ update_mode::WEAK,
-                /* aliased_env */ {},
+                /* mode        */ update_mode::WEAK,
             },
             flag_descriptor{
-                /* names    */ { "--periods" },
-                /* help     */
+                /* names       */ { "--periods" },
+                /* help        */
                 "Similar to specifying delay and/or duration except "
                 "in the form <DELAY>:<DURATION>, "
                 "<DELAY>:<DURATION>:<REPEAT>, and/or "
                 "<DELAY>:<DURATION>:<REPEAT>:<CLOCK_ID>",
-                /* dtype    */ "period-spec(s)",
-                /* count    */ count_spec::at_least(1),
-                /* kind     */ value_kind::list,
-                /* join     */ join_with::space,
-                /* env_vars */ { env::TRACE_PERIODS },
-                /* mode     */ update_mode::WEAK,
-                /* aliased_env */ {},
+                /* dtype       */ "period-spec(s)",
+                /* count       */ count_spec::at_least(1),
+                /* kind        */ value_kind::list,
+                /* join        */ join_with::space,
+                /* env_vars    */ { env::TRACE_PERIODS },
+                /* mode        */ update_mode::WEAK,
             },
             flag_descriptor{
-                /* names    */ { "--selected-regions" },
-                /* help     */
+                /* names       */ { "--selected-regions" },
+                /* help        */
                 "Comma-separated list of roctx region names. When "
                 "set, only activity inside matching roctx regions is "
                 "traced (matched against roctxRangeStartA message)",
-                /* dtype    */ "string",
-                /* count    */ count_spec::exactly(1),
-                /* kind     */ value_kind::scalar,
-                /* join     */ join_with::none,
-                /* env_vars */ { env::SELECTED_REGIONS },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ {},
+                /* dtype       */ "string",
+                /* count       */ count_spec::exactly(1),
+                /* kind        */ value_kind::scalar,
+                /* join        */ join_with::none,
+                /* env_vars    */ { env::SELECTED_REGIONS },
             },
             flag_descriptor{
-                /* names    */ { "--rank-filter-id" },
-                /* help     */
+                /* names       */ { "--rank-filter-id" },
+                /* help        */
                 "Sets the name of environment variable to read rank "
                 "from for MPI output filtering",
-                /* dtype    */ "string",
-                /* count    */ count_spec::at_most(1),
-                /* kind     */ value_kind::scalar,
-                /* join     */ join_with::none,
-                /* env_vars */ { env::RANK_FILTER_ID },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ {},
+                /* dtype       */ "string",
+                /* count       */ count_spec::at_most(1),
+                /* kind        */ value_kind::scalar,
+                /* join        */ join_with::none,
+                /* env_vars    */ { env::RANK_FILTER_ID },
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ {},
                 /* choices     */ {},
                 /* conflicts   */ {},
                 /* requires_   */ { "rank-filter-output" },
             },
             flag_descriptor{
-                /* names    */ { "--rank-filter-output" },
-                /* help     */
+                /* names       */ { "--rank-filter-output" },
+                /* help        */
                 "Ranks for which file output is generated. Values "
                 "should be separated by commas and can be explicit or "
                 "ranges, e.g. 0,1,5-8. An empty value enables output "
                 "for all ranks",
-                /* dtype    */ "int and/or range",
-                /* count    */ count_spec::at_most(1),
-                /* kind     */ value_kind::list,
-                /* join     */ join_with::comma,
-                /* env_vars */ { env::RANK_FILTER_OUTPUT },
-                /* mode     */ update_mode::REPLACE,
-                /* aliased_env */ {},
+                /* dtype       */ "int and/or range",
+                /* count       */ count_spec::at_most(1),
+                /* kind        */ value_kind::list,
+                /* join        */ join_with::comma,
+                /* env_vars    */ { env::RANK_FILTER_OUTPUT },
             },
         },
     };
     return group;
 }
-}  // namespace
-
-const flag_group&
-debug_group()
-{
-    return make_debug_group();
-}
-
-const flag_group&
-general_group()
-{
-    return make_general_group();
-}
 
 const flag_group&
 tracing_group()
 {
-    return make_tracing_group();
+    static const flag_group group{
+        "TRACING OPTIONS",
+        "Specific options controlling tracing (i.e. deterministic measurements of "
+        "every event)",
+        {
+            flag_descriptor{
+                /* names       */ { "--trace-file" },
+                /* help        */
+                "Specify the trace output filename. Relative filepath "
+                "will be with respect to output path and output prefix.",
+                /* dtype       */ "filepath",
+                /* count       */ count_spec::exactly(1),
+                /* kind        */ value_kind::scalar,
+                /* join        */ join_with::none,
+                /* env_vars    */ { env::PERFETTO_FILE },
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "perfetto_file" },
+            },
+            flag_descriptor{
+                /* names       */ { "--trace-buffer-size" },
+                /* help        */ "Size limit for the trace output (in KB)",
+                /* dtype       */ "KB",
+                /* count       */ count_spec::exactly(1),
+                /* kind        */ value_kind::scalar_int,
+                /* join        */ join_with::none,
+                /* env_vars    */ { env::PERFETTO_BUFFER_SIZE_KB },
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "perfetto_buffer_size_kb" },
+            },
+            flag_descriptor{
+                /* names       */ { "--trace-fill-policy" },
+                /* help        */
+                "Policy for new data when the buffer size limit is "
+                "reached:\n"
+                "    %{INDENT}%- discard     : new data is ignored\n"
+                "    %{INDENT}%- ring_buffer : new data overwrites "
+                "oldest data",
+                /* dtype       */ "policy",
+                /* count       */ count_spec::exactly(1),
+                /* kind        */ value_kind::scalar,
+                /* join        */ join_with::none,
+                /* env_vars    */ { env::PERFETTO_FILL_POLICY },
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "perfetto_fill_policy" },
+                /* choices     */ { "discard", "ring_buffer" },
+            },
+            flag_descriptor{
+                /* names       */ { "--trace-wait" },
+                /* help        */
+                "Set the wait time (in seconds) before collecting trace "
+                "and/or profiling data(in seconds). By default, the "
+                "duration is in seconds of realtime but that can changed "
+                "via --trace-clock-id.",
+                /* dtype       */ "seconds",
+                /* count       */ count_spec::exactly(1),
+                /* kind        */ value_kind::scalar_double,
+                /* join        */ join_with::none,
+                /* env_vars    */ { env::TRACE_DELAY },
+            },
+            flag_descriptor{
+                /* names       */ { "--trace-duration" },
+                /* help        */
+                "Set the duration of the trace and/or profile data "
+                "collection (in seconds). By default, the duration is in "
+                "seconds of realtime but that can changed via "
+                "--trace-clock-id.",
+                /* dtype       */ "seconds",
+                /* count       */ count_spec::exactly(1),
+                /* kind        */ value_kind::scalar_double,
+                /* join        */ join_with::none,
+                /* env_vars    */ { env::TRACE_DURATION },
+            },
+            flag_descriptor{
+                /* names       */ { "--trace-periods" },
+                /* help        */
+                "More powerful version of specifying trace delay and/or "
+                "duration. Format is one or more groups of: "
+                "<DELAY>:<DURATION>, <DELAY>:<DURATION>:<REPEAT>, and/or "
+                "<DELAY>:<DURATION>:<REPEAT>:<CLOCK_ID>.",
+                /* dtype       */ "period-spec(s)",
+                /* count       */ count_spec::at_least(1),
+                /* kind        */ value_kind::list,
+                /* join        */ join_with::comma,
+                /* env_vars    */ { env::TRACE_PERIODS },
+            },
+        },
+    };
+    return group;
 }
 
 const flag_group&
 profile_group()
 {
-    return make_profile_group();
+    static const flag_group group{
+        "PROFILE OPTIONS",
+        "Specific options controlling profiling (i.e. deterministic measurements "
+        "which are aggregated into a summary)",
+        {
+            flag_descriptor{
+                /* names       */ { "--profile-format" },
+                /* help        */ "Data formats for profiling results",
+                /* dtype       */ "string",
+                /* count       */ count_spec::range(1, 3),
+                /* kind        */ value_kind::list,
+                /* join        */ join_with::none,
+                /* env_vars    */ {},
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "text_output", "json_output", "cout_output" },
+                /* choices     */ { "text", "json", "console" },
+                /* conflicts   */ {},
+                /* requires_   */ { "profile|flat-profile" },
+                /* custom      */ &profile_format_action,
+            },
+            flag_descriptor{
+                /* names       */ { "--profile-diff" },
+                /* help        */
+                "Generate a diff output b/t the profile collected and "
+                "an existing profile from another run Accepts 1-2 "
+                "parameters corresponding to the input path and the "
+                "input prefix",
+                /* dtype       */ "path [prefix]",
+                /* count       */ count_spec::range(1, 2),
+                /* kind        */ value_kind::list,
+                /* join        */ join_with::none,
+                /* env_vars    */ {},
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "diff_output", "input_path", "input_prefix" },
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ {},
+                /* custom      */ &profile_diff_action,
+            },
+        },
+    };
+    return group;
 }
 
 const flag_group&
 process_sampling_group()
 {
-    return make_process_sampling_group();
+    static const flag_group group{
+        "HOST/DEVICE (PROCESS SAMPLING) OPTIONS",
+        "Process sampling is background measurements for resources available to the "
+        "entire process. These samples are not tied to specific lines/regions of code",
+        {
+            flag_descriptor{
+                /* names       */ { "--process-freq" },
+                /* help        */
+                "Set the default host/device sampling frequency "
+                "(number of interrupts per second)",
+                /* dtype       */ "floating-point",
+                /* count       */ count_spec::exactly(1),
+                /* kind        */ value_kind::scalar_double,
+                /* join        */ join_with::none,
+                /* env_vars    */ { env::PROCESS_SAMPLING_FREQ },
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "process_sampling_freq" },
+            },
+            flag_descriptor{
+                /* names       */ { "--process-wait" },
+                /* help        */
+                "Set the default wait time (i.e. delay) before taking "
+                "first host/device sample (in seconds of realtime)",
+                /* dtype       */ "seconds",
+                /* count       */ count_spec::exactly(1),
+                /* kind        */ value_kind::scalar_double,
+                /* join        */ join_with::none,
+                /* env_vars    */ { env::PROCESS_SAMPLING_DELAY },
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "process_sampling_delay" },
+            },
+            flag_descriptor{
+                /* names       */ { "--process-duration" },
+                /* help        */
+                "Set the duration of the host/device sampling (in "
+                "seconds of realtime)",
+                /* dtype       */ "seconds",
+                /* count       */ count_spec::exactly(1),
+                /* kind        */ value_kind::scalar_double,
+                /* join        */ join_with::none,
+                /* env_vars    */ { env::SAMPLING_PROCESS_DURATION },
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "process_sampling_duration" },
+            },
+            flag_descriptor{
+                /* names       */ { "--cpus" },
+                /* help        */
+                "CPU IDs for frequency sampling. Supports integers "
+                "and/or ranges",
+                /* dtype       */ "int and/or range",
+                /* count       */ count_spec::any(),
+                /* kind        */ value_kind::list,
+                /* join        */ join_with::comma,
+                /* env_vars    */ { env::SAMPLING_CPUS },
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "sampling_cpus" },
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ { "host" },
+            },
+            flag_descriptor{
+                /* names       */ { "--gpus" },
+                /* help        */
+                "GPU IDs for SMI queries. Supports integers and/or "
+                "ranges",
+                /* dtype       */ "int and/or range",
+                /* count       */ count_spec::any(),
+                /* kind        */ value_kind::list,
+                /* join        */ join_with::comma,
+                /* env_vars    */ { env::SAMPLING_GPUS },
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "sampling_gpus" },
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ { "device" },
+            },
+            flag_descriptor{
+                /* names       */ { "--ai-nics" },
+                /* help        */
+                "AI NIC IDs for SMI queries. Supports comma-separated "
+                "list",
+                /* dtype       */ "list of strings",
+                /* count       */ count_spec::any(),
+                /* kind        */ value_kind::list,
+                /* join        */ join_with::comma,
+                /* env_vars    */ { env::SAMPLING_AINICS },
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "sampling_ai-nics" },
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ { "device" },
+            },
+        },
+    };
+    return group;
 }
 
 const flag_group&
 general_sampling_group()
 {
-    return make_general_sampling_group();
+    static const flag_group group{
+        "GENERAL SAMPLING OPTIONS",
+        "General options for timer-based sampling per-thread",
+        {
+            flag_descriptor{
+                /* names       */ { "-f", "--sampling-freq" },
+                /* help        */
+                "Set the default sampling frequency "
+                "(number of interrupts per second)",
+                /* dtype       */ "floating-point",
+                /* count       */ count_spec::exactly(1),
+                /* kind        */ value_kind::scalar_double,
+                /* join        */ join_with::none,
+                /* env_vars    */ { env::SAMPLING_FREQ },
+            },
+            flag_descriptor{
+                /* names       */ { "-t", "--tids" },
+                /* help        */
+                "Specify the default thread IDs for sampling, where 0 "
+                "(zero) is the main thread and each thread created by "
+                "the target application is assigned an atomically "
+                "incrementing value.",
+                /* dtype       */ "int and/or range",
+                /* count       */ count_spec::at_least(1),
+                /* kind        */ value_kind::list,
+                /* join        */ join_with::none,
+                /* env_vars    */ {},
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "sampling_tids" },
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ {},
+                /* custom      */ &tids_action,
+            },
+            flag_descriptor{
+                /* names       */ { "--sampling-wait" },
+                /* help        */
+                "Set the default wait time (i.e. delay) before taking "
+                "first sample (in seconds). This delay time is based "
+                "on the clock of the sampler, i.e., a delay of 1 "
+                "second for CPU-clock sampler may not equal 1 second "
+                "of realtime",
+                /* dtype       */ "seconds",
+                /* count       */ count_spec::exactly(1),
+                /* kind        */ value_kind::scalar_double,
+                /* join        */ join_with::none,
+                /* env_vars    */ { env::SAMPLING_DELAY },
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "sampling_delay" },
+            },
+            flag_descriptor{
+                /* names       */ { "--sampling-duration" },
+                /* help        */
+                "Set the duration of the sampling (in seconds of "
+                "realtime). I.e., it is possible (currently) to set a "
+                "CPU-clock time delay that exceeds the real-time "
+                "duration... resulting in zero samples being taken",
+                /* dtype       */ "seconds",
+                /* count       */ count_spec::exactly(1),
+                /* kind        */ value_kind::scalar_double,
+                /* join        */ join_with::none,
+                /* env_vars    */ { env::SAMPLING_DURATION },
+            },
+        },
+    };
+    return group;
 }
 
 const flag_group&
 sampling_timer_group()
 {
-    return make_sampling_timer_group();
+    static const flag_group group{
+        "SAMPLING TIMER OPTIONS",
+        "These options determine the heuristic for deciding when to take a sample",
+        {
+            flag_descriptor{
+                /* names       */ { "--sample-cputime" },
+                /* help        */ CPUTIME_HELP,
+                /* dtype       */ "[freq] [delay] [tids...]",
+                /* count       */ count_spec::at_least(0),
+                /* kind        */ value_kind::list,
+                /* join        */ join_with::none,
+                /* env_vars    */ {},
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ {},
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ {},
+                /* custom      */ &sample_cputime_action,
+            },
+            flag_descriptor{
+                /* names       */ { "--sample-realtime" },
+                /* help        */ REALTIME_HELP,
+                /* dtype       */ "[freq] [delay] [tids...]",
+                /* count       */ count_spec::at_least(0),
+                /* kind        */ value_kind::list,
+                /* join        */ join_with::none,
+                /* env_vars    */ {},
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ {},
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ {},
+                /* custom      */ &sample_realtime_action,
+            },
+            flag_descriptor{
+                /* names       */ { "--sample-overflow" },
+                /* help        */ OVERFLOW_HELP,
+                /* dtype       */ "[event] [freq] [tids...]",
+                /* count       */ count_spec::at_least(0),
+                /* kind        */ value_kind::list,
+                /* join        */ join_with::none,
+                /* env_vars    */ {},
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ {},
+                /* choices     */ {},
+                /* conflicts   */ {},
+                /* requires_   */ {},
+                /* custom      */ &sample_overflow_action,
+            },
+        },
+    };
+    return group;
 }
 
 const flag_group&
 hw_counter_group()
 {
-    return make_hw_counter_group();
+    static const flag_group group{
+        "HARDWARE COUNTER OPTIONS",
+        "See also: rocprof-sys-avail -H",
+        {
+            flag_descriptor{
+                /* names       */ { "-C", "--cpu-events" },
+                /* help        */
+                "Set the CPU hardware counter events to record (ref: "
+                "`rocprof-sys-avail -H -c CPU`)",
+                /* dtype       */ "[EVENT ...]",
+                /* count       */ count_spec::at_least(1),
+                /* kind        */ value_kind::list,
+                /* join        */ join_with::comma,
+                /* env_vars    */ { env::PAPI_EVENTS },
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "papi_events" },
+            },
+            flag_descriptor{
+                /* names       */ { "-G", "--gpu-events" },
+                /* help        */
+                "Set the GPU hardware counter events to record (ref: "
+                "`rocprof-sys-avail -H -c GPU`)",
+                /* dtype       */ "[EVENT ...]",
+                /* count       */ count_spec::at_least(1),
+                /* kind        */ value_kind::list,
+                /* join        */ join_with::comma,
+                /* env_vars    */ { env::ROCM_EVENTS },
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "rocm_events" },
+            },
+        },
+    };
+    return group;
 }
 
 const flag_group&
 misc_group()
 {
-    return make_misc_group();
+    static const flag_group group{
+        "MISCELLANEOUS OPTIONS",
+        "",
+        {
+            flag_descriptor{
+                /* names       */ { "-i", "--inlines" },
+                /* help        */ "Include inline info in output when available",
+                /* dtype       */ {},
+                /* count       */ count_spec::at_most(1),
+                /* kind        */ value_kind::flag,
+                /* join        */ join_with::none,
+                /* env_vars    */ { env::SAMPLING_INCLUDE_INLINES },
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ { "sampling_include_inlines" },
+            },
+            // HSA_ENABLE_INTERRUPT is a non-ROCPROFSYS_ env var consumed by ROCm.
+            flag_descriptor{
+                /* names       */ { "--hsa-interrupt" },
+                /* help        */ HSA_INTERRUPT_HELP,
+                /* dtype       */ "int",
+                /* count       */ count_spec::exactly(1),
+                /* kind        */ value_kind::scalar_int,
+                /* join        */ join_with::none,
+                /* env_vars    */ { "HSA_ENABLE_INTERRUPT" },
+                /* mode        */ update_mode::REPLACE,
+                /* dedup_keys  */ {},
+                /* choices     */ { "0", "1" },
+            },
+        },
+    };
+    return group;
 }
 
 }  // namespace argparse

--- a/projects/rocprofiler-systems/source/lib/core/argparse/core_flags.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/core_flags.cpp
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 #include "core_flags.hpp"
+
 #include "common/env_vars.hpp"
+#include "detail/parser_engine.hpp"
 #include "exception.hpp"
 #include "flag_descriptor.hpp"
 #include "interpreter.hpp"

--- a/projects/rocprofiler-systems/source/lib/core/argparse/core_flags.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/core_flags.hpp
@@ -17,6 +17,9 @@ const flag_group&
 general_group();
 
 const flag_group&
+launcher_group();
+
+const flag_group&
 tracing_group();
 
 const flag_group&

--- a/projects/rocprofiler-systems/source/lib/core/argparse/core_flags.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/core_flags.hpp
@@ -1,0 +1,41 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "flag_descriptor.hpp"
+
+namespace rocprofsys
+{
+namespace argparse
+{
+
+const flag_group&
+debug_group();
+
+const flag_group&
+general_group();
+
+const flag_group&
+tracing_group();
+
+const flag_group&
+profile_group();
+
+const flag_group&
+process_sampling_group();
+
+const flag_group&
+general_sampling_group();
+
+const flag_group&
+sampling_timer_group();
+
+const flag_group&
+hw_counter_group();
+
+const flag_group&
+misc_group();
+
+}  // namespace argparse
+}  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/argparse/detail/parser_engine.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/detail/parser_engine.hpp
@@ -1,0 +1,18 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Internal engine header — the single place inside the argparse layer that
+// pulls in the timemory parser implementation. Other argparse TUs that need
+// the complete tim::argparse::argument_parser / tim::vsettings types include
+// THIS header rather than reaching for the timemory headers directly. Public
+// argparse.hpp forward-declares these types and exposes them only behind
+// references / pointers, so its consumers never pay the timemory include
+// cost.
+//
+// When the engine is swapped (e.g. to CLI11), this is one of two files that
+// must change — the other being parsed_values.cpp's specializations.
+
+#pragma once
+
+#include <timemory/settings/vsettings.hpp>
+#include <timemory/utility/argparse.hpp>

--- a/projects/rocprofiler-systems/source/lib/core/argparse/flag_descriptor.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/flag_descriptor.hpp
@@ -1,0 +1,71 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "argparse.hpp"
+#include "common/environment.hpp"
+
+#include <string_view>
+#include <vector>
+
+namespace rocprofsys
+{
+namespace argparse
+{
+
+enum class value_kind
+{
+    flag,
+    scalar,
+    list,
+};
+
+enum class join_with
+{
+    none,
+    space,
+    comma,
+    colon,
+};
+
+struct count_spec
+{
+    int exact = -1;
+    int min   = -1;
+    int max   = -1;
+
+    static constexpr count_spec exactly(int n) noexcept { return { n, -1, -1 }; }
+    static constexpr count_spec range(int lo, int hi) noexcept { return { -1, lo, hi }; }
+    static constexpr count_spec at_least(int lo) noexcept { return { -1, lo, -1 }; }
+    static constexpr count_spec at_most(int hi) noexcept { return { -1, -1, hi }; }
+};
+
+using custom_action_t = void (*)(parser_t&, parser_data&);
+
+struct flag_descriptor
+{
+    std::vector<std::string_view> names;
+    std::string_view              help;
+    std::string_view              dtype       = {};
+    count_spec                    count       = {};
+    value_kind                    kind        = value_kind::flag;
+    join_with                     join        = join_with::none;
+    std::vector<std::string_view> env_vars    = {};
+    common::update_mode           mode        = common::update_mode::REPLACE;
+    std::vector<std::string_view> aliased_env = {};
+    std::vector<std::string_view> choices     = {};
+    std::vector<std::string_view> conflicts   = {};
+    std::vector<std::string_view> requires_   = {};
+    custom_action_t               custom      = nullptr;
+};
+
+struct flag_group
+{
+    std::string_view             title;
+    std::string_view             subtitle = {};
+    std::vector<flag_descriptor> flags;
+};
+
+}  // namespace argparse
+}  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/argparse/flag_descriptor.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/flag_descriptor.hpp
@@ -5,6 +5,7 @@
 
 #include "argparse.hpp"
 #include "common/environment.hpp"
+#include "parsed_values.hpp"
 
 #include <string_view>
 #include <vector>
@@ -44,10 +45,20 @@ struct count_spec
     static constexpr count_spec any() noexcept { return {}; }
 };
 
-using custom_action_t = void (*)(parser_t&, parser_data&);
+// Engine-agnostic action callback. Receives a parsed_values accessor that
+// hides the underlying parser library; descriptors never name the engine.
+using custom_action_t = void (*)(parsed_values&, parser_data&);
 
+// Lifetime contract for the embedded string_views:
+// `names`, `help`, `dtype`, `env_vars`, `dedup_keys`, `choices`, `conflicts`,
+// and `requires_` must reference storage that outlives the descriptor's use
+// by the parser. In practice every site that builds a flag_descriptor
+// references either string literals or `constexpr std::string_view` constants
+// in core_flags.cpp (static storage), and the flag_group factories return
+// `static const flag_group&`. Do not assign view fields from temporaries.
+//
 // Convention: when multiple names are provided, the LONG name must be last.
-// `parser_key_from` derives the parser lookup key from `names.back()`.
+// The interpreter derives the parser lookup key from `names.back()`.
 struct flag_descriptor
 {
     std::vector<std::string_view> names;

--- a/projects/rocprofiler-systems/source/lib/core/argparse/flag_descriptor.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/flag_descriptor.hpp
@@ -18,6 +18,8 @@ enum class value_kind
 {
     flag,
     scalar,
+    scalar_int,
+    scalar_double,
     list,
 };
 

--- a/projects/rocprofiler-systems/source/lib/core/argparse/flag_descriptor.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/flag_descriptor.hpp
@@ -41,25 +41,28 @@ struct count_spec
     static constexpr count_spec range(int lo, int hi) noexcept { return { -1, lo, hi }; }
     static constexpr count_spec at_least(int lo) noexcept { return { -1, lo, -1 }; }
     static constexpr count_spec at_most(int hi) noexcept { return { -1, -1, hi }; }
+    static constexpr count_spec any() noexcept { return {}; }
 };
 
 using custom_action_t = void (*)(parser_t&, parser_data&);
 
+// Convention: when multiple names are provided, the LONG name must be last.
+// `parser_key_from` derives the parser lookup key from `names.back()`.
 struct flag_descriptor
 {
     std::vector<std::string_view> names;
     std::string_view              help;
-    std::string_view              dtype       = {};
-    count_spec                    count       = {};
-    value_kind                    kind        = value_kind::flag;
-    join_with                     join        = join_with::none;
-    std::vector<std::string_view> env_vars    = {};
-    common::update_mode           mode        = common::update_mode::REPLACE;
-    std::vector<std::string_view> aliased_env = {};
-    std::vector<std::string_view> choices     = {};
-    std::vector<std::string_view> conflicts   = {};
-    std::vector<std::string_view> requires_   = {};
-    custom_action_t               custom      = nullptr;
+    std::string_view              dtype      = {};
+    count_spec                    count      = count_spec::any();
+    value_kind                    kind       = value_kind::flag;
+    join_with                     join       = join_with::none;
+    std::vector<std::string_view> env_vars   = {};
+    common::update_mode           mode       = common::update_mode::REPLACE;
+    std::vector<std::string_view> dedup_keys = {};
+    std::vector<std::string_view> choices    = {};
+    std::vector<std::string_view> conflicts  = {};
+    std::vector<std::string_view> requires_  = {};
+    custom_action_t               custom     = nullptr;
 };
 
 struct flag_group

--- a/projects/rocprofiler-systems/source/lib/core/argparse/interpreter.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/interpreter.cpp
@@ -1,0 +1,157 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Interim engine: the interpreter dispatches descriptors onto
+// tim::argparse::argument_parser. The descriptor table itself is
+// engine-agnostic; replacing tim::argparse with another parser library
+// (e.g. CLI11) is a focused change confined to this translation unit.
+
+#include "interpreter.hpp"
+#include "exception.hpp"
+
+#include <spdlog/fmt/fmt.h>
+#include <spdlog/fmt/ranges.h>
+
+#include <algorithm>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace rocprofsys
+{
+namespace argparse
+{
+namespace
+{
+std::string_view
+strip_dashes(std::string_view name) noexcept
+{
+    while(!name.empty() && name.front() == '-')
+        name.remove_prefix(1);
+    return name;
+}
+
+std::string
+key_from(const flag_descriptor& descriptor)
+{
+    if(descriptor.names.empty())
+        throw exception<std::runtime_error>("flag_descriptor has no names");
+    return std::string{ strip_dashes(descriptor.names.back()) };
+}
+
+std::vector<std::string>
+to_strvec(const std::vector<std::string_view>& source)
+{
+    std::vector<std::string> result;
+    result.reserve(source.size());
+    std::transform(source.begin(), source.end(), std::back_inserter(result),
+                   [](std::string_view value) { return std::string{ value }; });
+    return result;
+}
+
+std::set<std::string>
+to_strset(const std::vector<std::string_view>& source)
+{
+    std::set<std::string> result;
+    for(auto value : source)
+        result.emplace(value);
+    return result;
+}
+
+const char*
+delimiter_for(join_with join) noexcept
+{
+    switch(join)
+    {
+        case join_with::space: return " ";
+        case join_with::comma: return ",";
+        case join_with::colon: return ":";
+        case join_with::none:
+        default: return " ";
+    }
+}
+
+std::string
+read_value(parser_t& parser, const std::string& key, const flag_descriptor& descriptor)
+{
+    switch(descriptor.kind)
+    {
+        case value_kind::flag: return parser.get<bool>(key) ? "true" : "false";
+
+        case value_kind::scalar: return parser.get<std::string>(key);
+
+        case value_kind::list:
+        {
+            auto values = parser.get<std::vector<std::string>>(key);
+            return fmt::format("{}", fmt::join(values, delimiter_for(descriptor.join)));
+        }
+    }
+    return {};
+}
+
+void
+emit_env(parser_data& data, const flag_descriptor& descriptor, const std::string& value)
+{
+    for(auto env_var : descriptor.env_vars)
+    {
+        common::update_env(data.env.current, env_var, value, descriptor.mode,
+                           delimiter_for(descriptor.join), data.env.updated,
+                           data.env.initial);
+    }
+}
+
+void
+remember_processed(parser_data& data, const std::string& key,
+                   const flag_descriptor& descriptor)
+{
+    data.reg.processed_environs.emplace(key);
+    for(auto alias : descriptor.aliased_env)
+        data.reg.processed_environs.emplace(std::string{ alias });
+}
+
+void
+apply_count(parser_t::argument& arg, const count_spec& count) noexcept
+{
+    if(count.exact >= 0) arg.count(count.exact);
+    if(count.min >= 0) arg.min_count(count.min);
+    if(count.max >= 0) arg.max_count(count.max);
+}
+}  // namespace
+
+void
+register_flag(parser_t& parser, parser_data& data, const flag_descriptor& descriptor)
+{
+    auto key = key_from(descriptor);
+    if(!data.reg.environ_filter(key, data)) return;
+
+    auto& arg =
+        parser.add_argument(to_strvec(descriptor.names), std::string{ descriptor.help });
+
+    apply_count(arg, descriptor.count);
+    if(!descriptor.dtype.empty()) arg.dtype(std::string{ descriptor.dtype });
+    if(!descriptor.choices.empty()) arg.choices(to_strset(descriptor.choices));
+    if(!descriptor.conflicts.empty()) arg.conflicts(to_strset(descriptor.conflicts));
+    if(!descriptor.requires_.empty()) arg.required(to_strvec(descriptor.requires_));
+
+    arg.action([&data, descriptor, key](parser_t& parser_ref) {
+        if(descriptor.custom != nullptr)
+        {
+            descriptor.custom(parser_ref, data);
+            return;
+        }
+        emit_env(data, descriptor, read_value(parser_ref, key, descriptor));
+    });
+
+    remember_processed(data, key, descriptor);
+}
+
+void
+register_group(parser_t& parser, parser_data& data, const flag_group& group)
+{
+    parser.start_group(std::string{ group.title }, std::string{ group.subtitle });
+    for(const auto& descriptor : group.flags)
+        register_flag(parser, data, descriptor);
+}
+
+}  // namespace argparse
+}  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/argparse/interpreter.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/interpreter.cpp
@@ -13,6 +13,7 @@
 #include <spdlog/fmt/ranges.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <set>
 #include <string>
 #include <vector>
@@ -32,11 +33,19 @@ strip_dashes(std::string_view name) noexcept
 }
 
 std::string
-key_from(const flag_descriptor& descriptor)
+parser_key_from(const flag_descriptor& descriptor)
 {
     if(descriptor.names.empty())
         throw exception<std::runtime_error>("flag_descriptor has no names");
     return std::string{ strip_dashes(descriptor.names.back()) };
+}
+
+std::string
+env_key_from(const std::string& parser_key)
+{
+    auto result = parser_key;
+    std::replace(result.begin(), result.end(), '-', '_');
+    return result;
 }
 
 std::vector<std::string>
@@ -80,6 +89,10 @@ read_value(parser_t& parser, const std::string& key, const flag_descriptor& desc
 
         case value_kind::scalar: return parser.get<std::string>(key);
 
+        case value_kind::scalar_int: return std::to_string(parser.get<int64_t>(key));
+
+        case value_kind::scalar_double: return std::to_string(parser.get<double>(key));
+
         case value_kind::list:
         {
             auto values = parser.get<std::vector<std::string>>(key);
@@ -121,8 +134,9 @@ apply_count(parser_t::argument& arg, const count_spec& count) noexcept
 void
 register_flag(parser_t& parser, parser_data& data, const flag_descriptor& descriptor)
 {
-    auto key = key_from(descriptor);
-    if(!data.reg.environ_filter(key, data)) return;
+    auto parser_key = parser_key_from(descriptor);
+    auto env_key    = env_key_from(parser_key);
+    if(!data.reg.environ_filter(env_key, data)) return;
 
     auto& arg =
         parser.add_argument(to_strvec(descriptor.names), std::string{ descriptor.help });
@@ -133,16 +147,16 @@ register_flag(parser_t& parser, parser_data& data, const flag_descriptor& descri
     if(!descriptor.conflicts.empty()) arg.conflicts(to_strset(descriptor.conflicts));
     if(!descriptor.requires_.empty()) arg.required(to_strvec(descriptor.requires_));
 
-    arg.action([&data, descriptor, key](parser_t& parser_ref) {
+    arg.action([&data, descriptor, parser_key](parser_t& parser_ref) {
         if(descriptor.custom != nullptr)
         {
             descriptor.custom(parser_ref, data);
             return;
         }
-        emit_env(data, descriptor, read_value(parser_ref, key, descriptor));
+        emit_env(data, descriptor, read_value(parser_ref, parser_key, descriptor));
     });
 
-    remember_processed(data, key, descriptor);
+    remember_processed(data, env_key, descriptor);
 }
 
 void

--- a/projects/rocprofiler-systems/source/lib/core/argparse/interpreter.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/interpreter.cpp
@@ -90,7 +90,7 @@ read_value(parser_t& parser, const std::string& key, const flag_descriptor& desc
     {
         case value_kind::flag: return parser.get<bool>(key) ? "true" : "false";
         case value_kind::scalar: return parser.get<std::string>(key);
-        case value_kind::scalar_int: return std::to_string(parser.get<int64_t>(key));
+        case value_kind::scalar_int: return std::to_string(parser.get<std::int64_t>(key));
         case value_kind::scalar_double: return std::to_string(parser.get<double>(key));
         case value_kind::list:
         {

--- a/projects/rocprofiler-systems/source/lib/core/argparse/interpreter.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/interpreter.cpp
@@ -13,6 +13,7 @@
 #include <spdlog/fmt/ranges.h>
 
 #include <algorithm>
+#include <cassert>
 #include <cstdint>
 #include <set>
 #include <string>
@@ -24,7 +25,7 @@ namespace argparse
 {
 namespace
 {
-std::string_view
+[[nodiscard]] std::string_view
 strip_dashes(std::string_view name) noexcept
 {
     while(!name.empty() && name.front() == '-')
@@ -32,42 +33,43 @@ strip_dashes(std::string_view name) noexcept
     return name;
 }
 
-std::string
-parser_key_from(const flag_descriptor& descriptor)
+struct flag_keys
+{
+    std::string parser_key;  // for parser.get<T>(key) — uses hyphens, e.g. "log-level"
+    std::string env_key;  // for processed_environs dedup — uses underscores, "log_level"
+};
+
+[[nodiscard]] flag_keys
+keys_from(const flag_descriptor& descriptor)
 {
     if(descriptor.names.empty())
         throw exception<std::runtime_error>("flag_descriptor has no names");
-    return std::string{ strip_dashes(descriptor.names.back()) };
+    auto parser_key = std::string{ strip_dashes(descriptor.names.back()) };
+    auto env_key    = parser_key;
+    std::replace(env_key.begin(), env_key.end(), '-', '_');
+    return { std::move(parser_key), std::move(env_key) };
 }
 
-std::string
-env_key_from(const std::string& parser_key)
+template <typename Container>
+[[nodiscard]] Container
+to_container(const std::vector<std::string_view>& source)
 {
-    auto result = parser_key;
-    std::replace(result.begin(), result.end(), '-', '_');
+    Container result;
+    if constexpr(std::is_same_v<Container, std::vector<std::string>>)
+    {
+        result.reserve(source.size());
+        for(auto value : source)
+            result.emplace_back(value);
+    }
+    else
+    {
+        for(auto value : source)
+            result.emplace(std::string{ value });
+    }
     return result;
 }
 
-std::vector<std::string>
-to_strvec(const std::vector<std::string_view>& source)
-{
-    std::vector<std::string> result;
-    result.reserve(source.size());
-    std::transform(source.begin(), source.end(), std::back_inserter(result),
-                   [](std::string_view value) { return std::string{ value }; });
-    return result;
-}
-
-std::set<std::string>
-to_strset(const std::vector<std::string_view>& source)
-{
-    std::set<std::string> result;
-    for(auto value : source)
-        result.emplace(value);
-    return result;
-}
-
-const char*
+[[nodiscard]] std::string_view
 delimiter_for(join_with join) noexcept
 {
     switch(join)
@@ -75,26 +77,27 @@ delimiter_for(join_with join) noexcept
         case join_with::space: return " ";
         case join_with::comma: return ",";
         case join_with::colon: return ":";
-        case join_with::none:
-        default: return " ";
+        case join_with::none: return {};
     }
+    return {};
 }
 
-std::string
+[[nodiscard]] std::string
 read_value(parser_t& parser, const std::string& key, const flag_descriptor& descriptor)
 {
     switch(descriptor.kind)
     {
         case value_kind::flag: return parser.get<bool>(key) ? "true" : "false";
-
         case value_kind::scalar: return parser.get<std::string>(key);
-
         case value_kind::scalar_int: return std::to_string(parser.get<int64_t>(key));
-
         case value_kind::scalar_double: return std::to_string(parser.get<double>(key));
-
         case value_kind::list:
         {
+            // List values must declare a join. `join_with::none` is a caller
+            // bug — emit_env's delimiter would be empty and produce concatenated
+            // garbage like "abc-def" instead of "abc,def".
+            assert(descriptor.join != join_with::none &&
+                   "value_kind::list requires an explicit join_with");
             auto values = parser.get<std::vector<std::string>>(key);
             return fmt::format("{}", fmt::join(values, delimiter_for(descriptor.join)));
         }
@@ -105,20 +108,19 @@ read_value(parser_t& parser, const std::string& key, const flag_descriptor& desc
 void
 emit_env(parser_data& data, const flag_descriptor& descriptor, const std::string& value)
 {
+    auto delim = delimiter_for(descriptor.join);
+    if(delim.empty()) delim = ":";  // safe scalar default for env-list joiners
     for(auto env_var : descriptor.env_vars)
-    {
-        common::update_env(data.env.current, env_var, value, descriptor.mode,
-                           delimiter_for(descriptor.join), data.env.updated,
-                           data.env.initial);
-    }
+        common::update_env(data.env.current, env_var, value, descriptor.mode, delim,
+                           data.env.updated, data.env.initial);
 }
 
 void
-remember_processed(parser_data& data, const std::string& key,
+remember_processed(parser_data& data, const std::string& env_key,
                    const flag_descriptor& descriptor)
 {
-    data.reg.processed_environs.emplace(key);
-    for(auto alias : descriptor.aliased_env)
+    data.reg.processed_environs.emplace(env_key);
+    for(auto alias : descriptor.dedup_keys)
         data.reg.processed_environs.emplace(std::string{ alias });
 }
 
@@ -129,25 +131,28 @@ apply_count(parser_t::argument& arg, const count_spec& count) noexcept
     if(count.min >= 0) arg.min_count(count.min);
     if(count.max >= 0) arg.max_count(count.max);
 }
-}  // namespace
 
 void
 register_flag(parser_t& parser, parser_data& data, const flag_descriptor& descriptor)
 {
-    auto parser_key = parser_key_from(descriptor);
-    auto env_key    = env_key_from(parser_key);
-    if(!data.reg.environ_filter(env_key, data)) return;
+    auto keys = keys_from(descriptor);
+    if(!data.reg.environ_filter(keys.env_key, data)) return;
 
     auto& arg =
-        parser.add_argument(to_strvec(descriptor.names), std::string{ descriptor.help });
+        parser.add_argument(to_container<std::vector<std::string>>(descriptor.names),
+                            std::string{ descriptor.help });
 
     apply_count(arg, descriptor.count);
     if(!descriptor.dtype.empty()) arg.dtype(std::string{ descriptor.dtype });
-    if(!descriptor.choices.empty()) arg.choices(to_strset(descriptor.choices));
-    if(!descriptor.conflicts.empty()) arg.conflicts(to_strset(descriptor.conflicts));
-    if(!descriptor.requires_.empty()) arg.required(to_strvec(descriptor.requires_));
+    if(!descriptor.choices.empty())
+        arg.choices(to_container<std::set<std::string>>(descriptor.choices));
+    if(!descriptor.conflicts.empty())
+        arg.conflicts(to_container<std::set<std::string>>(descriptor.conflicts));
+    if(!descriptor.requires_.empty())
+        arg.required(to_container<std::vector<std::string>>(descriptor.requires_));
 
-    arg.action([&data, descriptor, parser_key](parser_t& parser_ref) {
+    arg.action([&data, descriptor,
+                parser_key = std::move(keys.parser_key)](parser_t& parser_ref) {
         if(descriptor.custom != nullptr)
         {
             descriptor.custom(parser_ref, data);
@@ -156,8 +161,9 @@ register_flag(parser_t& parser, parser_data& data, const flag_descriptor& descri
         emit_env(data, descriptor, read_value(parser_ref, parser_key, descriptor));
     });
 
-    remember_processed(data, env_key, descriptor);
+    remember_processed(data, keys.env_key, descriptor);
 }
+}  // namespace
 
 void
 register_group(parser_t& parser, parser_data& data, const flag_group& group)

--- a/projects/rocprofiler-systems/source/lib/core/argparse/interpreter.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/interpreter.cpp
@@ -15,7 +15,6 @@
 #include <spdlog/fmt/ranges.h>
 
 #include <algorithm>
-#include <cassert>
 #include <cstdint>
 #include <set>
 #include <string>
@@ -95,11 +94,7 @@ read_value(parser_t& parser, const std::string& key, const flag_descriptor& desc
         case value_kind::scalar_double: return std::to_string(parser.get<double>(key));
         case value_kind::list:
         {
-            // List values must declare a join. `join_with::none` is a caller
-            // bug — emit_env's delimiter would be empty and produce concatenated
-            // garbage like "abc-def" instead of "abc,def".
-            assert(descriptor.join != join_with::none &&
-                   "value_kind::list requires an explicit join_with");
+            // Invariant (asserted by validate_descriptor): list ⇒ join != none.
             auto values = parser.get<std::vector<std::string>>(key);
             return fmt::format("{}", fmt::join(values, delimiter_for(descriptor.join)));
         }
@@ -110,8 +105,11 @@ read_value(parser_t& parser, const std::string& key, const flag_descriptor& desc
 void
 emit_env(parser_data& data, const flag_descriptor& descriptor, const std::string& value)
 {
-    auto delim = delimiter_for(descriptor.join);
-    if(delim.empty()) delim = ":";  // safe scalar default for env-list joiners
+    // Invariant (asserted by validate_descriptor): if mode requires a
+    // delimiter (APPEND/PREPEND) or the kind is list, join != none.
+    // For REPLACE / WEAK on a scalar, update_env ignores the delimiter
+    // entirely, so an empty `delim` is fine.
+    const auto delim = delimiter_for(descriptor.join);
     for(auto env_var : descriptor.env_vars)
         common::update_env(data.env.current, env_var, value, descriptor.mode, delim,
                            data.env.updated, data.env.initial);
@@ -135,8 +133,29 @@ apply_count(parser_t::argument& arg, const count_spec& count) noexcept
 }
 
 void
+validate_descriptor(const flag_descriptor& descriptor)
+{
+    // Custom actions handle their own emission, so they're exempt from the
+    // join_with invariant — `--output` etc. parse a list of values then
+    // write them to separate env vars without ever calling emit_env.
+    if(descriptor.custom != nullptr) return;
+
+    const bool needs_delim = descriptor.kind == value_kind::list ||
+                             descriptor.mode == common::update_mode::APPEND ||
+                             descriptor.mode == common::update_mode::PREPEND;
+    if(needs_delim && descriptor.join == join_with::none)
+    {
+        throw exception<std::runtime_error>(fmt::format(
+            "flag descriptor for '{}' must declare an explicit join_with: "
+            "value_kind::list and update_mode::APPEND/PREPEND require a delimiter",
+            descriptor.names.empty() ? "<unnamed>" : descriptor.names.back()));
+    }
+}
+
+void
 register_flag(parser_t& parser, parser_data& data, const flag_descriptor& descriptor)
 {
+    validate_descriptor(descriptor);
     auto keys = keys_from(descriptor);
     if(!data.reg.environ_filter(keys.env_key, data)) return;
 

--- a/projects/rocprofiler-systems/source/lib/core/argparse/interpreter.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/interpreter.cpp
@@ -157,7 +157,8 @@ register_flag(parser_t& parser, parser_data& data, const flag_descriptor& descri
                 parser_key = std::move(keys.parser_key)](parser_t& parser_ref) {
         if(descriptor.custom != nullptr)
         {
-            descriptor.custom(parser_ref, data);
+            parsed_values values{ parser_ref };
+            descriptor.custom(values, data);
             return;
         }
         emit_env(data, descriptor, read_value(parser_ref, parser_key, descriptor));

--- a/projects/rocprofiler-systems/source/lib/core/argparse/interpreter.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/interpreter.cpp
@@ -7,6 +7,8 @@
 // (e.g. CLI11) is a focused change confined to this translation unit.
 
 #include "interpreter.hpp"
+
+#include "detail/parser_engine.hpp"
 #include "exception.hpp"
 
 #include <spdlog/fmt/fmt.h>

--- a/projects/rocprofiler-systems/source/lib/core/argparse/interpreter.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/interpreter.hpp
@@ -11,9 +11,7 @@ namespace rocprofsys
 namespace argparse
 {
 
-void
-register_flag(parser_t& parser, parser_data& data, const flag_descriptor& descriptor);
-
+// Walks a flag_group, registering each descriptor onto the parser.
 void
 register_group(parser_t& parser, parser_data& data, const flag_group& group);
 

--- a/projects/rocprofiler-systems/source/lib/core/argparse/interpreter.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/interpreter.hpp
@@ -1,0 +1,21 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "argparse.hpp"
+#include "flag_descriptor.hpp"
+
+namespace rocprofsys
+{
+namespace argparse
+{
+
+void
+register_flag(parser_t& parser, parser_data& data, const flag_descriptor& descriptor);
+
+void
+register_group(parser_t& parser, parser_data& data, const flag_group& group);
+
+}  // namespace argparse
+}  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/argparse/parsed_values.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/parsed_values.cpp
@@ -1,0 +1,111 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Engine-bound implementation of parsed_values. This is one of the two
+// translation units that knows about tim::argparse — the other is the
+// interpreter. A future engine swap means rewriting these specializations
+// against the new engine's value-extraction API; nothing else needs to
+// change.
+
+#include "parsed_values.hpp"
+
+#include "detail/parser_engine.hpp"
+
+#include <cstdint>
+#include <deque>
+#include <set>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace rocprofsys
+{
+namespace argparse
+{
+
+namespace
+{
+[[nodiscard]] inline std::string
+to_key(std::string_view key)
+{
+    return std::string{ key };
+}
+}  // namespace
+
+bool
+parsed_values::exists(std::string_view key) const
+{
+    return m_engine->exists(to_key(key));
+}
+
+void
+parsed_values::set_use_color(bool enabled)
+{
+    m_engine->set_use_color(enabled);
+}
+
+template <>
+bool
+parsed_values::get<bool>(std::string_view key) const
+{
+    return m_engine->get<bool>(to_key(key));
+}
+
+template <>
+int
+parsed_values::get<int>(std::string_view key) const
+{
+    return m_engine->get<int>(to_key(key));
+}
+
+template <>
+std::int64_t
+parsed_values::get<std::int64_t>(std::string_view key) const
+{
+    return m_engine->get<std::int64_t>(to_key(key));
+}
+
+template <>
+double
+parsed_values::get<double>(std::string_view key) const
+{
+    return m_engine->get<double>(to_key(key));
+}
+
+template <>
+std::string
+parsed_values::get<std::string>(std::string_view key) const
+{
+    return m_engine->get<std::string>(to_key(key));
+}
+
+template <>
+std::set<std::string>
+parsed_values::get<std::set<std::string>>(std::string_view key) const
+{
+    return m_engine->get<std::set<std::string>>(to_key(key));
+}
+
+template <>
+std::vector<std::string>
+parsed_values::get<std::vector<std::string>>(std::string_view key) const
+{
+    return m_engine->get<std::vector<std::string>>(to_key(key));
+}
+
+template <>
+std::deque<std::string>
+parsed_values::get<std::deque<std::string>>(std::string_view key) const
+{
+    return m_engine->get<std::deque<std::string>>(to_key(key));
+}
+
+template <>
+std::vector<std::int64_t>
+parsed_values::get<std::vector<std::int64_t>>(std::string_view key) const
+{
+    return m_engine->get<std::vector<std::int64_t>>(to_key(key));
+}
+
+}  // namespace argparse
+}  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/argparse/parsed_values.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/parsed_values.hpp
@@ -77,20 +77,20 @@ template <>
 [[nodiscard]] std::string parsed_values::get<std::string>(std::string_view) const;
 
 template <>
-[[nodiscard]] std::set<std::string>
-parsed_values::get<std::set<std::string>>(std::string_view) const;
+[[nodiscard]] std::set<std::string> parsed_values::get<std::set<std::string>>(
+    std::string_view) const;
 
 template <>
-[[nodiscard]] std::vector<std::string>
-parsed_values::get<std::vector<std::string>>(std::string_view) const;
+[[nodiscard]] std::vector<std::string> parsed_values::get<std::vector<std::string>>(
+    std::string_view) const;
 
 template <>
-[[nodiscard]] std::deque<std::string>
-parsed_values::get<std::deque<std::string>>(std::string_view) const;
+[[nodiscard]] std::deque<std::string> parsed_values::get<std::deque<std::string>>(
+    std::string_view) const;
 
 template <>
-[[nodiscard]] std::vector<std::int64_t>
-parsed_values::get<std::vector<std::int64_t>>(std::string_view) const;
+[[nodiscard]] std::vector<std::int64_t> parsed_values::get<std::vector<std::int64_t>>(
+    std::string_view) const;
 
 }  // namespace argparse
 }  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/argparse/parsed_values.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/parsed_values.hpp
@@ -1,0 +1,96 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "argparse.hpp"
+
+#include <cstdint>
+#include <deque>
+#include <set>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace rocprofsys
+{
+namespace argparse
+{
+
+/**
+ * Engine-agnostic accessor for parsed argument values.
+ *
+ * Custom actions receive a `parsed_values` instead of the underlying
+ * `parser_t`, so descriptor-driven code never names the parsing engine.
+ * The implementation lives in parsed_values.cpp (the only TU outside of
+ * detail/ that knows about the concrete engine).
+ *
+ * Lifetime: non-owning. The engine pointer must outlive the accessor.
+ * In practice `parsed_values` is constructed by the interpreter for the
+ * duration of a single action callback, so the contract holds naturally.
+ *
+ * Unsupported value types deliberately fail at compile time via the
+ * deleted primary template — callers that try `get<unknown_t>(...)` get
+ * a "deleted function" error at the call site rather than an undefined
+ * symbol at link time.
+ */
+class parsed_values
+{
+public:
+    explicit parsed_values(parser_t& engine) noexcept
+    : m_engine{ &engine }
+    {}
+
+    parsed_values(const parsed_values&)            = delete;
+    parsed_values& operator=(const parsed_values&) = delete;
+    parsed_values(parsed_values&&)                 = delete;
+    parsed_values& operator=(parsed_values&&)      = delete;
+    ~parsed_values()                               = default;
+
+    template <typename Tp>
+    [[nodiscard]] Tp get(std::string_view key) const = delete;
+
+    [[nodiscard]] bool exists(std::string_view key) const;
+
+    void set_use_color(bool enabled);
+
+private:
+    parser_t* m_engine;  // non-owning; parser must outlive *this
+};
+
+// Supported value types. Adding a new type requires:
+//   1. a declaration here, and
+//   2. a matching definition in parsed_values.cpp.
+template <>
+[[nodiscard]] bool parsed_values::get<bool>(std::string_view) const;
+
+template <>
+[[nodiscard]] int parsed_values::get<int>(std::string_view) const;
+
+template <>
+[[nodiscard]] std::int64_t parsed_values::get<std::int64_t>(std::string_view) const;
+
+template <>
+[[nodiscard]] double parsed_values::get<double>(std::string_view) const;
+
+template <>
+[[nodiscard]] std::string parsed_values::get<std::string>(std::string_view) const;
+
+template <>
+[[nodiscard]] std::set<std::string>
+parsed_values::get<std::set<std::string>>(std::string_view) const;
+
+template <>
+[[nodiscard]] std::vector<std::string>
+parsed_values::get<std::vector<std::string>>(std::string_view) const;
+
+template <>
+[[nodiscard]] std::deque<std::string>
+parsed_values::get<std::deque<std::string>>(std::string_view) const;
+
+template <>
+[[nodiscard]] std::vector<std::int64_t>
+parsed_values::get<std::vector<std::int64_t>>(std::string_view) const;
+
+}  // namespace argparse
+}  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/argparse/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/tests/CMakeLists.txt
@@ -22,7 +22,5 @@ target_link_libraries(
 
 target_include_directories(
     argparse-tests
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/source/lib
-        ${PROJECT_SOURCE_DIR}/source/lib/core
+    PRIVATE ${PROJECT_SOURCE_DIR}/source/lib ${PROJECT_SOURCE_DIR}/source/lib/core
 )

--- a/projects/rocprofiler-systems/source/lib/core/argparse/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/tests/CMakeLists.txt
@@ -4,7 +4,9 @@
 add_library(
     argparse-tests
     OBJECT
+    test_core_flags_table.cpp
     test_flag_descriptor.cpp
+    test_parsed_values.cpp
     test_register_group.cpp
 )
 

--- a/projects/rocprofiler-systems/source/lib/core/argparse/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/tests/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+add_library(
+    argparse-tests
+    OBJECT
+    test_flag_descriptor.cpp
+    test_register_group.cpp
+)
+
+target_link_libraries(
+    argparse-tests
+    PUBLIC
+        rocprofiler-systems-headers
+        rocprofiler-systems-googletest-library
+        rocprofiler-systems-timemory
+        rocprofiler-systems-common-library
+        rocprofiler-systems-core-library
+)
+
+target_include_directories(
+    argparse-tests
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/source/lib
+        ${PROJECT_SOURCE_DIR}/source/lib/core
+)

--- a/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_core_flags_table.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_core_flags_table.cpp
@@ -1,0 +1,156 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Pure-data invariants on the descriptor tables exposed by core_flags.hpp.
+// These tests need no parser_t — they walk the static tables and assert
+// shape conditions that the validate_descriptor / interpreter logic
+// silently relies on.
+
+#include "core/argparse/core_flags.hpp"
+#include "core/argparse/flag_descriptor.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
+
+namespace
+{
+using rocprofsys::argparse::flag_descriptor;
+using rocprofsys::argparse::flag_group;
+using rocprofsys::argparse::join_with;
+using rocprofsys::argparse::value_kind;
+using rocprofsys::common::update_mode;
+
+const std::vector<const flag_group*>&
+all_core_groups()
+{
+    namespace argparse = rocprofsys::argparse;
+    static const std::vector<const flag_group*> groups = {
+        &argparse::debug_group(),     &argparse::general_group(),
+        &argparse::launcher_group(),  &argparse::tracing_group(),
+        &argparse::profile_group(),   &argparse::process_sampling_group(),
+        &argparse::general_sampling_group(), &argparse::sampling_timer_group(),
+        &argparse::hw_counter_group(), &argparse::misc_group(),
+    };
+    return groups;
+}
+
+[[nodiscard]] std::string_view
+last_name_or_unnamed(const flag_descriptor& descriptor)
+{
+    return descriptor.names.empty() ? std::string_view{ "<unnamed>" }
+                                    : descriptor.names.back();
+}
+
+}  // namespace
+
+TEST(CoreFlagsTable, EveryDescriptorHasNonEmptyNames)
+{
+    for(const auto* group : all_core_groups())
+    {
+        for(const auto& descriptor : group->flags)
+        {
+            EXPECT_FALSE(descriptor.names.empty())
+                << "descriptor in group '" << group->title << "' has no names";
+        }
+    }
+}
+
+TEST(CoreFlagsTable, LongNameIsLastAndDoubleDashed)
+{
+    // The interpreter derives the parser_key from names.back() via strip_dashes;
+    // by convention the LONG name (--foo) must be last. Short names (-x) may
+    // precede it.
+    for(const auto* group : all_core_groups())
+    {
+        for(const auto& descriptor : group->flags)
+        {
+            if(descriptor.names.empty()) continue;
+            const auto& last = descriptor.names.back();
+            EXPECT_GE(last.size(), 3u) << "last name '" << last << "' too short";
+            EXPECT_EQ(last.substr(0, 2), "--")
+                << "last name '" << last << "' missing -- prefix";
+        }
+    }
+}
+
+TEST(CoreFlagsTable, ListKindOrAppendModeDeclaresJoinExceptForCustom)
+{
+    // Same invariant validate_descriptor enforces at register time. Walking
+    // the static tables here catches the bug at test time, with file:line
+    // pointing at the descriptor.
+    for(const auto* group : all_core_groups())
+    {
+        for(const auto& descriptor : group->flags)
+        {
+            if(descriptor.custom != nullptr) continue;  // custom handles its own emission
+
+            const bool needs_delim = descriptor.kind == value_kind::list ||
+                                     descriptor.mode == update_mode::APPEND ||
+                                     descriptor.mode == update_mode::PREPEND;
+            if(needs_delim)
+            {
+                EXPECT_NE(descriptor.join, join_with::none)
+                    << "descriptor '" << last_name_or_unnamed(descriptor)
+                    << "' in group '" << group->title
+                    << "' needs an explicit join_with";
+            }
+        }
+    }
+}
+
+TEST(CoreFlagsTable, ParserKeysAreUniqueAcrossAllGroups)
+{
+    // parser_key derives from strip_dashes(names.back()). Duplicate keys
+    // across the descriptor tables would silently shadow each other in the
+    // parser.
+    std::unordered_set<std::string> keys;
+    for(const auto* group : all_core_groups())
+    {
+        for(const auto& descriptor : group->flags)
+        {
+            if(descriptor.names.empty()) continue;
+            auto       name = std::string{ descriptor.names.back() };
+            const auto first_non_dash = name.find_first_not_of('-');
+            if(first_non_dash != std::string::npos) name = name.substr(first_non_dash);
+
+            const bool inserted = keys.insert(name).second;
+            EXPECT_TRUE(inserted) << "duplicate parser key '" << name << "' in group '"
+                                  << group->title << "'";
+        }
+    }
+}
+
+TEST(CoreFlagsTable, DedupKeysDoNotCollideWithDerivedEnvKey)
+{
+    // emit_env writes to descriptor.env_vars; remember_processed writes the
+    // descriptor's own env_key plus all dedup_keys into processed_environs.
+    // A descriptor that names its own derived env_key in dedup_keys is
+    // redundant; flag it so the table stays clean.
+    for(const auto* group : all_core_groups())
+    {
+        for(const auto& descriptor : group->flags)
+        {
+            if(descriptor.names.empty()) continue;
+            auto       parser_key = std::string{ descriptor.names.back() };
+            const auto first_non_dash = parser_key.find_first_not_of('-');
+            if(first_non_dash != std::string::npos)
+                parser_key = parser_key.substr(first_non_dash);
+
+            auto env_key = parser_key;
+            std::replace(env_key.begin(), env_key.end(), '-', '_');
+
+            for(const auto& alias : descriptor.dedup_keys)
+            {
+                EXPECT_NE(std::string{ alias }, env_key)
+                    << "descriptor '" << last_name_or_unnamed(descriptor)
+                    << "' lists its own derived env_key '" << env_key
+                    << "' in dedup_keys (redundant)";
+            }
+        }
+    }
+}

--- a/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_core_flags_table.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_core_flags_table.cpp
@@ -28,13 +28,18 @@ using rocprofsys::common::update_mode;
 const std::vector<const flag_group*>&
 all_core_groups()
 {
-    namespace argparse = rocprofsys::argparse;
+    namespace argparse                                 = rocprofsys::argparse;
     static const std::vector<const flag_group*> groups = {
-        &argparse::debug_group(),     &argparse::general_group(),
-        &argparse::launcher_group(),  &argparse::tracing_group(),
-        &argparse::profile_group(),   &argparse::process_sampling_group(),
-        &argparse::general_sampling_group(), &argparse::sampling_timer_group(),
-        &argparse::hw_counter_group(), &argparse::misc_group(),
+        &argparse::debug_group(),
+        &argparse::general_group(),
+        &argparse::launcher_group(),
+        &argparse::tracing_group(),
+        &argparse::profile_group(),
+        &argparse::process_sampling_group(),
+        &argparse::general_sampling_group(),
+        &argparse::sampling_timer_group(),
+        &argparse::hw_counter_group(),
+        &argparse::misc_group(),
     };
     return groups;
 }
@@ -96,8 +101,7 @@ TEST(CoreFlagsTable, ListKindOrAppendModeDeclaresJoinExceptForCustom)
             {
                 EXPECT_NE(descriptor.join, join_with::none)
                     << "descriptor '" << last_name_or_unnamed(descriptor)
-                    << "' in group '" << group->title
-                    << "' needs an explicit join_with";
+                    << "' in group '" << group->title << "' needs an explicit join_with";
             }
         }
     }
@@ -114,7 +118,7 @@ TEST(CoreFlagsTable, ParserKeysAreUniqueAcrossAllGroups)
         for(const auto& descriptor : group->flags)
         {
             if(descriptor.names.empty()) continue;
-            auto       name = std::string{ descriptor.names.back() };
+            auto       name           = std::string{ descriptor.names.back() };
             const auto first_non_dash = name.find_first_not_of('-');
             if(first_non_dash != std::string::npos) name = name.substr(first_non_dash);
 
@@ -136,7 +140,7 @@ TEST(CoreFlagsTable, DedupKeysDoNotCollideWithDerivedEnvKey)
         for(const auto& descriptor : group->flags)
         {
             if(descriptor.names.empty()) continue;
-            auto       parser_key = std::string{ descriptor.names.back() };
+            auto       parser_key     = std::string{ descriptor.names.back() };
             const auto first_non_dash = parser_key.find_first_not_of('-');
             if(first_non_dash != std::string::npos)
                 parser_key = parser_key.substr(first_non_dash);

--- a/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_flag_descriptor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_flag_descriptor.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "core/argparse/flag_descriptor.hpp"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+using rocprofsys::argparse::count_spec;
+using rocprofsys::argparse::flag_descriptor;
+using rocprofsys::argparse::flag_group;
+using rocprofsys::argparse::join_with;
+using rocprofsys::argparse::value_kind;
+using rocprofsys::common::update_mode;
+
+constexpr int SENTINEL_UNSET = -1;
+}  // namespace
+
+TEST(CountSpec, ExactlyProducesExactOnly)
+{
+    constexpr auto spec = count_spec::exactly(3);
+    EXPECT_EQ(spec.exact, 3);
+    EXPECT_EQ(spec.min, SENTINEL_UNSET);
+    EXPECT_EQ(spec.max, SENTINEL_UNSET);
+}
+
+TEST(CountSpec, RangeProducesMinAndMax)
+{
+    constexpr auto spec = count_spec::range(1, 5);
+    EXPECT_EQ(spec.exact, SENTINEL_UNSET);
+    EXPECT_EQ(spec.min, 1);
+    EXPECT_EQ(spec.max, 5);
+}
+
+TEST(CountSpec, AtLeastProducesMinOnly)
+{
+    constexpr auto spec = count_spec::at_least(2);
+    EXPECT_EQ(spec.exact, SENTINEL_UNSET);
+    EXPECT_EQ(spec.min, 2);
+    EXPECT_EQ(spec.max, SENTINEL_UNSET);
+}
+
+TEST(CountSpec, AtMostProducesMaxOnly)
+{
+    constexpr auto spec = count_spec::at_most(4);
+    EXPECT_EQ(spec.exact, SENTINEL_UNSET);
+    EXPECT_EQ(spec.min, SENTINEL_UNSET);
+    EXPECT_EQ(spec.max, 4);
+}
+
+TEST(CountSpec, AnyLeavesAllUnset)
+{
+    constexpr auto spec = count_spec::any();
+    EXPECT_EQ(spec.exact, SENTINEL_UNSET);
+    EXPECT_EQ(spec.min, SENTINEL_UNSET);
+    EXPECT_EQ(spec.max, SENTINEL_UNSET);
+}
+
+TEST(CountSpec, DefaultConstructedMatchesAny)
+{
+    constexpr count_spec defaulted{};
+    constexpr auto       any_spec = count_spec::any();
+    EXPECT_EQ(defaulted.exact, any_spec.exact);
+    EXPECT_EQ(defaulted.min, any_spec.min);
+    EXPECT_EQ(defaulted.max, any_spec.max);
+}
+
+TEST(FlagDescriptor, DefaultConstructedHasSafeDefaults)
+{
+    flag_descriptor descriptor{};
+
+    EXPECT_TRUE(descriptor.names.empty());
+    EXPECT_TRUE(descriptor.help.empty());
+    EXPECT_TRUE(descriptor.dtype.empty());
+    EXPECT_EQ(descriptor.kind, value_kind::flag);
+    EXPECT_EQ(descriptor.join, join_with::none);
+    EXPECT_TRUE(descriptor.env_vars.empty());
+    EXPECT_EQ(descriptor.mode, update_mode::REPLACE);
+    EXPECT_TRUE(descriptor.dedup_keys.empty());
+    EXPECT_TRUE(descriptor.choices.empty());
+    EXPECT_TRUE(descriptor.conflicts.empty());
+    EXPECT_TRUE(descriptor.requires_.empty());
+    EXPECT_EQ(descriptor.custom, nullptr);
+
+    // Default count is "any" — no constraint.
+    EXPECT_EQ(descriptor.count.exact, SENTINEL_UNSET);
+    EXPECT_EQ(descriptor.count.min, SENTINEL_UNSET);
+    EXPECT_EQ(descriptor.count.max, SENTINEL_UNSET);
+}
+
+TEST(FlagGroup, DefaultConstructedHasEmptyFlags)
+{
+    flag_group group{};
+    EXPECT_TRUE(group.title.empty());
+    EXPECT_TRUE(group.subtitle.empty());
+    EXPECT_TRUE(group.flags.empty());
+}

--- a/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_parsed_values.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_parsed_values.cpp
@@ -150,7 +150,8 @@ TEST_F(ParsedValuesTest, GetInt64Vector)
 
 TEST_F(ParsedValuesTest, ExistsReturnsTrueForProvidedFlag)
 {
-    parser.add_argument({ std::string{ "--maybe" } }, std::string{ "maybe" }).max_count(1);
+    parser.add_argument({ std::string{ "--maybe" } }, std::string{ "maybe" })
+        .max_count(1);
     parse({ "--maybe" });
 
     parsed_values values{ parser };
@@ -159,7 +160,8 @@ TEST_F(ParsedValuesTest, ExistsReturnsTrueForProvidedFlag)
 
 TEST_F(ParsedValuesTest, ExistsReturnsFalseForOmittedFlag)
 {
-    parser.add_argument({ std::string{ "--maybe" } }, std::string{ "maybe" }).max_count(1);
+    parser.add_argument({ std::string{ "--maybe" } }, std::string{ "maybe" })
+        .max_count(1);
     parse({});  // do not provide --maybe
 
     parsed_values values{ parser };

--- a/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_parsed_values.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_parsed_values.cpp
@@ -1,0 +1,175 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// parsed_values is the engine-agnostic accessor handed to custom actions.
+// Tests construct a real parser_t, register a synthetic flag, parse argv,
+// then verify each get<T> specialization + exists + set_use_color through
+// the same path the production interpreter takes.
+
+#include "core/argparse/detail/parser_engine.hpp"
+#include "core/argparse/parsed_values.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <deque>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace
+{
+using rocprofsys::argparse::parsed_values;
+using rocprofsys::argparse::parser_t;
+
+class ParsedValuesTest : public ::testing::Test
+{
+protected:
+    parser_t parser{ "test" };
+
+    void SetUp() override { parser.enable_help(); }
+
+    void parse(std::vector<std::string> args)
+    {
+        args.insert(args.begin(), "test");
+        const auto err = parser.parse(args, 0);
+        ASSERT_FALSE(err) << err.what();
+    }
+};
+
+}  // namespace
+
+TEST_F(ParsedValuesTest, GetBoolFlag)
+{
+    parser.add_argument({ std::string{ "--flag" } }, std::string{ "f" }).max_count(1);
+    parse({ "--flag" });
+
+    parsed_values values{ parser };
+    EXPECT_TRUE(values.get<bool>("flag"));
+}
+
+TEST_F(ParsedValuesTest, GetInt)
+{
+    parser.add_argument({ std::string{ "--n" } }, std::string{ "n" })
+        .count(1)
+        .dtype("int");
+    parse({ "--n", "7" });
+
+    parsed_values values{ parser };
+    EXPECT_EQ(values.get<int>("n"), 7);
+}
+
+TEST_F(ParsedValuesTest, GetInt64)
+{
+    parser.add_argument({ std::string{ "--big" } }, std::string{ "big int" })
+        .count(1)
+        .dtype("int64");
+    parse({ "--big", "1234567890123" });
+
+    parsed_values values{ parser };
+    EXPECT_EQ(values.get<std::int64_t>("big"), std::int64_t{ 1234567890123 });
+}
+
+TEST_F(ParsedValuesTest, GetDouble)
+{
+    parser.add_argument({ std::string{ "--d" } }, std::string{ "d" })
+        .count(1)
+        .dtype("float");
+    parse({ "--d", "3.25" });
+
+    parsed_values values{ parser };
+    EXPECT_DOUBLE_EQ(values.get<double>("d"), 3.25);
+}
+
+TEST_F(ParsedValuesTest, GetString)
+{
+    parser.add_argument({ std::string{ "--name" } }, std::string{ "name" })
+        .count(1)
+        .dtype("string");
+    parse({ "--name", "marjan" });
+
+    parsed_values values{ parser };
+    EXPECT_EQ(values.get<std::string>("name"), "marjan");
+}
+
+TEST_F(ParsedValuesTest, GetStringSet)
+{
+    parser.add_argument({ std::string{ "--tags" } }, std::string{ "tags" })
+        .min_count(1)
+        .dtype("strings");
+    parse({ "--tags", "a", "b", "a" });  // duplicates collapsed by set
+
+    parsed_values values{ parser };
+    auto          result = values.get<std::set<std::string>>("tags");
+    EXPECT_EQ(result.size(), 2u);
+    EXPECT_TRUE(result.count("a") > 0);
+    EXPECT_TRUE(result.count("b") > 0);
+}
+
+TEST_F(ParsedValuesTest, GetStringVector)
+{
+    parser.add_argument({ std::string{ "--list" } }, std::string{ "list" })
+        .min_count(1)
+        .dtype("strings");
+    parse({ "--list", "x", "y", "z" });
+
+    parsed_values values{ parser };
+    auto          result = values.get<std::vector<std::string>>("list");
+    ASSERT_EQ(result.size(), 3u);
+    EXPECT_EQ(result[0], "x");
+    EXPECT_EQ(result[2], "z");
+}
+
+TEST_F(ParsedValuesTest, GetStringDeque)
+{
+    parser.add_argument({ std::string{ "--queue" } }, std::string{ "queue" })
+        .min_count(1)
+        .dtype("strings");
+    parse({ "--queue", "first", "second" });
+
+    parsed_values values{ parser };
+    auto          result = values.get<std::deque<std::string>>("queue");
+    ASSERT_EQ(result.size(), 2u);
+    EXPECT_EQ(result.front(), "first");
+    EXPECT_EQ(result.back(), "second");
+}
+
+TEST_F(ParsedValuesTest, GetInt64Vector)
+{
+    parser.add_argument({ std::string{ "--ids" } }, std::string{ "ids" })
+        .min_count(1)
+        .dtype("int and/or range");
+    parse({ "--ids", "10", "20", "30" });
+
+    parsed_values values{ parser };
+    auto          result = values.get<std::vector<std::int64_t>>("ids");
+    ASSERT_EQ(result.size(), 3u);
+    EXPECT_EQ(result[0], 10);
+    EXPECT_EQ(result[2], 30);
+}
+
+TEST_F(ParsedValuesTest, ExistsReturnsTrueForProvidedFlag)
+{
+    parser.add_argument({ std::string{ "--maybe" } }, std::string{ "maybe" }).max_count(1);
+    parse({ "--maybe" });
+
+    parsed_values values{ parser };
+    EXPECT_TRUE(values.exists("maybe"));
+}
+
+TEST_F(ParsedValuesTest, ExistsReturnsFalseForOmittedFlag)
+{
+    parser.add_argument({ std::string{ "--maybe" } }, std::string{ "maybe" }).max_count(1);
+    parse({});  // do not provide --maybe
+
+    parsed_values values{ parser };
+    EXPECT_FALSE(values.exists("maybe"));
+}
+
+TEST_F(ParsedValuesTest, SetUseColorPropagatesToEngine)
+{
+    parsed_values values{ parser };
+    values.set_use_color(false);  // smoke: must not throw
+    values.set_use_color(true);
+    SUCCEED();
+}

--- a/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_register_group.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_register_group.cpp
@@ -275,8 +275,12 @@ TEST_F(RegisterGroupTest, ValidatorRejectsListWithNoneJoinerWithoutCustom)
     flag_group group{
         "BAD",
         "",
-        { flag_descriptor{ { "--bad-list" }, "missing join", "items",
-                           count_spec::at_least(1), value_kind::list, join_with::none,
+        { flag_descriptor{ { "--bad-list" },
+                           "missing join",
+                           "items",
+                           count_spec::at_least(1),
+                           value_kind::list,
+                           join_with::none,
                            { "BAD_ENV" } } },
     };
     EXPECT_THROW(register_group(parser, data, group), std::runtime_error);
@@ -287,9 +291,14 @@ TEST_F(RegisterGroupTest, ValidatorRejectsAppendWithoutJoiner)
     flag_group group{
         "BAD",
         "",
-        { flag_descriptor{ { "--bad-append" }, "missing join", "string",
-                           count_spec::exactly(1), value_kind::scalar, join_with::none,
-                           { "BAD_ENV" }, update_mode::APPEND } },
+        { flag_descriptor{ { "--bad-append" },
+                           "missing join",
+                           "string",
+                           count_spec::exactly(1),
+                           value_kind::scalar,
+                           join_with::none,
+                           { "BAD_ENV" },
+                           update_mode::APPEND } },
     };
     EXPECT_THROW(register_group(parser, data, group), std::runtime_error);
 }
@@ -364,10 +373,20 @@ TEST_F(RegisterGroupTest, MultipleDescriptorsAllRegister)
         "MULTI",
         "subtitle",
         {
-            flag_descriptor{ { "--first" }, "first flag", {}, count_spec::at_most(1),
-                             value_kind::flag, join_with::none, { "FIRST_ENV" } },
-            flag_descriptor{ { "--second" }, "second flag", {}, count_spec::at_most(1),
-                             value_kind::flag, join_with::none, { "SECOND_ENV" } },
+            flag_descriptor{ { "--first" },
+                             "first flag",
+                             {},
+                             count_spec::at_most(1),
+                             value_kind::flag,
+                             join_with::none,
+                             { "FIRST_ENV" } },
+            flag_descriptor{ { "--second" },
+                             "second flag",
+                             {},
+                             count_spec::at_most(1),
+                             value_kind::flag,
+                             join_with::none,
+                             { "SECOND_ENV" } },
         },
     };
     register_group(parser, data, group);

--- a/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_register_group.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_register_group.cpp
@@ -1,0 +1,357 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Integration tests for argparse::register_group. Because the helpers in
+// interpreter.cpp (strip_dashes, keys_from, delimiter_for, read_value,
+// emit_env, register_flag) live in an anonymous namespace, they're covered
+// here through their observable effects on parser_data after a real
+// tim::argparse::argument_parser parses synthetic argv.
+
+#include "core/argparse.hpp"
+#include "core/argparse/flag_descriptor.hpp"
+#include "core/argparse/interpreter.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace
+{
+using rocprofsys::argparse::count_spec;
+using rocprofsys::argparse::flag_descriptor;
+using rocprofsys::argparse::flag_group;
+using rocprofsys::argparse::join_with;
+using rocprofsys::argparse::parser_data;
+using rocprofsys::argparse::parser_t;
+using rocprofsys::argparse::register_group;
+using rocprofsys::argparse::value_kind;
+using rocprofsys::common::update_mode;
+
+class RegisterGroupTest : public ::testing::Test
+{
+protected:
+    parser_t    parser{ "test" };
+    parser_data data{};
+
+    // tim::argparse::argument_parser requires enable_help() before start_group;
+    // skipping it causes a segfault inside start_group's bookkeeping. This
+    // mirrors the setup tool_runner does in production.
+    void SetUp() override { parser.enable_help(); }
+
+    void register_single(flag_descriptor descriptor)
+    {
+        flag_group group{ "TEST", "", { std::move(descriptor) } };
+        register_group(parser, data, group);
+    }
+
+    void parse(std::vector<std::string> args)
+    {
+        args.insert(args.begin(), "test");  // argv[0]
+        const auto err = parser.parse(args, 0);
+        ASSERT_FALSE(err) << err.what();
+    }
+
+    [[nodiscard]] std::string env_value(std::string_view key) const
+    {
+        const auto needle = std::string{ key } + "=";
+        for(const auto& entry : data.env.current)
+        {
+            if(entry.compare(0, needle.size(), needle) == 0)
+                return entry.substr(needle.size());
+        }
+        return {};
+    }
+};
+
+}  // namespace
+
+// -----------------------------------------------------------------------------
+// value_kind coverage — drives read_value / emit_env for each variant
+// -----------------------------------------------------------------------------
+
+TEST_F(RegisterGroupTest, FlagKindEmitsTrueWhenPresent)
+{
+    register_single({
+        /* names    */ { "--my-flag" },
+        /* help     */ "test flag",
+        /* dtype    */ {},
+        /* count    */ count_spec::at_most(1),
+        /* kind     */ value_kind::flag,
+        /* join     */ join_with::none,
+        /* env_vars */ { "MY_FLAG_ENV" },
+    });
+
+    parse({ "--my-flag" });
+
+    EXPECT_EQ(env_value("MY_FLAG_ENV"), "true");
+}
+
+TEST_F(RegisterGroupTest, ScalarKindEmitsRawValue)
+{
+    register_single({
+        /* names    */ { "--scalar-opt" },
+        /* help     */ "scalar option",
+        /* dtype    */ "string",
+        /* count    */ count_spec::exactly(1),
+        /* kind     */ value_kind::scalar,
+        /* join     */ join_with::none,
+        /* env_vars */ { "SCALAR_ENV" },
+    });
+
+    parse({ "--scalar-opt", "hello" });
+
+    EXPECT_EQ(env_value("SCALAR_ENV"), "hello");
+}
+
+TEST_F(RegisterGroupTest, ScalarIntEmitsIntegerString)
+{
+    register_single({
+        /* names    */ { "--int-opt" },
+        /* help     */ "int option",
+        /* dtype    */ "int",
+        /* count    */ count_spec::exactly(1),
+        /* kind     */ value_kind::scalar_int,
+        /* join     */ join_with::none,
+        /* env_vars */ { "INT_ENV" },
+    });
+
+    parse({ "--int-opt", "42" });
+
+    EXPECT_EQ(env_value("INT_ENV"), "42");
+}
+
+TEST_F(RegisterGroupTest, ScalarDoubleEmitsDoubleString)
+{
+    register_single({
+        /* names    */ { "--double-opt" },
+        /* help     */ "double option",
+        /* dtype    */ "float",
+        /* count    */ count_spec::exactly(1),
+        /* kind     */ value_kind::scalar_double,
+        /* join     */ join_with::none,
+        /* env_vars */ { "DOUBLE_ENV" },
+    });
+
+    parse({ "--double-opt", "3.5" });
+
+    // std::to_string(3.5) → "3.500000"; just check leading digits.
+    EXPECT_EQ(env_value("DOUBLE_ENV").substr(0, 3), "3.5");
+}
+
+TEST_F(RegisterGroupTest, ListKindWithCommaJoinerJoinsValues)
+{
+    register_single({
+        /* names    */ { "--list-opt" },
+        /* help     */ "list option",
+        /* dtype    */ "items",
+        /* count    */ count_spec::at_least(1),
+        /* kind     */ value_kind::list,
+        /* join     */ join_with::comma,
+        /* env_vars */ { "LIST_ENV" },
+    });
+
+    parse({ "--list-opt", "a", "b", "c" });
+
+    EXPECT_EQ(env_value("LIST_ENV"), "a,b,c");
+}
+
+TEST_F(RegisterGroupTest, ListKindWithSpaceJoinerJoinsValues)
+{
+    register_single({
+        /* names    */ { "--space-list" },
+        /* help     */ "list with spaces",
+        /* dtype    */ "items",
+        /* count    */ count_spec::at_least(1),
+        /* kind     */ value_kind::list,
+        /* join     */ join_with::space,
+        /* env_vars */ { "SPACE_LIST_ENV" },
+    });
+
+    parse({ "--space-list", "x", "y" });
+
+    EXPECT_EQ(env_value("SPACE_LIST_ENV"), "x y");
+}
+
+// -----------------------------------------------------------------------------
+// keys_from coverage — long-name derivation, hyphen-to-underscore env_key,
+// dedup_keys promotion
+// -----------------------------------------------------------------------------
+
+TEST_F(RegisterGroupTest, LongNameDerivesParserAndEnvKeys)
+{
+    // names = ["-x", "--extended-name"]; parser_key derives from the LAST name.
+    register_single({
+        /* names    */ { "-x", "--extended-name" },
+        /* help     */ "extended",
+        /* dtype    */ "string",
+        /* count    */ count_spec::exactly(1),
+        /* kind     */ value_kind::scalar,
+        /* join     */ join_with::none,
+        /* env_vars */ { "EXTENDED_ENV" },
+    });
+
+    parse({ "--extended-name", "value" });
+
+    EXPECT_EQ(env_value("EXTENDED_ENV"), "value");
+    // env_key derives from parser_key with hyphens → underscores.
+    EXPECT_TRUE(data.reg.processed_environs.count("extended_name") > 0);
+}
+
+TEST_F(RegisterGroupTest, DedupKeysArePromotedToProcessedEnvirons)
+{
+    register_single({
+        /* names      */ { "--dedup-flag" },
+        /* help       */ "dedup",
+        /* dtype      */ {},
+        /* count      */ count_spec::at_most(1),
+        /* kind       */ value_kind::flag,
+        /* join       */ join_with::none,
+        /* env_vars   */ {},
+        /* mode       */ update_mode::REPLACE,
+        /* dedup_keys */ { "alias_one", "alias_two" },
+    });
+
+    EXPECT_TRUE(data.reg.processed_environs.count("dedup_flag") > 0);
+    EXPECT_TRUE(data.reg.processed_environs.count("alias_one") > 0);
+    EXPECT_TRUE(data.reg.processed_environs.count("alias_two") > 0);
+}
+
+// -----------------------------------------------------------------------------
+// environ_filter integration — skip-on-false
+// -----------------------------------------------------------------------------
+
+TEST_F(RegisterGroupTest, EnvironFilterFalseSuppressesRegistration)
+{
+    data.reg.environ_filter = [](std::string_view key, const parser_data&) {
+        return key != "filtered_out";
+    };
+
+    register_single({
+        /* names    */ { "--filtered-out" },
+        /* help     */ "should not register",
+        /* dtype    */ {},
+        /* count    */ count_spec::at_most(1),
+        /* kind     */ value_kind::flag,
+        /* join     */ join_with::none,
+        /* env_vars */ { "FILTERED_ENV" },
+    });
+
+    // Filter blocked registration, so processed_environs stays clean for this key.
+    EXPECT_EQ(data.reg.processed_environs.count("filtered_out"), 0u);
+}
+
+// -----------------------------------------------------------------------------
+// update_mode coverage — drives emit_env behavior
+// -----------------------------------------------------------------------------
+
+TEST_F(RegisterGroupTest, UpdateModeAppendConcatenatesExisting)
+{
+    // Pre-seed env to make APPEND observable.
+    data.env.current.emplace_back("APPEND_ENV=base");
+    data.env.initial.emplace("APPEND_ENV=base");
+
+    register_single({
+        /* names    */ { "--append-opt" },
+        /* help     */ "append",
+        /* dtype    */ "string",
+        /* count    */ count_spec::exactly(1),
+        /* kind     */ value_kind::scalar,
+        /* join     */ join_with::none,
+        /* env_vars */ { "APPEND_ENV" },
+        /* mode     */ update_mode::APPEND,
+    });
+
+    parse({ "--append-opt", "added" });
+
+    // APPEND uses the default ":" delimiter from emit_env's scalar branch.
+    EXPECT_EQ(env_value("APPEND_ENV"), "base:added");
+}
+
+// -----------------------------------------------------------------------------
+// Multiple env_vars per descriptor — all should be written
+// -----------------------------------------------------------------------------
+
+TEST_F(RegisterGroupTest, MultipleEnvVarsAllWritten)
+{
+    register_single({
+        /* names    */ { "--multi-env" },
+        /* help     */ "multi env",
+        /* dtype    */ "string",
+        /* count    */ count_spec::exactly(1),
+        /* kind     */ value_kind::scalar,
+        /* join     */ join_with::none,
+        /* env_vars */ { "ENV_A", "ENV_B", "ENV_C" },
+    });
+
+    parse({ "--multi-env", "shared" });
+
+    EXPECT_EQ(env_value("ENV_A"), "shared");
+    EXPECT_EQ(env_value("ENV_B"), "shared");
+    EXPECT_EQ(env_value("ENV_C"), "shared");
+}
+
+// -----------------------------------------------------------------------------
+// Custom action path — short-circuits default env emission
+// -----------------------------------------------------------------------------
+
+namespace
+{
+void
+custom_writes_marker(parser_t& /*parser*/, parser_data& data)
+{
+    data.env.set("CUSTOM_MARKER", "yes");
+}
+}  // namespace
+
+TEST_F(RegisterGroupTest, CustomActionRunsInsteadOfDefaultEnvEmission)
+{
+    register_single({
+        /* names      */ { "--custom-flag" },
+        /* help       */ "custom",
+        /* dtype      */ {},
+        /* count      */ count_spec::at_most(1),
+        /* kind       */ value_kind::flag,
+        /* join       */ join_with::none,
+        /* env_vars   */ { "SHOULD_NOT_APPEAR" },
+        /* mode       */ update_mode::REPLACE,
+        /* dedup_keys */ {},
+        /* choices    */ {},
+        /* conflicts  */ {},
+        /* requires_  */ {},
+        /* custom     */ &custom_writes_marker,
+    });
+
+    parse({ "--custom-flag" });
+
+    EXPECT_EQ(env_value("CUSTOM_MARKER"), "yes");
+    EXPECT_EQ(env_value("SHOULD_NOT_APPEAR"), "");
+}
+
+// -----------------------------------------------------------------------------
+// Multi-descriptor group — every descriptor in flags[] registers
+// -----------------------------------------------------------------------------
+
+TEST_F(RegisterGroupTest, MultipleDescriptorsAllRegister)
+{
+    flag_group group{
+        "MULTI",
+        "subtitle",
+        {
+            flag_descriptor{ { "--first" }, "first flag", {}, count_spec::at_most(1),
+                             value_kind::flag, join_with::none, { "FIRST_ENV" } },
+            flag_descriptor{ { "--second" }, "second flag", {}, count_spec::at_most(1),
+                             value_kind::flag, join_with::none, { "SECOND_ENV" } },
+        },
+    };
+    register_group(parser, data, group);
+
+    EXPECT_GT(data.reg.processed_environs.count("first"), 0u);
+    EXPECT_GT(data.reg.processed_environs.count("second"), 0u);
+
+    parse({ "--first", "--second" });
+
+    EXPECT_EQ(env_value("FIRST_ENV"), "true");
+    EXPECT_EQ(env_value("SECOND_ENV"), "true");
+}

--- a/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_register_group.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_register_group.cpp
@@ -24,6 +24,7 @@ using rocprofsys::argparse::count_spec;
 using rocprofsys::argparse::flag_descriptor;
 using rocprofsys::argparse::flag_group;
 using rocprofsys::argparse::join_with;
+using rocprofsys::argparse::parsed_values;
 using rocprofsys::argparse::parser_data;
 using rocprofsys::argparse::parser_t;
 using rocprofsys::argparse::register_group;
@@ -300,7 +301,7 @@ TEST_F(RegisterGroupTest, MultipleEnvVarsAllWritten)
 namespace
 {
 void
-custom_writes_marker(parser_t& /*parser*/, parser_data& data)
+custom_writes_marker(parsed_values& /*values*/, parser_data& data)
 {
     data.env.set("CUSTOM_MARKER", "yes");
 }

--- a/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_register_group.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_register_group.cpp
@@ -8,6 +8,7 @@
 // tim::argparse::argument_parser parses synthetic argv.
 
 #include "core/argparse.hpp"
+#include "core/argparse/detail/parser_engine.hpp"
 #include "core/argparse/flag_descriptor.hpp"
 #include "core/argparse/interpreter.hpp"
 

--- a/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_register_group.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse/tests/test_register_group.cpp
@@ -260,15 +260,38 @@ TEST_F(RegisterGroupTest, UpdateModeAppendConcatenatesExisting)
         /* dtype    */ "string",
         /* count    */ count_spec::exactly(1),
         /* kind     */ value_kind::scalar,
-        /* join     */ join_with::none,
+        /* join     */ join_with::colon,  // APPEND requires an explicit join
         /* env_vars */ { "APPEND_ENV" },
         /* mode     */ update_mode::APPEND,
     });
 
     parse({ "--append-opt", "added" });
 
-    // APPEND uses the default ":" delimiter from emit_env's scalar branch.
     EXPECT_EQ(env_value("APPEND_ENV"), "base:added");
+}
+
+TEST_F(RegisterGroupTest, ValidatorRejectsListWithNoneJoinerWithoutCustom)
+{
+    flag_group group{
+        "BAD",
+        "",
+        { flag_descriptor{ { "--bad-list" }, "missing join", "items",
+                           count_spec::at_least(1), value_kind::list, join_with::none,
+                           { "BAD_ENV" } } },
+    };
+    EXPECT_THROW(register_group(parser, data, group), std::runtime_error);
+}
+
+TEST_F(RegisterGroupTest, ValidatorRejectsAppendWithoutJoiner)
+{
+    flag_group group{
+        "BAD",
+        "",
+        { flag_descriptor{ { "--bad-append" }, "missing join", "string",
+                           count_spec::exactly(1), value_kind::scalar, join_with::none,
+                           { "BAD_ENV" }, update_mode::APPEND } },
+    };
+    EXPECT_THROW(register_group(parser, data, group), std::runtime_error);
 }
 
 // -----------------------------------------------------------------------------

--- a/projects/rocprofiler-systems/source/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(UNIT_TEST_OBJECTS
     $<TARGET_OBJECTS:rocprofiler-sdk-components-unit-tests>
     $<$<TARGET_EXISTS:rccl-unit-tests>:$<TARGET_OBJECTS:rccl-unit-tests>>
     $<$<TARGET_EXISTS:bin-common-tests>:$<TARGET_OBJECTS:bin-common-tests>>
+    $<$<TARGET_EXISTS:argparse-tests>:$<TARGET_OBJECTS:argparse-tests>>
 )
 
 list(APPEND UNIT_TEST_OBJECTS $<TARGET_OBJECTS:pmc-common-tests>)


### PR DESCRIPTION
## Motivation

- So far `argparse` module has grown up to ~1400 lines of code, of which most of them were just repeating ~30 near identical argument registration blocks.
- This pattern made the (CLI flag → env var) intent invisible inside fluent chains plus hand-written lambdas, with no compile-time enforcement of the alias bookkeeping and with several flags coupling to the underlying `tim::argparse` engine in ways that would be expensive to swap.
- This PR replaces the handwritten registration with a declarative `flag_descriptor` table walked by a small `interpreter`, leaving the remaining handwritten flags only where their behavior cannot be expressed as data (runtime-conditional choices, settings-registry-driven flags). After the refactor, argparse.cpp is ~470 lines (down from ~1390), and the engine choice is confined to a single small  translation unit (`interpreter.cpp`) allowing for a future swap a focused change rather than a rewrite. 

**NOTE**: This PR is appended upon work done in #5142 

## Technical Details

- Introduces new structure to the argument parser module:

source/lib/core/argparse/                  (new directory)
├── flag_descriptor.hpp
│
├── interpreter.hpp
│
├── interpreter.cpp 
│
├── core_flags.hpp
│
├── core_flags.cpp
│
└── CMakeLists.txt.

- **`flag_descriptor`** -> Pure data: flag_descriptor, flag_group, count_spec, value_kind (flag/scalar/scalar_int/scalar_double/list), join_with, custom_action_t. No behavior.
- **`interpreter`** -> The engine seam. Top-of-file note documents tim::argparse as the interim engine; a future swap is confined to this TU.
- **`core_flags`** -> 9 group accessors: debug_group, general_group, tracing_group, profile_group, process_sampling_group, profile_group, process_sampling_group, general_sampling_group, sampling_timer_group, hw_counter_group, misc_group.

- Descriptors are engine-agnostic; `custom_action_t` is the only place the engine type leaks in. A future engine swap (CLI11 etc.) rewrites only `interpreter.cpp` plus the ~10 `custom` action bodies — the ~30 data-only descriptors stay byte-identical.

- Drops: per-file LOC tables, the verbose deferred-work table (now compressed into the surviving-handwritten lines), and the long set_env/update_env migration paragraph
  
## JIRA ID

N/A

## Test Plan

- Build rocprof-sys-run and rocprof-sys-sample at `-DROCPROFSYS_BUILD_DEVELOPER=ON` (catches -Werror regressions on the touched files).
- Manual smoke tests with representative flag combinations across each migrated groups
-  For each combo, captured the `ROCPROFSYS: env-var` lines emitted to stderr and diffed against the pre-refactor binary are byte-identical
-  `--help` rendering visually inspected for each migrated group; group titles, descriptions, and flag order preserved.
- Confirmed un-migrated handwritten flags (`-I, -E, -l, --trace-clock-id`) and settings-driven flags continue to work (they share the same `processed_environs` dedup mechanism with the `descriptor-driven` flags).

## Test Result

- Builds cleanly with `-Wall -Wextra -Wpedantic` and with `-Werror`.
- No behavior changes observed for any tested CLI combination.
- `--help` output identical (ordering, group titles, flag descriptions, dtype annotations).
- All existing tests pass 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.