### PR TITLE
[sna] install public headers and add find_package CI

### DIFF
--- a/.github/workflows/rocpdsna-install.yml
+++ b/.github/workflows/rocpdsna-install.yml
@@ -1,0 +1,107 @@
+name: rocpdsna Install
+run-name: rocpdsna-install
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+      - sna-develop
+    paths:
+      - '.github/workflows/rocpdsna-install.yml'
+      - 'projects/rocpdsna/**'
+      - '!projects/rocpdsna/build/**'
+      - '!projects/rocpdsna/docs/**'
+      - '!projects/rocpdsna/README.md'
+  pull_request:
+    paths:
+      - '.github/workflows/rocpdsna-install.yml'
+      - 'projects/rocpdsna/**'
+      - '!projects/rocpdsna/build/**'
+      - '!projects/rocpdsna/docs/**'
+      - '!projects/rocpdsna/README.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  install-and-consume:
+    name: ${{ matrix.os }} / install + find_package
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+    env:
+      CC: gcc
+      CXX: g++
+      INSTALL_PREFIX: ${{ github.workspace }}/rocpdsna-install
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            projects/rocpdsna
+            .github/workflows
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake \
+            gcc g++ \
+            libsqlite3-dev libspdlog-dev libfmt-dev nlohmann-json3-dev
+
+      - name: Configure rocpdsna
+        working-directory: projects/rocpdsna
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
+            -DROCPDSNA_BUILD_TESTS=OFF \
+            -DROCPDSNA_BUILD_BENCHMARKS=OFF
+
+      - name: Build rocpdsna
+        working-directory: projects/rocpdsna
+        run: cmake --build build --parallel $(nproc)
+
+      - name: Install rocpdsna
+        working-directory: projects/rocpdsna
+        run: cmake --install build
+
+      - name: Verify install layout
+        run: |
+          set -e
+          test -f ${INSTALL_PREFIX}/lib/librocpdsna.so       || { echo "::error::librocpdsna.so missing"; exit 1; }
+          test -f ${INSTALL_PREFIX}/lib/librocpdsna.a        || { echo "::error::librocpdsna.a missing";  exit 1; }
+          test -d ${INSTALL_PREFIX}/include/rocpdsna         || { echo "::error::include/rocpdsna missing"; exit 1; }
+          test -f ${INSTALL_PREFIX}/include/rocpdsna/writer.hpp  || { echo "::error::writer.hpp missing"; exit 1; }
+          test -f ${INSTALL_PREFIX}/include/rocpdsna/reader.hpp  || { echo "::error::reader.hpp missing"; exit 1; }
+          test -f ${INSTALL_PREFIX}/include/rocpdsna/storage.hpp || { echo "::error::storage.hpp missing"; exit 1; }
+          test -f ${INSTALL_PREFIX}/lib/cmake/rocpdsna/rocpdsna-config.cmake         || { echo "::error::rocpdsna-config.cmake missing"; exit 1; }
+          test -f ${INSTALL_PREFIX}/lib/cmake/rocpdsna/rocpdsna-config-version.cmake || { echo "::error::rocpdsna-config-version.cmake missing"; exit 1; }
+          test -f ${INSTALL_PREFIX}/lib/cmake/rocpdsna/rocpdsna-targets.cmake        || { echo "::error::rocpdsna-targets.cmake missing"; exit 1; }
+          test -f ${INSTALL_PREFIX}/lib/cmake/rocpdsna/Findrocpdsna.cmake            || { echo "::error::Findrocpdsna.cmake missing"; exit 1; }
+          echo "Install layout OK:"
+          find ${INSTALL_PREFIX} -type f | sort
+
+      - name: Configure consumer (find_package)
+        run: |
+          cmake \
+            -S projects/rocpdsna/tests/find_package \
+            -B consumer-build \
+            -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX}
+
+      - name: Build consumer
+        run: cmake --build consumer-build --parallel $(nproc)
+
+      - name: Run consumer smoke test
+        working-directory: consumer-build
+        env:
+          LD_LIBRARY_PATH: ${{ github.workspace }}/rocpdsna-install/lib
+        run: ctest --output-on-failure

