### PR TITLE
Add progress tracing capabilities to output file generation

### DIFF
--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -21,6 +21,7 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
 - Post-run output summary during library finalization showing result file locations.
 - JSON schema file (`share/rocprofiler-systems/presets/schema.json`) for preset validation.
 - Documentation (`docs/how-to/instrumenting-rewriting-binary-application.rst`) describing what to do when Dyninst reports a "Failed to transform trace" error during instrumentation.
+- Progress bars during trace cache post-processing: perfetto generation (`sequential dispatch`) shows one bar per buffered_storage file in turn; rocpd generation (`multithreaded dispatch`) shows a single aggregate bar accumulating updates from all worker threads.
 
 ### Changed
 

--- a/projects/rocprofiler-systems/source/lib/core/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/CMakeLists.txt
@@ -65,6 +65,7 @@ target_sources(rocprofiler-systems-core-library PRIVATE ${core_sources} ${core_h
 add_subdirectory(binary)
 add_subdirectory(components)
 add_subdirectory(containers)
+add_subdirectory(progress)
 add_subdirectory(rocpd)
 add_subdirectory(trace_cache)
 

--- a/projects/rocprofiler-systems/source/lib/core/progress/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/progress/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+set(progress_sources
+    ${CMAKE_CURRENT_LIST_DIR}/bar.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/tracker.cpp
+)
+
+set(progress_headers
+    ${CMAKE_CURRENT_LIST_DIR}/bar.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/callback.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/tracker.hpp
+)
+
+target_sources(
+    rocprofiler-systems-core-library
+    PRIVATE ${progress_sources} ${progress_headers}
+)
+
+if(ROCPROFSYS_BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/projects/rocprofiler-systems/source/lib/core/progress/bar.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/progress/bar.cpp
@@ -133,16 +133,15 @@ stream_is_tty(std::FILE* stream) noexcept
 }
 }  // namespace
 
+// Sample visibility once at construction. Verbose level and the stream's
+// TTY-ness are set during process startup and do not change during a
+// post-processing run, so re-checking on every advance would be waste.
 bar::bar(std::string label, std::uint64_t total, bar_options opts)
 : m_label(std::move(label))
 , m_opts(opts)
 , m_total(total)
-{
-    // Sample visibility once at construction. Verbose level and the stream's
-    // TTY-ness are set during process startup and do not change during a
-    // post-processing run, so re-checking on every advance would be waste.
-    m_visible = m_opts.enabled && m_opts.verbose >= 0 && stream_is_tty(m_opts.stream);
-}
+, m_visible(opts.enabled && opts.verbose >= 0 && stream_is_tty(opts.stream))
+{}
 
 // Idempotent: on_finish()'s CAS short-circuits if it was called already.
 bar::~bar() { on_finish(); }

--- a/projects/rocprofiler-systems/source/lib/core/progress/bar.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/progress/bar.cpp
@@ -1,0 +1,236 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "core/progress/bar.hpp"
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <mutex>
+#include <string>
+#include <utility>
+
+namespace rocprofsys::progress
+{
+namespace detail
+{
+namespace
+{
+// Eighth-block precision (UTF-8 bytes for U+2588 LEFT EIGHTH BLOCK family).
+inline constexpr std::array<const char*, 9> BLOCK_CHARS = {
+    " ",             // 0/8 (empty)
+    "\xe2\x96\x8f",  // 1/8 U+258F
+    "\xe2\x96\x8e",  // 2/8 U+258E
+    "\xe2\x96\x8d",  // 3/8 U+258D
+    "\xe2\x96\x8c",  // 4/8 U+258C
+    "\xe2\x96\x8b",  // 5/8 U+258B
+    "\xe2\x96\x8a",  // 6/8 U+258A
+    "\xe2\x96\x89",  // 7/8 U+2589
+    "\xe2\x96\x88"   // 8/8 U+2588 (full block)
+};
+inline constexpr std::size_t PARTS_PER_CELL = 8;
+}  // namespace
+
+std::string
+format_bar(bar_style style, std::size_t width, double frac)
+{
+    frac = std::clamp(frac, 0.0, 1.0);
+
+    std::string out;
+    out.reserve(width * 4);  // worst case: 3 UTF-8 bytes per cell + brackets
+
+    const auto filled = static_cast<std::size_t>(frac * static_cast<double>(width));
+    const auto empty  = width - filled;
+
+    switch(style)
+    {
+        case bar_style::ascii_brackets:
+        {
+            out.push_back('[');
+            out.append(filled, '#');
+            out.append(empty, '.');
+            out.push_back(']');
+            break;
+        }
+        case bar_style::ascii_arrow:
+        {
+            out.push_back('[');
+            if(filled == 0)
+                out.append(width, ' ');
+            else if(filled >= width)
+                out.append(width, '=');
+            else
+            {
+                out.append(filled - 1, '=');
+                out.push_back('>');
+                out.append(width - filled, ' ');
+            }
+            out.push_back(']');
+            break;
+        }
+        case bar_style::unicode_blocks:
+        {
+            // Clamp eighths to width*PARTS_PER_CELL so a floating-point
+            // rounding edge cannot underflow trailing_pad (size_t).
+            const auto max_eighths   = width * PARTS_PER_CELL;
+            const auto total_eighths = std::min(
+                static_cast<std::size_t>(frac * static_cast<double>(max_eighths)),
+                max_eighths);
+            const auto full         = total_eighths / PARTS_PER_CELL;
+            const auto remainder    = total_eighths % PARTS_PER_CELL;
+            const auto trailing_pad = width - full - (remainder > 0 ? 1 : 0);
+
+            out.push_back('[');
+            for(std::size_t i = 0; i < full; ++i)
+                out.append(BLOCK_CHARS[PARTS_PER_CELL]);
+            if(remainder > 0) out.append(BLOCK_CHARS[remainder]);
+            out.append(trailing_pad, ' ');
+            out.push_back(']');
+            break;
+        }
+        case bar_style::unicode_dots:
+        {
+            // U+25CF (filled), U+25CB (empty). No surrounding brackets.
+            for(std::size_t i = 0; i < filled; ++i)
+                out.append("\xe2\x97\x8f");
+            for(std::size_t i = 0; i < empty; ++i)
+                out.append("\xe2\x97\x8b");
+            break;
+        }
+        case bar_style::text_only: break;
+    }
+    return out;
+}
+}  // namespace detail
+
+namespace
+{
+// Carriage return + ANSI "Erase In Line" (mode 2 = entire line). Together they
+// move the cursor to column 0 and clear whatever was previously rendered there,
+// so the next write starts on a clean line. Used between throttled redraws.
+constexpr const char* ANSI_RESET_LINE = "\r\033[2K";
+
+[[nodiscard]] std::int64_t
+now_ns() noexcept
+{
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+
+[[nodiscard]] bool
+stream_is_tty(std::FILE* stream) noexcept
+{
+    if(stream == nullptr) return false;
+    const int fd = ::fileno(stream);
+    if(fd < 0) return false;
+    return ::isatty(fd) != 0;
+}
+}  // namespace
+
+bar::bar(std::string label, std::uint64_t total, bar_options opts)
+: m_label(std::move(label))
+, m_opts(opts)
+, m_total(total)
+{
+    // Sample visibility once at construction. Verbose level and the stream's
+    // TTY-ness are set during process startup and do not change during a
+    // post-processing run, so re-checking on every advance would be waste.
+    m_visible = m_opts.enabled && m_opts.verbose >= 0 && stream_is_tty(m_opts.stream);
+}
+
+// Idempotent: on_finish()'s CAS short-circuits if it was called already.
+bar::~bar() { on_finish(); }
+
+void
+bar::on_set_total(std::uint64_t total) noexcept
+{
+    m_total.store(total, std::memory_order_relaxed);
+}
+
+void
+bar::on_advance(std::uint64_t delta) noexcept
+{
+    if(delta == 0) return;
+    const auto prev    = m_current.fetch_add(delta, std::memory_order_relaxed);
+    const auto current = prev + delta;
+    const auto total   = m_total.load(std::memory_order_relaxed);
+
+    if(!m_visible) return;
+
+    // Finalize as soon as we cross the total so the bar's last line lands
+    // before any other code (e.g. file_output_message) writes to stderr.
+    if(total > 0 && current >= total)
+    {
+        on_finish();
+        return;
+    }
+    try_render();
+}
+
+void
+bar::on_finish() noexcept
+{
+    bool expected = false;
+    if(!m_finished.compare_exchange_strong(expected, true, std::memory_order_acq_rel))
+        return;
+    if(!m_visible) return;
+
+    std::lock_guard<std::mutex> lock{ m_render_mtx };
+    const auto                  total = m_total.load(std::memory_order_relaxed);
+    if(total > 0) m_current.store(total, std::memory_order_relaxed);
+    render_locked();
+    std::fputc('\n', m_opts.stream);
+    std::fflush(m_opts.stream);
+}
+
+void
+bar::try_render() noexcept
+{
+    // Cheap pre-check: avoid even attempting the lock once finished.
+    if(m_finished.load(std::memory_order_acquire)) return;
+
+    // Acquire the render lock first so the throttle timestamp is only read
+    // and updated by the single thread that will actually render. This avoids
+    // burning the throttle slot when contention causes try_lock() to fail.
+    std::unique_lock<std::mutex> lock{ m_render_mtx, std::try_to_lock };
+    if(!lock.owns_lock()) return;
+
+    // Re-check under the lock: on_finish() may have completed between the
+    // pre-check and acquiring the lock. Without this, a partial bar would be
+    // written after the final newline, leaving stray output on the next line.
+    if(m_finished.load(std::memory_order_relaxed)) return;
+
+    const auto now = now_ns();
+    const auto interval =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(m_opts.tick).count();
+    if(now - m_last_render_ns.load(std::memory_order_relaxed) < interval) return;
+    m_last_render_ns.store(now, std::memory_order_relaxed);
+
+    render_locked();
+}
+
+void
+bar::render_locked() noexcept
+{
+    const auto total   = m_total.load(std::memory_order_relaxed);
+    const auto current = std::min(m_current.load(std::memory_order_relaxed), total);
+
+    const double frac =
+        (total == 0) ? 0.0 : static_cast<double>(current) / static_cast<double>(total);
+    const auto width   = static_cast<std::size_t>(m_opts.width);
+    const auto bar_str = detail::format_bar(m_opts.style, width, frac);
+    const auto sep     = bar_str.empty() ? "" : " ";
+
+    std::fputs(ANSI_RESET_LINE, m_opts.stream);
+    std::fprintf(m_opts.stream, "%s%s%s %3.0f%%", m_label.c_str(), sep, bar_str.c_str(),
+                 frac * 100.0);
+    std::fflush(m_opts.stream);
+}
+
+}  // namespace rocprofsys::progress

--- a/projects/rocprofiler-systems/source/lib/core/progress/bar.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/progress/bar.hpp
@@ -1,0 +1,123 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <mutex>
+#include <string>
+
+namespace rocprofsys::progress
+{
+
+/**
+ * @brief Visual style for the rendered bar.
+ *
+ * - `ascii_brackets` (default): `[######......]` - safe everywhere.
+ * - `ascii_arrow`:              `[======>     ]` - leading edge marker.
+ * - `unicode_blocks`:           `[##########  ]` using 1/8-cell sub-precision
+ *                               via U+2588 etc. Requires a UTF-8 terminal.
+ * - `unicode_dots`:             `●●●●●●○○○○○○` - no brackets, dot fill.
+ *                               Requires a UTF-8 terminal.
+ * - `text_only`:                no bar drawn, just label + percent + counts.
+ */
+enum class bar_style
+{
+    ascii_brackets,
+    ascii_arrow,
+    unicode_blocks,
+    unicode_dots,
+    text_only
+};
+
+/**
+ * @brief Configuration for bar.
+ *
+ * @note `stream` is a `std::FILE*` rather than a `std::ostream&` so the
+ *       renderer can emit raw control sequences (`\r\033[2K`) and use
+ *       `printf`-style formatting cheaply.
+ * @note `verbose` is injected by the caller (typically the application's
+ *       configuration layer). The bar treats negative values as "quiet"
+ *       and skips all rendering. Keeping the dependency external means the
+ *       bar has no ties to the global config singleton, so it is unit-
+ *       testable in isolation.
+ */
+struct bar_options
+{
+    std::uint32_t             width   = 40;
+    std::chrono::milliseconds tick    = std::chrono::milliseconds{ 100 };
+    std::FILE*                stream  = stderr;
+    bool                      enabled = true;
+    int                       verbose = 0;
+    bar_style                 style   = bar_style::ascii_brackets;
+};
+
+namespace detail
+{
+/**
+ * @brief Renders the bar fill for a given style at fractional fill @p frac.
+ *
+ * Pure / side-effect-free; exposed in the header so it can be unit-tested
+ * without a TTY. @p frac is clamped to `[0, 1]` internally.
+ */
+[[nodiscard]] std::string
+format_bar(bar_style style, std::size_t width, double frac);
+}  // namespace detail
+
+/**
+ * @brief TTY-aware, throttled progress renderer.
+ *
+ * Producers report progress by calling `on_advance(delta)`. The bar is
+ * thread-safe so multiple worker threads may share a single instance.
+ * Typically a producer wraps the bar in a `progress::progress_callback`
+ * lambda -> see `core/progress/callback.hpp`.
+ *
+ * Behaviour:
+ * - When the configured @ref bar_options::stream is not a TTY, or when
+ *   verbose level is below 0, or when @ref bar_options::enabled is false,
+ *   the bar is silent - `on_*` calls update internal counters but never
+ *   render.
+ * - When visible, advances are throttled to one redraw per
+ *   @ref bar_options::tick interval. Each redraw issues `\r\033[2K` to
+ *   reset the current terminal line in place. Render is gated by
+ *   `try_lock` so only one thread at a time formats output; other threads
+ *   simply skip.
+ * - `on_finish()` (or destruction) prints the final line followed by a
+ *   newline so subsequent log lines are not clobbered.
+ *
+ * Thread-safety: `on_advance` is safe to call from multiple threads.
+ */
+class bar
+{
+public:
+    bar(std::string label, std::uint64_t total, bar_options opts = {});
+    ~bar();
+
+    bar(const bar&)            = delete;
+    bar& operator=(const bar&) = delete;
+    bar(bar&&)                 = delete;
+    bar& operator=(bar&&)      = delete;
+
+    void on_set_total(std::uint64_t total) noexcept;
+    void on_advance(std::uint64_t delta) noexcept;
+    void on_finish() noexcept;
+
+private:
+    void try_render() noexcept;
+    void render_locked() noexcept;
+
+    std::string                m_label;
+    bar_options                m_opts;
+    std::atomic<std::uint64_t> m_total;
+    std::atomic<std::uint64_t> m_current{ 0 };
+    std::atomic<std::int64_t>  m_last_render_ns{ 0 };
+    std::mutex                 m_render_mtx;
+    std::atomic<bool>          m_finished{ false };
+    bool                       m_visible{ false };
+};
+
+}  // namespace rocprofsys::progress

--- a/projects/rocprofiler-systems/source/lib/core/progress/bar.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/progress/bar.hpp
@@ -117,7 +117,7 @@ private:
     std::atomic<std::int64_t>  m_last_render_ns{ 0 };
     std::mutex                 m_render_mtx;
     std::atomic<bool>          m_finished{ false };
-    bool                       m_visible{ false };
+    const bool                 m_visible;
 };
 
 }  // namespace rocprofsys::progress

