### PR TITLE
[sna] SOVERSION + CHANGELOG + version-bump CI check

### DIFF
--- a/.github/workflows/rocpdsna-version-check.yml
+++ b/.github/workflows/rocpdsna-version-check.yml
@@ -1,0 +1,83 @@
+name: rocpdsna Version Check
+run-name: rocpdsna-version-check
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/rocpdsna-version-check.yml'
+      - 'projects/rocpdsna/**'
+      - '!projects/rocpdsna/build/**'
+      - '!projects/rocpdsna/docs/**'
+      - '!projects/rocpdsna/README.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  version-check:
+    name: version-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          sparse-checkout: |
+            projects/rocpdsna
+            .github/workflows
+
+      - name: Check version bump or CHANGELOG update
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -e
+          BASE="origin/${BASE_REF}"
+          git fetch origin "${BASE_REF}"
+
+          INCLUDE_DIFF=$(git diff --name-only "${BASE}...HEAD" -- \
+            'projects/rocpdsna/include/' | wc -l)
+          if [ "${INCLUDE_DIFF}" -eq 0 ]; then
+            echo "No public header changes - version check not required."
+            exit 0
+          fi
+
+          echo "Public headers changed in this PR:"
+          git diff --name-only "${BASE}...HEAD" -- 'projects/rocpdsna/include/'
+          echo
+
+          # Escape hatch: any commit subject containing [no-version-bump]
+          if git log "${BASE}..HEAD" --pretty=%s | grep -qF '[no-version-bump]'; then
+            echo "::notice::Version-bump check skipped via [no-version-bump] commit trailer"
+            exit 0
+          fi
+
+          OLD=$(git show "${BASE}:projects/rocpdsna/CMakeLists.txt" \
+            | grep -oE 'project\(rocpdsna VERSION [0-9]+\.[0-9]+\.[0-9]+' || true)
+          NEW=$(grep -oE 'project\(rocpdsna VERSION [0-9]+\.[0-9]+\.[0-9]+' \
+            projects/rocpdsna/CMakeLists.txt || true)
+
+          if [ -n "${NEW}" ] && [ "${OLD}" != "${NEW}" ]; then
+            echo "::notice::Version bumped: ${OLD##*VERSION } -> ${NEW##*VERSION }"
+            exit 0
+          fi
+
+          CHANGELOG_DIFF=$(git diff --name-only "${BASE}...HEAD" -- \
+            'projects/rocpdsna/CHANGELOG.md' | wc -l)
+          if [ "${CHANGELOG_DIFF}" -gt 0 ]; then
+            echo "::notice::CHANGELOG.md updated; version bump may be deferred to release."
+            exit 0
+          fi
+
+          {
+            echo "::error::Public headers under projects/rocpdsna/include/ changed but no version bump in CMakeLists.txt and no CHANGELOG.md update."
+            echo
+            echo "Pick one of:"
+            echo "  1. Bump 'project(rocpdsna VERSION ...)' in projects/rocpdsna/CMakeLists.txt"
+            echo "  2. Add an entry under '## [Unreleased]' in projects/rocpdsna/CHANGELOG.md"
+            echo "  3. Add '[no-version-bump]' to a commit subject if this change is genuinely non-user-facing"
+          }
+          exit 1

--- a/.github/workflows/rocpdsna-version-check.yml
+++ b/.github/workflows/rocpdsna-version-check.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   version-check:
     name: version-check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
@@ -55,9 +55,10 @@ jobs:
             exit 0
           fi
 
+          VERSION_REGEX='project\([[:space:]]*rocpdsna[[:space:]]+VERSION[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+'
           OLD=$(git show "${BASE}:projects/rocpdsna/CMakeLists.txt" \
-            | grep -oE 'project\(rocpdsna VERSION [0-9]+\.[0-9]+\.[0-9]+' || true)
-          NEW=$(grep -oE 'project\(rocpdsna VERSION [0-9]+\.[0-9]+\.[0-9]+' \
+            | grep -oE "${VERSION_REGEX}" || true)
+          NEW=$(grep -oE "${VERSION_REGEX}" \
             projects/rocpdsna/CMakeLists.txt || true)
 
           if [ -n "${NEW}" ] && [ "${OLD}" != "${NEW}" ]; then

--- a/projects/rocpdsna/CHANGELOG.md
+++ b/projects/rocpdsna/CHANGELOG.md
@@ -25,7 +25,7 @@ downstream consumer of the library.
 - `librocpdsna.so` now ships with a SOVERSION (`librocpdsna.so.0` symlink and
   `librocpdsna.so.0.1.0` actual file) so consumers can pin to a specific ABI.
 
-## [0.1.0] - 2026-04-23
+## [0.1.0] - 2026-05-05
 
 Initial release.
 

