### PR TITLE
[rocprofiler-sdk] Select profiler ioctl at runtime

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.cpp
@@ -49,10 +49,22 @@ get_profiler_ioctl_request()
         kfd_ioctl_get_version_args args = {};
         if(ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_GET_VERSION, &args) != 0)
         {
-            return static_cast<unsigned long>(AMDKFD_IOC_PROFILER);
+            auto err      = errno;
+            auto fallback = static_cast<unsigned long>(AMDKFD_IOC_PROFILER);
+            ROCP_INFO << fmt::format("KFD version query failed (error: {}); using fallback "
+                                     "profiler ioctl request {:#x}.",
+                                     strerror(err),
+                                     fallback);
+            return fallback;
         }
 
-        return get_profiler_ioctl_request_for_version(args.major_version, args.minor_version);
+        auto selected =
+            get_profiler_ioctl_request_for_version(args.major_version, args.minor_version);
+        ROCP_INFO << fmt::format("KFD version {}.{} detected; using profiler ioctl request {:#x}.",
+                                 args.major_version,
+                                 args.minor_version,
+                                 selected);
+        return selected;
     }();
 
     return request;
@@ -119,9 +131,11 @@ counter_collection_device_lock(const rocprofiler_agent_t* agent, bool all_queues
                 return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_ABI;
             default:
                 ROCP_WARNING << fmt::format(
-                    "Failed to lock device {}. PMC Counters may be inaccurate and System Counter "
+                    "Failed to lock device {} (error: {}). PMC Counters may be "
+                    "inaccurate and System Counter "
                     "Collection will be degraded.",
-                    agent->id.handle);
+                    agent->id.handle,
+                    strerror(err));
                 return ROCPROFILER_STATUS_ERROR;
         }
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.cpp
@@ -32,12 +32,50 @@ namespace rocprofiler
 {
 namespace counters
 {
+namespace
+{
+constexpr uint32_t mainline_profiler_ioctl_nr = 0x28;
+
+unsigned long
+get_mainline_profiler_ioctl_request()
+{
+    return AMDKFD_IOWR(mainline_profiler_ioctl_nr, struct kfd_ioctl_profiler_args);
+}
+
+unsigned long
+get_profiler_ioctl_request()
+{
+    static auto request = []() {
+        kfd_ioctl_get_version_args args = {};
+        if(ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_GET_VERSION, &args) != 0)
+        {
+            return static_cast<unsigned long>(AMDKFD_IOC_PROFILER);
+        }
+
+        return get_profiler_ioctl_request_for_version(args.major_version, args.minor_version);
+    }();
+
+    return request;
+}
+}  // namespace
+
+unsigned long
+get_profiler_ioctl_request_for_version(uint32_t major_version, uint32_t minor_version)
+{
+    if(major_version > 1 || (major_version == 1 && minor_version >= 23))
+    {
+        return get_mainline_profiler_ioctl_request();
+    }
+
+    return AMDKFD_IOC_PROFILER;
+}
+
 bool
 counter_collection_has_device_lock()
 {
     kfd_ioctl_profiler_args args = {};
     args.op                      = KFD_IOC_PROFILER_VERSION;
-    int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PROFILER, &args);
+    int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), get_profiler_ioctl_request(), &args);
     if(ret == 0)
     {
         return true;
@@ -55,24 +93,25 @@ counter_collection_device_lock(const rocprofiler_agent_t* agent, bool all_queues
     args.pmc.lock                = 1;
     args.pmc.perfcount_enable    = all_queues ? 1 : 0;
 
-    int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PROFILER, &args);
+    int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), get_profiler_ioctl_request(), &args);
     if(ret != 0)
     {
-        switch(ret)
+        auto err = errno;
+        switch(err)
         {
-            case -EBUSY:
+            case EBUSY:
                 ROCP_WARNING << fmt::format(
                     "Device {} has a profiler attached to it. PMC Counters may be inaccurate.",
                     agent->id.handle);
                 return ROCPROFILER_STATUS_ERROR_OUT_OF_RESOURCES;
-            case -EPERM:
+            case EPERM:
                 ROCP_WARNING << fmt::format(
                     "Device {} could not be locked for profiling due to lack of permissions "
                     "(capability SYS_PERFMON). PMC Counters may be inaccurate and System Counter "
                     "Collection will be degraded.",
                     agent->id.handle);
                 return ROCPROFILER_STATUS_ERROR_PERMISSION_DENIED;
-            case -EINVAL:
+            case EINVAL:
                 ROCP_WARNING << fmt::format(
                     "Driver/Kernel version does not support locking device {}. PMC Counters may be "
                     "inaccurate and System Counter Collection will be degraded.",
@@ -100,7 +139,7 @@ counter_collection_device_unlock(const rocprofiler_agent_t* agent)
     args.pmc.lock                = 0;
     args.pmc.perfcount_enable    = 0;
 
-    int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PROFILER, &args);
+    int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), get_profiler_ioctl_request(), &args);
     if(ret != 0)
     {
         auto err = errno;
@@ -118,7 +157,7 @@ ptl_control_supported()
 {
     kfd_ioctl_profiler_args args = {};
     args.op                      = KFD_IOC_PROFILER_VERSION;
-    int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PROFILER, &args);
+    int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), get_profiler_ioctl_request(), &args);
     return (ret == 0);
 }
 
