### PR TITLE
[Rocprofiler-Compute] Add torch operator stats and summary

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -8,11 +8,15 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Added ``--bench-only`` profile mode option to run the roofline microbenchmark standalone (without profiling an application or collecting performance counters). No application run is required. Useful for regenerating ``roofline.csv`` in an existing workload directory or running the microbenchmark on systems where only HIP is available. ``--bench-only`` is mutually exclusive with ``--block``, ``--set``, ``--roof-only``, and ``--no-roof``.
 * Added backward compatibility for live attach mode to work with older ROCm 7.x.x releases.
-* Added per-operator stats (calls, dispatch min/max/mean) and a flat operator summary table to ``--experimental analyze --list-torch-operators`` / ``--torch-operator`` output.
 
 ### Changed
 
 * Changed ratio metric aggregation from `AVG(A/B)` (arithmetic mean of per-dispatch ratios) to `SUM(A)/SUM(B)` (ratio of totals) across all analysis YAML configurations and all GPU architectures. `SUM(A)/SUM(B)` is a weighted average where each dispatch contributes proportionally to its denominator magnitude (duration, access count, cycle count). Single-dispatch workloads are unaffected (mathematically identical). Multi-dispatch workloads with different kernels or varying durations will see corrected values.
+
+* Added operator statistics in the analysis output of torch operators profiling. Added the following statistics for every torch operators and its children:
+    * Number of invocations
+    * Number of kernel dispatches
+    * Min/Max/Mean and Total duration of kernel dispatches
 
 ### Removed
 

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -8,6 +8,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Added ``--bench-only`` profile mode option to run the roofline microbenchmark standalone (without profiling an application or collecting performance counters). No application run is required. Useful for regenerating ``roofline.csv`` in an existing workload directory or running the microbenchmark on systems where only HIP is available. ``--bench-only`` is mutually exclusive with ``--block``, ``--set``, ``--roof-only``, and ``--no-roof``.
 * Added backward compatibility for live attach mode to work with older ROCm 7.x.x releases.
+* Added per-operator stats (calls, dispatch min/max/mean) and a flat operator summary table to ``--experimental analyze --list-torch-operators`` / ``--torch-operator`` output.
 
 ### Changed
 

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -13,7 +13,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Changed ratio metric aggregation from `AVG(A/B)` (arithmetic mean of per-dispatch ratios) to `SUM(A)/SUM(B)` (ratio of totals) across all analysis YAML configurations and all GPU architectures. `SUM(A)/SUM(B)` is a weighted average where each dispatch contributes proportionally to its denominator magnitude (duration, access count, cycle count). Single-dispatch workloads are unaffected (mathematically identical). Multi-dispatch workloads with different kernels or varying durations will see corrected values.
 
-* Added operator statistics in the analysis output of torch operators profiling. Added the following statistics for every torch operators and its children:
+* Added operator statistics and per-operator summary table in the analysis output of torch operators profiling. Added the following statistics for every torch operators and its children:
     * Number of invocations
     * Number of kernel dispatches
     * Min/Max/Mean and Total duration of kernel dispatches

--- a/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
+++ b/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
@@ -691,22 +691,45 @@ Display all PyTorch operators captured during profiling:
          └─ relu_kernel (dispatches: 30, total: 0.31 ms)
 
    Operator summary (Min/Max/Mean are per-dispatch over the subtree; sorted by Total):
-   ╒══════════════════════════════════════════════════╤═════════╤══════════════╤══════════════╤═══════════╤══════════════════╤═════════════╤════════════╤════════════╕
-   │ Operator                                         │   Calls │   Dispatches │   Total (ms) │   % Total │   Mean/Call (ms) │   Mean (us) │   Min (us) │   Max (us) │
-   ╞══════════════════════════════════════════════════╪═════════╪══════════════╪══════════════╪═══════════╪══════════════════╪═════════════╪════════════╪════════════╡
-   │ nn.Module.Net.forward                            │      10 │           90 │        42.80 │    100.00 │           4.2800 │      475.56 │      10.00 │    2100.00 │
-   ├──────────────────────────────────────────────────┼─────────┼──────────────┼──────────────┼───────────┼──────────────────┼─────────────┼────────────┼────────────┤
-   │ nn.Module.Net.forward/torch.nn.functional.conv2d │      20 │           40 │        27.08 │     63.27 │           1.3540 │      677.00 │     210.00 │    2100.00 │
-   ├──────────────────────────────────────────────────┼─────────┼──────────────┼──────────────┼───────────┼──────────────────┼─────────────┼────────────┼────────────┤
-   │ nn.Module.Net.forward/torch.nn.functional.linear │      20 │           20 │        15.41 │     36.00 │           0.7705 │      770.50 │     130.00 │    1820.00 │
-   ├──────────────────────────────────────────────────┼─────────┼──────────────┼──────────────┼───────────┼──────────────────┼─────────────┼────────────┼────────────┤
-   │ nn.Module.Net.forward/torch.nn.functional.relu   │      40 │           30 │         0.31 │      0.72 │           0.0077 │       10.33 │      10.00 │      20.00 │
-   ╘══════════════════════════════════════════════════╧═════════╧══════════════╧══════════════╧═══════════╧══════════════════╧═════════════╧════════════╧════════════╛
+   ╒══════════════════════════════════════════════════╤═════════╤══════════════╤══════════╤═══════════╤═════════════╤═════════╤═════════╤═════════╕
+   │ Operator                                         │   Calls │   Dispatches │    Total │   % Total │   Mean/Call │    Mean │     Min │     Max │
+   ╞══════════════════════════════════════════════════╪═════════╪══════════════╪══════════╪═══════════╪═════════════╪═════════╪═════════╪═════════╡
+   │ nn.Module.Net.forward                            │      10 │           90 │ 42.80 ms │    100.00 │     4.28 ms │ 0.48 ms │ 0.01 ms │ 2.10 ms │
+   ├──────────────────────────────────────────────────┼─────────┼──────────────┼──────────┼───────────┼─────────────┼─────────┼─────────┼─────────┤
+   │ nn.Module.Net.forward/torch.nn.functional.conv2d │      20 │           40 │ 27.08 ms │     63.27 │     1.35 ms │ 0.68 ms │ 0.21 ms │ 2.10 ms │
+   ├──────────────────────────────────────────────────┼─────────┼──────────────┼──────────┼───────────┼─────────────┼─────────┼─────────┼─────────┤
+   │ nn.Module.Net.forward/torch.nn.functional.linear │      20 │           20 │ 15.41 ms │     36.00 │     0.77 ms │ 0.77 ms │ 0.13 ms │ 1.82 ms │
+   ├──────────────────────────────────────────────────┼─────────┼──────────────┼──────────┼───────────┼─────────────┼─────────┼─────────┼─────────┤
+   │ nn.Module.Net.forward/torch.nn.functional.relu   │      40 │           30 │  0.31 ms │      0.72 │     7.70 us │ 0.01 ms │ 0.01 ms │ 0.02 ms │
+   ╘══════════════════════════════════════════════════╧═════════╧══════════════╧══════════╧═══════════╧═════════════╧═════════╧═════════╧═════════╛
 
 Output is grouped by source location (``file:line``) and shows full operator
 hierarchy (``/``-separated) and kernel stats. A consolidated CSV
 (``torch_trace/consolidated.csv``) is written with all operator/kernel data;
 see :ref:`torch-operator-profiling` for details.
+
+The flat **Operator summary** table below the call tree has one row per
+operator that ran at least one GPU kernel. Time cells auto-switch between
+milliseconds and microseconds per cell; missing values render as ``N/A``.
+
+* **Operator** — full operator path (for example
+  ``aten::matmul/aten::mm``).
+* **Calls** — how many times the operator was invoked. ``N/A`` when the
+  trace did not include ``Context_Id`` information to count invocations.
+* **Dispatches** — how many GPU kernels ran while the operator was on the
+  call stack (kernels launched by operators it called also count).
+* **Total** — total GPU time spent while the operator was on the call
+  stack.
+* **% Total** — share of the workload's total GPU time spent while this
+  operator was on the call stack. Because the same kernel time is counted
+  for an operator and for any operator that called it, the column can add
+  up to more than 100%. ``N/A`` when no GPU time was recorded.
+* **Mean/Call** — average GPU time per call to this operator.
+* **Mean / Min / Max** — per-kernel-dispatch timings across all kernels
+  launched while this operator was on the call stack.
+
+When no operator has any recorded dispatches, the table is replaced by the
+line ``Operator summary: (no operators with recorded dispatches)``.
 
 Filtering by Operator
 ---------------------

--- a/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
+++ b/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
@@ -681,12 +681,27 @@ Display all PyTorch operators captured during profiling:
    Grouped by source location, sorted by total GPU kernel duration.
    ================================================================================
 
-   main.py:60 (kernel_launches: 110, total_duration: 59.31 ms)
-   └─ nn.Module.Net.forward (kernel_launches: 110, total_duration: 59.31 ms)
-      ├─ nn.Module.Conv2d.forward
-      |  └─ torch.nn.functional.conv2d (kernel_launches: 40, total_duration: 27.08 ms)
-      └─ nn.Module.Linear.forward
-         └─ torch.nn.functional.linear (kernel_launches: 20, total_duration: 15.41 ms)
+   main.py:60 (dispatches: 90, total: 42.80 ms, dispatch_mean: 0.48 ms, dispatch_min: 0.01 ms, dispatch_max: 2.10 ms)
+   └─ nn.Module.Net.forward (calls: 10, dispatches: 90, total: 42.80 ms, dispatch_mean: 0.48 ms, dispatch_min: 0.01 ms, dispatch_max: 2.10 ms)
+      ├─ torch.nn.functional.conv2d (calls: 20)
+      |  └─ conv2d_fwd (dispatches: 40, total: 27.08 ms)
+      ├─ torch.nn.functional.linear (calls: 20)
+      |  └─ gemm (dispatches: 20, total: 15.41 ms)
+      └─ torch.nn.functional.relu (calls: 40)
+         └─ relu_kernel (dispatches: 30, total: 0.31 ms)
+
+   Operator summary (Min/Max/Mean are per-dispatch over the subtree; sorted by Total):
+   ╒══════════════════════════════════════════════════╤═════════╤══════════════╤══════════════╤═══════════╤══════════════════╤═════════════╤════════════╤════════════╕
+   │ Operator                                         │   Calls │   Dispatches │   Total (ms) │   % Total │   Mean/Call (ms) │   Mean (us) │   Min (us) │   Max (us) │
+   ╞══════════════════════════════════════════════════╪═════════╪══════════════╪══════════════╪═══════════╪══════════════════╪═════════════╪════════════╪════════════╡
+   │ nn.Module.Net.forward                            │      10 │           90 │        42.80 │    100.00 │           4.2800 │      475.56 │      10.00 │    2100.00 │
+   ├──────────────────────────────────────────────────┼─────────┼──────────────┼──────────────┼───────────┼──────────────────┼─────────────┼────────────┼────────────┤
+   │ nn.Module.Net.forward/torch.nn.functional.conv2d │      20 │           40 │        27.08 │     63.27 │           1.3540 │      677.00 │     210.00 │    2100.00 │
+   ├──────────────────────────────────────────────────┼─────────┼──────────────┼──────────────┼───────────┼──────────────────┼─────────────┼────────────┼────────────┤
+   │ nn.Module.Net.forward/torch.nn.functional.linear │      20 │           20 │        15.41 │     36.00 │           0.7705 │      770.50 │     130.00 │    1820.00 │
+   ├──────────────────────────────────────────────────┼─────────┼──────────────┼──────────────┼───────────┼──────────────────┼─────────────┼────────────┼────────────┤
+   │ nn.Module.Net.forward/torch.nn.functional.relu   │      40 │           30 │         0.31 │      0.72 │           0.0077 │       10.33 │      10.00 │      20.00 │
+   ╘══════════════════════════════════════════════════╧═════════╧══════════════╧══════════════╧═══════════╧══════════════════╧═════════════╧════════════╧════════════╛
 
 Output is grouped by source location (``file:line``) and shows full operator
 hierarchy (``/``-separated) and kernel stats. A consolidated CSV

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -15,6 +15,7 @@ from utils.roofline_calc import calc_ai_analyze
 from utils.utils_analysis import (
     build_call_trees,
     build_call_trees_with_kernel_ids,
+    build_operator_summary,
     process_torch_trace_output,
     write_torch_trace_consolidated_csv,
 )
