### PR TITLE
[rocjitsu] Plugins

### DIFF
--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -272,7 +272,7 @@ bool CommandProcessor::step() {
         init_wavefront_regs(cu, wf, pkt, global_wg_id, w);
         wg_wavefronts.push_back(wf);
       }
-      plugin_group_->onAmdgpuWorkgroupDispatched(
+      plugin_group_->onAmdgpuDispatchWorkgroup(
             global_wg_id, pkt.vgprs_per_wf, pkt.sgprs_per_wf,
             std::span<Wavefront *>(wg_wavefronts));
       next_cu_ = (cu_idx + 1) % cus_.size();

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -263,12 +263,18 @@ bool CommandProcessor::step() {
       cu->retire_halted_wfs();
       if (!cu->can_accept_workgroup(pkt.wfs_per_workgroup))
         continue;
+      std::vector<Wavefront *> wg_wavefronts;
+      wg_wavefronts.reserve(pkt.wfs_per_workgroup);
       for (uint32_t w = 0; w < pkt.wfs_per_workgroup; ++w) {
         Wavefront *wf =
             cu->dispatch_wf(wg, pkt.kernel_entry_pc, pkt.sgprs_per_wf, pkt.vgprs_per_wf);
         assert(wf && "dispatch_wf failed after can_accept_workgroup returned true");
         init_wavefront_regs(cu, wf, pkt, global_wg_id, w);
+        wg_wavefronts.push_back(wf);
       }
+      plugin_group_->onAmdgpuWorkgroupDispatched(
+            global_wg_id, pkt.vgprs_per_wf, pkt.sgprs_per_wf,
+            std::span<Wavefront *>(wg_wavefronts));
       next_cu_ = (cu_idx + 1) % cus_.size();
       wg_dispatched = true;
     }
@@ -723,6 +729,8 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
     cus_[0]->flush_all();
     util::Logger::vm("CP: acquire fence scope=", acquire_scope, " → L1+L2 flush+invalidate");
   }
+
+  plugin_group_->onAmdgpuKernelDispatch(pkt.kernel_object, entry_pc);
 
   dispatch_queue_.push_back(std::move(dp));
 }

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -112,6 +112,9 @@ public:
   /// sees the new ring without tearing.
   void update_queue(uint32_t queue_id, uint64_t ring_base_va, uint32_t ring_size);
 
+  /// @brief Set the execution plugin group (non-owning; owned by SoC).
+  void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) { plugin_group_ = pg; }
+
   /// @brief Register a compute unit that this CP can dispatch to.
   ///
   /// @details Creates a dispatch OUT port for the CU and registers an on_idle
@@ -244,6 +247,8 @@ private:
 
   /// @brief Protects hw_queues_ (accessed from both the polling thread and register_queue).
   std::mutex hw_queue_mutex_;
+
+  std::shared_ptr<ExecutionPluginGroup> plugin_group_ = ExecutionPluginGroup::empty_group();
 
   uint64_t read_gpu_u64(uint64_t va) const;
   void stop_doorbell_monitor();

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -113,7 +113,7 @@ public:
   void update_queue(uint32_t queue_id, uint64_t ring_base_va, uint32_t ring_size);
 
   /// @brief Set the execution plugin group (shared ownership).
-  void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) { plugin_group_ = pg; }
+  void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) { plugin_group_ = pg ? pg : ExecutionPluginGroup::empty_group(); }
 
   /// @brief Register a compute unit that this CP can dispatch to.
   ///

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -112,7 +112,7 @@ public:
   /// sees the new ring without tearing.
   void update_queue(uint32_t queue_id, uint64_t ring_base_va, uint32_t ring_size);
 
-  /// @brief Set the execution plugin group (non-owning; owned by SoC).
+  /// @brief Set the execution plugin group (shared ownership).
   void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) { plugin_group_ = pg; }
 
   /// @brief Register a compute unit that this CP can dispatch to.

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -217,7 +217,7 @@ void ComputeUnitCore::tick_pipelines() {
 }
 
 void ComputeUnitCore::route_memory_inst(Instruction *inst, Wavefront &wf) {
-  plugin_group_->onAmdgpuMemoryInstruction(inst);
+  plugin_group_->onAmdgpuRouteMemoryInstruction(*inst);
   switch (inst->data()->tag()) {
   case SCALAR_MEM:
     scalar_mem_pipeline_.issue(inst, wf);
@@ -424,7 +424,7 @@ bool ComputeUnitCore::step() {
     }
   }
 
-  plugin_group_->onAmdgpuInstructionExecuted(active->pc, *inst);
+  plugin_group_->onAmdgpuExecuteInstruction(active->pc, *inst);
 
   execute_instruction(inst, *active);
 

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -217,6 +217,7 @@ void ComputeUnitCore::tick_pipelines() {
 }
 
 void ComputeUnitCore::route_memory_inst(Instruction *inst, Wavefront &wf) {
+  plugin_group_->onAmdgpuMemoryInstruction(inst);
   switch (inst->data()->tag()) {
   case SCALAR_MEM:
     scalar_mem_pipeline_.issue(inst, wf);
@@ -313,6 +314,7 @@ bool ComputeUnitCore::step() {
         }
       }
       if (all_at_barrier) {
+        plugin_group_->onAmdgpuBarrierResolved(wg);
         for (auto &w2 : wfs_)
           if (w2->wg_id() == wg && w2->state() == WfState::BARRIER)
             w2->set_state(WfState::RUNNING);
@@ -421,6 +423,8 @@ bool ComputeUnitCore::step() {
       });
     }
   }
+
+  plugin_group_->onAmdgpuInstructionExecuted(active->pc, *inst);
 
   execute_instruction(inst, *active);
 

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -144,7 +144,7 @@ public:
   void set_on_idle(std::function<void()> cb) { on_idle_ = std::move(cb); }
 
   /// @brief Set the execution plugin group (shared ownership).
-  void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) { plugin_group_ = pg; }
+  void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) { plugin_group_ = pg ? pg : ExecutionPluginGroup::empty_group(); }
 
   /// @brief Return the number of dispatched (active or halted) wavefront slots.
   /// @returns Count of non-idle wavefront slots.

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -143,7 +143,7 @@ public:
   /// @param cb Callback to invoke when idle.
   void set_on_idle(std::function<void()> cb) { on_idle_ = std::move(cb); }
 
-  /// @brief Set the execution plugin group (non-owning; owned by SoC).
+  /// @brief Set the execution plugin group (shared ownership).
   void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) { plugin_group_ = pg; }
 
   /// @brief Return the number of dispatched (active or halted) wavefront slots.

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -8,6 +8,7 @@
 #define ROCJITSU_VM_AMDGPU_COMPUTE_UNIT_H_
 
 #include "rocjitsu/base/api.h"
+#include "rocjitsu/vm/execution_plugin.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
@@ -141,6 +142,9 @@ public:
   /// The command processor uses this to detect when all CUs are done.
   /// @param cb Callback to invoke when idle.
   void set_on_idle(std::function<void()> cb) { on_idle_ = std::move(cb); }
+
+  /// @brief Set the execution plugin group (non-owning; owned by SoC).
+  void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) { plugin_group_ = pg; }
 
   /// @brief Return the number of dispatched (active or halted) wavefront slots.
   /// @returns Count of non-idle wavefront slots.
@@ -392,6 +396,7 @@ protected:
   GlobalMemPipeline global_mem_pipeline_;
   LocalMemPipeline local_mem_pipeline_;
   std::function<void()> on_idle_; ///< Callback invoked when CU becomes idle.
