### PR TITLE
[memcache var size 2/2] memory cache: Allow allocating cache entries of varying sizes

### DIFF
--- a/projects/rocdbgapi/src/agent.cpp
+++ b/projects/rocdbgapi/src/agent.cpp
@@ -114,7 +114,7 @@ agent_t::agent_t (amd_dbgapi_agent_id_t agent_id, process_t &process,
 
 agent_t::~agent_t ()
 {
-  /* Drop all active cache lines.  */
+  /* Drop all active cache entries.  */
   m_memory_cache.write_back ();
   m_memory_cache.discard ();
 }

--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -528,21 +528,42 @@ host_address_space_t::convert (const wave_t &wave,
   throw api_error_t (AMD_DBGAPI_STATUS_ERROR_INVALID_ADDRESS_SPACE_CONVERSION);
 }
 
+/* Returns true if the ranges given by [A_ADDR, A_ADDR+A_SIZE) and
+   [B_ADDR, B_ADDR+B_SIZE) overlap.  */
+
+static bool
+ranges_overlap (agent_address_t a_addr, amd_dbgapi_size_t a_size,
+                agent_address_t b_addr, amd_dbgapi_size_t b_size)
+{
+  auto a_end = a_addr + a_size;
+  auto b_end = b_addr + b_size;
+
+  return a_addr < b_end && b_addr < a_end;
+}
+
 bool
 memory_cache_t::contains_all (agent_address_t address,
                               amd_dbgapi_size_t size) const
 {
   dbgapi_assert (address < (address + size) && "invalid size");
-  auto cache_line_begin = utils::align_down (address, cache_line_size);
-  auto cache_line_end = utils::align_up (address + size, cache_line_size);
 
-  for (auto cache_line_address = cache_line_begin;
-       cache_line_address < cache_line_end;
-       cache_line_address += cache_line_size)
-    if (m_cache_line_map.find (cache_line_address) == m_cache_line_map.end ())
-      return false;
+  auto end = address + size;
 
-  return true;
+  auto it = lower_bound (address, size);
+  auto limit = upper_bound (address, size);
+
+  while (it != limit)
+    {
+      auto &[cache_entry_address, cache_entry] = *it;
+
+      if (address < cache_entry_address)
+        return false;
+      address = std::min (cache_entry_address + cache_entry.m_size, end);
+      if (address == end)
+        return true;
+    }
+
+  return false;
 }
 
 void
@@ -553,16 +574,42 @@ memory_cache_t::prefetch (agent_address_t address, amd_dbgapi_size_t size,
     return;
 
   dbgapi_assert (address < (address + size) && "invalid size");
-  auto cache_line_begin = utils::align_down (address, cache_line_size);
-  auto cache_line_end = utils::align_up (address + size, cache_line_size);
 
-  auto staging_buffer
-    = std::make_unique<std::byte[]> (cache_line_end - cache_line_begin);
+#ifndef NDEBUG
+  {
+    auto it = lower_bound (address, size);
+    auto limit = upper_bound (address, size);
+
+    while (it != limit)
+      {
+        auto &[cache_entry_address, cache_entry] = *it;
+
+        if (ranges_overlap (cache_entry_address, cache_entry.m_size, address,
+                            size))
+          fatal_error ("cache entry overlap");
+      }
+  }
+#endif
+
+  auto [it, success] = m_cache_entry_map.try_emplace (address);
+  dbgapi_assert (success && "failed to create memory cache");
+  [] (auto &&...) {}(success); /* Silence an unused variable warning when
+                                  building without assertions enabled.  */
+
+  it->second.m_data = pool.alloc (size);
+  it->second.m_size = size;
+
+  /* Undo the allocation if reading memory fails for any reason.  */
+  auto rewind = utils::make_scope_exit (
+    [&] ()
+    {
+      pool.rewind (it->second.m_data, size);
+      m_cache_entry_map.erase (it);
+    });
 
   try
     {
-      m_xfer_agent_memory (cache_line_begin, &staging_buffer[0], nullptr,
-                           cache_line_end - cache_line_begin);
+      m_xfer_agent_memory (address, it->second.m_data, nullptr, size);
     }
   catch (const memory_error_t &)
     {
@@ -571,26 +618,7 @@ memory_cache_t::prefetch (agent_address_t address, amd_dbgapi_size_t size,
       return;
     }
 
-  for (auto cache_line_address = cache_line_begin;
-       cache_line_address < cache_line_end;
-       cache_line_address += cache_line_size)
-    {
-      if (contains_all (cache_line_address, cache_line_size))
-        /* There's already a cache line for that address that will have already
-           been read, and possibly updated.  So leave cache line with its
-           current contents.  */
-        continue;
-
-      auto [it, success] = m_cache_line_map.try_emplace (cache_line_address);
-      dbgapi_assert (success && "failed to create memory cache");
-      [] (auto &&...) {}(success); /* Silence an unused variable warning when
-                                      building without assertions enabled.  */
-
-      it->second.m_data = pool.alloc (cache_line_size);
-      memcpy (&it->second.m_data[0],
-              &staging_buffer[cache_line_address - cache_line_begin],
-              cache_line_size);
-    }
+  rewind.release ();
 }
 
 void
@@ -601,60 +629,28 @@ memory_cache_t::write_back (agent_address_t address, amd_dbgapi_size_t size)
     return;
 
   dbgapi_assert (address < (address + size) && "invalid size");
-  auto first_line = utils::align_down (address, cache_line_size);
-  auto last_line = utils::align_down (address + size - 1, cache_line_size);
 
-  auto it = m_cache_line_map.lower_bound (first_line);
-  auto limit = m_cache_line_map.upper_bound (last_line);
+  auto it = lower_bound (address, size);
+  auto limit = upper_bound (address, size);
 
-  std::unique_ptr<std::byte[]> staging_buffer;
-  size_t staging_buffer_size = 0;
-
-  while (it != limit)
+  for (; it != limit; std::advance (it, 1))
     {
-      auto &[cache_line_address, cache_line] = *it;
-      size_t request_size = cache_line_size;
+      auto &[cache_entry_address, cache_entry] = *it;
 
       /* Skip this line if it isn't dirty as we do not need to commit it to
          memory.  */
-      if (!cache_line.m_dirty)
-        {
-          std::advance (it, 1);
-          continue;
-        }
-
-      /* It is more efficient to do a single large memory access, so try to
-         group as many contiguous cache lines as possible.  */
-      auto next = std::next (it);
-      while (next != limit && next->second.m_dirty
-             && next->first == (cache_line_address + request_size))
-        {
-          request_size += cache_line_size;
-          std::advance (next, 1);
-        }
-
-      if (request_size > staging_buffer_size)
-        {
-          staging_buffer = std::make_unique<std::byte[]> (request_size);
-          staging_buffer_size = request_size;
-        }
-
-      while (it != next)
-        {
-          memcpy (&staging_buffer[0] + (it->first - cache_line_address),
-                  &it->second.m_data[0], cache_line_size);
-          it->second.m_dirty = false;
-          std::advance (it, 1);
-        }
+      if (!cache_entry.m_dirty)
+        continue;
 
       try
         {
-          size_t xfer_size = m_xfer_agent_memory (
-            cache_line_address, nullptr, &staging_buffer[0], request_size);
+          size_t xfer_size
+            = m_xfer_agent_memory (cache_entry_address, nullptr,
+                                   &cache_entry.m_data[0], cache_entry.m_size);
 
-          if (xfer_size != request_size)
+          if (xfer_size != cache_entry.m_size)
             throw memory_access_error_t (m_agent.agent_address_space (),
-                                         cache_line_address + xfer_size);
+                                         cache_entry_address + xfer_size);
         }
       catch (const process_exited_exception_t &)
         {
@@ -668,6 +664,8 @@ memory_cache_t::write_back (agent_address_t address, amd_dbgapi_size_t size)
           if (!exception)
             exception = std::current_exception ();
         }
+
+      cache_entry.m_dirty = false;
     }
 
   if (exception)
@@ -682,18 +680,40 @@ memory_cache_t::discard (agent_address_t address, amd_dbgapi_size_t size,
     return;
 
   dbgapi_assert (address < (address + size) && "invalid size");
-  auto first_line = utils::align_down (address, cache_line_size);
-  auto last_line = utils::align_down (address + size - 1, cache_line_size);
 
-  auto it = m_cache_line_map.lower_bound (first_line);
-  auto limit = m_cache_line_map.upper_bound (last_line);
+  auto it = lower_bound (address, size);
+  auto limit = upper_bound (address, size);
 
   while (it != limit)
     {
-      dbgapi_assert ((force_discard || !it->second.m_dirty)
-                     && "discarding a dirty cache line");
-      it = m_cache_line_map.erase (it);
+      auto &[entry_address, entry] = *it;
+
+      dbgapi_assert ((force_discard || !entry.m_dirty)
+                     && "discarding a dirty cache entry");
+
+      /* Don't allow discarding a partial entry.  */
+      [[maybe_unused]] auto range_end = address + size;
+      [[maybe_unused]] auto entry_end = entry_address + entry.m_size;
+      dbgapi_assert ((address <= entry_address && entry_end <= range_end)
+                     && "partial overlap when discarding entry");
+
+      it = m_cache_entry_map.erase (it);
     }
+}
+
+std::map<agent_address_t, memory_cache_t::cache_entry_t>::const_iterator
+memory_cache_t::lower_bound (agent_address_t address,
+                             amd_dbgapi_size_t size) const
+{
+  auto it = m_cache_entry_map.lower_bound (address);
+  if ((it == m_cache_entry_map.end () || it->first > address)
+      && it != m_cache_entry_map.begin ())
+    {
+      auto prev = std::prev (it);
+      if (ranges_overlap (prev->first, prev->second.m_size, address, size))
+        it = prev;
+    }
+  return it;
 }
 
 size_t
@@ -711,27 +731,32 @@ memory_cache_t::xfer_agent_memory (agent_address_t address, void *read,
   if (size > available)
     size = available;
 
-  auto first_line = utils::align_down (address, cache_line_size);
-  auto last_line = utils::align_down (address + size - 1, cache_line_size);
+  auto ptr = address;
 
-  /* Iterators to the first cache line, and one past the last cache line.  */
-  auto begin = m_cache_line_map.lower_bound (first_line);
-  auto end = m_cache_line_map.upper_bound (last_line);
-
-  /* If there are no cache lines affected by this access.  */
-  if (begin == end)
-    return m_xfer_agent_memory (address, read, write, size);
-
-  /* For cached accesses, handle one cache line at a time.  */
-  if (first_line != last_line)
+  while (size != 0)
     {
-      auto ptr = address;
-      while (size > 0)
-        {
-          auto limit = utils::align_up (ptr + 1, cache_line_size);
-          auto request_size = std::min (limit, ptr + size) - ptr;
+      /* Find the next overlapping cache entry.  */
+      cache_entry_t *entry = nullptr;
+      agent_address_t entry_address;
 
-          auto xfer_size = xfer_agent_memory (ptr, read, write, request_size);
+      auto it = lower_bound (ptr, size);
+      if (it != m_cache_entry_map.end ()
+          && ranges_overlap (it->first, it->second.m_size, ptr, size))
+        {
+          entry = &it->second;
+          entry_address = it->first;
+        }
+
+      /* Determine where uncached data stops.  */
+      auto uncached_end = entry != nullptr ? entry_address : ptr + size;
+
+      /* Handle uncached prefix, if any.  */
+      if (ptr < uncached_end)
+        {
+          auto request_size = std::min<size_t> (size, uncached_end - ptr);
+
+          auto xfer_size
+            = m_xfer_agent_memory (ptr, read, write, request_size);
 
           ptr += xfer_size;
           if (read != nullptr)
@@ -742,25 +767,38 @@ memory_cache_t::xfer_agent_memory (agent_address_t address, void *read,
 
           if (xfer_size != request_size)
             break;
+          continue;
         }
-      return ptr - address;
+
+      /* If no entry, we are done.  */
+      if (entry == nullptr)
+        continue;
+
+      /* Now PTR is inside the entry.  */
+      auto entry_end = entry_address + entry->m_size;
+      auto chunk_end = std::min (entry_end, ptr + size);
+
+      size_t offset = ptr - entry_address;
+      size_t chunk_size = chunk_end - ptr;
+
+      if (read != nullptr)
+        std::memcpy (read, entry->m_data + offset, chunk_size);
+      else
+        {
+          std::memcpy (entry->m_data + offset, write, chunk_size);
+          entry->m_dirty = true;
+        }
+
+      ptr += chunk_size;
+      if (read != nullptr)
+        read = static_cast<char *> (read) + chunk_size;
+      if (write != nullptr)
+        write = static_cast<const char *> (write) + chunk_size;
+
+      size -= chunk_size;
     }
 
-  dbgapi_assert (begin != m_cache_line_map.end ());
-  auto &cache_line = begin->second;
-  auto offset = address - first_line;
-
-  if (read != nullptr)
-    {
-      memcpy (read, &cache_line.m_data[0] + offset, size);
-    }
-  else
-    {
-      memcpy (&cache_line.m_data[0] + offset, write, size);
-      cache_line.m_dirty = true;
-    }
-
-  return size;
+  return size_t (ptr - address);
 }
 
 } /* namespace amd::dbgapi */

--- a/projects/rocdbgapi/src/memory.h
+++ b/projects/rocdbgapi/src/memory.h
@@ -563,6 +563,15 @@ public:
     m_used += size;
     return ptr;
   }
+
+  /* Revert the last allocation.  SIZE is the size of the last
+     allocation, and DATA must point at it.  */
+  void rewind ([[maybe_unused]] std::byte *data, size_t size)
+  {
+    dbgapi_assert (&m_pool[m_used - size] == data);
+    dbgapi_assert (m_used >= size);
+    m_used -= size;
+  }
 };
 
 /* A write-back memory cache.  Data is immediately updated in the cache, and
@@ -570,25 +579,59 @@ public:
 
 class memory_cache_t
 {
-public:
-  static constexpr size_t cache_line_size = 64;
-
 private:
   using delegate_fn_type
     = std::function<size_t (agent_address_t /* address */, void * /* read */,
                             const void * /* write */, size_t /* size */)>;
 
