### PR TITLE
Constrain python-dotenv for litellm extras

### DIFF
--- a/experimental/python/perfxpert/pyproject.toml
+++ b/experimental/python/perfxpert/pyproject.toml
@@ -42,12 +42,13 @@ rich = ["rich>=13.0"]
 # Without it, framework._sdk_invoke() silently routes every model string to
 # OpenAI's endpoint and fails with "requested model does not exist" for
 # Anthropic/Ollama models (Phase 8 fix).
-litellm = ["litellm>=1.50"]
+litellm = ["litellm>=1.50", "python-dotenv>=1.2.2"]
 all  = [
     "anthropic>=0.18",
     "openai>=1.0",
     "rich>=13.0",
     "litellm>=1.50",
+    "python-dotenv>=1.2.2",
 ]
 dev  = [
     "pytest>=8.0",


### PR DESCRIPTION
PR for PerfXpert vetting finding F06.

Base: develop
Branch: codex/perfxpert-f06-dotenv-floor

## Summary
- Constrain python-dotenv for litellm extras.
- Scoped as one draft PR per actionable vetting item for independent review.

## Validation
- editable .[all] reinstall and pip-audit -f json returned no known vulnerabilities
- Outbound guard: scripts/secret-scan.sh passed before this PR body update.