### PR TITLE
 [RCCL] Setting Algo to Ring for Navi4x, AllReduce

### DIFF
--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -2425,6 +2425,11 @@ rccl_static ncclResult_t getAlgoInfo(
       info->algorithm = NCCL_ALGO_TREE;
       info->protocol = NCCL_PROTO_LL;
     }
+
+    if(!userAlgoInput && (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1200") || IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1201")) && comm->nNodes == 1 && (info->func == ncclFuncAllReduce)) {
+       info->algorithm = NCCL_ALGO_RING; // for Navi RING algo always performs better than Tree based on data.
+    }
+
     // NCCL_CTA_POLICY_EFFICIENCY requires user (non-symmetric) buffer registration (currently unsupported with MNNVL)
     if (comm->config.CTAPolicy == NCCL_CTA_POLICY_EFFICIENCY && !userAlgoInput && ncclGetEnv("NCCL_PROTO") == NULL && !comm->MNNVL) {
       // make algorithm selection based on buffer registration


### PR DESCRIPTION
## Motivation
Navi4x is PCIe based system. 
RING algorithm for all_reduce always performing better than Tree in single node (Based on available data)

## Technical Details

For Single node Ring is better and for 2-Node , Tree is better. In our Tuning table design, we can't separate these two configs as we use same Tuning weights for <=2 nodes.  So, this specific if() condition resolves reported performance regression. In future, we plan to address this design gap. 

## JIRA ID
ROCM-21024

## Test Plan
Compared perf data for all collectives with RING/TREE algorithms.

## Test Result

Applied fixes work as intended.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
