### PR TITLE
perfxpert: harden git install and private SDK path

### DIFF
--- a/experimental/python/perfxpert/README.md
+++ b/experimental/python/perfxpert/README.md
@@ -118,6 +118,7 @@ flowchart TD
   classDef entry fill:#e8f3ff,stroke:#1664ad,color:#0f2f4a,stroke-width:1px
   classDef runtime fill:#fff4d8,stroke:#a66a00,color:#4a3100,stroke-width:1px
   classDef agent fill:#eaf8ef,stroke:#227343,color:#143b26,stroke-width:1px
+  classDef brain fill:#fff8c7,stroke:#9a6b00,color:#3d2b00,stroke-width:2px
   classDef guard fill:#ffe9e4,stroke:#b94a36,color:#5c2016,stroke-width:1px
   classDef data fill:#f4edff,stroke:#7250b5,color:#34205c,stroke-width:1px
 
@@ -128,8 +129,11 @@ flowchart TD
     api["perfxpert.api<br/>Python embedding"]
   end
 
-  runtime["Shared agent runtime/session<br/>same analysis brain for every shell"]
-  hierarchy["8-agent hierarchy<br/>Root → Analysis / Recommendation / Correctness<br/>Compute / Memory / Latency / Diff specialists"]
+  subgraph brainSection["🧠 Shared PerfXpert brain"]
+    runtime["Shared agent runtime/session<br/>same analysis brain for every shell"]
+    hierarchy["8-agent hierarchy<br/>Root → Analysis / Recommendation / Correctness<br/>Compute / Memory / Latency / Diff specialists"]
+  end
+
   knowledge["Deterministic tools + validated knowledge YAMLs<br/>classifiers, counters, hardware facts, trace diff"]
   gates["Correctness middleware<br/>gate_cascade + intent router"]
   readonly["56 READ_ONLY MCP tools<br/>8 agent tools + 47 classifier/knowledge tools + 1 diff tool"]
@@ -145,8 +149,7 @@ flowchart TD
   knowledge --> gates
 
   class analyze,code,mcp,api entry
-  class runtime runtime
-  class hierarchy agent
+  class runtime,hierarchy brain
   class gates guard
   class knowledge,readonly data
 ```

--- a/experimental/python/perfxpert/README.md
+++ b/experimental/python/perfxpert/README.md
@@ -13,89 +13,40 @@ AI-powered AMD ROCm GPU trace analysis.
 
 ## Quickstart
 
-### Prerequisites
-
-- Python 3.10+
-- `curl`, `git`, `unzip`, `python3-venv`, and `python3-pip` for the GitHub install
-  path. On Ubuntu 24+ and other externally managed Python environments,
-  create and activate a virtual environment before running pip.
-  For the RHEL 9/10 and SLES package-manager variants, see the detailed
-  install guide; RHEL 9 and SLES use versioned Python package names.
-- No separate `opencode` install is needed when using the GitHub wrapper below.
-  The wrapper bootstraps the required build tool and verifies that the patched
-  bundled `perfxpert-code` binary was built from the pinned PerfXpert submodule.
-  See [docs/guides/getting-started.md](docs/guides/getting-started.md) for
-  source/editable install details, the Ubuntu / RHEL / SLES package setup
-  matrix, and opt-out envs.
-- (Optional) `claude`, `codex`, or `gemini` CLI on PATH for multi-backend dispatch.
-
 ### Install
 
-> **Ubuntu 24 / clean-container setup:** use a virtual environment for
-> GitHub installs, and install the OS-level prerequisites first:
->
-> ```bash
-> # SKIP-SAMPLE — host package install + virtual environment creation
-> apt install -y curl git unzip python3-venv python3-pip
-> python3 -m venv .venv
-> . .venv/bin/activate
-> ```
->
-> If the venv's pip/setuptools are too old and metadata preparation fails,
-> upgrade them inside the venv and retry:
->
-> ```bash
-> # SKIP-SAMPLE — only needed for older venv toolchains
-> python -m pip install -U pip setuptools wheel
-> ```
+```bash
+# SKIP-SAMPLE — package install + venv setup are host-specific
+# Ubuntu 22/24 example. Use the package-manager equivalent on RHEL/SLES.
+apt install -y curl git unzip python3-venv python3-pip
+python3 -m venv .venv
+. .venv/bin/activate
+
+# Latest development build from ROCm/rocm-systems.
+REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
+```
+
+Pin a tag or commit by changing `REF`:
 
 ```bash
-# SKIP-SAMPLE — install from PyPI (when published)
+# SKIP-SAMPLE — replace <SHA> with a real tag or commit
+REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
+```
+
+The wrapper installs from GitHub, scopes submodule init to the pinned
+PerfXpert `opencode` submodule, and bootstraps bun when needed. It
+builds the patched bundled `perfxpert-code` binary and verifies it before exiting.
+No separate `opencode` install is needed for the default `perfxpert-code`
+TUI. See [docs/guides/getting-started.md](docs/guides/getting-started.md)
+for the Ubuntu/RHEL/SLES package matrix, direct-pip equivalent, editable
+installs, and troubleshooting.
+
+PyPI install, when published:
+
+```bash
+# SKIP-SAMPLE — install from PyPI after publication
 pip install "perfxpert[all]"
 ```
-
-To install the latest development build direct from the rocm-systems
-monorepo on GitHub, use the wrapper script. It scopes submodule init to
-the pinned PerfXpert `opencode` submodule, builds the patched bundled
-binary, and verifies `perfxpert-code` before exiting:
-
-```bash
-# SKIP-SAMPLE — latest develop branch, no local clone needed
-REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
-# Pin a tag / SHA or pass pip flags after the ref:
-# REF=v0.2.0; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
-# REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
-# REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}" --user
-# REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}" --extras ''
-```
-
-The README keeps the supported customer-facing install flow on the
-wrapper. The internal getting-started guide documents the verbose
-direct-pip equivalent and the submodule-scope rationale in detail.
-
-Both GitHub install paths require `git` on PATH because pip shells out
-to `git clone`. The supported Ubuntu 24+ path is a virtual environment;
-the wrapper exits early on externally managed system Python and points
-users at `python3 -m venv`. It prefers the active `python`, then
-`python3`, and only falls back to another already-installed
-`python3.10+` binary on PATH when the distro default is too old; it
-never downloads a separate Python runtime. During the pip build, `setup.py`
-bootstraps bun when needed so the bundled patched opencode binary is built
-from the pinned perfxpert submodule and `perfxpert-code` is ready end to
-end.
-
-The GitHub wrapper path has been validated in clean containers for
-Ubuntu 22.04, Ubuntu 24.04, UBI/RHEL 9, UBI/RHEL 10, and SLES 15.6.
-On UBI/RHEL, keep the distro's existing `curl` provider if present
-(`curl-minimal` satisfies the requirement); do not force-replace it
-with the full `curl` package.
-
-`[all]` pulls in the optional LLM providers (`anthropic`, `openai`,
-`litellm`) plus `rich` for pretty terminal output. That covers the
-hosted/local SDK-backed provider paths; the default patched `opencode`
-path is validated separately through the launcher/build flow. The GitHub
-wrapper verifies that the bundled patched `perfxpert-code` build completes
-during install. Pick a provider with `--llm <name>`.
 
 ### LLM Providers
 
@@ -113,49 +64,54 @@ Private endpoint example:
 # SKIP-SAMPLE — requires a real trace.db and reachable private endpoint
 export PERFXPERT_LLM_PRIVATE_URL="https://llm-api.iexample.com/OpenAI"
 export PERFXPERT_LLM_PRIVATE_MODEL="gpt-5.3-codex"
-# Required by CLI preflight; use a real key or a gateway-accepted placeholder
-# if authentication is entirely header-based.
 export PERFXPERT_LLM_PRIVATE_API_KEY="..."
-export PERFXPERT_LLM_PRIVATE_HEADERS='{
-  "Ocp-Apim-Subscription-Key": ".......",
-  "user": ".....",
-  "api-version": "preview"
-}'
+export PERFXPERT_LLM_PRIVATE_HEADERS='{"Ocp-Apim-Subscription-Key":".......","user":".....","api-version":"preview"}'
 perfxpert analyze -i trace.db --llm private
 ```
 
-### Run
+### Analyze
 
 ```bash
-# SKIP-SAMPLE — requires an existing rocprofv3 trace DB
-# One-shot analysis (batch mode)
+# SKIP-SAMPLE — requires a real trace.db and provider credentials
+export ANTHROPIC_API_KEY="sk-ant-..."
 perfxpert analyze -i trace.db --llm anthropic --format webview -o report.html
 
-# SKIP-SAMPLE — launches interactive TUI
-# Interactive agentic TUI (default patched opencode path)
+export OPENAI_API_KEY="sk-..."
+perfxpert analyze -i trace.db --llm openai --llm-model gpt-4o-mini --format markdown -o report.md
+
+PERFXPERT_AIRGAP=1 perfxpert analyze -i trace.db --format markdown -o report.md
+```
+
+### Interactive TUI
+
+```bash
+# SKIP-SAMPLE — launches interactive CLIs and may write backend config
+# Default first-class TUI: bundled patched opencode built during install.
 perfxpert-code
 
-# SKIP-SAMPLE — multi-backend dispatch (requires the native CLI installed)
-# Claude / Codex / Gemini native CLIs with perfxpert MCP wired in:
-perfxpert-code claude   # installs perfxpert MCP + gate into Claude Code, execs claude
-perfxpert-code codex    # same for Codex CLI (trust-gate workflow)
-perfxpert-code gemini   # same for Gemini CLI
-perfxpert-code claude --dry-run "analyze this trace"   # preview, write nothing
-perfxpert-code uninstall claude   # reverses install (refuses on marker drift)
+# Use native shells with PerfXpert MCP and context installed for that backend.
+perfxpert-code claude
+perfxpert-code codex
+perfxpert-code gemini
 
-# SKIP-SAMPLE — requires an existing rocprofv3 trace DB
-# Air-gap mode (no LLM; deterministic rule-based analysis only)
-PERFXPERT_AIRGAP=1 perfxpert analyze -i trace.db --format markdown -o report.md
+# Explicit upstream-opencode escape hatch. The default TUI does not need this.
+PERFXPERT_OPENCODE_PATH="$(command -v opencode)" perfxpert-code opencode
+```
 
-# SKIP-SAMPLE — requires two rocprofv3 trace DBs (baseline + candidate)
-# Diff two runs (schema-0.3.1 trace_diff block — per-kernel deltas + verdict)
+Preview or uninstall a backend integration:
+
+```bash
+# SKIP-SAMPLE — preview/uninstall commands mutate or inspect backend setup
+perfxpert-code claude --dry-run "analyze this trace"
+perfxpert-code uninstall claude
+```
+
+### Other Commands
+
+```bash
+# SKIP-SAMPLE — requires real trace DB paths
 perfxpert diff baseline.db candidate.db --format markdown
-
-# SKIP-SAMPLE — CI wrapper; rc=1 on regression, rc=0 otherwise
-# Regression gate for CI pipelines (wraps `diff` + fails the build if slower)
 perfxpert ci baseline.db candidate.db --threshold 3.0
-
-# Health check
 perfxpert doctor
 ```
 

--- a/experimental/python/perfxpert/README.md
+++ b/experimental/python/perfxpert/README.md
@@ -41,13 +41,6 @@ TUI. See [docs/guides/getting-started.md](docs/guides/getting-started.md)
 for the Ubuntu/RHEL/SLES package matrix, direct-pip equivalent, editable
 installs, and troubleshooting.
 
-PyPI install, when published:
-
-```bash
-# SKIP-SAMPLE — install from PyPI after publication
-pip install "perfxpert[all]"
-```
-
 ### LLM Providers
 
 | Provider | Source | Typical use |

--- a/experimental/python/perfxpert/README.md
+++ b/experimental/python/perfxpert/README.md
@@ -67,6 +67,10 @@ perfxpert analyze -i trace.db --llm private
 `--format` accepts `text` (default), `json`, `markdown`, and `webview`
 (AMD-themed HTML).
 
+LLM-backed analysis uses Chat Completions-style requests. Choose a provider
+model or private endpoint model that supports the Chat Completions API;
+Responses-only, embeddings-only, or non-chat models will fail.
+
 ```bash
 # SKIP-SAMPLE — requires a real trace.db and provider credentials
 export ANTHROPIC_API_KEY="sk-ant-..."

--- a/experimental/python/perfxpert/README.md
+++ b/experimental/python/perfxpert/README.md
@@ -72,6 +72,7 @@ perfxpert analyze -i trace.db --llm anthropic --format webview -o report.html
 export OPENAI_API_KEY="sk-..."
 perfxpert analyze -i trace.db --llm openai --llm-model gpt-4o-mini --format markdown -o report.md
 
+# Air-gap mode: no LLM calls, deterministic local analysis only.
 PERFXPERT_AIRGAP=1 perfxpert analyze -i trace.db --format markdown -o report.md
 ```
 

--- a/experimental/python/perfxpert/README.md
+++ b/experimental/python/perfxpert/README.md
@@ -16,23 +16,44 @@ AI-powered AMD ROCm GPU trace analysis.
 ### Prerequisites
 
 - Python 3.10+
+- `curl`, `git`, `python3-venv`, and `python3-pip` for the GitHub install
+  path. On Ubuntu 24+ and other externally managed Python environments,
+  create and activate a virtual environment before running pip.
+  For the RHEL 9/10 and SLES package-manager variants, see the detailed
+  install guide; RHEL 9 and SLES use versioned Python package names.
 - `bun` on PATH if you want the patched `opencode` build produced during
   `pip install`. Packaged installs bundle that build; source/editable
   checkouts can rebuild the same pinned fork locally. The build hook
   does not auto-download bun; if bun is missing, install still succeeds
-  and only the patched launcher build is skipped. See
+  and only the patched launcher build is skipped. `perfxpert analyze`,
+  `perfxpert-mcp`, and the Python API still work; `perfxpert-code`
+  needs either `perfxpert-code install-patches` once bun is available,
+  or an existing `opencode` binary on PATH / `PERFXPERT_OPENCODE_PATH`.
+  Install bun with `curl -fsSL https://bun.sh/install | bash` when you
+  need to enable the interactive TUI later.
+  See
   [docs/guides/getting-started.md](docs/guides/getting-started.md)
   for the exact install contract and opt-out envs.
 - (Optional) `claude`, `codex`, or `gemini` CLI on PATH for multi-backend dispatch.
 
 ### Install
 
-> **First-time tip (stock Ubuntu / `rocm/dev-ubuntu-22.04` images):** the
-> default pip (22.x) misreads perfxpert's PEP-621 metadata and aborts the
-> wheel build. Upgrade pip once before installing:
+> **Ubuntu 24 / clean-container setup:** use a virtual environment for
+> GitHub installs, and install the OS-level prerequisites first:
 >
 > ```bash
-> pip install -U pip setuptools wheel
+> # SKIP-SAMPLE — host package install + virtual environment creation
+> apt install -y curl git python3-venv python3-pip
+> python3 -m venv .venv
+> . .venv/bin/activate
+> ```
+>
+> If the venv's pip/setuptools are too old and metadata preparation fails,
+> upgrade them inside the venv and retry:
+>
+> ```bash
+> # SKIP-SAMPLE — only needed for older venv toolchains
+> python -m pip install -U pip setuptools wheel
 > ```
 
 ```bash
@@ -45,38 +66,36 @@ monorepo on GitHub, use the wrapper script (~5 sec instead of
 ~5 min — details below):
 
 ```bash
-# SKIP-SAMPLE — first clone the repo (no recursive submodules), then run
-git clone --depth 1 --no-recurse-submodules https://github.com/ROCm/rocm-systems.git
-bash rocm-systems/experimental/python/perfxpert/scripts/pip-install-from-git.sh
-# Pass a ref / pip flags as positional args:
-#   scripts/pip-install-from-git.sh v0.2.0
-#   scripts/pip-install-from-git.sh <SHA> --user
+# SKIP-SAMPLE — latest develop branch, no local clone needed
+REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
+# Pin a tag / SHA or pass pip flags after the ref:
+# REF=v0.2.0; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
+# REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
+# REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}" --user
+# REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}" --extras ''
 ```
 
-Or invoke pip directly with the submodule-scope env vars set
-(equivalent to the wrapper, just verbose):
+The README keeps the supported customer-facing install flow on the
+wrapper. The internal getting-started guide documents the verbose
+direct-pip equivalent and the submodule-scope rationale in detail.
 
-```bash
-# SKIP-SAMPLE — pip directly, scoped submodule init
-GIT_CONFIG_COUNT=1 \
-GIT_CONFIG_KEY_0=submodule.active \
-GIT_CONFIG_VALUE_0=experimental/python/perfxpert/opencode \
-  pip install "perfxpert[all] @ git+https://github.com/ROCm/rocm-systems.git#subdirectory=experimental/python/perfxpert"
-```
-
-The plain `pip install "perfxpert @ git+…"` one-liner still works but
-triggers pip's full recursive submodule init over the ~34 unrelated
-submodules declared at the rocm-systems repo root — 3-6 min of wasted
-network on stock `rocm/dev-ubuntu-22.04`. The wrapper script scopes
-the init down to just the opencode submodule perfxpert's build hook
-actually needs; see `docs/guides/getting-started.md` §1.2 for the
-measurements.
+Both GitHub install paths require `git` on PATH because pip shells out
+to `git clone`. The supported Ubuntu 24+ path is a virtual environment;
+the wrapper exits early on externally managed system Python and points
+users at `python3 -m venv`. It prefers the active `python`, then
+`python3`, and only falls back to another already-installed
+`python3.10+` binary on PATH when the distro default is too old; it
+never downloads a separate Python runtime.
 
 `[all]` pulls in the optional LLM providers (`anthropic`, `openai`,
 `litellm`) plus `rich` for pretty terminal output. That covers the
 hosted/local SDK-backed provider paths; the default patched `opencode`
-path is validated separately through the launcher/build flow. Pick a
-provider with `--llm <name>`.
+path is validated separately through the launcher/build flow. If bun is
+absent during install, `perfxpert analyze`, `perfxpert-mcp`, and the
+Python API still install cleanly, but `perfxpert-code` will ask you to
+install bun with `curl -fsSL https://bun.sh/install | bash`, then run
+`perfxpert-code install-patches`, or point `PERFXPERT_OPENCODE_PATH` at
+an existing binary. Pick a provider with `--llm <name>`.
 
 ### Run
 
@@ -156,14 +175,10 @@ binary until bun is available. As a last resort, set
 
 Advanced: for tightly-sandboxed CI where neither bun nor network access
 is available, set `PERFXPERT_SKIP_BUNDLED_BUILD=1` before
-`pip install` to suppress the build attempt entirely:
-
-```bash
-# SKIP-SAMPLE — actual installer; scripts/test-samples.py must not execute this
-curl -fsSL https://opencode.ai/install | bash
-```
-
-Or point `PERFXPERT_OPENCODE_PATH` at an existing opencode binary.
+`pip install` to suppress the build attempt entirely. When bun becomes
+available again, run `perfxpert-code install-patches` to build the
+repo-pinned patched binary, or point `PERFXPERT_OPENCODE_PATH` at an
+existing patched opencode binary.
 
 ## Contributing
 

--- a/experimental/python/perfxpert/README.md
+++ b/experimental/python/perfxpert/README.md
@@ -64,6 +64,9 @@ perfxpert analyze -i trace.db --llm private
 
 ### Analyze
 
+`--format` accepts `text` (default), `json`, `markdown`, and `webview`
+(AMD-themed HTML).
+
 ```bash
 # SKIP-SAMPLE — requires a real trace.db and provider credentials
 export ANTHROPIC_API_KEY="sk-ant-..."
@@ -162,14 +165,6 @@ an [RFC](docs/rfcs/README.md).
 |------|---------|---------|
 | `PERFXPERT_OPENCODE_PATH` | unset | Explicit upstream-opencode escape hatch used only by `perfxpert-code opencode ...`; the default TUI ignores it |
 
-The agentic runtime is the sole execution path; no feature flag
-toggles it. Setting any of the following has no effect:
-
-- `PERFXPERT_USE_AGENTS` — removed in Phase 7.1.
-- `PERFXPERT_LEGACY` — removed in Phase 7.1.
-
-See [CHANGELOG.md](CHANGELOG.md) for the removal history.
-
 ## Supported GPUs
 
 | Arch | GPU | CDNA/RDNA |
@@ -180,10 +175,6 @@ See [CHANGELOG.md](CHANGELOG.md) for the removal history.
 | gfx950 | MI350X/MI355X | CDNA4 |
 | gfx1030 | RX 6900 XT | RDNA2 |
 | gfx1100 | RX 7900 XTX | RDNA3 |
-
-## Output formats
-
-`--format` accepts: `text` (default), `json`, `markdown`, `webview` (AMD-themed HTML).
 
 ## Documentation
 

--- a/experimental/python/perfxpert/README.md
+++ b/experimental/python/perfxpert/README.md
@@ -16,24 +16,16 @@ AI-powered AMD ROCm GPU trace analysis.
 ### Prerequisites
 
 - Python 3.10+
-- `curl`, `git`, `python3-venv`, and `python3-pip` for the GitHub install
+- `curl`, `git`, `unzip`, `python3-venv`, and `python3-pip` for the GitHub install
   path. On Ubuntu 24+ and other externally managed Python environments,
   create and activate a virtual environment before running pip.
   For the RHEL 9/10 and SLES package-manager variants, see the detailed
   install guide; RHEL 9 and SLES use versioned Python package names.
-- `bun` on PATH if you want the patched `opencode` build produced during
-  `pip install`. Packaged installs bundle that build; source/editable
-  checkouts can rebuild the same pinned fork locally. The build hook
-  does not auto-download bun; if bun is missing, install still succeeds
-  and only the patched launcher build is skipped. `perfxpert analyze`,
-  `perfxpert-mcp`, and the Python API still work; `perfxpert-code`
-  needs either `perfxpert-code install-patches` once bun is available,
-  or an existing `opencode` binary on PATH / `PERFXPERT_OPENCODE_PATH`.
-  Install bun with `curl -fsSL https://bun.sh/install | bash` when you
-  need to enable the interactive TUI later.
-  See
-  [docs/guides/getting-started.md](docs/guides/getting-started.md)
-  for the exact install contract and opt-out envs.
+- No separate `opencode` install is needed when using the GitHub wrapper below.
+  The wrapper bootstraps the required build tool and verifies that the patched
+  bundled `perfxpert-code` binary was built from the pinned PerfXpert submodule.
+  See [docs/guides/getting-started.md](docs/guides/getting-started.md) for
+  source/editable install details and opt-out envs.
 - (Optional) `claude`, `codex`, or `gemini` CLI on PATH for multi-backend dispatch.
 
 ### Install
@@ -43,7 +35,7 @@ AI-powered AMD ROCm GPU trace analysis.
 >
 > ```bash
 > # SKIP-SAMPLE — host package install + virtual environment creation
-> apt install -y curl git python3-venv python3-pip
+> apt install -y curl git unzip python3-venv python3-pip
 > python3 -m venv .venv
 > . .venv/bin/activate
 > ```
@@ -62,8 +54,9 @@ pip install "perfxpert[all]"
 ```
 
 To install the latest development build direct from the rocm-systems
-monorepo on GitHub, use the wrapper script (~5 sec instead of
-~5 min — details below):
+monorepo on GitHub, use the wrapper script. It scopes submodule init to
+the pinned PerfXpert `opencode` submodule, builds the patched bundled
+binary, and verifies `perfxpert-code` before exiting:
 
 ```bash
 # SKIP-SAMPLE — latest develop branch, no local clone needed
@@ -85,17 +78,17 @@ the wrapper exits early on externally managed system Python and points
 users at `python3 -m venv`. It prefers the active `python`, then
 `python3`, and only falls back to another already-installed
 `python3.10+` binary on PATH when the distro default is too old; it
-never downloads a separate Python runtime.
+never downloads a separate Python runtime. During the pip build, `setup.py`
+bootstraps bun when needed so the bundled patched opencode binary is built
+from the pinned perfxpert submodule and `perfxpert-code` is ready end to
+end.
 
 `[all]` pulls in the optional LLM providers (`anthropic`, `openai`,
 `litellm`) plus `rich` for pretty terminal output. That covers the
 hosted/local SDK-backed provider paths; the default patched `opencode`
-path is validated separately through the launcher/build flow. If bun is
-absent during install, `perfxpert analyze`, `perfxpert-mcp`, and the
-Python API still install cleanly, but `perfxpert-code` will ask you to
-install bun with `curl -fsSL https://bun.sh/install | bash`, then run
-`perfxpert-code install-patches`, or point `PERFXPERT_OPENCODE_PATH` at
-an existing binary. Pick a provider with `--llm <name>`.
+path is validated separately through the launcher/build flow. The GitHub
+wrapper verifies that the bundled patched `perfxpert-code` build completes
+during install. Pick a provider with `--llm <name>`.
 
 ### Run
 
