### PR TITLE
[CUID] Updated HMAC implementation for crypto library interoperability

### DIFF
--- a/projects/cuid/CMakeLists.txt
+++ b/projects/cuid/CMakeLists.txt
@@ -18,15 +18,25 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.14)
 project(amdcuid)
 
 # Set platform-appropriate default install prefix
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     if(WIN32)
-        set(CMAKE_INSTALL_PREFIX "C:/Program Files/AMD/AMDCUID" CACHE PATH "Installation prefix" FORCE)
-    else()  # Linux/Unix
-        set(CMAKE_INSTALL_PREFIX "/opt/amdcuid" CACHE PATH "Installation prefix" FORCE)
+        set(CMAKE_INSTALL_PREFIX
+            "C:/Program Files/AMD/AMDCUID"
+            CACHE PATH
+            "Installation prefix"
+            FORCE
+        )
+    else() # Linux/Unix
+        set(CMAKE_INSTALL_PREFIX
+            "/opt/amdcuid"
+            CACHE PATH
+            "Installation prefix"
+            FORCE
+        )
     endif()
 endif()
 
@@ -34,15 +44,44 @@ include(GNUInstallDirs)
 
 if(WIN32)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)  # DLLs
-    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)  # Import libs
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin) # DLLs
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib) # Import libs
 endif()
 
-# Platform-specific dependencies; If we decide to use the default Windows crypto API, we can remove the OpenSSL dependency on Windows
+# Platform-specific dependencies; use native Windows bcrypt for HMAC, and OpenSSL on Linux/Unix
 if(WIN32)
-    # Windows may need different OpenSSL path
-    set(OPENSSL_ROOT_DIR "C:/OpenSSL-Win64" CACHE PATH "OpenSSL location")
+    # use native Windows bcrypt
+    find_package(bcrypt REQUIRED)
+else()
+    # Prefer a system-installed OpenSSL; fall back to building from source via
+    # FetchContent if the dev package is not present (e.g. in bare containers).
+    find_package(OpenSSL QUIET)
+    if(NOT OPENSSL_FOUND)
+        message(
+            STATUS
+            "OpenSSL not found on system; fetching and building from source"
+        )
+        include(FetchContent)
+        FetchContent_Declare(
+            openssl-cmake
+            GIT_REPOSITORY https://github.com/janbar/openssl-cmake.git
+            GIT_TAG 1.1.1w-20231130
+        )
+        FetchContent_MakeAvailable(openssl-cmake)
+    endif()
 endif()
+
+message("Build Configuration:")
+message("-----------ROCM_DIR : " ${ROCM_DIR})
+message("------Install Prefix: " ${CMAKE_INSTALL_PREFIX})
+message("--------Build Type  : " ${CMAKE_BUILD_TYPE})
+
+# Define all the install component labels
+set(LIB_COMPONENT "library")
+set(DAEMON_COMPONENT "daemon")
+set(CLI_COMPONENT "cli")
+set(EXAMPLE_COMPONENT "example")
+set(TESTS_COMPONENT "tests")
 
 add_subdirectory(lib)
 add_subdirectory(cli)
@@ -66,7 +105,9 @@ set(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
 set(CPACK_PACKAGE_VERSION_MAJOR "1")
 set(CPACK_PACKAGE_VERSION_MINOR "0")
 set(CPACK_PACKAGE_VERSION_PATCH "0")
-set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
+set(CPACK_PACKAGE_VERSION
+    "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}"
+)
 set(CPACK_PACKAGE_CONTACT "support@amd.com")
 set(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/README.md")
 
@@ -80,12 +121,12 @@ if(WIN32)
     set(CPACK_GENERATOR "ZIP;NSIS")
 else()
     set(CPACK_GENERATOR "TGZ;DEB;RPM")
-    
+
     # DEB-specific
     set(CPACK_DEBIAN_PACKAGE_MAINTAINER "${CPACK_PACKAGE_CONTACT}")
     set(CPACK_DEBIAN_PACKAGE_DEPENDS "libssl1.1 | libssl3")
     set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
-    
+
     # RPM-specific
     set(CPACK_RPM_PACKAGE_LICENSE "MIT")
     set(CPACK_RPM_PACKAGE_GROUP "System Environment/Libraries")

--- a/projects/cuid/CMakeLists.txt
+++ b/projects/cuid/CMakeLists.txt
@@ -50,8 +50,7 @@ endif()
 
 # Platform-specific dependencies; use native Windows bcrypt for HMAC, and OpenSSL on Linux/Unix
 if(WIN32)
-    # use native Windows bcrypt
-    find_package(bcrypt REQUIRED)
+    # Use the native Windows bcrypt library and link it directly on Windows targets.
 else()
     # Prefer a system-installed OpenSSL; fall back to building from source via
     # FetchContent if the dev package is not present (e.g. in bare containers).

--- a/projects/cuid/README.md
+++ b/projects/cuid/README.md
@@ -113,14 +113,19 @@ The CUID tool supports both privileged and non-privileged users:
 - Allows creation of primary/derived CUIDs (if privileged).
 - Simplifies device management and integration.
 
-### Build Instructions
+### Build and Install Instructions
+
+The below instructions allow the building of the CUID project and also the installation of its files and services:
 
 ```sh
 mkdir build
 cd build
-cmake ..
-make
-make install
+# Set CMAKE_INSTALL_PREFIX as needed (default is typically /opt/rocm/core)
+cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm ..
+# Use sudo if installing to a system prefix like /opt
+sudo make install
+# Replace <install-prefix> with the value used for CMAKE_INSTALL_PREFIX above
+sudo <install-prefix>/share/amdcuid/amdcuid_postinst.sh
 ```
 
 Both static and shared libraries are built.

--- a/projects/cuid/cli/CMakeLists.txt
+++ b/projects/cuid/cli/CMakeLists.txt
@@ -18,7 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.10)
 project(amdcuid_tool)
 
 set(CMAKE_CXX_STANDARD 14)
@@ -26,15 +25,20 @@ set(CMAKE_CXX_STANDARD 14)
 # Find OpenSSL
 find_package(OpenSSL REQUIRED)
 
-# Add the tool executable
-add_executable(amdcuid_tool amdcuid_tool.cc)
+set(AMDCUID_TOOL_EXECUTABLE amdcuid_tool)
+set(SRC_LIST amdcuid_tool.cc)
 
-# Link against the CUID library (public API only)
-# The tool now uses only the public API defined in amd_cuid.h
-target_link_libraries(amdcuid_tool amdcuid_static OpenSSL::Crypto)
+# Add the tool executable
+add_executable(${AMDCUID_TOOL_EXECUTABLE} ${SRC_LIST})
+
+# Link against the CUID library
+target_link_libraries(${AMDCUID_TOOL_EXECUTABLE} amdcuid_static)
 
 # Include directories - only need access to public headers
-target_include_directories(amdcuid_tool PRIVATE ${CMAKE_SOURCE_DIR}/lib)
+target_include_directories(
+    ${AMDCUID_TOOL_EXECUTABLE}
+    PRIVATE ${CMAKE_SOURCE_DIR}/lib
+)
 
 # Install the tool
-install(TARGETS amdcuid_tool DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS ${AMDCUID_TOOL_EXECUTABLE} DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/projects/cuid/cli/CMakeLists.txt
+++ b/projects/cuid/cli/CMakeLists.txt
@@ -22,9 +22,6 @@ project(amdcuid_tool)
 
 set(CMAKE_CXX_STANDARD 14)
 
-# Find OpenSSL
-find_package(OpenSSL REQUIRED)
-
 set(AMDCUID_TOOL_EXECUTABLE amdcuid_tool)
 set(SRC_LIST amdcuid_tool.cc)
 

--- a/projects/cuid/daemon/CMakeLists.txt
+++ b/projects/cuid/daemon/CMakeLists.txt
@@ -18,34 +18,49 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.10)
 project(amdcuid_daemon)
 
 set(CMAKE_CXX_STANDARD 14)
 
-# Find OpenSSL
-find_package(OpenSSL REQUIRED)
+set(INC_DIR ${CMAKE_SOURCE_DIR}/lib)
+set(AMDCUID_DAEMON_EXECUTABLE amdcuid_daemon)
+set(SRC_LIST amdcuid_daemon.cc)
+if(WIN32)
+    set(CONFIG_INSTALL_DIR "CONFIG") # Relative to prefix
+else()
+    set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/${AMDCUID}/config")
+endif()
+
+find_package(Threads REQUIRED)
 
 # Add the tool executable
 add_executable(amdcuid_daemon amdcuid_daemon.cc)
 
-# Link against the CUID library
-target_link_libraries(amdcuid_daemon amdcuid_static OpenSSL::Crypto)
-
 # Include directories
-target_include_directories(amdcuid_daemon PRIVATE ${CMAKE_SOURCE_DIR}/lib)
+target_include_directories(${AMDCUID_DAEMON_EXECUTABLE} PRIVATE ${INC_DIR})
 
-# Install the tool
-install(TARGETS amdcuid_daemon DESTINATION bin COMPONENT daemon)
+# Pass the version-independent shared config directory to the daemon at compile
+# time so that multi-version installs all reference the same HMAC key and conf.
+target_compile_definitions(
+    ${AMDCUID_DAEMON_EXECUTABLE}
+    PRIVATE AMDCUID_CONFIG_DIR="${AMDCUID_SHARED_CONFIG_DIR}"
+)
 
-# Platform-specific config directory
-if(WIN32)
-    set(CONFIG_INSTALL_DIR "etc")  # Relative to prefix
-else()
-    set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_SYSCONFDIR}")
-endif()
+# Link against the CUID library
+target_link_libraries(
+    ${AMDCUID_DAEMON_EXECUTABLE}
+    amdcuid_static
+    Threads::Threads
+)
 
-install(FILES amdcuid_daemon.conf DESTINATION ${CONFIG_INSTALL_DIR} COMPONENT daemon)
+# Install the daemon
+install(
+    TARGETS ${AMDCUID_DAEMON_EXECUTABLE}
+    DESTINATION bin
+    COMPONENT ${DAEMON_COMPONENT}
+)
+
+set(DAEMON_CONFIG_FILE amdcuid_daemon.conf)
 
 # udev rules for Linux; TODO: need to figure out Windows service/driver registration for device event handling
 if(UNIX AND NOT APPLE)
@@ -56,30 +71,44 @@ if(UNIX AND NOT APPLE)
     set(CONFIG_DAEMONIZE_DEFAULT "${CMAKE_MATCH_1}")
 
     # Create CMake option with config file default
-    option(ENABLE_DAEMONIZE "Enable daemon mode with udev rules" ${CONFIG_DAEMONIZE_DEFAULT})
+    option(
+        ENABLE_DAEMONIZE
+        "Enable daemon mode with udev rules"
+        ${CONFIG_DAEMONIZE_DEFAULT}
+    )
 
