### PR TITLE
Validate execution inputs before tool dependency checks

### DIFF
--- a/experimental/python/perfxpert/docs/contributing/external-tools.md
+++ b/experimental/python/perfxpert/docs/contributing/external-tools.md
@@ -31,11 +31,16 @@ Entries live in `perfxpert/tools/_tooldep.py`.
 ## Calling `require_tool()` from a tool
 
 Any tool that shells out or imports an optional dependency should call
-`require_tool(name)` first. The helper raises `ExternalToolMissing`
-with a human-readable install hint if the dep isn't available; your
-tool never has to hand-craft a "not found" error message.
+`require_tool(name)` before it invokes the dependency. Execution tools
+must sanitize, confine, and allowlist-check untrusted inputs before that
+dependency check so invalid user input fails without consulting host
+tool availability. The helper raises `ExternalToolMissing` with a
+human-readable install hint if the dep isn't available; your tool never
+has to hand-craft a "not found" error message.
 
 ```python
+import os
+
 from perfxpert.tools._tooldep import require_tool, ExternalToolMissing
 
 def lookup_trace_decoder_version() -> str:
@@ -52,18 +57,23 @@ def lookup_trace_decoder_version() -> str:
 import pytest
 with pytest.raises(Exception):
     require_tool("not-a-registered-dep")
+
+# Configured binary path: keep the registered dependency name for install
+# hints, but probe the exact executable path that will be invoked.
+require_tool("amdclang++", executable=os.environ.get("PERFXPERT_CXX", "amdclang++"))
 ```
 
 `require_tool` does three things in order:
 
 1. Looks up the registry entry for `name`.
 2. Dispatches to one of three detectors:
-   - `binary` — `shutil.which(name)` + optional smoke-test. The
-     smoke-test is a configurable `Optional[List[str]]` on the `_Dep`
-     entry (see `_tooldep.py:52`); the helper runs `<binary> <args>`
-     and treats a non-zero exit as a failed smoke-test. At present
-     only `opencode` registers a smoke-test (`["--version"]`); other
-     registered binaries rely on `shutil.which` alone.
+   - `binary` — `shutil.which(executable or name)` or direct
+     executable-path probing + optional smoke-test. The smoke-test is a
+     configurable `Optional[List[str]]` on the `_Dep` entry (see
+     `_tooldep.py:52`); the helper runs `<binary> <args>` and treats a
+     non-zero exit as a failed smoke-test. At present only `opencode`
+     registers a smoke-test (`["--version"]`); other registered binaries
+     rely on path resolution alone.
    - `pylib` — `importlib.import_module(name)`
    - `shared_lib` — ROCm-aware search across `${ROCM_PATH}/lib*`,
      `${PERFXPERT_<NAME>_PATH}`, `~/.local/opt/<name>/opt/rocm/lib*`,

--- a/experimental/python/perfxpert/perfxpert/tools/_tooldep.py
+++ b/experimental/python/perfxpert/perfxpert/tools/_tooldep.py
@@ -133,16 +133,41 @@ def _shared_lib_search_paths(name: str) -> List[str]:
     return [p for p in paths if p]
 
 
-def check_tool_available(name: str) -> Tuple[bool, str]:
-    """Return (is_available, detail_message) for the named dependency."""
+def _resolve_binary(name: str, executable: Optional[str] = None) -> Tuple[Optional[str], str]:
+    """Return executable path for a binary dependency, or an error detail."""
+    probe = executable or name
+    has_path_separator = os.path.sep in probe or (
+        os.path.altsep is not None and os.path.altsep in probe
+    )
+    if has_path_separator:
+        path = Path(probe).expanduser()
+        if not path.is_file():
+            return None, f"{probe} is not a file"
+        if not os.access(path, os.X_OK):
+            return None, f"{probe} is not executable"
+        return str(path), f"{name} at {path}"
+
+    path = shutil.which(probe)
+    if not path:
+        return None, f"{probe} not found on PATH"
+    return path, f"{name} at {path}"
+
+
+def check_tool_available(name: str, *, executable: Optional[str] = None) -> Tuple[bool, str]:
+    """Return (is_available, detail_message) for the named dependency.
+
+    For registered binary dependencies, `executable` may name the configured
+    binary path to probe while `name` remains the registry key used for install
+    hints and dependency ownership.
+    """
     dep = _TOOL_REGISTRY.get(name)
     if dep is None:
         return False, f"unknown tool {name!r} (not in _TOOL_REGISTRY)"
 
     if dep.kind == "binary":
