### PR TITLE
Derive runtime version from package metadata

### DIFF
--- a/experimental/python/perfxpert/CMakeLists.txt
+++ b/experimental/python/perfxpert/CMakeLists.txt
@@ -5,9 +5,20 @@
 ###############################################################################
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/pyproject.toml" _PERFXPERT_PYPROJECT)
+string(
+    REGEX MATCH "(^|\n)[ \t]*version[ \t]*=[ \t]*\"([^\"]+)\""
+    _PERFXPERT_VERSION_MATCH
+    "${_PERFXPERT_PYPROJECT}"
+)
+if(NOT CMAKE_MATCH_2)
+    message(FATAL_ERROR "Unable to read perfxpert version from pyproject.toml")
+endif()
+set(PERFXPERT_VERSION "${CMAKE_MATCH_2}")
+
 project(
     perfxpert
-    VERSION 0.1.0
+    VERSION ${PERFXPERT_VERSION}
     DESCRIPTION "AI-powered GPU trace analysis for rocprofiler-sdk databases"
     LANGUAGES NONE
 )

--- a/experimental/python/perfxpert/perfxpert/__init__.py
+++ b/experimental/python/perfxpert/perfxpert/__init__.py
@@ -17,12 +17,26 @@ CLI
     perfxpert analyze -i trace.db --format json
 """
 
-from importlib.metadata import PackageNotFoundError, version
+import re
+from importlib.metadata import PackageNotFoundError, version as _metadata_version
+from pathlib import Path
+
+
+def _source_tree_version() -> str:
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    try:
+        text = pyproject.read_text(encoding="utf-8")
+    except OSError:
+        return "0+unknown"
+    match = re.search(r"(?m)^version\s*=\s*\"([^\"]+)\"", text)
+    return match.group(1) if match else "0+unknown"
+
 
 try:
-    __version__ = version("perfxpert")
+    __version__ = _metadata_version("perfxpert")
 except PackageNotFoundError:
-    __version__ = "0.0.0"
+    __version__ = _source_tree_version()
+
 __author__ = "Advanced Micro Devices, Inc."
 
 from .connection import PerfxpertConnection, execute_statement, merge_sqlite_dbs

--- a/experimental/python/perfxpert/perfxpert/__main__.py
+++ b/experimental/python/perfxpert/perfxpert/__main__.py
@@ -453,15 +453,11 @@ def _run_doctor():
 
 def _get_version():
     try:
-        from importlib.metadata import version
+        from perfxpert import __version__
 
-        return version("perfxpert")
-    except (ImportError, ModuleNotFoundError):
-        # importlib.metadata not available (Python < 3.8 edge case)
-        return "0.1.0"
-    except ValueError:
-        # Package not installed / metadata lookup failed
-        return "0.1.0"
+        return __version__
+    except ImportError:
+        return "0+unknown"
 
 
 if __name__ == "__main__":

--- a/experimental/python/perfxpert/tests/e2e/test_perfxpert_code_version.py
+++ b/experimental/python/perfxpert/tests/e2e/test_perfxpert_code_version.py
@@ -1,5 +1,6 @@
 """E2E: `perfxpert-code --version` produces AMD-branded output."""
 
+from importlib.metadata import version
 import subprocess
 
 
@@ -36,3 +37,4 @@ def test_version_has_version_number():
     )
     # something like "AMD ROCm PerfXpert 0.2.0 (opencode wrapper)"
     assert re.search(r"\d+\.\d+\.\d+", result.stdout)
+    assert version("perfxpert") in result.stdout

--- a/experimental/python/perfxpert/tests/test_tools/test_opencode_launcher.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_opencode_launcher.py
@@ -1,6 +1,7 @@
 """Unit tests for perfxpert.cli.opencode_launcher."""
 
 import os
+from importlib.metadata import version
 from pathlib import Path
 from unittest import mock
 
@@ -23,6 +24,7 @@ def test_version_flag_short_circuit(capsys):
     assert rc == 0
     captured = capsys.readouterr()
     assert "AMD" in captured.out
+    assert version("perfxpert") in captured.out
 
 
 def test_v_short_flag(capsys):

--- a/experimental/python/perfxpert/tests/test_version_metadata.py
+++ b/experimental/python/perfxpert/tests/test_version_metadata.py
@@ -7,3 +7,7 @@ import perfxpert
 
 def test_runtime_version_matches_installed_metadata() -> None:
     assert perfxpert.__version__ == version("perfxpert")
+
+
+def test_source_tree_version_matches_installed_metadata() -> None:
+    assert perfxpert._source_tree_version() == version("perfxpert")


### PR DESCRIPTION
Draft PR for PerfXpert vetting finding F04.

Base: develop
Branch: codex/perfxpert-f04-single-version-source

## Summary
- Derive runtime version from package metadata.
- Scoped as one draft PR per actionable vetting item for independent review.

## Validation
- version unit/e2e tests with venv Scripts on PATH
- Outbound guard: scripts/secret-scan.sh passed before this PR body update.