### PR TITLE
rocr: add linearB2BCopy path for small copies

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_sdma.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_sdma.h
@@ -81,6 +81,17 @@ class BlitSdmaBase : public core::Blit {
       std::vector<core::Signal*>& dep_signals,
       core::Signal& out_signal) = 0;
 
+  /// @brief Submit back-to-back linear copy commands for all destinations from a
+  /// shared source in a single SDMA ring submission (linearB2BCopy path).
+  /// Unlike broadcast, each destination gets one or more standard
+  /// SDMA_PKT_COPY_LINEAR packets (chunked when size exceeds the per-packet
+  /// limit); the compactness comes from batching all of them into one
+  /// SubmitCommand call.
+  virtual hsa_status_t SubmitLinearCopyB2BCommand(
+      const std::vector<void*>& dsts, const void* src, size_t size,
+      std::vector<core::Signal*>& dep_signals,
+      core::Signal& out_signal) = 0;
+
   virtual bool BroadcastSupported() const = 0;
   virtual bool PlatformAtomicSupport() const = 0;
 
@@ -177,6 +188,11 @@ template <bool useGCR, bool scopeFields> class BlitSdma : public BlitSdmaBase {
   /// @param dep_signals Arrays of dependent signal.
   /// @param out_signal Output signal.
   hsa_status_t SubmitLinearCopyBroadcastCommand(
+      const std::vector<void*>& dsts, const void* src, size_t size,
+      std::vector<core::Signal*>& dep_signals,
+      core::Signal& out_signal) override;
+
+  hsa_status_t SubmitLinearCopyB2BCommand(
       const std::vector<void*>& dsts, const void* src, size_t size,
       std::vector<core::Signal*>& dep_signals,
       core::Signal& out_signal) override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -1143,6 +1143,40 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyBroadcastCommand(
 }
 
 template <bool useGCR, bool scopeFields>
+hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyB2BCommand(
+    const std::vector<void*>& dsts, const void* src, size_t size,
+    std::vector<core::Signal*>& dep_signals,
+    core::Signal& out_signal) {
+
+  if (dsts.empty() || size == 0) {
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+
+  const size_t max_copy_size = max_single_linear_copy_size_ ? max_single_linear_copy_size_
+                                                             : kMaxSingleCopySize;
+  const uint32_t num_chunks = static_cast<uint32_t>((size + max_copy_size - 1) / max_copy_size);
+
+  // One set of linear copy packets per destination, all packed back-to-back.
+  const size_t per_dst_bytes =
+      static_cast<size_t>(num_chunks) * static_cast<size_t>(linear_copy_command_size_);
+  const size_t total_cmd_size = dsts.size() * per_dst_bytes;
+
+  std::vector<char> cmd_buf(total_cmd_size);  // BuildCopyCommand memsets each packet
+  char* cmd_ptr = cmd_buf.data();
+
+  for (void* dst : dsts) {
+    BuildCopyCommand(cmd_ptr, num_chunks, dst, src, size);
+    cmd_ptr += per_dst_bytes;
+  }
+
+  const uint64_t total_bytes_moved = static_cast<uint64_t>(size) * dsts.size();
+
+  std::vector<core::Signal*> no_gang;
+  return SubmitCommand(cmd_buf.data(), total_cmd_size, total_bytes_moved,
+                       dep_signals, out_signal, no_gang);
+}
+
+template <bool useGCR, bool scopeFields>
 hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitCopyRectCommand(
     const hsa_pitched_ptr_t* dst, const hsa_dim3_t* dst_offset, const hsa_pitched_ptr_t* src,
     const hsa_dim3_t* src_offset, const hsa_dim3_t* range, std::vector<core::Signal*>& dep_signals,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -655,7 +655,7 @@ void GpuAgent::InitDerivedCuid() {
   amdcuid_id_t handle{};
   amdcuid_status_t status =
       amdcuid_get_handle_by_dev_path(device_node.c_str(), AMDCUID_DEVICE_TYPE_GPU, &handle);
-  
+
   if (status != AMDCUID_STATUS_SUCCESS) {
     debug_print("Secondary CUID not available: failed to get device handle.\n");
     return;
@@ -663,7 +663,7 @@ void GpuAgent::InitDerivedCuid() {
 
   // Query the derived CUID using the device handle
   uint32_t cuid_length;
-  status = amdcuid_query_device_property(handle, AMDCUID_QUERY_DERIVED_CUID, 
+  status = amdcuid_query_device_property(handle, AMDCUID_QUERY_DERIVED_CUID,
                                          derived_cuid_, &cuid_length);
 
   if (status != AMDCUID_STATUS_SUCCESS) {
@@ -1562,7 +1562,14 @@ hsa_status_t GpuAgent::DmaCopyBroadcast(
   const uint16_t num_entries = op.num_entries;
   constexpr size_t kBroadcastMaxSize = 1024 * 1024;
 
-  // Try HW broadcast for small transfers.
+  // linearB2BCopy outperforms HW broadcast for per-copy sizes >= 16KB
+  // HSA_SDMA_LINEAR_B2B: 1=force B2B, 0=force broadcast, unset=auto threshold.
+  constexpr size_t kLinearB2BMinSize = 16 * 1024;
+  const auto b2b_flag = core::Runtime::runtime_singleton_->flag().sdma_linear_b2b();
+  const bool use_linear_b2b = (b2b_flag == Flag::SDMA_ENABLE) ||
+                              (b2b_flag == Flag::SDMA_DEFAULT && op.size >= kLinearB2BMinSize);
+
+  // Try HW broadcast / linearB2B for transfers below 1MB.
   if (op.size < kBroadcastMaxSize) {
     SetCopyRequestRefCount(true);
     MAKE_SCOPE_GUARD([&]() { SetCopyRequestRefCount(false); });
@@ -1570,6 +1577,22 @@ hsa_status_t GpuAgent::DmaCopyBroadcast(
     lazy_ptr<core::Blit>& blit = GetBlitObject(BlitHostToDev);
     if (blit->isSDMA()) {
       BlitSdmaBase* sdma_blit = static_cast<BlitSdmaBase*>((*blit).get());
+
+      if (use_linear_b2b) {
+        if (profiling_enabled())
+          out_signal.async_copy_agent(core::Agent::Convert(this->public_handle()));
+
+        LogPrint(HSA_AMD_LOG_FLAG_SDMA,
+                 "SDMA linearB2BCopy using engine %02u, src=%p, num_entries=%u, size=%zu, "
+                 "dep_signal=0x%zx, completion_signal=0x%zx",
+                 BlitHostToDev, op.src, num_entries, op.size,
+                 dep_signals.empty() ? 0 : core::Signal::Convert(dep_signals[0]).handle,
+                 out_signal_obj->signal_);
+        std::vector<void*> dsts(op.dst_list, op.dst_list + num_entries);
+        return sdma_blit->SubmitLinearCopyB2BCommand(
+            dsts, op.src, op.size, dep_signals, out_signal);
+      }
+
       if (sdma_blit->BroadcastSupported()) {
         if (profiling_enabled())
           out_signal.async_copy_agent(core::Agent::Convert(this->public_handle()));

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -323,6 +323,11 @@ class Flag {
     // hsa_amd_counted_queue_acquire API. If not set, default queue size is set to 16384.
     var = os::GetEnvVar("HSA_COUNTED_QUEUE_SIZE");
     counted_queue_size_ = var.empty() ? DEFAULT_COUNTED_QUEUE_SIZE : atoi(var.c_str());
+
+    // HSA_SDMA_LINEAR_B2B: 1=force B2B, 0=force broadcast, unset=auto (size threshold)
+    var = os::GetEnvVar("HSA_SDMA_LINEAR_B2B");
+    sdma_linear_b2b_ = (var == "0") ? SDMA_DISABLE : ((var == "1") ? SDMA_ENABLE : SDMA_DEFAULT);
+
   }
 
   void parse_masks(uint32_t maxGpu, uint32_t maxCU) {
@@ -459,6 +464,8 @@ class Flag {
 
   bool enable_dxg_detection() const { return enable_dxg_detection_; }
 
+  SDMA_OVERRIDE sdma_linear_b2b() const { return sdma_linear_b2b_; }
+
   [[nodiscard]]
   bool core_dump_disable() const { return core_dump_disable_; }
 
@@ -536,6 +543,7 @@ class Flag {
   bool enable_3d_swizzle_ = false;
   bool enable_dtif_;
   bool enable_dxg_detection_;
+  SDMA_OVERRIDE sdma_linear_b2b_ = SDMA_DEFAULT;
 
   SDMA_OVERRIDE enable_sdma_;
   SDMA_OVERRIDE enable_peer_sdma_;


### PR DESCRIPTION
Introduces SubmitLinearCopyB2BCommand which packs one standard
SDMA_PKT_COPY_LINEAR per destination back-to-back in a single ring
submission, bypassing the HW broadcast packet.

DmaCopyBroadcast automatically selects linearB2BCopy for op.size >= 16KB
(kLinearB2BMinSize). The behaviour can be overridden via HSA_SDMA_LINEAR_B2B:
  1  - force linearB2BCopy for all sizes < 1MB
  0  - force HW broadcast for all sizes < 1MB
 unset - auto (default: linearB2BCopy >= 16KB, broadcast below)

## Motivation

On MI300X (8-GPU XGMI, hipMemcpyBatchAsync allgather) this shows 16-20% lower latency vs broadcast in the 32KB-512KB per-copy range with no difference below 32KB or above 1MB (fanout path).

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
