### PR TITLE
 [RCCL] Makefile changes for topo_expl compilation

### DIFF
--- a/projects/rccl/tools/topo_expl/Makefile
+++ b/projects/rccl/tools/topo_expl/Makefile
@@ -22,6 +22,7 @@ CXXFLAGS = -g -ffunction-sections -fdata-sections -DROCM_VERSION=$(ROCM_VERSION)
            -std=c++17 \
            -Wl,--gc-sections -fgpu-rdc \
            -Iinclude -Itest -Ihipify_rccl/include -Ihipify_rccl/include/plugin \
+		   -Ihipify_rccl/include/nccl_device \
            -Ihipify_rccl/src/device/include -Ihipify_rccl/graph -I/opt/rocm/include/ \
            -DTOPO_EXPL -DENABLE_TRACE -DENABLE_LL128 -DNVTX_NO_IMPL -DRCCL_EXPOSE_STATIC \
            -lpthread


### PR DESCRIPTION
## Motivation

This change is to fix issues in make file in rccl/tools/topo_expl

## Technical Details
This is not in the critical path of rccl production code, But this failure in compilation shows in CI checks. 

## JIRA ID
No Jira

## Test Plan



## Test Result



## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