--- a/projects/rocpdsna/CHANGELOG.md
+++ b/projects/rocpdsna/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+All notable user-facing changes to the rocpdsna library are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Sections in each release entry:
+
+- **Added** — new features, new public APIs, new build options
+- **Changed** — changes to existing public behavior or APIs
+- **Deprecated** — APIs that still work but will be removed
+- **Removed** — APIs or build options that no longer exist
+- **Fixed** — bug fixes visible to users
+- **Security** — vulnerability fixes
+
+Internal refactors and CI changes that have no user-visible impact do not need
+a changelog entry. Release entries should be written from the perspective of a
+downstream consumer of the library.
+
+## [Unreleased]
+
+### Added
+
+- `librocpdsna.so` now ships with a SOVERSION (`librocpdsna.so.0` symlink and
+  `librocpdsna.so.0.1.0` actual file) so consumers can pin to a specific ABI.
+
+## [0.1.0] - 2026-04-23
+
+Initial release.
+
+### Added
+
+- C++17 public API for storing and retrieving ROCm profiling data in the
+  rocpd (SQLite) database format. Public types under `rocpdsna::` namespace:
+  `storage_t`, `writer_t`, `reader_t`, `version_t`, plus the supporting
+  type families in `writer_types`, `reader_types`, `shared_types`,
+  `storage_types`.
+- Schema versions 3.0.0 and 4.0.0, runtime-selectable.
+- Both shared (`librocpdsna.so`) and static (`librocpdsna.a`) library
+  variants built from a shared object set.
+- CMake package config for downstream consumption:
+  `find_package(rocpdsna REQUIRED)` resolves the namespaced
+  `rocpdsna::rocpdsna` target, including a `Findrocpdsna.cmake` module
+  for non-CMake-config integrations.
+- Build options: `ROCPDSNA_BUILD_TESTS`, `ROCPDSNA_BUILD_BENCHMARKS`,
+  `ROCPDSNA_ENABLE_LOGGING`, `ROCPDSNA_ENABLE_COVERAGE`,
+  `ROCPDSNA_USE_SYSTEM_SPDLOG`, `ROCPDSNA_USE_SYSTEM_GTEST`.
+- System dependency support for SQLite3, spdlog, fmt, nlohmann_json,
+  GoogleTest, and Google Benchmark, with FetchContent fallback for
+  spdlog and GoogleTest when the system version is too old.
+- Public install layout:
+  - `<prefix>/lib/librocpdsna.{so,a}`
+  - `<prefix>/include/rocpdsna/{reader,reader_types,shared_types,storage,storage_types,writer,writer_types}.hpp`
+  - `<prefix>/lib/cmake/rocpdsna/{rocpdsna-config,rocpdsna-config-version,rocpdsna-targets,Findrocpdsna}.cmake`
+- Cobertura code coverage reports via the `coverage-xml` CMake target.
+- clang-tidy custom target using the bundled `.clang-tidy` configuration.
+
+[Unreleased]: https://github.com/ROCm/rocm-systems/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/ROCm/rocm-systems/releases/tag/v0.1.0

--- a/projects/rocpdsna/CMakeLists.txt
+++ b/projects/rocpdsna/CMakeLists.txt
@@ -49,12 +49,9 @@ endif()
 # Version
 # ------------------------------------------------------------ #
 
-set(rocpdsna_VERSION_MAJOR 0)
-set(rocpdsna_VERSION_MINOR 1)
-set(rocpdsna_VERSION_PATCH 0)
-set(rocpdsna_VERSION
-    ${rocpdsna_VERSION_MAJOR}.${rocpdsna_VERSION_MINOR}.${rocpdsna_VERSION_PATCH}
-)
+# Version is the single source of truth in `project(rocpdsna VERSION ...)`
+# above. CMake automatically populates rocpdsna_VERSION_{MAJOR,MINOR,PATCH}
+# and rocpdsna_VERSION from it.
 
 # ------------------------------------------------------------ #
 # Object Library (compiled once, used by both shared and static)
@@ -223,6 +220,14 @@ endif()
 add_library(rocpdsna SHARED $<TARGET_OBJECTS:rocpdsna-objects>)
 add_library(rocpdsna-static STATIC $<TARGET_OBJECTS:rocpdsna-objects>)
 set_target_properties(rocpdsna-static PROPERTIES OUTPUT_NAME rocpdsna)
