### PR TITLE
[ROCProfiler-SDK] Propose BPF-style rocprofiler buffer transport

### DIFF
--- a/projects/rocprofiler-sdk/cmake/rocprofiler_build_settings.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_build_settings.cmake
@@ -203,6 +203,11 @@ if(ROCPROFILER_BUILD_CI_STRICT_TIMESTAMPS)
                                            INTERFACE ROCPROFILER_CI_STRICT_TIMESTAMPS)
 endif()
 
+if(ROCPROFILER_EXPERIMENTAL_BPF_BUFFER)
+    rocprofiler_target_compile_definitions(
+        rocprofiler-sdk-build-flags INTERFACE ROCPROFILER_EXPERIMENTAL_BPF_BUFFER=1)
+endif()
+
 # ----------------------------------------------------------------------------------------#
 # extra flags for compiling with experimental warnings
 #

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_options.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_options.cmake
@@ -51,6 +51,11 @@ rocprofiler_add_option(
     "Use (internal) <rocprofiler-sdk/rccl/details/api_trace.h> instead of RCCL-provided <rccl/amd_detail/api_trace.h>. Note: this should never be used in production"
     OFF
     ADVANCED)
+rocprofiler_add_option(
+    ROCPROFILER_EXPERIMENTAL_BPF_BUFFER
+    "Use the experimental BPF-style internal record buffer backend for rocprofiler buffers"
+    OFF
+    ADVANCED)
 
 rocprofiler_add_option(
     ROCPROFILER_BUILD_GHC_FS

--- a/projects/rocprofiler-sdk/source/docs/conceptual/bpf-buffer-transport-proposal.rst
+++ b/projects/rocprofiler-sdk/source/docs/conceptual/bpf-buffer-transport-proposal.rst
@@ -80,6 +80,8 @@ Risks and follow-up work:
 
 * the prototype still takes a shared lock to keep flush and producers disjoint; a production version
   should move to explicit committed flags and drain only completed slots,
+* save/load paths must rebase in-slot payload pointers after remapping because serialized record
+  headers cannot safely keep process-local virtual addresses,
 * metadata overhead means effective payload capacity differs from the user-requested byte size, and
 * benchmarks must compare hot-path API tracing, kernel dispatch tracing, and lossless backpressure
   against the existing double-buffer implementation.

--- a/projects/rocprofiler-sdk/source/docs/conceptual/bpf-buffer-transport-proposal.rst
+++ b/projects/rocprofiler-sdk/source/docs/conceptual/bpf-buffer-transport-proposal.rst
@@ -26,6 +26,15 @@ kernel ``BPF_MAP_TYPE_RINGBUF``. ROCprofiler-SDK buffered tracing producers and 
 in-process, so using a kernel BPF map would add file descriptors, syscalls, kernel feature checks,
 and dependency or permission questions without removing a process boundary.
 
+Decision criteria
+-----------------
+
+Transport recommendations in this proposal family are ranked by lowest
+producer-side time overhead first. Memory footprint is the second criterion and
+is used to choose between designs that are close on producer time. This ordering
+keeps the dispatch/API hot path as the primary constraint while still accounting
+for long-running tools with many active buffers.
+
 Current buffer behavior
 -----------------------
 
@@ -108,13 +117,110 @@ layout intact.
 Recommendation
 --------------
 
-The lowest-footprint proposal is Option D because it changes only the current implementation. The best
-balance for a draft implementation is Option B: it demonstrates the BPF buffer idea while avoiding a
-kernel BPF dependency and preserving the SDK ABI. The fastest design for sustained high-rate tracing
-is Option C, but it should be treated as a second-stage design because its thread lifecycle and flush
-ordering semantics are more invasive than a buffer backend swap.
+Using the required ordering, Option C is the strongest long-term direction
+because per-thread or per-producer shards remove shared producer contention from
+the hot path. Option B is still useful as a narrower BPF-style draft because it
+shows how much footprint can be saved by colocating record headers and payloads
+without changing the public callback ABI. Option D is the least invasive and
+lowest review-risk path, but it is not the recommended performance direction
+unless implementation risk outweighs producer overhead.
 
-Use this draft to answer one question first: does the BPF-style in-process slot layout reduce producer
-overhead enough to justify replacing the current header-vector buffer? If benchmark data does not show
-a meaningful win, the safer path is to tune the current double buffer and keep BPF maps out of the
-in-process data path.
+Use this draft to answer one question first: does the BPF-style in-process slot
+layout reduce producer overhead enough to justify replacing the current
+header-vector buffer when compared with the faster per-producer ring proposal?
+If benchmark data shows that BPF-style storage wins mainly on footprint but not
+on producer time, keep it as a fallback or intermediate transport rather than
+the primary rocprofiler-sdk buffer direction.
+
+Benchmark note
+--------------
+
+The cross-proposal microbenchmark uses one unit for time, nanoseconds per
+record, and one unit for footprint, MiB. With 64-byte payload records and 131072
+records per round, the BPF-style buffer reduces storage from 136.07 MiB to
+12.01 MiB, but it does not beat the per-producer ring on producer time:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Producers
+     - Transport
+     - Emit ns/record
+     - Total ns/record
+     - Storage MiB
+     - Max RSS MiB
+   * - 1
+     - Current
+     - 24.518
+     - 27.016
+     - 136.07
+     - 141.81
+   * - 1
+     - BPF-style
+     - 17.299
+     - 31.173
+     - 12.01
+     - 17.83
+   * - 1
+     - Ring shared mmap
+     - 4.335
+     - 5.909
+     - 12.00
+     - 17.91
+   * - 1
+     - LTTng-UST inactive
+     - 29.520
+     - 31.953
+     - 136.07
+     - 141.81
+   * - 4
+     - Current
+     - 243.692
+     - 246.250
+     - 136.07
+     - 141.96
+   * - 4
+     - BPF-style
+     - 167.720
+     - 180.740
+     - 12.01
+     - 17.97
+   * - 4
+     - Ring shared mmap
+     - 5.970
+     - 9.315
+     - 12.02
+     - 17.79
+   * - 4
+     - LTTng-UST inactive
+     - 288.077
+     - 290.512
+     - 136.07
+     - 141.84
+   * - 16
+     - Current
+     - 260.940
+     - 263.424
+     - 136.07
+     - 142.28
+   * - 16
+     - BPF-style
+     - 150.954
+     - 167.847
+     - 12.01
+     - 18.00
+   * - 16
+     - Ring shared mmap
+     - 5.519
+     - 11.174
+     - 12.06
+     - 18.04
+   * - 16
+     - LTTng-UST inactive
+     - 294.816
+     - 297.481
+     - 136.07
+     - 142.29
+
+The resulting recommendation is ring first for lowest overhead, then BPF-style
+when low footprint is the stronger secondary constraint.

--- a/projects/rocprofiler-sdk/source/docs/conceptual/bpf-buffer-transport-proposal.rst
+++ b/projects/rocprofiler-sdk/source/docs/conceptual/bpf-buffer-transport-proposal.rst
@@ -138,7 +138,10 @@ Benchmark note
 The cross-proposal microbenchmark uses one unit for time, nanoseconds per
 record, and one unit for footprint, MiB. With 64-byte payload records and 131072
 records per round, the BPF-style buffer reduces storage from 136.07 MiB to
-12.01 MiB, but it does not beat the per-producer ring on producer time:
+12.01 MiB, but it does not beat the per-producer ring on producer time. The
+active LTTng rows were measured with a locally extracted matching LTTng 2.14
+userspace stack because the host install mixed ``lttng-tools`` 2.13 with
+``liblttng-ctl`` 2.14.
 
 .. list-table::
    :header-rows: 1
@@ -168,11 +171,11 @@ records per round, the BPF-style buffer reduces storage from 136.07 MiB to
      - 12.00
      - 17.91
    * - 1
-     - LTTng-UST inactive
-     - 29.520
-     - 31.953
+     - LTTng-UST active
+     - 141.760
+     - 144.479
      - 136.07
-     - 141.81
+     - 157.90
    * - 4
      - Current
      - 243.692
@@ -192,11 +195,11 @@ records per round, the BPF-style buffer reduces storage from 136.07 MiB to
      - 12.02
      - 17.79
    * - 4
-     - LTTng-UST inactive
-     - 288.077
-     - 290.512
+     - LTTng-UST active
+     - 501.102
+     - 503.294
      - 136.07
-     - 141.84
+     - 180.27
    * - 16
      - Current
      - 260.940
@@ -216,11 +219,13 @@ records per round, the BPF-style buffer reduces storage from 136.07 MiB to
      - 12.06
      - 18.04
    * - 16
-     - LTTng-UST inactive
-     - 294.816
-     - 297.481
+     - LTTng-UST active
+     - 563.533
+     - 565.863
      - 136.07
-     - 142.29
+     - 203.93
 
 The resulting recommendation is ring first for lowest overhead, then BPF-style
-when low footprint is the stronger secondary constraint.
+when low footprint is the stronger secondary constraint. LTTng-UST is validated
+as an active out-of-process tracepoint path, but its producer-side cost is not
+competitive with the ring or BPF-style buffer for the SDK-internal transport.

--- a/projects/rocprofiler-sdk/source/docs/conceptual/bpf-buffer-transport-proposal.rst
+++ b/projects/rocprofiler-sdk/source/docs/conceptual/bpf-buffer-transport-proposal.rst
@@ -1,0 +1,120 @@
+.. meta::
+  :description: Proposal for using a BPF-style buffer transport inside ROCprofiler-SDK
+  :keywords: ROCprofiler-SDK, buffer, BPF ring buffer, tracing transport
+
+.. _bpf-buffer-transport-proposal:
+
+Experimental BPF-style buffer transport proposal
+================================================
+
+This proposal keeps the public ROCprofiler-SDK buffer API unchanged and limits the experiment to
+the internal transport used by ``rocprofiler_create_buffer`` and the buffered tracing services. A
+tool still receives ``rocprofiler_record_header_t**`` batches through
+``rocprofiler_buffer_tracing_cb_t``. The only change is the backing storage used between SDK
+producers and the callback thread.
+
+The draft implementation adds ``ROCPROFILER_EXPERIMENTAL_BPF_BUFFER``. When enabled, each
+``rocprofiler::buffer::instance`` uses a BPF-style user-space record buffer:
+
+* each producer reserves one variable-size slot with an atomic write cursor,
+* the public ``rocprofiler_record_header_t`` and payload are stored in the same mapped region,
+* flush builds the callback header pointer array by walking the committed slots, and
+* no public ABI, callback signature, or service configuration changes.
+
+This intentionally borrows the reserve/commit data layout from BPF ring buffers without creating a
+kernel ``BPF_MAP_TYPE_RINGBUF``. ROCprofiler-SDK buffered tracing producers and tool callbacks are
+in-process, so using a kernel BPF map would add file descriptors, syscalls, kernel feature checks,
+and dependency or permission questions without removing a process boundary.
+
+Current buffer behavior
+-----------------------
+
+The current path uses ``record_header_buffer`` as the per-slot storage type. It maps a page-rounded
+payload region, keeps record headers in a separate vector, and serializes small parts of the producer
+path with locks before a flush task invokes the tool callback. Lossless mode uses two internal
+buffers so one can be flushed while producers continue into the other.
+
+The existing public API shape is good for tools. The main costs to target are internal:
+
+* header metadata lives outside the payload allocation,
+* each record write performs short critical sections around buffer allocation and header updates,
+* the callback thread has to process a separate side vector of headers, and
+* the payload buffer and header vector sizes scale separately.
+
+Option A: kernel BPF ring buffer
+--------------------------------
+
+This is the most literal BPF buffer interpretation, using ``BPF_MAP_TYPE_RINGBUF`` and libbpf-style
+polling.
+
+It is not the recommended default for ROCprofiler-SDK buffered services because SDK producers are
+user-space code. The BPF ring buffer is optimized for kernel/BPF producers delivering events to
+user-space consumers. For this use case it introduces a kernel object, map lifetime management,
+polling file descriptors, kernel-version gating, and likely extra syscall overhead. It is only worth
+revisiting if ROCprofiler-SDK needs to merge events that are already produced by kernel BPF programs
+or if a future out-of-process collector requires fd-based wakeup and isolation.
+
+Option B: BPF-style user-space ring buffer
+------------------------------------------
+
+This is the option prototyped by the draft compile flag. It keeps the BPF reserve/commit shape but
+implements it directly in ROCprofiler-SDK's address space.
+
+Expected advantages:
+
+* one mapped allocation carries both public record headers and payloads,
+* the producer path is an atomic slot reservation plus placement construction,
+* flushing can walk contiguous committed slots in allocation order, and
+* tool-facing ABI remains unchanged.
+
+Risks and follow-up work:
+
+* the prototype still takes a shared lock to keep flush and producers disjoint; a production version
+  should move to explicit committed flags and drain only completed slots,
+* metadata overhead means effective payload capacity differs from the user-requested byte size, and
+* benchmarks must compare hot-path API tracing, kernel dispatch tracing, and lossless backpressure
+  against the existing double-buffer implementation.
+
+Option C: per-thread SPSC shards plus callback aggregation
+----------------------------------------------------------
+
+For the fastest producer path, give each producer thread a small single-producer/single-consumer
+record shard and let the callback thread aggregate shards during flush. This minimizes atomics and
+shared cache-line traffic in API tracing paths.
+
+Expected advantages:
+
+* best hot-path latency for high-frequency runtime API records,
+* no multi-producer reservation contention,
+* natural cache locality for thread-local correlation and record construction.
+
+Tradeoffs:
+
+* higher memory footprint when many application threads touch traced APIs,
+* more complex flush ordering across threads, and
+* more lifecycle work for thread creation, teardown, and late attachment.
+
+This is likely the best long-term high-throughput design if traces are allowed to preserve per-thread
+ordering plus timestamps instead of strict global insertion order.
+
+Option D: tune the current double buffer
+----------------------------------------
+
+This is the least disruptive implementation path. Keep ``record_header_buffer`` and reduce the
+producer critical sections, pre-size header storage more tightly, and make watermark decisions use
+bytes available after alignment. It has the smallest review risk but leaves the split metadata/payload
+layout intact.
+
+Recommendation
+--------------
+
+The lowest-footprint proposal is Option D because it changes only the current implementation. The best
+balance for a draft implementation is Option B: it demonstrates the BPF buffer idea while avoiding a
+kernel BPF dependency and preserving the SDK ABI. The fastest design for sustained high-rate tracing
+is Option C, but it should be treated as a second-stage design because its thread lifecycle and flush
+ordering semantics are more invasive than a buffer backend swap.
+
+Use this draft to answer one question first: does the BPF-style in-process slot layout reduce producer
+overhead enough to justify replacing the current header-vector buffer? If benchmark data does not show
+a meaningful win, the safer path is to tune the current double buffer and keep BPF maps out of the
+in-process data path.

--- a/projects/rocprofiler-sdk/source/docs/index.rst
+++ b/projects/rocprofiler-sdk/source/docs/index.rst
@@ -64,6 +64,7 @@ The documentation is structured as follows:
   .. grid-item-card:: Conceptual
 
     * :ref:`comparing-with-legacy-tools`
+    * :ref:`bpf-buffer-transport-proposal`
 
 To contribute to the documentation, refer to
 `Contributing to ROCm <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.

--- a/projects/rocprofiler-sdk/source/lib/common/container/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/common/container/CMakeLists.txt
@@ -2,6 +2,7 @@
 #   add container sources and headers to common library target
 #
 set(containers_headers
+    bpf_record_header_buffer.hpp
     ring_buffer.hpp
     c_array.hpp
     operators.hpp
@@ -12,8 +13,12 @@ set(containers_headers
     small_vector.hpp
     stable_vector.hpp
     static_vector.hpp)
-set(containers_sources ring_buffer.cpp record_header_buffer.cpp ring_buffer.cpp
-                       small_vector.cpp)
+set(containers_sources
+    bpf_record_header_buffer.cpp
+    ring_buffer.cpp
+    record_header_buffer.cpp
+    ring_buffer.cpp
+    small_vector.cpp)
 
 target_sources(rocprofiler-sdk-common-library PRIVATE ${containers_sources}
                                                       ${containers_headers})

--- a/projects/rocprofiler-sdk/source/lib/common/container/bpf_record_header_buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/bpf_record_header_buffer.cpp
@@ -1,0 +1,243 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/common/container/bpf_record_header_buffer.hpp"
+#include "lib/common/units.hpp"
+
+#include <sys/mman.h>
+#include <algorithm>
+#include <cerrno>
+#include <cstring>
+#include <limits>
+#include <new>
+#include <utility>
+
+namespace rocprofiler::common::container
+{
+bpf_record_header_buffer::bpf_record_header_buffer(size_t num_bytes) { allocate(num_bytes); }
+
+bpf_record_header_buffer::~bpf_record_header_buffer() { destroy_storage(); }
+
+bpf_record_header_buffer::bpf_record_header_buffer(bpf_record_header_buffer&& rhs) noexcept
+{
+    move_from(std::move(rhs));
+}
+
+bpf_record_header_buffer&
+bpf_record_header_buffer::operator=(bpf_record_header_buffer&& rhs) noexcept
+{
+    if(this != &rhs)
+    {
+        destroy_storage();
+        move_from(std::move(rhs));
+    }
+    return *this;
+}
+
+bool
+bpf_record_header_buffer::allocate(size_t num_bytes)
+{
+    if(is_allocated()) return false;
+
+    auto  total_size = page_aligned_size(num_bytes + slot_size(1, alignof(std::max_align_t)));
+    auto* ptr =
+        mmap(nullptr, total_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+
+    if(ptr == MAP_FAILED)
+    {
+        m_ptr      = nullptr;
+        m_capacity = 0;
+        m_init     = false;
+        return false;
+    }
+
+    m_ptr      = ptr;
+    m_capacity = total_size;
+    m_init     = true;
+    return true;
+}
+
+size_t
+bpf_record_header_buffer::get_num_record_headers()
+{
+    return m_record_count.load(std::memory_order_acquire);
+}
+
+size_t
+bpf_record_header_buffer::clear()
+{
+    auto _lk = scope_destructor{[&]() { unlock(); }, [&]() { lock(); }};
+
+    auto records = m_record_count.load(std::memory_order_acquire);
+    auto bytes   = m_write_count.load(std::memory_order_acquire);
+    if(m_ptr && bytes > 0) std::memset(m_ptr, 0, std::min(bytes, m_capacity));
+
+    m_write_count.store(0, std::memory_order_release);
+    m_record_count.store(0, std::memory_order_release);
+    return records;
+}
+
+size_t
+bpf_record_header_buffer::reset()
+{
+    auto records = m_record_count.load(std::memory_order_acquire);
+    destroy_storage();
+    return records;
+}
+
+void
+bpf_record_header_buffer::save(std::fstream& fs)
+{
+    auto _lk = scope_destructor{[&]() { unlock(); }, [&]() { lock(); }};
+
+    auto write_count  = m_write_count.load(std::memory_order_acquire);
+    auto record_count = m_record_count.load(std::memory_order_acquire);
+
+    fs.write(reinterpret_cast<char*>(&m_capacity), sizeof(m_capacity));
+    fs.write(reinterpret_cast<char*>(&write_count), sizeof(write_count));
+    fs.write(reinterpret_cast<char*>(&record_count), sizeof(record_count));
+    if(m_ptr && m_capacity > 0) fs.write(reinterpret_cast<char*>(m_ptr), m_capacity);
+}
+
+void
+bpf_record_header_buffer::load(std::fstream& fs)
+{
+    auto capacity     = size_t{0};
+    auto write_count  = size_t{0};
+    auto record_count = size_t{0};
+
+    fs.read(reinterpret_cast<char*>(&capacity), sizeof(capacity));
+    fs.read(reinterpret_cast<char*>(&write_count), sizeof(write_count));
+    fs.read(reinterpret_cast<char*>(&record_count), sizeof(record_count));
+
+    reset();
+    auto  total_size = page_aligned_size(capacity);
+    auto* ptr =
+        mmap(nullptr, total_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    if(ptr == MAP_FAILED) throw std::bad_alloc{};
+
+    m_ptr      = ptr;
+    m_capacity = total_size;
+    m_init     = true;
+    fs.read(reinterpret_cast<char*>(m_ptr), m_capacity);
+    m_write_count.store(write_count, std::memory_order_release);
+    m_record_count.store(record_count, std::memory_order_release);
+}
+
+size_t
+bpf_record_header_buffer::align_up(size_t value, size_t alignment)
+{
+    if(alignment == 0) return value;
+    auto remainder = value % alignment;
+    return (remainder == 0) ? value : (value + alignment - remainder);
+}
+
+size_t
+bpf_record_header_buffer::page_aligned_size(size_t value)
+{
+    return align_up(value, units::get_page_size());
+}
+
+size_t
+bpf_record_header_buffer::slot_size(size_t payload_size, size_t payload_align)
+{
+    auto header_offset = align_up(sizeof(slot_header), alignof(rocprofiler_record_header_t));
+    auto payload_offset =
+        align_up(header_offset + sizeof(rocprofiler_record_header_t), payload_align);
+    return align_up(payload_offset + payload_size, alignof(std::max_align_t));
+}
+
+void*
+bpf_record_header_buffer::reserve_slot(size_t                        payload_size,
+                                       size_t                        payload_align,
+                                       rocprofiler_record_header_t** record)
+{
+    if(!m_ptr || !record) return nullptr;
+    if(payload_size > std::numeric_limits<uint32_t>::max()) return nullptr;
+
+    auto total_size = slot_size(payload_size, payload_align);
+    if(total_size > m_capacity) return nullptr;
+
+    auto write_count = size_t{0};
+    do
+    {
+        write_count = m_write_count.load(std::memory_order_acquire);
+        if(write_count + total_size > m_capacity) return nullptr;
+    } while(!m_write_count.compare_exchange_strong(
+        write_count, write_count + total_size, std::memory_order_acq_rel));
+
+    auto* base          = static_cast<std::byte*>(m_ptr) + write_count;
+    auto  header_offset = align_up(sizeof(slot_header), alignof(rocprofiler_record_header_t));
+    auto  payload_offset =
+        align_up(header_offset + sizeof(rocprofiler_record_header_t), payload_align);
+
+    auto* slot           = reinterpret_cast<slot_header*>(base);
+    slot->total_size     = static_cast<uint32_t>(total_size);
+    slot->header_offset  = static_cast<uint32_t>(header_offset);
+    slot->payload_offset = static_cast<uint32_t>(payload_offset);
+    slot->payload_size   = static_cast<uint32_t>(payload_size);
+
+    *record = reinterpret_cast<rocprofiler_record_header_t*>(base + header_offset);
+    std::memset(*record, 0, sizeof(rocprofiler_record_header_t));
+
+    return base + payload_offset;
+}
+
+void
+bpf_record_header_buffer::destroy_storage()
+{
+    if(m_ptr && m_capacity > 0)
+    {
+        munmap(m_ptr, m_capacity);
+    }
+
+    m_requested.store(0, std::memory_order_release);
+    m_locked.store(0, std::memory_order_release);
+    m_write_count.store(0, std::memory_order_release);
+    m_record_count.store(0, std::memory_order_release);
+    m_ptr      = nullptr;
+    m_capacity = 0;
+    m_init     = false;
+}
+
+void
+bpf_record_header_buffer::move_from(bpf_record_header_buffer&& rhs) noexcept
+{
+    m_requested.store(rhs.m_requested.load(std::memory_order_acquire), std::memory_order_release);
+    m_locked.store(rhs.m_locked.load(std::memory_order_acquire), std::memory_order_release);
+    m_write_count.store(rhs.m_write_count.load(std::memory_order_acquire),
+                        std::memory_order_release);
+    m_record_count.store(rhs.m_record_count.load(std::memory_order_acquire),
+                         std::memory_order_release);
+    m_ptr      = rhs.m_ptr;
+    m_capacity = rhs.m_capacity;
+    m_init     = rhs.m_init;
+
+    rhs.m_requested.store(0, std::memory_order_release);
+    rhs.m_locked.store(0, std::memory_order_release);
+    rhs.m_write_count.store(0, std::memory_order_release);
+    rhs.m_record_count.store(0, std::memory_order_release);
+    rhs.m_ptr      = nullptr;
+    rhs.m_capacity = 0;
+    rhs.m_init     = false;
+}
+}  // namespace rocprofiler::common::container

--- a/projects/rocprofiler-sdk/source/lib/common/container/bpf_record_header_buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/bpf_record_header_buffer.cpp
@@ -139,6 +139,20 @@ bpf_record_header_buffer::load(std::fstream& fs)
     m_capacity = total_size;
     m_init     = true;
     fs.read(reinterpret_cast<char*>(m_ptr), m_capacity);
+
+    auto*  base   = static_cast<std::byte*>(m_ptr);
+    size_t offset = 0;
+    while(base && offset < write_count)
+    {
+        auto* slot = reinterpret_cast<slot_header*>(base + offset);
+        if(slot->total_size == 0 || offset + slot->total_size > write_count) break;
+
+        auto* record =
+            reinterpret_cast<rocprofiler_record_header_t*>(base + offset + slot->header_offset);
+        record->payload = base + offset + slot->payload_offset;
+        offset += slot->total_size;
+    }
+
     m_write_count.store(write_count, std::memory_order_release);
     m_record_count.store(record_count, std::memory_order_release);
 }

--- a/projects/rocprofiler-sdk/source/lib/common/container/bpf_record_header_buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/bpf_record_header_buffer.hpp
@@ -291,7 +291,7 @@ bpf_record_header_buffer::process_record_headers(ClearRecordsT, FuncT&& functor,
 
         auto* record =
             reinterpret_cast<rocprofiler_record_header_t*>(base + offset + slot->header_offset);
-        if(record->hash > 0 && record->payload != nullptr) records.emplace_back(record);
+        if(record->payload != nullptr) records.emplace_back(record);
 
         offset += slot->total_size;
     }

--- a/projects/rocprofiler-sdk/source/lib/common/container/bpf_record_header_buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/bpf_record_header_buffer.hpp
@@ -1,0 +1,308 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "lib/common/scope_destructor.hpp"
+
+#include <rocprofiler-sdk/fwd.h>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <shared_mutex>
+#include <type_traits>
+#include <typeinfo>
+#include <vector>
+
+namespace rocprofiler
+{
+namespace common
+{
+namespace container
+{
+/// @brief Experimental BPF-style record buffer.
+///
+/// This is a user-space transport that borrows the BPF ring buffer reserve/commit layout:
+/// producers reserve a variable-size slot, write the public record header and payload in-band,
+/// and the consumer drains committed slots in allocation order. It intentionally does not create
+/// a kernel BPF map because rocprofiler-sdk producers and tool callbacks run in the same process.
+struct bpf_record_header_buffer
+{
+    using record_ptr_vec_t = std::vector<rocprofiler_record_header_t*>;
+
+    bpf_record_header_buffer() = default;
+    explicit bpf_record_header_buffer(size_t nbytes);
+    ~bpf_record_header_buffer();
+
+    bpf_record_header_buffer(const bpf_record_header_buffer&) = delete;
+    bpf_record_header_buffer(bpf_record_header_buffer&&) noexcept;
+
+    bpf_record_header_buffer& operator=(const bpf_record_header_buffer&) = delete;
+    bpf_record_header_buffer& operator=(bpf_record_header_buffer&&) noexcept;
+
+    bool allocate(size_t nbytes);
+    bool is_allocated() const;
+
+    template <typename Tp>
+    bool emplace(Tp&);
+
+    template <typename Tp>
+    bool emplace(uint64_t, Tp&);
+
+    template <typename Tp>
+    bool emplace(uint32_t, uint32_t, Tp&);
+
+    size_t get_num_record_headers();
+
+    template <typename ClearRecordsT, typename FuncT, typename... Args>
+    size_t process_record_headers(ClearRecordsT, FuncT&& functor, Args&&... args);
+
+    void lock();
+    void unlock();
+    void read_lock();
+    void read_unlock();
+    bool is_locked() const;
+
+    size_t clear();
+    void   save(std::fstream&);
+    void   load(std::fstream&);
+    size_t reset();
+
+    auto size() const;
+    auto capacity() const;
+    auto count() const;
+    auto free() const;
+    auto is_empty() const;
+    auto is_full() const;
+
+private:
+    struct slot_header
+    {
+        uint32_t total_size     = 0;
+        uint32_t header_offset  = 0;
+        uint32_t payload_offset = 0;
+        uint32_t payload_size   = 0;
+    };
+
+    static size_t align_up(size_t value, size_t alignment);
+    static size_t page_aligned_size(size_t value);
+    static size_t slot_size(size_t payload_size, size_t payload_align);
+
+    void* reserve_slot(size_t                        payload_size,
+                       size_t                        payload_align,
+                       rocprofiler_record_header_t** record);
+    void  write_lock();
+    void  write_unlock();
+    void  destroy_storage();
+    void  move_from(bpf_record_header_buffer&&) noexcept;
+
+private:
+    std::atomic<int64_t> m_requested    = {0};
+    std::atomic<int64_t> m_locked       = {0};
+    std::atomic<size_t>  m_write_count  = {0};
+    std::atomic<size_t>  m_record_count = {0};
+    std::shared_mutex    m_shared       = {};
+    void*                m_ptr          = nullptr;
+    size_t               m_capacity     = 0;
+    bool                 m_init         = false;
+};
+
+inline bool
+bpf_record_header_buffer::is_locked() const
+{
+    return m_locked.load(std::memory_order_acquire) > 0;
+}
+
+inline void
+bpf_record_header_buffer::lock()
+{
+    auto n = m_locked.fetch_add(1, std::memory_order_release);
+    if(n == 0) write_lock();
+}
+
+inline void
+bpf_record_header_buffer::unlock()
+{
+    auto n = m_locked.fetch_sub(1, std::memory_order_release);
+    if(n <= 1) write_unlock();
+}
+
+inline void
+bpf_record_header_buffer::read_lock()
+{
+    m_shared.lock_shared();
+}
+
+inline void
+bpf_record_header_buffer::read_unlock()
+{
+    m_shared.unlock_shared();
+}
+
+inline void
+bpf_record_header_buffer::write_lock()
+{
+    m_shared.lock();
+}
+
+inline void
+bpf_record_header_buffer::write_unlock()
+{
+    m_shared.unlock();
+}
+
+inline bool
+bpf_record_header_buffer::is_allocated() const
+{
+    return m_init && m_ptr != nullptr;
+}
+
+inline auto
+bpf_record_header_buffer::size() const
+{
+    return m_record_count.load(std::memory_order_acquire);
+}
+
+inline auto
+bpf_record_header_buffer::capacity() const
+{
+    return m_capacity;
+}
+
+inline auto
+bpf_record_header_buffer::count() const
+{
+    return m_write_count.load(std::memory_order_acquire);
+}
+
+inline auto
+bpf_record_header_buffer::free() const
+{
+    auto _count = count();
+    return (_count < m_capacity) ? (m_capacity - _count) : size_t{0};
+}
+
+inline auto
+bpf_record_header_buffer::is_empty() const
+{
+    return (count() == 0 && m_requested.load(std::memory_order_acquire) == 0);
+}
+
+inline auto
+bpf_record_header_buffer::is_full() const
+{
+    return free() == 0;
+}
+
+template <typename Tp>
+bool
+bpf_record_header_buffer::emplace(uint64_t hash, Tp& value)
+{
+    if(!is_allocated()) return false;
+
+    m_requested.fetch_add(1, std::memory_order_acq_rel);
+    auto _request_scope =
+        scope_destructor{[&]() { m_requested.fetch_sub(1, std::memory_order_acq_rel); }};
+
+    read_lock();
+    auto _read_scope = scope_destructor{[&]() { read_unlock(); }};
+
+    auto* record = static_cast<rocprofiler_record_header_t*>(nullptr);
+    auto* addr   = reserve_slot(sizeof(Tp), alignof(Tp), &record);
+    if(!addr) return false;
+
+    new(addr) Tp{value};
+    record->hash    = hash;
+    record->payload = addr;
+    m_record_count.fetch_add(1, std::memory_order_acq_rel);
+    return true;
+}
+
+template <typename Tp>
+bool
+bpf_record_header_buffer::emplace(uint32_t category, uint32_t kind, Tp& value)
+{
+    if(!is_allocated()) return false;
+
+    m_requested.fetch_add(1, std::memory_order_acq_rel);
+    auto _request_scope =
+        scope_destructor{[&]() { m_requested.fetch_sub(1, std::memory_order_acq_rel); }};
+
+    read_lock();
+    auto _read_scope = scope_destructor{[&]() { read_unlock(); }};
+
+    auto* record = static_cast<rocprofiler_record_header_t*>(nullptr);
+    auto* addr   = reserve_slot(sizeof(Tp), alignof(Tp), &record);
+    if(!addr) return false;
+
+    new(addr) Tp{value};
+    record->category = category;
+    record->kind     = kind;
+    record->payload  = addr;
+    m_record_count.fetch_add(1, std::memory_order_acq_rel);
+    return true;
+}
+
+template <typename Tp>
+bool
+bpf_record_header_buffer::emplace(Tp& value)
+{
+    return emplace(typeid(Tp).hash_code(), value);
+}
+
+template <typename ClearRecordsT, typename FuncT, typename... Args>
+size_t
+bpf_record_header_buffer::process_record_headers(ClearRecordsT, FuncT&& functor, Args&&... args)
+{
+    auto _lk = scope_destructor{[&]() { unlock(); }, [&]() { lock(); }};
+
+    auto records = record_ptr_vec_t{};
+    records.reserve(m_record_count.load(std::memory_order_acquire));
+
+    auto*  base       = static_cast<std::byte*>(m_ptr);
+    size_t offset     = 0;
+    auto   write_size = m_write_count.load(std::memory_order_acquire);
+
+    while(base && offset < write_size)
+    {
+        auto* slot = reinterpret_cast<slot_header*>(base + offset);
+        if(slot->total_size == 0 || offset + slot->total_size > write_size) break;
+
+        auto* record =
+            reinterpret_cast<rocprofiler_record_header_t*>(base + offset + slot->header_offset);
+        if(record->hash > 0 && record->payload != nullptr) records.emplace_back(record);
+
+        offset += slot->total_size;
+    }
+
+    auto num_records = records.size();
+    std::forward<FuncT>(functor)(std::move(records), std::forward<Args>(args)...);
+
+    if constexpr(ClearRecordsT::value) clear();
+
+    return num_records;
+}
+}  // namespace container
+}  // namespace common
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/buffer.hpp
@@ -25,9 +25,14 @@
 #include <rocprofiler-sdk/buffer.h>
 #include <rocprofiler-sdk/fwd.h>
 
-#include "lib/common/container/record_header_buffer.hpp"
+#if defined(ROCPROFILER_EXPERIMENTAL_BPF_BUFFER) && ROCPROFILER_EXPERIMENTAL_BPF_BUFFER > 0
+#    include "lib/common/container/bpf_record_header_buffer.hpp"
+#else
+#    include "lib/common/container/record_header_buffer.hpp"
+#endif
 #include "lib/common/container/stable_vector.hpp"
 #include "lib/common/demangle.hpp"
+#include "lib/common/logging.hpp"
 
 #include <fmt/format.h>
 
@@ -44,7 +49,11 @@ namespace buffer
 {
 struct instance
 {
-    using buffer_t                       = common::container::record_header_buffer;
+#if defined(ROCPROFILER_EXPERIMENTAL_BPF_BUFFER) && ROCPROFILER_EXPERIMENTAL_BPF_BUFFER > 0
+    using buffer_t = common::container::bpf_record_header_buffer;
+#else
+    using buffer_t = common::container::record_header_buffer;
+#endif
     static constexpr auto size           = 2;  // double buffering
     static constexpr auto sync_wait_usec = std::chrono::microseconds{10};
 

--- a/projects/rocprofiler-sdk/source/lib/tests/buffering/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/tests/buffering/CMakeLists.txt
@@ -7,6 +7,10 @@ include(GoogleTest)
 
 set(buffering_sources buffering-serial.cpp buffering-parallel.cpp buffering-save-load.cpp)
 
+if(ROCPROFILER_EXPERIMENTAL_BPF_BUFFER)
+    list(APPEND buffering_sources bpf-buffer.cpp)
+endif()
+
 add_executable(buffering-tests)
 target_sources(buffering-tests PRIVATE ${buffering_sources})
 target_link_libraries(

--- a/projects/rocprofiler-sdk/source/lib/tests/buffering/bpf-buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/buffering/bpf-buffer.cpp
@@ -1,0 +1,58 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/common/container/bpf_record_header_buffer.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <type_traits>
+
+namespace
+{
+using bpf_record_header_buffer_t = rocprofiler::common::container::bpf_record_header_buffer;
+
+struct test_payload
+{
+    uint64_t value = 0;
+};
+}  // namespace
+
+TEST(bpf_buffer, zero_hash_records_are_delivered)
+{
+    auto buffer  = bpf_record_header_buffer_t{4096};
+    auto payload = test_payload{42};
+
+    ASSERT_TRUE(buffer.emplace(uint64_t{0}, payload));
+
+    auto num_headers = buffer.process_record_headers(std::true_type{}, [](auto&& records) {
+        ASSERT_EQ(records.size(), 1);
+        auto* record = records.at(0);
+        ASSERT_NE(record, nullptr);
+        ASSERT_NE(record->payload, nullptr);
+        EXPECT_EQ(record->hash, 0);
+        EXPECT_EQ(static_cast<test_payload*>(record->payload)->value, 42);
+    });
+
+    EXPECT_EQ(num_headers, 1);
+    EXPECT_EQ(buffer.get_num_record_headers(), 0);
+}


### PR DESCRIPTION
## Summary

This is a proposal/draft PR for evaluating a BPF-style buffer transport inside `rocprofiler-sdk`.

It keeps the public buffer API unchanged and limits the experiment to the internal `rocprofiler::buffer::instance::buffer_t` backend:

- adds an opt-in `ROCPROFILER_EXPERIMENTAL_BPF_BUFFER` CMake option
- adds `bpf_record_header_buffer`, a user-space BPF-style reserve/slot buffer
- switches the internal buffer type only when the experimental option is enabled
- adds direct buffering coverage for the experimental backend, including zero-hash record delivery
- rebases in-slot payload pointers on save/load remap instead of preserving stale virtual addresses
- documents the design tradeoffs and alternatives in a conceptual proposal page

## Design Direction

This deliberately does not use a kernel `BPF_MAP_TYPE_RINGBUF` as the default proposal. ROCprofiler-SDK buffered-service producers and tool callbacks are in the same process, so a kernel BPF map would add fd lifetime, kernel feature checks, syscall/poll paths, and dependency or permission questions without solving a process-boundary problem.

The recommendation ranking is now:

- first: lowest producer-side time overhead
- second: least memory footprint when time overhead is close

With that ranking, per-thread or per-producer user-space rings are the preferred common direction. The BPF-style buffer remains useful as a compact fallback or intermediate backend: it reduces storage footprint substantially, but it still has shared producer contention and does not beat the ring proposal on producer time.

## Benchmark Snapshot

Units are normalized: time is `ns/record`, footprint is `MiB`.

The active LTTng rows were measured with a complete LTTng 2.14 userspace stack extracted under `/tmp`. The system install mixed `lttng-tools` 2.13 with `liblttng-ctl` 2.14, which made `lttng create` fail until the client, daemon, consumer, and libraries were matched.

| Producers | Transport | Emit | Total | Storage | Max RSS |
|---:|---|---:|---:|---:|---:|
| 1 | Current | 24.518 | 27.016 | 136.07 | 141.81 |
| 1 | BPF-style | 17.299 | 31.173 | 12.01 | 17.83 |
| 1 | Ring shared mmap | 4.335 | 5.909 | 12.00 | 17.91 |
| 1 | LTTng-UST active | 141.760 | 144.479 | 136.07 | 157.90 |
| 4 | Current | 243.692 | 246.250 | 136.07 | 141.96 |
| 4 | BPF-style | 167.720 | 180.740 | 12.01 | 17.97 |
| 4 | Ring shared mmap | 5.970 | 9.315 | 12.02 | 17.79 |
| 4 | LTTng-UST active | 501.102 | 503.294 | 136.07 | 180.27 |
| 16 | Current | 260.940 | 263.424 | 136.07 | 142.28 |
| 16 | BPF-style | 150.954 | 167.847 | 12.01 | 18.00 |
| 16 | Ring shared mmap | 5.519 | 11.174 | 12.06 | 18.04 |
| 16 | LTTng-UST active | 563.533 | 565.863 | 136.07 | 203.93 |

The active LTTng run produced 258.93 MiB of CTF trace data for the three LTTng active rows.

## Validation

- `cmake -S projects/rocprofiler-sdk -B /tmp/rocprofiler-bpf-buffer-build -DROCPROFILER_EXPERIMENTAL_BPF_BUFFER=ON -DROCPROFILER_BUILD_TESTS=ON -DROCPROFILER_BUILD_SAMPLES=OFF -DROCPROFILER_BUILD_BENCHMARK=OFF -DROCPROFILER_BUILD_DOCS=OFF`
- `cmake --build /tmp/rocprofiler-bpf-buffer-build --target buffering-tests -j 16`
- `/tmp/rocprofiler-bpf-buffer-build/bin/buffering-tests`
- `cmake --build /tmp/rocprofiler-bpf-buffer-build --target rocprofiler-sdk-lib-tests -j 16`
- `/tmp/rocprofiler-bpf-buffer-build/bin/rocprofiler-sdk-lib-tests --gtest_filter=rocprofiler_lib.buffer`
- `cmake -S projects/rocprofiler-sdk -B /tmp/rocprofiler-bpf-buffer-default-build -DROCPROFILER_BUILD_TESTS=OFF -DROCPROFILER_BUILD_SAMPLES=OFF -DROCPROFILER_BUILD_BENCHMARK=OFF -DROCPROFILER_BUILD_DOCS=OFF`
- `cmake --build /tmp/rocprofiler-bpf-buffer-default-build --target rocprofiler-sdk-common-library rocprofiler-sdk-object-library -j 8`
- `git diff --check`
- `rst2pseudoxml --halt=warning projects/rocprofiler-sdk/source/docs/conceptual/bpf-buffer-transport-proposal.rst /tmp/rocprofiler-bpf-buffer-transport-proposal.xml`
- `custom-ai-secret-scan` on touched files
- active LTTng benchmark with local `/tmp/lttng-2.14` stack and isolated `LTTNG_HOME`/`XDG_RUNTIME_DIR`
