### PR TITLE
[rocprofiler-compute] Fix subprocess stdout truncation and interleaving

### DIFF
--- a/projects/rocprofiler-compute/pyproject.toml
+++ b/projects/rocprofiler-compute/pyproject.toml
@@ -65,7 +65,6 @@ pythonpath = [
     ".",
     "src",
     "src/rocprof_compute_soc",
-    "src/utils",
     "src/roofline",
     "src/rocprof_compute_analyze/utils",
     "tests"

--- a/projects/rocprofiler-compute/src/utils/utils_common.py
+++ b/projects/rocprofiler-compute/src/utils/utils_common.py
@@ -469,24 +469,41 @@ def capture_subprocess_output(
         }
     )
 
-    # PTY (not a pipe) so the child sees a terminal and line-buffers its
-    # output. Prevents partial lines from one writer getting glued onto
-    # complete lines from another writer sharing the same fd.
-    pty_parent_fd, pty_child_fd = pty.openpty()
-    # env=None is Popen's default (inherit parent env), so passing
-    # sanitized_env directly handles both the None and dict cases.
-    process = subprocess.Popen(
-        subprocess_args,
-        stdin=subprocess.PIPE,
-        stdout=pty_child_fd,
-        stderr=pty_child_fd,
-        universal_newlines=True,
-        env=sanitized_env,
-    )
-    os.close(pty_child_fd)
-    # buffering=1 for line-buffered reads, errors="replace" so bad bytes
-    # don't crash the read loop.
-    process_stdout = os.fdopen(pty_parent_fd, "r", buffering=1, errors="replace")
+    # Use a PTY in profile mode to prevent instrumentation output from
+    # being interleaved with workload output.
+    if profileMode:
+        pty_parent_fd, pty_child_fd = pty.openpty()
+        stdout_arg = pty_child_fd
+        stderr_arg = pty_child_fd
+    else:
+        stdout_arg = subprocess.PIPE
+        stderr_arg = subprocess.STDOUT
+
+    # env=None is Popen's default (inherit parent env).
+    try:
+        process = subprocess.Popen(
+            subprocess_args,
+            stdin=subprocess.PIPE,
+            stdout=stdout_arg,
+            stderr=stderr_arg,
+            universal_newlines=True,
+            errors="replace",
+            env=sanitized_env,
+        )
+    except BaseException:
+        # Close PTY fds if Popen fails.
+        if profileMode:
+            os.close(pty_parent_fd)
+            os.close(pty_child_fd)
+        raise
+
+    if profileMode:
+        # Close the child end; parent only reads. errors="replace" skips
+        # bad bytes instead of crashing the read loop.
+        os.close(pty_child_fd)
+        process_stdout = os.fdopen(pty_parent_fd, "r", errors="replace")
+    else:
+        process_stdout = process.stdout
 
     # Create buffer for captured process output
     buf = io.StringIO()
