### PR TITLE
[rocprofiler-systems] Switch workflows to use backed ROCm images

### DIFF
--- a/.github/workflows/rocprofiler-systems-debian.yml
+++ b/.github/workflows/rocprofiler-systems-debian.yml
@@ -65,7 +65,6 @@ jobs:
       ROCPROFSYS_CI: 'ON'
       ROCPROFSYS_MAX_THREADS: '64'
       ROCPROFSYS_KEEP_TEST_OUTPUT: '0'
-      ROCM_PATH: /opt/rocm
 
     steps:
     - uses: actions/checkout@v6
@@ -90,6 +89,7 @@ jobs:
       shell: bash
       run: |
         echo "/opt/rocm/bin" >> $GITHUB_PATH
+        echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 
     - name: Configure, Build and Test

--- a/.github/workflows/rocprofiler-systems-debian.yml
+++ b/.github/workflows/rocprofiler-systems-debian.yml
@@ -49,7 +49,7 @@ jobs:
   debian:
     runs-on: ubuntu-latest
     container:
-      image: dgaliffiamd/rocprofiler-systems:ci-base-debian-${{ matrix.os-release }}
+      image: dgaliffiamd/rocprofiler-systems:ci-rocm-${{ matrix.rocm-version }}-debian-${{ matrix.os-release }}
     strategy:
       fail-fast: false
       matrix:
@@ -65,6 +65,7 @@ jobs:
       ROCPROFSYS_CI: 'ON'
       ROCPROFSYS_MAX_THREADS: '64'
       ROCPROFSYS_KEEP_TEST_OUTPUT: '0'
+      ROCM_PATH: /opt/rocm
 
     steps:
     - uses: actions/checkout@v6
@@ -72,19 +73,6 @@ jobs:
         sparse-checkout: |
           projects/rocprofiler-systems/
           .gitmodules
-
-    - name: Install Packages
-      timeout-minutes: 25
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
-      with:
-        retry_wait_seconds: 30
-        timeout_minutes: 25
-        max_attempts: 5
-        command: |
-          apt-get update &&
-          apt-get upgrade -y &&
-          apt-get install -y libomp-dev libopenmpi-dev &&
-          apt-get autoclean
 
     - name: Install Python Test Dependencies
       timeout-minutes: 10
@@ -98,21 +86,11 @@ jobs:
           fi
         done
 
-    - name: Install ROCm Packages
-      timeout-minutes: 115
+    - name: Configure ROCm Environment
       shell: bash
-      working-directory: projects/rocprofiler-systems/
       run: |
