### PR TITLE
[memcache var size 1/2] Move cache_line_t::m_data to an external buffer

### DIFF
--- a/projects/rocdbgapi/src/agent.cpp
+++ b/projects/rocdbgapi/src/agent.cpp
@@ -75,6 +75,7 @@ agent_t::agent_t (amd_dbgapi_agent_id_t agent_id, process_t &process,
       }(os_agent_info)),
     m_architecture (architecture), m_process (process),
     m_memory_cache (
+      *this,
       [this] (agent_address_t address, void *read, const void *write,
               size_t size)
       {

--- a/projects/rocdbgapi/src/agent.h
+++ b/projects/rocdbgapi/src/agent.h
@@ -109,14 +109,14 @@ public:
                                                   void *buffer,
                                                   size_t size) const
   {
-    return m_memory_cache.read_global_memory (address, buffer, size);
+    return m_memory_cache.read_agent_memory (address, buffer, size);
   }
 
   [[nodiscard]] size_t write_agent_memory_partial (agent_address_t address,
                                                    const void *buffer,
                                                    size_t size) const
   {
-    return m_memory_cache.write_global_memory (address, buffer, size);
+    return m_memory_cache.write_agent_memory (address, buffer, size);
   }
 
   template <typename T>

--- a/projects/rocdbgapi/src/agent.h
+++ b/projects/rocdbgapi/src/agent.h
@@ -60,7 +60,7 @@ private:
   const architecture_t *const m_architecture;
   process_t &m_process;
 
-  mutable memory_cache_t<agent_address_t> m_memory_cache;
+  mutable memory_cache_t m_memory_cache;
 
 public:
   agent_t (amd_dbgapi_agent_id_t agent_id, process_t &process,

--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -546,7 +546,8 @@ memory_cache_t::contains_all (agent_address_t address,
 }
 
 void
-memory_cache_t::prefetch (agent_address_t address, amd_dbgapi_size_t size)
+memory_cache_t::prefetch (agent_address_t address, amd_dbgapi_size_t size,
+                          memory_pool_t &pool)
 {
   if (size == 0)
     return;
@@ -585,6 +586,7 @@ memory_cache_t::prefetch (agent_address_t address, amd_dbgapi_size_t size)
       [] (auto &&...) {}(success); /* Silence an unused variable warning when
                                       building without assertions enabled.  */
 
+      it->second.m_data = pool.alloc (cache_line_size);
       memcpy (&it->second.m_data[0],
               &staging_buffer[cache_line_address - cache_line_begin],
               cache_line_size);

--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -600,7 +600,7 @@ void
 memory_cache_t<AddressType>::prefetch (AddressType address,
                                        amd_dbgapi_size_t size)
 {
-  if (policy == policy_t::uncached || size == 0)
+  if (size == 0)
     return;
 
   dbgapi_assert (address < (address + size) && "invalid size");
@@ -649,7 +649,7 @@ memory_cache_t<AddressType>::write_back (AddressType address,
                                          amd_dbgapi_size_t size)
 {
   std::exception_ptr exception;
-  if (policy != policy_t::write_back || size == 0)
+  if (size == 0)
     return;
 
   dbgapi_assert (address < (address + size) && "invalid size");
@@ -771,8 +771,8 @@ memory_cache_t<AddressType>::xfer_global_memory (AddressType address,
   auto begin = m_cache_line_map.lower_bound (first_line);
   auto end = m_cache_line_map.upper_bound (last_line);
 
-  /* If uncached or there are no cache lines affected by this access.  */
-  if (policy == policy_t::uncached || begin == end)
+  /* If there are no cache lines affected by this access.  */
+  if (begin == end)
     return m_xfer_global_memory (address, read, write, size);
 
   /* For cached accesses, handle one cache line at a time.  */
@@ -810,10 +810,6 @@ memory_cache_t<AddressType>::xfer_global_memory (AddressType address,
   else
     {
       memcpy (&cache_line.m_data[0] + offset, write, size);
-
-      if (policy != policy_t::write_back)
-        return m_xfer_global_memory (address, nullptr, write, size);
-
       cache_line.m_dirty = true;
     }
 

--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -528,10 +528,9 @@ host_address_space_t::convert (const wave_t &wave,
   throw api_error_t (AMD_DBGAPI_STATUS_ERROR_INVALID_ADDRESS_SPACE_CONVERSION);
 }
 
-template <typename AddressType>
 bool
-memory_cache_t<AddressType>::contains_all (AddressType address,
-                                           amd_dbgapi_size_t size) const
+memory_cache_t::contains_all (agent_address_t address,
+                              amd_dbgapi_size_t size) const
 {
   dbgapi_assert (address < (address + size) && "invalid size");
   auto cache_line_begin = utils::align_down (address, cache_line_size);
@@ -546,10 +545,8 @@ memory_cache_t<AddressType>::contains_all (AddressType address,
   return true;
 }
 
-template <typename AddressType>
 void
-memory_cache_t<AddressType>::prefetch (AddressType address,
-                                       amd_dbgapi_size_t size)
+memory_cache_t::prefetch (agent_address_t address, amd_dbgapi_size_t size)
 {
   if (size == 0)
     return;
@@ -594,10 +591,8 @@ memory_cache_t<AddressType>::prefetch (AddressType address,
     }
 }
 
-template <typename AddressType>
 void
-memory_cache_t<AddressType>::write_back (AddressType address,
-                                         amd_dbgapi_size_t size)
+memory_cache_t::write_back (agent_address_t address, amd_dbgapi_size_t size)
 {
   std::exception_ptr exception;
   if (size == 0)
@@ -678,11 +673,9 @@ memory_cache_t<AddressType>::write_back (AddressType address,
     std::rethrow_exception (exception);
 }
 
-template <typename AddressType>
 void
-memory_cache_t<AddressType>::discard (AddressType address,
-                                      amd_dbgapi_size_t size,
-                                      [[maybe_unused]] bool force_discard)
+memory_cache_t::discard (agent_address_t address, amd_dbgapi_size_t size,
+                         [[maybe_unused]] bool force_discard)
 {
   if (size == 0)
     return;
@@ -702,18 +695,16 @@ memory_cache_t<AddressType>::discard (AddressType address,
     }
 }
 
-template <typename AddressType>
 size_t
-memory_cache_t<AddressType>::xfer_global_memory (AddressType address,
-                                                 void *read, const void *write,
-                                                 size_t size)
+memory_cache_t::xfer_global_memory (agent_address_t address, void *read,
+                                    const void *write, size_t size)
 {
   if (size == 0)
     return 0;
 
   /* Clamp to the end of the global address space.  */
   if (address > (address + size))
-    size = AddressType{} - address;
+    size = agent_address_t{} - address;
 
   auto first_line = utils::align_down (address, cache_line_size);
   auto last_line = utils::align_down (address + size - 1, cache_line_size);
@@ -766,8 +757,6 @@ memory_cache_t<AddressType>::xfer_global_memory (AddressType address,
 
   return size;
 }
-
-template class memory_cache_t<agent_address_t>;
 
 } /* namespace amd::dbgapi */
 

--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -817,7 +817,6 @@ memory_cache_t<AddressType>::xfer_global_memory (AddressType address,
 }
 
 template class memory_cache_t<agent_address_t>;
-template class memory_cache_t<host_address_t>;
 
 } /* namespace amd::dbgapi */
 

--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -560,8 +560,8 @@ memory_cache_t::prefetch (agent_address_t address, amd_dbgapi_size_t size)
 
   try
     {
-      m_xfer_global_memory (cache_line_begin, &staging_buffer[0], nullptr,
-                            cache_line_end - cache_line_begin);
+      m_xfer_agent_memory (cache_line_begin, &staging_buffer[0], nullptr,
+                           cache_line_end - cache_line_begin);
     }
   catch (const memory_error_t &)
     {
@@ -647,13 +647,12 @@ memory_cache_t::write_back (agent_address_t address, amd_dbgapi_size_t size)
 
       try
         {
-          size_t xfer_size = m_xfer_global_memory (
+          size_t xfer_size = m_xfer_agent_memory (
             cache_line_address, nullptr, &staging_buffer[0], request_size);
 
           if (xfer_size != request_size)
-            throw memory_access_error_t (
-              /* FIXME_lmoriche:  */
-              address_space_t::global (), cache_line_address + xfer_size);
+            throw memory_access_error_t (m_agent.agent_address_space (),
+                                         cache_line_address + xfer_size);
         }
       catch (const process_exited_exception_t &)
         {
@@ -696,15 +695,19 @@ memory_cache_t::discard (agent_address_t address, amd_dbgapi_size_t size,
 }
 
 size_t
-memory_cache_t::xfer_global_memory (agent_address_t address, void *read,
-                                    const void *write, size_t size)
+memory_cache_t::xfer_agent_memory (agent_address_t address, void *read,
+                                   const void *write, size_t size)
 {
   if (size == 0)
     return 0;
 
-  /* Clamp to the end of the global address space.  */
-  if (address > (address + size))
-    size = agent_address_t{} - address;
+  /* Clamp to the end of the agent address space.  */
+  auto max = m_agent.agent_address_space ().last_address ();
+  if (address > max)
+    throw memory_access_error_t (m_agent.agent_address_space (), address);
+  auto available = (max - address) + 1;
+  if (size > available)
+    size = available;
 
   auto first_line = utils::align_down (address, cache_line_size);
   auto last_line = utils::align_down (address + size - 1, cache_line_size);
@@ -715,7 +718,7 @@ memory_cache_t::xfer_global_memory (agent_address_t address, void *read,
 
   /* If there are no cache lines affected by this access.  */
   if (begin == end)
-    return m_xfer_global_memory (address, read, write, size);
+    return m_xfer_agent_memory (address, read, write, size);
 
   /* For cached accesses, handle one cache line at a time.  */
   if (first_line != last_line)
@@ -726,7 +729,7 @@ memory_cache_t::xfer_global_memory (agent_address_t address, void *read,
           auto limit = utils::align_up (ptr + 1, cache_line_size);
           auto request_size = std::min (limit, ptr + size) - ptr;
 
-          auto xfer_size = xfer_global_memory (ptr, read, write, request_size);
+          auto xfer_size = xfer_agent_memory (ptr, read, write, request_size);
 
           ptr += xfer_size;
           if (read != nullptr)

--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -529,55 +529,6 @@ host_address_space_t::convert (const wave_t &wave,
 }
 
 template <typename AddressType>
-void
-memory_cache_t<AddressType>::fetch_cache_line (cache_line_t &cache_line,
-                                               AddressType address) const
-{
-  dbgapi_assert (!cache_line.m_dirty);
-
-  size_t xfer_size = m_xfer_global_memory (address, &cache_line.m_data[0],
-                                           nullptr, cache_line.m_data.size ());
-
-  if (xfer_size != cache_line.m_data.size ())
-    throw memory_access_error_t (
-      /* FIXME_lmoriche:  */
-      address_space_t::global (), address + cache_line_size);
-
-  cache_line.m_dirty = false;
-}
-
-template <typename AddressType>
-void
-memory_cache_t<AddressType>::commit_cache_line (cache_line_t &cache_line,
-                                                AddressType address) const
-{
-  if (!cache_line.m_dirty)
-    return;
-
-  size_t xfer_size = m_xfer_global_memory (
-    address, nullptr, &cache_line.m_data[0], cache_line.m_data.size ());
-
-  if (xfer_size != cache_line.m_data.size ())
-    throw memory_access_error_t (
-      /* FIXME_lmoriche:  */
-      address_space_t::global (), address + xfer_size);
-
-  cache_line.m_dirty = false;
-}
-
-template <typename AddressType>
-void
-memory_cache_t<AddressType>::allocate_0_cache_line (
-  cache_line_t &cache_line) const
-{
-  dbgapi_assert (!cache_line.m_dirty);
-
-  memset (&cache_line.m_data[0], '\0', cache_line.m_data.size ());
-
-  cache_line.m_dirty = false;
-}
-
-template <typename AddressType>
 bool
 memory_cache_t<AddressType>::contains_all (AddressType address,
                                            amd_dbgapi_size_t size) const

--- a/projects/rocdbgapi/src/memory.h
+++ b/projects/rocdbgapi/src/memory.h
@@ -530,6 +530,41 @@ public:
                  void *value) const;
 };
 
+/* Simple pool used as backing store for memory_cache_t cache entries.
+   Each queue has its own pool, reserved for as many bytes the queue
+   might need at most.  The pool never grows beyond the initial
+   reservation.  */
+class memory_pool_t
+{
+private:
+  std::unique_ptr<std::byte[]> m_pool;
+  size_t m_used{ 0 };
+  size_t m_size{ 0 };
+
+public:
+  void clear () { m_used = 0; }
+  bool empty () const { return m_used == 0; }
+
+  void reserve (size_t size)
+  {
+    if (m_size >= size)
+      return;
+    m_pool = std::make_unique<std::byte[]> (size);
+    m_size = size;
+  }
+
+  std::byte *alloc (size_t size)
+  {
+    /* The pool never grows.  If more space is needed, the initial
+       reservation should have been larger.  */
+    dbgapi_assert (m_used + size <= m_size);
+
+    std::byte *ptr = m_pool.get () + m_used;
+    m_used += size;
+    return ptr;
+  }
+};
+
 /* A write-back memory cache.  Data is immediately updated in the cache, and
    later updated in memory when the cache is flushed.  */
 
@@ -545,7 +580,7 @@ private:
 
   struct cache_line_t
   {
-    std::array<std::byte, cache_line_size> m_data{};
+    std::byte *m_data;
     bool m_dirty{ false };
   };
 
@@ -568,7 +603,8 @@ public:
   bool contains_all (agent_address_t address, amd_dbgapi_size_t size) const;
 
   /* Create cache lines if not already valid, and immediately fill them in.  */
-  void prefetch (agent_address_t address, amd_dbgapi_size_t size);
+  void prefetch (agent_address_t address, amd_dbgapi_size_t size,
+                 memory_pool_t &pool);
 
   /* Discard all cache lines in the specified range.  If FORCE_DISCARD
      is true, dirty lines are silently dropped.  Otherwise it is an error to

--- a/projects/rocdbgapi/src/memory.h
+++ b/projects/rocdbgapi/src/memory.h
@@ -552,10 +552,6 @@ private:
   std::map<AddressType, cache_line_t> m_cache_line_map;
   delegate_fn_type const m_xfer_global_memory;
 
-  void fetch_cache_line (cache_line_t &cache_line, AddressType address) const;
-  void commit_cache_line (cache_line_t &cache_line, AddressType address) const;
-  void allocate_0_cache_line (cache_line_t &cache_line) const;
-
   size_t xfer_global_memory (AddressType address, void *read,
                              const void *write, size_t size);
 

--- a/projects/rocdbgapi/src/memory.h
+++ b/projects/rocdbgapi/src/memory.h
@@ -530,24 +530,13 @@ public:
                  void *value) const;
 };
 
+/* A write-back memory cache.  Data is immediately updated in the cache, and
+   later updated in memory when the cache is flushed.  */
+
 template <typename AddressType> class memory_cache_t
 {
 public:
-  enum class policy_t
-  {
-    /* If uncached is used, data is immediately written to global memory, and
-       is not written to the cache.  */
-    uncached = 0,
-    /* If write-through is used, data is written both to global memory and to
-       the cache.  */
-    write_through,
-    /* If write-back is used, data is immediately updated in the cache, and
-       later updated in memory when the cache is flushed.  */
-    write_back
-  };
-
   static constexpr size_t cache_line_size = 64;
-  static constexpr policy_t policy = policy_t::write_back;
 
 private:
   using delegate_fn_type

--- a/projects/rocdbgapi/src/memory.h
+++ b/projects/rocdbgapi/src/memory.h
@@ -549,15 +549,18 @@ private:
     bool m_dirty{ false };
   };
 
-  std::map<agent_address_t, cache_line_t> m_cache_line_map;
-  delegate_fn_type const m_xfer_global_memory;
+  /* The agent which this cache is for.  */
+  const agent_t &m_agent;
 
-  size_t xfer_global_memory (agent_address_t address, void *read,
-                             const void *write, size_t size);
+  std::map<agent_address_t, cache_line_t> m_cache_line_map;
+  delegate_fn_type const m_xfer_agent_memory;
+
+  size_t xfer_agent_memory (agent_address_t address, void *read,
+                            const void *write, size_t size);
 
 public:
-  memory_cache_t (delegate_fn_type xfer_global_memory)
-    : m_xfer_global_memory (std::move (xfer_global_memory))
+  memory_cache_t (const agent_t &agent, delegate_fn_type xfer_agent_memory)
+    : m_agent (agent), m_xfer_agent_memory (std::move (xfer_agent_memory))
   {
   }
   ~memory_cache_t () { dbgapi_assert (m_cache_line_map.empty ()); }
@@ -578,16 +581,16 @@ public:
   void write_back (agent_address_t address = 0,
                    amd_dbgapi_size_t size = amd_dbgapi_size_t (-1));
 
-  [[nodiscard]] size_t read_global_memory (agent_address_t address,
-                                           void *buffer, size_t size)
+  [[nodiscard]] size_t read_agent_memory (agent_address_t address,
+                                          void *buffer, size_t size)
   {
-    return xfer_global_memory (address, buffer, nullptr, size);
+    return xfer_agent_memory (address, buffer, nullptr, size);
   }
 
-  [[nodiscard]] size_t write_global_memory (agent_address_t address,
-                                            const void *buffer, size_t size)
+  [[nodiscard]] size_t write_agent_memory (agent_address_t address,
+                                           const void *buffer, size_t size)
   {
-    return xfer_global_memory (address, nullptr, buffer, size);
+    return xfer_agent_memory (address, nullptr, buffer, size);
   }
 };
 

--- a/projects/rocdbgapi/src/memory.h
+++ b/projects/rocdbgapi/src/memory.h
@@ -533,14 +533,14 @@ public:
 /* A write-back memory cache.  Data is immediately updated in the cache, and
    later updated in memory when the cache is flushed.  */
 
-template <typename AddressType> class memory_cache_t
+class memory_cache_t
 {
 public:
   static constexpr size_t cache_line_size = 64;
 
 private:
   using delegate_fn_type
-    = std::function<size_t (AddressType /* address */, void * /* read */,
+    = std::function<size_t (agent_address_t /* address */, void * /* read */,
                             const void * /* write */, size_t /* size */)>;
 
   struct cache_line_t
@@ -549,10 +549,10 @@ private:
     bool m_dirty{ false };
   };
 
-  std::map<AddressType, cache_line_t> m_cache_line_map;
+  std::map<agent_address_t, cache_line_t> m_cache_line_map;
   delegate_fn_type const m_xfer_global_memory;
 
-  size_t xfer_global_memory (AddressType address, void *read,
+  size_t xfer_global_memory (agent_address_t address, void *read,
                              const void *write, size_t size);
 
 public:
@@ -562,29 +562,29 @@ public:
   }
   ~memory_cache_t () { dbgapi_assert (m_cache_line_map.empty ()); }
 
-  bool contains_all (AddressType address, amd_dbgapi_size_t size) const;
+  bool contains_all (agent_address_t address, amd_dbgapi_size_t size) const;
 
   /* Create cache lines if not already valid, and immediately fill them in.  */
-  void prefetch (AddressType address, amd_dbgapi_size_t size);
+  void prefetch (agent_address_t address, amd_dbgapi_size_t size);
 
   /* Discard all cache lines in the specified range.  If FORCE_DISCARD
      is true, dirty lines are silently dropped.  Otherwise it is an error to
      discarded dirty cache lines.  */
-  void discard (AddressType address = 0,
+  void discard (agent_address_t address = 0,
                 amd_dbgapi_size_t size = amd_dbgapi_size_t (-1),
                 bool force_discard = false);
 
   /* Write dirty lines back to memory.  */
-  void write_back (AddressType address = 0,
+  void write_back (agent_address_t address = 0,
                    amd_dbgapi_size_t size = amd_dbgapi_size_t (-1));
 
-  [[nodiscard]] size_t read_global_memory (AddressType address, void *buffer,
-                                           size_t size)
+  [[nodiscard]] size_t read_global_memory (agent_address_t address,
+                                           void *buffer, size_t size)
   {
     return xfer_global_memory (address, buffer, nullptr, size);
   }
 
-  [[nodiscard]] size_t write_global_memory (AddressType address,
+  [[nodiscard]] size_t write_global_memory (agent_address_t address,
                                             const void *buffer, size_t size)
   {
     return xfer_global_memory (address, nullptr, buffer, size);

--- a/projects/rocdbgapi/src/process.cpp
+++ b/projects/rocdbgapi/src/process.cpp
@@ -285,9 +285,8 @@ void
 process_t::read_string (host_address_t address, std::string *string,
                         size_t size) const
 {
-  constexpr size_t cache_line_size
-    = memory_cache_t<host_address_t>::cache_line_size;
-  constexpr size_t chunk_size = 4 * cache_line_size;
+  constexpr size_t host_cache_line_size = 64;
+  constexpr size_t chunk_size = 4 * host_cache_line_size;
 
   dbgapi_assert (string && "invalid argument");
 
@@ -300,8 +299,9 @@ process_t::read_string (host_address_t address, std::string *string,
          which could read less than a chunk if the start address is not
          cache line aligned.  */
 
-      static_assert (utils::is_power_of_two (cache_line_size));
-      size_t request_size = chunk_size - (address & (cache_line_size - 1));
+      static_assert (utils::is_power_of_two (host_cache_line_size));
+      size_t request_size
+        = chunk_size - (address & (host_cache_line_size - 1));
 
       size_t xfer_size
         = read_host_memory_partial (address, staging_buffer, request_size);

--- a/projects/rocdbgapi/src/queue.cpp
+++ b/projects/rocdbgapi/src/queue.cpp
@@ -129,6 +129,11 @@ private:
      deleted, as these waves are no longer active.  */
   monotonic_counter_t<epoch_t, 1> m_next_wave_mark{};
 
+  /* Pool used by the memory cache, holding save-area data.  */
+  memory_pool_t m_save_area_pool;
+
+  void discard_save_area_cache ();
+
   std::optional<amd_dbgapi_os_queue_packet_id_t> get_os_queue_packet_id (
     const architecture_t::cwsr_record_t &cwsr_record) const;
 
@@ -361,6 +366,17 @@ aql_queue_t::aql_queue_t (amd_dbgapi_queue_id_t queue_id, const agent_t &agent,
     fatal_error ("queue ring size = %#zx is not supported", size ());
 }
 
+void
+aql_queue_t::discard_save_area_cache ()
+{
+  const auto xcc_count = agent ().os_info ().xcc_count;
+
+  agent ().memory_cache ().discard (
+    m_os_queue_info.ctx_save_restore_address,
+    xcc_count * m_os_queue_info.ctx_save_restore_area_size, true);
+  m_save_area_pool.clear ();
+}
+
 aql_queue_t::~aql_queue_t ()
 {
   process_t &process = this->process ();
@@ -388,12 +404,7 @@ aql_queue_t::~aql_queue_t ()
      want to see stale data, or for stale dirty data to corrupt the future use.
      If the process is being detached, then there's really no need to discard
      since the process will be destructed and the cache destructed.  */
-
-  const auto xcc_count = agent ().os_info ().xcc_count;
-
-  agent ().memory_cache ().discard (
-    m_os_queue_info.ctx_save_restore_address,
-    xcc_count * m_os_queue_info.ctx_save_restore_area_size, true);
+  discard_save_area_cache ();
 }
 
 compute_queue_t::displaced_instruction_ptr_t
@@ -522,9 +533,7 @@ aql_queue_t::queue_state_changed ()
       /* Discard the previously cached wave saved state lines.  The saved state
          areas may be mapped to a different address in this new context wave
          save.  */
-      agent ().memory_cache ().discard (
-        m_os_queue_info.ctx_save_restore_address,
-        xcc_count * m_os_queue_info.ctx_save_restore_area_size);
+      discard_save_area_cache ();
 
       /* Refresh the scratch_backing_memory_location and
          scratch_backing_memory_size everytime the queue is suspended.
@@ -643,7 +652,7 @@ aql_queue_t::update_waves ()
 
     dbgapi_assert (prefetch_end > prefetch_begin);
     cwsr_record->agent ().memory_cache ().prefetch (
-      prefetch_begin, prefetch_end - prefetch_begin);
+      prefetch_begin, prefetch_end - prefetch_begin, m_save_area_pool);
 
     wave_t *wave = nullptr;
 
@@ -786,6 +795,10 @@ aql_queue_t::update_waves ()
   /* Start with 0 running waves.  When iterating the control stack (below)
      each discovered wave in the running state will increment this count.  */
   m_waves_running.emplace (0);
+
+  dbgapi_assert (m_save_area_pool.empty ());
+  m_save_area_pool.reserve (agent ().os_info ().xcc_count
+                            * m_os_queue_info.ctx_save_restore_area_size);
 
   for (uint32_t xcc_id = 0; xcc_id < agent ().os_info ().xcc_count; ++xcc_id)
     {


### PR DESCRIPTION
The following patch in the series will switch the memory cache to
allocating cache entries of varying sizes instead of fixed-size cache
lines.

Since each cache entry will have its own size, the current approach of
inlining the cache line buffer in the cache_line_t object directly no
longer works.  Naively allocating the cache entry buffer on the heap
with one allocation per cache entry degrades performance
substantially, too, if the caller code continues doing many small
allocations.

The solution for that is to introduce a memory pool object, from which
buffer space for the cache entries is carved out.  The pool object is
allocated just once per queue.

With this commit, we still alway allocates cache_line_size-sized
lines, but this will allow changing that in the following patch.

Change-Id: I0c52fba4ff3c55228315d1cec58e1878832dbd2b

---

**Stack**:
- #5546
- #5545 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*