### PR TITLE
Require opencode binary for provider doctor status

### DIFF
--- a/experimental/python/perfxpert/perfxpert/__main__.py
+++ b/experimental/python/perfxpert/perfxpert/__main__.py
@@ -374,6 +374,7 @@ def _check_opencode_bundled_config() -> tuple[bool, str]:
 def _check_llm_providers() -> tuple[list[str], list[str]]:
     """Check which LLM providers are configured."""
     import os
+    from perfxpert.cli.opencode_launcher import resolve_opencode_binary
 
     configured = []
     unconfigured = []
@@ -394,7 +395,14 @@ def _check_llm_providers() -> tuple[list[str], list[str]]:
     }
 
     for name, env_vars in providers.items():
-        if name == "opencode" or any(os.getenv(env_var) for env_var in env_vars):
+        if name == "opencode":
+            try:
+                resolve_opencode_binary()
+            except FileNotFoundError:
+                unconfigured.append(name)
+            else:
+                configured.append(name)
+        elif any(os.getenv(env_var) for env_var in env_vars):
             configured.append(name)
         else:
             unconfigured.append(name)

--- a/experimental/python/perfxpert/tests/test_cli/test_doctor_providers.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_doctor_providers.py
@@ -4,6 +4,10 @@ from perfxpert import __main__ as perfxpert_main
 
 
 def test_check_llm_providers_accepts_canonical_env_names(monkeypatch):
+    monkeypatch.setattr(
+        "perfxpert.cli.opencode_launcher.resolve_opencode_binary",
+        lambda: "/tmp/opencode",
+    )
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
     monkeypatch.setenv("PERFXPERT_LLM_LOCAL_URL", "http://localhost:11434")
@@ -18,6 +22,10 @@ def test_check_llm_providers_accepts_canonical_env_names(monkeypatch):
 
 
 def test_check_llm_providers_accepts_compatibility_aliases(monkeypatch):
+    monkeypatch.setattr(
+        "perfxpert.cli.opencode_launcher.resolve_opencode_binary",
+        lambda: "/tmp/opencode",
+    )
     monkeypatch.setenv("OLLAMA_HOST", "http://localhost:11434")
     monkeypatch.setenv("PRIVATE_LLM_ENDPOINT", "https://llm.example/v1")
 
@@ -26,3 +34,15 @@ def test_check_llm_providers_accepts_compatibility_aliases(monkeypatch):
     assert "ollama" in configured
     assert "private" in configured
     assert "opencode" in configured
+
+
+def test_check_llm_providers_requires_opencode_binary(monkeypatch):
+    def missing():
+        raise FileNotFoundError("missing opencode")
+
+    monkeypatch.setattr("perfxpert.cli.opencode_launcher.resolve_opencode_binary", missing)
+
+    configured, unconfigured = perfxpert_main._check_llm_providers()
+
+    assert "opencode" not in configured
+    assert "opencode" in unconfigured


### PR DESCRIPTION
Draft PR for PerfXpert vetting finding F17.

Base: develop
Branch: codex/perfxpert-f17-opencode-provider-doctor

## Summary
- Require opencode binary for provider doctor status.
- Scoped as one draft PR per actionable vetting item for independent review.

## Validation
- pytest tests/test_cli/test_doctor_providers.py -q
- Outbound guard: scripts/secret-scan.sh passed before this PR body update.