### PR TITLE
[hipfile] Add CMake for API examples

### DIFF
--- a/projects/hipfile/CMakeLists.txt
+++ b/projects/hipfile/CMakeLists.txt
@@ -286,6 +286,7 @@ endif()
 # Add the example directory
 if(AIS_INSTALL_EXAMPLES)
     add_subdirectory(examples/aiscp)
+    add_subdirectory(examples/api)
 endif()
 
 # Add tools directory

--- a/projects/hipfile/cmake/AISInstall.cmake
+++ b/projects/hipfile/cmake/AISInstall.cmake
@@ -42,10 +42,22 @@ if(AIS_INSTALL_EXAMPLES)
     configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/examples/aiscp/CMakeLists.install.cmake"
         "examples/aiscp/CMakeLists.txt"
+        @ONLY
     )
     install(FILES
         "${CMAKE_CURRENT_BINARY_DIR}/examples/aiscp/CMakeLists.txt"
         DESTINATION "share/doc/${CMAKE_PROJECT_NAME}/examples/aiscp/"
+    )
+
+    # API examples
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/examples/api/CMakeLists.install.in"
+        "examples/api/CMakeLists.txt"
+        @ONLY
+    )
+    install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/examples/api/CMakeLists.txt"
+        DESTINATION "share/doc/${CMAKE_PROJECT_NAME}/examples/api/"
     )
 endif()
 

--- a/projects/hipfile/examples/api/CMakeLists.install.in
+++ b/projects/hipfile/examples/api/CMakeLists.install.in
@@ -1,0 +1,26 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# You may need to add -DCMAKE_PREFIX_PATH=/path/to/hipfile
+# if hipFile has been installed to a non-standard location
+
+cmake_minimum_required(VERSION 3.21)
+
+project(api_examples LANGUAGES CXX)
+
+find_package(hip REQUIRED CONFIG)
+find_package(hipfile REQUIRED CONFIG)
+
+set(API_EXAMPLES
+    get-version
+)
+
+foreach(example ${API_EXAMPLES})
+    add_executable(${example} "${example}.cpp")
+
+    target_compile_features(${example} PRIVATE cxx_std_17)
+    set_target_properties(${example} PROPERTIES CXX_EXTENSIONS OFF)
+    target_compile_options(${example} PRIVATE -Wall -Wextra)
+    target_link_libraries(${example} PRIVATE hip::host hip::hipfile)
+endforeach()

--- a/projects/hipfile/examples/api/CMakeLists.txt
+++ b/projects/hipfile/examples/api/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+include(AISAddExecutable)
+
+set(API_EXAMPLES
+    get-version
+)
+
+foreach(example ${API_EXAMPLES})
+    ais_add_executable(
+        NAME ${example}
+        DEPS hipfile
+        SRCS "${example}.cpp"
+        SYSINCLS ${HIPFILE_INCLUDE_PATH}
+    )
+endforeach()

--- a/projects/hipfile/examples/api/get-version.cpp
+++ b/projects/hipfile/examples/api/get-version.cpp
@@ -1,0 +1,41 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* get-version - Get hipFile version info
+ *
+ * Usage: ./get-version
+ */
+
+#include <hipfile.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+int
+main(void)
+{
+    unsigned       major = 0;
+    unsigned       minor = 0;
+    unsigned       patch = 0;
+    hipFileError_t err;
+
+    printf("\n");
+
+    /* hipFile #defines symbols for the major, minor, and version numbers
+     * which are useful for #ifdefs at compile time.
+     */
+    printf("Version from the header symbols (major.minor.patch): %d.%d.%d\n", HIPFILE_VERSION_MAJOR,
+           HIPFILE_VERSION_MINOR, HIPFILE_VERSION_PATCH);
+    printf("\n");
+
+    /* You can also get the version numbers at runtime */
+    err = hipFileGetVersion(&major, &minor, &patch);
+    if (err.err != hipFileSuccess || err.hip_drv_err != hipSuccess)
+        return EXIT_FAILURE;
+    printf("Version from hipFileGetVersion() (major.minor.patch): %u.%u.%u\n", major, minor, patch);
+    printf("\n");
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Adds:
* CMakeLists.txt for building examples w/ hipFile
* CMakeLists.install.in to be installed as CMakeLists.txt for use after installation
* A sample example program (get_version.cpp)

AIHIPFILE-120
