### PR TITLE
[rocshmem] Add extern C reduce wrappers for Triton bitcode integration

### DIFF
--- a/projects/rocshmem/src/device/rocshmem_wrapper.cc
+++ b/projects/rocshmem/src/device/rocshmem_wrapper.cc
@@ -513,4 +513,27 @@ WRAP_WAIT(unsigned long, ulong)
 WRAP_WAIT(unsigned long long, ulonglong)
 WRAP_WAIT(uint64_t, uint64)
 
+// Only support reduce on team = 0 (ROCSHMEM_TEAM_WORLD)
+#define WRAP_REDUCE_OP(T, TNAME, OP)                                           \
+  ROCSHMEM_DEVICE_API int rocshmem_##TNAME##_##OP##_reduce_wg(                 \
+      int team, T *dest, const T *source, int nreduce) {                       \
+    if (team != 0) return rocshmem::ROCSHMEM_ERROR;                            \
+    return rocshmem::rocshmem_ctx_##TNAME##_##OP##_reduce_wg(                  \
+        rocshmem::ROCSHMEM_CTX_DEFAULT,                                        \
+        rocshmem::device::ROCSHMEM_TEAM_WORLD, dest, source, nreduce);         \
+  }
+
+#define WRAP_REDUCE_ARITH(T, TNAME)                                            \
+  WRAP_REDUCE_OP(T, TNAME, sum)                                                \
+  WRAP_REDUCE_OP(T, TNAME, min)                                                \
+  WRAP_REDUCE_OP(T, TNAME, max)                                                \
+  WRAP_REDUCE_OP(T, TNAME, prod)
+
+WRAP_REDUCE_ARITH(short, short)
+WRAP_REDUCE_ARITH(int, int)
+WRAP_REDUCE_ARITH(long, long)
+WRAP_REDUCE_ARITH(long long, longlong)
+WRAP_REDUCE_ARITH(float, float)
+WRAP_REDUCE_ARITH(double, double)
+
 }

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -92,7 +92,7 @@ namespace device {
     extern "C" __constant__ rocshmem_team_t
     __attribute__((visibility("default"))) ROCSHMEM_TEAM_WORLD = nullptr;
     extern "C" __constant__ rocshmem_team_t
-    __attribute__((visibility("default"))) ROCSHMEM_TEAM_SHARED = nullptr;
+    __attribute__((visibility("default"), used)) ROCSHMEM_TEAM_SHARED = nullptr;
 }
 
 #if defined(ENABLE_IPC_BITCODE)

--- a/projects/rocshmem/tests/functional_tests/device_bitcode_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/device_bitcode_tester.cpp
@@ -417,6 +417,40 @@ void DeviceBitcodeTester::execute() {
 
   rocshmem_barrier_all();
 
+  { // test_int_sum_reduce: source[i]=1 on every PE, expect dest[i]==n_pes
+    constexpr int COUNT = 4;
+    int* sym_src = static_cast<int*>(rocshmem_malloc(COUNT * sizeof(int)));
+    int* sym_dst = static_cast<int*>(rocshmem_malloc(COUNT * sizeof(int)));
+    for (int i = 0; i < COUNT; i++) {
+      sym_src[i] = 1;
+      sym_dst[i] = 0;
+    }
+    rocshmem_barrier_all();
+
+    int nreduce = COUNT;
+    int team = 0;
+    void* kargs[] = {&sym_dst, &sym_src, &nreduce, &team};
+    launch("test_int_sum_reduce", kargs);
+    rocshmem_barrier_all();
+
+    bool pass = true;
+    for (int i = 0; i < COUNT; i++) {
+      if (sym_dst[i] != n_pes) {
+        printf("[PE %d] test_int_sum_reduce: [%d] got=%d expect=%d FAIL\n",
+               my_pe, i, sym_dst[i], n_pes);
+        pass = false;
+      }
+    }
+    if (pass)
+      printf("[PE %d] test_int_sum_reduce: %d elements OK PASS\n", my_pe, COUNT);
+    if (!pass) all_pass = false;
+
+    rocshmem_free(sym_src);
+    rocshmem_free(sym_dst);
+  }
+
+  rocshmem_barrier_all();
+
   if (my_pe == 0)
     printf("\n=== %s ===\n",
            all_pass ? "ALL TESTS PASSED" : "SOME TESTS FAILED");

--- a/projects/rocshmem/tests/functional_tests/device_bitcode_tester_kernel.hip
+++ b/projects/rocshmem/tests/functional_tests/device_bitcode_tester_kernel.hip
@@ -39,6 +39,7 @@ extern "C" {
   __device__ int rocshmem_n_pes();
   __device__ void rocshmem_barrier_all();
   __device__ void rocshmem_barrier_all_wave();
+  __device__ int rocshmem_int_sum_reduce_wg(int team, int *dest, const int *source, int nreduce);
   __device__ void rocshmem_quiet();
 
   __device__ void rocshmem_putmem(void*, const void*, size_t, int);
@@ -264,4 +265,12 @@ extern "C" __global__ void test_typed_wait_vector(
 
     *out_idx = 1;
   }
+}
+
+// All threads in the workgroup participate in the wg collective.
+// Source is pre-filled by the host (1 per PE); expected dest = n_pes after sum.
+extern "C" __global__ void test_int_sum_reduce(
+    int *sym_dest, int *sym_src, int nreduce, int team)
+{
+  rocshmem_int_sum_reduce_wg(team, sym_dest, sym_src, nreduce);
 }


### PR DESCRIPTION
## Motivation

Enable PyTorch/Triton kernels to call rocSHMEM reduce collectives.

## Technical Details

- Add extern C wrappers for rocshmem_type_op_reduce_wg. Each wrapper delegates to  using ROCSHMEM_CTX_DEFAULT and ROCSHMEM_TEAM_WORLD
- Add attribute `used` so Triton's LinkOnlyNeeded option does not strip the symbol before rocshmem_hipmodule_init can reference it
- Add test_int_sum_reduce wrapper test

## JIRA ID

## Test Plan

test_int_sum_reduce test in device_bitcode_tester

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


Made-with: Cursor