### PR TITLE
[ci] Enabling RCCL for CI nightly

### DIFF
--- a/.github/scripts/tests/therock_configure_ci_test.py
+++ b/.github/scripts/tests/therock_configure_ci_test.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 import os
 import sys
@@ -294,6 +295,67 @@ class ConfigureCITest(unittest.TestCase):
 
         project_to_run = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 0)
+
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_rccl_ci_triggered_by_rccl_paths_pull_request(self, mock_get_modified):
+        """workflow_dispatch with a windows_only subtree must not trigger Linux CI."""
+        args = {"is_pull_request": True, "base_ref": "HEAD^", "platform": "linux"}
+
+        mock_get_modified.return_value = [
+            "projects/rccl/rccl.cpp",
+            "projects/rccl/test/test.cpp",
+        ]
+
+        outputs = therock_configure_ci.run(args)
+        projects = json.loads(outputs["projects"])
+        self.assertEqual(len(projects), 0)
+        self.assertEqual(outputs["run_linux_rccl_ci"], "true")
+
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_rccl_ci_not_triggered_by_non_rccl_paths_pull_request(
+        self, mock_get_modified
+    ):
+        """workflow_dispatch with a windows_only subtree must not trigger Linux CI."""
+        args = {"is_pull_request": True, "base_ref": "HEAD^", "platform": "linux"}
+
+        mock_get_modified.return_value = ["projects/rocprim/rocprim.cpp"]
+
+        outputs = therock_configure_ci.run(args)
+        projects = json.loads(outputs["projects"])
+        self.assertGreaterEqual(len(projects), 1)
+        self.assertEqual(outputs["run_linux_rccl_ci"], "false")
+
+    def test_rccl_ci_triggered_nightly(self):
+        """workflow_dispatch with a windows_only subtree must not trigger Linux CI."""
+        args = {"is_nightly": True, "base_ref": "HEAD^", "platform": "linux"}
+
+        outputs = therock_configure_ci.run(args)
+        projects = json.loads(outputs["projects"])
+        self.assertGreaterEqual(len(projects), 1)
+        self.assertEqual(outputs["run_linux_rccl_ci"], "true")
+
+    def test_rccl_ci_triggered_workflow_dispatch(self):
+        """workflow_dispatch with a windows_only subtree must not trigger Linux CI."""
+        args = {
+            "is_workflow_dispatch": True,
+            "input_projects": "projects/rccl",
+            "base_ref": "HEAD^",
+            "platform": "linux",
+        }
+
+        outputs = therock_configure_ci.run(args)
+        projects = json.loads(outputs["projects"])
+        self.assertEqual(len(projects), 0)
+        self.assertEqual(outputs["run_linux_rccl_ci"], "true")
+
+    def test_rccl_ci_not_triggered_push(self):
+        """workflow_dispatch with a windows_only subtree must not trigger Linux CI."""
+        args = {"is_push": True, "base_ref": "HEAD^", "platform": "linux"}
+
+        outputs = therock_configure_ci.run(args)
+        projects = json.loads(outputs["projects"])
+        self.assertGreaterEqual(len(projects), 1)
+        self.assertEqual(outputs["run_linux_rccl_ci"], "false")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -154,6 +154,9 @@ def retrieve_projects(args):
     # single nightly job with THEROCK_ENABLE_ALL=ON and full projects_to_test list.
     # Run all builds and tests including RCCL.
     if args.get("is_nightly"):
+        # For nightly runs, always run RCCL CI (only relevant for Linux platform)
+        if args.get("platform") == "linux":
+            set_github_output({"run_linux_rccl_ci": "true"})
         nightly_config = project_map.get("nightly")
         if not nightly_config:
             logging.warning("No 'nightly' entry in project_map, nightly will have no jobs")
@@ -300,11 +303,7 @@ def retrieve_projects(args):
 
 def run(args):
     project_to_run = retrieve_projects(args)
