### PR TITLE
Return hipErrorNotSupported for unsupported Pitch2D texture configs

### DIFF
--- a/projects/clr/hipamd/src/hip_texture.cpp
+++ b/projects/clr/hipamd/src/hip_texture.cpp
@@ -144,6 +144,19 @@ hipError_t ihipCreateTextureObject(hipTextureObject_t* pTexObject, const hipReso
     return hipErrorInvalidValue;
   }
 
+  // CUDA divergence: CUDA supports normalizedCoords and linear filtering with
+  // Pitch2D resources natively. AMD GPU texture units require tiled memory layouts
+  // for these features, so Pitch2D (linear layout) is incompatible.
+  if (pResDesc->resType == hipResourceTypePitch2D) {
+    if (pTexDesc->normalizedCoords || pTexDesc->filterMode == hipFilterModeLinear) {
+      LogPrintfError(
+          "Pitch2D resources do not support normalizedCoords or linear filtering "
+          "on this platform (normalizedCoords=%d, filterMode=%d)",
+          pTexDesc->normalizedCoords, pTexDesc->filterMode);
+      return hipErrorNotSupported;
+    }
+  }
+
   // We don't program the max_ansio_ratio field in the the HW sampler SRD.
   if (pTexDesc->maxAnisotropy != 0) {
     return hipErrorNotSupported;

--- a/projects/clr/hipamd/src/hip_texture.cpp
+++ b/projects/clr/hipamd/src/hip_texture.cpp
@@ -145,13 +145,14 @@ hipError_t ihipCreateTextureObject(hipTextureObject_t* pTexObject, const hipReso
   }
 
   // CUDA divergence: CUDA supports normalizedCoords and linear filtering with
-  // Pitch2D resources natively. AMD GPU texture units require tiled memory layouts
-  // for these features, so Pitch2D (linear layout) is incompatible.
+  // Pitch2D resources natively. AMD GPUs report these capabilities via
+  // device::Info; see roc::Device::populateOCLDeviceConstants().
   if (pResDesc->resType == hipResourceTypePitch2D) {
-    if (pTexDesc->normalizedCoords || pTexDesc->filterMode == hipFilterModeLinear) {
+    if ((pTexDesc->normalizedCoords && !info.pitch2DNormalizedCoordsSupport_) ||
+        (pTexDesc->filterMode == hipFilterModeLinear && !info.pitch2DLinearFilterSupport_)) {
       LogPrintfError(
           "Pitch2D resources do not support normalizedCoords or linear filtering "
-          "on this platform (normalizedCoords=%d, filterMode=%d)",
+          "on this device (normalizedCoords=%d, filterMode=%d)",
           pTexDesc->normalizedCoords, pTexDesc->filterMode);
       return hipErrorNotSupported;
     }

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -589,6 +589,17 @@ struct Info : public amd::EmbeddedObject {
   //! Describes whether buffers from images are supported
   uint32_t bufferFromImageSupport_;
 
+  //! True if Pitch2D resources support hipFilterModeLinear sampling.
+  //! AMD GPU texture units require tiled layouts for linear filtering,
+  //! so this is false on all current AMD architectures (gfx9-gfx12).
+  uint32_t pitch2DLinearFilterSupport_;
+
+  //! True if Pitch2D resources support normalized coordinates.
+  //! AMD GPU texture units require tiled layouts for normalized
+  //! coordinate sampling, so this is false on all current AMD
+  //! architectures (gfx9-gfx12).
+  uint32_t pitch2DNormalizedCoordsSupport_;
+
   //! Returns the supported SPIR versions for the device
   const char* spirVersions_;
 

--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -439,6 +439,8 @@ void NullDevice::fillDeviceInfo(const Pal::DeviceProperties& palProp,
     info_.imageBaseAddressAlignment_ = 256;  // XXX: 256 byte base address alignment for now
 
     info_.bufferFromImageSupport_ = true;
+    info_.pitch2DLinearFilterSupport_ = false;
+    info_.pitch2DNormalizedCoordsSupport_ = false;
   }
 
   info_.errorCorrectionSupport_ = false;

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -1331,6 +1331,8 @@ bool Device::populateOCLDeviceConstants() {
   info_.addressBits_ = LP64_SWITCH(32, 64);
   info_.maxSamplers_ = 16;
   info_.bufferFromImageSupport_ = false;
+  info_.pitch2DLinearFilterSupport_ = false;
+  info_.pitch2DNormalizedCoordsSupport_ = false;
   info_.oclcVersion_ = "OpenCL C " OPENCL_C_VERSION_STR " ";
   info_.spirVersions_ = "";
 
@@ -1497,6 +1499,8 @@ bool Device::populateOCLDeviceConstants() {
     info_.imageBaseAddressAlignment_ = 256;
 
     info_.bufferFromImageSupport_ = false;
+    info_.pitch2DLinearFilterSupport_ = false;
+    info_.pitch2DNormalizedCoordsSupport_ = false;
 
     info_.imageSupport_ = (info_.maxReadWriteImageArgs_ > 0) ? true : false;
   }

--- a/projects/hip-tests/catch/config/configs/unit/texture.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/texture.yaml
@@ -9,6 +9,9 @@ texture:
   Unit_hipCreateTextureObject_Pitch2DResource:
     <<: *level_2
     tags: [texobj, image]
+  Unit_hipCreateTextureObject_Pitch2D_NormalizedCoordsLinearFilter:
+    <<: *level_2
+    tags: [texobj, image]
   Unit_hipCreateTextureObject_ArrayResource:
     <<: *level_2
     tags: [texobj, image]

--- a/projects/hip-tests/catch/unit/texture/hipCreateTextureObject_Pitch2D.cc
+++ b/projects/hip-tests/catch/unit/texture/hipCreateTextureObject_Pitch2D.cc
@@ -226,6 +226,97 @@ HIP_TEST_CASE(Unit_hipCreateTextureObject_Pitch2DResource) {
   HIP_CHECK(hipFree(devPtrA));
 }
 
+/**
+ * Test Description
+ * ------------------------
+ *  - Validates that Pitch2D resources reject normalizedCoords and linear filtering:
+ *    -# When normalizedCoords is set to true with Pitch2D resource
+ *      - Expected output: return `hipErrorNotSupported`
+ *    -# When filterMode is hipFilterModeLinear with Pitch2D resource
+ *      - Expected output: return `hipErrorNotSupported`
+ *    -# When both normalizedCoords and hipFilterModeLinear are set with Pitch2D resource
+ *      - Expected output: return `hipErrorNotSupported`
+ *    -# When normalizedCoords is false and filterMode is hipFilterModePoint with Pitch2D resource
+ *      - Expected output: return `hipSuccess`
+ * Test source
+ * ------------------------
+ *  - unit/texture/hipCreateTextureObject_Pitch2D.cc
+ * Test requirements
+ * ------------------------
+ *  - Textures supported on device
+ *  - Platform is AMD (CUDA supports these combinations natively)
+ *  - HIP_VERSION >= 5.2
+ */
+HIP_TEST_CASE(Unit_hipCreateTextureObject_Pitch2D_NormalizedCoordsLinearFilter) {
+  CHECK_IMAGE_SUPPORT
+
+  // This is an AMD-specific limitation: CUDA supports these combinations natively.
+  if (!TestContext::get().isAmd()) {
+    HipTest::HIP_SKIP_TEST("Test not applicable on NVIDIA platform");
+    return;
+  }
+
+  hipError_t ret;
+  hipResourceDesc resDesc;
+  hipTextureDesc texDesc;
+  hipTextureObject_t texObj;
+  size_t devPitchA;
+  float* devPtrA;
+
+  // Initialization
+  HIP_CHECK(hipMallocPitch(reinterpret_cast<void**>(&devPtrA), &devPitchA, SIZE_W * sizeof(float),
+                           SIZE_H));
+  memset(&resDesc, 0, sizeof(resDesc));
+  resDesc.resType = hipResourceTypePitch2D;
+  resDesc.res.pitch2D.devPtr = devPtrA;
+  resDesc.res.pitch2D.height = SIZE_H;
+  resDesc.res.pitch2D.width = SIZE_W;
+  resDesc.res.pitch2D.pitchInBytes = devPitchA;
+  resDesc.res.pitch2D.desc = hipCreateChannelDesc<float>();
+
+  SECTION("hipResourceTypePitch2D and normalizedCoords(true)") {
+    memset(&texDesc, 0, sizeof(texDesc));
+    texDesc.readMode = hipReadModeElementType;
+    texDesc.normalizedCoords = 1;
+    texDesc.filterMode = hipFilterModePoint;
+
+    ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr);
+    REQUIRE(ret == hipErrorNotSupported);
+  }
+
+  SECTION("hipResourceTypePitch2D and filterMode(hipFilterModeLinear)") {
+    memset(&texDesc, 0, sizeof(texDesc));
+    texDesc.readMode = hipReadModeElementType;
+    texDesc.normalizedCoords = 0;
+    texDesc.filterMode = hipFilterModeLinear;
+
+    ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr);
+    REQUIRE(ret == hipErrorNotSupported);
+  }
+
+  SECTION("hipResourceTypePitch2D and normalizedCoords(true)/filterMode(hipFilterModeLinear)") {
+    memset(&texDesc, 0, sizeof(texDesc));
+    texDesc.readMode = hipReadModeElementType;
+    texDesc.normalizedCoords = 1;
+    texDesc.filterMode = hipFilterModeLinear;
+
+    ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr);
+    REQUIRE(ret == hipErrorNotSupported);
+  }
+
+  SECTION("hipResourceTypePitch2D and normalizedCoords(false)/filterMode(hipFilterModePoint)") {
+    memset(&texDesc, 0, sizeof(texDesc));
+    texDesc.readMode = hipReadModeElementType;
+    texDesc.normalizedCoords = 0;
+    texDesc.filterMode = hipFilterModePoint;
+
+    HIP_CHECK(hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr));
+    HIP_CHECK(hipDestroyTextureObject(texObj));
+  }
+
+  // De-Initialization
+  HIP_CHECK(hipFree(devPtrA));
+}
 
 /**
  * End doxygen group TextureTest.


### PR DESCRIPTION
## Summary

- Fix `hip_texture.cpp` to return `hipErrorNotSupported` instead of `hipErrorOutOfMemory` when `ihipCreateTextureObject` receives a Pitch2D resource with unsupported configuration (`normalizedCoords=true` or `hipFilterModeLinear`)
- Add early validation check with CUDA-divergence comment documenting the behavioral difference
- Add comprehensive negative tests covering all unsupported Pitch2D texture parameter combinations
- Add YAML config entry for the new Pitch2D texture validation test

## Test plan

- [x] New negative tests pass: Pitch2D with `normalizedCoords=true` returns `hipErrorNotSupported`
- [x] New negative tests pass: Pitch2D with `hipFilterModeLinear` returns `hipErrorNotSupported`
- [x] New negative tests pass: Pitch2D with both `normalizedCoords=true` and `hipFilterModeLinear` returns `hipErrorNotSupported`
- [x] New negative tests pass: Pitch2D with valid config (no normalized coords, no linear filter) succeeds
- [x] Existing texture regression tests still pass (4/4)
- [x] Full build succeeds (hip-clr + hip-tests, 892 targets)
- [x] Verify on physical GPU hardware (Linux CI hip-tests all 4 shards passed on AMD GPU runners)
- [x] Verify no regressions in downstream texture-dependent workloads

## Verification

8/8 tests passed (4 new negative tests + 4 existing regression tests). Build passed across 892 targets. See PR comment below for before/after test output demonstrating the fix.

🤖 Claude Code 🤖