### PR TITLE
kfdtest: Fix Assemble.cpp on older LLVMs

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/Assemble.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/Assemble.cpp
@@ -302,15 +302,25 @@ int Assembler::RunAssemble(const char* const AssemblySource) {
     SrcMgr.AddNewSourceBuffer(std::move(BufferPtr), SMLoc());
 
     // Initialize MC interfaces and base class objects
+#if LLVM_VERSION_MAJOR < 22
+    std::unique_ptr<const MCRegisterInfo> MRI(
+            TheTarget->createMCRegInfo(TripleName));
+#else
     std::unique_ptr<const MCRegisterInfo> MRI(
             TheTarget->createMCRegInfo(Triple(TripleName)));
+#endif
     if (!MRI) {
         outs() << "ASM Error: no register info for target " << MCPU << "\n";
         return -1;
     }
 #if LLVM_VERSION_MAJOR > 9
+  #if LLVM_VERSION_MAJOR < 22
+    std::unique_ptr<const MCAsmInfo> MAI(
+           TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
+  #else
     std::unique_ptr<const MCAsmInfo> MAI(
             TheTarget->createMCAsmInfo(*MRI, Triple(TripleName), MCOptions));
+  #endif
 #else
     std::unique_ptr<const MCAsmInfo> MAI(
             TheTarget->createMCAsmInfo(*MRI, TripleName));
@@ -325,8 +335,13 @@ int Assembler::RunAssemble(const char* const AssemblySource) {
         outs() << "ASM Error: no instruction info for target " << MCPU << "\n";
         return -1;
     }
+#if LLVM_VERSION_MAJOR < 22
+    std::unique_ptr<MCSubtargetInfo> STI(
+            TheTarget->createMCSubtargetInfo(TripleName, MCPU, std::string()));
+#else
     std::unique_ptr<MCSubtargetInfo> STI(
             TheTarget->createMCSubtargetInfo(Triple(TripleName), MCPU, std::string()));
+#endif
     if (!STI || !STI->isCPUStringValid(MCPU)) {
         outs() << "ASM Error: no subtarget info for target " << MCPU << "\n";
         return -1;


### PR DESCRIPTION
LLVM made the change to remove the Triple() cast in LLVM22, and removed the legacy function in LLVM23. However, using older LLVM will give a compilation error. Since we don't have a hard requirement to use the ROCM-provided LLVM, add a compiler check for the 3 functions and use the old format if the LLVM version is sufficiently low.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
