### PR TITLE
Escape read-only SQLite file URIs

### DIFF
--- a/experimental/python/perfxpert/perfxpert/tools/predict_impact.py
+++ b/experimental/python/perfxpert/perfxpert/tools/predict_impact.py
@@ -34,6 +34,7 @@ import hashlib
 import json
 import sqlite3
 import threading
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from perfxpert.knowledge import load_yaml
@@ -138,6 +139,13 @@ def _kernel_time_pct(baseline_db: str, kernel_name: str) -> Optional[float]:
 _COUNTER_TABLE_CANDIDATES = ("rocpd_counter_values", "counter_values", "COUNTER")
 
 
+def _readonly_sqlite_uri(db_path: str) -> str:
+    """Build a read-only SQLite file URI with path metacharacters escaped."""
+    if not db_path:
+        raise ValueError("db_path must not be empty")
+    return f"{Path(db_path).expanduser().resolve(strict=False).as_uri()}?mode=ro"
+
+
 def _baseline_has_counters(baseline_db: str) -> bool:
     """Return True iff the rocpd DB has any counter rows.
 
@@ -146,7 +154,7 @@ def _baseline_has_counters(baseline_db: str) -> bool:
     allowlist + fall back to ``False`` on any exception.
     """
     try:
-        with sqlite3.connect(f"file:{baseline_db}?mode=ro", uri=True) as conn:
+        with sqlite3.connect(_readonly_sqlite_uri(baseline_db), uri=True) as conn:
             cur = conn.cursor()
             for tbl in _COUNTER_TABLE_CANDIDATES:
                 try:
@@ -156,7 +164,7 @@ def _baseline_has_counters(baseline_db: str) -> bool:
                         return True
                 except sqlite3.Error:
                     continue
-    except sqlite3.Error:
+    except (ValueError, sqlite3.Error):
         return False
     return False
 

--- a/experimental/python/perfxpert/tests/test_tools/test_predict_impact.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_predict_impact.py
@@ -21,6 +21,18 @@ def _clear_prediction_store():
 # --------------------------------------------------------------------- #
 
 
+def test_readonly_sqlite_uri_escapes_path_metacharacters(tmp_path):
+    db = tmp_path / "trace db#1.db"
+    uri = predict_impact._readonly_sqlite_uri(str(db))
+    assert uri.startswith("file:")
+    assert uri.endswith("?mode=ro")
+    assert "trace%20db%231.db" in uri
+
+
+def test_baseline_has_counters_empty_path_returns_false():
+    assert predict_impact._baseline_has_counters("") is False
+
+
 def test_predict_change_impact_vgpr_reduction_returns_bracket(tmp_path):
     """Fake DB path; bypass DB probes via change_params. Assert bracket > 0."""
     result = predict_impact.predict_change_impact(


### PR DESCRIPTION
Draft PR for PerfXpert vetting finding F16.

Base: develop
Branch: codex/perfxpert-f16-escape-sqlite-uri

## Summary
- Escape read-only SQLite file URIs.
- Scoped as one draft PR per actionable vetting item for independent review.

## Validation
- pytest tests/test_tools/test_predict_impact.py -q
- Outbound guard: scripts/secret-scan.sh passed before this PR body update.