### PR TITLE
[rocprofiler-compute] [bugfix] Fix NOISE_CLAMP arg list in L2 cache YAMLs

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx908/config_delta/gfx950_diff.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx908/config_delta/gfx950_diff.yaml
@@ -1077,7 +1077,7 @@ Modification:
   metric_table:
     id: 301
     metrics:
-    - MFMA:
+    - Matrix Ops:
         value: ROUND(SUM(SQ_INSTS_MFMA) / SUM($denom), 0)
     - Wavefronts:
         value: ROUND(AVG(SPI_CS0_WAVE + SPI_CS1_WAVE + SPI_CS2_WAVE + SPI_CS3_WAVE), 0)
@@ -1206,8 +1206,8 @@ Modification:
         unit: Gbps
     - Remote Write and Atomic Traffic:
         avg: SUM(100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum)) / SUM(TCC_EA0_WRREQ_sum)
-        min: MIN((100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum), TCC_EA0_WRREQ_sum / TCC_EA0_WRREQ_sum))
-        max: MAX((100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum), TCC_EA0_WRREQ_sum / TCC_EA0_WRREQ_sum))
+        min: MIN(100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum) / TCC_EA0_WRREQ_sum)
+        max: MAX(100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum) / TCC_EA0_WRREQ_sum)
 - Panel Config:
     id: 1700
   metric_table:

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx90a/config_delta/gfx950_diff.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx90a/config_delta/gfx950_diff.yaml
@@ -934,8 +934,8 @@ Modification:
         max: MAX(100 * TCC_EA0_WRREQ_DRAM_sum / TCC_EA0_WRREQ_sum)
     - Remote Write and Atomic Traffic:
         avg: SUM(100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum)) / SUM(TCC_EA0_WRREQ_sum)
-        min: MIN((100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum), TCC_EA0_WRREQ_sum / TCC_EA0_WRREQ_sum))
-        max: MAX((100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum), TCC_EA0_WRREQ_sum / TCC_EA0_WRREQ_sum))
+        min: MIN(100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum) / TCC_EA0_WRREQ_sum)
+        max: MAX(100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum) / TCC_EA0_WRREQ_sum)
     - Atomic Traffic:
         avg: SUM(100 * TCC_EA0_ATOMIC_sum) / SUM(TCC_EA0_WRREQ_sum)
         min: MIN(100 * TCC_EA0_ATOMIC_sum / TCC_EA0_WRREQ_sum)

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx940/1700_l2_cache.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx940/1700_l2_cache.yaml
@@ -76,8 +76,8 @@ Panel Config:
           unit: Percent
         Remote Write and Atomic Traffic:
           avg: SUM(100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum)) / SUM(TCC_EA0_WRREQ_sum)
-          min: MIN((100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum), TCC_EA0_WRREQ_sum / TCC_EA0_WRREQ_sum))
-          max: MAX((100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum), TCC_EA0_WRREQ_sum / TCC_EA0_WRREQ_sum))
+          min: MIN(100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum) / TCC_EA0_WRREQ_sum)
+          max: MAX(100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum) / TCC_EA0_WRREQ_sum)
           unit: Percent
         Atomic Traffic:
           avg: SUM(100 * TCC_EA0_ATOMIC_sum) / SUM(TCC_EA0_WRREQ_sum)

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx941/1700_l2_cache.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx941/1700_l2_cache.yaml
@@ -54,8 +54,8 @@ Panel Config:
           unit: Percent
         Remote Read Traffic:
           avg: SUM(100 * NOISE_CLAMP(TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum, TCC_EA0_RDREQ_sum)) / SUM(TCC_EA0_RDREQ_sum)
