### PR TITLE
[RCCL] Add ncclCommSuspend/Resume/MemStats APIs with VMM memory manager

### DIFF
--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SRC_FILES
   channel.cc
   collectives.cc
   commDump.cc
+  mem_manager.cc
   debug.cc
   dev_runtime.cc
   enqueue.cc
@@ -103,6 +104,7 @@ set(SRC_FILES
   include/ibvwrap.h
   include/info.h
   include/ipcsocket.h
+  include/mem_manager.h
   include/mnnvl.h
   include/nccl_common.h
   include/nccl_device.h

--- a/projects/rccl/src/include/alloc.h
+++ b/projects/rccl/src/include/alloc.h
@@ -477,10 +477,10 @@ static inline ncclResult_t ncclCuMemFree(void *ptr) {
   ncclResult_t result = ncclSuccess;
   CUmemGenericAllocationHandle handle;
   size_t size = 0;
-  CUCHECK(cuMemRetainAllocationHandle(&handle, ptr));
-  CUCHECK(cuMemRelease(handle));
+  // HIP VMM: retain -> unmap -> release -> address_free (single release avoids double-free)
   CUdeviceptr base = nullptr;
   CUCHECK(cuMemGetAddressRange(&base, &size, (CUdeviceptr)ptr));
+  CUCHECK(cuMemRetainAllocationHandle(&handle, ptr));
   TRACE(NCCL_ALLOC, "CuMem Free Size %zu pointer %p handle %p", size, ptr, (void*)(uintptr_t)handle);
   CUCHECK(cuMemUnmap((CUdeviceptr)ptr, size));
   CUCHECK(cuMemRelease(handle));

--- a/projects/rccl/src/include/api_trace.h
+++ b/projects/rccl/src/include/api_trace.h
@@ -31,7 +31,7 @@
 #define RCCL_API_TRACE_VERSION_MAJOR 0
 
 // should be increased every time new members are added to existing dispatch tables
-#define RCCL_API_TRACE_VERSION_PATCH 3
+#define RCCL_API_TRACE_VERSION_PATCH 4
 
 #if !defined(RCCL_EXTERN_C_INIT)
 #    ifdef __cplusplus
@@ -166,6 +166,12 @@ typedef ncclResult_t (*ncclCommWindowRegister_fn_t)(ncclComm_t comm, void* userP
 
 typedef ncclResult_t (*ncclCommWindowDeregister_fn_t)(ncclComm_t comm, ncclWindow_t win);
 
+typedef ncclResult_t (*ncclCommSuspend_fn_t)(ncclComm_t comm, int flags);
+
+typedef ncclResult_t (*ncclCommResume_fn_t)(ncclComm_t comm);
+
+typedef ncclResult_t (*ncclCommMemStats_fn_t)(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value);
+
 typedef struct rcclApiFuncTable
 {
     // ADD NEW FUNCTIONS AT BOTTOM ONLY
@@ -213,6 +219,9 @@ typedef struct rcclApiFuncTable
     ncclCommWindowDeregister_fn_t ncclCommWindowDeregister_fn;
     ncclAlltoAll_fn_t             ncclAlltoAll_fn;
     ncclAlltoAllv_fn_t            ncclAlltoAllv_fn;
+    ncclCommSuspend_fn_t          ncclCommSuspend_fn;
+    ncclCommResume_fn_t           ncclCommResume_fn;
+    ncclCommMemStats_fn_t         ncclCommMemStats_fn;
     // ADD NEW FUNCTIONS HERE ONLY
 } rcclApiFuncTable;
 

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -129,6 +129,8 @@ struct ncclCommEventCallback {
   ncclResult_t(*fn)(struct ncclComm* comm, struct ncclCommEventCallback* cb);
 };
 
+#include "mem_manager.h"
+
 struct ncclSharedResources {
   int refCount;
   struct ncclComm* owner; /* comm which creates this shared res. */
@@ -788,6 +790,10 @@ struct ncclComm {
   bool enableDirectReduceScatter;
   // Temporary Buffer [RCCL]
   void* tempBuff;
+
+  struct ncclIntruQueue<struct ncclMemManagerTask, &ncclMemManagerTask::next> suspendTaskQueue;
+  struct ncclIntruQueue<struct ncclMemManagerTask, &ncclMemManagerTask::next> resumeTaskQueue;
+  struct ncclMemManager* memManager;
 
   uint64_t endMagic;
 };

--- a/projects/rccl/src/include/mem_manager.h
+++ b/projects/rccl/src/include/mem_manager.h
@@ -1,0 +1,150 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef NCCL_MEM_MANAGER_H_
+#define NCCL_MEM_MANAGER_H_
+
+#include "nccl.h"
+#include <hip/hip_runtime.h>
+#include <hip/hip_runtime_api.h>
+#include <mutex>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ncclComm;
+
+#define NCCL_MEM_EXPORT_PEERS_INIT 8
+
+typedef enum {
+  ncclMemPersist = 0,
+  ncclMemScratch = 1,
+  ncclMemOffload = 2
+} ncclMemType_t;
+
+typedef enum {
+  ncclDynMemStateActive   = 0,
+  ncclDynMemStateReleased = 1
+} ncclDynMemState_t;
+
+typedef struct ncclDynMemLocalDesc {
+  bool shareableHandleValid;
+  int  numExportedPeers;
+  int  exportedPeersCapacity;
+  int* exportedPeerRanks;
+} ncclDynMemLocalDesc;
+
+typedef struct ncclDynMemImportDesc {
+  int   ownerRank;
+  int   ownerDev;
+  void* ownerPtr;
+} ncclDynMemImportDesc;
+
+typedef struct ncclDynMemEntry {
+  void*                            ptr;        // Device VA
+  size_t                           size;
+  hipMemGenericAllocationHandle_t  handle;     // VMM physical handle
+  hipMemAllocationHandleType       handleType;
+  ncclMemType_t                    memType;
+  ncclDynMemState_t                state;
+  int                              cudaDev;
+
+  void* cpuBackup;
+  hipMemAllocationProp prop;
+
+  bool isImportedFromPeer;
+  union {
+    ncclDynMemLocalDesc  local;
+    ncclDynMemImportDesc imported;
+  } desc;
+
+  struct ncclDynMemEntry* next;
+} ncclDynMemEntry;
+
+struct ncclSuspendCanary {
+  void*                            va;       // reserved virtual address
+  size_t                           size;     // bytes (>= granularity)
+  hipMemGenericAllocationHandle_t  handle;   // physical handle when active
+  int                              cudaDev;
+  int                              valid;    // 1 iff `va` reservation alive
+};
+
+typedef struct ncclMemManager {
+  ncclDynMemEntry* entries;       // Linked list of scratch/offload entries.
+  int              numEntries;
+  std::mutex       lock;
+  int              released;      // 1 iff suspended (physical mappings dropped)
+  int              initialized;
+  int              refCount;      // Future-proof: split_share comm sharing
+
+  size_t totalPersist;
+  size_t totalPersistImported;
+  size_t totalScratch;
+  size_t totalScratchImported;
+  size_t totalOffload;
+  size_t totalOffloadImported;
+  size_t cpuBackupUsage;          // Bytes currently held in host backups.
+
+  int commCudaDev;
+
+  struct ncclSuspendCanary canary;
+} ncclMemManager;
+
+struct ncclMemManagerTask {
+  struct ncclMemManagerTask* next;
+  struct ncclComm*           comm;
+};
+
+ncclResult_t ncclMemManagerInit(struct ncclComm* comm);
+ncclResult_t ncclMemManagerDestroy(struct ncclComm* comm);
+
+ncclResult_t ncclMemTrack(
+    struct ncclMemManager*           manager,
+    void*                            ptr,
+    size_t                           size,
+    hipMemGenericAllocationHandle_t  handle,
+    hipMemAllocationHandleType       handleType,
+    ncclMemType_t                    memType);
+
+ncclResult_t ncclMemTrackImportFromPeer(
+    struct ncclMemManager*           manager,
+    void*                            ptr,
+    size_t                           size,
+    hipMemGenericAllocationHandle_t  handle,
+    hipMemAllocationHandleType       handleType,
+    ncclMemType_t                    memType,
+    int                              ownerRank,
+    int                              ownerDev,
+    void*                            ownerPtr);
+
+ncclResult_t ncclMemUntrack(
+    struct ncclMemManager* manager,
+    void*                  ptr,
+    size_t                 size);
+
+ncclResult_t ncclDynMemMarkExportToPeer(
+    struct ncclMemManager* manager,
+    void*                  ptr,
+    int                    peerRank);
+
+ncclResult_t ncclCommMemSuspend(struct ncclComm* comm);
+ncclResult_t ncclCommMemResume(struct ncclComm* comm);
+ncclResult_t ncclCommSuspendCanaryFree(struct ncclComm* comm);
+ncclResult_t ncclCommSuspendForceResumeForDestroy(struct ncclComm* comm);
+
+ncclResult_t ncclCommSuspend_impl(ncclComm_t comm, int flags);
+ncclResult_t ncclCommResume_impl(ncclComm_t comm);
+ncclResult_t ncclCommMemStats_impl(
+    ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NCCL_MEM_MANAGER_H_

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -440,6 +440,22 @@ void ncclCommPushCudaFree(struct ncclComm* comm, void* obj) {
   dtor->obj = obj;
   dtor->next = comm->destructorHead;
   comm->destructorHead = dtor;
+
+  // Track VMM-backed allocations for suspend/resume (VMM-only to avoid SIGSEGV on non-VMM ptrs)
+  if (obj != nullptr && comm != nullptr && comm->memManager != nullptr &&
+      ncclCuMemEnable()) {
+    hipDeviceptr_t base = 0;
+    size_t sz = 0;
+    hipError_t e = hipMemGetAddressRange(&base, &sz, (hipDeviceptr_t)obj);
+    if (e == hipSuccess && sz > 0) {
+      (void)ncclMemTrack(comm->memManager, obj, sz,
+                         /*handle=*/0,
+                         hipMemHandleTypePosixFileDescriptor,
+                         ncclMemOffload);
+    } else {
+      (void)hipGetLastError();
+    }
+  }
 }
 
 static ncclResult_t ncclDestructorFnCudaHostFree(struct ncclDestructor* dtor) {
@@ -603,6 +619,19 @@ skip_profiling:
 #if CUDART_VERSION >= 12010
   if (comm->nvlsSupport) NCCLCHECK(ncclNvlsFree(comm));
 #endif
+
+  // Drain suspend/resume queues, force-resume, tear down memory manager
+  while (!ncclIntruQueueEmpty(&comm->suspendTaskQueue)) {
+    struct ncclMemManagerTask* t = ncclIntruQueueDequeue(&comm->suspendTaskQueue);
+    free(t);
+  }
+  while (!ncclIntruQueueEmpty(&comm->resumeTaskQueue)) {
+    struct ncclMemManagerTask* t = ncclIntruQueueDequeue(&comm->resumeTaskQueue);
+    free(t);
+  }
+  NCCLCHECK(ncclCommSuspendForceResumeForDestroy(comm));
+  NCCLCHECK(ncclCommSuspendCanaryFree(comm));
+  NCCLCHECK(ncclMemManagerDestroy(comm));
 
   struct ncclDestructor* dtor = comm->destructorHead;
   while (dtor != nullptr) {
@@ -839,6 +868,10 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
   ncclIntruQueueMpscConstruct(&comm->callbackQueue);
   ncclIntruQueueConstruct(&comm->legacyRegCleanupQueue);
   ncclIntruQueueConstruct(&comm->ceInitTaskQueue);
+  ncclIntruQueueConstruct(&comm->suspendTaskQueue);
+  ncclIntruQueueConstruct(&comm->resumeTaskQueue);
+  comm->memManager = nullptr;
+  NCCLCHECK(ncclMemManagerInit(comm));
 
   comm->regCache.pageSize = sysconf(_SC_PAGESIZE);
 

--- a/projects/rccl/src/mem_manager.cc
+++ b/projects/rccl/src/mem_manager.cc
@@ -1,0 +1,877 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_runtime_api.h>
+
+#include "argcheck.h"
+#include "bootstrap.h"
+#include "comm.h"
+#include "debug.h"
+#include "mem_manager.h"
+#include "nccl.h"
+#include "param.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <new>
+
+NCCL_PARAM(MemManagerDisable, "DISABLE_MEM_MANAGER", 0);
+
+namespace {
+
+hipMemAllocationProp defaultProp(int dev) {
+  hipMemAllocationProp prop{};
+  prop.type                = hipMemAllocationTypePinned;
+  prop.location.type       = hipMemLocationTypeDevice;
+  prop.location.id         = dev;
+  prop.requestedHandleType = hipMemHandleTypePosixFileDescriptor;
+  return prop;
+}
+
+hipError_t setLocalAccess(void* va, size_t size, int dev) {
+  hipMemAccessDesc access{};
+  access.location.type = hipMemLocationTypeDevice;
+  access.location.id   = dev;
+  access.flags         = hipMemAccessFlagsProtReadWrite;
+  return hipMemSetAccess(va, size, &access, 1);
+}
+
+ncclResult_t quiesceBarrier(struct ncclComm* comm, int tag) {
+  if (comm->nRanks <= 1 || comm->bootstrap == nullptr) return ncclSuccess;
+  return bootstrapBarrier(comm->bootstrap, comm->rank, comm->nRanks, tag);
+}
+
+ncclResult_t ensureCanary(struct ncclComm* comm) {
+  ncclMemManager* mgr = comm->memManager;
+  struct ncclSuspendCanary* c = &mgr->canary;
+  if (c->valid) return ncclSuccess;
+
+  int vmmSupported = 0;
+  hipError_t e = hipDeviceGetAttribute(
+      &vmmSupported, hipDeviceAttributeVirtualMemoryManagementSupported,
+      comm->cudaDev);
+  if (e != hipSuccess || !vmmSupported) {
+    WARN("MemManager: HIP virtual memory management not supported on "
+         "device %d (hipDeviceGetAttribute=%d, vmm=%d)",
+         comm->cudaDev, (int)e, vmmSupported);
+    return ncclInvalidUsage;
+  }
+
+  hipMemAllocationProp prop = defaultProp(comm->cudaDev);
+  size_t granularity = 0;
+  e = hipMemGetAllocationGranularity(&granularity, &prop,
+                                     hipMemAllocationGranularityMinimum);
+  if (e != hipSuccess || granularity == 0) {
+    WARN("MemManager: hipMemGetAllocationGranularity failed (%d)", (int)e);
+    return ncclSystemError;
+  }
+  size_t size = granularity;
+
+  hipMemGenericAllocationHandle_t handle = nullptr;
+  void* va = nullptr;
+
+  e = hipMemCreate(&handle, size, &prop, 0);
+  if (e != hipSuccess) {
+    WARN("MemManager: canary hipMemCreate(size=%zu) failed (%d)", size, (int)e);
+    return ncclSystemError;
+  }
+  e = hipMemAddressReserve(&va, size, 0, nullptr, 0);
+  if (e != hipSuccess) {
+    (void)hipMemRelease(handle);
+    WARN("MemManager: canary hipMemAddressReserve failed (%d)", (int)e);
+    return ncclSystemError;
+  }
+  e = hipMemMap(va, size, 0, handle, 0);
+  if (e != hipSuccess) {
+    (void)hipMemAddressFree(va, size);
+    (void)hipMemRelease(handle);
+    WARN("MemManager: canary hipMemMap failed (%d)", (int)e);
+    return ncclSystemError;
+  }
+  e = setLocalAccess(va, size, comm->cudaDev);
+  if (e != hipSuccess) {
+    (void)hipMemUnmap(va, size);
+    (void)hipMemAddressFree(va, size);
+    (void)hipMemRelease(handle);
+    WARN("MemManager: canary hipMemSetAccess failed (%d)", (int)e);
+    return ncclSystemError;
+  }
+
+  c->va      = va;
+  c->size    = size;
+  c->handle  = handle;
+  c->cudaDev = comm->cudaDev;
+  c->valid   = 1;
+  INFO(NCCL_INIT,
+       "MemManager: canary VA=%p size=%zu dev=%d created (rank=%d)",
+       va, size, comm->cudaDev, comm->rank);
+  return ncclSuccess;
+}
+
+ncclResult_t suspendCanary(struct ncclComm* comm) {
+  struct ncclSuspendCanary* c = &comm->memManager->canary;
+  if (!c->valid || c->handle == nullptr) {
+    WARN("MemManager: canary not initialized");
+    return ncclInternalError;
+  }
+  hipError_t e = hipMemUnmap(c->va, c->size);
+  if (e != hipSuccess) {
+    WARN("MemManager: canary hipMemUnmap failed (%d)", (int)e);
+    return ncclUnhandledCudaError;
+  }
+  e = hipMemRelease(c->handle);
+  if (e != hipSuccess) {
+    WARN("MemManager: canary hipMemRelease failed (%d)", (int)e);
+    return ncclUnhandledCudaError;
+  }
+  c->handle = nullptr;
+  return ncclSuccess;
+}
+
+ncclResult_t resumeCanary(struct ncclComm* comm) {
+  struct ncclSuspendCanary* c = &comm->memManager->canary;
+  if (!c->valid) return ncclSuccess;          // never used; nothing to do
+  if (c->handle != nullptr) return ncclSuccess; // already mapped
+
+  hipMemAllocationProp prop = defaultProp(c->cudaDev);
+  hipMemGenericAllocationHandle_t newHandle = nullptr;
+  hipError_t e = hipMemCreate(&newHandle, c->size, &prop, 0);
+  if (e != hipSuccess) {
+    WARN("MemManager: canary hipMemCreate failed (%d)", (int)e);
+    return ncclSystemError;
+  }
+  e = hipMemMap(c->va, c->size, 0, newHandle, 0);
+  if (e != hipSuccess) {
+    (void)hipMemRelease(newHandle);
+    WARN("MemManager: canary hipMemMap failed (%d)", (int)e);
+    return ncclSystemError;
+  }
+  e = setLocalAccess(c->va, c->size, c->cudaDev);
+  if (e != hipSuccess) {
+    (void)hipMemUnmap(c->va, c->size);
+    (void)hipMemRelease(newHandle);
+    WARN("MemManager: canary hipMemSetAccess failed (%d)", (int)e);
+    return ncclSystemError;
+  }
+  c->handle = newHandle;
+  return ncclSuccess;
+}
+
+bool snapshotEntryForSuspend(ncclDynMemEntry* entry) {
+  hipPointerAttribute_t pa{};
+  hipError_t pe = hipPointerGetAttributes(&pa, entry->ptr);
+  if (pe != hipSuccess) {
+    (void)hipGetLastError();
+    return false;
+  }
+
+  hipMemGenericAllocationHandle_t handle = nullptr;
+  hipError_t e = hipMemRetainAllocationHandle(&handle, entry->ptr);
+  if (e != hipSuccess || handle == nullptr) {
+    (void)hipGetLastError();
+    return false;
+  }
+
+  hipMemAllocationProp prop{};
+  hipError_t propErr = hipMemGetAllocationPropertiesFromHandle(&prop, handle);
+  hipDeviceptr_t base = 0;
+  size_t live = 0;
+  hipError_t rangeErr = hipMemGetAddressRange(&base, &live, (hipDeviceptr_t)entry->ptr);
+
+  if (propErr != hipSuccess || rangeErr != hipSuccess || live == 0) {
+    (void)hipMemRelease(handle);
+    return false;
+  }
+
+  entry->prop   = prop;
+  entry->handle = handle;     // we're about to release it via unmap+release
+  if (entry->size == 0) entry->size = live;
+  return true;
+}
+
+}  // namespace
+
+ncclResult_t ncclMemManagerInit(struct ncclComm* comm) {
+  if (ncclParamMemManagerDisable()) return ncclSuccess;
+  if (comm == nullptr) return ncclInvalidArgument;
+
+  ncclMemManager* mgr = (ncclMemManager*)calloc(1, sizeof(*mgr));
+  if (mgr == nullptr) return ncclSystemError;
+  new (&mgr->lock) std::mutex();
+
+  mgr->entries     = nullptr;
+  mgr->numEntries  = 0;
+  mgr->released    = 0;
+  mgr->refCount    = 1;
+  mgr->commCudaDev = comm->cudaDev;
+
+  comm->memManager = mgr;
+
+  __atomic_store_n(&mgr->initialized, 1, __ATOMIC_RELEASE);
+
+  INFO(NCCL_INIT, "MemManager: initialized for device %d (rank=%d)",
+       comm->cudaDev, comm->rank);
+  return ncclSuccess;
+}
+
+ncclResult_t ncclMemManagerDestroy(struct ncclComm* comm) {
+  if (ncclParamMemManagerDisable()) return ncclSuccess;
+  if (comm == nullptr) return ncclInvalidArgument;
+  if (comm->memManager == nullptr) return ncclSuccess;
+
+  ncclMemManager* mgr = comm->memManager;
+
+  if (!__atomic_load_n(&mgr->initialized, __ATOMIC_ACQUIRE)) {
+    comm->memManager = nullptr;
+    return ncclSuccess;
+  }
+
+  int refCount = __atomic_sub_fetch(&mgr->refCount, 1, __ATOMIC_ACQ_REL);
+  if (refCount > 0) {
+    INFO(NCCL_INIT, "MemManager: decremented refCount to %d", refCount);
+    comm->memManager = nullptr;
+    return ncclSuccess;
+  }
+
+  __atomic_store_n(&mgr->initialized, 0, __ATOMIC_RELEASE);
+
+  ncclDynMemEntry* e = mgr->entries;
+  while (e != nullptr) {
+    ncclDynMemEntry* next = e->next;
+    if (e->cpuBackup != nullptr) free(e->cpuBackup);
+    if (!e->isImportedFromPeer && e->desc.local.exportedPeerRanks != nullptr) {
+      free(e->desc.local.exportedPeerRanks);
+    }
+    free(e);
+    e = next;
+  }
+  mgr->entries    = nullptr;
+  mgr->numEntries = 0;
+
+  mgr->lock.~mutex();
+  free(mgr);
+  comm->memManager = nullptr;
+
+  INFO(NCCL_INIT, "MemManager: destroyed");
+  return ncclSuccess;
+}
+
+namespace {
+
+ncclResult_t memTrackInternal(
+    struct ncclMemManager*           manager,
+    void*                            ptr,
+    size_t                           size,
+    hipMemGenericAllocationHandle_t  handle,
+    hipMemAllocationHandleType       handleType,
+    ncclMemType_t                    memType,
+    bool                             isImportedFromPeer,
+    int                              ownerRank,
+    int                              ownerDev,
+    void*                            ownerPtr) {
+  if (ncclParamMemManagerDisable()) return ncclSuccess;
+  if (manager == nullptr || ptr == nullptr) return ncclInternalError;
+  if (!__atomic_load_n(&manager->initialized, __ATOMIC_ACQUIRE)) {
+    WARN("MemManager: cannot track ptr=%p, manager not initialized", ptr);
+    return ncclInternalError;
+  }
+
+  if (memType == ncclMemPersist) {
+    if (isImportedFromPeer) {
+      __atomic_add_fetch(&manager->totalPersistImported, size, __ATOMIC_RELAXED);
+    } else {
+      __atomic_add_fetch(&manager->totalPersist, size, __ATOMIC_RELAXED);
+    }
+    return ncclSuccess;
+  }
+
+  ncclDynMemEntry* entry = (ncclDynMemEntry*)calloc(1, sizeof(*entry));
+  if (entry == nullptr) {
+    WARN("MemManager: failed to allocate entry");
+    return ncclSystemError;
+  }
+  entry->ptr        = ptr;
+  entry->size       = size;
+  entry->handle     = handle;
+  entry->handleType = handleType;
+  entry->memType    = memType;
+  entry->state      = ncclDynMemStateActive;
+  entry->cudaDev    = manager->commCudaDev;
+  entry->cpuBackup  = nullptr;
+  entry->isImportedFromPeer = isImportedFromPeer;
+
+  if (isImportedFromPeer) {
+    entry->desc.imported.ownerRank = ownerRank;
+    entry->desc.imported.ownerDev  = ownerDev;
+    entry->desc.imported.ownerPtr  = ownerPtr;
+  } else {
+    entry->desc.local.shareableHandleValid  = false;
+    entry->desc.local.numExportedPeers      = 0;
+    entry->desc.local.exportedPeersCapacity = 0;
+    entry->desc.local.exportedPeerRanks     = nullptr;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(manager->lock);
+    entry->next        = manager->entries;
+    manager->entries   = entry;
+    manager->numEntries++;
+  }
+
+  if (isImportedFromPeer) {
+    if (memType == ncclMemScratch) {
+      __atomic_add_fetch(&manager->totalScratchImported, size, __ATOMIC_RELAXED);
+    } else if (memType == ncclMemOffload) {
+      __atomic_add_fetch(&manager->totalOffloadImported, size, __ATOMIC_RELAXED);
+    }
+  } else {
+    if (memType == ncclMemScratch) {
+      __atomic_add_fetch(&manager->totalScratch, size, __ATOMIC_RELAXED);
+    } else if (memType == ncclMemOffload) {
+      __atomic_add_fetch(&manager->totalOffload, size, __ATOMIC_RELAXED);
+    }
+  }
+  return ncclSuccess;
+}
+
+}  // namespace
+
+ncclResult_t ncclMemTrack(
+    struct ncclMemManager*           manager,
+    void*                            ptr,
+    size_t                           size,
+    hipMemGenericAllocationHandle_t  handle,
+    hipMemAllocationHandleType       handleType,
+    ncclMemType_t                    memType) {
+  return memTrackInternal(manager, ptr, size, handle, handleType, memType,
+                          /*isImportedFromPeer=*/false,
+                          /*ownerRank=*/-1,
+                          /*ownerDev=*/-1,
+                          /*ownerPtr=*/nullptr);
+}
+
+ncclResult_t ncclMemTrackImportFromPeer(
+    struct ncclMemManager*           manager,
+    void*                            ptr,
+    size_t                           size,
+    hipMemGenericAllocationHandle_t  handle,
+    hipMemAllocationHandleType       handleType,
+    ncclMemType_t                    memType,
+    int                              ownerRank,
+    int                              ownerDev,
+    void*                            ownerPtr) {
+  return memTrackInternal(manager, ptr, size, handle, handleType, memType,
+                          /*isImportedFromPeer=*/true,
+                          ownerRank, ownerDev, ownerPtr);
+}
+
+ncclResult_t ncclMemUntrack(struct ncclMemManager* manager, void* ptr,
+                            size_t size) {
+  if (ncclParamMemManagerDisable()) return ncclSuccess;
+  if (manager == nullptr || ptr == nullptr) return ncclInternalError;
+  if (!__atomic_load_n(&manager->initialized, __ATOMIC_ACQUIRE)) {
+    return ncclInternalError;
+  }
+
+  size_t           entrySize          = 0;
+  bool             isImportedFromPeer = false;
+  ncclMemType_t    memType            = ncclMemScratch;
+
+  {
+    std::lock_guard<std::mutex> lock(manager->lock);
+
+    ncclDynMemEntry* prev  = nullptr;
+    ncclDynMemEntry* entry = manager->entries;
+
+    while (entry != nullptr) {
+      if (entry->ptr == ptr) {
+        if (prev == nullptr) {
+          manager->entries = entry->next;
+        } else {
+          prev->next = entry->next;
+        }
+        manager->numEntries--;
+
+        if (entry->cpuBackup != nullptr) {
+          manager->cpuBackupUsage -= entry->size;
+          free(entry->cpuBackup);
+        }
+
+        if (!entry->isImportedFromPeer &&
+            entry->desc.local.exportedPeerRanks != nullptr) {
+          free(entry->desc.local.exportedPeerRanks);
+        }
+
+        entrySize          = entry->size;
+        isImportedFromPeer = entry->isImportedFromPeer;
+        memType            = entry->memType;
+        free(entry);
+        break;
+      }
+      prev  = entry;
+      entry = entry->next;
+    }
+  }
+
+  if (entrySize > 0) {
+    if (isImportedFromPeer) {
+      if (memType == ncclMemScratch)
+        __atomic_sub_fetch(&manager->totalScratchImported, entrySize, __ATOMIC_RELAXED);
+      else if (memType == ncclMemOffload)
+        __atomic_sub_fetch(&manager->totalOffloadImported, entrySize, __ATOMIC_RELAXED);
+    } else {
+      if (memType == ncclMemScratch)
+        __atomic_sub_fetch(&manager->totalScratch, entrySize, __ATOMIC_RELAXED);
+      else if (memType == ncclMemOffload)
+        __atomic_sub_fetch(&manager->totalOffload, entrySize, __ATOMIC_RELAXED);
+    }
+  } else {
+    __atomic_sub_fetch(&manager->totalPersist, size, __ATOMIC_RELAXED);
+  }
+  return ncclSuccess;
+}
+
+ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager,
+                                        void* ptr, int peerRank) {
+  if (ncclParamMemManagerDisable()) return ncclSuccess;
+  if (manager == nullptr || ptr == nullptr) return ncclInternalError;
+  if (!__atomic_load_n(&manager->initialized, __ATOMIC_ACQUIRE)) {
+    return ncclInternalError;
+  }
+
+  std::lock_guard<std::mutex> lock(manager->lock);
+
+  ncclDynMemEntry* entry = manager->entries;
+  while (entry != nullptr && entry->ptr != ptr) entry = entry->next;
+  if (entry == nullptr) {
+    WARN("MemManager: cannot mark export for ptr=%p (not tracked)", ptr);
+    return ncclInternalError;
+  }
+  if (entry->isImportedFromPeer) {
+    WARN("MemManager: cannot export an imported entry (ptr=%p)", ptr);
+    return ncclInternalError;
+  }
+
+  for (int i = 0; i < entry->desc.local.numExportedPeers; ++i) {
+    if (entry->desc.local.exportedPeerRanks[i] == peerRank) return ncclSuccess;
+  }
+
+  if (entry->desc.local.numExportedPeers >=
+      entry->desc.local.exportedPeersCapacity) {
+    int newCap = entry->desc.local.exportedPeersCapacity == 0
+                     ? NCCL_MEM_EXPORT_PEERS_INIT
+                     : entry->desc.local.exportedPeersCapacity * 2;
+    int* grown = (int*)realloc(entry->desc.local.exportedPeerRanks,
+                               (size_t)newCap * sizeof(int));
+    if (grown == nullptr) return ncclSystemError;
+    entry->desc.local.exportedPeerRanks     = grown;
+    entry->desc.local.exportedPeersCapacity = newCap;
+  }
+
+  entry->desc.local.exportedPeerRanks[entry->desc.local.numExportedPeers++] =
+      peerRank;
+  return ncclSuccess;
+}
+
+ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
+  if (ncclParamMemManagerDisable()) {
+    WARN("MemManager: suspend failed, memory manager is disabled");
+    return ncclInvalidUsage;
+  }
+  if (comm == nullptr) return ncclInvalidArgument;
+  if (comm->memManager == nullptr) return ncclInvalidUsage;
+  ncclMemManager* mgr = comm->memManager;
+
+  if (mgr->released) {
+    WARN("MemManager: already suspended");
+    return ncclInvalidUsage;
+  }
+
+  NCCLCHECK(ensureCanary(comm));
+
+  if (hipDeviceSynchronize() != hipSuccess) {
+    WARN("MemManager: hipDeviceSynchronize failed before suspend");
+    return ncclUnhandledCudaError;
+  }
+
+  NCCLCHECK(quiesceBarrier(comm, /*tag=*/0xBEEF));
+  NCCLCHECK(suspendCanary(comm));
+  size_t releasedScratch = 0;
+  size_t releasedOffload = 0;
+  int    releasedCount   = 0;
+  int    skippedCount    = 0;
+
+  ncclDynMemEntry* entry = mgr->entries;
+  while (entry != nullptr) {
+    if (entry->isImportedFromPeer) {
+      entry = entry->next;
+      continue;
+    }
+    if (entry->state == ncclDynMemStateReleased) {
+      entry = entry->next;
+      continue;
+    }
+
+    if (!snapshotEntryForSuspend(entry)) {
+      ++skippedCount;
+      entry = entry->next;
+      continue;
+    }
+
+    if (entry->memType == ncclMemOffload) {
+      entry->cpuBackup = malloc(entry->size);
+      if (entry->cpuBackup == nullptr) {
+        WARN("MemManager: malloc(%zu) for host backup failed", entry->size);
+        (void)hipMemRelease(entry->handle);
+        entry->handle = 0;
+        return ncclSystemError;
+      }
+      hipError_t e = hipMemcpy(entry->cpuBackup, entry->ptr, entry->size,
+                               hipMemcpyDeviceToHost);
+      if (e != hipSuccess) {
+        WARN("MemManager: hipMemcpy DtoH failed for %p size %zu (%d)",
+             entry->ptr, entry->size, (int)e);
+        free(entry->cpuBackup);
+        entry->cpuBackup = nullptr;
+        (void)hipMemRelease(entry->handle);
+        entry->handle = 0;
+        return ncclUnhandledCudaError;
+      }
+      mgr->cpuBackupUsage += entry->size;
+      releasedOffload     += entry->size;
+    } else {
+      releasedScratch += entry->size;
+    }
+
+    // unmap -> release; skip hipMemAddressFree so VA reservation survives
+    if (hipMemUnmap(entry->ptr, entry->size) != hipSuccess) {
+      WARN("MemManager: hipMemUnmap failed for %p size %zu",
+           entry->ptr, entry->size);
+      if (entry->cpuBackup != nullptr) {
+        free(entry->cpuBackup);
+        entry->cpuBackup = nullptr;
+        mgr->cpuBackupUsage -= entry->size;
+      }
+      (void)hipMemRelease(entry->handle);
+      entry->handle = 0;
+      return ncclUnhandledCudaError;
+    }
+    if (hipMemRelease(entry->handle) != hipSuccess) {
+      WARN("MemManager: hipMemRelease failed for %p", entry->ptr);
+      entry->handle = 0;
+      return ncclUnhandledCudaError;
+    }
+    entry->handle = 0;
+    entry->state  = ncclDynMemStateReleased;
+    ++releasedCount;
+
+    entry = entry->next;
+  }
+
+  mgr->released = 1;
+
+  INFO(NCCL_INIT,
+       "MemManager: rank %d suspended canary + %d entries (scratch=%zu, "
+       "offload=%zu, cpuBackup=%zu, skipped=%d non-VMM)",
+       comm->rank, releasedCount, releasedScratch, releasedOffload,
+       mgr->cpuBackupUsage, skippedCount);
+  return ncclSuccess;
+}
+
+ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
+  if (ncclParamMemManagerDisable()) {
+    WARN("MemManager: resume failed, memory manager is disabled");
+    return ncclInvalidUsage;
+  }
+  if (comm == nullptr) return ncclInvalidArgument;
+  if (comm->memManager == nullptr) return ncclInvalidUsage;
+  ncclMemManager* mgr = comm->memManager;
+
+  if (!mgr->released) {
+    WARN("MemManager: not in suspended state");
+    return ncclInvalidUsage;
+  }
+
+  size_t restoredBytes = 0;
+  int    restoredCount = 0;
+
+  ncclDynMemEntry* entry = mgr->entries;
+  while (entry != nullptr) {
+    if (entry->isImportedFromPeer) {
+      entry = entry->next;
+      continue;
+    }
+    if (entry->state != ncclDynMemStateReleased) {
+      entry = entry->next;
+      continue;
+    }
+
+    hipMemGenericAllocationHandle_t newHandle = nullptr;
+    hipError_t e = hipMemCreate(&newHandle, entry->size, &entry->prop, 0);
+    if (e != hipSuccess) {
+      WARN("MemManager: resume hipMemCreate failed for VA=%p size=%zu (%d)",
+           entry->ptr, entry->size, (int)e);
+      return ncclSystemError;
+    }
+    e = hipMemMap(entry->ptr, entry->size, 0, newHandle, 0);
+    if (e != hipSuccess) {
+      (void)hipMemRelease(newHandle);
+      WARN("MemManager: resume hipMemMap failed for VA=%p (%d)", entry->ptr, (int)e);
+      return ncclSystemError;
+    }
+    e = setLocalAccess(entry->ptr, entry->size, entry->cudaDev);
+    if (e != hipSuccess) {
+      (void)hipMemUnmap(entry->ptr, entry->size);
+      (void)hipMemRelease(newHandle);
+      WARN("MemManager: resume hipMemSetAccess failed for VA=%p (%d)",
+           entry->ptr, (int)e);
+      return ncclSystemError;
+    }
+    entry->handle = newHandle;
+
+    if (entry->memType == ncclMemOffload && entry->cpuBackup != nullptr) {
+      e = hipMemcpy(entry->ptr, entry->cpuBackup, entry->size,
+                    hipMemcpyHostToDevice);
+      if (e != hipSuccess) {
+        WARN("MemManager: resume hipMemcpy HtoD failed for VA=%p (%d)",
+             entry->ptr, (int)e);
+        return ncclUnhandledCudaError;
+      }
+      free(entry->cpuBackup);
+      entry->cpuBackup = nullptr;
+      mgr->cpuBackupUsage -= entry->size;
+    }
+
+    entry->state = ncclDynMemStateActive;
+    ++restoredCount;
+    restoredBytes += entry->size;
+
+    entry = entry->next;
+  }
+
+  NCCLCHECK(resumeCanary(comm));
+  NCCLCHECK(quiesceBarrier(comm, /*tag=*/0xBEEF));
+
+  // P2P re-import not yet implemented (requires ncclProxyClientGetFdBlocking)
+  if (comm->nRanks > 1 && comm->bootstrap != nullptr) {
+    static int warnedOnce = 0;
+    if (__atomic_exchange_n(&warnedOnce, 1, __ATOMIC_RELAXED) == 0) {
+      INFO(NCCL_INIT,
+           "MemManager: peer P2P re-import not yet implemented; relying on "
+           "the caller to drain inter-rank traffic before suspend");
+    }
+  }
+
+  NCCLCHECK(quiesceBarrier(comm, /*tag=*/0xCAFE));
+
+  mgr->released = 0;
+
+  INFO(NCCL_INIT,
+       "MemManager: rank %d resumed canary + %d entries (%zu bytes); "
+       "comm is usable again",
+       comm->rank, restoredCount, restoredBytes);
+  return ncclSuccess;
+}
+
+ncclResult_t ncclCommSuspendCanaryFree(struct ncclComm* comm) {
+  if (comm == nullptr) return ncclSuccess;
+  if (comm->memManager == nullptr) return ncclSuccess;
+  struct ncclSuspendCanary* c = &comm->memManager->canary;
+  if (!c->valid) return ncclSuccess;
+  if (c->handle != nullptr) {
+    (void)hipMemUnmap(c->va, c->size);
+    (void)hipMemRelease(c->handle);
+    c->handle = nullptr;
+  }
+  if (c->va != nullptr) {
+    (void)hipMemAddressFree(c->va, c->size);
+    c->va = nullptr;
+  }
+  c->valid = 0;
+  return ncclSuccess;
+}
+
+ncclResult_t ncclCommSuspendForceResumeForDestroy(struct ncclComm* comm) {
+  if (comm == nullptr || comm->memManager == nullptr) return ncclSuccess;
+  ncclMemManager* mgr = comm->memManager;
+  if (!mgr->released) return ncclSuccess;
+
+  int    count = 0;
+  size_t bytes = 0;
+
+  ncclDynMemEntry* entry = mgr->entries;
+  while (entry != nullptr) {
+    if (entry->isImportedFromPeer || entry->state != ncclDynMemStateReleased) {
+      entry = entry->next;
+      continue;
+    }
+
+    hipMemGenericAllocationHandle_t newHandle = nullptr;
+    if (hipMemCreate(&newHandle, entry->size, &entry->prop, 0) != hipSuccess) {
+      entry = entry->next;
+      continue;
+    }
+    if (hipMemMap(entry->ptr, entry->size, 0, newHandle, 0) != hipSuccess) {
+      (void)hipMemRelease(newHandle);
+      entry = entry->next;
+      continue;
+    }
+    (void)setLocalAccess(entry->ptr, entry->size, entry->cudaDev);
+
+    entry->handle = newHandle;
+    entry->state  = ncclDynMemStateActive;
+    if (entry->cpuBackup != nullptr) {
+      free(entry->cpuBackup);
+      entry->cpuBackup = nullptr;
+      mgr->cpuBackupUsage -= entry->size;
+    }
+    ++count;
+    bytes += entry->size;
+    entry = entry->next;
+  }
+
+  mgr->released = 0;
+
+  INFO(NCCL_INIT,
+       "MemManager: ncclCommDestroy force-resumed %d suspended entries "
+       "(%zu bytes) so destructor walk can free them",
+       count, bytes);
+  return ncclSuccess;
+}
+
+extern "C" {
+
+ncclResult_t ncclCommSuspend_impl(ncclComm_t comm, int flags) {
+  NCCLCHECK(CommCheck(comm, "ncclCommSuspend", "comm"));
+  NCCLCHECK(ncclCommEnsureReady(comm));
+
+  if (flags == 0 || (flags & ~NCCL_SUSPEND_MEM) != 0) {
+    WARN("ncclCommSuspend: invalid flags 0x%x (only NCCL_SUSPEND_MEM=0x%x supported)",
+         flags, NCCL_SUSPEND_MEM);
+    return ncclInvalidArgument;
+  }
+
+  if (ncclParamMemManagerDisable()) {
+    WARN("MemManager: suspend not supported, memory manager is disabled");
+    return ncclInvalidUsage;
+  }
+
+  if (flags & NCCL_SUSPEND_MEM) {
+    if (comm->memManager != nullptr && comm->memManager->refCount > 1) {
+      WARN("ncclCommSuspend: not supported on split_share comms (refCount=%d)",
+           comm->memManager->refCount);
+      return ncclInvalidUsage;
+    }
+
+    INFO(NCCL_INIT, "ncclCommSuspend: rank %d suspending memory", comm->rank);
+    struct ncclMemManagerTask* task =
+        (struct ncclMemManagerTask*)calloc(1, sizeof(*task));
+    if (task == nullptr) return ncclSystemError;
+    task->comm = comm;
+    ncclIntruQueueEnqueue(&comm->suspendTaskQueue, task);
+
+    ncclResult_t ret = ncclSuccess;
+    while (!ncclIntruQueueEmpty(&comm->suspendTaskQueue)) {
+      struct ncclMemManagerTask* t =
+          ncclIntruQueueDequeue(&comm->suspendTaskQueue);
+      ret = ncclCommMemSuspend(t->comm);
+      free(t);
+      if (ret != ncclSuccess) {
+        while (!ncclIntruQueueEmpty(&comm->suspendTaskQueue)) {
+          free(ncclIntruQueueDequeue(&comm->suspendTaskQueue));
+        }
+        if (!comm->config.blocking) (void)ncclCommSetAsyncError(comm, ret);
+        return ret;
+      }
+    }
+  }
+  return ncclSuccess;
+}
+
+ncclResult_t ncclCommResume_impl(ncclComm_t comm) {
+  NCCLCHECK(CommCheck(comm, "ncclCommResume", "comm"));
+  NCCLCHECK(ncclCommEnsureReady(comm));
+
+  if (ncclParamMemManagerDisable()) {
+    WARN("MemManager: resume not supported, memory manager is disabled");
+    return ncclInvalidUsage;
+  }
+  if (comm->memManager != nullptr && comm->memManager->refCount > 1) {
+    WARN("ncclCommResume: not supported on split_share comms (refCount=%d)",
+         comm->memManager->refCount);
+    return ncclInvalidUsage;
+  }
+
+  INFO(NCCL_INIT, "ncclCommResume: rank %d resuming all resources", comm->rank);
+  struct ncclMemManagerTask* task =
+      (struct ncclMemManagerTask*)calloc(1, sizeof(*task));
+  if (task == nullptr) return ncclSystemError;
+  task->comm = comm;
+  ncclIntruQueueEnqueue(&comm->resumeTaskQueue, task);
+
+  ncclResult_t ret = ncclSuccess;
+  while (!ncclIntruQueueEmpty(&comm->resumeTaskQueue)) {
+    struct ncclMemManagerTask* t =
+        ncclIntruQueueDequeue(&comm->resumeTaskQueue);
+    ret = ncclCommMemResume(t->comm);
+    free(t);
+    if (ret != ncclSuccess) {
+      while (!ncclIntruQueueEmpty(&comm->resumeTaskQueue)) {
+        free(ncclIntruQueueDequeue(&comm->resumeTaskQueue));
+      }
+      if (!comm->config.blocking) (void)ncclCommSetAsyncError(comm, ret);
+      return ret;
+    }
+  }
+  return ncclSuccess;
+}
+
+ncclResult_t ncclCommMemStats_impl(ncclComm_t comm, ncclCommMemStat_t stat,
+                                   uint64_t* value) {
+  NCCLCHECK(CommCheck(comm, "ncclCommMemStats", "comm"));
+  if (value == nullptr) return ncclInvalidArgument;
+  NCCLCHECK(ncclCommEnsureReady(comm));
+
+  if (ncclParamMemManagerDisable()) {
+    WARN("MemManager: MemStats not supported, memory manager is disabled");
+    return ncclInvalidUsage;
+  }
+
+  if (comm->memManager == nullptr) {
+    *value = 0;
+    return ncclSuccess;
+  }
+
+  ncclMemManager* mgr = comm->memManager;
+  size_t totalPersist =
+      __atomic_load_n(&mgr->totalPersist, __ATOMIC_RELAXED);
+  size_t totalScratch =
+      __atomic_load_n(&mgr->totalScratch, __ATOMIC_RELAXED);
+  size_t totalOffload =
+      __atomic_load_n(&mgr->totalOffload, __ATOMIC_RELAXED);
+
+  switch (stat) {
+    case ncclStatGpuMemTotal:
+      *value = totalPersist + totalScratch + totalOffload;
+      return ncclSuccess;
+    case ncclStatGpuMemPersist:
+      *value = totalPersist;
+      return ncclSuccess;
+    case ncclStatGpuMemSuspend:
+      *value = totalScratch + totalOffload;
+      return ncclSuccess;
+    case ncclStatGpuMemSuspended:
+      *value = mgr->released ? 1 : 0;
+      return ncclSuccess;
+    default:
+      WARN("ncclCommMemStats: unknown stat %d", (int)stat);
+      return ncclInvalidArgument;
+  }
+}
+
+}  // extern "C"

--- a/projects/rccl/src/misc/api_trace.cc
+++ b/projects/rccl/src/misc/api_trace.cc
@@ -152,6 +152,8 @@ ncclCommWindowRegister_impl(ncclComm_t comm, void* buff, size_t size, ncclWindow
 ncclResult_t
 ncclCommWindowDeregister_impl(ncclComm_t comm, ncclWindow_t win);
 
+#include "mem_manager.h"
+
 ncclResult_t
 ncclAllReduceWithBias_impl(const void* sendbuff, void* recvbuff, size_t count,
                    ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm,
@@ -269,11 +271,14 @@ RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommWindowRegister_fn, 39);
 RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommWindowDeregister_fn, 40);
 RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclAlltoAll_fn, 41);
 RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclAlltoAllv_fn, 42);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommSuspend_fn, 43);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommResume_fn, 44);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommMemStats_fn, 45);
 // DO NOT REORDER, ADD NEW ITEMS HERE
 
 #undef RCCL_ASSERT_OFFSET
 
