### PR TITLE
perfxpert: follow up install and provider hardening

### DIFF
--- a/experimental/python/perfxpert/CHANGELOG.md
+++ b/experimental/python/perfxpert/CHANGELOG.md
@@ -84,6 +84,15 @@ is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   one-liner still works for users who want it.
 
 ### Changed
+- **Breaking: non-text `perfxpert analyze` formats now write report
+  files by default.** `--format json`, `--format markdown`, and
+  `--format webview` synthesize a report filename when `-o/-d` are
+  omitted. Use `-o -` to preserve stdout for shell pipelines.
+- **Git install hardening.** The GitHub wrapper no longer runs
+  apt/dnf/zypper/sudo unless `PERFXPERT_AUTO_INSTALL_PREREQS=1` or
+  `--auto-install-prereqs` is explicitly supplied. The bundled
+  opencode build no longer bootstraps bun unless
+  `PERFXPERT_AUTO_INSTALL_BUN=1` is explicitly supplied.
 - **`--llm` providers.** All five providers —
   `anthropic`, `openai`, `ollama`, `private`, `opencode` — are
   selectable from the CLI **and** from `perfxpert.api.agent_root(...,

--- a/experimental/python/perfxpert/README.md
+++ b/experimental/python/perfxpert/README.md
@@ -21,6 +21,7 @@ AI-powered AMD ROCm GPU trace analysis.
 apt install -y curl git unzip python3-venv python3-pip
 python3 -m venv .venv
 . .venv/bin/activate
+bun --version  # install bun from your approved package source if this fails
 
 # Latest development build from ROCm/rocm-systems.
 REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
@@ -34,8 +35,10 @@ REF=<SHA>; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF
 ```
 
 The wrapper installs from GitHub, scopes submodule init to the pinned
-PerfXpert `opencode` submodule, and bootstraps bun when needed. It
-builds the patched bundled `perfxpert-code` binary and verifies it before exiting.
+PerfXpert `opencode` submodule, and builds the patched bundled `perfxpert-code` binary.
+If bun is missing, pip fails with an actionable prerequisite message instead
+of producing a partial TUI install. The wrapper verifies `perfxpert-code`
+before exiting.
 No separate `opencode` install is needed for the default `perfxpert-code`
 TUI. See [docs/guides/getting-started.md](docs/guides/getting-started.md)
 for the Ubuntu/RHEL/SLES package matrix, direct-pip equivalent, editable
@@ -48,7 +51,7 @@ installs, and troubleshooting.
 | `anthropic` | Claude API | Production default; requires `ANTHROPIC_API_KEY` |
 | `openai` | OpenAI API | Alternative hosted; requires `OPENAI_API_KEY` |
 | `ollama` | Local Ollama | Fully local; requires a running `ollama serve` |
-| `private` | Any OpenAI-compatible endpoint | Internal deployments; requires `PERFXPERT_LLM_PRIVATE_URL` + `PERFXPERT_LLM_PRIVATE_MODEL`; CLI preflight also needs `PERFXPERT_LLM_PRIVATE_API_KEY` or `--llm-api-key` |
+| `private` | Any OpenAI-compatible endpoint | Internal deployments; requires an endpoint (`PERFXPERT_LLM_PRIVATE_URL`) plus either `PERFXPERT_LLM_PRIVATE_API_KEY` or `--llm-api-key`; set `PERFXPERT_LLM_PRIVATE_MODEL` to select the deployment model |
 | `opencode` | Bundled opencode CLI | Used by `perfxpert-code`; not callable from inside opencode itself (recursion-guarded) |
 
 Private endpoint example:
@@ -65,9 +68,9 @@ perfxpert analyze -i trace.db --llm private
 ### Analyze
 
 `--format` accepts `text` (default), `json`, `markdown`, and `webview`
-(AMD-themed HTML). `text` prints to stdout unless `-o/-d` is supplied;
-all other formats write a report file by default, even when `-o` and `-d`
-are omitted.
+(AMD-themed HTML). `text` prints to stdout unless `-o/-d` is supplied.
+All other formats write a report file by default, even when `-o` and
+`-d` are omitted; use `-o -` to force stdout for pipelines.
 
 LLM-backed analysis uses Chat Completions-style requests. Choose a provider
 model or private endpoint model that supports the Chat Completions API;

--- a/experimental/python/perfxpert/docs/guides/getting-started.md
+++ b/experimental/python/perfxpert/docs/guides/getting-started.md
@@ -20,15 +20,18 @@ RDNA2 / RDNA3.
 ![install](assets/gifs/01-install.gif)
 
 *Install in a clean ROCm container, then verify the CLI surfaces. The
-pip build hook bootstraps bun when needed so the bundled patched
-`perfxpert-code` build completes during install.*
+pip build hook compiles the bundled patched `perfxpert-code` binary
+when bun is already on PATH; bun bootstrap is available only as an
+explicit developer opt-in with `PERFXPERT_AUTO_INSTALL_BUN=1`.*
 
 PerfXpert ships as a single Python wheel. The `setuptools` build hook
 in `setup.py` compiles the AMD-branded bundled opencode binary during
-`pip install`. If bun is missing, pip bootstraps it into the user's home
-directory. If OS prerequisites such as `curl`, `git`, or `unzip` are
-missing, pip fails with the missing package-manager pieces instead of
-silently producing a broken `perfxpert-code`.
+`pip install`. If bun is missing, pip fails closed unless
+`PERFXPERT_AUTO_INSTALL_BUN=1` is set; that explicit opt-in lets
+setup.py bootstrap bun into the user's home directory for this build.
+If OS prerequisites such as `curl`, `git`, or `unzip` are missing, pip
+fails with the missing package-manager pieces instead of silently
+producing a broken `perfxpert-code`.
 
 ### Prerequisites
 
@@ -36,8 +39,9 @@ silently producing a broken `perfxpert-code`.
 - `curl`, `git`, `unzip`, `python3-venv`, and `python3-pip` for GitHub installs.
 - On Ubuntu 24+ and other externally managed Python environments,
   create and activate a virtual environment before invoking pip.
-- `bun` on PATH, or `curl` + `unzip` so pip can bootstrap bun into the
-  user's home directory during install.
+- `bun` on PATH. If you explicitly allow automatic bun bootstrap, also
+  make sure `curl` and `unzip` are present and set
+  `PERFXPERT_AUTO_INSTALL_BUN=1`.
 - The repo-pinned `experimental/python/perfxpert/opencode` submodule
   populated if you are installing from a checkout without using the
   wrapper. The setup hook may attempt a scoped `git submodule update
@@ -64,10 +68,9 @@ backend CLI instead.
 
 ### Distro package setup
 
-Use a virtual environment for the supported install flow. The GitHub
-wrapper path has been validated in clean containers for Ubuntu 22.04,
-Ubuntu 24.04, UBI/RHEL 9, UBI/RHEL 10, and SLES 15.6. Package setup
-differs slightly by distro:
+Use a virtual environment for the supported install flow. Package
+examples are provided for Ubuntu 22.04, Ubuntu 24.04, UBI/RHEL 9,
+UBI/RHEL 10, and SLES 15.6. Package setup differs slightly by distro:
 
 ```bash
 # SKIP-SAMPLE — Ubuntu 22.04 / 24.04
@@ -93,14 +96,14 @@ python3 -m venv .venv
 ```
 
 ```bash
-# SKIP-SAMPLE — SLES 15
+# SKIP-SAMPLE — SLES 15.6
 zypper install -y curl git unzip python311 python311-pip
 python3.11 -m venv .venv
 . .venv/bin/activate
 ```
 
 UBI/RHEL base images can provide `curl` through `curl-minimal`. That is
-valid for the wrapper and for pip's bun bootstrap; do not force dnf to
+valid for the wrapper and for opt-in bun bootstrap; do not force dnf to
 replace it with the full `curl` package unless `command -v curl` fails.
 
 If the venv's pip/setuptools are too old and metadata preparation fails
@@ -123,7 +126,8 @@ pip install -e "experimental/python/perfxpert[all]"
 wrapper (see §1.2 for why):
 
 ```bash
-# SKIP-SAMPLE — latest develop branch, no local clone needed
+# SKIP-SAMPLE — latest develop branch, no local clone needed.
+# Requires bun on PATH; install bun from your approved package source first.
 REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
 # Pin a tag or commit hash:
 # REF=v0.2.0; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
@@ -133,16 +137,17 @@ REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${R
 ```
 
 The GitHub install paths require `git` because pip shells out to
-`git clone`. The wrapper installs missing OS prerequisites with the host
-package manager when it is running as root or when sudo is available;
-otherwise it prints the exact package-manager command to run first. On
-externally managed system Python it tells the user to create a virtual
-environment first. It prefers the active `python`, then `python3`, and
-only falls back to another already-installed `python3.10+` binary on
-PATH when the distro default is too old; it never downloads a separate
-Python runtime. During the pip build, `setup.py` bootstraps bun when it
-is missing so the bundled patched opencode binary is built from the
-pinned perfxpert submodule.
+`git clone`. The wrapper prints missing OS prerequisites and exits by
+default; it only runs `apt`, `dnf`, `zypper`, or `sudo` when
+`PERFXPERT_AUTO_INSTALL_PREREQS=1` or `--auto-install-prereqs` is
+explicitly supplied. On externally managed system Python it tells the
+user to create a virtual environment first. It prefers the active
+`python`, then `python3`, and only falls back to another
+already-installed `python3.10+` binary on PATH when the distro default
+is too old; it never downloads a separate Python runtime. During the
+pip build, `setup.py` builds from the pinned perfxpert opencode
+submodule; if bun is missing, it only bootstraps bun when
+`PERFXPERT_AUTO_INSTALL_BUN=1` is explicitly set.
 
 Pass the ref as the first argument after `bash -s --` when you need to
 pin a specific tag or commit hash.
@@ -163,9 +168,10 @@ launcher/build flow. Omit `[all]` if you only want deterministic
 air-gap analysis (wrapper: pass `--extras ''` to skip extras entirely).
 On the GitHub wrapper path, the wrapper exits non-zero if the bundled
 patched `perfxpert-code` binary is still absent after install. Direct
-pip/editable paths use the same `setup.py` build hook: pip bootstraps
-bun when the OS prerequisites are available, or fails with a
-distro-specific prerequisite message when they are not.
+pip/editable paths use the same `setup.py` build hook: bun must be on
+PATH, or `PERFXPERT_AUTO_INSTALL_BUN=1` must be set to allow setup.py to
+bootstrap it. Otherwise pip fails with an actionable prerequisite
+message.
 
 ### 1.2 Why the wrapper: scoped submodule init
 
@@ -241,9 +247,11 @@ sandboxed CI that intentionally skips the interactive TUI build.
 Default `perfxpert-code` requires the bundled binary built from the
 pinned submodule.
 
-**Bun missing:** pip bootstraps bun into the user's home directory when
-`curl` and `unzip` are available. If those OS prerequisites are missing,
-pip exits with distro-specific package-manager guidance.
+**Bun missing:** pip fails closed by default. Install bun from an
+approved package source, or explicitly set `PERFXPERT_AUTO_INSTALL_BUN=1`
+to allow setup.py to bootstrap bun into the user's home directory for
+this build. If bootstrap prerequisites are missing, pip exits with
+distro-specific package-manager guidance.
 
 ## 2. Verify
 
@@ -260,7 +268,8 @@ perfxpert doctor
 ![doctor](assets/gifs/03-doctor.gif)
 
 *`perfxpert doctor` end-to-end: Python check, MCP server reachable
-(56 tools registered), 3/5 LLM providers configured, `ALL CLEAN`.*
+(56 tools registered), hosted/local/private LLM provider readiness,
+bundled opencode availability, `ALL CLEAN`.*
 
 Expected output ends with `ALL CLEAN` when everything is wired. The
 doctor checks:
@@ -270,11 +279,12 @@ doctor checks:
 - MCP server reachable (`perfxpert-mcp` boots + 56 tools registered — 8 agent-hierarchy + 47 classifier/knowledge + 1 `trace_diff.diff_runs`)
 - task store (`~/.perfxpert` or `$PERFXPERT_TASK_ROOT`)
 - patched opencode binary resolution + bundled opencode config dir
-- LLM providers configured (counts `N/5` against
+- LLM providers configured (counts hosted/local/private providers against
   `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
   `PERFXPERT_LLM_LOCAL_URL` or `OLLAMA_HOST`,
-  `PERFXPERT_LLM_PRIVATE_URL` or `PRIVATE_LLM_ENDPOINT`,
-  plus always-present `opencode`)
+  and `PERFXPERT_LLM_PRIVATE_URL` or `PRIVATE_LLM_ENDPOINT` plus
+  `PERFXPERT_LLM_PRIVATE_API_KEY`)
+- bundled opencode availability; opencode handles its own provider auth
 
 If `opencode binary` reports missing, the install skipped or failed the
 bundled build. Reinstall through the GitHub wrapper so the pinned
@@ -490,7 +500,7 @@ drive from scripts or dashboards.*
 
 ![analyze webview](assets/gifs/07-analyze-webview.gif)
 
-*`--format webview` produces a self-contained `analysis.html` with the
+*`--format webview -o report` produces a self-contained `report.html` with the
 fixed 7 top-level sections (Overview, Summary, Execution, Hotspots,
 Hardware Counters, Recommendations, Tier-0 when `--source-dir` is
 set). AMD dark theme, SVG gauges, collapsible cards — email-ready.*
@@ -945,9 +955,9 @@ perfxpert analyze -i trace.db --llm openai
 An LLM analysis can take 1-5 minutes per call — PerfXpert draws a live
 progress spinner on stderr so you can see each agent phase as it
 enters / exits (`entering root`, `entering analysis`, etc.) and if the
-fallback chain cascades across providers. The spinner is stderr-only,
-so piping stdout to a file (e.g. `--format json > out.json`) still
-captures clean output.
+fallback chain cascades across providers. The spinner is stderr-only.
+For non-text formats, reports write to files by default; use
+`--format json -o - > out.json` when a pipeline needs stdout.
 
 ![progress spinner](assets/gifs/10-progress-spinner.gif)
 
@@ -980,8 +990,8 @@ a one-line stderr WARNING so you know which credential is active):
 |---------|-----------------|-----------------|-------|
 | `anthropic` | `ANTHROPIC_API_KEY` | `PERFXPERT_LLM_ANTHROPIC_KEY` | Either works; alias kept for migration parity |
 | `openai` | `OPENAI_API_KEY` | `PERFXPERT_LLM_OPENAI_KEY` | Either works |
