### PR TITLE
Let CMake installs resolve Python dependencies

### DIFF
--- a/experimental/python/perfxpert/CMakeLists.txt
+++ b/experimental/python/perfxpert/CMakeLists.txt
@@ -30,11 +30,12 @@ if(PERFXPERT_INSTALL_PYTHON)
     endif()
 
     # Install the perfxpert Python package into the standard site-packages
+    # Dependencies are resolved by pip here; distro packaging can override
+    # this path when dependencies are provided by system packages instead.
     install(
         CODE "execute_process(
             COMMAND ${Python3_EXECUTABLE} -m pip install
                 --prefix \"\${CMAKE_INSTALL_PREFIX}\"
-                --no-deps
                 --no-build-isolation
                 \"${CMAKE_CURRENT_SOURCE_DIR}\"
             RESULT_VARIABLE _pip_result
@@ -42,13 +43,6 @@ if(PERFXPERT_INSTALL_PYTHON)
         if(NOT _pip_result EQUAL 0)
             message(FATAL_ERROR \"pip install failed: \${_pip_result}\")
         endif()"
-    )
-
-    # Also expose the entry-point script
-    install(
-        PROGRAMS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/perfxpert"
-        DESTINATION bin
-        OPTIONAL
     )
 endif()
 

--- a/experimental/python/perfxpert/tests/test_packaging/test_cmake_install.py
+++ b/experimental/python/perfxpert/tests/test_packaging/test_cmake_install.py
@@ -1,0 +1,17 @@
+"""Static checks for the CMake-driven perfxpert install path."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CMAKELISTS = REPO_ROOT / "CMakeLists.txt"
+
+
+def test_cmake_install_lets_pip_resolve_dependencies():
+    text = CMAKELISTS.read_text(encoding="utf-8")
+    assert "--no-deps" not in text
+
+
+def test_cmake_install_does_not_reference_missing_script():
+    text = CMAKELISTS.read_text(encoding="utf-8")
+    assert "scripts/perfxpert" not in text


### PR DESCRIPTION
Draft PR for PerfXpert vetting finding F05.

Base: develop
Branch: codex/perfxpert-f05-cmake-install-deps

## Summary
- Let CMake installs resolve Python dependencies.
- Scoped as one draft PR per actionable vetting item for independent review.

## Validation
- pytest tests/test_packaging/test_cmake_install.py -q
- Outbound guard: scripts/secret-scan.sh passed before this PR body update.