### PR TITLE
hipFile: Add a CLAUDE.md file to project root

### DIFF
--- a/projects/hipfile/CLAUDE.md
+++ b/projects/hipfile/CLAUDE.md
@@ -1,0 +1,25 @@
+Please consider the following for easier retrieval of hipFile project data:
+hipFile is located at projects/hipfile
+hipFile CI is located at .github/workflows/hipfile-*.yml
+hipFile Python bindings are located at projects/hipfile/python
+
+hipFile C Library
+- Use projects/hipfile/build as the build directory
+- Configure using `cmake -DCMAKE_CXX_COMPILER=amdclang++ ..`
+- CMake build with `cmake --build . --parallel`
+- Run unit tests from the build directory with `ctest -V -L "unit"`
+- System & Stress tests may not work on all systems
+- hipFile C Header to be found at projects/hipfile/include
+- hipFile C library to be found at projects/hipfile/build/src/amd_detail
+- projects/hipfile/util/format-source.sh is a clang-format wrapper for linting. Optionally takes the clang toolchain major version as an arg.
+
+hipFile Python Bindings
+- Uses Cython (see _chipfile.pxd & _hipfile.pyx)
+- Locally, I have a Python venv setup at .venv. Please consider it if needing to test the Python code
+- If needing to perform an install step for the Python bindings for test purposes, install it as an editable package within the .venv context
+- Built by `scikit-build-core`
+- If building/installing, be aware that the include & library paths for hipFile may need to be explicitly provided. In this case, use the following as a basis for your decision: 
+  1. First, try `pip install -e python` — the CMakeLists.txt specifies sane defaults
+  2. If that fails, add explicit paths: `pip install -e python -Ccmake.define.HIPFILE_INCLUDE_DIR=../include -Ccmake.define.HIPFILE_LIBRARY=../build/src/amd_detail -Ccmake.define.HIP_INCLUDE_DIR=/opt/rocm/include`
+  3. Assumes CWD is projects/hipfile
+- The Python code here uses a combination of 'pylint' and 'black' for linting


### PR DESCRIPTION
A team shared Claude file to assist Claude with navigating the hipFile project. For complete effect, a Claude Memory Reference & Path-scoped rule need to be manually created to ensure this Claude file is automatically read for new conversation/plans/changes/etc.

### 1. Path-scoped rule (automatic during development)
Create the file .claude/rules/hipfile.md in the repo root:
```
---
globs: projects/hipfile/**
---

@projects/hipfile/CLAUDE.md
```
This tells Claude Code to automatically load `projects/hipfile/CLAUDE.md` into context whenever it works with files under `projects/hipfile/`. No manual action needed — the system handles it.


### 2. Memory reference (conversational recall)
Create two files under your user-level memory directory at `~/.claude/projects/&lt;project-path&gt;/memory/`:
#### `MEMORY.md` (index file): 
```
- [hipFile CLAUDE.md location](reference_hipfile_claude_md.md) -- project-specific CLAUDE.md at projects/hipfile/CLAUDE.md
```

#### `reference_hipfile_claude_md.md` (the memory entry):
```
---
name: hipFile CLAUDE.md location
description: Location of the project-specific CLAUDE.md for hipFile
type: reference
---

The hipFile project has its own CLAUDE.md at projects/hipfile/CLAUDE.md with build, test, and lint instructions for both the C library and Python bindings.
```
This lets Claude recall where hipFile instructions live during planning or Q&amp;A conversations, even before any hipFile files are opened.

### When each kicks in
Scenario | Rule | Memory
-- | -- | --
Editing/reading hipFile code | Auto-loaded | Not needed
Asking about hipFile (no files open) | May not trigger | Claude recalls and reads it
Planning hipFile work | May not trigger yet | Gets Claude oriented early

<!--EndFragment-->
</body>
</html>
