### PR TITLE
[rccl] 2/4 node AllToAll performance tuning for AINIC/GFX950

### DIFF
--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -1220,6 +1220,9 @@ static ncclResult_t addP2pToPlan(struct ncclComm* comm, struct ncclKernelPlan* p
       // Tune chunk size for the network
       if (protocol[dir] == NCCL_PROTO_SIMPLE && bytes[dir] < stepSize[dir]) chunkSize[dir] /= 4;
       else if (bytes[dir] < 8 * stepSize[dir]) chunkSize[dir] /= 2;
+      if (protocol[dir] == NCCL_PROTO_SIMPLE && p2pTasks[dir] &&
+          p2pTasks[dir]->collAPI == ncclFuncAlltoAll)
+        chunkSize[dir] = std::min(chunkSize[dir], comm->p2pAlltoAllChunkSize);
     }
 
     chunkDataSize[dir] = chunkSize[dir];

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -1110,6 +1110,9 @@ static ncclResult_t addP2pToPlan(
       // Tune chunk size for the network
       if (protocol[dir] == NCCL_PROTO_SIMPLE && bytes[dir] < stepSize[dir]) chunkSize[dir] /= 4;
       else if (bytes[dir] < 8*stepSize[dir]) chunkSize[dir] /= 2;
+      if (protocol[dir] == NCCL_PROTO_SIMPLE && p2pTasks[dir] &&
+          p2pTasks[dir]->collAPI == ncclFuncAlltoAll)
+        chunkSize[dir] = std::min(chunkSize[dir], comm->p2pAlltoAllChunkSize);
     }
 
     chunkDataSize[dir] = chunkSize[dir];

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -727,6 +727,7 @@ struct ncclComm {
   // Buffer sizes
   int buffSizes[NCCL_NUM_PROTOCOLS];
   int p2pChunkSize;
+  int p2pAlltoAllChunkSize;
   int nvlsChunkSize;
 
   // Cross-clique P2P: when true, use global rank for IPC buffer indexing
@@ -918,9 +919,9 @@ struct ncclComm {
   int unroll;
   // custom collective [RCCL]
   bool enableCustColl;
-  int
-    pxnDisable; // per-comm PXN-disable cache: RCCL_VALUE_UNSET uninit, RCCL_VALUE_INVALID = arch/env override, otherwise 0/1
-  int p2pNetChunkSize; // per-comm P2P NET chunk size cache: RCCL_VALUE_UNSET uninit
+  int pxnDisable;  // per-comm PXN-disable cache: RCCL_VALUE_UNSET uninit, RCCL_VALUE_INVALID = arch/env override, otherwise 0/1
+  int p2pNetChunkSize;  // per-comm P2P NET chunk size cache: RCCL_VALUE_UNSET uninit
+  int p2pAlltoAllNetChunkSize;  // per-comm AllToAll P2P net chunk size cache: RCCL_VALUE_UNSET uninit, RCCL_VALUE_INVALID = no override
   // gfx name from hipDeviceProp_t [RCCL] , Memory resource owned by comm allocated in ncclCommInitRankFunc
   char* archName;
   // multiProcessorCount from hipDeviceProp_t [RCCL]

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -597,6 +597,7 @@ struct ncclComm {
   // Buffer sizes
   int buffSizes[NCCL_NUM_PROTOCOLS];
   int p2pChunkSize;
+  int p2pAlltoAllChunkSize;
   int nvlsChunkSize;
 
   // Tuner values

--- a/projects/rccl/src/include/rccl_common.h
+++ b/projects/rccl/src/include/rccl_common.h
@@ -133,6 +133,7 @@ bool rcclUseReduceScatterDirect(struct ncclComm* comm, size_t& msgSize);
 bool rcclUseAlltoAllGda(struct ncclComm* comm);
 void rcclSetPxn(struct ncclComm* comm, int& rcclPxnDisable);
 void rcclSetP2pNetChunkSize(struct ncclComm* comm, int& rcclP2pNetChunkSize);
+void rcclSetP2pAlltoAllChunkSize(struct ncclComm* comm, int& rcclP2pAlltoAllChunkSize);
 ncclResult_t rcclFuncMaxSendRecvCount(ncclFunc_t func, int nRanks, size_t count, size_t& maxCount);
 ncclResult_t commSetUnrollFactor(struct ncclComm* comm);
 ncclResult_t rcclCommSetP2pShiftSize(struct ncclComm* comm);

--- a/projects/rccl/src/include/rccl_common.h
+++ b/projects/rccl/src/include/rccl_common.h
@@ -120,6 +120,7 @@ bool rcclUseReduceScatterDirect(struct ncclComm* comm, size_t& msgSize);
 bool rcclUseAlltoAllGda(struct ncclComm* comm);
 void rcclSetPxn(struct ncclComm* comm,  int& rcclPxnDisable);
 void rcclSetP2pNetChunkSize(struct ncclComm* comm,  int& rcclP2pNetChunkSize);
+void rcclSetP2pAlltoAllChunkSize(struct ncclComm* comm, int& rcclP2pAlltoAllChunkSize);
 ncclResult_t rcclFuncMaxSendRecvCount(ncclFunc_t func, int nRanks, size_t count, size_t& maxCount);
 ncclResult_t commSetUnrollFactor(struct ncclComm* comm);
 ncclResult_t rcclCommSetP2pShiftSize(struct ncclComm* comm);

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -684,6 +684,7 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
   comm->nRanks = ndev;
   comm->pxnDisable = RCCL_VALUE_UNSET;
   comm->p2pNetChunkSize = RCCL_VALUE_UNSET;
+  comm->p2pAlltoAllNetChunkSize = RCCL_VALUE_UNSET;
 
   comm->hierarchicalIntraComm = nullptr;
   comm->hierarchicalInterComm = nullptr;
@@ -1206,7 +1207,17 @@ static ncclResult_t computeBuffSizes(struct ncclComm* comm) {
     comm->sharedRes->tpP2pChunkSize = comm->p2pChunkSize;
   }
 
-  INFO(NCCL_INIT, "P2P Chunksize set to %d", comm->p2pChunkSize);
+  // AllToAll tracks p2pChunkSize by default (every comm gets a valid value), and is only
+  // capped to a smaller *net* chunk size multi-node on specific hardware (e.g. AINIC/gfx950).
+  comm->p2pAlltoAllChunkSize = comm->p2pChunkSize;
+  if (comm->nNodes > 1) {
+    int a2a = RCCL_VALUE_UNSET;
+    rcclSetP2pAlltoAllChunkSize(comm, a2a);
+    if (a2a > RCCL_VALUE_INVALID) comm->p2pAlltoAllChunkSize = a2a;
+  }
+
+  INFO(NCCL_INIT, "P2P Chunksize set to %d, AllToAll P2P Chunksize set to %d",
+       comm->p2pChunkSize, comm->p2pAlltoAllChunkSize);
   return ncclSuccess;
 }
 

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -1203,7 +1203,14 @@ static ncclResult_t computeBuffSizes(struct ncclComm* comm) {
     comm->sharedRes->tpP2pChunkSize = comm->p2pChunkSize;
   }
 
-  INFO(NCCL_INIT, "P2P Chunksize set to %d", comm->p2pChunkSize);
+  // AllToAll may use a smaller chunk size on specific hardware (e.g. AINIC/gfx950).
+  // Defaults to p2pChunkSize when no override applies.
+  rcclSetP2pAlltoAllChunkSize(comm, comm->p2pAlltoAllChunkSize);
+  comm->p2pAlltoAllChunkSize = (comm->p2pAlltoAllChunkSize > RCCL_VALUE_INVALID)
+                               ? comm->p2pAlltoAllChunkSize : comm->p2pChunkSize;
+
+  INFO(NCCL_INIT, "P2P Chunksize set to %d, AllToAll P2P Chunksize set to %d",
+       comm->p2pChunkSize, comm->p2pAlltoAllChunkSize);
   return ncclSuccess;
 }
 

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -676,6 +676,27 @@ void rcclSetP2pNetChunkSize(struct ncclComm* comm, int& rcclP2pNetChunkSize) {
   comm->p2pNetChunkSize = p2pNetChunkSize;
   rcclP2pNetChunkSize = p2pNetChunkSize;
 }
+void rcclSetP2pAlltoAllChunkSize(struct ncclComm* comm, int& rcclP2pAlltoAllChunkSize) {
+  if (comm->p2pAlltoAllNetChunkSize != RCCL_VALUE_UNSET) {
+    rcclP2pAlltoAllChunkSize = comm->p2pAlltoAllNetChunkSize;
+    return;
+  }
+
+  // Auto-tune only on AINIC/gfx950, and only when the user has not pinned the global P2P
+  // net chunk size via NCCL_P2P_NET_CHUNKSIZE (which then takes precedence).
+  const char *inputStr = getenv("NCCL_P2P_NET_CHUNKSIZE");
+  const bool archGfx950 = IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950");
+  if (!archGfx950 || !rcclUseAinic() || inputStr) {
+    rcclP2pAlltoAllChunkSize = comm->p2pAlltoAllNetChunkSize = RCCL_VALUE_INVALID;
+    return;
+  }
+
+  comm->p2pAlltoAllNetChunkSize = (1 << 17);
+  rcclP2pAlltoAllChunkSize = comm->p2pAlltoAllNetChunkSize;
+  INFO(NCCL_INIT, "RCCL AllToAll P2P net chunk size set to %d for AINIC/gfx950",
+       comm->p2pAlltoAllNetChunkSize);
+}
+
 #ifdef ENABLE_WARP_SPEED
 void rcclSetWarpSpeedCUs(struct ncclComm* comm, int algo, int threadsPerBlock, int& rcclWarpSpeedChannels) {
   static int userChannelControlInput = RCCL_VALUE_UNSET;

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -644,7 +644,10 @@ void rcclSetPxn(struct ncclComm* comm, int& rcclPxnDisable) {
     rcclPxnDisable = comm->pxnDisable = RCCL_VALUE_INVALID;
     return;
   }
-  const int ranksThreshold = (archGfx942) ? 64 : 32;
+  // On gfx950 the default PXN-on threshold is 32 ranks, but on the AINIC RoCE path
+  // enabling PXN at 32 ranks collapses AllToAll BW at >=256MB (net proxy contention).
+  // Match the gfx942 threshold (64) for AINIC/gfx950 so PXN stays off at 32 ranks.
+  const int ranksThreshold = (archGfx942 || (archGfx950 && rcclUseAinic())) ? 64 : 32;
   int pxnDisable = (comm->nRanks >= ranksThreshold) ? 0 : 1;
   INFO(NCCL_INIT, "RCCL PXN set as %s (nRanks=%d threshold=%d)", !pxnDisable ? "enabled" : "disabled", comm->nRanks,
        ranksThreshold);

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "debug.h"
 #include "amdsmi_wrap.h"
 #include "include/graph.h"
+#include "net.h"
 #include "register.h"
 
 
@@ -530,6 +531,21 @@ void rcclSetP2pNetChunkSize(struct ncclComm* comm,  int& rcclP2pNetChunkSize) {
   }
   rcclP2pNetChunkSize = p2pNetChunkSize;
 }
+void rcclSetP2pAlltoAllChunkSize(struct ncclComm* comm, int& rcclP2pAlltoAllChunkSize) {
+  static int p2pAlltoAllChunkSize = RCCL_VALUE_UNSET;
+  if (p2pAlltoAllChunkSize == RCCL_VALUE_UNSET) {
+    const char *inputStr = getenv("NCCL_P2P_NET_CHUNKSIZE");
+    const bool archGfx950 = IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950");
+    if (!archGfx950 || !rcclUseAinic() || inputStr) {
+      rcclP2pAlltoAllChunkSize = p2pAlltoAllChunkSize = RCCL_VALUE_INVALID;
+      return;
+    }
+    p2pAlltoAllChunkSize = (1 << 17);
+    INFO(NCCL_INIT, "RCCL AllToAll P2P net chunk size set to %d for AINIC/gfx950", p2pAlltoAllChunkSize);
+  }
+  rcclP2pAlltoAllChunkSize = p2pAlltoAllChunkSize;
+}
+
 #ifdef ENABLE_WARP_SPEED
 void rcclSetWarpSpeedCUs(struct ncclComm* comm, int algo, int threadsPerBlock, int& rcclWarpSpeedChannels) {
   static int userChannelControlInput = RCCL_VALUE_UNSET;


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR addresses poor Alltoall performance on AINIC and MI355x combination.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
p2p chunk size provides higher and more stable throughput for alltoall on AINIC/MI355x. This fix specifically overwrites chunk size for alltoall, since lower performance for sendrecv_perf observed with 128k chunk size.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
ROCM-10991

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
2/4 nodes Alltoall_perf runs on AINIC+MI355x

## Test Result

WIP

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