--- a/projects/rocprofiler-systems/source/lib/core/progress/callback.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/progress/callback.hpp
@@ -1,0 +1,23 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+namespace rocprofsys::progress
+{
+
+/**
+ * @brief Callback invoked by a producer (e.g. storage_parser) to report
+ *        incremental byte progress to a consumer (e.g. progress::bar).
+ *
+ * The argument is the delta in bytes since the previous invocation. An
+ * empty (default-constructed) `progress_callback` means "no progress
+ * reporting requested" and producers should skip the per-record overhead
+ * of computing deltas.
+ */
+using progress_callback = std::function<void(std::uint64_t /*delta_bytes*/)>;
+
+}  // namespace rocprofsys::progress

--- a/projects/rocprofiler-systems/source/lib/core/progress/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/progress/tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+set(progress_tests_sources test_format_bar.cpp test_bar_silent.cpp)
+
+add_library(progress-tests OBJECT ${progress_tests_sources})
+
+target_link_libraries(
+    progress-tests
+    PRIVATE rocprofiler-systems-googletest-library rocprofiler-systems-core-library
+)
+
+target_include_directories(progress-tests PRIVATE ${PROJECT_SOURCE_DIR}/source/lib)

--- a/projects/rocprofiler-systems/source/lib/core/progress/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/progress/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-set(progress_tests_sources test_format_bar.cpp test_bar_silent.cpp)
+set(progress_tests_sources test_format_bar.cpp test_bar_silent.cpp test_tracker.cpp)
 
 add_library(progress-tests OBJECT ${progress_tests_sources})
 

--- a/projects/rocprofiler-systems/source/lib/core/progress/tests/test_bar_silent.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/progress/tests/test_bar_silent.cpp
@@ -1,0 +1,118 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "core/progress/bar.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <sys/stat.h>
+
+namespace rocprofsys::progress
+{
+namespace
+{
+class bar_silent_test : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        m_path = "bar_silent_test_" + std::to_string(s_counter++) + ".log";
+        m_fp   = std::fopen(m_path.c_str(), "w");
+        ASSERT_NE(m_fp, nullptr);
+        // Regular file (not a TTY) keeps the bar silent, so no rendering
+        // happens regardless of other options.
+        m_opts.stream = m_fp;
+        m_opts.tick   = std::chrono::milliseconds{ 0 };
+    }
+
+    void TearDown() override
+    {
+        if(m_fp != nullptr)
+        {
+            std::fclose(m_fp);
+            m_fp = nullptr;
+        }
+        std::remove(m_path.c_str());
+    }
+
+    [[nodiscard]] std::uint64_t file_size_after_close()
+    {
+        std::fclose(m_fp);
+        m_fp = nullptr;
+        struct stat st
+        {};
+        if(::stat(m_path.c_str(), &st) != 0) return 0;
+        return static_cast<std::uint64_t>(st.st_size);
+    }
+
+    std::string       m_path;
+    std::FILE*        m_fp = nullptr;
+    bar_options       m_opts;
+    static inline int s_counter = 0;
+};
+}  // namespace
+
+TEST_F(bar_silent_test, non_tty_stream_produces_no_output)
+{
+    {
+        bar b{ "label", 100, m_opts };
+        b.on_advance(50);
+        b.on_advance(50);
+    }
+    EXPECT_EQ(file_size_after_close(), 0u);
+}
+
+TEST_F(bar_silent_test, negative_verbose_silences_bar)
+{
+    m_opts.verbose = -1;
+    {
+        bar b{ "label", 100, m_opts };
+        b.on_advance(100);
+    }
+    EXPECT_EQ(file_size_after_close(), 0u);
+}
+
+TEST_F(bar_silent_test, enabled_false_silences_bar)
+{
+    m_opts.enabled = false;
+    {
+        bar b{ "label", 100, m_opts };
+        b.on_advance(100);
+    }
+    EXPECT_EQ(file_size_after_close(), 0u);
+}
+
+TEST_F(bar_silent_test, on_advance_zero_is_noop)
+{
+    {
+        bar b{ "label", 100, m_opts };
+        b.on_advance(0);
+        b.on_finish();
+    }
+    EXPECT_EQ(file_size_after_close(), 0u);
+}
+
+TEST_F(bar_silent_test, on_finish_is_idempotent)
+{
+    bar b{ "label", 10, m_opts };
+    b.on_finish();
+    b.on_finish();
+    b.on_finish();
+    SUCCEED();  // Must not assert / double-write / re-acquire mutex twice.
+}
+
+TEST_F(bar_silent_test, on_set_total_does_not_write)
+{
+    {
+        bar b{ "label", 0, m_opts };
+        b.on_set_total(500);
+        b.on_advance(250);
+    }
+    EXPECT_EQ(file_size_after_close(), 0u);
+}
+
+}  // namespace rocprofsys::progress

--- a/projects/rocprofiler-systems/source/lib/core/progress/tests/test_format_bar.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/progress/tests/test_format_bar.cpp
@@ -1,0 +1,76 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "core/progress/bar.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace rocprofsys::progress::detail
+{
+
+TEST(format_bar_test, ascii_brackets_empty)
+{
+    EXPECT_EQ(format_bar(bar_style::ascii_brackets, 10, 0.0), "[..........]");
+}
+
+TEST(format_bar_test, ascii_brackets_half)
+{
+    EXPECT_EQ(format_bar(bar_style::ascii_brackets, 10, 0.5), "[#####.....]");
+}
+
+TEST(format_bar_test, ascii_brackets_full)
+{
+    EXPECT_EQ(format_bar(bar_style::ascii_brackets, 10, 1.0), "[##########]");
+}
+
+TEST(format_bar_test, ascii_brackets_clamps_above_one)
+{
+    // frac > 1.0 must clamp; otherwise size_t underflow corrupts the string.
+    EXPECT_EQ(format_bar(bar_style::ascii_brackets, 10, 1.5), "[##########]");
+}
+
+TEST(format_bar_test, ascii_brackets_clamps_below_zero)
+{
+    EXPECT_EQ(format_bar(bar_style::ascii_brackets, 10, -0.5), "[..........]");
+}
+
+TEST(format_bar_test, ascii_arrow_empty)
+{
+    EXPECT_EQ(format_bar(bar_style::ascii_arrow, 10, 0.0), "[          ]");
+}
+
+TEST(format_bar_test, ascii_arrow_partial_has_arrowhead)
+{
+    EXPECT_EQ(format_bar(bar_style::ascii_arrow, 10, 0.5), "[====>     ]");
+}
+
+TEST(format_bar_test, ascii_arrow_full_no_arrowhead)
+{
+    EXPECT_EQ(format_bar(bar_style::ascii_arrow, 10, 1.0), "[==========]");
+}
+
+TEST(format_bar_test, unicode_blocks_full_uses_full_block)
+{
+    const std::string out = format_bar(bar_style::unicode_blocks, 4, 1.0);
+    EXPECT_EQ(out, "[\xe2\x96\x88\xe2\x96\x88\xe2\x96\x88\xe2\x96\x88]");
+}
+
+TEST(format_bar_test, unicode_blocks_empty_is_spaces)
+{
+    EXPECT_EQ(format_bar(bar_style::unicode_blocks, 4, 0.0), "[    ]");
+}
+
+TEST(format_bar_test, text_only_is_empty)
+{
+    EXPECT_EQ(format_bar(bar_style::text_only, 10, 0.5), "");
+}
+
+TEST(format_bar_test, unicode_dots_full_no_brackets)
+{
+    const std::string out = format_bar(bar_style::unicode_dots, 3, 1.0);
+    EXPECT_EQ(out, "\xe2\x97\x8f\xe2\x97\x8f\xe2\x97\x8f");
+}
+
+}  // namespace rocprofsys::progress::detail

