### PR TITLE
[rocprof-compute] Insufficient kernels warning for iteration multiplexing is difficult to read

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -100,8 +100,7 @@ def detect_missing_counters(
     if kernels_with_missing_counters:
         unique_kernels = list(set(kernels_with_missing_counters))
         kernel_list = "\n\n".join(
-            f"  Kernel {i}: {name}"
-            for i, name in enumerate(unique_kernels, start=1)
+            f"  Kernel {i}: {name}" for i, name in enumerate(unique_kernels, start=1)
         )
         console_warning(
             "join_prof",

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -99,11 +99,15 @@ def detect_missing_counters(
 
     if kernels_with_missing_counters:
         kernels_with_missing_counters = list(set(kernels_with_missing_counters))
+        kernel_list = "\n".join(
+            f"  Kernel {i}: {name}"
+            for i, name in enumerate(kernels_with_missing_counters, start=1)
+        )
         console_warning(
             "join_prof",
             (
-                f"Insufficient number of kernel calls for kernels: "
-                f"{', '.join(kernels_with_missing_counters)} "
+                f"Insufficient number of kernel calls for kernels:\n"
+                f"{kernel_list}\n"
                 f"to collect all counters using iteration multiplexing. "
                 f"These kernels do not have enough dispatches to fill all "
                 f"{num_files} counter sets. Use kernel filtering (-k) to "

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -98,16 +98,16 @@ def detect_missing_counters(
             kernels_with_missing_counters.append(kernel_name)
 
     if kernels_with_missing_counters:
-        kernels_with_missing_counters = list(set(kernels_with_missing_counters))
-        kernel_list = "\n".join(
+        unique_kernels = list(set(kernels_with_missing_counters))
+        kernel_list = "\n\n".join(
             f"  Kernel {i}: {name}"
-            for i, name in enumerate(kernels_with_missing_counters, start=1)
+            for i, name in enumerate(unique_kernels, start=1)
         )
         console_warning(
             "join_prof",
             (
-                f"Insufficient number of kernel calls for kernels:\n"
-                f"{kernel_list}\n"
+                f"Insufficient number of kernel calls for kernels:\n\n"
+                f"{kernel_list}\n\n"
                 f"to collect all counters using iteration multiplexing. "
                 f"These kernels do not have enough dispatches to fill all "
                 f"{num_files} counter sets. Use kernel filtering (-k) to "


### PR DESCRIPTION
## Motivation

The `[join_prof] Insufficient number of kernel calls` warning printed the kernels as one comma separated string. Since these kernels are extremely long and mangled C++ names, and we are not truncating them, the message was an extremely hard to read wall of text where individual kernels couldn't be visually separated.

## Technical Details

In `src/rocprof_compute_analyze/analysis_base.py::detect_missing_counters`, we can format the kernel list as a numbered newline separated block instead of a single joined string showing the same data with no truncation.

No behavioral changes.

## JIRA ID

AIPROFCOMP-294

## Test Plan

Run in the rocprof-compute dev container with a Mistral-7B inference workload that triggers the warning:

```bash
rocprof-compute profile -n mistral_iter --iteration-multiplexing -- \
    python3 /root/torch_mistral_workload/torch.py
rocprof-compute analyze -p workloads/mistral_iter/MI300X_A1
```

Captured the analyze output before and after:

## Test Result

Warning now lists each kernel on its own line and is fully readable.

**Before** (develop):

`WARNING Reading intermediate results_*.csv files is deprecated and will be removed in a future release.
WARNING [join_prof] Insufficient number of kernel calls for kernels: __amd_rocclr_fillBufferAligned, __amd_rocclr_copyBuffer, void at::native::vectorized_elementwise_kernel<4, at::native::compare_scalar_kernel<long>(at::TensorIteratorBase&, at::native::(anonymous namespace)::OpType, long)::{lambda(long)#1}, std::array<char*, 2ul> >(int, at::native::compare_scalar_kernel<long>(at::TensorIteratorBase&, at::native::(anonymous namespace)::OpType, long)::{lambda(long)#1}, std::array<char*, 2ul>), void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespace)::masked_fill_kernel(at::TensorIterator&, c10::Scalar const&)::{lambda()#1}::operator()() const::{lambda()#4}::operator()() const::{lambda(long, bool)#1}, std::array<char*, 3ul> >(int, at::native::(anonymous namespace)::masked_fill_kernel(at::TensorIterator&, c10::Scalar const&)::{lambda()#1}::operator()() const::{lambda()#4}::operator()() const::{lambda(long, bool)#1}, std::array<char*, 3ul>), Cijk_Ailk_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT16x16x128_MI16x16x1_SN_LDSB1_AFC1_AFEM1_AFEM1_ASEM1_CLR1_CADS0_DTLA0_DTLB0_DTVA0_DTVB0_EPS0_FDSI0_GRPM1_GRVWA4_GRVWB4_GSUAMB_GLS0_ISA942_IU1_K1_LDSTI0_LBSPPA256_LBSPPB512_LBSPPM0_LPA16_LPB8_LPM0_LRVW4_LWPMn1_MIAV0_MIWT1_1_MO40_NTn1_NTA0_NTB0_NTC0_NTD4_NTM0_NEPBS16_NLCA1_NLCB1_ONLL1_PGR2_PLR1_PKA1_SIA3_SS1_SPO0_SRVW0_SSO0_SVW1_SK0_SKFTR0_SKXCCM0_TLDS1_ULSGRO0_USL1_UIOFGRO0_USFGROn1_VSn1_VWA1_VWB1_WSGRA0_WSGRB0_WS64_WG16_4_4, void at::native::(anonymous namespace)::CatArrayBatchedCopy<at::native::(anonymous namespace)::OpaqueType<4u>, unsigned int, 3, 64, 64>(at::native::(anonymous namespace)::OpaqueType<4u>*, at::native::(anonymous namespace)::CatArrInputTensorMetadata<at::native::(anonymous namespace)::OpaqueType<4u>, unsigned int, 64, 64>, at::native::(anonymous namespace)::TensorSizeStride<unsigned int, 4u>, int, unsigned int), void rocprim::ROCPRIM_400200_NS::detail::trampoline_kernel<rocprim::ROCPRIM_400200_NS::detail::wrapped_scan_config<rocprim::ROCPRIM_400200_NS::default_config, long>, (rocprim::ROCPRIM_400200_NS::detail::target_arch)942, rocprim::ROCPRIM_400200_NS::detail::scan_impl<(rocprim::ROCPRIM_400200_NS::detail::lookback_scan_determinism)0, false, false, rocprim::ROCPRIM_400200_NS::default_config, long const*, long*, long, std::plus<long>, long>(void*, unsigned long&, long const*, long*, long, unsigned long, std::plus<long>, ihipStream_t*, bool)::{lambda(auto:1, auto:2)#1}::operator()<std::integral_constant<bool, false>, std::integral_constant<bool, true> >(std::integral_constant<bool, false>, std::integral_constant<bool, true>) const::{lambda(auto:1)#2}, rocprim::ROCPRIM_400200_NS::detail::default_config_selector>(rocprim::ROCPRIM_400200_NS::detail::scan_impl<(rocprim::ROCPRIM_400200_NS::detail::lookback_scan_determinism)0, false, false, rocprim::ROCPRIM_400200_NS::default_config, long const*, long*, long, std::plus<long>, long>(void*, unsigned long&, long const*, long*, long, unsigned long, std::plus<long>, ihipStream_t*, bool)::{lambda(auto:1, auto:2)#1}::operator()<std::integral_constant<bool, false>, std::integral_constant<bool, true> >(std::integral_constant<bool, false>, std::integral_constant<bool, true>) const::{lambda(auto:1)#2}), void at::native::reduce_kernel<512, 1, at::native::ReduceOp<bool, at::native::func_wrapper_t<bool, at::native::and_kernel_cuda(at::TensorIterator&)::{lambda()#1}::operator()() const::{lambda()#12}::operator()() const::{lambda(bool, bool)#1}>, unsigned int, bool, 4, 4> >(at::native::ReduceOp<bool, at::native::func_wrapper_t<bool, at::native::and_kernel_cuda(at::TensorIterator&)::{lambda()#1}::operator()() const::{lambda()#12}::operator()() const::{lambda(bool, bool)#1}>, unsigned int, bool, 4, 4>) to collect all counters using iteration multiplexing. These kernels do not have enough dispatches to fill all 13 counter sets. Use kernel filtering (-k) to profile only the kernels of interest, e.g.: rocprof-compute profile -k <your_kernel> --iteration-multiplexing -- <app>. Alternatively, remove --iteration-multiplexing to use application replay instead.
   INFO Created /root/torch_mistral_workload/workloads/mistral_iter/MI300X_A1/pmc_perf.csv`

**After** (this PR):

<img width="933" height="864" alt="image" src="https://github.com/user-attachments/assets/89567418-c6d5-438f-9424-0cf771ea83c8" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.