### PR TITLE
[clr] reduce fence scope for some coop group sync

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/hip_cooperative_groups_helper.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/hip_cooperative_groups_helper.h
@@ -249,14 +249,14 @@ __CG_STATIC_QUALIFIER__ void barrier_wait() {
 namespace tiled_group {
 
 // enforce ordering for memory intructions
-__CG_STATIC_QUALIFIER__ void sync() { __builtin_amdgcn_fence(__ATOMIC_ACQ_REL, "agent"); }
+__CG_STATIC_QUALIFIER__ void sync() { __builtin_amdgcn_fence(__ATOMIC_ACQ_REL, "wavefront"); }
 
 }  // namespace tiled_group
 
 namespace coalesced_group {
 
 // enforce ordering for memory intructions
-__CG_STATIC_QUALIFIER__ void sync() { __builtin_amdgcn_fence(__ATOMIC_ACQ_REL, "agent"); }
+__CG_STATIC_QUALIFIER__ void sync() { __builtin_amdgcn_fence(__ATOMIC_ACQ_REL, "wavefront"); }
 
 // Masked bit count
 //

--- a/projects/clr/hipamd/include/hip/amd_detail/hip_cooperative_groups_helper.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/hip_cooperative_groups_helper.h
@@ -248,14 +248,14 @@ __CG_STATIC_QUALIFIER__ void barrier_wait() {
 
 namespace tiled_group {
 
-// enforce ordering for memory intructions
+// enforce ordering for memory instructions
 __CG_STATIC_QUALIFIER__ void sync() { __builtin_amdgcn_fence(__ATOMIC_ACQ_REL, "wavefront"); }
 
 }  // namespace tiled_group
 
 namespace coalesced_group {
 
-// enforce ordering for memory intructions
+// enforce ordering for memory instructions
 __CG_STATIC_QUALIFIER__ void sync() { __builtin_amdgcn_fence(__ATOMIC_ACQ_REL, "wavefront"); }
 
 // Masked bit count


### PR DESCRIPTION
## Motivation

Reduce the fence scope for some coop group sync.

## Technical Details

For tiled group and coalesced group, we do not need to issue an agent level fence. On ptx its a `bar.warp.sync -1`. Making it a wavefront sync instead.

## JIRA ID

Resolves ROCM-23690

## Test Plan

Existing tests should work fine and performance of standalone app should improve.

## Test Result

Performance improves.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
