### PR TITLE
Honor HOME when resolving CLI config paths

### DIFF
--- a/experimental/python/perfxpert/perfxpert/cli/_backend/codex.py
+++ b/experimental/python/perfxpert/perfxpert/cli/_backend/codex.py
@@ -81,6 +81,7 @@ from perfxpert.cli._consent import (
     prompt_consent_interactive,
     revoke_consent,
 )
+from perfxpert.cli._paths import user_home
 
 
 __all__ = [
@@ -201,7 +202,7 @@ class CodexAdapter:
     # ------------------------------------------------------------------
 
     def _user_codex_config_path(self, home: Path | None = None) -> Path:
-        return (home or Path.home()) / self._CODEX_CFG_REL
+        return (home or user_home()) / self._CODEX_CFG_REL
 
     def _check_trust(
         self, cwd: Path, home: Path | None = None
@@ -256,7 +257,7 @@ class CodexAdapter:
         """Return the directory whose `config.toml` we should edit."""
         if scope == "project":
             return Path(cwd) / ".codex"
-        return Path.home() / ".codex"
+        return user_home() / ".codex"
 
     def _target_paths(
         self,

--- a/experimental/python/perfxpert/perfxpert/cli/_consent.py
+++ b/experimental/python/perfxpert/perfxpert/cli/_consent.py
@@ -32,6 +32,8 @@ from typing import Iterable
 
 import yaml
 
+from perfxpert.cli._paths import xdg_config_home
+
 
 __all__ = [
     "CONSENT_ASSUME_ENV",
@@ -55,10 +57,7 @@ CONSENT_ASSUME_ENV = "PERFXPERT_ASSUME_CONSENT"
 
 
 def _xdg_config_home() -> Path:
-    override = os.environ.get("XDG_CONFIG_HOME", "").strip()
-    if override:
-        return Path(override)
-    return Path.home() / ".config"
+    return xdg_config_home()
 
 
 def consent_path() -> Path:

--- a/experimental/python/perfxpert/perfxpert/cli/_paths.py
+++ b/experimental/python/perfxpert/perfxpert/cli/_paths.py
@@ -1,0 +1,22 @@
+"""Shared user path helpers for CLI config files."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def user_home() -> Path:
+    """Return the explicit HOME override when set, else the platform home."""
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        return Path(home).expanduser()
+    return Path.home()
+
+
+def xdg_config_home() -> Path:
+    """Return XDG_CONFIG_HOME, or HOME/.config when XDG is unset."""
+    override = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return user_home() / ".config"

--- a/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_adapter.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_adapter.py
@@ -109,6 +109,12 @@ def _mark_trusted(home: Path, cwd: Path) -> None:
     )
 
 
+def test_codex_user_paths_honor_home_env(isolated_home: Path, project_cwd: Path) -> None:
+    adapter = CodexAdapter()
+    assert adapter._user_codex_config_path() == isolated_home / ".codex" / "config.toml"
+    assert adapter._scope_config_dir(project_cwd, "user") == isolated_home / ".codex"
+
+
 def _fake_codex_subprocess(
     *,
     list_exit: int = 0,

--- a/experimental/python/perfxpert/tests/test_cli/test_consent.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_consent.py
@@ -261,7 +261,7 @@ def test_home_isolation_defaults_to_dot_config(
     monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
     p = consent_path()
     assert str(tmp_path) in str(p)
-    assert ".config/perfxpert/consent.yaml" in str(p)
+    assert p == tmp_path / ".config" / "perfxpert" / "consent.yaml"
 
 
 def test_grant_does_not_touch_other_home(


### PR DESCRIPTION
Draft PR for PerfXpert vetting finding F11.

Base: develop
Branch: codex/perfxpert-f11-home-aware-config-paths

## Summary
- Honor HOME when resolving CLI config paths.
- Scoped as one draft PR per actionable vetting item for independent review.

## Validation
- HOME isolation and Codex path tests passed
- Outbound guard: scripts/secret-scan.sh passed before this PR body update.