### PR TITLE
[sna] add code coverage workflow and README badges

### DIFF
--- a/.github/workflows/rocpdsna-coverage.yml
+++ b/.github/workflows/rocpdsna-coverage.yml
@@ -1,0 +1,102 @@
+name: rocpdsna Coverage
+run-name: rocpdsna-coverage
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+      - sna-develop
+    paths:
+      - '.github/workflows/rocpdsna-coverage.yml'
+      - 'projects/rocpdsna/**'
+      - '!projects/rocpdsna/build/**'
+      - '!projects/rocpdsna/docs/**'
+      - '!projects/rocpdsna/README.md'
+  pull_request:
+    paths:
+      - '.github/workflows/rocpdsna-coverage.yml'
+      - 'projects/rocpdsna/**'
+      - '!projects/rocpdsna/build/**'
+      - '!projects/rocpdsna/docs/**'
+      - '!projects/rocpdsna/README.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    name: coverage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      CC: gcc
+      CXX: g++
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            projects/rocpdsna
+            .github/workflows
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake \
+            gcc g++ \
+            lcov gcovr \
+            libsqlite3-dev libspdlog-dev libfmt-dev nlohmann-json3-dev \
+            libgtest-dev libgmock-dev libbenchmark-dev
+
+      - name: Configure
+        working-directory: projects/rocpdsna
+        run: |
+          cmake --version
+          gcovr --version | head -1
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DROCPDSNA_ENABLE_COVERAGE=ON \
+            -DROCPDSNA_BUILD_TESTS=ON \
+            -DROCPDSNA_BUILD_BENCHMARKS=OFF
+
+      - name: Build
+        working-directory: projects/rocpdsna
+        run: cmake --build build --parallel $(nproc)
+
+      - name: Generate Cobertura coverage report
+        working-directory: projects/rocpdsna
+        run: |
+          set -o pipefail
+          cmake --build build --target coverage-xml 2>&1 | tee coverage.log
+          test -f build/coverage/coverage.xml
+
+      - name: Summarize coverage
+        working-directory: projects/rocpdsna
+        run: |
+          LINES=$(grep -oE 'lines: [0-9.]+%' coverage.log | tail -1 || echo "lines: n/a")
+          FUNCS=$(grep -oE 'functions: [0-9.]+%' coverage.log | tail -1 || echo "functions: n/a")
+          BRANCHES=$(grep -oE 'branches: [0-9.]+%' coverage.log | tail -1 || echo "branches: n/a")
+          {
+            echo "## Coverage summary"
+            echo ""
+            echo "| Metric | Value |"
+            echo "|--------|-------|"
+            echo "| ${LINES%:*} | ${LINES#*: } |"
+            echo "| ${FUNCS%:*} | ${FUNCS#*: } |"
+            echo "| ${BRANCHES%:*} | ${BRANCHES#*: } |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+          echo "${LINES} | ${FUNCS} | ${BRANCHES}"
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-xml
+          path: projects/rocpdsna/build/coverage/coverage.xml
+          if-no-files-found: warn

--- a/projects/rocpdsna/README.md
+++ b/projects/rocpdsna/README.md
@@ -1,5 +1,11 @@
 # rocpdsna
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Build & Test](https://github.com/ROCm/rocm-systems/actions/workflows/rocpdsna-ci.yml/badge.svg?branch=sna-develop)](https://github.com/ROCm/rocm-systems/actions/workflows/rocpdsna-ci.yml?query=branch%3Asna-develop)
+[![Sanitizers](https://github.com/ROCm/rocm-systems/actions/workflows/rocpdsna-sanitizers.yml/badge.svg?branch=sna-develop)](https://github.com/ROCm/rocm-systems/actions/workflows/rocpdsna-sanitizers.yml?query=branch%3Asna-develop)
+[![Static Analysis](https://github.com/ROCm/rocm-systems/actions/workflows/rocpdsna-static-analysis.yml/badge.svg?branch=sna-develop)](https://github.com/ROCm/rocm-systems/actions/workflows/rocpdsna-static-analysis.yml?query=branch%3Asna-develop)
+[![Coverage](https://github.com/ROCm/rocm-systems/actions/workflows/rocpdsna-coverage.yml/badge.svg?branch=sna-develop)](https://github.com/ROCm/rocm-systems/actions/workflows/rocpdsna-coverage.yml?query=branch%3Asna-develop)
+
 A C++ library for storing and retrieving ROCm profiling data using SQLite (rocpd database format).
 
 ## Overview
@@ -49,6 +55,7 @@ cmake --build build -j$(nproc)
 | `ROCPDSNA_BUILD_TESTS` | ON | Build unit tests |
 | `ROCPDSNA_BUILD_BENCHMARKS` | ON | Build performance benchmarks |
 | `ROCPDSNA_ENABLE_LOGGING` | OFF | Enable debug logging |
+| `ROCPDSNA_ENABLE_COVERAGE` | OFF | Enable code coverage instrumentation (requires Debug build, gcov, and lcov or gcovr) |
 
 ## Installation
 


### PR DESCRIPTION
## Motivation

Add automated code coverage reporting to the rocpdsna CI so that every PR against `sna-develop` (and eventually `develop`) produces a Cobertura coverage report and surfaces line/function/branch coverage percentages in the workflow summary. Also add status badges to the README so contributors and consumers can see CI health at a glance, matching the convention used by other projects in this monorepo (e.g. hipFile, RCCL). Fifth in the planned CI/CD PR series for rocpdsna; follows formatting (#5313), build-test (#5314), static-analysis (#5316), and sanitizers (#5318).

## Technical Details

### Workflow (`.github/workflows/rocpdsna-coverage.yml`)

Single `coverage` job on `ubuntu-24.04` with gcc:

1. Sparse checkout of `projects/rocpdsna/` + `.github/workflows/`
2. Install deps via apt (cmake, gcc, lcov, gcovr, sqlite/spdlog/fmt/json/gtest/gmock/benchmark dev pkgs)
3. Configure with `-DCMAKE_BUILD_TYPE=Debug -DROCPDSNA_ENABLE_COVERAGE=ON -DROCPDSNA_BUILD_TESTS=ON -DROCPDSNA_BUILD_BENCHMARKS=OFF`
4. Build the library + unit tests
5. Run the project's `coverage-xml` CMake target (`projects/rocpdsna/cmake/coverage.cmake`) which executes the unit tests and emits a Cobertura-format `coverage.xml` via gcovr (excluding `/usr/*`, `_deps/*`, `tests/*`)
6. Parse the gcovr summary (lines/functions/branches %) and write a markdown table to `GITHUB_STEP_SUMMARY`
7. Upload `coverage.xml` as a workflow artifact

Reuses the project's existing coverage CMake support rather than reinventing it, so CI matches what developers run locally with `cmake --build build --target coverage-xml`.

### README badges (`projects/rocpdsna/README.md`)

Adds five status badges at the top of the README, modeled on the hipFile README pattern:

| Badge | Source |
|-------|--------|
| License: MIT | shields.io static badge |
| Build & Test | `rocpdsna-ci.yml` GitHub Actions badge |
| Sanitizers | `rocpdsna-sanitizers.yml` GitHub Actions badge |
| Static Analysis | `rocpdsna-static-analysis.yml` GitHub Actions badge |
| Coverage | `rocpdsna-coverage.yml` GitHub Actions badge |

All workflow badges are pinned to `?branch=sna-develop` for the duration that SNA work lives on the `sna-develop` long-lived branch. They should be updated to `?branch=develop` once the SNA project merges into `develop`. (Formatting workflow intentionally omitted from the README badge row to keep the header concise — full status remains visible in the Actions tab.)

Also documents the new `ROCPDSNA_ENABLE_COVERAGE` build option in the existing build-options table.

### What's NOT in this PR

- Codecov / coveralls integration (would surface a coverage-percentage badge instead of a pass/fail badge). Requires external service setup. Can be added in a follow-up.
- Coverage threshold gating (fail the build if coverage drops below a floor or by a delta). The current workflow is visibility-only. Worth adding once a baseline is locked in.

Workflow conventions match the rest of the rocpdsna CI series:
- Triggers on `pull_request` (any target) plus `push` to `develop` and `sna-develop`
- Path filters scope to `projects/rocpdsna/**` (excluding `build/`, `docs/`, top-level `README.md`)
- Concurrency cancellation enabled
- Sparse checkout
- Read-only permissions
- 30-minute job timeout

## JIRA ID

N/A

## Test Plan

- Local Debug build with `ROCPDSNA_ENABLE_COVERAGE=ON`
- Local invocation of the `coverage-xml` cmake target (which runs the full ctest suite under instrumentation and produces `build/coverage/coverage.xml`)
- Verify `coverage.xml` is non-empty Cobertura format
- YAML syntax validation
- Manual rendering of the badge URLs in a markdown preview to confirm they resolve
- First CI run on this PR exercises the full job end-to-end

## Test Result

- Coverage run on Ubuntu 24.04 / gcc 13.3.0: 240/240 tests pass under instrumentation in 2.97 s
- gcovr summary:
  - lines: 92.0% (2502 / 2721)
  - functions: 98.1% (774 / 789)
  - branches: 52.7% (1900 / 3608)
- `coverage.xml` produced (~266 KB, valid Cobertura)
- YAML parse: OK
- CI run on this PR: pending — will update once first run completes

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.