### PR TITLE
fix gfx1151 name in rocr backend

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
@@ -796,6 +796,15 @@ HSAKMT_STATUS topology_sysfs_get_node_props(uint32_t node_id, HsaNodeProperties&
     props.EngineId.ui32.Major = device->Major();
     props.EngineId.ui32.Minor = device->Minor();
     props.EngineId.ui32.Stepping = device->Stepping();
+
+    // Workaround for device 0x1586: When GPU_ENABLE_PAL=0, the driver incorrectly reports
+    // stepping=0 (gfx1150) instead of stepping=1 (gfx1151). Device 0x1586 is always gfx1151.
+    if (props.DeviceId == 0x1586 &&
+        props.EngineId.ui32.Major == 11 &&
+        props.EngineId.ui32.Minor == 5 &&
+        props.EngineId.ui32.Stepping == 0) {
+      props.EngineId.ui32.Stepping = 1;  // Force gfx1151 for device 0x1586
+    }
   }
 
   snprintf(reinterpret_cast<char*>(props.AMDName), sizeof(props.AMDName) - 1, "GFX%06x",


### PR DESCRIPTION
When GPU_ENABLE_PAL=0 is set on Windows, device 0x1586 (AMD Radeon Graphics APU) incorrectly reports stepping=0 (gfx1150) instead of stepping=1 (gfx1151).

This fix adds a workaround that forces the correct stepping value for device 0x1586, ensuring consistent gfx1151 reporting in both PAL-enabled and PAL-disabled modes.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
