### PR TITLE
Fix hsakmt_fmm_deregister_memory failure in systems without SVM API.

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -4358,14 +4358,23 @@ HSAKMT_STATUS hsakmt_fmm_deregister_memory(HsaKFDContext *ctx, void *address)
 	vm_object_t *object;
 	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
 
+	/* Unknown addresses are a no-op when not using dGPUs or when using SVM. */
+	bool require_registered_mem = hsakmt_is_dgpu && !ctx->hsakmt_is_svm_api_supported;
+
 	object = vm_find_object(fmm_ctx, address, 0, &aperture);
-	if (!object)
-		/* On APUs we assume it's a random system memory address
-		 * where registration and dergistration is a no-op
+	if (!object && require_registered_mem) {
+		/* The size=0 lookup rejects an address with more than one userptr
+		 * node (e.g. a single host VA registered with different pinAllocSize).
+		 * The HSA deregister API only takes an address, so fall back to the
+		 * range-based lookup which tolerates duplicates and releases any one
+		 * node whose range contains that address.
 		 */
-		return (!hsakmt_is_dgpu || ctx->hsakmt_is_svm_api_supported) ?
-			HSAKMT_STATUS_SUCCESS :
-			HSAKMT_STATUS_MEMORY_NOT_REGISTERED;
+		object = vm_find_object(fmm_ctx, address, UINT64_MAX, &aperture);
+	}
+	if (!object)
+		return require_registered_mem ?
+			HSAKMT_STATUS_MEMORY_NOT_REGISTERED :
+			HSAKMT_STATUS_SUCCESS;
 	/* Successful vm_find_object returns with aperture locked */
 
 	if (aperture == &fmm_ctx->cpuvm_aperture) {


### PR DESCRIPTION
## Motivation

Unit test Unit_hipMemsetFunctional_PartialSet_3D fails in systems where HMM support is disabled.

## Technical Details

After registering the same host VA address multiple times with different sizes, hsakmt_fmm_deregister_memory fails to resolve the ambiguity. This commit adds a fall-back path for that case in systems without SVM API support.

## JIRA ID

Resolves ROCM-21022

## Test Plan

Tested locally.

## Test Result

Test passes locally when HMM is disabled

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