-| `private` | `PERFXPERT_LLM_PRIVATE_API_KEY` | — | Plus `PERFXPERT_LLM_PRIVATE_URL` (required) and normally `PERFXPERT_LLM_PRIVATE_MODEL` |
-| `ollama` | — (no key) | — | Plus `PERFXPERT_LLM_LOCAL_URL` (default `http://localhost:11434`) |
+| `private` | `PERFXPERT_LLM_PRIVATE_API_KEY` | — | Plus `PERFXPERT_LLM_PRIVATE_URL` or `PRIVATE_LLM_ENDPOINT` and normally `PERFXPERT_LLM_PRIVATE_MODEL` |
+| `ollama` | — (no key) | — | Plus `PERFXPERT_LLM_LOCAL_URL` or `OLLAMA_HOST` (default `http://localhost:11434`) |
 | `opencode` | — (no key) | — | Default `perfxpert-code` uses the bundled binary; `PERFXPERT_OPENCODE_PATH` is only for `perfxpert-code opencode ...` |
 
 ```bash
@@ -1242,8 +1252,8 @@ optional; all analysis runs locally without internet when you omit
 | `anthropic` | `ANTHROPIC_API_KEY` | Claude API (production default) |
 | `openai` | `OPENAI_API_KEY` | OpenAI hosted API |
 | `ollama` | `PERFXPERT_LLM_LOCAL_URL` (compat: `OLLAMA_HOST`, default `http://localhost:11434`) | Local Ollama daemon — fully offline once the model is pulled |
