### PR TITLE
Use UTF-8 report writes and portable doctor symbols

### DIFF
--- a/experimental/python/perfxpert/perfxpert/__main__.py
+++ b/experimental/python/perfxpert/perfxpert/__main__.py
@@ -423,6 +423,28 @@ def _status_symbol(kind: str, stream=None) -> str:
     return glyph
 
 
+def _stream_safe_text(text: str, stream=None) -> str:
+    """Return text that can be encoded by the target stream."""
+    import sys
+
+    stream = stream or sys.stdout
+    encoding = getattr(stream, "encoding", None) or "utf-8"
+    try:
+        text.encode(encoding)
+        return text
+    except UnicodeEncodeError:
+        fallback = text.translate(str.maketrans({"—": "-", "–": "-"}))
+        return fallback.encode(encoding, errors="replace").decode(encoding)
+
+
+def _doctor_print(text: str = "", stream=None) -> None:
+    """Print a doctor line without assuming UTF-8 stdout."""
+    import sys
+
+    stream = stream or sys.stdout
+    print(_stream_safe_text(text, stream), file=stream)
+
+
 def _run_doctor():
     """Run all health checks and print results in canonical format."""
     import sys
@@ -443,28 +465,35 @@ def _run_doctor():
         symbol = _status_symbol(kind, sys.stdout)
         if not ok and kind == "fail":
             all_ok = False
-        print(f"{symbol} {msg}")
+        _doctor_print(f"{symbol} {msg}", sys.stdout)
 
     # Check LLM providers
     configured, unconfigured = _check_llm_providers()
     all_ok = all_ok and len(configured) > 0  # at least one provider configured
     configured_str = ", ".join(configured) if configured else "(none)"
     unconfigured_str = ", ".join(unconfigured) if unconfigured else "(all configured)"
-    print(f"{_status_symbol('ok', sys.stdout)} {len(configured)}/5 LLM providers configured ({configured_str})")
+    _doctor_print(
+        f"{_status_symbol('ok', sys.stdout)} "
+        f"{len(configured)}/5 LLM providers configured ({configured_str})",
+        sys.stdout,
+    )
     if unconfigured:
-        print(f"  {len(unconfigured)}/5 providers unconfigured ({unconfigured_str}) — see README")
+        _doctor_print(
+            f"  {len(unconfigured)}/5 providers unconfigured ({unconfigured_str}) — see README",
+            sys.stdout,
+        )
 
     # Report active mode
-    print()
-    print(_report_active_mode())
+    _doctor_print(stream=sys.stdout)
+    _doctor_print(_report_active_mode(), sys.stdout)
 
     # Final status
-    print()
+    _doctor_print(stream=sys.stdout)
     if all_ok:
-        print(f"{_status_symbol('ok', sys.stdout)} ALL CLEAN")
+        _doctor_print(f"{_status_symbol('ok', sys.stdout)} ALL CLEAN", sys.stdout)
         return 0
     else:
-        print(f"{_status_symbol('fail', sys.stdout)} Issues found — see above")
+        _doctor_print(f"{_status_symbol('fail', sys.stdout)} Issues found — see above", sys.stdout)
         return 1
 
 

--- a/experimental/python/perfxpert/perfxpert/__main__.py
+++ b/experimental/python/perfxpert/perfxpert/__main__.py
@@ -407,6 +407,22 @@ def _report_active_mode() -> str:
     return "Mode: agentic"
 
 
+def _status_symbol(kind: str, stream=None) -> str:
+    """Return a status symbol representable by the target stream."""
+    import sys
+
+    stream = stream or sys.stdout
+    glyphs = {"ok": "✓", "warn": "⚠", "fail": "✗"}
+    fallback = {"ok": "OK", "warn": "WARN", "fail": "FAIL"}
+    glyph = glyphs[kind]
+    encoding = getattr(stream, "encoding", None) or "utf-8"
+    try:
+        glyph.encode(encoding)
+    except UnicodeEncodeError:
+        return fallback[kind]
+    return glyph
+
+
 def _run_doctor():
     """Run all health checks and print results in canonical format."""
     import sys
@@ -423,8 +439,9 @@ def _run_doctor():
 
     all_ok = True
     for name, (ok, msg) in checks:
-        symbol = "✓" if ok else "⚠" if "unknown" in msg.lower() else "✗"
-        if not ok and symbol == "✗":
+        kind = "ok" if ok else "warn" if "unknown" in msg.lower() else "fail"
+        symbol = _status_symbol(kind, sys.stdout)
+        if not ok and kind == "fail":
             all_ok = False
         print(f"{symbol} {msg}")
 
@@ -433,7 +450,7 @@ def _run_doctor():
     all_ok = all_ok and len(configured) > 0  # at least one provider configured
     configured_str = ", ".join(configured) if configured else "(none)"
     unconfigured_str = ", ".join(unconfigured) if unconfigured else "(all configured)"
-    print(f"✓ {len(configured)}/5 LLM providers configured ({configured_str})")
+    print(f"{_status_symbol('ok', sys.stdout)} {len(configured)}/5 LLM providers configured ({configured_str})")
     if unconfigured:
         print(f"  {len(unconfigured)}/5 providers unconfigured ({unconfigured_str}) — see README")
 