--- a/projects/rocprofiler-systems/source/lib/core/progress/tests/test_tracker.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/progress/tests/test_tracker.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "core/progress/tracker.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace rocprofsys::progress
+{
+
+TEST(tracker_test, begin_with_factory_invokes_factory_with_label_and_total)
+{
+    std::string   recorded_label;
+    std::uint64_t recorded_total = 0;
+
+    tracker t{ [&recorded_label, &recorded_total](std::string   label,
+                                                  std::uint64_t total) {
+        recorded_label = std::move(label);
+        recorded_total = total;
+        return progress_callback{};
+    } };
+
+    (void) t.begin("perfetto: pid_1234.bin", 4096);
+
+    EXPECT_EQ(recorded_label, "perfetto: pid_1234.bin");
+    EXPECT_EQ(recorded_total, 4096U);
+}
+
+TEST(tracker_test, begin_returned_callback_advances_captured_renderer)
+{
+    struct recording_renderer
+    {
+        std::uint64_t total_advanced = 0;
+        void on_advance(std::uint64_t delta) noexcept { total_advanced += delta; }
+    };
+
+    auto    renderer = std::make_shared<recording_renderer>();
+    tracker t{ [renderer](std::string, std::uint64_t) {
+        return progress_callback{ [renderer](std::uint64_t delta) {
+            renderer->on_advance(delta);
+        } };
+    } };
+
+    auto cb = t.begin("rocpd", 1000);
+    cb(100);
+    cb(250);
+    cb(50);
+
+    EXPECT_EQ(renderer->total_advanced, 400U);
+}
+
+TEST(tracker_test, begin_with_empty_factory_returns_empty_callback)
+{
+    tracker t{ tracker::factory_t{} };
+
+    auto cb = t.begin("anything", 1234);
+
+    EXPECT_FALSE(static_cast<bool>(cb));
+}
+
+TEST(tracker_test, callback_outlives_call_site_and_still_advances_renderer)
+{
+    struct recording_renderer
+    {
+        std::uint64_t total_advanced = 0;
+        void on_advance(std::uint64_t delta) noexcept { total_advanced += delta; }
+    };
+
+    auto              renderer = std::make_shared<recording_renderer>();
+    progress_callback escaped_cb;
+
+    {
+        tracker t{ [renderer](std::string, std::uint64_t) {
+            return progress_callback{ [renderer](std::uint64_t delta) {
+                renderer->on_advance(delta);
+            } };
+        } };
+
+        escaped_cb = t.begin("scoped", 1000);
+        // tracker goes out of scope here; the renderer must still be reachable
+        // through escaped_cb's captured shared_ptr.
+    }
+
+    escaped_cb(42);
+    escaped_cb(58);
+
+    EXPECT_EQ(renderer->total_advanced, 100U);
+}
+
+}  // namespace rocprofsys::progress

--- a/projects/rocprofiler-systems/source/lib/core/progress/tracker.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/progress/tracker.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "core/progress/tracker.hpp"
+
+#include <cstdint>
+#include <utility>
+
+namespace rocprofsys::progress
+{
+
+tracker::tracker(factory_t make) noexcept
+: m_make(std::move(make))
+{}
+
+progress_callback
+tracker::begin(std::string label, std::uint64_t total_bytes)
+{
+    if(!m_make) return {};
+    return m_make(std::move(label), total_bytes);
+}
+
+}  // namespace rocprofsys::progress

