### PR TITLE
[sna] add sanitizer CI workflow (ASan+UBSan, TSan)

### DIFF
--- a/.github/workflows/rocpdsna-sanitizers.yml
+++ b/.github/workflows/rocpdsna-sanitizers.yml
@@ -1,0 +1,101 @@
+name: rocpdsna Sanitizers
+run-name: rocpdsna-sanitizers
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+      - sna-develop
+    paths:
+      - '.github/workflows/rocpdsna-sanitizers.yml'
+      - 'projects/rocpdsna/**'
+      - '!projects/rocpdsna/build/**'
+      - '!projects/rocpdsna/docs/**'
+      - '!projects/rocpdsna/README.md'
+  pull_request:
+    paths:
+      - '.github/workflows/rocpdsna-sanitizers.yml'
+      - 'projects/rocpdsna/**'
+      - '!projects/rocpdsna/build/**'
+      - '!projects/rocpdsna/docs/**'
+      - '!projects/rocpdsna/README.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  sanitizer:
+    name: ${{ matrix.sanitizer.name }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer:
+          - name: asan-ubsan
+            cflags: '-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all'
+            ldflags: '-fsanitize=address,undefined'
+            test_wrap: ''
+            runtime_env: 'ASAN_OPTIONS=detect_leaks=1:abort_on_error=0:halt_on_error=1 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1'
+          - name: tsan
+            cflags: '-fsanitize=thread -fno-omit-frame-pointer'
+            ldflags: '-fsanitize=thread'
+            test_wrap: 'setarch $(uname -m) -R'
+            runtime_env: 'TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1'
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            projects/rocpdsna
+            .github/workflows
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake \
+            gcc g++ \
+            libsqlite3-dev libspdlog-dev libfmt-dev nlohmann-json3-dev \
+            libgtest-dev libgmock-dev libbenchmark-dev util-linux
+
+      - name: Configure
+        working-directory: projects/rocpdsna
+        env:
+          CC: gcc
+          CXX: g++
+        run: |
+          cmake --version
+          ${CXX} --version
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DROCPDSNA_BUILD_TESTS=ON \
+            -DROCPDSNA_BUILD_BENCHMARKS=OFF \
+            -DCMAKE_C_FLAGS="${{ matrix.sanitizer.cflags }}" \
+            -DCMAKE_CXX_FLAGS="${{ matrix.sanitizer.cflags }}" \
+            -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.sanitizer.ldflags }}" \
+            -DCMAKE_SHARED_LINKER_FLAGS="${{ matrix.sanitizer.ldflags }}"
+
+      - name: Build
+        working-directory: projects/rocpdsna
+        run: cmake --build build --parallel $(nproc)
+
+      - name: Test
+        working-directory: projects/rocpdsna/build
+        run: |
+          env ${{ matrix.sanitizer.runtime_env }} \
+            ${{ matrix.sanitizer.test_wrap }} \
+            ctest --output-on-failure --output-junit test-results.xml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sanitizer-results-${{ matrix.sanitizer.name }}
+          path: projects/rocpdsna/build/test-results.xml
+          if-no-files-found: warn

--- a/.github/workflows/rocpdsna-sanitizers.yml
+++ b/.github/workflows/rocpdsna-sanitizers.yml
@@ -14,6 +14,9 @@ on:
       - '!projects/rocpdsna/docs/**'
       - '!projects/rocpdsna/README.md'
   pull_request:
+    branches:
+      - develop
+      - sna-develop
     paths:
       - '.github/workflows/rocpdsna-sanitizers.yml'
       - 'projects/rocpdsna/**'