-static_assert(sizeof(rcclApiFuncTable) == compute_table_size(43),
+static_assert(sizeof(rcclApiFuncTable) == compute_table_size(46),
               "Update table major/step version and add a new offset assertion if this "
               "fails to compile");
 
@@ -326,7 +331,10 @@ RcclGetFunctionTable_impl()
                                                &ncclCommWindowRegister_impl,
                                                &ncclCommWindowDeregister_impl,
                                                &ncclAlltoAll_impl,
-                                               &ncclAlltoAllv_impl
+                                               &ncclAlltoAllv_impl,
+                                               &ncclCommSuspend_impl,
+                                               &ncclCommResume_impl,
+                                               &ncclCommMemStats_impl
                                                // DO NOT REORDER, ADD NEW ITEMS HERE
                                              };
 
@@ -443,6 +451,12 @@ NCCL_API(ncclResult_t, ncclCommShrink, ncclComm_t comm, int* excludeRanksList, i
 
 NCCL_API(ncclResult_t, ncclCommSplit, ncclComm_t comm, int color, int key,
          ncclComm_t* newcomm, ncclConfig_t* config);
+
+NCCL_API(ncclResult_t, ncclCommSuspend, ncclComm_t comm, int flags);
+
+NCCL_API(ncclResult_t, ncclCommResume, ncclComm_t comm);
+
+NCCL_API(ncclResult_t, ncclCommMemStats, ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value);
 
 NCCL_API(const char*, ncclGetErrorString, ncclResult_t code);
 
@@ -787,4 +801,22 @@ ncclResult_t
 ncclCommWindowDeregister(ncclComm_t comm, ncclWindow_t win)
 {
     return ::rccl::RcclGetFunctionTable()->ncclCommWindowDeregister_fn(comm, win);
+}
+
+ncclResult_t
+ncclCommSuspend(ncclComm_t comm, int flags)
+{
+    return ::rccl::RcclGetFunctionTable()->ncclCommSuspend_fn(comm, flags);
+}
+
+ncclResult_t
+ncclCommResume(ncclComm_t comm)
+{
+    return ::rccl::RcclGetFunctionTable()->ncclCommResume_fn(comm);
+}
+
+ncclResult_t
+ncclCommMemStats(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value)
+{
+    return ::rccl::RcclGetFunctionTable()->ncclCommMemStats_fn(comm, stat, value);
 }

--- a/projects/rccl/src/nccl.h.in
+++ b/projects/rccl/src/nccl.h.in
@@ -25,6 +25,7 @@
 #define RCCL_GATHER_SCATTER 1
 #define RCCL_ALLTOALLV 1
 #define RCCL_ALLREDUCE_WITH_BIAS 1
+#define RCCL_SUSPEND_RESUME 1
 
 #ifdef __cplusplus
 extern "C" {
@@ -434,6 +435,35 @@ ncclResult_t pncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, n
 ncclResult_t  ncclCommWindowDeregister(ncclComm_t comm, ncclWindow_t win);
 /*! @cond       include_hidden */
 ncclResult_t pncclCommWindowDeregister(ncclComm_t comm, ncclWindow_t win);
+/*! @endcond */
+
+/* Communicator suspend flags */
+#define NCCL_SUSPEND_MEM 0x01
+
+/* Communicator memory statistics */
+typedef enum {
+  ncclStatGpuMemSuspend      = 0,
+  ncclStatGpuMemSuspended    = 1,
+  ncclStatGpuMemPersist      = 2,
+  ncclStatGpuMemTotal        = 3
+} ncclCommMemStat_t;
+
+/* Suspend communicator operations to free resources */
+ncclResult_t  ncclCommSuspend(ncclComm_t comm, int flags);
+/*! @cond       include_hidden */
+ncclResult_t pncclCommSuspend(ncclComm_t comm, int flags);
+/*! @endcond */
+
+/* Resume all previously suspended communicator resources */
+ncclResult_t  ncclCommResume(ncclComm_t comm);
+/*! @cond       include_hidden */
+ncclResult_t pncclCommResume(ncclComm_t comm);
+/*! @endcond */
+
+/* Query communicator memory statistics */
+ncclResult_t  ncclCommMemStats(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value);
+/*! @cond       include_hidden */
+ncclResult_t pncclCommMemStats(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value);
 /*! @endcond */
 
 /*! @defgroup   rccl_api_enumerations API Enumerations

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -274,6 +274,7 @@ if(BUILD_TESTS)
       transport/NetIbMPI/NicFusionTests.cpp
       ImplicitLaunchOrderMPITests.cpp
       RegistrationMPITests.cpp
+      SuspendResumeMPITests.cpp
     )
 
     add_executable(rccl-UnitTestsMPI ${MPI_TEST_SOURCE_FILES})

--- a/projects/rccl/test/SuspendResumeMPITests.cpp
+++ b/projects/rccl/test/SuspendResumeMPITests.cpp
@@ -1,0 +1,541 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+/**
+ * @file SuspendResumeMPITests.cpp
+ * @brief Multi-process MPI tests for ncclCommSuspend / ncclCommResume /
+ *        ncclCommMemStats.
+ *
+ * Coverage matrix:
+ *
+ *  Happy paths
+ *    - SuspendResumeBasic_BasicCycle              one Suspend->Resume round-trip
+ *    - SuspendResumeBasic_MultipleCycles          5 back-to-back cycles
+ *    - SuspendResumeBasic_BarrierSync             rank 0 sleeps before
+ *                                                 suspend; all other ranks
+ *                                                 must block until it joins
+ *                                                 the bootstrapBarrier
+ *    - MemStats_BeforeAndAfter                    ncclStatGpuMem* reports the
+ *                                                 expected values across the
+ *                                                 active/suspended/resumed
+ *                                                 transitions
+ *    - MemStats_Conservation                      total + suspended bytes is
+ *                                                 monotonically conserved
+ *                                                 across a Suspend
+ *    - CollectiveIntegrity_AllReduceAfterResume   real ncclAllReduce round-trip
+ *                                                 still produces the right
+ *                                                 answer after Suspend/Resume
+ *    - CollectiveIntegrity_AllReduceTwoCycles     same after multiple cycles
+ *    - Lifecycle_DestroyWhileSuspended            ncclCommDestroy succeeds on
+ *                                                 a comm whose memory is
+ *                                                 still suspended (the
+ *                                                 force-resume-for-destroy
+ *                                                 path is exercised)
+ *
+ *  Argument-validation / corner cases (no bootstrapBarrier reached, so each
+ *  rank can fail independently without deadlocking the others):
+ *    - ArgValidation_ZeroFlags
+ *    - ArgValidation_UnknownFlagsRejected
+ *    - ArgValidation_DoubleSuspend
+ *    - ArgValidation_ResumeWhenActive
+ *    - ArgValidation_DoubleResume
+ *    - MemStatsValidation_NullValuePtr
+ *    - MemStatsValidation_UnknownStat
+ *
+ *  Required environment:
+ *    - MPI launch with at least 2 processes (1 GPU per rank)
+ *    - For maximum signal, run with NCCL_DEBUG=INFO and inspect the
+ *      `ncclCommSuspend / ncclCommResume` lines per rank.
+ *
+ *  Caveats / known issues exercised here only with NCCL_CUMEM_ENABLE=0:
+ *    The pre-existing RCCL+ROCm 7.0.x p2p init crash with
+ *    NCCL_CUMEM_ENABLE=1 + nRanks>1 is unrelated to suspend/resume but
+ *    means these tests must NOT set NCCL_CUMEM_ENABLE=1; in default
+ *    (CUMEM=0) configuration the canary roundtrip is the gated piece.
+ *
+ *  Example invocations:
+ *    mpirun -np 2 ./rccl-UnitTestsMPI \
+ *           --gtest_filter="SuspendResumeBasic*:SuspendResumeMemStats*"
+ *    mpirun -np 4 ./rccl-UnitTestsMPI \
+ *           --gtest_filter="SuspendResumeArgValidation*"
+ */
+
+#include "DeviceBufferHelpers.hpp"
+#include "MPITestBase.hpp"
+#include "MPIHelpers.hpp"
+#include "ResourceGuards.hpp"
+#include "TestChecks.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <thread>
+#include <vector>
+
+#ifdef MPI_TESTS_ENABLED
+
+using namespace MPITestConstants;
+using namespace RCCLTestGuards;
+using namespace RCCLTestHelpers;
+
+namespace SuspendResumeTestConfig
+{
+    constexpr int    kMinRanks         = 2;     // multi-rank tests need >= 2
+    constexpr size_t kAllReduceCount   = 1024;  // 4 KiB float buffer
+    constexpr float  kEpsilon          = 1e-3f;
+    constexpr int    kMultiCycleCount  = 5;
+    constexpr int    kBarrierSleepMs   = 200;   // rank-0 stagger time
+} // namespace SuspendResumeTestConfig
+
+using namespace SuspendResumeTestConfig;
+
+/**
+ * @class SuspendResumeMPITestBase
+ * @brief Shared fixture for all suspend/resume MPI tests.
+ *
+ * Wraps MPITestBase to keep the setup/teardown trivial for individual
+ * test cases.  Test cases call `createTestCommunicator()` themselves so
+ * that argument-validation tests can also exercise sequences before the
+ * comm is built (e.g. NULL-comm checks).
+ */
+class SuspendResumeMPITestBase : public MPITestBase
+{
+protected:
+    // Convenience accessor: read one ncclCommMemStat as uint64_t. Fails the
+    // test on any non-success return so that callers can read the value
+    // directly.
+    uint64_t readStat(ncclComm_t comm, ncclCommMemStat_t stat)
+    {
+        uint64_t v = ~uint64_t{0};
+        ncclResult_t r = ncclCommMemStats(comm, stat, &v);
+        EXPECT_EQ(r, ncclSuccess) << "ncclCommMemStats failed for stat " << (int)stat;
+        return v;
+    }
+
+    // Run an AllReduce with float-sum and verify each element equals
+    // sum(1..nranks).  Returns true on success.
+    bool runAllReduceAndVerify(ncclComm_t comm, hipStream_t stream)
+    {
+        const size_t n     = kAllReduceCount;
+        const int    rank  = MPIEnvironment::world_rank;
+        const int    nrnks = MPIEnvironment::world_size;
+
+        void* sendbuf = nullptr;
+        void* recvbuf = nullptr;
+        if (hipMalloc(&sendbuf, n * sizeof(float)) != hipSuccess) return false;
+        if (hipMalloc(&recvbuf, n * sizeof(float)) != hipSuccess)
+        {
+            (void)hipFree(sendbuf);
+            return false;
+        }
+        auto sendGuard = makeDeviceBufferAutoGuard(sendbuf);
+        auto recvGuard = makeDeviceBufferAutoGuard(recvbuf);
+
+        // sendbuf := rank+1
+        if (initializeBufferWithPattern<float>(
+                sendbuf, n,
+                [rank](size_t) { return static_cast<float>(rank + 1); }) != hipSuccess)
+            return false;
+        if (zeroInitializeBuffer<float>(recvbuf, n) != hipSuccess) return false;
+
+        if (ncclAllReduce(sendbuf, recvbuf, n, ncclFloat32, ncclSum, comm, stream)
+            != ncclSuccess)
+            return false;
+        if (hipStreamSynchronize(stream) != hipSuccess) return false;
+
+        const float expected = static_cast<float>(nrnks * (nrnks + 1) / 2);
+        return verifyBufferData<float>(
+            recvbuf, n,
+            [expected](size_t) { return expected; },
+            0,
+            static_cast<double>(kEpsilon * expected));
+    }
+};
+
+// ============================================================================
+// 1. Basic happy-path tests
+// ============================================================================
+
+class SuspendResumeBasic : public SuspendResumeMPITestBase {};
+
+TEST_F(SuspendResumeBasic, BasicCycle)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended))
+        << "Newly initialized comm must report not-suspended";
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    EXPECT_EQ(1u, readStat(comm, ncclStatGpuMemSuspended))
+        << "After Suspend, ncclStatGpuMemSuspended must be 1";
+
+    // ncclStatGpuMemSuspend == totalScratch + totalOffload of *tracked*
+    // entries (matches NCCL upstream semantics). The canary is not a
+    // tracked user allocation and is not counted here. With NCCL_CUMEM_ENABLE=0
+    // the comm's internal allocations are not VMM-backed and therefore not
+    // tracked, so the count is legitimately zero. With CUMEM=1 it is > 0.
+    uint64_t suspBytes = readStat(comm, ncclStatGpuMemSuspend);
+    TEST_INFO("Rank %d ncclStatGpuMemSuspend after Suspend = %llu bytes",
+              MPIEnvironment::world_rank, (unsigned long long)suspBytes);
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+    EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended))
+        << "After Resume, ncclStatGpuMemSuspended must be 0";
+}
+
+TEST_F(SuspendResumeBasic, MultipleCycles)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    for (int i = 0; i < kMultiCycleCount; ++i)
+    {
+        TEST_INFO("Cycle %d: Suspend", i);
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+        EXPECT_EQ(1u, readStat(comm, ncclStatGpuMemSuspended)) << "cycle " << i;
+
+        TEST_INFO("Cycle %d: Resume", i);
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+        EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended)) << "cycle " << i;
+    }
+}
+
+TEST_F(SuspendResumeBasic, BarrierSync)
+{
+    // Rank 0 stages a deliberate delay before calling Suspend. Without the
+    // bootstrapBarrier inside ncclCommSuspend, the other ranks would return
+    // immediately and the elapsed time on those ranks would be much smaller
+    // than rank 0's. With the barrier wired up correctly, every rank must
+    // observe at least kBarrierSleepMs of elapsed wall-clock between the
+    // (cross-rank) start of the call and its return.
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    // Synchronize start across ranks.
+    MPI_Barrier(MPI_COMM_WORLD);
+    auto t0 = std::chrono::steady_clock::now();
+
+    if (MPIEnvironment::world_rank == 0)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(kBarrierSleepMs));
+    }
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    auto t1 = std::chrono::steady_clock::now();
+
+    auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                         t1 - t0).count();
+
+    // Allow generous slack -- this is a synchronization assertion, not a
+    // micro-benchmark: every rank should have waited *at least* roughly
+    // half the staged delay.  Without a barrier, the non-zero ranks would
+    // typically observe < 10 ms.
+    EXPECT_GE(elapsed_ms, kBarrierSleepMs / 2)
+        << "Rank " << MPIEnvironment::world_rank
+        << ": Suspend returned in " << elapsed_ms
+        << " ms (rank 0 staged a " << kBarrierSleepMs
+        << " ms delay; expected the barrier to hold every rank)";
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+}
+
+// ============================================================================
+// 2. Memory-statistics correctness
+// ============================================================================
+
+class SuspendResumeMemStats : public SuspendResumeMPITestBase {};
+
+TEST_F(SuspendResumeMemStats, BeforeAndAfter)
+{
+    // NCCL upstream semantics: ncclCommMemStats reads per-type counters on
+    // the memory manager. The counters cover *tracked* allocations only --
+    // i.e. entries that ncclMemTrack accepted. With NCCL_CUMEM_ENABLE=0
+    // RCCL skips tracking (HIP introspection is unsafe on non-VMM ptrs),
+    // so all counters legitimately read zero; the suspended boolean still
+    // toggles via the canary round-trip. With CUMEM=1, counters are
+    // non-zero and persist across the suspend boundary (Suspend doesn't
+    // change totalScratch/totalOffload -- it only flips `released`).
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    uint64_t totalActive = readStat(comm, ncclStatGpuMemTotal);
+    uint64_t suspActive  = readStat(comm, ncclStatGpuMemSuspend);
+    uint64_t persActive  = readStat(comm, ncclStatGpuMemPersist);
+    uint64_t isSusActive = readStat(comm, ncclStatGpuMemSuspended);
+    EXPECT_EQ(isSusActive, 0u) << "fresh comm must not be suspended";
+    EXPECT_EQ(totalActive, persActive + suspActive)
+        << "Total = persist + (scratch+offload) invariant";
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+
+    uint64_t totalSusp = readStat(comm, ncclStatGpuMemTotal);
+    uint64_t suspSusp  = readStat(comm, ncclStatGpuMemSuspend);
+    uint64_t isSusSusp = readStat(comm, ncclStatGpuMemSuspended);
+    EXPECT_EQ(isSusSusp, 1u) << "after Suspend, suspended boolean must be 1";
+    EXPECT_EQ(totalSusp, totalActive)
+        << "Suspend does not change tracked byte counters (mirrors NCCL)";
+    EXPECT_EQ(suspSusp, suspActive)
+        << "Suspend does not change scratch/offload byte counters";
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+
+    uint64_t totalResumed = readStat(comm, ncclStatGpuMemTotal);
+    uint64_t isSusResumed = readStat(comm, ncclStatGpuMemSuspended);
+    EXPECT_EQ(isSusResumed, 0u);
+    EXPECT_EQ(totalResumed, totalActive)
+        << "Resume does not change tracked byte counters either";
+
+    TEST_INFO("rank %d: total=%llu persist=%llu suspendable=%llu "
+              "[scratch+offload] (CUMEM gates whether non-zero)",
+              MPIEnvironment::world_rank,
+              (unsigned long long)totalActive,
+              (unsigned long long)persActive,
+              (unsigned long long)suspActive);
+}
+
+TEST_F(SuspendResumeMemStats, Conservation)
+{
+    // ncclCommMemStats reports per-type byte counters on the memory
+    // manager; Suspend doesn't move bytes between the persist / scratch /
+    // offload buckets, it only flips the released boolean. So the
+    // identity Total = Persist + (Scratch+Offload) holds in every state,
+    // and Total/Persist/Suspend are constant across a Suspend->Resume
+    // round-trip. (CPU backup memory used by ncclMemOffload entries is
+    // tracked separately on manager->cpuBackupUsage and not part of the
+    // public stats.)
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    uint64_t totalA = readStat(comm, ncclStatGpuMemTotal);
+    uint64_t persA  = readStat(comm, ncclStatGpuMemPersist);
+    uint64_t suspA  = readStat(comm, ncclStatGpuMemSuspend);
+    EXPECT_EQ(totalA, persA + suspA);
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    uint64_t totalS = readStat(comm, ncclStatGpuMemTotal);
+    uint64_t persS  = readStat(comm, ncclStatGpuMemPersist);
+    uint64_t suspS  = readStat(comm, ncclStatGpuMemSuspend);
+    EXPECT_EQ(totalS, totalA);
+    EXPECT_EQ(persS,  persA);
+    EXPECT_EQ(suspS,  suspA);
+    EXPECT_EQ(totalS, persS + suspS);
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+
+    uint64_t totalR = readStat(comm, ncclStatGpuMemTotal);
+    EXPECT_EQ(totalR, totalA);
+}
+
+// ============================================================================
+// 3. Collective integrity across a suspend/resume cycle
+// ============================================================================
+
+class SuspendResumeCollectiveIntegrity : public SuspendResumeMPITestBase {};
+
+TEST_F(SuspendResumeCollectiveIntegrity, AllReduceAfterResume)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t  comm   = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+
+    // Sanity-check the comm before suspend.
+    EXPECT_TRUE(runAllReduceAndVerify(comm, stream))
+        << "AllReduce baseline failed before any Suspend";
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+
+    EXPECT_TRUE(runAllReduceAndVerify(comm, stream))
+        << "AllReduce produced wrong values after Suspend/Resume cycle";
+}
+
+TEST_F(SuspendResumeCollectiveIntegrity, AllReduceTwoCycles)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t  comm   = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+
+    EXPECT_TRUE(runAllReduceAndVerify(comm, stream)) << "baseline AllReduce";
+
+    for (int i = 0; i < 2; ++i)
+    {
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+
+        EXPECT_TRUE(runAllReduceAndVerify(comm, stream))
+            << "AllReduce wrong after cycle " << i;
+    }
+}
+
+// ============================================================================
+// 4. Lifecycle: destroy while suspended (force-resume-for-destroy path)
+// ============================================================================
+
+class SuspendResumeLifecycle : public SuspendResumeMPITestBase
+{
+protected:
+    // We tear down our own comm in this test rather than relying on the
+    // base class, so that we drive ncclCommDestroy from a suspended state.
+    void TearDown() override
+    {
+        // No-op: each test explicitly destroys its own comm.
+        // Skip MPITestBase::TearDown's cleanupTestCommunicator since the
+        // test already destroyed it.
+        test_comm_   = nullptr;
+        test_stream_ = nullptr;
+    }
+};
+
+TEST_F(SuspendResumeLifecycle, DestroyWhileSuspended)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t  comm   = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    EXPECT_EQ(1u, readStat(comm, ncclStatGpuMemSuspended));
+
+    // Tear the comm down without resuming first. The implementation must
+    // restore mappings internally (force-resume-for-destroy) so the
+    // destructor walk can free each pointer cleanly. A bug here would
+    // SIGSEGV during ncclCuMemFree on an unmapped VA.
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommDestroy(comm));
+    test_comm_ = nullptr;
+    if (stream != nullptr)
+    {
+        (void)hipStreamDestroy(stream);
+        test_stream_ = nullptr;
+    }
+}
+
+// ============================================================================
+// 5. Argument validation / corner cases
+//
+// Each of these returns from inside ncclCommSuspend/Resume/MemStats BEFORE
+// the bootstrapBarrier is reached, so individual ranks failing the call do
+// not leave their peers blocked on a barrier.
+// ============================================================================
+
+class SuspendResumeArgValidation : public SuspendResumeMPITestBase {};
+
+TEST_F(SuspendResumeArgValidation, ZeroFlags)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    // flags == 0 must be rejected on every rank (no barrier reached).
+    ASSERT_MPI_EQ(ncclInvalidArgument, ncclCommSuspend(comm, 0));
+
+    // Comm must remain in active state after the rejected call.
+    EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended))
+        << "rejected Suspend should not transition the comm";
+
+    // A subsequent valid call must still succeed.
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+}
+
+TEST_F(SuspendResumeArgValidation, UnknownFlagsRejected)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    // Bogus high bits must be rejected (no barrier reached).
+    ASSERT_MPI_EQ(ncclInvalidArgument, ncclCommSuspend(comm, 0xffff));
+    ASSERT_MPI_EQ(ncclInvalidArgument,
+                  ncclCommSuspend(comm, NCCL_SUSPEND_MEM | 0x80));
+
+    // Subsequent valid call still works.
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+}
+
+TEST_F(SuspendResumeArgValidation, DoubleSuspend)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    // First suspend goes through the barrier successfully.
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+
+    // Second suspend rejects on every rank before reaching the barrier
+    // (state check sees comm->memManager->released==1).
+    ASSERT_MPI_EQ(ncclInvalidUsage, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+
+    // Resume restores active state.
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+    EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended));
+}
+
+TEST_F(SuspendResumeArgValidation, ResumeWhenActive)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    // Resume on an already-active comm must reject before any barrier.
+    ASSERT_MPI_EQ(ncclInvalidUsage, ncclCommResume(comm));
+
+    EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended))
+        << "rejected Resume should not transition the comm";
+}
+
+TEST_F(SuspendResumeArgValidation, DoubleResume)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+
+    // Second resume rejects -- comm is no longer suspended.
+    ASSERT_MPI_EQ(ncclInvalidUsage, ncclCommResume(comm));
+
+    EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended));
+}
+
+// ----- ncclCommMemStats validation --------------------------------------
+
+class SuspendResumeMemStatsValidation : public SuspendResumeMPITestBase {};
+
+TEST_F(SuspendResumeMemStatsValidation, NullValuePtr)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    EXPECT_EQ(ncclInvalidArgument,
+              ncclCommMemStats(comm, ncclStatGpuMemTotal, nullptr));
+    EXPECT_EQ(ncclInvalidArgument,
+              ncclCommMemStats(comm, ncclStatGpuMemSuspend, nullptr));
+}
+
+TEST_F(SuspendResumeMemStatsValidation, UnknownStat)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    uint64_t v = 0;
+    EXPECT_EQ(ncclInvalidArgument,
+              ncclCommMemStats(comm, static_cast<ncclCommMemStat_t>(999), &v));
+    EXPECT_EQ(ncclInvalidArgument,
+              ncclCommMemStats(comm, static_cast<ncclCommMemStat_t>(-1), &v));
+}
+
+#endif // MPI_TESTS_ENABLED