-    if (ENABLE_DAEMONIZE)
-        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/90-amdcuid.rules
-        "# AMD CUID daemon udev rules
+    if(ENABLE_DAEMONIZE)
+        file(
+            WRITE ${CMAKE_CURRENT_BINARY_DIR}/90-amdcuid.rules
+            "# AMD CUID daemon udev rules
         SUBSYSTEM==\"drm\", ACTION==\"add|remove|change\", RUN+=\"${CMAKE_INSTALL_PREFIX}/bin/amdcuid_tool --notify-daemon\"
         SUBSYSTEM==\"net\", ACTION==\"add|remove|change\", RUN+=\"${CMAKE_INSTALL_PREFIX}/bin/amdcuid_tool --notify-daemon\"
-        ")
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/90-amdcuid.rules
-        DESTINATION /etc/udev/rules.d
-        COMPONENT daemon)
+        "
+        )
+        install(
+            FILES ${CMAKE_CURRENT_BINARY_DIR}/90-amdcuid.rules
+            DESTINATION /etc/udev/rules.d
+            COMPONENT daemon
+        )
 
         # Custom target to reload rules (must run as root)
-        add_custom_target(reload-udev
-        COMMAND udevadm control --reload-rules
-        COMMAND udevadm trigger
-        COMMENT "Reloading udev rules..."
-        VERBATIM)
+        add_custom_target(
+            reload-udev
+            COMMAND udevadm control --reload-rules
+            COMMAND udevadm trigger
+            COMMENT "Reloading udev rules..."
+            VERBATIM
+        )
     else()
         # if not in daemon mode, create a cron job instead to start daemon at reboot
-        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/amdcuid_cron
-        "@reboot root ${CMAKE_INSTALL_PREFIX}/bin/amdcuid_daemon" )
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/amdcuid_cron
-        DESTINATION /etc/cron.d
-        COMPONENT daemon)
+        file(
+            WRITE ${CMAKE_CURRENT_BINARY_DIR}/amdcuid_cron
+            "@reboot root ${CMAKE_INSTALL_PREFIX}/bin/amdcuid_daemon"
+        )
+        install(
+            FILES ${CMAKE_CURRENT_BINARY_DIR}/amdcuid_cron
+            DESTINATION /etc/cron.d
+            COMPONENT daemon
+        )
     endif()
 endif()

--- a/projects/cuid/daemon/CMakeLists.txt
+++ b/projects/cuid/daemon/CMakeLists.txt
@@ -25,11 +25,6 @@ set(CMAKE_CXX_STANDARD 14)
 set(INC_DIR ${CMAKE_SOURCE_DIR}/lib)
 set(AMDCUID_DAEMON_EXECUTABLE amdcuid_daemon)
 set(SRC_LIST amdcuid_daemon.cc)
-if(WIN32)
-    set(CONFIG_INSTALL_DIR "CONFIG") # Relative to prefix
-else()
-    set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/amdcuid/config")
-endif()
 
 find_package(Threads REQUIRED)
 
@@ -44,7 +39,7 @@ target_include_directories(${AMDCUID_DAEMON_EXECUTABLE} PRIVATE ${INC_DIR})
 # location.
 target_compile_definitions(
     ${AMDCUID_DAEMON_EXECUTABLE}
-    PRIVATE AMDCUID_CONFIG_DIR="${CONFIG_INSTALL_DIR}"
+    PRIVATE AMDCUID_CONFIG_DIR="${CMAKE_INSTALL_SYSCONFDIR}"
 )
 
 # Link against the CUID library
@@ -64,7 +59,7 @@ install(
 set(DAEMON_CONFIG_FILE amdcuid_daemon.conf)
 install(
     FILES ${CMAKE_CURRENT_SOURCE_DIR}/${DAEMON_CONFIG_FILE}
-    DESTINATION ${AMDCUID_SHARED_CONFIG_DIR}
+    DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}
     COMPONENT ${DAEMON_COMPONENT}
 )
 

--- a/projects/cuid/daemon/CMakeLists.txt
+++ b/projects/cuid/daemon/CMakeLists.txt
@@ -28,7 +28,7 @@ set(SRC_LIST amdcuid_daemon.cc)
 if(WIN32)
     set(CONFIG_INSTALL_DIR "CONFIG") # Relative to prefix
 else()
-    set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/${AMDCUID}/config")
+    set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/amdcuid/config")
 endif()
 
 find_package(Threads REQUIRED)
@@ -39,11 +39,12 @@ add_executable(amdcuid_daemon amdcuid_daemon.cc)
 # Include directories
 target_include_directories(${AMDCUID_DAEMON_EXECUTABLE} PRIVATE ${INC_DIR})
 
-# Pass the version-independent shared config directory to the daemon at compile
-# time so that multi-version installs all reference the same HMAC key and conf.
+# Pass the resolved config install directory to the daemon at compile time so
+# the HMAC key and daemon configuration paths are always built from a concrete
+# location.
 target_compile_definitions(
     ${AMDCUID_DAEMON_EXECUTABLE}
-    PRIVATE AMDCUID_CONFIG_DIR="${AMDCUID_SHARED_CONFIG_DIR}"
+    PRIVATE AMDCUID_CONFIG_DIR="${CONFIG_INSTALL_DIR}"
 )
 
 # Link against the CUID library
@@ -61,6 +62,11 @@ install(
 )
 
 set(DAEMON_CONFIG_FILE amdcuid_daemon.conf)
+install(
+    FILES ${CMAKE_CURRENT_SOURCE_DIR}/${DAEMON_CONFIG_FILE}
+    DESTINATION ${AMDCUID_SHARED_CONFIG_DIR}
+    COMPONENT ${DAEMON_COMPONENT}
+)
 
 # udev rules for Linux; TODO: need to figure out Windows service/driver registration for device event handling
 if(UNIX AND NOT APPLE)

--- a/projects/cuid/daemon/amdcuid_daemon.cc
+++ b/projects/cuid/daemon/amdcuid_daemon.cc
@@ -21,27 +21,22 @@
  */
 
 #include "include/amd_cuid.h"
-#include "src/cuid_file.h"
-#include "src/cuid_device_manager.h"
-#include "src/cuid_device.h"
-#include "src/cuid_gpu.h"
-#include "src/cuid_cpu.h"
-#include "src/cuid_nic.h"
-#include "src/cuid_platform.h"
-#include "src/cuid_util.h"
 #include "src/hmac.h"
 #include "src/ipc_protocol.h"
-#include <sys/socket.h>
-#include <sys/un.h>
-#include <sys/stat.h>
-#include <thread>
 #include <atomic>
 #include <cstdlib>
+#include <fcntl.h>
 #include <fstream>
-#include <sstream>
+#include <iostream>
 #include <map>
-#include <unistd.h>
 #include <memory>
+#include <sstream>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <thread>
+#include <unistd.h>
+#include <vector>
 
 // static hmac instance for daemon
 static cuid_hmac daemon_hmac = cuid_hmac();
@@ -50,408 +45,275 @@ static cuid_hmac daemon_hmac = cuid_hmac();
 static std::unique_ptr<std::ofstream> g_log_file;
 static bool g_logging_to_file = false;
 
