### PR TITLE
[hipfile] Add IO error counts to stats

### DIFF
--- a/projects/hipfile/src/amd_detail/backend/fallback.cpp
+++ b/projects/hipfile/src/amd_detail/backend/fallback.cpp
@@ -122,6 +122,11 @@ Fallback::_io_impl(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBu
             if (e.code().value() == EINTR) {
                 continue;
             }
+            Context<StatsCollection>::get()->error(type, StatsBackend::Fallback, size);
+            throw;
+        }
+        catch (...) {
+            Context<StatsCollection>::get()->error(type, StatsBackend::Fallback, size);
             throw;
         }
 

--- a/projects/hipfile/src/amd_detail/backend/fastpath.cpp
+++ b/projects/hipfile/src/amd_detail/backend/fastpath.cpp
@@ -196,17 +196,23 @@ Fastpath::_io_impl(IoType type, shared_ptr<IFile> file, shared_ptr<IBuffer> buff
         hip_inited = true;
     }
 
-    switch (type) {
-        case IoType::Read:
-            nbytes = Context<Hip>::get()->hipAmdFileRead(handle, devptr, size, file_offset);
-            ioTracker.complete(nbytes);
-            break;
-        case IoType::Write:
-            nbytes = Context<Hip>::get()->hipAmdFileWrite(handle, devptr, size, file_offset);
-            ioTracker.complete(nbytes);
-            break;
-        default:
-            throw std::runtime_error("Invalid IoType");
+    try {
+        switch (type) {
+            case IoType::Read:
+                nbytes = Context<Hip>::get()->hipAmdFileRead(handle, devptr, size, file_offset);
+                ioTracker.complete(nbytes);
+                break;
+            case IoType::Write:
+                nbytes = Context<Hip>::get()->hipAmdFileWrite(handle, devptr, size, file_offset);
+                ioTracker.complete(nbytes);
+                break;
+            default:
+                throw std::runtime_error("Invalid IoType");
+        }
+    }
+    catch (...) {
+        Context<StatsCollection>::get()->error(type, StatsBackend::Fastpath, size);
+        throw;
     }
     return static_cast<ssize_t>(nbytes);
 }

--- a/projects/hipfile/src/amd_detail/stats.cpp
+++ b/projects/hipfile/src/amd_detail/stats.cpp
@@ -352,7 +352,7 @@ StatsClient::generateReportV1(std::ostream &stream, const StatsV1 *stats)
     static constexpr StatsBackend backends[]{StatsBackend::Fastpath, StatsBackend::Fallback};
     for (const auto &backend : backends) {
         for (const auto &ioType : ioTypes) {
-            uint64_t totalBytes{}, totalCount{}, totalTimeUs{};
+            uint64_t totalBytes{}, totalCount{}, totalTimeUs{}, totalErrors{};
             for (size_t i{}; i < StatsV1::MaxGpus; ++i) {
                 if (const auto *perGpuStats{stats->getPerGpuStats(i, backend)}) {
                     if (const auto [sizeHist, countHist, timeHist, errorCountHist] =
@@ -362,6 +362,7 @@ StatsClient::generateReportV1(std::ostream &stream, const StatsV1 *stats)
                         totalBytes += sizeHist->accumulate();
                         totalCount += countHist->accumulate();
                         totalTimeUs += timeHist->accumulate();
+                        totalErrors += errorCountHist->accumulate();
                     }
                 }
             }
@@ -370,7 +371,9 @@ StatsClient::generateReportV1(std::ostream &stream, const StatsV1 *stats)
             stream << "Average " << reportUtil::toString(backend) << ' ' << reportUtil::toString(ioType)
                    << " Bandwidth (GiB/s): " << reportUtil::bandwidthGiBs(totalBytes, totalTimeUs) << '\n';
             stream << "Average " << reportUtil::toString(backend) << ' ' << reportUtil::toString(ioType)
-                   << " Latency (us): " << reportUtil::latencyUs(totalTimeUs, totalCount) << "\n\n";
+                   << " Latency (us): " << reportUtil::latencyUs(totalTimeUs, totalCount) << '\n';
+            stream << "Total " << reportUtil::toString(backend) << ' ' << reportUtil::toString(ioType)
+                   << " Errors: " << totalErrors << "\n\n";
         }
     }
     for (size_t gpuId{}; gpuId < StatsV1::MaxGpus; ++gpuId) {
@@ -415,9 +418,21 @@ StatsClient::generateReportV1(std::ostream &stream, const StatsV1 *stats)
             }
             str << reportUtil::latencyUs(timeUs, count);
         };
