### PR TITLE
bug(perfxpert): Fix private provider SDK headers

### DIFF
--- a/experimental/python/perfxpert/perfxpert/agents/framework.py
+++ b/experimental/python/perfxpert/perfxpert/agents/framework.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import inspect
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type
@@ -230,15 +231,26 @@ def _build_sdk_run_config(provider: str) -> Any:
             provider_map.add_provider(provider, LitellmProvider())
         elif provider == "private":
             from agents.models.openai_provider import OpenAIProvider  # type: ignore[import-not-found]
+            from openai import AsyncOpenAI  # type: ignore[import-not-found]
+            import httpx
+
+            from perfxpert.providers.private_provider import _parse_headers, _verify_ssl_from_env
 
             base_url = (os.environ.get("PERFXPERT_LLM_PRIVATE_URL") or "").rstrip("/")
             if not base_url:
                 raise AuthError("private", "no endpoint configured (set PERFXPERT_LLM_PRIVATE_URL)")
+            api_key = os.environ.get("PERFXPERT_LLM_PRIVATE_API_KEY") or "dummy"
+            headers = _parse_headers(os.environ.get("PERFXPERT_LLM_PRIVATE_HEADERS", ""))
+            openai_client = AsyncOpenAI(
+                api_key=api_key,
+                base_url=base_url,
+                default_headers=headers,
+                http_client=httpx.AsyncClient(verify=_verify_ssl_from_env()),
+            )
             provider_map.add_provider(
                 "private",
                 OpenAIProvider(
-                    api_key=os.environ.get("PERFXPERT_LLM_PRIVATE_API_KEY") or "dummy",
-                    base_url=base_url,
+                    openai_client=openai_client,
                     use_responses=False,
                 ),
             )
@@ -343,6 +355,37 @@ def _sanitize_tool_name(name: str) -> str:
     return name.replace(".", "_")
 
 
