### PR TITLE
[rocshmem] make allocator constructor argument - 2

### DIFF
--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -279,7 +279,7 @@ void GDABackend::setup_host_ctx() {
 
 void GDABackend::setup_default_ctx() {
   TeamInfo *tinfo = team_tracker.get_team_world()->tinfo_wrt_world;
-  default_context_proxy_ = GDADefaultContextProxyT(this, tinfo, gda_provider);
+  default_context_proxy_ = GDADefaultContextProxy(this, tinfo, gda_provider);
 }
 
 void GDABackend::log_ctx_nics([[maybe_unused]] unsigned int ctx_id,

--- a/projects/rocshmem/src/gda/backend_gda.hpp
+++ b/projects/rocshmem/src/gda/backend_gda.hpp
@@ -504,7 +504,7 @@ class GDABackend : public Backend {
    *
    * @note Internal data ownership is managed by the proxy
    */
-  GDADefaultContextProxyT default_context_proxy_;  // init handled in constructor
+  GDADefaultContextProxy default_context_proxy_;  // init handled in constructor
 
   /**
    * @brief An array of @ref ROContexts that backs the context FreeList.

--- a/projects/rocshmem/src/gda/gda_context_proxy.hpp
+++ b/projects/rocshmem/src/gda/gda_context_proxy.hpp
@@ -28,14 +28,14 @@
 
 #include "device_proxy.hpp"
 #include "backend_gda.hpp"
+#include "memory/hip_allocator.hpp"
 
 namespace rocshmem {
 
 class GDABackend;
 
-template <typename ALLOCATOR>
 class GDADefaultContextProxy {
-  using ProxyT = DeviceProxy<ALLOCATOR, GDAContext>;
+  using ProxyT = DeviceProxy<HIPAllocator, GDAContext>;
 
  public:
   GDADefaultContextProxy() = default;
@@ -45,6 +45,7 @@ class GDADefaultContextProxy {
    */
   explicit GDADefaultContextProxy(GDABackend* backend, TeamInfo *tinfo,
                                   int gda_provider,
+                                  [[maybe_unused]] const HIPAllocator& alloc = HIPAllocator(),
                                   size_t num_elems = 1)
   : proxy_{num_elems}, constructed_{true} {
     auto ctx{proxy_.get()};
@@ -95,8 +96,6 @@ class GDADefaultContextProxy {
    */
   bool constructed_{false};
 };
-
-using GDADefaultContextProxyT = GDADefaultContextProxy<HIPAllocator>;
 
 }  // namespace rocshmem
 

--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -125,7 +125,7 @@ void IPCBackend::init() {
 
   TeamInfo *tinfo = team_tracker.get_team_world()->tinfo_wrt_world;
 
-  default_context_proxy_ = IPCDefaultContextProxyT(this, tinfo);
+  default_context_proxy_ = IPCDefaultContextProxy(this, tinfo);
 
   setup_ctxs();
 }

--- a/projects/rocshmem/src/ipc/backend_ipc.hpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.hpp
@@ -238,7 +238,7 @@ class IPCBackend : public Backend {
    *
    * @note Internal data ownership is managed by the proxy
    */
-  IPCDefaultContextProxyT default_context_proxy_;  // init handled in constructor
+  IPCDefaultContextProxy default_context_proxy_;  // init handled in constructor
 
   /**
    * @brief An array of @ref ROContexts that backs the context FreeList.

--- a/projects/rocshmem/src/ipc/ipc_context_proxy.hpp
+++ b/projects/rocshmem/src/ipc/ipc_context_proxy.hpp
@@ -28,14 +28,14 @@
 
 #include "device_proxy.hpp"
 #include "backend_ipc.hpp"
+#include "memory/hip_allocator.hpp"
 
 namespace rocshmem {
 
 class IPCBackend;
 
-template <typename ALLOCATOR>
 class IPCDefaultContextProxy {
-  using ProxyT = DeviceProxy<ALLOCATOR, IPCContext>;
+  using ProxyT = DeviceProxy<HIPAllocator, IPCContext>;
 
  public:
   IPCDefaultContextProxy() = default;
@@ -44,6 +44,7 @@ class IPCDefaultContextProxy {
    * Placement new the memory which is allocated by proxy_
    */
   explicit IPCDefaultContextProxy(IPCBackend* backend, TeamInfo *tinfo,
+                                  [[maybe_unused]] const HIPAllocator& alloc = HIPAllocator(),
                                   size_t num_elems = 1)
   : proxy_{num_elems}, constructed_{true} {
     auto ctx{proxy_.get()};
@@ -87,8 +88,6 @@ class IPCDefaultContextProxy {
    */
   bool constructed_{false};
 };
-
-using IPCDefaultContextProxyT = IPCDefaultContextProxy<HIPAllocator>;
 
 }  // namespace rocshmem
 

--- a/projects/rocshmem/src/ipc_policy.cpp
+++ b/projects/rocshmem/src/ipc_policy.cpp
@@ -43,7 +43,7 @@ __host__ void IpcOnImpl::ipcHostInit(int my_pe, const HEAP_BASES_T &heap_bases,
 
   // Check if we should use pod-based detection (for VMM Fabric allocator)
   HIPAllocator *allocator = get_default_allocator();
-  bool use_pod_detection = (allocator->type == AllocatorTypeVMMFabric);
+  bool use_pod_detection = (allocator->get_type() == AllocatorTypeVMMFabric);
 
   if (use_pod_detection) {
     // Use pod-based detection
@@ -189,7 +189,7 @@ __host__ void IpcOnImpl::ipcHostInit(int my_pe, const HEAP_BASES_T &heap_bases,
                                      TcpBootstrap *bootstr) {
   // Check if we should use pod-based detection (for VMM Fabric allocator)
   HIPAllocator *allocator = get_default_allocator();
-  bool use_pod_detection = (allocator->type == AllocatorTypeVMMFabric);
+  bool use_pod_detection = (allocator->get_type() == AllocatorTypeVMMFabric);
 
   // For VMM_FABRIC, use pod-based IPC capability detection; otherwise use local ranks
   auto shm_ranks = use_pod_detection ? bootstr->getIpcCapableRanks() : bootstr->getLocalRanks();

--- a/projects/rocshmem/src/memory/heap_memory.hpp
+++ b/projects/rocshmem/src/memory/heap_memory.hpp
@@ -49,7 +49,7 @@ namespace rocshmem {
     virtual __host__ __device__ char* get_ptr() = 0;
     virtual __host__ __device__ size_t get_size() = 0;
 
-    HIPAllocatorType type_;
+    AllocatorType type_;
   };
 
 
@@ -81,10 +81,8 @@ class HeapMemoryType : public HeapMemory {
      */
     ptr_ = up_.get();
 
-    // Get type from the actual HIPAllocator
-    // Safe since we know allocator is always HIPAllocator or derived
-    const HIPAllocator* hip_alloc = static_cast<const HIPAllocator*>(&allocator_);
-    type_ = hip_alloc->type;
+    // Get allocator type from the base class without unsafe casting
+    type_ = allocator_.get_type();
   }
 
   /**

--- a/projects/rocshmem/src/memory/heap_memory.hpp
+++ b/projects/rocshmem/src/memory/heap_memory.hpp
@@ -70,7 +70,7 @@ class HeapMemoryType : public HeapMemory {
    * @param[in] size User-specified size used as heap size
    */
   explicit HeapMemoryType(const MemoryAllocator& alloc, size_t size)
-      : allocator_{alloc}, up_{nullptr, Deleter(&allocator_)}, size_{size} {
+      : allocator_{alloc}, up_{nullptr, Deleter(alloc)}, size_{size} {
     char* temp;
     allocator_.allocate(reinterpret_cast<void**>(&temp), size_);
     assert(temp);
@@ -102,19 +102,19 @@ class HeapMemoryType : public HeapMemory {
  private:
   /**
    * @brief Wrap deallocator into a functor for up_ template.
+   *
+   * Stores allocator by value to avoid dangling pointer issues during move.
    */
   class Deleter {
    public:
-    Deleter() : a_{nullptr} {}
-    explicit Deleter(MemoryAllocator* alloc) : a_{alloc} {}
+    Deleter() = default;
+    explicit Deleter(const MemoryAllocator& alloc) : a_{alloc} {}
     void operator()(void* x) {
-      if (a_) {
-        a_->deallocate(x);
-      }
+      a_.deallocate(x);
     }
 
    private:
-    MemoryAllocator* a_;
+    MemoryAllocator a_{};
   };
 
   /**

--- a/projects/rocshmem/src/memory/heap_memory.hpp
+++ b/projects/rocshmem/src/memory/heap_memory.hpp
@@ -30,6 +30,7 @@
 #include <utility>
 
 #include "hip_allocator.hpp"
+#include "default_allocator.hpp"
 
 /**
  * @file heap_memory.hpp
@@ -52,7 +53,6 @@ namespace rocshmem {
   };
 
 
-template <typename ALLOCATOR>
 class HeapMemoryType : public HeapMemory {
  public:
   /**
@@ -60,25 +60,31 @@ class HeapMemoryType : public HeapMemory {
    *
    * Uses default heap size specified in class body.
    */
-  HeapMemoryType() : HeapMemoryType(gibibyte_) {}
+  explicit HeapMemoryType(const MemoryAllocator& alloc = *get_default_allocator())
+      : HeapMemoryType(alloc, gibibyte_) {}
 
   /**
    * @brief Secondary constructor type
    *
-   * @param[in] User-specified size used as heap size
+   * @param[in] alloc Allocator to use for heap allocation
+   * @param[in] size User-specified size used as heap size
    */
-  explicit HeapMemoryType(size_t size) : size_{size} {
+  explicit HeapMemoryType(const MemoryAllocator& alloc, size_t size)
+      : allocator_{alloc}, up_{nullptr, Deleter(&allocator_)}, size_{size} {
     char* temp;
     allocator_.allocate(reinterpret_cast<void**>(&temp), size_);
     assert(temp);
-    std::unique_ptr<char, Deleter> up{temp};
-    up_ = std::move(up);
+    up_.reset(temp);
 
     /*
      * Set a c-style ptr for access by the device.
      */
     ptr_ = up_.get();
-    type_ = allocator_.type;
+
+    // Get type from the actual HIPAllocator
+    // Safe since we know allocator is always HIPAllocator or derived
+    const HIPAllocator* hip_alloc = static_cast<const HIPAllocator*>(&allocator_);
+    type_ = hip_alloc->type;
   }
 
   /**
@@ -97,25 +103,31 @@ class HeapMemoryType : public HeapMemory {
 
  private:
   /**
-   * @brief Template type member with allocate and deallocate methods.
-   */
-  ALLOCATOR allocator_{};
-
-  /**
    * @brief Wrap deallocator into a functor for up_ template.
    */
   class Deleter {
    public:
-    void operator()(void* x) { a_.deallocate(x); }
+    Deleter() : a_{nullptr} {}
+    explicit Deleter(MemoryAllocator* alloc) : a_{alloc} {}
+    void operator()(void* x) {
+      if (a_) {
+        a_->deallocate(x);
+      }
+    }
 
    private:
-    ALLOCATOR a_;
+    MemoryAllocator* a_;
   };
+
+  /**
+   * @brief Memory allocator with allocate and deallocate methods.
+   */
+  MemoryAllocator allocator_{};
 
   /**
    * @brief Owning pointer to heap memory.
    */
-  std::unique_ptr<char, Deleter> up_{nullptr};
+  std::unique_ptr<char, Deleter> up_;
 
   /**
    * @brief Named constant for a gibibyte.

--- a/projects/rocshmem/src/memory/hip_allocator.hpp
+++ b/projects/rocshmem/src/memory/hip_allocator.hpp
@@ -56,15 +56,6 @@ enum HIPIpcHandleType {
   HandleTypeLast
 };
 
-enum HIPAllocatorType {
-  AllocatorTypeCoarsegrained = 0,
-  AllocatorTypeFinegrained,
-  AllocatorTypeUncached,
-  AllocatorTypeVMMPosix,
-  AllocatorTypeVMMFabric,
-  AllocatorTypeLast
-};
-
 #if HIP_VERSION >= 70000000
 struct HIPIpcMemHandlePosix_t {
   uint64_t fd;
@@ -130,8 +121,6 @@ class HIPAllocator : public MemoryAllocator {
 
   virtual ~HIPAllocator() = default;
 
-  HIPAllocatorType type = AllocatorTypeCoarsegrained;
-
   virtual hipError_t GetIpcHandle(void *dev_ptr, void *handle)
   {
     return hipIpcGetMemHandle(reinterpret_cast<hipIpcMemHandle_t *>(handle), dev_ptr);
@@ -190,7 +179,7 @@ class HIPAllocatorFinegrained : public HIPAllocator {
   HIPAllocatorFinegrained()
       : HIPAllocator(hipExtMallocWithFlags, hipFree,
                      hipDeviceMallocFinegrained) {
-    type = AllocatorTypeFinegrained;
+    type_ = AllocatorTypeFinegrained;
   }
 };
 
@@ -200,7 +189,7 @@ class HIPAllocatorUncached : public HIPAllocator {
   HIPAllocatorUncached()
       : HIPAllocator(hipExtMallocWithFlags, hipFree,
                      hipDeviceMallocUncached) {
-    type = AllocatorTypeUncached;
+    type_ = AllocatorTypeUncached;
   }
 };
 #endif

--- a/projects/rocshmem/src/memory/hip_allocator_vmm_fabric.cpp
+++ b/projects/rocshmem/src/memory/hip_allocator_vmm_fabric.cpp
@@ -87,7 +87,7 @@ hipError_t HIPAllocatorVMMFabric::VMMFree(void* ptr)
 HIPAllocatorVMMFabric::HIPAllocatorVMMFabric()
     : HIPAllocator(VMMAlloc, VMMFree)
 {
-  type = AllocatorTypeVMMFabric;
+  type_ = AllocatorTypeVMMFabric;
 
   // Check if the device supports fabric handles
   int device_id;

--- a/projects/rocshmem/src/memory/hip_allocator_vmm_posix.cpp
+++ b/projects/rocshmem/src/memory/hip_allocator_vmm_posix.cpp
@@ -96,7 +96,7 @@ hipError_t HIPAllocatorVMMPosixFd::VMMFree(void* ptr)
 }
 
 HIPAllocatorVMMPosixFd::HIPAllocatorVMMPosixFd() : HIPAllocator(VMMAlloc, VMMFree) {
-  type = AllocatorTypeVMMPosix;
+  type_ = AllocatorTypeVMMPosix;
 
   // Check Linux kernel version (recommends >= 6.8)
   struct utsname kernel_info;

--- a/projects/rocshmem/src/memory/memory_allocator.hpp
+++ b/projects/rocshmem/src/memory/memory_allocator.hpp
@@ -38,6 +38,22 @@
 
 namespace rocshmem {
 
+/**
+ * @brief Type of allocator
+ *
+ * Used to identify the memory allocation strategy at runtime.
+ */
+enum AllocatorType {
+  AllocatorTypeCoarsegrained = 0,
+  AllocatorTypeFinegrained,
+  AllocatorTypeUncached,
+  AllocatorTypeVMMPosix,
+  AllocatorTypeVMMFabric,
+  AllocatorTypeHost,
+  AllocatorTypePosix,
+  AllocatorTypeLast
+};
+
 class MemoryAllocator {
  public:
   /**
@@ -102,12 +118,24 @@ class MemoryAllocator {
    */
   void deallocate(void* ptr);
 
+  /**
+   * @brief Get allocator type
+   *
+   * @return AllocatorType identifying the allocator strategy
+   */
+  AllocatorType get_type() const { return type_; }
+
  public:
  protected:
   /**
    * @brief is this memory allocated using managed memory
    */
   bool _managed{false};
+
+  /**
+   * @brief Type of allocator for runtime identification
+   */
+  AllocatorType type_{AllocatorTypeCoarsegrained};
 
  private:
   /**

--- a/projects/rocshmem/src/memory/single_heap.cpp
+++ b/projects/rocshmem/src/memory/single_heap.cpp
@@ -37,48 +37,10 @@ HIPAllocator *default_allocator_{nullptr};
 SingleHeap::SingleHeap() {
 
   HIPAllocator *allocator = get_default_allocator();
-  if (allocator->type == AllocatorTypeCoarsegrained) {
-    heap_mem_ = new HeapMemoryType<HIPAllocatorCoarsegrained>(envvar::heap_size.get_value());
-  } else if (allocator->type == AllocatorTypeFinegrained) {
-    heap_mem_ = new HeapMemoryType<HIPAllocatorFinegrained>(envvar::heap_size.get_value());
-  } else if (allocator->type == AllocatorTypeUncached) {
-    heap_mem_ = new HeapMemoryType<HIPAllocatorUncached>(envvar::heap_size.get_value());
-  }
-#if defined USE_HEAP_DEVICE_VMM_POSIX
-  else if (allocator->type == AllocatorTypeVMMPosix) {
-    heap_mem_ = new HeapMemoryType<HIPAllocatorVMMPosixFd>(envvar::heap_size.get_value());
-  }
-#endif
-#if defined USE_HEAP_DEVICE_VMM_FABRIC
-  else if (allocator->type == AllocatorTypeVMMFabric) {
-    heap_mem_ = new HeapMemoryType<HIPAllocatorVMMFabric>(envvar::heap_size.get_value());
-  }
-#endif
-  else {
-    LOG_ERROR_ABORT("Unknown allocator type");
-  }
+  heap_mem_ = new HeapMemoryType(*allocator, envvar::heap_size.get_value());
   assert(heap_mem_ != nullptr);
 
-  if (heap_mem_->type_ == AllocatorTypeCoarsegrained) {
-    strat_ = new DLAllocatorStrategy<HeapMemoryType<HIPAllocatorCoarsegrained>>(reinterpret_cast<HeapMemoryType<HIPAllocatorCoarsegrained> *>(heap_mem_));
-  } else if (heap_mem_->type_ == AllocatorTypeFinegrained){
-    strat_ = new DLAllocatorStrategy<HeapMemoryType<HIPAllocatorFinegrained>>(reinterpret_cast<HeapMemoryType<HIPAllocatorFinegrained> *>(heap_mem_));
-  } else if (heap_mem_->type_ == AllocatorTypeUncached){
-    strat_ = new DLAllocatorStrategy<HeapMemoryType<HIPAllocatorUncached>>(reinterpret_cast<HeapMemoryType<HIPAllocatorUncached> *>(heap_mem_));
-  }
-#if defined USE_HEAP_DEVICE_VMM_POSIX
-  else if (heap_mem_->type_ == AllocatorTypeVMMPosix){
-    strat_ = new DLAllocatorStrategy<HeapMemoryType<HIPAllocatorVMMPosixFd>>(reinterpret_cast<HeapMemoryType<HIPAllocatorVMMPosixFd> *>(heap_mem_));
-  }
-#endif
-#if defined USE_HEAP_DEVICE_VMM_FABRIC
-  else if (heap_mem_->type_ == AllocatorTypeVMMFabric){
-    strat_ = new DLAllocatorStrategy<HeapMemoryType<HIPAllocatorVMMFabric>>(reinterpret_cast<HeapMemoryType<HIPAllocatorVMMFabric> *>(heap_mem_));
-  }
-#endif
-  else {
-    LOG_ERROR_ABORT("Unknown allocator type");
-  }
+  strat_ = new DLAllocatorStrategy<HeapMemoryType>(static_cast<HeapMemoryType *>(heap_mem_));
 }
 
 SingleHeap::~SingleHeap() {

--- a/projects/rocshmem/src/reverse_offload/backend_proxy.hpp
+++ b/projects/rocshmem/src/reverse_offload/backend_proxy.hpp
@@ -30,6 +30,7 @@
 #include "device_proxy.hpp"
 #include "memory/window_info.hpp"
 #include "memory/symmetric_heap.hpp"
+#include "memory/hip_allocator.hpp"
 #include "stats.hpp"
 #include "queue.hpp"
 
@@ -45,15 +46,16 @@ struct BackendRegister {
   SymmetricHeap *heap_ptr{nullptr};
 };
 
-template <typename ALLOCATOR>
 class BackendProxy {
-  using ProxyT = DeviceProxy<ALLOCATOR, BackendRegister>;
+  using ProxyT = DeviceProxy<HIPHostAllocator, BackendRegister>;
 
  public:
   /*
    * Placement new the memory which is allocated by proxy_
    */
-  BackendProxy(size_t num_elems = 1) : proxy_{num_elems} {
+  BackendProxy([[maybe_unused]] const HIPHostAllocator& alloc = HIPHostAllocator(),
+               size_t num_elems = 1)
+    : proxy_{num_elems} {
     new (proxy_.get()) BackendRegister();
   }
 
@@ -74,8 +76,6 @@ class BackendProxy {
    */
   ProxyT proxy_{};
 };
-
-using BackendProxyT = BackendProxy<HIPHostAllocator>;
 
 }  // namespace rocshmem
 

--- a/projects/rocshmem/src/reverse_offload/backend_ro.cpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.cpp
@@ -127,7 +127,7 @@ ROBackend::ROBackend(MPI_Comm comm)
 
   TeamInfo *tinfo = team_tracker.get_team_world()->tinfo_wrt_world;
 
-  default_context_proxy_ = DefaultContextProxyT(this, tinfo);
+  default_context_proxy_ = DefaultContextProxy(this, tinfo);
 
   block_handle_proxy_ = BlockHandleProxyT(g_ret_buffer_.get(),
                         atomic_ret_buffer_.get(), &queue_,

--- a/projects/rocshmem/src/reverse_offload/backend_ro.cpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.cpp
@@ -89,8 +89,8 @@ ROBackend::ROBackend(MPI_Comm comm)
 
   bp->heap_ptr = &heap;
 
-  ro_window_proxy_ = new WindowProxyT(&heap, transport_->get_world_comm(),
-                                      num_windows_);
+  ro_window_proxy_ = new WindowProxy(&heap, transport_->get_world_comm(),
+                                     num_windows_);
 
   bp->heap_window_info = ro_window_proxy_->get();
 
@@ -375,7 +375,7 @@ void ROBackend::ro_net_free_runtime() {
   }
   transport_->finalizeTransport();
 
-  ro_window_proxy_->~WindowProxyT();
+  ro_window_proxy_->~WindowProxy();
   team_world_proxy_->~ROTeamProxy<HIPAllocator>();
   transport_->~MPITransport();
   /*

--- a/projects/rocshmem/src/reverse_offload/backend_ro.cpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.cpp
@@ -54,7 +54,7 @@ ROBackend::ROBackend(MPI_Comm comm)
 
   poll_block_count_ = envvar::max_num_contexts;
 
-  profiler_proxy_ = ProfilerProxyT(envvar::max_num_contexts);
+  profiler_proxy_ = ProfilerProxy(envvar::max_num_contexts);
 
   int device_id;
   CHECK_HIP(hipGetDevice(&device_id));
@@ -104,7 +104,7 @@ ROBackend::ROBackend(MPI_Comm comm)
 
   ROCSHMEM_HOST_CTX_DEFAULT.ctx_opaque = default_host_ctx.get();
 
-  team_world_proxy_ = new ROTeamProxy<HIPAllocator>(
+  team_world_proxy_ = new ROTeamProxy(
       this, transport_->get_world_comm(), my_pe, num_pes);
   team_tracker.set_team_world(team_world_proxy_->get());
 
@@ -376,7 +376,7 @@ void ROBackend::ro_net_free_runtime() {
   transport_->finalizeTransport();
 
   ro_window_proxy_->~WindowProxy();
-  team_world_proxy_->~ROTeamProxy<HIPAllocator>();
+  team_world_proxy_->~ROTeamProxy();
   transport_->~MPITransport();
   /*
    * Free the profiler statistics structure.

--- a/projects/rocshmem/src/reverse_offload/backend_ro.cpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.cpp
@@ -375,9 +375,9 @@ void ROBackend::ro_net_free_runtime() {
   }
   transport_->finalizeTransport();
 
-  ro_window_proxy_->~WindowProxy();
-  team_world_proxy_->~ROTeamProxy();
-  transport_->~MPITransport();
+  delete ro_window_proxy_;
+  delete team_world_proxy_;
+  delete transport_;
   /*
    * Free the profiler statistics structure.
    */

--- a/projects/rocshmem/src/reverse_offload/backend_ro.hpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.hpp
@@ -205,7 +205,7 @@ class ROBackend : public Backend {
    *
    * See the transport class for more details.
    */
-  ROTeamProxyT *team_world_proxy_;
+  ROTeamProxy *team_world_proxy_;
 
   /**
    * @brief Allocate and initialize team shared.
@@ -248,7 +248,7 @@ class ROBackend : public Backend {
    *
    * @note Internal data ownership is managed by the proxy
    */
-  ProfilerProxyT profiler_proxy_;  // init handled in constructor
+  ProfilerProxy profiler_proxy_;  // init handled in constructor
 
  public:
   /**

--- a/projects/rocshmem/src/reverse_offload/backend_ro.hpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.hpp
@@ -262,7 +262,7 @@ class ROBackend : public Backend {
    *
    * @note Internal data ownership is managed by the proxy
    */
-  DefaultContextProxyT default_context_proxy_;  // init handled in constructor
+  DefaultContextProxy default_context_proxy_;  // init handled in constructor
 
   /**
    * @brief Controls how many thread blocks are monitored by polling thread.

--- a/projects/rocshmem/src/reverse_offload/backend_ro.hpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.hpp
@@ -146,7 +146,7 @@ class ROBackend : public Backend {
   /**
    * @brief Handle to device memory fields.
    */
-  BackendProxyT backend_proxy{};
+  BackendProxy backend_proxy{};
 
   /**
    * @brief Handle to block resources
@@ -233,7 +233,7 @@ class ROBackend : public Backend {
   /**
    * @brief Pool of contexts for RO_NET
    */
-  WindowProxyT *ro_window_proxy_;
+  WindowProxy *ro_window_proxy_;
 
  protected:
   /**

--- a/projects/rocshmem/src/reverse_offload/context_proxy.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_proxy.hpp
@@ -34,9 +34,8 @@ namespace rocshmem {
 
 class ROBackend;
 
-template <typename ALLOCATOR>
 class DefaultContextProxy {
-  using ProxyT = DeviceProxy<ALLOCATOR, ROContext>;
+  using ProxyT = DeviceProxy<HIPAllocator, ROContext>;
 
  public:
   DefaultContextProxy() = default;
@@ -45,6 +44,7 @@ class DefaultContextProxy {
    * Placement new the memory which is allocated by proxy_
    */
   explicit DefaultContextProxy(ROBackend* backend, TeamInfo *tinfo,
+                               [[maybe_unused]] const HIPAllocator& alloc = HIPAllocator(),
                                size_t num_elems = 1)
   : proxy_{num_elems}, constructed_{true} {
     auto ctx{proxy_.get()};
@@ -87,8 +87,6 @@ class DefaultContextProxy {
    */
   bool constructed_{false};
 };
-
-using DefaultContextProxyT = DefaultContextProxy<HIPAllocator>;
 
 }  // namespace rocshmem
 

--- a/projects/rocshmem/src/reverse_offload/mpi_transport.cpp
+++ b/projects/rocshmem/src/reverse_offload/mpi_transport.cpp
@@ -226,7 +226,7 @@ void MPITransport::submitRequestsToMPI() {
   }
 }
 
-void MPITransport::initTransport(int num_queues, BackendProxyT *proxy) {
+void MPITransport::initTransport(int num_queues, BackendProxy *proxy) {
   waiting_quiet.resize(num_queues, std::vector<volatile char *>());
   outstanding.resize(num_queues, 0);
   transport_up = false;

--- a/projects/rocshmem/src/reverse_offload/mpi_transport.hpp
+++ b/projects/rocshmem/src/reverse_offload/mpi_transport.hpp
@@ -44,7 +44,7 @@ public:
 
   virtual ~MPITransport();
 
-  void initTransport(int num_queues, BackendProxyT *proxy) override;
+  void initTransport(int num_queues, BackendProxy *proxy) override;
 
   void finalizeTransport() override;
 
@@ -182,7 +182,7 @@ private:
 
   std::atomic<bool> transport_up{false};
 
-  BackendProxyT *backend_proxy{nullptr};
+  BackendProxy *backend_proxy{nullptr};
 
   std::thread progress_thread{};
 

--- a/projects/rocshmem/src/reverse_offload/profiler.hpp
+++ b/projects/rocshmem/src/reverse_offload/profiler.hpp
@@ -51,14 +51,14 @@ typedef Stats<RO_NUM_STATS> ROStats;
 typedef NullStats<RO_NUM_STATS> ROStats;
 #endif
 
-template <typename ALLOCATOR>
 class ProfilerProxy {
-  using ProxyT = DeviceProxy<ALLOCATOR, ROStats>;
+  using ProxyT = DeviceProxy<HIPAllocator, ROStats>;
 
  public:
   ProfilerProxy() = default;
 
-  explicit ProfilerProxy(size_t num_blocks)
+  explicit ProfilerProxy(size_t num_blocks,
+                         [[maybe_unused]] const HIPAllocator& alloc = HIPAllocator())
     : proxy_{num_blocks}, num_elem_{num_blocks} {
 
     auto *stat{proxy_.get()};
@@ -97,8 +97,6 @@ class ProfilerProxy {
 
   size_t num_elem_{0};
 };
-
-using ProfilerProxyT = ProfilerProxy<HIPAllocator>;
 
 }  // namespace rocshmem
 

--- a/projects/rocshmem/src/reverse_offload/queue.hpp
+++ b/projects/rocshmem/src/reverse_offload/queue.hpp
@@ -62,7 +62,7 @@ class Queue {
 
   void copy_element_to_cache(uint64_t queue_index);
 
-  QueueProxyT queue_proxy_{};
+  QueueProxy queue_proxy_{};
 
   QueueDescProxyT queue_desc_proxy_{};
 

--- a/projects/rocshmem/src/reverse_offload/queue.hpp
+++ b/projects/rocshmem/src/reverse_offload/queue.hpp
@@ -66,7 +66,7 @@ class Queue {
 
   QueueDescProxyT queue_desc_proxy_{};
 
-  QueueElementProxyT queue_element_cache_proxy_{};
+  QueueElementProxy queue_element_cache_proxy_{};
 
   HdpProxy<HIPHostAllocator> hdp_proxy_{};
 

--- a/projects/rocshmem/src/reverse_offload/queue_proxy.hpp
+++ b/projects/rocshmem/src/reverse_offload/queue_proxy.hpp
@@ -31,6 +31,7 @@
 #include "commands_types.hpp"
 #include "profiler.hpp"
 #include "sync/abql_block_mutex.hpp"
+#include "memory/hip_allocator.hpp"
 
 namespace rocshmem {
 
@@ -101,10 +102,9 @@ class QueueElementProxy {
 
 using QueueElementProxyT = QueueElementProxy<PosixAligned64Allocator>;
 
-template <typename ALLOCATOR>
 class QueueProxy {
-  using ProxyT = DeviceProxy<ALLOCATOR, queue_element_t *>;
-  using ProxyPerBlockT = DeviceProxy<ALLOCATOR, queue_element_t>;
+  using ProxyT = DeviceProxy<HIPHostAllocator, queue_element_t *>;
+  using ProxyPerBlockT = DeviceProxy<HIPHostAllocator, queue_element_t>;
 
  public:
   /**
@@ -115,7 +115,8 @@ class QueueProxy {
    */
   QueueProxy() = default;
 
-  QueueProxy(size_t max_queues, size_t queue_size)
+  QueueProxy(size_t max_queues, size_t queue_size,
+             [[maybe_unused]] const HIPHostAllocator& alloc = HIPHostAllocator())
     : queue_proxy_{max_queues},
       per_block_queue_proxy_{queue_size * max_queues},
       max_queues_{max_queues}, queue_size_{queue_size},
@@ -124,7 +125,7 @@ class QueueProxy {
     auto **queue_array{queue_proxy_.get()};
     auto *per_block_queue{per_block_queue_proxy_.get()};
     for (size_t i{0}; i < max_queues_; i++) {
-      queue_array[i] = per_block_queue + i * queue_size;
+      queue_array[i] = per_block_queue + i * queue_size_;
     }
     size_t total_queue_element_bytes{sizeof(queue_element_t) *
                                      total_queue_elements_};
@@ -152,8 +153,6 @@ class QueueProxy {
 
   size_t total_queue_elements_{};
 };
-
-using QueueProxyT = QueueProxy<HIPHostAllocator>;
 
 }  // namespace rocshmem
 

--- a/projects/rocshmem/src/reverse_offload/queue_proxy.hpp
+++ b/projects/rocshmem/src/reverse_offload/queue_proxy.hpp
@@ -75,12 +75,13 @@ typedef struct queue_element {
   } ol2;
 } __attribute__((__aligned__(64))) queue_element_t;
 
-template <typename ALLOCATOR>
 class QueueElementProxy {
-  using ProxyT = DeviceProxy<ALLOCATOR, queue_element_t>;
+  using ProxyT = DeviceProxy<PosixAligned64Allocator, queue_element_t>;
 
  public:
-  QueueElementProxy(size_t num_elems = 1) : proxy_{num_elems} {
+  QueueElementProxy([[maybe_unused]] const PosixAligned64Allocator& alloc = PosixAligned64Allocator(),
+                    size_t num_elems = 1)
+    : proxy_{num_elems} {
     new (proxy_.get()) queue_element_t();
   }
 
@@ -99,8 +100,6 @@ class QueueElementProxy {
  private:
   ProxyT proxy_{};
 };
-
-using QueueElementProxyT = QueueElementProxy<PosixAligned64Allocator>;
 
 class QueueProxy {
   using ProxyT = DeviceProxy<HIPHostAllocator, queue_element_t *>;

--- a/projects/rocshmem/src/reverse_offload/ro_team_proxy.hpp
+++ b/projects/rocshmem/src/reverse_offload/ro_team_proxy.hpp
@@ -28,18 +28,19 @@
 #include "device_proxy.hpp"
 #include "ro_net_team.hpp"
 #include "mpi_instance.hpp"
+#include "memory/hip_allocator.hpp"
 
 namespace rocshmem {
 
-template <typename ALLOCATOR>
 class ROTeamProxy {
-  using ProxyT = DeviceProxy<ALLOCATOR, ROTeam>;
+  using ProxyT = DeviceProxy<HIPAllocator, ROTeam>;
 
  public:
   /*
    * Placement new the memory which is allocated by proxy_
    */
   ROTeamProxy(Backend* backend, MPI_Comm comm, int pe, int npes,
+              [[maybe_unused]] const HIPAllocator& alloc = HIPAllocator(),
               size_t num_elems = 1)
     : proxy_{num_elems} {
 
@@ -86,8 +87,6 @@ class ROTeamProxy {
    */
   ProxyT proxy_{};
 };
-
-using ROTeamProxyT = ROTeamProxy<HIPAllocator>;
 
 }  // namespace rocshmem
 

--- a/projects/rocshmem/src/reverse_offload/transport.hpp
+++ b/projects/rocshmem/src/reverse_offload/transport.hpp
@@ -41,7 +41,7 @@ class Transport {
  public:
   virtual ~Transport() = default;
 
-  virtual void initTransport(int num_queues, BackendProxyT *proxy) = 0;
+  virtual void initTransport(int num_queues, BackendProxy *proxy) = 0;
 
   virtual void finalizeTransport() = 0;
 

--- a/projects/rocshmem/src/reverse_offload/window_proxy.hpp
+++ b/projects/rocshmem/src/reverse_offload/window_proxy.hpp
@@ -27,20 +27,21 @@
 
 #include "device_proxy.hpp"
 #include "memory/window_info.hpp"
+#include "memory/hip_allocator.hpp"
 #include "mpi_transport.hpp"
 
 namespace rocshmem {
 
-template <typename ALLOCATOR>
 class WindowProxy {
  private:
-  using ProxyT = DeviceProxy<ALLOCATOR, WindowInfoMPI *>;
+  using ProxyT = DeviceProxy<HostAllocator, WindowInfoMPI *>;
 
  public:
   /*
    * Placement new the memory which is allocated by proxy_
    */
-  WindowProxy(SymmetricHeap *heap, MPI_Comm comm, size_t num_windows)
+  WindowProxy(SymmetricHeap *heap, MPI_Comm comm, size_t num_windows,
+              [[maybe_unused]] const HostAllocator& alloc = HostAllocator())
     : proxy_{num_windows}, num_windows_{num_windows} {
 
     WindowInfoMPI** window_info{proxy_.get()};
@@ -88,8 +89,6 @@ class WindowProxy {
    */
   size_t num_windows_{32};
 };
-
-using WindowProxyT = WindowProxy<HostAllocator>;
 
 }  // namespace rocshmem
 

--- a/projects/rocshmem/tests/unit_tests/dlmalloc_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/dlmalloc_gtest.hpp
@@ -38,7 +38,7 @@ class DLMallocTestFixture : public ::testing::Test
     /**
      * @brief Helper type for heap memory
      */
-    using HEAP_T = HeapMemoryType<HIPAllocator>;
+    using HEAP_T = HeapMemoryType;
 
     /**
      * @brief Helper type for allocation strategy
@@ -49,7 +49,8 @@ class DLMallocTestFixture : public ::testing::Test
     /**
      * @brief Heap memory object
      */
-    HEAP_T heap_mem_ {};
+    HIPAllocator alloc_{};
+    HEAP_T heap_mem_{alloc_};
 
     /**
      * @brief Allocation strategy object

--- a/projects/rocshmem/tests/unit_tests/heap_memory_gtest.cpp
+++ b/projects/rocshmem/tests/unit_tests/heap_memory_gtest.cpp
@@ -27,7 +27,8 @@
 using namespace rocshmem;
 
 TEST(HeapMemoryTest, size_constructor) {
-  HeapMemoryType<HIPAllocator> heap_mem{2048};
+  HIPAllocator alloc;
+  HeapMemoryType heap_mem{alloc, 2048};
   ASSERT_EQ(heap_mem.get_size(), 2048);
   ASSERT_NE(heap_mem.get_ptr(), nullptr);
 }

--- a/projects/rocshmem/tests/unit_tests/heap_memory_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/heap_memory_gtest.hpp
@@ -40,7 +40,8 @@ class HeapMemoryTestFixture : public ::testing::Test
     /**
      * @brief a heap memory object
      */
-    HeapMemoryType<HIPAllocator> heap_mem_ {};
+    HIPAllocator alloc_{};
+    HeapMemoryType heap_mem_{alloc_};
 };
 
 } // namespace rocshmem

--- a/projects/rocshmem/tests/unit_tests/ipc_impl_simple_coarse_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/ipc_impl_simple_coarse_gtest.hpp
@@ -67,7 +67,7 @@ kernel_simple_coarse_copy_warp(IpcImpl *ipc_impl, int *src, int *dest, size_t by
 }
 
 class IPCImplSimpleCoarse : public ::testing::TestWithParam<std::tuple<int, int, int>> {
-    using HEAP_T = HeapMemoryType<HIPAllocator>;
+    using HEAP_T = HeapMemoryType;
     using MPI_T = RemoteHeapInfo<CommunicatorMPI>;
     using FN_T = void (*)(IpcImpl*, int*, int*, size_t);
 
@@ -187,13 +187,12 @@ class IPCImplSimpleCoarse : public ::testing::TestWithParam<std::tuple<int, int,
   protected:
     std::vector<int> golden_;
 
-    HEAP_T heap_mem_ {};
+    HIPAllocator hip_allocator_ {};
+    HEAP_T heap_mem_ {hip_allocator_};
     MPI_T *mpi_{nullptr};
 
     IpcImpl ipc_impl_ {};
     IpcImpl *ipc_impl_dptr_ {nullptr};
-
-    HIPAllocator hip_allocator_ {};
 };
 
 class DegenerateSimpleCoarse : public IPCImplSimpleCoarse {

--- a/projects/rocshmem/tests/unit_tests/ipc_impl_simple_fine_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/ipc_impl_simple_fine_gtest.hpp
@@ -141,13 +141,7 @@ class IPCImplSimpleFine : public ::testing::TestWithParam<std::tuple<int, int, i
     IPCImplSimpleFine() {
         MPIInstance::mpilib_dl_init();
         hip_allocator_ = get_default_allocator();
-        if (hip_allocator_->type == AllocatorTypeCoarsegrained) {
-          heap_mem_ = new HeapMemoryType<HIPAllocatorCoarsegrained>(envvar::heap_size.get_value());
-        } else if (hip_allocator_->type == AllocatorTypeFinegrained) {
-          heap_mem_ = new HeapMemoryType<HIPAllocatorFinegrained>(envvar::heap_size.get_value());
-        } else if (hip_allocator_->type == AllocatorTypeUncached) {
-          heap_mem_ = new HeapMemoryType<HIPAllocatorUncached>(envvar::heap_size.get_value());
-        }
+        heap_mem_ = new HeapMemoryType(*hip_allocator_, envvar::heap_size.get_value());
         assert(heap_mem_ != nullptr);
 
         mpi_ = new MPI_T (heap_mem_->get_ptr(), heap_mem_->get_size(), MPI_COMM_WORLD);

--- a/projects/rocshmem/tests/unit_tests/ipc_impl_tiled_fine_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/ipc_impl_tiled_fine_gtest.hpp
@@ -159,13 +159,7 @@ class IPCImplTiledFine : public ::testing::TestWithParam<std::tuple<int, int, in
     IPCImplTiledFine() {
         MPIInstance::mpilib_dl_init();
         hip_allocator_ = get_default_allocator();
-        if (hip_allocator_->type == AllocatorTypeCoarsegrained) {
-          heap_mem_ = new HeapMemoryType<HIPAllocatorCoarsegrained>(envvar::heap_size.get_value());
-        } else if (hip_allocator_->type == AllocatorTypeFinegrained) {
-          heap_mem_ = new HeapMemoryType<HIPAllocatorFinegrained>(envvar::heap_size.get_value());
-        } else if (hip_allocator_->type == AllocatorTypeUncached) {
-          heap_mem_ = new HeapMemoryType<HIPAllocatorUncached>(envvar::heap_size.get_value());
-        }
+        heap_mem_ = new HeapMemoryType(*hip_allocator_, envvar::heap_size.get_value());
         assert(heap_mem_ != nullptr);
         mpi_ = new MPI_T (heap_mem_->get_ptr(), heap_mem_->get_size(), MPI_COMM_WORLD);
 

--- a/projects/rocshmem/tests/unit_tests/remote_heap_info_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/remote_heap_info_gtest.hpp
@@ -40,7 +40,7 @@ class RemoteHeapInfoTestFixture : public ::testing::Test
     /**
      * @brief Helper type for heap memory
      */
-    using HEAP_T = HeapMemoryType<HIPAllocator>;
+    using HEAP_T = HeapMemoryType;
 
     /**
      * @brief Helper type for RemoteHeapInfo with MPI
@@ -51,7 +51,8 @@ class RemoteHeapInfoTestFixture : public ::testing::Test
     /**
      * @brief Heap memory object
      */
-    HEAP_T heap_mem_ {};
+    HIPAllocator alloc_{};
+    HEAP_T heap_mem_{alloc_};
 
     /**
      * @brief Remote heap info with MPI Communicator


### PR DESCRIPTION
## Motivation

Part 2 of the work for removing allocators as template arguments from classes, in preparation for making the heap allocator used by rocSHMEM a runtime instead of a compile time decision.

## Technical Details

This PR tackles the following classes:
 - HeapMemoryType
 - {IPC/RO/GDA}DefaultContextProxy
 - reverse_offload:
     - BackendProxy
     - WindowProxy
     - QueueProxy
     - ProfilerProxy
     - ROTeamProxy
     - QueueElementProxy
 
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