+        auto errorCount = [](std::ostream &str, PerGpuStatsV1::ConstHistograms histograms, size_t bucket) {
+            const auto [sizeHist, countHist, timeHist, errorCountHist] = histograms;
+            (void)sizeHist;
+            (void)countHist;
+            (void)timeHist;
+            uint64_t errors{};
+            if (errorCountHist != nullptr) {
+                errors = errorCountHist->buckets[bucket].load();
+            }
+            str << errors;
+        };
         generateReportHistogramV1(stream, stats, gpuId, "Size", "Size (B)", ioSize);
         generateReportHistogramV1(stream, stats, gpuId, "Bandwidth", "Bandwidth (GiB/s)", bandwidth);
         generateReportHistogramV1(stream, stats, gpuId, "Latency", "Latency (us)", latency);
+        generateReportHistogramV1(stream, stats, gpuId, "Errors", "Error Count", errorCount);
     }
 }
 

--- a/projects/hipfile/src/amd_detail/stats.cpp
+++ b/projects/hipfile/src/amd_detail/stats.cpp
@@ -459,4 +459,34 @@ StatsCollection::addIo(IoType ioType, StatsBackend backend, uint64_t bytes, uint
     timeHist->buckets[bucket].fetch_add(timeUs, std::memory_order_relaxed);
     perGpuStats->inUse.store(1, std::memory_order_relaxed);
 }
+
+void
+StatsCollection::error(IoType ioType, StatsBackend backend, uint64_t bytes) const noexcept
+{
+    Stats *stats{Context<IStatsServer>::get()->getStats()};
+    if (stats == nullptr || stats->getLevel() < StatsLevel::Basic) {
+        return;
+    }
+    size_t device{};
+    try {
+        device = static_cast<size_t>(Context<Hip>::get()->hipGetDevice());
+    }
+    catch (...) {
+        return;
+    }
+    auto *perGpuStats{stats->getPerGpuStats(device, backend)};
+    if (perGpuStats == nullptr) {
+        return;
+    }
+    auto [sizeHist, countHist, timeHist, errorCountHist] = perGpuStats->getHistograms(ioType);
+    (void)sizeHist;
+    (void)countHist;
+    (void)timeHist;
+    if (errorCountHist == nullptr) {
+        return;
+    }
+    size_t bucket = StatsHistogram::toHistogramBucket(bytes);
+    errorCountHist->buckets[bucket].fetch_add(1, std::memory_order_relaxed);
+    perGpuStats->inUse.store(1, std::memory_order_relaxed);
+}
 }

