### PR TITLE
[ROCProfiler-SDK] Add user-space ring rocprofiler transport POC

### DIFF
--- a/projects/rocprofiler-sdk/cmake/rocprofiler_build_settings.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_build_settings.cmake
@@ -203,6 +203,11 @@ if(ROCPROFILER_BUILD_CI_STRICT_TIMESTAMPS)
                                            INTERFACE ROCPROFILER_CI_STRICT_TIMESTAMPS)
 endif()
 
+if(ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER)
+    rocprofiler_target_compile_definitions(
+        rocprofiler-sdk-build-flags INTERFACE ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER=1)
+endif()
+
 # ----------------------------------------------------------------------------------------#
 # extra flags for compiling with experimental warnings
 #

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_options.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_options.cmake
@@ -51,6 +51,11 @@ rocprofiler_add_option(
     "Use (internal) <rocprofiler-sdk/rccl/details/api_trace.h> instead of RCCL-provided <rccl/amd_detail/api_trace.h>. Note: this should never be used in production"
     OFF
     ADVANCED)
+rocprofiler_add_option(
+    ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER
+    "Use the experimental per-producer user-space ring backend for rocprofiler buffers"
+    OFF
+    ADVANCED)
 
 rocprofiler_add_option(
     ROCPROFILER_BUILD_GHC_FS

--- a/projects/rocprofiler-sdk/source/docs/conceptual/user-ring-transport-proposal.rst
+++ b/projects/rocprofiler-sdk/source/docs/conceptual/user-ring-transport-proposal.rst
@@ -18,6 +18,10 @@ initial public buffered-services API. Tools would continue to create buffers,
 configure buffered services, receive ``rocprofiler_record_header_t`` batches, and
 observe discard or lossless backpressure through existing buffer policy semantics.
 
+This draft PR includes a proof-of-concept implementation behind the
+``ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER`` CMake option. The default
+``record_header_buffer`` backend is unchanged when the option is disabled.
+
 Motivation
 ==========
 
@@ -110,6 +114,12 @@ space check, the payload write, and a commit-store. If the shard is full, the
 backend applies the buffer policy locally: increment the logical drop count for
 discard mode or wait for the shard consumer cursor in lossless mode.
 
+The POC backend uses ``user_ring_record_header_buffer`` as the internal storage
+type when ``ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER=ON``. Each producer thread
+lazily creates one shard for each logical buffer object. The shard uses
+page-aligned process-private memory by default and stores the slot header,
+``rocprofiler_record_header_t``, and payload in one contiguous slot.
+
 Out-of-process backend
 ======================
 
@@ -130,6 +140,12 @@ marker, feature flags, logical buffer id, shard count, per-shard state, producer
 identity, generation number, and lifecycle state. The collector must be able to
 detect a producer that exits without finalizing and drain all committed records
 whose commit markers are visible.
+
+The POC does not add the collector control channel yet. To exercise the storage
+mode, setting ``ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER_SHARED_MMAP=1`` makes
+the POC allocate shard storage with anonymous shared ``mmap`` instead of
+process-private memory. A production out-of-process backend still needs file
+descriptor handoff, collector lifecycle, and crash-recovery protocol work.
 
 Ordering model
 ==============
@@ -247,11 +263,11 @@ Migration plan
 
 The proposal can be implemented in staged PRs:
 
-1. Add an internal ring-shard abstraction behind an experimental build option,
-   for example ``ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER``.
+1. Add an internal ring-shard abstraction behind
+   ``ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER``.
 2. Add an in-process backend for one logical buffer using per-thread shards while
    preserving the existing callback ABI.
-3. Add tests for discard, lossless, watermark, explicit flush, final flush,
+3. Add tests for direct shard behavior plus discard, lossless, watermark, explicit flush,
    thread exit, and callback-thread assignment.
 4. Add microbenchmarks for hot API tracing, kernel dispatch records, and
    multi-thread producer pressure compared with the current double-buffer path.

--- a/projects/rocprofiler-sdk/source/docs/conceptual/user-ring-transport-proposal.rst
+++ b/projects/rocprofiler-sdk/source/docs/conceptual/user-ring-transport-proposal.rst
@@ -128,7 +128,11 @@ The POC backend uses ``user_ring_record_header_buffer`` as the internal storage
 type when ``ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER=ON``. Each producer thread
 lazily creates one shard for each logical buffer object. The shard uses
 page-aligned process-private memory by default and stores the slot header,
-``rocprofiler_record_header_t``, and payload in one contiguous slot.
+``rocprofiler_record_header_t``, and payload in one contiguous slot. The POC
+still keeps drain and reset disjoint from producers with the existing buffer
+synchronization; a production backend should replace that with committed-slot
+state, consumer cursors, and lifecycle reclamation that does not require
+excluding all producers during normal drains.
 
 Out-of-process backend
 ======================

--- a/projects/rocprofiler-sdk/source/docs/conceptual/user-ring-transport-proposal.rst
+++ b/projects/rocprofiler-sdk/source/docs/conceptual/user-ring-transport-proposal.rst
@@ -274,10 +274,9 @@ Benchmark snapshot
 
 The cross-proposal microbenchmark uses one unit for time, nanoseconds per
 record, and one unit for footprint, MiB. It uses 64-byte payload records, 131072
-records per round, and 15 rounds. The LTTng row is the measurable
-no-active-session path; active-session measurement is still blocked on this test
-host because ``lttng create`` fails in the local session-daemon control path
-after spawning ``lttng-sessiond``.
+records per round, and 15 rounds. The active LTTng rows were measured with a
+locally extracted matching LTTng 2.14 userspace stack because the host install
+mixed ``lttng-tools`` 2.13 with ``liblttng-ctl`` 2.14.
 
 .. list-table::
    :header-rows: 1
@@ -318,12 +317,12 @@ after spawning ``lttng-sessiond``.
      - 12.00
      - 17.91
    * - 1
-     - LTTng-UST inactive
-     - 29.520
-     - 2.433
-     - 31.953
+     - LTTng-UST active
+     - 141.760
+     - 2.719
+     - 144.479
      - 136.07
-     - 141.81
+     - 157.90
    * - 4
      - Current
      - 243.692
@@ -353,12 +352,12 @@ after spawning ``lttng-sessiond``.
      - 12.02
      - 17.79
    * - 4
-     - LTTng-UST inactive
-     - 288.077
-     - 2.435
-     - 290.512
+     - LTTng-UST active
+     - 501.102
+     - 2.192
+     - 503.294
      - 136.07
-     - 141.84
+     - 180.27
    * - 16
      - Current
      - 260.940
@@ -388,17 +387,17 @@ after spawning ``lttng-sessiond``.
      - 12.06
      - 18.04
    * - 16
-     - LTTng-UST inactive
-     - 294.816
-     - 2.665
-     - 297.481
+     - LTTng-UST active
+     - 563.533
+     - 2.330
+     - 565.863
      - 136.07
-     - 142.29
+     - 203.93
 
 Based on lowest overhead first, the shared-mmap ring is the best common
 in-process and out-of-process direction in this benchmark. It is within roughly
 the same memory band as the BPF-style buffer and is far below the current
-backend and inactive LTTng-UST shadow path on producer time.
+backend and active LTTng-UST shadow path on producer time.
 
 Migration plan
 ==============

--- a/projects/rocprofiler-sdk/source/docs/conceptual/user-ring-transport-proposal.rst
+++ b/projects/rocprofiler-sdk/source/docs/conceptual/user-ring-transport-proposal.rst
@@ -22,6 +22,16 @@ This draft PR includes a proof-of-concept implementation behind the
 ``ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER`` CMake option. The default
 ``record_header_buffer`` backend is unchanged when the option is disabled.
 
+Decision criteria
+=================
+
+Transport recommendations in this proposal family are ranked by lowest
+producer-side time overhead first. Memory footprint is the second criterion and
+is used after the time ranking. This is why the per-thread or per-producer ring
+is the recommended common direction: it removes shared producer contention first
+and still keeps memory close to the compact BPF-style proposal through lazy,
+bounded shard allocation.
+
 Motivation
 ==========
 
@@ -256,7 +266,139 @@ Comparison with other transport choices
 
 The recommendation is to use per-thread or per-producer SPSC rings as the common
 transport model, with separate storage backends for process-private memory and
-shared ``mmap`` memory.
+shared ``mmap`` memory. This recommendation is based on producer-side time
+overhead first and memory footprint second.
+
+Benchmark snapshot
+==================
+
+The cross-proposal microbenchmark uses one unit for time, nanoseconds per
+record, and one unit for footprint, MiB. It uses 64-byte payload records, 131072
+records per round, and 15 rounds. The LTTng row is the measurable
+no-active-session path; active-session measurement is still blocked on this test
+host because ``lttng create`` fails in the local session-daemon control path
+after spawning ``lttng-sessiond``.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Producers
+     - Transport
+     - Emit ns/record
+     - Drain ns/record
+     - Total ns/record
+     - Storage MiB
+     - Max RSS MiB
+   * - 1
+     - Current
+     - 24.518
+     - 2.498
+     - 27.016
+     - 136.07
+     - 141.81
+   * - 1
+     - BPF-style
+     - 17.299
+     - 13.874
+     - 31.173
+     - 12.01
+     - 17.83
+   * - 1
+     - Ring private
+     - 4.369
+     - 1.594
+     - 5.963
+     - 12.00
+     - 17.67
+   * - 1
+     - Ring shared mmap
+     - 4.335
+     - 1.574
+     - 5.909
+     - 12.00
+     - 17.91
+   * - 1
+     - LTTng-UST inactive
+     - 29.520
+     - 2.433
+     - 31.953
+     - 136.07
+     - 141.81
+   * - 4
+     - Current
+     - 243.692
+     - 2.558
+     - 246.250
+     - 136.07
+     - 141.96
+   * - 4
+     - BPF-style
+     - 167.720
+     - 13.020
+     - 180.740
+     - 12.01
+     - 17.97
+   * - 4
+     - Ring private
+     - 5.944
+     - 4.993
+     - 10.936
+     - 12.02
+     - 17.68
+   * - 4
+     - Ring shared mmap
+     - 5.970
+     - 3.345
+     - 9.315
+     - 12.02
+     - 17.79
+   * - 4
+     - LTTng-UST inactive
+     - 288.077
+     - 2.435
+     - 290.512
+     - 136.07
+     - 141.84
+   * - 16
+     - Current
+     - 260.940
+     - 2.484
+     - 263.424
+     - 136.07
+     - 142.28
+   * - 16
+     - BPF-style
+     - 150.954
+     - 16.893
+     - 167.847
+     - 12.01
+     - 18.00
+   * - 16
+     - Ring private
+     - 4.993
+     - 12.037
+     - 17.029
+     - 12.06
+     - 18.09
+   * - 16
+     - Ring shared mmap
+     - 5.519
+     - 5.655
+     - 11.174
+     - 12.06
+     - 18.04
+   * - 16
+     - LTTng-UST inactive
+     - 294.816
+     - 2.665
+     - 297.481
+     - 136.07
+     - 142.29
+
+Based on lowest overhead first, the shared-mmap ring is the best common
+in-process and out-of-process direction in this benchmark. It is within roughly
+the same memory band as the BPF-style buffer and is far below the current
+backend and inactive LTTng-UST shadow path on producer time.
 
 Migration plan
 ==============

--- a/projects/rocprofiler-sdk/source/docs/conceptual/user-ring-transport-proposal.rst
+++ b/projects/rocprofiler-sdk/source/docs/conceptual/user-ring-transport-proposal.rst
@@ -1,0 +1,288 @@
+.. meta::
+  :description: Proposal for a user-space ring transport for ROCprofiler-SDK buffered records
+  :keywords: ROCprofiler-SDK, buffer, tracing, shared memory, mmap, user-space ring, proposal
+
+.. _user-ring-transport-proposal:
+
+====================================================
+User-space ring transport proposal for buffered data
+====================================================
+
+This proposal describes a low-overhead transport for moving buffered
+ROCprofiler-SDK records from internal producers to tools. The proposed direction is
+to use per-thread or per-producer user-space rings, backed by process-private
+memory for in-process tools and shared ``mmap`` memory for out-of-process tools.
+
+The goal is to reduce producer-side overhead and contention without changing the
+initial public buffered-services API. Tools would continue to create buffers,
+configure buffered services, receive ``rocprofiler_record_header_t`` batches, and
+observe discard or lossless backpressure through existing buffer policy semantics.
+
+Motivation
+==========
+
+The current buffer implementation is intentionally simple: a buffer handle owns a
+small set of internal record-header buffers, records are emplaced into the active
+buffer, and watermark or explicit flushes move completed records to the callback
+thread. That model keeps the tool API straightforward, but producer threads still
+interact with shared buffer state when many runtime callbacks, dispatch records,
+or sampling records target the same buffer.
+
+A ring-per-producer design moves the hot path closer to single-producer,
+single-consumer behavior:
+
+* the producer reserves from its own shard;
+* the producer writes the record payload directly into that shard;
+* the producer publishes the record with a release-store update;
+* a callback or collector thread drains shards and forms the existing callback
+  batch of ``rocprofiler_record_header_t*``.
+
+For in-process tools, each shard can be normal process memory. For out-of-process
+tools, the same ring layout can live in shared memory mapped by both the
+instrumented process and the collector process.
+
+Design constraints
+==================
+
+The initial design should preserve these constraints:
+
+* Keep ``rocprofiler_create_buffer``, ``rocprofiler_flush_buffer``,
+  ``rocprofiler_create_callback_thread``, and ``rocprofiler_assign_callback_thread``
+  stable.
+* Keep the callback ABI based on ``rocprofiler_record_header_t**``,
+  ``num_headers``, callback data, and ``drop_count``.
+* Preserve per-producer record order.
+* Avoid a global total-ordering point on the producer hot path.
+* Preserve discard and lossless behavior, but implement the policy per shard.
+* Avoid syscalls on normal record insertion.
+* Keep shared-memory descriptors and process-attachment control messages private
+  to the runtime or collector transport instead of exposing them in the public
+  buffer API.
+
+High-level architecture
+=======================
+
+The proposed transport separates the public buffer handle from the storage used
+by individual producers:
+
+.. code-block:: text
+
+  rocprofiler_buffer_id_t
+          |
+          v
+  logical buffer state
+          |
+          +-- producer shard 0: SPSC ring
+          +-- producer shard 1: SPSC ring
+          +-- producer shard 2: SPSC ring
+          +-- ...
+          |
+          v
+  drain thread or collector process
+          |
+          v
+  rocprofiler_buffer_tracing_cb_t(headers, num_headers, drop_count)
+
+The logical buffer owns policy, watermark, callback, context, and drop accounting.
+Each producer owns a shard that contains fixed-size ring control fields and
+variable-size record slots. The drain side walks registered shards, converts
+committed slots into the callback's pointer array, invokes the callback, and then
+advances the consumer cursor.
+
+In-process backend
+==================
+
+In-process use should be the lowest-overhead mode because no inter-process
+coordination is required. The recommended backend is:
+
+* allocate shard memory from normal page-aligned process memory;
+* create shards lazily for active producer threads or internal producer objects;
+* store the producer's active shard in thread-local or producer-local state;
+* use monotonically increasing producer and consumer cursors;
+* publish records with a release-store commit marker;
+* drain records with acquire loads on the consumer side;
+* wake the callback thread only at watermark, explicit flush, finalization, or
+  lossless-pressure points.
+
+The producer path should avoid a global lock, a shared multi-producer cursor, and
+kernel transitions. A fast-path insertion should only need local cursor math, a
+space check, the payload write, and a commit-store. If the shard is full, the
+backend applies the buffer policy locally: increment the logical drop count for
+discard mode or wait for the shard consumer cursor in lossless mode.
+
+Out-of-process backend
+======================
+
+For an out-of-process tool, the same shard layout can be backed by shared memory:
+
+* create a shared segment for the logical buffer control block and shard metadata;
+* allocate ring storage with ``memfd_create`` plus ``mmap(MAP_SHARED)`` on Linux,
+  with ``shm_open`` as a possible portability fallback if needed;
+* pass file descriptors over the private attachment or collector control channel;
+* map producer shards into the instrumented process and collector process;
+* use ``eventfd`` or futex-style wakeups for watermark, flush, shutdown, and
+  lossless-pressure notifications;
+* keep record insertion syscall-free until a wakeup or backpressure transition is
+  required.
+
+The shared control block should include an ABI version, page size, byte order
+marker, feature flags, logical buffer id, shard count, per-shard state, producer
+identity, generation number, and lifecycle state. The collector must be able to
+detect a producer that exits without finalizing and drain all committed records
+whose commit markers are visible.
+
+Ordering model
+==============
+
+The lowest-overhead ordering contract is per-producer ordering, not global
+insertion ordering. Each shard preserves the order of records produced by that
+thread or producer. Cross-thread order should be reconstructed by timestamps,
+correlation ids, and existing record metadata.
+
+Requiring a globally ordered ring would reintroduce a shared multi-producer
+atomic cursor and contention at exactly the point this proposal is trying to
+remove. A global order can still be produced later by the tool or output writer
+when it has all records available.
+
+Record layout
+=============
+
+Each slot should carry enough metadata for the consumer to validate and skip
+records safely:
+
+* total record size;
+* category and kind values;
+* payload offset or inline payload start;
+* producer id and sequence number;
+* flags for committed, padding, wrap marker, dropped-record marker, or
+  end-of-stream;
+* optional checksum or generation field for shared-memory diagnostics.
+
+The in-process callback path can pass pointers directly into process-private
+ring memory while the callback is running. The out-of-process path can pass
+pointers into the collector's mapping of the same shared segment, or copy only
+when a consumer requires a different lifetime. The first implementation should
+prefer zero-copy callback delivery and document that record pointers are valid
+only for the duration of the callback, matching the existing buffered-service
+usage pattern.
+
+Backpressure and flush behavior
+===============================
+
+The current buffer policy maps naturally to sharded rings:
+
+``ROCPROFILER_BUFFER_POLICY_DISCARD``
+  If a producer shard has insufficient free space, the producer increments a
+  drop counter and skips the record. Drop counters can be per shard and folded
+  into the logical buffer's ``drop_count`` during drain.
+
+``ROCPROFILER_BUFFER_POLICY_LOSSLESS``
+  If a producer shard has insufficient free space, the producer requests a drain
+  and waits until the consumer cursor advances. The wait path can start with a
+  bounded spin or yield in-process, then fall back to callback-thread wakeup. In
+  shared-memory mode, the wait path can use futex-style waits or ``eventfd``.
+
+``rocprofiler_flush_buffer``
+  An explicit flush marks all shards under the logical buffer as drain targets
+  and waits until all committed records visible at the flush boundary are
+  delivered.
+
+Watermarks should be tracked per shard to keep producer checks local. The
+logical buffer can also maintain an approximate aggregate watermark for callback
+batch sizing, but producer hot paths should not update a globally contended byte
+counter for every record.
+
+Footprint controls
+==================
+
+The main cost of per-producer rings is memory footprint. The backend should use
+bounded and lazy allocation:
+
+* allocate a shard only when a thread or producer first emits a record;
+* cap the number of active shards per logical buffer;
+* choose small default shard sizes for API tracing and larger sizes for high-rate
+  activity streams;
+* reclaim inactive shards after thread exit and final drain;
+* allow environment or tool configuration to tune shard size and shard count;
+* store shared control metadata in a compact control page or small control
+  mapping instead of one mapping per field.
+
+For out-of-process collection, the descriptor count should also be bounded. A
+single shared memory object per logical buffer plus offsets to shards is usually
+preferable to one file descriptor per producer.
+
+Comparison with other transport choices
+=======================================
+
+.. list-table::
+   :header-rows: 1
+
+   * - Transport
+     - In-process producer overhead
+     - Out-of-process producer overhead
+     - Main tradeoff
+   * - Current double-buffer backend
+     - Simple, but shared buffer state can contend
+     - Requires an additional export path
+     - Lowest implementation risk
+   * - Kernel BPF ring buffer
+     - Higher than needed because user-space records cross a kernel interface
+     - Good wakeup and polling model, but still kernel-mediated
+     - Useful as inspiration, not ideal for SDK-internal user-space producers
+   * - Single shared MPSC user-space ring
+     - One shared producer cursor can contend under high thread counts
+     - Works with shared ``mmap``
+     - Lower footprint than sharding, higher hot-path contention
+   * - Per-thread or per-producer SPSC rings
+     - Lowest producer overhead because each producer writes a local shard
+     - Lowest practical shared-memory option when paired with mmap and eventfd
+     - More shard lifecycle and drain complexity
+
+The recommendation is to use per-thread or per-producer SPSC rings as the common
+transport model, with separate storage backends for process-private memory and
+shared ``mmap`` memory.
+
+Migration plan
+==============
+
+The proposal can be implemented in staged PRs:
+
+1. Add an internal ring-shard abstraction behind an experimental build option,
+   for example ``ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER``.
+2. Add an in-process backend for one logical buffer using per-thread shards while
+   preserving the existing callback ABI.
+3. Add tests for discard, lossless, watermark, explicit flush, final flush,
+   thread exit, and callback-thread assignment.
+4. Add microbenchmarks for hot API tracing, kernel dispatch records, and
+   multi-thread producer pressure compared with the current double-buffer path.
+5. Add the shared-memory storage backend and collector control block for
+   out-of-process collection.
+6. Add crash and detach tests for collector exit, producer exit, stale shared
+   memory, and version mismatch.
+
+Open questions
+==============
+
+The implementation should settle these details before enabling the backend by
+default:
+
+* whether shards should be per thread, per internal producer object, or selected
+  by service;
+* default shard size and maximum shard count;
+* exact shared-memory setup path for process attachment and external collectors;
+* whether in-process lossless waiting should use spin-yield, condition variable,
+  futex, or the existing callback-thread task group;
+* whether record slots should be variable-sized directly or use fixed-size
+  descriptors pointing into a per-shard byte arena;
+* how much global ordering, if any, is required by existing output writers.
+
+Expected result
+===============
+
+For both in-process and out-of-process transfer, this design minimizes the work
+done by producer threads. The in-process hot path stays entirely in user-space
+and writes process-private memory. The out-of-process hot path writes the same
+record format into shared ``mmap`` memory and pays a kernel cost only for
+wakeups, setup, teardown, or backpressure. This makes the ring-shard design the
+lowest-overhead common direction while keeping the current ROCprofiler-SDK
+buffer API stable for tools.

--- a/projects/rocprofiler-sdk/source/docs/index.rst
+++ b/projects/rocprofiler-sdk/source/docs/index.rst
@@ -64,6 +64,7 @@ The documentation is structured as follows:
   .. grid-item-card:: Conceptual
 
     * :ref:`comparing-with-legacy-tools`
+    * :ref:`user-ring-transport-proposal`
 
 To contribute to the documentation, refer to
 `Contributing to ROCm <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.

--- a/projects/rocprofiler-sdk/source/lib/common/container/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/common/container/CMakeLists.txt
@@ -11,9 +11,14 @@ set(containers_headers
     ring_buffer.hpp
     small_vector.hpp
     stable_vector.hpp
-    static_vector.hpp)
-set(containers_sources ring_buffer.cpp record_header_buffer.cpp ring_buffer.cpp
-                       small_vector.cpp)
+    static_vector.hpp
+    user_ring_record_header_buffer.hpp)
+set(containers_sources
+    ring_buffer.cpp
+    record_header_buffer.cpp
+    ring_buffer.cpp
+    small_vector.cpp
+    user_ring_record_header_buffer.cpp)
 
 target_sources(rocprofiler-sdk-common-library PRIVATE ${containers_sources}
                                                       ${containers_headers})

--- a/projects/rocprofiler-sdk/source/lib/common/container/user_ring_record_header_buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/user_ring_record_header_buffer.cpp
@@ -1,0 +1,403 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/common/container/user_ring_record_header_buffer.hpp"
+#include "lib/common/units.hpp"
+
+#include <sys/mman.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <new>
+#include <string_view>
+#include <utility>
+
+namespace rocprofiler::common::container
+{
+namespace
+{
+std::atomic<uint64_t>&
+next_generation()
+{
+    static auto _v = std::atomic<uint64_t>{1};
+    return _v;
+}
+
+struct tls_shard_entry
+{
+    const user_ring_record_header_buffer* owner      = nullptr;
+    uint64_t                              generation = 0;
+    void*                                 shard      = nullptr;
+};
+
+thread_local auto tls_shards = std::vector<tls_shard_entry>{};
+}  // namespace
+
+user_ring_record_header_buffer::user_ring_record_header_buffer()
+: m_generation{next_generation().fetch_add(1, std::memory_order_acq_rel)}
+{}
+
+user_ring_record_header_buffer::user_ring_record_header_buffer(size_t num_bytes)
+: user_ring_record_header_buffer{}
+{
+    allocate(num_bytes);
+}
+
+user_ring_record_header_buffer::~user_ring_record_header_buffer() { destroy_storage(); }
+
+user_ring_record_header_buffer::user_ring_record_header_buffer(
+    user_ring_record_header_buffer&& rhs) noexcept
+: user_ring_record_header_buffer{}
+{
+    move_from(std::move(rhs));
+}
+
+user_ring_record_header_buffer&
+user_ring_record_header_buffer::operator=(user_ring_record_header_buffer&& rhs) noexcept
+{
+    if(this != &rhs)
+    {
+        destroy_storage();
+        move_from(std::move(rhs));
+    }
+    return *this;
+}
+
+bool
+user_ring_record_header_buffer::allocate(size_t num_bytes)
+{
+    auto _lk = std::lock_guard<std::mutex>{m_mutex};
+    if(is_allocated()) return false;
+
+    m_capacity = page_aligned_size(num_bytes + slot_size(1, alignof(std::max_align_t)));
+    m_storage  = use_shared_mmap() ? storage_mode::shared_mmap : storage_mode::private_memory;
+    m_init     = true;
+    return true;
+}
+
+size_t
+user_ring_record_header_buffer::get_num_record_headers()
+{
+    return m_record_count.load(std::memory_order_acquire);
+}
+
+size_t
+user_ring_record_header_buffer::clear()
+{
+    auto _lk = scope_destructor{[&]() { unlock(); }, [&]() { lock(); }};
+    auto records = m_record_count.exchange(0, std::memory_order_acq_rel);
+
+    auto _shards_lk = std::lock_guard<std::mutex>{m_mutex};
+    for(auto& itr : m_shards)
+    {
+        itr->reset();
+    }
+    return records;
+}
+
+size_t
+user_ring_record_header_buffer::reset()
+{
+    auto _lk     = scope_destructor{[&]() { unlock(); }, [&]() { lock(); }};
+    auto records = m_record_count.load(std::memory_order_acquire);
+    destroy_storage();
+    return records;
+}
+
+void
+user_ring_record_header_buffer::save(std::fstream& fs)
+{
+    auto _lk = scope_destructor{[&]() { unlock(); }, [&]() { lock(); }};
+
+    auto record_count = m_record_count.load(std::memory_order_acquire);
+    fs.write(reinterpret_cast<char*>(&m_capacity), sizeof(m_capacity));
+    fs.write(reinterpret_cast<char*>(&record_count), sizeof(record_count));
+
+    auto _shards_lk = std::lock_guard<std::mutex>{m_mutex};
+    for(auto& shard_v : m_shards)
+    {
+        auto*  base       = static_cast<std::byte*>(shard_v->ptr);
+        size_t offset     = 0;
+        auto   write_size = shard_v->published.load(std::memory_order_acquire);
+        while(base && offset < write_size)
+        {
+            auto* slot = reinterpret_cast<slot_header*>(base + offset);
+            if(slot->total_size == 0 || offset + slot->total_size > write_size) break;
+
+            auto* record = reinterpret_cast<rocprofiler_record_header_t*>(
+                base + offset + slot->header_offset);
+            auto* payload = base + offset + slot->payload_offset;
+            auto  hash    = record->hash;
+
+            fs.write(reinterpret_cast<char*>(&hash), sizeof(hash));
+            fs.write(reinterpret_cast<char*>(&slot->payload_size), sizeof(slot->payload_size));
+            fs.write(reinterpret_cast<char*>(payload), slot->payload_size);
+            offset += slot->total_size;
+        }
+    }
+}
+
+void
+user_ring_record_header_buffer::load(std::fstream& fs)
+{
+    auto capacity     = size_t{0};
+    auto record_count = size_t{0};
+
+    fs.read(reinterpret_cast<char*>(&capacity), sizeof(capacity));
+    fs.read(reinterpret_cast<char*>(&record_count), sizeof(record_count));
+
+    reset();
+    allocate(capacity);
+
+    auto* _shard = create_shard_for_load(record_count * slot_size(1, alignof(std::max_align_t)));
+    if(!_shard) throw std::bad_alloc{};
+
+    for(size_t i = 0; i < record_count; ++i)
+    {
+        auto hash         = uint64_t{0};
+        auto payload_size = uint32_t{0};
+
+        fs.read(reinterpret_cast<char*>(&hash), sizeof(hash));
+        fs.read(reinterpret_cast<char*>(&payload_size), sizeof(payload_size));
+
+        auto* record = static_cast<rocprofiler_record_header_t*>(nullptr);
+        auto* addr   = _shard->reserve_slot(payload_size, alignof(std::max_align_t), &record);
+        if(!addr) throw std::bad_alloc{};
+
+        fs.read(reinterpret_cast<char*>(addr), payload_size);
+        record->hash    = hash;
+        record->payload = addr;
+        m_record_count.fetch_add(1, std::memory_order_acq_rel);
+    }
+}
+
+bool
+user_ring_record_header_buffer::shard::allocate(size_t bytes, storage_mode mode)
+{
+    destroy();
+    capacity = user_ring_record_header_buffer::page_aligned_size(bytes);
+    storage  = mode;
+
+    if(storage == storage_mode::shared_mmap)
+    {
+        ptr = mmap(nullptr, capacity, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_SHARED, -1, 0);
+        if(ptr == MAP_FAILED) ptr = nullptr;
+    }
+    else
+    {
+        auto alignment = std::align_val_t{static_cast<size_t>(units::get_page_size())};
+        ptr            = ::operator new(capacity, alignment, std::nothrow);
+    }
+
+    if(!ptr)
+    {
+        capacity = 0;
+        return false;
+    }
+
+    std::memset(ptr, 0, capacity);
+    reset();
+    return true;
+}
+
+void
+user_ring_record_header_buffer::shard::destroy()
+{
+    if(ptr)
+    {
+        if(storage == storage_mode::shared_mmap)
+            munmap(ptr, capacity);
+        else
+            ::operator delete(
+                ptr, std::align_val_t{static_cast<size_t>(units::get_page_size())});
+    }
+
+    ptr      = nullptr;
+    capacity = 0;
+    reset();
+}
+
+void
+user_ring_record_header_buffer::shard::reset()
+{
+    if(ptr && write_count > 0) std::memset(ptr, 0, std::min(write_count, capacity));
+    write_count  = 0;
+    record_count = 0;
+    published.store(0, std::memory_order_release);
+}
+
+void*
+user_ring_record_header_buffer::shard::reserve_slot(size_t                        payload_size,
+                                                    size_t                        payload_align,
+                                                    rocprofiler_record_header_t** record)
+{
+    if(!ptr || !record) return nullptr;
+    if(payload_size > std::numeric_limits<uint32_t>::max()) return nullptr;
+
+    auto total_size = user_ring_record_header_buffer::slot_size(payload_size, payload_align);
+    if(write_count + total_size > capacity) return nullptr;
+
+    auto* base          = static_cast<std::byte*>(ptr) + write_count;
+    auto  header_offset = user_ring_record_header_buffer::align_up(
+        sizeof(slot_header), alignof(rocprofiler_record_header_t));
+    auto payload_offset = user_ring_record_header_buffer::align_up(
+        header_offset + sizeof(rocprofiler_record_header_t), payload_align);
+
+    auto* slot           = reinterpret_cast<slot_header*>(base);
+    slot->total_size     = static_cast<uint32_t>(total_size);
+    slot->header_offset  = static_cast<uint32_t>(header_offset);
+    slot->payload_offset = static_cast<uint32_t>(payload_offset);
+    slot->payload_size   = static_cast<uint32_t>(payload_size);
+    slot->sequence       = record_count;
+
+    *record = reinterpret_cast<rocprofiler_record_header_t*>(base + header_offset);
+    std::memset(*record, 0, sizeof(rocprofiler_record_header_t));
+
+    auto* payload = base + payload_offset;
+    write_count += total_size;
+    ++record_count;
+
+    slot->flags = 1;
+    published.store(write_count, std::memory_order_release);
+    return payload;
+}
+
+size_t
+user_ring_record_header_buffer::align_up(size_t value, size_t alignment)
+{
+    if(alignment == 0) return value;
+    auto remainder = value % alignment;
+    return (remainder == 0) ? value : (value + alignment - remainder);
+}
+
+size_t
+user_ring_record_header_buffer::page_aligned_size(size_t value)
+{
+    return align_up(value, units::get_page_size());
+}
+
+size_t
+user_ring_record_header_buffer::slot_size(size_t payload_size, size_t payload_align)
+{
+    auto header_offset = align_up(sizeof(slot_header), alignof(rocprofiler_record_header_t));
+    auto payload_offset =
+        align_up(header_offset + sizeof(rocprofiler_record_header_t), payload_align);
+    return align_up(payload_offset + payload_size, alignof(std::max_align_t));
+}
+
+bool
+user_ring_record_header_buffer::use_shared_mmap()
+{
+    auto* envp = std::getenv("ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER_SHARED_MMAP");
+    return envp && std::string_view{envp} != "0" && std::string_view{envp} != "false";
+}
+
+user_ring_record_header_buffer::shard*
+user_ring_record_header_buffer::get_thread_shard()
+{
+    for(auto& itr : tls_shards)
+    {
+        if(itr.owner == this && itr.generation == m_generation)
+            return static_cast<shard*>(itr.shard);
+    }
+
+    auto _lk = std::lock_guard<std::mutex>{m_mutex};
+    auto* ret = create_shard_locked();
+    if(ret) tls_shards.emplace_back(tls_shard_entry{this, m_generation, ret});
+    return ret;
+}
+
+user_ring_record_header_buffer::shard*
+user_ring_record_header_buffer::create_shard_locked()
+{
+    auto _shard = std::make_unique<shard>();
+    if(!_shard->allocate(m_capacity, m_storage)) return nullptr;
+
+    auto* ret = _shard.get();
+    m_shards.emplace_back(std::move(_shard));
+    return ret;
+}
+
+user_ring_record_header_buffer::shard*
+user_ring_record_header_buffer::create_shard_for_load(size_t extra_bytes)
+{
+    auto _lk    = std::lock_guard<std::mutex>{m_mutex};
+    auto _shard = std::make_unique<shard>();
+    auto bytes  = std::max(m_capacity, page_aligned_size(extra_bytes + m_capacity));
+    if(!_shard->allocate(bytes, m_storage)) return nullptr;
+
+    auto* ret = _shard.get();
+    m_shards.emplace_back(std::move(_shard));
+    return ret;
+}
+
+void
+user_ring_record_header_buffer::destroy_storage()
+{
+    auto _lk = std::lock_guard<std::mutex>{m_mutex};
+    for(auto& itr : m_shards)
+    {
+        itr->destroy();
+    }
+    m_shards.clear();
+    m_requested.store(0, std::memory_order_release);
+    m_record_count.store(0, std::memory_order_release);
+    m_capacity   = 0;
+    m_init       = false;
+    m_generation = next_generation().fetch_add(1, std::memory_order_acq_rel);
+}
+
+void
+user_ring_record_header_buffer::move_from(user_ring_record_header_buffer&& rhs) noexcept
+{
+    auto lhs_lk = std::lock_guard<std::mutex>{m_mutex};
+    auto rhs_lk = std::lock_guard<std::mutex>{rhs.m_mutex};
+
+    m_requested.store(rhs.m_requested.load(std::memory_order_acquire), std::memory_order_release);
+    m_record_count.store(rhs.m_record_count.load(std::memory_order_acquire),
+                         std::memory_order_release);
+    m_shards   = std::move(rhs.m_shards);
+    m_capacity = rhs.m_capacity;
+    m_storage  = rhs.m_storage;
+    m_init     = rhs.m_init;
+
+    rhs.m_requested.store(0, std::memory_order_release);
+    rhs.m_record_count.store(0, std::memory_order_release);
+    rhs.m_capacity   = 0;
+    rhs.m_init       = false;
+    rhs.m_generation = next_generation().fetch_add(1, std::memory_order_acq_rel);
+}
+
+size_t
+user_ring_record_header_buffer::aggregate_count() const
+{
+    auto bytes = size_t{0};
+    auto _lk   = std::lock_guard<std::mutex>{m_mutex};
+    for(const auto& itr : m_shards)
+    {
+        bytes += itr->published.load(std::memory_order_acquire);
+    }
+    return bytes;
+}
+}  // namespace rocprofiler::common::container

--- a/projects/rocprofiler-sdk/source/lib/common/container/user_ring_record_header_buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/user_ring_record_header_buffer.hpp
@@ -1,0 +1,368 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "lib/common/scope_destructor.hpp"
+
+#include <rocprofiler-sdk/fwd.h>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <type_traits>
+#include <typeinfo>
+#include <vector>
+
+namespace rocprofiler
+{
+namespace common
+{
+namespace container
+{
+/// @brief Experimental per-producer record buffer.
+///
+/// This backend is a user-space POC for the logical-buffer-to-sharded-ring transport. Each
+/// producer thread lazily gets a single-producer shard and writes record headers and payloads
+/// in-band. The drain side walks the registered shards and forms the same
+/// rocprofiler_record_header_t pointer array used by the existing buffered callback ABI.
+struct user_ring_record_header_buffer
+{
+    using record_ptr_vec_t = std::vector<rocprofiler_record_header_t*>;
+
+    user_ring_record_header_buffer();
+    explicit user_ring_record_header_buffer(size_t nbytes);
+    ~user_ring_record_header_buffer();
+
+    user_ring_record_header_buffer(const user_ring_record_header_buffer&) = delete;
+    user_ring_record_header_buffer(user_ring_record_header_buffer&&) noexcept;
+
+    user_ring_record_header_buffer& operator=(const user_ring_record_header_buffer&) = delete;
+    user_ring_record_header_buffer& operator=(user_ring_record_header_buffer&&) noexcept;
+
+    bool allocate(size_t nbytes);
+    bool is_allocated() const;
+
+    template <typename Tp>
+    bool emplace(Tp&);
+
+    template <typename Tp>
+    bool emplace(uint64_t, Tp&);
+
+    template <typename Tp>
+    bool emplace(uint32_t, uint32_t, Tp&);
+
+    size_t get_num_record_headers();
+
+    template <typename ClearRecordsT, typename FuncT, typename... Args>
+    size_t process_record_headers(ClearRecordsT, FuncT&& functor, Args&&... args);
+
+    void lock();
+    void unlock();
+    void read_lock();
+    void read_unlock();
+    bool is_locked() const;
+
+    size_t clear();
+    void   save(std::fstream&);
+    void   load(std::fstream&);
+    size_t reset();
+
+    auto size() const;
+    auto capacity() const;
+    auto count() const;
+    auto free() const;
+    auto is_empty() const;
+    auto is_full() const;
+
+private:
+    enum class storage_mode
+    {
+        private_memory,
+        shared_mmap,
+    };
+
+    struct slot_header
+    {
+        uint32_t total_size     = 0;
+        uint32_t header_offset  = 0;
+        uint32_t payload_offset = 0;
+        uint32_t payload_size   = 0;
+        uint32_t flags          = 0;
+        uint32_t reserved       = 0;
+        uint64_t sequence       = 0;
+    };
+
+    struct shard
+    {
+        void*               ptr          = nullptr;
+        size_t              capacity     = 0;
+        size_t              write_count  = 0;
+        size_t              record_count = 0;
+        std::atomic<size_t> published    = {0};
+        storage_mode        storage      = storage_mode::private_memory;
+
+        bool allocate(size_t, storage_mode);
+        void destroy();
+        void reset();
+
+        void* reserve_slot(size_t, size_t, rocprofiler_record_header_t**);
+    };
+
+    static size_t align_up(size_t value, size_t alignment);
+    static size_t page_aligned_size(size_t value);
+    static size_t slot_size(size_t payload_size, size_t payload_align);
+    static bool   use_shared_mmap();
+
+    shard* get_thread_shard();
+    shard* create_shard_locked();
+    shard* create_shard_for_load(size_t);
+    void   destroy_storage();
+    void   move_from(user_ring_record_header_buffer&&) noexcept;
+    size_t aggregate_count() const;
+
+    void write_lock();
+    void write_unlock();
+
+private:
+    std::atomic<int64_t> m_requested = {0};
+    std::atomic<int64_t> m_locked    = {0};
+    std::shared_mutex    m_shared    = {};
+    mutable std::mutex   m_mutex     = {};
+
+    std::vector<std::unique_ptr<shard>> m_shards       = {};
+    std::atomic<size_t>                 m_record_count = {0};
+    size_t                              m_capacity     = 0;
+    storage_mode                        m_storage      = storage_mode::private_memory;
+    bool                                m_init         = false;
+    uint64_t                            m_generation   = 0;
+};
+
+inline bool
+user_ring_record_header_buffer::is_locked() const
+{
+    return m_locked.load(std::memory_order_acquire) > 0;
+}
+
+inline void
+user_ring_record_header_buffer::lock()
+{
+    auto n = m_locked.fetch_add(1, std::memory_order_release);
+    if(n == 0) write_lock();
+}
+
+inline void
+user_ring_record_header_buffer::unlock()
+{
+    auto n = m_locked.fetch_sub(1, std::memory_order_release);
+    if(n <= 1) write_unlock();
+}
+
+inline void
+user_ring_record_header_buffer::read_lock()
+{
+    m_shared.lock_shared();
+}
+
+inline void
+user_ring_record_header_buffer::read_unlock()
+{
+    m_shared.unlock_shared();
+}
+
+inline void
+user_ring_record_header_buffer::write_lock()
+{
+    m_shared.lock();
+}
+
+inline void
+user_ring_record_header_buffer::write_unlock()
+{
+    m_shared.unlock();
+}
+
+inline bool
+user_ring_record_header_buffer::is_allocated() const
+{
+    return m_init && m_capacity > 0;
+}
+
+inline auto
+user_ring_record_header_buffer::size() const
+{
+    return m_record_count.load(std::memory_order_acquire);
+}
+
+inline auto
+user_ring_record_header_buffer::capacity() const
+{
+    auto _lk = std::lock_guard<std::mutex>{m_mutex};
+    return m_shards.empty() ? m_capacity : (m_capacity * m_shards.size());
+}
+
+inline auto
+user_ring_record_header_buffer::count() const
+{
+    return aggregate_count();
+}
+
+inline auto
+user_ring_record_header_buffer::free() const
+{
+    auto _lk = std::lock_guard<std::mutex>{m_mutex};
+    auto used = size_t{0};
+    for(const auto& itr : m_shards)
+    {
+        used += itr->published.load(std::memory_order_acquire);
+    }
+    auto cap = m_shards.empty() ? m_capacity : (m_capacity * m_shards.size());
+    return (used < cap) ? (cap - used) : size_t{0};
+}
+
+inline auto
+user_ring_record_header_buffer::is_empty() const
+{
+    return size() == 0 && m_requested.load(std::memory_order_acquire) == 0;
+}
+
+inline auto
+user_ring_record_header_buffer::is_full() const
+{
+    if(!is_allocated()) return true;
+    auto _lk = std::lock_guard<std::mutex>{m_mutex};
+    if(m_shards.empty()) return false;
+    for(const auto& itr : m_shards)
+    {
+        if(itr->published.load(std::memory_order_acquire) < itr->capacity) return false;
+    }
+    return true;
+}
+
+template <typename Tp>
+bool
+user_ring_record_header_buffer::emplace(uint64_t hash, Tp& value)
+{
+    if(!is_allocated()) return false;
+
+    m_requested.fetch_add(1, std::memory_order_acq_rel);
+    auto _request_scope =
+        scope_destructor{[&]() { m_requested.fetch_sub(1, std::memory_order_acq_rel); }};
+
+    read_lock();
+    auto _read_scope = scope_destructor{[&]() { read_unlock(); }};
+
+    auto* _shard = get_thread_shard();
+    if(!_shard) return false;
+
+    auto* record = static_cast<rocprofiler_record_header_t*>(nullptr);
+    auto* addr   = _shard->reserve_slot(sizeof(Tp), alignof(Tp), &record);
+    if(!addr) return false;
+
+    new(addr) Tp{value};
+    record->hash    = hash;
+    record->payload = addr;
+    m_record_count.fetch_add(1, std::memory_order_acq_rel);
+    return true;
+}
+
+template <typename Tp>
+bool
+user_ring_record_header_buffer::emplace(uint32_t category, uint32_t kind, Tp& value)
+{
+    if(!is_allocated()) return false;
+
+    m_requested.fetch_add(1, std::memory_order_acq_rel);
+    auto _request_scope =
+        scope_destructor{[&]() { m_requested.fetch_sub(1, std::memory_order_acq_rel); }};
+
+    read_lock();
+    auto _read_scope = scope_destructor{[&]() { read_unlock(); }};
+
+    auto* _shard = get_thread_shard();
+    if(!_shard) return false;
+
+    auto* record = static_cast<rocprofiler_record_header_t*>(nullptr);
+    auto* addr   = _shard->reserve_slot(sizeof(Tp), alignof(Tp), &record);
+    if(!addr) return false;
+
+    new(addr) Tp{value};
+    record->category = category;
+    record->kind     = kind;
+    record->payload  = addr;
+    m_record_count.fetch_add(1, std::memory_order_acq_rel);
+    return true;
+}
+
+template <typename Tp>
+bool
+user_ring_record_header_buffer::emplace(Tp& value)
+{
+    return emplace(typeid(Tp).hash_code(), value);
+}
+
+template <typename ClearRecordsT, typename FuncT, typename... Args>
+size_t
+user_ring_record_header_buffer::process_record_headers(ClearRecordsT, FuncT&& functor, Args&&... args)
+{
+    auto _lk = scope_destructor{[&]() { unlock(); }, [&]() { lock(); }};
+
+    auto records = record_ptr_vec_t{};
+    records.reserve(m_record_count.load(std::memory_order_acquire));
+
+    {
+        auto _shards_lk = std::lock_guard<std::mutex>{m_mutex};
+        for(auto& shard_v : m_shards)
+        {
+            auto*  base       = static_cast<std::byte*>(shard_v->ptr);
+            size_t offset     = 0;
+            auto   write_size = shard_v->published.load(std::memory_order_acquire);
+
+            while(base && offset < write_size)
+            {
+                auto* slot = reinterpret_cast<slot_header*>(base + offset);
+                if(slot->total_size == 0 || offset + slot->total_size > write_size) break;
+
+                auto* record = reinterpret_cast<rocprofiler_record_header_t*>(
+                    base + offset + slot->header_offset);
+                if(slot->flags > 0 && record->hash > 0 && record->payload != nullptr)
+                    records.emplace_back(record);
+
+                offset += slot->total_size;
+            }
+        }
+    }
+
+    auto num_records = records.size();
+    std::forward<FuncT>(functor)(std::move(records), std::forward<Args>(args)...);
+
+    if constexpr(ClearRecordsT::value) clear();
+
+    return num_records;
+}
+}  // namespace container
+}  // namespace common
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/common/container/user_ring_record_header_buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/user_ring_record_header_buffer.hpp
@@ -348,8 +348,7 @@ user_ring_record_header_buffer::process_record_headers(ClearRecordsT, FuncT&& fu
 
                 auto* record = reinterpret_cast<rocprofiler_record_header_t*>(
                     base + offset + slot->header_offset);
-                if(slot->flags > 0 && record->hash > 0 && record->payload != nullptr)
-                    records.emplace_back(record);
+                if(slot->flags > 0 && record->payload != nullptr) records.emplace_back(record);
 
                 offset += slot->total_size;
             }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/buffer.hpp
@@ -25,9 +25,15 @@
 #include <rocprofiler-sdk/buffer.h>
 #include <rocprofiler-sdk/fwd.h>
 
-#include "lib/common/container/record_header_buffer.hpp"
+#if defined(ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER) && \
+    ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER > 0
+#    include "lib/common/container/user_ring_record_header_buffer.hpp"
+#else
+#    include "lib/common/container/record_header_buffer.hpp"
+#endif
 #include "lib/common/container/stable_vector.hpp"
 #include "lib/common/demangle.hpp"
+#include "lib/common/logging.hpp"
 
 #include <fmt/format.h>
 
@@ -44,7 +50,12 @@ namespace buffer
 {
 struct instance
 {
-    using buffer_t                       = common::container::record_header_buffer;
+#if defined(ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER) && \
+    ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER > 0
+    using buffer_t = common::container::user_ring_record_header_buffer;
+#else
+    using buffer_t = common::container::record_header_buffer;
+#endif
     static constexpr auto size           = 2;  // double buffering
     static constexpr auto sync_wait_usec = std::chrono::microseconds{10};
 

--- a/projects/rocprofiler-sdk/source/lib/tests/buffering/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/tests/buffering/CMakeLists.txt
@@ -5,7 +5,11 @@ project(rocprofiler-sdk-tests-buffering LANGUAGES C CXX)
 
 include(GoogleTest)
 
-set(buffering_sources buffering-serial.cpp buffering-parallel.cpp buffering-save-load.cpp)
+set(buffering_sources
+    buffering-serial.cpp
+    buffering-parallel.cpp
+    buffering-save-load.cpp
+    user-ring-buffer.cpp)
 
 add_executable(buffering-tests)
 target_sources(buffering-tests PRIVATE ${buffering_sources})

--- a/projects/rocprofiler-sdk/source/lib/tests/buffering/user-ring-buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/buffering/user-ring-buffer.cpp
@@ -137,6 +137,27 @@ TEST(user_ring_buffer, parallel_per_thread_shards)
     EXPECT_EQ(seen.load(), num_records);
 }
 
+TEST(user_ring_buffer, zero_hash_records_are_delivered)
+{
+    auto buffer = user_ring_buffer_t{4096};
+    auto record = make_record(2, 3);
+
+    ASSERT_TRUE(buffer.emplace(uint64_t{0}, record));
+
+    auto num_headers = buffer.process_record_headers(std::true_type{}, [&](auto&& records) {
+        ASSERT_EQ(records.size(), 1);
+        auto* header = records.at(0);
+        ASSERT_NE(header, nullptr);
+        ASSERT_EQ(header->hash, 0);
+        auto* payload = static_cast<test_record*>(header->payload);
+        ASSERT_NE(payload, nullptr);
+        EXPECT_EQ(payload->checksum, make_record(payload->tid, payload->index).checksum);
+    });
+
+    EXPECT_EQ(num_headers, 1);
+    EXPECT_TRUE(buffer.is_empty());
+}
+
 TEST(user_ring_buffer, save_load)
 {
     constexpr auto num_records = 64;

--- a/projects/rocprofiler-sdk/source/lib/tests/buffering/user-ring-buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/buffering/user-ring-buffer.cpp
@@ -1,0 +1,180 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/common/container/user_ring_record_header_buffer.hpp"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdint>
+#include <fstream>
+#include <thread>
+#include <vector>
+
+namespace
+{
+using user_ring_buffer_t = rocprofiler::common::container::user_ring_record_header_buffer;
+
+struct test_record
+{
+    uint64_t tid      = 0;
+    uint64_t index    = 0;
+    uint64_t checksum = 0;
+    uint64_t pad[5]   = {};
+};
+
+test_record
+make_record(uint64_t tid, uint64_t index)
+{
+    auto ret     = test_record{};
+    ret.tid      = tid;
+    ret.index    = index;
+    ret.checksum = (tid << 32) ^ index ^ 0x9e3779b97f4a7c15ULL;
+    for(size_t i = 0; i < std::size(ret.pad); ++i)
+        ret.pad[i] = ret.checksum + i;
+    return ret;
+}
+}  // namespace
+
+TEST(user_ring_buffer, serial)
+{
+    constexpr auto num_records = 1024;
+    auto           buffer      = user_ring_buffer_t{num_records * (sizeof(test_record) + 128)};
+
+    for(uint64_t i = 0; i < num_records; ++i)
+    {
+        auto record = make_record(0, i);
+        ASSERT_TRUE(buffer.emplace(record));
+    }
+
+    EXPECT_EQ(buffer.get_num_record_headers(), num_records);
+
+    auto seen = size_t{0};
+    auto num_headers =
+        buffer.process_record_headers(std::true_type{}, [&](auto&& records) {
+            for(auto* header : records)
+            {
+                ASSERT_EQ(header->hash, typeid(test_record).hash_code());
+                auto* payload = static_cast<test_record*>(header->payload);
+                ASSERT_NE(payload, nullptr);
+                EXPECT_EQ(payload->checksum, make_record(payload->tid, payload->index).checksum);
+                ++seen;
+            }
+        });
+
+    EXPECT_EQ(num_headers, num_records);
+    EXPECT_EQ(seen, num_records);
+    EXPECT_TRUE(buffer.is_empty());
+}
+
+TEST(user_ring_buffer, parallel_per_thread_shards)
+{
+    constexpr auto num_threads        = 16;
+    constexpr auto records_per_thread = 256;
+    constexpr auto num_records        = num_threads * records_per_thread;
+
+    auto buffer = user_ring_buffer_t{num_records * (sizeof(test_record) + 128)};
+    auto ready  = std::atomic<uint32_t>{0};
+    auto go     = std::atomic<bool>{false};
+    auto thrs   = std::vector<std::thread>{};
+    thrs.reserve(num_threads);
+
+    for(uint64_t tid = 0; tid < num_threads; ++tid)
+    {
+        thrs.emplace_back([&, tid]() {
+            ready.fetch_add(1, std::memory_order_release);
+            while(!go.load(std::memory_order_acquire)) std::this_thread::yield();
+
+            for(uint64_t i = 0; i < records_per_thread; ++i)
+            {
+                auto record = make_record(tid, i);
+                ASSERT_TRUE(buffer.emplace(1, 1, record));
+            }
+        });
+    }
+
+    while(ready.load(std::memory_order_acquire) != num_threads) std::this_thread::yield();
+    go.store(true, std::memory_order_release);
+    for(auto& itr : thrs)
+        itr.join();
+
+    EXPECT_EQ(buffer.get_num_record_headers(), num_records);
+
+    auto seen = std::atomic<size_t>{0};
+    auto num_headers =
+        buffer.process_record_headers(std::true_type{}, [&](auto&& records) {
+            for(auto* header : records)
+            {
+                ASSERT_EQ(header->category, 1);
+                ASSERT_EQ(header->kind, 1);
+                auto* payload = static_cast<test_record*>(header->payload);
+                ASSERT_NE(payload, nullptr);
+                EXPECT_EQ(payload->checksum, make_record(payload->tid, payload->index).checksum);
+                seen.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+
+    EXPECT_EQ(num_headers, num_records);
+    EXPECT_EQ(seen.load(), num_records);
+}
+
+TEST(user_ring_buffer, save_load)
+{
+    constexpr auto num_records = 64;
+    auto           buffer      = user_ring_buffer_t{num_records * (sizeof(test_record) + 128)};
+
+    for(uint64_t i = 0; i < num_records; ++i)
+    {
+        auto record = make_record(7, i);
+        ASSERT_TRUE(buffer.emplace(record));
+    }
+
+    {
+        auto ofs =
+            std::fstream{"user-ring-buffer-save-load.dat", std::ios::out | std::ios::binary};
+        buffer.save(ofs);
+    }
+
+    ASSERT_EQ(buffer.clear(), num_records);
+    EXPECT_EQ(buffer.get_num_record_headers(), 0);
+
+    {
+        auto ifs =
+            std::fstream{"user-ring-buffer-save-load.dat", std::ios::in | std::ios::binary};
+        buffer.load(ifs);
+    }
+
+    EXPECT_EQ(buffer.get_num_record_headers(), num_records);
+
+    auto num_headers =
+        buffer.process_record_headers(std::false_type{}, [&](auto&& records) {
+            for(auto* header : records)
+            {
+                ASSERT_EQ(header->hash, typeid(test_record).hash_code());
+                auto* payload = static_cast<test_record*>(header->payload);
+                ASSERT_NE(payload, nullptr);
+                EXPECT_EQ(payload->checksum, make_record(payload->tid, payload->index).checksum);
+            }
+        });
+
+    EXPECT_EQ(num_headers, num_records);
+}


### PR DESCRIPTION
## Summary

Draft POC for using per-thread or per-producer user-space rings as the lowest-overhead common buffered-data transport for rocprofiler-sdk:

- process-private, page-aligned memory for the in-process fast path
- anonymous shared `mmap` storage mode as the first out-of-process storage POC
- stable existing buffered-services API as the compatibility constraint
- per-producer ordering instead of a globally contended insertion order
- existing callback ABI preserved by draining shard records into the current record-header pointer view

## POC Implementation

This PR is no longer docs-only. It adds an opt-in internal backend:

- `common::container::user_ring_record_header_buffer`
- `ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER` CMake option
- `ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER_SHARED_MMAP=1` runtime toggle for shared-mmap shard storage
- direct tests for serial writes, per-thread shards, zero-hash record delivery, and save/load
- existing `rocprofiler-sdk` buffer API test coverage with the experimental backend enabled and disabled

The default build keeps using `record_header_buffer`; the new backend is selected only when the experimental option is enabled.

## Benchmark Snapshot

Units are normalized: time is `ns/record`, footprint is `MiB`. Recommendation is based on lowest producer-side time overhead first, then least memory footprint.

The active LTTng rows were measured with a complete LTTng 2.14 userspace stack extracted under `/tmp`. The system install mixed `lttng-tools` 2.13 with `liblttng-ctl` 2.14, which made `lttng create` fail until the client, daemon, consumer, and libraries were matched.

| Producers | Transport | Emit | Drain | Total | Storage | Max RSS |
|---:|---|---:|---:|---:|---:|---:|
| 1 | Current | 24.518 | 2.498 | 27.016 | 136.07 | 141.81 |
| 1 | BPF-style | 17.299 | 13.874 | 31.173 | 12.01 | 17.83 |
| 1 | Ring private | 4.369 | 1.594 | 5.963 | 12.00 | 17.67 |
| 1 | Ring shared mmap | 4.335 | 1.574 | 5.909 | 12.00 | 17.91 |
| 1 | LTTng-UST active | 141.760 | 2.719 | 144.479 | 136.07 | 157.90 |
| 4 | Current | 243.692 | 2.558 | 246.250 | 136.07 | 141.96 |
| 4 | BPF-style | 167.720 | 13.020 | 180.740 | 12.01 | 17.97 |
| 4 | Ring private | 5.944 | 4.993 | 10.936 | 12.02 | 17.68 |
| 4 | Ring shared mmap | 5.970 | 3.345 | 9.315 | 12.02 | 17.79 |
| 4 | LTTng-UST active | 501.102 | 2.192 | 503.294 | 136.07 | 180.27 |
| 16 | Current | 260.940 | 2.484 | 263.424 | 136.07 | 142.28 |
| 16 | BPF-style | 150.954 | 16.893 | 167.847 | 12.01 | 18.00 |
| 16 | Ring private | 4.993 | 12.037 | 17.029 | 12.06 | 18.09 |
| 16 | Ring shared mmap | 5.519 | 5.655 | 11.174 | 12.06 | 18.04 |
| 16 | LTTng-UST active | 563.533 | 2.330 | 565.863 | 136.07 | 203.93 |

Interpretation: the shared-mmap ring is the best common in-process and out-of-process direction in this benchmark. It has the lowest total time at 1, 4, and 16 producers while staying in the same memory band as the BPF-style buffer.

The active LTTng run produced 258.93 MiB of CTF trace data for the three LTTng active rows.

## Known POC Limits

- Shared `mmap` mode is storage only; fd handoff, collector lifecycle, and control-plane negotiation are still follow-up work.
- Drain still materializes the existing record-header pointer view to preserve today’s callback ABI.
- Drain and reset are still disjoint from producers through the existing buffer synchronization; production work should move to committed-slot state and consumer cursors.
- Capacity is currently per shard for compatibility and simplicity; production work should add explicit per-producer footprint controls.

## Validation

- `git diff --check`
- `rst2pseudoxml --halt=warning projects/rocprofiler-sdk/source/docs/conceptual/user-ring-transport-proposal.rst /tmp/rocprofiler-user-ring-transport-proposal.xml`
- `cmake -S projects/rocprofiler-sdk -B /tmp/rocprofiler-user-ring-poc-build -DROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER=ON -DROCPROFILER_BUILD_TESTS=ON -DROCPROFILER_BUILD_SAMPLES=OFF -DROCPROFILER_BUILD_BENCHMARK=OFF -DROCPROFILER_BUILD_DOCS=OFF`
- `cmake --build /tmp/rocprofiler-user-ring-poc-build --target buffering-tests -j 16`
- `/tmp/rocprofiler-user-ring-poc-build/bin/buffering-tests`
- `ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER_SHARED_MMAP=1 /tmp/rocprofiler-user-ring-poc-build/bin/buffering-tests --gtest_filter=user_ring_buffer.*`
- `cmake --build /tmp/rocprofiler-user-ring-poc-build --target rocprofiler-sdk-lib-tests -j 16`
- `/tmp/rocprofiler-user-ring-poc-build/bin/rocprofiler-sdk-lib-tests --gtest_filter=rocprofiler_lib.buffer`
- `ROCPROFILER_EXPERIMENTAL_USER_RING_BUFFER_SHARED_MMAP=1 /tmp/rocprofiler-user-ring-poc-build/bin/rocprofiler-sdk-lib-tests --gtest_filter=rocprofiler_lib.buffer`
- default/off configure, build, and matching buffering/lib buffer tests
- `custom-ai-secret-scan` on touched files
- active LTTng benchmark with local `/tmp/lttng-2.14` stack and isolated `LTTNG_HOME`/`XDG_RUNTIME_DIR`

Full Sphinx docs build was not run because the local Python environment does not have Sphinx installed, and the repo docs target bootstraps Miniforge from the network.
