### PR TITLE
Fix PerfXpert hardware spec mismatches

### DIFF
--- a/experimental/python/perfxpert/docs/contributing/gpu_arch.md
+++ b/experimental/python/perfxpert/docs/contributing/gpu_arch.md
@@ -17,35 +17,37 @@ test updates.
 ### Entry in `gpu_specs.yaml`
 
 ```yaml
-- gfx_id: "gfx950"
+gfx950:
   name: "MI350X"
-  family: "CDNA4"
-  compute_capability: 9.0
-  peak_fp32_tflops: 163.4
-  peak_fp64_tflops: 81.7
-  memory_bandwidth_gbs: 432
-  l2_cache_kb: 8192
-  lds_kb_per_cu: 160
-  num_cus: 152
-  wavefront_size: 64
-  vgpr_per_cu: 10240
-  sgpr_per_cu: 10240
-  lds_banks: 32
-  source: "AMD MI350X data sheet v1.0"
+  codename: "CDNA4"
+  peak_fp64_tflops: 72.1
+  peak_fp32_tflops: 144.2
+  peak_fp16_tflops: 2300.0
+  peak_bf16_tflops: 2300.0
+  peak_fp8_tflops: 4600.0
+  peak_int8_tops: 4600.0
+  memory_bandwidth_tbs: 8.0
+  cu_count: 256
+  lds_kb: 160
+  lds_per_cu_kb: 160
+  wave_size: 64
+  max_vgprs_per_thread: 256
+  vgprs_per_simd: 512
+  simds_per_cu: 4
+  max_waves_per_simd: 8
+  ridge_point: 18.0
 ```
 
 ### Entry in `vgpr_occupancy_tables.yaml`
 
 ```yaml
-- gfx_id: "gfx950"
-  tables:
-    - vgprs: 64
-      wave_occupancy: 0.5
-      waves_per_cu: 8
-    - vgprs: 128
-      wave_occupancy: 0.25
-      waves_per_cu: 4
-    # ... more entries
+gfx950:
+  - {max_vgprs: 64,  waves_per_eu: 8}
+  - {max_vgprs: 80,  waves_per_eu: 6}
+  - {max_vgprs: 96,  waves_per_eu: 5}
+  - {max_vgprs: 128, waves_per_eu: 4}
+  - {max_vgprs: 160, waves_per_eu: 3}
+  - {max_vgprs: 256, waves_per_eu: 2}
 ```
 
 ## Schema constraints (CI-enforced)
