### PR TITLE
[ROCProfiler-SDK] Add LTTng-UST rocprofiler transport POC

### DIFF
--- a/projects/rocprofiler-sdk/cmake/rocprofiler_build_settings.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_build_settings.cmake
@@ -203,6 +203,12 @@ if(ROCPROFILER_BUILD_CI_STRICT_TIMESTAMPS)
                                            INTERFACE ROCPROFILER_CI_STRICT_TIMESTAMPS)
 endif()
 
+if(ROCPROFILER_EXPERIMENTAL_LTTNG_BUFFER_TRANSPORT)
+    rocprofiler_target_compile_definitions(
+        rocprofiler-sdk-build-flags INTERFACE
+        ROCPROFILER_EXPERIMENTAL_LTTNG_BUFFER_TRANSPORT)
+endif()
+
 # ----------------------------------------------------------------------------------------#
 # extra flags for compiling with experimental warnings
 #

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_options.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_options.cmake
@@ -101,6 +101,10 @@ rocprofiler_add_option(
     "Enable warnings for experimental features but hide with -Wno-deprecated-declarations (this ensures that experimental warning message does not break macros)"
     OFF
     ADVANCED)
+rocprofiler_add_option(
+    ROCPROFILER_EXPERIMENTAL_LTTNG_BUFFER_TRANSPORT
+    "Use experimental LTTng-UST shadow emission for rocprofiler buffers" OFF
+    ADVANCED)
 rocprofiler_add_option(ROCPROFILER_BUILD_DEPRECATED_WARNINGS
                        "Enable warnings for use of deprecated features" OFF ADVANCED)
 

--- a/projects/rocprofiler-sdk/source/docs/_toc.yml.in
+++ b/projects/rocprofiler-sdk/source/docs/_toc.yml.in
@@ -92,6 +92,7 @@ subtrees:
   - caption: Conceptual
     entries:
     - file: conceptual/comparing-with-legacy-tools
+    - file: conceptual/lttng-ust-transport-proposal
   - caption: License
     entries:
     - file: license

--- a/projects/rocprofiler-sdk/source/docs/conceptual/lttng-ust-transport-proposal.rst
+++ b/projects/rocprofiler-sdk/source/docs/conceptual/lttng-ust-transport-proposal.rst
@@ -63,13 +63,16 @@ rocprofiler-sdk payloads.
 Expected Tradeoffs
 ------------------
 
-When no LTTng session is active, the hot path should be close to one enabled
-flag load plus one unlikely branch per event. When a session is active, the
-producer writes into LTTng's user-space CTF buffers and the out-of-process
-consumer drains completed sub-buffers asynchronously. This is a good match for
-generic out-of-process subscription, but it is not free: it adds the
-``liblttng-ust`` dependency and does not directly satisfy the existing
-in-process callback ABI without the local buffer kept by this POC.
+When no LTTng session is active, the ideal tracepoint model is close to one
+enabled flag load plus one unlikely branch per event. The measured POC still
+shows producer-side overhead, especially with multiple producers, because every
+record takes the normal rocprofiler-sdk buffer path and then calls the LTTng-UST
+tracepoint. When a session is active, the producer writes into LTTng's user-space
+CTF buffers and the out-of-process consumer drains completed sub-buffers
+asynchronously. This is a good match for generic out-of-process subscription,
+but it is not free: it adds the ``liblttng-ust`` dependency and does not directly
+satisfy the existing in-process callback ABI without the local buffer kept by
+this POC.
 
 Compatibility Problem
 ---------------------

--- a/projects/rocprofiler-sdk/source/docs/conceptual/lttng-ust-transport-proposal.rst
+++ b/projects/rocprofiler-sdk/source/docs/conceptual/lttng-ust-transport-proposal.rst
@@ -91,10 +91,12 @@ Benchmark Snapshot
 The draft benchmark compares the existing buffer, the BPF-style buffer, the
 per-producer ring POC, and the LTTng-UST shadow-emission POC with 64-byte
 payload records, 131072 records per round, and 15 rounds. Time values are
-median nanoseconds per record. Footprint values are MiB. The LTTng row below is
-the no-active-session path; active-session measurement is still blocked on this
-test host because ``lttng create`` fails in the local session-daemon control
-path after spawning ``lttng-sessiond``.
+median nanoseconds per record. Footprint values are MiB. The active LTTng
+benchmark required a matched LTTng userspace stack: the test host had
+``lttng-tools`` 2.13 loading ``liblttng-ctl`` 2.14, which made the client and
+session daemon disagree on control command IDs. The active rows below were run
+with a complete LTTng 2.14 stack extracted under ``/tmp`` and an isolated
+``LTTNG_HOME``/``XDG_RUNTIME_DIR``.
 
 .. list-table::
    :header-rows: 1
