### PR TITLE
[rocr-debug-agent] Correct .readthedocs path for monorepo migration

### DIFF
--- a/projects/rocr-debug-agent/.readthedocs.yaml
+++ b/projects/rocr-debug-agent/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: projects/rocr-debug-agent/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
   install:
-  - requirements: docs/sphinx/requirements.txt
+  - requirements: projects/rocr-debug-agent/docs/sphinx/requirements.txt
 
 build:
   os: ubuntu-22.04


### PR DESCRIPTION
## Motivation

.readthedocs.yml contains outdated path.

## Technical Details

Correct the path to match monorepo setup.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
