### PR TITLE
clr: Add batching on Windows to improve performance

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1289,11 +1289,16 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
                          Hsa::queue_load_read_index_scacquire(gpu_queue_), index,
                          virtual_pipe_prefix);
   }
-  // Optimization for native AQL path in windows has problems with PM4 emulation,
-  // skipping the doorbel will not wake up the AQL worker thread
-  //if (IS_WINDOWS && !dev().IsPm4Emulation() && (blocking || !hasPendingDispatch_))
-  {
+  // Optimization for native AQL path in Windows has problems with PM4 emulation,
+  // skipping the doorbell will not wake up the AQL worker thread
+  uint32_t skip_limit = DEBUG_CLR_DOORBELL_SKIP;
+  bool ring_doorbell = IS_LINUX || dev().IsPm4Emulation() || blocking ||
+                       (skippedDispatches_ >= skip_limit);
+  if (ring_doorbell) {
     Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, index);
+    skippedDispatches_ = 0;
+  } else {
+    ++skippedDispatches_;
   }
 
   // Mark the flag indicating if a dispatch is outstanding.
@@ -1729,6 +1734,7 @@ bool VirtualGPU::releaseGpuMemoryFence(bool skip_cpu_wait) {
     // Dispatch barrier packet into the queue
     dispatchBarrierPacket(kBarrierPacketHeader);
     hasPendingDispatch_ = false;
+    skippedDispatches_ = 0;
     retainExternalSignals_ = false;
   }
 
@@ -1773,6 +1779,7 @@ VirtualGPU::VirtualGPU(Device& device, bool profiling, bool cooperative,
   timestamp_ = nullptr;
   command_ = nullptr;
   hasPendingDispatch_ = false;
+  skippedDispatches_ = 0;
   profiling_ = profiling;
   cooperative_ = cooperative;
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -712,6 +712,7 @@ class VirtualGPU : public device::VirtualDevice {
   hsa_barrier_and_packet_t barrier_packet_ {};
   hsa_amd_barrier_value_packet_t barrier_value_packet_ {};
 
+  uint32_t skippedDispatches_;  //!< Count of consecutive dispatches that skipped the doorbell flush.
   uint32_t dispatch_id_;  //!< This variable must be updated atomically.
   Device& roc_device_;    //!< roc device object
   PrintfDbg* printfdbg_;

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -267,7 +267,10 @@ release(uint, DEBUG_CLR_BATCH_CPU_SYNC_SIZE, 8,                               \
 release(bool, DEBUG_CLR_DISABLE_IMAGE, false,                                 \
         "1 = Disable Image support for ROC path")                             \
 release(bool, DEBUG_CLR_ENABLE_PREFETCH_METADATA, true,                       \
-        "Enable metadata prefetch for some Aql packats")
+        "Enable metadata prefetch for some Aql packets")                      \
+release(uint, DEBUG_CLR_DOORBELL_SKIP, 16,                                    \
+        "Number of consecutive dispatches that may skip the doorbell flush.")
+ 
 
 namespace amd {
 


### PR DESCRIPTION
## Motivation
Performance of ROCR in Windows

## Technical Details
On Windows, the doorbell call maps to an OS scheduler invocation, which can be quite CPU‑expensive. To mitigate this overhead, batching is used via the DEBUG_CLR_DOORBELL_SKIP key, which defaults to triggering the doorbell once every 16 dispatches.

## JIRA ID
ROCM-1667

## Test Plan
N/A

## Test Result
N/A

## Submission Checklist
N/A