### PR TITLE
[rocprofiler-systems] Fix mock_driver ODR violation causing NicDeviceTest SIGSEGV

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/amd_smi.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/amd_smi.hpp
@@ -1,17 +1,19 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include "core/sdma_feature.hpp"
 #include "core/timemory.hpp"
 
 #include <amd_smi/amdsmi.h>
 
-// AMD-SMI >= 26.3 supports NIC APIs and SDMA usage
+// AMD-SMI >= 26.3 also exposes NIC APIs (gated independently by ROCPROFSYS_USE_AINIC).
+// The SDMA feature flag lives in sdma_feature.hpp so that mock_driver.hpp can include
+// it directly and avoid the ODR fragility from include-order dependence.
 #if AMDSMI_LIB_VERSION_MAJOR > 26 ||                                                     \
     (AMDSMI_LIB_VERSION_MAJOR == 26 && AMDSMI_LIB_VERSION_MINOR > 2)
 #    if ROCPROFSYS_USE_AINIC > 0
 #        define AINIC_SUPPORTED 1
 #    endif
-#    define AMD_SMI_SDMA_SUPPORTED 1
 #endif
 
 namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/sdma_feature.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/sdma_feature.hpp
@@ -1,0 +1,15 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <amd_smi/amdsmi.h>
+
+// AMD-SMI >= 26.3 exposes the SDMA process-list API. Defined in a single
+// shared header so every TU that mentions AMD_SMI_SDMA_SUPPORTED resolves it
+// identically — required because the macro gates layout-affecting MOCK_METHODs
+// in mock_driver.hpp.
+#if AMDSMI_LIB_VERSION_MAJOR > 26 ||                                                     \
+    (AMDSMI_LIB_VERSION_MAJOR == 26 && AMDSMI_LIB_VERSION_MINOR > 2)
+#    define AMD_SMI_SDMA_SUPPORTED 1
+#endif

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/device.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/device.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "core/amd_smi.hpp"
+#include "core/sdma_feature.hpp"
 #include "library/pmc/collectors/gpu/types.hpp"
 #include "logger/debug.hpp"
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/tests/test_device.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/tests/test_device.cpp
@@ -1,10 +1,6 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
-// Include amd_smi.hpp first to get proper AMD_SMI_SDMA_SUPPORTED detection
-// based on the actual AMD SMI library version
-#include "core/amd_smi.hpp"
-
 #include "library/pmc/collectors/gpu/device.hpp"
 #include "library/pmc/device_providers/amd_smi/drivers/tests/mock_driver.hpp"
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/device_providers/amd_smi/drivers/driver.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/device_providers/amd_smi/drivers/driver.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "core/sdma_feature.hpp"
+
 #include <cstdint>
 #include <memory>
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/device_providers/amd_smi/drivers/tests/mock_driver.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/device_providers/amd_smi/drivers/tests/mock_driver.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "core/sdma_feature.hpp"
+
 #include <gmock/gmock.h>
 
 #include <amd_smi/amdsmi.h>


### PR DESCRIPTION
## Motivation

`rocprof-sys-unit-tests` crashes with SIGSEGV in `NicDeviceTest.DeviceIsSupported_WhenRdmaAvailable`, inside `~mock_driver()` at gmock's `VerifyAndClearExpectationsLocked`.

Root cause is an ODR violation in `mock_driver`. `mock_driver.hpp:56` conditionally compiles a `MOCK_METHOD` on `AMD_SMI_SDMA_SUPPORTED`. `MOCK_METHOD` generates virtual members and state, so this `#if` changes the class size and vtable layout. The macro is `#define`d only in `core/amd_smi.hpp`, and `mock_driver.hpp` does not include it. So the macro's value depends on what each TU happens to include first:

- GPU test TUs include `amd_smi.hpp` transitively → macro defined → larger layout.
- NIC test TUs do not → macro undefined → smaller layout.

Both layouts end up in the same binary. With unity build + weak-symbol dedup, the linker picks one definition of the destructor (the larger one). Instances constructed against the smaller layout walk into uninitialized vtable slots when destroyed → crash. `NicDeviceTest` happens to be the first to fall over.

A workaround already existed in `gpu/tests/test_device.cpp:4` (an explicit ordered include of `core/amd_smi.hpp`), with a comment flagging the fragility. That workaround papered over the symptom for the GPU test TU but not for the rest of the binary.

## Technical Details

Make every TU that mentions `AMD_SMI_SDMA_SUPPORTED` self-sufficient by extracting the macro into a small dedicated header.

**New file**

- `source/lib/core/sdma_feature.hpp` — sole source of truth for `AMD_SMI_SDMA_SUPPORTED`. Includes `<amd_smi/amdsmi.h>` and applies the same version check that previously lived inline in `core/amd_smi.hpp` (`AMDSMI_LIB_VERSION_MAJOR > 26 || (== 26 && MINOR > 2)`).

**Modified files**

- `source/lib/core/amd_smi.hpp` — replace the inline `#if` with `#include "core/sdma_feature.hpp"`. AINIC detection logic is unchanged.
- `source/lib/rocprof-sys/library/pmc/device_providers/amd_smi/drivers/driver.hpp` — include the new header.
- `source/lib/rocprof-sys/library/pmc/device_providers/amd_smi/drivers/tests/mock_driver.hpp` — include the new header. **This is the actual ODR fix** — the layout-affecting `MOCK_METHOD` now sees a deterministic macro value regardless of include order.
- `source/lib/rocprof-sys/library/pmc/collectors/gpu/device.hpp` — include the new header directly so it does not rely on transitive include from `core/amd_smi.hpp`.
- `source/lib/rocprof-sys/library/pmc/collectors/gpu/tests/test_device.cpp` — drop the obsolete ordered-include workaround and its comment.

After this change, `git grep AMD_SMI_SDMA_SUPPORTED` shows the macro defined in exactly one place. `mock_driver` has a single layout across the whole binary.

No semantic change to production code — the version check is byte-identical to the one that previously lived in `core/amd_smi.hpp`.

## JIRA ID

AIPROFSYST-411

## Test Plan

- Build `rocprof-sys-unit-tests` with `ROCPROFSYS_BUILD_TESTING=ON`, `ROCPROFSYS_USE_AINIC=ON`, AMD-SMI 26.3+ in the toolchain.
- Run the previously crashing test in isolation: `rocprof-sys-unit-tests --gtest_filter=NicDeviceTest.DeviceIsSupported_WhenRdmaAvailable`.
- Run the wider suite for regressions: `rocprof-sys-unit-tests` (no filter).
- Verify the SDMA-gated `DeviceTest.sdma_delta_computation` still passes (proves the macro is still defined where expected).

## Test Result

- `cmake --preset debug && cmake --build build/debug --target rocprof-sys-unit-tests` — succeeds.
- `NicDeviceTest.*` (5 tests) — all pass, including the previously crashing case.
- `DeviceTest.sdma_delta_computation` — passes (SDMA macro still effective).
- Full suite: **507 tests across 28 suites, all pass**, no regressions.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
