### PR TITLE
[rocprof-compute] Removed --exit-zero from ruff formatting workflow

### DIFF
--- a/.github/workflows/rocprofiler-compute-formatting.yml
+++ b/.github/workflows/rocprofiler-compute-formatting.yml
@@ -45,7 +45,7 @@ jobs:
         if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
     - name: Run Ruff Linter and Import Sorter
       run: |
-        ruff check . --fix --exit-zero
+        ruff check . --fix
     - name: Run Ruff Formatter
       run: |
         ruff format .

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -521,7 +521,7 @@ Examples:
         default=False,
         action="store_true",
         help=(
-            "\t\t\t(DEPRECATED) Retain the large raw rocpd database in workload directory.\n"
+            "\t\t\t(DEPRECATED) Retain the large raw rocpd database in workload directory.\n"  # noqa: E501
             "\t\t\tThis option requires --format-rocprof-output rocpd.\n"
             "\t\t\t --retain-rocpd-output is deprecated. .db files will be retained by default in a future release."  # noqa: E501
         ),

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -521,9 +521,11 @@ Examples:
         default=False,
         action="store_true",
         help=(
-            "\t\t\t(DEPRECATED) Retain the large raw rocpd database in workload directory.\n"  # noqa: E501
+            "\t\t\t(DEPRECATED) Retain the large raw rocpd database "
+            "in workload directory.\n"
             "\t\t\tThis option requires --format-rocprof-output rocpd.\n"
-            "\t\t\t --retain-rocpd-output is deprecated. .db files will be retained by default in a future release."  # noqa: E501
+            "\t\t\t --retain-rocpd-output is deprecated. .db files will "
+            "be retained by default in a future release."
         ),
     )
 


### PR DESCRIPTION
## Motivation

The formatting workflow uses`ruff check . --fix --exit-zero`.

This PR drops `--exit-zero` from the ruff CI step so the workflow actually fails on lint errors that aren't auto fixable instead of silently passing them

## Technical Details

N/A 
## JIRA ID

N/A 

## Test Plan

N/A 

## Test Result

N/A 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
