### PR TITLE
Add PerfXpert maintainability regression guards

### DIFF
--- a/experimental/python/perfxpert/tests/test_maintainability/test_ast_hotspots.py
+++ b/experimental/python/perfxpert/tests/test_maintainability/test_ast_hotspots.py
@@ -1,0 +1,144 @@
+###############################################################################
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc.
+###############################################################################
+
+"""Regression guards for large PerfXpert implementation units.
+
+The current tree still has legacy formatter and backend hot spots. Keep their
+inventory explicit so future changes can shrink them deliberately without
+allowing new 120+ line functions/classes or silent growth in the existing ones.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+SOURCE_ROOTS = (PACKAGE_ROOT / "perfxpert", PACKAGE_ROOT / "mcp_server")
+MAX_UNIT_LINES = 120
+
+
+@dataclass(frozen=True)
+class Unit:
+    path: str
+    kind: str
+    name: str
+    line: int
+    lines: int
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (self.path, self.name)
+
+
+KNOWN_HOTSPOT_BUDGETS = {
+    ("perfxpert/__main__.py", "main"): 231,
+    ("perfxpert/agents/analysis.py", "_extract_hw_metrics"): 147,
+    ("perfxpert/agents/runtime.py", "AnalysisSession"): 141,
+    ("perfxpert/analysis/att.py", "analyze_thread_trace"): 198,
+    ("perfxpert/analysis/core.py", "analyze_kernel_resources"): 120,
+    ("perfxpert/analysis/payload.py", "scan_tier0_sources"): 216,
+    ("perfxpert/analysis/payload.py", "build_analysis_payload"): 229,
+    ("perfxpert/analysis/pmc.py", "_split_pmc_into_passes"): 138,
+    ("perfxpert/analysis/recommendations.py", "_filter_rec_commands"): 139,
+    ("perfxpert/analysis/recommendations.py", "generate_recommendations"): 748,
+    ("perfxpert/analyze.py", "add_args"): 274,
+    ("perfxpert/analyze.py", "_format_agentic_output"): 446,
+    ("perfxpert/analyze.py", "_execute_agentic"): 254,
+    ("perfxpert/cli/_backend/claude.py", "ClaudeCodeAdapter"): 619,
+    ("perfxpert/cli/_backend/codex.py", "CodexAdapter"): 1118,
+    ("perfxpert/cli/_backend/codex.py", "install"): 150,
+    ("perfxpert/cli/_backend/gemini.py", "GeminiAdapter"): 465,
+    ("perfxpert/cli/_gate_hooks/claude.py", "ClaudeGateHook"): 140,
+    ("perfxpert/cli/_gate_hooks/gemini.py", "GeminiGateHook"): 141,
+    ("perfxpert/cli/_mcp_warmup.py", "warmup_perfxpert_mcp"): 140,
+    ("perfxpert/connection.py", "PerfxpertConnection"): 294,
+    ("perfxpert/connection.py", "_create_union_views"): 164,
+    ("perfxpert/formatters/__init__.py", "format_analysis_output"): 651,
+    ("perfxpert/formatters/_att_flamegraph.py", "render_att_flamegraph"): 150,
+    ("perfxpert/formatters/_roofline_svg.py", "render_roofline_svg"): 221,
+    ("perfxpert/formatters/json_fmt.py", "_format_as_json"): 171,
+    ("perfxpert/formatters/markdown.py", "_format_as_markdown"): 338,
+    ("perfxpert/formatters/markdown.py", "_format_tier0_markdown"): 178,
+    ("perfxpert/formatters/webview.py", "_format_as_webview"): 1175,
+    ("perfxpert/formatters/webview.py", "_format_diff_webview"): 234,
+    ("perfxpert/formatters/webview.py", "_format_tier0_webview"): 480,
+    ("perfxpert/runtime/gate_cascade.py", "evaluate"): 123,
+    ("perfxpert/runtime/gate_cascade.py", "run_gate_cascade"): 225,
+    ("perfxpert/tools/predict_impact.py", "predict_change_impact"): 164,
+    ("perfxpert/tools/roofline.py", "plot_points"): 166,
+    ("perfxpert/tools/tasks.py", "TaskStore"): 153,
+    ("perfxpert/tools/trace_diff.py", "diff_runs"): 125,
+}
+
+
+def _iter_units() -> list[Unit]:
+    units: list[Unit] = []
+    for root in SOURCE_ROOTS:
+        if not root.exists():
+            continue
+        for path in root.rglob("*.py"):
+            rel = path.relative_to(PACKAGE_ROOT).as_posix()
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel)
+            for node in ast.walk(tree):
+                if not isinstance(
+                    node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+                ):
+                    continue
+                if node.end_lineno is None:
+                    continue
+                units.append(
+                    Unit(
+                        path=rel,
+                        kind=type(node).__name__,
+                        name=node.name,
+                        line=node.lineno,
+                        lines=node.end_lineno - node.lineno + 1,
+                    )
+                )
+    return units
+
+
+def test_large_units_are_registered_for_refactor_tracking():
+    large_units = [u for u in _iter_units() if u.lines >= MAX_UNIT_LINES]
+
+    unregistered = [
+        f"{u.path}:{u.line} {u.kind} {u.name} spans {u.lines} lines"
+        for u in large_units
+        if u.key not in KNOWN_HOTSPOT_BUDGETS
+    ]
+
+    assert not unregistered, (
+        "New large functions/classes must either be split before merge or "
+        "added here with an explicit refactor budget:\n" + "\n".join(unregistered)
+    )
+
+
+def test_registered_large_units_do_not_grow():
+    by_key = {u.key: u for u in _iter_units()}
+    grown = []
+    missing = []
+    for key, budget in KNOWN_HOTSPOT_BUDGETS.items():
+        unit = by_key.get(key)
+        if unit is None:
+            missing.append(f"{key[0]}::{key[1]}")
+            continue
+        if unit.lines > budget:
+            grown.append(
+                f"{unit.path}:{unit.line} {unit.name} grew to "
+                f"{unit.lines} lines (budget {budget})"
+            )
+
+    assert not missing, (
+        "Remove renamed/split units from KNOWN_HOTSPOT_BUDGETS:\n"
+        + "\n".join(missing)
+    )
+    assert not grown, (
+        "Large implementation units grew; split helper sections or adjust the "
+        "budget in the same review:\n" + "\n".join(grown)
+    )

--- a/experimental/python/perfxpert/tests/test_maintainability/test_formatter_contracts.py
+++ b/experimental/python/perfxpert/tests/test_maintainability/test_formatter_contracts.py
@@ -1,0 +1,110 @@
+###############################################################################
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc.
+###############################################################################
+
+"""Golden-style formatter contracts used before splitting large renderers."""
+
+from __future__ import annotations
+
+import json
+
+from perfxpert.formatters import format_analysis_output
+
+
+TIME_BREAKDOWN = {
+    "total_runtime": 2_000_000,
+    "total_kernel_time": 1_200_000,
+    "total_memcpy_time": 400_000,
+    "kernel_percent": 60.0,
+    "memcpy_percent": 20.0,
+    "overhead_percent": 20.0,
+}
+HOTSPOTS = [
+    {
+        "name": "vector_add",
+        "calls": 4,
+        "total_duration": 1_200_000,
+        "avg_duration": 300_000,
+        "percent_of_total": 100.0,
+    }
+]
+MEMORY_ANALYSIS = {
+    "Host-to-Device": {
+        "count": 2,
+        "total_bytes": 4096,
+        "total_duration": 400_000,
+        "avg_bytes": 2048,
+        "bandwidth_bytes_per_sec": 10_240_000,
+    }
+}
+RECOMMENDATIONS = [
+    {
+        "priority": "MEDIUM",
+        "category": "Memory Transfer",
+        "issue": "Host-to-device copies are visible in the profile.",
+        "suggestion": "Batch transfers and use async copies where possible.",
+        "actions": ["Group small transfers into larger batches."],
+    }
+]
+HARDWARE_COUNTERS = {"has_counters": False, "metrics": {}, "counters": {}}
+
+
+def _render(output_format: str) -> str:
+    return format_analysis_output(
+        time_breakdown=TIME_BREAKDOWN,
+        hotspots=HOTSPOTS,
+        memory_analysis=MEMORY_ANALYSIS,
+        recommendations=RECOMMENDATIONS,
+        hardware_counters=HARDWARE_COUNTERS,
+        database_path="sample.db",
+        output_format=output_format,
+    )
+
+
+def test_text_formatter_section_contract():
+    output = _render("text")
+
+    assert output.index("TIME BREAKDOWN") < output.index("HOTSPOTS")
+    assert output.index("HOTSPOTS") < output.index("MEMORY COPY ANALYSIS")
+    assert output.index("MEMORY COPY ANALYSIS") < output.index("RECOMMENDATIONS")
+    assert "vector_add" in output
+    assert "Host-to-Device" in output
+
+
+def test_markdown_formatter_section_contract():
+    output = _render("markdown")
+
+    assert output.index("## Time Breakdown") < output.index("## Top Kernel Hotspots")
+    assert output.index("## Top Kernel Hotspots") < output.index("## Memory Copy Analysis")
+    assert output.index("## Memory Copy Analysis") < output.index("## Recommendations")
+    assert "vector_add" in output
+    assert "Host-to-Device" in output
+
+
+def test_webview_formatter_section_contract():
+    output = _render("webview")
+
+    assert output.count("<!DOCTYPE html>") == 1
+    assert output.index("<h2>Execution Breakdown</h2>") < output.index("<h2>Top Kernel Hotspots</h2>")
+    assert output.index("<h2>Top Kernel Hotspots</h2>") < output.index("<h2>Memory Transfer Analysis</h2>")
+    assert output.index("<h2>Memory Transfer Analysis</h2>") < output.index("<h2>Optimization Recommendations</h2>")
+    assert "vector_add" in output
+    assert "Host-to-Device" in output
+
+
+def test_json_formatter_section_contract():
+    document = json.loads(_render("json"))
+
+    for key in (
+        "execution_breakdown",
+        "hotspots",
+        "memory_analysis",
+        "recommendations",
+        "hardware_counters",
+        "warnings",
+        "metadata",
+    ):
+        assert key in document
+    assert document["hotspots"][0]["name"] == "vector_add"


### PR DESCRIPTION
Draft PR for PerfXpert vetting finding F19.

Base: develop
Branch: codex/perfxpert-f19-maintainability-guard

## Summary
- Adds an AST-based inventory guard for existing 120+ line functions/classes so new large units or growth in known hot spots cannot land unnoticed.
- Adds direct formatter contract tests for text, markdown, webview, and JSON output before future renderer section refactors.

## Validation
- C:\Users\aelwazir\perfxpert-vet-venv\Scripts\python.exe -m pytest tests/test_maintainability -q
- Outbound guard: scripts/secret-scan.sh passed immediately before this PR create/update.