### PR TITLE
[rocdecode] - Modify thread ID logging format to match AMD_LOG_LEVEL

### DIFF
--- a/projects/rocdecode/CMakeLists.txt
+++ b/projects/rocdecode/CMakeLists.txt
@@ -113,6 +113,7 @@ set (HIP_PLATFORM amd CACHE STRING "HIP platform")
 find_package(HIP QUIET)
 find_package(Libva QUIET)
 find_package(Libdrm_amdgpu QUIET)
+find_package(Threads QUIET)
 
 # Check Libva version compatibility: requires libva >= 1.22
 if(Libva_FOUND)
@@ -133,7 +134,7 @@ if(ROCDECODE_ENABLE_HOST_DECODER)
   find_package(FFmpeg QUIET)
 endif()
 
-if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND)
+if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND AND Threads_FOUND)
 
   # HIP
   set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} hip::host)
@@ -150,6 +151,9 @@ if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND)
   if (rocprofiler-register_FOUND)
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocprofiler-register::rocprofiler-register)
   endif()
+
+  # Threads library (required for std::thread support)
+  set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} Threads::Threads)
 
   # local include files
   include_directories(${CMAKE_CURRENT_SOURCE_DIR}/api ${CMAKE_CURRENT_SOURCE_DIR}/src/rocdecode ${CMAKE_CURRENT_SOURCE_DIR}/src/parser ${CMAKE_CURRENT_SOURCE_DIR}/src/rocdecode/vaapi)
@@ -298,5 +302,8 @@ else()
   endif()
   if(NOT Libdrm_amdgpu_FOUND)
     message(FATAL_ERROR "-- ERROR!: libdrm_amdgpu Not Found!")
+  endif()
+  if(NOT Threads_FOUND)
+    message(FATAL_ERROR "-- ERROR!: Threads Not Found!")
   endif()
 endif()

--- a/projects/rocdecode/CMakeLists.txt
+++ b/projects/rocdecode/CMakeLists.txt
@@ -113,6 +113,7 @@ set (HIP_PLATFORM amd CACHE STRING "HIP platform")
 find_package(HIP QUIET)
 find_package(Libva QUIET)
 find_package(Libdrm_amdgpu QUIET)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads QUIET)
 
 # Check Libva version compatibility: requires libva >= 1.22

--- a/projects/rocdecode/src/commons.h
+++ b/projects/rocdecode/src/commons.h
@@ -32,7 +32,9 @@ THE SOFTWARE.
 #include <time.h>
 #include <unistd.h>
 #include <stdint.h>
-#include <sys/syscall.h>
+#include <thread>
+#include <sstream>
+#include <iomanip>
 
 #define MSG(X) std::clog << X << std::endl;
 #define MSG_NO_NEWLINE(X) std::clog << X;
