### PR TITLE
[rocdecode] - Enhance logging to display both kernel thread ID and hash ID

### DIFF
--- a/projects/rocdecode/src/commons.h
+++ b/projects/rocdecode/src/commons.h
@@ -35,6 +35,7 @@ THE SOFTWARE.
 #include <thread>
 #include <sstream>
 #include <iomanip>
+#include <sys/syscall.h>
 
 #define MSG(X) std::clog << X << std::endl;
 #define MSG_NO_NEWLINE(X) std::clog << X;
@@ -54,8 +55,9 @@ enum RocDecLogLevel {
 
 #define GET_TIME_NS() ([]() -> uint64_t { struct timespec ts_; clock_gettime(CLOCK_MONOTONIC, &ts_); return static_cast<uint64_t>(ts_.tv_sec) * 1000000000LL + ts_.tv_nsec; }())
 #define FILENAME_ONLY (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
-#define GET_THREAD_ID() ([]() -> std::string { std::ostringstream oss; oss << "0x" << std::hex << std::setw(5) << std::setfill('0') << (std::hash<std::thread::id>{}(std::this_thread::get_id()) & 0xFFFFF); return oss.str(); }())
-#define MakeMsg(msg) ROCDEC_STR(FILENAME_ONLY) + ":" + ROCDEC_TOSTR(__LINE__) + ": " + ROCDEC_TOSTR(GET_TIME_NS() / 1000ULL) + ROCDEC_STR(" us: ") + ROCDEC_STR("[pid:") + ROCDEC_TOSTR(getpid()) + ROCDEC_STR(" tid: ") + GET_THREAD_ID() + ROCDEC_STR("] ") + ROCDEC_STR(__func__) + "(): " + msg
+#define GET_HASHED_THREAD_ID() ([]() -> std::string { std::ostringstream oss; oss << "0x" << std::hex << std::setw(5) << std::setfill('0') << (std::hash<std::thread::id>{}(std::this_thread::get_id()) & 0xFFFFF); return oss.str(); }())
+#define GET_THREAD_ID() (static_cast<pid_t>(syscall(SYS_gettid)))
+#define MakeMsg(msg) ROCDEC_STR(FILENAME_ONLY) + ":" + ROCDEC_TOSTR(__LINE__) + ": " + ROCDEC_TOSTR(GET_TIME_NS() / 1000ULL) + ROCDEC_STR(" us: ") + ROCDEC_STR("[pid:") + ROCDEC_TOSTR(getpid()) + ROCDEC_STR(" tid:") + ROCDEC_TOSTR(GET_THREAD_ID()) + ROCDEC_STR(" hashid:") + GET_HASHED_THREAD_ID() + ROCDEC_STR("] ") + ROCDEC_STR(__func__) + "(): " + msg
 
 #define OutputMsg(msg) std::cout << msg << std::endl
 #define OutputErrMsg(msg) std::cerr << msg << std::endl
@@ -99,16 +101,16 @@ public:
         if (logger_.GetLogLevel() >= kRocDecLogInfo) {
             start_time_ = GET_TIME_NS() / 1000ULL;
             OutputMsg("[" + ROCDEC_TOSTR(kRocDecLogInfo) + ", Info] " + ROCDEC_STR(filename_) + ":" + ROCDEC_TOSTR(line_) + ": " +
-                      ROCDEC_TOSTR(start_time_) + ROCDEC_STR(" us: ") + ROCDEC_STR("[pid:") + ROCDEC_TOSTR(getpid()) + ROCDEC_STR(" tid: ") +
-                      GET_THREAD_ID() + ROCDEC_STR("] ") + ROCDEC_STR(func_) + "(): entry ...");
+                      ROCDEC_TOSTR(start_time_) + ROCDEC_STR(" us: ") + ROCDEC_STR("[pid:") + ROCDEC_TOSTR(getpid()) + ROCDEC_STR(" tid:") +
+                      ROCDEC_TOSTR(GET_THREAD_ID()) + ROCDEC_STR(" hashid:") + GET_HASHED_THREAD_ID() + ROCDEC_STR("] ") + ROCDEC_STR(func_) + "(): entry ...");
         }
     }
     ~RocDecFuncScopeLog() {
         if (logger_.GetLogLevel() >= kRocDecLogInfo) {
             uint64_t end_time = GET_TIME_NS() / 1000ULL;
             OutputMsg("[" + ROCDEC_TOSTR(kRocDecLogInfo) + ", Info] " + ROCDEC_STR(filename_) + ":" + ROCDEC_TOSTR(line_) + ": " +
-                      ROCDEC_TOSTR(end_time) + ROCDEC_STR(" us: ") + ROCDEC_STR("[pid:") + ROCDEC_TOSTR(getpid()) + ROCDEC_STR(" tid: ") +
-                      GET_THREAD_ID() + ROCDEC_STR("] ") + ROCDEC_STR(func_) + "(): exit (" +
+                      ROCDEC_TOSTR(end_time) + ROCDEC_STR(" us: ") + ROCDEC_STR("[pid:") + ROCDEC_TOSTR(getpid()) + ROCDEC_STR(" tid:") +
+                      ROCDEC_TOSTR(GET_THREAD_ID()) + ROCDEC_STR(" hashid:") + GET_HASHED_THREAD_ID() + ROCDEC_STR("] ") + ROCDEC_STR(func_) + "(): exit (" +
                       ROCDEC_TOSTR(end_time - start_time_) + " us) ...");
         }
     }

