### PR TITLE
[hip-samples] remove CXX11 standard

### DIFF
--- a/projects/hip-tests/samples/1_Utils/hipDispatchLatency/CMakeLists.txt
+++ b/projects/hip-tests/samples/1_Utils/hipDispatchLatency/CMakeLists.txt
@@ -65,9 +65,6 @@ if(UNIX)
   )
 endif()
 
-set_property(TARGET hipDispatchLatency PROPERTY CXX_STANDARD 11)
-set_property(TARGET hipDispatchEnqueueRateMT PROPERTY CXX_STANDARD 11)
-
 if(TARGET build_utils)
 add_dependencies(build_utils hipDispatchLatency hipDispatchEnqueueRateMT)
 endif()


### PR DESCRIPTION
## Motivation

Remove CXX11 standard enforced for a hip sample

## Technical Details

Clang has moved to CXX17 by default, so has HIP. We can now have CXX17 specific features inside headers. This hardcoded standard check was a relic, and should have been removed.

## JIRA ID

Closes ROCM-23424

## Test Plan

Sample should build fine.

## Test Result

Tested locally. Builds fine.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
