### PR TITLE
CLR: add in debug info when illegal mem access happens

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -41,6 +41,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cinttypes>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -3494,7 +3495,8 @@ device::Signal* Device::createIpcSignal() const { return new roc::IpcSignal(); }
 // ================================================================================================
 static std::string GetLocalHostName() {
 #if defined(__linux__)
-  char buf[HOST_NAME_MAX];
+  char buf[HOST_NAME_MAX + 1];
+  buf[HOST_NAME_MAX] = '\0';
   if (gethostname(buf, sizeof(buf)) == 0) return buf;
 #endif
   return "";
@@ -3506,6 +3508,7 @@ hsa_status_t Device::BackendErrorCallBackHandler(const hsa_amd_event_t* event, v
   switch (event->event_type) {
     case HSA_AMD_GPU_MEMORY_FAULT_EVENT: {
       gpu_error = CL_INVALID_MEM_OBJECT;
+      LogError("Memory Fault Error");
       std::string hostnameStr = GetLocalHostName();
       std::string host_tag = hostnameStr.empty() ? "" : "host: " + hostnameStr + ", ";
       for (auto* amd_dev : amd::Device::devices()) {

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -34,6 +34,11 @@
 #endif
 #endif
 
+#if defined(__linux__)
+#include <climits>
+#include <unistd.h>
+#endif
+
 #include <algorithm>
 #include <chrono>
 #include <cstring>
@@ -3487,12 +3492,22 @@ device::Signal* Device::createSignal() const { return new roc::Signal(); }
 device::Signal* Device::createIpcSignal() const { return new roc::IpcSignal(); }
 
 // ================================================================================================
+static std::string GetLocalHostName() {
+#if defined(__linux__)
+  char buf[HOST_NAME_MAX];
+  if (gethostname(buf, sizeof(buf)) == 0) return buf;
+#endif
+  return "";
+}
+
+// ================================================================================================
 hsa_status_t Device::BackendErrorCallBackHandler(const hsa_amd_event_t* event, void* data) {
   cl_int gpu_error = CL_SUCCESS;
   switch (event->event_type) {
     case HSA_AMD_GPU_MEMORY_FAULT_EVENT: {
       gpu_error = CL_INVALID_MEM_OBJECT;
-      LogError("Memory Fault Error");
+      std::string hostnameStr = GetLocalHostName();
+      std::string host_tag = hostnameStr.empty() ? "" : "host: " + hostnameStr + ", ";
       for (auto* amd_dev : amd::Device::devices()) {
         if (amd_dev->type() != CL_DEVICE_TYPE_GPU) continue;
         Device* roc_dev = reinterpret_cast<Device*>(amd_dev);
@@ -3504,7 +3519,13 @@ hsa_status_t Device::BackendErrorCallBackHandler(const hsa_amd_event_t* event, v
                                      HSA_AMD_QUEUE_INFO_VM_FAULT_STATUS,
                                      &faulted) == HSA_STATUS_SUCCESS &&
               faulted) {
-            vgpu->AnalyzeAqlQueue();
+            std::string kernelName = vgpu->AnalyzeAqlQueue();
+            const char* kname = kernelName.c_str();
+            ClPrint(amd::LOG_NONE, amd::LOG_ALWAYS,
+                    "Memory Fault Error [%sGPU index: %u, "
+                    "faulting addr: 0x%" PRIx64 ", kernel: %s]",
+                    host_tag.c_str(), roc_dev->index(),
+                    event->memory_fault.virtual_address, kname);
           }
         }
       }
@@ -3962,15 +3983,19 @@ cl_int ConvertHSAErrorIntoCLError(hsa_status_t hsa_status) {
 void callbackQueue(hsa_status_t status, hsa_queue_t* queue, void* data) {
   if (status != HSA_STATUS_SUCCESS && status != HSA_STATUS_INFO_BREAK) {
     Device* dev = reinterpret_cast<Device*>(data);
+    std::string hostnameStr = GetLocalHostName();
+    std::string host_tag = hostnameStr.empty() ? "" : "host: " + hostnameStr + ", ";
+    std::string kernelName;
     for (auto it : dev->vgpus()) {
       roc::VirtualGPU* vgpu = reinterpret_cast<roc::VirtualGPU*>(it);
       if (vgpu->gpu_queue() == queue) {
-        vgpu->AnalyzeAqlQueue();
+        kernelName = vgpu->AnalyzeAqlQueue();
       }
     }
     // Abort on device exceptions.
     const char* errorMsg = 0;
     Hsa::status_string(status, &errorMsg);
+    const char* kname = kernelName.c_str();
     if (status == HSA_STATUS_ERROR_OUT_OF_RESOURCES) {
       size_t global_available_mem = 0;
       if (HSA_STATUS_SUCCESS !=
@@ -3980,12 +4005,15 @@ void callbackQueue(hsa_status_t status, hsa_queue_t* queue, void* data) {
         LogError("HSA_AMD_AGENT_INFO_MEMORY_AVAIL query failed.");
       }
       ClPrint(amd::LOG_NONE, amd::LOG_ALWAYS,
-              "Callback: Queue %p Aborting with error : %s Code: 0x%x Available Free mem : %zu MB",
-              queue->base_address, errorMsg, status, global_available_mem / Mi);
+              "Callback: Queue %p Aborting with error : %s Code: 0x%x Available Free mem : %zu MB"
+              " [%sGPU index: %u, kernel: %s]",
+              queue->base_address, errorMsg, status, global_available_mem / Mi,
+              host_tag.c_str(), dev->index(), kname);
     } else {
       ClPrint(amd::LOG_NONE, amd::LOG_ALWAYS,
-              "Callback: Queue %p aborting with error : %s code: 0x%x", queue->base_address,
-              errorMsg, status);
+              "Callback: Queue %p aborting with error : %s code: 0x%x"
+              " [%sGPU index: %u, kernel: %s]",
+              queue->base_address, errorMsg, status, host_tag.c_str(), dev->index(), kname);
     }
 
     // Core dumps generally provide limited value for OOM or register overflow,

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1164,7 +1164,7 @@ std::string VirtualGPU::AnalyzeAqlQueue() const {
     auto printKernelName = [&](uint64_t kernel_object) {
       auto it = dev().KernelMap().find(kernel_object);
       if (it != dev().KernelMap().end()) {
-        kernelName = it->second.name();
+        kernelName = it->second.getDemangledName();
       } else {
         fprintf(stderr, "VGPU(%p) Queue(%p). Couldn't find kernel\n", this, gpu_queue_);
       }

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1131,7 +1131,8 @@ static inline void packet_store_release(uint32_t* packet, uint16_t header, uint1
 }
 
 // ================================================================================================
-void VirtualGPU::AnalyzeAqlQueue() const {
+std::string VirtualGPU::AnalyzeAqlQueue() const {
+  std::string kernelName = "<not identified>";
   const uint32_t queueSize = gpu_queue_->size;
   const uint32_t queueMask = queueSize - 1;
   uint64_t index = Hsa::queue_load_write_index_relaxed(gpu_queue_);
@@ -1152,7 +1153,7 @@ void VirtualGPU::AnalyzeAqlQueue() const {
     }
     if (valid_packet_idx == kAqlSearchWindow) {
       fprintf(stderr, "VGPU(%p) Queue(%p). Couldn't find the hang AQL packet!\n", this, gpu_queue_);
-      return;
+      return kernelName;
     }
     auto aql_loc = &(reinterpret_cast<hsa_kernel_dispatch_packet_t*>(
         gpu_queue_->base_address))[(read + valid_packet_idx) & queueMask];
@@ -1163,7 +1164,7 @@ void VirtualGPU::AnalyzeAqlQueue() const {
     auto printKernelName = [&](uint64_t kernel_object) {
       auto it = dev().KernelMap().find(kernel_object);
       if (it != dev().KernelMap().end()) {
-        fprintf(stderr, "Kernel Name: %s\n", it->second.name().c_str());
+        kernelName = it->second.name();
       } else {
         fprintf(stderr, "VGPU(%p) Queue(%p). Couldn't find kernel\n", this, gpu_queue_);
       }
@@ -1229,6 +1230,7 @@ void VirtualGPU::AnalyzeAqlQueue() const {
   } else {
     fprintf(stderr, "VGPU(%p) Queue(%p) is idle\n", this, gpu_queue_);
   }
+  return kernelName;
 }
 
 // ================================================================================================

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -19,6 +19,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <stack>
+#include <string>
 #include <thread>
 
 namespace amd::roc {
@@ -562,7 +563,7 @@ class VirtualGPU : public device::VirtualDevice {
   void startSchedulerQueueThread();
 
   //! Analyzes a crashed AQL queue to find a broken AQL packet.
-  //! Returns the faulting kernel name (empty if not found).
+  //! Returns the faulting kernel name ("<not identified>" if not found).
   std::string AnalyzeAqlQueue() const;
   bool ForceIrq() const { return force_irq_; }
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -561,8 +561,9 @@ class VirtualGPU : public device::VirtualDevice {
   //! Start the scheduler queue thread on first use
   void startSchedulerQueueThread();
 
-  //! Analyzes a crashed AQL queue to find a broken AQL packet
-  void AnalyzeAqlQueue() const;
+  //! Analyzes a crashed AQL queue to find a broken AQL packet.
+  //! Returns the faulting kernel name (empty if not found).
+  std::string AnalyzeAqlQueue() const;
   bool ForceIrq() const { return force_irq_; }
 
   //! SDMA engine affinity management


### PR DESCRIPTION
## Motivation                                                                                                                                                                                                              
                                                                                                                                                                                                                             
  GPU illegal memory access errors lack actionable context. In multi-node/multi-GPU environments it's hard to know which host, which GPU, or which kernel caused the fault. This PR adds hostname, GPU index, and kernel name
   to all GPU fault error messages in CLR.                                                                                                                                                                                   

  ## Technical Details                                             

  Extended two fault paths in `rocdevice.cpp`:         
    
  - **Queue exception (`callbackQueue`)**: appends `[host: <h>, GPU index: <n>, kernel: <name>]` to the existing `Callback: Queue ... aborting` message. The faulting queue is identified directly from the `hsa_queue_t*`   
  callback parameter.                                              
  - **VM page fault (`BackendErrorCallBackHandler`)**: same additions to the `Memory Fault Error` message. Uses `hsa_amd_queue_get_info(..., HSA_AMD_QUEUE_INFO_VM_FAULT_STATUS, ...)` (added by #4705) to identify which    
  vgpu queue faulted, since the `HSA_AMD_GPU_MEMORY_FAULT_EVENT` callback does not carry queue identity.      
    
  Kernel name is resolved in `AnalyzeAqlQueue()` (return type changed `void` → `std::string`) via CLR's `KernelMap`. Returns `"<not identified>"` if the queue is idle, the AQL scan is exhausted, or the kernel object is   
  not in the map.                                                  

  Hostname is Linux-only (`gethostname` / `HOST_NAME_MAX`). On other platforms the `host:` field is omitted from the message entirely. HIP on Windows uses the PAL backend; multi-node GPU clusters are a Linux-only         
  deployment so hostname adds no value there.

  Both fault paths use `ClPrint(amd::LOG_NONE, amd::LOG_ALWAYS, ...)`, consistent with the rest of `callbackQueue`, and print unconditionally regardless of `AMD_LOG_LEVEL`.                                                 
    
  No performance impact: `AnalyzeAqlQueue()` is only called from error-handling paths that are already aborting or returning an error.                                                                                       
                                                                   
  ## JIRA ID                                           
                                                                   
  ROCM-23771                                           
                                                                   
  ## Test Plan

  Two test cases on gfx1201 (RX 9070 XT) with `LD_PRELOAD` of the patched `libamdhip64.so`:                   
    
  - PyTorch out-of-bounds tensor index (queue exception / `HSA_STATUS_ERROR_EXCEPTION`)                       
  - HIP null-pointer kernel write (VM page fault / `HSA_STATUS_ERROR_MEMORY_FAULT`)

  ## Test Result                                                   

  Both cases pass. Example output:                                 

  **Case 1 — PyTorch OOB index (`x[:, mask] = y[:, indices]`, index 100 OOB for size-10 tensor):**            
  :0:rocdevice.cpp:4013: ... Callback: Queue 0x... aborting with error : HSA_STATUS_ERROR_EXCEPTION: An HSAIL operation resulted in a hardware exception. code: 0x1016 [host: sunhmy-desktop, GPU index: 0, kernel:
  _ZN2at6native24index_elementwise_kernelILi128ELi4E...]                                                      
                                                                   
  **Case 2 — HIP null-pointer write (`illegal_access_kernel`):**                                              
  :0:rocdevice.cpp:4013: ... Callback: Queue 0x... aborting with error : HSA_STATUS_ERROR_MEMORY_FAULT: Agent attempted to access an inaccessible address. code: 0x2b [host: sunhmy-desktop, GPU index: 0, kernel:
  _Z21illegal_access_kernelPi]                         
                               
  ## Submission Checklist                              

  - [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.