### PR TITLE
kpack: Limit wheel splitter jobs to 61 on Windows to avoid OS limit

### DIFF
--- a/shared/kpack/python/rocm_kpack/wheel_splitter.py
+++ b/shared/kpack/python/rocm_kpack/wheel_splitter.py
@@ -626,7 +626,9 @@ class WheelSplitter:
         self.compression = compression
         self.compression_level = compression_level
         self.verbose = verbose
-        self.jobs = max(1, jobs)
+        # Windows ProcessPoolExecutor caps at 61 (WaitForMultipleObjects limit).
+        max_jobs = 61 if os.name == "nt" else jobs
+        self.jobs = max(1, min(jobs, max_jobs))
         self.generate_variant_wheel = generate_variant_wheel
         self.variant_label = variant_label
 


### PR DESCRIPTION
## Motivation

Splitting of PyTorch wheels failed on Windows runners with 96 cores: https://github.com/ROCm/TheRock/actions/runs/24867494178/job/72842900379?pr=4783
```
Unexpected error: max_workers must be <= 61
Traceback (most recent call last):
  File "C:\home\runner\_work\TheRock\TheRock\rocm-systems\shared\kpack\python\rocm_kpack\tools\split_python_wheels.py", line 215, in main
    result = splitter.split(args.input, args.output_dir, args.output_format)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\home\runner\_work\TheRock\TheRock\rocm-systems\shared\kpack\python\rocm_kpack\wheel_splitter.py", line 658, in split
    return self._split_impl(wheel_root, output_dir, output_format)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\home\runner\_work\TheRock\TheRock\rocm-systems\shared\kpack\python\rocm_kpack\wheel_splitter.py", line 731, in _split_impl
    refs_by_arch = self._extract_kernels(fat_binaries, kernel_staging_dir)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\home\runner\_work\TheRock\TheRock\rocm-systems\shared\kpack\python\rocm_kpack\wheel_splitter.py", line 1274, in _extract_kernels
    with ProcessPoolExecutor(max_workers=self.jobs) as executor:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\home\runner\_work\_tool\Python\3.12.10\x64\Lib\concurrent\futures\process.py", line 682, in __init__
    raise ValueError(
ValueError: max_workers must be <= 61
```

This fixes that by limiting to 61.

## Technical Details

Docs: https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ProcessPoolExecutor
> On Windows, _max_workers_ must be less than or equal to `61`. If it is not then `ValueError` will be raised. If _max_workers_ is `None`, then the default chosen will be at most `61`, even if more processors are available.

## Test Plan

* Replaced `-j "$(nproc)"` with `-j 32` and ran successfully at https://github.com/ROCm/TheRock/actions/runs/24915005026
* I wanted to benchmark with different `-j` values locally but the CI jobs all deleted the unsplit wheels before uploading packages, so I would need to build packages from source to test more completely

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
