### PR TITLE
[RCCL] Guard directBuff usage in waitPeer when no IPC registration

### DIFF
--- a/projects/rccl/src/device/prims_simple.h
+++ b/projects/rccl/src/device/prims_simple.h
@@ -181,17 +181,20 @@ private:
       } else if ((flags & ConnFifoEnabled) && connFifo[step%NCCL_STEPS].mode == NCCL_MODE_OFFSET) {
         ptrs[index] = connEltsFifo + loadInt(&connFifo[step%NCCL_STEPS].offset)/sizeof(T);
       } else if (isSendNotRecv && DirectSend) {
-        if (flags & DirectWrite) {
+        // directBuff is only assigned by setDataPtrs when (Direct && ipcReg);
+        // when Direct=1 but no buffer was registered, it stays NULL and using
+        // it as a base would compute an invalid GPU address.
+        if ((flags & DirectWrite) && directBuff != nullptr) {
           ptrs[index] = directBuff + dstIx + offset;
-        } else if (flags & DirectRead) {  // empty send
+        } else if ((flags & DirectRead) && directBuff != nullptr) {  // empty send
           ptrs[index] = nullptr;
         } else {
           ptrs[index] = connEltsFifo + (step%NCCL_STEPS)*connStepSize;
         }
       } else if (!isSendNotRecv && DirectRecv) {
-        if (flags & DirectRead) {
+        if ((flags & DirectRead) && directBuff != nullptr) {
           ptrs[index] = directBuff + srcIx + offset;
-        } else if (flags & DirectWrite) {
+        } else if ((flags & DirectWrite) && directBuff != nullptr) {
           ptrs[index] = directBuff + dstIx + offset;  // send to next from my output buffer
         } else {
           ptrs[index] = connEltsFifo + (step%NCCL_STEPS)*connStepSize;


### PR DESCRIPTION
## Summary

When `Direct=1` is set in the `Primitives<>` template (as commit `f2e4b30` did for AllGather RING/PAT/NVLS) but the framework never calls `ncclCommRegister`, `ncclIpcLocalRegisterBuffer` is a no-op and `directBuff` is left at its initial `NULL`. `waitPeer` then computes `ptrs[index] = directBuff + dstIx + offset`, which is a tiny invalid GPU address.

Aliased AllGather paths (`directSend`, `Dst=-1`) survive because the resulting `dsts[index]` is not actually dereferenced. The first non-aliased AllGather (`directCopySend`, `Dst=Output`) writes to the bad pointer and the kernel hangs on a memory fault — observed as 100% GPU util with no progress.

This patch guards `directBuff` uses with a runtime null check, mirroring the `(Direct && fn.work->regUsed)` pattern already used in `process()`. When `directBuff` is `NULL` the kernel falls through to the `connEltsFifo` path. The UBR optimization is preserved when registration actually succeeds.

## Reproducer

`pyt_huggingface_llama2_70b_chat` (ZeRO-3, fp16, eval) on 8x MI355X (gfx950, ROCm 7.13, RCCL 2.28.3) — hang at AllGather `opCount 0x886` (count=32M, fp16, 64 MB).

Workaround for users not on the fix yet: `NCCL_LOCAL_REGISTER=0`.

## LL is not affected

`prims_ll.h`'s `Primitives` specialization inherits from `PrimitivesWithoutDirect` and has no `directBuff` field. Verified empirically by running `NCCL_PROTO=LL` with the unfixed lib through the same workload — eval completes (slower, as expected, but no hang).

## Test plan

- [x] Build RCCL locally with the patch and swap into the affected wheel
- [x] Re-run `pyt_huggingface_llama2_70b_chat` end-to-end — eval completes at `11.98 eval_samples_per_second` (vs hang on the bundled lib)
- [x] Confirm `NCCL_PROTO=LL` + bundled (unfixed) lib does not hang (rules out LL having an analogous bug)
- [ ] CI: standard rccl-tests sweep
- [ ] Reviewer to confirm the runtime null check is acceptable cost in the kernel hot path (analysis: branch is highly predictable since `directBuff` is either always-NULL or always-non-NULL within a kernel launch)

Fixes ROCM-21756. Related to AICOMRCCL-98 / ROCM-1974.