@@ -160,25 +153,18 @@ perfxpert doctor
 ```
 
 Core analysis is self-contained — `pip install perfxpert` handles all
-profiling + recommendation features. `perfxpert-code` defaults to the
-patched opencode path: packaged installs use the bundled AMD-branded
-binary, while source/editable checkouts can rebuild the same pinned
-`sst/opencode` fork locally from
-`experimental/python/perfxpert/opencode` plus our patch series
-(`experimental/python/perfxpert/.patches/`) when `bun` is on PATH.
+profiling + recommendation features. The default `perfxpert-code` path
+uses only the bundled AMD-branded opencode binary built from the pinned
+`experimental/python/perfxpert/opencode` submodule plus the local patch
+series. If the build prerequisites are missing, pip fails with the
+missing package-manager pieces instead of falling back to an arbitrary
+opencode binary.
 
-If `bun` is missing, the install still succeeds (library + analyze + MCP
-paths all work). Packaged installs then miss the bundled patched build,
-and source/editable checkouts cannot rebuild the repo-local patched
-binary until bun is available. As a last resort, set
-`PERFXPERT_OPENCODE_PATH` to point at a patched opencode binary.
-
-Advanced: for tightly-sandboxed CI where neither bun nor network access
-is available, set `PERFXPERT_SKIP_BUNDLED_BUILD=1` before
-`pip install` to suppress the build attempt entirely. When bun becomes
-available again, run `perfxpert-code install-patches` to build the
-repo-pinned patched binary, or point `PERFXPERT_OPENCODE_PATH` at an
-existing patched opencode binary.
+Advanced: `PERFXPERT_SKIP_BUNDLED_BUILD=1` is only for tightly-sandboxed
+CI that intentionally skips the interactive TUI build. Users who
+explicitly want their own upstream opencode can run
+`perfxpert-code opencode ...`; the default `perfxpert-code` command
+continues to require the bundled submodule-built binary.
 
 ## Contributing
 
@@ -191,7 +177,7 @@ an [RFC](docs/rfcs/README.md).
 
 | Flag | Default | Purpose |
 |------|---------|---------|
-| `PERFXPERT_OPENCODE_PATH` | system PATH | Override path to opencode binary; point this at a patched build if you need the full perfxpert gate behavior |
+| `PERFXPERT_OPENCODE_PATH` | unset | Explicit upstream-opencode escape hatch used only by `perfxpert-code opencode ...`; the default TUI ignores it |
 
 The agentic runtime is the sole execution path; no feature flag
 toggles it. Setting any of the following has no effect:

--- a/experimental/python/perfxpert/README.md
+++ b/experimental/python/perfxpert/README.md
@@ -65,7 +65,9 @@ perfxpert analyze -i trace.db --llm private
 ### Analyze
 
 `--format` accepts `text` (default), `json`, `markdown`, and `webview`
-(AMD-themed HTML).
+(AMD-themed HTML). `text` prints to stdout unless `-o/-d` is supplied;
+all other formats write a report file by default, even when `-o` and `-d`
+are omitted.
 
 LLM-backed analysis uses Chat Completions-style requests. Choose a provider
 model or private endpoint model that supports the Chat Completions API;

--- a/experimental/python/perfxpert/README.md
+++ b/experimental/python/perfxpert/README.md
@@ -113,44 +113,50 @@ perfxpert doctor
 
 ## Architecture (v0.2.0+)
 
-```
-┌────────────────────────────────────────────────────────────┐
-│  User shell                                                 │
-│  ┌─────────────┐  ┌──────────────┐  ┌──────────────────┐  │
-│  │ perfxpert   │  │ perfxpert-   │  │ Library API       │  │
-│  │ analyze     │  │ code (TUI)   │  │ (Python)          │  │
-│  └──────┬──────┘  └──────┬───────┘  └────────┬──────────┘  │
-│         │                │                    │             │
-│         └────────────────┴────────────────────┘             │
-│                          │                                   │
-│                          ▼                                   │
-│             OpenAI Agents SDK hierarchy                      │
-│   (Root → Analysis → Recommendation → Specialists)           │
-│   — all 8 agents callable via MCP + perfxpert.api            │
-│                          │                                   │
-│                          ▼                                   │
-│    Deterministic middleware (gate_cascade, intent router)    │
-│                          │                                   │
-│                          ▼                                   │
-│  56 READ_ONLY MCP tools (8 agent + 47 classifier + 1 diff)   │
-│            + ~22 knowledge YAMLs                             │
-│                                                              │
-└────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+  classDef entry fill:#e8f3ff,stroke:#1664ad,color:#0f2f4a,stroke-width:1px
+  classDef runtime fill:#fff4d8,stroke:#a66a00,color:#4a3100,stroke-width:1px
+  classDef agent fill:#eaf8ef,stroke:#227343,color:#143b26,stroke-width:1px
+  classDef guard fill:#ffe9e4,stroke:#b94a36,color:#5c2016,stroke-width:1px
+  classDef data fill:#f4edff,stroke:#7250b5,color:#34205c,stroke-width:1px
+
+  subgraph entry["Entry surfaces"]
+    analyze["perfxpert analyze<br/>batch reports"]
+    code["perfxpert-code<br/>bundled patched TUI"]
+    mcp["perfxpert-mcp<br/>external MCP clients"]
+    api["perfxpert.api<br/>Python embedding"]
+  end
+
+  runtime["Shared agent runtime/session<br/>same analysis brain for every shell"]
+  hierarchy["8-agent hierarchy<br/>Root → Analysis / Recommendation / Correctness<br/>Compute / Memory / Latency / Diff specialists"]
+  knowledge["Deterministic tools + validated knowledge YAMLs<br/>classifiers, counters, hardware facts, trace diff"]
+  gates["Correctness middleware<br/>gate_cascade + intent router"]
+  readonly["56 READ_ONLY MCP tools<br/>8 agent tools + 47 classifier/knowledge tools + 1 diff tool"]
+
+  analyze --> runtime
+  code --> runtime
+  api --> runtime
+  mcp --> readonly
+  readonly --> runtime
+  runtime --> hierarchy
+  hierarchy --> knowledge
+  hierarchy --> gates
+  knowledge --> gates
+
+  class analyze,code,mcp,api entry
+  class runtime runtime
+  class hierarchy agent
+  class gates guard
+  class knowledge,readonly data
 ```
 
-Core analysis is self-contained — `pip install perfxpert` handles all
-profiling + recommendation features. The default `perfxpert-code` path
-uses only the bundled AMD-branded opencode binary built from the pinned
+The GitHub wrapper is the supported install path today. It installs
+PerfXpert and builds the default `perfxpert-code` TUI from the pinned
 `experimental/python/perfxpert/opencode` submodule plus the local patch
-series. If the build prerequisites are missing, pip fails with the
-missing package-manager pieces instead of falling back to an arbitrary
-opencode binary.
-
-Advanced: `PERFXPERT_SKIP_BUNDLED_BUILD=1` is only for tightly-sandboxed
-CI that intentionally skips the interactive TUI build. Users who
-explicitly want their own upstream opencode can run
-`perfxpert-code opencode ...`; the default `perfxpert-code` command
-continues to require the bundled submodule-built binary.
+series. If build prerequisites are missing, install fails with
+package-manager guidance instead of falling back to an arbitrary opencode
+binary.
 
 ## Contributing
 

--- a/experimental/python/perfxpert/README.md
+++ b/experimental/python/perfxpert/README.md
@@ -25,7 +25,8 @@ AI-powered AMD ROCm GPU trace analysis.
   The wrapper bootstraps the required build tool and verifies that the patched
   bundled `perfxpert-code` binary was built from the pinned PerfXpert submodule.
   See [docs/guides/getting-started.md](docs/guides/getting-started.md) for
-  source/editable install details and opt-out envs.
+  source/editable install details, the Ubuntu / RHEL / SLES package setup
+  matrix, and opt-out envs.
 - (Optional) `claude`, `codex`, or `gemini` CLI on PATH for multi-backend dispatch.
 
 ### Install
@@ -83,12 +84,45 @@ bootstraps bun when needed so the bundled patched opencode binary is built
 from the pinned perfxpert submodule and `perfxpert-code` is ready end to
 end.
 
+The GitHub wrapper path has been validated in clean containers for
+Ubuntu 22.04, Ubuntu 24.04, UBI/RHEL 9, UBI/RHEL 10, and SLES 15.6.
+On UBI/RHEL, keep the distro's existing `curl` provider if present
+(`curl-minimal` satisfies the requirement); do not force-replace it
+with the full `curl` package.
+
 `[all]` pulls in the optional LLM providers (`anthropic`, `openai`,
 `litellm`) plus `rich` for pretty terminal output. That covers the
 hosted/local SDK-backed provider paths; the default patched `opencode`
 path is validated separately through the launcher/build flow. The GitHub
 wrapper verifies that the bundled patched `perfxpert-code` build completes
 during install. Pick a provider with `--llm <name>`.
+
+### LLM Providers
+
+| Provider | Source | Typical use |
+|----------|--------|-------------|
+| `anthropic` | Claude API | Production default; requires `ANTHROPIC_API_KEY` |
+| `openai` | OpenAI API | Alternative hosted; requires `OPENAI_API_KEY` |
+| `ollama` | Local Ollama | Fully local; requires a running `ollama serve` |
+| `private` | Any OpenAI-compatible endpoint | Internal deployments; requires `PERFXPERT_LLM_PRIVATE_URL` + `PERFXPERT_LLM_PRIVATE_MODEL`; CLI preflight also needs `PERFXPERT_LLM_PRIVATE_API_KEY` or `--llm-api-key` |
+| `opencode` | Bundled opencode CLI | Used by `perfxpert-code`; not callable from inside opencode itself (recursion-guarded) |
+
+Private endpoint example:
+
+```bash
+# SKIP-SAMPLE — requires a real trace.db and reachable private endpoint
+export PERFXPERT_LLM_PRIVATE_URL="https://llm-api.iexample.com/OpenAI"
+export PERFXPERT_LLM_PRIVATE_MODEL="gpt-5.3-codex"
+# Required by CLI preflight; use a real key or a gateway-accepted placeholder
+# if authentication is entirely header-based.
+export PERFXPERT_LLM_PRIVATE_API_KEY="..."
+export PERFXPERT_LLM_PRIVATE_HEADERS='{
+  "Ocp-Apim-Subscription-Key": ".......",
+  "user": ".....",
+  "api-version": "preview"
+}'
+perfxpert analyze -i trace.db --llm private
+```
 
 ### Run
 

--- a/experimental/python/perfxpert/README.md
+++ b/experimental/python/perfxpert/README.md
@@ -104,7 +104,6 @@ perfxpert-code uninstall claude
 ```bash
 # SKIP-SAMPLE — requires real trace DB paths
 perfxpert diff baseline.db candidate.db --format markdown
-perfxpert ci baseline.db candidate.db --threshold 3.0
 perfxpert doctor
 ```
 

--- a/experimental/python/perfxpert/docs/architecture.md
+++ b/experimental/python/perfxpert/docs/architecture.md
@@ -14,14 +14,37 @@ All four resolve into the same session/runtime layer in
 
 ## Agents (spec §2)
 
-```
-Root (intent router)
- ├─ Analysis  (classifies bottleneck, gathers metrics)
- ├─ Recommendation (hands off to specialists)
- │   ├─ compute_specialist
- │   ├─ memory_specialist
- │   └─ latency_specialist
- └─ Correctness (enforces 5 gates on proposed changes)
+```mermaid
+flowchart TD
+  classDef brain fill:#fff8c7,stroke:#9a6b00,color:#3d2b00,stroke-width:2px
+  classDef specialist fill:#eaf8ef,stroke:#227343,color:#143b26,stroke-width:1px
+
+  subgraph brainSection["🧠 PerfXpert agent brain"]
+    root["Root<br/>intent router"]
+    analysis["Analysis<br/>classifies bottlenecks + gathers metrics"]
+    recommendation["Recommendation<br/>hands off to specialists"]
+    correctness["Correctness<br/>summarizes gate verdicts"]
+  end
+
+  compute["compute_specialist"]
+  memory["memory_specialist"]
+  latency["latency_specialist"]
+  diff["diff_specialist"]
+
+  root --> analysis
+  root --> recommendation
+  root --> correctness
+  analysis --> compute
+  analysis --> memory
+  analysis --> latency
+  analysis --> diff
+  recommendation --> compute
+  recommendation --> memory
+  recommendation --> latency
+  recommendation --> diff
+
+  class root,analysis,recommendation,correctness brain
+  class compute,memory,latency,diff specialist
 ```
 
 8 agents total. Each has ≤ 400 lines of fence + ≤ 5 tools + ≤ 10 input / ≤ 5 output fields. Narrow scope is CI-enforced.
@@ -141,8 +164,6 @@ no longer present:
 
 - `interactive.py`, `llm_conversation.py` — bespoke LLM-session state machine (removed in Phase 7.1), superseded by OpenAI Agents SDK sessions.
 - `perfxpert/ai_analysis/` module — removed in Phase 7.1 and superseded by `perfxpert/agents/`.
-- `PERFXPERT_LEGACY` env var — no longer recognized (removed in Phase 7.1).
-- `PERFXPERT_USE_AGENTS` env var — no longer recognized (removed in Phase 7.1).
 
 Consult the git history or [CHANGELOG.md](../CHANGELOG.md) for the
 old code.

--- a/experimental/python/perfxpert/docs/architecture/agent-hierarchy.md
+++ b/experimental/python/perfxpert/docs/architecture/agent-hierarchy.md
@@ -38,25 +38,39 @@ Cross-links:
 
 ## Three tiers
 
-```
-                     ┌───────────────┐
-                     │     Root      │   Tier 0 — intent classify
-                     └───────┬───────┘
-                             │
-            ┌────────────────┼────────────────┐
-            ▼                ▼                ▼
-    ┌──────────────┐ ┌───────────────┐ ┌──────────────────┐
-    │   Analysis   │ │  Correctness  │ │  Recommendation  │   Tier 1
-    └───────┬──────┘ └───────────────┘ └────────┬─────────┘
-            │                                    │
-            └───────────────┬────────────────────┘
-                            ▼
-              ┌─────────┬────┴────┬────────────┐
-              ▼         ▼         ▼            ▼
-       ┌──────────┐ ┌────────┐ ┌────────┐ ┌────────┐
-       │ Compute  │ │ Memory │ │Latency │ │  Diff  │  Tier 2
-       │ special. │ │ spec.  │ │ spec.  │ │ spec.  │
-       └──────────┘ └────────┘ └────────┘ └────────┘
+```mermaid
+flowchart TD
+  classDef root fill:#e8f3ff,stroke:#1664ad,color:#0f2f4a,stroke-width:1px
+  classDef tier1 fill:#fff4d8,stroke:#a66a00,color:#4a3100,stroke-width:1px
+  classDef tier2 fill:#eaf8ef,stroke:#227343,color:#143b26,stroke-width:1px
+  classDef brain fill:#fff8c7,stroke:#9a6b00,color:#3d2b00,stroke-width:2px
+
+  subgraph brainSection["🧠 PerfXpert agent brain"]
+    root["Root<br/>Tier 0: intent classify"]
+    analysis["Analysis<br/>Tier 1: read traces + artifacts"]
+    correctness["Correctness<br/>Tier 1: verdicts and gate summaries"]
+    recommendation["Recommendation<br/>Tier 1: optimization strategy"]
+  end
+
+  compute["Compute specialist<br/>Tier 2"]
+  memory["Memory specialist<br/>Tier 2"]
+  latency["Latency specialist<br/>Tier 2"]
+  diff["Diff specialist<br/>Tier 2"]
+
+  root --> analysis
+  root --> correctness
+  root --> recommendation
+  analysis --> compute
+  analysis --> memory
+  analysis --> latency
+  analysis --> diff
+  recommendation --> compute
+  recommendation --> memory
+  recommendation --> latency
+  recommendation --> diff
+
+  class root,analysis,correctness,recommendation brain
+  class compute,memory,latency,diff tier2
 ```
 
 - **Tier 0 (Root)** — classifies the user's natural-language query

--- a/experimental/python/perfxpert/docs/guides/agentic-mode.md
+++ b/experimental/python/perfxpert/docs/guides/agentic-mode.md
@@ -129,12 +129,27 @@ Current entries:
 | `anthropic` | Claude API | Production default; requires `ANTHROPIC_API_KEY` |
 | `openai` | OpenAI API | Alternative hosted; requires `OPENAI_API_KEY` |
 | `ollama` | Local Ollama | Fully local; requires a running `ollama serve` |
-| `private` | Any OpenAI-compatible endpoint | Internal deployments; requires `PERFXPERT_LLM_PRIVATE_URL` + `PERFXPERT_LLM_PRIVATE_MODEL` |
+| `private` | Any OpenAI-compatible endpoint | Internal deployments; requires `PERFXPERT_LLM_PRIVATE_URL` + `PERFXPERT_LLM_PRIVATE_MODEL`; CLI preflight also needs `PERFXPERT_LLM_PRIVATE_API_KEY` or `--llm-api-key` |
 | `opencode` | Bundled opencode CLI | Used by `perfxpert-code`; not callable from inside opencode itself (recursion-guarded) |
 
 `perfxpert doctor` reports which providers are reachable from the
 current shell. See [contributing/providers.md](../contributing/providers.md)
 for how to register a new one.
+
+Private OpenAI-compatible endpoints use JSON for extra headers:
+
+```bash
+# SKIP-SAMPLE — requires a reachable private endpoint
+export PERFXPERT_LLM_PRIVATE_URL="https://llm-api.iexample.com/OpenAI"
+export PERFXPERT_LLM_PRIVATE_MODEL="gpt-5.3-codex"
+export PERFXPERT_LLM_PRIVATE_API_KEY="..."
+export PERFXPERT_LLM_PRIVATE_HEADERS='{
+  "Ocp-Apim-Subscription-Key": ".......",
+  "user": ".....",
+  "api-version": "preview"
+}'
+perfxpert analyze -i trace.db --llm private
+```
 
 ## Fallback chain (`PERFXPERT_LLM_FALLBACK_CHAIN`)
 

--- a/experimental/python/perfxpert/docs/guides/getting-started.md
+++ b/experimental/python/perfxpert/docs/guides/getting-started.md
@@ -64,7 +64,9 @@ backend CLI instead.
 
 ### Distro package setup
 
-Use a virtual environment for the supported install flow. Package setup
+Use a virtual environment for the supported install flow. The GitHub
+wrapper path has been validated in clean containers for Ubuntu 22.04,
+Ubuntu 24.04, UBI/RHEL 9, UBI/RHEL 10, and SLES 15.6. Package setup
 differs slightly by distro:
 
 ```bash
@@ -96,6 +98,10 @@ zypper install -y curl git unzip python311 python311-pip
 python3.11 -m venv .venv
 . .venv/bin/activate
 ```
+
+UBI/RHEL base images can provide `curl` through `curl-minimal`. That is
+valid for the wrapper and for pip's bun bootstrap; do not force dnf to
+replace it with the full `curl` package unless `command -v curl` fails.
 
 If the venv's pip/setuptools are too old and metadata preparation fails
 with `filename has 'perfxpert', but metadata has 'unknown'`, upgrade
@@ -221,10 +227,14 @@ Opt-outs:
 It applies all 26 patches in `.patches/` (AMD branding, color palette,
 per-model system-prompt preambles with the STRICT-TOOL-DISCIPLINE
 stanza, the tool-priority gate, and the deep-rebrand session UI) to the
-pinned `opencode` submodule, then runs `bun build` to produce the
-bundled binary at `perfxpert/_bundled/opencode`. Subsequent `pip install`
-invocations skip the rebuild if the binary is already newer than every
-patch file.
+pinned `opencode` submodule, runs the locked root `bun install`, then
+compiles the current-platform binary with `bun run build --single
+--skip-install`. The explicit `--skip-install` avoids opencode's
+secondary dynamic package install during the compile step; the locked
+install already populated the dependencies needed for the bundled
+binary. The final executable is copied to
+`perfxpert/_bundled/opencode`. Subsequent `pip install` invocations skip
+the rebuild if the binary is already newer than every patch file.
 
 **Opt-out:** set `PERFXPERT_SKIP_BUNDLED_BUILD=1` only in offline /
 sandboxed CI that intentionally skips the interactive TUI build.
@@ -970,7 +980,7 @@ a one-line stderr WARNING so you know which credential is active):
 |---------|-----------------|-----------------|-------|
 | `anthropic` | `ANTHROPIC_API_KEY` | `PERFXPERT_LLM_ANTHROPIC_KEY` | Either works; alias kept for migration parity |
 | `openai` | `OPENAI_API_KEY` | `PERFXPERT_LLM_OPENAI_KEY` | Either works |
-| `private` | `PERFXPERT_LLM_PRIVATE_API_KEY` | — | Plus `PERFXPERT_LLM_PRIVATE_URL` (required) |
+| `private` | `PERFXPERT_LLM_PRIVATE_API_KEY` | — | Plus `PERFXPERT_LLM_PRIVATE_URL` (required) and normally `PERFXPERT_LLM_PRIVATE_MODEL` |
 | `ollama` | — (no key) | — | Plus `PERFXPERT_LLM_LOCAL_URL` (default `http://localhost:11434`) |
 | `opencode` | — (no key) | — | Default `perfxpert-code` uses the bundled binary; `PERFXPERT_OPENCODE_PATH` is only for `perfxpert-code opencode ...` |
 
@@ -1232,8 +1242,8 @@ optional; all analysis runs locally without internet when you omit
 | `anthropic` | `ANTHROPIC_API_KEY` | Claude API (production default) |
 | `openai` | `OPENAI_API_KEY` | OpenAI hosted API |
 | `ollama` | `PERFXPERT_LLM_LOCAL_URL` (compat: `OLLAMA_HOST`, default `http://localhost:11434`) | Local Ollama daemon — fully offline once the model is pulled |
-| `private` | `PERFXPERT_LLM_PRIVATE_URL`, `PERFXPERT_LLM_PRIVATE_MODEL`, optional `PERFXPERT_LLM_PRIVATE_API_KEY`, optional `PERFXPERT_LLM_PRIVATE_HEADERS` (JSON), optional `PERFXPERT_LLM_PRIVATE_VERIFY_SSL=false` | Any OpenAI-compatible endpoint (enterprise / self-hosted) |
-| `opencode` | none required (bundled) | Bundled opencode CLI — subprocess wrapper |
+| `private` | `PERFXPERT_LLM_PRIVATE_URL`, `PERFXPERT_LLM_PRIVATE_MODEL`, `PERFXPERT_LLM_PRIVATE_API_KEY` or `--llm-api-key`, optional `PERFXPERT_LLM_PRIVATE_HEADERS` (JSON), optional `PERFXPERT_LLM_PRIVATE_VERIFY_SSL=false` | Any OpenAI-compatible endpoint (enterprise / self-hosted) |
+| `opencode` | none required (bundled) | Bundled opencode CLI — subprocess wrapper; recursion-guarded inside `perfxpert-code` |
 
 ```bash
 # SKIP-SAMPLE — requires a real trace.db and an LLM credential
@@ -1244,12 +1254,17 @@ export OPENAI_API_KEY="sk-..."
 perfxpert analyze -i trace.db --llm openai --llm-model gpt-4o
 
 # Private endpoint (any OpenAI-compatible server)
-export PERFXPERT_LLM_PRIVATE_URL="https://llm.corp.internal/v1"
-export PERFXPERT_LLM_PRIVATE_MODEL="llama-3-70b"
-# Optional: API key for endpoints that require Bearer auth
+export PERFXPERT_LLM_PRIVATE_URL="https://llm-api.iexample.com/OpenAI"
+export PERFXPERT_LLM_PRIVATE_MODEL="gpt-5.3-codex"
+# Required by CLI preflight; use a real key or a gateway-accepted placeholder
+# if authentication is entirely header-based.
 export PERFXPERT_LLM_PRIVATE_API_KEY="..."
 # Optional: extra HTTP headers as a JSON object (corp gateways, traceability)
-export PERFXPERT_LLM_PRIVATE_HEADERS='{"X-Tenant-Id":"team-perf","X-Auth-Token":"..."}'
+export PERFXPERT_LLM_PRIVATE_HEADERS='{
+  "Ocp-Apim-Subscription-Key": ".......",
+  "user": ".....",
+  "api-version": "preview"
+}'
 # Optional: bypass TLS verification for self-signed CAs (off by default)
 export PERFXPERT_LLM_PRIVATE_VERIFY_SSL=false
 perfxpert analyze -i trace.db --llm private

--- a/experimental/python/perfxpert/docs/guides/getting-started.md
+++ b/experimental/python/perfxpert/docs/guides/getting-started.md
@@ -76,14 +76,16 @@ python3 -m venv .venv
 
 ```bash
 # SKIP-SAMPLE — RHEL 9
-dnf install -y curl git unzip python3.11 python3.11-pip
+command -v curl >/dev/null || dnf install -y curl
+dnf install -y git unzip python3.11 python3.11-pip
 python3.11 -m venv .venv
 . .venv/bin/activate
 ```
 
 ```bash
 # SKIP-SAMPLE — RHEL 10
-dnf install -y curl git unzip python3 python3-pip
+command -v curl >/dev/null || dnf install -y curl
+dnf install -y git unzip python3 python3-pip
 python3 -m venv .venv
 . .venv/bin/activate
 ```

--- a/experimental/python/perfxpert/docs/guides/getting-started.md
+++ b/experimental/python/perfxpert/docs/guides/getting-started.md
@@ -19,8 +19,9 @@ RDNA2 / RDNA3.
 
 ![install](assets/gifs/01-install.gif)
 
-*Editable install in a clean `rocm/dev-ubuntu-22.04` container,
-including the bundled opencode build and CLI verification.*
+*Install in a clean ROCm container, then verify the CLI surfaces. If
+`bun` is absent, the library install still succeeds and only the bundled
+`opencode` build is skipped.*
 
 PerfXpert ships as a single Python wheel. The `setuptools` build hook
 in `setup.py` attempts to compile the AMD-branded bundled opencode
@@ -32,6 +33,9 @@ skipped.
 ### Prerequisites
 
 - Python 3.10+
+- `curl`, `git`, `python3-venv`, and `python3-pip` for GitHub installs.
+- On Ubuntu 24+ and other externally managed Python environments,
+  create and activate a virtual environment before invoking pip.
 - `bun` on PATH if you want the bundled AMD-branded `opencode` build
   to happen during install.
 - The repo-pinned `experimental/python/perfxpert/opencode` submodule
@@ -60,20 +64,49 @@ install …`) and use the multi-backend launcher
 (`perfxpert-code claude` / `codex` / `gemini`) against a native backend
 CLI instead.
 
-### Pip install
+### Distro package setup
 
-> **Run this FIRST on stock Ubuntu / rocm/dev-ubuntu images**: those
-> images ship with pip 22.x and pre-PEP-621 setuptools, which fails the
-> perfxpert wheel build with `filename has 'perfxpert', but metadata has
-> 'unknown'`. The fix is a one-liner:
->
-> ```bash
-> pip install -U pip setuptools wheel
-> ```
->
-> The build requires `setuptools>=61` (declared in `pyproject.toml`'s
-> `[build-system] requires`). Recent pip (23+) honors that declaration
-> automatically; older pip does not.
+Use a virtual environment for the supported install flow. Package setup
+differs slightly by distro:
+
+```bash
+# SKIP-SAMPLE — Ubuntu 22.04 / 24.04
+apt install -y curl git python3-venv python3-pip
+python3 -m venv .venv
+. .venv/bin/activate
+```
+
+```bash
+# SKIP-SAMPLE — RHEL 9
+dnf install -y curl git python3.11 python3.11-pip
+python3.11 -m venv .venv
+. .venv/bin/activate
+```
+
+```bash
+# SKIP-SAMPLE — RHEL 10
+dnf install -y curl git python3 python3-pip
+python3 -m venv .venv
+. .venv/bin/activate
+```
+
+```bash
+# SKIP-SAMPLE — SLES 15
+zypper install -y curl git python311 python311-pip
+python3.11 -m venv .venv
+. .venv/bin/activate
+```
+
+If the venv's pip/setuptools are too old and metadata preparation fails
+with `filename has 'perfxpert', but metadata has 'unknown'`, upgrade
+them inside the venv and retry:
+
+```bash
+# SKIP-SAMPLE — only needed for older venv toolchains
+python -m pip install -U pip setuptools wheel
+```
+
+### Pip install
 
 ```bash
 # SKIP-SAMPLE — install from a local checkout (editable mode)
@@ -84,9 +117,33 @@ pip install -e "experimental/python/perfxpert[all]"
 wrapper (see §1.2 for why):
 
 ```bash
-# SKIP-SAMPLE — clone root without recursing submodules, then run wrapper
-git clone --depth 1 --no-recurse-submodules https://github.com/ROCm/rocm-systems.git
-bash rocm-systems/experimental/python/perfxpert/scripts/pip-install-from-git.sh
+# SKIP-SAMPLE — latest develop branch, no local clone needed
+REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
+# Pin a tag or commit hash:
+# REF=v0.2.0; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
+# REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
+# Base package only:
+# REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}" --extras ''
+```
+
+The GitHub install paths require `git` on PATH because pip shells out to
+`git clone`. The wrapper exits early if `git` or `python -m pip` is
+missing, and on externally managed system Python it tells the user to
+create a virtual environment first. It prefers the active `python`,
+then `python3`, and only falls back to another already-installed
+`python3.10+` binary on PATH when the distro default is too old; it
+never downloads a separate Python runtime.
+
+Pass the ref as the first argument after `bash -s --` when you need to
+pin a specific tag or commit hash.
+
+If you already have a local rocm-systems checkout, the equivalent
+command is:
+
+```bash
+# SKIP-SAMPLE — local checkout equivalent
+bash rocm-systems/experimental/python/perfxpert/scripts/pip-install-from-git.sh develop
+# bash rocm-systems/experimental/python/perfxpert/scripts/pip-install-from-git.sh <SHA>
 ```
 
 The `[all]` extra pulls in `anthropic`, `openai`, `rich`, and
@@ -94,6 +151,11 @@ The `[all]` extra pulls in `anthropic`, `openai`, `rich`, and
 The bundled `opencode` path is validated separately through the
 launcher/build flow. Omit `[all]` if you only want deterministic
 air-gap analysis (wrapper: pass `--extras ''` to skip extras entirely).
+If bun is absent during install, the library, `perfxpert analyze`, and
+`perfxpert-mcp` still work; `perfxpert-code` then needs either
+`perfxpert-code install-patches` once bun is available or an existing
+`opencode` binary via PATH / `PERFXPERT_OPENCODE_PATH`. Install bun with
+`curl -fsSL https://bun.sh/install | bash`.
 
 ### 1.2 Why the wrapper: scoped submodule init
 
@@ -168,7 +230,11 @@ work fine. A last-resort override `PERFXPERT_OPENCODE_PATH` points the
 launcher at an explicit binary.
 
 **Bun missing:** the install completes with a clear warning; only
-`perfxpert-code` (the interactive TUI) is affected.
+`perfxpert-code` (the interactive TUI) is affected. `perfxpert analyze`,
+`perfxpert-mcp`, and the Python API are ready immediately. To enable the
+TUI later, install bun (`curl -fsSL https://bun.sh/install | bash`) and
+run `perfxpert-code install-patches`, or set `PERFXPERT_OPENCODE_PATH`
+to an existing binary.
 
 ## 2. Verify
 