-          min: MIN((100 * NOISE_CLAMP(TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum), TCC_EA0_RDREQ_sum / TCC_EA0_RDREQ_sum))
-          max: MAX((100 * NOISE_CLAMP(TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum), TCC_EA0_RDREQ_sum / TCC_EA0_RDREQ_sum))
+          min: MIN(100 * NOISE_CLAMP(TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum, TCC_EA0_RDREQ_sum) / TCC_EA0_RDREQ_sum)
+          max: MAX(100 * NOISE_CLAMP(TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum, TCC_EA0_RDREQ_sum) / TCC_EA0_RDREQ_sum)
           unit: Percent
         Uncached Read Traffic:
           avg: SUM(100 * TCC_EA0_RD_UNCACHED_32B_sum) / SUM(TCC_EA0_RDREQ_sum)
@@ -76,8 +76,8 @@ Panel Config:
           unit: Percent
         Remote Write and Atomic Traffic:
           avg: SUM(100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum)) / SUM(TCC_EA0_WRREQ_sum)
-          min: MIN((100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum), TCC_EA0_WRREQ_sum / TCC_EA0_WRREQ_sum))
-          max: MAX((100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum), TCC_EA0_WRREQ_sum / TCC_EA0_WRREQ_sum))
+          min: MIN(100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum) / TCC_EA0_WRREQ_sum)
+          max: MAX(100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum) / TCC_EA0_WRREQ_sum)
           unit: Percent
         Atomic Traffic:
           avg: SUM(100 * TCC_EA0_ATOMIC_sum) / SUM(TCC_EA0_WRREQ_sum)

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx941/config_delta/gfx950_diff.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx941/config_delta/gfx950_diff.yaml
@@ -841,9 +841,6 @@ Modification:
         avg: SUM(TCC_EA0_RDREQ_32B_sum * 32 + TCC_EA0_RDREQ_64B_sum * 64 + TCC_EA0_RDREQ_128B_sum * 128) / SUM(End_Timestamp - Start_Timestamp)
         min: MIN((((TCC_EA0_RDREQ_32B_sum * 32) + (TCC_EA0_RDREQ_64B_sum * 64) + (TCC_EA0_RDREQ_128B_sum * 128)) / (End_Timestamp - Start_Timestamp)))
         max: MAX((((TCC_EA0_RDREQ_32B_sum * 32) + (TCC_EA0_RDREQ_64B_sum * 64) + (TCC_EA0_RDREQ_128B_sum * 128)) / (End_Timestamp - Start_Timestamp)))
-    - Remote Read Traffic:
-        min: MIN(100 * NOISE_CLAMP(TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum, TCC_EA0_RDREQ_sum) / TCC_EA0_RDREQ_sum)
-        max: MAX(100 * NOISE_CLAMP(TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum, TCC_EA0_RDREQ_sum) / TCC_EA0_RDREQ_sum)
 - Panel Config:
     id: 1700
   metric_table:

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx942/1700_l2_cache.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx942/1700_l2_cache.yaml
@@ -56,8 +56,8 @@ Panel Config:
           unit: Percent
         Remote Read Traffic:
           avg: SUM(100 * NOISE_CLAMP(TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum, TCC_EA0_RDREQ_sum)) / SUM(TCC_EA0_RDREQ_sum)
-          min: MIN((100 * NOISE_CLAMP(TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum), TCC_EA0_RDREQ_sum / TCC_EA0_RDREQ_sum))
-          max: MAX((100 * NOISE_CLAMP(TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum), TCC_EA0_RDREQ_sum / TCC_EA0_RDREQ_sum))
+          min: MIN(100 * NOISE_CLAMP(TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum, TCC_EA0_RDREQ_sum) / TCC_EA0_RDREQ_sum)
+          max: MAX(100 * NOISE_CLAMP(TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum, TCC_EA0_RDREQ_sum) / TCC_EA0_RDREQ_sum)
           unit: Percent
         Uncached Read Traffic:
           avg: SUM(100 * TCC_EA0_RD_UNCACHED_32B_sum) / SUM(TCC_EA0_RDREQ_sum)