@@ -444,10 +461,10 @@ def _run_doctor():
     # Final status
     print()
     if all_ok:
-        print("✓ ALL CLEAN")
+        print(f"{_status_symbol('ok', sys.stdout)} ALL CLEAN")
         return 0
     else:
-        print(f"✗ Issues found — see above")
+        print(f"{_status_symbol('fail', sys.stdout)} Issues found — see above")
         return 1
 
 

--- a/experimental/python/perfxpert/perfxpert/analyze.py
+++ b/experimental/python/perfxpert/perfxpert/analyze.py
@@ -1833,7 +1833,7 @@ def _execute_agentic(
             base = base + _ext
         output_file = os.path.join(config.output_path, base)
         os.makedirs(config.output_path, exist_ok=True)
-        with open(output_file, "w") as f:
+        with open(output_file, "w", encoding="utf-8") as f:
             f.write(output)
         print(f"Analysis written to: {output_file}")
         if output_format == "text":

--- a/experimental/python/perfxpert/tests/test_cli/test_doctor_providers.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_doctor_providers.py
@@ -3,6 +3,21 @@
 from perfxpert import __main__ as perfxpert_main
 
 
+class _Stream:
+    def __init__(self, encoding):
+        self.encoding = encoding
+
+
+def test_status_symbol_falls_back_for_non_utf8_streams():
+    assert perfxpert_main._status_symbol("ok", _Stream("cp1252")) == "OK"
+    assert perfxpert_main._status_symbol("warn", _Stream("cp1252")) == "WARN"
+    assert perfxpert_main._status_symbol("fail", _Stream("cp1252")) == "FAIL"
+
+
+def test_status_symbol_keeps_unicode_for_utf8_streams():
+    assert perfxpert_main._status_symbol("ok", _Stream("utf-8")) == "✓"
+
+
 def test_check_llm_providers_accepts_canonical_env_names(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")

--- a/experimental/python/perfxpert/tests/test_cli/test_doctor_providers.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_doctor_providers.py
@@ -1,5 +1,8 @@
 """Unit tests for `perfxpert doctor` provider-env detection."""
 
+import io
+import sys
+
 from perfxpert import __main__ as perfxpert_main
 
 
@@ -16,6 +19,58 @@ def test_status_symbol_falls_back_for_non_utf8_streams():
 
 def test_status_symbol_keeps_unicode_for_utf8_streams():
     assert perfxpert_main._status_symbol("ok", _Stream("utf-8")) == "✓"
+
+
+def test_run_doctor_is_safe_for_ascii_stdout(monkeypatch):
+    task_store_msg = (
+        "Python task store ready\n"
+        "  WARNING: PERFXPERT_TASK_ROOT not set — defaulting to /tmp/.perfxpert. "
+        "Set PERFXPERT_TASK_ROOT to use a custom location."
+    )
+    monkeypatch.setattr(perfxpert_main, "_check_version", lambda: (True, "perfxpert 0.1"))
+    monkeypatch.setattr(
+        perfxpert_main,
+        "_check_python_version",
+        lambda: (True, "Python 3.10"),
+    )
+    monkeypatch.setattr(
+        perfxpert_main,
+        "_check_openai_agents",
+        lambda: (True, "openai-agents ok"),
+    )
+    monkeypatch.setattr(
+        perfxpert_main,
+        "_check_mcp_server",
+        lambda: (False, "MCP server FAILED"),
+    )
+    monkeypatch.setattr(perfxpert_main, "_check_task_store", lambda: (True, task_store_msg))
+    monkeypatch.setattr(
+        perfxpert_main,
+        "_check_opencode_bundled",
+        lambda: (True, "Bundled opencode ok"),
+    )
+    monkeypatch.setattr(
+        perfxpert_main,
+        "_check_opencode_bundled_config",
+        lambda: (True, "Bundled config ok"),
+    )
+    monkeypatch.setattr(
+        perfxpert_main,
+        "_check_llm_providers",
+        lambda: (["opencode"], ["anthropic"]),
+    )
+
+    buffer = io.BytesIO()
+    stdout = io.TextIOWrapper(buffer, encoding="ascii", errors="strict")
+    monkeypatch.setattr(sys, "stdout", stdout)
+
+    assert perfxpert_main._run_doctor() == 1
+    stdout.flush()
+    output = buffer.getvalue().decode("ascii")
+
+    assert "PERFXPERT_TASK_ROOT not set - defaulting" in output
+    assert "providers unconfigured (anthropic) - see README" in output
+    assert "FAIL Issues found - see above" in output
 
 
 def test_check_llm_providers_accepts_canonical_env_names(monkeypatch):


### PR DESCRIPTION
Draft PR for PerfXpert vetting finding F03.

Base: develop
Branch: codex/perfxpert-f03-utf8-cli-output

## Summary
- Use UTF-8 report writes and portable doctor symbols.
- Scoped as one draft PR per actionable vetting item for independent review.

## Validation
- pytest tests/test_cli/test_doctor_providers.py -q; compileall -q perfxpert; cp1252 doctor smoke run
- Outbound guard: scripts/secret-scan.sh passed before this PR body update.