@@ -201,9 +267,12 @@ doctor checks:
   `PERFXPERT_LLM_PRIVATE_URL` or `PRIVATE_LLM_ENDPOINT`,
   plus always-present `opencode`)
 
-If `opencode binary` reports missing, re-run the patch script
-(§1 step 2) or install upstream opencode:
-`curl -fsSL https://opencode.ai/install | bash`.
+If `opencode binary` reports missing, the install skipped the bundled
+build because bun (or another opencode source) was unavailable.
+`perfxpert analyze` and `perfxpert-mcp` still work. To enable
+`perfxpert-code`, install bun (`curl -fsSL https://bun.sh/install | bash`)
+and run `perfxpert-code install-patches`, or set
+`PERFXPERT_OPENCODE_PATH` to an existing patched binary.
 
 ## 3. Three entry points
 
@@ -1330,9 +1399,10 @@ Consult `perfxpert.counter_list_by_block` / `counter_lookup_info`
 before emitting a counter set.
 
 **`opencode binary not found` on `perfxpert doctor`.**
-Either run the patch script (§1 step 2) or install upstream opencode
-(`curl -fsSL https://opencode.ai/install | bash`) and retry. The
-launcher searches `$PERFXPERT_OPENCODE_PATH` → bundled wheel →
+Install bun (`curl -fsSL https://bun.sh/install | bash`), then run
+`perfxpert-code install-patches`, or point `PERFXPERT_OPENCODE_PATH` at
+an existing patched binary and retry. The launcher searches
+`$PERFXPERT_OPENCODE_PATH` → bundled wheel →
 `~/.opencode/bin/opencode` → `~/.local/bin/opencode` → `PATH`.
 
 **`claude mcp add perfxpert perfxpert-mcp` not finding the binary.**

--- a/experimental/python/perfxpert/docs/guides/getting-started.md
+++ b/experimental/python/perfxpert/docs/guides/getting-started.md
@@ -19,25 +19,25 @@ RDNA2 / RDNA3.
 
 ![install](assets/gifs/01-install.gif)
 
-*Install in a clean ROCm container, then verify the CLI surfaces. If
-`bun` is absent, the library install still succeeds and only the bundled
-`opencode` build is skipped.*
+*Install in a clean ROCm container, then verify the CLI surfaces. The
+pip build hook bootstraps bun when needed so the bundled patched
+`perfxpert-code` build completes during install.*
 
 PerfXpert ships as a single Python wheel. The `setuptools` build hook
-in `setup.py` attempts to compile the AMD-branded bundled opencode
-binary during `pip install`, but it never downloads bun or clones a
-mutable upstream `opencode` source tree. If the local prerequisites are
-missing, install still succeeds and only the bundled launcher build is
-skipped.
+in `setup.py` compiles the AMD-branded bundled opencode binary during
+`pip install`. If bun is missing, pip bootstraps it into the user's home
+directory. If OS prerequisites such as `curl`, `git`, or `unzip` are
+missing, pip fails with the missing package-manager pieces instead of
+silently producing a broken `perfxpert-code`.
 
 ### Prerequisites
 
 - Python 3.10+
-- `curl`, `git`, `python3-venv`, and `python3-pip` for GitHub installs.
+- `curl`, `git`, `unzip`, `python3-venv`, and `python3-pip` for GitHub installs.
 - On Ubuntu 24+ and other externally managed Python environments,
   create and activate a virtual environment before invoking pip.
-- `bun` on PATH if you want the bundled AMD-branded `opencode` build
-  to happen during install.
+- `bun` on PATH, or `curl` + `unzip` so pip can bootstrap bun into the
+  user's home directory during install.
 - The repo-pinned `experimental/python/perfxpert/opencode` submodule
   populated if you are installing from a checkout without using the
   wrapper. The setup hook may attempt a scoped `git submodule update
@@ -47,22 +47,20 @@ skipped.
 #### Opt-out env vars
 
 - `PERFXPERT_SKIP_BUNDLED_BUILD=1` — skip the entire opencode build.
-  Library + analyze + MCP all still work; `perfxpert-code` will
-  fall back to whatever `opencode` is on PATH or exit with a helpful
-  error.
+  Use only in CI that intentionally skips the interactive TUI. The
+  default `perfxpert-code` command will not fall back to an arbitrary
+  upstream opencode binary.
 - `PERFXPERT_SKIP_OPENCODE_FETCH=1` — don't even attempt the scoped
   submodule init when the vendored `opencode/` checkout is empty.
-- `PERFXPERT_OPENCODE_PATH=/path/to/opencode` — last-resort override
-  pointing the launcher at a pre-built binary.
+- `PERFXPERT_OPENCODE_PATH=/path/to/opencode` — explicit user-owned
+  upstream escape hatch used only by `perfxpert-code opencode ...`.
 
 #### Note on Windows
 
-PerfXpert does not auto-download bun on Windows. If the bundled
-`opencode` build is not available on your host, install `perfxpert`
-without the bundled launcher (`PERFXPERT_SKIP_BUNDLED_BUILD=1 pip
-install …`) and use the multi-backend launcher
-(`perfxpert-code claude` / `codex` / `gemini`) against a native backend
-CLI instead.
+PerfXpert does not auto-bootstrap bun on Windows. If the bundled
+`opencode` build is not available on your host, use the multi-backend
+launcher (`perfxpert-code claude` / `codex` / `gemini`) against a native
+backend CLI instead.
 
 ### Distro package setup
 
@@ -71,28 +69,28 @@ differs slightly by distro:
 
 ```bash
 # SKIP-SAMPLE — Ubuntu 22.04 / 24.04
-apt install -y curl git python3-venv python3-pip
+apt install -y curl git unzip python3-venv python3-pip
 python3 -m venv .venv
 . .venv/bin/activate
 ```
 
 ```bash
 # SKIP-SAMPLE — RHEL 9
-dnf install -y curl git python3.11 python3.11-pip
+dnf install -y curl git unzip python3.11 python3.11-pip
 python3.11 -m venv .venv
 . .venv/bin/activate
 ```
 
 ```bash
 # SKIP-SAMPLE — RHEL 10
-dnf install -y curl git python3 python3-pip
+dnf install -y curl git unzip python3 python3-pip
 python3 -m venv .venv
 . .venv/bin/activate
 ```
 
 ```bash
 # SKIP-SAMPLE — SLES 15
-zypper install -y curl git python311 python311-pip
+zypper install -y curl git unzip python311 python311-pip
 python3.11 -m venv .venv
 . .venv/bin/activate
 ```
@@ -126,13 +124,17 @@ REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${R
 # REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}" --extras ''
 ```
 
-The GitHub install paths require `git` on PATH because pip shells out to
-`git clone`. The wrapper exits early if `git` or `python -m pip` is
-missing, and on externally managed system Python it tells the user to
-create a virtual environment first. It prefers the active `python`,
-then `python3`, and only falls back to another already-installed
-`python3.10+` binary on PATH when the distro default is too old; it
-never downloads a separate Python runtime.
+The GitHub install paths require `git` because pip shells out to
+`git clone`. The wrapper installs missing OS prerequisites with the host
+package manager when it is running as root or when sudo is available;
+otherwise it prints the exact package-manager command to run first. On
+externally managed system Python it tells the user to create a virtual
+environment first. It prefers the active `python`, then `python3`, and
+only falls back to another already-installed `python3.10+` binary on
+PATH when the distro default is too old; it never downloads a separate
+Python runtime. During the pip build, `setup.py` bootstraps bun when it
+is missing so the bundled patched opencode binary is built from the
+pinned perfxpert submodule.
 
 Pass the ref as the first argument after `bash -s --` when you need to
 pin a specific tag or commit hash.
@@ -151,11 +153,11 @@ The `[all]` extra pulls in `anthropic`, `openai`, `rich`, and
 The bundled `opencode` path is validated separately through the
 launcher/build flow. Omit `[all]` if you only want deterministic
 air-gap analysis (wrapper: pass `--extras ''` to skip extras entirely).
-If bun is absent during install, the library, `perfxpert analyze`, and
-`perfxpert-mcp` still work; `perfxpert-code` then needs either
-`perfxpert-code install-patches` once bun is available or an existing
-`opencode` binary via PATH / `PERFXPERT_OPENCODE_PATH`. Install bun with
-`curl -fsSL https://bun.sh/install | bash`.
+On the GitHub wrapper path, the wrapper exits non-zero if the bundled
+patched `perfxpert-code` binary is still absent after install. Direct
+pip/editable paths use the same `setup.py` build hook: pip bootstraps
+bun when the OS prerequisites are available, or fails with a
+distro-specific prerequisite message when they are not.
 
 ### 1.2 Why the wrapper: scoped submodule init
 
@@ -202,9 +204,9 @@ still works — they just pay the 3-6 min submodule-init penalty once.
 The `setup.py` build hook notices if the opencode submodule is still
 empty after pip's checkout (i.e. the user scoped submodule init out
 manually without including opencode), but it does **not** clone from
-the network during install. Instead it warns clearly and skips only the
-bundled `opencode` build; library + analyze + MCP paths still install
-successfully.
+the network during install. Instead it fails with the missing pinned
+submodule path so the default `perfxpert-code` install cannot silently
+fall back to an arbitrary opencode binary.
 
 Opt-outs:
 
@@ -222,19 +224,14 @@ bundled binary at `perfxpert/_bundled/opencode`. Subsequent `pip install`
 invocations skip the rebuild if the binary is already newer than every
 patch file.
 
-**Opt-out:** set `PERFXPERT_SKIP_BUNDLED_BUILD=1` to suppress the build
-(useful in offline / sandboxed CI). `perfxpert-code` will then fall back
-to whatever `opencode` is on `PATH`, which will NOT include our tool-
-priority gate or system prompt — library + analyze + MCP paths still
-work fine. A last-resort override `PERFXPERT_OPENCODE_PATH` points the
-launcher at an explicit binary.
+**Opt-out:** set `PERFXPERT_SKIP_BUNDLED_BUILD=1` only in offline /
+sandboxed CI that intentionally skips the interactive TUI build.
+Default `perfxpert-code` requires the bundled binary built from the
+pinned submodule.
 
-**Bun missing:** the install completes with a clear warning; only
-`perfxpert-code` (the interactive TUI) is affected. `perfxpert analyze`,
-`perfxpert-mcp`, and the Python API are ready immediately. To enable the
-TUI later, install bun (`curl -fsSL https://bun.sh/install | bash`) and
-run `perfxpert-code install-patches`, or set `PERFXPERT_OPENCODE_PATH`
-to an existing binary.
+**Bun missing:** pip bootstraps bun into the user's home directory when
+`curl` and `unzip` are available. If those OS prerequisites are missing,
+pip exits with distro-specific package-manager guidance.
 
 ## 2. Verify
 
@@ -267,12 +264,10 @@ doctor checks:
   `PERFXPERT_LLM_PRIVATE_URL` or `PRIVATE_LLM_ENDPOINT`,
   plus always-present `opencode`)
 
-If `opencode binary` reports missing, the install skipped the bundled
-build because bun (or another opencode source) was unavailable.
-`perfxpert analyze` and `perfxpert-mcp` still work. To enable
-`perfxpert-code`, install bun (`curl -fsSL https://bun.sh/install | bash`)
-and run `perfxpert-code install-patches`, or set
-`PERFXPERT_OPENCODE_PATH` to an existing patched binary.
+If `opencode binary` reports missing, the install skipped or failed the
+bundled build. Reinstall through the GitHub wrapper so the pinned
+submodule is populated and bun is bootstrapped before the wheel build
+finishes.
 
 ## 3. Three entry points
 
@@ -975,7 +970,7 @@ a one-line stderr WARNING so you know which credential is active):
 | `openai` | `OPENAI_API_KEY` | `PERFXPERT_LLM_OPENAI_KEY` | Either works |
 | `private` | `PERFXPERT_LLM_PRIVATE_API_KEY` | — | Plus `PERFXPERT_LLM_PRIVATE_URL` (required) |
 | `ollama` | — (no key) | — | Plus `PERFXPERT_LLM_LOCAL_URL` (default `http://localhost:11434`) |
-| `opencode` | — (no key) | — | Plus `PERFXPERT_OPENCODE_PATH` if not on `PATH` |
+| `opencode` | — (no key) | — | Default `perfxpert-code` uses the bundled binary; `PERFXPERT_OPENCODE_PATH` is only for `perfxpert-code opencode ...` |
 
 ```bash
 # SKIP-SAMPLE — requires a real trace.db and a live ANTHROPIC_API_KEY
@@ -1133,7 +1128,7 @@ wraps the same agent runtime the batch-mode `analyze` CLI uses.
 `perfxpert-mcp` pre-wired and the TUI ready at startup.*
 
 ```bash
-# SKIP-SAMPLE — requires a patched opencode path (repo-local build or bundled wheel)
+# SKIP-SAMPLE — requires the bundled submodule-built opencode binary
 perfxpert-code
 ```
 
@@ -1302,7 +1297,7 @@ perfxpert-code run -m anthropic/claude-haiku-4-5 "optimize ./app.cpp"
 Fully interactive (drop into the TUI):
 
 ```bash
-# SKIP-SAMPLE — requires a patched opencode path (repo-local build or bundled wheel)
+# SKIP-SAMPLE — requires the bundled submodule-built opencode binary
 perfxpert-code
 ```
 
@@ -1366,15 +1361,12 @@ confirms the negotiated protocol version.*
 
 ## 14. Troubleshooting
 
-**`perfxpert-code` launches the unpatched upstream binary.**
-Check that `PERFXPERT_OPENCODE_PATH` is either unset or points at a
-patched binary. The launcher search order is: explicit env override →
-locally built patched submodule copy (source/editable checkouts) →
-bundled wheel copy → well-known upstream install locations / `PATH`.
-If you're in a source checkout, run `perfxpert-code install-patches` to
-rebuild the patched binary from the pinned submodule. If you're using a
-wheel build, reinstall with bun available so the bundled build can
-complete. The launcher prints a warning on unpatched fallback.
+**`perfxpert-code` says the bundled opencode binary is missing.**
+The default TUI path only uses the repo-pinned submodule build. Reinstall
+through the GitHub wrapper so the pinned submodule is populated, bun is
+available, and the bundled binary is verified before install exits. If
+you intentionally want a user-owned upstream opencode binary, run
+`perfxpert-code opencode ...` explicitly.
 
 **LLM quota exhausted (429 / `insufficient_quota`).**
 Set `PERFXPERT_LLM_FALLBACK_CHAIN` to a comma-separated provider
@@ -1399,11 +1391,9 @@ Consult `perfxpert.counter_list_by_block` / `counter_lookup_info`
 before emitting a counter set.
 
 **`opencode binary not found` on `perfxpert doctor`.**
-Install bun (`curl -fsSL https://bun.sh/install | bash`), then run
-`perfxpert-code install-patches`, or point `PERFXPERT_OPENCODE_PATH` at
-an existing patched binary and retry. The launcher searches
-`$PERFXPERT_OPENCODE_PATH` → bundled wheel →
-`~/.opencode/bin/opencode` → `~/.local/bin/opencode` → `PATH`.
+Reinstall through the GitHub wrapper. Direct `pip install` also checks
+for missing OS prerequisites and exits with package-manager guidance
+when it cannot build the bundled `perfxpert-code` binary.
 
 **`claude mcp add perfxpert perfxpert-mcp` not finding the binary.**
 The client's `PATH` is narrower than your login shell. Use the

--- a/experimental/python/perfxpert/docs/guides/getting-started.md
+++ b/experimental/python/perfxpert/docs/guides/getting-started.md
@@ -1281,8 +1281,9 @@ Model selection ladder (first hit wins, resolved at session boot):
 
 1. `PERFXPERT_AGENTS_MODEL_<PROVIDER>` — per-provider pin, e.g.
    `PERFXPERT_AGENTS_MODEL_OPENAI=gpt-4o-mini`
