### PR TITLE
rccl: net_ib: fix signed-shift UB in wr_id encoding

### DIFF
--- a/projects/rccl/src/transport/net_ib.cc
+++ b/projects/rccl/src/transport/net_ib.cc
@@ -2374,7 +2374,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
     wr->send_flags = 0;
     wr->wr.rdma.remote_addr = slots[r].addr;
     wr->next = wr + 1;
-    wr_id += (reqs[r] - comm->base.reqs) << (r*8);
+    wr_id += (uint64_t)((reqs[r] - comm->base.reqs) & 0xff) << (r*8);
 #ifdef NCCL_ENABLE_NET_PROFILING
     reqs[r]->pInfo[0].nEventHandles = 0;
 #endif

--- a/projects/rccl/src/transport/net_ib_cast.cc
+++ b/projects/rccl/src/transport/net_ib_cast.cc
@@ -2957,7 +2957,7 @@ static ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int n
       wr->wr.rdma.remote_addr = slots[r].addr;
     }
     wr->next = wr + 1;
-    wr_id += (reqs[r] - comm->base.reqs) << (r*8);
+    wr_id += (uint64_t)((reqs[r] - comm->base.reqs) & 0xff) << (r*8);
 #ifdef NCCL_ENABLE_NET_PROFILING
     reqs[r]->pInfo[0].nEventHandles = 0;
 #endif


### PR DESCRIPTION
## Motivation

Fixes simple signed shift overflow UB

## Technical Details

Similar to equivalent fix in NCCL 2.30 (NCCL/p2p.cc):
  wr_id += (uint64_t)(slot & 0xff) << (r*8);

Projects have diverged too much to cherry-pick (and NCCL drops huge commits once per version).

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
