### PR TITLE
[rocprofiler-systems] [runtime-instrument] Add the ability to debug `finalizeInsertionSet` SEGFAULTS

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/CMakeLists.txt
@@ -15,6 +15,8 @@ target_sources(
     rocprofiler-systems-instrument
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/details.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/analysis.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/analysis.hpp
         ${CMAKE_CURRENT_LIST_DIR}/function_signature.cpp
         ${CMAKE_CURRENT_LIST_DIR}/function_signature.hpp
         ${CMAKE_CURRENT_LIST_DIR}/fwd.hpp

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/analysis.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/analysis.cpp
@@ -357,7 +357,7 @@ is_unhelpful_family_token(const std::string& token)
 
     // State-machine implementation names are broad and drown out useful tokens
     if(token.size() >= 5 && ((token.rfind("state") == token.size() - 5) ||
-                             (token.rfind("helper") == std::string::npos &&
+                             (token.find("helper") == std::string::npos &&
                               token.find("statementstate") != std::string::npos)))
         return true;
     return false;
@@ -591,7 +591,16 @@ procedure_id
 to_procedure_id(const module_function& mf)
 {
     procedure_id out{};
-    out.module_name   = mf.module_name;
+    out.library_name = "main executable";
+    if(mf.module && mf.module->isSharedLib())
+    {
+        if(auto* obj = mf.module->getObject())
+            out.library_name = obj->name();
+        else if(auto* lib = mf.module->libraryName())
+            out.library_name = lib;
+        else
+            out.library_name = mf.module_name;
+    }
     out.function_name = mf.function_name;
     return out;
 }
@@ -738,7 +747,7 @@ run_trial(const std::vector<std::string>& parent_argv, const std::string& restri
     {
         int code = WEXITSTATUS(status);
         if(code == 0) return trial_result::pass;
-        if(code == CHILD_ANALYSIS_EXIT) return trial_result::fail;
+        if(code == child_analysis_exit_code) return trial_result::fail;
         verbprintf(0, "[analysis] child pid=%d exited with unexpected code %d\n",
                    (int) pid, code);
         return trial_result::unexpected;
@@ -784,8 +793,8 @@ print_analysis_result(const std::vector<std::vector<procedure_id>>& failing_subs
         if(subset.size() == 1)
         {
             const auto& p = subset.front();
-            verbprintf(0, "[analysis]   subset %zu singleton: module=%s function=%s\n",
-                       i + 1, p.module_name.c_str(), p.function_name.c_str());
+            verbprintf(0, "[analysis]   subset %zu singleton: library=%s function=%s\n",
+                       i + 1, p.library_name.c_str(), p.function_name.c_str());
             continue;
         }
 
@@ -793,8 +802,8 @@ print_analysis_result(const std::vector<std::vector<procedure_id>>& failing_subs
                    subset.size());
         for(const auto& p : subset)
         {
-            verbprintf(0, "[analysis]     cooperative: function=%s\n",
-                       p.function_name.c_str());
+            verbprintf(0, "[analysis]     cooperative: library=%s function=%s\n",
+                       p.library_name.c_str(), p.function_name.c_str());
         }
     }
 }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/analysis.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/analysis.cpp
@@ -793,19 +793,25 @@ print_analysis_result(const std::vector<std::vector<procedure_id>>& failing_subs
         if(subset.size() == 1)
         {
             const auto& p = subset.front();
-            verbprintf(0, "[analysis]   subset %zu singleton: library=%s function=%s\n",
-                       i + 1, p.library_name.c_str(), p.function_name.c_str());
+            verbprintf(0, "[analysis]   subset %zu single procedure:\n", i + 1);
+            verbprintf(0, "[analysis]     source: %s\n", p.library_name.c_str());
+            verbprintf(0, "[analysis]     function: %s\n", p.function_name.c_str());
             continue;
         }
 
-        verbprintf(0, "[analysis]   subset %zu cooperative procedures: %zu\n", i + 1,
+        verbprintf(0, "[analysis]   subset %zu grouped procedures: %zu\n", i + 1,
                    subset.size());
+        verbprintf(0, "[analysis]     This subset fails together; individual procedures "
+                      "inside it may not fail on their own.\n");
         for(const auto& p : subset)
         {
-            verbprintf(0, "[analysis]     cooperative: library=%s function=%s\n",
-                       p.library_name.c_str(), p.function_name.c_str());
+            verbprintf(0, "[analysis]     procedure:\n");
+            verbprintf(0, "[analysis]       source: %s\n", p.library_name.c_str());
+            verbprintf(0, "[analysis]       function: %s\n", p.function_name.c_str());
         }
     }
+    verbprintf(0, "[analysis] Excluding these functions from instrumentation via "
+                  "--function-exclude is recommended\n");
 }
 
 void
@@ -876,10 +882,8 @@ run_insertion_analysis(fmodset_t& instrumented_module_functions)
                             state.fallback_failing_subsets.end());
     print_analysis_result(reported_subsets);
 
-    verbprintf(0, "[analysis] Excluding the functions from instrumentation via "
-                  "--function-exclude is recommended\n");
     _wc.stop();
-    verbprintf(0, "[analysis] total wall-clock time: %.3f sec\n", _wc.get());
+    verbprintf(0, "[analysis] total time taken: %.3f sec\n", _wc.get());
 }
 
 }  // namespace analysis

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/analysis.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/analysis.cpp
@@ -45,6 +45,12 @@ struct family_group_candidate
 
 thread_local sigjmp_buf            guarded_signal_jmp_buf{};
 thread_local volatile sig_atomic_t guarded_signal_caught = 0;
+thread_local const char*           signal_message        = nullptr;
+thread_local std::size_t           signal_message_length = 0;
+thread_local struct sigaction signal_message_old_segv
+{};
+thread_local struct sigaction signal_message_old_bus
+{};
 
 // timemory signal handling is termination-oriented, we need to recover
 extern "C" void
@@ -52,6 +58,65 @@ guarded_signal_handler(int sig, siginfo_t* /*info*/, void* /*ucontext*/)
 {
     guarded_signal_caught = sig;
     siglongjmp(guarded_signal_jmp_buf, 1);
+}
+
+extern "C" void
+signal_message_handler(int sig, siginfo_t* info, void* ucontext)
+{
+    if(signal_message && signal_message_length > 0)
+        write(STDERR_FILENO, signal_message, signal_message_length);
+
+    auto* previous = (sig == SIGBUS) ? &signal_message_old_bus : &signal_message_old_segv;
+    if((previous->sa_flags & SA_SIGINFO) != 0 && previous->sa_sigaction)
+    {
+        previous->sa_sigaction(sig, info, ucontext);
+        _exit(128 + sig);
+    }
+
+    if(previous->sa_handler != SIG_DFL && previous->sa_handler != SIG_IGN &&
+       previous->sa_handler)
+    {
+        previous->sa_handler(sig);
+        _exit(128 + sig);
+    }
+
+    sigaction(sig, previous, nullptr);
+    kill(getpid(), sig);
+    _exit(128 + sig);
+}
+
+// Runs an operation with a temporary message-only signal handler. If the operation
+// crashes, the message is written first and then the previous handler, typically
+// timemory's backtrace handler, receives the original signal context.
+template <typename FuncT>
+guarded_result
+run_with_signal_message(const char* msg, FuncT&& func)
+{
+    signal_message        = msg;
+    signal_message_length = (msg) ? std::strlen(msg) : 0;
+
+    struct sigaction new_sa
+    {};
+    std::memset(&new_sa, 0, sizeof(new_sa));
+    new_sa.sa_sigaction = &signal_message_handler;
+    new_sa.sa_flags     = SA_SIGINFO | SA_NODEFER;
+    sigemptyset(&new_sa.sa_mask);
+
+    sigaction(SIGSEGV, &new_sa, &signal_message_old_segv);
+    sigaction(SIGBUS, &new_sa, &signal_message_old_bus);
+
+    struct restore_signal_handlers
+    {
+        ~restore_signal_handlers()
+        {
+            sigaction(SIGSEGV, &signal_message_old_segv, nullptr);
+            sigaction(SIGBUS, &signal_message_old_bus, nullptr);
+            signal_message        = nullptr;
+            signal_message_length = 0;
+        }
+    } restore;
+
+    return std::forward<FuncT>(func)();
 }
 
 // Runs an operation with temporary SIGSEGV/SIGBUS handlers so analysis can report
@@ -510,7 +575,16 @@ finalize_insertion_set(address_space_t* addr_space, bool* modified_out,
         return ok ? guarded_result::pass : guarded_result::fail;
     };
 
-    if(!debug_analysis) return finalize();
+    if(!debug_analysis)
+    {
+        static constexpr const char* finalize_crash_msg =
+            "[rocprof-sys][exe] Error! finalizeInsertionSet crashed. This may be due "
+            "to dyninst failing to instrument one or more functions.\n"
+            "[rocprof-sys][exe] Re-run with '--debug-analysis' to bisect the queued "
+            "functions and report "
+            "the offending procedure subset.\n";
+        return run_with_signal_message(finalize_crash_msg, finalize);
+    }
 
     return run_with_signal_guard("finalizeInsertionSet", finalize, [modified_out]() {
         if(modified_out) *modified_out = false;
@@ -729,7 +803,7 @@ run_insertion_analysis(fmodset_t& instrumented_module_functions)
     print_analysis_result(reported_subsets);
 
     verbprintf(0, "[analysis] Excluding the functions from instrumentation via "
-                  "--function-exclude is recommended") _wc.stop();
+                  "--function-exclude is recommended\n") _wc.stop();
     verbprintf(0, "[analysis] total wall-clock time: %.3f sec\n", _wc.get());
 }
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/analysis.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/analysis.cpp
@@ -18,6 +18,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <fcntl.h>
 #include <fstream>
 #include <map>
 #include <set>
