### PR TITLE
perfxpert: align agent architecture and exports

### DIFF
--- a/experimental/python/perfxpert/docs/architecture.md
+++ b/experimental/python/perfxpert/docs/architecture.md
@@ -23,7 +23,7 @@ flowchart TD
     root["Root<br/>intent router"]
     analysis["Analysis<br/>classifies bottlenecks + gathers metrics"]
     recommendation["Recommendation<br/>hands off to specialists"]
-    correctness["Correctness<br/>summarizes gate verdicts"]
+    correctness["Correctness<br/>narrates immutable gate verdicts"]
   end
 
   compute["compute_specialist"]
@@ -96,11 +96,14 @@ All five verified nightly via `.github/workflows/perfxpert-nightly.yml`.
 user  →  perfxpert analyze -i trace.db
         → perfxpert.agents.runtime.build_session(...)
         → session.run_root(RootInput(...))
-        → agent runtime (Root → Analysis → bottleneck.classify …)
-        → Recommendation hands off to specialist
-        → Correctness runs 5 gates
+        → RootOutput + deterministic analysis payload
         → formatters → text / json / markdown / html
 ```
+
+Recommendation is exercised on optimize flows. Gate-cascade middleware
+and Correctness are exercised on verify / code-change evaluation flows.
+Those paths are not part of the default `perfxpert analyze` summary
+path above.
 
 ### Interactive / backend TUIs
 
@@ -151,11 +154,15 @@ Level 0 — Knowledge YAML (PR)         pytest tests/test_knowledge
 
 ## Correctness gates (spec §5)
 
-1. **Claims** — magnitude within proven_optimizations range
-2. **Sakana** — hardware-counter sanity
-3. **Schema** — output shape valid
-4. **Regression** — no hot kernel regressed > 5% (weighted-geomean definition)
-5. **Correctness** — semantic preservation (structural)
+Current gate names match `perfxpert/runtime/gate_cascade.py`; see
+[architecture/gate-cascade.md](architecture/gate-cascade.md) for the
+full reject conditions and verdict semantics.
+
+1. **Compile** — reject on build failure
+2. **SOL sanity (anti-Sakana)** — reject implausible claimed speedups
+3. **Bitwise / Numeric** — reject output drift beyond tolerance
+4. **Regression (weighted-geomean)** — return `regressed` on total, tail, or hot-kernel regressions
+5. **Test Anchors** — when `candidate_binary` is present, reject if previously passing anchor tests now fail
 
 ## What's NOT in this diagram
 

--- a/experimental/python/perfxpert/perfxpert/agents/__init__.py
+++ b/experimental/python/perfxpert/perfxpert/agents/__init__.py
@@ -1,4 +1,4 @@
-"""Agent hierarchy — 8 agents on a deterministic tool floor (spec §2)."""
+"""PerfXpert agent package exports for the root, tier-1, and tier-2 roles."""
 
 from perfxpert.agents.runtime import AnalysisSession, build_session, DEFAULT_PROVIDER
 from perfxpert.agents.schemas import (
@@ -13,6 +13,7 @@ from perfxpert.agents.analysis import run_analysis, build_analysis_agent
 from perfxpert.agents.recommendation import run_recommendation, build_recommendation_agent
 from perfxpert.agents.correctness import run_correctness, build_correctness_agent
 from perfxpert.agents.compute_specialist import run_compute_specialist, build_compute_specialist
+from perfxpert.agents.diff_specialist import run_diff_specialist, build_diff_specialist
 from perfxpert.agents.memory_specialist import run_memory_specialist, build_memory_specialist
 from perfxpert.agents.latency_specialist import run_latency_specialist, build_latency_specialist
 
@@ -32,6 +33,7 @@ __all__ = [
     "run_recommendation", "build_recommendation_agent",
     "run_correctness", "build_correctness_agent",
     "run_compute_specialist", "build_compute_specialist",
+    "run_diff_specialist", "build_diff_specialist",
     "run_memory_specialist", "build_memory_specialist",
     "run_latency_specialist", "build_latency_specialist",
 ]

--- a/experimental/python/perfxpert/tests/test_agents/test_tool_allowlist_guardrail.py
+++ b/experimental/python/perfxpert/tests/test_agents/test_tool_allowlist_guardrail.py
@@ -12,6 +12,7 @@ from perfxpert.agents import (
     build_recommendation_agent,
     build_correctness_agent,
     build_compute_specialist,
+    build_diff_specialist,
     build_memory_specialist,
     build_latency_specialist,
 )
@@ -23,6 +24,7 @@ AGENT_BUILDERS = [
     build_recommendation_agent,
     build_correctness_agent,
     build_compute_specialist,
+    build_diff_specialist,
     build_memory_specialist,
     build_latency_specialist,
 ]
@@ -49,3 +51,10 @@ def test_no_execution_tool_in_allowlist(builder):
 def test_allowlist_within_cap(builder):
     agent = builder()
     assert len(agent.tools) <= 5, f"{agent.name} has {len(agent.tools)} tools (cap 5)"
+
+
+def test_agents_package_re_exports_diff_specialist_surface():
+    from perfxpert import agents
+
+    assert "build_diff_specialist" in agents.__all__
+    assert "run_diff_specialist" in agents.__all__


### PR DESCRIPTION
## Summary

Combines and supersedes:

- #5357
- #5358
- #5360

This rollup keeps the Diff specialist export cleanup and refreshes the PerfXpert agent architecture docs against current `develop`, including the Correctness gate wording and the deterministic batch CLI data-flow notes.

## Validation

- `env PYTHONPATH=experimental/python/perfxpert python3 -m pytest experimental/python/perfxpert/tests/test_agents/test_tool_allowlist_guardrail.py`
  - 17 passed
- `git diff --check origin/develop...HEAD`
- `custom-ai-secret-scan` on changed files

