### PR TITLE
[rocjpeg] Fix codespell errors

### DIFF
--- a/projects/rocjpeg/docs/how-to/rocjpeg-decoding-a-jpeg-stream.rst
+++ b/projects/rocjpeg/docs/how-to/rocjpeg-decoding-a-jpeg-stream.rst
@@ -91,7 +91,7 @@ The behaviors of ``rocJpegDecode()`` and ``rocJpegDecodeBatched()`` depend on ``
 .. csv-table::
   :header: "Output format", "Meaning"
 
-  "ROCJPEG_OUTPUT_NATIVE", "Return native unchanged decoded YUV image from the VCN JPEG deocder."
+  "ROCJPEG_OUTPUT_NATIVE", "Return native unchanged decoded YUV image from the VCN JPEG decoder."
   "ROCJPEG_OUTPUT_YUV_PLANAR", "Return in the YUV planar format."
   "ROCJPEG_OUTPUT_Y", "Return the Y component only."
   "ROCJPEG_OUTPUT_RGB", "Convert to interleaved RGB."

--- a/projects/rocjpeg/samples/jpegDecode/jpegdecode.cpp
+++ b/projects/rocjpeg/samples/jpegDecode/jpegdecode.cpp
@@ -209,10 +209,10 @@ int main(int argc, char **argv) {
                 std::cout << " ,total images that cannot be parsed: " << num_bad_jpegs;
             }
             if (num_jpegs_with_411_subsampling) {
-                std::cout << " ,total images with YUV 4:1:1 chroam subsampling: " << num_jpegs_with_411_subsampling;
+                std::cout << " ,total images with YUV 4:1:1 chroma subsampling: " << num_jpegs_with_411_subsampling;
             }
             if (num_jpegs_with_unknown_subsampling) {
-                std::cout << " ,total images with unknwon chroam subsampling: " << num_jpegs_with_unknown_subsampling;
+                std::cout << " ,total images with unknown chroma subsampling: " << num_jpegs_with_unknown_subsampling;
             }
             if (num_jpegs_with_unsupported_resolution) {
                 std::cout << " ,total images with unsupported_resolution: " << num_jpegs_with_unsupported_resolution;

--- a/projects/rocjpeg/samples/jpegDecodeBatched/jpegdecodebatched.cpp
+++ b/projects/rocjpeg/samples/jpegDecodeBatched/jpegdecodebatched.cpp
@@ -232,10 +232,10 @@ int main(int argc, char **argv) {
                 std::cout << " ,total images that cannot be parsed: " << num_bad_jpegs;
             }
             if (num_jpegs_with_411_subsampling) {
-                std::cout << " ,total images with YUV 4:1:1 chroam subsampling: " << num_jpegs_with_411_subsampling;
+                std::cout << " ,total images with YUV 4:1:1 chroma subsampling: " << num_jpegs_with_411_subsampling;
             }
             if (num_jpegs_with_unknown_subsampling) {
-                std::cout << " ,total images with unknwon chroam subsampling: " << num_jpegs_with_unknown_subsampling;
+                std::cout << " ,total images with unknown chroma subsampling: " << num_jpegs_with_unknown_subsampling;
             }
             if (num_jpegs_with_unsupported_resolution) {
                 std::cout << " ,total images with unsupported_resolution: " << num_jpegs_with_unsupported_resolution;

--- a/projects/rocjpeg/samples/jpegDecodePerf/jpegdecodeperf.cpp
+++ b/projects/rocjpeg/samples/jpegDecodePerf/jpegdecodeperf.cpp
@@ -285,10 +285,10 @@ int main(int argc, char **argv) {
             std::cout << " ,total images that cannot be parsed: " << total_num_bad_jpegs;
         }
         if (total_num_jpegs_with_411_subsampling) {
-            std::cout << " ,total images with YUV 4:1:1 chroam subsampling: " << total_num_jpegs_with_411_subsampling;
+            std::cout << " ,total images with YUV 4:1:1 chroma subsampling: " << total_num_jpegs_with_411_subsampling;
         }
         if (total_num_jpegs_with_unknown_subsampling) {
-            std::cout << " ,total images with unknwon chroam subsampling: " << total_num_jpegs_with_unknown_subsampling;
+            std::cout << " ,total images with unknown chroma subsampling: " << total_num_jpegs_with_unknown_subsampling;
         }
         if (total_num_jpegs_with_unsupported_resolution) {
             std::cout << " ,total images with unsupported_resolution: " << total_num_jpegs_with_unsupported_resolution;

--- a/projects/rocjpeg/src/rocjpeg_decoder.cpp
+++ b/projects/rocjpeg/src/rocjpeg_decoder.cpp
@@ -77,7 +77,7 @@ RocJpegStatus RocJpegDecoder::InitializeDecoder() {
     RocJpegStatus rocjpeg_status = ROCJPEG_STATUS_SUCCESS;
     rocjpeg_status = InitHIP(device_id_);
     if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
-        ERR("ERROR: Failed to initilize the HIP!");
+        ERR("ERROR: Failed to initialize the HIP!");
         return rocjpeg_status;
     }
     if (backend_ == ROCJPEG_BACKEND_HARDWARE) {

--- a/projects/rocjpeg/src/rocjpeg_parser.cpp
+++ b/projects/rocjpeg/src/rocjpeg_parser.cpp
@@ -272,7 +272,7 @@ bool RocJpegStreamParser::ParseDHT() {
         huffman_table_id = index & 0x0F;
 
         if (huffman_table_id >= HUFFMAN_TABLES) {
-            ERR("invlaid number of Huffman table!");
+            ERR("invalid number of Huffman table!");
             return false;
         }
 
@@ -296,7 +296,7 @@ bool RocJpegStreamParser::ParseDHT() {
             jpeg_stream_parameters_.huffman_table_buffer.load_huffman_table[huffman_table_id] = 1;
         } else {
             if (count > DC_HUFFMAN_TABLE_VALUES_SIZE) {
-                ERR("invlaid DC Huffman table!")
+                ERR("invalid DC Huffman table!")
                 return false;
             }
             std::memcpy(jpeg_stream_parameters_.huffman_table_buffer.huffman_table[huffman_table_id].dc_values, stream_, count);


### PR DESCRIPTION
Clean using `codespell --ignore-words-list=renderD .`