-2. `PERFXPERT_LLM_MODEL` — cross-provider override
-3. Built-in default (anthropic: `claude-sonnet-4-20250514`, openai:
+2. `PERFXPERT_LLM_PRIVATE_MODEL` — private-provider model pin
+3. `PERFXPERT_LLM_MODEL` — cross-provider override
+4. Built-in default (anthropic: `claude-sonnet-4-20250514`, openai:
    `gpt-4o-mini`)
 
 ### Fallback chain (recommended for interactive use)

--- a/experimental/python/perfxpert/docs/integration/mcp-server.md
+++ b/experimental/python/perfxpert/docs/integration/mcp-server.md
@@ -26,12 +26,12 @@ perfxpert-mcp
 ```
 
 The entry point is registered in `pyproject.toml` (`perfxpert-mcp`).
-Current wheels/install-from-source builds already depend on the Python
-`mcp` package, so no separate extra is required:
+Use the same GitHub wrapper as the main README so the package, MCP
+entry point, and bundled `perfxpert-code` build are installed together:
 
 ```bash
-# SKIP-SAMPLE — pip install is in the destructive-skip list
-pip install perfxpert
+# SKIP-SAMPLE — installs from the ROCm/rocm-systems monorepo
+REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
 ```
 
 Under `PERFXPERT_AIRGAP=1`, the server still serves cached READ_ONLY

--- a/experimental/python/perfxpert/perfxpert/agents/framework.py
+++ b/experimental/python/perfxpert/perfxpert/agents/framework.py
@@ -193,12 +193,23 @@ def _resolve_model(provider: str) -> str:
 
     Precedence:
       1. ``PERFXPERT_AGENTS_MODEL_<PROVIDER>`` (e.g. ``..._OPENAI``)
-      2. ``PERFXPERT_LLM_MODEL`` (cross-provider override)
-      3. Built-in default from :data:`_DEFAULT_MODELS`
+      2. ``PERFXPERT_LLM_PRIVATE_MODEL`` for the private provider
+      3. ``PERFXPERT_LLM_MODEL`` (cross-provider override)
+      4. Built-in default from :data:`_DEFAULT_MODELS`
     """
     specific = os.environ.get(f"PERFXPERT_AGENTS_MODEL_{provider.upper()}")
+    provider_specific = (
+        os.environ.get("PERFXPERT_LLM_PRIVATE_MODEL")
+        if provider == "private"
+        else None
+    )
     generic = os.environ.get("PERFXPERT_LLM_MODEL")
-    model = specific or generic or _DEFAULT_MODELS.get(provider, _DEFAULT_MODELS["openai"])
+    model = (
+        specific
+        or provider_specific
+        or generic
+        or _DEFAULT_MODELS.get(provider, _DEFAULT_MODELS["openai"])
+    )
     if "/" in model:
         return model
     if provider == "anthropic":
@@ -230,15 +241,26 @@ def _build_sdk_run_config(provider: str) -> Any:
             provider_map.add_provider(provider, LitellmProvider())
         elif provider == "private":
             from agents.models.openai_provider import OpenAIProvider  # type: ignore[import-not-found]
+            from openai import AsyncOpenAI  # type: ignore[import-not-found]
+            from perfxpert.providers.private_provider import _parse_headers
 
             base_url = (os.environ.get("PERFXPERT_LLM_PRIVATE_URL") or "").rstrip("/")
             if not base_url:
                 raise AuthError("private", "no endpoint configured (set PERFXPERT_LLM_PRIVATE_URL)")
+            try:
+                extra_headers = _parse_headers(os.environ.get("PERFXPERT_LLM_PRIVATE_HEADERS", ""))
+            except ValueError as exc:
+                raise AuthError("private", str(exc)) from exc
+            api_key = os.environ.get("PERFXPERT_LLM_PRIVATE_API_KEY") or "dummy"
+            openai_client = AsyncOpenAI(
+                api_key=api_key,
+                base_url=base_url,
+                default_headers=extra_headers or None,
+            )
             provider_map.add_provider(
                 "private",
                 OpenAIProvider(
-                    api_key=os.environ.get("PERFXPERT_LLM_PRIVATE_API_KEY") or "dummy",
-                    base_url=base_url,
+                    openai_client=openai_client,
                     use_responses=False,
                 ),
             )
@@ -440,6 +462,40 @@ def _final_output_structured(run_result: Any) -> Optional[Dict[str, Any]]:
     return None
 
 
+def _structured_from_text(text: str) -> Optional[Dict[str, Any]]:
+    stripped = text.strip()
+    if not (stripped.startswith("{") and stripped.endswith("}")):
+        return None
+    try:
+        parsed = json.loads(stripped)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _opencode_invoke(agent: "Agent", input_payload: Any) -> FakeProviderResponse:
+    from perfxpert.providers.opencode_provider import OpencodeProvider
+
+    instructions = agent.fence_text or (
+        f"You are the {agent.name} agent. "
+        "Follow the JSON payload contract defined in the perfxpert fence."
+    )
+    model = os.environ.get("PERFXPERT_AGENTS_MODEL_OPENCODE") or os.environ.get(
+        "PERFXPERT_LLM_MODEL"
+    )
+    response = OpencodeProvider().complete(
+        [{"role": "user", "content": _serialize_input(input_payload)}],
+        system=instructions,
+        model=model,
+    )
+    return FakeProviderResponse(
+        text=response.content,
+        tool_calls=[],
+        structured_output=_structured_from_text(response.content),
+        handoff=None,
+    )
+
+
 def _sdk_invoke(agent: "Agent", input_payload: Any, provider: str) -> FakeProviderResponse:
     """Invoke the openai-agents SDK Runner and return a FakeProviderResponse.
 
@@ -450,6 +506,9 @@ def _sdk_invoke(agent: "Agent", input_payload: Any, provider: str) -> FakeProvid
     The return type remains ``FakeProviderResponse`` so agents/runtime wiring
     is identical across mocked + live paths.
     """
+    if provider == "opencode":
+        return _opencode_invoke(agent, input_payload)
+
     if not _SDK_AVAILABLE or SdkAgent is None or SdkRunner is None or SdkRunConfig is None:
         raise RuntimeError(
             "OpenAI Agents SDK not installed; run `pip install openai-agents` "

--- a/experimental/python/perfxpert/perfxpert/agents/framework.py
+++ b/experimental/python/perfxpert/perfxpert/agents/framework.py
@@ -21,6 +21,7 @@ Runtime guardrails:
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import os
@@ -242,7 +243,9 @@ def _build_sdk_run_config(provider: str) -> Any:
         elif provider == "private":
             from agents.models.openai_provider import OpenAIProvider  # type: ignore[import-not-found]
             from openai import AsyncOpenAI  # type: ignore[import-not-found]
-            from perfxpert.providers.private_provider import _parse_headers
+            import httpx
+
+            from perfxpert.providers.private_provider import _parse_headers, _verify_ssl_from_env
 
             base_url = (os.environ.get("PERFXPERT_LLM_PRIVATE_URL") or "").rstrip("/")
             if not base_url:
@@ -256,6 +259,7 @@ def _build_sdk_run_config(provider: str) -> Any:
                 api_key=api_key,
                 base_url=base_url,
                 default_headers=extra_headers or None,
+                http_client=httpx.AsyncClient(verify=_verify_ssl_from_env()),
             )
             provider_map.add_provider(
                 "private",
@@ -365,6 +369,30 @@ def _sanitize_tool_name(name: str) -> str:
     return name.replace(".", "_")
 
 
+def _prepare_tool_callable_for_sdk(fn: Callable[..., Any], tool_name: str) -> Callable[..., Any]:
+    """Ensure SDK introspection has function metadata for bound callables."""
+    safe_name = _sanitize_tool_name(tool_name)
+    if inspect.isfunction(fn) or inspect.ismethod(fn):
+        if not getattr(fn, "__name__", None):
+            try:
+                setattr(fn, "__name__", safe_name)
+                setattr(fn, "__qualname__", safe_name)
+            except Exception:  # pragma: no cover - unusual callable object
+                pass
+        return fn
+
+    def _sdk_tool_wrapper(*args: Any, **kwargs: Any) -> Any:
+        return fn(*args, **kwargs)
+
+    _sdk_tool_wrapper.__name__ = safe_name
+    _sdk_tool_wrapper.__qualname__ = safe_name
+    try:
+        _sdk_tool_wrapper.__signature__ = inspect.signature(fn)  # type: ignore[attr-defined]
+    except (TypeError, ValueError):  # pragma: no cover - best effort
+        pass
+    return _sdk_tool_wrapper
+
+
 def _translate_tools(tools: List[ToolBinding]) -> List[Any]:
     """Wrap our ToolBinding list in openai-agents function_tool decorators.
 
@@ -378,9 +406,10 @@ def _translate_tools(tools: List[ToolBinding]) -> List[Any]:
     wrapped: List[Any] = []
     for tb in tools:
         try:
+            sdk_callable = _prepare_tool_callable_for_sdk(tb.fn, tb.name)
             wrapped.append(
                 sdk_function_tool(
-                    tb.fn,
+                    sdk_callable,
                     name_override=_sanitize_tool_name(tb.name),
                     # The SDK's introspection can be picky about third-party
                     # callables; relax strict mode so we don't 400 on schema

--- a/experimental/python/perfxpert/perfxpert/analyze.py
+++ b/experimental/python/perfxpert/perfxpert/analyze.py
@@ -197,7 +197,8 @@ def add_args(parser: argparse.ArgumentParser):
         choices=["text", "json", "markdown", "webview"],
         default="text",
         help="Output format: text, json, markdown, or webview (default: text). "
-        "File extension is set automatically: .txt, .json, .md, .html",
+        "File extension is set automatically: .txt, .json, .md, .html. "
+        "Non-text formats write a report file by default.",
     )
 
     analysis_options.add_argument(
@@ -1821,7 +1822,15 @@ def _execute_agentic(
     _ext_map = {"json": ".json", "markdown": ".md", "webview": ".html", "text": ".txt"}
     _ext = _ext_map.get(output_format, ".txt")
 
-    if config and config.output_path and not config.output_file:
+    if config and output_format != "text":
+        if not config.output_path:
+            config.output_path = "."
+        if not config.output_file:
+            if database_path:
+                config.output_file = os.path.splitext(os.path.basename(database_path))[0]
+            else:
+                config.output_file = "analysis"
+    elif config and config.output_path and not config.output_file:
         if database_path:
             config.output_file = os.path.splitext(os.path.basename(database_path))[0]
         else:

--- a/experimental/python/perfxpert/perfxpert/cli/opencode_launcher.py
+++ b/experimental/python/perfxpert/perfxpert/cli/opencode_launcher.py
@@ -1,17 +1,17 @@
 """opencode_launcher — `perfxpert-code` entry point.
 
-Launches opencode (from PERFXPERT_OPENCODE_PATH / locally built patched
-repo checkout / bundled wheel / well-known paths / system PATH in that
-order) with the AMD-themed config directory.
+Launches the locally built or packaged bundled opencode binary with the
+AMD-themed config directory.
 
 In source/editable checkouts, `perfxpert-code install-patches` can build the
 patched binary from the pinned `opencode` submodule. In packaged installs, the
-launcher prefers the bundled binary when present and falls back to an upstream
-`opencode` install only when no patched copy is available.
+launcher requires the bundled binary produced from that same pinned submodule.
+Users who intentionally want their own upstream opencode binary can run
+`perfxpert-code opencode ...`, which bypasses the PerfXpert bundle.
 
-PERFXPERT_OPENCODE_PATH, if set, must point to an existing executable file;
-the launcher raises FileNotFoundError immediately rather than silently
-falling back to bundled/PATH lookup.
+PERFXPERT_OPENCODE_PATH is only honored by the explicit
+`perfxpert-code opencode ...` escape hatch. The default PerfXpert TUI path
+does not use arbitrary opencode binaries.
 """
 
 from __future__ import annotations
@@ -78,6 +78,7 @@ _PERFXPERT_SUBCOMMANDS: "dict[str, str]" = {
     "config": "Show or set perfxpert configuration (~/.config/perfxpert/config.yaml)",
     "doctor": "Health check: verify MCP server, LLM providers, and dependencies",
     "install-patches": "(deprecated) Build the patched opencode submodule into perfxpert/_bundled/opencode",
+    "opencode": "Run a user-owned upstream opencode binary explicitly",
     "providers": "List LLM providers and configuration status",
     "uninstall": "Reverse `perfxpert-code <backend>` install: remove MCP + AGENTS + gate hook",
 }
@@ -107,13 +108,11 @@ def _perfxpert_version() -> str:
 
 
 def _wellknown_opencode_paths() -> "list[Path]":
-    """Canonical well-known install locations for the `opencode` binary.
+    """Canonical well-known install locations for a user-owned `opencode` binary.
 
-    Covers the upstream installer (`~/.opencode/bin/opencode`) and any
-    common Linux package locations. The list is consulted AFTER the
-    explicit env override and the bundled wheel path, but BEFORE the
-    PATH fallback, so users who ran the upstream installer get a clean
-    `perfxpert doctor` report without having to `export PATH`.
+    These are used only by `perfxpert-code opencode ...`. The default
+    PerfXpert TUI path requires the bundled binary built from the pinned
+    submodule.
     """
     home = Path.home()
     return [
@@ -143,92 +142,63 @@ def _repo_local_patched_opencode_paths() -> "list[Path]":
     ]
 
 
-def _warn_unpatched_fallback(path: Path) -> None:
-    """Emit a one-line warning when falling back to an unpatched opencode.
+def resolve_opencode_binary() -> Path:
+    """Locate the PerfXpert-managed bundled opencode binary.
 
-    The bundled binary carries perfxpert's tool-priority gate and AMD
-    rebrand; anything on disk (well-known path / PATH) is the vanilla
-    upstream binary. Warn once so the user knows the gate is inactive
-    and tells them how to build the bundled copy.
+    Priority:
+
+    1. locally built repo checkout under ``experimental/python/perfxpert/opencode``.
+    2. ``perfxpert/_bundled/opencode`` built from the pinned submodule.
+    3. Final actionable error with install command hint.
     """
-    if os.environ.get("PERFXPERT_SILENCE_UNPATCHED_WARNING", "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-    }:
-        return
-    sys.stderr.write(
-        "\033[33mWARNING: using unpatched upstream opencode at "
-        f"{path}; tool-priority gate + AMD rebrand not active.\n"
-        "  Run: perfxpert-code install-patches   (builds the bundled patched opencode)\n"
-        "  Silence: export PERFXPERT_SILENCE_UNPATCHED_WARNING=1\033[0m\n"
+    # Locally built patched repo checkout (editable/source installs).
+    for candidate in _repo_local_patched_opencode_paths():
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+
+    # Bundled binary built during pip install.
+    try:
+        with resources.as_file(resources.files("perfxpert") / "_bundled" / "opencode") as p:
+            if p.is_file() and os.access(p, os.X_OK):
+                return p
+    except (ModuleNotFoundError, FileNotFoundError):
+        pass
+
+    raise FileNotFoundError(
+        "bundled patched opencode binary not found. Reinstall perfxpert with the "
+        "GitHub wrapper so the pinned opencode submodule is built:\n"
+        '  REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"\n'
+        "For a user-owned upstream opencode binary, run: perfxpert-code opencode [args]"
     )
 
 
-def resolve_opencode_binary() -> Path:
-    """Locate the opencode binary.
-
-    Priority (patched local build wins over upstream):
-
-    1. ``$PERFXPERT_OPENCODE_PATH`` — explicit override, power users.
-    2. locally built repo checkout under ``experimental/python/perfxpert/opencode``.
-    3. ``perfxpert/_bundled/opencode`` — OUR patched bundle.
-    4. ``$HOME/.opencode/bin/opencode`` and other well-known install dirs
-       (upstream, unpatched — WARN on fallthrough).
-    5. ``shutil.which("opencode")`` on PATH (upstream, unpatched — WARN).
-    6. Final actionable error with install command hint.
-
-    When falling back past the bundled binary (layers 3 and 4), a
-    yellow warning is printed to stderr so the user knows the
-    tool-priority gate + AMD rebrand patches aren't active.
-    """
+def resolve_user_opencode_binary() -> Path:
+    """Locate a user-owned upstream opencode binary for `perfxpert-code opencode`."""
     override = os.environ.get("PERFXPERT_OPENCODE_PATH")
     if override:
         p = Path(override)
         if not p.is_file():
             raise FileNotFoundError(
                 f"PERFXPERT_OPENCODE_PATH={override!r} does not exist. "
-                "Correct the path or unset the variable to use bundled/PATH lookup."
+                "Correct the path or unset the variable to use normal opencode lookup."
             )
         return p
 
-    # Locally built patched repo checkout (editable/source installs).
-    # This MUST win over any upstream install so developers exercise the
-    # pinned patched fork they just built from the submodule.
-    for candidate in _repo_local_patched_opencode_paths():
-        if candidate.is_file() and os.access(candidate, os.X_OK):
-            return candidate
-
-    # Bundled binary (per-platform wheel ships this under _bundled/).
-    # This MUST win over any upstream install so users get our patches.
-    try:
-        with resources.as_file(resources.files("perfxpert") / "_bundled" / "opencode") as p:
-            if p.is_file():
-                return p
-    except (ModuleNotFoundError, FileNotFoundError):
-        pass
-
-    # Well-known install locations (upstream installer puts it at ~/.opencode/bin/).
-    # This is the UNPATCHED upstream — warn the user so they know our gate is off.
     for candidate in _wellknown_opencode_paths():
         if candidate.is_file() and os.access(candidate, os.X_OK):
-            _warn_unpatched_fallback(candidate)
             return candidate
 
-    # PATH fallback with install helper — also unpatched; warn.
     try:
         require_tool("opencode", allow_install=True)
         on_path = shutil.which("opencode")
         if on_path:
-            _warn_unpatched_fallback(Path(on_path))
             return Path(on_path)
     except Exception:
         pass
 
     raise FileNotFoundError(
-        "opencode binary not found. Install it with:\n"
+        "user-owned opencode binary not found. Install it with:\n"
         "  curl -fsSL https://opencode.ai/install.sh | bash\n"
-        "or run: perfxpert-code install-patches   (builds the bundled patched opencode)\n"
         "or set PERFXPERT_OPENCODE_PATH to point at an existing binary."
     )
 
@@ -286,6 +256,7 @@ def _print_perfxpert_help(stream=None) -> None:
         "",
         "Usage:",
         "  perfxpert-code [opencode-args]      Launch the AMD-branded opencode TUI",
+        "  perfxpert-code opencode [args]      Run a user-owned upstream opencode binary",
         "  perfxpert-code --version | -V       Print perfxpert version and exit",
         "  perfxpert-code --help | -h          Show this banner, then opencode help",
         "",
@@ -340,6 +311,8 @@ def route_subcommand(argv: list[str]) -> tuple[str, list[str]]:
         third-party agent backend (``claude`` / ``codex`` / ``gemini``);
         ``argv_out`` is forwarded to
         ``perfxpert.cli._backend_dispatch._exec_backend``.
+      - ``"user_opencode"``: the first positional is ``opencode``;
+        ``argv_out`` is forwarded to a user-owned upstream opencode binary.
       - ``"opencode_subcommand"``: the first positional is a known opencode
         subcommand; ``argv_out`` is forwarded verbatim to opencode.
       - ``"opencode_default"``: no recognized subcommand; ``argv_out`` is
@@ -368,6 +341,14 @@ def route_subcommand(argv: list[str]) -> tuple[str, list[str]]:
     # (if upstream opencode ever added one) still routes to the adapter.
     if first_positional in _BACKEND_SUBCOMMANDS:
         return ("backend", list(argv))
+
+    if first_positional == "opencode":
+        out = list(argv)
+        for idx, token in enumerate(out):
+            if token == "opencode":
+                del out[idx]
+                break
+        return ("user_opencode", out)
 
     if first_positional in _OPENCODE_SUBCOMMANDS:
         return ("opencode_subcommand", list(argv))
@@ -633,6 +614,18 @@ def main(argv: list[str] | None = None) -> int:
         from perfxpert.cli._backend_dispatch import _exec_backend
 
         return _exec_backend(backend_name, remaining)
+
+    if kind == "user_opencode":
+        try:
+            binary = resolve_user_opencode_binary()
+        except FileNotFoundError as e:
+            print(f"\033[31mperfxpert-code opencode: {e}\033[0m", file=sys.stderr)
+            return 1
+        try:
+            proc = subprocess.run([str(binary), *argv_out], env=dict(os.environ), check=False)
+        except KeyboardInterrupt:
+            return 130
+        return proc.returncode
 
     try:
         binary = resolve_opencode_binary()

--- a/experimental/python/perfxpert/perfxpert/cli/opencode_launcher.py
+++ b/experimental/python/perfxpert/perfxpert/cli/opencode_launcher.py
@@ -182,6 +182,11 @@ def resolve_user_opencode_binary() -> Path:
                 f"PERFXPERT_OPENCODE_PATH={override!r} does not exist. "
                 "Correct the path or unset the variable to use normal opencode lookup."
             )
+        if not os.access(p, os.X_OK):
+            raise FileNotFoundError(
+                f"PERFXPERT_OPENCODE_PATH={override!r} is not executable. "
+                "Fix permissions or unset the variable to use normal opencode lookup."
+            )
         return p
 
     for candidate in _wellknown_opencode_paths():
@@ -616,6 +621,8 @@ def main(argv: list[str] | None = None) -> int:
         return _exec_backend(backend_name, remaining)
 
     if kind == "user_opencode":
+        if _printed_perfxpert_help:
+            return 0
         try:
             binary = resolve_user_opencode_binary()
         except FileNotFoundError as e:

--- a/experimental/python/perfxpert/perfxpert/providers/opencode_provider.py
+++ b/experimental/python/perfxpert/perfxpert/providers/opencode_provider.py
@@ -7,7 +7,8 @@ opencode-launched session from spawning another opencode.
 Binary resolution order:
     1. constructor kwarg `opencode_path`
     2. env var PERFXPERT_OPENCODE_PATH
-    3. shutil.which("opencode") on PATH
+    3. bundled patched perfxpert opencode binary
+    4. shutil.which("opencode") on PATH
 """
 
 from __future__ import annotations
@@ -34,11 +35,18 @@ def _find_binary(explicit: Optional[str]) -> str:
     env = os.environ.get("PERFXPERT_OPENCODE_PATH")
     if env:
         return env
+    try:
+        from perfxpert.cli.opencode_launcher import resolve_opencode_binary
+
+        return str(resolve_opencode_binary())
+    except FileNotFoundError:
+        pass
     found = shutil.which("opencode")
     if found:
         return found
     raise ProviderError(
-        "[opencode] binary not found (set PERFXPERT_OPENCODE_PATH or install opencode on PATH)"
+        "[opencode] binary not found (reinstall perfxpert so the bundled binary is built, "
+        "set PERFXPERT_OPENCODE_PATH, or install opencode on PATH)"
     )
 
 

--- a/experimental/python/perfxpert/perfxpert/providers/private_provider.py
+++ b/experimental/python/perfxpert/perfxpert/providers/private_provider.py
@@ -44,6 +44,11 @@ def _parse_headers(raw: str) -> Dict[str, str]:
     return {str(k): str(v) for k, v in obj.items()}
 
 
+def _verify_ssl_from_env() -> bool:
+    env_flag = os.environ.get("PERFXPERT_LLM_PRIVATE_VERIFY_SSL", "1")
+    return env_flag.lower() not in ("0", "false", "no", "off")
+
+
 class PrivateProvider(Provider):
     """Generic OpenAI-compatible private endpoint."""
 
@@ -73,8 +78,7 @@ class PrivateProvider(Provider):
         self._extra_headers = merged
 
         if verify_ssl is None:
-            env_flag = os.environ.get("PERFXPERT_LLM_PRIVATE_VERIFY_SSL", "1")
-            verify_ssl = env_flag not in ("0", "false", "False", "no", "NO")
+            verify_ssl = _verify_ssl_from_env()
         self._verify_ssl = bool(verify_ssl)
         self._timeout = timeout
 
@@ -137,4 +141,4 @@ register(
 )
 
 
-__all__ = ["PrivateProvider"]
+__all__ = ["PrivateProvider", "_parse_headers", "_verify_ssl_from_env"]

--- a/experimental/python/perfxpert/perfxpert/providers/private_provider.py
+++ b/experimental/python/perfxpert/perfxpert/providers/private_provider.py
@@ -7,6 +7,7 @@ Optional TLS bypass for self-signed CAs (opt-in via env).
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 from typing import Any, Dict, List, Optional, Union
@@ -31,9 +32,13 @@ def _parse_headers(raw: str) -> Dict[str, str]:
     try:
         obj = json.loads(raw)
     except json.JSONDecodeError as e:
-        raise ValueError(
-            f"PERFXPERT_LLM_PRIVATE_HEADERS contains invalid JSON: {e}. " f"Value was: {raw[:80]!r}"
-        ) from e
+        try:
+            obj = ast.literal_eval(raw)
+        except (SyntaxError, ValueError) as literal_error:
+            raise ValueError(
+                "PERFXPERT_LLM_PRIVATE_HEADERS contains invalid JSON "
+                f"or Python literal dict: {e}. Value was: {raw[:80]!r}"
+            ) from literal_error
     if not isinstance(obj, dict):
         raise ValueError(f"PERFXPERT_LLM_PRIVATE_HEADERS must be a JSON object, got {type(obj).__name__}")
     return {str(k): str(v) for k, v in obj.items()}

--- a/experimental/python/perfxpert/pyproject.toml
+++ b/experimental/python/perfxpert/pyproject.toml
@@ -84,6 +84,7 @@ exclude = ["tests*", "opencode*"]
 [tool.setuptools.package-data]
 perfxpert = [
     "formatters/templates/*.html",
+    "_bundled/opencode",
     "_bundled/**/*",
     "_bundled/opencode_config/*",
     "knowledge/*.yaml",

--- a/experimental/python/perfxpert/scripts/build-bundled-opencode.sh
+++ b/experimental/python/perfxpert/scripts/build-bundled-opencode.sh
@@ -55,9 +55,6 @@ Install bun (one line, no root required):
 
 Then re-run:
     perfxpert-code install-patches
-
-Or point perfxpert at an already-built opencode binary:
-    export PERFXPERT_OPENCODE_PATH=/path/to/opencode
 EOF
   exit 2
 fi

--- a/experimental/python/perfxpert/scripts/build-bundled-opencode.sh
+++ b/experimental/python/perfxpert/scripts/build-bundled-opencode.sh
@@ -97,8 +97,8 @@ else
 fi
 
 cd "${SUBMODULE}/packages/opencode"
-echo "build-bundled-opencode: compiling opencode (bun run build --single)"
-bun run build --single
+echo "build-bundled-opencode: compiling opencode (bun run build --single --skip-install)"
+bun run build --single --skip-install
 
 file_size_bytes() {
   local path="$1"

--- a/experimental/python/perfxpert/scripts/pip-install-from-git.sh
+++ b/experimental/python/perfxpert/scripts/pip-install-from-git.sh
@@ -9,7 +9,8 @@
 #   bash scripts/pip-install-from-git.sh --extras '' --no-deps
 #
 # Notes:
-#   - Requires `git` because pip shells out to `git clone` for VCS installs.
+#   - Uses the host package manager to install missing OS prerequisites when
+#     running as root or when sudo is available.
 #   - Requires Python 3 + `python -m pip` in the active environment.
 #   - On Ubuntu 24+ and other externally managed Python environments,
 #     create and activate a virtual environment first.
@@ -27,16 +28,16 @@ _print_python_prereqs() {
   cat <<'EOF'
 Install the prerequisites first:
   Ubuntu 22.04 / 24.04:
-    apt install -y curl git python3-venv python3-pip
+    apt install -y curl git unzip python3-venv python3-pip
     python3 -m venv .venv
   RHEL 9:
-    dnf install -y curl git python3.11 python3.11-pip
+    dnf install -y curl git unzip python3.11 python3.11-pip
     python3.11 -m venv .venv
   RHEL 10:
-    dnf install -y curl git python3 python3-pip
+    dnf install -y curl git unzip python3 python3-pip
     python3 -m venv .venv
   SLES 15:
-    zypper install -y curl git python311 python311-pip
+    zypper install -y curl git unzip python311 python311-pip
     python3.11 -m venv .venv
   . .venv/bin/activate
 EOF
@@ -64,24 +65,35 @@ Interpreter selection:
   already-installed `python3.10+` interpreter on PATH. It never downloads
   or installs a different Python runtime.
 
+OS prerequisite handling:
+  If curl, git, unzip, or a supported Python/pip pair is missing, the wrapper
+  installs the distro packages with apt-get, dnf, or zypper when it is running
+  as root or sudo is available. This is the package-manager install path.
+  Otherwise it prints the exact package-manager command to run first.
+
+Patched perfxpert-code guarantee:
+  The pip build hook bootstraps bun when needed, then builds the bundled
+  patched opencode binary from the pinned perfxpert submodule. The wrapper
+  exits non-zero if that bundled binary is still missing after install.
+
 Supported Ubuntu 24+ flow:
-  apt install -y curl git python3-venv python3-pip
+  apt install -y curl git unzip python3-venv python3-pip
   python3 -m venv .venv
   . .venv/bin/activate
   REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
 
 Prerequisite package examples by distro:
   Ubuntu 22.04 / 24.04:
-    apt install -y curl git python3-venv python3-pip
+    apt install -y curl git unzip python3-venv python3-pip
     python3 -m venv .venv
   RHEL 9:
-    dnf install -y curl git python3.11 python3.11-pip
+    dnf install -y curl git unzip python3.11 python3.11-pip
     python3.11 -m venv .venv
   RHEL 10:
-    dnf install -y curl git python3 python3-pip
+    dnf install -y curl git unzip python3 python3-pip
     python3 -m venv .venv
   SLES 15:
-    zypper install -y curl git python311 python311-pip
+    zypper install -y curl git unzip python311 python311-pip
     python3.11 -m venv .venv
     # SLES ships the supported interpreter as python3.11 after installing
     # the python311 packages.
@@ -91,10 +103,9 @@ Pin a specific ref, tag, or commit hash:
   REF=v0.2.0; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
   REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
 
-If `perfxpert-code` later reports that `opencode` is missing, install bun and
-run `perfxpert-code install-patches`, or point `PERFXPERT_OPENCODE_PATH` at an
-existing opencode binary:
-  curl -fsSL https://bun.sh/install | bash
+If you are NOT using this wrapper and `perfxpert-code` later reports that
+the bundled opencode binary is missing, reinstall with the OS prerequisites
+available so pip can bootstrap bun and build the pinned submodule bundle.
 EOF
 }
 
@@ -102,6 +113,129 @@ _die() {
   echo "pip-install-from-git: $*" >&2
   exit 2
 }
+
+_supported_python_with_pip_available() {
+  local candidate
+  for candidate in python python3 python3.14 python3.13 python3.12 python3.11 python3.10; do
+    if ! command -v "${candidate}" >/dev/null 2>&1; then
+      continue
+    fi
+    if "${candidate}" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' >/dev/null 2>&1 \
+      && "${candidate}" -m pip --version >/dev/null 2>&1; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+_run_with_privilege() {
+  local uid
+  uid="${EUID:-$(id -u 2>/dev/null || echo 1)}"
+  if [ "${uid}" = "0" ]; then
+    "$@"
+    return
+  fi
+  if command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+    return
+  fi
+  return 127
+}
+
+_install_os_prereqs_if_needed() {
+  local -a missing
+  missing=()
+
+  for tool in curl git unzip; do
+    if ! command -v "${tool}" >/dev/null 2>&1; then
+      missing+=("${tool}")
+    fi
+  done
+
+  if ! _supported_python_with_pip_available; then
+    missing+=("python3.10+ with pip")
+  fi
+
+  if [ "${#missing[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  echo "pip-install-from-git: missing OS prerequisites: ${missing[*]}" >&2
+  echo "pip-install-from-git: attempting package-manager install" >&2
+
+  if command -v apt-get >/dev/null 2>&1; then
+    if ! _run_with_privilege apt-get update; then
+      _die "failed to run apt-get update. Install prerequisites manually:
+$(_print_python_prereqs)"
+    fi
+    if ! _run_with_privilege apt-get install -y curl git unzip python3-venv python3-pip; then
+      _die "failed to install prerequisites with apt-get. Install them manually:
+$(_print_python_prereqs)"
+    fi
+    return 0
+  fi
+
+  if command -v dnf >/dev/null 2>&1; then
+    local version_major
+    version_major=""
+    if [ -r /etc/os-release ]; then
+      # shellcheck disable=SC1091
+      . /etc/os-release
+      version_major="${VERSION_ID%%.*}"
+    fi
+    if [ "${version_major}" = "9" ]; then
+      if ! _run_with_privilege dnf install -y curl git unzip python3.11 python3.11-pip; then
+        _die "failed to install prerequisites with dnf. Install them manually:
+$(_print_python_prereqs)"
+      fi
+    else
+      if ! _run_with_privilege dnf install -y curl git unzip python3 python3-pip; then
+        _die "failed to install prerequisites with dnf. Install them manually:
+$(_print_python_prereqs)"
+      fi
+    fi
+    return 0
+  fi
+
+  if command -v zypper >/dev/null 2>&1; then
+    if ! _run_with_privilege zypper --non-interactive install -y curl git unzip python311 python311-pip; then
+      _die "failed to install prerequisites with zypper. Install them manually:
+$(_print_python_prereqs)"
+    fi
+    return 0
+  fi
+
+  _die "no supported package manager found for missing prerequisites. Install them manually:
+$(_print_python_prereqs)"
+}
+
+for _arg in "$@"; do
+  case "${_arg}" in
+    -h|--help)
+      _print_help
+      exit 0
+      ;;
+  esac
+done
+
+_verify_bundled_perfxpert_code() {
+  "${_PYTHON}" -c '
+from importlib import resources
+import os
+import sys
+
+path = resources.files("perfxpert") / "_bundled" / "opencode"
+if not path.is_file():
+    print(f"missing bundled opencode: {path}", file=sys.stderr)
+    raise SystemExit(1)
+if not os.access(path, os.X_OK):
+    print(f"bundled opencode is not executable: {path}", file=sys.stderr)
+    raise SystemExit(1)
+print(path)
+'
+}
+
+_install_os_prereqs_if_needed
 
 _PYTHON=""
 for _candidate in python python3 python3.14 python3.13 python3.12 python3.11 python3.10; do
@@ -117,6 +251,17 @@ done
 if [ -z "${_PYTHON}" ]; then
   {
     echo "pip-install-from-git: Python 3.10+ is required."
+    echo
+    _print_python_prereqs
+  } >&2
+  exit 2
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  {
+    cat <<'EOF'
+pip-install-from-git: `curl` is required for the GitHub install path and bun bootstrap.
+EOF
     echo
     _print_python_prereqs
   } >&2
@@ -223,14 +368,15 @@ GIT_CONFIG_KEY_0=submodule.active \
 GIT_CONFIG_VALUE_0="${_SUBMODULE_SCOPE}" \
   "${_PYTHON}" -m pip install "${_PIP_ARGS[@]}" "${_SPEC}"
 
-if ! command -v bun >/dev/null 2>&1 && ! command -v opencode >/dev/null 2>&1 && [ -z "${PERFXPERT_OPENCODE_PATH:-}" ]; then
+if ! _BUNDLED_OPENCODE="$(_verify_bundled_perfxpert_code)"; then
   cat >&2 <<'EOF'
-pip-install-from-git: install completed, but `perfxpert-code` still needs an opencode binary.
+pip-install-from-git: install finished, but the bundled patched opencode binary was not produced.
 
-`perfxpert analyze`, `perfxpert-mcp`, and the Python API are ready now.
-To enable the interactive TUI, either:
-  1. install bun (`curl -fsSL https://bun.sh/install | bash`), then run `perfxpert-code install-patches`, or
-  2. install opencode separately and ensure it is on PATH, or
-  3. set PERFXPERT_OPENCODE_PATH=/path/to/opencode
+`perfxpert analyze`, `perfxpert-mcp`, and the Python API may still be installed,
+but this wrapper requires `perfxpert-code` to be ready end-to-end.
+Check the build output above, then retry the same command.
 EOF
+  exit 2
 fi
+
+echo "pip-install-from-git: bundled patched perfxpert-code ready at ${_BUNDLED_OPENCODE}" >&2

--- a/experimental/python/perfxpert/scripts/pip-install-from-git.sh
+++ b/experimental/python/perfxpert/scripts/pip-install-from-git.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# pip-install-from-git.sh — install perfxpert from the rocm-systems monorepo
+# while scoping git submodule init down to the opencode subtree only.
+#
+# Usage:
+#   bash scripts/pip-install-from-git.sh
+#   bash scripts/pip-install-from-git.sh v0.2.0
+#   bash scripts/pip-install-from-git.sh <SHA> --user
+#   bash scripts/pip-install-from-git.sh --extras '' --no-deps
+#
+# Notes:
+#   - Requires `git` because pip shells out to `git clone` for VCS installs.
+#   - Requires Python 3 + `python -m pip` in the active environment.
+#   - On Ubuntu 24+ and other externally managed Python environments,
+#     create and activate a virtual environment first.
+#   - Prefers the active `python`, then `python3`, then any other
+#     already-installed `python3.10+` interpreter on PATH. It never
+#     downloads or installs Python for you.
+
+set -euo pipefail
+
+readonly _DEFAULT_REPO_URL="https://github.com/ROCm/rocm-systems.git"
+readonly _SUBDIRECTORY="experimental/python/perfxpert"
+readonly _SUBMODULE_SCOPE="experimental/python/perfxpert/opencode"
+
+_print_python_prereqs() {
+  cat <<'EOF'
+Install the prerequisites first:
+  Ubuntu 22.04 / 24.04:
+    apt install -y curl git python3-venv python3-pip
+    python3 -m venv .venv
+  RHEL 9:
+    dnf install -y curl git python3.11 python3.11-pip
+    python3.11 -m venv .venv
+  RHEL 10:
+    dnf install -y curl git python3 python3-pip
+    python3 -m venv .venv
+  SLES 15:
+    zypper install -y curl git python311 python311-pip
+    python3.11 -m venv .venv
+  . .venv/bin/activate
+EOF
+}
+
+_print_help() {
+  cat <<'EOF'
+pip-install-from-git.sh — install perfxpert from the rocm-systems monorepo
+while scoping git submodule init down to the opencode subtree only.
+
+Usage:
+  bash scripts/pip-install-from-git.sh
+  bash scripts/pip-install-from-git.sh v0.2.0
+  bash scripts/pip-install-from-git.sh <SHA> --user
+  bash scripts/pip-install-from-git.sh --extras '' --no-deps
+
+Options:
+  --extras <name>   Optional extras to install (default: all).
+                    Use `--extras ''` to install the base package only.
+  --repo-url <url>  Override the git remote (default: ROCm/rocm-systems).
+  -h, --help        Show this help.
+
+Interpreter selection:
+  The wrapper prefers the active `python`, then `python3`, then any other
+  already-installed `python3.10+` interpreter on PATH. It never downloads
+  or installs a different Python runtime.
+
+Supported Ubuntu 24+ flow:
+  apt install -y curl git python3-venv python3-pip
+  python3 -m venv .venv
+  . .venv/bin/activate
+  REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
+
+Prerequisite package examples by distro:
+  Ubuntu 22.04 / 24.04:
+    apt install -y curl git python3-venv python3-pip
+    python3 -m venv .venv
+  RHEL 9:
+    dnf install -y curl git python3.11 python3.11-pip
+    python3.11 -m venv .venv
+  RHEL 10:
+    dnf install -y curl git python3 python3-pip
+    python3 -m venv .venv
+  SLES 15:
+    zypper install -y curl git python311 python311-pip
+    python3.11 -m venv .venv
+    # SLES ships the supported interpreter as python3.11 after installing
+    # the python311 packages.
+
+Pin a specific ref, tag, or commit hash:
+  REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
+  REF=v0.2.0; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
+  REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
+
+If `perfxpert-code` later reports that `opencode` is missing, install bun and
+run `perfxpert-code install-patches`, or point `PERFXPERT_OPENCODE_PATH` at an
+existing opencode binary:
+  curl -fsSL https://bun.sh/install | bash
+EOF
+}
+
+_die() {
+  echo "pip-install-from-git: $*" >&2
+  exit 2
+}
+
+_PYTHON=""
+for _candidate in python python3 python3.14 python3.13 python3.12 python3.11 python3.10; do
+  if ! command -v "${_candidate}" >/dev/null 2>&1; then
+    continue
+  fi
+  if "${_candidate}" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' >/dev/null 2>&1; then
+    _PYTHON="${_candidate}"
+    break
+  fi
+done
+
+if [ -z "${_PYTHON}" ]; then
+  {
+    echo "pip-install-from-git: Python 3.10+ is required."
+    echo
+    _print_python_prereqs
+  } >&2
+  exit 2
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+  {
+    cat <<'EOF'
+pip-install-from-git: `git` is required for the GitHub install path.
+EOF
+    echo
+    _print_python_prereqs
+  } >&2
+  exit 2
+fi
+
+if ! "${_PYTHON}" -m pip --version >/dev/null 2>&1; then
+  {
+    cat <<'EOF'
+pip-install-from-git: `python -m pip` is unavailable in the current environment.
+EOF
+    echo
+    _print_python_prereqs
+  } >&2
+  exit 2
+fi
+
+_IN_VENV="$("${_PYTHON}" -c 'import sys; print("1" if sys.prefix != getattr(sys, "base_prefix", sys.prefix) or hasattr(sys, "real_prefix") else "0")')"
+_EXTERNALLY_MANAGED="$("${_PYTHON}" -c 'import pathlib, sysconfig; print(pathlib.Path(sysconfig.get_path("stdlib")) / "EXTERNALLY-MANAGED")')"
+
+if [ "${_IN_VENV}" != "1" ] && [ -f "${_EXTERNALLY_MANAGED}" ]; then
+  {
+    cat <<'EOF'
+pip-install-from-git: the current Python is externally managed.
+EOF
+    echo
+    echo "Use a virtual environment first:"
+    _print_python_prereqs
+    echo '  REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"'
+  } >&2
+  exit 2
+fi
+
+_REF=""
+_EXTRAS="all"
+_REPO_URL="${_DEFAULT_REPO_URL}"
+declare -a _PIP_ARGS=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      _print_help
+      exit 0
+      ;;
+    --extras)
+      [ "$#" -ge 2 ] || _die "--extras requires a value"
+      _EXTRAS="$2"
+      shift 2
+      ;;
+    --repo-url)
+      [ "$#" -ge 2 ] || _die "--repo-url requires a value"
+      _REPO_URL="$2"
+      shift 2
+      ;;
+    --)
+      shift
+      while [ "$#" -gt 0 ]; do
+        _PIP_ARGS+=("$1")
+        shift
+      done
+      ;;
+    -*)
+      _PIP_ARGS+=("$1")
+      shift
+      ;;
+    *)
+      if [ -z "${_REF}" ]; then
+        _REF="$1"
+      else
+        _PIP_ARGS+=("$1")
+      fi
+      shift
+      ;;
+  esac
+done
+
+_PACKAGE="perfxpert"
+if [ -n "${_EXTRAS}" ]; then
+  _PACKAGE="${_PACKAGE}[${_EXTRAS}]"
+fi
+
+_VCS_TARGET="git+${_REPO_URL}"
+if [ -n "${_REF}" ]; then
+  _VCS_TARGET="${_VCS_TARGET}@${_REF}"
+fi
+
+_SPEC="${_PACKAGE} @ ${_VCS_TARGET}#subdirectory=${_SUBDIRECTORY}"
+
+echo "pip-install-from-git: installing ${_SPEC}" >&2
+
+GIT_CONFIG_COUNT=1 \
+GIT_CONFIG_KEY_0=submodule.active \
+GIT_CONFIG_VALUE_0="${_SUBMODULE_SCOPE}" \
+  "${_PYTHON}" -m pip install "${_PIP_ARGS[@]}" "${_SPEC}"
+
+if ! command -v bun >/dev/null 2>&1 && ! command -v opencode >/dev/null 2>&1 && [ -z "${PERFXPERT_OPENCODE_PATH:-}" ]; then
+  cat >&2 <<'EOF'
+pip-install-from-git: install completed, but `perfxpert-code` still needs an opencode binary.
+
+`perfxpert analyze`, `perfxpert-mcp`, and the Python API are ready now.
+To enable the interactive TUI, either:
+  1. install bun (`curl -fsSL https://bun.sh/install | bash`), then run `perfxpert-code install-patches`, or
+  2. install opencode separately and ensure it is on PATH, or
+  3. set PERFXPERT_OPENCODE_PATH=/path/to/opencode
+EOF
+fi

