### PR TITLE
[rocprofiler-systems] Add guard for pmc::sampler reinit function for forked processes

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.cpp
@@ -108,6 +108,19 @@ std::unique_ptr<cpu_collector_t> g_cpu_collector;
 
 std::vector<collectors::collector_slice> g_collector_slices;
 
+std::atomic<bool> g_reinit_pending{ false };
+
+void
+should_reinit()
+{
+    bool _expected = true;
+    if(!g_reinit_pending.compare_exchange_strong(_expected, false)) return;
+
+    LOG_DEBUG("Performing deferred PMC reinit after fork.");
+    shutdown();
+    setup();
+}
+
 }  // namespace
 
 void
@@ -130,6 +143,8 @@ config()
 void
 sample()
 {
+    should_reinit();
+
     auto_lock_t _lk{ type_mutex<category::amd_smi>() };
 
     if(pmc::get_state() != State::Active)
@@ -269,9 +284,10 @@ postfork_child_cleanup()
 void
 postfork_parent_reinit()
 {
-    LOG_DEBUG("Reinitializing PMC sampling in parent process after fork.");
-    shutdown();
-    setup();
+    // Cannot call shutdown()/setup() here: setup() queries AMD SMI, which
+    // internally calls fork(), which would re-enter the postfork handler
+    // chain while glibc still holds __fork_lock. Defer to next sample().
+    g_reinit_pending.store(true);
 }
 
 }  // namespace rocprofsys::pmc

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.cpp
@@ -111,7 +111,7 @@ std::vector<collectors::collector_slice> g_collector_slices;
 std::atomic<bool> g_reinit_pending{ false };
 
 void
-should_reinit()
+reinit_if_pending()
 {
     bool _expected = true;
     if(!g_reinit_pending.compare_exchange_strong(_expected, false)) return;
@@ -143,7 +143,7 @@ config()
 void
 sample()
 {
-    should_reinit();
+    reinit_if_pending();
 
     auto_lock_t _lk{ type_mutex<category::amd_smi>() };
 


### PR DESCRIPTION
## Motivation

Seems like newer version of amd-smi library is calling fork and spawning helpers for each `get_metrics` request. This colides with forking within rocprofiler systems code and causes deadlocks and crashes when running application that forks and uses amd_smi for capturing traces. 

## Technical Details

### Root cause was: 

- `pmc::postfork_parent_reinit` ran inside glibc's `__run_postfork_handlers` (which holds `__fork_lock`) and called `pmc::setup` → `amdsmi_get_gpu_memory_usage` → AMD SMI internally `fork()`s → re-enters the postfork handler chain → recursive `pmc::setup` corrupts `g_collector_slices`'s device-entry vector → `SIGSEGV` in its destructor.

### Implemented fix:

- Added file-local `std::atomic<bool> g_reinit_pending` and `should_reinit()` (CAS-once).
- Rewrote `postfork_parent_reinit()` to just `g_reinit_pending.store(true)` - no AMD SMI calls in the handler chain.
- `sample()` calls `should_reinit()` before acquiring its lock; the deferred `shutdown();` `setup();` runs on the polling thread, where AMD SMI's internal fork is safe.

## JIRA ID

ROCM-23496

## Test Plan

- Manually run bot tools with previously crashing implementation on MI300A GPUs

## Test Result

All runs passed. No deadlocks and /or seg-faults

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