-        ROCM_VERSION=${{ matrix.rocm-version }}
-        ROCM_MAJOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $1}')
-        ROCM_MINOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $2}')
-        ROCM_VERSN=$(( (${ROCM_MAJOR}*10000)+(${ROCM_MINOR}*100) ))
-        echo "ROCM_MAJOR=${ROCM_MAJOR} ROCM_MINOR=${ROCM_MINOR} ROCM_VERSN=${ROCM_VERSN}"
-        wget -q https://repo.radeon.com/amdgpu-install/${{ matrix.rocm-version }}/ubuntu/jammy/amdgpu-install_${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1_all.deb
-        apt-get install -y ./amdgpu-install_${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1_all.deb
-        apt-get update
-        apt-get install -y rocm-dev rocdecode-dev libavformat-dev libavcodec-dev
-        apt-get autoclean
+        echo "/opt/rocm/bin" >> $GITHUB_PATH
+        echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 
     - name: Configure, Build and Test
       timeout-minutes: 115

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -60,16 +60,9 @@ jobs:
       fail-fast: false
       matrix:
         compiler: ['g++']
-        os-release: [ '8.10', '9', '10' ]
+        os-release: [ '8.10', '9' ]
         rocm-version: [ '6.3', '6.4', '7.0', '7.1', '7.2' ]
         build-type: ['Release']
-        exclude:
-          - os-release: '10'
-            rocm-version: '6.3'
-          - os-release: '10'
-            rocm-version: '6.4'
-          - os-release: '10'
-            rocm-version: '7.0'
 
     steps:
     - uses: actions/checkout@v6
@@ -99,14 +92,6 @@ jobs:
             chmod +x /opt/trace_processor/bin/trace_processor_shell
             # Set env var so validate_perfetto_trace() uses the downloaded binary
             echo "ROCPROFSYS_TRACE_PROC_SHELL=/opt/trace_processor/bin/trace_processor_shell" >> $GITHUB_ENV
-          fi
-          if [ $OS_VERSION_MAJOR -eq 10 ]; then
-            # RHEL 10 ships OpenMPI 5.x, whose PRRTE launcher consumes the '--'
-            # option-terminator that rocprof-sys-run requires. Install MPICH
-            # and put it ahead of OpenMPI on PATH so the test capability probe
-            # picks mpich's mpiexec instead.
-            dnf install -y --enablerepo=crb mpich mpich-devel
-            echo "/usr/lib64/mpich/bin" >> $GITHUB_PATH
           fi
 
     - name: Configure, Build, and Test

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -102,6 +102,14 @@ jobs:
             # Set env var so validate_perfetto_trace() uses the downloaded binary
             echo "ROCPROFSYS_TRACE_PROC_SHELL=/opt/trace_processor/bin/trace_processor_shell" >> $GITHUB_ENV
           fi
+          if [ $OS_VERSION_MAJOR -eq 10 ]; then
+            # RHEL 10 ships OpenMPI 5.x, whose PRRTE launcher consumes the '--'
+            # option-terminator that rocprof-sys-run requires. Install MPICH
+            # and put it ahead of OpenMPI on PATH so the test capability probe
+            # picks mpich's mpiexec instead.
+            dnf install -y --enablerepo=crb mpich mpich-devel
+            echo "/usr/lib64/mpich/bin" >> $GITHUB_PATH
+          fi
 
     - name: Configure, Build, and Test
       timeout-minutes: 115

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -53,16 +53,26 @@ jobs:
   rhel:
     runs-on: ubuntu-latest
     container:
-      image: dgaliffiamd/rocprofiler-systems:ci-base-rhel-${{ matrix.os-release }}
+      image: dgaliffiamd/rocprofiler-systems:ci-rocm-${{ matrix.rocm-version }}-rhel-${{ matrix.os-release }}
       options: --shm-size=512m
 
     strategy:
       fail-fast: false
       matrix:
         compiler: ['g++']
-        os-release: [ '8.10', '9' ]
+        os-release: [ '8.10', '9', '10' ]
         rocm-version: [ '6.3', '6.4', '7.0', '7.1', '7.2' ]
         build-type: ['Release']
+        exclude:
+          - os-release: '10'
+            rocm-version: '6.3'
+          - os-release: '10'
+            rocm-version: '6.4'
+          - os-release: '10'
+            rocm-version: '7.0'
+
+    env:
+      ROCM_PATH: /opt/rocm
 
     steps:
     - uses: actions/checkout@v6
@@ -78,6 +88,8 @@ jobs:
         echo "CC=$(echo '${{ matrix.compiler }}' | sed 's/+/c/g')" >> $GITHUB_ENV &&
         echo "CXX=${{ matrix.compiler }}" >> $GITHUB_ENV &&
         echo "OS_VERSION_MAJOR=$(cat /etc/os-release | grep 'VERSION_ID' | sed 's/=/ /1' | awk '{print $NF}' | sed 's/"//g' | sed 's/\./ /g' | awk '{print $1}')" >> $GITHUB_ENV &&
+        echo "/opt/rocm/bin" >> $GITHUB_PATH &&
+        echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV &&
         env
 
     - name: Install Packages
@@ -90,32 +102,6 @@ jobs:
             # Set env var so validate_perfetto_trace() uses the downloaded binary
             echo "ROCPROFSYS_TRACE_PROC_SHELL=/opt/trace_processor/bin/trace_processor_shell" >> $GITHUB_ENV
           fi
-
-    - name: Install ROCm Packages
-      timeout-minutes: 30
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
-      with:
-        retry_wait_seconds: 30
-        timeout_minutes: 30
-        max_attempts: 3
-        command: |
-          RPM_TAG=".el${OS_VERSION_MAJOR}"
-          ROCM_VERSION=${{ matrix.rocm-version }}
-          ROCM_MAJOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $1}')
-          ROCM_MINOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $2}')
-          ROCM_VERSN=$(( (${ROCM_MAJOR}*10000)+(${ROCM_MINOR}*100) ))
-          if [ "${OS_VERSION_MAJOR}" -eq 8 ]; then PERL_REPO=powertools; else PERL_REPO=crb; fi
-          dnf -y --enablerepo=${PERL_REPO} install perl-File-BaseDir
-          printf '%s\n' '[rocm]' \
-            "name=ROCm ${ROCM_VERSION} repository" \
-            "baseurl=https://repo.radeon.com/rocm/el${OS_VERSION_MAJOR}/${ROCM_VERSION}/main" \
-            'enabled=1' 'priority=50' 'gpgcheck=1' \
-            'gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key' |
-            tee /etc/yum.repos.d/rocm.repo
-          cat /etc/yum.repos.d/rocm.repo
-          # yum install -y https://repo.radeon.com/amdgpu-install/${{ matrix.rocm-version }}/rhel/${{ matrix.os-release }}/amdgpu-install-${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1${RPM_TAG}.noarch.rpm
-          dnf install -y rocm-dev
-          if [ "${OS_VERSION_MAJOR}" -gt 8 ]; then dnf install -y libavcodec-free-devel libavformat-free-devel; fi
 
     - name: Configure, Build, and Test
       timeout-minutes: 115

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -71,9 +71,6 @@ jobs:
           - os-release: '10'
             rocm-version: '7.0'
 
-    env:
-      ROCM_PATH: /opt/rocm
-
     steps:
     - uses: actions/checkout@v6
       with:
