### PR TITLE
Disable hostcalls and reset transfer queue on reset

### DIFF
--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -148,6 +148,11 @@ void Device::Reset() {
   // Clear hostcall allocations to avoid ~Device() accessing freed Memory objects later.
   auto* dev = devices()[0];
   dev->ClearHostcallMemories();
+
+  // Disable all hostcalls
+  auto hostcallBuffer = dev->getOrCreateHostcallBuffer();
+  amd::disableHostcalls(hostcallBuffer);
+
   amd::MemObjMap::Purge(dev);
   Create();
 }

--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -135,6 +135,10 @@ void Device::AddSafeStream(Stream* event_stream, Stream* wait_stream) {
 
 // ================================================================================================
 void Device::Reset() {
+  // Disable all hostcalls
+  auto hostcallBuffer = dev->getOrCreateHostcallBuffer();
+  amd::disableHostcalls(hostcallBuffer);
+
   {
     std::scoped_lock lock(lock_);
     auto pools_to_delete = std::exchange(mem_pools_, {});
@@ -149,10 +153,6 @@ void Device::Reset() {
   // Clear hostcall allocations to avoid ~Device() accessing freed Memory objects later.
   auto* dev = devices()[0];
   dev->ClearHostcallMemories();
-
-  // Disable all hostcalls
-  auto hostcallBuffer = dev->getOrCreateHostcallBuffer();
-  amd::disableHostcalls(hostcallBuffer);
 
   amd::MemObjMap::Purge(dev);
   Create();

--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -11,7 +11,6 @@
 #include "hip_internal.hpp"
 #include "hip_mempool_impl.hpp"
 #include "hip_platform.hpp"
-#include "device/devhostcall.hpp"
 
 #undef hipGetDeviceProperties
 #undef hipDeviceProp_t
@@ -135,9 +134,8 @@ void Device::AddSafeStream(Stream* event_stream, Stream* wait_stream) {
 
 // ================================================================================================
 void Device::Reset() {
-  // Disable all hostcalls
-  auto hostcallBuffer = dev->getOrCreateHostcallBuffer();
-  amd::disableHostcalls(hostcallBuffer);
+  auto* dev = devices()[0];
+  dev->destroyXferQueue();
 
   {
     std::scoped_lock lock(lock_);
@@ -151,7 +149,6 @@ void Device::Reset() {
   destroyAllStreams();
 
   // Clear hostcall allocations to avoid ~Device() accessing freed Memory objects later.
-  auto* dev = devices()[0];
   dev->ClearHostcallMemories();
 
   amd::MemObjMap::Purge(dev);

--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -11,6 +11,7 @@
 #include "hip_internal.hpp"
 #include "hip_mempool_impl.hpp"
 #include "hip_platform.hpp"
+#include "device/devhostcall.hpp"
 
 #undef hipGetDeviceProperties
 #undef hipDeviceProp_t

--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -135,7 +135,6 @@ void Device::AddSafeStream(Stream* event_stream, Stream* wait_stream) {
 // ================================================================================================
 void Device::Reset() {
   auto* dev = devices()[0];
-  dev->destroyXferQueue();
 
   {
     std::scoped_lock lock(lock_);
@@ -147,6 +146,8 @@ void Device::Reset() {
   }
   flags_ = hipDeviceScheduleSpin;
   destroyAllStreams();
+
+  dev->destroyXferQueue();
 
   // Clear hostcall allocations to avoid ~Device() accessing freed Memory objects later.
   dev->ClearHostcallMemories();

--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -136,6 +136,19 @@ void Device::AddSafeStream(Stream* event_stream, Stream* wait_stream) {
 void Device::Reset() {
   auto* dev = devices()[0];
 
+  flags_ = hipDeviceScheduleSpin;
+
+  // Destroy all user streams first so their GPU work completes (including the Windows
+  // VirtualGPU barrier flush in ~VirtualGPU) before any backing memory is freed.
+  destroyAllStreams();
+
+  // null_stream_ is excluded from destroyAllStreams() since it is a null stream.
+  // Destroy it explicitly so it is recreated fresh after reset.
+  if (null_stream_ != nullptr) {
+    hip::Stream::Destroy(null_stream_);
+    null_stream_ = nullptr;
+  }
+
   {
     std::scoped_lock lock(lock_);
     auto pools_to_delete = std::exchange(mem_pools_, {});
@@ -144,10 +157,8 @@ void Device::Reset() {
       delete pool;
     }
   }
-  flags_ = hipDeviceScheduleSpin;
-  destroyAllStreams();
 
-  dev->destroyXferQueue();
+  dev->recreateXferQueue();
 
   // Clear hostcall allocations to avoid ~Device() accessing freed Memory objects later.
   dev->ClearHostcallMemories();

--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -142,7 +142,7 @@ void Device::Reset() {
   // VirtualGPU barrier flush in ~VirtualGPU) before any backing memory is freed.
   destroyAllStreams();
 
-  // null_stream_ is excluded from destroyAllStreams() since it is a null stream.
+  // null_stream_ is excluded from destroyAllStreams(),
   // Destroy it explicitly so it is recreated fresh after reset.
   if (null_stream_ != nullptr) {
     hip::Stream::Destroy(null_stream_);
@@ -158,6 +158,10 @@ void Device::Reset() {
     }
   }
 
+  // Recreate the internal transfer queue so it starts fresh after reset.
+  // Must happen after pools and streams are torn down (PAL resource destructors
+  // call through xferQueue), but before Purge (ROCR svmFree of hostcallBuffer
+  // happens in ~VirtualGPU).
   dev->recreateXferQueue();
 
   // Clear hostcall allocations to avoid ~Device() accessing freed Memory objects later.

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1875,7 +1875,7 @@ class Device : public RuntimeObject {
    */
   bool customHostAllocator() const { return settings().customHostAllocator_ == 1; }
 
-  virtual void* getOrCreateHostcallBuffer() { return nullptr; }
+  virtual void destroyXferQueue() {}
 
   /**
    * @copydoc amd::Context::hostAlloc

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1875,7 +1875,7 @@ class Device : public RuntimeObject {
    */
   bool customHostAllocator() const { return settings().customHostAllocator_ == 1; }
 
-  virtual void destroyXferQueue() {}
+  virtual void recreateXferQueue() {}
 
   /**
    * @copydoc amd::Context::hostAlloc

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1875,6 +1875,8 @@ class Device : public RuntimeObject {
    */
   bool customHostAllocator() const { return settings().customHostAllocator_ == 1; }
 
+  virtual void* getOrCreateHostcallBuffer() { return nullptr; }
+
   /**
    * @copydoc amd::Context::hostAlloc
    */

--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -2821,9 +2821,21 @@ amd::Memory* Device::ImportShareableVMMHandle(void* osHandle) {
   return amd_mem_obj;
 }
 
-void Device::destroyXferQueue() {
+void Device::recreateXferQueue() {
   delete xferQueue_;
   xferQueue_ = nullptr;
+
+  // PAL's xferQueue() is a bare getter with no lazy re-creation, so recreate explicitly.
+  // Finalize() was already called during initializeHeapResources() and must not be called
+  // again, but creating a new VirtualGPU is safe at this point.
+  xferQueue_ = new VirtualGPU(*this);
+  if (!(xferQueue_ && xferQueue_->create(false))) {
+    delete xferQueue_;
+    xferQueue_ = nullptr;
+    LogError("Couldn't recreate the device transfer manager after reset!");
+    return;
+  }
+  xferQueue_->enableSyncedBlit();
 }
 
 }  // namespace amd::pal

--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -2821,8 +2821,9 @@ amd::Memory* Device::ImportShareableVMMHandle(void* osHandle) {
   return amd_mem_obj;
 }
 
-void* Device::getOrCreateHostcallBuffer() {
-  return xferQueue()->getOrCreateHostcallBuffer();
+void Device::destroyXferQueue() {
+  delete xferQueue_;
+  xferQueue_ = nullptr;
 }
 
 }  // namespace amd::pal

--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -2821,4 +2821,8 @@ amd::Memory* Device::ImportShareableVMMHandle(void* osHandle) {
   return amd_mem_obj;
 }
 
+void* Device::getOrCreateHostcallBuffer() {
+  return xferQueue()->getOrCreateHostcallBuffer();
+}
+
 }  // namespace amd::pal

--- a/projects/clr/rocclr/device/pal/paldevice.hpp
+++ b/projects/clr/rocclr/device/pal/paldevice.hpp
@@ -519,7 +519,7 @@ class Device : public NullDevice {
 
   VirtualGPU* xferQueue() const { return xferQueue_; }
 
-  void* getOrCreateHostcallBuffer() override;
+  void destroyXferQueue() override;
 
   //! Retrieves the internal format from the OCL format
   Pal::ChNumFormat getPalFormat(const amd::Image::Format& format,  //! OCL image format

--- a/projects/clr/rocclr/device/pal/paldevice.hpp
+++ b/projects/clr/rocclr/device/pal/paldevice.hpp
@@ -519,6 +519,8 @@ class Device : public NullDevice {
 
   VirtualGPU* xferQueue() const { return xferQueue_; }
 
+  void* getOrCreateHostcallBuffer() override;
+
   //! Retrieves the internal format from the OCL format
   Pal::ChNumFormat getPalFormat(const amd::Image::Format& format,  //! OCL image format
                                 Pal::ChannelMapping* channel) const;

--- a/projects/clr/rocclr/device/pal/paldevice.hpp
+++ b/projects/clr/rocclr/device/pal/paldevice.hpp
@@ -519,7 +519,7 @@ class Device : public NullDevice {
 
   VirtualGPU* xferQueue() const { return xferQueue_; }
 
-  void destroyXferQueue() override;
+  void recreateXferQueue() override;
 
   //! Retrieves the internal format from the OCL format
   Pal::ChNumFormat getPalFormat(const amd::Image::Format& format,  //! OCL image format

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3972,6 +3972,9 @@ void callbackQueue(hsa_status_t status, hsa_queue_t* queue, void* data) {
   }
 }
 
+void* Device::getOrCreateHostcallBuffer() {
+  return xferQueue()->getOrCreateHostcallBuffer();
+}
 // ================================================================================================
 #if defined(__clang__)
 #if __has_feature(address_sanitizer)

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3975,9 +3975,10 @@ void callbackQueue(hsa_status_t status, hsa_queue_t* queue, void* data) {
 void Device::recreateXferQueue() {
   delete xferQueue_;
   xferQueue_ = nullptr;
-  // xferQueue() is a lazy accessor that recreates xferQueue_ on next access,
-  // so nulling here is sufficient — no explicit recreation needed.
-  xferQueue();
+  // xferQueue() is a lazy accessor: it will recreate xferQueue_ on the next call.
+  // Do not eagerly recreate here — creating an HSA queue inside the hipDeviceReset
+  // call chain (where rocprofiler is already in a callback) causes reentrancy issues
+  // in rocprofiler's queue controller.
 }
 // ================================================================================================
 #if defined(__clang__)

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3972,9 +3972,12 @@ void callbackQueue(hsa_status_t status, hsa_queue_t* queue, void* data) {
   }
 }
 
-void Device::destroyXferQueue() {
+void Device::recreateXferQueue() {
   delete xferQueue_;
   xferQueue_ = nullptr;
+  // xferQueue() is a lazy accessor that recreates xferQueue_ on next access,
+  // so nulling here is sufficient — no explicit recreation needed.
+  xferQueue();
 }
 // ================================================================================================
 #if defined(__clang__)

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3972,8 +3972,9 @@ void callbackQueue(hsa_status_t status, hsa_queue_t* queue, void* data) {
   }
 }
 
-void* Device::getOrCreateHostcallBuffer() {
-  return xferQueue()->getOrCreateHostcallBuffer();
+void Device::destroyXferQueue() {
+  delete xferQueue_;
+  xferQueue_ = nullptr;
 }
 // ================================================================================================
 #if defined(__clang__)

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -370,7 +370,7 @@ class Device : public NullDevice {
 
   void checkAtomicSupport();  //!< Check the support for pcie atomics
 
-  void destroyXferQueue() override;
+  void recreateXferQueue() override;
 
   //! Destructor for the physical HSA device
   virtual ~Device();

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -370,7 +370,7 @@ class Device : public NullDevice {
 
   void checkAtomicSupport();  //!< Check the support for pcie atomics
 
-  void* getOrCreateHostcallBuffer() override;
+  void destroyXferQueue() override;
 
   //! Destructor for the physical HSA device
   virtual ~Device();

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -370,6 +370,8 @@ class Device : public NullDevice {
 
   void checkAtomicSupport();  //!< Check the support for pcie atomics
 
+  void* getOrCreateHostcallBuffer() override;
+
   //! Destructor for the physical HSA device
   virtual ~Device();
 


### PR DESCRIPTION
## Motivation
hipDeviceReset() did not properly tear down and reinitialize internal device state, causing crashes and hangs when the device was reused after reset.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Streams are now destroyed before memory pools so VirtualGPU destructors complete their GPU work before memory is freed. null_stream_ is explicitly destroyed so it is recreated fresh on next use. The internal transfer queue is destroyed and recreated on both ROCR and PAL paths via the new recreateXferQueue()
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
AIRUNTIME-2064
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
PSDB should pass without impacting any of the downstream projects
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Waiting for CI
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
