### PR TITLE
rocprofv3: add PC sampling attach/detach integration tests

### DIFF
--- a/projects/rocprofiler-sdk/tests/bin/pc-sampling/exec-mask-manipulation/exec_mask_manipulation.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/pc-sampling/exec-mask-manipulation/exec_mask_manipulation.cpp
@@ -54,11 +54,11 @@ check_hip_error(void);
 
 // ======================================================
 __global__ void
-kernel1(const int c)
+kernel1(const int c, const size_t iter_num)
 {
     int a = 0;
 #pragma nounroll
-    for(int i = 0; i < ITER_NUM; i++)
+    for(size_t i = 0; i < iter_num; i++)
     {
         asm volatile("v_mov_b32 %0 %1\n" : "=v"(a) : "s"(c));
         asm volatile("v_mov_b32 %0 %1\n" : "=v"(a) : "s"(c));
@@ -164,11 +164,11 @@ kernel1(const int c)
 }
 
 __global__ void
-kernel2(const int c)
+kernel2(const int c, const size_t iter_num)
 {
     int a = 0;
 #pragma nounroll
-    for(int i = 0; i < ITER_NUM; i++)
+    for(size_t i = 0; i < iter_num; i++)
     {
         asm volatile("s_mov_b32 %0 %1\n" : "=s"(a) : "s"(c));
         asm volatile("s_mov_b32 %0 %1\n" : "=s"(a) : "s"(c));
@@ -274,14 +274,14 @@ kernel2(const int c)
 }
 
 __global__ void
-kernel3(const float c)
+kernel3(const float c, const size_t iter_num)
 {
     double a        = threadIdx.x;
     float  i        = 0;
     float  d        = threadIdx.x;
     float  e        = 0;
     int    tid_even = threadIdx.x % 2;
-    for(int j = 0; j < ITER_NUM; j++)
+    for(size_t j = 0; j < iter_num; j++)
     {
         if(tid_even == 0)
         {
@@ -495,35 +495,35 @@ kernel3(const float c)
 // ======================================================
 
 void
-run_kernel()
+run_kernel(size_t iter_num)
 {
     int wave_size = 0;
     HIP_API_CALL(hipDeviceGetAttribute(&wave_size, hipDeviceAttributeWarpSize, 0));
 
-    // Get device properties to retrieve GFXIP version
     uint32_t num_blocks = BLOCK_SIZE;
-
     for(int i = 1; i <= wave_size; i++)
     {
         if(i % 2 == 1)
-            kernel1<<<num_blocks, i>>>(i);
+            kernel1<<<num_blocks, i>>>(i, iter_num);
         else
-            kernel2<<<num_blocks, i>>>(i);
+            kernel2<<<num_blocks, i>>>(i, iter_num);
 
         check_hip_error();
         HIP_API_CALL(hipDeviceSynchronize());
     }
 
     float arg = 0;
-    kernel3<<<num_blocks, 4 * wave_size>>>(arg);
+    kernel3<<<num_blocks, 4 * wave_size>>>(arg, iter_num);
     check_hip_error();
     HIP_API_CALL(hipDeviceSynchronize());
 }
 
 int
-main()
+main(int argc, char* argv[])
 {
-    run_kernel();
+    size_t iter_num = ITER_NUM;
+    if(argc > 1) iter_num = std::stoull(argv[1]);
+    run_kernel(iter_num);
     return 0;
 }
 

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/CMakeLists.txt
@@ -5,3 +5,4 @@
 add_subdirectory(attach-once)
 add_subdirectory(attach-twice)
 add_subdirectory(attach-tree)
+add_subdirectory(attach-pc-sampling)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/CMakeLists.txt
@@ -1,0 +1,6 @@
+#
+# PC sampling attachment tests
+#
+
+add_subdirectory(host-trap)
+add_subdirectory(stochastic)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/host-trap/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/host-trap/CMakeLists.txt
@@ -1,0 +1,73 @@
+#
+# rocprofv3 attachment test -- PC sampling (host_trap) with attach/detach
+#
+cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)
+
+project(
+    rocprofiler-sdk-tests-rocprofv3-attachment-attach-pc-sampling-host-trap
+    LANGUAGES CXX
+    VERSION 0.0.0)
+
+find_package(rocprofiler-sdk REQUIRED)
+
+rocprofiler_sdk_pc_sampling_disabled(IS_PC_SAMPLING_DISABLED)
+
+set(ROCPROFILER_MEMCHECK_TYPES "AddressSanitizer" "UndefinedBehaviorSanitizer"
+                               "ThreadSanitizer")
+
+if(IS_PC_SAMPLING_DISABLED OR (ROCPROFILER_MEMCHECK AND ROCPROFILER_MEMCHECK IN_LIST
+                                                        ROCPROFILER_MEMCHECK_TYPES))
+    set(IS_DISABLED ON)
+else()
+    set(IS_DISABLED OFF)
+endif()
+
+# PC sampling emits a high volume of INFO-level buffer traces; 'warning' keeps -V output
+# readable (also required under LeakSanitizer).
+set(LOG_LEVEL "warning")
+
+set(PRELOAD_ENV "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}")
+
+set(attachment-pc-sampling-host-trap-env
+    "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
+    )
+
+set(ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX
+    "PC sampling unavailable|PC sampling configuration is not supported")
+
+# Execute: launch exec-mask-manipulation in background, attach with PC sampling
+# (host_trap)
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-attachment-attach-pc-sampling-host-trap
+    COMMAND
+        ${CMAKE_CURRENT_SOURCE_DIR}/../run_attach_pc_sampling_test.sh
+        $<TARGET_FILE:exec-mask-manipulation> $<TARGET_FILE:rocprofiler-sdk::rocprofv3>
+        ${CMAKE_CURRENT_BINARY_DIR} ${LOG_LEVEL} out host_trap time 1 5000 1048576
+    DEPENDS rocprofiler-sdk::rocprofv3 exec-mask-manipulation
+    TIMEOUT 90
+    LABELS "integration-tests;attachment;pc-sampling"
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${PRELOAD_ENV}"
+    ENVIRONMENT "${attachment-pc-sampling-host-trap-env}"
+    SKIP_REGULAR_EXPRESSION
+        "This test is skipped.|${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
+    FIXTURES_SETUP rocprofv3-test-attachment-attach-pc-sampling-host-trap
+    FAIL_REGULAR_EXPRESSION "FATAL|${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
+# Validate: pytest checks on the collected PC sampling CSVs
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-attachment-attach-pc-sampling-host-trap-validate
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    TIMEOUT 30
+    LABELS "integration-tests;attachment;pc-sampling"
+    DISABLED ${IS_DISABLED}
+    SKIP_REGULAR_EXPRESSION "SKIPPED|${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
+    FIXTURES_REQUIRED rocprofv3-test-attachment-attach-pc-sampling-host-trap
+    ARGS --input-csv
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-pc-sampling-output/out_pc_sampling_host_trap.csv
+         --all-sampled
+         False
+         --skip-if
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-pc-sampling-output/skipped)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/host-trap/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/host-trap/conftest.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import os
+import pytest
+import pandas as pd
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--input-csv",
+        action="store",
+        help="Path to CSV file.",
+    )
+    parser.addoption(
+        "--all-sampled",
+        action="store",
+        help="All SW and HW units must be sampled.",
+    )
+    parser.addoption(
+        "--skip-if",
+        action="store",
+        help="Skip tests if this file exists (ptrace not permitted).",
+    )
+
+
+def _check_skip(request):
+    skip_path = request.config.getoption("--skip-if")
+    if skip_path and os.path.exists(skip_path):
+        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
+
+
+@pytest.fixture
+def input_csv(request):
+    _check_skip(request)
+    filename = request.config.getoption("--input-csv")
+    if not filename or not os.path.isfile(filename):
+        pytest.skip("PC sampling unavailable")
+    else:
+        with open(filename, "r") as inp:
+            return pd.read_csv(
+                inp,
+                na_filter=False,
+                keep_default_na=False,
+                dtype={
+                    "Exec_Mask": "uint64",
+                    "Instruction": str,
+                    "Instruction_Comment": str,
+                },
+            )
+
+
+@pytest.fixture
+def all_sampled(request):
+    _all_sampled_str = request.config.getoption("--all-sampled")
+    return _all_sampled_str == "True"

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/host-trap/pytest.ini
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/host-trap/pytest.ini
@@ -1,0 +1,5 @@
+
+[pytest]
+addopts = --durations=20 -rA -s
+testpaths = validate.py
+pythonpath = @ROCPROFILER_SDK_TESTS_BINARY_DIR@/pytest-packages

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/host-trap/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/host-trap/validate.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import sys
+import pytest
+import numpy as np
+import pandas as pd
+
+# =========================== Validating CSV output (attach mode, host_trap)
+
+
+def test_validate_pc_sampling_exec_mask_manipulation_csv(
+    input_csv: pd.DataFrame, all_sampled: bool
+):
+    # In attach mode the first captured dispatch surfaces as Correlation_Id == 1
+    # and earlier samples carry CID == 0. Drop the CID == 0 prefix and shift
+    # CID/Dispatch_Id by popcount(Exec_Mask @ CID==1) - 1 so wrap-mode csv.py
+    # helpers apply verbatim.
+
+    from rocprofiler_sdk.pc_sampling.exec_mask_manipulation.csv import (
+        validate_exec_mask_based_on_correlation_id,
+        validate_instruction_comment,
+        validate_instruction_correlation_id_relation,
+        validate_instruction_decoding,
+    )
+
+    assert not input_csv.empty, "Attach-mode PC sampling CSV is empty"
+
+    df = input_csv.sort_values("Sample_Timestamp").reset_index(drop=True)
+    resolved_rows = df[df["Correlation_Id"] != 0]
+    assert not resolved_rows.empty, "No resolved samples (all Correlation_Id == 0)"
+    first_resolved_idx = int(resolved_rows.index.min())
+    df = df.iloc[first_resolved_idx:].copy()
+    assert (
+        df["Correlation_Id"] != 0
+    ).all(), "Found Correlation_Id == 0 samples after the first resolved sample; "
+
+    cid1 = df[df["Correlation_Id"] == 1]
+    assert not cid1.empty, (
+        "No Correlation_Id == 1 samples found; attach window missed the first "
+        "captured dispatch and the offset cannot be inferred."
+    )
+    # Assumes the first captured dispatch is a loop kernel (popcount(Exec_Mask) == i);
+    # a kernel3-first capture would miscompute the offset.
+    cid1_popcount = int(
+        cid1["Exec_Mask"].apply(lambda exec_mask: bin(exec_mask).count("1")).mode()[0]
+    )
+    offset = cid1_popcount - 1
+
+    df["Correlation_Id"] = df["Correlation_Id"].astype(int) + offset
+    df["Dispatch_Id"] = df["Dispatch_Id"].astype(int) + offset
+
+    # Every dispatch in [min, max] must be represented; a gap means a lost
+    # correlation-id mapping during attach.
+    min_dispatch_id = int(df["Dispatch_Id"].min())
+    max_dispatch_id = int(df["Dispatch_Id"].max())
+    unique_dispatch_ids = df["Dispatch_Id"].nunique()
+    expected_unique_dispatch_ids = max_dispatch_id - min_dispatch_id + 1
+    assert unique_dispatch_ids == expected_unique_dispatch_ids, (
+        f"Gap in Dispatch_Id range: expected {expected_unique_dispatch_ids} unique "
+        f"dispatches in [{min_dispatch_id}, {max_dispatch_id}], "
+        f"got {unique_dispatch_ids}"
+    )
+
+    validate_instruction_comment(df)
+    validate_instruction_correlation_id_relation(df)
+
+    if max_dispatch_id in (33, 65):
+        # kernel3 has v_rcp on even/odd lanes; validate separately.
+        first_kernels_df = df[df["Dispatch_Id"] <= max_dispatch_id - 1]
+        validate_exec_mask_based_on_correlation_id(first_kernels_df.copy())
+
+        last_kernel = df[df["Dispatch_Id"] == max_dispatch_id]
+        exec_mask_size_hex_digits = max_dispatch_id // 4
+        even_simd_threads_active_exec_mask = int("5" * exec_mask_size_hex_digits, 16)
+        odd_simd_threads_active_exec_mask = int("A" * exec_mask_size_hex_digits, 16)
+
+        validate_instruction_decoding(
+            last_kernel,
+            "v_rcp_f64",
+            exec_mask_uint64=np.uint64(even_simd_threads_active_exec_mask),
+            source_code_lines_range=(288, 387),
+        )
+        validate_instruction_decoding(
+            last_kernel,
+            "v_rcp_f32",
+            exec_mask_uint64=np.uint64(odd_simd_threads_active_exec_mask),
+            source_code_lines_range=(391, 490),
+        )
+    else:
+        # Attach window did not reach kernel3; invariant holds on captured kernels.
+        validate_exec_mask_based_on_correlation_id(df.copy())
+
+
+if __name__ == "__main__":
+    exit_code = pytest.main(["-x", __file__] + sys.argv[1:])
+    sys.exit(exit_code)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/run_attach_pc_sampling_test.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/run_attach_pc_sampling_test.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+set -e
+
+# Arguments
+TEST_APP=$1
+ROCPROFV3=$2
+OUTPUT_DIR=${3:-${PWD}}
+LOG_LEVEL=${4:-info}
+OUTPUT_FILENAME=${5:-out}
+PC_SAMPLING_METHOD=${6:-host_trap}
+PC_SAMPLING_UNIT=${7:-time}
+PC_SAMPLING_INTERVAL=${8:-1}
+ATTACH_DURATION_MSEC=${9:-5000}
+# Iteration count for exec-mask-manipulation: keeps the app alive long enough
+# for the profiler to attach, sample, and detach within ATTACH_DURATION_MSEC.
+TEST_APP_ITER_NUM=${10:-1048576}
+
+export ROCP_TOOL_ATTACH=1
+
+OUTPUT_SUBDIR="attachment-pc-sampling-output"
+EXPECTED_CSV_FILES=("${OUTPUT_FILENAME}_pc_sampling_${PC_SAMPLING_METHOD}.csv" "${OUTPUT_FILENAME}_agent_info.csv")
+
+rm -rf ${OUTPUT_DIR}/${OUTPUT_SUBDIR}
+mkdir -p ${OUTPUT_DIR}/${OUTPUT_SUBDIR}
+
+# ptrace permission check: skip if ptrace_scope disallows and we lack privileges
+if [ -e /proc/sys/kernel/yama/ptrace_scope ]                             \
+&& [ $(cat /proc/sys/kernel/yama/ptrace_scope) -ne 0 ]                   \
+&& [ $(id -u) -ne 0 ]                                                    \
+&& [[ $(getpcaps self) != *"cap_sys_ptrace"* ]]                          \
+&& [[ $(getcap $(readlink -f $(which python3))) != *"cap_sys_ptrace"* ]]
+    then
+    echo "ptrace_scope is not 0, user is not root, and CAP_SYS_PTRACE is not present, so test cannot be completed. This test is skipped."
+    touch ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/skipped
+    exit 0
+fi
+
+echo "Starting PC sampling attachment test (method=${PC_SAMPLING_METHOD})..."
+
+echo "Launching test application: ${TEST_APP} ${TEST_APP_ITER_NUM}"
+LD_PRELOAD=${ROCPROF_PRELOAD} ${TEST_APP} ${TEST_APP_ITER_NUM} &
+APP_PID=$!
+
+sleep 1
+
+if ! kill -0 $APP_PID 2>/dev/null; then
+    echo "Test application failed to start or exited early"
+    exit 1
+fi
+
+echo "Test application started with PID: $APP_PID"
+
+if [ ! -f "${ROCPROFV3}" ]; then
+    echo "Error: rocprofv3 not found at ${ROCPROFV3}"
+    kill $APP_PID 2>/dev/null
+    exit 1
+fi
+
+echo "Attaching profiler to PID $APP_PID for ${ATTACH_DURATION_MSEC}ms with PC sampling (${PC_SAMPLING_METHOD})..."
+
+echo "===== COMMAND TO EXECUTE ====="
+echo "${ROCPROFV3} --attach $APP_PID --attach-duration-msec ${ATTACH_DURATION_MSEC} --pc-sampling-beta-enabled --pc-sampling-unit ${PC_SAMPLING_UNIT} --pc-sampling-method ${PC_SAMPLING_METHOD} --pc-sampling-interval ${PC_SAMPLING_INTERVAL} -f csv -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME}"
+echo ""
+
+LD_PRELOAD=${ROCPROF_PRELOAD} ${ROCPROFV3} --attach $APP_PID --attach-duration-msec ${ATTACH_DURATION_MSEC} --pc-sampling-beta-enabled --pc-sampling-unit ${PC_SAMPLING_UNIT} --pc-sampling-method ${PC_SAMPLING_METHOD} --pc-sampling-interval ${PC_SAMPLING_INTERVAL} -f csv -d ${OUTPUT_DIR}/${OUTPUT_SUBDIR} --log-level ${LOG_LEVEL} -o ${OUTPUT_FILENAME}
+
+echo "Profiler detached successfully"
+
+echo "Waiting for application to complete..."
+wait $APP_PID
+APP_EXIT_CODE=$?
+
+if [ $APP_EXIT_CODE -ne 0 ]; then
+    echo "Test application failed with exit code $APP_EXIT_CODE"
+    exit 1
+fi
+
+echo "Test application completed successfully"
+
+echo "Checking for generated output files..."
+ls -la ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/
+
+for expected_file in "${EXPECTED_CSV_FILES[@]}"; do
+    if [ ! -f "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file}" ]; then
+        echo "Error: Expected output file ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file} not found"
+        exit 1
+    fi
+done
+
+echo "PC sampling attachment test (method=${PC_SAMPLING_METHOD}) completed successfully"
+exit 0

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/stochastic/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/stochastic/CMakeLists.txt
@@ -1,0 +1,74 @@
+#
+# rocprofv3 attachment test -- PC sampling (stochastic) with attach/detach
+#
+cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)
+
+project(
+    rocprofiler-sdk-tests-rocprofv3-attachment-attach-pc-sampling-stochastic
+    LANGUAGES CXX
+    VERSION 0.0.0)
+
+find_package(rocprofiler-sdk REQUIRED)
+
+rocprofiler_sdk_pc_sampling_stochastic_disabled(IS_PC_SAMPLING_STOCHASTIC_DISABLED)
+
+set(ROCPROFILER_MEMCHECK_TYPES "AddressSanitizer" "UndefinedBehaviorSanitizer"
+                               "ThreadSanitizer")
+
+if(IS_PC_SAMPLING_STOCHASTIC_DISABLED
+   OR (ROCPROFILER_MEMCHECK AND ROCPROFILER_MEMCHECK IN_LIST ROCPROFILER_MEMCHECK_TYPES))
+    set(IS_DISABLED ON)
+else()
+    set(IS_DISABLED OFF)
+endif()
+
+# PC sampling emits a high volume of INFO-level buffer traces; 'warning' keeps -V output
+# readable (also required under LeakSanitizer).
+set(LOG_LEVEL "warning")
+
+set(PRELOAD_ENV "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}")
+
+set(attachment-pc-sampling-stochastic-env
+    "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
+    )
+
+set(ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX
+    "PC sampling unavailable|PC sampling configuration is not supported")
+
+# Execute: launch exec-mask-manipulation in background, attach with PC sampling
+# (stochastic)
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-attachment-attach-pc-sampling-stochastic
+    COMMAND
+        ${CMAKE_CURRENT_SOURCE_DIR}/../run_attach_pc_sampling_test.sh
+        $<TARGET_FILE:exec-mask-manipulation> $<TARGET_FILE:rocprofiler-sdk::rocprofv3>
+        ${CMAKE_CURRENT_BINARY_DIR} ${LOG_LEVEL} out stochastic cycles 1048576 5000
+        1048576
+    DEPENDS rocprofiler-sdk::rocprofv3 exec-mask-manipulation
+    TIMEOUT 90
+    LABELS "integration-tests;attachment;pc-sampling;stochastic"
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${PRELOAD_ENV}"
+    ENVIRONMENT "${attachment-pc-sampling-stochastic-env}"
+    SKIP_REGULAR_EXPRESSION
+        "This test is skipped.|${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
+    FIXTURES_SETUP rocprofv3-test-attachment-attach-pc-sampling-stochastic
+    FAIL_REGULAR_EXPRESSION "FATAL|${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
+# Validate: pytest checks on the collected PC sampling CSVs
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-attachment-attach-pc-sampling-stochastic-validate
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    TIMEOUT 30
+    LABELS "integration-tests;attachment;pc-sampling;stochastic"
+    DISABLED ${IS_DISABLED}
+    SKIP_REGULAR_EXPRESSION "SKIPPED|${ROCPROFV3_TESTS_PC_SAMPLING_SKIP_REGEX}"
+    FIXTURES_REQUIRED rocprofv3-test-attachment-attach-pc-sampling-stochastic
+    ARGS --input-csv
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-pc-sampling-output/out_pc_sampling_stochastic.csv
+         --all-sampled
+         False
+         --skip-if
+         ${CMAKE_CURRENT_BINARY_DIR}/attachment-pc-sampling-output/skipped)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/stochastic/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/stochastic/conftest.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import os
+import pytest
+import pandas as pd
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--input-csv",
+        action="store",
+        help="Path to CSV file.",
+    )
+    parser.addoption(
+        "--all-sampled",
+        action="store",
+        help="All SW and HW units must be sampled.",
+    )
+    parser.addoption(
+        "--skip-if",
+        action="store",
+        help="Skip tests if this file exists (ptrace not permitted).",
+    )
+
+
+def _check_skip(request):
+    skip_path = request.config.getoption("--skip-if")
+    if skip_path and os.path.exists(skip_path):
+        pytest.skip("Attach tests unavailable due to insufficient ptrace permissions")
+
+
+@pytest.fixture
+def input_csv(request):
+    _check_skip(request)
+    filename = request.config.getoption("--input-csv")
+    if not filename or not os.path.isfile(filename):
+        pytest.skip("PC sampling unavailable")
+    else:
+        with open(filename, "r") as inp:
+            return pd.read_csv(
+                inp,
+                na_filter=False,
+                keep_default_na=False,
+                dtype={
+                    "Exec_Mask": "uint64",
+                    "Instruction": str,
+                    "Instruction_Comment": str,
+                    "Wave_Issued_Instruction": bool,
+                    "Instruction_Type": str,
+                    "Stall_Reason": str,
+                },
+            )
+
+
+@pytest.fixture
+def all_sampled(request):
+    _all_sampled_str = request.config.getoption("--all-sampled")
+    return _all_sampled_str == "True"

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/stochastic/pytest.ini
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/stochastic/pytest.ini
@@ -1,0 +1,5 @@
+
+[pytest]
+addopts = --durations=20 -rA -s
+testpaths = validate.py
+pythonpath = @ROCPROFILER_SDK_TESTS_BINARY_DIR@/pytest-packages

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/stochastic/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-pc-sampling/stochastic/validate.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import sys
+import pytest
+import numpy as np
+import pandas as pd
+
+# =========================== Validating CSV output (attach mode, stochastic)
+
+
+def test_validate_pc_sampling_exec_mask_manipulation_csv(
+    input_csv: pd.DataFrame, all_sampled: bool
+):
+    # In attach mode the first captured dispatch surfaces as Correlation_Id == 1
+    # and earlier samples carry CID == 0. Drop the CID == 0 prefix and shift
+    # CID/Dispatch_Id by popcount(Exec_Mask @ CID==1) - 1 so wrap-mode csv.py
+    # helpers apply verbatim.
+
+    from rocprofiler_sdk.pc_sampling.exec_mask_manipulation.csv import (
+        validate_exec_mask_based_on_correlation_id,
+        validate_instruction_comment,
+        validate_instruction_correlation_id_relation,
+        validate_instruction_decoding,
+    )
+
+    assert not input_csv.empty, "Attach-mode PC sampling CSV is empty"
+
+    df = input_csv.sort_values("Sample_Timestamp").reset_index(drop=True)
+    resolved_rows = df[df["Correlation_Id"] != 0]
+    assert not resolved_rows.empty, "No resolved samples (all Correlation_Id == 0)"
+    first_resolved_idx = int(resolved_rows.index.min())
+    df = df.iloc[first_resolved_idx:].copy()
+    assert (
+        df["Correlation_Id"] != 0
+    ).all(), "Found Correlation_Id == 0 samples after the first resolved sample; "
+
+    cid1 = df[df["Correlation_Id"] == 1]
+    assert not cid1.empty, (
+        "No Correlation_Id == 1 samples found; attach window missed the first "
+        "captured dispatch and the offset cannot be inferred."
+    )
+    # Assumes the first captured dispatch is a loop kernel (popcount(Exec_Mask) == i);
+    # a kernel3-first capture would miscompute the offset.
+    cid1_popcount = int(
+        cid1["Exec_Mask"].apply(lambda exec_mask: bin(exec_mask).count("1")).mode()[0]
+    )
+    offset = cid1_popcount - 1
+
+    df["Correlation_Id"] = df["Correlation_Id"].astype(int) + offset
+    df["Dispatch_Id"] = df["Dispatch_Id"].astype(int) + offset
+
+    # Every dispatch in [min, max] must be represented; a gap means a lost
+    # correlation-id mapping during attach.
+    min_dispatch_id = int(df["Dispatch_Id"].min())
+    max_dispatch_id = int(df["Dispatch_Id"].max())
+    unique_dispatch_ids = df["Dispatch_Id"].nunique()
+    expected_unique_dispatch_ids = max_dispatch_id - min_dispatch_id + 1
+    assert unique_dispatch_ids == expected_unique_dispatch_ids, (
+        f"Gap in Dispatch_Id range: expected {expected_unique_dispatch_ids} unique "
+        f"dispatches in [{min_dispatch_id}, {max_dispatch_id}], "
+        f"got {unique_dispatch_ids}"
+    )
+
+    validate_instruction_comment(df)
+    validate_instruction_correlation_id_relation(df)
+
+    if max_dispatch_id in (33, 65):
+        # kernel3 has v_rcp on even/odd lanes; validate separately.
+        first_kernels_df = df[df["Dispatch_Id"] <= max_dispatch_id - 1]
+        validate_exec_mask_based_on_correlation_id(first_kernels_df.copy())
+
+        last_kernel = df[df["Dispatch_Id"] == max_dispatch_id]
+        exec_mask_size_hex_digits = max_dispatch_id // 4
+        even_simd_threads_active_exec_mask = int("5" * exec_mask_size_hex_digits, 16)
+        odd_simd_threads_active_exec_mask = int("A" * exec_mask_size_hex_digits, 16)
+
+        validate_instruction_decoding(
+            last_kernel,
+            "v_rcp_f64",
+            exec_mask_uint64=np.uint64(even_simd_threads_active_exec_mask),
+            source_code_lines_range=(288, 387),
+        )
+        validate_instruction_decoding(
+            last_kernel,
+            "v_rcp_f32",
+            exec_mask_uint64=np.uint64(odd_simd_threads_active_exec_mask),
+            source_code_lines_range=(391, 490),
+        )
+    else:
+        # Attach window did not reach kernel3; invariant holds on captured kernels.
+        validate_exec_mask_based_on_correlation_id(df.copy())
+
+
+if __name__ == "__main__":
+    exit_code = pytest.main(["-x", __file__] + sys.argv[1:])
+    sys.exit(exit_code)


