### PR TITLE
[rocprofiler-sdk]: Fix crash on iGPUs without PMC support #148

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -1353,6 +1353,11 @@ construct_counter_collection_profile(rocprofiler_agent_id_t       agent_id,
     const auto*       agent_v                 = tool_metadata->get_agent(agent_id);
     auto              expected_v              = counters.size();
 
+    if(gpu_agents_counter_info.find(agent_id) == gpu_agents_counter_info.end())
+    {
+        return std::nullopt;
+    }
+
     constexpr auto device_qualifier = std::string_view{":device="};
     for(const auto& itr : counters)
     {
@@ -1501,6 +1506,11 @@ get_att_perfcounter_params(rocprofiler_agent_id_t                           agen
     if(att_perf_counters.empty()) return _data;
 
     static const auto agent_counter_info = get_agent_counter_info();
+
+    if(agent_counter_info.find(agent) == agent_counter_info.end())
+    {
+        return _data;
+    }
 
     for(const auto& att_perf_counter : att_perf_counters)
     {


### PR DESCRIPTION
## Motivation

`rocprofv3 --pmc` crashes with `std::out_of_range` exception on systems with mixed GPU configurations (iGPU + dGPU) when the iGPU doesn't support performance counters. The tool attempts to access counter information for all agents without checking if the counter support exists which causes the crash when `.at` is called on a map entry that was never created.

fixes https://github.com/ROCm/rocprofiler-sdk/issues/148

## Technical Details

Added defensive checks in `rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp` before accessing `gpu_agents_counter_info` and `agent_counter_info` maps:
1. Check if `agent_id` exists in map before calling `.at()`, return early if not found in in `construct_counter_collection_profile()`
2.  Check if `agent_id` exists in map before calling `.at()`, return early if not found in in ` get_att_perfcounter_params()`

## JIRA ID

## Test Plan

  Tested on system with gfx1036 iGPU + gfx1100 dGPU:
  - Built rocprofiler-sdk with fix applied
  - Ran rocprofv3 --pmc SQ_WAVES -- <test_program>
  - Verified graceful handling of unsupported agent (warning logged)
  - Confirmed profiling succeeds on supported GPU (dGPU)

## Test Result

  - No crash - tool runs to completion
  - Warning logged for unsupported agent (expected behavior)
  - Performance database generated successfully
  - PMC data collected for supported GPU

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