### PR DESCRIPTION
## Summary

- Adds `ncclCommSuspend`, `ncclCommResume`, and `ncclCommMemStats` public APIs to RCCL, matching NCCL upstream signatures
- Implements a per-communicator VMM memory manager (`ncclMemManager`) that tracks dynamic GPU allocations and supports full suspend/resume cycles (unmap+release on suspend, re-create+map+restore on resume)
- Includes a suspend canary — a lightweight VMM sentinel buffer for round-trip validation of HIP VMM operations
- Offload-type buffers get automatic DtoH backup on suspend and HtoD restore on resume
- Bootstrap barriers (tags `0xBEEF`, `0xCAFE`) synchronize multi-rank quiesce during suspend/resume
- Fixes `ncclCuMemFree` deallocation order in `alloc.h` to avoid double-release SIGSEGV on ROCm 7.0.x (retain → unmap → release → address_free)
- Feature detection macro: `#define RCCL_SUSPEND_RESUME 1`

## Test plan

- [x] 15 MPI-based gtest cases across 6 suites (SuspendResumeBasic, MemStats, CollectiveIntegrity, Lifecycle, ArgValidation, MemStatsValidation)
- [x] Scale-up: 8 GPUs / 1 node (dell300x-ccs-aus-k13-03)
- [x] Scale-out: 16 GPUs / 2 nodes (k13-03 + k13-09)
- [x] All 15 tests passing on all configurations

