### PR TITLE
Filter explicit subprocess environment overrides

### DIFF
--- a/experimental/python/perfxpert/perfxpert/tools/_safety.py
+++ b/experimental/python/perfxpert/perfxpert/tools/_safety.py
@@ -154,16 +154,22 @@ _ENV_PREFIX_WHITELIST = (
 )
 
 
+def _env_key_allowed(key: str) -> bool:
+    return key in _ENV_WHITELIST or any(key.startswith(p) for p in _ENV_PREFIX_WHITELIST)
+
+
 def build_safe_env(extra: dict | None = None) -> dict:
     """Construct a minimal subprocess env containing only whitelisted keys.
 
     - API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, …) are NEVER forwarded.
-    - Adds anything in `extra` last (caller responsibility for those values).
+    - `extra` is filtered through the same allowlist as the parent env.
     """
     safe = {}
     for k, v in os.environ.items():
-        if k in _ENV_WHITELIST or any(k.startswith(p) for p in _ENV_PREFIX_WHITELIST):
+        if _env_key_allowed(k):
             safe[k] = v
     if extra:
-        safe.update(extra)
+        for k, v in extra.items():
+            if _env_key_allowed(k):
+                safe[k] = v
     return safe

--- a/experimental/python/perfxpert/tests/test_tools/test_safety.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_safety.py
@@ -105,3 +105,18 @@ def test_build_safe_env_only_whitelist(monkeypatch):
     assert "PATH" in env
     assert "ROCM_PATH" in env
     assert "ANTHROPIC_API_KEY" not in env, "API keys must NOT leak to subprocess"
+
+
+def test_build_safe_env_filters_extra_env():
+    env = _safety.build_safe_env(
+        extra={
+            "OPENAI_API_KEY": "sk-secret",
+            "PATH": "/custom/bin",
+            "ROCPROFV3_LOG_LEVEL": "debug",
+            "UNRELATED": "drop-me",
+        }
+    )
+    assert env["PATH"] == "/custom/bin"
+    assert env["ROCPROFV3_LOG_LEVEL"] == "debug"
+    assert "OPENAI_API_KEY" not in env
+    assert "UNRELATED" not in env


### PR DESCRIPTION
Draft PR for PerfXpert vetting finding F14.

Base: develop
Branch: codex/perfxpert-f14-filter-extra-env

## Summary
- Filter explicit subprocess environment overrides.
- Scoped as one draft PR per actionable vetting item for independent review.

## Validation
- focused safe-env tests passed
- Outbound guard: scripts/secret-scan.sh passed before this PR body update.