@@ -30,10 +31,11 @@ namespace analysis
 {
 namespace
 {
-using index_vec_t                    = std::vector<std::size_t>;
-using token_set_t                    = std::set<std::string>;
-using tokens_by_index_t              = std::map<std::size_t, token_set_t>;
-constexpr int exec_failure_exit_code = 127;
+using index_vec_t                     = std::vector<std::size_t>;
+using token_set_t                     = std::set<std::string>;
+using tokens_by_index_t               = std::map<std::size_t, token_set_t>;
+constexpr int exec_failure_exit_code  = 127;
+constexpr int signal_exit_code_offset = 128;  // shell convention for signal exits
 // Minimum length of a family token to be considered for grouping
 constexpr std::size_t min_family_token_length = 4;
 
@@ -43,13 +45,13 @@ struct family_group_candidate
     index_vec_t indices{};
 };
 
-thread_local sigjmp_buf            guarded_signal_jmp_buf{};
-thread_local volatile sig_atomic_t guarded_signal_caught = 0;
-thread_local const char*           signal_message        = nullptr;
-thread_local std::size_t           signal_message_length = 0;
-thread_local struct sigaction signal_message_old_segv
+sigjmp_buf            guarded_signal_jmp_buf{};
+volatile sig_atomic_t guarded_signal_caught = 0;
+const char*           signal_message        = nullptr;
+std::size_t           signal_message_length = 0;
+struct sigaction signal_message_old_segv
 {};
-thread_local struct sigaction signal_message_old_bus
+struct sigaction signal_message_old_bus
 {};
 
 // timemory signal handling is termination-oriented, we need to recover
@@ -64,30 +66,36 @@ extern "C" void
 signal_message_handler(int sig, siginfo_t* info, void* ucontext)
 {
     if(signal_message && signal_message_length > 0)
-        write(STDERR_FILENO, signal_message, signal_message_length);
+    {
+        auto written = write(STDERR_FILENO, signal_message, signal_message_length);
+        (void) written;
+    }
 
     auto* previous = (sig == SIGBUS) ? &signal_message_old_bus : &signal_message_old_segv;
     if((previous->sa_flags & SA_SIGINFO) != 0 && previous->sa_sigaction)
     {
         previous->sa_sigaction(sig, info, ucontext);
-        _exit(128 + sig);
+        // If the previous handler returns, preserve signal-style process status.
+        _exit(signal_exit_code_offset + sig);
     }
 
     if(previous->sa_handler != SIG_DFL && previous->sa_handler != SIG_IGN &&
        previous->sa_handler)
     {
         previous->sa_handler(sig);
-        _exit(128 + sig);
+        // If the previous handler returns, preserve signal-style process status.
+        _exit(signal_exit_code_offset + sig);
     }
 
     sigaction(sig, previous, nullptr);
     kill(getpid(), sig);
-    _exit(128 + sig);
+    _exit(signal_exit_code_offset + sig);
 }
 
 // Runs an operation with a temporary message-only signal handler. If the operation
 // crashes, the message is written first and then the previous handler, typically
-// timemory's backtrace handler, receives the original signal context.
+// timemory's backtrace handler, receives the original signal context. The message
+// must outlive the operation and any signal handling; use static storage.
 template <typename FuncT>
 guarded_result
 run_with_signal_message(const char* msg, FuncT&& func)
@@ -449,6 +457,7 @@ struct function_bisect_state
     std::vector<std::vector<procedure_id>> failing_subsets{};
     // Needed incase both disjoint subsets of a set fail
     std::vector<std::vector<procedure_id>> fallback_failing_subsets{};
+    bool                                   terminated = false;
 
     std::vector<procedure_id> to_procedures(const index_vec_t& subset) const
     {
@@ -499,6 +508,8 @@ struct function_bisect_state
 
     bool bisect(const index_vec_t& subset)
     {
+        if(terminated) return false;
+
         // The caller has already verified that this subset fails
         if(subset.size() == 1)
         {
@@ -512,14 +523,30 @@ struct function_bisect_state
 
         auto left_result  = run_subset(left);
         auto right_result = run_subset(right);
-        auto left_bad     = (left_result == trial_result::fail);
-        auto right_bad    = (right_result == trial_result::fail);
+        if(left_result == trial_result::unexpected ||
+           right_result == trial_result::unexpected)
+        {
+            terminated = true;
+            verbprintf(0, "[analysis] terminating analysis due to unexpected trial "
+                          "failure\n");
+            return false;
+        }
+        auto left_bad  = (left_result == trial_result::fail);
+        auto right_bad = (right_result == trial_result::fail);
 
         if(left_bad || right_bad)
         {
             bool found_precise_subset = false;
-            if(left_bad) found_precise_subset = bisect(left) || found_precise_subset;
-            if(right_bad) found_precise_subset = bisect(right) || found_precise_subset;
+            if(left_bad)
+            {
+                found_precise_subset = bisect(left) || found_precise_subset;
+                if(terminated) return false;
+            }
+            if(right_bad)
+            {
+                found_precise_subset = bisect(right) || found_precise_subset;
+                if(terminated) return false;
+            }
             return found_precise_subset;
         }
 
@@ -534,7 +561,16 @@ struct function_bisect_state
             verbprintf(0, "[analysis]   regroup candidate token='%s' size=%zu\n",
                        token.c_str(), grouped.size());
 
-            if(run_subset(grouped, false) == trial_result::fail)
+            auto grouped_result = run_subset(grouped, false);
+            if(grouped_result == trial_result::unexpected)
+            {
+                terminated = true;
+                verbprintf(0, "[analysis] terminating analysis due to unexpected "
+                              "regrouped trial failure\n");
+                return false;
+            }
+
+            if(grouped_result == trial_result::fail)
             {
                 verbprintf(0,
                            "[analysis]   -> regrouped family '%s' still crashes; "
@@ -609,14 +645,27 @@ run_trial(const std::vector<std::string>& parent_argv, const std::string& restri
     child_args.reserve(parent_argv.size() + 2);
 
     bool injected = false;
-    for(const auto& a : parent_argv)
+    for(std::size_t i = 0; i < parent_argv.size(); ++i)
     {
-        if(!injected && a == "--")
+        const auto& a = parent_argv.at(i);
+        if(a == "--")
         {
             child_args.emplace_back("-R");
             child_args.emplace_back(restrict_regex);
             injected = true;
+            child_args.insert(child_args.end(), parent_argv.begin() + i,
+                              parent_argv.end());
+            break;
         }
+
+        // Replace rocprof-sys function restrictions before "--" with this trial's
+        // subset regex
+        if(a == "-R" || a == "--function-restrict")
+        {
+            if(i + 1 < parent_argv.size() && parent_argv.at(i + 1) != "--") ++i;
+            continue;
+        }
+        if(a.rfind("--function-restrict=", 0) == 0) continue;
         child_args.emplace_back(a);
     }
     if(!injected)
@@ -636,7 +685,7 @@ run_trial(const std::vector<std::string>& parent_argv, const std::string& restri
     pid_t pid = fork();
     if(pid < 0)
     {
-        errprintf(0, "[analysis] fork failed: %s\n", std::strerror(errno));
+        verbprintf(0, "[analysis] fork failed: %s\n", std::strerror(errno));
         return trial_result::unexpected;
     }
 
@@ -670,7 +719,7 @@ run_trial(const std::vector<std::string>& parent_argv, const std::string& restri
         if(w < 0)
         {
             if(errno == EINTR) continue;
-            errprintf(0, "[analysis] waitpid failed: %s\n", std::strerror(errno));
+            verbprintf(0, "[analysis] waitpid failed: %s\n", std::strerror(errno));
             return trial_result::unexpected;
         }
         break;
@@ -690,8 +739,8 @@ run_trial(const std::vector<std::string>& parent_argv, const std::string& restri
         int code = WEXITSTATUS(status);
         if(code == 0) return trial_result::pass;
         if(code == CHILD_ANALYSIS_EXIT) return trial_result::fail;
-        errprintf(0, "[analysis] child pid=%d exited with unexpected code %d\n",
-                  (int) pid, code);
+        verbprintf(0, "[analysis] child pid=%d exited with unexpected code %d\n",
+                   (int) pid, code);
         return trial_result::unexpected;
     }
 
@@ -712,10 +761,11 @@ print_trial_result(size_t trial_idx, trial_result result, double elapsed_seconds
                        elapsed_seconds);
             break;
         case trial_result::unexpected:
-            errprintf(0,
-                      "[analysis]   An unexpected error occurred while running trial %zu "
-                      "(%.3f sec)\n",
-                      trial_idx, elapsed_seconds);
+            verbprintf(
+                0,
+                "[analysis]   An unexpected error occurred while running trial %zu "
+                "(%.3f sec)\n",
+                trial_idx, elapsed_seconds);
             break;
     }
 }
@@ -780,7 +830,7 @@ run_insertion_analysis(fmodset_t& instrumented_module_functions)
     auto parent_argv = read_proc_cmdline();
     if(parent_argv.empty())
     {
-        errprintf(0, "[analysis] could not read /proc/self/cmdline; aborting\n");
+        verbprintf(0, "[analysis] could not read /proc/self/cmdline; aborting\n");
         return;
     }
 
@@ -792,6 +842,21 @@ run_insertion_analysis(fmodset_t& instrumented_module_functions)
         root.emplace_back(i);
 
     state.bisect(root);  // Core
+    if(state.terminated)
+    {
+        verbprintf(0, "[analysis] analysis terminated before finding a failing subset\n");
+        return;
+    }
+
+    auto root_recorded_as_fallback = std::any_of(
+        state.fallback_failing_subsets.begin(), state.fallback_failing_subsets.end(),
+        [&queued](const auto& subset) { return subset.size() == queued.size(); });
+    if(root_recorded_as_fallback)
+    {
+        verbprintf(0, "[analysis] root set failed, but both halves and grouped candidate "
+                      "trials passed. The failure may not be due to individual functions "
+                      "alone.\n");
+    }
 
     // Singleton + name-regrouped subsets that fail
     auto reported_subsets = state.failing_subsets;
@@ -803,7 +868,8 @@ run_insertion_analysis(fmodset_t& instrumented_module_functions)
     print_analysis_result(reported_subsets);
 
     verbprintf(0, "[analysis] Excluding the functions from instrumentation via "
-                  "--function-exclude is recommended\n") _wc.stop();
+                  "--function-exclude is recommended\n");
+    _wc.stop();
     verbprintf(0, "[analysis] total wall-clock time: %.3f sec\n", _wc.get());
 }
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/analysis.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/analysis.cpp
@@ -1,0 +1,736 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+
+#include "analysis.hpp"
+
+#include "core/demangler.hpp"
+#include "fwd.hpp"
+#include "module_function.hpp"
+
+#include <BPatch_addressSpace.h>
+
+#include <timemory/components/timing/wall_clock.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <csetjmp>
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <map>
+#include <set>
+#include <sys/wait.h>
+#include <type_traits>
+#include <unistd.h>
+#include <utility>
+
+namespace analysis
+{
+namespace
+{
+using index_vec_t                    = std::vector<std::size_t>;
+using token_set_t                    = std::set<std::string>;
+using tokens_by_index_t              = std::map<std::size_t, token_set_t>;
+constexpr int exec_failure_exit_code = 127;
+// Minimum length of a family token to be considered for grouping
+constexpr std::size_t min_family_token_length = 4;
+
+struct family_group_candidate
+{
+    std::string token{};
+    index_vec_t indices{};
+};
+
+thread_local sigjmp_buf            guarded_signal_jmp_buf{};
+thread_local volatile sig_atomic_t guarded_signal_caught = 0;
+
+// timemory signal handling is termination-oriented, we need to recover
+extern "C" void
+guarded_signal_handler(int sig, siginfo_t* /*info*/, void* /*ucontext*/)
+{
+    guarded_signal_caught = sig;
+    siglongjmp(guarded_signal_jmp_buf, 1);
+}
+
+// Runs an operation with temporary SIGSEGV/SIGBUS handlers so analysis can report
+// the crash and choose a safer fallback instead of aborting outright.
+template <typename FuncT, typename SignalFuncT>
+guarded_result
+run_with_signal_guard(const char* context, FuncT&& func, SignalFuncT&& on_signal)
+{
+    // siglongjmp() skips C++ unwinding, so keep guarded callbacks trivially destructible
+    static_assert(std::is_trivially_destructible_v<std::decay_t<FuncT>>,
+                  "signal-guarded callback must be trivially destructible");
+    static_assert(std::is_trivially_destructible_v<std::decay_t<SignalFuncT>>,
+                  "signal-guarded signal callback must be trivially destructible");
+
+    guarded_signal_caught = 0;
+
+    struct sigaction new_sa
+    {};
+    std::memset(&new_sa, 0, sizeof(new_sa));
+    new_sa.sa_sigaction = &guarded_signal_handler;
+    new_sa.sa_flags     = SA_SIGINFO | SA_NODEFER;
+    sigemptyset(&new_sa.sa_mask);
+
+    struct sigaction old_segv
+    {};
+    struct sigaction old_bus
+    {};
+    sigaction(SIGSEGV, &new_sa, &old_segv);
+    sigaction(SIGBUS, &new_sa, &old_bus);
+
+    guarded_result result = guarded_result::fail;
+
+    if(sigsetjmp(guarded_signal_jmp_buf, 1) == 0)
+        result = std::forward<FuncT>(func)();
+    else
+        result = std::forward<SignalFuncT>(on_signal)();
+
+    sigaction(SIGSEGV, &old_segv, nullptr);
+    sigaction(SIGBUS, &old_bus, nullptr);
+
+    if(result == guarded_result::signaled)
+    {
+        verbprintf(0, "[analysis] caught signal %d (%s) inside %s\n",
+                   static_cast<int>(guarded_signal_caught),
+                   strsignal(guarded_signal_caught), context);
+    }
+
+    return result;
+}
+
+std::vector<std::string>
+read_proc_cmdline()
+{
+    std::vector<std::string> args;
+    std::ifstream            f{ "/proc/self/cmdline", std::ios::binary };
+    if(!f) return args;
+
+    std::string s;
+    char        c;
+    while(f.get(c))
+    {
+        if(c == '\0')
+        {
+            args.emplace_back(std::move(s));
+            s.clear();
+        }
+        else
+        {
+            s.push_back(c);
+        }
+    }
+    if(!s.empty()) args.emplace_back(std::move(s));
+    return args;
+}
+
+std::string
+regex_escape(const std::string& s)
+{
+    std::string out;
+    out.reserve(s.size() + 4);
+    for(char c : s)
+    {
+        switch(c)
+        {
+            case '.':
+            case '\\':
+            case '+':
+            case '*':
+            case '?':
+            case '(':
+            case ')':
+            case '[':
+            case ']':
+            case '{':
+            case '}':
+            case '^':
+            case '$':
+            case '|': out.push_back('\\'); break;
+            default: break;
+        }
+        out.push_back(c);
+    }
+    return out;
+}
+
+std::string
+build_restrict_regex(const std::vector<procedure_id>& universe,
+                     const index_vec_t&               indices)
+{
+    std::string r = "^(";
+    for(std::size_t i = 0; i < indices.size(); ++i)
+    {
+        if(i > 0) r.push_back('|');
+        r += regex_escape(universe.at(indices.at(i)).function_name);
+    }
+    r += ")$";
+    return r;
+}
+
+// ------------------------------------------------------------
+// Functions used in the name grouping fallback
+
+std::string
+index_subset_key(const index_vec_t& indices)
+{
+    std::string key{};
+    for(auto idx : indices)
+    {
+        key += std::to_string(idx);
+        key.push_back(',');
+    }
+    return key;
+}
+
+// For a given function, demangle the name and then tokenize the result
+token_set_t
+extract_family_tokens(const std::string& name)
+{
+    auto text = rocprofsys::utility::demangle(name);
+    if(text.empty()) text = name;
+
+    auto add_token = [](token_set_t& out, std::string& token) {
+        auto has_alphabetic = std::any_of(
+            token.begin(), token.end(), [](unsigned char c) { return std::isalpha(c); });
+        if(has_alphabetic && token.length() >= min_family_token_length)
+        {
+            std::transform(
+                token.begin(), token.end(), token.begin(),
+                [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+            out.emplace(token);
+        }
+        token.clear();
+    };
+
+    token_set_t out{};
+    std::string token{};
+    for(char c : text)
+    {
+        auto uc = static_cast<unsigned char>(c);
+        if(std::isalnum(uc) || c == '_')
+            token.push_back(c);
+        else
+            add_token(out, token);
+    }
+    add_token(out, token);
+    return out;
+}
+
+bool
+is_unhelpful_family_token(const std::string& token)
+{
+    // Discourage grouping by common tokens
+    static const std::set<std::string> generic = { "bool",
+                                                   "char",
+                                                   "clone",
+                                                   "common",
+                                                   "connection",
+                                                   "const",
+                                                   "constprop",
+                                                   "direction",
+                                                   "emit",
+                                                   "error",
+                                                   "erroneousiostatementstate",
+                                                   "external",
+                                                   "externalformattediostatementstate",
+                                                   "externallistiostatementstate",
+                                                   "externalmisciostatementstate",
+                                                   "externalunformattediostatementstate",
+                                                   "fortran",
+                                                   "formatted",
+                                                   "get",
+                                                   "handle",
+                                                   "input",
+                                                   "internal",
+                                                   "internalformattediostatementstate",
+                                                   "internallistiostatementstate",
+                                                   "inquire",
+                                                   "inquireiolengthstate",
+                                                   "inquirenounitstate",
+                                                   "inquireunconnectedfilestate",
+                                                   "inquireunitstate",
+                                                   "int",
+                                                   "io",
+                                                   "ioerrorhandler",
+                                                   "iostatementstate",
+                                                   "isra",
+                                                   "list",
+                                                   "long",
+                                                   "misc",
+                                                   "noop",
+                                                   "openstatementstate",
+                                                   "close",
+                                                   "closestatementstate",
+                                                   "position",
+                                                   "receive",
+                                                   "record",
+                                                   "referencewrapper",
+                                                   "relative",
+                                                   "runtime",
+                                                   "state",
+                                                   "statement",
+                                                   "std",
+                                                   "unformatted",
+                                                   "unit",
+                                                   "variant",
+                                                   "void" };
+
+    if(token.length() < min_family_token_length) return true;
+    if(generic.count(token) > 0) return true;
+
+    // State-machine implementation names are broad and drown out useful tokens
+    if(token.size() >= 5 && ((token.rfind("state") == token.size() - 5) ||
+                             (token.rfind("helper") == std::string::npos &&
+                              token.find("statementstate") != std::string::npos)))
+        return true;
+    return false;
+}
+
+bool
+prefer_family_token(const std::string& tokenA, const std::string& tokenB)
+{
+    auto score = [](const std::string& token) {
+        auto penalty = (is_unhelpful_family_token(token)) ? 1000 : 0;
+        return penalty + static_cast<int>(token.length());
+    };
+
+    auto ls = score(tokenA);
+    auto rs = score(tokenB);
+    if(ls != rs) return ls < rs;
+    return tokenA < tokenB;
+}
+
+// Group a set of functions by common family tokens as a last resort
+// Find common tokens from left and right subsets to construct new ones
+std::vector<family_group_candidate>
+build_common_name_groups(const std::vector<procedure_id>& universe,
+                         const index_vec_t& parent, const index_vec_t& left,
+                         const index_vec_t& right)
+{
+    // Extract tokens from all functions in the parent
+    tokens_by_index_t tokens_by_idx{};
+    for(auto idx : parent)
+        tokens_by_idx[idx] = extract_family_tokens(universe.at(idx).function_name);
+
+    // Collect every token seen in each half of the failed parent subset
+    token_set_t left_tokens{};
+    token_set_t right_tokens{};
+    for(auto idx : left)
+        left_tokens.insert(tokens_by_idx.at(idx).begin(), tokens_by_idx.at(idx).end());
+    for(auto idx : right)
+        right_tokens.insert(tokens_by_idx.at(idx).begin(), tokens_by_idx.at(idx).end());
+
+    // Shared tokens identify candidate families that cross the passing halves
+    std::vector<std::string> common_tokens{};
+    std::set_intersection(left_tokens.begin(), left_tokens.end(), right_tokens.begin(),
+                          right_tokens.end(), std::back_inserter(common_tokens));
+
+    std::map<std::string, family_group_candidate> dedup{};
+    for(const auto& token : common_tokens)
+    {
+        index_vec_t grouped{};
+        bool        has_left  = false;
+        bool        has_right = false;
+
+        // Build the new candidate group
+        for(auto idx : parent)
+        {
+            if(tokens_by_idx.at(idx).count(token) == 0) continue;
+
+            grouped.emplace_back(idx);
+            has_left  = has_left || std::binary_search(left.begin(), left.end(), idx);
+            has_right = has_right || std::binary_search(right.begin(), right.end(), idx);
+        }
+
+        // The candidate group should be larger than 1, and contain functions from both
+        // halves
+        if(grouped.size() <= 1 || grouped.size() >= parent.size()) continue;
+        if(!(has_left && has_right)) continue;
+
+        auto key = index_subset_key(grouped);
+        auto itr = dedup.find(key);
+        if(itr == dedup.end() || prefer_family_token(token, itr->second.token))
+            dedup[key] = { token, grouped };
+    }
+
+    auto groups = std::vector<family_group_candidate>{};
+    groups.reserve(dedup.size());
+    for(auto& [_, candidate] : dedup)
+        groups.emplace_back(std::move(candidate));
+
+    // Try smaller, better-labeled groups first.
+    std::sort(groups.begin(), groups.end(), [](const auto& lhs, const auto& rhs) {
+        if(lhs.indices.size() != rhs.indices.size())
+            return lhs.indices.size() < rhs.indices.size();
+        return prefer_family_token(lhs.token, rhs.token);
+    });
+    return groups;
+}
+
+//
+// ------------------------------------------------------------
+
+// Tracks bisection trials over queued procedures
+struct function_bisect_state
+{
+    const std::vector<procedure_id>& queued;
+    const std::vector<std::string>&  parent_argv;
+
+    std::size_t                            trials = 0;
+    std::vector<std::vector<procedure_id>> failing_subsets{};
+    // Needed incase both disjoint subsets of a set fail
+    std::vector<std::vector<procedure_id>> fallback_failing_subsets{};
+
+    std::vector<procedure_id> to_procedures(const index_vec_t& subset) const
+    {
+        std::vector<procedure_id> procedures{};
+        procedures.reserve(subset.size());
+        for(auto idx : subset)
+            procedures.emplace_back(queued[idx]);
+        return procedures;
+    }
+
+    void record_failing_subset(const index_vec_t& subset)
+    {
+        if(subset.empty()) return;
+        failing_subsets.emplace_back(to_procedures(subset));
+    }
+
+    void record_fallback_failing_subset(const index_vec_t& subset)
+    {
+        if(subset.empty()) return;
+        fallback_failing_subsets.emplace_back(to_procedures(subset));
+    }
+
+    trial_result run_subset(const index_vec_t& indices, bool is_bisect = true)
+    {
+        ++trials;
+        auto regex = build_restrict_regex(queued, indices);
+        auto first = indices.empty() ? 0 : indices.front();
+        auto last  = indices.empty() ? 0 : (indices.back() + 1);
+        auto _wc   = tim::component::wall_clock{};
+        _wc.start();
+        if(is_bisect)
+        {
+            verbprintf(0, "[analysis] trial %zu: subset [%zu, %zu) (size=%zu)\n", trials,
+                       first, last, indices.size());
+        }
+        else
+        {
+            // Indices make no sense in name based grouping
+            verbprintf(0, "[analysis] trial %zu: regrouped subset (size=%zu)\n", trials,
+                       indices.size());
+        }
+
+        auto result = analysis::run_trial(parent_argv, regex);
+        _wc.stop();
+        print_trial_result(trials, result, _wc.get());
+        return result;
+    }
+
+    bool bisect(const index_vec_t& subset)
+    {
+        // The caller has already verified that this subset fails
+        if(subset.size() == 1)
+        {
+            record_failing_subset(subset);
+            return true;
+        }
+
+        auto        mid = subset.size() / 2;
+        index_vec_t left{ subset.begin(), subset.begin() + mid };
+        index_vec_t right{ subset.begin() + mid, subset.end() };
+
+        auto left_result  = run_subset(left);
+        auto right_result = run_subset(right);
+        auto left_bad     = (left_result == trial_result::fail);
+        auto right_bad    = (right_result == trial_result::fail);
+
+        if(left_bad || right_bad)
+        {
+            bool found_precise_subset = false;
+            if(left_bad) found_precise_subset = bisect(left) || found_precise_subset;
+            if(right_bad) found_precise_subset = bisect(right) || found_precise_subset;
+            return found_precise_subset;
+        }
+
+        // It may be the case that a set of N functions fail, but both
+        // of their subsets pass. In this case, we attempt to group the functions
+        // by common family tokens as a last resort
+        auto groups = build_common_name_groups(queued, subset, left, right);
+        for(const auto& group : groups)
+        {
+            const auto& token   = group.token;
+            const auto& grouped = group.indices;
+            verbprintf(0, "[analysis]   regroup candidate token='%s' size=%zu\n",
+                       token.c_str(), grouped.size());
+
+            if(run_subset(grouped, false) == trial_result::fail)
+            {
+                verbprintf(0,
+                           "[analysis]   -> regrouped family '%s' still crashes; "
+                           "recording grouped subset\n",
+                           token.c_str());
+                record_failing_subset(grouped);
+                return true;
+            }
+        }
+
+        record_fallback_failing_subset(subset);
+        return false;
+    }
+};
+
+// Converts a module_function into a lightweight procedure_id object
+procedure_id
+to_procedure_id(const module_function& mf)
+{
+    procedure_id out{};
+    out.module_name   = mf.module_name;
+    out.function_name = mf.function_name;
+    return out;
+}
+
+}  // namespace
+
+guarded_result
+finalize_insertion_set(address_space_t* addr_space, bool* modified_out,
+                       bool debug_analysis)
+{
+    if(!addr_space) return guarded_result::fail;
+
+    auto finalize = [addr_space, modified_out]() {
+        bool modified = true;
+        bool ok       = addr_space->finalizeInsertionSet(true, &modified);
+        if(modified_out) *modified_out = modified;
+        return ok ? guarded_result::pass : guarded_result::fail;
+    };
+
+    if(!debug_analysis) return finalize();
+
+    return run_with_signal_guard("finalizeInsertionSet", finalize, [modified_out]() {
+        if(modified_out) *modified_out = false;
+        return guarded_result::signaled;
+    });
+}
+
+bool
+is_analysis_child()
+{
+    const char* s = std::getenv(child_analysis_env);
+    return s && *s && std::strcmp(s, "0") != 0;
+}
+
+// Forks a child process to run the target with a given restricted function regex
+// Generally, with runtime-instrument, the main time cost is attaching to the process
+// via processAttach() and the number of procedures being analyzed
+trial_result
+run_trial(const std::vector<std::string>& parent_argv, const std::string& restrict_regex)
+{
+    std::vector<std::string> child_args;
+    child_args.reserve(parent_argv.size() + 2);
+
+    bool injected = false;
+    for(const auto& a : parent_argv)
+    {
+        if(!injected && a == "--")
+        {
+            child_args.emplace_back("-R");
+            child_args.emplace_back(restrict_regex);
+            injected = true;
+        }
+        child_args.emplace_back(a);
+    }
+    if(!injected)
+    {
+        if(child_args.size() >= 1)
+            child_args.insert(child_args.begin() + 1, { "-R", restrict_regex });
+        else
+            child_args.insert(child_args.end(), { "-R", restrict_regex });
+    }
+
+    std::vector<char*> argv_ptrs;
+    argv_ptrs.reserve(child_args.size() + 1);
+    for(auto& s : child_args)
+        argv_ptrs.push_back(const_cast<char*>(s.c_str()));
+    argv_ptrs.push_back(nullptr);
+
+    pid_t pid = fork();
+    if(pid < 0)
+    {
+        errprintf(0, "[analysis] fork failed: %s\n", std::strerror(errno));
+        return trial_result::unexpected;
+    }
+
+    if(pid == 0)
+    {
+        const char* output_enabled  = std::getenv(analysis_output_env);
+        const bool  suppress_output = (!output_enabled || !*output_enabled ||
+                                      std::strcmp(output_enabled, "0") == 0);
+        if(suppress_output)
+        {
+            int fd = open("/dev/null", O_WRONLY);
+            if(fd >= 0)
+            {
+                dup2(fd, STDOUT_FILENO);
+                dup2(fd, STDERR_FILENO);
+                close(fd);
+            }
+        }
+
+        setenv(child_analysis_env, "1", 1);
+        execvp(argv_ptrs[0], argv_ptrs.data());
+        std::fprintf(stderr, "[analysis-child] execvp(%s) failed: %s\n", argv_ptrs[0],
+                     std::strerror(errno));
+        _exit(exec_failure_exit_code);
+    }
+
+    int status = 0;
+    while(true)
+    {
+        pid_t w = waitpid(pid, &status, 0);
+        if(w < 0)
+        {
+            if(errno == EINTR) continue;
+            errprintf(0, "[analysis] waitpid failed: %s\n", std::strerror(errno));
+            return trial_result::unexpected;
+        }
+        break;
+    }
+
+    if(WIFSIGNALED(status))
+    {
+        int sig = WTERMSIG(status);
+        verbprintf(1, "[analysis] child pid=%d killed by signal %d (%s)\n", (int) pid,
+                   sig, strsignal(sig));
+        if(sig == SIGSEGV || sig == SIGBUS || sig == SIGABRT) return trial_result::fail;
+        return trial_result::unexpected;
+    }
+
+    if(WIFEXITED(status))
+    {
+        int code = WEXITSTATUS(status);
+        if(code == 0) return trial_result::pass;
+        if(code == CHILD_ANALYSIS_EXIT) return trial_result::fail;
+        errprintf(0, "[analysis] child pid=%d exited with unexpected code %d\n",
+                  (int) pid, code);
+        return trial_result::unexpected;
+    }
+
+    return trial_result::unexpected;
+}
+
+void
+print_trial_result(size_t trial_idx, trial_result result, double elapsed_seconds)
+{
+    switch(result)
+    {
+        case trial_result::pass:
+            verbprintf(0, "[analysis]   trial %zu -> pass (%.3f sec)\n", trial_idx,
+                       elapsed_seconds);
+            break;
+        case trial_result::fail:
+            verbprintf(0, "[analysis]   trial %zu -> fail (%.3f sec)\n", trial_idx,
+                       elapsed_seconds);
+            break;
+        case trial_result::unexpected:
+            errprintf(0,
+                      "[analysis]   An unexpected error occurred while running trial %zu "
+                      "(%.3f sec)\n",
+                      trial_idx, elapsed_seconds);
+            break;
+    }
+}
+
+void
+print_analysis_result(const std::vector<std::vector<procedure_id>>& failing_subsets)
+{
+    if(failing_subsets.empty()) return;
+
+    verbprintf(0, "[analysis] failing procedure subset(s): %zu\n",
+               failing_subsets.size());
+
+    for(std::size_t i = 0; i < failing_subsets.size(); ++i)
+    {
+        const auto& subset = failing_subsets.at(i);
+        if(subset.size() == 1)
+        {
+            const auto& p = subset.front();
+            verbprintf(0, "[analysis]   subset %zu singleton: module=%s function=%s\n",
+                       i + 1, p.module_name.c_str(), p.function_name.c_str());
+            continue;
+        }
+
+        verbprintf(0, "[analysis]   subset %zu cooperative procedures: %zu\n", i + 1,
+                   subset.size());
+        for(const auto& p : subset)
+        {
+            verbprintf(0, "[analysis]     cooperative: function=%s\n",
+                       p.function_name.c_str());
+        }
+    }
+}
+
+void
+run_analysis(analysis_type type, fmodset_t& instrumented_module_functions)
+{
+    switch(type)
+    {
+        case analysis_type::insertion_set:
+            run_insertion_analysis(instrumented_module_functions);
+            return;
+    }
+}
+
+void
+run_insertion_analysis(fmodset_t& instrumented_module_functions)
+{
+    auto _wc = tim::component::wall_clock{};
+    _wc.start();
+
+    if(instrumented_module_functions.empty())
+    {
+        verbprintf(0, "[analysis] empty queue, nothing to analyze\n");
+        return;
+    }
+
+    auto queued = std::vector<procedure_id>{};
+    queued.reserve(instrumented_module_functions.size());
+    for(const auto& mf : instrumented_module_functions)
+        queued.emplace_back(to_procedure_id(mf));
+
+    auto parent_argv = read_proc_cmdline();
+    if(parent_argv.empty())
+    {
+        errprintf(0, "[analysis] could not read /proc/self/cmdline; aborting\n");
+        return;
+    }
+
+    function_bisect_state state{ queued, parent_argv };
+
+    index_vec_t root{};
+    root.reserve(queued.size());
+    for(std::size_t i = 0; i < queued.size(); ++i)
+        root.emplace_back(i);
+
+    state.bisect(root);  // Core
+
+    // Singleton + name-regrouped subsets that fail
+    auto reported_subsets = state.failing_subsets;
+    // Append the case where parent set fails, but both subsets
+    // and name grouping attempts pass
+    reported_subsets.insert(reported_subsets.end(),
+                            state.fallback_failing_subsets.begin(),
+                            state.fallback_failing_subsets.end());
+    print_analysis_result(reported_subsets);
+
+    verbprintf(0, "[analysis] Excluding the functions from instrumentation via "
+                  "--function-exclude is recommended") _wc.stop();
+    verbprintf(0, "[analysis] total wall-clock time: %.3f sec\n", _wc.get());
+}
+
+}  // namespace analysis

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/analysis.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/analysis.hpp
@@ -1,0 +1,81 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include "fwd.hpp"
+
+#include <string>
+#include <vector>
+
+enum class analysis_type
+{
+    insertion_set,
+};
+
+namespace analysis
+{
+// Used to determine if the current process is child
+constexpr const char* child_analysis_env = "ROCPROFSYS_CHILD_ANALYSIS";
+// Indicate that the child process failed to handle the given subset
+constexpr int CHILD_ANALYSIS_EXIT = 42;
+// Developer only var. Used to print the full logs of each child fork+exec subprocess
+constexpr const char* analysis_output_env = "ROCPROFSYS_ANALYSIS_OUTPUT";
+
+// A trial is a subprocess running a subset of functions
+enum class trial_result
+{
+    pass,        // Subset passed
+    fail,        // Subset failed
+    unexpected,  // Error not related to subset bisecting occurred, terminate analysis
+};
+
+// Result from an operation run under the analysis signal guard
+enum class guarded_result
+{
+    pass,
+    fail,
+    signaled,
+};
+
+// Stores minimal information from a module_function
+struct procedure_id
+{
+    string_t module_name   = {};
+    string_t function_name = {};
+};
+
+// Wrapper around finalizeInsertionSet(). In debug-analysis mode, SIGSEGV/SIGBUS
+// are caught so fork+exec child trials can report failing subsets; otherwise the
+// call is left unguarded so the normal process signal handler can report the crash
+guarded_result
+finalize_insertion_set(address_space_t* addr_space, bool* modified_out = nullptr,
+                       bool debug_analysis = false);
+
+// True if the current process is a subprocess trial spawned by the analysis
+bool
+is_analysis_child();
+
+// Entry point from rocprof-sys-instrument.cpp
+void
+run_analysis(analysis_type type, fmodset_t& instrumented_module_functions);
+
+// function-only insertion-set analysis
+// The primary cost of this analysis is from dyninst creating the new process
+// and the number of functions that it is analyzing
+void
+run_insertion_analysis(fmodset_t& instrumented_module_functions);
+
+// Run one subprocess trial restricted by "function-restrict"
+trial_result
+run_trial(const std::vector<std::string>& parent_argv, const std::string& restrict_regex);
+
+// Print a short summary of a single trial
+void
+print_trial_result(size_t trial_idx, trial_result result, double elapsed_seconds);
+
+// Print the final analysis result. Each failing subset contains one or more functions
+void
+print_analysis_result(const std::vector<std::vector<procedure_id>>& failing_subsets);
+
+}  // namespace analysis

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/analysis.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/analysis.hpp
@@ -18,7 +18,7 @@ namespace analysis
 // Used to determine if the current process is child
 constexpr const char* child_analysis_env = "ROCPROFSYS_CHILD_ANALYSIS";
 // Indicate that the child process failed to handle the given subset
-constexpr int CHILD_ANALYSIS_EXIT = 42;
+constexpr int child_analysis_exit_code = 42;
 // Developer only var. Used to print the full logs of each child fork+exec subprocess
 constexpr const char* analysis_output_env = "ROCPROFSYS_ANALYSIS_OUTPUT";
 
@@ -41,7 +41,7 @@ enum class guarded_result
 // Stores minimal information from a module_function
 struct procedure_id
 {
-    string_t module_name   = {};
+    string_t library_name  = {};
     string_t function_name = {};
 };
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/analysis.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/analysis.hpp
@@ -47,7 +47,7 @@ struct procedure_id
 
 // Wrapper around finalizeInsertionSet(). In debug-analysis mode, SIGSEGV/SIGBUS
 // are caught so fork+exec child trials can report failing subsets; otherwise the
-// call is left unguarded so the normal process signal handler can report the crash
+// call only prepends a diagnostic before forwarding crashes to the normal handler
 guarded_result
 finalize_insertion_set(address_space_t* addr_space, bool* modified_out = nullptr,
                        bool debug_analysis = false);

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -2347,8 +2347,8 @@ main(int argc, char** argv)
                 verbprintf(0,
                            "(analysis) Child finalizeInsertionSet crashed; exiting with "
                            "code %d so parent can record the failure\n",
-                           analysis::CHILD_ANALYSIS_EXIT);
-                std::_Exit(analysis::CHILD_ANALYSIS_EXIT);
+                           analysis::child_analysis_exit_code);
+                _exit(analysis::child_analysis_exit_code);
             }
 
             verbprintf(0, "finalizeInsertionSet crashed; running analysis via fork+exec "
@@ -2365,7 +2365,7 @@ main(int argc, char** argv)
         {
             verbprintf(0, "(analysis) finalize succeeded; exiting cleanly so parent "
                           "records this subset as safe\n");
-            std::_Exit(EXIT_SUCCESS);
+            _exit(EXIT_SUCCESS);
         }
 
         if(!success)

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprof-sys-instrument.hpp"
+#include "analysis.hpp"
 #include "common/defines.h"
 #include "common/join.hpp"
 #include "common/path.hpp"
@@ -93,6 +94,7 @@ bool   instr_print                  = false;
 bool   simulate                     = false;
 bool   include_uninstr              = false;
 bool   include_internal_linked_libs = false;
+bool   debug_analysis               = false;
 int    verbose_level   = tim::get_env<int>("ROCPROFSYS_VERBOSE_INSTRUMENT", 0);
 int    num_log_entries = tim::get_env<int>(
     "ROCPROFSYS_LOG_COUNT", tim::get_env<bool>("ROCPROFSYS_CI", false) ? 20 : 50);
@@ -732,6 +734,15 @@ main(int argc, char** argv)
         .dtype("boolean")
         .max_count(1)
         .action([](parser_t& p) { include_uninstr = p.get<bool>("all-functions"); });
+    parser
+        .add_argument(
+            { "--debug-analysis" },
+            "Opt-in debugging mode for finalizeInsertionSet crashes. When enabled, "
+            "rocprof-sys launches subprocess trials to bisect the queued functions "
+            "and report the smallest failing singleton or cooperative subset. ")
+        .dtype("boolean")
+        .max_count(1)
+        .action([](parser_t& p) { debug_analysis = p.get<bool>("debug-analysis"); });
 
     parser.add_argument({ "" }, "");
     parser.add_argument({ "[SYMBOL SELECTION OPTIONS]" }, "");
@@ -2323,7 +2334,49 @@ main(int argc, char** argv)
     {
         verbprintf(2, "Finalizing insertion set...\n");
         bool modified = true;
-        bool success  = addr_space->finalizeInsertionSet(true, &modified);
+        auto insertion_set_result =
+            analysis::finalize_insertion_set(addr_space, &modified, debug_analysis);
+        bool success = (insertion_set_result == analysis::guarded_result::pass);
+
+        // We only care about signaled results. If it is a normal failure, the backup
+        // batch insertion method will be used. No signal handling would be needed there.
+        if(insertion_set_result == analysis::guarded_result::signaled)
+        {
+            if(analysis::is_analysis_child())
+            {
+                verbprintf(0,
+                           "(analysis) Child finalizeInsertionSet crashed; exiting with "
+                           "code %d so parent can record the failure\n",
+                           analysis::CHILD_ANALYSIS_EXIT);
+                std::_Exit(analysis::CHILD_ANALYSIS_EXIT);
+            }
+
+            if(!debug_analysis)
+            {
+                errprintf(0, "finalizeInsertionSet crashed. This may be due to dyninst "
+                             "failing to instrument one or more functions. "
+                             "Re-run with '--debug-analysis' to bisect the queued "
+                             "functions and report the offending procedure subset.\n\n");
+                std::exit(EXIT_FAILURE);
+            }
+
+            verbprintf(0, "finalizeInsertionSet crashed; running analysis via fork+exec "
+                          "subprocesses...\n");
+            analysis::run_analysis(analysis_type::insertion_set,
+                                   instrumented_module_functions);
+            verbprintf(0, "Analysis complete; exiting with code %d\n", EXIT_FAILURE);
+            std::exit(EXIT_FAILURE);
+        }
+
+        // Skip the rest of the pipeline
+        if(insertion_set_result == analysis::guarded_result::pass &&
+           analysis::is_analysis_child())
+        {
+            verbprintf(0, "(analysis) finalize succeeded; exiting cleanly so parent "
+                          "records this subset as safe\n");
+            std::_Exit(EXIT_SUCCESS);
+        }
+
         if(!success)
         {
             verbprintf(

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -2351,15 +2351,6 @@ main(int argc, char** argv)
                 std::_Exit(analysis::CHILD_ANALYSIS_EXIT);
             }
 
-            if(!debug_analysis)
-            {
-                errprintf(0, "finalizeInsertionSet crashed. This may be due to dyninst "
-                             "failing to instrument one or more functions. "
-                             "Re-run with '--debug-analysis' to bisect the queued "
-                             "functions and report the offending procedure subset.\n\n");
-                std::exit(EXIT_FAILURE);
-            }
-
             verbprintf(0, "finalizeInsertionSet crashed; running analysis via fork+exec "
                           "subprocesses...\n");
             analysis::run_analysis(analysis_type::insertion_set,


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Suppose you're using `rocprof-sys-instrument`, on `runtime-instrument` mode, on some binary. And then you're hit with:
```
[...]
[rocprof-sys][exe] 1913 instrumented funcs in /opt/rocm-7.0.0/lib/llvm/lib/libomp.so
[rocprof-sys][exe]  579 instrumented funcs in /usr/lib64/libm-2.28.so

[rocprofiler-systems][3189][0] Signal 11 caught : Segmentation fault (Address not mapped to object [0x10])
### ERROR ### [rocprofiler-systems][PID=3189][TID=0] signal=11 (SIGSEGV) segmentation violation. code: 1 (SEGV_MAPERR :: Address not mapped), address of faulting memory reference: 0x10[01;31m
Backtrace:
[...]
[PID=3189][TID=0][26/28] _ZN14BPatch_process20finalizeInsertionSetEbPb +0x3d
[...]
```
From here, you're probably confused with no real idea on how to debug this. This PR aims to change this. 

Usually, `finalizeInsertionSet(...)` fails due to dyninst failing to handle instrumenting the queued functions, which by default is every function being instrumented. The idea is simple, capture the SEGFAULT, then re-run the program with smaller and smaller batches of functions until we can report the functions that should be excluded from instrumentation to allow it to succeed (at least with `finalizeInsertionSet(...)`.

**Note**: Technically this can also be used in binary rewrite mode, but I have yet to find an example where our tool fails there.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

### Overview

Add the ability to capture a signal from `finalizeInsertionSet(...)` (see `analysis` file)
Without `--debug-analysis` flag, along with the usual backtrace, the user is now also presented with a hint:
```
[rocprof-sys][exe] 1913 instrumented funcs in /opt/rocm-7.0.0/lib/llvm/lib/libomp.so
[rocprof-sys][exe]  579 instrumented funcs in /usr/lib64/libm-2.28.so
[rocprof-sys][exe] Error! finalizeInsertionSet crashed. This may be due to dyninst failing to instrument one or more functions.
[rocprof-sys][exe] Re-run with '--debug-analysis' to bisect the queued functions and report the offending procedure subset.

[rocprofiler-systems][6903][0] Signal 11 caught : Segmentation fault (Address not mapped to object [0x10])

### ERROR ### [rocprofiler-systems][PID=6903][TID=0] signal=11 (SIGSEGV) segmentation violation. code: 1 (SEGV_MAPERR :: Address not mapped), address of faulting memory reference: 0x10[01;31m
Backtrace:
[...]
```

Upon re-running with --debug-analysis, it attempts to find the function (or set of functions) that causes failure:
```
[rocprof-sys][exe] 1914 instrumented funcs in /opt/rocm-7.0.0/lib/llvm/lib/libomp.so
[rocprof-sys][exe]  575 instrumented funcs in /usr/lib64/libm-2.28.so
[rocprof-sys][exe] [analysis] caught signal 11 (Segmentation fault) inside finalizeInsertionSet
[rocprof-sys][exe] finalizeInsertionSet crashed; running analysis via fork+exec subprocesses...
[rocprof-sys][exe] [analysis] trial 1: subset [0, 1766) (size=1766)
[rocprof-sys][exe] [analysis]   trial 1 -> fail (0.142 sec)
[rocprof-sys][exe] [analysis] trial 2: subset [1766, 3533) (size=1767)
[rocprof-sys][exe] [analysis]   trial 2 -> pass (4.915 sec)
[...]
[rocprof-sys][exe] [analysis] trial 20: regrouped subset (size=18)
[rocprof-sys][exe] [analysis]   trial 20 -> fail (3.857 sec)
[rocprof-sys][exe] [analysis]   -> regrouped family '24ul' still crashes; recording grouped subset
[rocprof-sys][exe] [analysis] failing procedure subset(s): 1
[rocprof-sys][exe] [analysis]   subset 1 grouped procedures: 18
[rocprof-sys][exe] [analysis]     This subset fails together; individual procedures inside it may not fail on their own.
[rocprof-sys][exe] [analysis]     procedure:
[rocprof-sys][exe] [analysis]       source: main executable
[rocprof-sys][exe] [analysis]       function: _ZN7Fortran6common9log2visit15Log2VisitHelperILm0ELm24EPNS_7runtime2io26ListDirectedStatementStateILNS4_9DirectionE0EEEZNKS4_16IoStatementState6get_ifIS7_EEPT_vEUlRSB_E_JRKSt7variantIJSt17reference_wrapperINS4_18OpenStatementStateEESG_INS4_19CloseStatementStateEESG_INS4_18NoopStatementStateEESG_INS4_33InternalFormattedIoStatementStateILS6_0EcEEESG_INSN_ILS6_1EcEEESG_INS4_28InternalListIoStatementStateILS6_0EEEESG_INSS_ILS6_1EEEESG_INS4_33ExternalFormattedIoStatementStateILS6_0EcEEESG_INSX_ILS6_1EcEEESG_INS4_28ExternalListIoStatementStateILS6_0EEEESG_INS12_ILS6_1EEEESG_INS4_35ExternalUnformattedIoStatementStateILS6_0EEEESG_INS17_ILS6_1EEEESG_INS4_30ChildFormattedIoStatementStateILS6_0EcEEESG_INS1C_ILS6_1EcEEESG_INS4_25ChildListIoStatementStateILS6_0EEEESG_INS1H_ILS6_1EEEESG_INS4_32ChildUnformattedIoStatementStateILS6_0EEEESG_INS1M_ILS6_1EEEESG_INS4_16InquireUnitStateEESG_INS4_18InquireNoUnitStateEESG_INS4_27InquireUnconnectedFileStateEESG_INS4_20InquireIOLengthStateEESG_INS4_28ExternalMiscIoStatementStateEESG_INS4_25ErroneousIoStatementStateEEEEEEET1_OT2_mDpOT3_.isra.0.cold
[rocprof-sys][exe] [analysis]     procedure:
[rocprof-sys][exe] [analysis]       source: main executable
[rocprof-sys][exe] [analysis]       function: _ZN7Fortran6common9log2visit15Log2VisitHelperILm0ELm24EPNS_7runtime2io26ListDirectedStatementStateILNS4_9DirectionE0EEEZNKS4_16IoStatementState6get_ifIS7_EEPT_vEUlRSB_E_JRKSt7variantIJSt17reference_wrapperINS4_18OpenStatementStateEESG_INS4_19CloseStatementStateEESG_INS4_18NoopStatementStateEESG_INS4_33InternalFormattedIoStatementStateILS6_0EcEEESG_INSN_ILS6_1EcEEESG_INS4_28InternalListIoStatementStateILS6_0EEEESG_INSS_ILS6_1EEEESG_INS4_33ExternalFormattedIoStatementStateILS6_0EcEEESG_INSX_ILS6_1EcEEESG_INS4_28ExternalListIoStatementStateILS6_0EEEESG_INS12_ILS6_1EEEESG_INS4_35ExternalUnformattedIoStatementStateILS6_0EEEESG_INS17_ILS6_1EEEESG_INS4_30ChildFormattedIoStatementStateILS6_0EcEEESG_INS1C_ILS6_1EcEEESG_INS4_25ChildListIoStatementStateILS6_0EEEESG_INS1H_ILS6_1EEEESG_INS4_32ChildUnformattedIoStatementStateILS6_0EEEESG_INS1M_ILS6_1EEEESG_INS4_16InquireUnitStateEESG_INS4_18InquireNoUnitStateEESG_INS4_27InquireUnconnectedFileStateEESG_INS4_20InquireIOLengthStateEESG_INS4_28ExternalMiscIoStatementStateEESG_INS4_25ErroneousIoStatementStateEEEEEEET1_OT2_mDpOT3_.isra.0.cold
[rocprof-sys][exe] [analysis]     procedure:
[rocprof-sys][exe] [analysis]       source: main executable
[rocprof-sys][exe] [analysis]       function: _ZN7Fortran6common9log2visit15Log2VisitHelperILm0ELm24ERNS_7runtime2io12MutableModesEZNS4_16IoStatementState12mutableModesEvEUlRT_E_JRSt7variantIJSt17reference_wrapperINS4_18OpenStatementStateEESC_INS4_19CloseStatementStateEESC_INS4_18NoopStatementStateEESC_INS4_33InternalFormattedIoStatementStateILNS4_9DirectionE0EcEEESC_INSJ_ILSK_1EcEEESC_INS4_28InternalListIoStatementStateILSK_0EEEESC_INSP_ILSK_1EEEESC_INS4_33ExternalFormattedIoStatementStateILSK_0EcEEESC_INSU_ILSK_1EcEEESC_INS4_28ExternalListIoStatementStateILSK_0EEEESC_INSZ_ILSK_1EEEESC_INS4_35ExternalUnformattedIoStatementStateILSK_0EEEESC_INS14_ILSK_1EEEESC_INS4_30ChildFormattedIoStatementStateILSK_0EcEEESC_INS19_ILSK_1EcEEESC_INS4_25ChildListIoStatementStateILSK_0EEEESC_INS1E_ILSK_1EEEESC_INS4_32ChildUnformattedIoStatementStateILSK_0EEEESC_INS1J_ILSK_1EEEESC_INS4_16InquireUnitStateEESC_INS4_18InquireNoUnitStateEESC_INS4_27InquireUnconnectedFileStateEESC_INS4_20InquireIOLengthStateEESC_INS4_28ExternalMiscIoStatementStateEESC_INS4_25ErroneousIoStatementStateEEEEEEET1_OT2_mDpOT3_.isra.0
[rocprof-sys][exe] [analysis]     procedure:
[rocprof-sys][exe] [analysis]       source: main executable
[rocprof-sys][exe] [analysis]       function: _ZN7Fortran6common9log2visit15Log2VisitHelperILm0ELm24ERNS_7runtime2io12MutableModesEZNS4_16IoStatementState12mutableModesEvEUlRT_E_JRSt7variantIJSt17reference_wrapperINS4_18OpenStatementStateEESC_INS4_19CloseStatementStateEESC_INS4_18NoopStatementStateEESC_INS4_33InternalFormattedIoStatementStateILNS4_9DirectionE0EcEEESC_INSJ_ILSK_1EcEEESC_INS4_28InternalListIoStatementStateILSK_0EEEESC_INSP_ILSK_1EEEESC_INS4_33ExternalFormattedIoStatementStateILSK_0EcEEESC_INSU_ILSK_1EcEEESC_INS4_28ExternalListIoStatementStateILSK_0EEEESC_INSZ_ILSK_1EEEESC_INS4_35ExternalUnformattedIoStatementStateILSK_0EEEESC_INS14_ILSK_1EEEESC_INS4_30ChildFormattedIoStatementStateILSK_0EcEEESC_INS19_ILSK_1EcEEESC_INS4_25ChildListIoStatementStateILSK_0EEEESC_INS1E_ILSK_1EEEESC_INS4_32ChildUnformattedIoStatementStateILSK_0EEEESC_INS1J_ILSK_1EEEESC_INS4_16InquireUnitStateEESC_INS4_18InquireNoUnitStateEESC_INS4_27InquireUnconnectedFileStateEESC_INS4_20InquireIOLengthStateEESC_INS4_28ExternalMiscIoStatementStateEESC_INS4_25ErroneousIoStatementStateEEEEEEET1_OT2_mDpOT3_.isra.0.cold
[rocprof-sys][exe] [analysis]     procedure:
[rocprof-sys][exe] [analysis]       source: main executable
[rocprof-sys][exe] [analysis]       function: _ZN7Fortran6common9log2visit15Log2VisitHelperILm0ELm24ERNS_7runtime2io14IoErrorHandlerEZNKS4_16IoStatementState17GetIoErrorHandlerEvEUlRT_E_JRKSt7variantIJSt17reference_wrapperINS4_18OpenStatementStateEESC_INS4_19CloseStatementStateEESC_INS4_18NoopStatementStateEESC_INS4_33InternalFormattedIoStatementStateILNS4_9DirectionE0EcEEESC_INSJ_ILSK_1EcEEESC_INS4_28InternalListIoStatementStateILSK_0EEEESC_INSP_ILSK_1EEEESC_INS4_33ExternalFormattedIoStatementStateILSK_0EcEEESC_INSU_ILSK_1EcEEESC_INS4_28ExternalListIoStatementStateILSK_0EEEESC_INSZ_ILSK_1EEEESC_INS4_35ExternalUnformattedIoStatementStateILSK_0EEEESC_INS14_ILSK_1EEEESC_INS4_30ChildFormattedIoStatementStateILSK_0EcEEESC_INS19_ILSK_1EcEEESC_INS4_25ChildListIoStatementStateILSK_0EEEESC_INS1E_ILSK_1EEEESC_INS4_32ChildUnformattedIoStatementStateILSK_0EEEESC_INS1J_ILSK_1EEEESC_INS4_16InquireUnitStateEESC_INS4_18InquireNoUnitStateEESC_INS4_27InquireUnconnectedFileStateEESC_INS4_20InquireIOLengthStateEESC_INS4_28ExternalMiscIoStatementStateEESC_INS4_25ErroneousIoStatementStateEEEEEEET1_OT2_mDpOT3_.isra.0
[rocprof-sys][exe] [analysis]     procedure:
[rocprof-sys][exe] [analysis]       source: main executable
[rocprof-sys][exe] [analysis]       function: _ZN7Fortran6common9log2visit15Log2VisitHelperILm0ELm24ERNS_7runtime2io14IoErrorHandlerEZNKS4_16IoStatementState17GetIoErrorHandlerEvEUlRT_E_JRKSt7variantIJSt17reference_wrapperINS4_18OpenStatementStateEESC_INS4_19CloseStatementStateEESC_INS4_18NoopStatementStateEESC_INS4_33InternalFormattedIoStatementStateILNS4_9DirectionE0EcEEESC_INSJ_ILSK_1EcEEESC_INS4_28InternalListIoStatementStateILSK_0EEEESC_INSP_ILSK_1EEEESC_INS4_33ExternalFormattedIoStatementStateILSK_0EcEEESC_INSU_ILSK_1EcEEESC_INS4_28ExternalListIoStatementStateILSK_0EEEESC_INSZ_ILSK_1EEEESC_INS4_35ExternalUnformattedIoStatementStateILSK_0EEEESC_INS14_ILSK_1EEEESC_INS4_30ChildFormattedIoStatementStateILSK_0EcEEESC_INS19_ILSK_1EcEEESC_INS4_25ChildListIoStatementStateILSK_0EEEESC_INS1E_ILSK_1EEEESC_INS4_32ChildUnformattedIoStatementStateILSK_0EEEESC_INS1J_ILSK_1EEEESC_INS4_16InquireUnitStateEESC_INS4_18InquireNoUnitStateEESC_INS4_27InquireUnconnectedFileStateEESC_INS4_20InquireIOLengthStateEESC_INS4_28ExternalMiscIoStatementStateEESC_INS4_25ErroneousIoStatementStateEEEEEEET1_OT2_mDpOT3_.isra.0.cold
[rocprof-sys][exe] [analysis]     procedure:
[rocprof-sys][exe] [analysis]       source: main executable
[rocprof-sys][exe] [analysis]       function: _ZN7Fortran6common9log2visit15Log2VisitHelperILm0ELm24ERNS_7runtime2io15ConnectionStateEZNS4_16IoStatementState18GetConnectionStateEvEUlRT_E_JRSt7variantIJSt17reference_wrapperINS4_18OpenStatementStateEESC_INS4_19CloseStatementStateEESC_INS4_18NoopStatementStateEESC_INS4_33InternalFormattedIoStatementStateILNS4_9DirectionE0EcEEESC_INSJ_ILSK_1EcEEESC_INS4_28InternalListIoStatementStateILSK_0EEEESC_INSP_ILSK_1EEEESC_INS4_33ExternalFormattedIoStatementStateILSK_0EcEEESC_INSU_ILSK_1EcEEESC_INS4_28ExternalListIoStatementStateILSK_0EEEESC_INSZ_ILSK_1EEEESC_INS4_35ExternalUnformattedIoStatementStateILSK_0EEEESC_INS14_ILSK_1EEEESC_INS4_30ChildFormattedIoStatementStateILSK_0EcEEESC_INS19_ILSK_1EcEEESC_INS4_25ChildListIoStatementStateILSK_0EEEESC_INS1E_ILSK_1EEEESC_INS4_32ChildUnformattedIoStatementStateILSK_0EEEESC_INS1J_ILSK_1EEEESC_INS4_16InquireUnitStateEESC_INS4_18InquireNoUnitStateEESC_INS4_27InquireUnconnectedFileStateEESC_INS4_20InquireIOLengthStateEESC_INS4_28ExternalMiscIoStatementStateEESC_INS4_25ErroneousIoStatementStateEEEEEEET1_OT2_mDpOT3_.isra.0
[rocprof-sys][exe] [analysis]     procedure:
[rocprof-sys][exe] [analysis]       source: main executable
[rocprof-sys][exe] [analysis]       function: _ZN7Fortran6common9log2visit15Log2VisitHelperILm0ELm24ERNS_7runtime2io15ConnectionStateEZNS4_16IoStatementState18GetConnectionStateEvEUlRT_E_JRSt7variantIJSt17reference_wrapperINS4_18OpenStatementStateEESC_INS4_19CloseStatementStateEESC_INS4_18NoopStatementStateEESC_INS4_33InternalFormattedIoStatementStateILNS4_9DirectionE0EcEEESC_INSJ_ILSK_1EcEEESC_INS4_28InternalListIoStatementStateILSK_0EEEESC_INSP_ILSK_1EEEESC_INS4_33ExternalFormattedIoStatementStateILSK_0EcEEESC_INSU_ILSK_1EcEEESC_INS4_28ExternalListIoStatementStateILSK_0EEEESC_INSZ_ILSK_1EEEESC_INS4_35ExternalUnformattedIoStatementStateILSK_0EEEESC_INS14_ILSK_1EEEESC_INS4_30ChildFormattedIoStatementStateILSK_0EcEEESC_INS19_ILSK_1EcEEESC_INS4_25ChildListIoStatementStateILSK_0EEEESC_INS1E_ILSK_1EEEESC_INS4_32ChildUnformattedIoStatementStateILSK_0EEEESC_INS1J_ILSK_1EEEESC_INS4_16InquireUnitStateEESC_INS4_18InquireNoUnitStateEESC_INS4_27InquireUnconnectedFileStateEESC_INS4_20InquireIOLengthStateEESC_INS4_28ExternalMiscIoStatementStateEESC_INS4_25ErroneousIoStatementStateEEEEEEET1_OT2_mDpOT3_.isra.0.cold
[rocprof-sys][exe] [analysis]     procedure:
[rocprof-sys][exe] [analysis]       source: main executable
[rocprof-sys][exe] [analysis]       function: _ZN7Fortran6common9log2visit15Log2VisitHelperILm0ELm24EbZNS_7runtime2io16IoStatementState13AdvanceRecordEiEUlRT_E_JRSt7variantIJSt17reference_wrapperINS4_18OpenStatementStateEESA_INS4_19CloseStatementStateEESA_INS4_18NoopStatementStateEESA_INS4_33InternalFormattedIoStatementStateILNS4_9DirectionE0EcEEESA_INSH_ILSI_1EcEEESA_INS4_28InternalListIoStatementStateILSI_0EEEESA_INSN_ILSI_1EEEESA_INS4_33ExternalFormattedIoStatementStateILSI_0EcEEESA_INSS_ILSI_1EcEEESA_INS4_28ExternalListIoStatementStateILSI_0EEEESA_INSX_ILSI_1EEEESA_INS4_35ExternalUnformattedIoStatementStateILSI_0EEEESA_INS12_ILSI_1EEEESA_INS4_30ChildFormattedIoStatementStateILSI_0EcEEESA_INS17_ILSI_1EcEEESA_INS4_25ChildListIoStatementStateILSI_0EEEESA_INS1C_ILSI_1EEEESA_INS4_32ChildUnformattedIoStatementStateILSI_0EEEESA_INS1H_ILSI_1EEEESA_INS4_16InquireUnitStateEESA_INS4_18InquireNoUnitStateEESA_INS4_27InquireUnconnectedFileStateEESA_INS4_20InquireIOLengthStateEESA_INS4_28ExternalMiscIoStatementStateEESA_INS4_25ErroneousIoStatementStateEEEEEEET1_OT2_mDpOT3_
[rocprof-sys][exe] [analysis]     procedure:
[rocprof-sys][exe] [analysis]       source: main executable
[rocprof-sys][exe] [analysis]       function: _ZN7Fortran6common9log2visit15Log2VisitHelperILm0ELm24EbZNS_7runtime2io16IoStatementState13AdvanceRecordEiEUlRT_E_JRSt7variantIJSt17reference_wrapperINS4_18OpenStatementStateEESA_INS4_19CloseStatementStateEESA_INS4_18NoopStatementStateEESA_INS4_33InternalFormattedIoStatementStateILNS4_9DirectionE0EcEEESA_INSH_ILSI_1EcEEESA_INS4_28InternalListIoStatementStateILSI_0EEEESA_INSN_ILSI_1EEEESA_INS4_33ExternalFormattedIoStatementStateILSI_0EcEEESA_INSS_ILSI_1EcEEESA_INS4_28ExternalListIoStatementStateILSI_0EEEESA_INSX_ILSI_1EEEESA_INS4_35ExternalUnformattedIoStatementStateILSI_0EEEESA_INS12_ILSI_1EEEESA_INS4_30ChildFormattedIoStatementStateILSI_0EcEEESA_INS17_ILSI_1EcEEESA_INS4_25ChildListIoStatementStateILSI_0EEEESA_INS1C_ILSI_1EEEESA_INS4_32ChildUnformattedIoStatementStateILSI_0EEEESA_INS1H_ILSI_1EEEESA_INS4_16InquireUnitStateEESA_INS4_18InquireNoUnitStateEESA_INS4_27InquireUnconnectedFileStateEESA_INS4_20InquireIOLengthStateEESA_INS4_28ExternalMiscIoStatementStateEESA_INS4_25ErroneousIoStatementStateEEEEEEET1_OT2_mDpOT3_.constprop.0
[rocprof-sys][exe] [analysis]     procedure:
[rocprof-sys][exe] [analysis]       source: main executable
[rocprof-sys][exe] [analysis]       function: _ZN7Fortran6common9log2visit15Log2VisitHelperILm0ELm24EbZNS_7runtime2io16IoStatementState4EmitEPKcmmEUlRT_E_JRSt7variantIJSt17reference_wrapperINS4_18OpenStatementStateEESC_INS4_19CloseStatementStateEESC_INS4_18NoopStatementStateEESC_INS4_33InternalFormattedIoStatementStateILNS4_9DirectionE0EcEEESC_INSJ_ILSK_1EcEEESC_INS4_28InternalListIoStatementStateILSK_0EEEESC_INSP_ILSK_1EEEESC_INS4_33ExternalFormattedIoStatementStateILSK_0EcEEESC_INSU_ILSK_1EcEEESC_INS4_28ExternalListIoStatementStateILSK_0EEEESC_INSZ_ILSK_1EEEESC_INS4_35ExternalUnformattedIoStatementStateILSK_0EEEESC_INS14_ILSK_1EEEESC_INS4_30ChildFormattedIoStatementStateILSK_0EcEEESC_INS19_ILSK_1EcEEESC_INS4_25ChildListIoStatementStateILSK_0EEEESC_INS1E_ILSK_1EEEESC_INS4_32ChildUnformattedIoStatementStateILSK_0EEEESC_INS1J_ILSK_1EEEESC_INS4_16InquireUnitStateEESC_INS4_18InquireNoUnitStateEESC_INS4_27InquireUnconnectedFileStateEESC_INS4_20InquireIOLengthStateEESC_INS4_28ExternalMiscIoStatementStateEESC_INS4_25ErroneousIoStatementStateEEEEEEET1_OT2_mDpOT3_
[rocprof-sys][exe] [analysis]     procedure:
[rocprof-sys][exe] [analysis]       source: main executable
[rocprof-sys][exe] [analysis]       function: _ZN7Fortran6common9log2visit15Log2VisitHelperILm0ELm24EbZNS_7runtime2io16IoStatementState7ReceiveEPcmmEUlRT_E_JRSt7variantIJSt17reference_wrapperINS4_18OpenStatementStateEESB_INS4_19CloseStatementStateEESB_INS4_18NoopStatementStateEESB_INS4_33InternalFormattedIoStatementStateILNS4_9DirectionE0EcEEESB_INSI_ILSJ_1EcEEESB_INS4_28InternalListIoStatementStateILSJ_0EEEESB_INSO_ILSJ_1EEEESB_INS4_33ExternalFormattedIoStatementStateILSJ_0EcEEESB_INST_ILSJ_1EcEEESB_INS4_28ExternalListIoStatementStateILSJ_0EEEESB_INSY_ILSJ_1EEEESB_INS4_35ExternalUnformattedIoStatementStateILSJ_0EEEESB_INS13_ILSJ_1EEEESB_INS4_30ChildFormattedIoStatementStateILSJ_0EcEEESB_INS18_ILSJ_1EcEEESB_INS4_25ChildListIoStatementStateILSJ_0EEEESB_INS1D_ILSJ_1EEEESB_INS4_32ChildUnformattedIoStatementStateILSJ_0EEEESB_INS1I_ILSJ_1EEEESB_INS4_16InquireUnitStateEESB_INS4_18InquireNoUnitStateEESB_INS4_27InquireUnconnectedFileStateEESB_INS4_20InquireIOLengthStateEESB_INS4_28ExternalMiscIoStatementStateEESB_INS4_25ErroneousIoStatementStateEEEEEEET1_OT2_mDpOT3_
[rocprof-sys][exe] [analysis]     procedure:
[rocprof-sys][exe] [analysis]       source: main executable
[rocprof-sys][exe] [analysis]       function: _ZN7Fortran6common9log2visit15Log2VisitHelperILm0ELm24EmZNS_7runtime2io16IoStatementState17GetNextInputBytesERPKcEUlRT_E_JRSt7variantIJSt17reference_wrapperINS4_18OpenStatementStateEESD_INS4_19CloseStatementStateEESD_INS4_18NoopStatementStateEESD_INS4_33InternalFormattedIoStatementStateILNS4_9DirectionE0EcEEESD_INSK_ILSL_1EcEEESD_INS4_28InternalListIoStatementStateILSL_0EEEESD_INSQ_ILSL_1EEEESD_INS4_33ExternalFormattedIoStatementStateILSL_0EcEEESD_INSV_ILSL_1EcEEESD_INS4_28ExternalListIoStatementStateILSL_0EEEESD_INS10_ILSL_1EEEESD_INS4_35ExternalUnformattedIoStatementStateILSL_0EEEESD_INS15_ILSL_1EEEESD_INS4_30ChildFormattedIoStatementStateILSL_0EcEEESD_INS1A_ILSL_1EcEEESD_INS4_25ChildListIoStatementStateILSL_0EEEESD_INS1F_ILSL_1EEEESD_INS4_32ChildUnformattedIoStatementStateILSL_0EEEESD_INS1K_ILSL_1EEEESD_INS4_16InquireUnitStateEESD_INS4_18InquireNoUnitStateEESD_INS4_27InquireUnconnectedFileStateEESD_INS4_20InquireIOLengthStateEESD_INS4_28ExternalMiscIoStatementStateEESD_INS4_25ErroneousIoStatementStateEEEEEEET1_OT2_mDpOT3_.isra.0
[rocprof-sys][exe] [analysis]     procedure:
[rocprof-sys][exe] [analysis]       source: main executable
[rocprof-sys][exe] [analysis]       function: _ZN7Fortran6common9log2visit15Log2VisitHelperILm0ELm24EmZNS_7runtime2io16IoStatementState17GetNextInputBytesERPKcEUlRT_E_JRSt7variantIJSt17reference_wrapperINS4_18OpenStatementStateEESD_INS4_19CloseStatementStateEESD_INS4_18NoopStatementStateEESD_INS4_33InternalFormattedIoStatementStateILNS4_9DirectionE0EcEEESD_INSK_ILSL_1EcEEESD_INS4_28InternalListIoStatementStateILSL_0EEEESD_INSQ_ILSL_1EEEESD_INS4_33ExternalFormattedIoStatementStateILSL_0EcEEESD_INSV_ILSL_1EcEEESD_INS4_28ExternalListIoStatementStateILSL_0EEEESD_INS10_ILSL_1EEEESD_INS4_35ExternalUnformattedIoStatementStateILSL_0EEEESD_INS15_ILSL_1EEEESD_INS4_30ChildFormattedIoStatementStateILSL_0EcEEESD_INS1A_ILSL_1EcEEESD_INS4_25ChildListIoStatementStateILSL_0EEEESD_INS1F_ILSL_1EEEESD_INS4_32ChildUnformattedIoStatementStateILSL_0EEEESD_INS1K_ILSL_1EEEESD_INS4_16InquireUnitStateEESD_INS4_18InquireNoUnitStateEESD_INS4_27InquireUnconnectedFileStateEESD_INS4_20InquireIOLengthStateEESD_INS4_28ExternalMiscIoStatementStateEESD_INS4_25ErroneousIoStatementStateEEEEEEET1_OT2_mDpOT3_.isra.0.cold
[rocprof-sys][exe] [analysis]     procedure:
[rocprof-sys][exe] [analysis]       source: main executable
[rocprof-sys][exe] [analysis]       function: _ZN7Fortran6common9log2visit15Log2VisitHelperILm0ELm24EvZNS_7runtime2io16IoStatementState22HandleAbsolutePositionElEUlRT_E_JRSt7variantIJSt17reference_wrapperINS4_18OpenStatementStateEESA_INS4_19CloseStatementStateEESA_INS4_18NoopStatementStateEESA_INS4_33InternalFormattedIoStatementStateILNS4_9DirectionE0EcEEESA_INSH_ILSI_1EcEEESA_INS4_28InternalListIoStatementStateILSI_0EEEESA_INSN_ILSI_1EEEESA_INS4_33ExternalFormattedIoStatementStateILSI_0EcEEESA_INSS_ILSI_1EcEEESA_INS4_28ExternalListIoStatementStateILSI_0EEEESA_INSX_ILSI_1EEEESA_INS4_35ExternalUnformattedIoStatementStateILSI_0EEEESA_INS12_ILSI_1EEEESA_INS4_30ChildFormattedIoStatementStateILSI_0EcEEESA_INS17_ILSI_1EcEEESA_INS4_25ChildListIoStatementStateILSI_0EEEESA_INS1C_ILSI_1EEEESA_INS4_32ChildUnformattedIoStatementStateILSI_0EEEESA_INS1H_ILSI_1EEEESA_INS4_16InquireUnitStateEESA_INS4_18InquireNoUnitStateEESA_INS4_27InquireUnconnectedFileStateEESA_INS4_20InquireIOLengthStateEESA_INS4_28ExternalMiscIoStatementStateEESA_INS4_25ErroneousIoStatementStateEEEEEEET1_OT2_mDpOT3_.isra.0
[rocprof-sys][exe] [analysis]     procedure:
[rocprof-sys][exe] [analysis]       source: main executable
[rocprof-sys][exe] [analysis]       function: _ZN7Fortran6common9log2visit15Log2VisitHelperILm0ELm24EvZNS_7runtime2io16IoStatementState22HandleAbsolutePositionElEUlRT_E_JRSt7variantIJSt17reference_wrapperINS4_18OpenStatementStateEESA_INS4_19CloseStatementStateEESA_INS4_18NoopStatementStateEESA_INS4_33InternalFormattedIoStatementStateILNS4_9DirectionE0EcEEESA_INSH_ILSI_1EcEEESA_INS4_28InternalListIoStatementStateILSI_0EEEESA_INSN_ILSI_1EEEESA_INS4_33ExternalFormattedIoStatementStateILSI_0EcEEESA_INSS_ILSI_1EcEEESA_INS4_28ExternalListIoStatementStateILSI_0EEEESA_INSX_ILSI_1EEEESA_INS4_35ExternalUnformattedIoStatementStateILSI_0EEEESA_INS12_ILSI_1EEEESA_INS4_30ChildFormattedIoStatementStateILSI_0EcEEESA_INS17_ILSI_1EcEEESA_INS4_25ChildListIoStatementStateILSI_0EEEESA_INS1C_ILSI_1EEEESA_INS4_32ChildUnformattedIoStatementStateILSI_0EEEESA_INS1H_ILSI_1EEEESA_INS4_16InquireUnitStateEESA_INS4_18InquireNoUnitStateEESA_INS4_27InquireUnconnectedFileStateEESA_INS4_20InquireIOLengthStateEESA_INS4_28ExternalMiscIoStatementStateEESA_INS4_25ErroneousIoStatementStateEEEEEEET1_OT2_mDpOT3_.isra.0.cold
[rocprof-sys][exe] [analysis]     procedure:
[rocprof-sys][exe] [analysis]       source: main executable
[rocprof-sys][exe] [analysis]       function: _ZN7Fortran6common9log2visit15Log2VisitHelperILm0ELm24EvZNS_7runtime2io16IoStatementState22HandleRelativePositionElEUlRT_E_JRSt7variantIJSt17reference_wrapperINS4_18OpenStatementStateEESA_INS4_19CloseStatementStateEESA_INS4_18NoopStatementStateEESA_INS4_33InternalFormattedIoStatementStateILNS4_9DirectionE0EcEEESA_INSH_ILSI_1EcEEESA_INS4_28InternalListIoStatementStateILSI_0EEEESA_INSN_ILSI_1EEEESA_INS4_33ExternalFormattedIoStatementStateILSI_0EcEEESA_INSS_ILSI_1EcEEESA_INS4_28ExternalListIoStatementStateILSI_0EEEESA_INSX_ILSI_1EEEESA_INS4_35ExternalUnformattedIoStatementStateILSI_0EEEESA_INS12_ILSI_1EEEESA_INS4_30ChildFormattedIoStatementStateILSI_0EcEEESA_INS17_ILSI_1EcEEESA_INS4_25ChildListIoStatementStateILSI_0EEEESA_INS1C_ILSI_1EEEESA_INS4_32ChildUnformattedIoStatementStateILSI_0EEEESA_INS1H_ILSI_1EEEESA_INS4_16InquireUnitStateEESA_INS4_18InquireNoUnitStateEESA_INS4_27InquireUnconnectedFileStateEESA_INS4_20InquireIOLengthStateEESA_INS4_28ExternalMiscIoStatementStateEESA_INS4_25ErroneousIoStatementStateEEEEEEET1_OT2_mDpOT3_.isra.0
[rocprof-sys][exe] [analysis]     procedure:
[rocprof-sys][exe] [analysis]       source: main executable
[rocprof-sys][exe] [analysis]       function: _ZN7Fortran6common9log2visit15Log2VisitHelperILm0ELm24EvZNS_7runtime2io16IoStatementState22HandleRelativePositionElEUlRT_E_JRSt7variantIJSt17reference_wrapperINS4_18OpenStatementStateEESA_INS4_19CloseStatementStateEESA_INS4_18NoopStatementStateEESA_INS4_33InternalFormattedIoStatementStateILNS4_9DirectionE0EcEEESA_INSH_ILSI_1EcEEESA_INS4_28InternalListIoStatementStateILSI_0EEEESA_INSN_ILSI_1EEEESA_INS4_33ExternalFormattedIoStatementStateILSI_0EcEEESA_INSS_ILSI_1EcEEESA_INS4_28ExternalListIoStatementStateILSI_0EEEESA_INSX_ILSI_1EEEESA_INS4_35ExternalUnformattedIoStatementStateILSI_0EEEESA_INS12_ILSI_1EEEESA_INS4_30ChildFormattedIoStatementStateILSI_0EcEEESA_INS17_ILSI_1EcEEESA_INS4_25ChildListIoStatementStateILSI_0EEEESA_INS1C_ILSI_1EEEESA_INS4_32ChildUnformattedIoStatementStateILSI_0EEEESA_INS1H_ILSI_1EEEESA_INS4_16InquireUnitStateEESA_INS4_18InquireNoUnitStateEESA_INS4_27InquireUnconnectedFileStateEESA_INS4_20InquireIOLengthStateEESA_INS4_28ExternalMiscIoStatementStateEESA_INS4_25ErroneousIoStatementStateEEEEEEET1_OT2_mDpOT3_.isra.0.cold
[rocprof-sys][exe] [analysis] Excluding these functions from instrumentation via --function-exclude is recommended
[rocprof-sys][exe] [analysis] total time taken: 77.325 sec
[rocprof-sys][exe] Analysis complete; exiting with code 1
```

Indeed, re-running with `--function-exclude log2visit` result in a successful run.

### How it works

First, we call a custom wrapper of `finalizeInsertionSet` that is used to capture the SEGFAULT and redirect to debugging logic if `--debug-analysis` is set. Else it prints the typical backtrace.

If `--debug-analysis` is on, redirect to a `run_analysis` function (meant to be an entry point for analyzing other functions, but for now, it only uses `finalizeInsertionSet`).

The core idea here is that we pass in every function that was meant to be instrumented (`instrumented_module_functions`) and then bisect these functions until we find the set/singleton of functions that cause the failure (through `bisect` and `run_subset`).

A trial is an instance of `rocprof-sys-instrument` that was spawned to help debug. It is passed a custom `--function-exclude` regex that isolates the bisected set of functions for that run.

Bisect logic follows:
```
F fails
├─ size 1 → singleton culprit
└─ split into L/R (left/right)
   ├─ L fails → recurse L
   ├─ R fails → recurse R
   └─ L passes + R passes
      └─ grouped analysis once (group functions by tokens)
         ├─ group fails → report group
         └─ no group fails → report original F
```

The reason we group by tokens is that it could be multiple functions that cause the failure when instrumented together. Normal bisection does not account for this, so as a last resort, we group them by common names and see if any fail. 

Once analysis is done, it exits with `EXIT_FAILURE`.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFSYST-413
AIPROFSYST-410

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

This can't really be tested in CI as failing cases are sparse (good).

However, a manual test involves using a `rhel 8.10` docker container that uses `rocm 7.0` specifically (which I used for the logs above):
```
docker run -v "$(cd ../../.. && pwd)":/home/development   -it -w /home/development/projects/rocprofiler-systems   --device /dev/kfd --device /dev/dri   $(whoami)/rocprofiler-systems:release-base-rhel-8.10-rocm-7.0
```
Then running:
```
source rocprof-sys-build/share/rocprofiler-systems/setup-env.sh 
rocprof-sys-instrument --min-instructions 0 -- rocprof-sys-build/openmp-vv-host-test-parallel-for-simd-atomic 
```

This fails because of the `log2visit` functions... which is why they are a hardcoded exclusion in our code: https://github.com/ROCm/rocm-systems/blob/develop/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.cpp#L562

Analysis:
```
rocprof-sys-instrument --min-instructions 0 -debug-analysis -- rocprof-sys-build/openmp-vv-host-test-parallel-for-simd-atomic 
```

Good run with info from analysis:
```
rocprof-sys-instrument --min-instructions 0 --function-exclude log2visit  -- rocprof-sys-build/openmp-vv-host-test-parallel-for-simd-atomic 
```

## Test Result

<!-- Briefly summarize test outcomes. -->

Analysis passes with the reproducer and using the information obtained, a successful run is achieved.


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