-        path = shutil.which(name)
+        path, detail = _resolve_binary(name, executable)
         if not path:
-            return False, f"{name} not found on PATH. Install: {dep.install_hint}"
+            return False, f"{detail}. Install: {dep.install_hint}"
         if dep.smoke_test is not None:
             cmd = [path] + list(dep.smoke_test)
             try:
@@ -161,7 +186,7 @@ def check_tool_available(name: str) -> Tuple[bool, str]:
                 return False, f"binary at {path} but smoke-test failed: {e}"
             except subprocess.TimeoutExpired:
                 return False, f"binary at {path} but smoke-test timed out after 2 s"
-        return True, f"{name} at {path}"
+        return True, detail
 
     if dep.kind == "pylib":
         spec = importlib.util.find_spec(name)
@@ -214,7 +239,12 @@ def offer_install(name: str) -> bool:
     return ok
 
 
-def require_tool(name: str, *, allow_install: bool = False) -> str:
+def require_tool(
+    name: str,
+    *,
+    allow_install: bool = False,
+    executable: Optional[str] = None,
+) -> str:
     """Assert that `name` is available; raise ExternalToolMissing otherwise.
 
     If `allow_install=True` AND `PERFXPERT_ALLOW_INSTALL=1` AND the registry
@@ -223,7 +253,7 @@ def require_tool(name: str, *, allow_install: bool = False) -> str:
 
     Returns the detail string from check_tool_available on success.
     """
-    ok, detail = check_tool_available(name)
+    ok, detail = check_tool_available(name, executable=executable)
     if ok:
         return detail
 
@@ -232,7 +262,7 @@ def require_tool(name: str, *, allow_install: bool = False) -> str:
     if allow_install and user_opted_in and dep and dep.install_cmd:
         installed = offer_install(name)
         if installed:
-            ok, detail = check_tool_available(name)
+            ok, detail = check_tool_available(name, executable=executable)
             if ok:
                 return detail
 

--- a/experimental/python/perfxpert/perfxpert/tools/compile_runner.py
+++ b/experimental/python/perfxpert/perfxpert/tools/compile_runner.py
@@ -80,9 +80,6 @@ def build(
         ShellMetacharError — any input contains shell metachars.
         subprocess.TimeoutExpired — build exceeds `timeout`.
     """
-    # Check external dependencies
-    require_tool("amdclang++")
-
     # Sanitize + confine paths
     reject_shell_metachars(source_rel)
     source = confine_to_project_root(Path(project_root), source_rel)
@@ -106,6 +103,8 @@ def build(
     if output_rel is not None:
         output = confine_to_project_root(Path(project_root), output_rel)
         argv.extend(["-o", str(output)])
+
+    require_tool("amdclang++", executable=_DEFAULT_CXX)
 
     proc = subprocess.run(
         argv,

--- a/experimental/python/perfxpert/perfxpert/tools/profile_runner.py
+++ b/experimental/python/perfxpert/perfxpert/tools/profile_runner.py
@@ -103,10 +103,9 @@ def run(
         ShellMetacharError on metachar-bearing token.
         subprocess.TimeoutExpired on timeout.
     """
-    # Check external dependencies
+    _validate_argv(argv)
     require_tool("rocprofv3")
 
-    _validate_argv(argv)
     proc = subprocess.run(
         argv,
         shell=False,

--- a/experimental/python/perfxpert/tests/test_red_team/test_compiler_flag_smuggling.py
+++ b/experimental/python/perfxpert/tests/test_red_team/test_compiler_flag_smuggling.py
@@ -39,6 +39,7 @@ def test_allowlisted_flags_still_work(tmp_path: Path, monkeypatch):
             returncode=0, stdout=b"", stderr=b""
         )),
     )
