### PR TITLE
clr: Add hipExtGraphExecDump* extension APIs

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/hip_prof_str.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/hip_prof_str.h
@@ -485,7 +485,10 @@ enum hip_api_id_t {
   HIP_API_ID_hipMemPrefetchBatchAsync = 460,
   HIP_API_ID_hipOccupancyMaxActiveClusters = 461,
   HIP_API_ID_hipOccupancyMaxPotentialClusterSize = 462,
-  HIP_API_ID_LAST = 462,
+  HIP_API_ID_hipExtGraphExecDumpCreate = 463,
+  HIP_API_ID_hipExtGraphExecDumpGet = 464,
+  HIP_API_ID_hipExtGraphExecDumpDestroy = 465,
+  HIP_API_ID_LAST = 465,
 
   HIP_API_ID_hipChooseDevice = HIP_API_ID_CONCAT(HIP_API_ID_,hipChooseDevice),
   HIP_API_ID_hipGetDeviceProperties = HIP_API_ID_CONCAT(HIP_API_ID_,hipGetDeviceProperties),
@@ -611,6 +614,9 @@ static inline const char* hip_api_name(const uint32_t id) {
     case HIP_API_ID_hipExtEnableLogging: return "hipExtEnableLogging";
     case HIP_API_ID_hipExtGetLastError: return "hipExtGetLastError";
     case HIP_API_ID_hipExtGetLinkTypeAndHopCount: return "hipExtGetLinkTypeAndHopCount";
+    case HIP_API_ID_hipExtGraphExecDumpCreate: return "hipExtGraphExecDumpCreate";
+    case HIP_API_ID_hipExtGraphExecDumpDestroy: return "hipExtGraphExecDumpDestroy";
+    case HIP_API_ID_hipExtGraphExecDumpGet: return "hipExtGraphExecDumpGet";
     case HIP_API_ID_hipExtLaunchKernel: return "hipExtLaunchKernel";
     case HIP_API_ID_hipExtLaunchMultiKernelMultiDevice: return "hipExtLaunchMultiKernelMultiDevice";
     case HIP_API_ID_hipExtMallocWithFlags: return "hipExtMallocWithFlags";
@@ -1067,6 +1073,9 @@ static inline uint32_t hipApiIdByName(const char* name) {
   if (strcmp("hipExtEnableLogging", name) == 0) return HIP_API_ID_hipExtEnableLogging;
   if (strcmp("hipExtGetLastError", name) == 0) return HIP_API_ID_hipExtGetLastError;
   if (strcmp("hipExtGetLinkTypeAndHopCount", name) == 0) return HIP_API_ID_hipExtGetLinkTypeAndHopCount;
+  if (strcmp("hipExtGraphExecDumpCreate", name) == 0) return HIP_API_ID_hipExtGraphExecDumpCreate;
+  if (strcmp("hipExtGraphExecDumpDestroy", name) == 0) return HIP_API_ID_hipExtGraphExecDumpDestroy;
+  if (strcmp("hipExtGraphExecDumpGet", name) == 0) return HIP_API_ID_hipExtGraphExecDumpGet;
   if (strcmp("hipExtLaunchKernel", name) == 0) return HIP_API_ID_hipExtLaunchKernel;
   if (strcmp("hipExtLaunchMultiKernelMultiDevice", name) == 0) return HIP_API_ID_hipExtLaunchMultiKernelMultiDevice;
   if (strcmp("hipExtMallocWithFlags", name) == 0) return HIP_API_ID_hipExtMallocWithFlags;
@@ -1850,6 +1859,22 @@ typedef struct hip_api_data_s {
       unsigned int* hopcount;
       unsigned int hopcount__val;
     } hipExtGetLinkTypeAndHopCount;
+    struct {
+      hipGraphExec_t graphExec;
+      unsigned int flags;
+      hipExtGraphExecDump_t* dumpOut;
+      hipExtGraphExecDump_t dumpOut__val;
+    } hipExtGraphExecDumpCreate;
+    struct {
+      hipExtGraphExecDump_t dump;
+    } hipExtGraphExecDumpDestroy;
+    struct {
+      hipExtGraphExecDump_t dump;
+      hipExtGraphExecDumpQuery_t query;
+      size_t index;
+      hipExtGraphExecDumpResult_t* result;
+      hipExtGraphExecDumpResult_t result__val;
+    } hipExtGraphExecDumpGet;
     struct {
       const void* function_address;
       dim3 numBlocks;
@@ -4611,6 +4636,23 @@ typedef struct hip_api_data_s {
   cb_data.args.hipExtGetLinkTypeAndHopCount.linktype = (unsigned int*)linktype; \
   cb_data.args.hipExtGetLinkTypeAndHopCount.hopcount = (unsigned int*)hopcount; \
 };
+// hipExtGraphExecDumpCreate[('hipGraphExec_t', 'graphExec'), ('unsigned int', 'flags'), ('hipExtGraphExecDump_t*', 'dumpOut')]
+#define INIT_hipExtGraphExecDumpCreate_CB_ARGS_DATA(cb_data) { \
+  cb_data.args.hipExtGraphExecDumpCreate.graphExec = (hipGraphExec_t)graphExec; \
+  cb_data.args.hipExtGraphExecDumpCreate.flags = (unsigned int)flags; \
+  cb_data.args.hipExtGraphExecDumpCreate.dumpOut = (hipExtGraphExecDump_t*)dumpOut; \
+};
+// hipExtGraphExecDumpDestroy[('hipExtGraphExecDump_t', 'dump')]
+#define INIT_hipExtGraphExecDumpDestroy_CB_ARGS_DATA(cb_data) { \
+  cb_data.args.hipExtGraphExecDumpDestroy.dump = (hipExtGraphExecDump_t)dump; \
+};
+// hipExtGraphExecDumpGet[('hipExtGraphExecDump_t', 'dump'), ('hipExtGraphExecDumpQuery_t', 'query'), ('size_t', 'index'), ('hipExtGraphExecDumpResult_t*', 'result')]
+#define INIT_hipExtGraphExecDumpGet_CB_ARGS_DATA(cb_data) { \
+  cb_data.args.hipExtGraphExecDumpGet.dump = (hipExtGraphExecDump_t)dump; \
+  cb_data.args.hipExtGraphExecDumpGet.query = (hipExtGraphExecDumpQuery_t)query; \
+  cb_data.args.hipExtGraphExecDumpGet.index = (size_t)index; \
+  cb_data.args.hipExtGraphExecDumpGet.result = (hipExtGraphExecDumpResult_t*)result; \
+};
 // hipExtLaunchKernel[('const void*', 'function_address'), ('dim3', 'numBlocks'), ('dim3', 'dimBlocks'), ('void**', 'args'), ('size_t', 'sharedMemBytes'), ('hipStream_t', 'stream'), ('hipEvent_t', 'startEvent'), ('hipEvent_t', 'stopEvent'), ('int', 'flags')]
 #define INIT_hipExtLaunchKernel_CB_ARGS_DATA(cb_data) { \
   cb_data.args.hipExtLaunchKernel.function_address = (const void*)hostFunction; \
@@ -7322,6 +7364,17 @@ static inline void hipApiArgsInit(hip_api_id_t id, hip_api_data_t* data) {
       if (data->args.hipExtGetLinkTypeAndHopCount.linktype) data->args.hipExtGetLinkTypeAndHopCount.linktype__val = *(data->args.hipExtGetLinkTypeAndHopCount.linktype);
       if (data->args.hipExtGetLinkTypeAndHopCount.hopcount) data->args.hipExtGetLinkTypeAndHopCount.hopcount__val = *(data->args.hipExtGetLinkTypeAndHopCount.hopcount);
       break;
+// hipExtGraphExecDumpCreate[('hipGraphExec_t', 'graphExec'), ('unsigned int', 'flags'), ('hipExtGraphExecDump_t*', 'dumpOut')]
+    case HIP_API_ID_hipExtGraphExecDumpCreate:
+      if (data->args.hipExtGraphExecDumpCreate.dumpOut) data->args.hipExtGraphExecDumpCreate.dumpOut__val = *(data->args.hipExtGraphExecDumpCreate.dumpOut);
+      break;
+// hipExtGraphExecDumpDestroy[('hipExtGraphExecDump_t', 'dump')]
+    case HIP_API_ID_hipExtGraphExecDumpDestroy:
+      break;
+// hipExtGraphExecDumpGet[('hipExtGraphExecDump_t', 'dump'), ('hipExtGraphExecDumpQuery_t', 'query'), ('size_t', 'index'), ('hipExtGraphExecDumpResult_t*', 'result')]
+    case HIP_API_ID_hipExtGraphExecDumpGet:
+      if (data->args.hipExtGraphExecDumpGet.result) data->args.hipExtGraphExecDumpGet.result__val = *(data->args.hipExtGraphExecDumpGet.result);
+      break;
 // hipExtLaunchKernel[('const void*', 'function_address'), ('dim3', 'numBlocks'), ('dim3', 'dimBlocks'), ('void**', 'args'), ('size_t', 'sharedMemBytes'), ('hipStream_t', 'stream'), ('hipEvent_t', 'startEvent'), ('hipEvent_t', 'stopEvent'), ('int', 'flags')]
     case HIP_API_ID_hipExtLaunchKernel:
       if (data->args.hipExtLaunchKernel.args) data->args.hipExtLaunchKernel.args__val = *(data->args.hipExtLaunchKernel.args);
@@ -9377,6 +9430,28 @@ static inline const char* hipApiString(hip_api_id_t id, const hip_api_data_t* da
       else { oss << ", linktype="; roctracer::hip_support::detail::operator<<(oss, data->args.hipExtGetLinkTypeAndHopCount.linktype__val); }
       if (data->args.hipExtGetLinkTypeAndHopCount.hopcount == NULL) oss << ", hopcount=NULL";
       else { oss << ", hopcount="; roctracer::hip_support::detail::operator<<(oss, data->args.hipExtGetLinkTypeAndHopCount.hopcount__val); }
+      oss << ")";
+    break;
+    case HIP_API_ID_hipExtGraphExecDumpCreate:
+      oss << "hipExtGraphExecDumpCreate(";
+      oss << "graphExec="; roctracer::hip_support::detail::operator<<(oss, data->args.hipExtGraphExecDumpCreate.graphExec);
+      oss << ", flags="; roctracer::hip_support::detail::operator<<(oss, data->args.hipExtGraphExecDumpCreate.flags);
+      if (data->args.hipExtGraphExecDumpCreate.dumpOut == NULL) oss << ", dumpOut=NULL";
+      else { oss << ", dumpOut="; roctracer::hip_support::detail::operator<<(oss, data->args.hipExtGraphExecDumpCreate.dumpOut__val); }
+      oss << ")";
+    break;
+    case HIP_API_ID_hipExtGraphExecDumpDestroy:
+      oss << "hipExtGraphExecDumpDestroy(";
+      oss << "dump="; roctracer::hip_support::detail::operator<<(oss, data->args.hipExtGraphExecDumpDestroy.dump);
+      oss << ")";
+    break;
+    case HIP_API_ID_hipExtGraphExecDumpGet:
+      oss << "hipExtGraphExecDumpGet(";
+      oss << "dump="; roctracer::hip_support::detail::operator<<(oss, data->args.hipExtGraphExecDumpGet.dump);
+      oss << ", query="; roctracer::hip_support::detail::operator<<(oss, data->args.hipExtGraphExecDumpGet.query);
+      oss << ", index="; roctracer::hip_support::detail::operator<<(oss, data->args.hipExtGraphExecDumpGet.index);
+      if (data->args.hipExtGraphExecDumpGet.result == NULL) oss << ", result=NULL";
+      else { oss << ", result="; roctracer::hip_support::detail::operator<<(oss, data->args.hipExtGraphExecDumpGet.result__val); }
       oss << ")";
     break;
     case HIP_API_ID_hipExtLaunchKernel:

--- a/projects/clr/hipamd/src/CMakeLists.txt
+++ b/projects/clr/hipamd/src/CMakeLists.txt
@@ -104,6 +104,7 @@ target_sources(amdhip64 PRIVATE
   hip_global.cpp
   hip_graph_internal.cpp
   hip_graph.cpp
+  hip_graph_dump.cpp
   hip_hmm.cpp
   hip_intercept.cpp
   hip_log.cpp

--- a/projects/clr/hipamd/src/amdhip.def.in
+++ b/projects/clr/hipamd/src/amdhip.def.in
@@ -440,6 +440,9 @@ hipGraphReleaseUserObject
 hipLaunchHostFunc
 hipLaunchHostFunc_spt
 hipGraphDebugDotPrint
+hipExtGraphExecDumpCreate
+hipExtGraphExecDumpGet
+hipExtGraphExecDumpDestroy
 hipGraphKernelNodeCopyAttributes
 hipGraphNodeGetEnabled
 hipGraphNodeSetEnabled

--- a/projects/clr/hipamd/src/hip_graph_dump.cpp
+++ b/projects/clr/hipamd/src/hip_graph_dump.cpp
@@ -1,0 +1,464 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "hip_graph_internal.hpp"
+#include "hip_global.hpp"
+
+#include "device/devprogram.hpp"
+#include "device/devkernel.hpp"
+#include "platform/kernel.hpp"
+#include "platform/program.hpp"
+
+#include <sstream>
+#include <iomanip>
+#include <unordered_map>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// In-memory dump structure (full definition; hip_runtime_api.h has the typedef)
+// ---------------------------------------------------------------------------
+struct hipExtGraphExecDump_st {
+  std::string jsonContent;
+  // Insertion-ordered list of hashes (for stable indexed access)
+  std::vector<std::string> codeObjectOrder;
+  // Hash -> binary blob (for O(1) dedup lookup)
+  std::unordered_map<std::string, std::vector<uint8_t>> codeObjects;
+};
+
+namespace hip {
+
+// ---------------------------------------------------------------------------
+// JSON helper — lightweight JSON writer (no external dependency)
+// ---------------------------------------------------------------------------
+class JsonWriter {
+ public:
+  JsonWriter() : indent_(0), needsComma_(false) {}
+
+  void beginObject() {
+    maybeComma();
+    out_ << "{\n";
+    indent_ += 2;
+    needsComma_ = false;
+  }
+
+  void endObject() {
+    out_ << "\n";
+    indent_ -= 2;
+    writeIndent();
+    out_ << "}";
+    needsComma_ = true;
+  }
+
+  void beginArray(const char* key) {
+    maybeComma();
+    writeIndent();
+    out_ << "\"" << key << "\": [\n";
+    indent_ += 2;
+    needsComma_ = false;
+  }
+
+  void beginArrayItem() {
+    maybeComma();
+    writeIndent();
+    out_ << "{\n";
+    indent_ += 2;
+    needsComma_ = false;
+  }
+
+  void endArrayItem() {
+    out_ << "\n";
+    indent_ -= 2;
+    writeIndent();
+    out_ << "}";
+    needsComma_ = true;
+  }
+
+  void endArray() {
+    out_ << "\n";
+    indent_ -= 2;
+    writeIndent();
+    out_ << "]";
+    needsComma_ = true;
+  }
+
+  void writeInt(const char* key, int64_t value) {
+    maybeComma();
+    writeIndent();
+    out_ << "\"" << key << "\": " << value;
+    needsComma_ = true;
+  }
+
+  void writeUint(const char* key, uint64_t value) {
+    maybeComma();
+    writeIndent();
+    out_ << "\"" << key << "\": " << value;
+    needsComma_ = true;
+  }
+
+  void writeString(const char* key, const std::string& value) {
+    maybeComma();
+    writeIndent();
+    out_ << "\"" << key << "\": \"" << escapeJson(value) << "\"";
+    needsComma_ = true;
+  }
+
+  void writeBool(const char* key, bool value) {
+    maybeComma();
+    writeIndent();
+    out_ << "\"" << key << "\": " << (value ? "true" : "false");
+    needsComma_ = true;
+  }
+
+  // Write an inline object for dim3
+  void writeDim3(const char* key, uint32_t x, uint32_t y, uint32_t z) {
+    maybeComma();
+    writeIndent();
+    out_ << "\"" << key << "\": { \"x\": " << x << ", \"y\": " << y << ", \"z\": " << z << " }";
+    needsComma_ = true;
+  }
+
+  // Write an array of ints inline
+  void writeIntArray(const char* key, const std::vector<int>& values) {
+    maybeComma();
+    writeIndent();
+    out_ << "\"" << key << "\": [";
+    for (size_t i = 0; i < values.size(); i++) {
+      if (i > 0) out_ << ", ";
+      out_ << values[i];
+    }
+    out_ << "]";
+    needsComma_ = true;
+  }
+
+  std::string str() const { return out_.str(); }
+
+ private:
+  std::ostringstream out_;
+  int indent_;
+  bool needsComma_;
+
+  void writeIndent() {
+    for (int i = 0; i < indent_; i++) out_ << ' ';
+  }
+
+  void maybeComma() {
+    if (needsComma_) out_ << ",\n";
+  }
+
+  static std::string escapeJson(const std::string& s) {
+    std::string result;
+    result.reserve(s.size());
+    for (char c : s) {
+      switch (c) {
+        case '"':  result += "\\\""; break;
+        case '\\': result += "\\\\"; break;
+        case '\n': result += "\\n";  break;
+        case '\r': result += "\\r";  break;
+        case '\t': result += "\\t";  break;
+        default:   result += c;      break;
+      }
+    }
+    return result;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static std::string nodeTypeToString(hipGraphNodeType type) {
+  switch (type) {
+    case hipGraphNodeTypeKernel:             return "kernel";
+    case hipGraphNodeTypeMemcpy:             return "memcpy";
+    case hipGraphNodeTypeMemset:             return "memset";
+    case hipGraphNodeTypeHost:               return "host";
+    case hipGraphNodeTypeGraph:              return "child_graph";
+    case hipGraphNodeTypeEmpty:              return "empty";
+    case hipGraphNodeTypeWaitEvent:          return "wait_event";
+    case hipGraphNodeTypeEventRecord:        return "event_record";
+    case hipGraphNodeTypeExtSemaphoreSignal: return "ext_semaphore_signal";
+    case hipGraphNodeTypeExtSemaphoreWait:   return "ext_semaphore_wait";
+    case hipGraphNodeTypeMemAlloc:           return "mem_alloc";
+    case hipGraphNodeTypeMemFree:            return "mem_free";
+    default:                                 return "unknown";
+  }
+}
+
+static std::string bytesToHex(const void* data, size_t size) {
+  std::ostringstream oss;
+  oss << "0x";
+  // Little-endian: dump bytes from high to low for natural numeric representation
+  const uint8_t* bytes = static_cast<const uint8_t*>(data);
+  for (size_t i = size; i > 0; i--) {
+    oss << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(bytes[i - 1]);
+  }
+  return oss.str();
+}
+
+// Simple hash for code object deduplication (FNV-1a 64-bit)
+static std::string hashCodeObject(const void* data, size_t size) {
+  uint64_t hash = 0xcbf29ce484222325ULL;
+  const uint8_t* bytes = static_cast<const uint8_t*>(data);
+  for (size_t i = 0; i < size; i++) {
+    hash ^= bytes[i];
+    hash *= 0x100000001b3ULL;
+  }
+  std::ostringstream oss;
+  oss << std::hex << std::setfill('0') << std::setw(16) << hash;
+  return oss.str();
+}
+
+// ---------------------------------------------------------------------------
+// GraphExec::BuildDump() — build in-memory dump, no file I/O
+// ---------------------------------------------------------------------------
+
+hipExtGraphExecDump_t GraphExec::BuildDump(unsigned int flags) const {
+  hipExtGraphExecDump_st* dump = new (std::nothrow) hipExtGraphExecDump_st();
+  if (dump == nullptr) {
+    return nullptr;
+  }
+
+  JsonWriter json;
+  json.beginObject();
+  json.writeInt("format_version", 1);
+
+  // Count kernel nodes
+  size_t kernelNodeCount = 0;
+  for (const auto& node : topoOrder_) {
+    if (node->GetType() == hipGraphNodeTypeKernel) {
+      kernelNodeCount++;
+    }
+  }
+
+  json.writeUint("node_count", topoOrder_.size());
+  json.writeUint("kernel_node_count", kernelNodeCount);
+
+  json.beginArray("nodes");
+
+  for (const auto& node : topoOrder_) {
+    json.beginArrayItem();
+    json.writeInt("id", node->GetID());
+    json.writeString("type", nodeTypeToString(node->GetType()));
+    json.writeBool("enabled", node->GetEnabled() != 0);
+
+    // Kernel node: dump dispatch dims, arguments, code objects
+    if (node->GetType() == hipGraphNodeTypeKernel) {
+      GraphKernelNode* kernelNode = static_cast<GraphKernelNode*>(node);
+
+      // Get kernel params via public accessor
+      hipKernelNodeParams kparams = {};
+      kernelNode->GetParams(&kparams);
+
+      // Resolve the kernel function via public static method
+      hipFunction_t func = GraphKernelNode::getFunc(kparams, node->GetDeviceId());
+
+      if (func) {
+        amd::Kernel* kernel = hip::asKernel(func);
+        // Trim trailing whitespace and null bytes from kernel name
+        const std::string& rawName = kernel->name();
+        size_t len = rawName.size();
+        while (len > 0 && (rawName[len - 1] == ' ' || rawName[len - 1] == '\0')) len--;
+        if (len == rawName.size()) {
+          json.writeString("kernel_name", rawName);
+        } else {
+          json.writeString("kernel_name", rawName.substr(0, len));
+        }
+
+        // Dispatch dimensions
+        if (flags & hipExtGraphExecDumpFlagsDispatch) {
+          json.writeDim3("gridDim",  kparams.gridDim.x,  kparams.gridDim.y,  kparams.gridDim.z);
+          json.writeDim3("blockDim", kparams.blockDim.x, kparams.blockDim.y, kparams.blockDim.z);
+          json.writeUint("sharedMemBytes", kparams.sharedMemBytes);
+        }
+
+        // Kernel arguments
+        if (flags & hipExtGraphExecDumpFlagsKernelArgs) {
+          const amd::KernelSignature& sig = kernel->signature();
+          json.beginArray("arguments");
+
+          for (uint32_t i = 0; i < sig.numParameters(); i++) {
+            const auto& desc = sig.at(i);
+
+            json.beginArrayItem();
+            json.writeUint("index", i);
+            json.writeString("name", desc.name_);
+            json.writeString("typeName", desc.typeName_);
+            json.writeUint("size", desc.size_);
+            json.writeUint("offset", desc.offset_);
+
+            bool isPointer = (desc.type_ == T_POINTER) ||
+                             (desc.info_.oclObject_ ==
+                              amd::KernelParameterDescriptor::MemoryObject);
+            bool isImage = (desc.info_.oclObject_ ==
+                            amd::KernelParameterDescriptor::ImageObject);
+            bool isSampler = (desc.info_.oclObject_ ==
+                              amd::KernelParameterDescriptor::SamplerObject);
+
+            if (isPointer) {
+              json.writeString("kind", "pointer");
+              json.writeString("value", "PTR");
+            } else if (isImage) {
+              json.writeString("kind", "image");
+              json.writeString("value", "IMG");
+            } else if (isSampler) {
+              json.writeString("kind", "sampler");
+              json.writeString("value", "SAMPLER");
+            } else {
+              json.writeString("kind", "value");
+              // Read actual value from captured kernel params
+              std::string hexValue = "unknown";
+              if (kparams.kernelParams != nullptr && kparams.kernelParams[i] != nullptr) {
+                hexValue = bytesToHex(kparams.kernelParams[i], desc.size_);
+              } else if (kparams.extra != nullptr && kparams.extra[1] != nullptr) {
+                // Extra path: flat buffer at extra[1], read at desc.offset_
+                const uint8_t* extraBuf = static_cast<const uint8_t*>(kparams.extra[1]);
+                hexValue = bytesToHex(extraBuf + desc.offset_, desc.size_);
+              }
+              json.writeString("value", hexValue);
+            }
+
+            json.endArrayItem();
+          }
+
+          json.endArray();  // arguments
+        }
+
+        // Code objects
+        if (flags & hipExtGraphExecDumpFlagsCodeObjects) {
+          amd::Program& prog = kernel->program();
+          const amd::Device& device = *g_devices[node->GetDeviceId()]->devices()[0];
+          device::Program* devProg = prog.getDeviceProgram(device);
+
+          if (devProg != nullptr) {
+            auto bin = devProg->binary();
+            const void* image = bin.first;
+            size_t imageSize = bin.second;
+
+            if (image != nullptr && imageSize > 0) {
+              std::string hash = hashCodeObject(image, imageSize);
+
+              // Store binary in-memory, deduplicated by hash
+              if (dump->codeObjects.find(hash) == dump->codeObjects.end()) {
+                const uint8_t* imgBytes = static_cast<const uint8_t*>(image);
+                dump->codeObjects[hash] = std::vector<uint8_t>(imgBytes, imgBytes + imageSize);
+                dump->codeObjectOrder.push_back(hash);
+              }
+
+              // JSON references the hash so callers know which binary to associate
+              json.writeString("code_object_hash", hash);
+              json.writeUint("code_object_size", imageSize);
+            }
+          }
+        }
+      } else {
+        json.writeString("kernel_name", "unresolved");
+      }
+    }
+
+    // Dependencies
+    if (flags & hipExtGraphExecDumpFlagsDeps) {
+      const auto& deps = node->GetDependencies();
+      std::vector<int> depIds;
+      depIds.reserve(deps.size());
+      for (const auto& dep : deps) {
+        depIds.push_back(dep->GetID());
+      }
+      json.writeIntArray("dependencies", depIds);
+
+      const auto& edges = node->GetEdges();
+      std::vector<int> edgeIds;
+      edgeIds.reserve(edges.size());
+      for (const auto& edge : edges) {
+        edgeIds.push_back(edge->GetID());
+      }
+      json.writeIntArray("dependents", edgeIds);
+    }
+
+    json.endArrayItem();
+  }
+
+  json.endArray();  // nodes
+  // Write code object count
+  json.writeUint("code_object_count", dump->codeObjects.size());
+  json.endObject();
+
+  dump->jsonContent = json.str();
+  return dump;
+}
+
+}  // namespace hip
+
+// ---------------------------------------------------------------------------
+// Public HIP APIs
+// ---------------------------------------------------------------------------
+
+hipError_t hipExtGraphExecDumpCreate(hipGraphExec_t graphExec, unsigned int flags,
+                                     hipExtGraphExecDump_t* dumpOut) {
+  HIP_INIT_API(hipExtGraphExecDumpCreate, graphExec, flags, dumpOut);
+
+  if (graphExec == nullptr || dumpOut == nullptr) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+
+  hip::GraphExec* exec = reinterpret_cast<hip::GraphExec*>(graphExec);
+  if (!hip::GraphExec::isGraphExecValid(exec)) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+
+  *dumpOut = exec->BuildDump(flags);
+  HIP_RETURN(*dumpOut != nullptr ? hipSuccess : hipErrorOutOfMemory);
+}
+
+hipError_t hipExtGraphExecDumpGet(hipExtGraphExecDump_t dump,
+                                   hipExtGraphExecDumpQuery_t query,
+                                   size_t index,
+                                   hipExtGraphExecDumpResult_t* result) {
+  HIP_INIT_API(hipExtGraphExecDumpGet, dump, query, index, result);
+
+  if (dump == nullptr || result == nullptr) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+
+  switch (query) {
+    case hipExtGraphExecDumpQueryJson:
+      result->json.ptr = dump->jsonContent.c_str();
+      result->json.len = dump->jsonContent.size();
+      break;
+
+    case hipExtGraphExecDumpQueryCodeObjectCount:
+      result->count = dump->codeObjectOrder.size();
+      break;
+
+    case hipExtGraphExecDumpQueryCodeObject:
+      if (index >= dump->codeObjectOrder.size()) {
+        HIP_RETURN(hipErrorInvalidValue);
+      }
+      {
+        const std::string& h = dump->codeObjectOrder[index];
+        const auto& blob = dump->codeObjects.at(h);
+        result->codeObject.hash = h.c_str();
+        result->codeObject.data = blob.data();
+        result->codeObject.size = blob.size();
+      }
+      break;
+
+    default:
+      HIP_RETURN(hipErrorInvalidValue);
+  }
+
+  HIP_RETURN(hipSuccess);
+}
+
+hipError_t hipExtGraphExecDumpDestroy(hipExtGraphExecDump_t dump) {
+  HIP_INIT_API(hipExtGraphExecDumpDestroy, dump);
+
+  if (dump == nullptr) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+
+  delete dump;
+  HIP_RETURN(hipSuccess);
+}

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -998,6 +998,9 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
   // Capture GPU Packets from graph commands
   hipError_t CaptureAQLPackets();
   hipError_t UpdateAQLPacket(hip::GraphNode* node);
+  // Build an in-memory dump of this graph exec (no file I/O).
+  // Caller must eventually pass the result to hipExtGraphExecDumpDestroy.
+  hipExtGraphExecDump_t BuildDump(unsigned int flags) const;
   // Handle packetBatches_ updates when nodes are enabled/disabled
   hipError_t UpdatePacketBatchesForNodeEnableDisable(hip::GraphNode* node, bool isEnabled);
   // Kenrel arg manger is for the entire graph.

--- a/projects/clr/hipamd/src/hip_hcc.map.in
+++ b/projects/clr/hipamd/src/hip_hcc.map.in
@@ -500,6 +500,9 @@ global:
     hipLaunchHostFunc_spt;
     hipRegisterTracerCallback;
     hipGraphDebugDotPrint;
+    hipExtGraphExecDumpCreate;
+    hipExtGraphExecDumpGet;
+    hipExtGraphExecDumpDestroy;
     hipGraphKernelNodeCopyAttributes;
     hipGraphNodeGetEnabled;
     hipGraphNodeSetEnabled;

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -1661,3 +1661,18 @@ graph:
   Unit_hipEventSynchronize_ThreadLocalCapture_DefaultMode_CapturedEvent: *level_2
   Unit_hipEventQuery_SameThread_GlobalCapture: *level_2
   Unit_hipEventQuery_SameThread_RelaxedCapture: *level_2
+  Unit_hipExtGraphExecDump_Negative:
+    <<: *level_2
+    tags: [exec]
+  Unit_hipExtGraphExecDump_ScalarArgs:
+    <<: *level_2
+    tags: [exec]
+  Unit_hipExtGraphExecDump_ArrayArg:
+    <<: *level_2
+    tags: [exec]
+  Unit_hipExtGraphExecDump_MultiNodeDeps:
+    <<: *level_2
+    tags: [exec]
+  Unit_hipExtGraphExecDump_FlagsControl:
+    <<: *level_2
+    tags: [exec]

--- a/projects/hip-tests/catch/unit/graph/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/graph/CMakeLists.txt
@@ -152,6 +152,8 @@ if(HIP_PLATFORM MATCHES "amd")
     hipDrvGraphAddMemsetNode.cc
     # hipDrvGraphAddMemcpyNode not mapped to Nvidia
     hipDrvGraphAddMemcpyNode.cc
+    # hipExtGraphExecDump is AMD extension only
+    hipExtGraphExecDump.cc
   )
   set(TEST_SRC ${TEST_SRC} ${AMD_SRC})
   add_custom_target(add_Kernel.code COMMAND ${CMAKE_HIP_COMPILER} ${HIP_DEVICE_BUILD_FLAGS_NO_ARCH} ${OFFLOAD_ARCH_LIST}

--- a/projects/hip-tests/catch/unit/graph/hipExtGraphExecDump.cc
+++ b/projects/hip-tests/catch/unit/graph/hipExtGraphExecDump.cc
@@ -1,0 +1,497 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+Test Case Scenarios :
+Negative -
+1) Pass graphExec as nullptr to hipExtGraphExecDumpCreate and verify hipErrorInvalidValue.
+2) Pass dumpOut as nullptr to hipExtGraphExecDumpCreate and verify hipErrorInvalidValue.
+3) Pass dump as nullptr to hipExtGraphExecDumpGet and verify hipErrorInvalidValue.
+4) Pass result as nullptr to hipExtGraphExecDumpGet and verify hipErrorInvalidValue.
+5) Pass out-of-range index with CodeObject query and verify hipErrorInvalidValue.
+6) Pass invalid query enum to hipExtGraphExecDumpGet and verify hipErrorInvalidValue.
+7) Pass dump as nullptr to hipExtGraphExecDumpDestroy and verify hipErrorInvalidValue.
+Functional -
+1) Create a graph with kernel nodes that have pointer args, by-value uint args,
+   and a by-value uint16_t[8] array arg. Dump the graph exec and verify:
+   - JSON contains correct structure (node count, kernel name, dispatch dims)
+   - Pointer args are marked as "PTR"
+   - By-value uint args contain correct hex values
+   - By-value array arg contains correct hex bytes
+   - Code object binaries are accessible in-memory with valid hash and size
+2) Test with multiple kernel nodes and dependencies between them, including
+   code object deduplication across nodes sharing the same binary.
+3) Test that flags control what gets captured in the in-memory dump.
+*/
+
+#include <hip_test_common.hh>
+
+#include <sstream>
+#include <cstring>
+
+// Kernel with pointer args + by-value uint32_t scalars
+__global__ void kernel_scalar(float* output, const float* input, uint32_t count,
+                               uint32_t multiplier) {
+  uint32_t i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < count) {
+    output[i] = input[i] * multiplier;
+  }
+}
+
+// Struct to pass uint16_t[8] as a by-value argument
+struct ShortArray8 {
+  uint16_t data[8];
+};
+
+// Kernel with pointer arg + by-value uint16_t[8] array arg + by-value uint32_t
+__global__ void kernel_array_arg(float* output, ShortArray8 coeffs, uint32_t n) {
+  uint32_t i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) {
+    output[i] = static_cast<float>(coeffs.data[i % 8]);
+  }
+}
+
+// Helper: get the JSON string from a dump handle
+static std::string getDumpJson(hipExtGraphExecDump_t dump) {
+  hipExtGraphExecDumpResult_t r;
+  HIP_CHECK(hipExtGraphExecDumpGet(dump, hipExtGraphExecDumpQueryJson, 0, &r));
+  return std::string(r.json.ptr, r.json.len);
+}
+
+// Helper: find a JSON string or numeric value for a key (simple substring search)
+static std::string findJsonValue(const std::string& json, const std::string& key) {
+  std::string searchKey = "\"" + key + "\": ";
+  auto pos = json.find(searchKey);
+  if (pos == std::string::npos) return "";
+  pos += searchKey.size();
+  if (json[pos] == '"') {
+    pos++;
+    auto end = json.find('"', pos);
+    return json.substr(pos, end - pos);
+  } else {
+    auto end = json.find_first_of(",}\n", pos);
+    return json.substr(pos, end - pos);
+  }
+}
+
+// Helper: count occurrences of a substring
+static int countOccurrences(const std::string& str, const std::string& sub) {
+  int count = 0;
+  size_t pos = 0;
+  while ((pos = str.find(sub, pos)) != std::string::npos) {
+    count++;
+    pos += sub.size();
+  }
+  return count;
+}
+
+/* Test verifies hipExtGraphExecDumpCreate/Get/Destroy negative scenarios. */
+HIP_TEST_CASE(Unit_hipExtGraphExecDump_Negative) {
+  hipGraph_t graph;
+  hipGraphExec_t graphExec;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+
+  // Add an empty node so the graph can be instantiated
+  hipGraphNode_t emptyNode;
+  HIP_CHECK(hipGraphAddEmptyNode(&emptyNode, graph, nullptr, 0));
+  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  hipExtGraphExecDump_t dump = nullptr;
+
+  SECTION("hipExtGraphExecDumpCreate: graphExec nullptr") {
+    HIP_CHECK_ERROR(hipExtGraphExecDumpCreate(nullptr, 0, &dump), hipErrorInvalidValue);
+  }
+
+  SECTION("hipExtGraphExecDumpCreate: dumpOut nullptr") {
+    HIP_CHECK_ERROR(hipExtGraphExecDumpCreate(graphExec, 0, nullptr), hipErrorInvalidValue);
+  }
+
+  // Create a valid dump for the remaining negative tests
+  HIP_CHECK(hipExtGraphExecDumpCreate(graphExec, hipExtGraphExecDumpFlagsNone, &dump));
+  REQUIRE(dump != nullptr);
+
+  SECTION("hipExtGraphExecDumpGet: dump nullptr") {
+    hipExtGraphExecDumpResult_t r;
+    HIP_CHECK_ERROR(hipExtGraphExecDumpGet(nullptr, hipExtGraphExecDumpQueryJson, 0, &r),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("hipExtGraphExecDumpGet: result nullptr") {
+    HIP_CHECK_ERROR(hipExtGraphExecDumpGet(dump, hipExtGraphExecDumpQueryJson, 0, nullptr),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("hipExtGraphExecDumpGet: CodeObject out-of-range index") {
+    hipExtGraphExecDumpResult_t r;
+    // No code objects captured (FlagsNone), so any index is out of range
+    HIP_CHECK_ERROR(hipExtGraphExecDumpGet(dump, hipExtGraphExecDumpQueryCodeObject, 0, &r),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("hipExtGraphExecDumpGet: invalid query enum") {
+    hipExtGraphExecDumpResult_t r;
+    HIP_CHECK_ERROR(
+        hipExtGraphExecDumpGet(dump, static_cast<hipExtGraphExecDumpQuery_t>(999), 0, &r),
+        hipErrorInvalidValue);
+  }
+
+  SECTION("hipExtGraphExecDumpDestroy: dump nullptr") {
+    HIP_CHECK_ERROR(hipExtGraphExecDumpDestroy(nullptr), hipErrorInvalidValue);
+  }
+
+  HIP_CHECK(hipExtGraphExecDumpDestroy(dump));
+  HIP_CHECK(hipGraphExecDestroy(graphExec));
+  HIP_CHECK(hipGraphDestroy(graph));
+}
+
+/* Test verifies hipExtGraphExecDump captures by-value scalar args correctly. */
+HIP_TEST_CASE(Unit_hipExtGraphExecDump_ScalarArgs) {
+  constexpr int N = 1024;
+  constexpr int blockSize = 256;
+  constexpr int gridSize = (N + blockSize - 1) / blockSize;
+
+  float *d_input, *d_output;
+  HIP_CHECK(hipMalloc(&d_input, N * sizeof(float)));
+  HIP_CHECK(hipMalloc(&d_output, N * sizeof(float)));
+
+  hipGraph_t graph;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+
+  uint32_t count = N;        // 0x00000400
+  uint32_t multiplier = 42;  // 0x0000002a
+  void* args[] = {&d_output, &d_input, &count, &multiplier};
+
+  hipKernelNodeParams kparams{};
+  kparams.func = reinterpret_cast<void*>(kernel_scalar);
+  kparams.gridDim = dim3(gridSize);
+  kparams.blockDim = dim3(blockSize);
+  kparams.kernelParams = reinterpret_cast<void**>(args);
+  kparams.sharedMemBytes = 0;
+
+  hipGraphNode_t kNode;
+  HIP_CHECK(hipGraphAddKernelNode(&kNode, graph, nullptr, 0, &kparams));
+
+  hipGraphExec_t graphExec;
+  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  hipExtGraphExecDump_t dump = nullptr;
+  HIP_CHECK(hipExtGraphExecDumpCreate(graphExec, hipExtGraphExecDumpFlagsAll, &dump));
+  REQUIRE(dump != nullptr);
+
+  std::string json = getDumpJson(dump);
+  REQUIRE(!json.empty());
+  INFO("JSON content: " << json);
+
+  // Verify node counts
+  REQUIRE(findJsonValue(json, "node_count") == "1");
+  REQUIRE(findJsonValue(json, "kernel_node_count") == "1");
+
+  // Verify kernel name
+  REQUIRE(json.find("kernel_scalar") != std::string::npos);
+
+  // Verify dispatch dimensions
+  REQUIRE(json.find("\"gridDim\": { \"x\": 4, \"y\": 1, \"z\": 1 }") != std::string::npos);
+  REQUIRE(json.find("\"blockDim\": { \"x\": 256, \"y\": 1, \"z\": 1 }") != std::string::npos);
+
+  // Verify pointer args (output, input) are marked as PTR
+  REQUIRE(countOccurrences(json, "\"kind\": \"pointer\"") == 2);
+  REQUIRE(countOccurrences(json, "\"value\": \"PTR\"") == 2);
+
+  // Verify by-value args (count, multiplier) with correct hex values
+  REQUIRE(countOccurrences(json, "\"kind\": \"value\"") == 2);
+  REQUIRE(json.find("\"0x00000400\"") != std::string::npos);  // count = 1024
+  REQUIRE(json.find("\"0x0000002a\"") != std::string::npos);  // multiplier = 42
+
+  // Verify code objects are accessible in-memory
+  hipExtGraphExecDumpResult_t r;
+  HIP_CHECK(hipExtGraphExecDumpGet(dump, hipExtGraphExecDumpQueryCodeObjectCount, 0, &r));
+  size_t coCount = r.count;  // save before loop — each CodeObject call overwrites the union
+  REQUIRE(coCount > 0);
+  for (size_t i = 0; i < coCount; i++) {
+    HIP_CHECK(hipExtGraphExecDumpGet(dump, hipExtGraphExecDumpQueryCodeObject, i, &r));
+    REQUIRE(r.codeObject.hash != nullptr);
+    REQUIRE(r.codeObject.data != nullptr);
+    REQUIRE(r.codeObject.size > 0);
+    REQUIRE(strlen(r.codeObject.hash) == 16);  // 16-char hex hash
+  }
+
+  // Verify the hash is referenced in the JSON
+  REQUIRE(json.find("code_object_hash") != std::string::npos);
+
+  HIP_CHECK(hipExtGraphExecDumpDestroy(dump));
+  HIP_CHECK(hipGraphExecDestroy(graphExec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(d_input));
+  HIP_CHECK(hipFree(d_output));
+}
+
+/* Test verifies hipExtGraphExecDump captures a by-value uint16_t[8] array arg. */
+HIP_TEST_CASE(Unit_hipExtGraphExecDump_ArrayArg) {
+  constexpr int N = 256;
+  constexpr int blockSize = 64;
+  constexpr int gridSize = (N + blockSize - 1) / blockSize;
+
+  float* d_output;
+  HIP_CHECK(hipMalloc(&d_output, N * sizeof(float)));
+
+  hipGraph_t graph;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+
+  ShortArray8 coeffs;
+  coeffs.data[0] = 0x1111;
+  coeffs.data[1] = 0x2222;
+  coeffs.data[2] = 0x3333;
+  coeffs.data[3] = 0x4444;
+  coeffs.data[4] = 0x5555;
+  coeffs.data[5] = 0x6666;
+  coeffs.data[6] = 0x7777;
+  coeffs.data[7] = 0x8888;
+  uint32_t n = N;
+
+  void* args[] = {&d_output, &coeffs, &n};
+  hipKernelNodeParams kparams{};
+  kparams.func = reinterpret_cast<void*>(kernel_array_arg);
+  kparams.gridDim = dim3(gridSize);
+  kparams.blockDim = dim3(blockSize);
+  kparams.kernelParams = reinterpret_cast<void**>(args);
+  kparams.sharedMemBytes = 0;
+
+  hipGraphNode_t kNode;
+  HIP_CHECK(hipGraphAddKernelNode(&kNode, graph, nullptr, 0, &kparams));
+
+  hipGraphExec_t graphExec;
+  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  hipExtGraphExecDump_t dump = nullptr;
+  HIP_CHECK(hipExtGraphExecDumpCreate(graphExec, hipExtGraphExecDumpFlagsAll, &dump));
+  REQUIRE(dump != nullptr);
+
+  std::string json = getDumpJson(dump);
+  REQUIRE(!json.empty());
+  INFO("JSON content: " << json);
+
+  // Verify kernel name
+  REQUIRE(json.find("kernel_array_arg") != std::string::npos);
+
+  // Verify pointer arg (d_output) is marked as PTR
+  REQUIRE(countOccurrences(json, "\"kind\": \"pointer\"") == 1);
+
+  // Verify by-value args: the struct (16 bytes) + uint32_t n
+  REQUIRE(countOccurrences(json, "\"kind\": \"value\"") >= 2);
+
+  // Verify n = 256 = 0x00000100
+  REQUIRE(json.find("\"0x00000100\"") != std::string::npos);
+
+  // Verify the array bytes are present in hex.
+  // Little-endian stored, big-endian display: 0x88887777666655554444333322221111
+  REQUIRE(json.find("88887777666655554444333322221111") != std::string::npos);
+
+  HIP_CHECK(hipExtGraphExecDumpDestroy(dump));
+  HIP_CHECK(hipGraphExecDestroy(graphExec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(d_output));
+}
+
+/* Test verifies hipExtGraphExecDump with multiple nodes and dependencies. */
+HIP_TEST_CASE(Unit_hipExtGraphExecDump_MultiNodeDeps) {
+  constexpr int N = 512;
+  constexpr int blockSize = 128;
+  constexpr int gridSize = (N + blockSize - 1) / blockSize;
+
+  float *d_buf1, *d_buf2;
+  HIP_CHECK(hipMalloc(&d_buf1, N * sizeof(float)));
+  HIP_CHECK(hipMalloc(&d_buf2, N * sizeof(float)));
+
+  hipGraph_t graph;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+
+  // Node 0: kernel_scalar (no deps)
+  uint32_t count = N;
+  uint32_t mult1 = 7;
+  void* args0[] = {&d_buf1, &d_buf2, &count, &mult1};
+  hipKernelNodeParams kp0{};
+  kp0.func = reinterpret_cast<void*>(kernel_scalar);
+  kp0.gridDim = dim3(gridSize);
+  kp0.blockDim = dim3(blockSize);
+  kp0.kernelParams = reinterpret_cast<void**>(args0);
+
+  hipGraphNode_t node0;
+  HIP_CHECK(hipGraphAddKernelNode(&node0, graph, nullptr, 0, &kp0));
+
+  // Node 1: kernel_scalar (depends on node0)
+  uint32_t mult2 = 13;
+  void* args1[] = {&d_buf2, &d_buf1, &count, &mult2};
+  hipKernelNodeParams kp1{};
+  kp1.func = reinterpret_cast<void*>(kernel_scalar);
+  kp1.gridDim = dim3(gridSize);
+  kp1.blockDim = dim3(blockSize);
+  kp1.kernelParams = reinterpret_cast<void**>(args1);
+
+  hipGraphNode_t node1;
+  HIP_CHECK(hipGraphAddKernelNode(&node1, graph, &node0, 1, &kp1));
+
+  // Node 2: kernel_array_arg (depends on node0, parallel with node1)
+  ShortArray8 coeffs;
+  for (int i = 0; i < 8; i++) coeffs.data[i] = static_cast<uint16_t>(i + 1);
+  uint32_t n2 = N;
+  void* args2[] = {&d_buf2, &coeffs, &n2};
+  hipKernelNodeParams kp2{};
+  kp2.func = reinterpret_cast<void*>(kernel_array_arg);
+  kp2.gridDim = dim3(gridSize);
+  kp2.blockDim = dim3(blockSize);
+  kp2.kernelParams = reinterpret_cast<void**>(args2);
+
+  hipGraphNode_t node2;
+  HIP_CHECK(hipGraphAddKernelNode(&node2, graph, &node0, 1, &kp2));
+
+  hipGraphExec_t graphExec;
+  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  hipExtGraphExecDump_t dump = nullptr;
+  HIP_CHECK(hipExtGraphExecDumpCreate(graphExec, hipExtGraphExecDumpFlagsAll, &dump));
+  REQUIRE(dump != nullptr);
+
+  std::string json = getDumpJson(dump);
+  REQUIRE(!json.empty());
+  INFO("JSON content: " << json);
+
+  // Verify 3 nodes
+  REQUIRE(findJsonValue(json, "node_count") == "3");
+  REQUIRE(findJsonValue(json, "kernel_node_count") == "3");
+
+  // Verify node0 has no deps; node1 and node2 both depend on node0
+  REQUIRE(json.find("\"dependencies\": []") != std::string::npos);
+  REQUIRE(countOccurrences(json, "\"dependencies\": [0]") == 2);
+
+  // Verify both kernel names appear
+  REQUIRE(json.find("kernel_scalar") != std::string::npos);
+  REQUIRE(json.find("kernel_array_arg") != std::string::npos);
+
+  // Verify by-value scalar args: mult1=7 (0x00000007), mult2=13 (0x0000000d)
+  REQUIRE(json.find("\"0x00000007\"") != std::string::npos);
+  REQUIRE(json.find("\"0x0000000d\"") != std::string::npos);
+
+  // Verify code object deduplication: two kernels but kernel_scalar appears twice —
+  // only unique binaries are stored, so expect at most 2 code objects
+  hipExtGraphExecDumpResult_t r;
+  HIP_CHECK(hipExtGraphExecDumpGet(dump, hipExtGraphExecDumpQueryCodeObjectCount, 0, &r));
+  size_t coCount = r.count;  // save before loop — each CodeObject call overwrites the union
+  REQUIRE(coCount > 0);
+  REQUIRE(coCount <= 2);
+
+  HIP_CHECK(hipExtGraphExecDumpDestroy(dump));
+  HIP_CHECK(hipGraphExecDestroy(graphExec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(d_buf1));
+  HIP_CHECK(hipFree(d_buf2));
+}
+
+/* Test verifies flags control what gets captured in the in-memory dump. */
+HIP_TEST_CASE(Unit_hipExtGraphExecDump_FlagsControl) {
+  constexpr int N = 64;
+
+  float* d_buf;
+  HIP_CHECK(hipMalloc(&d_buf, N * sizeof(float)));
+
+  hipGraph_t graph;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+
+  uint32_t count = N;
+  uint32_t mult = 1;
+  void* args[] = {&d_buf, &d_buf, &count, &mult};
+  hipKernelNodeParams kp{};
+  kp.func = reinterpret_cast<void*>(kernel_scalar);
+  kp.gridDim = dim3(1);
+  kp.blockDim = dim3(N);
+  kp.kernelParams = reinterpret_cast<void**>(args);
+
+  hipGraphNode_t node;
+  HIP_CHECK(hipGraphAddKernelNode(&node, graph, nullptr, 0, &kp));
+
+  hipGraphExec_t graphExec;
+  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  SECTION("No flags - only basic node info") {
+    hipExtGraphExecDump_t dump = nullptr;
+    HIP_CHECK(hipExtGraphExecDumpCreate(graphExec, hipExtGraphExecDumpFlagsNone, &dump));
+    std::string json = getDumpJson(dump);
+    REQUIRE(!json.empty());
+    REQUIRE(json.find("arguments") == std::string::npos);
+    REQUIRE(json.find("gridDim") == std::string::npos);
+    REQUIRE(json.find("dependencies") == std::string::npos);
+
+    // No code objects captured
+    hipExtGraphExecDumpResult_t r;
+    HIP_CHECK(hipExtGraphExecDumpGet(dump, hipExtGraphExecDumpQueryCodeObjectCount, 0, &r));
+    REQUIRE(r.count == 0);
+
+    HIP_CHECK(hipExtGraphExecDumpDestroy(dump));
+  }
+
+  SECTION("Dispatch flag only") {
+    hipExtGraphExecDump_t dump = nullptr;
+    HIP_CHECK(hipExtGraphExecDumpCreate(graphExec, hipExtGraphExecDumpFlagsDispatch, &dump));
+    std::string json = getDumpJson(dump);
+    REQUIRE(!json.empty());
+    REQUIRE(json.find("gridDim") != std::string::npos);
+    REQUIRE(json.find("arguments") == std::string::npos);
+    HIP_CHECK(hipExtGraphExecDumpDestroy(dump));
+  }
+
+  SECTION("KernelArgs flag only") {
+    hipExtGraphExecDump_t dump = nullptr;
+    HIP_CHECK(hipExtGraphExecDumpCreate(graphExec, hipExtGraphExecDumpFlagsKernelArgs, &dump));
+    std::string json = getDumpJson(dump);
+    REQUIRE(!json.empty());
+    REQUIRE(json.find("arguments") != std::string::npos);
+    REQUIRE(json.find("gridDim") == std::string::npos);
+    HIP_CHECK(hipExtGraphExecDumpDestroy(dump));
+  }
+
+  HIP_CHECK(hipGraphExecDestroy(graphExec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(d_buf));
+}
+
+// ---------------------------------------------------------------------------
+// Example: dumping a graph exec to files on disk.
+//
+// This shows the intended end-to-end usage of the API — create a dump,
+// write the JSON metadata and ELF code objects to a directory, then clean up.
+// Uncomment and adapt as needed.
+// ---------------------------------------------------------------------------
+//
+// #include <filesystem>
+// #include <fstream>
+//
+// void dumpGraphExecToDir(hipGraphExec_t exec, const std::filesystem::path& outDir) {
+//   std::filesystem::create_directories(outDir);
+//
+//   hipExtGraphExecDump_t dump;
+//   hipExtGraphExecDumpCreate(exec, hipExtGraphExecDumpFlagsAll, &dump);
+//
+//   hipExtGraphExecDumpResult_t r;
+//
+//   // Write JSON metadata
+//   hipExtGraphExecDumpGet(dump, hipExtGraphExecDumpQueryJson, 0, &r);
+//   std::ofstream json(outDir / "graph.json");
+//   json.write(r.json.ptr, r.json.len);
+//   json.close();
+//
+//   // Write code object ELF binaries (deduplicated by content hash)
+//   hipExtGraphExecDumpGet(dump, hipExtGraphExecDumpQueryCodeObjectCount, 0, &r);
+//   size_t count = r.count;
+//   for (size_t i = 0; i < count; i++) {
+//     hipExtGraphExecDumpGet(dump, hipExtGraphExecDumpQueryCodeObject, i, &r);
+//     std::ofstream elf(outDir / (std::string(r.codeObject.hash) + ".elf"),
+//                       std::ios::binary);
+//     elf.write(reinterpret_cast<const char*>(r.codeObject.data), r.codeObject.size);
+//   }
+//
+//   hipExtGraphExecDumpDestroy(dump);
+//
+//   // Cleanup: std::filesystem::remove_all(outDir);
+// }

--- a/projects/hip/include/hip/hip_runtime_api.h
+++ b/projects/hip/include/hip/hip_runtime_api.h
@@ -9227,6 +9227,120 @@ hipError_t hipGraphReleaseUserObject(hipGraph_t graph, hipUserObject_t object,
 hipError_t hipGraphDebugDotPrint(hipGraph_t graph, const char* path, unsigned int flags);
 
 /**
+ * @brief Flags for hipExtGraphExecDump content control.
+ */
+typedef enum hipExtGraphExecDumpFlags {
+    hipExtGraphExecDumpFlagsNone        = 0x0,  ///< Dump node types and IDs only
+    hipExtGraphExecDumpFlagsCodeObjects = 0x1,  ///< Include code object ELF binaries
+    hipExtGraphExecDumpFlagsKernelArgs  = 0x2,  ///< Include kernel argument values
+    hipExtGraphExecDumpFlagsDeps        = 0x4,  ///< Include node dependency edges
+    hipExtGraphExecDumpFlagsDispatch    = 0x8,  ///< Include dispatch dimensions
+    hipExtGraphExecDumpFlagsAll         = 0xF   ///< Include everything
+} hipExtGraphExecDumpFlags;
+
+/**
+ * @brief Opaque handle to an in-memory graph exec dump.
+ *
+ * Created by hipExtGraphExecDumpCreate(), queried via hipExtGraphExecDumpGet(),
+ * and freed by hipExtGraphExecDumpDestroy().
+ */
+typedef struct hipExtGraphExecDump_st* hipExtGraphExecDump_t;
+
+/**
+ * @brief Query selector for hipExtGraphExecDumpGet().
+ */
+typedef enum hipExtGraphExecDumpQuery_e {
+    hipExtGraphExecDumpQueryJson            = 0,  ///< JSON metadata string (result.json)
+    hipExtGraphExecDumpQueryCodeObjectCount = 1,  ///< Number of unique code objects (result.count)
+    hipExtGraphExecDumpQueryCodeObject      = 2,  ///< ELF binary by index (result.codeObject)
+} hipExtGraphExecDumpQuery_t;
+
+/**
+ * @brief Result union for hipExtGraphExecDumpGet().
+ *
+ * The active field depends on the query passed to hipExtGraphExecDumpGet().
+ * All pointers are owned by the dump handle and remain valid until
+ * hipExtGraphExecDumpDestroy() is called.
+ */
+typedef struct hipExtGraphExecDumpResult_st {
+    union {
+        /** hipExtGraphExecDumpQueryJson: null-terminated JSON string and byte length. */
+        struct {
+          const char* ptr; ///< pointer to JSON string
+          size_t len;      ///< byte length of JSON string
+        } json;
+        /** hipExtGraphExecDumpQueryCodeObjectCount: number of unique ELF binaries. */
+        size_t count;
+        /** hipExtGraphExecDumpQueryCodeObject: one ELF binary, located by index. */
+        struct {
+            const char* hash;  ///< 16-char hex content hash (e.g. "3c1cad708846a399")
+            const void* data;  ///< pointer to ELF bytes
+            size_t      size;  ///< byte length of ELF
+        } codeObject;
+    };
+} hipExtGraphExecDumpResult_t;
+
+/**
+ * @brief Build an in-memory dump of a graph execution object.
+ *
+ * Captures graph structure, kernel arguments, dispatch dimensions, and code object
+ * binaries into an opaque handle. No file I/O is performed; the caller is responsible
+ * for persisting the data. The handle must be freed with hipExtGraphExecDumpDestroy().
+ *
+ * @param [in]  graphExec  The graph execution object to dump.
+ * @param [in]  flags      Bitmask of hipExtGraphExecDumpFlags controlling what to capture.
+ * @param [out] dumpOut    Output handle for the in-memory dump.
+ *
+ * @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorOutOfMemory
+ */
+hipError_t hipExtGraphExecDumpCreate(hipGraphExec_t graphExec, unsigned int flags,
+                                     hipExtGraphExecDump_t* dumpOut);
+
+/**
+ * @brief Query data from an in-memory graph exec dump.
+ *
+ * The @p query enum selects what to retrieve; @p index is only used for
+ * @ref hipExtGraphExecDumpQueryCodeObject (zero-based, must be < count) and is
+ * ignored for all other queries.
+ *
+ * Example usage:
+ * @code
+ *   hipExtGraphExecDumpResult_t r;
+ *   // JSON
+ *   hipExtGraphExecDumpGet(dump, hipExtGraphExecDumpQueryJson, 0, &r);
+ *   fwrite(r.json.ptr, 1, r.json.len, f);
+ *   // ELF count + iteration
+ *   hipExtGraphExecDumpGet(dump, hipExtGraphExecDumpQueryCodeObjectCount, 0, &r);
+ *   for (size_t i = 0; i < r.count; i++) {
+ *     hipExtGraphExecDumpGet(dump, hipExtGraphExecDumpQueryCodeObject, i, &r);
+ *     fwrite(r.codeObject.data, 1, r.codeObject.size, f);
+ *   }
+ * @endcode
+ *
+ * @param [in]  dump    Handle returned by hipExtGraphExecDumpCreate().
+ * @param [in]  query   What to retrieve (see hipExtGraphExecDumpQuery_t).
+ * @param [in]  index   Code object index for hipGraphExecDumpQueryCodeObject; 0 otherwise.
+ * @param [out] result  Output union; the relevant field is populated on success.
+ *                      When iterating code objects, copy result.count to a local variable
+ *                      before the loop — each CodeObject call overwrites the entire union.
+ *
+ * @returns #hipSuccess, #hipErrorInvalidValue
+ */
+hipError_t hipExtGraphExecDumpGet(hipExtGraphExecDump_t dump,
+                                   hipExtGraphExecDumpQuery_t query,
+                                   size_t index,
+                                   hipExtGraphExecDumpResult_t* result);
+
+/**
+ * @brief Free an in-memory graph exec dump and all associated data.
+ *
+ * @param [in] dump  Handle returned by hipExtGraphExecDumpCreate().
+ *
+ * @returns #hipSuccess, #hipErrorInvalidValue
+ */
+hipError_t hipExtGraphExecDumpDestroy(hipExtGraphExecDump_t dump);
+
+/**
  * @brief Copies attributes from source node to destination node.
  *
  * Copies attributes from source node to destination node.
@@ -9533,7 +9647,7 @@ hipError_t hipMemAddressReserve(void** ptr, size_t size, size_t alignment, void*
  * @param [in] prop - properties of the allocation.
  * @param [in] flags - currently unused, must be zero.
  * @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorNotSupported
- * 
+ *
  * This API creates a memory allocation on the target device specified through the prop structure.
  * The prop allocation type must be specified as either #hipMemAllocationTypePinned or
  * #hipMemAllocationTypeUncached.


### PR DESCRIPTION
Add a create/query/destroy API set for inspecting hipGraphExec
objects at runtime:

  - hipExtGraphExecDumpCreate()  — captures graph structure, kernel
    metadata, arguments, dispatch dimensions, code object binaries,
    and dependency edges into an opaque in-memory handle.  Content is
    controlled by a hipExtGraphExecDumpFlags bitmask.
  - hipExtGraphExecDumpGet()     — queries the handle via a tagged
    union (JSON string, code-object count, or indexed ELF binary).
  - hipExtGraphExecDumpDestroy() — frees the handle.

No file I/O is performed; the caller decides how to persist the data.
Code object ELF binaries are deduplicated by content hash (FNV-1a).

Includes profiler string registration and Catch2 unit tests covering
negative cases, scalar/array arguments, multi-node dependency graphs,
and per-flag output validation.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
