### PR TITLE
Minor doc update for PerfXpert and add PerfXpert project to skippable path

### DIFF
--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -134,6 +134,7 @@ SKIPPABLE_PATH_PATTERNS = [
     "projects/rocr-runtime/libhsakmt/src/dxg/*",
     "shared/*/docs/*",
     "shared/*/.gitignore",
+    "experimental/python/perfxpert/*",
 ]
 
 

--- a/experimental/python/perfxpert/README.md
+++ b/experimental/python/perfxpert/README.md
@@ -2,6 +2,15 @@
 
 AI-powered AMD ROCm GPU trace analysis.
 
+## Caution
+
+> **Experimental software.** PerfXpert is still evolving and is provided
+> without warranties or guarantees. AI-generated analysis, explanations, and
+> recommendations can be incomplete or incorrect, so verify important results
+> before relying on them in production or performance-critical workflows.
+
+
+
 ## Quickstart
 
 ### Prerequisites
@@ -216,13 +225,6 @@ See [CHANGELOG.md](CHANGELOG.md) for the removal history.
     - [External-tool dependencies (`require_tool`)](docs/contributing/external-tools.md)
 - **Other**
   - [Historical migration notes](docs/archive/migration-to-agentic.md)
-
-## Caution
-
-> **Experimental software.** PerfXpert is still evolving and is provided
-> without warranties or guarantees. AI-generated analysis, explanations, and
-> recommendations can be incomplete or incorrect, so verify important results
-> before relying on them in production or performance-critical workflows.
 
 ## Licensing
 


### PR DESCRIPTION
## Motivation

  PerfXpert is still experimental, so its current limitations and validation expectations should be visible before users get into setup and usage details.
  In addition, PerfXpert-only changes should not trigger TheRock CI selection while the project is still experimental and not yet covered by that CI flow.

  ## Technical Details

  - Move the PerfXpert caution/experimental notice to the top of `experimental/python/perfxpert/README.md` so users see it immediately after the project summary.
  - Add `experimental/python/perfxpert/*` to the skippable path list in `.github/scripts/therock_configure_ci.py` so PerfXpert-only changes do not trigger TheRock CI project selection.

  ## JIRA ID

  N/A

  ## Test Plan

  - Review the README update to confirm the caution block is shown near the top of the document.
  - Review the CI script change to confirm the new PerfXpert path is included only in the skippable path list.
  - Confirm the PR is limited to documentation visibility and CI path-selection behavior.

  ## Test Result

  - No functional runtime changes were made to PerfXpert.
  - No automated tests were run for this change.

  ## Submission Checklist

  - [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.