+    monkeypatch.setattr("perfxpert.tools.compile_runner.require_tool", mock.MagicMock())
     result = compile_runner.build(
         project_root=tmp_path,
         source_rel="src.cpp",

--- a/experimental/python/perfxpert/tests/test_red_team/test_rocprofv3_flag_smuggling.py
+++ b/experimental/python/perfxpert/tests/test_red_team/test_rocprofv3_flag_smuggling.py
@@ -32,6 +32,7 @@ def test_known_flags_still_work(tmp_path: Path, monkeypatch):
         "perfxpert.tools.profile_runner.subprocess.run",
         mock.MagicMock(return_value=mock.MagicMock(returncode=0, stdout=b"", stderr=b"")),
     )
+    monkeypatch.setattr("perfxpert.tools.profile_runner.require_tool", mock.MagicMock())
     result = profile_runner.run(
         argv=[
             "rocprofv3", "--sys-trace", "--kernel-trace", "--stats",

--- a/experimental/python/perfxpert/tests/test_tools/test_compile_runner.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_compile_runner.py
@@ -16,9 +16,11 @@ def test_build_is_execution_class():
 
 # -- flag allowlist ---------------------------------------------------------
 
-def test_build_rejects_unlisted_flag(tmp_path: Path):
+def test_build_rejects_unlisted_flag_before_tool_check(tmp_path: Path, monkeypatch):
     src = tmp_path / "src.cpp"
     src.write_text("int main(){return 0;}\n")
+    require_tool = mock.MagicMock(side_effect=AssertionError("require_tool reached"))
+    monkeypatch.setattr("perfxpert.tools.compile_runner.require_tool", require_tool)
 
     with pytest.raises(compile_runner.CompileFlagError) as exc:
         compile_runner.build(
@@ -27,6 +29,7 @@ def test_build_rejects_unlisted_flag(tmp_path: Path):
             flags=["-O2", "-Xlinker", "--wrap,write"],
         )
     assert "--wrap,write" in str(exc.value) or "-Xlinker" in str(exc.value)
+    require_tool.assert_not_called()
 
 
 def test_build_accepts_allowlisted_flags(tmp_path: Path, monkeypatch):
@@ -37,6 +40,7 @@ def test_build_accepts_allowlisted_flags(tmp_path: Path, monkeypatch):
     fake_run = mock.MagicMock(return_value=mock.MagicMock(
         returncode=0, stdout=b"", stderr=b""
     ))
+    monkeypatch.setattr("perfxpert.tools.compile_runner.require_tool", mock.MagicMock())
     monkeypatch.setattr("perfxpert.tools.compile_runner.subprocess.run", fake_run)
 
     result = compile_runner.build(
@@ -52,14 +56,38 @@ def test_build_accepts_allowlisted_flags(tmp_path: Path, monkeypatch):
     assert kwargs.get("shell") is False or "shell" not in kwargs
 
 
-def test_build_rejects_path_traversal_in_source(tmp_path: Path):
+def test_build_accepts_configured_cxx_path(tmp_path: Path, monkeypatch):
+    src = tmp_path / "src.cpp"
+    src.write_text("int main(){return 0;}\n")
+    fake_cxx = tmp_path / "toolchain" / "amdclang++"
+    fake_cxx.parent.mkdir()
+    fake_cxx.write_text("#!/bin/sh\n")
+    fake_cxx.chmod(0o755)
+    fake_run = mock.MagicMock(return_value=mock.MagicMock(
+        returncode=0, stdout=b"", stderr=b""
+    ))
+    monkeypatch.setattr(compile_runner, "_DEFAULT_CXX", str(fake_cxx))
+    monkeypatch.setattr("perfxpert.tools.compile_runner.subprocess.run", fake_run)
+
+    result = compile_runner.build(project_root=tmp_path, source_rel="src.cpp", flags=["-O2"])
+
+    assert result["returncode"] == 0
+    args, _ = fake_run.call_args
+    assert args[0][0] == str(fake_cxx)
+
+
+def test_build_rejects_path_traversal_in_source_before_tool_check(tmp_path: Path, monkeypatch):
     from perfxpert.tools._safety import PathConfinementError
+    require_tool = mock.MagicMock(side_effect=AssertionError("require_tool reached"))
+    monkeypatch.setattr("perfxpert.tools.compile_runner.require_tool", require_tool)
+
     with pytest.raises(PathConfinementError):
         compile_runner.build(
             project_root=tmp_path,
             source_rel="../escape.cpp",
             flags=[],
         )
+    require_tool.assert_not_called()
 
 
 def test_build_uses_safe_env(tmp_path: Path, monkeypatch):
@@ -75,6 +103,7 @@ def test_build_uses_safe_env(tmp_path: Path, monkeypatch):
         return mock.MagicMock(returncode=0, stdout=b"", stderr=b"")
 
     monkeypatch.setattr("perfxpert.tools.compile_runner.subprocess.run", fake_run)
+    monkeypatch.setattr("perfxpert.tools.compile_runner.require_tool", mock.MagicMock())
     compile_runner.build(project_root=tmp_path, source_rel="src.cpp", flags=["-O2"])
 
     assert "ANTHROPIC_API_KEY" not in captured_env
@@ -91,6 +120,7 @@ def test_build_parses_error_output(tmp_path: Path, monkeypatch):
             stderr=b"src.cpp:1:1: error: expected unqualified-id\n",
         )),
     )