--- a/experimental/python/perfxpert/scripts/pip-install-from-git.sh
+++ b/experimental/python/perfxpert/scripts/pip-install-from-git.sh
@@ -31,10 +31,12 @@ Install the prerequisites first:
     apt install -y curl git unzip python3-venv python3-pip
     python3 -m venv .venv
   RHEL 9:
-    dnf install -y curl git unzip python3.11 python3.11-pip
+    command -v curl >/dev/null || dnf install -y curl
+    dnf install -y git unzip python3.11 python3.11-pip
     python3.11 -m venv .venv
   RHEL 10:
-    dnf install -y curl git unzip python3 python3-pip
+    command -v curl >/dev/null || dnf install -y curl
+    dnf install -y git unzip python3 python3-pip
     python3 -m venv .venv
   SLES 15:
     zypper install -y curl git unzip python311 python311-pip
@@ -87,10 +89,12 @@ Prerequisite package examples by distro:
     apt install -y curl git unzip python3-venv python3-pip
     python3 -m venv .venv
   RHEL 9:
-    dnf install -y curl git unzip python3.11 python3.11-pip
+    command -v curl >/dev/null || dnf install -y curl
+    dnf install -y git unzip python3.11 python3.11-pip
     python3.11 -m venv .venv
   RHEL 10:
-    dnf install -y curl git unzip python3 python3-pip
+    command -v curl >/dev/null || dnf install -y curl
+    dnf install -y git unzip python3 python3-pip
     python3 -m venv .venv
   SLES 15:
     zypper install -y curl git unzip python311 python311-pip