-  struct cache_line_t
+  struct cache_entry_t
   {
     std::byte *m_data;
+    size_t m_size;
     bool m_dirty{ false };
   };
 
   /* The agent which this cache is for.  */
   const agent_t &m_agent;
 
-  std::map<agent_address_t, cache_line_t> m_cache_line_map;
+  std::map<agent_address_t, cache_entry_t> m_cache_entry_map;
   delegate_fn_type const m_xfer_agent_memory;
+
+  /* Returns an iterator pointing to the first cache entry that is not
+     strictly less than the specified range.  If ADDRESS overlaps a
+     preceding cache entry that starts earlier, that entry is
+     considered to be not less than the range.  IOW, this finds the
+     first cache entry that overlaps the range, or, if there is none,
+     the next cache entry (if there is one).  */
+  std::map<agent_address_t, cache_entry_t>::const_iterator
+  lower_bound (agent_address_t address, amd_dbgapi_size_t size) const;
+
+  /* Non-const version of the above, implemented on top of the const
+     method.  */
+  std::map<agent_address_t, memory_cache_t::cache_entry_t>::iterator
+  lower_bound (agent_address_t address, amd_dbgapi_size_t size)
+  {
+    auto it = std::as_const (*this).lower_bound (address, size);
+    /* Convert non-const iterator from a const one.  */
+    return m_cache_entry_map.erase (it, it);
+  }
+
+  /* Return an iterator pointing to the first cache entry that is
+     greater than the specified range.  I.e, an entry whose starting
+     address is greater than the last address of the specified
+     range.  */
+  std::map<agent_address_t, cache_entry_t>::const_iterator
+  upper_bound (agent_address_t address, amd_dbgapi_size_t size) const
+  {
+    return m_cache_entry_map.upper_bound (address + size - 1);
+  }
+
+  /* Non-const version of the above.  */
+  std::map<agent_address_t, cache_entry_t>::const_iterator
+  upper_bound (agent_address_t address, amd_dbgapi_size_t size)
+  {
+    return m_cache_entry_map.upper_bound (address + size - 1);
+  }
 
   size_t xfer_agent_memory (agent_address_t address, void *read,
                             const void *write, size_t size);
