### PR TITLE
Make platform-sensitive tests portable

### DIFF
--- a/experimental/python/perfxpert/tests/e2e/test_mcp_tool_coverage.py
+++ b/experimental/python/perfxpert/tests/e2e/test_mcp_tool_coverage.py
@@ -14,6 +14,7 @@ Each test asserts structural correctness of the JSON response and key values.
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Any, Dict
@@ -27,13 +28,9 @@ import pytest
 
 def _perfxpert_mcp_path() -> Path:
     """Locate the perfxpert-mcp entry point."""
-    result = subprocess.run(
-        ["which", "perfxpert-mcp"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode == 0:
-        return Path(result.stdout.strip())
+    found = shutil.which("perfxpert-mcp")
+    if found:
+        return Path(found)
     raise RuntimeError(
         "perfxpert-mcp not found in PATH. Install with: pip install -e ."
     )

--- a/experimental/python/perfxpert/tests/test_integration/test_mcp_protocol.py
+++ b/experimental/python/perfxpert/tests/test_integration/test_mcp_protocol.py
@@ -15,6 +15,7 @@ the server in isolation, avoiding MCP SDK client dependencies.
 """
 
 import json
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -25,13 +26,9 @@ import pytest
 
 def _perfxpert_mcp_path() -> Path:
     """Locate the perfxpert-mcp entry point."""
-    result = subprocess.run(
-        ["which", "perfxpert-mcp"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode == 0:
-        return Path(result.stdout.strip())
+    found = shutil.which("perfxpert-mcp")
+    if found:
+        return Path(found)
     raise RuntimeError(
         "perfxpert-mcp not found in PATH. Install with: pip install -e ."
     )

--- a/experimental/python/perfxpert/tests/test_red_team/test_path_traversal.py
+++ b/experimental/python/perfxpert/tests/test_red_team/test_path_traversal.py
@@ -8,6 +8,13 @@ from perfxpert.tools import patch_mgr
 from perfxpert.tools._safety import PathConfinementError
 
 
+def _symlink_or_skip(link: Path, target: Path) -> None:
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink creation unavailable on this host: {exc}")
+
+
 TRAVERSAL_PAYLOADS = [
     "../../../etc/passwd",
     "../outside",
@@ -29,7 +36,7 @@ def test_symlink_escape_rejected(tmp_path: Path):
     outside = tmp_path.parent / "outside_target.txt"
     outside.write_text("target\n")
     inside = tmp_path / "link.cpp"
-    inside.symlink_to(outside)
+    _symlink_or_skip(inside, outside)
 
     with pytest.raises(PathConfinementError):
         patch_mgr.apply(tmp_path, "link.cpp", "malicious\n")
@@ -40,9 +47,9 @@ def test_symlink_chain_escape_rejected(tmp_path: Path):
     outside = tmp_path.parent / "outside_final.txt"
     outside.write_text("target\n")
     middle = tmp_path.parent / "outside_middle"
-    middle.symlink_to(outside)
+    _symlink_or_skip(middle, outside)
     inside = tmp_path / "chain.cpp"
-    inside.symlink_to(middle)
+    _symlink_or_skip(inside, middle)
 
     with pytest.raises(PathConfinementError):
         patch_mgr.apply(tmp_path, "chain.cpp", "malicious\n")

--- a/experimental/python/perfxpert/tests/test_tools/test_safety.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_safety.py
@@ -7,6 +7,13 @@ import pytest
 from perfxpert.tools import _safety
 
 
+def _symlink_or_skip(link: Path, target: Path) -> None:
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink creation unavailable on this host: {exc}")
+
+
 # -- confine_to_project_root ------------------------------------------------
 
 def test_confine_to_project_root_accepts_relative(tmp_path: Path):
@@ -31,7 +38,7 @@ def test_confine_to_project_root_resolves_symlink_escape(tmp_path: Path):
     """Symlink pointing outside the project root must be rejected."""
     outside = tmp_path.parent / "outside_target"
     outside.write_text("hi")
-    (tmp_path / "link").symlink_to(outside)
+    _symlink_or_skip(tmp_path / "link", outside)
     with pytest.raises(_safety.PathConfinementError):
         _safety.confine_to_project_root(tmp_path, "link")
 


### PR DESCRIPTION
Draft PR for PerfXpert vetting finding F10.

Base: develop
Branch: codex/perfxpert-f10-cross-platform-tests

## Summary
- Make platform-sensitive tests portable.
- Scoped as one draft PR per actionable vetting item for independent review.

## Validation
- safety/path traversal/MCP handshake subset passed with symlink skips where unsupported
- Outbound guard: scripts/secret-scan.sh passed before this PR body update.