### PR TITLE
Apply path redaction before LLM provider calls

### DIFF
--- a/experimental/python/perfxpert/perfxpert/providers/_sanitization.py
+++ b/experimental/python/perfxpert/perfxpert/providers/_sanitization.py
@@ -29,5 +29,21 @@ def redact_paths(value: str) -> str:
     return result
 
 
+def sanitize_value(value: Any) -> Any:
+    """Recursively redact path-like strings in provider-bound payloads."""
+    if isinstance(value, str):
+        return redact_paths(value)
+    if isinstance(value, list):
+        return [sanitize_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: sanitize_value(item) for key, item in value.items()}
+    return value
+
+
+def sanitize_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return a sanitized copy of an OpenAI-style messages list."""
+    return sanitize_value(messages)
+
+
 # Alias for backward compatibility with existing code
 _redact_paths = redact_paths

--- a/experimental/python/perfxpert/perfxpert/providers/anthropic_provider.py
+++ b/experimental/python/perfxpert/perfxpert/providers/anthropic_provider.py
@@ -6,6 +6,7 @@ from perfxpert.providers._base import Provider, ProviderResponse
 from perfxpert.providers._exceptions import (
     AuthError, DryRunResponse, ProviderError, RateLimitError, TimeoutError,
 )
+from perfxpert.providers._sanitization import redact_paths, sanitize_messages
 from perfxpert.providers.registry import register
 from perfxpert.tools._tooldep import require_tool
 try:
@@ -44,6 +45,8 @@ class AnthropicProvider(Provider):
             return DryRunResponse
         model_id = model or _DEFAULT_MODEL
         budget = max_tokens or _DEFAULT_MAX_TOKENS
+        messages = sanitize_messages(messages)
+        system = redact_paths(system)
         try:
             resp = self._client.messages.create(
                 model=model_id, max_tokens=budget,

--- a/experimental/python/perfxpert/perfxpert/providers/ollama_provider.py
+++ b/experimental/python/perfxpert/perfxpert/providers/ollama_provider.py
@@ -13,6 +13,7 @@ from perfxpert.providers._exceptions import (
     ProviderError,
     TimeoutError,
 )
+from perfxpert.providers._sanitization import redact_paths, sanitize_messages
 from perfxpert.providers.registry import register
 
 _DEFAULT_URL = "http://localhost:11434"
@@ -47,6 +48,8 @@ class OllamaProvider(Provider):
             return DryRunResponse
 
         model_id = model or _DEFAULT_MODEL
+        messages = sanitize_messages(messages)
+        system = redact_paths(system)
         full = [{"role": "system", "content": system}] if system else []
         full.extend(messages)
 

--- a/experimental/python/perfxpert/perfxpert/providers/openai_provider.py
+++ b/experimental/python/perfxpert/perfxpert/providers/openai_provider.py
@@ -6,6 +6,7 @@ from perfxpert.providers._base import Provider, ProviderResponse
 from perfxpert.providers._exceptions import (
     AuthError, DryRunResponse, ProviderError, RateLimitError, TimeoutError,
 )
+from perfxpert.providers._sanitization import redact_paths, sanitize_messages
 from perfxpert.providers.registry import register
 from perfxpert.tools._tooldep import require_tool
 try:
@@ -53,6 +54,8 @@ class OpenAIProvider(Provider):
             return DryRunResponse
         model_id = model or _DEFAULT_MODEL
         budget = max_tokens or _DEFAULT_MAX_TOKENS
+        messages = sanitize_messages(messages)
+        system = redact_paths(system)
         try:
             resp = self._call(model=model_id, system=system, messages=messages, budget=budget)
         except _SDK.AuthenticationError as e:  # type: ignore[union-attr]

--- a/experimental/python/perfxpert/perfxpert/providers/opencode_provider.py
+++ b/experimental/python/perfxpert/perfxpert/providers/opencode_provider.py
@@ -23,6 +23,7 @@ from perfxpert.providers._exceptions import (
     ProviderError,
     TimeoutError,
 )
+from perfxpert.providers._sanitization import redact_paths, sanitize_messages
 from perfxpert.providers.registry import register
 
 _DEFAULT_TIMEOUT = 180.0
@@ -83,7 +84,7 @@ class OpencodeProvider(Provider):
                 "cannot invoke opencode provider inside an opencode session"
             )
 
-        prompt = _flatten_messages(messages, system)
+        prompt = _flatten_messages(sanitize_messages(messages), redact_paths(system))
         cmd = [self._binary, "run", "--no-color"]
         if model:
             cmd += ["--model", model]

--- a/experimental/python/perfxpert/perfxpert/providers/private_provider.py
+++ b/experimental/python/perfxpert/perfxpert/providers/private_provider.py
@@ -20,6 +20,7 @@ from perfxpert.providers._exceptions import (
     ProviderError,
     TimeoutError,
 )
+from perfxpert.providers._sanitization import redact_paths, sanitize_messages
 from perfxpert.providers.registry import register
 
 _DEFAULT_TIMEOUT = 120.0
@@ -86,6 +87,8 @@ class PrivateProvider(Provider):
             return DryRunResponse
 
         model_id = model or self._model_default
+        messages = sanitize_messages(messages)
+        system = redact_paths(system)
         full = [{"role": "system", "content": system}] if system else []
         full.extend(messages)
 

--- a/experimental/python/perfxpert/tests/test_providers/test_private_provider.py
+++ b/experimental/python/perfxpert/tests/test_providers/test_private_provider.py
@@ -88,6 +88,25 @@ def test_custom_headers_merged(monkeypatch):
         assert headers["X-Trace"] == "1"
 
 
+def test_provider_payload_redacts_paths(monkeypatch):
+    monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_URL", "https://llm.corp.internal/v1")
+    monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_MODEL", "internal-xl")
+    from perfxpert.providers.private_provider import PrivateProvider
+
+    with patch(
+        "perfxpert.providers.private_provider.httpx.post",
+        return_value=_fake_chat_response(),
+    ) as mp:
+        PrivateProvider().complete(
+            [{"role": "user", "content": "analyze /tmp/private/trace.db"}],
+            system=r"project is C:\Users\dev\repo",
+        )
+        payload = mp.call_args.kwargs["json"]
+        assert "/tmp/private/trace.db" not in str(payload)
+        assert r"C:\Users\dev\repo" not in str(payload)
+        assert "[REDACTED]" in str(payload)
+
+
 def test_verify_ssl_disabled_when_env_zero(monkeypatch):
     monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_URL", "https://internal.corp/v1")
     monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_MODEL", "m")

--- a/experimental/python/perfxpert/tests/test_providers/test_sanitization.py
+++ b/experimental/python/perfxpert/tests/test_providers/test_sanitization.py
@@ -4,6 +4,7 @@ import pytest
 
 from perfxpert.providers._sanitization import (
     redact_paths,
+    sanitize_messages,
 )
 
 
@@ -38,3 +39,20 @@ def test_redact_paths_multiple():
     assert "/opt/rocm/lib" not in out
     assert "/tmp/output.db" not in out
     assert out.count("[REDACTED]") >= 2
+
+
+def test_sanitize_messages_recurses_nested_content():
+    messages = [
+        {
+            "role": "user",
+            "content": {
+                "db": "/tmp/private/trace.db",
+                "notes": ["../../secret/file.hip"],
+            },
+        }
+    ]
+    out = sanitize_messages(messages)
+    assert "/tmp/private/trace.db" not in str(out)
+    assert "../../secret/file.hip" not in str(out)
+    assert "[REDACTED]" in str(out)
+    assert "[REDACTED_PATH]" in str(out)


### PR DESCRIPTION
Draft PR for PerfXpert vetting finding F07.

Base: develop
Branch: codex/perfxpert-f07-apply-llm-sanitization

## Summary
- Apply path redaction before LLM provider calls.
- Scoped as one draft PR per actionable vetting item for independent review.

## Validation
- pytest tests/test_providers/test_sanitization.py tests/test_providers/test_private_provider.py -q
- Outbound guard: scripts/secret-scan.sh passed before this PR body update.