+    monkeypatch.setattr("perfxpert.tools.compile_runner.require_tool", mock.MagicMock())
     result = compile_runner.build(project_root=tmp_path, source_rel="src.cpp", flags=["-O2"])
     assert result["returncode"] == 1
     assert "error: expected unqualified-id" in result["stderr"]

--- a/experimental/python/perfxpert/tests/test_tools/test_profile_runner.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_profile_runner.py
@@ -13,19 +13,24 @@ def test_run_is_execution_class():
     assert profile_runner.run.__tool_class__ == ToolClass.EXECUTION
 
 
-def test_run_rejects_unknown_flag(tmp_path: Path):
+def test_run_rejects_unknown_flag_before_tool_check(tmp_path: Path, monkeypatch):
+    require_tool = mock.MagicMock(side_effect=AssertionError("require_tool reached"))
+    monkeypatch.setattr("perfxpert.tools.profile_runner.require_tool", require_tool)
+
     with pytest.raises(profile_runner.RocprofFlagError) as exc:
         profile_runner.run(
             argv=["rocprofv3", "--totally-fake-flag", "--", "./app"],
             cwd=tmp_path,
         )
     assert "--totally-fake-flag" in str(exc.value)
+    require_tool.assert_not_called()
 
 
 def test_run_accepts_known_flags(tmp_path: Path, monkeypatch):
     fake = mock.MagicMock(return_value=mock.MagicMock(
         returncode=0, stdout=b"", stderr=b""
     ))
