### PR TITLE
[RCCL] Fix symmetric kernels validation errors on gfx942/gfx950

### DIFF
--- a/projects/rccl/src/include/nccl_device/impl/ll_a2a__funcs.h
+++ b/projects/rccl/src/include/nccl_device/impl/ll_a2a__funcs.h
@@ -26,9 +26,11 @@ NCCL_DEVICE_INLINE void amdLLA2aStoreLine(uint32_t* dst, uint32_t a0, uint32_t a
   __builtin_nontemporal_store(a2, (u32_gptr)dst + 2);
   __builtin_nontemporal_store(a3, (u32_gptr)dst + 3);
 #endif
+  asm volatile("" ::: "memory");
 }
 
 NCCL_DEVICE_INLINE void amdLLA2aLoadLine(const uint32_t* src, uint32_t& o0, uint32_t& o1, uint32_t& o2, uint32_t& o3) {
+  asm volatile("" ::: "memory");
 #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
   union { v4u v; uint32_t w[4]; } u;
   u.v = __builtin_amdgcn_global_load_b128((v4u_gptr)src, RCCL_SYSTEM_SYNCSCOPE);

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -569,7 +569,7 @@ void rcclSetWarpSpeedCUs(struct ncclComm* comm, int algo, int threadsPerBlock, i
 }
 
 bool rcclWarpSpeedSupported(struct ncclComm* comm, struct ncclKernelPlan* plan) {
-  if (!comm->topo->warpSpeedEnabled) {
+  if (!comm->topo->warpSpeedEnabled || plan->isSymColl) {
     return false;
   }
 

--- a/projects/rccl/src/sym_kernels.cc
+++ b/projects/rccl/src/sym_kernels.cc
@@ -91,7 +91,7 @@ static uint32_t kernelMask_user() {
 }
 
 NCCL_PARAM(SymCTAs, "SYM_CTAS", 0)
-NCCL_PARAM(SymLL, "SYM_LL", 0)
+NCCL_PARAM(SymLL, "SYM_LL", 1)
 
 static double softmin(double x, double ceiling, double softness) {
   // looks like a smooth version of: min(x, ceiling)


### PR DESCRIPTION
This PR fixes Symmetric kernels validation errors and hangs under both LL and SIMPLE protocols.

* Add compiler memory clobber to `amdLLA2aStoreLine` and `amdLLA2aLoadLine` to avoid potential reordering of loads and stores.
* Disable warpSpeed optimization for symmetric kernels
* Enable LL protocol by default

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
Resolves ROCM-20032
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