@@ -58,8 +60,9 @@ test updates.
 ## Key specs to get right
 
 - **MI300X FP64:** 81.7 TFLOPS (NOT 163.4 — that's FP32)
+- **MI300X occupancy:** 32 max waves/CU and 4 SIMDs/CU, so 8 waves/SIMD
 - **CDNA4 LDS:** 160 KB/CU (not 64)
-- **Compute capability:** must match Khronos / AMD numbering
+- **MI350X public peaks:** 72.1 FP64 TFLOPS, 144.2 FP32 TFLOPS, 8.0 TB/s HBM
 
 ## Tests you must add
 
@@ -79,8 +82,9 @@ Update `tests/test_knowledge/test_gpu_specs.py`:
 ## Common pitfalls
 
 - Don't confuse FP32 and FP64 TFLOPS (MI300X is 163.4 FP32, 81.7 FP64)
+- Don't use MI355X higher-bin peaks for the `gfx950` MI350X default unless you
+  explicitly split the SKU key first
 - VGPR table must be complete (cover typical code patterns: 64, 96, 128, 192, 256 at minimum)
-- Compute capability follows Khronos spec (e.g., CDNA1=9.0, CDNA2=9.0, CDNA3=9.0, CDNA4=9.0)
 - LDS must match official spec (check against latest AMD app notes)
 
 ## Related docs

--- a/experimental/python/perfxpert/docs/guides/python-api.md
+++ b/experimental/python/perfxpert/docs/guides/python-api.md
@@ -244,7 +244,7 @@ out = api.agent_compute_specialist(
     input={
         "gfx_id": "gfx942",
         "hot_kernels": [{"name": "gemm_k0", "duration_ns": 12000000}],
-        "counter_data": {"vgpr_used": 128, "waves_per_eu": 2},
+        "counter_data": {"vgpr_used": 128, "waves_per_eu": 4},
         "source_hints": {},
     },
     airgap=True,

--- a/experimental/python/perfxpert/perfxpert/knowledge/_schemas/interconnect_specs.schema.json
+++ b/experimental/python/perfxpert/perfxpert/knowledge/_schemas/interconnect_specs.schema.json
@@ -22,12 +22,12 @@
       ],
       "properties": {
         "name": {"type": "string"},
-        "xgmi_peak_gbps": {"type": "number", "minimum": 0, "description": "Aggregate bidirectional XGMI bandwidth (0 for NICs or GPUs without XGMI)."},
+        "xgmi_peak_gbps": {"type": "number", "minimum": 0, "description": "Aggregate AMD-published or explicitly derived IF/XGMI bandwidth (0 for NICs or GPUs without XGMI)."},
         "xgmi_links": {"type": "integer", "minimum": 0},
         "xgmi_per_link_gbps": {"type": "number", "minimum": 0},
         "pcie_tier": {"type": "string", "description": "Human-readable PCIe generation/width label, e.g. 'PCIe Gen5 x16'."},
-        "pcie_peak_gbps": {"type": "number", "minimum": 0},
-        "achievable_gbps": {"type": "number", "minimum": 0, "description": "Typical RCCL AllReduce busBW observed in practice."},
+        "pcie_peak_gbps": {"type": "number", "minimum": 0, "description": "Theoretical one-way PCIe peak bandwidth."},
+        "achievable_gbps": {"type": "number", "minimum": 0, "description": "Empirical RCCL AllReduce busBW observed in practice."},
         "source_url": {"type": "string", "format": "uri"},
         "measured_with": {"type": "string"}
       }

--- a/experimental/python/perfxpert/perfxpert/knowledge/gpu_specs.yaml
+++ b/experimental/python/perfxpert/perfxpert/knowledge/gpu_specs.yaml
@@ -1,10 +1,13 @@
 # AMD GPU hardware specifications per architecture.
-# Source of truth for arch.lookup_peaks(). Extracted during the agentic refactor
-# from vendor-published reference data.
+# Source of truth for arch.lookup_peaks(). Values below are AMD-published
+# product/ROCm hardware specs unless the field comment explicitly says it is
+# derived. Keep empirical or tool-limit defaults in their dedicated YAML files.
 #
-# CRITICAL CORRECTIONS (per CLAUDE.md):
+# CRITICAL CORRECTIONS (verified against AMD product pages and ROCm docs):
 # - MI300X FP64 = 81.7 TFLOPS (NOT 163.4 which is FP32)
 # - CDNA4 (gfx950) doubled LDS to 160 KB/CU (was 64 KB on CDNA3)
+# - MI300X occupancy is 32 waves/CU and 4 SIMDs/CU, i.e. 8 waves/SIMD
+# - gfx950 defaults to MI350X public peaks; MI355X is a higher-bin SKU
 #
 # Phase-10 Live-Roofline extension: per-dtype peak arrays
 # (peak_fp16_tflops / peak_bf16_tflops / peak_fp8_tflops / peak_int8_tops)
@@ -21,14 +24,14 @@ gfx908:
   peak_fp16_tflops: 184.6
   peak_bf16_tflops: 92.3
   peak_fp8_tflops: 0.0        # no FP8 MFMA on CDNA1
-  peak_int8_tops: 184.6
+  peak_int8_tops: 92.3
   memory_bandwidth_tbs: 1.2
   cu_count: 120
   lds_kb: 64
   lds_per_cu_kb: 64
   wave_size: 64
   max_vgprs_per_thread: 256
-  vgprs_per_simd: 512
+  vgprs_per_simd: 256
   simds_per_cu: 4
   max_waves_per_simd: 8
   ridge_point: 19.2  # FP32 vector peak / TB/s
@@ -36,7 +39,7 @@ gfx908:
     fp32: 128
     fp16: 4096
     bf16: 4096
-    fp8:  8192
+    fp8:  0
     int8: 8192
 
 gfx90a:
@@ -62,7 +65,7 @@ gfx90a:
     fp32: 128
     fp16: 4096
     bf16: 4096
-    fp8:  8192
+    fp8:  0
     int8: 8192
 
 gfx942:
@@ -82,7 +85,7 @@ gfx942:
   max_vgprs_per_thread: 256
   vgprs_per_simd: 512
   simds_per_cu: 4
-  max_waves_per_simd: 10
+  max_waves_per_simd: 8
   ridge_point: 30.8  # FP32 vector peak / TB/s; FP64 ridge is 15.4
   mfma_flops_per_inst:
     fp32: 128
@@ -94,8 +97,8 @@ gfx942:
 gfx950:
   name: "MI350X"
   codename: "CDNA4"
-  peak_fp64_tflops: 161.0   # doubled vs CDNA3
-  peak_fp32_tflops: 161.0
+  peak_fp64_tflops: 72.1
+  peak_fp32_tflops: 144.2
   peak_fp16_tflops: 2300.0
   peak_bf16_tflops: 2300.0
   peak_fp8_tflops: 4600.0
@@ -108,8 +111,8 @@ gfx950:
   max_vgprs_per_thread: 256
   vgprs_per_simd: 512
   simds_per_cu: 4
-  max_waves_per_simd: 10
-  ridge_point: 20.1
+  max_waves_per_simd: 8
+  ridge_point: 18.0
   mfma_flops_per_inst:
     fp32: 128
     fp16: 4096
@@ -121,8 +124,8 @@ gfx1030:
   name: "RX 6900 XT"
   codename: "RDNA2"
   peak_fp64_tflops: 0.7
-  peak_fp32_tflops: 23.0
-  peak_fp16_tflops: 46.0
+  peak_fp32_tflops: 23.04
+  peak_fp16_tflops: 46.08
   peak_bf16_tflops: 0.0
   peak_fp8_tflops: 0.0
   peak_int8_tops: 0.0
@@ -135,7 +138,7 @@ gfx1030:
   vgprs_per_simd: 1024
   simds_per_cu: 2
   max_waves_per_simd: 16
-  ridge_point: 44.9
+  ridge_point: 45.0
   mfma_flops_per_inst:
     fp32: 128
     fp16: 256
@@ -147,11 +150,11 @@ gfx1100:
   name: "RX 7900 XTX"
   codename: "RDNA3"
   peak_fp64_tflops: 1.9
-  peak_fp32_tflops: 61.0
-  peak_fp16_tflops: 122.0
-  peak_bf16_tflops: 122.0
+  peak_fp32_tflops: 61.4
+  peak_fp16_tflops: 123.0
+  peak_bf16_tflops: 123.0
   peak_fp8_tflops: 0.0
-  peak_int8_tops: 0.0
+  peak_int8_tops: 123.0
   memory_bandwidth_tbs: 0.960
   cu_count: 96
   lds_kb: 128
@@ -161,7 +164,7 @@ gfx1100:
   vgprs_per_simd: 1536
   simds_per_cu: 2
   max_waves_per_simd: 16
-  ridge_point: 63.5
+  ridge_point: 64.0
   mfma_flops_per_inst:
     fp32: 128
     fp16: 256

--- a/experimental/python/perfxpert/perfxpert/knowledge/interconnect_specs.yaml
+++ b/experimental/python/perfxpert/perfxpert/knowledge/interconnect_specs.yaml
@@ -4,12 +4,12 @@
 #
 # Fields
 # ------
-#   xgmi_peak_gbps    : aggregate bidirectional XGMI bandwidth per GPU (GB/s)
-#   xgmi_links        : number of XGMI links wired per GPU
-#   xgmi_per_link_gbps: per-link bidirectional peak (GB/s)
+#   xgmi_peak_gbps    : aggregate AMD-published or explicitly derived IF/XGMI bandwidth per GPU (GB/s)
+#   xgmi_links        : number of IF/XGMI links wired per GPU
+#   xgmi_per_link_gbps: per-link vendor-published IF/XGMI peak (GB/s)
 #   pcie_tier         : PCIe generation / width (human-readable label)
-#   pcie_peak_gbps    : PCIe aggregate peak (GB/s)
-#   achievable_gbps   : typical RCCL AllReduce busBW observed in practice
+#   pcie_peak_gbps    : PCIe theoretical one-way peak (GB/s)
+#   achievable_gbps   : empirical RCCL AllReduce busBW observed in practice
 #   source_url        : vendor / reference source for the published number
 #   measured_with     : short description of the measurement context
 #
@@ -25,47 +25,47 @@
 
 gfx908:
   name: "MI100"
-  xgmi_peak_gbps: 276.0         # 3 links x 92 GB/s bidirectional
+  xgmi_peak_gbps: 276.0         # 3 links x 92 GB/s vendor-published IF link bandwidth
   xgmi_links: 3
   xgmi_per_link_gbps: 92.0
   pcie_tier: "PCIe Gen4 x16"
   pcie_peak_gbps: 32.0
   achievable_gbps: 180.0
-  source_url: "https://www.amd.com/en/products/server-accelerators/instinct-mi100"
-  measured_with: "vendor datasheet (CDNA1)"
+  source_url: "https://www.amd.com/en/products/accelerators/instinct/mi100.html"
+  measured_with: "AMD product specs (CDNA1)"
 
 gfx90a:
   name: "MI250X"
-  xgmi_peak_gbps: 400.0         # 8 links x ~50 GB/s bidirectional (aggregate)
+  xgmi_peak_gbps: 800.0         # 8 links x 100 GB/s vendor-published IF link bandwidth
   xgmi_links: 8
-  xgmi_per_link_gbps: 50.0
+  xgmi_per_link_gbps: 100.0
   pcie_tier: "PCIe Gen4 x16"
   pcie_peak_gbps: 32.0
   achievable_gbps: 200.0
-  source_url: "https://www.amd.com/en/products/server-accelerators/instinct-mi250x"
-  measured_with: "vendor datasheet (CDNA2) + RCCL AllReduce"
+  source_url: "https://www.amd.com/en/products/accelerators/instinct/mi200/mi250x.html"
+  measured_with: "AMD product specs (CDNA2): 8 external IF links at 100 GB/s each"
 
 gfx942:
   name: "MI300X"
-  xgmi_peak_gbps: 448.0         # 7 links x ~64 GB/s bidirectional
-  xgmi_links: 7
-  xgmi_per_link_gbps: 64.0
+  xgmi_peak_gbps: 1024.0        # 8 links x 128 GB/s vendor-published IF peak
+  xgmi_links: 8
+  xgmi_per_link_gbps: 128.0
   pcie_tier: "PCIe Gen5 x16"
   pcie_peak_gbps: 64.0
   achievable_gbps: 340.0
   source_url: "https://www.amd.com/en/products/accelerators/instinct/mi300/mi300x.html"
-  measured_with: "vendor datasheet (CDNA3) + RCCL AllReduce, 8-GPU ring"
+  measured_with: "AMD product specs (CDNA3) + RCCL AllReduce, 8-GPU ring"
 
 gfx950:
   name: "MI350X"
-  xgmi_peak_gbps: 896.0         # doubled vs CDNA3 (CDNA4 projection)
+  xgmi_peak_gbps: 1071.0        # 7 links x 153 GB/s vendor-published IF peak
   xgmi_links: 7
-  xgmi_per_link_gbps: 128.0
+  xgmi_per_link_gbps: 153.0
   pcie_tier: "PCIe Gen5 x16"
   pcie_peak_gbps: 64.0
   achievable_gbps: 650.0
-  source_url: "https://www.amd.com/en/products/accelerators/instinct/mi350.html"
-  measured_with: "vendor datasheet (CDNA4)"
+  source_url: "https://www.amd.com/en/products/accelerators/instinct/mi350/mi350x.html"
+  measured_with: "AMD product specs (CDNA4) + projected RCCL baseline"
 
 gfx1030:
   name: "RX 6900 XT"
@@ -75,8 +75,8 @@ gfx1030:
   pcie_tier: "PCIe Gen4 x16"
   pcie_peak_gbps: 32.0
   achievable_gbps: 24.0
-  source_url: "https://www.amd.com/en/products/graphics/amd-radeon-rx-6900-xt"
-  measured_with: "vendor datasheet (RDNA2)"
+  source_url: "https://www.amd.com/en/products/graphics/desktops/radeon/6000-series/amd-radeon-rx-6900-xt.html"
+  measured_with: "AMD product specs (RDNA2)"
 
 gfx1100:
   name: "RX 7900 XTX"
@@ -86,8 +86,8 @@ gfx1100:
   pcie_tier: "PCIe Gen4 x16"
   pcie_peak_gbps: 32.0
   achievable_gbps: 24.0
-  source_url: "https://www.amd.com/en/products/graphics/amd-radeon-rx-7900xtx"
-  measured_with: "vendor datasheet (RDNA3)"
+  source_url: "https://www.amd.com/en/products/graphics/desktops/radeon/7000-series/amd-radeon-rx-7900xtx.html"
+  measured_with: "AMD product specs (RDNA3)"
 
 # -- Inter-node NIC entries -----------------------------------------------
 # Selected explicitly via interconnect.lookup_peaks("connectx7") etc.

--- a/experimental/python/perfxpert/perfxpert/knowledge/metric_thresholds.yaml
+++ b/experimental/python/perfxpert/perfxpert/knowledge/metric_thresholds.yaml
@@ -18,10 +18,10 @@ wave_occupancy_pct:
   medium: 0.50     # 50-75% acceptable
   low: 0.25        # < 25% very poor; VGPRs/LDS likely too high
   unit: fraction
-  description: "Avg waves per CU normalized to theoretical max (128 on CDNA3)"
+  description: "Avg waves per CU normalized to theoretical max (32 on MI300X/CDNA3)"
 
 avg_waves_per_cu:
-  high: 24         # ~75% of 32 max-per-EU on CDNA3
+  high: 24         # ~75% of 32 max waves/CU on MI300X/CDNA3
   medium: 16       # 50%
   low: 8           # 25% — latency-bound signature
   unit: waves

--- a/experimental/python/perfxpert/perfxpert/knowledge/pc_sampling_pipelines.yaml
+++ b/experimental/python/perfxpert/perfxpert/knowledge/pc_sampling_pipelines.yaml
@@ -7,7 +7,7 @@
 
 - name: MATRIX
   instructions: "Matrix FMA instructions (v_mfma_*)"
-  description: "MI300X has 4 MFMA units per CU; high MATRIX samples indicate matrix-math workloads"
+  description: "MI300X matrix pipeline capacity is derived from AMD-published matrix-core and CU counts; high MATRIX samples indicate matrix-math workloads"
   notes: "Also referred to as MFMA pipeline"
 
 - name: SCALAR

--- a/experimental/python/perfxpert/perfxpert/knowledge/pmc_limits.yaml
+++ b/experimental/python/perfxpert/perfxpert/knowledge/pmc_limits.yaml
@@ -1,5 +1,6 @@
-# Per-block hardware counter limits — AMD GPUs allow only N counters from the
-# same hardware block per rocprofv3 pass. Exceeding a limit yields error code 38.
+# Per-block counter collection limits observed through rocprofv3. These are
+# PerfXpert tool/runtime guardrails, not vendor-published GPU peak specs.
+# Exceeding a limit yields rocprofv3 error code 38 in the guarded paths.
 # Source: llm-reference-guide.md §"Hardware Counter Per-Block Limits" (lines 10-65).
 
 per_block_limits:

--- a/experimental/python/perfxpert/perfxpert/knowledge/rocprofv3_counter_limits.yaml
+++ b/experimental/python/perfxpert/perfxpert/knowledge/rocprofv3_counter_limits.yaml
@@ -1,4 +1,6 @@
 # rocprofv3-specific counter collection rules and isolation requirements.
+# These are empirical/tool-runtime rules used to avoid rocprofv3 collection
+# failures; they are not AMD-published architecture peak specifications.
 # Source: llm-reference-guide.md §"Hardware Counter Per-Block Limits" (lines 14-65)
 #         and CLAUDE.md §"Hardware Counter Per-Block Limits (error code 38)".
 #

--- a/experimental/python/perfxpert/perfxpert/knowledge/thermal_specs.yaml
+++ b/experimental/python/perfxpert/perfxpert/knowledge/thermal_specs.yaml
@@ -1,9 +1,9 @@
 # thermal_specs — per-arch thermal envelope + throttle thresholds used by
 # `gpu_runtime_monitor.analyze_thermal` when the caller supplies gfx_id.
 #
-# Junction temperature (TjMax) governs whether the driver dynamically
-# clock-gates. Exceeding `tj_throttle_margin_c` below TjMax is a strong
-# signal that perf is thermally bounded.
+# Public AMD product specs are used for TDP where available. Junction and HBM
+# temperature caps are conservative PerfXpert runtime defaults, not guaranteed
+# SKU-level AMD-published limits; override them when exact telemetry is known.
 #
 # Phase-10 Feature B.
 
@@ -51,7 +51,8 @@ verdict_buckets:
     description: "Junction temp within throttle_margin OR power >= TDP headroom."
 
 notes: |
-  Sourced from AMD data sheets / ROCm public documentation. Values are
-  *defaults* — real-world board partners may ship with more aggressive
-  thermal caps. Override via parse_amd_smi_json sample + analyze_thermal
-  tjmax_c argument when you know the exact sku.
+  TDP values are sourced from public AMD product specs where available.
+  Junction and HBM temperature limits are conservative PerfXpert defaults for
+  runtime classification, because public product pages do not consistently
+  publish SKU-level TjMax/HBM TjMax values. Override via parse_amd_smi_json
+  sample + analyze_thermal tjmax_c argument when you know the exact SKU.

--- a/experimental/python/perfxpert/perfxpert/knowledge/vgpr_occupancy_tables.yaml
+++ b/experimental/python/perfxpert/perfxpert/knowledge/vgpr_occupancy_tables.yaml
@@ -2,37 +2,34 @@
 # Ref: llm-reference-guide.md lines 695-714.
 # Used by: occupancy.lookup_waves_per_eu(vgpr_count, gfx_id)
 
-# CDNA3 (MI300X, gfx942) — 256 VGPRs per EU per thread
+# CDNA3 (MI300X, gfx942) — 512 regular VGPRs/EU, capped at 8 waves/EU
 gfx942:
-  - {max_vgprs: 32,  waves_per_eu: 8}
-  - {max_vgprs: 40,  waves_per_eu: 6}
-  - {max_vgprs: 48,  waves_per_eu: 5}
-  - {max_vgprs: 64,  waves_per_eu: 4}
-  - {max_vgprs: 80,  waves_per_eu: 3}
-  - {max_vgprs: 128, waves_per_eu: 2}
-  - {max_vgprs: 256, waves_per_eu: 1}
+  - {max_vgprs: 64,  waves_per_eu: 8}
+  - {max_vgprs: 80,  waves_per_eu: 6}
+  - {max_vgprs: 96,  waves_per_eu: 5}
+  - {max_vgprs: 128, waves_per_eu: 4}
+  - {max_vgprs: 160, waves_per_eu: 3}
+  - {max_vgprs: 256, waves_per_eu: 2}
 
-# CDNA4 (MI350X, gfx950) — same VGPR table as CDNA3 but LDS doubled
+# CDNA4 (MI350X, gfx950) — same 512-VGPR/EU occupancy basis as CDNA3
 gfx950:
-  - {max_vgprs: 32,  waves_per_eu: 8}
-  - {max_vgprs: 40,  waves_per_eu: 6}
-  - {max_vgprs: 48,  waves_per_eu: 5}
-  - {max_vgprs: 64,  waves_per_eu: 4}
-  - {max_vgprs: 80,  waves_per_eu: 3}
-  - {max_vgprs: 128, waves_per_eu: 2}
-  - {max_vgprs: 256, waves_per_eu: 1}
+  - {max_vgprs: 64,  waves_per_eu: 8}
+  - {max_vgprs: 80,  waves_per_eu: 6}
+  - {max_vgprs: 96,  waves_per_eu: 5}
+  - {max_vgprs: 128, waves_per_eu: 4}
+  - {max_vgprs: 160, waves_per_eu: 3}
+  - {max_vgprs: 256, waves_per_eu: 2}
 
-# CDNA2 (MI250X, gfx90a) — 256 VGPRs
+# CDNA2 (MI250X, gfx90a) — 512 regular VGPRs/EU, capped at 8 waves/EU
 gfx90a:
-  - {max_vgprs: 32,  waves_per_eu: 8}
-  - {max_vgprs: 40,  waves_per_eu: 6}
-  - {max_vgprs: 48,  waves_per_eu: 5}
-  - {max_vgprs: 64,  waves_per_eu: 4}
-  - {max_vgprs: 80,  waves_per_eu: 3}
-  - {max_vgprs: 128, waves_per_eu: 2}
-  - {max_vgprs: 256, waves_per_eu: 1}
+  - {max_vgprs: 64,  waves_per_eu: 8}
+  - {max_vgprs: 80,  waves_per_eu: 6}
+  - {max_vgprs: 96,  waves_per_eu: 5}
+  - {max_vgprs: 128, waves_per_eu: 4}
+  - {max_vgprs: 160, waves_per_eu: 3}
+  - {max_vgprs: 256, waves_per_eu: 2}
 
-# CDNA1 (MI100, gfx908) — 256 VGPRs
+# CDNA1 (MI100, gfx908) — 256 regular VGPRs/EU plus separate AccVGPRs
 gfx908:
   - {max_vgprs: 32,  waves_per_eu: 8}
   - {max_vgprs: 40,  waves_per_eu: 6}

--- a/experimental/python/perfxpert/perfxpert/tools/interconnect.py
+++ b/experimental/python/perfxpert/perfxpert/tools/interconnect.py
@@ -1,9 +1,9 @@
 """interconnect — XGMI / PCIe / NIC peak lookup tool.
 
-Structured lookup for RCCL communication analysis. Returns per-arch XGMI
-aggregate + per-link bandwidths, the PCIe tier, and an "achievable" RCCL
-AllReduce busBW number (typical field observation) so the Latency
-Specialist can classify bus-bandwidth efficiency.
+Structured lookup for RCCL communication analysis. Returns per-arch vendor
+IF/XGMI aggregate + per-link bandwidths, the PCIe tier, and an empirical
+"achievable" RCCL AllReduce busBW number so the Latency Specialist can
+classify bus-bandwidth efficiency.
 
 Tool class: READ_ONLY (MCP-safe).
 
@@ -39,7 +39,7 @@ def lookup_peaks(gfx_id: str) -> Dict[str, Any]:
         >>> from perfxpert.tools.interconnect import lookup_peaks
         >>> mi300x = lookup_peaks("gfx942")
         >>> mi300x["xgmi_peak_gbps"]
-        448.0
+        1024.0
     """
     specs = load_yaml("interconnect_specs")
     if gfx_id not in specs:

--- a/experimental/python/perfxpert/tests/test_knowledge/test_gpu_specs.py
+++ b/experimental/python/perfxpert/tests/test_knowledge/test_gpu_specs.py
@@ -36,7 +36,7 @@ def test_gpu_specs_validates_against_schema():
 
 
 def test_mi300x_fp64_peak_is_corrected():
-    """CLAUDE.md correction: MI300X FP64 = 81.7 TFLOPS (NOT 163.4 which is FP32)."""
+    """AMD product specs: MI300X FP64 = 81.7 TFLOPS, not the FP32 value."""
     specs = load_yaml("gpu_specs")
     mi300x = specs["gfx942"]
     fp64 = mi300x["peak_fp64_tflops"]
@@ -44,10 +44,62 @@ def test_mi300x_fp64_peak_is_corrected():
 
 
 def test_cdna4_has_160kb_lds():
-    """CDNA4 (gfx950) doubled LDS to 160 KB/CU per CLAUDE.md."""
+    """ROCm hardware specs list CDNA4 gfx950 LDS as 160 KiB."""
     specs = load_yaml("gpu_specs")
     mi350 = specs["gfx950"]
     assert mi350["lds_kb"] == 160, f"CDNA4 LDS expected 160 KB/CU, got {mi350['lds_kb']}"
+
+
+def test_mi300x_occupancy_caps_match_rocm_rocminfo_example():
+    """ROCm's MI300X rocminfo example reports 32 waves/CU and 4 SIMDs/CU."""
+    specs = load_yaml("gpu_specs")
+    mi300x = specs["gfx942"]
+    assert mi300x["simds_per_cu"] == 4
+    assert mi300x["max_waves_per_simd"] == 8
+    assert mi300x["simds_per_cu"] * mi300x["max_waves_per_simd"] == 32
+
+
+def test_mi350x_public_peaks_match_amd_product_specs():
+    specs = load_yaml("gpu_specs")
+    mi350 = specs["gfx950"]
+    assert mi350["peak_fp64_tflops"] == pytest.approx(72.1)
+    assert mi350["peak_fp32_tflops"] == pytest.approx(144.2)
+    assert mi350["peak_fp16_tflops"] == pytest.approx(2300.0)
+    assert mi350["peak_fp8_tflops"] == pytest.approx(4600.0)
+    assert mi350["memory_bandwidth_tbs"] == pytest.approx(8.0)
+    assert mi350["ridge_point"] == pytest.approx(18.0)
+
+
+def test_mi100_int8_peak_matches_amd_product_specs():
+    specs = load_yaml("gpu_specs")
+    mi100 = specs["gfx908"]
+    assert mi100["peak_int8_tops"] == pytest.approx(92.3)
+    assert mi100["vgprs_per_simd"] == 256
+
+
+def test_radeon_product_page_peaks_match_amd_product_specs():
+    specs = load_yaml("gpu_specs")
+
+    rx6900 = specs["gfx1030"]
+    assert rx6900["peak_fp32_tflops"] == pytest.approx(23.04)
+    assert rx6900["peak_fp16_tflops"] == pytest.approx(46.08)
+    assert rx6900["memory_bandwidth_tbs"] == pytest.approx(0.512)
+    assert rx6900["ridge_point"] == pytest.approx(45.0)
+
+    rx7900 = specs["gfx1100"]
+    assert rx7900["peak_fp32_tflops"] == pytest.approx(61.4)
+    assert rx7900["peak_fp16_tflops"] == pytest.approx(123.0)
+    assert rx7900["peak_int8_tops"] == pytest.approx(123.0)
+    assert rx7900["memory_bandwidth_tbs"] == pytest.approx(0.960)
+    assert rx7900["ridge_point"] == pytest.approx(64.0)
+
+
+def test_cdna_fp8_mfma_is_zero_when_arch_has_no_fp8_peak():
+    specs = load_yaml("gpu_specs")
+    for gfx_id in ("gfx908", "gfx90a"):
+        spec = specs[gfx_id]
+        assert spec["peak_fp8_tflops"] == 0.0
+        assert spec["mfma_flops_per_inst"]["fp8"] == 0
 
 
 def test_default_ridge_matches_fp32_peak_over_bandwidth():

--- a/experimental/python/perfxpert/tests/test_knowledge/test_vgpr_occupancy_tables.py
+++ b/experimental/python/perfxpert/tests/test_knowledge/test_vgpr_occupancy_tables.py
@@ -28,5 +28,7 @@ def test_vgpr_occupancy_tables_has_expected_content():
     data = load_yaml("vgpr_occupancy_tables")
     assert "gfx942" in data
     assert "gfx950" in data
-    # CDNA3 table has 7 entries
-    assert len(data["gfx942"]) == 7
+    # CDNA3 uses a 512-VGPR/EU basis capped at 8 waves/EU.
+    assert len(data["gfx942"]) == 6
+    assert data["gfx942"][0] == {"max_vgprs": 64, "waves_per_eu": 8}
+    assert data["gfx942"][-1] == {"max_vgprs": 256, "waves_per_eu": 2}

--- a/experimental/python/perfxpert/tests/test_knowledge/test_yaml_schemas.py
+++ b/experimental/python/perfxpert/tests/test_knowledge/test_yaml_schemas.py
@@ -16,7 +16,7 @@ KNOWLEDGE_DIR = (
 )
 SCHEMAS_DIR = KNOWLEDGE_DIR / "_schemas"
 
-# The 21 YAML files expected per spec Appendix B
+# Core YAML files expected per spec Appendix B and later agentic extensions.
 _EXPECTED_YAMLS = {
     "gpu_specs",
     "bottleneck_types",
@@ -56,7 +56,7 @@ def test_every_yaml_validates_against_its_schema(yaml_path):
     jsonschema.validate(data, schema)
 
 
-def test_all_21_expected_yaml_files_present():
+def test_expected_yaml_files_present():
     present = {p.stem for p in _all_yaml_files()}
     missing = _EXPECTED_YAMLS - present
     assert not missing, f"missing YAMLs: {missing}"

--- a/experimental/python/perfxpert/tests/test_tools/test_arch.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_arch.py
@@ -11,8 +11,19 @@ def test_lookup_peaks_returns_structured_data_for_mi300x():
     assert peaks["name"] == "MI300X"
     assert peaks["peak_fp64_tflops"] == 81.7
     assert peaks["memory_bandwidth_tbs"] == 5.3
+    assert peaks["max_waves_per_simd"] == 8
     assert peaks["ridge_point"] == pytest.approx(30.8, rel=0.01)
     assert peaks["ridge_points"]["fp64"] == pytest.approx(15.4, rel=0.01)
+
+
+def test_lookup_peaks_returns_public_mi350x_values_for_gfx950():
+    peaks = arch.lookup_peaks("gfx950")
+    assert peaks["name"] == "MI350X"
+    assert peaks["peak_fp64_tflops"] == pytest.approx(72.1)
+    assert peaks["peak_fp32_tflops"] == pytest.approx(144.2)
+    assert peaks["memory_bandwidth_tbs"] == pytest.approx(8.0)
+    assert peaks["max_waves_per_simd"] == 8
+    assert peaks["ridge_point"] == pytest.approx(18.0, rel=0.01)
 
 
 def test_lookup_peaks_exposes_runtime_caps_for_occupancy_users():

--- a/experimental/python/perfxpert/tests/test_tools/test_occupancy.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_occupancy.py
@@ -10,8 +10,20 @@ def test_lookup_vgpr_32_gives_8_waves_on_cdna3():
     assert occupancy.lookup_waves_per_eu(32, "gfx942") == 8
 
 
-def test_lookup_vgpr_128_gives_2_waves_on_cdna3():
-    assert occupancy.lookup_waves_per_eu(128, "gfx942") == 2
+def test_lookup_vgpr_64_gives_8_waves_on_cdna3():
+    assert occupancy.lookup_waves_per_eu(64, "gfx942") == 8
+
+
+def test_lookup_vgpr_128_gives_4_waves_on_cdna3():
+    assert occupancy.lookup_waves_per_eu(128, "gfx942") == 4
+
+
+def test_lookup_vgpr_256_gives_2_waves_on_cdna3():
+    assert occupancy.lookup_waves_per_eu(256, "gfx942") == 2
+
+
+def test_lookup_vgpr_128_gives_2_waves_on_cdna1():
+    assert occupancy.lookup_waves_per_eu(128, "gfx908") == 2
 
 
 def test_lookup_unknown_arch_raises():

--- a/experimental/python/perfxpert/tests/test_tools/test_rccl_analysis.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_rccl_analysis.py
@@ -43,7 +43,7 @@ def test_analyze_collectives_computes_busbw_allreduce():
     # busBW = 1048576 * 1.5 / 1e-3 / 1e9 = 1.572864 GB/s
     expected = 1048576 * 1.5 / 1e-3 / 1e9
     assert abs(first["effective_bw_gbps"] - expected) < 0.01
-    assert first["peak_bw_gbps"] == 340.0   # from interconnect_specs (MI300X)
+    assert first["peak_bw_gbps"] == 340.0   # achievable RCCL baseline for MI300X
     # 4 collectives, dominant AllReduce.
     assert r["summary"]["dominant_op"] == "AllReduce"
     assert r["summary"]["op_count"] == 4
@@ -81,6 +81,23 @@ def test_interconnect_lookup_peaks_returns_dict_per_arch():
         entry = interconnect.lookup_peaks(gfx)
         missing = required - set(entry)
         assert not missing, f"{gfx} missing fields: {missing}"
+
+
+def test_interconnect_lookup_peaks_uses_public_amd_link_specs():
+    mi250x = interconnect.lookup_peaks("gfx90a")
+    assert mi250x["xgmi_links"] == 8
+    assert mi250x["xgmi_per_link_gbps"] == pytest.approx(100.0)
+    assert mi250x["xgmi_peak_gbps"] == pytest.approx(800.0)
+
+    mi300x = interconnect.lookup_peaks("gfx942")
+    assert mi300x["xgmi_links"] == 8
+    assert mi300x["xgmi_per_link_gbps"] == pytest.approx(128.0)
+    assert mi300x["xgmi_peak_gbps"] == pytest.approx(1024.0)
+
+    mi350x = interconnect.lookup_peaks("gfx950")
+    assert mi350x["xgmi_links"] == 7
+    assert mi350x["xgmi_per_link_gbps"] == pytest.approx(153.0)
+    assert mi350x["xgmi_peak_gbps"] == pytest.approx(1071.0)
 
 
 def test_interconnect_lookup_peaks_unknown_raises():


### PR DESCRIPTION
## Motivation

PerfXpert knowledge YAMLs and doc examples had hardware spec drift from AMD and ROCm official resources, causing agents, tools, and tests to report stale peaks, occupancy caps, and interconnect numbers.

## Technical Details

- Align MI100, MI250X, MI300X, MI350X, RX 6900 XT, and RX 7900 XTX peak, VGPR, occupancy, and IF/XGMI fields with AMD product pages and ROCm hardware/rocminfo docs.
- Recompute ridge points from corrected FP32/HBM values.
- Distinguish AMD-published hardware specs from derived values and empirical PerfXpert guardrails.
- Correct contributor and Python API docs plus regression tests that lock official values.

Official references:
- AMD MI100 product specs: https://www.amd.com/en/products/accelerators/instinct/mi100.html
- AMD MI250X product specs: https://www.amd.com/en/products/accelerators/instinct/mi200/mi250x.html
- AMD MI300X product specs: https://www.amd.com/en/products/accelerators/instinct/mi300/mi300x.html
- AMD MI350X product specs: https://www.amd.com/en/products/accelerators/instinct/mi350/mi350x.html
- AMD RX 6900 XT product specs: https://www.amd.com/en/products/graphics/desktops/radeon/6000-series/amd-radeon-rx-6900-xt.html
- AMD RX 7900 XTX product specs: https://www.amd.com/en/products/graphics/desktops/radeon/7000-series/amd-radeon-rx-7900xtx.html
- ROCm GPU hardware specs: https://rocm.docs.amd.com/en/latest/reference/gpu-arch-specs.html
- ROCm rocminfo MI300X example: https://rocm.docs.amd.com/projects/rocminfo/en/develop/how-to/use-rocminfo.html

## JIRA ID

N/A

## Test Plan

- `PYTHONPATH=experimental/python/perfxpert pytest -q experimental/python/perfxpert/tests/test_knowledge/test_yaml_schemas.py experimental/python/perfxpert/tests/test_fence/test_filters.py experimental/python/perfxpert/tests/test_knowledge/test_gpu_specs.py experimental/python/perfxpert/tests/test_knowledge/test_vgpr_occupancy_tables.py experimental/python/perfxpert/tests/test_knowledge/test_yaml_content.py experimental/python/perfxpert/tests/test_tools/test_arch.py experimental/python/perfxpert/tests/test_tools/test_occupancy.py experimental/python/perfxpert/tests/test_tools/test_rccl_analysis.py`
- `timeout 180s env PYTHONPATH=experimental/python/perfxpert pytest -q experimental/python/perfxpert/tests/test_tools experimental/python/perfxpert/tests/test_knowledge experimental/python/perfxpert/tests/test_fence`
- `git diff --check`
- `custom-ai-secret-scan <changed files>`

## Test Result

- Focused spec/schema/fence/tool suite: 91 passed in 1.67s.
- Expanded PerfXpert tools, knowledge, and fence suite: 442 passed in 4.56s.
- `git diff --check`: clean.
- Changed-file secret scan: clean. A whole-repo fallback scan was not used as the publish proof because the base repository contains an unrelated checked-in drawio data URI that the fallback scanner flags as a candidate secret.
- Full PerfXpert test tree was attempted before this update but is not used as proof: collection is blocked in this environment by missing `hypothesis`, and a full-minus-fuzz attempt hit unrelated e2e doctor failures because the bundled patched opencode binary is not present in this worktree.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