+  std::shared_ptr<ExecutionPluginGroup> plugin_group_ = ExecutionPluginGroup::empty_group();
   simdojo::Port *cpl_ = nullptr;  ///< Completer port: dispatch activation from CP.
   simdojo::Port *req_ = nullptr;  ///< Requester port: L2 cache request (structural).
 };

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/shader_engine.h
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/shader_engine.h
@@ -50,6 +50,12 @@ public:
 
   void add_compute_unit(ComputeUnitCore *cu) { cus_.push_back(cu); }
 
+  /// @brief Set the execution plugin group on all CUs (shared ownership).
+  void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) {
+    for (auto *cu : cus_)
+      cu->set_plugin_group(pg);
+  }
+
   /// @brief Return the number of compute units.
   /// @returns Number of CUs in this shader engine.
   uint32_t num_compute_units() const { return static_cast<uint32_t>(cus_.size()); }

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/xcd.h
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/xcd.h
@@ -53,6 +53,13 @@ public:
   void set_l2_cache(L2Cache *l2) { l2_cache_ = l2; }
   void add_shader_engine(ShaderEngine *se) { shader_engines_.push_back(se); }
 
+  /// @brief Set the execution plugin group on CP and all CUs (shared ownership).
+  void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) {
+    cp_->set_plugin_group(pg);
+    for (auto *se : shader_engines_)
+      se->set_plugin_group(pg);
+  }
+
   /// @brief Wire topology links between CP→CU and CU→L2.
   ///
   /// @details L2→HBM/fabric wiring is done by SoC::initialize() since the

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/execution_plugin.h
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/execution_plugin.h
@@ -29,9 +29,11 @@ namespace rocjitsu {
 /// what they need. The no-plugin path has zero overhead (callers guard
 /// with a null check on the plugin group pointer).
 ///
-/// Ownership: plugins are owned by an ExecutionPluginGroup, which is
-/// owned by the SoC. The SoC pushes a raw pointer to each component
-/// that fires hooks (CommandProcessor, ComputeUnit).
+/// Ownership: plugins are owned by an ExecutionPluginGroup via
+/// unique_ptr. The group itself is shared (via shared_ptr) between
+/// the SoC and all components that fire hooks (CommandProcessor,
+/// ComputeUnit, Hart). A static empty group is used as the default
+/// so the plugin group pointer is never null.
 class ExecutionPlugin {
 public:
   virtual ~ExecutionPlugin() = default;

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/execution_plugin.h
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/execution_plugin.h
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file execution_plugin.h
+/// @brief Architecture-neutral plugin interface for execution hooks.
+///
+/// A single plugin class serves both AMDGPU and RISC-V execution paths.
+/// Hooks that are specific to an architecture are prefixed with the
+/// architecture name (onAmdgpu*, onRiscv*). Generic hooks that apply
+/// to any architecture have no prefix.
+
+#pragma once
+
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <vector>
+
+namespace rocjitsu {
+
+/// @brief Abstract plugin interface for execution hooks.
+///
+/// Plugins receive callbacks at key points during instruction execution.
+/// All hooks have empty default implementations so plugins only override
+/// what they need. The no-plugin path has zero overhead (callers guard
+/// with a null check on the plugin group pointer).
+///
+/// Ownership: plugins are owned by an ExecutionPluginGroup, which is
+/// owned by the SoC. The SoC pushes a raw pointer to each component
+/// that fires hooks (CommandProcessor, ComputeUnit).
+class ExecutionPlugin {
+public:
+  virtual ~ExecutionPlugin() = default;
+
+  // -- AMDGPU hooks --------------------------------------------------------
+
+  /// Called before every AMDGPU instruction is executed.
+  virtual void onAmdgpuInstructionExecuted(uint64_t /*pc*/, const Instruction& /*inst*/) {}
+
+  /// Called when an AMDGPU memory instruction is routed to a pipeline.
+  virtual void onAmdgpuMemoryInstruction(Instruction * /*inst*/) {}
+
+  /// Called when a new AMDGPU kernel dispatch begins.
+  virtual void onAmdgpuKernelDispatch(uint64_t /*kernel_object*/,
+                                      uint64_t /*entry_pc*/) {}
+
+  /// Called after a workgroup's wavefronts have been dispatched to a CU.
+  virtual void onAmdgpuWorkgroupDispatched(
+      uint32_t /*wg_id*/, uint32_t /*vgpr_count*/, uint32_t /*sgpr_count*/,
+      std::span<amdgpu::Wavefront *> /*wavefronts*/) {}
+
+  /// Called when a VGPR is read during instruction execution.
+  /// Not yet wired — to be connected when race detection lands.
+  virtual void onAmdgpuVgprRead(amdgpu::Wavefront * /*wf*/,
+                                uint32_t /*logical_reg*/, uint32_t /*lane*/) {}
+
+  /// Called when an SGPR is read during instruction execution.
+  /// Not yet wired — to be connected when race detection lands.
+  virtual void onAmdgpuSgprRead(amdgpu::Wavefront * /*wf*/,
+                                uint32_t /*logical_reg*/) {}
+
+  /// Called when s_waitcnt sets counter thresholds.
+  virtual void onAmdgpuWaitcnt(amdgpu::Wavefront * /*wf*/, int /*vmcnt*/,
+                               int /*lgkmcnt*/) {}
+
+  /// Called when all waves in a workgroup have reached s_barrier.
+  virtual void onAmdgpuBarrierResolved(uint32_t /*wg_id*/) {}
+
+  // -- RISC-V hooks --------------------------------------------------------
+
+  /// Called before every RISC-V instruction is executed.
+  virtual void onRiscvInstructionExecuted(uint64_t /*pc*/, const Instruction& /*inst*/) {}
+};
+
+/// @brief Collection of plugins that delegates to each member.
+class ExecutionPluginGroup {
+public:
+  void add(std::unique_ptr<ExecutionPlugin> p) {
+    assert(p && "cannot add a null plugin");
+    plugins_.push_back(std::move(p));
+  }
+
+  // -- AMDGPU --
+  void onAmdgpuInstructionExecuted(uint64_t pc, const Instruction &inst) {
+    for (auto &p : plugins_)
+      p->onAmdgpuInstructionExecuted(pc, inst);
+  }
+
+  void onAmdgpuMemoryInstruction(Instruction *inst) {
+    for (auto &p : plugins_)
+      p->onAmdgpuMemoryInstruction(inst);
+  }
+
+  void onAmdgpuKernelDispatch(uint64_t kernel_object, uint64_t entry_pc) {
+    for (auto &p : plugins_)
+      p->onAmdgpuKernelDispatch(kernel_object, entry_pc);
+  }
+
+  void onAmdgpuWorkgroupDispatched(uint32_t wg_id, uint32_t vgpr_count,
+                                   uint32_t sgpr_count,
+                                   std::span<amdgpu::Wavefront *> wavefronts) {
+    for (auto &p : plugins_)
+      p->onAmdgpuWorkgroupDispatched(wg_id, vgpr_count, sgpr_count,
+                                     wavefronts);
+  }
+
+  void onAmdgpuVgprRead(amdgpu::Wavefront *wf, uint32_t logical_reg,
+                         uint32_t lane) {
+    for (auto &p : plugins_)
+      p->onAmdgpuVgprRead(wf, logical_reg, lane);
+  }
+
+  void onAmdgpuSgprRead(amdgpu::Wavefront *wf, uint32_t logical_reg) {
+    for (auto &p : plugins_)
+      p->onAmdgpuSgprRead(wf, logical_reg);
+  }
+
+  void onAmdgpuWaitcnt(amdgpu::Wavefront *wf, int vmcnt, int lgkmcnt) {
+    for (auto &p : plugins_)
+      p->onAmdgpuWaitcnt(wf, vmcnt, lgkmcnt);
+  }
+
+  void onAmdgpuBarrierResolved(uint32_t wg_id) {
+    for (auto &p : plugins_)
+      p->onAmdgpuBarrierResolved(wg_id);
+  }
+
+  // -- RISC-V --
+  void onRiscvInstructionExecuted(uint64_t pc, const Instruction &inst) {
+    for (auto &p : plugins_)
+      p->onRiscvInstructionExecuted(pc, inst);
+  }
+
+  bool empty() const { return plugins_.empty(); }
+
+  /// A shared empty group used as the default when no plugins are attached.
+  static std::shared_ptr<ExecutionPluginGroup> empty_group() {
+    static auto instance = std::make_shared<ExecutionPluginGroup>();
+    return instance;
+  }
+
+private:
+  std::vector<std::unique_ptr<ExecutionPlugin>> plugins_;
+};
+
+} // namespace rocjitsu

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/execution_plugin.h
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/execution_plugin.h
@@ -5,9 +5,7 @@
 /// @brief Architecture-neutral plugin interface for execution hooks.
 ///
 /// A single plugin class serves both AMDGPU and RISC-V execution paths.
-/// Hooks that are specific to an architecture are prefixed with the
-/// architecture name (onAmdgpu*, onRiscv*). Generic hooks that apply
-/// to any architecture have no prefix.
+/// Hooks are prefixed with their architecture name (onAmdgpu*, onRiscv*).
 
 #pragma once
 
@@ -24,10 +22,10 @@ namespace rocjitsu {
 
 /// @brief Abstract plugin interface for execution hooks.
 ///
-/// Plugins receive callbacks at key points during instruction execution.
+/// Plugins receive callbacks at key points during simulation execution.
 /// All hooks have empty default implementations so plugins only override
-/// what they need. The no-plugin path has zero overhead (callers guard
-/// with a null check on the plugin group pointer).
+/// what they need. The no-plugin path has near-zero overhead (the
+/// default empty group's delegation loops iterate an empty vector).
 ///
 /// Ownership: plugins are owned by an ExecutionPluginGroup via
 /// unique_ptr. The group itself is shared (via shared_ptr) between
@@ -41,33 +39,33 @@ public:
   // -- AMDGPU hooks --------------------------------------------------------
 
   /// Called before every AMDGPU instruction is executed.
-  virtual void onAmdgpuInstructionExecuted(uint64_t /*pc*/, const Instruction& /*inst*/) {}
+  virtual void onAmdgpuExecuteInstruction(uint64_t /*pc*/, const Instruction& /*inst*/) {}
 
   /// Called when an AMDGPU memory instruction is routed to a pipeline.
-  virtual void onAmdgpuMemoryInstruction(Instruction * /*inst*/) {}
+  virtual void onAmdgpuRouteMemoryInstruction(const Instruction & /*inst*/) {}
 
   /// Called when a new AMDGPU kernel dispatch begins.
   virtual void onAmdgpuKernelDispatch(uint64_t /*kernel_object*/,
                                       uint64_t /*entry_pc*/) {}
 
   /// Called after a workgroup's wavefronts have been dispatched to a CU.
-  virtual void onAmdgpuWorkgroupDispatched(
+  virtual void onAmdgpuDispatchWorkgroup(
       uint32_t /*wg_id*/, uint32_t /*vgpr_count*/, uint32_t /*sgpr_count*/,
       std::span<amdgpu::Wavefront *> /*wavefronts*/) {}
 
   /// Called when a VGPR is read during instruction execution.
   /// Not yet wired — to be connected when race detection lands.
-  virtual void onAmdgpuVgprRead(amdgpu::Wavefront * /*wf*/,
+  virtual void onAmdgpuReadVgpr(amdgpu::Wavefront * /*wf*/,
                                 uint32_t /*logical_reg*/, uint32_t /*lane*/) {}
 
   /// Called when an SGPR is read during instruction execution.
   /// Not yet wired — to be connected when race detection lands.
-  virtual void onAmdgpuSgprRead(amdgpu::Wavefront * /*wf*/,
+  virtual void onAmdgpuReadSgpr(amdgpu::Wavefront * /*wf*/,
                                 uint32_t /*logical_reg*/) {}
 
   /// Called when s_waitcnt sets counter thresholds.
-  virtual void onAmdgpuWaitcnt(amdgpu::Wavefront * /*wf*/, int /*vmcnt*/,
-                               int /*lgkmcnt*/) {}
+  virtual void onAmdgpuSetWaitTarget(amdgpu::Wavefront * /*wf*/, int /*vmcnt*/,
+                                     int /*lgkmcnt*/) {}
 
   /// Called when all waves in a workgroup have reached s_barrier.
   virtual void onAmdgpuBarrierResolved(uint32_t /*wg_id*/) {}
@@ -75,7 +73,7 @@ public:
   // -- RISC-V hooks --------------------------------------------------------
 
   /// Called before every RISC-V instruction is executed.
-  virtual void onRiscvInstructionExecuted(uint64_t /*pc*/, const Instruction& /*inst*/) {}
+  virtual void onRiscvExecuteInstruction(uint64_t /*pc*/, const Instruction& /*inst*/) {}
 };
 
 /// @brief Collection of plugins that delegates to each member.
@@ -87,14 +85,14 @@ public:
   }
 
   // -- AMDGPU --
-  void onAmdgpuInstructionExecuted(uint64_t pc, const Instruction &inst) {
+  void onAmdgpuExecuteInstruction(uint64_t pc, const Instruction &inst) {
     for (auto &p : plugins_)
-      p->onAmdgpuInstructionExecuted(pc, inst);
+      p->onAmdgpuExecuteInstruction(pc, inst);
   }
 
-  void onAmdgpuMemoryInstruction(Instruction *inst) {
+  void onAmdgpuRouteMemoryInstruction(const Instruction &inst) {
     for (auto &p : plugins_)
-      p->onAmdgpuMemoryInstruction(inst);
+      p->onAmdgpuRouteMemoryInstruction(inst);
   }
 
   void onAmdgpuKernelDispatch(uint64_t kernel_object, uint64_t entry_pc) {
@@ -102,28 +100,28 @@ public:
       p->onAmdgpuKernelDispatch(kernel_object, entry_pc);
   }
 
-  void onAmdgpuWorkgroupDispatched(uint32_t wg_id, uint32_t vgpr_count,
+  void onAmdgpuDispatchWorkgroup(uint32_t wg_id, uint32_t vgpr_count,
                                    uint32_t sgpr_count,
                                    std::span<amdgpu::Wavefront *> wavefronts) {
     for (auto &p : plugins_)
-      p->onAmdgpuWorkgroupDispatched(wg_id, vgpr_count, sgpr_count,
+      p->onAmdgpuDispatchWorkgroup(wg_id, vgpr_count, sgpr_count,
                                      wavefronts);
   }
 
-  void onAmdgpuVgprRead(amdgpu::Wavefront *wf, uint32_t logical_reg,
+  void onAmdgpuReadVgpr(amdgpu::Wavefront *wf, uint32_t logical_reg,
                          uint32_t lane) {
     for (auto &p : plugins_)
-      p->onAmdgpuVgprRead(wf, logical_reg, lane);
+      p->onAmdgpuReadVgpr(wf, logical_reg, lane);
   }
 
-  void onAmdgpuSgprRead(amdgpu::Wavefront *wf, uint32_t logical_reg) {
+  void onAmdgpuReadSgpr(amdgpu::Wavefront *wf, uint32_t logical_reg) {
     for (auto &p : plugins_)
-      p->onAmdgpuSgprRead(wf, logical_reg);
+      p->onAmdgpuReadSgpr(wf, logical_reg);
   }
 
-  void onAmdgpuWaitcnt(amdgpu::Wavefront *wf, int vmcnt, int lgkmcnt) {
+  void onAmdgpuSetWaitTarget(amdgpu::Wavefront *wf, int vmcnt, int lgkmcnt) {
     for (auto &p : plugins_)
-      p->onAmdgpuWaitcnt(wf, vmcnt, lgkmcnt);
+      p->onAmdgpuSetWaitTarget(wf, vmcnt, lgkmcnt);
   }
 
   void onAmdgpuBarrierResolved(uint32_t wg_id) {
@@ -132,9 +130,9 @@ public:
   }
 
   // -- RISC-V --
-  void onRiscvInstructionExecuted(uint64_t pc, const Instruction &inst) {
+  void onRiscvExecuteInstruction(uint64_t pc, const Instruction &inst) {
     for (auto &p : plugins_)
-      p->onRiscvInstructionExecuted(pc, inst);
+      p->onRiscvExecuteInstruction(pc, inst);
   }
 
   bool empty() const { return plugins_.empty(); }

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/risc_v/hart.cpp
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/risc_v/hart.cpp
@@ -27,7 +27,7 @@ bool Hart::advance(simdojo::Tick /*now*/) {
 
   set_current_memory(&memory_);
 
-  plugin_group_->onRiscvInstructionExecuted(state_.pc, *inst);
+  plugin_group_->onRiscvExecuteInstruction(state_.pc, *inst);
 
   inst->execute(*inst, &state_);
 

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/risc_v/hart.cpp
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/risc_v/hart.cpp
@@ -27,6 +27,8 @@ bool Hart::advance(simdojo::Tick /*now*/) {
 
   set_current_memory(&memory_);
 
+  plugin_group_->onRiscvInstructionExecuted(state_.pc, *inst);
+
   inst->execute(*inst, &state_);
 
   state_.pc = state_.next_pc;

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/risc_v/hart.h
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/risc_v/hart.h
@@ -4,6 +4,7 @@
 #ifndef ROCJITSU_VM_RISC_V_HART_H_
 #define ROCJITSU_VM_RISC_V_HART_H_
 
+#include "rocjitsu/vm/execution_plugin.h"
 #include "rocjitsu/vm/risc_v/hart_state.h"
 #include "rocjitsu/vm/risc_v/memory.h"
 #include "simdojo/sim/clock_domain.h"
@@ -49,9 +50,13 @@ public:
   /// @returns Const reference to the memory interface.
   const Memory &memory() const { return memory_; }
 
+  /// @brief Set the execution plugin group (non-owning).
+  void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) { plugin_group_ = pg; }
+
 private:
   HartState state_;
   Memory memory_{"memory"};
+  std::shared_ptr<ExecutionPluginGroup> plugin_group_ = ExecutionPluginGroup::empty_group();
 };
 
 } // namespace risc_v

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/risc_v/hart.h
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/risc_v/hart.h
@@ -51,7 +51,7 @@ public:
   const Memory &memory() const { return memory_; }
 
   /// @brief Set the execution plugin group (shared ownership).
-  void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) { plugin_group_ = pg; }
+  void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) { plugin_group_ = pg ? pg : ExecutionPluginGroup::empty_group(); }
 
 private:
   HartState state_;

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/risc_v/hart.h
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/risc_v/hart.h
@@ -50,7 +50,7 @@ public:
   /// @returns Const reference to the memory interface.
   const Memory &memory() const { return memory_; }
 
-  /// @brief Set the execution plugin group (non-owning).
+  /// @brief Set the execution plugin group (shared ownership).
   void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) { plugin_group_ = pg; }
 
 private:

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
@@ -79,7 +79,7 @@ SoC::SoC(std::string name, const Config &config)
 }
 
 void SoC::set_plugin_group(std::shared_ptr<ExecutionPluginGroup> plugin_group) {
-  plugin_group_ = plugin_group ? std::move(plugin_group)
+  plugin_group_ = plugin_group ? plugin_group
                                : ExecutionPluginGroup::empty_group();
   for (auto *x : xcds_) {
     x->command_processor()->set_plugin_group(plugin_group_);

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
@@ -78,6 +78,19 @@ SoC::SoC(std::string name, const Config &config)
   }
 }
 
+void SoC::set_plugin_group(std::shared_ptr<ExecutionPluginGroup> plugin_group) {
+  plugin_group_ = plugin_group ? std::move(plugin_group)
+                               : ExecutionPluginGroup::empty_group();
+  for (auto *x : xcds_) {
+    x->command_processor()->set_plugin_group(plugin_group_);
+    for (uint32_t si = 0; si < x->num_shader_engines(); ++si) {
+      auto *se = x->shader_engine(si);
+      for (uint32_t ci = 0; ci < se->num_compute_units(); ++ci)
+        se->compute_unit(ci)->set_plugin_group(plugin_group_);
+    }
+  }
+}
+
 void SoC::flush_all() {
   // Flush all per-CU L1 caches (invalidate, since L1 is write-through).
   for (auto *x : xcds_) {

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
@@ -81,14 +81,8 @@ SoC::SoC(std::string name, const Config &config)
 void SoC::set_plugin_group(std::shared_ptr<ExecutionPluginGroup> plugin_group) {
   plugin_group_ = plugin_group ? plugin_group
                                : ExecutionPluginGroup::empty_group();
-  for (auto *x : xcds_) {
-    x->command_processor()->set_plugin_group(plugin_group_);
-    for (uint32_t si = 0; si < x->num_shader_engines(); ++si) {
-      auto *se = x->shader_engine(si);
-      for (uint32_t ci = 0; ci < se->num_compute_units(); ++ci)
-        se->compute_unit(ci)->set_plugin_group(plugin_group_);
-    }
-  }
+  for (auto *xcd : xcds_)
+    xcd->set_plugin_group(plugin_group_);
 }
 
 void SoC::flush_all() {

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.h
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.h
@@ -7,6 +7,7 @@
 #ifndef ROCJITSU_VM_SOC_H_
 #define ROCJITSU_VM_SOC_H_
 
+#include "rocjitsu/vm/execution_plugin.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/hbm_controller.h"
 #include "rocjitsu/vm/amdgpu/iod.h"
@@ -123,6 +124,9 @@ public:
   /// @returns Const pointer to the GPU memory.
   const amdgpu::GpuMemory *memory() const { return memory_; }
 
+  /// @brief Set the execution plugin group and distribute to CPs/CUs.
+  void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> plugin_group);
+
 private:
   rj_code_arch_t arch_ = ROCJITSU_CODE_ARCH_INVALID;
   simdojo::ExecMode exec_mode_ = simdojo::ExecMode::FUNCTIONAL;
@@ -130,6 +134,7 @@ private:
   std::vector<amdgpu::Iod *> iods_;
   amdgpu::GpuMemory *memory_ = nullptr;
   std::unique_ptr<amdgpu::HbmController> hbm_standalone_; ///< Used when num_iods == 0.
+  std::shared_ptr<ExecutionPluginGroup> plugin_group_;
 };
 
 } // namespace rocjitsu

--- a/experimental/rocjitsu/tests/CMakeLists.txt
+++ b/experimental/rocjitsu/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(rocjitsu_tests
     waitcnt_counter_test.cpp
     instruction_execution_harness_test.cpp
     decode_execute_benchmark.cpp
+    execution_plugin_test.cpp
 )
 target_link_libraries(rocjitsu_tests PRIVATE
     ${RJ_OBJECT_LIBS} rocjitsu_kmd util flatbuffers Threads::Threads GTest::gtest_main)

--- a/experimental/rocjitsu/tests/execution_plugin_test.cpp
+++ b/experimental/rocjitsu/tests/execution_plugin_test.cpp
@@ -139,7 +139,7 @@ struct PluginFixture {
     return addr;
   }
 
-  void step_until_done(uint32_t max_steps = 100000) {
+  void step_until_done(uint32_t max_steps = 10000) {
     for (uint32_t i = 0; i < max_steps && engine->step(); ++i) {
       if (cu()->num_wfs() > 0) {
         bool all_halted = true;
@@ -180,8 +180,6 @@ TEST(ExecutionPluginTest, SimpleKernelFiresHooks) {
   EXPECT_EQ(p->kernel_dispatches, 1);
   EXPECT_EQ(p->workgroup_dispatches, 1);
   EXPECT_GE(p->instructions, 2); // at least s_nop + s_endpgm
-  EXPECT_EQ(p->barriers, 0);
-  EXPECT_EQ(p->barriers_resolved, 0);
 }
 
 // --------------------------------------------------------------------------

--- a/experimental/rocjitsu/tests/execution_plugin_test.cpp
+++ b/experimental/rocjitsu/tests/execution_plugin_test.cpp
@@ -61,21 +61,21 @@ public:
   int riscv_instructions = 0;
 
   void onAmdgpuKernelDispatch(uint64_t, uint64_t) override { ++kernel_dispatches; }
-  void onAmdgpuWorkgroupDispatched(uint32_t, uint32_t, uint32_t,
+  void onAmdgpuDispatchWorkgroup(uint32_t, uint32_t, uint32_t,
                                    std::span<amdgpu::Wavefront *>) override {
     ++workgroup_dispatches;
   }
-  void onAmdgpuInstructionExecuted(uint64_t, const Instruction &inst) override {
+  void onAmdgpuExecuteInstruction(uint64_t, const Instruction &inst) override {
     ++instructions;
     if (inst.mnemonic() == "s_barrier")
       ++barriers;
   }
   void onAmdgpuBarrierResolved(uint32_t) override { ++barriers_resolved; }
-  void onAmdgpuWaitcnt(amdgpu::Wavefront *, int, int) override { ++waitcnts; }
-  void onAmdgpuMemoryInstruction(Instruction *) override {
+  void onAmdgpuSetWaitTarget(amdgpu::Wavefront *, int, int) override { ++waitcnts; }
+  void onAmdgpuRouteMemoryInstruction(const Instruction &) override {
     ++memory_insts;
   }
-  void onRiscvInstructionExecuted(uint64_t, const Instruction &) override {
+  void onRiscvExecuteInstruction(uint64_t, const Instruction &) override {
     ++riscv_instructions;
   }
 };

--- a/experimental/rocjitsu/tests/execution_plugin_test.cpp
+++ b/experimental/rocjitsu/tests/execution_plugin_test.cpp
@@ -3,10 +3,6 @@
 
 /// @file execution_plugin_test.cpp
 /// @brief Tests for the ExecutionPlugin infrastructure.
-///
-/// Verifies that all plugin hooks fire at the expected points during
-/// kernel dispatch and execution. Uses a counting plugin that records
-/// how many times each hook was called.
 
 #include "aql_queue.h"
 
@@ -15,7 +11,7 @@
 #include "rocjitsu/vm/risc_v/hart.h"
 #include "rocjitsu/vm/soc.h"
 
-#include "simdojo/sim/simulation.h" // provides SimulationEngine
+#include "simdojo/sim/simulation.h"
 
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
@@ -28,25 +24,21 @@ RJ_DIAGNOSTIC_POP
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <string_view>
-#include <vector>
 
 namespace {
 
 using namespace rocjitsu;
 
-// Path to the FlatBuffers schema used for JSON config parsing.
 const std::string SCHEMA_PATH =
     std::string(SCHEMA_DIR) + "/simulation_config.fbs";
 
-// SOPP encoding helper: bits[31:23]=0x17F, bits[22:16]=op, bits[15:0]=simm16.
+// SOPP encoding: bits[31:23]=0x17F, bits[22:16]=op, bits[15:0]=simm16.
 constexpr uint32_t sopp(uint32_t op, uint16_t simm16 = 0) {
   return 0xBF800000u | (op << 16) | simm16;
 }
-constexpr uint32_t S_NOP      = sopp(0);
-constexpr uint32_t S_ENDPGM   = sopp(1);
-constexpr uint32_t S_BARRIER  = sopp(10);
-constexpr uint32_t S_WAITCNT  = sopp(12, 0); // vmcnt=0, lgkmcnt=0
+constexpr uint32_t S_NOP     = sopp(0);
+constexpr uint32_t S_ENDPGM  = sopp(1);
+constexpr uint32_t S_BARRIER = sopp(10);
 
 /// A plugin that counts how many times each hook is called.
 class CountingPlugin : public ExecutionPlugin {
@@ -56,13 +48,12 @@ public:
   int instructions = 0;
   int barriers = 0;
   int barriers_resolved = 0;
-  int waitcnts = 0;
   int memory_insts = 0;
   int riscv_instructions = 0;
 
   void onAmdgpuKernelDispatch(uint64_t, uint64_t) override { ++kernel_dispatches; }
   void onAmdgpuDispatchWorkgroup(uint32_t, uint32_t, uint32_t,
-                                   std::span<amdgpu::Wavefront *>) override {
+                                 std::span<amdgpu::Wavefront *>) override {
     ++workgroup_dispatches;
   }
   void onAmdgpuExecuteInstruction(uint64_t, const Instruction &inst) override {
@@ -71,24 +62,19 @@ public:
       ++barriers;
   }
   void onAmdgpuBarrierResolved(uint32_t) override { ++barriers_resolved; }
-  void onAmdgpuSetWaitTarget(amdgpu::Wavefront *, int, int) override { ++waitcnts; }
-  void onAmdgpuRouteMemoryInstruction(const Instruction &) override {
-    ++memory_insts;
-  }
-  void onRiscvExecuteInstruction(uint64_t, const Instruction &) override {
-    ++riscv_instructions;
-  }
+  void onAmdgpuRouteMemoryInstruction(const Instruction &) override { ++memory_insts; }
+  void onRiscvExecuteInstruction(uint64_t, const Instruction &) override { ++riscv_instructions; }
 };
 
-/// Minimal SoC fixture: 1 XCD, 1 SE, 1 CU, configurable WF slots.
+/// Minimal SoC fixture: 1 XCD, 1 SE, 1 CU.
 struct PluginFixture {
   std::unique_ptr<simdojo::SimulationEngine> engine;
   SoC *soc = nullptr;
   amdgpu::GpuMemory *mem = nullptr;
 
-  PluginFixture(uint32_t num_wf_slots = 10) {
+  PluginFixture() {
     std::string json = R"({
-      "max_ticks":100000,"num_threads":1,"exec_mode":"functional",
+      "max_ticks":10000,"num_threads":1,"exec_mode":"functional",
       "vm":{"arch":"cdna4","gpu":{"device":{"wave_front_size":64}}},
       "topology":{"root":{"name":"soc","type":"soc","children":[
         {"name":"vram","type":"gpu_memory"},
@@ -97,8 +83,7 @@ struct PluginFixture {
           {"name":"cp","type":"command_processor"},
           {"name":"se0","type":"shader_engine","children":[
             {"name":"cu[0:1]","type":"compute_unit","config":[
-              {"key":"num_wf_slots","value":")" +
-                             std::to_string(num_wf_slots) + R"("},
+              {"key":"num_wf_slots","value":"10"},
               {"key":"sgprs_per_wf","value":"104"},
               {"key":"vgprs_per_wf","value":"256"},
               {"key":"lds_size_kb","value":"64"}
@@ -122,25 +107,35 @@ struct PluginFixture {
   amdgpu::ComputeUnitCore *cu() { return soc->xcd(0)->shader_engine(0)->compute_unit(0); }
   amdgpu::CommandProcessor *cp() { return soc->xcd(0)->command_processor(); }
 
-  /// Write kernel descriptor + code to GPU memory, return kernel_object addr.
-  uint64_t write_kernel(uint64_t addr, const uint32_t *code, size_t num_words,
-                        uint32_t sgprs = 104, uint32_t vgprs = 256, uint32_t user_sgprs = 2) {
+  uint64_t write_kernel(uint64_t addr, const uint32_t *code, size_t num_words) {
     using namespace rocr::llvm::amdhsa;
     kernel_descriptor_t kd{};
     kd.kernel_code_entry_byte_offset = sizeof(kernel_descriptor_t);
-    AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
-                    ((vgprs / 8) - 1));
-    AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
-                    ((sgprs / 8) - 1));
-    AMDHSA_BITS_SET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_USER_SGPR_COUNT, user_sgprs);
+    AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT, 31);
+    AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT, 12);
+    AMDHSA_BITS_SET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_USER_SGPR_COUNT, 2);
     mem->load_image(reinterpret_cast<const uint8_t *>(&kd), sizeof(kd), addr);
     mem->load_image(reinterpret_cast<const uint8_t *>(code), num_words * 4,
                     addr + sizeof(kernel_descriptor_t));
     return addr;
   }
 
-  void step_until_done(uint32_t max_steps = 10000) {
-    for (uint32_t i = 0; i < max_steps && engine->step(); ++i) {
+  /// Attach a CountingPlugin and return a raw pointer to it.
+  CountingPlugin *attach_plugin() {
+    auto group = std::make_shared<ExecutionPluginGroup>();
+    auto plugin = std::make_unique<CountingPlugin>();
+    auto *p = plugin.get();
+    group->add(std::move(plugin));
+    soc->set_plugin_group(group);
+    return p;
+  }
+
+  void run_kernel(const uint32_t *code, size_t num_words, uint32_t grid = 64,
+                  uint32_t workgroup = 64) {
+    uint64_t ko = write_kernel(0x1000, code, num_words);
+    test::AqlQueue queue(mem, cp());
+    queue.dispatch(ko, grid, workgroup);
+    for (uint32_t i = 0; i < 10000 && engine->step(); ++i) {
       if (cu()->num_wfs() > 0) {
         bool all_halted = true;
         for (uint32_t w = 0; w < cu()->num_wf_slots(); ++w) {
@@ -157,49 +152,24 @@ struct PluginFixture {
   }
 };
 
-// --------------------------------------------------------------------------
-// Test: simple kernel (s_nop + s_endpgm) triggers dispatch and instruction hooks.
-// --------------------------------------------------------------------------
 TEST(ExecutionPluginTest, SimpleKernelFiresHooks) {
   PluginFixture f;
+  auto *p = f.attach_plugin();
 
-  // Attach plugin.
-  auto group = std::make_shared<ExecutionPluginGroup>();
-  auto plugin = std::make_unique<CountingPlugin>();
-  auto *p = plugin.get();
-  group->add(std::move(plugin));
-  f.soc->set_plugin_group(group);
-
-  // Kernel: s_nop, s_endpgm (1 wavefront = 64 threads).
   const uint32_t code[] = {S_NOP, S_ENDPGM};
-  uint64_t ko = f.write_kernel(0x1000, code, 2);
-  test::AqlQueue queue(f.mem, f.cp());
-  queue.dispatch(ko, 64);
-  f.step_until_done();
+  f.run_kernel(code, 2);
 
   EXPECT_EQ(p->kernel_dispatches, 1);
   EXPECT_EQ(p->workgroup_dispatches, 1);
-  EXPECT_GE(p->instructions, 2); // at least s_nop + s_endpgm
+  EXPECT_GE(p->instructions, 2);
 }
 
-// --------------------------------------------------------------------------
-// Test: kernel with s_barrier fires barrier hooks (needs 2+ wavefronts).
-// --------------------------------------------------------------------------
 TEST(ExecutionPluginTest, BarrierFiresHooks) {
   PluginFixture f;
+  auto *p = f.attach_plugin();
 
-  auto group = std::make_shared<ExecutionPluginGroup>();
-  auto plugin = std::make_unique<CountingPlugin>();
-  auto *p = plugin.get();
-  group->add(std::move(plugin));
-  f.soc->set_plugin_group(std::move(group));
-
-  // Kernel: s_barrier, s_endpgm — dispatched with 128 threads (2 wavefronts).
   const uint32_t code[] = {S_BARRIER, S_ENDPGM};
-  uint64_t ko = f.write_kernel(0x1000, code, 2);
-  test::AqlQueue queue(f.mem, f.cp());
-  queue.dispatch(ko, 128, 128); // grid=128, wg=128 → 2 wavefronts in 1 workgroup
-  f.step_until_done();
+  f.run_kernel(code, 2, /*grid=*/128, /*workgroup=*/128);
 
   EXPECT_EQ(p->kernel_dispatches, 1);
   EXPECT_EQ(p->workgroup_dispatches, 1);
@@ -207,51 +177,13 @@ TEST(ExecutionPluginTest, BarrierFiresHooks) {
   EXPECT_EQ(p->barriers_resolved, 1); // one resolution for the workgroup
 }
 
-// --------------------------------------------------------------------------
-// Test: kernel with s_waitcnt fires waitcnt hook.
-// --------------------------------------------------------------------------
-TEST(ExecutionPluginTest, WaitcntFiresHook) {
-  PluginFixture f;
-
-  auto group = std::make_shared<ExecutionPluginGroup>();
-  auto plugin = std::make_unique<CountingPlugin>();
-  auto *p = plugin.get();
-  group->add(std::move(plugin));
-  f.soc->set_plugin_group(std::move(group));
-
-  // Kernel: s_waitcnt 0, s_endpgm.
-  const uint32_t code[] = {S_WAITCNT, S_ENDPGM};
-  uint64_t ko = f.write_kernel(0x1000, code, 2);
-  test::AqlQueue queue(f.mem, f.cp());
-  queue.dispatch(ko, 64);
-  f.step_until_done();
-
-  EXPECT_EQ(p->kernel_dispatches, 1);
-  // s_waitcnt is handled by the instruction executor, which calls
-  // set_wait_target on the wavefront. The onWaitcnt hook fires there.
-  // If the hook is not yet wired (set_wait_target is still inline),
-  // this will be 0 — that's expected for the minimal plugin PR.
-}
-
-// --------------------------------------------------------------------------
-// Test: no plugin attached — verify no crash (null plugin_group_ path).
-// --------------------------------------------------------------------------
 TEST(ExecutionPluginTest, NoPluginNoCrash) {
   PluginFixture f;
-  // No plugin set — just run a kernel and ensure no crash.
   const uint32_t code[] = {S_NOP, S_ENDPGM};
-  uint64_t ko = f.write_kernel(0x1000, code, 2);
-  test::AqlQueue queue(f.mem, f.cp());
-  queue.dispatch(ko, 64);
-  f.step_until_done();
-  // If we reach here, the null-check guards worked.
+  f.run_kernel(code, 2);
 }
 
-// --------------------------------------------------------------------------
-// Test: RISC-V plugin hook fires on instruction execution.
-// --------------------------------------------------------------------------
 TEST(ExecutionPluginTest, RiscvInstructionHook) {
-  // Build a standalone RISC-V hart (same pattern as rvsim_test.cpp).
   simdojo::SimulationEngine::Config config{};
   config.max_ticks = 1000;
   config.num_threads = 1;
@@ -262,7 +194,6 @@ TEST(ExecutionPluginTest, RiscvInstructionHook) {
   auto hart_ptr = std::make_unique<rocjitsu::risc_v::Hart>("hart0", *clk);
   auto *hart = static_cast<rocjitsu::risc_v::Hart *>(root->add_child(std::move(hart_ptr)));
 
-  // Attach plugin.
   auto group = std::make_shared<ExecutionPluginGroup>();
   auto plugin = std::make_unique<CountingPlugin>();
   auto *p = plugin.get();
@@ -272,16 +203,14 @@ TEST(ExecutionPluginTest, RiscvInstructionHook) {
   engine->topology().set_root(std::move(root));
   engine->build();
 
-  // Program: addi x1, x0, 42 then ebreak (halt).
-  //   addi x1, x0, 42  = 0x02A00093
-  //   ebreak            = 0x00100073
+  // addi x1, x0, 42 then ebreak (halt).
   const uint32_t program[] = {0x02A00093u, 0x00100073u};
   hart->memory().load_image(reinterpret_cast<const uint8_t *>(program),
                             sizeof(program), 0);
   hart->state().pc = 0;
   engine->run();
 
-  EXPECT_EQ(p->riscv_instructions, 2); // addi + ebreak
+  EXPECT_EQ(p->riscv_instructions, 2);
   EXPECT_EQ(hart->state().read_xreg(1), 42);
 }
 

--- a/experimental/rocjitsu/tests/execution_plugin_test.cpp
+++ b/experimental/rocjitsu/tests/execution_plugin_test.cpp
@@ -1,0 +1,290 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file execution_plugin_test.cpp
+/// @brief Tests for the ExecutionPlugin infrastructure.
+///
+/// Verifies that all plugin hooks fire at the expected points during
+/// kernel dispatch and execution. Uses a counting plugin that records
+/// how many times each hook was called.
+
+#include "aql_queue.h"
+
+#include "rocjitsu/config/config_loader.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/risc_v/hart.h"
+#include "rocjitsu/vm/soc.h"
+
+#include "simdojo/sim/simulation.h" // provides SimulationEngine
+
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "hsa/AMDHSAKernelDescriptor.h"
+RJ_DIAGNOSTIC_POP
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+using namespace rocjitsu;
+
+// Path to the FlatBuffers schema used for JSON config parsing.
+const std::string SCHEMA_PATH =
+    std::string(SCHEMA_DIR) + "/simulation_config.fbs";
+
+// SOPP encoding helper: bits[31:23]=0x17F, bits[22:16]=op, bits[15:0]=simm16.
+constexpr uint32_t sopp(uint32_t op, uint16_t simm16 = 0) {
+  return 0xBF800000u | (op << 16) | simm16;
+}
+constexpr uint32_t S_NOP      = sopp(0);
+constexpr uint32_t S_ENDPGM   = sopp(1);
+constexpr uint32_t S_BARRIER  = sopp(10);
+constexpr uint32_t S_WAITCNT  = sopp(12, 0); // vmcnt=0, lgkmcnt=0
+
+/// A plugin that counts how many times each hook is called.
+class CountingPlugin : public ExecutionPlugin {
+public:
+  int kernel_dispatches = 0;
+  int workgroup_dispatches = 0;
+  int instructions = 0;
+  int barriers = 0;
+  int barriers_resolved = 0;
+  int waitcnts = 0;
+  int memory_insts = 0;
+  int riscv_instructions = 0;
+
+  void onAmdgpuKernelDispatch(uint64_t, uint64_t) override { ++kernel_dispatches; }
+  void onAmdgpuWorkgroupDispatched(uint32_t, uint32_t, uint32_t,
+                                   std::span<amdgpu::Wavefront *>) override {
+    ++workgroup_dispatches;
+  }
+  void onAmdgpuInstructionExecuted(uint64_t, const Instruction &inst) override {
+    ++instructions;
+    if (inst.mnemonic() == "s_barrier")
+      ++barriers;
+  }
+  void onAmdgpuBarrierResolved(uint32_t) override { ++barriers_resolved; }
+  void onAmdgpuWaitcnt(amdgpu::Wavefront *, int, int) override { ++waitcnts; }
+  void onAmdgpuMemoryInstruction(Instruction *) override {
+    ++memory_insts;
+  }
+  void onRiscvInstructionExecuted(uint64_t, const Instruction &) override {
+    ++riscv_instructions;
+  }
+};
+
+/// Minimal SoC fixture: 1 XCD, 1 SE, 1 CU, configurable WF slots.
+struct PluginFixture {
+  std::unique_ptr<simdojo::SimulationEngine> engine;
+  SoC *soc = nullptr;
+  amdgpu::GpuMemory *mem = nullptr;
+
+  PluginFixture(uint32_t num_wf_slots = 10) {
+    std::string json = R"({
+      "max_ticks":100000,"num_threads":1,"exec_mode":"functional",
+      "vm":{"arch":"cdna4","gpu":{"device":{"wave_front_size":64}}},
+      "topology":{"root":{"name":"soc","type":"soc","children":[
+        {"name":"vram","type":"gpu_memory"},
+        {"name":"xcd0","type":"xcd","children":[
+          {"name":"l2","type":"l2_cache"},
+          {"name":"cp","type":"command_processor"},
+          {"name":"se0","type":"shader_engine","children":[
+            {"name":"cu[0:1]","type":"compute_unit","config":[
+              {"key":"num_wf_slots","value":")" +
+                             std::to_string(num_wf_slots) + R"("},
+              {"key":"sgprs_per_wf","value":"104"},
+              {"key":"vgprs_per_wf","value":"256"},
+              {"key":"lds_size_kb","value":"64"}
+            ]}
+          ]}
+        ]}
+      ]},"links":[
+        {"src":"xcd0.cp.req_0","dst":"xcd0.se0.cu0.cpl","latency":1,"weight":2},
+        {"src":"xcd0.se0.cu0.req","dst":"xcd0.l2.cpl_0","latency":1,"weight":10}
+      ]}}
+    )";
+    auto loaded = config::load_config_from_string(json, SCHEMA_PATH);
+    soc = loaded.soc();
+    mem = loaded.memory();
+    engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
+    engine->topology().set_root(loaded.take_root());
+    loaded.wire_links(engine->topology());
+    engine->build();
+  }
+
+  amdgpu::ComputeUnitCore *cu() { return soc->xcd(0)->shader_engine(0)->compute_unit(0); }
+  amdgpu::CommandProcessor *cp() { return soc->xcd(0)->command_processor(); }
+
+  /// Write kernel descriptor + code to GPU memory, return kernel_object addr.
+  uint64_t write_kernel(uint64_t addr, const uint32_t *code, size_t num_words,
+                        uint32_t sgprs = 104, uint32_t vgprs = 256, uint32_t user_sgprs = 2) {
+    using namespace rocr::llvm::amdhsa;
+    kernel_descriptor_t kd{};
+    kd.kernel_code_entry_byte_offset = sizeof(kernel_descriptor_t);
+    AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
+                    ((vgprs / 8) - 1));
+    AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
+                    ((sgprs / 8) - 1));
+    AMDHSA_BITS_SET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_USER_SGPR_COUNT, user_sgprs);
+    mem->load_image(reinterpret_cast<const uint8_t *>(&kd), sizeof(kd), addr);
+    mem->load_image(reinterpret_cast<const uint8_t *>(code), num_words * 4,
+                    addr + sizeof(kernel_descriptor_t));
+    return addr;
+  }
+
+  void step_until_done(uint32_t max_steps = 100000) {
+    for (uint32_t i = 0; i < max_steps && engine->step(); ++i) {
+      if (cu()->num_wfs() > 0) {
+        bool all_halted = true;
+        for (uint32_t w = 0; w < cu()->num_wf_slots(); ++w) {
+          auto *wf = cu()->wf(w);
+          if (wf && wf->sgpr_alloc().count > 0 && !wf->is_halted()) {
+            all_halted = false;
+            break;
+          }
+        }
+        if (all_halted)
+          break;
+      }
+    }
+  }
+};
+
+// --------------------------------------------------------------------------
+// Test: simple kernel (s_nop + s_endpgm) triggers dispatch and instruction hooks.
+// --------------------------------------------------------------------------
+TEST(ExecutionPluginTest, SimpleKernelFiresHooks) {
+  PluginFixture f;
+
+  // Attach plugin.
+  auto group = std::make_shared<ExecutionPluginGroup>();
+  auto plugin = std::make_unique<CountingPlugin>();
+  auto *p = plugin.get();
+  group->add(std::move(plugin));
+  f.soc->set_plugin_group(group);
+
+  // Kernel: s_nop, s_endpgm (1 wavefront = 64 threads).
+  const uint32_t code[] = {S_NOP, S_ENDPGM};
+  uint64_t ko = f.write_kernel(0x1000, code, 2);
+  test::AqlQueue queue(f.mem, f.cp());
+  queue.dispatch(ko, 64);
+  f.step_until_done();
+
+  EXPECT_EQ(p->kernel_dispatches, 1);
+  EXPECT_EQ(p->workgroup_dispatches, 1);
+  EXPECT_GE(p->instructions, 2); // at least s_nop + s_endpgm
+  EXPECT_EQ(p->barriers, 0);
+  EXPECT_EQ(p->barriers_resolved, 0);
+}
+
+// --------------------------------------------------------------------------
+// Test: kernel with s_barrier fires barrier hooks (needs 2+ wavefronts).
+// --------------------------------------------------------------------------
+TEST(ExecutionPluginTest, BarrierFiresHooks) {
+  PluginFixture f;
+
+  auto group = std::make_shared<ExecutionPluginGroup>();
+  auto plugin = std::make_unique<CountingPlugin>();
+  auto *p = plugin.get();
+  group->add(std::move(plugin));
+  f.soc->set_plugin_group(std::move(group));
+
+  // Kernel: s_barrier, s_endpgm — dispatched with 128 threads (2 wavefronts).
+  const uint32_t code[] = {S_BARRIER, S_ENDPGM};
+  uint64_t ko = f.write_kernel(0x1000, code, 2);
+  test::AqlQueue queue(f.mem, f.cp());
+  queue.dispatch(ko, 128, 128); // grid=128, wg=128 → 2 wavefronts in 1 workgroup
+  f.step_until_done();
+
+  EXPECT_EQ(p->kernel_dispatches, 1);
+  EXPECT_EQ(p->workgroup_dispatches, 1);
+  EXPECT_EQ(p->barriers, 2);          // one per wavefront
+  EXPECT_EQ(p->barriers_resolved, 1); // one resolution for the workgroup
+}
+
+// --------------------------------------------------------------------------
+// Test: kernel with s_waitcnt fires waitcnt hook.
+// --------------------------------------------------------------------------
+TEST(ExecutionPluginTest, WaitcntFiresHook) {
+  PluginFixture f;
+
+  auto group = std::make_shared<ExecutionPluginGroup>();
+  auto plugin = std::make_unique<CountingPlugin>();
+  auto *p = plugin.get();
+  group->add(std::move(plugin));
+  f.soc->set_plugin_group(std::move(group));
+
+  // Kernel: s_waitcnt 0, s_endpgm.
+  const uint32_t code[] = {S_WAITCNT, S_ENDPGM};
+  uint64_t ko = f.write_kernel(0x1000, code, 2);
+  test::AqlQueue queue(f.mem, f.cp());
+  queue.dispatch(ko, 64);
+  f.step_until_done();
+
+  EXPECT_EQ(p->kernel_dispatches, 1);
+  // s_waitcnt is handled by the instruction executor, which calls
+  // set_wait_target on the wavefront. The onWaitcnt hook fires there.
+  // If the hook is not yet wired (set_wait_target is still inline),
+  // this will be 0 — that's expected for the minimal plugin PR.
+}
+
+// --------------------------------------------------------------------------
+// Test: no plugin attached — verify no crash (null plugin_group_ path).
+// --------------------------------------------------------------------------
+TEST(ExecutionPluginTest, NoPluginNoCrash) {
+  PluginFixture f;
+  // No plugin set — just run a kernel and ensure no crash.
+  const uint32_t code[] = {S_NOP, S_ENDPGM};
+  uint64_t ko = f.write_kernel(0x1000, code, 2);
+  test::AqlQueue queue(f.mem, f.cp());
+  queue.dispatch(ko, 64);
+  f.step_until_done();
+  // If we reach here, the null-check guards worked.
+}
+
+// --------------------------------------------------------------------------
+// Test: RISC-V plugin hook fires on instruction execution.
+// --------------------------------------------------------------------------
+TEST(ExecutionPluginTest, RiscvInstructionHook) {
+  // Build a standalone RISC-V hart (same pattern as rvsim_test.cpp).
+  simdojo::SimulationEngine::Config config{};
+  config.max_ticks = 1000;
+  config.num_threads = 1;
+  auto engine = std::make_unique<simdojo::SimulationEngine>(config);
+  auto *clk = engine->topology().add_clock_domain("clk", simdojo::TICKS_PER_SECOND);
+
+  auto root = std::make_unique<simdojo::CompositeComponent>("soc");
+  auto hart_ptr = std::make_unique<rocjitsu::risc_v::Hart>("hart0", *clk);
+  auto *hart = static_cast<rocjitsu::risc_v::Hart *>(root->add_child(std::move(hart_ptr)));
+
+  // Attach plugin.
+  auto group = std::make_shared<ExecutionPluginGroup>();
+  auto plugin = std::make_unique<CountingPlugin>();
+  auto *p = plugin.get();
+  group->add(std::move(plugin));
+  hart->set_plugin_group(group);
+
+  engine->topology().set_root(std::move(root));
+  engine->build();
+
+  // Program: addi x1, x0, 42 then ebreak (halt).
+  //   addi x1, x0, 42  = 0x02A00093
+  //   ebreak            = 0x00100073
+  const uint32_t program[] = {0x02A00093u, 0x00100073u};
+  hart->memory().load_image(reinterpret_cast<const uint8_t *>(program),
+                            sizeof(program), 0);
+  hart->state().pc = 0;
+  engine->run();
+
+  EXPECT_EQ(p->riscv_instructions, 2); // addi + ebreak
+  EXPECT_EQ(hart->state().read_xreg(1), 42);
+}
+
+} // namespace


### PR DESCRIPTION
2 new classes: `rocjitsu::ExecutionPlugin` and `ExecutionPluginGroup`. The second is just a collection of the first. 

ExecutionPlugin defines a bunch of virtual 'hook' methods. Each hook is called from 1 location in rocjitsu -- currently either in a risc-v hart, or somewhere in the amdgpu SoC. 

The set of hooks added in this PR is based on what I need for race detection (although that plugin will come later). When new ideas for plugins arise, we will need to add more hook locations. 

Every virtual method in ExecutionPlugin is mirrored by ExecutionPluginGroup, which simply iterates over the plugins and calls its method. In the future we can make this more efficient, so that the loop is only over plugins that actually implement a hook. 

@atgutier you mentioned adapting the design so that a plugin can live entirely outside of rocjitsu. I would like to postpone this to future work
