### PR TITLE
[rocprofiler-compute] Use __file__ for native tool path detection

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -364,10 +364,7 @@ class RocProfCompute_Base:
             # Use native counter collection tool
             # Use lib* glob pattern to handle CMAKE_INSTALL_LIBDIR variations
             # (lib, lib64, lib32, etc. depending on distribution)
-            script_path = Path(sys.argv[0]).resolve()
-            native_tool_base_path = (
-                script_path.parents[2] if len(script_path.parents) >= 3 else Path()
-            )
+            native_tool_base_path = Path(__file__).parents[3]
             native_tool_glob_pattern = (
                 "lib*/rocprofiler-compute/librocprofiler-compute-tool.so"
             )


### PR DESCRIPTION
## Motivation

Anchor prefix discovery for the prebuilt `librocprofiler-compute-tool.so` to the module's own location, so it works under any `rocprof-compute` launcher (current `bin/` symlink, or a future wrapper script for wheel-style installs).

## Technical Details

- Replace `Path(sys.argv[0]).resolve().parents[2]` with `Path(__file__).parents[3]` in `RocProfCompute_Base` when computing the install-prefix glob root.
- `__file__` always points to the module's real location in `libexec/rocprofiler-compute/rocprof_compute_profile/`, so `parents[3]` lands at the install prefix regardless of how the entrypoint was launched.

## JIRA ID

## Test Plan

- Run a profile on an install where `librocprofiler-compute-tool.so` is prebuilt and confirm the glob finds it (no `Building native tool now.` debug output).
- Run a profile on an install where the prebuilt `.so` is absent and confirm the `hipcc` fallback path still works.

## Test Result

Pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
