### PR TITLE
Sync copied TheRock test scripts 2026-04-28

### DIFF
--- a/test/therock/test_hiptests.py
+++ b/test/therock/test_hiptests.py
@@ -68,6 +68,18 @@ TEST_TO_IGNORE = {
             "Unit_hipMemsetASyncMulti",
             "Unit_hipHostAlloc_AllocateMoreThanAvailGPUMemory",
             "Unit_hipStreamValue_Write - TestParams<uint32_t, PtrType::DevicePtrToHost>",
+            # TODO(#4244): Flaky with compiler submodule update - subprocess aborted.
+            "Unit_NonHost_Printf_loop",
+            "Unit_NonHost_Printf_multiple_Threads",
+            "Unit_NonHost_Printf_BufferAvailability",
+        ]
+    },
+    "gfx94X-dcgpu": {
+        "linux": [
+            # TODO(#4244): Flaky with compiler submodule update - subprocess aborted.
+            "Unit_NonHost_Printf_loop",
+            "Unit_NonHost_Printf_multiple_Threads",
+            "Unit_NonHost_Printf_BufferAvailability",
         ]
     },
     "gfx110X-all": {

--- a/test/therock/test_rocprofiler_compute.py
+++ b/test/therock/test_rocprofiler_compute.py
@@ -71,7 +71,7 @@ def execute_tests():
         "--output-on-failure",
         "--verbose",
         "--exclude-regex",
-        f"{" | ".join(EXCLUDED_TESTS)}",
+        f"{"|".join(EXCLUDED_TESTS)}",
         "--tests-information",
         f"{shard_index},,{total_shards}",
     ]

--- a/test/therock/test_rocr-debug-agent.py
+++ b/test/therock/test_rocr-debug-agent.py
@@ -135,9 +135,24 @@ def get_default_paths() -> Dict[str, Path]:
     therock_bin_dir = validate_path(Path(therock_bin_dir_str), "THEROCK_BIN_DIR")
     artifacts_dir = validate_path(Path(artifacts_dir_str), "OUTPUT_ARTIFACTS_DIR")
 
+    # Try the old testing script location first (for backwards compatibility).
+    test_bin = therock_bin_dir / "rocm-debug-agent-test"
+    test_script = artifacts_dir / "src" / "rocm-debug-agent-test" / "run-test.py"
+
+    if not test_script.exists():
+        # Fall back to the new testing script location (both binary and script
+        # in the same directory).
+        test_dir = artifacts_dir / "tests" / "rocm-debug-agent"
+        test_bin = test_dir / "rocm-debug-agent-test"
+        test_script = test_dir / "run-test.py"
+
+        if not test_script.exists():
+            logger.error("[X] Error: run-test.py not found.")
+            sys.exit(1)
+
     return {
-        "test_bin": therock_bin_dir / "rocm-debug-agent-test",
-        "test_script": artifacts_dir / "src" / "rocm-debug-agent-test" / "run-test.py",
+        "test_bin": test_bin,
+        "test_script": test_script,
     }
 
 

--- a/test/therock/test_rocrtst.py
+++ b/test/therock/test_rocrtst.py
@@ -28,6 +28,11 @@ cmd = ["./rocrtst64"]
 
 # TODO(#3851): Excluded tests (flaky or disabled in CI).
 TEST_TO_IGNORE = {
+    "gfx90a": {
+        "linux": [
+            "rocrtstFunc.Memory_Max_Mem",
+        ]
+    },
     "gfx94X-dcgpu": {
         "linux": [
             "rocrtstFunc.Memory_Max_Mem",
@@ -70,9 +75,10 @@ QUICK_TESTS = [
     "rocrtstFunc.Memory_Atomic_Xchg_Test",
 ]
 
+exclude_filter = "-"
 if AMDGPU_FAMILIES in TEST_TO_IGNORE and os_type in TEST_TO_IGNORE[AMDGPU_FAMILIES]:
     ignored_tests = TEST_TO_IGNORE[AMDGPU_FAMILIES][os_type]
-    exclude_filter = "-" + ":".join(ignored_tests)
+    exclude_filter += ":".join(ignored_tests)
 
 test_type = os.getenv("TEST_TYPE", "full")
 


### PR DESCRIPTION
Syncs the copied TheRock test runners under `test/therock` with current upstream fixes while preserving rocm-systems path adaptations.

Changes:
- update rocrtst filter initialization and gfx90a ignore coverage
- update hiptests gfx950/gfx94X flaky-test excludes
- update rocprofiler-compute exclude-regex handling
- support old and new rocr-debug-agent artifact locations

Validation:
- `python -m py_compile` passed for all scripts under `test/therock`