### PR TITLE
[ROCM-668] fix resolve node handle independent of AINIC init for UBB power

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -110,17 +110,17 @@ class AMDSMICommands:
                 else:
                     raise e
 
-            # Resolve the node handle.
-            for dev in self.device_handles:
-                try:
-                    nh = amdsmi_interface.amdsmi_get_node_handle(dev)
-                    if nh is not None:
-                        self.node_handle = nh
-                        # Only need one handle, break after first success
-                        break
-                except amdsmi_exception.AmdSmiLibraryException as e:
-                    logging.debug("Unable to get node handle: %s", e.get_error_info())
-                    # Node handle functionality is optional, so don't raise an error
+        # Resolve the node handle (independent of AINIC init; needed for amd-smi node).
+        for dev in self.device_handles:
+            try:
+                nh = amdsmi_interface.amdsmi_get_node_handle(dev)
+                if nh is not None:
+                    self.node_handle = nh
+                    # Only need one handle, break after first success
+                    break
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                logging.debug("Unable to get node handle: %s", e.get_error_info())
+                # Node handle functionality is optional, so don't raise an error
 
         if self.helpers.is_amd_hsmp_initialized():
             try:


### PR DESCRIPTION
## Motivation

Fix amd-smi node returning N/A for THRESHOLD/LIMIT/STATUS/baseboard temps/GTT on hosts without an AINIC card.
## Technical Details

In amdsmi_cli/amdsmi_commands.py, the node-handle resolution loop was nested inside if self.helpers.is_ainic_initialized(): — dedented one level so it runs unconditionally, matching the surrounding is_amd_hsmp_initialized() block (follow-up to PR #3262 / SWDEV-567812).
## JIRA ID

[ROCM-668]

## Test Plan

Ran amd-smi node and amd-smi metric --power on smci350-rck-g03-b20-31 (MI350X UBB, ROCm 7.3.0, AINIC absent) before and after the patch, cross-checked against /sys/bus/pci/devices/*/board/baseboard_power*.

## Test Result

Before: all node fields N/A. After: THRESHOLD: 8400 W, LIMIT: 0 W, STATUS: DISABLED, all 22 baseboard temperatures, GTT size, and UBB_POWER: 2127 W on the node-owner GPU — values match sysfs exactly.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


[ROCM-668]: https://amd-hub-sandbox-20240925.atlassian.net/browse/ROCM-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