### PR TITLE
fix(rocprofiler-sdk): add validation and error handling for the extra counter YAML file

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/output/metadata.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/metadata.cpp
@@ -134,8 +134,19 @@ process_agent_counters(rocprofiler_agent_id_t    agent_id,
                 auto _dim_ids  = std::vector<rocprofiler_counter_dimension_id_t>{};
                 auto _dim_info = std::vector<rocprofiler_counter_record_dimension_info_t>{};
 
-                ROCPROFILER_CHECK(rocprofiler_query_counter_info(
-                    counters[i], ROCPROFILER_COUNTER_INFO_VERSION_1, &_info));
+                auto _status = rocprofiler_query_counter_info(
+                    counters[i], ROCPROFILER_COUNTER_INFO_VERSION_1, &_info);
+                if(_status != ROCPROFILER_STATUS_SUCCESS)
+                {
+                    ROCP_ERROR << fmt::format(
+                        "[{}] rocprofiler_query_counter_info( counters[{}], "
+                        "ROCPROFILER_COUNTER_INFO_VERSION_1, &_info) returned {} :: {}",
+                        __FUNCTION__,
+                        i,
+                        rocprofiler_get_status_name(_status),
+                        rocprofiler_get_status_string(_status));
+                    std::exit(EXIT_FAILURE);
+                }
 
                 if(counters_set_data != nullptr && counters_set_data->count(_info.name) == 0)
                     continue;
@@ -194,20 +205,28 @@ metadata::metadata(inprocess)
 , node_data{read_node_info()}
 , command_line{common::read_command_line(getpid())}
 {
-    ROCPROFILER_CHECK(rocprofiler_query_available_agents(
+    auto _status = rocprofiler_query_available_agents(
         ROCPROFILER_AGENT_INFO_VERSION_0,
         [](rocprofiler_agent_version_t, const void** _agents, size_t _num_agents, void* _data) {
             auto* _agents_v = static_cast<agent_info_vec_t*>(_data);
             _agents_v->reserve(_num_agents);
             for(size_t i = 0; i < _num_agents; ++i)
             {
-                auto* agent = static_cast<const rocprofiler_agent_v0_t*>(_agents[i]);
+                const auto* agent = static_cast<const rocprofiler_agent_v0_t*>(_agents[i]);
                 _agents_v->emplace_back(*agent);
             }
             return ROCPROFILER_STATUS_SUCCESS;
         },
         sizeof(rocprofiler_agent_v0_t),
-        &agents));
+        &agents);
+    if(_status != ROCPROFILER_STATUS_SUCCESS)
+    {
+        ROCP_ERROR << fmt::format("[{}] rocprofiler_query_available_agents(...) returned {} :: {}",
+                                  __FUNCTION__,
+                                  rocprofiler_get_status_name(_status),
+                                  rocprofiler_get_status_string(_status));
+        std::exit(EXIT_FAILURE);
+    }
 
     {
         auto _gpu_agents = std::vector<agent_info*>{};
@@ -314,10 +333,13 @@ metadata::init(inprocess_with_counters&& data)
             name_v           = pmc_counter.substr(0, pos);
             auto device_id_s = pmc_counter.substr(pos + device_qualifier.length());
 
-            ROCP_FATAL_IF(device_id_s.empty() ||
-                          device_id_s.find_first_not_of("0123456789") != std::string::npos)
-                << fmt::format("Invalid device qualifier format (expected ':device=N') in '{}'",
-                               pmc_counter);
+            if(device_id_s.empty() ||
+               device_id_s.find_first_not_of("0123456789") != std::string::npos)
+            {
+                ROCP_ERROR << fmt::format(
+                    "Invalid device qualifier format (expected ':device=N') in '{}'", pmc_counter);
+                std::exit(EXIT_FAILURE);
+            }
 
             auto device_id_l = std::stol(device_id_s);
             if(gpu_index_to_counters_map.find(device_id_l) == gpu_index_to_counters_map.end())
@@ -433,7 +455,17 @@ const tool_counter_info*
 metadata::get_counter_info(uint64_t instance_id) const
 {
     auto _counter_id = rocprofiler_counter_id_t{.handle = 0};
-    ROCPROFILER_CHECK(rocprofiler_query_record_counter_id(instance_id, &_counter_id));
+    auto _status     = rocprofiler_query_record_counter_id(instance_id, &_counter_id);
+    if(_status != ROCPROFILER_STATUS_SUCCESS)
+    {
+        ROCP_ERROR << fmt::format(
+            "[{}] rocprofiler_query_record_counter_id({}, &_counter_id) returned {} :: {}",
+            __FUNCTION__,
+            instance_id,
+            rocprofiler_get_status_name(_status),
+            rocprofiler_get_status_string(_status));
+        std::exit(EXIT_FAILURE);
+    }
     return get_counter_info(_counter_id);
 }
 
@@ -780,8 +812,11 @@ agent_index
 metadata::get_agent_index(rocprofiler_agent_id_t id, agent_indexing index) const
 {
     const auto* _agent = get_agent(id);
-    ROCP_FATAL_IF(!_agent) << "Information of the agent with handle: " << id.handle
-                           << " is not present";
+    if(!_agent)
+    {
+        ROCP_ERROR << "Information of the agent with handle: " << id.handle << " is not present";
+        std::exit(EXIT_FAILURE);
+    }
 
     // stringify agent type
     auto get_type = [_agent]() -> std::string_view {

--- a/projects/rocprofiler-sdk/source/lib/output/metadata.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/metadata.cpp
@@ -134,19 +134,8 @@ process_agent_counters(rocprofiler_agent_id_t    agent_id,
                 auto _dim_ids  = std::vector<rocprofiler_counter_dimension_id_t>{};
                 auto _dim_info = std::vector<rocprofiler_counter_record_dimension_info_t>{};
 
-                auto _status = rocprofiler_query_counter_info(
-                    counters[i], ROCPROFILER_COUNTER_INFO_VERSION_1, &_info);
-                if(_status != ROCPROFILER_STATUS_SUCCESS)
-                {
-                    ROCP_ERROR << fmt::format(
-                        "[{}] rocprofiler_query_counter_info( counters[{}], "
-                        "ROCPROFILER_COUNTER_INFO_VERSION_1, &_info) returned {} :: {}",
-                        __FUNCTION__,
-                        i,
-                        rocprofiler_get_status_name(_status),
-                        rocprofiler_get_status_string(_status));
-                    std::exit(EXIT_FAILURE);
-                }
+                ROCPROFILER_CHECK(rocprofiler_query_counter_info(
+                    counters[i], ROCPROFILER_COUNTER_INFO_VERSION_1, &_info));
 
                 if(counters_set_data != nullptr && counters_set_data->count(_info.name) == 0)
                     continue;
@@ -205,28 +194,20 @@ metadata::metadata(inprocess)
 , node_data{read_node_info()}
 , command_line{common::read_command_line(getpid())}
 {
-    auto _status = rocprofiler_query_available_agents(
+    ROCPROFILER_CHECK(rocprofiler_query_available_agents(
         ROCPROFILER_AGENT_INFO_VERSION_0,
         [](rocprofiler_agent_version_t, const void** _agents, size_t _num_agents, void* _data) {
             auto* _agents_v = static_cast<agent_info_vec_t*>(_data);
             _agents_v->reserve(_num_agents);
             for(size_t i = 0; i < _num_agents; ++i)
             {
-                const auto* agent = static_cast<const rocprofiler_agent_v0_t*>(_agents[i]);
+                auto* agent = static_cast<const rocprofiler_agent_v0_t*>(_agents[i]);
                 _agents_v->emplace_back(*agent);
             }
             return ROCPROFILER_STATUS_SUCCESS;
         },
         sizeof(rocprofiler_agent_v0_t),
-        &agents);
-    if(_status != ROCPROFILER_STATUS_SUCCESS)
-    {
-        ROCP_ERROR << fmt::format("[{}] rocprofiler_query_available_agents(...) returned {} :: {}",
-                                  __FUNCTION__,
-                                  rocprofiler_get_status_name(_status),
-                                  rocprofiler_get_status_string(_status));
-        std::exit(EXIT_FAILURE);
-    }
+        &agents));
 
     {
         auto _gpu_agents = std::vector<agent_info*>{};
@@ -333,13 +314,10 @@ metadata::init(inprocess_with_counters&& data)
             name_v           = pmc_counter.substr(0, pos);
             auto device_id_s = pmc_counter.substr(pos + device_qualifier.length());
 
-            if(device_id_s.empty() ||
-               device_id_s.find_first_not_of("0123456789") != std::string::npos)
-            {
-                ROCP_ERROR << fmt::format(
-                    "Invalid device qualifier format (expected ':device=N') in '{}'", pmc_counter);
-                std::exit(EXIT_FAILURE);
-            }
+            ROCP_FATAL_IF(device_id_s.empty() ||
+                          device_id_s.find_first_not_of("0123456789") != std::string::npos)
+                << fmt::format("Invalid device qualifier format (expected ':device=N') in '{}'",
+                               pmc_counter);
 
             auto device_id_l = std::stol(device_id_s);
             if(gpu_index_to_counters_map.find(device_id_l) == gpu_index_to_counters_map.end())
@@ -455,17 +433,7 @@ const tool_counter_info*
 metadata::get_counter_info(uint64_t instance_id) const
 {
     auto _counter_id = rocprofiler_counter_id_t{.handle = 0};
-    auto _status     = rocprofiler_query_record_counter_id(instance_id, &_counter_id);
-    if(_status != ROCPROFILER_STATUS_SUCCESS)
-    {
-        ROCP_ERROR << fmt::format(
-            "[{}] rocprofiler_query_record_counter_id({}, &_counter_id) returned {} :: {}",
-            __FUNCTION__,
-            instance_id,
-            rocprofiler_get_status_name(_status),
-            rocprofiler_get_status_string(_status));
-        std::exit(EXIT_FAILURE);
-    }
+    ROCPROFILER_CHECK(rocprofiler_query_record_counter_id(instance_id, &_counter_id));
     return get_counter_info(_counter_id);
 }
 
@@ -812,11 +780,8 @@ agent_index
 metadata::get_agent_index(rocprofiler_agent_id_t id, agent_indexing index) const
 {
     const auto* _agent = get_agent(id);
-    if(!_agent)
-    {
-        ROCP_ERROR << "Information of the agent with handle: " << id.handle << " is not present";
-        std::exit(EXIT_FAILURE);
-    }
+    ROCP_FATAL_IF(!_agent) << "Information of the agent with handle: " << id.handle
+                           << " is not present";
 
     // stringify agent type
     auto get_type = [_agent]() -> std::string_view {

--- a/projects/rocprofiler-sdk/source/lib/output/metadata.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/metadata.cpp
@@ -119,8 +119,19 @@ process_agent_counters(rocprofiler_agent_id_t    agent_id,
                 auto _dim_ids  = std::vector<rocprofiler_counter_dimension_id_t>{};
                 auto _dim_info = std::vector<rocprofiler_counter_record_dimension_info_t>{};
 
-                ROCPROFILER_CHECK(rocprofiler_query_counter_info(
-                    counters[i], ROCPROFILER_COUNTER_INFO_VERSION_1, &_info));
+                auto _status = rocprofiler_query_counter_info(
+                    counters[i], ROCPROFILER_COUNTER_INFO_VERSION_1, &_info);
+                if(_status != ROCPROFILER_STATUS_SUCCESS)
+                {
+                    ROCP_ERROR << fmt::format(
+                        "[{}] rocprofiler_query_counter_info( counters[{}], "
+                        "ROCPROFILER_COUNTER_INFO_VERSION_1, &_info) returned {} :: {}",
+                        __FUNCTION__,
+                        i,
+                        rocprofiler_get_status_name(_status),
+                        rocprofiler_get_status_string(_status));
+                    std::exit(EXIT_FAILURE);
+                }
 
                 if(counters_set_data != nullptr && counters_set_data->count(_info.name) == 0)
                     continue;
@@ -179,20 +190,28 @@ metadata::metadata(inprocess)
 , node_data{read_node_info()}
 , command_line{common::read_command_line(getpid())}
 {
-    ROCPROFILER_CHECK(rocprofiler_query_available_agents(
+    auto _status = rocprofiler_query_available_agents(
         ROCPROFILER_AGENT_INFO_VERSION_0,
         [](rocprofiler_agent_version_t, const void** _agents, size_t _num_agents, void* _data) {
             auto* _agents_v = static_cast<agent_info_vec_t*>(_data);
             _agents_v->reserve(_num_agents);
             for(size_t i = 0; i < _num_agents; ++i)
             {
-                auto* agent = static_cast<const rocprofiler_agent_v0_t*>(_agents[i]);
+                const auto* agent = static_cast<const rocprofiler_agent_v0_t*>(_agents[i]);
                 _agents_v->emplace_back(*agent);
             }
             return ROCPROFILER_STATUS_SUCCESS;
         },
         sizeof(rocprofiler_agent_v0_t),
-        &agents));
+        &agents);
+    if(_status != ROCPROFILER_STATUS_SUCCESS)
+    {
+        ROCP_ERROR << fmt::format("[{}] rocprofiler_query_available_agents(...) returned {} :: {}",
+                                  __FUNCTION__,
+                                  rocprofiler_get_status_name(_status),
+                                  rocprofiler_get_status_string(_status));
+        std::exit(EXIT_FAILURE);
+    }
 
     {
         auto _gpu_agents = std::vector<agent_info*>{};
@@ -295,10 +314,13 @@ metadata::init(inprocess_with_counters&& data)
             name_v           = pmc_counter.substr(0, pos);
             auto device_id_s = pmc_counter.substr(pos + device_qualifier.length());
 
-            ROCP_FATAL_IF(device_id_s.empty() ||
-                          device_id_s.find_first_not_of("0123456789") != std::string::npos)
-                << fmt::format("Invalid device qualifier format (expected ':device=N') in '{}'",
-                               pmc_counter);
+            if(device_id_s.empty() ||
+               device_id_s.find_first_not_of("0123456789") != std::string::npos)
+            {
+                ROCP_ERROR << fmt::format(
+                    "Invalid device qualifier format (expected ':device=N') in '{}'", pmc_counter);
+                std::exit(EXIT_FAILURE);
+            }
 
             auto device_id_l = std::stol(device_id_s);
             if(gpu_index_to_counters_map.find(device_id_l) == gpu_index_to_counters_map.end())
@@ -414,7 +436,17 @@ const tool_counter_info*
 metadata::get_counter_info(uint64_t instance_id) const
 {
     auto _counter_id = rocprofiler_counter_id_t{.handle = 0};
-    ROCPROFILER_CHECK(rocprofiler_query_record_counter_id(instance_id, &_counter_id));
+    auto _status     = rocprofiler_query_record_counter_id(instance_id, &_counter_id);
+    if(_status != ROCPROFILER_STATUS_SUCCESS)
+    {
+        ROCP_ERROR << fmt::format(
+            "[{}] rocprofiler_query_record_counter_id({}, &_counter_id) returned {} :: {}",
+            __FUNCTION__,
+            instance_id,
+            rocprofiler_get_status_name(_status),
+            rocprofiler_get_status_string(_status));
+        std::exit(EXIT_FAILURE);
+    }
     return get_counter_info(_counter_id);
 }
 
@@ -748,8 +780,11 @@ agent_index
 metadata::get_agent_index(rocprofiler_agent_id_t id, agent_indexing index) const
 {
     const auto* _agent = get_agent(id);
-    ROCP_FATAL_IF(!_agent) << "Information of the agent with handle: " << id.handle
-                           << " is not present";
+    if(!_agent)
+    {
+        ROCP_ERROR << "Information of the agent with handle: " << id.handle << " is not present";
+        std::exit(EXIT_FAILURE);
+    }
 
     // stringify agent type
     auto get_type = [_agent]() -> std::string_view {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/helpers.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/helpers.cpp
@@ -47,8 +47,8 @@ get_query_info(rocprofiler_agent_id_t agent, const counters::Metric& metric)
     auto query = hsa_ven_amd_aqlprofile_id_query_t{metric.block().c_str(), 0, 0};
     if(aqlprofile_get_pmc_info(&profile, AQLPROFILE_INFO_BLOCK_ID, &query) != HSA_STATUS_SUCCESS)
     {
-        ROCP_ERROR << fmt::format("AQL failed to query info for counter {}", metric);
-        std::exit(EXIT_FAILURE);
+        ROCP_DFATAL << fmt::format("AQL failed to query info for counter {}", metric);
+        throw std::runtime_error(fmt::format("AQL failed to query info for counter {}", metric));
     }
     return query;
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/helpers.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/helpers.cpp
@@ -47,8 +47,8 @@ get_query_info(rocprofiler_agent_id_t agent, const counters::Metric& metric)
     auto query = hsa_ven_amd_aqlprofile_id_query_t{metric.block().c_str(), 0, 0};
     if(aqlprofile_get_pmc_info(&profile, AQLPROFILE_INFO_BLOCK_ID, &query) != HSA_STATUS_SUCCESS)
     {
-        ROCP_DFATAL << fmt::format("AQL failed to query info for counter {}", metric);
-        throw std::runtime_error(fmt::format("AQL failed to query info for counter {}", metric));
+        ROCP_ERROR << fmt::format("AQL failed to query info for counter {}", metric);
+        std::exit(EXIT_FAILURE);
     }
     return query;
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dimensions.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dimensions.cpp
@@ -115,8 +115,9 @@ generate_dimensions(rocprofiler_agent_id_t agent_id)
             dims.emplace(ast.out_id().handle, ast_copy.set_dimensions(agent_id));
         } catch(std::runtime_error& e)
         {
-            ROCP_FATAL << metric << " has improper dimensions"
+            ROCP_ERROR << metric << " has improper dimensions"
                        << " " << e.what();
+            std::exit(EXIT_FAILURE);
         }
     }
     return {.id_to_dim = dims};

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dimensions.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dimensions.cpp
@@ -115,9 +115,8 @@ generate_dimensions(rocprofiler_agent_id_t agent_id)
             dims.emplace(ast.out_id().handle, ast_copy.set_dimensions(agent_id));
         } catch(std::runtime_error& e)
         {
-            ROCP_ERROR << metric << " has improper dimensions"
+            ROCP_FATAL << metric << " has improper dimensions"
                        << " " << e.what();
-            std::exit(EXIT_FAILURE);
         }
     }
     return {.id_to_dim = dims};

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
@@ -96,6 +96,7 @@ get_constants(uint64_t starting_id)
     }
     return constants;
 }
+
 /**
  * Expected YAML Format:
  * COUNTER_NAME:
@@ -135,35 +136,46 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
         counter_data << override.data;
     }
 
-    auto     yaml       = YAML::Load(counter_data.str());
-    auto     header     = yaml["rocprofiler-sdk"]["counters"];
-    uint64_t current_id = 0;
+    YAML::Node yaml;
+    YAML::Node header;
+    uint64_t   current_id = 0;
+
+    try
+    {
+        yaml   = YAML::Load(counter_data.str());
+        header = yaml["rocprofiler-sdk"]["counters"];
+    } catch(const YAML::Exception& e)
+    {
+        ROCP_ERROR << "Failed to parse counter file " << filename << ": " << e.what();
+        std::exit(EXIT_FAILURE);
+    }
+
     if(!override.data.empty() && override.append)
     {
-        append_yaml = YAML::Load(override.data);
-        if(append_yaml["rocprofiler-sdk"] && append_yaml["rocprofiler-sdk"]["counters"])
+        try
         {
-            for(const auto& counter : append_yaml["rocprofiler-sdk"]["counters"])
+            append_yaml = YAML::Load(override.data);
+
+            auto error = validateExtraCounterYAML(append_yaml);
+            if(error)
             {
-                header.push_back(counter);
+                ROCP_ERROR << "Invalid extra counters YAML: " << *error << "\n"
+                           << "Content:\n"
+                           << override.data;
+                std::exit(EXIT_FAILURE);
             }
-        }
-        else
+
+            if(append_yaml["rocprofiler-sdk"] && append_yaml["rocprofiler-sdk"]["counters"])
+            {
+                for(const auto& counter : append_yaml["rocprofiler-sdk"]["counters"])
+                    header.push_back(counter);
+            }
+        } catch(const YAML::Exception& e)
         {
-            ROCP_ERROR << "Invalid extra counters YAML format. Expected structure:\n"
-                       << "rocprofiler-sdk:\n"
-                       << "  counters-schema-version: 1\n"
-                       << "  counters:\n"
-                       << "  - name: COUNTER_NAME\n"
-                       << "    description: 'Counter description'\n"
-                       << "    properties: []\n"
-                       << "    definitions:\n"
-                       << "    - architectures:\n"
-                       << "      - gfx942\n"
-                       << "      block: BLOCK_NAME\n"
-                       << "      event: EVENT_ID\n"
-                       << "Got:\n"
+            ROCP_ERROR << "Failed to parse extra counters YAML: " << e.what() << "\n"
+                       << "Content:\n"
                        << override.data;
+            std::exit(EXIT_FAILURE);
         }
     }
 
@@ -221,8 +233,11 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
         ret.emplace(add_metric->first, std::vector<Metric>{}).first->second.push_back(with_id);
     }
 
-    ROCP_FATAL_IF(current_id > 65536)
-        << "Counter count exceeds 16 bits, which may break counter id output";
+    if(current_id > 65536)
+    {
+        ROCP_ERROR << "Counter count exceeds 16 bits, which may break counter id output";
+        std::exit(EXIT_FAILURE);
+    }
 
     return {.arch_to_metric = ret,
             .id_to_metric =
@@ -313,13 +328,80 @@ locateMetricsFile(std::string_view name)
         return install_candidate;
     }
 
-    ROCP_FATAL << "Metric file '" << name << "' not found.\n"
-               << "  Tried: ROCPROFILER_METRICS_PATH (" << metric_env_path << "), and"
+    ROCP_ERROR << "Metric file '" << name << "' not found.\n"
+               << "  Tried: ROCPROFILER_METRICS_PATH (" << metric_env_path << "), and "
                << install_candidate;
-    return {};
+    std::exit(EXIT_FAILURE);
 }
 
 }  // namespace
+
+std::optional<std::string>
+validateExtraCounterYAML(const YAML::Node& root)
+{
+    if(!root["rocprofiler-sdk"]) return "Missing top-level 'rocprofiler-sdk' key";
+
+    auto counters_node = root["rocprofiler-sdk"]["counters"];
+    if(!counters_node) return "Missing 'counters' array under 'rocprofiler-sdk'";
+
+    if(!counters_node.IsSequence()) return "'counters' must be a sequence";
+
+    std::unordered_set<std::string> seen_counter_arch_pairs;
+    for(size_t i = 0; i < counters_node.size(); ++i)
+    {
+        const auto& counter = counters_node[i];
+        auto        ctx     = fmt::format("counters[{}]", i);
+
+        if(!counter["name"]) return fmt::format("{}: missing 'name' field", ctx);
+        if(!counter["name"].IsScalar()) return fmt::format("{}: 'name' must be a string", ctx);
+
+        auto name = counter["name"].as<std::string>();
+
+        if(!counter["definitions"]) return fmt::format("Counter '{}': missing 'definitions'", name);
+        if(!counter["definitions"].IsSequence())
+            return fmt::format("Counter '{}': 'definitions' must be a sequence", name);
+        if(counter["definitions"].size() == 0)
+            return fmt::format("Counter '{}': 'definitions' is empty", name);
+
+        for(size_t j = 0; j < counter["definitions"].size(); ++j)
+        {
+            const auto& def     = counter["definitions"][j];
+            auto        def_ctx = fmt::format("Counter '{}', definition [{}]", name, j);
+
+            if(!def["architectures"]) return fmt::format("{}: missing 'architectures'", def_ctx);
+            if(!def["architectures"].IsSequence())
+                return fmt::format("{}: 'architectures' must be a sequence", def_ctx);
+            if(def["architectures"].size() == 0)
+                return fmt::format("{}: 'architectures' is empty", def_ctx);
+
+            for(const auto& arch : def["architectures"])
+            {
+                if(!arch.IsScalar())
+                    return fmt::format("{}: architecture must be a string", def_ctx);
+
+                auto arch_str = arch.as<std::string>();
+                auto pair_key = fmt::format("{}:{}", name, arch_str);
+                if(seen_counter_arch_pairs.count(pair_key) != 0)
+                {
+                    ROCP_WARNING << "Duplicate counter '" << name << "' for architecture '"
+                                 << arch_str << "' ignored";
+                }
+                seen_counter_arch_pairs.insert(pair_key);
+            }
+
+            bool has_expr  = def["expression"] && def["expression"].IsScalar();
+            bool has_event = def["event"] && def["event"].IsScalar();
+            bool has_block = def["block"] && def["block"].IsScalar();
+
+            if(!has_expr && !has_event)
+                return fmt::format("{}: must have 'expression' or 'event'+'block'", def_ctx);
+            if(has_event && !has_block) return fmt::format("{}: 'event' requires 'block'", def_ctx);
+            if(has_block && !has_event) return fmt::format("{}: 'block' requires 'event'", def_ctx);
+        }
+    }
+
+    return std::nullopt;
+}
 
 rocprofiler_status_t
 setCustomCounterDefinition(const CustomCounterDefinition& def)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
@@ -384,7 +384,7 @@ validateExtraCounterYAML(const YAML::Node& root)
                 if(seen_counter_arch_pairs.count(pair_key) != 0)
                 {
                     ROCP_WARNING << "Duplicate counter '" << name << "' for architecture '"
-                                 << arch_str << "' ignored";
+                                 << arch_str << "' detected";
                 }
                 seen_counter_arch_pairs.insert(pair_key);
             }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
@@ -146,8 +146,7 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
         header = yaml["rocprofiler-sdk"]["counters"];
     } catch(const YAML::Exception& e)
     {
-        ROCP_ERROR << "Failed to parse counter file " << filename << ": " << e.what();
-        std::exit(EXIT_FAILURE);
+        ROCP_FATAL << "Failed to parse counter file " << filename << ": " << e.what();
     }
 
     if(!override.data.empty() && override.append)
@@ -159,10 +158,9 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
             auto error = validateExtraCounterYAML(append_yaml);
             if(error)
             {
-                ROCP_ERROR << "Invalid extra counters YAML: " << *error << "\n"
+                ROCP_FATAL << "Invalid extra counters YAML: " << *error << "\n"
                            << "Content:\n"
                            << override.data;
-                std::exit(EXIT_FAILURE);
             }
 
             if(append_yaml["rocprofiler-sdk"] && append_yaml["rocprofiler-sdk"]["counters"])
@@ -172,10 +170,9 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
             }
         } catch(const YAML::Exception& e)
         {
-            ROCP_ERROR << "Failed to parse extra counters YAML: " << e.what() << "\n"
+            ROCP_FATAL << "Failed to parse extra counters YAML: " << e.what() << "\n"
                        << "Content:\n"
                        << override.data;
-            std::exit(EXIT_FAILURE);
         }
     }
 
@@ -235,8 +232,7 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
 
     if(current_id > 65536)
     {
-        ROCP_ERROR << "Counter count exceeds 16 bits, which may break counter id output";
-        std::exit(EXIT_FAILURE);
+        ROCP_FATAL << "Counter count exceeds 16 bits, which may break counter id output";
     }
 
     return {.arch_to_metric = ret,
@@ -328,10 +324,9 @@ locateMetricsFile(std::string_view name)
         return install_candidate;
     }
 
-    ROCP_ERROR << "Metric file '" << name << "' not found.\n"
+    ROCP_FATAL << "Metric file '" << name << "' not found.\n"
                << "  Tried: ROCPROFILER_METRICS_PATH (" << metric_env_path << "), and "
                << install_candidate;
-    std::exit(EXIT_FAILURE);
 }
 
 }  // namespace

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
@@ -377,7 +377,7 @@ validateExtraCounterYAML(const YAML::Node& root)
                 if(seen_counter_arch_pairs.count(pair_key) != 0)
                 {
                     ROCP_WARNING << "Duplicate counter '" << name << "' for architecture '"
-                                 << arch_str << "' ignored";
+                                 << arch_str << "' detected";
                 }
                 seen_counter_arch_pairs.insert(pair_key);
             }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
@@ -91,6 +91,7 @@ get_constants(uint64_t starting_id)
     }
     return constants;
 }
+
 /**
  * Expected YAML Format:
  * COUNTER_NAME:
@@ -130,35 +131,46 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
         counter_data << override.data;
     }
 
-    auto     yaml       = YAML::Load(counter_data.str());
-    auto     header     = yaml["rocprofiler-sdk"]["counters"];
-    uint64_t current_id = 0;
+    YAML::Node yaml;
+    YAML::Node header;
+    uint64_t   current_id = 0;
+
+    try
+    {
+        yaml   = YAML::Load(counter_data.str());
+        header = yaml["rocprofiler-sdk"]["counters"];
+    } catch(const YAML::Exception& e)
+    {
+        ROCP_ERROR << "Failed to parse counter file " << filename << ": " << e.what();
+        std::exit(EXIT_FAILURE);
+    }
+
     if(!override.data.empty() && override.append)
     {
-        append_yaml = YAML::Load(override.data);
-        if(append_yaml["rocprofiler-sdk"] && append_yaml["rocprofiler-sdk"]["counters"])
+        try
         {
-            for(const auto& counter : append_yaml["rocprofiler-sdk"]["counters"])
+            append_yaml = YAML::Load(override.data);
+
+            auto error = validateExtraCounterYAML(append_yaml);
+            if(error)
             {
-                header.push_back(counter);
+                ROCP_ERROR << "Invalid extra counters YAML: " << *error << "\n"
+                           << "Content:\n"
+                           << override.data;
+                std::exit(EXIT_FAILURE);
             }
-        }
-        else
+
+            if(append_yaml["rocprofiler-sdk"] && append_yaml["rocprofiler-sdk"]["counters"])
+            {
+                for(const auto& counter : append_yaml["rocprofiler-sdk"]["counters"])
+                    header.push_back(counter);
+            }
+        } catch(const YAML::Exception& e)
         {
-            ROCP_ERROR << "Invalid extra counters YAML format. Expected structure:\n"
-                       << "rocprofiler-sdk:\n"
-                       << "  counters-schema-version: 1\n"
-                       << "  counters:\n"
-                       << "  - name: COUNTER_NAME\n"
-                       << "    description: 'Counter description'\n"
-                       << "    properties: []\n"
-                       << "    definitions:\n"
-                       << "    - architectures:\n"
-                       << "      - gfx942\n"
-                       << "      block: BLOCK_NAME\n"
-                       << "      event: EVENT_ID\n"
-                       << "Got:\n"
+            ROCP_ERROR << "Failed to parse extra counters YAML: " << e.what() << "\n"
+                       << "Content:\n"
                        << override.data;
+            std::exit(EXIT_FAILURE);
         }
     }
 
@@ -216,8 +228,11 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
         ret.emplace(add_metric->first, std::vector<Metric>{}).first->second.push_back(with_id);
     }
 
-    ROCP_FATAL_IF(current_id > 65536)
-        << "Counter count exceeds 16 bits, which may break counter id output";
+    if(current_id > 65536)
+    {
+        ROCP_ERROR << "Counter count exceeds 16 bits, which may break counter id output";
+        std::exit(EXIT_FAILURE);
+    }
 
     return {.arch_to_metric = ret,
             .id_to_metric =
@@ -306,13 +321,80 @@ locateMetricsFile(std::string_view name)
         return install_candidate;
     }
 
-    ROCP_FATAL << "Metric file '" << name << "' not found.\n"
-               << "  Tried: ROCPROFILER_METRICS_PATH (" << metric_env_path << "), and"
+    ROCP_ERROR << "Metric file '" << name << "' not found.\n"
+               << "  Tried: ROCPROFILER_METRICS_PATH (" << metric_env_path << "), and "
                << install_candidate;
-    return {};
+    std::exit(EXIT_FAILURE);
 }
 
 }  // namespace
+
+std::optional<std::string>
+validateExtraCounterYAML(const YAML::Node& root)
+{
+    if(!root["rocprofiler-sdk"]) return "Missing top-level 'rocprofiler-sdk' key";
+
+    auto counters_node = root["rocprofiler-sdk"]["counters"];
+    if(!counters_node) return "Missing 'counters' array under 'rocprofiler-sdk'";
+
+    if(!counters_node.IsSequence()) return "'counters' must be a sequence";
+
+    std::unordered_set<std::string> seen_counter_arch_pairs;
+    for(size_t i = 0; i < counters_node.size(); ++i)
+    {
+        const auto& counter = counters_node[i];
+        auto        ctx     = fmt::format("counters[{}]", i);
+
+        if(!counter["name"]) return fmt::format("{}: missing 'name' field", ctx);
+        if(!counter["name"].IsScalar()) return fmt::format("{}: 'name' must be a string", ctx);
+
+        auto name = counter["name"].as<std::string>();
+
+        if(!counter["definitions"]) return fmt::format("Counter '{}': missing 'definitions'", name);
+        if(!counter["definitions"].IsSequence())
+            return fmt::format("Counter '{}': 'definitions' must be a sequence", name);
+        if(counter["definitions"].size() == 0)
+            return fmt::format("Counter '{}': 'definitions' is empty", name);
+
+        for(size_t j = 0; j < counter["definitions"].size(); ++j)
+        {
+            const auto& def     = counter["definitions"][j];
+            auto        def_ctx = fmt::format("Counter '{}', definition [{}]", name, j);
+
+            if(!def["architectures"]) return fmt::format("{}: missing 'architectures'", def_ctx);
+            if(!def["architectures"].IsSequence())
+                return fmt::format("{}: 'architectures' must be a sequence", def_ctx);
+            if(def["architectures"].size() == 0)
+                return fmt::format("{}: 'architectures' is empty", def_ctx);
+
+            for(const auto& arch : def["architectures"])
+            {
+                if(!arch.IsScalar())
+                    return fmt::format("{}: architecture must be a string", def_ctx);
+
+                auto arch_str = arch.as<std::string>();
+                auto pair_key = fmt::format("{}:{}", name, arch_str);
+                if(seen_counter_arch_pairs.count(pair_key) != 0)
+                {
+                    ROCP_WARNING << "Duplicate counter '" << name << "' for architecture '"
+                                 << arch_str << "' ignored";
+                }
+                seen_counter_arch_pairs.insert(pair_key);
+            }
+
+            bool has_expr  = def["expression"] && def["expression"].IsScalar();
+            bool has_event = def["event"] && def["event"].IsScalar();
+            bool has_block = def["block"] && def["block"].IsScalar();
+
+            if(!has_expr && !has_event)
+                return fmt::format("{}: must have 'expression' or 'event'+'block'", def_ctx);
+            if(has_event && !has_block) return fmt::format("{}: 'event' requires 'block'", def_ctx);
+            if(has_block && !has_event) return fmt::format("{}: 'block' requires 'event'", def_ctx);
+        }
+    }
+
+    return std::nullopt;
+}
 
 rocprofiler_status_t
 setCustomCounterDefinition(const CustomCounterDefinition& def)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.hpp
@@ -37,6 +37,11 @@
 #include <unordered_set>
 #include <vector>
 
+namespace YAML
+{
+class Node;
+}
+
 namespace rocprofiler
 {
 namespace counters
@@ -132,6 +137,13 @@ setCustomCounterDefinition(const CustomCounterDefinition& def);
 
 bool
 has_spm_support(const Metric& metric, rocprofiler_agent_id_t agent_id);
+
+/**
+ * Validate extra counter YAML structure
+ * Returns std::nullopt if valid, or error message if invalid
+ */
+std::optional<std::string>
+validateExtraCounterYAML(const YAML::Node& root);
 }  // namespace counters
 }  // namespace rocprofiler
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.hpp
@@ -37,6 +37,11 @@
 #include <unordered_set>
 #include <vector>
 
+namespace YAML
+{
+class Node;
+}
+
 namespace rocprofiler
 {
 namespace counters
@@ -129,6 +134,13 @@ checkValidMetric(const std::string& agent, const Metric& metric);
  */
 rocprofiler_status_t
 setCustomCounterDefinition(const CustomCounterDefinition& def);
+
+/**
+ * Validate extra counter YAML structure
+ * Returns std::nullopt if valid, or error message if invalid
+ */
+std::optional<std::string>
+validateExtraCounterYAML(const YAML::Node& root);
 }  // namespace counters
 }  // namespace rocprofiler
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/metrics_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/metrics_test.cpp
@@ -34,6 +34,7 @@
 
 #include <gtest/gtest.h>
 #include <hsa/hsa.h>
+#include <yaml-cpp/yaml.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -409,4 +410,89 @@ TEST(metrics, counter_info_v1_size_field)
                 << (info.name ? info.name : "<null>") << " (handle=" << counter.handle << ")";
         }
     }
+}
+
+TEST(metrics, validate_malformed_yaml)
+{
+    EXPECT_THROW(YAML::Load("rocprofiler-sdk:\n  counters: \"unclosed"), YAML::Exception);
+}
+
+TEST(metrics, validate_missing_top_key)
+{
+    auto error = counters::validateExtraCounterYAML(YAML::Load("wrong-key:\n  counters: []"));
+    EXPECT_TRUE(error.has_value());
+    EXPECT_NE(error->find("top-level"), std::string::npos);
+}
+
+TEST(metrics, validate_missing_counters)
+{
+    auto error = counters::validateExtraCounterYAML(YAML::Load("rocprofiler-sdk:\n  schema: 1"));
+    EXPECT_TRUE(error.has_value());
+}
+
+TEST(metrics, validate_missing_name)
+{
+    auto error = counters::validateExtraCounterYAML(YAML::Load(
+        "rocprofiler-sdk:\n  counters:\n  - definitions:\n    - architectures: [gfx942]"));
+    EXPECT_TRUE(error.has_value());
+}
+
+TEST(metrics, validate_empty_architectures)
+{
+    auto error = counters::validateExtraCounterYAML(YAML::Load(
+        "rocprofiler-sdk:\n  counters:\n  - name: T\n    definitions:\n    - architectures: "
+        "[]"));
+    EXPECT_TRUE(error.has_value());
+}
+
+TEST(metrics, validate_no_event_or_expr)
+{
+    auto error = counters::validateExtraCounterYAML(YAML::Load(
+        "rocprofiler-sdk:\n  counters:\n  - name: T\n    definitions:\n    - architectures: "
+        "[gfx942]"));
+    EXPECT_TRUE(error.has_value());
+}
+
+TEST(metrics, validate_event_needs_block)
+{
+    auto error = counters::validateExtraCounterYAML(
+        YAML::Load("rocprofiler-sdk:\n  counters:\n  - name: T\n    definitions:\n    - "
+                   "architectures: [gfx942]\n      event: E"));
+    EXPECT_TRUE(error.has_value());
+}
+
+TEST(metrics, validate_block_needs_event)
+{
+    auto error = counters::validateExtraCounterYAML(
+        YAML::Load("rocprofiler-sdk:\n  counters:\n  - name: T\n    definitions:\n    - "
+                   "architectures: [gfx942]\n      block: B"));
+    EXPECT_TRUE(error.has_value());
+}
+
+TEST(metrics, validate_valid_yaml)
+{
+    auto error = counters::validateExtraCounterYAML(
+        YAML::Load("rocprofiler-sdk:\n  counters:\n  - name: T\n    definitions:\n    - "
+                   "architectures: [gfx942]\n      expression: test"));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(metrics, validate_duplicate_counter_same_arch)
+{
+    // Duplicate counter with same name and architecture should warn but not error
+    auto error = counters::validateExtraCounterYAML(YAML::Load(
+        "rocprofiler-sdk:\n  counters:\n  - name: DUP\n    definitions:\n    - architectures: "
+        "[gfx942]\n      expression: expr1\n  - name: DUP\n    definitions:\n    - architectures: "
+        "[gfx942]\n      expression: expr2"));
+    EXPECT_FALSE(error.has_value());  // Should not error, just warn
+}
+
+TEST(metrics, validate_duplicate_counter_different_arch)
+{
+    // Same counter name with different architectures should be valid
+    auto error = counters::validateExtraCounterYAML(YAML::Load(
+        "rocprofiler-sdk:\n  counters:\n  - name: MULTI\n    definitions:\n    - architectures: "
+        "[gfx906]\n      expression: expr1\n  - name: MULTI\n    definitions:\n    - "
+        "architectures: [gfx942]\n      expression: expr2"));
+    EXPECT_FALSE(error.has_value());
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/metrics_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/metrics_test.cpp
@@ -32,6 +32,7 @@
 #include <rocprofiler-sdk/rocprofiler.h>
 
 #include <gtest/gtest.h>
+#include <yaml-cpp/yaml.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -316,4 +317,89 @@ TEST(metrics, check_public_api_query)
             ASSERT_EQ(index_to_count.rbegin()->first + 1, current_dimension_size);
         }
     }
+}
+
+TEST(metrics, validate_malformed_yaml)
+{
+    EXPECT_THROW(YAML::Load("rocprofiler-sdk:\n  counters: \"unclosed"), YAML::Exception);
+}
+
+TEST(metrics, validate_missing_top_key)
+{
+    auto error = counters::validateExtraCounterYAML(YAML::Load("wrong-key:\n  counters: []"));
+    EXPECT_TRUE(error.has_value());
+    EXPECT_NE(error->find("top-level"), std::string::npos);
+}
+
+TEST(metrics, validate_missing_counters)
+{
+    auto error = counters::validateExtraCounterYAML(YAML::Load("rocprofiler-sdk:\n  schema: 1"));
+    EXPECT_TRUE(error.has_value());
+}
+
+TEST(metrics, validate_missing_name)
+{
+    auto error = counters::validateExtraCounterYAML(YAML::Load(
+        "rocprofiler-sdk:\n  counters:\n  - definitions:\n    - architectures: [gfx942]"));
+    EXPECT_TRUE(error.has_value());
+}
+
+TEST(metrics, validate_empty_architectures)
+{
+    auto error = counters::validateExtraCounterYAML(YAML::Load(
+        "rocprofiler-sdk:\n  counters:\n  - name: T\n    definitions:\n    - architectures: "
+        "[]"));
+    EXPECT_TRUE(error.has_value());
+}
+
+TEST(metrics, validate_no_event_or_expr)
+{
+    auto error = counters::validateExtraCounterYAML(YAML::Load(
+        "rocprofiler-sdk:\n  counters:\n  - name: T\n    definitions:\n    - architectures: "
+        "[gfx942]"));
+    EXPECT_TRUE(error.has_value());
+}
+
+TEST(metrics, validate_event_needs_block)
+{
+    auto error = counters::validateExtraCounterYAML(
+        YAML::Load("rocprofiler-sdk:\n  counters:\n  - name: T\n    definitions:\n    - "
+                   "architectures: [gfx942]\n      event: E"));
+    EXPECT_TRUE(error.has_value());
+}
+
+TEST(metrics, validate_block_needs_event)
+{
+    auto error = counters::validateExtraCounterYAML(
+        YAML::Load("rocprofiler-sdk:\n  counters:\n  - name: T\n    definitions:\n    - "
+                   "architectures: [gfx942]\n      block: B"));
+    EXPECT_TRUE(error.has_value());
+}
+
+TEST(metrics, validate_valid_yaml)
+{
+    auto error = counters::validateExtraCounterYAML(
+        YAML::Load("rocprofiler-sdk:\n  counters:\n  - name: T\n    definitions:\n    - "
+                   "architectures: [gfx942]\n      expression: test"));
+    EXPECT_FALSE(error.has_value());
+}
+
+TEST(metrics, validate_duplicate_counter_same_arch)
+{
+    // Duplicate counter with same name and architecture should warn but not error
+    auto error = counters::validateExtraCounterYAML(YAML::Load(
+        "rocprofiler-sdk:\n  counters:\n  - name: DUP\n    definitions:\n    - architectures: "
+        "[gfx942]\n      expression: expr1\n  - name: DUP\n    definitions:\n    - architectures: "
+        "[gfx942]\n      expression: expr2"));
+    EXPECT_FALSE(error.has_value());  // Should not error, just warn
+}
+
+TEST(metrics, validate_duplicate_counter_different_arch)
+{
+    // Same counter name with different architectures should be valid
+    auto error = counters::validateExtraCounterYAML(YAML::Load(
+        "rocprofiler-sdk:\n  counters:\n  - name: MULTI\n    definitions:\n    - architectures: "
+        "[gfx906]\n      expression: expr1\n  - name: MULTI\n    definitions:\n    - "
+        "architectures: [gfx942]\n      expression: expr2"));
+    EXPECT_FALSE(error.has_value());
 }

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/CMakeLists.txt
@@ -36,3 +36,19 @@ rocprofiler_add_integration_validate_test(
     TIMEOUT 45
     LABELS "integration-tests"
     FIXTURES_REQUIRED rocprofv3-test-counter-collection-txt-pmc1-extra-counters)
+
+# Test that invalid YAML files cause rocprofv3 to fail with error
+foreach(invalid_yaml malformed missing_root missing_counters missing_name empty_arch
+                     no_event_expr event_no_block block_no_event)
+    rocprofiler_add_integration_execute_test(
+        rocprofv3-test-extra-counters-invalid-${invalid_yaml}
+        COMMAND
+            $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -i
+            ${CMAKE_CURRENT_BINARY_DIR}/input.txt -E
+            ${CMAKE_CURRENT_BINARY_DIR}/invalid_${invalid_yaml}.yaml --
+            $<TARGET_FILE:vector-ops>
+        DEPENDS vector-ops COPY invalid_${invalid_yaml}.yaml
+        TIMEOUT 10
+        LABELS "integration-tests"
+        WILL_FAIL TRUE)
+endforeach()

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/invalid_block_no_event.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/invalid_block_no_event.yaml
@@ -1,0 +1,8 @@
+rocprofiler-sdk:
+  counters:
+  - name: TEST
+    description: test
+    definitions:
+    - architectures:
+      - gfx942
+      block: SQ

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/invalid_empty_arch.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/invalid_empty_arch.yaml
@@ -1,0 +1,7 @@
+rocprofiler-sdk:
+  counters:
+  - name: TEST
+    description: test
+    definitions:
+    - architectures: []
+      expression: test

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/invalid_event_no_block.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/invalid_event_no_block.yaml
@@ -1,0 +1,8 @@
+rocprofiler-sdk:
+  counters:
+  - name: TEST
+    description: test
+    definitions:
+    - architectures:
+      - gfx942
+      event: SQ_WAVES

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/invalid_malformed.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/invalid_malformed.yaml
@@ -1,0 +1,6 @@
+rocprofiler-sdk:
+  counters:
+  - name: TEST
+    definitions
+    - architectures:
+      - gfx942

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/invalid_missing_counters.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/invalid_missing_counters.yaml
@@ -1,0 +1,2 @@
+rocprofiler-sdk:
+  counters-schema-version: 1

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/invalid_missing_name.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/invalid_missing_name.yaml
@@ -1,0 +1,7 @@
+rocprofiler-sdk:
+  counters:
+  - description: test counter
+    definitions:
+    - architectures:
+      - gfx942
+      expression: test

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/invalid_missing_root.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/invalid_missing_root.yaml
@@ -1,0 +1,7 @@
+wrong-key:
+  counters:
+  - name: TEST
+    definitions:
+    - architectures:
+      - gfx942
+      expression: test

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/invalid_no_event_expr.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/invalid_no_event_expr.yaml
@@ -1,0 +1,7 @@
+rocprofiler-sdk:
+  counters:
+  - name: TEST
+    description: test
+    definitions:
+    - architectures:
+      - gfx942


### PR DESCRIPTION
Rework of #4760 

## Motivation
Prevent `rocprofv3` from crashing or hanging when malformed or invalid extra-counter YAML is provided through `-E` / `--extra-counters`.
Invalid definitions now produce field-specific fatal diagnostics and terminate unsuccessfully without hanging.

## Technical Details

### YAML validation
Added `validate_extra_counter_yaml()` to validate custom counter definitions before ingestion.
Validation covers:
- Required `rocprofiler-sdk` map and `counters` sequence.
- Optional `counters-schema-version`; when present, only version `1` is accepted.
- Required, non-empty counter names and scalar descriptions.
- Required, non-empty definitions and architecture lists.
- Exactly one counter form:
  - Derived counter: non-empty `expression`.
  - Hardware counter: non-empty `block` and unsigned integer `event`.
- Rejection of mixed derived and hardware fields.
- Type safety for every field later converted with `YAML::Node::as()`.

### Duplicate definitions
Counter identity is defined by `(name, architecture)`:
- Identical definitions are ignored with a warning.
- Conflicting definitions are rejected with a fatal diagnostic.
- The same counter name may have different definitions for different architectures.


## JIRA ID

AIPROFSDK-22

## Test Plan

### Unit tests
The metrics unit suite includes exhaustive validation coverage for missing fields, incorrect types, empty values, schema versions, hardware/derived exclusivity, and canonical documented YAML.
```shell
ctest -R "^unit\.metrics\."
```

### Integration tests
Representative end-to-end cases cover:
- Malformed YAML parser failure.
- Missing-description structural validation failure.
- Mixed hardware/derived semantic failure.
- Conflicting duplicate loader failure.
- Canonical extra-counter collection.
- Identical duplicate warning and successful collection.
The failure-test wrapper verifies:
- A nonzero process result.
- The expected field-specific diagnostic.
- Completion within the timeout.

## Test Result
All new and existing tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