--- a/.github/workflows/rocpdsna-install.yml
+++ b/.github/workflows/rocpdsna-install.yml
@@ -103,5 +103,5 @@ jobs:
       - name: Run consumer smoke test
         working-directory: consumer-build
         env:
-          LD_LIBRARY_PATH: ${{ github.workspace }}/rocpdsna-install/lib
+          LD_LIBRARY_PATH: ${{ env.INSTALL_PREFIX }}/lib
         run: ctest --output-on-failure

--- a/projects/rocpdsna/CMakeLists.txt
+++ b/projects/rocpdsna/CMakeLists.txt
@@ -126,7 +126,9 @@ endforeach()
 
 target_include_directories(
     rocpdsna-objects
-    PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 # ------------------------------------------------------------ #
@@ -270,7 +272,14 @@ install(
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT rocpdsna
+)
+
+install(
+    DIRECTORY ${CMAKE_BINARY_DIR}/include/${PACKAGE_NAME}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    COMPONENT rocpdsna
+    FILES_MATCHING
+    PATTERN "*.hpp"
 )
 
 install(

--- a/projects/rocpdsna/tests/find_package/CMakeLists.txt
+++ b/projects/rocpdsna/tests/find_package/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+cmake_minimum_required(VERSION 3.21)
+project(rocpdsna_find_package_test LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(rocpdsna REQUIRED)
+
+add_executable(rocpdsna_consumer consumer.cpp)
+target_link_libraries(rocpdsna_consumer PRIVATE rocpdsna::rocpdsna)
+
+enable_testing()
+add_test(NAME rocpdsna_consumer_smoke COMMAND rocpdsna_consumer)

--- a/projects/rocpdsna/tests/find_package/consumer.cpp
+++ b/projects/rocpdsna/tests/find_package/consumer.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Downstream consumer smoke test for the installed rocpdsna package.
+// Verifies that:
+//   - public headers are installed under <prefix>/include/rocpdsna/
+//   - find_package(rocpdsna) resolves the rocpdsna::rocpdsna target
+//   - the library links and a public API symbol is reachable at runtime
+
+#include <rocpdsna/storage.hpp>
+
+#include <iostream>
+
+int
+main()
+{
+    try
+    {
+        rocpdsna::storage_t storage{ ":memory:", "rocpdsna-find-package-smoke" };
+        const auto          version = storage.get_storage_version();
+        std::cout << "rocpdsna storage opened. schema version: " << version.major << "."
+                  << version.minor << "." << version.patch << '\n';
+    } catch(const std::exception& e)
+    {
+        std::cerr << "rocpdsna consumer smoke FAILED: " << e.what() << '\n';
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Motivation

Add an end-to-end install + downstream consumer smoke test to the rocpdsna CI so that every PR against `sna-develop` (and eventually `develop`) verifies the package is actually consumable: headers installed, exported targets resolvable via `find_package(rocpdsna)`, runtime linkage works. Sixth in the planned CI/CD PR series for rocpdsna; follows formatting (#5313), build-test (#5314), static-analysis (#5316), sanitizers (#5318), and coverage (#5319).

While wiring up the smoke test it became apparent that the public headers were never being installed — see fix below — so this PR also corrects that.

## Technical Details

### Bug fix: install public headers (commit `b8ad685`)

The prior install rule on the `rocpdsna` target used `PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}` but no `PUBLIC_HEADER` property was ever set on the target. As a result the install produced libs and CMake config files but **no headers**, so a downstream `find_package(rocpdsna)` would resolve the targets correctly and then fail to compile any TU that included a public header.

Fix:
- Drop the dead `PUBLIC_HEADER DESTINATION` line from the targets install
- Add an explicit `install(DIRECTORY ${CMAKE_BINARY_DIR}/include/rocpdsna ... FILES_MATCHING PATTERN "*.hpp")` that mirrors the layout already produced at build time by the existing `configure_file()` loop over `rocpdsna_public_headers`
- Add `$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>` to `target_include_directories(rocpdsna-objects PUBLIC ...)` so exported targets resolve includes from `<prefix>/include` after installation

After the fix, `cmake --install` produces:

```
<prefix>/include/rocpdsna/{reader,reader_types,shared_types,storage,storage_types,writer,writer_types}.hpp
<prefix>/lib/{librocpdsna.so,librocpdsna.a}
<prefix>/lib/cmake/rocpdsna/{rocpdsna-config,rocpdsna-config-version,rocpdsna-targets,rocpdsna-targets-release,Findrocpdsna}.cmake
```

### CI workflow (commit `6f1dd61`)

Adds `.github/workflows/rocpdsna-install.yml` with a single `install-and-consume` job fanned out across `ubuntu-22.04` and `ubuntu-24.04`. Per matrix entry:

1. Sparse checkout of `projects/rocpdsna/` + `.github/workflows/`
2. Install deps via apt (cmake, gcc, sqlite/spdlog/fmt/json dev pkgs — no gtest/gmock/benchmark needed since BUILD_TESTS=OFF)
3. Configure rocpdsna with `-DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/rocpdsna-install`, Release, BUILD_TESTS=OFF, BUILD_BENCHMARKS=OFF
4. Build the library
5. Install to the staging prefix
6. Assert the install layout: `librocpdsna.so`, `librocpdsna.a`, `include/rocpdsna/{writer,reader,storage}.hpp`, all four CMake config files (`rocpdsna-config.cmake`, `rocpdsna-config-version.cmake`, `rocpdsna-targets.cmake`, `Findrocpdsna.cmake`). Exit 1 with `::error::` annotation if any are missing.
7. Configure the consumer test project with `-DCMAKE_PREFIX_PATH=<staging>` so it picks up the staged rocpdsna
8. Build the consumer
9. Run the consumer smoke test via ctest (with `LD_LIBRARY_PATH` set so it finds `librocpdsna.so`)

### Consumer test project (`projects/rocpdsna/tests/find_package/`)

A standalone CMake project that mimics what a real downstream user would write:

- `CMakeLists.txt`: `find_package(rocpdsna REQUIRED)`, builds an executable, links `rocpdsna::rocpdsna`, registers a ctest entry
- `consumer.cpp`: instantiates `rocpdsna::storage_t{":memory:", "..."}` and prints the schema version. Catches exceptions and exits 1 on failure. Confirms (a) public headers are reachable, (b) the exported namespaced target links, and (c) library symbols are reachable at runtime.

The test project is intentionally separate from the main rocpdsna build (its own `cmake -S ... -B ...`) — that is the whole point of the smoke test.

Workflow conventions match the rest of the rocpdsna CI series:
- Triggers on `pull_request` (any target) plus `push` to `develop` and `sna-develop`
- Path filters scope to `projects/rocpdsna/**` (excluding `build/`, `docs/`, top-level `README.md`)
- Concurrency cancellation enabled
- Sparse checkout
- Read-only permissions
- 20-minute job timeout

## JIRA ID

N/A

## Test Plan

- Local install with the fix to a staging prefix on Ubuntu 24.04 / gcc 13.3.0
- Confirm install layout includes headers, libs, and all CMake config files
- Local consumer configure with `find_package(rocpdsna)`
- Local consumer build + ctest run
- YAML syntax validation
- First CI run on this PR exercises both matrix entries end to end

## Test Result

- Install layout (after fix): all expected files present, including 7 headers under `include/rocpdsna/`
- Consumer configure: `Found rocpdsna: <prefix>/include`, exported `rocpdsna::rocpdsna` target resolves
- Consumer build: clean
- Consumer ctest: 1/1 pass — output `rocpdsna storage opened. schema version: 0.1.0`
- YAML parse: OK
- CI run on this PR: pending — will update once first run completes

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.