### PR TITLE
perfxpert: align architecture overview with 8-agent hierarchy

### DIFF
--- a/experimental/python/perfxpert/docs/architecture.md
+++ b/experimental/python/perfxpert/docs/architecture.md
@@ -14,17 +14,23 @@ All four resolve into the same session/runtime layer in
 
 ## Agents (spec §2)
 
-```
-Root (intent router)
- ├─ Analysis  (classifies bottleneck, gathers metrics)
- ├─ Recommendation (hands off to specialists)
- │   ├─ compute_specialist
- │   ├─ memory_specialist
- │   └─ latency_specialist
- └─ Correctness (enforces 5 gates on proposed changes)
-```
+**Tier 0**
+- `Root` — intent classify
 
-8 agents total. Each has ≤ 400 lines of fence + ≤ 5 tools + ≤ 10 input / ≤ 5 output fields. Narrow scope is CI-enforced.
+**Tier 1**
+- `Analysis` — classifies bottlenecks and gathers metrics
+- `Recommendation` — proposes optimization techniques
+- `Correctness` — narrates gate verdicts
+
+**Tier 2 specialists**
+- `compute_specialist`
+- `memory_specialist`
+- `latency_specialist`
+- `diff_specialist`
+
+8 agents total. See
+[architecture/agent-hierarchy.md](architecture/agent-hierarchy.md) for
+the detailed tier map, per-agent guardrails, and handoff details.
 
 See [architecture/agent-hierarchy.md](architecture/agent-hierarchy.md) for the tier-by-tier map, fence-slice pattern, and source-tree locations, and [architecture/gate-cascade.md](architecture/gate-cascade.md) for the 5-gate correctness middleware that sits between the agents. The full architecture docs index lives at [architecture/README.md](architecture/README.md).
 


### PR DESCRIPTION
## Motivation

Align the top-level perfxpert architecture overview with the shipped 8-agent hierarchy so the summary page no longer collapses the model into a 7-agent view.

## Technical Details

Update `experimental/python/perfxpert/docs/architecture.md` to:
- replace the incomplete top-level agent summary with an explicit tiered 8-agent overview
- include the shipped `diff_specialist` in the top-level overview without assigning it to the wrong handoff path
- describe `Correctness` as narrating gate verdicts in the overview and point readers to `docs/architecture/agent-hierarchy.md` for the detailed tier map, guardrails, and handoff semantics
- remove the earlier overclaim that all per-agent guardrails for the overviewed set are CI-enforced in the current smoke checks

## JIRA ID

N/A

## Test Plan

- `env PYTHONPATH=experimental/python/perfxpert python3 -m pytest -q experimental/python/perfxpert/tests/test_docs_tooling/test_ship_readiness.py experimental/python/perfxpert/tests/test_integration/test_docs_links.py`
- targeted hierarchy review against `experimental/python/perfxpert/docs/architecture/agent-hierarchy.md`, `experimental/python/perfxpert/docs/guides/python-api.md`, and the relevant agent runtime docs
- reviewer-wave pass over the final diff

## Test Result

The focused docs suite passed (`6 passed`). Reviewer findings on the earlier incorrect `Recommendation -> diff_specialist` and root-to-Tier-2 implications were addressed before the final version was committed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
