### PR TITLE
[hip-tests] Add some prefetch APIs around Managed Memory movement

### DIFF
--- a/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsyncExtTsts.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsyncExtTsts.cc
@@ -315,15 +315,14 @@ HIP_TEST_CASE(Unit_hipMemPrefetchAsync_NonPageSz) {
   HIP_CHECK(hipMemPrefetchAsync(Hmm, (NumElms * sizeof(int) + 8), 0, strm));
   HIP_CHECK(hipStreamSynchronize(strm));
   MemPrftchAsyncKernel1<<<((NumElms + 2) / 32 + 1), 32, 0, strm>>>(Hmm, (NumElms + 2));
+  HIP_CHECK(hipMemPrefetchAsync(Hmm, (NumElms * sizeof(int) + 8), hipCpuDeviceId, strm));
   HIP_CHECK(hipStreamSynchronize(strm));
+  const auto expected = InitVal * InitVal;
   for (int i = 0; i < (NumElms + 2); ++i) {
-    if (Hmm[i] != (InitVal * InitVal)) {
-      WARN("Didnt receive expected output after kernel launch!!");
-      IfTestPassed = false;
-      break;
-    }
+    INFO("Index: " << i << " Expected: " << expected << " got: " << Hmm[i]);
+    // We do require before cleanup, if the test fails, we do not care about the leaks.
+    REQUIRE(expected == Hmm[i]);
   }
   HIP_CHECK(hipFree(Hmm));
   HIP_CHECK(hipStreamDestroy(strm));
-  REQUIRE(IfTestPassed);
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemPrefetchBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPrefetchBatchAsync.cc
@@ -63,10 +63,10 @@ static void VerifyDataOnDevice(int* data, hipStream_t stream) {
 
   constexpr int kBlockSize = 256;
   int num_blocks = (kTestBufferElements + kBlockSize - 1) / kBlockSize;
-
+  HIP_CHECK(hipMemPrefetchAsync(success_flag, sizeof(bool), 0, stream));
   VerifyDataKernel<<<num_blocks, kBlockSize, 0, stream>>>(data, kTestBufferElements, kTestValueBase,
                                                           success_flag);
-
+  HIP_CHECK(hipMemPrefetchAsync(success_flag, sizeof(bool), hipCpuDeviceId, stream));
   HIP_CHECK(hipStreamSynchronize(stream));
   REQUIRE(*success_flag == true);
   HIP_CHECK(hipFree(success_flag));


### PR DESCRIPTION
## Motivation

Use prefetch around managedMemory ops

## Technical Details

Most of the hip-tests run with XNACK off. This can cause random failures when some page do not move from GPU to CPU. This should help with those flaky-ness

## JIRA ID

NA

## Test Plan

Test should pass and hopefully should not fail as randomly as it should.

## Test Result

Awaiting CI Run

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
