### PR TITLE
[rocprofiler-systems] Fix re-attach hang in trace_cache buffer_storage

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.cpp
@@ -49,8 +49,9 @@ flush_worker_t::start(const pid_t& current_pid)
         throw std::runtime_error(_ss.str());
     }
 
-    m_worker_synchronization->origin_pid = current_pid;
-    m_worker_synchronization->is_running = true;
+    m_worker_synchronization->origin_pid    = current_pid;
+    m_worker_synchronization->exit_finished = false;
+    m_worker_synchronization->is_running    = true;
 
     m_flushing_thread = std::make_unique<std::thread>([&]() {
         LOG_TRACE("Flush worker thread started for pid={}",


### PR DESCRIPTION
## Motivation

Re-attaching to a target process via `rocprof-sys-attach` after a clean attach + detach hangs the second `detach` indefinitely. The hang is inside `cache_manager::shutdown` -> `buffer_storage::shutdown` -> `flush_worker_t::stop`, with the worker thread stuck on a futex wait that nobody will satisfy.

The bug was introduced in #4446 ("Fix sanitizer issues..."), which moved the CV mutexes from stack-local to shared `worker_synchronization_t` members. That fix was correct for the TSan UB, but it exposed a pre-existing latent flaw in the `start` / `stop` lifecycle: `start` resets `is_running` and `origin_pid` but does not reset `exit_finished`. The worker sets `exit_finished = true` on its way out; without resetting in `start`, a second `stop` finds the predicate already satisfied, returns from `wait` immediately, and races with the new worker's join.

Before #4446 this did not hang because the stack-local mutexes meant the CV's `wait` was effectively just polling the predicate; the second `stop` returned from `wait` immediately and `join` then completed normally. After #4446 the CV started doing real wait/notify work, and the missing reset became a deadlock.

## Technical Details

Reset `exit_finished` to `false` in `flush_worker_t::start` so the start/stop cycle is symmetric:

```cpp
m_worker_synchronization->origin_pid    = current_pid;
m_worker_synchronization->exit_finished = false;
m_worker_synchronization->is_running    = true;
```

The fix is one line. No interface or behaviour change for single-shot use; the existing `if(is_running()) return;` guard at the top of `start` already prevents this from interfering with an already-running worker.

## JIRA

N/A

## Test Plan

Manual reproduction with `rocprof-sys-attach -p <PID> -d 5 -F perfetto -o <path>` against a HIP target launched with `ROCP_TOOL_ATTACH=1`, repeated twice in sequence on the same target PID.

## Test Result

- Without patch: second `rocprof-sys-attach` invocation attaches, sleeps for the requested detach window, then hangs in `rocattach_detach`. The target's `rocp-bg-attach` thread is sleeping on `futex_do_wait` inside `cache_manager::shutdown`. The attacher must be `kill -KILL`-ed; the workload survives but is no longer cleanly attachable.
- With patch: both `rocprof-sys-attach` invocations exit with rc=0; both produce per-session perfetto traces; target survives both attach/detach cycles.

## Checklist

- [x] Fix verified locally on gfx1201 with two- and three-session re-attach
- [x] No behaviour change for single attach + detach
- [ ] Reviewed by trace_cache maintainers