## Follow-up items (NCCL alignment gaps)

### Critical

- [ ] **P2P imported buffer suspend/resume**: NCCL suspends/resumes peer-imported VMM mappings (`isImportedFromPeer` entries). Current RCCL implementation skips imported entries — needs IPC handle exchange during resume
- [ ] **Peer access restoration on resume**: NCCL calls `ncclTransportP2pSetup` + `hipDeviceEnablePeerAccess` after resume. RCCL does not restore peer access
- [ ] **Missing `ncclDynMemP2pHandleInfo`**: NCCL uses a separate struct for P2P export handles with `hipIpcMemHandle_t`. RCCL uses a simpler `ncclDynMemLocalDesc`
- [ ] **No FABRIC handle support**: NCCL supports `hipMemHandleTypeFabric` (multi-node VMM). RCCL only handles POSIX file descriptor handles
- [ ] **Pinned host memory tracking**: NCCL's `ncclCudaHostAlloc`/`ncclCudaHostFree` track host allocations via the memory manager. RCCL does not track host memory
- [ ] **Persistent memory suspend**: NCCL suspends persistent allocations (with DtoH backup). RCCL only suspends scratch/offload types

### Medium

- [ ] **Group-based suspend/resume**: NCCL supports `ncclGroupStart()`/`ncclGroupEnd()` wrapping of suspend/resume calls for atomic multi-comm operations
- [ ] **Device save/restore in entries**: NCCL saves `cudaDev` per entry and does `hipSetDevice` during resume. RCCL uses `commCudaDev` globally
- [ ] **Proxy thread lifecycle**: NCCL pauses/resumes proxy threads during suspend/resume. RCCL does not manage proxy state
- [ ] **Net plugin suspend hooks**: NCCL calls `ncclNet->suspend()`/`resume()` to let network plugins release/restore resources
- [ ] **Comm state machine integration**: NCCL integrates suspend state into the comm state machine (`ncclCommStateSuspend`). RCCL manages state only via `memManager.released` flag

### RCCL-only additions (not in NCCL)

- Suspend canary (VMM sentinel for HIP VMM round-trip validation)
- `ncclCommSuspendForceResumeForDestroy` (best-effort remap for safe destructor walk)
- Bootstrap barrier synchronization during suspend/resume
- Runtime VMM probing via `hipPointerGetAttributes` + `hipMemRetainAllocationHandle` in `snapshotEntryForSuspend`