-| `private` | `PERFXPERT_LLM_PRIVATE_URL`, `PERFXPERT_LLM_PRIVATE_MODEL`, `PERFXPERT_LLM_PRIVATE_API_KEY` or `--llm-api-key`, optional `PERFXPERT_LLM_PRIVATE_HEADERS` (JSON), optional `PERFXPERT_LLM_PRIVATE_VERIFY_SSL=false` | Any OpenAI-compatible endpoint (enterprise / self-hosted) |
-| `opencode` | none required (bundled) | Bundled opencode CLI — subprocess wrapper; recursion-guarded inside `perfxpert-code` |
+| `private` | `PERFXPERT_LLM_PRIVATE_URL` (compat: `PRIVATE_LLM_ENDPOINT`), `PERFXPERT_LLM_PRIVATE_API_KEY` or `--llm-api-key`, optional `PERFXPERT_LLM_PRIVATE_MODEL`, optional `PERFXPERT_LLM_PRIVATE_HEADERS` (JSON), optional `PERFXPERT_LLM_PRIVATE_VERIFY_SSL=false` | Any OpenAI-compatible endpoint (enterprise / self-hosted) |
+| `opencode` | bundled binary; provider auth is handled by opencode | Bundled opencode CLI — subprocess wrapper; recursion-guarded inside `perfxpert-code` |
 
 ```bash
 # SKIP-SAMPLE — requires a real trace.db and an LLM credential

--- a/experimental/python/perfxpert/perfxpert/__main__.py
+++ b/experimental/python/perfxpert/perfxpert/__main__.py
@@ -394,7 +394,13 @@ def _check_llm_providers() -> tuple[list[str], list[str]]:
     }
 
     for name, env_vars in providers.items():
-        if name == "opencode" or any(os.getenv(env_var) for env_var in env_vars):
+        if name == "private":
+            endpoint = any(os.getenv(env_var) for env_var in env_vars)
+            if endpoint and os.getenv("PERFXPERT_LLM_PRIVATE_API_KEY"):
+                configured.append(name)
+            else:
+                unconfigured.append(name)
+        elif name == "opencode" or any(os.getenv(env_var) for env_var in env_vars):
             configured.append(name)
         else:
             unconfigured.append(name)

--- a/experimental/python/perfxpert/perfxpert/agents/framework.py
+++ b/experimental/python/perfxpert/perfxpert/agents/framework.py
@@ -245,11 +245,18 @@ def _build_sdk_run_config(provider: str) -> Any:
             from openai import AsyncOpenAI  # type: ignore[import-not-found]
             import httpx
 
-            from perfxpert.providers.private_provider import _parse_headers, _verify_ssl_from_env
+            from perfxpert.providers.private_provider import (
+                _parse_headers,
+                _private_url_from_env,
+                _verify_ssl_from_env,
+            )
 
-            base_url = (os.environ.get("PERFXPERT_LLM_PRIVATE_URL") or "").rstrip("/")
+            base_url = _private_url_from_env()
             if not base_url:
-                raise AuthError("private", "no endpoint configured (set PERFXPERT_LLM_PRIVATE_URL)")
+                raise AuthError(
+                    "private",
+                    "no endpoint configured (set PERFXPERT_LLM_PRIVATE_URL or PRIVATE_LLM_ENDPOINT)",
+                )
             try:
                 extra_headers = _parse_headers(os.environ.get("PERFXPERT_LLM_PRIVATE_HEADERS", ""))
             except ValueError as exc:

--- a/experimental/python/perfxpert/perfxpert/analyze.py
+++ b/experimental/python/perfxpert/perfxpert/analyze.py
@@ -244,7 +244,7 @@ def add_args(parser: argparse.ArgumentParser):
             "'anthropic' (ANTHROPIC_API_KEY), 'openai' (OPENAI_API_KEY), "
             "'ollama' (local daemon, PERFXPERT_LLM_LOCAL_URL), "
             "'private' (self-hosted OpenAI-compatible endpoint, PERFXPERT_LLM_PRIVATE_URL + _API_KEY), "
-            "'opencode' (bundled opencode CLI, PERFXPERT_OPENCODE_PATH), "
+            "'opencode' (bundled opencode CLI), "
             "'claude-code' (compatibility alias for opencode). "
             "Local analysis always runs first; LLM provides additional natural language insights."
         ),
@@ -1461,10 +1461,11 @@ _PROVIDER_CREDENTIALS = {
     "private": {
         "env_vars": ("PERFXPERT_LLM_PRIVATE_API_KEY",),
         "hint": (
-            "private provider requires PERFXPERT_LLM_PRIVATE_URL + "
-            "PERFXPERT_LLM_PRIVATE_API_KEY (or --llm-api-key <key>)"
+            "private provider requires PERFXPERT_LLM_PRIVATE_URL "
+            "(or PRIVATE_LLM_ENDPOINT) plus PERFXPERT_LLM_PRIVATE_API_KEY "
+            "(or --llm-api-key <key>)"
         ),
-        "required_env": ("PERFXPERT_LLM_PRIVATE_URL",),
+        "required_env_any": (("PERFXPERT_LLM_PRIVATE_URL", "PRIVATE_LLM_ENDPOINT"),),
     },
     "ollama": {
         "env_vars": (),  # Ollama needs no key; URL is the credential.
@@ -1477,8 +1478,8 @@ _PROVIDER_CREDENTIALS = {
     "opencode": {
         "env_vars": (),
         "hint": (
-            "opencode provider requires the bundled CLI on PATH or set "
-            "PERFXPERT_OPENCODE_PATH=/path/to/opencode"
+            "opencode provider requires the bundled patched CLI produced by "
+            "the perfxpert install/build hook"
         ),
         "required_env": (),
     },
@@ -1522,11 +1523,14 @@ def _preflight_provider_auth(provider: str, flag_api_key: Optional[str]) -> None
 
 
 def _require_additional_env(provider: str, info: Dict[str, Any]) -> None:
-    """Verify any ``required_env`` vars for ``provider`` are set."""
+    """Verify any additional env requirements for ``provider`` are set."""
     from perfxpert.providers._exceptions import AuthError
 
     for var in info.get("required_env", ()) or ():
         if not os.environ.get(var):
+            raise AuthError(provider, info["hint"])
+    for choices in info.get("required_env_any", ()) or ():
+        if not any(os.environ.get(var) for var in choices):
             raise AuthError(provider, info["hint"])
 
 
@@ -1822,6 +1826,10 @@ def _execute_agentic(
     _ext_map = {"json": ".json", "markdown": ".md", "webview": ".html", "text": ".txt"}
     _ext = _ext_map.get(output_format, ".txt")
 
+    if config and config.output_file == "-":
+        print(output)
+        return input
+
     if config and output_format != "text":
         if not config.output_path:
             config.output_path = "."
@@ -1830,6 +1838,8 @@ def _execute_agentic(
                 config.output_file = os.path.splitext(os.path.basename(database_path))[0]
             else:
                 config.output_file = "analysis"
+    elif config and config.output_file and not config.output_path:
+        config.output_path = "."
     elif config and config.output_path and not config.output_file:
         if database_path:
             config.output_file = os.path.splitext(os.path.basename(database_path))[0]
@@ -1844,12 +1854,13 @@ def _execute_agentic(
         os.makedirs(config.output_path, exist_ok=True)
         with open(output_file, "w") as f:
             f.write(output)
-        print(f"Analysis written to: {output_file}")
+        print(f"Analysis written to: {output_file}", file=sys.stderr)
         if output_format == "text":
             print(
                 "Tip: use --format webview for an interactive HTML report, "
                 "--format json for machine-readable output, "
-                "or --format markdown for Markdown."
+                "or --format markdown for Markdown.",
+                file=sys.stderr,
             )
     else:
         print(output)
@@ -1988,9 +1999,12 @@ def _render_cli_error(exc: BaseException) -> int:
             "openai": "OPENAI_API_KEY",
             "anthropic": "ANTHROPIC_API_KEY",
             "ollama": "PERFXPERT_LLM_LOCAL_URL",
-            "private": "PERFXPERT_LLM_PRIVATE_API_KEY",
-            "opencode": "PERFXPERT_OPENCODE_PATH",
-            "claude-code": "PERFXPERT_OPENCODE_PATH",
+            "private": (
+                "PERFXPERT_LLM_PRIVATE_URL or PRIVATE_LLM_ENDPOINT, plus "
+                "PERFXPERT_LLM_PRIVATE_API_KEY or --llm-api-key"
+            ),
+            "opencode": "the bundled patched opencode build",
+            "claude-code": "the bundled patched opencode build",
         }.get(prov, f"{prov.upper()}_API_KEY")
         print(
             f"⚠ LLM auth failed for {prov}. "

--- a/experimental/python/perfxpert/perfxpert/cli/branding.py
+++ b/experimental/python/perfxpert/perfxpert/cli/branding.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import os
-import shutil
 from typing import List, Optional
 
+from perfxpert.cli.opencode_launcher import resolve_opencode_binary
 from perfxpert.runtime import recursion_guard
 
 
@@ -33,18 +33,32 @@ def _provider_configured(name: str) -> bool:
     checks = {
         "anthropic": ("PERFXPERT_LLM_ANTHROPIC_KEY", "ANTHROPIC_API_KEY"),
         "openai": ("PERFXPERT_LLM_OPENAI_KEY", "OPENAI_API_KEY"),
-        "ollama": ("PERFXPERT_LLM_LOCAL_URL",),
-        "private": ("PERFXPERT_LLM_PRIVATE_URL",),
-        "opencode": ("PERFXPERT_OPENCODE_PATH",),
+        "ollama": ("PERFXPERT_LLM_LOCAL_URL", "OLLAMA_HOST"),
+        "opencode": (),
     }
+    if name == "private":
+        endpoint = os.environ.get("PERFXPERT_LLM_PRIVATE_URL") or os.environ.get(
+            "PRIVATE_LLM_ENDPOINT"
+        )
+        return bool(endpoint and os.environ.get("PERFXPERT_LLM_PRIVATE_API_KEY"))
     for env in checks.get(name, ()):
         if os.environ.get(env):
             return True
     if name == "ollama":
         return True  # defaults to localhost
     if name == "opencode":
-        return shutil.which("opencode") is not None
+        try:
+            resolve_opencode_binary()
+            return True
+        except FileNotFoundError:
+            return False
     return False
+
+
+def _provider_status(name: str) -> str:
+    if name == "opencode":
+        return "available" if _provider_configured(name) else "missing"
+    return "configured" if _provider_configured(name) else "missing"
 
 
 def get_provider_status_table() -> str:
@@ -57,11 +71,11 @@ def get_provider_status_table() -> str:
         "anthropic": "PERFXPERT_LLM_ANTHROPIC_KEY | ANTHROPIC_API_KEY",
         "openai": "PERFXPERT_LLM_OPENAI_KEY | OPENAI_API_KEY",
         "ollama": "PERFXPERT_LLM_LOCAL_URL (defaults to localhost:11434)",
-        "private": "PERFXPERT_LLM_PRIVATE_URL + _MODEL + _API_KEY",
-        "opencode": "PERFXPERT_OPENCODE_PATH or opencode on PATH",
+        "private": "PERFXPERT_LLM_PRIVATE_URL/PRIVATE_LLM_ENDPOINT + _API_KEY",
+        "opencode": "bundled binary; opencode handles provider auth",
     }
     for name in ("anthropic", "openai", "ollama", "private", "opencode"):
-        status = "configured" if _provider_configured(name) else "missing"
+        status = _provider_status(name)
         rows.append(f"{name:<12} {status:<12} {hints[name]}")
     return "\n".join(rows)
 
@@ -76,11 +90,7 @@ def launch_opencode(
 
     dry_run=True returns the prospective command without exec'ing.
     """
-    binary = opencode_path or os.environ.get("PERFXPERT_OPENCODE_PATH") or shutil.which("opencode")
-    if not binary:
-        raise FileNotFoundError(
-            "opencode binary not found (set PERFXPERT_OPENCODE_PATH or install opencode on PATH)"
-        )
+    binary = opencode_path or str(resolve_opencode_binary())
 
     argv: List[str] = [binary]
     if extra_args:

--- a/experimental/python/perfxpert/perfxpert/cli/opencode_launcher.py
+++ b/experimental/python/perfxpert/perfxpert/cli/opencode_launcher.py
@@ -166,7 +166,9 @@ def resolve_opencode_binary() -> Path:
 
     raise FileNotFoundError(
         "bundled patched opencode binary not found. Reinstall perfxpert with the "
-        "GitHub wrapper so the pinned opencode submodule is built:\n"
+        "GitHub wrapper so the pinned opencode submodule is built. Ensure bun "
+        "is on PATH first, or explicitly set PERFXPERT_AUTO_INSTALL_BUN=1 for "
+        "a developer-local bootstrap:\n"
         '  REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"\n'
         "For a user-owned upstream opencode binary, run: perfxpert-code opencode [args]"
     )
@@ -629,7 +631,9 @@ def main(argv: list[str] | None = None) -> int:
             print(f"\033[31mperfxpert-code opencode: {e}\033[0m", file=sys.stderr)
             return 1
         try:
-            proc = subprocess.run([str(binary), *argv_out], env=dict(os.environ), check=False)
+            env = dict(os.environ)
+            env.pop("PERFXPERT_IN_OPENCODE_SESSION", None)
+            proc = subprocess.run([str(binary), *argv_out], env=env, check=False)
         except KeyboardInterrupt:
             return 130
         return proc.returncode

--- a/experimental/python/perfxpert/perfxpert/output_config.py
+++ b/experimental/python/perfxpert/perfxpert/output_config.py
@@ -43,8 +43,9 @@ def add_args(parser: argparse.ArgumentParser) -> None:
         default=None,
         metavar="NAME",
         help=(
-            "Base name for output file (without extension). "
-            "Extension is added automatically based on --format."
+            "Output file name; may include or omit extension. "
+            "Extension is added automatically when missing based on --format. "
+            "Use '-' to force stdout."
         ),
     )
     parser.add_argument(

--- a/experimental/python/perfxpert/perfxpert/providers/__init__.py
+++ b/experimental/python/perfxpert/perfxpert/providers/__init__.py
@@ -16,10 +16,14 @@ Public API:
 Env var conventions (canonical):
     PERFXPERT_LLM_ANTHROPIC_KEY
     PERFXPERT_LLM_OPENAI_KEY
-    PERFXPERT_LLM_LOCAL_URL         (ollama)
+    PERFXPERT_LLM_LOCAL_URL         (ollama; OLLAMA_HOST also accepted)
     PERFXPERT_LLM_PRIVATE_URL / _MODEL / _API_KEY / _HEADERS / _VERIFY_SSL
-    PERFXPERT_OPENCODE_PATH
+    PRIVATE_LLM_ENDPOINT            (private endpoint URL compatibility alias)
     PERFXPERT_IN_OPENCODE_SESSION   (recursion guard marker)
+
+PERFXPERT_OPENCODE_PATH is intentionally not a provider env var. It is
+honored only by the explicit `perfxpert-code opencode ...` launcher escape
+hatch for user-owned upstream binaries.
 
 Back-compat env-var aliases (honored with DeprecationWarning):
     ROCPD_LLM_*  → PERFXPERT_LLM_*   (pre-rename alias)

--- a/experimental/python/perfxpert/perfxpert/providers/ollama_provider.py
+++ b/experimental/python/perfxpert/perfxpert/providers/ollama_provider.py
@@ -21,10 +21,16 @@ _DEFAULT_TIMEOUT = 120.0
 
 
 def _resolve_url(explicit: Optional[str]) -> str:
-    if explicit:
-        return explicit.rstrip("/")
-    env = os.environ.get("PERFXPERT_LLM_LOCAL_URL")
-    return (env or _DEFAULT_URL).rstrip("/")
+    value = (
+        explicit
+        or os.environ.get("PERFXPERT_LLM_LOCAL_URL")
+        or os.environ.get("OLLAMA_HOST")
+        or _DEFAULT_URL
+    )
+    value = value.rstrip("/")
+    if "://" not in value:
+        value = f"http://{value}"
+    return value
 
 
 class OllamaProvider(Provider):
@@ -82,7 +88,7 @@ class OllamaProvider(Provider):
 register(
     "ollama",
     OllamaProvider,
-    "Local ollama daemon (default http://localhost:11434; override with PERFXPERT_LLM_LOCAL_URL)",
+    "Local ollama daemon (default http://localhost:11434; override with PERFXPERT_LLM_LOCAL_URL or OLLAMA_HOST)",
 )
 
 

--- a/experimental/python/perfxpert/perfxpert/providers/opencode_provider.py
+++ b/experimental/python/perfxpert/perfxpert/providers/opencode_provider.py
@@ -6,15 +6,12 @@ opencode-launched session from spawning another opencode.
 
 Binary resolution order:
     1. constructor kwarg `opencode_path`
-    2. env var PERFXPERT_OPENCODE_PATH
-    3. bundled patched perfxpert opencode binary
-    4. shutil.which("opencode") on PATH
+    2. bundled patched perfxpert opencode binary
 """
 
 from __future__ import annotations
 
 import os
-import shutil
 import subprocess
 from typing import Any, Dict, List, Optional, Union
 
@@ -32,22 +29,16 @@ _DEFAULT_TIMEOUT = 180.0
 def _find_binary(explicit: Optional[str]) -> str:
     if explicit:
         return explicit
-    env = os.environ.get("PERFXPERT_OPENCODE_PATH")
-    if env:
-        return env
     try:
         from perfxpert.cli.opencode_launcher import resolve_opencode_binary
 
         return str(resolve_opencode_binary())
-    except FileNotFoundError:
-        pass
-    found = shutil.which("opencode")
-    if found:
-        return found
-    raise ProviderError(
-        "[opencode] binary not found (reinstall perfxpert so the bundled binary is built, "
-        "set PERFXPERT_OPENCODE_PATH, or install opencode on PATH)"
-    )
+    except FileNotFoundError as exc:
+        raise ProviderError(
+            "[opencode] bundled patched binary not found. Reinstall perfxpert "
+            "so the pinned submodule-built binary is packaged, or use "
+            "`perfxpert-code opencode ...` for an explicit user-owned upstream binary."
+        ) from exc
 
 
 def _flatten_messages(messages: List[Dict[str, Any]], system: str) -> str:
@@ -127,7 +118,7 @@ class OpencodeProvider(Provider):
 register(
     "opencode",
     OpencodeProvider,
-    "opencode CLI (subprocess; recursion-guarded; PERFXPERT_OPENCODE_PATH or PATH lookup)",
+    "bundled patched opencode CLI (subprocess; recursion-guarded)",
 )
 
 

--- a/experimental/python/perfxpert/perfxpert/providers/private_provider.py
+++ b/experimental/python/perfxpert/perfxpert/providers/private_provider.py
@@ -26,6 +26,14 @@ from perfxpert.providers.registry import register
 _DEFAULT_TIMEOUT = 120.0
 
 
+def _private_url_from_env() -> str:
+    return (
+        os.environ.get("PERFXPERT_LLM_PRIVATE_URL")
+        or os.environ.get("PRIVATE_LLM_ENDPOINT")
+        or ""
+    ).rstrip("/")
+
+
 def _parse_headers(raw: str) -> Dict[str, str]:
     if not raw:
         return {}
@@ -37,7 +45,7 @@ def _parse_headers(raw: str) -> Dict[str, str]:
         except (SyntaxError, ValueError) as literal_error:
             raise ValueError(
                 "PERFXPERT_LLM_PRIVATE_HEADERS contains invalid JSON "
-                f"or Python literal dict: {e}. Value was: {raw[:80]!r}"
+                f"or Python literal dict: {e}. Value redacted because it may contain secrets."
             ) from literal_error
     if not isinstance(obj, dict):
         raise ValueError(f"PERFXPERT_LLM_PRIVATE_HEADERS must be a JSON object, got {type(obj).__name__}")
@@ -62,11 +70,11 @@ class PrivateProvider(Provider):
         timeout: float = _DEFAULT_TIMEOUT,
         **_: Any,
     ) -> None:
-        self._url = (url or os.environ.get("PERFXPERT_LLM_PRIVATE_URL", "")).rstrip("/")
+        self._url = (url.rstrip("/") if url else _private_url_from_env())
         if not self._url:
             raise AuthError(
                 "private",
-                "no endpoint configured (set PERFXPERT_LLM_PRIVATE_URL)",
+                "no endpoint configured (set PERFXPERT_LLM_PRIVATE_URL or PRIVATE_LLM_ENDPOINT)",
             )
         self._model_default = model or os.environ.get("PERFXPERT_LLM_PRIVATE_MODEL") or "default"
         self._api_key = api_key or os.environ.get("PERFXPERT_LLM_PRIVATE_API_KEY") or "dummy"
@@ -137,8 +145,8 @@ class PrivateProvider(Provider):
 register(
     "private",
     PrivateProvider,
-    "Private OpenAI-compatible endpoint (PERFXPERT_LLM_PRIVATE_URL required)",
+    "Private OpenAI-compatible endpoint (PERFXPERT_LLM_PRIVATE_URL or PRIVATE_LLM_ENDPOINT required)",
 )
 
 
-__all__ = ["PrivateProvider", "_parse_headers", "_verify_ssl_from_env"]
+__all__ = ["PrivateProvider", "_parse_headers", "_private_url_from_env", "_verify_ssl_from_env"]

--- a/experimental/python/perfxpert/scripts/build-bundled-opencode.sh
+++ b/experimental/python/perfxpert/scripts/build-bundled-opencode.sh
@@ -16,7 +16,7 @@
 #   PERFXPERT_OPENCODE_DIR  override submodule location
 #   PERFXPERT_BUNDLED_DIR   override output directory
 #
-# Requires: bun (https://bun.sh/install). Exits 2 if bun is missing.
+# Requires: bun on PATH. Exits 2 if bun is missing.
 
 set -euo pipefail
 
@@ -50,8 +50,9 @@ if ! command -v bun >/dev/null 2>&1; then
   cat >&2 <<'EOF'
 build-bundled-opencode: bun is required to compile opencode.
 
-Install bun (one line, no root required):
-    curl -fsSL https://bun.sh/install | bash
+Install bun from your approved package source, or rerun the pip build with
+PERFXPERT_AUTO_INSTALL_BUN=1 to explicitly allow setup.py to bootstrap bun
+into your home directory for this build.
 
 Then re-run:
     perfxpert-code install-patches

--- a/experimental/python/perfxpert/scripts/pip-install-from-git.sh
+++ b/experimental/python/perfxpert/scripts/pip-install-from-git.sh
@@ -9,8 +9,10 @@
 #   bash scripts/pip-install-from-git.sh --extras '' --no-deps
 #
 # Notes:
-#   - Uses the host package manager to install missing OS prerequisites when
-#     running as root or when sudo is available.
+#   - Does not install OS prerequisites by default. If a package is missing,
+#     the wrapper prints the distro command to run first. Use
+#     --auto-install-prereqs or PERFXPERT_AUTO_INSTALL_PREREQS=1 only when
+#     package-manager mutation is intentional.
 #   - Requires Python 3 + `python -m pip` in the active environment.
 #   - On Ubuntu 24+ and other externally managed Python environments,
 #     create and activate a virtual environment first.
@@ -23,6 +25,18 @@ set -euo pipefail
 readonly _DEFAULT_REPO_URL="https://github.com/ROCm/rocm-systems.git"
 readonly _SUBDIRECTORY="experimental/python/perfxpert"
 readonly _SUBMODULE_SCOPE="experimental/python/perfxpert/opencode"
+_AUTO_INSTALL_PREREQS="${PERFXPERT_AUTO_INSTALL_PREREQS:-0}"
+
+_truthy() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES|on|ON)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
 
 _print_python_prereqs() {
   cat <<'EOF'
@@ -38,7 +52,7 @@ Install the prerequisites first:
     command -v curl >/dev/null || dnf install -y curl
     dnf install -y git unzip python3 python3-pip
     python3 -m venv .venv
-  SLES 15:
+  SLES 15.6:
     zypper install -y curl git unzip python311 python311-pip
     python3.11 -m venv .venv
   . .venv/bin/activate
@@ -60,6 +74,9 @@ Options:
   --extras <name>   Optional extras to install (default: all).
                     Use `--extras ''` to install the base package only.
   --repo-url <url>  Override the git remote (default: ROCm/rocm-systems).
+  --auto-install-prereqs
+                    Explicitly allow apt/dnf/zypper prerequisite installs.
+                    By default the wrapper prints the command and exits.
   -h, --help        Show this help.
 
 Interpreter selection:
@@ -68,20 +85,24 @@ Interpreter selection:
   or installs a different Python runtime.
 
 OS prerequisite handling:
-  If curl, git, unzip, or a supported Python/pip pair is missing, the wrapper
-  installs the distro packages with apt-get, dnf, or zypper when it is running
-  as root or sudo is available. This is the package-manager install path.
-  Otherwise it prints the exact package-manager command to run first.
+  If git, a supported Python/pip pair, or bun-bootstrap prerequisites
+  (`curl`/`unzip` when PERFXPERT_AUTO_INSTALL_BUN=1) are missing, the wrapper
+  prints the exact package-manager command to run first and exits non-zero.
+  It never runs apt, dnf, zypper, or sudo unless --auto-install-prereqs or
+  PERFXPERT_AUTO_INSTALL_PREREQS=1 is explicitly set.
 
 Patched perfxpert-code guarantee:
-  The pip build hook bootstraps bun when needed, then builds the bundled
-  patched opencode binary from the pinned perfxpert submodule. The wrapper
-  exits non-zero if that bundled binary is still missing after install.
+  The pip build hook builds the bundled patched opencode binary from the
+  pinned perfxpert submodule. If bun is missing, pip fails closed with an
+  actionable message unless PERFXPERT_AUTO_INSTALL_BUN=1 is explicitly set.
+  The wrapper exits non-zero if that bundled binary is still missing after
+  install or if the `perfxpert-code` console entry point cannot run.
 
 Supported Ubuntu 24+ flow:
   apt install -y curl git unzip python3-venv python3-pip
   python3 -m venv .venv
   . .venv/bin/activate
+  bun --version  # install bun from your approved package source if this fails
   REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"
 
 Prerequisite package examples by distro:
@@ -96,7 +117,7 @@ Prerequisite package examples by distro:
     command -v curl >/dev/null || dnf install -y curl
     dnf install -y git unzip python3 python3-pip
     python3 -m venv .venv
-  SLES 15:
+  SLES 15.6:
     zypper install -y curl git unzip python311 python311-pip
     python3.11 -m venv .venv
     # SLES ships the supported interpreter as python3.11 after installing
@@ -109,7 +130,8 @@ Pin a specific ref, tag, or commit hash:
 
 If you are NOT using this wrapper and `perfxpert-code` later reports that
 the bundled opencode binary is missing, reinstall with the OS prerequisites
-available so pip can bootstrap bun and build the pinned submodule bundle.
+available and bun on PATH, or explicitly set PERFXPERT_AUTO_INSTALL_BUN=1
+so pip can bootstrap bun and build the pinned submodule bundle.
 EOF
 }
 
@@ -149,13 +171,18 @@ _run_with_privilege() {
 _install_os_prereqs_if_needed() {
   local -a missing
   missing=()
-  local need_curl need_git need_unzip need_python
+  local need_curl need_git need_unzip need_python need_bun_bootstrap_prereqs
   need_curl=0
   need_git=0
   need_unzip=0
   need_python=0
+  need_bun_bootstrap_prereqs=0
 
-  if ! command -v curl >/dev/null 2>&1; then
+  if ! command -v bun >/dev/null 2>&1 && _truthy "${PERFXPERT_AUTO_INSTALL_BUN:-0}"; then
+    need_bun_bootstrap_prereqs=1
+  fi
+
+  if [ "${need_bun_bootstrap_prereqs}" = "1" ] && ! command -v curl >/dev/null 2>&1; then
     missing+=("curl")
     need_curl=1
   fi
@@ -163,7 +190,7 @@ _install_os_prereqs_if_needed() {
     missing+=("git")
     need_git=1
   fi
-  if ! command -v unzip >/dev/null 2>&1; then
+  if [ "${need_bun_bootstrap_prereqs}" = "1" ] && ! command -v unzip >/dev/null 2>&1; then
     missing+=("unzip")
     need_unzip=1
   fi
@@ -178,7 +205,22 @@ _install_os_prereqs_if_needed() {
   fi
 
   echo "pip-install-from-git: missing OS prerequisites: ${missing[*]}" >&2
-  echo "pip-install-from-git: attempting package-manager install" >&2
+  if ! _truthy "${_AUTO_INSTALL_PREREQS}"; then
+    {
+      echo "pip-install-from-git: refusing to auto-install prerequisites by default."
+      echo "pip-install-from-git: install the packages manually, then rerun the wrapper:"
+      echo
+      _print_python_prereqs
+      echo
+      echo "To allow this wrapper to run apt/dnf/zypper explicitly, rerun with:"
+      echo "  PERFXPERT_AUTO_INSTALL_PREREQS=1 bash scripts/pip-install-from-git.sh ..."
+      echo "or:"
+      echo "  bash scripts/pip-install-from-git.sh --auto-install-prereqs ..."
+    } >&2
+    exit 2
+  fi
+
+  echo "pip-install-from-git: explicit prerequisite auto-install enabled; attempting package-manager install" >&2
 
   if command -v apt-get >/dev/null 2>&1; then
     local -a apt_packages
@@ -204,9 +246,7 @@ $(_print_python_prereqs)"
     version_major=""
     dnf_packages=()
     if [ -r /etc/os-release ]; then
-      # shellcheck disable=SC1091
-      . /etc/os-release
-      version_major="${VERSION_ID%%.*}"
+      version_major="$( (. /etc/os-release; printf '%s' "${VERSION_ID%%.*}") 2>/dev/null || true )"
     fi
     [ "${need_curl}" = "1" ] && dnf_packages+=("curl")
     [ "${need_git}" = "1" ] && dnf_packages+=("git")
@@ -247,6 +287,12 @@ $(_print_python_prereqs)"
 
 for _arg in "$@"; do
   case "${_arg}" in
+    --auto-install-prereqs)
+      _AUTO_INSTALL_PREREQS=1
+      ;;
+    --)
+      break
+      ;;
     -h|--help)
       _print_help
       exit 0
@@ -271,6 +317,42 @@ print(path)
 '
 }
 
+_pip_args_include_user() {
+  local arg
+  for arg in "${_PIP_ARGS[@]:-}"; do
+    if [ "${arg}" = "--user" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+_python_scripts_dir() {
+  if _pip_args_include_user; then
+    "${_PYTHON}" -c 'import site; print(site.USER_BASE + "/bin")'
+  else
+    "${_PYTHON}" -c 'import sysconfig; print(sysconfig.get_path("scripts"))'
+  fi
+}
+
+_verify_perfxpert_code_entrypoint() {
+  local scripts_dir exe
+  if ! scripts_dir="$(_python_scripts_dir)" || [ -z "${scripts_dir}" ]; then
+    echo "could not resolve the selected Python scripts directory" >&2
+    return 1
+  fi
+  exe="${scripts_dir%/}/perfxpert-code"
+  if [ ! -x "${exe}" ]; then
+    echo "missing executable perfxpert-code console script at ${exe}" >&2
+    return 1
+  fi
+  if ! "${exe}" --version >/dev/null 2>&1; then
+    echo "perfxpert-code console script exists but failed --version: ${exe}" >&2
+    return 1
+  fi
+  printf '%s\n' "${exe}"
+}
+
 _install_os_prereqs_if_needed
 
 _PYTHON=""
@@ -278,7 +360,8 @@ for _candidate in python python3 python3.14 python3.13 python3.12 python3.11 pyt
   if ! command -v "${_candidate}" >/dev/null 2>&1; then
     continue
   fi
-  if "${_candidate}" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' >/dev/null 2>&1; then
+  if "${_candidate}" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' >/dev/null 2>&1 \
+    && "${_candidate}" -m pip --version >/dev/null 2>&1; then
     _PYTHON="${_candidate}"
     break
   fi
@@ -287,17 +370,6 @@ done
 if [ -z "${_PYTHON}" ]; then
   {
     echo "pip-install-from-git: Python 3.10+ is required."
-    echo
-    _print_python_prereqs
-  } >&2
-  exit 2
-fi
-
-if ! command -v curl >/dev/null 2>&1; then
-  {
-    cat <<'EOF'
-pip-install-from-git: `curl` is required for the GitHub install path and bun bootstrap.
-EOF
     echo
     _print_python_prereqs
   } >&2
@@ -363,6 +435,9 @@ while [ "$#" -gt 0 ]; do
       _REPO_URL="$2"
       shift 2
       ;;
+    --auto-install-prereqs)
+      shift
+      ;;
     --)
       shift
       while [ "$#" -gt 0 ]; do
@@ -422,4 +497,16 @@ EOF
   exit 2
 fi
 
-echo "pip-install-from-git: bundled patched perfxpert-code ready at ${_BUNDLED_OPENCODE}" >&2
+if ! _PERFXPERT_CODE="$(_verify_perfxpert_code_entrypoint)"; then
+  cat >&2 <<'EOF'
+pip-install-from-git: install finished, but the `perfxpert-code` console entry point is not usable.
+
+`perfxpert analyze`, `perfxpert-mcp`, and the Python API may still be installed,
+but this wrapper requires `perfxpert-code --version` to run and the bundled
+patched opencode binary to exist. Check the build output above, then retry the same command.
+EOF
+  exit 2
+fi
+
+echo "pip-install-from-git: perfxpert-code ready at ${_PERFXPERT_CODE}" >&2
+echo "pip-install-from-git: bundled patched opencode ready at ${_BUNDLED_OPENCODE}" >&2

--- a/experimental/python/perfxpert/setup.py
+++ b/experimental/python/perfxpert/setup.py
@@ -10,10 +10,10 @@ Behavior:
 * Pre-build (``build_py``), pre-editable-install (``develop`` /
   ``editable_wheel``): invoke the build script if the bundled binary
   is missing OR older than the patch series.
-* If ``bun`` is not on PATH: bootstrap bun into the user's home directory
-  and add it to PATH for this build. If the OS-level prerequisites needed
-  for that bootstrap are missing, fail with distro-specific package-manager
-  guidance instead of silently producing a broken ``perfxpert-code``.
+* If ``bun`` is not on PATH: fail with distro-specific package-manager
+  guidance by default. Set ``PERFXPERT_AUTO_INSTALL_BUN=1`` only when you
+  explicitly want setup.py to bootstrap bun into the user's home directory
+  for this build.
 * Opt-out via ``PERFXPERT_SKIP_BUNDLED_BUILD=1`` — useful in
   tightly-sandboxed CI where network isn't available and the interactive
   ``perfxpert-code`` TUI is intentionally not being built.
@@ -88,6 +88,8 @@ _PATCHES_DIR = _HERE / ".patches"
 _OPENCODE_DIR = _HERE / "opencode"
 _SKIP_ENV = "PERFXPERT_SKIP_BUNDLED_BUILD"
 _SKIP_OPENCODE_FETCH_ENV = "PERFXPERT_SKIP_OPENCODE_FETCH"
+_AUTO_INSTALL_BUN_ENV = "PERFXPERT_AUTO_INSTALL_BUN"
+_DEFAULT_BUN_VERSION = "1.2.23"
 _DEFAULT_BUN_INSTALL_URL = "https://bun.sh/install"
 
 
@@ -102,7 +104,7 @@ def _package_manager_prereq_hint() -> str:
         "  RHEL 10:\n"
         "    command -v curl >/dev/null || dnf install -y curl\n"
         "    dnf install -y git unzip python3 python3-pip\n"
-        "  SLES 15:\n"
+        "  SLES 15.6:\n"
         "    zypper install -y curl git unzip python311 python311-pip\n"
     )
 
@@ -123,8 +125,8 @@ def _missing_bun_bootstrap_prereqs() -> list[str]:
     return _missing_tools(("bash", "curl", "unzip"))
 
 
-def _missing_os_prereqs() -> list[str]:
-    return _missing_tools(("bash", "curl", "git", "unzip"))
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _fail_build(message: str) -> None:
@@ -136,6 +138,8 @@ def _fail_build(message: str) -> None:
 
 
 def _run_bun_install_script(env: dict[str, str]) -> int:
+    # Internal mirrors may override the installer URL, but only after the
+    # caller has explicitly opted into automatic bun bootstrap.
     url = os.environ.get("PERFXPERT_BUN_INSTALL_URL", _DEFAULT_BUN_INSTALL_URL)
     missing = _missing_bun_bootstrap_prereqs()
     if missing:
@@ -149,37 +153,46 @@ def _run_bun_install_script(env: dict[str, str]) -> int:
     assert curl is not None
     assert bash is not None
 
-    curl_proc = subprocess.Popen(
+    curl_result = subprocess.run(
         [curl, "-fsSL", url],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env=env,
-        text=False,
-    )
-    assert curl_proc.stdout is not None
-    bash_proc = subprocess.run(
-        [bash],
-        stdin=curl_proc.stdout,
+        capture_output=True,
         env=env,
         check=False,
     )
-    curl_proc.stdout.close()
-    _, curl_stderr = curl_proc.communicate()
-    if curl_proc.returncode != 0:
-        sys.stderr.write(curl_stderr.decode("utf-8", errors="replace"))
-        return curl_proc.returncode
-    return bash_proc.returncode
+    if curl_result.returncode != 0:
+        sys.stderr.write(curl_result.stderr.decode("utf-8", errors="replace"))
+        return curl_result.returncode
+
+    bash_result = subprocess.run(
+        [bash],
+        input=curl_result.stdout,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        check=False,
+    )
+    if bash_result.returncode != 0:
+        sys.stderr.write(bash_result.stdout.decode("utf-8", errors="replace"))
+        sys.stderr.write(bash_result.stderr.decode("utf-8", errors="replace"))
+    return bash_result.returncode
 
 
 def _ensure_bun_on_path() -> str | None:
     """Return a PATH env string that includes an available bun binary.
 
-    Bootstraps bun into ``$BUN_INSTALL`` when needed so ``pip install`` can
-    produce the bundled patched ``perfxpert-code`` binary end to end.
+    Automatic bootstrap is opt-in because it downloads and executes an
+    external installer. Default installs fail closed with an actionable hint.
     """
     existing = shutil.which("bun")
     if existing:
         return os.environ.get("PATH", "")
+    if not _env_truthy(_AUTO_INSTALL_BUN_ENV):
+        _fail_build(
+            "bun is not on PATH. Install bun from an approved package source, "
+            f"or set {_AUTO_INSTALL_BUN_ENV}=1 to explicitly allow setup.py "
+            f"to bootstrap bun {_DEFAULT_BUN_VERSION} into $BUN_INSTALL "
+            "(defaults to ~/.bun) for this build."
+        )
     missing = _missing_bun_bootstrap_prereqs()
     if missing:
         _fail_build(
@@ -191,10 +204,12 @@ def _ensure_bun_on_path() -> str | None:
     bun_install = os.environ.get("BUN_INSTALL") or str(Path.home() / ".bun")
     env = os.environ.copy()
     env["BUN_INSTALL"] = bun_install
+    env.setdefault("BUN_VERSION", _DEFAULT_BUN_VERSION)
 
     print(
-        "[perfxpert/setup.py] bun not on PATH — bootstrapping bun so the "
-        "bundled patched opencode binary is built during pip install.",
+        f"[perfxpert/setup.py] {_AUTO_INSTALL_BUN_ENV}=1 — bootstrapping "
+        f"bun {env['BUN_VERSION']} so the bundled patched opencode binary is "
+        "built during pip install.",
         file=sys.stderr,
     )
     rc = _run_bun_install_script(env)

--- a/experimental/python/perfxpert/tests/e2e/test_opencode_session.py
+++ b/experimental/python/perfxpert/tests/e2e/test_opencode_session.py
@@ -3,36 +3,27 @@
 Requires:
 - perfxpert-code installed (entry point)
 - perfxpert-mcp installed (entry point)
-- bundled opencode binary OR PERFXPERT_OPENCODE_PATH set
+- bundled patched opencode binary available
 - Any LLM provider configured, OR --no-llm / air-gap mode
 
 Skips gracefully if the opencode binary isn't available.
 """
 
 import os
-import shutil
 import subprocess
-from pathlib import Path
 
 import pytest
 
 
 @pytest.fixture
 def opencode_available():
-    # Check bundled OR PATH
-    if os.environ.get("PERFXPERT_OPENCODE_PATH"):
-        if Path(os.environ["PERFXPERT_OPENCODE_PATH"]).is_file():
-            return True
-    if shutil.which("opencode"):
-        return True
     try:
-        from importlib import resources
-        with resources.as_file(resources.files("perfxpert") / "_bundled" / "opencode") as p:
-            if p.is_file():
-                return True
+        from perfxpert.cli.opencode_launcher import resolve_opencode_binary
+
+        resolve_opencode_binary()
+        return True
     except Exception:
-        pass
-    return False
+        return False
 
 
 def test_perfxpert_code_launches_if_opencode_available(opencode_available):

--- a/experimental/python/perfxpert/tests/e2e/test_perfxpert_code_live_mcp.py
+++ b/experimental/python/perfxpert/tests/e2e/test_perfxpert_code_live_mcp.py
@@ -8,7 +8,7 @@ This test proves the full stack works:
 5. opencode returns the result to the user
 
 Gated on:
-- opencode binary available (path via PERFXPERT_OPENCODE_PATH or shutil.which)
+- bundled patched opencode binary available
 - LLM API key (OPENAI_API_KEY or ANTHROPIC_API_KEY)
 - Reasonable timeout (180s for network latency)
 """
@@ -25,10 +25,14 @@ _CHECKOUT_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _opencode_available():
-    """Check if opencode binary is available."""
-    if os.environ.get("PERFXPERT_OPENCODE_PATH"):
-        return os.path.isfile(os.environ["PERFXPERT_OPENCODE_PATH"])
-    return shutil.which("opencode") is not None
+    """Check if the bundled patched opencode binary is available."""
+    try:
+        from perfxpert.cli.opencode_launcher import resolve_opencode_binary
+
+        resolve_opencode_binary()
+        return True
+    except Exception:
+        return False
 
 
 def _llm_key_set():

--- a/experimental/python/perfxpert/tests/test_agents/test_framework.py
+++ b/experimental/python/perfxpert/tests/test_agents/test_framework.py
@@ -583,6 +583,71 @@ def test_sdk_invoke_private_provider_uses_custom_openai_base_url(monkeypatch):
     assert "model_provider" in captured["run_config"]["kwargs"]
 
 
+def test_sdk_invoke_private_provider_accepts_compat_endpoint_env(monkeypatch):
+    captured = {}
+
+    class _FakeSdkAgent:
+        def __init__(self, *, name, instructions, tools, model):
+            captured["model"] = model
+
+    class _FakeRunResult:
+        def __init__(self):
+            self.final_output = {"narrative": "ok"}
+            self.new_items = []
+
+    class _FakeRunner:
+        @staticmethod
+        def run_sync(*, starting_agent, input, max_turns, run_config):
+            captured["run_config"] = run_config
+            return _FakeRunResult()
+
+    import agents.models.openai_provider as openai_provider_module
+    import httpx as httpx_module
+    import openai as openai_module
+
+    class _FakeAsyncOpenAI:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+
+    class _FakeOpenAIProvider:
+        def __init__(self, **kwargs):
+            captured["provider_kwargs"] = kwargs
+
+    class _FakeAsyncClient:
+        def __init__(self, **kwargs):
+            captured["http_client_kwargs"] = kwargs
+
+    monkeypatch.setattr(openai_module, "AsyncOpenAI", _FakeAsyncOpenAI)
+    monkeypatch.setattr(openai_provider_module, "OpenAIProvider", _FakeOpenAIProvider)
+    monkeypatch.setattr(httpx_module, "AsyncClient", _FakeAsyncClient)
+
+    monkeypatch.delenv("PERFXPERT_LLM_PRIVATE_URL", raising=False)
+    monkeypatch.setenv("PRIVATE_LLM_ENDPOINT", "https://compat-llm.example/v1")
+    monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_MODEL", "compat-codex")
+    monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_API_KEY", "sk-private")
+    monkeypatch.setattr(framework, "_SDK_AVAILABLE", True)
+    monkeypatch.setattr(framework, "SdkAgent", _FakeSdkAgent)
+    monkeypatch.setattr(framework, "SdkRunner", _FakeRunner)
+    monkeypatch.setattr(framework, "SdkRunConfig", lambda **kwargs: {"kwargs": kwargs})
+    monkeypatch.setattr(framework, "sdk_function_tool", lambda fn, **kwargs: {"fn": fn, **kwargs})
+
+    agent = Agent(
+        name="T",
+        layer=1,
+        fence_path=None,
+        input_schema=dict,
+        output_schema=dict,
+        tools=[],
+    )
+
+    framework._sdk_invoke(agent, {"user_query": "?"}, provider="private")
+
+    assert captured["model"] == "private/compat-codex"
+    assert captured["client_kwargs"]["base_url"] == "https://compat-llm.example/v1"
+    assert captured["client_kwargs"]["api_key"] == "sk-private"
+    assert "model_provider" in captured["run_config"]["kwargs"]
+
+
 def test_sdk_invoke_opencode_dispatches_to_subprocess_provider(monkeypatch):
     captured = {}
 

--- a/experimental/python/perfxpert/tests/test_cli/test_analyze_args.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_analyze_args.py
@@ -95,6 +95,28 @@ def test_llm_flag_absent_does_not_set_enable_llm():
     assert "enable_llm" not in kwargs
 
 
+def test_private_preflight_accepts_compat_endpoint_env(monkeypatch):
+    from perfxpert import analyze as analyze_mod
+
+    monkeypatch.delenv("PERFXPERT_LLM_PRIVATE_URL", raising=False)
+    monkeypatch.setenv("PRIVATE_LLM_ENDPOINT", "https://llm.example/v1")
+    monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_API_KEY", "secret")
+
+    analyze_mod._preflight_provider_auth("private", None)
+
+
+def test_private_preflight_requires_either_endpoint_env(monkeypatch):
+    from perfxpert import analyze as analyze_mod
+    from perfxpert.providers._exceptions import AuthError
+
+    monkeypatch.delenv("PERFXPERT_LLM_PRIVATE_URL", raising=False)
+    monkeypatch.delenv("PRIVATE_LLM_ENDPOINT", raising=False)
+    monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_API_KEY", "secret")
+
+    with pytest.raises(AuthError, match="PRIVATE_LLM_ENDPOINT"):
+        analyze_mod._preflight_provider_auth("private", None)
+
+
 def test_format_and_llm_flags_compose():
     """Both flags set in the same invocation must both propagate."""
     process_args, ns = _build_parsed_args(
@@ -283,12 +305,42 @@ def test_non_text_formats_default_to_file_output_without_output_flags(
 
     out = tmp_path / f"analysis{ext}"
     assert out.read_text() == "REPORT"
-    assert f"Analysis written to: ./{out.name}" in capsys.readouterr().out
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert f"Analysis written to: ./{out.name}" in captured.err
+
+
+@pytest.mark.parametrize(
+    ("fmt", "ext"),
+    [("json", ".json"), ("markdown", ".md"), ("webview", ".html")],
+)
+def test_non_text_formats_dir_only_default_to_analysis_stem(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    fmt,
+    ext,
+):
+    from perfxpert import analyze as analyze_mod
+
+    _stub_agentic_render(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    out_dir = tmp_path / "reports"
+
+    cfg = output_config.output_config(output_file=None, output_path=str(out_dir))
+    analyze_mod._execute_agentic(None, config=cfg, output_format=fmt)
+
+    out = out_dir / f"analysis{ext}"
+    assert out.read_text() == "REPORT"
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert f"Analysis written to: {out}" in captured.err
 
 
 def test_non_text_format_with_output_name_defaults_to_current_directory(
     tmp_path,
     monkeypatch,
+    capsys,
 ):
     from perfxpert import analyze as analyze_mod
 
@@ -299,6 +351,9 @@ def test_non_text_format_with_output_name_defaults_to_current_directory(
     analyze_mod._execute_agentic(None, config=cfg, output_format="json")
 
     assert (tmp_path / "custom-report.json").read_text() == "{}"
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Analysis written to: ./custom-report.json" in captured.err
 
 
 def test_text_format_without_output_flags_stays_on_stdout(
@@ -316,3 +371,60 @@ def test_text_format_without_output_flags_stays_on_stdout(
 
     assert capsys.readouterr().out == "REPORT\n"
     assert list(tmp_path.iterdir()) == []
+
+
+def test_non_text_format_output_dash_stays_on_stdout(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    from perfxpert import analyze as analyze_mod
+
+    _stub_agentic_render(monkeypatch, rendered="{}")
+    monkeypatch.chdir(tmp_path)
+
+    cfg = output_config.output_config(output_file="-", output_path=None)
+    analyze_mod._execute_agentic(None, config=cfg, output_format="json")
+
+    captured = capsys.readouterr()
+    assert captured.out == "{}\n"
+    assert captured.err == ""
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_non_text_format_output_dash_ignores_output_dir(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    from perfxpert import analyze as analyze_mod
+
+    _stub_agentic_render(monkeypatch, rendered="{}")
+    monkeypatch.chdir(tmp_path)
+
+    cfg = output_config.output_config(output_file="-", output_path=str(tmp_path / "reports"))
+    analyze_mod._execute_agentic(None, config=cfg, output_format="json")
+
+    captured = capsys.readouterr()
+    assert captured.out == "{}\n"
+    assert captured.err == ""
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_text_format_with_output_name_defaults_to_current_directory(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    from perfxpert import analyze as analyze_mod
+
+    _stub_agentic_render(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    cfg = output_config.output_config(output_file="custom-report", output_path=None)
+    analyze_mod._execute_agentic(None, config=cfg, output_format="text")
+
+    assert (tmp_path / "custom-report.txt").read_text() == "REPORT"
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Analysis written to: ./custom-report.txt" in captured.err

--- a/experimental/python/perfxpert/tests/test_cli/test_branding.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_branding.py
@@ -11,6 +11,10 @@ from perfxpert.cli.branding import (
 )
 
 
+def _provider_line(table: str, provider: str) -> str:
+    return next(line for line in table.splitlines() if line.lower().startswith(provider))
+
+
 def test_amd_banner_contains_perfxpert():
     banner = get_amd_banner()
     assert "PerfXpert" in banner
@@ -39,6 +43,33 @@ def test_provider_status_marks_configured(monkeypatch):
     assert "openai" in lower
 
 
+def test_provider_status_private_requires_endpoint_and_key(monkeypatch):
+    monkeypatch.delenv("PERFXPERT_LLM_PRIVATE_URL", raising=False)
+    monkeypatch.delenv("PRIVATE_LLM_ENDPOINT", raising=False)
+    monkeypatch.delenv("PERFXPERT_LLM_PRIVATE_API_KEY", raising=False)
+    monkeypatch.setenv("PRIVATE_LLM_ENDPOINT", "https://llm.example/v1")
+
+    table = get_provider_status_table()
+    assert "missing" in _provider_line(table, "private").lower()
+
+    monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_API_KEY", "sk-private")
+    table = get_provider_status_table()
+    assert "configured" in _provider_line(table, "private").lower()
+
+
+def test_provider_status_opencode_reports_availability_not_provider_auth(monkeypatch):
+    with patch(
+        "perfxpert.cli.branding.resolve_opencode_binary",
+        return_value="/tmp/perfxpert-bundled-opencode",
+    ):
+        table = get_provider_status_table()
+
+    opencode = _provider_line(table, "opencode").lower()
+    assert "available" in opencode
+    assert "configured" not in opencode
+    assert "provider auth" in opencode
+
+
 def test_launch_opencode_dry_run_returns_command():
     cmd = launch_opencode(dry_run=True, opencode_path="/tmp/opencode", extra_args=["--foo"])
     assert cmd[0] == "/tmp/opencode"
@@ -47,14 +78,15 @@ def test_launch_opencode_dry_run_returns_command():
 
 def test_launch_opencode_missing_binary_raises(monkeypatch):
     monkeypatch.delenv("PERFXPERT_OPENCODE_PATH", raising=False)
-    with patch("perfxpert.cli.branding.shutil.which", return_value=None):
+    with patch(
+        "perfxpert.cli.branding.resolve_opencode_binary",
+        side_effect=FileNotFoundError("missing"),
+    ):
         with pytest.raises(FileNotFoundError):
             launch_opencode()
 
 
-def test_launch_opencode_sets_recursion_env(monkeypatch):
-    monkeypatch.setenv("PERFXPERT_OPENCODE_PATH", "/bin/opencode")
-    import os as _os
+def test_launch_opencode_sets_recursion_env():
     captured_env = {}
 
     def fake_execvpe(path, argv, env):  # noqa: D401
@@ -63,5 +95,5 @@ def test_launch_opencode_sets_recursion_env(monkeypatch):
 
     with patch("perfxpert.cli.branding.os.execvpe", side_effect=fake_execvpe):
         with pytest.raises(SystemExit):
-            launch_opencode()
+            launch_opencode(opencode_path="/bin/opencode")
     assert captured_env.get("PERFXPERT_IN_OPENCODE_SESSION") == "1"

--- a/experimental/python/perfxpert/tests/test_cli/test_doctor_providers.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_doctor_providers.py
@@ -8,6 +8,7 @@ def test_check_llm_providers_accepts_canonical_env_names(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
     monkeypatch.setenv("PERFXPERT_LLM_LOCAL_URL", "http://localhost:11434")
     monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_URL", "https://llm.example/v1")
+    monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_API_KEY", "sk-private")
 
     configured, unconfigured = perfxpert_main._check_llm_providers()
 
@@ -20,9 +21,20 @@ def test_check_llm_providers_accepts_canonical_env_names(monkeypatch):
 def test_check_llm_providers_accepts_compatibility_aliases(monkeypatch):
     monkeypatch.setenv("OLLAMA_HOST", "http://localhost:11434")
     monkeypatch.setenv("PRIVATE_LLM_ENDPOINT", "https://llm.example/v1")
+    monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_API_KEY", "sk-private")
 
     configured, unconfigured = perfxpert_main._check_llm_providers()
 
     assert "ollama" in configured
     assert "private" in configured
     assert "opencode" in configured
+
+
+def test_check_llm_providers_private_endpoint_without_key_is_missing(monkeypatch):
+    monkeypatch.setenv("PRIVATE_LLM_ENDPOINT", "https://llm.example/v1")
+    monkeypatch.delenv("PERFXPERT_LLM_PRIVATE_API_KEY", raising=False)
+
+    configured, unconfigured = perfxpert_main._check_llm_providers()
+
+    assert "private" not in configured
+    assert "private" in unconfigured

--- a/experimental/python/perfxpert/tests/test_cli/test_launcher_subcommands.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_launcher_subcommands.py
@@ -357,6 +357,7 @@ class TestBundledPriority:
             "resolve_user_opencode_binary",
             lambda: explicit,
         )
+        monkeypatch.setenv("PERFXPERT_IN_OPENCODE_SESSION", "1")
 
         def _fake_run(cmd, env=None, check=False, cwd=None):
             seen["cmd"] = cmd

--- a/experimental/python/perfxpert/tests/test_cli/test_progress_callback.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_progress_callback.py
@@ -4,7 +4,7 @@ Covers:
   * env-forced airgap skips provider-auth preflight even when
     ``enable_llm=True`` is requested for progress UX,
   * CLI non-TTY behaviour (plain ``[perfxpert]`` status lines on stderr,
-    real output on stdout — no ANSI escape codes),
+    real output on stdout when ``-o -`` is requested — no ANSI escape codes),
   * ``--no-progress`` silences the feature entirely.
 
 All tests use airgap mode so nothing hits an LLM provider.
@@ -71,7 +71,7 @@ _CLI_PRELUDE = (
     # driving _execute_agentic through the process_args path.
     "import sys\n"
     "from unittest.mock import patch\n"
-    "from perfxpert import analyze\n"
+    "from perfxpert import analyze, output_config\n"
     "def _fake_agent_root(**kwargs):\n"
     "    cb = kwargs.get('progress_callback')\n"
     "    if cb is not None:\n"
@@ -90,7 +90,7 @@ _CLI_PRELUDE = (
     "     patch('perfxpert.api.agent_root', side_effect=_fake_agent_root):\n"
     "    analyze._execute_agentic(\n"
     "        None,\n"
-    "        config=None,\n"
+    "        config=output_config.output_config(output_file='-'),\n"
     "        source_dir='.',\n"
     "        output_format='json',\n"
     "        enable_llm=True,\n"
@@ -120,7 +120,8 @@ def _airgap_env(monkeypatch, tmp_path):
 def test_analyze_cli_non_tty_prints_status_lines(_airgap_env):
     """Subprocess run of ``_execute_agentic`` with live LLM mode and a piped
     stderr emits the ``[perfxpert]`` status prefix on stderr and the
-    JSON result on stdout. No ANSI escapes in either stream.
+    JSON result on stdout when stdout output is explicitly requested.
+    No ANSI escapes in either stream.
     """
     env = dict(_airgap_env)
     env.pop("PERFXPERT_AIRGAP", None)

--- a/experimental/python/perfxpert/tests/test_integration/test_cli_dispatch.py
+++ b/experimental/python/perfxpert/tests/test_integration/test_cli_dispatch.py
@@ -10,6 +10,7 @@ from unittest import mock
 import pytest
 
 from perfxpert import analyze as analyze_mod
+from perfxpert.output_config import output_config
 
 
 @pytest.fixture
@@ -129,6 +130,7 @@ def test_execute_agentic_runs_analysis_and_formats_reports(fmt, expected_fragmen
             analyze_mod._execute_agentic(
                 input=fake_input,
                 output_format=fmt,
+                config=output_config(output_file="-"),
                 prompt="why is matmul slow?",
                 llm_provider="openai",
                 enable_llm=True,
@@ -182,7 +184,11 @@ def test_execute_agentic_renders_structured_json_from_analysis_outputs(capsys):
             "perfxpert.analysis.payload.build_analysis_payload",
             return_value=_analysis_payload(),
         ):
-            analyze_mod._execute_agentic(input=fake_input, format="json")
+            analyze_mod._execute_agentic(
+                input=fake_input,
+                format="json",
+                config=output_config(output_file="-"),
+            )
 
     captured = capsys.readouterr()
     import json
@@ -285,6 +291,7 @@ def test_execute_agentic_json_output_parity_across_airgap_and_llm(capsys):
                 input=fake_input,
                 output_format="json",
                 enable_llm=False,
+                config=output_config(output_file="-"),
             )
             airgap_payload = json.loads(capsys.readouterr().out)
 
@@ -293,6 +300,7 @@ def test_execute_agentic_json_output_parity_across_airgap_and_llm(capsys):
                 output_format="json",
                 enable_llm=True,
                 llm_provider="openai",
+                config=output_config(output_file="-"),
             )
             llm_payload = json.loads(capsys.readouterr().out)
 

--- a/experimental/python/perfxpert/tests/test_integration/test_install_docs.py
+++ b/experimental/python/perfxpert/tests/test_integration/test_install_docs.py
@@ -24,6 +24,8 @@ def _write_executable(path: Path, body: str) -> None:
 def _env_with_path(path: Path) -> dict[str, str]:
     env = os.environ.copy()
     env["PATH"] = str(path)
+    env.pop("PERFXPERT_AUTO_INSTALL_PREREQS", None)
+    env.pop("PERFXPERT_AUTO_INSTALL_BUN", None)
     return env
 
 
@@ -31,6 +33,13 @@ def _symlink_tool(bin_dir: Path, name: str) -> None:
     tool = shutil.which(name)
     assert tool is not None, f"Missing host tool needed by test: {name}"
     os.symlink(tool, bin_dir / name)
+
+
+def _write_fake_perfxpert_code(bin_dir: Path) -> None:
+    _write_executable(
+        bin_dir / "perfxpert-code",
+        "#!/bin/sh\necho 'AMD ROCm PerfXpert 0.2.0 (opencode wrapper)'\n",
+    )
 
 
 def test_install_wrapper_exists_and_is_non_empty() -> None:
@@ -54,9 +63,11 @@ def test_install_wrapper_help_mentions_supported_prereqs() -> None:
     assert "python3-venv" in result.stdout
     assert "python3-pip" in result.stdout
     assert "git" in result.stdout
-    assert "pip build hook bootstraps bun" in result.stdout
-    assert "package-manager install" in result.stdout
+    assert "PERFXPERT_AUTO_INSTALL_BUN=1" in result.stdout
+    assert "PERFXPERT_AUTO_INSTALL_PREREQS=1" in result.stdout
     assert "It never downloads" in result.stdout
+    assert "bun --version" in result.stdout
+    assert "SLES 15.6" in result.stdout
     assert "command -v curl >/dev/null || dnf install -y curl" in result.stdout
     assert "dnf install -y git unzip python3.11 python3.11-pip" in result.stdout
     assert "dnf install -y git unzip python3 python3-pip" in result.stdout
@@ -75,9 +86,11 @@ def test_install_wrapper_help_works_from_stdin() -> None:
     assert result.returncode == 0, result.stderr
     assert "pip-install-from-git.sh" in result.stdout
     assert "curl -fsSL" in result.stdout
-    assert "pip build hook bootstraps bun" in result.stdout
-    assert "package-manager install" in result.stdout
+    assert "PERFXPERT_AUTO_INSTALL_BUN=1" in result.stdout
+    assert "PERFXPERT_AUTO_INSTALL_PREREQS=1" in result.stdout
     assert "It never downloads" in result.stdout
+    assert "bun --version" in result.stdout
+    assert "SLES 15.6" in result.stdout
     assert "command -v curl >/dev/null || dnf install -y curl" in result.stdout
     assert "dnf install -y git unzip python3.11 python3.11-pip" in result.stdout
     assert "zypper install -y curl git unzip python311 python311-pip" in result.stdout
@@ -91,7 +104,7 @@ def test_readme_keeps_customer_install_flow_curl_only() -> None:
     assert "python3 -m venv .venv" in text
     assert "python3-venv" in text
     assert "python3-pip" in text
-    assert "bootstraps bun when needed" in text
+    assert "PERFXPERT_AUTO_INSTALL_BUN=1" not in text
     assert "No separate `opencode` install is needed" in text
     assert "patched bundled `perfxpert-code` binary" in text
     assert "builds the patched bundled" in text
@@ -131,7 +144,7 @@ def test_getting_started_keeps_internal_install_detail() -> None:
     assert "python3-pip" in text
     assert "never downloads a separate" in text
     assert "Python runtime" in text
-    assert "pip bootstraps\nbun when the OS prerequisites are available" in text
+    assert "PERFXPERT_AUTO_INSTALL_BUN=1" in text
     for distro in (
         "Ubuntu 22.04",
         "Ubuntu 24.04",
@@ -168,11 +181,11 @@ def test_install_docs_explain_perfxpert_code_follow_up() -> None:
     readme = _README.read_text(encoding="utf-8")
     guide = _GETTING_STARTED.read_text(encoding="utf-8")
 
-    assert "bootstraps bun when needed" in readme
-    assert "verifies it before exiting" in readme
+    assert "PERFXPERT_AUTO_INSTALL_BUN=1" not in readme
+    assert "verifies `perfxpert-code`" in readme
     assert "curl -fsSL https://bun.sh/install | bash" not in readme
     assert "Direct\npip/editable paths use the same `setup.py` build hook" in guide
-    assert "pip exits with distro-specific package-manager guidance" in guide
+    assert "pip fails with an actionable prerequisite" in guide
     assert "opencode.ai/install" not in readme
 
 
@@ -188,7 +201,7 @@ def test_provider_docs_keep_private_endpoint_contract_current() -> None:
         assert "ROCPD_LLM_PRIVATE" not in text
 
 
-def test_install_wrapper_reports_missing_prereqs_when_package_manager_unavailable(tmp_path: Path) -> None:
+def test_install_wrapper_prints_missing_prereqs_without_auto_install(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     os.symlink(shutil.which("python3"), bin_dir / "python3")
@@ -205,9 +218,9 @@ def test_install_wrapper_reports_missing_prereqs_when_package_manager_unavailabl
 
     assert result.returncode == 2
     assert "missing OS prerequisites" in result.stderr
-    assert "no supported package manager found" in result.stderr
+    assert "refusing to auto-install prerequisites by default" in result.stderr
+    assert "PERFXPERT_AUTO_INSTALL_PREREQS=1" in result.stderr
     assert "git" in result.stderr
-    assert "unzip" in result.stderr
     assert "apt install -y curl git unzip python3-venv python3-pip" in result.stderr
     assert "command -v curl >/dev/null || dnf install -y curl" in result.stderr
     assert "dnf install -y git unzip python3.11 python3.11-pip" in result.stderr
@@ -215,7 +228,83 @@ def test_install_wrapper_reports_missing_prereqs_when_package_manager_unavailabl
     assert "zypper install -y curl git unzip python311 python311-pip" in result.stderr
 
 
-def test_install_wrapper_installs_missing_prereqs_with_apt_get(tmp_path: Path) -> None:
+def test_install_wrapper_does_not_run_package_manager_without_opt_in(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    os.symlink(shutil.which("python3"), bin_dir / "python3")
+    _symlink_tool(bin_dir, "cat")
+    marker = tmp_path / "apt-ran.txt"
+    _write_executable(
+        bin_dir / "apt-get",
+        f"""#!/bin/bash
+echo "$*" >> "{marker}"
+exit 0
+""",
+    )
+
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER)],
+        capture_output=True,
+        text=True,
+        env=_env_with_path(bin_dir),
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "refusing to auto-install prerequisites by default" in result.stderr
+    assert not marker.exists()
+
+
+def test_install_wrapper_double_dash_does_not_enable_prereq_auto_install(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    os.symlink(shutil.which("python3"), bin_dir / "python3")
+    _symlink_tool(bin_dir, "cat")
+    marker = tmp_path / "apt-ran.txt"
+    _write_executable(
+        bin_dir / "apt-get",
+        f"""#!/bin/bash
+echo "$*" >> "{marker}"
+exit 0
+""",
+    )
+
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER), "--", "--auto-install-prereqs"],
+        capture_output=True,
+        text=True,
+        env=_env_with_path(bin_dir),
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "refusing to auto-install prerequisites by default" in result.stderr
+    assert not marker.exists()
+
+
+def test_install_wrapper_auto_install_reports_missing_package_manager(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    os.symlink(shutil.which("python3"), bin_dir / "python3")
+    _symlink_tool(bin_dir, "cat")
+    _symlink_tool(bin_dir, "curl")
+
+    env = _env_with_path(bin_dir)
+    env["PERFXPERT_AUTO_INSTALL_PREREQS"] = "1"
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "missing OS prerequisites" in result.stderr
+    assert "no supported package manager found" in result.stderr
+
+
+def test_install_wrapper_auto_installs_missing_prereqs_with_apt_get(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     bundled = tmp_path / "site-packages" / "perfxpert" / "_bundled" / "opencode"
@@ -241,6 +330,10 @@ if [ "$1" = "-c" ]; then
       echo 1
       exit 0
       ;;
+    *'sysconfig.get_path("scripts")'*)
+      echo "{bin_dir}"
+      exit 0
+      ;;
     *'sysconfig.get_path("stdlib")'*)
       echo "{tmp_path / 'missing-externally-managed'}"
       exit 0
@@ -257,6 +350,7 @@ exit 99
     _symlink_tool(bin_dir, "cat")
     _symlink_tool(bin_dir, "chmod")
     _symlink_tool(bin_dir, "git")
+    _write_fake_perfxpert_code(bin_dir)
     _write_executable(
         bin_dir / "sudo",
         """#!/bin/bash
@@ -278,10 +372,10 @@ exit 0
     )
 
     result = subprocess.run(
-        ["/bin/bash", str(_INSTALL_WRAPPER), "develop"],
+        ["/bin/bash", str(_INSTALL_WRAPPER), "--auto-install-prereqs", "develop"],
         capture_output=True,
         text=True,
-        env=_env_with_path(bin_dir),
+        env={**_env_with_path(bin_dir), "PERFXPERT_AUTO_INSTALL_BUN": "1"},
         check=False,
     )
 
@@ -323,6 +417,10 @@ if [ "$1" = "-c" ]; then
       echo 1
       exit 0
       ;;
+    *'sysconfig.get_path("scripts")'*)
+      echo "{bin_dir}"
+      exit 0
+      ;;
     *'sysconfig.get_path("stdlib")'*)
       echo "{tmp_path / 'missing-externally-managed'}"
       exit 0
@@ -339,6 +437,7 @@ exit 99
     _symlink_tool(bin_dir, "cat")
     _symlink_tool(bin_dir, "chmod")
     _write_executable(bin_dir / "curl", "#!/bin/sh\nexit 0\n")
+    _write_fake_perfxpert_code(bin_dir)
     _write_executable(
         bin_dir / "sudo",
         """#!/bin/bash
@@ -353,7 +452,7 @@ echo "$*" >> "{installed}"
 if [ "$1" = "install" ]; then
   printf '#!/bin/sh\\nexit 0\\n' > "{bin_dir}/git"
   printf '#!/bin/sh\\nexit 0\\n' > "{bin_dir}/unzip"
-  chmod +x "{bin_dir}/git" "{bin_dir}/unzip"
+  /bin/chmod +x "{bin_dir}/git" "{bin_dir}/unzip"
 fi
 exit 0
 """,
@@ -363,13 +462,94 @@ exit 0
         ["/bin/bash", str(_INSTALL_WRAPPER), "develop"],
         capture_output=True,
         text=True,
-        env=_env_with_path(bin_dir),
+        env={**_env_with_path(bin_dir), "PERFXPERT_AUTO_INSTALL_PREREQS": "1"},
         check=False,
     )
 
     assert result.returncode == 0
     assert installed.read_text(encoding="utf-8").splitlines() == [
-        "install -y git unzip",
+        "install -y git",
+    ]
+
+
+def test_install_wrapper_auto_installs_missing_prereqs_with_zypper(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    bundled = tmp_path / "site-packages" / "perfxpert" / "_bundled" / "opencode"
+    bundled.parent.mkdir(parents=True)
+    bundled.write_text("fake-opencode", encoding="utf-8")
+    bundled.chmod(0o755)
+    _write_executable(
+        bin_dir / "python3",
+        f"""#!/bin/bash
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  echo "pip 24.0"
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+  exit 0
+fi
+if [ "$1" = "-c" ]; then
+  case "$2" in
+    *"sys.version_info"*)
+      exit 0
+      ;;
+    *'sys.prefix != getattr(sys, "base_prefix", sys.prefix)'*)
+      echo 1
+      exit 0
+      ;;
+    *'sysconfig.get_path("scripts")'*)
+      echo "{bin_dir}"
+      exit 0
+      ;;
+    *'sysconfig.get_path("stdlib")'*)
+      echo "{tmp_path / 'missing-externally-managed'}"
+      exit 0
+      ;;
+    *'resources.files("perfxpert")'*)
+      echo "{bundled}"
+      exit 0
+      ;;
+  esac
+fi
+exit 99
+""",
+    )
+    _symlink_tool(bin_dir, "cat")
+    _symlink_tool(bin_dir, "chmod")
+    _write_executable(bin_dir / "curl", "#!/bin/sh\nexit 0\n")
+    _write_fake_perfxpert_code(bin_dir)
+    _write_executable(
+        bin_dir / "sudo",
+        """#!/bin/bash
+"$@"
+""",
+    )
+    installed = tmp_path / "installed.txt"
+    _write_executable(
+        bin_dir / "zypper",
+        f"""#!/bin/bash
+echo "$*" >> "{installed}"
+if [ "$1" = "--non-interactive" ] && [ "$2" = "install" ]; then
+  printf '#!/bin/sh\\nexit 0\\n' > "{bin_dir}/git"
+  printf '#!/bin/sh\\nexit 0\\n' > "{bin_dir}/unzip"
+  /bin/chmod +x "{bin_dir}/git" "{bin_dir}/unzip"
+fi
+exit 0
+""",
+    )
+
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER), "develop"],
+        capture_output=True,
+        text=True,
+        env={**_env_with_path(bin_dir), "PERFXPERT_AUTO_INSTALL_PREREQS": "1"},
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert installed.read_text(encoding="utf-8").splitlines() == [
+        "--non-interactive install -y git",
     ]
 
 
@@ -405,7 +585,7 @@ exit 99
     assert result.returncode == 2
     assert "missing OS prerequisites" in result.stderr
     assert "python3.10+ with pip" in result.stderr
-    assert "no supported package manager found" in result.stderr
+    assert "refusing to auto-install prerequisites by default" in result.stderr
 
 
 def test_install_wrapper_fails_when_python_m_pip_is_missing(tmp_path: Path) -> None:
@@ -439,12 +619,96 @@ exit 99
     assert result.returncode == 2
     assert "missing OS prerequisites" in result.stderr
     assert "python3.10+ with pip" in result.stderr
-    assert "no supported package manager found" in result.stderr
+    assert "refusing to auto-install prerequisites by default" in result.stderr
     assert "apt install -y curl git unzip python3-venv python3-pip" in result.stderr
     assert "command -v curl >/dev/null || dnf install -y curl" in result.stderr
     assert "dnf install -y git unzip python3.11 python3.11-pip" in result.stderr
     assert "dnf install -y git unzip python3 python3-pip" in result.stderr
     assert "zypper install -y curl git unzip python311 python311-pip" in result.stderr
+
+
+def test_install_wrapper_skips_active_python_without_pip_for_versioned_fallback(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    chosen = tmp_path / "chosen.txt"
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    bundled = tmp_path / "site-packages" / "perfxpert" / "_bundled" / "opencode"
+    bundled.parent.mkdir(parents=True)
+    bundled.write_text("fake-opencode", encoding="utf-8")
+    bundled.chmod(0o755)
+
+    _write_executable(
+        bin_dir / "python",
+        """#!/bin/bash
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  exit 1
+fi
+if [ "$1" = "-c" ]; then
+  case "$2" in
+    *"sys.version_info"*)
+      exit 0
+      ;;
+  esac
+fi
+exit 99
+""",
+    )
+    _write_executable(
+        bin_dir / "python3.11",
+        f"""#!/bin/bash
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  echo "pip 24.0"
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+  echo "python3.11" > "{chosen}"
+  exit 0
+fi
+if [ "$1" = "-c" ]; then
+  case "$2" in
+    *"sys.version_info"*)
+      exit 0
+      ;;
+    *'sys.prefix != getattr(sys, "base_prefix", sys.prefix)'*)
+      echo 1
+      exit 0
+      ;;
+    *'sysconfig.get_path("scripts")'*)
+      echo "{bin_dir}"
+      exit 0
+      ;;
+    *'sysconfig.get_path("stdlib")'*)
+      echo "{tmp_path / 'missing-externally-managed'}"
+      exit 0
+      ;;
+    *'resources.files("perfxpert")'*)
+      echo "{bundled}"
+      exit 0
+      ;;
+  esac
+fi
+exit 99
+""",
+    )
+    _symlink_tool(bin_dir, "curl")
+    _symlink_tool(bin_dir, "unzip")
+    _symlink_tool(bin_dir, "git")
+    _symlink_tool(bin_dir, "cat")
+    _write_fake_perfxpert_code(bin_dir)
+
+    env = _env_with_path(bin_dir)
+    env["HOME"] = str(home_dir)
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER), "develop"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert chosen.read_text(encoding="utf-8").strip() == "python3.11"
 
 
 def test_install_wrapper_rejects_externally_managed_python(tmp_path: Path) -> None:
@@ -467,6 +731,10 @@ if [ "$1" = "-c" ]; then
       ;;
     *'sys.prefix != getattr(sys, "base_prefix", sys.prefix)'*)
       echo 0
+      exit 0
+      ;;
+    *'sysconfig.get_path("scripts")'*)
+      echo "{bin_dir}"
       exit 0
       ;;
     *'sysconfig.get_path("stdlib")'*)
@@ -505,6 +773,7 @@ def test_install_wrapper_reports_ready_bundle_from_pip_build(tmp_path: Path) -> 
     bin_dir.mkdir()
     home_dir = tmp_path / "home"
     home_dir.mkdir()
+    version_marker = tmp_path / "perfxpert-code-version.txt"
     bundled = tmp_path / "site-packages" / "perfxpert" / "_bundled" / "opencode"
     bundled.parent.mkdir(parents=True)
     bundled.write_text("fake-opencode", encoding="utf-8")
@@ -517,6 +786,12 @@ if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
   exit 0
 fi
 if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+  cat > "{bin_dir}/perfxpert-code" <<'SH'
+#!/bin/sh
+echo "$*" >> "{version_marker}"
+echo 'AMD ROCm PerfXpert 0.2.0 (opencode wrapper)'
+SH
+  /bin/chmod +x "{bin_dir}/perfxpert-code"
   exit 0
 fi
 if [ "$1" = "-c" ]; then
@@ -526,6 +801,10 @@ if [ "$1" = "-c" ]; then
       ;;
     *'sys.prefix != getattr(sys, "base_prefix", sys.prefix)'*)
       echo 1
+      exit 0
+      ;;
+    *'sysconfig.get_path("scripts")'*)
+      echo "{bin_dir}"
       exit 0
       ;;
     *'sysconfig.get_path("stdlib")'*)
@@ -557,7 +836,74 @@ exit 99
     )
 
     assert result.returncode == 0
-    assert "bundled patched perfxpert-code ready" in result.stderr
+    assert "perfxpert-code ready at" in result.stderr
+    assert "bundled patched opencode ready at" in result.stderr
+    assert version_marker.read_text(encoding="utf-8").strip() == "--version"
+
+
+def test_install_wrapper_fails_when_perfxpert_code_entrypoint_missing(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    bundled = tmp_path / "site-packages" / "perfxpert" / "_bundled" / "opencode"
+    bundled.parent.mkdir(parents=True)
+    bundled.write_text("fake-opencode", encoding="utf-8")
+    bundled.chmod(0o755)
+    _write_executable(
+        bin_dir / "python3",
+        f"""#!/bin/bash
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  echo "pip 24.0"
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+  exit 0
+fi
+if [ "$1" = "-c" ]; then
+  case "$2" in
+    *"sys.version_info"*)
+      exit 0
+      ;;
+    *'sys.prefix != getattr(sys, "base_prefix", sys.prefix)'*)
+      echo 1
+      exit 0
+      ;;
+    *'sysconfig.get_path("scripts")'*)
+      echo "{bin_dir}"
+      exit 0
+      ;;
+    *'sysconfig.get_path("stdlib")'*)
+      echo "{tmp_path / 'missing-externally-managed'}"
+      exit 0
+      ;;
+    *'resources.files("perfxpert")'*)
+      echo "{bundled}"
+      exit 0
+      ;;
+  esac
+fi
+exit 99
+""",
+    )
+    _symlink_tool(bin_dir, "curl")
+    _symlink_tool(bin_dir, "unzip")
+    _symlink_tool(bin_dir, "git")
+    _symlink_tool(bin_dir, "cat")
+
+    env = _env_with_path(bin_dir)
+    env["HOME"] = str(home_dir)
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER), "develop"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "perfxpert-code` console entry point is not usable" in result.stderr
+    assert "missing executable perfxpert-code console script" in result.stderr
 
 
 def test_install_wrapper_fails_when_bundled_opencode_is_missing_after_install(tmp_path: Path) -> None:
