### PR TITLE
perfxpert: export diff specialist from agents package

### DIFF
--- a/experimental/python/perfxpert/perfxpert/agents/__init__.py
+++ b/experimental/python/perfxpert/perfxpert/agents/__init__.py
@@ -1,4 +1,4 @@
-"""Agent hierarchy — 8 agents on a deterministic tool floor (spec §2)."""
+"""PerfXpert agent package exports for the root, tier-1, and tier-2 roles."""
 
 from perfxpert.agents.runtime import AnalysisSession, build_session, DEFAULT_PROVIDER
 from perfxpert.agents.schemas import (
@@ -13,6 +13,7 @@ from perfxpert.agents.analysis import run_analysis, build_analysis_agent
 from perfxpert.agents.recommendation import run_recommendation, build_recommendation_agent
 from perfxpert.agents.correctness import run_correctness, build_correctness_agent
 from perfxpert.agents.compute_specialist import run_compute_specialist, build_compute_specialist
+from perfxpert.agents.diff_specialist import run_diff_specialist, build_diff_specialist
 from perfxpert.agents.memory_specialist import run_memory_specialist, build_memory_specialist
 from perfxpert.agents.latency_specialist import run_latency_specialist, build_latency_specialist
 
@@ -32,6 +33,7 @@ __all__ = [
     "run_recommendation", "build_recommendation_agent",
     "run_correctness", "build_correctness_agent",
     "run_compute_specialist", "build_compute_specialist",
+    "run_diff_specialist", "build_diff_specialist",
     "run_memory_specialist", "build_memory_specialist",
     "run_latency_specialist", "build_latency_specialist",
 ]

--- a/experimental/python/perfxpert/tests/test_agents/test_tool_allowlist_guardrail.py
+++ b/experimental/python/perfxpert/tests/test_agents/test_tool_allowlist_guardrail.py
@@ -12,6 +12,7 @@ from perfxpert.agents import (
     build_recommendation_agent,
     build_correctness_agent,
     build_compute_specialist,
+    build_diff_specialist,
     build_memory_specialist,
     build_latency_specialist,
 )
@@ -23,6 +24,7 @@ AGENT_BUILDERS = [
     build_recommendation_agent,
     build_correctness_agent,
     build_compute_specialist,
+    build_diff_specialist,
     build_memory_specialist,
     build_latency_specialist,
 ]
@@ -49,3 +51,10 @@ def test_no_execution_tool_in_allowlist(builder):
 def test_allowlist_within_cap(builder):
     agent = builder()
     assert len(agent.tools) <= 5, f"{agent.name} has {len(agent.tools)} tools (cap 5)"
+
+
+def test_agents_package_re_exports_diff_specialist_surface():
+    from perfxpert import agents
+
+    assert "build_diff_specialist" in agents.__all__
+    assert "run_diff_specialist" in agents.__all__


### PR DESCRIPTION
## Motivation

`perfxpert.agents.__init__` had drifted from the actual agent hierarchy surface. The package still used hard-coded counted wording and did not re-export the diff specialist builder/runner, so package-level imports and `__all__` lagged behind the runtime and docs surface.

## Technical Details

- replaced the counted module docstring with a count-free package export description to avoid future wording drift
- re-exported `build_diff_specialist` and `run_diff_specialist` from `perfxpert.agents`
- extended the focused guardrail test to include `build_diff_specialist` and assert the package `__all__` includes the diff specialist exports

## JIRA ID

N/A

## Test Plan

- `PYTHONPATH=experimental/python/perfxpert pytest experimental/python/perfxpert/tests/test_agents/test_tool_allowlist_guardrail.py -q`
- `PYTHONPATH=experimental/python/perfxpert pytest experimental/python/perfxpert/tests/test_agents/test_runtime.py -q`

## Test Result

- `test_tool_allowlist_guardrail.py`: 17 passed
- `test_runtime.py`: 20 passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
