### PR TITLE
[RCCL] use 256 threads per block on gfx950

### DIFF
--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -125,7 +125,7 @@ union ncclLLFifoLine {
   #define WARP_SIZE 32
   #endif
   #if defined (__gfx950__)
-  #define NCCL_MAX_NTHREADS 512
+  #define NCCL_MAX_NTHREADS 256
   #else
   #define NCCL_MAX_NTHREADS 256
   #endif

--- a/projects/rccl/src/include/rccl_common.h
+++ b/projects/rccl/src/include/rccl_common.h
@@ -47,7 +47,7 @@ typedef enum RcclTunableColls {
 #define RCCL_PROTOCOL_THREAD_THRESHOLD_IDX 3
 
 #define RCCL_SINGLE_NODE_MAX_NTHREADS 256
-#define RCCL_GFX950_MAX_NTHREADS 512  // for Simple and LL64/LL128 gfx950
+#define RCCL_GFX950_MAX_NTHREADS 256  // for Simple and LL64/LL128 gfx950
 #define RCCL_DEFAULT_MAX_NTHREADS 256 // for Simple and LL64/LL128 other archs
 #define RCCL_LL_MAX_NTHREADS 256
 #define RCCL_P2P_MAX_NTHREADS 256


### PR DESCRIPTION
## Motivation

Reduce register spills on gfx950

## Technical Details

Reduce threads per block from 512 to 256 on gfx950

## JIRA ID

## Test Plan

Check register spills

## Test Result

Scratch Size [bytes per lane]

| kernels| 512 threads | 256 threads |
| -------- | -------- | -------- |
| unroll 1  | 520  | 352  |
| unroll 2  | 544  | 352  |

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