--- a/projects/rocprofiler-systems/source/lib/core/progress/tracker.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/progress/tracker.hpp
@@ -1,0 +1,34 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "core/progress/callback.hpp"
+
+#include <cstdint>
+#include <functional>
+#include <string>
+
+namespace rocprofsys::progress
+{
+
+class tracker
+{
+public:
+    using factory_t = std::function<progress_callback(std::string, std::uint64_t)>;
+
+    explicit tracker(factory_t make) noexcept;
+    ~tracker() = default;
+
+    tracker(const tracker&)            = delete;
+    tracker& operator=(const tracker&) = delete;
+    tracker(tracker&&)                 = delete;
+    tracker& operator=(tracker&&)      = delete;
+
+    [[nodiscard]] progress_callback begin(std::string label, std::uint64_t total_bytes);
+
+private:
+    factory_t m_make;
+};
+
+}  // namespace rocprofsys::progress

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/CMakeLists.txt
@@ -4,13 +4,18 @@
 set(trace_cache_sources
     ${CMAKE_CURRENT_LIST_DIR}/cache_manager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/buffer_storage.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/data_types.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/discovery.cpp
     ${CMAKE_CURRENT_LIST_DIR}/metadata_registry.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/post_processor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rocpd_processor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/perfetto_processor.cpp
 )
 
 set(trace_cache_headers
     ${CMAKE_CURRENT_LIST_DIR}/cache_manager.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/data_types.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/discovery.hpp
     ${CMAKE_CURRENT_LIST_DIR}/storage_parser.hpp
     ${CMAKE_CURRENT_LIST_DIR}/buffer_storage.hpp
     ${CMAKE_CURRENT_LIST_DIR}/cacheable.hpp
@@ -19,8 +24,10 @@ set(trace_cache_headers
     ${CMAKE_CURRENT_LIST_DIR}/metadata_registry.hpp
     ${CMAKE_CURRENT_LIST_DIR}/rocpd_processor.hpp
     ${CMAKE_CURRENT_LIST_DIR}/perfetto_processor.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/post_processor.hpp
     ${CMAKE_CURRENT_LIST_DIR}/sample_processor.hpp
     ${CMAKE_CURRENT_LIST_DIR}/sample_type.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/storage_parser_alias.hpp
 )
 
 target_sources(rocprofiler-systems-core-library PRIVATE ${trace_cache_sources})

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/cache_manager.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/cache_manager.cpp
@@ -4,534 +4,22 @@
 #include "cache_manager.hpp"
 #include <cstdint>
 
-#include "core/output_file_registry.hpp"
-#include "core/trace_cache/metadata_registry.hpp"
-#include "core/trace_cache/perfetto_processor.hpp"
-#include "core/trace_cache/rocpd_processor.hpp"
-#include "core/trace_cache/sample_processor.hpp"
-
 #include "core/agent_manager.hpp"
 #include "core/config.hpp"
-#include "core/timemory.hpp"
-
+#include "core/output_file_registry.hpp"
+#include "core/trace_cache/data_types.hpp"
+#include "core/trace_cache/discovery.hpp"
+#include "core/trace_cache/post_processor.hpp"
 #include "library/runtime.hpp"
 #include "logger/debug.hpp"
 
-#include <algorithm>
-#include <cstring>
-#include <fstream>
 #include <memory>
-#include <sstream>
-#include <stdexcept>
-#include <vector>
+#include <unistd.h>
 
 namespace rocprofsys
 {
 namespace trace_cache
 {
-
-namespace data
-{
-struct cache_files_t
-{
-    std::string buff_storage;
-    std::string metadata;
-    inline bool empty() const { return buff_storage.empty() || metadata.empty(); }
-};
-
-struct format_t
-{
-    bool        process_parallel;
-    bool        enabled;
-    const char* name;
-};
-
-struct enabled_formats_t
-{
-    std::vector<format_t> formats = { { true, get_use_rocpd(), "rocpd" },
-                                      { false, get_caching_perfetto(), "perfetto" } };
-
-    void print() const
-    {
-        if(std::none_of(formats.begin(), formats.end(),
-                        [](const auto& f) { return f.enabled; }))
-            return;
-
-        std::stringstream ss;
-        bool              first = true;
-
-        for(const auto& fmt : formats)
-        {
-            if(fmt.enabled)
-            {
-                if(!first) ss << ", ";
-                ss << fmt.name;
-                first = false;
-            }
-        }
-
-        LOG_INFO(
-            "Generating [{}] format(s) with collected data from trace cache. This may "
-            "take a while..",
-            ss.str().c_str());
-
-        if(has_parallel_formats())
-        {
-            std::stringstream parallel_ss;
-            bool              first_parallel = true;
-            for(const auto& fmt : formats)
-            {
-                if(fmt.enabled && fmt.process_parallel)
-                {
-                    if(!first_parallel) parallel_ss << ", ";
-                    parallel_ss << fmt.name;
-                    first_parallel = false;
-                }
-            }
-            LOG_INFO("  - Using parallel processing for: {}", parallel_ss.str());
-        }
-
-        if(has_sequential_formats())
-        {
-            std::stringstream sequential_ss;
-            bool              first_sequential = true;
-            for(const auto& fmt : formats)
-            {
-                if(fmt.enabled && !fmt.process_parallel)
-                {
-                    if(!first_sequential) sequential_ss << ", ";
-                    sequential_ss << fmt.name;
-                    first_sequential = false;
-                }
-            }
-            LOG_INFO("  - Using sequential processing for: {}",
-                     sequential_ss.str().c_str());
-        }
-    }
-
-    bool has_parallel_formats() const
-    {
-        return std::any_of(formats.begin(), formats.end(),
-                           [](const auto& f) { return f.enabled && f.process_parallel; });
-    }
-
-    bool has_sequential_formats() const
-    {
-        return std::any_of(formats.begin(), formats.end(), [](const auto& f) {
-            return f.enabled && !f.process_parallel;
-        });
-    }
-
-    enabled_formats_t get_parallel_formats() const
-    {
-        enabled_formats_t parallel_formats;
-        parallel_formats.formats.clear();
-        for(const auto& fmt : formats)
-        {
-            parallel_formats.formats.push_back(
-                { true, fmt.enabled && fmt.process_parallel, fmt.name });
-        }
-        return parallel_formats;
-    }
-
-    enabled_formats_t get_sequential_formats() const
-    {
-        enabled_formats_t sequential_formats;
-        sequential_formats.formats.clear();
-        for(const auto& fmt : formats)
-        {
-            sequential_formats.formats.push_back(
-                { false, fmt.enabled && !fmt.process_parallel, fmt.name });
-        }
-        return sequential_formats;
-    }
-
-    bool is_rocpd_enabled() const
-    {
-        auto it = std::find_if(formats.begin(), formats.end(), [](const auto& f) {
-            return std::strcmp(f.name, "rocpd") == 0;
-        });
-        return it != formats.end() && it->enabled;
-    }
-
-    bool is_perfetto_enabled() const
-    {
-        auto it = std::find_if(formats.begin(), formats.end(), [](const auto& f) {
-            return std::strcmp(f.name, "perfetto") == 0;
-        });
-        return it != formats.end() && it->enabled;
-    }
-};
-
-struct processor_config_t
-{
-    processor_config_t(pid_t pid, pid_t ppid,
-                       std::shared_ptr<metadata_registry> metadata_registry_ptr,
-                       std::shared_ptr<agent_manager>     agent_manager_ptr)
-    : _pid(pid)
-    , _ppid(ppid)
-    , _metadata_registry(std::move(metadata_registry_ptr))
-    , _agent_manager(std::move(agent_manager_ptr))
-    {}
-
-    pid_t _pid;
-    pid_t _ppid;
-
-    std::shared_ptr<metadata_registry> _metadata_registry;
-    std::shared_ptr<agent_manager>     _agent_manager;
-};
-
-struct processor_storage_t
-{
-    std::shared_ptr<rocpd_processor_t>    rocpd_processor{ nullptr };
-    std::shared_ptr<perfetto_processor_t> perfetto_processor{ nullptr };
-};
-
-using directory_files_t    = std::vector<std::string>;
-using mapped_cache_files_t = std::map<pid_t, cache_files_t>;
-}  // namespace data
-
-namespace filesystem_utils
-{
-
-void
-remove_if_exists(const std::string& fname)
-{
-    if(fname.empty()) return;
-    std::ifstream file(fname);
-    if(file.is_open())
-    {
-        file.close();
-        auto result = std::remove(fname.c_str());
-        if(result == 0)
-        {
-            LOG_DEBUG("Removed file: {}", fname);
-        }
-        else if(errno == ENOENT)
-        {
-            LOG_DEBUG("File does not exist: {}", fname);
-        }
-        else
-        {
-            LOG_WARNING("Failed to remove file: {} (errno: {} - {})", fname, errno,
-                        std::strerror(errno));
-        }
-    }
-}
-
-data::directory_files_t
-list_dir_files(const std::string& _path)
-{
-    if(_path.empty())
-    {
-        return {};
-    }
-
-    auto dir_deleter = [](DIR* d) {
-        if(d) closedir(d);
-    };
-
-    std::unique_ptr<DIR, decltype(dir_deleter)> dir(opendir(_path.c_str()), dir_deleter);
-
-    if(!dir)
-    {
-        throw std::runtime_error(fmt::format("Error opening directory: {}", _path));
-    }
-
-    data::directory_files_t result{};
-    dirent*                 entry;
-
-    while((entry = readdir(dir.get())) != nullptr)
-    {
-        if(std::string(entry->d_name) != "." && std::string(entry->d_name) != "..")
-        {
-            result.emplace_back(entry->d_name);
-        }
-    }
-
-    return result;
-}
-
-data::mapped_cache_files_t
-get_cache_files(const pid_t&                   root_pid,
-                const data::directory_files_t& _files_from_temp_directory)
-{
-    if(_files_from_temp_directory.empty())
-    {
-        return {};
-    }
-
-    data::mapped_cache_files_t cache_map{};
-
-    auto parse_and_fill_cache = [&](const std::string& filename) {
-        if(filename.empty())
-        {
-            return;
-        }
-
-        const std::regex buff_regex(R"(buffered_storage_(\d+)_(\d+)\.bin)");
-        const std::regex meta_regex(R"(metadata_(\d+)_(\d+)\.json)");
-        std::smatch      match;
-
-        if(std::regex_match(filename, match, buff_regex))
-        {
-            int parent_pid = std::stoi(match[1]);
-            int pid        = std::stoi(match[2]);
-            if(parent_pid == root_pid)
-            {
-                cache_map[pid].buff_storage = trace_cache::tmp_directory + filename;
-            }
-        }
-        else if(std::regex_match(filename, match, meta_regex))
-        {
-            int parent_pid = std::stoi(match[1]);
-            int pid        = std::stoi(match[2]);
-            if(parent_pid == root_pid)
-            {
-                cache_map[pid].metadata = trace_cache::tmp_directory + filename;
-            }
-        }
-    };
-
-    std::for_each(_files_from_temp_directory.begin(), _files_from_temp_directory.end(),
-                  parse_and_fill_cache);
-    return cache_map;
-}
-
-void
-clear_cache_files(const data::mapped_cache_files_t& _cache_files)
-{
-    LOG_DEBUG("Removing cached temporary files...");
-    for(const auto& [_, files] : _cache_files)
-    {
-        LOG_DEBUG("Removing cached temporary file: {}", files.buff_storage);
-        filesystem_utils::remove_if_exists(files.buff_storage);
-
-        LOG_DEBUG("Removing cached temporary file: {}", files.metadata);
-        filesystem_utils::remove_if_exists(files.metadata);
-    }
-}
-
-void
-merge_perfetto_files()
-{
-    // MPI merge: use merge script to combine traces from all MPI ranks
-    // This matches the legacy behavior in perfetto.cpp
-    //
-    //
-    // IMPORTANT: dmp::rank() returns 0 if MPI is not initialized/finalized.
-    // During shutdown, MPI may already be finalized, so we use
-    // settings::default_process_suffix() which was set to dmp::rank() during
-    // initialization
-
-    auto         suffix_variant  = settings::default_process_suffix();
-    std::int32_t cached_mpi_rank = 0;
-
-    if(std::holds_alternative<int>(suffix_variant))
-    {
-        cached_mpi_rank = std::get<int>(suffix_variant);
-    }
-    else if(std::holds_alternative<std::string>(suffix_variant))
-    {
-        try
-        {
-            cached_mpi_rank = std::stoi(std::get<std::string>(suffix_variant));
-        } catch(...)
-        {
-            cached_mpi_rank = 0;
-        }
-    }
-
-    LOG_DEBUG("Merging perfetto files: rank={} (from settings::default_process_suffix)",
-              cached_mpi_rank);
-
-    // Only rank 0 performs the merge
-    if(cached_mpi_rank == 0)
-    {
-        auto _filename      = config::get_perfetto_output_filename();
-        auto _output_folder = tim::filepath::dirname(_filename);
-        auto _script_path   = std::string{ "rocprof-sys-merge-output.sh" };
-        auto _script_dir    = get_env("ROCPROFSYS_SCRIPT_PATH", std::string{}, false);
-
-        if(!_script_dir.empty())
-        {
-            _script_path = fmt::format("{}/{}", _script_dir, _script_path);
-        }
-
-        if(!tim::filepath::exists(_script_path))
-        {
-            LOG_WARNING("Merge script not found: {}", _script_path);
-        }
-        else
-        {
-            auto _command = _script_path + " '" + _output_folder + "'";
-
-            int result = system(_command.c_str());
-
-            if(result != 0)
-            {
-                LOG_ERROR("Failed to execute merge script: {}", _command);
-            }
-            else
-            {
-                LOG_INFO("Successfully executed: {}", _command);
-            }
-        }
-    }
-}
-}  // namespace filesystem_utils
-
-namespace processing_utils
-{
-[[nodiscard]] data::processor_storage_t
-configure_processors(const std::shared_ptr<sample_processor_t>&       _type_processing,
-                     const std::shared_ptr<data::processor_config_t>& _processor_config,
-                     const data::enabled_formats_t&                   _enabled_formats,
-                     output_file_registry&                            _output_registry)
-{
-    data::processor_storage_t processor_storage;
-    if(_enabled_formats.is_rocpd_enabled())
-    {
-        processor_storage.rocpd_processor = std::make_shared<rocpd_processor_t>(
-            _processor_config->_metadata_registry, _processor_config->_agent_manager,
-            _processor_config->_pid, _processor_config->_ppid, _output_registry);
-        _type_processing->add_handler(*processor_storage.rocpd_processor);
-    }
-    if(_enabled_formats.is_perfetto_enabled())
-    {
-        processor_storage.perfetto_processor = std::make_shared<perfetto_processor_t>(
-            _processor_config->_metadata_registry, _processor_config->_agent_manager,
-            _processor_config->_pid, _processor_config->_ppid, _output_registry);
-        _type_processing->add_handler(*processor_storage.perfetto_processor);
-    }
-    return processor_storage;
-}
-
-void
-process_buffered_storage(
-    const std::shared_ptr<data::processor_config_t>& _processor_config,
-    const std::string& _storage_filename, const data::enabled_formats_t& _enabled_formats,
-    output_file_registry& _output_registry)
-{
-    LOG_DEBUG("Processing buffered storage: {} for pid={}", _storage_filename,
-              _processor_config->_pid);
-
-    auto _processor_coordinator = std::make_shared<sample_processor_t>();
-    auto processor_storage      = configure_processors(
-        _processor_coordinator, _processor_config, _enabled_formats, _output_registry);
-    storage_parser_t _parser(_storage_filename);
-
-    _processor_coordinator->prepare_for_processing();
-    try
-    {
-        _parser.load(_processor_coordinator);
-        LOG_TRACE("Successfully loaded buffered storage: {}", _storage_filename);
-    } catch(const std::runtime_error& exp)
-    {
-        LOG_WARNING("Error parsing buffered storage {}: {}", _storage_filename,
-                    exp.what());
-    }
-    _processor_coordinator->finalize_processing();
-
-    LOG_DEBUG("Finished processing buffered storage: {}", _storage_filename);
-}
-
-std::vector<std::shared_ptr<data::processor_config_t>>
-create_processor_configs(const data::mapped_cache_files_t& _cache_files,
-                         const pid_t&                      _root_pid)
-{
-    constexpr size_t ROOT_PROCESS_INCREMENT{ 1 };
-
-    std::vector<std::shared_ptr<data::processor_config_t>> processor_configs;
-    processor_configs.reserve(_cache_files.size() + ROOT_PROCESS_INCREMENT);
-
-    for(const auto& [pid, files] : _cache_files)
-    {
-        if(files.empty())
-        {
-            continue;
-        }
-
-        std::vector<std::shared_ptr<agent>> _agents;
-        auto _metadata = std::make_shared<metadata_registry>();
-        _metadata->load_from_file(files.metadata, _agents);
-
-        auto _agent_manager = std::make_shared<agent_manager>(_agents);
-
-        processor_configs.push_back(std::make_shared<data::processor_config_t>(
-            pid, _root_pid, _metadata, _agent_manager));
-    }
-    return processor_configs;
-}
-
-void
-multithreaded_processing(
-    const std::vector<std::shared_ptr<data::processor_config_t>>& _processor_configs,
-    const data::enabled_formats_t&                                _enabled_formats,
-    output_file_registry&                                         _output_registry)
-{
-    LOG_DEBUG("Starting multithreaded processing with {} configs",
-              _processor_configs.size());
-    ROCPROFSYS_SCOPED_SAMPLING_ON_CHILD_THREADS(false);
-
-    std::vector<std::thread> processing_threads;
-    processing_threads.reserve(_processor_configs.size());
-    for(const auto& processor_config : _processor_configs)
-    {
-        LOG_TRACE("Spawning processing thread for pid={}", processor_config->_pid);
-        processing_threads.emplace_back(
-            process_buffered_storage, processor_config,
-            utility::get_buffered_storage_filename(processor_config->_ppid,
-                                                   processor_config->_pid),
-            _enabled_formats, std::ref(_output_registry));
-    }
-
-    LOG_TRACE("Waiting for {} processing threads to complete", processing_threads.size());
-    for(auto& thread : processing_threads)
-    {
-        thread.join();
-    }
-    LOG_DEBUG("Multithreaded processing completed");
-}
-
-void
-sequential_processing(
-    const std::vector<std::shared_ptr<data::processor_config_t>>& _processor_configs,
-    const data::enabled_formats_t&                                _enabled_formats,
-    output_file_registry&                                         _output_registry)
-{
-    LOG_DEBUG("Starting sequential processing with {} configs",
-              _processor_configs.size());
-    for(const auto& processor_config : _processor_configs)
-    {
-        LOG_TRACE("Processing config for pid={}", processor_config->_pid);
-        process_buffered_storage(processor_config,
-                                 utility::get_buffered_storage_filename(
-                                     processor_config->_ppid, processor_config->_pid),
-                                 _enabled_formats, _output_registry);
-    }
-    LOG_DEBUG("Sequential processing completed");
-}
-
-void
-dispatch_processing(
-    const std::vector<std::shared_ptr<data::processor_config_t>>& _processor_configs,
-    const data::enabled_formats_t&                                _enabled_formats,
-    output_file_registry&                                         _output_registry)
-{
-    if(_enabled_formats.has_sequential_formats())
-    {
-        auto sequential_formats = _enabled_formats.get_sequential_formats();
-        sequential_processing(_processor_configs, sequential_formats, _output_registry);
-    }
-    if(_enabled_formats.has_parallel_formats())
-    {
-        auto parallel_formats = _enabled_formats.get_parallel_formats();
-        multithreaded_processing(_processor_configs, parallel_formats, _output_registry);
-    }
-}
-
-}  // namespace processing_utils
 
 cache_manager&
 cache_manager::get_instance()
@@ -541,7 +29,8 @@ cache_manager::get_instance()
 }
 
 void
-cache_manager::post_process_bulk(output_file_registry& _output_registry)
+cache_manager::post_process_bulk(output_file_registry& _output_registry,
+                                 progress::tracker&    _tracker)
 {
     LOG_TRACE("Starting trace cache bulk post-processing");
 
@@ -553,9 +42,8 @@ cache_manager::post_process_bulk(output_file_registry& _output_registry)
 
     if(m_storage.is_running())
     {
-        LOG_WARNING(
-            "Post-processing called without previously shutting down cache storage"
-            "cache storage. Calling shutdown explicitly..");
+        LOG_WARNING("Post-processing called without previously shutting down cache "
+                    "storage. Calling shutdown explicitly..");
         shutdown();
     }
 
@@ -563,11 +51,11 @@ cache_manager::post_process_bulk(output_file_registry& _output_registry)
     LOG_DEBUG("Root process ID: {}", root_pid);
 
     const auto temp_directory_content =
-        filesystem_utils::list_dir_files(trace_cache::tmp_directory);
+        discovery::list_dir_files(trace_cache::tmp_directory);
     LOG_TRACE("Found {} files in temp directory", temp_directory_content.size());
 
     const auto cache_files =
-        filesystem_utils::get_cache_files(root_pid, temp_directory_content);
+        discovery::find_cache_files(root_pid, temp_directory_content);
     LOG_DEBUG("Found {} cache file pairs to process", cache_files.size());
 
     if(config::output_filtering::is_output_enabled_for_current_mpi_rank())
@@ -575,24 +63,21 @@ cache_manager::post_process_bulk(output_file_registry& _output_registry)
         const data::enabled_formats_t enabled_formats;
         enabled_formats.print();
 
-        auto processor_configs =
-            processing_utils::create_processor_configs(cache_files, root_pid);
+        auto processor_configs = post_processor::make_configs(cache_files, root_pid);
 
         processor_configs.push_back(std::make_shared<data::processor_config_t>(
             getpid(), root_pid, m_metadata,
             std::make_shared<agent_manager>(get_agent_manager_instance().get_agents())));
 
         LOG_INFO("Processing {} trace cache configurations", processor_configs.size());
-        processing_utils::dispatch_processing(processor_configs, enabled_formats,
-                                              _output_registry);
+        post_processor processor{ _tracker, _output_registry };
+        processor.process(processor_configs, enabled_formats);
 
         if(enabled_formats.is_perfetto_enabled() && get_merge_perfetto_files())
-        {
-            filesystem_utils::merge_perfetto_files();
-        }
+            discovery::merge_perfetto_files();
     }
 
-    filesystem_utils::clear_cache_files(cache_files);
+    discovery::clear(cache_files);
 
     LOG_TRACE("Trace cache bulk post-processing completed");
 }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/cache_manager.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/cache_manager.hpp
@@ -4,13 +4,11 @@
 #pragma once
 
 #include "core/output_file_registry.hpp"
+#include "core/progress/tracker.hpp"
 #include "core/trace_cache/buffer_storage.hpp"
 #include "core/trace_cache/metadata_registry.hpp"
 #include "core/trace_cache/sample_type.hpp"
-#include "core/trace_cache/storage_parser.hpp"
-#include "library/pmc/collectors/cpu/sample.hpp"
-#include "library/pmc/collectors/gpu/sample.hpp"
-#include "library/pmc/collectors/nic/sample.hpp"
+#include "core/trace_cache/storage_parser_alias.hpp"
 #include "library/runtime.hpp"
 #include <memory>
 #include <unistd.h>
@@ -19,13 +17,6 @@ namespace rocprofsys
 {
 namespace trace_cache
 {
-
-using storage_parser_t =
-    storage_parser<type_identifier_t, kernel_dispatch_sample, memory_copy_sample,
-                   memory_allocate_sample, region_sample, in_time_sample,
-                   pmc_event_with_sample, pmc::collectors::gpu::sample,
-                   pmc::collectors::nic::sample, pmc::collectors::cpu::sample,
-                   backtrace_region_sample, scratch_memory_sample, kfd_sample>;
 
 using buffer_storage_t = buffer_storage<flush_worker_factory_t, type_identifier_t>;
 
@@ -36,7 +27,8 @@ public:
     buffer_storage_t&     get_buffer_storage() { return m_storage; }
     metadata_registry&    get_metadata_registry() { return *m_metadata; }
     void                  shutdown();
-    void                  post_process_bulk(output_file_registry& output_registry);
+    void                  post_process_bulk(output_file_registry& output_registry,
+                                            progress::tracker&    tracker);
 
 private:
     cache_manager() = default;

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/data_types.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/data_types.cpp
@@ -1,0 +1,135 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "core/trace_cache/data_types.hpp"
+
+#include "core/agent_manager.hpp"
+#include "core/config.hpp"
+#include "logger/debug.hpp"
+
+#include <algorithm>
+#include <utility>
+
+namespace rocprofsys::trace_cache::data
+{
+namespace
+{
+template <typename Predicate>
+[[nodiscard]] enabled_formats_t
+filter_formats(const std::vector<format_t>& src, Predicate&& pred)
+{
+    std::vector<format_t> kept;
+    kept.reserve(src.size());
+    for(const auto& fmt : src)
+    {
+        if(fmt.enabled && pred(fmt)) kept.push_back(fmt);
+    }
+    return enabled_formats_t{ std::move(kept) };
+}
+
+template <typename Predicate>
+[[nodiscard]] std::string
+join_names(const std::vector<format_t>& formats, Predicate&& pred)
+{
+    std::string out;
+    for(const auto& fmt : formats)
+    {
+        if(!fmt.enabled || !pred(fmt)) continue;
+        if(!out.empty()) out += ", ";
+        out += fmt.name;
+    }
+    return out;
+}
+
+constexpr auto any_format      = [](const format_t&) { return true; };
+constexpr auto parallel_pred   = [](const format_t& f) { return f.process_parallel; };
+constexpr auto sequential_pred = [](const format_t& f) { return !f.process_parallel; };
+}  // namespace
+
+enabled_formats_t::enabled_formats_t()
+: formats{ { format_kind::rocpd, true, get_use_rocpd(), "rocpd" },
+           { format_kind::perfetto, false, get_caching_perfetto(), "perfetto" } }
+{}
+
+enabled_formats_t::enabled_formats_t(std::vector<format_t> _formats) noexcept
+: formats(std::move(_formats))
+{}
+
+void
+enabled_formats_t::print() const
+{
+    if(std::none_of(formats.begin(), formats.end(),
+                    [](const auto& f) { return f.enabled; }))
+        return;
+
+    LOG_INFO("Generating [{}] format(s) with collected data from trace cache. "
+             "This may take a while..",
+             names().c_str());
+
+    if(has_parallel_formats())
+        LOG_INFO("  - Using parallel processing for: {}",
+                 join_names(formats, parallel_pred));
+
+    if(has_sequential_formats())
+        LOG_INFO("  - Using sequential processing for: {}",
+                 join_names(formats, sequential_pred));
+}
+
+bool
+enabled_formats_t::has_parallel_formats() const
+{
+    return std::any_of(formats.begin(), formats.end(),
+                       [](const auto& f) { return f.enabled && f.process_parallel; });
+}
+
+bool
+enabled_formats_t::has_sequential_formats() const
+{
+    return std::any_of(formats.begin(), formats.end(),
+                       [](const auto& f) { return f.enabled && !f.process_parallel; });
+}
+
+enabled_formats_t
+enabled_formats_t::get_parallel_formats() const
+{
+    return filter_formats(formats, parallel_pred);
+}
+
+enabled_formats_t
+enabled_formats_t::get_sequential_formats() const
+{
+    return filter_formats(formats, sequential_pred);
+}
+
+bool
+enabled_formats_t::is_rocpd_enabled() const
+{
+    auto it = std::find_if(formats.begin(), formats.end(),
+                           [](const auto& f) { return f.kind == format_kind::rocpd; });
+    return it != formats.end() && it->enabled;
+}
+
+bool
+enabled_formats_t::is_perfetto_enabled() const
+{
+    auto it = std::find_if(formats.begin(), formats.end(),
+                           [](const auto& f) { return f.kind == format_kind::perfetto; });
+    return it != formats.end() && it->enabled;
+}
+
+std::string
+enabled_formats_t::names() const
+{
+    return join_names(formats, any_format);
+}
+
+processor_config_t::processor_config_t(
+    pid_t pid, pid_t ppid, std::shared_ptr<metadata_registry> metadata_registry_ptr,
+    std::shared_ptr<agent_manager> agent_manager_ptr)
+: _pid(pid)
+, _ppid(ppid)
+, _metadata_registry(std::move(metadata_registry_ptr))
+, _agent_manager(std::move(agent_manager_ptr))
+{}
+
+}  // namespace rocprofsys::trace_cache::data

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/data_types.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/data_types.hpp
@@ -1,0 +1,91 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <sys/types.h>
+#include <vector>
+
+namespace rocprofsys
+{
+class agent_manager;
+}
+
+namespace rocprofsys::trace_cache
+{
+class metadata_registry;
+class rocpd_processor_t;
+class perfetto_processor_t;
+}  // namespace rocprofsys::trace_cache
+
+namespace rocprofsys::trace_cache::data
+{
+
+struct cache_files_t
+{
+    std::string buff_storage;
+    std::string metadata;
+
+    [[nodiscard]] bool empty() const noexcept
+    {
+        return buff_storage.empty() || metadata.empty();
+    }
+};
+
+enum class format_kind
+{
+    rocpd,
+    perfetto
+};
+
+struct format_t
+{
+    format_kind kind;
+    bool        process_parallel;
+    bool        enabled;
+    const char* name;
+};
+
+struct enabled_formats_t
+{
+    std::vector<format_t> formats;
+
+    enabled_formats_t();
+    explicit enabled_formats_t(std::vector<format_t> _formats) noexcept;
+
+    void                            print() const;
+    [[nodiscard]] bool              has_parallel_formats() const;
+    [[nodiscard]] bool              has_sequential_formats() const;
+    [[nodiscard]] enabled_formats_t get_parallel_formats() const;
+    [[nodiscard]] enabled_formats_t get_sequential_formats() const;
+    [[nodiscard]] bool              is_rocpd_enabled() const;
+    [[nodiscard]] bool              is_perfetto_enabled() const;
+    [[nodiscard]] std::string       names() const;
+};
+
+struct processor_config_t
+{
+    processor_config_t(pid_t pid, pid_t ppid,
+                       std::shared_ptr<metadata_registry> metadata_registry_ptr,
+                       std::shared_ptr<agent_manager>     agent_manager_ptr);
+
+    pid_t _pid;
+    pid_t _ppid;
+
+    std::shared_ptr<metadata_registry> _metadata_registry;
+    std::shared_ptr<agent_manager>     _agent_manager;
+};
+
+struct processor_storage_t
+{
+    std::shared_ptr<rocpd_processor_t>    rocpd_processor;
+    std::shared_ptr<perfetto_processor_t> perfetto_processor;
+};
+
+using directory_files_t    = std::vector<std::string>;
+using mapped_cache_files_t = std::map<pid_t, cache_files_t>;
+
+}  // namespace rocprofsys::trace_cache::data

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/discovery.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/discovery.cpp
@@ -1,0 +1,183 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "core/trace_cache/discovery.hpp"
+
+#include "core/config.hpp"
+#include "core/timemory.hpp"
+#include "core/trace_cache/cacheable.hpp"
+#include "logger/debug.hpp"
+
+#include <dirent.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <memory>
+#include <regex>
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+namespace rocprofsys::trace_cache::discovery
+{
+namespace
+{
+void
+remove_if_exists(const std::string& fname)
+{
+    if(fname.empty()) return;
+    std::ifstream file(fname);
+    if(!file.is_open()) return;
+
+    file.close();
+    auto result = std::remove(fname.c_str());
+    if(result == 0)
+        LOG_DEBUG("Removed file: {}", fname);
+    else if(errno == ENOENT)
+        LOG_DEBUG("File does not exist: {}", fname);
+    else
+        LOG_WARNING("Failed to remove file: {} (errno: {} - {})", fname, errno,
+                    std::strerror(errno));
+}
+}  // namespace
+
+data::directory_files_t
+list_dir_files(const std::string& path)
+{
+    if(path.empty()) return {};
+
+    auto dir_deleter = [](DIR* d) {
+        if(d) closedir(d);
+    };
+
+    std::unique_ptr<DIR, decltype(dir_deleter)> dir(opendir(path.c_str()), dir_deleter);
+
+    if(!dir) throw std::runtime_error(fmt::format("Error opening directory: {}", path));
+
+    data::directory_files_t result{};
+    dirent*                 entry;
+
+    while((entry = readdir(dir.get())) != nullptr)
+    {
+        if(std::string(entry->d_name) != "." && std::string(entry->d_name) != "..")
+            result.emplace_back(entry->d_name);
+    }
+
+    return result;
+}
+
+data::mapped_cache_files_t
+find_cache_files(const pid_t& root_pid, const data::directory_files_t& dir_contents)
+{
+    if(dir_contents.empty()) return {};
+
+    data::mapped_cache_files_t cache_map{};
+
+    auto parse_and_fill_cache = [&](const std::string& filename) {
+        if(filename.empty()) return;
+
+        const std::regex buff_regex(R"(buffered_storage_(\d+)_(\d+)\.bin)");
+        const std::regex meta_regex(R"(metadata_(\d+)_(\d+)\.json)");
+        std::smatch      match;
+
+        // Wrap stoi: regex's (\d+) can match digit runs that overflow int.
+        // A pathological file in the temp dir must not abort discovery.
+        try
+        {
+            if(std::regex_match(filename, match, buff_regex))
+            {
+                int parent_pid = std::stoi(match[1]);
+                int pid        = std::stoi(match[2]);
+                if(parent_pid == root_pid)
+                    cache_map[pid].buff_storage = trace_cache::tmp_directory + filename;
+            }
+            else if(std::regex_match(filename, match, meta_regex))
+            {
+                int parent_pid = std::stoi(match[1]);
+                int pid        = std::stoi(match[2]);
+                if(parent_pid == root_pid)
+                    cache_map[pid].metadata = trace_cache::tmp_directory + filename;
+            }
+        } catch(const std::exception& e)
+        {
+            LOG_WARNING("Skipping cache file with unparsable PID '{}': {}", filename,
+                        e.what());
+        }
+    };
+
+    std::for_each(dir_contents.begin(), dir_contents.end(), parse_and_fill_cache);
+    return cache_map;
+}
+
+void
+clear(const data::mapped_cache_files_t& cache_files)
+{
+    LOG_DEBUG("Removing cached temporary files...");
+    for(const auto& [_, files] : cache_files)
+    {
+        LOG_DEBUG("Removing cached temporary file: {}", files.buff_storage);
+        remove_if_exists(files.buff_storage);
+
+        LOG_DEBUG("Removing cached temporary file: {}", files.metadata);
+        remove_if_exists(files.metadata);
+    }
+}
+
+void
+merge_perfetto_files()
+{
+    // dmp::rank() returns 0 if MPI is not initialized/finalized. During shutdown
+    // MPI may already be finalized, so we read the rank captured at init time
+    // via settings::default_process_suffix().
+    auto    suffix_variant  = settings::default_process_suffix();
+    std::int32_t cached_mpi_rank = 0;
+
+    if(std::holds_alternative<int>(suffix_variant))
+    {
+        cached_mpi_rank = std::get<int>(suffix_variant);
+    }
+    else if(std::holds_alternative<std::string>(suffix_variant))
+    {
+        try
+        {
+            cached_mpi_rank = std::stoi(std::get<std::string>(suffix_variant));
+        } catch(...)
+        {
+            cached_mpi_rank = 0;
+        }
+    }
+
+    LOG_DEBUG("Merging perfetto files: rank={} (from settings::default_process_suffix)",
+              cached_mpi_rank);
+
+    if(cached_mpi_rank != 0) return;
+
+    auto _filename      = config::get_perfetto_output_filename();
+    auto _output_folder = tim::filepath::dirname(_filename);
+    auto _script_path   = std::string{ "rocprof-sys-merge-output.sh" };
+    auto _script_dir    = get_env("ROCPROFSYS_SCRIPT_PATH", std::string{}, false);
+
+    if(!_script_dir.empty())
+        _script_path = fmt::format("{}/{}", _script_dir, _script_path);
+
+    if(!tim::filepath::exists(_script_path))
+    {
+        LOG_WARNING("Merge script not found: {}", _script_path);
+        return;
+    }
+
+    auto _command = _script_path + " '" + _output_folder + "'";
+    int  result   = system(_command.c_str());
+
+    if(result != 0)
+        LOG_ERROR("Failed to execute merge script: {}", _command);
+    else
+        LOG_INFO("Successfully executed: {}", _command);
+}
+
+}  // namespace rocprofsys::trace_cache::discovery

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/discovery.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/discovery.cpp
@@ -11,41 +11,18 @@
 #include <dirent.h>
 
 #include <algorithm>
-#include <cerrno>
 #include <cstdint>
-#include <cstdio>
 #include <cstdlib>
-#include <cstring>
-#include <fstream>
+#include <filesystem>
 #include <memory>
 #include <regex>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 #include <variant>
 
 namespace rocprofsys::trace_cache::discovery
 {
-namespace
-{
-void
-remove_if_exists(const std::string& fname)
-{
-    if(fname.empty()) return;
-    std::ifstream file(fname);
-    if(!file.is_open()) return;
-
-    file.close();
-    auto result = std::remove(fname.c_str());
-    if(result == 0)
-        LOG_DEBUG("Removed file: {}", fname);
-    else if(errno == ENOENT)
-        LOG_DEBUG("File does not exist: {}", fname);
-    else
-        LOG_WARNING("Failed to remove file: {} (errno: {} - {})", fname, errno,
-                    std::strerror(errno));
-}
-}  // namespace
-
 data::directory_files_t
 list_dir_files(const std::string& path)
 {
@@ -120,11 +97,16 @@ clear(const data::mapped_cache_files_t& cache_files)
     LOG_DEBUG("Removing cached temporary files...");
     for(const auto& [_, files] : cache_files)
     {
-        LOG_DEBUG("Removing cached temporary file: {}", files.buff_storage);
-        remove_if_exists(files.buff_storage);
+        for(const auto* fname : { &files.buff_storage, &files.metadata })
+        {
+            if(fname->empty()) continue;
 
-        LOG_DEBUG("Removing cached temporary file: {}", files.metadata);
-        remove_if_exists(files.metadata);
+            std::error_code ec;
+            if(std::filesystem::remove(*fname, ec))
+                LOG_DEBUG("Removed file: {}", *fname);
+            else if(ec)
+                LOG_WARNING("Failed to remove file: {}: {}", *fname, ec.message());
+        }
     }
 }
 

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/discovery.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/discovery.cpp
@@ -11,14 +11,15 @@
 #include <dirent.h>
 
 #include <algorithm>
+#include <cerrno>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
-#include <filesystem>
+#include <cstring>
 #include <memory>
 #include <regex>
 #include <stdexcept>
 #include <string>
-#include <system_error>
 #include <variant>
 
 namespace rocprofsys::trace_cache::discovery
@@ -101,11 +102,11 @@ clear(const data::mapped_cache_files_t& cache_files)
         {
             if(fname->empty()) continue;
 
-            std::error_code ec;
-            if(std::filesystem::remove(*fname, ec))
+            if(std::remove(fname->c_str()) == 0)
                 LOG_DEBUG("Removed file: {}", *fname);
-            else if(ec)
-                LOG_WARNING("Failed to remove file: {}: {}", *fname, ec.message());
+            else if(errno != ENOENT)
+                LOG_WARNING("Failed to remove file: {}: {}", *fname,
+                            std::strerror(errno));
         }
     }
 }
@@ -116,7 +117,7 @@ merge_perfetto_files()
     // dmp::rank() returns 0 if MPI is not initialized/finalized. During shutdown
     // MPI may already be finalized, so we read the rank captured at init time
     // via settings::default_process_suffix().
-    auto    suffix_variant  = settings::default_process_suffix();
+    auto         suffix_variant  = settings::default_process_suffix();
     std::int32_t cached_mpi_rank = 0;
 
     if(std::holds_alternative<int>(suffix_variant))

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/discovery.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/discovery.hpp
@@ -1,0 +1,26 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "core/trace_cache/data_types.hpp"
+
+#include <string>
+#include <sys/types.h>
+
+namespace rocprofsys::trace_cache::discovery
+{
+
+[[nodiscard]] data::directory_files_t
+list_dir_files(const std::string& path);
+
+[[nodiscard]] data::mapped_cache_files_t
+find_cache_files(const pid_t& root_pid, const data::directory_files_t& dir_contents);
+
+void
+clear(const data::mapped_cache_files_t& cache_files);
+
+void
+merge_perfetto_files();
+
+}  // namespace rocprofsys::trace_cache::discovery

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/post_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/post_processor.cpp
@@ -1,0 +1,200 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "core/trace_cache/post_processor.hpp"
+
+#include "core/agent_manager.hpp"
+#include "core/trace_cache/cacheable.hpp"
+#include "core/trace_cache/metadata_registry.hpp"
+#include "core/trace_cache/perfetto_processor.hpp"
+#include "core/trace_cache/rocpd_processor.hpp"
+#include "core/trace_cache/sample_processor.hpp"
+#include "core/trace_cache/storage_parser_alias.hpp"
+#include "library/runtime.hpp"
+#include "logger/debug.hpp"
+
+#include <sys/stat.h>
+
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace rocprofsys::trace_cache
+{
+namespace
+{
+
+std::uint64_t
+file_size_or_zero(const std::string& path) noexcept
+{
+    struct stat st
+    {};
+    if(::stat(path.c_str(), &st) != 0) return 0;
+    return static_cast<std::uint64_t>(st.st_size);
+}
+
+std::uint64_t
+sum_storage_bytes(const std::vector<std::shared_ptr<data::processor_config_t>>& configs)
+{
+    std::uint64_t total = 0;
+    for(const auto& cfg : configs)
+        total += file_size_or_zero(
+            utility::get_buffered_storage_filename(cfg->_ppid, cfg->_pid));
+    return total;
+}
+
+[[nodiscard]] data::processor_storage_t
+configure_processors(const std::shared_ptr<sample_processor_t>&       _coordinator,
+                     const std::shared_ptr<data::processor_config_t>& _config,
+                     const data::enabled_formats_t&                   _formats,
+                     output_file_registry&                            _registry)
+{
+    data::processor_storage_t storage;
+    if(_formats.is_rocpd_enabled())
+    {
+        storage.rocpd_processor = std::make_shared<rocpd_processor_t>(
+            _config->_metadata_registry, _config->_agent_manager, _config->_pid,
+            _config->_ppid, _registry);
+        _coordinator->add_handler(*storage.rocpd_processor);
+    }
+    if(_formats.is_perfetto_enabled())
+    {
+        storage.perfetto_processor = std::make_shared<perfetto_processor_t>(
+            _config->_metadata_registry, _config->_agent_manager, _config->_pid,
+            _config->_ppid, _registry);
+        _coordinator->add_handler(*storage.perfetto_processor);
+    }
+    return storage;
+}
+
+void
+process_buffered_storage(const std::shared_ptr<data::processor_config_t>& _config,
+                         const std::string&             _storage_filename,
+                         const data::enabled_formats_t& _formats,
+                         output_file_registry&          _registry,
+                         progress::progress_callback    _progress_cb)
+{
+    LOG_DEBUG("Processing buffered storage: {} for pid={}", _storage_filename,
+              _config->_pid);
+
+    auto _coordinator = std::make_shared<sample_processor_t>();
+    // RAII lifetime guard: configure_processors registers raw references to the
+    // returned processors as handlers on _coordinator. Holding _storage in scope
+    // keeps those processors alive until the parse + finalize is done.
+    [[maybe_unused]] auto _storage =
+        configure_processors(_coordinator, _config, _formats, _registry);
+    storage_parser_t _parser(_storage_filename);
+
+    _coordinator->prepare_for_processing();
+    try
+    {
+        _parser.load(_coordinator, std::move(_progress_cb));
+        LOG_TRACE("Successfully loaded buffered storage: {}", _storage_filename);
+    } catch(const std::runtime_error& exp)
+    {
+        LOG_WARNING("Error parsing buffered storage {}: {}", _storage_filename,
+                    exp.what());
+    }
+    _coordinator->finalize_processing();
+
+    LOG_DEBUG("Finished processing buffered storage: {}", _storage_filename);
+}
+}  // namespace
+
+post_processor::post_processor(progress::tracker&    tracker,
+                               output_file_registry& registry) noexcept
+: m_tracker(tracker)
+, m_registry(registry)
+{}
+
+void
+post_processor::process(
+    const std::vector<std::shared_ptr<data::processor_config_t>>& configs,
+    const data::enabled_formats_t&                                formats)
+{
+    if(formats.has_sequential_formats())
+        run_sequential(configs, formats.get_sequential_formats());
+    if(formats.has_parallel_formats())
+        run_multithreaded(configs, formats.get_parallel_formats());
+}
+
+void
+post_processor::run_sequential(
+    const std::vector<std::shared_ptr<data::processor_config_t>>& configs,
+    const data::enabled_formats_t&                                formats)
+{
+    LOG_DEBUG("Starting sequential processing with {} configs", configs.size());
+    for(const auto& cfg : configs)
+    {
+        LOG_TRACE("Processing config for pid={}", cfg->_pid);
+        const auto _filename =
+            utility::get_buffered_storage_filename(cfg->_ppid, cfg->_pid);
+        auto _progress_cb = m_tracker.begin(
+            fmt::format("Generating Perfetto proto file for process [{}]", cfg->_pid),
+            file_size_or_zero(_filename));
+        process_buffered_storage(cfg, _filename, formats, m_registry, _progress_cb);
+    }
+    LOG_DEBUG("Sequential processing completed");
+}
+
+void
+post_processor::run_multithreaded(
+    const std::vector<std::shared_ptr<data::processor_config_t>>& configs,
+    const data::enabled_formats_t&                                formats)
+{
+    LOG_DEBUG("Starting multithreaded processing with {} configs", configs.size());
+    ROCPROFSYS_SCOPED_SAMPLING_ON_CHILD_THREADS(false);
+
+    auto _progress_cb = m_tracker.begin("Generating ROCpd output database file",
+                                        sum_storage_bytes(configs));
+
+    std::vector<std::thread> processing_threads;
+    processing_threads.reserve(configs.size());
+    for(const auto& cfg : configs)
+    {
+        LOG_TRACE("Spawning processing thread for pid={}", cfg->_pid);
+        // Capture the callback by value: it holds a shared_ptr to the bar,
+        // and bar::on_advance is thread-safe, so concurrent calls are fine.
+        processing_threads.emplace_back([this, cfg, &formats, _progress_cb] {
+            const auto _filename =
+                utility::get_buffered_storage_filename(cfg->_ppid, cfg->_pid);
+            process_buffered_storage(cfg, _filename, formats, m_registry, _progress_cb);
+        });
+    }
+
+    LOG_TRACE("Waiting for {} processing threads to complete", processing_threads.size());
+    for(auto& thread : processing_threads)
+        thread.join();
+    LOG_DEBUG("Multithreaded processing completed");
+}
+
+std::vector<std::shared_ptr<data::processor_config_t>>
+post_processor::make_configs(const data::mapped_cache_files_t& cache_files,
+                             const pid_t&                      root_pid)
+{
+    constexpr size_t ROOT_PROCESS_INCREMENT = 1;
+
+    std::vector<std::shared_ptr<data::processor_config_t>> configs;
+    configs.reserve(cache_files.size() + ROOT_PROCESS_INCREMENT);
+
+    for(const auto& [pid, files] : cache_files)
+    {
+        if(files.empty()) continue;
+
+        std::vector<std::shared_ptr<agent>> _agents;
+        auto _metadata = std::make_shared<metadata_registry>();
+        _metadata->load_from_file(files.metadata, _agents);
+
+        auto _agent_manager = std::make_shared<agent_manager>(_agents);
+
+        configs.push_back(std::make_shared<data::processor_config_t>(
+            pid, root_pid, _metadata, _agent_manager));
+    }
+    return configs;
+}
+
+}  // namespace rocprofsys::trace_cache

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/post_processor.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/post_processor.hpp
@@ -1,0 +1,46 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "core/output_file_registry.hpp"
+#include "core/progress/tracker.hpp"
+#include "core/trace_cache/data_types.hpp"
+
+#include <memory>
+#include <sys/types.h>
+#include <vector>
+
+namespace rocprofsys::trace_cache
+{
+
+class post_processor
+{
+public:
+    post_processor(progress::tracker& tracker, output_file_registry& registry) noexcept;
+
+    post_processor(const post_processor&)            = delete;
+    post_processor& operator=(const post_processor&) = delete;
+    post_processor(post_processor&&)                 = delete;
+    post_processor& operator=(post_processor&&)      = delete;
+
+    void process(const std::vector<std::shared_ptr<data::processor_config_t>>& configs,
+                 const data::enabled_formats_t&                                formats);
+
+    [[nodiscard]] static std::vector<std::shared_ptr<data::processor_config_t>>
+    make_configs(const data::mapped_cache_files_t& cache_files, const pid_t& root_pid);
+
+private:
+    void run_sequential(
+        const std::vector<std::shared_ptr<data::processor_config_t>>& configs,
+        const data::enabled_formats_t&                                formats);
+
+    void run_multithreaded(
+        const std::vector<std::shared_ptr<data::processor_config_t>>& configs,
+        const data::enabled_formats_t&                                formats);
+
+    progress::tracker&    m_tracker;
+    output_file_registry& m_registry;
+};
+
+}  // namespace rocprofsys::trace_cache

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser.hpp
@@ -5,6 +5,7 @@
 
 #include "common/defines.h"
 
+#include "core/progress/callback.hpp"
 #include "core/trace_cache/cacheable.hpp"
 #include "core/trace_cache/type_registry.hpp"
 
@@ -17,6 +18,7 @@
 #include <fstream>
 #include <memory>
 #include <string>
+#include <utility>
 
 namespace rocprofsys
 {
@@ -31,12 +33,13 @@ class storage_parser
     static_assert(sizeof...(SupportedTypes) != 0, "SupportedTypes must be non-empty");
 
 public:
-    storage_parser(std::string _filename)
+    explicit storage_parser(std::string _filename)
     : m_filename(std::move(_filename))
     {}
 
     template <typename TypeProcessing>
-    void load(std::shared_ptr<TypeProcessing> _type_processing)
+    void load(std::shared_ptr<TypeProcessing> _type_processing,
+              progress::progress_callback     _progress_cb = {})
     {
         static_assert(
             type_traits::has_execute_processing<TypeProcessing, TypeIdentifierEnum,
@@ -70,6 +73,8 @@ public:
         sample.reserve(4096);
         size_t last_capacity = sample.capacity();
 
+        std::uint64_t last_pos = 0;
+
         while(!ifs.eof())
         {
             if(!ifs.good())
@@ -100,6 +105,20 @@ public:
                     fmt::format("Bad read while consuming buffered storage. Filename: {} "
                                 "Bytes read: {}",
                                 m_filename, static_cast<int>(ifs.tellg())));
+            }
+
+            if(_progress_cb)
+            {
+                const auto pos = ifs.tellg();
+                if(pos != std::streampos{ -1 })
+                {
+                    const auto absolute = static_cast<std::uint64_t>(pos);
+                    if(absolute > last_pos)
+                    {
+                        _progress_cb(absolute - last_pos);
+                        last_pos = absolute;
+                    }
+                }
             }
 
             if(header.type == TypeIdentifierEnum::fragmented_space)

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser_alias.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser_alias.hpp
@@ -1,0 +1,22 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "core/trace_cache/sample_type.hpp"
+#include "core/trace_cache/storage_parser.hpp"
+#include "library/pmc/collectors/cpu/sample.hpp"
+#include "library/pmc/collectors/gpu/sample.hpp"
+#include "library/pmc/collectors/nic/sample.hpp"
+
+namespace rocprofsys::trace_cache
+{
+
+using storage_parser_t =
+    storage_parser<type_identifier_t, kernel_dispatch_sample, memory_copy_sample,
+                   memory_allocate_sample, region_sample, in_time_sample,
+                   pmc_event_with_sample, pmc::collectors::gpu::sample,
+                   pmc::collectors::nic::sample, pmc::collectors::cpu::sample,
+                   backtrace_region_sample, scratch_memory_sample, kfd_sample>;
+
+}  // namespace rocprofsys::trace_cache

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/CMakeLists.txt
@@ -11,6 +11,8 @@ set(trace_cache_tests_sources
     test_sample_type.cpp
     test_kfd_args.cpp
     test_rocpd_xcp_output.cpp
+    test_enabled_formats.cpp
+    test_discovery.cpp
 )
 
 add_library(trace-cache-tests OBJECT ${trace_cache_tests_sources})

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_discovery.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_discovery.cpp
@@ -4,8 +4,15 @@
 #include "core/trace_cache/discovery.hpp"
 
 #include <gtest/gtest.h>
+#include <spdlog/fmt/fmt.h>
 
-#include <filesystem>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <stdexcept>
 #include <string>
@@ -14,37 +21,65 @@ namespace rocprofsys::trace_cache::discovery
 {
 namespace
 {
-namespace fs = std::filesystem;
+std::string
+temp_root()
+{
+    if(const char* env = std::getenv("TMPDIR"); env != nullptr && env[0] != '\0')
+        return env;
+    return "/tmp";
+}
+
+bool
+file_exists(const std::string& path)
+{
+    return ::access(path.c_str(), F_OK) == 0;
+}
+
+void
+remove_dir_recursive(const std::string& dir)
+{
+    DIR* d = ::opendir(dir.c_str());
+    if(d == nullptr) return;
+
+    while(dirent* entry = ::readdir(d))
+    {
+        const std::string name = entry->d_name;
+        if(name == "." || name == "..") continue;
+        ::unlink(fmt::format("{}/{}", dir, name).c_str());  // best effort, files only
+    }
+    ::closedir(d);
+    ::rmdir(dir.c_str());
+}
 
 class temp_dir_fixture : public ::testing::Test
 {
 protected:
     void SetUp() override
     {
-        m_dir = fs::temp_directory_path() /
-                ("rocprofsys_discovery_test_" +
-                 std::to_string(::testing::UnitTest::GetInstance()->random_seed()) + "_" +
-                 ::testing::UnitTest::GetInstance()->current_test_info()->name());
-        fs::create_directories(m_dir);
+        m_dir =
+            fmt::format("{}/rocprofsys_discovery_test_{}_{}", temp_root(),
+                        ::testing::UnitTest::GetInstance()->random_seed(),
+                        ::testing::UnitTest::GetInstance()->current_test_info()->name());
+
+        if(::mkdir(m_dir.c_str(), S_IRWXU) != 0 && errno != EEXIST)
+        {
+            FAIL() << fmt::format("mkdir({}) failed: {}", m_dir, std::strerror(errno));
+        }
     }
 
-    void TearDown() override
-    {
-        std::error_code ec;
-        fs::remove_all(m_dir, ec);  // best effort
-    }
+    void TearDown() override { remove_dir_recursive(m_dir); }
 
     void touch(const std::string& filename)
     {
-        std::ofstream{ (m_dir / filename).string() }.put('x');
+        std::ofstream{ path_of(filename) }.put('x');
     }
 
     [[nodiscard]] std::string path_of(const std::string& filename) const
     {
-        return (m_dir / filename).string();
+        return fmt::format("{}/{}", m_dir, filename);
     }
 
-    fs::path m_dir;
+    std::string m_dir;
 };
 }  // namespace
 
@@ -65,7 +100,7 @@ TEST_F(temp_dir_fixture, list_dir_files_returns_files_excluding_dot_entries)
     touch("b.bin");
     touch("c.json");
 
-    auto files = list_dir_files(m_dir.string());
+    auto files = list_dir_files(m_dir);
 
     EXPECT_EQ(files.size(), 3U);
     EXPECT_NE(std::find(files.begin(), files.end(), "a.txt"), files.end());
@@ -130,8 +165,8 @@ TEST_F(temp_dir_fixture, clear_removes_existing_files)
 
     clear(cache);
 
-    EXPECT_FALSE(fs::exists(path_of("buff.bin")));
-    EXPECT_FALSE(fs::exists(path_of("meta.json")));
+    EXPECT_FALSE(file_exists(path_of("buff.bin")));
+    EXPECT_FALSE(file_exists(path_of("meta.json")));
 }
 
 TEST(discovery_test, clear_does_not_throw_on_missing_files)

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_discovery.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_discovery.cpp
@@ -1,0 +1,146 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "core/trace_cache/discovery.hpp"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+
+namespace rocprofsys::trace_cache::discovery
+{
+namespace
+{
+namespace fs = std::filesystem;
+
+class temp_dir_fixture : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        m_dir = fs::temp_directory_path() /
+                ("rocprofsys_discovery_test_" +
+                 std::to_string(::testing::UnitTest::GetInstance()->random_seed()) + "_" +
+                 ::testing::UnitTest::GetInstance()->current_test_info()->name());
+        fs::create_directories(m_dir);
+    }
+
+    void TearDown() override
+    {
+        std::error_code ec;
+        fs::remove_all(m_dir, ec);  // best effort
+    }
+
+    void touch(const std::string& filename)
+    {
+        std::ofstream{ (m_dir / filename).string() }.put('x');
+    }
+
+    [[nodiscard]] std::string path_of(const std::string& filename) const
+    {
+        return (m_dir / filename).string();
+    }
+
+    fs::path m_dir;
+};
+}  // namespace
+
+TEST(discovery_test, list_dir_files_empty_path_returns_empty)
+{
+    EXPECT_TRUE(list_dir_files("").empty());
+}
+
+TEST(discovery_test, list_dir_files_nonexistent_path_throws)
+{
+    EXPECT_THROW(list_dir_files("/nonexistent_path_for_rocprofsys_test"),
+                 std::runtime_error);
+}
+
+TEST_F(temp_dir_fixture, list_dir_files_returns_files_excluding_dot_entries)
+{
+    touch("a.txt");
+    touch("b.bin");
+    touch("c.json");
+
+    auto files = list_dir_files(m_dir.string());
+
+    EXPECT_EQ(files.size(), 3U);
+    EXPECT_NE(std::find(files.begin(), files.end(), "a.txt"), files.end());
+    EXPECT_NE(std::find(files.begin(), files.end(), "b.bin"), files.end());
+    EXPECT_NE(std::find(files.begin(), files.end(), "c.json"), files.end());
+    EXPECT_EQ(std::find(files.begin(), files.end(), "."), files.end());
+    EXPECT_EQ(std::find(files.begin(), files.end(), ".."), files.end());
+}
+
+TEST(discovery_test, find_cache_files_empty_input_returns_empty)
+{
+    EXPECT_TRUE(find_cache_files(1234, {}).empty());
+}
+
+TEST(discovery_test, find_cache_files_matches_buffered_storage_pattern)
+{
+    auto m = find_cache_files(100, { "buffered_storage_100_42.bin" });
+    ASSERT_EQ(m.size(), 1U);
+    EXPECT_NE(m.find(42), m.end());
+    EXPECT_NE(m[42].buff_storage.find("buffered_storage_100_42.bin"), std::string::npos);
+}
+
+TEST(discovery_test, find_cache_files_matches_metadata_pattern)
+{
+    auto m = find_cache_files(100, { "metadata_100_42.json" });
+    ASSERT_EQ(m.size(), 1U);
+    EXPECT_NE(m.find(42), m.end());
+    EXPECT_NE(m[42].metadata.find("metadata_100_42.json"), std::string::npos);
+}
+
+TEST(discovery_test, find_cache_files_pairs_buffered_and_metadata_for_same_pid)
+{
+    auto m =
+        find_cache_files(100, { "buffered_storage_100_42.bin", "metadata_100_42.json" });
+    ASSERT_EQ(m.size(), 1U);
+    EXPECT_FALSE(m[42].empty());
+}
+
+TEST(discovery_test, find_cache_files_skips_mismatched_parent_pid)
+{
+    auto m = find_cache_files(100, { "buffered_storage_999_42.bin" });
+    EXPECT_TRUE(m.empty());
+}
+
+TEST(discovery_test, find_cache_files_skips_unparsable_pid_without_aborting)
+{
+    // A PID that overflows int (regression: try/catch around stoi).
+    auto m = find_cache_files(100, { "buffered_storage_99999999999999999999_42.bin",
+                                     "buffered_storage_100_42.bin" });
+    EXPECT_EQ(m.size(), 1U);
+    EXPECT_NE(m.find(42), m.end());
+}
+
+TEST_F(temp_dir_fixture, clear_removes_existing_files)
+{
+    touch("buff.bin");
+    touch("meta.json");
+
+    data::mapped_cache_files_t cache;
+    cache[1].buff_storage = path_of("buff.bin");
+    cache[1].metadata     = path_of("meta.json");
+
+    clear(cache);
+
+    EXPECT_FALSE(fs::exists(path_of("buff.bin")));
+    EXPECT_FALSE(fs::exists(path_of("meta.json")));
+}
+
+TEST(discovery_test, clear_does_not_throw_on_missing_files)
+{
+    data::mapped_cache_files_t cache;
+    cache[1].buff_storage = "/tmp/rocprofsys_does_not_exist_buff.bin";
+    cache[1].metadata     = "/tmp/rocprofsys_does_not_exist_meta.json";
+
+    EXPECT_NO_THROW(clear(cache));
+}
+
+}  // namespace rocprofsys::trace_cache::discovery

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_enabled_formats.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_enabled_formats.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "core/trace_cache/data_types.hpp"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace rocprofsys::trace_cache::data
+{
+namespace
+{
+enabled_formats_t
+make_with(bool rocpd_enabled, bool perfetto_enabled)
+{
+    return enabled_formats_t{ std::vector<format_t>{
+        { format_kind::rocpd, true, rocpd_enabled, "rocpd" },
+        { format_kind::perfetto, false, perfetto_enabled, "perfetto" },
+    } };
+}
+}  // namespace
+
+TEST(enabled_formats_test, names_empty_when_no_formats_enabled)
+{
+    EXPECT_EQ(make_with(false, false).names(), "");
+}
+
+TEST(enabled_formats_test, names_joins_enabled_formats_with_comma)
+{
+    EXPECT_EQ(make_with(true, true).names(), "rocpd, perfetto");
+    EXPECT_EQ(make_with(true, false).names(), "rocpd");
+    EXPECT_EQ(make_with(false, true).names(), "perfetto");
+}
+
+TEST(enabled_formats_test, has_parallel_formats_true_when_rocpd_enabled)
+{
+    EXPECT_TRUE(make_with(true, false).has_parallel_formats());
+    EXPECT_FALSE(make_with(false, true).has_parallel_formats());
+    EXPECT_FALSE(make_with(false, false).has_parallel_formats());
+}
+
+TEST(enabled_formats_test, has_sequential_formats_true_when_perfetto_enabled)
+{
+    EXPECT_TRUE(make_with(false, true).has_sequential_formats());
+    EXPECT_FALSE(make_with(true, false).has_sequential_formats());
+    EXPECT_FALSE(make_with(false, false).has_sequential_formats());
+}
+
+TEST(enabled_formats_test, get_parallel_formats_filters_out_sequential)
+{
+    auto sub = make_with(true, true).get_parallel_formats();
+
+    EXPECT_EQ(sub.formats.size(), 1U);
+    EXPECT_EQ(sub.formats.front().kind, format_kind::rocpd);
+    EXPECT_TRUE(sub.formats.front().process_parallel);
+    EXPECT_TRUE(sub.formats.front().enabled);
+}
+
+TEST(enabled_formats_test, get_sequential_formats_filters_out_parallel)
+{
+    auto sub = make_with(true, true).get_sequential_formats();
+
+    EXPECT_EQ(sub.formats.size(), 1U);
+    EXPECT_EQ(sub.formats.front().kind, format_kind::perfetto);
+    EXPECT_FALSE(sub.formats.front().process_parallel);
+    EXPECT_TRUE(sub.formats.front().enabled);
+}
+
+TEST(enabled_formats_test, is_rocpd_enabled_uses_format_kind)
+{
+    EXPECT_TRUE(make_with(true, false).is_rocpd_enabled());
+    EXPECT_FALSE(make_with(false, true).is_rocpd_enabled());
+}
+
+TEST(enabled_formats_test, is_perfetto_enabled_uses_format_kind)
+{
+    EXPECT_TRUE(make_with(false, true).is_perfetto_enabled());
+    EXPECT_FALSE(make_with(true, false).is_perfetto_enabled());
+}
+
+}  // namespace rocprofsys::trace_cache::data

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -24,6 +24,8 @@
 #include "core/node_info.hpp"
 #include "core/output_file_registry.hpp"
 #include "core/perfetto_fwd.hpp"
+#include "core/progress/bar.hpp"
+#include "core/progress/callback.hpp"
 #include "core/rocpd/data_processor.hpp"
 #include "core/timemory.hpp"
 #include "core/trace_cache/cache_manager.hpp"
@@ -1178,7 +1180,20 @@ rocprofsys_finalize_hidden(void)
     {
         auto& _manager = rocprofsys::trace_cache::cache_manager::get_instance();
         _manager.shutdown();
-        _manager.post_process_bulk(_output_registry);
+
+        rocprofsys::progress::bar_options _bar_opts;
+        _bar_opts.verbose = config::get_verbose();
+
+        rocprofsys::progress::tracker _tracker{ [_bar_opts](std::string   _label,
+                                                            std::uint64_t _total) {
+            auto                      _bar = std::make_shared<rocprofsys::progress::bar>(std::move(_label),
+                                                                                         _total, _bar_opts);
+            return rocprofsys::progress::progress_callback{ [_bar](std::uint64_t _delta) {
+                _bar->on_advance(_delta);
+            } };
+        } };
+
+        _manager.post_process_bulk(_output_registry, _tracker);
     }
 
     if(_timemory_manager && _timemory_manager != nullptr)

--- a/projects/rocprofiler-systems/source/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(UNIT_TEST_OBJECTS
     $<TARGET_OBJECTS:lib-common-tests>
     $<TARGET_OBJECTS:trace-cache-tests>
     $<TARGET_OBJECTS:demangler-tests>
+    $<TARGET_OBJECTS:progress-tests>
     $<TARGET_OBJECTS:logger-tests>
     $<TARGET_OBJECTS:lib-components-tests>
     $<TARGET_OBJECTS:rocprofiler-sdk-components-unit-tests>


### PR DESCRIPTION
## Motivation

- Generating output files can take a long time, especially for large files. Users may mistakenly think the application has crashed and exit it prematurely.

## Technical Details

### Progress bars

- Self-contained, thread-safe `progress::bar` that renders to a stream with `\r\033[2K` in-place updates and a final newline. Throttled to one redraw per `bar_options::tick` (default 100 ms); render lock acquired via `try_lock` so contended threads simply skip.
- Eager finalisation: when `on_advance` crosses the total it claims the final render via `compare_exchange_strong` on `m_finished`, ensuring the bar's last line lands before any other code (e.g. `file_output_message`) writes to stderr.
- Five visual styles selectable via `bar_options::style` enum: `ascii_brackets` (default), `ascii_arrow`, `unicode_blocks` (1/8-cell sub-precision via U+2588 family), `unicode_dots`, `text_only`.
- TTY + verbose-aware: silent when stderr is not a TTY, when verbose level is below 0, or when explicitly disabled. `bar_options::verbose` is injected by the caller -> bar has no dependency on the global config singleton, so it is unit-testable in isolation.

### Producer/consumer decoupling

- `storage_parser::load()` accepts an optional `progress::progress_callback = std::function<void(uint64_t)>`. Empty by default - single-arg form preserved so existing test call sites remain unchanged.
- `progress::tracker` is a small factory holder: `using factory_t = std::function<progress_callback(std::string, std::uint64_t)>;`. The factory closure is the only place that names `progress::bar`. Swapping in a different renderer (mock, metrics emitter, etc.) is a one-line change at the application layer.
- For perfetto output: one bar per buffered_storage file, created and destroyed within each loop iteration in `post_processor::run_sequential`.
- For rocpd output: one bar shared across all worker threads in `post_processor::run_multithreaded`. Each thread invokes the same `progress_callback`; `bar::on_advance` is thread-safe (atomic `fetch_add` + try-lock render).

- This PR also includes `cache_manager.cpp` decomposition.

## JIRA ID

AIPROFSYST-372

## Test Plan

- Existing test suites (`test_storage_parser`, `test_cache_integration`) compile and pass unchanged.
- New unit tests:
  - `test_format_bar` — pure renderer for all 5 styles, no TTY required.
  - `test_bar_silent` — silent-mode contract (non-TTY / verbose < 0 / disabled).
- Manual verification with single-process and multiprocess `transpose` example: perfetto bar appears per file in turn; rocpd aggregate bar shows continuous progress; both finalise cleanly above the perfetto/rocpd log lines with no scrambling.

## Test Result

- All tests passing.

<img width="1529" height="157" alt="image" src="https://github.com/user-attachments/assets/b1a89513-f767-4f8c-9248-bc58811d872f" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