--- a/projects/rocdecode/utils/rocvideodecode/roc_video_dec.h
+++ b/projects/rocdecode/utils/rocvideodecode/roc_video_dec.h
@@ -49,7 +49,7 @@ THE SOFTWARE.
 #define ROCVIDEODEC_STR(X) std::string(X)
 
 // Simple logging macros - format matches src/commons.h:
-//   [0, Critical] filename:line: timestamp_us us: [pid:X tid:Y htid:0xZZZZZ] func(): message
+//   [0, Critical] filename:line: timestamp_us us: [pid:X tid:Y hashid:0xZZZZZ] func(): message
 #define RocVideoDecCriticalLog(msg) \
     do { \
         struct timespec _ts_; \
@@ -62,7 +62,7 @@ THE SOFTWARE.
                   << (std::hash<std::thread::id>{}(std::this_thread::get_id()) & 0xFFFFF); \
         std::cerr << "[0, Critical] " << (_f_ ? _f_ + 1 : __FILE__) \
                   << ":" << __LINE__ << ": " << _us_ << " us: [pid:" \
-                  << getpid() << " tid:" << _tid_ << " htid:" << _htid_oss_.str() << "] " \
+                  << getpid() << " tid:" << _tid_ << " hashid:" << _htid_oss_.str() << "] " \
                   << __func__ << "(): " << (msg) << std::endl; \
     } while (0)
 

--- a/projects/rocdecode/utils/rocvideodecode/roc_video_dec.h
+++ b/projects/rocdecode/utils/rocvideodecode/roc_video_dec.h
@@ -40,6 +40,7 @@ THE SOFTWARE.
 #include <ctime>
 #include <time.h>
 #include <unistd.h>
+#include <sys/syscall.h>
 #include <hip/hip_runtime.h>
 #include "rocdecode/rocdecode.h"
 #include "rocdecode/rocparser.h"
@@ -48,19 +49,20 @@ THE SOFTWARE.
 #define ROCVIDEODEC_STR(X) std::string(X)
 
 // Simple logging macros - format matches src/commons.h:
-//   [0, Critical] filename:line: timestamp_us us: [pid:X tid: 0xYYYYY] func(): message
+//   [0, Critical] filename:line: timestamp_us us: [pid:X tid:Y htid:0xZZZZZ] func(): message
 #define RocVideoDecCriticalLog(msg) \
     do { \
         struct timespec _ts_; \
         clock_gettime(CLOCK_MONOTONIC, &_ts_); \
         uint64_t _us_ = static_cast<uint64_t>(_ts_.tv_sec) * 1000000ULL + _ts_.tv_nsec / 1000ULL; \
         const char *_f_ = strrchr(__FILE__, '/'); \
-        std::ostringstream _tid_oss_; \
-        _tid_oss_ << "0x" << std::hex << std::setw(5) << std::setfill('0') \
+        pid_t _tid_ = static_cast<pid_t>(syscall(SYS_gettid)); \
+        std::ostringstream _htid_oss_; \
+        _htid_oss_ << "0x" << std::hex << std::setw(5) << std::setfill('0') \
                   << (std::hash<std::thread::id>{}(std::this_thread::get_id()) & 0xFFFFF); \
         std::cerr << "[0, Critical] " << (_f_ ? _f_ + 1 : __FILE__) \
                   << ":" << __LINE__ << ": " << _us_ << " us: [pid:" \
-                  << getpid() << " tid: " << _tid_oss_.str() << "] " \
+                  << getpid() << " tid:" << _tid_ << " htid:" << _htid_oss_.str() << "] " \
                   << __func__ << "(): " << (msg) << std::endl; \
     } while (0)
 