--- a/projects/hipfile/src/amd_detail/stats.cpp
+++ b/projects/hipfile/src/amd_detail/stats.cpp
@@ -355,8 +355,10 @@ StatsClient::generateReportV1(std::ostream &stream, const StatsV1 *stats)
             uint64_t totalBytes{}, totalCount{}, totalTimeUs{};
             for (size_t i{}; i < StatsV1::MaxGpus; ++i) {
                 if (const auto *perGpuStats{stats->getPerGpuStats(i, backend)}) {
-                    if (const auto [sizeHist, countHist, timeHist] = perGpuStats->getHistograms(ioType);
-                        sizeHist != nullptr && countHist != nullptr && timeHist != nullptr) {
+                    if (const auto [sizeHist, countHist, timeHist, errorCountHist] =
+                            perGpuStats->getHistograms(ioType);
+                        sizeHist != nullptr && countHist != nullptr && timeHist != nullptr &&
+                        errorCountHist != nullptr) {
                         totalBytes += sizeHist->accumulate();
                         totalCount += countHist->accumulate();
                         totalTimeUs += timeHist->accumulate();
@@ -377,7 +379,10 @@ StatsClient::generateReportV1(std::ostream &stream, const StatsV1 *stats)
         }
         stream << "GPU " << gpuId << ":\n";
         auto ioSize = [](std::ostream &str, PerGpuStatsV1::ConstHistograms histograms, size_t bucket) {
-            const auto [sizeHist, countHist, timeHist] = histograms;
+            const auto [sizeHist, countHist, timeHist, errorCountHist] = histograms;
+            (void)countHist;
+            (void)timeHist;
+            (void)errorCountHist;
             uint64_t size{};
             if (sizeHist != nullptr) {
                 size = sizeHist->buckets[bucket].load();
@@ -385,7 +390,9 @@ StatsClient::generateReportV1(std::ostream &stream, const StatsV1 *stats)
             str << size;
         };
         auto bandwidth = [](std::ostream &str, PerGpuStatsV1::ConstHistograms histograms, size_t bucket) {
-            const auto [sizeHist, countHist, timeHist] = histograms;
+            const auto [sizeHist, countHist, timeHist, errorCountHist] = histograms;
+            (void)countHist;
+            (void)errorCountHist;
             uint64_t size{}, timeUs{};
             if (sizeHist != nullptr) {
                 size = sizeHist->buckets[bucket].load();
@@ -396,7 +403,9 @@ StatsClient::generateReportV1(std::ostream &stream, const StatsV1 *stats)
             str << reportUtil::bandwidthGiBs(size, timeUs);
         };
         auto latency = [](std::ostream &str, PerGpuStatsV1::ConstHistograms histograms, size_t bucket) {
-            const auto [sizeHist, countHist, timeHist] = histograms;
+            const auto [sizeHist, countHist, timeHist, errorCountHist] = histograms;
+            (void)sizeHist;
+            (void)errorCountHist;
             uint64_t timeUs{}, count{};
             if (timeHist != nullptr) {
                 timeUs = timeHist->buckets[bucket].load();
@@ -439,7 +448,8 @@ StatsCollection::addIo(IoType ioType, StatsBackend backend, uint64_t bytes, uint
     if (perGpuStats == nullptr) {
         return;
     }
-    auto [sizeHist, countHist, timeHist] = perGpuStats->getHistograms(ioType);
+    auto [sizeHist, countHist, timeHist, errorCountHist] = perGpuStats->getHistograms(ioType);
+    (void)errorCountHist;
     if (sizeHist == nullptr || countHist == nullptr || timeHist == nullptr) {
         return;
     }

--- a/projects/hipfile/src/amd_detail/stats.h
+++ b/projects/hipfile/src/amd_detail/stats.h
@@ -265,5 +265,6 @@ class StatsCollection {
 public:
     virtual ~StatsCollection() = default;
     virtual void addIo(IoType ioType, StatsBackend backend, uint64_t bytes, uint64_t timeUs) const noexcept;
+    virtual void error(IoType ioType, StatsBackend backend, uint64_t bytes) const noexcept;
 };
 }

--- a/projects/hipfile/src/amd_detail/stats.h
+++ b/projects/hipfile/src/amd_detail/stats.h
@@ -74,27 +74,29 @@ struct PerGpuStatsV1 {
     std::array<StatsHistogram, 2> ioSizeBytes{};
     std::array<StatsHistogram, 2> ioCount{};
     std::array<StatsHistogram, 2> ioTimeUs{};
+    std::array<StatsHistogram, 2> errorCount{};
 
-    using Histograms = std::tuple<StatsHistogram *, StatsHistogram *, StatsHistogram *>;
-    using ConstHistograms =
-        std::tuple<const StatsHistogram *, const StatsHistogram *, const StatsHistogram *>;
+    using Histograms = std::tuple<StatsHistogram *, StatsHistogram *, StatsHistogram *, StatsHistogram *>;
+    using ConstHistograms = std::tuple<const StatsHistogram *, const StatsHistogram *, const StatsHistogram *,
+                                       const StatsHistogram *>;
 
     Histograms getHistograms(IoType ioType) noexcept
     {
         if (ioType != IoType::Read && ioType != IoType::Write) {
-            return Histograms{nullptr, nullptr, nullptr};
+            return Histograms{nullptr, nullptr, nullptr, nullptr};
         }
         return Histograms{&ioSizeBytes[static_cast<size_t>(ioType)], &ioCount[static_cast<size_t>(ioType)],
-                          &ioTimeUs[static_cast<size_t>(ioType)]};
+                          &ioTimeUs[static_cast<size_t>(ioType)], &errorCount[static_cast<size_t>(ioType)]};
     }
 
     ConstHistograms getHistograms(IoType ioType) const noexcept
     {
         if (ioType != IoType::Read && ioType != IoType::Write) {
-            return ConstHistograms{nullptr, nullptr, nullptr};
+            return ConstHistograms{nullptr, nullptr, nullptr, nullptr};
         }
         return ConstHistograms{&ioSizeBytes[static_cast<size_t>(ioType)],
-                               &ioCount[static_cast<size_t>(ioType)], &ioTimeUs[static_cast<size_t>(ioType)]};
+                               &ioCount[static_cast<size_t>(ioType)], &ioTimeUs[static_cast<size_t>(ioType)],
+                               &errorCount[static_cast<size_t>(ioType)]};
     }
 };
 

--- a/projects/hipfile/test/amd_detail/fallback.cpp
+++ b/projects/hipfile/test/amd_detail/fallback.cpp
@@ -392,6 +392,7 @@ TEST_F(FallbackWrite, FallbackWriteThrowsOnPwriteException)
     EXPECT_CALL(mhip, hipStreamSynchronize);
     EXPECT_CALL(msys, pwrite).WillOnce(testing::Throw(std::system_error(EIO, std::generic_category())));
     EXPECT_CALL(msys, munmap).WillOnce(testing::Invoke(::munmap));
+    EXPECT_CALL(mstats, error).Times(1);
 
     ASSERT_THROW(Fallback().io(IoType::Write, file, buffer, buffer->getLength(), 0, 0), std::system_error);
 }
@@ -402,6 +403,7 @@ TEST_F(FallbackWrite, FallbackWriteThrowsOnHipmemcpyFailure)
     EXPECT_CALL(msys, mmap).WillOnce(testing::Invoke(::mmap));
     EXPECT_CALL(mhip, hipMemcpy).WillOnce(testing::Throw(Hip::RuntimeError(hipErrorUnknown)));
     EXPECT_CALL(msys, munmap).WillOnce(testing::Invoke(::munmap));
+    EXPECT_CALL(mstats, error).Times(1);
 
     ASSERT_THROW(Fallback().io(IoType::Write, file, buffer, buffer->getLength(), 0, 0), Hip::RuntimeError);
 }
@@ -413,6 +415,7 @@ TEST_F(FallbackWrite, FallbackWriteThrowsOnHipStreamSynchronizeError)
     EXPECT_CALL(mhip, hipMemcpy);
     EXPECT_CALL(mhip, hipStreamSynchronize).WillOnce(testing::Throw(Hip::RuntimeError(hipErrorUnknown)));
     EXPECT_CALL(msys, munmap).WillOnce(testing::Invoke(::munmap));
+    EXPECT_CALL(mstats, error).Times(1);
 
     ASSERT_THROW(Fallback().io(IoType::Write, file, buffer, buffer->getLength(), 0, 0), Hip::RuntimeError);
 }
@@ -591,6 +594,7 @@ TEST_F(FallbackRead, FallbackReadThrowsOnPreadException)
     EXPECT_CALL(msys, mmap).WillOnce(testing::Invoke(::mmap));
     EXPECT_CALL(msys, pread).WillOnce(testing::Throw(std::system_error(EIO, std::generic_category())));
     EXPECT_CALL(msys, munmap).WillOnce(testing::Invoke(::munmap));
+    EXPECT_CALL(mstats, error).Times(1);
     ASSERT_THROW(Fallback().io(IoType::Read, file, buffer, 4096, 0, 0), std::system_error);
 }
 
@@ -604,6 +608,8 @@ TEST_F(FallbackRead, FallbackReadThrowsOnHipmemcpyFailure)
     EXPECT_CALL(msys, pread).WillRepeatedly(testing::Invoke(this, &FallbackRead::fake_pread));
     EXPECT_CALL(mhip, hipMemcpy).WillOnce(testing::Throw(Hip::RuntimeError(hipErrorUnknown)));
     EXPECT_CALL(msys, munmap).WillOnce(testing::Invoke(::munmap));
+    EXPECT_CALL(mstats, error).Times(1);
+
     ASSERT_THROW(Fallback().io(IoType::Read, file, buffer, file_length, 0, 0), Hip::RuntimeError);
 }
 