@@ -33,20 +36,25 @@ jobs:
     name: ${{ matrix.sanitizer.name }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    env:
+      SUPPRESSIONS_DIR: ${{ github.workspace }}/projects/rocpdsna/.sanitizer-suppressions
     strategy:
       fail-fast: false
       matrix:
         sanitizer:
+          # ASan/UBSan run at -O0 (Debug default); stack traces are usable as-is.
+          # Note: detect_leaks=1 + halt_on_error=1 means a leaking but otherwise-passing
+          # test will still fail the job. Leaks are reported at process exit.
           - name: asan-ubsan
             cflags: '-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all'
             ldflags: '-fsanitize=address,undefined'
             test_wrap: ''
-            runtime_env: 'ASAN_OPTIONS=detect_leaks=1:abort_on_error=0:halt_on_error=1 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1'
+          # TSan runs at -O1: at -O0 the compiler does not reorder enough to expose
+          # races that production builds will hit. -O1 keeps stack traces readable.
           - name: tsan
-            cflags: '-fsanitize=thread -fno-omit-frame-pointer'
+            cflags: '-fsanitize=thread -fno-omit-frame-pointer -O1'
             ldflags: '-fsanitize=thread'
             test_wrap: 'setarch $(uname -m) -R'
-            runtime_env: 'TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1'
 
     steps:
       - uses: actions/checkout@v6
@@ -55,14 +63,30 @@ jobs:
             projects/rocpdsna
             .github/workflows
 
+      # cmake, gcc/g++, util-linux are preinstalled on ubuntu-24.04 runners.
+      # The sqlite3/spdlog/fmt/nlohmann_json system packages are intentionally
+      # omitted: the project's cmake/{sqlite3,spdlog,nlohmann_json}.cmake fall
+      # back to FetchContent when find_package fails, so deps build with the
+      # sanitizer flags applied. System libs built without -fsanitize would
+      # produce false-positive reports.
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            cmake \
-            gcc g++ \
-            libsqlite3-dev libspdlog-dev libfmt-dev nlohmann-json3-dev \
-            libgtest-dev libgmock-dev libbenchmark-dev util-linux
+          sudo apt-get install -y libgtest-dev libgmock-dev libbenchmark-dev
+
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ matrix.sanitizer.name }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ matrix.sanitizer.name }}-
+
+      - name: Setup ccache
+        run: |
+          sudo apt-get install -y ccache
+          ccache --max-size=1G
+          ccache --zero-stats
 
       - name: Configure
         working-directory: projects/rocpdsna
@@ -76,6 +100,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug \
             -DROCPDSNA_BUILD_TESTS=ON \
             -DROCPDSNA_BUILD_BENCHMARKS=OFF \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_C_FLAGS="${{ matrix.sanitizer.cflags }}" \
             -DCMAKE_CXX_FLAGS="${{ matrix.sanitizer.cflags }}" \
             -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.sanitizer.ldflags }}" \
@@ -85,12 +111,24 @@ jobs:
         working-directory: projects/rocpdsna
         run: cmake --build build --parallel $(nproc)
 
-      - name: Test
+      - name: ccache stats
+        run: ccache --show-stats
+
+      - name: Test (ASan + UBSan)
+        if: matrix.sanitizer.name == 'asan-ubsan'
         working-directory: projects/rocpdsna/build
-        run: |
-          env ${{ matrix.sanitizer.runtime_env }} \
-            ${{ matrix.sanitizer.test_wrap }} \
-            ctest --output-on-failure --output-junit test-results.xml
+        env:
+          ASAN_OPTIONS: 'detect_leaks=1:abort_on_error=0:halt_on_error=1:print_summary=1:suppressions=${{ env.SUPPRESSIONS_DIR }}/asan.supp'
+          LSAN_OPTIONS: 'suppressions=${{ env.SUPPRESSIONS_DIR }}/lsan.supp'
+          UBSAN_OPTIONS: 'print_stacktrace=1:halt_on_error=1:print_summary=1:suppressions=${{ env.SUPPRESSIONS_DIR }}/ubsan.supp'
+        run: ctest --output-on-failure --output-junit test-results.xml
+
+      - name: Test (TSan)
+        if: matrix.sanitizer.name == 'tsan'
+        working-directory: projects/rocpdsna/build
+        env:
+          TSAN_OPTIONS: 'halt_on_error=1:second_deadlock_stack=1:print_summary=1:suppressions=${{ env.SUPPRESSIONS_DIR }}/tsan.supp'
+        run: ${{ matrix.sanitizer.test_wrap }} ctest --output-on-failure --output-junit test-results.xml
 
       - name: Upload test results
         if: always()

--- a/projects/rocpdsna/.sanitizer-suppressions/asan.supp
+++ b/projects/rocpdsna/.sanitizer-suppressions/asan.supp
@@ -1,0 +1,3 @@
+# ASan suppressions for rocpdsna.
+# Format: interceptor_via_lib:<libname>  /  interceptor_name:<func>
+# See https://github.com/google/sanitizers/wiki/AddressSanitizer

--- a/projects/rocpdsna/.sanitizer-suppressions/lsan.supp
+++ b/projects/rocpdsna/.sanitizer-suppressions/lsan.supp
@@ -1,0 +1,3 @@
+# LSan suppressions for rocpdsna (paired with ASan).
+# Format: leak:<symbol-or-lib>
+# See https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer

