### PR TITLE
perfxpert: guard git installer user-site deps

### DIFF
--- a/experimental/python/perfxpert/README.md
+++ b/experimental/python/perfxpert/README.md
@@ -37,7 +37,9 @@ The wrapper installs from GitHub, scopes submodule init to the pinned
 PerfXpert `opencode` submodule, and bootstraps bun when needed. It
 builds the patched bundled `perfxpert-code` binary and verifies it before exiting.
 No separate `opencode` install is needed for the default `perfxpert-code`
-TUI. See [docs/guides/getting-started.md](docs/guides/getting-started.md)
+TUI. The wrapper refuses dependency installs outside an active virtual
+environment by default because the LLM provider extras can update shared
+Python packages in the user site. See [docs/guides/getting-started.md](docs/guides/getting-started.md)
 for the Ubuntu/RHEL/SLES package matrix, direct-pip equivalent, editable
 installs, and troubleshooting.
 

--- a/experimental/python/perfxpert/docs/guides/getting-started.md
+++ b/experimental/python/perfxpert/docs/guides/getting-started.md
@@ -167,6 +167,15 @@ pip/editable paths use the same `setup.py` build hook: pip bootstraps
 bun when the OS prerequisites are available, or fails with a
 distro-specific prerequisite message when they are not.
 
+The wrapper intentionally refuses dependency installs outside an active
+virtual environment unless `--allow-user-site` is passed. The default
+LLM extras include LiteLLM and the OpenAI Agents SDK; those packages can
+pin shared dependencies such as `openai`, `pydantic`, `jsonschema`,
+`aiohttp`, and `click`, so installing them into the user site can update
+or downgrade unrelated Python tools. If the dependencies are already
+present and only the PerfXpert package needs to be refreshed, use
+`--extras '' --no-deps`.
+
 ### 1.2 Why the wrapper: scoped submodule init
 
 `pip install "perfxpert @ git+https://...rocm-systems.git#subdirectory=..."`

--- a/experimental/python/perfxpert/scripts/pip-install-from-git.sh
+++ b/experimental/python/perfxpert/scripts/pip-install-from-git.sh
@@ -5,7 +5,7 @@
 # Usage:
 #   bash scripts/pip-install-from-git.sh
 #   bash scripts/pip-install-from-git.sh v0.2.0
-#   bash scripts/pip-install-from-git.sh <SHA> --user
+#   bash scripts/pip-install-from-git.sh <SHA> --allow-user-site --user
 #   bash scripts/pip-install-from-git.sh --extras '' --no-deps
 #
 # Notes:
@@ -53,13 +53,16 @@ while scoping git submodule init down to the opencode subtree only.
 Usage:
   bash scripts/pip-install-from-git.sh
   bash scripts/pip-install-from-git.sh v0.2.0
-  bash scripts/pip-install-from-git.sh <SHA> --user
+  bash scripts/pip-install-from-git.sh <SHA> --allow-user-site --user
   bash scripts/pip-install-from-git.sh --extras '' --no-deps
 
 Options:
   --extras <name>   Optional extras to install (default: all).
                     Use `--extras ''` to install the base package only.
   --repo-url <url>  Override the git remote (default: ROCm/rocm-systems).
+  --allow-user-site Allow dependency installation outside a virtualenv.
+                    This can update or downgrade packages in the active
+                    Python/user site. Prefer a virtualenv.
   -h, --help        Show this help.
 
 Interpreter selection:
@@ -345,6 +348,8 @@ fi
 _REF=""
 _EXTRAS="all"
 _REPO_URL="${_DEFAULT_REPO_URL}"
+_ALLOW_USER_SITE="0"
+_PIP_NO_DEPS="0"
 declare -a _PIP_ARGS=()
 
 while [ "$#" -gt 0 ]; do
@@ -363,9 +368,21 @@ while [ "$#" -gt 0 ]; do
       _REPO_URL="$2"
       shift 2
       ;;
+    --allow-user-site)
+      _ALLOW_USER_SITE="1"
+      shift
+      ;;
+    --no-deps)
+      _PIP_NO_DEPS="1"
+      _PIP_ARGS+=("$1")
+      shift
+      ;;
     --)
       shift
       while [ "$#" -gt 0 ]; do
+        if [ "$1" = "--no-deps" ]; then
+          _PIP_NO_DEPS="1"
+        fi
         _PIP_ARGS+=("$1")
         shift
       done
