### PR TITLE
[rocSHMEM] Fence corrections and scope narrowing

### DIFF
--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -201,60 +201,98 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
                                           int size) {
   switch (size) {
     case 2: {
-#if defined(__gfx90a__)
       int16_t val16{*(reinterpret_cast<int16_t*>(val))};
-      asm volatile("flat_store_short %0 %1 glc slc" : : "v"(dst), "v"(val16));
+#if defined(__gfx90a__)
+      asm volatile("flat_store_short %0, %1, glc slc"
+                   :
+                   : "v"(dst), "v"(val16)
+                   : "memory");
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
-      int16_t val16{*(reinterpret_cast<int16_t*>(val))};
-      asm volatile("flat_store_short %0 %1 sc0 sc1" : : "v"(dst), "v"(val16));
+      asm volatile("flat_store_short %0, %1, sc0 sc1 nt"
+                   :
+                   : "v"(dst), "v"(val16)
+                   : "memory");
 #endif
 #if defined(__gfx1100__)
-      int32_t val32{*(reinterpret_cast<int32_t*>(val))};
-      asm volatile("flat_store_short %0 %1 glc slc" : : "v"(dst), "v"(val32));
+      int32_t val32{static_cast<int32_t>(val16)};
+      asm volatile("flat_store_short %0, %1, glc slc"
+                   :
+                   : "v"(dst), "v"(val32)
+                   : "memory");
 #endif
 #if defined(__gfx1201__)
-      int32_t val32{*(reinterpret_cast<int32_t*>(val))};
-      asm volatile("flat_store_b16 %0 %1 scope:SCOPE_SYS" : : "v"(dst), "v"(val32));
+      int32_t val32{static_cast<int32_t>(val16)};
+      asm volatile("flat_store_b16 %0, %1, scope:SCOPE_SYS"
+                   :
+                   : "v"(dst), "v"(val32)
+                   : "memory");
 #endif
       break;
     }
     case 4: {
       [[maybe_unused]] int32_t val32{*(reinterpret_cast<int32_t*>(val))};
 #if defined(__gfx90a__) || defined(__gfx1100__)
-      asm volatile("flat_store_dword %0 %1 glc slc" : : "v"(dst), "v"(val32));
+      asm volatile("flat_store_dword %0, %1, glc slc"
+                   :
+                   : "v"(dst), "v"(val32)
+                   : "memory");
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
-      asm volatile("flat_store_dword %0 %1 sc0 sc1" : : "v"(dst), "v"(val32));
+      asm volatile("flat_store_dword %0, %1, sc0 sc1 nt"
+                   :
+                   : "v"(dst), "v"(val32)
+                   : "memory");
 #endif
 #if defined(__gfx1201__)
-      asm volatile("flat_store_b32 %0 %1 scope:SCOPE_SYS" : : "v"(dst), "v"(val32));
+      asm volatile("flat_store_b32 %0, %1, scope:SCOPE_SYS"
+                   :
+                   : "v"(dst), "v"(val32)
+                   : "memory");
 #endif
       break;
     }
     case 8: {
       [[maybe_unused]] int64_t val64{*(reinterpret_cast<int64_t*>(val))};
 #if defined(__gfx90a__) || defined(__gfx1100__)
-      asm volatile("flat_store_dwordx2 %0 %1 glc slc" : : "v"(dst), "v"(val64));
+      asm volatile("flat_store_dwordx2 %0, %1, glc slc"
+                   :
+                   : "v"(dst), "v"(val64)
+                   : "memory");
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
-      asm volatile("flat_store_dwordx2 %0 %1 sc0 sc1" : : "v"(dst), "v"(val64));
+      asm volatile("flat_store_dwordx2 %0, %1, sc0 sc1 nt"
+                   :
+                   : "v"(dst), "v"(val64)
+                   : "memory");
 #endif
 #if defined(__gfx1201__)
-      asm volatile("flat_store_b64 %0 %1 scope:SCOPE_SYS" : : "v"(dst), "v"(val64));
+      asm volatile("flat_store_b64 %0, %1, scope:SCOPE_SYS"
+                   :
+                   : "v"(dst), "v"(val64)
+                   : "memory");
 #endif
       break;
     }
     case 16: {
       [[maybe_unused]] __int128_t val128{*(reinterpret_cast<__int128_t*>(val))};
 #if defined(__gfx90a__) || defined(__gfx1100__)
-      asm volatile("flat_store_dwordx4 %0 %1 glc slc" : : "v"(dst), "v"(val128));
+      asm volatile("flat_store_dwordx4 %0, %1, glc slc"
+                   :
+                   : "v"(dst), "v"(val128)
+                   : "memory");
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
-      asm volatile("flat_store_dwordx4 %0 %1 sc0 sc1" : : "v"(dst), "v"(val128));
+      asm volatile("flat_store_dwordx4 %0, %1, sc0 sc1 nt"
+                   :
+                   : "v"(dst), "v"(val128)
+                   : "memory");
 #endif
 #if defined(__gfx1201__)
-      asm volatile("flat_store_b128 %0 %1 scope:SCOPE_SYS" : : "v"(dst), "v"(val128));
+      asm volatile("flat_store_b128 %0, %1, scope:SCOPE_SYS"
+                   :
+                   : "v"(dst), "v"(val128)
+                   : "memory");
 #endif
       break;
     }

--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -228,7 +228,7 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
                    : "memory");
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
-      asm volatile("flat_store_short %0, %1, sc0 sc1 nt"
+      asm volatile("flat_store_short %0, %1, sc0 sc1"
                    :
                    : "v"(dst), "v"(val16)
                    : "memory");
@@ -258,7 +258,7 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
                    : "memory");
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
-      asm volatile("flat_store_dword %0, %1, sc0 sc1 nt"
+      asm volatile("flat_store_dword %0, %1, sc0 sc1"
                    :
                    : "v"(dst), "v"(val32)
                    : "memory");
@@ -286,7 +286,7 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
                    : "memory");
 #endif
 #if defined(__gfx1201__)
-      asm volatile("flat_store_b64 %0, %1, scope:SCOPE_SYS"
+      asm volatile("flat_store_b64 %0, %1, th:TH_STORE_NT_RT scope:SCOPE_SYS"
                    :
                    : "v"(dst), "v"(val64)
                    : "memory");
@@ -308,7 +308,7 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
                    : "memory");
 #endif
 #if defined(__gfx1201__)
-      asm volatile("flat_store_b128 %0, %1, scope:SCOPE_SYS"
+      asm volatile("flat_store_b128 %0, %1, th:TH_STORE_NT_RT scope:SCOPE_SYS"
                    :
                    : "v"(dst), "v"(val128)
                    : "memory");

--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -203,19 +203,31 @@ __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t
     case 1: {
 #if defined(__gfx90a__)
       int16_t val16{static_cast<int16_t>(*val)};
-      asm volatile("flat_store_byte %0 %1 glc slc" : : "v"(dst), "v"(val16));
+      asm volatile("flat_store_byte %0 %1 glc slc"
+                   :
+                   : "v"(dst), "v"(val16)
+                   : "memory");
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
       int16_t val16{static_cast<int16_t>(*val)};
-      asm volatile("flat_store_byte %0 %1 sc0 sc1" : : "v"(dst), "v"(val16));
+      asm volatile("flat_store_byte %0 %1 sc0 sc1"
+                   :
+                   : "v"(dst), "v"(val16)
+                   : "memory");
 #endif
 #if defined(__gfx1100__)
       int32_t val32{static_cast<int32_t>(*val)};
-      asm volatile("flat_store_byte %0 %1 glc slc" : : "v"(dst), "v"(val32));
+      asm volatile("flat_store_byte %0 %1 glc slc"
+                   :
+                   : "v"(dst), "v"(val32)
+                   : "memory");
 #endif
 #if defined(__gfx1201__)
       int32_t val32{static_cast<int32_t>(*val)};
-      asm volatile("flat_store_b8 %0 %1 scope:SCOPE_SYS" : : "v"(dst), "v"(val32));
+      asm volatile("flat_store_b8 %0 %1 scope:SCOPE_SYS"
+                   :
+                   : "v"(dst), "v"(val32)
+                   : "memory");
 #endif
       break;
     }

--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -200,8 +200,27 @@ __device__ __forceinline__ void __roc_flush() {
 __device__ __forceinline__ void store_asm(uint8_t* val, [[maybe_unused]] uint8_t* dst,
                                           int size) {
   switch (size) {
+    case 1: {
+#if defined(__gfx90a__)
+      int16_t val16{static_cast<int16_t>(*val)};
+      asm volatile("flat_store_byte %0 %1 glc slc" : : "v"(dst), "v"(val16));
+#endif
+#if defined(__gfx942__) || defined(__gfx950__)
+      int16_t val16{static_cast<int16_t>(*val)};
+      asm volatile("flat_store_byte %0 %1 sc0 sc1" : : "v"(dst), "v"(val16));
+#endif
+#if defined(__gfx1100__)
+      int32_t val32{static_cast<int32_t>(*val)};
+      asm volatile("flat_store_byte %0 %1 glc slc" : : "v"(dst), "v"(val32));
+#endif
+#if defined(__gfx1201__)
+      int32_t val32{static_cast<int32_t>(*val)};
+      asm volatile("flat_store_b8 %0 %1 scope:SCOPE_SYS" : : "v"(dst), "v"(val32));
+#endif
+      break;
+    }
     case 2: {
-      int16_t val16{*(reinterpret_cast<int16_t*>(val))};
+      [[maybe_unused]] int16_t val16{*(reinterpret_cast<int16_t*>(val))};
 #if defined(__gfx90a__)
       asm volatile("flat_store_short %0, %1, glc slc"
                    :

--- a/projects/rocshmem/src/ipc/context_ipc_device.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.cpp
@@ -51,15 +51,17 @@ __host__ IPCContext::IPCContext(Backend *b, unsigned int ctx_id)
 __device__ void IPCContext::putmem(void *dest, const void *source, size_t nelems,
                                   int pe) {
   putmem_nbi(dest, source, nelems, pe);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_workgroup,
                     detail::atomic::memory_order_release>();
 }
 
 __device__ void IPCContext::getmem(void *dest, const void *source, size_t nelems,
                                   int pe) {
-  getmem_nbi(dest, source, nelems, pe);
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_acquire>();
+  getmem_nbi(dest, source, nelems, pe);
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_workgroup,
+                    detail::atomic::memory_order_release>();
 }
 
 __device__ void IPCContext::putmem_nbi(void *dest, const void *source,
@@ -104,16 +106,18 @@ __device__ void *IPCContext::shmem_ptr(const void *dest, int pe) {
 __device__ void IPCContext::putmem_wg(void *dest, const void *source,
                                      size_t nelems, int pe) {
   putmem_nbi_wg(dest, source, nelems, pe);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
-                    detail::atomic::memory_order_release>();
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_workgroup,
+                  detail::atomic::memory_order_release>();
   __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::getmem_wg(void *dest, const void *source,
                                      size_t nelems, int pe) {
-  getmem_nbi_wg(dest, source, nelems, pe);
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_acquire>();
+  getmem_nbi_wg(dest, source, nelems, pe);
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_workgroup,
+                    detail::atomic::memory_order_release>();
   __builtin_amdgcn_s_barrier();
 }
 
@@ -133,15 +137,17 @@ __device__ void IPCContext::getmem_nbi_wg(void *dest, const void *source,
 __device__ void IPCContext::putmem_wave(void *dest, const void *source,
                                        size_t nelems, int pe) {
   putmem_nbi_wave(dest, source, nelems, pe);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_workgroup,
                     detail::atomic::memory_order_release>();
 }
 
 __device__ void IPCContext::getmem_wave(void *dest, const void *source,
                                        size_t nelems, int pe) {
-  getmem_nbi_wave(dest, source, nelems, pe);
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_acquire>();
+  getmem_nbi_wave(dest, source, nelems, pe);
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_workgroup,
+                    detail::atomic::memory_order_release>();
 }
 
 __device__ void IPCContext::putmem_nbi_wave(void *dest, const void *source,
@@ -161,7 +167,7 @@ __device__ void IPCContext::internal_putmem(void *dest, const void *source,
                                             size_t nelems, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
   memcpy_lane(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source), nelems);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_workgroup,
                     detail::atomic::memory_order_release>();
 }
 
@@ -169,16 +175,18 @@ __device__ void IPCContext::internal_getmem(void *dest, const void *source,
                                             size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   uint64_t L_offset = const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
-  memcpy_lane(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_acquire>();
+  memcpy_lane(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
+                    detail::atomic::memory_order_release>();
 }
 
 __device__ void IPCContext::internal_putmem_wg(void *dest, const void *source,
                                      size_t nelems, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
   memcpy_wg(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source), nelems);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_workgroup,
                     detail::atomic::memory_order_release>();
   __builtin_amdgcn_s_barrier();
 }
@@ -187,9 +195,11 @@ __device__ void IPCContext::internal_getmem_wg(void *dest, const void *source,
                                      size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   uint64_t L_offset = const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
-  memcpy_wg(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_acquire>();
+  memcpy_wg(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
+                    detail::atomic::memory_order_release>();
   __builtin_amdgcn_s_barrier();
 }
 
@@ -197,7 +207,7 @@ __device__ void IPCContext::internal_putmem_wave(void *dest,
                         const void *source, size_t nelems, int pe) {
   uint64_t L_offset = reinterpret_cast<char *>(dest) - wrk_sync_pool_bases_[my_pe];
   memcpy_wave(wrk_sync_pool_bases_[pe] + L_offset, const_cast<void *>(source), nelems);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_workgroup,
                     detail::atomic::memory_order_release>();
 }
 
@@ -205,9 +215,11 @@ __device__ void IPCContext::internal_getmem_wave(void *dest,
                         const void *source, size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   uint64_t L_offset = const_cast<char *>(src_typed) - wrk_sync_pool_bases_[my_pe];
-  memcpy_wave(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_acquire>();
+  memcpy_wave(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
+                    detail::atomic::memory_order_release>();
 }
 
 __device__ void IPCContext::putmem_signal(void *dest, const void *source, size_t nelems,

--- a/projects/rocshmem/src/ipc/context_ipc_device.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.cpp
@@ -178,7 +178,7 @@ __device__ void IPCContext::internal_getmem(void *dest, const void *source,
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_acquire>();
   memcpy_lane(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_workgroup,
                     detail::atomic::memory_order_release>();
 }
 
@@ -198,7 +198,7 @@ __device__ void IPCContext::internal_getmem_wg(void *dest, const void *source,
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_acquire>();
   memcpy_wg(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_workgroup,
                     detail::atomic::memory_order_release>();
   __builtin_amdgcn_s_barrier();
 }
@@ -218,7 +218,7 @@ __device__ void IPCContext::internal_getmem_wave(void *dest,
   ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
                     detail::atomic::memory_order_acquire>();
   memcpy_wave(dest, wrk_sync_pool_bases_[pe] + L_offset, nelems);
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_workgroup,
                     detail::atomic::memory_order_release>();
 }
 

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -394,17 +394,13 @@ __device__ __forceinline__ bool is_last_active_lane() {
   uint8_t* dst_bytes{static_cast<uint8_t*>(dst)};
   uint8_t* src_bytes{static_cast<uint8_t*>(src)};
 
-  for (size_t i = 16; i > 1; i >>= 1) {
+  for (size_t i = 16; i >= 1; i >>= 1) {
     while (size >= i) {
       store_asm(src_bytes, dst_bytes, i);
       src_bytes += i;
       dst_bytes += i;
       size -= i;
     }
-  }
-
-  if (size == 1) {
-    *dst_bytes = *src_bytes;
   }
 }
 
@@ -423,7 +419,7 @@ __device__ __forceinline__ bool is_last_active_lane() {
   dst_bytes = dst_def;
   src_bytes = src_def;
 
-  for (int j = 16; j > 1; j >>= 1) {
+  for (int j = 16; j >= 1; j >>= 1) {
     cpy_size = size / j;
     for (int i = thread_id; i < cpy_size; i += block_size) {
       dst_bytes = dst_def;
@@ -437,12 +433,6 @@ __device__ __forceinline__ bool is_last_active_lane() {
     size -= cpy_size * j;
     dst_def += cpy_size * j;
     src_def += cpy_size * j;
-  }
-
-  if (size == 1) {
-    if (is_thread_zero_in_block()) {
-      *dst_bytes = *src_bytes;
-    }
   }
 }
 
@@ -461,7 +451,7 @@ __device__ __forceinline__ bool is_last_active_lane() {
   dst_bytes = dst_def;
   src_bytes = src_def;
 
-  for (int j = 16; j > 1; j >>= 1) {
+  for (int j = 16; j >= 1; j >>= 1) {
     cpy_size = size / j;
     for (int i = wave_tid; i < cpy_size; i += wave_size) {
       dst_bytes = dst_def;
@@ -475,12 +465,6 @@ __device__ __forceinline__ bool is_last_active_lane() {
     size -= cpy_size * j;
     dst_def += cpy_size * j;
     src_def += cpy_size * j;
-  }
-
-  if (size == 1) {
-    if (is_thread_zero_in_wave()) {
-      *dst_bytes = *src_bytes;
-    }
   }
 }
 


### PR DESCRIPTION
## TLDR

IPC backend: fix fence ordering, add asm memory clobbers, and extend store_asm to handle 1-byte stores

## Technical Details

1. Fence correctness and scope narrowing (`context_ipc_device.cpp`)

- Fixed `getmem` functions where the acquire fence was issued after the copy, allowing data to be read before remote writes were visible. Fence is now correctly placed before the copy, with a release fence after.
- Narrowed post-put release fences from `memory_scope_system` to `memory_scope_workgroup`

2. `store_asm` correctness fixes (assembly.hpp)

- Added "memory" clobber to all `flat_store_*` inline asm calls, preventing the compiler from reordering stores.
- Added nt (non-temporal) modifier.
- Added case 1 for 1-byte stores using flat_store_byte / flat_store_b8 across all supported architectures.

3. Route all copy sizes through store_asm (util.hpp)

- `memcpy_lane`, `memcpy_wg`, and `memcpy_wave` previously handled 1-byte remainders with a plain pointer assignment, bypassing coherence guarantees. Changed loop bounds from `i > 1` to `i >= 1` so all sizes go through `store_asm`.

## JIRA ID

AIROCSHMEM-394

## Test Result

Unit tests are passing, wgput, waveput, wgget were also tested. DeepEP LL test also passes.
