### PR TITLE
Tighten PerfXpert gate fallback guidance

### DIFF
--- a/experimental/python/perfxpert/CHANGELOG.md
+++ b/experimental/python/perfxpert/CHANGELOG.md
@@ -84,6 +84,11 @@ is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   one-liner still works for users who want it.
 
 ### Changed
+- **Codex gate discovery.** Codex-rendered gate prompts now allow only
+  `tool_search` / `tool_search_tool` as a discovery-only prelude when
+  the required PerfXpert MCP gate tools are deferred out of the initial
+  tool inventory; shell, SSH, build, edit, and profiling fallbacks
+  remain blocked until `perfxpert_intent_classify` returns.
 - **`--llm` providers.** All five providers —
   `anthropic`, `openai`, `ollama`, `private`, `opencode` — are
   selectable from the CLI **and** from `perfxpert.api.agent_root(...,

--- a/experimental/python/perfxpert/docs/architecture/backend-adapter.md
+++ b/experimental/python/perfxpert/docs/architecture/backend-adapter.md
@@ -110,10 +110,11 @@ module per backend. Every gate-hook installer satisfies three rules:
 
 3. **Reject non-perfxpert tool calls until lift.** Until
    `perfxpert_intent_classify` has been invoked in the current
-   session, every non-`mcp_perfxpert_*` tool call is denied with a
+   session, every non-PerfXpert MCP tool call is denied with a
    user-visible reason matching the opencode fork patch 0020
    `retryWith` message ("call `intent_classify` first"). This keeps
-   the UX identical across backends.
+   the UX identical across backends while allowing each backend to use
+   its own MCP wire-name format.
 
 The three `LiveCheckReport.gate_hook_installed` states encode these
 outcomes: `None` = probe skipped, `False` = surface unsupported

--- a/experimental/python/perfxpert/docs/guides/backends.md
+++ b/experimental/python/perfxpert/docs/guides/backends.md
@@ -193,6 +193,14 @@ embedded in a perfxpert-managed `AGENTS.override.md`
 appends a perfxpert-managed block so Codex sees both the repo guidance
 and the perfxpert gate. `AGENTS.override.md` is a compatibility file
 owned by the adapter, not a native Codex-only source of truth.
+Codex can defer MCP tool metadata out of the initial model-visible tool
+inventory when the session is crowded. In that case, the generated
+Codex prompt allows exactly one pre-gate exception: use Codex's
+metadata search tool (`tool_search` / `tool_search_tool`) to expose the
+PerfXpert `intent_classify` and `workflow_next_step` MCP tools, then
+call the gate immediately. If discovery does not expose the gate, the
+agent must still stop with a PerfXpert configuration error instead of
+using shell, SSH, build, edit, or profiling commands as a fallback.
 Smaller models may bypass advisory language; if
 mechanical enforcement matters for your workflow, use
 `perfxpert-code claude` or the bundled `opencode` default (both

--- a/experimental/python/perfxpert/docs/guides/backends.md
+++ b/experimental/python/perfxpert/docs/guides/backends.md
@@ -56,7 +56,7 @@ fork-only opencode gate hook without any extra backend install.
 | **opencode** (default patched path) | `perfxpert-code` | Any (via opencode provider) | `~/.cache/perfxpert/opencode/opencode.json` | Per-bundle / per-checkout | Patched system prompt + fork patches 0010, 0020 | `perfxpert_*` |
 | **Claude Code** | `perfxpert-code claude` | Anthropic Claude | `./.mcp.json` + `./CLAUDE.local.md` + `./.claude/settings.json` | Project | Native `PreToolUse` hook (event-based lift) | `mcp__perfxpert__*` |
 | **Gemini CLI** | `perfxpert-code gemini` | Google Gemini | `./.gemini/settings.json` + `./.perfxpert/AGENTS.md` | Project | Native `BeforeTool` / `AfterTool` hooks (event-based lift) | `mcp_perfxpert_*` |
-| **Codex CLI** | `perfxpert-code codex` | OpenAI | `~/.codex/config.toml` (trust) + `./.codex/config.toml` when trusted or fallback `~/.codex/config.toml` for MCP + `./AGENTS.override.md` | Trust in user config; MCP project-local when trusted | Prompt-layer-only (Codex `PreToolUse` is Bash-only — see decision record) | `mcp_perfxpert_*` |
+| **Codex CLI** | `perfxpert-code codex` | OpenAI | `~/.codex/config.toml` (trust) + `./.codex/config.toml` when trusted or fallback `~/.codex/config.toml` for MCP + `./AGENTS.override.md` | Trust in user config; MCP project-local when trusted | Prompt-layer-only (Codex `PreToolUse` is Bash-only — see decision record) | `mcp__perfxpert__*` |
 
 Consent is requested once per **(backend, cwd-hash, file-set-hash)**
 tuple and persisted — re-running the same subcommand in the same

--- a/experimental/python/perfxpert/docs/integration/mcp-server.md
+++ b/experimental/python/perfxpert/docs/integration/mcp-server.md
@@ -538,7 +538,7 @@ session:
 |---|---|---|---|
 | `perfxpert-code claude`  | Claude Code | `.mcp.json` + `CLAUDE.local.md` + `.claude/settings.json` | `mcp__perfxpert__<tool>` |
 | `perfxpert-code gemini`  | Gemini CLI  | `.gemini/settings.json` (project-local list-append, never touches `GEMINI.md`) | `mcp_perfxpert_<tool>` |
-| `perfxpert-code codex`   | Codex CLI   | `~/.codex/config.toml` (trust) + `<cwd>/.codex/config.toml` when trusted or fallback `~/.codex/config.toml` for MCP + `AGENTS.override.md` | `mcp_perfxpert_<tool>` |
+| `perfxpert-code codex`   | Codex CLI   | `~/.codex/config.toml` (trust) + `<cwd>/.codex/config.toml` when trusted or fallback `~/.codex/config.toml` for MCP + `AGENTS.override.md` | `mcp__perfxpert__<tool>` |
 
 All three subcommands accept the same dispatcher-owned flags:
 

--- a/experimental/python/perfxpert/perfxpert/__init__.py
+++ b/experimental/python/perfxpert/perfxpert/__init__.py
@@ -17,7 +17,12 @@ CLI
     perfxpert analyze -i trace.db --format json
 """
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("perfxpert")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
 __author__ = "Advanced Micro Devices, Inc."
 
 from .connection import PerfxpertConnection, execute_statement, merge_sqlite_dbs

--- a/experimental/python/perfxpert/perfxpert/_bundled/opencode_config/AGENTS.md
+++ b/experimental/python/perfxpert/perfxpert/_bundled/opencode_config/AGENTS.md
@@ -29,6 +29,17 @@ MCP server (stdio, command `perfxpert-mcp`).
      is unavailable / not exposed in the backend session, STOP with a
      PerfXpert configuration error. Do NOT use a native SSH/build/profile
      fallback path.
+   <!--backend:codex-->
+   - Codex may defer MCP tools behind its metadata-search surface when
+     the initial tool inventory is crowded. If
+     `perfxpert_intent_classify` is not directly exposed but `tool_search`
+     / `tool_search_tool` is available, the only allowed pre-gate
+     exception is to search for "perfxpert intent_classify
+     workflow_next_step" and then immediately call the returned
+     PerfXpert MCP gate tool. If discovery cannot expose the gate, STOP
+     with the same PerfXpert configuration error. Do NOT use shell, SSH,
+     build, edit, or profiling tools as a discovery fallback.
+   <!--/backend:codex-->
    - AFTER `perfxpert_workflow_next_step` returns a phase (profile /
      optimize / reprofile / analyze / build), the gate is LIFTED.
      At that point you MUST use `bash` to run the profiler (rocprofv3,

--- a/experimental/python/perfxpert/perfxpert/_bundled/opencode_config/AGENTS.md
+++ b/experimental/python/perfxpert/perfxpert/_bundled/opencode_config/AGENTS.md
@@ -39,6 +39,14 @@ MCP server (stdio, command `perfxpert-mcp`).
      `perfxpert_regression_compare_runs` / `perfxpert_sol_sanity_check`
      on the results. Don't ask the user to copy-paste commands you
      could run yourself.
+   - If required execution or validation tooling is missing on the local
+     machine or an SSH remote host (for example `sqlite3` needed to
+     inspect a generated `.db`), do NOT silently skip the validation,
+     leave the artifact uninspected, or continue with lower confidence.
+     Ask the user for explicit permission to install the missing tool on
+     the specific host, naming the package/tool and the install command
+     you would run. If the user declines, report that the validation is
+     blocked and stop or ask for an alternate validation path.
 
 3. **Route intent via `perfxpert_intent_classify` first.** Then pick
    downstream tools freely — there is no forced handoff after intent

--- a/experimental/python/perfxpert/perfxpert/_bundled/opencode_config/AGENTS.md
+++ b/experimental/python/perfxpert/perfxpert/_bundled/opencode_config/AGENTS.md
@@ -23,6 +23,12 @@ MCP server (stdio, command `perfxpert-mcp`).
    **Gate discipline for GPU-performance requests:**
    - FIRST call `perfxpert_intent_classify`, THEN `perfxpert_workflow_next_step`.
    - Do NOT call `bash`/`edit`/`read`/`glob`/`grep` BEFORE those two.
+   - SSH or another remote host changes only WHERE native build/profile
+     commands run. It never bypasses the PerfXpert MCP gate.
+   - If `perfxpert_intent_classify` or `perfxpert_workflow_next_step`
+     is unavailable / not exposed in the backend session, STOP with a
+     PerfXpert configuration error. Do NOT use a native SSH/build/profile
+     fallback path.
    - AFTER `perfxpert_workflow_next_step` returns a phase (profile /
      optimize / reprofile / analyze / build), the gate is LIFTED.
      At that point you MUST use `bash` to run the profiler (rocprofv3,

--- a/experimental/python/perfxpert/perfxpert/cli/_backend/_prompt_adapter.py
+++ b/experimental/python/perfxpert/perfxpert/cli/_backend/_prompt_adapter.py
@@ -71,6 +71,11 @@ pre-tool-call hook — the rejection is not advisory.
 
 After `{classify_tool}` returns, any tool is permitted for the
 rest of the session.
+
+If `{classify_tool}` is not available or not exposed in the current
+backend session, STOP with a PerfXpert configuration error. Do not
+fall back to native execution tools, including local shells, SSH
+commands, remote-host builds, or profiling commands.
 """
 
 

--- a/experimental/python/perfxpert/perfxpert/cli/_backend/_prompt_adapter.py
+++ b/experimental/python/perfxpert/perfxpert/cli/_backend/_prompt_adapter.py
@@ -65,17 +65,18 @@ REJECTION_LANGUAGE_STANZA = """\
 # Tool-priority gate (NON-NEGOTIABLE)
 
 Your response WILL BE REJECTED if you call any tool other than
-`{classify_tool}` before `{classify_tool}` has been observed to
-return in this session. This is mechanically enforced by a
-pre-tool-call hook — the rejection is not advisory.
+`{classify_tool}`{discovery_exception} before `{classify_tool}` has been observed to
+return in this session. This is enforced by the backend pre-tool-call
+hook when that hook surface is available; Codex sessions enforce the
+same rule through this prompt-layer gate.
 
 After `{classify_tool}` returns, any tool is permitted for the
 rest of the session.
 
 If `{classify_tool}` is not available or not exposed in the current
-backend session, STOP with a PerfXpert configuration error. Do not
-fall back to native execution tools, including local shells, SSH
-commands, remote-host builds, or profiling commands.
+backend session, {missing_tool_action}. Do not fall back to native
+execution tools, including local shells, SSH commands, remote-host
+builds, or profiling commands.
 """
 
 
@@ -129,6 +130,7 @@ def render_prompt(
     known_tools: tuple[str, ...],
     reject_language: bool = True,
     classify_tool: str = "intent_classify",
+    discovery_tools: tuple[str, ...] = (),
 ) -> str:
     """Render a source prompt file into the backend-specific form.
 
@@ -144,7 +146,9 @@ def render_prompt(
 
     The `classify_tool` kwarg lets the caller pass a pre-rendered
     tool name (e.g. `mcp__perfxpert__intent_classify`) so the stanza
-    refers to the exact name the backend exposes.
+    refers to the exact name the backend exposes. `discovery_tools`
+    names backend-native metadata search tools that may be called only
+    to expose a deferred PerfXpert classify tool before the gate opens.
     """
     if isinstance(source, Path):
         raw = source.read_text(encoding="utf-8")
@@ -156,7 +160,24 @@ def render_prompt(
 
     if reject_language:
         rendered_classify = tool_name_template.format(tool=classify_tool)
-        stanza = REJECTION_LANGUAGE_STANZA.format(classify_tool=rendered_classify)
+        discovery_exception = ""
+        missing_tool_action = "STOP with a PerfXpert configuration error"
+        if discovery_tools:
+            rendered_discovery = ", ".join(f"`{tool}`" for tool in discovery_tools)
+            discovery_exception = (
+                " or one of the discovery-only metadata tools "
+                f"{rendered_discovery} solely to search for the PerfXpert "
+                "classify/workflow MCP tools"
+            )
+            missing_tool_action = (
+                "use the discovery exception above if it is available; "
+                "otherwise STOP with a PerfXpert configuration error"
+            )
+        stanza = REJECTION_LANGUAGE_STANZA.format(
+            classify_tool=rendered_classify,
+            discovery_exception=discovery_exception,
+            missing_tool_action=missing_tool_action,
+        )
         return stanza + "\n" + substituted
     return substituted
 

--- a/experimental/python/perfxpert/perfxpert/cli/_backend/codex.py
+++ b/experimental/python/perfxpert/perfxpert/cli/_backend/codex.py
@@ -1109,6 +1109,7 @@ class CodexAdapter:
                 tool_name_template=self.tool_name_template,
                 known_tools=_KNOWN_TOOLS,
                 reject_language=True,
+                discovery_tools=("tool_search", "tool_search_tool"),
             )
         return pa.render_prompt(
             bundled_source,
@@ -1116,6 +1117,7 @@ class CodexAdapter:
             tool_name_template=self.tool_name_template,
             known_tools=_KNOWN_TOOLS,
             reject_language=True,
+            discovery_tools=("tool_search", "tool_search_tool"),
         )
 
     def _stage_codex_prompt_file(

--- a/experimental/python/perfxpert/perfxpert/cli/_backend/codex.py
+++ b/experimental/python/perfxpert/perfxpert/cli/_backend/codex.py
@@ -149,10 +149,9 @@ class CodexAdapter:
     )
     min_version: str | None = "0.7.0"
     known_schema_versions: tuple[str, ...] = ("0.7.x",)
-    # Codex's MCP tool name wire format is `mcp_<server>_<tool>` per
-    # the April 2026 observed behavior. verify_mcp_live() probes the
-    # actual wire format and warns on drift (plan B1).
-    tool_name_template: str = "mcp_perfxpert_{tool}"
+    # Codex exposes MCP tools using the same namespace form surfaced in
+    # backend sessions: `mcp__<server>__<tool>`.
+    tool_name_template: str = "mcp__perfxpert__{tool}"
     spawn_strategy: Literal["execvpe", "subprocess"] = "execvpe"
 
     _PERFXPERT_DIR = ".perfxpert"  # legacy cleanup only

--- a/experimental/python/perfxpert/perfxpert/cli/_backend/codex.py
+++ b/experimental/python/perfxpert/perfxpert/cli/_backend/codex.py
@@ -737,7 +737,15 @@ class CodexAdapter:
             "editing codex config.toml directly"
         )
 
-        config_toml.parent.mkdir(parents=True, exist_ok=True)
+        config_dir = config_toml.parent
+        try:
+            config_dir.mkdir(parents=True, exist_ok=True)
+        except FileExistsError as exc:
+            raise ConfigClobber(
+                f"{config_dir} exists but is not a directory. Move it "
+                f"aside (for example: `mv {config_dir} "
+                f"{config_dir}.bak`) and re-run perfxpert-code codex."
+            ) from exc
         existing = (
             config_toml.read_text(encoding="utf-8")
             if config_toml.is_file()

--- a/experimental/python/perfxpert/perfxpert/cli/_backend/codex.py
+++ b/experimental/python/perfxpert/perfxpert/cli/_backend/codex.py
@@ -631,12 +631,22 @@ class CodexAdapter:
         config_toml: Path,
         scope: Literal["project", "user"],
     ) -> None:
-        """Primary: `codex mcp add perfxpert -- perfxpert-mcp`.
+        """Register the PerfXpert MCP server for the effective scope.
 
-        Fallback: lazy-import `tomlkit` and add/merge
-        `[mcp_servers.perfxpert]` into `config_toml` directly
-        (preserves comments + unknown keys).
+        Project scope edits `<cwd>/.codex/config.toml` directly because
+        `codex mcp add` targets the default Codex config. User scope
+        still prefers `codex mcp add`, then falls back to a structured
+        direct TOML edit.
         """
+        if scope == "project":
+            # `codex mcp add` writes the default Codex config, while a
+            # trusted project launch depends on the project-scoped layer.
+            # Always write the project entry directly so a stale/global
+            # perfxpert listing cannot make install pass with no tools
+            # exposed in the launched session.
+            self._structured_edit_config_toml(config_toml)
+            return
+
         binary = shutil.which(self.binary_name)
 
         # 1) Idempotency: skip if already registered.
@@ -747,15 +757,19 @@ class CodexAdapter:
                     f"{config_toml} already has [mcp_servers.perfxpert] "
                     f"with command {cmd!r}; refuse to overwrite."
                 )
-            # Same entry — idempotent no-op.
-            return
+            entry = existing_entry
+        else:
+            entry = tomlkit_mod.table()
+            servers["perfxpert"] = entry
 
-        entry = tomlkit_mod.table()
         entry["command"] = "perfxpert-mcp"
         entry["args"] = tomlkit_mod.array()
         entry["enabled"] = True
+        entry["required"] = True
         entry["startup_timeout_sec"] = 10
-        servers["perfxpert"] = entry
+        for filter_key in ("enabled_tools", "disabled_tools"):
+            if filter_key in entry:
+                del entry[filter_key]
 
         pa.atomic_write(config_toml, tomlkit_mod.dumps(doc))
 

--- a/experimental/python/perfxpert/perfxpert/cli/_gate_hooks/codex.py
+++ b/experimental/python/perfxpert/perfxpert/cli/_gate_hooks/codex.py
@@ -93,7 +93,7 @@ def evaluate_gate_state(
     tool_name: str,
     *,
     intent_classify_observed: bool,
-    classify_tool: str = "mcp_perfxpert_intent_classify",
+    classify_tool: str = "mcp__perfxpert__intent_classify",
 ) -> dict[str, Any]:
     """Mirror of the Claude / Gemini evaluators for unit test parity.
 
