### PR TITLE
[RCCL] net-ib: per-QP fault injection API, hooks, and tests for IB and CAST paths

### DIFF
--- a/projects/rccl/cmake/rocmIb.cmake
+++ b/projects/rccl/cmake/rocmIb.cmake
@@ -265,6 +265,10 @@ execute_process(
   WORKING_DIRECTORY ${RCCL_SRC_DIR}
 )
 execute_process(
+  COMMAND bash -c "sed -i 's/ncclIbFault/rocmIbFault/g' ${ROCM_NETIB_FILE}"
+  WORKING_DIRECTORY ${RCCL_SRC_DIR}
+)
+execute_process(
   COMMAND bash -c "sed -i 's/cuMemGetHandleForAddressRange/hipMemGetHandleForAddressRange/g' ${ROCM_NETIB_FILE}"
   WORKING_DIRECTORY ${RCCL_SRC_DIR}
 )

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -214,6 +214,8 @@ set(SRC_FILES
   include/plugin/net/net_v11.h
   include/plugin/profiler/net_ib_v1.h
   include/plugin/profiler/net_ib.h
+  include/net_ib_cast_inspect.h
+  include/net_ib_fault_inject.h
   include/plugin/profiler/net_socket_v1.h
   include/plugin/profiler/net_socket.h
   include/plugin/profiler/profiler_v1.h

--- a/projects/rccl/src/include/net_ib_fault_inject.h
+++ b/projects/rccl/src/include/net_ib_fault_inject.h
@@ -1,0 +1,59 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef RCCL_NET_IB_FAULT_INJECT_H_
+#define RCCL_NET_IB_FAULT_INJECT_H_
+
+#ifdef ENABLE_FAULT_INJECTION
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+#include "nccl.h"  /* ncclResult_t */
+extern "C" {
+#else
+#include <stdbool.h>
+#include "nccl.h"
+#endif
+
+/*
+ * Test-only per-QP fault injection API for the net-ib CAST transport.
+ *
+ * Implemented in src/transport/net_ib_cast.cc (CAST multi-QP path).
+ *
+ * NCCL_IB_MAX_QPS is defined in net_ib_cast_inspect.h; guard against
+ * double-definition when both headers are included together.
+ */
+#ifndef NCCL_IB_MAX_QPS
+#define NCCL_IB_MAX_QPS 128
+#endif
+
+/* ── CAST path (net_ib_cast.cc) ───────────────────────────────────────── */
+
+/* Set an artificial delay (microseconds) on a specific QP index.
+ * qpIdx must be in [0, NCCL_IB_MAX_QPS).
+ * Set delayUs=0 to clear the delay. */
+ncclResult_t ncclIbCastFaultSetQpDelay(void* sendComm, int qpIdx, uint32_t delayUs);
+
+/* Arm error injection on a specific QP index.
+ * When armed, the hook calls ncclIbStatsFatalError and then returns
+ * ncclSystemError instead of calling wrap_ibv_post_send.
+ * Set inject=false to disarm. */
+ncclResult_t ncclIbCastFaultSetQpError(void* sendComm, int qpIdx, bool inject);
+
+/* Clear all fault state (delays and errors) on the connection. */
+ncclResult_t ncclIbCastFaultClear(void* sendComm);
+
+/* Return the current fatalErrorCount from the connection's stats. */
+ncclResult_t ncclIbCastFaultGetFatalCount(void* sendComm, int* out);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* ENABLE_FAULT_INJECTION */
+
+#endif /* RCCL_NET_IB_FAULT_INJECT_H_ */

--- a/projects/rccl/src/transport/net_ib_cast.cc
+++ b/projects/rccl/src/transport/net_ib_cast.cc
@@ -2942,7 +2942,7 @@ exit:
 ncclResult_t ncclIbCastFaultSetQpDelay(void* sendComm, int qpIdx, uint32_t delayUs) {
   if (!sendComm) return ncclInvalidArgument;
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
-  if (qpIdx < 0 || qpIdx >= NCCL_IB_MAX_QPS) return ncclInvalidArgument;
+  if (qpIdx < 0 || qpIdx >= comm->base.nqps) return ncclInvalidArgument;
   comm->base.faultQpDelayUs[qpIdx] = delayUs;
   return ncclSuccess;
 }
@@ -2950,7 +2950,7 @@ ncclResult_t ncclIbCastFaultSetQpDelay(void* sendComm, int qpIdx, uint32_t delay
 ncclResult_t ncclIbCastFaultSetQpError(void* sendComm, int qpIdx, bool inject) {
   if (!sendComm) return ncclInvalidArgument;
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
-  if (qpIdx < 0 || qpIdx >= NCCL_IB_MAX_QPS) return ncclInvalidArgument;
+  if (qpIdx < 0 || qpIdx >= comm->base.nqps) return ncclInvalidArgument;
   comm->base.faultQpError[qpIdx] = inject;
   return ncclSuccess;
 }
@@ -2960,6 +2960,7 @@ ncclResult_t ncclIbCastFaultClear(void* sendComm) {
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
   memset(comm->base.faultQpDelayUs, 0, sizeof(comm->base.faultQpDelayUs));
   memset(comm->base.faultQpError, 0, sizeof(comm->base.faultQpError));
+  __atomic_store_n(&comm->base.stats.fatalErrorCount, 0, __ATOMIC_RELEASE);
   return ncclSuccess;
 }
 

--- a/projects/rccl/src/transport/net_ib_cast.cc
+++ b/projects/rccl/src/transport/net_ib_cast.cc
@@ -10,6 +10,7 @@
 #include "socket.h"
 #include "net.h"
 #include "net_ib_cast_inspect.h"
+#include "net_ib_fault_inject.h"
 #include "graph.h"
 #include "utils.h"
 #include "param.h"
@@ -1714,6 +1715,10 @@ struct alignas(32) ncclIbNetCommBase {
   struct ncclIbDevInfo remDevs[NCCL_IB_MAX_DEVS_PER_NIC];
   // statistics about the comm
   struct ncclIbStats stats;
+#ifdef ENABLE_FAULT_INJECTION
+  uint32_t faultQpDelayUs[NCCL_IB_MAX_QPS];
+  bool     faultQpError[NCCL_IB_MAX_QPS];
+#endif
 };
 
 struct ncclIbSendComm {
@@ -2931,6 +2936,42 @@ exit:
   return nqps;
 }
 
+/* ── Fault injection API (CAST path) ──────────────────────────────────── */
+#ifdef ENABLE_FAULT_INJECTION
+
+ncclResult_t ncclIbCastFaultSetQpDelay(void* sendComm, int qpIdx, uint32_t delayUs) {
+  if (!sendComm) return ncclInvalidArgument;
+  struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
+  if (qpIdx < 0 || qpIdx >= NCCL_IB_MAX_QPS) return ncclInvalidArgument;
+  comm->base.faultQpDelayUs[qpIdx] = delayUs;
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbCastFaultSetQpError(void* sendComm, int qpIdx, bool inject) {
+  if (!sendComm) return ncclInvalidArgument;
+  struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
+  if (qpIdx < 0 || qpIdx >= NCCL_IB_MAX_QPS) return ncclInvalidArgument;
+  comm->base.faultQpError[qpIdx] = inject;
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbCastFaultClear(void* sendComm) {
+  if (!sendComm) return ncclInvalidArgument;
+  struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
+  memset(comm->base.faultQpDelayUs, 0, sizeof(comm->base.faultQpDelayUs));
+  memset(comm->base.faultQpError, 0, sizeof(comm->base.faultQpError));
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbCastFaultGetFatalCount(void* sendComm, int* out) {
+  if (!sendComm || !out) return ncclInvalidArgument;
+  struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
+  *out = __atomic_load_n(&comm->base.stats.fatalErrorCount, __ATOMIC_ACQUIRE);
+  return ncclSuccess;
+}
+
+#endif /* ENABLE_FAULT_INJECTION */
+
 static ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, int qpIndex, bool wrrSched, bool use_write_op) {
   struct ncclIbRequest** reqs = comm->fifoReqs[slot];
   volatile struct ncclIbSendFifo* slots = comm->fifo[slot];
@@ -3086,6 +3127,16 @@ static ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int n
       void* pHandle = reqs[r]->pInfo[0].pHandle;
       NCCLCHECK(ncclProfilerFunction(&reqs[r]->pInfo[0].qpEventHandles[nEventHandles], ncclProfilerNetEventStart, pHandle, pluginId, &reqs[r]->pInfo[0].data));
       reqs[r]->pInfo[0].nEventHandles++;
+    }
+#endif
+#ifdef ENABLE_FAULT_INJECTION
+    {
+      const uint32_t faultDelay = comm->base.faultQpDelayUs[qpIndex];
+      if (faultDelay) usleep(faultDelay);
+      if (comm->base.faultQpError[qpIndex]) {
+        ncclIbStatsFatalError(&comm->base.stats);
+        return ncclSystemError;
+      }
     }
 #endif
     NCCLCHECK(wrap_ibv_post_send(qp->qp, comm->wrs, &bad_wr));

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -274,6 +274,7 @@ if(BUILD_TESTS)
       transport/NetIbMPI/GeneralTests.cpp
       transport/NetIbMPI/NicFusionTests.cpp
       transport/NetIbMPI/CastTests.cpp
+      transport/NetIbMPI/FaultInjectTests.cpp
       ImplicitLaunchOrderMPITests.cpp
       RegistrationMPITests.cpp
     )

--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -607,6 +607,10 @@ TEST_F(NetIbMPITest, FaultInjCastQpErrorClearRecovers) {
     MPI_Barrier(MPI_COMM_WORLD);
 
     // Trigger the fault (rank 0 posts recv, rank 1 posts send that will fail).
+    // rank 1 forwards its fault result to rank 0 so we can assert the fault
+    // was actually observed before testing recovery in phase 2.
+    static constexpr int kPhase1MpiTag = 9882;
+    FaultInjectResult p1 = {};
     if (rank == 0) {
         void*  bufs[1]    = {buf1};
         size_t sizes[1]   = {kMsgSize};
@@ -628,17 +632,32 @@ TEST_F(NetIbMPITest, FaultInjCastQpErrorClearRecovers) {
             if (sendRet != ncclSuccess || sendReq != nullptr) break;
             usleep(kPollIntervalUs);
         }
+        int fatalCount = 0;
         if (sendRet == ncclSuccess && sendReq != nullptr) {
             for (int poll = 0; poll < 200; poll++) {
                 int done = 0, sz = 0;
-                int fc = 0;
                 TestRequest(sendReq, &done, &sz);
-                ncclIbCastFaultGetFatalCount(sendComm1, &fc);
-                if (done || fc > 0) break;
+                ncclIbCastFaultGetFatalCount(sendComm1, &fatalCount);
+                if (done || fatalCount > 0) break;
                 usleep(kPollIntervalUs);
             }
+        } else {
+            ncclIbCastFaultGetFatalCount(sendComm1, &fatalCount);
         }
+        p1.sendRet    = static_cast<int>(sendRet);
+        p1.fatalCount = fatalCount;
         ncclIbCastFaultClear(sendComm1);
+        MPI_Send(&p1, sizeof(p1), MPI_BYTE, 0, kPhase1MpiTag, MPI_COMM_WORLD);
+    }
+
+    if (rank == 0) {
+        MPI_Recv(&p1, sizeof(p1), MPI_BYTE, 1, kPhase1MpiTag, MPI_COMM_WORLD,
+                 MPI_STATUS_IGNORE);
+        bool isendFailed = (p1.sendRet != static_cast<int>(ncclSuccess));
+        EXPECT_TRUE(isendFailed || p1.fatalCount > 0)
+            << "Phase 1: fault injection did not trigger — isend returned "
+            << p1.sendRet << ", fatalCount=" << p1.fatalCount
+            << "; recovery test is meaningless without a confirmed fault";
     }
 
     MPI_Barrier(MPI_COMM_WORLD);

--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -170,4 +170,159 @@ TEST_F(NetIbMPITest, FaultInjCastQpErrorIsFatal) {
     MPI_Barrier(MPI_COMM_WORLD);
 }
 
+// =============================================================================
+// Test: FaultInjCastSlowQpRebalances
+//
+// CAST path with WRR enabled. Arm a 10 ms delay on QP 0 and run 500 sends.
+// The RTT timer fires every 50 ms (several times during the run) and updates
+// initQpTokens based on measured per-QP latency.
+//
+// The test follows the pattern of CastStressMultiRoundTwoConns:
+//   - rank 1 reads ncclIbCastSchedState and sends it to rank 0 via MPI
+//   - rank 0 performs all assertions (scheduler state + data integrity)
+//
+// Verifies:
+//   - initQpTokens[0] differs from the initial equal share (RTT timer fired)
+//   - Data arrives intact on the receiver
+//   - Requires >= 2 actual QPs; skipped otherwise.
+//
+// Message size is kept below GetSplitDataMin() so messages always take the
+// WRR token path (same rationale as CastStressMultiRoundTwoConns).
+// =============================================================================
+TEST_F(NetIbMPITest, FaultInjCastSlowQpRebalances) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    const int rank = MPIEnvironment::world_rank;
+
+    CAST_ENV_CHECK_OR_SKIP();
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    void* listenComm = nullptr;
+    void* sendComm   = nullptr;
+    void* recvComm   = nullptr;
+    SetupCastConnection(/*dev=*/0, &listenComm, &sendComm, &recvComm);
+
+    constexpr int kNMsgs = 500;
+    // Keep below splitDataMin so messages take the WRR token path.
+    const size_t kMsgSz = std::max<size_t>(64, GetSplitDataMin() - 1);
+    const size_t kBufSz = static_cast<size_t>(kNMsgs) * kMsgSz;
+    constexpr int kBaseTag = 4000;
+
+    std::vector<char> sendBuf(kBufSz), recvBuf(kBufSz);
+    for (size_t i = 0; i < kBufSz; i++) sendBuf[i] = static_cast<char>((i * 3 + 7) & 0xFF);
+    memset(recvBuf.data(), 0, kBufSz);
+
+    void* comm    = (rank == 0) ? recvComm : sendComm;
+    char* regBuf  = (rank == 0) ? recvBuf.data() : sendBuf.data();
+    void* mhandle = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, regBuf, kBufSz, NCCL_PTR_HOST, &mhandle), ncclSuccess);
+
+    // Warmup: initialise WRR state and learn actual nqps.
+    const int actualNqps = GetActualNqps(sendComm, recvComm, regBuf, kMsgSz, kBaseTag - 1, mhandle);
+    ASSERT_GT(actualNqps, 0);
+
+    // Broadcast skip decision from rank 1 (the only rank that owns sendComm
+    // and can read the real QP count after the warmup send).  root=1 is
+    // intentional: rank 1 sets doSkip, rank 0 receives it.
+    int doSkip = (actualNqps < 2) ? 1 : 0;
+    MPI_Bcast(&doSkip, 1, MPI_INT, /*root=*/1, MPI_COMM_WORLD);
+    if (doSkip) {
+        GTEST_SKIP() << "Need >= 2 actual QPs for rebalancing test (got " << actualNqps << ")";
+    }
+
+    if (rank == 1) {
+        // Arm equal-weight tokens as baseline for the RTT comparison.
+        const std::vector<int> tokens = EqualTokens(actualNqps);
+        ASSERT_EQ(ncclIbCastSetTokens(sendComm, tokens.data(), actualNqps), ncclSuccess);
+        // Arm 10 ms delay on QP 0 — makes QP 0 observably slower to the RTT timer.
+        ASSERT_EQ(ncclIbCastFaultSetQpDelay(sendComm, /*qpIdx=*/0, /*delayUs=*/10000), ncclSuccess);
+    }
+
+    // 500 sends in batches of 16 (mirrors CastStressMultiRoundTwoConns).
+    constexpr int kBatch = 16;
+    if (rank == 0) {
+        for (int base = 0; base < kNMsgs; base += kBatch) {
+            const int end = std::min(base + kBatch, kNMsgs);
+            std::vector<void*> reqs(end - base, nullptr);
+            for (int i = base; i < end; i++) {
+                void*  bufs[1]    = {recvBuf.data() + i * kMsgSz};
+                size_t sizes[1]   = {kMsgSz};
+                int    tags[1]    = {kBaseTag + i};
+                void*  handles[1] = {mhandle};
+                ASSERT_EQ(PostRecv(recvComm, 1, bufs, sizes, tags, handles, &reqs[i - base]),
+                          ncclSuccess);
+                ASSERT_NE(reqs[i - base], nullptr);
+            }
+            for (int i = 0; i < end - base; i++) {
+                int sz = 0;
+                ASSERT_EQ(WaitForCompletion(reqs[i], &sz, 10000), ncclSuccess);
+            }
+        }
+    } else {
+        for (int base = 0; base < kNMsgs; base += kBatch) {
+            const int end = std::min(base + kBatch, kNMsgs);
+            std::vector<void*> reqs(end - base, nullptr);
+            for (int i = base; i < end; i++)
+                PostSendWithRetry(sendComm, sendBuf.data() + i * kMsgSz, kMsgSz,
+                                  kBaseTag + i, mhandle, &reqs[i - base]);
+            for (int i = 0; i < end - base; i++) {
+                int sz = 0;
+                ASSERT_EQ(WaitForCompletion(reqs[i], &sz, 10000), ncclSuccess);
+            }
+        }
+    }
+
+    // rank 1 reads scheduler state and ships it to rank 0 for assertions.
+    // (State lives in sendComm which only rank 1 owns.)
+    struct ncclIbCastSchedState st = {};
+    if (rank == 1) {
+        ASSERT_EQ(ncclIbCastGetSchedState(sendComm, &st), ncclSuccess);
+        MPI_Send(&st, sizeof(st), MPI_BYTE, 0, kSchedStateMpiTag, MPI_COMM_WORLD);
+        ASSERT_EQ(ncclIbCastFaultClear(sendComm), ncclSuccess);
+    } else {
+        MPI_Recv(&st, sizeof(st), MPI_BYTE, 1, kSchedStateMpiTag, MPI_COMM_WORLD,
+                 MPI_STATUS_IGNORE);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (rank == 0) {
+        // Data integrity: recvBuf must match what rank 1 sent.
+        EXPECT_EQ(memcmp(recvBuf.data(), sendBuf.data(), kBufSz), 0)
+            << "data corruption with 10 ms QP 0 delay";
+
+        // RTT timer check: initQpTokens[0] must have changed from the initial
+        // equal share.  Use EqualTokens() — not integer division — to get the
+        // exact baseline value that was set by rank 1 before the sends, so the
+        // comparison is consistent even when 100 % actualNqps != 0.
+        const std::vector<int> baseTokens = EqualTokens(actualNqps);
+        EXPECT_LT(st.initQpTokens[0], baseTokens[0])
+            << "RTT timer did not reduce QP 0 tokens below equal share (initQpTokens[0]=" << st.initQpTokens[0]
+            << ", equalShare=" << baseTokens[0] << "); "
+            << "was 10 ms delay insufficient for the RTT timer interval?";
+
+        // WRR invariants: token accounting must be consistent.
+        EXPECT_TRUE(st.schedInit) << "schedInit must be true after 500 sends";
+        {
+            int s = 0;
+            for (int q = 0; q < st.nqps; q++) s += st.activeQpTokens[q];
+            EXPECT_EQ(s, st.activeTotTokens) << "activeQpTokens sum mismatch";
+        }
+        EXPECT_GE(st.activeTotTokens, 0);
+        EXPECT_LE(st.activeTotTokens, st.initTotTokens);
+    }
+
+    ASSERT_EQ(DeregisterMemory(comm, mhandle), ncclSuccess);
+    if (rank == 0) {
+        ASSERT_EQ(CloseRecvComm(recvComm), ncclSuccess);
+        ASSERT_EQ(CloseListenComm(listenComm), ncclSuccess);
+    } else {
+        ASSERT_EQ(CloseSendComm(sendComm), ncclSuccess);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
 #endif /* MPI_TESTS_ENABLED && ENABLE_FAULT_INJECTION */

--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -1,0 +1,173 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include "NetIbMPITestBase.hpp"
+#include "NetIbCastInspect.hpp"
+#include "NetIbFaultInject.hpp"
+
+#if defined(MPI_TESTS_ENABLED) && defined(ENABLE_FAULT_INJECTION)
+
+// MPI tags used for inter-rank result forwarding (rank 1 → rank 0).
+// Keep these distinct from NCCL-level recv tags (per-message ints passed to irecv).
+static constexpr int kSchedStateMpiTag  = 9880;  // ncclIbCastSchedState from FaultInjCastSlowQpRebalances
+static constexpr int kFaultResultMpiTag = 9881;  // FaultInjectResult from FaultInjCastQpErrorIsFatal
+
+// Carries rank 1's observable state after the fault injection attempt to rank 0
+// so all assertions run on rank 0 (the only rank with GTest listeners).
+struct FaultInjectResult {
+    int  sendRet;       // ncclResult_t from PostSend (cast to int)
+    int  fatalCount;    // ncclIbCastFaultGetFatalCount result
+    int  clearRet;      // ncclResult_t from ncclIbCastFaultClear (cast to int)
+    int  setErrRet;     // first non-Success from ncclIbCastFaultSetQpError, or ncclSuccess
+    int  actualNqps;    // number of QPs armed with the error fault
+};
+
+// =============================================================================
+// Test: FaultInjCastQpErrorIsFatal
+//
+// CAST path. Arm error injection on QP 0. The fault hook fires inside
+// IbCastMultiSend before wrap_ibv_post_send and returns ncclSystemError;
+// NCCLCHECK propagates it to IbCastIsend → net_->isend caller.
+//
+// Verifies:
+//   - isend returns an error OR fatalErrorCount > 0
+// =============================================================================
+TEST_F(NetIbMPITest, FaultInjCastQpErrorIsFatal) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    CAST_ENV_CHECK_OR_SKIP();
+
+    const int rank = MPIEnvironment::world_rank;
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    void* listenComm = nullptr;
+    void* sendComm   = nullptr;
+    void* recvComm   = nullptr;
+    SetupCastConnection(/*dev=*/0, &listenComm, &sendComm, &recvComm);
+
+    constexpr size_t kMsgSize = 1024;
+    std::vector<char> sendBuf(kMsgSize), recvBuf(kMsgSize);
+    for (size_t i = 0; i < kMsgSize; i++) sendBuf[i] = static_cast<char>(i & 0xFF);
+    memset(recvBuf.data(), 0, kMsgSize);
+
+    void* comm    = (rank == 0) ? recvComm : sendComm;
+    void* buf     = (rank == 0) ? static_cast<void*>(recvBuf.data())
+                                : static_cast<void*>(sendBuf.data());
+    void* mhandle = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf, kMsgSize, NCCL_PTR_HOST, &mhandle), ncclSuccess);
+
+    // Warmup: initialise WRR scheduler state before arming the fault.
+    const int actualNqps = GetActualNqps(sendComm, recvComm, buf, kMsgSize, /*tag=*/300, mhandle);
+    ASSERT_GT(actualNqps, 0);
+
+    // rank 1 arms the fault on every active QP so it fires regardless of which
+    // one the WRR scheduler selects for the next send.
+    FaultInjectResult r1 = {};
+    r1.actualNqps = actualNqps;
+    if (rank == 1) {
+        r1.setErrRet = static_cast<int>(ncclSuccess);
+        for (int q = 0; q < actualNqps; ++q) {
+            ncclResult_t ret = ncclIbCastFaultSetQpError(sendComm, q, /*inject=*/true);
+            if (ret != ncclSuccess && r1.setErrRet == static_cast<int>(ncclSuccess))
+                r1.setErrRet = static_cast<int>(ret);
+        }
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Track whether the recv request completed so we can drain before CloseRecvComm.
+    bool recvDone = false;
+    void* recvReq = nullptr;
+
+    if (rank == 0) {
+        void*  bufs[1]    = {buf};
+        size_t sizes[1]   = {kMsgSize};
+        int    tags[1]    = {301};
+        void*  handles[1] = {mhandle};
+        ASSERT_EQ(PostRecv(recvComm, 1, bufs, sizes, tags, handles, &recvReq), ncclSuccess);
+        for (int poll = 0; poll < 100; poll++) {
+            int done = 0, sz = 0;
+            if (TestRequest(recvReq, &done, &sz) != ncclSuccess) break;
+            if (done) { recvDone = true; break; }
+            usleep(kPollIntervalUs);
+        }
+    } else {
+        // IbCastIsend sets *request before IbCastMultiSend is called, so sendReq
+        // may be non-null even when sendRet != ncclSuccess. Break on either condition.
+        void* sendReq = nullptr;
+        ncclResult_t sendRet = ncclSuccess;
+        for (int attempt = 0; attempt < kMaxRetryAttempts; attempt++) {
+            sendRet = PostSend(sendComm, buf, kMsgSize, 301, mhandle, &sendReq);
+            if (sendRet != ncclSuccess || sendReq != nullptr) break;
+            usleep(kPollIntervalUs);
+        }
+
+        int fatalCount = 0;
+        ncclIbCastFaultGetFatalCount(sendComm, &fatalCount);
+
+        if (sendRet == ncclSuccess && sendReq != nullptr) {
+            for (int poll = 0; poll < 200; poll++) {
+                int done = 0, sz = 0;
+                TestRequest(sendReq, &done, &sz);
+                ncclIbCastFaultGetFatalCount(sendComm, &fatalCount);
+                if (done || fatalCount > 0) break;
+                usleep(kPollIntervalUs);
+            }
+        }
+
+        r1.sendRet   = static_cast<int>(sendRet);
+        r1.fatalCount = fatalCount;
+        r1.clearRet  = static_cast<int>(ncclIbCastFaultClear(sendComm));
+
+        // Ship results to rank 0 for assertions (rank 1 has no GTest listeners).
+        MPI_Send(&r1, sizeof(r1), MPI_BYTE, 0, kFaultResultMpiTag, MPI_COMM_WORLD);
+    }
+
+    if (rank == 0) {
+        MPI_Recv(&r1, sizeof(r1), MPI_BYTE, 1, kFaultResultMpiTag, MPI_COMM_WORLD,
+                 MPI_STATUS_IGNORE);
+
+        EXPECT_EQ(r1.setErrRet, static_cast<int>(ncclSuccess))
+            << "rank 1: ncclIbCastFaultSetQpError failed with " << r1.setErrRet
+            << " (armed " << r1.actualNqps << " QPs)";
+
+        bool isendFailed = (r1.sendRet != static_cast<int>(ncclSuccess));
+        EXPECT_TRUE(isendFailed || r1.fatalCount > 0)
+            << "rank 1: expected isend to fail OR fatalErrorCount > 0 after arming all "
+            << r1.actualNqps << " CAST QPs with error injection; "
+            << "isend returned " << r1.sendRet << ", fatalCount=" << r1.fatalCount;
+
+        EXPECT_EQ(r1.clearRet, static_cast<int>(ncclSuccess))
+            << "rank 1: ncclIbCastFaultClear failed with " << r1.clearRet;
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Drain any outstanding recv request before closing the comm.
+    // Note: recv may not complete if sender faulted — that is expected here.
+    if (rank == 0 && !recvDone && recvReq != nullptr) {
+        for (int poll = 0; poll < 500; poll++) {
+            int done = 0, sz = 0;
+            if (TestRequest(recvReq, &done, &sz) != ncclSuccess) break;
+            if (done) break;
+            usleep(kPollIntervalUs);
+        }
+    }
+
+    ASSERT_EQ(DeregisterMemory(comm, mhandle), ncclSuccess);
+    if (rank == 0) {
+        ASSERT_EQ(CloseRecvComm(recvComm), ncclSuccess);
+        ASSERT_EQ(CloseListenComm(listenComm), ncclSuccess);
+    } else {
+        ASSERT_EQ(CloseSendComm(sendComm), ncclSuccess);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+#endif /* MPI_TESTS_ENABLED && ENABLE_FAULT_INJECTION */

--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -325,4 +325,78 @@ TEST_F(NetIbMPITest, FaultInjCastSlowQpRebalances) {
     MPI_Barrier(MPI_COMM_WORLD);
 }
 
+// =============================================================================
+// Test: FaultInjCastDelayDataIntegrity
+//
+// CAST path. Inject 2 ms delay on QP 0, run 50 sends.
+// Verifies: data integrity is preserved despite the artificial per-QP delay.
+//
+// Unlike FaultInjCastSlowQpRebalances, this test does not aim to trigger
+// the RTT timer; it only confirms that usleep in the send path does not
+// corrupt or drop data.
+// =============================================================================
+TEST_F(NetIbMPITest, FaultInjCastDelayDataIntegrity) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    const int rank = MPIEnvironment::world_rank;
+
+    CAST_ENV_CHECK_OR_SKIP();
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    void* listenComm = nullptr;
+    void* sendComm   = nullptr;
+    void* recvComm   = nullptr;
+    SetupCastConnection(/*dev=*/0, &listenComm, &sendComm, &recvComm);
+
+    constexpr int    kNMsgs  = 50;
+    constexpr size_t kMsgSz  = 8192;
+    const size_t     kBufSz  = static_cast<size_t>(kNMsgs) * kMsgSz;
+    constexpr int    kBaseTag = 5000;
+
+    std::vector<char> sendBuf(kBufSz), recvBuf(kBufSz);
+    for (size_t i = 0; i < kBufSz; i++) sendBuf[i] = static_cast<char>((i * 7 + 3) & 0xFF);
+    memset(recvBuf.data(), 0, kBufSz);
+
+    void* comm    = (rank == 0) ? recvComm : sendComm;
+    char* regBuf  = (rank == 0) ? recvBuf.data() : sendBuf.data();
+    void* mhandle = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, regBuf, kBufSz, NCCL_PTR_HOST, &mhandle), ncclSuccess);
+
+    const int actualNqps = GetActualNqps(sendComm, recvComm, regBuf, kMsgSz, kBaseTag - 1, mhandle);
+    ASSERT_GT(actualNqps, 0);
+
+    if (rank == 1) {
+        ASSERT_EQ(ncclIbCastFaultSetQpDelay(sendComm, /*qpIdx=*/0, /*delayUs=*/2000), ncclSuccess);
+    }
+
+    CastDoBatchSendRecv(rank, sendComm, recvComm, sendBuf.data(), recvBuf.data(),
+                        kMsgSz, kNMsgs, kBaseTag, mhandle);
+
+    if (rank == 1) {
+        ASSERT_EQ(ncclIbCastFaultClear(sendComm), ncclSuccess);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (rank == 0) {
+        // recvBuf must match the pattern rank 1 sent.
+        // Both ranks initialise sendBuf with the same deterministic pattern,
+        // so rank 0's sendBuf is a valid reference without extra MPI traffic.
+        EXPECT_EQ(memcmp(recvBuf.data(), sendBuf.data(), kBufSz), 0)
+            << "data corruption with 2 ms QP 0 delay (50 sends)";
+    }
+
+    ASSERT_EQ(DeregisterMemory(comm, mhandle), ncclSuccess);
+    if (rank == 0) {
+        ASSERT_EQ(CloseRecvComm(recvComm), ncclSuccess);
+        ASSERT_EQ(CloseListenComm(listenComm), ncclSuccess);
+    } else {
+        ASSERT_EQ(CloseSendComm(sendComm), ncclSuccess);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
 #endif /* MPI_TESTS_ENABLED && ENABLE_FAULT_INJECTION */

--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -399,4 +399,154 @@ TEST_F(NetIbMPITest, FaultInjCastDelayDataIntegrity) {
     MPI_Barrier(MPI_COMM_WORLD);
 }
 
+// =============================================================================
+// Test: FaultInjCastSingleQpErrorIsFatal
+//
+// CAST path with WRR enabled. Arm error injection on exactly one QP —
+// QP 0 — using ncclIbCastSetTokens to steer all WRR tokens there before the
+// fault send. This models the realistic "one link failed" scenario where only
+// a specific physical path is broken.
+//
+// Verifies:
+//   - isend returns an error OR fatalErrorCount > 0
+//   - Skipped when actualNqps < 2 (single-QP: no WRR, cursor is always 0
+//     and FaultInjCastQpErrorIsFatal already covers that case)
+// =============================================================================
+TEST_F(NetIbMPITest, FaultInjCastSingleQpErrorIsFatal) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    CAST_ENV_CHECK_OR_SKIP();
+
+    const int rank = MPIEnvironment::world_rank;
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    void* listenComm = nullptr;
+    void* sendComm   = nullptr;
+    void* recvComm   = nullptr;
+    SetupCastConnection(/*dev=*/0, &listenComm, &sendComm, &recvComm);
+
+    constexpr size_t kMsgSize = 1024;  // below splitDataMin → single-QP WRR path
+    std::vector<char> sendBuf(kMsgSize), recvBuf(kMsgSize);
+    for (size_t i = 0; i < kMsgSize; i++) sendBuf[i] = static_cast<char>(i & 0xFF);
+    memset(recvBuf.data(), 0, kMsgSize);
+
+    void* comm    = (rank == 0) ? recvComm : sendComm;
+    void* buf     = (rank == 0) ? static_cast<void*>(recvBuf.data())
+                                : static_cast<void*>(sendBuf.data());
+    void* mhandle = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf, kMsgSize, NCCL_PTR_HOST, &mhandle), ncclSuccess);
+
+    // Warmup: initialise WRR state and determine actual QP count.
+    const int actualNqps = GetActualNqps(sendComm, recvComm, buf, kMsgSize, /*tag=*/400, mhandle);
+    ASSERT_GT(actualNqps, 0);
+
+    // Broadcast skip decision from rank 1 (owns sendComm and the WRR cursor).
+    int doSkip = (actualNqps < 2) ? 1 : 0;
+    MPI_Bcast(&doSkip, 1, MPI_INT, /*root=*/1, MPI_COMM_WORLD);
+    if (doSkip) {
+        GTEST_SKIP() << "Need >= 2 actual QPs for single-QP fault test (got " << actualNqps
+                     << "); FaultInjCastQpErrorIsFatal covers the single-QP case";
+    }
+
+    // rank 1: steer WRR onto QP 0 by setting all tokens there, then arm the
+    // fault on QP 0 only. Using SetTokens makes the chosen QP deterministic
+    // regardless of where the WRR cursor landed after warmup.
+    struct FaultInjectResult r1 = {};
+    r1.actualNqps = actualNqps;
+    const int targetQp = 0;
+    if (rank == 1) {
+        // Concentrate all tokens on QP 0: tokens[0]=1, tokens[1..n-1]=0.
+        std::vector<int> tokens(actualNqps, 0);
+        tokens[0] = 1;
+        ncclIbCastSetTokens(sendComm, tokens.data(), actualNqps);
+        r1.setErrRet = static_cast<int>(ncclIbCastFaultSetQpError(sendComm, targetQp, /*inject=*/true));
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    bool recvDone = false;
+    void* recvReq = nullptr;
+
+    if (rank == 0) {
+        void*  bufs[1]    = {buf};
+        size_t sizes[1]   = {kMsgSize};
+        int    tags[1]    = {401};
+        void*  handles[1] = {mhandle};
+        ASSERT_EQ(PostRecv(recvComm, 1, bufs, sizes, tags, handles, &recvReq), ncclSuccess);
+        for (int poll = 0; poll < 100; poll++) {
+            int done = 0, sz = 0;
+            if (TestRequest(recvReq, &done, &sz) != ncclSuccess) break;
+            if (done) { recvDone = true; break; }
+            usleep(kPollIntervalUs);
+        }
+    } else {
+        void* sendReq = nullptr;
+        ncclResult_t sendRet = ncclSuccess;
+        for (int attempt = 0; attempt < kMaxRetryAttempts; attempt++) {
+            sendRet = PostSend(sendComm, buf, kMsgSize, 401, mhandle, &sendReq);
+            if (sendRet != ncclSuccess || sendReq != nullptr) break;
+            usleep(kPollIntervalUs);
+        }
+
+        int fatalCount = 0;
+        ncclIbCastFaultGetFatalCount(sendComm, &fatalCount);
+
+        if (sendRet == ncclSuccess && sendReq != nullptr) {
+            for (int poll = 0; poll < 200; poll++) {
+                int done = 0, sz = 0;
+                TestRequest(sendReq, &done, &sz);
+                ncclIbCastFaultGetFatalCount(sendComm, &fatalCount);
+                if (done || fatalCount > 0) break;
+                usleep(kPollIntervalUs);
+            }
+        }
+
+        r1.sendRet    = static_cast<int>(sendRet);
+        r1.fatalCount = fatalCount;
+        r1.clearRet   = static_cast<int>(ncclIbCastFaultClear(sendComm));
+
+        MPI_Send(&r1, sizeof(r1), MPI_BYTE, 0, kFaultResultMpiTag, MPI_COMM_WORLD);
+    }
+
+    if (rank == 0) {
+        MPI_Recv(&r1, sizeof(r1), MPI_BYTE, 1, kFaultResultMpiTag, MPI_COMM_WORLD,
+                 MPI_STATUS_IGNORE);
+
+        EXPECT_EQ(r1.setErrRet, static_cast<int>(ncclSuccess))
+            << "rank 1: ncclIbCastFaultSetQpError failed for QP " << targetQp;
+
+        bool isendFailed = (r1.sendRet != static_cast<int>(ncclSuccess));
+        EXPECT_TRUE(isendFailed || r1.fatalCount > 0)
+            << "rank 1: expected isend to fail OR fatalErrorCount > 0 after single-QP "
+            << targetQp << " error injection (of " << r1.actualNqps << " total); "
+            << "isend returned " << r1.sendRet << ", fatalCount=" << r1.fatalCount;
+
+        EXPECT_EQ(r1.clearRet, static_cast<int>(ncclSuccess))
+            << "rank 1: ncclIbCastFaultClear failed";
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (rank == 0 && !recvDone && recvReq != nullptr) {
+        for (int poll = 0; poll < 500; poll++) {
+            int done = 0, sz = 0;
+            if (TestRequest(recvReq, &done, &sz) != ncclSuccess) break;
+            if (done) break;
+            usleep(kPollIntervalUs);
+        }
+    }
+
+    ASSERT_EQ(DeregisterMemory(comm, mhandle), ncclSuccess);
+    if (rank == 0) {
+        ASSERT_EQ(CloseRecvComm(recvComm), ncclSuccess);
+        ASSERT_EQ(CloseListenComm(listenComm), ncclSuccess);
+    } else {
+        ASSERT_EQ(CloseSendComm(sendComm), ncclSuccess);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
 #endif /* MPI_TESTS_ENABLED && ENABLE_FAULT_INJECTION */

--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -549,4 +549,157 @@ TEST_F(NetIbMPITest, FaultInjCastSingleQpErrorIsFatal) {
     MPI_Barrier(MPI_COMM_WORLD);
 }
 
+// =============================================================================
+// Test: FaultInjCastQpErrorClearRecovers
+//
+// CAST path. Arm error injection on all QPs, trigger one failed send, then
+// call ncclIbCastFaultClear and open a new connection. Verifies that after
+// clearing fault state a fresh connection sends and receives N messages
+// without errors and with full data integrity.
+//
+// A new connection is used for the recovery phase because a faulted
+// connection increments fatalErrorCount and future IbCastIsend calls check
+// that counter before proceeding (NCCL_IB_RETURN_ASYNC_EVENTS=1). The test
+// therefore validates that fault injection does not leave persistent state
+// that contaminates subsequent connections.
+//
+// Verifies:
+//   - After fault injection and FaultClear, a new CAST connection transfers
+//     data correctly
+//   - fatalErrorCount on the new connection remains 0
+// =============================================================================
+TEST_F(NetIbMPITest, FaultInjCastQpErrorClearRecovers) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    CAST_ENV_CHECK_OR_SKIP();
+
+    const int rank = MPIEnvironment::world_rank;
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    // ── Phase 1: inject fault on first connection ─────────────────────────
+    void* listenComm1 = nullptr;
+    void* sendComm1   = nullptr;
+    void* recvComm1   = nullptr;
+    SetupCastConnection(/*dev=*/0, &listenComm1, &sendComm1, &recvComm1);
+
+    constexpr size_t kMsgSize = 1024;
+    std::vector<char> sendBuf(kMsgSize), recvBuf(kMsgSize);
+    for (size_t i = 0; i < kMsgSize; i++) sendBuf[i] = static_cast<char>(i & 0xFF);
+    memset(recvBuf.data(), 0, kMsgSize);
+
+    void* comm1   = (rank == 0) ? recvComm1 : sendComm1;
+    void* buf1    = (rank == 0) ? static_cast<void*>(recvBuf.data())
+                                : static_cast<void*>(sendBuf.data());
+    void* mhandle1 = nullptr;
+    ASSERT_EQ(RegisterMemory(comm1, buf1, kMsgSize, NCCL_PTR_HOST, &mhandle1), ncclSuccess);
+
+    const int actualNqps = GetActualNqps(sendComm1, recvComm1, buf1, kMsgSize, /*tag=*/500, mhandle1);
+    ASSERT_GT(actualNqps, 0);
+
+    if (rank == 1) {
+        for (int q = 0; q < actualNqps; ++q)
+            ncclIbCastFaultSetQpError(sendComm1, q, /*inject=*/true);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Trigger the fault (rank 0 posts recv, rank 1 posts send that will fail).
+    if (rank == 0) {
+        void*  bufs[1]    = {buf1};
+        size_t sizes[1]   = {kMsgSize};
+        int    tags[1]    = {501};
+        void*  handles[1] = {mhandle1};
+        void* recvReq = nullptr;
+        ASSERT_EQ(PostRecv(recvComm1, 1, bufs, sizes, tags, handles, &recvReq), ncclSuccess);
+        for (int poll = 0; poll < 100; poll++) {
+            int done = 0, sz = 0;
+            if (TestRequest(recvReq, &done, &sz) != ncclSuccess) break;
+            if (done) break;
+            usleep(kPollIntervalUs);
+        }
+    } else {
+        void* sendReq = nullptr;
+        ncclResult_t sendRet = ncclSuccess;
+        for (int attempt = 0; attempt < kMaxRetryAttempts; attempt++) {
+            sendRet = PostSend(sendComm1, buf1, kMsgSize, 501, mhandle1, &sendReq);
+            if (sendRet != ncclSuccess || sendReq != nullptr) break;
+            usleep(kPollIntervalUs);
+        }
+        if (sendRet == ncclSuccess && sendReq != nullptr) {
+            for (int poll = 0; poll < 200; poll++) {
+                int done = 0, sz = 0;
+                int fc = 0;
+                TestRequest(sendReq, &done, &sz);
+                ncclIbCastFaultGetFatalCount(sendComm1, &fc);
+                if (done || fc > 0) break;
+                usleep(kPollIntervalUs);
+            }
+        }
+        ncclIbCastFaultClear(sendComm1);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    ASSERT_EQ(DeregisterMemory(comm1, mhandle1), ncclSuccess);
+    if (rank == 0) {
+        ASSERT_EQ(CloseRecvComm(recvComm1), ncclSuccess);
+        ASSERT_EQ(CloseListenComm(listenComm1), ncclSuccess);
+    } else {
+        ASSERT_EQ(CloseSendComm(sendComm1), ncclSuccess);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // ── Phase 2: open fresh connection, verify it works cleanly ──────────
+    constexpr int    kNMsgs   = 20;
+    constexpr size_t kMsgSz2  = 4096;
+    const size_t     kBufSz2  = static_cast<size_t>(kNMsgs) * kMsgSz2;
+    constexpr int    kBaseTag = 510;
+
+    std::vector<char> sendBuf2(kBufSz2), recvBuf2(kBufSz2);
+    for (size_t i = 0; i < kBufSz2; i++) sendBuf2[i] = static_cast<char>((i * 5 + 11) & 0xFF);
+    memset(recvBuf2.data(), 0, kBufSz2);
+
+    void* listenComm2 = nullptr;
+    void* sendComm2   = nullptr;
+    void* recvComm2   = nullptr;
+    SetupCastConnection(/*dev=*/0, &listenComm2, &sendComm2, &recvComm2);
+
+    void* comm2   = (rank == 0) ? recvComm2 : sendComm2;
+    char* regBuf2 = (rank == 0) ? recvBuf2.data() : sendBuf2.data();
+    void* mhandle2 = nullptr;
+    ASSERT_EQ(RegisterMemory(comm2, regBuf2, kBufSz2, NCCL_PTR_HOST, &mhandle2), ncclSuccess);
+
+    CastDoBatchSendRecv(rank, sendComm2, recvComm2,
+                        sendBuf2.data(), recvBuf2.data(),
+                        kMsgSz2, kNMsgs, kBaseTag, mhandle2);
+
+    // Verify fatalCount on the new connection is still 0 (forwarded rank 1 → 0).
+    int newFatalCount = 0;
+    if (rank == 1) {
+        ncclIbCastFaultGetFatalCount(sendComm2, &newFatalCount);
+    }
+    MPI_Bcast(&newFatalCount, 1, MPI_INT, /*root=*/1, MPI_COMM_WORLD);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (rank == 0) {
+        EXPECT_EQ(memcmp(recvBuf2.data(), sendBuf2.data(), kBufSz2), 0)
+            << "data corruption in post-fault recovery connection";
+        EXPECT_EQ(newFatalCount, 0)
+            << "new connection has non-zero fatalErrorCount after FaultClear on previous connection";
+    }
+
+    ASSERT_EQ(DeregisterMemory(comm2, mhandle2), ncclSuccess);
+    if (rank == 0) {
+        ASSERT_EQ(CloseRecvComm(recvComm2), ncclSuccess);
+        ASSERT_EQ(CloseListenComm(listenComm2), ncclSuccess);
+    } else {
+        ASSERT_EQ(CloseSendComm(sendComm2), ncclSuccess);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
 #endif /* MPI_TESTS_ENABLED && ENABLE_FAULT_INJECTION */

--- a/projects/rccl/test/transport/NetIbMPI/NetIbFaultInject.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbFaultInject.hpp
@@ -1,0 +1,21 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef RCCL_TEST_NET_IB_FAULT_INJECT_HPP_
+#define RCCL_TEST_NET_IB_FAULT_INJECT_HPP_
+
+#ifdef MPI_TESTS_ENABLED
+
+/*
+ * Re-export the shared fault injection API declarations from the library's
+ * internal header. Using the same header in both the library and the tests
+ * guarantees that the ABI can never silently diverge.
+ */
+#include "net_ib_fault_inject.h"
+
+#endif /* MPI_TESTS_ENABLED */
+
+#endif /* RCCL_TEST_NET_IB_FAULT_INJECT_HPP_ */

--- a/projects/rccl/test/transport/NetIbMPI/NetIbFaultInject.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbFaultInject.hpp
@@ -7,7 +7,7 @@
 #ifndef RCCL_TEST_NET_IB_FAULT_INJECT_HPP_
 #define RCCL_TEST_NET_IB_FAULT_INJECT_HPP_
 
-#ifdef MPI_TESTS_ENABLED
+#if defined(MPI_TESTS_ENABLED) && defined(ENABLE_FAULT_INJECTION)
 
 /*
  * Re-export the shared fault injection API declarations from the library's
@@ -16,6 +16,6 @@
  */
 #include "net_ib_fault_inject.h"
 
-#endif /* MPI_TESTS_ENABLED */
+#endif /* MPI_TESTS_ENABLED && ENABLE_FAULT_INJECTION */
 
 #endif /* RCCL_TEST_NET_IB_FAULT_INJECT_HPP_ */

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -879,6 +879,47 @@
       ]
     },
 
+    "fault_inject_cast": {
+      "extends": "cast_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_IB_SPLIT_DATA_ON_QPS":          "1",
+        "NCCL_IB_QPS_PER_CONNECTION":         "4",
+        "RCCL_IB_QP_SCHED_WRR_ENABLE":       "1",
+        "RCCL_IB_QP_SCHED_UPDATE_INTERVAL":   "100",
+        "RCCL_IB_QP_SCHED_RESET_INTERVAL":    "1000",
+        "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN":    "2000",
+        "NCCL_IB_RETURN_ASYNC_EVENTS":         "1"
+      },
+      "tests": [
+        {
+          "name": "FaultInj_Cast_QpErrorIsFatal",
+          "description": "CAST path: error injected on QP 0 increments fatalErrorCount",
+          "test_filter": "NetIbMPITest.FaultInjCastQpErrorIsFatal"
+        },
+        {
+          "name": "FaultInj_Cast_SlowQpRebalances",
+          "description": "CAST WRR: 10 ms delay on QP 0 causes RTT timer to reduce QP 0 active tokens below equal share after 500 sends",
+          "test_filter": "NetIbMPITest.FaultInjCastSlowQpRebalances"
+        },
+        {
+          "name": "FaultInj_Cast_DelayDataIntegrity",
+          "description": "CAST path: 2 ms per-QP delay preserves full data integrity across 50 sends",
+          "test_filter": "NetIbMPITest.FaultInjCastDelayDataIntegrity"
+        },
+        {
+          "name": "FaultInj_Cast_SingleQpErrorIsFatal",
+          "description": "CAST WRR: error on one QP (tokens steered to QP 0 via SetTokens) triggers fatalErrorCount > 0 or isend failure",
+          "test_filter": "NetIbMPITest.FaultInjCastSingleQpErrorIsFatal"
+        },
+        {
+          "name": "FaultInj_Cast_QpErrorClearRecovers",
+          "description": "CAST path: after FaultClear on a faulted connection, a fresh connection completes 20 sends with no corruption and fatalCount==0",
+          "test_filter": "NetIbMPITest.FaultInjCastQpErrorClearRecovers"
+        }
+      ]
+    },
+
     "graph_capture_multi_node": {
       "extends": "default",
       "is_gtest": true,
@@ -1052,6 +1093,12 @@
       "name": "NET IB - CAST Stress (QPS=2)",
       "description": "500 sends on 2 concurrent connections: RTT timer fires mid-run, consistency invariants verified",
       "config": "cast_stress",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Fault Injection (CAST path, QPS=4, splitData=1)",
+      "description": "Per-QP fault injection on CAST multi-QP path: error propagation, RTT rebalancing, data integrity under delay",
+      "config": "fault_inject_cast",
       "enabled": true
     }
   ]

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -594,6 +594,47 @@
       "env_variables": {
         "NCCL_NET": "ib-cast"
       }
+    },
+
+    "fault_inject_cast": {
+      "extends": "cast_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_IB_SPLIT_DATA_ON_QPS":          "1",
+        "NCCL_IB_QPS_PER_CONNECTION":         "4",
+        "RCCL_IB_QP_SCHED_WRR_ENABLE":       "1",
+        "RCCL_IB_QP_SCHED_UPDATE_INTERVAL":   "100",
+        "RCCL_IB_QP_SCHED_RESET_INTERVAL":    "1000",
+        "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN":    "2000",
+        "NCCL_IB_RETURN_ASYNC_EVENTS":         "1"
+      },
+      "tests": [
+        {
+          "name": "FaultInj_Cast_QpErrorIsFatal",
+          "description": "CAST path: error injected on QP 0 increments fatalErrorCount",
+          "test_filter": "NetIbMPITest.FaultInjCastQpErrorIsFatal"
+        },
+        {
+          "name": "FaultInj_Cast_SlowQpRebalances",
+          "description": "CAST WRR: 10 ms delay on QP 0 causes RTT timer to reduce QP 0 active tokens below equal share after 500 sends",
+          "test_filter": "NetIbMPITest.FaultInjCastSlowQpRebalances"
+        },
+        {
+          "name": "FaultInj_Cast_DelayDataIntegrity",
+          "description": "CAST path: 2 ms per-QP delay preserves full data integrity across 50 sends",
+          "test_filter": "NetIbMPITest.FaultInjCastDelayDataIntegrity"
+        },
+        {
+          "name": "FaultInj_Cast_SingleQpErrorIsFatal",
+          "description": "CAST WRR: error on one QP (tokens steered to QP 0 via SetTokens) triggers fatalErrorCount > 0 or isend failure",
+          "test_filter": "NetIbMPITest.FaultInjCastSingleQpErrorIsFatal"
+        },
+        {
+          "name": "FaultInj_Cast_QpErrorClearRecovers",
+          "description": "CAST path: after FaultClear on a faulted connection, a fresh connection completes 20 sends with no corruption and fatalCount==0",
+          "test_filter": "NetIbMPITest.FaultInjCastQpErrorClearRecovers"
+        }
+      ]
     }
   },
   "test_suites": [
@@ -757,6 +798,12 @@
       "name": "NET IB - vNIC Stress (ib-cast)",
       "description": "Virtual NIC stress tests via ib-cast plugin (NCCL_NET=ib-cast)",
       "config": "net_ib_vnic_stress_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Fault Injection (CAST path)",
+      "description": "Per-QP fault injection: error detection, WRR rebalancing under artificial delay, data integrity on CAST multi-QP path",
+      "config": "fault_inject_cast",
       "enabled": true
     }
   ]


### PR DESCRIPTION
## Motivation

  Adds a test-only per-QP fault injection facility to the net-ib CAST path, guarded by `ENABLE_FAULT_INJECTION` so production builds are zero-cost.

  ## Technical Details

  **Infrastructure (`net-ib: fault injection API and hooks...`)**
  - `ncclIbNetCommBase`: two new fields `faultQpDelayUs[]` / `faultQpError[]`
  - Hook in `IbCastMultiSend` (`net_ib_cast.cc`): inject artificial `usleep` or return `ncclSystemError` + increment `fatalErrorCount` before `wrap_ibv_post_send`
  - Public API in `src/include/net_ib_fault_inject.h`: `ncclIbCastFault{SetQpDelay,SetQpError,Clear,GetFatalCount}` for the CAST path
  - `cmake/rocmIb.cmake`: added `ncclIbFault → rocmIbFault` rename rule to fix duplicate symbol linker errors in `net_ib_rocm.cc`

  ## Test Plan

  - `FaultInjCastQpErrorIsFatal` — CAST: QP error propagates as a fatal event; fault is armed on all active QPs, results forwarded from rank 1 to rank 0 for assertion
  - `FaultInjCastSlowQpRebalances` — CAST WRR: 10 ms delay on QP 0 causes the RTT timer to rebalance tokens below equal share; scheduler state forwarded from rank 1 to rank 0
  - `FaultInjCastDelayDataIntegrity` — CAST: 2 ms per-QP delay across 50 sends, full data integrity verified on rank 0
  - `FaultInjCastSingleQpErrorIsFatal` — CAST WRR "one link failed" scenario: all WRR tokens steered to QP 0 via `ncclIbCastSetTokens` before arming the fault on that QP only; verifies `isend` returns error or `fatalErrorCount > 0`; skipped when `actualNqps < 2`
  - `FaultInjCastQpErrorClearRecovers` — CAST recovery: after arming error on all QPs, triggering one failed send, and calling `FaultClear`, a fresh connection completes 20 × 4096-byte sends with data integrity and `fatalErrorCount == 0`

  ## JIRA ID

  AICOMNET-133

  ## Submission Checklist

  - [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.