### PR TITLE
[rocprofiler-systems] Backport elfutils GCC 15 register-name fix

### DIFF
--- a/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
@@ -186,6 +186,9 @@ else()
             "https://sourceware.org/elfutils/ftp/${ELFUTILS_DOWNLOAD_VERSION}/elfutils-${ELFUTILS_DOWNLOAD_VERSION}.tar.bz2"
             "https://mirrors.kernel.org/sourceware/elfutils/${ELFUTILS_DOWNLOAD_VERSION}/elfutils-${ELFUTILS_DOWNLOAD_VERSION}.tar.bz2"
         BUILD_IN_SOURCE 1
+        PATCH_COMMAND
+            patch -p1 -d <SOURCE_DIR> -i
+            ${CMAKE_CURRENT_LIST_DIR}/elfutils-0.188-gcc15-regs.patch
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3
             CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=-fPIC\ -O3

--- a/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
@@ -177,6 +177,24 @@ else()
     file(MAKE_DIRECTORY "${_eu_root}/lib")
     file(MAKE_DIRECTORY "${_eu_root}/include")
 
+    # Backport elfutils commit 7508696d (released in 0.192) to fix GCC 15
+    # -Werror=unterminated-string-initialization in the i386/x86_64 register
+    # tables. Only applied to versions older than 0.192 where the upstream
+    # fix is missing.
+    set(_eu_patch_args)
+    if(ELFUTILS_DOWNLOAD_VERSION VERSION_LESS 0.192)
+        find_program(PATCH_EXECUTABLE NAMES patch REQUIRED)
+        set(_eu_patch_args
+            PATCH_COMMAND
+            ${PATCH_EXECUTABLE}
+            -p1
+            -d
+            <SOURCE_DIR>
+            -i
+            ${CMAKE_CURRENT_LIST_DIR}/elfutils-0.188-gcc15-regs.patch
+        )
+    endif()
+
     include(ExternalProject)
     ExternalProject_Add(
         rocprofiler-systems-elfutils-build
@@ -186,9 +204,7 @@ else()
             "https://sourceware.org/elfutils/ftp/${ELFUTILS_DOWNLOAD_VERSION}/elfutils-${ELFUTILS_DOWNLOAD_VERSION}.tar.bz2"
             "https://mirrors.kernel.org/sourceware/elfutils/${ELFUTILS_DOWNLOAD_VERSION}/elfutils-${ELFUTILS_DOWNLOAD_VERSION}.tar.bz2"
         BUILD_IN_SOURCE 1
-        PATCH_COMMAND
-            patch -p1 -d <SOURCE_DIR> -i
-            ${CMAKE_CURRENT_LIST_DIR}/elfutils-0.188-gcc15-regs.patch
+        ${_eu_patch_args}
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3
             CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=-fPIC\ -O3

--- a/projects/rocprofiler-systems/cmake/elfutils-0.188-gcc15-regs.patch
+++ b/projects/rocprofiler-systems/cmake/elfutils-0.188-gcc15-regs.patch
@@ -1,0 +1,67 @@
+From 7508696d107ca01b65ce8273c881462a8658f90f Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Wed, 17 Jul 2024 23:03:34 +0100
+Subject: [PATCH] backends: allocate enough stace for null terminator
+
+`gcc-15` added a new warning in https://gcc.gnu.org/PR115185:
+
+    i386_regs.c:88:11: error: initializer-string for array of 'char' is too long [-Werror=unterminated-string-initialization]
+       88 |           "ax", "cx", "dx", "bx", "sp", "bp", "si", "di", "ip"
+          |           ^~~~
+
+`elfutils` does not need to store '\0'. We could either initialize the
+arrays with individual bytes or allocate extra byte for null.
+
+This change initializes the array bytewise.
+
+	* backends/i386_regs.c (i386_register_info): Initialize the
+	array bytewise to fix gcc-15 warning.
+	* backends/x86_64_regs.c (x86_64_register_info): Ditto.
+
+Signed-off-by: Sergei Trofimovich <slyich@gmail.com>
+---
+ backends/i386_regs.c   | 10 +++++++++-
+ backends/x86_64_regs.c |  9 ++++++++-
+ 2 files changed, 17 insertions(+), 2 deletions(-)
+
+diff --git a/backends/i386_regs.c b/backends/i386_regs.c
+index 7ec93bb..ead55ef 100644
+--- a/backends/i386_regs.c
++++ b/backends/i386_regs.c
+@@ -85,7 +85,15 @@ i386_register_info (Ebl *ebl __attribute__ ((unused)),
+     {
+       static const char baseregs[][2] =
+ 	{
+-	  "ax", "cx", "dx", "bx", "sp", "bp", "si", "di", "ip"
++	  {'a', 'x'},
++	  {'c', 'x'},
++	  {'d', 'x'},
++	  {'b', 'x'},
++	  {'s', 'p'},
++	  {'b', 'p'},
++	  {'s', 'i'},
++	  {'d', 'i'},
++	  {'i', 'p'},
+ 	};
+
+     case 4:
+diff --git a/backends/x86_64_regs.c b/backends/x86_64_regs.c
+index ef987da..dab8f27 100644
+--- a/backends/x86_64_regs.c
++++ b/backends/x86_64_regs.c
+@@ -82,7 +82,14 @@ x86_64_register_info (Ebl *ebl __attribute__ ((unused)),
+     {
+       static const char baseregs[][2] =
+ 	{
+-	  "ax", "dx", "cx", "bx", "si", "di", "bp", "sp"
++	  {'a', 'x'},
++	  {'d', 'x'},
++	  {'c', 'x'},
++	  {'b', 'x'},
++	  {'s', 'i'},
++	  {'d', 'i'},
++	  {'b', 'p'},
++	  {'s', 'p'},
+ 	};
+
+     case 6 ... 7:


### PR DESCRIPTION
## Motivation

The vendored elfutils 0.188 used by Dyninst trips GCC 15's
`-Werror=unterminated-string-initialization` in `backends/i386_regs.c`
and `backends/x86_64_regs.c`. In both files, 2-byte register-name
arrays are initialized with 3-byte string literals (the `\0` is
silently truncated), and GCC 15 promotes that to a hard error. Builds
fail before linking on any GCC 15 host. This is GCC-only:
`therock-elfutils` builds with clang and is unaffected; only Dyninst's
hardcoded-GNU vendored copy hits it.

Reported and fixed upstream:
- GCC bug: https://gcc.gnu.org/PR115185
- elfutils commit `7508696d` ("backends: allocate enough stace for
  null terminator") by Sergei Trofimovich, 2024-07-17. First released
  in elfutils-0.192.

## Technical Details

Backport upstream `7508696d` verbatim as a patch applied via
`PATCH_COMMAND` during the elfutils ExternalProject build. The patch
converts the offending string literals to char-init lists
(`{'a', 'x'}`) so no `\0` is implied and the warning is sidestepped at
the source. Same memory layout, same indexing behavior, zero runtime
impact.

Files:
- `projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake`: 3 lines
  added wiring `PATCH_COMMAND patch -p1 -d <SOURCE_DIR> -i
  ${CMAKE_CURRENT_LIST_DIR}/elfutils-0.188-gcc15-regs.patch`.
- `projects/rocprofiler-systems/cmake/elfutils-0.188-gcc15-regs.patch`:
  verbatim copy of upstream commit `7508696d`, preserving Author /
  Date / Subject / Signed-off-by attribution.

### Why backport rather than version-bump

#4877 (`Update ELFUTILS_DOWNLOAD_VERSION to 0.194`) was closed because
elfutils 0.192+ raises the Glibc/Jammy-base baseline beyond what
current CI containers tolerate. Backporting the surgical 17-line
register-name fix to 0.188 captures the same source-level correction
without crossing that compat wall.

### Why backport rather than `-Werror` workaround

Disabling the warning is a workaround; backporting the upstream fix is
the actual repair. This mirrors the lesson from TheRock #4302 ->
#4380 in another part of the build, where the rocgdb
libpython/libiberty linker collision was redirected away from
`--allow-multiple-definition` toward the root-cause fix.

## JIRA ID

N/A.

## Test Plan

Cleaned the elfutils ExternalProject state in TheRock's build,
re-ran cmake, and triggered the `rocprofiler-systems-elfutils-build`
ninja target, forcing the full sequence: fresh tarball extract ->
PATCH_COMMAND -> configure -> build -> install. Verified the patched
source via direct inspection of `backends/i386_regs.c` and
`backends/x86_64_regs.c` after extraction; both contain the char-init
form. Pre-commit hooks (clang-format-18, gersemi 0.22.1,
trailing-whitespace, end-of-file-fixer) all pass on both modified
files. Beyond the elfutils build, exercised the runtime path:
`rocprof-sys-instrument` parses real binaries through Dyninst ->
libelf/libdw built from the patched source.

Host: Ubuntu 25.10, GCC 15.2.0.

## Test Result

```
[3/7] Performing patch step for 'rocprofiler-systems-elfutils-build'
patching file backends/i386_regs.c
patching file backends/x86_64_regs.c
[7/7] Completed 'rocprofiler-systems-elfutils-build'
```

`libdw.so` and `libelf.so` produced cleanly; zero `-Werror` failures.
The newly-built `libelf-0.188.so` is SHA256-identical to the
previously-installed copy in `dist/lib/rocprofiler-systems/`,
confirming the patch is semantically zero-impact on the produced
binaries (char-init lists and string literals lower to the same
memory layout for `static const char[N][2]`).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.