-static std::ostream& log_out() {
-    if (g_logging_to_file && g_log_file && g_log_file->is_open()) {
-        *g_log_file << "timestamp: " << time(nullptr) << ": ";
-        return *g_log_file;
-    }
-    std::cout << "timestamp: " << time(nullptr) << ": ";
-    return std::cout;
+static std::ostream &log_out() {
+  if (g_logging_to_file && g_log_file && g_log_file->is_open()) {
+    *g_log_file << "timestamp: " << time(nullptr) << ": ";
+    return *g_log_file;
+  }
+  std::cout << "timestamp: " << time(nullptr) << ": ";
+  return std::cout;
 }
 
-static std::ostream& log_err() {
-    if (g_logging_to_file && g_log_file && g_log_file->is_open()) {
-        *g_log_file << "timestamp: " << time(nullptr) << ": ";
-        return *g_log_file;
-    }
-    std::cerr << "timestamp: " << time(nullptr) << ": ";
-    return std::cerr;
+static std::ostream &log_err() {
+  if (g_logging_to_file && g_log_file && g_log_file->is_open()) {
+    *g_log_file << "timestamp: " << time(nullptr) << ": ";
+    return *g_log_file;
+  }
+  std::cerr << "timestamp: " << time(nullptr) << ": ";
+  return std::cerr;
 }
 
 static void init_logging(bool enabled) {
-    if (enabled) {
-        g_log_file = std::make_unique<std::ofstream>("/var/log/amdcuid.log", std::ios::app);
-        if (g_log_file->is_open()) {
-            g_logging_to_file = true;
-            // Add timestamp to log entry
-            time_t now = time(nullptr);
-            *g_log_file << "\n=== Log started at " << ctime(&now);
-        }
+  if (enabled) {
+    g_log_file =
+        std::make_unique<std::ofstream>("/var/log/amdcuid.log", std::ios::app);
+    if (g_log_file->is_open()) {
+      g_logging_to_file = true;
+      // Add timestamp to log entry
+      time_t now = time(nullptr);
+      *g_log_file << "\n=== Log started at " << ctime(&now);
     }
-}
-
-amdcuid_status_t update_device(std::string output_file,
-                                std::string priv_output_file,
-                                CuidFileEntry *device) {
-    // Load existing CUID files
-    CuidFile unpriv_file(output_file, false);
-    CuidFile priv_file(priv_output_file, true);
-    unpriv_file.load();
-    priv_file.load();
-
-    log_out() << "Attempting update of device with derived CUID: " << CuidUtilities::get_cuid_as_string(&device->derived_cuid) << std::endl;
-
-    amdcuid_status_t status;
-    // Remove entry from both files
-    status = unpriv_file.add_entry(*device);
-    if (status != AMDCUID_STATUS_SUCCESS) {
-        log_err() << "Error updating device in unprivileged file: " << amdcuid_status_to_string(status) << std::endl;
-        return status;
-    }
-    status = priv_file.add_entry(*device);
-    if (status != AMDCUID_STATUS_SUCCESS) {
-        log_err() << "Error updating device in privileged file: " << amdcuid_status_to_string(status) << std::endl;
-        return status;
-    }
-
-
-    // Save updated CUID files
-    unpriv_file.save();
-    priv_file.save();
-
-    return AMDCUID_STATUS_SUCCESS;
+  }
 }
 
 // Daemon Server
-class CuidDaemonServer
-{
+class CuidDaemonServer {
 public:
-    CuidDaemonServer() : is_running_(false), server_fd_(-1) {}
-    ~CuidDaemonServer() {
-        stop();
+  CuidDaemonServer() : is_running_(false), server_fd_(-1) {}
+  ~CuidDaemonServer() { stop(); }
+
+  amdcuid_status_t start() {
+    if (is_running_) {
+      return AMDCUID_STATUS_SUCCESS; // Already running
     }
 
-    amdcuid_status_t start() {
-        if (is_running_) {
-            return AMDCUID_STATUS_SUCCESS; // Already running
-        }
-
-        server_fd_ = socket(AF_UNIX, SOCK_STREAM, 0);
-        if (server_fd_ < 0) {
-            return AMDCUID_STATUS_IPC_ERROR;
-        }
-
-        unlink(AMDCUID_SOCKET_PATH); // Remove existing socket file
-
-        // bind to socket path
-        struct sockaddr_un server_addr;
-        memset(&server_addr, 0, sizeof(server_addr));
-        server_addr.sun_family = AF_UNIX;
-        strncpy(server_addr.sun_path, AMDCUID_SOCKET_PATH, sizeof(server_addr.sun_path) - 1);
-
-        if (bind(server_fd_, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
-            close(server_fd_);
-            return AMDCUID_STATUS_IPC_ERROR;
-        }
-
-        // Set permissions; only root permissions can access
-        chmod(AMDCUID_SOCKET_PATH, 0600);
-
-        if (listen(server_fd_, 5) < 0) {
-            close(server_fd_);
-            return AMDCUID_STATUS_IPC_ERROR;
-        }
-
-        is_running_ = true;
-        server_thread_ = std::thread(&CuidDaemonServer::accept_loop, this);
-
-        return AMDCUID_STATUS_SUCCESS;
+    server_fd_ = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (server_fd_ < 0) {
+      return AMDCUID_STATUS_IPC_ERROR;
     }
 
-    void stop() {
-        if (!is_running_) {
-            return;
-        }
-        is_running_ = false;
-        if (server_fd_ >= 0) {
-            shutdown(server_fd_, SHUT_RDWR);
-            close(server_fd_);
-            server_fd_ = -1;
-        }
-        if (server_thread_.joinable()) {
-            server_thread_.join();
-        }
-        unlink(AMDCUID_SOCKET_PATH);
+    unlink(AMDCUID_SOCKET_PATH); // Remove existing socket file
+
+    // bind to socket path
+    struct sockaddr_un server_addr;
+    memset(&server_addr, 0, sizeof(server_addr));
+    server_addr.sun_family = AF_UNIX;
+    strncpy(server_addr.sun_path, AMDCUID_SOCKET_PATH,
+            sizeof(server_addr.sun_path) - 1);
+
+    if (bind(server_fd_, (struct sockaddr *)&server_addr, sizeof(server_addr)) <
+        0) {
+      close(server_fd_);
+      return AMDCUID_STATUS_IPC_ERROR;
     }
 
-private:
-    std::atomic<bool> is_running_;
-    int server_fd_;
-    std::thread server_thread_;
+    // Set permissions; only root permissions can access
+    chmod(AMDCUID_SOCKET_PATH, 0600);
 
-    void accept_loop() {
-        while (is_running_) {
-            int client_fd = accept(server_fd_, nullptr, nullptr);
-            if (client_fd < 0) {
-                continue;
-            }
-
-            handle_client(client_fd);
-            close(client_fd);
-        }
+    if (listen(server_fd_, 5) < 0) {
+      close(server_fd_);
+      return AMDCUID_STATUS_IPC_ERROR;
     }
 
-    void handle_client(int client_fd) {
-        IpcRequest request;
-        if (recv(client_fd, &request, sizeof(request), 0) != sizeof(request)) {
-            return;
-        }
-
-        IpcResponse response;
-        memset(&response, 0, sizeof(response));
-
-        // Handle different request types
-        switch (request.type) {
-            case IpcMessageType::ADD_DEVICE:
-                response.status = handle_add_device(request, response.device_handle);
-                break;
-            case IpcMessageType::REFRESH_DEVICES:
-                response.status = amdcuid_refresh();
-                break;
-            default:
-                response.status = AMDCUID_STATUS_INVALID_ARGUMENT;
-                break;
-        }
-
-        send(client_fd, &response, sizeof(response), 0);
-    }
-
-    amdcuid_status_t handle_add_device(
-        const IpcRequest& request,
-        amdcuid_id_t& device_handle
-    ) {
-        std::string dev_path(request.device_path);
-        amdcuid_device_type_t device_type = request.device_type;
-        amdcuid_status_t status = amdcuid_get_handle_by_dev_path(
-            dev_path.c_str(),
-            device_type,
-            &device_handle
-        );
-
-        return status;
-    }
-
-};
-
-amdcuid_status_t get_device_from_udev(std::string *action_output, CuidFileEntry *device_entry, cuid_hmac* hmac) {
-    // udev passes device information as environment variables when triggering rules
-    const char* action = std::getenv("ACTION");
-    const char* devpath = std::getenv("DEVPATH");
-    const char* subsystem = std::getenv("SUBSYSTEM");
-    const char* devname = std::getenv("DEVNAME");
-    const char* pci_slot = std::getenv("PCI_SLOT_NAME");
-
-    // Validate required environment variables
-    if (!devpath || !subsystem) {
-        log_err() << "Error: Missing required udev environment variables (DEVPATH, SUBSYSTEM)" << std::endl;
-        return AMDCUID_STATUS_DEVICE_NOT_FOUND;
-    }
-
-    // Log udev event info
-    log_out() << "udev event received:" << std::endl;
-    log_out() << "  ACTION: " << (action ? action : "(null)") << std::endl;
-    log_out() << "  DEVPATH: " << devpath << std::endl;
-    log_out() << "  SUBSYSTEM: " << subsystem << std::endl;
-    log_out() << "  DEVNAME: " << (devname ? devname : "(null)") << std::endl;
-    log_out() << "  PCI_SLOT_NAME: " << (pci_slot ? pci_slot : "(null)") << std::endl;
-
-    // Build sysfs path from DEVPATH
-    std::string syspath = "/sys" + std::string(devpath);
-
-    // Parse uevent file for additional properties
-    std::map<std::string, std::string> uevent_props;
-    std::ifstream uevent_file(syspath + "/uevent");
-    if (uevent_file.is_open()) {
-        std::string line;
-        while (std::getline(uevent_file, line)) {
-            size_t eq = line.find('=');
-            if (eq != std::string::npos) {
-                uevent_props[line.substr(0, eq)] = line.substr(eq + 1);
-            }
-        }
-        uevent_file.close();
-    }
-    else {
-        log_out() << "Failed to open uevent file. Exiting." << std::endl;
-        return AMDCUID_STATUS_FILE_NOT_FOUND;
-    }
-
-    // Determine device type from subsystem and create appropriate device entry
-    std::string subsys_str(subsystem);
-    CuidFileEntry entry = CuidFileEntry();
-
-    if (subsys_str == "drm") {
-        // GPU device
-        amdcuid_gpu_info info = {};
-        amdcuid_status_t status = CuidGpu::discover_single(&info, syspath + "/device");
-        auto gpu_device = std::make_shared<CuidGpu>(info);
-
-        entry.device_type = AMDCUID_DEVICE_TYPE_GPU;
-        amdcuid_primary_id primary_id;
-        status = gpu_device->get_primary_cuid(primary_id);
-        if (status != AMDCUID_STATUS_SUCCESS) {
-            log_err() << "Error: Failed to get primary CUID for GPU device" << std::endl;
-            return status;
-        }
-        entry.primary_cuid = primary_id.UUIDv8_representation;
-        amdcuid_derived_id derived_id;
-        status = gpu_device->get_derived_cuid(derived_id, hmac);
-        if (status != AMDCUID_STATUS_SUCCESS) {
-            log_err() << "Error: Failed to generate derived CUID for GPU device" << std::endl;
-            return status;
-        }
-        log_out() << "Generated derived CUID for GPU device: " << CuidUtilities::get_cuid_as_string(&derived_id.UUIDv8_representation) << std::endl;
-        entry.derived_cuid = derived_id.UUIDv8_representation;
-        entry.device_node = info.render_node;
-        entry.bdf = info.bdf;
-        entry.device_index = 0; // could be set based on existing entries
-        entry.last_update = time(nullptr);
-    } else if (subsys_str == "net") {
-        // NIC device
-        amdcuid_nic_info info = {};
-        amdcuid_status_t status = CuidNic::discover_single(&info, syspath + "/device");
-        auto nic_device = std::make_shared<CuidNic>(info);
-
-        entry.device_type = AMDCUID_DEVICE_TYPE_NIC;
-        amdcuid_primary_id primary_id;
-        status = nic_device->get_primary_cuid(primary_id);
-        if (status != AMDCUID_STATUS_SUCCESS) {
-            log_err() << "Error: Failed to get primary CUID for NIC device" << std::endl;
-            return status;
-        }
-        entry.primary_cuid = primary_id.UUIDv8_representation;
-        amdcuid_derived_id derived_id;
-        status = nic_device->get_derived_cuid(derived_id, hmac);
-        if (status != AMDCUID_STATUS_SUCCESS) {
-            log_err() << "Error: Failed to generate derived CUID for NIC device" << std::endl;
-            return status;
-        }
-        entry.derived_cuid = derived_id.UUIDv8_representation;
-        entry.device_node = info.network_interface;
-        entry.bdf = info.bdf;
-        entry.device_index = 0; // could be set based on existing entries
-        entry.last_update = time(nullptr);
-    } else {
-        // additional subsystems can be added later as support expands
-        log_err() << "Error: Unsupported subsystem: " << subsystem << std::endl;
-        return AMDCUID_STATUS_UNSUPPORTED;
-    }
-
-    if (!device_entry) {
-        return AMDCUID_STATUS_DEVICE_NOT_FOUND;
-    }
-
-    // Set action output
-    if (action_output) {
-        *action_output = std::string(action);
-    } else {
-        *action_output = "unknown";
-    }
-    // Store the device entry
-    *device_entry = entry;
+    is_running_ = true;
+    server_thread_ = std::thread(&CuidDaemonServer::accept_loop, this);
 
     return AMDCUID_STATUS_SUCCESS;
-}
+  }
+
+  void stop() {
+    if (!is_running_) {
+      return;
+    }
+    is_running_ = false;
+    if (server_fd_ >= 0) {
+      shutdown(server_fd_, SHUT_RDWR);
+      close(server_fd_);
+      server_fd_ = -1;
+    }
+    if (server_thread_.joinable()) {
+      server_thread_.join();
+    }
+    unlink(AMDCUID_SOCKET_PATH);
+  }
+
+private:
+  std::atomic<bool> is_running_;
+  int server_fd_;
+  std::thread server_thread_;
+
+  void accept_loop() {
+    while (is_running_) {
+      int client_fd = accept(server_fd_, nullptr, nullptr);
+      if (client_fd < 0) {
+        continue;
+      }
+
+      handle_client(client_fd);
+      close(client_fd);
+    }
+  }
+
+  void handle_client(int client_fd) {
+    IpcRequest request;
+    if (recv(client_fd, &request, sizeof(request), 0) != sizeof(request)) {
+      return;
+    }
+
+    IpcResponse response;
+    memset(&response, 0, sizeof(response));
+
+    // Handle different request types
+    switch (request.type) {
+    case IpcMessageType::ADD_DEVICE:
+      response.status = handle_add_device(request, response.device_handle);
+      break;
+    case IpcMessageType::REFRESH_DEVICES:
+      response.status = amdcuid_refresh();
+      break;
+    default:
+      response.status = AMDCUID_STATUS_INVALID_ARGUMENT;
+      break;
+    }
+
+    send(client_fd, &response, sizeof(response), 0);
+  }
+
+  amdcuid_status_t handle_add_device(const IpcRequest &request,
+                                     amdcuid_id_t &device_handle) {
+    std::string dev_path(request.device_path);
+    amdcuid_device_type_t device_type = request.device_type;
+    amdcuid_status_t status = amdcuid_get_handle_by_dev_path(
+        dev_path.c_str(), device_type, &device_handle);
+
+    return status;
+  }
+};
 
 int main() {
-    // Note: We can't log to file yet until we read the config
-    std::cout << "AMD CUID Daemon Starting..." << std::endl;
+  // Note: We can't log to file yet until we read the config
+  std::cout << "AMD CUID Daemon Starting..." << std::endl;
 
-    if (geteuid() != 0) {
-        std::cerr << "Root privileges required to detect relevant devices and generate CUID. Exiting" << std::endl;
-        return 1;
-    }
+  if (geteuid() != 0) {
+    std::cerr << "Root privileges required to detect relevant devices and "
+                 "generate CUID. Exiting"
+              << std::endl;
+    return 1;
+  }
 
-    // if no HMAC key exists, generate and store it
-    int fd = open(daemon_hmac.key_file_path.c_str(), O_RDONLY);
-    if (fd < 0) {
-        uint8_t key[32];
-        amdcuid_status_t key_status = amdcuid_generate_hash_key(key);
-        if (key_status != AMDCUID_STATUS_SUCCESS) {
-            log_err() << "Error generating/loading HMAC key (status: " << amdcuid_status_to_string(key_status) << ")" << std::endl;
-            return 1;
-        }
-        key_status = amdcuid_set_hash_key(key);
-        if (key_status != AMDCUID_STATUS_SUCCESS) {
-            log_err() << "Error setting HMAC key for daemon (status: " << amdcuid_status_to_string(key_status) << ")" << std::endl;
-            return 1;
-        }
+  // if no HMAC key exists, generate and store it
+  int fd = open(daemon_hmac.key_file_path.c_str(), O_RDONLY);
+  if (fd < 0) {
+    uint8_t key[32];
+    amdcuid_status_t key_status = amdcuid_generate_hash_key(key);
+    if (key_status != AMDCUID_STATUS_SUCCESS) {
+      log_err() << "Error generating/loading HMAC key (status: "
+                << amdcuid_status_to_string(key_status) << ")" << std::endl;
+      return 1;
     }
+    key_status = amdcuid_set_hash_key(key);
+    if (key_status != AMDCUID_STATUS_SUCCESS) {
+      log_err() << "Error setting HMAC key for daemon (status: "
+                << amdcuid_status_to_string(key_status) << ")" << std::endl;
+      return 1;
+    }
+  } else {
+    // The key file exists. Verify size matches the expected key length before
+    // proceeding, to avoid using a corrupt key file.
+    struct stat key_stat;
+    bool stat_ok = (fstat(fd, &key_stat) == 0);
     close(fd);
-
-    // read config file first get logging options and whether to run as a daemon or only on boot
-    std::ifstream config_file("/opt/amdcuid/etc/amdcuid_daemon.conf");
-    std::vector<std::string> config_lines;
-
-    if (config_file.is_open()) {
-        std::string line;
-        while (std::getline(config_file, line)) {
-            // Skip empty lines and comments
-            if (line.empty() || line[0] == '#') {
-                continue;
-            }
-            size_t eq = line.find('=');
-            if (eq != std::string::npos) {
-                config_lines.push_back(line.substr(eq + 1));
-            }
-        }
-        config_file.close();
+    if (!stat_ok || key_stat.st_size != key_length) {
+      log_err() << "Error: HMAC key file has unexpected size ("
+                << (stat_ok ? key_stat.st_size : -1) << " bytes, expected "
+                << key_length << "). Key file may be corrupt; "
+                << "remove it to allow regeneration." << std::endl;
+      return 1;
     }
-    else {
-        std::cerr << "Failed to open config file. Exiting." << std::endl;
-        return 1;
+  }
+  close(fd);
+
+  // read config file first get logging options and whether to run as a daemon
+  // or only on boot
+  std::ifstream config_file("/opt/amdcuid/etc/amdcuid_daemon.conf");
+  std::vector<std::string> config_lines;
+
+  if (config_file.is_open()) {
+    std::string line;
+    while (std::getline(config_file, line)) {
+      // Skip empty lines and comments
+      if (line.empty() || line[0] == '#') {
+        continue;
+      }
+      size_t eq = line.find('=');
+      if (eq != std::string::npos) {
+        config_lines.push_back(line.substr(eq + 1));
+      }
     }
+    config_file.close();
+  } else {
+    std::cerr << "Failed to open config file. Exiting." << std::endl;
+    return 1;
+  }
 
-    if (config_lines.size() < 2) {
-        std::cerr << "Insufficient config parameters. Exiting." << std::endl;
-        return 1;
+  if (config_lines.size() < 2) {
+    std::cerr << "Insufficient config parameters. Exiting." << std::endl;
+    return 1;
+  }
+
+  bool logging_enabled = (config_lines[1] == "true");
+
+  // Initialize file logging if enabled
+  init_logging(logging_enabled);
+  log_out() << "AMD CUID Daemon initialized with logging "
+            << (logging_enabled ? "enabled" : "disabled") << std::endl;
+
+  if (config_lines[0] == "true") {
+    // in daemon mode, we expect to receive device events via IPC from clients
+    // and from udev
+    CuidDaemonServer server;
+    amdcuid_status_t status = server.start();
+    if (status != AMDCUID_STATUS_SUCCESS) {
+      log_err() << "Error: Failed to start daemon server (status: "
+                << amdcuid_status_to_string(status) << ")" << std::endl;
+      return 1;
     }
+    log_out() << "Daemon server started, listening for device events..."
+              << std::endl;
 
-    bool logging_enabled = (config_lines[1] == "true");
-
-    // Initialize file logging if enabled
-    init_logging(logging_enabled);
-    log_out() << "AMD CUID Daemon initialized with logging " << (logging_enabled ? "enabled" : "disabled") << std::endl;
-
-    if (config_lines[0] == "true") {
-        // in daemon mode, we expect to receive device events via IPC from clients and from udev
-        CuidDaemonServer server;
-        amdcuid_status_t status = server.start();
-        if (status != AMDCUID_STATUS_SUCCESS) {
-            log_err() << "Error: Failed to start daemon server (status: " << amdcuid_status_to_string(status) << ")" << std::endl;
-            return 1;
-        }
-        log_out() << "Daemon server started, listening for device events..." << std::endl;
-
-        // Keep the main thread alive while the server is running
-        while (true) {
-            std::this_thread::sleep_for(std::chrono::seconds(10));
-        }
-
-        // On shutdown (not reachable in current code)
-        log_out() << "Daemon server stopping, no longer listening for device events." << std::endl;
-        server.stop();
-    }
-    else {
-        log_out() << "Running in non-daemon mode, generating/updating CUID files once..." << std::endl;
-        // non-daemon mode discovers devices on bootup and updates their CUIDs once
-        // discover devices by refreshing
-        amdcuid_status_t status = amdcuid_refresh();
-        if (status != AMDCUID_STATUS_SUCCESS) {
-            log_err() << "Error: Failed to generate CUID files (status: " << amdcuid_status_to_string(status) << ")" << std::endl;
-            return 1;
-        }
-
-        log_out() << "CUID files generated/updated successfully." << std::endl;
-
-        // get handle count for logging
-        uint32_t count = 0;
-        amdcuid_id_t dummy[1] = {};
-        status = amdcuid_get_all_handles(dummy, &count);
-
-        log_out() << "Total devices with CUIDs: " << count << std::endl;
+    // Keep the main thread alive while the server is running
+    while (true) {
+      std::this_thread::sleep_for(std::chrono::seconds(10));
     }
 
-    log_out() << "AMD CUID Daemon Exiting..." << std::endl;
-    return 0;
+    // On shutdown (not reachable in current code)
+    log_out()
+        << "Daemon server stopping, no longer listening for device events."
+        << std::endl;
+    server.stop();
+  } else {
+    log_out()
+        << "Running in non-daemon mode, generating/updating CUID files once..."
+        << std::endl;
+    // non-daemon mode discovers devices on bootup and updates their CUIDs once
+    // discover devices by refreshing
+    amdcuid_status_t status = amdcuid_refresh();
+    if (status != AMDCUID_STATUS_SUCCESS) {
+      log_err() << "Error: Failed to generate CUID files (status: "
+                << amdcuid_status_to_string(status) << ")" << std::endl;
+      return 1;
+    }
+
+    log_out() << "CUID files generated/updated successfully." << std::endl;
+
+    // get handle count for logging
+    uint32_t count = 0;
+    amdcuid_id_t dummy[1] = {};
+    status = amdcuid_get_all_handles(dummy, &count);
+
+    log_out() << "Total devices with CUIDs: " << count << std::endl;
+  }
+
+  log_out() << "AMD CUID Daemon Exiting..." << std::endl;
+  return 0;
 }

--- a/projects/cuid/daemon/amdcuid_daemon.cc
+++ b/projects/cuid/daemon/amdcuid_daemon.cc
@@ -25,6 +25,8 @@
 #include "src/ipc_protocol.h"
 #include <atomic>
 #include <cstdlib>
+#include <cstring>
+#include <ctime>
 #include <fcntl.h>
 #include <fstream>
 #include <iostream>

--- a/projects/cuid/daemon/amdcuid_daemon.cc
+++ b/projects/cuid/daemon/amdcuid_daemon.cc
@@ -231,7 +231,6 @@ int main() {
       return 1;
     }
   }
-  close(fd);
 
   // read config file first get logging options and whether to run as a daemon
   // or only on boot

--- a/projects/cuid/example/CMakeLists.txt
+++ b/projects/cuid/example/CMakeLists.txt
@@ -18,17 +18,33 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.10)
 project(amdcuid_example)
 
 set(CMAKE_CXX_STANDARD 14)
 
 find_package(OpenSSL REQUIRED)
 
-add_executable(amdcuid_example main.cc)
+set(AMDCUID_EXAMPLE_EXECUTABLE amdcuid_example)
+set(SRC_LIST main.cc)
 
-target_include_directories(amdcuid_example PRIVATE ${CMAKE_SOURCE_DIR}/lib)
-target_link_libraries(amdcuid_example PRIVATE amdcuid_static OpenSSL::Crypto pthread)
+add_executable(${AMDCUID_EXAMPLE_EXECUTABLE} ${SRC_LIST})
 
-# Install example source and binary into documentation
-install(FILES main.cc DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT example)
+target_include_directories(
+    ${AMDCUID_EXAMPLE_EXECUTABLE}
+    PRIVATE ${CMAKE_SOURCE_DIR}/lib
+)
+
+# Link against the CUID library (public API only)
+# The example now uses only the public API defined in amd_cuid.h
+target_link_libraries(${AMDCUID_EXAMPLE_EXECUTABLE} amdcuid_static pthread)
+
+# Install example source into documentation
+install(
+    FILES ${SRC_LIST}
+    DESTINATION ${CMAKE_INSTALL_DOCDIR}
+    COMPONENT ${EXAMPLE_COMPONENT}
+)
+
+message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
+message("                  Finished Cmake amdcuid_example                   ")
+message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")

--- a/projects/cuid/example/CMakeLists.txt
+++ b/projects/cuid/example/CMakeLists.txt
@@ -22,8 +22,6 @@ project(amdcuid_example)
 
 set(CMAKE_CXX_STANDARD 14)
 
-find_package(OpenSSL REQUIRED)
-
 set(AMDCUID_EXAMPLE_EXECUTABLE amdcuid_example)
 set(SRC_LIST main.cc)
 

--- a/projects/cuid/lib/CMakeLists.txt
+++ b/projects/cuid/lib/CMakeLists.txt
@@ -18,12 +18,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.10)
 project(amdcuid_lib)
 
 set(CMAKE_CXX_STANDARD 14)
 
-find_package(OpenSSL REQUIRED)
+# When built as part of the top-level project, OpenSSL is already resolved
+# (either from the system or via FetchContent). QUIET prevents a redundant
+# hard failure when targets are already available through FetchContent.
+find_package(OpenSSL QUIET)
 
 set(CUID_SOURCES
     src/cuid.cc
@@ -63,30 +65,62 @@ set(CUID_HEADERS
 add_library(amdcuid_static STATIC ${CUID_SOURCES} ${CUID_HEADERS})
 add_library(amdcuid_shared SHARED ${CUID_SOURCES} ${CUID_HEADERS})
 
-target_include_directories(amdcuid_static 
+target_include_directories(
+    amdcuid_static
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
-target_include_directories(amdcuid_shared 
+target_include_directories(
+    amdcuid_shared
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
+# Pass the version-independent shared config directory to the library at compile
+# time. All installed versions of the library must agree on this path so that
+# the HMAC key is shared and CUIDs remain stable across version upgrades.
+target_compile_definitions(
+    amdcuid_static
+    PRIVATE AMDCUID_CONFIG_DIR="${AMDCUID_SHARED_CONFIG_DIR}"
+)
+target_compile_definitions(
+    amdcuid_shared
+    PRIVATE AMDCUID_CONFIG_DIR="${AMDCUID_SHARED_CONFIG_DIR}"
+)
+
+if(WIN32)
+    target_link_libraries(amdcuid_shared PRIVATE bcrypt)
+    target_link_libraries(amdcuid_static PUBLIC bcrypt)
+else()
+    target_link_libraries(amdcuid_shared PRIVATE OpenSSL::Crypto)
+    target_link_libraries(amdcuid_static PUBLIC OpenSSL::Crypto)
+endif()
+
 # Shared library
-install(TARGETS amdcuid_shared
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}    # Windows DLLs go here
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}    # Linux .so
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}    # Static libs & Windows import libs
-    COMPONENT library
+install(
+    TARGETS amdcuid_shared
+    RUNTIME
+        DESTINATION
+            ${CMAKE_INSTALL_BINDIR} # Windows DLLs go here
+    LIBRARY
+        DESTINATION
+            ${CMAKE_INSTALL_LIBDIR} # Linux .so
+    ARCHIVE
+        DESTINATION
+            ${CMAKE_INSTALL_LIBDIR} # Static libs & Windows import libs
+        COMPONENT library
 )
 
 # Static library
-install(TARGETS amdcuid_static
+install(
+    TARGETS amdcuid_static
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT library
 )
 
 # Install public headers
-set(PUBLIC_HEADERS
-    include/amd_cuid.h
+set(PUBLIC_HEADERS include/amd_cuid.h)
+install(
+    FILES ${PUBLIC_HEADERS}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    COMPONENT library
 )
-install(FILES ${PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT library)

--- a/projects/cuid/lib/CMakeLists.txt
+++ b/projects/cuid/lib/CMakeLists.txt
@@ -81,11 +81,11 @@ target_include_directories(
 # the HMAC key is shared and CUIDs remain stable across version upgrades.
 target_compile_definitions(
     amdcuid_static
-    PRIVATE AMDCUID_CONFIG_DIR="${AMDCUID_SHARED_CONFIG_DIR}"
+    PRIVATE AMDCUID_CONFIG_DIR="${CMAKE_INSTALL_SYSCONFDIR}"
 )
 target_compile_definitions(
     amdcuid_shared
-    PRIVATE AMDCUID_CONFIG_DIR="${AMDCUID_SHARED_CONFIG_DIR}"
+    PRIVATE AMDCUID_CONFIG_DIR="${CMAKE_INSTALL_SYSCONFDIR}"
 )
 
 if(WIN32)

--- a/projects/cuid/lib/src/cuid_util.cc
+++ b/projects/cuid/lib/src/cuid_util.cc
@@ -388,7 +388,7 @@ CuidUtilities::generate_derived_cuid(const amdcuid_primary_id *primary_id,
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
 
-  uint8_t hash[EVP_MAX_MD_SIZE];
+  uint8_t hash[hash_length];
   size_t hash_len = 0;
 
   amdcuid_status_t status =

--- a/projects/cuid/lib/src/hmac.cc
+++ b/projects/cuid/lib/src/hmac.cc
@@ -20,160 +20,494 @@
  * THE SOFTWARE.
  */
 
-#include <openssl/hmac.h>
-#include <openssl/evp.h>
-#include <openssl/rand.h>
-#include <iostream>
-#include <cstring>
-#include <unistd.h>
-#include <sys/stat.h>
+// Backend selection (compile-time):
+//   _WIN32                               -> Windows CNG  (BCrypt)
+//   OpenSSL >= 3.0 (all other platforms) -> EVP_MAC API
+//   OpenSSL <  3.0 (all other platforms) -> HMAC_CTX API
+
 #include "hmac.h"
+#include <cstring>
+#include <fstream>
+#include <iostream>
+
+#ifndef AMDCUID_CONFIG_DIR
+#error                                                                         \
+    "AMDCUID_CONFIG_DIR is not defined. Please define it to the CUID configuration directory path."
+#endif
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Windows CNG backend (BCrypt)
+// ─────────────────────────────────────────────────────────────────────────────
+#if defined(_WIN32)
+
+#define WIN32_LEAN_AND_MEAN
+#include <bcrypt.h>
+#include <windows.h>
+
+struct cuid_hmac::Impl {
+  BCRYPT_ALG_HANDLE hAlg;
+  std::string digest_name;
+
+  // Map an OpenSSL-style digest name to the BCrypt HMAC provider ID.
+  static const wchar_t *to_bcrypt_alg(const char *name) {
+    if (!name)
+      return BCRYPT_SHA256_ALGORITHM;
+    if (_stricmp(name, "SHA256") == 0 || _stricmp(name, "SHA-256") == 0)
+      return BCRYPT_SHA256_ALGORITHM;
+    if (_stricmp(name, "SHA1") == 0 || _stricmp(name, "SHA-1") == 0)
+      return BCRYPT_SHA1_ALGORITHM;
+    if (_stricmp(name, "SHA384") == 0 || _stricmp(name, "SHA-384") == 0)
+      return BCRYPT_SHA384_ALGORITHM;
+    if (_stricmp(name, "SHA512") == 0 || _stricmp(name, "SHA-512") == 0)
+      return BCRYPT_SHA512_ALGORITHM;
+    return nullptr;
+  }
+};
 
 cuid_hmac::cuid_hmac()
-    : ctx(nullptr), mac(nullptr), key(nullptr), key_len(0), valid(false)
-{
-    mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
-    if (!mac) {
-        std::cerr << "Error creating EVP_MAC" << std::endl;
-        return;
-    }
+    : impl_(nullptr), key(nullptr), key_len(0), valid(false),
+      key_file_path(std::string(AMDCUID_CONFIG_DIR) + "/hmac_key.bin") {
+  impl_ = new Impl();
+  impl_->digest_name = "SHA256";
+  impl_->hAlg = nullptr;
 
-    ctx = EVP_MAC_CTX_new(mac);
-    if (!ctx) {
-        EVP_MAC_free(mac);
-        mac = nullptr;
-        std::cerr << "Error creating EVP_MAC_CTX" << std::endl;
-        return;
-    }
+  NTSTATUS status =
+      BCryptOpenAlgorithmProvider(&impl_->hAlg, BCRYPT_SHA256_ALGORITHM,
+                                  nullptr, BCRYPT_ALG_HANDLE_HMAC_FLAG);
+  if (!BCRYPT_SUCCESS(status)) {
+    std::cerr << "Error opening BCrypt HMAC algorithm provider" << std::endl;
+    delete impl_;
+    impl_ = nullptr;
+    return;
+  }
 
-    std::ifstream key_file_stream(key_file_path, std::ios::binary);
-    if (!key_file_stream.is_open()) {
-        std::cerr << "Error opening key file" << std::endl;
-        return;
-    }
-    key_file_stream.seekg(0, std::ios::end);
-    key_len = key_file_stream.tellg();
-    key_file_stream.seekg(0, std::ios::beg);
-    key = new uint8_t[key_len];
-    key_file_stream.read(reinterpret_cast<char*>(key), key_len);
-    key_file_stream.close();
-    
-    valid = true;
+  std::ifstream key_file_stream(key_file_path, std::ios::binary);
+  if (!key_file_stream.is_open()) {
+    std::cerr << "Error opening key file" << std::endl;
+    return;
+  }
+  key_file_stream.seekg(0, std::ios::end);
+  key_len = static_cast<size_t>(key_file_stream.tellg());
+  key_file_stream.seekg(0, std::ios::beg);
+  key = new uint8_t[key_len];
+  key_file_stream.read(reinterpret_cast<char *>(key), key_len);
+  key_file_stream.close();
+
+  valid = true;
 }
 
-cuid_hmac::~cuid_hmac()
-{
-    if (ctx) EVP_MAC_CTX_free(ctx);
-    if (mac) EVP_MAC_free(mac);
-    if (key) delete[] key;
+cuid_hmac::~cuid_hmac() {
+  if (impl_) {
+    if (impl_->hAlg)
+      BCryptCloseAlgorithmProvider(impl_->hAlg, 0);
+    delete impl_;
+  }
+  delete[] key;
 }
 
-amdcuid_status_t cuid_hmac::generate_hmac_sha256(
-    const uint8_t* data,
-    size_t data_len,
-    uint8_t* out_hash,
-    size_t* out_len
-)
-{
-    if (!ctx) {
-        std::cerr << "MAC context is not initialized" << std::endl;
-        return AMDCUID_STATUS_HMAC_ERROR;
-    }
+amdcuid_status_t cuid_hmac::generate_hmac_sha256(const uint8_t *data,
+                                                 size_t data_len,
+                                                 uint8_t *out_hash,
+                                                 size_t *out_len) {
+  if (!impl_ || !impl_->hAlg) {
+    std::cerr << "BCrypt backend not initialized" << std::endl;
+    return AMDCUID_STATUS_HMAC_ERROR;
+  }
 
-    OSSL_PARAM params[2];
-    const char* digest_name = "SHA256";
-    params[0] = OSSL_PARAM_construct_utf8_string("digest", const_cast<char*>(digest_name), 0);
-    params[1] = OSSL_PARAM_construct_end();
+  BCRYPT_HASH_HANDLE hHash = nullptr;
+  NTSTATUS status = BCryptCreateHash(impl_->hAlg, &hHash, nullptr, 0,
+                                     reinterpret_cast<PUCHAR>(key),
+                                     static_cast<ULONG>(key_len), 0);
+  if (!BCRYPT_SUCCESS(status)) {
+    std::cerr << "BCryptCreateHash failed" << std::endl;
+    return AMDCUID_STATUS_HMAC_ERROR;
+  }
 
-    if (EVP_MAC_CTX_set_params(ctx, params) != 1) {
-        std::cerr << "Error setting HMAC digest algorithm" << std::endl;
-        return AMDCUID_STATUS_HMAC_ERROR;
-    }
+  status = BCryptHashData(
+      hHash, const_cast<PUCHAR>(reinterpret_cast<const UCHAR *>(data)),
+      static_cast<ULONG>(data_len), 0);
+  if (!BCRYPT_SUCCESS(status)) {
+    BCryptDestroyHash(hHash);
+    std::cerr << "BCryptHashData failed" << std::endl;
+    return AMDCUID_STATUS_HMAC_ERROR;
+  }
 
-    if (EVP_MAC_init(ctx, reinterpret_cast<const unsigned char*>(key), key_len, NULL) != 1) {
-        std::cerr << "Error initializing MAC context" << std::endl;
-        return AMDCUID_STATUS_HMAC_ERROR;
-    }
+  DWORD hash_len = 0, result_size = 0;
+  status = BCryptGetProperty(impl_->hAlg, BCRYPT_HASH_LENGTH,
+                             reinterpret_cast<PUCHAR>(&hash_len),
+                             sizeof(hash_len), &result_size, 0);
+  if (!BCRYPT_SUCCESS(status)) {
+    BCryptDestroyHash(hHash);
+    return AMDCUID_STATUS_HMAC_ERROR;
+  }
 
-    if (EVP_MAC_update(ctx, reinterpret_cast<const unsigned char*>(data), data_len) != 1) {
-        std::cerr << "Error updating MAC context" << std::endl;
-        return AMDCUID_STATUS_HMAC_ERROR;
-    }
+  status =
+      BCryptFinishHash(hHash, reinterpret_cast<PUCHAR>(out_hash), hash_len, 0);
+  BCryptDestroyHash(hHash);
+  if (!BCRYPT_SUCCESS(status)) {
+    std::cerr << "BCryptFinishHash failed" << std::endl;
+    return AMDCUID_STATUS_HMAC_ERROR;
+  }
 
-    if (EVP_MAC_final(ctx, reinterpret_cast<unsigned char*>(out_hash), out_len, EVP_MAX_MD_SIZE) != 1) {
-        std::cerr << "Error finalizing MAC" << std::endl;
-        return AMDCUID_STATUS_HMAC_ERROR;
-    }
-
-    return AMDCUID_STATUS_SUCCESS;
+  *out_len = hash_len;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t cuid_hmac::set_hmac_algorithm(const EVP_MD* md)
-{
-    if (!ctx) {
-        std::cerr << "MAC context is not initialized" << std::endl;
-        return AMDCUID_STATUS_HMAC_ERROR;
-    }
-    if (!md) {
-        md = EVP_sha256();
-    }
+amdcuid_status_t cuid_hmac::set_hmac_algorithm(const char *digest_name) {
+  if (!impl_)
+    return AMDCUID_STATUS_HMAC_ERROR;
 
-    OSSL_PARAM params[2];
-    const char* algorithm = EVP_MD_get0_name(md);
-    params[0] = OSSL_PARAM_construct_utf8_string("digest", const_cast<char*>(algorithm), 0);
-    params[1] = OSSL_PARAM_construct_end();
+  const wchar_t *alg_id = Impl::to_bcrypt_alg(digest_name);
+  if (!alg_id) {
+    std::cerr << "Unsupported digest: "
+              << (digest_name ? digest_name : "(null)") << std::endl;
+    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  }
 
-    if (EVP_MAC_CTX_set_params(ctx, params) != 1) {
-        std::cerr << "Error setting HMAC algorithm" << std::endl;
-        return AMDCUID_STATUS_HMAC_ERROR;
-    }
+  BCRYPT_ALG_HANDLE hNew = nullptr;
+  NTSTATUS status = BCryptOpenAlgorithmProvider(&hNew, alg_id, nullptr,
+                                                BCRYPT_ALG_HANDLE_HMAC_FLAG);
+  if (!BCRYPT_SUCCESS(status)) {
+    std::cerr << "BCryptOpenAlgorithmProvider failed for new digest"
+              << std::endl;
+    return AMDCUID_STATUS_HMAC_ERROR;
+  }
 
-    return AMDCUID_STATUS_SUCCESS;
+  if (impl_->hAlg)
+    BCryptCloseAlgorithmProvider(impl_->hAlg, 0);
+  impl_->hAlg = hNew;
+  impl_->digest_name = digest_name;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
 amdcuid_status_t cuid_hmac::set_hmac_key(const uint8_t key_data[key_length]) {
-    if (geteuid() != 0) {
-        return AMDCUID_STATUS_PERMISSION_DENIED;
-    }
+  delete[] key;
+  key = new uint8_t[key_length];
+  key_len = key_length;
+  std::memcpy(key, key_data, key_length);
 
-    if (key) {
-        delete[] key;
-    }
-    key = new uint8_t[key_length];
-    std::memcpy(key, key_data, key_length);
+  // Remove existing key file if it exists, ignoring error if it doesn't exist
+  if (std::remove(key_file_path.c_str()) != 0 && errno != ENOENT)
+    return AMDCUID_STATUS_KEY_ERROR;
 
-    // if key_file exists, delete it first
-    if (std::remove(key_file_path.c_str()) != 0 && errno != ENOENT) {
-        // failed to delete existing file due to different permissions
-        return AMDCUID_STATUS_KEY_ERROR;
-    }
+  std::ofstream key_file(key_file_path, std::ios::out | std::ios::binary);
+  if (!key_file)
+    return AMDCUID_STATUS_KEY_ERROR;
 
-    std::ofstream key_file(key_file_path, std::ios::out | std::ios::binary);
-    if (!key_file) {
-        return AMDCUID_STATUS_KEY_ERROR;
-    }
-    key_file.write(reinterpret_cast<const char*>(key), key_length);
-    if (!key_file) {
-        key_file.close();
-        return AMDCUID_STATUS_KEY_ERROR;
-    }
+  key_file.write(reinterpret_cast<const char *>(key), key_length);
+  if (!key_file) {
     key_file.close();
+    return AMDCUID_STATUS_KEY_ERROR;
+  }
+  key_file.close();
 
-    // set permissions to read/write for owner only
-    if (chmod(key_file_path.c_str(), S_IRUSR | S_IWUSR) != 0) {
-        return AMDCUID_STATUS_PERMISSION_DENIED;
-    }
-
-    return AMDCUID_STATUS_SUCCESS;
+  return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t cuid_hmac::generate_key(uint8_t key[key_length]) {
-    if (!key)
-        return AMDCUID_STATUS_INVALID_ARGUMENT;
-
-    if (RAND_bytes(key, key_length) != 1) {
-        return AMDCUID_STATUS_KEY_ERROR;
-    }
-
-    return AMDCUID_STATUS_SUCCESS;
+amdcuid_status_t cuid_hmac::generate_key(uint8_t out_key[key_length]) {
+  if (!out_key)
+    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  NTSTATUS status =
+      BCryptGenRandom(nullptr, reinterpret_cast<PUCHAR>(out_key), key_length,
+                      BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+  return BCRYPT_SUCCESS(status) ? AMDCUID_STATUS_SUCCESS
+                                : AMDCUID_STATUS_KEY_ERROR;
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OpenSSL backends (Linux / macOS)
+// ─────────────────────────────────────────────────────────────────────────────
+#else // !defined(_WIN32)
+
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/opensslv.h>
+#include <openssl/rand.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OpenSSL 3.0+  — EVP_MAC API
+//
+// NOTE: LibreSSL (used by Alpine Linux) and BoringSSL (custom builds) both
+// define OPENSSL_VERSION_NUMBER with a fake value below 0x30000000L even on
+// their modern releases, so they fall through to the HMAC_CTX backend below.
+// LibreSSL also defines LIBRESSL_VERSION_NUMBER; BoringSSL defines
+// OPENSSL_IS_BORINGSSL. Neither requires a separate code path because both
+// fully implement the HMAC_CTX API that the 1.x backend uses.
+// ─────────────────────────────────────────────────────────────────────────────
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(LIBRESSL_VERSION_NUMBER)
+
+#include <openssl/params.h>
+
+struct cuid_hmac::Impl {
+  EVP_MAC *mac;
+  EVP_MAC_CTX *ctx;
+  std::string digest_name;
+};
+
+cuid_hmac::cuid_hmac()
+    : impl_(nullptr), key(nullptr), key_len(0), valid(false),
+      key_file_path(std::string(AMDCUID_CONFIG_DIR) + "/hmac_key.bin") {
+  impl_ = new Impl();
+  impl_->digest_name = "SHA256";
+  impl_->mac = nullptr;
+  impl_->ctx = nullptr;
+
+  impl_->mac = EVP_MAC_fetch(nullptr, "HMAC", nullptr);
+  if (!impl_->mac) {
+    std::cerr << "Error fetching EVP_MAC" << std::endl;
+    delete impl_;
+    impl_ = nullptr;
+    return;
+  }
+
+  impl_->ctx = EVP_MAC_CTX_new(impl_->mac);
+  if (!impl_->ctx) {
+    std::cerr << "Error creating EVP_MAC_CTX" << std::endl;
+    EVP_MAC_free(impl_->mac);
+    delete impl_;
+    impl_ = nullptr;
+    return;
+  }
+
+  std::ifstream key_file_stream(key_file_path, std::ios::binary);
+  if (!key_file_stream.is_open()) {
+    std::cerr << "Error opening key file" << std::endl;
+    return;
+  }
+
+  key_file_stream.seekg(0, std::ios::end);
+  key_len = static_cast<size_t>(key_file_stream.tellg());
+  if (key_len == 0 || key_len != key_length) { // sanity check on key length
+    std::cerr << "Invalid key length in key file" << std::endl;
+    key_file_stream.close();
+    return;
+  }
+  key_file_stream.seekg(0, std::ios::beg);
+
+  key = new uint8_t[key_length];
+  key_file_stream.read(reinterpret_cast<char *>(key), key_length);
+  key_file_stream.close();
+
+  valid = true;
+}
+
+cuid_hmac::~cuid_hmac() {
+  if (impl_) {
+    if (impl_->ctx)
+      EVP_MAC_CTX_free(impl_->ctx);
+    if (impl_->mac)
+      EVP_MAC_free(impl_->mac);
+    delete impl_;
+  }
+  delete[] key;
+}
+
+amdcuid_status_t cuid_hmac::generate_hmac_sha256(const uint8_t *data,
+                                                 size_t data_len,
+                                                 uint8_t *out_hash,
+                                                 size_t *out_len) {
+  if (!impl_ || !impl_->ctx) {
+    std::cerr << "MAC context is not initialized" << std::endl;
+    return AMDCUID_STATUS_HMAC_ERROR;
+  }
+
+  OSSL_PARAM params[2];
+  params[0] = OSSL_PARAM_construct_utf8_string(
+      "digest", const_cast<char *>(impl_->digest_name.c_str()), 0);
+  params[1] = OSSL_PARAM_construct_end();
+
+  if (EVP_MAC_init(impl_->ctx, reinterpret_cast<const unsigned char *>(key),
+                   key_len, params) != 1) {
+    std::cerr << "Error initializing MAC context" << std::endl;
+    return AMDCUID_STATUS_HMAC_ERROR;
+  }
+
+  if (EVP_MAC_update(impl_->ctx, reinterpret_cast<const unsigned char *>(data),
+                     data_len) != 1) {
+    std::cerr << "Error updating MAC context" << std::endl;
+    return AMDCUID_STATUS_HMAC_ERROR;
+  }
+
+  if (EVP_MAC_final(impl_->ctx, reinterpret_cast<unsigned char *>(out_hash),
+                    out_len, EVP_MAX_MD_SIZE) != 1) {
+    std::cerr << "Error finalizing MAC" << std::endl;
+    return AMDCUID_STATUS_HMAC_ERROR;
+  }
+
+  return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t cuid_hmac::set_hmac_algorithm(const char *digest_name) {
+  if (!impl_)
+    return AMDCUID_STATUS_HMAC_ERROR;
+
+  impl_->digest_name =
+      "SHA256"; // default to SHA256 if null or empty string provided
+  if (digest_name && digest_name[0] != '\0')
+    impl_->digest_name = digest_name;
+
+  return AMDCUID_STATUS_SUCCESS;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OpenSSL 1.x  — HMAC_CTX API
+// ─────────────────────────────────────────────────────────────────────────────
+#else // OPENSSL_VERSION_NUMBER < 0x30000000L
+
+struct cuid_hmac::Impl {
+  HMAC_CTX *ctx;
+  std::string digest_name;
+};
+
+cuid_hmac::cuid_hmac()
+    : impl_(nullptr), key(nullptr), key_len(0), valid(false),
+      key_file_path(std::string(AMDCUID_CONFIG_DIR) + "/hmac_key.bin") {
+  impl_ = new Impl();
+  impl_->digest_name = "SHA256";
+  impl_->ctx = HMAC_CTX_new();
+  if (!impl_->ctx) {
+    std::cerr << "Error creating HMAC_CTX" << std::endl;
+    delete impl_;
+    impl_ = nullptr;
+    return;
+  }
+
+  std::ifstream key_file_stream(key_file_path, std::ios::binary);
+  if (!key_file_stream.is_open()) {
+    std::cerr << "Error opening key file" << std::endl;
+    return;
+  }
+
+  key_file_stream.seekg(0, std::ios::end);
+  key_len = static_cast<size_t>(key_file_stream.tellg());
+  if (key_len == 0 || key_len != key_length) { // sanity check on key length
+    std::cerr << "Invalid key length in key file" << std::endl;
+    key_file_stream.close();
+    return;
+  }
+  key_file_stream.seekg(0, std::ios::beg);
+
+  key = new uint8_t[key_length];
+  key_file_stream.read(reinterpret_cast<char *>(key), key_length);
+  key_file_stream.close();
+
+  valid = true;
+}
+
+cuid_hmac::~cuid_hmac() {
+  if (impl_) {
+    if (impl_->ctx)
+      HMAC_CTX_free(impl_->ctx);
+    delete impl_;
+  }
+  delete[] key;
+}
+
+amdcuid_status_t cuid_hmac::generate_hmac_sha256(const uint8_t *data,
+                                                 size_t data_len,
+                                                 uint8_t *out_hash,
+                                                 size_t *out_len) {
+  if (!impl_ || !impl_->ctx) {
+    std::cerr << "HMAC context is not initialized" << std::endl;
+    return AMDCUID_STATUS_HMAC_ERROR;
+  }
+
+  const EVP_MD *md = EVP_get_digestbyname(impl_->digest_name.c_str());
+  if (!md) {
+    std::cerr << "Unknown digest: " << impl_->digest_name << std::endl;
+    return AMDCUID_STATUS_HMAC_ERROR;
+  }
+
+  if (HMAC_Init_ex(impl_->ctx, reinterpret_cast<const void *>(key),
+                   static_cast<int>(key_len), md, nullptr) != 1) {
+    std::cerr << "Error initializing HMAC context" << std::endl;
+    return AMDCUID_STATUS_HMAC_ERROR;
+  }
+
+  if (HMAC_Update(impl_->ctx, reinterpret_cast<const unsigned char *>(data),
+                  data_len) != 1) {
+    std::cerr << "Error updating HMAC context" << std::endl;
+    return AMDCUID_STATUS_HMAC_ERROR;
+  }
+
+  unsigned int len = 0;
+  if (HMAC_Final(impl_->ctx, reinterpret_cast<unsigned char *>(out_hash),
+                 &len) != 1) {
+    std::cerr << "Error finalizing HMAC" << std::endl;
+    return AMDCUID_STATUS_HMAC_ERROR;
+  }
+
+  *out_len = len;
+  return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t cuid_hmac::set_hmac_algorithm(const char *digest_name) {
+  if (!impl_)
+    return AMDCUID_STATUS_HMAC_ERROR;
+
+  impl_->digest_name =
+      "SHA256"; // default to SHA256 if null or empty string provided
+  if (digest_name && digest_name[0] != '\0')
+    impl_->digest_name = digest_name;
+
+  return AMDCUID_STATUS_SUCCESS;
+}
+
+#endif // OPENSSL_VERSION_NUMBER
+
+// ─────────────────────────────────────────────────────────────────────────────
+// set_hmac_key / generate_key  — shared by both OpenSSL backends
+// ─────────────────────────────────────────────────────────────────────────────
+
+amdcuid_status_t cuid_hmac::set_hmac_key(const uint8_t key_data[key_length]) {
+  if (geteuid() != 0)
+    return AMDCUID_STATUS_PERMISSION_DENIED;
+
+  delete[] key;
+  key = new uint8_t[key_length];
+  key_len = key_length;
+  std::memcpy(key, key_data, key_length);
+
+  if (std::remove(key_file_path.c_str()) != 0 && errno != ENOENT)
+    return AMDCUID_STATUS_KEY_ERROR;
+
+  // TODO: This is backwards, we're never actually reading the stored key file,
+  // but we're always overwriting it. Need to rethink this Maybe have public
+  // facing API write the stored key file and then call this function to set the
+  // in-memory key, and have this function only update the in-memory key without
+  // touching the file system? That way we can ensure the file is only written
+  // to when we actually want to change the key, and not every time we start the
+  // daemon? Remember to also adjust the Windows CNG implementation to match any
+  // changes made here for consistency.
+  std::ofstream key_file(key_file_path, std::ios::out | std::ios::binary);
+  if (!key_file)
+    return AMDCUID_STATUS_KEY_ERROR;
+  key_file.write(reinterpret_cast<const char *>(key), key_length);
+  if (!key_file) {
+    key_file.close();
+    return AMDCUID_STATUS_KEY_ERROR;
+  }
+  key_file.close();
+
+  if (chmod(key_file_path.c_str(), S_IRUSR | S_IWUSR) != 0)
+    return AMDCUID_STATUS_PERMISSION_DENIED;
+
+  return AMDCUID_STATUS_SUCCESS;
+}
+
+amdcuid_status_t cuid_hmac::generate_key(uint8_t out_key[key_length]) {
+  if (!out_key)
+    return AMDCUID_STATUS_INVALID_ARGUMENT;
+
+  int success = RAND_bytes(out_key, key_length);
+  if (success != 1) {
+    std::cerr << "Error generating random bytes for HMAC key" << std::endl;
+    return AMDCUID_STATUS_KEY_ERROR;
+  }
+
+  return AMDCUID_STATUS_SUCCESS;
+}
+
+#endif // _WIN32

--- a/projects/cuid/lib/src/hmac.cc
+++ b/projects/cuid/lib/src/hmac.cc
@@ -26,6 +26,8 @@
 //   OpenSSL <  3.0 (all other platforms) -> HMAC_CTX API
 
 #include "hmac.h"
+#include <cerrno>
+#include <cstdio>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -65,8 +67,7 @@ struct cuid_hmac::Impl {
 };
 
 cuid_hmac::cuid_hmac()
-    : impl_(nullptr), key(nullptr), key_len(0), valid(false),
-      key_file_path(std::string(AMDCUID_CONFIG_DIR) + "/hmac_key.bin") {
+    : impl_(nullptr), key(nullptr), key_len(0), valid(false)) {
   impl_ = new Impl();
   impl_->digest_name = "SHA256";
   impl_->hAlg = nullptr;
@@ -153,33 +154,6 @@ amdcuid_status_t cuid_hmac::generate_hmac_sha256(const uint8_t *data,
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t cuid_hmac::set_hmac_algorithm(const char *digest_name) {
-  if (!impl_)
-    return AMDCUID_STATUS_HMAC_ERROR;
-
-  const wchar_t *alg_id = Impl::to_bcrypt_alg(digest_name);
-  if (!alg_id) {
-    std::cerr << "Unsupported digest: "
-              << (digest_name ? digest_name : "(null)") << std::endl;
-    return AMDCUID_STATUS_INVALID_ARGUMENT;
-  }
-
-  BCRYPT_ALG_HANDLE hNew = nullptr;
-  NTSTATUS status = BCryptOpenAlgorithmProvider(&hNew, alg_id, nullptr,
-                                                BCRYPT_ALG_HANDLE_HMAC_FLAG);
-  if (!BCRYPT_SUCCESS(status)) {
-    std::cerr << "BCryptOpenAlgorithmProvider failed for new digest"
-              << std::endl;
-    return AMDCUID_STATUS_HMAC_ERROR;
-  }
-
-  if (impl_->hAlg)
-    BCryptCloseAlgorithmProvider(impl_->hAlg, 0);
-  impl_->hAlg = hNew;
-  impl_->digest_name = digest_name;
-  return AMDCUID_STATUS_SUCCESS;
-}
-
 amdcuid_status_t cuid_hmac::set_hmac_key(const uint8_t key_data[key_length]) {
   delete[] key;
   key = new uint8_t[key_length];
@@ -247,8 +221,7 @@ struct cuid_hmac::Impl {
 };
 
 cuid_hmac::cuid_hmac()
-    : impl_(nullptr), key(nullptr), key_len(0), valid(false),
-      key_file_path(std::string(AMDCUID_CONFIG_DIR) + "/hmac_key.bin") {
+    : impl_(nullptr), key(nullptr), key_len(0), valid(false) {
   impl_ = new Impl();
   impl_->digest_name = "SHA256";
   impl_->mac = nullptr;
@@ -339,18 +312,6 @@ amdcuid_status_t cuid_hmac::generate_hmac_sha256(const uint8_t *data,
   return AMDCUID_STATUS_SUCCESS;
 }
 
-amdcuid_status_t cuid_hmac::set_hmac_algorithm(const char *digest_name) {
-  if (!impl_)
-    return AMDCUID_STATUS_HMAC_ERROR;
-
-  impl_->digest_name =
-      "SHA256"; // default to SHA256 if null or empty string provided
-  if (digest_name && digest_name[0] != '\0')
-    impl_->digest_name = digest_name;
-
-  return AMDCUID_STATUS_SUCCESS;
-}
-
 // ─────────────────────────────────────────────────────────────────────────────
 // OpenSSL 1.x  — HMAC_CTX API
 // ─────────────────────────────────────────────────────────────────────────────
@@ -362,8 +323,7 @@ struct cuid_hmac::Impl {
 };
 
 cuid_hmac::cuid_hmac()
-    : impl_(nullptr), key(nullptr), key_len(0), valid(false),
-      key_file_path(std::string(AMDCUID_CONFIG_DIR) + "/hmac_key.bin") {
+    : impl_(nullptr), key(nullptr), key_len(0), valid(false) {
   impl_ = new Impl();
   impl_->digest_name = "SHA256";
   impl_->ctx = HMAC_CTX_new();
@@ -440,18 +400,6 @@ amdcuid_status_t cuid_hmac::generate_hmac_sha256(const uint8_t *data,
   }
 
   *out_len = len;
-  return AMDCUID_STATUS_SUCCESS;
-}
-
-amdcuid_status_t cuid_hmac::set_hmac_algorithm(const char *digest_name) {
-  if (!impl_)
-    return AMDCUID_STATUS_HMAC_ERROR;
-
-  impl_->digest_name =
-      "SHA256"; // default to SHA256 if null or empty string provided
-  if (digest_name && digest_name[0] != '\0')
-    impl_->digest_name = digest_name;
-
   return AMDCUID_STATUS_SUCCESS;
 }
 

--- a/projects/cuid/lib/src/hmac.cc
+++ b/projects/cuid/lib/src/hmac.cc
@@ -67,7 +67,7 @@ struct cuid_hmac::Impl {
 };
 
 cuid_hmac::cuid_hmac()
-    : impl_(nullptr), key(nullptr), key_len(0), valid(false)) {
+    : impl_(nullptr), key(nullptr), key_len(0), valid(false) {
   impl_ = new Impl();
   impl_->digest_name = "SHA256";
   impl_->hAlg = nullptr;

--- a/projects/cuid/lib/src/hmac.h
+++ b/projects/cuid/lib/src/hmac.h
@@ -24,7 +24,7 @@
 #define HMAC_H
 
 #include "include/amd_cuid.h"
-#include <stdint.h>
+#include <cstddef>
 #include <string>
 
 #define key_length 32
@@ -50,9 +50,6 @@ public:
 
   amdcuid_status_t generate_hmac_sha256(const uint8_t *data, size_t data_len,
                                         uint8_t *out_hash, size_t *out_len);
-  // digest_name follows OpenSSL naming conventions, e.g. "SHA256", "SHA512".
-  // On Windows CNG, "SHA1", "SHA256", "SHA384", "SHA512" are supported.
-  amdcuid_status_t set_hmac_algorithm(const char *digest_name);
   amdcuid_status_t set_hmac_key(const uint8_t key_data[key_length]);
   amdcuid_status_t generate_key(uint8_t key[key_length]);
 

--- a/projects/cuid/lib/src/hmac.h
+++ b/projects/cuid/lib/src/hmac.h
@@ -23,33 +23,40 @@
 #ifndef HMAC_H
 #define HMAC_H
 
-#include <openssl/hmac.h>
-#include <openssl/evp.h>
-#include <fstream>
-#include <iostream>
 #include "include/amd_cuid.h"
+#include <stdint.h>
+#include <string>
 
 #define key_length 32
+#define hash_length 32
 
-class cuid_hmac
-{
+// cuid_hmac uses a pimpl to hide the crypto-backend context entirely.
+// The active backend is selected at compile time:
+//   _WIN32                              -> Windows CNG  (BCrypt)
+//   OpenSSL >= 3.0  (all other platforms) -> EVP_MAC API
+//   OpenSSL <  3.0  (all other platforms) -> HMAC_CTX API
+class cuid_hmac {
 private:
-    EVP_MAC_CTX* ctx;
-    EVP_MAC* mac;
-    uint8_t* key;
-    size_t key_len;
-    bool valid;
+  struct Impl; // defined in hmac.cc per-backend
+  Impl *impl_;
+  uint8_t *key;
+  size_t key_len;
+  bool valid;
 
 public:
-    cuid_hmac();
-    ~cuid_hmac();
-    bool is_valid() const { return valid; }
-    amdcuid_status_t generate_hmac_sha256(const uint8_t* data, size_t data_len, uint8_t* out_hash, size_t* out_len);
-    amdcuid_status_t set_hmac_algorithm(const EVP_MD* md);
-    amdcuid_status_t set_hmac_key(const uint8_t key_data[key_length]);
-    amdcuid_status_t generate_key(uint8_t key[key_length]);
+  cuid_hmac();
+  ~cuid_hmac();
+  bool is_valid() const { return valid; }
 
-    std::string key_file_path = "/opt/amdcuid/etc/hmac_key.bin";
+  amdcuid_status_t generate_hmac_sha256(const uint8_t *data, size_t data_len,
+                                        uint8_t *out_hash, size_t *out_len);
+  // digest_name follows OpenSSL naming conventions, e.g. "SHA256", "SHA512".
+  // On Windows CNG, "SHA1", "SHA256", "SHA384", "SHA512" are supported.
+  amdcuid_status_t set_hmac_algorithm(const char *digest_name);
+  amdcuid_status_t set_hmac_key(const uint8_t key_data[key_length]);
+  amdcuid_status_t generate_key(uint8_t key[key_length]);
+
+  std::string key_file_path = "/opt/amdcuid/etc/hmac_key.bin";
 };
 
 #endif // HMAC_H

--- a/projects/cuid/tests/CMakeLists.txt
+++ b/projects/cuid/tests/CMakeLists.txt
@@ -18,36 +18,49 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.10)
-
 # Find required packages
-find_package(GTest REQUIRED)
-find_package(OpenSSL REQUIRED)
+find_package(GTest CONFIG QUIET)
+# fallback to CMake module if GTest is not found via config
+if(NOT GTest_FOUND)
+    find_package(GTest MODULE QUIET)
+endif()
+# If GTest is still not found, we'll fetch it from source in the next step.
+if(NOT GTest_FOUND)
+    # Download and compile googletest to ensure it's available
+    message("GTest not found on system. Fetching from source...")
+    include(FetchContent)
+    FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.14.0
+    )
+    FetchContent_MakeAvailable(googletest)
+endif()
 
-# Enable testing
-enable_testing()
-
-# Unit tests executable
-add_executable(
-    amdcuid_test
+set(AMDCUID_TST_EXECUTABLE amdcuid_test)
+set(UNIT_TEST_SOURCES
     unit/cuid_api_test.cc
     unit/cuid_misc_test.cc
     functional/cuid_reverse_lookup_test.cc
 )
 
+# Enable testing
+enable_testing()
+
+# Unit tests executable
+add_executable(amdcuid_test ${UNIT_TEST_SOURCES})
+
 target_include_directories(amdcuid_test PRIVATE ${CMAKE_SOURCE_DIR}/lib)
 
 target_link_libraries(
-    amdcuid_test
+    ${AMDCUID_TST_EXECUTABLE}
     amdcuid_static
     GTest::GTest
     GTest::Main
-    OpenSSL::SSL
-    OpenSSL::Crypto
 )
 
 # Register tests with CTest
-add_test(NAME cuid_unit_tests COMMAND amdcuid_test)
+add_test(NAME cuid_unit_tests COMMAND ${AMDCUID_TST_EXECUTABLE})
 
 # Platform-specific config directory
 if(WIN32)
@@ -57,4 +70,8 @@ else()
 endif()
 
 # Install the test binary
-install(TARGETS amdcuid_test DESTINATION ${TESTS_INSTALL_DIR} COMPONENT tests)
+install(
+    TARGETS ${AMDCUID_TST_EXECUTABLE}
+    DESTINATION ${TESTS_INSTALL_DIR}
+    COMPONENT tests
+)


### PR DESCRIPTION
## Motivation
CUID library was failing to build on systems with older OpenSSL versions

## Technical Details
reimplements hmac code to work with both older OpenSSL version and Windows native bcrypt library for eventual Windows expansion.

## JIRA ID
N/A