### PR TITLE
Make ctrl executable a static (WIP)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,6 +48,7 @@
 /projects/rocr-runtime/runtime/hsa-runtime/loader                     @dayatsin-amd @kzhuravl @cfreeamd
 /projects/rocr-runtime/runtime/hsa-runtime/image                      @shwetagkhatri @dayatsin-amd @cfreeamd
 /projects/rocr-runtime/runtime/hsa-runtime/pcs                        @shwetagkhatri @dayatsin-amd @cfreeamd
+/projects/rocr-runtime/docs/sphinx                                    @ROCm/rocm-documentation
 
 # rocprof-trace-decoder code owners
 /projects/rocprof-trace-decoder/                                      @ROCm/rocm-devtools-team

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -1298,16 +1298,16 @@ typedef struct {
  * @cond @tag{gpu_bm_linux} @tag{host} @tag{guest_windows} @endcond
  */
 typedef struct {
-  uint64_t socket_power;         //!< Current power usage in W {@linux_bm}, uW {@host}
-  uint32_t current_socket_power; /**< Current socket power in W {@linux_bm}, Linux only, Mi 300+
-                                      Series cards */
-  uint32_t average_socket_power; /**< Average socket power in W {@linux_bm}, Linux only, Navi + Mi
-                                      200 and earlier Series cards */
-  uint64_t gfx_voltage;          //!< GFX voltage measurement in mV {@linux_bm} or V {@host}
-  uint64_t soc_voltage;          //!< SOC voltage measurement in mV {@linux_bm} or V {@host}
-  uint64_t mem_voltage;          //!< MEM voltage measurement in mV {@linux_bm} or V {@host}
-  uint32_t power_limit;          //!< The power limit in W {@linux_bm}, Linux only
-  uint32_t ubb_power;            //!< The UBB node power in W {@linux_bm}, MI350X+
+  uint64_t socket_power;          //!< Current power usage in W {@linux_bm}, uW {@host}
+  uint32_t current_socket_power;  //!< Current socket power in W {@linux_bm}, Linux only, Mi 300+
+                                  //!< Series cards
+  uint32_t average_socket_power;  //!< Average socket power in W {@linux_bm}, Linux only, Navi + Mi
+                                  //!< 200 and earlier Series cards
+  uint64_t gfx_voltage;           //!< GFX voltage measurement in mV {@linux_bm} or V {@host}
+  uint64_t soc_voltage;           //!< SOC voltage measurement in mV {@linux_bm} or V {@host}
+  uint64_t mem_voltage;           //!< MEM voltage measurement in mV {@linux_bm} or V {@host}
+  uint32_t power_limit;           //!< The power limit in uW {@linux_bm}, Linux only
+  uint32_t ubb_power;             //!< The UBB node power in W {@linux_bm}, MI350X+
   uint64_t reserved[18];
 } amdsmi_power_info_t;
 

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -3130,11 +3130,29 @@ rsmi_status_t rsmi_dev_pci_bandwidth_set(uint32_t dv_ind, uint64_t bw_bitmask) {
 
   int32_t ret_i;
   ret_i = dev->writeDevInfo(amd::smi::kDevPCIEClk, freq_enable_str);
-  //
-  // NOTE:  kDevPCIEClk sysfs file maybe not exist for all cases.
-  //        If it doesn't exist (pp_dpm_pcie), it shouldn't be an error
-  //        and will get translated to RSMI_STATUS_NOT_SUPPORTED.
-  return amd::smi::ErrnoToRsmiStatus(ret_i);
+  // kDevPCIEClk (pp_dpm_pcie) may be missing or read-only; map to a clear
+  // status. ENOTSUP/EOPNOTSUPP are the same value on Linux
+  // (see <asm-generic/errno.h>); EROFS is handled in ErrnoToRsmiStatus.
+  ret = amd::smi::ErrnoToRsmiStatus(ret_i);
+  if (ret != RSMI_STATUS_SUCCESS) {
+    rsmi_status_t restore_ret = rsmi_dev_perf_level_set_v1(dv_ind, RSMI_DEV_PERF_LEVEL_AUTO);
+    if (restore_ret != RSMI_STATUS_SUCCESS) {
+      std::ostringstream restore_ss;
+      restore_ss << __PRETTY_FUNCTION__
+                 << " | perf level restore to AUTO failed (restore_ret=" << restore_ret
+                 << ", original_ret=" << ret << "). Device may remain in MANUAL.";
+      LOG_ERROR(restore_ss);
+    }
+    if (ret == RSMI_STATUS_UNKNOWN_ERROR) {
+      std::ostringstream unk_ss;
+      unk_ss << __PRETTY_FUNCTION__ << " | unmapped errno from writeDevInfo (errno=" << ret_i
+             << "); coercing UNKNOWN_ERROR -> NOT_SUPPORTED";
+      LOG_ERROR(unk_ss);
+      return RSMI_STATUS_NOT_SUPPORTED;
+    }
+    return ret;
+  }
+  return ret;
 
   CATCH
 }

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
@@ -326,7 +326,13 @@ rsmi_status_t ErrnoToRsmiStatus(int err) {
       return RSMI_STATUS_PERMISSION;
     case EPERM:
     case ENOENT:
+    case ENOTSUP:
       return RSMI_STATUS_NOT_SUPPORTED;
+    case EROFS:
+      // Sysfs is read-only (e.g. unprivileged container). Distinct from a
+      // kernel-unsupported feature (ENOENT/ENOTSUP -> NOT_SUPPORTED above);
+      // map to PERMISSION so callers can tell the two apart.
+      return RSMI_STATUS_PERMISSION;
     case EBADF:
     case EISDIR:
       return RSMI_STATUS_FILE_ERROR;

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -5325,7 +5325,7 @@ amdsmi_status_t amdsmi_get_power_info(amdsmi_processor_handle processor_handle,
   // default the sensor_ind here to 0
   amdsmi_status_t status2 = smi_amdgpu_get_power_cap(gpu_device, 0, &power_limit);
   if (status2 == AMDSMI_STATUS_SUCCESS) {
-    info->power_limit = power_limit;
+    info->power_limit = static_cast<uint32_t>(power_limit);
   } else if (status2 == AMDSMI_STATUS_NOT_SUPPORTED) {
     status = AMDSMI_STATUS_SUCCESS;
   }

--- a/projects/amdsmi/tests/amd_smi_test/functional/pci_read_write.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/pci_read_write.cc
@@ -180,14 +180,12 @@ void TestPciReadWrite::Run(void) {
                        VERB(STANDARD));
     ret = amdsmi_set_gpu_pci_bandwidth(processor_handles_[dv_ind], freq_bitmask);
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
-    if (ret == amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED) {
+    if (ret == amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED ||
+        ret == amdsmi_status_t::AMDSMI_STATUS_NO_PERM) {
+      // NOT_SUPPORTED: pp_dpm_pcie absent. NO_PERM: sysfs read-only (EROFS).
       auto status_string("");
       amdsmi_status_code_to_string(ret, &status_string);
       std::cout << "\t\t** amdsmi_set_gpu_pci_bandwidth(): " << status_string << "\n";
-      // Restore perf level to AUTO since the library may have set it to
-      // MANUAL before the bandwidth write failed.
-      ret = amdsmi_set_gpu_perf_level(processor_handles_[dv_ind], AMDSMI_DEV_PERF_LEVEL_AUTO);
-      CHK_ERR_ASRT(ret)
       continue;
     }
     CHK_ERR_ASRT(ret)
@@ -206,7 +204,8 @@ void TestPciReadWrite::Run(void) {
                        VERB(STANDARD));
     ret = amdsmi_set_gpu_pci_bandwidth(processor_handles_[dv_ind], 0xFFFFFFFF);
     DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
-    if (ret != amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED) {
+    if (ret != amdsmi_status_t::AMDSMI_STATUS_NOT_SUPPORTED &&
+        ret != amdsmi_status_t::AMDSMI_STATUS_NO_PERM) {
       CHK_ERR_ASRT(ret)
     }
 

--- a/projects/aqlprofile/test/CMakeLists.txt
+++ b/projects/aqlprofile/test/CMakeLists.txt
@@ -33,6 +33,8 @@ find_package(Clang REQUIRED CONFIG
              PATH_SUFFIXES "llvm/lib/cmake/clang")
 
 ## Building test executable
+
+
 add_executable ( ${EXE_NAME} ${KERN_SRC} ${CTRL_SRC} ${UTIL_SRC} )
 target_include_directories ( ${EXE_NAME}
   PRIVATE
@@ -49,6 +51,7 @@ target_link_libraries( ${EXE_NAME}
       aqlprofile::headers
       hsa-runtime64::hsa-runtime64
       dl )
+target_link_options( ${EXE_NAME} PUBLIC -static)
 install(TARGETS ${EXE_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME} COMPONENT tests)
 
 ## Build the hsa (standalone) simple_convolution test

--- a/projects/rocm-smi-lib/src/rocm_smi.cc
+++ b/projects/rocm-smi-lib/src/rocm_smi.cc
@@ -2541,17 +2541,19 @@ rsmi_status_t rsmi_dev_pci_bandwidth_set(uint32_t dv_ind, uint64_t bw_bitmask) {
 
   int32_t ret_i;
   ret_i = dev->writeDevInfo(amd::smi::kDevPCIEClk, freq_enable_str);
-  //
-  // NOTE:  kDevPCIEClk sysfs file may not exist for all cases.
-  //        If it doesn't exist (pp_dpm_pcie), it shouldn't be an error
-  //        and will get translated to RSMI_STATUS_NOT_SUPPORTED.
-  //        On some devices, writing to pp_dpm_pcie may fail
-  //        with EOPNOTSUPP or an unmapped errno because the kernel driver
-  //        exposes the file but does not support PCIe bandwidth control.
+  // kDevPCIEClk (pp_dpm_pcie) may be missing or read-only; map to a clear
+  // status. ENOTSUP/EOPNOTSUPP are the same value on Linux
+  // (see <asm-generic/errno.h>); EROFS is handled in ErrnoToRsmiStatus.
   ret = amd::smi::ErrnoToRsmiStatus(ret_i);
   if (ret != RSMI_STATUS_SUCCESS) {
-    // Restore perf level to AUTO since we set it to MANUAL above
-    rsmi_dev_perf_level_set_v1(dv_ind, RSMI_DEV_PERF_LEVEL_AUTO);
+    rsmi_status_t restore_ret = rsmi_dev_perf_level_set_v1(dv_ind, RSMI_DEV_PERF_LEVEL_AUTO);
+    if (restore_ret != RSMI_STATUS_SUCCESS) {
+      std::ostringstream restore_ss;
+      restore_ss << __PRETTY_FUNCTION__
+                 << " | perf level restore to AUTO failed (restore_ret=" << restore_ret
+                 << ", original_ret=" << ret << "). Device may remain in MANUAL.";
+      LOG_ERROR(restore_ss);
+    }
     if (ret == RSMI_STATUS_UNKNOWN_ERROR) {
       return RSMI_STATUS_NOT_SUPPORTED;
     }

--- a/projects/rocm-smi-lib/src/rocm_smi_utils.cc
+++ b/projects/rocm-smi-lib/src/rocm_smi_utils.cc
@@ -344,6 +344,11 @@ rsmi_status_t ErrnoToRsmiStatus(int err) {
     case ENOENT:
     case ENOTSUP:
       return RSMI_STATUS_NOT_SUPPORTED;
+    case EROFS:
+      // Sysfs is read-only (e.g. unprivileged container). Distinct from a
+      // kernel-unsupported feature (ENOENT/ENOTSUP -> NOT_SUPPORTED above);
+      // map to PERMISSION so callers can tell the two apart.
+      return RSMI_STATUS_PERMISSION;
     case EBADF:
     case EISDIR:
       return RSMI_STATUS_FILE_ERROR;


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Make a "statically" linked executable for ctrl test. We do not want to accidentally run/use libraries that are installed in other paths (like /opt/)
## Technical Details
Added -static flag to executable compilation options. 
Still need to figure out how to make libhsa-runtime64 a static object. It is dynamic right now. 

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
