### PR TITLE
clr: Optimize memory reuse in Graph for alloc nodes

### DIFF
--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -98,10 +98,10 @@ void Device::RemoveMemoryPool(MemoryPool* pool) {
 }
 
 // ================================================================================================
-bool Device::FreeMemory(amd::Memory* memory, Stream* stream, Event* event) {
+bool Device::FreeMemory(amd::Memory* memory, Stream* stream, Event* event, bool skip_event) {
   std::scoped_lock lock(lock_);
   for (auto* pool : mem_pools_) {
-    if (pool->FreeMemory(memory, stream, event)) {
+    if (pool->FreeMemory(memory, stream, event, skip_event)) {
       return true;
     }
   }

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -2936,7 +2936,27 @@ hipError_t hipDeviceGraphMemTrim(int device) {
   if ((static_cast<size_t>(device) >= g_devices.size()) || device < 0) {
     HIP_RETURN(hipErrorInvalidDevice);
   }
-  g_devices[device]->GetGraphMemoryPool()->TrimTo(0);
+  auto* pool = g_devices[device]->GetGraphMemoryPool();
+
+  // Phase 1: Release all idle graph-cached VA mappings and decrement refcounts.
+  {
+    std::scoped_lock lock(hip::GraphExec::graphExecSetLock_);
+    for (auto* ge : hip::GraphExec::graphExecSet_) {
+      if (ge->Device() != g_devices[device] ||
+          ge->GetMemAllocNodeCount() > 0) {
+        continue;
+      }
+      for (auto* node : ge->GetNodes()) {
+        if (node->GetType() != hipGraphNodeTypeMemAlloc) continue;
+        auto* alloc_node = static_cast<hip::GraphMemAllocNode*>(node);
+        alloc_node->ReleaseCachedMapping(pool);
+      }
+    }
+  }
+
+  // Phase 2: All previously-refcounted entries now have refcount==0.
+  pool->TrimTo(0);
+
   HIP_RETURN(hipSuccess);
 }
 

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -1616,9 +1616,13 @@ hipError_t hipGraphExecDestroy(hipGraphExec_t pGraphExec) {
     HIP_RETURN(hipErrorInvalidValue);
   }
   hip::GraphExec* ge = reinterpret_cast<hip::GraphExec*>(pGraphExec);
+  {
+    // Erase from the set before releasing, so that concurrent
+    // hipDeviceGraphMemTrim cannot retain a dangling pointer.
+    std::scoped_lock lock(GraphExec::graphExecSetLock_);
+    GraphExec::graphExecSet_.erase(ge);
+  }
   ge->release();
-  std::scoped_lock lock(GraphExec::graphExecSetLock_);
-  GraphExec::graphExecSet_.erase(ge);
   HIP_RETURN(hipSuccess);
 }
 
@@ -2953,9 +2957,14 @@ hipError_t hipDeviceGraphMemTrim(int device) {
       retained_graph_execs.push_back(ge);
     }
   }
-  // Phase 2: Release all idle graph-cached VA mappings and decrement refcounts
-  // outside graphExecSetLock_.
+  // Phase 2: Release idle graph-cached VA mappings and decrement refcounts
+  // outside graphExecSetLock_. Skip graph execs that are currently executing:
+  // GraphExec::Run() retains the object for the duration of GPU work, so
+  // refcount > 2 (1 owner + 1 trim-retain + 1+ in-flight) means active.
   for (auto* ge : retained_graph_execs) {
+    if (ge->referenceCount() > 2) {
+      continue;
+    }
     for (auto* node : ge->GetNodes()) {
       if (node->GetType() != hipGraphNodeTypeMemAlloc) {
         continue;

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -2946,7 +2946,7 @@ hipError_t hipDeviceGraphMemTrim(int device) {
   {
     std::scoped_lock lock(hip::GraphExec::graphExecSetLock_);
     for (auto* ge : hip::GraphExec::graphExecSet_) {
-      if (ge->Device() != g_devices[device] || ge->GetMemAllocNodeCount() > 0) {
+      if (ge->Device() != g_devices[device]) {
         continue;
       }
       ge->retain();

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -2938,23 +2938,36 @@ hipError_t hipDeviceGraphMemTrim(int device) {
   }
   auto* pool = g_devices[device]->GetGraphMemoryPool();
 
-  // Phase 1: Release all idle graph-cached VA mappings and decrement refcounts.
+  std::vector<hip::GraphExec*> retained_graph_execs;
+  // Phase 1: Collect eligible graph execs under graphExecSetLock_ and retain them
+  // so they remain valid after dropping the lock. Do not call ReleaseCachedMapping()
+  // while holding graphExecSetLock_ because it may enqueue/await GPU work and take
+  // the graph memory pool lock.
   {
     std::scoped_lock lock(hip::GraphExec::graphExecSetLock_);
     for (auto* ge : hip::GraphExec::graphExecSet_) {
-      if (ge->Device() != g_devices[device] ||
-          ge->GetMemAllocNodeCount() > 0) {
+      if (ge->Device() != g_devices[device] || ge->GetMemAllocNodeCount() > 0) {
         continue;
       }
-      for (auto* node : ge->GetNodes()) {
-        if (node->GetType() != hipGraphNodeTypeMemAlloc) continue;
-        auto* alloc_node = static_cast<hip::GraphMemAllocNode*>(node);
-        alloc_node->ReleaseCachedMapping(pool);
-      }
+      ge->retain();
+      retained_graph_execs.push_back(ge);
     }
   }
-
-  // Phase 2: All previously-refcounted entries now have refcount==0.
+  // Phase 2: Release all idle graph-cached VA mappings and decrement refcounts
+  // outside graphExecSetLock_.
+  for (auto* ge : retained_graph_execs) {
+    for (auto* node : ge->GetNodes()) {
+      if (node->GetType() != hipGraphNodeTypeMemAlloc) {
+        continue;
+      }
+      auto* alloc_node = static_cast<hip::GraphMemAllocNode*>(node);
+      alloc_node->ReleaseCachedMapping(pool);
+    }
+  }
+  for (auto* ge : retained_graph_execs) {
+    ge->release();
+  }
+  // Phase 3: All previously-refcounted entries now have refcount==0.
   pool->TrimTo(0);
 
   HIP_RETURN(hipSuccess);

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -2240,8 +2240,15 @@ hipError_t GraphExec::Run(hip::Stream* launch_stream) {
 
   if (flags_ & hipGraphInstantiateFlagAutoFreeOnLaunch) {
     if (firstNode != nullptr) {
-      firstNode->GetParentGraph()->FreeAllMemory(launch_stream);
-      firstNode->GetParentGraph()->memalloc_nodes_ = 0;
+      auto* parentGraph = firstNode->GetParentGraph();
+      auto* pool = parentGraph->Device()->GetGraphMemoryPool();
+      for (auto* node : topoOrder_) {
+        if (node->GetType() == hipGraphNodeTypeMemAlloc) {
+          static_cast<GraphMemAllocNode*>(node)->ReleaseCachedMapping(pool);
+        }
+      }
+      parentGraph->FreeAllMemory(launch_stream);
+      parentGraph->memalloc_nodes_ = 0;
       if (!AMD_DIRECT_DISPATCH) {
         // The MemoryPool::FreeAllMemory queues a memory unmap command that for !AMD_DIRECT_DISPATCH
         // runs asynchonously. Make sure that freeAllMemory is complete before creating new commands

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -2244,7 +2244,7 @@ hipError_t GraphExec::Run(hip::Stream* launch_stream) {
       auto* pool = parentGraph->Device()->GetGraphMemoryPool();
       for (auto* node : topoOrder_) {
         if (node->GetType() == hipGraphNodeTypeMemAlloc) {
-          static_cast<GraphMemAllocNode*>(node)->ReleaseCachedMapping(pool);
+          static_cast<GraphMemAllocNode*>(node)->ReleaseCachedMapping(pool, launch_stream);
         }
       }
       parentGraph->FreeAllMemory(launch_stream);

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1606,8 +1606,8 @@ void GraphExec::PacketBatch::appendPacketToFlatBuffer(const uint8_t* pkt_raw,
   // packet until the valid header is committed with release semantics during
   // dispatch. Using type=0 (VENDOR_SPECIFIC) would be a processable packet type
   // that the CP could attempt to execute with incomplete body data.
-  static constexpr uint16_t kInvalidAqlHeader =
-      1;  // HSA_PACKET_TYPE_INVALID << HSA_PACKET_HEADER_TYPE
+  static constexpr uint16_t kInvalidAqlHeader = 1;
+       //HSA_PACKET_TYPE_INVALID << HSA_PACKET_HEADER_TYPE;
   memcpy(dst, &kInvalidAqlHeader, sizeof(kInvalidAqlHeader));
   // Zero completion signal; ApplyHwEventPatches re-patches it directly via flat_packet pointers.
   memset(dst + kSigOff, 0, sizeof(uint64_t));

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1602,8 +1602,13 @@ void GraphExec::PacketBatch::appendPacketToFlatBuffer(const uint8_t* pkt_raw,
   uint32_t fullHeader = 0;
   memcpy(&fullHeader, pkt_raw, sizeof(fullHeader));
   fullHeaders.push_back(fullHeader);
-  // Invalidate header
-  dst[0] = dst[1] = 0;
+  // Set header to HSA_PACKET_TYPE_INVALID (type=1) so the GPU CP skips this
+  // packet until the valid header is committed with release semantics during
+  // dispatch. Using type=0 (VENDOR_SPECIFIC) would be a processable packet type
+  // that the CP could attempt to execute with incomplete body data.
+  static constexpr uint16_t kInvalidAqlHeader =
+      1;  // HSA_PACKET_TYPE_INVALID << HSA_PACKET_HEADER_TYPE
+  memcpy(dst, &kInvalidAqlHeader, sizeof(kInvalidAqlHeader));
   // Zero completion signal; ApplyHwEventPatches re-patches it directly via flat_packet pointers.
   memset(dst + kSigOff, 0, sizeof(uint64_t));
 }

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -2897,17 +2897,23 @@ class GraphMemAllocNode final : public GraphNode {
 
   virtual GraphNode* clone() const final { return new GraphMemAllocNode(*this); }
 
-  void ReleaseCachedMapping(MemoryPool* pool) {
+  void ReleaseCachedMapping(MemoryPool* pool, hip::Stream* launch_stream = nullptr) {
     if (!mapped_) return;
     auto sub_obj = amd::MemObjMap::FindMemObj(node_params_.dptr);
     if (sub_obj != nullptr) {
       auto* phys = sub_obj->getUserData().phys_mem_obj;
-      auto device_id = phys ? phys->getUserData().deviceId : 0;
-      auto* stream = g_devices[device_id]->NullStream();
+      hip::Stream* stream = launch_stream;
+      if (stream == nullptr) {
+        auto device_id = phys ? phys->getUserData().deviceId : 0;
+        stream = g_devices[device_id]->NullStream();
+      }
       auto cmd = new amd::VirtualMapCommand(
           *stream, amd::Command::EventWaitList{},
           node_params_.dptr, sub_obj->getSize(), nullptr);
       cmd->enqueue();
+      if (launch_stream == nullptr) {
+        cmd->awaitCompletion();
+      }
       cmd->release();
       if (phys != nullptr && pool != nullptr) {
         pool->DecrementRefCount(phys);

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -2777,30 +2777,43 @@ class GraphEmptyNode : public GraphNode {
 class GraphMemAllocNode final : public GraphNode {
   hipMemAllocNodeParams node_params_;  // Node parameters for memory allocation
   amd::Memory* va_ = nullptr;          // Memory object, which holds a virtual address
+  bool mapped_ = false;                // True after first successful VA map with matching free
+  void* phys_ptr_ = nullptr;           // Physical memory dev_ptr for targeted FindMemory reuse
 
   // Derive the new class for VirtualMapCommand,
   // so runtime can allocate memory during the execution of command
   class VirtualMemAllocNode : public amd::VirtualMapCommand {
    public:
     VirtualMemAllocNode(amd::HostQueue& queue, const amd::Event::EventWaitList& eventWaitList,
-                        amd::Memory* va, size_t size, amd::Memory* memory, Graph* graph)
+                        amd::Memory* va, size_t size, amd::Memory* memory, Graph* graph,
+                        bool* mapped_ref, void** phys_ptr_ref)
         : VirtualMapCommand(queue, eventWaitList, va->getSvmPtr(), size, memory),
           va_(va),
-          graph_(graph) {}
+          graph_(graph),
+          mapped_ref_(mapped_ref),
+          phys_ptr_ref_(phys_ptr_ref) {}
 
     virtual void submit(device::VirtualDevice& device) final {
-      // Remove VA reference from the global mapping. Runtime has to keep a dummy reference for
-      // validation logic during the capture or creation of the nodes
       if (!AMD_DIRECT_DISPATCH) {
         WorkerThreadLock_.lock();
       }
-      if (amd::MemObjMap::FindMemObj(va_->getSvmPtr())) {
-        amd::MemObjMap::RemoveMemObj(va_->getSvmPtr());
-      }
-      // Allocate real memory for mapping
+
       const auto& dev_info = queue()->device().info();
       auto aligned_size = amd::alignUp(size_, dev_info.virtualMemAllocGranularityRecommended_);
-      auto dptr = graph_->AllocateMemory(aligned_size, static_cast<hip::Stream*>(queue()), nullptr);
+      const bool relaunch = *mapped_ref_;
+
+      // On first launch remove stale VA reference; on re-launch sub_obj must persist
+      if (!relaunch) {
+        if (amd::MemObjMap::FindMemObj(va_->getSvmPtr())) {
+          amd::MemObjMap::RemoveMemObj(va_->getSvmPtr());
+        }
+      }
+
+      // Re-launch passes phys_ptr hint so FindMemory matches by exact address;
+      // first launch passes nullptr to allocate fresh physical memory
+      auto dptr = graph_->AllocateMemory(
+          aligned_size, static_cast<hip::Stream*>(queue()),
+          relaunch ? *phys_ptr_ref_ : nullptr);
       if (dptr == nullptr) {
         setStatus(CL_INVALID_OPERATION);
         if (!AMD_DIRECT_DISPATCH) {
@@ -2809,31 +2822,44 @@ class GraphMemAllocNode final : public GraphNode {
         return;
       }
       size_t offset = 0;
-      // Get memory object associated with the real allocation
       memory_ = getMemoryObject(dptr, offset);
       if (!AMD_DIRECT_DISPATCH) {
-        // Retain memory object because command release will release it
         memory_->retain();
       }
       size_ = aligned_size;
-      // Execute the original mapping command
-      VirtualMapCommand::submit(device);
+
+      if (!relaunch) {
+        VirtualMapCommand::submit(device);
+      }
       if (!AMD_DIRECT_DISPATCH) {
         WorkerThreadLock_.unlock();
       }
-      amd::Memory* vaddr_sub_obj = amd::MemObjMap::FindMemObj(va_->getSvmPtr());
-      assert(vaddr_sub_obj != nullptr);
-      queue()->device().SetMemAccess(vaddr_sub_obj->getSvmPtr(), aligned_size,
-                                     amd::Device::VmmAccess::kReadWrite);
-      graph_->IncrementMemAllocNodeCount();  // Increment count of unreleased mem alloc nodes
+      if (!relaunch) {
+        amd::Memory* vaddr_sub_obj = amd::MemObjMap::FindMemObj(va_->getSvmPtr());
+        assert(vaddr_sub_obj != nullptr);
+        queue()->device().SetMemAccess(vaddr_sub_obj->getSvmPtr(), aligned_size,
+                                       amd::Device::VmmAccess::kReadWrite);
+
+        bool has_matching_free = (graph_->memAllocNodePtrs_.find(va_->getSvmPtr())
+                                  == graph_->memAllocNodePtrs_.end());
+        if (has_matching_free) {
+          graph_->Device()->GetGraphMemoryPool()->IncrementRefCount(memory_);
+          *phys_ptr_ref_ = dptr;
+          *mapped_ref_ = true;
+        }
+      }
+
+      graph_->IncrementMemAllocNodeCount();
       ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_MEM_POOL, "Graph MemAlloc execute [%p-%p], %p",
-              vaddr_sub_obj->getSvmPtr(),
-              reinterpret_cast<char*>(vaddr_sub_obj->getSvmPtr()) + aligned_size, memory());
+              va_->getSvmPtr(),
+              reinterpret_cast<char*>(va_->getSvmPtr()) + aligned_size, memory());
     }
 
    private:
-    amd::Memory* va_;  // Memory object with the new virtual address for mapping
-    Graph* graph_;     // Graph which allocates/maps memory
+    amd::Memory* va_;       // Memory object with the new virtual address for mapping
+    Graph* graph_;          // Graph which allocates/maps memory
+    bool* mapped_ref_;      // Pointer to owning GraphMemAllocNode::mapped_
+    void** phys_ptr_ref_;   // Pointer to owning GraphMemAllocNode::phys_ptr_
   };
 
  protected:
@@ -2844,6 +2870,8 @@ class GraphMemAllocNode final : public GraphNode {
       assert(rhs.va_ != nullptr && "Graph MemAlloc runtime can't clone an invalid node!");
       va_ = rhs.va_;
       va_->retain();
+      mapped_ = rhs.mapped_;
+      phys_ptr_ = rhs.phys_ptr_;
     }
   }
 
@@ -2855,13 +2883,11 @@ class GraphMemAllocNode final : public GraphNode {
 
   virtual ~GraphMemAllocNode() final {
     if (va_ != nullptr) {
-      if (va_->referenceCount() == 1) {
-        auto graph = GetParentGraph();
-        if (graph != nullptr) {
-          graph->FreeAddress(va_->getSvmPtr());
-        }
+      auto graph = GetParentGraph();
+      ReleaseCachedMapping(graph ? graph->Device()->GetGraphMemoryPool() : nullptr);
+      if (va_->referenceCount() == 1 && graph != nullptr) {
+        graph->FreeAddress(va_->getSvmPtr());
       }
-
       va_->release();
     }
   }
@@ -2870,6 +2896,26 @@ class GraphMemAllocNode final : public GraphNode {
   GraphMemAllocNode& operator=(const GraphMemAllocNode&) = delete;
 
   virtual GraphNode* clone() const final { return new GraphMemAllocNode(*this); }
+
+  void ReleaseCachedMapping(MemoryPool* pool) {
+    if (!mapped_) return;
+    auto sub_obj = amd::MemObjMap::FindMemObj(node_params_.dptr);
+    if (sub_obj != nullptr) {
+      auto* phys = sub_obj->getUserData().phys_mem_obj;
+      auto device_id = phys ? phys->getUserData().deviceId : 0;
+      auto* stream = g_devices[device_id]->NullStream();
+      auto cmd = new amd::VirtualMapCommand(
+          *stream, amd::Command::EventWaitList{},
+          node_params_.dptr, sub_obj->getSize(), nullptr);
+      cmd->enqueue();
+      cmd->release();
+      if (phys != nullptr && pool != nullptr) {
+        pool->DecrementRefCount(phys);
+      }
+    }
+    mapped_ = false;
+    phys_ptr_ = nullptr;
+  }
 
   virtual hipError_t CreateCommand(hip::Stream* stream) final {
     auto error = GraphNode::CreateCommand(stream);
@@ -2882,7 +2928,8 @@ class GraphMemAllocNode final : public GraphNode {
         stream->GetDevice()->GetGraphMemoryPool()->SetGraphInUse();
         // Create command for memory mapping
         auto cmd = new VirtualMemAllocNode(*stream, amd::Event::EventWaitList{}, va_,
-                                           node_params_.bytesize, nullptr, graph);
+                                           node_params_.bytesize, nullptr, graph,
+                                           &mapped_, &phys_ptr_);
         commands_.push_back(cmd);
         size_t offset = 0;
         // Check if memory was already added after first reserve
@@ -2952,26 +2999,21 @@ class GraphMemFreeNode : public GraphNode {
           device_id_(device_id) {}
 
     virtual void submit(device::VirtualDevice& device) final {
-      // Find memory object before unmap logic
       auto vaddr_sub_obj = amd::MemObjMap::FindMemObj(ptr());
       assert(vaddr_sub_obj != nullptr);
       amd::Memory* phys_mem_obj = vaddr_sub_obj->getUserData().phys_mem_obj;
       assert(phys_mem_obj != nullptr);
-      auto vaddr_mem_obj = amd::MemObjMap::FindVirtualMemObj(ptr());
-      assert(vaddr_mem_obj != nullptr);
-      // sub_obj is released inside submitVirtualMap after HW unmap completes
-      VirtualMapCommand::submit(device);
+      // Skip HW unmap: sub_obj, HSA mapping, and MemObjMap entry persist for reuse
+      // The refcount > 0 guard in MemoryPool::FreeMemory also skips VA unmap
       if (!AMD_DIRECT_DISPATCH) {
-        // Update the current device, since hip event, used in mem pools, requires device
         hip::setCurrentDevice(device_id_);
       }
-      // Release the allocation back to graph's pool
       auto device_id = phys_mem_obj->getUserData().deviceId;
       if (!g_devices[device_id]->FreeMemory(phys_mem_obj, static_cast<hip::Stream*>(queue()))) {
         LogError("Memory didn't belong to any pool!");
       }
-      amd::MemObjMap::AddMemObj(ptr(), vaddr_mem_obj);
-      graph_->DecrementMemAllocNodeCount();  // Decrement count of unreleased memalloc nodes
+      // Skip MemObjMap::AddMemObj -- sub_obj is the active entry for this VA
+      graph_->DecrementMemAllocNodeCount();
       ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_MEM_POOL, "Graph MemFree execute: %p, %p", ptr(),
               vaddr_sub_obj);
     }

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -3046,9 +3046,9 @@ class GraphMemFreeNode : public GraphNode {
         hip::setCurrentDevice(device_id_);
       }
       auto device_id = phys_mem_obj->getUserData().deviceId;
-      // event markers enqeued by FreeMemory is not required in graph path
+      // event markers enqueued by FreeMemory is not required in graph path
       // on non DD path. Its causing deadlock in command queue thread.
-      // Packet batch flat is already ensuring barriers packets are added
+      // Graph Packet Batch is already ensuring barriers packets are added
       // before/after the AQL packet batch.
       bool kSkipEvent =  !AMD_DIRECT_DISPATCH;
       if (!g_devices[device_id]->FreeMemory(phys_mem_obj,

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -821,7 +821,8 @@ class Graph {
     auto memory = getMemoryObject(dev_ptr, offset);
     if (memory != nullptr) {
       auto device_id = memory->getUserData().deviceId;
-      constexpr bool kSkipEvent = true;
+      // Skip event marker for non-DD path when pool frees memory
+      bool kSkipEvent = !AMD_DIRECT_DISPATCH;
       if (!g_devices[device_id]->FreeMemory(memory, stream, nullptr, kSkipEvent)) {
         LogError("Memory didn't belong to any pool!");
       }

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -2830,7 +2830,7 @@ class GraphMemAllocNode final : public GraphNode {
       size_ = aligned_size;
 
       // Remap is needed on relaunch when the original physical memory was
-      // reused by another consumer (hipMallocAsync or another graph). In that
+      // reused by another consumer (another graph on different stream). In that
       // case AllocateMemory returns new physical memory and the VA must be
       // remapped from the old physical address to the new one.
       const bool remap_needed = relaunch && (dptr != *phys_ptr_ref_);

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -821,7 +821,8 @@ class Graph {
     auto memory = getMemoryObject(dev_ptr, offset);
     if (memory != nullptr) {
       auto device_id = memory->getUserData().deviceId;
-      if (!g_devices[device_id]->FreeMemory(memory, stream)) {
+      constexpr bool kSkipEvent = true;
+      if (!g_devices[device_id]->FreeMemory(memory, stream, nullptr, kSkipEvent)) {
         LogError("Memory didn't belong to any pool!");
       }
     }
@@ -3015,7 +3016,13 @@ class GraphMemFreeNode : public GraphNode {
         hip::setCurrentDevice(device_id_);
       }
       auto device_id = phys_mem_obj->getUserData().deviceId;
-      if (!g_devices[device_id]->FreeMemory(phys_mem_obj, static_cast<hip::Stream*>(queue()))) {
+      // event markers enqeued by FreeMemory is not required in graph path
+      // on non DD path. Its causing deadlock in command queue thread.
+      // Packet batch flat is already ensuring barriers packets are added
+      // before/after the AQL packet batch.
+      bool kSkipEvent =  !AMD_DIRECT_DISPATCH;
+      if (!g_devices[device_id]->FreeMemory(phys_mem_obj,
+              static_cast<hip::Stream*>(queue()), nullptr, kSkipEvent)) {
         LogError("Memory didn't belong to any pool!");
       }
       // Skip MemObjMap::AddMemObj -- sub_obj is the active entry for this VA

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -847,7 +847,7 @@ class Graph {
   //! Increments the graph memory alloc node count
   void IncrementMemAllocNodeCount() { memalloc_nodes_++; }
   //! Decrements the graph memory alloc node count
-  void DecrementMemAllocNodeCount() { memalloc_nodes_--; }
+  void DecrementMemAllocNodeCount() { memalloc_nodes_ -= (memalloc_nodes_ > 0); }
   //! returns device object
   hip::Device* Device() { return device_; }
   bool IsLeafNodeSyncRequired() const {

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -2829,13 +2829,32 @@ class GraphMemAllocNode final : public GraphNode {
       }
       size_ = aligned_size;
 
-      if (!relaunch) {
+      // Remap is needed on relaunch when the original physical memory was
+      // reused by another consumer (hipMallocAsync or another graph). In that
+      // case AllocateMemory returns new physical memory and the VA must be
+      // remapped from the old physical address to the new one.
+      const bool remap_needed = relaunch && (dptr != *phys_ptr_ref_);
+
+      if (!relaunch || remap_needed) {
+        if (remap_needed) {
+          // Unmap old VA→old_phys before mapping to new physical memory.
+          // Submit directly to the device (not enqueue) since we're already
+          // on the queue thread inside submit(). Enqueuing would push to the
+          // back of the FIFO and deadlock the non-DD queue thread.
+          auto* sub_obj = amd::MemObjMap::FindMemObj(va_->getSvmPtr());
+          if (sub_obj != nullptr) {
+            amd::VirtualMapCommand unmap_cmd(
+                *static_cast<amd::HostQueue*>(queue()), amd::Command::EventWaitList{},
+                va_->getSvmPtr(), sub_obj->getSize(), nullptr);
+            device.submitVirtualMap(unmap_cmd);
+          }
+        }
         VirtualMapCommand::submit(device);
       }
       if (!AMD_DIRECT_DISPATCH) {
         WorkerThreadLock_.unlock();
       }
-      if (!relaunch) {
+      if (!relaunch || remap_needed) {
         amd::Memory* vaddr_sub_obj = amd::MemObjMap::FindMemObj(va_->getSvmPtr());
         assert(vaddr_sub_obj != nullptr);
         queue()->device().SetMemAccess(vaddr_sub_obj->getSvmPtr(), aligned_size,
@@ -2844,7 +2863,18 @@ class GraphMemAllocNode final : public GraphNode {
         bool has_matching_free = (graph_->memAllocNodePtrs_.find(va_->getSvmPtr())
                                   == graph_->memAllocNodePtrs_.end());
         if (has_matching_free) {
-          graph_->Device()->GetGraphMemoryPool()->IncrementRefCount(memory_);
+          auto* pool = graph_->Device()->GetGraphMemoryPool();
+          if (remap_needed) {
+            // Release the old graph's refcount claim on the stolen physical memory.
+            // The old memory is in busy_heap_ (owned by whoever took it from free_heap_).
+            // DecrementRefCount is lock-protected and checks both heaps.
+            size_t old_offset = 0;
+            auto* old_memory = getMemoryObject(*phys_ptr_ref_, old_offset);
+            if (old_memory != nullptr) {
+              pool->DecrementRefCount(old_memory);
+            }
+          }
+          pool->IncrementRefCount(memory_);
           *phys_ptr_ref_ = dptr;
           *mapped_ref_ = true;
         }

--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -541,7 +541,8 @@ namespace hip {
     MemoryPool* GetDefaultManagedMemoryPool() const { return default_managed_mem_pool_; }
     void AddMemoryPool(MemoryPool* pool);
     void RemoveMemoryPool(MemoryPool* pool);
-    bool FreeMemory(amd::Memory* memory, Stream* stream, Event* event = nullptr);
+    bool FreeMemory(amd::Memory* memory, Stream* stream, Event* event = nullptr,
+                    bool skip_event = false);
     void ReleaseFreedMemory();
     void RemoveStreamFromPools(Stream* stream);
     void AddSafeStream(Stream* event_stream, Stream* wait_stream);

--- a/projects/clr/hipamd/src/hip_mempool_impl.cpp
+++ b/projects/clr/hipamd/src/hip_mempool_impl.cpp
@@ -435,8 +435,9 @@ hipError_t MemoryPool::GetAttribute(hipMemPoolAttr attr, void* value) {
           (state_.use_vm_heap_) ? MaxMappedSize() : max_total_size_;
       break;
     case hipMemPoolAttrUsedMemCurrent:
-      // Total currently used memory by the pool
-      *reinterpret_cast<uint64_t*>(value) = busy_heap_.GetTotalSize();
+      // Total currently used memory by the pool, including graph-cached entries in free_heap_
+      *reinterpret_cast<uint64_t*>(value) =
+          busy_heap_.GetTotalSize() + free_heap_.GetRefcountedSize();
       break;
     case hipMemPoolAttrUsedMemHigh:
       // High watermark of all used memoryS, since the last reset

--- a/projects/clr/hipamd/src/hip_mempool_impl.cpp
+++ b/projects/clr/hipamd/src/hip_mempool_impl.cpp
@@ -297,26 +297,27 @@ bool MemoryPool::FreeMemory(amd::Memory* memory, Stream* stream, Event* event, b
       // The stream of destruction is a safe stream, because the app must handle sync
       ts.AddSafeStream(stream);
 
-      // Graph path: skip marker creation and blocking waits to avoid deadlocking
-      // the non-direct-dispatch queue thread. Markers enqueued during submit() land
-      // behind commands in the FIFO that depend on them, causing a deadlock.
-      // The safe stream added above is sufficient for reuse checks in FindMemory.
-      if (!skip_event) {
-        if (event == nullptr) {
-          // Add a marker to the stream to trace availability of this memory
-          Event* e = new hip::Event(0);
-          if (hipSuccess == e->addMarker(stream, nullptr)) {
-            ts.SetEvent(e);
-            // Make sure runtime sends a notification
-            auto result = e->ready();
-          }
-        } else {
-          ts.SetEvent(event);
+      // Preserve any caller-provided completion event even when marker creation is
+      // skipped. A null event is reserved for the explicit host-safe free path below.
+      if (event != nullptr) {
+        // If event is provided, then use it to track memory availability
+        ts.SetEvent(event);
+      } else if (!skip_event) {
+        // Add a marker to the stream to trace availability of this memory
+        // Graph path: skip marker creation and blocking waits to avoid deadlocking
+        // the non-direct-dispatch queue thread. Markers enqueued during submit() land
+        // behind commands in the FIFO that depend on them, causing a deadlock.
+        // The safe stream added above is sufficient for reuse checks in FindMemory.
+        Event* e = new hip::Event(0);
+        if (hipSuccess == e->addMarker(stream, nullptr)) {
+          ts.SetEvent(e);
+          // Make sure runtime sends a notification
+          auto result = e->ready();
         }
+      } else {
+        // Assume a safe release from hipFree() if stream is nullptr
+        ts.SetEvent(nullptr);
       }
-    } else {
-      // Assume a safe release from hipFree() if stream is nullptr
-      ts.SetEvent(nullptr);
     }
     free_heap_.AddMemory(memory, ts);
   }

--- a/projects/clr/hipamd/src/hip_mempool_impl.cpp
+++ b/projects/clr/hipamd/src/hip_mempool_impl.cpp
@@ -242,7 +242,7 @@ void* MemoryPool::AllocateMemory(size_t size, Stream* stream, void* dptr) {
 }
 
 // ================================================================================================
-bool MemoryPool::FreeMemory(amd::Memory* memory, Stream* stream, Event* event) {
+bool MemoryPool::FreeMemory(amd::Memory* memory, Stream* stream, Event* event, bool skip_event) {
   {
     std::scoped_lock lock(lock_pool_ops_);
 
@@ -297,16 +297,22 @@ bool MemoryPool::FreeMemory(amd::Memory* memory, Stream* stream, Event* event) {
       // The stream of destruction is a safe stream, because the app must handle sync
       ts.AddSafeStream(stream);
 
-      if (event == nullptr) {
-        // Add a marker to the stream to trace availability of this memory
-        Event* e = new hip::Event(0);
-        if (hipSuccess == e->addMarker(stream, nullptr)) {
-          ts.SetEvent(e);
-          // Make sure runtime sends a notification
-          auto result = e->ready();
+      // Graph path: skip marker creation and blocking waits to avoid deadlocking
+      // the non-direct-dispatch queue thread. Markers enqueued during submit() land
+      // behind commands in the FIFO that depend on them, causing a deadlock.
+      // The safe stream added above is sufficient for reuse checks in FindMemory.
+      if (!skip_event) {
+        if (event == nullptr) {
+          // Add a marker to the stream to trace availability of this memory
+          Event* e = new hip::Event(0);
+          if (hipSuccess == e->addMarker(stream, nullptr)) {
+            ts.SetEvent(e);
+            // Make sure runtime sends a notification
+            auto result = e->ready();
+          }
+        } else {
+          ts.SetEvent(event);
         }
-      } else {
-        ts.SetEvent(event);
       }
     } else {
       // Assume a safe release from hipFree() if stream is nullptr

--- a/projects/clr/hipamd/src/hip_mempool_impl.cpp
+++ b/projects/clr/hipamd/src/hip_mempool_impl.cpp
@@ -48,6 +48,7 @@ amd::Memory* Heap::FindMemory(size_t size, Stream* stream, bool opportunistic, v
       total_size_ -= memory->getSize();
       // Preserve event, since the logic could skip GPU wait on reuse
       ts->event_ = it->second.event_;
+      ts->refcount_ = it->second.refcount_;
       // Remove found allocation from the map
       it = allocations_.erase(it);
       break;
@@ -77,6 +78,9 @@ bool Heap::RemoveMemory(amd::Memory* memory, MemoryTimestamp* ts) {
 
 // ================================================================================================
 Heap::SortedMap::iterator Heap::EraseAllocation(Heap::SortedMap::iterator& it) {
+  if (it->second.refcount_ > 0) {
+    return ++it;
+  }
   auto memory = it->first.second;
   const device::Memory* dev_mem = memory->getDeviceMemory(*device_->devices()[0]);
   void* dev_mem_vaddr = reinterpret_cast<void*>(dev_mem->virtualAddress());
@@ -103,6 +107,10 @@ bool Heap::ReleaseAllMemory(size_t min_bytes_to_hold, bool safe_release) {
     if (total_size_ <= min_bytes_to_hold) {
       return true;
     }
+    if (it->second.refcount_ > 0) {
+      ++it;
+      continue;
+    }
     // Safe release forces unconditional wait for memory
     if (safe_release) {
       it->second.Wait();
@@ -127,6 +135,10 @@ bool Heap::ReleaseAllMemory() {
     // @note: Managed memory controls the threshold on its own
     if (!use_vm_heap_ && (total_size_ <= release_threshold_)) {
       return true;
+    }
+    if (it->second.refcount_ > 0) {
+      ++it;
+      continue;
     }
     if (it->second.IsSafeRelease()) {
       it = EraseAllocation(it);
@@ -269,7 +281,7 @@ bool MemoryPool::FreeMemory(amd::Memory* memory, Stream* stream, Event* event) {
     }
     ClPrint(amd::LOG_INFO, amd::LOG_MEM_POOL, "Pool FreeMem: %p, %p", memory->getSvmPtr(), memory);
 
-    if (memory->getUserData().vaddr_mem_obj != nullptr) {
+    if (ts.refcount_ == 0 && memory->getUserData().vaddr_mem_obj != nullptr) {
       auto va_mem = memory->getUserData().vaddr_mem_obj;
       if (stream == nullptr) {
         stream = g_devices[memory->getUserData().deviceId]->NullStream();

--- a/projects/clr/hipamd/src/hip_mempool_impl.hpp
+++ b/projects/clr/hipamd/src/hip_mempool_impl.hpp
@@ -82,6 +82,7 @@ struct MemoryTimestamp {
 
   std::unordered_set<hip::Stream*> safe_streams_;  //!< Safe streams for memory reuse
   hip::Event* event_ = nullptr;  //!< Last known HIP event, associated with the memory object
+  uint32_t refcount_ = 0;  //!< VA-mapping refcount: >0 means skip unmap/erase (graph caching)
 };
 
 class Heap : public amd::EmbeddedObject {
@@ -155,6 +156,25 @@ class Heap : public amd::EmbeddedObject {
   /// Checks if memory belongs to this heap
   bool IsActiveMemory(amd::Memory* memory) const {
     return (allocations_.find({memory->getSize(), memory}) != allocations_.end());
+  }
+
+  /// Increments refcount for the given memory allocation
+  bool IncrementRefCount(amd::Memory* memory) {
+    if (auto it = allocations_.find({memory->getSize(), memory}); it != allocations_.end()) {
+      it->second.refcount_++;
+      return true;
+    }
+    return false;
+  }
+
+  /// Decrements refcount for the given memory allocation
+  bool DecrementRefCount(amd::Memory* memory) {
+    if (auto it = allocations_.find({memory->getSize(), memory}); it != allocations_.end()) {
+      assert(it->second.refcount_ > 0);
+      it->second.refcount_--;
+      return true;
+    }
+    return false;
   }
 
   /// Enabled VM heap for memory, instead of direct allocations
@@ -312,6 +332,18 @@ class MemoryPool : public amd::ReferenceCountedObject, amd::VmHeapArray {
   bool InternalDependencies() const { return (state_.internal_dependencies_) ? true : false; }
   bool GraphInUse() const { return (state_.graph_in_use_) ? true : false; }
   void SetGraphInUse() { state_.graph_in_use_ = true; }
+
+  /// Increments refcount for the given memory in either busy or free heap
+  bool IncrementRefCount(amd::Memory* memory) {
+    std::scoped_lock lock(lock_pool_ops_);
+    return busy_heap_.IncrementRefCount(memory) || free_heap_.IncrementRefCount(memory);
+  }
+
+  /// Decrements refcount for the given memory in either busy or free heap
+  bool DecrementRefCount(amd::Memory* memory) {
+    std::scoped_lock lock(lock_pool_ops_);
+    return busy_heap_.DecrementRefCount(memory) || free_heap_.DecrementRefCount(memory);
+  }
 
  private:
   MemoryPool() = delete;

--- a/projects/clr/hipamd/src/hip_mempool_impl.hpp
+++ b/projects/clr/hipamd/src/hip_mempool_impl.hpp
@@ -277,7 +277,8 @@ class MemoryPool : public amd::ReferenceCountedObject, amd::VmHeapArray {
   void* AllocateMemory(size_t size, Stream* stream, void* dptr = nullptr);
 
   /// Frees memory by placing memory object with HIP event into free_heap_
-  bool FreeMemory(amd::Memory* memory, Stream* stream, Event* event = nullptr);
+  bool FreeMemory(amd::Memory* memory, Stream* stream, Event* event = nullptr,
+                  bool skip_event = false);
 
   /// Check if memory is active and belongs to the busy heap
   bool IsBusyMemory(amd::Memory* memory) const { return busy_heap_.IsActiveMemory(memory); }

--- a/projects/clr/hipamd/src/hip_mempool_impl.hpp
+++ b/projects/clr/hipamd/src/hip_mempool_impl.hpp
@@ -170,22 +170,18 @@ class Heap : public amd::EmbeddedObject {
   }
 
   /// Increments refcount for the given memory allocation
-  bool IncrementRefCount(amd::Memory* memory) {
+  void IncrementRefCount(amd::Memory* memory) {
     if (auto it = allocations_.find({memory->getSize(), memory}); it != allocations_.end()) {
       it->second.refcount_++;
-      return true;
     }
-    return false;
   }
 
   /// Decrements refcount for the given memory allocation
-  bool DecrementRefCount(amd::Memory* memory) {
+  void DecrementRefCount(amd::Memory* memory) {
     if (auto it = allocations_.find({memory->getSize(), memory}); it != allocations_.end()) {
       assert(it->second.refcount_ > 0);
       it->second.refcount_--;
-      return true;
     }
-    return false;
   }
 
   /// Enabled VM heap for memory, instead of direct allocations
@@ -345,15 +341,17 @@ class MemoryPool : public amd::ReferenceCountedObject, amd::VmHeapArray {
   void SetGraphInUse() { state_.graph_in_use_ = true; }
 
   /// Increments refcount for the given memory in either busy or free heap
-  bool IncrementRefCount(amd::Memory* memory) {
+  void IncrementRefCount(amd::Memory* memory) {
     std::scoped_lock lock(lock_pool_ops_);
-    return busy_heap_.IncrementRefCount(memory) || free_heap_.IncrementRefCount(memory);
+    busy_heap_.IncrementRefCount(memory);
+    free_heap_.IncrementRefCount(memory);
   }
 
   /// Decrements refcount for the given memory in either busy or free heap
-  bool DecrementRefCount(amd::Memory* memory) {
+  void DecrementRefCount(amd::Memory* memory) {
     std::scoped_lock lock(lock_pool_ops_);
-    return busy_heap_.DecrementRefCount(memory) || free_heap_.DecrementRefCount(memory);
+    busy_heap_.DecrementRefCount(memory);
+    free_heap_.DecrementRefCount(memory);
   }
 
  private:

--- a/projects/clr/hipamd/src/hip_mempool_impl.hpp
+++ b/projects/clr/hipamd/src/hip_mempool_impl.hpp
@@ -137,6 +137,17 @@ class Heap : public amd::EmbeddedObject {
   /// Get the size of all allocations in the heap
   uint64_t GetTotalSize() const { return total_size_; }
 
+  /// Get the total size of allocations with refcount > 0 (graph-cached, VA-mapped)
+  uint64_t GetRefcountedSize() const {
+    uint64_t size = 0;
+    for (const auto& it : allocations_) {
+      if (it.second.refcount_ > 0) {
+        size += it.first.first;
+      }
+    }
+    return size;
+  }
+
   /// Get the size of all allocations in the heap
   uint64_t GetMaxTotalSize() const { return max_total_size_; }
 

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -1689,4 +1689,5 @@ graph:
     tags: [node]
   Unit_hipGraphAllocNodeMemReuse_MallocWithoutFree_NoReuse:
     <<: *level_2
+    disabled: [amd_windows]
     tags: [node]

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -1669,3 +1669,24 @@ graph:
   Unit_hipEventSynchronize_ThreadLocalCapture_DefaultMode_CapturedEvent: *level_2
   Unit_hipEventQuery_SameThread_GlobalCapture: *level_2
   Unit_hipEventQuery_SameThread_RelaxedCapture: *level_2
+  Unit_hipGraphAllocNodeMemReuse_SameStream_SameSizes:
+    <<: *level_2
+    tags: [node]
+  Unit_hipGraphAllocNodeMemReuse_SameStream_DifferentSizes_NoReuse:
+    <<: *level_2
+    tags: [node]
+  Unit_hipGraphAllocNodeMemReuse_RepeatedLaunches:
+    <<: *level_2
+    tags: [node]
+  Unit_hipGraphAllocNodeMemReuse_MemoryTrim:
+    <<: *level_2
+    tags: [node]
+  Unit_hipGraphAllocNodeMemReuse_ExplicitAllocFreeNodes_SameSize:
+    <<: *level_2
+    tags: [node]
+  Unit_hipGraphAllocNodeMemReuse_ExplicitAllocFreeNodes_DifferentSizes:
+    <<: *level_2
+    tags: [node]
+  Unit_hipGraphAllocNodeMemReuse_MallocWithoutFree_NoReuse:
+    <<: *level_2
+    tags: [node]

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -1691,3 +1691,12 @@ graph:
     <<: *level_2
     disabled: [amd_windows]
     tags: [node]
+  Unit_hipGraphAllocNodeMemReuse_DifferentStreams_Reuse:
+    <<: *level_2
+    tags: [node]
+  Unit_hipGraphAllocNodeMemReuse_MemSteal_Remap:
+    <<: *level_2
+    tags: [node]
+  Unit_hipGraphAllocNodeMemReuse_AutoFreeOnLaunch:
+    <<: *level_2
+    tags: [node]

--- a/projects/hip-tests/catch/unit/graph/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/graph/CMakeLists.txt
@@ -137,6 +137,7 @@ set(TEST_SRC
   hipGraphMemAllocNodeGetParams.cc
   hipGraphAddMemAllocNode.cc
   hipGraphAddMemFreeNode.cc
+  hipGraphAllocNodeMemReuse.cc
   hipDrvGraphMemcpyNodeGetParams.cc
   hipDrvGraphMemcpyNodeSetParams.cc
   hipDeviceSetGraphMemAttribute.cc

--- a/projects/hip-tests/catch/unit/graph/hipGraphAllocNodeMemReuse.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAllocNodeMemReuse.cc
@@ -132,9 +132,12 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_SameStream_SameSizes") {
 
   // Launch all three sequentially on the same stream
   HIP_CHECK(hipGraphLaunch(execA, stream));
-  HIP_CHECK(hipGraphLaunch(execB, stream));
-  HIP_CHECK(hipGraphLaunch(execC, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
 
+  HIP_CHECK(hipGraphLaunch(execB, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  HIP_CHECK(hipGraphLaunch(execC, stream));
   HIP_CHECK(hipStreamSynchronize(stream));
 
   // Check memory statistics after launch+sync
@@ -195,9 +198,12 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_SameStream_DifferentSizes_NoReuse") {
 
   // Launch all three sequentially on the same stream
   HIP_CHECK(hipGraphLaunch(execA, stream));
-  HIP_CHECK(hipGraphLaunch(execB, stream));
-  HIP_CHECK(hipGraphLaunch(execC, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
 
+  HIP_CHECK(hipGraphLaunch(execB, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  HIP_CHECK(hipGraphLaunch(execC, stream));
   HIP_CHECK(hipStreamSynchronize(stream));
 
   // Check memory statistics
@@ -258,9 +264,8 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_RepeatedLaunches") {
   constexpr int numLaunches = 10;
   for (int i = 0; i < numLaunches; i++) {
     HIP_CHECK(hipGraphLaunch(exec, stream));
+    HIP_CHECK(hipStreamSynchronize(stream));
   }
-
-  HIP_CHECK(hipStreamSynchronize(stream));
 
   // Check memory statistics
   auto stats = queryGraphMem(device);
@@ -398,6 +403,7 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_ExplicitAllocFreeNodes_SameSize") {
 
   // Launch both graphs sequentially on same stream
   HIP_CHECK(hipGraphLaunch(execA, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
   HIP_CHECK(hipGraphLaunch(execB, stream));
   HIP_CHECK(hipStreamSynchronize(stream));
 
@@ -494,6 +500,7 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_ExplicitAllocFreeNodes_DifferentSizes"
 
   // Launch both graphs sequentially on same stream
   HIP_CHECK(hipGraphLaunch(execA, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
   HIP_CHECK(hipGraphLaunch(execB, stream));
   HIP_CHECK(hipStreamSynchronize(stream));
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphAllocNodeMemReuse.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAllocNodeMemReuse.cc
@@ -10,13 +10,13 @@
 #include <resource_guards.hh>
 #include <utils.hh>
 #include <thread>
+#include <atomic>
 
 /**
  * @addtogroup hipGraphAllocNodeMemReuse hipGraphAllocNodeMemReuse
  * @{
  * @ingroup GraphTest
- * Tests for verifying memory reuse optimization for graph allocation nodes when graphs
- * are launched sequentially on the same stream.
+ * Tests for verifying memory reuse optimization for graph allocation nodes.
  */
 
 static constexpr int kBlockSize = 256;
@@ -35,6 +35,20 @@ __global__ void verifyKernel(const float* buf, float expected, int64_t n, int* e
   }
 }
 
+// Busy-spin kernel: each thread loops `iters` times, reading/writing buf to
+// prevent the compiler from optimizing the loop away. Use a large iteration
+// count to keep the GPU busy long enough for concurrent host-thread launches.
+__global__ void busyKernel(float* buf, float value, int64_t n, int64_t iters) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < n) {
+    float v = value;
+    for (int64_t i = 0; i < iters; ++i) {
+      v = v * 1.0001f + 0.0001f;
+    }
+    buf[idx] = v;
+  }
+}
+
 // Helper to capture a graph with hipMallocAsync and kernel launch
 static hipGraphExec_t captureGraphWithAlloc(hipStream_t stream, size_t allocBytes,
                                             float fillValue) {
@@ -47,6 +61,34 @@ static hipGraphExec_t captureGraphWithAlloc(hipStream_t stream, size_t allocByte
   HIP_CHECK(hipMallocAsync(reinterpret_cast<void**>(&dTemp), allocBytes, stream));
 
   fillKernel<<<gridSize, kBlockSize, 0, stream>>>(dTemp, fillValue, numElems);
+
+  HIP_CHECK(hipFreeAsync(dTemp, stream));
+
+  hipGraph_t graph = nullptr;
+  HIP_CHECK(hipStreamEndCapture(stream, &graph));
+
+  hipGraphExec_t exec = nullptr;
+  HIP_CHECK(hipGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
+
+  HIP_CHECK(hipGraphDestroy(graph));
+
+  return exec;
+}
+
+// Helper to capture a graph with hipMallocAsync and a long-running busy kernel.
+// The busy kernel spins for `iters` iterations to keep the GPU occupied, ensuring
+// concurrent launches from different host threads actually overlap on the GPU.
+static hipGraphExec_t captureGraphWithBusyKernel(hipStream_t stream, size_t allocBytes,
+                                                  float fillValue, int64_t iters) {
+  int64_t numElems = static_cast<int64_t>(allocBytes / sizeof(float));
+  int gridSize = static_cast<int>((numElems + kBlockSize - 1) / kBlockSize);
+
+  HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+
+  float* dTemp = nullptr;
+  HIP_CHECK(hipMallocAsync(reinterpret_cast<void**>(&dTemp), allocBytes, stream));
+
+  busyKernel<<<gridSize, kBlockSize, 0, stream>>>(dTemp, fillValue, numElems, iters);
 
   HIP_CHECK(hipFreeAsync(dTemp, stream));
 
@@ -113,7 +155,7 @@ void printDeviceMem(const char* label) {
  *  - /unit/graph/hipGraphAllocNodeMemReuse.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 7.2
+ *  - HIP_VERSION >= 7.14
  */
 TEST_CASE("Unit_hipGraphAllocNodeMemReuse_SameStream_SameSizes") {
   const int device = 0;
@@ -171,13 +213,13 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_SameStream_SameSizes") {
  *  - The memory reuse optimization only works for exact size matches. Different sizes
  *    require separate physical allocations acquired directly from the OS.
  *  - This test creates three graphs with different allocation sizes and verifies that
- *    the current memory usage is sum of all 3 allocations for amd
+ *    the current memory usage is the sum of all 3 allocations on AMD.
  * Test source
  * ------------------------
  *  - /unit/graph/hipGraphAllocNodeMemReuse.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 7.2
+ *  - HIP_VERSION >= 7.14
  */
 TEST_CASE("Unit_hipGraphAllocNodeMemReuse_SameStream_DifferentSizes_NoReuse") {
   const int device = 0;
@@ -245,7 +287,7 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_SameStream_DifferentSizes_NoReuse") {
  *  - /unit/graph/hipGraphAllocNodeMemReuse.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 6.0
+ *  - HIP_VERSION >= 7.14
  */
 TEST_CASE("Unit_hipGraphAllocNodeMemReuse_RepeatedLaunches") {
   const int device = 0;
@@ -300,7 +342,7 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_RepeatedLaunches") {
  *  - /unit/graph/hipGraphAllocNodeMemReuse.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 6.0
+ *  - HIP_VERSION >= 7.14
  */
 TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MemoryTrim") {
   const int device = 0;
@@ -347,7 +389,7 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MemoryTrim") {
  *  - /unit/graph/hipGraphAllocNodeMemReuse.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 6.0
+ *  - HIP_VERSION >= 7.14
  */
 TEST_CASE("Unit_hipGraphAllocNodeMemReuse_ExplicitAllocFreeNodes_SameSize") {
   const int device = 0;
@@ -443,7 +485,7 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_ExplicitAllocFreeNodes_SameSize") {
  *  - /unit/graph/hipGraphAllocNodeMemReuse.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 6.0
+ *  - HIP_VERSION >= 7.14
  */
 TEST_CASE("Unit_hipGraphAllocNodeMemReuse_ExplicitAllocFreeNodes_DifferentSizes") {
   const int device = 0;
@@ -550,7 +592,7 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_ExplicitAllocFreeNodes_DifferentSizes"
  *  - /unit/graph/hipGraphAllocNodeMemReuse.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 6.0
+ *  - HIP_VERSION >= 7.14
  */
 TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MallocWithoutFree_NoReuse") {
   const int device = 0;
@@ -663,16 +705,17 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MallocWithoutFree_NoReuse") {
 /**
  * Test Description
  * ------------------------
- *  - Test to verify that graphs captured on different streams do NOT share memory.
+ *  - Test to verify that graphs captured on different streams CAN share memory
+ *    from the shared graph memory pool.
  *  - Two graphs are captured on separate streams, each with a malloc->kernel->free
- *  - sequence. Memory can be shared between graphs and current graph pool usage
- *  - should reflect that.
+ *    sequence. When launched sequentially, the second graph reuses the physical
+ *    memory freed by the first, so usedCurrent reflects a single allocation.
  * Test source
  * ------------------------
  *  - /unit/graph/hipGraphAllocNodeMemReuse.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 7.2
+ *  - HIP_VERSION >= 7.14
  */
 TEST_CASE("Unit_hipGraphAllocNodeMemReuse_DifferentStreams_Reuse") {
   const int device = 0;
@@ -701,11 +744,11 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_DifferentStreams_Reuse") {
   HIP_CHECK(hipGraphLaunch(execB, stream2));
   HIP_CHECK(hipStreamSynchronize(stream2));
 
-  // Check memory statistics - each graph has its own allocation
+  // Check memory statistics
   auto stats = queryGraphMem(device);
 
-  // Both graphs retain their own memory (no cross-graph reuse on different streams),
-  // so usedCurrent should be the sum of both allocations.
+  // Both graphs share the same graph memory pool. When launched sequentially,
+  // graph B reuses graph A's freed physical memory, so usedCurrent == kAllocSize.
   REQUIRE(stats.usedCurrent == kAllocSize);
 
   // Destroy graph executables - memory should be released
@@ -739,7 +782,7 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_DifferentStreams_Reuse") {
  *  - /unit/graph/hipGraphAllocNodeMemReuse.cc
  * Test requirements
  * ------------------------
- *  - HIP_VERSION >= 7.2
+ *  - HIP_VERSION >= 7.14
  */
 TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MemSteal_Remap") {
   const int device = 0;
@@ -752,12 +795,14 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MemSteal_Remap") {
   hipStream_t stream2 = stream_guard2.stream();
 
   constexpr size_t kAllocSize = 64ULL * 1024 * 1024;  // 64 MB - same for both graphs
+  // Enough iterations to keep the GPU busy so both threads overlap
+  constexpr int64_t kBusyIters = 100;
 
   resetGraphMemAttributes(device);
 
-  // Step 1: Capture two graphs with identical alloc sizes
-  hipGraphExec_t execA = captureGraphWithAlloc(stream1, kAllocSize, 1.0f);
-  hipGraphExec_t execB = captureGraphWithAlloc(stream2, kAllocSize, 2.0f);
+  // Step 1: Capture two graphs with busyKernel to ensure long-running GPU work.
+  hipGraphExec_t execA = captureGraphWithBusyKernel(stream1, kAllocSize, 1.0f, kBusyIters);
+  hipGraphExec_t execB = captureGraphWithBusyKernel(stream2, kAllocSize, 2.0f, kBusyIters);
 
   // Step 2: Launch graph A first and sync — its physical memory goes to the shared
   // graph pool's free_heap, available for opportunistic reuse by graph B.
@@ -769,10 +814,14 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MemSteal_Remap") {
 
   // Step 3: Concurrently launch graph B (which may steal graph A's memory) and
   // relaunch graph A (which must remap if its memory was stolen).
+  // Use an atomic flag as a barrier so both threads launch at roughly the same time.
   hipError_t errB = hipSuccess;
   hipError_t errA = hipSuccess;
+  std::atomic<int> ready{0};
 
   std::thread threadB([&]() {
+    ready.fetch_add(1, std::memory_order_release);
+    while (ready.load(std::memory_order_acquire) < 2) {}
     errB = hipGraphLaunch(execB, stream2);
     if (errB == hipSuccess) {
       errB = hipStreamSynchronize(stream2);
@@ -780,6 +829,8 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MemSteal_Remap") {
   });
 
   std::thread threadA([&]() {
+    ready.fetch_add(1, std::memory_order_release);
+    while (ready.load(std::memory_order_acquire) < 2) {}
     errA = hipGraphLaunch(execA, stream1);
     if (errA == hipSuccess) {
       errA = hipStreamSynchronize(stream1);
@@ -810,6 +861,115 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MemSteal_Remap") {
   auto statsAfterDestroy = queryGraphMem(device);
   REQUIRE(statsAfterDestroy.usedCurrent == 0);
 #endif
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Test to verify that hipGraphInstantiateFlagAutoFreeOnLaunch frees unmatched
+ *    alloc node memory at the start of each launch, allowing re-launch to succeed.
+ *  - A graph with alloc -> kernel and NO free node is used. Without the flag,
+ *    a second launch fails with hipErrorInvalidValue because the alloc node's
+ *    memory is still live (memAllocNodeCount > 0). With AutoFreeOnLaunch, the
+ *    runtime frees all prior allocations before re-executing, so the second
+ *    launch succeeds and the kernel writes to freshly allocated memory.
+ *  - Data correctness is verified by reading back the buffer after the second
+ *    launch to confirm the kernel wrote the expected value.
+ * Test source
+ * ------------------------
+ *  - /unit/graph/hipGraphAllocNodeMemReuse.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.14
+ */
+TEST_CASE("Unit_hipGraphAllocNodeMemReuse_AutoFreeOnLaunch") {
+  const int device = 0;
+  HIP_CHECK(hipSetDevice(device));
+
+  StreamGuard stream_guard(Streams::created);
+  hipStream_t stream = stream_guard.stream();
+
+  constexpr size_t kAllocSize = 64ULL * 1024 * 1024;  // 64 MB
+  int64_t numElems = static_cast<int64_t>(kAllocSize / sizeof(float));
+  int gridSize = static_cast<int>((numElems + kBlockSize - 1) / kBlockSize);
+
+  resetGraphMemAttributes(device);
+
+  // Create a graph with alloc -> kernel (no free node)
+  hipGraph_t graph;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+
+  hipGraphNode_t allocNode;
+  hipMemAllocNodeParams allocParam;
+  memset(&allocParam, 0, sizeof(allocParam));
+  allocParam.bytesize = kAllocSize;
+  allocParam.poolProps.allocType = hipMemAllocationTypePinned;
+  allocParam.poolProps.location.id = device;
+  allocParam.poolProps.location.type = hipMemLocationTypeDevice;
+
+  HIP_CHECK(hipGraphAddMemAllocNode(&allocNode, graph, nullptr, 0, &allocParam));
+  REQUIRE(allocParam.dptr != nullptr);
+
+  hipGraphNode_t kernelNode;
+  hipKernelNodeParams kernelParam;
+  memset(&kernelParam, 0, sizeof(kernelParam));
+  float fillValue = 42.0f;
+  void* kernelArgs[] = {&allocParam.dptr, &fillValue, &numElems};
+  kernelParam.func = reinterpret_cast<void*>(fillKernel);
+  kernelParam.gridDim = dim3(gridSize);
+  kernelParam.blockDim = dim3(kBlockSize);
+  kernelParam.kernelParams = kernelArgs;
+
+  HIP_CHECK(hipGraphAddKernelNode(&kernelNode, graph, &allocNode, 1, &kernelParam));
+
+  // Without AutoFreeOnLaunch: second launch must fail because the alloc node's
+  // memory is still live (no matching free node, memAllocNodeCount > 0).
+  SECTION("Without AutoFreeOnLaunch") {
+    hipGraphExec_t exec;
+    HIP_CHECK(hipGraphInstantiateWithFlags(&exec, graph, 0));
+
+    HIP_CHECK(hipGraphLaunch(exec, stream));
+    HIP_CHECK(hipStreamSynchronize(stream));
+
+    // Second launch must return hipErrorInvalidValue
+    hipError_t err = hipGraphLaunch(exec, stream);
+    REQUIRE(err == hipErrorInvalidValue);
+
+    HIP_CHECK(hipGraphExecDestroy(exec));
+  }
+
+  // With AutoFreeOnLaunch: the runtime frees all prior allocations before
+  // re-executing, so the second launch succeeds.
+  SECTION("With AutoFreeOnLaunch") {
+    hipGraphExec_t exec;
+    HIP_CHECK(hipGraphInstantiateWithFlags(&exec, graph,
+                                           hipGraphInstantiateFlagAutoFreeOnLaunch));
+
+    // First launch — alloc node acquires memory
+    HIP_CHECK(hipGraphLaunch(exec, stream));
+    HIP_CHECK(hipStreamSynchronize(stream));
+
+    // Second launch — AutoFreeOnLaunch frees the previous allocation
+    // (even though it was still mapped), then alloc node re-allocates.
+    HIP_CHECK(hipGraphLaunch(exec, stream));
+    HIP_CHECK(hipStreamSynchronize(stream));
+    
+    auto statsAfterSecond = queryGraphMem(device);
+    
+#if HT_AMD
+    // usedCurrent should still be a single allocation (old freed, new allocated)
+    REQUIRE(statsAfterSecond.usedCurrent == kAllocSize);
+#else
+    // on nvidia, allocation is not freed with hipGraphExecDestroy,
+    // so second launch allocates another chunk without freeing the first,
+    // resulting in 2x allocation size
+    REQUIRE(statsAfterSecond.usedCurrent == kAllocSize * 2 );
+#endif
+
+    HIP_CHECK(hipGraphExecDestroy(exec));
+  }
+
+  HIP_CHECK(hipGraphDestroy(graph));
 }
 
 /**

--- a/projects/hip-tests/catch/unit/graph/hipGraphAllocNodeMemReuse.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAllocNodeMemReuse.cc
@@ -1,0 +1,657 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip_test_common.hh>
+#include <hip_test_checkers.hh>
+#include <hip_test_kernels.hh>
+#include <resource_guards.hh>
+#include <utils.hh>
+
+/**
+ * @addtogroup hipGraphAllocNodeMemReuse hipGraphAllocNodeMemReuse
+ * @{
+ * @ingroup GraphTest
+ * Tests for verifying memory reuse optimization for graph allocation nodes when graphs
+ * are launched sequentially on the same stream.
+ */
+
+static constexpr int kBlockSize = 256;
+
+__global__ void fillKernel(float* buf, float value, int64_t n) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < n) {
+    buf[idx] = value;
+  }
+}
+
+__global__ void verifyKernel(const float* buf, float expected, int64_t n, int* error) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < n && buf[idx] != expected) {
+    atomicAdd(error, 1);
+  }
+}
+
+// Helper to capture a graph with hipMallocAsync and kernel launch
+static hipGraphExec_t captureGraphWithAlloc(hipStream_t stream, size_t allocBytes,
+                                            float fillValue) {
+  int64_t numElems = static_cast<int64_t>(allocBytes / sizeof(float));
+  int gridSize = static_cast<int>((numElems + kBlockSize - 1) / kBlockSize);
+
+  HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+
+  float* dTemp = nullptr;
+  HIP_CHECK(hipMallocAsync(reinterpret_cast<void**>(&dTemp), allocBytes, stream));
+
+  fillKernel<<<gridSize, kBlockSize, 0, stream>>>(dTemp, fillValue, numElems);
+
+  HIP_CHECK(hipFreeAsync(dTemp, stream));
+
+  hipGraph_t graph = nullptr;
+  HIP_CHECK(hipStreamEndCapture(stream, &graph));
+
+  hipGraphExec_t exec = nullptr;
+  HIP_CHECK(hipGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
+
+  HIP_CHECK(hipGraphDestroy(graph));
+
+  return exec;
+}
+
+// Helper to reset graph memory attributes
+static void resetGraphMemAttributes(int device) {
+  uint64_t zero = 0;
+  HIP_CHECK(hipDeviceSetGraphMemAttribute(device, hipGraphMemAttrUsedMemHigh, &zero));
+  HIP_CHECK(hipDeviceSetGraphMemAttribute(device, hipGraphMemAttrReservedMemHigh, &zero));
+}
+
+// Helper to query graph memory attributes
+struct GraphMemStats {
+  uint64_t usedCurrent;
+  uint64_t usedHigh;
+  uint64_t reservedCurrent;
+  uint64_t reservedHigh;
+};
+
+static GraphMemStats queryGraphMem(int device) {
+  GraphMemStats s{};
+  HIP_CHECK(
+      hipDeviceGetGraphMemAttribute(device, hipGraphMemAttrUsedMemCurrent, &s.usedCurrent));
+  HIP_CHECK(hipDeviceGetGraphMemAttribute(device, hipGraphMemAttrUsedMemHigh, &s.usedHigh));
+  HIP_CHECK(hipDeviceGetGraphMemAttribute(device, hipGraphMemAttrReservedMemCurrent,
+                                          &s.reservedCurrent));
+  HIP_CHECK(
+      hipDeviceGetGraphMemAttribute(device, hipGraphMemAttrReservedMemHigh, &s.reservedHigh));
+  return s;
+}
+
+void printDeviceMem(const char* label) {
+    size_t freeMem = 0, totalMem = 0;
+    HIP_CHECK(hipMemGetInfo(&freeMem, &totalMem));
+    size_t usedMem = totalMem - freeMem;
+    std::printf("[DevMem]   %-45s  used: %8.2f MB  free: %8.2f MB\n",
+        label,
+        static_cast<double>(usedMem) / (1024.0 * 1024.0),
+        static_cast<double>(freeMem) / (1024.0 * 1024.0));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Test to verify that when multiple graphs with the SAME allocation size are launched
+ *    sequentially on the same stream, they reuse the same physical memory.
+ *  - The memory reuse optimization works by caching allocations at the exact size requested.
+ *    When a subsequent graph requests the same allocation size, it can reuse the cached
+ *    physical memory from the previous allocation.
+ *  - This test creates three graphs with identical allocation sizes and verifies that the
+ *    high water mark reflects only a single allocation, not the sum of all three.
+ * Test source
+ * ------------------------
+ *  - /unit/graph/hipGraphAllocNodeMemReuse.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.2
+ */
+TEST_CASE("Unit_hipGraphAllocNodeMemReuse_SameStream_SameSizes") {
+  const int device = 0;
+  HIP_CHECK(hipSetDevice(device));
+
+  StreamGuard stream_guard(Streams::created);
+  hipStream_t stream = stream_guard.stream();
+
+  constexpr size_t kAllocSize = 128ULL * 1024 * 1024;  // 128 MB - same for all
+
+  resetGraphMemAttributes(device);
+
+  // Capture three graphs with IDENTICAL allocation sizes
+  hipGraphExec_t execA = captureGraphWithAlloc(stream, kAllocSize, 1.0f);
+  hipGraphExec_t execB = captureGraphWithAlloc(stream, kAllocSize, 2.0f);
+  hipGraphExec_t execC = captureGraphWithAlloc(stream, kAllocSize, 3.0f);
+
+  // Launch all three sequentially on the same stream
+  HIP_CHECK(hipGraphLaunch(execA, stream));
+  HIP_CHECK(hipGraphLaunch(execB, stream));
+  HIP_CHECK(hipGraphLaunch(execC, stream));
+
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  // Check memory statistics after launch+sync
+  auto stats = queryGraphMem(device);
+
+  // Memory is retained in the graph for reuse - usedCurrent should reflect
+  // a single allocation's worth (all three graphs reuse the same memory)
+  REQUIRE(stats.usedCurrent == kAllocSize);
+
+  // High water mark should be highest memory usage size
+  REQUIRE(stats.usedHigh == kAllocSize);
+
+  // Destroy graph executables - memory should be released
+  HIP_CHECK(hipGraphExecDestroy(execA));
+  HIP_CHECK(hipGraphExecDestroy(execB));
+  HIP_CHECK(hipGraphExecDestroy(execC));
+
+#if HT_AMD
+  // After graph destruction, memory should return to 0
+  auto statsAfterDestroy = queryGraphMem(device);
+  REQUIRE(statsAfterDestroy.usedCurrent == 0);
+#endif
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Test to verify that graphs with DIFFERENT allocation sizes do NOT reuse memory,
+ *    even when launched sequentially on the same stream.
+ *  - The memory reuse optimization only works for exact size matches. Different sizes
+ *    require separate physical allocations acquired directly from the OS.
+ *  - This test creates three graphs with different allocation sizes and verifies that
+ *    the high water mark reflects the sum of all allocations, NOT just the largest.
+ * Test source
+ * ------------------------
+ *  - /unit/graph/hipGraphAllocNodeMemReuse.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.2
+ */
+TEST_CASE("Unit_hipGraphAllocNodeMemReuse_SameStream_DifferentSizes_NoReuse") {
+  const int device = 0;
+  HIP_CHECK(hipSetDevice(device));
+
+  StreamGuard stream_guard(Streams::created);
+  hipStream_t stream = stream_guard.stream();
+
+  constexpr size_t kAllocA = 128ULL * 1024 * 1024;  // 128 MB
+  constexpr size_t kAllocB = 64ULL * 1024 * 1024;   // 64 MB
+  constexpr size_t kAllocC = 32ULL * 1024 * 1024;   // 32 MB
+
+  resetGraphMemAttributes(device);
+
+  // Capture three graphs with DIFFERENT allocation sizes
+  hipGraphExec_t execA = captureGraphWithAlloc(stream, kAllocA, 1.0f);
+  hipGraphExec_t execB = captureGraphWithAlloc(stream, kAllocB, 2.0f);
+  hipGraphExec_t execC = captureGraphWithAlloc(stream, kAllocC, 3.0f);
+
+  // Launch all three sequentially on the same stream
+  HIP_CHECK(hipGraphLaunch(execA, stream));
+  HIP_CHECK(hipGraphLaunch(execB, stream));
+  HIP_CHECK(hipGraphLaunch(execC, stream));
+
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  // Check memory statistics
+  auto stats = queryGraphMem(device);
+
+  // Memory is retained in graphs until destruction or trim.
+#if HT_NVIDIA
+  constexpr size_t totalAlloc = kAllocA;
+#else
+  constexpr size_t totalAlloc = kAllocA + kAllocB + kAllocC;
+#endif
+  REQUIRE(stats.usedCurrent == totalAlloc);
+
+  // High water mark should reflect highest memory usage at any time
+  REQUIRE(stats.usedHigh == kAllocA);
+
+  // Destroy graph executables - memory should be released
+  HIP_CHECK(hipGraphExecDestroy(execA));
+  HIP_CHECK(hipGraphExecDestroy(execB));
+  HIP_CHECK(hipGraphExecDestroy(execC));
+
+#if HT_AMD
+  // After graph destruction, memory should return to 0
+  auto statsAfterDestroy = queryGraphMem(device);
+  REQUIRE(statsAfterDestroy.usedCurrent == 0);
+#endif
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Test to verify that memory reuse works correctly across multiple launches of the same
+ *    graph executable.
+ *  - This test launches the same graph multiple times sequentially and verifies that the
+ *    memory high water mark remains stable (not growing with each launch).
+ * Test source
+ * ------------------------
+ *  - /unit/graph/hipGraphAllocNodeMemReuse.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 6.0
+ */
+TEST_CASE("Unit_hipGraphAllocNodeMemReuse_RepeatedLaunches") {
+  const int device = 0;
+  HIP_CHECK(hipSetDevice(device));
+
+  StreamGuard stream_guard(Streams::created);
+  hipStream_t stream = stream_guard.stream();
+
+  constexpr size_t kAllocSize = 64ULL * 1024 * 1024;  // 64 MB
+
+  resetGraphMemAttributes(device);
+
+  // Capture a single graph
+  hipGraphExec_t exec = captureGraphWithAlloc(stream, kAllocSize, 1.0f);
+
+  // Launch the same graph multiple times
+  constexpr int numLaunches = 10;
+  for (int i = 0; i < numLaunches; i++) {
+    HIP_CHECK(hipGraphLaunch(exec, stream));
+  }
+
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  // Check memory statistics
+  auto stats = queryGraphMem(device);
+
+  // Memory is retained in graph until destruction or trim
+  REQUIRE(stats.usedCurrent == kAllocSize);
+
+  // High water mark should be close to a single allocation size
+  // Not numLaunches * kAllocSize
+  REQUIRE(stats.usedHigh == kAllocSize);
+
+  // Destroy graph executable - memory should be released
+  HIP_CHECK(hipGraphExecDestroy(exec));
+
+#if HT_AMD
+  // After graph destruction, memory should return to 0
+  auto statsAfterDestroy = queryGraphMem(device);
+  REQUIRE(statsAfterDestroy.usedCurrent == 0);
+#endif
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Test to verify that hipDeviceGraphMemTrim properly releases reserved graph memory.
+ *  - After launching graphs and synchronizing, reserved memory should still be held for
+ *    potential reuse. After calling hipDeviceGraphMemTrim, the reserved memory should be
+ *    released back to the OS.
+ * Test source
+ * ------------------------
+ *  - /unit/graph/hipGraphAllocNodeMemReuse.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 6.0
+ */
+TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MemoryTrim") {
+  const int device = 0;
+  HIP_CHECK(hipSetDevice(device));
+
+  StreamGuard stream_guard(Streams::created);
+  hipStream_t stream = stream_guard.stream();
+
+  constexpr size_t kAllocSize = 128ULL * 1024 * 1024;  // 128 MB
+
+  resetGraphMemAttributes(device);
+
+  // Capture and launch a graph
+  hipGraphExec_t exec = captureGraphWithAlloc(stream, kAllocSize, 1.0f);
+  HIP_CHECK(hipGraphLaunch(exec, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  // Memory is retained in graph for reuse after launch+sync
+  auto statsBefore = queryGraphMem(device);
+  REQUIRE(statsBefore.usedCurrent == kAllocSize);
+  REQUIRE(statsBefore.reservedCurrent > 0);  // Memory should be reserved for reuse
+
+  // Trim graph memory
+  HIP_CHECK(hipDeviceGraphMemTrim(device));
+
+  // Check that reserved memory is released after trim
+  auto statsAfter = queryGraphMem(device);
+  REQUIRE(statsAfter.usedCurrent == 0);
+  REQUIRE(statsAfter.reservedCurrent == 0);  // Reserved memory should be freed
+
+  // Cleanup
+  HIP_CHECK(hipGraphExecDestroy(exec));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Test to verify memory reuse with graphs containing explicit hipGraphAddMemAllocNode
+ *    and hipGraphAddMemFreeNode instead of stream capture.
+ *  - This test manually constructs two graphs with IDENTICAL allocation sizes and verifies
+ *    memory reuse when launched sequentially on the same stream.
+ * Test source
+ * ------------------------
+ *  - /unit/graph/hipGraphAllocNodeMemReuse.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 6.0
+ */
+TEST_CASE("Unit_hipGraphAllocNodeMemReuse_ExplicitAllocFreeNodes_SameSize") {
+  const int device = 0;
+  HIP_CHECK(hipSetDevice(device));
+
+  StreamGuard stream_guard(Streams::created);
+  hipStream_t stream = stream_guard.stream();
+
+  constexpr size_t kAllocSize = 128ULL * 1024 * 1024;  // 128 MB - same for both
+
+  resetGraphMemAttributes(device);
+
+  // Create first graph with explicit alloc/free nodes
+  hipGraph_t graphA;
+  HIP_CHECK(hipGraphCreate(&graphA, 0));
+
+  hipGraphNode_t allocNodeA;
+  hipMemAllocNodeParams allocParamA;
+  memset(&allocParamA, 0, sizeof(allocParamA));
+  allocParamA.bytesize = kAllocSize;
+  allocParamA.poolProps.allocType = hipMemAllocationTypePinned;
+  allocParamA.poolProps.location.id = 0;
+  allocParamA.poolProps.location.type = hipMemLocationTypeDevice;
+
+  HIP_CHECK(hipGraphAddMemAllocNode(&allocNodeA, graphA, nullptr, 0, &allocParamA));
+  REQUIRE(allocParamA.dptr != nullptr);
+
+  hipGraphNode_t freeNodeA;
+  HIP_CHECK(hipGraphAddMemFreeNode(&freeNodeA, graphA, &allocNodeA, 1, allocParamA.dptr));
+
+  hipGraphExec_t execA;
+  HIP_CHECK(hipGraphInstantiate(&execA, graphA, nullptr, nullptr, 0));
+
+  // Create second graph with explicit alloc/free nodes - SAME SIZE
+  hipGraph_t graphB;
+  HIP_CHECK(hipGraphCreate(&graphB, 0));
+
+  hipGraphNode_t allocNodeB;
+  hipMemAllocNodeParams allocParamB;
+  memset(&allocParamB, 0, sizeof(allocParamB));
+  allocParamB.bytesize = kAllocSize;  // Same size as graph A
+  allocParamB.poolProps.allocType = hipMemAllocationTypePinned;
+  allocParamB.poolProps.location.id = 0;
+  allocParamB.poolProps.location.type = hipMemLocationTypeDevice;
+
+  HIP_CHECK(hipGraphAddMemAllocNode(&allocNodeB, graphB, nullptr, 0, &allocParamB));
+  REQUIRE(allocParamB.dptr != nullptr);
+
+  hipGraphNode_t freeNodeB;
+  HIP_CHECK(hipGraphAddMemFreeNode(&freeNodeB, graphB, &allocNodeB, 1, allocParamB.dptr));
+
+  hipGraphExec_t execB;
+  HIP_CHECK(hipGraphInstantiate(&execB, graphB, nullptr, nullptr, 0));
+
+  // Launch both graphs sequentially on same stream
+  HIP_CHECK(hipGraphLaunch(execA, stream));
+  HIP_CHECK(hipGraphLaunch(execB, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  // Check memory statistics
+  auto stats = queryGraphMem(device);
+
+  // Memory is retained in graphs until destruction or trim.
+  // Both graphs reuse the same memory (same size), so usedCurrent == kAllocSize.
+  REQUIRE(stats.usedCurrent == kAllocSize);
+
+  // High water mark should be a single allocation (kAllocSize)
+  // NOT 2x, proving memory reuse for same-sized allocations
+  REQUIRE(stats.usedHigh == kAllocSize);
+
+  // Destroy graph executables and graphs - memory should be released
+  HIP_CHECK(hipGraphExecDestroy(execA));
+  HIP_CHECK(hipGraphExecDestroy(execB));
+  HIP_CHECK(hipGraphDestroy(graphA));
+  HIP_CHECK(hipGraphDestroy(graphB));
+
+#if HT_AMD
+  // After graph destruction, memory should return to 0
+  auto statsAfterDestroy = queryGraphMem(device);
+  REQUIRE(statsAfterDestroy.usedCurrent == 0);
+#endif
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Test to verify that explicit alloc nodes with DIFFERENT sizes do NOT reuse memory.
+ *  - This complements the previous test by showing that different-sized allocations
+ *    require separate physical memory, even with explicit alloc/free nodes.
+ * Test source
+ * ------------------------
+ *  - /unit/graph/hipGraphAllocNodeMemReuse.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 6.0
+ */
+TEST_CASE("Unit_hipGraphAllocNodeMemReuse_ExplicitAllocFreeNodes_DifferentSizes") {
+  const int device = 0;
+  HIP_CHECK(hipSetDevice(device));
+
+  StreamGuard stream_guard(Streams::created);
+  hipStream_t stream = stream_guard.stream();
+
+  constexpr size_t kAllocA = 128ULL * 1024 * 1024;  // 128 MB
+  constexpr size_t kAllocB = 64ULL * 1024 * 1024;   // 64 MB - different size
+
+  resetGraphMemAttributes(device);
+
+  // Create first graph with explicit alloc/free nodes
+  hipGraph_t graphA;
+  HIP_CHECK(hipGraphCreate(&graphA, 0));
+
+  hipGraphNode_t allocNodeA;
+  hipMemAllocNodeParams allocParamA;
+  memset(&allocParamA, 0, sizeof(allocParamA));
+  allocParamA.bytesize = kAllocA;
+  allocParamA.poolProps.allocType = hipMemAllocationTypePinned;
+  allocParamA.poolProps.location.id = 0;
+  allocParamA.poolProps.location.type = hipMemLocationTypeDevice;
+
+  HIP_CHECK(hipGraphAddMemAllocNode(&allocNodeA, graphA, nullptr, 0, &allocParamA));
+  REQUIRE(allocParamA.dptr != nullptr);
+
+  hipGraphNode_t freeNodeA;
+  HIP_CHECK(hipGraphAddMemFreeNode(&freeNodeA, graphA, &allocNodeA, 1, allocParamA.dptr));
+
+  hipGraphExec_t execA;
+  HIP_CHECK(hipGraphInstantiate(&execA, graphA, nullptr, nullptr, 0));
+
+  // Create second graph with DIFFERENT size
+  hipGraph_t graphB;
+  HIP_CHECK(hipGraphCreate(&graphB, 0));
+
+  hipGraphNode_t allocNodeB;
+  hipMemAllocNodeParams allocParamB;
+  memset(&allocParamB, 0, sizeof(allocParamB));
+  allocParamB.bytesize = kAllocB;  // Different size
+  allocParamB.poolProps.allocType = hipMemAllocationTypePinned;
+  allocParamB.poolProps.location.id = 0;
+  allocParamB.poolProps.location.type = hipMemLocationTypeDevice;
+
+  HIP_CHECK(hipGraphAddMemAllocNode(&allocNodeB, graphB, nullptr, 0, &allocParamB));
+  REQUIRE(allocParamB.dptr != nullptr);
+
+  hipGraphNode_t freeNodeB;
+  HIP_CHECK(hipGraphAddMemFreeNode(&freeNodeB, graphB, &allocNodeB, 1, allocParamB.dptr));
+
+  hipGraphExec_t execB;
+  HIP_CHECK(hipGraphInstantiate(&execB, graphB, nullptr, nullptr, 0));
+
+  // Launch both graphs sequentially on same stream
+  HIP_CHECK(hipGraphLaunch(execA, stream));
+  HIP_CHECK(hipGraphLaunch(execB, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  // Check memory statistics
+  auto stats = queryGraphMem(device);
+
+  // Memory is retained in graphs until destruction or trim.
+  // Each graph holds its own allocation (no reuse across different sizes).
+#if HT_NVIDIA
+  constexpr size_t totalAlloc = kAllocA; // on Nvidia 128MB chunk is reused
+#else
+  constexpr size_t totalAlloc = kAllocA + kAllocB;
+#endif
+  REQUIRE(stats.usedCurrent == totalAlloc);
+
+  // High water mark should reflect highest memory usage at any time
+  REQUIRE(stats.usedHigh == kAllocA);
+
+  // Destroy graph executables and graphs - memory should be released
+  HIP_CHECK(hipGraphExecDestroy(execA));
+  HIP_CHECK(hipGraphExecDestroy(execB));
+  HIP_CHECK(hipGraphDestroy(graphA));
+  HIP_CHECK(hipGraphDestroy(graphB));
+
+#if HT_AMD
+  // After graph destruction, memory should return to 0
+  auto statsAfterDestroy = queryGraphMem(device);
+  REQUIRE(statsAfterDestroy.usedCurrent == 0);
+#endif
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Test to verify that memory reuse does NOT occur for malloc nodes that don't have
+ *    a corresponding free node within the graph.
+ *  - This test creates a graph with 4 malloc nodes (all same size), but only 3 have
+ *    corresponding free nodes in the graph. The 4th malloc node's memory is freed
+ *    using hipFreeAsync outside the graph after launch.
+ *  - Since the 4th malloc node lacks an in-graph free node, it cannot participate in
+ *    memory reuse optimization. The total memory usage should reflect this.
+ *  - Expected: Memory usage > single allocation size (because the orphan malloc node
+ *    holds separate memory that can't be reused by the other nodes).
+ * Test source
+ * ------------------------
+ *  - /unit/graph/hipGraphAllocNodeMemReuse.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 6.0
+ */
+TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MallocWithoutFree_NoReuse") {
+  const int device = 0;
+  HIP_CHECK(hipSetDevice(device));
+
+  StreamGuard stream_guard(Streams::created);
+  hipStream_t stream = stream_guard.stream();
+
+  constexpr size_t kAllocSize = 64ULL * 1024 * 1024;  // 64 MB - same for all nodes
+
+  resetGraphMemAttributes(device);
+
+  // Create a graph with 4 malloc nodes, but only 3 have free nodes.
+  // The orphan malloc node is placed FIRST in the graph.
+  hipGraph_t graph;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+
+  // Node 1: Orphan malloc WITHOUT corresponding free (placed first)
+  hipGraphNode_t allocNode1;
+  hipMemAllocNodeParams allocParam1;
+  memset(&allocParam1, 0, sizeof(allocParam1));
+  allocParam1.bytesize = kAllocSize;
+  allocParam1.poolProps.allocType = hipMemAllocationTypePinned;
+  allocParam1.poolProps.location.id = 0;
+  allocParam1.poolProps.location.type = hipMemLocationTypeDevice;
+
+  HIP_CHECK(hipGraphAddMemAllocNode(&allocNode1, graph, nullptr, 0, &allocParam1));
+  REQUIRE(allocParam1.dptr != nullptr);
+  void* orphanPtr = allocParam1.dptr;  // Will free this outside the graph
+
+  // Node 2: Malloc with corresponding free (depends on orphan node)
+  hipGraphNode_t allocNode2;
+  hipMemAllocNodeParams allocParam2;
+  memset(&allocParam2, 0, sizeof(allocParam2));
+  allocParam2.bytesize = kAllocSize;
+  allocParam2.poolProps.allocType = hipMemAllocationTypePinned;
+  allocParam2.poolProps.location.id = 0;
+  allocParam2.poolProps.location.type = hipMemLocationTypeDevice;
+
+  HIP_CHECK(hipGraphAddMemAllocNode(&allocNode2, graph, &allocNode1, 1, &allocParam2));
+  REQUIRE(allocParam2.dptr != nullptr);
+
+  hipGraphNode_t freeNode2;
+  HIP_CHECK(hipGraphAddMemFreeNode(&freeNode2, graph, &allocNode2, 1, allocParam2.dptr));
+
+  // Node 3: Malloc with corresponding free (depends on freeNode2)
+  hipGraphNode_t allocNode3;
+  hipMemAllocNodeParams allocParam3;
+  memset(&allocParam3, 0, sizeof(allocParam3));
+  allocParam3.bytesize = kAllocSize;
+  allocParam3.poolProps.allocType = hipMemAllocationTypePinned;
+  allocParam3.poolProps.location.id = 0;
+  allocParam3.poolProps.location.type = hipMemLocationTypeDevice;
+
+  HIP_CHECK(hipGraphAddMemAllocNode(&allocNode3, graph, &freeNode2, 1, &allocParam3));
+  REQUIRE(allocParam3.dptr != nullptr);
+
+  hipGraphNode_t freeNode3;
+  HIP_CHECK(hipGraphAddMemFreeNode(&freeNode3, graph, &allocNode3, 1, allocParam3.dptr));
+
+  // Node 4: Malloc with corresponding free (depends on freeNode3)
+  hipGraphNode_t allocNode4;
+  hipMemAllocNodeParams allocParam4;
+  memset(&allocParam4, 0, sizeof(allocParam4));
+  allocParam4.bytesize = kAllocSize;
+  allocParam4.poolProps.allocType = hipMemAllocationTypePinned;
+  allocParam4.poolProps.location.id = 0;
+  allocParam4.poolProps.location.type = hipMemLocationTypeDevice;
+
+  HIP_CHECK(hipGraphAddMemAllocNode(&allocNode4, graph, &freeNode3, 1, &allocParam4));
+  REQUIRE(allocParam4.dptr != nullptr);
+
+  hipGraphNode_t freeNode4;
+  HIP_CHECK(hipGraphAddMemFreeNode(&freeNode4, graph, &allocNode4, 1, allocParam4.dptr));
+
+  // Instantiate and launch the graph
+  hipGraphExec_t graphExec;
+  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  HIP_CHECK(hipGraphLaunch(graphExec, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  // Check memory statistics BEFORE freeing the orphan allocation
+  auto statsBefore = queryGraphMem(device);
+
+  // The orphan malloc node (node 1) has no in-graph free, so it cannot participate in
+  // memory reuse. It holds its own 64MB allocation throughout.
+  // Nodes 2-4 have free nodes and can reuse memory among themselves, needing one
+  // additional 64MB allocation.
+  // Therefore usedCurrent == 2 * kAllocSize:
+  //   - kAllocSize for the orphan node (still allocated, no in-graph free)
+  //   - kAllocSize for the reusable pool shared by nodes 2-4
+  REQUIRE(statsBefore.usedCurrent == kAllocSize * 2);
+
+  // Free the orphan allocation outside the graph using hipFreeAsync
+  HIP_CHECK(hipFreeAsync(orphanPtr, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  // Destroy graph executable and graph - remaining retained memory should be released
+  HIP_CHECK(hipGraphExecDestroy(graphExec));
+  HIP_CHECK(hipGraphDestroy(graph));
+
+#if HT_AMD
+  // After graph destruction, memory should return to 0
+  auto statsAfterDestroy = queryGraphMem(device);
+  REQUIRE(statsAfterDestroy.usedCurrent == 0);
+#endif
+}
+
+/**
+ * @}
+ */

--- a/projects/hip-tests/catch/unit/graph/hipGraphAllocNodeMemReuse.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAllocNodeMemReuse.cc
@@ -167,7 +167,7 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_SameStream_SameSizes") {
  *  - The memory reuse optimization only works for exact size matches. Different sizes
  *    require separate physical allocations acquired directly from the OS.
  *  - This test creates three graphs with different allocation sizes and verifies that
- *    the high water mark reflects the sum of all allocations, NOT just the largest.
+ *    the current memory usage is sum of all 3 allocations for amd
  * Test source
  * ------------------------
  *  - /unit/graph/hipGraphAllocNodeMemReuse.cc

--- a/projects/hip-tests/catch/unit/graph/hipGraphAllocNodeMemReuse.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAllocNodeMemReuse.cc
@@ -9,6 +9,7 @@
 #include <hip_test_kernels.hh>
 #include <resource_guards.hh>
 #include <utils.hh>
+#include <thread>
 
 /**
  * @addtogroup hipGraphAllocNodeMemReuse hipGraphAllocNodeMemReuse
@@ -654,6 +655,158 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MallocWithoutFree_NoReuse") {
 
 #if HT_AMD
   // After graph destruction, memory should return to 0
+  auto statsAfterDestroy = queryGraphMem(device);
+  REQUIRE(statsAfterDestroy.usedCurrent == 0);
+#endif
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Test to verify that graphs captured on different streams do NOT share memory.
+ *  - Two graphs are captured on separate streams, each with a malloc->kernel->free
+ *  - sequence. Memory can be shared between graphs and current graph pool usage
+ *  - should reflect that.
+ * Test source
+ * ------------------------
+ *  - /unit/graph/hipGraphAllocNodeMemReuse.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.2
+ */
+TEST_CASE("Unit_hipGraphAllocNodeMemReuse_DifferentStreams_Reuse") {
+  const int device = 0;
+  HIP_CHECK(hipSetDevice(device));
+
+  StreamGuard stream_guard1(Streams::created);
+  hipStream_t stream1 = stream_guard1.stream();
+
+  StreamGuard stream_guard2(Streams::created);
+  hipStream_t stream2 = stream_guard2.stream();
+
+  constexpr size_t kAllocSize = 64ULL * 1024 * 1024;  // 64 MB for each graph
+
+  resetGraphMemAttributes(device);
+
+  // Capture graph A on stream1: malloc -> fill kernel -> free
+  hipGraphExec_t execA = captureGraphWithAlloc(stream1, kAllocSize, 1.0f);
+
+  // Capture graph B on stream2: malloc -> fill kernel -> free
+  hipGraphExec_t execB = captureGraphWithAlloc(stream2, kAllocSize, 2.0f);
+
+  // Launch graph A on stream1 and graph B on stream2
+  HIP_CHECK(hipGraphLaunch(execA, stream1));
+  HIP_CHECK(hipStreamSynchronize(stream1));
+
+  HIP_CHECK(hipGraphLaunch(execB, stream2));
+  HIP_CHECK(hipStreamSynchronize(stream2));
+
+  // Check memory statistics - each graph has its own allocation
+  auto stats = queryGraphMem(device);
+
+  // Both graphs retain their own memory (no cross-graph reuse on different streams),
+  // so usedCurrent should be the sum of both allocations.
+  REQUIRE(stats.usedCurrent == kAllocSize);
+
+  // Destroy graph executables - memory should be released
+  HIP_CHECK(hipGraphExecDestroy(execA));
+  HIP_CHECK(hipGraphExecDestroy(execB));
+
+#if HT_AMD
+  // After graph destruction, memory should return to 0
+  auto statsAfterDestroy = queryGraphMem(device);
+  REQUIRE(statsAfterDestroy.usedCurrent == 0);
+#endif
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Test to verify that VA remap works correctly when two graphs share the same
+ *    memory pool and one graph steals the other's physical memory.
+ *  - Sequence:
+ *    1. Capture graph A and graph B with malloc->kernel->free (same alloc size).
+ *    2. Launch graph A on stream1 and sync. Physical memory goes to the shared
+ *       graph pool's free_heap.
+ *    3. From two host threads, concurrently:
+ *       - Thread 1: launch graph B on stream2 (may steal graph A's physical memory
+ *         from free_heap via opportunistic reuse).
+ *       - Thread 2: relaunch graph A on stream1 (if its physical memory was stolen,
+ *         the runtime must allocate new memory and remap the VA).
+ *    4. Both threads sync. Verify neither graph crashes and memory stats are consistent.
+ * Test source
+ * ------------------------
+ *  - /unit/graph/hipGraphAllocNodeMemReuse.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.2
+ */
+TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MemSteal_Remap") {
+  const int device = 0;
+  HIP_CHECK(hipSetDevice(device));
+
+  StreamGuard stream_guard1(Streams::created);
+  hipStream_t stream1 = stream_guard1.stream();
+
+  StreamGuard stream_guard2(Streams::created);
+  hipStream_t stream2 = stream_guard2.stream();
+
+  constexpr size_t kAllocSize = 64ULL * 1024 * 1024;  // 64 MB - same for both graphs
+
+  resetGraphMemAttributes(device);
+
+  // Step 1: Capture two graphs with identical alloc sizes
+  hipGraphExec_t execA = captureGraphWithAlloc(stream1, kAllocSize, 1.0f);
+  hipGraphExec_t execB = captureGraphWithAlloc(stream2, kAllocSize, 2.0f);
+
+  // Step 2: Launch graph A first and sync — its physical memory goes to the shared
+  // graph pool's free_heap, available for opportunistic reuse by graph B.
+  HIP_CHECK(hipGraphLaunch(execA, stream1));
+  HIP_CHECK(hipStreamSynchronize(stream1));
+
+  auto statsAfterFirstLaunch = queryGraphMem(device);
+  REQUIRE(statsAfterFirstLaunch.usedCurrent == kAllocSize);
+
+  // Step 3: Concurrently launch graph B (which may steal graph A's memory) and
+  // relaunch graph A (which must remap if its memory was stolen).
+  hipError_t errB = hipSuccess;
+  hipError_t errA = hipSuccess;
+
+  std::thread threadB([&]() {
+    errB = hipGraphLaunch(execB, stream2);
+    if (errB == hipSuccess) {
+      errB = hipStreamSynchronize(stream2);
+    }
+  });
+
+  std::thread threadA([&]() {
+    errA = hipGraphLaunch(execA, stream1);
+    if (errA == hipSuccess) {
+      errA = hipStreamSynchronize(stream1);
+    }
+  });
+
+  threadB.join();
+  threadA.join();
+
+  REQUIRE(errB == hipSuccess);
+  REQUIRE(errA == hipSuccess);
+
+  // Step 4: Verify memory stats. Both graphs completed successfully.
+  // Depending on which thread won the race:
+  //   - If graph B stole graph A's memory: graph A remapped to new memory,
+  //     usedCurrent == 2 * kAllocSize (each graph holds its own allocation)
+  //   - If graph A reclaimed its own memory: graph B allocated fresh,
+  //     usedCurrent == 2 * kAllocSize
+  // Either way, both graphs hold one allocation each after completion.
+  auto statsAfterConcurrent = queryGraphMem(device);
+  REQUIRE(statsAfterConcurrent.usedCurrent == kAllocSize * 2);
+
+  // Cleanup
+  HIP_CHECK(hipGraphExecDestroy(execA));
+  HIP_CHECK(hipGraphExecDestroy(execB));
+
+#if HT_AMD
   auto statsAfterDestroy = queryGraphMem(device);
   REQUIRE(statsAfterDestroy.usedCurrent == 0);
 #endif

--- a/projects/hip-tests/catch/unit/graph/hipGraphAllocNodeMemReuse.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAllocNodeMemReuse.cc
@@ -843,15 +843,16 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MemSteal_Remap") {
   REQUIRE(errB == hipSuccess);
   REQUIRE(errA == hipSuccess);
 
-  // Step 4: Verify memory stats. Both graphs completed successfully.
-  // Depending on which thread won the race:
-  //   - If graph B stole graph A's memory: graph A remapped to new memory,
-  //     usedCurrent == 2 * kAllocSize (each graph holds its own allocation)
-  //   - If graph A reclaimed its own memory: graph B allocated fresh,
-  //     usedCurrent == 2 * kAllocSize
-  // Either way, both graphs hold one allocation each after completion.
+  // Step 4: Verify both graphs completed successfully and memory stats are sane.
+  // The outcome depends on thread scheduling:
+  //   - If launches overlapped: graph B stole graph A's memory, graph A remapped
+  //     to new memory → usedCurrent == 2 * kAllocSize
+  //   - If launches serialized: one graph reused the other's freed memory
+  //     → usedCurrent == kAllocSize
+  // Both outcomes are correct — the key assertion is no crash and no corruption.
   auto statsAfterConcurrent = queryGraphMem(device);
-  REQUIRE(statsAfterConcurrent.usedCurrent == kAllocSize * 2);
+  REQUIRE((statsAfterConcurrent.usedCurrent == kAllocSize ||
+           statsAfterConcurrent.usedCurrent == kAllocSize * 2));
 
   // Cleanup
   HIP_CHECK(hipGraphExecDestroy(execA));


### PR DESCRIPTION
## Motivation
**Remove map/unmap calls during graph launch**
1. Avoid map/unmap calls during relaunch for alloc/free nodes
2. Reuse physical memory by tracking using a reference counter in heap allocation map.
3. allocations are moved from busy heap to free heap during free node execution and are available for downstream nodes to reuse.
4. allocations are unmapped on hipGraphExecDestroy call and freed to device. This differs from cuda behavior, which retains allocations even after graph exec destroy and only frees the allocation on pool trim.
5. test cases are added to validate this limited memory reuse feature. 

**Fix Race condition in WDDM queue for ROCR on windows path**
1. By removing map/umap calls the queue is not in idle state when graph is relaunched and kernel command is queued.
2. After post marker enqueue, the bulk memcpy of AQL packets into the ring buffer leaves zeroed (0x0) headers on subsequent packets. The WDDM AQL processing thread processes packets sequentially and could read these invalid headers before the valid ones were written. 
3. To fix this race condition in WDDM queue, the first header in packet batch needs to be set correctly to Invalid type. This would block the WDDM queue to execute the packet until valid header is written to the queue.

**Deadlock in non-DD path due to incorrect ordering of marker**
1. for non-DD path (windows pal), there are two threads 'user thread' and 'command queue thread'.
2. packet batch submission enqueues packets to user thread before any submission for command queue thread.
3. while processing VirtualMemFreeNode command, it submits an event marker to the command queue thread which goes to the end of the queue, behind the other commands submitted by graph packet batch.
4. Since this event marker is not submitted in-order, command queue thread goes into deadlock waiting for this marker to complete. 
5. For non-DD path, on graph submission,  this event Marker is skipped since graph packet batch already appends post-marker after each uncaptured node.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