@@ -585,6 +931,10 @@ if [ "$1" = "-c" ]; then
       echo 1
       exit 0
       ;;
+    *'sysconfig.get_path("scripts")'*)
+      echo "{bin_dir}"
+      exit 0
+      ;;
     *'sysconfig.get_path("stdlib")'*)
       echo "{tmp_path / 'missing-externally-managed'}"
       exit 0
@@ -601,6 +951,7 @@ exit 99
     _symlink_tool(bin_dir, "unzip")
     _symlink_tool(bin_dir, "git")
     _symlink_tool(bin_dir, "cat")
+    _write_fake_perfxpert_code(bin_dir)
 
     env = _env_with_path(bin_dir)
     env["HOME"] = str(home_dir)
@@ -647,6 +998,10 @@ if [ "$1" = "-c" ]; then
       echo 1
       exit 0
       ;;
+    *'sysconfig.get_path("scripts")'*)
+      echo "{bin_dir}"
+      exit 0
+      ;;
     *'sysconfig.get_path("stdlib")'*)
       echo "{tmp_path / 'missing-externally-managed'}"
       exit 0
@@ -680,6 +1035,10 @@ if [ "$1" = "-c" ]; then
       echo 1
       exit 0
       ;;
+    *'sysconfig.get_path("scripts")'*)
+      echo "{bin_dir}"
+      exit 0
+      ;;
     *'sysconfig.get_path("stdlib")'*)
       echo "{tmp_path / 'missing-externally-managed'}"
       exit 0
