### PR TITLE
[RCCL][Topo Vis] Fix topology explorer for MI350 and several other platforms

### DIFF
--- a/projects/rccl/tools/topo_expl/include/topo_expl_impl.h
+++ b/projects/rccl/tools/topo_expl/include/topo_expl_impl.h
@@ -34,8 +34,6 @@ void initCollNet();
 
 ncclResult_t ncclTopoGetSystem(const char* xmlTopoFile, struct ncclTopoSystem** system);
 
-ncclResult_t ncclTopoGetSystemFromXml(struct ncclXml* xml, struct ncclTopoSystem** topoSystem);
-
 ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, uint64_t commHash);
 
 ncclResult_t initTransportsRank_1(struct ncclComm* comm, struct allGatherInfo *allGather3Data,

--- a/projects/rccl/tools/topo_expl/src/topo_expl_impl.cpp
+++ b/projects/rccl/tools/topo_expl/src/topo_expl_impl.cpp
@@ -228,7 +228,23 @@ ncclResult_t ncclTopoGetSystem(const char* xmlTopoFile, struct ncclTopoSystem** 
   struct ncclXml* xml;
   NCCLCHECK(xmlAlloc(&xml, NCCL_GRAPH_XML_MAX_NODES));
   NCCLCHECK(ncclTopoGetXmlFromFile(xmlTopoFile, xml, 0));
-  NCCLCHECK(ncclTopoGetSystemFromXml(xml, system, 0));
+  // Extract host_hash from the first CPU node so XMLs with explicit host_hash
+  // attributes (e.g. topo_8p_950.xml) are handled correctly. XMLs without
+  // host_hash default to 0, which matches the previous behaviour.
+  uint64_t localHostHash = 0;
+  struct ncclXmlNode* systemNode;
+  if (xmlFindTag(xml, "system", &systemNode) == ncclSuccess) {
+    for (int s = 0; s < systemNode->nSubs; s++) {
+      struct ncclXmlNode* node = systemNode->subs[s];
+      if (strcmp(node->name, "cpu") == 0) {
+        const char* hostHashStr;
+        if (xmlGetAttr(node, "host_hash", &hostHashStr) == ncclSuccess && hostHashStr)
+          localHostHash = strtoull(hostHashStr, NULL, 16);
+        break;
+      }
+    }
+  }
+  NCCLCHECK(ncclTopoGetSystemFromXml(xml, system, localHostHash));
   free(xml);
   return ncclSuccess;
 }


### PR DESCRIPTION
## Motivation

- Revive topo explorer for MI350 (`-m 59`) and all attempted models that were broken before
- Need to maintain the tool for RCCL-compatible MI450 topology viewing

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
