### PR TITLE
[rocprofiler-sdk] Add rocprofv3 lite trace path

### DIFF
--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -473,6 +473,11 @@ For attachment profiling of running processes:
     )
     add_parser_bool_argument(
         basic_tracing_options,
+        "--lite-trace",
+        help="Collect only kernel dispatch names and timestamps by setting ROCPROF_LITE_TRACE=1 for the profiled process. This option is mutually exclusive with all other trace services.",
+    )
+    add_parser_bool_argument(
+        basic_tracing_options,
         "--memory-copy-trace",
         help="For collecting Memory Copy Traces. This was part of HIP and HSA traces in previous rocprof versions but is now a separate option",
     )
@@ -1131,7 +1136,8 @@ def parse_input(input_file):
 
     _, extension = os.path.splitext(input_file)
     if extension == ".txt" or extension == ".text":
-        warning("""
+        warning(
+            """
             Text file format for counter collection is deprecated and will be removed in a future release.
             Please use JSON or YAML format instead.
 
@@ -1148,7 +1154,8 @@ def parse_input(input_file):
 
             JSON file (recommended):
                 {"jobs":[{"pmc": ["SQ_WAVES"]},{ "pmc":["GRBM_COUNT"]}]}
-            """)
+            """
+        )
         text_input = parse_text(input_file)
         text_input_lst = [{"pmc": itr, "sub_directory": "pmc_"} for itr in text_input]
         return [dotdict(itr) for itr in text_input_lst]
@@ -1354,6 +1361,16 @@ def run(app_args, args, **kwargs):
                 except Exception as e:
                     fatal_error(f"{e}\n")
 
+    def env_is_enabled(env_var):
+        return str(app_env.get(env_var, "")).strip().lower() in (
+            "1",
+            "true",
+            "t",
+            "yes",
+            "y",
+            "on",
+        )
+
     def setattrifnone(obj, attr, value):
         if getattr(obj, f"{attr}") is None:
             setattr(obj, f"{attr}", value)
@@ -1546,6 +1563,42 @@ def run(app_args, args, **kwargs):
         for itr in ("core", "amd", "image", "finalizer"):
             setattrifnone(args, f"hsa_{itr}_trace", True)
 
+    lite_trace_enabled = env_is_enabled("ROCPROF_LITE_TRACE") or bool(args.lite_trace)
+    if lite_trace_enabled:
+        setattrifnone(args, "kernel_trace", True)
+
+        incompatible = (
+            "runtime_trace",
+            "sys_trace",
+            "hip_trace",
+            "hip_runtime_trace",
+            "hip_compiler_trace",
+            "hsa_trace",
+            "hsa_core_trace",
+            "hsa_amd_trace",
+            "hsa_image_trace",
+            "hsa_finalizer_trace",
+            "marker_trace",
+            "rccl_trace",
+            "rocdecode_trace",
+            "rocjpeg_trace",
+            "memory_copy_trace",
+            "memory_allocation_trace",
+            "kfd_trace",
+            "kfd_page_migration_trace",
+            "kfd_page_mapping_trace",
+            "kfd_queue_trace",
+            "kfd_dropped_events_trace",
+            "scratch_memory_trace",
+            "advanced_thread_trace",
+            "pc_sampling_beta_enabled",
+        )
+        for opt in incompatible:
+            if hasattr(args, opt) and getattr(args, opt):
+                fatal_error(
+                    f"--lite-trace/ROCPROF_LITE_TRACE only supports kernel tracing; disable --{opt.replace('_', '-')}"
+                )
+
     if args.kfd_trace:
         for itr in ("page_migration", "page_mapping", "queue", "dropped_events"):
             setattrifnone(args, f"kfd_{itr}_trace", True)
@@ -1579,6 +1632,8 @@ def run(app_args, args, **kwargs):
         update_env(f"ROCPROF_{env_val}", val, overwrite_if_true=True)
         trace_count += 1 if val else 0
         trace_opts += ["--{}".format(opt.replace("_", "-"))]
+
+    update_env("ROCPROF_LITE_TRACE", lite_trace_enabled, overwrite_if_true=True)
 
     for opt in ["advanced_thread_trace", "pmc", "pc_sampling_beta_enabled"]:
         if not hasattr(args, f"{opt}"):