@@ -52,7 +54,8 @@ enum RocDecLogLevel {
 
 #define GET_TIME_NS() ([]() -> uint64_t { struct timespec ts_; clock_gettime(CLOCK_MONOTONIC, &ts_); return static_cast<uint64_t>(ts_.tv_sec) * 1000000000LL + ts_.tv_nsec; }())
 #define FILENAME_ONLY (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
-#define MakeMsg(msg) ROCDEC_STR(FILENAME_ONLY) + ":" + ROCDEC_TOSTR(__LINE__) + ": " + ROCDEC_TOSTR(GET_TIME_NS() / 1000ULL) + ROCDEC_STR(" us: ") + ROCDEC_STR("[pid:") + ROCDEC_TOSTR(getpid()) + ROCDEC_STR(" tid:") + ROCDEC_TOSTR(syscall(SYS_gettid)) + ROCDEC_STR("] ") + ROCDEC_STR(__func__) + "(): " + msg
+#define GET_THREAD_ID() ([]() -> std::string { std::ostringstream oss; oss << "0x" << std::hex << std::setw(5) << std::setfill('0') << (std::hash<std::thread::id>{}(std::this_thread::get_id()) & 0xFFFFF); return oss.str(); }())
+#define MakeMsg(msg) ROCDEC_STR(FILENAME_ONLY) + ":" + ROCDEC_TOSTR(__LINE__) + ": " + ROCDEC_TOSTR(GET_TIME_NS() / 1000ULL) + ROCDEC_STR(" us: ") + ROCDEC_STR("[pid:") + ROCDEC_TOSTR(getpid()) + ROCDEC_STR(" tid: ") + GET_THREAD_ID() + ROCDEC_STR("] ") + ROCDEC_STR(__func__) + "(): " + msg
 
 #define OutputMsg(msg) std::cout << msg << std::endl
 #define OutputErrMsg(msg) std::cerr << msg << std::endl
@@ -96,16 +99,16 @@ public:
         if (logger_.GetLogLevel() >= kRocDecLogInfo) {
             start_time_ = GET_TIME_NS() / 1000ULL;
             OutputMsg("[" + ROCDEC_TOSTR(kRocDecLogInfo) + ", Info] " + ROCDEC_STR(filename_) + ":" + ROCDEC_TOSTR(line_) + ": " +
-                      ROCDEC_TOSTR(start_time_) + ROCDEC_STR(" us: ") + ROCDEC_STR("[pid:") + ROCDEC_TOSTR(getpid()) + ROCDEC_STR(" tid:") +
-                      ROCDEC_TOSTR(syscall(SYS_gettid)) + ROCDEC_STR("] ") + ROCDEC_STR(func_) + "(): entry ...");
+                      ROCDEC_TOSTR(start_time_) + ROCDEC_STR(" us: ") + ROCDEC_STR("[pid:") + ROCDEC_TOSTR(getpid()) + ROCDEC_STR(" tid: ") +
+                      GET_THREAD_ID() + ROCDEC_STR("] ") + ROCDEC_STR(func_) + "(): entry ...");
         }
     }
     ~RocDecFuncScopeLog() {
         if (logger_.GetLogLevel() >= kRocDecLogInfo) {
             uint64_t end_time = GET_TIME_NS() / 1000ULL;
             OutputMsg("[" + ROCDEC_TOSTR(kRocDecLogInfo) + ", Info] " + ROCDEC_STR(filename_) + ":" + ROCDEC_TOSTR(line_) + ": " +
-                      ROCDEC_TOSTR(end_time) + ROCDEC_STR(" us: ") + ROCDEC_STR("[pid:") + ROCDEC_TOSTR(getpid()) + ROCDEC_STR(" tid:") +
-                      ROCDEC_TOSTR(syscall(SYS_gettid)) + ROCDEC_STR("] ") + ROCDEC_STR(func_) + "(): exit (" +
+                      ROCDEC_TOSTR(end_time) + ROCDEC_STR(" us: ") + ROCDEC_STR("[pid:") + ROCDEC_TOSTR(getpid()) + ROCDEC_STR(" tid: ") +
+                      GET_THREAD_ID() + ROCDEC_STR("] ") + ROCDEC_STR(func_) + "(): exit (" +
                       ROCDEC_TOSTR(end_time - start_time_) + " us) ...");
         }
     }

--- a/projects/rocdecode/utils/rocvideodecode/roc_video_dec.h
+++ b/projects/rocdecode/utils/rocvideodecode/roc_video_dec.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include <string>
 #include <iostream>
 #include <sstream>
+#include <iomanip>
 #include <string.h>
 #include <queue>
 #include <stdexcept>
@@ -39,7 +40,6 @@ THE SOFTWARE.
 #include <ctime>
 #include <time.h>
 #include <unistd.h>
-#include <sys/syscall.h>
 #include <hip/hip_runtime.h>
 #include "rocdecode/rocdecode.h"
 #include "rocdecode/rocparser.h"
@@ -48,16 +48,19 @@ THE SOFTWARE.
 #define ROCVIDEODEC_STR(X) std::string(X)
 
 // Simple logging macros - format matches src/commons.h:
