### PR TITLE
[rocprofiler-systems] Add `ROCPROFSYS_DEFAULT_MIN_INSTRUCTIONS` to base test environment and fix transpose-rocprofiler test

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/config.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/config.py
@@ -233,6 +233,7 @@ class RocprofsysConfig:
     def get_base_environment(self) -> dict[str, str]:
         """Get base environment variables for test execution."""
         return {
+            "ROCPROFSYS_DEFAULT_MIN_INSTRUCTIONS": "64",
             "ROCPROFSYS_CI": "ON",
             "ROCPROFSYS_CI_TIMEOUT": os.environ.get("ROCPROFSYS_CI_TIMEOUT", "300"),
             "ROCPROFSYS_CONFIG_FILE": "",

--- a/projects/rocprofiler-systems/tests/pytest/test_transpose.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_transpose.py
@@ -266,6 +266,7 @@ class TestTransposeROCProfiler(RocprofsysTest):
             check_target_arch=True,
             launcher="mpi",
             num_procs=num_processes,
+            rewrite_args=self.REWRITE_ARGS,
         )
         self.assert_regex(result)
         # Counter file device ID depends on GPU topology, search across IDs 0-9


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

In #3962 , I forgot to port over `ROCPROFSYS_DEFAULT_MIN_INSTRUCTIONS` from the old `ROCPROFILER_SYSTEMS_ADD_TEST` function.

It would also appear I forgot to pass `REWRITE_ARGS` into the `run_test(...)` part of the `transpose-rocprofiler` test, meaning the `binary-rewrite` wasn't excluding the expected function.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Add `ROCPROFSYS_DEFAULT_MIN_INSTRUCTIONS=64` to `get_base_environment`
Pass `REWRITE_ARGS` into `transpose-rocprofiler` `run_test`

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

Part of AIPROFSYST-251

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Workflows

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
