### PR TITLE
hip-tests: Fix GraphsTest2 target cmake

### DIFF
--- a/projects/hip-tests/catch/cmake/hip-tests.cmake
+++ b/projects/hip-tests/catch/cmake/hip-tests.cmake
@@ -55,11 +55,11 @@ function(hip_gen_exe_target)
     "${args}"
     "${list_args}"
   )
-  foreach(SRC_NAME ${TEST_SRC})
+  foreach(SRC_NAME ${_TEST_SRC})
 
     if(NOT _STANDALONE_FLAG EQUAL "1")
       set(_EXE_NAME ${_NAME})
-      set(SRC_NAME ${TEST_SRC})
+      set(SRC_NAME ${_TEST_SRC})
     else()
       # strip extension of src and use exe name as src name
       get_filename_component(_EXE_NAME ${SRC_NAME} NAME_WLE)

--- a/projects/hip-tests/catch/unit/graph/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/graph/CMakeLists.txt
@@ -171,7 +171,7 @@ if(HIP_PLATFORM MATCHES "amd")
   set_property(GLOBAL APPEND PROPERTY
                G_INSTALL_CUSTOM_TARGETS ${CMAKE_CURRENT_BINARY_DIR}/hipMatMul.code)
   if(UNIX)
-    set(TEST_SRC hipSimpleGraphWithKernel.cc)
+    set(TEST_KERNEL_ARG_PREFETCH_SRC hipSimpleGraphWithKernel.cc)
     hip_add_exe_to_target(NAME GraphsKernelArgPrefetchTest
                           TEST_SRC ${TEST_KERNEL_ARG_PREFETCH_SRC}
                           TEST_TARGET_NAME build_tests)


### PR DESCRIPTION
## Motivation

- Currently GraphsTest2 target is only including a single test due to incorrect cmake config
- This change includes all files to GraphsTest2 target.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