+
+# Embed semantic version + ABI version on the shared library so that
+# librocpdsna.so.<MAJOR> is the SONAME and librocpdsna.so.<MAJOR>.<MINOR>.<PATCH>
+# is the actual file, with both symlinks installed alongside librocpdsna.so.
+set_target_properties(
+    rocpdsna
+    PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR}
+)
 
 foreach(_target rocpdsna rocpdsna-static)
     target_include_directories(


### PR DESCRIPTION
## Motivation

Close out three related gaps in rocpdsna versioning hygiene before any release tag:

1. The shared library has no SOVERSION, so `cmake --install` produces a single `librocpdsna.so` with no major-version symlink and no embedded SONAME. Bumping the version overwrites the prior `.so` instead of producing the canonical `librocpdsna.so` -> `librocpdsna.so.0` -> `librocpdsna.so.0.1.0` triple. ABI-aware consumers and distros can't pin.
2. The version is duplicated between `project(rocpdsna VERSION 0.1.0)` and a manual `set(rocpdsna_VERSION_MAJOR ...)` block. The two can silently disagree on a bump.
3. There is no CHANGELOG, and no CI gate that catches public API changes landing without a version bump or a release-notes entry.

This PR fixes all three.

## Technical Details

### 1. SOVERSION + version dedup (commit `996962d`)

- `set_target_properties(rocpdsna PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})` on the shared library target. The static library is unaffected (SOVERSION does not apply).
- Removed the manual `set(rocpdsna_VERSION_MAJOR 0) ...` block. CMake's `project(rocpdsna VERSION 0.1.0)` already populates the same `rocpdsna_VERSION_{MAJOR,MINOR,PATCH}` and `rocpdsna_VERSION` variables, so all the existing references (compile-time defines, package-config version file, install rules) keep working with no further changes.

After the fix, `cmake --install` produces:

```
<prefix>/lib/librocpdsna.so          -> librocpdsna.so.0
<prefix>/lib/librocpdsna.so.0        -> librocpdsna.so.0.1.0
<prefix>/lib/librocpdsna.so.0.1.0    (real file, SONAME = librocpdsna.so.0)
<prefix>/lib/librocpdsna.a
```

Verified locally with `readelf -d`:

```
0x000000000000000e (SONAME)             Library soname: [librocpdsna.so.0]
```

### 2. CHANGELOG.md (commit `06187273`)

Adds `projects/rocpdsna/CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/) format. Documents the existing 0.1.0 surface (public API, build options, install layout, supporting tooling) and seeds an `[Unreleased]` section for ongoing work.

Going forward: any user-visible change (public API, build option, install layout, behavior) adds an entry under `[Unreleased]`. At release time the `[Unreleased]` heading becomes the new version section and a fresh `[Unreleased]` takes its place.

### 3. Version-bump CI check (commit `deb2a79`)

New workflow `.github/workflows/rocpdsna-version-check.yml` runs on PRs that touch `projects/rocpdsna/**`. Logic:

```
if any file under projects/rocpdsna/include/ changed in the PR diff:
    if any commit subject contains [no-version-bump]:                        pass (notice)
    elif `project(rocpdsna VERSION ...)` line differs from base branch:      pass (notice)
    elif projects/rocpdsna/CHANGELOG.md was modified:                        pass (notice)
    else:                                                                    fail with actionable error
```

Three escape paths so every API change is a conscious decision but no friction for non-user-facing churn:

1. Bump `project(rocpdsna VERSION ...)` in CMakeLists.txt (immediate version bump in this PR)
2. Add an entry under `## [Unreleased]` in CHANGELOG.md (queue for the next release)
3. `[no-version-bump]` in a commit subject (formatting, comment-only, or other non-API changes)

Headers under `include/` are the proxy for "public API surface" (rocpdsna's public types live there). Implementation changes that are also ABI-breaking (e.g., adding a virtual to a class) are not caught — known limitation, would need ABI tooling.

Workflow conventions match the rest of the rocpdsna CI series:
- `pull_request` only (no `push` — version-bump checks on already-merged commits are meaningless)
- Path filter scoped to `projects/rocpdsna/**`
- Sparse checkout
- Read-only permissions
- 5-minute timeout (the script is just `git diff` + `grep`)
- Concurrency cancellation enabled

## JIRA ID

N/A

## Test Plan

- Local `cmake --install` after the SOVERSION change → check the three .so files / symlinks exist
- `readelf -d` on the installed `.so.0.1.0` → confirm SONAME embeds the major-version suffix
- Local rebuild + run of the find_package consumer test from #5320 → confirm the SOVERSION change does not break the previously-installed-headers contract
- Rendering CHANGELOG.md in a markdown preview to confirm structure
- YAML syntax check on the new workflow
- Bash syntax check (`bash -n`) on the workflow's inline script
- First CI run on this PR exercises the version-check job (this PR itself doesn't change `include/`, so the job should report "No public header changes - version check not required")

## Test Result

- Install layout (after SOVERSION):
  ```
  -rw-r--r-- librocpdsna.a
  lrwxrwxrwx librocpdsna.so       -> librocpdsna.so.0
  lrwxrwxrwx librocpdsna.so.0     -> librocpdsna.so.0.1.0
  -rw-r--r-- librocpdsna.so.0.1.0
  ```
- SONAME: `[librocpdsna.so.0]` (was `[librocpdsna.so]`)
- Package-config version file: unchanged (`PACKAGE_VERSION "0.1.0"`)
- YAML parse: OK; `bash -n` on inline script: OK
- CI run on this PR: pending — will update once first run completes

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.