### PR TITLE
[rocshmem] Add bitcode support for The Rock

### DIFF
--- a/projects/rocshmem/cmake/DeviceBitcode.cmake
+++ b/projects/rocshmem/cmake/DeviceBitcode.cmake
@@ -6,8 +6,16 @@
 
 # Device bitcode for JIT linking: librocshmem_device_{arch}.bc
 
-find_program(LLVM_CLANG clang++ PATHS ${ROCM_PATH}/llvm/bin NO_DEFAULT_PATH QUIET)
-find_program(LLVM_LINK llvm-link PATHS ${ROCM_PATH}/llvm/bin NO_DEFAULT_PATH QUIET)
+find_program(LLVM_CLANG clang++
+             PATHS
+               ${ROCM_PATH}/llvm/bin
+               ${THEROCK_TOOLCHAIN_ROOT}/lib/llvm/bin
+             NO_DEFAULT_PATH QUIET)
+find_program(LLVM_LINK llvm-link
+             PATHS
+               ${ROCM_PATH}/llvm/bin
+               ${THEROCK_TOOLCHAIN_ROOT}/lib/llvm/bin
+               NO_DEFAULT_PATH QUIET)
 
 if(NOT LLVM_CLANG OR NOT LLVM_LINK)
   message(WARNING "ROCm LLVM tools (clang++, llvm-link) not found under "


### PR DESCRIPTION
## Motivation

`ROCM_PATH` is no longer advisable for project that are built by The Rock, i.e rocSHMEM.

## Technical Details

1. rocSHMEM assumes we have `ROCM_PATH` but when building from The Rock we do not.
  a. We should use `THE_ROCK_TOOLCHAIN` for LLVM needs
2. Ideally, we would no longer rely `ROCM_PATH` but this PR just does the minimum for whats need for The Rock integration

## JIRA ID

AIROCSHMEM-327

## Test Plan

Steps to repoduce:

```
#!/bin/bash

#git clone https://github.com/ROCm/TheRock.git
cd TheRock
#git reset HEAD --hard
git clean -xdf

# Ensure that you've applied this patch to rocm-systems!!

# Install a patched patchelf from source. For details see
# https://github.com/ROCm/TheRock/blob/main/docs/environment_setup_guide.md#patchelf
#sudo apt install curl make
sudo env INSTALL_PREFIX=/usr/local ./dockerfiles/install_pinned_patchelf.sh

# Init python virtual environment and install python dependencies
python3 -m venv .venv && source .venv/bin/activate
pip install --upgrade pip
pip install -r requirements.txt
#
## Download submodules and apply patches
#python3 ./build_tools/fetch_sources.py
#
## Configure
cmake -B build -GNinja . --preset linux-release-package \
    -DTHEROCK_AMDGPU_FAMILIES=gfx950-dcgpu  \
    -DTHEROCK_ENABLE_ROCSHMEM=ON  \
    -DTHEROCK_ENABLE_ALL=OFF \

# Build
cmake --build build --target therock-archives .
```

## Test Result

Validate we have bitcode files. It can be seen that we currently build for arches we do not support in rocSHMEM however that change will have to be done in The Rock

```
(.venv) ytemucin@smci355-ccs-aus-m10-13:~/TheRock/TheRock$ find build/artifacts/ -iname "*.bc" | grep shmem
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx900.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx90c.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1030.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1102.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1153.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1012.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1201.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1034.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx942.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1200.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1101.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1103.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx90a.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1152.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1032.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx950.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1011.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx908.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1036.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx906.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1150.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1033.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1100.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1031.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1151.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1010.bc
build/artifacts/rocshmem_lib_generic/comm-libs/rocshmem/stage/lib/librocshmem_device_gfx1035.bc
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
