### PR TITLE
Package bundled opencode license

### DIFF
--- a/experimental/python/perfxpert/perfxpert/_bundled/opencode_LICENSE
+++ b/experimental/python/perfxpert/perfxpert/_bundled/opencode_LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 opencode
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/experimental/python/perfxpert/pyproject.toml
+++ b/experimental/python/perfxpert/pyproject.toml
@@ -91,7 +91,7 @@ perfxpert = [
     "agents/fence/*.md",
     "agents/templates/*",
     "../NOTICE",
-    "../opencode/LICENSE",
+    "_bundled/opencode_LICENSE",
 ]
 
 [tool.pytest.ini_options]

--- a/experimental/python/perfxpert/tests/test_packaging/test_bundled_licenses.py
+++ b/experimental/python/perfxpert/tests/test_packaging/test_bundled_licenses.py
@@ -1,0 +1,17 @@
+"""Packaging checks for bundled third-party license files."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_bundled_opencode_license_is_package_data_and_present():
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    package_data = data["tool"]["setuptools"]["package-data"]["perfxpert"]
+    assert "_bundled/opencode_LICENSE" in package_data
+    license_path = REPO_ROOT / "perfxpert" / "_bundled" / "opencode_LICENSE"
+    assert "MIT License" in license_path.read_text(encoding="utf-8")


### PR DESCRIPTION
Draft PR for PerfXpert vetting finding F18.

Base: develop
Branch: codex/perfxpert-f18-bundled-opencode-license

## Summary
- Package bundled opencode license.
- Scoped as one draft PR per actionable vetting item for independent review.

## Validation
- packaging test passed; built wheel contains perfxpert/_bundled/opencode_LICENSE
- Outbound guard: scripts/secret-scan.sh passed before this PR body update.