### PR TITLE
[CI] Add labeler.yml to the skippable list

### DIFF
--- a/.github/scripts/tests/therock_configure_ci_test.py
+++ b/.github/scripts/tests/therock_configure_ci_test.py
@@ -117,6 +117,9 @@ class ConfigureCITest(unittest.TestCase):
             therock_configure_ci.is_path_skippable("projects/rocminfo/docs/api.rst")
         )
         self.assertTrue(therock_configure_ci.is_path_skippable(".gitignore"))
+        self.assertTrue(therock_configure_ci.is_path_skippable(".github/labeler.yml"))
+        self.assertTrue(therock_configure_ci.is_path_skippable(".github/labels.yml"))
+        self.assertTrue(therock_configure_ci.is_path_skippable(".github/workflows/labeler.yml"))
 
         # Test non-skippable patterns
         self.assertFalse(

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -135,6 +135,8 @@ SKIPPABLE_PATH_PATTERNS = [
     "shared/*/docs/*",
     "shared/*/.gitignore",
     "experimental/python/perfxpert/*",
+    ".github/label*.yml",
+    ".github/workflows/labeler.yml",
 ]
 
 


### PR DESCRIPTION
## Motivation

We are running the full CI when files change that don't need to trigger a full build and test of TheRock.

## Technical Details

Add label-related files to the list that doesn't trigger a full build and test in `therock_configure_ci.py`.

* .github/labeler.yml
* .github/labels.yml
* .github/workflows/labeler.yml

These just add labels to PRs in GitHub so there's no need to build and test TheRock when they change.

## JIRA ID

N/A

## Test Plan

Added asserts to the skippable list tests in `therock_configure_ci_test.py`

## Test Result

Passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
