### PR TITLE
perfxpert: consolidate packaging and portability cleanup

### DIFF
--- a/experimental/python/perfxpert/CMakeLists.txt
+++ b/experimental/python/perfxpert/CMakeLists.txt
@@ -41,11 +41,12 @@ if(PERFXPERT_INSTALL_PYTHON)
     endif()
 
     # Install the perfxpert Python package into the standard site-packages
+    # Dependencies are resolved by pip here; distro packaging can override
+    # this path when dependencies are provided by system packages instead.
     install(
         CODE "execute_process(
             COMMAND ${Python3_EXECUTABLE} -m pip install
                 --prefix \"\${CMAKE_INSTALL_PREFIX}\"
-                --no-deps
                 --no-build-isolation
                 \"${CMAKE_CURRENT_SOURCE_DIR}\"
             RESULT_VARIABLE _pip_result
@@ -53,13 +54,6 @@ if(PERFXPERT_INSTALL_PYTHON)
         if(NOT _pip_result EQUAL 0)
             message(FATAL_ERROR \"pip install failed: \${_pip_result}\")
         endif()"
-    )
-
-    # Also expose the entry-point script
-    install(
-        PROGRAMS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/perfxpert"
-        DESTINATION bin
-        OPTIONAL
     )
 endif()
 

--- a/experimental/python/perfxpert/perfxpert/cli/_backend/codex.py
+++ b/experimental/python/perfxpert/perfxpert/cli/_backend/codex.py
@@ -81,6 +81,7 @@ from perfxpert.cli._consent import (
     prompt_consent_interactive,
     revoke_consent,
 )
+from perfxpert.cli._paths import user_home
 
 
 __all__ = [
@@ -200,7 +201,7 @@ class CodexAdapter:
     # ------------------------------------------------------------------
 
     def _user_codex_config_path(self, home: Path | None = None) -> Path:
-        return (home or Path.home()) / self._CODEX_CFG_REL
+        return (home or user_home()) / self._CODEX_CFG_REL
 
     def _check_trust(
         self, cwd: Path, home: Path | None = None
@@ -255,7 +256,7 @@ class CodexAdapter:
         """Return the directory whose `config.toml` we should edit."""
         if scope == "project":
             return Path(cwd) / ".codex"
-        return Path.home() / ".codex"
+        return user_home() / ".codex"
 
     def _target_paths(
         self,

--- a/experimental/python/perfxpert/perfxpert/cli/_consent.py
+++ b/experimental/python/perfxpert/perfxpert/cli/_consent.py
@@ -32,6 +32,8 @@ from typing import Iterable
 
 import yaml
 
+from perfxpert.cli._paths import xdg_config_home
+
 
 __all__ = [
     "CONSENT_ASSUME_ENV",
@@ -55,10 +57,7 @@ CONSENT_ASSUME_ENV = "PERFXPERT_ASSUME_CONSENT"
 
 
 def _xdg_config_home() -> Path:
-    override = os.environ.get("XDG_CONFIG_HOME", "").strip()
-    if override:
-        return Path(override)
-    return Path.home() / ".config"
+    return xdg_config_home()
 
 
 def consent_path() -> Path:

--- a/experimental/python/perfxpert/perfxpert/cli/_paths.py
+++ b/experimental/python/perfxpert/perfxpert/cli/_paths.py
@@ -1,0 +1,22 @@
+"""Shared user path helpers for CLI config files."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def user_home() -> Path:
+    """Return the explicit HOME override when set, else the platform home."""
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        return Path(home).expanduser()
+    return Path.home()
+
+
+def xdg_config_home() -> Path:
+    """Return XDG_CONFIG_HOME, or HOME/.config when XDG is unset."""
+    override = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return user_home() / ".config"

--- a/experimental/python/perfxpert/pyproject.toml
+++ b/experimental/python/perfxpert/pyproject.toml
@@ -58,6 +58,7 @@ dev  = [
     "pexpect>=4.8",
     "pytest-xdist>=3.5",    # parallel red-team / parity execution
     "hypothesis>=6.100",    # property-based fuzz for sanitizer
+    "tomli>=2.0; python_version<'3.11'",
     "rich>=13.0",           # exit-dashboard rendering (already a runtime dep; dev pin kept for parity)
 ]
 

--- a/experimental/python/perfxpert/requirements-dev.txt
+++ b/experimental/python/perfxpert/requirements-dev.txt
@@ -10,3 +10,4 @@ black
 pexpect>=4.8
 pytest-xdist>=3.5
 hypothesis>=6.100
+tomli>=2.0; python_version < "3.11"

--- a/experimental/python/perfxpert/requirements-dev.txt
+++ b/experimental/python/perfxpert/requirements-dev.txt
@@ -1,10 +1,12 @@
-# perfxpert — development dependencies
-# Equivalent to: pip install -e ".[all,dev]"
+# perfxpert development install
+# Keep this fallback file in sync with pyproject.toml: project.dependencies + [all,dev].
+
 -r requirements.txt
 
-# Testing
-pytest
-
-# Linting / formatting
+pytest>=8.0
+pytest-asyncio>=0.21
 flake8
 black
+pexpect>=4.8
+pytest-xdist>=3.5
+hypothesis>=6.100

--- a/experimental/python/perfxpert/requirements.txt
+++ b/experimental/python/perfxpert/requirements.txt
@@ -13,3 +13,4 @@ anthropic>=0.18
 openai>=1.0
 rich>=13.0
 litellm>=1.50
+python-dotenv>=1.2.2

--- a/experimental/python/perfxpert/requirements.txt
+++ b/experimental/python/perfxpert/requirements.txt
@@ -1,16 +1,15 @@
-# perfxpert — full installation (LLM providers + rich output)
-# Equivalent to: pip install -e ".[all]"
-#
-# Core analysis works with stdlib only (zero mandatory deps).
-# Install this file to enable all optional features.
+# perfxpert full runtime install
+# Keep this fallback file in sync with pyproject.toml: project.dependencies + [all].
 
-# LLM providers
+pydantic>=2.0
+pyyaml>=6.0
+jsonschema>=4.0
+httpx>=0.25
+mcp>=1.0
+numpy>=1.24
+openai-agents>=0.1
+tomlkit>=0.12
 anthropic>=0.18
 openai>=1.0
-
-# Rich terminal output
 rich>=13.0
-
-# --llm anthropic|openai|ollama|private|opencode are the supported
-# provider values; configure keys via ANTHROPIC_API_KEY / OPENAI_API_KEY /
-# PERFXPERT_LLM_PRIVATE_API_KEY (see docs/guides/getting-started.md §10).
+litellm>=1.50

--- a/experimental/python/perfxpert/scripts/test-samples.py
+++ b/experimental/python/perfxpert/scripts/test-samples.py
@@ -6,6 +6,7 @@ Part of the docs-audit tooling
 
 import os
 import re
+import shutil
 import subprocess
 import sys
 import json
@@ -94,12 +95,12 @@ def extract_samples(doc_path: Path) -> List[Dict[str, Any]]:
     return samples
 
 
-def run_bash_sample(code: str) -> Dict[str, Any]:
+def run_bash_sample(code: str, bash: str) -> Dict[str, Any]:
     """Execute a bash sample."""
     try:
         result = subprocess.run(
-            code,
-            shell=True,
+            [bash, "-lc", code],
+            shell=False,
             capture_output=True,
             text=True,
             timeout=10,
@@ -131,7 +132,7 @@ def run_python_sample(code: str) -> Dict[str, Any]:
     """
     try:
         result = subprocess.run(
-            ['python3', '-c', code],
+            [sys.executable, '-c', code],
             capture_output=True,
             text=True,
             timeout=10,
@@ -173,7 +174,12 @@ def run_sample(sample: Dict[str, Any]) -> Dict[str, Any]:
 
     # Run sample
     if sample['type'] == 'bash':
-        result = run_bash_sample(code)
+        bash = shutil.which("bash")
+        if bash is None:
+            sample['status'] = 'SKIPPED'
+            sample['reason'] = 'bash not found on PATH'
+            return sample
+        result = run_bash_sample(code, bash)
     elif sample['type'] == 'python':
         result = run_python_sample(code)
     else:

--- a/experimental/python/perfxpert/tests/e2e/test_mcp_tool_coverage.py
+++ b/experimental/python/perfxpert/tests/e2e/test_mcp_tool_coverage.py
@@ -14,6 +14,7 @@ Each test asserts structural correctness of the JSON response and key values.
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Any, Dict
@@ -27,13 +28,9 @@ import pytest
 
 def _perfxpert_mcp_path() -> Path:
     """Locate the perfxpert-mcp entry point."""
-    result = subprocess.run(
-        ["which", "perfxpert-mcp"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode == 0:
-        return Path(result.stdout.strip())
+    found = shutil.which("perfxpert-mcp")
+    if found:
+        return Path(found)
     raise RuntimeError(
         "perfxpert-mcp not found in PATH. Install with: pip install -e ."
     )

--- a/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_adapter.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_adapter.py
@@ -109,6 +109,12 @@ def _mark_trusted(home: Path, cwd: Path) -> None:
     )
 
 
+def test_codex_user_paths_honor_home_env(isolated_home: Path, project_cwd: Path) -> None:
+    adapter = CodexAdapter()
+    assert adapter._user_codex_config_path() == isolated_home / ".codex" / "config.toml"
+    assert adapter._scope_config_dir(project_cwd, "user") == isolated_home / ".codex"
+
+
 def _fake_codex_subprocess(
     *,
     list_exit: int = 0,

--- a/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_adapter.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_adapter.py
@@ -514,7 +514,7 @@ def test_install_uses_tomlkit_lazy_import_in_fallback(
     # `import tomlkit` + accesses an attr, we blow up loudly.
     _sys.modules["tomlkit"] = _Sentinel()  # type: ignore[assignment]
     try:
-        CodexAdapter().install(project_cwd, scope="project")
+        CodexAdapter().install(project_cwd, scope="user")
     finally:
         # Restore original tomlkit binding (or clear).
         if original is None:
@@ -538,9 +538,9 @@ def test_structured_edit_fallback_uses_tomlkit(
         _fake_codex_subprocess(add_exit=1, list_stdout=b""),
     )
 
-    CodexAdapter().install(project_cwd, scope="project")
-    # Project-scope config.toml should exist + contain mcp_servers.perfxpert.
-    cfg = project_cwd / ".codex" / "config.toml"
+    CodexAdapter().install(project_cwd, scope="user")
+    # User-scope fallback config.toml should exist + contain mcp_servers.perfxpert.
+    cfg = isolated_home / ".codex" / "config.toml"
     assert cfg.is_file()
     text = cfg.read_text()
     assert "[mcp_servers.perfxpert]" in text or "perfxpert" in text

--- a/experimental/python/perfxpert/tests/test_cli/test_consent.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_consent.py
@@ -261,7 +261,7 @@ def test_home_isolation_defaults_to_dot_config(
     monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
     p = consent_path()
     assert str(tmp_path) in str(p)
-    assert ".config/perfxpert/consent.yaml" in str(p)
+    assert p == tmp_path / ".config" / "perfxpert" / "consent.yaml"
 
 
 def test_grant_does_not_touch_other_home(

--- a/experimental/python/perfxpert/tests/test_integration/test_mcp_protocol.py
+++ b/experimental/python/perfxpert/tests/test_integration/test_mcp_protocol.py
@@ -15,6 +15,7 @@ the server in isolation, avoiding MCP SDK client dependencies.
 """
 
 import json
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -25,13 +26,9 @@ import pytest
 
 def _perfxpert_mcp_path() -> Path:
     """Locate the perfxpert-mcp entry point."""
-    result = subprocess.run(
-        ["which", "perfxpert-mcp"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode == 0:
-        return Path(result.stdout.strip())
+    found = shutil.which("perfxpert-mcp")
+    if found:
+        return Path(found)
     raise RuntimeError(
         "perfxpert-mcp not found in PATH. Install with: pip install -e ."
     )

--- a/experimental/python/perfxpert/tests/test_packaging/test_bundled_licenses.py
+++ b/experimental/python/perfxpert/tests/test_packaging/test_bundled_licenses.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
-import tomllib
 from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    import tomli as tomllib
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/experimental/python/perfxpert/tests/test_packaging/test_cmake_install.py
+++ b/experimental/python/perfxpert/tests/test_packaging/test_cmake_install.py
@@ -1,0 +1,17 @@
+"""Static checks for the CMake-driven perfxpert install path."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CMAKELISTS = REPO_ROOT / "CMakeLists.txt"
+
+
+def test_cmake_install_lets_pip_resolve_dependencies():
+    text = CMAKELISTS.read_text(encoding="utf-8")
+    assert "--no-deps" not in text
+
+
+def test_cmake_install_does_not_reference_missing_script():
+    text = CMAKELISTS.read_text(encoding="utf-8")
+    assert "scripts/perfxpert" not in text

--- a/experimental/python/perfxpert/tests/test_packaging/test_requirements_sync.py
+++ b/experimental/python/perfxpert/tests/test_packaging/test_requirements_sync.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
-import tomllib
 from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    import tomli as tomllib
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/experimental/python/perfxpert/tests/test_packaging/test_requirements_sync.py
+++ b/experimental/python/perfxpert/tests/test_packaging/test_requirements_sync.py
@@ -1,0 +1,40 @@
+"""Checks that fallback requirements files mirror pyproject metadata."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _requirement_names(path: Path) -> set[str]:
+    names: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("-r "):
+            continue
+        names.add(line.split(";", 1)[0].split("[", 1)[0].split("=", 1)[0].split("<", 1)[0].split(">", 1)[0])
+    return names
+
+
+def _pyproject_names(extra: str | None = None) -> set[str]:
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    values = list(data["project"].get("dependencies", []))
+    if extra:
+        values.extend(data["project"]["optional-dependencies"][extra])
+    return {
+        value.split(";", 1)[0].split("[", 1)[0].split("=", 1)[0].split("<", 1)[0].split(">", 1)[0]
+        for value in values
+    }
+
+
+def test_requirements_txt_matches_full_runtime_dependencies():
+    assert _requirement_names(REPO_ROOT / "requirements.txt") == _pyproject_names("all")
+
+
+def test_requirements_dev_txt_matches_dev_dependencies():
+    expected = _pyproject_names("all") | _pyproject_names("dev")
+    actual = _requirement_names(REPO_ROOT / "requirements.txt") | _requirement_names(REPO_ROOT / "requirements-dev.txt")
+    assert actual == expected

--- a/experimental/python/perfxpert/tests/test_red_team/test_path_traversal.py
+++ b/experimental/python/perfxpert/tests/test_red_team/test_path_traversal.py
@@ -8,6 +8,13 @@ from perfxpert.tools import patch_mgr
 from perfxpert.tools._safety import PathConfinementError
 
 
+def _symlink_or_skip(link: Path, target: Path) -> None:
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink creation unavailable on this host: {exc}")
+
+
 TRAVERSAL_PAYLOADS = [
     "../../../etc/passwd",
     "../outside",
@@ -29,7 +36,7 @@ def test_symlink_escape_rejected(tmp_path: Path):
     outside = tmp_path.parent / "outside_target.txt"
     outside.write_text("target\n")
     inside = tmp_path / "link.cpp"
-    inside.symlink_to(outside)
+    _symlink_or_skip(inside, outside)
 
     with pytest.raises(PathConfinementError):
         patch_mgr.apply(tmp_path, "link.cpp", "malicious\n")
@@ -40,9 +47,9 @@ def test_symlink_chain_escape_rejected(tmp_path: Path):
     outside = tmp_path.parent / "outside_final.txt"
     outside.write_text("target\n")
     middle = tmp_path.parent / "outside_middle"
-    middle.symlink_to(outside)
+    _symlink_or_skip(middle, outside)
     inside = tmp_path / "chain.cpp"
-    inside.symlink_to(middle)
+    _symlink_or_skip(inside, middle)
 
     with pytest.raises(PathConfinementError):
         patch_mgr.apply(tmp_path, "chain.cpp", "malicious\n")

--- a/experimental/python/perfxpert/tests/test_scripts/test_sample_runner.py
+++ b/experimental/python/perfxpert/tests/test_scripts/test_sample_runner.py
@@ -1,0 +1,45 @@
+"""Tests for scripts/test-samples.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "test-samples.py"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("test_samples_script", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_python_samples_use_current_interpreter(monkeypatch):
+    module = _load_script()
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    result = module.run_python_sample("print('ok')")
+
+    assert result["passed"] is True
+    assert captured["argv"][:2] == [sys.executable, "-c"]
+
+
+def test_bash_sample_skips_when_bash_missing(monkeypatch):
+    module = _load_script()
+    monkeypatch.setattr(module.shutil, "which", lambda _: None)
+
+    result = module.run_sample({"type": "bash", "code": "echo ok"})
+
+    assert result["status"] == "SKIPPED"
+    assert result["reason"] == "bash not found on PATH"

--- a/experimental/python/perfxpert/tests/test_tools/test_safety.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_safety.py
@@ -7,6 +7,13 @@ import pytest
 from perfxpert.tools import _safety
 
 
+def _symlink_or_skip(link: Path, target: Path) -> None:
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink creation unavailable on this host: {exc}")
+
+
 # -- confine_to_project_root ------------------------------------------------
 
 def test_confine_to_project_root_accepts_relative(tmp_path: Path):
@@ -31,7 +38,7 @@ def test_confine_to_project_root_resolves_symlink_escape(tmp_path: Path):
     """Symlink pointing outside the project root must be rejected."""
     outside = tmp_path.parent / "outside_target"
     outside.write_text("hi")
-    (tmp_path / "link").symlink_to(outside)
+    _symlink_or_skip(tmp_path / "link", outside)
     with pytest.raises(_safety.PathConfinementError):
         _safety.confine_to_project_root(tmp_path, "link")
 


### PR DESCRIPTION
## Summary

Combines and supersedes:

- #5387
- #5390
- #5391
- #5392
- #5393

This rollup consolidates packaging and portability work:

- CMake install dependency resolution
- fallback requirements and license metadata sync
- hermetic documentation sample runner behavior
- platform-sensitive test cleanup
- HOME-aware CLI config path handling
- Python 3.10-compatible packaging tests via `tomli`
- Codex backend tests aligned with scoped MCP registration

## Validation

- `env PYTHONPATH=experimental/python/perfxpert python3 -m pytest experimental/python/perfxpert/tests/test_packaging experimental/python/perfxpert/tests/test_scripts/test_sample_runner.py experimental/python/perfxpert/tests/test_red_team/test_path_traversal.py experimental/python/perfxpert/tests/test_tools/test_safety.py experimental/python/perfxpert/tests/test_cli/test_backend/test_codex_adapter.py experimental/python/perfxpert/tests/test_cli/test_consent.py`
  - 114 passed
- `env PYTHONPATH=experimental/python/perfxpert python3 -m pytest experimental/python/perfxpert/tests/test_packaging/test_requirements_sync.py experimental/python/perfxpert/tests/test_packaging/test_bundled_licenses.py`
  - 3 passed
- `git diff --check origin/develop...HEAD`
- `custom-ai-secret-scan` on changed files

Note: broader live MCP protocol tests were not included in the pass criteria because the current local `perfxpert-mcp` process hung on raw initialize during exploratory validation.

