### PR TITLE
RCCL: add new net-ib tests for MultiRecv

### DIFF
--- a/projects/rccl/test/common/HostBufferHelpers.hpp
+++ b/projects/rccl/test/common/HostBufferHelpers.hpp
@@ -146,6 +146,34 @@ bool verifyHostBufferData(const void* buffer,
     return true;
 }
 
+// ============================================================================
+// Standard Test Pattern Factory
+// ============================================================================
+
+/**
+ * @brief Returns a callable that generates the standard sequential byte pattern.
+ *
+ * Produces: static_cast<uint8_t>((seed + index) % 256)
+ *
+ * Intended for use with fillHostBufferWithPattern, verifyHostBufferData,
+ * initializeBufferWithPattern, and verifyBufferData. Centralises the formula
+ * so call sites do not repeat it.
+ *
+ * Example:
+ * @code
+ * fillHostBufferWithPattern<uint8_t>(buf, sz, makeBytePattern(seed));
+ * verifyHostBufferData<uint8_t>(buf, sz, makeBytePattern(seed));
+ * verifyHostBufferData<uint8_t>(buf, sz, makeBytePattern(seed), 0, 0.0, &errIdx, &errExp, &errGot);
+ * @endcode
+ *
+ * @param seed Starting offset for the pattern.
+ * @return Lambda: uint8_t f(size_t index)
+ */
+inline auto makeBytePattern(int seed)
+{
+    return [seed](size_t i) { return static_cast<uint8_t>((seed + i) % 256); };
+}
+
 } // namespace RCCLTestHelpers
 
 #endif // HOST_BUFFER_HELPERS_HPP