+def _prepare_tool_callable_for_sdk(fn: Callable[..., Any], tool_name: str) -> Callable[..., Any]:
+    """Ensure SDK introspection has basic callable metadata.
+
+    ``functools.partial`` preserves the effective signature, but it does not
+    expose ``__name__`` and is not accepted as a plain function by the Agents
+    SDK. For those callables, create a real wrapper function and copy the
+    effective signature so the generated tool schema still matches the bound
+    callable.
+    """
+    safe_name = _sanitize_tool_name(tool_name)
+    if inspect.isfunction(fn) or inspect.ismethod(fn):
+        if not getattr(fn, "__name__", None):
+            try:
+                setattr(fn, "__name__", safe_name)
+                setattr(fn, "__qualname__", safe_name)
+            except Exception:  # pragma: no cover - unusual callable object
+                pass
+        return fn
+
+    def _sdk_tool_wrapper(*args: Any, **kwargs: Any) -> Any:
+        return fn(*args, **kwargs)
+
+    _sdk_tool_wrapper.__name__ = safe_name
+    _sdk_tool_wrapper.__qualname__ = safe_name
+    try:
+        _sdk_tool_wrapper.__signature__ = inspect.signature(fn)  # type: ignore[attr-defined]
+    except (TypeError, ValueError):  # pragma: no cover - best effort
+        pass
+    return _sdk_tool_wrapper
+
+
 def _translate_tools(tools: List[ToolBinding]) -> List[Any]:
     """Wrap our ToolBinding list in openai-agents function_tool decorators.
 
@@ -356,9 +399,10 @@ def _translate_tools(tools: List[ToolBinding]) -> List[Any]:
     wrapped: List[Any] = []
     for tb in tools:
         try:
+            sdk_callable = _prepare_tool_callable_for_sdk(tb.fn, tb.name)
             wrapped.append(
                 sdk_function_tool(
-                    tb.fn,
+                    sdk_callable,
                     name_override=_sanitize_tool_name(tb.name),
                     # The SDK's introspection can be picky about third-party
                     # callables; relax strict mode so we don't 400 on schema

--- a/experimental/python/perfxpert/perfxpert/providers/private_provider.py
+++ b/experimental/python/perfxpert/perfxpert/providers/private_provider.py
@@ -7,6 +7,7 @@ Optional TLS bypass for self-signed CAs (opt-in via env).
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 from typing import Any, Dict, List, Optional, Union
@@ -31,12 +32,21 @@ def _parse_headers(raw: str) -> Dict[str, str]:
     try:
         obj = json.loads(raw)
     except json.JSONDecodeError as e:
-        raise ValueError(
-            f"PERFXPERT_LLM_PRIVATE_HEADERS contains invalid JSON: {e}. " f"Value was: {raw[:80]!r}"
-        ) from e
+        try:
+            obj = ast.literal_eval(raw)
+        except (SyntaxError, ValueError) as literal_exc:
+            raise ValueError(
+                "PERFXPERT_LLM_PRIVATE_HEADERS contains invalid JSON or Python dict literal: "
+                f"{e}. Value was: {raw[:80]!r}"
+            ) from literal_exc
     if not isinstance(obj, dict):
         raise ValueError(f"PERFXPERT_LLM_PRIVATE_HEADERS must be a JSON object, got {type(obj).__name__}")
     return {str(k): str(v) for k, v in obj.items()}
+
+
+def _verify_ssl_from_env() -> bool:
+    env_flag = os.environ.get("PERFXPERT_LLM_PRIVATE_VERIFY_SSL", "1")
+    return env_flag.lower() not in ("0", "false", "no", "off")
 
 
 class PrivateProvider(Provider):
@@ -68,8 +78,7 @@ class PrivateProvider(Provider):
         self._extra_headers = merged
 
         if verify_ssl is None:
-            env_flag = os.environ.get("PERFXPERT_LLM_PRIVATE_VERIFY_SSL", "1")
-            verify_ssl = env_flag not in ("0", "false", "False", "no", "NO")
+            verify_ssl = _verify_ssl_from_env()
         self._verify_ssl = bool(verify_ssl)
         self._timeout = timeout
 

--- a/experimental/python/perfxpert/tests/test_agents/test_framework.py
+++ b/experimental/python/perfxpert/tests/test_agents/test_framework.py
@@ -1,5 +1,8 @@
 """Tests for perfxpert.agents.framework — the SDK facade."""
 
+import inspect
+from functools import partial
+
 import pytest
 
 from perfxpert.agents import framework
@@ -360,6 +363,30 @@ def test_sdk_invoke_wires_openai_agents_sdk(monkeypatch):
     assert captured["run_config"] == {"kwargs": {}}
 
 
+def test_translate_tools_accepts_partial_callables(monkeypatch):
+    from perfxpert.agents import framework
+    from perfxpert.agents.framework import ToolBinding, _translate_tools
+
+    captured = {}
+
+    def _fake_function_tool(fn, *, name_override, strict_mode):
+        captured["callable_name"] = fn.__name__
+        return {"name": name_override, "fn": fn}
+
+    def _create_at(root, title):
+        return f"{root}:{title}"
+
+    monkeypatch.setattr(framework, "sdk_function_tool", _fake_function_tool)
+
+    tool = ToolBinding(name="tasks.create", fn=partial(_create_at, "demo-app"))
+    wrapped = _translate_tools([tool])
+
+    assert captured["callable_name"] == "tasks_create"
+    assert wrapped[0]["name"] == "tasks_create"
+    assert wrapped[0]["fn"]("check") == "demo-app:check"
+    assert str(inspect.signature(wrapped[0]["fn"])) == "(title)"
+
+
 def test_sdk_invoke_raises_runtime_error_when_sdk_missing(monkeypatch):
     """When openai-agents is not installed, _sdk_invoke must raise RuntimeError
     with an actionable message — NOT NotImplementedError."""
@@ -492,6 +519,10 @@ def test_sdk_invoke_private_provider_uses_custom_openai_base_url(monkeypatch):
 
     monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_URL", "https://llm.example/v1")
     monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_API_KEY", "sk-private")
+    monkeypatch.setenv(
+        "PERFXPERT_LLM_PRIVATE_HEADERS",
+        "{'Ocp-Apim-Subscription-Key': 'sub-key', 'user': 'test-user', 'api-version': 'preview'}",
+    )
     monkeypatch.setattr(framework, "_SDK_AVAILABLE", True)
     monkeypatch.setattr(framework, "SdkAgent", _FakeSdkAgent)
     monkeypatch.setattr(framework, "SdkRunner", _FakeRunner)
@@ -511,6 +542,11 @@ def test_sdk_invoke_private_provider_uses_custom_openai_base_url(monkeypatch):
 
     assert captured["model"] == "private/gpt-4o-mini"
     assert "model_provider" in captured["run_config"]["kwargs"]
+    model_provider = captured["run_config"]["kwargs"]["model_provider"]
+    private_provider = model_provider.provider_map.get_provider("private")
+    assert private_provider._client.default_headers["Ocp-Apim-Subscription-Key"] == "sub-key"
+    assert private_provider._client.default_headers["user"] == "test-user"
+    assert private_provider._client.default_headers["api-version"] == "preview"
 
 
 def test_sdk_invoke_maps_rate_limit_like_runtime_errors(monkeypatch):

--- a/experimental/python/perfxpert/tests/test_providers/test_private_provider.py
+++ b/experimental/python/perfxpert/tests/test_providers/test_private_provider.py
@@ -141,6 +141,13 @@ def test_parse_headers_valid_json_dict():
     assert result == {"X-Tenant": "amd", "X-Version": "1"}
 
 
+def test_parse_headers_valid_python_literal_dict():
+    from perfxpert.providers.private_provider import _parse_headers
+
+    result = _parse_headers("{'X-Tenant': 'amd', 'X-Version': '1'}")
+    assert result == {"X-Tenant": "amd", "X-Version": "1"}
+
+
 def test_parse_headers_invalid_json_raises_value_error():
     from perfxpert.providers.private_provider import _parse_headers
 


### PR DESCRIPTION
## Summary
- forward PERFXPERT_LLM_PRIVATE_HEADERS into the OpenAI Agents SDK private provider path
- share SSL verification parsing with the direct private provider
- wrap partial-bound SDK tools as real functions so task tools are not skipped

## Root Cause
The direct private provider parsed custom headers, but the agentic SDK path built OpenAIProvider with only api_key/base_url. AMD LLM Gateway therefore received no Ocp-Apim-Subscription-Key. The source-dir root agent also used functools.partial for tasks.* bindings, which the SDK rejected as tool callables.

## Validation
- PYTHONPATH=. pytest -q tests/test_agents/test_framework.py::test_translate_tools_accepts_partial_callables tests/test_agents/test_framework.py::test_sdk_invoke_private_provider_uses_custom_openai_base_url tests/test_providers/test_private_provider.py
- perfxpert analyze --source-dir demo-app --llm private