@@ -141,6 +143,13 @@ path after spawning ``lttng-sessiond``.
      - 31.953
      - 136.07
      - 141.81
+   * - 1
+     - LTTng-UST active
+     - 141.760
+     - 2.719
+     - 144.479
+     - 136.07
+     - 157.90
    * - 4
      - Current
      - 243.692
@@ -176,6 +185,13 @@ path after spawning ``lttng-sessiond``.
      - 290.512
      - 136.07
      - 141.84
+   * - 4
+     - LTTng-UST active
+     - 501.102
+     - 2.192
+     - 503.294
+     - 136.07
+     - 180.27
    * - 16
      - Current
      - 260.940
@@ -211,11 +227,20 @@ path after spawning ``lttng-sessiond``.
      - 297.481
      - 136.07
      - 142.29
+   * - 16
+     - LTTng-UST active
+     - 563.533
+     - 2.330
+     - 565.863
+     - 136.07
+     - 203.93
 
 With the requested ranking, the benchmark keeps the per-producer user-space
 ring as the preferred common transport. It has the lowest producer-side time in
 both private-memory and shared-mmap forms and it keeps footprint near the
 BPF-style buffer. BPF-style storage remains interesting only when minimizing
 footprint is more important than producer time. LTTng-UST remains a separate
-out-of-process subscription experiment until active-session measurements show a
-competitive time cost.
+out-of-process subscription experiment: the active tracepoint path works and
+produced 258.93 MiB of CTF trace data for the three-row active benchmark run,
+but its measured producer-side time is higher than the ring and BPF-style
+proposals.

--- a/projects/rocprofiler-sdk/source/docs/conceptual/lttng-ust-transport-proposal.rst
+++ b/projects/rocprofiler-sdk/source/docs/conceptual/lttng-ust-transport-proposal.rst
@@ -71,6 +71,25 @@ generic out-of-process subscription, but it is not free: it adds the
 ``liblttng-ust`` dependency and does not directly satisfy the existing
 in-process callback ABI without the local buffer kept by this POC.
 
+Compatibility Problem
+---------------------
+
+LTTng introduces a packaging and backward-compatibility risk that the SDK does
+not control. During active-session benchmarking, the host installation had
+``lttng-tools`` 2.13 but ``liblttng-ctl0`` 2.14. That mixed userspace stack made
+the client and session daemon disagree on control command IDs: ``lttng create``
+failed with ``Session name not found`` even though the session daemon was
+spawned.
+
+The benchmark worked only after avoiding the system installation and running a
+complete matching LTTng 2.14 stack extracted under ``/tmp/lttng-2.14`` with
+isolated ``LTTNG_HOME`` and ``XDG_RUNTIME_DIR`` directories. A production
+rocprofiler-sdk LTTng transport would need to treat this as a real compatibility
+problem: it should validate the LTTng client, session daemon, consumer daemon,
+and libraries as a matched stack, document supported version ranges, and fail
+with a clear diagnostic when the installed LTTng control-plane ABI is
+inconsistent.
+
 Design Position
 ---------------
 