--- a/projects/hipfile/test/amd_detail/fastpath.cpp
+++ b/projects/hipfile/test/amd_detail/fastpath.cpp
@@ -642,6 +642,7 @@ TEST_P(FastpathIoParam, IoReturnsBytesTransferredShort)
 TEST_P(FastpathIoParam, IoDoesNotMaskHipRuntimeError)
 {
     expect_io();
+    EXPECT_CALL(mstats, error).Times(1);
     switch (GetParam()) {
         case IoType::Read:
             EXPECT_CALL(mhip, hipAmdFileRead).WillOnce(Throw(Hip::RuntimeError(hipErrorUnknown)));
@@ -662,6 +663,7 @@ TEST_P(FastpathIoParam, IoDoesNotMaskHipRuntimeError)
 TEST_P(FastpathIoParam, IoDoesNotMaskSystemError)
 {
     expect_io();
+    EXPECT_CALL(mstats, error).Times(1);
     switch (GetParam()) {
         case IoType::Read:
             EXPECT_CALL(mhip, hipAmdFileRead).WillOnce(Throw(system_error(ENODEV, generic_category())));
@@ -713,6 +715,7 @@ TEST_P(FastpathIoParam, IoWithFallbackThrowsAFallbackIneligibleException)
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(reinterpret_cast<void *>(DEFAULT_BUFFER_ADDR)));
     EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
     EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(mstats, error).Times(1);
 
     switch (GetParam()) {
         case IoType::Read:
@@ -742,6 +745,7 @@ TEST_P(FastpathIoParam, IoWithFallbackThrowsHipRuntimeException)
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(reinterpret_cast<void *>(DEFAULT_BUFFER_ADDR)));
     EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
     EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(mstats, error).Times(1);
 
     switch (GetParam()) {
         case IoType::Read:
@@ -770,6 +774,7 @@ TEST_P(FastpathIoParam, IoThrowsAFallbackEligibleENODEV)
     EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
     EXPECT_CALL(mhip, hipInit).WillOnce(Return());
     EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(mstats, error).Times(1);
 
     switch (GetParam()) {
         case IoType::Read:
@@ -801,6 +806,7 @@ TEST_P(FastpathIoParam, IoThrowsAFallbackEligibleEREMOTEIO)
     EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
     EXPECT_CALL(mhip, hipInit).WillOnce(Return());
     EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    EXPECT_CALL(mstats, error).Times(1);
 
     switch (GetParam()) {
         case IoType::Read:
@@ -839,6 +845,7 @@ TEST_P(FastpathIoParam, FallbackRejectsIoRequest)
     EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
     EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
     EXPECT_CALL(*m_fallback, score).WillOnce(Return(SCORE_REJECT));
+    EXPECT_CALL(mstats, error).Times(1);
 
     switch (GetParam()) {
         case IoType::Read:

--- a/projects/hipfile/test/amd_detail/mstats.h
+++ b/projects/hipfile/test/amd_detail/mstats.h
@@ -30,5 +30,7 @@ public:
     }
     MOCK_METHOD(void, addIo, (IoType ioType, StatsBackend backend, uint64_t bytes, uint64_t timeUs),
                 (const, noexcept, override));
+    MOCK_METHOD(void, error, (IoType ioType, StatsBackend backend, uint64_t bytes),
+                (const, noexcept, override));
 };
 }

--- a/projects/hipfile/test/amd_detail/stats.cpp
+++ b/projects/hipfile/test/amd_detail/stats.cpp
@@ -55,6 +55,37 @@ TEST_F(HipFileStats, StatsCollectionAddIo)
                       .load());
 }
 
+TEST_F(HipFileStats, StatsCollectionError)
+{
+    Stats                    stats{};
+    StrictMock<MStatsServer> mstats{};
+    StrictMock<MHip>         mhip{};
+    EXPECT_CALL(mstats, getStats).WillRepeatedly(testing::Return(&stats));
+    EXPECT_CALL(mhip, hipGetDevice).WillRepeatedly(testing::Return(0));
+    stats.setLevel(StatsLevel::Basic);
+    Context<StatsCollection>::get()->error(IoType::Read, StatsBackend::Fastpath, 10);
+    ASSERT_EQ(1, stats.getPerGpuStats(0, StatsBackend::Fastpath)
+                     ->errorCount[static_cast<size_t>(IoType::Read)]
+                     .buckets[0]
+                     .load());
+    Context<StatsCollection>::get()->error(IoType::Write, StatsBackend::Fallback, 10);
+    ASSERT_EQ(1, stats.getPerGpuStats(0, StatsBackend::Fallback)
+                     ->errorCount[static_cast<size_t>(IoType::Write)]
+                     .buckets[0]
+                     .load());
+    Context<StatsCollection>::get()->error(IoType::Read, StatsBackend::Fastpath, 10);
+    ASSERT_EQ(2, stats.getPerGpuStats(0, StatsBackend::Fastpath)
+                     ->errorCount[static_cast<size_t>(IoType::Read)]
+                     .buckets[0]
+                     .load());
+    stats.setLevel(StatsLevel::Disabled);
+    Context<StatsCollection>::get()->error(IoType::Write, StatsBackend::Fallback, 10);
+    ASSERT_EQ(1, stats.getPerGpuStats(0, StatsBackend::Fallback)
+                     ->errorCount[static_cast<size_t>(IoType::Write)]
+                     .buckets[0]
+                     .load());
+}
+
 TEST_F(HipFileStats, StatsContainer)
 {
     StrictMock<MSys>           msys{};

--- a/projects/hipfile/test/amd_detail/stats.cpp
+++ b/projects/hipfile/test/amd_detail/stats.cpp
@@ -119,12 +119,28 @@ TEST_F(HipFileStats, GenerateReportV1)
     stats.getPerGpuStats(0, StatsBackend::Fallback)
         ->ioSizeBytes[static_cast<size_t>(IoType::Write)]
         .buckets[0] = 8;
+    stats.getPerGpuStats(0, StatsBackend::Fastpath)
+        ->errorCount[static_cast<size_t>(IoType::Read)]
+        .buckets[0] = 1;
+    stats.getPerGpuStats(0, StatsBackend::Fastpath)
+        ->errorCount[static_cast<size_t>(IoType::Write)]
+        .buckets[0] = 2;
+    stats.getPerGpuStats(0, StatsBackend::Fallback)
+        ->errorCount[static_cast<size_t>(IoType::Read)]
+        .buckets[0] = 3;
+    stats.getPerGpuStats(0, StatsBackend::Fallback)
+        ->errorCount[static_cast<size_t>(IoType::Write)]
+        .buckets[0] = 4;
     StatsClient::generateReportV1(os, &stats);
     std::string str{os.str()};
     ASSERT_GT(std::string::npos, str.find("Total Fastpath Read Size (B): 2"));
     ASSERT_GT(std::string::npos, str.find("Total Fastpath Write Size (B): 4"));
     ASSERT_GT(std::string::npos, str.find("Total Fallback Read Size (B): 6"));
     ASSERT_GT(std::string::npos, str.find("Total Fallback Write Size (B): 8"));
+    ASSERT_GT(std::string::npos, str.find("Total Fastpath Read Errors: 1"));
+    ASSERT_GT(std::string::npos, str.find("Total Fastpath Write Errors: 2"));
+    ASSERT_GT(std::string::npos, str.find("Total Fallback Read Errors: 3"));
+    ASSERT_GT(std::string::npos, str.find("Total Fallback Write Errors: 4"));
 }
 
 TEST_F(HipFileStats, GenerateReportV1TwoGpus)
@@ -137,9 +153,16 @@ TEST_F(HipFileStats, GenerateReportV1TwoGpus)
     stats.getPerGpuStats(1, StatsBackend::Fastpath)
         ->ioSizeBytes[static_cast<size_t>(IoType::Read)]
         .buckets[0] = 4;
+    stats.getPerGpuStats(0, StatsBackend::Fastpath)
+        ->errorCount[static_cast<size_t>(IoType::Read)]
+        .buckets[0] = 1;
+    stats.getPerGpuStats(1, StatsBackend::Fastpath)
+        ->errorCount[static_cast<size_t>(IoType::Read)]
+        .buckets[0] = 2;
     StatsClient::generateReportV1(os, &stats);
     std::string str{os.str()};
     ASSERT_GT(std::string::npos, str.find("Total Fastpath Read Size (B): 6"));
+    ASSERT_GT(std::string::npos, str.find("Total Fastpath Read Errors: 3"));
 }
 
 struct HipFileStatsHistogram : public HipFileUnopened {};

--- a/projects/hipfile/test/amd_detail/stats.cpp
+++ b/projects/hipfile/test/amd_detail/stats.cpp
@@ -155,18 +155,22 @@ struct HipFileStatsPerGpuStatsV1 : public HipFileUnopened {};
 TEST_F(HipFileStatsPerGpuStatsV1, GetHistograms)
 {
     PerGpuStatsV1 stats{};
-    auto [readSize, readCount, readTime]          = stats.getHistograms(IoType::Read);
-    auto [writeSize, writeCount, writeTime]       = stats.getHistograms(IoType::Write);
-    auto [invalidSize, invalidCount, invalidTime] = stats.getHistograms(static_cast<IoType>(-1));
+    auto [readSize, readCount, readTime, readError]     = stats.getHistograms(IoType::Read);
+    auto [writeSize, writeCount, writeTime, writeError] = stats.getHistograms(IoType::Write);
+    auto [invalidSize, invalidCount, invalidTime, invalidError] =
+        stats.getHistograms(static_cast<IoType>(-1));
     ASSERT_EQ(&stats.ioSizeBytes[0], readSize);
     ASSERT_EQ(&stats.ioCount[0], readCount);
     ASSERT_EQ(&stats.ioTimeUs[0], readTime);
+    ASSERT_EQ(&stats.errorCount[0], readError);
     ASSERT_EQ(&stats.ioSizeBytes[1], writeSize);
     ASSERT_EQ(&stats.ioCount[1], writeCount);
     ASSERT_EQ(&stats.ioTimeUs[1], writeTime);
+    ASSERT_EQ(&stats.errorCount[1], writeError);
     ASSERT_EQ(nullptr, invalidSize);
     ASSERT_EQ(nullptr, invalidCount);
     ASSERT_EQ(nullptr, invalidTime);
+    ASSERT_EQ(nullptr, invalidError);
 }
 
 struct HipFileStatsV1 : public HipFileUnopened {};


### PR DESCRIPTION
[AIHIPFILE-184] This adds some basic counting of IO errors to ais-stats, broken down by backend, operation, and IO size.

[AIHIPFILE-184]: https://amd-hub.atlassian.net/browse/AIHIPFILE-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