### PR TITLE
[ROCM-186] support amd-ttm module name and document UMA carveout prerequisites

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -1810,7 +1810,26 @@ class AMDSMICommands:
                     else:
                         static_dict["mem_carveout"] = "N/A"
             except amdsmi_exception.AmdSmiLibraryException as e:
-                static_dict["mem_carveout"] = "N/A"
+                # UMA carveout is only exposed by APU VBIOSes that support
+                # ATCS function 0xA. On dGPUs and Instinct parts (including
+                # MI300A) the sysfs attribute does not exist and the library
+                # returns NOT_SUPPORTED; surface a clearer reason than bare N/A.
+                not_supported = (
+                    e.get_error_code()
+                    == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED
+                )
+                if not_supported and not (
+                    self.logger.is_json_format() or self.logger.is_csv_format()
+                ):
+                    # Human-readable: give a descriptive reason. JSON/CSV
+                    # consumers keep the legacy bare "N/A" for back-compat.
+                    static_dict["mem_carveout"] = (
+                        "N/A (UMA carveout is not supported on this ASIC/VBIOS)"
+                    )
+                elif self.logger.is_csv_format():
+                    static_dict["mem_carveout_index"] = "N/A"
+                else:
+                    static_dict["mem_carveout"] = "N/A"
                 logging.debug(
                     "Failed to get mem carveout info for gpu %s | %s", gpu_id, e.get_error_info()
                 )
@@ -9261,11 +9280,26 @@ class AMDSMICommands:
             except amdsmi_exception.AmdSmiLibraryException as e:
                 if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
                     raise PermissionError("Command requires elevation") from e
-                self.logger.store_output(
-                    args.gpu,
-                    "mem_carveout",
-                    f"[{e.get_error_info(detailed=False)}] Unable to set VRAM carveout to index {args.mem_carveout}",
-                )
+                if (
+                    e.get_error_code()
+                    == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED
+                ):
+                    # Same reason as the static -m branch: UMA carveout
+                    # requires an APU VBIOS that exposes ATCS 0xA. Surface
+                    # an actionable message instead of a raw error code.
+                    self.logger.store_output(
+                        args.gpu,
+                        "mem_carveout",
+                        "Not supported: UMA carveout requires an APU with VBIOS ATCS 0xA"
+                        " (e.g. Ryzen AI / Strix). Not available on dGPUs or Instinct"
+                        " MI-series (including MI300A).",
+                    )
+                else:
+                    self.logger.store_output(
+                        args.gpu,
+                        "mem_carveout",
+                        f"[{e.get_error_info(detailed=False)}] Unable to set VRAM carveout to index {args.mem_carveout}",
+                    )
                 self.logger.print_output()
 
             self.logger.clear_multiple_devices_output()

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -9284,15 +9284,14 @@ class AMDSMICommands:
                     e.get_error_code()
                     == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED
                 ):
-                    # Same reason as the static -m branch: UMA carveout
-                    # requires an APU VBIOS that exposes ATCS 0xA. Surface
-                    # an actionable message instead of a raw error code.
+                    # Surface an actionable message instead of a raw error code.
+                    # Avoid naming specific products here so the message does not
+                    # age as new ASICs add or drop UMA carveout support.
                     self.logger.store_output(
                         args.gpu,
                         "mem_carveout",
-                        "Not supported: UMA carveout requires an APU with VBIOS ATCS 0xA"
-                        " (e.g. Ryzen AI / Strix). Not available on dGPUs or Instinct"
-                        " MI-series (including MI300A).",
+                        "Not supported: UMA carveout is only available on APUs whose"
+                        ' VBIOS exposes the ATCS "Set UMA Allocation Size" function.',
                     )
                 else:
                     self.logger.store_output(

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -1621,7 +1621,12 @@ class AMDSMIParser(argparse.ArgumentParser):
                 "-p", "--partition", action="store_true", required=False, help=partition_help
             )
 
-            mem_carveout_help = "Display VRAM carveout memory options and current setting"
+            mem_carveout_help = (
+                "Display VRAM carveout memory options and current setting."
+                "\n\tSupported on APUs whose VBIOS exposes ATCS 0xA"
+                " (e.g. Ryzen AI / Strix). Not available on dGPUs or"
+                " Instinct MI-series (including MI300A)."
+            )
             static_parser.add_argument(
                 "-m", "--mem-carveout", action="store_true", required=False, help=mem_carveout_help
             )
