### PR TITLE
[sna] add clang-tidy static analysis workflow

### DIFF
--- a/.github/workflows/rocpdsna-static-analysis.yml
+++ b/.github/workflows/rocpdsna-static-analysis.yml
@@ -1,0 +1,95 @@
+name: rocpdsna Static Analysis
+run-name: rocpdsna-static-analysis
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+      - sna-develop
+    paths:
+      - '.github/workflows/rocpdsna-static-analysis.yml'
+      - 'projects/rocpdsna/**'
+      - '!projects/rocpdsna/build/**'
+      - '!projects/rocpdsna/docs/**'
+      - '!projects/rocpdsna/README.md'
+  pull_request:
+    paths:
+      - '.github/workflows/rocpdsna-static-analysis.yml'
+      - 'projects/rocpdsna/**'
+      - '!projects/rocpdsna/build/**'
+      - '!projects/rocpdsna/docs/**'
+      - '!projects/rocpdsna/README.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  clang-tidy:
+    name: clang-tidy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            projects/rocpdsna
+            .github/workflows
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake \
+            gcc g++ clang-tidy-18 \
+            libsqlite3-dev libspdlog-dev libfmt-dev nlohmann-json3-dev \
+            libgtest-dev libgmock-dev libbenchmark-dev
+          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-18 100
+
+      - name: Configure
+        working-directory: projects/rocpdsna
+        env:
+          CC: gcc
+          CXX: g++
+        run: |
+          cmake --version
+          clang-tidy --version | head -2
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DROCPDSNA_BUILD_TESTS=OFF \
+            -DROCPDSNA_BUILD_BENCHMARKS=OFF
+
+      - name: Build
+        working-directory: projects/rocpdsna
+        run: cmake --build build --parallel $(nproc)
+
+      - name: Run clang-tidy
+        working-directory: projects/rocpdsna
+        run: |
+          set -o pipefail
+          cmake --build build --target clang-tidy 2>&1 | tee clang-tidy.log
+          WARNINGS=$(grep -cE 'warning:' clang-tidy.log || true)
+          ERRORS=$(grep -cE 'error:' clang-tidy.log || true)
+          {
+            echo "## clang-tidy summary"
+            echo ""
+            echo "| Severity | Count |"
+            echo "|----------|-------|"
+            echo "| Errors   | ${ERRORS} |"
+            echo "| Warnings | ${WARNINGS} |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+          echo "Errors: ${ERRORS}, Warnings: ${WARNINGS}"
+
+      - name: Upload clang-tidy log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: clang-tidy-log
+          path: projects/rocpdsna/clang-tidy.log
+          if-no-files-found: warn

--- a/.github/workflows/rocpdsna-static-analysis.yml
+++ b/.github/workflows/rocpdsna-static-analysis.yml
@@ -14,6 +14,9 @@ on:
       - '!projects/rocpdsna/docs/**'
       - '!projects/rocpdsna/README.md'
   pull_request:
+    branches:
+      - develop
+      - sna-develop
     paths:
       - '.github/workflows/rocpdsna-static-analysis.yml'
       - 'projects/rocpdsna/**'


### PR DESCRIPTION
## Motivation

Add automated clang-tidy static analysis to the rocpdsna CI so that every PR against `sna-develop` (and eventually `develop`) gets visibility into newly introduced lint issues. Third in the planned CI/CD PR series for rocpdsna; follows the formatting (#5313) and build-test (#5314) workflows.

## Technical Details

Adds `.github/workflows/rocpdsna-static-analysis.yml` with a single `clang-tidy` job on `ubuntu-24.04`:

1. Sparse checkout of `projects/rocpdsna/` + `.github/workflows/`
2. Install deps via apt (cmake, gcc, clang-tidy-18, sqlite/spdlog/fmt/json/gtest/gmock/benchmark dev pkgs)
3. Configure with `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`, `BUILD_TESTS=OFF`, `BUILD_BENCHMARKS=OFF` (neither needed for analysis; saves build time)
4. Build the library to populate `compile_commands.json` and any generated headers
5. Run the project's existing `clang-tidy` CMake target which invokes `clang-tidy --config-file=.clang-tidy` against the globbed source/ and include/ files
6. Tee output to `clang-tidy.log`, count warnings/errors, write summary to `GITHUB_STEP_SUMMARY`
7. Upload `clang-tidy.log` as artifact

Reuses the existing in-project clang-tidy target (`projects/rocpdsna/CMakeLists.txt:362`) instead of inventing a new invocation, so CI matches what developers run locally with `cmake --build build --target clang-tidy`.

Failure model:
- Warnings do NOT fail the job. The project's `.clang-tidy` has `WarningsAsErrors: ''`. Without this CI would block on the ~116 existing warnings; visibility-only is the right Tier 1 stance.
- Errors DO fail the job (clang-tidy exits non-zero).
- Step summary always shows warning/error counts; full log uploaded as artifact.

A future PR can tighten this by setting `WarningsAsErrors` for specific check categories once the existing warnings are addressed.

Workflow conventions match the rest of the rocpdsna CI series:
- Triggers on `pull_request` (any target) plus `push` to `develop` and `sna-develop`
- Path filters scope to `projects/rocpdsna/**` (excluding `build/`, `docs/`, top-level `README.md`)
- Concurrency cancellation enabled
- Read-only permissions
- 20-minute job timeout

## JIRA ID

N/A

## Test Plan

- Local configure with `CMAKE_EXPORT_COMPILE_COMMANDS=ON`
- Local full build (Release, BUILD_TESTS=OFF)
- Local invocation of the `clang-tidy` cmake target with the project's `.clang-tidy` config
- Wall-clock timing with `time cmake --build build --target clang-tidy`
- YAML syntax validation with `python3 -c "import yaml; yaml.safe_load(...)"`
- First CI run on this PR exercises the full job end-to-end

## Test Result

- Local clang-tidy run: 116 warnings, 0 errors, target exits 0
- Wall-clock: 3 min 26 s (single-threaded clang-tidy invocation; well within the 20 min timeout)
- All warnings come from existing code; this PR introduces no new code under analysis
- YAML parse: OK
- CI run on this PR: pending — will update once first run completes

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.