--- a/projects/rocprofiler-sdk/source/docs/conceptual/lttng-ust-transport-proposal.rst
+++ b/projects/rocprofiler-sdk/source/docs/conceptual/lttng-ust-transport-proposal.rst
@@ -1,0 +1,221 @@
+.. _lttng-ust-transport-proposal:
+
+LTTng-UST Transport Proposal
+============================
+
+This draft POC evaluates LTTng-UST as an out-of-process event delivery
+transport for rocprofiler-sdk records. It is motivated by the medium-term
+HIP/HSA emit-and-subscribe direction in the CPC tracing research branch:
+runtime producers emit typed events without naming rocprofiler-sdk as the
+consumer, and tools subscribe from another process.
+
+Decision Criteria
+-----------------
+
+Transport recommendations in this proposal family are ranked by the lowest
+producer-side time overhead first. Memory footprint is the second criterion.
+This ordering is intentional: adding latency to HIP/HSA dispatch paths is the
+most user-visible regression risk, while memory footprint matters most when two
+approaches are close on time overhead.
+
+Recommendation
+--------------
+
+For the common rocprofiler-sdk buffer path, the current recommendation remains
+the per-thread or per-producer user-space ring transport because it has the
+lowest measured producer-side time overhead. The BPF-style buffer improves
+footprint compared with the current buffer, but it still has shared producer
+contention. LTTng-UST is recommended only for the out-of-process generic
+subscription track, not as the lowest-overhead in-process callback backend.
+
+Why LTTng-UST Is Still Worth Testing
+------------------------------------
+
+LTTng-UST satisfies the constraints called out in the CPC tracing research:
+
+* no ``LD_PRELOAD`` requirement after the producer is linked with LTTng-UST,
+* no runtime text-segment modification when a consumer attaches,
+* late attach through ``lttng-sessiond``,
+* typed CTF metadata for event schemas,
+* out-of-process consumers.
+
+This PR therefore adds an experimental shadow-emission backend:
+
+* the current in-process ``record_header_buffer`` is retained for compatibility,
+* each successful record insertion also emits a typed LTTng-UST record envelope,
+* the public buffer callback ABI is unchanged,
+* the feature is selected only with
+  ``ROCPROFILER_EXPERIMENTAL_LTTNG_BUFFER_TRANSPORT``.
+
+The POC deliberately emits only a generic record envelope:
+
+* ``category``
+* ``kind``
+* ``hash``
+* ``payload_size``
+* ``payload_alignment``
+* ``sequence``
+
+A production design should use typed tracepoints for high-volume domains such
+as HIP API, HSA API, and kernel dispatch records instead of serializing opaque
+rocprofiler-sdk payloads.
+
+Expected Tradeoffs
+------------------
+
+When no LTTng session is active, the hot path should be close to one enabled
+flag load plus one unlikely branch per event. When a session is active, the
+producer writes into LTTng's user-space CTF buffers and the out-of-process
+consumer drains completed sub-buffers asynchronously. This is a good match for
+generic out-of-process subscription, but it is not free: it adds the
+``liblttng-ust`` dependency and does not directly satisfy the existing
+in-process callback ABI without the local buffer kept by this POC.
+
+Design Position
+---------------
+
+Based on the required ranking:
+
+#. lowest time overhead: per-producer user-space rings,
+#. next best footprint/time compromise: BPF-style shared buffer,
+#. best generic out-of-process subscription experiment: LTTng-UST.
+
+LTTng-UST should be evaluated as a runtime-to-tool delivery path for
+out-of-process consumers. It should not displace the per-producer ring as the
+preferred rocprofiler-sdk internal buffer transport unless benchmarks show a
+lower producer-side time cost.
+
+Benchmark Snapshot
+------------------
+
+The draft benchmark compares the existing buffer, the BPF-style buffer, the
+per-producer ring POC, and the LTTng-UST shadow-emission POC with 64-byte
+payload records, 131072 records per round, and 15 rounds. Time values are
+median nanoseconds per record. Footprint values are MiB. The LTTng row below is
+the no-active-session path; active-session measurement is still blocked on this
+test host because ``lttng create`` fails in the local session-daemon control
+path after spawning ``lttng-sessiond``.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Producers
+     - Transport
+     - Emit ns/record
+     - Drain ns/record
+     - Total ns/record
+     - Storage MiB
+     - Max RSS MiB
+   * - 1
+     - Current
+     - 24.518
+     - 2.498
+     - 27.016
+     - 136.07
+     - 141.81
+   * - 1
+     - BPF-style
+     - 17.299
+     - 13.874
+     - 31.173
+     - 12.01
+     - 17.83
+   * - 1
+     - Ring private
+     - 4.369
+     - 1.594
+     - 5.963
+     - 12.00
+     - 17.67
+   * - 1
+     - Ring shared mmap
+     - 4.335
+     - 1.574
+     - 5.909
+     - 12.00
+     - 17.91
+   * - 1
+     - LTTng-UST inactive
+     - 29.520
+     - 2.433
+     - 31.953
+     - 136.07
+     - 141.81
+   * - 4
+     - Current
+     - 243.692
+     - 2.558
+     - 246.250
+     - 136.07
+     - 141.96
+   * - 4
+     - BPF-style
+     - 167.720
+     - 13.020
+     - 180.740
+     - 12.01
+     - 17.97
+   * - 4
+     - Ring private
+     - 5.944
+     - 4.993
+     - 10.936
+     - 12.02
+     - 17.68
+   * - 4
+     - Ring shared mmap
+     - 5.970
+     - 3.345
+     - 9.315
+     - 12.02
+     - 17.79
+   * - 4
+     - LTTng-UST inactive
+     - 288.077
+     - 2.435
+     - 290.512
+     - 136.07
+     - 141.84
+   * - 16
+     - Current
+     - 260.940
+     - 2.484
+     - 263.424
+     - 136.07
+     - 142.28
+   * - 16
+     - BPF-style
+     - 150.954
+     - 16.893
+     - 167.847
+     - 12.01
+     - 18.00
+   * - 16
+     - Ring private
+     - 4.993
+     - 12.037
+     - 17.029
+     - 12.06
+     - 18.09
+   * - 16
+     - Ring shared mmap
+     - 5.519
+     - 5.655
+     - 11.174
+     - 12.06
+     - 18.04
+   * - 16
+     - LTTng-UST inactive
+     - 294.816
+     - 2.665
+     - 297.481
+     - 136.07
+     - 142.29
+
+With the requested ranking, the benchmark keeps the per-producer user-space
+ring as the preferred common transport. It has the lowest producer-side time in
+both private-memory and shared-mmap forms and it keeps footprint near the
+BPF-style buffer. BPF-style storage remains interesting only when minimizing
+footprint is more important than producer time. LTTng-UST remains a separate
+out-of-process subscription experiment until active-session measurements show a
+competitive time cost.

