### PR TITLE
fix(cmake): give ROCM_PATH higher priority than ROCPROFSYS_DEFAULT_ROCM_PATH

### DIFF
--- a/projects/rocprofiler-systems/cmake/Modules/FindROCmVersion.cmake
+++ b/projects/rocprofiler-systems/cmake/Modules/FindROCmVersion.cmake
@@ -281,8 +281,8 @@ function(ROCM_VERSION_PARSE_VERSION_FILES)
         ROCmVersion_DIR
         ROCmVersion_ROOT
         ROCmVersion_ROOT_DIR
-        ROCPROFSYS_DEFAULT_ROCM_PATH
         ROCM_PATH
+        ROCPROFSYS_DEFAULT_ROCM_PATH
     )
         if(NOT DEFINED ${_PATH} AND DEFINED ENV{${_PATH}})
             set(_VAL "$ENV{${_PATH}}")
@@ -306,8 +306,8 @@ function(ROCM_VERSION_PARSE_VERSION_FILES)
             ${ROCmVersion_ROOT_DIR}
             $ENV{CMAKE_PREFIX_PATH}
             ${CMAKE_PREFIX_PATH}
-            ${ROCPROFSYS_DEFAULT_ROCM_PATH}
             ${ROCM_PATH}
+            ${ROCPROFSYS_DEFAULT_ROCM_PATH}
             /opt/rocm
         )
             if(EXISTS ${_DIR})

--- a/projects/rocprofiler-systems/cmake/Modules/FindROCmVersion.cmake
+++ b/projects/rocprofiler-systems/cmake/Modules/FindROCmVersion.cmake
@@ -310,7 +310,7 @@ function(ROCM_VERSION_PARSE_VERSION_FILES)
             ${ROCPROFSYS_DEFAULT_ROCM_PATH}
             /opt/rocm
         )
-            if(EXISTS ${_DIR})
+            if(EXISTS "${_DIR}")
                 get_filename_component(_ABS_DIR "${_DIR}" REALPATH)
                 list(APPEND _PATHS ${_ABS_DIR})
             endif()
@@ -322,8 +322,8 @@ function(ROCM_VERSION_PARSE_VERSION_FILES)
 
     foreach(_PATH ${_PATHS})
         foreach(_FILE ${_VERSION_FILES})
-            set(_F ${_PATH}/.info/${_FILE})
-            if(EXISTS ${_F})
+            set(_F "${_PATH}/.info/${_FILE}")
+            if(EXISTS "${_F}")
                 set(ROCmVersion_VERSION_FILE
                     "${_F}"
                     CACHE FILEPATH


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The `ROCM_PATH` env variable is a common way to specify ROCm's installation directory. We should be able to use it to specify the path to ROCm when building rocprofiler-systems.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- In `FindROCmVersion.cmake`: swap search order so `ROCM_PATH` is
  evaluated before `ROCPROFSYS_DEFAULT_ROCM_PATH` in both the env
  promotion loop and the path search list

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
n/a 

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- I have ROCm 7.2 installed in `/opt/rocm`.
- I have a ROCm 7.13 preview build installed to `~/therock`
- `export ROCM_PATH=~/therock`
- Build `rocprofiler-systems` and verify that `~/therock` is used.

## Test Result

<!-- Briefly summarize test outcomes. -->
- Test passes

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