@@ -101,7 +101,7 @@ def evaluate_gate_state(
     supported MCP interception. Not wired into any live code path
     today; purely documentation-via-test.
     """
-    if tool_name.startswith("mcp_perfxpert_"):
+    if tool_name.startswith("mcp__perfxpert__"):
         return {"allowed": True, "enforced_by": "prompt-layer"}
     if intent_classify_observed:
         return {"allowed": True, "enforced_by": "prompt-layer"}

--- a/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_adapter.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_adapter.py
@@ -522,6 +522,66 @@ def test_structured_edit_fallback_uses_tomlkit(
     assert "perfxpert-mcp" in text
 
 
+def test_register_project_scope_writes_project_config_without_codex_mcp_add(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list] = []
+
+    def _run(cmd, *args, **kwargs):
+        calls.append(list(cmd))
+
+        class _R:
+            returncode = 0
+            stdout = b"perfxpert\n"
+            stderr = b""
+
+        return _R()
+
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/codex")
+    monkeypatch.setattr("perfxpert.cli._backend.codex.subprocess.run", _run)
+
+    project_cwd = tmp_path / "proj"
+    project_cwd.mkdir()
+    cfg = project_cwd / ".codex" / "config.toml"
+    CodexAdapter()._register_mcp(project_cwd, cfg, "project")
+
+    assert cfg.is_file()
+    text = cfg.read_text()
+    assert "[mcp_servers.perfxpert]" in text or "perfxpert" in text
+    assert 'command = "perfxpert-mcp"' in text
+    assert "required = true" in text
+    assert "enabled_tools" not in text
+    assert "disabled_tools" not in text
+    assert not [c for c in calls if "mcp" in c and "add" in c]
+
+
+def test_structured_edit_refreshes_stale_perfxpert_filters(
+    tmp_path: Path,
+) -> None:
+    project_cwd = tmp_path / "proj"
+    project_cwd.mkdir()
+    cfg = project_cwd / ".codex" / "config.toml"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        '[mcp_servers.perfxpert]\n'
+        'command = "perfxpert-mcp"\n'
+        "args = []\n"
+        "enabled = false\n"
+        'enabled_tools = ["report"]\n'
+        'disabled_tools = ["intent_classify"]\n'
+    )
+
+    CodexAdapter()._structured_edit_config_toml(cfg)
+
+    text = cfg.read_text()
+    assert 'command = "perfxpert-mcp"' in text
+    assert "enabled = true" in text
+    assert "required = true" in text
+    assert "enabled_tools" not in text
+    assert "disabled_tools" not in text
+
+
 # ---------------------------------------------------------------------------
 # Never mutates tracked AGENTS.md.
 # ---------------------------------------------------------------------------

--- a/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_adapter.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_adapter.py
@@ -582,6 +582,19 @@ def test_structured_edit_refreshes_stale_perfxpert_filters(
     assert "disabled_tools" not in text
 
 
+def test_structured_edit_reports_file_at_codex_config_dir(
+    tmp_path: Path,
+) -> None:
+    project_cwd = tmp_path / "proj"
+    project_cwd.mkdir()
+    (project_cwd / ".codex").write_text("not a directory\n")
+
+    with pytest.raises(ConfigClobber, match="exists but is not a directory"):
+        CodexAdapter()._structured_edit_config_toml(
+            project_cwd / ".codex" / "config.toml"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Never mutates tracked AGENTS.md.
 # ---------------------------------------------------------------------------

--- a/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_adapter.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_adapter.py
@@ -159,6 +159,17 @@ def test_tool_name_template() -> None:
     assert CodexAdapter.tool_name_template == "mcp_perfxpert_{tool}"
 
 
+def test_codex_prompt_forbids_ssh_fallback_without_gate_tools() -> None:
+    rendered = CodexAdapter()._render_prompt_for_codex()
+    assert "SSH or another remote host" in rendered
+    assert "never bypasses the PerfXpert MCP gate" in rendered
+    assert "mcp_perfxpert_intent_classify" in rendered
+    assert "mcp_perfxpert_workflow_next_step" in rendered
+    assert "not exposed in the backend session" in rendered
+    assert "native SSH/build/profile" in rendered
+    assert "fallback path" in rendered
+
+
 def test_spawn_strategy_is_execvpe() -> None:
     assert CodexAdapter.spawn_strategy == "execvpe"
 

--- a/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_adapter.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_adapter.py
@@ -171,6 +171,15 @@ def test_codex_prompt_forbids_ssh_fallback_without_gate_tools() -> None:
     assert "fallback path" in rendered
 
 
+def test_codex_prompt_requires_consent_before_installing_missing_remote_tooling() -> None:
+    rendered = CodexAdapter()._render_prompt_for_codex()
+    assert "sqlite3" in rendered
+    assert "SSH remote host" in rendered
+    assert "Ask the user for explicit permission" in rendered
+    assert "install command" in rendered
+    assert "leave the artifact uninspected" in rendered
+
+
 def test_spawn_strategy_is_execvpe() -> None:
     assert CodexAdapter.spawn_strategy == "execvpe"
 

--- a/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_adapter.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_adapter.py
@@ -171,6 +171,16 @@ def test_codex_prompt_forbids_ssh_fallback_without_gate_tools() -> None:
     assert "fallback path" in rendered
 
 
+def test_codex_prompt_allows_only_tool_search_for_deferred_gate_tool() -> None:
+    rendered = CodexAdapter()._render_prompt_for_codex()
+    assert "tool_search" in rendered
+    assert "tool_search_tool" in rendered
+    assert "discovery-only metadata tools" in rendered
+    assert "perfxpert intent_classify" in rendered
+    assert "Do NOT use shell, SSH," in rendered
+    assert "build, edit, or profiling tools as a discovery fallback" in rendered
+
+
 def test_codex_prompt_requires_consent_before_installing_missing_remote_tooling() -> None:
     rendered = CodexAdapter()._render_prompt_for_codex()
     assert "sqlite3" in rendered

--- a/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_adapter.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_adapter.py
@@ -156,15 +156,16 @@ def test_adapter_conforms_to_protocol() -> None:
 
 
 def test_tool_name_template() -> None:
-    assert CodexAdapter.tool_name_template == "mcp_perfxpert_{tool}"
+    assert CodexAdapter.tool_name_template == "mcp__perfxpert__{tool}"
 
 
 def test_codex_prompt_forbids_ssh_fallback_without_gate_tools() -> None:
     rendered = CodexAdapter()._render_prompt_for_codex()
     assert "SSH or another remote host" in rendered
     assert "never bypasses the PerfXpert MCP gate" in rendered
-    assert "mcp_perfxpert_intent_classify" in rendered
-    assert "mcp_perfxpert_workflow_next_step" in rendered
+    assert "mcp__perfxpert__intent_classify" in rendered
+    assert "mcp__perfxpert__workflow_next_step" in rendered
+    assert "mcp_perfxpert_intent_classify" not in rendered
     assert "not exposed in the backend session" in rendered
     assert "native SSH/build/profile" in rendered
     assert "fallback path" in rendered

--- a/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_gate_hook.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_gate_hook.py
@@ -70,9 +70,9 @@ def test_uninstall_is_noop(tmp_path: Path) -> None:
 
 
 def test_evaluate_permits_perfxpert_tool_always() -> None:
-    """Any `mcp_perfxpert_*` tool is allowed before intent_classify."""
+    """Any `mcp__perfxpert__*` tool is allowed before intent_classify."""
     r = evaluate_gate_state(
-        "mcp_perfxpert_intent_classify", intent_classify_observed=False
+        "mcp__perfxpert__intent_classify", intent_classify_observed=False
     )
     assert r["allowed"] is True
 

--- a/experimental/python/perfxpert/tests/test_cli/test_backend/test_prompt_adapter.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_backend/test_prompt_adapter.py
@@ -92,6 +92,20 @@ def test_render_includes_rejection_stanza_when_true() -> None:
     assert "mcp__perfxpert__intent_classify" in out
 
 
+def test_render_rejects_native_fallback_when_gate_tool_missing() -> None:
+    out = pa.render_prompt(
+        SOURCE,
+        backend="codex",
+        tool_name_template="mcp_perfxpert_{tool}",
+        known_tools=TOOLS,
+        reject_language=True,
+    )
+    assert "not available or not exposed" in out
+    assert "STOP with a PerfXpert configuration error" in out
+    assert "SSH" in out
+    assert "remote-host builds" in out
+
+
 def test_render_omits_rejection_stanza_when_false() -> None:
     out = pa.render_prompt(
         SOURCE,

--- a/experimental/python/perfxpert/tests/test_cli/test_backend/test_prompt_adapter.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_backend/test_prompt_adapter.py
@@ -61,6 +61,17 @@ def test_render_substitutes_tool_names_gemini() -> None:
     assert "mcp_perfxpert_intent_classify" in out
 
 
+def test_render_substitutes_tool_names_codex() -> None:
+    out = pa.render_prompt(
+        SOURCE,
+        backend="codex",
+        tool_name_template="mcp__perfxpert__{tool}",
+        known_tools=TOOLS,
+        reject_language=False,
+    )
+    assert "mcp__perfxpert__intent_classify" in out
+
+
 def test_render_strips_non_target_backend_blocks() -> None:
     out = pa.render_prompt(
         SOURCE,
@@ -96,7 +107,7 @@ def test_render_rejects_native_fallback_when_gate_tool_missing() -> None:
     out = pa.render_prompt(
         SOURCE,
         backend="codex",
-        tool_name_template="mcp_perfxpert_{tool}",
+        tool_name_template="mcp__perfxpert__{tool}",
         known_tools=TOOLS,
         reject_language=True,
     )

--- a/experimental/python/perfxpert/tests/test_cli/test_backend/test_prompt_adapter.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_backend/test_prompt_adapter.py
@@ -114,7 +114,23 @@ def test_render_rejects_native_fallback_when_gate_tool_missing() -> None:
     assert "not available or not exposed" in out
     assert "STOP with a PerfXpert configuration error" in out
     assert "SSH" in out
-    assert "remote-host builds" in out
+    assert "remote-host" in out
+    assert "builds, or profiling commands" in out
+
+
+def test_render_allows_discovery_tool_before_gate_when_requested() -> None:
+    out = pa.render_prompt(
+        SOURCE,
+        backend="codex",
+        tool_name_template="mcp__perfxpert__{tool}",
+        known_tools=TOOLS,
+        reject_language=True,
+        discovery_tools=("tool_search", "tool_search_tool"),
+    )
+    assert "`mcp__perfxpert__intent_classify` or one of the discovery-only" in out
+    assert "`tool_search`, `tool_search_tool`" in out
+    assert "solely to search for the PerfXpert classify/workflow MCP tools" in out
+    assert "otherwise STOP with a PerfXpert configuration error" in out
 
 
 def test_render_omits_rejection_stanza_when_false() -> None:

--- a/experimental/python/perfxpert/tests/test_version_metadata.py
+++ b/experimental/python/perfxpert/tests/test_version_metadata.py
@@ -1,0 +1,9 @@
+"""Version metadata consistency tests."""
+
+from importlib.metadata import version
+
+import perfxpert
+
+
+def test_runtime_version_matches_installed_metadata() -> None:
+    assert perfxpert.__version__ == version("perfxpert")


### PR DESCRIPTION
## Summary
- require a PerfXpert configuration error when gate tools are unavailable instead of falling back to native execution
- clarify that SSH/remote-host execution does not bypass the PerfXpert MCP gate
- add focused regression coverage for Codex prompt rendering and shared gate language

## Validation
- python -m pytest tests\\test_cli\\test_backend\\test_prompt_adapter.py tests\\test_cli\\test_backend\\test_codex_adapter.py::test_codex_prompt_forbids_ssh_fallback_without_gate_tools -q
- git diff --check
- scripts/secret-scan.sh via Git-for-Windows Bash: secret-scan: no high-confidence secrets found

Note: scripts/secret-scan.sh was used as a local untracked scanner only and is not part of this PR.