--- a/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
@@ -255,7 +255,7 @@ TEST_F(NetIbMPITest, SimpleSendRecv) {
         PostSingleRecv(pair.recvComm, buffer, bufferSize, tag, mhandle, &request);
     } else {
         // Sender
-        FillHostBuffer(buffer, bufferSize, rank);
+        fillHostBufferWithPattern<uint8_t>(buffer, bufferSize, makeBytePattern(rank));
         PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
 
@@ -271,7 +271,7 @@ TEST_F(NetIbMPITest, SimpleSendRecv) {
 
         // Verify received data
         int senderRank = 1;  // Data was sent by rank 1
-        EXPECT_TRUE(VerifyHostBuffer(buffer, bufferSize, senderRank)) << "Data validation failed";
+        EXPECT_TRUE(verifyHostBufferData<uint8_t>(buffer, bufferSize, makeBytePattern(senderRank))) << "Data validation failed";
     }
 
     // NetMHandleGuard will automatically deregister memory when test scope ends
@@ -317,7 +317,7 @@ TEST_F(NetIbMPITest, SendRecvMultipleSizes) {
             PostSingleRecv(pair.recvComm, buffer, size, tag, mhandle, &request);
             ASSERT_NE(request, nullptr) << "Recv request should never be NULL";
         } else {
-            FillHostBuffer(buffer, size, seed);
+            fillHostBufferWithPattern<uint8_t>(buffer, size, makeBytePattern(seed));
             PostSendWithRetry(pair.sendComm, buffer, size, tag, mhandle, &request);
         }
 
@@ -335,7 +335,7 @@ TEST_F(NetIbMPITest, SendRecvMultipleSizes) {
 
         if (rank == 0) {
             EXPECT_EQ(sizes[0], size) << "Size mismatch for transfer of " << size << " bytes";
-            EXPECT_TRUE(VerifyHostBuffer(buffer, size, seed)) << "Data validation failed for size " << size;
+            EXPECT_TRUE(verifyHostBufferData<uint8_t>(buffer, size, makeBytePattern(seed))) << "Data validation failed for size " << size;
         }
 
         // NetMHandleGuard will automatically deregister at end of loop iteration
@@ -448,7 +448,7 @@ TEST_F(NetIbMPITest, FlushAfterRecv) {
                           recvHandles, &request), ncclSuccess);
     } else {
         // Sender
-        ASSERT_EQ(InitializeBuffer(buffer, bufferSize, rank), hipSuccess);
+        ASSERT_EQ(initializeBufferWithPattern<uint8_t>(buffer, bufferSize, makeBytePattern(rank)), hipSuccess);
 
         PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
@@ -546,7 +546,7 @@ TEST_F(NetIbMPITest, MultipleSequentialTransfers) {
             PostSingleRecv(pair.recvComm, recvBuffer, bufferSize, tag, mhandle, &request);
             ASSERT_NE(request, nullptr) << "Recv request should never be NULL";
         } else {
-            FillHostBuffer(sendBuffer, bufferSize, seed);
+            fillHostBufferWithPattern<uint8_t>(sendBuffer, bufferSize, makeBytePattern(seed));
             PostSendWithRetry(pair.sendComm, sendBuffer, bufferSize, tag, mhandle, &request);
         }
 
@@ -565,7 +565,7 @@ TEST_F(NetIbMPITest, MultipleSequentialTransfers) {
         if (rank == 0) {
             EXPECT_EQ(sizes[0], bufferSize) << "Transfer " << i << " size mismatch";
 
-            EXPECT_TRUE(VerifyHostBuffer(recvBuffer, bufferSize, seed)) << "Transfer " << i << " data validation failed (seed=" << seed << ")";
+            EXPECT_TRUE(verifyHostBufferData<uint8_t>(recvBuffer, bufferSize, makeBytePattern(seed))) << "Transfer " << i << " data validation failed (seed=" << seed << ")";
 
             // NOTE: Flush is NOT called for host memory transfers
             // Flush (iflush) is only needed for GPU Direct RDMA to ensure data visibility on GPU.
@@ -610,7 +610,7 @@ TEST_F(NetIbMPITest, LargeTransfer) {
         PostSingleRecv(pair.recvComm, buffer, bufferSize, tag, mhandle, &request);
     } else {
         // Sender
-        FillHostBuffer(buffer, bufferSize, rank);
+        fillHostBufferWithPattern<uint8_t>(buffer, bufferSize, makeBytePattern(rank));
         PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
 
@@ -626,7 +626,7 @@ TEST_F(NetIbMPITest, LargeTransfer) {
 
         // Verify received data
         int senderRank = 1;  // Data was sent by rank 1
-        EXPECT_TRUE(VerifyHostBuffer(buffer, bufferSize, senderRank)) << "Large transfer data validation failed";
+        EXPECT_TRUE(verifyHostBufferData<uint8_t>(buffer, bufferSize, makeBytePattern(senderRank))) << "Large transfer data validation failed";
     }
 
     // NetMHandleGuard will automatically deregister at scope end
@@ -830,7 +830,7 @@ TEST_F(NetIbMPITest, MultipleSimultaneousListens) {
                   ncclSuccess);
 
         if (rank == 1) {
-            FillHostBuffer(buf, kTransferSize, seed);
+            fillHostBufferWithPattern<uint8_t>(buf, kTransferSize, makeBytePattern(seed));
         } else {
             memset(buf, 0xDE, kTransferSize);
         }
@@ -857,9 +857,8 @@ TEST_F(NetIbMPITest, MultipleSimultaneousListens) {
 
             size_t errIdx = 0;
             uint8_t errExp = 0, errGot = 0;
-            bool ok = RCCLTestHelpers::verifyHostBufferData<uint8_t>(buf, kTransferSize,
-                [seed](size_t j) { return static_cast<uint8_t>((seed + j) % kBytePatternModulo); },
-                0, 0.0, &errIdx, &errExp, &errGot);
+            bool ok = verifyHostBufferData<uint8_t>(buf, kTransferSize,
+                makeBytePattern(seed), 0, 0.0, &errIdx, &errExp, &errGot);
             EXPECT_TRUE(ok) << listens[c].label << " data mismatch at byte " << errIdx
                             << ": expected " << (int)errExp << " got " << (int)errGot;
         }

--- a/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
@@ -1118,20 +1118,15 @@ TEST_F(NetIbMPITest, MultiRecv) {
     };
 
     auto FillPattern = [&](void* buf, size_t size, int batch, int slot) {
-        uint8_t* p = static_cast<uint8_t*>(buf);
-        for (size_t j = 0; j < size; j++) {
-            p[j] = static_cast<uint8_t>((batch * 17 + slot * 31 + j) % kBytePatternModulo);
-        }
+        fillHostBufferWithPattern<uint8_t>(buf, size, [batch, slot](size_t j) {
+            return static_cast<uint8_t>((batch * 17 + slot * 31 + j) % 256);
+        });
     };
 
     auto CheckPattern = [&](void* buf, size_t size, int batch, int slot) -> bool {
-        uint8_t* p = static_cast<uint8_t*>(buf);
-        for (size_t j = 0; j < size; j++) {
-            uint8_t expected =
-                static_cast<uint8_t>((batch * 17 + slot * 31 + j) % kBytePatternModulo);
-            if (p[j] != expected) return false;
-        }
-        return true;
+        return verifyHostBufferData<uint8_t>(buf, size, [batch, slot](size_t j) {
+            return static_cast<uint8_t>((batch * 17 + slot * 31 + j) % 256);
+        });
     };
 
     ConnectionPair pair;
@@ -1276,20 +1271,15 @@ TEST_F(NetIbMPITest, MultiRecvShuffled) {
     static constexpr int kSendOrder[kWidth] = {5, 2, 7, 0, 6, 3, 1, 4};
 
     auto FillPattern = [&](void* buf, size_t size, int batch, int msgId) {
-        uint8_t* p = static_cast<uint8_t*>(buf);
-        for (size_t j = 0; j < size; j++) {
-            p[j] = static_cast<uint8_t>((batch * 19 + msgId * 37 + j) % kBytePatternModulo);
-        }
+        fillHostBufferWithPattern<uint8_t>(buf, size, [batch, msgId](size_t j) {
+            return static_cast<uint8_t>((batch * 19 + msgId * 37 + j) % 256);
+        });
     };
 
     auto CheckPattern = [&](void* buf, size_t size, int batch, int msgId) -> bool {
-        uint8_t* p = static_cast<uint8_t*>(buf);
-        for (size_t j = 0; j < size; j++) {
-            uint8_t expected =
-                static_cast<uint8_t>((batch * 19 + msgId * 37 + j) % kBytePatternModulo);
-            if (p[j] != expected) return false;
-        }
-        return true;
+        return verifyHostBufferData<uint8_t>(buf, size, [batch, msgId](size_t j) {
+            return static_cast<uint8_t>((batch * 19 + msgId * 37 + j) % 256);
+        });
     };
 
     ConnectionPair pair;

--- a/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
@@ -1252,4 +1252,181 @@ TEST_F(NetIbMPITest, MultiRecv) {
     // connGuard closes comms on scope exit
 }
 
+TEST_F(NetIbMPITest, MultiRecvShuffled) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly 2 processes";
+
+    int rank = MPIEnvironment::world_rank;
+    int peerRank = (rank + 1) % 2;
+
+    ASSERT_EQ(InitNetIb(), ncclSuccess);
+
+    static constexpr int kWidth = 8;
+    static constexpr int kNumBatches = 255;
+    static constexpr int kBaseTag = 12000;
+    // stride 100 between batches keeps tags visually distinct in debug logs
+    static constexpr int kTagStride = 100;
+    static constexpr size_t kBaseSizes[kWidth] = {
+        1, 64, 256, 1024, 4096, 16384, 65536, 131072
+    };
+
+    // kRecvOrder[slot] = msgId posted at that recv slot (recv posts in slot order)
+    static constexpr int kRecvOrder[kWidth] = {3, 0, 6, 1, 7, 2, 5, 4};
+    // kSendOrder[issueIndex] = msgId to send at that issue position
+    static constexpr int kSendOrder[kWidth] = {5, 2, 7, 0, 6, 3, 1, 4};
+
+    auto FillPattern = [&](void* buf, size_t size, int batch, int msgId) {
+        uint8_t* p = static_cast<uint8_t*>(buf);
+        for (size_t j = 0; j < size; j++) {
+            p[j] = static_cast<uint8_t>((batch * 19 + msgId * 37 + j) % kBytePatternModulo);
+        }
+    };
+
+    auto CheckPattern = [&](void* buf, size_t size, int batch, int msgId) -> bool {
+        uint8_t* p = static_cast<uint8_t*>(buf);
+        for (size_t j = 0; j < size; j++) {
+            uint8_t expected =
+                static_cast<uint8_t>((batch * 19 + msgId * 37 + j) % kBytePatternModulo);
+            if (p[j] != expected) return false;
+        }
+        return true;
+    };
+
+    ConnectionPair pair;
+    ASSERT_EQ(SetupConnection(0, pair, rank, peerRank), ncclSuccess);
+    void* recvComm = pair.recvComm;
+    void* sendComm = pair.sendComm;
+
+    NetConnectionGuard connGuard(net_);
+    if (rank == 0) {
+        connGuard.setRecvComm(pair.recvComm);
+        connGuard.setListenComm(pair.listenComm);
+    } else {
+        connGuard.setSendComm(pair.sendComm);
+    }
+
+    for (int batch = 0; batch < kNumBatches; batch++) {
+        int msgTags[kWidth];
+        size_t msgSizes[kWidth];
+        for (int msgId = 0; msgId < kWidth; msgId++) {
+            msgTags[msgId] = kBaseTag + batch * kTagStride + msgId;
+            msgSizes[msgId] = kBaseSizes[msgId];
+        }
+
+        if (rank == 0) {
+            void* bufs[kWidth] = {};
+            void* mhs[kWidth] = {};
+            size_t recvSizesArg[kWidth];
+            int recvTags[kWidth];
+            int recvSizesOut[kWidth] = {};
+
+            auto cleanup = makeScopeGuard([&]() {
+                for (int i = 0; i < kWidth; i++) {
+                    if (mhs[i]) { DeregisterMemory(recvComm, mhs[i]); mhs[i] = nullptr; }
+                    if (bufs[i]) { free(bufs[i]); bufs[i] = nullptr; }
+                }
+            });
+
+            for (int slot = 0; slot < kWidth; slot++) {
+                int msgId = kRecvOrder[slot];
+                recvTags[slot] = msgTags[msgId];
+                recvSizesArg[slot] = msgSizes[msgId];
+
+                bufs[slot] = malloc(recvSizesArg[slot]);
+                ASSERT_NE(bufs[slot], nullptr)
+                    << "malloc failed for recv batch=" << batch << " slot=" << slot;
+                memset(bufs[slot], 0xCC, recvSizesArg[slot]);
+
+                ASSERT_EQ(RegisterMemory(recvComm, bufs[slot], recvSizesArg[slot],
+                                         NCCL_PTR_HOST, &mhs[slot]),
+                          ncclSuccess)
+                    << "RegisterMemory failed for recv batch=" << batch << " slot=" << slot;
+                ASSERT_NE(mhs[slot], nullptr);
+            }
+
+            void* req = nullptr;
+            ASSERT_EQ(PostRecv(recvComm, kWidth, bufs, recvSizesArg, recvTags, mhs, &req),
+                      ncclSuccess)
+                << "PostRecv failed for batch=" << batch;
+            ASSERT_NE(req, nullptr) << "PostRecv returned null request for batch=" << batch;
+
+            MPI_Barrier(MPI_COMM_WORLD);
+
+            ASSERT_EQ(WaitForCompletion(req, recvSizesOut, kLargeTransferTimeoutMs), ncclSuccess)
+                << "WaitForCompletion failed for recv batch=" << batch;
+
+            for (int slot = 0; slot < kWidth; slot++) {
+                int msgId = kRecvOrder[slot];
+                EXPECT_EQ(recvSizesOut[slot], static_cast<int>(msgSizes[msgId]))
+                    << "recv size mismatch at batch=" << batch
+                    << " slot=" << slot
+                    << " msgId=" << msgId;
+
+                EXPECT_TRUE(CheckPattern(bufs[slot], msgSizes[msgId], batch, msgId))
+                    << "data mismatch at batch=" << batch
+                    << " slot=" << slot
+                    << " expected msgId=" << msgId
+                    << " tag=" << msgTags[msgId]
+                    << " size=" << msgSizes[msgId];
+            }
+
+            // cleanup guard fires here, deregistering MRs and freeing buffers
+        } else {
+            void* bufs[kWidth] = {};
+            void* mhs[kWidth] = {};
+            void* reqs[kWidth] = {};
+
+            auto cleanup = makeScopeGuard([&]() {
+                for (int i = 0; i < kWidth; i++) {
+                    if (mhs[i]) { DeregisterMemory(sendComm, mhs[i]); mhs[i] = nullptr; }
+                    if (bufs[i]) { free(bufs[i]); bufs[i] = nullptr; }
+                }
+            });
+
+            for (int msgId = 0; msgId < kWidth; msgId++) {
+                bufs[msgId] = malloc(msgSizes[msgId]);
+                ASSERT_NE(bufs[msgId], nullptr)
+                    << "malloc failed for send batch=" << batch << " msgId=" << msgId;
+
+                FillPattern(bufs[msgId], msgSizes[msgId], batch, msgId);
+
+                ASSERT_EQ(RegisterMemory(sendComm, bufs[msgId], msgSizes[msgId],
+                                         NCCL_PTR_HOST, &mhs[msgId]),
+                          ncclSuccess)
+                    << "RegisterMemory failed for send batch=" << batch
+                    << " msgId=" << msgId;
+                ASSERT_NE(mhs[msgId], nullptr);
+            }
+
+            MPI_Barrier(MPI_COMM_WORLD);
+
+            for (int oi = 0; oi < kWidth; oi++) {
+                int msgId = kSendOrder[oi];
+                reqs[msgId] = nullptr;
+                PostSendWithRetry(sendComm, bufs[msgId], msgSizes[msgId],
+                                  msgTags[msgId], mhs[msgId], &reqs[msgId]);
+                ASSERT_NE(reqs[msgId], nullptr)
+                    << "PostSend returned null request for batch=" << batch
+                    << " msgId=" << msgId;
+            }
+
+            for (int msgId = 0; msgId < kWidth; msgId++) {
+                int sentSize[1] = {0}; // send request yields one size entry
+                ASSERT_EQ(WaitForCompletion(reqs[msgId], sentSize, kLargeTransferTimeoutMs),
+                          ncclSuccess)
+                    << "send completion failed for batch=" << batch
+                    << " msgId=" << msgId;
+            }
+
+            // cleanup guard fires here, deregistering MRs and freeing buffers
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    // connGuard closes comms on scope exit
+}
+
 #endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
@@ -1101,4 +1101,155 @@ TEST_F(NetIbMPITest, RapidConnectDisconnect) {
     }
 }
 
+TEST_F(NetIbMPITest, MultiRecv) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly 2 processes";
+
+    int rank = MPIEnvironment::world_rank;
+    int peerRank = (rank + 1) % 2;
+
+    ASSERT_EQ(InitNetIb(), ncclSuccess);
+
+    static constexpr int kWidth = 8;
+    static constexpr int kNumBatches = 255;
+    static constexpr int kBaseTag = 8000;
+    static constexpr size_t kSizes[kWidth] = {
+        1, 64, 256, 1024, 4096, 16384, 65536, 131072
+    };
+
+    auto FillPattern = [&](void* buf, size_t size, int batch, int slot) {
+        uint8_t* p = static_cast<uint8_t*>(buf);
+        for (size_t j = 0; j < size; j++) {
+            p[j] = static_cast<uint8_t>((batch * 17 + slot * 31 + j) % kBytePatternModulo);
+        }
+    };
+
+    auto CheckPattern = [&](void* buf, size_t size, int batch, int slot) -> bool {
+        uint8_t* p = static_cast<uint8_t*>(buf);
+        for (size_t j = 0; j < size; j++) {
+            uint8_t expected =
+                static_cast<uint8_t>((batch * 17 + slot * 31 + j) % kBytePatternModulo);
+            if (p[j] != expected) return false;
+        }
+        return true;
+    };
+
+    ConnectionPair pair;
+    ASSERT_EQ(SetupConnection(0, pair, rank, peerRank), ncclSuccess);
+    void* recvComm = pair.recvComm;
+    void* sendComm = pair.sendComm;
+
+    NetConnectionGuard connGuard(net_);
+    if (rank == 0) {
+        connGuard.setRecvComm(pair.recvComm);
+        connGuard.setListenComm(pair.listenComm);
+    } else {
+        connGuard.setSendComm(pair.sendComm);
+    }
+
+    for (int batch = 0; batch < kNumBatches; batch++) {
+        size_t sizes[kWidth];
+        int tags[kWidth];
+        for (int i = 0; i < kWidth; i++) {
+            sizes[i] = kSizes[i];
+            tags[i] = kBaseTag + batch * kWidth + i;
+        }
+
+        if (rank == 0) {
+            void* bufs[kWidth] = {};
+            void* mhs[kWidth] = {};
+            int recvSizes[kWidth] = {};
+
+            auto cleanup = makeScopeGuard([&]() {
+                for (int i = 0; i < kWidth; i++) {
+                    if (mhs[i]) { DeregisterMemory(recvComm, mhs[i]); mhs[i] = nullptr; }
+                    if (bufs[i]) { free(bufs[i]); bufs[i] = nullptr; }
+                }
+            });
+
+            for (int i = 0; i < kWidth; i++) {
+                bufs[i] = malloc(sizes[i]);
+                ASSERT_NE(bufs[i], nullptr)
+                    << "malloc failed for recv batch=" << batch << " slot=" << i;
+                memset(bufs[i], 0xCC, sizes[i]);
+
+                ASSERT_EQ(RegisterMemory(recvComm, bufs[i], sizes[i], NCCL_PTR_HOST, &mhs[i]),
+                          ncclSuccess)
+                    << "RegisterMemory failed for recv batch=" << batch << " slot=" << i;
+                ASSERT_NE(mhs[i], nullptr);
+            }
+
+            void* req = nullptr;
+            ASSERT_EQ(PostRecv(recvComm, kWidth, bufs, sizes, tags, mhs, &req), ncclSuccess)
+                << "PostRecv failed for batch=" << batch;
+            ASSERT_NE(req, nullptr) << "PostRecv returned null request for batch=" << batch;
+
+            MPI_Barrier(MPI_COMM_WORLD);
+
+            ASSERT_EQ(WaitForCompletion(req, recvSizes, kLargeTransferTimeoutMs), ncclSuccess)
+                << "WaitForCompletion failed for recv batch=" << batch;
+
+            for (int i = 0; i < kWidth; i++) {
+                EXPECT_EQ(recvSizes[i], static_cast<int>(sizes[i]))
+                    << "recv size mismatch at batch=" << batch << " slot=" << i;
+
+                EXPECT_TRUE(CheckPattern(bufs[i], sizes[i], batch, i))
+                    << "data mismatch at batch=" << batch
+                    << " slot=" << i
+                    << " size=" << sizes[i];
+            }
+
+            // cleanup guard fires here, deregistering MRs and freeing buffers
+        } else {
+            void* bufs[kWidth] = {};
+            void* mhs[kWidth] = {};
+            void* reqs[kWidth] = {};
+
+            auto cleanup = makeScopeGuard([&]() {
+                for (int i = 0; i < kWidth; i++) {
+                    if (mhs[i]) { DeregisterMemory(sendComm, mhs[i]); mhs[i] = nullptr; }
+                    if (bufs[i]) { free(bufs[i]); bufs[i] = nullptr; }
+                }
+            });
+
+            for (int i = 0; i < kWidth; i++) {
+                bufs[i] = malloc(sizes[i]);
+                ASSERT_NE(bufs[i], nullptr)
+                    << "malloc failed for send batch=" << batch << " slot=" << i;
+
+                FillPattern(bufs[i], sizes[i], batch, i);
+
+                ASSERT_EQ(RegisterMemory(sendComm, bufs[i], sizes[i], NCCL_PTR_HOST, &mhs[i]),
+                          ncclSuccess)
+                    << "RegisterMemory failed for send batch=" << batch << " slot=" << i;
+                ASSERT_NE(mhs[i], nullptr);
+            }
+
+            MPI_Barrier(MPI_COMM_WORLD);
+
+            for (int i = 0; i < kWidth; i++) {
+                reqs[i] = nullptr;
+                PostSendWithRetry(sendComm, bufs[i], sizes[i], tags[i], mhs[i], &reqs[i]);
+                ASSERT_NE(reqs[i], nullptr)
+                    << "PostSend returned null request for batch=" << batch
+                    << " slot=" << i;
+            }
+
+            for (int i = 0; i < kWidth; i++) {
+                int sentSize[1] = {0}; // send request yields one size entry
+                ASSERT_EQ(WaitForCompletion(reqs[i], sentSize, kLargeTransferTimeoutMs), ncclSuccess)
+                    << "send completion failed for batch=" << batch << " slot=" << i;
+            }
+
+            // cleanup guard fires here, deregistering MRs and freeing buffers
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    // connGuard closes comms on scope exit
+}
+
 #endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -94,9 +94,6 @@ protected:
     static constexpr bool kRequirePowerOfTwo = true;
     static constexpr int kNoNodeLimit = MPITestConstants::kNoNodeLimit;
 
-    // Buffer pattern constants
-    static constexpr int kBytePatternModulo = 256;
-
     // Timing constants
     static constexpr int kDefaultTimeoutMs = 5000;
     static constexpr int kLargeTransferTimeoutMs = 30000;
@@ -281,42 +278,6 @@ protected:
 
         MPI_Barrier(MPI_COMM_WORLD);
         return ncclSuccess;
-    }
-
-    // Helper: Initialize device buffer with pattern using DeviceBufferHelpers
-    hipError_t InitializeBuffer(void* buffer, size_t size, int pattern) {
-        // Use template-based helper with custom pattern: (pattern + i) % kBytePatternModulo
-        return initializeBufferWithPattern<uint8_t>(
-            buffer, size,
-            [pattern](size_t i) { return static_cast<uint8_t>((pattern + i) % kBytePatternModulo); }
-        );
-    }
-
-    // Helper: Verify device buffer pattern using DeviceBufferHelpers
-    bool VerifyBuffer(void* buffer, size_t size, int pattern) {
-        // Use template-based helper with pattern verification
-        return verifyBufferData<uint8_t>(
-            buffer, size,
-            [pattern](size_t i) {
-                return static_cast<uint8_t>((pattern + i) % kBytePatternModulo);
-            }
-        );
-    }
-
-    // Helper: Fill host buffer with pattern using HostBufferHelpers
-    void FillHostBuffer(void* buffer, size_t size, int seed) {
-        fillHostBufferWithPattern<uint8_t>(
-            buffer, size,
-            [seed](size_t i) { return static_cast<uint8_t>((seed + i) % kBytePatternModulo); }
-        );
-    }
-
-    // Helper: Verify host buffer pattern using HostBufferHelpers
-    bool VerifyHostBuffer(const void* buffer, size_t size, int seed) {
-        return verifyHostBufferData<uint8_t>(
-            buffer, size,
-            [seed](size_t i) { return static_cast<uint8_t>((seed + i) % kBytePatternModulo); }
-        );
     }
 
     // Helper: Retry until the receiver's FIFO slot is ready.

--- a/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
@@ -107,7 +107,7 @@ TEST_F(NetIbMPITest, ConnectAndTransfer_VNic) {
         memset(buffer, 0, bufferSize);
         PostSingleRecv(pair.recvComm, buffer, bufferSize, tag, mhandle, &request);
     } else {
-        FillHostBuffer(buffer, bufferSize, seed);
+        fillHostBufferWithPattern<uint8_t>(buffer, bufferSize, makeBytePattern(seed));
         PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
 
@@ -119,7 +119,7 @@ TEST_F(NetIbMPITest, ConnectAndTransfer_VNic) {
     // Verify data integrity.
     if (rank == 0) {
         EXPECT_EQ(sizes[0], bufferSize) << "Received size mismatch";
-        EXPECT_TRUE(VerifyHostBuffer(buffer, bufferSize, seed)) << "Data validation failed on vNIC transfer";
+        EXPECT_TRUE(verifyHostBufferData<uint8_t>(buffer, bufferSize, makeBytePattern(seed))) << "Data validation failed on vNIC transfer";
     }
 }
 
@@ -210,7 +210,7 @@ TEST_F(NetIbMPITest, AsymmetricMerge_VNic) {
         memset(buffer, 0, bufferSize);
         PostSingleRecv(pair.recvComm, buffer, bufferSize, tag, mhandle, &request);
     } else {
-        FillHostBuffer(buffer, bufferSize, seed);
+        fillHostBufferWithPattern<uint8_t>(buffer, bufferSize, makeBytePattern(seed));
         PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
 
@@ -222,7 +222,7 @@ TEST_F(NetIbMPITest, AsymmetricMerge_VNic) {
     // Verify data integrity across the asymmetric connection.
     if (rank == 0) {
         EXPECT_EQ(sizes[0], bufferSize) << "Received size mismatch";
-        EXPECT_TRUE(VerifyHostBuffer(buffer, bufferSize, seed)) << "Data validation failed on asymmetric vNIC transfer";
+        EXPECT_TRUE(verifyHostBufferData<uint8_t>(buffer, bufferSize, makeBytePattern(seed))) << "Data validation failed on asymmetric vNIC transfer";
     }
 }
 
@@ -287,7 +287,7 @@ TEST_F(NetIbMPITest, CloseWithoutTransfer_VNic) {
         memset(buffer, 0, bufferSize);
         PostSingleRecv(pair2.recvComm, buffer, bufferSize, tag, mhandle, &request);
     } else {
-        FillHostBuffer(buffer, bufferSize, seed);
+        fillHostBufferWithPattern<uint8_t>(buffer, bufferSize, makeBytePattern(seed));
         PostSendWithRetry(pair2.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
 
@@ -299,7 +299,7 @@ TEST_F(NetIbMPITest, CloseWithoutTransfer_VNic) {
     // Verify the vNIC is still functional after the no-transfer teardown.
     if (rank == 0) {
         EXPECT_EQ(sizes[0], bufferSize) << "Received size mismatch";
-        EXPECT_TRUE(VerifyHostBuffer(buffer, bufferSize, seed)) << "Data validation failed after no-transfer teardown reconnect";
+        EXPECT_TRUE(verifyHostBufferData<uint8_t>(buffer, bufferSize, makeBytePattern(seed))) << "Data validation failed after no-transfer teardown reconnect";
     }
 }
 
@@ -366,7 +366,7 @@ TEST_F(NetIbMPITest, RegDeregCycling_VNic) {
         memset(buffer, 0, bufferSize);
         PostSingleRecv(pair.recvComm, buffer, bufferSize, tag, mhandle, &request);
     } else {
-        FillHostBuffer(buffer, bufferSize, seed);
+        fillHostBufferWithPattern<uint8_t>(buffer, bufferSize, makeBytePattern(seed));
         PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
 
@@ -378,7 +378,7 @@ TEST_F(NetIbMPITest, RegDeregCycling_VNic) {
     // Data integrity check after MR cache cycling.
     if (rank == 0) {
         EXPECT_EQ(sizes[0], bufferSize) << "Received size mismatch";
-        EXPECT_TRUE(VerifyHostBuffer(buffer, bufferSize, seed)) << "Data validation failed after reg/dereg cycling";
+        EXPECT_TRUE(verifyHostBufferData<uint8_t>(buffer, bufferSize, makeBytePattern(seed))) << "Data validation failed after reg/dereg cycling";
     }
 }
 
@@ -431,7 +431,7 @@ TEST_F(NetIbMPITest, LargeTransfer_VNic) {
         memset(buffer, 0, bufferSize);
         PostSingleRecv(pair.recvComm, buffer, bufferSize, tag, mhandle, &request);
     } else {
-        FillHostBuffer(buffer, bufferSize, seed);
+        fillHostBufferWithPattern<uint8_t>(buffer, bufferSize, makeBytePattern(seed));
         PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
     }
 
@@ -445,7 +445,7 @@ TEST_F(NetIbMPITest, LargeTransfer_VNic) {
     // ncclIbMultiSend would corrupt data at QP split points.
     if (rank == 0) {
         EXPECT_EQ(sizes[0], bufferSize) << "Large transfer size mismatch";
-        EXPECT_TRUE(VerifyHostBuffer(buffer, bufferSize, seed)) << "Large vNIC transfer data validation failed";
+        EXPECT_TRUE(verifyHostBufferData<uint8_t>(buffer, bufferSize, makeBytePattern(seed))) << "Large vNIC transfer data validation failed";
     }
 }
 
@@ -507,7 +507,7 @@ TEST_F(NetIbMPITest, MixedSizes_VNic) {
             memset(buffer, 0, size);
             PostSingleRecv(pair.recvComm, buffer, size, tag, mhandle, &request);
         } else {
-            FillHostBuffer(buffer, size, seed);
+            fillHostBufferWithPattern<uint8_t>(buffer, size, makeBytePattern(seed));
             PostSendWithRetry(pair.sendComm, buffer, size, tag, mhandle, &request);
         }
 
@@ -522,7 +522,7 @@ TEST_F(NetIbMPITest, MixedSizes_VNic) {
 
         if (rank == 0) {
             EXPECT_EQ(sizes[0], size) << "Size mismatch for transfer of " << size << " bytes";
-            EXPECT_TRUE(VerifyHostBuffer(buffer, size, seed)) << "Data validation failed for size " << size;
+            EXPECT_TRUE(verifyHostBufferData<uint8_t>(buffer, size, makeBytePattern(seed))) << "Data validation failed for size " << size;
         }
     }
 }
@@ -584,7 +584,7 @@ TEST_F(NetIbMPITest, UnalignedSizeTransfer_VNic) {
             memset(buffer, 0, size);
             PostSingleRecv(pair.recvComm, buffer, size, tag, mhandle, &request);
         } else {
-            FillHostBuffer(buffer, size, seed);
+            fillHostBufferWithPattern<uint8_t>(buffer, size, makeBytePattern(seed));
             PostSendWithRetry(pair.sendComm, buffer, size, tag, mhandle, &request);
         }
 
@@ -599,7 +599,7 @@ TEST_F(NetIbMPITest, UnalignedSizeTransfer_VNic) {
         // Byte level verification at the striping boundary.
         if (rank == 0) {
             EXPECT_EQ(sizes[0], size) << "Size mismatch for transfer of " << size << " bytes";
-            EXPECT_TRUE(VerifyHostBuffer(buffer, size, seed)) << "Data validation failed for size " << size;
+            EXPECT_TRUE(verifyHostBufferData<uint8_t>(buffer, size, makeBytePattern(seed))) << "Data validation failed for size " << size;
         }
     }
 }
@@ -713,7 +713,7 @@ TEST_F(NetIbMPITest, Bidirectional_VNic) {
     const int sendSeed = 5700 + rank;
 
     // Fill send buffer with rank-specific pattern.
-    FillHostBuffer(sendBuf, bufferSize, sendSeed);
+    fillHostBufferWithPattern<uint8_t>(sendBuf, bufferSize, makeBytePattern(sendSeed));
 
     // Post recv and send simultaneously on both connections.
     void* recvRequest = nullptr;
@@ -737,7 +737,7 @@ TEST_F(NetIbMPITest, Bidirectional_VNic) {
     // Verify received data matches the peer's send pattern.
     int peerSeed = 5700 + peerRank;
     EXPECT_EQ(recvSizesOut[0], bufferSize) << "Received size mismatch";
-    EXPECT_TRUE(VerifyHostBuffer(recvBuf, bufferSize, peerSeed)) << "Bidirectional vNIC transfer data validation failed";
+    EXPECT_TRUE(verifyHostBufferData<uint8_t>(recvBuf, bufferSize, makeBytePattern(peerSeed))) << "Bidirectional vNIC transfer data validation failed";
 }
 
 TEST_F(NetIbMPITest, FlushRepeated_VNic) {
@@ -794,7 +794,7 @@ TEST_F(NetIbMPITest, FlushRepeated_VNic) {
 
         if (rank == 1) {
             // Fill GPU buffer via DeviceBufferHelpers (host vector → hipMemcpy in one call).
-            ASSERT_EQ(InitializeBuffer(gpuBuffer, bufferSize, seed), hipSuccess);
+            ASSERT_EQ(initializeBufferWithPattern<uint8_t>(gpuBuffer, bufferSize, makeBytePattern(seed)), hipSuccess);
             PostSendWithRetry(pair.sendComm, gpuBuffer, bufferSize, tag, mhandle, &request);
         } else {
             // Rank 0: post recv on GPU buffer.
@@ -822,7 +822,7 @@ TEST_F(NetIbMPITest, FlushRepeated_VNic) {
             }
 
             // Verify GPU buffer via DeviceBufferHelpers (hipMemcpy + compare in one call).
-            ASSERT_TRUE(VerifyBuffer(gpuBuffer, bufferSize, seed))
+            ASSERT_TRUE(verifyBufferData<uint8_t>(gpuBuffer, bufferSize, makeBytePattern(seed)))
                 << "Iter " << iter << ": data verification failed after flush";
         }
 
@@ -880,7 +880,7 @@ TEST_F(NetIbMPITest, SequentialTransfers_VNic) {
 
         if (rank == 1) {
             // Fill buffer with per-iteration pattern.
-            FillHostBuffer(buffer, bufferSize, seed);
+            fillHostBufferWithPattern<uint8_t>(buffer, bufferSize, makeBytePattern(seed));
             PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
         } else {
             // Zero buffer before recv to ensure verification catches stale data.
@@ -897,7 +897,7 @@ TEST_F(NetIbMPITest, SequentialTransfers_VNic) {
         // Verify received data matches the iteration-specific pattern.
         if (rank == 0) {
             ASSERT_EQ(sizes[0], bufferSize) << "Iter " << iter << ": received size mismatch";
-            ASSERT_TRUE(VerifyHostBuffer(buffer, bufferSize, seed)) << "Iter " << iter << ": data verification failed";
+            ASSERT_TRUE(verifyHostBufferData<uint8_t>(buffer, bufferSize, makeBytePattern(seed))) << "Iter " << iter << ": data verification failed";
         }
 
         // Sync before next iteration to prevent request reuse races.
@@ -999,9 +999,9 @@ TEST_F(NetIbMPITest, SendRecvDifferentMemoryTypes) {
 
         if (rank == 1) {
             if (memType == NCCL_PTR_CUDA) {
-                ASSERT_EQ(InitializeBuffer(buf, sz, seed), hipSuccess);
+                ASSERT_EQ(initializeBufferWithPattern<uint8_t>(buf, sz, makeBytePattern(seed)), hipSuccess);
             } else {
-                FillHostBuffer(buf, sz, seed);
+                fillHostBufferWithPattern<uint8_t>(buf, sz, makeBytePattern(seed));
             }
         } else {
             if (memType == NCCL_PTR_CUDA) {
@@ -1040,9 +1040,9 @@ TEST_F(NetIbMPITest, SendRecvDifferentMemoryTypes) {
             }
 
             if (memType == NCCL_PTR_CUDA) {
-                EXPECT_TRUE(VerifyBuffer(buf, sz, seed)) << "Data mismatch for " << c.desc;
+                EXPECT_TRUE(verifyBufferData<uint8_t>(buf, sz, makeBytePattern(seed))) << "Data mismatch for " << c.desc;
             } else {
-                EXPECT_TRUE(VerifyHostBuffer(buf, sz, seed)) << "Data mismatch for " << c.desc;
+                EXPECT_TRUE(verifyHostBufferData<uint8_t>(buf, sz, makeBytePattern(seed))) << "Data mismatch for " << c.desc;
             }
         }
     }
@@ -1125,7 +1125,7 @@ TEST_F(NetIbMPITest, SendRecvMultipleSizesFusion) {
         int seed = 9000 + (int)idx;
 
         if (rank == 1) {
-            FillHostBuffer(buffer, sz, seed);
+            fillHostBufferWithPattern<uint8_t>(buffer, sz, makeBytePattern(seed));
         } else {
             memset(buffer, 0xDE, sz);
         }
@@ -1153,9 +1153,8 @@ TEST_F(NetIbMPITest, SendRecvMultipleSizesFusion) {
             uint8_t errExp = 0, errGot = 0;
 
             if (sizeOk) {
-                dataOk = RCCLTestHelpers::verifyHostBufferData<uint8_t>(buffer, sz,
-                    [seed](size_t i) { return static_cast<uint8_t>((seed + i) % kBytePatternModulo); },
-                    0, 0.0, &errIdx, &errExp, &errGot);
+                dataOk = verifyHostBufferData<uint8_t>(buffer, sz,
+                    makeBytePattern(seed), 0, 0.0, &errIdx, &errExp, &errGot);
             }
 
             bool ok = sizeOk && dataOk;
@@ -1259,7 +1258,7 @@ TEST_F(NetIbMPITest, MultidirectionalTransfer) {
         ASSERT_EQ(RegisterMemory(myRecvComm, recvBuf, pat.recvSize,
                                  NCCL_PTR_HOST, &recvMr), ncclSuccess);
 
-        FillHostBuffer(sendBuf, pat.sendSize, pat.sendSeed);
+        fillHostBufferWithPattern<uint8_t>(sendBuf, pat.sendSize, makeBytePattern(pat.sendSeed));
         memset(recvBuf, 0xDE, pat.recvSize);
 
         // BOTH ranks post recv
@@ -1290,9 +1289,8 @@ TEST_F(NetIbMPITest, MultidirectionalTransfer) {
         {
             size_t errIdx = 0;
             uint8_t errExp = 0, errGot = 0;
-            bool ok = RCCLTestHelpers::verifyHostBufferData<uint8_t>(recvBuf, pat.recvSize,
-                [&pat](size_t j) { return static_cast<uint8_t>((pat.recvSeed + j) % kBytePatternModulo); },
-                0, 0.0, &errIdx, &errExp, &errGot);
+            bool ok = verifyHostBufferData<uint8_t>(recvBuf, pat.recvSize,
+                makeBytePattern(pat.recvSeed), 0, 0.0, &errIdx, &errExp, &errGot);
             EXPECT_TRUE(ok) << pat.name << " rank " << rank
                             << " data mismatch at byte " << errIdx
                             << ": expected " << (int)errExp << " got " << (int)errGot;
@@ -1427,7 +1425,7 @@ TEST_F(NetIbMPITest, MultipleOutstandingSendRecv) {
         // Fill each buffer with a unique pattern and post send
         for (int i = 0; i < kNumOutstanding; i++) {
             int seed = kTagBase + i;
-            FillHostBuffer(bufs[i], kLargeBufferSize, seed);
+            fillHostBufferWithPattern<uint8_t>(bufs[i], kLargeBufferSize, makeBytePattern(seed));
 
             void* sendReq = nullptr;
             ASSERT_EQ(PostSend(pair.sendComm, bufs[i], kLargeBufferSize,
@@ -1471,9 +1469,8 @@ TEST_F(NetIbMPITest, MultipleOutstandingSendRecv) {
             int seed = kTagBase + i;
             size_t errIdx = 0;
             uint8_t errExp = 0, errGot = 0;
-            bool good = RCCLTestHelpers::verifyHostBufferData<uint8_t>(bufs[i], kLargeBufferSize,
-                [seed](size_t j) { return static_cast<uint8_t>((seed + j) % kBytePatternModulo); },
-                0, 0.0, &errIdx, &errExp, &errGot);
+            bool good = verifyHostBufferData<uint8_t>(bufs[i], kLargeBufferSize,
+                makeBytePattern(seed), 0, 0.0, &errIdx, &errExp, &errGot);
 
             if (good) {
                 ok++;
@@ -1765,7 +1762,7 @@ TEST_F(NetIbMPITest, Reconnect_VNic) {
 
         if (rank == 1) {
             // Fill with cycle-specific pattern.
-            FillHostBuffer(buffer, bufferSize, seed);
+            fillHostBufferWithPattern<uint8_t>(buffer, bufferSize, makeBytePattern(seed));
             PostSendWithRetry(pair.sendComm, buffer, bufferSize, tag, mhandle, &request);
         } else {
             memset(buffer, 0, bufferSize);
@@ -1780,7 +1777,7 @@ TEST_F(NetIbMPITest, Reconnect_VNic) {
         // Verify received data matches the cycle-specific pattern.
         if (rank == 0) {
             ASSERT_EQ(sizes[0], bufferSize) << "Cycle " << cycle << ": received size mismatch";
-            ASSERT_TRUE(VerifyHostBuffer(buffer, bufferSize, seed)) << "Cycle " << cycle << ": data verification failed";
+            ASSERT_TRUE(verifyHostBufferData<uint8_t>(buffer, bufferSize, makeBytePattern(seed))) << "Cycle " << cycle << ": data verification failed";
         }
 
         MPI_Barrier(MPI_COMM_WORLD);

--- a/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
@@ -1841,18 +1841,15 @@ TEST_F(NetIbMPITest, MultiRecvGPUShuffled) {
 
     // Patterns keyed by msgId (same formula as MultiRecvShuffled for consistency)
     auto FillPattern = [&](uint8_t* hostBuf, size_t size, int batch, int msgId) {
-        for (size_t j = 0; j < size; j++) {
-            hostBuf[j] = static_cast<uint8_t>((batch * 19 + msgId * 37 + j) % kBytePatternModulo);
-        }
+        fillHostBufferWithPattern<uint8_t>(hostBuf, size, [batch, msgId](size_t j) {
+            return static_cast<uint8_t>((batch * 19 + msgId * 37 + j) % 256);
+        });
     };
 
     auto CheckPattern = [&](const uint8_t* hostBuf, size_t size, int batch, int msgId) -> bool {
-        for (size_t j = 0; j < size; j++) {
-            uint8_t expected =
-                static_cast<uint8_t>((batch * 19 + msgId * 37 + j) % kBytePatternModulo);
-            if (hostBuf[j] != expected) return false;
-        }
-        return true;
+        return verifyHostBufferData<uint8_t>(hostBuf, size, [batch, msgId](size_t j) {
+            return static_cast<uint8_t>((batch * 19 + msgId * 37 + j) % 256);
+        });
     };
 
     ConnectionPair pair;

--- a/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
@@ -1805,4 +1805,195 @@ TEST_F(NetIbMPITest, Reconnect_VNic) {
     }
 }
 
+TEST_F(NetIbMPITest, MultiRecvGPUShuffled) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly 2 processes";
+
+    int rank = MPIEnvironment::world_rank;
+    int peerRank = (rank + 1) % 2;
+
+    ASSERT_EQ(InitNetIb(), ncclSuccess);
+
+    int dev = CreateMergedDevice(3, rank);
+    if (dev == -1) {
+        GTEST_SKIP() << "Failed to create 3-NIC merged device";
+    }
+
+    {
+        ncclNetProperties_t props = {};
+        ASSERT_EQ(GetDeviceProperties(dev, &props), ncclSuccess);
+        if (!(props.ptrSupport & NCCL_PTR_CUDA)) {
+            GTEST_SKIP() << "GDR not supported on this device, skipping GPU MultiRecv test";
+        }
+    }
+
+    static constexpr int kWidth = 8;
+    static constexpr int kNumBatches = 255;
+    static constexpr int kBaseTag = 16000;
+    static constexpr int kTagStride = 100;
+    // Keep sizes modest to limit GPU memory allocation per batch
+    static constexpr size_t kBaseSizes[kWidth] = {
+        64, 256, 1024, 4096, 16384, 65536, 131072, 262144
+    };
+
+    // kRecvOrder[slot] = msgId posted at that recv slot
+    static constexpr int kRecvOrder[kWidth] = {3, 0, 6, 1, 7, 2, 5, 4};
+    // kSendOrder[issueIndex] = msgId to send at that issue position
+    static constexpr int kSendOrder[kWidth] = {5, 2, 7, 0, 6, 3, 1, 4};
+
+    // Patterns keyed by msgId (same formula as MultiRecvShuffled for consistency)
+    auto FillPattern = [&](uint8_t* hostBuf, size_t size, int batch, int msgId) {
+        for (size_t j = 0; j < size; j++) {
+            hostBuf[j] = static_cast<uint8_t>((batch * 19 + msgId * 37 + j) % kBytePatternModulo);
+        }
+    };
+
+    auto CheckPattern = [&](const uint8_t* hostBuf, size_t size, int batch, int msgId) -> bool {
+        for (size_t j = 0; j < size; j++) {
+            uint8_t expected =
+                static_cast<uint8_t>((batch * 19 + msgId * 37 + j) % kBytePatternModulo);
+            if (hostBuf[j] != expected) return false;
+        }
+        return true;
+    };
+
+    ConnectionPair pair;
+    ASSERT_EQ(SetupConnection(dev, pair, rank, peerRank), ncclSuccess);
+    void* recvComm = pair.recvComm;
+    void* sendComm = pair.sendComm;
+
+    NetConnectionGuard connGuard(net_);
+    if (rank == 0) {
+        connGuard.setRecvComm(pair.recvComm);
+        connGuard.setListenComm(pair.listenComm);
+    } else {
+        connGuard.setSendComm(pair.sendComm);
+    }
+
+    for (int batch = 0; batch < kNumBatches; batch++) {
+        int msgTags[kWidth];
+        size_t msgSizes[kWidth];
+        for (int msgId = 0; msgId < kWidth; msgId++) {
+            msgTags[msgId] = kBaseTag + batch * kTagStride + msgId;
+            msgSizes[msgId] = kBaseSizes[msgId];
+        }
+
+        if (rank == 0) {
+            void* gpuBufs[kWidth] = {};
+            void* mhs[kWidth] = {};
+            size_t recvSizesArg[kWidth];
+            int recvTags[kWidth];
+            int recvSizesOut[kWidth] = {};
+
+            auto cleanup = makeScopeGuard([&]() {
+                for (int i = 0; i < kWidth; i++) {
+                    if (mhs[i]) { DeregisterMemory(recvComm, mhs[i]); mhs[i] = nullptr; }
+                    if (gpuBufs[i]) { hipFreeWrapper(gpuBufs[i]); gpuBufs[i] = nullptr; }
+                }
+            });
+
+            for (int slot = 0; slot < kWidth; slot++) {
+                int msgId = kRecvOrder[slot];
+                recvTags[slot] = msgTags[msgId];
+                recvSizesArg[slot] = msgSizes[msgId];
+
+                HIP_TEST_CHECK_GTEST_FAIL(hipMalloc(&gpuBufs[slot], recvSizesArg[slot]));
+                HIP_TEST_CHECK_GTEST_FAIL(hipMemset(gpuBufs[slot], 0xCC, recvSizesArg[slot]));
+
+                ASSERT_EQ(RegisterMemory(recvComm, gpuBufs[slot], recvSizesArg[slot],
+                                         NCCL_PTR_CUDA, &mhs[slot]),
+                          ncclSuccess)
+                    << "GPU RegisterMemory failed for recv batch=" << batch << " slot=" << slot;
+                ASSERT_NE(mhs[slot], nullptr);
+            }
+
+            void* req = nullptr;
+            ASSERT_EQ(PostRecv(recvComm, kWidth, gpuBufs, recvSizesArg, recvTags, mhs, &req),
+                      ncclSuccess)
+                << "PostRecv failed for batch=" << batch;
+            ASSERT_NE(req, nullptr) << "PostRecv returned null request for batch=" << batch;
+
+            MPI_Barrier(MPI_COMM_WORLD);
+
+            ASSERT_EQ(WaitForCompletion(req, recvSizesOut, kLargeTransferTimeoutMs), ncclSuccess)
+                << "WaitForCompletion failed for recv batch=" << batch;
+
+            for (int slot = 0; slot < kWidth; slot++) {
+                int msgId = kRecvOrder[slot];
+                EXPECT_EQ(recvSizesOut[slot], static_cast<int>(msgSizes[msgId]))
+                    << "recv size mismatch at batch=" << batch
+                    << " slot=" << slot << " msgId=" << msgId;
+
+                std::vector<uint8_t> hostBuf(msgSizes[msgId]);
+                HIP_TEST_CHECK_GTEST_FAIL(
+                    hipMemcpy(hostBuf.data(), gpuBufs[slot], msgSizes[msgId],
+                              hipMemcpyDeviceToHost));
+
+                EXPECT_TRUE(CheckPattern(hostBuf.data(), msgSizes[msgId], batch, msgId))
+                    << "data mismatch at batch=" << batch
+                    << " slot=" << slot << " expected msgId=" << msgId
+                    << " tag=" << msgTags[msgId] << " size=" << msgSizes[msgId];
+            }
+
+            // cleanup guard fires here, deregistering MRs and freeing GPU buffers
+        } else {
+            void* gpuBufs[kWidth] = {};
+            void* mhs[kWidth] = {};
+            void* reqs[kWidth] = {};
+
+            auto cleanup = makeScopeGuard([&]() {
+                for (int i = 0; i < kWidth; i++) {
+                    if (mhs[i]) { DeregisterMemory(sendComm, mhs[i]); mhs[i] = nullptr; }
+                    if (gpuBufs[i]) { hipFreeWrapper(gpuBufs[i]); gpuBufs[i] = nullptr; }
+                }
+            });
+
+            for (int msgId = 0; msgId < kWidth; msgId++) {
+                HIP_TEST_CHECK_GTEST_FAIL(hipMalloc(&gpuBufs[msgId], msgSizes[msgId]));
+
+                std::vector<uint8_t> hostBuf(msgSizes[msgId]);
+                FillPattern(hostBuf.data(), msgSizes[msgId], batch, msgId);
+                HIP_TEST_CHECK_GTEST_FAIL(
+                    hipMemcpy(gpuBufs[msgId], hostBuf.data(), msgSizes[msgId],
+                              hipMemcpyHostToDevice));
+
+                ASSERT_EQ(RegisterMemory(sendComm, gpuBufs[msgId], msgSizes[msgId],
+                                         NCCL_PTR_CUDA, &mhs[msgId]),
+                          ncclSuccess)
+                    << "GPU RegisterMemory failed for send batch=" << batch
+                    << " msgId=" << msgId;
+                ASSERT_NE(mhs[msgId], nullptr);
+            }
+
+            MPI_Barrier(MPI_COMM_WORLD);
+
+            for (int oi = 0; oi < kWidth; oi++) {
+                int msgId = kSendOrder[oi];
+                reqs[msgId] = nullptr;
+                PostSendWithRetry(sendComm, gpuBufs[msgId], msgSizes[msgId],
+                                  msgTags[msgId], mhs[msgId], &reqs[msgId]);
+
+                ASSERT_NE(reqs[msgId], nullptr)
+                    << "PostSend returned null request for batch=" << batch
+                    << " msgId=" << msgId;
+            }
+
+            for (int msgId = 0; msgId < kWidth; msgId++) {
+                int sentSize[1] = {0}; // send request yields one size entry
+                ASSERT_EQ(WaitForCompletion(reqs[msgId], sentSize, kLargeTransferTimeoutMs),
+                          ncclSuccess)
+                    << "send completion failed for batch=" << batch << " msgId=" << msgId;
+            }
+
+            // cleanup guard fires here, deregistering MRs and freeing GPU buffers
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    // connGuard closes comms on scope exit
+}
+
 #endif // MPI_TESTS_ENABLED

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -285,6 +285,31 @@
         }
       ]
     },
+    "net_ib_multirecv": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "NCCL_DEBUG_SUBSYS": "NET,INIT"
+      },
+      "tests": [
+        {
+          "name": "NetIB_MultiRecv",
+          "description": "irecv(n=8) batching over host memory, sequential tag order, 255 batches",
+          "test_filter": "NetIbMPITest.MultiRecv"
+        },
+        {
+          "name": "NetIB_MultiRecvShuffled",
+          "description": "irecv(n=8) batching over host memory, shuffled recv-slot and send-issue order, 255 batches",
+          "test_filter": "NetIbMPITest.MultiRecvShuffled"
+        },
+        {
+          "name": "NetIB_MultiRecvGPUShuffled",
+          "description": "irecv(n=8) batching over GPU memory (GDR path), shuffled order, 255 batches; skipped if GDR unavailable",
+          "test_filter": "NetIbMPITest.MultiRecvGPUShuffled"
+        }
+      ]
+    },
     "unit_tests_fixtures": {
       "is_gtest": true,
       "binary": "rccl-UnitTestsFixtures",
@@ -771,6 +796,12 @@
       "name": "NET IB - Data Transfer",
       "description": "InfiniBand data transfer and stress tests",
       "config": "net_ib_transfer",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - MultiRecv",
+      "description": "irecv(n>1) multi-slot batching tests",
+      "config": "net_ib_multirecv",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -340,6 +340,32 @@
           "test_filter": "NetIbMPITest.RegDeregCycling_VNic"
         }
       ]
+    },
+
+    "net_ib_multirecv": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "NCCL_DEBUG_SUBSYS": "NET,INIT"
+      },
+      "tests": [
+        {
+          "name": "NetIB_MultiRecv",
+          "description": "irecv(n=8) batching over host memory, sequential tag order, 255 batches",
+          "test_filter": "NetIbMPITest.MultiRecv"
+        },
+        {
+          "name": "NetIB_MultiRecvShuffled",
+          "description": "irecv(n=8) batching over host memory, shuffled recv-slot and send-issue order, 255 batches",
+          "test_filter": "NetIbMPITest.MultiRecvShuffled"
+        },
+        {
+          "name": "NetIB_MultiRecvGPUShuffled",
+          "description": "irecv(n=8) batching over GPU memory (GDR path), shuffled order, 255 batches; skipped if GDR unavailable",
+          "test_filter": "NetIbMPITest.MultiRecvGPUShuffled"
+        }
+      ]
     }
   },
   "test_suites": [
@@ -401,6 +427,12 @@
       "name": "NET IB - vNIC Stress",
       "description": "Virtual NIC stress, reconnect, and repeated-operation tests",
       "config": "net_ib_vnic_stress",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - MultiRecv",
+      "description": "irecv(n>1) multi-slot batching tests",
+      "config": "net_ib_multirecv",
       "enabled": true
     }
   ]


### PR DESCRIPTION
## Motivation

RCCL's InfiniBand transport layer supports a multi-receive path that allows a receiver to post multiple receive buffers and match them against incoming sends in a single batch. This path had limited test coverage, particularly for high-volume scenarios and non-sequential tag ordering. This PR adds targeted MPI-level unit tests to validate correctness of the multi-receive path under realistic stress conditions.

## JIRA ID

Resolves AICOMNET-168

## Test Plan

AICOMNET-168

##  Test Result

Both tests pass on a Thor2 cluster. Data integrity verified across all 255 batches and all 8 message sizes, including the shuffled-tag-order variant. To be validated at AINIC cluster.

##  Submission Checklist

 - [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.