@@ -145,15 +149,28 @@ _run_with_privilege() {
 _install_os_prereqs_if_needed() {
   local -a missing
   missing=()
+  local need_curl need_git need_unzip need_python
+  need_curl=0
+  need_git=0
+  need_unzip=0
+  need_python=0
 
-  for tool in curl git unzip; do
-    if ! command -v "${tool}" >/dev/null 2>&1; then
-      missing+=("${tool}")
-    fi
-  done
+  if ! command -v curl >/dev/null 2>&1; then
+    missing+=("curl")
+    need_curl=1
+  fi
+  if ! command -v git >/dev/null 2>&1; then
+    missing+=("git")
+    need_git=1
+  fi
+  if ! command -v unzip >/dev/null 2>&1; then
+    missing+=("unzip")
+    need_unzip=1
+  fi
 
   if ! _supported_python_with_pip_available; then
     missing+=("python3.10+ with pip")
+    need_python=1
   fi
 
   if [ "${#missing[@]}" -eq 0 ]; then
@@ -164,11 +181,17 @@ _install_os_prereqs_if_needed() {
   echo "pip-install-from-git: attempting package-manager install" >&2
 
   if command -v apt-get >/dev/null 2>&1; then
+    local -a apt_packages
+    apt_packages=()
+    [ "${need_curl}" = "1" ] && apt_packages+=("curl")
+    [ "${need_git}" = "1" ] && apt_packages+=("git")
+    [ "${need_unzip}" = "1" ] && apt_packages+=("unzip")
+    [ "${need_python}" = "1" ] && apt_packages+=("python3-venv" "python3-pip")
     if ! _run_with_privilege apt-get update; then
       _die "failed to run apt-get update. Install prerequisites manually:
 $(_print_python_prereqs)"
     fi
-    if ! _run_with_privilege apt-get install -y curl git unzip python3-venv python3-pip; then
+    if ! _run_with_privilege apt-get install -y "${apt_packages[@]}"; then
       _die "failed to install prerequisites with apt-get. Install them manually:
 $(_print_python_prereqs)"
     fi
@@ -177,19 +200,26 @@ $(_print_python_prereqs)"
 
   if command -v dnf >/dev/null 2>&1; then
     local version_major
+    local -a dnf_packages
     version_major=""
+    dnf_packages=()
     if [ -r /etc/os-release ]; then
       # shellcheck disable=SC1091
       . /etc/os-release
       version_major="${VERSION_ID%%.*}"
     fi
+    [ "${need_curl}" = "1" ] && dnf_packages+=("curl")
+    [ "${need_git}" = "1" ] && dnf_packages+=("git")
+    [ "${need_unzip}" = "1" ] && dnf_packages+=("unzip")
     if [ "${version_major}" = "9" ]; then
-      if ! _run_with_privilege dnf install -y curl git unzip python3.11 python3.11-pip; then
+      [ "${need_python}" = "1" ] && dnf_packages+=("python3.11" "python3.11-pip")
+      if ! _run_with_privilege dnf install -y "${dnf_packages[@]}"; then
         _die "failed to install prerequisites with dnf. Install them manually:
 $(_print_python_prereqs)"
       fi
     else
-      if ! _run_with_privilege dnf install -y curl git unzip python3 python3-pip; then
+      [ "${need_python}" = "1" ] && dnf_packages+=("python3" "python3-pip")
+      if ! _run_with_privilege dnf install -y "${dnf_packages[@]}"; then
         _die "failed to install prerequisites with dnf. Install them manually:
 $(_print_python_prereqs)"
       fi
@@ -198,7 +228,13 @@ $(_print_python_prereqs)"
   fi
 
   if command -v zypper >/dev/null 2>&1; then
-    if ! _run_with_privilege zypper --non-interactive install -y curl git unzip python311 python311-pip; then
+    local -a zypper_packages
+    zypper_packages=()
+    [ "${need_curl}" = "1" ] && zypper_packages+=("curl")
+    [ "${need_git}" = "1" ] && zypper_packages+=("git")
+    [ "${need_unzip}" = "1" ] && zypper_packages+=("unzip")
+    [ "${need_python}" = "1" ] && zypper_packages+=("python311" "python311-pip")
+    if ! _run_with_privilege zypper --non-interactive install -y "${zypper_packages[@]}"; then
       _die "failed to install prerequisites with zypper. Install them manually:
 $(_print_python_prereqs)"
     fi

--- a/experimental/python/perfxpert/scripts/pip-install-from-git.sh
+++ b/experimental/python/perfxpert/scripts/pip-install-from-git.sh
@@ -359,7 +359,14 @@ if [ -n "${_REF}" ]; then
   _VCS_TARGET="${_VCS_TARGET}@${_REF}"
 fi
 
-_SPEC="${_PACKAGE} @ ${_VCS_TARGET}#subdirectory=${_SUBDIRECTORY}"
+if [[ "${_REPO_URL}" == file://* ]]; then
+  # Older pip releases reject the PEP 508 direct-reference form for
+  # git+file URLs. Keep the customer HTTPS path on PEP 508, but use pip's
+  # VCS URL form for local validation and air-gap mirrors.
+  _SPEC="${_VCS_TARGET}#egg=${_PACKAGE}&subdirectory=${_SUBDIRECTORY}"
+else
+  _SPEC="${_PACKAGE} @ ${_VCS_TARGET}#subdirectory=${_SUBDIRECTORY}"
+fi
 
 echo "pip-install-from-git: installing ${_SPEC}" >&2
 

--- a/experimental/python/perfxpert/setup.py
+++ b/experimental/python/perfxpert/setup.py
@@ -10,16 +10,17 @@ Behavior:
 * Pre-build (``build_py``), pre-editable-install (``develop`` /
   ``editable_wheel``): invoke the build script if the bundled binary
   is missing OR older than the patch series.
-* If ``bun`` is not on PATH: DO NOT download build tooling during
-  ``pip install``. Emit a warning and skip the bundled opencode build.
-  Install still succeeds —
-  only ``perfxpert-code`` is affected; library + analyze + MCP paths
-  all work regardless.
+* If ``bun`` is not on PATH: bootstrap bun into the user's home directory
+  and add it to PATH for this build. If the OS-level prerequisites needed
+  for that bootstrap are missing, fail with distro-specific package-manager
+  guidance instead of silently producing a broken ``perfxpert-code``.
 * Opt-out via ``PERFXPERT_SKIP_BUNDLED_BUILD=1`` — useful in
-  tightly-sandboxed CI where network isn't available.
+  tightly-sandboxed CI where network isn't available and the interactive
+  ``perfxpert-code`` TUI is intentionally not being built.
 * The setup hook will initialize the repo-pinned opencode submodule
-  when possible. If the source tree is missing that submodule, it warns
-  and skips rather than cloning a mutable upstream tag during install.
+  when possible. If the source tree is missing that submodule, it fails
+  with an actionable message rather than cloning a mutable upstream tag
+  during install.
 """
 
 from __future__ import annotations
@@ -87,24 +88,106 @@ _PATCHES_DIR = _HERE / ".patches"
 _OPENCODE_DIR = _HERE / "opencode"
 _SKIP_ENV = "PERFXPERT_SKIP_BUNDLED_BUILD"
 _SKIP_OPENCODE_FETCH_ENV = "PERFXPERT_SKIP_OPENCODE_FETCH"
+_DEFAULT_BUN_INSTALL_URL = "https://bun.sh/install"
+
+
+def _package_manager_prereq_hint() -> str:
+    return (
+        "Install the OS prerequisites first:\n"
+        "  Ubuntu 22.04 / 24.04:\n"
+        "    apt install -y curl git unzip python3-venv python3-pip\n"
+        "  RHEL 9:\n"
+        "    dnf install -y curl git unzip python3.11 python3.11-pip\n"
+        "  RHEL 10:\n"
+        "    dnf install -y curl git unzip python3 python3-pip\n"
+        "  SLES 15:\n"
+        "    zypper install -y curl git unzip python311 python311-pip\n"
+    )
+
+
+def _missing_os_prereqs() -> list[str]:
+    missing: list[str] = []
+    for tool in ("bash", "curl", "git", "unzip"):
+        if shutil.which(tool) is None:
+            missing.append(tool)
+    return missing
+
+
+def _fail_build(message: str) -> None:
+    print(
+        f"[perfxpert/setup.py] ERROR: {message}\n\n{_package_manager_prereq_hint()}",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+
+def _run_bun_install_script(env: dict[str, str]) -> int:
+    url = os.environ.get("PERFXPERT_BUN_INSTALL_URL", _DEFAULT_BUN_INSTALL_URL)
+    curl = shutil.which("curl")
+    bash = shutil.which("bash")
+    if curl is None or bash is None:
+        missing = ", ".join(_missing_os_prereqs())
+        _fail_build(f"missing OS prerequisites for bun bootstrap: {missing}.")
+
+    curl_proc = subprocess.Popen(
+        [curl, "-fsSL", url],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        text=False,
+    )
+    assert curl_proc.stdout is not None
+    bash_proc = subprocess.run(
+        [bash],
+        stdin=curl_proc.stdout,
+        env=env,
+        check=False,
+    )
+    curl_proc.stdout.close()
+    _, curl_stderr = curl_proc.communicate()
+    if curl_proc.returncode != 0:
+        sys.stderr.write(curl_stderr.decode("utf-8", errors="replace"))
+        return curl_proc.returncode
+    return bash_proc.returncode
 
 
 def _ensure_bun_on_path() -> str | None:
     """Return a PATH env string that includes an available bun binary.
 
-    Returns ``None`` if bun is unavailable. The setup hook deliberately
-    refuses to download build tooling during ``pip install``.
+    Bootstraps bun into ``$BUN_INSTALL`` when needed so ``pip install`` can
+    produce the bundled patched ``perfxpert-code`` binary end to end.
     """
     existing = shutil.which("bun")
     if existing:
         return os.environ.get("PATH", "")
+    missing = _missing_os_prereqs()
+    if missing:
+        _fail_build(
+            "missing OS prerequisites for bundled perfxpert-code build: "
+            + ", ".join(missing)
+            + "."
+        )
+
+    bun_install = os.environ.get("BUN_INSTALL") or str(Path.home() / ".bun")
+    env = os.environ.copy()
+    env["BUN_INSTALL"] = bun_install
+
     print(
-        "[perfxpert/setup.py] bun not on PATH — refusing to download build "
-        "tooling during pip install. Install bun manually before building "
-        "the bundled opencode binary.",
+        "[perfxpert/setup.py] bun not on PATH — bootstrapping bun so the "
+        "bundled patched opencode binary is built during pip install.",
         file=sys.stderr,
     )
-    return None
+    rc = _run_bun_install_script(env)
+    if rc != 0:
+        _fail_build(f"bun bootstrap failed with exit code {rc}.")
+
+    bun_path = str(Path(bun_install) / "bin")
+    path = os.environ.get("PATH", "")
+    if bun_path not in path.split(os.pathsep):
+        path = bun_path + os.pathsep + path if path else bun_path
+    if shutil.which("bun", path=path) is None:
+        _fail_build(f"bun bootstrap finished but bun is unavailable under {bun_path}.")
+    return path
 
 
 # ---------------------------------------------------------------------------
@@ -190,7 +273,7 @@ def _ensure_opencode_checkout() -> bool:
     if os.environ.get(_SKIP_OPENCODE_FETCH_ENV, "").strip() in {"1", "true", "yes"}:
         print(
             f"[perfxpert/setup.py] {_SKIP_OPENCODE_FETCH_ENV}=1 — "
-            "not fetching opencode source; bundled build will be skipped.",
+            "not fetching opencode source.",
             file=sys.stderr,
         )
         return False
@@ -256,7 +339,8 @@ def _ensure_opencode_checkout() -> bool:
         "[perfxpert/setup.py] WARNING: opencode/ is empty and setup.py will "
         "not clone from the network during install. Initialize the pinned "
         f"submodule first (`git submodule update --init --depth 1 -- {rel_hint}`) "
-        "or set PERFXPERT_OPENCODE_PATH at runtime.",
+        "or use scripts/pip-install-from-git.sh so pip scopes submodule init "
+        "to the PerfXpert opencode submodule.",
         file=sys.stderr,
     )
     return False
@@ -289,6 +373,13 @@ def _run_opencode_build() -> None:
     print(f"[perfxpert/setup.py] opencode build: {reason}", file=sys.stderr)
     if not should_build:
         return
+    missing = _missing_os_prereqs()
+    if missing:
+        _fail_build(
+            "missing OS prerequisites for bundled perfxpert-code build: "
+            + ", ".join(missing)
+            + "."
+        )
     # Belt-and-suspenders: the opencode source tree is normally populated
     # by the enclosing git submodule init, but when the user invokes
     # `scripts/pip-install-from-git.sh` (or sets `submodule.active`
@@ -296,24 +387,13 @@ def _run_opencode_build() -> None:
     # be missing here. Check + fetch on-demand before the build script
     # tries to find package.json.
     if not _ensure_opencode_checkout():
-        print(
-            "[perfxpert/setup.py] WARNING: opencode source tree unavailable — "
-            "bundled opencode binary NOT built. Library + analyze + MCP "
-            "paths still work; `perfxpert-code` will exit with a helpful "
-            "error at first launch.",
-            file=sys.stderr,
+        _fail_build(
+            "opencode source tree unavailable. The default perfxpert-code "
+            "path requires the repo-pinned opencode submodule."
         )
-        return
     build_path = _ensure_bun_on_path()
     if build_path is None:
-        print(
-            "[perfxpert/setup.py] WARNING: bun not available — "
-            "bundled opencode binary NOT built. Library + analyze + MCP "
-            "paths still work; `perfxpert-code` will prompt to install "
-            "bun at first launch.",
-            file=sys.stderr,
-        )
-        return
+        _fail_build("bun is unavailable after bootstrap.")
     env = os.environ.copy()
     env["PATH"] = build_path
     result = subprocess.run(
@@ -323,12 +403,9 @@ def _run_opencode_build() -> None:
         check=False,
     )
     if result.returncode != 0:
-        # Don't fail the install — leave a clear breadcrumb.
-        print(
-            f"[perfxpert/setup.py] WARNING: build-bundled-opencode.sh exited "
-            f"{result.returncode}. `perfxpert-code` won't launch until you run "
-            f"`bash {_BUILD_SCRIPT.relative_to(_HERE)}` successfully.",
-            file=sys.stderr,
+        _fail_build(
+            f"build-bundled-opencode.sh exited {result.returncode}; "
+            "bundled perfxpert-code was not produced."
         )
 
 

--- a/experimental/python/perfxpert/setup.py
+++ b/experimental/python/perfxpert/setup.py
@@ -97,9 +97,11 @@ def _package_manager_prereq_hint() -> str:
         "  Ubuntu 22.04 / 24.04:\n"
         "    apt install -y curl git unzip python3-venv python3-pip\n"
         "  RHEL 9:\n"
-        "    dnf install -y curl git unzip python3.11 python3.11-pip\n"
+        "    command -v curl >/dev/null || dnf install -y curl\n"
+        "    dnf install -y git unzip python3.11 python3.11-pip\n"
         "  RHEL 10:\n"
-        "    dnf install -y curl git unzip python3 python3-pip\n"
+        "    command -v curl >/dev/null || dnf install -y curl\n"
+        "    dnf install -y git unzip python3 python3-pip\n"
         "  SLES 15:\n"
         "    zypper install -y curl git unzip python311 python311-pip\n"
     )

--- a/experimental/python/perfxpert/setup.py
+++ b/experimental/python/perfxpert/setup.py
@@ -107,12 +107,24 @@ def _package_manager_prereq_hint() -> str:
     )
 
 
-def _missing_os_prereqs() -> list[str]:
+def _missing_tools(tools: tuple[str, ...]) -> list[str]:
     missing: list[str] = []
-    for tool in ("bash", "curl", "git", "unzip"):
+    for tool in tools:
         if shutil.which(tool) is None:
             missing.append(tool)
     return missing
+
+
+def _missing_build_prereqs() -> list[str]:
+    return _missing_tools(("bash", "git"))
+
+
+def _missing_bun_bootstrap_prereqs() -> list[str]:
+    return _missing_tools(("bash", "curl", "unzip"))
+
+
+def _missing_os_prereqs() -> list[str]:
+    return _missing_tools(("bash", "curl", "git", "unzip"))
 
 
 def _fail_build(message: str) -> None:
@@ -125,11 +137,17 @@ def _fail_build(message: str) -> None:
 
 def _run_bun_install_script(env: dict[str, str]) -> int:
     url = os.environ.get("PERFXPERT_BUN_INSTALL_URL", _DEFAULT_BUN_INSTALL_URL)
+    missing = _missing_bun_bootstrap_prereqs()
+    if missing:
+        _fail_build(
+            "missing OS prerequisites for bun bootstrap: "
+            + ", ".join(missing)
+            + "."
+        )
     curl = shutil.which("curl")
     bash = shutil.which("bash")
-    if curl is None or bash is None:
-        missing = ", ".join(_missing_os_prereqs())
-        _fail_build(f"missing OS prerequisites for bun bootstrap: {missing}.")
+    assert curl is not None
+    assert bash is not None
 
     curl_proc = subprocess.Popen(
         [curl, "-fsSL", url],
@@ -162,10 +180,10 @@ def _ensure_bun_on_path() -> str | None:
     existing = shutil.which("bun")
     if existing:
         return os.environ.get("PATH", "")
-    missing = _missing_os_prereqs()
+    missing = _missing_bun_bootstrap_prereqs()
     if missing:
         _fail_build(
-            "missing OS prerequisites for bundled perfxpert-code build: "
+            "missing OS prerequisites for bun bootstrap: "
             + ", ".join(missing)
             + "."
         )
@@ -358,7 +376,7 @@ def _opencode_build_needed() -> tuple[bool, str]:
     if os.environ.get(_SKIP_ENV, "").strip() in {"1", "true", "yes"}:
         return False, f"{_SKIP_ENV}=1 — skipping bundled opencode build"
     if not _BUILD_SCRIPT.is_file():
-        return False, f"build script missing ({_BUILD_SCRIPT}); nothing to do"
+        return True, f"build script missing ({_BUILD_SCRIPT})"
     # Rebuild when the binary is missing OR older than the newest patch.
     if not _BUNDLE_PATH.is_file():
         return True, "bundled opencode binary missing — building"
@@ -375,7 +393,12 @@ def _run_opencode_build() -> None:
     print(f"[perfxpert/setup.py] opencode build: {reason}", file=sys.stderr)
     if not should_build:
         return
-    missing = _missing_os_prereqs()
+    if not _BUILD_SCRIPT.is_file():
+        _fail_build(
+            f"required bundled opencode build script is missing: {_BUILD_SCRIPT}. "
+            f"Set {_SKIP_ENV}=1 only if this build intentionally excludes perfxpert-code."
+        )
+    missing = _missing_build_prereqs()
     if missing:
         _fail_build(
             "missing OS prerequisites for bundled perfxpert-code build: "

--- a/experimental/python/perfxpert/tests/test_agents/test_framework.py
+++ b/experimental/python/perfxpert/tests/test_agents/test_framework.py
@@ -1,5 +1,7 @@
 """Tests for perfxpert.agents.framework — the SDK facade."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from perfxpert.agents import framework
@@ -421,7 +423,10 @@ def test_sdk_invoke_preserves_provider_taxonomy(monkeypatch):
         ("private", "private/gpt-4o-mini"),
     ],
 )
-def test_resolve_model_qualifies_non_openai_providers(provider, expected):
+def test_resolve_model_qualifies_non_openai_providers(provider, expected, monkeypatch):
+    monkeypatch.delenv("PERFXPERT_LLM_PRIVATE_MODEL", raising=False)
+    monkeypatch.delenv(f"PERFXPERT_AGENTS_MODEL_{provider.upper()}", raising=False)
+    monkeypatch.delenv("PERFXPERT_LLM_MODEL", raising=False)
     assert framework._resolve_model(provider) == expected
 
 
@@ -431,6 +436,11 @@ def test_resolve_model_preserves_explicit_prefixed_override(monkeypatch):
         "litellm/anthropic/claude-3-7-sonnet-latest",
     )
     assert framework._resolve_model("anthropic") == "litellm/anthropic/claude-3-7-sonnet-latest"
+
+
+def test_resolve_model_uses_private_specific_model_env(monkeypatch):
+    monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_MODEL", "gpt-5.3-codex")
+    assert framework._resolve_model("private") == "private/gpt-5.3-codex"
 
 
 def test_sdk_invoke_builds_litellm_route_for_anthropic(monkeypatch):
@@ -490,8 +500,27 @@ def test_sdk_invoke_private_provider_uses_custom_openai_base_url(monkeypatch):
             captured["run_config"] = run_config
             return _FakeRunResult()
 
+    import agents.models.openai_provider as openai_provider_module
+    import openai as openai_module
+
+    class _FakeAsyncOpenAI:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+
+    class _FakeOpenAIProvider:
+        def __init__(self, **kwargs):
+            captured["provider_kwargs"] = kwargs
+
+    monkeypatch.setattr(openai_module, "AsyncOpenAI", _FakeAsyncOpenAI)
+    monkeypatch.setattr(openai_provider_module, "OpenAIProvider", _FakeOpenAIProvider)
+
     monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_URL", "https://llm.example/v1")
+    monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_MODEL", "internal-xl")
     monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_API_KEY", "sk-private")
+    monkeypatch.setenv(
+        "PERFXPERT_LLM_PRIVATE_HEADERS",
+        '{"Ocp-Apim-Subscription-Key": "secret", "api-version": "preview"}',
+    )
     monkeypatch.setattr(framework, "_SDK_AVAILABLE", True)
     monkeypatch.setattr(framework, "SdkAgent", _FakeSdkAgent)
     monkeypatch.setattr(framework, "SdkRunner", _FakeRunner)
@@ -509,8 +538,57 @@ def test_sdk_invoke_private_provider_uses_custom_openai_base_url(monkeypatch):
 
     framework._sdk_invoke(agent, {"user_query": "?"}, provider="private")
 
-    assert captured["model"] == "private/gpt-4o-mini"
+    assert captured["model"] == "private/internal-xl"
+    assert captured["client_kwargs"] == {
+        "api_key": "sk-private",
+        "base_url": "https://llm.example/v1",
+        "default_headers": {
+            "Ocp-Apim-Subscription-Key": "secret",
+            "api-version": "preview",
+        },
+    }
+    assert "openai_client" in captured["provider_kwargs"]
+    assert captured["provider_kwargs"]["use_responses"] is False
     assert "model_provider" in captured["run_config"]["kwargs"]
+
+
+def test_sdk_invoke_opencode_dispatches_to_subprocess_provider(monkeypatch):
+    captured = {}
+
+    class _FakeOpencodeProvider:
+        def complete(self, messages, *, system="", model=None, **_kwargs):
+            captured["messages"] = messages
+            captured["system"] = system
+            captured["model"] = model
+            return SimpleNamespace(
+                content='{"narrative": "ok"}',
+                provider="opencode",
+                model=model or "opencode-default",
+            )
+
+    import perfxpert.providers.opencode_provider as opencode_provider_module
+
+    monkeypatch.setenv("PERFXPERT_AGENTS_MODEL_OPENCODE", "github-copilot/gpt-5")
+    monkeypatch.setattr(opencode_provider_module, "OpencodeProvider", _FakeOpencodeProvider)
+    monkeypatch.setattr(framework, "_SDK_AVAILABLE", False)
+
+    agent = Agent(
+        name="T",
+        layer=1,
+        fence_path=None,
+        input_schema=dict,
+        output_schema=dict,
+        tools=[],
+    )
+
+    response = framework._sdk_invoke(agent, {"user_query": "?"}, provider="opencode")
+
+    assert captured["model"] == "github-copilot/gpt-5"
+    assert captured["messages"][0]["role"] == "user"
+    assert "user_query" in captured["messages"][0]["content"]
+    assert "You are the T agent" in captured["system"]
+    assert response.text == '{"narrative": "ok"}'
+    assert response.structured_output == {"narrative": "ok"}
 
 
 def test_sdk_invoke_maps_rate_limit_like_runtime_errors(monkeypatch):

--- a/experimental/python/perfxpert/tests/test_agents/test_framework.py
+++ b/experimental/python/perfxpert/tests/test_agents/test_framework.py
@@ -1,5 +1,7 @@
 """Tests for perfxpert.agents.framework — the SDK facade."""
 
+import inspect
+from functools import partial
 from types import SimpleNamespace
 
 import pytest
@@ -362,6 +364,27 @@ def test_sdk_invoke_wires_openai_agents_sdk(monkeypatch):
     assert captured["run_config"] == {"kwargs": {}}
 
 
+def test_translate_tools_accepts_partial_callables(monkeypatch):
+    captured = {}
+
+    def _fake_function_tool(fn, *, name_override, strict_mode):
+        captured["callable_name"] = fn.__name__
+        return {"name": name_override, "fn": fn}
+
+    def _create_at(root, title):
+        return f"{root}:{title}"
+
+    monkeypatch.setattr(framework, "sdk_function_tool", _fake_function_tool)
+
+    tool = ToolBinding(name="tasks.create", fn=partial(_create_at, "demo-app"))
+    wrapped = framework._translate_tools([tool])
+
+    assert captured["callable_name"] == "tasks_create"
+    assert wrapped[0]["name"] == "tasks_create"
+    assert wrapped[0]["fn"]("check") == "demo-app:check"
+    assert str(inspect.signature(wrapped[0]["fn"])) == "(title)"
+
+
 def test_sdk_invoke_raises_runtime_error_when_sdk_missing(monkeypatch):
     """When openai-agents is not installed, _sdk_invoke must raise RuntimeError
     with an actionable message — NOT NotImplementedError."""
@@ -511,12 +534,20 @@ def test_sdk_invoke_private_provider_uses_custom_openai_base_url(monkeypatch):
         def __init__(self, **kwargs):
             captured["provider_kwargs"] = kwargs
 
+    import httpx as httpx_module
     monkeypatch.setattr(openai_module, "AsyncOpenAI", _FakeAsyncOpenAI)
     monkeypatch.setattr(openai_provider_module, "OpenAIProvider", _FakeOpenAIProvider)
+
+    class _FakeAsyncClient:
+        def __init__(self, **kwargs):
+            captured["http_client_kwargs"] = kwargs
+
+    monkeypatch.setattr(httpx_module, "AsyncClient", _FakeAsyncClient)
 
     monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_URL", "https://llm.example/v1")
     monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_MODEL", "internal-xl")
     monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_API_KEY", "sk-private")
+    monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_VERIFY_SSL", "false")
     monkeypatch.setenv(
         "PERFXPERT_LLM_PRIVATE_HEADERS",
         '{"Ocp-Apim-Subscription-Key": "secret", "api-version": "preview"}',
@@ -539,14 +570,14 @@ def test_sdk_invoke_private_provider_uses_custom_openai_base_url(monkeypatch):
     framework._sdk_invoke(agent, {"user_query": "?"}, provider="private")
 
     assert captured["model"] == "private/internal-xl"
-    assert captured["client_kwargs"] == {
-        "api_key": "sk-private",
-        "base_url": "https://llm.example/v1",
-        "default_headers": {
-            "Ocp-Apim-Subscription-Key": "secret",
-            "api-version": "preview",
-        },
+    assert captured["client_kwargs"]["api_key"] == "sk-private"
+    assert captured["client_kwargs"]["base_url"] == "https://llm.example/v1"
+    assert captured["client_kwargs"]["default_headers"] == {
+        "Ocp-Apim-Subscription-Key": "secret",
+        "api-version": "preview",
     }
+    assert captured["client_kwargs"]["http_client"] is not None
+    assert captured["http_client_kwargs"] == {"verify": False}
     assert "openai_client" in captured["provider_kwargs"]
     assert captured["provider_kwargs"]["use_responses"] is False
     assert "model_provider" in captured["run_config"]["kwargs"]

--- a/experimental/python/perfxpert/tests/test_cli/test_analyze_args.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_analyze_args.py
@@ -12,10 +12,12 @@ This test suite asserts that the CLI surface maps `--format` to
 from __future__ import annotations
 
 import argparse
+from types import SimpleNamespace
 
 import pytest
 
 from perfxpert import analyze
+from perfxpert import output_config
 
 
 def _build_parsed_args(argv):
@@ -238,3 +240,79 @@ def test_execute_agentic_warns_on_unknown_kwargs(tmp_path, monkeypatch):
         f"expected RuntimeWarning mentioning 'some_future_flag'; got "
         f"{[str(w.message) for w in caught]}"
     )
+
+
+def _stub_agentic_render(monkeypatch, rendered: str = "REPORT") -> None:
+    from perfxpert import api as api_mod
+    from perfxpert.analysis import payload as payload_mod
+    from perfxpert import analyze as analyze_mod
+
+    monkeypatch.setattr(
+        api_mod,
+        "agent_root",
+        lambda **_kwargs: SimpleNamespace(
+            narrative="",
+            recommendations=[],
+            primary_bottleneck="mixed",
+            warnings=[],
+            metadata={},
+        ),
+    )
+    monkeypatch.setattr(payload_mod, "build_analysis_payload", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(analyze_mod, "_format_agentic_output", lambda *_args, **_kwargs: rendered)
+
+
+@pytest.mark.parametrize(
+    ("fmt", "ext"),
+    [("json", ".json"), ("markdown", ".md"), ("webview", ".html")],
+)
+def test_non_text_formats_default_to_file_output_without_output_flags(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    fmt,
+    ext,
+):
+    from perfxpert import analyze as analyze_mod
+
+    _stub_agentic_render(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    cfg = output_config.output_config(output_file=None, output_path=None)
+    analyze_mod._execute_agentic(None, config=cfg, output_format=fmt)
+
+    out = tmp_path / f"analysis{ext}"
+    assert out.read_text() == "REPORT"
+    assert f"Analysis written to: ./{out.name}" in capsys.readouterr().out
+
+
+def test_non_text_format_with_output_name_defaults_to_current_directory(
+    tmp_path,
+    monkeypatch,
+):
+    from perfxpert import analyze as analyze_mod
+
+    _stub_agentic_render(monkeypatch, rendered="{}")
+    monkeypatch.chdir(tmp_path)
+
+    cfg = output_config.output_config(output_file="custom-report", output_path=None)
+    analyze_mod._execute_agentic(None, config=cfg, output_format="json")
+
+    assert (tmp_path / "custom-report.json").read_text() == "{}"
+
+
+def test_text_format_without_output_flags_stays_on_stdout(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    from perfxpert import analyze as analyze_mod
+
+    _stub_agentic_render(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    cfg = output_config.output_config(output_file=None, output_path=None)
+    analyze_mod._execute_agentic(None, config=cfg, output_format="text")
+
+    assert capsys.readouterr().out == "REPORT\n"
+    assert list(tmp_path.iterdir()) == []

--- a/experimental/python/perfxpert/tests/test_cli/test_launcher_subcommands.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_launcher_subcommands.py
@@ -193,7 +193,7 @@ def test_route_install_patches_is_perfxpert_owned() -> None:
 
 class TestBundledPriority:
     """resolve_opencode_binary() priority order:
-       env override → _bundled → well-known → PATH.
+       repo-local patched build → _bundled.
 
     Requirement: the bundled binary wins over
     ~/.opencode/bin/opencode (upstream, unpatched).
@@ -251,26 +251,49 @@ class TestBundledPriority:
             f"bundled must win over upstream; got {resolved}"
         )
 
-    def test_env_override_wins_over_bundled(
+    def test_env_override_does_not_replace_default_bundle(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path
     ) -> None:
-        """PERFXPERT_OPENCODE_PATH trumps bundled — power-user escape hatch."""
+        """PERFXPERT_OPENCODE_PATH is not a replacement for the default bundle."""
         explicit = tmp_path / "mycustom" / "opencode"
         explicit.parent.mkdir(parents=True)
         explicit.write_text("#!/bin/sh\nexit 0\n")
         explicit.chmod(0o755)
+        bundled = tmp_path / "bundled" / "opencode"
+        bundled.parent.mkdir(parents=True)
+        bundled.write_text("#!/bin/sh\nexit 0\n")
+        bundled.chmod(0o755)
 
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _fake_as_file(p):
+            yield bundled
+
+        class _FakeTraversable:
+            def __truediv__(self, other):
+                return self
+
+            def is_file(self):
+                return True
+
+        monkeypatch.setattr(opencode_launcher.resources, "as_file", _fake_as_file)
+        monkeypatch.setattr(
+            opencode_launcher.resources,
+            "files",
+            lambda _pkg: _FakeTraversable(),
+        )
         monkeypatch.setenv("PERFXPERT_OPENCODE_PATH", str(explicit))
-        resolved = opencode_launcher.resolve_opencode_binary()
-        assert resolved == explicit
 
-    def test_wellknown_emits_warning_when_bundled_absent(
+        resolved = opencode_launcher.resolve_opencode_binary()
+        assert resolved == bundled
+
+    def test_default_path_refuses_wellknown_when_bundled_absent(
         self,
-        capsys: pytest.CaptureFixture,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path,
     ) -> None:
-        """Falling through to upstream must warn the user that patches aren't active."""
+        """The default TUI path must not silently use upstream opencode."""
         upstream = tmp_path / "home" / ".opencode" / "bin" / "opencode"
         upstream.parent.mkdir(parents=True)
         upstream.write_text("#!/bin/sh\nexit 0\n")
@@ -304,14 +327,54 @@ class TestBundledPriority:
             lambda: [upstream],
         )
         monkeypatch.delenv("PERFXPERT_OPENCODE_PATH", raising=False)
-        monkeypatch.delenv("PERFXPERT_SILENCE_UNPATCHED_WARNING", raising=False)
 
-        resolved = opencode_launcher.resolve_opencode_binary()
-        assert resolved == upstream
+        with pytest.raises(FileNotFoundError, match="bundled patched opencode"):
+            opencode_launcher.resolve_opencode_binary()
 
-        captured = capsys.readouterr()
-        assert "unpatched" in captured.err.lower()
-        assert "install-patches" in captured.err
+    def test_explicit_opencode_escape_hatch_uses_env_override(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        explicit = tmp_path / "mycustom" / "opencode"
+        explicit.parent.mkdir(parents=True)
+        explicit.write_text("#!/bin/sh\nexit 0\n")
+        explicit.chmod(0o755)
+
+        monkeypatch.setenv("PERFXPERT_OPENCODE_PATH", str(explicit))
+
+        resolved = opencode_launcher.resolve_user_opencode_binary()
+        assert resolved == explicit
+
+    def test_explicit_opencode_escape_hatch_routes_without_marker(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        explicit = tmp_path / "opencode"
+        explicit.write_text("#!/bin/sh\nexit 0\n")
+        explicit.chmod(0o755)
+        seen: dict[str, object] = {}
+
+        monkeypatch.setattr(
+            opencode_launcher,
+            "resolve_user_opencode_binary",
+            lambda: explicit,
+        )
+
+        def _fake_run(cmd, env=None, check=False, cwd=None):
+            seen["cmd"] = cmd
+            seen["env"] = env
+            seen["cwd"] = cwd
+
+            class _Result:
+                returncode = 0
+
+            return _Result()
+
+        monkeypatch.setattr(opencode_launcher.subprocess, "run", _fake_run)
+
+        rc = opencode_launcher.main(["opencode", "models"])
+
+        assert rc == 0
+        assert seen["cmd"] == [str(explicit), "models"]
+        assert "PERFXPERT_IN_OPENCODE_SESSION" not in seen["env"]
 
 
 class TestRunAutoAgentInject:

--- a/experimental/python/perfxpert/tests/test_cli/test_launcher_subcommands.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_launcher_subcommands.py
@@ -376,6 +376,20 @@ class TestBundledPriority:
         assert seen["cmd"] == [str(explicit), "models"]
         assert "PERFXPERT_IN_OPENCODE_SESSION" not in seen["env"]
 
+    def test_explicit_opencode_help_does_not_require_user_binary(
+        self, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        monkeypatch.setattr(
+            opencode_launcher,
+            "resolve_user_opencode_binary",
+            lambda: (_ for _ in ()).throw(FileNotFoundError("missing")),
+        )
+
+        rc = opencode_launcher.main(["--help", "opencode"])
+
+        assert rc == 0
+        assert "perfxpert-code opencode [args]" in capsys.readouterr().out
+
 
 class TestRunAutoAgentInject:
     """`perfxpert-code run ...` must load the perfxpert agent

--- a/experimental/python/perfxpert/tests/test_integration/test_install_docs.py
+++ b/experimental/python/perfxpert/tests/test_integration/test_install_docs.py
@@ -56,8 +56,9 @@ def test_install_wrapper_help_mentions_supported_prereqs() -> None:
     assert "pip build hook bootstraps bun" in result.stdout
     assert "package-manager install" in result.stdout
     assert "It never downloads" in result.stdout
-    assert "dnf install -y curl git unzip python3.11 python3.11-pip" in result.stdout
-    assert "dnf install -y curl git unzip python3 python3-pip" in result.stdout
+    assert "command -v curl >/dev/null || dnf install -y curl" in result.stdout
+    assert "dnf install -y git unzip python3.11 python3.11-pip" in result.stdout
+    assert "dnf install -y git unzip python3 python3-pip" in result.stdout
     assert "zypper install -y curl git unzip python311 python311-pip" in result.stdout
     assert "python3.11 -m venv .venv" in result.stdout
     assert 'REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"' in result.stdout
@@ -76,7 +77,8 @@ def test_install_wrapper_help_works_from_stdin() -> None:
     assert "pip build hook bootstraps bun" in result.stdout
     assert "package-manager install" in result.stdout
     assert "It never downloads" in result.stdout
-    assert "dnf install -y curl git unzip python3.11 python3.11-pip" in result.stdout
+    assert "command -v curl >/dev/null || dnf install -y curl" in result.stdout
+    assert "dnf install -y git unzip python3.11 python3.11-pip" in result.stdout
     assert "zypper install -y curl git unzip python311 python311-pip" in result.stdout
     assert 'REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"' in result.stdout
 
@@ -111,8 +113,9 @@ def test_getting_started_keeps_internal_install_detail() -> None:
     assert "never downloads a separate" in text
     assert "Python runtime" in text
     assert "pip bootstraps\nbun when the OS prerequisites are available" in text
-    assert "dnf install -y curl git unzip python3.11 python3.11-pip" in text
-    assert "dnf install -y curl git unzip python3 python3-pip" in text
+    assert "command -v curl >/dev/null || dnf install -y curl" in text
+    assert "dnf install -y git unzip python3.11 python3.11-pip" in text
+    assert "dnf install -y git unzip python3 python3-pip" in text
     assert "zypper install -y curl git unzip python311 python311-pip" in text
     assert "python3.11 -m venv .venv" in text
     assert 'REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"' in text
@@ -162,8 +165,9 @@ def test_install_wrapper_reports_missing_prereqs_when_package_manager_unavailabl
     assert "git" in result.stderr
     assert "unzip" in result.stderr
     assert "apt install -y curl git unzip python3-venv python3-pip" in result.stderr
-    assert "dnf install -y curl git unzip python3.11 python3.11-pip" in result.stderr
-    assert "dnf install -y curl git unzip python3 python3-pip" in result.stderr
+    assert "command -v curl >/dev/null || dnf install -y curl" in result.stderr
+    assert "dnf install -y git unzip python3.11 python3.11-pip" in result.stderr
+    assert "dnf install -y git unzip python3 python3-pip" in result.stderr
     assert "zypper install -y curl git unzip python311 python311-pip" in result.stderr
 
 
@@ -240,7 +244,88 @@ exit 0
     assert result.returncode == 0
     assert installed.read_text(encoding="utf-8").splitlines() == [
         "update",
-        "install -y curl git unzip python3-venv python3-pip",
+        "install -y curl unzip",
+    ]
+
+
+def test_install_wrapper_dnf_keeps_existing_curl_provider(tmp_path: Path) -> None:
+    """RHEL/UBI images can provide `curl` through curl-minimal.
+
+    The wrapper must not ask dnf to install full `curl` again when the command
+    is already present, because that conflicts with curl-minimal on UBI.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    bundled = tmp_path / "site-packages" / "perfxpert" / "_bundled" / "opencode"
+    bundled.parent.mkdir(parents=True)
+    bundled.write_text("fake-opencode", encoding="utf-8")
+    bundled.chmod(0o755)
+    _write_executable(
+        bin_dir / "python3",
+        f"""#!/bin/bash
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  echo "pip 24.0"
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+  exit 0
+fi
+if [ "$1" = "-c" ]; then
+  case "$2" in
+    *"sys.version_info"*)
+      exit 0
+      ;;
+    *'sys.prefix != getattr(sys, "base_prefix", sys.prefix)'*)
+      echo 1
+      exit 0
+      ;;
+    *'sysconfig.get_path("stdlib")'*)
+      echo "{tmp_path / 'missing-externally-managed'}"
+      exit 0
+      ;;
+    *'resources.files("perfxpert")'*)
+      echo "{bundled}"
+      exit 0
+      ;;
+  esac
+fi
+exit 99
+""",
+    )
+    _symlink_tool(bin_dir, "cat")
+    _symlink_tool(bin_dir, "chmod")
+    _write_executable(bin_dir / "curl", "#!/bin/sh\nexit 0\n")
+    _write_executable(
+        bin_dir / "sudo",
+        """#!/bin/bash
+"$@"
+""",
+    )
+    installed = tmp_path / "installed.txt"
+    _write_executable(
+        bin_dir / "dnf",
+        f"""#!/bin/bash
+echo "$*" >> "{installed}"
+if [ "$1" = "install" ]; then
+  printf '#!/bin/sh\\nexit 0\\n' > "{bin_dir}/git"
+  printf '#!/bin/sh\\nexit 0\\n' > "{bin_dir}/unzip"
+  chmod +x "{bin_dir}/git" "{bin_dir}/unzip"
+fi
+exit 0
+""",
+    )
+
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER), "develop"],
+        capture_output=True,
+        text=True,
+        env=_env_with_path(bin_dir),
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert installed.read_text(encoding="utf-8").splitlines() == [
+        "install -y git unzip",
     ]
 
 
@@ -312,8 +397,9 @@ exit 99
     assert "python3.10+ with pip" in result.stderr
     assert "no supported package manager found" in result.stderr
     assert "apt install -y curl git unzip python3-venv python3-pip" in result.stderr
-    assert "dnf install -y curl git unzip python3.11 python3.11-pip" in result.stderr
-    assert "dnf install -y curl git unzip python3 python3-pip" in result.stderr
+    assert "command -v curl >/dev/null || dnf install -y curl" in result.stderr
+    assert "dnf install -y git unzip python3.11 python3.11-pip" in result.stderr
+    assert "dnf install -y git unzip python3 python3-pip" in result.stderr
     assert "zypper install -y curl git unzip python311 python311-pip" in result.stderr
 
 
@@ -364,8 +450,9 @@ exit 99
     assert result.returncode == 2
     assert "the current Python is externally managed" in result.stderr
     assert "curl -fsSL" in result.stderr
-    assert "dnf install -y curl git unzip python3.11 python3.11-pip" in result.stderr
-    assert "dnf install -y curl git unzip python3 python3-pip" in result.stderr
+    assert "command -v curl >/dev/null || dnf install -y curl" in result.stderr
+    assert "dnf install -y git unzip python3.11 python3.11-pip" in result.stderr
+    assert "dnf install -y git unzip python3 python3-pip" in result.stderr
     assert "zypper install -y curl git unzip python311 python311-pip" in result.stderr
 
 

--- a/experimental/python/perfxpert/tests/test_integration/test_install_docs.py
+++ b/experimental/python/perfxpert/tests/test_integration/test_install_docs.py
@@ -1,0 +1,445 @@
+"""Guard the documented Git install path and cross-distro Python guidance."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+_APP_ROOT = Path(__file__).resolve().parents[2]
+_README = _APP_ROOT / "README.md"
+_GETTING_STARTED = _APP_ROOT / "docs" / "guides" / "getting-started.md"
+_INSTALL_WRAPPER = _APP_ROOT / "scripts" / "pip-install-from-git.sh"
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _env_with_path(path: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["PATH"] = str(path)
+    return env
+
+
+def test_install_wrapper_exists_and_is_non_empty() -> None:
+    assert _INSTALL_WRAPPER.is_file(), f"Missing install wrapper: {_INSTALL_WRAPPER}"
+    assert _INSTALL_WRAPPER.stat().st_size > 1_000, (
+        "Install wrapper is unexpectedly tiny; likely truncated."
+    )
+
+
+def test_install_wrapper_help_mentions_supported_prereqs() -> None:
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "curl" in result.stdout
+    assert "python3 -m venv .venv" in result.stdout
+    assert "python3-venv" in result.stdout
+    assert "python3-pip" in result.stdout
+    assert "git" in result.stdout
+    assert "bun.sh/install" in result.stdout
+    assert "It never downloads" in result.stdout
+    assert "dnf install -y curl git python3.11 python3.11-pip" in result.stdout
+    assert "dnf install -y curl git python3 python3-pip" in result.stdout
+    assert "zypper install -y curl git python311 python311-pip" in result.stdout
+    assert "python3.11 -m venv .venv" in result.stdout
+    assert 'REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"' in result.stdout
+
+
+def test_install_wrapper_help_works_from_stdin() -> None:
+    result = subprocess.run(
+        ["/bin/bash", "-lc", f"/bin/bash -s -- --help < {shlex.quote(str(_INSTALL_WRAPPER))}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "pip-install-from-git.sh" in result.stdout
+    assert "curl -fsSL" in result.stdout
+    assert "bun.sh/install" in result.stdout
+    assert "It never downloads" in result.stdout
+    assert "dnf install -y curl git python3.11 python3.11-pip" in result.stdout
+    assert "zypper install -y curl git python311 python311-pip" in result.stdout
+    assert 'REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"' in result.stdout
+
+
+def test_readme_keeps_customer_install_flow_curl_only() -> None:
+    text = _README.read_text(encoding="utf-8")
+    assert "curl" in text
+    assert "curl -fsSL https://bun.sh/install | bash" in text
+    assert "python3 -m venv .venv" in text
+    assert "python3-venv" in text
+    assert "python3-pip" in text
+    assert "never downloads a separate Python runtime" in text
+    assert 'REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"' in text
+    assert "GIT_CONFIG_COUNT=1" not in text
+    assert "git clone --depth 1 --no-recurse-submodules" not in text
+    assert "wget -qO-" not in text
+
+
+def test_getting_started_keeps_internal_install_detail() -> None:
+    text = _GETTING_STARTED.read_text(encoding="utf-8")
+    assert "curl" in text
+    assert "curl -fsSL https://bun.sh/install | bash" in text
+    assert "python3 -m venv .venv" in text
+    assert "python3-venv" in text
+    assert "python3-pip" in text
+    assert "never downloads a separate Python runtime" in text
+    assert "dnf install -y curl git python3.11 python3.11-pip" in text
+    assert "dnf install -y curl git python3 python3-pip" in text
+    assert "zypper install -y curl git python311 python311-pip" in text
+    assert "python3.11 -m venv .venv" in text
+    assert 'REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"' in text
+    assert "GIT_CONFIG_COUNT=1" in text
+    assert "bash rocm-systems/experimental/python/perfxpert/scripts/pip-install-from-git.sh <SHA>" in text
+    assert "wget -qO-" not in text
+
+
+def test_install_docs_do_not_recommend_break_system_packages() -> None:
+    for doc in (_README, _GETTING_STARTED):
+        text = doc.read_text(encoding="utf-8")
+        assert "--break-system-packages" not in text, (
+            f"{doc} must not recommend --break-system-packages."
+        )
+
+
+def test_install_docs_explain_perfxpert_code_follow_up() -> None:
+    for doc in (_README, _GETTING_STARTED):
+        text = doc.read_text(encoding="utf-8")
+        assert "perfxpert-code install-patches" in text, (
+            f"{doc} must explain how to enable perfxpert-code after a bun-less install."
+        )
+        assert "curl -fsSL https://bun.sh/install | bash" in text, (
+            f"{doc} must include the bun install command."
+        )
+        assert "opencode.ai/install" not in text, (
+            f"{doc} must not send users to an upstream opencode curl installer."
+        )
+
+
+def test_install_wrapper_fails_cleanly_when_git_missing(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    os.symlink(shutil.which("python3"), bin_dir / "python3")
+    os.symlink(shutil.which("cat"), bin_dir / "cat")
+
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER)],
+        capture_output=True,
+        text=True,
+        env=_env_with_path(bin_dir),
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "`git` is required" in result.stderr
+    assert "apt install -y curl git python3-venv python3-pip" in result.stderr
+    assert "dnf install -y curl git python3.11 python3.11-pip" in result.stderr
+    assert "dnf install -y curl git python3 python3-pip" in result.stderr
+    assert "zypper install -y curl git python311 python311-pip" in result.stderr
+
+
+def test_install_wrapper_rejects_python_older_than_310(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "python3",
+        """#!/bin/bash
+if [ "$1" = "-c" ]; then
+  exit 1
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  echo "pip 24.0"
+  exit 0
+fi
+exit 99
+""",
+    )
+    os.symlink(shutil.which("cat"), bin_dir / "cat")
+
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER)],
+        capture_output=True,
+        text=True,
+        env=_env_with_path(bin_dir),
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "Python 3.10+ is required" in result.stderr
+
+
+def test_install_wrapper_fails_when_python_m_pip_is_missing(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "python3",
+        """#!/bin/bash
+if [ "$1" = "-c" ]; then
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  exit 1
+fi
+exit 99
+""",
+    )
+    os.symlink(shutil.which("git"), bin_dir / "git")
+    os.symlink(shutil.which("cat"), bin_dir / "cat")
+
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER)],
+        capture_output=True,
+        text=True,
+        env=_env_with_path(bin_dir),
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "`python -m pip` is unavailable" in result.stderr
+    assert "apt install -y curl git python3-venv python3-pip" in result.stderr
+    assert "dnf install -y curl git python3.11 python3.11-pip" in result.stderr
+    assert "dnf install -y curl git python3 python3-pip" in result.stderr
+    assert "zypper install -y curl git python311 python311-pip" in result.stderr
+
+
+def test_install_wrapper_rejects_externally_managed_python(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    managed = tmp_path / "stdlib" / "EXTERNALLY-MANAGED"
+    managed.parent.mkdir()
+    managed.write_text("", encoding="utf-8")
+    _write_executable(
+        bin_dir / "python3",
+        f"""#!/bin/bash
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  echo "pip 24.0"
+  exit 0
+fi
+if [ "$1" = "-c" ]; then
+  case "$2" in
+    *"sys.version_info"*)
+      exit 0
+      ;;
+    *'sys.prefix != getattr(sys, "base_prefix", sys.prefix)'*)
+      echo 0
+      exit 0
+      ;;
+    *'sysconfig.get_path("stdlib")'*)
+      echo "{managed}"
+      exit 0
+      ;;
+  esac
+fi
+exit 99
+""",
+    )
+    os.symlink(shutil.which("cat"), bin_dir / "cat")
+    os.symlink(shutil.which("git"), bin_dir / "git")
+
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER)],
+        capture_output=True,
+        text=True,
+        env=_env_with_path(bin_dir),
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "the current Python is externally managed" in result.stderr
+    assert "curl -fsSL" in result.stderr
+    assert "dnf install -y curl git python3.11 python3.11-pip" in result.stderr
+    assert "dnf install -y curl git python3 python3-pip" in result.stderr
+    assert "zypper install -y curl git python311 python311-pip" in result.stderr
+
+
+def test_install_wrapper_reports_bunless_tui_follow_up(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "python3",
+        f"""#!/bin/bash
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  echo "pip 24.0"
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+  exit 0
+fi
+if [ "$1" = "-c" ]; then
+  case "$2" in
+    *"sys.version_info"*)
+      exit 0
+      ;;
+    *'sys.prefix != getattr(sys, "base_prefix", sys.prefix)'*)
+      echo 1
+      exit 0
+      ;;
+    *'sysconfig.get_path("stdlib")'*)
+      echo "{tmp_path / 'missing-externally-managed'}"
+      exit 0
+      ;;
+  esac
+fi
+exit 99
+""",
+    )
+    os.symlink(shutil.which("git"), bin_dir / "git")
+    os.symlink(shutil.which("cat"), bin_dir / "cat")
+
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER), "develop"],
+        capture_output=True,
+        text=True,
+        env=_env_with_path(bin_dir),
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "perfxpert-code install-patches" in result.stderr
+    assert "bun.sh/install" in result.stderr
+
+
+def test_install_wrapper_prefers_active_python_before_versioned_fallbacks(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    chosen = tmp_path / "chosen.txt"
+
+    _write_executable(
+        bin_dir / "python",
+        f"""#!/bin/bash
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  echo "pip 24.0"
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+  echo "python" > "{chosen}"
+  exit 0
+fi
+if [ "$1" = "-c" ]; then
+  case "$2" in
+    *"sys.version_info"*)
+      exit 0
+      ;;
+    *'sys.prefix != getattr(sys, "base_prefix", sys.prefix)'*)
+      echo 1
+      exit 0
+      ;;
+    *'sysconfig.get_path("stdlib")'*)
+      echo "{tmp_path / 'missing-externally-managed'}"
+      exit 0
+      ;;
+  esac
+fi
+exit 99
+""",
+    )
+    _write_executable(
+        bin_dir / "python3.11",
+        f"""#!/bin/bash
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+  echo "python3.11" > "{chosen}"
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  echo "pip 24.0"
+  exit 0
+fi
+if [ "$1" = "-c" ]; then
+  case "$2" in
+    *"sys.version_info"*)
+      exit 0
+      ;;
+    *'sys.prefix != getattr(sys, "base_prefix", sys.prefix)'*)
+      echo 1
+      exit 0
+      ;;
+    *'sysconfig.get_path("stdlib")'*)
+      echo "{tmp_path / 'missing-externally-managed'}"
+      exit 0
+      ;;
+  esac
+fi
+exit 99
+""",
+    )
+    os.symlink(shutil.which("git"), bin_dir / "git")
+    os.symlink(shutil.which("cat"), bin_dir / "cat")
+
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER), "develop"],
+        capture_output=True,
+        text=True,
+        env=_env_with_path(bin_dir),
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert chosen.read_text(encoding="utf-8").strip() == "python"
+
+
+def test_install_wrapper_falls_back_to_supported_versioned_python(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    chosen = tmp_path / "chosen.txt"
+
+    _write_executable(
+        bin_dir / "python3",
+        """#!/bin/bash
+if [ "$1" = "-c" ]; then
+  exit 1
+fi
+exit 99
+""",
+    )
+    _write_executable(
+        bin_dir / "python3.11",
+        f"""#!/bin/bash
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  echo "pip 24.0"
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+  echo "python3.11" > "{chosen}"
+  exit 0
+fi
+if [ "$1" = "-c" ]; then
+  case "$2" in
+    *"sys.version_info"*)
+      exit 0
+      ;;
+    *'sys.prefix != getattr(sys, "base_prefix", sys.prefix)'*)
+      echo 1
+      exit 0
+      ;;
+    *'sysconfig.get_path("stdlib")'*)
+      echo "{tmp_path / 'missing-externally-managed'}"
+      exit 0
+      ;;
+  esac
+fi
+exit 99
+""",
+    )
+    os.symlink(shutil.which("git"), bin_dir / "git")
+    os.symlink(shutil.which("cat"), bin_dir / "cat")
+
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER), "develop"],
+        capture_output=True,
+        text=True,
+        env=_env_with_path(bin_dir),
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert chosen.read_text(encoding="utf-8").strip() == "python3.11"

--- a/experimental/python/perfxpert/tests/test_integration/test_install_docs.py
+++ b/experimental/python/perfxpert/tests/test_integration/test_install_docs.py
@@ -91,21 +91,11 @@ def test_readme_keeps_customer_install_flow_curl_only() -> None:
     assert "python3 -m venv .venv" in text
     assert "python3-venv" in text
     assert "python3-pip" in text
-    assert "never downloads a separate" in text
-    assert "Python runtime" in text
-    assert "`setup.py`\nbootstraps bun when needed" in text
+    assert "bootstraps bun when needed" in text
     assert "No separate `opencode` install is needed" in text
-    assert "bundled `perfxpert-code` binary was built" in text
+    assert "patched bundled `perfxpert-code` binary" in text
     assert "builds the patched bundled" in text
-    for distro in (
-        "Ubuntu 22.04",
-        "Ubuntu 24.04",
-        "UBI/RHEL 9",
-        "UBI/RHEL 10",
-        "SLES 15.6",
-    ):
-        assert distro in text
-    assert "curl-minimal" in text
+    assert "Ubuntu/RHEL/SLES package matrix" in text
     assert "| `private` | Any OpenAI-compatible endpoint |" in text
     assert "PERFXPERT_LLM_PRIVATE_URL" in text
     assert "PERFXPERT_LLM_PRIVATE_MODEL" in text
@@ -118,6 +108,18 @@ def test_readme_keeps_customer_install_flow_curl_only() -> None:
     assert "git clone --depth 1 --no-recurse-submodules" not in text
     assert "wget -qO-" not in text
     assert "curl -fsSL https://bun.sh/install | bash" not in text
+
+
+def test_readme_keeps_copy_paste_command_shapes() -> None:
+    text = _README.read_text(encoding="utf-8")
+    assert "perfxpert analyze -i trace.db --llm anthropic --format webview -o report.html" in text
+    assert "perfxpert analyze -i trace.db --llm openai --llm-model gpt-4o-mini" in text
+    assert "PERFXPERT_AIRGAP=1 perfxpert analyze -i trace.db" in text
+    assert "\nperfxpert-code\n" in text
+    assert "perfxpert-code claude" in text
+    assert "perfxpert-code codex" in text
+    assert "perfxpert-code gemini" in text
+    assert 'PERFXPERT_OPENCODE_PATH="$(command -v opencode)" perfxpert-code opencode' in text
 
 
 def test_getting_started_keeps_internal_install_detail() -> None:
@@ -166,8 +168,8 @@ def test_install_docs_explain_perfxpert_code_follow_up() -> None:
     readme = _README.read_text(encoding="utf-8")
     guide = _GETTING_STARTED.read_text(encoding="utf-8")
 
-    assert "`setup.py`\nbootstraps bun when needed" in readme
-    assert "bundled patched `perfxpert-code` build completes" in readme
+    assert "bootstraps bun when needed" in readme
+    assert "verifies it before exiting" in readme
     assert "curl -fsSL https://bun.sh/install | bash" not in readme
     assert "Direct\npip/editable paths use the same `setup.py` build hook" in guide
     assert "pip exits with distro-specific package-manager guidance" in guide

--- a/experimental/python/perfxpert/tests/test_integration/test_install_docs.py
+++ b/experimental/python/perfxpert/tests/test_integration/test_install_docs.py
@@ -12,6 +12,7 @@ from pathlib import Path
 _APP_ROOT = Path(__file__).resolve().parents[2]
 _README = _APP_ROOT / "README.md"
 _GETTING_STARTED = _APP_ROOT / "docs" / "guides" / "getting-started.md"
+_AGENTIC_MODE = _APP_ROOT / "docs" / "guides" / "agentic-mode.md"
 _INSTALL_WRAPPER = _APP_ROOT / "scripts" / "pip-install-from-git.sh"
 
 
@@ -96,6 +97,22 @@ def test_readme_keeps_customer_install_flow_curl_only() -> None:
     assert "No separate `opencode` install is needed" in text
     assert "bundled `perfxpert-code` binary was built" in text
     assert "builds the patched bundled" in text
+    for distro in (
+        "Ubuntu 22.04",
+        "Ubuntu 24.04",
+        "UBI/RHEL 9",
+        "UBI/RHEL 10",
+        "SLES 15.6",
+    ):
+        assert distro in text
+    assert "curl-minimal" in text
+    assert "| `private` | Any OpenAI-compatible endpoint |" in text
+    assert "PERFXPERT_LLM_PRIVATE_URL" in text
+    assert "PERFXPERT_LLM_PRIVATE_MODEL" in text
+    assert "PERFXPERT_LLM_PRIVATE_API_KEY" in text
+    assert "PERFXPERT_LLM_PRIVATE_HEADERS" in text
+    assert "https://llm-api.iexample.com/OpenAI" in text
+    assert "Ocp-Apim-Subscription-Key" in text
     assert 'REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"' in text
     assert "GIT_CONFIG_COUNT=1" not in text
     assert "git clone --depth 1 --no-recurse-submodules" not in text
@@ -113,10 +130,23 @@ def test_getting_started_keeps_internal_install_detail() -> None:
     assert "never downloads a separate" in text
     assert "Python runtime" in text
     assert "pip bootstraps\nbun when the OS prerequisites are available" in text
+    for distro in (
+        "Ubuntu 22.04",
+        "Ubuntu 24.04",
+        "UBI/RHEL 9",
+        "UBI/RHEL 10",
+        "SLES 15.6",
+    ):
+        assert distro in text
+    assert "curl-minimal" in text
     assert "command -v curl >/dev/null || dnf install -y curl" in text
     assert "dnf install -y git unzip python3.11 python3.11-pip" in text
     assert "dnf install -y git unzip python3 python3-pip" in text
     assert "zypper install -y curl git unzip python311 python311-pip" in text
+    assert "bun run build --single\n--skip-install" in text
+    assert "PERFXPERT_LLM_PRIVATE_API_KEY` or `--llm-api-key" in text
+    assert "https://llm-api.iexample.com/OpenAI" in text
+    assert "Ocp-Apim-Subscription-Key" in text
     assert "python3.11 -m venv .venv" in text
     assert 'REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"' in text
     assert "GIT_CONFIG_COUNT=1" in text
@@ -142,6 +172,18 @@ def test_install_docs_explain_perfxpert_code_follow_up() -> None:
     assert "Direct\npip/editable paths use the same `setup.py` build hook" in guide
     assert "pip exits with distro-specific package-manager guidance" in guide
     assert "opencode.ai/install" not in readme
+
+
+def test_provider_docs_keep_private_endpoint_contract_current() -> None:
+    for doc in (_README, _GETTING_STARTED, _AGENTIC_MODE):
+        text = doc.read_text(encoding="utf-8")
+        assert "PERFXPERT_LLM_PRIVATE_URL" in text
+        assert "PERFXPERT_LLM_PRIVATE_MODEL" in text
+        assert "PERFXPERT_LLM_PRIVATE_API_KEY" in text
+        assert "PERFXPERT_LLM_PRIVATE_HEADERS" in text
+        assert "https://llm-api.iexample.com/OpenAI" in text
+        assert "Ocp-Apim-Subscription-Key" in text
+        assert "ROCPD_LLM_PRIVATE" not in text
 
 
 def test_install_wrapper_reports_missing_prereqs_when_package_manager_unavailable(tmp_path: Path) -> None:

--- a/experimental/python/perfxpert/tests/test_integration/test_install_docs.py
+++ b/experimental/python/perfxpert/tests/test_integration/test_install_docs.py
@@ -26,6 +26,12 @@ def _env_with_path(path: Path) -> dict[str, str]:
     return env
 
 
+def _symlink_tool(bin_dir: Path, name: str) -> None:
+    tool = shutil.which(name)
+    assert tool is not None, f"Missing host tool needed by test: {name}"
+    os.symlink(tool, bin_dir / name)
+
+
 def test_install_wrapper_exists_and_is_non_empty() -> None:
     assert _INSTALL_WRAPPER.is_file(), f"Missing install wrapper: {_INSTALL_WRAPPER}"
     assert _INSTALL_WRAPPER.stat().st_size > 1_000, (
@@ -42,15 +48,17 @@ def test_install_wrapper_help_mentions_supported_prereqs() -> None:
     )
     assert result.returncode == 0, result.stderr
     assert "curl" in result.stdout
+    assert "unzip" in result.stdout
     assert "python3 -m venv .venv" in result.stdout
     assert "python3-venv" in result.stdout
     assert "python3-pip" in result.stdout
     assert "git" in result.stdout
-    assert "bun.sh/install" in result.stdout
+    assert "pip build hook bootstraps bun" in result.stdout
+    assert "package-manager install" in result.stdout
     assert "It never downloads" in result.stdout
-    assert "dnf install -y curl git python3.11 python3.11-pip" in result.stdout
-    assert "dnf install -y curl git python3 python3-pip" in result.stdout
-    assert "zypper install -y curl git python311 python311-pip" in result.stdout
+    assert "dnf install -y curl git unzip python3.11 python3.11-pip" in result.stdout
+    assert "dnf install -y curl git unzip python3 python3-pip" in result.stdout
+    assert "zypper install -y curl git unzip python311 python311-pip" in result.stdout
     assert "python3.11 -m venv .venv" in result.stdout
     assert 'REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"' in result.stdout
 
@@ -65,38 +73,47 @@ def test_install_wrapper_help_works_from_stdin() -> None:
     assert result.returncode == 0, result.stderr
     assert "pip-install-from-git.sh" in result.stdout
     assert "curl -fsSL" in result.stdout
-    assert "bun.sh/install" in result.stdout
+    assert "pip build hook bootstraps bun" in result.stdout
+    assert "package-manager install" in result.stdout
     assert "It never downloads" in result.stdout
-    assert "dnf install -y curl git python3.11 python3.11-pip" in result.stdout
-    assert "zypper install -y curl git python311 python311-pip" in result.stdout
+    assert "dnf install -y curl git unzip python3.11 python3.11-pip" in result.stdout
+    assert "zypper install -y curl git unzip python311 python311-pip" in result.stdout
     assert 'REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"' in result.stdout
 
 
 def test_readme_keeps_customer_install_flow_curl_only() -> None:
     text = _README.read_text(encoding="utf-8")
     assert "curl" in text
-    assert "curl -fsSL https://bun.sh/install | bash" in text
+    assert "unzip" in text
     assert "python3 -m venv .venv" in text
     assert "python3-venv" in text
     assert "python3-pip" in text
-    assert "never downloads a separate Python runtime" in text
+    assert "never downloads a separate" in text
+    assert "Python runtime" in text
+    assert "`setup.py`\nbootstraps bun when needed" in text
+    assert "No separate `opencode` install is needed" in text
+    assert "bundled `perfxpert-code` binary was built" in text
+    assert "builds the patched bundled" in text
     assert 'REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"' in text
     assert "GIT_CONFIG_COUNT=1" not in text
     assert "git clone --depth 1 --no-recurse-submodules" not in text
     assert "wget -qO-" not in text
+    assert "curl -fsSL https://bun.sh/install | bash" not in text
 
 
 def test_getting_started_keeps_internal_install_detail() -> None:
     text = _GETTING_STARTED.read_text(encoding="utf-8")
     assert "curl" in text
-    assert "curl -fsSL https://bun.sh/install | bash" in text
+    assert "unzip" in text
     assert "python3 -m venv .venv" in text
     assert "python3-venv" in text
     assert "python3-pip" in text
-    assert "never downloads a separate Python runtime" in text
-    assert "dnf install -y curl git python3.11 python3.11-pip" in text
-    assert "dnf install -y curl git python3 python3-pip" in text
-    assert "zypper install -y curl git python311 python311-pip" in text
+    assert "never downloads a separate" in text
+    assert "Python runtime" in text
+    assert "pip bootstraps\nbun when the OS prerequisites are available" in text
+    assert "dnf install -y curl git unzip python3.11 python3.11-pip" in text
+    assert "dnf install -y curl git unzip python3 python3-pip" in text
+    assert "zypper install -y curl git unzip python311 python311-pip" in text
     assert "python3.11 -m venv .venv" in text
     assert 'REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"' in text
     assert "GIT_CONFIG_COUNT=1" in text
@@ -113,24 +130,23 @@ def test_install_docs_do_not_recommend_break_system_packages() -> None:
 
 
 def test_install_docs_explain_perfxpert_code_follow_up() -> None:
-    for doc in (_README, _GETTING_STARTED):
-        text = doc.read_text(encoding="utf-8")
-        assert "perfxpert-code install-patches" in text, (
-            f"{doc} must explain how to enable perfxpert-code after a bun-less install."
-        )
-        assert "curl -fsSL https://bun.sh/install | bash" in text, (
-            f"{doc} must include the bun install command."
-        )
-        assert "opencode.ai/install" not in text, (
-            f"{doc} must not send users to an upstream opencode curl installer."
-        )
+    readme = _README.read_text(encoding="utf-8")
+    guide = _GETTING_STARTED.read_text(encoding="utf-8")
+
+    assert "`setup.py`\nbootstraps bun when needed" in readme
+    assert "bundled patched `perfxpert-code` build completes" in readme
+    assert "curl -fsSL https://bun.sh/install | bash" not in readme
+    assert "Direct\npip/editable paths use the same `setup.py` build hook" in guide
+    assert "pip exits with distro-specific package-manager guidance" in guide
+    assert "opencode.ai/install" not in readme
 
 
-def test_install_wrapper_fails_cleanly_when_git_missing(tmp_path: Path) -> None:
+def test_install_wrapper_reports_missing_prereqs_when_package_manager_unavailable(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     os.symlink(shutil.which("python3"), bin_dir / "python3")
-    os.symlink(shutil.which("cat"), bin_dir / "cat")
+    _symlink_tool(bin_dir, "cat")
+    _symlink_tool(bin_dir, "curl")
 
     result = subprocess.run(
         ["/bin/bash", str(_INSTALL_WRAPPER)],
@@ -141,11 +157,91 @@ def test_install_wrapper_fails_cleanly_when_git_missing(tmp_path: Path) -> None:
     )
 
     assert result.returncode == 2
-    assert "`git` is required" in result.stderr
-    assert "apt install -y curl git python3-venv python3-pip" in result.stderr
-    assert "dnf install -y curl git python3.11 python3.11-pip" in result.stderr
-    assert "dnf install -y curl git python3 python3-pip" in result.stderr
-    assert "zypper install -y curl git python311 python311-pip" in result.stderr
+    assert "missing OS prerequisites" in result.stderr
+    assert "no supported package manager found" in result.stderr
+    assert "git" in result.stderr
+    assert "unzip" in result.stderr
+    assert "apt install -y curl git unzip python3-venv python3-pip" in result.stderr
+    assert "dnf install -y curl git unzip python3.11 python3.11-pip" in result.stderr
+    assert "dnf install -y curl git unzip python3 python3-pip" in result.stderr
+    assert "zypper install -y curl git unzip python311 python311-pip" in result.stderr
+
+
+def test_install_wrapper_installs_missing_prereqs_with_apt_get(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    bundled = tmp_path / "site-packages" / "perfxpert" / "_bundled" / "opencode"
+    bundled.parent.mkdir(parents=True)
+    bundled.write_text("fake-opencode", encoding="utf-8")
+    bundled.chmod(0o755)
+    _write_executable(
+        bin_dir / "python3",
+        f"""#!/bin/bash
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  echo "pip 24.0"
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+  exit 0
+fi
+if [ "$1" = "-c" ]; then
+  case "$2" in
+    *"sys.version_info"*)
+      exit 0
+      ;;
+    *'sys.prefix != getattr(sys, "base_prefix", sys.prefix)'*)
+      echo 1
+      exit 0
+      ;;
+    *'sysconfig.get_path("stdlib")'*)
+      echo "{tmp_path / 'missing-externally-managed'}"
+      exit 0
+      ;;
+    *'resources.files("perfxpert")'*)
+      echo "{bundled}"
+      exit 0
+      ;;
+  esac
+fi
+exit 99
+""",
+    )
+    _symlink_tool(bin_dir, "cat")
+    _symlink_tool(bin_dir, "chmod")
+    _symlink_tool(bin_dir, "git")
+    _write_executable(
+        bin_dir / "sudo",
+        """#!/bin/bash
+"$@"
+""",
+    )
+    installed = tmp_path / "installed.txt"
+    _write_executable(
+        bin_dir / "apt-get",
+        f"""#!/bin/bash
+echo "$*" >> "{installed}"
+if [ "$1" = "install" ]; then
+  printf '#!/bin/sh\\nexit 0\\n' > "{bin_dir}/curl"
+  printf '#!/bin/sh\\nexit 0\\n' > "{bin_dir}/unzip"
+  chmod +x "{bin_dir}/curl" "{bin_dir}/unzip"
+fi
+exit 0
+""",
+    )
+
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER), "develop"],
+        capture_output=True,
+        text=True,
+        env=_env_with_path(bin_dir),
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert installed.read_text(encoding="utf-8").splitlines() == [
+        "update",
+        "install -y curl git unzip python3-venv python3-pip",
+    ]
 
 
 def test_install_wrapper_rejects_python_older_than_310(tmp_path: Path) -> None:
@@ -164,7 +260,10 @@ fi
 exit 99
 """,
     )
