### PR TITLE
[rocprofiler-systems] Prevent librocprof-sys-dl.so from being unintentionally mutated

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -2202,6 +2202,7 @@ main(int argc, char** argv)
     {
         for(auto* itr : _objs)
         {
+            if(itr->name().find("librocprof-sys") != std::string::npos) continue;
             try
             {
                 itr->insertFiniCallback(_fini_sequence);


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

If using binary-rewrite mode on a library, it may be that `librocprof-sys-dl.so` is also rewritten and appears in the CWD of where the binary-rewrite command was used (`rocprof-sys-instrument -o ...`). This only occurs if dyninst can see the `_fini` symbol, which can be achieved by building with `ROCPROFSYS_STRIP_LIBRARIES=OFF`.

The reason it was being rewritten is because when calling dyninst's `insertFiniCallback(...)`, we did not skip `librocprof-sys` libraries. Interestingly enough, `librocprof-sys` libraries were skipped for `insertInitCallback(...)` (https://github.com/ROCm/rocm-systems/blob/develop/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp#L2167), so it appears that someone forgot to skip the `_fini`.

**Note**: Dyninst sees `librocprof-sys-dl.so` because `rocprof-sys-instrument` explicitly loads it with `BPatch_binaryEdit::loadLibrary(...)` so inserted snippets can call `rocprof-sys` runtime entry points such as `rocprofsys_push_trace`... Once loaded this way, Dyninst tracks it as a secondary `BinaryEdit`. If `rocprof-sys` inserts a callback into it, Dyninst marks it dirty and writes it during `writeFile(...)`.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Skip `librocprof-sys` from having `insertFiniCallback` affect it.
*This is the same thing as was done for `insertInitCallback` (https://github.com/ROCm/rocm-systems/blob/develop/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp#L2167)

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

AIPROFSYST-94

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Tested locally when `ROCPROFSYS_STRIP_LIBRARIES=OFF`

## Test Result

<!-- Briefly summarize test outcomes. -->

Before: Contaminated `librocprof-sys-dl.so` observed

After: No longer present

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