@@ -697,6 +1056,7 @@ exit 99
     _symlink_tool(bin_dir, "unzip")
     _symlink_tool(bin_dir, "git")
     _symlink_tool(bin_dir, "cat")
+    _write_fake_perfxpert_code(bin_dir)
 
     env = _env_with_path(bin_dir)
     env["HOME"] = str(home_dir)
@@ -752,6 +1112,10 @@ if [ "$1" = "-c" ]; then
       echo 1
       exit 0
       ;;
+    *'sysconfig.get_path("scripts")'*)
+      echo "{bin_dir}"
+      exit 0
+      ;;
     *'sysconfig.get_path("stdlib")'*)
       echo "{tmp_path / 'missing-externally-managed'}"
       exit 0
@@ -769,6 +1133,7 @@ exit 99
     _symlink_tool(bin_dir, "unzip")
     _symlink_tool(bin_dir, "git")
     _symlink_tool(bin_dir, "cat")
+    _write_fake_perfxpert_code(bin_dir)
 
     env = _env_with_path(bin_dir)
     env["HOME"] = str(home_dir)

--- a/experimental/python/perfxpert/tests/test_providers/test_ollama_provider.py
+++ b/experimental/python/perfxpert/tests/test_providers/test_ollama_provider.py
@@ -30,6 +30,7 @@ def test_dry_run_no_network():
 
 def test_default_url_localhost(monkeypatch):
     monkeypatch.delenv("PERFXPERT_LLM_LOCAL_URL", raising=False)
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
     from perfxpert.providers.ollama_provider import OllamaProvider
     with patch(
         "perfxpert.providers.ollama_provider.httpx.post",
@@ -49,6 +50,18 @@ def test_custom_url_from_env(monkeypatch):
     ) as mock_post:
         OllamaProvider().complete([{"role": "user", "content": "hi"}])
         assert mock_post.call_args.args[0] == "http://gpu-box:11434/api/chat"