-    os.symlink(shutil.which("cat"), bin_dir / "cat")
+    _symlink_tool(bin_dir, "curl")
+    _symlink_tool(bin_dir, "unzip")
+    _symlink_tool(bin_dir, "git")
+    _symlink_tool(bin_dir, "cat")
 
     result = subprocess.run(
         ["/bin/bash", str(_INSTALL_WRAPPER)],
@@ -175,7 +274,9 @@ exit 99
     )
 
     assert result.returncode == 2
-    assert "Python 3.10+ is required" in result.stderr
+    assert "missing OS prerequisites" in result.stderr
+    assert "python3.10+ with pip" in result.stderr
+    assert "no supported package manager found" in result.stderr
 
 
 def test_install_wrapper_fails_when_python_m_pip_is_missing(tmp_path: Path) -> None:
@@ -193,8 +294,10 @@ fi
 exit 99
 """,
     )
-    os.symlink(shutil.which("git"), bin_dir / "git")
-    os.symlink(shutil.which("cat"), bin_dir / "cat")
+    _symlink_tool(bin_dir, "curl")
+    _symlink_tool(bin_dir, "unzip")
+    _symlink_tool(bin_dir, "git")
+    _symlink_tool(bin_dir, "cat")
 
     result = subprocess.run(
         ["/bin/bash", str(_INSTALL_WRAPPER)],
@@ -205,11 +308,13 @@ exit 99
     )
 
     assert result.returncode == 2
-    assert "`python -m pip` is unavailable" in result.stderr
-    assert "apt install -y curl git python3-venv python3-pip" in result.stderr
-    assert "dnf install -y curl git python3.11 python3.11-pip" in result.stderr
-    assert "dnf install -y curl git python3 python3-pip" in result.stderr
-    assert "zypper install -y curl git python311 python311-pip" in result.stderr
+    assert "missing OS prerequisites" in result.stderr
+    assert "python3.10+ with pip" in result.stderr
+    assert "no supported package manager found" in result.stderr
+    assert "apt install -y curl git unzip python3-venv python3-pip" in result.stderr
+    assert "dnf install -y curl git unzip python3.11 python3.11-pip" in result.stderr
+    assert "dnf install -y curl git unzip python3 python3-pip" in result.stderr
+    assert "zypper install -y curl git unzip python311 python311-pip" in result.stderr
 
 
 def test_install_wrapper_rejects_externally_managed_python(tmp_path: Path) -> None:
@@ -243,8 +348,10 @@ fi
 exit 99
 """,
     )
-    os.symlink(shutil.which("cat"), bin_dir / "cat")
-    os.symlink(shutil.which("git"), bin_dir / "git")
+    _symlink_tool(bin_dir, "curl")
+    _symlink_tool(bin_dir, "unzip")
+    _symlink_tool(bin_dir, "cat")
+    _symlink_tool(bin_dir, "git")
 
     result = subprocess.run(
         ["/bin/bash", str(_INSTALL_WRAPPER)],
@@ -257,14 +364,20 @@ exit 99
     assert result.returncode == 2
     assert "the current Python is externally managed" in result.stderr
     assert "curl -fsSL" in result.stderr
-    assert "dnf install -y curl git python3.11 python3.11-pip" in result.stderr
-    assert "dnf install -y curl git python3 python3-pip" in result.stderr
-    assert "zypper install -y curl git python311 python311-pip" in result.stderr
+    assert "dnf install -y curl git unzip python3.11 python3.11-pip" in result.stderr
+    assert "dnf install -y curl git unzip python3 python3-pip" in result.stderr
+    assert "zypper install -y curl git unzip python311 python311-pip" in result.stderr
 
 
-def test_install_wrapper_reports_bunless_tui_follow_up(tmp_path: Path) -> None:
+def test_install_wrapper_reports_ready_bundle_from_pip_build(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    bundled = tmp_path / "site-packages" / "perfxpert" / "_bundled" / "opencode"
+    bundled.parent.mkdir(parents=True)
+    bundled.write_text("fake-opencode", encoding="utf-8")
+    bundled.chmod(0o755)
     _write_executable(
         bin_dir / "python3",
         f"""#!/bin/bash
@@ -288,31 +401,100 @@ if [ "$1" = "-c" ]; then
       echo "{tmp_path / 'missing-externally-managed'}"
       exit 0
       ;;
+    *'resources.files("perfxpert")'*)
+      echo "{bundled}"
+      exit 0
+      ;;
   esac
 fi
 exit 99
 """,
     )
-    os.symlink(shutil.which("git"), bin_dir / "git")
-    os.symlink(shutil.which("cat"), bin_dir / "cat")
+    _symlink_tool(bin_dir, "curl")
+    _symlink_tool(bin_dir, "unzip")
+    _symlink_tool(bin_dir, "git")
+    _symlink_tool(bin_dir, "cat")
 
+    env = _env_with_path(bin_dir)
+    env["HOME"] = str(home_dir)
     result = subprocess.run(
         ["/bin/bash", str(_INSTALL_WRAPPER), "develop"],
         capture_output=True,
         text=True,
-        env=_env_with_path(bin_dir),
+        env=env,
         check=False,
     )
 
     assert result.returncode == 0
-    assert "perfxpert-code install-patches" in result.stderr
-    assert "bun.sh/install" in result.stderr
+    assert "bundled patched perfxpert-code ready" in result.stderr
+
+
+def test_install_wrapper_fails_when_bundled_opencode_is_missing_after_install(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+
+    _write_executable(
+        bin_dir / "python3",
+        f"""#!/bin/bash
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  echo "pip 24.0"
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+  exit 0
+fi
+if [ "$1" = "-c" ]; then
+  case "$2" in
+    *"sys.version_info"*)
+      exit 0
+      ;;
+    *'sys.prefix != getattr(sys, "base_prefix", sys.prefix)'*)
+      echo 1
+      exit 0
+      ;;
+    *'sysconfig.get_path("stdlib")'*)
+      echo "{tmp_path / 'missing-externally-managed'}"
+      exit 0
+      ;;
+    *'resources.files("perfxpert")'*)
+      exit 1
+      ;;
+  esac
+fi
+exit 99
+""",
+    )
+    _symlink_tool(bin_dir, "curl")
+    _symlink_tool(bin_dir, "unzip")
+    _symlink_tool(bin_dir, "git")
+    _symlink_tool(bin_dir, "cat")
+
+    env = _env_with_path(bin_dir)
+    env["HOME"] = str(home_dir)
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER), "develop"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "bundled patched opencode binary was not produced" in result.stderr
 
 
 def test_install_wrapper_prefers_active_python_before_versioned_fallbacks(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     chosen = tmp_path / "chosen.txt"
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    bundled = tmp_path / "site-packages" / "perfxpert" / "_bundled" / "opencode"
+    bundled.parent.mkdir(parents=True)
+    bundled.write_text("fake-opencode", encoding="utf-8")
+    bundled.chmod(0o755)
 
     _write_executable(
         bin_dir / "python",
@@ -336,6 +518,10 @@ if [ "$1" = "-c" ]; then
       ;;
     *'sysconfig.get_path("stdlib")'*)
       echo "{tmp_path / 'missing-externally-managed'}"
+      exit 0
+      ;;
+    *'resources.files("perfxpert")'*)
+      echo "{bundled}"
       exit 0
       ;;
   esac
@@ -367,19 +553,27 @@ if [ "$1" = "-c" ]; then
       echo "{tmp_path / 'missing-externally-managed'}"
       exit 0
       ;;
+    *'resources.files("perfxpert")'*)
+      echo "{bundled}"
+      exit 0
+      ;;
   esac
 fi
 exit 99
 """,
     )
-    os.symlink(shutil.which("git"), bin_dir / "git")
-    os.symlink(shutil.which("cat"), bin_dir / "cat")
+    _symlink_tool(bin_dir, "curl")
+    _symlink_tool(bin_dir, "unzip")
+    _symlink_tool(bin_dir, "git")
+    _symlink_tool(bin_dir, "cat")
 
+    env = _env_with_path(bin_dir)
+    env["HOME"] = str(home_dir)
     result = subprocess.run(
         ["/bin/bash", str(_INSTALL_WRAPPER), "develop"],
         capture_output=True,
         text=True,
-        env=_env_with_path(bin_dir),
+        env=env,
         check=False,
     )
 
@@ -391,6 +585,12 @@ def test_install_wrapper_falls_back_to_supported_versioned_python(tmp_path: Path
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     chosen = tmp_path / "chosen.txt"
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    bundled = tmp_path / "site-packages" / "perfxpert" / "_bundled" / "opencode"
+    bundled.parent.mkdir(parents=True)
+    bundled.write_text("fake-opencode", encoding="utf-8")
+    bundled.chmod(0o755)
 
     _write_executable(
         bin_dir / "python3",
@@ -425,19 +625,27 @@ if [ "$1" = "-c" ]; then
       echo "{tmp_path / 'missing-externally-managed'}"
       exit 0
       ;;
+    *'resources.files("perfxpert")'*)
+      echo "{bundled}"
+      exit 0
+      ;;
   esac
 fi
 exit 99
 """,
     )