--- a/projects/rocprofiler-sdk/source/lib/common/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/common/CMakeLists.txt
@@ -27,6 +27,7 @@ set(common_headers
     environment.hpp
     filesystem.hpp
     hasher.hpp
+    lite_trace_internal.hpp
     logging.hpp
     md5sum.hpp
     mpl.hpp

--- a/projects/rocprofiler-sdk/source/lib/common/lite_trace_internal.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/lite_trace_internal.hpp
@@ -1,0 +1,247 @@
+// MIT License
+//
+/* Copyright (c) 2026 Advanced Micro Devices, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE. */
+
+#pragma once
+
+#include "lib/common/environment.hpp"
+
+#include <rocprofiler-sdk/buffer_tracing.h>
+#include <rocprofiler-sdk/callback_tracing.h>
+#include <rocprofiler-sdk/fwd.h>
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <initializer_list>
+
+namespace rocprofiler
+{
+namespace common
+{
+namespace lite_trace
+{
+inline bool
+enabled()
+{
+    return ::rocprofiler::common::get_env("ROCPROF_LITE_TRACE", false);
+}
+
+inline bool
+is_allowed_buffer_tracing_kind(rocprofiler_buffer_tracing_kind_t kind)
+{
+    return kind == ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH;
+}
+
+inline bool
+is_allowed_callback_tracing_kind(rocprofiler_callback_tracing_kind_t kind)
+{
+    return kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT;
+}
+
+struct kernel_dispatch_record_t
+{
+    rocprofiler_thread_id_t            thread_id = 0;
+    rocprofiler_timestamp_t            start     = 0;
+    rocprofiler_timestamp_t            end       = 0;
+    rocprofiler_kernel_dispatch_info_t dispatch_info{};
+};
+
+constexpr uint64_t record_store_magic    = 0x52504c4954453031ULL;
+constexpr uint64_t record_store_capacity = 1ULL << 20;
+
+struct record_store_header_t
+{
+    uint64_t magic    = 0;
+    uint64_t pid      = 0;
+    uint64_t capacity = 0;
+    uint64_t count    = 0;
+};
+
+struct mapped_record_store_t
+{
+    record_store_header_t*    header  = nullptr;
+    kernel_dispatch_record_t* records = nullptr;
+    size_t                    bytes   = 0;
+};
+
+inline size_t
+record_store_bytes()
+{
+    return sizeof(record_store_header_t) +
+           (record_store_capacity * sizeof(kernel_dispatch_record_t));
+}
+
+inline std::array<char, 128>
+record_store_path(const char* directory)
+{
+    auto path = std::array<char, 128>{};
+    std::snprintf(path.data(),
+                  path.size(),
+                  "%s/rocprofiler-lite-trace-%ld.records",
+                  directory,
+                  long{getpid()});
+    return path;
+}
+
+inline mapped_record_store_t
+map_record_store_at(const std::array<char, 128>& path, bool create_if_missing)
+{
+    const auto bytes = record_store_bytes();
+    auto       flags = O_RDWR | O_CLOEXEC;
+
+    if(create_if_missing) flags |= O_CREAT;
+
+    auto fd = ::open(path.data(), flags, S_IRUSR | S_IWUSR);
+    if(fd < 0) return {};
+
+    auto cleanup_fd = [&fd]() {
+        if(fd >= 0)
+        {
+            ::close(fd);
+            fd = -1;
+        }
+    };
+
+    struct stat statbuf = {};
+    if(::fstat(fd, &statbuf) != 0)
+    {
+        cleanup_fd();
+        return {};
+    }
+
+    const bool resize = statbuf.st_size != static_cast<off_t>(bytes);
+    if(resize && create_if_missing && ::ftruncate(fd, static_cast<off_t>(bytes)) != 0)
+    {
+        cleanup_fd();
+        return {};
+    }
+
+    if(resize && !create_if_missing)
+    {
+        cleanup_fd();
+        return {};
+    }
+
+    void* mapping = ::mmap(nullptr, bytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    cleanup_fd();
+
+    if(mapping == MAP_FAILED) return {};
+
+    auto* header  = static_cast<record_store_header_t*>(mapping);
+    auto* records = reinterpret_cast<kernel_dispatch_record_t*>(header + 1);
+
+    const auto pid = static_cast<uint64_t>(getpid());
+    if(create_if_missing || header->magic != record_store_magic || header->pid != pid ||
+       header->capacity != record_store_capacity)
+    {
+        std::memset(mapping, 0, bytes);
+        header->magic    = record_store_magic;
+        header->pid      = pid;
+        header->capacity = record_store_capacity;
+        __atomic_store_n(&header->count, 0, __ATOMIC_RELAXED);
+    }
+
+    return mapped_record_store_t{header, records, bytes};
+}
+
+inline mapped_record_store_t
+map_record_store(bool create_if_missing)
+{
+    for(const auto* directory : {"/dev/shm", "/tmp"})
+    {
+        auto store = map_record_store_at(record_store_path(directory), create_if_missing);
+        if(store.header && store.records) return store;
+    }
+
+    return {};
+}
+
+inline mapped_record_store_t&
+append_record_store()
+{
+    static auto store = map_record_store(true);
+    return store;
+}
+
+inline mapped_record_store_t&
+read_record_store()
+{
+    static auto store = map_record_store(false);
+    return store;
+}
+
+inline bool
+record_store_available()
+{
+    auto& store = append_record_store();
+    return store.header && store.records;
+}
+
+inline bool
+record_try_append(const kernel_dispatch_record_t& record)
+{
+    auto& store = append_record_store();
+    if(!store.header || !store.records) return false;
+
+    auto idx = __atomic_fetch_add(&store.header->count, 1, __ATOMIC_RELAXED);
+    if(idx >= record_store_capacity) return false;
+
+    store.records[idx] = record;
+    return true;
+}
+
+inline const kernel_dispatch_record_t*
+records(uint64_t* count)
+{
+    auto& store = read_record_store();
+    if(!store.header || !store.records)
+    {
+        if(count) *count = 0;
+        return nullptr;
+    }
+
+    auto available = std::min<uint64_t>(__atomic_load_n(&store.header->count, __ATOMIC_ACQUIRE),
+                                        record_store_capacity);
+    if(count) *count = available;
+    return store.records;
+}
+
+inline void
+unlink_record_store()
+{
+    for(const auto* directory : {"/dev/shm", "/tmp"})
+    {
+        const auto path = record_store_path(directory);
+        ::unlink(path.data());
+    }
+}
+}  // namespace lite_trace
+}  // namespace common
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -33,6 +33,7 @@
 #include "lib/common/demangle.hpp"
 #include "lib/common/filesystem.hpp"
 #include "lib/common/hasher.hpp"
+#include "lib/common/lite_trace_internal.hpp"
 #include "lib/common/logging.hpp"
 #include "lib/common/md5sum.hpp"
 #include "lib/common/mpl.hpp"
@@ -62,11 +63,14 @@
 #include <dlfcn.h>
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cctype>
 #include <chrono>
 #include <filesystem>
 #include <initializer_list>
 #include <limits>
+#include <memory>
+#include <mutex>
 #include <set>
 #include <type_traits>
 #include <unordered_map>
@@ -136,10 +140,10 @@ struct rocpd_db
 
     rocpd_db() = default;
     ~rocpd_db();
-    rocpd_db(const rocpd_db&) = delete;
+    rocpd_db(const rocpd_db&)            = delete;
     rocpd_db& operator=(const rocpd_db&) = delete;
     rocpd_db(rocpd_db&&)                 = delete;
-    rocpd_db& operator=(rocpd_db&&) = delete;
+    rocpd_db& operator=(rocpd_db&&)      = delete;
 
     sqlite3*            conn                = nullptr;
     std::string         uuid                = {};
@@ -884,7 +888,7 @@ extract_flags_field(const Tp& _data)
 
 #define GENERATE_FIELD_ACCESSOR(FUNC_NAME, FIELD_NAME, DATA_TYPE, ...)                             \
     template <typename Tp, typename Up = Tp>                                                       \
-    auto FUNC_NAME(const Tp& _data, int)->decltype(std::declval<Up>().FIELD_NAME, DATA_TYPE{})     \
+    auto FUNC_NAME(const Tp& _data, int) -> decltype(std::declval<Up>().FIELD_NAME, DATA_TYPE{})   \
     {                                                                                              \
         return _data.FIELD_NAME;                                                                   \
     }                                                                                              \
@@ -905,6 +909,262 @@ GENERATE_FIELD_ACCESSOR(extract_stream_field, stream_id, rocprofiler_stream_id_t
 GENERATE_FIELD_ACCESSOR(extract_queue_field, queue_id, rocprofiler_queue_id_t, 0)
 GENERATE_FIELD_ACCESSOR(extract_allocation_size_field, allocation_size, uint64_t, 0)
 GENERATE_FIELD_ACCESSOR(extract_address_field, address, rocprofiler_address_t, 0)
+
+void
+write_fast_rocpd(
+    const output_config&                                               cfg,
+    const metadata&                                                    tool_metadata,
+    const generator<tool_buffer_tracing_kernel_dispatch_ext_record_t>& kernel_dispatch_gen)
+{
+    static auto get_simple_timer = [](std::string_view label) {
+        return common::simple_timer{fmt::format("SQLite3 fast-path :: {:24}", label)};
+    };
+
+    auto _sqlgenperf = get_simple_timer("total");
+
+    auto node_hash =
+        get_hash_id(tool_metadata.node_data.machine_id) % std::numeric_limits<int64_t>::max();
+    auto node_id = node_hash % std::numeric_limits<uint32_t>::max();
+
+    const uint64_t this_pid         = tool_metadata.process_id;
+    const uint64_t this_ppid        = tool_metadata.parent_process_id;
+    const uint64_t this_pid_init_ns = tool_metadata.process_start_ns;
+
+    const auto& mach_id = tool_metadata.node_data.machine_id;
+    auto        ticks   = common::get_process_start_ticks_since_boot(this_pid);
+    auto        seed    = common::compute_system_seed(mach_id, this_pid, this_ppid, ticks);
+    auto        uuid_v7 = common::generate_uuid_v7(this_pid_init_ns, seed);
+
+    auto      db   = rocpd_db{};
+    sqlite3*& conn = db.conn;
+
+    db.guid = fmt::format("{}", uuid_v7);
+    db.uuid = fmt::format("_{}", replace_all(uuid_v7, '-', "_"));
+
+    auto output_file = get_output_filename(cfg, "results", "db");
+    if(fs::exists(output_file)) fs::remove(output_file);
+
+    SQLITE3_CHECK(sqlite3_open_v2(
+        output_file.c_str(), &conn, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr));
+    SQLITE3_CHECK(sqlite3_busy_handler(conn, &sql::busy_handler, nullptr));
+
+    execute_raw_sql_statements(conn,
+                               "PRAGMA journal_mode = WAL;"
+                               "PRAGMA synchronous = OFF;"
+                               "PRAGMA cache_size = -65536;");
+
+    ROCP_ERROR << fmt::format("Opened fast-path result file: {} (UUID={})", output_file, uuid_v7);
+
+    auto ddl = fmt::format(
+        R"sql(
+CREATE TABLE rocpd_metadata{0} (
+    tag TEXT NOT NULL,
+    value TEXT
+);
+CREATE TABLE rocpd_string{0} (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    guid TEXT NOT NULL DEFAULT "{1}",
+    string TEXT NOT NULL UNIQUE
+);
+CREATE TABLE rocpd_info_kernel_symbol{0} (
+    id INTEGER NOT NULL PRIMARY KEY,
+    guid TEXT NOT NULL DEFAULT "{1}",
+    nid INTEGER NOT NULL,
+    pid INTEGER NOT NULL,
+    code_object_id INTEGER,
+    kernel_name TEXT,
+    display_name TEXT,
+    kernel_object INTEGER,
+    extdata JSONB NOT NULL DEFAULT "{{}}"
+);
+CREATE TABLE rocpd_kernel_dispatch{0} (
+    id INTEGER NOT NULL PRIMARY KEY,
+    guid TEXT NOT NULL DEFAULT "{1}",
+    nid INTEGER NOT NULL,
+    pid INTEGER NOT NULL,
+    tid INTEGER,
+    agent_id INTEGER NOT NULL,
+    kernel_id INTEGER NOT NULL,
+    dispatch_id INTEGER NOT NULL,
+    queue_id INTEGER NOT NULL,
+    stream_id INTEGER NOT NULL,
+    start BIGINT NOT NULL,
+    end BIGINT NOT NULL,
+    private_segment_size INTEGER,
+    group_segment_size INTEGER,
+    workgroup_size_x INTEGER NOT NULL,
+    workgroup_size_y INTEGER NOT NULL,
+    workgroup_size_z INTEGER NOT NULL,
+    grid_size_x INTEGER NOT NULL,
+    grid_size_y INTEGER NOT NULL,
+    grid_size_z INTEGER NOT NULL,
+    extdata JSONB NOT NULL DEFAULT "{{}}"
+);
+)sql",
+        db.uuid,
+        db.guid);
+    execute_raw_sql_statements(conn, ddl);
+
+    sqlite3_stmt* metadata_stmt = nullptr;
+    sqlite3_stmt* string_stmt   = nullptr;
+    sqlite3_stmt* symbol_stmt   = nullptr;
+    sqlite3_stmt* dispatch_stmt = nullptr;
+
+    auto finalize_statement = [](sqlite3_stmt*& stmt) {
+        if(!stmt) return;
+        SQLITE3_CHECK(sqlite3_finalize(stmt));
+        stmt = nullptr;
+    };
+
+    auto metadata_sql =
+        fmt::format("INSERT INTO rocpd_metadata{} (tag, value) VALUES (?, ?);", db.uuid);
+    auto string_sql =
+        fmt::format("INSERT OR IGNORE INTO rocpd_string{} (string) VALUES (?);", db.uuid);
+    auto symbol_sql =
+        fmt::format("INSERT OR IGNORE INTO rocpd_info_kernel_symbol{} "
+                    "(id, nid, pid, code_object_id, kernel_name, display_name, kernel_object) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?);",
+                    db.uuid);
+    auto dispatch_sql = fmt::format(
+        "INSERT INTO rocpd_kernel_dispatch{} "
+        "(id, nid, pid, tid, agent_id, kernel_id, dispatch_id, queue_id, stream_id, start, end, "
+        "private_segment_size, group_segment_size, workgroup_size_x, workgroup_size_y, "
+        "workgroup_size_z, grid_size_x, grid_size_y, grid_size_z) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
+        db.uuid);
+
+    SQLITE3_CHECK(sqlite3_prepare_v2(conn, metadata_sql.c_str(), -1, &metadata_stmt, nullptr));
+    SQLITE3_CHECK(sqlite3_prepare_v2(conn, string_sql.c_str(), -1, &string_stmt, nullptr));
+    SQLITE3_CHECK(sqlite3_prepare_v2(conn, symbol_sql.c_str(), -1, &symbol_stmt, nullptr));
+    SQLITE3_CHECK(sqlite3_prepare_v2(conn, dispatch_sql.c_str(), -1, &dispatch_stmt, nullptr));
+
+    auto bind_text = [](sqlite3_stmt* stmt, int idx, std::string_view value) {
+        SQLITE3_CHECK(sqlite3_bind_text(
+            stmt, idx, value.data(), static_cast<int>(value.size()), SQLITE_TRANSIENT));
+    };
+
+    auto step_reset = [](sqlite3_stmt* stmt) {
+        auto status = sqlite3_step(stmt);
+        ROCP_FATAL_IF(status != SQLITE_DONE && status != SQLITE_ROW)
+            << "sqlite3_step failed with status " << status;
+        SQLITE3_CHECK(sqlite3_reset(stmt));
+        SQLITE3_CHECK(sqlite3_clear_bindings(stmt));
+    };
+
+    execute_raw_sql_statements(conn, "BEGIN TRANSACTION;");
+
+    bind_text(metadata_stmt, 1, "pid");
+    bind_text(metadata_stmt, 2, fmt::format("{}", this_pid));
+    step_reset(metadata_stmt);
+
+    {
+        auto _sqlgenperf_rocpd = get_simple_timer("kernel_symbols");
+        for(const auto& itr : tool_metadata.get_kernel_symbols())
+        {
+            if(itr.kernel_id == 0 && itr.code_object_id == 0) continue;
+
+            bind_text(string_stmt, 1, itr.formatted_kernel_name);
+            step_reset(string_stmt);
+
+            SQLITE3_CHECK(
+                sqlite3_bind_int64(symbol_stmt, 1, static_cast<sqlite3_int64>(itr.kernel_id)));
+            SQLITE3_CHECK(sqlite3_bind_int64(symbol_stmt, 2, static_cast<sqlite3_int64>(node_id)));
+            SQLITE3_CHECK(sqlite3_bind_int64(symbol_stmt, 3, static_cast<sqlite3_int64>(this_pid)));
+            SQLITE3_CHECK(
+                sqlite3_bind_int64(symbol_stmt, 4, static_cast<sqlite3_int64>(itr.code_object_id)));
+            bind_text(symbol_stmt, 5, itr.kernel_name);
+            bind_text(symbol_stmt, 6, itr.formatted_kernel_name);
+            SQLITE3_CHECK(
+                sqlite3_bind_int64(symbol_stmt, 7, static_cast<sqlite3_int64>(itr.kernel_object)));
+            step_reset(symbol_stmt);
+        }
+    }
+
+    auto insert_dispatch = [&](rocprofiler_thread_id_t                   thread_id,
+                               rocprofiler_timestamp_t                   start_timestamp,
+                               rocprofiler_timestamp_t                   end_timestamp,
+                               rocprofiler_stream_id_t                   stream_id,
+                               const rocprofiler_kernel_dispatch_info_t& info) {
+        auto agent_node_id = CHECK_NOTNULL(tool_metadata.get_agent(info.agent_id))->node_id;
+
+        SQLITE3_CHECK(
+            sqlite3_bind_int64(dispatch_stmt, 1, static_cast<sqlite3_int64>(info.dispatch_id)));
+        SQLITE3_CHECK(sqlite3_bind_int64(dispatch_stmt, 2, static_cast<sqlite3_int64>(node_id)));
+        SQLITE3_CHECK(sqlite3_bind_int64(dispatch_stmt, 3, static_cast<sqlite3_int64>(this_pid)));
+        SQLITE3_CHECK(sqlite3_bind_int64(dispatch_stmt, 4, static_cast<sqlite3_int64>(thread_id)));
+        SQLITE3_CHECK(
+            sqlite3_bind_int64(dispatch_stmt, 5, static_cast<sqlite3_int64>(agent_node_id)));
+        SQLITE3_CHECK(
+            sqlite3_bind_int64(dispatch_stmt, 6, static_cast<sqlite3_int64>(info.kernel_id)));
+        SQLITE3_CHECK(
+            sqlite3_bind_int64(dispatch_stmt, 7, static_cast<sqlite3_int64>(info.dispatch_id)));
+        SQLITE3_CHECK(
+            sqlite3_bind_int64(dispatch_stmt, 8, static_cast<sqlite3_int64>(info.queue_id.handle)));
+        SQLITE3_CHECK(
+            sqlite3_bind_int64(dispatch_stmt, 9, static_cast<sqlite3_int64>(stream_id.handle)));
+        SQLITE3_CHECK(
+            sqlite3_bind_int64(dispatch_stmt, 10, static_cast<sqlite3_int64>(start_timestamp)));
+        SQLITE3_CHECK(
+            sqlite3_bind_int64(dispatch_stmt, 11, static_cast<sqlite3_int64>(end_timestamp)));
+        SQLITE3_CHECK(sqlite3_bind_int64(
+            dispatch_stmt, 12, static_cast<sqlite3_int64>(info.private_segment_size)));
+        SQLITE3_CHECK(sqlite3_bind_int64(
+            dispatch_stmt, 13, static_cast<sqlite3_int64>(info.group_segment_size)));
+        SQLITE3_CHECK(sqlite3_bind_int64(
+            dispatch_stmt, 14, static_cast<sqlite3_int64>(info.workgroup_size.x)));
+        SQLITE3_CHECK(sqlite3_bind_int64(
+            dispatch_stmt, 15, static_cast<sqlite3_int64>(info.workgroup_size.y)));
+        SQLITE3_CHECK(sqlite3_bind_int64(
+            dispatch_stmt, 16, static_cast<sqlite3_int64>(info.workgroup_size.z)));
+        SQLITE3_CHECK(
+            sqlite3_bind_int64(dispatch_stmt, 17, static_cast<sqlite3_int64>(info.grid_size.x)));
+        SQLITE3_CHECK(
+            sqlite3_bind_int64(dispatch_stmt, 18, static_cast<sqlite3_int64>(info.grid_size.y)));
+        SQLITE3_CHECK(
+            sqlite3_bind_int64(dispatch_stmt, 19, static_cast<sqlite3_int64>(info.grid_size.z)));
+        step_reset(dispatch_stmt);
+    };
+
+    {
+        auto     _sqlgenperf_rocpd = get_simple_timer("kernel_dispatch");
+        uint64_t compact_count     = 0;
+        auto*    compact_records   = common::lite_trace::records(&compact_count);
+
+        if(compact_records && compact_count > 0)
+        {
+            for(uint64_t i = 0; i < compact_count; ++i)
+            {
+                const auto& itr = compact_records[i];
+                insert_dispatch(itr.thread_id,
+                                itr.start,
+                                itr.end,
+                                rocprofiler_stream_id_t{0},
+                                itr.dispatch_info);
+            }
+        }
+        else
+        {
+            for(auto pitr : kernel_dispatch_gen)
+            {
+                for(auto itr : kernel_dispatch_gen.get(pitr))
+                {
+                    insert_dispatch(itr.thread_id,
+                                    itr.start_timestamp,
+                                    itr.end_timestamp,
+                                    itr.stream_id,
+                                    itr.dispatch_info);
+                }
+            }
+        }
+    }
+
+    execute_raw_sql_statements(conn, "COMMIT;");
+    common::lite_trace::unlink_record_store();
+    finalize_statement(metadata_stmt);
+    finalize_statement(string_stmt);
+    finalize_statement(symbol_stmt);
+    finalize_statement(dispatch_stmt);
+}
 }  // namespace
 
 namespace
@@ -1028,6 +1288,12 @@ write_rocpd(
         return common::simple_timer{fmt::format("SQLite3 generation :: {:24}", label)};
     };
 
+    if(cfg.rocpd_fast_path)
+    {
+        write_fast_rocpd(cfg, tool_metadata, kernel_dispatch_gen);
+        return;
+    }
+
     auto _sqlgenperf = get_simple_timer("total");
 
     auto node_hash =
@@ -1062,18 +1328,28 @@ write_rocpd(
         SQLITE3_CHECK(sqlite3_open_v2(
             output_file.c_str(), &conn, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr));
         SQLITE3_CHECK(sqlite3_busy_handler(conn, &sql::busy_handler, nullptr));
+        if(cfg.rocpd_fast_path)
+        {
+            execute_raw_sql_statements(conn,
+                                       "PRAGMA journal_mode = WAL;"
+                                       "PRAGMA synchronous = OFF;"
+                                       "PRAGMA cache_size = -65536;");
+        }
 
         ROCP_ERROR << fmt::format("Opened result file: {} (UUID={})", output_file, uuid_v7);
 
         execute_raw_sql_statements(conn, table_schema);
 
-        for(auto itr : {ROCPD_SQL_SCHEMA_ROCPD_VIEWS,
-                        ROCPD_SQL_SCHEMA_ROCPD_DATA_VIEWS,
-                        ROCPD_SQL_SCHEMA_ROCPD_MARKER_VIEWS,
-                        ROCPD_SQL_SCHEMA_ROCPD_SUMMARY_VIEWS})
+        if(!cfg.rocpd_fast_path)
         {
-            auto views_schema = read_schema_file(db, itr);
-            execute_raw_sql_statements(conn, views_schema);
+            for(auto itr : {ROCPD_SQL_SCHEMA_ROCPD_VIEWS,
+                            ROCPD_SQL_SCHEMA_ROCPD_DATA_VIEWS,
+                            ROCPD_SQL_SCHEMA_ROCPD_MARKER_VIEWS,
+                            ROCPD_SQL_SCHEMA_ROCPD_SUMMARY_VIEWS})
+            {
+                auto views_schema = read_schema_file(db, itr);
+                execute_raw_sql_statements(conn, views_schema);
+            }
         }
     }
 
@@ -2028,6 +2304,7 @@ write_rocpd(
         insert_memory_alloc_data(scratch_memory_gen);
     }
 
+    if(!cfg.rocpd_fast_path)
     {
         auto kfd_pmc_ids = std::unordered_map<rocprofiler_buffer_tracing_kind_t, uint64_t>{};
         insert_kfd_data(kfd_pmc_ids);
@@ -2043,9 +2320,12 @@ write_rocpd(
         }
 
         {
-            auto _sqlgenperf_rocpd = get_simple_timer("SQL indexing");
-            auto indexes_schema    = read_schema_file(db, ROCPD_SQL_SCHEMA_ROCPD_INDEXES);
-            execute_raw_sql_statements(conn, indexes_schema);
+            if(!cfg.rocpd_fast_path)
+            {
+                auto _sqlgenperf_rocpd = get_simple_timer("SQL indexing");
+                auto indexes_schema    = read_schema_file(db, ROCPD_SQL_SCHEMA_ROCPD_INDEXES);
+                execute_raw_sql_statements(conn, indexes_schema);
+            }
         }
     }
 }

--- a/projects/rocprofiler-sdk/source/lib/output/output_config.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/output_config.cpp
@@ -66,6 +66,7 @@ output_config::parse_env()
     annotate_args  = common::get_env("ROCPROF_ANNOTATE_ARGS", false);
     annotate_kfd   = common::get_env("ROCPROF_ANNOTATE_KFD", false);
     annotate_pmc   = common::get_env("ROCPROF_ANNOTATE_PMC", false);
+    rocpd_fast_path = common::get_env("ROCPROF_LITE_TRACE", false);
     auto to_upper  = [](std::string val) {
         for(auto& vitr : val)
             vitr = toupper(vitr);

--- a/projects/rocprofiler-sdk/source/lib/output/output_config.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/output_config.hpp
@@ -68,6 +68,7 @@ struct output_config
     bool                     pftrace_output              = false;
     bool                     otf2_output                 = false;
     bool                     rocpd_output                = false;
+    bool                     rocpd_fast_path             = false;
     bool                     summary_output              = false;
     bool                     kernel_rename               = false;
     bool                     group_by_queue              = false;
@@ -134,6 +135,7 @@ output_config::save(ArchiveT& ar) const
     CFG_SERIALIZE_MEMBER(otf2_output);
     CFG_SERIALIZE_MEMBER(summary_output);
     CFG_SERIALIZE_MEMBER(rocpd_output);
+    CFG_SERIALIZE_MEMBER(rocpd_fast_path);
     CFG_SERIALIZE_MEMBER(kernel_rename);
     CFG_SERIALIZE_MEMBER(group_by_queue);
     CFG_SERIALIZE_MEMBER(annotate_args);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.cpp
@@ -309,6 +309,42 @@ config::config()
         }
     }
 