### PR DESCRIPTION
## Motivation

PC sampling was recently extended to support the rocprofv3 attach/detach workflow (#3921 / commit d86e9a3097: "Enable PC sampling with attach/detach"). That code path currently has no integration tests. This PR adds them.

## Technical Details

 Two new ctest cases under `tests/rocprofv3/attachment/attach-pc-sampling/`:
  - `attach-pc-sampling-host-trap`  — 5s attach, host_trap method
  - `attach-pc-sampling-stochastic` — 5s attach, stochastic method
  
Each test launches `exec-mask-manipulation` in the background, attaches rocprofv3 with `--pc-sampling-*` flags and `--attach-duration-msec 5000`, detaches, and validates the resulting CSV.
  
**Validation.** In attach mode the first captured dispatch surfaces as `Correlation_Id == 1` rather than its true wrap-mode index. The new `validate.py`:
  1. Drops the `CID == 0` prefix (unresolved samples emitted before profiling actually started tracking).
  2. Infers `offset = popcount(Exec_Mask @ CID==1) - 1` (relies on the loop kernels' block-size-equals-popcount design property).
  3. Shifts `Correlation_Id` and `Dispatch_Id` by that offset.
  4. Reuses the existing wrap-mode helpers from `tests/pytest-packages/pc_sampling/exec_mask_manipulation/csv.py` verbatim on the shifted DataFrame.

**App change.** `exec_mask_manipulation.cpp` now takes an optional `iter_num` in `argv[1]` (default: the existing `ITER_NUM` macro), so the app can be kept alive long enough to cover the 5s attach window. Wrap-mode invocations without arguments pick up the default and are unaffected.


## Test Result

- [x] `ctest -R attach-pc-sampling` — host-trap and stochastic both pass
- [x]  Reproduced the attach workflow end-to-end with standalone scripts and manually verified the CSV output against the validator logic before integrating the checks into ctest.  

## Follow-ups (tracked, not in this PR)
  - Tune `iter_num` so the attach window reliably captures kernel3, enabling the `v_rcp_f64`/`v_rcp_f32` decoding checks.
  -  Add PC sampling reattach coverage (multiple attach/detach cycles on the same process, mirror of `attach-twice`).
  - Add stochastic-specific gfx9 CSV validation (`Wave_Issued_Instruction`, `Instruction_Type`, `Stall_Reason`, `Wave_Count`).
  - Add multi-agent attach coverage (mirror of `transpose-multiple-agents`).
  - Add JSON-output validation for attach mode.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