+
+
+def test_compat_ollama_host_env(monkeypatch):
+    monkeypatch.delenv("PERFXPERT_LLM_LOCAL_URL", raising=False)
+    monkeypatch.setenv("OLLAMA_HOST", "compat-ollama:11434")
+    from perfxpert.providers.ollama_provider import OllamaProvider
+    with patch(
+        "perfxpert.providers.ollama_provider.httpx.post",
+        return_value=_fake_response(),
+    ) as mock_post:
+        OllamaProvider().complete([{"role": "user", "content": "hi"}])
+        assert mock_post.call_args.args[0] == "http://compat-ollama:11434/api/chat"
 
 
 def test_complete_response_shape():

--- a/experimental/python/perfxpert/tests/test_providers/test_opencode_provider.py
+++ b/experimental/python/perfxpert/tests/test_providers/test_opencode_provider.py
@@ -20,9 +20,11 @@ def _fake_completed(stdout="opencode-out", returncode=0):
 
 
 def test_dry_run_no_subprocess(monkeypatch):
-    monkeypatch.setenv("PERFXPERT_OPENCODE_PATH", "/usr/local/bin/opencode")
     monkeypatch.delenv("PERFXPERT_IN_OPENCODE_SESSION", raising=False)
+    import perfxpert.cli.opencode_launcher as opencode_launcher
     from perfxpert.providers.opencode_provider import OpencodeProvider
