### PR TITLE
[rocprofiler-sdk-rocattach] Fix wrong library base in find_library()

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -35,6 +35,7 @@
 #include <link.h>
 
 #include <optional>
+#include <sstream>
 #include <unordered_map>
 #include <vector>
 
@@ -165,20 +166,28 @@ find_library(void*& addr, int inpid, const std::string& library)
     }
 
     std::string line;
+    bool        found = false;
     while(std::getline(maps, line))
     {
-        if(line.find(library) != std::string::npos)
-        {
-            ROCP_TRACE << "[rocprofiler-sdk-rocattach] Entry in pid " << inpid
-                       << " maps file is: " << line;
-            break;
-        }
+        if(line.find(library) == std::string::npos) continue;
+
+        std::istringstream iss(line);
+        std::string        addr_range;
+        std::string        perms;
+        std::string        offset_str;
+        if(!(iss >> addr_range >> perms >> offset_str)) continue;
+        if(std::stoull(offset_str, nullptr, 16) != 0) continue;
+
+        ROCP_TRACE << "[rocprofiler-sdk-rocattach] Entry in pid " << inpid
+                   << " maps file is: " << line;
+        found = true;
+        break;
     }
 
-    if(!maps)
+    if(!found)
     {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Couldn't find library " << library << " in "
-                   << filename.str();
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Couldn't find library " << library
+                   << " (with file offset 0) in " << filename.str();
         return false;
     }
 


### PR DESCRIPTION
## Motivation

`find_library()` returns the wrong load base when multiple `/proc/<pid>/maps` lines mention the library. The current code takes the first match. By definition, the load base is the line whose file offset is `0`.

When the runtime adds extra file-backed mappings of the same library at non-zero file offsets at addresses below the original load (observed during attach setup of `librocprofiler-register.so`), symbol resolution computes `wrong_base + symbol_offset`, lands in unrelated memory, and SIGSEGVs the injected ptrace call. The dying thread leaves the ptrace state machine unrecoverable, `PTraceSession::~PTraceSession` throws during cleanup, and the attacher aborts.

## Technical Details

Filter the `/proc/<pid>/maps` scan to entries whose file offset is `0`. This is the unique discriminator for the library load base, robust to any number of extra shadow mappings at other offsets.

Replace the implicit `if (!maps)` no-match detection with an explicit `found` flag. The new filter would otherwise let a substring-matching but offset-nonzero line reach `std::stoull(line, ...)` and silently return a wrong address.

## JIRA

N/A

## Test Plan

Manual repro with `rocprof-sys-attach -p <PID> -d 5` against a HIP target launched with `ROCP_TOOL_ATTACH=1`.

## Test Result

- Without patch: `rocattach_detach` SIGSEGVs in target on first detach, attacher dies with SIGABRT.
- With patch: attach + detach complete with rc=0, target survives.

## Checklist

- [x] Fix verified locally
- [ ] Reviewed by rocattach maintainers