### PR TITLE
[RCCL] Fix --generate-sym-kernels with default --device-linker

### DIFF
--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -476,10 +476,57 @@ add_custom_command(
 )
 
 # ===========================================================================
+# Symmetric kernels: per-instantiation device TUs from gensrc/symmetric/.
+# Each instantiation file defines a handful of __global__ ncclSymkDevKernel_*
+# entries. Compiled standalone as multi-arch fat objects, mirroring onerank.o.
+#
+# RCCL_DEVICE_TABLE_OMIT mirrors what specialized .cpp files do: it suppresses
+# the cross-TU ncclDevFuncTable_2 emission inside common.h. Without this guard
+# each sym TU pulls in the table and demands ncclDevFunc_* definitions that
+# only live in other TUs, breaking amdgcn-link on stricter toolchains
+# (lld error: undefined hidden symbol: ncclDevFunc_*).
+#
+# Compile every .cpp under gensrc/symmetric/. Some files (all_gather.cpp)
+# define __global__ kernels directly; others (all_reduce.cpp, reduce_scatter.cpp)
+# are include-only stubs that compile to empty objects — harmless.
+#
+# SYM_FAT_OBJS is plural (vs the singular COMMON/ONERANK/COLLECTIVES_FAT_OBJ
+# siblings) because the symmetric generator emits one TU per instantiation.
+# ===========================================================================
+set(SYM_FAT_OBJS "")
+if(GENERATE_SYM_KERNELS)
+  file(GLOB _sym_srcs CONFIGURE_DEPENDS "${HIPIFY_DIR}/gensrc/symmetric/*.cpp")
+  foreach(_sym_src IN LISTS _sym_srcs)
+    get_filename_component(_sym_name "${_sym_src}" NAME_WE)
+    set(_sym_obj "${DEVICE_BUILD_DIR}/sym_${_sym_name}.o")
+    add_custom_command(
+      OUTPUT  ${_sym_obj}
+      COMMAND ${DL_CLANG}
+        -x hip ${DL_OFFLOAD_ARCH_FLAGS}
+        ${DL_HIP_COMPILER_FLAGS}
+        -DRCCL_DEVICE_LINKER
+        -DRCCL_DEVICE_TABLE_OMIT
+        ${_link_def_flags}
+        ${_host_inc_flags}
+        ${DL_OPT_FLAGS}
+        -std=c++17
+        -fPIC
+        -w
+        -c -o ${_sym_obj}
+        ${_sym_src}
+      DEPENDS ${_sym_src}
+      COMMENT "DL compile: sym ${_sym_name} (multi-arch fat object)"
+      VERBATIM
+    )
+    list(APPEND SYM_FAT_OBJS ${_sym_obj})
+  endforeach()
+endif()
+
+# ===========================================================================
 # Top-level target
 # ===========================================================================
 add_custom_target(device_linker_build ALL
-  DEPENDS ${COMMON_FAT_OBJ} ${ONERANK_FAT_OBJ} ${COLLECTIVES_FAT_OBJ}
+  DEPENDS ${COMMON_FAT_OBJ} ${ONERANK_FAT_OBJ} ${COLLECTIVES_FAT_OBJ} ${SYM_FAT_OBJS}
 )
 add_dependencies(device_linker_build hipify_all)
 
@@ -487,6 +534,7 @@ set(DEVICE_LINKER_OBJECTS
   ${COMMON_FAT_OBJ}
   ${ONERANK_FAT_OBJ}
   ${COLLECTIVES_FAT_OBJ}
+  ${SYM_FAT_OBJS}
 )
 
 # ===========================================================================

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -447,8 +447,8 @@ list(FILTER HIP_SOURCES EXCLUDE REGEX "gensrc/specialized/")
 # Device Linker: filter out device sources that are built by the pipeline
 #==================================================================================================
 if(ENABLE_DEVICE_LINKER)
-  # Remove per-collective .cpp files from gensrc/ (replaced by specialized pipeline)
-  list(FILTER HIP_SOURCES EXCLUDE REGEX "gensrc/[^/]*\\.cpp$")
+  # Remove per-collective .cpp files from gensrc/ and any subdirs (replaced by specialized/symmetric pipelines)
+  list(FILTER HIP_SOURCES EXCLUDE REGEX "gensrc/.*\\.cpp$")
   # Add back host-only generated files
   list(APPEND HIP_SOURCES "${GEN_DIR}/host_table.cpp")
   if(EXISTS "${GEN_DIR}/device_table.cpp")
@@ -458,7 +458,7 @@ if(ENABLE_DEVICE_LINKER)
   list(FILTER HIP_SOURCES EXCLUDE REGEX "common\\.cu\\.cpp$")
   list(FILTER HIP_SOURCES EXCLUDE REGEX "onerank\\.cu\\.cpp$")
   list(FILTER HIP_SOURCES EXCLUDE REGEX "collectives\\.cc$")