+
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: "/pkg/opencode")
     with patch("perfxpert.providers.opencode_provider.subprocess.run") as mr:
         assert OpencodeProvider().complete([], dry_run=True) is DryRunResponse
         mr.assert_not_called()
@@ -30,14 +32,16 @@ def test_dry_run_no_subprocess(monkeypatch):
 
 def test_recursion_guard_raises(monkeypatch):
     monkeypatch.setenv("PERFXPERT_IN_OPENCODE_SESSION", "1")
-    monkeypatch.setenv("PERFXPERT_OPENCODE_PATH", "/usr/local/bin/opencode")
+    import perfxpert.cli.opencode_launcher as opencode_launcher
     from perfxpert.providers.opencode_provider import OpencodeProvider
+
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: "/pkg/opencode")
     prov = OpencodeProvider()
     with pytest.raises(ProviderError, match="recursion guard"):
         prov.complete([{"role": "user", "content": "hi"}])
 
 
-def test_binary_path_from_env(monkeypatch):
+def test_explicit_constructor_binary_path(monkeypatch):
     monkeypatch.setenv("PERFXPERT_OPENCODE_PATH", "/custom/path/opencode")
     monkeypatch.delenv("PERFXPERT_IN_OPENCODE_SESSION", raising=False)
     from perfxpert.providers.opencode_provider import OpencodeProvider
@@ -45,26 +49,31 @@ def test_binary_path_from_env(monkeypatch):
         "perfxpert.providers.opencode_provider.subprocess.run",
         return_value=_fake_completed(),
     ) as mr:
-        OpencodeProvider().complete([{"role": "user", "content": "hi"}])
+        OpencodeProvider(opencode_path="/custom/path/opencode").complete(
+            [{"role": "user", "content": "hi"}]
+        )
         cmd = mr.call_args.args[0]
         assert cmd[0] == "/custom/path/opencode"
 
 