@@ -598,22 +641,24 @@ public:
     : m_agent (agent), m_xfer_agent_memory (std::move (xfer_agent_memory))
   {
   }
-  ~memory_cache_t () { dbgapi_assert (m_cache_line_map.empty ()); }
+  ~memory_cache_t () { dbgapi_assert (m_cache_entry_map.empty ()); }
 
   bool contains_all (agent_address_t address, amd_dbgapi_size_t size) const;
 
-  /* Create cache lines if not already valid, and immediately fill them in.  */
+  /* Create a cache entry for the [address, address+size) range.  The
+     range must not be already cached.  */
   void prefetch (agent_address_t address, amd_dbgapi_size_t size,
                  memory_pool_t &pool);
 
-  /* Discard all cache lines in the specified range.  If FORCE_DISCARD
-     is true, dirty lines are silently dropped.  Otherwise it is an error to
-     discarded dirty cache lines.  */
+  /* Discard all cache entries in the specified range.  Discarding a partial
+     entry is not allowed; the specified range must contain whole cached
+     regions (or none).  If FORCE_DISCARD is true, dirty entries are silently
+     dropped. Otherwise it is an error to discard dirty cache entries.  */
   void discard (agent_address_t address = 0,
                 amd_dbgapi_size_t size = amd_dbgapi_size_t (-1),
                 bool force_discard = false);
 