@@ -89,6 +86,7 @@ jobs:
         echo "CXX=${{ matrix.compiler }}" >> $GITHUB_ENV &&
         echo "OS_VERSION_MAJOR=$(cat /etc/os-release | grep 'VERSION_ID' | sed 's/=/ /1' | awk '{print $NF}' | sed 's/"//g' | sed 's/\./ /g' | awk '{print $1}')" >> $GITHUB_ENV &&
         echo "/opt/rocm/bin" >> $GITHUB_PATH &&
+        echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV &&
         echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV &&
         env
 

--- a/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
@@ -404,6 +404,8 @@ jobs:
       ROCPROFSYS_CI: 'ON'
       ROCPROFSYS_MAX_THREADS: '64'
       ROCM_PATH: /opt/rocm
+      OMPI_ALLOW_RUN_AS_ROOT: 1
+      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
 
     steps:
     - *sparse-checkout

--- a/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
@@ -69,7 +69,6 @@ jobs:
       ROCPROFSYS_CI: 'ON'
       ROCPROFSYS_MAX_THREADS: '64'
       ROCPROFSYS_KEEP_TEST_OUTPUT: '0'
-      ROCM_PATH: /opt/rocm
 
     steps:
     - &sparse-checkout
@@ -83,6 +82,7 @@ jobs:
       shell: bash
       run: |
         echo "/opt/rocm/bin" >> $GITHUB_PATH
+        echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 
     - name: Install Packages
@@ -268,7 +268,6 @@ jobs:
       ROCPROFSYS_CI: 'ON'
       ROCPROFSYS_MAX_THREADS: '64'
       ROCPROFSYS_KEEP_TEST_OUTPUT: '0'
-      ROCM_PATH: /opt/rocm
 
     steps:
     - *sparse-checkout
@@ -277,6 +276,7 @@ jobs:
       shell: bash
       run: |
         echo "/opt/rocm/bin" >> $GITHUB_PATH
+        echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 
     - name: Install System Dependency Packages
@@ -403,7 +403,6 @@ jobs:
       ROCPROFSYS_CAUSAL_BACKEND: perf
       ROCPROFSYS_CI: 'ON'
       ROCPROFSYS_MAX_THREADS: '64'
-      ROCM_PATH: /opt/rocm
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
 
@@ -414,6 +413,7 @@ jobs:
       shell: bash
       run: |
         echo "/opt/rocm/bin" >> $GITHUB_PATH
+        echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 
     - name: Install Packages
@@ -426,6 +426,8 @@ jobs:
         command: |
           cd projects/rocprofiler-systems/
           apt-get update &&
+          apt-get remove -y --purge 'libopenmpi-dev' 'libopenmpi3' 'openmpi-bin' 'openmpi-common' &&
+          apt-get autoremove -y --purge &&
           apt-get upgrade -y &&
           apt-get install -y libmpich-dev mpich &&
           apt-get autoclean

--- a/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
@@ -49,7 +49,7 @@ jobs:
   ubuntu-jammy:
     runs-on: ubuntu-latest
     container:
-      image: dgaliffiamd/rocprofiler-systems:ci-base-ubuntu-22.04
+      image: dgaliffiamd/rocprofiler-systems:ci-rocm-${{ matrix.rocm-version }}-ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -69,6 +69,7 @@ jobs:
       ROCPROFSYS_CI: 'ON'
       ROCPROFSYS_MAX_THREADS: '64'
       ROCPROFSYS_KEEP_TEST_OUTPUT: '0'
+      ROCM_PATH: /opt/rocm
 
     steps:
     - &sparse-checkout
@@ -77,6 +78,12 @@ jobs:
         sparse-checkout: |
           projects/rocprofiler-systems/
           .gitmodules
+
+    - name: Configure ROCm Environment
+      shell: bash
+      run: |
+        echo "/opt/rocm/bin" >> $GITHUB_PATH
+        echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 
     - name: Install Packages
       timeout-minutes: 25
@@ -89,7 +96,7 @@ jobs:
           cd projects/rocprofiler-systems/
           apt-get update &&
           apt-get upgrade -y &&
-          apt-get install -y libomp-dev libopenmpi-dev ${{ matrix.compiler }} &&
+          apt-get install -y ${{ matrix.compiler }} &&
           apt-get autoclean
 
     - name: Install Python Test Dependencies
@@ -104,30 +111,11 @@ jobs:
           fi
         done
 