--- a/projects/rocprofiler-sdk/source/docs/index.rst
+++ b/projects/rocprofiler-sdk/source/docs/index.rst
@@ -64,6 +64,7 @@ The documentation is structured as follows:
   .. grid-item-card:: Conceptual
 
     * :ref:`comparing-with-legacy-tools`
+    * :ref:`lttng-ust-transport-proposal`
 
 To contribute to the documentation, refer to
 `Contributing to ROCm <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.

--- a/projects/rocprofiler-sdk/source/lib/common/container/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/common/container/CMakeLists.txt
@@ -15,5 +15,17 @@ set(containers_headers
 set(containers_sources ring_buffer.cpp record_header_buffer.cpp ring_buffer.cpp
                        small_vector.cpp)
 
+if(ROCPROFILER_EXPERIMENTAL_LTTNG_BUFFER_TRANSPORT)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(LTTNG_UST REQUIRED IMPORTED_TARGET lttng-ust)
+    list(APPEND containers_headers lttng_record_header_buffer.hpp
+                lttng_record_header_buffer_tracepoints.h)
+    list(APPEND containers_sources lttng_record_header_buffer.cpp)
+endif()
+
 target_sources(rocprofiler-sdk-common-library PRIVATE ${containers_sources}
                                                       ${containers_headers})
+
+if(ROCPROFILER_EXPERIMENTAL_LTTNG_BUFFER_TRANSPORT)
+    target_link_libraries(rocprofiler-sdk-common-library PRIVATE PkgConfig::LTTNG_UST)
+endif()

--- a/projects/rocprofiler-sdk/source/lib/common/container/lttng_record_header_buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/lttng_record_header_buffer.cpp
@@ -1,0 +1,65 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#define LTTNG_UST_TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+#include "lib/common/container/lttng_record_header_buffer.hpp"
+
+namespace rocprofiler::common::container
+{
+lttng_record_header_buffer::lttng_record_header_buffer(size_t nbytes) { allocate(nbytes); }
+
+lttng_record_header_buffer::lttng_record_header_buffer(
+    lttng_record_header_buffer&& rhs) noexcept
+{
+    this->operator=(std::move(rhs));
+}
+
+lttng_record_header_buffer&
+lttng_record_header_buffer::operator=(lttng_record_header_buffer&& rhs) noexcept
+{
+    if(this != &rhs)
+    {
+        m_buffer   = std::move(rhs.m_buffer);
+        m_sequence = rhs.m_sequence.exchange(0, std::memory_order_acq_rel);
+    }
+    return *this;
+}
+
+void
+lttng_record_header_buffer::emit(uint32_t category,
+                                 uint32_t kind,
+                                 uint64_t hash,
+                                 size_t   payload_size,
+                                 size_t   payload_alignment)
+{
+    auto sequence = m_sequence.fetch_add(1, std::memory_order_acq_rel);
+    lttng_ust_tracepoint(rocprofiler_sdk_buffer,
+                         record,
+                         category,
+                         kind,
+                         hash,
+                         payload_size,
+                         payload_alignment,
+                         sequence);
+}
+}  // namespace rocprofiler::common::container

--- a/projects/rocprofiler-sdk/source/lib/common/container/lttng_record_header_buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/lttng_record_header_buffer.cpp
@@ -45,6 +45,15 @@ lttng_record_header_buffer::operator=(lttng_record_header_buffer&& rhs) noexcept
     return *this;
 }
 
+uint64_t
+lttng_record_header_buffer::make_record_hash(uint32_t category, uint32_t kind)
+{
+    auto record     = rocprofiler_record_header_t{};
+    record.category = category;
+    record.kind     = kind;
+    return record.hash;
+}
+
 void
 lttng_record_header_buffer::emit(uint32_t category,
                                  uint32_t kind,

--- a/projects/rocprofiler-sdk/source/lib/common/container/lttng_record_header_buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/lttng_record_header_buffer.hpp
@@ -95,6 +95,8 @@ struct lttng_record_header_buffer
     auto is_full() const;
 
 private:
+    static uint64_t make_record_hash(uint32_t category, uint32_t kind);
+
     void emit(uint32_t category, uint32_t kind, uint64_t hash, size_t size, size_t alignment);
 
 private:
@@ -225,7 +227,7 @@ bool
 lttng_record_header_buffer::emplace(uint32_t category, uint32_t kind, Tp& value)
 {
     auto ret = m_buffer.emplace(category, kind, value);
-    if(ret) emit(category, kind, typeid(Tp).hash_code(), sizeof(Tp), alignof(Tp));
+    if(ret) emit(category, kind, make_record_hash(category, kind), sizeof(Tp), alignof(Tp));
     return ret;
 }
 

--- a/projects/rocprofiler-sdk/source/lib/common/container/lttng_record_header_buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/lttng_record_header_buffer.hpp
@@ -1,0 +1,248 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "lib/common/container/lttng_record_header_buffer_tracepoints.h"
+#include "lib/common/container/record_header_buffer.hpp"
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <typeinfo>
+#include <utility>
+
+namespace rocprofiler
+{
+namespace common
+{
+namespace container
+{
+/// @brief Experimental LTTng-UST shadow-emission backend for rocprofiler buffers.
+///
+/// The class keeps the existing in-process record_header_buffer semantics so the current
+/// buffered callback ABI remains valid, while also emitting a typed LTTng-UST record envelope
+/// for out-of-process subscription experiments.
+struct lttng_record_header_buffer
+{
+    using base_buffer_t    = record_header_buffer::base_buffer_t;
+    using record_vec_t     = record_header_buffer::record_vec_t;
+    using record_ptr_vec_t = record_header_buffer::record_ptr_vec_t;
+
+    lttng_record_header_buffer() = default;
+    explicit lttng_record_header_buffer(size_t nbytes);
+    ~lttng_record_header_buffer() = default;
+
+    lttng_record_header_buffer(const lttng_record_header_buffer&) = delete;
+    lttng_record_header_buffer(lttng_record_header_buffer&&) noexcept;
+
+    lttng_record_header_buffer& operator=(const lttng_record_header_buffer&) = delete;
+    lttng_record_header_buffer& operator=(lttng_record_header_buffer&&) noexcept;
+
+    bool allocate(size_t nbytes);
+    bool is_allocated() const;
+
+    template <typename Tp>
+    bool emplace(Tp&);
+
+    template <typename Tp>
+    bool emplace(uint64_t, Tp&);
+
+    template <typename Tp>
+    bool emplace(uint32_t, uint32_t, Tp&);
+
+    size_t get_num_record_headers();
+
+    template <typename ClearRecordsT, typename FuncT, typename... Args>
+    size_t process_record_headers(ClearRecordsT, FuncT&& functor, Args&&... args);
+
+    void lock();
+    void unlock();
+    void read_lock();
+    void read_unlock();
+    bool is_locked() const;
+
+    size_t clear();
+    void   save(std::fstream&);
+    void   load(std::fstream&);
+    size_t reset();
+
+    auto size() const;
+    auto capacity() const;
+    auto count() const;
+    auto free() const;
+    auto is_empty() const;
+    auto is_full() const;
+
+private:
+    void emit(uint32_t category, uint32_t kind, uint64_t hash, size_t size, size_t alignment);
+
+private:
+    record_header_buffer m_buffer   = {};
+    std::atomic<uint64_t> m_sequence = {0};
+};
+
+inline bool
+lttng_record_header_buffer::allocate(size_t nbytes)
+{
+    return m_buffer.allocate(nbytes);
+}
+
+inline bool
+lttng_record_header_buffer::is_allocated() const
+{
+    return m_buffer.is_allocated();
+}
+
+inline size_t
+lttng_record_header_buffer::get_num_record_headers()
+{
+    return m_buffer.get_num_record_headers();
+}
+
+inline void
+lttng_record_header_buffer::lock()
+{
+    m_buffer.lock();
+}
+
+inline void
+lttng_record_header_buffer::unlock()
+{
+    m_buffer.unlock();
+}
+
+inline void
+lttng_record_header_buffer::read_lock()
+{
+    m_buffer.read_lock();
+}
+
+inline void
+lttng_record_header_buffer::read_unlock()
+{
+    m_buffer.read_unlock();
+}
+
+inline bool
+lttng_record_header_buffer::is_locked() const
+{
+    return m_buffer.is_locked();
+}
+
+inline size_t
+lttng_record_header_buffer::clear()
+{
+    return m_buffer.clear();
+}
+
+inline void
+lttng_record_header_buffer::save(std::fstream& fs)
+{
+    m_buffer.save(fs);
+}
+
+inline void
+lttng_record_header_buffer::load(std::fstream& fs)
+{
+    m_buffer.load(fs);
+}
+
+inline size_t
+lttng_record_header_buffer::reset()
+{
+    m_sequence.store(0, std::memory_order_release);
+    return m_buffer.reset();
+}
+
+inline auto
+lttng_record_header_buffer::size() const
+{
+    return m_buffer.size();
+}
+
+inline auto
+lttng_record_header_buffer::capacity() const
+{
+    return m_buffer.capacity();
+}
+
+inline auto
+lttng_record_header_buffer::count() const
+{
+    return m_buffer.count();
+}
+
+inline auto
+lttng_record_header_buffer::free() const
+{
+    return m_buffer.free();
+}
+
+inline auto
+lttng_record_header_buffer::is_empty() const
+{
+    return m_buffer.is_empty();
+}
+
+inline auto
+lttng_record_header_buffer::is_full() const
+{
+    return m_buffer.is_full();
+}
+
+template <typename Tp>
+bool
+lttng_record_header_buffer::emplace(uint64_t hash, Tp& value)
+{
+    auto ret = m_buffer.emplace(hash, value);
+    if(ret) emit(0, 0, hash, sizeof(Tp), alignof(Tp));
+    return ret;
+}
+
+template <typename Tp>
+bool
+lttng_record_header_buffer::emplace(uint32_t category, uint32_t kind, Tp& value)
+{
+    auto ret = m_buffer.emplace(category, kind, value);
+    if(ret) emit(category, kind, typeid(Tp).hash_code(), sizeof(Tp), alignof(Tp));
+    return ret;
+}
+
+template <typename Tp>
+bool
+lttng_record_header_buffer::emplace(Tp& value)
+{
+    return emplace(typeid(Tp).hash_code(), value);
+}
+
+template <typename ClearRecordsT, typename FuncT, typename... Args>
+size_t
+lttng_record_header_buffer::process_record_headers(ClearRecordsT, FuncT&& functor, Args&&... args)
+{
+    return m_buffer.process_record_headers(
+        ClearRecordsT{}, std::forward<FuncT>(functor), std::forward<Args>(args)...);
+}
+}  // namespace container
+}  // namespace common
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/common/container/lttng_record_header_buffer_tracepoints.h
+++ b/projects/rocprofiler-sdk/source/lib/common/container/lttng_record_header_buffer_tracepoints.h
@@ -1,0 +1,61 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER rocprofiler_sdk_buffer
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE                                                        \
+    "lib/common/container/lttng_record_header_buffer_tracepoints.h"
+
+#if !defined(ROCPROFILER_SDK_LTTNG_RECORD_HEADER_BUFFER_TRACEPOINTS_H) ||                  \
+    defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#    define ROCPROFILER_SDK_LTTNG_RECORD_HEADER_BUFFER_TRACEPOINTS_H
+
+#    include <lttng/tracepoint.h>
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    rocprofiler_sdk_buffer,
+    record,
+    LTTNG_UST_TP_ARGS(uint32_t,
+                      category,
+                      uint32_t,
+                      kind,
+                      uint64_t,
+                      hash,
+                      uint64_t,
+                      payload_size,
+                      uint64_t,
+                      payload_alignment,
+                      uint64_t,
+                      sequence),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(uint32_t, category, category)
+                            lttng_ust_field_integer(uint32_t, kind, kind)
+                                lttng_ust_field_integer(uint64_t, hash, hash)
+                                    lttng_ust_field_integer(uint64_t, payload_size, payload_size)
+                                        lttng_ust_field_integer(
+                                            uint64_t, payload_alignment, payload_alignment)
+                                            lttng_ust_field_integer(uint64_t, sequence, sequence)))
+
+#endif
+
+#include <lttng/tracepoint-event.h>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/buffer.hpp
@@ -32,6 +32,7 @@
 #endif
 #include "lib/common/container/stable_vector.hpp"
 #include "lib/common/demangle.hpp"
+#include "lib/common/logging.hpp"
 
 #include <fmt/format.h>
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/buffer.hpp
@@ -25,7 +25,11 @@
 #include <rocprofiler-sdk/buffer.h>
 #include <rocprofiler-sdk/fwd.h>
 
-#include "lib/common/container/record_header_buffer.hpp"
+#if defined(ROCPROFILER_EXPERIMENTAL_LTTNG_BUFFER_TRANSPORT)
+#    include "lib/common/container/lttng_record_header_buffer.hpp"
+#else
+#    include "lib/common/container/record_header_buffer.hpp"
+#endif
 #include "lib/common/container/stable_vector.hpp"
 #include "lib/common/demangle.hpp"
 
@@ -44,7 +48,11 @@ namespace buffer
 {
 struct instance
 {
+#if defined(ROCPROFILER_EXPERIMENTAL_LTTNG_BUFFER_TRANSPORT)
+    using buffer_t = common::container::lttng_record_header_buffer;
+#else
     using buffer_t                       = common::container::record_header_buffer;
+#endif
     static constexpr auto size           = 2;  // double buffering
     static constexpr auto sync_wait_usec = std::chrono::microseconds{10};
 

--- a/projects/rocprofiler-sdk/source/lib/tests/buffering/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/tests/buffering/CMakeLists.txt
@@ -7,6 +7,10 @@ include(GoogleTest)
 
 set(buffering_sources buffering-serial.cpp buffering-parallel.cpp buffering-save-load.cpp)
 
+if(ROCPROFILER_EXPERIMENTAL_LTTNG_BUFFER_TRANSPORT)
+    list(APPEND buffering_sources lttng-buffer.cpp)
+endif()
+
 add_executable(buffering-tests)
 target_sources(buffering-tests PRIVATE ${buffering_sources})
 target_link_libraries(

--- a/projects/rocprofiler-sdk/source/lib/tests/buffering/lttng-buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/buffering/lttng-buffer.cpp
@@ -1,0 +1,135 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/common/container/lttng_record_header_buffer.hpp"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdint>
+#include <thread>
+#include <typeinfo>
+#include <vector>
+
+namespace
+{
+using lttng_buffer_t = rocprofiler::common::container::lttng_record_header_buffer;
+
+struct test_record
+{
+    uint64_t tid      = 0;
+    uint64_t index    = 0;
+    uint64_t checksum = 0;
+};
+
+test_record
+make_record(uint64_t tid, uint64_t index)
+{
+    return test_record{tid, index, (tid << 32U) ^ (index * 1315423911ULL)};
+}
+}  // namespace
+
+TEST(lttng_buffer, delegates_existing_buffer_abi)
+{
+    constexpr auto num_records = 128;
+    auto           buffer      = lttng_buffer_t{num_records * (sizeof(test_record) + 128)};
+
+    for(uint64_t i = 0; i < num_records; ++i)
+    {
+        auto record = make_record(3, i);
+        ASSERT_TRUE(buffer.emplace(record));
+    }
+
+    EXPECT_EQ(buffer.get_num_record_headers(), num_records);
+
+    auto seen = uint64_t{0};
+    auto num_headers =
+        buffer.process_record_headers(std::true_type{}, [&](auto&& records) {
+            for(auto* header : records)
+            {
+                ASSERT_EQ(header->hash, typeid(test_record).hash_code());
+                auto* payload = static_cast<test_record*>(header->payload);
+                ASSERT_NE(payload, nullptr);
+                EXPECT_EQ(payload->checksum, make_record(payload->tid, payload->index).checksum);
+                ++seen;
+            }
+        });
+
+    EXPECT_EQ(num_headers, num_records);
+    EXPECT_EQ(seen, num_records);
+    EXPECT_EQ(buffer.get_num_record_headers(), 0);
+}
+
+TEST(lttng_buffer, supports_parallel_producers)
+{
+    constexpr auto num_threads        = 8;
+    constexpr auto records_per_thread = 128;
+    constexpr auto num_records        = num_threads * records_per_thread;
+
+    auto buffer = lttng_buffer_t{num_records * (sizeof(test_record) + 128)};
+    auto ready  = std::atomic<int>{0};
+    auto start  = std::atomic<bool>{false};
+    auto threads = std::vector<std::thread>{};
+
+    threads.reserve(num_threads);
+    for(uint64_t tid = 0; tid < num_threads; ++tid)
+    {
+        threads.emplace_back([&, tid]() {
+            ready.fetch_add(1, std::memory_order_acq_rel);
+            while(!start.load(std::memory_order_acquire))
+            {}
+
+            for(uint64_t i = 0; i < records_per_thread; ++i)
+            {
+                auto record = make_record(tid, i);
+                ASSERT_TRUE(buffer.emplace(ROCPROFILER_BUFFER_CATEGORY_TRACING, tid, record));
+            }
+        });
+    }
+
+    while(ready.load(std::memory_order_acquire) != num_threads)
+    {}
+    start.store(true, std::memory_order_release);
+
+    for(auto& itr : threads)
+    {
+        itr.join();
+    }
+
+    EXPECT_EQ(buffer.get_num_record_headers(), num_records);
+
+    auto seen = std::atomic<uint64_t>{0};
+    auto num_headers =
+        buffer.process_record_headers(std::true_type{}, [&](auto&& records) {
+            for(auto* header : records)
+            {
+                ASSERT_EQ(header->category, ROCPROFILER_BUFFER_CATEGORY_TRACING);
+                auto* payload = static_cast<test_record*>(header->payload);
+                ASSERT_NE(payload, nullptr);
+                EXPECT_EQ(payload->checksum, make_record(payload->tid, payload->index).checksum);
+                seen.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+
+    EXPECT_EQ(num_headers, num_records);
+    EXPECT_EQ(seen.load(), num_records);
+}


### PR DESCRIPTION
## Summary

Draft POC for evaluating LTTng-UST as a rocprofiler-sdk buffer transport experiment:

- adds `ROCPROFILER_EXPERIMENTAL_LTTNG_BUFFER_TRANSPORT`
- preserves the existing `rocprofiler_record_header_t**` callback ABI
- keeps the current local buffer and shadow-emits a typed LTTng-UST record envelope on successful insert
- emits the same category/kind union hash in the LTTng envelope that the callback header exposes
- adds LTTng-specific buffering tests and a conceptual proposal doc

This is intentionally not proposed as the lowest-overhead in-process buffer backend. The recommendation ordering used in the docs is: lowest producer-side time overhead first, memory footprint second.

## Compatibility Problem

The active-session benchmark exposed a real LTTng backward-compatibility and packaging risk. The host installation had `lttng-tools` 2.13 but `liblttng-ctl0` 2.14, so the client and session daemon disagreed on control command IDs. In that mixed stack, `lttng create` failed with `Session name not found` even though the session daemon was spawned.

I avoided changing the system install by extracting a complete matching LTTng 2.14 stack into `/tmp/lttng-2.14` and running the active benchmark with isolated `LTTNG_HOME` and `XDG_RUNTIME_DIR`. A production rocprofiler-sdk LTTng transport would need to validate that the LTTng client, session daemon, consumer daemon, and libraries are a matched stack, document supported version ranges, and fail with a clear diagnostic when the control-plane ABI is inconsistent.

## Benchmark Snapshot

Units are normalized: time is `ns/record`, footprint is `MiB`.

The active LTTng rows were measured with a complete LTTng 2.14 userspace stack extracted under `/tmp`. The system install mixed `lttng-tools` 2.13 with `liblttng-ctl` 2.14, which made `lttng create` fail until the client, daemon, consumer, and libraries were matched.

| Producers | Transport | Emit | Drain | Total | Storage | Max RSS |
|---:|---|---:|---:|---:|---:|---:|
| 1 | Current | 24.518 | 2.498 | 27.016 | 136.07 | 141.81 |
| 1 | BPF-style | 17.299 | 13.874 | 31.173 | 12.01 | 17.83 |
| 1 | Ring private | 4.369 | 1.594 | 5.963 | 12.00 | 17.67 |
| 1 | Ring shared mmap | 4.335 | 1.574 | 5.909 | 12.00 | 17.91 |
| 1 | LTTng-UST active | 141.760 | 2.719 | 144.479 | 136.07 | 157.90 |
| 4 | Current | 243.692 | 2.558 | 246.250 | 136.07 | 141.96 |
| 4 | BPF-style | 167.720 | 13.020 | 180.740 | 12.01 | 17.97 |
| 4 | Ring private | 5.944 | 4.993 | 10.936 | 12.02 | 17.68 |
| 4 | Ring shared mmap | 5.970 | 3.345 | 9.315 | 12.02 | 17.79 |
| 4 | LTTng-UST active | 501.102 | 2.192 | 503.294 | 136.07 | 180.27 |
| 16 | Current | 260.940 | 2.484 | 263.424 | 136.07 | 142.28 |
| 16 | BPF-style | 150.954 | 16.893 | 167.847 | 12.01 | 18.00 |
| 16 | Ring private | 4.993 | 12.037 | 17.029 | 12.06 | 18.09 |
| 16 | Ring shared mmap | 5.519 | 5.655 | 11.174 | 12.06 | 18.04 |
| 16 | LTTng-UST active | 563.533 | 2.330 | 565.863 | 136.07 | 203.93 |

The active LTTng run produced 258.93 MiB of CTF trace data for the three LTTng active rows.

## Validation

- `git diff --check`
- `rst2pseudoxml --halt=warning projects/rocprofiler-sdk/source/docs/conceptual/lttng-ust-transport-proposal.rst /tmp/rocprofiler-lttng-ust-transport-proposal.xml`
- `cmake -S projects/rocprofiler-sdk -B /tmp/rocprofiler-lttng-poc-build -DROCPROFILER_EXPERIMENTAL_LTTNG_BUFFER_TRANSPORT=ON -DROCPROFILER_BUILD_TESTS=ON -DROCPROFILER_BUILD_SAMPLES=OFF -DROCPROFILER_BUILD_BENCHMARK=OFF -DROCPROFILER_BUILD_DOCS=OFF`
- `cmake --build /tmp/rocprofiler-lttng-poc-build --target buffering-tests -j 16`
- `/tmp/rocprofiler-lttng-poc-build/bin/buffering-tests`
- `cmake --build /tmp/rocprofiler-lttng-poc-build --target rocprofiler-sdk-lib-tests -j 16`
- `/tmp/rocprofiler-lttng-poc-build/bin/rocprofiler-sdk-lib-tests --gtest_filter=rocprofiler_lib.buffer`
- default/off configure, build, and matching buffering/lib buffer tests
- `custom-ai-secret-scan` on touched files
- active LTTng benchmark with local `/tmp/lttng-2.14` stack and isolated `LTTNG_HOME`/`XDG_RUNTIME_DIR`