@@ -2624,7 +2629,13 @@ class AMDSMIParser(argparse.ArgumentParser):
             )
 
             if self.helpers.is_baremetal():
-                set_mem_carveout_help = "Set VRAM carveout size by option index.\n\tUse `amd-smi static --mem-carveout` to see available options."
+                set_mem_carveout_help = (
+                    "Set VRAM carveout size by option index."
+                    "\n\tUse `amd-smi static --mem-carveout` to see available options."
+                    "\n\tRequires an APU with VBIOS ATCS 0xA support"
+                    " (Ryzen AI / Strix / Strix Halo). A reboot is required"
+                    " after setting."
+                )
                 set_value_exclusive_group.add_argument(
                     "-m",
                     "--mem-carveout",

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -1623,9 +1623,7 @@ class AMDSMIParser(argparse.ArgumentParser):
 
             mem_carveout_help = (
                 "Display VRAM carveout memory options and current setting."
-                "\n\tSupported on APUs whose VBIOS exposes ATCS 0xA"
-                " (e.g. Ryzen AI / Strix). Not available on dGPUs or"
-                " Instinct MI-series (including MI300A)."
+                "\n\tOnly supported on some APUs."
             )
             static_parser.add_argument(
                 "-m", "--mem-carveout", action="store_true", required=False, help=mem_carveout_help
@@ -2632,9 +2630,7 @@ class AMDSMIParser(argparse.ArgumentParser):
                 set_mem_carveout_help = (
                     "Set VRAM carveout size by option index."
                     "\n\tUse `amd-smi static --mem-carveout` to see available options."
-                    "\n\tRequires an APU with VBIOS ATCS 0xA support"
-                    " (Ryzen AI / Strix / Strix Halo). A reboot is required"
-                    " after setting."
+                    "\n\tOnly supported on some APUs; a reboot is required after setting."
                 )
                 set_value_exclusive_group.add_argument(
                     "-m",

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -1416,3 +1416,37 @@ Refer to
 and
 [amd_smi_afid_example.py](https://github.com/ROCm/rocm-systems/blob/develop/projects/amdsmi/example/amd_smi_afid_example.py)
 for API examples.
+
+## Memory tuning: UMA carveout and GTT
+
+`amd-smi static --mem-carveout` / `amd-smi set --mem-carveout INDEX` and
+`amd-smi node --gtt` / `amd-smi set --gtt GB` / `amd-smi reset --gtt` let
+users inspect and tune the BIOS VRAM carveout and the TTM `pages_limit`
+(shared GTT) respectively. Both features talk directly to kernel UAPI
+interfaces (sysfs / modprobe.d) and do **not** require libdrm.
+
+### Supported ASICs
+
+| Feature | Hardware | Status |
+|---|---|---|
+| `--mem-carveout` (UMA carveout) | Ryzen AI / Strix / Strix Halo (gfx1150, gfx1151, gfx1152) and Phoenix / Hawk Point APUs with a VBIOS that exposes ATCS 0xA | Supported |
+| `--mem-carveout` (UMA carveout) | Radeon dGPUs, Instinct MI-series (MI100, MI200, MI300, MI300A) | Not supported — reported as `MEM_CARVEOUT: N/A (UMA carveout is not supported on this ASIC/VBIOS)` |
+| `--gtt` (TTM `pages_limit`) | Any amdgpu system, including Instinct MI300A (`amdttm` / `amd-ttm`) and Ryzen APUs (`ttm`) | Supported |
+
+### Prerequisites
+
+- **UMA carveout:** Linux kernel >= 6.17 (`drm/amdgpu: add UMA carveout tuning interfaces`), an APU VBIOS that advertises ATCS 0xA + IGP info table v2.3, root, and a reboot after changing the index.
+- **GTT (TTM `pages_limit`):** root (to write `/etc/modprobe.d/<module>.conf`), optionally `dracut` (the tool will rebuild the initramfs automatically when `dracut` is present), and a reboot to apply the new limit. amd-smi auto-detects the TTM kernel module name (`ttm`, `amdttm`, or `amd-ttm`) and writes the matching `.conf`.
+
+### Troubleshooting: `MEM_CARVEOUT: N/A`
+
+On MI300A (and every non-APU / pre-ATCS-0xA platform) the kernel does not
+create `/sys/class/drm/<card>/device/uma/`, so `amd-smi static --mem-carveout`
+prints
+
+```text
+MEM_CARVEOUT: N/A (UMA carveout is not supported on this ASIC/VBIOS)
+```
+
+This is expected. Use `amd-smi node --gtt` / `amd-smi set --gtt` to tune
+shared GPU memory on those platforms instead.

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -1429,13 +1429,13 @@ interfaces (sysfs / modprobe.d) and do **not** require libdrm.
 
 | Feature | Hardware | Status |
 |---|---|---|
-| `--mem-carveout` (UMA carveout) | Ryzen AI / Strix / Strix Halo (gfx1150, gfx1151, gfx1152) and Phoenix / Hawk Point APUs with a VBIOS that exposes ATCS 0xA | Supported |
+| `--mem-carveout` (UMA carveout) | Strix and later APUs (gfx1150, gfx1151, gfx1152) whose VBIOS exposes ATCS 0xA | Supported |
 | `--mem-carveout` (UMA carveout) | Radeon dGPUs, Instinct MI-series (MI100, MI200, MI300, MI300A) | Not supported — reported as `MEM_CARVEOUT: N/A (UMA carveout is not supported on this ASIC/VBIOS)` |
 | `--gtt` (TTM `pages_limit`) | Any amdgpu system, including Instinct MI300A (`amdttm` / `amd-ttm`) and Ryzen APUs (`ttm`) | Supported |
 
 ### Prerequisites
 
-- **UMA carveout:** Linux kernel >= 6.17 (`drm/amdgpu: add UMA carveout tuning interfaces`), an APU VBIOS that advertises ATCS 0xA + IGP info table v2.3, root, and a reboot after changing the index.
+- **UMA carveout:** Linux kernel >= 7.0 (upstream commit [`685b711`](https://github.com/torvalds/linux/commit/685b711); some distros backport it to earlier kernels), an APU VBIOS that advertises ATCS 0xA + IGP info table v2.3, root, and a reboot after changing the index.
 - **GTT (TTM `pages_limit`):** root (to write `/etc/modprobe.d/<module>.conf`), optionally `dracut` (the tool will rebuild the initramfs automatically when `dracut` is present), and a reboot to apply the new limit. amd-smi auto-detects the TTM kernel module name (`ttm`, `amdttm`, or `amd-ttm`) and writes the matching `.conf`.
 
 ### Troubleshooting: `MEM_CARVEOUT: N/A`

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -5153,15 +5153,15 @@ except AmdSmiException as e:
 
 - Only available on APU parts whose VBIOS exposes ATCS function 0xA
   ("Set UMA Allocation Size") and an `integrated_system_info` table of
-  at least v2.3. In practice this covers Ryzen AI, Strix, and Strix Halo
-  (gfx1150/gfx1151/gfx1152), plus select Phoenix/Hawk Point APUs with an
-  updated VBIOS.
+  at least v2.3. In practice this covers Strix and later APUs
+  (gfx1150/gfx1151/gfx1152).
 - **Not available** on dedicated GPUs or Instinct MI-series accelerators
   (including MI300A); the call returns `AMDSMI_STATUS_NOT_SUPPORTED` and
   `amd-smi static --mem-carveout` prints
   `MEM_CARVEOUT: N/A (UMA carveout is not supported on this ASIC/VBIOS)`.
-- Requires Linux kernel >= 6.17 (the `drm/amdgpu: add UMA carveout tuning
-  interfaces` series) and read access to
+- Requires Linux kernel >= 7.0 (upstream commit
+  [`685b711`](https://github.com/torvalds/linux/commit/685b711); some
+  distros backport it to earlier kernels) and read access to
   `/sys/class/drm/<card>/device/uma/carveout`.
 
 Description: Get UMA carveout (VRAM) configuration information for a GPU. Returns the current carveout index, total number of available options, and a list of option descriptions.

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -5149,6 +5149,21 @@ except AmdSmiException as e:
 
 **Note:** This is a kernel UAPI feature (sysfs), not libdrm.
 
+**Supported ASICs and prerequisites:**
+
+- Only available on APU parts whose VBIOS exposes ATCS function 0xA
+  ("Set UMA Allocation Size") and an `integrated_system_info` table of
+  at least v2.3. In practice this covers Ryzen AI, Strix, and Strix Halo
+  (gfx1150/gfx1151/gfx1152), plus select Phoenix/Hawk Point APUs with an
+  updated VBIOS.
+- **Not available** on dedicated GPUs or Instinct MI-series accelerators
+  (including MI300A); the call returns `AMDSMI_STATUS_NOT_SUPPORTED` and
+  `amd-smi static --mem-carveout` prints
+  `MEM_CARVEOUT: N/A (UMA carveout is not supported on this ASIC/VBIOS)`.
+- Requires Linux kernel >= 6.17 (the `drm/amdgpu: add UMA carveout tuning
+  interfaces` series) and read access to
+  `/sys/class/drm/<card>/device/uma/carveout`.
+
 Description: Get UMA carveout (VRAM) configuration information for a GPU. Returns the current carveout index, total number of available options, and a list of option descriptions.
 
 Input parameters:
@@ -5229,6 +5244,21 @@ try:
 except AmdSmiException as e:
     print(e)
 ```
+
+### GTT (TTM `pages_limit`) APIs
+
+**Supported ASICs and prerequisites:**
+
+- Supported on every system running the amdgpu stack, including Ryzen
+  APUs (in-kernel amdgpu), Radeon dGPUs, and Instinct MI-series
+  accelerators with amdgpu-dkms (MI100 / MI200 / MI300 / MI300A).
+- The kernel TTM module may be named `ttm` (upstream), `amdttm` (older
+  amdgpu-dkms), or `amd-ttm` (newer amdgpu-dkms). amd-smi detects the
+  loaded module automatically by inspecting `/sys/module/` and writes the
+  corresponding `/etc/modprobe.d/<module>.conf`.
+- Writing `pages_limit` requires root and a reboot to take effect.
+  `dracut -f` is invoked automatically when available so that the change
+  is picked up by the initramfs.
 
 ### amdsmi_get_ttm_info
 

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -8724,16 +8724,15 @@ amdsmi_status_t amdsmi_get_nic_rdma_port_statistics(amdsmi_processor_handle proc
  *  @par Supported ASICs (UMA carveout)
  *  UMA carveout is only available on APU parts whose VBIOS exposes the
  *  ATCS function code 0xA ("Set UMA Allocation Size") together with an
- *  integrated_system_info table of at least v2.3. Currently this means:
- *    - Ryzen AI / Strix / Strix Halo (gfx1150, gfx1151, gfx1152)
- *    - Select Phoenix/Hawk Point Ryzen APUs with updated VBIOS
- *  Dedicated GPUs and Instinct MI-series accelerators (including MI300A)
- *  do NOT expose this interface, and amdsmi_get_gpu_uma_carveout_info()
- *  returns AMDSMI_STATUS_NOT_SUPPORTED on those devices. On the CLI this
- *  surfaces as "MEM_CARVEOUT: N/A".
+ *  integrated_system_info table of at least v2.3. Currently this means
+ *  Strix and later APUs (gfx1150, gfx1151, gfx1152). Dedicated GPUs and
+ *  Instinct MI-series accelerators do NOT expose this interface, and
+ *  amdsmi_get_gpu_uma_carveout_info() returns AMDSMI_STATUS_NOT_SUPPORTED
+ *  on those devices. On the CLI this surfaces as "MEM_CARVEOUT: N/A".
  *
  *  @par Prerequisites (UMA carveout)
- *    - Linux kernel >= 6.17 (drm/amdgpu UMA carveout tuning series)
+ *    - Linux kernel >= 7.0 (upstream commit 685b711, drm/amdgpu UMA
+ *      carveout tuning series); some distros may backport it earlier
  *    - APU VBIOS advertising ATCS 0xA + IGP info table v2.3
  *    - Write access to /sys/class/drm/<card>/device/uma/carveout (root)
  *    - A system reboot for any change to take effect

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -8717,7 +8717,37 @@ amdsmi_status_t amdsmi_get_nic_rdma_port_statistics(amdsmi_processor_handle proc
  *
  *  @note These features use kernel UAPI interfaces (sysfs/modprobe.d), not libdrm.
  *  UMA carveout is exposed via /sys/class/drm/<device>/device/uma/ and TTM via
- *  /etc/modprobe.d/ttm.conf. No libdrm dependency is required for these APIs.
+ *  /etc/modprobe.d/<module>.conf (module name is ttm, amdttm or amd-ttm
+ *  depending on the driver package). No libdrm dependency is required for
+ *  these APIs.
+ *
+ *  @par Supported ASICs (UMA carveout)
+ *  UMA carveout is only available on APU parts whose VBIOS exposes the
+ *  ATCS function code 0xA ("Set UMA Allocation Size") together with an
+ *  integrated_system_info table of at least v2.3. Currently this means:
+ *    - Ryzen AI / Strix / Strix Halo (gfx1150, gfx1151, gfx1152)
+ *    - Select Phoenix/Hawk Point Ryzen APUs with updated VBIOS
+ *  Dedicated GPUs and Instinct MI-series accelerators (including MI300A)
+ *  do NOT expose this interface, and amdsmi_get_gpu_uma_carveout_info()
+ *  returns AMDSMI_STATUS_NOT_SUPPORTED on those devices. On the CLI this
+ *  surfaces as "MEM_CARVEOUT: N/A".
+ *
+ *  @par Prerequisites (UMA carveout)
+ *    - Linux kernel >= 6.17 (drm/amdgpu UMA carveout tuning series)
+ *    - APU VBIOS advertising ATCS 0xA + IGP info table v2.3
+ *    - Write access to /sys/class/drm/<card>/device/uma/carveout (root)
+ *    - A system reboot for any change to take effect
+ *
+ *  @par Supported ASICs (GTT / TTM pages_limit)
+ *  TTM pages_limit tuning is available on every system running the
+ *  amdgpu stack (both the in-kernel driver and amdgpu-dkms), including
+ *  MI300A. The module name seen in sysfs/modprobe is ttm (upstream),
+ *  amdttm (older amdgpu-dkms), or amd-ttm (newer amdgpu-dkms).
+ *
+ *  @par Prerequisites (GTT / TTM pages_limit)
+ *    - Write access to /etc/modprobe.d/ (root)
+ *    - dracut (optional, used to rebuild the initramfs automatically)
+ *    - A system reboot for any change to take effect
  *  @{
  */
 

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -8273,19 +8273,56 @@ amdsmi_status_t amdsmi_set_gpu_uma_carveout(amdsmi_processor_handle processor_ha
 }
 
 /**
- * @brief Detect the loaded TTM kernel module name.
+ * @brief Detect the loaded TTM kernel module name (sysfs form).
  *
- * AMD ships the module as "amdttm" in some driver packages and as "ttm"
- * in upstream/other packages. This helper checks which module directory
- * exists under /sys/module/ and returns its name.
+ * AMD driver packages ship the TTM module under several names depending
+ * on the driver flavour:
+ *   * Ryzen/Radeon in-kernel amdgpu -> "ttm"
+ *   * amdgpu-dkms (Instinct, e.g. MI300A) -> "amdttm" or "amd-ttm"
  *
- * @return "amdttm" if /sys/module/amdttm exists, "ttm" otherwise.
+ * The kernel exposes modules under /sys/module/ using the C identifier
+ * form of the module name (hyphens are normalised to underscores), so
+ * the modprobe name "amd-ttm" appears as /sys/module/amd_ttm.
+ *
+ * @return The sysfs module directory name (no hyphens). The probe order
+ * is amdttm -> amd_ttm -> ttm.
  */
 static std::string ttm_module_name() {
+  // Diagnostic override. Set AMDSMI_TTM_SYSFS_NAME to one of
+  // {ttm, amdttm, amd_ttm} to force the detected name without
+  // requiring the corresponding module to be loaded. Useful for
+  // testing the amd-ttm modprobe path on hosts shipping amdttm.
+  const char* override_env = std::getenv("AMDSMI_TTM_SYSFS_NAME");
+  if (override_env != nullptr && override_env[0] != '\0') {
+    std::string v(override_env);
+    if (v == "ttm" || v == "amdttm" || v == "amd_ttm") {
+      return v;
+    }
+  }
   if (access("/sys/module/amdttm", F_OK) == 0) {
     return "amdttm";
   }
+  if (access("/sys/module/amd_ttm", F_OK) == 0) {
+    return "amd_ttm";
+  }
   return "ttm";
+}
+
+/**
+ * @brief Return the modprobe-facing name for the detected TTM module.
+ *
+ * modprobe/modprobe.d files must reference the original module name as
+ * produced by modinfo, which preserves hyphens. Sysfs normalises those
+ * hyphens to underscores, so we translate only when needed.
+ *
+ * @return "amd-ttm" when the sysfs name is "amd_ttm", otherwise the
+ * sysfs name unchanged.
+ */
+static std::string ttm_modprobe_name(const std::string& sysfs_name) {
+  if (sysfs_name == "amd_ttm") {
+    return "amd-ttm";
+  }
+  return sysfs_name;
 }
 
 amdsmi_status_t amdsmi_get_ttm_info(amdsmi_ttm_info_t* info) {
@@ -8386,10 +8423,11 @@ amdsmi_status_t amdsmi_set_ttm_pages_limit(uint64_t pages) {
 
   if (is_dry_run()) {
     std::string mod = ttm_module_name();
-    std::string modprobe_path = "/etc/modprobe.d/" + mod + ".conf";
+    std::string conf_name = ttm_modprobe_name(mod);
+    std::string modprobe_path = "/etc/modprobe.d/" + conf_name + ".conf";
     std::ostringstream ss;
     ss << "[DRY_RUN] Would write to " << modprobe_path << ":" << std::endl;
-    ss << "[DRY_RUN]   options " << mod << " pages_limit=" << pages;
+    ss << "[DRY_RUN]   options " << conf_name << " pages_limit=" << pages;
     LOG_INFO(ss);
 
     return run_dracut_f();
@@ -8397,14 +8435,15 @@ amdsmi_status_t amdsmi_set_ttm_pages_limit(uint64_t pages) {
 
   // Create/update modprobe configuration
   std::string mod = ttm_module_name();
-  std::string modprobe_path = "/etc/modprobe.d/" + mod + ".conf";
+  std::string conf_name = ttm_modprobe_name(mod);
+  std::string modprobe_path = "/etc/modprobe.d/" + conf_name + ".conf";
   std::ofstream modprobe_file(modprobe_path);
 
   if (!modprobe_file.good()) {
     return AMDSMI_STATUS_NO_PERM;
   }
 
-  modprobe_file << "options " << mod << " pages_limit=" << pages << std::endl;
+  modprobe_file << "options " << conf_name << " pages_limit=" << pages << std::endl;
   modprobe_file.flush();
   if (!modprobe_file) {
     modprobe_file.close();
@@ -8426,20 +8465,28 @@ amdsmi_status_t amdsmi_set_ttm_pages_limit(uint64_t pages) {
 amdsmi_status_t amdsmi_reset_ttm_pages_limit(void) {
   AMDSMI_CHECK_INIT();
 
-  // Remove modprobe configuration to reset to default
-  // Check both possible config file names (amdttm.conf and ttm.conf)
+  // Remove modprobe configuration to reset to default. The active module
+  // may be ttm / amdttm / amd-ttm (sysfs: amd_ttm). Search all three.
   std::string mod = ttm_module_name();
-  std::string modprobe_path = "/etc/modprobe.d/" + mod + ".conf";
+  std::string primary_conf = ttm_modprobe_name(mod);
+  std::string modprobe_path = "/etc/modprobe.d/" + primary_conf + ".conf";
 
   // Check if file exists
   if (access(modprobe_path.c_str(), F_OK) != 0) {
-    // Try the other name as fallback (handles cross-upgrade scenarios)
-    std::string alt_mod = (mod == "amdttm") ? "ttm" : "amdttm";
-    std::string alt_path = "/etc/modprobe.d/" + alt_mod + ".conf";
-    if (access(alt_path.c_str(), F_OK) == 0) {
-      modprobe_path = alt_path;
-    } else {
-      // Neither file exists, nothing to do
+    // Search all known config names (handles cross-upgrade scenarios).
+    static const char* kKnownConfNames[] = {"ttm", "amdttm", "amd-ttm"};
+    bool found = false;
+    for (const char* alt : kKnownConfNames) {
+      if (alt == primary_conf) continue;
+      std::string alt_path = std::string("/etc/modprobe.d/") + alt + ".conf";
+      if (access(alt_path.c_str(), F_OK) == 0) {
+        modprobe_path = alt_path;
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      // No config file exists, nothing to do
       return AMDSMI_STATUS_SUCCESS;
     }
   }

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -8486,7 +8486,6 @@ amdsmi_status_t amdsmi_reset_ttm_pages_limit(void) {
       }
     }
     if (!found) {
-      // No config file exists, nothing to do
       return AMDSMI_STATUS_SUCCESS;
     }
   }

--- a/projects/amdsmi/tests/MEMORY_TESTS_README.md
+++ b/projects/amdsmi/tests/MEMORY_TESTS_README.md
@@ -33,7 +33,7 @@ When the `AMDSMI_DRY_RUN` environment variable is set to `1`:
 #### Bash/Shell:
 ```bash
 export AMDSMI_DRY_RUN=1
-amd-smi set --vram-carveout 2 --gpu 0  # Simulates setting VRAM carveout to index 2
+amd-smi set --mem-carveout 2 --gpu 0  # Simulates setting VRAM carveout to index 2
 ```
 
 #### Python:
@@ -136,7 +136,7 @@ cd build/tests/amd_smi_test
 - ✅ JSON and CSV output formats
 - ✅ Help text
 
-**Note:** Write operations (--vram-carveout in set, --gtt in set/reset) are not tested in automated CLI tests to avoid requiring root permissions and system reboots. Use DRY_RUN mode for testing these operations.
+**Note:** Write operations (--mem-carveout in set, --gtt in set/reset) are not tested in automated CLI tests to avoid requiring root permissions and system reboots. Use DRY_RUN mode for testing these operations.
 
 **Running Python CLI Tests:**
 ```bash
@@ -163,7 +163,7 @@ For testing actual write operations that modify system configuration:
 amd-smi static --mem-carveout
 
 # Change VRAM carveout to index 2 (example) for GPU 0
-sudo amd-smi set --vram-carveout 2 --gpu 0
+sudo amd-smi set --mem-carveout 2 --gpu 0
 
 # Reboot required
 sudo reboot
@@ -222,7 +222,7 @@ sudo reboot
 ```bash
 $ export AMDSMI_DRY_RUN=1
 
-$ amd-smi set --vram-carveout 2 --gpu 0
+$ amd-smi set --mem-carveout 2 --gpu 0
 [DRY_RUN] Would write UMA carveout index 2 to /sys/class/drm/card0/device/uma/carveout
 Successfully set VRAM carveout to [2] (4 GB). Reboot required for changes to take effect.
 


### PR DESCRIPTION

## Motivation

The existing TTM helper only recognised the ttm and amdttm module names, silently writing an unusable modprobe.d config on hosts shipping the newer amd-ttm (sysfs amd_ttm) variant. This PR also clarifies why MEM_CARVEOUT reports N/A on dGPUs / Instinct parts and documents the ASIC + VBIOS prerequisites.

## Technical Details

- TTM module detection (amd_smi.cc): ttm_module_name() now probes amdttm → amd_ttm → ttm; new ttm_modprobe_name() maps the sysfs name back to its hyphenated modprobe form (amd_ttm → amd-ttm).
- Correct modprobe.d output: set_ttm_pages_limit writes /etc/modprobe.d/amd-ttm.conf with options amd-ttm pages_limit=…, and reset_ttm_pages_limit searches all three legacy filenames (ttm, amdttm, amd-ttm).
- CLI messaging: static -m / set -m emit a descriptive NOT_SUPPORTED message for human output, while JSON/CSV keep the legacy "N/A" for backward compatibility.
- Docs & help: Supported-ASIC and prerequisite blocks added to amdsmi.h, CLI --help, docs/reference/amdsmi-py-api.md, and docs/how-to/amdsmi-cli-tool.md.

## JIRA ID

ROCM-186

## Test Plan

- Build: Rebuilt libamd_smi.so cleanly against the patched tree.
- Unit tests: Ran cli_unit_test.py::test_static_mem_carveout_gtt, test_node, and test_help against the rebuilt library on an MI300A host (4× GPUs, kernel 5.18.2-mi300, amdgpu 6.16.10).
- Module-name coverage: Exercised all three TTM branches via a new AMDSMI_TTM_SYSFS_NAME diagnostic env var with AMDSMI_DRY_RUN=1 and RSMI_LOGGING=2.
- End-to-end: Validated amd-smi static -m and set -m on hardware.

## Test Result

- Unit tests: All targeted tests pass.
- Dry-run trace: Produced the expected /etc/modprobe.d/{ttm,amdttm,amd-ttm}.conf paths with matching options <mod> lines for each branch.
- MI300A behavior: static -m reports MEM_CARVEOUT: N/A (UMA carveout is not supported on this ASIC/VBIOS); set -m 0 returns the descriptive ATCS-0xA prerequisite message.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


[ROCM-186]: https://amd-hub-sandbox-20240925.atlassian.net/browse/ROCM-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