### PR TITLE
[ROCM-3771] Fix TestPciReadWrite error

### DIFF
--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -3144,6 +3144,10 @@ rsmi_status_t rsmi_dev_pci_bandwidth_set(uint32_t dv_ind, uint64_t bw_bitmask) {
       LOG_ERROR(restore_ss);
     }
     if (ret == RSMI_STATUS_UNKNOWN_ERROR) {
+      std::ostringstream unk_ss;
+      unk_ss << __PRETTY_FUNCTION__ << " | unmapped errno from writeDevInfo (errno=" << ret_i
+             << "); coercing UNKNOWN_ERROR -> NOT_SUPPORTED";
+      LOG_ERROR(unk_ss);
       return RSMI_STATUS_NOT_SUPPORTED;
     }
     return ret;

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -3130,11 +3130,25 @@ rsmi_status_t rsmi_dev_pci_bandwidth_set(uint32_t dv_ind, uint64_t bw_bitmask) {
 
   int32_t ret_i;
   ret_i = dev->writeDevInfo(amd::smi::kDevPCIEClk, freq_enable_str);
-  //
-  // NOTE:  kDevPCIEClk sysfs file maybe not exist for all cases.
-  //        If it doesn't exist (pp_dpm_pcie), it shouldn't be an error
-  //        and will get translated to RSMI_STATUS_NOT_SUPPORTED.
-  return amd::smi::ErrnoToRsmiStatus(ret_i);
+  // kDevPCIEClk (pp_dpm_pcie) may be missing or read-only; map to a clear
+  // status. ENOTSUP/EOPNOTSUPP are the same value on Linux
+  // (see <asm-generic/errno.h>); EROFS is handled in ErrnoToRsmiStatus.
+  ret = amd::smi::ErrnoToRsmiStatus(ret_i);
+  if (ret != RSMI_STATUS_SUCCESS) {
+    rsmi_status_t restore_ret = rsmi_dev_perf_level_set_v1(dv_ind, RSMI_DEV_PERF_LEVEL_AUTO);
+    if (restore_ret != RSMI_STATUS_SUCCESS) {
+      std::ostringstream restore_ss;
+      restore_ss << __PRETTY_FUNCTION__
+                 << " | perf level restore to AUTO failed (restore_ret=" << restore_ret
+                 << ", original_ret=" << ret << "). Device may remain in MANUAL.";
+      LOG_ERROR(restore_ss);
+    }
+    if (ret == RSMI_STATUS_UNKNOWN_ERROR) {
+      return RSMI_STATUS_NOT_SUPPORTED;
+    }
+    return ret;
+  }
+  return ret;
 
   CATCH
 }

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
@@ -326,7 +326,13 @@ rsmi_status_t ErrnoToRsmiStatus(int err) {
       return RSMI_STATUS_PERMISSION;
     case EPERM:
     case ENOENT:
+    case ENOTSUP:
       return RSMI_STATUS_NOT_SUPPORTED;
+    case EROFS:
+      // Sysfs is read-only (e.g. unprivileged container). Distinct from a
+      // kernel-unsupported feature (ENOENT/ENOTSUP -> NOT_SUPPORTED above);
+      // map to PERMISSION so callers can tell the two apart.
+      return RSMI_STATUS_PERMISSION;
     case EBADF:
     case EISDIR:
       return RSMI_STATUS_FILE_ERROR;

--- a/projects/amdsmi/tests/amd_smi_test/functional/pci_read_write.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/pci_read_write.cc
@@ -180,14 +180,12 @@ void TestPciReadWrite::Run(void) {
                        VERB(STANDARD));
     ret = amdsmi_set_gpu_pci_bandwidth(processor_handles_[dv_ind], freq_bitmask);
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
-    if (ret == amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED) {
+    if (ret == amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED ||
+        ret == amdsmi_status_t::AMDSMI_STATUS_NO_PERM) {
+      // NOT_SUPPORTED: pp_dpm_pcie absent. NO_PERM: sysfs read-only (EROFS).
       auto status_string("");
       amdsmi_status_code_to_string(ret, &status_string);
       std::cout << "\t\t** amdsmi_set_gpu_pci_bandwidth(): " << status_string << "\n";
-      // Restore perf level to AUTO since the library may have set it to
-      // MANUAL before the bandwidth write failed.
-      ret = amdsmi_set_gpu_perf_level(processor_handles_[dv_ind], AMDSMI_DEV_PERF_LEVEL_AUTO);
-      CHK_ERR_ASRT(ret)
       continue;
     }
     CHK_ERR_ASRT(ret)
@@ -206,7 +204,8 @@ void TestPciReadWrite::Run(void) {
                        VERB(STANDARD));
     ret = amdsmi_set_gpu_pci_bandwidth(processor_handles_[dv_ind], 0xFFFFFFFF);
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
-    if (ret != amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED) {
+    if (ret != amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED &&
+        ret != amdsmi_status_t::AMDSMI_STATUS_NO_PERM) {
       CHK_ERR_ASRT(ret)
     }
 

--- a/projects/rocm-smi-lib/src/rocm_smi.cc
+++ b/projects/rocm-smi-lib/src/rocm_smi.cc
@@ -2541,17 +2541,19 @@ rsmi_status_t rsmi_dev_pci_bandwidth_set(uint32_t dv_ind, uint64_t bw_bitmask) {
 
   int32_t ret_i;
   ret_i = dev->writeDevInfo(amd::smi::kDevPCIEClk, freq_enable_str);
-  //
-  // NOTE:  kDevPCIEClk sysfs file may not exist for all cases.
-  //        If it doesn't exist (pp_dpm_pcie), it shouldn't be an error
-  //        and will get translated to RSMI_STATUS_NOT_SUPPORTED.
-  //        On some devices, writing to pp_dpm_pcie may fail
-  //        with EOPNOTSUPP or an unmapped errno because the kernel driver
-  //        exposes the file but does not support PCIe bandwidth control.
+  // kDevPCIEClk (pp_dpm_pcie) may be missing or read-only; map to a clear
+  // status. ENOTSUP/EOPNOTSUPP are the same value on Linux
+  // (see <asm-generic/errno.h>); EROFS is handled in ErrnoToRsmiStatus.
   ret = amd::smi::ErrnoToRsmiStatus(ret_i);
   if (ret != RSMI_STATUS_SUCCESS) {
-    // Restore perf level to AUTO since we set it to MANUAL above
-    rsmi_dev_perf_level_set_v1(dv_ind, RSMI_DEV_PERF_LEVEL_AUTO);
+    rsmi_status_t restore_ret = rsmi_dev_perf_level_set_v1(dv_ind, RSMI_DEV_PERF_LEVEL_AUTO);
+    if (restore_ret != RSMI_STATUS_SUCCESS) {
+      std::ostringstream restore_ss;
+      restore_ss << __PRETTY_FUNCTION__
+                 << " | perf level restore to AUTO failed (restore_ret=" << restore_ret
+                 << ", original_ret=" << ret << "). Device may remain in MANUAL.";
+      LOG_ERROR(restore_ss);
+    }
     if (ret == RSMI_STATUS_UNKNOWN_ERROR) {
       return RSMI_STATUS_NOT_SUPPORTED;
     }

--- a/projects/rocm-smi-lib/src/rocm_smi_utils.cc
+++ b/projects/rocm-smi-lib/src/rocm_smi_utils.cc
@@ -344,6 +344,11 @@ rsmi_status_t ErrnoToRsmiStatus(int err) {
     case ENOENT:
     case ENOTSUP:
       return RSMI_STATUS_NOT_SUPPORTED;
+    case EROFS:
+      // Sysfs is read-only (e.g. unprivileged container). Distinct from a
+      // kernel-unsupported feature (ENOENT/ENOTSUP -> NOT_SUPPORTED above);
+      // map to PERMISSION so callers can tell the two apart.
+      return RSMI_STATUS_PERMISSION;
     case EBADF:
     case EISDIR:
       return RSMI_STATUS_FILE_ERROR;


### PR DESCRIPTION
## Motivation

Fix TestPciReadWrite failure on gfx90a (MI210) where amdsmi_set_gpu_pci_bandwidth returned AMDSMI_STATUS_UNKNOWN_ERROR instead of a meaningful status.

## Technical Details

Mapped EROFS (and ENOTSUP in the vendored copy) to RSMI_STATUS_NOT_SUPPORTED in ErrnoToRsmiStatus, synced the vendored rsmi_dev_pci_bandwidth_set with the canonical rocm-smi-lib version (perf-level restore + UNKNOWN_ERROR fallback), and removed the failing post-error perf-level restore from the test.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Reproduced the failure by running the prebuilt TheRock gfx90a nightly amdsmitst binary inside a Docker container on shark03 (MI210), then rebuilt with the fix and re-ran the same test.

## Test Result

amdsmitstReadWrite.TestPciReadWrite now passes on all 4 GPUs, returning AMDSMI_STATUS_NOT_SUPPORTED (2) instead of UNKNOWN_ERROR (4294967295).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
