### PR TITLE
clr: Replace emulated IPC events with true ROCr IPC signals

### DIFF
--- a/projects/clr/hipamd/src/hip_event.cpp
+++ b/projects/clr/hipamd/src/hip_event.cpp
@@ -191,7 +191,7 @@ hipError_t Event::recordCommand(amd::Command*& command, amd::HostQueue* stream, 
   }
 
   const auto flags = (ext_flags == 0) ? flags_ : ext_flags;
-  
+
   const auto releaseFlags = [&]() {
     if (flags & hipEventDisableSystemFence) {
       return amd::Device::kCacheStateIgnore;
@@ -273,7 +273,15 @@ hipError_t ihipEventCreateWithFlags(hipEvent_t* event, uint32_t flags) {
   // Create appropriate event type based on flags
   hip::Event* e = nullptr;
   if (flags & hipEventInterprocess) {
-    e = new hip::IPCEvent(flags);
+    auto* dev = g_devices[hip::getCurrentDevice()->deviceId()]->devices()[0];
+    // Probe whether the device supports IPC signals
+    auto* probe = dev->createIpcSignal();
+    if (probe != nullptr) {
+      delete probe;
+      e = new hip::IPCEvent(flags);
+    } else {
+      e = new hip::IPCEventEmulated(flags);
+    }
   } else if (AMD_DIRECT_DISPATCH) {
     e = new hip::EventDD(flags);
   } else {
@@ -286,6 +294,44 @@ hipError_t ihipEventCreateWithFlags(hipEvent_t* event, uint32_t flags) {
   hip::eventSet.insert(*event);
 
   return hipSuccess;
+}
+
+// ================================================================================================
+// Create an IPC event of a specific implementation type (ROCr or Emulated).
+// Used by hipIpcOpenEventHandle to match the opener to the exporter's type.
+hipError_t ihipCreateIpcEventByType(hipEvent_t* event, ihipIpcEventHandleType type) {
+  constexpr uint32_t kIpcEventFlags = hipEventDisableTiming | hipEventInterprocess;
+
+  hip::Event* e = nullptr;
+  switch (type) {
+    case kIpcEventHandleROCr:
+      e = new hip::IPCEvent(kIpcEventFlags);
+      break;
+    case kIpcEventHandleEmulated:
+      e = new hip::IPCEventEmulated(kIpcEventFlags);
+      break;
+    default:
+      return hipErrorInvalidValue;
+  }
+
+  if (e == nullptr) {
+    return hipErrorOutOfMemory;
+  }
+
+  *event = reinterpret_cast<hipEvent_t>(e);
+  std::unique_lock lock(hip::eventSetLock);
+  hip::eventSet.insert(*event);
+  return hipSuccess;
+}
+
+// ================================================================================================
+// Destroy an event created by ihipCreateIpcEventByType (removes from eventSet + deletes).
+void ihipDestroyIpcEvent(hipEvent_t event) {
+  if (event == nullptr) return;
+  std::unique_lock lock(hip::eventSetLock);
+  hip::eventSet.erase(event);
+  lock.unlock();
+  delete reinterpret_cast<hip::Event*>(event);
 }
 
 // ================================================================================================
@@ -442,7 +488,7 @@ static hipError_t checkEventCaptureRestrictions(hipEvent_t event) {
   if (s->GetCaptureStatus() == hipStreamCaptureStatusActive && s->IsEventCaptured(event)) {
     s->SetCaptureStatus(hipStreamCaptureStatusInvalidated);
     return hipErrorCapturedEvent;
-  }  
+  }
   // Case 2: The event was recorded on a stream that is neither actively capturing nor part of an
   // active capture session (proceed to next checks).
 

--- a/projects/clr/hipamd/src/hip_event.hpp
+++ b/projects/clr/hipamd/src/hip_event.hpp
@@ -179,7 +179,9 @@ class EventDD : public Event {
   int64_t time(bool getStartTs) const override;
 };
 
-class IPCEvent : public Event {
+/// Emulated IPC event using POSIX shared memory + stream write/wait value.
+/// Used on PAL/Windows path where ROCr IPC signals are unavailable.
+class IPCEventEmulated : public Event {
   /// IPC event metadata structure
   struct ihipIpcEvent_t {
     std::string ipc_name_;                //!< Name of the shared memory object for IPC
@@ -188,13 +190,12 @@ class IPCEvent : public Event {
     ihipIpcEvent_t() : ipc_shmem_(nullptr) {
       ipc_name_.reserve(32);  // Reserve space for typical IPC name "/hip_<pid>_<counter>"
     }
-    void setipcname(const char* name) { ipc_name_ = name; }
   };
   ihipIpcEvent_t ipc_evt_;
 
  public:
-  explicit IPCEvent(uint32_t flags = hipEventInterprocess) : Event(flags) {}
-  ~IPCEvent() override {
+  explicit IPCEventEmulated(uint32_t flags = hipEventInterprocess) : Event(flags) {}
+  ~IPCEventEmulated() override {
     if (ipc_evt_.ipc_shmem_) {
       int owners = --ipc_evt_.ipc_shmem_->owners;
       // Make sure event is synchronized
@@ -231,6 +232,33 @@ class IPCEvent : public Event {
 struct CallbackData {
   const int previous_read_index;               //!< Snapshot of read index for synchronization
   hip::ihipIpcEventShmem_t* const shmem;       //!< IPC shared memory for event signaling
+};
+
+/// True IPC event backed by a device::Signal with IPC capability.
+/// On ROCm, this uses ROCr IPC signals
+/// Record dispatches a standard barrier with an internal tracking signal, then
+/// registers an async handler that sets the IPC signal to 0 when work completes.
+/// StreamWait dispatches a barrier with the IPC signal as dep_signal;
+/// the GPU waits until the signal reaches 0 before proceeding.
+class IPCEvent : public Event {
+  amd::device::Signal* ipc_signal_;
+
+ public:
+  explicit IPCEvent(uint32_t flags = hipEventInterprocess)
+      : Event(flags), ipc_signal_(nullptr) {}
+  ~IPCEvent() override;
+
+  hipError_t GetHandle(ihipIpcEventHandle_t* handle) override;
+  hipError_t OpenHandle(ihipIpcEventHandle_t* handle) override;
+  hipError_t synchronize() override;
+  hipError_t query() override;
+  hipError_t streamWait(hip::Stream* stream, uint flags) override;
+  hipError_t recordCommand(amd::Command*& command, amd::HostQueue* queue, uint32_t flags = 0,
+                           bool batch_flush = true) override;
+  hipError_t enqueueRecordCommand(hip::Stream* stream, amd::Command* command) override;
+
+ private:
+  hipError_t createIpcSignalIfNeeded();
 };
 }  // namespace hip
 

--- a/projects/clr/hipamd/src/hip_event_ipc.cpp
+++ b/projects/clr/hipamd/src/hip_event_ipc.cpp
@@ -17,9 +17,11 @@
 namespace hip {
 
 hipError_t ihipEventCreateWithFlags(hipEvent_t* event, unsigned flags);
+hipError_t ihipCreateIpcEventByType(hipEvent_t* event, ihipIpcEventHandleType type);
+void ihipDestroyIpcEvent(hipEvent_t event);
 
 // ================================================================================================
-bool IPCEvent::createIpcEventShmemIfNeeded() {
+bool IPCEventEmulated::createIpcEventShmemIfNeeded() {
   // Early return if shared memory already exists
   if (ipc_evt_.ipc_shmem_) {
     return true;
@@ -58,7 +60,7 @@ bool IPCEvent::createIpcEventShmemIfNeeded() {
 }
 
 // ================================================================================================
-hipError_t IPCEvent::query() {
+hipError_t IPCEventEmulated::query() {
   if (ipc_evt_.ipc_shmem_) {
     const int prev_read_idx = ipc_evt_.ipc_shmem_->read_index;
     const int offset = prev_read_idx % IPC_SIGNALS_PER_EVENT;
@@ -72,7 +74,7 @@ hipError_t IPCEvent::query() {
 }
 
 // ================================================================================================
-hipError_t IPCEvent::synchronize() {
+hipError_t IPCEventEmulated::synchronize() {
   if (ipc_evt_.ipc_shmem_) {
     int prev_read_idx = ipc_evt_.ipc_shmem_->read_index;
     if (prev_read_idx >= 0) {
@@ -87,7 +89,7 @@ hipError_t IPCEvent::synchronize() {
 }
 
 // ================================================================================================
-hipError_t IPCEvent::streamWait(hip::Stream* stream, uint flags) {
+hipError_t IPCEventEmulated::streamWait(hip::Stream* stream, uint flags) {
   const int offset = ipc_evt_.ipc_shmem_->read_index;
   return ihipStreamOperation(
       reinterpret_cast<hipStream_t>(stream),
@@ -97,14 +99,14 @@ hipError_t IPCEvent::streamWait(hip::Stream* stream, uint flags) {
 }
 
 // ================================================================================================
-hipError_t IPCEvent::recordCommand(amd::Command*& command, amd::HostQueue* stream, uint32_t flags,
-                                   bool batch_flush) {
+hipError_t IPCEventEmulated::recordCommand(amd::Command*& command, amd::HostQueue* stream,
+                                           uint32_t flags, bool batch_flush) {
   command = new amd::Marker(*stream, kMarkerDisableFlush);
   return hipSuccess;
 }
 
 // ================================================================================================
-hipError_t IPCEvent::enqueueRecordCommand(hip::Stream* stream, amd::Command* command) {
+hipError_t IPCEventEmulated::enqueueRecordCommand(hip::Stream* stream, amd::Command* command) {
   createIpcEventShmemIfNeeded();
 
   // Allocate signal slot for this event
@@ -147,19 +149,21 @@ hipError_t IPCEvent::enqueueRecordCommand(hip::Stream* stream, amd::Command* com
 }
 
 // ================================================================================================
-hipError_t IPCEvent::GetHandle(ihipIpcEventHandle_t* handle) {
+hipError_t IPCEventEmulated::GetHandle(ihipIpcEventHandle_t* handle) {
   if (!createIpcEventShmemIfNeeded()) {
     return hipErrorInvalidValue;
   }
   ipc_evt_.ipc_shmem_->owners_device_id = deviceId();
   ipc_evt_.ipc_shmem_->owners_process_id = amd::Os::getProcessId();
-  memset(handle->shmem_name, 0, HIP_IPC_HANDLE_SIZE);
+  handle->type = kIpcEventHandleEmulated;
+  handle->creator_pid = static_cast<int32_t>(amd::Os::getProcessId());
+  memset(handle->shmem_name, 0, IHIP_IPC_EVENT_HANDLE_SIZE);
   ipc_evt_.ipc_name_.copy(handle->shmem_name, std::string::npos);
   return hipSuccess;
 }
 
 // ================================================================================================
-hipError_t IPCEvent::OpenHandle(ihipIpcEventHandle_t* handle) {
+hipError_t IPCEventEmulated::OpenHandle(ihipIpcEventHandle_t* handle) {
   ipc_evt_.ipc_name_ = handle->shmem_name;
 
   // Map shared memory from IPC handle
@@ -186,6 +190,167 @@ hipError_t IPCEvent::OpenHandle(ihipIpcEventHandle_t* handle) {
 }
 
 // ================================================================================================
+// IPCEvent implementation (true IPC signals for supported backends)
+// Record: standard barrier + async handler sets IPC signal to 0 when GPU work completes
+// StreamWait: barrier packet with IPC signal as dep_signal (GPU waits until signal reaches 0)
+// ================================================================================================
+
+hipError_t IPCEvent::createIpcSignalIfNeeded() {
+  if (ipc_signal_ != nullptr) {
+    return hipSuccess;
+  }
+
+  auto* dev = g_devices[deviceId()]->devices()[0];
+  ipc_signal_ = dev->createIpcSignal();
+  if (ipc_signal_ == nullptr) {
+    return hipErrorInvalidValue;
+  }
+
+  const auto ws = (flags_ & hipEventBlockingSync)
+      ? amd::device::Signal::WaitState::Blocked
+      : amd::device::Signal::WaitState::Active;
+  if (!ipc_signal_->Init(*dev, 1, ws)) {
+    delete ipc_signal_;
+    ipc_signal_ = nullptr;
+    return hipErrorInvalidValue;
+  }
+
+  return hipSuccess;
+}
+
+IPCEvent::~IPCEvent() {
+  if (ipc_signal_ != nullptr) {
+    // If the event was recorded (signal armed), wait for any in-flight barrier
+    // to finish before destroying the signal; otherwise the GPU could write to
+    // freed memory.  Skip the wait when the signal was never recorded (still at
+    // its initial value) — waiting would hang forever.
+    if (event_ != nullptr) {
+      ipc_signal_->Wait(1, amd::device::Signal::Condition::Lt, UINT64_MAX);
+    }
+    delete ipc_signal_;
+    ipc_signal_ = nullptr;
+  }
+}
+
+// ================================================================================================
+hipError_t IPCEvent::GetHandle(ihipIpcEventHandle_t* handle) {
+  auto status = createIpcSignalIfNeeded();
+  if (status != hipSuccess) {
+    return status;
+  }
+
+  handle->type = kIpcEventHandleROCr;
+  handle->creator_pid = static_cast<int32_t>(amd::Os::getProcessId());
+  if (!ipc_signal_->IpcExport(handle->ipc_signal_handle, IHIP_IPC_EVENT_HANDLE_SIZE)) {
+    return hipErrorInvalidValue;
+  }
+
+  return hipSuccess;
+}
+
+// ================================================================================================
+hipError_t IPCEvent::OpenHandle(ihipIpcEventHandle_t* handle) {
+  if (handle->type != kIpcEventHandleROCr) {
+    return hipErrorInvalidValue;
+  }
+
+  if (static_cast<int32_t>(amd::Os::getProcessId()) == handle->creator_pid) {
+    return hipErrorInvalidContext;
+  }
+
+  auto* dev = g_devices[deviceId()]->devices()[0];
+  ipc_signal_ = dev->createIpcSignal();
+  if (ipc_signal_ == nullptr) {
+    return hipErrorInvalidValue;
+  }
+
+  if (!ipc_signal_->IpcImport(handle->ipc_signal_handle, IHIP_IPC_EVENT_HANDLE_SIZE, dev)) {
+    delete ipc_signal_;
+    ipc_signal_ = nullptr;
+    return hipErrorInvalidValue;
+  }
+
+  return hipSuccess;
+}
+
+// ================================================================================================
+hipError_t IPCEvent::recordCommand(amd::Command*& command, amd::HostQueue* stream,
+                                   uint32_t flags, bool batch_flush) {
+  auto status = createIpcSignalIfNeeded();
+  if (status != hipSuccess) {
+    return status;
+  }
+
+  auto* marker = new amd::Marker(*stream, kMarkerDisableFlush);
+  marker->setIpcCompletionSignal(ipc_signal_);
+  command = marker;
+  return hipSuccess;
+}
+
+// ================================================================================================
+hipError_t IPCEvent::enqueueRecordCommand(hip::Stream* stream, amd::Command* command) {
+  // Re-arm the signal; GPU barrier will decrement to 0 when work completes
+  ipc_signal_->Reset(1);
+
+  command->enqueue();
+
+  if (event_ != nullptr) {
+    event_->release();
+  }
+  event_ = &command->event();
+
+  return hipSuccess;
+}
+
+// ================================================================================================
+hipError_t IPCEvent::synchronize() {
+  std::scoped_lock lock(lock_);
+
+  if (ipc_signal_ == nullptr) {
+    return hipSuccess;
+  }
+
+  ipc_signal_->Wait(1, amd::device::Signal::Condition::Lt, UINT64_MAX);
+  return hipSuccess;
+}
+
+// ================================================================================================
+hipError_t IPCEvent::query() {
+  std::scoped_lock lock(lock_);
+
+  if (ipc_signal_ == nullptr) {
+    return hipSuccess;
+  }
+
+  if (ipc_signal_->Load() >= 1) {
+    return hipErrorNotReady;
+  }
+  return hipSuccess;
+}
+
+// ================================================================================================
+hipError_t IPCEvent::streamWait(hip::Stream* stream, uint flags) {
+  std::scoped_lock lock(lock_);
+
+  if (ipc_signal_ == nullptr) {
+    return hipSuccess;
+  }
+
+  if (ipc_signal_->Load() < 1) {
+    return hipSuccess;
+  }
+
+  // Dispatch a barrier that waits on the IPC signal as dep_signal
+  auto* marker = new amd::Marker(*stream, kMarkerDisableFlush);
+  marker->setIpcDepSignal(ipc_signal_);
+  marker->enqueue();
+  return hipSuccess;
+}
+
+// ================================================================================================
+// HIP API functions for IPC events
+// ================================================================================================
+
 hipError_t hipIpcGetEventHandle(hipIpcEventHandle_t* handle, hipEvent_t event) {
   HIP_INIT_API(hipIpcGetEventHandle, handle, event);
 
@@ -205,19 +370,20 @@ hipError_t hipIpcOpenEventHandle(hipEvent_t* event, hipIpcEventHandle_t handle) 
     HIP_RETURN(hipErrorInvalidValue);
   }
 
-  // Create IPC event with timing disabled
-  constexpr uint32_t kIpcEventFlags = hipEventDisableTiming | hipEventInterprocess;
-  auto status = ihipEventCreateWithFlags(event, kIpcEventFlags);
+  auto* const iHandle = reinterpret_cast<ihipIpcEventHandle_t*>(&handle);
+
+  // Select event implementation based on the handle's type field rather than
+  // a runtime probe — the opener must match the exporter's implementation.
+  auto status = ihipCreateIpcEventByType(event, iHandle->type);
   if (status != hipSuccess) {
     HIP_RETURN(status);
   }
 
   auto* const e = reinterpret_cast<hip::Event*>(*event);
-  auto* const iHandle = reinterpret_cast<ihipIpcEventHandle_t*>(&handle);
-
   const auto open_status = e->OpenHandle(iHandle);
   if (open_status != hipSuccess) {
-    delete e;
+    ihipDestroyIpcEvent(*event);
+    *event = nullptr;
   }
   HIP_RETURN(open_status);
 }

--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -69,13 +69,23 @@ struct UserObject;
 class Stream;
 
 #define IHIP_IPC_EVENT_HANDLE_SIZE 32
-#define IHIP_IPC_EVENT_RESERVED_SIZE LP64_SWITCH(28,24)
+
+enum ihipIpcEventHandleType : uint32_t {
+    kIpcEventHandleEmulated = 0,
+    kIpcEventHandleROCr     = 1,
+};
+
 typedef struct ihipIpcEventHandle_st {
-    //hsa_amd_ipc_signal_t ipc_handle;  //!< ipc signal handle on ROCr
-    //char ipc_handle[IHIP_IPC_EVENT_HANDLE_SIZE];
-    //char reserved[IHIP_IPC_EVENT_RESERVED_SIZE];
-    char shmem_name[IHIP_IPC_EVENT_HANDLE_SIZE];
+    ihipIpcEventHandleType type;
+    int32_t creator_pid;
+    union {
+        char shmem_name[IHIP_IPC_EVENT_HANDLE_SIZE];
+        char ipc_signal_handle[IHIP_IPC_EVENT_HANDLE_SIZE];
+    };
 } ihipIpcEventHandle_t;
+
+static_assert(sizeof(ihipIpcEventHandle_t) <= sizeof(hipIpcEventHandle_t),
+              "ihipIpcEventHandle_t exceeds hipIpcEventHandle_t storage");
 
 const char* ihipGetErrorName(hipError_t hip_error);
 

--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -1207,6 +1207,23 @@ bool Device::IpcAttach(const char* handle, size_t mem_size, size_t mem_offset, u
   if (mem_obj_exist == nullptr) {
     // Add the original mem_ptr to the MemObjMap with newly created amd_mem_obj
     amd::MemObjMap::AddMemObj(amd_mem_obj->getSvmPtr(), amd_mem_obj);
+  } else if (mem_obj_exist->ipcShared()) {
+    // Stale IPC import at the same VA. The app freed memory on the
+    // exporter side and reallocated at the same VA without the importer calling
+    // hipIpcCloseMemHandle. Replace the stale object with the new mapping.
+    void* old_ptr = mem_obj_exist->getSvmPtr();
+    void* new_ptr = amd_mem_obj->getSvmPtr();
+    amd::MemObjMap::RemoveIpcHandleMemObj(mem_obj_exist);
+    amd::MemObjMap::RemoveMemObj(old_ptr);
+
+    if (old_ptr == new_ptr) {
+      // Clear ipcShared to prevent the destructor from calling ipc_memory_detach,
+      // which would unmap the new (valid) mapping at this VA.
+      mem_obj_exist->setIpcShared(false);
+    }
+    // Different VA: destructor will call ipc_memory_detach to unmap the old VA.
+    mem_obj_exist->release();
+    amd::MemObjMap::AddMemObj(new_ptr, amd_mem_obj);
   } else {
     amd_mem_obj->release();
     amd_mem_obj = mem_obj_exist;

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1843,6 +1843,9 @@ class Device : public RuntimeObject {
   ///! Allocates a device signal object
   virtual device::Signal* createSignal() const = 0;
 
+  ///! Allocates an IPC-capable signal, or returns nullptr if unsupported
+  virtual device::Signal* createIpcSignal() const { return nullptr; }
+
   //! Return true if initialized external API interop, otherwise false
   virtual bool bindExternalDevice(
       uint flags,             //!< Enum val. for ext.API type: GL, D3D10, etc.

--- a/projects/clr/rocclr/device/devsignal.hpp
+++ b/projects/clr/rocclr/device/devsignal.hpp
@@ -44,8 +44,21 @@ class Signal : public amd::HeapObject {
   // Atomically sets the current value of the signal
   virtual void Reset(uint64_t value) {}
 
+  // Atomically loads the current value of the signal
+  virtual uint64_t Load() { return 0; }
+
+  // Exports the signal as an IPC handle into the provided buffer
+  virtual bool IpcExport(void* handle, size_t handle_size) { return false; }
+
+  // Initializes this signal from an IPC handle (alternative to Init for imported signals)
+  virtual bool IpcImport(const void* handle, size_t handle_size,
+                         const amd::Device* dev = nullptr) { return false; }
+
   // Return the handle to the underlying amd_signal_t object
   virtual void* getHandle() { return nullptr; }
+
+  // Return a GPU-accessible handle (may differ from getHandle for IPC signals)
+  virtual void* getGpuHandle() { return getHandle(); }
 };
 
 };  // namespace amd::device

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3484,6 +3484,9 @@ void Device::getGlobalCUMask(std::string_view cuMaskStr) {
 device::Signal* Device::createSignal() const { return new roc::Signal(); }
 
 // ================================================================================================
+device::Signal* Device::createIpcSignal() const { return new roc::IpcSignal(); }
+
+// ================================================================================================
 hsa_status_t Device::BackendErrorCallBackHandler(const hsa_amd_event_t* event, void* data) {
   cl_int gpu_error = CL_SUCCESS;
   switch (event->event_type) {

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -404,6 +404,7 @@ class Device : public NullDevice {
   }
 
   virtual device::Signal* createSignal() const override;
+  virtual device::Signal* createIpcSignal() const override;
 
   //! Acquire external graphics API object in the host thread
   //! Needed for OpenGL objects on CPU device

--- a/projects/clr/rocclr/device/rocm/rocrctx.cpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.cpp
@@ -88,6 +88,8 @@ bool Hsa::LoadLib() {
   GET_ROCR_SYMBOL(hsa_amd_ipc_memory_create)
   GET_ROCR_SYMBOL(hsa_amd_ipc_memory_attach)
   GET_ROCR_SYMBOL(hsa_amd_ipc_memory_detach)
+  GET_ROCR_SYMBOL(hsa_amd_ipc_signal_create)
+  GET_ROCR_SYMBOL(hsa_amd_ipc_signal_attach)
   GET_ROCR_SYMBOL(hsa_amd_signal_create)
   GET_ROCR_SYMBOL(hsa_amd_register_system_event_handler)
   GET_ROCR_SYMBOL(hsa_amd_queue_set_priority)

--- a/projects/clr/rocclr/device/rocm/rocrctx.hpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.hpp
@@ -97,6 +97,8 @@ struct RocrEntryPoints {
   decltype(hsa_amd_ipc_memory_create)* hsa_amd_ipc_memory_create_;
   decltype(hsa_amd_ipc_memory_attach)* hsa_amd_ipc_memory_attach_;
   decltype(hsa_amd_ipc_memory_detach)* hsa_amd_ipc_memory_detach_;
+  decltype(hsa_amd_ipc_signal_create)* hsa_amd_ipc_signal_create_;
+  decltype(hsa_amd_ipc_signal_attach)* hsa_amd_ipc_signal_attach_;
   decltype(hsa_amd_signal_create)* hsa_amd_signal_create_;
   decltype(hsa_amd_register_system_event_handler)* hsa_amd_register_system_event_handler_;
   decltype(hsa_amd_queue_set_priority)* hsa_amd_queue_set_priority_;
@@ -407,6 +409,13 @@ class Hsa : public amd::AllStatic {
   }
   static hsa_status_t ipc_memory_detach(void* mapped_ptr) {
     return ROCR_DYN(hsa_amd_ipc_memory_detach)(mapped_ptr);
+  }
+  static hsa_status_t ipc_signal_create(hsa_signal_t signal, hsa_amd_ipc_signal_t* handle) {
+    return ROCR_DYN(hsa_amd_ipc_signal_create)(signal, handle);
+  }
+  static hsa_status_t ipc_signal_attach(const hsa_amd_ipc_signal_t* handle,
+                                        hsa_signal_t* signal) {
+    return ROCR_DYN(hsa_amd_ipc_signal_attach)(handle, signal);
   }
   static hsa_status_t signal_create(hsa_signal_value_t initial_value, uint32_t num_consumers,
     const hsa_agent_t* consumers, uint64_t attributes, hsa_signal_t* signal) {

--- a/projects/clr/rocclr/device/rocm/rocsignal.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsignal.cpp
@@ -32,4 +32,75 @@ uint64_t Signal::Wait(uint64_t value, device::Signal::Condition c, uint64_t time
 
 void Signal::Reset(uint64_t value) { Hsa::signal_store_screlease(signal_, value); }
 
+// ================================================================================================
+// IpcSignal implementation
+// ================================================================================================
+
+IpcSignal::~IpcSignal() {
+  if (gpu_ptr_ != nullptr) {
+    Hsa::memory_unlock(reinterpret_cast<void*>(signal_.handle));
+  }
+  if (signal_.handle != 0) {
+    Hsa::signal_destroy(signal_);
+  }
+}
+
+bool IpcSignal::Init(const amd::Device& dev, uint64_t init, device::Signal::WaitState ws) {
+  hsa_status_t status = Hsa::signal_create(init, 0, nullptr, HSA_AMD_SIGNAL_IPC, &signal_);
+  if (status != HSA_STATUS_SUCCESS) {
+    return false;
+  }
+  ws_ = ws;
+  return true;
+}
+
+uint64_t IpcSignal::Wait(uint64_t value, device::Signal::Condition c, uint64_t timeout) {
+  return Hsa::signal_wait_scacquire(signal_, static_cast<hsa_signal_condition_t>(c), value,
+                                    timeout, static_cast<hsa_wait_state_t>(ws_));
+}
+
+void IpcSignal::Reset(uint64_t value) { Hsa::signal_store_screlease(signal_, value); }
+
+uint64_t IpcSignal::Load() {
+  return Hsa::signal_load_relaxed(signal_);
+}
+
+bool IpcSignal::IpcExport(void* handle, size_t handle_size) {
+  if (handle_size < sizeof(hsa_amd_ipc_signal_t)) {
+    return false;
+  }
+  hsa_amd_ipc_signal_t ipc_handle;
+  hsa_status_t status = Hsa::ipc_signal_create(signal_, &ipc_handle);
+  if (status != HSA_STATUS_SUCCESS) {
+    return false;
+  }
+  memcpy(handle, &ipc_handle, sizeof(ipc_handle));
+  return true;
+}
+
+bool IpcSignal::IpcImport(const void* handle, size_t handle_size, const amd::Device* dev) {
+  if (handle_size < sizeof(hsa_amd_ipc_signal_t)) {
+    return false;
+  }
+  hsa_amd_ipc_signal_t ipc_handle;
+  memcpy(&ipc_handle, handle, sizeof(ipc_handle));
+
+  hsa_status_t status = Hsa::ipc_signal_attach(&ipc_handle, &signal_);
+  if (status != HSA_STATUS_SUCCESS) {
+    return false;
+  }
+
+  // Lock the imported signal memory for GPU access.
+  // The IPC signal is CPU-only after dma-buf import.
+  if (dev != nullptr) {
+    auto* rocDev = static_cast<const roc::Device*>(dev);
+    constexpr size_t kSignalAbiSize = 4096;
+    gpu_ptr_ = rocDev->hostLock(reinterpret_cast<void*>(signal_.handle),
+                                kSignalAbiSize, amd::Device::kNoAtomics);
+  }
+
+  ws_ = WaitState::Active;
+  return true;
+}
+
 };  // namespace amd::roc

--- a/projects/clr/rocclr/device/rocm/rocsignal.hpp
+++ b/projects/clr/rocclr/device/rocm/rocsignal.hpp
@@ -27,4 +27,29 @@ class Signal : public device::Signal {
   void* getHandle() override { return reinterpret_cast<void*>(signal_.handle); }
 };
 
+//! IPC-capable signal using hsa_amd_ipc_signal_create/attach.
+//! Used directly as completion_signal / dep_signal on AQL barrier packets.
+class IpcSignal : public device::Signal {
+ private:
+  hsa_signal_t signal_;
+  void* gpu_ptr_ = nullptr;  // GPU-accessible pointer from memory_lock (if needed)
+
+ public:
+  IpcSignal() { signal_.handle = 0; }
+  ~IpcSignal() override;
+
+  bool Init(const amd::Device& dev, uint64_t init, device::Signal::WaitState ws) override;
+
+  uint64_t Wait(uint64_t value, device::Signal::Condition c, uint64_t timeout) override;
+  void Reset(uint64_t value) override;
+  uint64_t Load() override;
+  bool IpcExport(void* handle, size_t handle_size) override;
+  bool IpcImport(const void* handle, size_t handle_size,
+                 const amd::Device* dev = nullptr) override;
+  void* getHandle() override { return reinterpret_cast<void*>(signal_.handle); }
+  void* getGpuHandle() override {
+    return gpu_ptr_ ? gpu_ptr_ : reinterpret_cast<void*>(signal_.handle);
+  }
+};
+
 };  // namespace amd::roc

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -768,6 +768,12 @@ std::vector<hsa_signal_t>& VirtualGPU::HwQueueTracker::WaitingSignal(HwQueueEngi
   }
   external_signals_.clear();
 
+  // Append raw signals added via AddDynamicQueueWait (e.g. IPC dep signals)
+  for (auto& s : dynamic_queue_waits_) {
+    waiting_signals_.push_back(s);
+  }
+  dynamic_queue_waits_.clear();
+
   // Return the array of waiting HSA signals
   return waiting_signals_;
 }
@@ -1584,7 +1590,9 @@ bool VirtualGPU::dispatchCounterAqlPacket(hsa_ext_amd_aql_pm4_packet_t* packet,
 
 // ================================================================================================
 void VirtualGPU::WaitCompleteSignal(hsa_signal_t signal) {
-  barrier_packet_.dep_signal[0] = signal;
+  // Add the signal as a dynamic dependency so WaitingSignal() includes it
+  // alongside any pending external signals in the barrier's dep_signal list.
+  Barriers().AddDynamicQueueWait(signal);
   dispatchBarrierPacket(kBarrierPacketHeader, false);
 }
 
@@ -4445,6 +4453,68 @@ void VirtualGPU::submitNativeFn(amd::NativeFnCommand& cmd) {}
 void VirtualGPU::submitMarker(amd::Marker& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
   std::scoped_lock lock(execution());
+
+  // IPC event record: first dispatch a NOP barrier with the IPC signal as
+  // completion_signal — this decrements the IPC signal when prior work completes.
+  // Then dispatch a regular barrier with an ActiveSignal so that normal
+  // tracking, command completion, and fence management all work without hacks.
+  if (vcmd.ipcCompletionSignal() != nullptr) {
+    if (!dedicated_queue_ && gpu_queue_ == nullptr) {
+      gpu_queue_ = roc_device_.AcquireActiveQueue(priority_);
+    }
+    profilingBegin(vcmd);
+    hsa_signal_t ipc_s;
+    ipc_s.handle = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(
+        vcmd.ipcCompletionSignal()->getHandle()));
+    const Settings& settings = dev().settings();
+
+    // NOP barrier with IPC signal as completion — fires when prior work finishes
+    if (settings.barrier_value_packet_) {
+      dispatchBarrierValuePacket(kBarrierVendorPacketNopScopeHeader, false,
+                                hsa_signal_t{0}, 0, 0,
+                                HSA_SIGNAL_CONDITION_EQ, true, ipc_s);
+    } else {
+      dispatchBarrierPacket(kNopPacketHeader, true, ipc_s);
+    }
+
+    // Submit a barrier that allows tracking as IPC signals are not tracked
+    int32_t releaseFlags = vcmd.getCommandEntryScope();
+    if (releaseFlags == Device::CacheState::kCacheStateIgnore) {
+      if (settings.barrier_value_packet_ && vcmd.profilingInfo().marker_ts_) {
+        dispatchBarrierValuePacket(kBarrierVendorPacketNopScopeHeader, true);
+      } else {
+        dispatchBarrierPacket(kNopPacketHeader, false);
+      }
+    } else {
+      force_irq_ = IS_WINDOWS;
+      if (settings.barrier_value_packet_ && vcmd.profilingInfo().marker_ts_) {
+        dispatchBarrierValuePacket(kBarrierVendorPacketHeader, true);
+      } else {
+        dispatchBarrierPacket(kBarrierPacketHeader, false);
+      }
+      hasPendingDispatch_ = false;
+    }
+
+    profilingEnd();
+    return;
+  }
+
+  // IPC stream wait: dispatch a barrier that waits on the IPC dep_signal.
+  // Use getGpuHandle() which returns the GPU-accessible (memory_lock'd)
+  // pointer if the signal memory was CPU-only from dma-buf sys-mem import.
+  if (vcmd.ipcDepSignal() != nullptr) {
+    if (!dedicated_queue_ && gpu_queue_ == nullptr) {
+      gpu_queue_ = roc_device_.AcquireActiveQueue(priority_);
+    }
+    profilingBegin(vcmd);
+    hsa_signal_t s;
+    s.handle = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(
+        vcmd.ipcDepSignal()->getGpuHandle()));
+    WaitCompleteSignal(s);
+    profilingEnd();
+    return;
+  }
+
   if (vcmd.CpuWaitRequested()) {
     force_irq_ = IS_WINDOWS;
     // It should be safe to call flush directly if there are not pending dispatches without

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -4453,68 +4453,6 @@ void VirtualGPU::submitNativeFn(amd::NativeFnCommand& cmd) {}
 void VirtualGPU::submitMarker(amd::Marker& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
   std::scoped_lock lock(execution());
-
-  // IPC event record: first dispatch a NOP barrier with the IPC signal as
-  // completion_signal — this decrements the IPC signal when prior work completes.
-  // Then dispatch a regular barrier with an ActiveSignal so that normal
-  // tracking, command completion, and fence management all work without hacks.
-  if (vcmd.ipcCompletionSignal() != nullptr) {
-    if (!dedicated_queue_ && gpu_queue_ == nullptr) {
-      gpu_queue_ = roc_device_.AcquireActiveQueue(priority_);
-    }
-    profilingBegin(vcmd);
-    hsa_signal_t ipc_s;
-    ipc_s.handle = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(
-        vcmd.ipcCompletionSignal()->getHandle()));
-    const Settings& settings = dev().settings();
-
-    // NOP barrier with IPC signal as completion — fires when prior work finishes
-    if (settings.barrier_value_packet_) {
-      dispatchBarrierValuePacket(kBarrierVendorPacketNopScopeHeader, false,
-                                hsa_signal_t{0}, 0, 0,
-                                HSA_SIGNAL_CONDITION_EQ, true, ipc_s);
-    } else {
-      dispatchBarrierPacket(kNopPacketHeader, true, ipc_s);
-    }
-
-    // Submit a barrier that allows tracking as IPC signals are not tracked
-    int32_t releaseFlags = vcmd.getCommandEntryScope();
-    if (releaseFlags == Device::CacheState::kCacheStateIgnore) {
-      if (settings.barrier_value_packet_ && vcmd.profilingInfo().marker_ts_) {
-        dispatchBarrierValuePacket(kBarrierVendorPacketNopScopeHeader, true);
-      } else {
-        dispatchBarrierPacket(kNopPacketHeader, false);
-      }
-    } else {
-      force_irq_ = IS_WINDOWS;
-      if (settings.barrier_value_packet_ && vcmd.profilingInfo().marker_ts_) {
-        dispatchBarrierValuePacket(kBarrierVendorPacketHeader, true);
-      } else {
-        dispatchBarrierPacket(kBarrierPacketHeader, false);
-      }
-      hasPendingDispatch_ = false;
-    }
-
-    profilingEnd();
-    return;
-  }
-
-  // IPC stream wait: dispatch a barrier that waits on the IPC dep_signal.
-  // Use getGpuHandle() which returns the GPU-accessible (memory_lock'd)
-  // pointer if the signal memory was CPU-only from dma-buf sys-mem import.
-  if (vcmd.ipcDepSignal() != nullptr) {
-    if (!dedicated_queue_ && gpu_queue_ == nullptr) {
-      gpu_queue_ = roc_device_.AcquireActiveQueue(priority_);
-    }
-    profilingBegin(vcmd);
-    hsa_signal_t s;
-    s.handle = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(
-        vcmd.ipcDepSignal()->getGpuHandle()));
-    WaitCompleteSignal(s);
-    profilingEnd();
-    return;
-  }
-
   if (vcmd.CpuWaitRequested()) {
     force_irq_ = IS_WINDOWS;
     // It should be safe to call flush directly if there are not pending dispatches without
@@ -4525,10 +4463,31 @@ void VirtualGPU::submitMarker(amd::Marker& vcmd) {
     flush(vcmd.GetBatchHead());
   } else {
     profilingBegin(vcmd);
-    if (timestamp_ != nullptr) {
-      const Settings& settings = dev().settings();
-      int32_t releaseFlags = vcmd.getCommandEntryScope();
+    const Settings& settings = dev().settings();
+    hsa_signal_t ipc_s{0};
+    if (vcmd.ipcCompletionSignal() != nullptr) {
+      ipc_s.handle = static_cast<uint64_t>(
+          reinterpret_cast<uintptr_t>(vcmd.ipcCompletionSignal()->getGpuHandle()));
+    }
 
+    if (vcmd.ipcDepSignal() != nullptr) {
+      hsa_signal_t s;
+      s.handle = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(
+          vcmd.ipcDepSignal()->getGpuHandle()));
+      WaitCompleteSignal(s);
+    } else if (timestamp_ != nullptr || ipc_s.handle != 0) {
+      // IPC event record: if ipc_s is non-zero, first dispatch a NOP barrier with
+      // the IPC signal as completion_signal; it fires when prior work completes.
+      if (ipc_s.handle != 0) {
+        if (settings.barrier_value_packet_) {
+          dispatchBarrierValuePacket(kBarrierVendorPacketNopScopeHeader, false, hsa_signal_t{0}, 0,
+                                     0, HSA_SIGNAL_CONDITION_EQ, true, ipc_s);
+        } else {
+          dispatchBarrierPacket(kNopPacketHeader, true, ipc_s);
+        }
+      }
+
+      int32_t releaseFlags = vcmd.getCommandEntryScope();
       if (releaseFlags == Device::CacheState::kCacheStateIgnore) {
         if (settings.barrier_value_packet_ && vcmd.profilingInfo().marker_ts_) {
           dispatchBarrierValuePacket(kBarrierVendorPacketNopScopeHeader, true);

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -1471,6 +1471,9 @@ class ExternalSemaphoreCmd : public Command {
 
 
 class Marker : public Command {
+  device::Signal* ipc_completion_signal_ = nullptr;
+  device::Signal* ipc_dep_signal_ = nullptr;
+
  public:
   //! Create a new Marker
   Marker(HostQueue& queue, bool userVisible, const EventWaitList& eventWaitList = nullWaitList,
@@ -1478,6 +1481,14 @@ class Marker : public Command {
       : Command(queue, userVisible ? CL_COMMAND_MARKER : 0, eventWaitList, 0, waitingEvent) {
     cpu_wait_ = cpu_wait;
   }
+
+  //! Attach an IPC signal as completion_signal on the barrier packet (for event record)
+  void setIpcCompletionSignal(device::Signal* s) { ipc_completion_signal_ = s; }
+  device::Signal* ipcCompletionSignal() const { return ipc_completion_signal_; }
+
+  //! Attach an IPC signal as dep_signal on the barrier packet (for stream wait)
+  void setIpcDepSignal(device::Signal* s) { ipc_dep_signal_ = s; }
+  device::Signal* ipcDepSignal() const { return ipc_dep_signal_; }
 
   //! The actual command implementation.
   virtual void submit(device::VirtualDevice& device) { device.submitMarker(*this); }

--- a/projects/hip-tests/catch/unit/event/Unit_hipEventIpc_shm_cleanup.cc
+++ b/projects/hip-tests/catch/unit/event/Unit_hipEventIpc_shm_cleanup.cc
@@ -49,6 +49,23 @@ std::set<std::string> get_hip_ipc_shm_files() {
 }
 
 HIP_TEST_CASE(Unit_hipEventIpc_shm_cleanup) {
+  // This test validates /dev/shm cleanup for the emulated IPC event path.
+  // Skip when the device uses native IPC signals (no /dev/shm involved).
+  {
+    auto shm_before = get_hip_ipc_shm_files();
+    hipEvent_t probe;
+    HIP_CHECK(hipEventCreateWithFlags(&probe,
+                                      hipEventInterprocess | hipEventDisableTiming));
+    hipIpcEventHandle_t h;
+    HIP_CHECK(hipIpcGetEventHandle(&h, probe));
+    auto shm_after = get_hip_ipc_shm_files();
+    HIP_CHECK(hipEventDestroy(probe));
+    if (shm_after.size() <= shm_before.size()) {
+      HipTest::HIP_SKIP_TEST("Device uses native IPC signals; /dev/shm cleanup not applicable");
+      return;
+    }
+  }
+
   auto before = get_hip_ipc_shm_files();
 
   int pipefd[2];

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -1517,9 +1517,7 @@ int Runtime::IPCClientImport(uint32_t conn_handle, uint64_t dmabuf_fd_handle,
         std::lock_guard<std::shared_mutex> lock(memory_lock_);
         auto [it, inserted] = allocation_map_.try_emplace(
         *importAddress, nullptr, *importSize, *importSize, core::MemoryRegion::AllocateNoFlags);
-        if (inserted) {
-          it->second.thunk_bo = res.buf_handle;
-        }
+        it->second.thunk_bo = res.buf_handle;
       }
       runtime_singleton_->DmaBufClose(static_cast<int>(dmabuf_fd));
     }
@@ -1622,6 +1620,7 @@ hsa_status_t Runtime::IPCAttach(const hsa_amd_ipc_memory_t* handle, size_t len, 
 
     // Create a shared cpu access pointer for user
     void *cpuPtr;
+    void* intermediateAddr = importAddress;
     HsaMemoryObjectHandle bo = allocation_map_[importAddress].thunk_bo;
     HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtMemoryCpuMap(bo, &cpuPtr));
     if (status != HSAKMT_STATUS_SUCCESS) {
@@ -1634,6 +1633,14 @@ hsa_status_t Runtime::IPCAttach(const hsa_amd_ipc_memory_t* handle, size_t len, 
     }
     importAddress = cpuPtr;
     fixFragment(bo);
+
+    // Remove the stale intermediate entry created by IPCClientImport.
+    // The canonical entry now lives at cpuPtr (set by fixFragment above).
+    if (intermediateAddr != importAddress) {
+      std::lock_guard<std::shared_mutex> lock(memory_lock_);
+      allocation_map_.erase(intermediateAddr);
+    }
+
     *mapped_ptr = importAddress;
     return HSA_STATUS_SUCCESS;
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -1512,11 +1512,16 @@ int Runtime::IPCClientImport(uint32_t conn_handle, uint64_t dmabuf_fd_handle,
         return -1;
       }
 
-      // Store the buffer object handle in allocation map for later use
+      // Store the buffer object handle in allocation map for later use.
+      // If a stale entry exists at this VA (from a previous import that was
+      // never detached), free the old BO first to avoid leaking it.
       if (status == HSAKMT_STATUS_SUCCESS) {
         std::lock_guard<std::shared_mutex> lock(memory_lock_);
         auto [it, inserted] = allocation_map_.try_emplace(
         *importAddress, nullptr, *importSize, *importSize, core::MemoryRegion::AllocateNoFlags);
+        if (!inserted && it->second.thunk_bo) {
+          HSAKMT_CALL(hsaKmtMemHandleFree(it->second.thunk_bo));
+        }
         it->second.thunk_bo = res.buf_handle;
       }
       runtime_singleton_->DmaBufClose(static_cast<int>(dmabuf_fd));


### PR DESCRIPTION
Use hsa_amd_ipc_signal_create/attach for cross-process event synchronization instead of shared-memory slots and blit kernels. Record uses an async signal handler on the barrier's internal signal to set the IPC signal; StreamWait uses WaitCompleteSignal for GPU-side waits. The emulated path is preserved as fallback for PAL/Windows.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