@@ -78,8 +78,8 @@ Panel Config:
           unit: Percent
         Remote Write and Atomic Traffic:
           avg: SUM(100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum)) / SUM(TCC_EA0_WRREQ_sum)
-          min: MIN((100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum), TCC_EA0_WRREQ_sum / TCC_EA0_WRREQ_sum))
-          max: MAX((100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum), TCC_EA0_WRREQ_sum / TCC_EA0_WRREQ_sum))
+          min: MIN(100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum) / TCC_EA0_WRREQ_sum)
+          max: MAX(100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum) / TCC_EA0_WRREQ_sum)
           unit: Percent
         Atomic Traffic:
           avg: SUM(100 * TCC_EA0_ATOMIC_sum) / SUM(TCC_EA0_WRREQ_sum)

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx942/config_delta/gfx950_diff.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx942/config_delta/gfx950_diff.yaml
@@ -844,9 +844,6 @@ Modification:
         avg: SUM(TCC_EA0_RDREQ_32B_sum * 32 + TCC_EA0_RDREQ_64B_sum * 64 + TCC_EA0_RDREQ_128B_sum * 128) / SUM(End_Timestamp - Start_Timestamp)
         min: MIN((((TCC_EA0_RDREQ_32B_sum * 32) + (TCC_EA0_RDREQ_64B_sum * 64) + (TCC_EA0_RDREQ_128B_sum * 128)) / (End_Timestamp - Start_Timestamp)))
         max: MAX((((TCC_EA0_RDREQ_32B_sum * 32) + (TCC_EA0_RDREQ_64B_sum * 64) + (TCC_EA0_RDREQ_128B_sum * 128)) / (End_Timestamp - Start_Timestamp)))
-    - Remote Read Traffic:
-        min: MIN(100 * NOISE_CLAMP(TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum, TCC_EA0_RDREQ_sum) / TCC_EA0_RDREQ_sum)
-        max: MAX(100 * NOISE_CLAMP(TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum, TCC_EA0_RDREQ_sum) / TCC_EA0_RDREQ_sum)
 - Panel Config:
     id: 1700
   metric_table:

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx950/1700_l2_cache.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx950/1700_l2_cache.yaml
@@ -76,8 +76,8 @@ Panel Config:
           unit: Percent
         Remote Write and Atomic Traffic:
           avg: SUM(100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum)) / SUM(TCC_EA0_WRREQ_sum)
-          min: MIN((100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum), TCC_EA0_WRREQ_sum / TCC_EA0_WRREQ_sum))
-          max: MAX((100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum), TCC_EA0_WRREQ_sum / TCC_EA0_WRREQ_sum))
+          min: MIN(100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum) / TCC_EA0_WRREQ_sum)
+          max: MAX(100 * NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum) / TCC_EA0_WRREQ_sum)
           unit: Percent
         Atomic Traffic:
           avg: SUM(100 * TCC_EA0_ATOMIC_sum) / SUM(TCC_EA0_WRREQ_sum)