@@ -371,6 +372,7 @@ class cli_analysis(OmniAnalyze_Base):
         print("Grouped by source location, sorted by total GPU kernel duration.")
         print(f"{'=' * 80}")
         tty.show_call_tree(call_trees)
+        tty.show_operator_summary(build_operator_summary(call_trees))
         print(f"{'=' * 80}")
 
         console_log(

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -3,6 +3,7 @@
 
 import argparse
 import copy
+import math
 import shutil
 import textwrap
 from pathlib import Path
@@ -344,38 +345,42 @@ def list_torch_operators(
     print(f"\n{'=' * 80}")
 
 
-def format_duration(duration_ms: float) -> str:
-    """Format a duration in ms, switching to us below 0.01 ms for readability."""
+def format_duration(duration_ms: Optional[float]) -> str:
+    """Format a duration in ms; switch to us below 0.01 ms; None/NaN render as N/A."""
+    if duration_ms is None:
+        return "N/A"
+    if isinstance(duration_ms, float) and math.isnan(duration_ms):
+        return "N/A"
     if duration_ms < 0.01:
         return f"{duration_ms * 1000:.2f} us"
     return f"{duration_ms:.2f} ms"
 
 
-def format_stats(launches: int, duration_ms: float) -> str:
-    """Format kernel-leaf stats as an inline parenthesized string."""
-    return f"(dispatches: {launches}, total: {format_duration(duration_ms)})"
-
-
-def format_node_stats(node: CallTreeNode, include_calls: bool = True) -> str:
+def format_node_stats(node: CallTreeNode) -> str:
     """Format operator-node stats (calls, dispatches, total, dispatch_mean/min/max).
 
-    ``dispatch_mean``/``dispatch_min``/``dispatch_max`` are per-GPU-kernel-dispatch
-    duration stats (one dispatch = one trace row = one kernel invocation).
-    ``include_calls=False`` is used for location-root lines, which are file:line
-    buckets rather than invocation frames and therefore have no meaningful
-    per-frame call count.
+    dispatch_mean / dispatch_min / dispatch_max are per kernel dispatch.
+    The "calls:" segment is omitted when invocation_ids is empty (location
+    roots and frames recorded without Context_Id).
     """
-    parts: list[str] = []
-    if include_calls:
-        parts.append(f"calls: {node.call_count}")
-    parts.append(f"dispatches: {node.kernel_launches}")
-    parts.append(f"total: {format_duration(node.total_duration_ms)}")
-    parts.append(
-        f"dispatch_mean: {format_duration(node.mean_dispatch_ns * NS_TO_MS)}"
+    mean_ms = (
+        node.mean_dispatch_ns * NS_TO_MS if node.mean_dispatch_ns is not None else None
     )
-    parts.append(f"dispatch_min: {format_duration(node.min_dispatch_ns * NS_TO_MS)}")
-    parts.append(f"dispatch_max: {format_duration(node.max_dispatch_ns * NS_TO_MS)}")
-    return "(" + ", ".join(parts) + ")"
+    min_ms = (
+        node.min_dispatch_ns * NS_TO_MS if node.min_dispatch_ns is not None else None
+    )
+    max_ms = (
+        node.max_dispatch_ns * NS_TO_MS if node.max_dispatch_ns is not None else None
+    )
+    calls_prefix = f"calls: {node.call_count}, " if len(node.invocation_ids) > 0 else ""
+    return (
+        f"({calls_prefix}"
+        f"dispatches: {node.kernel_launches}, "
+        f"total: {format_duration(node.total_duration_ms)}, "
+        f"dispatch_mean: {format_duration(mean_ms)}, "
+        f"dispatch_min: {format_duration(min_ms)}, "
+        f"dispatch_max: {format_duration(max_ms)})"
+    )
 
 
 def get_tree_wrap_width(min_width: int = 72, max_width: int = 120) -> int:
@@ -463,7 +468,7 @@ def show_call_tree(call_trees: dict[str, CallTreeNode]) -> None:
     for i, (location, root) in enumerate(sorted_locations):
         if i > 0:
             print(f"\n{'- ' * 40}")
-        stats = format_node_stats(root, include_calls=False)
+        stats = format_node_stats(root)
         print(f"\n{location} {stats}")
         for child in sorted(
             root.children.values(),
@@ -473,47 +478,62 @@ def show_call_tree(call_trees: dict[str, CallTreeNode]) -> None:
             print_operator_node(child)
 
 
-OPERATOR_NAME_WRAP_WIDTH = 72
-
-
 def show_operator_summary(summary_df: pd.DataFrame) -> None:
     """Print a flat per-operator summary table alongside the call tree.
 
-    Visually matches the rest of the analyze CLI: ``fancy_grid`` bordered
-    table via ``tabulate``. The ``Operator`` column is wrapped at
-    ``OPERATOR_NAME_WRAP_WIDTH`` only when an operator path exceeds that
-    width; numeric columns size to content. A header line above the table
-    spells out the aggregation basis so the column names can stay short.
-    ``NaN`` values render as ``"N/A"``.
+    - Rendered as a fancy_grid bordered table via tabulate, matching the
+      rest of the analyze CLI.
+
+    - Operator column wraps long paths; numeric columns size to content.
+
+    - A header line above the table explains the aggregation so column
+      names can stay short.
+
+    - Time cells are formatted per-cell via format_duration (auto-switching
+      between ms and us). NaN renders as "N/A".
     """
     if summary_df is None or summary_df.empty:
-        print("\nOperator summary: (no operators with recorded calls)")
+        print("\nOperator summary: (no operators with recorded dispatches)")
         return
 
-    # (DataFrame column, display label) pairs. DataFrame names are the
-    # programmatic schema (OPERATOR_SUMMARY_COLUMNS); display labels are
-    # short because the header line below explains units and semantics.
+    operator_name_wrap_width = 72
+
+    # (DataFrame column, display label) pairs. DataFrame names match the
+    # schema produced by build_operator_summary; display labels are short
+    # because the header line below explains the semantics and time cells
+    # self-label their unit.
     column_map = [
         ("Operator", "Operator"),
         ("Calls", "Calls"),
         ("Dispatches", "Dispatches"),
-        ("Total_GPU_ms", "Total (ms)"),
+        ("Total_GPU", "Total"),
         ("Pct_Total_GPU", "% Total"),
-        ("Mean_Per_Call_ms", "Mean/Call (ms)"),
-        ("Mean_Per_Dispatch_us", "Mean (us)"),
-        ("Min_Dispatch_us", "Min (us)"),
-        ("Max_Dispatch_us", "Max (us)"),
+        ("Mean_Per_Call", "Mean/Call"),
+        ("Mean_Per_Dispatch", "Mean"),
+        ("Min_Dispatch", "Min"),
+        ("Max_Dispatch", "Max"),
     ]
     source_cols = [c for c, _ in column_map]
     headers = [h for _, h in column_map]
-
-    display_df = summary_df[source_cols].copy()
-    display_df["Operator"] = display_df["Operator"].astype(str).apply(
-        lambda s: textwrap.fill(s, width=OPERATOR_NAME_WRAP_WIDTH)
+    time_cols = (
+        "Total_GPU",
+        "Mean_Per_Call",
+        "Mean_Per_Dispatch",
+        "Min_Dispatch",
+        "Max_Dispatch",
     )
 
-    # Per-column float format; "" for string and integer columns.
-    floatfmt = ("", "", "", ".2f", ".2f", ".4f", ".2f", ".2f", ".2f")
+    display_df = summary_df[source_cols].copy()
+    display_df["Operator"] = (
+        display_df["Operator"]
+        .astype(str)
+        .apply(lambda s: textwrap.fill(s, width=operator_name_wrap_width))
+    )
+    for col in time_cols:
+        display_df[col] = display_df[col].apply(format_duration)
+
+    # Time columns are pre-formatted strings; only % Total still needs floatfmt.
+    floatfmt = ("", "", "", "", ".2f", "", "", "", "")
     colalign = ("left",) + ("right",) * (len(headers) - 1)
 
     print(
@@ -581,7 +601,7 @@ def print_operator_node(
         id_suffix = f" (id {kernel_id})" if kernel_id is not None else ""
         display_name = simplify_kernel_name(kernel_name)
         total_ms = duration_ns * NS_TO_MS
-        stats = format_stats(launches, total_ms)
+        stats = f"(dispatches: {launches}, total: {format_duration(total_ms)})"
 
         # Last kernel gets └─, others get ├─
         kernel_is_last = i == len(node.kernels) - 1

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -20,6 +20,7 @@ from utils.logger import console_error, console_log, console_warning
 from utils.utils_analysis import (
     NS_TO_MS,
     CallTreeNode,
+    build_operator_summary,
     get_bw_scale_and_unit,
     simplify_kernel_name,
 )
@@ -339,16 +340,42 @@ def list_torch_operators(
     print("Grouped by source location, sorted by total GPU kernel duration.")
     print(f"{'=' * 80}")
     show_call_tree(call_trees)
+    show_operator_summary(build_operator_summary(call_trees))
     print(f"\n{'=' * 80}")
 
 
-def format_stats(launches: int, duration_ms: float) -> str:
-    """Format launch count and duration as an inline parenthesized string."""
+def format_duration(duration_ms: float) -> str:
+    """Format a duration in ms, switching to us below 0.01 ms for readability."""
     if duration_ms < 0.01:
-        formatted_duration = f"{duration_ms * 1000:.2f} us"
-    else:
-        formatted_duration = f"{duration_ms:.2f} ms"
-    return f"(kernel_launches: {launches}, total_duration: {formatted_duration})"
+        return f"{duration_ms * 1000:.2f} us"
+    return f"{duration_ms:.2f} ms"
+
+
+def format_stats(launches: int, duration_ms: float) -> str:
+    """Format kernel-leaf stats as an inline parenthesized string."""
+    return f"(dispatches: {launches}, total: {format_duration(duration_ms)})"
+
+
+def format_node_stats(node: CallTreeNode, include_calls: bool = True) -> str:
+    """Format operator-node stats (calls, dispatches, total, dispatch_mean/min/max).
+
+    ``dispatch_mean``/``dispatch_min``/``dispatch_max`` are per-GPU-kernel-dispatch
+    duration stats (one dispatch = one trace row = one kernel invocation).
+    ``include_calls=False`` is used for location-root lines, which are file:line
+    buckets rather than invocation frames and therefore have no meaningful
+    per-frame call count.
+    """
+    parts: list[str] = []
+    if include_calls:
+        parts.append(f"calls: {node.call_count}")
+    parts.append(f"dispatches: {node.kernel_launches}")
+    parts.append(f"total: {format_duration(node.total_duration_ms)}")
+    parts.append(
+        f"dispatch_mean: {format_duration(node.mean_dispatch_ns * NS_TO_MS)}"
+    )
+    parts.append(f"dispatch_min: {format_duration(node.min_dispatch_ns * NS_TO_MS)}")
+    parts.append(f"dispatch_max: {format_duration(node.max_dispatch_ns * NS_TO_MS)}")
+    return "(" + ", ".join(parts) + ")"
 
 
 def get_tree_wrap_width(min_width: int = 72, max_width: int = 120) -> int:
@@ -436,7 +463,7 @@ def show_call_tree(call_trees: dict[str, CallTreeNode]) -> None:
     for i, (location, root) in enumerate(sorted_locations):
         if i > 0:
             print(f"\n{'- ' * 40}")
-        stats = format_stats(root.kernel_launches, root.total_duration_ms)
+        stats = format_node_stats(root, include_calls=False)
         print(f"\n{location} {stats}")
         for child in sorted(
             root.children.values(),
@@ -444,6 +471,57 @@ def show_call_tree(call_trees: dict[str, CallTreeNode]) -> None:
             reverse=True,
         ):
             print_operator_node(child)
+
+
+OPERATOR_NAME_WRAP_WIDTH = 48
+
+
+def show_operator_summary(summary_df: pd.DataFrame) -> None:
+    """Print a flat per-operator summary table alongside the call tree.
+
+    Visually matches the rest of the analyze CLI: ``fancy_grid`` bordered
+    table via ``tabulate``. The ``Operator`` column is wrapped at
+    ``OPERATOR_NAME_WRAP_WIDTH`` so deep call-stack paths do not blow out
+    the right margin. Per-column ``floatfmt`` keeps ``ms`` columns at 4
+    decimals and ``us``/percentage columns at 2. ``NaN`` values render as
+    ``"N/A"``.
+    """
+    if summary_df is None or summary_df.empty:
+        print("\nOperator summary: (no operators with recorded calls)")
+        return
+
+    display_columns = [
+        "Operator",
+        "Calls",
+        "Dispatches",
+        "Total_GPU_ms",
+        "Pct_Total_GPU",
+        "Mean_Per_Call_ms",
+        "Mean_Per_Dispatch_us",
+        "Min_Dispatch_us",
+        "Max_Dispatch_us",
+    ]
+    display_df = summary_df[display_columns].copy()
+    display_df["Operator"] = display_df["Operator"].astype(str).apply(
+        lambda s: textwrap.fill(s, width=OPERATOR_NAME_WRAP_WIDTH)
+    )
+
+    # Per-column float format; "" for string and integer columns (tabulate
+    # picks a sensible default for those).
+    floatfmt = ("", "", "", ".4f", ".2f", ".4f", ".2f", ".2f", ".2f")
+    colalign = ("left",) + ("right",) * (len(display_columns) - 1)
+
+    print("\nOperator summary (sorted by Total_GPU_ms):")
+    print(
+        tabulate(
+            display_df.values,
+            headers=display_columns,
+            tablefmt="fancy_grid",
+            floatfmt=floatfmt,
+            colalign=colalign,
+            missingval="N/A",
+        )
+    )
 
 
 def print_operator_node(
@@ -458,10 +536,13 @@ def print_operator_node(
     node_prefix = f"{indent}{branch_char}"
 
     if is_branching:
-        stats = format_stats(node.kernel_launches, node.total_duration_ms)
-        print_wrapped_tree_line(node_prefix, f"{node.name} {stats}")
+        print_wrapped_tree_line(node_prefix, f"{node.name} {format_node_stats(node)}")
     else:
-        print_wrapped_tree_line(node_prefix, node.name)
+        if len(node.invocation_ids) > 0:
+            suffix = f" (calls: {node.call_count})"
+        else:
+            suffix = ""
+        print_wrapped_tree_line(node_prefix, f"{node.name}{suffix}")
 
     # Build new parent_pipes for children
     if is_last:

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -473,7 +473,7 @@ def show_call_tree(call_trees: dict[str, CallTreeNode]) -> None:
             print_operator_node(child)
 
 
-OPERATOR_NAME_WRAP_WIDTH = 48
+OPERATOR_NAME_WRAP_WIDTH = 72
 
 
 def show_operator_summary(summary_df: pd.DataFrame) -> None:
@@ -481,41 +481,49 @@ def show_operator_summary(summary_df: pd.DataFrame) -> None:
 
     Visually matches the rest of the analyze CLI: ``fancy_grid`` bordered
     table via ``tabulate``. The ``Operator`` column is wrapped at
-    ``OPERATOR_NAME_WRAP_WIDTH`` so deep call-stack paths do not blow out
-    the right margin. Per-column ``floatfmt`` keeps ``ms`` columns at 4
-    decimals and ``us``/percentage columns at 2. ``NaN`` values render as
-    ``"N/A"``.
+    ``OPERATOR_NAME_WRAP_WIDTH`` only when an operator path exceeds that
+    width; numeric columns size to content. A header line above the table
+    spells out the aggregation basis so the column names can stay short.
+    ``NaN`` values render as ``"N/A"``.
     """
     if summary_df is None or summary_df.empty:
         print("\nOperator summary: (no operators with recorded calls)")
         return
 
-    display_columns = [
-        "Operator",
-        "Calls",
-        "Dispatches",
-        "Total_GPU_ms",
-        "Pct_Total_GPU",
-        "Mean_Per_Call_ms",
-        "Mean_Per_Dispatch_us",
-        "Min_Dispatch_us",
-        "Max_Dispatch_us",
+    # (DataFrame column, display label) pairs. DataFrame names are the
+    # programmatic schema (OPERATOR_SUMMARY_COLUMNS); display labels are
+    # short because the header line below explains units and semantics.
+    column_map = [
+        ("Operator", "Operator"),
+        ("Calls", "Calls"),
+        ("Dispatches", "Dispatches"),
+        ("Total_GPU_ms", "Total (ms)"),
+        ("Pct_Total_GPU", "% Total"),
+        ("Mean_Per_Call_ms", "Mean/Call (ms)"),
+        ("Mean_Per_Dispatch_us", "Mean (us)"),
+        ("Min_Dispatch_us", "Min (us)"),
+        ("Max_Dispatch_us", "Max (us)"),
     ]
-    display_df = summary_df[display_columns].copy()
+    source_cols = [c for c, _ in column_map]
+    headers = [h for _, h in column_map]
+
+    display_df = summary_df[source_cols].copy()
     display_df["Operator"] = display_df["Operator"].astype(str).apply(
         lambda s: textwrap.fill(s, width=OPERATOR_NAME_WRAP_WIDTH)
     )
 
-    # Per-column float format; "" for string and integer columns (tabulate
-    # picks a sensible default for those).
-    floatfmt = ("", "", "", ".4f", ".2f", ".4f", ".2f", ".2f", ".2f")
-    colalign = ("left",) + ("right",) * (len(display_columns) - 1)
+    # Per-column float format; "" for string and integer columns.
+    floatfmt = ("", "", "", ".2f", ".2f", ".4f", ".2f", ".2f", ".2f")
+    colalign = ("left",) + ("right",) * (len(headers) - 1)
 
-    print("\nOperator summary (sorted by Total_GPU_ms):")
+    print(
+        "\nOperator summary (Min/Max/Mean are per-dispatch over the subtree; "
+        "sorted by Total):"
+    )
     print(
         tabulate(
             display_df.values,
-            headers=display_columns,
+            headers=headers,
             tablefmt="fancy_grid",
             floatfmt=floatfmt,
             colalign=colalign,

--- a/projects/rocprofiler-compute/src/utils/utils_analysis.py
+++ b/projects/rocprofiler-compute/src/utils/utils_analysis.py
@@ -60,10 +60,17 @@ def format_bw_human_readable(
 
 @dataclass
 class KernelStats:
-    """Aggregated kernel launch stats for one kernel name."""
+    """Aggregated kernel launch stats for one kernel name.
+
+    ``min_duration_ns`` starts at ``math.inf`` and is only lowered by dispatches
+    with a positive duration; callers must treat ``math.isinf(min_duration_ns)``
+    as "no meaningful minimum recorded".
+    """
 
     launches: int = 0
     total_duration_ns: float = 0.0
+    min_duration_ns: float = math.inf
+    max_duration_ns: float = 0.0
     kernel_id: Optional[int] = None
 
 
@@ -71,9 +78,19 @@ class KernelStats:
 class CallTreeNode:
     """A node in the operator call tree.
 
-    Children are ordered operator sub-calls; kernels maps each kernel name to
-    a ``KernelStats`` record. ``kernel_launches``
-    and ``total_duration_ms`` are inclusive (rolled up from all descendants).
+    Fields split by semantics:
+
+    Local to this frame (not rolled up from descendants):
+      - ``invocation_ids``: distinct ``Context_Id`` prefixes at this frame's
+        depth, one per time the frame was invoked.
+      - ``call_count``: equals ``len(invocation_ids)``. Materialized by
+        ``rollup_node_stats`` so display code can read an int directly.
+
+    Inclusive (rolled up over this node plus all descendants):
+      - ``kernel_launches``: kernel dispatches in the subtree.
+      - ``total_duration_ms``: cumulative GPU time in the subtree.
+      - ``min_dispatch_ns`` / ``max_dispatch_ns`` / ``mean_dispatch_ns``:
+        per-kernel-dispatch duration extremes and mean over the subtree.
     """
 
     name: str
@@ -81,6 +98,25 @@ class CallTreeNode:
     kernels: dict[str, KernelStats] = field(default_factory=dict)
     kernel_launches: int = 0
     total_duration_ms: float = 0.0
+    invocation_ids: set[str] = field(default_factory=set)
+    call_count: int = 0
+    min_dispatch_ns: float = 0.0
+    max_dispatch_ns: float = 0.0
+    mean_dispatch_ns: float = 0.0
+
+
+@dataclass
+class NodeRollup:
+    """Inclusive subtree aggregate returned by ``rollup_node_stats``.
+
+    Used only internally for bottom-up recursion; node fields are the
+    canonical read surface.
+    """
+
+    launches: int
+    total_duration_ns: float
+    min_dispatch_ns: float
+    max_dispatch_ns: float
 
 
 def simplify_kernel_name(full_kernel_name: str) -> str:
@@ -123,19 +159,56 @@ def parse_top_level_location(context_id: object) -> str:
     return location if ":" in location else "unknown:0"
 
 
-def rollup_node_stats(node: CallTreeNode) -> tuple[int, float]:
-    """Bottom-up rollup: set kernel_launches and total_duration_ms inclusive."""
-    launches = sum(stats.launches for stats in node.kernels.values())
-    duration_ns = sum(stats.total_duration_ns for stats in node.kernels.values())
+def rollup_node_stats(node: CallTreeNode) -> NodeRollup:
+    """Bottom-up rollup over this node and all descendants.
+
+    Sets inclusive fields on ``node``: ``kernel_launches``, ``total_duration_ms``,
+    ``min_dispatch_ns``, ``max_dispatch_ns``, ``mean_dispatch_ns``. Also
+    materializes ``call_count = len(node.invocation_ids)`` (local, but set here
+    so display code can read an int).
+
+    Returns a ``NodeRollup`` carrying the subtree aggregates used by the caller's
+    recursion. Kernels with no positive-duration dispatches (``min`` still
+    ``math.inf``) are skipped for min/max so they never leak a bogus zero
+    upward. The ``NodeRollup`` preserves the ``math.inf`` sentinel on
+    ``min_dispatch_ns`` when the subtree had no positive-duration dispatches,
+    so parents can skip the contribution via ``math.isinf`` in their own guard.
+    The node's displayed ``min_dispatch_ns`` is coerced to ``0.0`` for that
+    case, keeping the sentinel internal to the recursion.
+    """
+    launches = 0
+    total_duration_ns = 0.0
+    min_dispatch_ns = math.inf
+    max_dispatch_ns = 0.0
+
+    for stats in node.kernels.values():
+        launches += stats.launches
+        total_duration_ns += stats.total_duration_ns
+        if stats.launches > 0 and not math.isinf(stats.min_duration_ns):
+            min_dispatch_ns = min(min_dispatch_ns, stats.min_duration_ns)
+            max_dispatch_ns = max(max_dispatch_ns, stats.max_duration_ns)
 
     for child in node.children.values():
-        child_launches, child_duration_ns = rollup_node_stats(child)
-        launches += child_launches
-        duration_ns += child_duration_ns
+        child_rollup = rollup_node_stats(child)
+        launches += child_rollup.launches
+        total_duration_ns += child_rollup.total_duration_ns
+        if child_rollup.launches > 0 and not math.isinf(child_rollup.min_dispatch_ns):
+            min_dispatch_ns = min(min_dispatch_ns, child_rollup.min_dispatch_ns)
+            max_dispatch_ns = max(max_dispatch_ns, child_rollup.max_dispatch_ns)
 
     node.kernel_launches = launches
-    node.total_duration_ms = duration_ns * NS_TO_MS
-    return launches, duration_ns
+    node.total_duration_ms = total_duration_ns * NS_TO_MS
+    node.call_count = len(node.invocation_ids)
+    node.min_dispatch_ns = 0.0 if math.isinf(min_dispatch_ns) else min_dispatch_ns
+    node.max_dispatch_ns = max_dispatch_ns
+    node.mean_dispatch_ns = (total_duration_ns / launches) if launches > 0 else 0.0
+
+    return NodeRollup(
+        launches=launches,
+        total_duration_ns=total_duration_ns,
+        min_dispatch_ns=min_dispatch_ns,
+        max_dispatch_ns=max_dispatch_ns,
+    )
 
 
 def build_call_trees(
@@ -190,11 +263,20 @@ def build_call_trees(
             call_trees[location] = CallTreeNode(name=location)
         location_root = call_trees[location]
 
+        op_segments = op_path.split("/")
+        ctx_segments = (
+            str(context_id).split("/")
+            if has_context_id and context_id is not None and pd.notna(context_id)
+            else []
+        )
+
         current_node = location_root
-        for path_segment in op_path.split("/"):
+        for i, path_segment in enumerate(op_segments):
             if path_segment not in current_node.children:
                 current_node.children[path_segment] = CallTreeNode(name=path_segment)
             current_node = current_node.children[path_segment]
+            if i < len(ctx_segments):
+                current_node.invocation_ids.add("/".join(ctx_segments[: i + 1]))
 
         if kernel_name not in current_node.kernels:
             kernel_id = None
@@ -202,8 +284,12 @@ def build_call_trees(
             if pd.notna(kernel_id_value):
                 kernel_id = int(kernel_id_value)
             current_node.kernels[kernel_name] = KernelStats(kernel_id=kernel_id)
-        current_node.kernels[kernel_name].launches += 1
-        current_node.kernels[kernel_name].total_duration_ns += duration_ns
+        kstats = current_node.kernels[kernel_name]
+        kstats.launches += 1
+        kstats.total_duration_ns += duration_ns
+        if duration_ns > 0:
+            kstats.min_duration_ns = min(kstats.min_duration_ns, duration_ns)
+            kstats.max_duration_ns = max(kstats.max_duration_ns, duration_ns)
 
     for location_root in call_trees.values():
         rollup_node_stats(location_root)
@@ -236,6 +322,98 @@ def build_call_trees_with_kernel_ids(
         consolidated_with_ids["Kernel_Name"].str.strip().map(kernel_name_to_id)
     )
     return build_call_trees(consolidated_with_ids)
+
+
+OPERATOR_SUMMARY_COLUMNS: list[str] = [
+    "Operator",
+    "Location",
+    "Calls",
+    "Dispatches",
+    "Dispatches_Per_Call",
+    "Total_GPU_ms",
+    "Pct_Total_GPU",
+    "Mean_Per_Call_ms",
+    "Mean_Per_Dispatch_us",
+    "Min_Dispatch_us",
+    "Max_Dispatch_us",
+]
+
+
+def build_operator_summary(
+    call_trees: dict[str, CallTreeNode],
+) -> pd.DataFrame:
+    """Flatten per-location call trees into one row per invoked operator frame.
+
+    Column contract:
+
+    - ``Operator``: full ``"/"``-joined operator path.
+    - ``Location``: outermost Python ``file:line`` (the call tree's location-root
+      key). Operators nested under the same outer frame share this value.
+    - ``Calls``: distinct invocations of this specific frame
+      (``len(node.invocation_ids)``).
+    - ``Dispatches``: GPU kernel dispatches in this frame's subtree
+      (``node.kernel_launches``; one dispatch = one kernel invocation).
+    - ``Dispatches_Per_Call``: ``Dispatches / Calls`` (``NaN`` if ``Calls == 0``).
+    - ``Total_GPU_ms``: cumulative GPU time in the subtree
+      (``node.total_duration_ms``).
+    - ``Pct_Total_GPU``: share of total GPU time across all location roots
+      (``sum(root.total_duration_ms)``), counted once per dispatch regardless
+      of nesting depth. Because each row carries an *inclusive* subtree total,
+      percentages legitimately sum to more than 100% when operators are
+      nested; each row's value is the correct share for that frame's subtree.
+      ``0.0`` when the grand total is ``0``.
+    - ``Mean_Per_Call_ms``: ``Total_GPU_ms / Calls`` (``NaN`` if ``Calls == 0``).
+    - ``Mean_Per_Dispatch_us``, ``Min_Dispatch_us``, ``Max_Dispatch_us``:
+      per-kernel-dispatch stats from the subtree, converted from ns to us.
+
+    Row filter: location roots are skipped; a descendant node emits a row iff
+    ``kernel_launches > 0`` AND ``len(invocation_ids) > 0``.
+
+    Sort order: ``(Total_GPU_ms desc, Operator asc, Location asc)``.
+
+    Empty input returns a DataFrame with the full schema and zero rows.
+    """
+    rows: list[dict[str, Any]] = []
+
+    def walk(node: CallTreeNode, location: str, path_parts: list[str]) -> None:
+        for child_name, child in node.children.items():
+            full_path = path_parts + [child_name]
+            if child.kernel_launches > 0 and len(child.invocation_ids) > 0:
+                calls = len(child.invocation_ids)
+                dispatches = child.kernel_launches
+                total_gpu_ms = child.total_duration_ms
+                rows.append({
+                    "Operator": "/".join(full_path),
+                    "Location": location,
+                    "Calls": calls,
+                    "Dispatches": dispatches,
+                    "Dispatches_Per_Call": dispatches / calls,
+                    "Total_GPU_ms": total_gpu_ms,
+                    "Pct_Total_GPU": 0.0,  # filled in after grand total is known
+                    "Mean_Per_Call_ms": total_gpu_ms / calls,
+                    "Mean_Per_Dispatch_us": child.mean_dispatch_ns / 1000.0,
+                    "Min_Dispatch_us": child.min_dispatch_ns / 1000.0,
+                    "Max_Dispatch_us": child.max_dispatch_ns / 1000.0,
+                })
+            walk(child, location, full_path)
+
+    for location, root in call_trees.items():
+        walk(root, location, [])
+
+    if not rows:
+        return pd.DataFrame(columns=OPERATOR_SUMMARY_COLUMNS)
+
+    grand_total_ms = sum(root.total_duration_ms for root in call_trees.values())
+    if grand_total_ms > 0:
+        for r in rows:
+            r["Pct_Total_GPU"] = 100.0 * r["Total_GPU_ms"] / grand_total_ms
+
+    df = pd.DataFrame(rows, columns=OPERATOR_SUMMARY_COLUMNS)
+    return df.sort_values(
+        by=["Total_GPU_ms", "Operator", "Location"],
+        ascending=[False, True, True],
+        ignore_index=True,
+    )
 
 
 @demarcate

--- a/projects/rocprofiler-compute/src/utils/utils_analysis.py
+++ b/projects/rocprofiler-compute/src/utils/utils_analysis.py
@@ -62,15 +62,14 @@ def format_bw_human_readable(
 class KernelStats:
     """Aggregated kernel launch stats for one kernel name.
 
-    ``min_duration_ns`` starts at ``math.inf`` and is only lowered by dispatches
-    with a positive duration; callers must treat ``math.isinf(min_duration_ns)``
-    as "no meaningful minimum recorded".
+    min_duration_ns and max_duration_ns are None until a dispatch with a
+    non-zero duration is observed.
     """
 
     launches: int = 0
     total_duration_ns: float = 0.0
-    min_duration_ns: float = math.inf
-    max_duration_ns: float = 0.0
+    min_duration_ns: Optional[float] = None
+    max_duration_ns: Optional[float] = None
     kernel_id: Optional[int] = None
 
 
@@ -78,19 +77,15 @@ class KernelStats:
 class CallTreeNode:
     """A node in the operator call tree.
 
-    Fields split by semantics:
+    Local to this frame:
+      - invocation_ids: distinct Context_Id prefixes at this frame's depth.
+      - call_count: derived as len(invocation_ids); see the property below.
 
-    Local to this frame (not rolled up from descendants):
-      - ``invocation_ids``: distinct ``Context_Id`` prefixes at this frame's
-        depth, one per time the frame was invoked.
-      - ``call_count``: equals ``len(invocation_ids)``. Materialized by
-        ``rollup_node_stats`` so display code can read an int directly.
-
-    Inclusive (rolled up over this node plus all descendants):
-      - ``kernel_launches``: kernel dispatches in the subtree.
-      - ``total_duration_ms``: cumulative GPU time in the subtree.
-      - ``min_dispatch_ns`` / ``max_dispatch_ns`` / ``mean_dispatch_ns``:
-        per-kernel-dispatch duration extremes and mean over the subtree.
+    Inclusive over this node plus all descendants:
+      - kernel_launches: kernel dispatches in the subtree.
+      - total_duration_ms: cumulative GPU time in the subtree.
+      - min_dispatch_ns / max_dispatch_ns / mean_dispatch_ns: per-kernel-dispatch
+        duration stats. None when no non-zero-duration dispatch is in the subtree.
     """
 
     name: str
@@ -99,24 +94,23 @@ class CallTreeNode:
     kernel_launches: int = 0
     total_duration_ms: float = 0.0
     invocation_ids: set[str] = field(default_factory=set)
-    call_count: int = 0
-    min_dispatch_ns: float = 0.0
-    max_dispatch_ns: float = 0.0
-    mean_dispatch_ns: float = 0.0
+    min_dispatch_ns: Optional[float] = None
+    max_dispatch_ns: Optional[float] = None
+    mean_dispatch_ns: Optional[float] = None
+
+    @property
+    def call_count(self) -> int:
+        return len(self.invocation_ids)
 
 
 @dataclass
 class NodeRollup:
-    """Inclusive subtree aggregate returned by ``rollup_node_stats``.
-
-    Used only internally for bottom-up recursion; node fields are the
-    canonical read surface.
-    """
+    """Inclusive subtree aggregate returned by rollup_node_stats."""
 
     launches: int
     total_duration_ns: float
-    min_dispatch_ns: float
-    max_dispatch_ns: float
+    min_dispatch_ns: Optional[float]
+    max_dispatch_ns: Optional[float]
 
 
 def simplify_kernel_name(full_kernel_name: str) -> str:
@@ -162,52 +156,45 @@ def parse_top_level_location(context_id: object) -> str:
 def rollup_node_stats(node: CallTreeNode) -> NodeRollup:
     """Bottom-up rollup over this node and all descendants.
 
-    Sets inclusive fields on ``node``: ``kernel_launches``, ``total_duration_ms``,
-    ``min_dispatch_ns``, ``max_dispatch_ns``, ``mean_dispatch_ns``. Also
-    materializes ``call_count = len(node.invocation_ids)`` (local, but set here
-    so display code can read an int).
+    Sets inclusive fields on node: kernel_launches, total_duration_ms,
+    min_dispatch_ns, max_dispatch_ns, mean_dispatch_ns.
 
-    Returns a ``NodeRollup`` carrying the subtree aggregates used by the caller's
-    recursion. Kernels with no positive-duration dispatches (``min`` still
-    ``math.inf``) are skipped for min/max so they never leak a bogus zero
-    upward. The ``NodeRollup`` preserves the ``math.inf`` sentinel on
-    ``min_dispatch_ns`` when the subtree had no positive-duration dispatches,
-    so parents can skip the contribution via ``math.isinf`` in their own guard.
-    The node's displayed ``min_dispatch_ns`` is coerced to ``0.0`` for that
-    case, keeping the sentinel internal to the recursion.
+    Subtrees with no non-zero-duration dispatch leave min/max/mean as None so
+    callers can render N/A rather than a misleading 0.
     """
     launches = 0
     total_duration_ns = 0.0
-    min_dispatch_ns = math.inf
-    max_dispatch_ns = 0.0
+    mins: list[float] = []
+    maxes: list[float] = []
 
     for stats in node.kernels.values():
         launches += stats.launches
         total_duration_ns += stats.total_duration_ns
-        if stats.launches > 0 and not math.isinf(stats.min_duration_ns):
-            min_dispatch_ns = min(min_dispatch_ns, stats.min_duration_ns)
-            max_dispatch_ns = max(max_dispatch_ns, stats.max_duration_ns)
+        if stats.min_duration_ns is not None:
+            mins.append(stats.min_duration_ns)
+        if stats.max_duration_ns is not None:
+            maxes.append(stats.max_duration_ns)
 
     for child in node.children.values():
         child_rollup = rollup_node_stats(child)
         launches += child_rollup.launches
         total_duration_ns += child_rollup.total_duration_ns
-        if child_rollup.launches > 0 and not math.isinf(child_rollup.min_dispatch_ns):
-            min_dispatch_ns = min(min_dispatch_ns, child_rollup.min_dispatch_ns)
-            max_dispatch_ns = max(max_dispatch_ns, child_rollup.max_dispatch_ns)
+        if child_rollup.min_dispatch_ns is not None:
+            mins.append(child_rollup.min_dispatch_ns)
+        if child_rollup.max_dispatch_ns is not None:
+            maxes.append(child_rollup.max_dispatch_ns)
 
     node.kernel_launches = launches
     node.total_duration_ms = total_duration_ns * NS_TO_MS
-    node.call_count = len(node.invocation_ids)
-    node.min_dispatch_ns = 0.0 if math.isinf(min_dispatch_ns) else min_dispatch_ns
-    node.max_dispatch_ns = max_dispatch_ns
-    node.mean_dispatch_ns = (total_duration_ns / launches) if launches > 0 else 0.0
+    node.min_dispatch_ns = min(mins, default=None)
+    node.max_dispatch_ns = max(maxes, default=None)
+    node.mean_dispatch_ns = total_duration_ns / launches if launches > 0 else None
 
     return NodeRollup(
         launches=launches,
         total_duration_ns=total_duration_ns,
-        min_dispatch_ns=min_dispatch_ns,
-        max_dispatch_ns=max_dispatch_ns,
+        min_dispatch_ns=node.min_dispatch_ns,
+        max_dispatch_ns=node.max_dispatch_ns,
     )
 
 
@@ -288,8 +275,10 @@ def build_call_trees(
         kstats.launches += 1
         kstats.total_duration_ns += duration_ns
         if duration_ns > 0:
-            kstats.min_duration_ns = min(kstats.min_duration_ns, duration_ns)
-            kstats.max_duration_ns = max(kstats.max_duration_ns, duration_ns)
+            if kstats.min_duration_ns is None or duration_ns < kstats.min_duration_ns:
+                kstats.min_duration_ns = duration_ns
+            if kstats.max_duration_ns is None or duration_ns > kstats.max_duration_ns:
+                kstats.max_duration_ns = duration_ns
 
     for location_root in call_trees.values():
         rollup_node_stats(location_root)
@@ -324,62 +313,70 @@ def build_call_trees_with_kernel_ids(
     return build_call_trees(consolidated_with_ids)
 
 
-OPERATOR_SUMMARY_COLUMNS: list[str] = [
-    "Operator",
-    "Location",
-    "Calls",
-    "Dispatches",
-    "Dispatches_Per_Call",
-    "Total_GPU_ms",
-    "Pct_Total_GPU",
-    "Mean_Per_Call_ms",
-    "Mean_Per_Dispatch_us",
-    "Min_Dispatch_us",
-    "Max_Dispatch_us",
-]
-
-
 def build_operator_summary(
     call_trees: dict[str, CallTreeNode],
 ) -> pd.DataFrame:
-    """Flatten per-location call trees into one row per invoked operator frame.
+    """Build a one-row-per-operator summary table from the call trees.
 
-    Column contract:
+    Each row describes one operator (e.g. aten::matmul) that ran at least
+    one GPU kernel. All time values are in milliseconds.
 
-    - ``Operator``: full ``"/"``-joined operator path.
-    - ``Location``: outermost Python ``file:line`` (the call tree's location-root
-      key). Operators nested under the same outer frame share this value.
-    - ``Calls``: distinct invocations of this specific frame
-      (``len(node.invocation_ids)``).
-    - ``Dispatches``: GPU kernel dispatches in this frame's subtree
-      (``node.kernel_launches``; one dispatch = one kernel invocation).
-    - ``Dispatches_Per_Call``: ``Dispatches / Calls`` (``NaN`` if ``Calls == 0``).
-    - ``Total_GPU_ms``: cumulative GPU time in the subtree
-      (``node.total_duration_ms``).
-    - ``Pct_Total_GPU``: share of total GPU time across all location roots
-      (``sum(root.total_duration_ms)``), counted once per dispatch regardless
-      of nesting depth. Because each row carries an *inclusive* subtree total,
-      percentages legitimately sum to more than 100% when operators are
-      nested; each row's value is the correct share for that frame's subtree.
-      ``0.0`` when the grand total is ``0``.
-    - ``Mean_Per_Call_ms``: ``Total_GPU_ms / Calls`` (``NaN`` if ``Calls == 0``).
-    - ``Mean_Per_Dispatch_us``, ``Min_Dispatch_us``, ``Max_Dispatch_us``:
-      per-kernel-dispatch stats from the subtree, converted from ns to us.
+    Columns:
 
-    Row filter: location roots are skipped; a descendant node emits a row iff
-    ``kernel_launches > 0`` AND ``len(invocation_ids) > 0``.
+    - Operator: full path of the operator (e.g. "aten::matmul/aten::mm").
 
-    Sort order: ``(Total_GPU_ms desc, Operator asc, Location asc)``.
+    - Location: Python file:line where the outermost caller lives.
 
-    Empty input returns a DataFrame with the full schema and zero rows.
+    - Calls: how many times this operator was invoked. NaN when the trace
+      did not include Context_Id information to count invocations.
+
+    - Dispatches: how many GPU kernels ran while this operator was on the
+      call stack (kernels launched by operators it called also count).
+
+    - Dispatches_Per_Call: Dispatches divided by Calls. NaN when Calls is
+      unknown.
+
+    - Total_GPU: total GPU time spent while this operator was on the call
+      stack.
+
+    - Pct_Total_GPU: how much of the workload's total GPU time fell while
+      this operator was on the call stack. The same kernel time gets
+      counted for an operator and for any operator that called it, so the
+      column can add up to more than 100%. NaN when no GPU time was
+      recorded at all.
+
+    - Mean_Per_Call: average GPU time per call to this operator.
+
+    - Mean_Per_Dispatch, Min_Dispatch, Max_Dispatch: per-kernel timings
+      across kernels launched while this operator was on the call stack.
+
+    Operators that ran no GPU kernels and the synthetic location-root nodes
+    are skipped. Empty input returns an empty DataFrame with the full
+    column list.
+
+    Sorted by Total_GPU descending, then Operator and Location ascending.
     """
+    columns = [
+        "Operator",
+        "Location",
+        "Calls",
+        "Dispatches",
+        "Dispatches_Per_Call",
+        "Total_GPU",
+        "Pct_Total_GPU",
+        "Mean_Per_Call",
+        "Mean_Per_Dispatch",
+        "Min_Dispatch",
+        "Max_Dispatch",
+    ]
     rows: list[dict[str, Any]] = []
 
     def walk(node: CallTreeNode, location: str, path_parts: list[str]) -> None:
         for child_name, child in node.children.items():
             full_path = path_parts + [child_name]
-            if child.kernel_launches > 0 and len(child.invocation_ids) > 0:
-                calls = len(child.invocation_ids)
+            if child.kernel_launches > 0:
+                has_calls = len(child.invocation_ids) > 0
+                calls = len(child.invocation_ids) if has_calls else float("nan")
                 dispatches = child.kernel_launches
                 total_gpu_ms = child.total_duration_ms
                 rows.append({
@@ -387,13 +384,29 @@ def build_operator_summary(
                     "Location": location,
                     "Calls": calls,
                     "Dispatches": dispatches,
-                    "Dispatches_Per_Call": dispatches / calls,
-                    "Total_GPU_ms": total_gpu_ms,
-                    "Pct_Total_GPU": 0.0,  # filled in after grand total is known
-                    "Mean_Per_Call_ms": total_gpu_ms / calls,
-                    "Mean_Per_Dispatch_us": child.mean_dispatch_ns / 1000.0,
-                    "Min_Dispatch_us": child.min_dispatch_ns / 1000.0,
-                    "Max_Dispatch_us": child.max_dispatch_ns / 1000.0,
+                    "Dispatches_Per_Call": (
+                        dispatches / calls if has_calls else float("nan")
+                    ),
+                    "Total_GPU": total_gpu_ms,
+                    "Pct_Total_GPU": float("nan"),  # filled in if grand total > 0
+                    "Mean_Per_Call": (
+                        total_gpu_ms / calls if has_calls else float("nan")
+                    ),
+                    "Mean_Per_Dispatch": (
+                        child.mean_dispatch_ns * NS_TO_MS
+                        if child.mean_dispatch_ns is not None
+                        else float("nan")
+                    ),
+                    "Min_Dispatch": (
+                        child.min_dispatch_ns * NS_TO_MS
+                        if child.min_dispatch_ns is not None
+                        else float("nan")
+                    ),
+                    "Max_Dispatch": (
+                        child.max_dispatch_ns * NS_TO_MS
+                        if child.max_dispatch_ns is not None
+                        else float("nan")
+                    ),
                 })
             walk(child, location, full_path)
 
@@ -401,16 +414,16 @@ def build_operator_summary(
         walk(root, location, [])
 
     if not rows:
-        return pd.DataFrame(columns=OPERATOR_SUMMARY_COLUMNS)
+        return pd.DataFrame(columns=columns)
 
     grand_total_ms = sum(root.total_duration_ms for root in call_trees.values())
     if grand_total_ms > 0:
         for r in rows:
-            r["Pct_Total_GPU"] = 100.0 * r["Total_GPU_ms"] / grand_total_ms
+            r["Pct_Total_GPU"] = 100.0 * r["Total_GPU"] / grand_total_ms
 
-    df = pd.DataFrame(rows, columns=OPERATOR_SUMMARY_COLUMNS)
+    df = pd.DataFrame(rows, columns=columns)
     return df.sort_values(
-        by=["Total_GPU_ms", "Operator", "Location"],
+        by=["Total_GPU", "Operator", "Location"],
         ascending=[False, True, True],
         ignore_index=True,
     )

--- a/projects/rocprofiler-compute/tests/test_analyze_workloads.py
+++ b/projects/rocprofiler-compute/tests/test_analyze_workloads.py
@@ -1906,8 +1906,8 @@ def test_analyze_torch_trace_list_operators_MI350(
     assert "torch.nn.functional.relu" in output
     assert "torch.nn.functional.linear" in output
     assert "torch.ones_like" in output
-    assert "kernel_launches:" in output
-    assert "total_duration:" in output
+    assert "dispatches:" in output
+    assert "total:" in output
 
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
@@ -1931,8 +1931,8 @@ def test_analyze_torch_trace_filter_operator_MI350(
 
     assert "Matched PyTorch Operators:" in output
     assert "relu" in output
-    assert "kernel_launches:" in output
-    assert "total_duration:" in output
+    assert "dispatches:" in output
+    assert "total:" in output
 
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
@@ -2003,7 +2003,7 @@ def test_analyze_torch_trace_hierarchy_path_MI350(
 
     assert "Matched PyTorch Operators:" in output
     assert "torch.relu" in output
-    assert "kernel_launches:" in output
+    assert "dispatches:" in output
 
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
@@ -2027,6 +2027,6 @@ def test_analyze_torch_trace_torch_prefix_MI350(
 
     assert "Matched PyTorch Operators:" in output
     assert "torch.relu" in output
-    assert "kernel_launches:" in output
+    assert "dispatches:" in output
 
     test_utils.clean_output_dir(config["cleanup"], workload_dir)

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -2970,7 +2970,7 @@ def test_torch_trace_profile(
 
     # 14. Source locations sorted by descending total duration
     location_durations = re.findall(
-        r"^(\S+:\d+)\s+\(dispatches:\s+\d+,\s+total:\s+([\d.]+)\s+(ms|us)\)",
+        r"^(\S+:\d+)\s+\(dispatches:\s+\d+,\s+total:\s+([\d.]+)\s+(ms|us)",
         list_output,
         re.MULTILINE,
     )

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -2950,12 +2950,12 @@ def test_torch_trace_profile(
 
     # 10. Source-location grouping (file:line headers)
     location_headers = re.findall(
-        r"^(\S+:\d+)\s+\(kernel_launches:", list_output, re.MULTILINE
+        r"^(\S+:\d+)\s+\(dispatches:", list_output, re.MULTILINE
     )
     assert location_headers, "No source-location headers found in output"
 
     # 11. Aggregated stats on tree nodes
-    assert re.search(r"\(kernel_launches:\s+\d+,\s+total_duration:", list_output), (
+    assert re.search(r"\(dispatches:\s+\d+,\s+total:", list_output), (
         "No aggregated stats found in output"
     )
 
@@ -2964,13 +2964,13 @@ def test_torch_trace_profile(
     assert kernel_ids, "No kernel IDs found in output"
 
     # 13. Kernel launch durations
-    assert re.search(r"kernel_launches:\s+\d+,\s+total_duration:", list_output), (
+    assert re.search(r"dispatches:\s+\d+,\s+total:", list_output), (
         "No kernel duration info in output"
     )
 
     # 14. Source locations sorted by descending total duration
     location_durations = re.findall(
-        r"^(\S+:\d+)\s+\(kernel_launches:\s+\d+,\s+total_duration:\s+([\d.]+)\s+(ms|us)\)",
+        r"^(\S+:\d+)\s+\(dispatches:\s+\d+,\s+total:\s+([\d.]+)\s+(ms|us)\)",
         list_output,
         re.MULTILINE,
     )
@@ -3036,8 +3036,8 @@ def test_torch_trace_profile(
     assert "Matched PyTorch Operators" in out_exact, (
         "Expected 'Matched PyTorch Operators' header in --torch-operator output"
     )
-    assert "kernel_launches" in out_exact, (
-        "Expected call tree with kernel_launches stats in --torch-operator output"
+    assert "dispatches" in out_exact, (
+        "Expected call tree with dispatches stats in --torch-operator output"
     )
 
     # 18. Glob wildcard pattern (*relu) matches the relu operator
@@ -3052,7 +3052,7 @@ def test_torch_trace_profile(
     ])
     assert rc_glob == 0, "Analyze with --torch-operator *relu failed"
     out_glob = capsys.readouterr().out
-    assert "kernel_launches" in out_glob, (
+    assert "dispatches" in out_glob, (
         "Glob pattern *relu should match relu operator and render call tree"
     )
 
@@ -3068,7 +3068,7 @@ def test_torch_trace_profile(
     ])
     assert rc_all == 0, "Analyze with --torch-operator all failed"
     out_all = capsys.readouterr().out
-    assert "kernel_launches" in out_all, "'all' keyword should match operators"
+    assert "dispatches" in out_all, "'all' keyword should match operators"
 
     # 20. --torch-operator + -k intersection succeeds and renders call tree
     capsys.readouterr()

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -6,6 +6,7 @@ import inspect
 import io
 import locale
 import logging
+import math
 import os
 import re
 import shutil
@@ -21,14 +22,18 @@ import utils.utils_analysis as utils_analysis
 import utils.utils_common as utils_common
 import utils.utils_profile as utils_profile
 from utils.tty import (
-    format_stats,
+    format_duration,
+    format_node_stats,
     print_operator_node,
     show_call_tree,
+    show_operator_summary,
 )
 from utils.utils_analysis import (
     CallTreeNode,
     KernelStats,
+    NodeRollup,
     build_call_trees,
+    build_operator_summary,
     parse_top_level_location,
     rollup_node_stats,
 )
@@ -6936,22 +6941,81 @@ def test_parse_location_no_colon():
     assert parse_top_level_location("10@mainpy") == "unknown:0"
 
 
-def test_format_stats_microseconds():
-    assert "us" in format_stats(1, 0.005)
+def test_format_duration_microseconds_below_threshold():
+    assert format_duration(0.005) == "5.00 us"
 
 
-def test_format_stats_milliseconds():
-    assert "1.50 ms" in format_stats(1, 1.5)
+def test_format_duration_milliseconds_above_threshold():
+    assert format_duration(1.5) == "1.50 ms"
 
 
-def test_format_stats_boundary():
-    assert "ms" in format_stats(1, 0.01)
+def test_format_duration_boundary_value_is_milliseconds():
+    assert format_duration(0.01) == "0.01 ms"
 
 
-def test_format_stats_basic():
-    result = format_stats(3, 1.5)
-    assert "dispatches: 3" in result
-    assert "total: 1.50 ms" in result
+def test_format_duration_none_renders_na():
+    assert format_duration(None) == "N/A"
+
+
+def test_format_duration_nan_renders_na():
+    assert format_duration(float("nan")) == "N/A"
+
+
+def test_kernel_stats_defaults_min_max_to_none():
+    stats = KernelStats()
+    assert stats.min_duration_ns is None
+    assert stats.max_duration_ns is None
+
+
+def test_call_tree_node_defaults_dispatch_stats_to_none():
+    node = CallTreeNode(name="x")
+    assert node.min_dispatch_ns is None
+    assert node.max_dispatch_ns is None
+    assert node.mean_dispatch_ns is None
+
+
+def test_call_tree_node_call_count_is_property_of_invocation_ids():
+    node = CallTreeNode(name="x")
+    assert node.call_count == 0
+    node.invocation_ids.add("ctx1")
+    node.invocation_ids.add("ctx2")
+    assert node.call_count == 2
+
+
+def test_format_node_stats_omits_calls_when_no_invocation_ids():
+    node = CallTreeNode(name="x")
+    node.kernel_launches = 1
+    node.total_duration_ms = 1.0
+    node.mean_dispatch_ns = 1_000_000.0
+    node.min_dispatch_ns = 1_000_000.0
+    node.max_dispatch_ns = 1_000_000.0
+    rendered = format_node_stats(node)
+    assert "calls:" not in rendered
+    assert "dispatches: 1" in rendered
+    assert "total: 1.00 ms" in rendered
+
+
+def test_format_node_stats_includes_calls_when_invocation_ids_present():
+    node = CallTreeNode(name="x")
+    node.invocation_ids.add("ctx1")
+    node.invocation_ids.add("ctx2")
+    node.kernel_launches = 4
+    node.total_duration_ms = 2.0
+    node.mean_dispatch_ns = 500_000.0
+    node.min_dispatch_ns = 500_000.0
+    node.max_dispatch_ns = 500_000.0
+    rendered = format_node_stats(node)
+    assert "calls: 2" in rendered
+    assert "dispatches: 4" in rendered
+
+
+def test_format_node_stats_renders_na_when_dispatch_stats_missing():
+    node = CallTreeNode(name="x")
+    node.kernel_launches = 0
+    rendered = format_node_stats(node)
+    assert "dispatch_mean: N/A" in rendered
+    assert "dispatch_min: N/A" in rendered
+    assert "dispatch_max: N/A" in rendered
 
 
 def test_rollup_leaf_node():
@@ -6961,6 +7025,39 @@ def test_rollup_leaf_node():
     assert rollup.launches == 2
     assert rollup.total_duration_ns == 1000.0
     assert node.kernel_launches == 2
+
+
+def test_rollup_leaf_node_with_no_min_max_returns_none():
+    node = CallTreeNode(name="leaf")
+    node.kernels["kern"] = KernelStats(launches=1, total_duration_ns=0.0)
+    rollup = rollup_node_stats(node)
+    assert isinstance(rollup, NodeRollup)
+    assert rollup.min_dispatch_ns is None
+    assert rollup.max_dispatch_ns is None
+    assert node.min_dispatch_ns is None
+    assert node.max_dispatch_ns is None
+    assert node.mean_dispatch_ns == 0.0
+
+
+def test_rollup_leaf_node_with_zero_launches_has_mean_none():
+    node = CallTreeNode(name="leaf")
+    rollup = rollup_node_stats(node)
+    assert rollup.launches == 0
+    assert node.mean_dispatch_ns is None
+
+
+def test_rollup_propagates_min_max_from_kernel_stats():
+    node = CallTreeNode(name="leaf")
+    node.kernels["k"] = KernelStats(
+        launches=2,
+        total_duration_ns=3000.0,
+        min_duration_ns=1000.0,
+        max_duration_ns=2000.0,
+    )
+    rollup_node_stats(node)
+    assert node.min_dispatch_ns == 1000.0
+    assert node.max_dispatch_ns == 2000.0
+    assert node.mean_dispatch_ns == 1500.0
 
 
 def test_rollup_parent_rolls_up_children():
@@ -7207,6 +7304,202 @@ def test_print_operator_node_long_kernel_wraps(capsys):
     ]
     assert wrapped_kernel_lines
     assert not any(line.strip().startswith("(id 7)") for line in output_lines)
+
+
+# ---------------------------------------------------------------------------
+# build_operator_summary
+# ---------------------------------------------------------------------------
+
+
+_OPERATOR_SUMMARY_COLUMNS = [
+    "Operator",
+    "Location",
+    "Calls",
+    "Dispatches",
+    "Dispatches_Per_Call",
+    "Total_GPU",
+    "Pct_Total_GPU",
+    "Mean_Per_Call",
+    "Mean_Per_Dispatch",
+    "Min_Dispatch",
+    "Max_Dispatch",
+]
+
+
+def _build_summary_from_dataframe(rows):
+    call_trees = build_call_trees(pd.DataFrame(rows))
+    return build_operator_summary(call_trees)
+
+
+def test_build_operator_summary_empty_input_returns_empty_with_full_schema():
+    summary = build_operator_summary({})
+    assert list(summary.columns) == _OPERATOR_SUMMARY_COLUMNS
+    assert summary.empty
+
+
+def test_build_operator_summary_skips_synthetic_location_root():
+    summary = _build_summary_from_dataframe([
+        {
+            "Operator_Name": "op_a",
+            "Kernel_Name": "kern",
+            "Context_Id": "10@f.py:1",
+            "Start_Timestamp_kernel": 0,
+            "End_Timestamp_kernel": 1_000_000,
+        }
+    ])
+    assert "f.py:1" not in summary["Operator"].tolist()
+    assert "op_a" in summary["Operator"].tolist()
+
+
+def test_build_operator_summary_row_values_for_single_dispatch():
+    summary = _build_summary_from_dataframe([
+        {
+            "Operator_Name": "op_a",
+            "Kernel_Name": "kern",
+            "Context_Id": "10@f.py:1",
+            "Start_Timestamp_kernel": 0,
+            "End_Timestamp_kernel": 2_000_000,
+        }
+    ])
+    row = summary.loc[summary["Operator"] == "op_a"].iloc[0]
+    assert row["Location"] == "f.py:1"
+    assert row["Calls"] == 1
+    assert row["Dispatches"] == 1
+    assert row["Dispatches_Per_Call"] == 1.0
+    assert row["Total_GPU"] == pytest.approx(2.0)
+    assert row["Pct_Total_GPU"] == pytest.approx(100.0)
+    assert row["Mean_Per_Call"] == pytest.approx(2.0)
+    assert row["Mean_Per_Dispatch"] == pytest.approx(2.0)
+    assert row["Min_Dispatch"] == pytest.approx(2.0)
+    assert row["Max_Dispatch"] == pytest.approx(2.0)
+
+
+def test_build_operator_summary_sort_by_total_descending():
+    summary = _build_summary_from_dataframe([
+        {
+            "Operator_Name": "small_op",
+            "Kernel_Name": "kern",
+            "Context_Id": "10@f.py:1",
+            "Start_Timestamp_kernel": 0,
+            "End_Timestamp_kernel": 1_000_000,
+        },
+        {
+            "Operator_Name": "big_op",
+            "Kernel_Name": "kern",
+            "Context_Id": "20@f.py:2",
+            "Start_Timestamp_kernel": 0,
+            "End_Timestamp_kernel": 10_000_000,
+        },
+    ])
+    operators_in_order = summary["Operator"].tolist()
+    assert operators_in_order.index("big_op") < operators_in_order.index("small_op")
+
+
+def test_build_operator_summary_pct_total_gpu_sums_to_100_at_top_level():
+    summary = _build_summary_from_dataframe([
+        {
+            "Operator_Name": "op_a",
+            "Kernel_Name": "kern",
+            "Context_Id": "10@f.py:1",
+            "Start_Timestamp_kernel": 0,
+            "End_Timestamp_kernel": 3_000_000,
+        },
+        {
+            "Operator_Name": "op_b",
+            "Kernel_Name": "kern",
+            "Context_Id": "20@f.py:2",
+            "Start_Timestamp_kernel": 0,
+            "End_Timestamp_kernel": 1_000_000,
+        },
+    ])
+    op_a_pct = summary.loc[summary["Operator"] == "op_a", "Pct_Total_GPU"].iloc[0]
+    op_b_pct = summary.loc[summary["Operator"] == "op_b", "Pct_Total_GPU"].iloc[0]
+    assert op_a_pct == pytest.approx(75.0)
+    assert op_b_pct == pytest.approx(25.0)
+
+
+def test_build_operator_summary_pct_total_gpu_is_nan_when_grand_total_zero():
+    root = CallTreeNode(name="f.py:1")
+    op = CallTreeNode(name="op")
+    op.kernel_launches = 1
+    op.total_duration_ms = 0.0
+    op.invocation_ids.add("ctx")
+    root.children["op"] = op
+    summary = build_operator_summary({"f.py:1": root})
+    pct = summary.loc[summary["Operator"] == "op", "Pct_Total_GPU"].iloc[0]
+    assert math.isnan(pct)
+
+
+def test_build_operator_summary_min_max_mean_are_nan_when_no_dispatch_stats():
+    root = CallTreeNode(name="f.py:1")
+    op = CallTreeNode(name="op")
+    op.kernel_launches = 1
+    op.total_duration_ms = 5.0
+    op.invocation_ids.add("ctx")
+    root.children["op"] = op
+    summary = build_operator_summary({"f.py:1": root})
+    row = summary.loc[summary["Operator"] == "op"].iloc[0]
+    assert math.isnan(row["Min_Dispatch"])
+    assert math.isnan(row["Max_Dispatch"])
+    assert math.isnan(row["Mean_Per_Dispatch"])
+
+
+def test_build_operator_summary_calls_nan_when_no_invocation_ids():
+    root = CallTreeNode(name="f.py:1")
+    op = CallTreeNode(name="torch.ops.x")
+    op.kernel_launches = 2
+    op.total_duration_ms = 4.0
+    op.mean_dispatch_ns = 2_000_000.0
+    op.min_dispatch_ns = 2_000_000.0
+    op.max_dispatch_ns = 2_000_000.0
+    root.children["torch.ops.x"] = op
+    summary = build_operator_summary({"f.py:1": root})
+    row = summary.loc[summary["Operator"] == "torch.ops.x"].iloc[0]
+    assert math.isnan(row["Calls"])
+    assert math.isnan(row["Dispatches_Per_Call"])
+    assert math.isnan(row["Mean_Per_Call"])
+    assert row["Dispatches"] == 2
+
+
+# ---------------------------------------------------------------------------
+# show_operator_summary
+# ---------------------------------------------------------------------------
+
+
+def test_show_operator_summary_empty_prints_no_dispatches_message(capsys):
+    show_operator_summary(pd.DataFrame(columns=_OPERATOR_SUMMARY_COLUMNS))
+    output = capsys.readouterr().out
+    assert "no operators with recorded dispatches" in output
+
+
+def test_show_operator_summary_renders_per_cell_unit_suffix(capsys):
+    summary = _build_summary_from_dataframe([
+        {
+            "Operator_Name": "op_a",
+            "Kernel_Name": "kern",
+            "Context_Id": "10@f.py:1",
+            "Start_Timestamp_kernel": 0,
+            "End_Timestamp_kernel": 2_000_000,
+        }
+    ])
+    show_operator_summary(summary)
+    output = capsys.readouterr().out
+    assert "ms" in output or "us" in output
+    assert "Operator" in output
+    assert "Total" in output
+
+
+def test_show_operator_summary_renders_na_for_nan_cells(capsys):
+    root = CallTreeNode(name="f.py:1")
+    op = CallTreeNode(name="op")
+    op.kernel_launches = 1
+    op.total_duration_ms = 0.0
+    op.invocation_ids.add("ctx")
+    root.children["op"] = op
+    summary = build_operator_summary({"f.py:1": root})
+    show_operator_summary(summary)
+    output = capsys.readouterr().out
+    assert "N/A" in output
 
 
 # =============================================================================

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -6950,16 +6950,16 @@ def test_format_stats_boundary():
 
 def test_format_stats_basic():
     result = format_stats(3, 1.5)
-    assert "kernel_launches: 3" in result
-    assert "total_duration: 1.50 ms" in result
+    assert "dispatches: 3" in result
+    assert "total: 1.50 ms" in result
 
 
 def test_rollup_leaf_node():
     node = CallTreeNode(name="leaf")
     node.kernels["kern_a"] = KernelStats(launches=2, total_duration_ns=1000.0)
-    launches, dur_ns = rollup_node_stats(node)
-    assert launches == 2
-    assert dur_ns == 1000.0
+    rollup = rollup_node_stats(node)
+    assert rollup.launches == 2
+    assert rollup.total_duration_ns == 1000.0
     assert node.kernel_launches == 2
 
 
@@ -7126,7 +7126,7 @@ def test_show_call_tree_prints_location_and_stats(capsys):
     show_call_tree({"main.py:10": root})
     output = capsys.readouterr().out
     assert "main.py:10" in output
-    assert "kernel_launches: 1" in output
+    assert "dispatches: 1" in output
     assert "kern" in output
 
 
@@ -7166,7 +7166,7 @@ def test_print_operator_node_branching_shows_stats(capsys):
     node.kernels["k2"] = KernelStats(launches=1, total_duration_ns=2_500_000.0)
     print_operator_node(node)
     output = capsys.readouterr().out
-    assert "kernel_launches: 2" in output
+    assert "dispatches: 2" in output
     assert "k1" in output
     assert "k2" in output
 
@@ -7180,7 +7180,7 @@ def test_print_operator_node_non_branching_omits_stats(capsys):
     output = capsys.readouterr().out
     lines = output.strip().split("\n")
     assert "└─ single" in lines[0]
-    assert "kernel_launches" not in lines[0]
+    assert "dispatches" not in lines[0]
 
 
 def test_print_operator_node_long_kernel_wraps(capsys):


### PR DESCRIPTION
## Motivation

The existing --list-torch-operators / --torch-operator tree reported only kernel_launches and total duration per node, making it hard to spot hot operators or see per-dispatch variance. This branch adds per-operator call counts, per-dispatch duration extremes, and a flat sortable summary table printed alongside the tree.

## Technical Details

1. src/utils/utils_analysis.py — CallTreeNode and KernelStats extended with per-call/per-dispatch stats; new NodeRollup helper for subtree aggregates.
2. src/utils/utils_analysis.py — build_call_trees and rollup_node_stats updated to populate the new fields; new build_operator_summary flattens trees into one row per operator.
3. src/utils/tty.py (wired via src/rocprof_compute_analyze/analysis_cli.py) — call tree prints the new stats per node; new show_operator_summary renders a bordered table alongside the tree.

## Torch operator analysis output
### Before
```
================================================================================
Matched PyTorch Operators: torch.nn.functional.conv2d
Grouped by source location, sorted by total GPU kernel duration.
================================================================================

pytorch_inference_example.py:88 (kernel_launches: 800, total_duration: 62.58 ms)
└─ nn.Module.SimpleCNN.forward
   └─ nn.Module.Sequential.forward
      └─ nn.Module.Conv2d.forward
         └─ torch.nn.functional.conv2d (kernel_launches: 800, total_duration: 62.58 ms)
            ├─ miopenSp3AsmConv_v30_3_1_gfx9_fp32_f2x3_stride1 (id 0) (kernel_launches: 300, total_duration: 39.72 ms)
            ├─ miopenSp3AsmConv_v30_3_1_gfx9_fp32_f3x2_stride2 (id 1) (kernel_launches: 100, total_duration: 12.28 ms)
            └─ elementwise_kernel_manual_unroll (id 2) (kernel_launches: 400, total_duration: 10.58 ms)
```

### After

```
================================================================================
Matched PyTorch Operators: torch.nn.functional.conv2d
Grouped by source location, sorted by total GPU kernel duration.
================================================================================

pytorch_inference_example.py:88 (dispatches: 800, total: 63.75 ms, dispatch_mean: 0.08 ms, dispatch_min: 9.96 us, dispatch_max: 0.16 ms)
└─ nn.Module.SimpleCNN.forward (calls: 100)
   └─ nn.Module.Sequential.forward (calls: 100)
      └─ nn.Module.Conv2d.forward (calls: 100)
         └─ torch.nn.functional.conv2d (calls: 400, dispatches: 800, total: 63.75 ms, dispatch_mean: 0.08 ms,
            dispatch_min: 9.96 us, dispatch_max: 0.16 ms)
            ├─ miopenSp3AsmConv_v30_3_1_gfx9_fp32_f2x3_stride1 (id 0) (dispatches: 300, total: 40.34 ms)
            ├─ miopenSp3AsmConv_v30_3_1_gfx9_fp32_f3x2_stride2 (id 1) (dispatches: 100, total: 12.67 ms)
            └─ elementwise_kernel_manual_unroll (id 2) (dispatches: 400, total: 10.74 ms)

Operator summary (Min/Max/Mean are per-dispatch over the subtree; sorted by Total):
╒══════════════════════════════════════════════════════════════════════════╤═════════╤══════════════╤══════════╤═══════════╤═════════════╤═════════╤═════════╤═════════╕
│ Operator                                                                 │   Calls │   Dispatches │    Total │   % Total │   Mean/Call │    Mean │     Min │     Max │
╞══════════════════════════════════════════════════════════════════════════╪═════════╪══════════════╪══════════╪═══════════╪═════════════╪═════════╪═════════╪═════════╡
│ nn.Module.SimpleCNN.forward                                              │     100 │          800 │ 63.75 ms │     82.72 │     0.64 ms │ 0.08 ms │ 9.96 us │ 0.16 ms │
├──────────────────────────────────────────────────────────────────────────┼─────────┼──────────────┼──────────┼───────────┼─────────────┼─────────┼─────────┼─────────┤
│ nn.Module.SimpleCNN.forward/nn.Module.Sequential.forward                 │     100 │          800 │ 63.75 ms │     82.72 │     0.64 ms │ 0.08 ms │ 9.96 us │ 0.16 ms │
├──────────────────────────────────────────────────────────────────────────┼─────────┼──────────────┼──────────┼───────────┼─────────────┼─────────┼─────────┼─────────┤
│ nn.Module.SimpleCNN.forward/nn.Module.Sequential.forward/nn.Module.Conv2 │     100 │          800 │ 63.75 ms │     82.72 │     0.64 ms │ 0.08 ms │ 9.96 us │ 0.16 ms │
│ d.forward                                                                │         │              │          │           │             │         │         │         │
├──────────────────────────────────────────────────────────────────────────┼─────────┼──────────────┼──────────┼───────────┼─────────────┼─────────┼─────────┼─────────┤
│ nn.Module.SimpleCNN.forward/nn.Module.Sequential.forward/nn.Module.Conv2 │     400 │          800 │ 63.75 ms │     82.72 │     0.16 ms │ 0.08 ms │ 9.96 us │ 0.16 ms │
│ d.forward/torch.nn.functional.conv2d                                     │         │              │          │           │             │         │         │         │
├──────────────────────────────────────────────────────────────────────────┼─────────┼──────────────┼──────────┼───────────┼─────────────┼─────────┼─────────┼─────────┤
│ nn.Module.SimpleCNN.forward                                              │      10 │           81 │  6.96 ms │      9.03 │     0.70 ms │ 0.09 ms │ 0.01 ms │ 0.31 ms │
├──────────────────────────────────────────────────────────────────────────┼─────────┼──────────────┼──────────┼───────────┼─────────────┼─────────┼─────────┼─────────┤
│ nn.Module.SimpleCNN.forward/nn.Module.Sequential.forward                 │      10 │           81 │  6.96 ms │      9.03 │     0.70 ms │ 0.09 ms │ 0.01 ms │ 0.31 ms │
├──────────────────────────────────────────────────────────────────────────┼─────────┼──────────────┼──────────┼───────────┼─────────────┼─────────┼─────────┼─────────┤
│ nn.Module.SimpleCNN.forward/nn.Module.Sequential.forward/nn.Module.Conv2 │      10 │           81 │  6.96 ms │      9.03 │     0.70 ms │ 0.09 ms │ 0.01 ms │ 0.31 ms │
│ d.forward                                                                │         │              │          │           │             │         │         │         │
├──────────────────────────────────────────────────────────────────────────┼─────────┼──────────────┼──────────┼───────────┼─────────────┼─────────┼─────────┼─────────┤
│ nn.Module.SimpleCNN.forward/nn.Module.Sequential.forward/nn.Module.Conv2 │      40 │           81 │  6.96 ms │      9.03 │     0.17 ms │ 0.09 ms │ 0.01 ms │ 0.31 ms │
│ d.forward/torch.nn.functional.conv2d                                     │         │              │          │           │             │         │         │         │
├──────────────────────────────────────────────────────────────────────────┼─────────┼──────────────┼──────────┼───────────┼─────────────┼─────────┼─────────┼─────────┤
│ nn.Module.SimpleCNN.forward                                              │      10 │           80 │  6.36 ms │      8.26 │     0.64 ms │ 0.08 ms │ 0.01 ms │ 0.15 ms │
├──────────────────────────────────────────────────────────────────────────┼─────────┼──────────────┼──────────┼───────────┼─────────────┼─────────┼─────────┼─────────┤
│ nn.Module.SimpleCNN.forward/nn.Module.Sequential.forward                 │      10 │           80 │  6.36 ms │      8.26 │     0.64 ms │ 0.08 ms │ 0.01 ms │ 0.15 ms │
├──────────────────────────────────────────────────────────────────────────┼─────────┼──────────────┼──────────┼───────────┼─────────────┼─────────┼─────────┼─────────┤
│ nn.Module.SimpleCNN.forward/nn.Module.Sequential.forward/nn.Module.Conv2 │      10 │           80 │  6.36 ms │      8.26 │     0.64 ms │ 0.08 ms │ 0.01 ms │ 0.15 ms │
│ d.forward                                                                │         │              │          │           │             │         │         │         │
├──────────────────────────────────────────────────────────────────────────┼─────────┼──────────────┼──────────┼───────────┼─────────────┼─────────┼─────────┼─────────┤
│ nn.Module.SimpleCNN.forward/nn.Module.Sequential.forward/nn.Module.Conv2 │      40 │           80 │  6.36 ms │      8.26 │     0.16 ms │ 0.08 ms │ 0.01 ms │ 0.15 ms │
│ d.forward/torch.nn.functional.conv2d                                     │         │              │          │           │             │         │         │         │
╘══════════════════════════════════════════════════════════════════════════╧═════════╧══════════════╧══════════╧═══════════╧═════════════╧═════════╧═════════╧═════════╛
```

## JIRA ID
AIPROFCOMP-525

## Test Plan

pytest tests -m torch_ops

## Test Result

Test passes.
<img width="449" height="329" alt="Screenshot 2026-04-24 173358" src="https://github.com/user-attachments/assets/4fe3542a-50d9-4699-acc9-5348d18b5e85" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
