### PR TITLE
[rocshmem] convert some classes to use allocator as constructor argument

### DIFF
--- a/projects/rocshmem/src/containers/atomic_wf_queue.hpp
+++ b/projects/rocshmem/src/containers/atomic_wf_queue.hpp
@@ -40,7 +40,7 @@ namespace rocshmem {
 template <typename TYPE, typename ALLOCATOR = HIPDefaultFinegrainedAllocator>
 class AtomicWFQueue {
 
-  using MutexProxyType = ABQLBlockMutexProxy<ALLOCATOR>;
+  using MutexProxyType = ABQLBlockMutexProxy;
   using MutexType = ABQLBlockMutex;
 
   /**

--- a/projects/rocshmem/src/containers/atomic_wf_queue.hpp
+++ b/projects/rocshmem/src/containers/atomic_wf_queue.hpp
@@ -37,7 +37,7 @@ namespace rocshmem {
  ******************************* WAVE FREE LIST ******************************
  *****************************************************************************/
 
-template <typename TYPE, typename ALLOCATOR = HIPDefaultFinegrainedAllocator>
+template <typename TYPE>
 class AtomicWFQueue {
 
   using MutexProxyType = ABQLBlockMutexProxy;
@@ -92,7 +92,7 @@ class AtomicWFQueue {
    * @param allocator Allocator to use for allocating internal structures of the
    * AtomicWFQueue.
    */
-  explicit AtomicWFQueue(const ALLOCATOR& allocator = ALLOCATOR());
+  explicit AtomicWFQueue(const MemoryAllocator& allocator = *get_default_allocator());
 
   /**
    * @brief Destroy the AtomicWFQueue object
@@ -288,7 +288,7 @@ class AtomicWFQueue {
    * @brief Internal memory allocator used to create internal structures of
    * the AtomicWFQueue.
    */
-  ALLOCATOR allocator_{};
+  MemoryAllocator allocator_{};
 
   /**
    * @brief Points to the index of first element in the AtomicWFQueue.
@@ -326,16 +326,18 @@ class AtomicWFQueue {
   MutexProxyType enqueue_mutex_;
 };
 
-template <typename ALLOCATOR, typename TYPE>
+template <typename TYPE>
 class AtomicWFQueueProxy {
-  using AtomicWFQueueT = AtomicWFQueue<TYPE, ALLOCATOR>;
-  using ProxyT = DeviceProxy<ALLOCATOR, AtomicWFQueueT>;
+  using AtomicWFQueueT = AtomicWFQueue<TYPE>;
+  using ProxyT = DeviceProxy<HIPAllocator, AtomicWFQueueT>;
 
  public:
   __host__ __device__ AtomicWFQueueT* get() { return proxy_.get(); }
 
-  AtomicWFQueueProxy(size_t num_elems = 1) : proxy_{num_elems} {
-    new (proxy_.get()) AtomicWFQueueT();
+  explicit AtomicWFQueueProxy(const MemoryAllocator& alloc = HIPAllocator(),
+                              size_t num_elems = 1)
+      : allocator_{alloc}, proxy_{num_elems} {
+    new (proxy_.get()) AtomicWFQueueT(allocator_);
   }
 
   AtomicWFQueueProxy(const AtomicWFQueueProxy& other) = delete;
@@ -353,6 +355,7 @@ class AtomicWFQueueProxy {
   }
 
  private:
+  MemoryAllocator allocator_{};
   ProxyT proxy_{};
 };
 }  // namespace rocshmem

--- a/projects/rocshmem/src/containers/atomic_wf_queue_impl.hpp
+++ b/projects/rocshmem/src/containers/atomic_wf_queue_impl.hpp
@@ -34,11 +34,11 @@ namespace rocshmem {
  ******************************* WAVE FREE LIST ******************************
  *****************************************************************************/
 
-template <typename TYPE, typename ALLOCATOR>
-AtomicWFQueue<TYPE, ALLOCATOR>::~AtomicWFQueue() {}
+template <typename TYPE>
+AtomicWFQueue<TYPE>::~AtomicWFQueue() {}
 
-template <typename TYPE, typename ALLOCATOR>
-__host__ void AtomicWFQueue<TYPE, ALLOCATOR>::deallocate_queue() {
+template <typename TYPE>
+__host__ void AtomicWFQueue<TYPE>::deallocate_queue() {
   if (queue_ != nullptr) {
     allocator_.deallocate((void*)queue_);
     queue_ = nullptr;
@@ -49,12 +49,13 @@ __host__ void AtomicWFQueue<TYPE, ALLOCATOR>::deallocate_queue() {
   tail_ = 0;
 }
 
-template <typename TYPE, typename ALLOCATOR>
-AtomicWFQueue<TYPE, ALLOCATOR>::AtomicWFQueue(const ALLOCATOR& allocator)
-    : allocator_{allocator}, head_{0}, tail_{0}, size_{0}, curr_size_{0} {}
+template <typename TYPE>
+AtomicWFQueue<TYPE>::AtomicWFQueue(const MemoryAllocator& allocator)
+    : allocator_{allocator}, head_{0}, tail_{0}, size_{0}, curr_size_{0},
+      dequeue_mutex_{allocator}, enqueue_mutex_{allocator} {}
 
-template <typename TYPE, typename ALLOCATOR>
-__host__ void AtomicWFQueue<TYPE, ALLOCATOR>::allocate_queue(
+template <typename TYPE>
+__host__ void AtomicWFQueue<TYPE>::allocate_queue(
   unsigned int size) {
 
   size_ = size;
@@ -65,8 +66,8 @@ __host__ void AtomicWFQueue<TYPE, ALLOCATOR>::allocate_queue(
                       sizeof(TYPE) * size_);
 }
 
-template <typename TYPE, typename ALLOCATOR>
-__host__ void AtomicWFQueue<TYPE, ALLOCATOR>::push(const TYPE& val) {
+template <typename TYPE>
+__host__ void AtomicWFQueue<TYPE>::push(const TYPE& val) {
   if (curr_size_ < size_) {
     queue_[tail_] = val;
     tail_ = (tail_ + 1) % size_;
@@ -78,9 +79,9 @@ __host__ void AtomicWFQueue<TYPE, ALLOCATOR>::push(const TYPE& val) {
   }
 }
 
-template <typename TYPE, typename ALLOCATOR>
+template <typename TYPE>
 __device__ unsigned int
-AtomicWFQueue<TYPE, ALLOCATOR>::active_logical_lane_id() {
+AtomicWFQueue<TYPE>::active_logical_lane_id() {
   uint64_t ballot{__ballot(1)};
   uint64_t my_physical_lane_id{__lane_id()};
   uint64_t all_ones_mask = -1;
@@ -91,8 +92,8 @@ AtomicWFQueue<TYPE, ALLOCATOR>::active_logical_lane_id() {
   return my_logical_lane_id; 
 }
 
-template <typename TYPE, typename ALLOCATOR>
-__device__ TYPE AtomicWFQueue<TYPE, ALLOCATOR>::broadcast_lds(
+template <typename TYPE>
+__device__ TYPE AtomicWFQueue<TYPE>::broadcast_lds(
   bool lowest_active, TYPE value) {
 
   /**
@@ -110,8 +111,8 @@ __device__ TYPE AtomicWFQueue<TYPE, ALLOCATOR>::broadcast_lds(
   return value_per_warp[wavefront_id];
 }
 
-template <typename TYPE, typename ALLOCATOR>
-__device__ void AtomicWFQueue<TYPE, ALLOCATOR>::enqueue(const TYPE& val) {
+template <typename TYPE>
+__device__ void AtomicWFQueue<TYPE>::enqueue(const TYPE& val) {
   unsigned int my_active_lane_id {active_logical_lane_id()};
   bool is_lowest_active_lane {my_active_lane_id == 0};
   if (is_lowest_active_lane) {
@@ -135,8 +136,8 @@ __device__ void AtomicWFQueue<TYPE, ALLOCATOR>::enqueue(const TYPE& val) {
   }
 }
 
-template <typename TYPE, typename ALLOCATOR>
-__device__ TYPE AtomicWFQueue<TYPE, ALLOCATOR>::dequeue() {
+template <typename TYPE>
+__device__ TYPE AtomicWFQueue<TYPE>::dequeue() {
   TYPE ret_val {TYPE()};
   unsigned int my_active_lane_id {active_logical_lane_id()};
   bool is_lowest_active_lane {my_active_lane_id == 0};

--- a/projects/rocshmem/src/containers/free_list.hpp
+++ b/projects/rocshmem/src/containers/free_list.hpp
@@ -40,11 +40,12 @@ class FreeListProxy;
  ******************************* FREE LIST ***********************************
  *****************************************************************************/
 
-template <typename TYPE, typename ALLOC = HIPDefaultFinegrainedAllocator>
+template <typename TYPE>
 class FreeList {
-  friend class FreeListProxy<ALLOC, TYPE>;
+  template <typename ALLOCATOR, typename T>
+  friend class FreeListProxy;
 
-  using MutexProxyType = ABQLBlockMutexProxy<ALLOC>;
+  using MutexProxyType = ABQLBlockMutexProxy;
   using MutexType = ABQLBlockMutex;
 
   struct Node {
@@ -105,7 +106,7 @@ class FreeList {
    *
    * @param alloc Allocator to use for free list nodes allocations.
    */
-  explicit FreeList(const ALLOC& alloc = ALLOC());
+  explicit FreeList(const MemoryAllocator& alloc = *get_default_allocator());
 
   /**
    * @brief Constructs a FreeList object with contents from a range of elements
@@ -118,7 +119,7 @@ class FreeList {
    * free list.
    */
   template <class InputIt>
-  FreeList(InputIt first, InputIt last, const ALLOC& alloc = ALLOC());
+  FreeList(InputIt first, InputIt last, const MemoryAllocator& alloc = *get_default_allocator());
 
   /**
    * @brief Pushes a range of elements defined by [`first`, `last`).
@@ -258,14 +259,14 @@ class FreeList {
 
 template <typename ALLOCATOR, typename TYPE>
 class FreeListProxy {
-  using FreeListT = FreeList<TYPE, ALLOCATOR>;
+  using FreeListT = FreeList<TYPE>;
   using ProxyT = DeviceProxy<ALLOCATOR, FreeListT>;
 
  public:
   __host__ __device__ FreeListT* get() { return proxy_.get(); }
 
   FreeListProxy(size_t num_elems = 1) : proxy_{num_elems} {
-    new (proxy_.get()) FreeListT();
+    new (proxy_.get()) FreeListT(*get_default_allocator());
   }
 
   FreeListProxy(const FreeListProxy& other) = delete;

--- a/projects/rocshmem/src/containers/free_list.hpp
+++ b/projects/rocshmem/src/containers/free_list.hpp
@@ -33,7 +33,7 @@
 namespace rocshmem {
 
 // Forward declaration of the proxy.
-template <typename ALLOCATOR, typename TYPE>
+template <typename TYPE>
 class FreeListProxy;
 
 /*****************************************************************************
@@ -42,7 +42,7 @@ class FreeListProxy;
 
 template <typename TYPE>
 class FreeList {
-  template <typename ALLOCATOR, typename T>
+  template <typename T>
   friend class FreeListProxy;
 
   using MutexProxyType = ABQLBlockMutexProxy;
@@ -257,16 +257,18 @@ class FreeList {
   MutexProxyType mutex_;
 };
 
-template <typename ALLOCATOR, typename TYPE>
+template <typename TYPE>
 class FreeListProxy {
   using FreeListT = FreeList<TYPE>;
-  using ProxyT = DeviceProxy<ALLOCATOR, FreeListT>;
+  using ProxyT = DeviceProxy<HIPAllocator, FreeListT>;
 
  public:
   __host__ __device__ FreeListT* get() { return proxy_.get(); }
 
-  FreeListProxy(size_t num_elems = 1) : proxy_{num_elems} {
-    new (proxy_.get()) FreeListT(*get_default_allocator());
+  explicit FreeListProxy(const MemoryAllocator& alloc = HIPAllocator(),
+                         size_t num_elems = 1)
+      : allocator_{alloc}, proxy_{num_elems} {
+    new (proxy_.get()) FreeListT(allocator_);
   }
 
   FreeListProxy(const FreeListProxy& other) = delete;
@@ -284,6 +286,7 @@ class FreeListProxy {
   }
 
  private:
+  MemoryAllocator allocator_{};
   ProxyT proxy_{};
 };
 }  // namespace rocshmem

--- a/projects/rocshmem/src/containers/free_list_impl.hpp
+++ b/projects/rocshmem/src/containers/free_list_impl.hpp
@@ -33,11 +33,11 @@ namespace rocshmem {
  ******************************* FREE LIST ***********************************
  *****************************************************************************/
 
-template <typename TYPE, typename ALLOC>
-FreeList<TYPE, ALLOC>::~FreeList() {}
+template <typename TYPE>
+FreeList<TYPE>::~FreeList() {}
 
-template <typename TYPE, typename ALLOC>
-void FreeList<TYPE, ALLOC>::deallocate_all_nodes() {
+template <typename TYPE>
+void FreeList<TYPE>::deallocate_all_nodes() {
   // Deallocate any existing nodes
   while (head_ != nullptr) {
     auto temp = head_;
@@ -56,16 +56,17 @@ void FreeList<TYPE, ALLOC>::deallocate_all_nodes() {
   }
 }
 
-template <typename TYPE, typename ALLOC>
-FreeList<TYPE, ALLOC>::FreeList(const ALLOC& alloc)
+template <typename TYPE>
+FreeList<TYPE>::FreeList(const MemoryAllocator& alloc)
     : allocator_{alloc},
       head_{nullptr},
       tail_{nullptr},
-      deallocated_nodes_{nullptr} {}
+      deallocated_nodes_{nullptr},
+      mutex_{alloc} {}
 
-template <typename TYPE, typename ALLOC>
+template <typename TYPE>
 template <class InputIt>
-bool FreeList<TYPE, ALLOC>::push_back_range(InputIt first, InputIt last) {
+bool FreeList<TYPE>::push_back_range(InputIt first, InputIt last) {
   for (auto iter = first; iter != last; iter++) {
     auto key = *iter;
     const bool result = push_back(key);
@@ -76,8 +77,8 @@ bool FreeList<TYPE, ALLOC>::push_back_range(InputIt first, InputIt last) {
   return true;
 }
 
-template <typename TYPE, typename ALLOC>
-__device__ bool FreeList<TYPE, ALLOC>::push_back(const TYPE& val) {
+template <typename TYPE>
+__device__ bool FreeList<TYPE>::push_back(const TYPE& val) {
   TicketLockGuard<MutexType> guard(*mutex_.get());
   auto node = allocate_node();
   if (node == nullptr) {
@@ -92,13 +93,13 @@ __device__ bool FreeList<TYPE, ALLOC>::push_back(const TYPE& val) {
   return true;
 }
 
-template <typename TYPE, typename ALLOC>
-__device__ bool FreeList<TYPE, ALLOC>::push_back(TYPE&& val) {
+template <typename TYPE>
+__device__ bool FreeList<TYPE>::push_back(TYPE&& val) {
   return push_back(std::forward<const TYPE>(val));
 }
 
-template <typename TYPE, typename ALLOC>
-__host__ bool FreeList<TYPE, ALLOC>::push_back(const TYPE& val) {
+template <typename TYPE>
+__host__ bool FreeList<TYPE>::push_back(const TYPE& val) {
   auto node = allocate_node();
   if (node == nullptr) {
     return false;
@@ -110,14 +111,14 @@ __host__ bool FreeList<TYPE, ALLOC>::push_back(const TYPE& val) {
 
   return true;
 }
-template <typename TYPE, typename ALLOC>
-__host__ bool FreeList<TYPE, ALLOC>::push_back(TYPE&& val) {
+template <typename TYPE>
+__host__ bool FreeList<TYPE>::push_back(TYPE&& val) {
   return push_back(std::forward<const TYPE>(val));
 }
 
-template <typename TYPE, typename ALLOC>
-__device__ typename FreeList<TYPE, ALLOC>::PopBackResult
-FreeList<TYPE, ALLOC>::pop_front() {
+template <typename TYPE>
+__device__ typename FreeList<TYPE>::PopBackResult
+FreeList<TYPE>::pop_front() {
   TicketLockGuard<MutexType> guard(*mutex_.get());
 
   if (head_ == nullptr) {

--- a/projects/rocshmem/src/gda/backend_gda.hpp
+++ b/projects/rocshmem/src/gda/backend_gda.hpp
@@ -514,7 +514,7 @@ class GDABackend : public Backend {
   /**
    * @brief A free-list containing contexts.
    */
-  FreeListProxy<HIPAllocator, GDAContext *> ctx_free_list{};
+  FreeListProxy<GDAContext *> ctx_free_list{};
 
   /**
    * @brief The bitmask representing the availability of teams in the pool

--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -44,7 +44,7 @@ QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider) {
   allocator.allocate((void**)&nonfetching_atomic, 8);
   allocator.allocate((void**)&fetching_atomic, 8 * FETCHING_ATOMIC_CNT);
   allocator.allocate((void**)&fetching_atomic_freelist, sizeof(FreeListT*));
-  new (fetching_atomic_freelist) FreeListT();
+  new (fetching_atomic_freelist) FreeListT(HIPAllocator());
 
   CHECK_HIP(hipMemset(nonfetching_atomic, 0, 8));
   CHECK_HIP(hipMemset(fetching_atomic, 0, 8 * FETCHING_ATOMIC_CNT));

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -461,7 +461,7 @@ class QueuePair {
 
   static constexpr uint32_t FETCHING_ATOMIC_CNT{1024};
   static_assert(FETCHING_ATOMIC_CNT % WF_SIZE == 0);
-  using FreeListT = FreeList<uint64_t*, HIPAllocator>;
+  using FreeListT = FreeList<uint64_t*>;
   FreeListT* fetching_atomic_freelist{nullptr};
 
   HIPAllocator allocator{};

--- a/projects/rocshmem/src/ipc/backend_ipc.hpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.hpp
@@ -248,7 +248,7 @@ class IPCBackend : public Backend {
   /**
    * @brief A free-list containing contexts.
    */
-  FreeListProxy<HIPAllocator, IPCContext *> ctx_free_list{};
+  FreeListProxy<IPCContext *> ctx_free_list{};
 
   /**
    * @brief The bitmask representing the availability of teams in the pool

--- a/projects/rocshmem/src/reverse_offload/backend_ro.hpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.hpp
@@ -283,19 +283,19 @@ class ROBackend : public Backend {
   /**
    * @brief AtomicWFQueue containing status flag buffers for default context
    */
-  AtomicWFQueueProxy<HIPAllocator, volatile char*> default_ctx_status_{};
+  AtomicWFQueueProxy<volatile char*> default_ctx_status_{};
 
   /**
    * @brief AtomicWFQueue containing rocshmem_g return buffers for default
    * context
    */
-  AtomicWFQueueProxy<HIPAllocator, uint64_t*> default_ctx_g_ret_buffer_{};
+  AtomicWFQueueProxy<uint64_t*> default_ctx_g_ret_buffer_{};
 
   /**
    * @brief AtomicWFQueue containing rocshmem return buffers for default
    * context
    */
-  AtomicWFQueueProxy<HIPAllocator, uint64_t*> default_ctx_atomic_ret_buffer_{};
+  AtomicWFQueueProxy<uint64_t*> default_ctx_atomic_ret_buffer_{};
 
   /**
    * @brief Holds maximum threads per work-group

--- a/projects/rocshmem/src/reverse_offload/backend_ro.hpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.hpp
@@ -278,7 +278,7 @@ class ROBackend : public Backend {
   /**
    * @brief A free-list containing contexts.
    */
-  FreeListProxy<HIPAllocator, ROContext *> ctx_free_list{};
+  FreeListProxy<ROContext *> ctx_free_list{};
 
   /**
    * @brief AtomicWFQueue containing status flag buffers for default context

--- a/projects/rocshmem/src/reverse_offload/block_handle.hpp
+++ b/projects/rocshmem/src/reverse_offload/block_handle.hpp
@@ -33,8 +33,8 @@
 
 namespace rocshmem {
 
-using AWF_Queue_statusT = AtomicWFQueue<volatile char*, HIPAllocator>;
-using AWF_Queue_ret_buffT = AtomicWFQueue<uint64_t*, HIPAllocator>;
+using AWF_Queue_statusT = AtomicWFQueue<volatile char*>;
+using AWF_Queue_ret_buffT = AtomicWFQueue<uint64_t*>;
 
 struct BlockHandle {
   ROStats profiler{};

--- a/projects/rocshmem/src/sync/abql_block_mutex.hpp
+++ b/projects/rocshmem/src/sync/abql_block_mutex.hpp
@@ -26,6 +26,8 @@
 #define LIBRARY_SRC_SYNC_ABQL_BLOCK_MUTEX_HPP_
 
 #include "device_proxy.hpp"
+#include "memory/hip_allocator.hpp"
+#include "memory/default_allocator.hpp"
 
 #include <hip/hip_runtime.h>
 
@@ -111,12 +113,13 @@ class ABQLBlockMutex {
   Turn turns_[memory_channels_]{};
 };
 
-template <typename ALLOCATOR>
 class ABQLBlockMutexProxy {
-  using ProxyT = DeviceProxy<ALLOCATOR, ABQLBlockMutex>;
+  using ProxyT = DeviceProxy<HIPDefaultFinegrainedAllocator, ABQLBlockMutex>;
 
  public:
-  ABQLBlockMutexProxy(size_t num_elems = 1) : proxy_{num_elems} {}
+  explicit ABQLBlockMutexProxy(const MemoryAllocator& alloc = *get_default_allocator(),
+                               size_t num_elems = 1)
+      : allocator_{alloc}, proxy_{num_elems} {}
 
   ABQLBlockMutexProxy(const ABQLBlockMutexProxy& other) = delete;
 
@@ -129,6 +132,7 @@ class ABQLBlockMutexProxy {
   __host__ __device__ ABQLBlockMutex* get() { return proxy_.get(); }
 
  private:
+  MemoryAllocator allocator_{};
   ProxyT proxy_{};
 };
 

--- a/projects/rocshmem/src/sync/abql_block_mutex.hpp
+++ b/projects/rocshmem/src/sync/abql_block_mutex.hpp
@@ -117,9 +117,9 @@ class ABQLBlockMutexProxy {
   using ProxyT = DeviceProxy<HIPDefaultFinegrainedAllocator, ABQLBlockMutex>;
 
  public:
-  explicit ABQLBlockMutexProxy(const MemoryAllocator& alloc = *get_default_allocator(),
+  explicit ABQLBlockMutexProxy([[maybe_unused]] const MemoryAllocator& alloc = *get_default_allocator(),
                                size_t num_elems = 1)
-      : allocator_{alloc}, proxy_{num_elems} {}
+      : proxy_{num_elems} {}
 
   ABQLBlockMutexProxy(const ABQLBlockMutexProxy& other) = delete;
 
@@ -132,7 +132,6 @@ class ABQLBlockMutexProxy {
   __host__ __device__ ABQLBlockMutex* get() { return proxy_.get(); }
 
  private:
-  MemoryAllocator allocator_{};
   ProxyT proxy_{};
 };
 

--- a/projects/rocshmem/tests/unit_tests/atomic_wf_queue_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/atomic_wf_queue_gtest.hpp
@@ -153,8 +153,8 @@ class AtomicWFQueueTestFixture : public ::testing::Test {
 
   protected:
 
-    AtomicWFQueueProxy<HIPAllocator, int> awf_queue_proxy{};
-    AtomicWFQueue<int, HIPAllocator>* awf_queue{};
+    AtomicWFQueueProxy<int> awf_queue_proxy{};
+    AtomicWFQueue<int>* awf_queue{};
 
     /**
      * @brief An allocator to create objects in device memory.

--- a/projects/rocshmem/tests/unit_tests/free_list_gtest.cpp
+++ b/projects/rocshmem/tests/unit_tests/free_list_gtest.cpp
@@ -83,7 +83,7 @@ TYPED_TEST(FreeListTestFixture, pop_empty_device) {
 
   CHECK_HIP(hipMemset(is_empty, 0, sizeof(bool)));
   FreeListProxy<Allocator, T> empty_list_proxy{};
-  FreeList<T, Allocator>* empty_free_list{empty_list_proxy.get()};
+  FreeList<T>* empty_free_list{empty_list_proxy.get()};
 
   rocshmem::pop_empty<<<1, 1>>>(empty_free_list, is_empty);
   CHECK_HIP(hipDeviceSynchronize());
@@ -166,7 +166,7 @@ TYPED_TEST(FreeListTestFixture, push_host_concurrent_pop_device) {
 TYPED_TEST(FreeListTestFixture, push_host_pop_push_device) {
   using Allocator = typename TestFixture::Allocator;
   using T = typename TestFixture::T;
-  using FreeListType = FreeList<T, Allocator>;
+  using FreeListType = FreeList<T>;
 
   auto& h_input = this->h_input;
   auto& free_list = this->free_list;
@@ -205,7 +205,7 @@ TYPED_TEST(FreeListTestFixture, push_host_pop_push_device) {
 TYPED_TEST(FreeListTestFixture, push_host_pop_concurrent_push_device) {
   using Allocator = typename TestFixture::Allocator;
   using T = typename TestFixture::T;
-  using FreeListType = FreeList<T, Allocator>;
+  using FreeListType = FreeList<T>;
 
   auto& h_input = this->h_input;
   auto& free_list = this->free_list;
@@ -255,7 +255,7 @@ TYPED_TEST(FreeListTestFixture, push_host_pop_concurrent_push_device) {
 TYPED_TEST(FreeListTestFixture, push_host_concurrent_pop_push_device) {
   using Allocator = typename TestFixture::Allocator;
   using T = typename TestFixture::T;
-  using FreeListType = FreeList<T, Allocator>;
+  using FreeListType = FreeList<T>;
 
   auto& h_input = this->h_input;
   auto& free_list = this->free_list;

--- a/projects/rocshmem/tests/unit_tests/free_list_gtest.cpp
+++ b/projects/rocshmem/tests/unit_tests/free_list_gtest.cpp
@@ -82,7 +82,7 @@ TYPED_TEST(FreeListTestFixture, pop_empty_device) {
                           sizeof(bool));
 
   CHECK_HIP(hipMemset(is_empty, 0, sizeof(bool)));
-  FreeListProxy<Allocator, T> empty_list_proxy{};
+  FreeListProxy<T> empty_list_proxy{};
   FreeList<T>* empty_free_list{empty_list_proxy.get()};
 
   rocshmem::pop_empty<<<1, 1>>>(empty_free_list, is_empty);

--- a/projects/rocshmem/tests/unit_tests/free_list_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/free_list_gtest.hpp
@@ -57,7 +57,7 @@ class FreeListTestFixture : public ::testing::Test {
   int wf_size;
 
   FreeListProxy<Allocator, T> list_proxy{};
-  FreeList<T, Allocator>* free_list{};
+  FreeList<T>* free_list{};
 };
 
 using TestTypes = ::testing::Types<std::uint32_t, std::uint64_t>;

--- a/projects/rocshmem/tests/unit_tests/free_list_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/free_list_gtest.hpp
@@ -56,7 +56,7 @@ class FreeListTestFixture : public ::testing::Test {
   std::vector<T> h_input{};
   int wf_size;
 
-  FreeListProxy<Allocator, T> list_proxy{};
+  FreeListProxy<T> list_proxy{};
   FreeList<T>* free_list{};
 };
 


### PR DESCRIPTION
## Motivation

This PR is in preparation for converting the heap memory type being used to be a runtime argument instead of a compile time decision. For this, a number of classes that use a AllocatorType as a template argument have been converted to take the allocator as an argument to the default constructor, typically with a default value being also provided.

In order to keep the size of changes manageable, the work will be split up into multiple PR.
This PR converts the following classes:
- FreeList
- FreeListProxy
- ABQLBlockMutexProxy 
- AtomicWFQueue
- AtomicWFQueueProxy
 
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
