### PR TITLE
perfxpert: fix stale opencode launcher docstring

### DIFF
--- a/experimental/python/perfxpert/perfxpert/cli/opencode_launcher.py
+++ b/experimental/python/perfxpert/perfxpert/cli/opencode_launcher.py
@@ -1,17 +1,23 @@
 """opencode_launcher — `perfxpert-code` entry point.
 
-Launches opencode (from PERFXPERT_OPENCODE_PATH / locally built patched
-repo checkout / bundled wheel / well-known paths / system PATH in that
-order) with the AMD-themed config directory.
+Launches opencode with the bundled AMD-themed config. Runtime binary resolution
+prefers, in order: `PERFXPERT_OPENCODE_PATH`, a locally built patched repo
+checkout under `experimental/python/perfxpert/opencode`, the packaged
+`perfxpert/_bundled/opencode` resource when it exists, then upstream well-known
+install paths and finally `PATH`.
 
-In source/editable checkouts, `perfxpert-code install-patches` can build the
-patched binary from the pinned `opencode` submodule. In packaged installs, the
-launcher prefers the bundled binary when present and falls back to an upstream
-`opencode` install only when no patched copy is available.
+Bundling the patched binary is best-effort, not guaranteed. `setup.py` tries to
+run `scripts/build-bundled-opencode.sh` during wheel/editable installs when the
+repo-pinned submodule and `bun` are available, but it warns and skips the build
+instead of downloading tooling or cloning mutable upstream source. The
+deprecated `perfxpert-code install-patches` alias is the editable/source escape
+hatch for rebuilding `_bundled/opencode` from that pinned submodule.
 
-PERFXPERT_OPENCODE_PATH, if set, must point to an existing executable file;
-the launcher raises FileNotFoundError immediately rather than silently
-falling back to bundled/PATH lookup.
+If no patched copy is available at runtime, the launcher falls through to an
+upstream `opencode` install and emits a warning that the perfxpert gate/rebrand
+patches are inactive. `PERFXPERT_OPENCODE_PATH`, if set, must point to an
+existing executable file; otherwise the launcher raises `FileNotFoundError`
+instead of silently continuing to bundled/PATH lookup.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Motivation

The top-level `opencode_launcher.py` docstring was stale relative to the shipped launcher behavior. It implied the bundled binary was part of the normal packaged path, but current setup/build logic only bundles `_bundled/opencode` when the pinned submodule and `bun` are available and otherwise skips the build without failing install.

## Technical Details

Updated the module docstring in `experimental/python/perfxpert/perfxpert/cli/opencode_launcher.py` to match the current resolution/build contract:
- document the real runtime lookup order, including repo-local patched builds ahead of `_bundled/opencode`
- call out that bundling the patched binary is best-effort during install, not guaranteed
- describe `perfxpert-code install-patches` as the deprecated editable/source rebuild escape hatch
- note that upstream `opencode` fallback is expected and warned when no patched binary is available

## JIRA ID

N/A

## Test Plan

Run focused perfxpert launcher/setup tests that cover binary resolution, fallback, and bundled build expectations.

## Test Result

`env PYTHONPATH=experimental/python/perfxpert python3 -m pytest experimental/python/perfxpert/tests/test_cli/test_launcher_subcommands.py experimental/python/perfxpert/tests/test_tools/test_opencode_launcher.py experimental/python/perfxpert/tests/test_setup/test_setup_build.py`

77 tests passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
