### PR TITLE
[rocprofiler-compute] Fix empty-frame fallback in iteration-multiplex imputation

### DIFF
--- a/projects/rocprofiler-compute/src/utils/utils_analysis.py
+++ b/projects/rocprofiler-compute/src/utils/utils_analysis.py
@@ -523,7 +523,7 @@ def impute_counters_iteration_multiplex(
         result_dfs.append(
             pd.concat(group_dfs, ignore_index=True)
             if group_dfs
-            else pd.DataFrame(df.columns)
+            else pd.DataFrame(columns=df.columns)
         )
 
     final_df = pd.concat(result_dfs, keys=coll_levels, axis=1, copy=False)

--- a/projects/rocprofiler-compute/tests/test_data_imputation.py
+++ b/projects/rocprofiler-compute/tests/test_data_imputation.py
@@ -1238,13 +1238,10 @@ def test_impute_counters_iteration_multiplex_empty_dataframe():
     df_empty = make_multilevel_df(data_empty)
     result = utils.impute_counters_iteration_multiplex(df_empty, "kernel")
 
-    # Result is a fallback DataFrame, not actual data.
-    # It has a single column ("file1", 0) containing 15 column name strings.
+    # Empty-group fallback preserves the input schema with zero rows.
     assert isinstance(result, pd.DataFrame)
-    assert list(result.columns) == [("file1", 0)]
-    assert len(result) == 15
-    assert "Dispatch_ID" in result[("file1", 0)].values
-    assert "C1" in result[("file1", 0)].values
+    assert list(result.columns) == list(df_empty.columns)
+    assert len(result) == 0
 
 
 def test_impute_counters_iteration_multiplex_all_counters_nan():
@@ -1275,15 +1272,10 @@ def test_impute_counters_iteration_multiplex_all_counters_nan():
     df_all_nan = make_multilevel_df(data_all_nan)
     result = utils.impute_counters_iteration_multiplex(df_all_nan, "kernel")
 
-    # Group was dropped (no valid counters) -- fallback DataFrame returned.
+    # Group was dropped (no valid counters) -- empty schema-aligned frame.
     assert isinstance(result, pd.DataFrame)
-    assert list(result.columns) == [("file1", 0)]
-    assert len(result) == 15
-
-    # Original dispatch data is absent from the result
-    assert 1 not in result[("file1", 0)].values
-    assert 2 not in result[("file1", 0)].values
-    assert 3 not in result[("file1", 0)].values
+    assert list(result.columns) == list(df_all_nan.columns)
+    assert len(result) == 0
 
 
 def test_impute_counters_iteration_multiplex_no_counter_columns():
@@ -1312,14 +1304,10 @@ def test_impute_counters_iteration_multiplex_no_counter_columns():
     df_no_counters = make_multilevel_df(data_no_counters)
     result = utils.impute_counters_iteration_multiplex(df_no_counters, "kernel")
 
-    # Group was dropped (no counter columns exist) -- fallback DataFrame returned.
+    # Group was dropped (no counter columns exist) -- empty schema-aligned frame.
     assert isinstance(result, pd.DataFrame)
-    assert list(result.columns) == [("file1", 0)]
-    assert len(result) == 13
-
-    # No counter column names in the fallback values
-    assert "C1" not in result[("file1", 0)].values
-    assert "C2" not in result[("file1", 0)].values
+    assert list(result.columns) == list(df_no_counters.columns)
+    assert len(result) == 0
 
 
 def test_impute_counters_iteration_multiplex_unrecognized_policy():


### PR DESCRIPTION
## Motivation

Bugfix: Make the empty-group fallback in `impute_counters_iteration_multiplex` produce an empty frame with the correct schema so the downstream `pd.concat(..., axis=1)` stays aligned.

## Technical Details

- Pass `columns=df.columns` to `pd.DataFrame` so the fallback frame has the right column labels instead of one column whose rows are the column names.

## JIRA ID

## Test Plan

- Run iteration-multiplex imputation on input that yields an empty group and confirm the resulting multi-indexed frame is well-formed.

## Test Result

Passed

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