--- a/projects/rocprofiler-compute/src/utils/.config_hashes.json
+++ b/projects/rocprofiler-compute/src/utils/.config_hashes.json
@@ -19,7 +19,7 @@
       }
     },
     "gfx908": {
-      "delta_hash": "dd21fd76149d9a3098fd630f7ee2b16d",
+      "delta_hash": "4c1287023f79e12dde62b0cec8a1ab63",
       "files": {
         "0000_top_stats.yaml": "2819d96f5b1c3704f2ac50868a246a7f",
         "0100_system_info.yaml": "cefae2b10db8cf4b0d3a971cff5e82c8",
@@ -42,7 +42,7 @@
       }
     },
     "gfx90a": {
-      "delta_hash": "ce81cecd978df3ca80e0c6e8e730fefc",
+      "delta_hash": "429d5af92493bb26900dddbae85fa6bb",
       "files": {
         "0000_top_stats.yaml": "2819d96f5b1c3704f2ac50868a246a7f",
         "0100_system_info.yaml": "cefae2b10db8cf4b0d3a971cff5e82c8",
@@ -82,13 +82,13 @@
         "1400_scalar_l1_data_cache.yaml": "96bfa80b3d153a60971c575249036a9f",
         "1500_address_processing_unit_and_data_return_path_ta_td.yaml": "7aef5f1f15166ac06943272fa0e304f3",
         "1600_vector_l1_data_cache.yaml": "23eb6a07c89f1cdc00dfda74f1d504a7",
-        "1700_l2_cache.yaml": "d323bce38ffd7e410844eff8abc0d10b",
+        "1700_l2_cache.yaml": "dad68e81a715094e2f0b2478f25864d5",
         "1800_l2_cache_per_channel.yaml": "abae21632ecfeb445d05718916c3c838",
         "2100_pc_sampling.yaml": "8049866f25214544f1e53a9e2f08399b"
       }
     },
     "gfx941": {
-      "delta_hash": "2c2038e1cb0908299282a5a11110310f",
+      "delta_hash": "047e922ae1342a16e832d34ad98aba3d",
       "files": {
         "0000_top_stats.yaml": "2819d96f5b1c3704f2ac50868a246a7f",
         "0100_system_info.yaml": "cefae2b10db8cf4b0d3a971cff5e82c8",
@@ -105,13 +105,13 @@
         "1400_scalar_l1_data_cache.yaml": "96bfa80b3d153a60971c575249036a9f",
         "1500_address_processing_unit_and_data_return_path_ta_td.yaml": "7aef5f1f15166ac06943272fa0e304f3",
         "1600_vector_l1_data_cache.yaml": "23eb6a07c89f1cdc00dfda74f1d504a7",
-        "1700_l2_cache.yaml": "77a425b07361263665cb1a46219cd7ce",
+        "1700_l2_cache.yaml": "dad68e81a715094e2f0b2478f25864d5",
         "1800_l2_cache_per_channel.yaml": "abae21632ecfeb445d05718916c3c838",
         "2100_pc_sampling.yaml": "8049866f25214544f1e53a9e2f08399b"
       }
     },
     "gfx942": {
-      "delta_hash": "feda1f58cd49ee9039074c1e90bd609d",
+      "delta_hash": "a4dcec314effebc4d0a648b45112de10",
       "files": {
         "0000_top_stats.yaml": "2819d96f5b1c3704f2ac50868a246a7f",
         "0100_system_info.yaml": "cefae2b10db8cf4b0d3a971cff5e82c8",
@@ -128,7 +128,7 @@
         "1400_scalar_l1_data_cache.yaml": "96bfa80b3d153a60971c575249036a9f",
         "1500_address_processing_unit_and_data_return_path_ta_td.yaml": "a9ead82b6537d4c9e97695195a13caf0",
         "1600_vector_l1_data_cache.yaml": "23eb6a07c89f1cdc00dfda74f1d504a7",
-        "1700_l2_cache.yaml": "ef47b15d8e605eccae9ac8e5d64a4bea",
+        "1700_l2_cache.yaml": "0fb46ccc8e071ccf61847526c141dc2b",
         "1800_l2_cache_per_channel.yaml": "abae21632ecfeb445d05718916c3c838",
         "2100_pc_sampling.yaml": "8049866f25214544f1e53a9e2f08399b"
       }
@@ -151,7 +151,7 @@
         "1400_scalar_l1_data_cache.yaml": "9358238e7adc61c0da89323626eb01c6",
         "1500_address_processing_unit_and_data_return_path_ta_td.yaml": "7d6d8cfd60256877f20d78e037c5ddad",
         "1600_vector_l1_data_cache.yaml": "fb29fd502f3937daeec4dfd4a2434ead",
-        "1700_l2_cache.yaml": "d4f8bd983a4e74f8f9d7459ed3f68571",
+        "1700_l2_cache.yaml": "4a798cde1e58f0b0d337197d36eec1fb",
         "1800_l2_cache_per_channel.yaml": "0d2447fc336fc797a4bb38ef95688afb",
         "2100_pc_sampling.yaml": "8049866f25214544f1e53a9e2f08399b",
         "3000_mem_bw.yaml": "4ed0c6d2ef7a9db804f6f319ac6e3cee"


### PR DESCRIPTION
## Motivation

Several L2-cache min/max YAML expressions for Remote Read Traffic and Remote Write and Atomic Traffic close NOISE_CLAMP after only the first argument and then continue with `, Z / Z))`. At runtime that parses as MIN((100 * NOISE_CLAMP(diff), ref / ref)) — NOISE_CLAMP is invoked with one argument (which violates its (diff, ref) signature in to_noise_clamp), and MIN/MAX then aggregates a tuple containing the unclamped 100 * NOISE_CLAMP(diff) term and a constant 1.0. The reported per-row min/max for those metrics is therefore wrong on every gfx9 architecture that exposes L2 cache panels, undermining the variance-correction guarantee the NOISE_CLAMP helper was added to provide. We are fixing this now so analyze output matches the (already-correct) avg line on the same metric and so the multi-pass noise-clamp diagnostics remain trustworthy.

## Technical Details

The fix is purely YAML parenthesization: each affected min/max line is rewritten so that NOISE_CLAMP closes after both arguments and the / ref divisor sits inside the outer MIN/MAX. The (diff, ref) argument order matches the existing to_noise_clamp(difference, reference) signature in src/utils/metrics/noise_clamper.py and the convention already used by every working avg invocation, so no Python or test code changes are needed.

- Repair min/max lines for Remote Write and Atomic Traffic in gfx940/1700_l2_cache.yaml, gfx941/1700_l2_cache.yaml, gfx942/1700_l2_cache.yaml, and gfx950/1700_l2_cache.yaml, and additionally repair Remote Read Traffic in gfx941/gfx942 (gfx940/gfx950 already had the correct two-arg RDREQ form).
- Regenerate config_delta/gfx950_diff.yaml for gfx908, gfx90a, gfx940, gfx941, and gfx942 with tools/config_management/generate_config_deltas.py; this picks up the corrected gfx950 form for the gfx908/gfx90a WRREQ modification and drops the obsolete RDREQ modification entries from the gfx941/gfx942 deltas now that they agree with gfx950.
- Recompute src/utils/.config_hashes.json via tools/config_management/hash_manager.py --compute-all so tests/test_autogen_config.py and hash_checker.py stay green; no manual edits to the diff YAMLs or hash DB.

## JIRA ID

N/A

## Test Plan

Validation pairs the existing hash-integrity gate with the focused noise-clamp unit tests so we cover both the byte-level config invariants and the runtime semantics of the helper that the YAML expressions now invoke correctly.

- [x] Run `pytest tests/test_autogen_config.py` to confirm every panel/delta YAML still matches the regenerated hash database byte-for-byte.
- [x] Run `PYTHONPATH=src pytest -m noise_clamp tests/test_utils.py` to exercise scalar/array clamping, zero-reference handling, threshold boundaries, and per-instance isolation of the (diff, ref) API the YAMLs now invoke correctly.
- [x] Repo-wide grep for any remaining one-arg `NOISE_CLAMP(...) ,` invocations under src/rocprof_compute_soc/analysis_configs/ to confirm the bug class is fully eliminated.

## Test Result

All local validation passed: tests/test_autogen_config.py::test_config_hashes_match_files (1/1), the noise_clamp marker (7/7), and the grep for one-arg NOISE_CLAMP(...) , patterns in src/rocprof_compute_soc/analysis_configs/ returned no matches. Full CI is expected to provide independent confirmation across the remaining gfx targets.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.