### PR TITLE
clr: raise DEBUG_CLR_BATCH_CPU_SYNC_SIZE default from 8 to 16

### DIFF
--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -271,7 +271,7 @@ release(uint, HIP_SKIP_ABORT_ON_GPU_ERROR, true,                              \
         "Set this to true, to avoid host side abort for GPU errors")          \
 release(bool, HIP_FORCE_SPIRV_CODEOBJECT, false,                              \
         "Force use of SPIRV instead of device specific code object.")         \
-release(uint, DEBUG_CLR_BATCH_CPU_SYNC_SIZE, 8,                               \
+release(uint, DEBUG_CLR_BATCH_CPU_SYNC_SIZE, 16,                               \
         "Forces the minimum batch size for CPU sync")  // clang-format on
 
 namespace amd {


### PR DESCRIPTION
## Motivation

On MI308X (CPX) inference workloads (TensorFlow + hipBLASLt), the default value of 8 causes a ~54% P99 latency regression vs ROCm 6.3.4 (P99 4154us -> 6402us).

Note on branch targeting: this PR targets release/rocm-rel-7.2 because that is where the regression was validated. The same one-line fix is also needed on develop (same default value). 

## Technical Details
HostQueue::finish() constructs a Marker with cpu_wait = (batchSize < DEBUG_CLR_BATCH_CPU_SYNC_SIZE). With the default of 8, the typical submission batch size for per-inference GEMM chains (~8-16) straddles the threshold and a large fraction of finish() calls take the submitMarker barrier path, dispatching an unnecessary AQL barrier packet on every sync. Those extra barriers serialize GPU execution and inflate IsHwEventReady() wait time.

Raising the default to 16 pushes the majority of these calls onto the lightweight flush() path (which only dispatches a barrier when hasPendingDispatch_ is set), eliminating the regression:

  P99:     6402us -> 4108us  (-36%)
  mean:    4261us -> 3851us  (-10%)
  stddev:   853us ->  118us  (-86%)

This restores parity with ROCm 6.3.4 without any user-visible API change. A sweep of values (0, 8, 16, 32, 64) shows 16-32 as the sweet spot; 0 and 64+ both regress for different reasons, so a conservative bump to 16 is chosen here.

## JIRA ID

ROCM-14140

## Test Plan

Tested on: MI308X CPX mode, TF + hipBLASLt GSU inference.
Workaround previously: export DEBUG_CLR_BATCH_CPU_SYNC_SIZE=16

## Test Result

Passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