-//   [0, Critical] filename:line: timestamp_us us: [pid:X tid:Y] func(): message
+//   [0, Critical] filename:line: timestamp_us us: [pid:X tid: 0xYYYYY] func(): message
 #define RocVideoDecCriticalLog(msg) \
     do { \
         struct timespec _ts_; \
         clock_gettime(CLOCK_MONOTONIC, &_ts_); \
         uint64_t _us_ = static_cast<uint64_t>(_ts_.tv_sec) * 1000000ULL + _ts_.tv_nsec / 1000ULL; \
         const char *_f_ = strrchr(__FILE__, '/'); \
+        std::ostringstream _tid_oss_; \
+        _tid_oss_ << "0x" << std::hex << std::setw(5) << std::setfill('0') \
+                  << (std::hash<std::thread::id>{}(std::this_thread::get_id()) & 0xFFFFF); \
         std::cerr << "[0, Critical] " << (_f_ ? _f_ + 1 : __FILE__) \
                   << ":" << __LINE__ << ": " << _us_ << " us: [pid:" \
-                  << getpid() << " tid:" << syscall(SYS_gettid) << "] " \
+                  << getpid() << " tid: " << _tid_oss_.str() << "] " \
                   << __func__ << "(): " << (msg) << std::endl; \
     } while (0)
 

--- a/projects/rocdecode/utils/video_demuxer.h
+++ b/projects/rocdecode/utils/video_demuxer.h
@@ -35,21 +35,26 @@ extern "C" {
 #include <ctime>
 #include <time.h>
 #include <unistd.h>
-#include <sys/syscall.h>
+#include <thread>
+#include <sstream>
+#include <iomanip>
 #include "rocdecode/rocdecode.h"
 
 // Minimal critical logging for video_demuxer.h.
 // Matches the format produced by the full logger in src/commons.h:
-//   [0, Critical] filename:line: timestamp_us us: [pid:X tid:Y] func(): message
+//   [0, Critical] filename:line: timestamp_us us: [pid:X tid: 0xYYYYY] func(): message
 #define DemuxCriticalLog(msg) \
     do { \
         struct timespec _ts_; \
         clock_gettime(CLOCK_MONOTONIC, &_ts_); \
         uint64_t _us_ = static_cast<uint64_t>(_ts_.tv_sec) * 1000000ULL + _ts_.tv_nsec / 1000ULL; \
         const char *_f_ = strrchr(__FILE__, '/'); \
+        std::ostringstream _tid_oss_; \
+        _tid_oss_ << "0x" << std::hex << std::setw(5) << std::setfill('0') \
+                  << (std::hash<std::thread::id>{}(std::this_thread::get_id()) & 0xFFFFF); \
         std::cerr << "[0, Critical] " << (_f_ ? _f_ + 1 : __FILE__) \
                   << ":" << __LINE__ << ": " << _us_ << " us: [pid:" \
-                  << getpid() << " tid:" << syscall(SYS_gettid) << "] " \
+                  << getpid() << " tid: " << _tid_oss_.str() << "] " \
                   << __func__ << "(): " << (msg) << std::endl; \
     } while (0)
 


### PR DESCRIPTION
## Motivation

Match rocdecode thread ID logging format with HIP/CLR to provide consistent thread ID reporting when using both ROCDEC_LOG_LEVEL and AMD_LOG_LEVEL.

See below for tid when both ROCDEC_LOG_LEVEL and AMD_LOG_LEVEL are enabled

Before this PR: 
```
:3:hip_memory.cpp           :205 : 185087797883 us: [pid:73084 tid: 0xece25 ] hipDestroyExternalMemory: Returned hipSuccess : 
[3, Info] vaapi_videodecoder.cpp:616: 185087797886 us: [pid:73084 **tid:  73084**] DestroyDataBuffers(): entry ...
```
After this PR:
```
:3:hip_memory.cpp           :205 : 185087797883 us: [pid:73084 tid: 0xece25] hipDestroyExternalMemory: Returned hipSuccess : 
[3, Info] vaapi_videodecoder.cpp:616: 185087797886 us: [pid:73084 **tid: 0xece25**] DestroyDataBuffers(): entry ...
```


## Technical Details

Changes:
- Replace syscall(SYS_gettid) with std::hash<std::thread::id>{}
- Format thread IDs as 5-digit hex (0xXXXXX) matching HIP/CLR
- Add Threads library as a required dependency in CMakeLists.txt
- Update all logging macros in commons.h, video_demuxer.h, and roc_video_dec.h

Benefits:
- Consistent thread IDs across different logging systems
- Portable implementation using standard C++ instead of Linux-specific syscalls
- Eliminates user confusion from mismatched thread IDs in logs

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

rocdecode CTEST

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