-    outputs = {"projects": json.dumps(project_to_run)}
-    # For nightly runs, always run RCCL CI (only relevant for Linux platform)
-    if args.get("is_nightly") and args.get("platform") == "linux":
-        outputs["run_linux_rccl_ci"] = "true"
-    set_github_output(outputs)
+    set_github_output({"projects": json.dumps(project_to_run)})
 
 
 if __name__ == "__main__":

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -149,14 +149,18 @@ def check_for_non_skippable_path(paths: Optional[Iterable[str]]) -> bool:
     return any(not is_path_skippable(p) for p in paths)
 
 
+def check_rccl_changes(modified_paths: Optional[Iterable[str]]) -> bool:
+    """Returns true if any files under projects/rccl/ were modified."""
+    if modified_paths is None:
+        return False
+    return any(path.startswith("projects/rccl/") for path in modified_paths)
+
+
 def retrieve_projects(args):
     # Nightly (schedule): use same test coverage as TheRock submodule bump PRs —
     # single nightly job with THEROCK_ENABLE_ALL=ON and full projects_to_test list.
     # Run all builds and tests including RCCL.
     if args.get("is_nightly"):
-        # For nightly runs, always run RCCL CI (only relevant for Linux platform)
-        if args.get("platform") == "linux":
-            set_github_output({"run_linux_rccl_ci": "true"})
         nightly_config = project_map.get("nightly")
         if not nightly_config:
             logging.warning("No 'nightly' entry in project_map, nightly will have no jobs")
@@ -303,7 +307,30 @@ def retrieve_projects(args):
 
 def run(args):
     project_to_run = retrieve_projects(args)
-    set_github_output({"projects": json.dumps(project_to_run)})
+    outputs = {"projects": json.dumps(project_to_run)}
+
+    # Determine if RCCL CI should run (only relevant for Linux platform)
+    if args.get("platform") == "linux":
+        if args.get("is_nightly"):
+            # Nightly runs always run RCCL CI
+            outputs["run_linux_rccl_ci"] = "true"
+        elif args.get("is_workflow_dispatch"):
+            # For workflow_dispatch, check if projects/rccl was explicitly selected
+            input_projects = args.get("input_projects", "")
+            if "projects/rccl" in input_projects:
+                outputs["run_linux_rccl_ci"] = "true"
+            else:
+                outputs["run_linux_rccl_ci"] = "false"
+        else:
+            # For push/PR events, check if any files under projects/rccl/ changed
+            base_ref = args.get("base_ref")
+            modified_paths = get_modified_paths(base_ref)
+            if check_rccl_changes(modified_paths):
+                outputs["run_linux_rccl_ci"] = "true"
+            else:
+                outputs["run_linux_rccl_ci"] = "false"
+
+    set_github_output(outputs)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -163,7 +163,9 @@ def retrieve_projects(args):
     if args.get("is_nightly"):
         nightly_config = project_map.get("nightly")
         if not nightly_config:
-            logging.warning("No 'nightly' entry in project_map, nightly will have no jobs")
+            logging.warning(
+                "No 'nightly' entry in project_map, nightly will have no jobs"
+            )
             return []
         # Run full coverage on both Linux and Windows (no path-based skip).
         return [

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -223,7 +223,7 @@ def retrieve_projects(args):
             subtrees = list(matched_subtrees)
 
         # If files changed but no subtree matched → evaluate all
-        if modified_paths and not subtrees:
+        if modified_paths and not subtrees and not check_rccl_changes(modified_paths):
             logging.info(
                 "Modified files did not match known subtrees, evaluating all projects"
             )
@@ -333,6 +333,7 @@ def run(args):
                 outputs["run_linux_rccl_ci"] = "false"
 
     set_github_output(outputs)
+    return outputs
 
 
 if __name__ == "__main__":

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -152,6 +152,7 @@ def check_for_non_skippable_path(paths: Optional[Iterable[str]]) -> bool:
 def retrieve_projects(args):
     # Nightly (schedule): use same test coverage as TheRock submodule bump PRs —
     # single nightly job with THEROCK_ENABLE_ALL=ON and full projects_to_test list.
+    # Run all builds and tests including RCCL.
     if args.get("is_nightly"):
         nightly_config = project_map.get("nightly")
         if not nightly_config:
@@ -299,16 +300,25 @@ def retrieve_projects(args):
 
 def run(args):
     project_to_run = retrieve_projects(args)
-    set_github_output({"projects": json.dumps(project_to_run)})
+    outputs = {"projects": json.dumps(project_to_run)}
+    # For nightly runs, always run RCCL CI (only relevant for Linux platform)
+    if args.get("is_nightly") and args.get("platform") == "linux":
+        outputs["run_linux_rccl_ci"] = "true"
+    set_github_output(outputs)
 
 
 if __name__ == "__main__":
     args = {}
     github_event_name = os.getenv("GITHUB_EVENT_NAME")
+    github_workflow = os.getenv("GITHUB_WORKFLOW", "")
     args["is_pull_request"] = github_event_name == "pull_request"
     args["is_push"] = github_event_name == "push"
     args["is_workflow_dispatch"] = github_event_name == "workflow_dispatch"
-    args["is_nightly"] = github_event_name == "schedule"
+    # Nightly: either scheduled run or manual dispatch of the nightly workflow
+    args["is_nightly"] = github_event_name == "schedule" or (
+        github_event_name == "workflow_dispatch"
+        and github_workflow == "TheRock CI Nightly"
+    )
 
     input_subtrees = os.getenv("SUBTREES", "")
     args["input_subtrees"] = input_subtrees

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -31,7 +31,7 @@ jobs:
     outputs:
       linux_projects: ${{ steps.linux_projects.outputs.projects }}
       windows_projects: ${{ steps.windows_projects.outputs.projects }}
-      run_linux_rccl_ci: ${{ steps.rccl_check.outputs.run_linux_rccl_ci }}
+      run_linux_rccl_ci: ${{ steps.linux_projects.outputs.run_linux_rccl_ci }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -66,28 +66,13 @@ jobs:
         run: |
           python .github/scripts/therock_configure_ci.py
 
-      - name: "Detect RCCL file changes"
-        id: rccl_check
-        shell: bash
-        run: |
-          echo "Changed files:"
-          git diff --name-only HEAD^
-
-          if git diff --name-only HEAD^ | grep -q '^projects/rccl/'; then
-            echo "run_linux_rccl_ci=true" >> "$GITHUB_OUTPUT"
-            echo "RCCL changes detected"
-          else
-            echo "run_linux_rccl_ci=false" >> "$GITHUB_OUTPUT"
-            echo "No RCCL changes detected"
-          fi
-
   therock-ci-linux:
     name: Linux (${{ matrix.projects.projects_to_test }})
     permissions:
       contents: read
       id-token: write
     needs: setup
-    if: ${{ needs.setup.outputs.linux_projects != '[]' && needs.setup.outputs.run_linux_rccl_ci != 'true' }}
+    if: ${{ needs.setup.outputs.linux_projects != '[]' }}
     strategy:
       fail-fast: false
       matrix:
@@ -128,7 +113,7 @@ jobs:
       contents: read
       id-token: write
     needs: setup
-    if: ${{ needs.setup.outputs.windows_projects != '[]' && needs.setup.outputs.run_linux_rccl_ci != 'true' }}
+    if: ${{ needs.setup.outputs.windows_projects != '[]' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -31,7 +31,7 @@ jobs:
     outputs:
       linux_projects: ${{ steps.linux_projects.outputs.projects }}
       windows_projects: ${{ steps.windows_projects.outputs.projects }}
-      run_linux_rccl_ci: ${{ steps.rccl_check.outputs.run_linux_rccl_ci }}
+      run_linux_rccl_ci: ${{ steps.linux_projects.outputs.run_linux_rccl_ci }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -70,13 +70,6 @@ jobs:
         id: rccl_check
         shell: bash
         run: |
-          # For nightly runs, always run RCCL CI
-          if [[ "${{ steps.linux_projects.outputs.run_linux_rccl_ci }}" == "true" ]]; then
-            echo "run_linux_rccl_ci=true" >> "$GITHUB_OUTPUT"
-            echo "Nightly run - RCCL CI enabled"
-            exit 0
-          fi
-
           echo "Changed files:"
           git diff --name-only HEAD^
 

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -31,7 +31,7 @@ jobs:
     outputs:
       linux_projects: ${{ steps.linux_projects.outputs.projects }}
       windows_projects: ${{ steps.windows_projects.outputs.projects }}
-      run_linux_rccl_ci: ${{ steps.linux_projects.outputs.run_linux_rccl_ci }}
+      run_linux_rccl_ci: ${{ steps.rccl_check.outputs.run_linux_rccl_ci }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -65,6 +65,28 @@ jobs:
           PLATFORM: "windows"
         run: |
           python .github/scripts/therock_configure_ci.py
+
+      - name: "Detect RCCL file changes"
+        id: rccl_check
+        shell: bash
+        run: |
+          # For nightly runs, always run RCCL CI
+          if [[ "${{ steps.linux_projects.outputs.run_linux_rccl_ci }}" == "true" ]]; then
+            echo "run_linux_rccl_ci=true" >> "$GITHUB_OUTPUT"
+            echo "Nightly run - RCCL CI enabled"
+            exit 0
+          fi
+
+          echo "Changed files:"
+          git diff --name-only HEAD^
+
+          if git diff --name-only HEAD^ | grep -q '^projects/rccl/'; then
+            echo "run_linux_rccl_ci=true" >> "$GITHUB_OUTPUT"
+            echo "RCCL changes detected"
+          else
+            echo "run_linux_rccl_ci=false" >> "$GITHUB_OUTPUT"
+            echo "No RCCL changes detected"
+          fi
 
   therock-ci-linux:
     name: Linux (${{ matrix.projects.projects_to_test }})

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -87,7 +87,7 @@ jobs:
       contents: read
       id-token: write
     needs: setup
-    if: ${{ needs.setup.outputs.linux_projects != '[]' }}
+    if: ${{ needs.setup.outputs.linux_projects != '[]' && needs.setup.outputs.run_linux_rccl_ci != 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -115,10 +115,10 @@ jobs:
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}
       cmake_options: >
-        -DTHEROCK_ENABLE_ALL=OFF 
-        -DTHEROCK_BUILD_TESTING=ON 
-        -DTHEROCK_BUNDLE_SYSDEPS=ON 
-        -DTHEROCK_ENABLE_COMM_LIBS=ON 
+        -DTHEROCK_ENABLE_ALL=OFF
+        -DTHEROCK_BUILD_TESTING=ON
+        -DTHEROCK_BUNDLE_SYSDEPS=ON
+        -DTHEROCK_ENABLE_COMM_LIBS=ON
         -DTHEROCK_ENABLE_ROCPROFV3=ON
         -DTHEROCK_ENABLE_MPI=ON
 
@@ -128,7 +128,7 @@ jobs:
       contents: read
       id-token: write
     needs: setup
-    if: ${{ needs.setup.outputs.windows_projects != '[]' }}
+    if: ${{ needs.setup.outputs.windows_projects != '[]' && needs.setup.outputs.run_linux_rccl_ci != 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -66,28 +66,13 @@ jobs:
         run: |
           python .github/scripts/therock_configure_ci.py
 
-      - name: "Detect RCCL file changes"
-        id: rccl_check
-        shell: bash
-        run: |
-          echo "Changed files:"
-          git diff --name-only HEAD^
-
-          if git diff --name-only HEAD^ | grep -q '^projects/rccl/'; then
-            echo "run_linux_rccl_ci=true" >> "$GITHUB_OUTPUT"
-            echo "RCCL changes detected"
-          else
-            echo "run_linux_rccl_ci=false" >> "$GITHUB_OUTPUT"
-            echo "No RCCL changes detected"
-          fi
-
   therock-ci-linux:
     name: Linux (${{ matrix.projects.projects_to_test }})
     permissions:
       contents: read
       id-token: write
     needs: setup
-    if: ${{ needs.setup.outputs.linux_projects != '[]' && needs.setup.outputs.run_linux_rccl_ci != 'true' }}
+    if: ${{ needs.setup.outputs.linux_projects != '[]' }}
     strategy:
       fail-fast: false
       matrix:
@@ -128,7 +113,7 @@ jobs:
       contents: read
       id-token: write
     needs: setup
-    if: ${{ needs.setup.outputs.windows_projects != '[]' && needs.setup.outputs.run_linux_rccl_ci != 'true' }}
+    if: ${{ needs.setup.outputs.windows_projects != '[]' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -92,7 +92,7 @@ jobs:
       contents: read
       id-token: write
     needs: setup
-    if: ${{ needs.setup.outputs.linux_projects != '[]' && needs.setup.outputs.run_linux_rccl_ci != 'true' }}
+    if: ${{ needs.setup.outputs.linux_projects != '[]' }}
     strategy:
       fail-fast: false
       matrix:
@@ -133,7 +133,7 @@ jobs:
       contents: read
       id-token: write
     needs: setup
-    if: ${{ needs.setup.outputs.windows_projects != '[]' && needs.setup.outputs.run_linux_rccl_ci != 'true' }}
+    if: ${{ needs.setup.outputs.windows_projects != '[]' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -38,7 +38,7 @@ jobs:
     outputs:
       linux_projects: ${{ steps.linux_projects.outputs.projects }}
       windows_projects: ${{ steps.windows_projects.outputs.projects }}
-      run_linux_rccl_ci: ${{ steps.rccl_check.outputs.run_linux_rccl_ci }}
+      run_linux_rccl_ci: ${{ steps.linux_projects.outputs.run_linux_rccl_ci }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -86,32 +86,6 @@ jobs:
         run: |
           python .github/scripts/therock_configure_ci.py
 
-      - name: "Detect RCCL file changes"
-        id: rccl_check
-        shell: bash
-        run: |
-          # For workflow_dispatch, check if projects/rccl was explicitly selected
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            if echo "${{ inputs.projects }}" | grep -qw 'projects/rccl'; then
-              echo "run_linux_rccl_ci=true" >> "$GITHUB_OUTPUT"
-              echo "RCCL selected via workflow_dispatch"
-            else
-              echo "run_linux_rccl_ci=false" >> "$GITHUB_OUTPUT"
-              echo "RCCL not selected via workflow_dispatch"
-            fi
-          else
-            echo "Changed files:"
-            git diff --name-only HEAD^
-
-            if git diff --name-only HEAD^ | grep -q '^projects/rccl/'; then
-              echo "run_linux_rccl_ci=true" >> "$GITHUB_OUTPUT"
-              echo "RCCL changes detected"
-            else
-              echo "run_linux_rccl_ci=false" >> "$GITHUB_OUTPUT"
-              echo "No RCCL changes detected"
-            fi
-          fi
-
   therock-ci-linux:
     name: Linux (${{ matrix.projects.projects_to_test }})
     permissions:
@@ -146,10 +120,10 @@ jobs:
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}
       cmake_options: >
-        -DTHEROCK_ENABLE_ALL=OFF 
-        -DTHEROCK_BUILD_TESTING=ON 
-        -DTHEROCK_BUNDLE_SYSDEPS=ON 
-        -DTHEROCK_ENABLE_COMM_LIBS=ON 
+        -DTHEROCK_ENABLE_ALL=OFF
+        -DTHEROCK_BUILD_TESTING=ON
+        -DTHEROCK_BUNDLE_SYSDEPS=ON
+        -DTHEROCK_ENABLE_COMM_LIBS=ON
         -DTHEROCK_ENABLE_ROCPROFV3=ON
         -DTHEROCK_ENABLE_MPI=ON
 


### PR DESCRIPTION
Previously, CI nightly did not run RCCL build and test. now, it runs RCCL build and test for nightly (as well as some cleanup)

Paired with #4202 , this will run everything now!

Test working here: https://github.com/ROCm/rocm-systems/actions/runs/24858656770 (it triggers everything on CI nightly)

Tests working here:
```
----------------------------------------------------------------------
Ran 22 tests in 0.040s

OK
```