### PR TITLE
[rocm-bootstrap] Add Windows GPU detection via clinfo

### DIFF
--- a/python/rocm-bootstrap/python/rocm_bootstrap/__init__.py
+++ b/python/rocm-bootstrap/python/rocm_bootstrap/__init__.py
@@ -2,7 +2,7 @@
 
 This package provides:
     - Canonical GFX target hierarchy (family/sub-family/target)
-    - Pure-Python GPU detection via Linux sysfs
+    - GPU detection via Linux sysfs (KFD topology) or ``clinfo`` (Windows)
     - Python dist-safe and module-safe naming APIs
     - WheelNext variant plugin for AMD GPU detection
 """

--- a/python/rocm-bootstrap/python/rocm_bootstrap/detect.py
+++ b/python/rocm-bootstrap/python/rocm_bootstrap/detect.py
@@ -1,14 +1,15 @@
 """GPU detection orchestration.
 
-Detects AMD GPUs on the current system by reading kernel sysfs interfaces.
+Detects AMD GPUs on the current system using platform-appropriate methods.
 All I/O is delegated to the :mod:`rocm_bootstrap._platform` module so that
-tests can monkeypatch it with fake sysfs content.
+tests can monkeypatch it with fake sysfs content and clinfo output.
 
 Detection chain:
     1. ``ROCM_BOOTSTRAP_DISABLE_DETECTION`` → return ``[]``
     2. ``ROCM_BOOTSTRAP_FORCE_GFX_ARCH`` → parse forced targets
     3. KFD topology (``/sys/class/kfd/kfd/topology/nodes/*/properties``)
-    4. Return empty list if KFD is not available
+    4. ``clinfo`` subprocess (Windows fallback)
+    5. Return empty list if no method succeeds
 """
 
 from __future__ import annotations
@@ -66,8 +67,13 @@ def detect_gpus() -> list[DetectedGpu]:
     if forced:
         return _parse_forced_targets(forced)
 
-    # 3. KFD topology (only supported detection method)
-    return _detect_via_kfd_topology()
+    # 3. KFD topology (Linux)
+    gpus = _detect_via_kfd_topology()
+    if gpus:
+        return gpus
+
+    # 4. clinfo subprocess (Windows fallback)
+    return _detect_via_clinfo()
 
 
 def detect_gfx_targets() -> list[GfxTarget]:
@@ -159,6 +165,43 @@ def _detect_via_kfd_topology() -> list[DetectedGpu]:
         )
 
     return gpus
+
+
+def _parse_clinfo_output(text: str) -> list[DetectedGpu]:
+    """Parse ``clinfo`` text output into DetectedGpu list.
+
+    Looks for ``Device Type: CL_DEVICE_TYPE_GPU`` blocks and extracts
+    the ``Name:`` field (which is the gfx target name, e.g. ``gfx1100``).
+    Devices with unrecognized target names are skipped.
+    """
+    gpus: list[DetectedGpu] = []
+    current_is_gpu = False
+    device_index = 0
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Device Type:"):
+            current_is_gpu = "CL_DEVICE_TYPE_GPU" in stripped
+        elif stripped.startswith("Name:") and current_is_gpu:
+            name = stripped.split(":", 1)[1].strip()
+            try:
+                target = lookup_target(name)
+            except ValueError:
+                current_is_gpu = False
+                continue
+            gpus.append(DetectedGpu(target=target, node_id=device_index))
+            device_index += 1
+            current_is_gpu = False
+
+    return gpus
+
+
+def _detect_via_clinfo() -> list[DetectedGpu]:
+    """Detect GPUs via ``clinfo`` subprocess output."""
+    text = _platform.run_clinfo()
+    if not text:
+        return []
+    return _parse_clinfo_output(text)
 
 
 # ---------------------------------------------------------------------------

--- a/python/rocm-bootstrap/python/rocm_bootstrap/tests/conftest.py
+++ b/python/rocm-bootstrap/python/rocm_bootstrap/tests/conftest.py
@@ -95,6 +95,50 @@ def kfd_gpu_properties(target: GfxTarget, device_id: int = 30000) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Realistic clinfo output template
+# ---------------------------------------------------------------------------
+
+_CLINFO_HEADER = """\
+Number of platforms:\t\t\t\t 1
+  Platform Profile:\t\t\t\t FULL_PROFILE
+  Platform Version:\t\t\t\t OpenCL 2.1 AMD-APP (3652.0)
+  Platform Name:\t\t\t\t AMD Accelerated Parallel Processing
+  Platform Vendor:\t\t\t\t Advanced Micro Devices, Inc.
+  Platform Extensions:\t\t\t\t cl_khr_icd cl_amd_event_callback
+
+
+  Platform Name:\t\t\t\t AMD Accelerated Parallel Processing
+"""
+
+_CLINFO_GPU_TEMPLATE = """\
+  Device Type:\t\t\t\t\t CL_DEVICE_TYPE_GPU
+  Vendor ID:\t\t\t\t\t 1002h
+  Board name:\t\t\t\t\t {board_name}
+  Device Topology:\t\t\t\t PCI[ B#{bus}, D#0, F#0 ]
+  Max compute units:\t\t\t\t 48
+  Name:\t\t\t\t\t\t {name}
+  Vendor:\t\t\t\t\t Advanced Micro Devices, Inc.
+  Device OpenCL C version:\t\t\t OpenCL C 2.0
+"""
+
+
+def clinfo_output(*targets: GfxTarget, board_name: str = "AMD GPU") -> str:
+    """Generate realistic clinfo output listing the given GPU targets."""
+    device_blocks = []
+    for i, target in enumerate(targets):
+        device_blocks.append(
+            _CLINFO_GPU_TEMPLATE.format(
+                name=target.name,
+                board_name=board_name,
+                bus=i + 1,
+            )
+        )
+    num_devices = len(targets)
+    header = _CLINFO_HEADER + f"Number of devices:\t\t\t\t {num_devices}\n"
+    return header + "".join(device_blocks)
+
+
+# ---------------------------------------------------------------------------
 # Platform patching helpers
 # ---------------------------------------------------------------------------
 
@@ -113,6 +157,7 @@ class FakePlatform:
     def __init__(self) -> None:
         self.kfd_nodes: dict[int, str] = {}  # node_id -> properties text
         self.env: dict[str, str] = {}
+        self.clinfo_output: str = ""
 
     def add_cpu_node(self, node_id: int) -> None:
         """Add a CPU-only KFD node."""
@@ -131,6 +176,10 @@ class FakePlatform:
         """Set a fake environment variable."""
         self.env[key] = value
 
+    def set_clinfo(self, output: str) -> None:
+        """Set fake ``clinfo`` subprocess output."""
+        self.clinfo_output = output
+
     def apply(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Monkeypatch _platform functions with this fake's state."""
         kfd_nodes = self.kfd_nodes
@@ -148,9 +197,13 @@ class FakePlatform:
         def fake_get_env(key: str) -> str | None:
             return env.get(key)
 
+        def fake_run_clinfo() -> str:
+            return self.clinfo_output
+
         monkeypatch.setattr(_platform, "list_kfd_nodes", fake_list_kfd_nodes)
         monkeypatch.setattr(_platform, "read_kfd_properties", fake_read_kfd_properties)
         monkeypatch.setattr(_platform, "get_env", fake_get_env)
+        monkeypatch.setattr(_platform, "run_clinfo", fake_run_clinfo)
 
 
 @pytest.fixture()

--- a/python/rocm-bootstrap/python/rocm_bootstrap/tests/test_detect.py
+++ b/python/rocm-bootstrap/python/rocm_bootstrap/tests/test_detect.py
@@ -1,13 +1,15 @@
 """Tests for rocm_bootstrap.detect — GPU detection via faked _platform I/O.
 
 Every test patches _platform functions through the FakePlatform fixture,
-injecting realistic sysfs content. No real filesystem access occurs.
+injecting realistic sysfs content and clinfo output. No real filesystem
+access or subprocess calls occur.
 """
 
 import pytest
 
 from rocm_bootstrap.detect import (
     DetectedGpu,
+    _parse_clinfo_output,
     _parse_kfd_properties,
     detect_gpus,
     detect_gfx_targets,
@@ -19,7 +21,7 @@ from rocm_bootstrap.targets import (
     lookup_target,
     parse_gfx_target_version,
 )
-from rocm_bootstrap.tests.conftest import FakePlatform
+from rocm_bootstrap.tests.conftest import FakePlatform, clinfo_output
 
 
 # ---------------------------------------------------------------------------
@@ -339,3 +341,139 @@ class TestCliMutualExclusion:
     def test_unique_and_verbose_conflict(self, fake_platform: FakePlatform):
         with pytest.raises(SystemExit):
             main(["--unique", "--verbose"])
+
+
+# ---------------------------------------------------------------------------
+# clinfo parser unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseClinfo:
+    def test_single_gpu(self):
+        gfx1100 = lookup_target("gfx1100")
+        text = clinfo_output(gfx1100, board_name="AMD Radeon PRO W7900")
+        gpus = _parse_clinfo_output(text)
+        assert len(gpus) == 1
+        assert gpus[0].target is gfx1100
+        assert gpus[0].node_id == 0
+
+    def test_two_identical_gpus(self):
+        gfx1100 = lookup_target("gfx1100")
+        text = clinfo_output(gfx1100, gfx1100, board_name="AMD Radeon PRO W7900")
+        gpus = _parse_clinfo_output(text)
+        assert len(gpus) == 2
+        assert all(g.target is gfx1100 for g in gpus)
+        assert gpus[0].node_id == 0
+        assert gpus[1].node_id == 1
+
+    def test_two_different_gpus(self):
+        gfx1100 = lookup_target("gfx1100")
+        gfx1151 = lookup_target("gfx1151")
+        text = clinfo_output(gfx1100, gfx1151)
+        gpus = _parse_clinfo_output(text)
+        assert len(gpus) == 2
+        assert gpus[0].target is gfx1100
+        assert gpus[1].target is gfx1151
+
+    def test_empty_output(self):
+        assert _parse_clinfo_output("") == []
+
+    def test_no_gpu_devices(self):
+        text = "Number of devices:\t\t 0\n"
+        assert _parse_clinfo_output(text) == []
+
+    def test_cpu_device_skipped(self):
+        text = (
+            "  Device Type:\t\t CL_DEVICE_TYPE_CPU\n"
+            "  Name:\t\t\t not_a_gpu\n"
+        )
+        assert _parse_clinfo_output(text) == []
+
+    def test_unknown_target_skipped(self):
+        text = (
+            "  Device Type:\t\t CL_DEVICE_TYPE_GPU\n"
+            "  Name:\t\t\t gfx_unknown_9999\n"
+        )
+        assert _parse_clinfo_output(text) == []
+
+    def test_unknown_target_does_not_break_subsequent(self):
+        gfx1100 = lookup_target("gfx1100")
+        text = (
+            "  Device Type:\t\t CL_DEVICE_TYPE_GPU\n"
+            "  Name:\t\t\t gfx_unknown_9999\n"
+            "  Device Type:\t\t CL_DEVICE_TYPE_GPU\n"
+            "  Name:\t\t\t gfx1100\n"
+        )
+        gpus = _parse_clinfo_output(text)
+        assert len(gpus) == 1
+        assert gpus[0].target is gfx1100
+        assert gpus[0].node_id == 0
+
+    @pytest.mark.parametrize("target", ALL_TARGETS, ids=lambda t: t.name)
+    def test_all_targets_parseable(self, target: GfxTarget):
+        text = clinfo_output(target)
+        gpus = _parse_clinfo_output(text)
+        assert len(gpus) == 1
+        assert gpus[0].target is target
+
+    def test_pci_id_not_set(self):
+        """clinfo does not provide KFD-style device_id, so pci_id is None."""
+        text = clinfo_output(lookup_target("gfx1100"))
+        gpus = _parse_clinfo_output(text)
+        assert gpus[0].pci_id is None
+
+
+# ---------------------------------------------------------------------------
+# clinfo detection integration (via detect_gpus fallback)
+# ---------------------------------------------------------------------------
+
+
+class TestClinfoFallback:
+    def test_clinfo_used_when_kfd_empty(self, fake_platform: FakePlatform):
+        """When KFD returns no GPUs, clinfo is tried as fallback."""
+        gfx1151 = lookup_target("gfx1151")
+        fake_platform.set_clinfo(clinfo_output(gfx1151))
+        gpus = detect_gpus()
+        assert len(gpus) == 1
+        assert gpus[0].target is gfx1151
+
+    def test_kfd_takes_precedence_over_clinfo(self, fake_platform: FakePlatform):
+        """When KFD detects GPUs, clinfo is not used."""
+        gfx942 = lookup_target("gfx942")
+        gfx1100 = lookup_target("gfx1100")
+        fake_platform.add_cpu_node(0)
+        fake_platform.add_gpu_node(1, gfx942)
+        # clinfo reports a different GPU — should be ignored
+        fake_platform.set_clinfo(clinfo_output(gfx1100))
+        gpus = detect_gpus()
+        assert len(gpus) == 1
+        assert gpus[0].target is gfx942
+
+    def test_clinfo_empty_returns_empty(self, fake_platform: FakePlatform):
+        """When both KFD and clinfo return nothing, result is empty."""
+        fake_platform.set_clinfo("")
+        assert detect_gpus() == []
+
+    def test_clinfo_with_env_disable(self, fake_platform: FakePlatform):
+        """Disable flag takes precedence over clinfo."""
+        fake_platform.set_clinfo(
+            clinfo_output(lookup_target("gfx1100"))
+        )
+        fake_platform.set_env("ROCM_BOOTSTRAP_DISABLE_DETECTION", "1")
+        assert detect_gpus() == []
+
+    def test_clinfo_two_gpus_via_detect(self, fake_platform: FakePlatform):
+        gfx1100 = lookup_target("gfx1100")
+        fake_platform.set_clinfo(
+            clinfo_output(gfx1100, gfx1100, board_name="AMD Radeon PRO W7900")
+        )
+        gpus = detect_gpus()
+        assert len(gpus) == 2
+        assert all(g.target is gfx1100 for g in gpus)
+
+    def test_clinfo_dedup_via_detect_gfx_targets(self, fake_platform: FakePlatform):
+        gfx1100 = lookup_target("gfx1100")
+        fake_platform.set_clinfo(clinfo_output(gfx1100, gfx1100))
+        targets = detect_gfx_targets()
+        assert len(targets) == 1
+        assert targets[0] is gfx1100


### PR DESCRIPTION
## Motivation

This allows rocm-bootstrap to work on Windows, which will help uv/pip select the correct device-specific rocm/torch/etc. python packages automatically.

See also:
* https://github.com/ROCm/TheRock/issues/4865
* https://github.com/ROCm/rocm-systems/issues/3975

## Technical Details

I considered other detection methods like running `hipinfo`, running `offload-arch`, or reading registry keys but decided to use `clinfo` since that is currently installed by the GPU driver in system32 and this code already had a `run_clinfo()` platform helper. The detection chain is now:
1. env overrides
2. KFD topology
3. clinfo
4. empty list

The clinfo `Name:` field seems to provide the gfx target name directly (e.g., `gfx1100`), so no marketing-name-to-target mapping should be needed.

## Test Plan

Added new unit tests and tested locally on a Windows system with 2x gfx1100 GPUs:

```
λ py -V:3.13 -m venv 3.13.venv && .\3.13.venv\Scripts\activate.bat
(3.13.venv) λ pip install -e D:\projects\TheRock\rocm-systems\python\rocm-bootstrap
(3.13.venv) λ rocm-bootstrap-detect --verbose
Detected 2 AMD GPU(s):

  Node 0: gfx1100  major=11 minor=0 stepping=0
    sub-family: gfx11_0 (RDNA3)
    family: gfx11 (RDNA3)  generic: gfx11-generic

  Node 1: gfx1100  major=11 minor=0 stepping=0
    sub-family: gfx11_0 (RDNA3)
    family: gfx11 (RDNA3)  generic: gfx11-generic

(3.13.venv) λ rocm-bootstrap-detect
gfx1100
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
