### PR TITLE
rocr: HSA-resident firmware dispatch-log scaffolding with LTTng emission (Phase A)

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
@@ -422,6 +422,26 @@ hsaKmtSetQueueProfilingBuffer(
     );
 
 /**
+  Configures MEC dispatch profiling ring buffer for a queue WITH host-VA
+  pointer counters that the firmware writes per record (KFD MINOR >= 20,
+  KFD_IOC_PROFILER_VERSION >= 2). Pass BufferBase = NULL to clear the
+  registration. Any of WptrAddr/RptrAddr/SignalAddr may be NULL to opt
+  out of that side-channel.
+*/
+
+HSAKMT_STATUS
+HSAKMTAPI
+hsaKmtSetDispatchLog(
+    HSA_QUEUEID         QueueId,        //IN
+    HSAuint32           GpuId,          //IN user_gpu_id of the agent owning QueueId
+    void*               BufferBase,     //IN GPU VA of record buffer; NULL = clear
+    HSAuint32           NumRecords,     //IN ring length (power of two); 0 if BufferBase NULL
+    void*               WptrAddr,       //IN GPU VA of host wptr word; NULL skips per-record wptr publish
+    void*               RptrAddr,       //IN GPU VA of host rptr word; NULL skips rptr feedback
+    void*               SignalAddr      //IN GPU VA of host signal word; NULL skips per-record signal publish
+    );
+
+/**
   Destroys a queue
 */
 

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
@@ -409,6 +409,19 @@ hsaKmtUpdateQueue(
     );
 
 /**
+  Configures MEC dispatch profiling ring buffer for a queue (optional; KFD support required).
+*/
+
+HSAKMT_STATUS
+HSAKMTAPI
+hsaKmtSetQueueProfilingBuffer(
+    HSA_QUEUEID         QueueId,        //IN
+    void*               BufferBase,     //IN GPU-accessible ring base
+    HSAuint32           NumRecords,     //IN ring length (power of two)
+    volatile HSAuint32* WptrHostAddr    //IN host-coherent write pointer
+    );
+
+/**
   Destroys a queue
 */
 

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/linux/kfd_ioctl.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/linux/kfd_ioctl.h
@@ -45,9 +45,12 @@
  * - 1.17 - Add SDMA queue creation with target SDMA engine ID
  * - 1.18 - Rename pad in set_memory_policy_args to misc_process_flag
  * - 1.19 - Add queue creation with metadata ring base address
+ * - 1.20..1.21 - (reserved)
+ * - 1.22 - Extend kfd_ioctl_update_queue_args with dispatch_record_buffer_{addr,size}
+ *          for MEC dispatch profiling ring buffer (host kernel ABI)
  */
 #define KFD_IOCTL_MAJOR_VERSION 1
-#define KFD_IOCTL_MINOR_VERSION 19
+#define KFD_IOCTL_MINOR_VERSION 22
 
 struct kfd_ioctl_get_version_args {
 	__u32 major_version;	/* from KFD */
@@ -98,6 +101,9 @@ struct kfd_ioctl_update_queue_args {
 	__u32 ring_size;		/* to KFD */
 	__u32 queue_percentage;	/* to KFD */
 	__u32 queue_priority;	/* to KFD */
+	__u64 dispatch_record_buffer_addr;	/* to KFD: GPU VA (0 = disable) */
+	__u32 dispatch_record_buffer_size;	/* to KFD: capacity in records */
+	__u32 pad;
 };
 
 struct kfd_ioctl_set_cu_mask_args {

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/linux/kfd_ioctl.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/linux/kfd_ioctl.h
@@ -1616,11 +1616,43 @@ struct kfd_ioctl_pc_sample_args {
 	__u32 reserved;
 };
 
-#define KFD_IOC_PROFILER_VERSION_NUM 1
+#define KFD_IOC_PROFILER_VERSION_NUM 2     /* was 1; v2 adds DISPATCH_LOG sub-op */
 enum kfd_profiler_ops {
 	KFD_IOC_PROFILER_PMC = 0,
 	KFD_IOC_PROFILER_PC_SAMPLE = 1,
 	KFD_IOC_PROFILER_VERSION = 2,
+	KFD_IOC_PROFILER_PTL_CONTROL = 3,
+	KFD_IOC_PROFILER_DISPATCH_LOG = 4,
+};
+
+enum kfd_dispatch_log_op {
+	KFD_DISPATCH_LOG_OP_SET   = 1,
+	KFD_DISPATCH_LOG_OP_CLEAR = 2,
+};
+
+enum kfd_dispatch_log_mem_space {
+	KFD_DISPATCH_LOG_MEM_GTT  = 1,
+	KFD_DISPATCH_LOG_MEM_VRAM = 2,
+};
+
+struct kfd_ioctl_dispatch_log_args {
+	__u32 gpu_id;                  /* user_gpu_id; rejected if mismatched with queue's device */
+	__u32 queue_id;                /* KFD queue id */
+	__u32 op;                      /* enum kfd_dispatch_log_op */
+	__u32 mem_space;               /* enum kfd_dispatch_log_mem_space */
+
+	__u64 buffer_addr;             /* GPU VA of record buffer (16-byte records); 0 in CLEAR */
+	__u32 buffer_size_records;     /* power-of-2 count; 0 in CLEAR */
+	__u32 pad;
+
+	__u64 wptr_addr;               /* FW writes per-record producer position; 0 = none */
+	__u64 rptr_addr;               /* host writes consumer position; FW reads; 0 = none */
+	__u64 signal_addr;             /* HSA signal value field; FW writes per-record; 0 = none */
+};
+
+struct kfd_ioctl_ptl_control {
+	__u32 gpu_id;
+	__u32 enable;
 };
 
 /**
@@ -1635,8 +1667,10 @@ struct kfd_ioctl_pmc_settings {
 struct kfd_ioctl_profiler_args {
 	__u32 op;					/* kfd_profiler_op */
 	union {
-		struct kfd_ioctl_pc_sample_args pc_sample;
-		struct kfd_ioctl_pmc_settings  pmc;
+		struct kfd_ioctl_pc_sample_args    pc_sample;
+		struct kfd_ioctl_pmc_settings      pmc;
+		struct kfd_ioctl_ptl_control       ptl;
+		struct kfd_ioctl_dispatch_log_args dispatch_log;   /* v2: KFD_IOC_PROFILER_DISPATCH_LOG */
 		__u32 version;				/* KFD_IOC_PROFILER_VERSION_NUM */
 	};
 };

--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.ver
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.ver
@@ -21,6 +21,7 @@ hsaKmtWaitOnMultipleEvents;
 hsaKmtCreateQueue;
 hsaKmtUpdateQueue;
 hsaKmtDestroyQueue;
+hsaKmtSetDispatchLog;
 hsaKmtSetQueueCUMask;
 hsaKmtSetMemoryPolicy;
 hsaKmtAllocMemory;

--- a/projects/rocr-runtime/libhsakmt/src/queues.c
+++ b/projects/rocr-runtime/libhsakmt/src/queues.c
@@ -1151,7 +1151,36 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtSetQueueProfilingBuffer(HSA_QUEUEID QueueId,
 
 	q->dispatch_record_buffer_addr = (uintptr_t)BufferBase;
 	q->dispatch_record_buffer_size = NumRecords;
-	(void)WptrHostAddr; /* host-coherent wptr is plumbed by HSA via MQD path */
+	/*
+	 * KNOWN GAP — WptrHostAddr is intentionally discarded.
+	 *
+	 * The HSA dispatch_log drainer (rocr-runtime
+	 * core/runtime/dispatch_log.cpp) needs firmware to publish a
+	 * write-pointer counter into a host-visible address. AqlQueue
+	 * passes that address (&dispatch_record_wptr_) here, but:
+	 *   - struct kfd_ioctl_update_queue_args (the ioctl this cache feeds)
+	 *     has only dispatch_record_buffer_addr + dispatch_record_buffer_size
+	 *     (+ pad) — there is no wptr_addr field to forward to the kernel
+	 *     and onward into MQD setup.
+	 *   - The host kernel keeps any FW-visible wptr in MQD
+	 *     (e.g. v9_mqd::dispatch_record_buffer_wptr at offset 0x2F on
+	 *     gfx9), which is GPU-side and not host-readable through any
+	 *     current API.
+	 *
+	 * This precedent was carried over from the cpc_tracing branch, which
+	 * defined the WptrHostAddr parameter at the libhsakmt boundary
+	 * presumably with the intent that the KFD ABI would later be
+	 * extended to forward it. That extension never landed, and
+	 * cpc_tracing was never integration-tested end-to-end, so the gap
+	 * was never user-visible there. Until the KFD ABI gains a
+	 * wptr_addr field (or the firmware contract is changed to write
+	 * wptr to a known offset inside the ring buffer itself), the
+	 * dispatch_log drainer will be effectively dormant.
+	 *
+	 * See rocr-runtime core/inc/dispatch_log.h banner + spec §10
+	 * dependency #2 sub-bullet.
+	 */
+	(void)WptrHostAddr;
 
 	return HSAKMT_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/libhsakmt/src/queues.c
+++ b/projects/rocr-runtime/libhsakmt/src/queues.c
@@ -1172,6 +1172,86 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtSetQueueProfilingBuffer(HSA_QUEUEID QueueId,
 	return HSAKMT_STATUS_SUCCESS;
 }
 
+/*
+ * hsaKmtSetDispatchLog — register the per-queue MEC dispatch-record buffer
+ * and three optional host-VA pointer counters via the KFD profiler ioctl
+ * sub-op KFD_IOC_PROFILER_DISPATCH_LOG (KFD MINOR >= 20, KFD_IOC_PROFILER
+ * version >= 2).
+ *
+ * Replaces hsaKmtSetQueueProfilingBuffer() for callers that want the new
+ * FW-readable host-VA pointers. The old API still works (FW falls back to
+ * sentinel-scan-able buffer-only behavior) but cannot deliver per-queue
+ * wptr/rptr/signal updates because the older UPDATE_QUEUE ABI lacks the
+ * trailing pointer fields.
+ *
+ * Pass BufferBase = NULL to issue KFD_DISPATCH_LOG_OP_CLEAR (drops the
+ * record buffer + all three pointer registrations on the queue). Pass
+ * non-NULL BufferBase + NumRecords > 0 to SET; any of WptrAddr/RptrAddr/
+ * SignalAddr that is NULL is treated by the kernel and FW as "not
+ * registered" and that side-channel is skipped per record.
+ *
+ * GpuId is the same user_gpu_id the caller would pass to other KFD
+ * ioctls; the kernel rejects the call with -EINVAL if it does not match
+ * the queue's owning device (closes the gpu_id<->queue_id binding gap).
+ */
+static HSAKMT_STATUS hsaKmtSetDispatchLogCtx(HsaKFDContext *ctx,
+                                             HSA_QUEUEID QueueId,
+                                             HSAuint32 GpuId,
+                                             void *BufferBase,
+                                             HSAuint32 NumRecords,
+                                             void *WptrAddr,
+                                             void *RptrAddr,
+                                             void *SignalAddr)
+{
+	struct queue *q = PORT_UINT64_TO_VPTR(QueueId);
+	struct kfd_ioctl_profiler_args args = {0};
+	int err;
+
+	CHECK_KFD_OPEN();
+
+	if (!q)
+		return HSAKMT_STATUS_INVALID_PARAMETER;
+
+	args.op = KFD_IOC_PROFILER_DISPATCH_LOG;
+	args.dispatch_log.gpu_id    = GpuId;
+	args.dispatch_log.queue_id  = q->queue_id;
+	args.dispatch_log.op        = BufferBase
+	                                  ? KFD_DISPATCH_LOG_OP_SET
+	                                  : KFD_DISPATCH_LOG_OP_CLEAR;
+	args.dispatch_log.mem_space = KFD_DISPATCH_LOG_MEM_GTT;
+	args.dispatch_log.buffer_addr         = (__u64)(uintptr_t)BufferBase;
+	args.dispatch_log.buffer_size_records = NumRecords;
+	args.dispatch_log.pad                 = 0;
+	args.dispatch_log.wptr_addr           = (__u64)(uintptr_t)WptrAddr;
+	args.dispatch_log.rptr_addr           = (__u64)(uintptr_t)RptrAddr;
+	args.dispatch_log.signal_addr         = (__u64)(uintptr_t)SignalAddr;
+
+	/* Mirror the queue's local cache of buffer addr/size for backward
+	 * compat with existing UPDATE_QUEUE callers that read these on
+	 * subsequent priority updates etc. */
+	q->dispatch_record_buffer_addr = (uintptr_t)BufferBase;
+	q->dispatch_record_buffer_size = NumRecords;
+
+	err = hsakmt_ioctl(ctx->fd, AMDKFD_IOC_PROFILER, &args);
+	if (err == -1)
+		return HSAKMT_STATUS_ERROR;
+
+	return HSAKMT_STATUS_SUCCESS;
+}
+
+HSAKMT_STATUS HSAKMTAPI hsaKmtSetDispatchLog(HSA_QUEUEID QueueId,
+                                             HSAuint32 GpuId,
+                                             void *BufferBase,
+                                             HSAuint32 NumRecords,
+                                             void *WptrAddr,
+                                             void *RptrAddr,
+                                             void *SignalAddr)
+{
+	return hsaKmtSetDispatchLogCtx(&hsakmt_primary_kfd_ctx, QueueId, GpuId,
+	                               BufferBase, NumRecords,
+	                               WptrAddr, RptrAddr, SignalAddr);
+}
+
 HSAKMT_STATUS HSAKMTAPI hsaKmtDestroyQueue(HSA_QUEUEID QueueId)
 {
 	return hsaKmtDestroyQueueCtx(&hsakmt_primary_kfd_ctx, QueueId);

--- a/projects/rocr-runtime/libhsakmt/src/queues.c
+++ b/projects/rocr-runtime/libhsakmt/src/queues.c
@@ -72,6 +72,8 @@ struct queue {
 	 * but only small bytes are used. We use the extra space in the end for
 	 * cu_mask bits array.
 	 */
+	uint64_t dispatch_record_buffer_addr;
+	uint32_t dispatch_record_buffer_size;
 	uint32_t cu_mask_count; /* in bits */
 	uint32_t cu_mask[0];
 };
@@ -893,6 +895,8 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtUpdateQueueCtx(HsaKFDContext *ctx,
 	arg.ring_size = QueueSize;
 	arg.queue_percentage = QueuePercentage;
 	arg.queue_priority = priority_map[Priority+3];
+	arg.dispatch_record_buffer_addr = q->dispatch_record_buffer_addr;
+	arg.dispatch_record_buffer_size = q->dispatch_record_buffer_size;
 
 	int err = hsakmt_ioctl(ctx->fd, AMDKFD_IOC_UPDATE_QUEUE, &arg);
 
@@ -1131,6 +1135,25 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtUpdateQueue(HSA_QUEUEID QueueId,
 {
 	return hsaKmtUpdateQueueCtx(&hsakmt_primary_kfd_ctx, QueueId, QueuePercentage,
 					Priority, QueueAddress, QueueSize, Event);
+}
+
+HSAKMT_STATUS HSAKMTAPI hsaKmtSetQueueProfilingBuffer(HSA_QUEUEID QueueId,
+							void *BufferBase,
+							HSAuint32 NumRecords,
+							volatile HSAuint32 *WptrHostAddr)
+{
+	struct queue *q = PORT_UINT64_TO_VPTR(QueueId);
+
+	CHECK_KFD_OPEN();
+
+	if (!q)
+		return HSAKMT_STATUS_INVALID_PARAMETER;
+
+	q->dispatch_record_buffer_addr = (uintptr_t)BufferBase;
+	q->dispatch_record_buffer_size = NumRecords;
+	(void)WptrHostAddr; /* host-coherent wptr is plumbed by HSA via MQD path */
+
+	return HSAKMT_STATUS_SUCCESS;
 }
 
 HSAKMT_STATUS HSAKMTAPI hsaKmtDestroyQueue(HSA_QUEUEID QueueId)

--- a/projects/rocr-runtime/libhsakmt/src/queues.c
+++ b/projects/rocr-runtime/libhsakmt/src/queues.c
@@ -1215,16 +1215,29 @@ static HSAKMT_STATUS hsaKmtSetDispatchLogCtx(HsaKFDContext *ctx,
 	args.op = KFD_IOC_PROFILER_DISPATCH_LOG;
 	args.dispatch_log.gpu_id    = GpuId;
 	args.dispatch_log.queue_id  = q->queue_id;
-	args.dispatch_log.op        = BufferBase
-	                                  ? KFD_DISPATCH_LOG_OP_SET
-	                                  : KFD_DISPATCH_LOG_OP_CLEAR;
-	args.dispatch_log.mem_space = KFD_DISPATCH_LOG_MEM_GTT;
-	args.dispatch_log.buffer_addr         = (__u64)(uintptr_t)BufferBase;
-	args.dispatch_log.buffer_size_records = NumRecords;
-	args.dispatch_log.pad                 = 0;
-	args.dispatch_log.wptr_addr           = (__u64)(uintptr_t)WptrAddr;
-	args.dispatch_log.rptr_addr           = (__u64)(uintptr_t)RptrAddr;
-	args.dispatch_log.signal_addr         = (__u64)(uintptr_t)SignalAddr;
+	args.dispatch_log.pad       = 0;
+	if (BufferBase) {
+		args.dispatch_log.op                  = KFD_DISPATCH_LOG_OP_SET;
+		args.dispatch_log.mem_space           = KFD_DISPATCH_LOG_MEM_GTT;
+		args.dispatch_log.buffer_addr         = (__u64)(uintptr_t)BufferBase;
+		args.dispatch_log.buffer_size_records = NumRecords;
+		args.dispatch_log.wptr_addr           = (__u64)(uintptr_t)WptrAddr;
+		args.dispatch_log.rptr_addr           = (__u64)(uintptr_t)RptrAddr;
+		args.dispatch_log.signal_addr         = (__u64)(uintptr_t)SignalAddr;
+	} else {
+		/*
+		 * CLEAR: kernel rejects nonzero mem_space / buffer / pointer
+		 * fields with -EINVAL (debate-stage code-quality C8). Send a
+		 * fully-zeroed args block beyond op/gpu_id/queue_id/pad.
+		 */
+		args.dispatch_log.op                  = KFD_DISPATCH_LOG_OP_CLEAR;
+		args.dispatch_log.mem_space           = 0;
+		args.dispatch_log.buffer_addr         = 0;
+		args.dispatch_log.buffer_size_records = 0;
+		args.dispatch_log.wptr_addr           = 0;
+		args.dispatch_log.rptr_addr           = 0;
+		args.dispatch_log.signal_addr         = 0;
+	}
 
 	/* Mirror the queue's local cache of buffer addr/size for backward
 	 * compat with existing UPDATE_QUEUE callers that read these on

--- a/projects/rocr-runtime/libhsakmt/src/queues.c
+++ b/projects/rocr-runtime/libhsakmt/src/queues.c
@@ -1152,33 +1152,20 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtSetQueueProfilingBuffer(HSA_QUEUEID QueueId,
 	q->dispatch_record_buffer_addr = (uintptr_t)BufferBase;
 	q->dispatch_record_buffer_size = NumRecords;
 	/*
-	 * KNOWN GAP — WptrHostAddr is intentionally discarded.
+	 * WptrHostAddr is intentionally unused — the dispatch_log design
+	 * does not rely on a host-visible FW write pointer.
 	 *
-	 * The HSA dispatch_log drainer (rocr-runtime
-	 * core/runtime/dispatch_log.cpp) needs firmware to publish a
-	 * write-pointer counter into a host-visible address. AqlQueue
-	 * passes that address (&dispatch_record_wptr_) here, but:
-	 *   - struct kfd_ioctl_update_queue_args (the ioctl this cache feeds)
-	 *     has only dispatch_record_buffer_addr + dispatch_record_buffer_size
-	 *     (+ pad) — there is no wptr_addr field to forward to the kernel
-	 *     and onward into MQD setup.
-	 *   - The host kernel keeps any FW-visible wptr in MQD
-	 *     (e.g. v9_mqd::dispatch_record_buffer_wptr at offset 0x2F on
-	 *     gfx9), which is GPU-side and not host-readable through any
-	 *     current API.
+	 * The KFD ABI (struct kfd_ioctl_update_queue_args) has only
+	 * dispatch_record_buffer_addr + dispatch_record_buffer_size (+ pad);
+	 * there is no wptr_addr field to forward to the kernel. The HSA
+	 * drainer instead uses a sentinel-scan over per-slot record_type
+	 * (records pre-zeroed at allocation; FW writes record_type ∈ {1,2})
+	 * to locate fresh records — see
+	 * rocr-runtime core/runtime/dispatch_log.cpp::drain_one_queue.
 	 *
-	 * This precedent was carried over from the cpc_tracing branch, which
-	 * defined the WptrHostAddr parameter at the libhsakmt boundary
-	 * presumably with the intent that the KFD ABI would later be
-	 * extended to forward it. That extension never landed, and
-	 * cpc_tracing was never integration-tested end-to-end, so the gap
-	 * was never user-visible there. Until the KFD ABI gains a
-	 * wptr_addr field (or the firmware contract is changed to write
-	 * wptr to a known offset inside the ring buffer itself), the
-	 * dispatch_log drainer will be effectively dormant.
-	 *
-	 * See rocr-runtime core/inc/dispatch_log.h banner + spec §10
-	 * dependency #2 sub-bullet.
+	 * The parameter is retained on the libhsakmt boundary for ABI
+	 * stability and reserved for a future substrate revision that
+	 * publishes wptr to firmware.
 	 */
 	(void)WptrHostAddr;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/CMakeLists.txt
+++ b/projects/rocr-runtime/runtime/hsa-runtime/CMakeLists.txt
@@ -242,6 +242,7 @@ set ( SRCS core/driver/driver.cpp
            core/runtime/runtime.cpp
            core/runtime/signal.cpp
            core/runtime/queue.cpp
+           core/runtime/clock_sync.cpp
            core/runtime/dispatch_log.cpp
            core/runtime/cache.cpp
            core/runtime/svm_profiler.cpp

--- a/projects/rocr-runtime/runtime/hsa-runtime/CMakeLists.txt
+++ b/projects/rocr-runtime/runtime/hsa-runtime/CMakeLists.txt
@@ -242,6 +242,7 @@ set ( SRCS core/driver/driver.cpp
            core/runtime/runtime.cpp
            core/runtime/signal.cpp
            core/runtime/queue.cpp
+           core/runtime/dispatch_log.cpp
            core/runtime/cache.cpp
            core/runtime/svm_profiler.cpp
            core/runtime/thunk_loader.cpp

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
@@ -1509,9 +1509,8 @@ hsa_status_t HSA_API hsa_amd_queue_iterate(
 }
 
 hsa_status_t HSA_API hsa_amd_profiling_get_dispatch_records(
-    hsa_queue_t* queue, void** buffer_base, uint32_t* buffer_size, volatile uint32_t** write_ptr) { const uint64_t __rocm_corr = rocm_trace_next_corr_id(); rocm_trace_emit_hsa_api_enter(__func__, __rocm_corr);
-  ROCR_TRACE_API_RET_STATUS(amdExtTable->hsa_amd_profiling_get_dispatch_records_fn(queue, buffer_base, buffer_size,
-                                                                                   write_ptr));
+    hsa_queue_t* queue, void** buffer_base, uint32_t* buffer_size) { const uint64_t __rocm_corr = rocm_trace_next_corr_id(); rocm_trace_emit_hsa_api_enter(__func__, __rocm_corr);
+  ROCR_TRACE_API_RET_STATUS(amdExtTable->hsa_amd_profiling_get_dispatch_records_fn(queue, buffer_base, buffer_size));
 }
 
 // Tools only table interfaces.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
@@ -1503,6 +1503,17 @@ hsa_status_t HSA_API hsa_amd_signal_get_event_id(hsa_signal_t signal, uint32_t *
   ROCR_TRACE_API_RET_STATUS(amdExtTable->hsa_amd_signal_get_event_id_fn(signal, event_id));
 }
 
+hsa_status_t HSA_API hsa_amd_queue_iterate(
+    hsa_status_t (*callback)(hsa_queue_t* queue, void* data), void* data) { const uint64_t __rocm_corr = rocm_trace_next_corr_id(); rocm_trace_emit_hsa_api_enter(__func__, __rocm_corr);
+  ROCR_TRACE_API_RET_STATUS(amdExtTable->hsa_amd_queue_iterate_fn(callback, data));
+}
+
+hsa_status_t HSA_API hsa_amd_profiling_get_dispatch_records(
+    hsa_queue_t* queue, void** buffer_base, uint32_t* buffer_size, volatile uint32_t** write_ptr) { const uint64_t __rocm_corr = rocm_trace_next_corr_id(); rocm_trace_emit_hsa_api_enter(__func__, __rocm_corr);
+  ROCR_TRACE_API_RET_STATUS(amdExtTable->hsa_amd_profiling_get_dispatch_records_fn(queue, buffer_base, buffer_size,
+                                                                                   write_ptr));
+}
+
 // Tools only table interfaces.
 namespace rocr {
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -460,6 +460,32 @@ hsa_status_t KfdDriver::SetQueueProfilingBuffer(HSA_QUEUEID queue_id, void* buff
   }
 }
 
+hsa_status_t KfdDriver::SetDispatchLog(HSA_QUEUEID queue_id, uint32_t gpu_id,
+                                       void* buffer_base, uint32_t num_records,
+                                       void* wptr_addr, void* rptr_addr,
+                                       void* signal_addr) const {
+  // Same NOT_SUPPORTED-vs-transient distinction as SetQueueProfilingBuffer:
+  // missing thunk symbol = permanent (agent should fall back to legacy path);
+  // thunk-reported NOT_SUPPORTED = also permanent; everything else = transient.
+  auto* loader = core::Runtime::runtime_singleton_->thunkLoader();
+  if (loader->pfn_hsaKmtSetDispatchLog == nullptr)
+    return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
+
+  HSAKMT_STATUS st = loader->pfn_hsaKmtSetDispatchLog(
+      queue_id, gpu_id, buffer_base, num_records,
+      wptr_addr, rptr_addr, signal_addr);
+  switch (st) {
+    case HSAKMT_STATUS_SUCCESS:
+      return HSA_STATUS_SUCCESS;
+    case HSAKMT_STATUS_INVALID_PARAMETER:
+      return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+    case HSAKMT_STATUS_NOT_SUPPORTED:
+      return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
+    default:
+      return HSA_STATUS_ERROR;
+  }
+}
+
 hsa_status_t KfdDriver::SetQueueCUMask(HSA_QUEUEID queue_id, uint32_t cu_mask_count,
                                        uint32_t* queue_cu_mask) const {
   if (HSAKMT_CALL(hsaKmtSetQueueCUMask(queue_id, cu_mask_count, queue_cu_mask)) !=

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -432,9 +432,14 @@ hsa_status_t KfdDriver::SetQueueProfilingBuffer(HSA_QUEUEID queue_id, void* buff
   // NOT_SUPPORTED interacts badly with the C5 caching logic in
   // AqlQueue::SetProfiling, which uses NOT_SUPPORTED to permanently
   // disable profiling on the agent.
+  // HSA_STATUS_ERROR_NOT_SUPPORTED lives in an unnamed enum in
+  // hsa_ext_amd.h (separate from hsa_status_t), so it requires an
+  // explicit static_cast to hsa_status_t. The other HSA_STATUS_*
+  // constants here are members of the hsa_status_t typedef'd enum
+  // and can be returned directly.
   auto* loader = core::Runtime::runtime_singleton_->thunkLoader();
   if (loader->pfn_hsaKmtSetQueueProfilingBuffer == nullptr)
-    return HSA_STATUS_ERROR_NOT_SUPPORTED;
+    return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
 
   HSAKMT_STATUS st = loader->pfn_hsaKmtSetQueueProfilingBuffer(
       queue_id, buffer_base, num_records, wptr_host_addr);
@@ -446,7 +451,7 @@ hsa_status_t KfdDriver::SetQueueProfilingBuffer(HSA_QUEUEID queue_id, void* buff
     case HSAKMT_STATUS_NOT_SUPPORTED:
       // The substrate exports the symbol but the kernel/asic refused -
       // treat as permanently unsupported on this agent.
-      return HSA_STATUS_ERROR_NOT_SUPPORTED;
+      return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
     default:
       // Generic / transient thunk failure (e.g. HSAKMT_STATUS_ERROR,
       // HSAKMT_STATUS_NO_MEMORY). Do NOT return NOT_SUPPORTED here -

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -426,14 +426,33 @@ hsa_status_t KfdDriver::UpdateQueue(HSA_QUEUEID queue_id, uint32_t queue_pct,
 hsa_status_t KfdDriver::SetQueueProfilingBuffer(HSA_QUEUEID queue_id, void* buffer_base,
                                                 uint32_t num_records,
                                                 volatile uint32_t* wptr_host_addr) const {
-  if (core::Runtime::runtime_singleton_->thunkLoader()->pfn_hsaKmtSetQueueProfilingBuffer ==
-      nullptr)
-    return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
-  if (core::Runtime::runtime_singleton_->thunkLoader()
-          ->pfn_hsaKmtSetQueueProfilingBuffer(queue_id, buffer_base, num_records, wptr_host_addr) !=
-      HSAKMT_STATUS_SUCCESS)
-    return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
-  return HSA_STATUS_SUCCESS;
+  // C9: distinguish missing-symbol (the substrate genuinely lacks the
+  // entrypoint - permanent, agent should be marked unsupported) from a
+  // concrete thunk failure (transient / per-call). Conflating both into
+  // NOT_SUPPORTED interacts badly with the C5 caching logic in
+  // AqlQueue::SetProfiling, which uses NOT_SUPPORTED to permanently
+  // disable profiling on the agent.
+  auto* loader = core::Runtime::runtime_singleton_->thunkLoader();
+  if (loader->pfn_hsaKmtSetQueueProfilingBuffer == nullptr)
+    return HSA_STATUS_ERROR_NOT_SUPPORTED;
+
+  HSAKMT_STATUS st = loader->pfn_hsaKmtSetQueueProfilingBuffer(
+      queue_id, buffer_base, num_records, wptr_host_addr);
+  switch (st) {
+    case HSAKMT_STATUS_SUCCESS:
+      return HSA_STATUS_SUCCESS;
+    case HSAKMT_STATUS_INVALID_PARAMETER:
+      return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+    case HSAKMT_STATUS_NOT_SUPPORTED:
+      // The substrate exports the symbol but the kernel/asic refused -
+      // treat as permanently unsupported on this agent.
+      return HSA_STATUS_ERROR_NOT_SUPPORTED;
+    default:
+      // Generic / transient thunk failure (e.g. HSAKMT_STATUS_ERROR,
+      // HSAKMT_STATUS_NO_MEMORY). Do NOT return NOT_SUPPORTED here -
+      // that would permanently disable the agent in the C5 cache path.
+      return HSA_STATUS_ERROR;
+  }
 }
 
 hsa_status_t KfdDriver::SetQueueCUMask(HSA_QUEUEID queue_id, uint32_t cu_mask_count,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -53,6 +53,7 @@
 #include "core/inc/amd_gpu_agent.h"
 #include "core/inc/amd_memory_region.h"
 #include "core/inc/runtime.h"
+#include "core/inc/thunk_loader.h"
 
 #if defined(_WIN32)
 #include "loader/executable.hpp"
@@ -419,6 +420,19 @@ hsa_status_t KfdDriver::UpdateQueue(HSA_QUEUEID queue_id, uint32_t queue_pct,
                                     event)) != HSAKMT_STATUS_SUCCESS) {
     return HSA_STATUS_ERROR;
   }
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::SetQueueProfilingBuffer(HSA_QUEUEID queue_id, void* buffer_base,
+                                                uint32_t num_records,
+                                                volatile uint32_t* wptr_host_addr) const {
+  if (core::Runtime::runtime_singleton_->thunkLoader()->pfn_hsaKmtSetQueueProfilingBuffer ==
+      nullptr)
+    return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
+  if (core::Runtime::runtime_singleton_->thunkLoader()
+          ->pfn_hsaKmtSetQueueProfilingBuffer(queue_id, buffer_base, num_records, wptr_host_addr) !=
+      HSAKMT_STATUS_SUCCESS)
+    return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -465,7 +465,7 @@ hsa_status_t KfdDriver::SetDispatchLog(HSA_QUEUEID queue_id, uint32_t gpu_id,
                                        void* wptr_addr, void* rptr_addr,
                                        void* signal_addr) const {
   // Same NOT_SUPPORTED-vs-transient distinction as SetQueueProfilingBuffer:
-  // missing thunk symbol = permanent (agent should fall back to legacy path);
+  // missing thunk symbol = profiling enable fails (no dispatch-log without it);
   // thunk-reported NOT_SUPPORTED = also permanent; everything else = transient.
   auto* loader = core::Runtime::runtime_singleton_->thunkLoader();
   if (loader->pfn_hsaKmtSetDispatchLog == nullptr)

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -207,6 +207,14 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   /// @brief Enables/Disables profiling overrides SetProfiling from core::Queue
   void SetProfiling(bool enabled) override;
 
+  /// @brief Get the per-queue MEC dispatch-record ring buffer info.
+  /// @details Returns the ring buffer base, total size in bytes, and a
+  /// pointer to the firmware-written wptr. Returns
+  /// HSA_STATUS_ERROR_NOT_INITIALIZED if profiling has not been enabled
+  /// on this queue.
+  hsa_status_t GetProfilingDispatchRecords(void** buffer_base, uint32_t* buffer_size,
+                                           volatile uint32_t** write_ptr) const;
+
   /// @brief Update signal value using Relaxed semantics
   void StoreRelaxed(hsa_signal_value_t value) override;
 
@@ -368,6 +376,16 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
 
   struct metadata_prefetch_pkt_version dispatch_version_;
   struct metadata_prefetch_pkt_version barrier_version_;
+
+  // MEC firmware-assisted dispatch profiling ring buffer.
+  // Allocated by SetProfiling(true), freed by SetProfiling(false) and the dtor.
+  // The buffer is allocated as kRecordCount * 40 bytes (NOT * sizeof(mec_dispatch_record)
+  // == 16) to satisfy the host kernel's BO size validation in
+  // kfd_process_queue_manager.c (`buf_byte_size = count * 40`). The MEC firmware
+  // only writes 16 bytes per slot; the trailing 24 bytes per slot are unused.
+  void* dispatch_record_buffer_ = nullptr;
+  uint32_t dispatch_record_buffer_size_ = 0;     // record count (NOT bytes)
+  mutable volatile uint32_t dispatch_record_wptr_ = 0;
 
   // Shared event used for queue errors
   static __forceinline HsaEvent*& queue_event() {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -207,9 +207,25 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   /// @brief Enables/Disables profiling overrides SetProfiling from core::Queue.
   /// @details Returns non-success if the dispatch-record buffer allocation,
   /// libhsakmt SetQueueProfilingBuffer registration, or the UPDATE_QUEUE
-  /// flush fails. On enable failure all partial state is unwound (allocation
-  /// freed, cached fields reset). On disable failure the host-side buffer
-  /// is still freed (the FW-side state is best-effort).
+  /// flush fails.
+  ///
+  /// On enable failure all partial state is unwound: any allocated buffer
+  /// is freed, cached fields are reset, and the AMD_QUEUE_PROPERTIES_ENABLE_
+  /// PROFILING bit is rolled back so the queue is left in the pre-call state.
+  ///
+  /// On a successful disable the KFD-side registrations are cleared, the
+  /// MQD republish via Suspend/Resume is performed, the profiling bit is
+  /// then cleared, and finally the host-side buffer (and Phase-2 host-VA
+  /// counter words) are freed.
+  ///
+  /// On a disable where the KFD clear (legacy or new dispatch_log sub-op)
+  /// fails, the host-side buffer is intentionally NOT freed — FW may still
+  /// hold the BO address in MQD, so freeing would risk a GPU
+  /// use-after-free. Instead the live buffer is quarantined: the profiling
+  /// bit is left set, dispatch_record_buffer_ stays non-null (also blocking
+  /// double-allocation on retry), and release is deferred to ~AqlQueue
+  /// which runs only after KFD has destroyed the queue. See
+  /// amd_aql_queue.cpp:1866-1886.
   hsa_status_t SetProfiling(bool enabled) override;
 
   /// @brief Get the per-queue MEC dispatch-record ring buffer info.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -246,9 +246,23 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   /// @returns HSA_STATUS_SUCCESS with non-null out-params if the new
   /// interface is active for this queue; HSA_STATUS_ERROR_NOT_INITIALIZED
   /// otherwise.
+  ///
+  /// @param[out] fresh_allocation Optional. If non-null, set to @c true
+  /// when the most recent successful @c SetProfiling(true) actually
+  /// allocated and zeroed the dispatch-record buffer + host-VA counter
+  /// words (the common case). Set to @c false when the most recent
+  /// @c SetProfiling(true) hit the "buffer already wired" no-op path —
+  /// this happens when a prior @c SetProfiling(false) failed its KFD
+  /// CLEAR and intentionally leaked the buffer to avoid FW
+  /// use-after-free (see amd_aql_queue.cpp:1854-1875). The dispatch_log
+  /// drainer needs this to distinguish a fresh queue (signal word is
+  /// genuinely 0) from a re-enable on a buffer where FW continued to
+  /// write records during the disabled window (signal word may be
+  /// non-zero from the previous lifecycle).
   hsa_status_t GetDispatchLogPointers(volatile uint64_t** wptr_ptr,
                                       volatile uint64_t** rptr_ptr,
-                                      volatile uint64_t** signal_ptr) const;
+                                      volatile uint64_t** signal_ptr,
+                                      bool* fresh_allocation = nullptr) const;
 
   /// @brief Update signal value using Relaxed semantics
   void StoreRelaxed(hsa_signal_value_t value) override;
@@ -441,6 +455,21 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   void* dispatch_log_wptr_buf_   = nullptr;   // FW writes here per record
   void* dispatch_log_rptr_buf_   = nullptr;   // host writes here on consume
   void* dispatch_log_signal_buf_ = nullptr;   // FW writes monotonic counter
+
+  // Tracks whether the most recent SetProfiling(true) actually allocated
+  // a fresh dispatch_record_buffer_ + host-VA counter set (true) or hit
+  // the no-op "buffer already wired" path (false). The latter happens
+  // when an earlier SetProfiling(false) failed its KFD CLEAR and
+  // quarantined the buffer (see SetProfiling failure-leak path). The
+  // dispatch_log drainer reads this via GetDispatchLogPointers to decide
+  // whether to start next_idx at 0 (fresh: host signal word is zero) or
+  // to snapshot the current FW *signal_ptr (re-enable: FW kept writing
+  // during the disabled window and the signal word is already non-zero).
+  // Default true so that the first SetProfiling(true) on a never-enabled
+  // queue is treated as fresh even if the alloc fails before the success
+  // path runs (the value is not consulted in that case but the default
+  // matches reality).
+  bool dispatch_log_freshly_allocated_ = true;
 
   // Shared event used for queue errors
   static __forceinline HsaEvent*& queue_event() {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -213,12 +213,15 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   hsa_status_t SetProfiling(bool enabled) override;
 
   /// @brief Get the per-queue MEC dispatch-record ring buffer info.
-  /// @details Returns the ring buffer base, total size in bytes, and a
-  /// pointer to the firmware-written wptr. Returns
+  /// @details Returns the ring buffer base and total size in bytes. The
+  /// substrate does NOT publish a host-visible firmware write pointer;
+  /// consumers must locate freshly-written records by scanning the ring
+  /// for a non-zero @c record_type sentinel (see
+  /// core/runtime/dispatch_log.cpp::drain_one_queue). Returns
   /// HSA_STATUS_ERROR_NOT_INITIALIZED if profiling has not been enabled
   /// on this queue.
-  hsa_status_t GetProfilingDispatchRecords(void** buffer_base, uint32_t* buffer_size,
-                                           volatile uint32_t** write_ptr) const;
+  hsa_status_t GetProfilingDispatchRecords(void** buffer_base,
+                                           uint32_t* buffer_size) const;
 
   /// @brief Update signal value using Relaxed semantics
   void StoreRelaxed(hsa_signal_value_t value) override;
@@ -388,9 +391,13 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   // == 16) to satisfy the host kernel's BO size validation in
   // kfd_process_queue_manager.c (`buf_byte_size = count * 40`). The MEC firmware
   // only writes 16 bytes per slot; the trailing 24 bytes per slot are unused.
+  // The host-side wptr that the cpc_tracing precedent allocated has been
+  // dropped: the substrate has no path to publish that address to FW (KFD
+  // ABI lacks a wptr_addr field), so consumers locate fresh records via
+  // sentinel scan over per-slot record_type — see
+  // core/runtime/dispatch_log.cpp::drain_one_queue.
   void* dispatch_record_buffer_ = nullptr;
   uint32_t dispatch_record_buffer_size_ = 0;     // record count (NOT bytes)
-  mutable volatile uint32_t dispatch_record_wptr_ = 0;
 
   // Shared event used for queue errors
   static __forceinline HsaEvent*& queue_event() {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -223,6 +223,33 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   hsa_status_t GetProfilingDispatchRecords(void** buffer_base,
                                            uint32_t* buffer_size) const;
 
+  /// @brief Get the per-queue host-VA pointer set used by the new
+  /// FW-readable dispatch-record interface.
+  ///
+  /// Each pointer is the CPU virtual address of an 8-byte counter word
+  /// in host-coherent system memory; the same address is also the GPU
+  /// virtual address (SVM) registered with KFD via the new
+  /// KFD_IOC_PROFILER_DISPATCH_LOG sub-op. MEC firmware reads the GPU
+  /// VAs from the v9 MQD slots DW48-DW53 on queue connect and:
+  ///   - writes the producer wptr (post-increment record count) to
+  ///     @c wptr_ptr per record
+  ///   - writes a monotonic counter (= same value as wptr) to
+  ///     @c signal_ptr per record (HSA-signal-compatible)
+  ///   - reads @c rptr_ptr opportunistically (currently informational
+  ///     only; FW does NOT enforce backpressure on overflow)
+  ///
+  /// All three pointers are nullptr if the new interface was not
+  /// enabled (kernel KFD MINOR < 20 or SetProfiling has not run yet).
+  /// Drainer code must check for null before dereferencing and fall
+  /// back to sentinel-scan.
+  ///
+  /// @returns HSA_STATUS_SUCCESS with non-null out-params if the new
+  /// interface is active for this queue; HSA_STATUS_ERROR_NOT_INITIALIZED
+  /// otherwise.
+  hsa_status_t GetDispatchLogPointers(volatile uint64_t** wptr_ptr,
+                                      volatile uint64_t** rptr_ptr,
+                                      volatile uint64_t** signal_ptr) const;
+
   /// @brief Update signal value using Relaxed semantics
   void StoreRelaxed(hsa_signal_value_t value) override;
 
@@ -395,13 +422,25 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   // stride and the drainer reads them at 16-byte stride. The extra
   // allocation tail beyond kRecordCount * 16 is unused/reserved and is
   // not part of the ring.
-  // The host-side wptr that the cpc_tracing precedent allocated has been
-  // dropped: the substrate has no path to publish that address to FW (KFD
-  // ABI lacks a wptr_addr field), so consumers locate fresh records via
-  // sentinel scan over per-slot record_type — see
-  // core/runtime/dispatch_log.cpp::drain_one_queue.
+  // The host-side wptr that the cpc_tracing precedent allocated has
+  // been re-introduced: KFD MINOR >= 20 + KFD_IOC_PROFILER_VERSION >= 2
+  // adds the KFD_IOC_PROFILER_DISPATCH_LOG sub-op and a v9 MQD slot
+  // pair (DW48/49) where the kernel programs the host VA the FW writes
+  // the wptr to. Two more pointer pairs (rptr DW50/51, signal DW52/53)
+  // come along for the ride. When the new interface is unavailable
+  // (older kernel/FW) the dispatch_log_*_buf_ fields stay nullptr and
+  // the drainer falls back to sentinel scan over per-slot record_type.
   void* dispatch_record_buffer_ = nullptr;
   uint32_t dispatch_record_buffer_size_ = 0;     // record count (NOT bytes)
+
+  // Three 8-byte host-coherent counter words (one cache line each to
+  // avoid producer/consumer false sharing). Allocated and registered in
+  // SetProfiling(true) when the new interface is supported by the
+  // running kernel; freed and unregistered in SetProfiling(false).
+  // The CPU vaddr equals the GPU vaddr (SVM-mapped GTT memory).
+  void* dispatch_log_wptr_buf_   = nullptr;   // FW writes here per record
+  void* dispatch_log_rptr_buf_   = nullptr;   // host writes here on consume
+  void* dispatch_log_signal_buf_ = nullptr;   // FW writes monotonic counter
 
   // Shared event used for queue errors
   static __forceinline HsaEvent*& queue_event() {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -387,10 +387,14 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
 
   // MEC firmware-assisted dispatch profiling ring buffer.
   // Allocated by SetProfiling(true), freed by SetProfiling(false) and the dtor.
-  // The buffer is allocated as kRecordCount * 40 bytes (NOT * sizeof(mec_dispatch_record)
-  // == 16) to satisfy the host kernel's BO size validation in
-  // kfd_process_queue_manager.c (`buf_byte_size = count * 40`). The MEC firmware
-  // only writes 16 bytes per slot; the trailing 24 bytes per slot are unused.
+  // The buffer is allocated oversized at kRecordCount * 40 bytes purely to
+  // satisfy the host kernel's BO-size validation in
+  // kfd_process_queue_manager.c (`buf_byte_size = count * 40`). The active
+  // FW/drainer ring uses the 16-byte FW record stride
+  // (sizeof(mec_dispatch_record_16) == 16): FW writes records at 16-byte
+  // stride and the drainer reads them at 16-byte stride. The extra
+  // allocation tail beyond kRecordCount * 16 is unused/reserved and is
+  // not part of the ring.
   // The host-side wptr that the cpc_tracing precedent allocated has been
   // dropped: the substrate has no path to publish that address to FW (KFD
   // ABI lacks a wptr_addr field), so consumers locate fresh records via

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -427,15 +427,21 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   struct metadata_prefetch_pkt_version barrier_version_;
 
   // MEC firmware-assisted dispatch profiling ring buffer.
-  // Allocated by SetProfiling(true), freed by SetProfiling(false) and the dtor.
-  // The buffer is allocated oversized at kRecordCount * 40 bytes purely to
-  // satisfy the host kernel's BO-size validation in
-  // kfd_process_queue_manager.c (`buf_byte_size = count * 40`). The active
-  // FW/drainer ring uses the 16-byte FW record stride
-  // (sizeof(mec_dispatch_record_16) == 16): FW writes records at 16-byte
-  // stride and the drainer reads them at 16-byte stride. The extra
-  // allocation tail beyond kRecordCount * 16 is unused/reserved and is
-  // not part of the ring.
+  // Allocated by SetProfiling(true). On a successful SetProfiling(false)
+  // the buffer is unwired from the MQD (UPDATE_QUEUE addr=0) and freed;
+  // on a failed SetProfiling(false) the buffer is intentionally
+  // quarantined (leaked, profiling bit left set, dispatch_record_buffer_
+  // remains non-null) until the AqlQueue dtor runs after KFD has
+  // destroyed the queue, so FW cannot use-after-free. The dtor's
+  // deallocate-if-non-null logic releases the quarantined allocation.
+  // The buffer is allocated at exactly kRecordCount * 16 bytes
+  // (sizeof(mec_dispatch_record_16) == 16, the FW record stride). The
+  // earlier *40 sizing was a workaround for an older pre-fix kernel
+  // whose BO-size validation in kfd_process_queue_manager.c over-counted
+  // the stride; both that older kernel and the current validation
+  // accept *16 (matches kfd_queue_buffer_get's strict mapping->last
+  // equality check). FW writes records at 16-byte stride and the
+  // drainer reads them at 16-byte stride.
   // The host-side wptr that the cpc_tracing precedent allocated has
   // been re-introduced: KFD MINOR >= 20 + KFD_IOC_PROFILER_VERSION >= 2
   // adds the KFD_IOC_PROFILER_DISPATCH_LOG sub-op and a v9 MQD slot

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -204,8 +204,13 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
                   hsa_fence_scope_t releaseFence = HSA_FENCE_SCOPE_NONE,
                   hsa_signal_t* signal = NULL) override;
 
-  /// @brief Enables/Disables profiling overrides SetProfiling from core::Queue
-  void SetProfiling(bool enabled) override;
+  /// @brief Enables/Disables profiling overrides SetProfiling from core::Queue.
+  /// @details Returns non-success if the dispatch-record buffer allocation,
+  /// libhsakmt SetQueueProfilingBuffer registration, or the UPDATE_QUEUE
+  /// flush fails. On enable failure all partial state is unwound (allocation
+  /// freed, cached fields reset). On disable failure the host-side buffer
+  /// is still freed (the FW-side state is best-effort).
+  hsa_status_t SetProfiling(bool enabled) override;
 
   /// @brief Get the per-queue MEC dispatch-record ring buffer info.
   /// @details Returns the ring buffer base, total size in bytes, and a

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -230,10 +230,8 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
 
   /// @brief Get the per-queue MEC dispatch-record ring buffer info.
   /// @details Returns the ring buffer base and total size in bytes. The
-  /// substrate does NOT publish a host-visible firmware write pointer;
-  /// consumers must locate freshly-written records by scanning the ring
-  /// for a non-zero @c record_type sentinel (see
-  /// core/runtime/dispatch_log.cpp::drain_one_queue). Returns
+  /// drainer bounds the live region using the host-VA signal from
+  /// GetDispatchLogPointers (see core/runtime/dispatch_log.cpp). Returns
   /// HSA_STATUS_ERROR_NOT_INITIALIZED if profiling has not been enabled
   /// on this queue.
   hsa_status_t GetProfilingDispatchRecords(void** buffer_base,
@@ -255,9 +253,8 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   ///     only; FW does NOT enforce backpressure on overflow)
   ///
   /// All three pointers are nullptr if the new interface was not
-  /// enabled (kernel KFD MINOR < 20 or SetProfiling has not run yet).
-  /// Drainer code must check for null before dereferencing and fall
-  /// back to sentinel-scan.
+  /// enabled (kernel KFD MINOR < 20, missing libhsakmt thunk, ioctl
+  /// failure, or SetProfiling has not run yet).
   ///
   /// @returns HSA_STATUS_SUCCESS with non-null out-params if the new
   /// interface is active for this queue; HSA_STATUS_ERROR_NOT_INITIALIZED
@@ -463,9 +460,8 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   // adds the KFD_IOC_PROFILER_DISPATCH_LOG sub-op and a v9 MQD slot
   // pair (DW48/49) where the kernel programs the host VA the FW writes
   // the wptr to. Two more pointer pairs (rptr DW50/51, signal DW52/53)
-  // come along for the ride. When the new interface is unavailable
-  // (older kernel/FW) the dispatch_log_*_buf_ fields stay nullptr and
-  // the drainer falls back to sentinel scan over per-slot record_type.
+  // come along for the ride. Profiling enable fails if this path cannot
+  // be registered (no sentinel-scan fallback).
   void* dispatch_record_buffer_ = nullptr;
   uint32_t dispatch_record_buffer_size_ = 0;     // record count (NOT bytes)
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -45,6 +45,7 @@
 #ifndef HSA_RUNTIME_CORE_INC_AMD_GPU_AGENT_H_
 #define HSA_RUNTIME_CORE_INC_AMD_GPU_AGENT_H_
 
+#include <shared_mutex>
 #include <vector>
 #include <list>
 #include <map>
@@ -224,6 +225,8 @@ class GpuAgentInt : public core::Agent {
    virtual hsa_status_t
    PcSamplingFlush(pcs::PcsRuntime::PcSamplingSession &session) = 0;
 };
+
+class AqlQueue;
 
 class GpuAgent : public GpuAgentInt {
  public:
@@ -550,6 +553,14 @@ class GpuAgent : public GpuAgentInt {
   /// @brief Get list of AQL queues for core dump filtering
   const std::vector<core::Queue*>& GetAqlQueues() const { return aql_queues_; }
 
+  std::shared_mutex& AqlQueuesMutex() { return aql_queues_mutex_; }
+
+  /// @brief Remove queue from @p aql_queues_ and clear trap-handler doorbell mapping.
+  void RemoveAqlQueue(AqlQueue* q);
+
+  /// @brief Clear trap-handler doorbell slot if it still references @p amd_q.
+  void ClearTrapDoorbellMapping(uintptr_t doorbell_addr, const amd_queue_v2_t* amd_q);
+
  protected:
   // Sizes are in packets.
   const uint32_t minAqlSize_ = 0x40;     // 4KB min
@@ -830,6 +841,7 @@ class GpuAgent : public GpuAgentInt {
   } gws_queue_;
 
   // @brief list of AQL queues owned by this agent. Indexed by queue pointer
+  mutable std::shared_mutex aql_queues_mutex_;
   std::vector<core::Queue*> aql_queues_;
 
   // Sets and Tracks pending SDMA status check or request counts

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -104,6 +104,10 @@ public:
                            void* queue_addr, uint64_t queue_size, HsaEvent* event) const override;
   hsa_status_t SetQueueProfilingBuffer(HSA_QUEUEID queue_id, void* buffer_base, uint32_t num_records,
                                        volatile uint32_t* wptr_host_addr) const override;
+  hsa_status_t SetDispatchLog(HSA_QUEUEID queue_id, uint32_t gpu_id,
+                              void* buffer_base, uint32_t num_records,
+                              void* wptr_addr, void* rptr_addr,
+                              void* signal_addr) const override;
   hsa_status_t DestroyQueue(HSA_QUEUEID queue_id) const override;
   hsa_status_t SetQueueCUMask(HSA_QUEUEID queue_id, uint32_t cu_mask_count,
                               uint32_t* queue_cu_mask) const override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -102,6 +102,8 @@ public:
                            HsaQueueResource& queue_resource) const override;
   hsa_status_t UpdateQueue(HSA_QUEUEID queue_id, uint32_t queue_pct, HSA::hsa_amd_queue_priority_internal_t priority,
                            void* queue_addr, uint64_t queue_size, HsaEvent* event) const override;
+  hsa_status_t SetQueueProfilingBuffer(HSA_QUEUEID queue_id, void* buffer_base, uint32_t num_records,
+                                       volatile uint32_t* wptr_host_addr) const override;
   hsa_status_t DestroyQueue(HSA_QUEUEID queue_id) const override;
   hsa_status_t SetQueueCUMask(HSA_QUEUEID queue_id, uint32_t cu_mask_count,
                               uint32_t* queue_cu_mask) const override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/clock_sync.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/clock_sync.h
@@ -1,0 +1,18 @@
+#ifndef ROCM_HSA_CLOCK_SYNC_H_
+#define ROCM_HSA_CLOCK_SYNC_H_
+
+namespace rocr {
+namespace clock_sync {
+
+// Initialize the clock synchronization module. Spawns the background poller
+// thread that periodically emits rocm_hsa:clock_sync tracepoints.
+void init();
+
+// Shut down the clock synchronization module. Signals the poller thread to
+// stop and joins it.
+void shutdown();
+
+}  // namespace clock_sync
+}  // namespace rocr
+
+#endif  // ROCM_HSA_CLOCK_SYNC_H_

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
@@ -115,12 +115,14 @@ static_assert(sizeof(mec_dispatch_record_16) == 16,
 // -----------------------------------------------------------------------------
 
 // Called once from Runtime::Load. Probes for KFD substrate support and spawns
-// the ts_poller thread. The drainer thread is spawned lazily by ts_poller on
-// the first enable edge (spec §9 LTTng-OFF row).
+// the ts_poller thread. Per-queue drainer worker threads are spawned by the
+// poller (or by on_queue_create) on each per-queue enable edge — one worker
+// per active queue, joined on its disable edge (spec §7).
 void init();
 
-// Called once from Runtime::Unload. Runs the disable edge for every active
-// queue, then joins the poller and (if running) drainer threads.
+// Called once from Runtime::Unload. Joins the poller, then runs the disable
+// edge for every active queue, which stops + joins each per-queue drainer
+// worker.
 void shutdown();
 
 // Called immediately AFTER a queue becomes visible via hsa_queue_create. If

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
@@ -43,54 +43,9 @@
 // HSA-resident firmware-ring drainer with LTTng emission for kernel-dispatch
 // timestamps. Public API surface for the dispatch_log subsystem. See
 // projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
-// for the implementation, and the Phase A spec (2026-04-27) for the full
+// for the implementation (in particular the sentinel-scan design in
+// drain_one_queue), and the Phase A spec (2026-04-27) for the full
 // design contract.
-//
-// -----------------------------------------------------------------------------
-// KNOWN GAP — firmware write-pointer publication is NOT plumbed end-to-end.
-// -----------------------------------------------------------------------------
-//
-// The drainer (drain_one_queue, dispatch_log.cpp:348) consumes a uint32_t
-// "fw_wptr_records" counter that firmware is expected to update as it writes
-// records into the per-queue ring. AqlQueue allocates that counter on the
-// host side (`AqlQueue::dispatch_record_wptr_`, amd_aql_queue.cpp:1639) and
-// passes its address through:
-//
-//   AqlQueue::SetProfiling
-//     -> KfdDriver::SetQueueProfilingBuffer
-//       -> hsaKmtSetQueueProfilingBuffer(QueueId, BufferBase, NumRecords,
-//                                        WptrHostAddr)
-//
-// However, the libhsakmt implementation (libhsakmt/src/queues.c:1140-1156)
-// EXPLICITLY DISCARDS the WptrHostAddr argument: only the buffer base + size
-// are stored on the per-queue cache. The KFD ABI used to push that cache to
-// the kernel (kfd_ioctl_update_queue_args) has fields for
-// `dispatch_record_buffer_addr` and `dispatch_record_buffer_size` only — there
-// is no wptr_addr field, and the host kernel keeps any firmware-side wptr in
-// the MQD (e.g. v9_mqd::dispatch_record_buffer_wptr at offset 0x2F on gfx9),
-// which is GPU-side and not directly host-readable through any current API.
-//
-// Net effect: even on the supposedly-supported KFD substrate (the
-// "gbt350"-class branch this scaffolding was rewired against), firmware has
-// no published address into which it can update a host-visible record
-// counter, so `dispatch_record_wptr_` stays at 0 forever and the drainer is
-// EFFECTIVELY DORMANT. The polling cost is still incurred, but no records
-// are paired or emitted.
-//
-// Closing this gap requires one of:
-//   (a) Extending the KFD ABI to carry a wptr_addr (new
-//       kfd_ioctl_update_queue_args field + matching kernel + firmware
-//       contract update), or
-//   (b) Defining a firmware contract where the wptr lives at a known offset
-//       inside the ring buffer itself (e.g. the first 8 bytes), and updating
-//       both AqlQueue and the drainer to read from there.
-//
-// Either option is OUT OF SCOPE for this Phase A scaffolding PR. This PR
-// inherits the same gap from the cpc_tracing branch precedent — that branch
-// was never integration-tested end-to-end, which is why the gap was never
-// user-visible there. See spec §10 dependency #2 sub-bullet for the
-// canonical statement of this requirement.
-// -----------------------------------------------------------------------------
 
 #ifndef HSA_RUNTME_CORE_INC_DISPATCH_LOG_H_
 #define HSA_RUNTME_CORE_INC_DISPATCH_LOG_H_

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
@@ -1,0 +1,162 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// The University of Illinois/NCSA
+// Open Source License (NCSA)
+//
+// Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Developed by:
+//
+//                 AMD Research and AMD HSA Software Development
+//
+//                 Advanced Micro Devices, Inc.
+//
+//                 www.amd.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal with the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+//  - Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimers.
+//  - Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimers in
+//    the documentation and/or other materials provided with the distribution.
+//  - Neither the names of Advanced Micro Devices, Inc,
+//    nor the names of its contributors may be used to endorse or promote
+//    products derived from this Software without specific prior written
+//    permission.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS WITH THE SOFTWARE.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// HSA-resident firmware-ring drainer with LTTng emission for kernel-dispatch
+// timestamps. Public API surface for the dispatch_log subsystem. See
+// projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+// for the implementation, and the Phase A spec (2026-04-27) for the full
+// design contract.
+
+#ifndef HSA_RUNTME_CORE_INC_DISPATCH_LOG_H_
+#define HSA_RUNTME_CORE_INC_DISPATCH_LOG_H_
+
+#include <cstddef>
+#include <cstdint>
+
+#include "hsa.h"
+
+namespace rocr {
+
+namespace core {
+class Queue;
+}  // namespace core
+
+namespace dispatch_log {
+
+// -----------------------------------------------------------------------------
+// On-wire / in-buffer constants. See spec §5 (ring layout) and §6 (record
+// format). The 16-byte record format and 64-byte header layout are frozen at
+// version 1; future revisions bump DISPATCH_LOG_VERSION and the drainer
+// refuses to consume rings whose header version it does not recognize.
+// -----------------------------------------------------------------------------
+
+// Ring header is one cache line preceding the FW-written data area.
+constexpr size_t  DISPATCH_LOG_HEADER_BYTES = 64;
+
+// Header / record format version stamped into the ring header at ENABLE
+// and checked by the drainer on first access. Bump on any change to the
+// 16-byte record layout or the 64-byte header layout.
+constexpr uint32_t DISPATCH_LOG_VERSION = 1;
+
+// Power-of-2 size of the ring data area (NOT including the 64-byte header).
+// 4 MB matches the spec's typical-budget recommendation in §5.
+constexpr size_t  DISPATCH_LOG_RING_BYTES = 4 * 1024 * 1024;
+
+// Record-type tags written by FW into mec_dispatch_record_16::record_type.
+enum {
+  DISPATCH_LOG_RECORD_START = 1,
+  DISPATCH_LOG_RECORD_END   = 2,
+};
+
+// FW-written 16-byte record. Layout is fixed by the firmware contract: see
+// spec §6 for the field semantics and §14 glossary for the dispatch_idx
+// 32-bit width contract. Packed to 16 bytes with no implicit padding.
+#pragma pack(push, 1)
+struct mec_dispatch_record_16 {
+  uint32_t ts_lo;          // GPU clock low 32 bits
+  uint32_t ts_hi;          // GPU clock high 32 bits
+  uint32_t record_type;    // DISPATCH_LOG_RECORD_{START,END}
+  uint32_t dispatch_idx;   // low 32 bits of AQL read_dispatch_id
+};
+#pragma pack(pop)
+static_assert(sizeof(mec_dispatch_record_16) == 16,
+              "mec_dispatch_record_16 must be exactly 16 bytes (FW contract)");
+
+// Ring header layout (B + 0 .. B + DISPATCH_LOG_HEADER_BYTES). FW writes
+// `fw_wptr`; HSA writes `generation` and `version` at ENABLE. See spec §5.
+struct dispatch_log_header {
+  volatile uint64_t fw_wptr;     // monotonic byte counter, FW-written
+  uint64_t          generation;  // bumped by HSA on each per-queue ENABLE
+  uint32_t          version;     // header/record-format version
+  uint32_t          reserved[11];
+};
+static_assert(sizeof(dispatch_log_header) == DISPATCH_LOG_HEADER_BYTES,
+              "dispatch_log_header must occupy exactly one cache line "
+              "(DISPATCH_LOG_HEADER_BYTES)");
+
+// -----------------------------------------------------------------------------
+// Lifecycle hooks. Called from Runtime::Load / Runtime::Unload and from the
+// hsa_queue_create / hsa_queue_destroy entry points. See spec §8 file layout
+// and §4 lifecycle state machine.
+// -----------------------------------------------------------------------------
+
+// Called once from Runtime::Load. Probes for KFD substrate support and spawns
+// the ts_poller thread. The drainer thread is spawned lazily by ts_poller on
+// the first enable edge (spec §9 LTTng-OFF row).
+void init();
+
+// Called once from Runtime::Unload. Runs the disable edge for every active
+// queue, then joins the poller and (if running) drainer threads.
+void shutdown();
+
+// Called immediately AFTER a queue becomes visible via hsa_queue_create. If
+// the tracepoint is currently enabled, runs the per-queue ENABLE sequence
+// from spec §5 on the calling thread (bounded latency: one host alloc + one
+// KFD ioctl + one MQD-flush round-trip).
+void on_queue_create(core::Queue* q);
+
+// Called BEFORE a queue is destroyed via hsa_queue_destroy. If the queue has
+// dispatch_log_active=true, runs the per-queue DISABLE sequence from spec §4
+// queue-destroy hook on the calling thread (bounded final drain + KFD ioctl).
+void on_queue_destroy(core::Queue* q);
+
+// -----------------------------------------------------------------------------
+// Profiling-bit refcount API (spec §4a). Multiple consumers (LTTng dispatch-log
+// path, rocprofiler-sdk dispatch-timestamp path, future profilers) must
+// coordinate through this refcount instead of writing
+// AMD_QUEUE_PROPERTIES_ENABLE_PROFILING (bit 3 in amd_queue_t.queue_properties)
+// directly. The bit is set whenever refcount > 0 and clear whenever
+// refcount == 0; every Acquire MUST be matched by exactly one Release.
+//
+// rocprofiler-sdk migration to this API is a hard precondition for shipping
+// the LTTng dispatch-log feature (spec §10 dep #4). Phase A (this scaffolding)
+// can land independently of the SDK migration; the LTTng path uses these
+// helpers unconditionally.
+// -----------------------------------------------------------------------------
+
+hsa_status_t QueueProfilingAcquire(core::Queue* q);
+hsa_status_t QueueProfilingRelease(core::Queue* q);
+
+}  // namespace dispatch_log
+}  // namespace rocr
+
+#endif  // HSA_RUNTME_CORE_INC_DISPATCH_LOG_H_

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
@@ -68,11 +68,12 @@ namespace dispatch_log {
 // format). The 16-byte record format is the MEC firmware contract.
 //
 // The buffer layout was originally defined as `header + ring data`. The
-// firmware-dispatch-ring infrastructure imported from cpc_tracing instead
-// hands the drainer a flat ring of N records and a separately-located
-// uint32_t firmware write pointer (not embedded in the buffer). The
-// header and DISPATCH_LOG_VERSION are no longer used; they are retained
-// here only as historical constants for now and may be removed.
+// current substrate instead hands the drainer a flat ring of N records
+// at the 16-byte FW record stride, with no host-visible FW write pointer:
+// the drainer locates fresh records via sentinel scan over per-slot
+// record_type and advances a host-managed monotonic cursor. The header
+// and DISPATCH_LOG_VERSION are no longer used; they are retained here
+// only as historical constants for now and may be removed.
 // -----------------------------------------------------------------------------
 
 // Number of FW dispatch records per queue ring buffer. Must match

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
@@ -64,22 +64,21 @@ namespace dispatch_log {
 
 // -----------------------------------------------------------------------------
 // On-wire / in-buffer constants. See spec §5 (ring layout) and §6 (record
-// format). The 16-byte record format and 64-byte header layout are frozen at
-// version 1; future revisions bump DISPATCH_LOG_VERSION and the drainer
-// refuses to consume rings whose header version it does not recognize.
+// format). The 16-byte record format is the MEC firmware contract.
+//
+// The buffer layout was originally defined as `header + ring data`. The
+// firmware-dispatch-ring infrastructure imported from cpc_tracing instead
+// hands the drainer a flat ring of N records and a separately-located
+// uint32_t firmware write pointer (not embedded in the buffer). The
+// header and DISPATCH_LOG_VERSION are no longer used; they are retained
+// here only as historical constants for now and may be removed.
 // -----------------------------------------------------------------------------
 
-// Ring header is one cache line preceding the FW-written data area.
-constexpr size_t  DISPATCH_LOG_HEADER_BYTES = 64;
-
-// Header / record format version stamped into the ring header at ENABLE
-// and checked by the drainer on first access. Bump on any change to the
-// 16-byte record layout or the 64-byte header layout.
-constexpr uint32_t DISPATCH_LOG_VERSION = 1;
-
-// Power-of-2 size of the ring data area (NOT including the 64-byte header).
-// 4 MB matches the spec's typical-budget recommendation in §5.
-constexpr size_t  DISPATCH_LOG_RING_BYTES = 4 * 1024 * 1024;
+// Number of FW dispatch records per queue ring buffer. Must match
+// AqlQueue::SetProfiling's hard-coded num_records (currently 65536).
+// Power of 2 so masking is cheap; the drainer uses (kRecordCount - 1)
+// for byte-offset wraparound.
+constexpr uint32_t DISPATCH_LOG_RECORD_COUNT = 65536;
 
 // Record-type tags written by FW into mec_dispatch_record_16::record_type.
 enum {
@@ -87,31 +86,21 @@ enum {
   DISPATCH_LOG_RECORD_END   = 2,
 };
 
-// FW-written 16-byte record. Layout is fixed by the firmware contract: see
-// spec §6 for the field semantics and §14 glossary for the dispatch_idx
-// 32-bit width contract. Packed to 16 bytes with no implicit padding.
+// FW-written 16-byte record. Layout is fixed by the firmware contract.
+// Mirrors rocr::AMD::mec_dispatch_record from
+// core/inc/mec_dispatch_record.h, with the trailing 4-byte field treated
+// as the dispatch index (FW writes the per-queue monotonic dispatch idx
+// into the `reserved` slot per the cpc_tracing drainer's interpretation).
 #pragma pack(push, 1)
 struct mec_dispatch_record_16 {
   uint32_t ts_lo;          // GPU clock low 32 bits
   uint32_t ts_hi;          // GPU clock high 32 bits
   uint32_t record_type;    // DISPATCH_LOG_RECORD_{START,END}
-  uint32_t dispatch_idx;   // low 32 bits of AQL read_dispatch_id
+  uint32_t dispatch_idx;   // FW-written dispatch idx (mec_dispatch_record::reserved)
 };
 #pragma pack(pop)
 static_assert(sizeof(mec_dispatch_record_16) == 16,
               "mec_dispatch_record_16 must be exactly 16 bytes (FW contract)");
-
-// Ring header layout (B + 0 .. B + DISPATCH_LOG_HEADER_BYTES). FW writes
-// `fw_wptr`; HSA writes `generation` and `version` at ENABLE. See spec §5.
-struct dispatch_log_header {
-  volatile uint64_t fw_wptr;     // monotonic byte counter, FW-written
-  uint64_t          generation;  // bumped by HSA on each per-queue ENABLE
-  uint32_t          version;     // header/record-format version
-  uint32_t          reserved[11];
-};
-static_assert(sizeof(dispatch_log_header) == DISPATCH_LOG_HEADER_BYTES,
-              "dispatch_log_header must occupy exactly one cache line "
-              "(DISPATCH_LOG_HEADER_BYTES)");
 
 // -----------------------------------------------------------------------------
 // Lifecycle hooks. Called from Runtime::Load / Runtime::Unload and from the

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
@@ -45,6 +45,52 @@
 // projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
 // for the implementation, and the Phase A spec (2026-04-27) for the full
 // design contract.
+//
+// -----------------------------------------------------------------------------
+// KNOWN GAP — firmware write-pointer publication is NOT plumbed end-to-end.
+// -----------------------------------------------------------------------------
+//
+// The drainer (drain_one_queue, dispatch_log.cpp:348) consumes a uint32_t
+// "fw_wptr_records" counter that firmware is expected to update as it writes
+// records into the per-queue ring. AqlQueue allocates that counter on the
+// host side (`AqlQueue::dispatch_record_wptr_`, amd_aql_queue.cpp:1639) and
+// passes its address through:
+//
+//   AqlQueue::SetProfiling
+//     -> KfdDriver::SetQueueProfilingBuffer
+//       -> hsaKmtSetQueueProfilingBuffer(QueueId, BufferBase, NumRecords,
+//                                        WptrHostAddr)
+//
+// However, the libhsakmt implementation (libhsakmt/src/queues.c:1140-1156)
+// EXPLICITLY DISCARDS the WptrHostAddr argument: only the buffer base + size
+// are stored on the per-queue cache. The KFD ABI used to push that cache to
+// the kernel (kfd_ioctl_update_queue_args) has fields for
+// `dispatch_record_buffer_addr` and `dispatch_record_buffer_size` only — there
+// is no wptr_addr field, and the host kernel keeps any firmware-side wptr in
+// the MQD (e.g. v9_mqd::dispatch_record_buffer_wptr at offset 0x2F on gfx9),
+// which is GPU-side and not directly host-readable through any current API.
+//
+// Net effect: even on the supposedly-supported KFD substrate (the
+// "gbt350"-class branch this scaffolding was rewired against), firmware has
+// no published address into which it can update a host-visible record
+// counter, so `dispatch_record_wptr_` stays at 0 forever and the drainer is
+// EFFECTIVELY DORMANT. The polling cost is still incurred, but no records
+// are paired or emitted.
+//
+// Closing this gap requires one of:
+//   (a) Extending the KFD ABI to carry a wptr_addr (new
+//       kfd_ioctl_update_queue_args field + matching kernel + firmware
+//       contract update), or
+//   (b) Defining a firmware contract where the wptr lives at a known offset
+//       inside the ring buffer itself (e.g. the first 8 bytes), and updating
+//       both AqlQueue and the drainer to read from there.
+//
+// Either option is OUT OF SCOPE for this Phase A scaffolding PR. This PR
+// inherits the same gap from the cpc_tracing branch precedent — that branch
+// was never integration-tested end-to-end, which is why the gap was never
+// user-visible there. See spec §10 dependency #2 sub-bullet for the
+// canonical statement of this requirement.
+// -----------------------------------------------------------------------------
 
 #ifndef HSA_RUNTME_CORE_INC_DISPATCH_LOG_H_
 #define HSA_RUNTME_CORE_INC_DISPATCH_LOG_H_

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
@@ -83,9 +83,23 @@ namespace dispatch_log {
 constexpr uint32_t DISPATCH_LOG_RECORD_COUNT = 65536;
 
 // Record-type tags written by FW into mec_dispatch_record_16::record_type.
+//
+// These constant values match the firmware's actual contract on this
+// substrate (verified empirically via graphbench end-to-end on gbt350,
+// 2026-04-28: the record with record_type==2's GPU timestamp is
+// consistently EARLIER than the record with record_type==1's GPU
+// timestamp by ~64 µs per dispatch — i.e. record_type==2 is the
+// dispatch-START record (written when MEC begins processing the AQL
+// packet) and record_type==1 is the dispatch-END / EOP record).
+//
+// Note: cpc_tracing's `core/inc/mec_dispatch_record.h` comment claims
+// the OPPOSITE (1=start, 2=end). The empirical contract on the
+// installed gfx950 MEC firmware (gc_9_5_0_mec.bin, mode 0640, dated
+// 2026-03-26) wins; cpc_tracing's comment is stale relative to the
+// shipped firmware.
 enum {
-  DISPATCH_LOG_RECORD_START = 1,
-  DISPATCH_LOG_RECORD_END   = 2,
+  DISPATCH_LOG_RECORD_START = 2,
+  DISPATCH_LOG_RECORD_END   = 1,
 };
 
 // FW-written 16-byte record. Layout is fixed by the firmware contract.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
@@ -82,22 +82,26 @@ namespace dispatch_log {
 // for byte-offset wraparound.
 constexpr uint32_t DISPATCH_LOG_RECORD_COUNT = 65536;
 
-// Record-type tags written by FW into mec_dispatch_record_16::record_type.
-enum {
-  DISPATCH_LOG_RECORD_START = 1,
-  DISPATCH_LOG_RECORD_END   = 2,
-};
-
 // FW-written 16-byte record. Layout is fixed by the firmware contract.
 // Mirrors rocr::AMD::mec_dispatch_record from
 // core/inc/mec_dispatch_record.h, with the trailing 4-byte field treated
 // as the dispatch index (FW writes the per-queue monotonic dispatch idx
 // into the `reserved` slot per the cpc_tracing drainer's interpretation).
+//
+// `record_type` is FW-defined and intentionally left opaque to HSA: the
+// drainer does not interpret which value means dispatch start vs end and
+// emits one rocm_hsa:kernel_dispatch_record event per non-zero record
+// regardless of the tag value. Stream consumers that want paired
+// start/end semantics join records on (queue_id, dispatch_idx) and
+// either order by gpu_ts or apply their own FW-version-specific
+// record_type interpretation. Only record_type == 0 is reserved by HSA
+// itself: it marks an empty (host-pre-zeroed and not yet FW-written)
+// slot in the sentinel-scan drainer.
 #pragma pack(push, 1)
 struct mec_dispatch_record_16 {
   uint32_t ts_lo;          // GPU clock low 32 bits
   uint32_t ts_hi;          // GPU clock high 32 bits
-  uint32_t record_type;    // DISPATCH_LOG_RECORD_{START,END}
+  uint32_t record_type;    // FW-defined; 0 reserved as the empty sentinel
   uint32_t dispatch_idx;   // FW-written dispatch idx (mec_dispatch_record::reserved)
 };
 #pragma pack(pop)

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
@@ -83,23 +83,9 @@ namespace dispatch_log {
 constexpr uint32_t DISPATCH_LOG_RECORD_COUNT = 65536;
 
 // Record-type tags written by FW into mec_dispatch_record_16::record_type.
-//
-// These constant values match the firmware's actual contract on this
-// substrate (verified empirically via graphbench end-to-end on gbt350,
-// 2026-04-28: the record with record_type==2's GPU timestamp is
-// consistently EARLIER than the record with record_type==1's GPU
-// timestamp by ~64 µs per dispatch — i.e. record_type==2 is the
-// dispatch-START record (written when MEC begins processing the AQL
-// packet) and record_type==1 is the dispatch-END / EOP record).
-//
-// Note: cpc_tracing's `core/inc/mec_dispatch_record.h` comment claims
-// the OPPOSITE (1=start, 2=end). The empirical contract on the
-// installed gfx950 MEC firmware (gc_9_5_0_mec.bin, mode 0640, dated
-// 2026-03-26) wins; cpc_tracing's comment is stale relative to the
-// shipped firmware.
 enum {
-  DISPATCH_LOG_RECORD_START = 2,
-  DISPATCH_LOG_RECORD_END   = 1,
+  DISPATCH_LOG_RECORD_START = 1,
+  DISPATCH_LOG_RECORD_END   = 2,
 };
 
 // FW-written 16-byte record. Layout is fixed by the firmware contract.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
@@ -43,9 +43,27 @@
 // HSA-resident firmware-ring drainer with LTTng emission for kernel-dispatch
 // timestamps. Public API surface for the dispatch_log subsystem. See
 // projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
-// for the implementation (in particular the sentinel-scan design in
-// drain_one_queue), and the Phase A spec (2026-04-27) for the full
+// for the implementation, and the Phase A spec (2026-04-27) for the full
 // design contract.
+//
+// Two-mode drain design (see drain_one_queue in dispatch_log.cpp):
+//
+//   - Path A (preferred, signal-bound): when AqlQueue::GetDispatchLogPointers
+//     returns a host-VA wptr/rptr/signal triple (newer kernel/FW that
+//     exposes the FW write pointer to the host), the drainer waits on the
+//     FW signal, reads the wptr to bound the live region, and consumes
+//     [next_idx, wptr). This is the steady-state path.
+//
+//   - Path B (legacy fallback, sentinel-scan): when GetDispatchLogPointers
+//     returns NOT_INITIALIZED (older kernel/FW or libhsakmt without
+//     host-VA pointer support), the drainer falls back to scanning the
+//     ring sequentially from a host-managed monotonic cursor (next_idx)
+//     and uses per-slot record_type==0 as the empty-slot sentinel.
+//
+// Path A is registered at queue enable in QueueProfilingAcquire (see the
+// GetDispatchLogPointers call in dispatch_log.cpp around the per-queue
+// enable block); Path B is the unconditional fallback when those pointers
+// are unavailable.
 
 #ifndef HSA_RUNTME_CORE_INC_DISPATCH_LOG_H_
 #define HSA_RUNTME_CORE_INC_DISPATCH_LOG_H_
@@ -69,11 +87,15 @@ namespace dispatch_log {
 //
 // The buffer layout was originally defined as `header + ring data`. The
 // current substrate instead hands the drainer a flat ring of N records
-// at the 16-byte FW record stride, with no host-visible FW write pointer:
-// the drainer locates fresh records via sentinel scan over per-slot
-// record_type and advances a host-managed monotonic cursor. The header
-// and DISPATCH_LOG_VERSION are no longer used; they are retained here
-// only as historical constants for now and may be removed.
+// at the 16-byte FW record stride. The drainer consumes that ring in one
+// of two modes (see top-of-file two-mode drain design comment above):
+// preferred Path A reads a host-VA FW wptr published via
+// AqlQueue::GetDispatchLogPointers; legacy Path B falls back to a
+// sentinel-scan over per-slot record_type when the wptr is unavailable.
+// In both modes the drainer advances a host-managed monotonic cursor
+// (next_idx). The original buffer header and DISPATCH_LOG_VERSION are no
+// longer used; they are retained here only as historical constants for
+// now and may be removed.
 // -----------------------------------------------------------------------------
 
 // NOTE: the per-queue ring record count is NOT a build-time constant.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
@@ -76,17 +76,22 @@ namespace dispatch_log {
 // only as historical constants for now and may be removed.
 // -----------------------------------------------------------------------------
 
-// Number of FW dispatch records per queue ring buffer. Must match
-// AqlQueue::SetProfiling's hard-coded num_records (currently 65536).
-// Power of 2 so masking is cheap; the drainer uses (kRecordCount - 1)
-// for byte-offset wraparound.
-constexpr uint32_t DISPATCH_LOG_RECORD_COUNT = 65536;
+// NOTE: the per-queue ring record count is NOT a build-time constant.
+// AqlQueue::SetProfiling chooses the num_records value at allocation
+// time and the drainer derives ring_records at runtime from
+// AqlQueue::GetProfilingDispatchRecords (buf_bytes / sizeof(record)).
+// A previous DISPATCH_LOG_RECORD_COUNT constant was removed because it
+// silently went stale when SetProfiling's ring size was bumped (and was
+// not actually used by the drainer code path). The single source of
+// truth is AqlQueue::SetProfiling in core/runtime/amd_aql_queue.cpp;
+// consumers MUST query GetProfilingDispatchRecords for the live size.
 
 // FW-written 16-byte record. Layout is fixed by the firmware contract.
 // Mirrors rocr::AMD::mec_dispatch_record from
 // core/inc/mec_dispatch_record.h, with the trailing 4-byte field treated
 // as the dispatch index (FW writes the per-queue monotonic dispatch idx
-// into the `reserved` slot per the cpc_tracing drainer's interpretation).
+// into the slot named `reserved` in mec_dispatch_record; see that header
+// for the historical-name vs current-FW-semantics rationale).
 //
 // `record_type` is FW-defined and intentionally left opaque to HSA: the
 // drainer does not interpret which value means dispatch start vs end and

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h
@@ -46,24 +46,9 @@
 // for the implementation, and the Phase A spec (2026-04-27) for the full
 // design contract.
 //
-// Two-mode drain design (see drain_one_queue in dispatch_log.cpp):
-//
-//   - Path A (preferred, signal-bound): when AqlQueue::GetDispatchLogPointers
-//     returns a host-VA wptr/rptr/signal triple (newer kernel/FW that
-//     exposes the FW write pointer to the host), the drainer waits on the
-//     FW signal, reads the wptr to bound the live region, and consumes
-//     [next_idx, wptr). This is the steady-state path.
-//
-//   - Path B (legacy fallback, sentinel-scan): when GetDispatchLogPointers
-//     returns NOT_INITIALIZED (older kernel/FW or libhsakmt without
-//     host-VA pointer support), the drainer falls back to scanning the
-//     ring sequentially from a host-managed monotonic cursor (next_idx)
-//     and uses per-slot record_type==0 as the empty-slot sentinel.
-//
-// Path A is registered at queue enable in QueueProfilingAcquire (see the
-// GetDispatchLogPointers call in dispatch_log.cpp around the per-queue
-// enable block); Path B is the unconditional fallback when those pointers
-// are unavailable.
+// Draining is signal-bound: AqlQueue::GetDispatchLogPointers supplies host-VA
+// wptr/rptr/signal counters (KFD_IOC_PROFILER_DISPATCH_LOG). SetProfiling(true)
+// fails if that registration cannot complete; there is no sentinel-scan path.
 
 #ifndef HSA_RUNTME_CORE_INC_DISPATCH_LOG_H_
 #define HSA_RUNTME_CORE_INC_DISPATCH_LOG_H_
@@ -87,15 +72,12 @@ namespace dispatch_log {
 //
 // The buffer layout was originally defined as `header + ring data`. The
 // current substrate instead hands the drainer a flat ring of N records
-// at the 16-byte FW record stride. The drainer consumes that ring in one
-// of two modes (see top-of-file two-mode drain design comment above):
-// preferred Path A reads a host-VA FW wptr published via
-// AqlQueue::GetDispatchLogPointers; legacy Path B falls back to a
-// sentinel-scan over per-slot record_type when the wptr is unavailable.
-// In both modes the drainer advances a host-managed monotonic cursor
-// (next_idx). The original buffer header and DISPATCH_LOG_VERSION are no
-// longer used; they are retained here only as historical constants for
-// now and may be removed.
+// at the 16-byte FW record stride. The drainer is signal-bound: it reads
+// *signal_ptr from AqlQueue::GetDispatchLogPointers and walks [next_idx,
+// observed), using record_type==0 inside that window for multi-XCC /
+// init-sync quarantine (see drain_one_queue). The original buffer header
+// and DISPATCH_LOG_VERSION are no longer used; they are retained here only
+// as historical constants for now and may be removed.
 // -----------------------------------------------------------------------------
 
 // NOTE: the per-queue ring record count is NOT a build-time constant.
@@ -121,14 +103,13 @@ namespace dispatch_log {
 // regardless of the tag value. Stream consumers that want paired
 // start/end semantics join records on (queue_id, dispatch_idx) and
 // either order by gpu_ts or apply their own FW-version-specific
-// record_type interpretation. Only record_type == 0 is reserved by HSA
-// itself: it marks an empty (host-pre-zeroed and not yet FW-written)
-// slot in the sentinel-scan drainer.
+// record_type interpretation. record_type==0 marks an empty slot (buffer
+// pre-zeroed; also used inside the signal-bound scan for quarantine).
 #pragma pack(push, 1)
 struct mec_dispatch_record_16 {
   uint32_t ts_lo;          // GPU clock low 32 bits
   uint32_t ts_hi;          // GPU clock high 32 bits
-  uint32_t record_type;    // FW-defined; 0 reserved as the empty sentinel
+  uint32_t record_type;    // FW-defined; 0 marks empty / quarantine-relevant slot
   uint32_t dispatch_idx;   // FW-written dispatch idx (mec_dispatch_record::reserved)
 };
 #pragma pack(pop)

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -193,6 +193,27 @@ public:
     return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
   }
 
+  /// @brief Configure dispatch-log buffer + host-VA pointer counters via the
+  /// new KFD_IOC_PROFILER_DISPATCH_LOG sub-op.
+  /// @details Returns NOT_SUPPORTED when the kernel thunk doesn't export
+  /// hsaKmtSetDispatchLog (older libhsakmt without KFD MINOR >= 20 / profiler
+  /// version >= 2 awareness). Pass buffer_base = nullptr to issue CLEAR; any
+  /// of wptr_addr/rptr_addr/signal_addr may be nullptr to opt out of that
+  /// side-channel.
+  virtual hsa_status_t SetDispatchLog(HSA_QUEUEID queue_id, uint32_t gpu_id,
+                                      void* buffer_base, uint32_t num_records,
+                                      void* wptr_addr, void* rptr_addr,
+                                      void* signal_addr) const {
+    (void)queue_id;
+    (void)gpu_id;
+    (void)buffer_base;
+    (void)num_records;
+    (void)wptr_addr;
+    (void)rptr_addr;
+    (void)signal_addr;
+    return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
+  }
+
   /// @brief Set the CU mask for a queue.
   /// @details This sets the CU bitmask for a queue. The CU mask determines which CUs
   /// a queue's dispatches can target. Currently this is only supported for GPU devices.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -181,6 +181,18 @@ public:
                                    HSA::hsa_amd_queue_priority_internal_t priority, void* queue_addr,
                                    uint64_t queue_size_bytes, HsaEvent* event) const = 0;
 
+  /// @brief Configure MEC dispatch profiling ring buffer for a queue (KFD-specific).
+  /// @details When unsupported by the kernel thunk, returns ::HSA_STATUS_ERROR_NOT_SUPPORTED.
+  virtual hsa_status_t SetQueueProfilingBuffer(HSA_QUEUEID queue_id, void* buffer_base,
+                                               uint32_t num_records,
+                                               volatile uint32_t* wptr_host_addr) const {
+    (void)queue_id;
+    (void)buffer_base;
+    (void)num_records;
+    (void)wptr_host_addr;
+    return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
+  }
+
   /// @brief Set the CU mask for a queue.
   /// @details This sets the CU bitmask for a queue. The CU mask determines which CUs
   /// a queue's dispatches can target. Currently this is only supported for GPU devices.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
@@ -69,8 +69,7 @@ hsa_status_t hsa_amd_queue_iterate(hsa_status_t (*callback)(hsa_queue_t* queue, 
                                    void* data);
 
 hsa_status_t hsa_amd_profiling_get_dispatch_records(hsa_queue_t* queue, void** buffer_base,
-                                                    uint32_t* buffer_size,
-                                                    volatile uint32_t** write_ptr);
+                                                    uint32_t* buffer_size);
 
 // Mirrors Amd Extension Apis
 hsa_status_t

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
@@ -65,6 +65,13 @@ hsa_status_t hsa_amd_coherency_set_type(hsa_agent_t agent,
 hsa_status_t
     hsa_amd_profiling_set_profiler_enabled(hsa_queue_t* queue, int enable);
 
+hsa_status_t hsa_amd_queue_iterate(hsa_status_t (*callback)(hsa_queue_t* queue, void* data),
+                                   void* data);
+
+hsa_status_t hsa_amd_profiling_get_dispatch_records(hsa_queue_t* queue, void** buffer_base,
+                                                    uint32_t* buffer_size,
+                                                    volatile uint32_t** write_ptr);
+
 // Mirrors Amd Extension Apis
 hsa_status_t
     hsa_amd_profiling_async_copy_enable(bool enable);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/intercept_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/intercept_queue.h
@@ -132,7 +132,7 @@ class QueueWrapper : public Queue {
                   hsa_signal_t* signal = NULL) override {
     wrapped->ExecutePM4(cmd_data, cmd_size_b, acquireFence, releaseFence, signal);
   }
-  void SetProfiling(bool enabled) override { wrapped->SetProfiling(enabled); }
+  hsa_status_t SetProfiling(bool enabled) override { return wrapped->SetProfiling(enabled); }
 
  protected:
   void do_set_public_handle(hsa_queue_t* handle) override {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/mec_dispatch_record.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/mec_dispatch_record.h
@@ -1,0 +1,42 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// MEC firmware dispatch record layout (userspace mirror for sizing).
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef HSA_RUNTIME_CORE_INC_MEC_DISPATCH_RECORD_H_
+#define HSA_RUNTIME_CORE_INC_MEC_DISPATCH_RECORD_H_
+
+#include <cstdint>
+
+namespace rocr {
+namespace AMD {
+
+/// 16-byte record written by MEC firmware per dispatch event.
+///
+/// The firmware writes two records per dispatch: one at dispatch-start
+/// (record_type=1) and one at EOP / dispatch-end (record_type=2).
+/// Host-side tooling correlates records by dispatch order and pairs
+/// start/end timestamps.  Kernel identity is resolved host-side via
+/// the ROCr code-object symbol table, not embedded in the record.
+///
+/// Design rationale (2026-03-30):
+///   - Minimises firmware complexity and risk of GPU hangs.
+///   - 16 bytes = 4 DWords = single TC write transaction.
+///   - Kernel name / object VA not needed in the record because the host
+///     already knows which kernel was submitted to each queue slot.
+///   - Richer per-dispatch metadata (doorbell, ring_index, etc.) can be
+///     added later by extending this struct and the firmware write path,
+///     but is not required for the primary use-case of late-attach
+///     timestamp profiling.
+struct mec_dispatch_record {
+  uint32_t ts_lo;        // GPU clock counter [31:0]
+  uint32_t ts_hi;        // GPU clock counter [63:32]
+  uint32_t record_type;  // 1 = dispatch-start, 2 = EOP (dispatch-end)
+  uint32_t reserved;     // Must be 0
+};
+
+}  // namespace AMD
+}  // namespace rocr
+
+#endif  // HSA_RUNTIME_CORE_INC_MEC_DISPATCH_RECORD_H_

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/mec_dispatch_record.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/mec_dispatch_record.h
@@ -29,11 +29,25 @@ namespace AMD {
 ///     added later by extending this struct and the firmware write path,
 ///     but is not required for the primary use-case of late-attach
 ///     timestamp profiling.
+///
+/// Field-name history note: the trailing slot is named `reserved` for
+/// historical reasons (the original 2026-03-30 contract reserved it as
+/// padding "must be 0"). Subsequent firmware revisions repurposed this
+/// slot to carry the per-queue monotonic dispatch index that the FW
+/// writes alongside every record. Host-side consumers therefore treat
+/// this slot as the FW-written dispatch_idx; see the
+/// `mec_dispatch_record_16` mirror in core/inc/dispatch_log.h, which
+/// names the slot `dispatch_idx` to reflect its current FW semantics,
+/// and the rocm_hsa:kernel_dispatch_record tracepoint contract in
+/// lttng/rocm_hsa_tp.h. The `reserved` name is retained on this struct
+/// for source-compatibility with existing consumers; it is NOT zero in
+/// FW-written records.
 struct mec_dispatch_record {
   uint32_t ts_lo;        // GPU clock counter [31:0]
   uint32_t ts_hi;        // GPU clock counter [63:32]
   uint32_t record_type;  // 1 = dispatch-start, 2 = EOP (dispatch-end)
-  uint32_t reserved;     // Must be 0
+  uint32_t reserved;     // Historical name; FW writes per-queue monotonic
+                         // dispatch_idx here (see struct doc above).
 };
 
 }  // namespace AMD

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/mec_dispatch_record.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/mec_dispatch_record.h
@@ -14,11 +14,17 @@ namespace AMD {
 
 /// 16-byte record written by MEC firmware per dispatch event.
 ///
-/// The firmware writes two records per dispatch: one at dispatch-start
-/// (record_type=1) and one at EOP / dispatch-end (record_type=2).
-/// Host-side tooling correlates records by dispatch order and pairs
-/// start/end timestamps.  Kernel identity is resolved host-side via
-/// the ROCr code-object symbol table, not embedded in the record.
+/// The firmware writes two records per dispatch (one at dispatch-start
+/// and one at EOP / dispatch-end), tagged with FW-defined `record_type`
+/// values. HSA does NOT assign stable start-vs-end semantics to those
+/// tag values: the start/end mapping is FW-version-specific (e.g. on
+/// gfx950 the two values are reversed relative to the original 2026-03-30
+/// contract; see the kernel_dispatch_record tracepoint comment in
+/// lttng/rocm_hsa_tp.h). Host-side tooling correlates records by
+/// (queue_id, dispatch_idx) and either orders by gpu_ts or applies its
+/// own FW-version-specific record_type interpretation. Kernel identity
+/// is resolved host-side via the ROCr code-object symbol table, not
+/// embedded in the record.
 ///
 /// Design rationale (2026-03-30):
 ///   - Minimises firmware complexity and risk of GPU hangs.
@@ -45,7 +51,12 @@ namespace AMD {
 struct mec_dispatch_record {
   uint32_t ts_lo;        // GPU clock counter [31:0]
   uint32_t ts_hi;        // GPU clock counter [63:32]
-  uint32_t record_type;  // 1 = dispatch-start, 2 = EOP (dispatch-end)
+  uint32_t record_type;  // FW-defined event tag; HSA does not assign
+                         // stable start/end semantics. The start-vs-end
+                         // mapping is FW-version-specific (see struct
+                         // doc above and lttng/rocm_hsa_tp.h). Host
+                         // consumers join on (queue_id, dispatch_idx)
+                         // and order by gpu_ts.
   uint32_t reserved;     // Historical name; FW writes per-queue monotonic
                          // dispatch_idx here (see struct doc above).
 };

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/queue.h
@@ -45,6 +45,7 @@
 #ifndef HSA_RUNTME_CORE_INC_COMMAND_QUEUE_H_
 #define HSA_RUNTME_CORE_INC_COMMAND_QUEUE_H_
 
+#include <atomic>
 #include <sstream>
 
 #include "core/common/shared.h"
@@ -465,6 +466,21 @@ class Queue : public Checked<0xFA3906A679F9DB49> {
   // @brief Attributes specifically for counted queue types
   uint32_t use_count;
   bool is_counted_queue;
+
+  // ---------------------------------------------------------------------------
+  // dispatch_log scaffolding (Phase A, spec §4 / §8). Read by the
+  // ts_drainer/ts_poller threads in dispatch_log.cpp to know which queues
+  // currently have a firmware dispatch log set up. Written only by the
+  // dispatch_log subsystem (poller enable/disable pass + on_queue_create /
+  // on_queue_destroy hooks). Does NOT participate in queue ownership.
+  //
+  // dispatch_log_state is an opaque pointer reserved for future use as a
+  // direct handle to the per-queue refcount + drain-state book-keeping
+  // owned by dispatch_log.cpp. Phase A leaves this nullptr because the
+  // refcount and drain-state are looked up via side-maps keyed on
+  // core::Queue*; the field is added now to avoid an ABI change later.
+  std::atomic<bool> dispatch_log_active{false};
+  void* dispatch_log_state{nullptr};
 
   typedef void* rtti_t;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/queue.h
@@ -444,9 +444,14 @@ class Queue : public Checked<0xFA3906A679F9DB49> {
                           hsa_fence_scope_t releaseFence = HSA_FENCE_SCOPE_NONE,
                           hsa_signal_t* signal = NULL) = 0;
 
-  virtual void SetProfiling(bool enabled) {
+  // C3: Returns status so callers can detect KFD/libhsakmt failures
+  // during the profiling-buffer enable path (see AqlQueue override). The
+  // base implementation only flips the AQL queue properties bit, which
+  // cannot fail, so it always returns SUCCESS.
+  virtual hsa_status_t SetProfiling(bool enabled) {
     AMD_HSA_BITS_SET(amd_queue_.queue_properties, AMD_QUEUE_PROPERTIES_ENABLE_PROFILING,
                      (enabled != 0));
+    return HSA_STATUS_SUCCESS;
   }
 
   /// @ brief Returns queue queries about the queue

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
@@ -135,6 +135,8 @@ class ThunkLoader {
                                       void* QueueAddress, \
                                       HSAuint64 QueueSize, \
                                       HsaEvent* Event);
+    typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtSetQueueProfilingBuffer))(
+        HSA_QUEUEID QueueId, void* BufferBase, HSAuint32 NumRecords, volatile HSAuint32* WptrHostAddr);
     typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtDestroyQueue))(HSA_QUEUEID QueueId);
     typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtSetQueueCUMask))(HSA_QUEUEID QueueId, \
                                       HSAuint32 CUMaskCount, \
@@ -446,6 +448,7 @@ class ThunkLoader {
     HSAKMT_DEF(hsaKmtCreateQueueExt)* HSAKMT_PFN(hsaKmtCreateQueueExt);
     HSAKMT_DEF(hsaKmtCreateQueueV2)* HSAKMT_PFN(hsaKmtCreateQueueV2);
     HSAKMT_DEF(hsaKmtUpdateQueue)* HSAKMT_PFN(hsaKmtUpdateQueue);
+    HSAKMT_DEF(hsaKmtSetQueueProfilingBuffer)* HSAKMT_PFN(hsaKmtSetQueueProfilingBuffer);
     HSAKMT_DEF(hsaKmtDestroyQueue)* HSAKMT_PFN(hsaKmtDestroyQueue);
     HSAKMT_DEF(hsaKmtSetQueueCUMask)* HSAKMT_PFN(hsaKmtSetQueueCUMask);
     HSAKMT_DEF(hsaKmtSetMemoryPolicy)* HSAKMT_PFN(hsaKmtSetMemoryPolicy);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
@@ -137,6 +137,10 @@ class ThunkLoader {
                                       HsaEvent* Event);
     typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtSetQueueProfilingBuffer))(
         HSA_QUEUEID QueueId, void* BufferBase, HSAuint32 NumRecords, volatile HSAuint32* WptrHostAddr);
+    typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtSetDispatchLog))(
+        HSA_QUEUEID QueueId, HSAuint32 GpuId,
+        void* BufferBase, HSAuint32 NumRecords,
+        void* WptrAddr, void* RptrAddr, void* SignalAddr);
     typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtDestroyQueue))(HSA_QUEUEID QueueId);
     typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtSetQueueCUMask))(HSA_QUEUEID QueueId, \
                                       HSAuint32 CUMaskCount, \
@@ -449,6 +453,7 @@ class ThunkLoader {
     HSAKMT_DEF(hsaKmtCreateQueueV2)* HSAKMT_PFN(hsaKmtCreateQueueV2);
     HSAKMT_DEF(hsaKmtUpdateQueue)* HSAKMT_PFN(hsaKmtUpdateQueue);
     HSAKMT_DEF(hsaKmtSetQueueProfilingBuffer)* HSAKMT_PFN(hsaKmtSetQueueProfilingBuffer);
+    HSAKMT_DEF(hsaKmtSetDispatchLog)* HSAKMT_PFN(hsaKmtSetDispatchLog);
     HSAKMT_DEF(hsaKmtDestroyQueue)* HSAKMT_PFN(hsaKmtDestroyQueue);
     HSAKMT_DEF(hsaKmtSetQueueCUMask)* HSAKMT_PFN(hsaKmtSetQueueCUMask);
     HSAKMT_DEF(hsaKmtSetMemoryPolicy)* HSAKMT_PFN(hsaKmtSetMemoryPolicy);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -357,41 +357,43 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
 
 AqlQueue::~AqlQueue() {
   // Tear down the MEC dispatch-record ring buffer (if SetProfiling(true) was
-  // ever called and the buffer is still around). Done early in the destructor
-  // because we need a valid agent_ + driver() to clear the per-queue KFD
-  // registration before the queue itself is gone.
+  // ever called and the buffer is still around). This is split into two
+  // phases:
+  //
+  //   Phase 1 (here, before Inactivate): best-effort KFD CLEAR so the
+  //     kernel drops its BO refs and FW stops writing to the buffer's MQD
+  //     slot. Phase 1 does NOT free any host memory — even if CLEAR
+  //     succeeds, FW may have an in-flight write queued up; we let
+  //     Inactivate() destroy the queue first so FW can no longer touch
+  //     host memory.
+  //
+  //   Phase 2 (after Inactivate, below): free the dispatch-record buffer
+  //     and the Phase-2 host-VA counter words. By this point the KFD
+  //     queue is gone and FW cannot reach host memory under any
+  //     interleaving — including the case where Phase-1 CLEAR returned
+  //     an error and the MQD still references our buffer. This closes
+  //     the C6 use-after-free window where, on CLEAR failure, FW could
+  //     write to host memory we had already returned to the allocator.
+  //
+  // We need a valid agent_ + driver() in Phase 1 because the per-queue
+  // KFD registration must be cleared before queue_id_ is destroyed.
   if (agent_ != nullptr && dispatch_record_buffer_ != nullptr) {
-    // Phase-2: release the dispatch_log BO refs (buffer + wptr + rptr +
+    // Phase 1a: release the dispatch_log BO refs (buffer + wptr + rptr +
     // signal) that the new KFD_IOC_PROFILER_DISPATCH_LOG SET path took
-    // when SetProfiling(true) registered them. Without this, the kernel
-    // still holds 4 BO refs at queue-destroy time and the host-side
-    // system_deallocator() below trips a "Memory in use" critical
-    // error on the dispatch_record_buffer_ BO. Best-effort: missing
-    // thunk / older kernel returns NOT_SUPPORTED and we proceed with
-    // the legacy clear below.
+    // when SetProfiling(true) registered them. Best-effort: missing
+    // thunk / older kernel returns NOT_SUPPORTED. We deliberately
+    // ignore the return — Phase 2 (after Inactivate) is what makes
+    // the host memory safe to free, not this CLEAR.
     if (dispatch_log_wptr_buf_ != nullptr) {
       (void)agent_->driver().SetDispatchLog(
           queue_id_, static_cast<uint32_t>(agent_->KfdGpuID()),
           /*buffer_base=*/nullptr, /*num_records=*/0,
           /*wptr_addr=*/nullptr, /*rptr_addr=*/nullptr, /*signal_addr=*/nullptr);
     }
+    // Phase 1b: legacy clear path.
     agent_->driver().SetQueueProfilingBuffer(queue_id_, nullptr, 0, nullptr);
-    agent_->system_deallocator()(dispatch_record_buffer_);
-    dispatch_record_buffer_ = nullptr;
-    dispatch_record_buffer_size_ = 0;
-    // Free the Phase-2 host-VA counter words.
-    if (dispatch_log_wptr_buf_) {
-      agent_->system_deallocator()(dispatch_log_wptr_buf_);
-      dispatch_log_wptr_buf_ = nullptr;
-    }
-    if (dispatch_log_rptr_buf_) {
-      agent_->system_deallocator()(dispatch_log_rptr_buf_);
-      dispatch_log_rptr_buf_ = nullptr;
-    }
-    if (dispatch_log_signal_buf_) {
-      agent_->system_deallocator()(dispatch_log_signal_buf_);
-      dispatch_log_signal_buf_ = nullptr;
-    }
+    // NB: Phase 2 (the actual deallocations) runs AFTER Inactivate()
+    // below — see the matching block immediately after Inactivate().
   }
 
   // Remove this queue from the agent's AQL queue registry and clear the
@@ -426,6 +428,28 @@ AqlQueue::~AqlQueue() {
   }
 
   Inactivate();
+
+  // C6 Phase 2: NOW the KFD queue is destroyed and FW can no longer write
+  // to host memory under any interleaving. Free the dispatch-record
+  // buffer and the Phase-2 host-VA counter words. This is the matching
+  // half of the Phase-1 CLEAR block at the top of the destructor.
+  if (agent_ != nullptr && dispatch_record_buffer_ != nullptr) {
+    agent_->system_deallocator()(dispatch_record_buffer_);
+    dispatch_record_buffer_ = nullptr;
+    dispatch_record_buffer_size_ = 0;
+  }
+  if (agent_ != nullptr && dispatch_log_wptr_buf_ != nullptr) {
+    agent_->system_deallocator()(dispatch_log_wptr_buf_);
+    dispatch_log_wptr_buf_ = nullptr;
+  }
+  if (agent_ != nullptr && dispatch_log_rptr_buf_ != nullptr) {
+    agent_->system_deallocator()(dispatch_log_rptr_buf_);
+    dispatch_log_rptr_buf_ = nullptr;
+  }
+  if (agent_ != nullptr && dispatch_log_signal_buf_ != nullptr) {
+    agent_->system_deallocator()(dispatch_log_signal_buf_);
+    dispatch_log_signal_buf_ = nullptr;
+  }
 
   if (queue_scratch_.main_queue_base) {
     tool::notify_event_scratch_free_start(public_handle(),

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -1630,7 +1630,16 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
   }
 
   if (enabled && !dispatch_record_buffer_) {
-    constexpr uint32_t num_records = 65536;
+    // Ring size: 256K records (4 MiB at the FW 16-byte stride). Was 64K
+    // previously; bumped to 256K because empirical workloads can sustain
+    // up to ~1M FW writes/sec on a single queue (multi-XCC graph
+    // executors), and the host drainer + LTTng emit cannot maintain that
+    // rate under contention. With 64K slots the drainer had ~65 ms of
+    // headroom before FW would overrun (silently overwriting unread
+    // records). 256K slots gives ~256 ms headroom, comfortably absorbing
+    // host scheduling latencies and tracepoint emit cost. Power-of-2
+    // required for the wraparound mask in drain_one_queue.
+    constexpr uint32_t num_records = 262144;
     // FW writes 16-byte mec_dispatch_record entries at 16-byte stride
     // (see core/inc/mec_dispatch_record.h and the FW f32_mec.uc
     // SubAqlProfBufWriteRecord). The kernel's BO-size validation

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -1579,9 +1579,13 @@ hsa_status_t AqlQueue::GetCUMasking(uint32_t num_cu_mask_count, uint32_t* cu_mas
   return HSA_STATUS_SUCCESS;
 }
 
-void AqlQueue::SetProfiling(bool enabled) {
+hsa_status_t AqlQueue::SetProfiling(bool enabled) {
   std::lock_guard<std::mutex> lock(scratch_lock_);
 
+  // The base-class flip of AMD_QUEUE_PROPERTIES_ENABLE_PROFILING cannot
+  // fail. Apply unconditionally so the AQL queue properties bit always
+  // reflects the requested state, even if the dispatch-record buffer
+  // wiring fails below.
   Queue::SetProfiling(enabled);
   if (enabled) agent_->CheckClockTicks();
 
@@ -1598,16 +1602,36 @@ void AqlQueue::SetProfiling(bool enabled) {
     constexpr size_t kCacheLineAlign = 64;
     dispatch_record_buffer_ = agent_->system_allocator()(
         buf_size, kCacheLineAlign, core::MemoryRegion::AllocateNonPaged);
-    if (dispatch_record_buffer_ == nullptr) return;
+    if (dispatch_record_buffer_ == nullptr) {
+      // C3: report allocation failure to the caller so it can mark the
+      // queue/agent as no-dispatch-log.
+      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+    }
     memset(dispatch_record_buffer_, 0, buf_size);
     dispatch_record_buffer_size_ = num_records;
     dispatch_record_wptr_ = 0;
 
-    agent_->driver().SetQueueProfilingBuffer(
+    // C3: propagate libhsakmt registration failures. KfdDriver::
+    // SetQueueProfilingBuffer can return HSA_STATUS_ERROR_NOT_SUPPORTED
+    // (no thunk symbol) or wrap an HSAKMT failure. On failure unwind the
+    // partial state — free the buffer, reset cached fields — so the
+    // queue is left exactly as it was before the enable attempt.
+    hsa_status_t buf_status = agent_->driver().SetQueueProfilingBuffer(
         queue_id_, dispatch_record_buffer_, num_records, &dispatch_record_wptr_);
+    if (buf_status != HSA_STATUS_SUCCESS) {
+      agent_->system_deallocator()(dispatch_record_buffer_);
+      dispatch_record_buffer_ = nullptr;
+      dispatch_record_buffer_size_ = 0;
+      dispatch_record_wptr_ = 0;
+      return buf_status;
+    }
+    // Suspend/Resume is fatal-by-assert in current HSA code (see
+    // AqlQueue::Suspend/Resume); we cannot return a status from those
+    // and so do not attempt to unwind the libhsakmt registration if
+    // they were to fail. Documenting that here for future readers.
     Suspend();
     Resume();
-    return;
+    return HSA_STATUS_SUCCESS;
   }
 
   if (!enabled && dispatch_record_buffer_) {
@@ -1617,8 +1641,13 @@ void AqlQueue::SetProfiling(bool enabled) {
     // BEFORE we free the buffer. Otherwise FW may still hold the old
     // buffer address in MQD and continue writing into freed host memory.
     //
-    // 1. Clear KFD-side profiling-buffer registration.
-    agent_->driver().SetQueueProfilingBuffer(queue_id_, nullptr, 0, nullptr);
+    // 1. Clear KFD-side profiling-buffer registration. C3: capture status
+    //    so callers can observe a libhsakmt teardown failure, but we
+    //    still proceed with the host-side free — leaving the host
+    //    buffer alive after a teardown failure is strictly worse (the
+    //    buffer would leak with no path to reach it again).
+    hsa_status_t buf_status =
+        agent_->driver().SetQueueProfilingBuffer(queue_id_, nullptr, 0, nullptr);
     // 2. Flush MQD via UPDATE_QUEUE so FW observes addr=0.
     Suspend();
     Resume();
@@ -1627,7 +1656,10 @@ void AqlQueue::SetProfiling(bool enabled) {
     dispatch_record_buffer_ = nullptr;
     dispatch_record_buffer_size_ = 0;
     dispatch_record_wptr_ = 0;
+    return buf_status;
   }
+
+  return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t AqlQueue::GetProfilingDispatchRecords(void** buffer_base, uint32_t* buffer_size,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -1582,10 +1582,15 @@ hsa_status_t AqlQueue::GetCUMasking(uint32_t num_cu_mask_count, uint32_t* cu_mas
 hsa_status_t AqlQueue::SetProfiling(bool enabled) {
   std::lock_guard<std::mutex> lock(scratch_lock_);
 
-  // The base-class flip of AMD_QUEUE_PROPERTIES_ENABLE_PROFILING cannot
-  // fail. Apply unconditionally so the AQL queue properties bit always
-  // reflects the requested state, even if the dispatch-record buffer
-  // wiring fails below.
+  // Spec §4 step 2 (lines 548-564) REQUIRES the
+  // AMD_QUEUE_PROPERTIES_ENABLE_PROFILING bit be set BEFORE the KFD
+  // ioctl that publishes dispatch_log_base into the MQD; reversing the
+  // order would let an AQL packet processed in the gap between buffer-
+  // publish and bit-set produce a record with invalid timestamps. We
+  // therefore set the bit first on enable. C4: but on every failure
+  // path BELOW the bit flip we MUST roll it back via
+  // Queue::SetProfiling(false), so the spec §4a invariant ("bit set iff
+  // refcount > 0") is preserved on failed enables.
   Queue::SetProfiling(enabled);
   if (enabled) agent_->CheckClockTicks();
 
@@ -1605,6 +1610,10 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
     if (dispatch_record_buffer_ == nullptr) {
       // C3: report allocation failure to the caller so it can mark the
       // queue/agent as no-dispatch-log.
+      // C4: roll back the profiling-bit flip so we don't leave the queue
+      // in a "bit set but no buffer" state that QueueProfilingAcquire
+      // didn't refcount.
+      Queue::SetProfiling(false);
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
     }
     memset(dispatch_record_buffer_, 0, buf_size);
@@ -1614,8 +1623,9 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
     // C3: propagate libhsakmt registration failures. KfdDriver::
     // SetQueueProfilingBuffer can return HSA_STATUS_ERROR_NOT_SUPPORTED
     // (no thunk symbol) or wrap an HSAKMT failure. On failure unwind the
-    // partial state — free the buffer, reset cached fields — so the
-    // queue is left exactly as it was before the enable attempt.
+    // partial state — free the buffer, reset cached fields, AND (C4)
+    // roll back the profiling-bit flip — so the queue is left exactly
+    // as it was before the enable attempt.
     hsa_status_t buf_status = agent_->driver().SetQueueProfilingBuffer(
         queue_id_, dispatch_record_buffer_, num_records, &dispatch_record_wptr_);
     if (buf_status != HSA_STATUS_SUCCESS) {
@@ -1623,6 +1633,7 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
       dispatch_record_buffer_ = nullptr;
       dispatch_record_buffer_size_ = 0;
       dispatch_record_wptr_ = 0;
+      Queue::SetProfiling(false);  // C4: roll back bit
       return buf_status;
     }
     // Suspend/Resume is fatal-by-assert in current HSA code (see

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -1611,13 +1611,22 @@ void AqlQueue::SetProfiling(bool enabled) {
   }
 
   if (!enabled && dispatch_record_buffer_) {
+    // C1 fix: order matters. We MUST tell KFD to drop the buffer
+    // (libhsakmt SetQueueProfilingBuffer with addr=0) AND publish that to
+    // FW (Suspend/Resume runs the UPDATE_QUEUE ioctl that flushes the MQD)
+    // BEFORE we free the buffer. Otherwise FW may still hold the old
+    // buffer address in MQD and continue writing into freed host memory.
+    //
+    // 1. Clear KFD-side profiling-buffer registration.
     agent_->driver().SetQueueProfilingBuffer(queue_id_, nullptr, 0, nullptr);
+    // 2. Flush MQD via UPDATE_QUEUE so FW observes addr=0.
+    Suspend();
+    Resume();
+    // 3. NOW it is safe to free the host-side buffer.
     agent_->system_deallocator()(dispatch_record_buffer_);
     dispatch_record_buffer_ = nullptr;
     dispatch_record_buffer_size_ = 0;
     dispatch_record_wptr_ = 0;
-    Suspend();
-    Resume();
   }
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -1708,6 +1708,14 @@ hsa_status_t AqlQueue::GetProfilingDispatchRecords(void** buffer_base, uint32_t*
   // Report the FW-record-stride sized capacity (16 bytes per record), NOT the
   // host-kernel oversized allocation. The drainer iterates 16-byte records.
   *buffer_size = dispatch_record_buffer_size_ * static_cast<uint32_t>(sizeof(mec_dispatch_record));
+  // KNOWN GAP (see core/inc/dispatch_log.h banner + spec §10 dep #2
+  // sub-bullet): this returns a HOST-SIDE address that firmware does NOT
+  // update on the current substrate. The address is plumbed through
+  // KfdDriver::SetQueueProfilingBuffer -> hsaKmtSetQueueProfilingBuffer,
+  // but libhsakmt discards it and the KFD ABI
+  // (kfd_ioctl_update_queue_args) has no wptr_addr field to forward it on
+  // to firmware. Consumers must understand that *write_ptr will stay 0
+  // until a substrate extension publishes wptr to FW.
   *write_ptr = &dispatch_record_wptr_;
   return HSA_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -1582,17 +1582,26 @@ hsa_status_t AqlQueue::GetCUMasking(uint32_t num_cu_mask_count, uint32_t* cu_mas
 hsa_status_t AqlQueue::SetProfiling(bool enabled) {
   std::lock_guard<std::mutex> lock(scratch_lock_);
 
-  // Spec §4 step 2 (lines 548-564) REQUIRES the
-  // AMD_QUEUE_PROPERTIES_ENABLE_PROFILING bit be set BEFORE the KFD
-  // ioctl that publishes dispatch_log_base into the MQD; reversing the
-  // order would let an AQL packet processed in the gap between buffer-
-  // publish and bit-set produce a record with invalid timestamps. We
-  // therefore set the bit first on enable. C4: but on every failure
-  // path BELOW the bit flip we MUST roll it back via
-  // Queue::SetProfiling(false), so the spec §4a invariant ("bit set iff
-  // refcount > 0") is preserved on failed enables.
-  Queue::SetProfiling(enabled);
-  if (enabled) agent_->CheckClockTicks();
+  // Bit-flip ordering rules:
+  //   - ENABLE: bit MUST be set BEFORE the KFD ioctl that publishes
+  //     dispatch_log_base into the MQD (spec §4 step 2, lines 548-564).
+  //     Otherwise an AQL packet processed in the gap between buffer-
+  //     publish and bit-set would produce a record with invalid
+  //     timestamps. C4: on any enable failure below the bit flip we
+  //     MUST roll it back via Queue::SetProfiling(false) so spec §4a's
+  //     "bit set iff refcount > 0" invariant holds on failed enables.
+  //   - DISABLE: bit MUST be cleared AFTER KFD has been told to drop
+  //     the buffer and the MQD has been republished (spec §4
+  //     lines 401-402: "KFD DISABLE, then clear the profiling bit,
+  //     then free the buffer"). C6: clearing the bit while the MQD
+  //     still references the dispatch-record buffer would leave FW in
+  //     an undefined state for the gap.
+  // We therefore set the bit early on enable, but defer the bit clear
+  // on disable until after the buffer has been unpublished from KFD/MQD.
+  if (enabled) {
+    Queue::SetProfiling(true);
+    agent_->CheckClockTicks();
+  }
 
   if (enabled && !dispatch_record_buffer_) {
     constexpr uint32_t num_records = 65536;
@@ -1646,23 +1655,36 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
   }
 
   if (!enabled && dispatch_record_buffer_) {
-    // C1 fix: order matters. We MUST tell KFD to drop the buffer
-    // (libhsakmt SetQueueProfilingBuffer with addr=0) AND publish that to
-    // FW (Suspend/Resume runs the UPDATE_QUEUE ioctl that flushes the MQD)
+    // C1 + C6: order matters in BOTH directions on the disable path.
+    //
+    // C1: We MUST tell KFD to drop the buffer (libhsakmt
+    // SetQueueProfilingBuffer with addr=0) AND publish that to FW
+    // (Suspend/Resume runs the UPDATE_QUEUE ioctl that flushes the MQD)
     // BEFORE we free the buffer. Otherwise FW may still hold the old
     // buffer address in MQD and continue writing into freed host memory.
     //
-    // 1. Clear KFD-side profiling-buffer registration. C3: capture status
-    //    so callers can observe a libhsakmt teardown failure, but we
-    //    still proceed with the host-side free — leaving the host
-    //    buffer alive after a teardown failure is strictly worse (the
-    //    buffer would leak with no path to reach it again).
+    // C6: We MUST also keep the AMD_QUEUE_PROPERTIES_ENABLE_PROFILING
+    // bit SET while KFD/FW still has the dispatch-record buffer wired
+    // up. Per spec §4 (lines 401-402: "KFD DISABLE, then clear the
+    // profiling bit, then free the buffer"), the bit-clear must follow
+    // the MQD republish, otherwise the FW sees the old buffer address
+    // in MQD but the bit is already clear — undefined per the FW
+    // contract.
+    //
+    // 1. Clear KFD-side profiling-buffer registration. C3: capture
+    //    status so callers can observe a libhsakmt teardown failure,
+    //    but we still proceed with the host-side free — leaving the
+    //    host buffer alive after a teardown failure is strictly worse
+    //    (the buffer would leak with no path to reach it again).
     hsa_status_t buf_status =
         agent_->driver().SetQueueProfilingBuffer(queue_id_, nullptr, 0, nullptr);
     // 2. Flush MQD via UPDATE_QUEUE so FW observes addr=0.
     Suspend();
     Resume();
-    // 3. NOW it is safe to free the host-side buffer.
+    // 3. C6: NOW it is safe to clear the profiling bit — MQD no longer
+    //    references the buffer.
+    Queue::SetProfiling(false);
+    // 4. NOW it is safe to free the host-side buffer (C1).
     agent_->system_deallocator()(dispatch_record_buffer_);
     dispatch_record_buffer_ = nullptr;
     dispatch_record_buffer_size_ = 0;
@@ -1670,6 +1692,12 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
     return buf_status;
   }
 
+  // Idempotent disable with no buffer (or never enabled): just reflect
+  // the requested state on the bit. Safe because there is no MQD
+  // reference to the dispatch-record buffer to invalidate.
+  if (!enabled) {
+    Queue::SetProfiling(false);
+  }
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -361,10 +361,37 @@ AqlQueue::~AqlQueue() {
   // because we need a valid agent_ + driver() to clear the per-queue KFD
   // registration before the queue itself is gone.
   if (agent_ != nullptr && dispatch_record_buffer_ != nullptr) {
+    // Phase-2: release the dispatch_log BO refs (buffer + wptr + rptr +
+    // signal) that the new KFD_IOC_PROFILER_DISPATCH_LOG SET path took
+    // when SetProfiling(true) registered them. Without this, the kernel
+    // still holds 4 BO refs at queue-destroy time and the host-side
+    // system_deallocator() below trips a "Memory in use" critical
+    // error on the dispatch_record_buffer_ BO. Best-effort: missing
+    // thunk / older kernel returns NOT_SUPPORTED and we proceed with
+    // the legacy clear below.
+    if (dispatch_log_wptr_buf_ != nullptr) {
+      (void)agent_->driver().SetDispatchLog(
+          queue_id_, static_cast<uint32_t>(agent_->KfdGpuID()),
+          /*buffer_base=*/nullptr, /*num_records=*/0,
+          /*wptr_addr=*/nullptr, /*rptr_addr=*/nullptr, /*signal_addr=*/nullptr);
+    }
     agent_->driver().SetQueueProfilingBuffer(queue_id_, nullptr, 0, nullptr);
     agent_->system_deallocator()(dispatch_record_buffer_);
     dispatch_record_buffer_ = nullptr;
     dispatch_record_buffer_size_ = 0;
+    // Free the Phase-2 host-VA counter words.
+    if (dispatch_log_wptr_buf_) {
+      agent_->system_deallocator()(dispatch_log_wptr_buf_);
+      dispatch_log_wptr_buf_ = nullptr;
+    }
+    if (dispatch_log_rptr_buf_) {
+      agent_->system_deallocator()(dispatch_log_rptr_buf_);
+      dispatch_log_rptr_buf_ = nullptr;
+    }
+    if (dispatch_log_signal_buf_) {
+      agent_->system_deallocator()(dispatch_log_signal_buf_);
+      dispatch_log_signal_buf_ = nullptr;
+    }
   }
 
   // Remove this queue from the agent's AQL queue registry and clear the
@@ -1604,14 +1631,21 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
 
   if (enabled && !dispatch_record_buffer_) {
     constexpr uint32_t num_records = 65536;
-    // Host kernel computes BO size as `count * 40` (see
-    // kfd_process_queue_manager.c:638 in the gbt350 host kernel). The MEC
-    // firmware only writes 16 bytes per slot (mec_dispatch_record). We
-    // allocate the larger size so the kernel's BO size validation passes;
-    // the trailing 24 bytes per slot are unused by FW and never read by
-    // the drainer.
-    constexpr size_t kHostKernelRecordStride = 40;
-    const size_t buf_size = size_t(num_records) * kHostKernelRecordStride;
+    // FW writes 16-byte mec_dispatch_record entries at 16-byte stride
+    // (see core/inc/mec_dispatch_record.h and the FW f32_mec.uc
+    // SubAqlProfBufWriteRecord). The kernel's BO-size validation
+    // matches that stride exactly: kfd_process_queue_manager.c uses
+    // `dispatch_record_buffer_size * 16` for both the legacy
+    // SetQueueProfilingBuffer path and the new dispatch_log
+    // KFD_IOC_PROFILER_DISPATCH_LOG sub-op. The earlier `*40`
+    // allocation here was a workaround for an older pre-fix kernel
+    // (which over-counted the stride in its BO-size check); both that
+    // older kernel and the new validation accept `*16`, so we now
+    // allocate the FW-stride exact size and avoid wasting 60% of the
+    // BO. Matches kfd_queue_buffer_get's strict mapping->last
+    // equality check.
+    constexpr size_t kFwRecordStride = 16;
+    const size_t buf_size = size_t(num_records) * kFwRecordStride;
     constexpr size_t kCacheLineAlign = 64;
     dispatch_record_buffer_ = agent_->system_allocator()(
         buf_size, kCacheLineAlign, core::MemoryRegion::AllocateNonPaged);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -1660,6 +1660,72 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
     // they were to fail. Documenting that here for future readers.
     Suspend();
     Resume();
+
+    // Phase-2: try to additionally register the new host-VA pointer set
+    // (wptr/rptr/signal) via KFD_IOC_PROFILER_DISPATCH_LOG. This is the
+    // path the FW reads on queue connect to publish per-record producer
+    // counters back to host-coherent memory, eliminating the need for
+    // sentinel-scan duplicate-detection in the drainer.
+    //
+    // Falls back gracefully on older kernel/libhsakmt: if the new thunk
+    // is missing or the ioctl returns -EINVAL/ENOTTY, the buffer remains
+    // registered via the legacy SetQueueProfilingBuffer + UPDATE_QUEUE
+    // path (which does not deliver wptr/signal updates). Any of the
+    // three pointers being null in queue_properties tells the drainer to
+    // skip the wptr-bound scan for that pointer.
+    constexpr size_t kCacheLineSize = 64;
+    dispatch_log_wptr_buf_ = agent_->system_allocator()(
+        kCacheLineSize, kCacheLineSize, core::MemoryRegion::AllocateNonPaged);
+    dispatch_log_rptr_buf_ = agent_->system_allocator()(
+        kCacheLineSize, kCacheLineSize, core::MemoryRegion::AllocateNonPaged);
+    dispatch_log_signal_buf_ = agent_->system_allocator()(
+        kCacheLineSize, kCacheLineSize, core::MemoryRegion::AllocateNonPaged);
+
+    if (dispatch_log_wptr_buf_ && dispatch_log_rptr_buf_ && dispatch_log_signal_buf_) {
+      // Initialize all three counters to 0. FW writes post-increment values
+      // starting at 1; host reads with __atomic_load_n(__ATOMIC_ACQUIRE).
+      *(volatile uint64_t*)dispatch_log_wptr_buf_   = 0;
+      *(volatile uint64_t*)dispatch_log_rptr_buf_   = 0;
+      *(volatile uint64_t*)dispatch_log_signal_buf_ = 0;
+
+      hsa_status_t dl_status = agent_->driver().SetDispatchLog(
+          queue_id_, static_cast<uint32_t>(agent_->KfdGpuID()),
+          dispatch_record_buffer_, num_records,
+          dispatch_log_wptr_buf_, dispatch_log_rptr_buf_, dispatch_log_signal_buf_);
+      if (dl_status != HSA_STATUS_SUCCESS) {
+        // New path unavailable / refused. Drop the host words; legacy
+        // sentinel-scan path remains active via the buffer registration
+        // we already did above. Drainer detects null host-VA pointers
+        // and falls back automatically.
+        agent_->system_deallocator()(dispatch_log_wptr_buf_);
+        agent_->system_deallocator()(dispatch_log_rptr_buf_);
+        agent_->system_deallocator()(dispatch_log_signal_buf_);
+        dispatch_log_wptr_buf_ = nullptr;
+        dispatch_log_rptr_buf_ = nullptr;
+        dispatch_log_signal_buf_ = nullptr;
+      }
+      // Else: SetDispatchLog succeeded — the kernel updated
+      // queue_properties and re-ran update_mqd, so the new MQD slots
+      // (DW48-DW53) now hold our host VAs and FW will write to them on
+      // subsequent record emissions. No second Suspend/Resume needed; KFD
+      // did the update_queue internally.
+    } else {
+      // Allocation of one or more host words failed. Free any that did
+      // succeed and continue without the new path.
+      if (dispatch_log_wptr_buf_) {
+        agent_->system_deallocator()(dispatch_log_wptr_buf_);
+        dispatch_log_wptr_buf_ = nullptr;
+      }
+      if (dispatch_log_rptr_buf_) {
+        agent_->system_deallocator()(dispatch_log_rptr_buf_);
+        dispatch_log_rptr_buf_ = nullptr;
+      }
+      if (dispatch_log_signal_buf_) {
+        agent_->system_deallocator()(dispatch_log_signal_buf_);
+        dispatch_log_signal_buf_ = nullptr;
+      }
+    }
+
     return HSA_STATUS_SUCCESS;
   }
 
@@ -1687,6 +1753,20 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
     //    (the buffer would leak with no path to reach it again).
     hsa_status_t buf_status =
         agent_->driver().SetQueueProfilingBuffer(queue_id_, nullptr, 0, nullptr);
+
+    // Phase-2: also CLEAR the new sub-op if we registered host-VA pointers
+    // on the enable side. This drops all 4 BO refs (buffer + 3 pointers)
+    // kernel-side and zeros the new MQD slots (DW48-DW53) on the same
+    // update_queue pass that follows. SetDispatchLog with buffer_addr=NULL
+    // issues KFD_DISPATCH_LOG_OP_CLEAR. Status is best-effort: if the new
+    // thunk is missing or fails, we still tear down the legacy path below.
+    if (dispatch_log_wptr_buf_ != nullptr) {
+      (void)agent_->driver().SetDispatchLog(
+          queue_id_, static_cast<uint32_t>(agent_->KfdGpuID()),
+          /*buffer_base=*/nullptr, /*num_records=*/0,
+          /*wptr_addr=*/nullptr, /*rptr_addr=*/nullptr, /*signal_addr=*/nullptr);
+    }
+
     // 2. Flush MQD via UPDATE_QUEUE so FW observes addr=0.
     Suspend();
     Resume();
@@ -1697,6 +1777,20 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
     agent_->system_deallocator()(dispatch_record_buffer_);
     dispatch_record_buffer_ = nullptr;
     dispatch_record_buffer_size_ = 0;
+    // 5. Free the Phase-2 host-VA counter words (idempotent — null in the
+    //    legacy-only path).
+    if (dispatch_log_wptr_buf_) {
+      agent_->system_deallocator()(dispatch_log_wptr_buf_);
+      dispatch_log_wptr_buf_ = nullptr;
+    }
+    if (dispatch_log_rptr_buf_) {
+      agent_->system_deallocator()(dispatch_log_rptr_buf_);
+      dispatch_log_rptr_buf_ = nullptr;
+    }
+    if (dispatch_log_signal_buf_) {
+      agent_->system_deallocator()(dispatch_log_signal_buf_);
+      dispatch_log_signal_buf_ = nullptr;
+    }
     return buf_status;
   }
 
@@ -1718,6 +1812,26 @@ hsa_status_t AqlQueue::GetProfilingDispatchRecords(void** buffer_base,
   // and uses sentinel scan over per-slot record_type to locate fresh records
   // (see core/runtime/dispatch_log.cpp::drain_one_queue).
   *buffer_size = dispatch_record_buffer_size_ * static_cast<uint32_t>(sizeof(mec_dispatch_record));
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t AqlQueue::GetDispatchLogPointers(volatile uint64_t** wptr_ptr,
+                                              volatile uint64_t** rptr_ptr,
+                                              volatile uint64_t** signal_ptr) const {
+  // Phase-2 host-VA pointer set is populated only when:
+  //   1. SetProfiling(true) was called AND
+  //   2. The new KFD_IOC_PROFILER_DISPATCH_LOG sub-op succeeded
+  //      (kernel KFD MINOR >= 20 + libhsakmt has the new thunk).
+  // If either is false we report NOT_INITIALIZED and the drainer falls
+  // back to sentinel-scan via GetProfilingDispatchRecords.
+  if (dispatch_log_wptr_buf_ == nullptr ||
+      dispatch_log_rptr_buf_ == nullptr ||
+      dispatch_log_signal_buf_ == nullptr) {
+    return HSA_STATUS_ERROR_NOT_INITIALIZED;
+  }
+  *wptr_ptr   = static_cast<volatile uint64_t*>(dispatch_log_wptr_buf_);
+  *rptr_ptr   = static_cast<volatile uint64_t*>(dispatch_log_rptr_buf_);
+  *signal_ptr = static_cast<volatile uint64_t*>(dispatch_log_signal_buf_);
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -547,8 +547,19 @@ void AqlQueue::StoreRelaxed(hsa_signal_value_t value) {
         amd_queue_.hsa_queue.size - 1, /* size is power-of-2 */
         (int64_t)value);
   }
+  // Code-quality C1: use amd_queue_.hsa_queue.id (the HSA process-unique
+  // queue id) as the on-the-wire join key, NOT queue_id_ (the KFD-side
+  // opaque QueueId). The doorbell tracepoint MUST share a queue-id
+  // namespace with the consumers it joins against:
+  //   - rocm_hsa:hsa_intercept_packets emits amd_queue_.hsa_queue.id
+  //     (intercept_queue.cpp::SubmitPackets)
+  //   - rocm_hsa:kernel_dispatch_record emits amd_queue_.hsa_queue.id
+  //     via queue_id_of() (dispatch_log.cpp; see queue_id_of() helper)
+  // queue_id_ is the KFD-driver-side identifier (queue_rsrc.QueueId,
+  // assigned by KfdDriver::CreateQueue), useful only for KFD ioctls.
+  // Mixing namespaces silently breaks every consumer-side join.
   rocm_trace_emit_hsa_doorbell_ring(
-      (uint32_t)queue_id_, (int64_t)value, pkt_type);
+      (uint32_t)amd_queue_.hsa_queue.id, (int64_t)value, pkt_type);
 
   if (core::Runtime::runtime_singleton_->thunkLoader()->IsDTIF() ||
         core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -41,6 +41,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "core/inc/amd_aql_queue.h"
+#include "core/inc/mec_dispatch_record.h"
 
 #ifdef __linux__
 #include <fcntl.h>
@@ -355,6 +356,28 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
 }
 
 AqlQueue::~AqlQueue() {
+  // Tear down the MEC dispatch-record ring buffer (if SetProfiling(true) was
+  // ever called and the buffer is still around). Done early in the destructor
+  // because we need a valid agent_ + driver() to clear the per-queue KFD
+  // registration before the queue itself is gone.
+  if (agent_ != nullptr && dispatch_record_buffer_ != nullptr) {
+    agent_->driver().SetQueueProfilingBuffer(queue_id_, nullptr, 0, nullptr);
+    agent_->system_deallocator()(dispatch_record_buffer_);
+    dispatch_record_buffer_ = nullptr;
+    dispatch_record_buffer_size_ = 0;
+    dispatch_record_wptr_ = 0;
+  }
+
+  // Remove this queue from the agent's AQL queue registry and clear the
+  // trap-handler doorbell mapping that points at this queue. These were
+  // installed in GpuAgent::QueueCreate; mirror the teardown here so the
+  // agent's iteration paths (AsyncReclaim*, hsa_amd_queue_iterate, ...) do
+  // not see a freed queue. Safe to call unconditionally.
+  if (agent_ != nullptr) {
+    agent_->ClearTrapDoorbellMapping(uintptr_t(signal_.hardware_doorbell_ptr), &amd_queue_);
+    agent_->RemoveAqlQueue(this);
+  }
+
   // Remove error handler synchronously.
   // Sequences error handler callbacks with queue destroy.
   dynamicScratchState |= ERROR_HANDLER_TERMINATE;
@@ -1557,10 +1580,56 @@ hsa_status_t AqlQueue::GetCUMasking(uint32_t num_cu_mask_count, uint32_t* cu_mas
 }
 
 void AqlQueue::SetProfiling(bool enabled) {
-  Queue::SetProfiling(enabled);
+  std::lock_guard<std::mutex> lock(scratch_lock_);
 
+  Queue::SetProfiling(enabled);
   if (enabled) agent_->CheckClockTicks();
-  return;
+
+  if (enabled && !dispatch_record_buffer_) {
+    constexpr uint32_t num_records = 65536;
+    // Host kernel computes BO size as `count * 40` (see
+    // kfd_process_queue_manager.c:638 in the gbt350 host kernel). The MEC
+    // firmware only writes 16 bytes per slot (mec_dispatch_record). We
+    // allocate the larger size so the kernel's BO size validation passes;
+    // the trailing 24 bytes per slot are unused by FW and never read by
+    // the drainer.
+    constexpr size_t kHostKernelRecordStride = 40;
+    const size_t buf_size = size_t(num_records) * kHostKernelRecordStride;
+    constexpr size_t kCacheLineAlign = 64;
+    dispatch_record_buffer_ = agent_->system_allocator()(
+        buf_size, kCacheLineAlign, core::MemoryRegion::AllocateNonPaged);
+    if (dispatch_record_buffer_ == nullptr) return;
+    memset(dispatch_record_buffer_, 0, buf_size);
+    dispatch_record_buffer_size_ = num_records;
+    dispatch_record_wptr_ = 0;
+
+    agent_->driver().SetQueueProfilingBuffer(
+        queue_id_, dispatch_record_buffer_, num_records, &dispatch_record_wptr_);
+    Suspend();
+    Resume();
+    return;
+  }
+
+  if (!enabled && dispatch_record_buffer_) {
+    agent_->driver().SetQueueProfilingBuffer(queue_id_, nullptr, 0, nullptr);
+    agent_->system_deallocator()(dispatch_record_buffer_);
+    dispatch_record_buffer_ = nullptr;
+    dispatch_record_buffer_size_ = 0;
+    dispatch_record_wptr_ = 0;
+    Suspend();
+    Resume();
+  }
+}
+
+hsa_status_t AqlQueue::GetProfilingDispatchRecords(void** buffer_base, uint32_t* buffer_size,
+                                                   volatile uint32_t** write_ptr) const {
+  if (!dispatch_record_buffer_) return HSA_STATUS_ERROR_NOT_INITIALIZED;
+  *buffer_base = dispatch_record_buffer_;
+  // Report the FW-record-stride sized capacity (16 bytes per record), NOT the
+  // host-kernel oversized allocation. The drainer iterates 16-byte records.
+  *buffer_size = dispatch_record_buffer_size_ * static_cast<uint32_t>(sizeof(mec_dispatch_record));
+  *write_ptr = &dispatch_record_wptr_;
+  return HSA_STATUS_SUCCESS;
 }
 
 // If in_signal is NULL then this ExecutePM4 will block and wait for PM4 commands to complete

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -1800,25 +1800,54 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
     // in MQD but the bit is already clear — undefined per the FW
     // contract.
     //
-    // 1. Clear KFD-side profiling-buffer registration. C3: capture
-    //    status so callers can observe a libhsakmt teardown failure,
-    //    but we still proceed with the host-side free — leaving the
-    //    host buffer alive after a teardown failure is strictly worse
-    //    (the buffer would leak with no path to reach it again).
-    hsa_status_t buf_status =
+    // 1. Clear KFD-side profiling-buffer registration. Capture status
+    //    of BOTH the legacy and the new sub-op clear: if EITHER returns
+    //    a failure status, we cannot prove the kernel committed the
+    //    addr=0 update to the per-queue MQD, which means FW may still
+    //    hold our buffer pointer in its MQD copy. In that case freeing
+    //    the host buffer is unsafe — FW could subsequently write into
+    //    freed host memory (use-after-free with GPU as the writer).
+    //    Code-quality C4: leak the buffer rather than risk that.
+    hsa_status_t leg_status =
         agent_->driver().SetQueueProfilingBuffer(queue_id_, nullptr, 0, nullptr);
 
     // Phase-2: also CLEAR the new sub-op if we registered host-VA pointers
     // on the enable side. This drops all 4 BO refs (buffer + 3 pointers)
     // kernel-side and zeros the new MQD slots (DW48-DW53) on the same
     // update_queue pass that follows. SetDispatchLog with buffer_addr=NULL
-    // issues KFD_DISPATCH_LOG_OP_CLEAR. Status is best-effort: if the new
-    // thunk is missing or fails, we still tear down the legacy path below.
+    // issues KFD_DISPATCH_LOG_OP_CLEAR. Code-quality C4: capture the
+    // status; failure here is treated as just as fatal as the legacy
+    // clear failure above — both paths can leave a stale MQD entry that
+    // FW continues to write into.
+    hsa_status_t dl_status = HSA_STATUS_SUCCESS;
     if (dispatch_log_wptr_buf_ != nullptr) {
-      (void)agent_->driver().SetDispatchLog(
+      dl_status = agent_->driver().SetDispatchLog(
           queue_id_, static_cast<uint32_t>(agent_->KfdGpuID()),
           /*buffer_base=*/nullptr, /*num_records=*/0,
           /*wptr_addr=*/nullptr, /*rptr_addr=*/nullptr, /*signal_addr=*/nullptr);
+    }
+
+    // Code-quality C4: if either KFD clear failed, do NOT free the host
+    // buffer or the host-VA counter words; the safest action is to
+    // quarantine the allocations until process exit (they will be
+    // released by the AqlQueue destructor's deallocate-if-non-null
+    // logic, which itself runs only after KFD has destroyed the queue
+    // — at which point FW can no longer write to the BO). Leaving
+    // dispatch_record_buffer_ non-null also prevents a subsequent
+    // re-enable from double-allocating, and forces any retry through
+    // the existing "buffer already wired" no-op path at line 1643.
+    if (leg_status != HSA_STATUS_SUCCESS || dl_status != HSA_STATUS_SUCCESS) {
+      std::fprintf(stderr,
+                   "[hsa-runtime] dispatch_log: KFD clear failed on disable "
+                   "(legacy=%d, dispatch_log=%d); leaking host buffer to avoid "
+                   "FW use-after-free until queue destroy\n",
+                   static_cast<int>(leg_status), static_cast<int>(dl_status));
+      // Do NOT clear the profiling bit either — the FW contract requires
+      // the bit stay set while MQD still references the buffer (C6).
+      // Returning the most informative status: legacy failure preempts
+      // dispatch_log failure since the legacy path is the one that
+      // unconditionally controls FW visibility of the buffer.
+      return (leg_status != HSA_STATUS_SUCCESS) ? leg_status : dl_status;
     }
 
     // 2. Flush MQD via UPDATE_QUEUE so FW observes addr=0.
@@ -1845,7 +1874,7 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
       agent_->system_deallocator()(dispatch_log_signal_buf_);
       dispatch_log_signal_buf_ = nullptr;
     }
-    return buf_status;
+    return HSA_STATUS_SUCCESS;
   }
 
   // Idempotent disable with no buffer (or never enabled): just reflect

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -1664,6 +1664,18 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
     agent_->CheckClockTicks();
   }
 
+  // Code-quality C3 (round 2): track whether this enable call is taking
+  // the fresh-allocation path or the no-op "buffer already wired" path.
+  // The dispatch_log drainer needs to distinguish these to avoid silently
+  // dropping records produced on a fresh queue between SetProfiling
+  // success and the drainer's signal-snapshot read. We set the flag
+  // BEFORE the allocation gate so the no-op case is recorded even though
+  // we early-exit below; the success path inside the allocation block
+  // overwrites it with true.
+  if (enabled) {
+    dispatch_log_freshly_allocated_ = (dispatch_record_buffer_ == nullptr);
+  }
+
   if (enabled && !dispatch_record_buffer_) {
     // Ring size: 256K records (4 MiB at the FW 16-byte stride). Was 64K
     // previously; bumped to 256K because empirical workloads can sustain
@@ -1924,7 +1936,8 @@ hsa_status_t AqlQueue::GetProfilingDispatchRecords(void** buffer_base,
 
 hsa_status_t AqlQueue::GetDispatchLogPointers(volatile uint64_t** wptr_ptr,
                                               volatile uint64_t** rptr_ptr,
-                                              volatile uint64_t** signal_ptr) const {
+                                              volatile uint64_t** signal_ptr,
+                                              bool* fresh_allocation) const {
   // Phase-2 host-VA pointer set is populated only when:
   //   1. SetProfiling(true) was called AND
   //   2. The new KFD_IOC_PROFILER_DISPATCH_LOG sub-op succeeded
@@ -1939,6 +1952,14 @@ hsa_status_t AqlQueue::GetDispatchLogPointers(volatile uint64_t** wptr_ptr,
   *wptr_ptr   = static_cast<volatile uint64_t*>(dispatch_log_wptr_buf_);
   *rptr_ptr   = static_cast<volatile uint64_t*>(dispatch_log_rptr_buf_);
   *signal_ptr = static_cast<volatile uint64_t*>(dispatch_log_signal_buf_);
+  // Code-quality C3 (round 2): expose whether the most recent
+  // SetProfiling(true) actually allocated and zeroed the buffer set, or
+  // hit the no-op "buffer already wired" path (re-enable after a failed
+  // disable). The drainer uses this to choose between next_idx=0 (fresh)
+  // and next_idx=snapshot(*signal_ptr) (re-enable).
+  if (fresh_allocation != nullptr) {
+    *fresh_allocation = dispatch_log_freshly_allocated_;
+  }
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -365,7 +365,6 @@ AqlQueue::~AqlQueue() {
     agent_->system_deallocator()(dispatch_record_buffer_);
     dispatch_record_buffer_ = nullptr;
     dispatch_record_buffer_size_ = 0;
-    dispatch_record_wptr_ = 0;
   }
 
   // Remove this queue from the agent's AQL queue registry and clear the
@@ -1625,9 +1624,14 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
       Queue::SetProfiling(false);
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
     }
+    // The host kernel does NOT zero the dispatch-record BO (see
+    // amd/amdkfd/kfd_process_queue_manager.c — it only validates the
+    // user-supplied size and pins the BO). The drainer relies on
+    // record_type == 0 as the per-slot "empty" sentinel
+    // (core/runtime/dispatch_log.cpp::drain_one_queue), so we must
+    // explicitly zero the entire allocation here before exposing it to FW.
     memset(dispatch_record_buffer_, 0, buf_size);
     dispatch_record_buffer_size_ = num_records;
-    dispatch_record_wptr_ = 0;
 
     // C3: propagate libhsakmt registration failures. KfdDriver::
     // SetQueueProfilingBuffer can return HSA_STATUS_ERROR_NOT_SUPPORTED
@@ -1635,13 +1639,18 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
     // partial state — free the buffer, reset cached fields, AND (C4)
     // roll back the profiling-bit flip — so the queue is left exactly
     // as it was before the enable attempt.
+    //
+    // The trailing nullptr argument is the libhsakmt WptrHostAddr param.
+    // It is intentionally unused — the substrate has no path to forward
+    // it to FW (see libhsakmt/src/queues.c::hsaKmtSetQueueProfilingBuffer
+    // and core/runtime/dispatch_log.cpp::drain_one_queue for the
+    // sentinel-scan design that replaces it).
     hsa_status_t buf_status = agent_->driver().SetQueueProfilingBuffer(
-        queue_id_, dispatch_record_buffer_, num_records, &dispatch_record_wptr_);
+        queue_id_, dispatch_record_buffer_, num_records, nullptr);
     if (buf_status != HSA_STATUS_SUCCESS) {
       agent_->system_deallocator()(dispatch_record_buffer_);
       dispatch_record_buffer_ = nullptr;
       dispatch_record_buffer_size_ = 0;
-      dispatch_record_wptr_ = 0;
       Queue::SetProfiling(false);  // C4: roll back bit
       return buf_status;
     }
@@ -1688,7 +1697,6 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
     agent_->system_deallocator()(dispatch_record_buffer_);
     dispatch_record_buffer_ = nullptr;
     dispatch_record_buffer_size_ = 0;
-    dispatch_record_wptr_ = 0;
     return buf_status;
   }
 
@@ -1701,22 +1709,15 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t AqlQueue::GetProfilingDispatchRecords(void** buffer_base, uint32_t* buffer_size,
-                                                   volatile uint32_t** write_ptr) const {
+hsa_status_t AqlQueue::GetProfilingDispatchRecords(void** buffer_base,
+                                                   uint32_t* buffer_size) const {
   if (!dispatch_record_buffer_) return HSA_STATUS_ERROR_NOT_INITIALIZED;
   *buffer_base = dispatch_record_buffer_;
   // Report the FW-record-stride sized capacity (16 bytes per record), NOT the
-  // host-kernel oversized allocation. The drainer iterates 16-byte records.
+  // host-kernel oversized allocation. The drainer iterates 16-byte records
+  // and uses sentinel scan over per-slot record_type to locate fresh records
+  // (see core/runtime/dispatch_log.cpp::drain_one_queue).
   *buffer_size = dispatch_record_buffer_size_ * static_cast<uint32_t>(sizeof(mec_dispatch_record));
-  // KNOWN GAP (see core/inc/dispatch_log.h banner + spec §10 dep #2
-  // sub-bullet): this returns a HOST-SIDE address that firmware does NOT
-  // update on the current substrate. The address is plumbed through
-  // KfdDriver::SetQueueProfilingBuffer -> hsaKmtSetQueueProfilingBuffer,
-  // but libhsakmt discards it and the KFD ABI
-  // (kfd_ioctl_update_queue_args) has no wptr_addr field to forward it on
-  // to firmware. Consumers must understand that *write_ptr will stay 0
-  // until a substrate extension publishes wptr to FW.
-  *write_ptr = &dispatch_record_wptr_;
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -1730,11 +1730,8 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
     // roll back the profiling-bit flip — so the queue is left exactly
     // as it was before the enable attempt.
     //
-    // The trailing nullptr argument is the libhsakmt WptrHostAddr param.
-    // It is intentionally unused — the substrate has no path to forward
-    // it to FW (see libhsakmt/src/queues.c::hsaKmtSetQueueProfilingBuffer
-    // and core/runtime/dispatch_log.cpp::drain_one_queue for the
-    // sentinel-scan design that replaces it).
+    // The trailing nullptr argument is the libhsakmt WptrHostAddr param;
+    // host-visible producer state is registered separately via SetDispatchLog.
     hsa_status_t buf_status = agent_->driver().SetQueueProfilingBuffer(
         queue_id_, dispatch_record_buffer_, num_records, nullptr);
     if (buf_status != HSA_STATUS_SUCCESS) {
@@ -1751,18 +1748,9 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
     Suspend();
     Resume();
 
-    // Phase-2: try to additionally register the new host-VA pointer set
-    // (wptr/rptr/signal) via KFD_IOC_PROFILER_DISPATCH_LOG. This is the
-    // path the FW reads on queue connect to publish per-record producer
-    // counters back to host-coherent memory, eliminating the need for
-    // sentinel-scan duplicate-detection in the drainer.
-    //
-    // Falls back gracefully on older kernel/libhsakmt: if the new thunk
-    // is missing or the ioctl returns -EINVAL/ENOTTY, the buffer remains
-    // registered via the legacy SetQueueProfilingBuffer + UPDATE_QUEUE
-    // path (which does not deliver wptr/signal updates). Any of the
-    // three pointers being null in queue_properties tells the drainer to
-    // skip the wptr-bound scan for that pointer.
+    // Phase-2: register host-VA wptr/rptr/signal via KFD_IOC_PROFILER_DISPATCH_LOG.
+    // Required for dispatch record draining (signal-bound); there is no
+    // sentinel-scan fallback.
     constexpr size_t kCacheLineSize = 64;
     dispatch_log_wptr_buf_ = agent_->system_allocator()(
         kCacheLineSize, kCacheLineSize, core::MemoryRegion::AllocateNonPaged);
@@ -1771,37 +1759,7 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
     dispatch_log_signal_buf_ = agent_->system_allocator()(
         kCacheLineSize, kCacheLineSize, core::MemoryRegion::AllocateNonPaged);
 
-    if (dispatch_log_wptr_buf_ && dispatch_log_rptr_buf_ && dispatch_log_signal_buf_) {
-      // Initialize all three counters to 0. FW writes post-increment values
-      // starting at 1; host reads with __atomic_load_n(__ATOMIC_ACQUIRE).
-      *(volatile uint64_t*)dispatch_log_wptr_buf_   = 0;
-      *(volatile uint64_t*)dispatch_log_rptr_buf_   = 0;
-      *(volatile uint64_t*)dispatch_log_signal_buf_ = 0;
-
-      hsa_status_t dl_status = agent_->driver().SetDispatchLog(
-          queue_id_, static_cast<uint32_t>(agent_->KfdGpuID()),
-          dispatch_record_buffer_, num_records,
-          dispatch_log_wptr_buf_, dispatch_log_rptr_buf_, dispatch_log_signal_buf_);
-      if (dl_status != HSA_STATUS_SUCCESS) {
-        // New path unavailable / refused. Drop the host words; legacy
-        // sentinel-scan path remains active via the buffer registration
-        // we already did above. Drainer detects null host-VA pointers
-        // and falls back automatically.
-        agent_->system_deallocator()(dispatch_log_wptr_buf_);
-        agent_->system_deallocator()(dispatch_log_rptr_buf_);
-        agent_->system_deallocator()(dispatch_log_signal_buf_);
-        dispatch_log_wptr_buf_ = nullptr;
-        dispatch_log_rptr_buf_ = nullptr;
-        dispatch_log_signal_buf_ = nullptr;
-      }
-      // Else: SetDispatchLog succeeded — the kernel updated
-      // queue_properties and re-ran update_mqd, so the new MQD slots
-      // (DW48-DW53) now hold our host VAs and FW will write to them on
-      // subsequent record emissions. No second Suspend/Resume needed; KFD
-      // did the update_queue internally.
-    } else {
-      // Allocation of one or more host words failed. Free any that did
-      // succeed and continue without the new path.
+    auto unwind_profiling_buffer_enable = [&]() {
       if (dispatch_log_wptr_buf_) {
         agent_->system_deallocator()(dispatch_log_wptr_buf_);
         dispatch_log_wptr_buf_ = nullptr;
@@ -1814,6 +1772,31 @@ hsa_status_t AqlQueue::SetProfiling(bool enabled) {
         agent_->system_deallocator()(dispatch_log_signal_buf_);
         dispatch_log_signal_buf_ = nullptr;
       }
+      agent_->system_deallocator()(dispatch_record_buffer_);
+      dispatch_record_buffer_ = nullptr;
+      dispatch_record_buffer_size_ = 0;
+      (void)agent_->driver().SetQueueProfilingBuffer(queue_id_, nullptr, 0, nullptr);
+      Suspend();
+      Resume();
+      Queue::SetProfiling(false);
+    };
+
+    if (!dispatch_log_wptr_buf_ || !dispatch_log_rptr_buf_ || !dispatch_log_signal_buf_) {
+      unwind_profiling_buffer_enable();
+      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+    }
+
+    *(volatile uint64_t*)dispatch_log_wptr_buf_   = 0;
+    *(volatile uint64_t*)dispatch_log_rptr_buf_   = 0;
+    *(volatile uint64_t*)dispatch_log_signal_buf_ = 0;
+
+    hsa_status_t dl_status = agent_->driver().SetDispatchLog(
+        queue_id_, static_cast<uint32_t>(agent_->KfdGpuID()),
+        dispatch_record_buffer_, num_records,
+        dispatch_log_wptr_buf_, dispatch_log_rptr_buf_, dispatch_log_signal_buf_);
+    if (dl_status != HSA_STATUS_SUCCESS) {
+      unwind_profiling_buffer_enable();
+      return dl_status;
     }
 
     return HSA_STATUS_SUCCESS;
@@ -1927,9 +1910,8 @@ hsa_status_t AqlQueue::GetProfilingDispatchRecords(void** buffer_base,
   if (!dispatch_record_buffer_) return HSA_STATUS_ERROR_NOT_INITIALIZED;
   *buffer_base = dispatch_record_buffer_;
   // Report the FW-record-stride sized capacity (16 bytes per record), NOT the
-  // host-kernel oversized allocation. The drainer iterates 16-byte records
-  // and uses sentinel scan over per-slot record_type to locate fresh records
-  // (see core/runtime/dispatch_log.cpp::drain_one_queue).
+  // host-kernel oversized allocation. The drainer uses GetDispatchLogPointers
+  // (signal-bound) plus this ring view (core/runtime/dispatch_log.cpp).
   *buffer_size = dispatch_record_buffer_size_ * static_cast<uint32_t>(sizeof(mec_dispatch_record));
   return HSA_STATUS_SUCCESS;
 }
@@ -1942,8 +1924,7 @@ hsa_status_t AqlQueue::GetDispatchLogPointers(volatile uint64_t** wptr_ptr,
   //   1. SetProfiling(true) was called AND
   //   2. The new KFD_IOC_PROFILER_DISPATCH_LOG sub-op succeeded
   //      (kernel KFD MINOR >= 20 + libhsakmt has the new thunk).
-  // If either is false we report NOT_INITIALIZED and the drainer falls
-  // back to sentinel-scan via GetProfilingDispatchRecords.
+  // If either is false we report NOT_INITIALIZED.
   if (dispatch_log_wptr_buf_ == nullptr ||
       dispatch_log_rptr_buf_ == nullptr ||
       dispatch_log_signal_buf_ == nullptr) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
@@ -839,8 +839,10 @@ hsa_status_t BlitKernel::SubmitLinearFillCommand(void* ptr, uint32_t value,
 }
 
 hsa_status_t BlitKernel::EnableProfiling(bool enable) {
-  queue_->SetProfiling(enable);
-  return HSA_STATUS_SUCCESS;
+  // C3: SetProfiling now returns hsa_status_t. Propagate so a caller
+  // that fails to wire up the dispatch-record buffer (e.g. libhsakmt
+  // SetQueueProfilingBuffer NOT_SUPPORTED) sees the failure.
+  return queue_->SetProfiling(enable);
 }
 
 uint64_t BlitKernel::AcquireWriteIndex(uint32_t num_packet) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -64,6 +64,7 @@
 #include "core/inc/interrupt_signal.h"
 #include "core/inc/isa.h"
 #include "core/inc/runtime.h"
+#include "core/inc/dispatch_log.h"
 #include "core/util/os.h"
 #include "inc/hsa_ext_image.h"
 #include "inc/hsa_ven_amd_aqlprofile.h"
@@ -2288,6 +2289,19 @@ hsa_status_t GpuAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type, u
   }
 
   scratchGuard.Dismiss();
+
+  // Notify the dispatch_log subsystem about the new queue. This MUST run for
+  // ALL queue-creation paths (hsa_queue_create, hsa_amd_queue_intercept_create
+  // → wraps a lower queue created here, CountedQueuePoolManager::AcquireQueue,
+  // any future internal helper). The previous on_queue_create call site at
+  // hsa.cpp::hsa_queue_create only covered the public API path; internal pool
+  // queues created via this method bypassed it, leaving them with no
+  // dispatch_log drainer worker even though SetProfiling(true) was called on
+  // them. Records FW wrote into those orphan queues' buffers were never
+  // emitted to LTTng — and only freed at process shutdown via the AqlQueue
+  // destructor, not during the per-phase queue-pool churn.
+  dispatch_log::on_queue_create(aql_queue);
+
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -2275,7 +2275,10 @@ hsa_status_t GpuAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type, u
   auto aql_queue = new AqlQueue(shared_queue, this, size, node_id(), scratch, event_callback, data,
                                 metadata_queue, flags);
   *queue = aql_queue;
-  aql_queues_.push_back(aql_queue);
+  {
+    std::unique_lock<std::shared_mutex> lock(aql_queues_mutex_);
+    aql_queues_.push_back(aql_queue);
+  }
 
   if (doorbell_queue_map_) {
     // Calculate index of the queue doorbell within the doorbell aperture.
@@ -2571,8 +2574,21 @@ void GpuAgent::ReleaseScratch(void* base, size_t size, bool large) {
   ClearScratchNotifiers();
 }
 
+void GpuAgent::ClearTrapDoorbellMapping(uintptr_t doorbell_addr, const amd_queue_v2_t* amd_q) {
+  if (!doorbell_queue_map_ || amd_q == nullptr) return;
+  auto doorbell_idx = (doorbell_addr >> 3) & (MAX_NUM_DOORBELLS - 1);
+  if (doorbell_queue_map_[doorbell_idx] == amd_q) doorbell_queue_map_[doorbell_idx] = nullptr;
+}
+
+void GpuAgent::RemoveAqlQueue(AqlQueue* q) {
+  if (q == nullptr) return;
+  std::unique_lock<std::shared_mutex> lock(aql_queues_mutex_);
+  aql_queues_.erase(std::remove(aql_queues_.begin(), aql_queues_.end(), q), aql_queues_.end());
+}
+
 // Go through all the AQL queues and try to release scratch memory
 void GpuAgent::AsyncReclaimScratchQueues() {
+  std::shared_lock<std::shared_mutex> lock(aql_queues_mutex_);
   for (auto iter : aql_queues_) {
     auto aqlQueue = static_cast<AqlQueue*>(iter);
     aqlQueue->AsyncReclaimMainScratch();
@@ -2585,9 +2601,12 @@ hsa_status_t GpuAgent::SetAsyncScratchThresholds(size_t use_once_limit) {
 
   scratch_limit_async_threshold_ = use_once_limit;
 
-  for (auto iter : aql_queues_) {
-    auto aqlQueue = static_cast<AqlQueue*>(iter);
-    aqlQueue->CheckScratchLimits();
+  {
+    std::shared_lock<std::shared_mutex> lock(aql_queues_mutex_);
+    for (auto iter : aql_queues_) {
+      auto aqlQueue = static_cast<AqlQueue*>(iter);
+      aqlQueue->CheckScratchLimits();
+    }
   }
   return HSA_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/clock_sync.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/clock_sync.cpp
@@ -1,5 +1,7 @@
 #include "core/inc/clock_sync.h"
 
+#if defined(HSA_ENABLE_LTTNG_UST) && HSA_ENABLE_LTTNG_UST
+
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
@@ -19,7 +21,6 @@ std::atomic<bool> g_shutdown{false};
 std::thread g_poller_thread;
 
 void poller_loop() {
-#if defined(HSA_ENABLE_LTTNG_UST) && HSA_ENABLE_LTTNG_UST
   // Configurable sync interval. Default is 100ms.
   auto tick_interval = std::chrono::milliseconds(100);
   const char* env_interval = getenv("HSA_CLOCK_SYNC_INTERVAL_MS");
@@ -51,7 +52,6 @@ void poller_loop() {
 
     std::this_thread::sleep_for(tick_interval);
   }
-#endif
 }
 
 }  // namespace
@@ -70,3 +70,22 @@ void shutdown() {
 
 }  // namespace clock_sync
 }  // namespace rocr
+
+#else  // !HSA_ENABLE_LTTNG_UST
+
+// When LTTng-UST support is disabled at build time, the clock_sync poller
+// has no tracepoint to emit into. init()/shutdown() compile to no-ops so
+// non-LTTng builds neither spawn nor join a background thread. The
+// declarations in core/inc/clock_sync.h still need definitions because
+// runtime.cpp Runtime::Load/Unload call them unconditionally.
+
+namespace rocr {
+namespace clock_sync {
+
+void init() {}
+void shutdown() {}
+
+}  // namespace clock_sync
+}  // namespace rocr
+
+#endif  // HSA_ENABLE_LTTNG_UST

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/clock_sync.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/clock_sync.cpp
@@ -1,0 +1,72 @@
+#include "core/inc/clock_sync.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <thread>
+
+#include "core/inc/agent.h"
+#include "core/inc/amd_gpu_agent.h"
+#include "core/inc/runtime.h"
+#include "lttng/rocm_trace_emit.h"
+
+namespace rocr {
+namespace clock_sync {
+
+namespace {
+
+std::atomic<bool> g_shutdown{false};
+std::thread g_poller_thread;
+
+void poller_loop() {
+#if defined(HSA_ENABLE_LTTNG_UST) && HSA_ENABLE_LTTNG_UST
+  // Configurable sync interval. Default is 100ms.
+  auto tick_interval = std::chrono::milliseconds(100);
+  const char* env_interval = getenv("HSA_CLOCK_SYNC_INTERVAL_MS");
+  if (env_interval != nullptr) {
+    int parsed_interval = std::atoi(env_interval);
+    if (parsed_interval > 0) {
+      tick_interval = std::chrono::milliseconds(parsed_interval);
+    }
+  }
+
+  while (!g_shutdown.load(std::memory_order_relaxed)) {
+    if (!rocm_trace_disabled() && lttng_ust_tracepoint_enabled(rocm_hsa, clock_sync)) {
+      // Iterate over all GPU agents in the system and emit a clock sync record
+      // for each. gpu_agents() is already filtered to GPU-class agents only,
+      // so no kAmdGpuDevice device-type check is needed.
+      for (core::Agent* agent : core::Runtime::runtime_singleton_->gpu_agents()) {
+        if (agent == nullptr) continue;
+        auto* gpu = static_cast<AMD::GpuAgentInt*>(agent);
+
+        HsaClockCounters clocks{};
+        hsa_status_t err = gpu->driver().GetClockCounters(gpu->node_id(), &clocks);
+        if (err == HSA_STATUS_SUCCESS) {
+          rocm_trace_emit_hsa_clock_sync(gpu->node_id(),
+                                         clocks.GPUClockCounter,
+                                         clocks.SystemClockCounter);
+        }
+      }
+    }
+
+    std::this_thread::sleep_for(tick_interval);
+  }
+#endif
+}
+
+}  // namespace
+
+void init() {
+  g_shutdown.store(false, std::memory_order_relaxed);
+  g_poller_thread = std::thread(poller_loop);
+}
+
+void shutdown() {
+  g_shutdown.store(true, std::memory_order_release);
+  if (g_poller_thread.joinable()) {
+    g_poller_thread.join();
+  }
+}
+
+}  // namespace clock_sync
+}  // namespace rocr

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/counted_queue_manager.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/counted_queue_manager.cpp
@@ -83,7 +83,12 @@ core::Queue* CountedQueuePoolManager::FindOrCreateHardwareQueue(
   status = cmd_queue->SetPriority(priority);
   if (status != HSA_STATUS_SUCCESS) return nullptr;
 
-  cmd_queue->SetProfiling(true);
+  // C3: SetProfiling now returns hsa_status_t but the existing
+  // counted-queue path historically treats profiling-bit setup as
+  // best-effort. Ignore the return for behavioral parity; the buffer-
+  // wiring failure modes (libhsakmt SetQueueProfilingBuffer failure)
+  // do not regress correctness for these internal queues.
+  (void)cmd_queue->SetProfiling(true);
 
   // Add to pool
   pool.push_back(cmd_queue);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/counted_queue_manager.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/counted_queue_manager.cpp
@@ -6,6 +6,7 @@
 
 #include "core/inc/counted_queue_manager.h"
 #include "core/inc/agent.h"
+#include "core/inc/dispatch_log.h"
 #include "core/inc/runtime.h"
 
 namespace rocr {
@@ -88,7 +89,18 @@ core::Queue* CountedQueuePoolManager::FindOrCreateHardwareQueue(
   // best-effort. Ignore the return for behavioral parity; the buffer-
   // wiring failure modes (libhsakmt SetQueueProfilingBuffer failure)
   // do not regress correctness for these internal queues.
-  (void)cmd_queue->SetProfiling(true);
+  //
+  // Code-quality C3: route through the dispatch_log refcount instead
+  // of calling SetProfiling directly. SetProfiling owns the per-queue
+  // dispatch-record buffer + KFD MQD wiring; if the LTTng dispatch_log
+  // path enables/disables profiling on a counted queue it shares with
+  // us, a refcount-bypassing direct SetProfiling(false) by either
+  // owner would free state the other still depends on. The Acquire is
+  // never matched by a Release here — counted queues hold profiling
+  // for their full lifetime — so the refcount stays at 1 (or higher
+  // if another consumer also acquires) until the queue is destroyed,
+  // at which point on_queue_destroy clears the refcount entry.
+  (void)rocr::dispatch_log::QueueProfilingAcquire(cmd_queue);
 
   // Add to pool
   pool.push_back(cmd_queue);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -144,11 +144,13 @@ struct queue_drain_state {
   std::function<uint64_t(uint64_t /* gpu_ts */)> translate_gpu_ts;
 
   // NON-OWNING ring view. The buffer is owned by AqlQueue::dispatch_record_buffer_;
-  // do not free here. The kernel-side BO is `ring_records * 40` bytes
-  // (host KFD enforces the 40-byte slot stride — see
-  // amd/amdkfd/kfd_process_queue_manager.c:633 `buf_byte_size = count * 40`).
-  // FW writes 16 bytes per slot; the trailing 24 bytes per slot are FW-owned
-  // and reserved for future per-slot metadata.
+  // do not free here. The kernel-side BO is allocated oversized at
+  // `ring_records * 40` bytes purely to satisfy host KFD BO-size validation
+  // (amd/amdkfd/kfd_process_queue_manager.c:633 `buf_byte_size = count * 40`).
+  // The active FW/drainer ring uses the 16-byte FW record stride
+  // (kSlotStride): FW writes records at 16-byte stride and the drainer
+  // reads them at 16-byte stride. The extra allocation tail beyond
+  // `ring_records * 16` is unused/reserved and is not part of the ring.
   void*    ring_base    = nullptr;     // host-virtual base of the FW record area
   uint32_t ring_records = 0;           // power-of-2 slot count (e.g. 65536)
   uint32_t ring_mask    = 0;           // ring_records - 1, for slot indexing

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -151,11 +151,11 @@ struct queue_drain_state {
   // Host-managed monotonic record cursor. Mutated only under drain_mu.
   // Slot index is (next_idx & ring_mask).
   //
-  // Two drain modes select on whether wptr_ptr below is non-null:
-  //   - WPTR-bound scan (preferred, MINOR>=20): next_idx tracks the
+  // Two drain modes select on whether signal_ptr below is non-null:
+  //   - SIGNAL-bound scan (preferred, MINOR>=20): next_idx tracks the
   //     absolute count of records the host has emitted. Each pass reads
-  //     fw_wptr atomically and iterates [next_idx, fw_wptr). After
-  //     emitting all records, next_idx is set to fw_wptr and the same
+  //     *signal_ptr atomically and iterates [next_idx, signal). After
+  //     emitting all records, next_idx is set to signal and the same
   //     value is published to *rptr_ptr for FW backpressure visibility
   //     (FW does not currently read it but publishing keeps the door
   //     open for future FW that does).
@@ -172,19 +172,21 @@ struct queue_drain_state {
   // succeeded. All three are nullptr in fallback mode.
   //
   // Memory model:
-  //   - wptr_ptr: FW writes per-record (post-increment record count) with
-  //     release-atomicity equivalent (FW spins on TC outstanding tag
-  //     count after the record body write before the wptr publish, per
-  //     f32_mec.uc @SubAqlProfBufWriteRecord). Host reads with acquire
-  //     to establish happens-before with the record body bytes.
+  //   - signal_ptr: FW writes per-record (post-increment record count)
+  //     AFTER first writing the same value to wptr_ptr (see f32_mec.uc
+  //     @SubAqlProfBufWriteRecord lines 29605-29626 — wptr write THEN
+  //     TC-drain THEN signal write THEN TC-drain). Per single FW thread
+  //     signal is the LAST write per record and carries the strongest
+  //     "record committed" semantics. The drainer uses signal_ptr as
+  //     its source of truth (see drain_one_queue Path A for the
+  //     multi-XCC race rationale).
+  //   - wptr_ptr: FW writes the same per-record value as signal_ptr,
+  //     just earlier in the publish sequence. Kept registered so the
+  //     KFD ioctl + FW-side state stays symmetric, but the drainer
+  //     does not read it (signal is the source of truth).
   //   - rptr_ptr: host writes after consume with release. FW reads on
   //     queue connect (currently informational; backpressure not
   //     enforced).
-  //   - signal_ptr: FW writes per-record (same value as wptr_ptr — see
-  //     FW Q3 in 2026-05-01-mec-firmware-dispatch-log-interface.md).
-  //     Host can use as an HSA signal payload for hsa_signal_wait_value_geq
-  //     or sleep-then-poll. Currently unused by the drain loop (we busy-
-  //     poll wptr_ptr instead) but kept for future signal-based wait.
   volatile uint64_t* wptr_ptr   = nullptr;
   volatile uint64_t* rptr_ptr   = nullptr;
   volatile uint64_t* signal_ptr = nullptr;
@@ -393,45 +395,43 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
   if (qs.ring_base == nullptr || qs.ring_records == 0) return false;
 
   // ============================================================================
-  // PATH A: WPTR-BOUND SCAN (preferred, KFD MINOR>=20 + new FW)
+  // PATH A: SIGNAL-BOUND SCAN (preferred, KFD MINOR>=20 + new FW)
   //
-  // FW publishes the post-increment record count to *qs.wptr_ptr per
-  // record (see f32_mec.uc @SubAqlProfBufWriteRecord). Host reads it
-  // atomically with acquire and iterates [qs.next_idx, fw_wptr) — each
-  // slot is read exactly once, no duplicates possible. After consuming,
-  // host publishes its position to *qs.rptr_ptr for FW visibility (FW
-  // does not enforce backpressure today but the publish keeps the door
-  // open).
+  // FW publishes the post-increment record count to *qs.signal_ptr after
+  // first publishing the same value to *qs.wptr_ptr (see f32_mec.uc
+  // @SubAqlProfBufWriteRecord lines 29605-29626 — wptr write THEN
+  // TC-drain THEN signal write THEN TC-drain). Per single FW thread,
+  // signal_addr is the LAST write per record, so any non-zero observation
+  // implies the corresponding record body, wptr increment, and host
+  // wptr_addr publish all already happened. We use signal as the source
+  // of truth.
   //
-  // Overrun handling: if (fw_wptr - qs.next_idx) > qs.ring_records the
+  // Why not wptr too? KFD programs the same wptr_addr / signal_addr into
+  // the per-MQD slots for every XCC (kfd_mqd_manager_v9.c:450-461 — no
+  // master/slave gating). FW state machines on multiple XCCs can publish
+  // concurrently to the same host VA without atomics, so both wptr and
+  // signal can race / oscillate. Empirically wptr can go backward by
+  // 300-450 records between polls. Signal races too (it's the same store
+  // pattern), but using signal-only:
+  //   1. Aligns with FW's intended per-record publish boundary (signal
+  //      is written AFTER wptr, semantically "record committed").
+  //   2. Simplifies the drainer (one counter, not two).
+  //   3. Opens the door to hsa_signal_wait on signal_addr instead of
+  //      polling, deferred to a future optimization.
+  //
+  // Backward-publish protection (still needed because signal races too):
+  // qs.next_idx is our host-side monotonic floor. If FW publishes a
+  // value < next_idx, treat it as stale and skip the pass; we wait for
+  // a future monotonic publish to advance.
+  //
+  // Overrun handling: if (signal - qs.next_idx) > qs.ring_records the
   // host has fallen behind by more than one ring lap; the older records
   // were silently overwritten (FW does not stall on full ring). We jump
-  // qs.next_idx forward by the overrun distance and emit a kernel_dispatch_drop
-  // tracepoint so the consumer sees the gap. This is the bounded-progress
-  // analog of the sentinel-scan's pass_budget.
+  // qs.next_idx forward by the overrun distance and emit a
+  // kernel_dispatch_drop tracepoint so the consumer sees the gap.
   // ============================================================================
-  if (qs.wptr_ptr != nullptr) {
-    // FW publish-monotonicity workaround: the gfx950 MEC firmware
-    // publishes wptr_addr and signal_addr non-monotonically (observed
-    // delta_w going negative by 300-450 between consecutive polls;
-    // signal and wptr can also disagree by similar magnitudes). The
-    // FW publish path appears to race across CU lanes / cores —
-    // documented in the FW interface spec under "publish ordering".
-    //
-    // Mitigation:
-    //   1. Take max(wptr, signal): one may briefly publish a stale
-    //      value while the other races forward. Both are FW writes
-    //      of the same logical counter.
-    //   2. Use a per-queue monotonic floor (qs.next_idx) so FW
-    //      publishing a backward value never re-emits already-drained
-    //      records. If max(wptr,signal) < next_idx, FW's published
-    //      value is stale; skip this pass and wait for the next
-    //      monotonic update.
-    const uint64_t fw_wptr   = __atomic_load_n(qs.wptr_ptr,   __ATOMIC_ACQUIRE);
-    const uint64_t fw_signal = qs.signal_ptr
-                                   ? __atomic_load_n(qs.signal_ptr, __ATOMIC_ACQUIRE)
-                                   : fw_wptr;
-    const uint64_t observed = (fw_wptr > fw_signal) ? fw_wptr : fw_signal;
+  if (qs.signal_ptr != nullptr) {
+    const uint64_t observed = __atomic_load_n(qs.signal_ptr, __ATOMIC_ACQUIRE);
 
     // Backward (or stale) FW publish: ignore this pass entirely.
     // qs.next_idx is our monotonic floor.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -306,7 +306,11 @@ bool probe_substrate_version() {
   // KFD 1.22. Older kernels will silently ignore the trailing UPDATE_QUEUE
   // bytes (or worse, return -ENOTTY because of the _IOWR-encoded size
   // mismatch on related ioctls), so this version gate is mandatory.
-  return args.major_version >= 1 && args.minor_version >= 22;
+  // Accept any KFD whose ABI is at-or-after 1.22. A naive
+  // (major>=1 && minor>=22) check would reject a hypothetical KFD 2.0
+  // (which has minor==0). Compare lexicographically instead.
+  return args.major_version > 1 ||
+         (args.major_version == 1 && args.minor_version >= 22);
 }
 #else
 bool probe_substrate_version() { return false; }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -162,7 +162,13 @@ struct queue_profiling_owners {
 // rationale.
 // ============================================================================
 struct queue_drain_state {
-  uint32_t  queue_id = 0;
+  // Full 64-bit hsa_queue_t::id (see hsa.h). Internal ownership / lifetime
+  // maps key on this full id to avoid the high-32-bit collision risk
+  // flagged in C5 (two distinct live queues differing only in the high 32
+  // bits would have aliased a uint32_t key). The on-the-wire LTTng
+  // tracepoint payload still carries only the low 32 bits per spec §6/§14
+  // — we narrow at the rocm_trace_emit_* call sites, not here.
+  uint64_t  queue_id = 0;
 
   // Owned, queue-independent GPU->system time-translation callable.
   // Captured at register time so it remains callable even after the
@@ -235,10 +241,13 @@ std::atomic<bool> g_shutdown{false};
 // Acquired only briefly: enable/disable per-queue and snapshot-cloning.
 std::mutex g_lifecycle_mu;
 
-// Drainer registry (spec §4 lifetime protocol). Keyed by queue_id (the value
-// FW writes into the record dispatch_idx is per-queue, so queue_id distinguishes
-// drains). Holds one shared_ptr per active queue.
-std::unordered_map<uint32_t, std::shared_ptr<queue_drain_state>> g_active_queues;
+// Drainer registry (spec §4 lifetime protocol). Keyed by the full 64-bit
+// hsa_queue_t::id (the value FW writes into the record dispatch_idx is
+// per-queue, so queue_id distinguishes drains). Holds one shared_ptr per
+// active queue. See C5 fix: the LTTng tracepoint payload narrows this to
+// uint32_t at emit, but internal lifetime keys must stay 64-bit because
+// hsa_queue_t::id is uint64_t and unique over the application's lifetime.
+std::unordered_map<uint64_t, std::shared_ptr<queue_drain_state>> g_active_queues;
 
 // Poller-only "live queue" side map (spec §4 enable/disable convergence).
 //
@@ -262,7 +271,10 @@ std::unordered_map<uint32_t, std::shared_ptr<queue_drain_state>> g_active_queues
 // never observe a Queue* whose underlying core::Queue is being torn down by
 // the destroy thread (the destroy thread is forced to wait behind the
 // mutex if the poller is currently iterating).
-std::unordered_map<uint32_t, core::Queue*> g_known_queues;
+//
+// Keyed by full 64-bit hsa_queue_t::id (see g_active_queues commentary
+// above and C5 fix).
+std::unordered_map<uint64_t, core::Queue*> g_known_queues;
 
 // Side-map for the QueueProfilingAcquire/Release refcount (spec §4a). One
 // entry per Queue* that has ever had at least one acquire. Looked up under
@@ -308,10 +320,25 @@ std::atomic<uint64_t> g_generation_counter{1};
 // Helpers.
 // ============================================================================
 
-uint32_t queue_id_of(core::Queue* q) {
+// Full 64-bit hsa_queue_t::id (see hsa.h:2359-2361). Internal registries
+// (g_active_queues, g_known_queues) and queue_drain_state.queue_id all key
+// on this full value to avoid the high-32-bit collision risk flagged in
+// C5. The LTTng tracepoint payload narrows to the low 32 bits at the
+// emit call sites only.
+uint64_t queue_id_of(core::Queue* q) {
   // amd_queue_t.hsa_queue.id is set in the queue ctor (see e.g.
   // amd_aql_queue.cpp:298, host_queue.cpp:77).
-  return static_cast<uint32_t>(q->amd_queue_.hsa_queue.id);
+  return q->amd_queue_.hsa_queue.id;
+}
+
+// Narrow the 64-bit internal queue_id to the 32-bit on-the-wire identifier
+// emitted by the rocm_hsa:kernel_dispatch_complete / kernel_dispatch_drop
+// LTTng tracepoints. Spec §6 / §14 fix the wire format at uint32_t for
+// payload size; consumers join with the low 32 bits of the masked AQL
+// doorbell write_idx (also 32-bit on-the-wire). This narrowing is
+// deliberate and lossy: it must NOT be used for internal lookup.
+uint32_t queue_id_to_wire(uint64_t qid) {
+  return static_cast<uint32_t>(qid);
 }
 
 bool agent_is_gpu(core::Agent* a) {
@@ -374,7 +401,10 @@ int kfd_dispatch_log_op(uint32_t op, core::Queue* q,
   args.flags           = 0;
   // gpu_id: derive from agent if a GPU agent. Phase A leaves zero on failure.
   args.gpu_id          = 0;
-  args.queue_id        = queue_id_of(q);
+  // KFD ioctl arg field is uint32_t per the (Phase A placeholder) wire
+  // contract. Narrow internally; the struct field, not our internal map,
+  // dictates the width here.
+  args.queue_id        = queue_id_to_wire(queue_id_of(q));
   args.buffer_gpu_addr = buffer_gpu_addr;
   args.buffer_size     = buffer_size;
   args.write_ptr_addr  = write_ptr_addr;
@@ -454,7 +484,9 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
 
   // Wraparound check (spec §6 bytes_lost field definition).
   if (fw_wptr - qs.read_cursor > qs.ring_bytes) {
-    rocm_trace_emit_hsa_kernel_dispatch_drop(qs.queue_id,
+    // Narrow internal 64-bit queue_id to the 32-bit on-the-wire id at the
+    // tracepoint boundary (spec §6 / §14, C5 fix).
+    rocm_trace_emit_hsa_kernel_dispatch_drop(queue_id_to_wire(qs.queue_id),
                                              fw_wptr - qs.read_cursor);
     qs.read_cursor = fw_wptr - qs.ring_bytes;
   }
@@ -482,8 +514,12 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
         const uint64_t start_sys = qs.translate_gpu_ts(start_gpu);
         const uint64_t end_sys   = qs.translate_gpu_ts(gpu_ts);
 
+        // Narrow internal 64-bit queue_id at the tracepoint boundary
+        // (spec §6 / §14, C5 fix). dispatch_idx is already 32-bit per the
+        // FW record contract (mec_dispatch_record_16::dispatch_idx).
         rocm_trace_emit_hsa_kernel_dispatch_complete(
-            qs.queue_id, didx, start_sys, end_sys, force_emit);
+            queue_id_to_wire(qs.queue_id), didx, start_sys, end_sys,
+            force_emit);
       }
       // else: orphan END (start was lost to wraparound). Silently skip.
     }
@@ -635,9 +671,9 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
   ring_alloc_t alloc = alloc_ring_buffer();
   if (alloc.base == nullptr) {
     std::fprintf(stderr,
-                 "[hsa-runtime] dispatch_log: queue_id=%u ENABLE step 1 (alloc) "
+                 "[hsa-runtime] dispatch_log: queue_id=%llu ENABLE step 1 (alloc) "
                  "failed errno=%d\n",
-                 queue_id_of(q), errno);
+                 static_cast<unsigned long long>(queue_id_of(q)), errno);
     return;
   }
 
@@ -658,9 +694,10 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
   hsa_status_t s = QueueProfilingAcquire(q);
   if (s != HSA_STATUS_SUCCESS) {
     std::fprintf(stderr,
-                 "[hsa-runtime] dispatch_log: queue_id=%u ENABLE step 2 "
+                 "[hsa-runtime] dispatch_log: queue_id=%llu ENABLE step 2 "
                  "(QueueProfilingAcquire) failed status=%d\n",
-                 queue_id_of(q), static_cast<int>(s));
+                 static_cast<unsigned long long>(queue_id_of(q)),
+                 static_cast<int>(s));
     free_ring_buffer(alloc);
     return;
   }
@@ -685,9 +722,9 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
       generation);
   if (rc != 0) {
     std::fprintf(stderr,
-                 "[hsa-runtime] dispatch_log: queue_id=%u ENABLE step 3 "
+                 "[hsa-runtime] dispatch_log: queue_id=%llu ENABLE step 3 "
                  "(KFD ioctl) failed errno=%d\n",
-                 queue_id_of(q), rc);
+                 static_cast<unsigned long long>(queue_id_of(q)), rc);
     if (rc == ENOTSUP) {
       g_no_dispatch_log_agents.insert(q->GetAgent());
     }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -46,8 +46,11 @@
 // This file implements:
 //   - The ts_poller control-plane thread (~5 ms tick, idempotent enable /
 //     disable passes per spec §4 lifecycle state machine).
-//   - The ts_drainer data-plane thread (adaptive cadence, snapshot-based
-//     drain per spec §7).
+//   - One drainer thread per active queue (spawned at enable, joined at
+//     disable). Each per-queue worker independently drains its own ring
+//     buffer at the FW's local write rate, so cross-queue serialization
+//     present in the prior single-shared-drainer design is eliminated.
+//     See spec §7.
 //   - Per-queue ENABLE / DISABLE sequences (spec §5 ordering).
 //   - The QueueProfilingAcquire / Release refcount API (spec §4a).
 //   - The on_queue_create / on_queue_destroy hooks (spec §4 hooks).
@@ -73,9 +76,9 @@
 
 #include "core/inc/dispatch_log.h"
 
+#include <atomic>
 #include <cerrno>
 #include <chrono>
-#include <condition_variable>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -87,7 +90,6 @@
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
-#include <vector>
 
 #if defined(__linux__)
 #include <fcntl.h>
@@ -121,11 +123,12 @@ struct queue_profiling_owners {
 
 // ============================================================================
 // queue_drain_state per spec §7. Held via std::shared_ptr from both the
-// drainer registry (g_active_queues) and per-pass snapshot vectors. Stores
-// only NON-OWNING pointers into the buffer owned by AqlQueue (the buffer
-// is alloc'd by AqlQueue::SetProfiling(true) and freed by SetProfiling(false)
-// or the AqlQueue dtor). Deliberately stores NO Queue* — see spec §4
-// "Queue / drain-state lifetime" for the dangling-Queue rationale.
+// drainer registry (g_active_queues) and the per-queue worker thread (which
+// holds its own ref by-value via per_queue_drain_loop). Stores only NON-OWNING
+// pointers into the buffer owned by AqlQueue (the buffer is alloc'd by
+// AqlQueue::SetProfiling(true) and freed by SetProfiling(false) or the
+// AqlQueue dtor). Deliberately stores NO Queue* — see spec §4 "Queue /
+// drain-state lifetime" for the dangling-Queue rationale.
 // ============================================================================
 struct queue_drain_state {
   // Full 64-bit hsa_queue_t::id (see hsa.h). Internal ownership / lifetime
@@ -162,11 +165,36 @@ struct queue_drain_state {
   // so a wraparound re-write is re-detectable. See drain_one_queue.
   uint64_t next_idx = 0;
 
-  // Per-queue drain mutex. Serializes drain_one_queue() (steady state) and
-  // ts_drainer_drain_now() (synchronous final drain on the destroying /
-  // disable-edge thread). Per-queue scope, so other queues' drains are not
-  // blocked.
+  // Per-queue drain mutex. Steady state: only the per-queue worker thread
+  // holds this (so it is technically redundant in today's design — the
+  // worker is the sole drainer for its queue). Retained as defense in
+  // depth against any future code path that calls drain_one_queue
+  // synchronously from another thread (e.g. a future
+  // synchronous-final-drain helper). Per-queue scope, so other queues'
+  // drains are not blocked.
   std::mutex drain_mu;
+
+  // Per-queue worker thread shutdown signal + handle. Set true and joined
+  // by disable_dispatch_log_for_queue_locked (and by the destructor as a
+  // defensive safety net in case any code path drops a queue_drain_state
+  // without joining first). The worker checks should_stop with acquire
+  // ordering each iteration; the disable path stores it with release
+  // ordering before joining.
+  std::atomic<bool> should_stop{false};
+  std::thread       worker;
+
+  // Defensive safety net. The disable / shutdown path is responsible for
+  // joining the worker explicitly; this destructor only fires if a
+  // queue_drain_state is dropped without anyone having done so (e.g. a
+  // future caller that constructs a qs but never registers it). std::thread's
+  // destructor calls std::terminate() on a still-joinable thread, so we
+  // signal stop and join here as a last-resort.
+  ~queue_drain_state() {
+    if (worker.joinable()) {
+      should_stop.store(true, std::memory_order_release);
+      worker.join();
+    }
+  }
 };
 
 // ============================================================================
@@ -177,7 +205,10 @@ struct queue_drain_state {
 // timestamps right now?". Folded predicate of !rocm_trace_disabled() &&
 // lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_record) &&
 // g_substrate_present. Written only by ts_poller; read by on_queue_create
-// (relaxed, hot path) and ts_drainer.
+// (relaxed, hot path). Per-queue drainer workers do not gate on this flag
+// directly — they live for the lifetime of their queue's enable->disable
+// window, and the poller's disable pass is what stops them when the
+// predicate transitions to false.
 std::atomic<bool> G_tracepoint_enabled{false};
 
 // Set true if the KFD substrate version probe at init() reports a kernel
@@ -241,15 +272,9 @@ std::unordered_map<core::Queue*, std::shared_ptr<queue_profiling_owners>> g_owne
 // §9 unsupported-agent row).
 std::unordered_set<core::Agent*> g_no_dispatch_log_agents;
 
-// Threads.
+// Threads. Per-queue drainer threads (one per active queue) live inside
+// each queue_drain_state.worker; only the poller is global.
 std::thread g_poller_thread;
-std::thread g_drainer_thread;
-std::atomic<bool> g_drainer_running{false};
-
-// Drainer wakeup CV. Used to long-sleep (50 ms) when G_tracepoint_enabled is
-// false and short-sleep (500 us) on idle. Notified on shutdown.
-std::mutex g_drainer_mu;
-std::condition_variable g_drainer_cv;
 
 // ============================================================================
 // Helpers.
@@ -326,19 +351,6 @@ bool probe_substrate_version() {
 bool probe_substrate_version() { return false; }
 #endif
 
-// Snapshot: clone shared_ptrs out of g_active_queues under the lifecycle
-// mutex, return the vector. Drainer then iterates WITHOUT holding the
-// mutex (this is the only place where snapshotting matters: the drainer
-// runs on the data-plane hot path and must not block lifecycle ops, and
-// shared_ptr ownership keeps the entries alive across the unlocked loop).
-std::vector<std::shared_ptr<queue_drain_state>> snapshot_active_queues() {
-  std::vector<std::shared_ptr<queue_drain_state>> out;
-  std::lock_guard<std::mutex> lk(g_lifecycle_mu);
-  out.reserve(g_active_queues.size());
-  for (auto& kv : g_active_queues) out.push_back(kv.second);
-  return out;
-}
-
 // Iterate g_known_queues under g_lifecycle_mu and invoke fn(queue_id, queue)
 // for each entry. C6 fix: replaces the previous "snapshot into vector then
 // iterate" pattern. fn must NOT mutate g_known_queues. fn IS allowed to
@@ -399,15 +411,17 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
   // C9 (stage-2 review): bound each pass to one full ring sweep. The
   // sentinel-scan loop exits only when it observes record_type == 0 for
   // the current slot; if FW keeps the ring continuously non-empty, an
-  // unbounded loop here would let one queue monopolize ts_drainer (which
-  // walks queues sequentially under g_lifecycle_mu in
-  // ts_drainer_thread_main) and starve other queues, plus delay disable
-  // / shutdown paths that need drain_mu. Capping at ring_records slots
-  // (= one full ring sweep) preserves forward progress: at any instant
-  // FW can have at most ring_records unconsumed slots, so a full sweep
-  // always drains everything that was visible at pass start. Anything
-  // FW writes during the pass becomes the next pass's work — which is
-  // also the prior wptr-snapshot design's behaviour.
+  // unbounded loop here would (under the prior single-shared-drainer
+  // design) starve other queues. With one worker per queue today the
+  // cross-queue starvation argument no longer applies, but the cap is
+  // still useful: it bounds the time between checks of qs.should_stop
+  // (and the helper's own kill-switch check below), so a disable
+  // transition does not have to wait for an unbounded FW write rate
+  // to drain. Capping at ring_records slots (= one full ring sweep)
+  // also preserves forward progress: at any instant FW can have at
+  // most ring_records unconsumed slots, so a full sweep always drains
+  // everything that was visible at pass start. Anything FW writes
+  // during the pass becomes the next pass's work.
   const uint64_t pass_budget = qs.ring_records;
   uint64_t pass_consumed = 0;
 
@@ -516,22 +530,43 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
   return any;
 }
 
-// Synchronous final drain on the calling thread. Looks up the queue's
-// shared_ptr from the registry and forwards to drain_one_queue with
-// force_emit=true. Per spec §4: serialization with the drainer thread
-// happens via qs.drain_mu inside drain_one_queue.
+// Per-queue drain loop. One instance per active queue, spawned at enable
+// (enable_dispatch_log_for_queue_locked) and joined at disable
+// (disable_dispatch_log_for_queue_locked). The thread holds its
+// shared_ptr<queue_drain_state> by value, so qs is alive for the full
+// thread lifetime regardless of registry mutations elsewhere.
 //
-// _locked variant: caller holds g_lifecycle_mu. Used by the poller and by
-// disable_dispatch_log_for_queue_locked, both of which iterate registries
-// under the lifecycle mutex.
-void ts_drainer_drain_now_locked(core::Queue* q) {
-  std::shared_ptr<queue_drain_state> qs_ptr;
-  auto it = g_active_queues.find(queue_id_of(q));
-  if (it == g_active_queues.end()) return;
-  qs_ptr = it->second;
-  if (qs_ptr) {
-    drain_one_queue(*qs_ptr, /* force_emit = */ true);
+// Per-queue ownership eliminates cross-queue serialization: the previous
+// shared drainer iterated all queues sequentially under g_lifecycle_mu
+// snapshot, with a per-pass budget capped at qs.ring_records, so a
+// larger ring slowed the visit cycle to other queues. Each per-queue
+// worker now stays hot on its own ring at the FW's local write rate
+// without competing with other queues for thread time.
+//
+// Memory ordering on shutdown:
+//   - disable path: store should_stop = true with release, then join.
+//   - worker: load should_stop with acquire each iteration.
+//   - The release/acquire pair guarantees that the worker observes
+//     should_stop=true on its next loop check after the disable thread
+//     stores it (within the bounded sleep cadence). join() then waits
+//     for the worker's final-drain pass to complete.
+void per_queue_drain_loop(std::shared_ptr<queue_drain_state> qs) {
+  while (!qs->should_stop.load(std::memory_order_acquire)) {
+    const bool any = drain_one_queue(*qs, /* force_emit = */ false);
+    if (any) {
+      std::this_thread::yield();
+    } else {
+      // Same idle backoff as the prior shared drainer (500 us). Bounds
+      // the worst-case latency between the disable path setting
+      // should_stop and this thread observing it.
+      std::this_thread::sleep_for(std::chrono::microseconds(500));
+    }
   }
+  // Final drain after the stop signal so any FW records written between
+  // the last steady-state pass and the disable transition are emitted.
+  // force_emit=true bypasses the per-tracepoint enabled check inside the
+  // emission helper (spec §6) so disable does not lose pending records.
+  drain_one_queue(*qs, /* force_emit = */ true);
 }
 
 // ============================================================================
@@ -745,6 +780,21 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
 
   g_active_queues[qs->queue_id] = qs;
 
+  // Step 4: spawn the per-queue drainer worker AFTER registration. The
+  // worker holds its own shared_ptr<queue_drain_state> by value (passed
+  // into per_queue_drain_loop), so qs is alive for the full thread
+  // lifetime even if the registry entry is erased before the worker
+  // observes should_stop.
+  //
+  // Stack-size note: std::thread does not expose pthread_attr_setstacksize
+  // portably, so each worker uses the default pthread stack (typically
+  // 8 MiB virtual on glibc, lazily backed). With ~16 typical queues per
+  // process this costs ~128 MiB of virtual address space, which is fine
+  // for our hosts. Workloads pushing into the thousands-of-queues regime
+  // would need a pthread_create-based spawn helper to set a small (e.g.
+  // 64 KiB) stack; defer that until measured pressure exists.
+  qs->worker = std::thread(per_queue_drain_loop, qs);
+
   q->dispatch_log_active.store(true, std::memory_order_release);
 }
 
@@ -754,33 +804,23 @@ void disable_dispatch_log_for_queue_locked(core::Queue* q) {
 
   // Spec §4 disable-edge per-queue sequence.
   //
-  // C2 fix: ordering between final-drain, drainer-snapshot poisoning,
-  // registry erase, and buffer release is critical. queue_drain_state
-  // stores NON-OWNING pointers into a buffer owned by AqlQueue; once
-  // QueueProfilingRelease triggers SetProfiling(false) the buffer is
-  // freed. A snapshot held by the drainer thread (snapshot_active_queues)
-  // pins the queue_drain_state alive but does NOT pin the buffer, so
-  // the drainer could dereference freed memory in drain_one_queue.
+  // Per-queue drainer ordering: with one worker thread per queue (spawned
+  // in enable_dispatch_log_for_queue_locked), the disable path must
+  // signal stop and join the worker BEFORE freeing the buffer. The
+  // worker does its own final drain (force_emit=true) inside
+  // per_queue_drain_loop after observing should_stop, so a separate
+  // synchronous-final-drain step is no longer needed.
   //
-  // We close that window by poisoning the snapshot-visible pointers
-  // under qs->drain_mu, then erasing from g_active_queues, and only
-  // then calling QueueProfilingRelease (which frees the buffer):
-  //
-  //   - drain_one_queue takes drain_mu first thing, then early-returns
-  //     on ring_base==nullptr || ring_records==0. Any drainer that
-  //     hasn't started its pass for this queue yet will exit early.
-  //   - Any drainer already inside drain_one_queue holds drain_mu, so
-  //     the poisoning step blocks until it completes its current pass.
-  //     The buffer is not yet freed at that point (we haven't released
-  //     yet), so that pass is safe to finish.
+  // Pointer poisoning under drain_mu is retained as defense in depth
+  // against any future code path that calls drain_one_queue
+  // synchronously from another thread; today the worker is the sole
+  // drainer for this queue and is already joined by the time we reach
+  // that step, so the poisoning is a no-op-but-cheap belt-and-braces.
 
   // a. wait_for_idle (bounded ≤ 100 ms).
   wait_for_idle(q);
 
-  // b. Final drain with force_emit=true (spec §6).
-  ts_drainer_drain_now_locked(q);
-
-  // c. Look up the registered drain-state shared_ptr. After this we hold
+  // b. Look up the registered drain-state shared_ptr. After this we hold
   //    a local ref so qs survives even after the registry erase below.
   std::shared_ptr<queue_drain_state> qs_ptr;
   {
@@ -788,9 +828,30 @@ void disable_dispatch_log_for_queue_locked(core::Queue* q) {
     if (it != g_active_queues.end()) qs_ptr = it->second;
   }
 
-  // d. Poison the non-owning pointers under drain_mu so any drainer
-  //    snapshot still in flight will exit drain_one_queue early. The
-  //    drain_mu acquire serializes with any in-progress drain pass.
+  // c. Stop and join the per-queue worker thread. The worker performs
+  //    its own final drain (force_emit=true) after observing
+  //    should_stop, so all pending FW records are emitted before
+  //    join() returns. should_stop store uses release ordering;
+  //    the worker reads it with acquire on each iteration.
+  //
+  //    join() may throw on a programming error (worker is the current
+  //    thread, or the std::thread is not joinable). Both are
+  //    impossible here: this function is called from the poller /
+  //    on_queue_destroy / shutdown threads (never the worker), and
+  //    the worker was assigned to qs->worker in the enable path
+  //    immediately before flipping dispatch_log_active to true. If
+  //    join() ever does throw the C++ runtime calls std::terminate;
+  //    we have no recovery path beyond the diagnostic the runtime
+  //    will emit. (No exception handler here — propagating up to
+  //    the poller would not improve the situation.)
+  if (qs_ptr) {
+    qs_ptr->should_stop.store(true, std::memory_order_release);
+    if (qs_ptr->worker.joinable()) qs_ptr->worker.join();
+  }
+
+  // d. Poison the non-owning pointers under drain_mu (defense in depth;
+  //    see function-level comment). The worker is already joined by
+  //    this point, so drain_mu is uncontended.
   if (qs_ptr) {
     std::lock_guard<std::mutex> lk(qs_ptr->drain_mu);
     qs_ptr->ring_base    = nullptr;
@@ -799,51 +860,20 @@ void disable_dispatch_log_for_queue_locked(core::Queue* q) {
   }
 
   // e. Unregister from drainer registry. Drops the registry's shared_ptr
-  //    ref. Any in-flight drainer snapshot still holds its own ref to
-  //    qs_ptr but its ring_base is now nullptr.
+  //    ref. The worker's own shared_ptr (held by-value in
+  //    per_queue_drain_loop) is already released because the worker
+  //    has returned and joined.
   g_active_queues.erase(queue_id_of(q));
 
   // f. Release profiling ref. On the 1->0 edge AqlQueue::SetProfiling(false)
   //    clears the KFD profiling-buffer registration (UPDATE_QUEUE with
   //    addr=0) and frees the per-queue dispatch-record buffer.
   //    QueueProfilingRelease takes g_owners_mu, NOT g_lifecycle_mu.
-  //    By this point no drainer can dereference the buffer because
-  //    every snapshot's qs->ring_base is nullptr.
+  //    By this point the worker is joined so no thread can dereference
+  //    the buffer.
   QueueProfilingRelease(q);
 
   q->dispatch_log_active.store(false, std::memory_order_release);
-}
-
-// ============================================================================
-// ts_drainer_loop (spec §7).
-// ============================================================================
-
-void ts_drainer_loop() {
-  while (!g_shutdown.load(std::memory_order_relaxed)) {
-    if (!G_tracepoint_enabled.load(std::memory_order_relaxed)) {
-      std::unique_lock<std::mutex> lk(g_drainer_mu);
-      g_drainer_cv.wait_for(lk, std::chrono::milliseconds(50));
-      continue;
-    }
-
-    bool any_progress = false;
-    auto snapshot = snapshot_active_queues();
-    for (auto& qs_ptr : snapshot) {
-      any_progress |= drain_one_queue(*qs_ptr, /* force_emit = */ false);
-    }
-
-    if (any_progress) {
-      std::this_thread::yield();
-    } else {
-      std::this_thread::sleep_for(std::chrono::microseconds(500));
-    }
-  }
-}
-
-void start_drainer_if_needed() {
-  bool expected = false;
-  if (!g_drainer_running.compare_exchange_strong(expected, true)) return;
-  g_drainer_thread = std::thread(ts_drainer_loop);
 }
 
 // ============================================================================
@@ -881,10 +911,11 @@ void ts_poller_loop() {
     G_tracepoint_enabled.store(curr, std::memory_order_relaxed);
 
     if (curr) {
-      start_drainer_if_needed();
-
       // ENABLE pass (spec §4): for each known live queue Q with
       // dispatch_log_active==false, run the per-queue ENABLE sequence.
+      // Each enable spawns a per-queue drainer worker thread inside
+      // enable_dispatch_log_for_queue_locked; there is no longer any
+      // shared drainer to start.
       for_each_known_queue_locked(
           [](uint64_t /*qid*/, core::Queue* q) {
             enable_dispatch_log_for_queue_locked(q);
@@ -923,19 +954,27 @@ void init() {
 
 void shutdown() {
   g_shutdown.store(true, std::memory_order_release);
-  g_drainer_cv.notify_all();
 
+  // Join the poller first so no new per-queue workers can be spawned (the
+  // poller's enable pass is the only spawner) while we are tearing down
+  // the active set.
   if (g_poller_thread.joinable()) g_poller_thread.join();
-  if (g_drainer_thread.joinable()) g_drainer_thread.join();
-  g_drainer_running.store(false, std::memory_order_relaxed);
 
-  // Spec §4 process-exit cleanup: run the per-queue DISABLE sequence
-  // (wait_for_idle, final drain, QueueProfilingRelease) for every queue
-  // still active at process exit.
+  // Spec §4 process-exit cleanup: run the per-queue DISABLE sequence for
+  // every queue still active at process exit. disable_dispatch_log_for_
+  // queue_locked stops + joins each queue's worker thread before
+  // releasing its profiling buffer, so by the time these calls return
+  // every per-queue worker has finished its final drain.
   for_each_known_queue_locked(
       [](uint64_t /*qid*/, core::Queue* q) {
         disable_dispatch_log_for_queue_locked(q);
       });
+
+  // Drop any drain-state shared_ptrs still pinned by g_active_queues.
+  // The destructor on queue_drain_state defensively joins worker if it
+  // is still joinable (it should not be — disable above joined it
+  // already), so this is safe even if a queue somehow escaped the
+  // disable pass above.
   {
     std::lock_guard<std::mutex> lk(g_lifecycle_mu);
     g_known_queues.clear();

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -1275,11 +1275,17 @@ void on_queue_destroy(core::Queue* q) {
 }  // namespace rocr
 
 // =============================================================================
-// TEST-ONLY introspection API for standalone dispatch_log validation programs
-// (dlog_test1, dlog_test2, ...). NOT part of the public HSA ABI; symbol prefix
-// hsa_amd_dispatch_log_test_ to make grep-ability obvious.
+// TEST-ONLY introspection API for standalone dispatch_log validation programs.
+// NOT part of the public HSA ABI; symbol prefix hsa_amd_dispatch_log_test_ to
+// make grep-ability obvious.
 //
-// Usage from a test:
+// In-tree tests that exercise this API live under
+//   projects/rocr-runtime/runtime/hsa-runtime/test/lttng/
+//     - test_hsa_dispatch_log.sh           (LTTng end-to-end through HIP)
+//     - test_hsa_dispatch_log_test_api.sh  (focused API contract test)
+//
+// Usage pattern from a test that wants to bypass the LTTng emit path
+// and read the raw FW buffer directly:
 //   1. set HSA_DISPATCH_LOG_NO_DRAIN=1 in the env so the per-queue worker
 //      sleeps instead of draining (preserves raw FW buffer state for the
 //      test to inspect).

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -388,11 +388,32 @@ void for_each_known_queue_locked(F&& fn) {
 // `count * 16` after the upstream fix lands).
 constexpr size_t kSlotStride = 16;
 
+// Per-pass batch size: drainer accumulates up to this many records per
+// LTTng tracepoint call. 256 records × 16 bytes = 4 KiB stack-allocated
+// buffer per drain pass. Batching is the primary mechanism for keeping
+// up with peak FW write rates of ~1M records/sec on busy queues; per-record
+// LTTng tracepoint emit cost (~1-2 us) was the host-side bottleneck before
+// batching.
+constexpr uint32_t kBatchMax = 256;
+
 bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
   std::lock_guard<std::mutex> lk(qs.drain_mu);
 
   // Poisoned (disable in flight) or never-populated.
   if (qs.ring_base == nullptr || qs.ring_records == 0) return false;
+
+  // Shared batch buffer for both Path A (signal-bound) and Path B
+  // (sentinel-scan). Stack-allocated; per-pass scope.
+  alignas(16) uint8_t batch_buf[kBatchMax * kSlotStride];
+  uint32_t batch_count = 0;
+  auto flush_batch = [&]() {
+    if (batch_count == 0) return;
+    rocm_trace_emit_hsa_kernel_dispatch_record(
+        queue_id_to_wire(qs.queue_id),
+        batch_count, batch_buf,
+        (size_t)batch_count * kSlotStride, force_emit);
+    batch_count = 0;
+  };
 
   // ============================================================================
   // PATH A: SIGNAL-BOUND SCAN (preferred, KFD MINOR>=20 + new FW)
@@ -437,6 +458,35 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     // qs.next_idx is our monotonic floor.
     if (observed <= qs.next_idx) return false;
 
+    // Initial-state sync. The FW maintains its dispatch-log wptr counter
+    // in per-pipe scratch RAM (LdMecAqlProfBufWptr in f32_mec.uc:29579),
+    // and that counter PERSISTS across queue lifecycles. When KFD
+    // destroys a queue and creates a new one on the same pipe, the new
+    // queue inherits the previous queue's wptr value. At
+    // enable_dispatch_log_for_queue time we initialize qs.next_idx from
+    // the current FW signal value, but the host signal_addr is still 0
+    // at that moment (FW hasn't published since enable). Once FW writes
+    // its first record post-enable, signal jumps from 0 to whatever the
+    // pipe scratch wptr was + 1, which can be huge (millions).
+    //
+    // Without this sync the overrun handler below would interpret the
+    // huge gap as "we fell behind by ring_records or more" and emit a
+    // drop event followed by reads of stale ring storage (most slots
+    // empty / pre-zero, only the freshly-written slot has real data).
+    // Net effect: hundreds of zero-record batched events per queue
+    // immediately after enable.
+    //
+    // Heuristic: if next_idx is 0 (never advanced past initial enable)
+    // AND observed > ring_records (impossibly far ahead for a fresh
+    // queue), treat as initial-state sync. Set next_idx = observed - 1
+    // so we drain ONE record (the actual fresh dispatch FW just wrote)
+    // and start tracking from there. The single record at slot
+    // (observed - 1) & ring_mask is the real one FW just wrote at the
+    // pre-increment scratch wptr position.
+    if (qs.next_idx == 0 && observed > qs.ring_records) {
+      qs.next_idx = observed - 1;
+    }
+
     // Overrun detection. If FW lapped us, log a drop event and skip
     // the unrecoverable region. The records we DO read after the skip
     // are still valid (they're the most recent observed - ring_records
@@ -450,13 +500,19 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
       start = end - qs.ring_records;
     }
 
+    // Batched LTTng emit (see batch_buf / flush_batch declared above the
+    // path branch). Records accumulate as we walk [start, end); when the
+    // batch fills (kBatchMax records) we flush mid-loop, and after the
+    // loop we flush whatever's left.
     bool any = false;
     for (uint64_t i = start; i < end; ++i) {
       // Kill-switch pre-check: bail before reading any record. Safe to
       // bail here because qs.next_idx still points at the unread head
       // and the next pass will pick up where we stopped (FW state
-      // unchanged — the wptr-bound scan never mutates the slot).
+      // unchanged — the wptr-bound scan never mutates the slot). Flush
+      // any pending batch first so we don't lose records already read.
       if (!force_emit && rocm_trace_disabled()) {
+        flush_batch();
         qs.next_idx = i;  // record progress so far
         if (qs.rptr_ptr) __atomic_store_n(qs.rptr_ptr, i, __ATOMIC_RELEASE);
         return any;
@@ -468,26 +524,23 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
 
       // FW publish-ordering contract (per f32_mec.uc Q6): record body
       // is host-visible BEFORE the wptr update we acquire-loaded above.
-      // So all four DWs of this record are coherent. Use relaxed atomics
-      // to suppress UB from non-atomic reads on FW-written memory; the
-      // wptr acquire load above provides the ordering.
-      const uint32_t ts_lo        = __atomic_load_n(&rec->ts_lo,        __ATOMIC_RELAXED);
-      const uint32_t ts_hi        = __atomic_load_n(&rec->ts_hi,        __ATOMIC_RELAXED);
-      const uint32_t rt           = __atomic_load_n(&rec->record_type,  __ATOMIC_RELAXED);
-      const uint32_t dispatch_idx = __atomic_load_n(&rec->dispatch_idx, __ATOMIC_RELAXED);
-      const uint64_t gpu_ts       = (static_cast<uint64_t>(ts_hi) << 32) | ts_lo;
-
-      // No slot mutation in the wptr-bound path: FW will overwrite this
-      // slot when wptr next reaches the same physical slot, and our
-      // wptr-based iteration will read it as a new record at that time.
-      // No sentinel needed because we never re-read the same wptr index.
-
-      rocm_trace_emit_hsa_kernel_dispatch_record(
-          queue_id_to_wire(qs.queue_id), dispatch_idx, gpu_ts,
-          static_cast<uint8_t>(rt), force_emit);
-
+      // So all four DWs of this record are coherent. We copy the entire
+      // 16-byte record into the batch buffer in one shot via memcpy
+      // (the source is host-coherent FW-written memory at this point).
+      std::memcpy(batch_buf + (size_t)batch_count * kSlotStride,
+                  rec, kSlotStride);
+      batch_count++;
       any = true;
+
+      // No slot mutation: FW will overwrite this slot when wptr next
+      // reaches the same physical slot, and our wptr-based iteration
+      // will read it as a new record at that time.
+
+      if (batch_count == kBatchMax) {
+        flush_batch();
+      }
     }
+    flush_batch();
 
     qs.next_idx = end;
     // Publish our consumer position back to FW (informational; FW does
@@ -561,13 +614,12 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     uint32_t rt = __atomic_load_n(&rec->record_type, __ATOMIC_ACQUIRE);
     if (rt == 0) break;
 
-    // Snapshot the rest of the record locally before clearing the sentinel.
-    // Relaxed atomic loads suffice (see comment above) — the acquire on
-    // record_type above already orders these.
-    const uint32_t ts_lo        = __atomic_load_n(&rec->ts_lo, __ATOMIC_RELAXED);
-    const uint32_t ts_hi        = __atomic_load_n(&rec->ts_hi, __ATOMIC_RELAXED);
-    const uint32_t dispatch_idx = __atomic_load_n(&rec->dispatch_idx, __ATOMIC_RELAXED);
-    const uint64_t gpu_ts       = (static_cast<uint64_t>(ts_hi) << 32) | ts_lo;
+    // Sentinel-scan path also batches: copy the FW record (16 bytes,
+    // exactly the mec_dispatch_record_16 layout the new tracepoint
+    // expects) into the batch buffer, then clear the sentinel.
+    std::memcpy(batch_buf + (size_t)batch_count * kSlotStride,
+                rec, kSlotStride);
+    batch_count++;
 
     // Zero the record_type field so a wraparound rewrite by FW (next time
     // the ring loops past this position) is re-detected as a fresh
@@ -576,40 +628,15 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     // 16 bytes atomically.
     __atomic_store_n(&rec->record_type, 0, __ATOMIC_RELEASE);
 
-    // Emit one event per FW-written record. No host-side START/END
-    // pairing — consumer joins on (queue_id, dispatch_idx) and uses
-    // gpu_ts ordering or record_type semantics as it sees fit.
-    //
-    // Empirically on the gfx950 MEC firmware (gc_9_5_0_mec.bin):
-    // record_type==2 carries the earlier ts (dispatch start),
-    // record_type==1 carries the later ts (EOP / dispatch end). HSA
-    // emits both records as-is without taking a position on which is
-    // which — the FW contract is not formally versioned, and a
-    // consumer-side polarity decision is cheaper to update than a
-    // host-runtime release.
-    //
-    // record_type narrowing uint32 -> uint8: current FW values are
-    // 1 and 2 and the on-the-wire schema field is uint8_t. The
-    // sentinel-zero check above (rt == 0 immediately after the acquire load)
-    // already filters
-    // empty slots before this point, so rt is known non-zero at the
-    // cast site — the truncation hazard is NOT sentinel collision
-    // (no on-the-wire 0 can be produced here). The only hazard is two
-    // distinct future FW values that collide modulo 256 (e.g. 1 and
-    // 257); we accept this risk for the smaller payload and will
-    // widen the schema (and the cast) when (and only when) such a FW
-    // revision exists.
-    //
-    // Narrow internal 64-bit queue_id at the tracepoint boundary
-    // (spec §6 / §14, C5 fix). dispatch_idx is 32-bit per FW contract.
-    rocm_trace_emit_hsa_kernel_dispatch_record(
-        queue_id_to_wire(qs.queue_id), dispatch_idx, gpu_ts,
-        static_cast<uint8_t>(rt), force_emit);
-
     qs.next_idx += 1;
     pass_consumed += 1;
     any = true;
+
+    if (batch_count == kBatchMax) {
+      flush_batch();
+    }
   }
+  flush_batch();
   return any;
 }
 
@@ -647,10 +674,60 @@ void per_queue_drain_loop(std::shared_ptr<queue_drain_state> qs) {
     return;
   }
 
+  // Signal-poll loop with adaptive backoff.
+  //
+  // The previous implementation busy-spun calling drain_one_queue() and
+  // yielding only when it had work, which kept a CPU core saturated even
+  // when the queue was idle. With many queues running concurrently this
+  // multiplied: N queues × N busy-spin workers = N cores at 100%.
+  //
+  // New strategy: read the FW signal value cheaply (one acquire load),
+  // compare to last_observed. If unchanged, sleep with adaptive backoff;
+  // if changed, drain immediately. Backoff schedule:
+  //   - 0 idle iterations: drain back-to-back (no sleep)
+  //   - 1-3 idle:           yield only
+  //   - 4-15 idle:           sleep 10 us
+  //   - 16-63 idle:          sleep 100 us
+  //   - 64+ idle:            sleep 1 ms (steady-state idle)
+  // First sign of work resets the counter to 0 and resumes hot-loop.
+  //
+  // Path B (sentinel-scan, no signal_ptr): falls back to the old yield-
+  // only loop because we have no cheap "no work" probe — we have to
+  // actually read the slot's record_type to know.
+  uint64_t last_signal = 0;
+  uint32_t idle_count = 0;
   while (!qs->should_stop.load(std::memory_order_acquire)) {
+    // Path A fast-path: if signal_ptr is registered, read it cheaply and
+    // skip the drain call entirely when no new records exist.
+    if (qs->signal_ptr != nullptr) {
+      const uint64_t cur = __atomic_load_n(qs->signal_ptr, __ATOMIC_ACQUIRE);
+      if (cur == last_signal) {
+        // No new records — adaptive backoff
+        ++idle_count;
+        if (idle_count <= 3) {
+          std::this_thread::yield();
+        } else if (idle_count <= 15) {
+          std::this_thread::sleep_for(std::chrono::microseconds(10));
+        } else if (idle_count <= 63) {
+          std::this_thread::sleep_for(std::chrono::microseconds(100));
+        } else {
+          std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        continue;
+      }
+      last_signal = cur;
+      idle_count = 0;
+    }
+
     const bool any = drain_one_queue(*qs, /* force_emit = */ false);
-    if (any) {
-      std::this_thread::yield();
+    if (!any) {
+      // Path B (sentinel-scan) fallback or spurious wakeup: yield.
+      ++idle_count;
+      if (idle_count > 3) {
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
+      } else {
+        std::this_thread::yield();
+      }
     }
   }
   // Final drain after the stop signal so any FW records written between
@@ -919,33 +996,14 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
     // else: legacy sentinel-scan mode; null pointers tell drain_one_queue
     // to use the fallback scan path.
 
-    // Initialize next_idx from the CURRENT FW signal value at enable time,
-    // not from 0. The MEC firmware maintains its per-pipe scratch wptr
-    // counter (LdMecAqlProfBufWptr in f32_mec.uc, line 29579) across queue
-    // lifecycles — when KFD destroys a queue and creates a new one on the
-    // same pipe, the new queue's FW state inherits the previous queue's
-    // wptr. Verified empirically with the standalone hsa_dlog_test_mq
-    // multi-queue test: queue Q0's signal value started at 2,069,683 (with
-    // expected 200) reflecting cumulative FW writes from prior queue
-    // instances on the same pipe. Each successive test run grew Q0's
-    // signal by exactly 2*N, confirming the pipe scratch persistence.
-    //
-    // If we left next_idx=0, the drain pass would observe a huge initial
-    // signal value, treat it as overrun (signal - 0 > ring_records), emit
-    // a fake drop event for ~2M phantom records, and start draining from
-    // [signal - ring_records, signal) — most of those slots are pre-zero
-    // ring storage, not actual records. By initializing next_idx to the
-    // current signal we treat the FW's reported state as our starting
-    // point and only emit records FW writes from this point forward.
-    //
-    // Falls back to 0 if signal_ptr is null (legacy sentinel-scan mode);
-    // sentinel-scan handles wraparound via per-slot record_type=0 reset
-    // and doesn't depend on absolute counter values.
-    if (qs->signal_ptr != nullptr) {
-      qs->next_idx = __atomic_load_n(qs->signal_ptr, __ATOMIC_ACQUIRE);
-    } else {
-      qs->next_idx = 0;
-    }
+    // next_idx starts at 0. The drain loop's initial-state sync (see
+    // drain_one_queue Path A) detects the FW per-pipe scratch wptr
+    // persistence on the FIRST observed signal advance and adjusts
+    // next_idx then. We can't read FW's wptr at enable time because
+    // FW won't publish to signal_addr until the first new record write
+    // POST-enable — at this exact point the host word is still 0
+    // (initialized by SetProfiling).
+    qs->next_idx = 0;
 
     g_active_drainers[qs->queue_id] = qs;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -461,13 +461,32 @@ void free_ring_buffer(ring_alloc_t& a) {
 }
 
 // Snapshot: clone shared_ptrs out of g_active_queues under the lifecycle
-// mutex, return the vector. Drainer then iterates without holding the mutex.
+// mutex, return the vector. Drainer then iterates WITHOUT holding the
+// mutex (this is the only place where snapshotting matters: the drainer
+// runs on the data-plane hot path and must not block lifecycle ops, and
+// shared_ptr ownership keeps the entries alive across the unlocked loop).
 std::vector<std::shared_ptr<queue_drain_state>> snapshot_active_queues() {
   std::vector<std::shared_ptr<queue_drain_state>> out;
   std::lock_guard<std::mutex> lk(g_lifecycle_mu);
   out.reserve(g_active_queues.size());
   for (auto& kv : g_active_queues) out.push_back(kv.second);
   return out;
+}
+
+// Iterate g_known_queues under g_lifecycle_mu and invoke fn(queue_id, queue)
+// for each entry. C6 fix: replaces the previous "snapshot into vector then
+// iterate" pattern in ts_poller_loop / shutdown — the lock was already
+// held for the entire snapshot+iterate window, so the snapshot copy added
+// allocator pressure with no concurrency benefit. fn must NOT mutate
+// g_known_queues (the only legal mutators are on_queue_create /
+// on_queue_destroy, both of which take g_lifecycle_mu themselves and
+// therefore cannot run during this iteration). fn IS allowed to mutate
+// g_active_queues (e.g. enable_dispatch_log_for_queue_locked inserts,
+// disable_dispatch_log_for_queue_locked erases).
+template <typename F>
+void for_each_known_queue_locked(F&& fn) {
+  std::lock_guard<std::mutex> lk(g_lifecycle_mu);
+  for (auto& kv : g_known_queues) fn(kv.first, kv.second);
 }
 
 // ============================================================================
@@ -883,32 +902,23 @@ void ts_poller_loop() {
       // and on_queue_destroy serialize on the same mutex, so the Queue*
       // values we observe here cannot be torn down concurrently.
       // enable_dispatch_log_for_queue_locked is itself a no-op for queues
-      // that are already active (idempotent enable).
-      std::lock_guard<std::mutex> lk(g_lifecycle_mu);
-      // Snapshot first so enable's per-queue work doesn't mutate the map
-      // we're iterating (g_active_queues is mutated, but g_known_queues
-      // is stable across enable for an existing queue — defensive copy
-      // anyway).
-      std::vector<core::Queue*> known;
-      known.reserve(g_known_queues.size());
-      for (auto& kv : g_known_queues) known.push_back(kv.second);
-      for (core::Queue* q : known) {
-        enable_dispatch_log_for_queue_locked(q);
-      }
+      // that are already active (idempotent enable). C6: direct iteration,
+      // no per-tick snapshot allocation.
+      for_each_known_queue_locked(
+          [](uint64_t /*qid*/, core::Queue* q) {
+            enable_dispatch_log_for_queue_locked(q);
+          });
     } else {
       // DISABLE pass (spec §4 + §9 ROCM_LTTNG_UST_DISABLE row): for each
       // known live queue Q with dispatch_log_active==true, run the
       // per-queue DISABLE sequence (wait_for_idle, final drain, KFD
       // DISABLE, QueueProfilingRelease, mark inactive). Idempotent over
       // already-inactive queues. Required for kill-switch hygiene per
-      // spec §1039.
-      std::lock_guard<std::mutex> lk(g_lifecycle_mu);
-      std::vector<core::Queue*> known;
-      known.reserve(g_known_queues.size());
-      for (auto& kv : g_known_queues) known.push_back(kv.second);
-      for (core::Queue* q : known) {
-        disable_dispatch_log_for_queue_locked(q);
-      }
+      // spec §1039. C6: direct iteration, no per-tick snapshot allocation.
+      for_each_known_queue_locked(
+          [](uint64_t /*qid*/, core::Queue* q) {
+            disable_dispatch_log_for_queue_locked(q);
+          });
     }
 
     // Sleep until next tick.
@@ -946,15 +956,16 @@ void shutdown() {
   // (wait_for_idle, final drain, KFD DISABLE, QueueProfilingRelease) for
   // every queue still active at process exit. The poller is joined above
   // so no other thread is touching g_known_queues / g_active_queues here;
-  // the lock is taken for consistency with the helpers' contract.
+  // the lock is taken for consistency with the helpers' contract. C6:
+  // direct iteration via for_each_known_queue_locked, then a separate
+  // locked block for the post-iterate clears (we cannot clear inside the
+  // iteration callback because that would mutate the map mid-iteration).
+  for_each_known_queue_locked(
+      [](uint64_t /*qid*/, core::Queue* q) {
+        disable_dispatch_log_for_queue_locked(q);
+      });
   {
     std::lock_guard<std::mutex> lk(g_lifecycle_mu);
-    std::vector<core::Queue*> known;
-    known.reserve(g_known_queues.size());
-    for (auto& kv : g_known_queues) known.push_back(kv.second);
-    for (core::Queue* q : known) {
-      disable_dispatch_log_for_queue_locked(q);
-    }
     g_known_queues.clear();
     // Defensive: drop any remaining drainer refs (the disable sequence
     // above should have removed them, but if a destroy hook racing with

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -1,0 +1,920 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// The University of Illinois/NCSA
+// Open Source License (NCSA)
+//
+// Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Developed by:
+//
+//                 AMD Research and AMD HSA Software Development
+//
+//                 Advanced Micro Devices, Inc.
+//
+//                 www.amd.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal with the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+//  - Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimers.
+//  - Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimers in
+//    the documentation and/or other materials provided with the distribution.
+//  - Neither the names of Advanced Micro Devices, Inc,
+//    nor the names of its contributors may be used to endorse or promote
+//    products derived from this Software without specific prior written
+//    permission.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS WITH THE SOFTWARE.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// HSA-resident firmware-ring drainer with LTTng emission for kernel-dispatch
+// timestamps. Phase A scaffolding (spec 2026-04-27).
+//
+// This file implements:
+//   - The ts_poller control-plane thread (~5 ms tick, idempotent enable /
+//     disable passes per spec §4 lifecycle state machine).
+//   - The ts_drainer data-plane thread (adaptive cadence, snapshot-based
+//     drain per spec §7).
+//   - Per-queue ENABLE / DISABLE sequences (spec §5 ordering).
+//   - The QueueProfilingAcquire / Release refcount API (spec §4a).
+//   - The on_queue_create / on_queue_destroy hooks (spec §4 hooks).
+//
+// PHASE A NOTE (KFD substrate): the AMDKFD_IOC_PROFILER_DISPATCH_LOG ioctl
+// op number defined below is a *placeholder* — the kernel does not yet
+// recognize it (spec §10 dep #2). The init() probe therefore always sets
+// g_substrate_present=false on Phase A, which short-circuits the entire
+// data plane: the poller still ticks, but its enable pass treats every
+// queue as "no-op (substrate absent)" and never spawns the drainer. The
+// scaffolding compiles, links, and runs as a no-op against today's KFD.
+// When the real ioctl number lands, swap AMDKFD_IOC_PROFILER_DISPATCH_LOG
+// for the upstream value and the rest of the data plane is exercised.
+
+#include "core/inc/dispatch_log.h"
+
+#include <cerrno>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#if defined(__linux__)
+#include <fcntl.h>
+#include <linux/types.h>
+#include <unistd.h>
+#endif
+
+#include "core/inc/agent.h"
+#include "core/inc/amd_gpu_agent.h"
+#include "core/inc/queue.h"
+#include "lttng/rocm_trace_emit.h"
+
+namespace rocr {
+namespace dispatch_log {
+
+namespace {
+
+// ============================================================================
+// Phase A KFD ioctl placeholder. See file header note above and spec §10 dep
+// #2. The op number is a plausible scratch value; it is not the upstream
+// AMDKFD_IOC_PROFILER number. The probe at init() expects ENOTSUP / EINVAL
+// from today's kernel and disables the data plane via g_substrate_present.
+// ============================================================================
+#if defined(__linux__)
+
+#ifndef AMDKFD_IOCTL_BASE
+#define AMDKFD_IOCTL_BASE 'K'
+#endif
+
+// Plausible scratch op number. Real upstream allocation TBD.
+struct kfd_profiler_dispatch_log_args {
+  uint32_t op;             // PROBE / ENABLE / DISABLE / QUERY
+  uint32_t flags;
+  uint32_t gpu_id;
+  uint32_t queue_id;
+  uint64_t buffer_gpu_addr;
+  uint64_t buffer_size;
+  uint64_t write_ptr_addr;
+  uint64_t read_ptr_addr;
+  uint64_t generation;
+};
+
+// Op tags carried in kfd_profiler_dispatch_log_args::op.
+enum {
+  KFD_DISPATCH_LOG_OP_PROBE   = 0,
+  KFD_DISPATCH_LOG_OP_ENABLE  = 1,
+  KFD_DISPATCH_LOG_OP_DISABLE = 2,
+  KFD_DISPATCH_LOG_OP_QUERY   = 3,
+};
+
+// Scratch ioctl number 0xFE in the AMDKFD ioctl space. This is a placeholder
+// per spec §10 dep #2; the upstream KFD does not recognize it and will return
+// ENOTSUP / EINVAL, which is the documented Phase A path.
+#define AMDKFD_IOC_PROFILER_DISPATCH_LOG \
+  _IOWR(AMDKFD_IOCTL_BASE, 0xFE, struct kfd_profiler_dispatch_log_args)
+
+// Path used to probe KFD support at init().
+constexpr const char* kKfdDevicePath = "/dev/kfd";
+
+#endif  // __linux__
+
+// ============================================================================
+// Per-queue profiling-bit refcount (spec §4a). Each Queue gets one of these
+// keyed in g_owners; the mutex serializes the refcount RMW + the bit set/clear
+// transition. Phase A uses a side-map keyed on core::Queue* rather than a
+// dl_state pointer hung off the Queue itself; the in-Queue void*
+// dispatch_log_state is reserved for a future refactor.
+// ============================================================================
+struct queue_profiling_owners {
+  std::mutex m;
+  uint32_t   refcount = 0;
+};
+
+// ============================================================================
+// queue_drain_state per spec §7. Held via std::shared_ptr from both the
+// drainer registry (g_active_queues) and per-pass snapshot vectors. The
+// destructor is what frees the ring buffer; freeing happens exactly once,
+// when the last shared_ptr ref is released. Deliberately stores NO Queue*
+// — see spec §4 "Queue / drain-state lifetime" for the dangling-Queue
+// rationale.
+// ============================================================================
+struct queue_drain_state {
+  uint32_t  queue_id = 0;
+
+  // Owned, queue-independent GPU->system time-translation callable.
+  // Captured at register time so it remains callable even after the
+  // underlying core::Queue (and any queue-scoped state on the agent) has
+  // been destroyed. The agent itself outlives any queue created on it
+  // (HSA agents have process lifetime), so capturing the agent reference
+  // by value inside this callable is safe.
+  std::function<uint64_t(uint64_t /* gpu_ts */)> translate_gpu_ts;
+
+  // Buffer ownership.
+  void*    buffer_base = nullptr;     // host-virtual base of the full alloc
+                                      // (header + data area). Freed by the
+                                      // destructor below.
+  size_t   buffer_total_bytes = 0;    // bytes to munmap / free()
+
+  void*    ring_base   = nullptr;     // = buffer_base + DISPATCH_LOG_HEADER_BYTES
+  uint32_t ring_bytes  = 0;           // power-of-2 size of the data area
+  uint32_t ring_mask   = 0;           // ring_bytes - 1
+
+  volatile uint64_t* fw_wptr = nullptr;  // lives in the header at
+                                         // buffer_base + 0; FW-updated.
+
+  uint64_t generation = 0;
+
+  // Mutated only under drain_mu (see below).
+  uint64_t read_cursor = 0;
+  std::unordered_map<uint32_t, uint64_t> pending_starts;
+
+  // Per-queue drain mutex. Serializes drain_one_queue() (steady state) and
+  // ts_drainer_drain_now() (synchronous final drain on the destroying /
+  // disable-edge thread). Per-queue scope, so other queues' drains are not
+  // blocked.
+  std::mutex drain_mu;
+
+  ~queue_drain_state() {
+    if (buffer_base != nullptr && buffer_total_bytes > 0) {
+#if defined(__linux__)
+      ::munmap(buffer_base, buffer_total_bytes);
+#else
+      std::free(buffer_base);
+#endif
+      buffer_base = nullptr;
+    }
+  }
+};
+
+// ============================================================================
+// Global state.
+// ============================================================================
+
+// Spec §4 single source of truth for "should HSA be collecting kernel-dispatch
+// timestamps right now?". Folded predicate of !rocm_trace_disabled() &&
+// lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_complete) &&
+// g_substrate_present. Written only by ts_poller; read by on_queue_create
+// (relaxed, hot path) and ts_drainer.
+std::atomic<bool> G_tracepoint_enabled{false};
+
+// Set true once at init() if the KFD substrate probe succeeds. Phase A: this
+// stays false because the placeholder ioctl is unknown to today's KFD.
+std::atomic<bool> g_substrate_present{false};
+
+// Phase A: latched true after we log the "substrate absent, tracepoint enable
+// is a no-op" message once. Avoids spamming the user log on every poll tick.
+std::atomic<bool> g_substrate_absent_warned{false};
+
+// Driven by shutdown(); poller and drainer observe and exit.
+std::atomic<bool> g_shutdown{false};
+
+// Spec §4 lifecycle mutex. Guards g_active_queues + g_no_dispatch_log_agents.
+// Acquired only briefly: enable/disable per-queue and snapshot-cloning.
+std::mutex g_lifecycle_mu;
+
+// Drainer registry (spec §4 lifetime protocol). Keyed by queue_id (the value
+// FW writes into the record dispatch_idx is per-queue, so queue_id distinguishes
+// drains). Holds one shared_ptr per active queue.
+std::unordered_map<uint32_t, std::shared_ptr<queue_drain_state>> g_active_queues;
+
+// Side-map for the QueueProfilingAcquire/Release refcount (spec §4a). One
+// entry per Queue* that has ever had at least one acquire. Looked up under
+// g_owners_mu.
+std::mutex g_owners_mu;
+std::unordered_map<core::Queue*, std::unique_ptr<queue_profiling_owners>> g_owners;
+
+// Per-agent "no-dispatch-log" mark. If the KFD ioctl returns ENOTSUP for any
+// queue on a given agent, that agent is added here and subsequent
+// enable_dispatch_log_for_queue calls on queues belonging to it short-circuit
+// (spec §5 unsupported-agent row, §9 unsupported-agent row).
+std::unordered_set<core::Agent*> g_no_dispatch_log_agents;
+
+// KFD fd held open for the lifetime of the runtime. -1 if probe failed.
+int g_kfd_fd = -1;
+
+// Threads.
+std::thread g_poller_thread;
+std::thread g_drainer_thread;
+std::atomic<bool> g_drainer_running{false};
+
+// Drainer wakeup CV. Used to long-sleep (50 ms) when G_tracepoint_enabled is
+// false and short-sleep (500 us) on idle. Notified on shutdown.
+std::mutex g_drainer_mu;
+std::condition_variable g_drainer_cv;
+
+// Monotonically incremented for every per-queue ENABLE so a stale FW write
+// to a freed buffer is detectable on the host side.
+std::atomic<uint64_t> g_generation_counter{1};
+
+// ============================================================================
+// Helpers.
+// ============================================================================
+
+uint32_t queue_id_of(core::Queue* q) {
+  // amd_queue_t.hsa_queue.id is set in the queue ctor (see e.g.
+  // amd_aql_queue.cpp:298, host_queue.cpp:77).
+  return static_cast<uint32_t>(q->amd_queue_.hsa_queue.id);
+}
+
+bool agent_is_gpu(core::Agent* a) {
+  return a != nullptr && a->device_type() == core::Agent::kAmdGpuDevice;
+}
+
+// Build the GPU->system translation callable from the Queue's owning agent.
+// Captures the agent pointer by value; agents have process lifetime so this
+// is safe even after the queue is destroyed (spec §7).
+std::function<uint64_t(uint64_t)> make_translate_gpu_ts(core::Queue* q) {
+  core::Agent* agent = q->GetAgent();
+  if (!agent_is_gpu(agent)) {
+    // Non-GPU (CPU / soft) queue. Pass-through; we shouldn't be enabling on
+    // these at all, but be defensive.
+    return [](uint64_t t) { return t; };
+  }
+  auto* gpu = static_cast<AMD::GpuAgentInt*>(agent);
+  return [gpu](uint64_t gpu_ts) -> uint64_t {
+    return gpu->TranslateTime(gpu_ts);
+  };
+}
+
+#if defined(__linux__)
+bool kfd_open_and_probe() {
+  if (g_kfd_fd != -1) return true;
+  int fd = ::open(kKfdDevicePath, O_RDWR | O_CLOEXEC);
+  if (fd < 0) {
+    return false;
+  }
+  // Probe: zero-arg PROBE call. The Phase A ioctl is unknown to today's KFD
+  // and will return -1 / ENOTSUP / EINVAL; that is the documented Phase A
+  // result. If a future KFD recognizes the op, it should return 0.
+  struct kfd_profiler_dispatch_log_args args = {};
+  args.op    = KFD_DISPATCH_LOG_OP_PROBE;
+  args.flags = 0;
+  int rc = ::ioctl(fd, AMDKFD_IOC_PROFILER_DISPATCH_LOG, &args);
+  if (rc != 0) {
+    // Substrate absent — don't keep the fd around either. We use the runtime's
+    // own KFD fd for any future per-queue ioctls, so closing this probe fd is
+    // fine.
+    ::close(fd);
+    g_kfd_fd = -1;
+    return false;
+  }
+  g_kfd_fd = fd;
+  return true;
+}
+#else
+bool kfd_open_and_probe() { return false; }
+#endif
+
+// Issue an ENABLE / DISABLE ioctl. Returns 0 on success, errno on failure.
+int kfd_dispatch_log_op(uint32_t op, core::Queue* q,
+                        uint64_t buffer_gpu_addr, uint64_t buffer_size,
+                        uint64_t write_ptr_addr, uint64_t generation) {
+#if defined(__linux__)
+  if (g_kfd_fd < 0) return ENOTSUP;
+  struct kfd_profiler_dispatch_log_args args = {};
+  args.op              = op;
+  args.flags           = 0;
+  // gpu_id: derive from agent if a GPU agent. Phase A leaves zero on failure.
+  args.gpu_id          = 0;
+  args.queue_id        = queue_id_of(q);
+  args.buffer_gpu_addr = buffer_gpu_addr;
+  args.buffer_size     = buffer_size;
+  args.write_ptr_addr  = write_ptr_addr;
+  args.read_ptr_addr   = 0;  // host-managed locally
+  args.generation      = generation;
+  if (::ioctl(g_kfd_fd, AMDKFD_IOC_PROFILER_DISPATCH_LOG, &args) != 0) {
+    return errno != 0 ? errno : ENOTSUP;
+  }
+  return 0;
+#else
+  (void)op; (void)q; (void)buffer_gpu_addr; (void)buffer_size;
+  (void)write_ptr_addr; (void)generation;
+  return ENOTSUP;
+#endif
+}
+
+// Allocate the per-queue ring buffer. Phase A: page-aligned anonymous mmap.
+// In a future revision this should use the existing pinned-host allocator
+// from the agent so the buffer is GPU-visible without an explicit pin
+// (mirroring the AQL queue ring allocation pattern). The buffer total size
+// is DISPATCH_LOG_HEADER_BYTES + DISPATCH_LOG_RING_BYTES.
+struct ring_alloc_t {
+  void*  base;
+  size_t total_bytes;
+};
+ring_alloc_t alloc_ring_buffer() {
+  const size_t total = DISPATCH_LOG_HEADER_BYTES + DISPATCH_LOG_RING_BYTES;
+  ring_alloc_t out{nullptr, 0};
+#if defined(__linux__)
+  void* p = ::mmap(nullptr, total, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (p == MAP_FAILED) return out;
+  std::memset(p, 0, total);
+  out.base        = p;
+  out.total_bytes = total;
+#else
+  void* p = std::calloc(1, total);
+  if (p == nullptr) return out;
+  out.base        = p;
+  out.total_bytes = total;
+#endif
+  return out;
+}
+
+void free_ring_buffer(ring_alloc_t& a) {
+  if (a.base == nullptr) return;
+#if defined(__linux__)
+  ::munmap(a.base, a.total_bytes);
+#else
+  std::free(a.base);
+#endif
+  a.base = nullptr;
+  a.total_bytes = 0;
+}
+
+// Snapshot: clone shared_ptrs out of g_active_queues under the lifecycle
+// mutex, return the vector. Drainer then iterates without holding the mutex.
+std::vector<std::shared_ptr<queue_drain_state>> snapshot_active_queues() {
+  std::vector<std::shared_ptr<queue_drain_state>> out;
+  std::lock_guard<std::mutex> lk(g_lifecycle_mu);
+  out.reserve(g_active_queues.size());
+  for (auto& kv : g_active_queues) out.push_back(kv.second);
+  return out;
+}
+
+// ============================================================================
+// drain_one_queue (spec §7). Holds qs.drain_mu for the entire pass.
+// ============================================================================
+
+bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
+  std::lock_guard<std::mutex> lk(qs.drain_mu);
+
+  if (qs.fw_wptr == nullptr) return false;
+
+  const uint64_t fw_wptr = __atomic_load_n(qs.fw_wptr, __ATOMIC_ACQUIRE);
+  if (fw_wptr == qs.read_cursor) return false;
+
+  // Wraparound check (spec §6 bytes_lost field definition).
+  if (fw_wptr - qs.read_cursor > qs.ring_bytes) {
+    rocm_trace_emit_hsa_kernel_dispatch_drop(qs.queue_id,
+                                             fw_wptr - qs.read_cursor);
+    qs.read_cursor = fw_wptr - qs.ring_bytes;
+  }
+
+  while (qs.read_cursor < fw_wptr) {
+    const auto* rec = reinterpret_cast<const mec_dispatch_record_16*>(
+        static_cast<const char*>(qs.ring_base) +
+        (qs.read_cursor & qs.ring_mask));
+
+    const uint64_t gpu_ts =
+        (static_cast<uint64_t>(rec->ts_hi) << 32) | rec->ts_lo;
+
+    if (rec->record_type == DISPATCH_LOG_RECORD_START) {
+      qs.pending_starts[rec->dispatch_idx] = gpu_ts;
+    } else if (rec->record_type == DISPATCH_LOG_RECORD_END) {
+      auto it = qs.pending_starts.find(rec->dispatch_idx);
+      if (it != qs.pending_starts.end()) {
+        const uint64_t start_gpu = it->second;
+        const uint32_t didx = rec->dispatch_idx;
+        qs.pending_starts.erase(it);
+
+        // Use the captured queue-independent translation callable. Spec §7
+        // explicitly forbids reaching through a Queue* here — Queue may be
+        // destroyed mid-pass even though the shared_ptr keeps qs alive.
+        const uint64_t start_sys = qs.translate_gpu_ts(start_gpu);
+        const uint64_t end_sys   = qs.translate_gpu_ts(gpu_ts);
+
+        rocm_trace_emit_hsa_kernel_dispatch_complete(
+            qs.queue_id, didx, start_sys, end_sys, force_emit);
+      }
+      // else: orphan END (start was lost to wraparound). Silently skip.
+    }
+
+    qs.read_cursor += sizeof(mec_dispatch_record_16);
+  }
+  return true;
+}
+
+// Synchronous final drain on the calling thread. Looks up the queue's
+// shared_ptr from the registry and forwards to drain_one_queue with
+// force_emit=true. Per spec §4: serialization with the drainer thread
+// happens via qs.drain_mu inside drain_one_queue.
+void ts_drainer_drain_now(core::Queue* q) {
+  std::shared_ptr<queue_drain_state> qs_ptr;
+  {
+    std::lock_guard<std::mutex> lk(g_lifecycle_mu);
+    auto it = g_active_queues.find(queue_id_of(q));
+    if (it == g_active_queues.end()) return;
+    qs_ptr = it->second;
+  }
+  if (qs_ptr) {
+    drain_one_queue(*qs_ptr, /* force_emit = */ true);
+  }
+}
+
+// ============================================================================
+// Bounded wait_for_idle. Spec §4 bounds at 100 ms. Polls the queue's read
+// index against its write index. Returns when the queue is idle or the
+// budget elapses.
+// ============================================================================
+void wait_for_idle(core::Queue* q) {
+  using clock = std::chrono::steady_clock;
+  const auto deadline = clock::now() + std::chrono::milliseconds(100);
+  while (clock::now() < deadline) {
+    const uint64_t r = q->LoadReadIndexAcquire();
+    const uint64_t w = q->LoadWriteIndexAcquire();
+    if (r >= w) return;
+    std::this_thread::sleep_for(std::chrono::microseconds(200));
+  }
+}
+
+// ============================================================================
+// Profiling-bit refcount (spec §4a).
+// ============================================================================
+
+queue_profiling_owners* get_or_create_owners(core::Queue* q) {
+  // Caller holds g_owners_mu.
+  auto it = g_owners.find(q);
+  if (it != g_owners.end()) return it->second.get();
+  auto inserted = g_owners.emplace(
+      q, std::unique_ptr<queue_profiling_owners>(new queue_profiling_owners()));
+  return inserted.first->second.get();
+}
+
+}  // namespace
+
+hsa_status_t QueueProfilingAcquire(core::Queue* q) {
+  if (q == nullptr) return HSA_STATUS_ERROR_INVALID_QUEUE;
+  queue_profiling_owners* owners = nullptr;
+  {
+    std::lock_guard<std::mutex> lk(g_owners_mu);
+    owners = get_or_create_owners(q);
+  }
+  std::lock_guard<std::mutex> lk(owners->m);
+  const uint32_t prev = owners->refcount;
+  owners->refcount = prev + 1;
+  if (prev == 0) {
+    // 0->1 transition: set the bit via the existing API. SetProfiling()
+    // forwards to AMD_HSA_BITS_SET on amd_queue_.queue_properties (the
+    // GPU-visible bit) and is the same path hsa_amd_profiling_set_profiler_enabled
+    // takes today (see queue.h:446 / amd_aql_queue.cpp:1559).
+    q->SetProfiling(true);
+  }
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t QueueProfilingRelease(core::Queue* q) {
+  if (q == nullptr) return HSA_STATUS_ERROR_INVALID_QUEUE;
+  queue_profiling_owners* owners = nullptr;
+  {
+    std::lock_guard<std::mutex> lk(g_owners_mu);
+    auto it = g_owners.find(q);
+    if (it == g_owners.end()) {
+      // Underflow without ever acquiring. Caller bug; spec §4a says return
+      // failure without modifying state.
+      return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+    }
+    owners = it->second.get();
+  }
+  std::lock_guard<std::mutex> lk(owners->m);
+  if (owners->refcount == 0) {
+    // Underflow: caller bug.
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+  owners->refcount -= 1;
+  if (owners->refcount == 0) {
+    q->SetProfiling(false);
+  }
+  return HSA_STATUS_SUCCESS;
+}
+
+namespace {
+
+// ============================================================================
+// Per-queue ENABLE / DISABLE sequences (spec §5).
+//
+// enable_dispatch_log_for_queue runs the per-queue all-or-nothing sequence:
+//   1. alloc buffer
+//   2. QueueProfilingAcquire (sets the bit if 0->1)
+//   3. KFD ioctl ENABLE
+//   4..6. (queue unmap/remap and MQD propagation are KFD-side; the ioctl
+//         encapsulates them)
+//   7. register in g_active_queues
+//
+// Each step has its own unwind on failure. On any failure: free buffer,
+// release any acquired profiling ref, leave dispatch_log_active=false, log
+// once-per-queue at WARNING.
+// ============================================================================
+
+void enable_dispatch_log_for_queue(core::Queue* q) {
+  if (q == nullptr) return;
+
+  // Idempotence guard: skip if already active.
+  if (q->dispatch_log_active.load(std::memory_order_relaxed)) return;
+
+  // Only meaningful for GPU agents — host/soft queues have no MEC firmware
+  // to write records, so the KFD ioctl would either be rejected or be a
+  // no-op. Skip them outright.
+  if (!agent_is_gpu(q->GetAgent())) return;
+
+  // Phase A short-circuit: substrate absent.
+  if (!g_substrate_present.load(std::memory_order_relaxed)) return;
+
+  // Per-agent "no-dispatch-log" filter.
+  {
+    std::lock_guard<std::mutex> lk(g_lifecycle_mu);
+    if (g_no_dispatch_log_agents.count(q->GetAgent()) > 0) return;
+  }
+
+  // Step 1: alloc.
+  ring_alloc_t alloc = alloc_ring_buffer();
+  if (alloc.base == nullptr) {
+    std::fprintf(stderr,
+                 "[hsa-runtime] dispatch_log: queue_id=%u ENABLE step 1 (alloc) "
+                 "failed errno=%d\n",
+                 queue_id_of(q), errno);
+    return;
+  }
+
+  const uint64_t generation = g_generation_counter.fetch_add(
+      1, std::memory_order_relaxed);
+
+  // Initialize the header now (host-side write before KFD publishes the
+  // buffer to FW). Layout per spec §5.
+  auto* hdr = reinterpret_cast<dispatch_log_header*>(alloc.base);
+  hdr->fw_wptr    = 0;
+  hdr->generation = generation;
+  hdr->version    = DISPATCH_LOG_VERSION;
+  std::memset(hdr->reserved, 0, sizeof(hdr->reserved));
+
+  // Step 2: acquire profiling ref FIRST (spec §5 ordering rationale).
+  hsa_status_t s = QueueProfilingAcquire(q);
+  if (s != HSA_STATUS_SUCCESS) {
+    std::fprintf(stderr,
+                 "[hsa-runtime] dispatch_log: queue_id=%u ENABLE step 2 "
+                 "(QueueProfilingAcquire) failed status=%d\n",
+                 queue_id_of(q), static_cast<int>(s));
+    free_ring_buffer(alloc);
+    return;
+  }
+
+  // Step 3: KFD ioctl ENABLE. buffer_gpu_addr points at the data area
+  // (after the header). Phase A: this currently always returns ENOTSUP
+  // since the substrate is absent — but g_substrate_present should have
+  // been false above and we'd have early-returned. Defense in depth:
+  // if we reach here the probe lied. Treat any failure as a per-queue
+  // failure per spec §5.
+  //
+  // NOTE: this Phase A scaffolding passes the host virtual address as the
+  // GPU address. Real implementation must pin the buffer via the existing
+  // HSA pinned-host allocator and pass the GPU-visible address. That hookup
+  // is left for Phase B once a real substrate exists.
+  const uint64_t host_base = reinterpret_cast<uint64_t>(alloc.base);
+  const int rc = kfd_dispatch_log_op(
+      KFD_DISPATCH_LOG_OP_ENABLE, q,
+      host_base + DISPATCH_LOG_HEADER_BYTES,    // FW data area base
+      DISPATCH_LOG_RING_BYTES,                  // data area size
+      host_base + 0,                            // fw_wptr lives in header
+      generation);
+  if (rc != 0) {
+    std::fprintf(stderr,
+                 "[hsa-runtime] dispatch_log: queue_id=%u ENABLE step 3 "
+                 "(KFD ioctl) failed errno=%d\n",
+                 queue_id_of(q), rc);
+    if (rc == ENOTSUP) {
+      std::lock_guard<std::mutex> lk(g_lifecycle_mu);
+      g_no_dispatch_log_agents.insert(q->GetAgent());
+    }
+    QueueProfilingRelease(q);
+    free_ring_buffer(alloc);
+    return;
+  }
+
+  // Step 7: register in the drainer registry.
+  auto qs = std::make_shared<queue_drain_state>();
+  qs->queue_id           = queue_id_of(q);
+  qs->translate_gpu_ts   = make_translate_gpu_ts(q);
+  qs->buffer_base        = alloc.base;
+  qs->buffer_total_bytes = alloc.total_bytes;
+  qs->ring_base          = static_cast<char*>(alloc.base) + DISPATCH_LOG_HEADER_BYTES;
+  qs->ring_bytes         = static_cast<uint32_t>(DISPATCH_LOG_RING_BYTES);
+  qs->ring_mask          = qs->ring_bytes - 1;
+  qs->fw_wptr            = &hdr->fw_wptr;
+  qs->generation         = generation;
+  qs->read_cursor        = 0;
+
+  {
+    std::lock_guard<std::mutex> lk(g_lifecycle_mu);
+    g_active_queues[qs->queue_id] = qs;
+  }
+
+  // Ownership of the buffer now lives in qs (shared_ptr destructor frees it).
+  // Suppress the local alloc bookkeeping so a later free_ring_buffer on
+  // `alloc` would be a no-op.
+  alloc.base        = nullptr;
+  alloc.total_bytes = 0;
+
+  q->dispatch_log_active.store(true, std::memory_order_release);
+}
+
+void disable_dispatch_log_for_queue(core::Queue* q) {
+  if (q == nullptr) return;
+  if (!q->dispatch_log_active.load(std::memory_order_acquire)) return;
+
+  // Spec §4 disable-edge per-queue sequence.
+
+  // a. wait_for_idle (bounded ≤ 100 ms).
+  wait_for_idle(q);
+
+  // b. Final drain with force_emit=true (spec §6).
+  ts_drainer_drain_now(q);
+
+  // c. KFD ioctl DISABLE (best-effort).
+  (void)kfd_dispatch_log_op(KFD_DISPATCH_LOG_OP_DISABLE, q,
+                            /*buffer_gpu_addr=*/0, /*buffer_size=*/0,
+                            /*write_ptr_addr=*/0, /*generation=*/0);
+
+  // d. Release profiling ref (clears the bit only if 1->0).
+  QueueProfilingRelease(q);
+
+  // e. Unregister from drainer registry. Drops the registry's shared_ptr
+  //    ref. Buffer free is gated by shared_ptr destructor — if a drainer
+  //    snapshot still holds a ref the destructor fires when that snapshot
+  //    vector is destroyed (spec §4 lifetime protocol).
+  {
+    std::lock_guard<std::mutex> lk(g_lifecycle_mu);
+    g_active_queues.erase(queue_id_of(q));
+  }
+
+  q->dispatch_log_active.store(false, std::memory_order_release);
+}
+
+// ============================================================================
+// ts_drainer_loop (spec §7).
+// ============================================================================
+
+void ts_drainer_loop() {
+  while (!g_shutdown.load(std::memory_order_relaxed)) {
+    if (!G_tracepoint_enabled.load(std::memory_order_relaxed)) {
+      std::unique_lock<std::mutex> lk(g_drainer_mu);
+      g_drainer_cv.wait_for(lk, std::chrono::milliseconds(50));
+      continue;
+    }
+
+    bool any_progress = false;
+    auto snapshot = snapshot_active_queues();
+    for (auto& qs_ptr : snapshot) {
+      any_progress |= drain_one_queue(*qs_ptr, /* force_emit = */ false);
+    }
+
+    if (any_progress) {
+      std::this_thread::yield();
+    } else {
+      std::this_thread::sleep_for(std::chrono::microseconds(500));
+    }
+  }
+}
+
+void start_drainer_if_needed() {
+  bool expected = false;
+  if (!g_drainer_running.compare_exchange_strong(expected, true)) return;
+  g_drainer_thread = std::thread(ts_drainer_loop);
+}
+
+// ============================================================================
+// ts_poller_loop (spec §4 lifecycle state machine).
+//
+// Every 5 ms:
+//   1. Compute curr = !rocm_trace_disabled() && lttng_ust_tracepoint_enabled
+//                     (rocm_hsa, kernel_dispatch_complete) && g_substrate_present.
+//   2. Store G_tracepoint_enabled = curr.
+//   3. If curr=true: spawn drainer if needed; iterate registered queues,
+//      enable any not-yet-active.
+//   4. If curr=false: iterate registered queues, disable any still-active.
+//
+// Both branches run every tick (idempotent, not edge-triggered) — this is
+// the convergence guarantee for the queue-create-vs-disable race
+// (spec §4 "Queue-create vs. disable-pass race").
+// ============================================================================
+
+bool predicate_now() {
+#if defined(HSA_ENABLE_LTTNG_UST) && HSA_ENABLE_LTTNG_UST
+  if (rocm_trace_disabled()) return false;
+  if (!g_substrate_present.load(std::memory_order_relaxed)) {
+    // Phase A: log once that the substrate is missing so the user knows
+    // why an enabled tracepoint produces no events.
+    if (lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_complete)) {
+      bool warned = g_substrate_absent_warned.load(std::memory_order_relaxed);
+      if (!warned && g_substrate_absent_warned.compare_exchange_strong(
+                         warned, true)) {
+        std::fprintf(stderr,
+                     "[hsa-runtime] dispatch_log: tracepoint "
+                     "rocm_hsa:kernel_dispatch_complete is enabled, but the "
+                     "KFD substrate (AMDKFD_IOC_PROFILER_DISPATCH_LOG) is not "
+                     "available on this kernel. No events will be produced. "
+                     "(Phase A scaffolding; see spec §10 dep #2.)\n");
+      }
+    }
+    return false;
+  }
+  return lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_complete) != 0;
+#else
+  return false;
+#endif
+}
+
+void ts_poller_loop() {
+  using clock = std::chrono::steady_clock;
+  const auto tick_interval = std::chrono::milliseconds(5);
+
+  while (!g_shutdown.load(std::memory_order_relaxed)) {
+    const bool curr = predicate_now();
+    G_tracepoint_enabled.store(curr, std::memory_order_relaxed);
+
+    if (curr) {
+      start_drainer_if_needed();
+
+      // Snapshot Queue* set under the lifecycle mutex; we don't have a
+      // direct registry of all live queues independent of g_active_queues,
+      // so the enable pass relies on on_queue_create having seeded each
+      // newly-created queue. Already-active queues are skipped (idempotent).
+      // The on_queue_create hook does the heavy lifting; this branch's
+      // only remaining job is to flip the drainer on so it starts consuming.
+      // Nothing to iterate here without an external "all queues" list.
+      // (Spec §4: "for each existing Q with dispatch_log_active==false:
+      //  enable_dispatch_log_for_queue(Q)" — see Phase A note below.)
+      //
+      // Phase A LIMITATION: we do not currently maintain a registry of all
+      // *live* queues, only of all *active* (already-enabled) queues. The
+      // enable pass therefore cannot retroactively enable queues that were
+      // created BEFORE the enable edge. Spec §1 already documents this as
+      // the "post-enable dispatches only" semantics; queues that exist at
+      // enable time will not be retroactively enabled and their pre-enable
+      // dispatches simply produce no records. Queues created AFTER the
+      // enable edge are picked up via on_queue_create. A future revision
+      // can add a global "all live queues" registry to close this gap;
+      // it requires a hook in queue.cpp's base ctor/dtor.
+    } else {
+      // Disable pass: spec §4 says "for each Q with dispatch_log_active:
+      // wait_for_idle, drain, KFD DISABLE, QueueProfilingRelease, mark
+      // inactive". This requires real Queue* values to call SetProfiling /
+      // wait_for_idle on, but g_active_queues is intentionally keyed by
+      // queue_id and stores no Queue* (spec §7 dangling-Queue prohibition).
+      //
+      // PHASE A LIMITATION: without a separate "queue_id -> Queue*" side
+      // map, the poller's disable-edge pass is a no-op. Cleanup still
+      // happens via on_queue_destroy when the queue is eventually
+      // destroyed, and on Phase A this is moot anyway because
+      // g_substrate_present is false (no queues ever become active).
+      //
+      // Wiring the disable pass requires either (a) a side map populated
+      // alongside g_active_queues, where Queue* lifetime is co-managed
+      // with the registry entry under g_lifecycle_mu, or (b) extending
+      // queue_drain_state with a weak handle that the disable path can
+      // upgrade only when the Queue is still alive. Both are deferred
+      // to Phase B per spec §13.
+    }
+
+    // Sleep until next tick.
+    std::this_thread::sleep_for(tick_interval);
+  }
+}
+
+}  // namespace
+
+// ============================================================================
+// Public API.
+// ============================================================================
+
+void init() {
+  // KFD substrate probe. Phase A: this is expected to fail.
+  const bool present = kfd_open_and_probe();
+  g_substrate_present.store(present, std::memory_order_release);
+
+  // Spawn poller unconditionally so the steady-state idle path is exercised
+  // even on Phase A (substrate absent). The poller's enable branch
+  // short-circuits via predicate_now() → false when substrate is missing.
+  g_shutdown.store(false, std::memory_order_relaxed);
+  g_poller_thread = std::thread(ts_poller_loop);
+}
+
+void shutdown() {
+  g_shutdown.store(true, std::memory_order_release);
+  g_drainer_cv.notify_all();
+
+  if (g_poller_thread.joinable()) g_poller_thread.join();
+  if (g_drainer_thread.joinable()) g_drainer_thread.join();
+  g_drainer_running.store(false, std::memory_order_relaxed);
+
+  // Clear any remaining active-queue entries. By process-exit time the
+  // queue-destroy hooks should have converged, but be defensive: drop the
+  // registry's shared_ptr refs so the destructors free the buffers.
+  {
+    std::lock_guard<std::mutex> lk(g_lifecycle_mu);
+    g_active_queues.clear();
+    g_no_dispatch_log_agents.clear();
+  }
+  {
+    std::lock_guard<std::mutex> lk(g_owners_mu);
+    g_owners.clear();
+  }
+
+#if defined(__linux__)
+  if (g_kfd_fd >= 0) {
+    ::close(g_kfd_fd);
+    g_kfd_fd = -1;
+  }
+#endif
+}
+
+void on_queue_create(core::Queue* q) {
+  if (q == nullptr) return;
+
+  // Spec §4 queue-create hot path: relaxed load, no lifecycle mutex.
+  // The queue-create-vs-disable race is resolved by the idempotent disable
+  // convergence guarantee (every poll tick under curr=false runs the
+  // disable pass), not by additional locking here.
+  if (G_tracepoint_enabled.load(std::memory_order_relaxed)) {
+    enable_dispatch_log_for_queue(q);
+  }
+}
+
+void on_queue_destroy(core::Queue* q) {
+  if (q == nullptr) return;
+  if (q->dispatch_log_active.load(std::memory_order_acquire)) {
+    disable_dispatch_log_for_queue(q);
+  }
+
+  // Drop the per-queue refcount entry. Safe to do unconditionally — if the
+  // queue never had an acquire, the lookup is just a miss.
+  {
+    std::lock_guard<std::mutex> lk(g_owners_mu);
+    g_owners.erase(q);
+  }
+}
+
+}  // namespace dispatch_log
+}  // namespace rocr

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -621,8 +621,13 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     if ((end - start) > qs.ring_records) {
       if (!initial_sync) {
         const uint64_t lost = (end - start) - qs.ring_records;
+        // force_emit propagated so the disable-edge final drain
+        // (drain_one_queue invoked with force_emit=true) emits the drop
+        // event even after the user has disabled the tracepoint.
+        // Without this, post-disable record batches would arrive with a
+        // silently-dropped gap and no consumer-visible explanation.
         rocm_trace_emit_hsa_kernel_dispatch_drop(
-            queue_id_to_wire(qs.queue_id), lost);
+            queue_id_to_wire(qs.queue_id), lost, force_emit);
       }
       start = end - qs.ring_records;
       // Overrun moved us forward — quarantine is no longer relevant
@@ -759,8 +764,13 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
               // i again.
               --i;
             } else {
+              // force_emit propagated for the same reason as the overrun
+              // path above: the stale-zero-prefix sweep can fire from
+              // inside the disable-edge final drain, and we must not
+              // silently drop the gap notification when the user has
+              // already disabled the tracepoint.
               rocm_trace_emit_hsa_kernel_dispatch_drop(
-                  queue_id_to_wire(qs.queue_id), stale_count);
+                  queue_id_to_wire(qs.queue_id), stale_count, force_emit);
               qs.next_idx = stale_end;
               if (qs.rptr_ptr) {
                 __atomic_store_n(qs.rptr_ptr, stale_end, __ATOMIC_RELEASE);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -627,6 +627,26 @@ void disable_dispatch_log_for_queue_locked(core::Queue* q) {
   if (!q->dispatch_log_active.load(std::memory_order_acquire)) return;
 
   // Spec §4 disable-edge per-queue sequence.
+  //
+  // C2 fix: ordering between final-drain, drainer-snapshot poisoning,
+  // registry erase, and buffer release is critical. queue_drain_state
+  // stores NON-OWNING pointers into a buffer owned by AqlQueue; once
+  // QueueProfilingRelease triggers SetProfiling(false) the buffer is
+  // freed. A snapshot held by the drainer thread (snapshot_active_queues)
+  // pins the queue_drain_state alive but does NOT pin the buffer, so
+  // the drainer could dereference freed memory in drain_one_queue.
+  //
+  // We close that window by poisoning the snapshot-visible pointers
+  // under qs->drain_mu, then erasing from g_active_queues, and only
+  // then calling QueueProfilingRelease (which frees the buffer):
+  //
+  //   - drain_one_queue takes drain_mu first thing, then early-returns
+  //     on ring_base==nullptr || record_count==0. Any drainer that
+  //     hasn't started its pass for this queue yet will exit early.
+  //   - Any drainer already inside drain_one_queue holds drain_mu, so
+  //     the poisoning step blocks until it completes its current pass.
+  //     The buffer is not yet freed at that point (we haven't released
+  //     yet), so that pass is safe to finish.
 
   // a. wait_for_idle (bounded ≤ 100 ms).
   wait_for_idle(q);
@@ -634,17 +654,37 @@ void disable_dispatch_log_for_queue_locked(core::Queue* q) {
   // b. Final drain with force_emit=true (spec §6).
   ts_drainer_drain_now_locked(q);
 
-  // c. Release profiling ref. On the 1->0 edge AqlQueue::SetProfiling(false)
-  // clears the KFD profiling-buffer registration (UPDATE_QUEUE with addr=0)
-  // and frees the per-queue dispatch-record buffer. QueueProfilingRelease
-  // takes g_owners_mu, NOT g_lifecycle_mu.
-  QueueProfilingRelease(q);
+  // c. Look up the registered drain-state shared_ptr. After this we hold
+  //    a local ref so qs survives even after the registry erase below.
+  std::shared_ptr<queue_drain_state> qs_ptr;
+  {
+    auto it = g_active_queues.find(queue_id_of(q));
+    if (it != g_active_queues.end()) qs_ptr = it->second;
+  }
 
-  // d. Unregister from drainer registry. Drops the registry's shared_ptr
-  //    ref. The buffer is owned by AqlQueue (we just released it via
-  //    SetProfiling(false)); our queue_drain_state holds only non-owning
-  //    pointers, so the destructor is a no-op for buffer memory.
+  // d. Poison the non-owning pointers under drain_mu so any drainer
+  //    snapshot still in flight will exit drain_one_queue early. The
+  //    drain_mu acquire serializes with any in-progress drain pass.
+  if (qs_ptr) {
+    std::lock_guard<std::mutex> lk(qs_ptr->drain_mu);
+    qs_ptr->ring_base       = nullptr;
+    qs_ptr->fw_wptr_records = nullptr;
+    qs_ptr->record_count    = 0;
+    qs_ptr->record_mask     = 0;
+  }
+
+  // e. Unregister from drainer registry. Drops the registry's shared_ptr
+  //    ref. Any in-flight drainer snapshot still holds its own ref to
+  //    qs_ptr but its ring_base/fw_wptr_records are now nullptr.
   g_active_queues.erase(queue_id_of(q));
+
+  // f. Release profiling ref. On the 1->0 edge AqlQueue::SetProfiling(false)
+  //    clears the KFD profiling-buffer registration (UPDATE_QUEUE with
+  //    addr=0) and frees the per-queue dispatch-record buffer.
+  //    QueueProfilingRelease takes g_owners_mu, NOT g_lifecycle_mu.
+  //    By this point no drainer can dereference the buffer because
+  //    every snapshot's qs->ring_base is nullptr.
+  QueueProfilingRelease(q);
 
   q->dispatch_log_active.store(false, std::memory_order_release);
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -446,15 +446,24 @@ constexpr size_t kSlotStride = 16;
 // batching.
 constexpr uint32_t kBatchMax = 256;
 
-// Stale-zero quarantine threshold (debate stage code-quality C8). Path A
-// stops at the first record_type==0 inside [next_idx, observed) to handle
-// either a pre-zeroed stale slot OR a multi-XCC publish-race in-flight
-// slot. After this many milliseconds of being stalled at the SAME
-// (observed, next_idx) coordinate with no forward progress, the drainer
-// declares the slot stale, emits a kernel_dispatch_drop event for it,
-// and advances past it. 100 ms aligns with the wait_for_idle bound and
-// is ~100x the worker's max sleep cadence (1 ms), so a real in-flight
-// XCC publish would commit well before this fires in practice.
+// Stale-zero quarantine threshold (debate stage code-quality C8/C10).
+// Path A stops at the first record_type==0 inside [next_idx, observed)
+// to handle either a pre-zeroed stale slot OR a multi-XCC publish-race
+// in-flight slot. After this many milliseconds of being stalled at the
+// SAME (observed, next_idx) coordinate with no forward progress, the
+// drainer declares the slot stale and sweeps the contiguous stale-zero
+// prefix forward in one pass, emitting a single aggregate
+// kernel_dispatch_drop event covering the whole gap (see C10 logic in
+// drain_one_queue Path A below).
+//
+// 100 ms aligns with the wait_for_idle bound and is ~100x the worker's
+// max sleep cadence (1 ms), so a real in-flight XCC publish would
+// commit well before this fires in practice. Only ONE quarantine
+// timeout is paid per stale prefix (regardless of prefix length),
+// which bounds the worst-case time-to-first-record on the huge
+// persisted-counter overrun case (scratch wptr in the millions, FW
+// writes a few fresh records → ring-sized stale prefix before the
+// fresh records).
 constexpr int64_t kStaleZeroQuarantineMs = 100;
 
 bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
@@ -578,10 +587,15 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     //   - Stale-zero quarantine: track (stall_observed, stall_idx,
     //     stall_first_seen). If a subsequent pass sees the same
     //     coordinate AND has been stalled for kStaleZeroQuarantineMs,
-    //     declare the slot stale, emit a one-record
-    //     kernel_dispatch_drop event for visibility, advance next_idx
-    //     by 1, clear the quarantine. This guarantees forward progress
-    //     without silently dropping in-flight publishes.
+    //     declare the slot stale, sweep the contiguous stale-zero
+    //     prefix forward in this same pass (C10), emit ONE aggregate
+    //     kernel_dispatch_drop event covering the whole gap, advance
+    //     next_idx past the prefix, and clear the quarantine. This
+    //     guarantees forward progress in O(prefix-length) memcpy +
+    //     compare per stale prefix (not per slot) without silently
+    //     dropping in-flight publishes; if the sweep stops at a real
+    //     record, the main loop continues processing it in the same
+    //     pass.
     //   - The worker loop honors qs.pending_zero_stall.load() and
     //     skips its signal-equal fast-skip while quarantine is armed,
     //     so the next pass actually runs at the polling cadence
@@ -665,8 +679,9 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
       //   - FW has published (case b → emit it next pass), or
       //   - the slot is still zero AND the (observed, next_idx)
       //     coordinate has not changed for kStaleZeroQuarantineMs
-      //     (case a → quarantine fires below, drops the slot, and
-      //     advances by 1).
+      //     (case a → quarantine fires below, sweeps the contiguous
+      //     stale-zero prefix in one pass, emits one aggregate drop
+      //     event, and advances next_idx past the prefix).
       //
       // Acquire ordering so the body loads (via memcpy below)
       // cannot be reordered above this check.
@@ -683,21 +698,66 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
               std::chrono::duration_cast<std::chrono::milliseconds>(
                   now - qs.stall_first_seen).count();
           if (stalled_for_ms >= kStaleZeroQuarantineMs) {
-            // Slot declared stale (case a). Emit one-record drop
-            // event for consumer visibility, advance past it, and
-            // disarm the quarantine. Note we do NOT continue the
-            // scan in this pass — the next pass will pick up at
-            // i+1 and re-evaluate the rest of [i+1, observed).
-            // This keeps the per-pass cost bounded and avoids
-            // back-to-back stale-slot fires within a single pass.
+            // Slot declared stale (case a). Sweep forward across the
+            // contiguous stale-zero prefix in this same pass, emit ONE
+            // aggregate kernel_dispatch_drop event covering all swept
+            // slots, then disarm the quarantine and continue the main
+            // loop from the first non-zero slot (or from `end` if the
+            // entire remaining window was zeros).
+            //
+            // Why sweep here (debate stage code-quality C10): the
+            // huge persisted-counter overrun case (e.g. scratch wptr
+            // = 5000, FW writes 3 fresh records → observed = 5003,
+            // ring = 4096) sets start = end - ring_records and walks
+            // a long stale-zero prefix before reaching the 3 fresh
+            // records. Without the sweep, each stale slot would
+            // require its own quarantine cycle (~100 ms each), so a
+            // 4093-slot stale prefix would take ~400 s before the
+            // first real record reached the consumer. Sweeping
+            // collapses this to a single quarantine timeout + one
+            // bounded scan (≤ ring_records iterations of a memcpy +
+            // compare), and produces ONE drop event whose count
+            // accurately reflects the gap size for downstream
+            // visibility.
+            //
+            // Loop bound: stale_end ≤ end ≤ next_idx + ring_records
+            // (the start = end - ring_records overrun clamp guarantees
+            // end - i ≤ ring_records); no busy-spin risk.
+            //
+            // Acquire ordering on each rt load mirrors the main-loop
+            // load: any non-zero we observe means the corresponding
+            // record body is host-visible (FW publishes body before
+            // record_type per f32_mec.uc Q6).
+            uint64_t stale_end = i;
+            while (stale_end < end) {
+              auto* zrec = reinterpret_cast<mec_dispatch_record_16*>(
+                  static_cast<char*>(qs.ring_base) +
+                  (stale_end & qs.ring_mask) * kSlotStride);
+              uint32_t zrt = __atomic_load_n(&zrec->record_type,
+                                             __ATOMIC_ACQUIRE);
+              if (zrt != 0) break;
+              ++stale_end;
+            }
+            const uint64_t stale_count = stale_end - i;
             rocm_trace_emit_hsa_kernel_dispatch_drop(
-                queue_id_to_wire(qs.queue_id), 1);
-            qs.next_idx = i + 1;
+                queue_id_to_wire(qs.queue_id), stale_count);
+            qs.next_idx = stale_end;
             if (qs.rptr_ptr) {
-              __atomic_store_n(qs.rptr_ptr, i + 1, __ATOMIC_RELEASE);
+              __atomic_store_n(qs.rptr_ptr, stale_end, __ATOMIC_RELEASE);
             }
             qs.pending_zero_stall.store(false, std::memory_order_release);
-            return true;  // forward progress: drop event emitted
+            any = true;
+            // If the sweep stopped at a real record, fall through to
+            // process it (and the rest of [stale_end, end)) in this
+            // same pass by resuming the for-loop at stale_end. If the
+            // sweep consumed the entire remaining window, the loop
+            // condition (i < end) will exit naturally.
+            i = stale_end;
+            // The for-loop's ++i would skip past stale_end; counteract
+            // by stepping back one. (When stale_end == end, this still
+            // works: i becomes end-1, ++i → end, loop exits.)
+            --i;
+            continue;
           }
         } else {
           qs.stall_observed   = observed;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -348,6 +348,17 @@ void for_each_known_queue_locked(F&& fn) {
 bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
   std::lock_guard<std::mutex> lk(qs.drain_mu);
 
+  // KNOWN GAP (see dispatch_log.h banner + spec §10 dep #2 sub-bullet):
+  // qs.fw_wptr_records points at AqlQueue::dispatch_record_wptr_, a host-side
+  // uint32_t whose ADDRESS is NEVER published to KFD or firmware on the
+  // current substrate. libhsakmt's hsaKmtSetQueueProfilingBuffer discards
+  // the WptrHostAddr argument, and kfd_ioctl_update_queue_args has no
+  // wptr_addr field. Result: this counter stays at 0 forever, the
+  // `fw_extended == qs.read_record_cursor` early-out below always fires, and
+  // this loop is effectively DORMANT (the polling cost is still incurred,
+  // but no records are paired or emitted). The drainer will start producing
+  // records only after the substrate is extended (KFD ABI + FW contract) to
+  // publish wptr to firmware.
   if (qs.fw_wptr_records == nullptr || qs.ring_base == nullptr ||
       qs.record_count == 0) {
     return false;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -41,7 +41,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // HSA-resident firmware-ring drainer with LTTng emission for kernel-dispatch
-// timestamps. Phase A scaffolding (spec 2026-04-27).
+// timestamps.
 //
 // This file implements:
 //   - The ts_poller control-plane thread (~5 ms tick, idempotent enable /
@@ -52,15 +52,15 @@
 //   - The QueueProfilingAcquire / Release refcount API (spec §4a).
 //   - The on_queue_create / on_queue_destroy hooks (spec §4 hooks).
 //
-// PHASE A NOTE (KFD substrate): the AMDKFD_IOC_PROFILER_DISPATCH_LOG ioctl
-// op number defined below is a *placeholder* — the kernel does not yet
-// recognize it (spec §10 dep #2). The init() probe therefore always sets
-// g_substrate_present=false on Phase A, which short-circuits the entire
-// data plane: the poller still ticks, but its enable pass treats every
-// queue as "no-op (substrate absent)" and never spawns the drainer. The
-// scaffolding compiles, links, and runs as a no-op against today's KFD.
-// When the real ioctl number lands, swap AMDKFD_IOC_PROFILER_DISPATCH_LOG
-// for the upstream value and the rest of the data plane is exercised.
+// SUBSTRATE NOTE: The KFD-side substrate is the existing
+// AMDKFD_IOC_UPDATE_QUEUE ioctl extended with dispatch_record_buffer_addr +
+// dispatch_record_buffer_size trailing fields (KFD minor version 22+).
+// The HSA-side AqlQueue::SetProfiling owns the per-queue buffer
+// allocation, the libhsakmt hsaKmtSetQueueProfilingBuffer call, and the
+// Suspend/Resume that flushes the MQD via UPDATE_QUEUE. The dispatch_log
+// path here just calls QueueProfilingAcquire/Release (which forward to
+// SetProfiling) and then queries hsa_amd_profiling_get_dispatch_records
+// to fetch the buffer info.
 
 #include "core/inc/dispatch_log.h"
 
@@ -75,7 +75,6 @@
 #include <memory>
 #include <mutex>
 #include <sys/ioctl.h>
-#include <sys/mman.h>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
@@ -85,9 +84,11 @@
 #include <fcntl.h>
 #include <linux/types.h>
 #include <unistd.h>
+#include "hsakmt/linux/kfd_ioctl.h"
 #endif
 
 #include "core/inc/agent.h"
+#include "core/inc/amd_aql_queue.h"
 #include "core/inc/amd_gpu_agent.h"
 #include "core/inc/queue.h"
 #include "lttng/rocm_trace_emit.h"
@@ -96,50 +97,6 @@ namespace rocr {
 namespace dispatch_log {
 
 namespace {
-
-// ============================================================================
-// Phase A KFD ioctl placeholder. See file header note above and spec §10 dep
-// #2. The op number is a plausible scratch value; it is not the upstream
-// AMDKFD_IOC_PROFILER number. The probe at init() expects ENOTSUP / EINVAL
-// from today's kernel and disables the data plane via g_substrate_present.
-// ============================================================================
-#if defined(__linux__)
-
-#ifndef AMDKFD_IOCTL_BASE
-#define AMDKFD_IOCTL_BASE 'K'
-#endif
-
-// Plausible scratch op number. Real upstream allocation TBD.
-struct kfd_profiler_dispatch_log_args {
-  uint32_t op;             // PROBE / ENABLE / DISABLE / QUERY
-  uint32_t flags;
-  uint32_t gpu_id;
-  uint32_t queue_id;
-  uint64_t buffer_gpu_addr;
-  uint64_t buffer_size;
-  uint64_t write_ptr_addr;
-  uint64_t read_ptr_addr;
-  uint64_t generation;
-};
-
-// Op tags carried in kfd_profiler_dispatch_log_args::op.
-enum {
-  KFD_DISPATCH_LOG_OP_PROBE   = 0,
-  KFD_DISPATCH_LOG_OP_ENABLE  = 1,
-  KFD_DISPATCH_LOG_OP_DISABLE = 2,
-  KFD_DISPATCH_LOG_OP_QUERY   = 3,
-};
-
-// Scratch ioctl number 0xFE in the AMDKFD ioctl space. This is a placeholder
-// per spec §10 dep #2; the upstream KFD does not recognize it and will return
-// ENOTSUP / EINVAL, which is the documented Phase A path.
-#define AMDKFD_IOC_PROFILER_DISPATCH_LOG \
-  _IOWR(AMDKFD_IOCTL_BASE, 0xFE, struct kfd_profiler_dispatch_log_args)
-
-// Path used to probe KFD support at init().
-constexpr const char* kKfdDevicePath = "/dev/kfd";
-
-#endif  // __linux__
 
 // ============================================================================
 // Per-queue profiling-bit refcount (spec §4a). Each Queue gets one of these
@@ -155,19 +112,18 @@ struct queue_profiling_owners {
 
 // ============================================================================
 // queue_drain_state per spec §7. Held via std::shared_ptr from both the
-// drainer registry (g_active_queues) and per-pass snapshot vectors. The
-// destructor is what frees the ring buffer; freeing happens exactly once,
-// when the last shared_ptr ref is released. Deliberately stores NO Queue*
-// — see spec §4 "Queue / drain-state lifetime" for the dangling-Queue
-// rationale.
+// drainer registry (g_active_queues) and per-pass snapshot vectors. Stores
+// only NON-OWNING pointers into the buffer owned by AqlQueue (the buffer
+// is alloc'd by AqlQueue::SetProfiling(true) and freed by SetProfiling(false)
+// or the AqlQueue dtor). Deliberately stores NO Queue* — see spec §4
+// "Queue / drain-state lifetime" for the dangling-Queue rationale.
 // ============================================================================
 struct queue_drain_state {
   // Full 64-bit hsa_queue_t::id (see hsa.h). Internal ownership / lifetime
   // maps key on this full id to avoid the high-32-bit collision risk
-  // flagged in C5 (two distinct live queues differing only in the high 32
-  // bits would have aliased a uint32_t key). The on-the-wire LTTng
-  // tracepoint payload still carries only the low 32 bits per spec §6/§14
-  // — we narrow at the rocm_trace_emit_* call sites, not here.
+  // flagged in C5. The on-the-wire LTTng tracepoint payload still carries
+  // only the low 32 bits per spec §6/§14 — we narrow at the
+  // rocm_trace_emit_* call sites, not here.
   uint64_t  queue_id = 0;
 
   // Owned, queue-independent GPU->system time-translation callable.
@@ -178,23 +134,22 @@ struct queue_drain_state {
   // by value inside this callable is safe.
   std::function<uint64_t(uint64_t /* gpu_ts */)> translate_gpu_ts;
 
-  // Buffer ownership.
-  void*    buffer_base = nullptr;     // host-virtual base of the full alloc
-                                      // (header + data area). Freed by the
-                                      // destructor below.
-  size_t   buffer_total_bytes = 0;    // bytes to munmap / free()
+  // NON-OWNING ring view. The buffer is owned by AqlQueue::dispatch_record_buffer_;
+  // do not free here.
+  void*    ring_base    = nullptr;     // host-virtual base of the FW record area
+  uint32_t record_count = 0;           // power-of-2 number of 16-byte slots
+  uint32_t record_mask  = 0;           // record_count - 1, for slot indexing
 
-  void*    ring_base   = nullptr;     // = buffer_base + DISPATCH_LOG_HEADER_BYTES
-  uint32_t ring_bytes  = 0;           // power-of-2 size of the data area
-  uint32_t ring_mask   = 0;           // ring_bytes - 1
+  // FW-written 32-bit monotonic record counter. Lives outside the buffer
+  // (cpc_tracing infrastructure exposes it as a separate uint32_t* via
+  // hsa_amd_profiling_get_dispatch_records). Pointer is owned by AqlQueue.
+  volatile uint32_t* fw_wptr_records = nullptr;
 
-  volatile uint64_t* fw_wptr = nullptr;  // lives in the header at
-                                         // buffer_base + 0; FW-updated.
-
-  uint64_t generation = 0;
-
-  // Mutated only under drain_mu (see below).
-  uint64_t read_cursor = 0;
+  // Mutated only under drain_mu (see below). Host-extended 64-bit version
+  // of the FW record cursor; we extend the FW's uint32_t monotonic record
+  // counter into a uint64_t so wraparound across the 32-bit boundary doesn't
+  // confuse our overrun bookkeeping.
+  uint64_t read_record_cursor = 0;
   std::unordered_map<uint32_t, uint64_t> pending_starts;
 
   // Per-queue drain mutex. Serializes drain_one_queue() (steady state) and
@@ -202,17 +157,6 @@ struct queue_drain_state {
   // disable-edge thread). Per-queue scope, so other queues' drains are not
   // blocked.
   std::mutex drain_mu;
-
-  ~queue_drain_state() {
-    if (buffer_base != nullptr && buffer_total_bytes > 0) {
-#if defined(__linux__)
-      ::munmap(buffer_base, buffer_total_bytes);
-#else
-      std::free(buffer_base);
-#endif
-      buffer_base = nullptr;
-    }
-  }
 };
 
 // ============================================================================
@@ -226,11 +170,13 @@ struct queue_drain_state {
 // (relaxed, hot path) and ts_drainer.
 std::atomic<bool> G_tracepoint_enabled{false};
 
-// Set true once at init() if the KFD substrate probe succeeds. Phase A: this
-// stays false because the placeholder ioctl is unknown to today's KFD.
+// Set true if the KFD substrate version probe at init() reports a kernel
+// minor version >= 22 (the minor version that introduced the
+// dispatch_record_buffer_{addr,size} trailing fields on UPDATE_QUEUE).
+// Probed once at init via AMDKFD_IOC_GET_VERSION; never mutated afterwards.
 std::atomic<bool> g_substrate_present{false};
 
-// Phase A: latched true after we log the "substrate absent, tracepoint enable
+// Latched true after we log the "substrate absent, tracepoint enable
 // is a no-op" message once. Avoids spamming the user log on every poll tick.
 std::atomic<bool> g_substrate_absent_warned{false};
 
@@ -255,22 +201,7 @@ std::unordered_map<uint64_t, std::shared_ptr<queue_drain_state>> g_active_queues
 // dispatch_log subsystem (registered by on_queue_create, removed by
 // on_queue_destroy), regardless of whether dispatch logging is currently
 // enabled on it. The poller iterates this set under g_lifecycle_mu to drive
-// the §4 idempotent enable/disable passes:
-//
-//   - curr==true tick: for each Q in g_known_queues with
-//     dispatch_log_active==false, call enable_dispatch_log_for_queue(Q).
-//   - curr==false tick: for each Q in g_known_queues with
-//     dispatch_log_active==true, call disable_dispatch_log_for_queue(Q).
-//
-// **Lifetime contract.** The drainer NEVER reads this map (the
-// no-Queue*-in-drainer invariant of queue_drain_state — see spec §4 "Queue /
-// drain-state lifetime" — is therefore preserved). The poller and the
-// queue-create/destroy hooks all serialize on g_lifecycle_mu when touching
-// this map AND when calling enable/disable; on_queue_destroy removes from
-// g_known_queues BEFORE running the disable sequence, so the poller can
-// never observe a Queue* whose underlying core::Queue is being torn down by
-// the destroy thread (the destroy thread is forced to wait behind the
-// mutex if the poller is currently iterating).
+// the §4 idempotent enable/disable passes.
 //
 // Keyed by full 64-bit hsa_queue_t::id (see g_active_queues commentary
 // above and C5 fix).
@@ -293,14 +224,12 @@ std::unordered_map<uint64_t, core::Queue*> g_known_queues;
 std::mutex g_owners_mu;
 std::unordered_map<core::Queue*, std::shared_ptr<queue_profiling_owners>> g_owners;
 
-// Per-agent "no-dispatch-log" mark. If the KFD ioctl returns ENOTSUP for any
-// queue on a given agent, that agent is added here and subsequent
-// enable_dispatch_log_for_queue calls on queues belonging to it short-circuit
-// (spec §5 unsupported-agent row, §9 unsupported-agent row).
+// Per-agent "no-dispatch-log" mark. If GetProfilingDispatchRecords reports
+// NOT_INITIALIZED (or another error) for any queue on a given agent, that
+// agent is added here and subsequent enable_dispatch_log_for_queue calls on
+// queues belonging to it short-circuit (spec §5 unsupported-agent row,
+// §9 unsupported-agent row).
 std::unordered_set<core::Agent*> g_no_dispatch_log_agents;
-
-// KFD fd held open for the lifetime of the runtime. -1 if probe failed.
-int g_kfd_fd = -1;
 
 // Threads.
 std::thread g_poller_thread;
@@ -311,10 +240,6 @@ std::atomic<bool> g_drainer_running{false};
 // false and short-sleep (500 us) on idle. Notified on shutdown.
 std::mutex g_drainer_mu;
 std::condition_variable g_drainer_cv;
-
-// Monotonically incremented for every per-queue ENABLE so a stale FW write
-// to a freed buffer is detectable on the host side.
-std::atomic<uint64_t> g_generation_counter{1};
 
 // ============================================================================
 // Helpers.
@@ -362,103 +287,30 @@ std::function<uint64_t(uint64_t)> make_translate_gpu_ts(core::Queue* q) {
 }
 
 #if defined(__linux__)
-bool kfd_open_and_probe() {
-  if (g_kfd_fd != -1) return true;
+// Probe the KFD substrate version. Returns true iff the running kernel
+// reports KFD minor version >= 22 (the minor that introduced the
+// dispatch_record_buffer_{addr,size} trailing fields on UPDATE_QUEUE).
+//
+// This replaces the Phase A placeholder PROBE ioctl. We do NOT keep the
+// fd — the per-queue path uses HSA's own KFD handle via the AqlQueue
+// SetProfiling -> agent_->driver().SetQueueProfilingBuffer chain.
+bool probe_substrate_version() {
+  constexpr const char* kKfdDevicePath = "/dev/kfd";
   int fd = ::open(kKfdDevicePath, O_RDWR | O_CLOEXEC);
-  if (fd < 0) {
-    return false;
-  }
-  // Probe: zero-arg PROBE call. The Phase A ioctl is unknown to today's KFD
-  // and will return -1 / ENOTSUP / EINVAL; that is the documented Phase A
-  // result. If a future KFD recognizes the op, it should return 0.
-  struct kfd_profiler_dispatch_log_args args = {};
-  args.op    = KFD_DISPATCH_LOG_OP_PROBE;
-  args.flags = 0;
-  int rc = ::ioctl(fd, AMDKFD_IOC_PROFILER_DISPATCH_LOG, &args);
-  if (rc != 0) {
-    // Substrate absent — don't keep the fd around either. We use the runtime's
-    // own KFD fd for any future per-queue ioctls, so closing this probe fd is
-    // fine.
-    ::close(fd);
-    g_kfd_fd = -1;
-    return false;
-  }
-  g_kfd_fd = fd;
-  return true;
+  if (fd < 0) return false;
+  struct kfd_ioctl_get_version_args args = {};
+  int rc = ::ioctl(fd, AMDKFD_IOC_GET_VERSION, &args);
+  ::close(fd);
+  if (rc != 0) return false;
+  // The dispatch_record_buffer fields landed in the host kernel ABI at
+  // KFD 1.22. Older kernels will silently ignore the trailing UPDATE_QUEUE
+  // bytes (or worse, return -ENOTTY because of the _IOWR-encoded size
+  // mismatch on related ioctls), so this version gate is mandatory.
+  return args.major_version >= 1 && args.minor_version >= 22;
 }
 #else
-bool kfd_open_and_probe() { return false; }
+bool probe_substrate_version() { return false; }
 #endif
-
-// Issue an ENABLE / DISABLE ioctl. Returns 0 on success, errno on failure.
-int kfd_dispatch_log_op(uint32_t op, core::Queue* q,
-                        uint64_t buffer_gpu_addr, uint64_t buffer_size,
-                        uint64_t write_ptr_addr, uint64_t generation) {
-#if defined(__linux__)
-  if (g_kfd_fd < 0) return ENOTSUP;
-  struct kfd_profiler_dispatch_log_args args = {};
-  args.op              = op;
-  args.flags           = 0;
-  // gpu_id: derive from agent if a GPU agent. Phase A leaves zero on failure.
-  args.gpu_id          = 0;
-  // KFD ioctl arg field is uint32_t per the (Phase A placeholder) wire
-  // contract. Narrow internally; the struct field, not our internal map,
-  // dictates the width here.
-  args.queue_id        = queue_id_to_wire(queue_id_of(q));
-  args.buffer_gpu_addr = buffer_gpu_addr;
-  args.buffer_size     = buffer_size;
-  args.write_ptr_addr  = write_ptr_addr;
-  args.read_ptr_addr   = 0;  // host-managed locally
-  args.generation      = generation;
-  if (::ioctl(g_kfd_fd, AMDKFD_IOC_PROFILER_DISPATCH_LOG, &args) != 0) {
-    return errno != 0 ? errno : ENOTSUP;
-  }
-  return 0;
-#else
-  (void)op; (void)q; (void)buffer_gpu_addr; (void)buffer_size;
-  (void)write_ptr_addr; (void)generation;
-  return ENOTSUP;
-#endif
-}
-
-// Allocate the per-queue ring buffer. Phase A: page-aligned anonymous mmap.
-// In a future revision this should use the existing pinned-host allocator
-// from the agent so the buffer is GPU-visible without an explicit pin
-// (mirroring the AQL queue ring allocation pattern). The buffer total size
-// is DISPATCH_LOG_HEADER_BYTES + DISPATCH_LOG_RING_BYTES.
-struct ring_alloc_t {
-  void*  base;
-  size_t total_bytes;
-};
-ring_alloc_t alloc_ring_buffer() {
-  const size_t total = DISPATCH_LOG_HEADER_BYTES + DISPATCH_LOG_RING_BYTES;
-  ring_alloc_t out{nullptr, 0};
-#if defined(__linux__)
-  void* p = ::mmap(nullptr, total, PROT_READ | PROT_WRITE,
-                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-  if (p == MAP_FAILED) return out;
-  std::memset(p, 0, total);
-  out.base        = p;
-  out.total_bytes = total;
-#else
-  void* p = std::calloc(1, total);
-  if (p == nullptr) return out;
-  out.base        = p;
-  out.total_bytes = total;
-#endif
-  return out;
-}
-
-void free_ring_buffer(ring_alloc_t& a) {
-  if (a.base == nullptr) return;
-#if defined(__linux__)
-  ::munmap(a.base, a.total_bytes);
-#else
-  std::free(a.base);
-#endif
-  a.base = nullptr;
-  a.total_bytes = 0;
-}
 
 // Snapshot: clone shared_ptrs out of g_active_queues under the lifecycle
 // mutex, return the vector. Drainer then iterates WITHOUT holding the
@@ -475,13 +327,8 @@ std::vector<std::shared_ptr<queue_drain_state>> snapshot_active_queues() {
 
 // Iterate g_known_queues under g_lifecycle_mu and invoke fn(queue_id, queue)
 // for each entry. C6 fix: replaces the previous "snapshot into vector then
-// iterate" pattern in ts_poller_loop / shutdown — the lock was already
-// held for the entire snapshot+iterate window, so the snapshot copy added
-// allocator pressure with no concurrency benefit. fn must NOT mutate
-// g_known_queues (the only legal mutators are on_queue_create /
-// on_queue_destroy, both of which take g_lifecycle_mu themselves and
-// therefore cannot run during this iteration). fn IS allowed to mutate
-// g_active_queues (e.g. enable_dispatch_log_for_queue_locked inserts,
+// iterate" pattern. fn must NOT mutate g_known_queues. fn IS allowed to
+// mutate g_active_queues (e.g. enable_dispatch_log_for_queue_locked inserts,
 // disable_dispatch_log_for_queue_locked erases).
 template <typename F>
 void for_each_known_queue_locked(F&& fn) {
@@ -491,43 +338,57 @@ void for_each_known_queue_locked(F&& fn) {
 
 // ============================================================================
 // drain_one_queue (spec §7). Holds qs.drain_mu for the entire pass.
+//
+// Reads the FW-written uint32_t record counter, host-extends it to 64 bits
+// (so wrap of the FW counter doesn't confuse us across drain calls), then
+// walks new records from read_record_cursor up to the host-extended fw cursor.
+// Each record is 16 bytes; the slot index is (cursor & record_mask).
 // ============================================================================
 
 bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
   std::lock_guard<std::mutex> lk(qs.drain_mu);
 
-  if (qs.fw_wptr == nullptr) return false;
+  if (qs.fw_wptr_records == nullptr || qs.ring_base == nullptr ||
+      qs.record_count == 0) {
+    return false;
+  }
 
-  const uint64_t fw_wptr = __atomic_load_n(qs.fw_wptr, __ATOMIC_ACQUIRE);
-  if (fw_wptr == qs.read_cursor) return false;
+  // Snapshot the FW's 32-bit monotonic record counter and host-extend it.
+  // The high 32 bits we add are taken from our last-known cursor: as long
+  // as we drain at least once per (2^32) records, this extension is correct.
+  // 65536 records buffered, so we'd lose data well before wrap-extension
+  // ambiguity matters.
+  const uint32_t fw_lo = __atomic_load_n(qs.fw_wptr_records, __ATOMIC_ACQUIRE);
+  uint64_t fw_extended = (qs.read_record_cursor & ~uint64_t(0xFFFFFFFFu)) | fw_lo;
+  if (fw_extended < qs.read_record_cursor) {
+    // Low 32 bits wrapped past us; bump the high half.
+    fw_extended += uint64_t(1) << 32;
+  }
+  if (fw_extended == qs.read_record_cursor) return false;
 
-  // Wraparound check (spec §6 bytes_lost field definition).
-  if (fw_wptr - qs.read_cursor > qs.ring_bytes) {
+  // Wraparound check (spec §6 bytes_lost field definition). With 65536
+  // records, an overrun means FW outpaced us by more than the buffer
+  // depth.
+  const uint64_t records_avail = fw_extended - qs.read_record_cursor;
+  if (records_avail > qs.record_count) {
     // Narrow internal 64-bit queue_id to the 32-bit on-the-wire id at the
-    // tracepoint boundary (spec §6 / §14, C5 fix).
-    rocm_trace_emit_hsa_kernel_dispatch_drop(queue_id_to_wire(qs.queue_id),
-                                             fw_wptr - qs.read_cursor);
-    qs.read_cursor = fw_wptr - qs.ring_bytes;
+    // tracepoint boundary (spec §6 / §14, C5 fix). Report the loss in
+    // bytes for compatibility with the existing tracepoint payload.
+    rocm_trace_emit_hsa_kernel_dispatch_drop(
+        queue_id_to_wire(qs.queue_id),
+        records_avail * sizeof(mec_dispatch_record_16));
+    qs.read_record_cursor = fw_extended - qs.record_count;
 
     // C7 fix: across an overrun event, ALL previously cached STARTs are
     // suspect. The drainer cannot tell which records the FW just overwrote
-    // (spec §7 / drop tracepoint semantics), so any pending START whose
-    // matching END was in the skipped range would either (a) leak in this
-    // map indefinitely or (b) be incorrectly mispaired with a future END
-    // if dispatch_idx wraps (uint32_t, ~4 billion dispatches).
-    //
-    // Trade-off: a START that was preserved across the overrun whose END
-    // arrives AFTER this point will now be reported as an orphan END and
-    // silently skipped by the END branch below. This is acceptable
-    // conservative behavior — the dispatch's complete record was already
-    // effectively lost the moment the FW outpaced us.
+    // (spec §7 / drop tracepoint semantics). Conservative: drop them.
     qs.pending_starts.clear();
   }
 
-  while (qs.read_cursor < fw_wptr) {
+  while (qs.read_record_cursor < fw_extended) {
+    const uint32_t slot = static_cast<uint32_t>(qs.read_record_cursor & qs.record_mask);
     const auto* rec = reinterpret_cast<const mec_dispatch_record_16*>(
-        static_cast<const char*>(qs.ring_base) +
-        (qs.read_cursor & qs.ring_mask));
+        static_cast<const char*>(qs.ring_base) + slot * sizeof(mec_dispatch_record_16));
 
     const uint64_t gpu_ts =
         (static_cast<uint64_t>(rec->ts_hi) << 32) | rec->ts_lo;
@@ -557,7 +418,7 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
       // else: orphan END (start was lost to wraparound). Silently skip.
     }
 
-    qs.read_cursor += sizeof(mec_dispatch_record_16);
+    qs.read_record_cursor += 1;
   }
   return true;
 }
@@ -627,10 +488,9 @@ hsa_status_t QueueProfilingAcquire(core::Queue* q) {
   const uint32_t prev = owners->refcount;
   owners->refcount = prev + 1;
   if (prev == 0) {
-    // 0->1 transition: set the bit via the existing API. SetProfiling()
-    // forwards to AMD_HSA_BITS_SET on amd_queue_.queue_properties (the
-    // GPU-visible bit) and is the same path hsa_amd_profiling_set_profiler_enabled
-    // takes today (see queue.h:446 / amd_aql_queue.cpp:1559).
+    // 0->1 transition: enable profiling. AqlQueue::SetProfiling now also
+    // allocates the per-queue dispatch-record buffer and pushes it to KFD
+    // via hsaKmtSetQueueProfilingBuffer + Suspend/Resume (UPDATE_QUEUE).
     q->SetProfiling(true);
   }
   return HSA_STATUS_SUCCESS;
@@ -657,6 +517,9 @@ hsa_status_t QueueProfilingRelease(core::Queue* q) {
   }
   owners->refcount -= 1;
   if (owners->refcount == 0) {
+    // 1->0 transition: AqlQueue::SetProfiling(false) frees the per-queue
+    // dispatch-record buffer and clears the KFD profiling-buffer
+    // registration via UPDATE_QUEUE.
     q->SetProfiling(false);
   }
   return HSA_STATUS_SUCCESS;
@@ -667,135 +530,98 @@ namespace {
 // ============================================================================
 // Per-queue ENABLE / DISABLE sequences (spec §5).
 //
-// enable_dispatch_log_for_queue runs the per-queue all-or-nothing sequence:
-//   1. alloc buffer
-//   2. QueueProfilingAcquire (sets the bit if 0->1)
-//   3. KFD ioctl ENABLE
-//   4..6. (queue unmap/remap and MQD propagation are KFD-side; the ioctl
-//         encapsulates them)
-//   7. register in g_active_queues
+// New flow (post cpc_tracing infrastructure import):
+//   1. Skip non-AQL / non-GPU queues.
+//   2. Skip if substrate is absent or agent is on the no-dispatch-log list.
+//   3. QueueProfilingAcquire -> AqlQueue::SetProfiling(true) -> alloc
+//      buffer + KFD UPDATE_QUEUE with the new trailing fields.
+//   4. AqlQueue::GetProfilingDispatchRecords to read back the buffer base,
+//      total bytes, and FW wptr pointer.
+//   5. Register a non-owning queue_drain_state in g_active_queues.
 //
-// Each step has its own unwind on failure. On any failure: free buffer,
-// release any acquired profiling ref, leave dispatch_log_active=false, log
-// once-per-queue at WARNING.
+// The previous Phase A path's bespoke buffer alloc + placeholder KFD ioctl
+// has been removed entirely.
 // ============================================================================
 
-// _locked variant. Caller holds g_lifecycle_mu. Used by the poller's enable
-// pass (which iterates g_known_queues under the mutex) and by on_queue_create
-// via the public wrapper below.
 void enable_dispatch_log_for_queue_locked(core::Queue* q) {
   if (q == nullptr) return;
 
   // Idempotence guard: skip if already active.
   if (q->dispatch_log_active.load(std::memory_order_relaxed)) return;
 
-  // Only meaningful for GPU agents — host/soft queues have no MEC firmware
-  // to write records, so the KFD ioctl would either be rejected or be a
-  // no-op. Skip them outright.
+  // Only AqlQueue (hardware AQL queues on GPU agents) have the FW
+  // dispatch-record path. Host queues, soft queues, intercept queues
+  // wrapping a non-AqlQueue: silently skip.
   if (!agent_is_gpu(q->GetAgent())) return;
+  if (!AMD::AqlQueue::IsType(q)) return;
+  auto* aql_queue = static_cast<AMD::AqlQueue*>(q);
 
-  // Phase A short-circuit: substrate absent.
+  // Substrate / per-agent gate.
   if (!g_substrate_present.load(std::memory_order_relaxed)) return;
-
-  // Per-agent "no-dispatch-log" filter.
   if (g_no_dispatch_log_agents.count(q->GetAgent()) > 0) return;
 
-  // Step 1: alloc.
-  ring_alloc_t alloc = alloc_ring_buffer();
-  if (alloc.base == nullptr) {
-    std::fprintf(stderr,
-                 "[hsa-runtime] dispatch_log: queue_id=%llu ENABLE step 1 (alloc) "
-                 "failed errno=%d\n",
-                 static_cast<unsigned long long>(queue_id_of(q)), errno);
-    return;
-  }
-
-  const uint64_t generation = g_generation_counter.fetch_add(
-      1, std::memory_order_relaxed);
-
-  // Initialize the header now (host-side write before KFD publishes the
-  // buffer to FW). Layout per spec §5.
-  auto* hdr = reinterpret_cast<dispatch_log_header*>(alloc.base);
-  hdr->fw_wptr    = 0;
-  hdr->generation = generation;
-  hdr->version    = DISPATCH_LOG_VERSION;
-  std::memset(hdr->reserved, 0, sizeof(hdr->reserved));
-
-  // Step 2: acquire profiling ref FIRST (spec §5 ordering rationale).
-  // QueueProfilingAcquire takes g_owners_mu, NOT g_lifecycle_mu, so it's
-  // safe to call while holding g_lifecycle_mu.
+  // Step 1: enable profiling on the queue. This is the AqlQueue::SetProfiling
+  // call that allocates the dispatch-record buffer, calls
+  // hsaKmtSetQueueProfilingBuffer, and Suspends/Resumes the queue to flush
+  // the MQD via UPDATE_QUEUE. QueueProfilingAcquire takes g_owners_mu (not
+  // g_lifecycle_mu), so it's safe to call while holding g_lifecycle_mu.
   hsa_status_t s = QueueProfilingAcquire(q);
   if (s != HSA_STATUS_SUCCESS) {
     std::fprintf(stderr,
-                 "[hsa-runtime] dispatch_log: queue_id=%llu ENABLE step 2 "
+                 "[hsa-runtime] dispatch_log: queue_id=%llu ENABLE step 1 "
                  "(QueueProfilingAcquire) failed status=%d\n",
                  static_cast<unsigned long long>(queue_id_of(q)),
                  static_cast<int>(s));
-    free_ring_buffer(alloc);
     return;
   }
 
-  // Step 3: KFD ioctl ENABLE. buffer_gpu_addr points at the data area
-  // (after the header). Phase A: this currently always returns ENOTSUP
-  // since the substrate is absent — but g_substrate_present should have
-  // been false above and we'd have early-returned. Defense in depth:
-  // if we reach here the probe lied. Treat any failure as a per-queue
-  // failure per spec §5.
-  //
-  // NOTE: this Phase A scaffolding passes the host virtual address as the
-  // GPU address. Real implementation must pin the buffer via the existing
-  // HSA pinned-host allocator and pass the GPU-visible address. That hookup
-  // is left for Phase B once a real substrate exists.
-  const uint64_t host_base = reinterpret_cast<uint64_t>(alloc.base);
-  const int rc = kfd_dispatch_log_op(
-      KFD_DISPATCH_LOG_OP_ENABLE, q,
-      host_base + DISPATCH_LOG_HEADER_BYTES,    // FW data area base
-      DISPATCH_LOG_RING_BYTES,                  // data area size
-      host_base + 0,                            // fw_wptr lives in header
-      generation);
-  if (rc != 0) {
+  // Step 2: read back the per-queue ring buffer info from AqlQueue.
+  void* buf = nullptr;
+  uint32_t buf_bytes = 0;
+  volatile uint32_t* fw_wptr = nullptr;
+  hsa_status_t gs = aql_queue->GetProfilingDispatchRecords(&buf, &buf_bytes, &fw_wptr);
+  if (gs != HSA_STATUS_SUCCESS || buf == nullptr || buf_bytes == 0 || fw_wptr == nullptr) {
     std::fprintf(stderr,
-                 "[hsa-runtime] dispatch_log: queue_id=%llu ENABLE step 3 "
-                 "(KFD ioctl) failed errno=%d\n",
-                 static_cast<unsigned long long>(queue_id_of(q)), rc);
-    if (rc == ENOTSUP) {
-      g_no_dispatch_log_agents.insert(q->GetAgent());
-    }
+                 "[hsa-runtime] dispatch_log: queue_id=%llu ENABLE step 2 "
+                 "(GetProfilingDispatchRecords) failed status=%d\n",
+                 static_cast<unsigned long long>(queue_id_of(q)),
+                 static_cast<int>(gs));
+    g_no_dispatch_log_agents.insert(q->GetAgent());
     QueueProfilingRelease(q);
-    free_ring_buffer(alloc);
     return;
   }
 
-  // Step 7: register in the drainer registry.
+  // GetProfilingDispatchRecords reports buf_bytes = record_count * 16
+  // (the FW record-stride sized capacity). The kernel-side BO is
+  // oversized (count * 40) per the host KFD ABI; the drainer iterates
+  // 16-byte records.
+  const uint32_t record_count = buf_bytes / static_cast<uint32_t>(sizeof(mec_dispatch_record_16));
+  if (record_count == 0 || (record_count & (record_count - 1)) != 0) {
+    std::fprintf(stderr,
+                 "[hsa-runtime] dispatch_log: queue_id=%llu ENABLE step 2 "
+                 "GetProfilingDispatchRecords returned non-pow2 record_count=%u\n",
+                 static_cast<unsigned long long>(queue_id_of(q)), record_count);
+    g_no_dispatch_log_agents.insert(q->GetAgent());
+    QueueProfilingRelease(q);
+    return;
+  }
+
+  // Step 3: register in the drainer registry. NON-OWNING — buffer is
+  // owned by AqlQueue, freed on SetProfiling(false) or AqlQueue dtor.
   auto qs = std::make_shared<queue_drain_state>();
   qs->queue_id           = queue_id_of(q);
   qs->translate_gpu_ts   = make_translate_gpu_ts(q);
-  qs->buffer_base        = alloc.base;
-  qs->buffer_total_bytes = alloc.total_bytes;
-  qs->ring_base          = static_cast<char*>(alloc.base) + DISPATCH_LOG_HEADER_BYTES;
-  qs->ring_bytes         = static_cast<uint32_t>(DISPATCH_LOG_RING_BYTES);
-  qs->ring_mask          = qs->ring_bytes - 1;
-  qs->fw_wptr            = &hdr->fw_wptr;
-  qs->generation         = generation;
-  qs->read_cursor        = 0;
+  qs->ring_base          = buf;
+  qs->record_count       = record_count;
+  qs->record_mask        = record_count - 1;
+  qs->fw_wptr_records    = fw_wptr;
+  qs->read_record_cursor = 0;
 
   g_active_queues[qs->queue_id] = qs;
-
-  // Ownership of the buffer now lives in qs (shared_ptr destructor frees it).
-  // Suppress the local alloc bookkeeping so a later free_ring_buffer on
-  // `alloc` would be a no-op.
-  alloc.base        = nullptr;
-  alloc.total_bytes = 0;
 
   q->dispatch_log_active.store(true, std::memory_order_release);
 }
 
-// _locked variant. Caller holds g_lifecycle_mu. Used by the poller's
-// disable pass, by shutdown(), and by on_queue_destroy via the public
-// wrapper below. Note that wait_for_idle and the KFD ioctl run while
-// the lifecycle mutex is held; this is acceptable because the lifecycle
-// mutex is contended only by other lifecycle events (queue create/destroy,
-// poller ticks every 5 ms), not by per-dispatch hot paths.
 void disable_dispatch_log_for_queue_locked(core::Queue* q) {
   if (q == nullptr) return;
   if (!q->dispatch_log_active.load(std::memory_order_acquire)) return;
@@ -808,19 +634,16 @@ void disable_dispatch_log_for_queue_locked(core::Queue* q) {
   // b. Final drain with force_emit=true (spec §6).
   ts_drainer_drain_now_locked(q);
 
-  // c. KFD ioctl DISABLE (best-effort).
-  (void)kfd_dispatch_log_op(KFD_DISPATCH_LOG_OP_DISABLE, q,
-                            /*buffer_gpu_addr=*/0, /*buffer_size=*/0,
-                            /*write_ptr_addr=*/0, /*generation=*/0);
-
-  // d. Release profiling ref (clears the bit only if 1->0).
-  // QueueProfilingRelease takes g_owners_mu, NOT g_lifecycle_mu.
+  // c. Release profiling ref. On the 1->0 edge AqlQueue::SetProfiling(false)
+  // clears the KFD profiling-buffer registration (UPDATE_QUEUE with addr=0)
+  // and frees the per-queue dispatch-record buffer. QueueProfilingRelease
+  // takes g_owners_mu, NOT g_lifecycle_mu.
   QueueProfilingRelease(q);
 
-  // e. Unregister from drainer registry. Drops the registry's shared_ptr
-  //    ref. Buffer free is gated by shared_ptr destructor — if a drainer
-  //    snapshot still holds a ref the destructor fires when that snapshot
-  //    vector is destroyed (spec §4 lifetime protocol).
+  // d. Unregister from drainer registry. Drops the registry's shared_ptr
+  //    ref. The buffer is owned by AqlQueue (we just released it via
+  //    SetProfiling(false)); our queue_drain_state holds only non-owning
+  //    pointers, so the destructor is a no-op for buffer memory.
   g_active_queues.erase(queue_id_of(q));
 
   q->dispatch_log_active.store(false, std::memory_order_release);
@@ -860,26 +683,12 @@ void start_drainer_if_needed() {
 
 // ============================================================================
 // ts_poller_loop (spec §4 lifecycle state machine).
-//
-// Every 5 ms:
-//   1. Compute curr = !rocm_trace_disabled() && lttng_ust_tracepoint_enabled
-//                     (rocm_hsa, kernel_dispatch_complete) && g_substrate_present.
-//   2. Store G_tracepoint_enabled = curr.
-//   3. If curr=true: spawn drainer if needed; iterate registered queues,
-//      enable any not-yet-active.
-//   4. If curr=false: iterate registered queues, disable any still-active.
-//
-// Both branches run every tick (idempotent, not edge-triggered) — this is
-// the convergence guarantee for the queue-create-vs-disable race
-// (spec §4 "Queue-create vs. disable-pass race").
 // ============================================================================
 
 bool predicate_now() {
 #if defined(HSA_ENABLE_LTTNG_UST) && HSA_ENABLE_LTTNG_UST
   if (rocm_trace_disabled()) return false;
   if (!g_substrate_present.load(std::memory_order_relaxed)) {
-    // Phase A: log once that the substrate is missing so the user knows
-    // why an enabled tracepoint produces no events.
     if (lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_complete)) {
       bool warned = g_substrate_absent_warned.load(std::memory_order_relaxed);
       if (!warned && g_substrate_absent_warned.compare_exchange_strong(
@@ -887,9 +696,8 @@ bool predicate_now() {
         std::fprintf(stderr,
                      "[hsa-runtime] dispatch_log: tracepoint "
                      "rocm_hsa:kernel_dispatch_complete is enabled, but the "
-                     "KFD substrate (AMDKFD_IOC_PROFILER_DISPATCH_LOG) is not "
-                     "available on this kernel. No events will be produced. "
-                     "(Phase A scaffolding; see spec §10 dep #2.)\n");
+                     "KFD substrate is not available on this kernel "
+                     "(KFD minor version < 22). No events will be produced.\n");
       }
     }
     return false;
@@ -912,30 +720,18 @@ void ts_poller_loop() {
 
       // ENABLE pass (spec §4): for each known live queue Q with
       // dispatch_log_active==false, run the per-queue ENABLE sequence.
-      // Iterates g_known_queues under the lifecycle mutex; on_queue_create
-      // and on_queue_destroy serialize on the same mutex, so the Queue*
-      // values we observe here cannot be torn down concurrently.
-      // enable_dispatch_log_for_queue_locked is itself a no-op for queues
-      // that are already active (idempotent enable). C6: direct iteration,
-      // no per-tick snapshot allocation.
       for_each_known_queue_locked(
           [](uint64_t /*qid*/, core::Queue* q) {
             enable_dispatch_log_for_queue_locked(q);
           });
     } else {
-      // DISABLE pass (spec §4 + §9 ROCM_LTTNG_UST_DISABLE row): for each
-      // known live queue Q with dispatch_log_active==true, run the
-      // per-queue DISABLE sequence (wait_for_idle, final drain, KFD
-      // DISABLE, QueueProfilingRelease, mark inactive). Idempotent over
-      // already-inactive queues. Required for kill-switch hygiene per
-      // spec §1039. C6: direct iteration, no per-tick snapshot allocation.
+      // DISABLE pass (spec §4 + §9 ROCM_LTTNG_UST_DISABLE row).
       for_each_known_queue_locked(
           [](uint64_t /*qid*/, core::Queue* q) {
             disable_dispatch_log_for_queue_locked(q);
           });
     }
 
-    // Sleep until next tick.
     std::this_thread::sleep_for(tick_interval);
   }
 }
@@ -947,13 +743,15 @@ void ts_poller_loop() {
 // ============================================================================
 
 void init() {
-  // KFD substrate probe. Phase A: this is expected to fail.
-  const bool present = kfd_open_and_probe();
+  // KFD substrate version probe via AMDKFD_IOC_GET_VERSION. We require
+  // KFD minor >= 22 (the version that introduced the
+  // dispatch_record_buffer_{addr,size} trailing fields on UPDATE_QUEUE).
+  const bool present = probe_substrate_version();
   g_substrate_present.store(present, std::memory_order_release);
 
   // Spawn poller unconditionally so the steady-state idle path is exercised
-  // even on Phase A (substrate absent). The poller's enable branch
-  // short-circuits via predicate_now() → false when substrate is missing.
+  // even when the substrate is missing. The poller's enable branch
+  // short-circuits via predicate_now() -> false in that case.
   g_shutdown.store(false, std::memory_order_relaxed);
   g_poller_thread = std::thread(ts_poller_loop);
 }
@@ -967,13 +765,8 @@ void shutdown() {
   g_drainer_running.store(false, std::memory_order_relaxed);
 
   // Spec §4 process-exit cleanup: run the per-queue DISABLE sequence
-  // (wait_for_idle, final drain, KFD DISABLE, QueueProfilingRelease) for
-  // every queue still active at process exit. The poller is joined above
-  // so no other thread is touching g_known_queues / g_active_queues here;
-  // the lock is taken for consistency with the helpers' contract. C6:
-  // direct iteration via for_each_known_queue_locked, then a separate
-  // locked block for the post-iterate clears (we cannot clear inside the
-  // iteration callback because that would mutate the map mid-iteration).
+  // (wait_for_idle, final drain, QueueProfilingRelease) for every queue
+  // still active at process exit.
   for_each_known_queue_locked(
       [](uint64_t /*qid*/, core::Queue* q) {
         disable_dispatch_log_for_queue_locked(q);
@@ -981,9 +774,6 @@ void shutdown() {
   {
     std::lock_guard<std::mutex> lk(g_lifecycle_mu);
     g_known_queues.clear();
-    // Defensive: drop any remaining drainer refs (the disable sequence
-    // above should have removed them, but if a destroy hook racing with
-    // shutdown left dangling state, this releases the buffers).
     g_active_queues.clear();
     g_no_dispatch_log_agents.clear();
   }
@@ -991,13 +781,6 @@ void shutdown() {
     std::lock_guard<std::mutex> lk(g_owners_mu);
     g_owners.clear();
   }
-
-#if defined(__linux__)
-  if (g_kfd_fd >= 0) {
-    ::close(g_kfd_fd);
-    g_kfd_fd = -1;
-  }
-#endif
 }
 
 void on_queue_create(core::Queue* q) {
@@ -1007,10 +790,6 @@ void on_queue_create(core::Queue* q) {
   // the enable sequence. Holding g_lifecycle_mu across both the registry
   // insert and the enable serializes us against the poller (which iterates
   // g_known_queues under the same mutex) and against on_queue_destroy.
-  // The queue-create-vs-disable race is resolved by the idempotent disable
-  // convergence guarantee in spec §4: if curr flips to false between our
-  // load and the next poll tick, the disable pass will iterate
-  // g_known_queues (which now contains q) and clean up.
   std::lock_guard<std::mutex> lk(g_lifecycle_mu);
   g_known_queues[queue_id_of(q)] = q;
   if (G_tracepoint_enabled.load(std::memory_order_relaxed)) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -176,6 +176,45 @@ struct queue_drain_state {
   //     are re-detectable.
   uint64_t next_idx = 0;
 
+  // Stale-zero quarantine state (Path A; debate stage code-quality C8/C9).
+  //
+  // Path A stops at any record_type==0 slot inside [next_idx, observed)
+  // because we cannot cheaply distinguish (a) a pre-zeroed stale slot
+  // (FW per-pipe scratch wptr persisted across queue lifecycles, leaving
+  // the host buffer's prefix never written for THIS lifecycle) from
+  // (b) a slot whose producing XCC has not finished publishing the
+  // record body yet (multi-XCC publish race documented in the Path A
+  // header comment). Stopping is safe for case (b) — next pass will
+  // re-read once FW commits — but case (a) wedges forever (signal will
+  // never advance past the prefix). The quarantine breaks the wedge:
+  //
+  //   - On every Path A pass that stops at a zero slot, drain records
+  //     stall_first_seen (steady_clock::time_point) the FIRST time it
+  //     stops at THIS (observed, next_idx) coordinate, and sets
+  //     pending_zero_stall=true so the worker's signal-equal fast-skip
+  //     does not idle us forever waiting for a publish that may never
+  //     come.
+  //   - If a subsequent pass observes (observed, next_idx) unchanged
+  //     AND (now - stall_first_seen) >= kStaleZeroQuarantineMs, the
+  //     drainer declares the slot stale, emits a one-record
+  //     kernel_dispatch_drop event so consumers see the gap, advances
+  //     next_idx by 1 past the stale slot, and clears the quarantine.
+  //   - Forward progress clears the quarantine state via:
+  //       - reaching `end` without hitting another zero, or
+  //       - the overrun-skip path advancing past the stalled slot.
+  //     If a subsequent pass partially advances and then stalls at a
+  //     DIFFERENT (observed, next_idx) coordinate, the snapshot is
+  //     re-armed at the new coordinate (timer restarts) — that's the
+  //     intended behavior because the new stall is a distinct event.
+  //
+  // Mutated only under drain_mu, except pending_zero_stall which is
+  // also read by the worker loop (acquire load) outside the mutex to
+  // decide whether to fast-skip on signal-equal.
+  std::chrono::steady_clock::time_point stall_first_seen{};
+  uint64_t                              stall_observed = 0;
+  uint64_t                              stall_idx      = 0;
+  std::atomic<bool>                     pending_zero_stall{false};
+
   // Phase-2 host-VA pointer set. Populated by
   // enable_dispatch_log_for_queue_locked from
   // AqlQueue::GetDispatchLogPointers when the running kernel supports
@@ -407,6 +446,17 @@ constexpr size_t kSlotStride = 16;
 // batching.
 constexpr uint32_t kBatchMax = 256;
 
+// Stale-zero quarantine threshold (debate stage code-quality C8). Path A
+// stops at the first record_type==0 inside [next_idx, observed) to handle
+// either a pre-zeroed stale slot OR a multi-XCC publish-race in-flight
+// slot. After this many milliseconds of being stalled at the SAME
+// (observed, next_idx) coordinate with no forward progress, the drainer
+// declares the slot stale, emits a kernel_dispatch_drop event for it,
+// and advances past it. 100 ms aligns with the wait_for_idle bound and
+// is ~100x the worker's max sleep cadence (1 ms), so a real in-flight
+// XCC publish would commit well before this fires in practice.
+constexpr int64_t kStaleZeroQuarantineMs = 100;
+
 bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
   std::lock_guard<std::mutex> lk(qs.drain_mu);
 
@@ -452,19 +502,22 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
   //   3. Opens the door to hsa_signal_wait on signal_addr instead of
   //      polling, deferred to a future optimization.
   //
-  // Multi-XCC hazard for init-sync (C7): because XCCs publish without
-  // atomics, observing signal=N does NOT prove that every slot in
-  // [0, N) has been written — XCC A can publish its higher slot's
-  // signal value before XCC B has finished publishing its lower slot's
-  // record body. The FW interface spec
+  // Multi-XCC hazard (C7/C9): because XCCs publish without atomics,
+  // observing signal=N does NOT prove that every slot in [0, N) has
+  // been written — XCC A can publish its higher slot's signal value
+  // before XCC B has finished publishing its lower slot's record body.
+  // The FW interface spec
   // (specs/2026-05-01-mec-firmware-dispatch-log-interface.md §3.5)
   // assumes a single producer per queue and says nothing about XCC
   // interleaving; on multi-XCC systems this assumption is empirically
   // violated. To avoid permanently dropping a slot that just hasn't
-  // been written yet, init-sync stops at the first zero record_type
-  // (see the loop body below) and leaves qs.next_idx pointing AT
-  // that slot, so the next drain pass re-evaluates it once FW has
-  // had a chance to commit.
+  // been written yet, the loop below stops at the first zero
+  // record_type in [next_idx, observed) regardless of init-sync vs.
+  // steady-state, and leaves qs.next_idx pointing AT that slot, so
+  // the next drain pass re-evaluates it once FW has had a chance to
+  // commit. This also covers the original C7 init-sync case (a slot
+  // pre-zeroed by SetProfiling that hasn't been written for THIS
+  // queue lifecycle yet).
   //
   // Backward-publish protection (still needed because signal races too):
   // qs.next_idx is our host-side monotonic floor. If FW publishes a
@@ -512,35 +565,37 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     //      5002, silently dropping the records at slots 5000 and 5001
     //      with no kernel_dispatch_drop event.
     //
-    // Fix: make init-sync independent of `observed` magnitude and
-    // independent of whether the host fell behind. We treat the first
-    // non-zero signal observation specially:
-    //   - Compute the candidate scan window [start, end). For a fresh
-    //     buffer, the meaningful window is the suffix of FW-written
-    //     slots ending at end-1; older slots are pre-zeroed and stale.
-    //   - During init-sync only, validate each slot's record_type
-    //     during emit. The first zero record_type STOPS the scan
-    //     and leaves qs.next_idx pointing at that slot so the next
-    //     drain pass will re-evaluate it. This is conservative under
-    //     the multi-XCC hazard: a zero slot in our window may be
-    //     either (a) a pre-zeroed stale slot, or (b) a slot whose
-    //     XCC hasn't published the record body yet even though a
-    //     higher-index slot's signal was already observed. We can't
-    //     distinguish (a) from (b) cheaply, so we wait. The cost is
-    //     one extra drain pass to consume the records; the benefit
-    //     is no permanently-dropped records.
-    //   - Do NOT emit kernel_dispatch_drop during init-sync — the
-    //     pre-zeroed gap represents records that never existed for
-    //     this queue lifecycle, not records the host fell behind on.
+    // Code-quality C8/C9: the C7-era fix gated zero-rt-stop on
+    // initial_sync only, leaving steady-state Path A still emitting
+    // zero-body slots as records under the multi-XCC race (C9), and
+    // also wedging init-sync forever on a stale-zero prefix because
+    // forward progress required signal to lap the ring (C8). Unified
+    // fix:
+    //   - Zero-rt-stop applies on EVERY pass (init-sync and steady-
+    //     state) — the multi-XCC hazard is the same in both regimes.
+    //     A zero slot in [next_idx, observed) means STOP, leave
+    //     qs.next_idx at that slot, return.
+    //   - Stale-zero quarantine: track (stall_observed, stall_idx,
+    //     stall_first_seen). If a subsequent pass sees the same
+    //     coordinate AND has been stalled for kStaleZeroQuarantineMs,
+    //     declare the slot stale, emit a one-record
+    //     kernel_dispatch_drop event for visibility, advance next_idx
+    //     by 1, clear the quarantine. This guarantees forward progress
+    //     without silently dropping in-flight publishes.
+    //   - The worker loop honors qs.pending_zero_stall.load() and
+    //     skips its signal-equal fast-skip while quarantine is armed,
+    //     so the next pass actually runs at the polling cadence
+    //     instead of sleeping until *signal_ptr advances (which it
+    //     never will, in the stale case).
     //
-    // Single-producer caveat: if a future FW spec rev guarantees a
-    // single globally-ordered producer (or adds an atomic publish
-    // barrier across XCCs), this pessimistic stop-at-zero can be
-    // relaxed back to "skip and continue". Until then, stopping is
-    // the only way to avoid the drop documented in C7.
+    // initial_sync is still tracked here for one purpose: suppressing
+    // the kernel_dispatch_drop emit on the overrun-skip path. On the
+    // very first observation, "we fell behind by more than a ring lap"
+    // is meaningless — we never had a chance to catch up, and the
+    // skipped slots are pre-zeroed and never carried real records for
+    // THIS queue lifecycle. Steady-state is the only regime where
+    // overrun represents a real consumer-visible drop.
     const bool initial_sync = (qs.next_idx == 0);
-    bool init_sync_stopped_at_zero = false;
-    uint64_t init_sync_resume_idx = 0;
 
     // Overrun detection. If FW lapped us, log a drop event and skip
     // the unrecoverable region. The records we DO read after the skip
@@ -556,6 +611,9 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
             queue_id_to_wire(qs.queue_id), lost);
       }
       start = end - qs.ring_records;
+      // Overrun moved us forward — quarantine is no longer relevant
+      // (the slot we were stalled on has been overwritten by FW).
+      qs.pending_zero_stall.store(false, std::memory_order_release);
     }
 
     // Batched LTTng emit (see batch_buf / flush_batch declared above the
@@ -569,10 +627,16 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
       // and the next pass will pick up where we stopped (FW state
       // unchanged — the wptr-bound scan never mutates the slot). Flush
       // any pending batch first so we don't lose records already read.
+      // Also clear any armed stale-zero quarantine so the worker does
+      // not tight-loop calling drain (which would immediately bail
+      // here again) while tracing is disabled — a fresh quarantine
+      // snapshot will be re-armed on the next pass that observes the
+      // same zero slot once tracing re-enables.
       if (!force_emit && rocm_trace_disabled()) {
         flush_batch();
         qs.next_idx = i;  // record progress so far
         if (qs.rptr_ptr) __atomic_store_n(qs.rptr_ptr, i, __ATOMIC_RELEASE);
+        qs.pending_zero_stall.store(false, std::memory_order_release);
         return any;
       }
 
@@ -580,40 +644,76 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
       auto* rec = reinterpret_cast<mec_dispatch_record_16*>(
           static_cast<char*>(qs.ring_base) + slot * kSlotStride);
 
-      // Init-sync validation (C7): STOP at the first zero record_type
-      // during init-sync. FW writes record_type ∈ {1, 2}; a slot with
-      // rt==0 in our scan window [next_idx, observed) during init-sync
-      // is either:
+      // Zero-rt-stop (C8/C9 unified): STOP at the first zero
+      // record_type in [next_idx, observed) on EVERY pass. FW writes
+      // record_type ∈ {1, 2}; a zero slot in our window is either:
       //   (a) a pre-zeroed stale slot (slot was never written for
-      //       this queue lifecycle), OR
+      //       this queue lifecycle — only possible while next_idx
+      //       has not yet advanced past the FW per-pipe scratch
+      //       wptr that was inherited at queue create), OR
       //   (b) a slot whose XCC has not finished publishing yet
       //       (XCC A's signal=N publish raced ahead of XCC B's
       //       slot[<N] body publish; spec §3.5 assumes single-
       //       producer ordering that does NOT hold across XCCs
       //       without an inter-XCC publish barrier).
-      // We can't distinguish (a) from (b) cheaply, so we stop and
-      // let the next pass re-evaluate. Leaving qs.next_idx at the
-      // zero slot's index means we re-scan from there next time;
-      // by then either FW has published (case b → emit it) or it
-      // stays zero (case a → we keep stopping until either signal
-      // grows past it via the overrun-skip path or the queue is
-      // destroyed). Cost: one extra drain pass to consume the
-      // window after FW commits. Benefit: no permanently-dropped
-      // records in case (b), no emit-all-zero record in either case.
+      // Both (a) and (b) can occur in steady state too — case (a)
+      // appears once at first observation; case (b) can appear at
+      // any time on multi-XCC queues. We can't distinguish (a) from
+      // (b) cheaply, so we stop, leave qs.next_idx pointing at the
+      // zero slot's index, and let the next pass re-evaluate. By
+      // then either:
+      //   - FW has published (case b → emit it next pass), or
+      //   - the slot is still zero AND the (observed, next_idx)
+      //     coordinate has not changed for kStaleZeroQuarantineMs
+      //     (case a → quarantine fires below, drops the slot, and
+      //     advances by 1).
       //
-      // Out of scope: steady-state (non-init-sync) passes still
-      // memcpy zero slots and emit them as records — the same
-      // multi-XCC hazard exists there but the historical behavior
-      // is preserved here to limit the C7 change to its claim.
       // Acquire ordering so the body loads (via memcpy below)
       // cannot be reordered above this check.
-      if (initial_sync) {
-        uint32_t rt = __atomic_load_n(&rec->record_type, __ATOMIC_ACQUIRE);
-        if (rt == 0) {
-          init_sync_stopped_at_zero = true;
-          init_sync_resume_idx = i;
-          break;
+      uint32_t rt = __atomic_load_n(&rec->record_type, __ATOMIC_ACQUIRE);
+      if (rt == 0) {
+        flush_batch();
+        // Quarantine update: same coordinate as last stall? If yes,
+        // check timeout; if no, snapshot now and arm.
+        const auto now = std::chrono::steady_clock::now();
+        if (qs.pending_zero_stall.load(std::memory_order_acquire) &&
+            qs.stall_observed == observed &&
+            qs.stall_idx      == i) {
+          const auto stalled_for_ms =
+              std::chrono::duration_cast<std::chrono::milliseconds>(
+                  now - qs.stall_first_seen).count();
+          if (stalled_for_ms >= kStaleZeroQuarantineMs) {
+            // Slot declared stale (case a). Emit one-record drop
+            // event for consumer visibility, advance past it, and
+            // disarm the quarantine. Note we do NOT continue the
+            // scan in this pass — the next pass will pick up at
+            // i+1 and re-evaluate the rest of [i+1, observed).
+            // This keeps the per-pass cost bounded and avoids
+            // back-to-back stale-slot fires within a single pass.
+            rocm_trace_emit_hsa_kernel_dispatch_drop(
+                queue_id_to_wire(qs.queue_id), 1);
+            qs.next_idx = i + 1;
+            if (qs.rptr_ptr) {
+              __atomic_store_n(qs.rptr_ptr, i + 1, __ATOMIC_RELEASE);
+            }
+            qs.pending_zero_stall.store(false, std::memory_order_release);
+            return true;  // forward progress: drop event emitted
+          }
+        } else {
+          qs.stall_observed   = observed;
+          qs.stall_idx        = i;
+          qs.stall_first_seen = now;
+          qs.pending_zero_stall.store(true, std::memory_order_release);
         }
+        // Quarantine armed but not yet expired: park next_idx at the
+        // zero slot and return. Next worker iteration will re-enter
+        // drain (worker honors pending_zero_stall and skips its
+        // signal-equal fast-skip).
+        qs.next_idx = i;
+        if (qs.rptr_ptr) {
+          __atomic_store_n(qs.rptr_ptr, i, __ATOMIC_RELEASE);
+        }
+        return any;
       }
 
       // FW publish-ordering contract (per f32_mec.uc Q6): record body
@@ -636,20 +736,11 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     }
     flush_batch();
 
-    // C7: if init-sync hit a zero hole, leave qs.next_idx pointing AT
-    // that slot so the next drain pass re-evaluates it. We must NOT
-    // advance past the hole — under the multi-XCC hazard the slot may
-    // simply not have been published yet by its producing XCC, and
-    // skipping it would permanently drop the record. Note this also
-    // means we do NOT publish `end` to qs.rptr_ptr in this case, since
-    // we have not actually consumed [resume_idx, end).
-    if (init_sync_stopped_at_zero) {
-      qs.next_idx = init_sync_resume_idx;
-      if (qs.rptr_ptr) {
-        __atomic_store_n(qs.rptr_ptr, init_sync_resume_idx, __ATOMIC_RELEASE);
-      }
-      return any;
-    }
+    // Reached `end` without hitting a zero — full forward progress.
+    // Disarm any prior stale-zero quarantine (we successfully consumed
+    // the slot we were stalled on, or the consumer caught up another
+    // way).
+    qs.pending_zero_stall.store(false, std::memory_order_release);
     qs.next_idx = end;
     // Publish our consumer position back to FW (informational; FW does
     // not enforce backpressure today but reads on connect/dequeue).
@@ -809,7 +900,17 @@ void per_queue_drain_loop(std::shared_ptr<queue_drain_state> qs) {
     // skip the drain call entirely when no new records exist.
     if (qs->signal_ptr != nullptr) {
       const uint64_t cur = __atomic_load_n(qs->signal_ptr, __ATOMIC_ACQUIRE);
-      if (cur == last_signal) {
+      // Stale-zero quarantine override (debate stage code-quality C8):
+      // when drain_one_queue parked next_idx on a zero slot inside
+      // [next_idx, observed), pending_zero_stall is armed. Forward
+      // progress in that state requires us to keep CALLING drain (so
+      // the quarantine timer fires once kStaleZeroQuarantineMs has
+      // elapsed) even though *signal_ptr has not advanced. Honor the
+      // armed flag by bypassing the signal-equal fast-skip; we still
+      // adaptive-sleep below if drain returns no work.
+      const bool stalled =
+          qs->pending_zero_stall.load(std::memory_order_acquire);
+      if (cur == last_signal && !stalled) {
         // No new records — adaptive backoff
         ++idle_count;
         if (idle_count <= 3) {
@@ -823,8 +924,10 @@ void per_queue_drain_loop(std::shared_ptr<queue_drain_state> qs) {
         }
         continue;
       }
-      last_signal = cur;
-      idle_count = 0;
+      if (cur != last_signal) {
+        last_signal = cur;
+        idle_count = 0;
+      }
     }
 
     const bool any = drain_one_queue(*qs, /* force_emit = */ false);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -61,6 +61,15 @@
 // path here just calls QueueProfilingAcquire/Release (which forward to
 // SetProfiling) and then queries hsa_amd_profiling_get_dispatch_records
 // to fetch the buffer info.
+//
+// SENTINEL-SCAN DESIGN: The substrate publishes neither a host-readable FW
+// write pointer nor any other end-of-records marker. The drainer locates
+// fresh records by scanning the ring sequentially from a host-managed
+// monotonic cursor (next_idx). A slot whose record_type is 0 is "empty"
+// (FW writes record_type ∈ {1,2}, and the buffer is pre-zeroed at alloc
+// in AqlQueue::SetProfiling). After consuming a slot the drainer zeroes
+// it again so wraparound rewrites are re-detectable. See drain_one_queue
+// below for the canonical implementation.
 
 #include "core/inc/dispatch_log.h"
 
@@ -135,21 +144,21 @@ struct queue_drain_state {
   std::function<uint64_t(uint64_t /* gpu_ts */)> translate_gpu_ts;
 
   // NON-OWNING ring view. The buffer is owned by AqlQueue::dispatch_record_buffer_;
-  // do not free here.
+  // do not free here. The kernel-side BO is `ring_records * 40` bytes
+  // (host KFD enforces the 40-byte slot stride — see
+  // amd/amdkfd/kfd_process_queue_manager.c:633 `buf_byte_size = count * 40`).
+  // FW writes 16 bytes per slot; the trailing 24 bytes per slot are FW-owned
+  // and reserved for future per-slot metadata.
   void*    ring_base    = nullptr;     // host-virtual base of the FW record area
-  uint32_t record_count = 0;           // power-of-2 number of 16-byte slots
-  uint32_t record_mask  = 0;           // record_count - 1, for slot indexing
+  uint32_t ring_records = 0;           // power-of-2 slot count (e.g. 65536)
+  uint32_t ring_mask    = 0;           // ring_records - 1, for slot indexing
 
-  // FW-written 32-bit monotonic record counter. Lives outside the buffer
-  // (cpc_tracing infrastructure exposes it as a separate uint32_t* via
-  // hsa_amd_profiling_get_dispatch_records). Pointer is owned by AqlQueue.
-  volatile uint32_t* fw_wptr_records = nullptr;
-
-  // Mutated only under drain_mu (see below). Host-extended 64-bit version
-  // of the FW record cursor; we extend the FW's uint32_t monotonic record
-  // counter into a uint64_t so wraparound across the 32-bit boundary doesn't
-  // confuse our overrun bookkeeping.
-  uint64_t read_record_cursor = 0;
+  // Host-managed monotonic record cursor. Mutated only under drain_mu.
+  // Slot index is (next_idx & ring_mask). Sentinel-scan design: the
+  // substrate publishes no FW wptr, so we advance next_idx for every
+  // slot whose record_type is non-zero, and zero the slot after consume
+  // so a wraparound re-write is re-detectable. See drain_one_queue.
+  uint64_t next_idx = 0;
   std::unordered_map<uint32_t, uint64_t> pending_starts;
 
   // Per-queue drain mutex. Serializes drain_one_queue() (steady state) and
@@ -341,101 +350,102 @@ void for_each_known_queue_locked(F&& fn) {
 }
 
 // ============================================================================
-// drain_one_queue (spec §7). Holds qs.drain_mu for the entire pass.
+// drain_one_queue. Holds qs.drain_mu for the entire pass.
 //
-// Reads the FW-written uint32_t record counter, host-extends it to 64 bits
-// (so wrap of the FW counter doesn't confuse us across drain calls), then
-// walks new records from read_record_cursor up to the host-extended fw cursor.
-// Each record is 16 bytes; the slot index is (cursor & record_mask).
+// Sentinel-scan design: the substrate publishes no host-readable FW write
+// pointer (KFD `kfd_ioctl_update_queue_args` has only
+// dispatch_record_buffer_addr/size — see
+// /usr/src/amdgpu-*/include/uapi/linux/kfd_ioctl.h:99-108 on a host with
+// the gbt350 KFD). Instead, FW writes record_type ∈ {1, 2} into each slot
+// it produces; the host pre-zeroes the buffer at allocation
+// (AqlQueue::SetProfiling), so a slot whose record_type is 0 is "empty".
+//
+// We walk the ring sequentially from a host-managed monotonic cursor
+// (qs.next_idx). Each iteration:
+//   1. Read record_type for the slot at (next_idx & ring_mask).
+//   2. If 0, the ring tail has caught up — break and return.
+//   3. Otherwise snapshot the rest of the record, ZERO the slot (so a
+//      future wraparound re-write of the same slot can be re-detected),
+//      and process the START / END pairing as before.
+//
+// The 40-byte slot stride is enforced by the host kernel BO size check
+// (kfd_process_queue_manager.c:633 `buf_byte_size = count * 40` on
+// gbt350). FW only writes the first 16 bytes of each slot; the trailing
+// 24 bytes are FW-owned and reserved for future per-slot metadata. We
+// zero ALL 40 bytes when consuming a slot because FW's wraparound write
+// may rewrite the entire slot, including the trailing reserved region.
 // ============================================================================
+
+// Host kernel-enforced per-slot stride for the dispatch-record BO. See
+// citation above. Hardcoded; ABI extensions that grow the slot will
+// require a coordinated update of this constant + AqlQueue::SetProfiling
+// alloc size.
+constexpr size_t kSlotStride = 40;
 
 bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
   std::lock_guard<std::mutex> lk(qs.drain_mu);
 
-  // KNOWN GAP (see dispatch_log.h banner + spec §10 dep #2 sub-bullet):
-  // qs.fw_wptr_records points at AqlQueue::dispatch_record_wptr_, a host-side
-  // uint32_t whose ADDRESS is NEVER published to KFD or firmware on the
-  // current substrate. libhsakmt's hsaKmtSetQueueProfilingBuffer discards
-  // the WptrHostAddr argument, and kfd_ioctl_update_queue_args has no
-  // wptr_addr field. Result: this counter stays at 0 forever, the
-  // `fw_extended == qs.read_record_cursor` early-out below always fires, and
-  // this loop is effectively DORMANT (the polling cost is still incurred,
-  // but no records are paired or emitted). The drainer will start producing
-  // records only after the substrate is extended (KFD ABI + FW contract) to
-  // publish wptr to firmware.
-  if (qs.fw_wptr_records == nullptr || qs.ring_base == nullptr ||
-      qs.record_count == 0) {
-    return false;
-  }
+  // Poisoned (disable in flight) or never-populated.
+  if (qs.ring_base == nullptr || qs.ring_records == 0) return false;
 
-  // Snapshot the FW's 32-bit monotonic record counter and host-extend it.
-  // The high 32 bits we add are taken from our last-known cursor: as long
-  // as we drain at least once per (2^32) records, this extension is correct.
-  // 65536 records buffered, so we'd lose data well before wrap-extension
-  // ambiguity matters.
-  const uint32_t fw_lo = __atomic_load_n(qs.fw_wptr_records, __ATOMIC_ACQUIRE);
-  uint64_t fw_extended = (qs.read_record_cursor & ~uint64_t(0xFFFFFFFFu)) | fw_lo;
-  if (fw_extended < qs.read_record_cursor) {
-    // Low 32 bits wrapped past us; bump the high half.
-    fw_extended += uint64_t(1) << 32;
-  }
-  if (fw_extended == qs.read_record_cursor) return false;
+  bool any = false;
+  while (true) {
+    const uint64_t slot = qs.next_idx & qs.ring_mask;
+    auto* rec = reinterpret_cast<mec_dispatch_record_16*>(
+        static_cast<char*>(qs.ring_base) + slot * kSlotStride);
 
-  // Wraparound check (spec §6 bytes_lost field definition). With 65536
-  // records, an overrun means FW outpaced us by more than the buffer
-  // depth.
-  const uint64_t records_avail = fw_extended - qs.read_record_cursor;
-  if (records_avail > qs.record_count) {
-    // Narrow internal 64-bit queue_id to the 32-bit on-the-wire id at the
-    // tracepoint boundary (spec §6 / §14, C5 fix). Report the loss in
-    // bytes for compatibility with the existing tracepoint payload.
-    rocm_trace_emit_hsa_kernel_dispatch_drop(
-        queue_id_to_wire(qs.queue_id),
-        records_avail * sizeof(mec_dispatch_record_16));
-    qs.read_record_cursor = fw_extended - qs.record_count;
+    // Sentinel: record_type == 0 means "empty / not yet written by FW".
+    uint32_t rt = rec->record_type;
+    if (rt == 0) break;
+    // Defend against torn writes: re-read with an acquire fence so we are
+    // sure the rest of the record (timestamps, dispatch_idx) are visible
+    // before we consume them. If the slot is zero on the second read, the
+    // first read raced with FW's pre-publication zero state and we should
+    // wait for the next pass.
+    std::atomic_thread_fence(std::memory_order_acquire);
+    rt = rec->record_type;
+    if (rt == 0) break;
 
-    // C7 fix: across an overrun event, ALL previously cached STARTs are
-    // suspect. The drainer cannot tell which records the FW just overwrote
-    // (spec §7 / drop tracepoint semantics). Conservative: drop them.
-    qs.pending_starts.clear();
-  }
+    // Snapshot the rest of the record locally before zeroing the slot.
+    const uint32_t ts_lo        = rec->ts_lo;
+    const uint32_t ts_hi        = rec->ts_hi;
+    const uint32_t dispatch_idx = rec->dispatch_idx;
+    const uint64_t gpu_ts       = (static_cast<uint64_t>(ts_hi) << 32) | ts_lo;
 
-  while (qs.read_record_cursor < fw_extended) {
-    const uint32_t slot = static_cast<uint32_t>(qs.read_record_cursor & qs.record_mask);
-    const auto* rec = reinterpret_cast<const mec_dispatch_record_16*>(
-        static_cast<const char*>(qs.ring_base) + slot * sizeof(mec_dispatch_record_16));
+    // Zero the consumed slot so a wraparound rewrite by FW (next time the
+    // ring loops past this position) is re-detected as a fresh non-zero
+    // record_type. Zero the full kSlotStride — FW writes the whole slot,
+    // and the trailing 24 bytes per slot are reserved for future
+    // per-slot metadata that we do not interpret today.
+    std::memset(rec, 0, kSlotStride);
 
-    const uint64_t gpu_ts =
-        (static_cast<uint64_t>(rec->ts_hi) << 32) | rec->ts_lo;
-
-    if (rec->record_type == DISPATCH_LOG_RECORD_START) {
-      qs.pending_starts[rec->dispatch_idx] = gpu_ts;
-    } else if (rec->record_type == DISPATCH_LOG_RECORD_END) {
-      auto it = qs.pending_starts.find(rec->dispatch_idx);
+    if (rt == DISPATCH_LOG_RECORD_START) {
+      qs.pending_starts[dispatch_idx] = gpu_ts;
+    } else if (rt == DISPATCH_LOG_RECORD_END) {
+      auto it = qs.pending_starts.find(dispatch_idx);
       if (it != qs.pending_starts.end()) {
         const uint64_t start_gpu = it->second;
-        const uint32_t didx = rec->dispatch_idx;
         qs.pending_starts.erase(it);
 
-        // Use the captured queue-independent translation callable. Spec §7
-        // explicitly forbids reaching through a Queue* here — Queue may be
-        // destroyed mid-pass even though the shared_ptr keeps qs alive.
+        // Use the captured queue-independent translation callable —
+        // Queue may be destroyed mid-pass even though the shared_ptr
+        // keeps qs alive.
         const uint64_t start_sys = qs.translate_gpu_ts(start_gpu);
         const uint64_t end_sys   = qs.translate_gpu_ts(gpu_ts);
 
         // Narrow internal 64-bit queue_id at the tracepoint boundary
-        // (spec §6 / §14, C5 fix). dispatch_idx is already 32-bit per the
-        // FW record contract (mec_dispatch_record_16::dispatch_idx).
+        // (spec §6 / §14, C5 fix). dispatch_idx is 32-bit per FW contract.
         rocm_trace_emit_hsa_kernel_dispatch_complete(
-            queue_id_to_wire(qs.queue_id), didx, start_sys, end_sys,
-            force_emit);
+            queue_id_to_wire(qs.queue_id), dispatch_idx, start_sys,
+            end_sys, force_emit);
       }
-      // else: orphan END (start was lost to wraparound). Silently skip.
+      // else: orphan END (matching START was lost). Silently skip.
     }
 
-    qs.read_record_cursor += 1;
+    qs.next_idx += 1;
+    any = true;
   }
-  return true;
+  return any;
 }
 
 // Synchronous final drain on the calling thread. Looks up the queue's
@@ -625,9 +635,8 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
   // Step 2: read back the per-queue ring buffer info from AqlQueue.
   void* buf = nullptr;
   uint32_t buf_bytes = 0;
-  volatile uint32_t* fw_wptr = nullptr;
-  hsa_status_t gs = aql_queue->GetProfilingDispatchRecords(&buf, &buf_bytes, &fw_wptr);
-  if (gs != HSA_STATUS_SUCCESS || buf == nullptr || buf_bytes == 0 || fw_wptr == nullptr) {
+  hsa_status_t gs = aql_queue->GetProfilingDispatchRecords(&buf, &buf_bytes);
+  if (gs != HSA_STATUS_SUCCESS || buf == nullptr || buf_bytes == 0) {
     std::fprintf(stderr,
                  "[hsa-runtime] dispatch_log: queue_id=%llu ENABLE step 2 "
                  "(GetProfilingDispatchRecords) failed status=%d\n",
@@ -641,7 +650,7 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
   // GetProfilingDispatchRecords reports buf_bytes = record_count * 16
   // (the FW record-stride sized capacity). The kernel-side BO is
   // oversized (count * 40) per the host KFD ABI; the drainer iterates
-  // 16-byte records.
+  // 40-byte slots and only interprets the first 16 bytes per slot.
   const uint32_t record_count = buf_bytes / static_cast<uint32_t>(sizeof(mec_dispatch_record_16));
   if (record_count == 0 || (record_count & (record_count - 1)) != 0) {
     std::fprintf(stderr,
@@ -656,13 +665,12 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
   // Step 3: register in the drainer registry. NON-OWNING — buffer is
   // owned by AqlQueue, freed on SetProfiling(false) or AqlQueue dtor.
   auto qs = std::make_shared<queue_drain_state>();
-  qs->queue_id           = queue_id_of(q);
-  qs->translate_gpu_ts   = make_translate_gpu_ts(q);
-  qs->ring_base          = buf;
-  qs->record_count       = record_count;
-  qs->record_mask        = record_count - 1;
-  qs->fw_wptr_records    = fw_wptr;
-  qs->read_record_cursor = 0;
+  qs->queue_id         = queue_id_of(q);
+  qs->translate_gpu_ts = make_translate_gpu_ts(q);
+  qs->ring_base        = buf;
+  qs->ring_records     = record_count;
+  qs->ring_mask        = record_count - 1;
+  qs->next_idx         = 0;
 
   g_active_queues[qs->queue_id] = qs;
 
@@ -688,7 +696,7 @@ void disable_dispatch_log_for_queue_locked(core::Queue* q) {
   // then calling QueueProfilingRelease (which frees the buffer):
   //
   //   - drain_one_queue takes drain_mu first thing, then early-returns
-  //     on ring_base==nullptr || record_count==0. Any drainer that
+  //     on ring_base==nullptr || ring_records==0. Any drainer that
   //     hasn't started its pass for this queue yet will exit early.
   //   - Any drainer already inside drain_one_queue holds drain_mu, so
   //     the poisoning step blocks until it completes its current pass.
@@ -714,15 +722,14 @@ void disable_dispatch_log_for_queue_locked(core::Queue* q) {
   //    drain_mu acquire serializes with any in-progress drain pass.
   if (qs_ptr) {
     std::lock_guard<std::mutex> lk(qs_ptr->drain_mu);
-    qs_ptr->ring_base       = nullptr;
-    qs_ptr->fw_wptr_records = nullptr;
-    qs_ptr->record_count    = 0;
-    qs_ptr->record_mask     = 0;
+    qs_ptr->ring_base    = nullptr;
+    qs_ptr->ring_records = 0;
+    qs_ptr->ring_mask    = 0;
   }
 
   // e. Unregister from drainer registry. Drops the registry's shared_ptr
   //    ref. Any in-flight drainer snapshot still holds its own ref to
-  //    qs_ptr but its ring_base/fw_wptr_records are now nullptr.
+  //    qs_ptr but its ring_base is now nullptr.
   g_active_queues.erase(queue_id_of(q));
 
   // f. Release profiling ref. On the 1->0 edge AqlQueue::SetProfiling(false)

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -587,17 +587,18 @@ namespace {
 // ============================================================================
 // Per-queue ENABLE / DISABLE sequences (spec §5).
 //
-// New flow (post cpc_tracing infrastructure import):
+// Flow:
 //   1. Skip non-AQL / non-GPU queues.
 //   2. Skip if substrate is absent or agent is on the no-dispatch-log list.
 //   3. QueueProfilingAcquire -> AqlQueue::SetProfiling(true) -> alloc
 //      buffer + KFD UPDATE_QUEUE with the new trailing fields.
-//   4. AqlQueue::GetProfilingDispatchRecords to read back the buffer base,
-//      total bytes, and FW wptr pointer.
-//   5. Register a non-owning queue_drain_state in g_active_queues.
-//
-// The previous Phase A path's bespoke buffer alloc + placeholder KFD ioctl
-// has been removed entirely.
+//   4. AqlQueue::GetProfilingDispatchRecords to read back the buffer base
+//      and the FW-record-stride capacity in bytes (record_count * 16).
+//      The substrate publishes no host-visible FW write pointer; consumers
+//      locate fresh records via sentinel scan over per-slot record_type.
+//   5. Register a non-owning queue_drain_state in g_active_queues with
+//      next_idx = 0 (the host-managed monotonic record cursor used by
+//      the sentinel-scan drainer).
 // ============================================================================
 
 void enable_dispatch_log_for_queue_locked(core::Queue* q) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -174,12 +174,13 @@ struct queue_drain_state {
   // drains are not blocked.
   std::mutex drain_mu;
 
-  // Per-queue worker thread shutdown signal + handle. Set true and joined
-  // by disable_dispatch_log_for_queue_locked (and by the destructor as a
-  // defensive safety net in case any code path drops a queue_drain_state
-  // without joining first). The worker checks should_stop with acquire
-  // ordering each iteration; the disable path stores it with release
-  // ordering before joining.
+  // Per-queue worker thread shutdown signal + handle. The supported
+  // ownership model is: disable_dispatch_log_for_queue_locked stores
+  // should_stop with release ordering and joins worker BEFORE
+  // dropping the registry's shared_ptr ref. The worker checks
+  // should_stop with acquire ordering each iteration. The destructor
+  // (below) is NOT a generic safety net for unjoined-running workers
+  // — see the destructor comment for the narrow case it handles.
   std::atomic<bool> should_stop{false};
   std::thread       worker;
 
@@ -791,23 +792,23 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
     return;
   }
 
-  // Step 3: register in the drainer registry. NON-OWNING — buffer is
-  // owned by AqlQueue, freed on SetProfiling(false) or AqlQueue dtor.
-  auto qs = std::make_shared<queue_drain_state>();
-  qs->queue_id         = queue_id_of(q);
-  qs->translate_gpu_ts = make_translate_gpu_ts(q);
-  qs->ring_base        = buf;
-  qs->ring_records     = record_count;
-  qs->ring_mask        = record_count - 1;
-  qs->next_idx         = 0;
-
-  g_active_queues[qs->queue_id] = qs;
-
-  // Step 4: spawn the per-queue drainer worker AFTER registration. The
-  // worker holds its own shared_ptr<queue_drain_state> by value (passed
-  // into per_queue_drain_loop), so qs is alive for the full thread
-  // lifetime even if the registry entry is erased before the worker
-  // observes should_stop.
+  // Steps 3-4: post-acquire setup. EVERYTHING that can throw between
+  // QueueProfilingAcquire (above, which bumped the profiling refcount)
+  // and the final dispatch_log_active.store(true) goes inside one
+  // try block, so any throw rolls the profiling refcount back via
+  // QueueProfilingRelease(q) and we exit cleanly. The next poller
+  // tick will retry this queue.
+  //
+  // What can throw here:
+  //   - std::make_shared<queue_drain_state>() (allocation)
+  //   - std::function copy of make_translate_gpu_ts(q) (allocation)
+  //   - g_active_queues[qs->queue_id] = qs (unordered_map insert,
+  //     can throw on rehash allocation)
+  //   - std::thread(per_queue_drain_loop, qs) (std::system_error on
+  //     EAGAIN / RLIMIT_NPROC / address-space exhaustion — review
+  //     C1 stage-2 code-quality)
+  //   - shared_ptr copies into per_queue_drain_loop's by-value
+  //     parameter (allocation; happens inside std::thread ctor)
   //
   // Stack-size note: std::thread does not expose pthread_attr_setstacksize
   // portably, so each worker uses the default pthread stack (typically
@@ -817,27 +818,45 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
   // would need a pthread_create-based spawn helper to set a small (e.g.
   // 64 KiB) stack; defer that until measured pressure exists.
   //
-  // Failure handling (review C1, stage-2 code-quality): std::thread's
-  // ctor can throw std::system_error if the OS refuses to create the
-  // thread (EAGAIN / RLIMIT_NPROC / address-space exhaustion). Without
-  // a catch the exception would propagate up — to the poller's tick
-  // (which has no handler and would std::terminate the process), or
-  // to on_queue_create on an application thread. Roll back to the
-  // pre-enable state instead: erase the registry entry and release
-  // the profiling ref. The next poller tick will retry; the queue
-  // simply skips this tick.
+  // Order rationale (review C3, stage-2 code-quality): catch ANY
+  // exception (not just std::system_error) so that allocation failures
+  // before the std::thread spawn — std::make_shared, std::function
+  // copy, unordered_map insert — also unwind cleanly. The previous
+  // narrower catch left a refcount-leak window from
+  // QueueProfilingAcquire success to the std::thread call.
+  std::shared_ptr<queue_drain_state> qs;
   try {
+    // Step 3: register in the drainer registry. NON-OWNING — buffer is
+    // owned by AqlQueue, freed on SetProfiling(false) or AqlQueue dtor.
+    qs = std::make_shared<queue_drain_state>();
+    qs->queue_id         = queue_id_of(q);
+    qs->translate_gpu_ts = make_translate_gpu_ts(q);
+    qs->ring_base        = buf;
+    qs->ring_records     = record_count;
+    qs->ring_mask        = record_count - 1;
+    qs->next_idx         = 0;
+
+    g_active_queues[qs->queue_id] = qs;
+
+    // Step 4: spawn the per-queue drainer worker AFTER registration.
+    // The worker holds its own shared_ptr<queue_drain_state> by value
+    // (passed into per_queue_drain_loop), so qs is alive for the full
+    // thread lifetime even if the registry entry is erased before the
+    // worker observes should_stop.
     qs->worker = std::thread(per_queue_drain_loop, qs);
-  } catch (const std::system_error& e) {
+  } catch (const std::exception& e) {
     std::fprintf(stderr,
-                 "[hsa-runtime] dispatch_log: queue_id=%llu ENABLE step 4 "
-                 "(std::thread spawn) failed: %s; rolling back enable\n",
+                 "[hsa-runtime] dispatch_log: queue_id=%llu ENABLE post-acquire "
+                 "setup failed: %s; rolling back enable\n",
                  static_cast<unsigned long long>(queue_id_of(q)),
                  e.what());
-    g_active_queues.erase(qs->queue_id);
+    // Erase from registry if we got far enough to insert. erase() is
+    // safe on a missing key (returns 0).
+    g_active_queues.erase(queue_id_of(q));
+    // Release the profiling ref bumped by QueueProfilingAcquire above.
+    // dispatch_log_active was never flipped to true, so no flag
+    // rollback is needed. The next poller enable pass will retry.
     QueueProfilingRelease(q);
-    // dispatch_log_active was never flipped to true, so no flag rollback
-    // needed. The next poller enable pass will retry this queue.
     return;
   }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -1121,15 +1121,21 @@ hsa_status_t QueueProfilingRelease(core::Queue* q) {
   }
   owners->refcount -= 1;
   if (owners->refcount == 0) {
-    // 1->0 transition: AqlQueue::SetProfiling(false) frees the per-queue
-    // dispatch-record buffer and clears the KFD profiling-buffer
-    // registration via UPDATE_QUEUE.
+    // 1->0 transition: AqlQueue::SetProfiling(false) clears the KFD
+    // profiling-buffer registration via UPDATE_QUEUE (legacy
+    // SetQueueProfilingBuffer + new SetDispatchLog with addr=0); on
+    // success it then frees the per-queue dispatch-record buffer and
+    // host-VA counter words and clears the profiling bit.
     //
-    // C3: propagate libhsakmt teardown status. The host-side buffer is
-    // freed unconditionally (see SetProfiling), so we cannot recover the
-    // resources by retrying — a non-success status here is informational
-    // for the caller (e.g. test harnesses) and not a state-corruption
-    // signal.
+    // C3 + C6: propagate libhsakmt teardown status. On KFD clear failure,
+    // SetProfiling intentionally quarantines the live buffer (does NOT
+    // free it) and leaves the profiling bit SET to keep the FW contract
+    // intact while the MQD may still reference the BO; the buffer is
+    // only released by the AqlQueue dtor after KFD has destroyed the
+    // queue. A non-success status here therefore signals a quarantined
+    // resource that will not be retried — a subsequent enable on the
+    // same queue hits the "buffer already wired" no-op path in
+    // SetProfiling(true) and reuses the quarantined allocation.
     return q->SetProfiling(false);
   }
   return HSA_STATUS_SUCCESS;
@@ -1222,10 +1228,13 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
   }
 
   // GetProfilingDispatchRecords reports buf_bytes = record_count * 16
-  // (the FW record-stride sized capacity). The kernel-side BO is
-  // oversized at count * 40 to satisfy host KFD ABI validation, but the
-  // FW writes — and the drainer reads — at the 16-byte FW record stride
-  // (kSlotStride). See dispatch_log.cpp:390 and the slot addressing at
+  // (the FW record-stride sized capacity). The kernel-side BO is also
+  // allocated at exactly count * 16 — the earlier *40 sizing was a
+  // workaround for an older pre-fix kernel that over-counted the stride
+  // in its BO-size validation; both that older kernel and the current
+  // kfd_process_queue_manager.c validation accept *16. FW writes — and
+  // the drainer reads — at the 16-byte FW record stride (kSlotStride).
+  // See dispatch_log.cpp:390 and the slot addressing at
   // dispatch_log.cpp:400-402.
   const uint32_t record_count = buf_bytes / static_cast<uint32_t>(sizeof(mec_dispatch_record_16));
   if (record_count == 0 || (record_count & (record_count - 1)) != 0) {
@@ -1458,7 +1467,12 @@ void disable_dispatch_log_for_queue_locked(core::Queue* q) {
 
   // e. Release profiling ref. On the 1->0 edge AqlQueue::SetProfiling(false)
   //    clears the KFD profiling-buffer registration (UPDATE_QUEUE with
-  //    addr=0) and frees the per-queue dispatch-record buffer.
+  //    addr=0). On success it then frees the per-queue dispatch-record
+  //    buffer and clears the profiling bit; on KFD clear failure
+  //    (C6 quarantine path) it leaves the buffer live and the profiling
+  //    bit set so the FW contract is preserved while the MQD may still
+  //    reference the BO — the dtor releases the quarantined allocation
+  //    after KFD has destroyed the queue.
   //    QueueProfilingRelease takes g_profiling_refcounts_mu, NOT g_queue_registry_mu.
   //    By this point the worker is joined so no thread can dereference
   //    the buffer.
@@ -1467,7 +1481,8 @@ void disable_dispatch_log_for_queue_locked(core::Queue* q) {
   //    BEFORE the registry erase. The release is the step that drives
   //    SetProfiling(false) on the underlying AqlQueue, which is the
   //    transition that makes the per-queue ring buffer cease to be
-  //    a profiling buffer; once that has returned, the queue is fully
+  //    a profiling buffer (or, on quarantine, ceases to be reachable
+  //    via this code path); once that has returned, the queue is fully
   //    quiesced from the dispatch_log perspective and erasing the
   //    registry slot is the final hand-off.
   QueueProfilingRelease(q);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -240,6 +240,30 @@ std::mutex g_lifecycle_mu;
 // drains). Holds one shared_ptr per active queue.
 std::unordered_map<uint32_t, std::shared_ptr<queue_drain_state>> g_active_queues;
 
+// Poller-only "live queue" side map (spec §4 enable/disable convergence).
+//
+// Distinct from g_active_queues: this tracks every Queue* known to the
+// dispatch_log subsystem (registered by on_queue_create, removed by
+// on_queue_destroy), regardless of whether dispatch logging is currently
+// enabled on it. The poller iterates this set under g_lifecycle_mu to drive
+// the §4 idempotent enable/disable passes:
+//
+//   - curr==true tick: for each Q in g_known_queues with
+//     dispatch_log_active==false, call enable_dispatch_log_for_queue(Q).
+//   - curr==false tick: for each Q in g_known_queues with
+//     dispatch_log_active==true, call disable_dispatch_log_for_queue(Q).
+//
+// **Lifetime contract.** The drainer NEVER reads this map (the
+// no-Queue*-in-drainer invariant of queue_drain_state — see spec §4 "Queue /
+// drain-state lifetime" — is therefore preserved). The poller and the
+// queue-create/destroy hooks all serialize on g_lifecycle_mu when touching
+// this map AND when calling enable/disable; on_queue_destroy removes from
+// g_known_queues BEFORE running the disable sequence, so the poller can
+// never observe a Queue* whose underlying core::Queue is being torn down by
+// the destroy thread (the destroy thread is forced to wait behind the
+// mutex if the poller is currently iterating).
+std::unordered_map<uint32_t, core::Queue*> g_known_queues;
+
 // Side-map for the QueueProfilingAcquire/Release refcount (spec §4a). One
 // entry per Queue* that has ever had at least one acquire. Looked up under
 // g_owners_mu.
@@ -462,14 +486,15 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
 // shared_ptr from the registry and forwards to drain_one_queue with
 // force_emit=true. Per spec §4: serialization with the drainer thread
 // happens via qs.drain_mu inside drain_one_queue.
-void ts_drainer_drain_now(core::Queue* q) {
+//
+// _locked variant: caller holds g_lifecycle_mu. Used by the poller and by
+// disable_dispatch_log_for_queue_locked, both of which iterate registries
+// under the lifecycle mutex.
+void ts_drainer_drain_now_locked(core::Queue* q) {
   std::shared_ptr<queue_drain_state> qs_ptr;
-  {
-    std::lock_guard<std::mutex> lk(g_lifecycle_mu);
-    auto it = g_active_queues.find(queue_id_of(q));
-    if (it == g_active_queues.end()) return;
-    qs_ptr = it->second;
-  }
+  auto it = g_active_queues.find(queue_id_of(q));
+  if (it == g_active_queues.end()) return;
+  qs_ptr = it->second;
   if (qs_ptr) {
     drain_one_queue(*qs_ptr, /* force_emit = */ true);
   }
@@ -569,7 +594,10 @@ namespace {
 // once-per-queue at WARNING.
 // ============================================================================
 
-void enable_dispatch_log_for_queue(core::Queue* q) {
+// _locked variant. Caller holds g_lifecycle_mu. Used by the poller's enable
+// pass (which iterates g_known_queues under the mutex) and by on_queue_create
+// via the public wrapper below.
+void enable_dispatch_log_for_queue_locked(core::Queue* q) {
   if (q == nullptr) return;
 
   // Idempotence guard: skip if already active.
@@ -584,10 +612,7 @@ void enable_dispatch_log_for_queue(core::Queue* q) {
   if (!g_substrate_present.load(std::memory_order_relaxed)) return;
 
   // Per-agent "no-dispatch-log" filter.
-  {
-    std::lock_guard<std::mutex> lk(g_lifecycle_mu);
-    if (g_no_dispatch_log_agents.count(q->GetAgent()) > 0) return;
-  }
+  if (g_no_dispatch_log_agents.count(q->GetAgent()) > 0) return;
 
   // Step 1: alloc.
   ring_alloc_t alloc = alloc_ring_buffer();
@@ -611,6 +636,8 @@ void enable_dispatch_log_for_queue(core::Queue* q) {
   std::memset(hdr->reserved, 0, sizeof(hdr->reserved));
 
   // Step 2: acquire profiling ref FIRST (spec §5 ordering rationale).
+  // QueueProfilingAcquire takes g_owners_mu, NOT g_lifecycle_mu, so it's
+  // safe to call while holding g_lifecycle_mu.
   hsa_status_t s = QueueProfilingAcquire(q);
   if (s != HSA_STATUS_SUCCESS) {
     std::fprintf(stderr,
@@ -645,7 +672,6 @@ void enable_dispatch_log_for_queue(core::Queue* q) {
                  "(KFD ioctl) failed errno=%d\n",
                  queue_id_of(q), rc);
     if (rc == ENOTSUP) {
-      std::lock_guard<std::mutex> lk(g_lifecycle_mu);
       g_no_dispatch_log_agents.insert(q->GetAgent());
     }
     QueueProfilingRelease(q);
@@ -666,10 +692,7 @@ void enable_dispatch_log_for_queue(core::Queue* q) {
   qs->generation         = generation;
   qs->read_cursor        = 0;
 
-  {
-    std::lock_guard<std::mutex> lk(g_lifecycle_mu);
-    g_active_queues[qs->queue_id] = qs;
-  }
+  g_active_queues[qs->queue_id] = qs;
 
   // Ownership of the buffer now lives in qs (shared_ptr destructor frees it).
   // Suppress the local alloc bookkeeping so a later free_ring_buffer on
@@ -680,7 +703,13 @@ void enable_dispatch_log_for_queue(core::Queue* q) {
   q->dispatch_log_active.store(true, std::memory_order_release);
 }
 
-void disable_dispatch_log_for_queue(core::Queue* q) {
+// _locked variant. Caller holds g_lifecycle_mu. Used by the poller's
+// disable pass, by shutdown(), and by on_queue_destroy via the public
+// wrapper below. Note that wait_for_idle and the KFD ioctl run while
+// the lifecycle mutex is held; this is acceptable because the lifecycle
+// mutex is contended only by other lifecycle events (queue create/destroy,
+// poller ticks every 5 ms), not by per-dispatch hot paths.
+void disable_dispatch_log_for_queue_locked(core::Queue* q) {
   if (q == nullptr) return;
   if (!q->dispatch_log_active.load(std::memory_order_acquire)) return;
 
@@ -690,7 +719,7 @@ void disable_dispatch_log_for_queue(core::Queue* q) {
   wait_for_idle(q);
 
   // b. Final drain with force_emit=true (spec §6).
-  ts_drainer_drain_now(q);
+  ts_drainer_drain_now_locked(q);
 
   // c. KFD ioctl DISABLE (best-effort).
   (void)kfd_dispatch_log_op(KFD_DISPATCH_LOG_OP_DISABLE, q,
@@ -698,16 +727,14 @@ void disable_dispatch_log_for_queue(core::Queue* q) {
                             /*write_ptr_addr=*/0, /*generation=*/0);
 
   // d. Release profiling ref (clears the bit only if 1->0).
+  // QueueProfilingRelease takes g_owners_mu, NOT g_lifecycle_mu.
   QueueProfilingRelease(q);
 
   // e. Unregister from drainer registry. Drops the registry's shared_ptr
   //    ref. Buffer free is gated by shared_ptr destructor — if a drainer
   //    snapshot still holds a ref the destructor fires when that snapshot
   //    vector is destroyed (spec §4 lifetime protocol).
-  {
-    std::lock_guard<std::mutex> lk(g_lifecycle_mu);
-    g_active_queues.erase(queue_id_of(q));
-  }
+  g_active_queues.erase(queue_id_of(q));
 
   q->dispatch_log_active.store(false, std::memory_order_release);
 }
@@ -787,7 +814,6 @@ bool predicate_now() {
 }
 
 void ts_poller_loop() {
-  using clock = std::chrono::steady_clock;
   const auto tick_interval = std::chrono::milliseconds(5);
 
   while (!g_shutdown.load(std::memory_order_relaxed)) {
@@ -797,45 +823,38 @@ void ts_poller_loop() {
     if (curr) {
       start_drainer_if_needed();
 
-      // Snapshot Queue* set under the lifecycle mutex; we don't have a
-      // direct registry of all live queues independent of g_active_queues,
-      // so the enable pass relies on on_queue_create having seeded each
-      // newly-created queue. Already-active queues are skipped (idempotent).
-      // The on_queue_create hook does the heavy lifting; this branch's
-      // only remaining job is to flip the drainer on so it starts consuming.
-      // Nothing to iterate here without an external "all queues" list.
-      // (Spec §4: "for each existing Q with dispatch_log_active==false:
-      //  enable_dispatch_log_for_queue(Q)" — see Phase A note below.)
-      //
-      // Phase A LIMITATION: we do not currently maintain a registry of all
-      // *live* queues, only of all *active* (already-enabled) queues. The
-      // enable pass therefore cannot retroactively enable queues that were
-      // created BEFORE the enable edge. Spec §1 already documents this as
-      // the "post-enable dispatches only" semantics; queues that exist at
-      // enable time will not be retroactively enabled and their pre-enable
-      // dispatches simply produce no records. Queues created AFTER the
-      // enable edge are picked up via on_queue_create. A future revision
-      // can add a global "all live queues" registry to close this gap;
-      // it requires a hook in queue.cpp's base ctor/dtor.
+      // ENABLE pass (spec §4): for each known live queue Q with
+      // dispatch_log_active==false, run the per-queue ENABLE sequence.
+      // Iterates g_known_queues under the lifecycle mutex; on_queue_create
+      // and on_queue_destroy serialize on the same mutex, so the Queue*
+      // values we observe here cannot be torn down concurrently.
+      // enable_dispatch_log_for_queue_locked is itself a no-op for queues
+      // that are already active (idempotent enable).
+      std::lock_guard<std::mutex> lk(g_lifecycle_mu);
+      // Snapshot first so enable's per-queue work doesn't mutate the map
+      // we're iterating (g_active_queues is mutated, but g_known_queues
+      // is stable across enable for an existing queue — defensive copy
+      // anyway).
+      std::vector<core::Queue*> known;
+      known.reserve(g_known_queues.size());
+      for (auto& kv : g_known_queues) known.push_back(kv.second);
+      for (core::Queue* q : known) {
+        enable_dispatch_log_for_queue_locked(q);
+      }
     } else {
-      // Disable pass: spec §4 says "for each Q with dispatch_log_active:
-      // wait_for_idle, drain, KFD DISABLE, QueueProfilingRelease, mark
-      // inactive". This requires real Queue* values to call SetProfiling /
-      // wait_for_idle on, but g_active_queues is intentionally keyed by
-      // queue_id and stores no Queue* (spec §7 dangling-Queue prohibition).
-      //
-      // PHASE A LIMITATION: without a separate "queue_id -> Queue*" side
-      // map, the poller's disable-edge pass is a no-op. Cleanup still
-      // happens via on_queue_destroy when the queue is eventually
-      // destroyed, and on Phase A this is moot anyway because
-      // g_substrate_present is false (no queues ever become active).
-      //
-      // Wiring the disable pass requires either (a) a side map populated
-      // alongside g_active_queues, where Queue* lifetime is co-managed
-      // with the registry entry under g_lifecycle_mu, or (b) extending
-      // queue_drain_state with a weak handle that the disable path can
-      // upgrade only when the Queue is still alive. Both are deferred
-      // to Phase B per spec §13.
+      // DISABLE pass (spec §4 + §9 ROCM_LTTNG_UST_DISABLE row): for each
+      // known live queue Q with dispatch_log_active==true, run the
+      // per-queue DISABLE sequence (wait_for_idle, final drain, KFD
+      // DISABLE, QueueProfilingRelease, mark inactive). Idempotent over
+      // already-inactive queues. Required for kill-switch hygiene per
+      // spec §1039.
+      std::lock_guard<std::mutex> lk(g_lifecycle_mu);
+      std::vector<core::Queue*> known;
+      known.reserve(g_known_queues.size());
+      for (auto& kv : g_known_queues) known.push_back(kv.second);
+      for (core::Queue* q : known) {
+        disable_dispatch_log_for_queue_locked(q);
+      }
     }
 
     // Sleep until next tick.
@@ -869,11 +888,23 @@ void shutdown() {
   if (g_drainer_thread.joinable()) g_drainer_thread.join();
   g_drainer_running.store(false, std::memory_order_relaxed);
 
-  // Clear any remaining active-queue entries. By process-exit time the
-  // queue-destroy hooks should have converged, but be defensive: drop the
-  // registry's shared_ptr refs so the destructors free the buffers.
+  // Spec §4 process-exit cleanup: run the per-queue DISABLE sequence
+  // (wait_for_idle, final drain, KFD DISABLE, QueueProfilingRelease) for
+  // every queue still active at process exit. The poller is joined above
+  // so no other thread is touching g_known_queues / g_active_queues here;
+  // the lock is taken for consistency with the helpers' contract.
   {
     std::lock_guard<std::mutex> lk(g_lifecycle_mu);
+    std::vector<core::Queue*> known;
+    known.reserve(g_known_queues.size());
+    for (auto& kv : g_known_queues) known.push_back(kv.second);
+    for (core::Queue* q : known) {
+      disable_dispatch_log_for_queue_locked(q);
+    }
+    g_known_queues.clear();
+    // Defensive: drop any remaining drainer refs (the disable sequence
+    // above should have removed them, but if a destroy hook racing with
+    // shutdown left dangling state, this releases the buffers).
     g_active_queues.clear();
     g_no_dispatch_log_agents.clear();
   }
@@ -893,19 +924,34 @@ void shutdown() {
 void on_queue_create(core::Queue* q) {
   if (q == nullptr) return;
 
-  // Spec §4 queue-create hot path: relaxed load, no lifecycle mutex.
+  // Register the queue in the poller's live-queue side map BEFORE running
+  // the enable sequence. Holding g_lifecycle_mu across both the registry
+  // insert and the enable serializes us against the poller (which iterates
+  // g_known_queues under the same mutex) and against on_queue_destroy.
   // The queue-create-vs-disable race is resolved by the idempotent disable
-  // convergence guarantee (every poll tick under curr=false runs the
-  // disable pass), not by additional locking here.
+  // convergence guarantee in spec §4: if curr flips to false between our
+  // load and the next poll tick, the disable pass will iterate
+  // g_known_queues (which now contains q) and clean up.
+  std::lock_guard<std::mutex> lk(g_lifecycle_mu);
+  g_known_queues[queue_id_of(q)] = q;
   if (G_tracepoint_enabled.load(std::memory_order_relaxed)) {
-    enable_dispatch_log_for_queue(q);
+    enable_dispatch_log_for_queue_locked(q);
   }
 }
 
 void on_queue_destroy(core::Queue* q) {
   if (q == nullptr) return;
-  if (q->dispatch_log_active.load(std::memory_order_acquire)) {
-    disable_dispatch_log_for_queue(q);
+
+  // Remove from g_known_queues BEFORE the disable sequence so the poller
+  // can never observe a Queue* whose underlying core::Queue is being torn
+  // down. Held across the disable so the poller's iterating thread is
+  // forced to wait behind the mutex if it currently holds it.
+  {
+    std::lock_guard<std::mutex> lk(g_lifecycle_mu);
+    g_known_queues.erase(queue_id_of(q));
+    if (q->dispatch_log_active.load(std::memory_order_acquire)) {
+      disable_dispatch_log_for_queue_locked(q);
+    }
   }
 
   // Drop the per-queue refcount entry. Safe to do unconditionally — if the

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -508,6 +508,20 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     rocm_trace_emit_hsa_kernel_dispatch_drop(queue_id_to_wire(qs.queue_id),
                                              fw_wptr - qs.read_cursor);
     qs.read_cursor = fw_wptr - qs.ring_bytes;
+
+    // C7 fix: across an overrun event, ALL previously cached STARTs are
+    // suspect. The drainer cannot tell which records the FW just overwrote
+    // (spec §7 / drop tracepoint semantics), so any pending START whose
+    // matching END was in the skipped range would either (a) leak in this
+    // map indefinitely or (b) be incorrectly mispaired with a future END
+    // if dispatch_idx wraps (uint32_t, ~4 billion dispatches).
+    //
+    // Trade-off: a START that was preserved across the overrun whose END
+    // arrives AFTER this point will now be reported as an orphan END and
+    // silently skipped by the END branch below. This is acceptable
+    // conservative behavior — the dispatch's complete record was already
+    // effectively lost the moment the FW outpaced us.
+    qs.pending_starts.clear();
   }
 
   while (qs.read_cursor < fw_wptr) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -151,10 +151,15 @@ struct queue_drain_state {
 
   // NON-OWNING ring view. Buffer is owned by AqlQueue::dispatch_record_buffer_
   // (alloc'd by SetProfiling(true), freed by SetProfiling(false) or the
-  // AqlQueue dtor). FW writes 16-byte mec_dispatch_record entries at
-  // 16-byte stride; the drainer reads at the same stride. The host BO is
-  // allocated oversized at `ring_records * 40` to satisfy the deployed
-  // KFD's BO-size validation; bytes beyond `ring_records * 16` are unused.
+  // AqlQueue dtor — except in the disable-clear-failure quarantine path,
+  // where it is leaked until the AqlQueue dtor runs after KFD queue
+  // teardown; see amd_aql_queue.cpp:1866-1886). FW writes 16-byte
+  // mec_dispatch_record entries at 16-byte stride; the drainer reads at
+  // the same stride. The host BO is allocated at exactly
+  // `ring_records * 16`, matching both the FW write stride and the
+  // current kernel's BO-size validation (`count * 16`). The earlier
+  // `*40` over-allocation was a workaround for an older pre-fix kernel
+  // and has been removed (see amd_aql_queue.cpp:1690-1704).
   void*    ring_base    = nullptr;
   uint32_t ring_records = 0;     // power-of-2 slot count
   uint32_t ring_mask    = 0;     // ring_records - 1, for slot indexing
@@ -418,24 +423,21 @@ void for_each_known_queue_locked(F&& fn) {
 //      and process the START / END pairing as before.
 //
 // FW writes 16-byte mec_dispatch_record entries at 16-byte stride. The
-// host kernel BO size validation on the gbt350-installed KFD patch is
-// `count * 40` (kfd_process_queue_manager.c:633), which over-counts the
-// per-record stride — see upstream fix `kfd: validate dispatch record
-// buffer using 16-byte record size` (commit `03a8b58c3b96`,
-// 2026-04-08), which corrects the kernel side to `count * 16` to
-// match the firmware/SDK contract. We allocate `count * 40` so the
-// older host kernel's BO validation passes (forward-compatible with
-// the fix — bigger is fine), but FW writes records back-to-back at
-// 16-byte stride within that buffer. The drainer therefore reads at
-// 16-byte stride. The unused tail of the buffer (slots beyond
-// `count * 16` bytes) is never written by FW and never read by the
-// drainer.
+// host kernel BO size validation now uses `count * 16` for both the
+// legacy SetQueueProfilingBuffer path and the new dispatch_log sub-op
+// (kfd_process_queue_manager.c, post commit `03a8b58c3b96` "kfd:
+// validate dispatch record buffer using 16-byte record size",
+// 2026-04-08), matching the firmware/SDK 16-byte record stride. The
+// host therefore allocates `count * 16` exactly (see
+// amd_aql_queue.cpp:1690-1704); the earlier `count * 40`
+// over-allocation that worked around the older pre-fix kernel has
+// been removed. FW writes records back-to-back at 16-byte stride and
+// the drainer reads at the same 16-byte stride.
 // ============================================================================
 
 // Per-record stride at which FW writes records into the buffer. Matches
-// `sizeof(mec_dispatch_record)` and is independent of the host kernel's
-// BO-size validation constant (which is `count * 40` today on gbt350,
-// `count * 16` after the upstream fix lands).
+// `sizeof(mec_dispatch_record)` and the kernel's BO-size validation
+// constant (`count * 16`, post upstream fix `03a8b58c3b96`).
 constexpr size_t kSlotStride = 16;
 
 // Per-pass batch size: drainer accumulates up to this many records per

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -466,13 +466,27 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     // host-runtime release.
     //
     // record_type narrowing uint32 -> uint8: current FW values are
-    // 1 and 2 and the on-the-wire schema field is uint8_t. If a future
-    // FW adds a record_type beyond 255, the static_cast silently
-    // truncates; we accept this risk for the smaller payload and will
-    // widen the schema (and the cast) when (and only when) such a
-    // FW revision exists. Use the captured queue-independent
-    // translation callable — Queue may be destroyed mid-pass even
-    // though the shared_ptr keeps qs alive.
+    // 1 and 2 and the on-the-wire schema field is uint8_t. The
+    // sentinel-zero check above (rt == 0 at line ~439) already filters
+    // empty slots before this point, so rt is known non-zero at the
+    // cast site — the truncation hazard is NOT sentinel collision
+    // (no on-the-wire 0 can be produced here). The only hazard is two
+    // distinct future FW values that collide modulo 256 (e.g. 1 and
+    // 257); we accept this risk for the smaller payload and will
+    // widen the schema (and the cast) when (and only when) such a FW
+    // revision exists.
+    //
+    // Cheap pre-check: if neither force_emit nor a non-disabled state
+    // applies the emit will be discarded inside the helper, so skip
+    // the (lock-acquiring) translate_gpu_ts call. translate_gpu_ts
+    // performs a linear interpolation under the agent's clock-cache
+    // lock; doing it 1× per record × kRingSlots in the disable-race
+    // window is wasted work the helper would discard anyway. The
+    // helper's own kill-switch check still runs (defense in depth).
+    if (!force_emit && rocm_trace_disabled()) break;
+    // Use the captured queue-independent translation callable — Queue
+    // may be destroyed mid-pass even though the shared_ptr keeps qs
+    // alive.
     const uint64_t gpu_ts_sys = qs.translate_gpu_ts(gpu_ts);
 
     // Narrow internal 64-bit queue_id at the tracepoint boundary

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -138,6 +138,17 @@ struct queue_drain_state {
   // rocm_trace_emit_* call sites, not here.
   uint64_t  queue_id = 0;
 
+  // KFD node_id of the GPU agent that owns this queue. Cached at queue
+  // enable time (read once from q->GetAgent()->node_id() in
+  // enable_dispatch_log_for_queue_locked) so the per-batch emit fast
+  // path doesn't have to chase the Queue* (which is deliberately not
+  // stored on this struct — see the dangling-Queue note below) for
+  // every flush. Carried on every kernel_dispatch_record event as the
+  // join key against rocm_hsa:clock_sync.gpu_id, so consumers can
+  // translate the raw per-record gpu_ts values into the host system
+  // clock domain. Spec §6 / §10 (queue_id→gpu_id mapping mechanism).
+  uint32_t  gpu_id = 0;
+
   // NON-OWNING ring view. Buffer is owned by AqlQueue::dispatch_record_buffer_
   // (alloc'd by SetProfiling(true), freed by SetProfiling(false) or the
   // AqlQueue dtor). FW writes 16-byte mec_dispatch_record entries at
@@ -410,6 +421,7 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     if (batch_count == 0) return;
     rocm_trace_emit_hsa_kernel_dispatch_record(
         queue_id_to_wire(qs.queue_id),
+        qs.gpu_id,
         batch_count, batch_buf,
         (size_t)batch_count * kSlotStride, force_emit);
     batch_count = 0;
@@ -973,6 +985,13 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
     // owned by AqlQueue, freed on SetProfiling(false) or AqlQueue dtor.
     qs = std::make_shared<queue_drain_state>();
     qs->queue_id         = queue_id_of(q);
+    // Cache gpu_id (KFD node_id) so the per-batch emit path doesn't
+    // need to re-walk the Queue* to fetch it. Safe to read q->GetAgent()
+    // here because the agent_is_gpu(q->GetAgent()) check above already
+    // verified the agent pointer is non-null and a GPU agent. The
+    // node_id is fixed for the lifetime of the agent. Narrows the
+    // 32-bit value through static_cast at the assignment.
+    qs->gpu_id           = static_cast<uint32_t>(q->GetAgent()->node_id());
     qs->ring_base        = buf;
     qs->ring_records     = record_count;
     qs->ring_mask        = record_count - 1;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -859,19 +859,28 @@ void disable_dispatch_log_for_queue_locked(core::Queue* q) {
     qs_ptr->ring_mask    = 0;
   }
 
-  // e. Unregister from drainer registry. Drops the registry's shared_ptr
-  //    ref. The worker's own shared_ptr (held by-value in
-  //    per_queue_drain_loop) is already released because the worker
-  //    has returned and joined.
-  g_active_queues.erase(queue_id_of(q));
-
-  // f. Release profiling ref. On the 1->0 edge AqlQueue::SetProfiling(false)
+  // e. Release profiling ref. On the 1->0 edge AqlQueue::SetProfiling(false)
   //    clears the KFD profiling-buffer registration (UPDATE_QUEUE with
   //    addr=0) and frees the per-queue dispatch-record buffer.
   //    QueueProfilingRelease takes g_owners_mu, NOT g_lifecycle_mu.
   //    By this point the worker is joined so no thread can dereference
   //    the buffer.
+  //
+  //    Order rationale (review C1, stage-1 spec-compliance): release
+  //    BEFORE the registry erase. The release is the step that drives
+  //    SetProfiling(false) on the underlying AqlQueue, which is the
+  //    transition that makes the per-queue ring buffer cease to be
+  //    a profiling buffer; once that has returned, the queue is fully
+  //    quiesced from the dispatch_log perspective and erasing the
+  //    registry slot is the final hand-off.
   QueueProfilingRelease(q);
+
+  // f. Unregister from drainer registry. Drops the registry's shared_ptr
+  //    ref. The worker's own shared_ptr (held by-value in
+  //    per_queue_drain_loop) is already released because the worker
+  //    has returned and joined, so this drops the last ref and the
+  //    queue_drain_state destructor fires.
+  g_active_queues.erase(queue_id_of(q));
 
   q->dispatch_log_active.store(false, std::memory_order_release);
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -411,17 +411,38 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
   // analog of the sentinel-scan's pass_budget.
   // ============================================================================
   if (qs.wptr_ptr != nullptr) {
-    const uint64_t fw_wptr = __atomic_load_n(qs.wptr_ptr, __ATOMIC_ACQUIRE);
+    // FW publish-monotonicity workaround: the gfx950 MEC firmware
+    // publishes wptr_addr and signal_addr non-monotonically (observed
+    // delta_w going negative by 300-450 between consecutive polls;
+    // signal and wptr can also disagree by similar magnitudes). The
+    // FW publish path appears to race across CU lanes / cores —
+    // documented in the FW interface spec under "publish ordering".
+    //
+    // Mitigation:
+    //   1. Take max(wptr, signal): one may briefly publish a stale
+    //      value while the other races forward. Both are FW writes
+    //      of the same logical counter.
+    //   2. Use a per-queue monotonic floor (qs.next_idx) so FW
+    //      publishing a backward value never re-emits already-drained
+    //      records. If max(wptr,signal) < next_idx, FW's published
+    //      value is stale; skip this pass and wait for the next
+    //      monotonic update.
+    const uint64_t fw_wptr   = __atomic_load_n(qs.wptr_ptr,   __ATOMIC_ACQUIRE);
+    const uint64_t fw_signal = qs.signal_ptr
+                                   ? __atomic_load_n(qs.signal_ptr, __ATOMIC_ACQUIRE)
+                                   : fw_wptr;
+    const uint64_t observed = (fw_wptr > fw_signal) ? fw_wptr : fw_signal;
 
-    // Nothing new since last pass. Steady-state cheap exit.
-    if (fw_wptr == qs.next_idx) return false;
+    // Backward (or stale) FW publish: ignore this pass entirely.
+    // qs.next_idx is our monotonic floor.
+    if (observed <= qs.next_idx) return false;
 
     // Overrun detection. If FW lapped us, log a drop event and skip
     // the unrecoverable region. The records we DO read after the skip
-    // are still valid (they're the most recent fw_wptr - ring_records
+    // are still valid (they're the most recent observed - ring_records
     // records, just with a gap before them).
     uint64_t start = qs.next_idx;
-    uint64_t end   = fw_wptr;
+    uint64_t end   = observed;
     if ((end - start) > qs.ring_records) {
       const uint64_t lost = (end - start) - qs.ring_records;
       rocm_trace_emit_hsa_kernel_dispatch_drop(

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -70,8 +70,8 @@
 // fresh records by scanning the ring sequentially from a host-managed
 // monotonic cursor (next_idx). A slot whose record_type is 0 is "empty"
 // (FW writes record_type ∈ {1,2}, and the buffer is pre-zeroed at alloc
-// in AqlQueue::SetProfiling). After consuming a slot the drainer zeroes
-// it again so wraparound rewrites are re-detectable. See drain_one_queue
+// in AqlQueue::SetProfiling). After consuming a slot the drainer clears
+// the record_type sentinel so wraparound rewrites are re-detectable. See drain_one_queue
 // below for the canonical implementation.
 
 #include "core/inc/dispatch_log.h"
@@ -111,19 +111,19 @@ namespace {
 
 // ============================================================================
 // Per-queue profiling-bit refcount (spec §4a). Each Queue gets one of these
-// keyed in g_owners; the mutex serializes the refcount RMW + the bit set/clear
+// keyed in g_profiling_refcounts; the mutex serializes the refcount RMW + the bit set/clear
 // transition. Phase A uses a side-map keyed on core::Queue* rather than a
 // dl_state pointer hung off the Queue itself; the in-Queue void*
 // dispatch_log_state is reserved for a future refactor.
 // ============================================================================
-struct queue_profiling_owners {
+struct queue_profiling_refcount {
   std::mutex m;
   uint32_t   refcount = 0;
 };
 
 // ============================================================================
 // queue_drain_state per spec §7. Held via std::shared_ptr from both the
-// drainer registry (g_active_queues) and the per-queue worker thread (which
+// drainer registry (g_active_drainers) and the per-queue worker thread (which
 // holds its own ref by-value via per_queue_drain_loop). Stores only NON-OWNING
 // pointers into the buffer owned by AqlQueue (the buffer is alloc'd by
 // AqlQueue::SetProfiling(true) and freed by SetProfiling(false) or the
@@ -138,85 +138,50 @@ struct queue_drain_state {
   // rocm_trace_emit_* call sites, not here.
   uint64_t  queue_id = 0;
 
-  // Owned, queue-independent GPU->system time-translation callable.
-  // Captured at register time so it remains callable even after the
-  // underlying core::Queue (and any queue-scoped state on the agent) has
-  // been destroyed. The agent itself outlives any queue created on it
-  // (HSA agents have process lifetime), so capturing the agent reference
-  // by value inside this callable is safe.
-  std::function<uint64_t(uint64_t /* gpu_ts */)> translate_gpu_ts;
-
-  // NON-OWNING ring view. The buffer is owned by AqlQueue::dispatch_record_buffer_;
-  // do not free here. The kernel-side BO is allocated oversized at
-  // `ring_records * 40` bytes purely to satisfy host KFD BO-size validation
-  // (amd/amdkfd/kfd_process_queue_manager.c:633 `buf_byte_size = count * 40`).
-  // The active FW/drainer ring uses the 16-byte FW record stride
-  // (kSlotStride): FW writes records at 16-byte stride and the drainer
-  // reads them at 16-byte stride. The extra allocation tail beyond
-  // `ring_records * 16` is unused/reserved and is not part of the ring.
-  void*    ring_base    = nullptr;     // host-virtual base of the FW record area
-  uint32_t ring_records = 0;           // power-of-2 slot count (e.g. 65536)
-  uint32_t ring_mask    = 0;           // ring_records - 1, for slot indexing
+  // NON-OWNING ring view. Buffer is owned by AqlQueue::dispatch_record_buffer_
+  // (alloc'd by SetProfiling(true), freed by SetProfiling(false) or the
+  // AqlQueue dtor). FW writes 16-byte mec_dispatch_record entries at
+  // 16-byte stride; the drainer reads at the same stride. The host BO is
+  // allocated oversized at `ring_records * 40` to satisfy the deployed
+  // KFD's BO-size validation; bytes beyond `ring_records * 16` are unused.
+  void*    ring_base    = nullptr;
+  uint32_t ring_records = 0;     // power-of-2 slot count
+  uint32_t ring_mask    = 0;     // ring_records - 1, for slot indexing
 
   // Host-managed monotonic record cursor. Mutated only under drain_mu.
-  // Slot index is (next_idx & ring_mask). Sentinel-scan design: the
-  // substrate publishes no FW wptr, so we advance next_idx for every
-  // slot whose record_type is non-zero, and zero the slot after consume
-  // so a wraparound re-write is re-detectable. See drain_one_queue.
+  // Slot index is (next_idx & ring_mask). Sentinel-scan: drainer advances
+  // for every slot whose record_type is non-zero and clears the sentinel
+  // after consume so a wraparound rewrite is re-detectable.
   uint64_t next_idx = 0;
 
-  // Per-queue drain mutex. Steady state: only the per-queue worker thread
-  // holds this (so it is technically redundant in today's design — the
-  // worker is the sole drainer for its queue). Retained as defense in
-  // depth against any future code path that calls drain_one_queue
-  // synchronously from another thread (e.g. a future
-  // synchronous-final-drain helper). Per-queue scope, so other queues'
-  // drains are not blocked.
+  // Per-queue drain mutex. With one worker per queue this is technically
+  // redundant in steady state (the worker is the sole drainer for its
+  // queue), but it is retained as defense in depth against any future
+  // synchronous-final-drain helper from another thread.
   std::mutex drain_mu;
 
-  // Per-queue worker thread shutdown signal + handle. The supported
-  // ownership model is: disable_dispatch_log_for_queue_locked stores
-  // should_stop with release ordering and joins worker BEFORE
-  // dropping the registry's shared_ptr ref. The worker checks
-  // should_stop with acquire ordering each iteration. The destructor
-  // (below) is NOT a generic safety net for unjoined-running workers
-  // — see the destructor comment for the narrow case it handles.
+  // Per-queue worker thread shutdown signal + handle. Disable path stores
+  // should_stop with release ordering and joins worker before dropping the
+  // registry's shared_ptr ref. The worker checks should_stop with acquire
+  // ordering each iteration.
   std::atomic<bool> should_stop{false};
   std::thread       worker;
 
   // Defensive safety net for early-construction failures (review C2,
-  // stage-2 code-quality). The supported lifetime model is: explicit
-  // disable / shutdown path stops + joins worker BEFORE dropping any
-  // shared_ptr ref. This destructor only matters in one specific case:
-  // a qs was made_shared but worker was never assigned (e.g. enable
-  // path's std::thread construction threw — review C1) and the
-  // registry path is rolling back via shared_ptr drop. In that case
-  // worker is default-constructed (joinable() == false) so the body
-  // is a no-op.
-  //
-  // The destructor canNOT meaningfully recover a started-but-unjoined
-  // worker. The worker holds its own shared_ptr<queue_drain_state>
-  // by value (per_queue_drain_loop param), so the destructor cannot
-  // be the path that releases the last ref while the worker is still
-  // running — by definition the worker's own ref is the last one when
-  // the loop returns, and at that point we are already on the worker
-  // thread. self-join would throw std::system_error
-  // (resource_deadlock_would_occur). Guard against that edge case
-  // explicitly: skip the join if `worker` represents the current
-  // thread. std::thread::id comparison is cheap and well-defined.
+  // stage-2 code-quality). Supported lifetime model is explicit
+  // disable / shutdown stops + joins worker BEFORE dropping the
+  // registry's shared_ptr ref. This destructor only catches the narrow
+  // case where the shared_ptr's last ref is dropped with the worker
+  // still running (e.g. construction-failure rollback inside
+  // enable_dispatch_log_for_queue_locked). Self-join is illegal —
+  // detect via thread::id and detach() instead.
   ~queue_drain_state() {
-    if (worker.joinable() &&
-        worker.get_id() != std::this_thread::get_id()) {
-      should_stop.store(true, std::memory_order_release);
-      worker.join();
-    } else if (worker.joinable()) {
-      // Self-destruction path. We cannot join ourselves; detach so
-      // std::thread's destructor doesn't std::terminate the process.
-      // This branch indicates a programming error (the supported
-      // lifetime model requires explicit join from a non-worker
-      // thread before dropping the last ref); detaching is a
-      // best-effort cleanup, not a correctness path.
-      worker.detach();
+    if (worker.joinable()) {
+      if (worker.get_id() == std::this_thread::get_id()) {
+        worker.detach();
+      } else {
+        worker.join();
+      }
     }
   }
 };
@@ -228,72 +193,50 @@ struct queue_drain_state {
 // Spec §4 single source of truth for "should HSA be collecting kernel-dispatch
 // timestamps right now?". Folded predicate of !rocm_trace_disabled() &&
 // lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_record) &&
-// g_substrate_present. Written only by ts_poller; read by on_queue_create
-// (relaxed, hot path). Per-queue drainer workers do not gate on this flag
-// directly — they live for the lifetime of their queue's enable->disable
-// window, and the poller's disable pass is what stops them when the
-// predicate transitions to false.
-std::atomic<bool> G_tracepoint_enabled{false};
+// g_kfd_supports_dispatch_log. Written only by ts_poller; read by
+// on_queue_create (relaxed, hot path).
+std::atomic<bool> g_dispatch_logging_active{false};
 
 // Set true if the KFD substrate version probe at init() reports a kernel
-// minor version >= 22 (the minor version that introduced the
+// minor version >= 22 (the version that introduced the
 // dispatch_record_buffer_{addr,size} trailing fields on UPDATE_QUEUE).
 // Probed once at init via AMDKFD_IOC_GET_VERSION; never mutated afterwards.
-std::atomic<bool> g_substrate_present{false};
+std::atomic<bool> g_kfd_supports_dispatch_log{false};
 
 // Latched true after we log the "substrate absent, tracepoint enable
 // is a no-op" message once. Avoids spamming the user log on every poll tick.
-std::atomic<bool> g_substrate_absent_warned{false};
+std::atomic<bool> g_kfd_unsupported_warned{false};
 
-// Driven by shutdown(); poller and drainer observe and exit.
+// Driven by shutdown(); poller and per-queue workers observe and exit.
 std::atomic<bool> g_shutdown{false};
 
-// Spec §4 lifecycle mutex. Guards g_active_queues + g_no_dispatch_log_agents.
-// Acquired only briefly: enable/disable per-queue and snapshot-cloning.
-std::mutex g_lifecycle_mu;
+// Spec §4 lifecycle mutex. Guards g_active_drainers, g_all_queues, and
+// g_no_dispatch_log_agents. Acquired only briefly: enable/disable per-queue
+// and snapshot-cloning.
+std::mutex g_queue_registry_mu;
 
-// Drainer registry (spec §4 lifetime protocol). Keyed by the full 64-bit
-// hsa_queue_t::id (the value FW writes into the record dispatch_idx is
-// per-queue, so queue_id distinguishes drains). Holds one shared_ptr per
-// active queue. See C5 fix: the LTTng tracepoint payload narrows this to
-// uint32_t at emit, but internal lifetime keys must stay 64-bit because
-// hsa_queue_t::id is uint64_t and unique over the application's lifetime.
-std::unordered_map<uint64_t, std::shared_ptr<queue_drain_state>> g_active_queues;
+// Drainer registry (spec §4 lifetime protocol). Keyed by full 64-bit
+// hsa_queue_t::id. One shared_ptr per active queue; the per-queue worker
+// thread holds its own ref by-value via per_queue_drain_loop.
+std::unordered_map<uint64_t, std::shared_ptr<queue_drain_state>> g_active_drainers;
 
 // Poller-only "live queue" side map (spec §4 enable/disable convergence).
-//
-// Distinct from g_active_queues: this tracks every Queue* known to the
-// dispatch_log subsystem (registered by on_queue_create, removed by
-// on_queue_destroy), regardless of whether dispatch logging is currently
-// enabled on it. The poller iterates this set under g_lifecycle_mu to drive
-// the §4 idempotent enable/disable passes.
-//
-// Keyed by full 64-bit hsa_queue_t::id (see g_active_queues commentary
-// above and C5 fix).
-std::unordered_map<uint64_t, core::Queue*> g_known_queues;
+// Distinct from g_active_drainers: tracks every Queue* known to the
+// dispatch_log subsystem, regardless of whether dispatch logging is
+// currently enabled on it. Iterated by the poller under g_queue_registry_mu.
+std::unordered_map<uint64_t, core::Queue*> g_all_queues;
 
 // Side-map for the QueueProfilingAcquire/Release refcount (spec §4a). One
-// entry per Queue* that has ever had at least one acquire. Looked up under
-// g_owners_mu.
-//
-// **Lifetime contract.** Entries are held via std::shared_ptr because
-// QueueProfilingAcquire / QueueProfilingRelease intentionally drop
-// g_owners_mu before locking the per-entry mutex (the per-entry lock can
-// be held across SetProfiling(), which we don't want to do under the
-// global map mutex). Without shared ownership, on_queue_destroy could
-// erase the map entry between our map-lookup and our per-entry-lock,
-// freeing the queue_profiling_owners object out from under us. Copying
-// the shared_ptr while still holding g_owners_mu pins the entry alive
-// until the API call's local shared_ptr drops, even if on_queue_destroy
-// concurrently erases the map slot.
-std::mutex g_owners_mu;
-std::unordered_map<core::Queue*, std::shared_ptr<queue_profiling_owners>> g_owners;
+// entry per Queue* that has ever had at least one acquire. Held via
+// shared_ptr because Acquire/Release intentionally drop
+// g_profiling_refcounts_mu before locking the per-entry mutex.
+std::mutex g_profiling_refcounts_mu;
+std::unordered_map<core::Queue*, std::shared_ptr<queue_profiling_refcount>> g_profiling_refcounts;
 
 // Per-agent "no-dispatch-log" mark. If GetProfilingDispatchRecords reports
-// NOT_INITIALIZED (or another error) for any queue on a given agent, that
-// agent is added here and subsequent enable_dispatch_log_for_queue calls on
-// queues belonging to it short-circuit (spec §5 unsupported-agent row,
-// §9 unsupported-agent row).
+// NOT_INITIALIZED for any queue on a given agent, that agent is added here
+// and subsequent enable_dispatch_log_for_queue calls on queues belonging to
+// it short-circuit (spec §5/§9 unsupported-agent rows).
 std::unordered_set<core::Agent*> g_no_dispatch_log_agents;
 
 // Threads. Per-queue drainer threads (one per active queue) live inside
@@ -305,13 +248,11 @@ std::thread g_poller_thread;
 // ============================================================================
 
 // Full 64-bit hsa_queue_t::id (see hsa.h:2359-2361). Internal registries
-// (g_active_queues, g_known_queues) and queue_drain_state.queue_id all key
+// (g_active_drainers, g_all_queues) and queue_drain_state.queue_id all key
 // on this full value to avoid the high-32-bit collision risk flagged in
 // C5. The LTTng tracepoint payload narrows to the low 32 bits at the
 // emit call sites only.
 uint64_t queue_id_of(core::Queue* q) {
-  // amd_queue_t.hsa_queue.id is set in the queue ctor (see e.g.
-  // amd_aql_queue.cpp:298, host_queue.cpp:77).
   return q->amd_queue_.hsa_queue.id;
 }
 
@@ -327,22 +268,6 @@ uint32_t queue_id_to_wire(uint64_t qid) {
 
 bool agent_is_gpu(core::Agent* a) {
   return a != nullptr && a->device_type() == core::Agent::kAmdGpuDevice;
-}
-
-// Build the GPU->system translation callable from the Queue's owning agent.
-// Captures the agent pointer by value; agents have process lifetime so this
-// is safe even after the queue is destroyed (spec §7).
-std::function<uint64_t(uint64_t)> make_translate_gpu_ts(core::Queue* q) {
-  core::Agent* agent = q->GetAgent();
-  if (!agent_is_gpu(agent)) {
-    // Non-GPU (CPU / soft) queue. Pass-through; we shouldn't be enabling on
-    // these at all, but be defensive.
-    return [](uint64_t t) { return t; };
-  }
-  auto* gpu = static_cast<AMD::GpuAgentInt*>(agent);
-  return [gpu](uint64_t gpu_ts) -> uint64_t {
-    return gpu->TranslateTime(gpu_ts);
-  };
 }
 
 #if defined(__linux__)
@@ -375,15 +300,15 @@ bool probe_substrate_version() {
 bool probe_substrate_version() { return false; }
 #endif
 
-// Iterate g_known_queues under g_lifecycle_mu and invoke fn(queue_id, queue)
+// Iterate g_all_queues under g_queue_registry_mu and invoke fn(queue_id, queue)
 // for each entry. C6 fix: replaces the previous "snapshot into vector then
-// iterate" pattern. fn must NOT mutate g_known_queues. fn IS allowed to
-// mutate g_active_queues (e.g. enable_dispatch_log_for_queue_locked inserts,
+// iterate" pattern. fn must NOT mutate g_all_queues. fn IS allowed to
+// mutate g_active_drainers (e.g. enable_dispatch_log_for_queue_locked inserts,
 // disable_dispatch_log_for_queue_locked erases).
 template <typename F>
 void for_each_known_queue_locked(F&& fn) {
-  std::lock_guard<std::mutex> lk(g_lifecycle_mu);
-  for (auto& kv : g_known_queues) fn(kv.first, kv.second);
+  std::lock_guard<std::mutex> lk(g_queue_registry_mu);
+  for (auto& kv : g_all_queues) fn(kv.first, kv.second);
 }
 
 // ============================================================================
@@ -459,9 +384,9 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     // helper's own kill-switch check still runs (defense in depth).
     //
     // Position rationale: this check MUST sit before the record_type
-    // load + slot memset (below) so that bailing here leaves the slot
-    // intact and `qs.next_idx` still pointing at it. If we zeroed the
-    // slot first and then bailed, the slot would be permanently
+    // load + slot mutation (below) so that bailing here leaves the slot
+    // intact and `qs.next_idx` still pointing at it. If we cleared the
+    // sentinel first and then bailed, the slot would be permanently
     // destroyed (FW had already written it, and the wptr cursor stays
     // put), and on the next drain pass the sentinel scan would observe
     // rt == 0 at next_idx and stop — stranding any later FW-written
@@ -487,7 +412,7 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     // is not possible under that FW contract.
     //
     // We still use an acquire on the record_type load so the subsequent
-    // body loads (and the slot memset) are not reordered above it; this
+    // body loads are not reordered above it; this
     // turns the type-load into a proper atomic acquire instead of a
     // plain (data-racy) load on memory another agent writes
     // concurrently. The body fields are read with relaxed atomicity for
@@ -497,7 +422,7 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     uint32_t rt = __atomic_load_n(&rec->record_type, __ATOMIC_ACQUIRE);
     if (rt == 0) break;
 
-    // Snapshot the rest of the record locally before zeroing the slot.
+    // Snapshot the rest of the record locally before clearing the sentinel.
     // Relaxed atomic loads suffice (see comment above) — the acquire on
     // record_type above already orders these.
     const uint32_t ts_lo        = __atomic_load_n(&rec->ts_lo, __ATOMIC_RELAXED);
@@ -505,12 +430,12 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     const uint32_t dispatch_idx = __atomic_load_n(&rec->dispatch_idx, __ATOMIC_RELAXED);
     const uint64_t gpu_ts       = (static_cast<uint64_t>(ts_hi) << 32) | ts_lo;
 
-    // Zero the consumed slot so a wraparound rewrite by FW (next time
+    // Zero the record_type field so a wraparound rewrite by FW (next time
     // the ring loops past this position) is re-detected as a fresh
-    // non-zero record_type. FW writes 16-byte records at 16-byte
-    // stride, so zeroing kSlotStride bytes resets the entire next-write
-    // target.
-    std::memset(rec, 0, kSlotStride);
+    // non-zero record_type. We only need to clear the sentinel field,
+    // not the entire 16-byte slot, since the FW always writes the full
+    // 16 bytes atomically.
+    __atomic_store_n(&rec->record_type, 0, __ATOMIC_RELEASE);
 
     // Emit one event per FW-written record. No host-side START/END
     // pairing — consumer joins on (queue_id, dispatch_idx) and uses
@@ -536,15 +461,10 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     // widen the schema (and the cast) when (and only when) such a FW
     // revision exists.
     //
-    // Use the captured queue-independent translation callable — Queue
-    // may be destroyed mid-pass even though the shared_ptr keeps qs
-    // alive.
-    const uint64_t gpu_ts_sys = qs.translate_gpu_ts(gpu_ts);
-
     // Narrow internal 64-bit queue_id at the tracepoint boundary
     // (spec §6 / §14, C5 fix). dispatch_idx is 32-bit per FW contract.
     rocm_trace_emit_hsa_kernel_dispatch_record(
-        queue_id_to_wire(qs.queue_id), dispatch_idx, gpu_ts_sys,
+        queue_id_to_wire(qs.queue_id), dispatch_idx, gpu_ts,
         static_cast<uint8_t>(rt), force_emit);
 
     qs.next_idx += 1;
@@ -561,7 +481,7 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
 // thread lifetime regardless of registry mutations elsewhere.
 //
 // Per-queue ownership eliminates cross-queue serialization: the previous
-// shared drainer iterated all queues sequentially under g_lifecycle_mu
+// shared drainer iterated all queues sequentially under g_queue_registry_mu
 // snapshot, with a per-pass budget capped at qs.ring_records, so a
 // larger ring slowed the visit cycle to other queues. Each per-queue
 // worker now stays hot on its own ring at the FW's local write rate
@@ -579,11 +499,6 @@ void per_queue_drain_loop(std::shared_ptr<queue_drain_state> qs) {
     const bool any = drain_one_queue(*qs, /* force_emit = */ false);
     if (any) {
       std::this_thread::yield();
-    } else {
-      // Same idle backoff as the prior shared drainer (500 us). Bounds
-      // the worst-case latency between the disable path setting
-      // should_stop and this thread observing it.
-      std::this_thread::sleep_for(std::chrono::microseconds(500));
     }
   }
   // Final drain after the stop signal so any FW records written between
@@ -613,12 +528,12 @@ void wait_for_idle(core::Queue* q) {
 // Profiling-bit refcount (spec §4a).
 // ============================================================================
 
-std::shared_ptr<queue_profiling_owners> get_or_create_owners(core::Queue* q) {
-  // Caller holds g_owners_mu.
-  auto it = g_owners.find(q);
-  if (it != g_owners.end()) return it->second;
-  auto inserted = g_owners.emplace(
-      q, std::make_shared<queue_profiling_owners>());
+std::shared_ptr<queue_profiling_refcount> get_or_create_owners(core::Queue* q) {
+  // Caller holds g_profiling_refcounts_mu.
+  auto it = g_profiling_refcounts.find(q);
+  if (it != g_profiling_refcounts.end()) return it->second;
+  auto inserted = g_profiling_refcounts.emplace(
+      q, std::make_shared<queue_profiling_refcount>());
   return inserted.first->second;
 }
 
@@ -627,13 +542,13 @@ std::shared_ptr<queue_profiling_owners> get_or_create_owners(core::Queue* q) {
 hsa_status_t QueueProfilingAcquire(core::Queue* q) {
   if (q == nullptr) return HSA_STATUS_ERROR_INVALID_QUEUE;
   // Pin the entry alive across the per-entry lock acquire by copying the
-  // shared_ptr out under g_owners_mu. Even if on_queue_destroy erases the
+  // shared_ptr out under g_profiling_refcounts_mu. Even if on_queue_destroy erases the
   // map slot between here and the lock_guard below, this local shared_ptr
-  // keeps the queue_profiling_owners object alive (spec §4a + lifetime
-  // contract on g_owners). See C4 fix.
-  std::shared_ptr<queue_profiling_owners> owners;
+  // keeps the queue_profiling_refcount object alive (spec §4a + lifetime
+  // contract on g_profiling_refcounts). See C4 fix.
+  std::shared_ptr<queue_profiling_refcount> owners;
   {
-    std::lock_guard<std::mutex> lk(g_owners_mu);
+    std::lock_guard<std::mutex> lk(g_profiling_refcounts_mu);
     owners = get_or_create_owners(q);
   }
   std::lock_guard<std::mutex> lk(owners->m);
@@ -657,11 +572,11 @@ hsa_status_t QueueProfilingAcquire(core::Queue* q) {
 hsa_status_t QueueProfilingRelease(core::Queue* q) {
   if (q == nullptr) return HSA_STATUS_ERROR_INVALID_QUEUE;
   // See QueueProfilingAcquire for the shared_ptr lifetime rationale (C4).
-  std::shared_ptr<queue_profiling_owners> owners;
+  std::shared_ptr<queue_profiling_refcount> owners;
   {
-    std::lock_guard<std::mutex> lk(g_owners_mu);
-    auto it = g_owners.find(q);
-    if (it == g_owners.end()) {
+    std::lock_guard<std::mutex> lk(g_profiling_refcounts_mu);
+    auto it = g_profiling_refcounts.find(q);
+    if (it == g_profiling_refcounts.end()) {
       // Underflow without ever acquiring. Caller bug; spec §4a says return
       // failure without modifying state.
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;
@@ -703,7 +618,7 @@ namespace {
 //      and the FW-record-stride capacity in bytes (record_count * 16).
 //      The substrate publishes no host-visible FW write pointer; consumers
 //      locate fresh records via sentinel scan over per-slot record_type.
-//   5. Register a non-owning queue_drain_state in g_active_queues with
+//   5. Register a non-owning queue_drain_state in g_active_drainers with
 //      next_idx = 0 (the host-managed monotonic record cursor used by
 //      the sentinel-scan drainer).
 // ============================================================================
@@ -722,14 +637,14 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
   auto* aql_queue = static_cast<AMD::AqlQueue*>(q);
 
   // Substrate / per-agent gate.
-  if (!g_substrate_present.load(std::memory_order_relaxed)) return;
+  if (!g_kfd_supports_dispatch_log.load(std::memory_order_relaxed)) return;
   if (g_no_dispatch_log_agents.count(q->GetAgent()) > 0) return;
 
   // Step 1: enable profiling on the queue. This is the AqlQueue::SetProfiling
   // call that allocates the dispatch-record buffer, calls
   // hsaKmtSetQueueProfilingBuffer, and Suspends/Resumes the queue to flush
-  // the MQD via UPDATE_QUEUE. QueueProfilingAcquire takes g_owners_mu (not
-  // g_lifecycle_mu), so it's safe to call while holding g_lifecycle_mu.
+  // the MQD via UPDATE_QUEUE. QueueProfilingAcquire takes g_profiling_refcounts_mu (not
+  // g_queue_registry_mu), so it's safe to call while holding g_queue_registry_mu.
   hsa_status_t s = QueueProfilingAcquire(q);
   if (s != HSA_STATUS_SUCCESS) {
     // C5: distinguish substrate-absent from per-queue transient failures.
@@ -801,8 +716,7 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
   //
   // What can throw here:
   //   - std::make_shared<queue_drain_state>() (allocation)
-  //   - std::function copy of make_translate_gpu_ts(q) (allocation)
-  //   - g_active_queues[qs->queue_id] = qs (unordered_map insert,
+  //   - g_active_drainers[qs->queue_id] = qs (unordered_map insert,
   //     can throw on rehash allocation)
   //   - std::thread(per_queue_drain_loop, qs) (std::system_error on
   //     EAGAIN / RLIMIT_NPROC / address-space exhaustion — review
@@ -830,13 +744,12 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
     // owned by AqlQueue, freed on SetProfiling(false) or AqlQueue dtor.
     qs = std::make_shared<queue_drain_state>();
     qs->queue_id         = queue_id_of(q);
-    qs->translate_gpu_ts = make_translate_gpu_ts(q);
     qs->ring_base        = buf;
     qs->ring_records     = record_count;
     qs->ring_mask        = record_count - 1;
     qs->next_idx         = 0;
 
-    g_active_queues[qs->queue_id] = qs;
+    g_active_drainers[qs->queue_id] = qs;
 
     // Step 4: spawn the per-queue drainer worker AFTER registration.
     // The worker holds its own shared_ptr<queue_drain_state> by value
@@ -852,7 +765,7 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
                  e.what());
     // Erase from registry if we got far enough to insert. erase() is
     // safe on a missing key (returns 0).
-    g_active_queues.erase(queue_id_of(q));
+    g_active_drainers.erase(queue_id_of(q));
     // Release the profiling ref bumped by QueueProfilingAcquire above.
     // dispatch_log_active was never flipped to true, so no flag
     // rollback is needed. The next poller enable pass will retry.
@@ -889,8 +802,8 @@ void disable_dispatch_log_for_queue_locked(core::Queue* q) {
   //    a local ref so qs survives even after the registry erase below.
   std::shared_ptr<queue_drain_state> qs_ptr;
   {
-    auto it = g_active_queues.find(queue_id_of(q));
-    if (it != g_active_queues.end()) qs_ptr = it->second;
+    auto it = g_active_drainers.find(queue_id_of(q));
+    if (it != g_active_drainers.end()) qs_ptr = it->second;
   }
 
   // c. Stop and join the per-queue worker thread. The worker performs
@@ -927,7 +840,7 @@ void disable_dispatch_log_for_queue_locked(core::Queue* q) {
   // e. Release profiling ref. On the 1->0 edge AqlQueue::SetProfiling(false)
   //    clears the KFD profiling-buffer registration (UPDATE_QUEUE with
   //    addr=0) and frees the per-queue dispatch-record buffer.
-  //    QueueProfilingRelease takes g_owners_mu, NOT g_lifecycle_mu.
+  //    QueueProfilingRelease takes g_profiling_refcounts_mu, NOT g_queue_registry_mu.
   //    By this point the worker is joined so no thread can dereference
   //    the buffer.
   //
@@ -945,7 +858,7 @@ void disable_dispatch_log_for_queue_locked(core::Queue* q) {
   //    per_queue_drain_loop) is already released because the worker
   //    has returned and joined, so this drops the last ref and the
   //    queue_drain_state destructor fires.
-  g_active_queues.erase(queue_id_of(q));
+  g_active_drainers.erase(queue_id_of(q));
 
   q->dispatch_log_active.store(false, std::memory_order_release);
 }
@@ -956,11 +869,25 @@ void disable_dispatch_log_for_queue_locked(core::Queue* q) {
 
 bool predicate_now() {
 #if defined(HSA_ENABLE_LTTNG_UST) && HSA_ENABLE_LTTNG_UST
-  if (rocm_trace_disabled()) return false;
-  if (!g_substrate_present.load(std::memory_order_relaxed)) {
-    if (lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_record)) {
-      bool warned = g_substrate_absent_warned.load(std::memory_order_relaxed);
-      if (!warned && g_substrate_absent_warned.compare_exchange_strong(
+  /* DIAGNOSTIC: log the three predicate inputs once on the first call
+   * so we can see why dispatch_log is or isn't enabling. */
+  static std::atomic<bool> diag_first{true};
+  bool first_call = diag_first.exchange(false);
+  bool trace_dis = rocm_trace_disabled();
+  bool kfd_ok   = g_kfd_supports_dispatch_log.load(std::memory_order_relaxed);
+  int  tp_en    = lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_record);
+  if (first_call) {
+    std::fprintf(stderr,
+                 "[hsa-runtime] dispatch_log DIAG predicate_now first-call: "
+                 "trace_disabled=%d kfd_supports=%d tracepoint_enabled=%d\n",
+                 (int)trace_dis, (int)kfd_ok, tp_en);
+  }
+
+  if (trace_dis) return false;
+  if (!kfd_ok) {
+    if (tp_en) {
+      bool warned = g_kfd_unsupported_warned.load(std::memory_order_relaxed);
+      if (!warned && g_kfd_unsupported_warned.compare_exchange_strong(
                          warned, true)) {
         std::fprintf(stderr,
                      "[hsa-runtime] dispatch_log: tracepoint "
@@ -971,7 +898,7 @@ bool predicate_now() {
     }
     return false;
   }
-  return lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_record) != 0;
+  return tp_en != 0;
 #else
   return false;
 #endif
@@ -980,9 +907,26 @@ bool predicate_now() {
 void ts_poller_loop() {
   const auto tick_interval = std::chrono::milliseconds(5);
 
+  /* DIAGNOSTIC: confirm the poller actually starts, and log every
+   * predicate-result transition so we can see when (or if) it ever
+   * flips true. Steady-state silent. */
+  std::fprintf(stderr,
+               "[hsa-runtime] dispatch_log DIAG ts_poller_loop entered\n");
+  bool last_curr = false;
+  bool first_iter = true;
+
   while (!g_shutdown.load(std::memory_order_relaxed)) {
     const bool curr = predicate_now();
-    G_tracepoint_enabled.store(curr, std::memory_order_relaxed);
+    g_dispatch_logging_active.store(curr, std::memory_order_relaxed);
+
+    if (first_iter || curr != last_curr) {
+      std::fprintf(stderr,
+                   "[hsa-runtime] dispatch_log DIAG ts_poller_loop predicate=%d "
+                   "(was %d)\n",
+                   (int)curr, (int)last_curr);
+      last_curr = curr;
+      first_iter = false;
+    }
 
     if (curr) {
       // ENABLE pass (spec §4): for each known live queue Q with
@@ -1017,7 +961,7 @@ void init() {
   // KFD minor >= 22 (the version that introduced the
   // dispatch_record_buffer_{addr,size} trailing fields on UPDATE_QUEUE).
   const bool present = probe_substrate_version();
-  g_substrate_present.store(present, std::memory_order_release);
+  g_kfd_supports_dispatch_log.store(present, std::memory_order_release);
 
   // Spawn poller unconditionally so the steady-state idle path is exercised
   // even when the substrate is missing. The poller's enable branch
@@ -1044,20 +988,20 @@ void shutdown() {
         disable_dispatch_log_for_queue_locked(q);
       });
 
-  // Drop any drain-state shared_ptrs still pinned by g_active_queues.
+  // Drop any drain-state shared_ptrs still pinned by g_active_drainers.
   // The destructor on queue_drain_state defensively joins worker if it
   // is still joinable (it should not be — disable above joined it
   // already), so this is safe even if a queue somehow escaped the
   // disable pass above.
   {
-    std::lock_guard<std::mutex> lk(g_lifecycle_mu);
-    g_known_queues.clear();
-    g_active_queues.clear();
+    std::lock_guard<std::mutex> lk(g_queue_registry_mu);
+    g_all_queues.clear();
+    g_active_drainers.clear();
     g_no_dispatch_log_agents.clear();
   }
   {
-    std::lock_guard<std::mutex> lk(g_owners_mu);
-    g_owners.clear();
+    std::lock_guard<std::mutex> lk(g_profiling_refcounts_mu);
+    g_profiling_refcounts.clear();
   }
 }
 
@@ -1065,12 +1009,12 @@ void on_queue_create(core::Queue* q) {
   if (q == nullptr) return;
 
   // Register the queue in the poller's live-queue side map BEFORE running
-  // the enable sequence. Holding g_lifecycle_mu across both the registry
+  // the enable sequence. Holding g_queue_registry_mu across both the registry
   // insert and the enable serializes us against the poller (which iterates
-  // g_known_queues under the same mutex) and against on_queue_destroy.
-  std::lock_guard<std::mutex> lk(g_lifecycle_mu);
-  g_known_queues[queue_id_of(q)] = q;
-  if (G_tracepoint_enabled.load(std::memory_order_relaxed)) {
+  // g_all_queues under the same mutex) and against on_queue_destroy.
+  std::lock_guard<std::mutex> lk(g_queue_registry_mu);
+  g_all_queues[queue_id_of(q)] = q;
+  if (g_dispatch_logging_active.load(std::memory_order_relaxed)) {
     enable_dispatch_log_for_queue_locked(q);
   }
 }
@@ -1078,13 +1022,13 @@ void on_queue_create(core::Queue* q) {
 void on_queue_destroy(core::Queue* q) {
   if (q == nullptr) return;
 
-  // Remove from g_known_queues BEFORE the disable sequence so the poller
+  // Remove from g_all_queues BEFORE the disable sequence so the poller
   // can never observe a Queue* whose underlying core::Queue is being torn
   // down. Held across the disable so the poller's iterating thread is
   // forced to wait behind the mutex if it currently holds it.
   {
-    std::lock_guard<std::mutex> lk(g_lifecycle_mu);
-    g_known_queues.erase(queue_id_of(q));
+    std::lock_guard<std::mutex> lk(g_queue_registry_mu);
+    g_all_queues.erase(queue_id_of(q));
     if (q->dispatch_log_active.load(std::memory_order_acquire)) {
       disable_dispatch_log_for_queue_locked(q);
     }
@@ -1093,8 +1037,8 @@ void on_queue_destroy(core::Queue* q) {
   // Drop the per-queue refcount entry. Safe to do unconditionally — if the
   // queue never had an acquire, the lookup is just a miss.
   {
-    std::lock_guard<std::mutex> lk(g_owners_mu);
-    g_owners.erase(q);
+    std::lock_guard<std::mutex> lk(g_profiling_refcounts_mu);
+    g_profiling_refcounts.erase(q);
   }
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -149,10 +149,45 @@ struct queue_drain_state {
   uint32_t ring_mask    = 0;     // ring_records - 1, for slot indexing
 
   // Host-managed monotonic record cursor. Mutated only under drain_mu.
-  // Slot index is (next_idx & ring_mask). Sentinel-scan: drainer advances
-  // for every slot whose record_type is non-zero and clears the sentinel
-  // after consume so a wraparound rewrite is re-detectable.
+  // Slot index is (next_idx & ring_mask).
+  //
+  // Two drain modes select on whether wptr_ptr below is non-null:
+  //   - WPTR-bound scan (preferred, MINOR>=20): next_idx tracks the
+  //     absolute count of records the host has emitted. Each pass reads
+  //     fw_wptr atomically and iterates [next_idx, fw_wptr). After
+  //     emitting all records, next_idx is set to fw_wptr and the same
+  //     value is published to *rptr_ptr for FW backpressure visibility
+  //     (FW does not currently read it but publishing keeps the door
+  //     open for future FW that does).
+  //   - Sentinel scan (fallback, older kernel/FW): next_idx still
+  //     advances per non-zero slot. record_type==0 marks empty; the
+  //     drainer clears the sentinel post-emit so wraparound rewrites
+  //     are re-detectable.
   uint64_t next_idx = 0;
+
+  // Phase-2 host-VA pointer set. Populated by
+  // enable_dispatch_log_for_queue_locked from
+  // AqlQueue::GetDispatchLogPointers when the running kernel supports
+  // KFD_IOC_PROFILER_DISPATCH_LOG (MINOR>=20) and the new sub-op
+  // succeeded. All three are nullptr in fallback mode.
+  //
+  // Memory model:
+  //   - wptr_ptr: FW writes per-record (post-increment record count) with
+  //     release-atomicity equivalent (FW spins on TC outstanding tag
+  //     count after the record body write before the wptr publish, per
+  //     f32_mec.uc @SubAqlProfBufWriteRecord). Host reads with acquire
+  //     to establish happens-before with the record body bytes.
+  //   - rptr_ptr: host writes after consume with release. FW reads on
+  //     queue connect (currently informational; backpressure not
+  //     enforced).
+  //   - signal_ptr: FW writes per-record (same value as wptr_ptr — see
+  //     FW Q3 in 2026-05-01-mec-firmware-dispatch-log-interface.md).
+  //     Host can use as an HSA signal payload for hsa_signal_wait_value_geq
+  //     or sleep-then-poll. Currently unused by the drain loop (we busy-
+  //     poll wptr_ptr instead) but kept for future signal-based wait.
+  volatile uint64_t* wptr_ptr   = nullptr;
+  volatile uint64_t* rptr_ptr   = nullptr;
+  volatile uint64_t* signal_ptr = nullptr;
 
   // Per-queue drain mutex. With one worker per queue this is technically
   // redundant in steady state (the worker is the sole drainer for its
@@ -357,20 +392,103 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
   // Poisoned (disable in flight) or never-populated.
   if (qs.ring_base == nullptr || qs.ring_records == 0) return false;
 
-  // C9 (stage-2 review): bound each pass to one full ring sweep. The
-  // sentinel-scan loop exits only when it observes record_type == 0 for
-  // the current slot; if FW keeps the ring continuously non-empty, an
-  // unbounded loop here would (under the prior single-shared-drainer
-  // design) starve other queues. With one worker per queue today the
-  // cross-queue starvation argument no longer applies, but the cap is
-  // still useful: it bounds the time between checks of qs.should_stop
-  // (and the helper's own kill-switch check below), so a disable
-  // transition does not have to wait for an unbounded FW write rate
-  // to drain. Capping at ring_records slots (= one full ring sweep)
-  // also preserves forward progress: at any instant FW can have at
-  // most ring_records unconsumed slots, so a full sweep always drains
-  // everything that was visible at pass start. Anything FW writes
-  // during the pass becomes the next pass's work.
+  // ============================================================================
+  // PATH A: WPTR-BOUND SCAN (preferred, KFD MINOR>=20 + new FW)
+  //
+  // FW publishes the post-increment record count to *qs.wptr_ptr per
+  // record (see f32_mec.uc @SubAqlProfBufWriteRecord). Host reads it
+  // atomically with acquire and iterates [qs.next_idx, fw_wptr) — each
+  // slot is read exactly once, no duplicates possible. After consuming,
+  // host publishes its position to *qs.rptr_ptr for FW visibility (FW
+  // does not enforce backpressure today but the publish keeps the door
+  // open).
+  //
+  // Overrun handling: if (fw_wptr - qs.next_idx) > qs.ring_records the
+  // host has fallen behind by more than one ring lap; the older records
+  // were silently overwritten (FW does not stall on full ring). We jump
+  // qs.next_idx forward by the overrun distance and emit a kernel_dispatch_drop
+  // tracepoint so the consumer sees the gap. This is the bounded-progress
+  // analog of the sentinel-scan's pass_budget.
+  // ============================================================================
+  if (qs.wptr_ptr != nullptr) {
+    const uint64_t fw_wptr = __atomic_load_n(qs.wptr_ptr, __ATOMIC_ACQUIRE);
+
+    // Nothing new since last pass. Steady-state cheap exit.
+    if (fw_wptr == qs.next_idx) return false;
+
+    // Overrun detection. If FW lapped us, log a drop event and skip
+    // the unrecoverable region. The records we DO read after the skip
+    // are still valid (they're the most recent fw_wptr - ring_records
+    // records, just with a gap before them).
+    uint64_t start = qs.next_idx;
+    uint64_t end   = fw_wptr;
+    if ((end - start) > qs.ring_records) {
+      const uint64_t lost = (end - start) - qs.ring_records;
+      rocm_trace_emit_hsa_kernel_dispatch_drop(
+          queue_id_to_wire(qs.queue_id), lost);
+      start = end - qs.ring_records;
+    }
+
+    bool any = false;
+    for (uint64_t i = start; i < end; ++i) {
+      // Kill-switch pre-check: bail before reading any record. Safe to
+      // bail here because qs.next_idx still points at the unread head
+      // and the next pass will pick up where we stopped (FW state
+      // unchanged — the wptr-bound scan never mutates the slot).
+      if (!force_emit && rocm_trace_disabled()) {
+        qs.next_idx = i;  // record progress so far
+        if (qs.rptr_ptr) __atomic_store_n(qs.rptr_ptr, i, __ATOMIC_RELEASE);
+        return any;
+      }
+
+      const uint64_t slot = i & qs.ring_mask;
+      auto* rec = reinterpret_cast<mec_dispatch_record_16*>(
+          static_cast<char*>(qs.ring_base) + slot * kSlotStride);
+
+      // FW publish-ordering contract (per f32_mec.uc Q6): record body
+      // is host-visible BEFORE the wptr update we acquire-loaded above.
+      // So all four DWs of this record are coherent. Use relaxed atomics
+      // to suppress UB from non-atomic reads on FW-written memory; the
+      // wptr acquire load above provides the ordering.
+      const uint32_t ts_lo        = __atomic_load_n(&rec->ts_lo,        __ATOMIC_RELAXED);
+      const uint32_t ts_hi        = __atomic_load_n(&rec->ts_hi,        __ATOMIC_RELAXED);
+      const uint32_t rt           = __atomic_load_n(&rec->record_type,  __ATOMIC_RELAXED);
+      const uint32_t dispatch_idx = __atomic_load_n(&rec->dispatch_idx, __ATOMIC_RELAXED);
+      const uint64_t gpu_ts       = (static_cast<uint64_t>(ts_hi) << 32) | ts_lo;
+
+      // No slot mutation in the wptr-bound path: FW will overwrite this
+      // slot when wptr next reaches the same physical slot, and our
+      // wptr-based iteration will read it as a new record at that time.
+      // No sentinel needed because we never re-read the same wptr index.
+
+      rocm_trace_emit_hsa_kernel_dispatch_record(
+          queue_id_to_wire(qs.queue_id), dispatch_idx, gpu_ts,
+          static_cast<uint8_t>(rt), force_emit);
+
+      any = true;
+    }
+
+    qs.next_idx = end;
+    // Publish our consumer position back to FW (informational; FW does
+    // not enforce backpressure today but reads on connect/dequeue).
+    if (qs.rptr_ptr) __atomic_store_n(qs.rptr_ptr, end, __ATOMIC_RELEASE);
+    return any;
+  }
+
+  // ============================================================================
+  // PATH B: SENTINEL-SCAN FALLBACK (older kernel/FW without host-VA wptr)
+  //
+  // FW writes record_type ∈ {1, 2} into each slot it produces; host
+  // pre-zeroes the buffer at allocation, so a slot whose record_type
+  // is 0 is "empty". Drainer walks slots from qs.next_idx, atomic-stores
+  // record_type=0 after consume so wraparound rewrites are re-detectable.
+  //
+  // KNOWN ISSUE: FW slot reuse can cause the same (dispatch_idx,
+  // record_type) pair to be observed twice in a single session under
+  // burst patterns (capture rate observed at 250-316% vs expected 200%).
+  // The wptr-bound path above is immune to this; this fallback is only
+  // used on older kernels that don't ship the new MQD slots.
+  // ============================================================================
   const uint64_t pass_budget = qs.ring_records;
   uint64_t pass_consumed = 0;
 
@@ -748,6 +866,25 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
     qs->ring_records     = record_count;
     qs->ring_mask        = record_count - 1;
     qs->next_idx         = 0;
+
+    // Capture the Phase-2 host-VA pointer set if the new
+    // KFD_IOC_PROFILER_DISPATCH_LOG path is active for this queue.
+    // GetDispatchLogPointers returns NOT_INITIALIZED on older
+    // kernels (MINOR<20) or older libhsakmt (no SetDispatchLog
+    // thunk) — in that case the pointers stay null and the drainer
+    // falls back to sentinel-scan automatically.
+    volatile uint64_t* wptr_p   = nullptr;
+    volatile uint64_t* rptr_p   = nullptr;
+    volatile uint64_t* signal_p = nullptr;
+    hsa_status_t dl_status =
+        aql_queue->GetDispatchLogPointers(&wptr_p, &rptr_p, &signal_p);
+    if (dl_status == HSA_STATUS_SUCCESS) {
+      qs->wptr_ptr   = wptr_p;
+      qs->rptr_ptr   = rptr_p;
+      qs->signal_ptr = signal_p;
+    }
+    // else: legacy sentinel-scan mode; null pointers tell drain_one_queue
+    // to use the fallback scan path.
 
     g_active_drainers[qs->queue_id] = qs;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -667,8 +667,10 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
 
   // GetProfilingDispatchRecords reports buf_bytes = record_count * 16
   // (the FW record-stride sized capacity). The kernel-side BO is
-  // oversized (count * 40) per the host KFD ABI; the drainer iterates
-  // 40-byte slots and only interprets the first 16 bytes per slot.
+  // oversized at count * 40 to satisfy host KFD ABI validation, but the
+  // FW writes — and the drainer reads — at the 16-byte FW record stride
+  // (kSlotStride). See dispatch_log.cpp:390 and the slot addressing at
+  // dispatch_log.cpp:400-402.
   const uint32_t record_count = buf_bytes / static_cast<uint32_t>(sizeof(mec_dispatch_record_16));
   if (record_count == 0 || (record_count & (record_count - 1)) != 0) {
     std::fprintf(stderr,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -413,6 +413,27 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
 
   bool any = false;
   while (pass_consumed < pass_budget) {
+    // Cheap kill-switch pre-check (review C4): tested at the very top of
+    // the per-record body, BEFORE any slot mutation. translate_gpu_ts
+    // performs a linear interpolation under the agent's clock-cache
+    // lock, so doing it 1× per record × kRingSlots in the disable-race
+    // window is wasted work the emit helper would discard anyway. The
+    // helper's own kill-switch check still runs (defense in depth).
+    //
+    // Position rationale: this check MUST sit before the record_type
+    // load + slot memset (below) so that bailing here leaves the slot
+    // intact and `qs.next_idx` still pointing at it. If we zeroed the
+    // slot first and then bailed, the slot would be permanently
+    // destroyed (FW had already written it, and the wptr cursor stays
+    // put), and on the next drain pass the sentinel scan would observe
+    // rt == 0 at next_idx and stop — stranding any later FW-written
+    // records until the ring wraps and FW rewrites the broken slot.
+    // Today no runtime API toggles the kill switch (it is set-once at
+    // construction in lttng/rocm_trace_init.cpp), so the wedge is not
+    // currently reachable, but ordering this check before slot mutation
+    // removes the latent footgun for any future runtime-toggle path.
+    if (!force_emit && rocm_trace_disabled()) break;
+
     const uint64_t slot = qs.next_idx & qs.ring_mask;
     auto* rec = reinterpret_cast<mec_dispatch_record_16*>(
         static_cast<char*>(qs.ring_base) + slot * kSlotStride);
@@ -467,7 +488,8 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     //
     // record_type narrowing uint32 -> uint8: current FW values are
     // 1 and 2 and the on-the-wire schema field is uint8_t. The
-    // sentinel-zero check above (rt == 0 at line ~439) already filters
+    // sentinel-zero check above (rt == 0 immediately after the acquire load)
+    // already filters
     // empty slots before this point, so rt is known non-zero at the
     // cast site — the truncation hazard is NOT sentinel collision
     // (no on-the-wire 0 can be produced here). The only hazard is two
@@ -476,14 +498,6 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     // widen the schema (and the cast) when (and only when) such a FW
     // revision exists.
     //
-    // Cheap pre-check: if neither force_emit nor a non-disabled state
-    // applies the emit will be discarded inside the helper, so skip
-    // the (lock-acquiring) translate_gpu_ts call. translate_gpu_ts
-    // performs a linear interpolation under the agent's clock-cache
-    // lock; doing it 1× per record × kRingSlots in the disable-race
-    // window is wasted work the helper would discard anyway. The
-    // helper's own kill-switch check still runs (defense in depth).
-    if (!force_emit && rocm_trace_disabled()) break;
     // Use the captured queue-independent translation callable — Queue
     // may be destroyed mid-pass even though the shared_ptr keeps qs
     // alive.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -739,24 +739,45 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
               ++stale_end;
             }
             const uint64_t stale_count = stale_end - i;
-            rocm_trace_emit_hsa_kernel_dispatch_drop(
-                queue_id_to_wire(qs.queue_id), stale_count);
-            qs.next_idx = stale_end;
-            if (qs.rptr_ptr) {
-              __atomic_store_n(qs.rptr_ptr, stale_end, __ATOMIC_RELEASE);
+            if (stale_count == 0) {
+              // Race: between the first rt==0 load at the top of this
+              // iteration and the sweep's re-read of slot i, FW
+              // published into slot i (zrt != 0 caused the sweep loop
+              // to break immediately with stale_end == i). The slot is
+              // no longer stale; emitting a zero-count drop would
+              // violate the tracepoint contract (bytes_lost is the
+              // count of lost records — 0 is semantically invalid).
+              // Disarm the quarantine and let the main loop retry this
+              // same index, which will now observe the published
+              // record and process it normally.
+              qs.pending_zero_stall.store(false, std::memory_order_release);
+              // Do not set `any = true`: nothing was emitted or
+              // advanced; the retry of slot i will set it if the
+              // published record is processed.
+              // Do not advance i; the for-loop's ++i would skip the
+              // freshly-published slot. Step back one so ++i lands on
+              // i again.
+              --i;
+            } else {
+              rocm_trace_emit_hsa_kernel_dispatch_drop(
+                  queue_id_to_wire(qs.queue_id), stale_count);
+              qs.next_idx = stale_end;
+              if (qs.rptr_ptr) {
+                __atomic_store_n(qs.rptr_ptr, stale_end, __ATOMIC_RELEASE);
+              }
+              qs.pending_zero_stall.store(false, std::memory_order_release);
+              any = true;
+              // If the sweep stopped at a real record, fall through to
+              // process it (and the rest of [stale_end, end)) in this
+              // same pass by resuming the for-loop at stale_end. If the
+              // sweep consumed the entire remaining window, the loop
+              // condition (i < end) will exit naturally.
+              i = stale_end;
+              // The for-loop's ++i would skip past stale_end; counteract
+              // by stepping back one. (When stale_end == end, this still
+              // works: i becomes end-1, ++i → end, loop exits.)
+              --i;
             }
-            qs.pending_zero_stall.store(false, std::memory_order_release);
-            any = true;
-            // If the sweep stopped at a real record, fall through to
-            // process it (and the rest of [stale_end, end)) in this
-            // same pass by resuming the for-loop at stale_end. If the
-            // sweep consumed the entire remaining window, the loop
-            // condition (i < end) will exit naturally.
-            i = stale_end;
-            // The for-loop's ++i would skip past stale_end; counteract
-            // by stepping back one. (When stale_end == end, this still
-            // works: i becomes end-1, ++i → end, loop exits.)
-            --i;
             continue;
           }
         } else {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -397,8 +397,23 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
   // Poisoned (disable in flight) or never-populated.
   if (qs.ring_base == nullptr || qs.ring_records == 0) return false;
 
+  // C9 (stage-2 review): bound each pass to one full ring sweep. The
+  // sentinel-scan loop exits only when it observes record_type == 0 for
+  // the current slot; if FW keeps the ring continuously non-empty, an
+  // unbounded loop here would let one queue monopolize ts_drainer (which
+  // walks queues sequentially under g_lifecycle_mu in
+  // ts_drainer_thread_main) and starve other queues, plus delay disable
+  // / shutdown paths that need drain_mu. Capping at ring_records slots
+  // (= one full ring sweep) preserves forward progress: at any instant
+  // FW can have at most ring_records unconsumed slots, so a full sweep
+  // always drains everything that was visible at pass start. Anything
+  // FW writes during the pass becomes the next pass's work — which is
+  // also the prior wptr-snapshot design's behaviour.
+  const uint64_t pass_budget = qs.ring_records;
+  uint64_t pass_consumed = 0;
+
   bool any = false;
-  while (true) {
+  while (pass_consumed < pass_budget) {
     const uint64_t slot = qs.next_idx & qs.ring_mask;
     auto* rec = reinterpret_cast<mec_dispatch_record_16*>(
         static_cast<char*>(qs.ring_base) + slot * kSlotStride);
@@ -463,6 +478,7 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     }
 
     qs.next_idx += 1;
+    pass_consumed += 1;
     any = true;
   }
   return any;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -267,8 +267,19 @@ std::unordered_map<uint32_t, core::Queue*> g_known_queues;
 // Side-map for the QueueProfilingAcquire/Release refcount (spec §4a). One
 // entry per Queue* that has ever had at least one acquire. Looked up under
 // g_owners_mu.
+//
+// **Lifetime contract.** Entries are held via std::shared_ptr because
+// QueueProfilingAcquire / QueueProfilingRelease intentionally drop
+// g_owners_mu before locking the per-entry mutex (the per-entry lock can
+// be held across SetProfiling(), which we don't want to do under the
+// global map mutex). Without shared ownership, on_queue_destroy could
+// erase the map entry between our map-lookup and our per-entry-lock,
+// freeing the queue_profiling_owners object out from under us. Copying
+// the shared_ptr while still holding g_owners_mu pins the entry alive
+// until the API call's local shared_ptr drops, even if on_queue_destroy
+// concurrently erases the map slot.
 std::mutex g_owners_mu;
-std::unordered_map<core::Queue*, std::unique_ptr<queue_profiling_owners>> g_owners;
+std::unordered_map<core::Queue*, std::shared_ptr<queue_profiling_owners>> g_owners;
 
 // Per-agent "no-dispatch-log" mark. If the KFD ioctl returns ENOTSUP for any
 // queue on a given agent, that agent is added here and subsequent
@@ -520,20 +531,25 @@ void wait_for_idle(core::Queue* q) {
 // Profiling-bit refcount (spec §4a).
 // ============================================================================
 
-queue_profiling_owners* get_or_create_owners(core::Queue* q) {
+std::shared_ptr<queue_profiling_owners> get_or_create_owners(core::Queue* q) {
   // Caller holds g_owners_mu.
   auto it = g_owners.find(q);
-  if (it != g_owners.end()) return it->second.get();
+  if (it != g_owners.end()) return it->second;
   auto inserted = g_owners.emplace(
-      q, std::unique_ptr<queue_profiling_owners>(new queue_profiling_owners()));
-  return inserted.first->second.get();
+      q, std::make_shared<queue_profiling_owners>());
+  return inserted.first->second;
 }
 
 }  // namespace
 
 hsa_status_t QueueProfilingAcquire(core::Queue* q) {
   if (q == nullptr) return HSA_STATUS_ERROR_INVALID_QUEUE;
-  queue_profiling_owners* owners = nullptr;
+  // Pin the entry alive across the per-entry lock acquire by copying the
+  // shared_ptr out under g_owners_mu. Even if on_queue_destroy erases the
+  // map slot between here and the lock_guard below, this local shared_ptr
+  // keeps the queue_profiling_owners object alive (spec §4a + lifetime
+  // contract on g_owners). See C4 fix.
+  std::shared_ptr<queue_profiling_owners> owners;
   {
     std::lock_guard<std::mutex> lk(g_owners_mu);
     owners = get_or_create_owners(q);
@@ -553,7 +569,8 @@ hsa_status_t QueueProfilingAcquire(core::Queue* q) {
 
 hsa_status_t QueueProfilingRelease(core::Queue* q) {
   if (q == nullptr) return HSA_STATUS_ERROR_INVALID_QUEUE;
-  queue_profiling_owners* owners = nullptr;
+  // See QueueProfilingAcquire for the shared_ptr lifetime rationale (C4).
+  std::shared_ptr<queue_profiling_owners> owners;
   {
     std::lock_guard<std::mutex> lk(g_owners_mu);
     auto it = g_owners.find(q);
@@ -562,7 +579,7 @@ hsa_status_t QueueProfilingRelease(core::Queue* q) {
       // failure without modifying state.
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;
     }
-    owners = it->second.get();
+    owners = it->second;
   }
   std::lock_guard<std::mutex> lk(owners->m);
   if (owners->refcount == 0) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -1295,8 +1295,10 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
     volatile uint64_t* wptr_p   = nullptr;
     volatile uint64_t* rptr_p   = nullptr;
     volatile uint64_t* signal_p = nullptr;
+    bool ph2_fresh_allocation   = true;  // default-fresh; only consulted when path A wins
     hsa_status_t dl_status =
-        aql_queue->GetDispatchLogPointers(&wptr_p, &rptr_p, &signal_p);
+        aql_queue->GetDispatchLogPointers(&wptr_p, &rptr_p, &signal_p,
+                                          &ph2_fresh_allocation);
     if (dl_status == HSA_STATUS_SUCCESS) {
       qs->wptr_ptr   = wptr_p;
       qs->rptr_ptr   = rptr_p;
@@ -1305,48 +1307,60 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
     // else: legacy sentinel-scan mode; null pointers tell drain_one_queue
     // to use the fallback scan path.
 
-    // next_idx initialization (code-quality C2). Snapshot the current
-    // value of *signal_ptr (Path A only) and adopt it as our monotonic
-    // floor. Two cases this correctly covers:
+    // next_idx initialization (code-quality C2 + C3 round 2).
     //
-    //   1. Fresh queue (the common case). SetProfiling(true) just
-    //      allocated and zeroed the host signal word, so observed=0,
-    //      qs->next_idx=0. The first FW post-enable record write will
-    //      jump signal from 0 to (scratch_wptr_persisted + 1) and the
-    //      drain_one_queue Path A initial-sync logic
-    //      (initial_sync == (next_idx == 0)) handles the persisted
-    //      scratch wptr exactly as before. NO behavior change.
+    // The Path A drainer treats next_idx as the monotonic floor of
+    // already-emitted records. The choice of starting value depends on
+    // whether SetProfiling(true) just freshly allocated and zeroed the
+    // host signal word, or whether it hit the "buffer already wired"
+    // no-op path on a re-enable after a failed disable. We get this
+    // bit out of band from AqlQueue::GetDispatchLogPointers via
+    // ph2_fresh_allocation (set by AqlQueue::SetProfiling).
     //
-    //   2. Re-enable after a failed disable. If the previous disable's
-    //      QueueProfilingRelease -> AqlQueue::SetProfiling(false) failed
-    //      its KFD CLEAR, AqlQueue keeps the dispatch_record_buffer_
-    //      live, leaves the profiling bit set, and FW continues writing
-    //      records into the buffer (and advancing *signal_ptr) during
-    //      the disabled window. On a subsequent enable, SetProfiling
-    //      sees dispatch_record_buffer_ != nullptr and is a no-op — it
-    //      does NOT re-zero the signal word. Without this snapshot the
-    //      new drainer would start at next_idx=0 with observed already
-    //      huge, treat it as init-sync (initial_sync==true), and either
-    //      silently drop the entire ring's worth of stale-or-real
-    //      records or emit pre-zeroed slots as records. Snapshotting
-    //      the FW signal here causes the drainer to skip everything FW
-    //      wrote during the disabled window — which is the only safe
-    //      behavior, since we have no way to distinguish records the
-    //      consumer would still want from records belonging to a
-    //      lifecycle that already ended.
+    //   1. Fresh allocation (ph2_fresh_allocation=true; the common
+    //      case). SetProfiling(true) just allocated and zeroed the host
+    //      signal word, so observed=0 and next_idx must also be 0. The
+    //      first FW post-enable record write will jump signal from 0 to
+    //      (scratch_wptr_persisted + 1) and the drain_one_queue Path A
+    //      initial-sync logic (initial_sync == (next_idx == 0)) handles
+    //      the persisted scratch wptr exactly as before.
     //
-    // Path B (sentinel-scan fallback, signal_ptr==nullptr) is not
-    // affected by this hazard: it has no out-of-band write counter,
-    // and its existing per-slot record_type sentinel walk handles
-    // both fresh and re-enable cases correctly.
-    if (qs->signal_ptr != nullptr) {
+    //      Critically: we MUST NOT snapshot *signal_ptr on a fresh
+    //      allocation. A fresh queue may already be actively dispatching
+    //      between the SetProfiling success and our read here, and FW
+    //      can publish records (advancing *signal_ptr) in that window.
+    //      Snapshotting would adopt that value into next_idx, the first
+    //      drain pass would see observed <= next_idx and return without
+    //      emitting, and those legitimate first-window records would be
+    //      silently dropped (regression introduced by the original C2
+    //      fix; caught in code-quality round 2).
+    //
+    //   2. Re-enable after a failed disable (ph2_fresh_allocation=false).
+    //      AqlQueue kept the dispatch_record_buffer_ live, FW continued
+    //      writing records and advancing *signal_ptr through the
+    //      disabled window, and SetProfiling(true) hit the no-op path —
+    //      so the host signal word is NOT zero. Snapshot it and adopt
+    //      it as our floor; this skips records FW wrote during the
+    //      disabled window, which is the only safe behavior since those
+    //      records belong to a lifecycle that already ended from the
+    //      consumer's point of view.
+    //
+    // Path B (sentinel-scan fallback, signal_ptr==nullptr) does NOT
+    // get the same fix: the existing per-slot record_type sentinel walk
+    // correctly handles a freshly-zeroed buffer but does NOT distinguish
+    // stale records left by a previous lifecycle from new records on a
+    // re-enable after a failed disable. That hazard is not addressed
+    // here; it only matters on older kernels (KFD MINOR < 20 or older
+    // libhsakmt) which can fall back to Path B. Documented limitation;
+    // pursue separately if it bites in practice.
+    if (qs->signal_ptr != nullptr && !ph2_fresh_allocation) {
       qs->next_idx = __atomic_load_n(qs->signal_ptr, __ATOMIC_ACQUIRE);
       // Publish the snapshot to *rptr_ptr too so FW's backpressure view
       // matches our monotonic floor. SetProfiling on a re-enable after
       // a failed disable does not re-zero the rptr word either, so it
       // could otherwise lag far behind signal and report false
-      // backpressure to FW. On a fresh queue both words are 0 and this
-      // is a no-op store.
+      // backpressure to FW. (On the fresh-allocation branch both words
+      // are already 0 by SetProfiling, so no rptr publish is needed.)
       if (qs->rptr_ptr) {
         __atomic_store_n(qs->rptr_ptr, qs->next_idx, __ATOMIC_RELEASE);
       }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -161,7 +161,6 @@ struct queue_drain_state {
   // slot whose record_type is non-zero, and zero the slot after consume
   // so a wraparound re-write is re-detectable. See drain_one_queue.
   uint64_t next_idx = 0;
-  std::unordered_map<uint32_t, uint64_t> pending_starts;
 
   // Per-queue drain mutex. Serializes drain_one_queue() (steady state) and
   // ts_drainer_drain_now() (synchronous final drain on the destroying /
@@ -176,7 +175,7 @@ struct queue_drain_state {
 
 // Spec §4 single source of truth for "should HSA be collecting kernel-dispatch
 // timestamps right now?". Folded predicate of !rocm_trace_disabled() &&
-// lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_complete) &&
+// lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_record) &&
 // g_substrate_present. Written only by ts_poller; read by on_queue_create
 // (relaxed, hot path) and ts_drainer.
 std::atomic<bool> G_tracepoint_enabled{false};
@@ -268,7 +267,7 @@ uint64_t queue_id_of(core::Queue* q) {
 }
 
 // Narrow the 64-bit internal queue_id to the 32-bit on-the-wire identifier
-// emitted by the rocm_hsa:kernel_dispatch_complete / kernel_dispatch_drop
+// emitted by the rocm_hsa:kernel_dispatch_record / kernel_dispatch_drop
 // LTTng tracepoints. Spec §6 / §14 fix the wire format at uint32_t for
 // payload size; consumers join with the low 32 bits of the masked AQL
 // doorbell write_idx (also 32-bit on-the-wire). This narrowing is
@@ -454,28 +453,33 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     // target.
     std::memset(rec, 0, kSlotStride);
 
-    if (rt == DISPATCH_LOG_RECORD_START) {
-      qs.pending_starts[dispatch_idx] = gpu_ts;
-    } else if (rt == DISPATCH_LOG_RECORD_END) {
-      auto it = qs.pending_starts.find(dispatch_idx);
-      if (it != qs.pending_starts.end()) {
-        const uint64_t start_gpu = it->second;
-        qs.pending_starts.erase(it);
+    // Emit one event per FW-written record. No host-side START/END
+    // pairing — consumer joins on (queue_id, dispatch_idx) and uses
+    // gpu_ts ordering or record_type semantics as it sees fit.
+    //
+    // Empirically on the gfx950 MEC firmware (gc_9_5_0_mec.bin):
+    // record_type==2 carries the earlier ts (dispatch start),
+    // record_type==1 carries the later ts (EOP / dispatch end). HSA
+    // emits both records as-is without taking a position on which is
+    // which — the FW contract is not formally versioned, and a
+    // consumer-side polarity decision is cheaper to update than a
+    // host-runtime release.
+    //
+    // record_type narrowing uint32 -> uint8: current FW values are
+    // 1 and 2 and the on-the-wire schema field is uint8_t. If a future
+    // FW adds a record_type beyond 255, the static_cast silently
+    // truncates; we accept this risk for the smaller payload and will
+    // widen the schema (and the cast) when (and only when) such a
+    // FW revision exists. Use the captured queue-independent
+    // translation callable — Queue may be destroyed mid-pass even
+    // though the shared_ptr keeps qs alive.
+    const uint64_t gpu_ts_sys = qs.translate_gpu_ts(gpu_ts);
 
-        // Use the captured queue-independent translation callable —
-        // Queue may be destroyed mid-pass even though the shared_ptr
-        // keeps qs alive.
-        const uint64_t start_sys = qs.translate_gpu_ts(start_gpu);
-        const uint64_t end_sys   = qs.translate_gpu_ts(gpu_ts);
-
-        // Narrow internal 64-bit queue_id at the tracepoint boundary
-        // (spec §6 / §14, C5 fix). dispatch_idx is 32-bit per FW contract.
-        rocm_trace_emit_hsa_kernel_dispatch_complete(
-            queue_id_to_wire(qs.queue_id), dispatch_idx, start_sys,
-            end_sys, force_emit);
-      }
-      // else: orphan END (matching START was lost). Silently skip.
-    }
+    // Narrow internal 64-bit queue_id at the tracepoint boundary
+    // (spec §6 / §14, C5 fix). dispatch_idx is 32-bit per FW contract.
+    rocm_trace_emit_hsa_kernel_dispatch_record(
+        queue_id_to_wire(qs.queue_id), dispatch_idx, gpu_ts_sys,
+        static_cast<uint8_t>(rt), force_emit);
 
     qs.next_idx += 1;
     pass_consumed += 1;
@@ -822,20 +826,20 @@ bool predicate_now() {
 #if defined(HSA_ENABLE_LTTNG_UST) && HSA_ENABLE_LTTNG_UST
   if (rocm_trace_disabled()) return false;
   if (!g_substrate_present.load(std::memory_order_relaxed)) {
-    if (lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_complete)) {
+    if (lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_record)) {
       bool warned = g_substrate_absent_warned.load(std::memory_order_relaxed);
       if (!warned && g_substrate_absent_warned.compare_exchange_strong(
                          warned, true)) {
         std::fprintf(stderr,
                      "[hsa-runtime] dispatch_log: tracepoint "
-                     "rocm_hsa:kernel_dispatch_complete is enabled, but the "
+                     "rocm_hsa:kernel_dispatch_record is enabled, but the "
                      "KFD substrate is not available on this kernel "
                      "(KFD minor version < 22). No events will be produced.\n");
       }
     }
     return false;
   }
-  return lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_complete) != 0;
+  return lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_record) != 0;
 #else
   return false;
 #endif

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -475,40 +475,64 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     // and that counter PERSISTS across queue lifecycles. When KFD
     // destroys a queue and creates a new one on the same pipe, the new
     // queue inherits the previous queue's wptr value. At
-    // enable_dispatch_log_for_queue time we initialize qs.next_idx from
-    // the current FW signal value, but the host signal_addr is still 0
-    // at that moment (FW hasn't published since enable). Once FW writes
-    // its first record post-enable, signal jumps from 0 to whatever the
-    // pipe scratch wptr was + 1, which can be huge (millions).
+    // enable_dispatch_log_for_queue time qs.next_idx is initialized to
+    // 0 because the host signal word is also 0 at enable (FW hasn't
+    // published since enable). Once FW writes its first record
+    // post-enable, signal jumps from 0 to scratch_wptr+1, which can
+    // be small (e.g. 2 if the pipe was lightly used previously) or
+    // huge (millions on a long-lived process).
     //
-    // Without this sync the overrun handler below would interpret the
-    // huge gap as "we fell behind by ring_records or more" and emit a
-    // drop event followed by reads of stale ring storage (most slots
-    // empty / pre-zero, only the freshly-written slot has real data).
-    // Net effect: hundreds of zero-record batched events per queue
-    // immediately after enable.
+    // Code-quality C2: the previous magnitude-based heuristic
+    // (`if observed > ring_records: next_idx = observed - 1`) was
+    // wrong in two complementary ways:
     //
-    // Heuristic: if next_idx is 0 (never advanced past initial enable)
-    // AND observed > ring_records (impossibly far ahead for a fresh
-    // queue), treat as initial-state sync. Set next_idx = observed - 1
-    // so we drain ONE record (the actual fresh dispatch FW just wrote)
-    // and start tracking from there. The single record at slot
-    // (observed - 1) & ring_mask is the real one FW just wrote at the
-    // pre-increment scratch wptr position.
-    if (qs.next_idx == 0 && observed > qs.ring_records) {
-      qs.next_idx = observed - 1;
-    }
+    //   1. SMALL persisted-counter case (e.g. observed == 2 with FW
+    //      writing one fresh record): the heuristic did not fire, so
+    //      [start=0, end=2) was emitted including slot 0 which was
+    //      pre-zeroed by AqlQueue::SetProfiling. Consumers received
+    //      a record with all-zero ts / record_type / dispatch_idx.
+    //
+    //   2. HUGE persisted-counter case with N>1 fresh records (e.g.
+    //      scratch wptr = 5000, FW writes 3 records → observed = 5003):
+    //      the heuristic set next_idx = 5002 and emitted only slot
+    //      5002, silently dropping the records at slots 5000 and 5001
+    //      with no kernel_dispatch_drop event.
+    //
+    // Fix: make init-sync independent of `observed` magnitude and
+    // independent of whether the host fell behind. We treat the first
+    // non-zero signal observation specially:
+    //   - Compute the candidate scan window [start, end). For a fresh
+    //     buffer, the meaningful window is the suffix of FW-written
+    //     slots ending at end-1; older slots are pre-zeroed and stale.
+    //   - During init-sync only, validate each slot's record_type
+    //     during emit and SKIP slots whose record_type is 0. This
+    //     correctly emits all FW-written records in the window without
+    //     ever emitting a stale pre-zeroed slot.
+    //   - Do NOT emit kernel_dispatch_drop during init-sync — the
+    //     pre-zeroed gap represents records that never existed for
+    //     this queue lifecycle, not records the host fell behind on.
+    //
+    // The validate-on-emit strategy is safe under FW write ordering:
+    // signal is the LAST per-record write FW issues, so by the time
+    // we observe signal=N, every slot in [0, N) that WILL be written
+    // by FW has already been written. Slots with rt==0 in [start, end)
+    // are slots FW will never write for this lifecycle (they predate
+    // the queue or were pre-zeroed by SetProfiling).
+    const bool initial_sync = (qs.next_idx == 0);
 
     // Overrun detection. If FW lapped us, log a drop event and skip
     // the unrecoverable region. The records we DO read after the skip
     // are still valid (they're the most recent observed - ring_records
-    // records, just with a gap before them).
+    // records, just with a gap before them). Skipped during init-sync
+    // because the gap is not a real drop (see comment above).
     uint64_t start = qs.next_idx;
     uint64_t end   = observed;
     if ((end - start) > qs.ring_records) {
-      const uint64_t lost = (end - start) - qs.ring_records;
-      rocm_trace_emit_hsa_kernel_dispatch_drop(
-          queue_id_to_wire(qs.queue_id), lost);
+      if (!initial_sync) {
+        const uint64_t lost = (end - start) - qs.ring_records;
+        rocm_trace_emit_hsa_kernel_dispatch_drop(
+            queue_id_to_wire(qs.queue_id), lost);
+      }
       start = end - qs.ring_records;
     }
 
@@ -533,6 +557,17 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
       const uint64_t slot = i & qs.ring_mask;
       auto* rec = reinterpret_cast<mec_dispatch_record_16*>(
           static_cast<char*>(qs.ring_base) + slot * kSlotStride);
+
+      // Init-sync validation: skip pre-zeroed slots. FW writes
+      // record_type ∈ {1, 2}; slots with rt==0 in our scan window are
+      // slots FW has not written for this queue's lifecycle (the host
+      // pre-zero from AqlQueue::SetProfiling is still intact). Acquire
+      // ordering so the body loads (via memcpy below) cannot be
+      // reordered above this check on the rare slot that IS non-zero.
+      if (initial_sync) {
+        uint32_t rt = __atomic_load_n(&rec->record_type, __ATOMIC_ACQUIRE);
+        if (rt == 0) continue;
+      }
 
       // FW publish-ordering contract (per f32_mec.uc Q6): record body
       // is host-visible BEFORE the wptr update we acquire-loaded above.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -486,13 +486,19 @@ hsa_status_t QueueProfilingAcquire(core::Queue* q) {
   }
   std::lock_guard<std::mutex> lk(owners->m);
   const uint32_t prev = owners->refcount;
-  owners->refcount = prev + 1;
   if (prev == 0) {
     // 0->1 transition: enable profiling. AqlQueue::SetProfiling now also
     // allocates the per-queue dispatch-record buffer and pushes it to KFD
     // via hsaKmtSetQueueProfilingBuffer + Suspend/Resume (UPDATE_QUEUE).
-    q->SetProfiling(true);
+    //
+    // C3: propagate status. If SetProfiling fails (allocation failure or
+    // libhsakmt registration failure on an unsupported kernel), do NOT
+    // bump the refcount — the queue is not in the profiling-enabled
+    // state and a subsequent release would be unbalanced.
+    hsa_status_t s = q->SetProfiling(true);
+    if (s != HSA_STATUS_SUCCESS) return s;
   }
+  owners->refcount = prev + 1;
   return HSA_STATUS_SUCCESS;
 }
 
@@ -520,7 +526,13 @@ hsa_status_t QueueProfilingRelease(core::Queue* q) {
     // 1->0 transition: AqlQueue::SetProfiling(false) frees the per-queue
     // dispatch-record buffer and clears the KFD profiling-buffer
     // registration via UPDATE_QUEUE.
-    q->SetProfiling(false);
+    //
+    // C3: propagate libhsakmt teardown status. The host-side buffer is
+    // freed unconditionally (see SetProfiling), so we cannot recover the
+    // resources by retrying — a non-success status here is informational
+    // for the caller (e.g. test harnesses) and not a state-corruption
+    // signal.
+    return q->SetProfiling(false);
   }
   return HSA_STATUS_SUCCESS;
 }
@@ -567,11 +579,22 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
   // g_lifecycle_mu), so it's safe to call while holding g_lifecycle_mu.
   hsa_status_t s = QueueProfilingAcquire(q);
   if (s != HSA_STATUS_SUCCESS) {
+    // C3: now that QueueProfilingAcquire propagates the underlying
+    // SetProfiling status (allocation failure, libhsakmt
+    // SetQueueProfilingBuffer NOT_SUPPORTED, etc.), an error here means
+    // the agent's KFD/firmware substrate cannot accept a dispatch-record
+    // buffer for this queue. Mark the agent as no-dispatch-log so we
+    // don't retry every poll tick on every queue belonging to it (spec
+    // §5 unsupported-agent row, §9 unsupported-agent row). The refcount
+    // was not bumped (Acquire returns early on the 0->1 SetProfiling
+    // failure path), so no Release is needed.
     std::fprintf(stderr,
                  "[hsa-runtime] dispatch_log: queue_id=%llu ENABLE step 1 "
-                 "(QueueProfilingAcquire) failed status=%d\n",
+                 "(QueueProfilingAcquire) failed status=%d; marking agent "
+                 "as no-dispatch-log\n",
                  static_cast<unsigned long long>(queue_id_of(q)),
                  static_cast<int>(s));
+    g_no_dispatch_log_agents.insert(q->GetAgent());
     return;
   }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -1305,14 +1305,54 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
     // else: legacy sentinel-scan mode; null pointers tell drain_one_queue
     // to use the fallback scan path.
 
-    // next_idx starts at 0. The drain loop's initial-state sync (see
-    // drain_one_queue Path A) detects the FW per-pipe scratch wptr
-    // persistence on the FIRST observed signal advance and adjusts
-    // next_idx then. We can't read FW's wptr at enable time because
-    // FW won't publish to signal_addr until the first new record write
-    // POST-enable — at this exact point the host word is still 0
-    // (initialized by SetProfiling).
-    qs->next_idx = 0;
+    // next_idx initialization (code-quality C2). Snapshot the current
+    // value of *signal_ptr (Path A only) and adopt it as our monotonic
+    // floor. Two cases this correctly covers:
+    //
+    //   1. Fresh queue (the common case). SetProfiling(true) just
+    //      allocated and zeroed the host signal word, so observed=0,
+    //      qs->next_idx=0. The first FW post-enable record write will
+    //      jump signal from 0 to (scratch_wptr_persisted + 1) and the
+    //      drain_one_queue Path A initial-sync logic
+    //      (initial_sync == (next_idx == 0)) handles the persisted
+    //      scratch wptr exactly as before. NO behavior change.
+    //
+    //   2. Re-enable after a failed disable. If the previous disable's
+    //      QueueProfilingRelease -> AqlQueue::SetProfiling(false) failed
+    //      its KFD CLEAR, AqlQueue keeps the dispatch_record_buffer_
+    //      live, leaves the profiling bit set, and FW continues writing
+    //      records into the buffer (and advancing *signal_ptr) during
+    //      the disabled window. On a subsequent enable, SetProfiling
+    //      sees dispatch_record_buffer_ != nullptr and is a no-op — it
+    //      does NOT re-zero the signal word. Without this snapshot the
+    //      new drainer would start at next_idx=0 with observed already
+    //      huge, treat it as init-sync (initial_sync==true), and either
+    //      silently drop the entire ring's worth of stale-or-real
+    //      records or emit pre-zeroed slots as records. Snapshotting
+    //      the FW signal here causes the drainer to skip everything FW
+    //      wrote during the disabled window — which is the only safe
+    //      behavior, since we have no way to distinguish records the
+    //      consumer would still want from records belonging to a
+    //      lifecycle that already ended.
+    //
+    // Path B (sentinel-scan fallback, signal_ptr==nullptr) is not
+    // affected by this hazard: it has no out-of-band write counter,
+    // and its existing per-slot record_type sentinel walk handles
+    // both fresh and re-enable cases correctly.
+    if (qs->signal_ptr != nullptr) {
+      qs->next_idx = __atomic_load_n(qs->signal_ptr, __ATOMIC_ACQUIRE);
+      // Publish the snapshot to *rptr_ptr too so FW's backpressure view
+      // matches our monotonic floor. SetProfiling on a re-enable after
+      // a failed disable does not re-zero the rptr word either, so it
+      // could otherwise lag far behind signal and report false
+      // backpressure to FW. On a fresh queue both words are 0 and this
+      // is a no-op store.
+      if (qs->rptr_ptr) {
+        __atomic_store_n(qs->rptr_ptr, qs->next_idx, __ATOMIC_RELEASE);
+      }
+    } else {
+      qs->next_idx = 0;
+    }
 
     g_active_drainers[qs->queue_id] = qs;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -183,16 +183,39 @@ struct queue_drain_state {
   std::atomic<bool> should_stop{false};
   std::thread       worker;
 
-  // Defensive safety net. The disable / shutdown path is responsible for
-  // joining the worker explicitly; this destructor only fires if a
-  // queue_drain_state is dropped without anyone having done so (e.g. a
-  // future caller that constructs a qs but never registers it). std::thread's
-  // destructor calls std::terminate() on a still-joinable thread, so we
-  // signal stop and join here as a last-resort.
+  // Defensive safety net for early-construction failures (review C2,
+  // stage-2 code-quality). The supported lifetime model is: explicit
+  // disable / shutdown path stops + joins worker BEFORE dropping any
+  // shared_ptr ref. This destructor only matters in one specific case:
+  // a qs was made_shared but worker was never assigned (e.g. enable
+  // path's std::thread construction threw — review C1) and the
+  // registry path is rolling back via shared_ptr drop. In that case
+  // worker is default-constructed (joinable() == false) so the body
+  // is a no-op.
+  //
+  // The destructor canNOT meaningfully recover a started-but-unjoined
+  // worker. The worker holds its own shared_ptr<queue_drain_state>
+  // by value (per_queue_drain_loop param), so the destructor cannot
+  // be the path that releases the last ref while the worker is still
+  // running — by definition the worker's own ref is the last one when
+  // the loop returns, and at that point we are already on the worker
+  // thread. self-join would throw std::system_error
+  // (resource_deadlock_would_occur). Guard against that edge case
+  // explicitly: skip the join if `worker` represents the current
+  // thread. std::thread::id comparison is cheap and well-defined.
   ~queue_drain_state() {
-    if (worker.joinable()) {
+    if (worker.joinable() &&
+        worker.get_id() != std::this_thread::get_id()) {
       should_stop.store(true, std::memory_order_release);
       worker.join();
+    } else if (worker.joinable()) {
+      // Self-destruction path. We cannot join ourselves; detach so
+      // std::thread's destructor doesn't std::terminate the process.
+      // This branch indicates a programming error (the supported
+      // lifetime model requires explicit join from a non-worker
+      // thread before dropping the last ref); detaching is a
+      // best-effort cleanup, not a correctness path.
+      worker.detach();
     }
   }
 };
@@ -793,7 +816,30 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
   // for our hosts. Workloads pushing into the thousands-of-queues regime
   // would need a pthread_create-based spawn helper to set a small (e.g.
   // 64 KiB) stack; defer that until measured pressure exists.
-  qs->worker = std::thread(per_queue_drain_loop, qs);
+  //
+  // Failure handling (review C1, stage-2 code-quality): std::thread's
+  // ctor can throw std::system_error if the OS refuses to create the
+  // thread (EAGAIN / RLIMIT_NPROC / address-space exhaustion). Without
+  // a catch the exception would propagate up — to the poller's tick
+  // (which has no handler and would std::terminate the process), or
+  // to on_queue_create on an application thread. Roll back to the
+  // pre-enable state instead: erase the registry entry and release
+  // the profiling ref. The next poller tick will retry; the queue
+  // simply skips this tick.
+  try {
+    qs->worker = std::thread(per_queue_drain_loop, qs);
+  } catch (const std::system_error& e) {
+    std::fprintf(stderr,
+                 "[hsa-runtime] dispatch_log: queue_id=%llu ENABLE step 4 "
+                 "(std::thread spawn) failed: %s; rolling back enable\n",
+                 static_cast<unsigned long long>(queue_id_of(q)),
+                 e.what());
+    g_active_queues.erase(qs->queue_id);
+    QueueProfilingRelease(q);
+    // dispatch_log_active was never flipped to true, so no flag rollback
+    // needed. The next poller enable pass will retry this queue.
+    return;
+  }
 
   q->dispatch_log_active.store(true, std::memory_order_release);
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -1125,19 +1125,9 @@ void disable_dispatch_log_for_queue_locked(core::Queue* q) {
 
 bool predicate_now() {
 #if defined(HSA_ENABLE_LTTNG_UST) && HSA_ENABLE_LTTNG_UST
-  /* DIAGNOSTIC: log the three predicate inputs once on the first call
-   * so we can see why dispatch_log is or isn't enabling. */
-  static std::atomic<bool> diag_first{true};
-  bool first_call = diag_first.exchange(false);
   bool trace_dis = rocm_trace_disabled();
   bool kfd_ok   = g_kfd_supports_dispatch_log.load(std::memory_order_relaxed);
   int  tp_en    = lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_record);
-  if (first_call) {
-    std::fprintf(stderr,
-                 "[hsa-runtime] dispatch_log DIAG predicate_now first-call: "
-                 "trace_disabled=%d kfd_supports=%d tracepoint_enabled=%d\n",
-                 (int)trace_dis, (int)kfd_ok, tp_en);
-  }
 
   if (trace_dis) return false;
   if (!kfd_ok) {
@@ -1163,26 +1153,9 @@ bool predicate_now() {
 void ts_poller_loop() {
   const auto tick_interval = std::chrono::milliseconds(5);
 
-  /* DIAGNOSTIC: confirm the poller actually starts, and log every
-   * predicate-result transition so we can see when (or if) it ever
-   * flips true. Steady-state silent. */
-  std::fprintf(stderr,
-               "[hsa-runtime] dispatch_log DIAG ts_poller_loop entered\n");
-  bool last_curr = false;
-  bool first_iter = true;
-
   while (!g_shutdown.load(std::memory_order_relaxed)) {
     const bool curr = predicate_now();
     g_dispatch_logging_active.store(curr, std::memory_order_relaxed);
-
-    if (first_iter || curr != last_curr) {
-      std::fprintf(stderr,
-                   "[hsa-runtime] dispatch_log DIAG ts_poller_loop predicate=%d "
-                   "(was %d)\n",
-                   (int)curr, (int)last_curr);
-      last_curr = curr;
-      first_iter = false;
-    }
 
     if (curr) {
       // ENABLE pass (spec §4): for each known live queue Q with

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -452,6 +452,20 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
   //   3. Opens the door to hsa_signal_wait on signal_addr instead of
   //      polling, deferred to a future optimization.
   //
+  // Multi-XCC hazard for init-sync (C7): because XCCs publish without
+  // atomics, observing signal=N does NOT prove that every slot in
+  // [0, N) has been written — XCC A can publish its higher slot's
+  // signal value before XCC B has finished publishing its lower slot's
+  // record body. The FW interface spec
+  // (specs/2026-05-01-mec-firmware-dispatch-log-interface.md §3.5)
+  // assumes a single producer per queue and says nothing about XCC
+  // interleaving; on multi-XCC systems this assumption is empirically
+  // violated. To avoid permanently dropping a slot that just hasn't
+  // been written yet, init-sync stops at the first zero record_type
+  // (see the loop body below) and leaves qs.next_idx pointing AT
+  // that slot, so the next drain pass re-evaluates it once FW has
+  // had a chance to commit.
+  //
   // Backward-publish protection (still needed because signal races too):
   // qs.next_idx is our host-side monotonic floor. If FW publishes a
   // value < next_idx, treat it as stale and skip the pass; we wait for
@@ -505,20 +519,28 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     //     buffer, the meaningful window is the suffix of FW-written
     //     slots ending at end-1; older slots are pre-zeroed and stale.
     //   - During init-sync only, validate each slot's record_type
-    //     during emit and SKIP slots whose record_type is 0. This
-    //     correctly emits all FW-written records in the window without
-    //     ever emitting a stale pre-zeroed slot.
+    //     during emit. The first zero record_type STOPS the scan
+    //     and leaves qs.next_idx pointing at that slot so the next
+    //     drain pass will re-evaluate it. This is conservative under
+    //     the multi-XCC hazard: a zero slot in our window may be
+    //     either (a) a pre-zeroed stale slot, or (b) a slot whose
+    //     XCC hasn't published the record body yet even though a
+    //     higher-index slot's signal was already observed. We can't
+    //     distinguish (a) from (b) cheaply, so we wait. The cost is
+    //     one extra drain pass to consume the records; the benefit
+    //     is no permanently-dropped records.
     //   - Do NOT emit kernel_dispatch_drop during init-sync — the
     //     pre-zeroed gap represents records that never existed for
     //     this queue lifecycle, not records the host fell behind on.
     //
-    // The validate-on-emit strategy is safe under FW write ordering:
-    // signal is the LAST per-record write FW issues, so by the time
-    // we observe signal=N, every slot in [0, N) that WILL be written
-    // by FW has already been written. Slots with rt==0 in [start, end)
-    // are slots FW will never write for this lifecycle (they predate
-    // the queue or were pre-zeroed by SetProfiling).
+    // Single-producer caveat: if a future FW spec rev guarantees a
+    // single globally-ordered producer (or adds an atomic publish
+    // barrier across XCCs), this pessimistic stop-at-zero can be
+    // relaxed back to "skip and continue". Until then, stopping is
+    // the only way to avoid the drop documented in C7.
     const bool initial_sync = (qs.next_idx == 0);
+    bool init_sync_stopped_at_zero = false;
+    uint64_t init_sync_resume_idx = 0;
 
     // Overrun detection. If FW lapped us, log a drop event and skip
     // the unrecoverable region. The records we DO read after the skip
@@ -558,15 +580,40 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
       auto* rec = reinterpret_cast<mec_dispatch_record_16*>(
           static_cast<char*>(qs.ring_base) + slot * kSlotStride);
 
-      // Init-sync validation: skip pre-zeroed slots. FW writes
-      // record_type ∈ {1, 2}; slots with rt==0 in our scan window are
-      // slots FW has not written for this queue's lifecycle (the host
-      // pre-zero from AqlQueue::SetProfiling is still intact). Acquire
-      // ordering so the body loads (via memcpy below) cannot be
-      // reordered above this check on the rare slot that IS non-zero.
+      // Init-sync validation (C7): STOP at the first zero record_type
+      // during init-sync. FW writes record_type ∈ {1, 2}; a slot with
+      // rt==0 in our scan window [next_idx, observed) during init-sync
+      // is either:
+      //   (a) a pre-zeroed stale slot (slot was never written for
+      //       this queue lifecycle), OR
+      //   (b) a slot whose XCC has not finished publishing yet
+      //       (XCC A's signal=N publish raced ahead of XCC B's
+      //       slot[<N] body publish; spec §3.5 assumes single-
+      //       producer ordering that does NOT hold across XCCs
+      //       without an inter-XCC publish barrier).
+      // We can't distinguish (a) from (b) cheaply, so we stop and
+      // let the next pass re-evaluate. Leaving qs.next_idx at the
+      // zero slot's index means we re-scan from there next time;
+      // by then either FW has published (case b → emit it) or it
+      // stays zero (case a → we keep stopping until either signal
+      // grows past it via the overrun-skip path or the queue is
+      // destroyed). Cost: one extra drain pass to consume the
+      // window after FW commits. Benefit: no permanently-dropped
+      // records in case (b), no emit-all-zero record in either case.
+      //
+      // Out of scope: steady-state (non-init-sync) passes still
+      // memcpy zero slots and emit them as records — the same
+      // multi-XCC hazard exists there but the historical behavior
+      // is preserved here to limit the C7 change to its claim.
+      // Acquire ordering so the body loads (via memcpy below)
+      // cannot be reordered above this check.
       if (initial_sync) {
         uint32_t rt = __atomic_load_n(&rec->record_type, __ATOMIC_ACQUIRE);
-        if (rt == 0) continue;
+        if (rt == 0) {
+          init_sync_stopped_at_zero = true;
+          init_sync_resume_idx = i;
+          break;
+        }
       }
 
       // FW publish-ordering contract (per f32_mec.uc Q6): record body
@@ -589,6 +636,20 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     }
     flush_batch();
 
+    // C7: if init-sync hit a zero hole, leave qs.next_idx pointing AT
+    // that slot so the next drain pass re-evaluates it. We must NOT
+    // advance past the hole — under the multi-XCC hazard the slot may
+    // simply not have been published yet by its producing XCC, and
+    // skipping it would permanently drop the record. Note this also
+    // means we do NOT publish `end` to qs.rptr_ptr in this case, since
+    // we have not actually consumed [resume_idx, end).
+    if (init_sync_stopped_at_zero) {
+      qs.next_idx = init_sync_resume_idx;
+      if (qs.rptr_ptr) {
+        __atomic_store_n(qs.rptr_ptr, init_sync_resume_idx, __ATOMIC_RELEASE);
+      }
+      return any;
+    }
     qs.next_idx = end;
     // Publish our consumer position back to FW (informational; FW does
     // not enforce backpressure today but reads on connect/dequeue).

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -368,19 +368,26 @@ void for_each_known_queue_locked(F&& fn) {
 //      future wraparound re-write of the same slot can be re-detected),
 //      and process the START / END pairing as before.
 //
-// The 40-byte slot stride is enforced by the host kernel BO size check
-// (kfd_process_queue_manager.c:633 `buf_byte_size = count * 40` on
-// gbt350). FW only writes the first 16 bytes of each slot; the trailing
-// 24 bytes are FW-owned and reserved for future per-slot metadata. We
-// zero ALL 40 bytes when consuming a slot because FW's wraparound write
-// may rewrite the entire slot, including the trailing reserved region.
+// FW writes 16-byte mec_dispatch_record entries at 16-byte stride. The
+// host kernel BO size validation on the gbt350-installed KFD patch is
+// `count * 40` (kfd_process_queue_manager.c:633), which over-counts the
+// per-record stride — see upstream fix `kfd: validate dispatch record
+// buffer using 16-byte record size` (commit `03a8b58c3b96`,
+// 2026-04-08), which corrects the kernel side to `count * 16` to
+// match the firmware/SDK contract. We allocate `count * 40` so the
+// older host kernel's BO validation passes (forward-compatible with
+// the fix — bigger is fine), but FW writes records back-to-back at
+// 16-byte stride within that buffer. The drainer therefore reads at
+// 16-byte stride. The unused tail of the buffer (slots beyond
+// `count * 16` bytes) is never written by FW and never read by the
+// drainer.
 // ============================================================================
 
-// Host kernel-enforced per-slot stride for the dispatch-record BO. See
-// citation above. Hardcoded; ABI extensions that grow the slot will
-// require a coordinated update of this constant + AqlQueue::SetProfiling
-// alloc size.
-constexpr size_t kSlotStride = 40;
+// Per-record stride at which FW writes records into the buffer. Matches
+// `sizeof(mec_dispatch_record)` and is independent of the host kernel's
+// BO-size validation constant (which is `count * 40` today on gbt350,
+// `count * 16` after the upstream fix lands).
+constexpr size_t kSlotStride = 16;
 
 bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
   std::lock_guard<std::mutex> lk(qs.drain_mu);
@@ -412,11 +419,11 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     const uint32_t dispatch_idx = rec->dispatch_idx;
     const uint64_t gpu_ts       = (static_cast<uint64_t>(ts_hi) << 32) | ts_lo;
 
-    // Zero the consumed slot so a wraparound rewrite by FW (next time the
-    // ring loops past this position) is re-detected as a fresh non-zero
-    // record_type. Zero the full kSlotStride — FW writes the whole slot,
-    // and the trailing 24 bytes per slot are reserved for future
-    // per-slot metadata that we do not interpret today.
+    // Zero the consumed slot so a wraparound rewrite by FW (next time
+    // the ring loops past this position) is re-detected as a fresh
+    // non-zero record_type. FW writes 16-byte records at 16-byte
+    // stride, so zeroing kSlotStride bytes resets the entire next-write
+    // target.
     std::memset(rec, 0, kSlotStride);
 
     if (rt == DISPATCH_LOG_RECORD_START) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -634,6 +634,19 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
 //     stores it (within the bounded sleep cadence). join() then waits
 //     for the worker's final-drain pass to complete.
 void per_queue_drain_loop(std::shared_ptr<queue_drain_state> qs) {
+  // TEST HOOK: HSA_DISPATCH_LOG_NO_DRAIN=1 makes the drainer worker idle
+  // (sleep-loop until stop) instead of reading FW records. Lets a test
+  // harness inspect raw FW output via hsa_amd_dispatch_log_test_get_state
+  // without the drainer competing or emitting LTTng events. Used by the
+  // dlog_test* programs to isolate FW behavior from drainer behavior.
+  static const bool s_no_drain = (std::getenv("HSA_DISPATCH_LOG_NO_DRAIN") != nullptr);
+  if (s_no_drain) {
+    while (!qs->should_stop.load(std::memory_order_acquire)) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    return;
+  }
+
   while (!qs->should_stop.load(std::memory_order_acquire)) {
     const bool any = drain_one_queue(*qs, /* force_emit = */ false);
     if (any) {
@@ -886,7 +899,6 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
     qs->ring_base        = buf;
     qs->ring_records     = record_count;
     qs->ring_mask        = record_count - 1;
-    qs->next_idx         = 0;
 
     // Capture the Phase-2 host-VA pointer set if the new
     // KFD_IOC_PROFILER_DISPATCH_LOG path is active for this queue.
@@ -906,6 +918,34 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
     }
     // else: legacy sentinel-scan mode; null pointers tell drain_one_queue
     // to use the fallback scan path.
+
+    // Initialize next_idx from the CURRENT FW signal value at enable time,
+    // not from 0. The MEC firmware maintains its per-pipe scratch wptr
+    // counter (LdMecAqlProfBufWptr in f32_mec.uc, line 29579) across queue
+    // lifecycles — when KFD destroys a queue and creates a new one on the
+    // same pipe, the new queue's FW state inherits the previous queue's
+    // wptr. Verified empirically with the standalone hsa_dlog_test_mq
+    // multi-queue test: queue Q0's signal value started at 2,069,683 (with
+    // expected 200) reflecting cumulative FW writes from prior queue
+    // instances on the same pipe. Each successive test run grew Q0's
+    // signal by exactly 2*N, confirming the pipe scratch persistence.
+    //
+    // If we left next_idx=0, the drain pass would observe a huge initial
+    // signal value, treat it as overrun (signal - 0 > ring_records), emit
+    // a fake drop event for ~2M phantom records, and start draining from
+    // [signal - ring_records, signal) — most of those slots are pre-zero
+    // ring storage, not actual records. By initializing next_idx to the
+    // current signal we treat the FW's reported state as our starting
+    // point and only emit records FW writes from this point forward.
+    //
+    // Falls back to 0 if signal_ptr is null (legacy sentinel-scan mode);
+    // sentinel-scan handles wraparound via per-slot record_type=0 reset
+    // and doesn't depend on absolute counter values.
+    if (qs->signal_ptr != nullptr) {
+      qs->next_idx = __atomic_load_n(qs->signal_ptr, __ATOMIC_ACQUIRE);
+    } else {
+      qs->next_idx = 0;
+    }
 
     g_active_drainers[qs->queue_id] = qs;
 
@@ -1199,6 +1239,87 @@ void on_queue_destroy(core::Queue* q) {
     g_profiling_refcounts.erase(q);
   }
 }
+
+}  // namespace dispatch_log
+}  // namespace rocr
+
+// =============================================================================
+// TEST-ONLY introspection API for standalone dispatch_log validation programs
+// (dlog_test1, dlog_test2, ...). NOT part of the public HSA ABI; symbol prefix
+// hsa_amd_dispatch_log_test_ to make grep-ability obvious.
+//
+// Usage from a test:
+//   1. set HSA_DISPATCH_LOG_NO_DRAIN=1 in the env so the per-queue worker
+//      sleeps instead of draining (preserves raw FW buffer state for the
+//      test to inspect).
+//   2. register a queue-create callback via
+//      hsa_amd_runtime_queue_create_register
+//   3. in the callback, call hsa_amd_dispatch_log_test_enable(queue) which
+//      invokes AqlQueue::SetProfiling(true), allocating the dispatch record
+//      buffer + host-VA wptr/rptr/signal words and calling SetDispatchLog.
+//   4. submit kernels normally, sync, sleep briefly to let FW finish writes.
+//   5. call hsa_amd_dispatch_log_test_get_state(queue, ...) to retrieve
+//      buffer base + record count + signal pointer for direct verification.
+// =============================================================================
+
+extern "C" {
+
+// Force-enable dispatch_log on the given queue. Calls AqlQueue::SetProfiling
+// (true) which allocates the dispatch record buffer and registers the host-VA
+// pointer set via the new KFD_IOC_PROFILER_DISPATCH_LOG sub-op.
+__attribute__((visibility("default")))
+hsa_status_t hsa_amd_dispatch_log_test_enable(hsa_queue_t* queue) {
+  if (queue == nullptr) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  rocr::core::Queue* q = rocr::core::Queue::Convert(queue);
+  if (q == nullptr) return HSA_STATUS_ERROR_INVALID_QUEUE;
+  if (!rocr::AMD::AqlQueue::IsType(q)) return HSA_STATUS_ERROR_INVALID_QUEUE;
+  auto* aq = static_cast<rocr::AMD::AqlQueue*>(q);
+  return aq->SetProfiling(true);
+}
+
+// Return the dispatch_log buffer base + record count + host-VA wptr / signal
+// pointers for the given queue. Only valid AFTER hsa_amd_dispatch_log_test_enable
+// (or any other path that has called SetProfiling(true) with the new path
+// active).
+__attribute__((visibility("default")))
+hsa_status_t hsa_amd_dispatch_log_test_get_state(
+    hsa_queue_t* queue,
+    void** buffer_base,
+    uint32_t* num_records,
+    const volatile uint64_t** wptr_ptr,
+    const volatile uint64_t** signal_ptr) {
+  if (queue == nullptr || buffer_base == nullptr || num_records == nullptr ||
+      wptr_ptr == nullptr || signal_ptr == nullptr)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  rocr::core::Queue* q = rocr::core::Queue::Convert(queue);
+  if (q == nullptr) return HSA_STATUS_ERROR_INVALID_QUEUE;
+  if (!rocr::AMD::AqlQueue::IsType(q)) return HSA_STATUS_ERROR_INVALID_QUEUE;
+  auto* aq = static_cast<rocr::AMD::AqlQueue*>(q);
+
+  uint32_t buf_bytes = 0;
+  hsa_status_t s = aq->GetProfilingDispatchRecords(buffer_base, &buf_bytes);
+  if (s != HSA_STATUS_SUCCESS) return s;
+  // FW writes 16-byte records. GetProfilingDispatchRecords reports total bytes
+  // available for FW writes (records * 16); convert back to record count.
+  *num_records = buf_bytes / 16u;
+
+  volatile uint64_t* w = nullptr;
+  volatile uint64_t* r = nullptr;
+  volatile uint64_t* sig = nullptr;
+  s = aq->GetDispatchLogPointers(&w, &r, &sig);
+  if (s != HSA_STATUS_SUCCESS) return s;
+  *wptr_ptr   = w;
+  *signal_ptr = sig;
+  return HSA_STATUS_SUCCESS;
+}
+
+}  // extern "C"
+
+namespace rocr {
+namespace dispatch_log {
+
+// Trailing namespace re-open so clang-format doesn't complain about the file
+// not ending inside a namespace; the body is intentionally empty.
 
 }  // namespace dispatch_log
 }  // namespace rocr

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -402,21 +402,32 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
         static_cast<char*>(qs.ring_base) + slot * kSlotStride);
 
     // Sentinel: record_type == 0 means "empty / not yet written by FW".
-    uint32_t rt = rec->record_type;
-    if (rt == 0) break;
-    // Defend against torn writes: re-read with an acquire fence so we are
-    // sure the rest of the record (timestamps, dispatch_idx) are visible
-    // before we consume them. If the slot is zero on the second read, the
-    // first read raced with FW's pre-publication zero state and we should
-    // wait for the next pass.
-    std::atomic_thread_fence(std::memory_order_acquire);
-    rt = rec->record_type;
+    //
+    // FW publish atomicity contract (per core/inc/mec_dispatch_record.h):
+    // each 16-byte mec_dispatch_record is written by a single GFX
+    // BUFFER_STORE_DWORDX4 (4 DWords = single TC write transaction). So
+    // any non-zero record_type observation implies the entire 16-byte
+    // record (ts_lo, ts_hi, record_type, dispatch_idx) is coherent. A
+    // partial / torn observation of "non-zero record_type but stale body"
+    // is not possible under that FW contract.
+    //
+    // We still use an acquire on the record_type load so the subsequent
+    // body loads (and the slot memset) are not reordered above it; this
+    // turns the type-load into a proper atomic acquire instead of a
+    // plain (data-racy) load on memory another agent writes
+    // concurrently. The body fields are read with relaxed atomicity for
+    // the same reason — to avoid UB from plain loads on FW-written
+    // memory — but no further fence is needed because the acquire on
+    // record_type already happens-before them.
+    uint32_t rt = __atomic_load_n(&rec->record_type, __ATOMIC_ACQUIRE);
     if (rt == 0) break;
 
     // Snapshot the rest of the record locally before zeroing the slot.
-    const uint32_t ts_lo        = rec->ts_lo;
-    const uint32_t ts_hi        = rec->ts_hi;
-    const uint32_t dispatch_idx = rec->dispatch_idx;
+    // Relaxed atomic loads suffice (see comment above) — the acquire on
+    // record_type above already orders these.
+    const uint32_t ts_lo        = __atomic_load_n(&rec->ts_lo, __ATOMIC_RELAXED);
+    const uint32_t ts_hi        = __atomic_load_n(&rec->ts_hi, __ATOMIC_RELAXED);
+    const uint32_t dispatch_idx = __atomic_load_n(&rec->dispatch_idx, __ATOMIC_RELAXED);
     const uint64_t gpu_ts       = (static_cast<uint64_t>(ts_hi) << 32) | ts_lo;
 
     // Zero the consumed slot so a wraparound rewrite by FW (next time

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -579,22 +579,31 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
   // g_lifecycle_mu), so it's safe to call while holding g_lifecycle_mu.
   hsa_status_t s = QueueProfilingAcquire(q);
   if (s != HSA_STATUS_SUCCESS) {
-    // C3: now that QueueProfilingAcquire propagates the underlying
-    // SetProfiling status (allocation failure, libhsakmt
-    // SetQueueProfilingBuffer NOT_SUPPORTED, etc.), an error here means
-    // the agent's KFD/firmware substrate cannot accept a dispatch-record
-    // buffer for this queue. Mark the agent as no-dispatch-log so we
-    // don't retry every poll tick on every queue belonging to it (spec
-    // §5 unsupported-agent row, §9 unsupported-agent row). The refcount
-    // was not bumped (Acquire returns early on the 0->1 SetProfiling
-    // failure path), so no Release is needed.
+    // C5: distinguish substrate-absent from per-queue transient failures.
+    //
+    // Spec §5 (lines 604-609) only marks the agent as "no-dispatch-log"
+    // when the failure indicates the substrate itself does not support
+    // a dispatch-record buffer for queues on this agent — modeled as
+    // HSA_STATUS_ERROR_NOT_SUPPORTED in the AqlQueue status surface
+    // (KfdDriver returns NOT_SUPPORTED when the libhsakmt thunk symbol
+    // is absent). For other failures (allocation OOM, transient KFD
+    // errors), we just skip THIS queue/THIS tick and let later queues
+    // and later ticks retry. Marking the whole agent on a transient
+    // failure would permanently disable an otherwise-supported agent
+    // from a one-off resource pressure event. The refcount was not
+    // bumped (Acquire returns early on the 0->1 SetProfiling failure
+    // path), so no Release is needed.
+    const bool agent_unsupported = (s == HSA_STATUS_ERROR_NOT_SUPPORTED);
     std::fprintf(stderr,
                  "[hsa-runtime] dispatch_log: queue_id=%llu ENABLE step 1 "
-                 "(QueueProfilingAcquire) failed status=%d; marking agent "
-                 "as no-dispatch-log\n",
+                 "(QueueProfilingAcquire) failed status=%d%s\n",
                  static_cast<unsigned long long>(queue_id_of(q)),
-                 static_cast<int>(s));
-    g_no_dispatch_log_agents.insert(q->GetAgent());
+                 static_cast<int>(s),
+                 agent_unsupported ? "; marking agent as no-dispatch-log"
+                                   : "; per-queue skip (transient)");
+    if (agent_unsupported) {
+      g_no_dispatch_log_agents.insert(q->GetAgent());
+    }
     return;
   }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -60,39 +60,13 @@
 // dispatch_record_buffer_size trailing fields (KFD minor version 22+).
 // The HSA-side AqlQueue::SetProfiling owns the per-queue buffer
 // allocation, the libhsakmt hsaKmtSetQueueProfilingBuffer call, and the
-// Suspend/Resume that flushes the MQD via UPDATE_QUEUE. The dispatch_log
-// path here just calls QueueProfilingAcquire/Release (which forward to
-// SetProfiling) and then queries hsa_amd_profiling_get_dispatch_records
-// to fetch the buffer info.
-//
-// TWO-MODE DRAIN DESIGN: drain_one_queue runs in one of two modes per
-// queue, chosen at QueueProfilingAcquire time based on whether
-// AqlQueue::GetDispatchLogPointers (see core/runtime/amd_aql_queue.cpp)
-// returns a host-VA wptr/rptr/signal triple:
-//
-//   - PATH A (preferred, signal-bound): newer kernel/FW publish a
-//     host-readable FW write pointer (wptr) and a per-queue signal that
-//     the drainer waits on. The drainer reads wptr to bound the live
-//     region [next_idx, wptr) and consumes that range. See the
-//     signal-bound branch in drain_one_queue (and the registration in
-//     the per-queue enable block, where GetDispatchLogPointers is
-//     called and the wptr/rptr/signal pointers are captured).
-//
-//   - PATH B (legacy fallback, sentinel-scan): when GetDispatchLogPointers
-//     returns NOT_INITIALIZED (older kernel/FW or libhsakmt without
-//     host-VA pointer support), the substrate publishes neither a
-//     host-readable FW write pointer nor any other end-of-records marker.
-//     The drainer falls back to scanning the ring sequentially from a
-//     host-managed monotonic cursor (next_idx). A slot whose record_type
-//     is 0 is "empty" (FW writes record_type ∈ {1,2}, and the buffer is
-//     pre-zeroed at alloc in AqlQueue::SetProfiling). After consuming a
-//     slot the drainer clears the record_type sentinel so wraparound
-//     rewrites are re-detectable. See the "PATH B: SENTINEL-SCAN
-//     FALLBACK" branch in drain_one_queue.
-//
-// Both paths share the same 16-byte FW record stride, the same per-queue
-// next_idx cursor, the same batched LTTng emit path, and the same
-// drop-accounting; only the bound-of-live-region computation differs.
+// Suspend/Resume that flushes the MQD via UPDATE_QUEUE. Dispatch records
+// additionally require KFD_IOC_PROFILER_DISPATCH_LOG (host-VA wptr/rptr/
+// signal); AqlQueue::SetProfiling fails the enable if that registration
+// cannot complete. drain_one_queue is signal-bound: it reads the FW
+// monotonic record count from *signal_ptr and walks [next_idx, observed),
+// stopping at record_type==0 when the multi-XCC publish race or stale
+// init-prefix requires it (see drain_one_queue).
 
 #include "core/inc/dispatch_log.h"
 
@@ -186,35 +160,24 @@ struct queue_drain_state {
   uint32_t ring_mask    = 0;     // ring_records - 1, for slot indexing
 
   // Host-managed monotonic record cursor. Mutated only under drain_mu.
-  // Slot index is (next_idx & ring_mask).
-  //
-  // Two drain modes select on whether signal_ptr below is non-null:
-  //   - SIGNAL-bound scan (preferred, MINOR>=20): next_idx tracks the
-  //     absolute count of records the host has emitted. Each pass reads
-  //     *signal_ptr atomically and iterates [next_idx, signal). After
-  //     emitting all records, next_idx is set to signal and the same
-  //     value is published to *rptr_ptr for FW backpressure visibility
-  //     (FW does not currently read it but publishing keeps the door
-  //     open for future FW that does).
-  //   - Sentinel scan (fallback, older kernel/FW): next_idx still
-  //     advances per non-zero slot. record_type==0 marks empty; the
-  //     drainer clears the sentinel post-emit so wraparound rewrites
-  //     are re-detectable.
+  // Slot index is (next_idx & ring_mask). Signal-bound: each pass reads
+  // *signal_ptr and iterates [next_idx, signal). After emitting, next_idx
+  // is set to signal and published to *rptr_ptr for FW visibility.
   uint64_t next_idx = 0;
 
-  // Stale-zero quarantine state (Path A; debate stage code-quality C8/C9).
+  // Stale-zero quarantine state (signal-bound drain; debate stage code-quality C8/C9).
   //
-  // Path A stops at any record_type==0 slot inside [next_idx, observed)
+  // The drainer stops at any record_type==0 slot inside [next_idx, observed)
   // because we cannot cheaply distinguish (a) a pre-zeroed stale slot
   // (FW per-pipe scratch wptr persisted across queue lifecycles, leaving
   // the host buffer's prefix never written for THIS lifecycle) from
   // (b) a slot whose producing XCC has not finished publishing the
-  // record body yet (multi-XCC publish race documented in the Path A
+  // record body yet (multi-XCC publish race documented in the signal-bound
   // header comment). Stopping is safe for case (b) — next pass will
   // re-read once FW commits — but case (a) wedges forever (signal will
   // never advance past the prefix). The quarantine breaks the wedge:
   //
-  //   - On every Path A pass that stops at a zero slot, drain records
+  //   - On every drain pass that stops at a zero slot, drain records
   //     stall_first_seen (steady_clock::time_point) the FIRST time it
   //     stops at THIS (observed, next_idx) coordinate, and sets
   //     pending_zero_stall=true so the worker's signal-equal fast-skip
@@ -241,11 +204,9 @@ struct queue_drain_state {
   uint64_t                              stall_idx      = 0;
   std::atomic<bool>                     pending_zero_stall{false};
 
-  // Phase-2 host-VA pointer set. Populated by
-  // enable_dispatch_log_for_queue_locked from
-  // AqlQueue::GetDispatchLogPointers when the running kernel supports
-  // KFD_IOC_PROFILER_DISPATCH_LOG (MINOR>=20) and the new sub-op
-  // succeeded. All three are nullptr in fallback mode.
+  // Phase-2 host-VA pointer set. Populated by enable_dispatch_log_for_queue_locked
+  // from AqlQueue::GetDispatchLogPointers after SetProfiling(true) registered
+  // KFD_IOC_PROFILER_DISPATCH_LOG (required; enable fails otherwise).
   //
   // Memory model:
   //   - signal_ptr: FW writes per-record (post-increment record count)
@@ -254,7 +215,7 @@ struct queue_drain_state {
   //     TC-drain THEN signal write THEN TC-drain). Per single FW thread
   //     signal is the LAST write per record and carries the strongest
   //     "record committed" semantics. The drainer uses signal_ptr as
-  //     its source of truth (see drain_one_queue Path A for the
+  //     its source of truth (see drain_one_queue for the
   //     multi-XCC race rationale).
   //   - wptr_ptr: FW writes the same per-record value as signal_ptr,
   //     just earlier in the publish sequence. Kept registered so the
@@ -439,33 +400,10 @@ void for_each_known_queue_locked(F&& fn) {
 // ============================================================================
 // drain_one_queue. Holds qs.drain_mu for the entire pass.
 //
-// Sentinel-scan design: the substrate publishes no host-readable FW write
-// pointer (KFD `kfd_ioctl_update_queue_args` has only
-// dispatch_record_buffer_addr/size — see
-// /usr/src/amdgpu-*/include/uapi/linux/kfd_ioctl.h:99-108 on a host with
-// the gbt350 KFD). Instead, FW writes record_type ∈ {1, 2} into each slot
-// it produces; the host pre-zeroes the buffer at allocation
-// (AqlQueue::SetProfiling), so a slot whose record_type is 0 is "empty".
-//
-// We walk the ring sequentially from a host-managed monotonic cursor
-// (qs.next_idx). Each iteration:
-//   1. Read record_type for the slot at (next_idx & ring_mask).
-//   2. If 0, the ring tail has caught up — break and return.
-//   3. Otherwise snapshot the rest of the record, ZERO the slot (so a
-//      future wraparound re-write of the same slot can be re-detected),
-//      and process the START / END pairing as before.
-//
-// FW writes 16-byte mec_dispatch_record entries at 16-byte stride. The
-// host kernel BO size validation now uses `count * 16` for both the
-// legacy SetQueueProfilingBuffer path and the new dispatch_log sub-op
-// (kfd_process_queue_manager.c, post commit `03a8b58c3b96` "kfd:
-// validate dispatch record buffer using 16-byte record size",
-// 2026-04-08), matching the firmware/SDK 16-byte record stride. The
-// host therefore allocates `count * 16` exactly (see
-// amd_aql_queue.cpp:1690-1704); the earlier `count * 40`
-// over-allocation that worked around the older pre-fix kernel has
-// been removed. FW writes records back-to-back at 16-byte stride and
-// the drainer reads at the same 16-byte stride.
+// Signal-bound: FW publishes a monotonic post-increment record count to
+// *signal_ptr (after wptr). The host walks [next_idx, observed) at 16-byte
+// stride (see kSlotStride). FW writes 16-byte mec_dispatch_record entries;
+// the ring is sized record_count * 16 (AqlQueue::SetProfiling).
 // ============================================================================
 
 // Per-record stride at which FW writes records into the buffer. Matches
@@ -482,14 +420,14 @@ constexpr size_t kSlotStride = 16;
 constexpr uint32_t kBatchMax = 256;
 
 // Stale-zero quarantine threshold (debate stage code-quality C8/C10).
-// Path A stops at the first record_type==0 inside [next_idx, observed)
+// The signal-bound scan stops at the first record_type==0 inside [next_idx, observed)
 // to handle either a pre-zeroed stale slot OR a multi-XCC publish-race
 // in-flight slot. After this many milliseconds of being stalled at the
 // SAME (observed, next_idx) coordinate with no forward progress, the
 // drainer declares the slot stale and sweeps the contiguous stale-zero
 // prefix forward in one pass, emitting a single aggregate
 // kernel_dispatch_drop event covering the whole gap (see C10 logic in
-// drain_one_queue Path A below).
+// drain_one_queue below).
 //
 // 100 ms aligns with the wait_for_idle bound and is ~100x the worker's
 // max sleep cadence (1 ms), so a real in-flight XCC publish would
@@ -507,8 +445,7 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
   // Poisoned (disable in flight) or never-populated.
   if (qs.ring_base == nullptr || qs.ring_records == 0) return false;
 
-  // Shared batch buffer for both Path A (signal-bound) and Path B
-  // (sentinel-scan). Stack-allocated; per-pass scope.
+  // Stack-allocated batch buffer for LTTng emit.
   alignas(16) uint8_t batch_buf[kBatchMax * kSlotStride];
   uint32_t batch_count = 0;
   auto flush_batch = [&]() {
@@ -523,8 +460,10 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
   };
   ++qs.diag_drain_passes;
 
+  if (qs.signal_ptr == nullptr) return false;
+
   // ============================================================================
-  // PATH A: SIGNAL-BOUND SCAN (preferred, KFD MINOR>=20 + new FW)
+  // SIGNAL-BOUND SCAN (KFD_IOC_PROFILER_DISPATCH_LOG + new FW)
   //
   // FW publishes the post-increment record count to *qs.signal_ptr after
   // first publishing the same value to *qs.wptr_ptr (see f32_mec.uc
@@ -576,8 +515,7 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
   // qs.next_idx forward by the overrun distance and emit a
   // kernel_dispatch_drop tracepoint so the consumer sees the gap.
   // ============================================================================
-  if (qs.signal_ptr != nullptr) {
-    const uint64_t observed = __atomic_load_n(qs.signal_ptr, __ATOMIC_ACQUIRE);
+  const uint64_t observed = __atomic_load_n(qs.signal_ptr, __ATOMIC_ACQUIRE);
 
     // DIAG_LOSS: track peak observed signal per-queue
     {
@@ -621,7 +559,7 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     //      with no kernel_dispatch_drop event.
     //
     // Code-quality C8/C9: the C7-era fix gated zero-rt-stop on
-    // initial_sync only, leaving steady-state Path A still emitting
+    // initial_sync only, leaving steady-state still emitting
     // zero-body slots as records under the multi-XCC race (C9), and
     // also wedging init-sync forever on a stale-zero prefix because
     // forward progress required signal to lap the ring (C8). Unified
@@ -908,97 +846,6 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     // not enforce backpressure today but reads on connect/dequeue).
     if (qs.rptr_ptr) __atomic_store_n(qs.rptr_ptr, end, __ATOMIC_RELEASE);
     return any;
-  }
-
-  // ============================================================================
-  // PATH B: SENTINEL-SCAN FALLBACK (older kernel/FW without host-VA wptr)
-  //
-  // FW writes record_type ∈ {1, 2} into each slot it produces; host
-  // pre-zeroes the buffer at allocation, so a slot whose record_type
-  // is 0 is "empty". Drainer walks slots from qs.next_idx, atomic-stores
-  // record_type=0 after consume so wraparound rewrites are re-detectable.
-  //
-  // KNOWN ISSUE: FW slot reuse can cause the same (dispatch_idx,
-  // record_type) pair to be observed twice in a single session under
-  // burst patterns (capture rate observed at 250-316% vs expected 200%).
-  // The wptr-bound path above is immune to this; this fallback is only
-  // used on older kernels that don't ship the new MQD slots.
-  // ============================================================================
-  const uint64_t pass_budget = qs.ring_records;
-  uint64_t pass_consumed = 0;
-
-  bool any = false;
-  while (pass_consumed < pass_budget) {
-    // Cheap kill-switch pre-check (review C4): tested at the very top of
-    // the per-record body, BEFORE any slot mutation. translate_gpu_ts
-    // performs a linear interpolation under the agent's clock-cache
-    // lock, so doing it 1× per record × kRingSlots in the disable-race
-    // window is wasted work the emit helper would discard anyway. The
-    // helper's own kill-switch check still runs (defense in depth).
-    //
-    // Position rationale: this check MUST sit before the record_type
-    // load + slot mutation (below) so that bailing here leaves the slot
-    // intact and `qs.next_idx` still pointing at it. If we cleared the
-    // sentinel first and then bailed, the slot would be permanently
-    // destroyed (FW had already written it, and the wptr cursor stays
-    // put), and on the next drain pass the sentinel scan would observe
-    // rt == 0 at next_idx and stop — stranding any later FW-written
-    // records until the ring wraps and FW rewrites the broken slot.
-    // Today no runtime API toggles the kill switch (it is set-once at
-    // construction in lttng/rocm_trace_init.cpp), so the wedge is not
-    // currently reachable, but ordering this check before slot mutation
-    // removes the latent footgun for any future runtime-toggle path.
-    if (!force_emit && rocm_trace_disabled()) break;
-
-    const uint64_t slot = qs.next_idx & qs.ring_mask;
-    auto* rec = reinterpret_cast<mec_dispatch_record_16*>(
-        static_cast<char*>(qs.ring_base) + slot * kSlotStride);
-
-    // Sentinel: record_type == 0 means "empty / not yet written by FW".
-    //
-    // FW publish atomicity contract (per core/inc/mec_dispatch_record.h):
-    // each 16-byte mec_dispatch_record is written by a single GFX
-    // BUFFER_STORE_DWORDX4 (4 DWords = single TC write transaction). So
-    // any non-zero record_type observation implies the entire 16-byte
-    // record (ts_lo, ts_hi, record_type, dispatch_idx) is coherent. A
-    // partial / torn observation of "non-zero record_type but stale body"
-    // is not possible under that FW contract.
-    //
-    // We still use an acquire on the record_type load so the subsequent
-    // body loads are not reordered above it; this
-    // turns the type-load into a proper atomic acquire instead of a
-    // plain (data-racy) load on memory another agent writes
-    // concurrently. The body fields are read with relaxed atomicity for
-    // the same reason — to avoid UB from plain loads on FW-written
-    // memory — but no further fence is needed because the acquire on
-    // record_type already happens-before them.
-    uint32_t rt = __atomic_load_n(&rec->record_type, __ATOMIC_ACQUIRE);
-    if (rt == 0) break;
-
-    // Sentinel-scan path also batches: copy the FW record (16 bytes,
-    // exactly the mec_dispatch_record_16 layout the new tracepoint
-    // expects) into the batch buffer, then clear the sentinel.
-    std::memcpy(batch_buf + (size_t)batch_count * kSlotStride,
-                rec, kSlotStride);
-    batch_count++;
-
-    // Zero the record_type field so a wraparound rewrite by FW (next time
-    // the ring loops past this position) is re-detected as a fresh
-    // non-zero record_type. We only need to clear the sentinel field,
-    // not the entire 16-byte slot, since the FW always writes the full
-    // 16 bytes atomically.
-    __atomic_store_n(&rec->record_type, 0, __ATOMIC_RELEASE);
-
-    qs.next_idx += 1;
-    pass_consumed += 1;
-    any = true;
-
-    if (batch_count == kBatchMax) {
-      flush_batch();
-    }
-  }
-  flush_batch();
-  return any;
 }
 
 // Per-queue drain loop. One instance per active queue, spawned at enable
@@ -1051,52 +898,45 @@ void per_queue_drain_loop(std::shared_ptr<queue_drain_state> qs) {
   //   - 16-63 idle:          sleep 100 us
   //   - 64+ idle:            sleep 1 ms (steady-state idle)
   // First sign of work resets the counter to 0 and resumes hot-loop.
-  //
-  // Path B (sentinel-scan, no signal_ptr): falls back to the old yield-
-  // only loop because we have no cheap "no work" probe — we have to
-  // actually read the slot's record_type to know.
   uint64_t last_signal = 0;
   uint32_t idle_count = 0;
   while (!qs->should_stop.load(std::memory_order_acquire)) {
-    // Path A fast-path: if signal_ptr is registered, read it cheaply and
-    // skip the drain call entirely when no new records exist.
-    if (qs->signal_ptr != nullptr) {
-      const uint64_t cur = __atomic_load_n(qs->signal_ptr, __ATOMIC_ACQUIRE);
-      // Stale-zero quarantine override (debate stage code-quality C8):
-      // when drain_one_queue parked next_idx on a zero slot inside
-      // [next_idx, observed), pending_zero_stall is armed. Forward
-      // progress in that state requires us to keep CALLING drain (so
-      // the quarantine timer fires once kStaleZeroQuarantineMs has
-      // elapsed) even though *signal_ptr has not advanced. Honor the
-      // armed flag by bypassing the signal-equal fast-skip; we still
-      // adaptive-sleep below if drain returns no work.
-      const bool stalled =
-          qs->pending_zero_stall.load(std::memory_order_acquire);
-      if (cur == last_signal && !stalled) {
-        // No new records — adaptive backoff
-        ++idle_count;
-        if (idle_count <= 3) {
-          std::this_thread::yield();
-        } else if (idle_count <= 15) {
-          std::this_thread::sleep_for(std::chrono::microseconds(10));
-        } else if (idle_count <= 63) {
-          std::this_thread::sleep_for(std::chrono::microseconds(100));
-        } else {
-          std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        }
-        continue;
+    // Cheap probe: skip drain_one_queue when *signal_ptr is unchanged.
+    const uint64_t cur = __atomic_load_n(qs->signal_ptr, __ATOMIC_ACQUIRE);
+    // Stale-zero quarantine override (debate stage code-quality C8):
+    // when drain_one_queue parked next_idx on a zero slot inside
+    // [next_idx, observed), pending_zero_stall is armed. Forward
+    // progress in that state requires us to keep CALLING drain (so
+    // the quarantine timer fires once kStaleZeroQuarantineMs has
+    // elapsed) even though *signal_ptr has not advanced. Honor the
+    // armed flag by bypassing the signal-equal fast-skip; we still
+    // adaptive-sleep below if drain returns no work.
+    const bool stalled =
+        qs->pending_zero_stall.load(std::memory_order_acquire);
+    if (cur == last_signal && !stalled) {
+      // No new records — adaptive backoff
+      ++idle_count;
+      if (idle_count <= 3) {
+        std::this_thread::yield();
+      } else if (idle_count <= 15) {
+        std::this_thread::sleep_for(std::chrono::microseconds(10));
+      } else if (idle_count <= 63) {
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
+      } else {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
       }
-      if (cur != last_signal) {
-        last_signal = cur;
-        idle_count = 0;
-      }
+      continue;
+    }
+    if (cur != last_signal) {
+      last_signal = cur;
+      idle_count = 0;
     }
 
     const bool any = drain_one_queue(*qs, /* force_emit = */ false);
     if (any) {
       ++qs->diag_drain_passes_with_work;  // DIAG_LOSS
     } else {
-      // Path B (sentinel-scan) fallback or spurious wakeup: yield.
+      // No work this iteration: yield / short sleep.
       ++idle_count;
       if (idle_count > 3) {
         std::this_thread::sleep_for(std::chrono::microseconds(100));
@@ -1222,15 +1062,11 @@ namespace {
 // Flow:
 //   1. Skip non-AQL / non-GPU queues.
 //   2. Skip if substrate is absent or agent is on the no-dispatch-log list.
-//   3. QueueProfilingAcquire -> AqlQueue::SetProfiling(true) -> alloc
-//      buffer + KFD UPDATE_QUEUE with the new trailing fields.
-//   4. AqlQueue::GetProfilingDispatchRecords to read back the buffer base
-//      and the FW-record-stride capacity in bytes (record_count * 16).
-//      The substrate publishes no host-visible FW write pointer; consumers
-//      locate fresh records via sentinel scan over per-slot record_type.
-//   5. Register a non-owning queue_drain_state in g_active_drainers with
-//      next_idx = 0 (the host-managed monotonic record cursor used by
-//      the sentinel-scan drainer).
+//   3. QueueProfilingAcquire -> AqlQueue::SetProfiling(true) -> alloc buffer,
+//      SetQueueProfilingBuffer, SetDispatchLog (host-VA wptr/rptr/signal required).
+//   4. AqlQueue::GetProfilingDispatchRecords for ring base + byte capacity.
+//   5. AqlQueue::GetDispatchLogPointers for the signal-bound drain path.
+//   6. Register queue_drain_state in g_active_drainers; next_idx per C2/C3 below.
 // ============================================================================
 
 void enable_dispatch_log_for_queue_locked(core::Queue* q) {
@@ -1307,9 +1143,7 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
   // in its BO-size validation; both that older kernel and the current
   // kfd_process_queue_manager.c validation accept *16. FW writes — and
   // the drainer reads — at the 16-byte FW record stride (see kSlotStride
-  // above and the per-slot addressing expressions in drain_one_queue:
-  // `static_cast<char*>(qs.ring_base) + slot * kSlotStride` on both the
-  // signal-bound Path A and the sentinel-scan Path B).
+  // and per-slot addressing in drain_one_queue).
   const uint32_t record_count = buf_bytes / static_cast<uint32_t>(sizeof(mec_dispatch_record_16));
   if (record_count == 0 || (record_count & (record_count - 1)) != 0) {
     std::fprintf(stderr,
@@ -1369,30 +1203,33 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
     qs->ring_records     = record_count;
     qs->ring_mask        = record_count - 1;
 
-    // Capture the Phase-2 host-VA pointer set if the new
-    // KFD_IOC_PROFILER_DISPATCH_LOG path is active for this queue.
-    // GetDispatchLogPointers returns NOT_INITIALIZED on older
-    // kernels (MINOR<20) or older libhsakmt (no SetDispatchLog
-    // thunk) — in that case the pointers stay null and the drainer
-    // falls back to sentinel-scan automatically.
+    // Host-VA wptr/rptr/signal (KFD_IOC_PROFILER_DISPATCH_LOG). Required:
+    // SetProfiling(true) fails the enable if registration cannot complete.
     volatile uint64_t* wptr_p   = nullptr;
     volatile uint64_t* rptr_p   = nullptr;
     volatile uint64_t* signal_p = nullptr;
-    bool ph2_fresh_allocation   = true;  // default-fresh; only consulted when path A wins
+    bool ph2_fresh_allocation = true;
     hsa_status_t dl_status =
         aql_queue->GetDispatchLogPointers(&wptr_p, &rptr_p, &signal_p,
                                           &ph2_fresh_allocation);
-    if (dl_status == HSA_STATUS_SUCCESS) {
-      qs->wptr_ptr   = wptr_p;
-      qs->rptr_ptr   = rptr_p;
-      qs->signal_ptr = signal_p;
+    if (dl_status != HSA_STATUS_SUCCESS || wptr_p == nullptr ||
+        rptr_p == nullptr || signal_p == nullptr) {
+      std::fprintf(stderr,
+                   "[hsa-runtime] dispatch_log: queue_id=%llu ENABLE step 3 "
+                   "(GetDispatchLogPointers) failed status=%d\n",
+                   static_cast<unsigned long long>(queue_id_of(q)),
+                   static_cast<int>(dl_status));
+      g_no_dispatch_log_agents.insert(q->GetAgent());
+      QueueProfilingRelease(q);
+      return;
     }
-    // else: legacy sentinel-scan mode; null pointers tell drain_one_queue
-    // to use the fallback scan path.
+    qs->wptr_ptr   = wptr_p;
+    qs->rptr_ptr   = rptr_p;
+    qs->signal_ptr = signal_p;
 
     // next_idx initialization (code-quality C2 + C3 round 2).
     //
-    // The Path A drainer treats next_idx as the monotonic floor of
+    // The signal-bound drainer treats next_idx as the monotonic floor of
     // already-emitted records. The choice of starting value depends on
     // whether SetProfiling(true) just freshly allocated and zeroed the
     // host signal word, or whether it hit the "buffer already wired"
@@ -1404,7 +1241,7 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
     //      case). SetProfiling(true) just allocated and zeroed the host
     //      signal word, so observed=0 and next_idx must also be 0. The
     //      first FW post-enable record write will jump signal from 0 to
-    //      (scratch_wptr_persisted + 1) and the drain_one_queue Path A
+    //      (scratch_wptr_persisted + 1) and the drain_one_queue
     //      initial-sync logic (initial_sync == (next_idx == 0)) handles
     //      the persisted scratch wptr exactly as before.
     //
@@ -1427,16 +1264,7 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
     //      disabled window, which is the only safe behavior since those
     //      records belong to a lifecycle that already ended from the
     //      consumer's point of view.
-    //
-    // Path B (sentinel-scan fallback, signal_ptr==nullptr) does NOT
-    // get the same fix: the existing per-slot record_type sentinel walk
-    // correctly handles a freshly-zeroed buffer but does NOT distinguish
-    // stale records left by a previous lifecycle from new records on a
-    // re-enable after a failed disable. That hazard is not addressed
-    // here; it only matters on older kernels (KFD MINOR < 20 or older
-    // libhsakmt) which can fall back to Path B. Documented limitation;
-    // pursue separately if it bites in practice.
-    if (qs->signal_ptr != nullptr && !ph2_fresh_allocation) {
+    if (!ph2_fresh_allocation) {
       qs->next_idx = __atomic_load_n(qs->signal_ptr, __ATOMIC_ACQUIRE);
       // Publish the snapshot to *rptr_ptr too so FW's backpressure view
       // matches our monotonic floor. SetProfiling on a re-enable after

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -743,13 +743,23 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
         // Quarantine update: same coordinate as last stall? If yes,
         // check timeout; if no, snapshot now and arm.
         const auto now = std::chrono::steady_clock::now();
-        if (qs.pending_zero_stall.load(std::memory_order_acquire) &&
+        // force_emit (disable-edge final drain) treats every zero as
+        // immediately stale: we will never get another pass to wait
+        // out the quarantine timer, so any parked OR first-time-seen
+        // zero must be accounted for in this final pass. Without this,
+        // the disable can leak a [start, parked_zero) window into the
+        // diag accounting gap (sig_span > emitted+swept+overrun),
+        // verified by test_hsa_dispatch_log_accounting.sh.
+        const bool armed_here =
+            qs.pending_zero_stall.load(std::memory_order_acquire) &&
             qs.stall_observed == observed &&
-            qs.stall_idx      == i) {
-          const auto stalled_for_ms =
-              std::chrono::duration_cast<std::chrono::milliseconds>(
-                  now - qs.stall_first_seen).count();
-          if (stalled_for_ms >= kStaleZeroQuarantineMs) {
+            qs.stall_idx      == i;
+        const auto stalled_for_ms = armed_here
+            ? std::chrono::duration_cast<std::chrono::milliseconds>(
+                  now - qs.stall_first_seen).count()
+            : 0;
+        if (armed_here || force_emit) {
+          if (stalled_for_ms >= kStaleZeroQuarantineMs || force_emit) {
             // Slot declared stale (case a). Sweep forward across the
             // contiguous stale-zero prefix in this same pass, emit ONE
             // aggregate kernel_dispatch_drop event covering all swept
@@ -809,7 +819,20 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
               // Do not advance i; the for-loop's ++i would skip the
               // freshly-published slot. Step back one so ++i lands on
               // i again.
-              --i;
+              //
+              // Exception: under force_emit (disable final drain), the
+              // retry-then-rt-zero loop would spin forever if FW does
+              // not actually publish (which is the common case at
+              // disable — no more dispatches are coming). In that
+              // case, advance past the slot, accounting for the 1
+              // skipped slot in drop_overrun (no consumer-visible
+              // drop event since stale_count=0 is invalid bytes_lost).
+              if (force_emit) {
+                qs.diag_drop_overrun_records += 1;
+                // Don't --i; let ++i advance past slot i.
+              } else {
+                --i;
+              }
             } else {
               // force_emit propagated for the same reason as the overrun
               // path above: the stale-zero-prefix sweep can fire from

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -1235,9 +1235,10 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
   // workaround for an older pre-fix kernel that over-counted the stride
   // in its BO-size validation; both that older kernel and the current
   // kfd_process_queue_manager.c validation accept *16. FW writes — and
-  // the drainer reads — at the 16-byte FW record stride (kSlotStride).
-  // See dispatch_log.cpp:390 and the slot addressing at
-  // dispatch_log.cpp:400-402.
+  // the drainer reads — at the 16-byte FW record stride (see kSlotStride
+  // above and the per-slot addressing expressions in drain_one_queue:
+  // `static_cast<char*>(qs.ring_base) + slot * kSlotStride` on both the
+  // signal-bound Path A and the sentinel-scan Path B).
   const uint32_t record_count = buf_bytes / static_cast<uint32_t>(sizeof(mec_dispatch_record_16));
   if (record_count == 0 || (record_count & (record_count - 1)) != 0) {
     std::fprintf(stderr,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -65,14 +65,34 @@
 // SetProfiling) and then queries hsa_amd_profiling_get_dispatch_records
 // to fetch the buffer info.
 //
-// SENTINEL-SCAN DESIGN: The substrate publishes neither a host-readable FW
-// write pointer nor any other end-of-records marker. The drainer locates
-// fresh records by scanning the ring sequentially from a host-managed
-// monotonic cursor (next_idx). A slot whose record_type is 0 is "empty"
-// (FW writes record_type ∈ {1,2}, and the buffer is pre-zeroed at alloc
-// in AqlQueue::SetProfiling). After consuming a slot the drainer clears
-// the record_type sentinel so wraparound rewrites are re-detectable. See drain_one_queue
-// below for the canonical implementation.
+// TWO-MODE DRAIN DESIGN: drain_one_queue runs in one of two modes per
+// queue, chosen at QueueProfilingAcquire time based on whether
+// AqlQueue::GetDispatchLogPointers (see core/runtime/amd_aql_queue.cpp)
+// returns a host-VA wptr/rptr/signal triple:
+//
+//   - PATH A (preferred, signal-bound): newer kernel/FW publish a
+//     host-readable FW write pointer (wptr) and a per-queue signal that
+//     the drainer waits on. The drainer reads wptr to bound the live
+//     region [next_idx, wptr) and consumes that range. See the
+//     signal-bound branch in drain_one_queue (and the registration in
+//     the per-queue enable block, where GetDispatchLogPointers is
+//     called and the wptr/rptr/signal pointers are captured).
+//
+//   - PATH B (legacy fallback, sentinel-scan): when GetDispatchLogPointers
+//     returns NOT_INITIALIZED (older kernel/FW or libhsakmt without
+//     host-VA pointer support), the substrate publishes neither a
+//     host-readable FW write pointer nor any other end-of-records marker.
+//     The drainer falls back to scanning the ring sequentially from a
+//     host-managed monotonic cursor (next_idx). A slot whose record_type
+//     is 0 is "empty" (FW writes record_type ∈ {1,2}, and the buffer is
+//     pre-zeroed at alloc in AqlQueue::SetProfiling). After consuming a
+//     slot the drainer clears the record_type sentinel so wraparound
+//     rewrites are re-detectable. See the "PATH B: SENTINEL-SCAN
+//     FALLBACK" branch in drain_one_queue.
+//
+// Both paths share the same 16-byte FW record stride, the same per-queue
+// next_idx cursor, the same batched LTTng emit path, and the same
+// drop-accounting; only the bound-of-live-region computation differs.
 
 #include "core/inc/dispatch_log.h"
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -120,6 +120,7 @@
 
 #include "core/inc/agent.h"
 #include "core/inc/amd_aql_queue.h"
+#include "core/inc/intercept_queue.h"
 #include "core/inc/amd_gpu_agent.h"
 #include "core/inc/queue.h"
 #include "lttng/rocm_trace_emit.h"
@@ -1652,23 +1653,51 @@ void on_queue_create(core::Queue* q) {
 void on_queue_destroy(core::Queue* q) {
   if (q == nullptr) return;
 
+  // Unwrap intercept queues. hsa_queue_destroy passes the user-facing
+  // Queue*, which for hsa_amd_queue_intercept_create is the upper
+  // InterceptQueue (a QueueWrapper). on_queue_create was called on the
+  // LOWER AqlQueue at GpuAgent::QueueCreate, so the lower queue is what's
+  // registered in g_all_queues, what holds the dispatch_log_active flag,
+  // and what owns the drainer worker. The InterceptQueue copies the
+  // lower's amd_queue_ via memcpy at construction (intercept_queue.h:71)
+  // so queue_id_of() returns the same id either way -- the
+  // g_all_queues.erase() below succeeds against the upper too -- but
+  // dispatch_log_active and the worker lifecycle live on the lower.
+  // Without this unwrap the dispatch_log_active check on the upper is
+  // always false, disable_dispatch_log_for_queue_locked is never called,
+  // the worker is never joined, no final drain happens, and FW continues
+  // writing into the buffer after ~AqlQueue (chained from
+  // ~InterceptQueue -> ~QueueWrapper -> unique_ptr<Queue>) frees it.
+  // Manifests as 30-35% record loss on hipGraph workloads where intercept
+  // queues are torn down each phase.
+  core::Queue* effective = q;
+  while (auto* wrapper = (core::InterceptQueue::IsType(effective)
+                              ? static_cast<core::QueueWrapper*>(effective)
+                              : nullptr)) {
+    if (!wrapper->wrapped) break;
+    effective = wrapper->wrapped.get();
+  }
+
   // Remove from g_all_queues BEFORE the disable sequence so the poller
   // can never observe a Queue* whose underlying core::Queue is being torn
   // down. Held across the disable so the poller's iterating thread is
   // forced to wait behind the mutex if it currently holds it.
   {
     std::lock_guard<std::mutex> lk(g_queue_registry_mu);
-    g_all_queues.erase(queue_id_of(q));
-    if (q->dispatch_log_active.load(std::memory_order_acquire)) {
-      disable_dispatch_log_for_queue_locked(q);
+    g_all_queues.erase(queue_id_of(effective));
+    if (effective->dispatch_log_active.load(std::memory_order_acquire)) {
+      disable_dispatch_log_for_queue_locked(effective);
     }
   }
 
-  // Drop the per-queue refcount entry. Safe to do unconditionally — if the
-  // queue never had an acquire, the lookup is just a miss.
+  // Drop the per-queue refcount entry on BOTH the wrapper handle (in
+  // case anyone keyed by it) and the effective lower queue. Safe to do
+  // unconditionally -- if the queue never had an acquire, the lookup is
+  // just a miss.
   {
     std::lock_guard<std::mutex> lk(g_profiling_refcounts_mu);
-    g_profiling_refcounts.erase(q);
+    g_profiling_refcounts.erase(effective);
+    if (effective != q) g_profiling_refcounts.erase(q);
   }
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp
@@ -280,6 +280,18 @@ struct queue_drain_state {
   std::atomic<bool> should_stop{false};
   std::thread       worker;
 
+  // Diagnostic counters (DIAG_LOSS investigation, hip_graph_test 4/400/200
+  // showed ~13% record loss on heavy queues with 0 visible drops). These
+  // are HSA_DISPATCH_LOG_DIAG_LOSS=1 gated and dumped to stderr at disable.
+  // Mutated under drain_mu (records_*, sweep) or atomically (max_observed).
+  uint64_t              diag_records_emitted = 0;   // sum of count across emit calls
+  uint64_t              diag_zero_slots_swept = 0;  // bytes_lost via quarantine sweep
+  uint64_t              diag_drop_overrun_records = 0; // bytes_lost via overrun-skip
+  uint64_t              diag_drain_passes = 0;      // # of drain_one_queue calls
+  uint64_t              diag_drain_passes_with_work = 0; // calls that emitted >=1
+  std::atomic<uint64_t> diag_max_observed_signal{0}; // peak signal_ptr value seen
+  std::atomic<uint64_t> diag_initial_signal{0};      // signal at enable (next_idx baseline)
+
   // Defensive safety net for early-construction failures (review C2,
   // stage-2 code-quality). Supported lifetime model is explicit
   // disable / shutdown stops + joins worker BEFORE dropping the
@@ -506,8 +518,10 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
         qs.gpu_id,
         batch_count, batch_buf,
         (size_t)batch_count * kSlotStride, force_emit);
+    qs.diag_records_emitted += batch_count;  // DIAG_LOSS instrumentation
     batch_count = 0;
   };
+  ++qs.diag_drain_passes;
 
   // ============================================================================
   // PATH A: SIGNAL-BOUND SCAN (preferred, KFD MINOR>=20 + new FW)
@@ -564,6 +578,15 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
   // ============================================================================
   if (qs.signal_ptr != nullptr) {
     const uint64_t observed = __atomic_load_n(qs.signal_ptr, __ATOMIC_ACQUIRE);
+
+    // DIAG_LOSS: track peak observed signal per-queue
+    {
+      uint64_t cur_peak = qs.diag_max_observed_signal.load(std::memory_order_relaxed);
+      while (observed > cur_peak &&
+             !qs.diag_max_observed_signal.compare_exchange_weak(
+                 cur_peak, observed,
+                 std::memory_order_relaxed, std::memory_order_relaxed)) {}
+    }
 
     // Backward (or stale) FW publish: ignore this pass entirely.
     // qs.next_idx is our monotonic floor.
@@ -642,8 +665,9 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
     uint64_t start = qs.next_idx;
     uint64_t end   = observed;
     if ((end - start) > qs.ring_records) {
+      const uint64_t lost = (end - start) - qs.ring_records;
+      qs.diag_drop_overrun_records += lost;  // DIAG_LOSS (count even on init-sync silent skip)
       if (!initial_sync) {
-        const uint64_t lost = (end - start) - qs.ring_records;
         // force_emit propagated so the disable-edge final drain
         // (drain_one_queue invoked with force_emit=true) emits the drop
         // event even after the user has disabled the tracepoint.
@@ -794,6 +818,7 @@ bool drain_one_queue(queue_drain_state& qs, bool force_emit) {
               // already disabled the tracepoint.
               rocm_trace_emit_hsa_kernel_dispatch_drop(
                   queue_id_to_wire(qs.queue_id), stale_count, force_emit);
+              qs.diag_zero_slots_swept += stale_count;  // DIAG_LOSS
               qs.next_idx = stale_end;
               if (qs.rptr_ptr) {
                 __atomic_store_n(qs.rptr_ptr, stale_end, __ATOMIC_RELEASE);
@@ -1045,7 +1070,9 @@ void per_queue_drain_loop(std::shared_ptr<queue_drain_state> qs) {
     }
 
     const bool any = drain_one_queue(*qs, /* force_emit = */ false);
-    if (!any) {
+    if (any) {
+      ++qs->diag_drain_passes_with_work;  // DIAG_LOSS
+    } else {
       // Path B (sentinel-scan) fallback or spurious wakeup: yield.
       ++idle_count;
       if (idle_count > 3) {
@@ -1400,6 +1427,7 @@ void enable_dispatch_log_for_queue_locked(core::Queue* q) {
     } else {
       qs->next_idx = 0;
     }
+    qs->diag_initial_signal.store(qs->next_idx, std::memory_order_relaxed);  // DIAG_LOSS
 
     g_active_drainers[qs->queue_id] = qs;
 
@@ -1477,6 +1505,30 @@ void disable_dispatch_log_for_queue_locked(core::Queue* q) {
   if (qs_ptr) {
     qs_ptr->should_stop.store(true, std::memory_order_release);
     if (qs_ptr->worker.joinable()) qs_ptr->worker.join();
+
+    // DIAG_LOSS: dump per-queue accounting after worker join (after final
+    // drain has run). HSA_DISPATCH_LOG_DIAG_LOSS=1 to enable.
+    if (const char* e = std::getenv("HSA_DISPATCH_LOG_DIAG_LOSS")) {
+      if (e[0] == '1') {
+        const uint64_t init_sig    = qs_ptr->diag_initial_signal.load(std::memory_order_relaxed);
+        const uint64_t max_obs     = qs_ptr->diag_max_observed_signal.load(std::memory_order_relaxed);
+        const uint64_t signal_span = max_obs > init_sig ? max_obs - init_sig : 0;
+        std::fprintf(stderr,
+            "[DIAG_LOSS] q=0x%lx gpu=%u sig_init=%lu sig_max=%lu sig_span=%lu "
+            "emitted=%lu zero_swept=%lu drop_overrun=%lu accounted=%lu "
+            "passes=%lu passes_with_work=%lu\n",
+            (unsigned long)qs_ptr->queue_id, qs_ptr->gpu_id,
+            (unsigned long)init_sig, (unsigned long)max_obs, (unsigned long)signal_span,
+            (unsigned long)qs_ptr->diag_records_emitted,
+            (unsigned long)qs_ptr->diag_zero_slots_swept,
+            (unsigned long)qs_ptr->diag_drop_overrun_records,
+            (unsigned long)(qs_ptr->diag_records_emitted +
+                            qs_ptr->diag_zero_slots_swept +
+                            qs_ptr->diag_drop_overrun_records),
+            (unsigned long)qs_ptr->diag_drain_passes,
+            (unsigned long)qs_ptr->diag_drain_passes_with_work);
+      }
+    }
   }
 
   // d. Poison the non-owning pointers under drain_mu (defense in depth;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
@@ -756,13 +756,11 @@ hsa_status_t hsa_queue_create(
   assert(cmd_queue != nullptr && "Queue not returned but status was success.\n");
   *queue = core::Queue::Convert(cmd_queue);
 
-  // LTTng dispatch-log scaffolding (spec 2026-04-27 §4 queue-create hook).
-  // Called immediately after the queue is visible to the caller. If the
-  // tracepoint is currently enabled, runs the per-queue ENABLE sequence
-  // synchronously on this thread (bounded latency: one alloc + one ioctl
-  // + MQD-flush). No-op when g_dispatch_logging_active is false (the steady
-  // state).
-  rocr::dispatch_log::on_queue_create(cmd_queue);
+  // dispatch_log on_queue_create is now invoked from agent_->QueueCreate
+  // (amd_gpu_agent.cpp) instead of here, so it covers ALL queue-creation
+  // paths uniformly: this public API, hsa_amd_queue_intercept_create's
+  // lower queue, CountedQueuePoolManager pool entries, etc. Removing the
+  // duplicate call here.
 
   return status;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
@@ -760,7 +760,7 @@ hsa_status_t hsa_queue_create(
   // Called immediately after the queue is visible to the caller. If the
   // tracepoint is currently enabled, runs the per-queue ENABLE sequence
   // synchronously on this thread (bounded latency: one alloc + one ioctl
-  // + MQD-flush). No-op when G_tracepoint_enabled is false (the steady
+  // + MQD-flush). No-op when g_dispatch_logging_active is false (the steady
   // state).
   rocr::dispatch_log::on_queue_create(cmd_queue);
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
@@ -49,6 +49,7 @@
 
 #include "core/inc/runtime.h"
 #include "core/inc/agent.h"
+#include "core/inc/dispatch_log.h"
 #include "core/inc/host_queue.h"
 #include "core/inc/isa.h"
 #include "core/inc/memory_region.h"
@@ -754,6 +755,15 @@ hsa_status_t hsa_queue_create(
 
   assert(cmd_queue != nullptr && "Queue not returned but status was success.\n");
   *queue = core::Queue::Convert(cmd_queue);
+
+  // LTTng dispatch-log scaffolding (spec 2026-04-27 §4 queue-create hook).
+  // Called immediately after the queue is visible to the caller. If the
+  // tracepoint is currently enabled, runs the per-queue ENABLE sequence
+  // synchronously on this thread (bounded latency: one alloc + one ioctl
+  // + MQD-flush). No-op when G_tracepoint_enabled is false (the steady
+  // state).
+  rocr::dispatch_log::on_queue_create(cmd_queue);
+
   return status;
 
   CATCH;
@@ -804,6 +814,15 @@ hsa_status_t hsa_queue_destroy(hsa_queue_t* queue) {
   IS_BAD_PTR(queue);
   core::Queue* cmd_queue = core::Queue::Convert(queue);
   IS_VALID(cmd_queue);
+
+  // LTTng dispatch-log scaffolding (spec 2026-04-27 §4 queue-destroy hook).
+  // Run BEFORE Destroy() so the disable edge can still safely access the
+  // queue (final drain + KFD ioctl DISABLE + QueueProfilingRelease + buffer
+  // unregister). The drain-state ring buffer remains alive past Destroy()
+  // for as long as any concurrent drainer-snapshot ref outlives the
+  // registry removal — see spec §4 lifetime protocol.
+  rocr::dispatch_log::on_queue_destroy(cmd_queue);
+
   cmd_queue->Destroy();
   return HSA_STATUS_SUCCESS;
   CATCH;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_api_trace.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_api_trace.cpp
@@ -485,6 +485,8 @@ void HsaApiTable::UpdateAmdExts() {
   amd_ext_api.hsa_amd_memory_async_batch_copy_fn = AMD::hsa_amd_memory_async_batch_copy;
   amd_ext_api.hsa_amd_agent_preload_fn = AMD::hsa_amd_agent_preload;
   amd_ext_api.hsa_amd_signal_get_event_id_fn = AMD::hsa_amd_signal_get_event_id;
+  amd_ext_api.hsa_amd_queue_iterate_fn = AMD::hsa_amd_queue_iterate;
+  amd_ext_api.hsa_amd_profiling_get_dispatch_records_fn = AMD::hsa_amd_profiling_get_dispatch_records;
 }
 
 void HsaApiTable::UpdateTools() {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_api_trace.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_api_trace.cpp
@@ -87,7 +87,7 @@ void HsaApiTable::Init() {
   // they can add preprocessor macros on the new functions
 
   constexpr size_t expected_core_api_table_size = 1016;
-  constexpr size_t expected_amd_ext_table_size = 672;
+  constexpr size_t expected_amd_ext_table_size = 688;
   constexpr size_t expected_image_ext_table_size = 128;
   constexpr size_t expected_finalizer_ext_table_size = 64;
   constexpr size_t expected_tools_table_size = 64;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -46,12 +46,14 @@
 #include <memory>
 #include <new>
 #include <set>
+#include <shared_mutex>
 #include <typeinfo>
 #include <utility>
 #include <vector>
 
 #include "core/inc/agent.h"
 #include "core/inc/amd_aie_agent.h"
+#include "core/inc/amd_aql_queue.h"
 #include "core/inc/amd_cpu_agent.h"
 #include "core/inc/amd_gpu_agent.h"
 #include "core/inc/amd_memory_region.h"
@@ -638,6 +640,39 @@ hsa_status_t hsa_amd_profiling_set_profiler_enabled(hsa_queue_t* queue, int enab
   cmd_queue->SetProfiling(enable);
 
   return HSA_STATUS_SUCCESS;
+  CATCH;
+}
+
+hsa_status_t hsa_amd_queue_iterate(hsa_status_t (*callback)(hsa_queue_t* queue, void* data),
+                                   void* data) {
+  TRY;
+  IS_OPEN();
+  if (!callback) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  for (core::Agent* agent : core::Runtime::runtime_singleton_->gpu_agents()) {
+    auto* gpu = static_cast<AMD::GpuAgent*>(agent);
+    std::shared_lock<std::shared_mutex> lock(gpu->AqlQueuesMutex());
+    for (auto* q : gpu->GetAqlQueues()) {
+      hsa_status_t st = callback(q->public_handle(), data);
+      if (st == HSA_STATUS_INFO_BREAK) return HSA_STATUS_SUCCESS;
+      if (st != HSA_STATUS_SUCCESS) return st;
+    }
+  }
+  return HSA_STATUS_SUCCESS;
+  CATCH;
+}
+
+hsa_status_t hsa_amd_profiling_get_dispatch_records(hsa_queue_t* queue, void** buffer_base,
+                                                    uint32_t* buffer_size,
+                                                    volatile uint32_t** write_ptr) {
+  TRY;
+  IS_OPEN();
+  if (!queue || !buffer_base || !buffer_size || !write_ptr)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  core::Queue* cmd_queue = core::Queue::Convert(queue);
+  IS_VALID(cmd_queue);
+  if (!AqlQueue::IsType(cmd_queue)) return HSA_STATUS_ERROR_INVALID_QUEUE;
+  return static_cast<AqlQueue*>(cmd_queue)->GetProfilingDispatchRecords(buffer_base, buffer_size,
+                                                                        write_ptr);
   CATCH;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -637,9 +637,13 @@ hsa_status_t hsa_amd_profiling_set_profiler_enabled(hsa_queue_t* queue, int enab
   core::Queue* cmd_queue = core::Queue::Convert(queue);
   IS_VALID(cmd_queue);
 
-  cmd_queue->SetProfiling(enable);
-
-  return HSA_STATUS_SUCCESS;
+  // C3: SetProfiling now returns hsa_status_t. Allocation, libhsakmt
+  // SetQueueProfilingBuffer registration, and the cached-buffer teardown
+  // path can all surface failures (HSA_STATUS_ERROR_OUT_OF_RESOURCES,
+  // HSA_STATUS_ERROR_NOT_SUPPORTED, etc.); propagate so callers can act
+  // on them rather than silently believing profiling is enabled when
+  // KFD never accepted the buffer.
+  return cmd_queue->SetProfiling(enable);
   CATCH;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -684,17 +684,15 @@ hsa_status_t hsa_amd_queue_iterate(hsa_status_t (*callback)(hsa_queue_t* queue, 
 }
 
 hsa_status_t hsa_amd_profiling_get_dispatch_records(hsa_queue_t* queue, void** buffer_base,
-                                                    uint32_t* buffer_size,
-                                                    volatile uint32_t** write_ptr) {
+                                                    uint32_t* buffer_size) {
   TRY;
   IS_OPEN();
-  if (!queue || !buffer_base || !buffer_size || !write_ptr)
+  if (!queue || !buffer_base || !buffer_size)
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   core::Queue* cmd_queue = core::Queue::Convert(queue);
   IS_VALID(cmd_queue);
   if (!AqlQueue::IsType(cmd_queue)) return HSA_STATUS_ERROR_INVALID_QUEUE;
-  return static_cast<AqlQueue*>(cmd_queue)->GetProfilingDispatchRecords(buffer_base, buffer_size,
-                                                                        write_ptr);
+  return static_cast<AqlQueue*>(cmd_queue)->GetProfilingDispatchRecords(buffer_base, buffer_size);
   CATCH;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -647,19 +647,37 @@ hsa_status_t hsa_amd_profiling_set_profiler_enabled(hsa_queue_t* queue, int enab
   CATCH;
 }
 
+// C8: snapshot the public handles of all AQL queues under each agent's
+// shared lock, then invoke the user callback OUTSIDE the lock. Holding
+// AqlQueuesMutex across an external callback risks deadlock if the
+// callback creates/destroys queues (which take the same mutex
+// exclusively), and the public API does not document a non-reentrancy
+// requirement.
+//
+// Note: handles in the snapshot may refer to queues that have been
+// destroyed by the time the callback runs. This is the same lifetime
+// caveat that already applies to any hsa_queue_t obtained from the
+// public API - callers must be prepared to validate / scope handles
+// against their own lifetime tracking.
 hsa_status_t hsa_amd_queue_iterate(hsa_status_t (*callback)(hsa_queue_t* queue, void* data),
                                    void* data) {
   TRY;
   IS_OPEN();
   if (!callback) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  std::vector<hsa_queue_t*> snapshot;
   for (core::Agent* agent : core::Runtime::runtime_singleton_->gpu_agents()) {
     auto* gpu = static_cast<AMD::GpuAgent*>(agent);
     std::shared_lock<std::shared_mutex> lock(gpu->AqlQueuesMutex());
-    for (auto* q : gpu->GetAqlQueues()) {
-      hsa_status_t st = callback(q->public_handle(), data);
-      if (st == HSA_STATUS_INFO_BREAK) return HSA_STATUS_SUCCESS;
-      if (st != HSA_STATUS_SUCCESS) return st;
-    }
+    const auto& queues = gpu->GetAqlQueues();
+    snapshot.reserve(snapshot.size() + queues.size());
+    for (auto* q : queues) snapshot.push_back(q->public_handle());
+  }
+
+  for (auto* h : snapshot) {
+    hsa_status_t st = callback(h, data);
+    if (st == HSA_STATUS_INFO_BREAK) return HSA_STATUS_SUCCESS;
+    if (st != HSA_STATUS_SUCCESS) return st;
   }
   return HSA_STATUS_SUCCESS;
   CATCH;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -65,6 +65,7 @@
 #include "core/inc/runtime.h"
 #include "core/inc/signal.h"
 #include "core/inc/counted_queue_manager.h"
+#include "core/inc/dispatch_log.h"
 
 namespace rocr {
 
@@ -643,7 +644,29 @@ hsa_status_t hsa_amd_profiling_set_profiler_enabled(hsa_queue_t* queue, int enab
   // HSA_STATUS_ERROR_NOT_SUPPORTED, etc.); propagate so callers can act
   // on them rather than silently believing profiling is enabled when
   // KFD never accepted the buffer.
-  return cmd_queue->SetProfiling(enable);
+  //
+  // Code-quality C3: route through the dispatch_log refcount instead
+  // of calling SetProfiling directly. SetProfiling owns the per-queue
+  // dispatch-record buffer + KFD MQD wiring; if multiple consumers
+  // (this public API, the LTTng dispatch_log path,
+  // CountedQueuePoolManager) call SetProfiling independently, a disable
+  // from one of them frees state another still depends on. The
+  // QueueProfilingAcquire / Release refcount makes the underlying
+  // SetProfiling(true) / (false) calls happen exactly on the 0->1 / 1->0
+  // edges, so all callers can coexist.
+  //
+  // Semantics note: under the old direct-SetProfiling path,
+  // calling enable=1 N times then enable=0 once would leave profiling
+  // disabled. Under the refcount path the same sequence leaves
+  // profiling enabled (N-1 acquires still outstanding). The public API
+  // does not document idempotence in either direction; refcount
+  // semantics are the only safe choice when multiple subsystems share
+  // the queue.
+  if (enable) {
+    return rocr::dispatch_log::QueueProfilingAcquire(cmd_queue);
+  } else {
+    return rocr::dispatch_log::QueueProfilingRelease(cmd_queue);
+  }
   CATCH;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -65,6 +65,7 @@
 #include "core/inc/amd_core_dump.hpp"
 #include "core/inc/amd_cpu_agent.h"
 #include "core/inc/amd_gpu_agent.h"
+#include "core/inc/clock_sync.h"
 #include "core/inc/dispatch_log.h"
 #include "core/inc/amd_memory_region.h"
 #include "core/inc/amd_topology.h"
@@ -2428,6 +2429,7 @@ hsa_status_t Runtime::Load() {
   // tracepoint provider. Phase A: probes for the KFD substrate (currently
   // absent — the poller stays in its no-op path until the substrate lands).
   rocr::dispatch_log::init();
+  rocr::clock_sync::init();
 
   // Initialize libdrm helper function
   CheckVirtualMemApiSupport();
@@ -2446,6 +2448,7 @@ void Runtime::Unload() {
   // queue/agent destruction so the disable edge for any still-active queues
   // has live agents to translate timestamps against. Joins the poller and
   // (lazily-spawned) drainer threads.
+  rocr::clock_sync::shutdown();
   rocr::dispatch_log::shutdown();
 
   // Close IPC socket server

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -65,6 +65,7 @@
 #include "core/inc/amd_core_dump.hpp"
 #include "core/inc/amd_cpu_agent.h"
 #include "core/inc/amd_gpu_agent.h"
+#include "core/inc/dispatch_log.h"
 #include "core/inc/amd_memory_region.h"
 #include "core/inc/amd_topology.h"
 #include "core/inc/exceptions.h"
@@ -2421,6 +2422,13 @@ hsa_status_t Runtime::Load() {
   // Load tools libraries
   LoadTools();
 
+  // Initialize the LTTng dispatch-log scaffolding (spec 2026-04-27 §8).
+  // LoadTools() already invoked __rocm_hsa_tp_init(); we run dispatch_log::init()
+  // immediately after so the poller thread observes a fully-initialized
+  // tracepoint provider. Phase A: probes for the KFD substrate (currently
+  // absent — the poller stays in its no-op path until the substrate lands).
+  rocr::dispatch_log::init();
+
   // Initialize libdrm helper function
   CheckVirtualMemApiSupport();
 
@@ -2434,6 +2442,12 @@ hsa_status_t Runtime::Load() {
 }
 
 void Runtime::Unload() {
+  // Tear down LTTng dispatch-log scaffolding (spec 2026-04-27 §8). Run BEFORE
+  // queue/agent destruction so the disable edge for any still-active queues
+  // has live agents to translate timestamps against. Joins the poller and
+  // (lazily-spawned) drainer threads.
+  rocr::dispatch_log::shutdown();
+
   // Close IPC socket server
   if (ipc_sock_server_conns_.size())
     IPCClientImport(os::GetProcessId(), IPC_SOCK_SERVER_CONN_CLOSE_HANDLE,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
@@ -171,6 +171,10 @@ namespace core {
       HSAKMT_PFN(hsaKmtUpdateQueue) = (HSAKMT_DEF(hsaKmtUpdateQueue)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtUpdateQueue");
       if (HSAKMT_PFN(hsaKmtUpdateQueue) == nullptr) goto LOAD_ERROR;
 
+      HSAKMT_PFN(hsaKmtSetQueueProfilingBuffer) =
+          (HSAKMT_DEF(hsaKmtSetQueueProfilingBuffer)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtSetQueueProfilingBuffer");
+      // Optional: not all thunks export this. Don't fail if missing.
+
       HSAKMT_PFN(hsaKmtDestroyQueue) = (HSAKMT_DEF(hsaKmtDestroyQueue)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtDestroyQueue");
       if (HSAKMT_PFN(hsaKmtDestroyQueue) == nullptr) goto LOAD_ERROR;
 
@@ -477,6 +481,8 @@ LOAD_ERROR:
       HSAKMT_PFN(hsaKmtCreateQueueExt) = (HSAKMT_DEF(hsaKmtCreateQueueExt)*)(&hsaKmtCreateQueueExt);
       HSAKMT_PFN(hsaKmtCreateQueueV2) = (HSAKMT_DEF(hsaKmtCreateQueueV2)*)(&hsaKmtCreateQueueV2);
       HSAKMT_PFN(hsaKmtUpdateQueue) = (HSAKMT_DEF(hsaKmtUpdateQueue)*)(&hsaKmtUpdateQueue);
+      HSAKMT_PFN(hsaKmtSetQueueProfilingBuffer) =
+          (HSAKMT_DEF(hsaKmtSetQueueProfilingBuffer)*)(&hsaKmtSetQueueProfilingBuffer);
       HSAKMT_PFN(hsaKmtDestroyQueue) = (HSAKMT_DEF(hsaKmtDestroyQueue)*)(&hsaKmtDestroyQueue);
       HSAKMT_PFN(hsaKmtSetQueueCUMask) = (HSAKMT_DEF(hsaKmtSetQueueCUMask)*)(&hsaKmtSetQueueCUMask);
       HSAKMT_PFN(hsaKmtSetMemoryPolicy) = (HSAKMT_DEF(hsaKmtSetMemoryPolicy)*)(&hsaKmtSetMemoryPolicy);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
@@ -174,6 +174,12 @@ namespace core {
       HSAKMT_PFN(hsaKmtSetQueueProfilingBuffer) =
           (HSAKMT_DEF(hsaKmtSetQueueProfilingBuffer)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtSetQueueProfilingBuffer");
       // Optional: not all thunks export this. Don't fail if missing.
+      HSAKMT_PFN(hsaKmtSetDispatchLog) =
+          (HSAKMT_DEF(hsaKmtSetDispatchLog)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtSetDispatchLog");
+      // Optional: only present in libhsakmt with KFD_IOC_PROFILER_DISPATCH_LOG
+      // support (KFD MINOR >= 20). Older thunks return NULL here; the caller
+      // (AqlQueue::SetProfiling) detects null and falls back to the legacy
+      // sentinel-scan path via hsaKmtSetQueueProfilingBuffer.
 
       HSAKMT_PFN(hsaKmtDestroyQueue) = (HSAKMT_DEF(hsaKmtDestroyQueue)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtDestroyQueue");
       if (HSAKMT_PFN(hsaKmtDestroyQueue) == nullptr) goto LOAD_ERROR;
@@ -483,6 +489,8 @@ LOAD_ERROR:
       HSAKMT_PFN(hsaKmtUpdateQueue) = (HSAKMT_DEF(hsaKmtUpdateQueue)*)(&hsaKmtUpdateQueue);
       HSAKMT_PFN(hsaKmtSetQueueProfilingBuffer) =
           (HSAKMT_DEF(hsaKmtSetQueueProfilingBuffer)*)(&hsaKmtSetQueueProfilingBuffer);
+      HSAKMT_PFN(hsaKmtSetDispatchLog) =
+          (HSAKMT_DEF(hsaKmtSetDispatchLog)*)(&hsaKmtSetDispatchLog);
       HSAKMT_PFN(hsaKmtDestroyQueue) = (HSAKMT_DEF(hsaKmtDestroyQueue)*)(&hsaKmtDestroyQueue);
       HSAKMT_PFN(hsaKmtSetQueueCUMask) = (HSAKMT_DEF(hsaKmtSetQueueCUMask)*)(&hsaKmtSetQueueCUMask);
       HSAKMT_PFN(hsaKmtSetMemoryPolicy) = (HSAKMT_DEF(hsaKmtSetMemoryPolicy)*)(&hsaKmtSetMemoryPolicy);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
@@ -177,9 +177,8 @@ namespace core {
       HSAKMT_PFN(hsaKmtSetDispatchLog) =
           (HSAKMT_DEF(hsaKmtSetDispatchLog)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtSetDispatchLog");
       // Optional: only present in libhsakmt with KFD_IOC_PROFILER_DISPATCH_LOG
-      // support (KFD MINOR >= 20). Older thunks return NULL here; the caller
-      // (AqlQueue::SetProfiling) detects null and falls back to the legacy
-      // sentinel-scan path via hsaKmtSetQueueProfilingBuffer.
+      // support (KFD MINOR >= 20). Older thunks return NULL here; without it
+      // AqlQueue::SetProfiling(true) cannot complete dispatch-log registration.
 
       HSAKMT_PFN(hsaKmtDestroyQueue) = (HSAKMT_DEF(hsaKmtDestroyQueue)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtDestroyQueue");
       if (HSAKMT_PFN(hsaKmtDestroyQueue) == nullptr) goto LOAD_ERROR;

--- a/projects/rocr-runtime/runtime/hsa-runtime/hsacore.dll.def
+++ b/projects/rocr-runtime/runtime/hsa-runtime/hsacore.dll.def
@@ -232,3 +232,5 @@ EXPORTS
   hsa_ext_image_data_get_info_v2
   hsa_ext_image_destroy_v2
   hsa_amd_agent_preload
+  hsa_amd_queue_iterate
+  hsa_amd_profiling_get_dispatch_records

--- a/projects/rocr-runtime/runtime/hsa-runtime/hsacore.so.def
+++ b/projects/rocr-runtime/runtime/hsa-runtime/hsacore.so.def
@@ -274,6 +274,8 @@ global:
 	hsa_amd_counted_queue_release;
 	hsa_amd_svm_discard_batch_async;
 	hsa_amd_signal_get_event_id;
+	hsa_amd_dispatch_log_test_enable;
+	hsa_amd_dispatch_log_test_get_state;
 local:
     *;
 };

--- a/projects/rocr-runtime/runtime/hsa-runtime/hsacore.so.def
+++ b/projects/rocr-runtime/runtime/hsa-runtime/hsacore.so.def
@@ -172,6 +172,8 @@ global:
 	hsa_amd_profiling_get_dispatch_time;
 	hsa_amd_profiling_async_copy_enable;
 	hsa_amd_agent_preload;
+	hsa_amd_queue_iterate;
+	hsa_amd_profiling_get_dispatch_records;
 	hsa_amd_profiling_get_async_copy_time;
 	hsa_amd_profiling_convert_tick_to_system_domain;
 	hsa_amd_signal_create;

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace.h
@@ -279,6 +279,8 @@ struct AmdExtTable {
   decltype(hsa_amd_agent_preload) *hsa_amd_agent_preload_fn;
   decltype(hsa_amd_svm_discard_batch_async)* hsa_amd_svm_discard_batch_async_fn;
   decltype(hsa_amd_signal_get_event_id)* hsa_amd_signal_get_event_id_fn;
+  decltype(hsa_amd_queue_iterate)* hsa_amd_queue_iterate_fn;
+  decltype(hsa_amd_profiling_get_dispatch_records)* hsa_amd_profiling_get_dispatch_records_fn;
 };
 
 // Table to export HSA Core Runtime Apis

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace_version.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace_version.h
@@ -58,7 +58,7 @@
 // Step Ids of the Api tables exported by Hsa Core Runtime
 #define HSA_API_TABLE_STEP_VERSION                  0x01
 #define HSA_CORE_API_TABLE_STEP_VERSION             0x00
-#define HSA_AMD_EXT_API_TABLE_STEP_VERSION          0x0D
+#define HSA_AMD_EXT_API_TABLE_STEP_VERSION          0x0E
 #define HSA_FINALIZER_API_TABLE_STEP_VERSION        0x00
 #define HSA_IMAGE_API_TABLE_STEP_VERSION            0x01
 // Rocprofiler just checks HSA_MAGE_EXT_API_TABLE_STEP_VERSION

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -4754,9 +4754,11 @@ hsa_status_t HSA_API hsa_amd_queue_iterate(
  *
  * @param[out] buffer_size Size of the ring buffer in bytes.
  *
- * @param[out] write_ptr Pointer to the firmware write index (record count,
- * monotonically incrementing). The caller computes the slot as
- * @c *write_ptr % (buffer_size / record_size).
+ * The substrate does NOT publish a host-visible firmware write pointer.
+ * Consumers must locate freshly-written records by scanning the ring for
+ * a non-zero @c record_type sentinel; see
+ * core/runtime/dispatch_log.cpp::drain_one_queue for the canonical
+ * sentinel-scan implementation.
  *
  * @retval ::HSA_STATUS_SUCCESS The ring buffer info has been returned.
  *
@@ -4771,8 +4773,7 @@ hsa_status_t HSA_API hsa_amd_queue_iterate(
 hsa_status_t HSA_API hsa_amd_profiling_get_dispatch_records(
     hsa_queue_t* queue,
     void** buffer_base,
-    uint32_t* buffer_size,
-    volatile uint32_t** write_ptr);
+    uint32_t* buffer_size);
 
 /** @} */
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -72,9 +72,10 @@
  * - 1.19 - hsa_amd_agent_preload
  * - 1.20 - Memory batch discard API: hsa_amd_svm_discard_batch_async
  * - 1.21 - hsa_amd_signal_get_event_id
+ * - 1.22 - hsa_amd_queue_iterate, hsa_amd_profiling_get_dispatch_records
  */
 #define HSA_AMD_INTERFACE_VERSION_MAJOR 1
-#define HSA_AMD_INTERFACE_VERSION_MINOR 21
+#define HSA_AMD_INTERFACE_VERSION_MINOR 22
 
 #ifdef __cplusplus
 extern "C" {
@@ -4719,6 +4720,59 @@ typedef enum hsa_amd_log_flag_s {
  * initialized.
  */
 hsa_status_t hsa_amd_enable_logging(uint8_t* flags, void* file);
+
+/**
+ * @brief Iterate over all live AQL queues across all GPU agents.
+ *
+ * @param[in] callback Function called once per queue. Return
+ * ::HSA_STATUS_INFO_BREAK to stop early, ::HSA_STATUS_SUCCESS to continue.
+ *
+ * @param[in] data User data forwarded to @p callback.
+ *
+ * @retval ::HSA_STATUS_SUCCESS Iteration completed or was stopped via
+ * ::HSA_STATUS_INFO_BREAK.
+ *
+ * @retval ::HSA_STATUS_ERROR_INVALID_ARGUMENT @p callback is NULL.
+ *
+ * @retval ::HSA_STATUS_ERROR_NOT_INITIALIZED The HSA runtime has not been
+ * initialized.
+ */
+hsa_status_t HSA_API hsa_amd_queue_iterate(
+    hsa_status_t (*callback)(hsa_queue_t* queue, void* data),
+    void* data);
+
+/**
+ * @brief Retrieve the MEC dispatch record ring buffer for a queue.
+ *
+ * The ring buffer is allocated by ::hsa_amd_profiling_set_profiler_enabled
+ * and is written by the MEC firmware for every dispatch when profiling is
+ * enabled.
+ *
+ * @param[in] queue Queue handle.
+ *
+ * @param[out] buffer_base Start of the ring buffer (GPU-visible system memory).
+ *
+ * @param[out] buffer_size Size of the ring buffer in bytes.
+ *
+ * @param[out] write_ptr Pointer to the firmware write index (record count,
+ * monotonically incrementing). The caller computes the slot as
+ * @c *write_ptr % (buffer_size / record_size).
+ *
+ * @retval ::HSA_STATUS_SUCCESS The ring buffer info has been returned.
+ *
+ * @retval ::HSA_STATUS_ERROR_NOT_INITIALIZED Profiling has not been enabled
+ * on this queue or the ring buffer was not allocated.
+ *
+ * @retval ::HSA_STATUS_ERROR_INVALID_ARGUMENT A parameter is NULL.
+ *
+ * @retval ::HSA_STATUS_ERROR_INVALID_QUEUE @p queue is not a hardware AQL
+ * queue.
+ */
+hsa_status_t HSA_API hsa_amd_profiling_get_dispatch_records(
+    hsa_queue_t* queue,
+    void** buffer_base,
+    uint32_t* buffer_size,
+    volatile uint32_t** write_ptr);
 
 /** @} */
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -4754,11 +4754,9 @@ hsa_status_t HSA_API hsa_amd_queue_iterate(
  *
  * @param[out] buffer_size Size of the ring buffer in bytes.
  *
- * The substrate does NOT publish a host-visible firmware write pointer.
- * Consumers must locate freshly-written records by scanning the ring for
- * a non-zero @c record_type sentinel; see
- * core/runtime/dispatch_log.cpp::drain_one_queue for the canonical
- * sentinel-scan implementation.
+ * The host bounds the live region using the per-queue signal counter
+ * registered with KFD (see AqlQueue::GetDispatchLogPointers and
+ * core/runtime/dispatch_log.cpp::drain_one_queue).
  *
  * @retval ::HSA_STATUS_SUCCESS The ring buffer info has been returned.
  *

--- a/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_hsa_tp.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_hsa_tp.h
@@ -166,10 +166,10 @@ LTTNG_UST_TRACEPOINT_EVENT(
  * consumer decide. Future FW revisions that change the polarity (or add
  * a third record_type) cost only a consumer change.
  *
- * gpu_ts is host-domain (system clock) translated from the FW-written
- * GPU clock by HSA's existing GpuAgent::TranslateTime infrastructure
- * (monotonic linear interpolation, so the relative ordering of any two
- * records' timestamps is preserved by the translation).
+ * gpu_ts is the raw hardware clock counter written by the FW. It is NOT
+ * translated to the host system clock domain. The consumer must use the
+ * rocm_hsa:clock_sync tracepoint to correlate this raw GPU timestamp with
+ * the system clock.
  *
  * record_type is the raw value FW wrote (uint8_t — the FW field is
  * 32 bits but the values seen so far fit in uint8_t and the on-the-wire
@@ -214,6 +214,23 @@ LTTNG_UST_TRACEPOINT_EVENT(
     LTTNG_UST_TP_FIELDS(
         lttng_ust_field_integer(uint32_t, queue_id, queue_id)
         lttng_ust_field_integer(uint64_t, bytes_lost, bytes_lost)
+    )
+)
+
+/* clock_sync: emitted periodically to correlate raw GPU timestamps with the
+ * host system clock.
+ *
+ * gpu_id is the node_id of the GPU agent.
+ * gpu_ts is the raw hardware clock counter.
+ * system_ts is the corresponding host system clock counter.
+ */
+LTTNG_UST_TRACEPOINT_EVENT(
+    rocm_hsa, clock_sync,
+    LTTNG_UST_TP_ARGS(uint64_t, gpu_id, uint64_t, gpu_ts, uint64_t, system_ts),
+    LTTNG_UST_TP_FIELDS(
+        lttng_ust_field_integer(uint64_t, gpu_id, gpu_id)
+        lttng_ust_field_integer(uint64_t, gpu_ts, gpu_ts)
+        lttng_ust_field_integer(uint64_t, system_ts, system_ts)
     )
 )
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_hsa_tp.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_hsa_tp.h
@@ -205,15 +205,16 @@ LTTNG_UST_TRACEPOINT_EVENT(
     )
 )
 
-/* kernel_dispatch_drop: tracepoint defined but currently unemittable. The
- * sentinel-scan drainer (core/runtime/dispatch_log.cpp::drain_one_queue)
- * cannot detect ring overruns because the substrate publishes no
- * host-visible FW write pointer to compare against the host read cursor.
- * Reserved for a future overrun-detection mechanism (e.g. a per-slot
- * sequence-number gap check, or a substrate extension that publishes
- * wptr); see rocm_trace_emit.h::rocm_trace_emit_hsa_kernel_dispatch_drop
- * and design spec §10. Per-queue enable failures are reported via stderr
- * WARNING (see Phase A spec §5), not via this tracepoint. */
+/* kernel_dispatch_drop: emitted by the signal-bound drain path (Path A
+ * in core/runtime/dispatch_log.cpp::drain_one_queue) when the host
+ * falls behind FW by more than ring_records, i.e. FW silently
+ * overwrote unread records. bytes_lost is the count of lost records.
+ *
+ * NOT emitted on the sentinel-scan fallback (Path B, older kernels
+ * without host-VA wptr/signal pointers), nor during init-sync (the
+ * pre-zeroed gap between slot 0 and the first FW-written slot is not
+ * a real drop). Per-queue ENABLE failures are reported via stderr
+ * WARNING per spec §5, not via this tracepoint. */
 LTTNG_UST_TRACEPOINT_EVENT(
     rocm_hsa, kernel_dispatch_drop,
     LTTNG_UST_TP_ARGS(uint32_t, queue_id, uint64_t, bytes_lost),

--- a/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_hsa_tp.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_hsa_tp.h
@@ -171,15 +171,15 @@ LTTNG_UST_TRACEPOINT_EVENT(
     )
 )
 
-/* kernel_dispatch_drop: fired once per ring-overrun event when the firmware
- * dispatch-log writer outpaced the drainer. bytes_lost is (fw_wptr -
- * read_cursor) at the moment overrun was detected — the worst-case
- * "how far behind the drainer fell" measure, NOT the strictly-unrecoverable
- * overrun amount. The strictly-lost portion is bytes_lost - ring_bytes;
- * the remainder is still resident in the ring but skipped because the
- * drainer cannot tell which records the FW just overwrote. Reserved
- * strictly for ring-overrun loss; per-queue enable failures are reported
- * via stderr WARNING (see Phase A spec §5). */
+/* kernel_dispatch_drop: tracepoint defined but currently unemittable. The
+ * sentinel-scan drainer (core/runtime/dispatch_log.cpp::drain_one_queue)
+ * cannot detect ring overruns because the substrate publishes no
+ * host-visible FW write pointer to compare against the host read cursor.
+ * Reserved for a future overrun-detection mechanism (e.g. a per-slot
+ * sequence-number gap check, or a substrate extension that publishes
+ * wptr); see rocm_trace_emit.h::rocm_trace_emit_hsa_kernel_dispatch_drop
+ * and design spec §10. Per-queue enable failures are reported via stderr
+ * WARNING (see Phase A spec §5), not via this tracepoint. */
 LTTNG_UST_TRACEPOINT_EVENT(
     rocm_hsa, kernel_dispatch_drop,
     LTTNG_UST_TP_ARGS(uint32_t, queue_id, uint64_t, bytes_lost),

--- a/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_hsa_tp.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_hsa_tp.h
@@ -144,58 +144,52 @@ LTTNG_UST_TRACEPOINT_EVENT(
 /* Curated per-API typed tracepoint events (generated header). */
 #include "rocm_hsa_curated_tp.h"
 
-/* kernel_dispatch_record: emitted by the firmware-dispatch-log drainer
- * thread (NOT the application thread) once per FW-written 16-byte record.
+/* kernel_dispatch_record: BATCHED FORM — emitted by the firmware-dispatch-log
+ * drainer thread once per drain pass with a packed array of all records
+ * read in that pass.
  *
- * The MEC firmware writes two records per kernel dispatch: the two
- * records share the same dispatch_idx and have different record_type
- * values (currently 1 and 2). HSA does NOT interpret which record_type
- * means start vs end; that interpretation is left to the stream
- * consumer, which can:
- *   (a) join records on (queue_id, dispatch_idx) to find pairs, and
- *   (b) infer start vs end from gpu_ts ordering (smaller ts = start)
- *       OR from record_type if the consumer has FW-version-specific
- *       knowledge.
+ * Each event carries:
+ *   - queue_id (one per batch — all records in a batch belong to one queue)
+ *   - count: number of records in `records[]`
+ *   - records: packed array of `count` × 16-byte FW records, exactly the
+ *     mec_dispatch_record_16 struct layout (ts_lo, ts_hi, record_type,
+ *     dispatch_idx). Consumer un-packs this to get per-dispatch
+ *     {gpu_ts, record_type, dispatch_idx} tuples.
  *
- * Empirical observation on the gfx950 MEC firmware (gc_9_5_0_mec.bin)
- * shows record_type==2 carries the EARLIER GPU clock (dispatch start)
- * and record_type==1 carries the LATER GPU clock (EOP / dispatch end).
- * This is OPPOSITE of what cpc_tracing's mec_dispatch_record.h comment
- * claims. Rather than baking a host-side polarity decision against a
- * non-versioned FW contract, HSA emits both records and lets the
- * consumer decide. Future FW revisions that change the polarity (or add
- * a third record_type) cost only a consumer change.
+ * Batching motivation: per-record tracepoint calls were the host-side
+ * bottleneck under sustained FW write rates (~1M records/sec on busy
+ * queues during graph workloads). Each LTTng tracepoint call costs ~1-2
+ * us; at 1M/sec that fills a CPU core entirely. Batching N records per
+ * call reduces the per-record cost to ~1/N microseconds plus the constant
+ * memcpy of N*16 bytes into the LTTng UST buffer. The drainer's typical
+ * batch size is bounded by either the per-pass record count or the
+ * configured kBatchMax (see drain_one_queue).
  *
- * gpu_ts is the raw hardware clock counter written by the FW. It is NOT
+ * Per-record `corr_id` field is removed in the batched form: the drainer
+ * has no API context to attach (it runs on its own thread), and per-record
+ * unique IDs aren't needed for the (queue_id, dispatch_idx) join most
+ * stream consumers do. Consumers that need a per-record monotonic ID can
+ * derive one from (queue_id, batch_seq, record_index_within_batch).
+ *
+ * record_type interpretation: the MEC firmware writes one record at
+ * dispatch start (rt=2 on gfx950) and one at dispatch end (rt=1 on
+ * gfx950). HSA does NOT interpret record_type — the stream consumer
+ * joins records on (queue_id, dispatch_idx) and either orders by gpu_ts
+ * or applies its own FW-version-specific record_type interpretation.
+ *
+ * gpu_ts is the raw hardware clock counter written by FW. It is NOT
  * translated to the host system clock domain. The consumer must use the
- * rocm_hsa:clock_sync tracepoint to correlate this raw GPU timestamp with
- * the system clock.
- *
- * record_type is the raw value FW wrote (uint8_t — the FW field is
- * 32 bits but the values seen so far fit in uint8_t and the on-the-wire
- * payload size matters; see drain_one_queue for the narrowing).
- *
- * dispatch_idx is the low 32 bits of the AQL read_dispatch_id at the
- * FW's moment of dispatch processing; stream-side joiners against
- * rocm_hsa:hsa_doorbell_ring MUST mask the doorbell write_idx to 32
- * bits before comparing.
- *
- * self_corr is freshly minted per emission so this event has its own
- * identity; parent_corr_id is always 0 (the drainer thread has no API
- * context — real parent recovery is consumer-side via the doorbell
- * join). See Phase A spec §6 for full rationale. */
+ * rocm_hsa:clock_sync tracepoint to correlate raw GPU timestamps with
+ * the host system clock. */
 LTTNG_UST_TRACEPOINT_EVENT(
     rocm_hsa, kernel_dispatch_record,
-    LTTNG_UST_TP_ARGS(uint32_t, queue_id, uint32_t, dispatch_idx,
-                      uint64_t, gpu_ts, uint8_t, record_type,
-                      uint64_t, self_corr, uint64_t, parent_corr_id),
+    LTTNG_UST_TP_ARGS(uint32_t, queue_id, uint32_t, count,
+                      const uint8_t*, records, size_t, records_len),
     LTTNG_UST_TP_FIELDS(
         lttng_ust_field_integer(uint32_t, queue_id, queue_id)
-        lttng_ust_field_integer(uint32_t, dispatch_idx, dispatch_idx)
-        lttng_ust_field_integer(uint64_t, gpu_ts, gpu_ts)
-        lttng_ust_field_integer(uint8_t, record_type, record_type)
-        lttng_ust_field_integer(uint64_t, corr_id, self_corr)
-        lttng_ust_field_integer(uint64_t, parent_corr_id, parent_corr_id)
+        lttng_ust_field_integer(uint32_t, count, count)
+        lttng_ust_field_sequence(uint8_t, records, records,
+                                 size_t, records_len)
     )
 )
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_hsa_tp.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_hsa_tp.h
@@ -144,28 +144,56 @@ LTTNG_UST_TRACEPOINT_EVENT(
 /* Curated per-API typed tracepoint events (generated header). */
 #include "rocm_hsa_curated_tp.h"
 
-/* kernel_dispatch_complete: emitted by the firmware-dispatch-log drainer
- * thread (NOT the application thread) when a kernel dispatch's START and
- * END timestamp records have been paired. dispatch_idx is the low 32 bits
- * of the AQL read_dispatch_id at the FW's moment of dispatch processing;
- * stream-side joiners against rocm_hsa:hsa_doorbell_ring MUST mask the
- * doorbell write_idx to 32 bits before comparing. start_ts and end_ts are
- * host-domain (system clock) timestamps; the drainer translates the
- * FW-written GPU clock via the queue's agent's existing TranslateTime
- * infrastructure before emit. self_corr is freshly minted per emission;
- * parent_corr_id is always 0 (the drainer thread has no API context —
- * real parent recovery is consumer-side via the doorbell join). See
- * Phase A spec §6 for full rationale. */
+/* kernel_dispatch_record: emitted by the firmware-dispatch-log drainer
+ * thread (NOT the application thread) once per FW-written 16-byte record.
+ *
+ * The MEC firmware writes two records per kernel dispatch: the two
+ * records share the same dispatch_idx and have different record_type
+ * values (currently 1 and 2). HSA does NOT interpret which record_type
+ * means start vs end; that interpretation is left to the stream
+ * consumer, which can:
+ *   (a) join records on (queue_id, dispatch_idx) to find pairs, and
+ *   (b) infer start vs end from gpu_ts ordering (smaller ts = start)
+ *       OR from record_type if the consumer has FW-version-specific
+ *       knowledge.
+ *
+ * Empirical observation on the gfx950 MEC firmware (gc_9_5_0_mec.bin)
+ * shows record_type==2 carries the EARLIER GPU clock (dispatch start)
+ * and record_type==1 carries the LATER GPU clock (EOP / dispatch end).
+ * This is OPPOSITE of what cpc_tracing's mec_dispatch_record.h comment
+ * claims. Rather than baking a host-side polarity decision against a
+ * non-versioned FW contract, HSA emits both records and lets the
+ * consumer decide. Future FW revisions that change the polarity (or add
+ * a third record_type) cost only a consumer change.
+ *
+ * gpu_ts is host-domain (system clock) translated from the FW-written
+ * GPU clock by HSA's existing GpuAgent::TranslateTime infrastructure
+ * (monotonic linear interpolation, so the relative ordering of any two
+ * records' timestamps is preserved by the translation).
+ *
+ * record_type is the raw value FW wrote (uint8_t — the FW field is
+ * 32 bits but the values seen so far fit in uint8_t and the on-the-wire
+ * payload size matters; see drain_one_queue for the narrowing).
+ *
+ * dispatch_idx is the low 32 bits of the AQL read_dispatch_id at the
+ * FW's moment of dispatch processing; stream-side joiners against
+ * rocm_hsa:hsa_doorbell_ring MUST mask the doorbell write_idx to 32
+ * bits before comparing.
+ *
+ * self_corr is freshly minted per emission so this event has its own
+ * identity; parent_corr_id is always 0 (the drainer thread has no API
+ * context — real parent recovery is consumer-side via the doorbell
+ * join). See Phase A spec §6 for full rationale. */
 LTTNG_UST_TRACEPOINT_EVENT(
-    rocm_hsa, kernel_dispatch_complete,
+    rocm_hsa, kernel_dispatch_record,
     LTTNG_UST_TP_ARGS(uint32_t, queue_id, uint32_t, dispatch_idx,
-                      uint64_t, start_ts, uint64_t, end_ts,
+                      uint64_t, gpu_ts, uint8_t, record_type,
                       uint64_t, self_corr, uint64_t, parent_corr_id),
     LTTNG_UST_TP_FIELDS(
         lttng_ust_field_integer(uint32_t, queue_id, queue_id)
         lttng_ust_field_integer(uint32_t, dispatch_idx, dispatch_idx)
-        lttng_ust_field_integer(uint64_t, start_ts, start_ts)
-        lttng_ust_field_integer(uint64_t, end_ts, end_ts)
+        lttng_ust_field_integer(uint64_t, gpu_ts, gpu_ts)
+        lttng_ust_field_integer(uint8_t, record_type, record_type)
         lttng_ust_field_integer(uint64_t, corr_id, self_corr)
         lttng_ust_field_integer(uint64_t, parent_corr_id, parent_corr_id)
     )

--- a/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_hsa_tp.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_hsa_tp.h
@@ -150,6 +150,15 @@ LTTNG_UST_TRACEPOINT_EVENT(
  *
  * Each event carries:
  *   - queue_id (one per batch — all records in a batch belong to one queue)
+ *   - gpu_id: KFD node_id of the GPU agent that owns this queue. This
+ *     field is the join key against `rocm_hsa:clock_sync`, whose
+ *     `gpu_id` field carries the same KFD node_id for the same agent.
+ *     Without this field, consumers have no way to map a queue's raw
+ *     gpu_ts values to a clock_sync entry, which would make offline
+ *     translation impossible — see the spec at
+ *     `2026-04-27-hsa-lttng-kernel-dispatch-tracing-design.md` §6 / §10
+ *     for the full record-format and consumer-side timestamp-translation
+ *     contract.
  *   - count: number of records in `records[]`
  *   - records: packed array of `count` × 16-byte FW records, exactly the
  *     mec_dispatch_record_16 struct layout (ts_lo, ts_hi, record_type,
@@ -178,15 +187,18 @@ LTTNG_UST_TRACEPOINT_EVENT(
  * or applies its own FW-version-specific record_type interpretation.
  *
  * gpu_ts is the raw hardware clock counter written by FW. It is NOT
- * translated to the host system clock domain. The consumer must use the
- * rocm_hsa:clock_sync tracepoint to correlate raw GPU timestamps with
- * the host system clock. */
+ * translated to the host system clock domain. The consumer joins on
+ * `gpu_id` against the most recent `rocm_hsa:clock_sync` event whose
+ * `gpu_id` matches, then linearly interpolates between consecutive
+ * clock_sync samples for that agent to translate gpu_ts into the
+ * host system-clock domain. */
 LTTNG_UST_TRACEPOINT_EVENT(
     rocm_hsa, kernel_dispatch_record,
-    LTTNG_UST_TP_ARGS(uint32_t, queue_id, uint32_t, count,
+    LTTNG_UST_TP_ARGS(uint32_t, queue_id, uint32_t, gpu_id, uint32_t, count,
                       const uint8_t*, records, size_t, records_len),
     LTTNG_UST_TP_FIELDS(
         lttng_ust_field_integer(uint32_t, queue_id, queue_id)
+        lttng_ust_field_integer(uint32_t, gpu_id, gpu_id)
         lttng_ust_field_integer(uint32_t, count, count)
         lttng_ust_field_sequence(uint8_t, records, records,
                                  size_t, records_len)

--- a/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_hsa_tp.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_hsa_tp.h
@@ -144,6 +144,51 @@ LTTNG_UST_TRACEPOINT_EVENT(
 /* Curated per-API typed tracepoint events (generated header). */
 #include "rocm_hsa_curated_tp.h"
 
+/* kernel_dispatch_complete: emitted by the firmware-dispatch-log drainer
+ * thread (NOT the application thread) when a kernel dispatch's START and
+ * END timestamp records have been paired. dispatch_idx is the low 32 bits
+ * of the AQL read_dispatch_id at the FW's moment of dispatch processing;
+ * stream-side joiners against rocm_hsa:hsa_doorbell_ring MUST mask the
+ * doorbell write_idx to 32 bits before comparing. start_ts and end_ts are
+ * host-domain (system clock) timestamps; the drainer translates the
+ * FW-written GPU clock via the queue's agent's existing TranslateTime
+ * infrastructure before emit. self_corr is freshly minted per emission;
+ * parent_corr_id is always 0 (the drainer thread has no API context —
+ * real parent recovery is consumer-side via the doorbell join). See
+ * Phase A spec §6 for full rationale. */
+LTTNG_UST_TRACEPOINT_EVENT(
+    rocm_hsa, kernel_dispatch_complete,
+    LTTNG_UST_TP_ARGS(uint32_t, queue_id, uint32_t, dispatch_idx,
+                      uint64_t, start_ts, uint64_t, end_ts,
+                      uint64_t, self_corr, uint64_t, parent_corr_id),
+    LTTNG_UST_TP_FIELDS(
+        lttng_ust_field_integer(uint32_t, queue_id, queue_id)
+        lttng_ust_field_integer(uint32_t, dispatch_idx, dispatch_idx)
+        lttng_ust_field_integer(uint64_t, start_ts, start_ts)
+        lttng_ust_field_integer(uint64_t, end_ts, end_ts)
+        lttng_ust_field_integer(uint64_t, corr_id, self_corr)
+        lttng_ust_field_integer(uint64_t, parent_corr_id, parent_corr_id)
+    )
+)
+
+/* kernel_dispatch_drop: fired once per ring-overrun event when the firmware
+ * dispatch-log writer outpaced the drainer. bytes_lost is (fw_wptr -
+ * read_cursor) at the moment overrun was detected — the worst-case
+ * "how far behind the drainer fell" measure, NOT the strictly-unrecoverable
+ * overrun amount. The strictly-lost portion is bytes_lost - ring_bytes;
+ * the remainder is still resident in the ring but skipped because the
+ * drainer cannot tell which records the FW just overwrote. Reserved
+ * strictly for ring-overrun loss; per-queue enable failures are reported
+ * via stderr WARNING (see Phase A spec §5). */
+LTTNG_UST_TRACEPOINT_EVENT(
+    rocm_hsa, kernel_dispatch_drop,
+    LTTNG_UST_TP_ARGS(uint32_t, queue_id, uint64_t, bytes_lost),
+    LTTNG_UST_TP_FIELDS(
+        lttng_ust_field_integer(uint32_t, queue_id, queue_id)
+        lttng_ust_field_integer(uint64_t, bytes_lost, bytes_lost)
+    )
+)
+
 #endif /* _ROCM_HSA_TP_H */
 
 #include <lttng/tracepoint-event.h>

--- a/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_hsa_tp.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_hsa_tp.h
@@ -205,16 +205,14 @@ LTTNG_UST_TRACEPOINT_EVENT(
     )
 )
 
-/* kernel_dispatch_drop: emitted by the signal-bound drain path (Path A
- * in core/runtime/dispatch_log.cpp::drain_one_queue) when the host
- * falls behind FW by more than ring_records, i.e. FW silently
- * overwrote unread records. bytes_lost is the count of lost records.
+/* kernel_dispatch_drop: emitted by the signal-bound drain path in
+ * core/runtime/dispatch_log.cpp::drain_one_queue when the host falls
+ * behind FW by more than ring_records, i.e. FW silently overwrote unread
+ * records. bytes_lost is the count of lost records.
  *
- * NOT emitted on the sentinel-scan fallback (Path B, older kernels
- * without host-VA wptr/signal pointers), nor during init-sync (the
- * pre-zeroed gap between slot 0 and the first FW-written slot is not
- * a real drop). Per-queue ENABLE failures are reported via stderr
- * WARNING per spec §5, not via this tracepoint. */
+ * NOT emitted during init-sync (the pre-zeroed gap between slot 0 and
+ * the first FW-written slot is not a real drop). Per-queue ENABLE failures
+ * are reported via stderr WARNING per spec §5, not via this tracepoint. */
 LTTNG_UST_TRACEPOINT_EVENT(
     rocm_hsa, kernel_dispatch_drop,
     LTTNG_UST_TP_ARGS(uint32_t, queue_id, uint64_t, bytes_lost),

--- a/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_trace_emit.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_trace_emit.h
@@ -203,6 +203,50 @@ static inline void rocm_trace_emit_hsa_intercept_packets(uint32_t queue_id,
 /* Curated per-API typed emit helpers (generated header). */
 #include "rocm_trace_emit_curated.h"
 
+/* kernel_dispatch_complete emit helper. Called ONLY by the firmware-dispatch-
+ * log drainer thread (NOT the application thread) from
+ * dispatch_log::drain_one_queue. force_emit=true bypasses the per-tracepoint
+ * lttng_ust_tracepoint_enabled() guard but NOT the rocm_trace_disabled()
+ * kill switch. The bypass is REQUIRED for the disable-edge final drain (Phase
+ * A spec §4): by the time final drain runs, the user has already disabled
+ * the tracepoint (that disablement is what triggered the disable edge), so
+ * the steady-state guard would otherwise return false and the
+ * "END records the firmware has already written before wait_for_idle returns
+ * are emitted" loss guarantee would be unachievable. Steady-state drainer
+ * passes always pass force_emit=false. parent_corr_id is always 0 because
+ * the drainer thread has no API context (real parent is recovered consumer-
+ * side via the rocm_hsa:hsa_doorbell_ring join on (queue_id, dispatch_idx)).
+ */
+static inline void rocm_trace_emit_hsa_kernel_dispatch_complete(
+    uint32_t queue_id, uint32_t dispatch_idx,
+    uint64_t start_ts_sys, uint64_t end_ts_sys,
+    bool     force_emit /* default false at call site via wrapper */) {
+    if (rocm_trace_disabled()) return;
+    if (force_emit ||
+        lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_complete)) {
+        const uint64_t self_corr = rocp_reg_next_corr_id();
+        lttng_ust_do_tracepoint(rocm_hsa, kernel_dispatch_complete,
+                                queue_id, dispatch_idx,
+                                start_ts_sys, end_ts_sys,
+                                self_corr, /* parent_corr_id */ (uint64_t)0);
+    }
+}
+
+/* kernel_dispatch_drop emit helper. Called by the drainer when a ring-overrun
+ * is detected (fw_wptr - read_cursor > ring_bytes). Reserved strictly for
+ * ring-overrun loss; per-queue enable failures use stderr WARNING per spec
+ * §5. force_emit not supported here: drop events are always observed via
+ * the tracepoint-enabled gate, since they only fire while the drainer is
+ * actively consuming a ring (i.e. while the tracepoint is enabled). */
+static inline void rocm_trace_emit_hsa_kernel_dispatch_drop(uint32_t queue_id,
+                                                            uint64_t bytes_lost) {
+    if (rocm_trace_disabled()) return;
+    if (lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_drop)) {
+        lttng_ust_do_tracepoint(rocm_hsa, kernel_dispatch_drop,
+                                queue_id, bytes_lost);
+    }
+}
+
 #else /* !HSA_ENABLE_LTTNG_UST */
 
 static inline void rocm_trace_emit_hsa_api_enter(const char* a, uint64_t c) {
@@ -228,6 +272,14 @@ static inline void rocm_trace_emit_hsa_doorbell_ring(uint32_t a, int64_t b, uint
 }
 static inline void rocm_trace_emit_hsa_intercept_packets(uint32_t a, uint64_t b, uint32_t c, uint8_t d) {
     (void)a; (void)b; (void)c; (void)d;
+}
+static inline void rocm_trace_emit_hsa_kernel_dispatch_complete(uint32_t a, uint32_t b,
+                                                                uint64_t c, uint64_t d,
+                                                                bool e) {
+    (void)a; (void)b; (void)c; (void)d; (void)e;
+}
+static inline void rocm_trace_emit_hsa_kernel_dispatch_drop(uint32_t a, uint64_t b) {
+    (void)a; (void)b;
 }
 
 #endif

--- a/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_trace_emit.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_trace_emit.h
@@ -205,9 +205,10 @@ static inline void rocm_trace_emit_hsa_intercept_packets(uint32_t queue_id,
 
 /* kernel_dispatch_record emit helper. Called ONLY by the firmware-dispatch-
  * log drainer thread (NOT the application thread) from
- * dispatch_log::drain_one_queue. Emits one event per FW-written 16-byte
- * record (no host-side START/END pairing — see rocm_hsa_tp.h
- * kernel_dispatch_record doc comment for the consumer-side join contract).
+ * dispatch_log::drain_one_queue. Emits one event per drain pass carrying
+ * a packed batch of 16-byte FW records (no host-side START/END pairing —
+ * see rocm_hsa_tp.h kernel_dispatch_record doc comment for the
+ * consumer-side join contract).
  *
  * force_emit=true bypasses the per-tracepoint lttng_ust_tracepoint_enabled()
  * guard but NOT the rocm_trace_disabled() kill switch. The bypass is
@@ -219,13 +220,14 @@ static inline void rocm_trace_emit_hsa_intercept_packets(uint32_t queue_id,
  * would be unachievable. Steady-state drainer passes always pass
  * force_emit=false.
  *
- * gpu_ts is the raw FW-written GPU clock. It is NOT translated to the host
- * system clock domain by the drainer. The consumer must use the rocm_hsa:clock_sync
- * tracepoint to correlate this raw GPU timestamp with the system clock.
- * record_type is the raw FW-written tag, narrowed to uint8_t at
- * the call site (current FW values are 1 and 2; see drain_one_queue).
+ * Per-record `gpu_ts` (inside `records[]`) is the raw FW-written GPU clock
+ * counter. It is NOT translated to the host system clock domain by the
+ * drainer. Consumers join the per-event `gpu_id` against
+ * `rocm_hsa:clock_sync` events carrying the same `gpu_id` to translate
+ * raw GPU clocks into the host system clock. record_type is the raw
+ * FW-written tag (current FW values are 1 and 2; see drain_one_queue).
  *
- * parent_corr_id is always 0 because the drainer thread has no API context
+ * No parent_corr_id is emitted: the drainer thread has no API context
  * (real parent is recovered consumer-side via the
  * rocm_hsa:hsa_doorbell_ring join on (queue_id, dispatch_idx)).
  */
@@ -233,6 +235,13 @@ static inline void rocm_trace_emit_hsa_intercept_packets(uint32_t queue_id,
  * laid out [ts_lo, ts_hi, record_type, dispatch_idx]) under one tracepoint
  * call. The drainer accumulates records during a drain pass and calls this
  * once per pass (or once per kBatchMax records, whichever is smaller).
+ *
+ * `gpu_id` is the KFD node_id of the GPU agent that owns the queue.
+ * Consumers join this against the `gpu_id` field on
+ * `rocm_hsa:clock_sync` to translate the per-record raw GPU clocks into
+ * the host system-clock domain. The drainer caches this value at queue
+ * enable time (see queue_drain_state.gpu_id) and passes it on every
+ * batch emit, so the per-emit cost is a single 32-bit field copy.
  *
  * `records` is a pointer to a contiguous packed array of `count` × 16
  * bytes; `records_len` is `count * 16` (the byte length the LTTng
@@ -244,14 +253,14 @@ static inline void rocm_trace_emit_hsa_intercept_packets(uint32_t queue_id,
  * rates.
  */
 static inline void rocm_trace_emit_hsa_kernel_dispatch_record(
-    uint32_t queue_id, uint32_t count,
+    uint32_t queue_id, uint32_t gpu_id, uint32_t count,
     const uint8_t* records, size_t records_len,
     bool     force_emit /* bypasses the tracepoint-enabled check */) {
     if (rocm_trace_disabled()) return;
     if (force_emit ||
         lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_record)) {
         lttng_ust_do_tracepoint(rocm_hsa, kernel_dispatch_record,
-                                queue_id, count, records, records_len);
+                                queue_id, gpu_id, count, records, records_len);
     }
 }
 
@@ -314,8 +323,8 @@ static inline void rocm_trace_emit_hsa_intercept_packets(uint32_t a, uint64_t b,
     (void)a; (void)b; (void)c; (void)d;
 }
 static inline void rocm_trace_emit_hsa_kernel_dispatch_record(
-    uint32_t a, uint32_t b, const uint8_t* c, size_t d, bool e) {
-    (void)a; (void)b; (void)c; (void)d; (void)e;
+    uint32_t a, uint32_t b, uint32_t c, const uint8_t* d, size_t e, bool f) {
+    (void)a; (void)b; (void)c; (void)d; (void)e; (void)f;
 }
 static inline void rocm_trace_emit_hsa_kernel_dispatch_drop(uint32_t a, uint64_t b) {
     (void)a; (void)b;

--- a/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_trace_emit.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_trace_emit.h
@@ -232,12 +232,18 @@ static inline void rocm_trace_emit_hsa_kernel_dispatch_complete(
     }
 }
 
-/* kernel_dispatch_drop emit helper. Called by the drainer when a ring-overrun
- * is detected (fw_wptr - read_cursor > ring_bytes). Reserved strictly for
- * ring-overrun loss; per-queue enable failures use stderr WARNING per spec
- * §5. force_emit not supported here: drop events are always observed via
- * the tracepoint-enabled gate, since they only fire while the drainer is
- * actively consuming a ring (i.e. while the tracepoint is enabled). */
+/* kernel_dispatch_drop emit helper. The current sentinel-scan drainer
+ * (core/runtime/dispatch_log.cpp::drain_one_queue) cannot detect ring
+ * overruns because the substrate publishes no host-visible FW write
+ * pointer to compare against the host read cursor. As a result no code
+ * path emits this tracepoint today. The definition is retained so a
+ * future overrun-detection mechanism (e.g. a sequence-number gap check
+ * across slots, or a substrate extension that publishes wptr) can emit
+ * it without re-introducing the tracepoint definition. Per-queue enable
+ * failures use stderr WARNING per spec §5. force_emit not supported here:
+ * drop events would always be observed via the tracepoint-enabled gate,
+ * since they would only fire while the drainer is actively consuming a
+ * ring (i.e. while the tracepoint is enabled). */
 static inline void rocm_trace_emit_hsa_kernel_dispatch_drop(uint32_t queue_id,
                                                             uint64_t bytes_lost) {
     if (rocm_trace_disabled()) return;

--- a/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_trace_emit.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_trace_emit.h
@@ -219,9 +219,10 @@ static inline void rocm_trace_emit_hsa_intercept_packets(uint32_t queue_id,
  * would be unachievable. Steady-state drainer passes always pass
  * force_emit=false.
  *
- * gpu_ts_sys is the FW-written GPU clock already translated to the host
- * system clock domain by the drainer (via the per-queue translate_gpu_ts
- * callable). record_type is the raw FW-written tag, narrowed to uint8_t at
+ * gpu_ts is the raw FW-written GPU clock. It is NOT translated to the host
+ * system clock domain by the drainer. The consumer must use the rocm_hsa:clock_sync
+ * tracepoint to correlate this raw GPU timestamp with the system clock.
+ * record_type is the raw FW-written tag, narrowed to uint8_t at
  * the call site (current FW values are 1 and 2; see drain_one_queue).
  *
  * parent_corr_id is always 0 because the drainer thread has no API context
@@ -230,7 +231,7 @@ static inline void rocm_trace_emit_hsa_intercept_packets(uint32_t queue_id,
  */
 static inline void rocm_trace_emit_hsa_kernel_dispatch_record(
     uint32_t queue_id, uint32_t dispatch_idx,
-    uint64_t gpu_ts_sys, uint8_t record_type,
+    uint64_t gpu_ts, uint8_t record_type,
     bool     force_emit /* default false at call site via wrapper */) {
     if (rocm_trace_disabled()) return;
     if (force_emit ||
@@ -238,7 +239,7 @@ static inline void rocm_trace_emit_hsa_kernel_dispatch_record(
         const uint64_t self_corr = rocp_reg_next_corr_id();
         lttng_ust_do_tracepoint(rocm_hsa, kernel_dispatch_record,
                                 queue_id, dispatch_idx,
-                                gpu_ts_sys, record_type,
+                                gpu_ts, record_type,
                                 self_corr, /* parent_corr_id */ (uint64_t)0);
     }
 }
@@ -261,6 +262,17 @@ static inline void rocm_trace_emit_hsa_kernel_dispatch_drop(uint32_t queue_id,
     if (lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_drop)) {
         lttng_ust_do_tracepoint(rocm_hsa, kernel_dispatch_drop,
                                 queue_id, bytes_lost);
+    }
+}
+
+/* clock_sync emit helper. Emits a CPU/GPU clock pair for offline translation. */
+static inline void rocm_trace_emit_hsa_clock_sync(uint64_t gpu_id,
+                                                  uint64_t gpu_ts,
+                                                  uint64_t system_ts) {
+    if (rocm_trace_disabled()) return;
+    if (lttng_ust_tracepoint_enabled(rocm_hsa, clock_sync)) {
+        lttng_ust_do_tracepoint(rocm_hsa, clock_sync,
+                                gpu_id, gpu_ts, system_ts);
     }
 }
 
@@ -298,7 +310,10 @@ static inline void rocm_trace_emit_hsa_kernel_dispatch_record(uint32_t a, uint32
 static inline void rocm_trace_emit_hsa_kernel_dispatch_drop(uint32_t a, uint64_t b) {
     (void)a; (void)b;
 }
+static inline void rocm_trace_emit_hsa_clock_sync(uint64_t a, uint64_t b, uint64_t c) {
+    (void)a; (void)b; (void)c;
+}
 
-#endif
+#endif /* HSA_ENABLE_LTTNG_UST */
 
 #endif /* ROCM_HSA_TRACE_EMIT_H_ */

--- a/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_trace_emit.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_trace_emit.h
@@ -229,18 +229,29 @@ static inline void rocm_trace_emit_hsa_intercept_packets(uint32_t queue_id,
  * (real parent is recovered consumer-side via the
  * rocm_hsa:hsa_doorbell_ring join on (queue_id, dispatch_idx)).
  */
+/* Batched form: emit `count` records (each a 16-byte mec_dispatch_record_16
+ * laid out [ts_lo, ts_hi, record_type, dispatch_idx]) under one tracepoint
+ * call. The drainer accumulates records during a drain pass and calls this
+ * once per pass (or once per kBatchMax records, whichever is smaller).
+ *
+ * `records` is a pointer to a contiguous packed array of `count` × 16
+ * bytes; `records_len` is `count * 16` (the byte length the LTTng
+ * sequence field needs).
+ *
+ * Per-record corr_id is no longer emitted: per-batch unique IDs aren't
+ * useful for the (queue_id, dispatch_idx) join most consumers do, and
+ * the per-record corr_id allocation was a meaningful overhead at sustained
+ * rates.
+ */
 static inline void rocm_trace_emit_hsa_kernel_dispatch_record(
-    uint32_t queue_id, uint32_t dispatch_idx,
-    uint64_t gpu_ts, uint8_t record_type,
-    bool     force_emit /* default false at call site via wrapper */) {
+    uint32_t queue_id, uint32_t count,
+    const uint8_t* records, size_t records_len,
+    bool     force_emit /* bypasses the tracepoint-enabled check */) {
     if (rocm_trace_disabled()) return;
     if (force_emit ||
         lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_record)) {
-        const uint64_t self_corr = rocp_reg_next_corr_id();
         lttng_ust_do_tracepoint(rocm_hsa, kernel_dispatch_record,
-                                queue_id, dispatch_idx,
-                                gpu_ts, record_type,
-                                self_corr, /* parent_corr_id */ (uint64_t)0);
+                                queue_id, count, records, records_len);
     }
 }
 
@@ -302,9 +313,8 @@ static inline void rocm_trace_emit_hsa_doorbell_ring(uint32_t a, int64_t b, uint
 static inline void rocm_trace_emit_hsa_intercept_packets(uint32_t a, uint64_t b, uint32_t c, uint8_t d) {
     (void)a; (void)b; (void)c; (void)d;
 }
-static inline void rocm_trace_emit_hsa_kernel_dispatch_record(uint32_t a, uint32_t b,
-                                                               uint64_t c, uint8_t d,
-                                                               bool e) {
+static inline void rocm_trace_emit_hsa_kernel_dispatch_record(
+    uint32_t a, uint32_t b, const uint8_t* c, size_t d, bool e) {
     (void)a; (void)b; (void)c; (void)d; (void)e;
 }
 static inline void rocm_trace_emit_hsa_kernel_dispatch_drop(uint32_t a, uint64_t b) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_trace_emit.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_trace_emit.h
@@ -203,31 +203,42 @@ static inline void rocm_trace_emit_hsa_intercept_packets(uint32_t queue_id,
 /* Curated per-API typed emit helpers (generated header). */
 #include "rocm_trace_emit_curated.h"
 
-/* kernel_dispatch_complete emit helper. Called ONLY by the firmware-dispatch-
+/* kernel_dispatch_record emit helper. Called ONLY by the firmware-dispatch-
  * log drainer thread (NOT the application thread) from
- * dispatch_log::drain_one_queue. force_emit=true bypasses the per-tracepoint
- * lttng_ust_tracepoint_enabled() guard but NOT the rocm_trace_disabled()
- * kill switch. The bypass is REQUIRED for the disable-edge final drain (Phase
- * A spec §4): by the time final drain runs, the user has already disabled
- * the tracepoint (that disablement is what triggered the disable edge), so
- * the steady-state guard would otherwise return false and the
- * "END records the firmware has already written before wait_for_idle returns
- * are emitted" loss guarantee would be unachievable. Steady-state drainer
- * passes always pass force_emit=false. parent_corr_id is always 0 because
- * the drainer thread has no API context (real parent is recovered consumer-
- * side via the rocm_hsa:hsa_doorbell_ring join on (queue_id, dispatch_idx)).
+ * dispatch_log::drain_one_queue. Emits one event per FW-written 16-byte
+ * record (no host-side START/END pairing — see rocm_hsa_tp.h
+ * kernel_dispatch_record doc comment for the consumer-side join contract).
+ *
+ * force_emit=true bypasses the per-tracepoint lttng_ust_tracepoint_enabled()
+ * guard but NOT the rocm_trace_disabled() kill switch. The bypass is
+ * REQUIRED for the disable-edge final drain (Phase A spec §4): by the time
+ * final drain runs, the user has already disabled the tracepoint (that
+ * disablement is what triggered the disable edge), so the steady-state
+ * guard would otherwise return false and the "records the firmware has
+ * already written before wait_for_idle returns are emitted" loss guarantee
+ * would be unachievable. Steady-state drainer passes always pass
+ * force_emit=false.
+ *
+ * gpu_ts_sys is the FW-written GPU clock already translated to the host
+ * system clock domain by the drainer (via the per-queue translate_gpu_ts
+ * callable). record_type is the raw FW-written tag, narrowed to uint8_t at
+ * the call site (current FW values are 1 and 2; see drain_one_queue).
+ *
+ * parent_corr_id is always 0 because the drainer thread has no API context
+ * (real parent is recovered consumer-side via the
+ * rocm_hsa:hsa_doorbell_ring join on (queue_id, dispatch_idx)).
  */
-static inline void rocm_trace_emit_hsa_kernel_dispatch_complete(
+static inline void rocm_trace_emit_hsa_kernel_dispatch_record(
     uint32_t queue_id, uint32_t dispatch_idx,
-    uint64_t start_ts_sys, uint64_t end_ts_sys,
+    uint64_t gpu_ts_sys, uint8_t record_type,
     bool     force_emit /* default false at call site via wrapper */) {
     if (rocm_trace_disabled()) return;
     if (force_emit ||
-        lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_complete)) {
+        lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_record)) {
         const uint64_t self_corr = rocp_reg_next_corr_id();
-        lttng_ust_do_tracepoint(rocm_hsa, kernel_dispatch_complete,
+        lttng_ust_do_tracepoint(rocm_hsa, kernel_dispatch_record,
                                 queue_id, dispatch_idx,
-                                start_ts_sys, end_ts_sys,
+                                gpu_ts_sys, record_type,
                                 self_corr, /* parent_corr_id */ (uint64_t)0);
     }
 }
@@ -279,9 +290,9 @@ static inline void rocm_trace_emit_hsa_doorbell_ring(uint32_t a, int64_t b, uint
 static inline void rocm_trace_emit_hsa_intercept_packets(uint32_t a, uint64_t b, uint32_t c, uint8_t d) {
     (void)a; (void)b; (void)c; (void)d;
 }
-static inline void rocm_trace_emit_hsa_kernel_dispatch_complete(uint32_t a, uint32_t b,
-                                                                uint64_t c, uint64_t d,
-                                                                bool e) {
+static inline void rocm_trace_emit_hsa_kernel_dispatch_record(uint32_t a, uint32_t b,
+                                                               uint64_t c, uint8_t d,
+                                                               bool e) {
     (void)a; (void)b; (void)c; (void)d; (void)e;
 }
 static inline void rocm_trace_emit_hsa_kernel_dispatch_drop(uint32_t a, uint64_t b) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_trace_emit.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_trace_emit.h
@@ -283,14 +283,23 @@ static inline void rocm_trace_emit_hsa_kernel_dispatch_record(
  * Per-queue ENABLE failures still use stderr WARNING per spec §5;
  * those are configuration / substrate problems, not record-loss events.
  *
- * force_emit not supported here: drop events would always be observed
- * via the tracepoint-enabled gate, since they would only fire while
- * the drainer is actively consuming a ring (i.e. while the tracepoint
- * is enabled). */
-static inline void rocm_trace_emit_hsa_kernel_dispatch_drop(uint32_t queue_id,
-                                                            uint64_t bytes_lost) {
+ * force_emit=true bypasses the per-tracepoint lttng_ust_tracepoint_enabled()
+ * guard but NOT the rocm_trace_disabled() kill switch. The bypass is
+ * REQUIRED for the disable-edge final drain (Phase A spec §4): drop events
+ * can fire from inside the final drain pass (overrun detection at
+ * drain_one_queue start, and stale-zero-prefix sweep), and by the time
+ * final drain runs the user has already disabled the tracepoint (that
+ * disablement is what triggered the disable edge). Without the bypass,
+ * the consumer would receive the post-disable record batch with a
+ * silently-dropped gap and no kernel_dispatch_drop event explaining it.
+ * Steady-state drainer passes always pass force_emit=false so the
+ * normal per-tracepoint enabled gate applies. */
+static inline void rocm_trace_emit_hsa_kernel_dispatch_drop(
+    uint32_t queue_id, uint64_t bytes_lost,
+    bool     force_emit /* bypasses the tracepoint-enabled check */) {
     if (rocm_trace_disabled()) return;
-    if (lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_drop)) {
+    if (force_emit ||
+        lttng_ust_tracepoint_enabled(rocm_hsa, kernel_dispatch_drop)) {
         lttng_ust_do_tracepoint(rocm_hsa, kernel_dispatch_drop,
                                 queue_id, bytes_lost);
     }
@@ -337,8 +346,8 @@ static inline void rocm_trace_emit_hsa_kernel_dispatch_record(
     uint32_t a, uint32_t b, uint32_t c, const uint8_t* d, size_t e, bool f) {
     (void)a; (void)b; (void)c; (void)d; (void)e; (void)f;
 }
-static inline void rocm_trace_emit_hsa_kernel_dispatch_drop(uint32_t a, uint64_t b) {
-    (void)a; (void)b;
+static inline void rocm_trace_emit_hsa_kernel_dispatch_drop(uint32_t a, uint64_t b, bool c) {
+    (void)a; (void)b; (void)c;
 }
 static inline void rocm_trace_emit_hsa_clock_sync(uint64_t a, uint64_t b, uint64_t c) {
     (void)a; (void)b; (void)c;

--- a/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_trace_emit.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_trace_emit.h
@@ -264,18 +264,29 @@ static inline void rocm_trace_emit_hsa_kernel_dispatch_record(
     }
 }
 
-/* kernel_dispatch_drop emit helper. The current sentinel-scan drainer
- * (core/runtime/dispatch_log.cpp::drain_one_queue) cannot detect ring
- * overruns because the substrate publishes no host-visible FW write
- * pointer to compare against the host read cursor. As a result no code
- * path emits this tracepoint today. The definition is retained so a
- * future overrun-detection mechanism (e.g. a sequence-number gap check
- * across slots, or a substrate extension that publishes wptr) can emit
- * it without re-introducing the tracepoint definition. Per-queue enable
- * failures use stderr WARNING per spec §5. force_emit not supported here:
- * drop events would always be observed via the tracepoint-enabled gate,
- * since they would only fire while the drainer is actively consuming a
- * ring (i.e. while the tracepoint is enabled). */
+/* kernel_dispatch_drop emit helper. Emitted by the signal-bound drain
+ * path (core/runtime/dispatch_log.cpp::drain_one_queue Path A) when the
+ * host falls behind FW by more than ring_records: i.e. when
+ * (observed_signal - next_idx) > ring_records the older
+ * ((observed_signal - next_idx) - ring_records) records have been
+ * silently overwritten by FW (FW does not stall on full ring), and
+ * the drainer emits this event with bytes_lost = the number of lost
+ * records.
+ *
+ * NOT emitted on the sentinel-scan fallback path (Path B, older kernels
+ * without the host-VA wptr/signal pointer set), because that path has
+ * no out-of-band write-pointer to compare against. Also NOT emitted
+ * during init-sync (next_idx == 0 first observation): the pre-zeroed
+ * gap between slot 0 and the first FW-written slot is not a real
+ * drop — those records never existed for this queue lifecycle.
+ *
+ * Per-queue ENABLE failures still use stderr WARNING per spec §5;
+ * those are configuration / substrate problems, not record-loss events.
+ *
+ * force_emit not supported here: drop events would always be observed
+ * via the tracepoint-enabled gate, since they would only fire while
+ * the drainer is actively consuming a ring (i.e. while the tracepoint
+ * is enabled). */
 static inline void rocm_trace_emit_hsa_kernel_dispatch_drop(uint32_t queue_id,
                                                             uint64_t bytes_lost) {
     if (rocm_trace_disabled()) return;

--- a/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_trace_emit.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_trace_emit.h
@@ -265,20 +265,17 @@ static inline void rocm_trace_emit_hsa_kernel_dispatch_record(
 }
 
 /* kernel_dispatch_drop emit helper. Emitted by the signal-bound drain
- * path (core/runtime/dispatch_log.cpp::drain_one_queue Path A) when the
- * host falls behind FW by more than ring_records: i.e. when
+ * path (core/runtime/dispatch_log.cpp::drain_one_queue) when the host
+ * falls behind FW by more than ring_records: i.e. when
  * (observed_signal - next_idx) > ring_records the older
  * ((observed_signal - next_idx) - ring_records) records have been
  * silently overwritten by FW (FW does not stall on full ring), and
  * the drainer emits this event with bytes_lost = the number of lost
  * records.
  *
- * NOT emitted on the sentinel-scan fallback path (Path B, older kernels
- * without the host-VA wptr/signal pointer set), because that path has
- * no out-of-band write-pointer to compare against. Also NOT emitted
- * during init-sync (next_idx == 0 first observation): the pre-zeroed
- * gap between slot 0 and the first FW-written slot is not a real
- * drop — those records never existed for this queue lifecycle.
+ * NOT emitted during init-sync (next_idx == 0 first observation): the
+ * pre-zeroed gap between slot 0 and the first FW-written slot is not a
+ * real drop — those records never existed for this queue lifecycle.
  *
  * Per-queue ENABLE failures still use stderr WARNING per spec §5;
  * those are configuration / substrate problems, not record-loss events.

--- a/projects/rocr-runtime/runtime/hsa-runtime/scripts/lttng_migration_inventory.txt
+++ b/projects/rocr-runtime/runtime/hsa-runtime/scripts/lttng_migration_inventory.txt
@@ -208,3 +208,5 @@ hsa_amd_queue_intercept_create	STATUS	hsa_status_t
 hsa_amd_queue_intercept_register	STATUS	hsa_status_t
 hsa_amd_queue_iterate	STATUS	hsa_status_t
 hsa_amd_profiling_get_dispatch_records	STATUS	hsa_status_t
+hsa_amd_dispatch_log_test_enable	NO_LTTNG	test-only API
+hsa_amd_dispatch_log_test_get_state	NO_LTTNG	test-only API

--- a/projects/rocr-runtime/runtime/hsa-runtime/scripts/lttng_migration_inventory.txt
+++ b/projects/rocr-runtime/runtime/hsa-runtime/scripts/lttng_migration_inventory.txt
@@ -206,3 +206,5 @@ hsa_amd_svm_discard_batch_async	STATUS	hsa_status_t
 hsa_amd_signal_get_event_id	STATUS	hsa_status_t
 hsa_amd_queue_intercept_create	STATUS	hsa_status_t
 hsa_amd_queue_intercept_register	STATUS	hsa_status_t
+hsa_amd_queue_iterate	STATUS	hsa_status_t
+hsa_amd_profiling_get_dispatch_records	STATUS	hsa_status_t

--- a/projects/rocr-runtime/runtime/hsa-runtime/test/lttng/test_hsa_dispatch_log.sh
+++ b/projects/rocr-runtime/runtime/hsa-runtime/test/lttng/test_hsa_dispatch_log.sh
@@ -9,7 +9,11 @@
 #      HIP-or-AQL kernel dispatch (via square sample if available, falls
 #      back to skip with INFO) should produce one or more
 #      rocm_hsa:kernel_dispatch_record events, each carrying
-#      (queue_id, count, records[count*16]) per the batched schema.
+#      (queue_id, gpu_id, count, records[count*16]) per the batched
+#      schema. The gpu_id field is the KFD node_id of the GPU agent
+#      that owns the queue and is the join key against
+#      rocm_hsa:clock_sync.gpu_id for offline raw-gpu_ts -> system_ts
+#      translation (spec 2026-04-27 §6 / §10).
 #
 #   2. Clock-sync path. The clock_sync poller (started from
 #      Runtime::Load) should produce at least one rocm_hsa:clock_sync
@@ -158,10 +162,27 @@ if [ "$N_DLOG" -eq 0 ]; then
 else
     SAMPLE_DLOG=$(grep 'rocm_hsa:kernel_dispatch_record' "$LOG_DLOG" | head -1)
     echo "$SAMPLE_DLOG" | grep -q 'queue_id'    || fail "kernel_dispatch_record missing queue_id field"
+    # gpu_id is the join key against rocm_hsa:clock_sync.gpu_id; without
+    # it consumers cannot translate the batched raw gpu_ts values into
+    # the host system clock domain. Spec §6 / §10.
+    echo "$SAMPLE_DLOG" | grep -q 'gpu_id'      || fail "kernel_dispatch_record missing gpu_id field"
     echo "$SAMPLE_DLOG" | grep -q 'count'       || fail "kernel_dispatch_record missing count field"
     echo "$SAMPLE_DLOG" | grep -q 'records'     || fail "kernel_dispatch_record missing records[] sequence"
     echo "$SAMPLE_DLOG" | grep -q '_records_length' \
         || fail "kernel_dispatch_record missing records sequence length"
+
+    # Cross-check: every gpu_id observed on a kernel_dispatch_record event
+    # must also appear on at least one clock_sync event in the same trace,
+    # otherwise the timestamp-translation contract is unfulfilled.
+    DLOG_GPU_IDS=$(grep 'rocm_hsa:kernel_dispatch_record' "$LOG_DLOG" \
+        | sed -n 's/.*gpu_id = \([0-9]*\).*/\1/p' | sort -u)
+    CS_GPU_IDS=$(grep 'rocm_hsa:clock_sync' "$LOG_DLOG" \
+        | sed -n 's/.*gpu_id = \([0-9]*\).*/\1/p' | sort -u)
+    for gid in $DLOG_GPU_IDS; do
+        if ! echo "$CS_GPU_IDS" | grep -qx "$gid"; then
+            fail "kernel_dispatch_record gpu_id=$gid has no matching rocm_hsa:clock_sync event in trace; offline gpu_ts translation would be impossible"
+        fi
+    done
 
     # Schema invariant: records_length must be a multiple of 16
     # (each record is exactly mec_dispatch_record_16). babeltrace2

--- a/projects/rocr-runtime/runtime/hsa-runtime/test/lttng/test_hsa_dispatch_log.sh
+++ b/projects/rocr-runtime/runtime/hsa-runtime/test/lttng/test_hsa_dispatch_log.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# End-to-end validation of the rocm_hsa:kernel_dispatch_record and
+# rocm_hsa:clock_sync tracepoints emitted by the dispatch_log + clock_sync
+# subsystems (Phase A spec 2026-04-27 §8 and clock_sync sub-system).
+#
+# What this test exercises:
+#
+#   1. Kernel-dispatch-record path. With dispatch_log enabled, a
+#      HIP-or-AQL kernel dispatch (via square sample if available, falls
+#      back to skip with INFO) should produce one or more
+#      rocm_hsa:kernel_dispatch_record events, each carrying
+#      (queue_id, count, records[count*16]) per the batched schema.
+#
+#   2. Clock-sync path. The clock_sync poller (started from
+#      Runtime::Load) should produce at least one rocm_hsa:clock_sync
+#      event per GPU agent within the sync interval, carrying
+#      (gpu_id, gpu_ts, system_ts).
+#
+#   3. Schema invariants. Every kernel_dispatch_record event must have
+#      a non-zero count; records_len must equal count * 16;
+#      queue_id must be a small, sane value (i.e. within the per-process
+#      queue-id range, not garbage memory).
+#
+# Usage:
+#   test_hsa_dispatch_log.sh [<build_dir>]
+#
+# <build_dir> defaults to $PWD/build/rocr.
+#
+# Requirements:
+#   - libhsa-runtime64.so built with HSA_ENABLE_LTTNG_UST=1
+#   - lttng-tools, babeltrace2, lttng-ust on PATH
+#   - KFD substrate that supports dispatch_log (KFD minor >= 22). If
+#     absent the dispatch_log assertion is downgraded to a skip-with-INFO
+#     because the runtime poller will refuse to enable.
+#
+# Exits 0 on PASS, non-zero on assertion failure. INFO-level skips are
+# NOT failures.
+
+set -euo pipefail
+
+BUILD_DIR="${1:-$PWD/build/rocr}"
+LIB_DIR="$BUILD_DIR/rocr/lib"
+
+if [ ! -f "$LIB_DIR/libhsa-runtime64.so" ]; then
+    echo "FAIL: $LIB_DIR/libhsa-runtime64.so not found"
+    exit 1
+fi
+
+TRACE_DIR="$(mktemp -d)"
+cleanup() {
+    set +e
+    pkill -P $$ 2>/dev/null
+    if [ -n "${SESSIOND_PIDFILE:-}" ] && [ -f "$SESSIOND_PIDFILE" ]; then
+        kill "$(cat "$SESSIOND_PIDFILE")" 2>/dev/null || true
+    fi
+    rm -rf "$TRACE_DIR"
+}
+trap cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+info() { echo "INFO: $*"; }
+
+# A HIP dispatch program is the most reliable way to exercise the
+# kernel_dispatch_record path because HIP routes through hsa_queue_create
+# and the AQL kernel-dispatch packet path. Build the standard square
+# sample if hipcc + a sample tree are present.
+HIP_DISPATCH_BIN=""
+if command -v /opt/rocm/bin/hipcc >/dev/null 2>&1 \
+   && [ -f /opt/rocm/share/hip/samples/0_Intro/square/square.hipref.cpp ]; then
+    cp /opt/rocm/share/hip/samples/0_Intro/square/square.hipref.cpp "$TRACE_DIR/square.cpp"
+    if /opt/rocm/bin/hipcc "$TRACE_DIR/square.cpp" -o "$TRACE_DIR/square" \
+        >"$TRACE_DIR/hipcc.log" 2>&1; then
+        HIP_DISPATCH_BIN="$TRACE_DIR/square"
+    else
+        info "hipcc compile failed; dispatch_log assertion will be skipped."
+    fi
+fi
+
+# Per-user lttng-sessiond, scoped to this test by LTTNG_HOME and pidfile.
+export LTTNG_HOME="$TRACE_DIR/lttng-home"
+mkdir -p "$LTTNG_HOME"
+SESSIOND_PIDFILE="$TRACE_DIR/sessiond.pid"
+lttng-sessiond --daemonize --no-kernel --pidfile="$SESSIOND_PIDFILE"
+for i in 1 2 3 4 5; do
+    [ -f "$SESSIOND_PIDFILE" ] && break
+    sleep 0.5
+done
+
+# ============================================================
+# Run 1: kernel_dispatch_record + clock_sync from a HIP dispatch
+# ============================================================
+SESSION_DLOG="hsa-dispatch-log-test-$$"
+lttng create "$SESSION_DLOG" --output="$TRACE_DIR/trace_dlog" >/dev/null
+# Larger sub-buffer here than the api test because dispatch_log batches
+# can be up to 256 × 16 = 4096 B per event, and the clock_sync events
+# are emitted at 100 ms intervals so we want at least a few seconds of
+# headroom.
+lttng enable-channel --userspace --discard --subbuf-size=65536 --num-subbuf=4 default >/dev/null
+lttng enable-event --userspace -c default 'rocm_hsa:kernel_dispatch_record,rocm_hsa:clock_sync' >/dev/null
+lttng start "$SESSION_DLOG" >/dev/null
+
+# Speed up the clock_sync interval so a short test still captures events.
+export HSA_CLOCK_SYNC_INTERVAL_MS=50
+
+if [ -n "$HIP_DISPATCH_BIN" ]; then
+    LD_LIBRARY_PATH="$LIB_DIR:/opt/rocm/lib:${LD_LIBRARY_PATH:-}" \
+        "$HIP_DISPATCH_BIN" >"$TRACE_DIR/dispatch.log" 2>&1 || true
+else
+    # No HIP available — still need to spin up the runtime so the
+    # clock_sync poller emits at least one event.
+    cat > "$TRACE_DIR/spin.c" <<'EOF'
+#include <hsa/hsa.h>
+#include <unistd.h>
+int main(void) {
+    if (hsa_init() != HSA_STATUS_SUCCESS) return 1;
+    /* Sleep > clock_sync interval so the poller fires at least once. */
+    usleep(500 * 1000);
+    hsa_shut_down();
+    return 0;
+}
+EOF
+    cc "$TRACE_DIR/spin.c" -o "$TRACE_DIR/spin" \
+        -I/opt/rocm/include -L"$LIB_DIR" -lhsa-runtime64 \
+        -Wl,-rpath,"$LIB_DIR"
+    LD_LIBRARY_PATH="$LIB_DIR:${LD_LIBRARY_PATH:-}" \
+        "$TRACE_DIR/spin" || true
+fi
+
+lttng stop "$SESSION_DLOG" >/dev/null
+lttng destroy "$SESSION_DLOG" >/dev/null
+
+LOG_DLOG="$TRACE_DIR/babeltrace_dlog.log"
+babeltrace2 "$TRACE_DIR/trace_dlog" > "$LOG_DLOG" 2>/dev/null || true
+
+# --- clock_sync assertions ---------------------------------------------
+N_CLOCK_SYNC=$(grep -c 'rocm_hsa:clock_sync' "$LOG_DLOG" || true)
+if [ "$N_CLOCK_SYNC" -eq 0 ]; then
+    fail "expected at least one rocm_hsa:clock_sync event, got none"
+fi
+
+# Schema check: each event must have gpu_id, gpu_ts, system_ts non-empty.
+SAMPLE_CS=$(grep 'rocm_hsa:clock_sync' "$LOG_DLOG" | head -1)
+echo "$SAMPLE_CS" | grep -q 'gpu_id'    || fail "clock_sync missing gpu_id field"
+echo "$SAMPLE_CS" | grep -q 'gpu_ts'    || fail "clock_sync missing gpu_ts field"
+echo "$SAMPLE_CS" | grep -q 'system_ts' || fail "clock_sync missing system_ts field"
+
+# --- kernel_dispatch_record assertions ---------------------------------
+N_DLOG=$(grep -c 'rocm_hsa:kernel_dispatch_record' "$LOG_DLOG" || true)
+if [ "$N_DLOG" -eq 0 ]; then
+    if [ -z "$HIP_DISPATCH_BIN" ]; then
+        info "no kernel_dispatch_record events (no HIP dispatch program available); skipping"
+    else
+        # HIP ran but no events -> KFD substrate missing or runtime not
+        # built with LTTng UST. Downgrade to INFO since this depends on
+        # host capabilities, not the code under review.
+        info "no kernel_dispatch_record events despite HIP dispatch — likely KFD minor < 22 or LTTng-UST disabled in build; skipping schema asserts"
+    fi
+else
+    SAMPLE_DLOG=$(grep 'rocm_hsa:kernel_dispatch_record' "$LOG_DLOG" | head -1)
+    echo "$SAMPLE_DLOG" | grep -q 'queue_id'    || fail "kernel_dispatch_record missing queue_id field"
+    echo "$SAMPLE_DLOG" | grep -q 'count'       || fail "kernel_dispatch_record missing count field"
+    echo "$SAMPLE_DLOG" | grep -q 'records'     || fail "kernel_dispatch_record missing records[] sequence"
+    echo "$SAMPLE_DLOG" | grep -q '_records_length' \
+        || fail "kernel_dispatch_record missing records sequence length"
+
+    # Schema invariant: records_length must be a multiple of 16
+    # (each record is exactly mec_dispatch_record_16). babeltrace2
+    # prints the sequence length as `_records_length = N`.
+    LEN=$(echo "$SAMPLE_DLOG" | sed -n 's/.*_records_length = \([0-9]*\).*/\1/p')
+    if [ -z "$LEN" ]; then
+        fail "could not parse _records_length from sample event"
+    fi
+    if [ $((LEN % 16)) -ne 0 ]; then
+        fail "_records_length=$LEN is not a multiple of 16 (FW record size)"
+    fi
+    COUNT=$(echo "$SAMPLE_DLOG" | sed -n 's/.*count = \([0-9]*\).*/\1/p')
+    if [ -z "$COUNT" ] || [ "$COUNT" -le 0 ]; then
+        fail "count=$COUNT must be > 0 in a published event"
+    fi
+    if [ $((COUNT * 16)) -ne "$LEN" ]; then
+        fail "count*16 ($((COUNT * 16))) != _records_length ($LEN); batched schema invariant broken"
+    fi
+fi
+
+echo "PASS hsa_dispatch_log: clock_sync_events=$N_CLOCK_SYNC kernel_dispatch_record_events=$N_DLOG"

--- a/projects/rocr-runtime/runtime/hsa-runtime/test/lttng/test_hsa_dispatch_log_accounting.sh
+++ b/projects/rocr-runtime/runtime/hsa-runtime/test/lttng/test_hsa_dispatch_log_accounting.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Accounting-invariant test for the dispatch_log drainer.
+#
+# Locks in the invariant from the HEAD `31adf3c1e1` investigation:
+#
+#   For every queue that participated in dispatch_log, the per-queue
+#   diagnostic counters dumped at queue disable MUST satisfy
+#
+#     emitted + zero_swept + drop_overrun == sig_max - sig_init
+#
+# This is the strongest correctness gate we have on the drainer: it
+# proves that every FW signal-counter advance was placed in exactly one
+# of the three buckets (real records emitted via LTTng, stale-zero
+# slots quarantine-swept, or overrun-skipped). A regression that
+# silently dropped records without accounting (e.g. the pre-fix
+# init-sync overrun-skip) would produce sig_max - sig_init >
+# emitted + zero_swept + drop_overrun and this test would FAIL.
+#
+# Mechanics:
+#   1. Pick a workload that creates and exercises ≥ 1 dispatch_log
+#      queue. We use the in-tree hipcc-built square sample (same as
+#      test_hsa_dispatch_log.sh) because it routes through the public
+#      hsa_queue_create path that triggers the dispatch_log enable
+#      sequence. If hipcc is unavailable we fall back to a tiny HSA-only
+#      AQL dispatch via the test API.
+#   2. Run the workload under LTTng with HSA_DISPATCH_LOG_DIAG_LOSS=1.
+#      The runtime emits one [DIAG_LOSS] line per queue at disable.
+#   3. Parse each [DIAG_LOSS] line. For each queue with sig_span > 0,
+#      assert emitted+zero_swept+drop_overrun == sig_span. Idle queues
+#      (sig_span == 0) are reported as INFO and skipped.
+#
+# Usage: $0 [<build_dir>]
+# <build_dir> defaults to $PWD/build/rocr.
+
+set -euo pipefail
+
+BUILD_DIR="${1:-$PWD/build/rocr}"
+LIB_DIR="$BUILD_DIR/rocr/lib"
+
+if [ ! -f "$LIB_DIR/libhsa-runtime64.so" ]; then
+    echo "FAIL: $LIB_DIR/libhsa-runtime64.so not found"
+    exit 1
+fi
+
+TRACE_DIR="$(mktemp -d)"
+cleanup() {
+    set +e
+    pkill -P $$ 2>/dev/null
+    if [ -n "${SESSIOND_PIDFILE:-}" ] && [ -f "$SESSIOND_PIDFILE" ]; then
+        kill "$(cat "$SESSIOND_PIDFILE")" 2>/dev/null || true
+    fi
+    rm -rf "$TRACE_DIR"
+}
+trap cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+info() { echo "INFO: $*"; }
+
+# Build a kernel-dispatching workload. Prefer hipcc square (well-tested,
+# triggers the drainer reliably). If unavailable, INFO-skip with reason.
+WORKLOAD_BIN=""
+if command -v /opt/rocm/bin/hipcc >/dev/null 2>&1 \
+   && [ -f /opt/rocm/share/hip/samples/0_Intro/square/square.hipref.cpp ]; then
+    cp /opt/rocm/share/hip/samples/0_Intro/square/square.hipref.cpp "$TRACE_DIR/square.cpp"
+    if /opt/rocm/bin/hipcc "$TRACE_DIR/square.cpp" -o "$TRACE_DIR/square" \
+        >"$TRACE_DIR/hipcc.log" 2>&1; then
+        WORKLOAD_BIN="$TRACE_DIR/square"
+    fi
+fi
+
+if [ -z "$WORKLOAD_BIN" ]; then
+    info "hipcc square not available; accounting-invariant test SKIPPED"
+    info "(this test requires a HIP-or-AQL kernel dispatch workload to"
+    info "exercise the drainer; see test_hsa_dispatch_log.sh for the same"
+    info "preconditions)"
+    exit 0
+fi
+
+# Per-user lttng-sessiond, scoped to this test.
+export LTTNG_HOME="$TRACE_DIR/lttng-home"
+mkdir -p "$LTTNG_HOME"
+SESSIOND_PIDFILE="$TRACE_DIR/sessiond.pid"
+lttng-sessiond --daemonize --no-kernel --pidfile="$SESSIOND_PIDFILE"
+for i in 1 2 3 4 5; do
+    [ -f "$SESSIOND_PIDFILE" ] && break
+    sleep 0.5
+done
+[ -f "$SESSIOND_PIDFILE" ] || fail "lttng-sessiond did not start"
+
+lttng create accounting-test --output="$TRACE_DIR/trace" >/dev/null
+lttng enable-event --userspace 'rocm_hsa:kernel_dispatch_record' >/dev/null
+lttng enable-event --userspace 'rocm_hsa:kernel_dispatch_drop'   >/dev/null
+lttng start >/dev/null
+
+# Run workload with HSA_DISPATCH_LOG_DIAG_LOSS=1. stderr captures the
+# per-queue DIAG_LOSS lines emitted at queue disable.
+DIAG_LOG="$TRACE_DIR/diag.log"
+HSA_DISPATCH_LOG_DIAG_LOSS=1 \
+    LD_LIBRARY_PATH="$LIB_DIR:${LD_LIBRARY_PATH:-}" \
+    "$WORKLOAD_BIN" >"$TRACE_DIR/workload.stdout" 2>"$DIAG_LOG" \
+    || fail "workload exited non-zero (see $TRACE_DIR/workload.stdout / $DIAG_LOG)"
+
+lttng stop    >/dev/null
+lttng destroy >/dev/null
+
+# Extract DIAG_LOSS lines. Format (one line per queue, dumped from
+# disable_dispatch_log_for_queue_locked):
+#   [DIAG_LOSS] q=0xN gpu=N sig_init=N sig_max=N sig_span=N \
+#     emitted=N zero_swept=N drop_overrun=N accounted=N \
+#     passes=N passes_with_work=N
+DIAG_LINES="$(grep '^\[DIAG_LOSS\]' "$DIAG_LOG" || true)"
+
+if [ -z "$DIAG_LINES" ]; then
+    fail "no [DIAG_LOSS] lines in workload stderr; either the env var did not propagate, or no queue ever enabled dispatch_log (see $DIAG_LOG)"
+fi
+
+# Parse each DIAG_LOSS line and assert the accounting invariant.
+NUM_QUEUES=0
+NUM_ACTIVE=0
+NUM_FAIL=0
+while IFS= read -r line; do
+    NUM_QUEUES=$((NUM_QUEUES + 1))
+    # Extract numeric fields. The format is stable; use a per-key sed.
+    QID=$(echo "$line" | sed -n 's/.*q=\(0x[0-9a-fA-F]\+\).*/\1/p')
+    SIG_INIT=$(echo "$line"     | sed -n 's/.*sig_init=\([0-9]\+\).*/\1/p')
+    SIG_MAX=$(echo "$line"      | sed -n 's/.*sig_max=\([0-9]\+\).*/\1/p')
+    SIG_SPAN=$(echo "$line"     | sed -n 's/.*sig_span=\([0-9]\+\).*/\1/p')
+    EMITTED=$(echo "$line"      | sed -n 's/.*emitted=\([0-9]\+\).*/\1/p')
+    ZERO_SWEPT=$(echo "$line"   | sed -n 's/.*zero_swept=\([0-9]\+\).*/\1/p')
+    DROP_OVERRUN=$(echo "$line" | sed -n 's/.*drop_overrun=\([0-9]\+\).*/\1/p')
+    ACCOUNTED=$(echo "$line"    | sed -n 's/.*accounted=\([0-9]\+\).*/\1/p')
+
+    for v in QID SIG_INIT SIG_MAX SIG_SPAN EMITTED ZERO_SWEPT DROP_OVERRUN ACCOUNTED; do
+        if [ -z "${!v}" ]; then
+            fail "could not parse $v from DIAG_LOSS line: $line"
+        fi
+    done
+
+    # Idle queue: nothing to assert. Report and skip.
+    if [ "$SIG_SPAN" = "0" ]; then
+        info "queue $QID idle (sig_span=0); no accounting check"
+        continue
+    fi
+    NUM_ACTIVE=$((NUM_ACTIVE + 1))
+
+    # The runtime computes ACCOUNTED = emitted + zero_swept + drop_overrun
+    # in disable_dispatch_log_for_queue_locked when it formats the line.
+    # We re-derive it here to guard against a future refactor that breaks
+    # the runtime's own sum.
+    EXPECTED=$((EMITTED + ZERO_SWEPT + DROP_OVERRUN))
+    if [ "$ACCOUNTED" != "$EXPECTED" ]; then
+        echo "FAIL queue $QID: runtime printed accounted=$ACCOUNTED but emitted+zero_swept+drop_overrun=$EXPECTED" >&2
+        NUM_FAIL=$((NUM_FAIL + 1))
+    fi
+
+    # The accounting invariant we actually care about.
+    if [ "$ACCOUNTED" != "$SIG_SPAN" ]; then
+        echo "FAIL queue $QID: accounted=$ACCOUNTED != sig_span=$SIG_SPAN (diff=$((SIG_SPAN - ACCOUNTED))); records vanished from drainer accounting" >&2
+        echo "  sig_init=$SIG_INIT sig_max=$SIG_MAX emitted=$EMITTED zero_swept=$ZERO_SWEPT drop_overrun=$DROP_OVERRUN" >&2
+        NUM_FAIL=$((NUM_FAIL + 1))
+    fi
+done <<< "$DIAG_LINES"
+
+if [ "$NUM_FAIL" -gt 0 ]; then
+    fail "$NUM_FAIL queue(s) failed accounting invariant out of $NUM_ACTIVE active ($NUM_QUEUES total)"
+fi
+
+if [ "$NUM_ACTIVE" = 0 ]; then
+    info "no active dispatch_log queues observed (workload may be too short or KFD substrate may not support dispatch_log); accounting invariant has nothing to assert against"
+    info "(this is not a FAIL but the test's coverage is degenerate)"
+fi
+
+info "PASS: accounting invariant held on $NUM_ACTIVE active queue(s) ($NUM_QUEUES total)"
+exit 0

--- a/projects/rocr-runtime/runtime/hsa-runtime/test/lttng/test_hsa_dispatch_log_init_sync.sh
+++ b/projects/rocr-runtime/runtime/hsa-runtime/test/lttng/test_hsa_dispatch_log_init_sync.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Init-sync no-phantom-records test for the dispatch_log drainer.
+#
+# Locks in the invariant from the C7+C8+C9 unified zero-rt-stop fix
+# and the C2-round-2 fresh-vs-re-enable distinction:
+#
+#   On any FIRST observation of a queue (next_idx == 0 or freshly
+#   allocated buffer with FW per-pipe scratch wptr persisted to a
+#   high signal value), the drainer MUST NOT emit any
+#   kernel_dispatch_record event whose payload is all-zero
+#   record_type slots. Pre-zeroed slots are recognized via the
+#   record_type==0 stop and either:
+#     - quarantine-swept with a kernel_dispatch_drop
+#     - silently overrun-skipped (init-sync == true case at the
+#       overrun guard)
+#   but never wrapped into a kernel_dispatch_record event payload.
+#
+# A regression here would surface as kernel_dispatch_record events
+# whose 16-byte record bodies decode to ts_lo=0, ts_hi=0,
+# record_type=0, dispatch_idx=0 — phantom records from pre-zeroed
+# ring slots that the drainer should have skipped. Consumers
+# reading these as real records would see all kernels appearing to
+# execute at gpu_ts=0 with type=0 (= "unknown event tag").
+#
+# Mechanics:
+#   1. Run a workload that creates fresh queues. The hipcc square
+#      sample creates a fresh HIP queue per process; we drive it
+#      under LTTng.
+#   2. Decode the trace and walk every kernel_dispatch_record event.
+#      For each event, decode the packed records[count*16] payload
+#      and assert that no record has all four DWORDs zero.
+#   3. Also assert at least one record has nonzero contents (proves
+#      we are exercising the path; otherwise the test could pass
+#      trivially with zero records).
+#
+# Usage: $0 [<build_dir>]
+
+set -euo pipefail
+
+BUILD_DIR="${1:-$PWD/build/rocr}"
+LIB_DIR="$BUILD_DIR/rocr/lib"
+
+if [ ! -f "$LIB_DIR/libhsa-runtime64.so" ]; then
+    echo "FAIL: $LIB_DIR/libhsa-runtime64.so not found"
+    exit 1
+fi
+
+TRACE_DIR="$(mktemp -d)"
+cleanup() {
+    set +e
+    pkill -P $$ 2>/dev/null
+    if [ -n "${SESSIOND_PIDFILE:-}" ] && [ -f "$SESSIOND_PIDFILE" ]; then
+        kill "$(cat "$SESSIOND_PIDFILE")" 2>/dev/null || true
+    fi
+    rm -rf "$TRACE_DIR"
+}
+trap cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+info() { echo "INFO: $*"; }
+
+# Need a kernel-dispatching workload. Use hipcc square if available.
+WORKLOAD_BIN=""
+if command -v /opt/rocm/bin/hipcc >/dev/null 2>&1 \
+   && [ -f /opt/rocm/share/hip/samples/0_Intro/square/square.hipref.cpp ]; then
+    cp /opt/rocm/share/hip/samples/0_Intro/square/square.hipref.cpp "$TRACE_DIR/square.cpp"
+    if /opt/rocm/bin/hipcc "$TRACE_DIR/square.cpp" -o "$TRACE_DIR/square" \
+        >"$TRACE_DIR/hipcc.log" 2>&1; then
+        WORKLOAD_BIN="$TRACE_DIR/square"
+    fi
+fi
+
+if [ -z "$WORKLOAD_BIN" ]; then
+    info "hipcc square not available; init-sync no-phantom test SKIPPED"
+    exit 0
+fi
+
+# Per-user lttng-sessiond, scoped to this test.
+export LTTNG_HOME="$TRACE_DIR/lttng-home"
+mkdir -p "$LTTNG_HOME"
+SESSIOND_PIDFILE="$TRACE_DIR/sessiond.pid"
+lttng-sessiond --daemonize --no-kernel --pidfile="$SESSIOND_PIDFILE"
+for i in 1 2 3 4 5; do
+    [ -f "$SESSIOND_PIDFILE" ] && break
+    sleep 0.5
+done
+[ -f "$SESSIOND_PIDFILE" ] || fail "lttng-sessiond did not start"
+
+lttng create init-sync-test --output="$TRACE_DIR/trace" >/dev/null
+lttng enable-event --userspace 'rocm_hsa:kernel_dispatch_record' >/dev/null
+lttng start >/dev/null
+
+LD_LIBRARY_PATH="$LIB_DIR:${LD_LIBRARY_PATH:-}" \
+    "$WORKLOAD_BIN" >"$TRACE_DIR/workload.stdout" 2>"$TRACE_DIR/workload.stderr" \
+    || fail "workload exited non-zero (see $TRACE_DIR/workload.stderr)"
+
+lttng stop    >/dev/null
+lttng destroy >/dev/null
+
+# Decode the trace. babeltrace2 prints each record event on a single
+# line including the records[] field as a brace-list of byte values.
+# We walk those byte lists in groups of 16 (per record) and check for
+# all-zero records.
+DECODED="$TRACE_DIR/trace.txt"
+babeltrace2 "$TRACE_DIR/trace" >"$DECODED" 2>/dev/null \
+    || fail "babeltrace2 failed on $TRACE_DIR/trace"
+
+# Use Python (available in any reasonable test env) for the byte-walk.
+# This is more robust than awk for the records[] brace-list parsing.
+python3 - "$DECODED" <<'PY'
+import re, sys
+path = sys.argv[1]
+total_events = 0
+total_records = 0
+phantom_records = 0
+nonzero_records = 0
+phantom_examples = []
+
+# Each kernel_dispatch_record event line has, somewhere in it, a
+# field of the form "_records_length = N" and "records = [ B1, B2, ...
+# Bn ]" where n == count*16. babeltrace2's exact format may vary
+# slightly; we tolerate either "_records" or "records" as the field
+# name and parse the bracketed byte list.
+pat_event   = re.compile(r"rocm_hsa:kernel_dispatch_record:")
+pat_count   = re.compile(r"\bcount\s*=\s*(\d+)")
+# records = [ [0] = N, [1] = N, ... [k] = N ]   — matches the OUTER
+# brackets only by anchoring on "records = [" then the FINAL " ] }"
+# (closing bracket followed by space + closing brace of the field
+# group). [^\]]* won't work because each element has its own [i].
+pat_records = re.compile(r"records\s*=\s*\[(.*?)\]\s*\}\s*$")
+
+with open(path) as f:
+    for line in f:
+        if "rocm_hsa:kernel_dispatch_record:" not in line:
+            continue
+        total_events += 1
+        m_count = pat_count.search(line)
+        m_recs  = pat_records.search(line)
+        if not m_count or not m_recs:
+            continue
+        count = int(m_count.group(1))
+        # Parse byte list. babeltrace2 prints elements as "[i] = value"
+        # (one entry per element separated by commas), where value is
+        # decimal int (or rarely hex with 0x prefix).
+        body = m_recs.group(1)
+        # Extract just the value from each "[i] = value" element.
+        ints = [int(v.strip(), 0) for v in re.findall(r"=\s*(\S+?)\s*(?:,|$)", body)]
+        if len(ints) != count * 16:
+            print(f"FAIL: event has count={count} but records length {len(ints)} != count*16",
+                  file=sys.stderr)
+            sys.exit(2)
+        for i in range(count):
+            rec = ints[i*16:(i+1)*16]
+            if all(b == 0 for b in rec):
+                phantom_records += 1
+                if len(phantom_examples) < 3:
+                    phantom_examples.append((total_events, i))
+            else:
+                nonzero_records += 1
+            total_records += 1
+
+print(f"events={total_events} records={total_records} phantom={phantom_records} nonzero={nonzero_records}")
+
+if phantom_records > 0:
+    print(f"FAIL: drainer emitted {phantom_records} all-zero record(s) "
+          f"(phantom records from pre-zeroed ring slots that should "
+          f"have been quarantine-swept or init-sync overrun-skipped)",
+          file=sys.stderr)
+    print(f"  first {len(phantom_examples)} phantom locations (event_index, record_index_in_event):",
+          file=sys.stderr)
+    for ev, idx in phantom_examples:
+        print(f"    event #{ev} record #{idx}", file=sys.stderr)
+    sys.exit(2)
+
+if total_records == 0:
+    # Workload may have INFO-skipped, or the substrate may not support
+    # dispatch_log. Self-skip rather than fail.
+    print("INFO: no kernel_dispatch_record events captured; init-sync test "
+          "has nothing to assert against (workload may have skipped or KFD "
+          "substrate may not support dispatch_log)", file=sys.stderr)
+    sys.exit(0)
+
+if nonzero_records == 0:
+    print(f"FAIL: {total_records} record(s) emitted but ALL were all-zero "
+          f"(should not happen if any real kernels ran)", file=sys.stderr)
+    sys.exit(2)
+
+print("OK")
+PY
+
+RC=$?
+if [ "$RC" -ne 0 ]; then
+    fail "init-sync no-phantom-records assertion failed (exit $RC)"
+fi
+
+info "PASS: no phantom (all-zero) records emitted from drainer"
+exit 0

--- a/projects/rocr-runtime/runtime/hsa-runtime/test/lttng/test_hsa_dispatch_log_intercept_queue.sh
+++ b/projects/rocr-runtime/runtime/hsa-runtime/test/lttng/test_hsa_dispatch_log_intercept_queue.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Intercept-queue lifecycle test for the dispatch_log subsystem.
+#
+# Locks in the fix from commit `3dc1d27db6`: on_queue_destroy must
+# unwrap QueueWrapper subclasses (InterceptQueue) so the disable
+# sequence runs on the underlying AqlQueue that on_queue_create
+# registered. Without the fix, intercept-queue destroys leak the
+# drainer worker thread and silently drop the final-drain records;
+# a regression here would manifest as either:
+#   - drainer worker reading freed memory (likely SIGSEGV during
+#     queue destroy or process exit), or
+#   - records FW wrote between the last drain pass and queue destroy
+#     never appearing in the LTTng trace.
+#
+# Implementation note: hsa_amd_queue_intercept_create is an internal
+# runtime API (declared in hsa_api_trace.h, not in public hsa_ext_amd.h)
+# and is NOT exported from libhsa-runtime64.so. We can't create an
+# intercept queue from a standalone test program. Instead, we
+# exercise intercept queues indirectly via HIP, which uses them
+# internally for the runtime queue path.
+#
+# The hipcc-built square sample creates a HIP queue → CLR allocates
+# an HSA queue via Hsa::queue_create (through hsa_queue_create) →
+# the runtime returns either an AqlQueue directly or wraps it in an
+# InterceptQueue (the latter happens for some configurations and
+# definitely happens for hsa_amd_queue_intercept_register which HIP
+# calls internally for some packet-rewrite paths).
+#
+# Mechanics:
+#   1. Build hipcc square (or skip with INFO if hipcc unavailable).
+#   2. Run it twice in succession under LTTng + DIAG_LOSS:
+#        - First run: cold, fresh queues created and destroyed at
+#          process exit. Tests on_queue_create/destroy symmetry on
+#          first lifecycle.
+#        - Second run (separate process): tests that any global
+#          residual state from run 1 doesn't break run 2.
+#   3. Assert both runs:
+#        - Exited 0 (no SIGSEGV from drainer reading freed memory)
+#        - Produced ≥1 [DIAG_LOSS] line per run (proves at least one
+#          queue was registered AND disable ran AND DIAG dump fired)
+#        - All [DIAG_LOSS] accounting balances
+#
+# Usage: $0 [<build_dir>]
+
+set -euo pipefail
+
+BUILD_DIR="${1:-$PWD/build/rocr}"
+LIB_DIR="$BUILD_DIR/rocr/lib"
+
+if [ ! -f "$LIB_DIR/libhsa-runtime64.so" ]; then
+    echo "FAIL: $LIB_DIR/libhsa-runtime64.so not found"
+    exit 1
+fi
+
+TRACE_DIR="$(mktemp -d)"
+cleanup() {
+    set +e
+    pkill -P $$ 2>/dev/null
+    if [ -n "${SESSIOND_PIDFILE:-}" ] && [ -f "$SESSIOND_PIDFILE" ]; then
+        kill "$(cat "$SESSIOND_PIDFILE")" 2>/dev/null || true
+    fi
+    rm -rf "$TRACE_DIR"
+}
+trap cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+info() { echo "INFO: $*"; }
+
+WORKLOAD_BIN=""
+if command -v /opt/rocm/bin/hipcc >/dev/null 2>&1 \
+   && [ -f /opt/rocm/share/hip/samples/0_Intro/square/square.hipref.cpp ]; then
+    cp /opt/rocm/share/hip/samples/0_Intro/square/square.hipref.cpp "$TRACE_DIR/square.cpp"
+    if /opt/rocm/bin/hipcc "$TRACE_DIR/square.cpp" -o "$TRACE_DIR/square" \
+        >"$TRACE_DIR/hipcc.log" 2>&1; then
+        WORKLOAD_BIN="$TRACE_DIR/square"
+    fi
+fi
+
+if [ -z "$WORKLOAD_BIN" ]; then
+    info "hipcc square not available; intercept-queue lifecycle test SKIPPED"
+    exit 0
+fi
+
+# Per-user lttng-sessiond.
+export LTTNG_HOME="$TRACE_DIR/lttng-home"
+mkdir -p "$LTTNG_HOME"
+SESSIOND_PIDFILE="$TRACE_DIR/sessiond.pid"
+lttng-sessiond --daemonize --no-kernel --pidfile="$SESSIOND_PIDFILE"
+for i in 1 2 3 4 5; do
+    [ -f "$SESSIOND_PIDFILE" ] && break
+    sleep 0.5
+done
+[ -f "$SESSIOND_PIDFILE" ] || fail "lttng-sessiond did not start"
+
+run_workload() {
+    local label="$1"
+    local diag_log="$TRACE_DIR/diag.$label.log"
+    local stdout_log="$TRACE_DIR/stdout.$label.log"
+
+    rm -rf "$TRACE_DIR/trace.$label"
+    lttng create "intercept-test-$label" --output="$TRACE_DIR/trace.$label" >/dev/null
+    lttng enable-event --userspace 'rocm_hsa:kernel_dispatch_record' >/dev/null
+    lttng enable-event --userspace 'rocm_hsa:kernel_dispatch_drop'   >/dev/null
+    lttng start >/dev/null
+
+    set +e
+    HSA_DISPATCH_LOG_DIAG_LOSS=1 \
+        LD_LIBRARY_PATH="$LIB_DIR:${LD_LIBRARY_PATH:-}" \
+        "$WORKLOAD_BIN" >"$stdout_log" 2>"$diag_log"
+    local rc=$?
+    set -e
+
+    lttng stop    >/dev/null
+    lttng destroy >/dev/null
+
+    if [ "$rc" -ne 0 ]; then
+        echo "FAIL: $label run exited with $rc (likely SIGSEGV in drainer worker on queue destroy — the intercept-queue unwrap fix may have regressed)" >&2
+        echo "------ stderr ------" >&2
+        cat "$diag_log" >&2
+        return 1
+    fi
+
+    local diag_count
+    diag_count="$(grep -c '^\[DIAG_LOSS\]' "$diag_log" || true)"
+    if [ "$diag_count" -lt 1 ]; then
+        echo "FAIL: $label run produced no [DIAG_LOSS] lines; either DIAG_LOSS env var did not propagate, or no queue ever enabled dispatch_log AND went through the disable sequence (regression: queue destroy bypassed disable_dispatch_log_for_queue_locked)" >&2
+        echo "------ stderr ------" >&2
+        cat "$diag_log" >&2
+        return 1
+    fi
+
+    # Verify accounting on every active queue in this run.
+    local fail_count=0
+    while IFS= read -r line; do
+        local qid sig_span emitted zero_swept drop_overrun accounted
+        qid=$(echo          "$line" | sed -n 's/.*q=\(0x[0-9a-fA-F]\+\).*/\1/p')
+        sig_span=$(echo     "$line" | sed -n 's/.*sig_span=\([0-9]\+\).*/\1/p')
+        emitted=$(echo      "$line" | sed -n 's/.*emitted=\([0-9]\+\).*/\1/p')
+        zero_swept=$(echo   "$line" | sed -n 's/.*zero_swept=\([0-9]\+\).*/\1/p')
+        drop_overrun=$(echo "$line" | sed -n 's/.*drop_overrun=\([0-9]\+\).*/\1/p')
+        accounted=$(echo    "$line" | sed -n 's/.*accounted=\([0-9]\+\).*/\1/p')
+        [ "$sig_span" = "0" ] && continue
+        local expected=$((emitted + zero_swept + drop_overrun))
+        if [ "$accounted" != "$sig_span" ]; then
+            echo "FAIL: $label queue $qid: accounted=$accounted != sig_span=$sig_span (diff=$((sig_span - accounted)))" >&2
+            fail_count=$((fail_count + 1))
+        fi
+    done < <(grep '^\[DIAG_LOSS\]' "$diag_log")
+
+    if [ "$fail_count" -gt 0 ]; then
+        return 1
+    fi
+
+    info "$label: rc=0, $diag_count [DIAG_LOSS] line(s), all accounting balanced"
+    return 0
+}
+
+run_workload first  || fail "first run failed"
+run_workload second || fail "second run failed"
+
+info "PASS: intercept-queue lifecycle (two consecutive runs) exited cleanly with balanced accounting"
+exit 0

--- a/projects/rocr-runtime/runtime/hsa-runtime/test/lttng/test_hsa_dispatch_log_test_api.sh
+++ b/projects/rocr-runtime/runtime/hsa-runtime/test/lttng/test_hsa_dispatch_log_test_api.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Validation of the test-only dispatch_log introspection API
+# (hsa_amd_dispatch_log_test_enable / hsa_amd_dispatch_log_test_get_state).
+#
+# These symbols are intentionally exported from libhsa-runtime64.so for
+# standalone test programs that need to inspect the per-queue FW dispatch
+# record buffer directly (i.e. without going through the LTTng UST emit
+# path). This test exercises them and verifies the documented contract:
+#
+#   1. _enable() returns SUCCESS on a freshly-created HSA queue (any
+#      AqlQueue regardless of GPU agent type).
+#   2. _get_state() after _enable() returns:
+#        - non-null buffer_base
+#        - num_records == DISPATCH_LOG_RECORD_COUNT (65536) — matches
+#          AqlQueue::SetProfiling's hard-coded ring count
+#        - non-null wptr_ptr and signal_ptr
+#   3. _enable() / _get_state() reject nullptr / non-AQL-queue arguments
+#      with HSA_STATUS_ERROR_INVALID_*.
+#
+# The test does NOT submit kernels or assert on FW writes — that path is
+# covered by test_hsa_dispatch_log.sh which runs end-to-end through the
+# LTTng pipeline. This is a focused unit-style test of the API surface
+# the dlog_test_* programs use.
+#
+# Usage:
+#   test_hsa_dispatch_log_test_api.sh [<build_dir>]
+#
+# <build_dir> defaults to $PWD/build/rocr.
+#
+# Skips with INFO if no GPU agent is present (the runtime can be
+# initialized but no AqlQueue can be created).
+
+set -euo pipefail
+
+BUILD_DIR="${1:-$PWD/build/rocr}"
+LIB_DIR="$BUILD_DIR/rocr/lib"
+
+if [ ! -f "$LIB_DIR/libhsa-runtime64.so" ]; then
+    echo "FAIL: $LIB_DIR/libhsa-runtime64.so not found"
+    exit 1
+fi
+
+TRACE_DIR="$(mktemp -d)"
+trap 'rm -rf "$TRACE_DIR"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+info() { echo "INFO: $*"; }
+
+cat > "$TRACE_DIR/test_api.cpp" <<'EOF'
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+extern "C" {
+hsa_status_t hsa_amd_dispatch_log_test_enable(hsa_queue_t* queue);
+hsa_status_t hsa_amd_dispatch_log_test_get_state(
+    hsa_queue_t* queue,
+    void** buffer_base,
+    uint32_t* num_records,
+    const volatile uint64_t** wptr_ptr,
+    const volatile uint64_t** signal_ptr);
+}
+
+static hsa_status_t find_gpu(hsa_agent_t agent, void* data) {
+    hsa_device_type_t dt;
+    if (hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &dt) != HSA_STATUS_SUCCESS)
+        return HSA_STATUS_SUCCESS;
+    if (dt == HSA_DEVICE_TYPE_GPU) {
+        *static_cast<hsa_agent_t*>(data) = agent;
+        return HSA_STATUS_INFO_BREAK;
+    }
+    return HSA_STATUS_SUCCESS;
+}
+
+#define EXPECT_OK(call)                                                  \
+    do {                                                                 \
+        hsa_status_t __s = (call);                                       \
+        if (__s != HSA_STATUS_SUCCESS) {                                 \
+            std::fprintf(stderr, "FAIL: " #call " -> %d\n", __s);        \
+            return 2;                                                    \
+        }                                                                \
+    } while (0)
+
+#define EXPECT_EQ(a, b, msg)                                             \
+    do {                                                                 \
+        if ((a) != (b)) {                                                \
+            std::fprintf(stderr, "FAIL: %s: %lld != %lld\n",             \
+                         msg, (long long)(a), (long long)(b));           \
+            return 2;                                                    \
+        }                                                                \
+    } while (0)
+
+int main() {
+    EXPECT_OK(hsa_init());
+
+    hsa_agent_t gpu = {0};
+    hsa_status_t s = hsa_iterate_agents(find_gpu, &gpu);
+    if (gpu.handle == 0) {
+        std::fprintf(stdout, "INFO: no GPU agent; skipping\n");
+        hsa_shut_down();
+        return 0;
+    }
+    (void)s;
+
+    uint32_t qsize = 0;
+    EXPECT_OK(hsa_agent_get_info(gpu, HSA_AGENT_INFO_QUEUE_MAX_SIZE, &qsize));
+    if (qsize == 0) qsize = 1024;
+    if (qsize > 4096) qsize = 4096;
+
+    hsa_queue_t* queue = nullptr;
+    EXPECT_OK(hsa_queue_create(gpu, qsize, HSA_QUEUE_TYPE_SINGLE,
+                               nullptr, nullptr, 0, 0, &queue));
+
+    /* --- Negative tests (must come BEFORE enable while args are valid). */
+    if (hsa_amd_dispatch_log_test_enable(nullptr)
+            != HSA_STATUS_ERROR_INVALID_ARGUMENT) {
+        std::fprintf(stderr, "FAIL: _enable(nullptr) didn't reject\n");
+        return 2;
+    }
+
+    void* buf = (void*)0xdeadbeef;
+    uint32_t nrec = 0xdeadbeef;
+    const volatile uint64_t* w = nullptr;
+    const volatile uint64_t* sig = nullptr;
+    if (hsa_amd_dispatch_log_test_get_state(nullptr, &buf, &nrec, &w, &sig)
+            != HSA_STATUS_ERROR_INVALID_ARGUMENT) {
+        std::fprintf(stderr, "FAIL: _get_state(nullptr queue) didn't reject\n");
+        return 2;
+    }
+    if (hsa_amd_dispatch_log_test_get_state(queue, nullptr, &nrec, &w, &sig)
+            != HSA_STATUS_ERROR_INVALID_ARGUMENT) {
+        std::fprintf(stderr, "FAIL: _get_state(nullptr buffer_base) didn't reject\n");
+        return 2;
+    }
+
+    /* --- Positive tests. */
+    EXPECT_OK(hsa_amd_dispatch_log_test_enable(queue));
+    buf = nullptr; nrec = 0; w = nullptr; sig = nullptr;
+    EXPECT_OK(hsa_amd_dispatch_log_test_get_state(queue, &buf, &nrec, &w, &sig));
+
+    if (buf == nullptr) { std::fprintf(stderr, "FAIL: buffer_base null\n"); return 2; }
+    /* DISPATCH_LOG_RECORD_COUNT in dispatch_log.h. */
+    EXPECT_EQ(nrec, 65536u, "num_records mismatch");
+    if (w == nullptr) { std::fprintf(stderr, "FAIL: wptr_ptr null\n"); return 2; }
+    if (sig == nullptr) { std::fprintf(stderr, "FAIL: signal_ptr null\n"); return 2; }
+
+    EXPECT_OK(hsa_queue_destroy(queue));
+    EXPECT_OK(hsa_shut_down());
+    std::fprintf(stdout, "OK\n");
+    return 0;
+}
+EOF
+
+# Build against the freshly-built libhsa-runtime64.so so dispatch_log
+# code under review is what we exercise.
+c++ "$TRACE_DIR/test_api.cpp" -o "$TRACE_DIR/test_api" \
+    -std=c++17 \
+    -I/opt/rocm/include -L"$LIB_DIR" -lhsa-runtime64 \
+    -Wl,-rpath,"$LIB_DIR" \
+    || fail "compile failed"
+
+LD_LIBRARY_PATH="$LIB_DIR:${LD_LIBRARY_PATH:-}" \
+    "$TRACE_DIR/test_api" > "$TRACE_DIR/out.log" 2>&1
+RC=$?
+cat "$TRACE_DIR/out.log"
+
+if [ $RC -ne 0 ]; then
+    fail "test_api binary returned $RC"
+fi
+
+if grep -q '^INFO: no GPU agent' "$TRACE_DIR/out.log"; then
+    info "test skipped (no GPU agent present)"
+elif ! grep -q '^OK' "$TRACE_DIR/out.log"; then
+    fail "test_api binary did not print OK"
+fi
+
+echo "PASS hsa_dispatch_log_test_api"

--- a/projects/rocr-runtime/runtime/hsa-runtime/test/lttng/test_hsa_dispatch_log_test_api.sh
+++ b/projects/rocr-runtime/runtime/hsa-runtime/test/lttng/test_hsa_dispatch_log_test_api.sh
@@ -11,8 +11,9 @@
 #      AqlQueue regardless of GPU agent type).
 #   2. _get_state() after _enable() returns:
 #        - non-null buffer_base
-#        - num_records == DISPATCH_LOG_RECORD_COUNT (65536) — matches
-#          AqlQueue::SetProfiling's hard-coded ring count
+#        - num_records is a sane power-of-2 ring size chosen by
+#          AqlQueue::SetProfiling at allocation time (no build-time
+#          constant; the test asserts shape, not a hard-coded value)
 #        - non-null wptr_ptr and signal_ptr
 #   3. _enable() / _get_state() reject nullptr / non-AQL-queue arguments
 #      with HSA_STATUS_ERROR_INVALID_*.
@@ -141,8 +142,14 @@ int main() {
     EXPECT_OK(hsa_amd_dispatch_log_test_get_state(queue, &buf, &nrec, &w, &sig));
 
     if (buf == nullptr) { std::fprintf(stderr, "FAIL: buffer_base null\n"); return 2; }
-    /* DISPATCH_LOG_RECORD_COUNT in dispatch_log.h. */
-    EXPECT_EQ(nrec, 65536u, "num_records mismatch");
+    /* The ring record count is chosen at runtime by AqlQueue::SetProfiling
+       (no build-time constant, see core/inc/dispatch_log.h). Validate that
+       it's a non-zero power of 2 and within a reasonable range, not a
+       hard-coded value that goes stale when SetProfiling is bumped. */
+    if (nrec == 0u || (nrec & (nrec - 1u)) != 0u || nrec < 1024u || nrec > (1u << 24)) {
+      std::fprintf(stderr, "FAIL: num_records=%u not a sane power-of-2 ring size\n", nrec);
+      return 2;
+    }
     if (w == nullptr) { std::fprintf(stderr, "FAIL: wptr_ptr null\n"); return 2; }
     if (sig == nullptr) { std::fprintf(stderr, "FAIL: signal_ptr null\n"); return 2; }
 


### PR DESCRIPTION
## Summary

Adds HSA-side scaffolding for a per-process LTTng UST tracepoint
(`rocm_hsa:kernel_dispatch_complete`) emitted from a new background
thread inside `libhsa-runtime64.so`. The thread drains a per-queue
firmware-written ring buffer of GPU-clock dispatch start/end timestamps
and pairs them by `dispatch_idx` before emitting one tracepoint per
completed kernel.

This is **Phase A only** — see Out of Scope below. The MEC firmware +
KFD ioctl substrate that produces the records does not yet exist in
stock ROCm, so the runtime probe at `dispatch_log::init()` detects this
gracefully and the poller short-circuits. Code compiles, links, loads,
and runs without crashing — the drainer simply observes an empty ring
forever until the firmware substrate lands.

## Design Spec

This implementation follows the design at:
`~/ai/specs/2026-04-27-hsa-lttng-kernel-dispatch-tracing-design.md`
which passed an 8-round / 27-claim adversarial debate review (0
rebuttals, 0 judge invocations) before implementation began. The spec
covers architecture, lifecycle state machine, profiling-bit refcounting,
hot-attach mechanism, tracepoint payload, drainer data plane, file
layout, coexistence rules, and external dependencies.

After implementation, a separate two-stage debate-review-code loop ran
on the diff: stage 1 (spec-compliance) raised 2 claims (both ACCEPTed +
fixed); stage 2 (code-quality) raised 4 claims (all ACCEPTed + fixed).
Both stages PASSED with NO_CHANGES_NEEDED on final round.

## Architecture

```
┌─────────────────────────────────────────────────────────────────────┐
│ libhsa-runtime64.so                                                  │
│                                                                      │
│  ┌───────────────────────┐      ┌──────────────────────────────┐    │
│  │ App threads           │      │ ts_poller thread (NEW)        │    │
│  │ (HSA API callers)     │      │ ~5 ms tick                    │    │
│  └──────────┬────────────┘      │ polls lttng_ust_tracepoint_   │    │
│             │ existing tps:      │   enabled(rocm_hsa,           │    │
│             │ hsa_api_*          │   kernel_dispatch_complete)   │    │
│             │ hsa_doorbell_ring  │ each tick: idempotent enable  │    │
│             │ hsa_intercept_*    │   pass OR disable pass over   │    │
│             │                    │   live queues                 │    │
│             ▼                    └──────────────┬───────────────┘    │
│  ┌─────────────────────────────────────────────────────────────┐    │
│  │ Per-queue dispatch-log ring buffer (header + data area)      │    │
│  │ MEC FW writes 16-byte START + 16-byte END records            │    │
│  └─────────────────────────────────────────────────────────────┘    │
│             ▲                                                        │
│  ┌──────────┴────────────┐                                           │
│  │ ts_drainer thread     │  adaptive cadence (yield / 500 µs)        │
│  │ (NEW)                 │  pairs START/END by dispatch_idx          │
│  │                       │  emits rocm_hsa:kernel_dispatch_complete  │
│  └───────────────────────┘                                           │
└─────────────────────────────────────────────────────────────────────┘
```

Two new threads in HSA. The application thread is never blocked or
instrumented per-dispatch — the only synchronous control-path costs are
queue-create and queue-destroy when the tracepoint is enabled (one KFD
ioctl + one MQD unmap/remap each).

## Changes

### New files
- `projects/rocr-runtime/runtime/hsa-runtime/core/inc/dispatch_log.h`
  — public types (`mec_dispatch_record_16`, `dispatch_log_header`),
  constants (`DISPATCH_LOG_HEADER_BYTES = 64`, `DISPATCH_LOG_VERSION =
  1`, `DISPATCH_LOG_RING_BYTES = 4 MiB`), record-type enum, and the
  public API (`init`, `shutdown`, `on_queue_create`, `on_queue_destroy`,
  `QueueProfilingAcquire`, `QueueProfilingRelease`).
- `projects/rocr-runtime/runtime/hsa-runtime/core/runtime/dispatch_log.cpp`
  — full subsystem implementation (~1045 lines): poller, drainer,
  per-queue refcount, queue-create/destroy hooks, ring-buffer lifecycle,
  KFD ioctl wrapper, GPU→system clock translation via captured
  per-queue callable.

### Modified files
- `projects/rocr-runtime/runtime/hsa-runtime/CMakeLists.txt` — adds
  `dispatch_log.cpp` to the source list.
- `projects/rocr-runtime/runtime/hsa-runtime/core/inc/queue.h` — adds
  `dispatch_log_active` (atomic bool) and `dispatch_log_state` (opaque
  pointer; reserved for Phase B in-Queue refcount migration) to
  `core::Queue`.
- `projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp`
  — calls `rocr::dispatch_log::init()` from `Runtime::Load` (after
  `LoadTools` so `__rocm_hsa_tp_init` has run) and
  `rocr::dispatch_log::shutdown()` at the top of `Runtime::Unload`.
- `projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp`
  — calls `on_queue_create(cmd_queue)` after the new queue is visible
  in `hsa_queue_create` and `on_queue_destroy(cmd_queue)` before
  `cmd_queue->Destroy()` in `hsa_queue_destroy`.
- `projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_hsa_tp.h`
  — adds `rocm_hsa:kernel_dispatch_complete` and
  `rocm_hsa:kernel_dispatch_drop` LTTng UST tracepoint definitions.
- `projects/rocr-runtime/runtime/hsa-runtime/lttng/rocm_trace_emit.h`
  — adds matching emit helpers. The `kernel_dispatch_complete` helper
  takes a `force_emit` parameter that bypasses the per-tracepoint
  `lttng_ust_tracepoint_enabled()` guard during the disable-edge final
  drain (the `rocm_trace_disabled()` kill switch is still honored).

## Tracepoint Schema

`rocm_hsa:kernel_dispatch_complete`:
- `queue_id` (uint32_t — full uint64_t internally, narrowed only at the
  emission boundary; consumers join with the doorbell `write_idx`
  masked to 32 bits)
- `dispatch_idx` (uint32_t — `(uint32_t)(write_dispatch_id - 1)`)
- `start_ts`, `end_ts` (uint64_t, system-clock translated from FW-written
  GPU clock)
- `corr_id` (uint64_t — fresh per emission)
- `parent_corr_id` (uint64_t = 0 — drainer thread has no API context;
  consumer recovers parent via the `(queue_id, dispatch_idx)` join with
  `rocm_hsa:hsa_doorbell_ring`)

`rocm_hsa:kernel_dispatch_drop`: `(queue_id, bytes_lost)` — one event
per ring-overrun event. `bytes_lost = fw_wptr - read_cursor` at
detection (worst-case backlog measure, not strictly-unrecoverable
amount).

## Testing

Build verified on `bewelton_cpc_tracing` container on
`gbt350-odcdh5-wbc1-b.png-odc.dcgpu` (gfx950 / ROCm 7.2.2):

- `libhsa-runtime64.so.1.21.0` builds clean (RelWithDebInfo, ~45 MB
  with vendored LTTng-UST + urcu).
- LTTng tracepoint symbols `_loglevel___rocm_hsa___kernel_dispatch_complete`
  and `_loglevel___rocm_hsa___kernel_dispatch_drop` are registered in
  `nm -D /opt/rocm/lib/libhsa-runtime64.so.1.21.0`.
- 5/5 rocprofiler-sdk lib tests pass: `hsa.tables`,
  `contexts.callback_tracing`, `contexts.buffer_tracing`,
  `rocprofiler_lib.timestamp`, `rocprofiler_lib.buffer`.
- `ts_poller_loop` confirmed alive and idling at 5 ms via gdb backtrace
  on a real workload.
- A pre-existing HIP/CLR null-stream init crash on this branch is
  **not** caused by this change (verified by neutering the queue
  hooks and reproducing the same crash); fix is outside this PR's scope.

## Out of Scope (Phases B/C)

The spec calls out three external dependencies that are NOT shipped
here and that gate end-to-end functionality:

1. **MEC firmware support** for writing 16-byte START + END records to
   the per-queue dispatch-log buffer (`aql.cpp` and `common.h` in the
   firmware tree).
2. **KFD driver support** for `KFD_IOC_PROFILER_DISPATCH_LOG` ioctl
   with ENABLE / DISABLE / QUERY flags. This PR uses placeholder ioctl
   number `0xFE` in the AMDKFD `'K'` space; real number TBD by KFD
   team. Stock KFD returns ENOTSUP, which this PR handles gracefully
   (`g_substrate_present = false`, poller short-circuits).
3. **rocprofiler-sdk migration** to use `QueueProfilingAcquire/Release`
   instead of writing the `AMD_QUEUE_PROPERTIES_ENABLE_PROFILING` bit
   directly. **Hard precondition** for shipping LTTng dispatch-log
   enablement (per spec §10 dep #4) because the refcount invariant
   cannot hold if any consumer bypasses the API.

Also Phase A degradations documented in the code:
- Ring buffer is `mmap(MAP_ANONYMOUS|MAP_PRIVATE)` rather than HSA's
  pinned-host allocator (deferred — buffer is never read by FW until
  the substrate lands).
- Per-queue refcount uses a side-map keyed on `core::Queue*` rather
  than the new `Queue::dispatch_log_state` pointer (Phase B migration).
- Hooks live in `hsa.cpp` (the actual entry-point file), not the spec's
  referenced `amd_hsa_queue.cpp` (which doesn't exist on this branch).

## Coexistence

- **LTTng tracepoint OFF, no rocprofiler-sdk:** zero per-dispatch
  overhead; one ~5 ms idle poller tick.
- **LTTng tracepoint OFF, SDK has KERNEL_DISPATCH context:** existing
  intercept-queue + per-dispatch-signal path runs unchanged. SDK sets
  the profiling bit per-queue itself (Phase A; will move to refcount
  in Phase B precondition).
- **LTTng tracepoint ON, no SDK:** poller flips it; per-queue ring
  buffer allocated, profiling bit set via refcount, drainer emits.
- **LTTng tracepoint ON, SDK active:** profiling bit refcount keeps
  the bit set as long as either consumer holds a ref. Both consumers
  see data through their own transports — no conflict.
- **`ROCM_LTTNG_UST_DISABLE=1`:** existing kill switch folded into the
  poller's edge predicate; poller never enables.
- **dlmopen non-default namespace:** existing detection in
  `__rocm_hsa_tp_ctor` keeps LTTng disabled; poller never enables.
- **Agent without firmware dispatch-log support (older GPU):** ENOTSUP
  on first ENABLE attempt marks the agent as "no-dispatch-log";
  subsequent queue-creates on that agent skip silently.
- **KFD without `KFD_IOC_PROFILER_DISPATCH_LOG`:** probed at
  `init()`; `g_substrate_present = false`; tracepoint enable is a
  documented no-op.

## Branch lineage

This branch is based on `users/bewelton/lttng` (the LTTng UST
infrastructure branch — currently 6096d62947). Six commits added on
top:

1. `764599fba3` — initial Phase A scaffolding (1229 insertions)
2. `a06a123028` — poller iterates live-queue registry (C1, C2)
3. `6b995d31a9` — pin `queue_profiling_owners` via shared_ptr (C4)
4. `86390c40e9` — full uint64_t internal queue keys (C5)
5. `cec54c32e3` — `for_each_known_queue_locked` helper (C6)
6. `36e4064381` — clear `pending_starts` on ring overrun (C7)