### PR TITLE
ROCM-23425 - Delay release/free so that hsa/kfd does not use same VA …

### DIFF
--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -365,19 +365,12 @@ amd::Memory* MemObjMap::FindMemObj(const void* k, size_t* offset, Device* dev) {
   uintptr_t key = reinterpret_cast<uintptr_t>(k);
 
   // First search the global map
-  auto it = MemObjMap_.upper_bound(key);
-  if (it != MemObjMap_.begin()) {
-    --it;
-    amd::Memory* mem = it->second;
-    size_t mem_size = (mem->getMemFlags() & ROCCLR_MEM_PHYMEM)
-                          ? sizeof(mem->getUserData().hsa_handle)
-                          : mem->getSize();
-    if (key >= it->first && key < (it->first + mem_size)) {
-      if (offset != nullptr) {
-        *offset = key - it->first;
-      }
-      return mem;
+  auto it = FindMemObjIter(key);
+  if (it != MemObjMap_.end()) {
+    if (offset != nullptr) {
+      *offset = key - it->first;
     }
+    return it->second;
   }
 
   // Search per-device va maps on Windows (due to overlapping ranges)
@@ -388,12 +381,10 @@ amd::Memory* MemObjMap::FindMemObj(const void* k, size_t* offset, Device* dev) {
   return nullptr;
 }
 
-amd::Memory* MemObjMap::FindAndRemoveMemObj(const void* k) {
-  std::unique_lock lock(AllocatedLock_);
-  uintptr_t key = reinterpret_cast<uintptr_t>(k);
+std::map<uintptr_t, amd::Memory*>::iterator MemObjMap::FindMemObjIter(uintptr_t key) {
   auto it = MemObjMap_.upper_bound(key);
   if (it == MemObjMap_.begin()) {
-    return nullptr;
+    return MemObjMap_.end();
   }
   --it;
   amd::Memory* mem = it->second;
@@ -401,8 +392,19 @@ amd::Memory* MemObjMap::FindAndRemoveMemObj(const void* k) {
                         ? sizeof(mem->getUserData().hsa_handle)
                         : mem->getSize();
   if (key < it->first || key >= (it->first + mem_size)) {
+    return MemObjMap_.end();
+  }
+  return it;
+}
+
+amd::Memory* MemObjMap::FindAndRemoveMemObj(const void* k) {
+  std::unique_lock lock(AllocatedLock_);
+  uintptr_t key = reinterpret_cast<uintptr_t>(k);
+  auto it = FindMemObjIter(key);
+  if (it == MemObjMap_.end()) {
     return nullptr;
   }
+  amd::Memory* mem = it->second;
   MemObjMap_.erase(it);
   return mem;
 }

--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -388,6 +388,25 @@ amd::Memory* MemObjMap::FindMemObj(const void* k, size_t* offset, Device* dev) {
   return nullptr;
 }
 
+amd::Memory* MemObjMap::FindAndRemoveMemObj(const void* k) {
+  std::unique_lock lock(AllocatedLock_);
+  uintptr_t key = reinterpret_cast<uintptr_t>(k);
+  auto it = MemObjMap_.upper_bound(key);
+  if (it == MemObjMap_.begin()) {
+    return nullptr;
+  }
+  --it;
+  amd::Memory* mem = it->second;
+  size_t mem_size = (mem->getMemFlags() & ROCCLR_MEM_PHYMEM)
+                        ? sizeof(mem->getUserData().hsa_handle)
+                        : mem->getSize();
+  if (key < it->first || key >= (it->first + mem_size)) {
+    return nullptr;
+  }
+  MemObjMap_.erase(it);
+  return mem;
+}
+
 void MemObjMap::UpdateAccess(amd::Device* peerDev) {
   if (peerDev == nullptr) {
     return;

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1472,6 +1472,9 @@ class MemObjMap : public AllStatic {
   //!< Same as FindMemObj but for ipc handle to MemObj mapping
   static amd::Memory* FindIpcHandleMemObj(const IpcMemHandle& k);
 
+  //!< Atomically find and remove a mem object by ptr. Returns the removed Memory* or nullptr.
+  static amd::Memory* FindAndRemoveMemObj(const void* k);
+
   //!< Shared read/write lock for all MemObjMap operations (including per-device maps)
   static std::shared_mutex AllocatedLock_;
 

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1479,6 +1479,10 @@ class MemObjMap : public AllStatic {
   static std::shared_mutex AllocatedLock_;
 
  private:
+  //!< Lookup helper shared by FindMemObj and FindAndRemoveMemObj. Caller must hold AllocatedLock_.
+  //!< Returns an iterator to the matching entry, or MemObjMap_.end() if not found.
+  static std::map<uintptr_t, amd::Memory*>::iterator FindMemObjIter(uintptr_t key);
+
   //!< the mem object<->hostptr information container
   static std::map<uintptr_t, amd::Memory*> MemObjMap_;
   //!< the virtual mem object<->hostptr information container

--- a/projects/clr/rocclr/platform/context.cpp
+++ b/projects/clr/rocclr/platform/context.cpp
@@ -350,10 +350,18 @@ void* Context::svmAlloc(size_t size, size_t alignment, cl_svm_mem_flags flags,
 
 void Context::svmFree(void* ptr) const {
   amd::ScopedLock lock(&ctxLock_);
+  // Atomically remove from map before any device frees the GPU VA.
+  // This prevents a concurrent allocation from reusing the same VA and being
+  // wrongly freed by a subsequent device iteration (MGPU race).
+  // The actual HSA free (release) is deferred until after all devices have
+  // iterated, so KFD cannot reuse the VA during the loop.
+  amd::Memory* svmMem = amd::MemObjMap::FindAndRemoveMemObj(ptr);
   for (const auto& dev : svmAllocDevice_) {
-    dev->svmFree(ptr);
+    dev->svmFree(ptr);  // FindMemObj returns nullptr → no-op for GPU path
   }
-  return;
+  if (svmMem != nullptr) {
+    svmMem->release();
+  }
 }
 
 bool Context::containsDevice(const Device* device) const {


### PR DESCRIPTION
…during svmFree device loop.

## Motivation

Delay release/free so that hsa/kfd does not use same VA during svmFree device loop.

## Technical Details

Delay release/free so that hsa/kfd does not use same VA during svmFree device loop.

## JIRA ID

ROCM-23425

## Test Plan

NA

## Test Result

NA

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