+    if(lite_trace)
+    {
+        ROCP_FATAL_IF(!kernel_trace || !kernel_trace_fast_path)
+            << "ROCPROF_LITE_TRACE requires kernel tracing through the fast path";
+
+        const auto incompatible = std::vector<std::pair<std::string_view, bool>>{
+            {"ROCPROF_HSA_CORE_API_TRACE", hsa_core_api_trace},
+            {"ROCPROF_HSA_AMD_EXT_API_TRACE", hsa_amd_ext_api_trace},
+            {"ROCPROF_HSA_IMAGE_EXT_API_TRACE", hsa_image_ext_api_trace},
+            {"ROCPROF_HSA_FINALIZER_EXT_API_TRACE", hsa_finalizer_ext_api_trace},
+            {"ROCPROF_MARKER_API_TRACE", marker_api_trace},
+            {"ROCPROF_MEMORY_COPY_TRACE", memory_copy_trace},
+            {"ROCPROF_MEMORY_ALLOCATION_TRACE", memory_allocation_trace},
+            {"ROCPROF_SCRATCH_MEMORY_TRACE", scratch_memory_trace},
+            {"ROCPROF_COUNTER_COLLECTION", counter_collection},
+            {"ROCPROF_HIP_RUNTIME_API_TRACE", hip_runtime_api_trace},
+            {"ROCPROF_HIP_COMPILER_API_TRACE", hip_compiler_api_trace},
+            {"ROCPROF_RCCL_API_TRACE", rccl_api_trace},
+            {"ROCPROF_ROCDECODE_API_TRACE", rocdecode_api_trace},
+            {"ROCPROF_ROCJPEG_API_TRACE", rocjpeg_api_trace},
+            {"ROCPROF_ADVANCED_THREAD_TRACE", advanced_thread_trace},
+            {"ROCPROF_PC_SAMPLING_METHOD",
+             pc_sampling_method_value != ROCPROFILER_PC_SAMPLING_METHOD_NONE},
+            {"ROCPROF_COLLECTION_PERIOD", !collection_periods.empty()},
+            {"ROCPROF_COUNTERS", !counters.empty()},
+            {"ROCPROF_EXTRA_COUNTERS_CONTENTS", !extra_counters_contents.empty()},
+        };
+
+        for(const auto& itr : incompatible)
+        {
+            ROCP_FATAL_IF(itr.second)
+                << "ROCPROF_LITE_TRACE only supports kernel dispatch tracing; disable "
+                << itr.first;
+        }
+    }
+
     // Benchmarking Enable/Disable
     if(!benchmark_mode_env.empty())
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.hpp
@@ -113,7 +113,9 @@ struct config : output_config
 
     bool   demangle                    = get_env("ROCPROF_DEMANGLE_KERNELS", true);
     bool   truncate                    = get_env("ROCPROF_TRUNCATE_KERNELS", false);