@@ -138,7 +177,7 @@ counter_collection_ptl_disable(const rocprofiler_agent_t* agent)
     args.ptl.gpu_id              = agent->gpu_id;
     args.ptl.enable              = 0;
 
-    int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PROFILER, &args);
+    int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), get_profiler_ioctl_request(), &args);
     if(ret != 0)
     {
         auto err = errno;
@@ -161,7 +200,7 @@ counter_collection_ptl_enable(const rocprofiler_agent_t* agent)
     args.ptl.gpu_id              = agent->gpu_id;
     args.ptl.enable              = 1;
 
-    int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PROFILER, &args);
+    int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), get_profiler_ioctl_request(), &args);
     if(ret != 0)
     {
         auto err = errno;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.hpp
@@ -24,10 +24,15 @@
 
 #include <rocprofiler-sdk/agent.h>
 
+#include <cstdint>
+
 namespace rocprofiler
 {
 namespace counters
 {
+unsigned long
+get_profiler_ioctl_request_for_version(uint32_t major_version, uint32_t minor_version);
+
 bool
 counter_collection_has_device_lock();
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/device_counting.cpp
@@ -25,9 +25,11 @@
 #include "lib/common/utility.hpp"
 #include "lib/rocprofiler-sdk/agent.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
+#include "lib/rocprofiler-sdk/counters/ioctl.hpp"
 #include "lib/rocprofiler-sdk/counters/metrics.hpp"
 #include "lib/rocprofiler-sdk/counters/tests/code_object_loader.hpp"
 #include "lib/rocprofiler-sdk/counters/tests/hsa_tables.hpp"
+#include "lib/rocprofiler-sdk/details/kfd_ioctl.h"
 #include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
 #include "lib/rocprofiler-sdk/registration.hpp"
@@ -645,6 +647,25 @@ protected:
 
 TEST_F(device_counting_service_test, sync_counters) { test_run(); }
 TEST_F(device_counting_service_test, async_counters) { test_run(ROCPROFILER_COUNTER_FLAG_ASYNC); }
+
+TEST(profiler_ioctl_request, version_1_22_uses_legacy_request)
+{
+    EXPECT_EQ(counters::get_profiler_ioctl_request_for_version(1, 22),
+              static_cast<unsigned long>(AMDKFD_IOC_PROFILER));
+}
+
+TEST(profiler_ioctl_request, version_1_23_uses_mainline_request)
+{
+    EXPECT_EQ(counters::get_profiler_ioctl_request_for_version(1, 23),
+              static_cast<unsigned long>(AMDKFD_IOWR(0x28, struct kfd_ioctl_profiler_args)));
+}
+
+TEST(profiler_ioctl_request, version_2_0_uses_mainline_request)
+{
+    EXPECT_EQ(counters::get_profiler_ioctl_request_for_version(2, 0),
+              static_cast<unsigned long>(AMDKFD_IOWR(0x28, struct kfd_ioctl_profiler_args)));
+}
+
 TEST_F(device_counting_service_test, sync_grbm_verify)
 {
     test_run(ROCPROFILER_COUNTER_FLAG_NONE, {"GRBM_COUNT"}, 50000);


### PR DESCRIPTION
## Summary
- Add runtime selection for the KFD PROFILER ioctl request number so rocprofiler-sdk can use the future mainline `0x28` request when the runtime KFD ioctl version is at least 1.23.
- Preserve the existing copied-header `AMDKFD_IOC_PROFILER` request (`0x86`) as the fallback for older kernels or failed version queries.
- Add unit coverage for the version-based request selection behavior.

## Motivation
This prepares rocprofiler-sdk for the upcoming mainline push of Perry's PROFILER ioctl change, where the ioctl number moves to `0x28`. Runtime selection is required because the deployed kernel may differ from the headers used to build rocprofiler-sdk.

## Changes
- `projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.cpp` - Adds cached runtime request selection via `AMDKFD_IOC_GET_VERSION`, computes `AMDKFD_IOWR(0x28, struct kfd_ioctl_profiler_args)` for KFD `>= 1.23`, and routes all PROFILER ioctl calls through the selected request. Also fixes the touched device-lock error path to switch on `errno` instead of libc `ioctl()`'s return value.
- `projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.hpp` - Adds the pure version-selection helper declaration used by tests.
- `projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/device_counting.cpp` - Adds tests for KFD versions `1.22`, `1.23`, and `2.0`.

## Testing
- Formatted changed files with `clang-format` 11.1.0 and verified with `clang-format --dry-run --Werror`.
- Verified whitespace with `git diff --check`.
- Deployed to `banff-ccs-aus-g05-05.cs-aus.dcgpu` in container `bewelton_mainline`.
- Configured rocprofiler-sdk in `/root/rocm-systems/projects/rocprofiler-sdk/build`.
- Built rocprofiler-sdk successfully with `cmake --build . --parallel $(nproc)`.
- Ran focused tests successfully: `./bin/counter-tests --gtest_filter=profiler_ioctl_request.*` (`3 passed`).

## Notes
- The initial deploy script's full dependency build failed in `rocr-runtime` while assembling a GFX12 trap handler. The rocprofiler-sdk build itself was then configured and built successfully in the deployed container against the installed ROCm stack.