-  /* Write dirty lines back to memory.  */
+  /* Write dirty cache entries back to memory.  */
   void write_back (agent_address_t address = 0,
                    amd_dbgapi_size_t size = amd_dbgapi_size_t (-1));
 

--- a/projects/rocdbgapi/src/queue.cpp
+++ b/projects/rocdbgapi/src/queue.cpp
@@ -519,20 +519,20 @@ aql_queue_t::queue_state_changed ()
       m_waves_running.reset ();
 
       /* The queue just changed state and is about to be placed back onto the
-         hardware.  Write back dirty cache lines in the wave saved state
-         region, but leave the cache lines valid so that accessing stopped
-         waves' cached registers does not require a queue suspend/resume.  The
-         saved state cache lines will be discarded when this queue is next
-         suspended again (see the 'case state_t::suspended:' below).  */
+         hardware.  Write back the cached wave saved state region for this
+         queue (if dirty), but leave the cached state valid so that accessing
+         stopped waves' cached registers does not require a queue
+         suspend/resume.  The saved state cache will be discarded when this
+         queue is next suspended again (see the 'case state_t::suspended:'
+         below).  */
       agent ().memory_cache ().write_back (
         m_os_queue_info.ctx_save_restore_address,
         xcc_count * m_os_queue_info.ctx_save_restore_area_size);
       break;
 
     case state_t::suspended:
-      /* Discard the previously cached wave saved state lines.  The saved state
-         areas may be mapped to a different address in this new context wave
-         save.  */
+      /* Discard the previously cached wave saved state.  The saved state areas
+         may be mapped to a different address in this new context wave save.  */
       discard_save_area_cache ();
 
       /* Refresh the scratch_backing_memory_location and


### PR DESCRIPTION
If we change the save area prefetch code in queue.cpp to prefetch
e.g. the whole used save area in one big chunk, then performance
around updating waves surprisingly degrades on Linux by some 10x,
which is unacceptable.

The reason for that slowdown is the cache lines allocation mechanism.
E.g., with a prefetch used save area size of 12134416, and 64 bytes
long cache lines, we end up allocating some 190k cache lines, each a
separate std::map entry, with corresponding heap allocation...  For a
single prefetch call, the memory xfer would be fast, but we would now
be spending up to 100ms just allocating the cache lines and filling in
the std::map, in the loop at the bottom of
memory_cache_t<AddressType>::prefetch.  This completely explains the
10x slowdown observed.

Now, I considered several ways to address this.  However, there is one
important detail -- the memory cache mechanism is solely used for save
area caching, nothing else.  There is no code that wants to cache
random areas without a defined access pattern.

This suggests to me that we can redesign the class, make it more tuned
to save area caching, and simplify it at the same time.  That's what
this patch does.

- Remove the concept of cache lines, and replace it with cache
entries, which can have any size.  The previous patch introducing a
memory pool object made this possible without causing any
performance degradation.

- Assume (and document, and assert) that discarding never tries to
discard a partial cached entry.

- We don't need to bother with coalescing entries on write_back,
since we shouldn't be seeing contiguous entries.  In fact, running
the testsuite with a fatal_error in the existing loop never
triggers.  Not surprising since we prefetch a chunk of each wave's
save area, and there's a non-cached gap between each wave's range.
If we find two contiguous ranges that could be cached, then that
should be done with a single cache entry prefetch covering both
ranges.

- No longer align cache lines.  There's no need for that anymore, and
it just results in reading more memory than needed.

Tested on both Linux and Windows.

This commit only changes the data structures, does not actually change
what we prefetch.

Change-Id: I1eead950f76ab757435ab39b073263cd0611f4f5

---

**Stack**:
- #5546 ⬅
- #5545


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*