-    bool   kernel_trace                = get_env("ROCPROF_KERNEL_TRACE", false);
+    bool   lite_trace                  = get_env("ROCPROF_LITE_TRACE", false);
+    bool   kernel_trace                = get_env("ROCPROF_KERNEL_TRACE", false) || lite_trace;
+    bool   kernel_trace_fast_path      = lite_trace;
     bool   hsa_core_api_trace          = get_env("ROCPROF_HSA_CORE_API_TRACE", false);
     bool   hsa_amd_ext_api_trace       = get_env("ROCPROF_HSA_AMD_EXT_API_TRACE", false);
     bool   hsa_image_ext_api_trace     = get_env("ROCPROF_HSA_IMAGE_EXT_API_TRACE", false);
@@ -198,6 +200,8 @@ inline auto
 config::get_attach_invariants() const
 {
     return std::make_tuple(kernel_trace,
+                           lite_trace,
+                           kernel_trace_fast_path,
                            hsa_core_api_trace,
                            hsa_amd_ext_api_trace,
                            hsa_image_ext_api_trace,
@@ -261,7 +265,9 @@ config::save(ArchiveT& ar) const
 {
     CFG_SERIALIZE_NAMED_MEMBER("benchmark_mode", benchmark_mode_env);
 
+    CFG_SERIALIZE_MEMBER(lite_trace);
     CFG_SERIALIZE_MEMBER(kernel_trace);
+    CFG_SERIALIZE_MEMBER(kernel_trace_fast_path);
     CFG_SERIALIZE_MEMBER(hsa_core_api_trace);
     CFG_SERIALIZE_MEMBER(hsa_amd_ext_api_trace);
     CFG_SERIALIZE_MEMBER(hsa_image_ext_api_trace);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -2340,7 +2340,8 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
         rocprofiler_callback_tracing_cb_t   callback = nullptr;
     };
 
-    for(auto&& itr : {callback_service_config{tool::get_config().kernel_trace,
+    for(auto&& itr : {callback_service_config{tool::get_config().kernel_trace &&
+                                                  !tool::get_config().kernel_trace_fast_path,
                                               ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH,
                                               dummy_callback_tracing_callback},
                       callback_service_config{tool::get_config().memory_copy_trace,
@@ -2523,60 +2524,64 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
         start_context(counter_collection_ctx, "counter collection");
     }
 
-    auto rename_ctx            = rocprofiler_context_id_t{0};
-    auto marker_core_api_kinds = std::array<rocprofiler_tracing_operation_t, 2>{
-        ROCPROFILER_MARKER_CORE_RANGE_API_ID_roctxMarkA,
-        ROCPROFILER_MARKER_CORE_RANGE_API_ID_roctxThreadRangeA,
-    };
+    if(!tool::get_config().lite_trace)
+    {
+        auto rename_ctx            = rocprofiler_context_id_t{0};
+        auto marker_core_api_kinds = std::array<rocprofiler_tracing_operation_t, 2>{
+            ROCPROFILER_MARKER_CORE_RANGE_API_ID_roctxMarkA,
+            ROCPROFILER_MARKER_CORE_RANGE_API_ID_roctxThreadRangeA,
+        };
 
-    ROCPROFILER_CALL(rocprofiler_create_context(&rename_ctx), "failed to create context");
+        ROCPROFILER_CALL(rocprofiler_create_context(&rename_ctx), "failed to create context");
 
-    ROCPROFILER_CALL(rocprofiler_configure_callback_tracing_service(
-                         rename_ctx,
-                         ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_RANGE_API,
-                         marker_core_api_kinds.data(),
-                         marker_core_api_kinds.size(),
-                         callbacks.kernel_rename,
-                         nullptr),
-                     "callback tracing service failed to configure");
+        ROCPROFILER_CALL(rocprofiler_configure_callback_tracing_service(
+                             rename_ctx,
+                             ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_RANGE_API,
+                             marker_core_api_kinds.data(),
+                             marker_core_api_kinds.size(),
+                             callbacks.kernel_rename,
+                             nullptr),
+                         "callback tracing service failed to configure");
 
-    start_context(rename_ctx, "kernel rename");
+        start_context(rename_ctx, "kernel rename");
 
-    // Track stream ID information via callback service
-    auto hip_stream_display_ctx = rocprofiler_context_id_t{0};
+        // Track stream ID information via callback service
+        auto hip_stream_display_ctx = rocprofiler_context_id_t{0};
 
-    ROCPROFILER_CALL(rocprofiler_create_context(&hip_stream_display_ctx),
-                     "failed to create hip stream context");
+        ROCPROFILER_CALL(rocprofiler_create_context(&hip_stream_display_ctx),
+                         "failed to create hip stream context");
 
-    ROCPROFILER_CALL(
-        rocprofiler_configure_callback_tracing_service(hip_stream_display_ctx,
-                                                       ROCPROFILER_CALLBACK_TRACING_HIP_STREAM,
-                                                       nullptr,
-                                                       0,
-                                                       callbacks.hip_stream,
-                                                       nullptr),
-        "hip stream tracing configure failed");
+        ROCPROFILER_CALL(
+            rocprofiler_configure_callback_tracing_service(hip_stream_display_ctx,
+                                                           ROCPROFILER_CALLBACK_TRACING_HIP_STREAM,
+                                                           nullptr,
+                                                           0,
+                                                           callbacks.hip_stream,
+                                                           nullptr),
+            "hip stream tracing configure failed");
 
-    start_context(hip_stream_display_ctx, "hip stream");
+        start_context(hip_stream_display_ctx, "hip stream");
 
-    // Track if HIP runtime has been initialized via runtime_intialization service
-    auto runtime_initialization_ctx = rocprofiler_context_id_t{0};
+        // Track if HIP runtime has been initialized via runtime_intialization service
+        auto runtime_initialization_ctx = rocprofiler_context_id_t{0};
 
-    ROCPROFILER_CALL(rocprofiler_create_context(&runtime_initialization_ctx),
-                     "failed to create runtime initialization context");
+        ROCPROFILER_CALL(rocprofiler_create_context(&runtime_initialization_ctx),
+                         "failed to create runtime initialization context");
 
-    ROCPROFILER_CALL(rocprofiler_configure_callback_tracing_service(
-                         runtime_initialization_ctx,
-                         ROCPROFILER_CALLBACK_TRACING_RUNTIME_INITIALIZATION,
-                         nullptr,
-                         0,
-                         runtime_initialization_callback,
-                         nullptr),
-                     "runtime initialization tracing configure failed");
+        ROCPROFILER_CALL(rocprofiler_configure_callback_tracing_service(
+                             runtime_initialization_ctx,
+                             ROCPROFILER_CALLBACK_TRACING_RUNTIME_INITIALIZATION,
+                             nullptr,
+                             0,
+                             runtime_initialization_callback,
+                             nullptr),
+                         "runtime initialization tracing configure failed");
 
-    start_context(runtime_initialization_ctx, "runtime initialization");
+        start_context(runtime_initialization_ctx, "runtime initialization");
+    }
 
-    if(tool::get_config().benchmark_mode != tool::config::benchmark::execution_profile)
+    if(tool::get_config().benchmark_mode != tool::config::benchmark::execution_profile &&
+       !tool::get_config().lite_trace)
     {
         auto external_corr_id_request_kinds =
             std::array<rocprofiler_external_correlation_id_request_kind_t, 4>{
@@ -3021,8 +3026,13 @@ generate_output(cleanup_mode _cleanup_mode)
                              rocjpeg_output.get_generator());
     }
 
-    if(tool::get_config().rocpd_output && outdata.num_output > 0 &&
-       outdata.num_bytes >= tool::get_config().minimum_output_bytes)
+    const auto force_fast_rocpd_output =
+        (tool::get_config().kernel_trace && tool::get_config().kernel_trace_fast_path &&
+         tool::get_config().rocpd_output);
+
+    if(tool::get_config().rocpd_output &&
+       ((outdata.num_output > 0 && outdata.num_bytes >= tool::get_config().minimum_output_bytes) ||
+        force_fast_rocpd_output))
     {
         tool::write_rocpd(tool::get_config(),
                           *tool_metadata,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/buffer_tracing.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/buffer_tracing.cpp
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include "lib/common/lite_trace_internal.hpp"
 #include "lib/common/logging.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
 #include "lib/rocprofiler-sdk/context/domain.hpp"
@@ -138,7 +139,8 @@ get_unsupported()
 }  // namespace buffer_tracing
 }  // namespace rocprofiler
 
-extern "C" {
+extern "C"
+{
 rocprofiler_status_t
 rocprofiler_configure_buffer_tracing_service(rocprofiler_context_id_t               context_id,
                                              rocprofiler_buffer_tracing_kind_t      kind,
@@ -150,6 +152,10 @@ rocprofiler_configure_buffer_tracing_service(rocprofiler_context_id_t           
 
     if(rocprofiler::registration::get_init_status() > -1)
         return ROCPROFILER_STATUS_ERROR_CONFIGURATION_LOCKED;
+
+    if(rocprofiler::common::lite_trace::enabled() &&
+       !rocprofiler::common::lite_trace::is_allowed_buffer_tracing_kind(kind))
+        return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
 
     if(unsupported.count(kind) > 0) return ROCPROFILER_STATUS_ERROR_NOT_IMPLEMENTED;
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/callback_tracing.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/callback_tracing.cpp
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include "lib/common/lite_trace_internal.hpp"
 #include "lib/rocprofiler-sdk/code_object/code_object.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
 #include "lib/rocprofiler-sdk/context/domain.hpp"
@@ -123,7 +124,8 @@ get_unsupported()
 }  // namespace callback_tracing
 }  // namespace rocprofiler
 
-extern "C" {
+extern "C"
+{
 rocprofiler_status_t
 rocprofiler_configure_callback_tracing_service(rocprofiler_context_id_t               context_id,
                                                rocprofiler_callback_tracing_kind_t    kind,
@@ -136,6 +138,10 @@ rocprofiler_configure_callback_tracing_service(rocprofiler_context_id_t         
 
     if(rocprofiler::registration::get_init_status() > -1)
         return ROCPROFILER_STATUS_ERROR_CONFIGURATION_LOCKED;
+
+    if(rocprofiler::common::lite_trace::enabled() &&
+       !rocprofiler::common::lite_trace::is_allowed_callback_tracing_kind(kind))
+        return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
 
     if(unsupported.count(kind) > 0) return ROCPROFILER_STATUS_ERROR_NOT_IMPLEMENTED;
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/device_counting_service.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/device_counting_service.cpp
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include "lib/common/lite_trace_internal.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
 #include "lib/rocprofiler-sdk/counters/core.hpp"
 #include "lib/rocprofiler-sdk/counters/device_counting.hpp"
@@ -36,7 +37,8 @@ namespace
 constexpr auto rocprofiler_context_none = ROCPROFILER_CONTEXT_NONE;
 }
 
-extern "C" {
+extern "C"
+{
 rocprofiler_status_t
 rocprofiler_configure_device_counting_service(rocprofiler_context_id_t                 context_id,
                                               rocprofiler_buffer_id_t                  buffer_id,
@@ -44,6 +46,8 @@ rocprofiler_configure_device_counting_service(rocprofiler_context_id_t          
                                               rocprofiler_device_counting_service_cb_t cb,
                                               void*                                    user_data)
 {
+    if(rocprofiler::common::lite_trace::enabled()) return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
+
     return rocprofiler::counters::configure_agent_collection(
         context_id, buffer_id, agent_id, cb, user_data);
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/dispatch_counting_service.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/dispatch_counting_service.cpp
@@ -20,12 +20,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include "lib/common/lite_trace_internal.hpp"
 #include "lib/rocprofiler-sdk/counters/controller.hpp"
 #include "lib/rocprofiler-sdk/counters/core.hpp"
 
 #include <rocprofiler-sdk/dispatch_counting_service.h>
 
-extern "C" {
+extern "C"
+{
 /**
  * @brief Configure buffered dispatch profile Counting Service.
  *        Collects the counters in dispatch packets and stores them
@@ -45,6 +47,8 @@ rocprofiler_configure_buffer_dispatch_counting_service(
     rocprofiler_dispatch_counting_service_cb_t callback,
     void*                                      callback_data_args)
 {
+    if(rocprofiler::common::lite_trace::enabled()) return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
+
     return rocprofiler::counters::configure_buffered_dispatch(
         context_id, buffer_id, callback, callback_data_args);
 }
@@ -69,6 +73,8 @@ rocprofiler_configure_callback_dispatch_counting_service(
     rocprofiler_dispatch_counting_record_cb_t  record_callback,
     void*                                      record_callback_args)
 {
+    if(rocprofiler::common::lite_trace::enabled()) return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
+
     return rocprofiler::counters::configure_callback_dispatch(context_id,
                                                               dispatch_callback,
                                                               dispatch_callback_args,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/external_correlation.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/external_correlation.cpp
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 #include "lib/rocprofiler-sdk/external_correlation.hpp"
+#include "lib/common/lite_trace_internal.hpp"
 #include "lib/common/synchronized.hpp"
 #include "lib/common/utility.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
@@ -163,7 +164,8 @@ external_correlation::push(rocprofiler_thread_id_t tid, rocprofiler_user_data_t 
             return true;
         },
         tid))
-    {}
+    {
+    }
 
     // since we know from above that there will be a key for the tid, we start with a read
     // lock and then once we have have the mapped data for the key, we leverage the enabling
@@ -267,7 +269,8 @@ external_correlation::invoke_callback(rocprofiler_thread_id_t thr_id,
 }  // namespace external_correlation
 }  // namespace rocprofiler
 
-extern "C" {
+extern "C"
+{
 rocprofiler_status_t
 rocprofiler_configure_external_correlation_id_request_service(
     rocprofiler_context_id_t                                  context_id,
@@ -276,6 +279,8 @@ rocprofiler_configure_external_correlation_id_request_service(
     rocprofiler_external_correlation_id_request_cb_t          callback,
     void*                                                     callback_args)
 {
+    if(rocprofiler::common::lite_trace::enabled()) return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
+
     auto* ctx = rocprofiler::context::get_mutable_registered_context(context_id);
     if(!ctx) return ROCPROFILER_STATUS_ERROR_CONTEXT_NOT_FOUND;
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -22,6 +22,8 @@
 
 #include "lib/rocprofiler-sdk/hsa/queue.hpp"
 #include "lib/common/container/pool.hpp"
+#include "lib/common/environment.hpp"
+#include "lib/common/lite_trace_internal.hpp"
 #include "lib/common/logging.hpp"
 #include "lib/common/scope_destructor.hpp"
 #include "lib/common/static_object.hpp"
@@ -48,8 +50,12 @@
 #include <hsa/hsa.h>
 #include <hsa/hsa_ext_amd.h>
 
+#include <algorithm>
+#include <array>
 #include <atomic>
 #include <memory>
+#include <mutex>
+#include <new>
 #include <utility>
 
 // static assert for rocprofiler_packet ABI compatibility
@@ -286,6 +292,434 @@ bit_extract(Integral x, int first, int last)
     return (x >> first) & bit_mask(0, last - first);
 }
 
+bool
+kernel_trace_fast_path_enabled()
+{
+    static const auto enabled = common::get_env("ROCPROF_LITE_TRACE", false);
+    return enabled;
+}
+
+struct fast_path_counters_t
+{
+    std::atomic<uint64_t> intercepts             = {0};
+    std::atomic<uint64_t> recorded               = {0};
+    std::atomic<uint64_t> skipped_no_context     = {0};
+    std::atomic<uint64_t> skipped_non_kernel     = {0};
+    std::atomic<uint64_t> skipped_batch          = {0};
+    std::atomic<uint64_t> reused_existing_signal = {0};
+    std::atomic<uint64_t> injected_signal        = {0};
+    std::atomic<uint64_t> signal_fail            = {0};
+    std::atomic<uint64_t> timestamp_fail         = {0};
+    std::atomic<uint64_t> timestamp_invalid      = {0};
+    std::atomic<uint64_t> async_handler_fail     = {0};
+    std::atomic<uint64_t> allocation_fail        = {0};
+    std::atomic<uint64_t> record_overflow        = {0};
+    std::atomic<bool>     reported               = {false};
+};
+
+fast_path_counters_t&
+fast_path_counters()
+{
+    static auto counters = fast_path_counters_t{};
+    return counters;
+}
+
+constexpr size_t fast_signal_pool_capacity = 4096;
+constexpr size_t fast_signal_pool_mask     = fast_signal_pool_capacity - 1;
+
+bool
+fast_path_record_try_append(common::lite_trace::kernel_dispatch_record_t record)
+{
+    if(!common::lite_trace::record_store_available())
+    {
+        fast_path_counters().allocation_fail.fetch_add(1, std::memory_order_relaxed);
+        return false;
+    }
+
+    if(!common::lite_trace::record_try_append(record))
+    {
+        fast_path_counters().record_overflow.fetch_add(1, std::memory_order_relaxed);
+        return false;
+    }
+
+    return true;
+}
+
+struct alignas(64) fast_signal_slot_t
+{
+    std::atomic<uint64_t> sequence = {0};
+    hsa_signal_t          signal   = {.handle = 0};
+};
+
+auto&
+fast_signal_slots()
+{
+    static auto slots = std::array<fast_signal_slot_t, fast_signal_pool_capacity>{};
+    return slots;
+}
+
+auto&
+fast_signal_head()
+{
+    static auto head = std::atomic<uint64_t>{0};
+    return head;
+}
+
+auto&
+fast_signal_tail()
+{
+    static auto tail = std::atomic<uint64_t>{0};
+    return tail;
+}
+
+bool
+fast_signal_try_pop(hsa_signal_t& out)
+{
+    auto&    slots = fast_signal_slots();
+    uint64_t pos   = fast_signal_head().load(std::memory_order_relaxed);
+    while(true)
+    {
+        auto&   slot = slots[pos & fast_signal_pool_mask];
+        auto    seq  = slot.sequence.load(std::memory_order_acquire);
+        int64_t diff = static_cast<int64_t>(seq) - static_cast<int64_t>(pos + 1);
+        if(diff == 0)
+        {
+            if(fast_signal_head().compare_exchange_weak(
+                   pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed))
+            {
+                out = slot.signal;
+                slot.sequence.store(pos + fast_signal_pool_capacity, std::memory_order_release);
+                return true;
+            }
+        }
+        else if(diff < 0)
+        {
+            return false;
+        }
+        else
+        {
+            pos = fast_signal_head().load(std::memory_order_relaxed);
+        }
+    }
+}
+
+bool
+fast_signal_try_push(hsa_signal_t signal)
+{
+    auto&    slots = fast_signal_slots();
+    uint64_t pos   = fast_signal_tail().load(std::memory_order_relaxed);
+    while(true)
+    {
+        auto&   slot = slots[pos & fast_signal_pool_mask];
+        auto    seq  = slot.sequence.load(std::memory_order_acquire);
+        int64_t diff = static_cast<int64_t>(seq) - static_cast<int64_t>(pos);
+        if(diff == 0)
+        {
+            if(fast_signal_tail().compare_exchange_weak(
+                   pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed))
+            {
+                slot.signal = signal;
+                slot.sequence.store(pos + 1, std::memory_order_release);
+                return true;
+            }
+        }
+        else if(diff < 0)
+        {
+            return false;
+        }
+        else
+        {
+            pos = fast_signal_tail().load(std::memory_order_relaxed);
+        }
+    }
+}
+
+void
+init_fast_signal_pool()
+{
+    auto& slots = fast_signal_slots();
+    for(size_t i = 0; i < slots.size(); ++i)
+    {
+        slots.at(i).sequence.store(i, std::memory_order_relaxed);
+        slots.at(i).signal = null_hsa_signal;
+    }
+
+    if(!get_amd_ext_table() || !get_amd_ext_table()->hsa_amd_signal_create_fn) return;
+
+    for(size_t i = 0; i < fast_signal_pool_capacity; ++i)
+    {
+        auto signal = hsa_signal_t{.handle = 0};
+        auto status = get_amd_ext_table()->hsa_amd_signal_create_fn(1, 0, nullptr, 0, &signal);
+        if(status != HSA_STATUS_SUCCESS) break;
+        if(!fast_signal_try_push(signal))
+        {
+            get_core_table()->hsa_signal_destroy_fn(signal);
+            break;
+        }
+    }
+}
+
+hsa_signal_t
+fast_acquire_signal()
+{
+    static auto init_once = std::once_flag{};
+    std::call_once(init_once, init_fast_signal_pool);
+
+    auto signal = hsa_signal_t{.handle = 0};
+    if(fast_signal_try_pop(signal))
+    {
+        get_core_table()->hsa_signal_store_relaxed_fn(signal, 1);
+        return signal;
+    }
+
+    if(!get_amd_ext_table() || !get_amd_ext_table()->hsa_amd_signal_create_fn)
+        return null_hsa_signal;
+
+    auto status = get_amd_ext_table()->hsa_amd_signal_create_fn(1, 0, nullptr, 0, &signal);
+    if(status != HSA_STATUS_SUCCESS) return null_hsa_signal;
+    return signal;
+}
+
+void
+fast_release_signal(hsa_signal_t signal)
+{
+    if(signal == null_hsa_signal) return;
+    if(fast_signal_try_push(signal)) return;
+    get_core_table()->hsa_signal_destroy_fn(signal);
+}
+
+struct fast_path_session_t
+{
+    Queue*                             queue       = nullptr;
+    hsa_signal_t                       signal      = {.handle = 0};
+    hsa_signal_value_t                 wait_value  = 1;
+    bool                               owns_signal = false;
+    rocprofiler_thread_id_t            tid         = 0;
+    rocprofiler_timestamp_t            enqueue_ts  = 0;
+    rocprofiler_dispatch_id_t          dispatch_id = 0;
+    rocprofiler_kernel_dispatch_info_t dispatch_info{};
+};
+
+bool
+FastPathSignalHandler(hsa_signal_value_t /*signal_value*/, void* data)
+{
+    auto* session = static_cast<fast_path_session_t*>(data);
+    if(!session || !session->queue) return false;
+
+    auto _cleanup = common::scope_destructor{[session]() {
+        if(session->owns_signal) fast_release_signal(session->signal);
+        session->queue->async_complete();
+        delete session;
+    }};
+
+    if(registration::get_fini_status() > 0) return false;
+
+    auto dispatch_time =
+        kernel_dispatch::get_dispatch_time(session->queue->get_agent().get_hsa_agent(),
+                                           session->signal,
+                                           session->dispatch_info.kernel_id,
+                                           session->enqueue_ts);
+
+    if(dispatch_time.status != HSA_STATUS_SUCCESS)
+    {
+        fast_path_counters().timestamp_fail.fetch_add(1, std::memory_order_relaxed);
+        return false;
+    }
+
+    if(dispatch_time.end <= dispatch_time.start)
+    {
+        fast_path_counters().timestamp_invalid.fetch_add(1, std::memory_order_relaxed);
+        return false;
+    }
+
+    if(fast_path_record_try_append(common::lite_trace::kernel_dispatch_record_t{
+           session->tid, dispatch_time.start, dispatch_time.end, session->dispatch_info}))
+    {
+        fast_path_counters().recorded.fetch_add(1, std::memory_order_relaxed);
+    }
+    return false;
+}
+
+void
+cleanup_fast_path_session_after_register_failure(fast_path_session_t* session)
+{
+    if(!session) return;
+
+    if(session->owns_signal && session->queue)
+    {
+        constexpr auto timeout_hint =
+            std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::seconds{1});
+        session->queue->core_api().hsa_signal_wait_scacquire_fn(session->signal,
+                                                                HSA_SIGNAL_CONDITION_LT,
+                                                                session->wait_value,
+                                                                timeout_hint.count(),
+                                                                HSA_WAIT_STATE_BLOCKED);
+        fast_release_signal(session->signal);
+    }
+
+    if(session->queue) session->queue->async_complete();
+    delete session;
+}
+
+void
+register_fast_path_handler(fast_path_session_t* session)
+{
+    auto status = session->queue->ext_api().hsa_amd_signal_async_handler_fn(session->signal,
+                                                                            HSA_SIGNAL_CONDITION_LT,
+                                                                            session->wait_value,
+                                                                            FastPathSignalHandler,
+                                                                            session);
+
+    if(status == HSA_STATUS_INFO_BREAK)
+    {
+        return;
+    }
+
+    if(status != HSA_STATUS_SUCCESS)
+    {
+        fast_path_counters().async_handler_fail.fetch_add(1, std::memory_order_relaxed);
+        cleanup_fast_path_session_after_register_failure(session);
+    }
+}
+
+bool
+FastPathWriteInterceptor(const void*                           packets,
+                         uint64_t                              pkt_count,
+                         Queue&                                queue,
+                         hsa_amd_queue_intercept_packet_writer writer)
+{
+    auto& counters = fast_path_counters();
+    counters.intercepts.fetch_add(1, std::memory_order_relaxed);
+
+    if(pkt_count == 0)
+    {
+        writer(packets, pkt_count);
+        return true;
+    }
+
+    if(pkt_count > 1)
+    {
+        counters.skipped_batch.fetch_add(pkt_count, std::memory_order_relaxed);
+        writer(packets, pkt_count);
+        return true;
+    }
+
+    const auto* packets_arr     = static_cast<const rocprofiler_packet*>(packets);
+    const auto& original_packet = packets_arr[0].kernel_dispatch;
+    auto        packet_type     = bit_extract(original_packet.header,
+                                   HSA_PACKET_HEADER_TYPE,
+                                   HSA_PACKET_HEADER_TYPE + HSA_PACKET_HEADER_WIDTH_TYPE - 1);
+
+    if(packet_type != HSA_PACKET_TYPE_KERNEL_DISPATCH)
+    {
+        counters.skipped_non_kernel.fetch_add(1, std::memory_order_relaxed);
+        writer(packets, pkt_count);
+        return true;
+    }
+
+    auto signal      = original_packet.completion_signal;
+    auto wait_value  = hsa_signal_value_t{1};
+    auto owns_signal = false;
+    auto out_packet  = packets_arr[0];
+
+    if(signal == null_hsa_signal)
+    {
+        signal = fast_acquire_signal();
+        if(signal == null_hsa_signal)
+        {
+            counters.signal_fail.fetch_add(1, std::memory_order_relaxed);
+            writer(packets, pkt_count);
+            return true;
+        }
+
+        owns_signal                                  = true;
+        out_packet.kernel_dispatch.completion_signal = signal;
+        counters.injected_signal.fetch_add(1, std::memory_order_relaxed);
+    }
+    else
+    {
+        wait_value = queue.core_api().hsa_signal_load_scacquire_fn(signal);
+        counters.reused_existing_signal.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    // unique sequence id for the dispatch
+    static auto sequence_counter = std::atomic<rocprofiler_dispatch_id_t>{0};
+    const auto  dispatch_id      = ++sequence_counter;
+
+    constexpr auto kernel_dispatch_info_rt_size =
+        common::compute_runtime_sizeof<rocprofiler_kernel_dispatch_info_t>();
+
+    auto dispatch_info = rocprofiler_kernel_dispatch_info_t{
+        .size                 = kernel_dispatch_info_rt_size,
+        .agent_id             = queue.get_agent().get_rocp_agent()->id,
+        .queue_id             = queue.get_id(),
+        .kernel_id            = code_object::get_kernel_id(original_packet.kernel_object),
+        .dispatch_id          = dispatch_id,
+        .private_segment_size = original_packet.private_segment_size,
+        .group_segment_size   = original_packet.group_segment_size,
+        .workgroup_size       = rocprofiler_dim3_t{original_packet.workgroup_size_x,
+                                             original_packet.workgroup_size_y,
+                                             original_packet.workgroup_size_z},
+        .grid_size            = rocprofiler_dim3_t{original_packet.grid_size_x,
+                                        original_packet.grid_size_y,
+                                        original_packet.grid_size_z},
+        .reserved_padding     = {0}};
+
+    auto* session = new(std::nothrow) fast_path_session_t{.queue         = &queue,
+                                                          .signal        = signal,
+                                                          .wait_value    = wait_value,
+                                                          .owns_signal   = owns_signal,
+                                                          .tid           = common::get_tid(),
+                                                          .enqueue_ts    = common::timestamp_ns(),
+                                                          .dispatch_id   = dispatch_id,
+                                                          .dispatch_info = dispatch_info};
+
+    if(!session)
+    {
+        counters.allocation_fail.fetch_add(1, std::memory_order_relaxed);
+        if(owns_signal) fast_release_signal(signal);
+        writer(packets, pkt_count);
+        return true;
+    }
+
+    queue.async_started();
+    if(owns_signal)
+        writer(&out_packet, 1);
+    else
+        writer(packets, pkt_count);
+
+    register_fast_path_handler(session);
+    return true;
+}
+
+void
+report_fast_path_counters_once()
+{
+    if(!kernel_trace_fast_path_enabled()) return;
+
+    auto& counters = fast_path_counters();
+    if(counters.reported.exchange(true, std::memory_order_acq_rel)) return;
+
+    ROCP_WARNING << fmt::format(
+        "rocprofv3 kernel fast-path summary: intercepts={}, recorded={}, "
+        "skipped_no_context={}, skipped_non_kernel={}, skipped_batch={}, "
+        "reused_existing_signal={}, injected_signal={}, signal_fail={}, timestamp_fail={}, "
+        "timestamp_invalid={}, async_handler_fail={}, allocation_fail={}, record_overflow={}",
+        counters.intercepts.load(std::memory_order_relaxed),
+        counters.recorded.load(std::memory_order_relaxed),
+        counters.skipped_no_context.load(std::memory_order_relaxed),
+        counters.skipped_non_kernel.load(std::memory_order_relaxed),
+        counters.skipped_batch.load(std::memory_order_relaxed),
+        counters.reused_existing_signal.load(std::memory_order_relaxed),
+        counters.injected_signal.load(std::memory_order_relaxed),
+        counters.signal_fail.load(std::memory_order_relaxed),
+        counters.timestamp_fail.load(std::memory_order_relaxed),
+        counters.timestamp_invalid.load(std::memory_order_relaxed),
+        counters.async_handler_fail.load(std::memory_order_relaxed),
+        counters.allocation_fail.load(std::memory_order_relaxed),
+        counters.record_overflow.load(std::memory_order_relaxed));
+}
+
 /**
  * @brief This function is a queue write interceptor. It intercepts the
  * packet write function. Creates an instance of packet class with the raw
@@ -329,6 +763,11 @@ WriteInterceptor(const void* packets,
     ROCP_FATAL_IF(data == nullptr) << "WriteInterceptor was not passed a pointer to the queue";
 
     auto& queue = *static_cast<Queue*>(data);
+
+    if(kernel_trace_fast_path_enabled() && queue.get_notifiers() == 0)
+    {
+        if(FastPathWriteInterceptor(packets, pkt_count, queue, writer)) return;
+    }
 
     // We have no packets or no one who needs to be notified, do nothing.
     if(pkt_count == 0 ||
@@ -405,7 +844,7 @@ WriteInterceptor(const void* packets,
         }
     }};
 
-    using packet_writer_fn_t = std::function<void(packet_vector_t &&)>;
+    using packet_writer_fn_t = std::function<void(packet_vector_t&&)>;
 
     auto process_packet_batch = [&queue, &corr_id, tracing_data_v](
                                     const rocprofiler_packet* _packets,
@@ -847,6 +1286,7 @@ Queue::Queue(
 Queue::~Queue()
 {
     sync();
+    report_fast_path_counters_once();
     _core_api.hsa_signal_destroy_fn(_active_kernels);
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -498,6 +498,7 @@ struct fast_path_session_t
     rocprofiler_timestamp_t            enqueue_ts  = 0;
     rocprofiler_dispatch_id_t          dispatch_id = 0;
     rocprofiler_kernel_dispatch_info_t dispatch_info{};
+    tracing::tracing_data              tracing_data{};
 };
 
 bool
@@ -536,6 +537,27 @@ FastPathSignalHandler(hsa_signal_value_t /*signal_value*/, void* data)
            session->tid, dispatch_time.start, dispatch_time.end, session->dispatch_info}))
     {
         fast_path_counters().recorded.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    if(!session->tracing_data.empty())
+    {
+        auto packet                                            = packet_data_t{};
+        packet.tracing_data                                    = std::move(session->tracing_data);
+        packet.kernel_packet.kernel_dispatch.completion_signal = session->signal;
+        packet.callback_record =
+            packet_data_t::callback_record_t{sizeof(packet_data_t::callback_record_t),
+                                             rocprofiler_timestamp_t{0},
+                                             rocprofiler_timestamp_t{0},
+                                             session->dispatch_info};
+
+        auto queue_info_session = queue_info_session_t{.queue          = *session->queue,
+                                                       .tid            = session->tid,
+                                                       .enqueue_ts     = session->enqueue_ts,
+                                                       .correlation_id = nullptr,
+                                                       .packet_data    = {}};
+        queue_info_session.packet_data.emplace_back(std::move(packet));
+        kernel_dispatch::dispatch_complete(
+            queue_info_session, queue_info_session.packet_data.front(), dispatch_time);
     }
     return false;
 }
@@ -645,6 +667,10 @@ FastPathWriteInterceptor(const void*                           packets,
     // unique sequence id for the dispatch
     static auto sequence_counter = std::atomic<rocprofiler_dispatch_id_t>{0};
     const auto  dispatch_id      = ++sequence_counter;
+    auto        tracing_data_v   = tracing::tracing_data{};
+    tracing::populate_contexts(ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH,
+                               ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
+                               tracing_data_v);
 
     constexpr auto kernel_dispatch_info_rt_size =
         common::compute_runtime_sizeof<rocprofiler_kernel_dispatch_info_t>();
@@ -665,14 +691,16 @@ FastPathWriteInterceptor(const void*                           packets,
                                         original_packet.grid_size_z},
         .reserved_padding     = {0}};
 
-    auto* session = new(std::nothrow) fast_path_session_t{.queue         = &queue,
-                                                          .signal        = signal,
-                                                          .wait_value    = wait_value,
-                                                          .owns_signal   = owns_signal,
-                                                          .tid           = common::get_tid(),
-                                                          .enqueue_ts    = common::timestamp_ns(),
-                                                          .dispatch_id   = dispatch_id,
-                                                          .dispatch_info = dispatch_info};
+    auto* session =
+        new(std::nothrow) fast_path_session_t{.queue         = &queue,
+                                              .signal        = signal,
+                                              .wait_value    = wait_value,
+                                              .owns_signal   = owns_signal,
+                                              .tid           = common::get_tid(),
+                                              .enqueue_ts    = common::timestamp_ns(),
+                                              .dispatch_id   = dispatch_id,
+                                              .dispatch_info = dispatch_info,
+                                              .tracing_data  = std::move(tracing_data_v)};
 
     if(!session)
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.hpp
@@ -34,6 +34,7 @@
 #include <rocprofiler-sdk/agent.h>
 #include <rocprofiler-sdk/buffer_tracing.h>
 #include <rocprofiler-sdk/callback_tracing.h>
+#include <rocprofiler-sdk/defines.h>
 #include <rocprofiler-sdk/fwd.h>
 
 #include <hsa/amd_hsa_kernel_code.h>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling.cpp
@@ -24,6 +24,7 @@
 #include <rocprofiler-sdk/pc_sampling.h>
 
 #include "lib/common/environment.hpp"
+#include "lib/common/lite_trace_internal.hpp"
 #include "lib/rocprofiler-sdk/agent.hpp"
 #include "lib/rocprofiler-sdk/buffer.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
@@ -140,7 +141,8 @@ is_pc_sampling_explicitly_enabled()
 }
 }  // namespace
 
-extern "C" {
+extern "C"
+{
 rocprofiler_status_t
 rocprofiler_configure_pc_sampling_service(rocprofiler_context_id_t         context_id,
                                           rocprofiler_agent_id_t           agent_id,
@@ -150,6 +152,8 @@ rocprofiler_configure_pc_sampling_service(rocprofiler_context_id_t         conte
                                           rocprofiler_buffer_id_t          buffer_id,
                                           int /*flags*/)
 {
+    if(rocprofiler::common::lite_trace::enabled()) return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
+
     if(!is_pc_sampling_explicitly_enabled()) return ROCPROFILER_STATUS_ERROR_NOT_IMPLEMENTED;
 
 #if ROCPROFILER_SDK_HSA_PC_SAMPLING > 0

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -27,6 +27,7 @@
 #include "lib/common/elf_utils.hpp"
 #include "lib/common/environment.hpp"
 #include "lib/common/filesystem.hpp"
+#include "lib/common/lite_trace_internal.hpp"
 #include "lib/common/logging.hpp"
 #include "lib/common/static_object.hpp"
 #include "lib/common/static_tl_object.hpp"
@@ -90,7 +91,8 @@
 #include <unordered_set>
 #include <vector>
 
-extern "C" {
+extern "C"
+{
 #pragma weak rocprofiler_configure
 
 extern rocprofiler_tool_configure_result_t*
@@ -323,7 +325,7 @@ struct client_library
     client_library(const client_library&)     = delete;
     client_library(client_library&&) noexcept = default;
 
-    client_library& operator=(const client_library&) = delete;
+    client_library& operator=(const client_library&)     = delete;
     client_library& operator=(client_library&&) noexcept = delete;
 
     std::string                                 name                    = {};
@@ -998,6 +1000,7 @@ finalize()
         {
             invoke_client_finalizers();
         }
+        if(common::lite_trace::enabled()) common::lite_trace::unlink_record_store();
         if(num_clients > 0) internal_threading::finalize();
         set_fini_status(1);
     });
@@ -1021,7 +1024,8 @@ detach()
 }  // namespace registration
 }  // namespace rocprofiler
 
-extern "C" {
+extern "C"
+{
 rocprofiler_status_t
 rocprofiler_is_initialized(int* status)
 {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.hpp
@@ -30,7 +30,8 @@
 #include <string>
 #include <vector>
 
-extern "C" {
+extern "C"
+{
 // this is the "hidden" function that rocprofiler-register invokes to pass
 // the API tables to rocprofiler
 int

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/service.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/service.cpp
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include "lib/common/lite_trace_internal.hpp"
 #include "lib/rocprofiler-sdk/aql/helpers.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
 #include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
@@ -98,7 +99,8 @@ build_pack_from_array(parameter_pack&                             pack,
 }
 };  // namespace
 
-extern "C" {
+extern "C"
+{
 rocprofiler_status_t
 rocprofiler_configure_dispatch_thread_trace_service(
     rocprofiler_context_id_t                        context_id,
@@ -110,6 +112,8 @@ rocprofiler_configure_dispatch_thread_trace_service(
     void*                                           callback_userdata)
 {
     ROCP_TRACE << "Configuring Dispatch ATT for agent " << agent_id.handle;
+
+    if(rocprofiler::common::lite_trace::enabled()) return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
 
     if(rocprofiler::registration::get_init_status() > -1)
         return ROCPROFILER_STATUS_ERROR_CONFIGURATION_LOCKED;
@@ -149,6 +153,8 @@ rocprofiler_configure_device_thread_trace_service(
     rocprofiler_user_data_t                         userdata)
 {
     ROCP_TRACE << "Configuring Device ATT for agent " << agent_id.handle;
+
+    if(rocprofiler::common::lite_trace::enabled()) return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
 
     if(rocprofiler::registration::get_init_status() > -1)
         return ROCPROFILER_STATUS_ERROR_CONFIGURATION_LOCKED;


### PR DESCRIPTION
## Summary

This adds rocprofv3 `--lite-trace` as a low-overhead kernel-dispatch tracing mode. The CLI option is only a convenience wrapper: it sets `ROCPROF_LITE_TRACE=1` for the profiled process and implies kernel tracing.

`--fast-path` is removed as a user-facing option. The old `ROCPROF_KERNEL_TRACE_FAST_PATH` env hook is also removed; lite mode is selected only through `--lite-trace` or `ROCPROF_LITE_TRACE=1`.

No public rocprofiler-sdk API/header/signature is added. SDK/tool behavior is controlled by the existing environment variable path: when `ROCPROF_LITE_TRACE=1`, existing configure APIs only allow kernel-dispatch buffer tracing and code-object callbacks needed for kernel names. Other services are rejected with `ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT`.

This revision also removes the earlier internal cross-DSO hook shape:

- removed `source/lib/rocprofiler-sdk/lite_trace.hpp`
- removed `registration::get_client_symbol(...)`
- removed the exported tool hook `rocprofiler_sdk_tool_lite_trace_append_record`
- removed the hook symbol-name/compact-record declarations from the rocprofiler-sdk internal namespace

The compact dispatch handoff is now source-internal implementation detail only: queue interception appends compact records into a preallocated mmap-backed store from `lib/common/lite_trace_internal.hpp`, preferring `/dev/shm` and falling back to `/tmp`; the lite rocpd writer reads the same store and unlinks it after output generation. User/API control remains only `ROCPROF_LITE_TRACE=1`.

## Remaining internal-only overhead work

The current PR removes the large generic SDK/tool/rocpd overheads, but two internal dispatch-path costs remain visible:

- Reduce async handler registration cost. Current lite trace still registers an async signal handler per dispatch completion signal. A lower-overhead internal design is a preallocated completion-signal pool plus a small internal poll/drain thread, or batched waits, so dispatch only stores compact state and returns.
- Make injected signal reuse tighter. This workload has `reused_existing_signal=0`, so reuse of app-provided signals will not help here. Reusing rocprofiler-owned signals/session slots without per-dispatch churn should help. This PR already keeps profiler-owned completion signals in an internal pool, but the next step is to reuse the per-dispatch session/completion state more aggressively and avoid per-dispatch handler registration.

## What lite trace removes

Lite trace keeps:

- kernel dispatch records
- kernel dispatch timestamps
- code-object metadata needed to resolve kernel names

Lite trace disables or rejects:

- HIP/HSA/marker/RCCL/rocDecode/rocJPEG API tracing
- memory copy/allocation/scratch tracing
- counter collection
- PC sampling
- ATT/thread trace
- external correlation id mapping
- marker kernel rename, HIP stream, and runtime-initialization callback contexts in rocprofv3
- the normal rocpd output path; lite mode writes compact kernel dispatch rows and kernel symbols through the fast rocpd writer

## Usage

CLI:

```bash
rocprofv3 --lite-trace --output-format rocpd -d ./out -o results -- ./app [args]
```

Environment-driven rocprofv3:

```bash
ROCPROF_LITE_TRACE=1 rocprofv3 --output-format rocpd -d ./out -o results -- ./app [args]
```

SDK/tool usage:

```c
setenv("ROCPROF_LITE_TRACE", "1", 1);

/* Allowed */
rocprofiler_configure_buffer_tracing_service(
    ctx, ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH, NULL, 0, buffer);

/* Optional metadata path for kernel names */
rocprofiler_configure_callback_tracing_service(
    ctx, ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT, NULL, 0, code_object_cb, NULL);
```

Do not configure other SDK services in lite mode. They are intentionally rejected so a lite-mode tool cannot accidentally reintroduce API/runtime/correlation overhead.

## End-to-end timing

Measured locally from this `origin/develop`-rebased branch with `ROCR_VISIBLE_DEVICES=0`; 3 measured rounds, median wall time.

Worktree used for this run: `/home/aelwazir/work/.worktrees/rocprofv3-fastpath-rocm722-work-s8n`.

`lite SDK sample app` is a local SDK API sample executable based on the same `gpu_workload` source. It configures kernel-dispatch buffer tracing plus code-object metadata with the existing public SDK APIs, runs under `ROCPROF_LITE_TRACE=1`, and calls the client finalizer explicitly before process exit.

| workload | none | normal `--kernel-trace` | lite rocprofv3 `--lite-trace` | lite SDK sample app | overhead normal | overhead lite rocprofv3 | overhead lite SDK sample | lite rocprofv3 vs normal | lite SDK sample vs normal |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| L1-gemm-steady (`gemm 64 5000`) | 211.323 ms | 1102.817 ms | 288.514 ms | 228.835 ms | +421.9% | +36.5% | +8.3% | 73.8% lower / 3.82x faster | 79.2% lower / 4.82x faster |
| L1-short-kernels (`short 8000`) | 149.571 ms | 1038.547 ms | 270.334 ms | 217.855 ms | +594.4% | +80.7% | +45.7% | 74.0% lower / 3.84x faster | 79.0% lower / 4.77x faster |

These numbers are local measurements from this host/GPU and should not be treated as a cross-machine performance guarantee.

## Additional workload checks

Measured locally with `ROCR_VISIBLE_DEVICES=0`. These are focused single-run checks, not the 3-round L1 median sweep above.

GraphBench command:

```bash
graph_bench --size 1024 --iters 10 --topology full4 --no-sync
```

| mode | return code | wall time | GraphBench `full4` |
| --- | ---: | ---: | ---: |
| baseline | 0 | 0.381 s | 580.133 us |
| lite rocprofv3 `--lite-trace` | 0 | 0.535 s | 1288.048 us |
| lite SDK sample app | 0 | 0.390 s | 2752.262 us |

GraphBench lite rocprofv3 output verification:

- kernel dispatch rows: 20480
- invalid timestamp rows: 0
- kernel symbol rows: 17
- hot symbol: `null_kernel()` with 20480 dispatches
- fast-path summary: `recorded=20480`, `injected_signal=20480`, `reused_existing_signal=0`, all failure counters 0

The GraphBench lite SDK sample app used the same existing public SDK API pattern under `ROCPROF_LITE_TRACE=1`; it recorded the same 20480 compact dispatch records with all failure counters 0.

PyTorch command:

```bash
python3 pytorch_lite_workload.py --n 1024 --iters 50 --warmup 5
```

Container: `rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.7.1`. The wall time below includes Docker startup; the PyTorch duration is the workload's own measured `torch.mm` loop timing.

| mode | return code | wall time | PyTorch duration | average iteration |
| --- | ---: | ---: | ---: | ---: |
| baseline | 0 | 2.201 s | 18.253 ms | 0.365 ms |
| lite rocprofv3 `--lite-trace` | 0 | 2.623 s | 18.498 ms | 0.370 ms |
| lite SDK sample tool | 0 | 2.611 s | 18.177 ms | 0.364 ms |

PyTorch lite rocprofv3 output verification:

- kernel dispatch rows: 58
- invalid timestamp rows: 0
- kernel symbol rows: 2491
- hot symbol: rocBLAS/Tensile GEMM kernel with 55 dispatches
- fast-path summary: `recorded=58`, `injected_signal=58`, `reused_existing_signal=0`, all failure counters 0

The PyTorch lite SDK sample tool used `ROCPROF_LITE_TRACE=1` and explicit tool shutdown from the workload before process teardown; it recorded the same 58 compact dispatch records with all failure counters 0.

## PyTorch/Kineto SDK-source validation

The prebuilt ROCm PyTorch containers were not used for the SDK performance claim because their Kineto path still loaded ROCTracer/register rather than `librocprofiler-sdk.so`. I built ROCm PyTorch from source in `/tmp/pytorch-kineto-sdk-src` from `ROCmSoftwarePlatform/pytorch:kineto_rocprof_release2.10`, with `third_party/kineto` from `ROCm/kineto`, inside `rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.10.0` using Docker `--privileged` and `ROCR_VISIBLE_DEVICES=0`. The CMake configure log showed `Building with: rocprofiler-sdk` and `Building with rocprofiler-sdk`; `ldd torch/lib/libtorch_cpu.so` showed `librocprofiler-sdk.so.1`.

The source-built Kineto run exposed a correctness gap in the first lite implementation: `ROCPROF_LITE_TRACE=1` was producing compact records but bypassed SDK buffer emission, so PyTorch reported `cuda_event_count=0`. This revision now keeps the compact lite record and, when an SDK API consumer has kernel-dispatch buffer tracing active, emits the kernel-dispatch buffer record with the same name/timestamp metadata. Lite mode still omits external correlation/callback machinery, so the PyTorch trace keeps GPU kernel events but not the normal higher-level `aten::mm` device attribution.

Command shape:

```bash
docker run --privileged --rm --ipc=host -v /tmp:/tmp \
  -e ROCR_VISIBLE_DEVICES=0 \
  -e PYTHONPATH=/tmp/pytorch-kineto-sdk-src \
  -e LD_LIBRARY_PATH=/tmp/pytorch-kineto-sdk-src/torch/lib:/tmp/rocprofv3-fastpath-722-install/lib:/opt/rocm/lib:/opt/rocm-7.2.0/lib \
  -e ROCPROF_LITE_TRACE=1 \
  -w /tmp/pytorch-kineto-sdk-src \
  rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.10.0 \
  python3 /tmp/pytorch_kineto_workload.py --mode profile --n 1024 --iters 50 --trace /tmp/kineto_trace.json
```

| Kineto variant | SDK actually loaded | lite env | median wall time | median `profile_total_ms` | median `profile_region_ms` | median `trace_export_ms` | CUDA/device events | Chrome trace GPU kernel events |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| source-built PyTorch + stock SDK | `/opt/rocm-7.2.0/lib/librocprofiler-sdk.so.1.1.0` | no | 5.71 s | 500.60 ms | 37.12 ms | 0.528 ms | 2 | 50 |
| source-built PyTorch + patched SDK normal | `/tmp/rocprofv3-fastpath-722-install/lib/librocprofiler-sdk.so.1.2.3` | no | 2.07 s | 500.84 ms | 36.96 ms | 0.526 ms | 2 | 50 |
| source-built PyTorch + patched SDK lite, before SDK-buffer fix | `/tmp/rocprofv3-fastpath-722-install/lib/librocprofiler-sdk.so.1.2.3` | yes | 2.07 s | 494.45 ms | 37.08 ms | 0.144 ms | 0 | 0 |
| source-built PyTorch + patched SDK lite, after SDK-buffer fix | `/tmp/rocprofv3-fastpath-722-install/lib/librocprofiler-sdk.so.1.2.3` | yes | 2.08 s | 496.88 ms | 37.08 ms | 0.255 ms | 1 | 50 |

Final smoke after rebuild/formatting: `cuda_event_count=1`, 50 GPU kernel events in the Chrome trace, patched SDK path present in `/proc/self/maps`, and `ROCPROF_LITE_TRACE=1` present in workload JSON.

## Validation

- Rebased onto `origin/develop`.
- `cmake --build projects/rocprofiler-sdk/build-fastpath-722 --parallel 16 --target all`
- `cmake --install projects/rocprofiler-sdk/build-fastpath-722`
- `rocprofv3 --fast-path -- /bin/true` fails as an unrecognized argument
- No `ROCPROF_KERNEL_TRACE_FAST_PATH` or `--fast-path` references remain in source/wrapper checks
- No lite compact-record types/accessors are present in installed public headers
- `librocprofiler-sdk.so` and `librocprofiler-sdk-tool.so` do not export or reference `get_client_symbol`, `rocprofiler_sdk_tool_lite_trace_append_record`, `append_record_symbol_name`, `compact_kernel_dispatch_record_t`, or other lite-trace record names
- API guard tool loaded via `ROCP_TOOL_LIBRARIES` verified allowed/rejected SDK services:
  - kernel dispatch buffer tracing: success
  - code-object metadata callback: success
  - memory copy, HIP runtime callback, dispatch counting, external correlation, PC sampling: `ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT`
- CLI `--lite-trace` smoke DB: 102 kernel rows, 0 bad timestamps, 17 kernel symbols
- Env-only `ROCPROF_LITE_TRACE=1` smoke DB: 102 kernel rows, 0 bad timestamps, 17 kernel symbols
- Normal `--kernel-trace` smoke DB: 102 kernel rows, 0 bad timestamps, 17 kernel symbols
- Benchmark validation DBs:
  - `L1-gemm-steady`: normal/lite both 5002 kernel rows, 0 bad timestamps, 17 kernel symbols
  - `L1-short-kernels`: normal/lite both 8002 kernel rows, 0 bad timestamps, 17 kernel symbols
- Lite SDK sample app validation:
  - `L1-gemm-steady`: 5002 compact kernel records, 0 timestamp/record failures
  - `L1-short-kernels`: 8002 compact kernel records, 0 timestamp/record failures
- Temporary compact-record files under `/dev/shm` or `/tmp` are unlinked after lite rocpd generation
- `git diff --check`
- outbound secret scan over the changed files with `custom-ai-secret-scan --repo-root <worktree> <changed files>`; full-repo fallback scanner hit a local `Argument list too long` runtime error

