### PR TITLE
Redact private provider header parse errors

### DIFF
--- a/experimental/python/perfxpert/perfxpert/providers/private_provider.py
+++ b/experimental/python/perfxpert/perfxpert/providers/private_provider.py
@@ -32,7 +32,8 @@ def _parse_headers(raw: str) -> Dict[str, str]:
         obj = json.loads(raw)
     except json.JSONDecodeError as e:
         raise ValueError(
-            f"PERFXPERT_LLM_PRIVATE_HEADERS contains invalid JSON: {e}. " f"Value was: {raw[:80]!r}"
+            f"PERFXPERT_LLM_PRIVATE_HEADERS contains invalid JSON at "
+            f"line {e.lineno} column {e.colno}: {e.msg}"
         ) from e
     if not isinstance(obj, dict):
         raise ValueError(f"PERFXPERT_LLM_PRIVATE_HEADERS must be a JSON object, got {type(obj).__name__}")

--- a/experimental/python/perfxpert/tests/test_providers/test_private_provider.py
+++ b/experimental/python/perfxpert/tests/test_providers/test_private_provider.py
@@ -144,8 +144,11 @@ def test_parse_headers_valid_json_dict():
 def test_parse_headers_invalid_json_raises_value_error():
     from perfxpert.providers.private_provider import _parse_headers
 
-    with pytest.raises(ValueError, match="invalid JSON"):
-        _parse_headers("not-json{{{")
+    secret = '{"Authorization": "Bearer super-secret"'
+    with pytest.raises(ValueError, match="invalid JSON") as exc:
+        _parse_headers(secret)
+    assert "super-secret" not in str(exc.value)
+    assert "Authorization" not in str(exc.value)
 
 
 def test_parse_headers_non_dict_json_raises_value_error():


### PR DESCRIPTION
Draft PR for PerfXpert vetting finding F15.

Base: develop
Branch: codex/perfxpert-f15-redact-private-header-errors

## Summary
- Redact private provider header parse errors.
- Scoped as one draft PR per actionable vetting item for independent review.

## Validation
- pytest tests/test_providers/test_private_provider.py -q
- Outbound guard: scripts/secret-scan.sh passed before this PR body update.