@@ -402,6 +419,32 @@ if [[ "${_REPO_URL}" == file://* ]]; then
   _SPEC="${_VCS_TARGET}#egg=${_PACKAGE}&subdirectory=${_SUBDIRECTORY}"
 else
   _SPEC="${_PACKAGE} @ ${_VCS_TARGET}#subdirectory=${_SUBDIRECTORY}"
+fi
+
+if [ "${_IN_VENV}" != "1" ] && [ "${_ALLOW_USER_SITE}" != "1" ] && [ "${_PIP_NO_DEPS}" != "1" ]; then
+  {
+    cat <<'EOF'
+pip-install-from-git: refusing to install dependencies into a non-virtualenv Python.
+
+The default `perfxpert[all]` install includes LLM provider packages such as
+LiteLLM and the OpenAI Agents SDK. Those packages may pin shared dependencies
+like openai, pydantic, jsonschema, aiohttp, and click, so installing them into
+the user site can update or downgrade tools unrelated to PerfXpert.
+
+Create and activate a virtual environment first:
+EOF
+    _print_python_prereqs
+    cat <<'EOF'
+
+If you intentionally want to mutate this Python environment, rerun with:
+  --allow-user-site
+
+If the dependencies are already present and you only want to refresh
+PerfXpert itself, rerun with:
+  --extras '' --no-deps
+EOF
+  } >&2
+  exit 2
 fi
 
 echo "pip-install-from-git: installing ${_SPEC}" >&2

--- a/experimental/python/perfxpert/tests/test_integration/test_install_docs.py
+++ b/experimental/python/perfxpert/tests/test_integration/test_install_docs.py
@@ -57,6 +57,7 @@ def test_install_wrapper_help_mentions_supported_prereqs() -> None:
     assert "pip build hook bootstraps bun" in result.stdout
     assert "package-manager install" in result.stdout
     assert "It never downloads" in result.stdout
+    assert "--allow-user-site" in result.stdout
     assert "command -v curl >/dev/null || dnf install -y curl" in result.stdout
     assert "dnf install -y git unzip python3.11 python3.11-pip" in result.stdout
     assert "dnf install -y git unzip python3 python3-pip" in result.stdout
@@ -78,6 +79,7 @@ def test_install_wrapper_help_works_from_stdin() -> None:
     assert "pip build hook bootstraps bun" in result.stdout
     assert "package-manager install" in result.stdout
     assert "It never downloads" in result.stdout
+    assert "--allow-user-site" in result.stdout
     assert "command -v curl >/dev/null || dnf install -y curl" in result.stdout
     assert "dnf install -y git unzip python3.11 python3.11-pip" in result.stdout
     assert "zypper install -y curl git unzip python311 python311-pip" in result.stdout
@@ -498,6 +500,182 @@ exit 99
     assert "dnf install -y git unzip python3.11 python3.11-pip" in result.stderr
     assert "dnf install -y git unzip python3 python3-pip" in result.stderr
     assert "zypper install -y curl git unzip python311 python311-pip" in result.stderr
+
+
+def test_install_wrapper_rejects_non_venv_dependency_install(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "python3",
+        f"""#!/bin/bash
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  echo "pip 24.0"
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+  echo "pip install should not run" >&2
+  exit 88
+fi
+if [ "$1" = "-c" ]; then
+  case "$2" in
+    *"sys.version_info"*)
+      exit 0
+      ;;
+    *'sys.prefix != getattr(sys, "base_prefix", sys.prefix)'*)
+      echo 0
+      exit 0
+      ;;
+    *'sysconfig.get_path("stdlib")'*)
+      echo "{tmp_path / 'missing-externally-managed'}"
+      exit 0
+      ;;
+  esac
+fi
+exit 99
+""",
+    )
+    _symlink_tool(bin_dir, "curl")
+    _symlink_tool(bin_dir, "unzip")
+    _symlink_tool(bin_dir, "cat")
+    _symlink_tool(bin_dir, "git")
+
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER), "develop"],
+        capture_output=True,
+        text=True,
+        env=_env_with_path(bin_dir),
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "refusing to install dependencies into a non-virtualenv Python" in result.stderr
+    assert "LiteLLM and the OpenAI Agents SDK" in result.stderr
+    assert "openai, pydantic, jsonschema, aiohttp, and click" in result.stderr
+    assert "--allow-user-site" in result.stderr
+    assert "--extras '' --no-deps" in result.stderr
+    assert "pip install should not run" not in result.stderr
+
+
+def test_install_wrapper_allow_user_site_is_explicit_escape_hatch(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    bundled = tmp_path / "site-packages" / "perfxpert" / "_bundled" / "opencode"
+    bundled.parent.mkdir(parents=True)
+    bundled.write_text("fake-opencode", encoding="utf-8")
+    bundled.chmod(0o755)
+    pip_args = tmp_path / "pip-args.txt"
+    _write_executable(
+        bin_dir / "python3",
+        f"""#!/bin/bash
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  echo "pip 24.0"
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+  printf '%s\\n' "$*" > "{pip_args}"
+  exit 0
+fi
+if [ "$1" = "-c" ]; then
+  case "$2" in
+    *"sys.version_info"*)
+      exit 0
+      ;;
+    *'sys.prefix != getattr(sys, "base_prefix", sys.prefix)'*)
+      echo 0
+      exit 0
+      ;;
+    *'sysconfig.get_path("stdlib")'*)
+      echo "{tmp_path / 'missing-externally-managed'}"
+      exit 0
+      ;;
+    *'resources.files("perfxpert")'*)
+      echo "{bundled}"
+      exit 0
+      ;;
+  esac
+fi
+exit 99
+""",
+    )
+    _symlink_tool(bin_dir, "curl")
+    _symlink_tool(bin_dir, "unzip")
+    _symlink_tool(bin_dir, "cat")
+    _symlink_tool(bin_dir, "git")
+
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER), "develop", "--allow-user-site"],
+        capture_output=True,
+        text=True,
+        env=_env_with_path(bin_dir),
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "bundled patched perfxpert-code ready" in result.stderr
+    text = pip_args.read_text(encoding="utf-8")
+    assert "--allow-user-site" not in text
+    assert "perfxpert[all] @ git+https://github.com/ROCm/rocm-systems.git@develop" in text
+
+
+def test_install_wrapper_no_deps_can_refresh_base_package_outside_venv(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    bundled = tmp_path / "site-packages" / "perfxpert" / "_bundled" / "opencode"
+    bundled.parent.mkdir(parents=True)
+    bundled.write_text("fake-opencode", encoding="utf-8")
+    bundled.chmod(0o755)
+    pip_args = tmp_path / "pip-args.txt"
+    _write_executable(
+        bin_dir / "python3",
+        f"""#!/bin/bash
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "--version" ]; then
+  echo "pip 24.0"
+  exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ] && [ "$3" = "install" ]; then
+  printf '%s\\n' "$*" > "{pip_args}"
+  exit 0
+fi
+if [ "$1" = "-c" ]; then
+  case "$2" in
+    *"sys.version_info"*)
+      exit 0
+      ;;
+    *'sys.prefix != getattr(sys, "base_prefix", sys.prefix)'*)
+      echo 0
+      exit 0
+      ;;
+    *'sysconfig.get_path("stdlib")'*)
+      echo "{tmp_path / 'missing-externally-managed'}"
+      exit 0
+      ;;
+    *'resources.files("perfxpert")'*)
+      echo "{bundled}"
+      exit 0
+      ;;
+  esac
+fi
+exit 99
+""",
+    )
+    _symlink_tool(bin_dir, "curl")
+    _symlink_tool(bin_dir, "unzip")
+    _symlink_tool(bin_dir, "cat")
+    _symlink_tool(bin_dir, "git")
+
+    result = subprocess.run(
+        ["/bin/bash", str(_INSTALL_WRAPPER), "develop", "--extras", "", "--no-deps"],
+        capture_output=True,
+        text=True,
+        env=_env_with_path(bin_dir),
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    text = pip_args.read_text(encoding="utf-8")
+    assert "--no-deps" in text
+    assert "perfxpert @ git+https://github.com/ROCm/rocm-systems.git@develop" in text
+    assert "perfxpert[all]" not in text
 
 
 def test_install_wrapper_reports_ready_bundle_from_pip_build(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Refuse default GitHub wrapper dependency installs outside an active virtualenv.
- Add an explicit `--allow-user-site` escape hatch for intentional user-site mutation.
- Preserve the `--extras '' --no-deps` refresh path for updating only PerfXpert when dependencies are already present.
- Document why the guard exists: LiteLLM/OpenAI Agents extras can pin shared packages such as openai, pydantic, jsonschema, aiohttp, and click.

## Validation
- `bash -n experimental/python/perfxpert/scripts/pip-install-from-git.sh`
- `env PYTHONPATH=experimental/python/perfxpert python3 -m pytest -q experimental/python/perfxpert/tests/test_integration/test_install_docs.py` -> `22 passed`
- `env PYTHONPATH=experimental/python/perfxpert python3 -m pytest -q experimental/python/perfxpert/tests/test_docs_tooling/test_ship_readiness.py experimental/python/perfxpert/tests/test_integration/test_docs_links.py` -> `6 passed`
- `git diff --check`
- Local non-venv wrapper invocation exits before pip can install dependencies.

## Publish guard
- Repo-local `scripts/secret-scan.sh` was absent in this checkout.
- Approved fallback `custom-ai-secret-scan` failed on the full monorepo with `Argument list too long`.
- Approved fallback `custom-ai-secret-scan` passed on the four changed PR files.

## JIRA ID
N/A