-def test_binary_path_from_shutil_which(monkeypatch):
-    monkeypatch.delenv("PERFXPERT_OPENCODE_PATH", raising=False)
+def test_env_override_is_ignored_for_bundled_provider(monkeypatch):
+    monkeypatch.setenv("PERFXPERT_OPENCODE_PATH", "/custom/path/opencode")
     monkeypatch.delenv("PERFXPERT_IN_OPENCODE_SESSION", raising=False)
+    import perfxpert.cli.opencode_launcher as opencode_launcher
     from perfxpert.providers.opencode_provider import OpencodeProvider
+
+    monkeypatch.setattr(
+        opencode_launcher,
+        "resolve_opencode_binary",
+        lambda: "/pkg/perfxpert/_bundled/opencode",
+    )
     with patch(
-        "perfxpert.providers.opencode_provider.shutil.which",
-        return_value="/opt/bin/opencode",
-    ):
-        with patch(
-            "perfxpert.providers.opencode_provider.subprocess.run",
-            return_value=_fake_completed(stdout="ok"),
-        ) as mr:
-            OpencodeProvider().complete([{"role": "user", "content": "hi"}])
-            cmd = mr.call_args.args[0]
-            assert cmd[0] == "/opt/bin/opencode"
+        "perfxpert.providers.opencode_provider.subprocess.run",
+        return_value=_fake_completed(stdout="ok"),
+    ) as mr:
+        OpencodeProvider().complete([{"role": "user", "content": "hi"}])
+        cmd = mr.call_args.args[0]
+        assert cmd[0] == "/pkg/perfxpert/_bundled/opencode"
 
 
 def test_binary_path_from_bundled_launcher(monkeypatch):
@@ -97,26 +106,25 @@ def test_no_binary_found_raises(monkeypatch):
         "resolve_opencode_binary",
         lambda: (_ for _ in ()).throw(FileNotFoundError("missing")),
     )
-    with patch("perfxpert.providers.opencode_provider.shutil.which", return_value=None):
-        with pytest.raises(ProviderError, match="opencode"):
-            OpencodeProvider()
+    with pytest.raises(ProviderError, match="bundled patched binary"):
+        OpencodeProvider()
 
 
 def test_subprocess_output_parsed(monkeypatch):
-    monkeypatch.setenv("PERFXPERT_OPENCODE_PATH", "/bin/opencode")
     monkeypatch.delenv("PERFXPERT_IN_OPENCODE_SESSION", raising=False)
     from perfxpert.providers.opencode_provider import OpencodeProvider
     with patch(
         "perfxpert.providers.opencode_provider.subprocess.run",
         return_value=_fake_completed(stdout="the-answer"),
     ):
-        r = OpencodeProvider().complete([{"role": "user", "content": "hi"}])
+        r = OpencodeProvider(opencode_path="/bin/opencode").complete(
+            [{"role": "user", "content": "hi"}]
+        )
         assert r.content == "the-answer"
         assert r.provider == "opencode"
 
 
 def test_timeout_mapped(monkeypatch):
-    monkeypatch.setenv("PERFXPERT_OPENCODE_PATH", "/bin/opencode")
     monkeypatch.delenv("PERFXPERT_IN_OPENCODE_SESSION", raising=False)
     import subprocess as sp
 
@@ -126,11 +134,12 @@ def test_timeout_mapped(monkeypatch):
         side_effect=sp.TimeoutExpired(cmd="opencode", timeout=1.0),
     ):
         with pytest.raises(PTO):
-            OpencodeProvider(timeout=1.0).complete([{"role": "user", "content": "x"}])
+            OpencodeProvider(opencode_path="/bin/opencode", timeout=1.0).complete(
+                [{"role": "user", "content": "x"}]
+            )
 
 
 def test_nonzero_exit_raises(monkeypatch):
-    monkeypatch.setenv("PERFXPERT_OPENCODE_PATH", "/bin/opencode")
     monkeypatch.delenv("PERFXPERT_IN_OPENCODE_SESSION", raising=False)
     from perfxpert.providers.opencode_provider import OpencodeProvider
     with patch(
@@ -138,7 +147,9 @@ def test_nonzero_exit_raises(monkeypatch):
         return_value=_fake_completed(stdout="", returncode=2),
     ):
         with pytest.raises(ProviderError):
-            OpencodeProvider().complete([{"role": "user", "content": "x"}])
+            OpencodeProvider(opencode_path="/bin/opencode").complete(
+                [{"role": "user", "content": "x"}]
+            )
 
 
 def test_registered():

--- a/experimental/python/perfxpert/tests/test_providers/test_private_provider.py
+++ b/experimental/python/perfxpert/tests/test_providers/test_private_provider.py
@@ -32,6 +32,7 @@ def test_dry_run_no_network(monkeypatch):
 
 def test_missing_url_raises_auth(monkeypatch):
     monkeypatch.delenv("PERFXPERT_LLM_PRIVATE_URL", raising=False)
+    monkeypatch.delenv("PRIVATE_LLM_ENDPOINT", raising=False)
     from perfxpert.providers.private_provider import PrivateProvider
 
     with pytest.raises(AuthError):
@@ -50,6 +51,20 @@ def test_posts_to_chat_completions(monkeypatch):
         PrivateProvider().complete([{"role": "user", "content": "hi"}])
         url = mp.call_args.args[0]
         assert url == "https://llm.corp.internal/v1/chat/completions"
+
+
+def test_compat_endpoint_env_is_honored(monkeypatch):
+    monkeypatch.delenv("PERFXPERT_LLM_PRIVATE_URL", raising=False)
+    monkeypatch.setenv("PRIVATE_LLM_ENDPOINT", "https://compat.example/v1")
+    monkeypatch.setenv("PERFXPERT_LLM_PRIVATE_MODEL", "internal-xl")
+    from perfxpert.providers.private_provider import PrivateProvider
+
+    with patch(
+        "perfxpert.providers.private_provider.httpx.post",
+        return_value=_fake_chat_response(),
+    ) as mp:
+        PrivateProvider().complete([{"role": "user", "content": "hi"}])
+        assert mp.call_args.args[0] == "https://compat.example/v1/chat/completions"
 
 
 def test_default_api_key_dummy(monkeypatch):
@@ -168,6 +183,19 @@ def test_parse_headers_invalid_json_raises_value_error():
 
     with pytest.raises(ValueError, match="invalid JSON"):
         _parse_headers("not-json{{{")
+
+
+def test_parse_headers_invalid_json_redacts_raw_value():
+    from perfxpert.providers.private_provider import _parse_headers
+
+    secret = "Ocp-Apim-Subscription-Key: secret-token"
+    with pytest.raises(ValueError) as excinfo:
+        _parse_headers(secret)
+
+    message = str(excinfo.value)
+    assert "Value redacted" in message
+    assert "secret-token" not in message
+    assert "Ocp-Apim-Subscription-Key" not in message
 
 
 def test_parse_headers_non_dict_json_raises_value_error():

--- a/experimental/python/perfxpert/tests/test_setup/test_setup_build.py
+++ b/experimental/python/perfxpert/tests/test_setup/test_setup_build.py
@@ -5,7 +5,13 @@ import itertools
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 import setuptools
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    tomllib = None  # type: ignore[assignment]
 
 
 _COUNTER = itertools.count()
@@ -26,10 +32,13 @@ def _load_setup_module(monkeypatch):
 
 
 def test_pyproject_packages_top_level_bundled_opencode_binary() -> None:
-    text = _PYPROJECT.read_text()
+    if tomllib is None:
+        pytest.skip("tomllib is available on Python 3.11+")
+    data = tomllib.loads(_PYPROJECT.read_text())
+    package_data = data["tool"]["setuptools"]["package-data"]["perfxpert"]
 
-    assert '"_bundled/opencode"' in text
-    assert '"_bundled/**/*"' in text
+    assert "_bundled/opencode" in package_data
+    assert "_bundled/**/*" in package_data
 
 
 def test_ensure_bun_on_path_bootstraps_user_local_bun(
@@ -39,6 +48,7 @@ def test_ensure_bun_on_path_bootstraps_user_local_bun(
     home = tmp_path / "home"
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("PERFXPERT_AUTO_INSTALL_BUN", "1")
     calls: list[dict[str, str]] = []
 
     def _fake_which(name: str, path: str | None = None) -> str | None:
@@ -64,11 +74,37 @@ def test_ensure_bun_on_path_bootstraps_user_local_bun(
 
     assert str(home / ".bun" / "bin") in path.split(":")
     assert calls and calls[0]["BUN_INSTALL"] == str(home / ".bun")
+    assert calls[0]["BUN_VERSION"] == module._DEFAULT_BUN_VERSION
     assert "bootstrapping bun" in capsys.readouterr().err
+
+
+def test_ensure_bun_on_path_requires_explicit_auto_install(monkeypatch) -> None:
+    module = _load_setup_module(monkeypatch)
+    monkeypatch.delenv("PERFXPERT_AUTO_INSTALL_BUN", raising=False)
+
+    def _fake_which(name: str, path: str | None = None) -> str | None:
+        if name in {"bash", "curl", "git", "unzip"}:
+            return f"/usr/bin/{name}"
+        return None
+
+    monkeypatch.setattr(module.shutil, "which", _fake_which)
+    monkeypatch.setattr(
+        module,
+        "_run_bun_install_script",
+        lambda _env: (_ for _ in ()).throw(AssertionError("unexpected bootstrap")),
+    )
+
+    try:
+        module._ensure_bun_on_path()
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:
+        raise AssertionError("expected SystemExit when bun auto-install is not enabled")
 
 
 def test_ensure_bun_on_path_fails_when_unzip_missing(monkeypatch) -> None:
     module = _load_setup_module(monkeypatch)
+    monkeypatch.setenv("PERFXPERT_AUTO_INSTALL_BUN", "1")
 
     def _fake_which(name: str, path: str | None = None) -> str | None:
         return None
@@ -102,6 +138,40 @@ def test_ensure_bun_on_path_accepts_existing_bun_without_bootstrap_tools(
     )
 
     assert module._ensure_bun_on_path() == "/opt/bun/bin"
+
+
+def test_run_bun_install_script_fetches_before_running_bash(monkeypatch) -> None:
+    module = _load_setup_module(monkeypatch)
+    calls: list[tuple[str, object]] = []
+
+    class _Result:
+        def __init__(self, returncode: int, stdout: bytes = b"", stderr: bytes = b""):
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def _fake_which(name: str, path: str | None = None) -> str | None:
+        return f"/usr/bin/{name}" if name in {"bash", "curl", "unzip"} else None
+
+    def _fake_run(args, **kwargs):
+        if args[0].endswith("curl"):
+            calls.append(("curl", kwargs.get("capture_output")))
+            return _Result(0, stdout=b"echo bun\n")
+        if args[0].endswith("bash"):
+            calls.append(("bash", kwargs.get("input")))
+            return _Result(0)
+        raise AssertionError(args)
+
+    monkeypatch.setattr(module.shutil, "which", _fake_which)
+    monkeypatch.setattr(module.subprocess, "run", _fake_run)
+    monkeypatch.setattr(
+        module.subprocess,
+        "Popen",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected Popen")),
+    )
+
+    assert module._run_bun_install_script({}) == 0
+    assert calls == [("curl", True), ("bash", b"echo bun\n")]
 
 
 def test_opencode_dir_is_populated_requires_git_metadata(
@@ -206,6 +276,40 @@ def test_run_opencode_build_fails_when_checkout_unavailable(
         assert exc.code == 1
     else:
         raise AssertionError("expected SystemExit when opencode checkout is unavailable")
+
+
+def test_run_opencode_build_fails_closed_when_bun_is_missing(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    module = _load_setup_module(monkeypatch)
+    monkeypatch.delenv("PERFXPERT_AUTO_INSTALL_BUN", raising=False)
+    build_script = tmp_path / "build-bundled-opencode.sh"
+    build_script.write_text("#!/bin/sh\nexit 0\n")
+    monkeypatch.setattr(module, "_BUILD_SCRIPT", build_script)
+    monkeypatch.setattr(module, "_BUNDLE_PATH", tmp_path / "missing-opencode")
+    monkeypatch.setattr(module, "_ensure_opencode_checkout", lambda: True)
+
+    def _fake_which(name: str, path: str | None = None) -> str | None:
+        if name in {"bash", "git", "curl", "unzip"}:
+            return f"/usr/bin/{name}"
+        return None
+
+    monkeypatch.setattr(module.shutil, "which", _fake_which)
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("build script should not run without bun")
+        ),
+    )
+
+    try:
+        module._run_opencode_build()
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:
+        raise AssertionError("expected SystemExit when bun is missing")
+    assert "bun is not on PATH" in capsys.readouterr().err
 
 
 def test_run_opencode_build_fails_when_build_script_missing(


### PR DESCRIPTION
## Motivation

Follow up on review feedback after #5378 merged. This keeps the remaining install/provider hardening on a separate branch based on current `develop`.

## Technical Details

- Harden `scripts/pip-install-from-git.sh` so package-manager installs remain opt-in, `--` stops wrapper option scanning, curl/unzip are only required for explicit bun bootstrap, and `perfxpert-code` verification checks the selected Python install target rather than a stale PATH entry.
- Keep the bundled patched opencode path fail-closed: pip/setup requires bun on PATH unless `PERFXPERT_AUTO_INSTALL_BUN=1` is explicitly set, and tests cover the build hook path directly.
- Align provider behavior and docs for private OpenAI-compatible endpoints, `PRIVATE_LLM_ENDPOINT`, `OLLAMA_HOST` without a scheme, bundled opencode availability, and non-text `perfxpert analyze` file-output defaults.
- Update install docs for customer-facing curl one-liners and internal distro guidance without claiming unperformed clean-container validation.

## JIRA ID

N/A

## Test Plan

- `PYTHONPATH=experimental/python/perfxpert pytest -q experimental/python/perfxpert/tests/test_setup/test_setup_build.py experimental/python/perfxpert/tests/test_integration/test_install_docs.py experimental/python/perfxpert/tests/test_integration/test_cli_dispatch.py experimental/python/perfxpert/tests/test_cli/test_analyze_args.py experimental/python/perfxpert/tests/test_cli/test_progress_callback.py experimental/python/perfxpert/tests/test_cli/test_branding.py experimental/python/perfxpert/tests/test_cli/test_doctor_providers.py experimental/python/perfxpert/tests/test_cli/test_launcher_subcommands.py experimental/python/perfxpert/tests/test_providers/test_private_provider.py experimental/python/perfxpert/tests/test_providers/test_ollama_provider.py experimental/python/perfxpert/tests/test_providers/test_opencode_provider.py experimental/python/perfxpert/tests/test_agents/test_framework.py`
- `git diff --check`

## Test Result

- `241 passed, 1 skipped`
- `git diff --check` passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