--- a/projects/rocpdsna/.sanitizer-suppressions/tsan.supp
+++ b/projects/rocpdsna/.sanitizer-suppressions/tsan.supp
@@ -1,0 +1,3 @@
+# TSan suppressions for rocpdsna.
+# Format: race:<symbol-or-file>  /  deadlock:<symbol>  /  thread:<symbol>
+# See https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions

--- a/projects/rocpdsna/.sanitizer-suppressions/ubsan.supp
+++ b/projects/rocpdsna/.sanitizer-suppressions/ubsan.supp
@@ -1,0 +1,3 @@
+# UBSan suppressions for rocpdsna.
+# Format: <category>:<symbol-or-file>  (e.g. signed-integer-overflow:foo)
+# See https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#suppressing-errors-in-recompiled-code-blacklist


### PR DESCRIPTION
## Motivation

Add runtime memory and threading sanitizers to the rocpdsna CI so that every PR against `sna-develop` (and eventually `develop`) catches use-after-free, buffer overflows, undefined behavior, data races, and deadlocks before they reach `develop`. Fourth in the planned CI/CD PR series for rocpdsna; follows formatting (#5313), build-test (#5314), and static-analysis (#5316).

## Technical Details

Adds `.github/workflows/rocpdsna-sanitizers.yml` with a single `sanitizer` job fanned out across a 2-entry matrix on `ubuntu-24.04` (Debug builds, gcc):

| Matrix entry | Compile flags | Link flags | Test wrap | Runtime env |
|--------------|---------------|------------|-----------|-------------|
| `asan-ubsan` | `-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all` | `-fsanitize=address,undefined` | _(none)_ | `ASAN_OPTIONS=detect_leaks=1:abort_on_error=0:halt_on_error=1` + `UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1` |
| `tsan` | `-fsanitize=thread -fno-omit-frame-pointer` | `-fsanitize=thread` | `setarch $(uname -m) -R` | `TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1` |

Per matrix entry:
1. Sparse checkout of `projects/rocpdsna/` + `.github/workflows/`
2. Install deps via apt (cmake, gcc, sqlite/spdlog/fmt/json/gtest/gmock/benchmark dev pkgs, `util-linux` for `setarch`)
3. Configure with Debug build type, the matrix-supplied sanitizer flags applied via `CMAKE_C_FLAGS` / `CMAKE_CXX_FLAGS` / `CMAKE_EXE_LINKER_FLAGS` / `CMAKE_SHARED_LINKER_FLAGS`
4. Build the library + unit tests with `cmake --build build --parallel $(nproc)`
5. Run `ctest --output-on-failure --output-junit test-results.xml` under the runtime env vars (and wrapped in `setarch -R` for TSan)
6. Upload JUnit results as an artifact named per sanitizer

Why `setarch -R` for TSan: modern kernel ASLR creates memory mappings that fall outside what TSan's interceptor expects, producing `FATAL: ThreadSanitizer: unexpected memory mapping` on test startup. `setarch -R` (`--addr-no-randomize`) disables randomization for the ctest process and its children, which is the standard workaround. ASan is unaffected.

`fail-fast: false` so both sanitizer jobs run independently and surface their own findings.

Workflow conventions match the rest of the rocpdsna CI series:
- Triggers on `pull_request` (any target) plus `push` to `develop` and `sna-develop`
- Path filters scope to `projects/rocpdsna/**` (excluding `build/`, `docs/`, top-level `README.md`)
- Concurrency cancellation enabled
- Sparse checkout in every job
- Read-only permissions
- 30-minute job timeout

## JIRA ID

N/A

## Test Plan

- Local Debug build with ASan+UBSan flags
- Local Debug build with TSan flags
- Run full ctest suite under each sanitizer
- Verify TSan startup issue is resolved by `setarch -R`
- YAML syntax validation
- First CI run on this PR exercises both matrix entries end-to-end

## Test Result

- ASan+UBSan (gcc 13.3.0, Ubuntu 24.04): 240/240 tests pass in 8.66s, no sanitizer reports
- TSan + `setarch -R` (gcc 13.3.0, Ubuntu 24.04): 240/240 tests pass in 9.68s, no sanitizer reports
- Without `setarch -R` TSan reproducibly aborts with "unexpected memory mapping" on startup
- YAML parse: OK, matrix expands to 2 entries: asan-ubsan, tsan
- CI run on this PR: pending — will update once first run completes

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.