@@ -528,9 +545,8 @@ def capture_subprocess_output(
     input_thread = threading.Thread(target=forward_input, daemon=True)
     input_thread.start()
 
-    # Read until the child closes its end. On Linux, reading a closed PTY
-    # parent end raises OSError(EIO) instead of returning an empty string,
-    # so that's how we detect end-of-stream here.
+    # Read until the child closes its end. Pipes signal EOF with an empty
+    # string; PTYs signal it with OSError(EIO). The two never overlap.
     while True:
         try:
             line = process_stdout.readline()
@@ -538,6 +554,8 @@ def capture_subprocess_output(
             if e.errno == errno.EIO:
                 break
             raise
+        if not line:
+            break
         buf.write(line)
         if not enable_logging:
             continue

--- a/projects/rocprofiler-compute/src/utils/utils_common.py
+++ b/projects/rocprofiler-compute/src/utils/utils_common.py
@@ -10,7 +10,6 @@ import locale
 import os
 import re
 import select
-import selectors
 import shutil
 import subprocess
 import sys
@@ -492,30 +491,8 @@ def capture_subprocess_output(
         )
     )
 
-    # Create callback function for process output
+    # Create buffer for captured process output
     buf = io.StringIO()
-
-    def handle_output(stream: io.TextIOWrapper, _mask) -> None:
-        try:
-            # Because the process' output is line buffered, there's only ever one
-            # line to read when this function is called
-            line = stream.readline()
-            if not line:
-                return
-            buf.write(line)
-            if enable_logging:
-                if profileMode:
-                    console_log(get_rocprof_cmd(), line.strip(), indent_level=1)
-                else:
-                    console_log(line.strip())
-        except UnicodeDecodeError:
-            # Skip this line
-            pass
-
-    # Register callback for an "available for read" event from subprocess' stdout stream
-    selector = selectors.DefaultSelector()
-    if process.stdout is not None:
-        selector.register(process.stdout, selectors.EVENT_READ, handle_output)
 
     def forward_input() -> None:
         """
@@ -554,19 +531,28 @@ def capture_subprocess_output(
     input_thread = threading.Thread(target=forward_input, daemon=True)
     input_thread.start()
 
-    # Loop until subprocess is terminated
-    while process.poll() is None:
-        # Wait for events and handle them with their registered callbacks
-        events = selector.select()
-        for key, mask in events:
-            callback = key.data
-            callback(key.fileobj, mask)
+    # Read until the pipe closes, not until the child exits. Otherwise lines
+    # still buffered in the pipe at exit time are dropped.
+    if process.stdout is not None:
+        while True:
+            try:
+                line = process.stdout.readline()
+            except UnicodeDecodeError:
+                continue
+            if not line:
+                break
+            buf.write(line)
+            if not enable_logging:
+                continue
+            if profileMode:
+                console_log(get_rocprof_cmd(), line.strip(), indent_level=1)
+            else:
+                console_log(line.strip())
 
     input_thread.join(timeout=1)
 
     # Get process return code
     return_code = process.wait()
-    selector.close()
 
     success = return_code == 0
 

--- a/projects/rocprofiler-compute/src/utils/utils_common.py
+++ b/projects/rocprofiler-compute/src/utils/utils_common.py
@@ -477,7 +477,6 @@ def capture_subprocess_output(
     # sanitized_env directly handles both the None and dict cases.
     process = subprocess.Popen(
         subprocess_args,
-        bufsize=1,
         stdin=subprocess.PIPE,
         stdout=pty_child_fd,
         stderr=pty_child_fd,

--- a/projects/rocprofiler-compute/src/utils/utils_common.py
+++ b/projects/rocprofiler-compute/src/utils/utils_common.py
@@ -4,10 +4,12 @@
 import argparse
 import csv
 import ctypes
+import errno
 import glob
 import io
 import locale
 import os
+import pty
 import re
 import select
 import shutil
@@ -458,9 +460,6 @@ def capture_subprocess_output(
     profileMode: bool = False,
     enable_logging: bool = True,
 ) -> tuple[bool, str]:
-    # Start subprocess
-    # bufsize = 1 means output is line buffered
-    # universal_newlines = True is required for line buffering
     sanitized_env = (
         None
         if new_env is None
@@ -470,26 +469,25 @@ def capture_subprocess_output(
         }
     )
 
-    process = (
-        subprocess.Popen(
-            subprocess_args,
-            bufsize=1,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            universal_newlines=True,
-        )
-        if sanitized_env == None
-        else subprocess.Popen(
-            subprocess_args,
-            bufsize=1,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            universal_newlines=True,
-            env=sanitized_env,
-        )
+    # PTY (not a pipe) so the child sees a terminal and line-buffers its
+    # output. Prevents partial lines from one writer getting glued onto
+    # complete lines from another writer sharing the same fd.
+    pty_parent_fd, pty_child_fd = pty.openpty()
+    # env=None is Popen's default (inherit parent env), so passing
+    # sanitized_env directly handles both the None and dict cases.
+    process = subprocess.Popen(
+        subprocess_args,
+        bufsize=1,
+        stdin=subprocess.PIPE,
+        stdout=pty_child_fd,
+        stderr=pty_child_fd,
+        universal_newlines=True,
+        env=sanitized_env,
     )
+    os.close(pty_child_fd)
+    # buffering=1 for line-buffered reads, errors="replace" so bad bytes
+    # don't crash the read loop.
+    process_stdout = os.fdopen(pty_parent_fd, "r", buffering=1, errors="replace")
 
     # Create buffer for captured process output
     buf = io.StringIO()
@@ -531,24 +529,25 @@ def capture_subprocess_output(
     input_thread = threading.Thread(target=forward_input, daemon=True)
     input_thread.start()
 
-    # Read until the pipe closes, not until the child exits. Otherwise lines
-    # still buffered in the pipe at exit time are dropped.
-    if process.stdout is not None:
-        while True:
-            try:
-                line = process.stdout.readline()
-            except UnicodeDecodeError:
-                continue
-            if not line:
+    # Read until the child closes its end. On Linux, reading a closed PTY
+    # parent end raises OSError(EIO) instead of returning an empty string,
+    # so that's how we detect end-of-stream here.
+    while True:
+        try:
+            line = process_stdout.readline()
+        except OSError as e:
+            if e.errno == errno.EIO:
                 break
-            buf.write(line)
-            if not enable_logging:
-                continue
-            if profileMode:
-                console_log(get_rocprof_cmd(), line.strip(), indent_level=1)
-            else:
-                console_log(line.strip())
+            raise
+        buf.write(line)
+        if not enable_logging:
+            continue
+        if profileMode:
+            console_log(get_rocprof_cmd(), line.strip(), indent_level=1)
+        else:
+            console_log(line.strip())
 
+    process_stdout.close()
     input_thread.join(timeout=1)
 
     # Get process return code

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -596,35 +596,46 @@ def test_detect_rocprof_sdk(monkeypatch):
     assert any("rocprof_cmd is rocprofiler-sdk" in log_entry for log_entry in logs)
 
 
+def make_dummy_process(*, lines=(), returncode=0, poll_pending_first=False):
+    """Fake subprocess.Popen for capture_subprocess_output tests."""
+
+    class Stdout:
+        def __init__(self):
+            self.iter = iter(lines)
+
+        def readline(self):
+            return next(self.iter, "")
+
+        def fileno(self):
+            return 1
+
+        def close(self):
+            pass
+
+    class Process:
+        def __init__(self):
+            self.stdout = Stdout()
+            self.poll_pending = poll_pending_first
+
+        def poll(self):
+            if self.poll_pending:
+                self.poll_pending = False
+                return None
+            return returncode
+
+        def wait(self):
+            return returncode
+
+    return Process()
+
+
 def test_capture_subprocess_output_with_new_env(monkeypatch):
     """
     Test capture_subprocess_output with custom environment variables.
     Verifies that new_env parameter is properly passed to subprocess.
     """
 
-    class DummyProcess:
-        def __init__(self):
-            self.stdout = type(
-                "MockStdout",
-                (),
-                {
-                    "readline": lambda self: "",
-                    "fileno": lambda self: 1,
-                    "close": lambda self: None,
-                },
-            )()
-            self._poll_count = 0
-
-        def poll(self):
-            if self._poll_count == 0:
-                self._poll_count += 1
-                return None
-            return 0
-
-        def wait(self):
-            return 0
-
-    dummy_process = DummyProcess()
+    dummy_process = make_dummy_process(poll_pending_first=True)
     popen_calls = []
 
     def dummy_popen(*args, **kwargs):
@@ -649,25 +660,7 @@ def test_capture_subprocess_output_profile_mode(monkeypatch):
     Verifies different behavior when profiling mode is active.
     """
 
-    class DummyProcess:
-        def __init__(self):
-            self.stdout = type(
-                "MockStdout",
-                (),
-                {
-                    "readline": lambda self: "",
-                    "fileno": lambda self: 1,
-                    "close": lambda self: None,
-                },
-            )()
-
-        def poll(self):
-            return 0
-
-        def wait(self):
-            return 0
-
-    monkeypatch.setattr("subprocess.Popen", lambda *a, **k: DummyProcess())
+    monkeypatch.setattr("subprocess.Popen", lambda *a, **k: make_dummy_process())
     monkeypatch.setattr("utils.utils_common.console_log", lambda *a, **k: None)
     monkeypatch.setattr("utils.logger.console_debug", lambda *a, **k: None)
 
@@ -684,43 +677,10 @@ def test_capture_subprocess_output_failure(monkeypatch):
     Test capture_subprocess_output returns
     (False, output) when subprocess exits with nonzero code.
     """
-    lines = ["fail\n"]
-
-    class DummyStdout:
-        def __init__(self, lines):
-            self._lines = lines
-            self._idx = 0
-
-        def readline(self):
-            if self._idx < len(self._lines):
-                val = self._lines[self._idx]
-                self._idx += 1
-                return val
-            return ""
-
-        def close(self):
-            pass
-
-    class DummyProcess:
-        def __init__(self):
-            self.stdout = DummyStdout(lines)
-            self._poll_count = 0
-
-        def poll(self):
-            if self._poll_count == 0:
-                self._poll_count += 1
-                return None
-            return 1
-
-        def wait(self):
-            return 1
-
-    dummy_process = DummyProcess()
-
-    def dummy_popen(*args, **kwargs):
-        return dummy_process
-
-    monkeypatch.setattr("subprocess.Popen", dummy_popen)
+    dummy_process = make_dummy_process(
+        lines=["fail\n"], returncode=1, poll_pending_first=True
+    )
+    monkeypatch.setattr("subprocess.Popen", lambda *a, **k: dummy_process)
     monkeypatch.setattr("utils.utils_common.console_log", lambda *a, **k: None)
     monkeypatch.setattr("utils.logger.console_debug", lambda *a, **k: None)
 
@@ -738,34 +698,11 @@ def test_capture_subprocess_output_unicode_decode(monkeypatch):
 
     popen_calls = []
 
-    class DummyStdout:
-        def __init__(self):
-            # Lines as the TextIOWrapper would yield them after error
-            # replacement: bad bytes show up as �, not as exceptions.
-            self._lines = ["good line\n", "bad � byte\n", ""]
-            self._idx = 0
-
-        def readline(self):
-            val = self._lines[self._idx]
-            self._idx += 1
-            return val
-
-        def close(self):
-            pass
-
-    class DummyProcess:
-        def __init__(self):
-            self.stdout = DummyStdout()
-
-        def poll(self):
-            return 0
-
-        def wait(self):
-            return 0
-
+    # Lines as the TextIOWrapper would yield them after error replacement:
+    # bad bytes show up as �, not as exceptions.
     def dummy_popen(*args, **kwargs):
         popen_calls.append(kwargs)
-        return DummyProcess()
+        return make_dummy_process(lines=["good line\n", "bad � byte\n"])
 
     monkeypatch.setattr("subprocess.Popen", dummy_popen)
     monkeypatch.setattr("utils.utils_common.console_log", lambda *a, **k: None)
@@ -2180,17 +2117,10 @@ def test_capture_subprocess_output_with_logging_disabled(monkeypatch):
     Test capture_subprocess_output with enable_logging=False doesn't call console_log.
     """
 
-    class DummyProcess:
-        def __init__(self):
-            self.stdout = io.StringIO("test output\n")
-
-        def poll(self):
-            return 0
-
-        def wait(self):
-            return 0
-
-    monkeypatch.setattr("subprocess.Popen", lambda *a, **k: DummyProcess())
+    monkeypatch.setattr(
+        "subprocess.Popen",
+        lambda *a, **k: make_dummy_process(lines=["test output\n"]),
+    )
 
     log_calls = []
     monkeypatch.setattr(

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -605,7 +605,13 @@ def test_capture_subprocess_output_with_new_env(monkeypatch):
     class DummyProcess:
         def __init__(self):
             self.stdout = type(
-                "MockStdout", (), {"readline": lambda: "", "fileno": lambda: 1}
+                "MockStdout",
+                (),
+                {
+                    "readline": lambda self: "",
+                    "fileno": lambda self: 1,
+                    "close": lambda self: None,
+                },
             )()
             self._poll_count = 0
 
@@ -626,18 +632,6 @@ def test_capture_subprocess_output_with_new_env(monkeypatch):
         return dummy_process
 
     monkeypatch.setattr("subprocess.Popen", dummy_popen)
-
-    class DummySelector:
-        def register(self, fileobj, event, callback):
-            pass
-
-        def select(self, timeout=1):
-            return []
-
-        def close(self):
-            pass
-
-    monkeypatch.setattr("selectors.DefaultSelector", DummySelector)
     monkeypatch.setattr("utils.utils_common.console_log", lambda *a, **k: None)
     monkeypatch.setattr("utils.logger.console_debug", lambda *a, **k: None)
 
@@ -658,7 +652,13 @@ def test_capture_subprocess_output_profile_mode(monkeypatch):
     class DummyProcess:
         def __init__(self):
             self.stdout = type(
-                "MockStdout", (), {"readline": lambda: "", "fileno": lambda: 1}
+                "MockStdout",
+                (),
+                {
+                    "readline": lambda self: "",
+                    "fileno": lambda self: 1,
+                    "close": lambda self: None,
+                },
             )()
 
         def poll(self):
@@ -668,18 +668,6 @@ def test_capture_subprocess_output_profile_mode(monkeypatch):
             return 0
 
     monkeypatch.setattr("subprocess.Popen", lambda *a, **k: DummyProcess())
-
-    class DummySelector:
-        def register(self, fileobj, event, callback):
-            pass
-
-        def select(self, timeout=1):
-            return []
-
-        def close(self):
-            pass
-
-    monkeypatch.setattr("selectors.DefaultSelector", DummySelector)
     monkeypatch.setattr("utils.utils_common.console_log", lambda *a, **k: None)
     monkeypatch.setattr("utils.logger.console_debug", lambda *a, **k: None)
 
@@ -710,6 +698,9 @@ def test_capture_subprocess_output_failure(monkeypatch):
                 return val
             return ""
 
+        def close(self):
+            pass
+
     class DummyProcess:
         def __init__(self):
             self.stdout = DummyStdout(lines)
@@ -730,32 +721,6 @@ def test_capture_subprocess_output_failure(monkeypatch):
         return dummy_process
 
     monkeypatch.setattr("subprocess.Popen", dummy_popen)
-
-    class DummySelector:
-        def __init__(self):
-            self._registered = []
-
-        def register(self, fileobj, event, callback):
-            self._registered.append((fileobj, event, callback))
-
-        def select(self):
-            if hasattr(self, "_called"):
-                return []
-            self._called = True
-            key_obj = type(
-                "Key",
-                (),
-                {
-                    "data": staticmethod(self._registered[0][2]),
-                    "fileobj": self._registered[0][0],
-                },
-            )()
-            return [(key_obj, 1)]
-
-        def close(self):
-            pass
-
-    monkeypatch.setattr("selectors.DefaultSelector", DummySelector)
     monkeypatch.setattr("utils.utils_common.console_log", lambda *a, **k: None)
     monkeypatch.setattr("utils.logger.console_debug", lambda *a, **k: None)
 
@@ -766,72 +731,53 @@ def test_capture_subprocess_output_failure(monkeypatch):
 
 def test_capture_subprocess_output_unicode_decode(monkeypatch):
     """
-    Test capture_subprocess_output handles
-    UnicodeDecodeError in handle_output gracefully.
+    Test capture_subprocess_output handles bad bytes from the child without
+    crashing. errors="replace" on Popen substitutes invalid bytes with the
+    Unicode replacement character (\\ufffd), so readline never raises.
     """
+
+    popen_calls = []
 
     class DummyStdout:
         def __init__(self):
-            self._called = False
+            # Lines as the TextIOWrapper would yield them after error
+            # replacement: bad bytes show up as �, not as exceptions.
+            self._lines = ["good line\n", "bad � byte\n", ""]
+            self._idx = 0
 
         def readline(self):
-            if not self._called:
-                self._called = True
-                raise UnicodeDecodeError("utf-8", b"", 0, 1, "reason")
-            return ""
+            val = self._lines[self._idx]
+            self._idx += 1
+            return val
+
+        def close(self):
+            pass
 
     class DummyProcess:
         def __init__(self):
             self.stdout = DummyStdout()
-            self._poll_count = 0
 
         def poll(self):
-            if self._poll_count == 0:
-                self._poll_count += 1
-                return None
             return 0
 
         def wait(self):
             return 0
 
-    dummy_process = DummyProcess()
-
     def dummy_popen(*args, **kwargs):
-        return dummy_process
+        popen_calls.append(kwargs)
+        return DummyProcess()
 
     monkeypatch.setattr("subprocess.Popen", dummy_popen)
-
-    class DummySelector:
-        def __init__(self):
-            self._registered = []
-
-        def register(self, fileobj, event, callback):
-            self._registered.append((fileobj, event, callback))
-
-        def select(self):
-            if hasattr(self, "_called"):
-                return []
-            self._called = True
-            key_obj = type(
-                "Key",
-                (),
-                {
-                    "data": staticmethod(self._registered[0][2]),
-                    "fileobj": self._registered[0][0],
-                },
-            )()
-            return [(key_obj, 1)]
-
-        def close(self):
-            pass
-
-    monkeypatch.setattr("selectors.DefaultSelector", DummySelector)
     monkeypatch.setattr("utils.utils_common.console_log", lambda *a, **k: None)
     monkeypatch.setattr("utils.logger.console_debug", lambda *a, **k: None)
 
     success, output = utils_common.capture_subprocess_output(["echo", "test"])
+
     assert success is True
-    assert output == ""
+    assert "good line" in output
+    assert "�" in output
+    # Popen must request "replace" error handling so bad bytes never raise.
+    assert popen_calls[0].get("errors") == "replace"
 
 
 # =============================================================================
@@ -2245,10 +2191,6 @@ def test_capture_subprocess_output_with_logging_disabled(monkeypatch):
             return 0
 
     monkeypatch.setattr("subprocess.Popen", lambda *a, **k: DummyProcess())
-    monkeypatch.setattr(
-        "selectors.DefaultSelector",
-        lambda: mock.Mock(register=mock.Mock(), select=lambda: [], close=mock.Mock()),
-    )
 
     log_calls = []
     monkeypatch.setattr(


### PR DESCRIPTION
## Motivation

Bugfix: when `rocprof-compute profile` runs a workload, the captured output was missing the last lines of the workload's output and showing partial lines from the workload glued onto the instrumentation's lines.

## Technical Details

- Read the child's stdout until it closes, not just until the child exits. The old loop stopped at child exit and lost any output still in the pipe.

- Use a PTY instead of a pipe for the child's stdout/stderr. With a terminal on the other end, the workload flushes after every newline, so its lines no longer get mixed with the instrumentation's lines.

- A closed PTY raises `OSError(EIO)` instead of returning an empty string, so use that to detect end of stream.

- Remove `bufsize=1` from the Popen call. It does not apply to stdout/stderr (now raw fds Popen does not wrap), and stdin is flushed after every write.

## JIRA ID

AIPROFCOMP-558

## Test Plan

- Run `rocprof-compute profile --set compute_thruput_util -- /path/to/workload` on a workload that prints continuously for 20+ seconds (e.g. hipBone with 100 CG iterations). Check that the captured output contains every line the workload printed.

- Check that no lines in the captured output are spliced together.

## Test Result

Manually tested in a separate container. Captured output contains every workload line and shows no spliced lines.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