--- a/projects/rocdecode/utils/video_demuxer.h
+++ b/projects/rocdecode/utils/video_demuxer.h
@@ -43,7 +43,7 @@ extern "C" {
 
 // Minimal critical logging for video_demuxer.h.
 // Matches the format produced by the full logger in src/commons.h:
-//   [0, Critical] filename:line: timestamp_us us: [pid:X tid:Y htid:0xZZZZZ] func(): message
+//   [0, Critical] filename:line: timestamp_us us: [pid:X tid:Y hashid:0xZZZZZ] func(): message
 #define DemuxCriticalLog(msg) \
     do { \
         struct timespec _ts_; \
@@ -56,7 +56,7 @@ extern "C" {
                   << (std::hash<std::thread::id>{}(std::this_thread::get_id()) & 0xFFFFF); \
         std::cerr << "[0, Critical] " << (_f_ ? _f_ + 1 : __FILE__) \
                   << ":" << __LINE__ << ": " << _us_ << " us: [pid:" \
-                  << getpid() << " tid:" << _tid_ << " htid:" << _htid_oss_.str() << "] " \
+                  << getpid() << " tid:" << _tid_ << " hashid:" << _htid_oss_.str() << "] " \
                   << __func__ << "(): " << (msg) << std::endl; \
     } while (0)
 

--- a/projects/rocdecode/utils/video_demuxer.h
+++ b/projects/rocdecode/utils/video_demuxer.h
@@ -35,6 +35,7 @@ extern "C" {
 #include <ctime>
 #include <time.h>
 #include <unistd.h>
+#include <sys/syscall.h>
 #include <thread>
 #include <sstream>
 #include <iomanip>
@@ -42,19 +43,20 @@ extern "C" {
 
 // Minimal critical logging for video_demuxer.h.
 // Matches the format produced by the full logger in src/commons.h:
-//   [0, Critical] filename:line: timestamp_us us: [pid:X tid: 0xYYYYY] func(): message
+//   [0, Critical] filename:line: timestamp_us us: [pid:X tid:Y htid:0xZZZZZ] func(): message
 #define DemuxCriticalLog(msg) \
     do { \
         struct timespec _ts_; \
         clock_gettime(CLOCK_MONOTONIC, &_ts_); \
         uint64_t _us_ = static_cast<uint64_t>(_ts_.tv_sec) * 1000000ULL + _ts_.tv_nsec / 1000ULL; \
         const char *_f_ = strrchr(__FILE__, '/'); \
-        std::ostringstream _tid_oss_; \
-        _tid_oss_ << "0x" << std::hex << std::setw(5) << std::setfill('0') \
+        pid_t _tid_ = static_cast<pid_t>(syscall(SYS_gettid)); \
+        std::ostringstream _htid_oss_; \
+        _htid_oss_ << "0x" << std::hex << std::setw(5) << std::setfill('0') \
                   << (std::hash<std::thread::id>{}(std::this_thread::get_id()) & 0xFFFFF); \
         std::cerr << "[0, Critical] " << (_f_ ? _f_ + 1 : __FILE__) \
                   << ":" << __LINE__ << ": " << _us_ << " us: [pid:" \
-                  << getpid() << " tid: " << _tid_oss_.str() << "] " \
+                  << getpid() << " tid:" << _tid_ << " htid:" << _htid_oss_.str() << "] " \
                   << __func__ << "(): " << (msg) << std::endl; \
     } while (0)
 


### PR DESCRIPTION


## Motivation

This PR enhances the rocDecode logging to include both the kernel thread ID and the hash ID. This addresses issue #5462  

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