-  message(STATUS "Device Linker: filtered HIP_SOURCES (removed device .cpp, common.cu, onerank.cu, collectives.cc)")
+  message(STATUS "Device Linker: filtered HIP_SOURCES (removed device .cpp under gensrc/ + subdirs, common.cu, onerank.cu, collectives.cc)")
 endif()
 
 # Create an initial git_version.cpp file (that will be updated with latest git version)


### PR DESCRIPTION
## Summary

`./install.sh -l --generate-sym-kernels` with the default `--device-linker` was producing a librccl.so where symmetric kernels (e.g. `ncclSymkRun_AllReduce_AGxLL_R`) failed at launch with `hipErrorInvalidDeviceFunction` and undefined `__hip_fatbin_*` symbols. The only working combination was `--no-device-linker`.

The device-linker pipeline was introduced in #4795. This change extends it to cover the symmetric kernel TUs, which were left uncovered when the symmetric generator started emitting per-instantiation files into `gensrc/symmetric/`.

Two root causes:

- The HIP-source filter at `src/CMakeLists.txt:451` matched only `gensrc/[^/]*\.cpp$`, so the per-instantiation files under `gensrc/symmetric/` slipped through and were compiled host-only by the rccl target — producing host stubs that referenced fat-binary symbols nothing defined.
- There was no parallel device-pipeline branch for those files (unlike `common.cu.cpp`, `onerank.cu.cpp`, `collectives.cc`), so no device code ever got produced.

Fix:

- Broaden the gensrc filter regex to `gensrc/.*\.cpp$` so symmetric files are also excluded from the rccl host-only HIP pass.
- Add a `SYM_FAT_OBJS` block in `cmake/DeviceLinker.cmake` mirroring the `onerank.o` pattern: glob every `gensrc/symmetric/*.cpp`, compile each as a multi-arch fat object with `-DRCCL_DEVICE_TABLE_OMIT` (suppresses cross-TU `ncclDevFuncTable_2` emission that would otherwise demand undefined `ncclDevFunc_*` symbols and break amdgcn-link on stricter lld), and wire the resulting objects into `device_linker_build` and `DEVICE_LINKER_OBJECTS`.

Fixes AICOMRCCL-942.

## Why this slipped past CI

The bug only triggers when **both** `--device-linker` (default ON since #4795) **and** `--generate-sym-kernels` (default OFF) are enabled, **and** a symmetric kernel actually launches at runtime (which itself requires `NCCL_CUMEM_ENABLE=1`, `NCCL_CTA_POLICY=2`, and buffers registered via `ncclCommWindowRegister`). Specifically:

- No CI lane builds with `--generate-sym-kernels`, so the device-linker × sym combination was never exercised.
- The host build still succeeds — librccl.so links with undefined `__hip_fatbin_*` data symbols (the loader is tolerant of these); the failure only surfaces at kernel launch, and only when the symmetric path is actually selected.
- `--generate-sym-kernels` is opt-in for production, and the symmetric path needs all of the above runtime gates, so the typical RCCL test flow (rccl-tests with default env) bypasses it entirely.
- #4795 added the device-linker pipeline for `common.cu.cpp` / `onerank.cu.cpp` / `collectives.cc`, but the symmetric per-instantiation TUs hadn't yet been folded into the same pattern.

A `--generate-sym-kernels --device-linker` CI lane would have caught this; worth adding as a follow-up.

## Test plan

Verified end-to-end on ROCm 7.13 / MI300X:

- [x] `./install.sh -l --generate-sym-kernels` (default device linker) builds cleanly
- [x] `nm -D librccl.so | grep '__hip_fatbin' | grep ' U '` → empty
- [x] All `ncclSymkDevKernel_AllReduce_AGxLL_R_sum_*` mangled names present in `.hip_fatbin`
- [x] rccl-tests AllReduce sweep 4 B – 64 KB with `NCCL_CUMEM_ENABLE=1 RCCLT_USE_SYM=1`: `#wrong = 0` everywhere
- [x] A/B at 256 B: ring 22.6 µs → sym 8.76 µs (2.6×), matching the documented AGxLL_R signature
- [x] `--generate-sym-kernels --no-device-linker` (the previous workaround) still builds and behaves identically — no regression

## Risk

- `GENERATE_SYM_KERNELS=OFF` (default): no behavior change. The new block is gated on `if(GENERATE_SYM_KERNELS)` and `SYM_FAT_OBJS` stays empty.
- `ENABLE_DEVICE_LINKER=OFF` (legacy `--no-device-linker` path): untouched. The regex change is inside `if(ENABLE_DEVICE_LINKER)`.
- Only the previously broken combination (`--device-linker` + `--generate-sym-kernels`) changes behavior — from broken to working.