### PR TITLE
[rocprofiler-systems] Fix jacobi-hip markers.h include paths

### DIFF
--- a/projects/rocprofiler-systems/examples/hpc/jacobi-hip/markers.h
+++ b/projects/rocprofiler-systems/examples/hpc/jacobi-hip/markers.h
@@ -16,8 +16,8 @@
 #if defined(__HIP_PLATFORM_HCC__)
 // begin HCC
 
-#    include <roctracer_ext.h>
-#    include <roctx.h>
+#    include <roctracer/roctracer_ext.h>
+#    include <roctracer/roctx.h>
 
 #    define BEGIN_RANGE(name, group)                                                     \
         do                                                                               \


### PR DESCRIPTION
## Motivation

`examples/hpc/jacobi-hip/markers.h` includes `<roctracer_ext.h>` and
`<roctx.h>` unqualified. This compiles today only because the example's
CMakeLists.txt prepends custom `-I` paths (`${ROCM_PATH}/roctracer/include`
and `${ROCM_PATH}/include/roctracer`). Consumers that wire up roctracer
through an installed ROCm layout without those specific flags hit an
include-not-found failure — the canonical install is
`<prefix>/include/roctracer/`, so the idiomatic form is
`<roctracer/roctracer_ext.h>`.

Sibling examples (`examples/roctx/*.cpp`, `examples/hpc/matrix-exponential-streams-sync-hip/mat_exp.cpp`) already use the subdir-qualified `<rocprofiler-sdk-roctx/roctx.h>` form, so this change aligns jacobi-hip with existing project convention.

## Changes

- `examples/hpc/jacobi-hip/markers.h`: use `<roctracer/roctracer_ext.h>` and `<roctracer/roctx.h>`.