-    - name: Install ROCm Packages
-      timeout-minutes: 25
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
-      with:
-        retry_wait_seconds: 30
-        timeout_minutes: 25
-        max_attempts: 5
-        shell: bash
-        command: |
-          cd projects/rocprofiler-systems/
-          ROCM_VERSION=${{ matrix.rocm-version }}
-          ROCM_MAJOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $1}')
-          ROCM_MINOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $2}')
-          ROCM_VERSN=$(( (${ROCM_MAJOR}*10000)+(${ROCM_MINOR}*100) ))
-          echo "ROCM_MAJOR=${ROCM_MAJOR} ROCM_MINOR=${ROCM_MINOR} ROCM_VERSN=${ROCM_VERSN}"
-          wget -q https://repo.radeon.com/amdgpu-install/${{ matrix.rocm-version }}/ubuntu/jammy/amdgpu-install_${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1_all.deb
-          apt-get install -y ./amdgpu-install_${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1_all.deb
-          apt-get update
-          apt-get install -y rocm-dev rocdecode-dev libavformat-dev libavcodec-dev
-          apt-get autoclean
-          echo "/opt/rocm/bin" >> $GITHUB_PATH
-          echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
-          /opt/rocm/bin/hipcc -O3 -c ./examples/transpose/transpose.cpp -o /tmp/transpose.o
+    - name: Sanity Check ROCm
+      shell: bash
+      working-directory: projects/rocprofiler-systems/
+      run: |
+        /opt/rocm/bin/hipcc -O3 -c ./examples/transpose/transpose.cpp -o /tmp/transpose.o
 
     - name: Test Environment Modules
       timeout-minutes: 15
@@ -261,7 +249,7 @@ jobs:
   ubuntu-jammy-system-deps:
     runs-on: ubuntu-latest
     container:
-      image: dgaliffiamd/rocprofiler-systems:ci-base-ubuntu-22.04
+      image: dgaliffiamd/rocprofiler-systems:ci-rocm-7.2-ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -280,9 +268,16 @@ jobs:
       ROCPROFSYS_CI: 'ON'
       ROCPROFSYS_MAX_THREADS: '64'
       ROCPROFSYS_KEEP_TEST_OUTPUT: '0'
+      ROCM_PATH: /opt/rocm
 
     steps:
     - *sparse-checkout
+
+    - name: Configure ROCm Environment
+      shell: bash
+      run: |
+        echo "/opt/rocm/bin" >> $GITHUB_PATH
+        echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 
     - name: Install System Dependency Packages
       timeout-minutes: 25
@@ -295,7 +290,7 @@ jobs:
           cd projects/rocprofiler-systems/
           apt-get update &&
           apt-get upgrade -y &&
-          apt-get install -y libomp-dev libopenmpi-dev g++ \
+          apt-get install -y g++ \
             binutils-dev libboost-all-dev libtbb-dev \
             libdw-dev libdwarf-dev libelf-dev libiberty-dev &&
           apt-get autoclean
@@ -313,30 +308,11 @@ jobs:
           fi
         done
 
-    - name: Install ROCm 7.2
-      timeout-minutes: 25
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
-      with:
-        retry_wait_seconds: 30
-        timeout_minutes: 25
-        max_attempts: 5
-        shell: bash
-        command: |
-          cd projects/rocprofiler-systems/
-          ROCM_VERSION=7.2
-          ROCM_MAJOR=7
-          ROCM_MINOR=2
-          ROCM_VERSN=70200
-          echo "Installing ROCm ${ROCM_VERSION}"
-          wget -q https://repo.radeon.com/amdgpu-install/${ROCM_VERSION}/ubuntu/jammy/amdgpu-install_${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1_all.deb
-          apt-get install -y ./amdgpu-install_${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1_all.deb
-          apt-get update
-          apt-get install -y rocm-dev rocdecode-dev libavformat-dev libavcodec-dev
-          apt-get autoclean
-          echo "/opt/rocm/bin" >> $GITHUB_PATH
-          echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
-          /opt/rocm/bin/hipcc -O3 -c ./examples/transpose/transpose.cpp -o /tmp/transpose.o
+    - name: Sanity Check ROCm
+      shell: bash
+      working-directory: projects/rocprofiler-systems/
+      run: |
+        /opt/rocm/bin/hipcc -O3 -c ./examples/transpose/transpose.cpp -o /tmp/transpose.o
 
     - name: Configure, Build, and Test with System Dependencies
       timeout-minutes: 115
@@ -419,7 +395,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: dgaliffiamd/rocprofiler-systems:ci-base-ubuntu-22.04
+      image: dgaliffiamd/rocprofiler-systems:ci-rocm-7.2-ubuntu-22.04
       options: --cap-add CAP_SYS_ADMIN
 
     env:
@@ -427,9 +403,16 @@ jobs:
       ROCPROFSYS_CAUSAL_BACKEND: perf
       ROCPROFSYS_CI: 'ON'
       ROCPROFSYS_MAX_THREADS: '64'
+      ROCM_PATH: /opt/rocm
 
     steps:
     - *sparse-checkout
+
+    - name: Configure ROCm Environment
+      shell: bash
+      run: |
+        echo "/opt/rocm/bin" >> $GITHUB_PATH
+        echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 
     - name: Install Packages
       timeout-minutes: 25
@@ -442,7 +425,7 @@ jobs:
           cd projects/rocprofiler-systems/
           apt-get update &&
           apt-get upgrade -y &&
-          apt-get install -y libomp-dev libmpich-dev mpich &&
+          apt-get install -y libmpich-dev mpich &&
           apt-get autoclean
 
     - name: Install Python Test Dependencies
@@ -456,30 +439,6 @@ jobs:
             "${env_dir}bin/python3" -m pip install -r requirements.txt
           fi
         done
-
-    - name: Install ROCm Packages
-      timeout-minutes: 25
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
-      with:
-        retry_wait_seconds: 30
-        timeout_minutes: 25
-        max_attempts: 5
-        shell: bash
-        command: |
-          cd projects/rocprofiler-systems/
-          ROCM_VERSION=7.2
-          ROCM_MAJOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $1}')
-          ROCM_MINOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $2}')
-          ROCM_VERSN=$(( (${ROCM_MAJOR}*10000)+(${ROCM_MINOR}*100) ))
-          echo "ROCM_MAJOR=${ROCM_MAJOR} ROCM_MINOR=${ROCM_MINOR} ROCM_VERSN=${ROCM_VERSN}"
-          wget -q https://repo.radeon.com/amdgpu-install/${ROCM_VERSION}/ubuntu/jammy/amdgpu-install_${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1_all.deb
-          apt-get install -y ./amdgpu-install_${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1_all.deb
-          apt-get update
-          apt-get install -y rocm-dev
-          apt-get autoclean
-          echo "/opt/rocm/bin" >> $GITHUB_PATH
-          echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 
     - name: Configure Env
       run:

--- a/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
@@ -49,7 +49,7 @@ jobs:
   ubuntu-noble:
     runs-on: ubuntu-latest
     container:
-      image: dgaliffiamd/rocprofiler-systems:ci-base-ubuntu-24.04
+      image: dgaliffiamd/rocprofiler-systems:ci-rocm-${{ matrix.rocm-version }}-ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -64,6 +64,7 @@ jobs:
       ROCPROFSYS_CI: 'ON'
       ROCPROFSYS_MAX_THREADS: '64'
       ROCPROFSYS_KEEP_TEST_OUTPUT: '0'
+      ROCM_PATH: /opt/rocm
 
     steps:
     - &sparse-checkout
@@ -72,19 +73,6 @@ jobs:
         sparse-checkout: |
           projects/rocprofiler-systems/
           .gitmodules
-
-    - name: Install Packages
-      timeout-minutes: 25
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
-      with:
-        retry_wait_seconds: 30
-        timeout_minutes: 25
-        max_attempts: 5
-        command: |
-          apt-get update &&
-          apt-get upgrade -y &&
-          apt-get install -y libomp-dev libopenmpi-dev &&
-          apt-get autoclean
 
     - name: Install Python Test Dependencies
       timeout-minutes: 10
@@ -98,21 +86,11 @@ jobs:
           fi
         done
 
-    - name: Install ROCm Packages
-      timeout-minutes: 115
+    - name: Configure ROCm Environment
       shell: bash
-      working-directory: projects/rocprofiler-systems/
       run: |
-        ROCM_VERSION=${{ matrix.rocm-version }}
-        ROCM_MAJOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $1}')
-        ROCM_MINOR=$(echo ${ROCM_VERSION} | sed 's/\./ /g' | awk '{print $2}')
-        ROCM_VERSN=$(( (${ROCM_MAJOR}*10000)+(${ROCM_MINOR}*100) ))
-        echo "ROCM_MAJOR=${ROCM_MAJOR} ROCM_MINOR=${ROCM_MINOR} ROCM_VERSN=${ROCM_VERSN}"
-        wget -q https://repo.radeon.com/amdgpu-install/${{ matrix.rocm-version }}/ubuntu/noble/amdgpu-install_${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1_all.deb
-        apt-get install -y ./amdgpu-install_${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1_all.deb
-        apt-get update
-        apt-get install -y rocm-dev rocdecode-dev libavformat-dev libavcodec-dev
-        apt-get autoclean
+        echo "/opt/rocm/bin" >> $GITHUB_PATH
+        echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 
     - name: Configure, Build and Test
       timeout-minutes: 115
@@ -224,7 +202,7 @@ jobs:
   ubuntu-noble-system-deps:
     runs-on: ubuntu-latest
     container:
-      image: dgaliffiamd/rocprofiler-systems:ci-base-ubuntu-24.04
+      image: dgaliffiamd/rocprofiler-systems:ci-rocm-7.2-ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -243,9 +221,16 @@ jobs:
       ROCPROFSYS_CI: 'ON'
       ROCPROFSYS_MAX_THREADS: '64'
       ROCPROFSYS_KEEP_TEST_OUTPUT: '0'
+      ROCM_PATH: /opt/rocm
 
     steps:
     - *sparse-checkout
+
+    - name: Configure ROCm Environment
+      shell: bash
+      run: |
+        echo "/opt/rocm/bin" >> $GITHUB_PATH
+        echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 
     - name: Install System Dependency Packages
       timeout-minutes: 25
@@ -258,7 +243,7 @@ jobs:
           cd projects/rocprofiler-systems/
           apt-get update &&
           apt-get upgrade -y &&
-          apt-get install -y libomp-dev libopenmpi-dev g++ \
+          apt-get install -y g++ \
             binutils-dev libboost-all-dev libtbb-dev \
             libdw-dev libdwarf-dev libelf-dev libiberty-dev &&
           apt-get autoclean
@@ -275,30 +260,11 @@ jobs:
           fi
         done
 
-    - name: Install ROCm 7.2
-      timeout-minutes: 25
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
-      with:
-        retry_wait_seconds: 30
-        timeout_minutes: 25
-        max_attempts: 5
-        shell: bash
-        command: |
-          cd projects/rocprofiler-systems/
-          ROCM_VERSION=7.2
-          ROCM_MAJOR=7
-          ROCM_MINOR=2
-          ROCM_VERSN=70200
-          echo "Installing ROCm ${ROCM_VERSION}"
-          wget -q https://repo.radeon.com/amdgpu-install/${ROCM_VERSION}/ubuntu/noble/amdgpu-install_${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1_all.deb
-          apt-get install -y ./amdgpu-install_${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1_all.deb
-          apt-get update
-          apt-get install -y rocm-dev rocdecode-dev libavformat-dev libavcodec-dev
-          apt-get autoclean
-          echo "/opt/rocm/bin" >> $GITHUB_PATH
-          echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
-          /opt/rocm/bin/hipcc -O3 -c ./examples/transpose/transpose.cpp -o /tmp/transpose.o
+    - name: Sanity Check ROCm
+      shell: bash
+      working-directory: projects/rocprofiler-systems/
+      run: |
+        /opt/rocm/bin/hipcc -O3 -c ./examples/transpose/transpose.cpp -o /tmp/transpose.o
 
     - name: Configure, Build, and Test with System Dependencies
       timeout-minutes: 115

--- a/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
@@ -64,7 +64,6 @@ jobs:
       ROCPROFSYS_CI: 'ON'
       ROCPROFSYS_MAX_THREADS: '64'
       ROCPROFSYS_KEEP_TEST_OUTPUT: '0'
-      ROCM_PATH: /opt/rocm
 
     steps:
     - &sparse-checkout
@@ -90,6 +89,7 @@ jobs:
       shell: bash
       run: |
         echo "/opt/rocm/bin" >> $GITHUB_PATH
+        echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 
     - name: Configure, Build and Test
@@ -221,7 +221,6 @@ jobs:
       ROCPROFSYS_CI: 'ON'
       ROCPROFSYS_MAX_THREADS: '64'
       ROCPROFSYS_KEEP_TEST_OUTPUT: '0'
-      ROCM_PATH: /opt/rocm
 
     steps:
     - *sparse-checkout
@@ -230,6 +229,7 @@ jobs:
       shell: bash
       run: |
         echo "/opt/rocm/bin" >> $GITHUB_PATH
+        echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 
     - name: Install System Dependency Packages

--- a/projects/rocprofiler-systems/cmake/Packages.cmake
+++ b/projects/rocprofiler-systems/cmake/Packages.cmake
@@ -669,6 +669,12 @@ else()
     endif()
 endif()
 
+# Dyninst's Annotatable.h triggers GCC 14's -Wcalloc-transposed-args; suppress it
+# for any TU that pulls in dyninst headers since the project builds with -Werror.
+add_target_cxx_flag_if_avail(
+    rocprofiler-systems-dyninst "-Wno-calloc-transposed-args"
+)
+
 # ----------------------------------------------------------------------------------------#
 #
 # Modify CMAKE_C_FLAGS and CMAKE_CXX_FLAGS with -static-libgcc and -static-libstdc++

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -48,6 +48,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <exception>
+#include <filesystem>
 #include <fstream>
 #include <limits>
 #include <linux/capability.h>
@@ -55,6 +56,7 @@
 #include <ostream>
 #include <sstream>
 #include <string>
+#include <system_error>
 #include <type_traits>
 #include <unistd.h>
 #include <utility>
@@ -2710,12 +2712,20 @@ tmp_file::~tmp_file()
 void
 tmp_file::touch() const
 {
-    if(!filepath::exists(filename))
-    {
-        // if the filepath does not exist, open in out mode to create it
-        auto _ofs = std::ofstream{};
-        filepath::open(_ofs, filename);
-    }
+    namespace fs = std::filesystem;
+
+    std::error_code _ec;
+    if(fs::exists(filename, _ec)) return;
+
+    // Pre-create parent directories with std::filesystem, which treats an
+    // already-existing directory as success. timemory's filepath::makedir
+    // races on EEXIST when multiple MPI ranks share a parent directory and
+    // can fail to create the file as a result.
+    auto _parent = fs::path{ filename }.parent_path();
+    if(!_parent.empty()) fs::create_directories(_parent, _ec);
+
+    auto _ofs = std::ofstream{};
+    filepath::open(_ofs, filename);
 }
 
 bool

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -43,6 +43,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <cerrno>
 #include <csignal>
 #include <cstdint>
 #include <cstdio>
@@ -56,6 +57,7 @@
 #include <ostream>
 #include <sstream>
 #include <string>
+#include <sys/stat.h>
 #include <system_error>
 #include <type_traits>
 #include <unistd.h>
@@ -2712,17 +2714,30 @@ tmp_file::~tmp_file()
 void
 tmp_file::touch() const
 {
-    namespace fs = std::filesystem;
+    // Use POSIX primitives instead of std::filesystem here. Some downstream
+    // libraries (e.g. ROCm 6.3/6.4 librocprofiler-register.so) statically
+    // link libstdc++ and re-export std::filesystem::__cxx11::path symbols
+    // with default visibility. The dynamic linker then binds path methods to
+    // an ABI-incompatible copy and segfaults at the first call. POSIX stat()
+    // and mkdir() avoid that resolution path entirely. Multi-rank EEXIST
+    // races are tolerated by ignoring EEXIST on each segment.
 
-    std::error_code _ec;
-    if(fs::exists(filename, _ec)) return;
+    struct stat _st = {};
+    if(::stat(filename.c_str(), &_st) == 0) return;
 
-    // Pre-create parent directories with std::filesystem, which treats an
-    // already-existing directory as success. timemory's filepath::makedir
-    // races on EEXIST when multiple MPI ranks share a parent directory and
-    // can fail to create the file as a result.
-    auto _parent = fs::path{ filename }.parent_path();
-    if(!_parent.empty()) fs::create_directories(_parent, _ec);
+    auto _slash = filename.find_last_of('/');
+    if(_slash != std::string::npos && _slash > 0)
+    {
+        auto _parent = filename.substr(0, _slash);
+        for(std::string::size_type i = 1; i <= _parent.size(); ++i)
+        {
+            if(i == _parent.size() || _parent[i] == '/')
+            {
+                std::string _segment = _parent.substr(0, i);
+                if(::mkdir(_segment.c_str(), 0755) != 0 && errno != EEXIST) break;
+            }
+        }
+    }
 
     auto _ofs = std::ofstream{};
     filepath::open(_ofs, filename);

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -43,13 +43,11 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
-#include <cerrno>
 #include <csignal>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <exception>
-#include <filesystem>
 #include <fstream>
 #include <limits>
 #include <linux/capability.h>
@@ -57,8 +55,6 @@
 #include <ostream>
 #include <sstream>
 #include <string>
-#include <sys/stat.h>
-#include <system_error>
 #include <type_traits>
 #include <unistd.h>
 #include <utility>
@@ -2714,33 +2710,12 @@ tmp_file::~tmp_file()
 void
 tmp_file::touch() const
 {
-    // Use POSIX primitives instead of std::filesystem here. Some downstream
-    // libraries (e.g. ROCm 6.3/6.4 librocprofiler-register.so) statically
-    // link libstdc++ and re-export std::filesystem::__cxx11::path symbols
-    // with default visibility. The dynamic linker then binds path methods to
-    // an ABI-incompatible copy and segfaults at the first call. POSIX stat()
-    // and mkdir() avoid that resolution path entirely. Multi-rank EEXIST
-    // races are tolerated by ignoring EEXIST on each segment.
-
-    struct stat _st = {};
-    if(::stat(filename.c_str(), &_st) == 0) return;
-
-    auto _slash = filename.find_last_of('/');
-    if(_slash != std::string::npos && _slash > 0)
+    if(!filepath::exists(filename))
     {
-        auto _parent = filename.substr(0, _slash);
-        for(std::string::size_type i = 1; i <= _parent.size(); ++i)
-        {
-            if(i == _parent.size() || _parent[i] == '/')
-            {
-                std::string _segment = _parent.substr(0, i);
-                if(::mkdir(_segment.c_str(), 0755) != 0 && errno != EEXIST) break;
-            }
-        }
+        // if the filepath does not exist, open in out mode to create it
+        auto _ofs = std::ofstream{};
+        filepath::open(_ofs, filename);
     }
-
-    auto _ofs = std::ofstream{};
-    filepath::open(_ofs, filename);
 }
 
 bool

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/shmem_gotcha.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/shmem_gotcha.hpp
@@ -185,12 +185,12 @@ struct shmem_gotcha : tim::component::base<shmem_gotcha<SHMEMPolicy>, void>
 
     static constexpr size_t gotcha_capacity = 120;
 
-    shmem_gotcha<SHMEMPolicy>()                                                = default;
-    shmem_gotcha<SHMEMPolicy>(const shmem_gotcha<SHMEMPolicy>&)                = default;
-    shmem_gotcha<SHMEMPolicy>& operator=(const shmem_gotcha<SHMEMPolicy>&)     = default;
-    shmem_gotcha<SHMEMPolicy>(shmem_gotcha<SHMEMPolicy>&&) noexcept            = default;
-    shmem_gotcha<SHMEMPolicy>& operator=(shmem_gotcha<SHMEMPolicy>&&) noexcept = default;
-    ~shmem_gotcha<SHMEMPolicy>() noexcept                                      = default;
+    shmem_gotcha()                                   = default;
+    shmem_gotcha(const shmem_gotcha&)                = default;
+    shmem_gotcha& operator=(const shmem_gotcha&)     = default;
+    shmem_gotcha(shmem_gotcha&&) noexcept            = default;
+    shmem_gotcha& operator=(shmem_gotcha&&) noexcept = default;
+    ~shmem_gotcha() noexcept                         = default;
 
     static std::string label() { return "shmem_gotcha"; }
 

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/runners.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/runners.py
@@ -18,7 +18,6 @@ from dataclasses import dataclass, field
 from enum import Enum
 import os
 from pathlib import Path
-import shlex
 import shutil
 import subprocess
 from typing import Optional
@@ -253,11 +252,15 @@ class BaseRunner(ABC):
             except (subprocess.TimeoutExpired, OSError):
                 pass
 
-        if self.launcher is type(self).Launcher.SHMEM:
-            # oshrun on RHEL 10 / ROCm 7.x drops argv after `--`, so the wrapped
-            # binary receives no command and prints its usage banner. Wrapping
-            # the inner command in a single `bash -c` string preserves it.
-            return cmd + ["bash", "-c", shlex.join(command)]
+        if self.launcher is type(self).Launcher.SHMEM and command:
+            # PRRTE-based oshrun (Open MPI >= 5.0) strips the first literal
+            # `--` from the program argv, breaking `rocprof-sys-run -- <binary>`.
+            # A second `--` survives, so insert a decoy right after the program
+            # name to absorb the strip. Older ORTE-based oshrun (4.x) preserves
+            # `--` and would forward the decoy verbatim, so gate on version.
+            oshrun_version = self.config.capabilities.oshrun_version
+            if oshrun_version is not None and oshrun_version[0] >= 5:
+                command = [command[0], "--"] + command[1:]
 
         return cmd + command
 

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/runners.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/runners.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 import os
 from pathlib import Path
+import shlex
 import shutil
 import subprocess
 from typing import Optional
@@ -251,6 +252,12 @@ class BaseRunner(ABC):
                     cmd.insert(1, "--oversubscribe")
             except (subprocess.TimeoutExpired, OSError):
                 pass
+
+        if self.launcher is type(self).Launcher.SHMEM:
+            # oshrun on RHEL 10 / ROCm 7.x drops argv after `--`, so the wrapped
+            # binary receives no command and prints its usage banner. Wrapping
+            # the inner command in a single `bash -c` string preserves it.
+            return cmd + ["bash", "-c", shlex.join(command)]
 
         return cmd + command
 

--- a/projects/rocprofiler-systems/tests/pytest/test_shmem.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_shmem.py
@@ -110,6 +110,7 @@ class TestShmem(RocprofsysTest):
         if mode == "sys_run":
             self.assert_perfetto(
                 result,
+                categories=["shmem", "host"],
                 labels=["shmem_pingpong", "start_pes"],
                 counts=[1, 1],
                 depths=[0, 1],

--- a/projects/rocprofiler-systems/tests/pytest/test_shmem.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_shmem.py
@@ -110,7 +110,6 @@ class TestShmem(RocprofsysTest):
         if mode == "sys_run":
             self.assert_perfetto(
                 result,
-                categories=["shmem"],
                 labels=["shmem_pingpong", "start_pes"],
                 counts=[1, 1],
                 depths=[0, 1],

--- a/projects/rocprofiler-systems/tests/pytest/test_shmem.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_shmem.py
@@ -110,6 +110,7 @@ class TestShmem(RocprofsysTest):
         if mode == "sys_run":
             self.assert_perfetto(
                 result,
+                categories=["shmem"],
                 labels=["shmem_pingpong", "start_pes"],
                 counts=[1, 1],
                 depths=[0, 1],


### PR DESCRIPTION
## Motivation

Switch rocprofiler-systems CI workflows from installing ROCm at runtime
(via `amdgpu-install` / `dnf`) to using pre-built Docker images that
already contain ROCm. This eliminates the slowest, most failure-prone CI
step and makes builds reproducible against a fixed ROCm snapshot.

## Technical Details

**Workflow changes** (Debian, RHEL, Ubuntu Jammy, Ubuntu Noble):
- Container images changed from `ci-base-<distro>` to
  `ci-rocm-<version>-<distro>` (ROCm pre-installed).
- Removed the `Install ROCm Packages` / `Install Packages` steps that
  downloaded and installed ROCm from repo.radeon.com at runtime.
- Replaced with a lightweight `Configure ROCm Environment` step that
  sets `GITHUB_PATH`, `ROCM_PATH`, and `LD_LIBRARY_PATH`.
- Added `Sanity Check ROCm` step (hipcc compile test) where applicable.
- Removed `libomp-dev` / `libopenmpi-dev` from package installs (now in
  the base image).

**Bug fixes uncovered during bring-up:**
- `shmem_gotcha.hpp`: removed redundant template-id on special member
  function declarations (fixes GCC 14 `-Wextra` warnings under
  `-Werror`).
- `Packages.cmake`: suppress `-Wcalloc-transposed-args` for TUs that
  include Dyninst headers (GCC 14).
- `runners.py` (SHMEM tests): work around PRRTE-based `oshrun` (Open
  MPI >= 5.0) stripping the first literal `--` from argv by inserting a
  decoy `--` token.
- `test_shmem.py`: tighten Perfetto assertion with explicit `categories`
  filter.

## Test Plan

- CI workflows pass on all four distro targets (Debian, RHEL8.10, RHEL 9, Ubuntu
  Jammy, Ubuntu Noble) with the new images.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.