### PR TITLE
[kpack] Drop per-target deps from family device wheel METADATA

### DIFF
--- a/shared/kpack/python/rocm_kpack/wheel_splitter.py
+++ b/shared/kpack/python/rocm_kpack/wheel_splitter.py
@@ -342,6 +342,12 @@ def generate_device_metadata(
         f"Requires-Dist: {host_identity.name} == {host_identity.version}",
     ]
     for dep in device_requires_dist:
+        if "@GFXARCH@" in dep and bundle.level != rocm_bootstrap.PackagingLevel.TARGET:
+            # `@GFXARCH@` deps name per-target packages (e.g.
+            # rocm-sdk-device-<target>) which are only published for
+            # PackagingLevel.TARGET bundles. Family/sub-family device wheels
+            # are co-installed with a target wheel that carries those deps.
+            continue
         expanded = dep.replace("@GFXARCH@", bundle_key)
         lines.append(f"Requires-Dist: {expanded}")
     return "\n".join(lines) + "\n"

--- a/shared/kpack/tests/test_wheel_splitter.py
+++ b/shared/kpack/tests/test_wheel_splitter.py
@@ -278,6 +278,37 @@ class TestGenerateDeviceMetadata:
         )
         assert "Requires-Dist: some-dep-gfx1100 >= 2.0" in metadata
 
+    def test_gfxarch_dep_dropped_for_family(self):
+        # @GFXARCH@-templated deps name per-target packages (e.g.
+        # rocm-sdk-device-<target>) which only exist for TARGET-level
+        # bundles. Family/sub-family device wheels are co-installed with a
+        # target wheel that already carries those deps, so the line must be
+        # dropped here.
+        identity = WheelIdentity(
+            name="torch",
+            version="2.10.0+rocm7.13",
+            python_tag="cp313",
+            abi_tag="cp313",
+            platform_tag="manylinux_2_28_x86_64",
+            dist_info_name="torch-2.10.0+rocm7.13.dist-info",
+        )
+        family_metadata = generate_device_metadata(
+            identity,
+            "gfx11",
+            "amd-torch-device",
+            ["rocm-sdk-device-@GFXARCH@ == 7.13", "static-dep == 1.0"],
+        )
+        assert "rocm-sdk-device" not in family_metadata
+        assert "Requires-Dist: static-dep == 1.0" in family_metadata
+
+        sub_family_metadata = generate_device_metadata(
+            identity,
+            "gfx12_0",
+            "amd-torch-device",
+            ["rocm-sdk-device-@GFXARCH@ == 7.13"],
+        )
+        assert "rocm-sdk-device" not in sub_family_metadata
+
 
 class TestArchToBundleKey:
     def test_bare_arch(self):


### PR DESCRIPTION
## Motivation

The published `amd-torch-device-<family>` wheels declare a `Requires-Dist`
against a `rocm-sdk-device-<family>` package that is never built. From the
current staging index at https://rocm.devreleases.amd.com/whl-staging-multi-arch/:

```diff
 Name: amd-torch-device-gfx11
 ...
 Requires-Dist: torch == 2.10.0+devrocm7.13.0.dev0.6039b7c0...
-Requires-Dist: rocm-sdk-device-gfx11 == 7.13.0.dev0+6039b7c0...
```

`rocm-sdk-device-*` is only published per **target**
(`gfx1100`/`gfx1101`/.../`gfx1201`); there is no
`rocm-sdk-device-gfx11` or `rocm-sdk-device-gfx12-0`, so
`pip install amd-torch-device-gfx11` fails to resolve.

Root cause: `generate_device_metadata()` expands every entry in
`device_requires_dist` unconditionally, including `@GFXARCH@`-templated
deps, regardless of whether the bundle is a target, family, or sub-family.

## Technical Details

`rocm-sdk-device-*` is a per-target package, so the dep belongs only on
per-target device wheels. Configure `generate_device_metadata()` so that
`@GFXARCH@`-templated entries in `device_requires_dist` are emitted only
when the bundle is `PackagingLevel.TARGET`, and skipped for family /
sub-family bundles. Per-target device wheels still get their
`rocm-sdk-device-<target>` line; family and sub-family wheels get no
`rocm-sdk-device-*` line at all.

| device wheel | `bundle.level` | `rocm-sdk-device-...` line |
| --- | --- | --- |
| `amd-torch-device-gfx1100` | `TARGET` | **kept** (`rocm-sdk-device-gfx1100`) |
| `amd-torch-device-gfx11` | `FAMILY` | **dropped** |
| `amd-torch-device-gfx12-0` | `SUB_FAMILY` | **dropped** |

This is safe for the host `torch` wheel as this only emits per-target extras and
no `gfx11`/`gfx12-0` extras), and each target extra pulls both the target and
the family device wheel via the packaging chain. Hence, `pip install torch[gfx1100]` resolves:

```
torch[gfx1100]
  -> amd-torch-device-gfx1100  -> rocm-sdk-device-gfx1100
  -> amd-torch-device-gfx11     (now resolves on its own, no rocm-sdk-device-gfx11 lookup)
```

## Test Plan

Two unit tests in `shared/kpack/tests/test_wheel_splitter.py`:

- `test_with_device_requires_dist` (existing, `gfx942` target) asserts
  `rocm-sdk-device-gfx942` *is* in the generated metadata.
- `test_gfxarch_dep_dropped_for_family` (new, `gfx11` family and
  `gfx12_0` sub-family) asserts `rocm-sdk-device` is *not* in the
  generated metadata and that non-templated deps still pass through.

Run:

```
cd shared/kpack && \
  python -m pytest tests/test_wheel_splitter.py::TestGenerateDeviceMetadata
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.