### PR TITLE
[sna]: add build & test CI workflow

### DIFF
--- a/.github/workflows/rocpdsna-ci.yml
+++ b/.github/workflows/rocpdsna-ci.yml
@@ -14,6 +14,9 @@ on:
       - '!projects/rocpdsna/docs/**'
       - '!projects/rocpdsna/README.md'
   pull_request:
+    branches:
+      - develop
+      - sna-develop
     paths:
       - '.github/workflows/rocpdsna-ci.yml'
       - 'projects/rocpdsna/**'

--- a/.github/workflows/rocpdsna-ci.yml
+++ b/.github/workflows/rocpdsna-ci.yml
@@ -1,0 +1,96 @@
+name: rocpdsna CI
+run-name: rocpdsna-ci
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+      - sna-develop
+    paths:
+      - '.github/workflows/rocpdsna-ci.yml'
+      - 'projects/rocpdsna/**'
+      - '!projects/rocpdsna/build/**'
+      - '!projects/rocpdsna/docs/**'
+      - '!projects/rocpdsna/README.md'
+  pull_request:
+    paths:
+      - '.github/workflows/rocpdsna-ci.yml'
+      - 'projects/rocpdsna/**'
+      - '!projects/rocpdsna/build/**'
+      - '!projects/rocpdsna/docs/**'
+      - '!projects/rocpdsna/README.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    name: ${{ matrix.os }} / ${{ matrix.compiler.name }} / ${{ matrix.build-type }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+        compiler:
+          - { name: gcc,   cc: gcc,   cxx: g++,     pkg: 'gcc g++' }
+          - { name: clang, cc: clang, cxx: clang++, pkg: 'clang' }
+        build-type: [Debug, Release]
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            projects/rocpdsna
+            .github/workflows
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake \
+            ${{ matrix.compiler.pkg }} \
+            libsqlite3-dev libspdlog-dev libfmt-dev nlohmann-json3-dev \
+            libgtest-dev libgmock-dev libbenchmark-dev
+
+      - name: Configure
+        working-directory: projects/rocpdsna
+        env:
+          CC: ${{ matrix.compiler.cc }}
+          CXX: ${{ matrix.compiler.cxx }}
+        run: |
+          cmake --version
+          ${CXX} --version
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+            -DROCPDSNA_BUILD_TESTS=ON \
+            -DROCPDSNA_BUILD_BENCHMARKS=ON
+
+      - name: Build
+        working-directory: projects/rocpdsna
+        run: cmake --build build --parallel $(nproc)
+
+      - name: Verify library artifacts
+        working-directory: projects/rocpdsna
+        run: |
+          set -e
+          test -f build/lib/librocpdsna.so || { echo "::error::librocpdsna.so not built"; exit 1; }
+          test -f build/lib/librocpdsna.a  || { echo "::error::librocpdsna.a not built";  exit 1; }
+          ls -la build/lib/
+
+      - name: Test
+        working-directory: projects/rocpdsna/build
+        run: ctest --output-on-failure --output-junit test-results.xml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-${{ matrix.os }}-${{ matrix.compiler.name }}-${{ matrix.build-type }}
+          path: projects/rocpdsna/build/test-results.xml
+          if-no-files-found: warn


### PR DESCRIPTION
## Motivation

Establish build & test CI for the new \`rocpdsna\` library across the compiler/OS/build-type combinations the project is expected to support, gating every PR against \`sna-develop\` (and eventually \`develop\`) on a green build and a passing unit test suite. Second in the planned CI/CD PR series for rocpdsna; follows the formatting workflow added in #5313.

## Technical Details

Adds \`.github/workflows/rocpdsna-ci.yml\` with a single \`build-test\` job that fans out across an 8-entry matrix:

| Dimension | Values |
|-----------|--------|
| OS | \`ubuntu-22.04\`, \`ubuntu-24.04\` (vanilla GitHub-hosted runners) |
| Compiler | gcc / g++, clang / clang++ |
| Build type | Debug, Release |

Per job:
1. Sparse checkout of \`projects/rocpdsna/\` + \`.github/workflows/\`
2. Install system deps via apt: \`cmake\`, compiler pkg, \`libsqlite3-dev\`, \`libspdlog-dev\`, \`libfmt-dev\`, \`nlohmann-json3-dev\`, \`libgtest-dev\`, \`libbenchmark-dev\`
3. Configure with explicit \`CC\`/\`CXX\`, \`CMAKE_BUILD_TYPE\`, \`ROCPDSNA_BUILD_TESTS=ON\`, \`ROCPDSNA_BUILD_BENCHMARKS=ON\`
4. Build with \`cmake --build build --parallel \$(nproc)\`
5. Verify both library artifacts exist (\`librocpdsna.so\` and \`librocpdsna.a\`)
6. Run \`ctest --output-on-failure --output-junit test-results.xml\` (240 unit tests)
7. Upload JUnit results as an artifact (one per matrix combination)

Workflow conventions follow existing monorepo patterns:
- Triggers on \`pull_request\` (any target) plus \`push\` to \`develop\` and \`sna-develop\`
- Path filters scope to \`projects/rocpdsna/**\` (excluding \`build/\`, \`docs/\`, top-level \`README.md\`)
- Concurrency cancellation: superseded runs cancelled on new push
- Sparse checkout in every job
- \`fail-fast: false\` so all 8 combos run independently
- 30-minute per-job timeout (typical run ~5-7 min)
- Read-only permissions

System deps notes:
- spdlog is pinned to \`>=1.14.1\` in the project's CMake; Ubuntu 22.04 / 24.04 ship 1.10 / 1.12 respectively, so \`FetchContent\` will pull \`v1.14.1\` from upstream as a fallback. apt install of \`libspdlog-dev\` is harmless and exercises the system-detection path.
- SQLite3 is bundled via amalgamation (built from \`cmake/sqlite3-3450300.zip\`); \`libsqlite3-dev\` is installed for completeness.

## JIRA ID

N/A

## Test Plan

- Local Debug build with system deps on Ubuntu 24.04 / gcc 13.3.0
- Verify both \`librocpdsna.so\` and \`librocpdsna.a\` are produced
- Run full ctest suite locally
- YAML syntax validation with \`python3 -c "import yaml; yaml.safe_load(...)"\`
- First CI run on this PR exercises all 8 matrix combinations end-to-end

## Test Result

- Local Debug build (gcc 13.3.0, Ubuntu 24.04): SUCCESS, both artifacts produced
- ctest: 240/240 tests passed in 2.06s
- JUnit output: 240 testcases recorded
- YAML parse: OK
- CI run on this PR: pending — will update once first run completes

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.