### PR TITLE
[rocdecode] Fix codespell issues

### DIFF
--- a/projects/rocdecode/CHANGELOG.md
+++ b/projects/rocdecode/CHANGELOG.md
@@ -102,7 +102,7 @@ Full documentation for rocDecode is available at [https://rocm.docs.amd.com/proj
 * The new bitstream reader feature. The bitstream reader contains built-in stream file parsers, including an elementary stream file parser and an IVF container file parser. It can parse AVC/HEVC/AV1 elementary stream files and AV1 IVF container files. Additional format support can be added in the future.
 * VP9 decode support.
 * More CTests: VP9 test and tests on video decode raw sample.
-* Two new samples, videodecoderaw and videodecodepicfiles, have been added. videodecoderaw uses the bitstream reader instead of the FFMPEG demuxer to get picture data, and videodecodepicfiles shows how to decode an elementary video stream stored in multiple files with each file containing bitstream data of a coded picutre
+* Two new samples, videodecoderaw and videodecodepicfiles, have been added. videodecoderaw uses the bitstream reader instead of the FFMPEG demuxer to get picture data, and videodecodepicfiles shows how to decode an elementary video stream stored in multiple files with each file containing bitstream data of a coded picture
 
 ### Changed
 

--- a/projects/rocdecode/api/rocdecode/rocdecode.h
+++ b/projects/rocdecode/api/rocdecode/rocdecode.h
@@ -473,9 +473,9 @@ typedef struct _RocdecAvcPicParams {
 typedef struct _RocdecAvcSliceParams {
     uint32_t slice_data_size;   // slice size in bytes
     uint32_t slice_data_offset; // byte offset of the current slice in the slice data buffer
-    uint32_t slice_data_flag;   /* see VA_SLICE_DATA_FLAG_XXX defintions */
+    uint32_t slice_data_flag;   /* see VA_SLICE_DATA_FLAG_XXX definitions */
     /**
-     * \brief Bit offset from NAL Header Unit to the begining of slice_data().
+     * \brief Bit offset from NAL Header Unit to the beginning of slice_data().
      *
      * This bit offset is relative to and includes the NAL unit byte
      * and represents the number of bits parsed in the slice_header()
@@ -593,7 +593,7 @@ typedef struct _RocdecHevcPicParams {
     uint8_t num_tile_rows_minus1;
     /**
      * when uniform_spacing_flag equals 1, application should populate
-     * column_width_minus[], and row_height_minus1[] with approperiate values.
+     * column_width_minus[], and row_height_minus1[] with appropriate values.
      */
     uint16_t column_width_minus1[19];
     uint16_t row_height_minus1[21];
@@ -664,7 +664,7 @@ typedef struct _RocdecHevcSliceParams {
     /** \brief Slice data buffer flags. See \c VA_SLICE_DATA_FLAG_XXX. */
     uint32_t slice_data_flag;
     /**
-     * \brief Byte offset from NAL unit header to the begining of slice_data().
+     * \brief Byte offset from NAL unit header to the beginning of slice_data().
      *
      * This byte offset is relative to and includes the NAL unit header
      * and represents the number of bytes parsed in the slice_header()
@@ -1000,7 +1000,7 @@ typedef struct  _RocdecVp9SegmentParameter {
 typedef struct _RocdecVp9SliceParams {
     /** \brief The byte count of current frame in the bitstream buffer,
      *  starting from first byte of the buffer.
-     *  It uses the name slice_data_size to be consitent with other codec,
+     *  It uses the name slice_data_size to be consistent with other codec,
      *  but actually means frame_data_size.
      */
     uint32_t slice_data_size;
@@ -1259,9 +1259,9 @@ typedef struct _RocdecAV1PicParams {
      *  pixel frames. And this process may happen multiple times.
      *  The array anchor_frames_list[] is used to register all the available
      *  anchor frames from both external and internal, up to the current
-     *  frame instance. If a previously registerred anchor frame is no longer
+     *  frame instance. If a previously registered anchor frame is no longer
      *  needed, it should be removed from the list. But it does not prevent
-     *  applications from relacing the frame buffer with new anchor frames.
+     *  applications from replacing the frame buffer with new anchor frames.
      *  Please note that the internal anchor frames may not still be present
      *  in the current DPB buffer. But if it is in the anchor_frames_list[],
      *  it should not be replaced with other frames or removed from memory
@@ -1743,7 +1743,7 @@ extern rocDecStatus ROCDECAPI rocDecReconfigureDecoder(rocDecDecoderHandle decod
 //!                                           RocdecProcParams *vid_postproc_params);
 //! \ingroup group_amd_rocdecode
 //! Post-process and map video frame corresponding to pic_idx for use in HIP. Returns HIP device pointer and associated
-//! pitch(horizontal stride) of the video frame. Returns device memory pointers and pitch for each plane (Y, U and V) seperately
+//! pitch(horizontal stride) of the video frame. Returns device memory pointers and pitch for each plane (Y, U and V) separately
 //! horizontal_pitch is a pointer to an unsigned 32-bit integer array of size 3.
 //! Please note that this API is a blocking call. If the video frame associated with the pic_idx is not ready, the call
 //! will wait for the decoding to complete before mapping the video frame for use in HIP.

--- a/projects/rocdecode/api/rocdecode/rocdecode_host.h
+++ b/projects/rocdecode/api/rocdecode/rocdecode_host.h
@@ -84,7 +84,7 @@ typedef struct _RocdecPicParamsHost {
 typedef struct _RocDecoderHostCreateInfo {
     uint32_t width;                        /**< IN: Coded sequence width in pixels */
     uint32_t height;                       /**< IN: Coded sequence height in pixels */
-    uint32_t num_decode_threads;           /**< IN: Maximum number of internal decode threads for multi-threading <default value 0: threading will be chosen as appropriate to get the max performace> */
+    uint32_t num_decode_threads;           /**< IN: Maximum number of internal decode threads for multi-threading <default value 0: threading will be chosen as appropriate to get the max performance> */
     rocDecVideoCodec codec_type;           /**< IN: rocDecVideoCodec_XXX */
     rocDecVideoChromaFormat chroma_format; /**< IN: rocDecVideoChromaFormat_XXX */
     uint32_t bit_depth_minus_8;            /**< IN: The value "BitDepth minus 8" */
@@ -171,7 +171,7 @@ extern rocDecStatus ROCDECAPI rocDecReconfigureDecoderHost(rocDecDecoderHandle d
 //!                                           RocdecProcParams *vid_postproc_params);
 //! \ingroup group_amd_rocdecode
 //! Post-process and map video frame corresponding to pic_idx for use in HIP. Returns HIP device pointer and associated
-//! line_size of the video frame. Returns host memory pointers and pitch for each plane (Y, U and V) seperately
+//! line_size of the video frame. Returns host memory pointers and pitch for each plane (Y, U and V) separately
 //! line_size is a pointer to an unsigned 32-bit integer array of size 3.
 /************************************************************************************************************************/
 extern rocDecStatus ROCDECAPI rocDecGetVideoFrameHost(rocDecDecoderHandle decoder_handle, int pic_idx,

--- a/projects/rocdecode/docs/how-to/using-rocDecode-video-decoder.rst
+++ b/projects/rocdecode/docs/how-to/using-rocDecode-video-decoder.rst
@@ -6,7 +6,7 @@
 Using the rocDecode RocVideoDecoder
 ********************************************************************
 
-rocDecode provides two methods fpr decoding a video stream: using the rocDecode RocVideoDecoder on the GPU or using the FFmpeg decoder on the CPU. 
+rocDecode provides two methods for decoding a video stream: using the rocDecode RocVideoDecoder on the GPU or using the FFmpeg decoder on the CPU. 
 
 
 This topic covers how to decode a video stream using the RocVideoDecoder class in |roc_video_dec|_. The RocVideoDecode class provides high-level calls to the core APIs in the |apifolder|_ of the rocDecode GitHub repository. For information about the core APIs, see :doc:`Using the rocDecode core APIs <../reference/rocDecode-core-APIs>`.

--- a/projects/rocdecode/samples/rocdecDecode/rocdecdecode.cpp
+++ b/projects/rocdecode/samples/rocdecDecode/rocdecdecode.cpp
@@ -181,7 +181,7 @@ struct DecoderInfo {
 };
 
 /**
- * @brief Funtion to save internal frame buffer to file for device buffer : chroma format is assumed to be NV12 for internal device memory
+ * @brief Function to save internal frame buffer to file for device buffer : chroma format is assumed to be NV12 for internal device memory
  * 
  * @param p_dec_info 
  * @param surf_mem  device mem pointers of luma and chroma planes
@@ -263,7 +263,7 @@ void save_frame_to_file(DecoderInfo *p_dec_info, void *surf_mem[], uint32_t *pit
 }
 
 /**
- * @brief Funtion to save internal frame buffer to file for host buffer
+ * @brief Function to save internal frame buffer to file for host buffer
  * 
  * @param p_dec_info 
  * @param frame_mem 
@@ -598,7 +598,7 @@ void create_parser(DecoderInfo& dec_info) {
     RocdecParserParams params = {};
     params.codec_type = dec_info.rocdec_codec_id;
     params.max_num_decode_surfaces = 6;
-    params.max_display_delay = 1;       // min display delay of 1 is recommented to get optimal performance from hardware decoder
+    params.max_display_delay = 1;       // min display delay of 1 is recommended to get optimal performance from hardware decoder
     params.user_data = &dec_info;
     params.pfn_sequence_callback = handle_video_sequence;
     params.pfn_decode_picture = handle_picture_decode;

--- a/projects/rocdecode/samples/videoDecodePicFiles/README.md
+++ b/projects/rocdecode/samples/videoDecodePicFiles/README.md
@@ -1,6 +1,6 @@
 # Video decode picture files sample
 
-The video decode picture files sample illustrates decoding an elementary video stream which is stored in multiple files with each file containing bitstream data of a coded picutre. This sample can be configured with a device ID and optionally able to dump the output to a file. This sample uses the high-level RocVideoDecoder class which connects both the video parser and Rocdecoder. This process repeats in a loop until all frames have been decoded.
+The video decode picture files sample illustrates decoding an elementary video stream which is stored in multiple files with each file containing bitstream data of a coded picture. This sample can be configured with a device ID and optionally able to dump the output to a file. This sample uses the high-level RocVideoDecoder class which connects both the video parser and Rocdecoder. This process repeats in a loop until all frames have been decoded.
 
 ## Prerequisites:
 

--- a/projects/rocdecode/samples/videoToSequence/README.md
+++ b/projects/rocdecode/samples/videoToSequence/README.md
@@ -28,7 +28,7 @@ make -j
               -d <GPU device ID - 0:device 0 / 1:device 1/ ... [optional - default:0]>
               -b <batch_size - specify the number of sequences to be decoded [optional - default:1]>
               -step <frame interval between each sequence [optional - default:1]> 
-              -stride <distance between consective frames in a sequence [optional - default:1]>
+              -stride <distance between consecutive frames in a sequence [optional - default:1]>
               -l <Number of frames in each sequence [optional - default:1]>
               -crop <crop rectangle for output (not used when using interopped decoded frame) [optional - default:1]>
               -seek_mode <option for seeking (0: no seek 1: seek to prev key frame) [optional - default: 0]>

--- a/projects/rocdecode/samples/videoToSequence/videotosequence.cpp
+++ b/projects/rocdecode/samples/videoToSequence/videotosequence.cpp
@@ -228,7 +228,7 @@ void ShowHelpAndExit(const char *option = NULL) {
     << "-d GPU device ID (0 for the first device, 1 for the second, etc.); optional; default: 0" << std::endl
     << "-b seq_info.batch_size - specify the number of sequences to be decoded; (default: all sequences till eof)" << std::endl
     << "-step - frame interval between each sequence; (default: sequence length)" << std::endl
-    << "-stride - distance between consective frames in a sequence; (default: 1)" << std::endl
+    << "-stride - distance between consecutive frames in a sequence; (default: 1)" << std::endl
     << "-l - Number of frames in each sequence; (default: 3)" << std::endl
     << "-crop crop rectangle for output (not used when using interopped decoded frame); optional; default: 0" << std::endl
     << "-seek_mode option for seeking (0: no seek 1: seek to prev key frame); optional; default: 0" << std::endl

--- a/projects/rocdecode/src/bit_stream_reader/es_reader.cpp
+++ b/projects/rocdecode/src/bit_stream_reader/es_reader.cpp
@@ -320,7 +320,7 @@ int RocVideoESParser::GetPicDataAvcHevc(uint8_t **p_pic_data, int *pic_size) {
                 CheckHevcNalForSlice(next_start_code_offset_, &slice_nal_flag, &first_slice_flag); // peek the next NAL
             }
             if (slice_nal_flag && first_slice_flag) {
-                // Between two pictures, we can have non-slice NAL units which are associated with the next picutre
+                // Between two pictures, we can have non-slice NAL units which are associated with the next picture
                 if (curr_pic_end_ < pic_data_size_) {
                     next_pic_start_ = curr_pic_end_;
                 }

--- a/projects/rocdecode/src/bit_stream_reader/es_reader.h
+++ b/projects/rocdecode/src/bit_stream_reader/es_reader.h
@@ -203,7 +203,7 @@ class RocVideoESParser {
         int CheckHevcEStream(uint8_t *p_stream, int stream_size);
 
         /*! \brief Function to convert from Encapsulated Byte Sequence Packets to Raw Byte Sequence Payload
-        * \param [inout] stream_buffer A pointer of <tt>uint8_t</tt> for the converted RBSP buffer.
+        * \param [in,out] stream_buffer A pointer of <tt>uint8_t</tt> for the converted RBSP buffer.
         * \param [in] begin_bytepos Start position in the EBSP buffer to convert
         * \param [in] end_bytepos End position in the EBSP buffer to convert, generally it's size.
         * \return Returns the size of the converted buffer

--- a/projects/rocdecode/src/parser/av1_parser.cpp
+++ b/projects/rocdecode/src/parser/av1_parser.cpp
@@ -255,7 +255,7 @@ ParserResult Av1VideoParser::NotifyNewSequence(Av1SequenceHeader *p_seq_header, 
     video_format_params_.display_area.bottom = p_frame_header->render_size.render_height;
     video_format_params_.bitrate = 0;
 
-    // Dispaly aspect ratio
+    // Display aspect ratio
     int disp_width = (video_format_params_.display_area.right - video_format_params_.display_area.left);
     int disp_height = (video_format_params_.display_area.bottom - video_format_params_.display_area.top);
     int gcd = std::__gcd(disp_width, disp_height); // greatest common divisor

--- a/projects/rocdecode/src/parser/av1_parser.h
+++ b/projects/rocdecode/src/parser/av1_parser.h
@@ -139,7 +139,7 @@ protected:
 
     /*! \brief Function to notify decoder about new sequence format through callback
      * \param [in] p_seq_header Pointer to the current sequence header
-     * \param [in] p_frame_header Ponter to the current frame header
+     * \param [in] p_frame_header Pointer to the current frame header
      * \return <tt>ParserResult</tt>
      */
     ParserResult NotifyNewSequence(Av1SequenceHeader *p_seq_header, Av1FrameHeader *p_frame_header);
@@ -241,7 +241,7 @@ protected:
 
     /*! \brief Function to mark reference frames
      * \param [in] p_seq_header Pointer to sequence header
-     * \param [in] p_frame_header Ponter to frame header
+     * \param [in] p_frame_header Pointer to frame header
      * \param [in] id_len Current frame id length
      */
     void MarkRefFrames(Av1SequenceHeader *p_seq_header, Av1FrameHeader *p_frame_header, uint32_t id_len);
@@ -291,7 +291,7 @@ protected:
     int GetRelativeDist(Av1SequenceHeader *p_seq_header, int a, int b);
 
     /*! \brief Function to compute the elements in the ref_frame_idx array. 7.8. Set frame refs process.
-     * \param [in] p_seq_header Pinter to sequence header struct
+     * \param [in] p_seq_header Pointer to sequence header struct
      * \param [out] p_frame_header Pointer to frame header struct
      * \return None
      */
@@ -511,7 +511,7 @@ protected:
      *         via multiplying by div_factor and shifting right by div_shift.
      *  \param [in] d Input variable d
      *  \param [out] div_shift The output shift value
-     *  \param [out] div_factor The ouput factor value
+     *  \param [out] div_factor The output factor value
      *  \return None
      */
     void ResolveDivisor(int d, int *div_shift, int *div_factor);

--- a/projects/rocdecode/src/parser/avc_parser.cpp
+++ b/projects/rocdecode/src/parser/avc_parser.cpp
@@ -391,7 +391,7 @@ ParserResult AvcVideoParser::NotifyNewSps(AvcSeqParameterSet *p_sps) {
 
     video_format_params_.bitrate = 0;
 
-    // Dispaly aspect ratio
+    // Display aspect ratio
     // Table E-1.
     static const Rational avc_sar[] = {
         {0, 0}, // unspecified
@@ -2277,7 +2277,7 @@ ParserResult AvcVideoParser::SetupReflist(AvcSliceInfo *p_slice_info) {
     }
 
     if (p_slice_header->slice_type == kAvcSliceTypeI || p_slice_header->slice_type == kAvcSliceTypeSI || p_slice_header->slice_type == kAvcSliceTypeI_7 || p_slice_header->slice_type == kAvcSliceTypeSI_9) {
-        // We still need to do 8.2.4.1 above for I pictures but will not go furhter.
+        // We still need to do 8.2.4.1 above for I pictures but will not go further.
         return PARSER_OK;
     }
 
@@ -2809,7 +2809,7 @@ ParserResult AvcVideoParser::MarkDecodedRefPics() {
             dpb_buffer_.field_pic_list[i * 2].is_reference = kUnusedForReference;
             dpb_buffer_.field_pic_list[i * 2 + 1].is_reference = kUnusedForReference;
         }
-        // Output the remaining picutres in DPB
+        // Output the remaining pictures in DPB
         if (FlushDpb() != PARSER_OK) {
             return PARSER_FAIL;
         }
@@ -3014,7 +3014,7 @@ ParserResult AvcVideoParser::MarkDecodedRefPics() {
                             dpb_buffer_.field_pic_list[j * 2].is_reference = kUnusedForReference;
                             dpb_buffer_.field_pic_list[j * 2 + 1].is_reference = kUnusedForReference;
                         }
-                        // Output the remaining picutres in DPB
+                        // Output the remaining pictures in DPB
                         if (FlushDpb() != PARSER_OK) {
                                 return PARSER_FAIL;
                         }

--- a/projects/rocdecode/src/parser/avc_parser.h
+++ b/projects/rocdecode/src/parser/avc_parser.h
@@ -186,7 +186,7 @@ protected:
     /*! \brief Function to parse slice header
      * \param p_stream The pointer to the input bit stream
      * \param [in] stream_size_in_byte The byte size of the stream
-     * \param [out] p_slice_header The pointer to the slice header strucutre
+     * \param [out] p_slice_header The pointer to the slice header structure
      * \return <tt>ParserResult</tt>
      */
     ParserResult ParseSliceHeader(uint8_t *p_stream, size_t stream_size_in_byte, AvcSliceHeader *p_slice_header);
@@ -230,8 +230,8 @@ protected:
      */
    ParserResult DecodeFrameNumGaps();
 
-    /*! \brief Function to set up the reference picutre lists for each slice. 8.2.4.
-     * \param [in] p_slice_info Poiner to slice info struct
+    /*! \brief Function to set up the reference picture lists for each slice. 8.2.4.
+     * \param [in] p_slice_info Pointer to slice info struct
      * \return <tt>ParserResult</tt>
      */
     ParserResult SetupReflist(AvcSliceInfo *p_slice_info);

--- a/projects/rocdecode/src/parser/hevc_parser.cpp
+++ b/projects/rocdecode/src/parser/hevc_parser.cpp
@@ -185,7 +185,7 @@ int HevcVideoParser::FillSeqCallbackFn(HevcSeqParamSet* sps_data) {
     
     video_format_params_.bitrate = 0;
 
-    // Dispaly aspect ratio
+    // Display aspect ratio
     // Table E-1.
     static const Rational hevc_sar[] = {
         {0, 0}, // unspecified
@@ -270,7 +270,7 @@ int HevcVideoParser::SendPicForDecode() {
     dec_pic_params_.intra_pic_flag = slice_info_list_[0].slice_header.slice_type == HEVC_SLICE_TYPE_I ? 1 : 0;
 
     // Todo: field_pic_flag, bottom_field_flag, second_field, ref_pic_flag, and intra_pic_flag seems to be associated with AVC/H.264.
-    // Do we need them for general purpose? Reomve if not.
+    // Do we need them for general purpose? Remove if not.
 
     // Fill picture parameters
     RocdecHevcPicParams *pic_param_ptr = &dec_pic_params_.pic_params.hevc;
@@ -671,7 +671,7 @@ ParserResult HevcVideoParser::ParsePictureData(const uint8_t* p_stream, uint32_t
                         // Get POC. 8.3.1.
                         CalculateCurrPoc();
 
-                        // Locate a free buffer for the current picutre in decode buffer pool before output picture marking (C.5.2.2)
+                        // Locate a free buffer for the current picture in decode buffer pool before output picture marking (C.5.2.2)
                         if (FindFreeInDecBufPool() != PARSER_OK) {
                             FunctionExitLog(g_rocdec_logger);
                             return PARSER_FAIL;
@@ -767,7 +767,7 @@ void HevcVideoParser::ParsePtl(HevcProfileTierLevel *ptl, bool profile_present_f
         ptl->general_frame_only_constraint_flag = Parser::GetBit(nalu, offset);
         // ReadBits is limited to 32
         offset += 44; // skip 44 bits
-        // Todo: add constrant flags parsing for higher profiles when needed
+        // Todo: add constraint flags parsing for higher profiles when needed
     }
 
     ptl->general_level_idc = Parser::ReadBits(nalu, offset, 8);
@@ -794,7 +794,7 @@ void HevcVideoParser::ParsePtl(HevcProfileTierLevel *ptl, bool profile_present_f
             ptl->sub_layer_frame_only_constraint_flag[i] = Parser::GetBit(nalu, offset);
             // ReadBits is limited to 32
             offset += 44;  // skip 44 bits
-            // Todo: add constrant flags parsing for higher profiles when needed
+            // Todo: add constraint flags parsing for higher profiles when needed
         }
         if (ptl->sub_layer_level_present_flag[i]) {
             ptl->sub_layer_level_idc[i] = Parser::ReadBits(nalu, offset, 8);
@@ -1994,7 +1994,7 @@ ParserResult HevcVideoParser::ParseSliceHeader(uint8_t *nalu, size_t size, HevcS
         p_slice_header->is_received = 1;
         memcpy(&slice_header_copy_, p_slice_header, sizeof(HevcSliceSegHeader));
     } else {
-        //dependant slice
+        //dependent slice
         if (!slice_header_copy_.is_received) {
             return PARSER_WRONG_STATE;
         }
@@ -2510,7 +2510,7 @@ int HevcVideoParser::BumpPicFromDpb() {
         }
     }
     if (min_poc_pic_idx >= HEVC_MAX_DPB_FRAMES) {
-        // No picture that is needed for ouput is found
+        // No picture that is needed for output is found
         return PARSER_OK;
     }
 

--- a/projects/rocdecode/src/parser/hevc_parser.h
+++ b/projects/rocdecode/src/parser/hevc_parser.h
@@ -186,7 +186,7 @@ protected:
     ParserResult ParsePps(uint8_t *nalu, size_t size);
 
     /*! \brief Function to parse Profiles, Tiers and Levels
-     * \param [out] ptl A pointer of <tt>HevcProfileTierLevel</tt> for the output from teh parsed stream
+     * \param [out] ptl A pointer of <tt>HevcProfileTierLevel</tt> for the output from the parsed stream
      * \param [in] profile_present_flag Input of <tt>bool</tt> - 1 specifies profile information is present, else 0
      * \param [in] max_num_sub_layers_minus1 Input of <tt>uint32_t</tt> - plus 1 specifies the maximum number of temporal sub-layers that may be present
      * \param [in] nalu A pointer of <tt>uint8_t</tt> for the input stream to be parsed
@@ -197,7 +197,7 @@ protected:
     void ParsePtl(HevcProfileTierLevel *ptl, bool profile_present_flag, uint32_t max_num_sub_layers_minus1, uint8_t *nalu, size_t size, size_t &offset);
     
     /*! \brief Function to parse Sub Layer Hypothetical Reference Decoder Parameters
-     * \param [out] sub_hrd A pointer of <tt>HevcSubLayerHrdParameters</tt> for the output from teh parsed stream
+     * \param [out] sub_hrd A pointer of <tt>HevcSubLayerHrdParameters</tt> for the output from the parsed stream
      * \param [in] cpb_cnt Input of <tt>uint32_t</tt> - specifies the coded picture buffer count in a HRD buffer
      * \param [in] sub_pic_hrd_params_present_flag Input of <tt>bool</tt> - 1 specifies sub layer HRD information is present, else 0
      * \param [in] nalu A pointer of <tt>uint8_t</tt> for the input stream to be parsed
@@ -273,7 +273,7 @@ protected:
      */
     ParserResult ParseSliceHeader(uint8_t *nalu, size_t size, HevcSliceSegHeader *p_slice_header);
 
-    /*! \brief Function to calculate the picture order count of the current picture. Once per picutre. (8.3.1)
+    /*! \brief Function to calculate the picture order count of the current picture. Once per picture. (8.3.1)
      */
     void CalculateCurrPoc();
 

--- a/projects/rocdecode/src/parser/roc_video_parser.h
+++ b/projects/rocdecode/src/parser/roc_video_parser.h
@@ -117,7 +117,7 @@ public:
     virtual rocDecStatus UnInitialize() = 0;     // pure virtual: implemented by derived class
     /**
      * @brief function to to release surface with pic_idx and mark it for reuse, can be called from a different thread than decode thread
-     * @brief calling thread is responsible for syncronizing
+     * @brief calling thread is responsible for synchronizing
      * \param [in] pic_idx surface index for the picture to be released
      * 
      * @return rocDecStatus 
@@ -153,7 +153,7 @@ protected:
      * is used to retrieve the VA surface Id.
      */
     std::vector<DecodeFrameBuffer> decode_buffer_pool_;
-    uint32_t num_output_pics_;  // number of pictures that are ready to be ouput
+    uint32_t num_output_pics_;  // number of pictures that are ready to be output
     std::vector<uint32_t> output_pic_list_; // sorted output frame index to decode_buffer_pool_
 
     RocdecTimeStamp curr_pts_;
@@ -195,7 +195,7 @@ protected:
     void CheckAndAdjustDecBufPoolSize(int dpb_size);
 
     /*! \brief Callback function to output decoded pictures from DPB for post-processing.
-     * \param [in] no_delay Indicator to override the display delay parameter wth no delay
+     * \param [in] no_delay Indicator to override the display delay parameter with no delay
      * \return <tt>ParserResult</tt>
      */
     ParserResult OutputDecodedPictures(bool no_delay);
@@ -207,7 +207,7 @@ protected:
 
     /*! \brief Function to convert from Encapsulated Byte Sequence Packets to Raw Byte Sequence Payload
      * 
-     * \param [inout] stream_buffer A pointer of <tt>uint8_t</tt> for the converted RBSP buffer.
+     * \param [in,out] stream_buffer A pointer of <tt>uint8_t</tt> for the converted RBSP buffer.
      * \param [in] begin_bytepos Start position in the EBSP buffer to convert
      * \param [in] end_bytepos End position in the EBSP buffer to convert, generally it's size.
      * \return Returns the size of the converted buffer in <tt>size_t</tt>

--- a/projects/rocdecode/src/parser/vp9_parser.cpp
+++ b/projects/rocdecode/src/parser/vp9_parser.cpp
@@ -236,7 +236,7 @@ ParserResult Vp9VideoParser::NotifyNewSequence(Vp9UncompressedHeader *p_uncomp_h
     video_format_params_.display_area.bottom = p_uncomp_header->frame_size.frame_height;
     video_format_params_.bitrate = 0;
 
-    // Dispaly aspect ratio
+    // Display aspect ratio
     int disp_width = (video_format_params_.display_area.right - video_format_params_.display_area.left);
     int disp_height = (video_format_params_.display_area.bottom - video_format_params_.display_area.top);
     int gcd = std::__gcd(disp_width, disp_height); // greatest common divisor
@@ -582,7 +582,7 @@ ParserResult Vp9VideoParser::ParseUncompressedHeader(uint8_t *p_stream, size_t s
     p_uncomp_header->header_size_in_bytes = Parser::ReadBits(p_stream, offset, 16);
 
     // Arbitrary size change is only supported on key frames. For other frame types, particularly inter-coded frames, only size down is
-    // supported where the existing surface can be re-used.
+    // supported where the existing surface can be reused.
     if (pic_width_ != p_uncomp_header->frame_size.frame_width || pic_height_ != p_uncomp_header->frame_size.frame_height) {
         pic_width_ = p_uncomp_header->frame_size.frame_width;
         pic_height_ = p_uncomp_header->frame_size.frame_height;

--- a/projects/rocdecode/src/parser/vp9_parser.h
+++ b/projects/rocdecode/src/parser/vp9_parser.h
@@ -159,7 +159,7 @@ protected:
 
     /*! \brief Function to parse frame sync syntax (frame_sync_code(), 6.2.1)
      * \param [in] p_stream Pointer to the bit stream
-     * \param [inout] offset Bit offset
+     * \param [in,out] offset Bit offset
      * \param [out] p_uncomp_header Pointer to uncompressed header struct
      * \return <tt>ParserResult</tt>
      */
@@ -167,7 +167,7 @@ protected:
 
     /*! \brief Function to parse color config syntax (color_config(), 6.2.2)
      * \param [in] p_stream Pointer to the bit stream
-     * \param [inout] offset Bit offset
+     * \param [in,out] offset Bit offset
      * \param [out] p_uncomp_header Pointer to uncompressed header struct
      * \return <tt>ParserResult</tt>
      */
@@ -175,7 +175,7 @@ protected:
 
     /*! \brief Function to parse frame size syntax (frame_size(), 6.2.3)
      * \param [in] p_stream Pointer to the bit stream
-     * \param [inout] offset Bit offset
+     * \param [in,out] offset Bit offset
      * \param [out] p_uncomp_header Pointer to uncompressed header struct
      *  \return None
      */
@@ -183,7 +183,7 @@ protected:
 
     /*! \brief Function to parse render size syntax (frame_size(), 6.2.4)
      * \param [in] p_stream Pointer to the bit stream
-     * \param [inout] offset Bit offset
+     * \param [in,out] offset Bit offset
      * \param [out] p_uncomp_header Pointer to uncompressed header struct
      *  \return None
      */
@@ -191,14 +191,14 @@ protected:
 
     /*! \brief Function to parse frame size with refs syntax (frame_size_with_refs(), 6.2.5)
      * \param [in] p_stream Pointer to the bit stream
-     * \param [inout] offset Bit offset
+     * \param [in,out] offset Bit offset
      * \param [out] p_uncomp_header Pointer to uncompressed header struct
      *  \return None
      */
     void FrameSizeWithRefs(const uint8_t *p_stream, size_t &offset, Vp9UncompressedHeader *p_uncomp_header);
 
     /*! \brief Function to calculate 8x8 and 64x64 block columns and rows of the frame (compute_image_size(), 6.2.6)
-     * \param [inout] p_uncomp_header Pointer to uncompressed header struct
+     * \param [in,out] p_uncomp_header Pointer to uncompressed header struct
      * \return None
      */
     void ComputeImageSize(Vp9UncompressedHeader *p_uncomp_header);
@@ -210,7 +210,7 @@ protected:
 
     /*! \brief Function to parse loop filter params syntax (loop_filter_params(), 6.2.8)
      * \param [in] p_stream Pointer to the bit stream
-     * \param [inout] offset Bit offset
+     * \param [in,out] offset Bit offset
      * \param [out] p_uncomp_header Pointer to uncompressed header struct
      *  \return None
      */
@@ -218,7 +218,7 @@ protected:
 
     /*! \brief Function to parse quantization params syntax (quantization_params(), 6.2.9)
      * \param [in] p_stream Pointer to the bit stream
-     * \param [inout] offset Bit offset
+     * \param [in,out] offset Bit offset
      * \param [out] p_uncomp_header Pointer to uncompressed header struct
      *  \return None
      */
@@ -226,14 +226,14 @@ protected:
 
     /*! \brief Function to parse delta quantizer syntax (read_delta_q(), 6.2.10)
      * \param [in] p_stream Pointer to the bit stream
-     * \param [inout] offset Bit offset
+     * \param [in,out] offset Bit offset
      * \return <tt>int8_t</tt>
      */
     int8_t ReadDeltaQ(const uint8_t *p_stream, size_t &offset);
 
     /*! \brief Function to parse segmentation params syntax (segmentation_params(), 6.2.11)
      * \param [in] p_stream Pointer to the bit stream
-     * \param [inout] offset Bit offset
+     * \param [in,out] offset Bit offset
      * \param [out] p_uncomp_header Pointer to uncompressed header struct
      * \return <tt>ParserResult</tt>
      */
@@ -241,14 +241,14 @@ protected:
 
     /*! \brief Function to parse probability syntax (read_delta_q(), 6.2.12)
      * \param [in] p_stream Pointer to the bit stream
-     * \param [inout] offset Bit offset
+     * \param [in,out] offset Bit offset
      * \return <tt>uint8_t</tt>
      */
     uint8_t ReadProb(const uint8_t *p_stream, size_t &offset);
 
     /*! \brief Function to parse tile info syntax (tile_info(), 6.2.13)
      * \param [in] p_stream Pointer to the bit stream
-     * \param [inout] offset Bit offset
+     * \param [in,out] offset Bit offset
      * \param [out] p_uncomp_header Pointer to uncompressed header struct
      * \return <tt>ParserResult</tt>
      */

--- a/projects/rocdecode/src/rocdecode-host/avcodec/avcodec_videodecoder.cpp
+++ b/projects/rocdecode/src/rocdecode-host/avcodec/avcodec_videodecoder.cpp
@@ -241,7 +241,7 @@ rocDecStatus AvcodecVideoDecoder::SubmitDecode(RocdecPicParamsHost *pPicParams) 
     AVPacket *av_pkt = av_packets_[av_pkt_cnt_];
     std::pair<uint8_t *, int> *packet_data = &av_packet_data_[av_pkt_cnt_];
     if (pPicParams->bitstream_data_len > packet_data->second) {
-        void *new_pkt_data = av_realloc(av_pkt->data, (pPicParams->bitstream_data_len + MAX_AV_PACKET_DATA_SIZE));  // add more to avoid frequence reallocation
+        void *new_pkt_data = av_realloc(av_pkt->data, (pPicParams->bitstream_data_len + MAX_AV_PACKET_DATA_SIZE));  // add more to avoid frequent reallocation
         if (!new_pkt_data) {
             ErrorLog(g_rocdec_logger, "ERROR: couldn't allocate packet data");
             FunctionExitLog(g_rocdec_logger);

--- a/projects/rocdecode/test/testScripts/README.md
+++ b/projects/rocdecode/test/testScripts/README.md
@@ -35,7 +35,7 @@ optional arguments:
   --gpu_device_id GPU_DEVICE_ID
                         The GPU device ID that will be used to run the test on it - optional (default:0 [range:0 - N-1] N = total number of available GPUs on a machine)
   --files_directory FILES_DIRECTORY
-                        The path to a dirctory containing one or more supported files for decoding (e.g., mp4, mov, etc.) - required
+                        The path to a directory containing one or more supported files for decoding (e.g., mp4, mov, etc.) - required
   --sample_mode SAMPLE_MODE
                         The sample to run - optional (default:0 [range:0-1] 0: videoDecode, 1: videoDecodePerf)
   --num_threads NUM_THREADS
@@ -58,5 +58,5 @@ optional arguments:
   --gpu_device_id GPU_DEVICE_ID
                         The GPU device ID that will be used to run the test on it - optional (default:0 [range:0 - N-1] N = total number of available GPUs on a machine)
   --files_directory FILES_DIRECTORY
-                        The path to a dirctory containing one or more supported files for decoding (e.g., mp4, mov, etc.) and their corresponding reference MD5 digests - required
+                        The path to a directory containing one or more supported files for decoding (e.g., mp4, mov, etc.) and their corresponding reference MD5 digests - required
 ```

--- a/projects/rocdecode/test/testScripts/run_rocDecodeSamples.py
+++ b/projects/rocdecode/test/testScripts/run_rocDecodeSamples.py
@@ -85,7 +85,7 @@ parser.add_argument('--videodecode_exe',   type=str, default='',
 parser.add_argument('--gpu_device_id',      type=int, default=0,
                     help='The GPU device ID that will be used to run the test on it - optional (default:0 [range:0 - N-1] N = total number of available GPUs on a machine)')
 parser.add_argument('--files_directory',    type=str, default='',
-                    help='The path to a dirctory containing one or more supported files for decoding (e.g., mp4, mov, etc.) - required')
+                    help='The path to a directory containing one or more supported files for decoding (e.g., mp4, mov, etc.) - required')
 parser.add_argument('--sample_mode',          type=int, default=0,
                     help='The sample to run - optional (default:0 [range:0-1] 0: videoDecode, 1: videoDecodePerf)')
 parser.add_argument('--num_threads',          type=int, default=1,
@@ -93,7 +93,7 @@ parser.add_argument('--num_threads',          type=int, default=1,
 parser.add_argument('--max_num_decoded_frames',          type=int, default=0,
                     help='The max number of decoded frames. Useful for partial decoding of a long stream. - optional (default:0, meaning no limit)')
 parser.add_argument('--results_directory',    type=str, default='',
-                    help='The path to a dirctory to store results - optional')
+                    help='The path to a directory to store results - optional')
 parser.add_argument('--check_decode_status',          type=int, default=0,
                     help='Report the number of streams that have completed decoding without abortion. For decoder stability check. - optional (default:0, meaning normal performance report)')
 parser.add_argument('--use_ffmpeg_demuxer',   type=int, default=1,

--- a/projects/rocdecode/test/testScripts/run_rocDecode_Conformance.py
+++ b/projects/rocdecode/test/testScripts/run_rocDecode_Conformance.py
@@ -42,9 +42,9 @@ parser.add_argument('--videodecode_exe',   type=str, default='',
 parser.add_argument('--gpu_device_id',      type=int, default=0,
                     help='The GPU device ID that will be used to run the test on it - optional (default:0 [range:0 - N-1] N = total number of available GPUs on a machine)')
 parser.add_argument('--files_directory',    type=str, default='',
-                    help='The path to a dirctory containing one or more supported files for decoding (e.g., mp4, mov, etc.) and their corresponding reference MD5 digests - required')
+                    help='The path to a directory containing one or more supported files for decoding (e.g., mp4, mov, etc.) and their corresponding reference MD5 digests - required')
 parser.add_argument('--results_directory',    type=str, default='',
-                    help='The path to a dirctory to store results - optional')
+                    help='The path to a directory to store results - optional')
 parser.add_argument('--use_ffmpeg_demuxer',   type=int, default=1,
                     help='Indicator to use FFMPEG demuxer - optional (default:1). If set to 0, built-in bitstream reader is used.')
 

--- a/projects/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp
+++ b/projects/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp
@@ -440,7 +440,7 @@ int FFMpegVideoDecoder::HandlePictureDisplay(RocdecParserDispInfo *pDispInfo) {
         }
     }
     // Copy chroma plane/s
-    // rocDec output gives pointer to luma and chroma pointers seperated for the decoded frame
+    // rocDec output gives pointer to luma and chroma pointers separated for the decoded frame
     uint8_t *p_frame_uv = p_dec_frame + dst_pitch * disp_height_;
     uint8_t *p_src_ptr_uv = static_cast<uint8_t *>(src_ptr[1]) + ((disp_rect_.top + crop_rect_.top) >> 1) * src_pitch[1] + ((disp_rect_.left + crop_rect_.left)>>1) * byte_per_pixel_ ;
     dst_pitch = chroma_width_ *  byte_per_pixel_;          
@@ -528,7 +528,7 @@ uint8_t* FFMpegVideoDecoder::GetFrame(int64_t *pts) {
 }
 
 bool FFMpegVideoDecoder::ReleaseFrame(int64_t pTimestamp, bool b_flushing) {
-    // if not flushing the buffers are re-used, so keep them
+    // if not flushing the buffers are reused, so keep them
     if (!b_flushing)  
         return true;
     else {

--- a/projects/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.h
+++ b/projects/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.h
@@ -63,13 +63,13 @@ class FFMpegVideoDecoder: public RocVideoDecoder {
         ~FFMpegVideoDecoder();
 
         /**
-         * @brief this function decodes a frame and returns the number of frames avalable for display
+         * @brief this function decodes a frame and returns the number of frames available for display
          * 
          * @param data - pointer to the compressed data buffer that is to be decoded
          * @param size - size of the data buffer in bytes
          * @param pts - presentation timestamp
          * @param flags - video packet flags
-         * @param num_decoded_pics - nummber of pictures decoded in this call
+         * @param num_decoded_pics - number of pictures decoded in this call
          * @return int - num of frames to display
          */
         int DecodeFrame(const uint8_t *data, size_t size, int pkt_flags, int64_t pts = 0, int *num_decoded_pics = nullptr) override;
@@ -95,7 +95,7 @@ class FFMpegVideoDecoder: public RocVideoDecoder {
          * @param pTimestamp - timestamp of the frame to be released (unmapped)
          * @param b_flushing - true when flushing
          * @return true      - success
-         * @return false     - falied
+         * @return false     - failed
          */
         bool ReleaseFrame(int64_t pTimestamp, bool b_flushing = false) override;
 

--- a/projects/rocdecode/utils/md5.h
+++ b/projects/rocdecode/utils/md5.h
@@ -92,7 +92,7 @@ public:
             return;
         }
 
-        // Need to covert interleaved planar to stacked planar, assuming 4:2:0 chroma sampling.
+        // Need to convert interleaved planar to stacked planar, assuming 4:2:0 chroma sampling.
         uint8_t *stacked_ptr = new uint8_t [output_image_size];
         uint8_t *tmp_hst_ptr = hst_ptr;
         int output_stride =  surf_info->output_pitch;

--- a/projects/rocdecode/utils/rocvideodecode/roc_video_dec.cpp
+++ b/projects/rocdecode/utils/rocvideodecode/roc_video_dec.cpp
@@ -312,7 +312,7 @@ int RocVideoDecoder::HandleVideoSequence(RocdecVideoFormat *p_video_format) {
     else if (video_chroma_format_ == rocDecVideoChromaFormat_422)
         video_surface_format_ = bitdepth_minus_8_ ? rocDecVideoSurfaceFormat_YUV422_16Bit : rocDecVideoSurfaceFormat_YUV422;
 
-    // Check if output format supported. If not, check falback options
+    // Check if output format supported. If not, check fallback options
     if (!(decode_caps.output_format_mask & (1 << video_surface_format_))){
         if (decode_caps.output_format_mask & (1 << rocDecVideoSurfaceFormat_NV12))
             video_surface_format_ = rocDecVideoSurfaceFormat_NV12;
@@ -628,7 +628,7 @@ int RocVideoDecoder::ReconfigureDecoder(RocdecVideoFormat *p_video_format) {
     }
 
     if (roc_decoder_ == nullptr) {
-        ROCDEC_THROW("Reconfigurition of the decoder detected but the decoder was not initialized previoulsy!", ROCDEC_NOT_SUPPORTED);
+        ROCDEC_THROW("Reconfiguration of the decoder detected but the decoder was not initialized previously!", ROCDEC_NOT_SUPPORTED);
         return 0;
     }
     if (p_video_format->reconfig_options == ROCDEC_RECONFIG_NEW_SURFACES) {
@@ -783,7 +783,7 @@ int RocVideoDecoder::HandlePictureDisplay(RocdecParserDispInfo *pDispInfo) {
                 HIP_API_CALL(hipMemcpy2DAsync(p_dec_frame, dst_pitch, p_src_ptr_y, src_pitch[0], dst_pitch, disp_height_, hipMemcpyDeviceToHost, hip_stream_));
 
             // Copy chroma plane ( )
-            // rocDec output gives pointer to luma and chroma pointers seperated for the decoded frame
+            // rocDec output gives pointer to luma and chroma pointers separated for the decoded frame
             uint8_t *p_frame_uv = p_dec_frame + dst_pitch * disp_height_;
             uint8_t *p_src_ptr_uv = (num_chroma_planes_ == 1) ? static_cast<uint8_t *>(src_dev_ptr[1]) + ((disp_rect_.top + crop_rect_.top) >> 1) * src_pitch[1] + (disp_rect_.left + crop_rect_.left) * byte_per_pixel_ :
             static_cast<uint8_t *>(src_dev_ptr[1]) + (disp_rect_.top + crop_rect_.top) * src_pitch[1] + (disp_rect_.left + crop_rect_.left) * byte_per_pixel_;
@@ -901,14 +901,14 @@ uint8_t* RocVideoDecoder::GetFrame(int64_t *pts) {
  * 
  * @param pTimestamp - timestamp of the frame to be released (unmapped)
  * @return true      - success
- * @return false     - falied
+ * @return false     - failed
  */
 
 bool RocVideoDecoder::ReleaseFrame(int64_t pTimestamp, bool b_flushing) {
     if (out_mem_type_ == OUT_SURFACE_MEM_NOT_MAPPED)
         return true;    // nothing to do
     if (out_mem_type_ != OUT_SURFACE_MEM_DEV_INTERNAL) {
-        if (!b_flushing)  // if not flushing the buffers are re-used, so keep them
+        if (!b_flushing)  // if not flushing the buffers are reused, so keep them
             return true;            // nothing to do
         else {
             DecFrameBuffer *fb = &vp_frames_[0];
@@ -939,7 +939,7 @@ bool RocVideoDecoder::ReleaseFrame(int64_t pTimestamp, bool b_flushing) {
  * @brief function to release all internal frames and clear the q (used with reconfigure): Only used with "OUT_SURFACE_MEM_DEV_INTERNAL"
  * 
  * @return true      - success
- * @return false     - falied
+ * @return false     - failed
  */
 bool RocVideoDecoder::ReleaseInternalFrames() {
     if (out_mem_type_ != OUT_SURFACE_MEM_DEV_INTERNAL || out_mem_type_ == OUT_SURFACE_MEM_NOT_MAPPED)

--- a/projects/rocdecode/utils/rocvideodecode/roc_video_dec.h
+++ b/projects/rocdecode/utils/rocvideodecode/roc_video_dec.h
@@ -328,13 +328,13 @@ class RocVideoDecoder {
          */
         int FlushAndReconfigure();
         /**
-         * @brief this function decodes a frame and returns the number of frames avalable for display
+         * @brief this function decodes a frame and returns the number of frames available for display
          * 
-         * @param data - pointer to the data buffer that is to be decode
+         * @param data - pointer to the data buffer that is to be decoded
          * @param size - size of the data buffer in bytes
          * @param pts - presentation timestamp
          * @param flags - video packet flags
-         * @param num_decoded_pics - nummber of pictures decoded in this call
+         * @param num_decoded_pics - number of pictures decoded in this call
          * @return int - num of frames to display
          */
         virtual int DecodeFrame(const uint8_t *data, size_t size, int pkt_flags, int64_t pts = 0, int *num_decoded_pics = nullptr);
@@ -350,7 +350,7 @@ class RocVideoDecoder {
          * @param pTimestamp - timestamp of the frame to be released (unmapped)
          * @param b_flushing - true when flushing
          * @return true      - success
-         * @return false     - falied
+         * @return false     - failed
          */
         virtual bool ReleaseFrame(int64_t pTimestamp, bool b_flushing = false);
 
@@ -386,7 +386,7 @@ class RocVideoDecoder {
         virtual void SaveFrameToFile(std::string output_file_name, void *surf_mem, OutputSurfaceInfo *surf_info, size_t rgb_image_size = 0);
 
         /**
-         * @brief Helper funtion to close a existing file and dump to new file in case of multiple files using same decoder
+         * @brief Helper function to close an existing file and dump to new file in case of multiple files using same decoder
         */
         virtual void ResetSaveFrameToFile();
 
@@ -470,7 +470,7 @@ class RocVideoDecoder {
          * @brief function to release all internal frames and clear the vp_frames_q_ (used with reconfigure): Only used with "OUT_SURFACE_MEM_DEV_INTERNAL"
          * 
          * @return true      - success
-         * @return false     - falied
+         * @return false     - failed
          */
         bool ReleaseInternalFrames();
 


### PR DESCRIPTION
## Motivation

Spelling errors are embarrassing. We should fix them.

## Technical Details

* Mostly comments and strings
* Corrects Doxygen `inout` to `in,out`
* No errors with `codespell -L=ue,renderD`

## JIRA ID

N/A

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