+    monkeypatch.setattr("perfxpert.tools.profile_runner.require_tool", mock.MagicMock())
     monkeypatch.setattr("perfxpert.tools.profile_runner.subprocess.run", fake)
 
     result = profile_runner.run(
@@ -38,13 +43,17 @@ def test_run_accepts_known_flags(tmp_path: Path, monkeypatch):
     assert kwargs.get("shell", False) is False
 
 
-def test_run_rejects_shell_injection_in_args(tmp_path: Path):
+def test_run_rejects_shell_injection_in_args_before_tool_check(tmp_path: Path, monkeypatch):
     from perfxpert.tools._safety import ShellMetacharError
+    require_tool = mock.MagicMock(side_effect=AssertionError("require_tool reached"))
+    monkeypatch.setattr("perfxpert.tools.profile_runner.require_tool", require_tool)
+
     with pytest.raises(ShellMetacharError):
         profile_runner.run(
             argv=["rocprofv3", "--sys-trace", "--", "./app;rm -rf ~"],
             cwd=tmp_path,
         )
+    require_tool.assert_not_called()
 
 
 def test_run_strips_api_keys_from_env(tmp_path: Path, monkeypatch):
@@ -55,6 +64,7 @@ def test_run_strips_api_keys_from_env(tmp_path: Path, monkeypatch):
         return mock.MagicMock(returncode=0, stdout=b"", stderr=b"")
 
     monkeypatch.setattr("perfxpert.tools.profile_runner.subprocess.run", fake_run)
+    monkeypatch.setattr("perfxpert.tools.profile_runner.require_tool", mock.MagicMock())
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-should-not-leak")
 
     profile_runner.run(argv=["rocprofv3", "--sys-trace", "--", "./app"], cwd=tmp_path)
@@ -73,6 +83,7 @@ def test_run_respects_timeout(tmp_path: Path, monkeypatch):
         raise _sp.TimeoutExpired(cmd=a[0], timeout=kw.get("timeout", 10))
 
     monkeypatch.setattr("perfxpert.tools.profile_runner.subprocess.run", raise_timeout)
+    monkeypatch.setattr("perfxpert.tools.profile_runner.require_tool", mock.MagicMock())
     with pytest.raises(_sp.TimeoutExpired):
         profile_runner.run(
             argv=["rocprofv3", "--sys-trace", "--", "./app"],

--- a/experimental/python/perfxpert/tests/test_tools/test_tooldep.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_tooldep.py
@@ -106,6 +106,16 @@ def test_check_binary_missing_returns_false(monkeypatch):
     assert "install" in detail.lower() or "not found" in detail.lower()
 
 
+def test_require_tool_accepts_explicit_binary_path_for_registered_dep(tmp_path):
+    fake_cxx = tmp_path / "amdclang++"
+    fake_cxx.write_text("#!/bin/sh\n")
+    fake_cxx.chmod(0o755)
+
+    detail = require_tool("amdclang++", executable=str(fake_cxx))
+
+    assert str(fake_cxx) in detail
+
+
 def test_check_pylib_present_returns_true():
     # mcp is a required runtime dep and should be importable
     ok, detail = check_tool_available("mcp")


### PR DESCRIPTION
Draft PR for PerfXpert vetting finding F01.

Base: develop
Branch: codex/perfxpert-f01-validation-before-tooldep

## Summary
- Validate execution inputs before tool dependency checks.
- Keep configured compiler path overrides routed through the registered `amdclang++` dependency entry.
- Lock the validation-before-tooldep contract with focused regression tests.

## Validation
All pytest commands were run from `experimental/python/perfxpert` in the isolated worktree `/home/aelwazir/work/.worktrees/rocm-rocm-systems-pr-5383-8122f3b9`.

- `python3 -m pytest tests/test_tools/test_profile_runner.py tests/test_tools/test_compile_runner.py tests/test_tools/test_tooldep.py tests/test_red_team/test_rocprofv3_flag_smuggling.py tests/test_red_team/test_compiler_flag_smuggling.py tests/test_red_team/test_inject_disallowed_rocprofv3_flag.py tests/test_red_team/test_inject_disallowed_compiler_flag.py tests/test_red_team/test_shell_injection.py -q` — 71 passed.
- `python3 -m pytest tests/test_tools -q` — 291 passed.
- `python3 -m pytest tests/test_red_team --ignore=tests/test_red_team/test_sanitizer_fuzz.py -q` — 91 passed. The full red-team directory was not runnable in this local environment because `test_sanitizer_fuzz.py` requires the optional `hypothesis` package, which is not installed here.
- `git diff --check origin/develop...HEAD` — passed.
- Outbound guard: this checkout does not ship `scripts/secret-scan.sh` (see `docs/known-issues.md`), so I used the approved installed fallback `custom-ai-secret-scan --repo-root . <changed files>` against the files in this PR; it passed.