-    os.symlink(shutil.which("git"), bin_dir / "git")
-    os.symlink(shutil.which("cat"), bin_dir / "cat")
+    _symlink_tool(bin_dir, "curl")
+    _symlink_tool(bin_dir, "unzip")
+    _symlink_tool(bin_dir, "git")
+    _symlink_tool(bin_dir, "cat")
 
+    env = _env_with_path(bin_dir)
+    env["HOME"] = str(home_dir)
     result = subprocess.run(
         ["/bin/bash", str(_INSTALL_WRAPPER), "develop"],
         capture_output=True,
         text=True,
-        env=_env_with_path(bin_dir),
+        env=env,
         check=False,
     )
 

--- a/experimental/python/perfxpert/tests/test_providers/test_opencode_provider.py
+++ b/experimental/python/perfxpert/tests/test_providers/test_opencode_provider.py
@@ -67,10 +67,36 @@ def test_binary_path_from_shutil_which(monkeypatch):
             assert cmd[0] == "/opt/bin/opencode"
 
 
+def test_binary_path_from_bundled_launcher(monkeypatch):
+    monkeypatch.delenv("PERFXPERT_OPENCODE_PATH", raising=False)
+    monkeypatch.delenv("PERFXPERT_IN_OPENCODE_SESSION", raising=False)
+    import perfxpert.cli.opencode_launcher as opencode_launcher
+    from perfxpert.providers.opencode_provider import OpencodeProvider
+
+    monkeypatch.setattr(
+        opencode_launcher,
+        "resolve_opencode_binary",
+        lambda: "/pkg/perfxpert/_bundled/opencode",
+    )
+    with patch(
+        "perfxpert.providers.opencode_provider.subprocess.run",
+        return_value=_fake_completed(stdout="ok"),
+    ) as mr:
+        OpencodeProvider().complete([{"role": "user", "content": "hi"}])
+        cmd = mr.call_args.args[0]
+        assert cmd[0] == "/pkg/perfxpert/_bundled/opencode"
+
+
 def test_no_binary_found_raises(monkeypatch):
     monkeypatch.delenv("PERFXPERT_OPENCODE_PATH", raising=False)
     monkeypatch.delenv("PERFXPERT_IN_OPENCODE_SESSION", raising=False)
+    import perfxpert.cli.opencode_launcher as opencode_launcher
     from perfxpert.providers.opencode_provider import OpencodeProvider
+    monkeypatch.setattr(
+        opencode_launcher,
+        "resolve_opencode_binary",
+        lambda: (_ for _ in ()).throw(FileNotFoundError("missing")),
+    )
     with patch("perfxpert.providers.opencode_provider.shutil.which", return_value=None):
         with pytest.raises(ProviderError, match="opencode"):
             OpencodeProvider()

--- a/experimental/python/perfxpert/tests/test_providers/test_private_provider.py
+++ b/experimental/python/perfxpert/tests/test_providers/test_private_provider.py
@@ -102,6 +102,21 @@ def test_verify_ssl_disabled_when_env_zero(monkeypatch):
         assert mp.call_args.kwargs["verify"] is False
 
 
+def test_verify_ssl_from_env_defaults_true(monkeypatch):
+    monkeypatch.delenv("PERFXPERT_LLM_PRIVATE_VERIFY_SSL", raising=False)
+    from perfxpert.providers.private_provider import _verify_ssl_from_env
+
+    assert _verify_ssl_from_env() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "False", "no", "NO", "off", "OFF"])
+def test_verify_ssl_from_env_false_values(monkeypatch, value):
+    monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_VERIFY_SSL", value)
+    from perfxpert.providers.private_provider import _verify_ssl_from_env
+
+    assert _verify_ssl_from_env() is False
+
+
 def test_response_parsed(monkeypatch):
     monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_URL", "https://llm.corp.internal/v1")
     monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_MODEL", "internal-xl")

--- a/experimental/python/perfxpert/tests/test_providers/test_private_provider.py
+++ b/experimental/python/perfxpert/tests/test_providers/test_private_provider.py
@@ -141,6 +141,13 @@ def test_parse_headers_valid_json_dict():
     assert result == {"X-Tenant": "amd", "X-Version": "1"}
 
 
+def test_parse_headers_accepts_python_literal_dict_for_legacy_shell_snippets():
+    from perfxpert.providers.private_provider import _parse_headers
+
+    result = _parse_headers("{'Ocp-Apim-Subscription-Key': 'abc', 'user': 'amd'}")
+    assert result == {"Ocp-Apim-Subscription-Key": "abc", "user": "amd"}
+
+
 def test_parse_headers_invalid_json_raises_value_error():
     from perfxpert.providers.private_provider import _parse_headers
 

--- a/experimental/python/perfxpert/tests/test_setup/test_setup_build.py
+++ b/experimental/python/perfxpert/tests/test_setup/test_setup_build.py
@@ -24,14 +24,55 @@ def _load_setup_module(monkeypatch):
     return module
 
 
-def test_ensure_bun_on_path_refuses_network_download(
-    monkeypatch, capsys
+def test_ensure_bun_on_path_bootstraps_user_local_bun(
+    monkeypatch, tmp_path: Path, capsys
 ) -> None:
     module = _load_setup_module(monkeypatch)
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("PATH", "/usr/bin")
-    monkeypatch.setattr(module.shutil, "which", lambda _: None)
-    assert module._ensure_bun_on_path() is None
-    assert "refusing to download build tooling" in capsys.readouterr().err
+    calls: list[dict[str, str]] = []
+
+    def _fake_which(name: str, path: str | None = None) -> str | None:
+        if name == "bun":
+            if path and str(home / ".bun" / "bin") in path.split(":"):
+                return str(home / ".bun" / "bin" / "bun")
+            return None
+        if name == "unzip":
+            return "/usr/bin/unzip"
+        if name in {"bash", "curl", "git"}:
+            return f"/usr/bin/{name}"
+        return None
+
+    monkeypatch.setattr(module.shutil, "which", _fake_which)
+
+    def _fake_install(env: dict[str, str]) -> int:
+        calls.append(env)
+        return 0
+
+    monkeypatch.setattr(module, "_run_bun_install_script", _fake_install)
+
+    path = module._ensure_bun_on_path()
+
+    assert str(home / ".bun" / "bin") in path.split(":")
+    assert calls and calls[0]["BUN_INSTALL"] == str(home / ".bun")
+    assert "bootstrapping bun" in capsys.readouterr().err
+
+
+def test_ensure_bun_on_path_fails_when_unzip_missing(monkeypatch) -> None:
+    module = _load_setup_module(monkeypatch)
+
+    def _fake_which(name: str, path: str | None = None) -> str | None:
+        return None
+
+    monkeypatch.setattr(module.shutil, "which", _fake_which)
+
+    try:
+        module._ensure_bun_on_path()
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:
+        raise AssertionError("expected SystemExit when unzip is missing")
 
 
 def test_opencode_dir_is_populated_requires_git_metadata(
@@ -117,6 +158,50 @@ def test_ensure_opencode_checkout_refuses_direct_network_clone(
     assert module._ensure_opencode_checkout() is False
     assert calls == []
     assert "will not clone from the network" in capsys.readouterr().err
+
+
+def test_run_opencode_build_fails_when_checkout_unavailable(
+    monkeypatch, tmp_path: Path
+) -> None:
+    module = _load_setup_module(monkeypatch)
+    build_script = tmp_path / "build-bundled-opencode.sh"
+    build_script.write_text("#!/bin/sh\nexit 0\n")
+    monkeypatch.setattr(module, "_BUILD_SCRIPT", build_script)
+    monkeypatch.setattr(module, "_BUNDLE_PATH", tmp_path / "missing-opencode")
+    monkeypatch.setattr(module, "_ensure_opencode_checkout", lambda: False)
+    monkeypatch.setattr(module.shutil, "which", lambda name, path=None: f"/usr/bin/{name}")
+
+    try:
+        module._run_opencode_build()
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:
+        raise AssertionError("expected SystemExit when opencode checkout is unavailable")
+
+
+def test_run_opencode_build_fails_when_build_script_fails(
+    monkeypatch, tmp_path: Path
+) -> None:
+    module = _load_setup_module(monkeypatch)
+    build_script = tmp_path / "build-bundled-opencode.sh"
+    build_script.write_text("#!/bin/sh\nexit 3\n")
+    monkeypatch.setattr(module, "_BUILD_SCRIPT", build_script)
+    monkeypatch.setattr(module, "_BUNDLE_PATH", tmp_path / "missing-opencode")
+    monkeypatch.setattr(module, "_ensure_opencode_checkout", lambda: True)
+    monkeypatch.setattr(module, "_ensure_bun_on_path", lambda: "/usr/bin")
+    monkeypatch.setattr(module.shutil, "which", lambda name, path=None: f"/usr/bin/{name}")
+
+    class _Result:
+        returncode = 3
+
+    monkeypatch.setattr(module.subprocess, "run", lambda *args, **kwargs: _Result())
+
+    try:
+        module._run_opencode_build()
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:
+        raise AssertionError("expected SystemExit when bundled opencode build fails")
 
 
 def test_build_script_has_portable_size_and_sha_helpers() -> None:

--- a/experimental/python/perfxpert/tests/test_setup/test_setup_build.py
+++ b/experimental/python/perfxpert/tests/test_setup/test_setup_build.py
@@ -75,6 +75,27 @@ def test_ensure_bun_on_path_fails_when_unzip_missing(monkeypatch) -> None:
         raise AssertionError("expected SystemExit when unzip is missing")
 
 
+def test_ensure_bun_on_path_accepts_existing_bun_without_bootstrap_tools(
+    monkeypatch,
+) -> None:
+    module = _load_setup_module(monkeypatch)
+    monkeypatch.setenv("PATH", "/opt/bun/bin")
+
+    def _fake_which(name: str, path: str | None = None) -> str | None:
+        if name == "bun":
+            return "/opt/bun/bin/bun"
+        return None
+
+    monkeypatch.setattr(module.shutil, "which", _fake_which)
+    monkeypatch.setattr(
+        module,
+        "_run_bun_install_script",
+        lambda _env: (_ for _ in ()).throw(AssertionError("unexpected bootstrap")),
+    )
+
+    assert module._ensure_bun_on_path() == "/opt/bun/bin"
+
+
 def test_opencode_dir_is_populated_requires_git_metadata(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -177,6 +198,21 @@ def test_run_opencode_build_fails_when_checkout_unavailable(
         assert exc.code == 1
     else:
         raise AssertionError("expected SystemExit when opencode checkout is unavailable")
+
+
+def test_run_opencode_build_fails_when_build_script_missing(
+    monkeypatch, tmp_path: Path
+) -> None:
+    module = _load_setup_module(monkeypatch)
+    monkeypatch.setattr(module, "_BUILD_SCRIPT", tmp_path / "missing-build.sh")
+    monkeypatch.setattr(module, "_BUNDLE_PATH", tmp_path / "missing-opencode")
+
+    try:
+        module._run_opencode_build()
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:
+        raise AssertionError("expected SystemExit when build script is missing")
 
 
 def test_run_opencode_build_fails_when_build_script_fails(

--- a/experimental/python/perfxpert/tests/test_setup/test_setup_build.py
+++ b/experimental/python/perfxpert/tests/test_setup/test_setup_build.py
@@ -217,3 +217,4 @@ def test_build_script_retries_when_frozen_lockfile_install_fails() -> None:
     assert "bun install --frozen-lockfile --ignore-scripts" in text
     assert "frozen lockfile install failed; retrying" in text
     assert "bun install --ignore-scripts" in text
+    assert "bun run build --single --skip-install" in text

--- a/experimental/python/perfxpert/tests/test_setup/test_setup_build.py
+++ b/experimental/python/perfxpert/tests/test_setup/test_setup_build.py
@@ -10,6 +10,7 @@ import setuptools
 
 _COUNTER = itertools.count()
 _SETUP_PY = Path(__file__).resolve().parents[2] / "setup.py"
+_PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
 _BUILD_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "build-bundled-opencode.sh"
 
 
@@ -22,6 +23,13 @@ def _load_setup_module(monkeypatch):
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def test_pyproject_packages_top_level_bundled_opencode_binary() -> None:
+    text = _PYPROJECT.read_text()
+
+    assert '"_bundled/opencode"' in text
+    assert '"_bundled/**/*"' in text
 
 
 def test_ensure_bun_on_path_bootstraps_user_local_bun(

--- a/experimental/python/perfxpert/tests/test_tools/test_opencode_launcher.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_opencode_launcher.py
@@ -80,6 +80,18 @@ def test_resolve_user_binary_raises_when_override_missing(tmp_path: Path, monkey
         opencode_launcher.resolve_user_opencode_binary()
 
 
+def test_resolve_user_binary_raises_when_override_not_executable(
+    tmp_path: Path, monkeypatch
+):
+    """The explicit upstream-opencode escape hatch validates execute bit."""
+    fake_bin = tmp_path / "fake-opencode"
+    fake_bin.write_text("#!/bin/sh\necho fake\n")
+    fake_bin.chmod(0o644)
+    monkeypatch.setenv("PERFXPERT_OPENCODE_PATH", str(fake_bin))
+    with pytest.raises(FileNotFoundError, match="not executable"):
+        opencode_launcher.resolve_user_opencode_binary()
+
+
 def test_prepare_runtime_config_dir_skips_subdirectories(tmp_path: Path):
     """_prepare_runtime_config_dir must not crash on subdirectories in src_config_dir."""
     src = tmp_path / "src_config"

--- a/experimental/python/perfxpert/tests/test_tools/test_opencode_launcher.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_opencode_launcher.py
@@ -39,12 +39,12 @@ def test_resolve_config_dir_returns_bundled_path():
     assert (p / "mcp.json").exists()
 
 
-def test_resolve_binary_uses_override(tmp_path: Path, monkeypatch):
+def test_resolve_user_binary_uses_override(tmp_path: Path, monkeypatch):
     fake_bin = tmp_path / "fake-opencode"
     fake_bin.write_text("#!/bin/sh\necho fake\n")
     fake_bin.chmod(0o755)
     monkeypatch.setenv("PERFXPERT_OPENCODE_PATH", str(fake_bin))
-    assert opencode_launcher.resolve_opencode_binary() == fake_bin
+    assert opencode_launcher.resolve_user_opencode_binary() == fake_bin
 
 
 def test_resolve_binary_prefers_repo_local_patched_build(tmp_path: Path, monkeypatch):
@@ -73,11 +73,11 @@ def test_resolve_binary_prefers_repo_local_patched_build(tmp_path: Path, monkeyp
     assert opencode_launcher.resolve_opencode_binary() == local_bin
 
 
-def test_resolve_binary_raises_when_override_missing(tmp_path: Path, monkeypatch):
-    """PERFXPERT_OPENCODE_PATH pointing to a nonexistent file must raise immediately."""
+def test_resolve_user_binary_raises_when_override_missing(tmp_path: Path, monkeypatch):
+    """The explicit upstream-opencode escape hatch validates its override."""
     monkeypatch.setenv("PERFXPERT_OPENCODE_PATH", str(tmp_path / "nonexistent"))
     with pytest.raises(FileNotFoundError, match="does not exist"):
-        opencode_launcher.resolve_opencode_binary()
+        opencode_launcher.resolve_user_opencode_binary()
 
 
 def test_prepare_runtime_config_dir_skips_subdirectories(tmp_path: Path):
@@ -178,9 +178,9 @@ def test_amd_red_in_banner(monkeypatch):
 # -- Fix 4: doctor autodiscovery of well-known opencode paths ---------------
 
 
-def test_resolve_binary_autodiscovers_home_opencode_bin(tmp_path: Path, monkeypatch):
+def test_resolve_user_binary_autodiscovers_home_opencode_bin(tmp_path: Path, monkeypatch):
     """`~/.opencode/bin/opencode` is the upstream installer's default;
-    resolve_opencode_binary() must find it without PATH munging."""
+    the explicit `perfxpert-code opencode` path must find it without PATH munging."""
     fake_home = tmp_path
     fake_bin_dir = fake_home / ".opencode" / "bin"
     fake_bin_dir.mkdir(parents=True)
@@ -202,7 +202,7 @@ def test_resolve_binary_autodiscovers_home_opencode_bin(tmp_path: Path, monkeypa
 
     monkeypatch.setattr(opencode_launcher.resources, "as_file", _fake_as_file)
 
-    resolved = opencode_launcher.resolve_opencode_binary()
+    resolved = opencode_launcher.resolve_user_opencode_binary()
     assert resolved == fake_bin
 
 
@@ -213,10 +213,10 @@ def test_resolve_binary_autodiscovers_home_opencode_bin(tmp_path: Path, monkeypa
         ".local/bin/opencode",
     ],
 )
-def test_resolve_binary_autodiscovers_multiple_wellknown_paths(
+def test_resolve_user_binary_autodiscovers_multiple_wellknown_paths(
     tmp_path: Path, monkeypatch, subpath
 ):
-    """Each of the well-known install locations must be auto-discovered."""
+    """Each well-known upstream location must be auto-discovered for the escape hatch."""
     fake_home = tmp_path
     fake_bin = fake_home / subpath
     fake_bin.parent.mkdir(parents=True, exist_ok=True)
@@ -235,13 +235,11 @@ def test_resolve_binary_autodiscovers_multiple_wellknown_paths(
 
     monkeypatch.setattr(opencode_launcher.resources, "as_file", _fake_as_file)
 
-    assert opencode_launcher.resolve_opencode_binary() == fake_bin
+    assert opencode_launcher.resolve_user_opencode_binary() == fake_bin
 
 
-def test_resolve_binary_missing_suggests_install_command(monkeypatch, tmp_path: Path):
-    """When no opencode binary is found anywhere, the error message must
-    mention the upstream install command so doctor's output is actionable.
-    """
+def test_resolve_default_binary_missing_suggests_wrapper(monkeypatch, tmp_path: Path):
+    """The default path must point users back to the bundled submodule build."""
     monkeypatch.delenv("PERFXPERT_OPENCODE_PATH", raising=False)
     # Ensure no well-known path resolves
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
@@ -258,9 +256,22 @@ def test_resolve_binary_missing_suggests_install_command(monkeypatch, tmp_path: 
     with pytest.raises(FileNotFoundError) as exc:
         opencode_launcher.resolve_opencode_binary()
     msg = str(exc.value)
-    assert "opencode.ai/install.sh" in msg, (
-        "install hint must surface the upstream installer URL"
-    )
+    assert "bundled patched opencode binary not found" in msg
+    assert "pip-install-from-git.sh" in msg
+    assert "perfxpert-code opencode" in msg
+
+
+def test_resolve_user_binary_missing_suggests_upstream_install(
+    monkeypatch, tmp_path: Path
+):
+    """The explicit upstream-opencode escape hatch gives upstream install help."""
+    monkeypatch.delenv("PERFXPERT_OPENCODE_PATH", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(opencode_launcher.shutil, "which", lambda _: None)
+
+    with pytest.raises(FileNotFoundError) as exc:
+        opencode_launcher.resolve_user_opencode_binary()
+    assert "opencode.ai/install.sh" in str(exc.value)
 
 
 def test_wellknown_paths_list_includes_home_opencode():


### PR DESCRIPTION
## Motivation

Fix the PerfXpert GitHub install path so the documented wrapper flow works across supported distro variants and installs both `perfxpert` and the bundled patched `perfxpert-code` TUI end-to-end.

## Technical Details

- add `experimental/python/perfxpert/scripts/pip-install-from-git.sh`
- keep the README customer-facing install flow on the pinned `curl | bash` wrapper
- simplify the main README into copy-paste install, `perfxpert analyze`, `perfxpert-code`, and `perfxpert-code claude|codex|gemini|opencode` recipes
- make `perfxpert analyze --format json|markdown|webview` write a report file by default even when `-o/--output` and `-d/--dir` are omitted, while preserving stdout as the default for `text`
- remove unpublished PyPI install guidance and normal-user CI quickstart clutter from the README
- move detailed install/platform guidance into `docs/guides/getting-started.md`
- harden interpreter selection so the wrapper prefers the active `python`, then `python3`, then any already-installed `python3.10+` fallback on `PATH`
- document Ubuntu 22/24, RHEL/UBI 9/10, and SLES 15 package prerequisites without recommending `--break-system-packages`
- build the pinned patched opencode submodule during pip install, bootstrap bun when needed, and fail if the bundled `perfxpert-code` binary is not produced
- package the top-level generated `perfxpert/_bundled/opencode` binary explicitly in the wheel so the final wrapper verification imports the same ready binary that the build hook produced
- keep default `perfxpert-code` on the bundled submodule-built opencode; leave user-owned upstream opencode only behind explicit `perfxpert-code opencode`
- align provider docs and runtime for `private` endpoint model/header envs and the `opencode` provider path
- import #5382's private-provider SDK fixes: forward private custom headers and SSL verification into the OpenAI Agents SDK client path, and preserve partial-bound tool callables during SDK tool translation
- replace dense README/architecture ASCII diagrams with clearer Mermaid diagrams that identify the shared PerfXpert brain/runtime layer
- update MCP install docs to use the wrapper instead of unpublished `pip install perfxpert`
- add regression coverage for install-doc contracts, setup build-hook behavior, launcher escape-hatch behavior, provider routing, and README command shapes

## JIRA ID

N/A

## Test Plan

- run focused install-doc integration tests
- run docs/readiness/link checks
- run setup/provider/framework/launcher regression suites
- run analyze output-routing regression coverage
- run focused private-provider SDK header/SSL and partial-tool regression coverage
- run clean-container install validation for Ubuntu 22, Ubuntu 24, UBI 9, UBI 10, and SLES 15
- run shell syntax checks for install/build scripts

## Test Result

- `env PYTHONPATH=experimental/python/perfxpert python3 -m pytest -q experimental/python/perfxpert/tests/test_setup/test_setup_build.py experimental/python/perfxpert/tests/test_agents/test_framework.py experimental/python/perfxpert/tests/test_providers/test_opencode_provider.py experimental/python/perfxpert/tests/test_tools/test_opencode_launcher.py experimental/python/perfxpert/tests/test_cli/test_launcher_subcommands.py experimental/python/perfxpert/tests/test_integration/test_install_docs.py` -> `148 passed`
- `env PYTHONPATH=experimental/python/perfxpert python3 -m pytest -q experimental/python/perfxpert/tests/test_agents/test_framework.py::test_translate_tools_accepts_partial_callables experimental/python/perfxpert/tests/test_agents/test_framework.py::test_sdk_invoke_private_provider_uses_custom_openai_base_url experimental/python/perfxpert/tests/test_providers/test_private_provider.py` -> `24 passed`
- `env PYTHONPATH=experimental/python/perfxpert python3 -m pytest -q experimental/python/perfxpert/tests/test_setup/test_setup_build.py experimental/python/perfxpert/tests/test_agents/test_framework.py experimental/python/perfxpert/tests/test_providers/test_opencode_provider.py experimental/python/perfxpert/tests/test_providers/test_private_provider.py experimental/python/perfxpert/tests/test_tools/test_opencode_launcher.py experimental/python/perfxpert/tests/test_cli/test_launcher_subcommands.py experimental/python/perfxpert/tests/test_integration/test_install_docs.py experimental/python/perfxpert/tests/test_docs_tooling/test_ship_readiness.py experimental/python/perfxpert/tests/test_integration/test_docs_links.py` -> `179 passed`
- `env PYTHONPATH=experimental/python/perfxpert python3 -m pytest -q experimental/python/perfxpert/tests/test_setup/test_setup_build.py experimental/python/perfxpert/tests/test_agents/test_framework.py experimental/python/perfxpert/tests/test_providers/test_opencode_provider.py experimental/python/perfxpert/tests/test_providers/test_private_provider.py experimental/python/perfxpert/tests/test_tools/test_opencode_launcher.py experimental/python/perfxpert/tests/test_cli/test_launcher_subcommands.py experimental/python/perfxpert/tests/test_cli/test_analyze_args.py experimental/python/perfxpert/tests/test_integration/test_install_docs.py experimental/python/perfxpert/tests/test_docs_tooling/test_ship_readiness.py experimental/python/perfxpert/tests/test_integration/test_docs_links.py` -> `212 passed`
- `env PYTHONPATH=experimental/python/perfxpert python3 -m pytest -q experimental/python/perfxpert/tests/test_integration/test_install_docs.py experimental/python/perfxpert/tests/test_docs_tooling/test_ship_readiness.py experimental/python/perfxpert/tests/test_integration/test_docs_links.py` -> `25 passed`
- `bash -n experimental/python/perfxpert/scripts/pip-install-from-git.sh` -> passed
- `bash -n experimental/python/perfxpert/scripts/build-bundled-opencode.sh` -> passed
- Earlier clean-container installs on this branch passed on `ubuntu:22.04`, `ubuntu:24.04`, `registry.access.redhat.com/ubi9/ubi`, `registry.access.redhat.com/ubi10/ubi`, and `registry.suse.com/bci/bci-base:15.6`
- Full perfxpert collection was not used as the final gate because this environment is missing optional `hypothesis` for `tests/test_red_team/test_sanitizer_fuzz.py`; rerunning with that file ignored hit host-specific `perfxpert doctor` state under the sandboxed read-only home.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
