### PR TITLE
rocr/aie: UMQ-based AIE packet format

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -141,7 +141,7 @@ struct ert_start_kernel_cmd {
   };
   /// @brief 1 mandatory CU mask, up to 4 optional CU masks, determined by @ref extra_cu_masks. Rest
   /// of data.
-  uint32_t data[] __counted_by(count);
+  uint32_t data[];
 };
 
 /// @brief Command chain packet.
@@ -159,7 +159,7 @@ struct ert_cmd_chain_data {
   uint32_t reserved[3];
   /// @brief BO handles of each command in the chain. The number of BO handles is determined by @ref
   /// command_count.
-  uint64_t data[] __counted_by(command_count);
+  uint64_t data[];
 };
 
 /// @brief XDNA device type.
@@ -985,7 +985,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
   bo_handles.erase(std::unique(bo_handles.begin(), bo_handles.end()), bo_handles.end());
 
   // Flush cache for the arguments.
-  for (uint32_t i = 0; i < num_pkts; ++i) {
+  for (uint64_t i = 0; i < num_pkts; ++i) {
     const auto pkt_idx = (first_pkt_idx + i) & mask;
     auto* pkt = queue + pkt_idx;
     FlushArguments(pkt);
@@ -1000,7 +1000,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
 
   // Flush cache for the arguments again to ensure visibility of any changes made by the AIE kernels
   // and fire completion signal for each packet.
-  for (uint32_t i = 0; i < num_pkts; ++i) {
+  for (uint64_t i = 0; i < num_pkts; ++i) {
     const auto pkt_idx = (first_pkt_idx + i) & mask;
     auto* pkt = queue + pkt_idx;
 
@@ -1199,5 +1199,5 @@ hsa_status_t XdnaDriver::GetQueueSaveAreaInfo(HSA_QUEUEID queue_id, void** addre
 
 hsa_status_t XdnaDriver::MakeMemoryUnresident(const void* mem) const { return HSA_STATUS_ERROR; }
 
-} // namespace AMD
-} // namespace rocr
+}  // namespace AMD
+}  // namespace rocr

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -55,12 +55,119 @@
 #include <string>
 #include <string_view>
 
+#include "inc/hsa_ext_amd_aie.h"
 #include "core/inc/amd_memory_region.h"
 #include "core/inc/runtime.h"
 #include "core/inc/signal.h"
 #include "core/util/memory.h"
 #include "core/util/utils.h"
 #include "uapi/amdxdna_accel.h"
+
+// COPIED FROM
+// https://github.com/amd/xdna-driver/blob/c8d172716d2dbeb3063c6ca3805c5812d708bf47/drivers/accel/amdxdna/amdxdna_ctx.h
+
+/**
+ * @brief Opcode types for commands
+ *
+ * ERT_INVALID_CMD:       invalid command
+ * ERT_START_CU:          start a workgroup on a CU
+ * ERT_START_DPU:         instruction buffer command format
+ * ERT_CMD_CHAIN:         command chain
+ * ERT_START_NPU:         instruction buffer command format on NPU format
+ * ERT_START_NPU_PREEMPT: instruction buffer command with preemption format on NPU
+ */
+enum ert_cmd_opcode {
+  ERT_INVALID_CMD = ~0U,
+  ERT_START_CU = 0,
+  ERT_START_DPU = 18,
+  ERT_CMD_CHAIN = 19,
+  ERT_START_NPU = 20,
+  ERT_START_NPU_PREEMPT = 21,
+  ERT_START_NPU_PREEMPT_ELF = 22,
+};
+
+/**
+ * @brief ERT command state
+ *
+ * ERT_CMD_STATE_INVALID:     Invalid state
+ * ERT_CMD_STATE_NEW:         Set by host before submitting a command to
+ *                            scheduler
+ * ERT_CMD_STATE_QUEUED:      Internal scheduler state
+ * ERT_CMD_STATE_SUBMITTED:   Internal scheduler state
+ * ERT_CMD_STATE_RUNNING:     Internal scheduler state
+ * ERT_CMD_STATE_COMPLETED:   Set by scheduler when command completes
+ * ERT_CMD_STATE_ERROR:       Set by scheduler if command failed
+ * ERT_CMD_STATE_ABORT:       Set by scheduler if command abort
+ * ERT_CMD_STATE_TIMEOUT:     Set by scheduler if command timeout and reset
+ * ERT_CMD_STATE_NORESPONSE:  Set by scheduler if command timeout and fail to
+ *                            reset
+ */
+enum ert_cmd_state {
+  ERT_CMD_STATE_INVALID,
+  ERT_CMD_STATE_NEW,
+  ERT_CMD_STATE_QUEUED,
+  ERT_CMD_STATE_RUNNING,
+  ERT_CMD_STATE_COMPLETED,
+  ERT_CMD_STATE_ERROR,
+  ERT_CMD_STATE_ABORT,
+  ERT_CMD_STATE_SUBMITTED,
+  ERT_CMD_STATE_TIMEOUT,
+  ERT_CMD_STATE_NORESPONSE,
+};
+
+using u32 = uint32_t;
+using u64 = uint64_t;
+
+/**
+ * ERT start kernel command format
+ *
+ * state:           [3-0]   current state of a command
+ * unused:          [9-4]   unused bits
+ * extra_cu_masks:  [11-10] extra CU masks in addition to mandatory mask
+ * count:           [22-12] number of words following header for cmd data
+ * opcode:          [27-23] 0, opcode for start_kernel
+ * reserved:        [31-28] 0
+ *
+ * cu_mask:         first mandatory CU mask
+ * data:            count-1 number of words representing interpreted payload
+ *
+ * The packet payload is comprised of reserved id field, a mandatory CU mask,
+ * and extra_cu_masks per header field, followed by a CU register map of size
+ * (count - (1 + extra_cu_masks)) uint32_t words.
+ */
+struct amdxdna_cmd {
+  union {
+    struct {
+      u32 state : 4;
+      u32 unused : 6;
+      u32 extra_cu_masks : 2;
+      u32 count : 11;
+      u32 opcode : 5;
+      u32 reserved : 4;
+    };
+    u32 header;
+  };
+  u32 data[] __counted_by(count);
+};
+
+/**
+ * @brief Interpretation of the beginning of data payload for ERT_CMD_CHAIN in
+ * amdxdna_cmd. The rest of the payload in amdxdna_cmd is cmd BO handles.
+ *
+ * command_count: number of commands in chain
+ * submit_index:  index of last successfully submitted command in chain
+ * error_index:   index of failing command if cmd status is not completed
+ * data[]:        address of each command in chain
+ */
+struct amdxdna_cmd_chain {
+  u32 command_count;
+  u32 submit_index;
+  u32 error_index;
+  u32 reserved[3];
+  u64 data[] __counted_by(command_count);
+};
+
+// END OF COPIED FROM
 
 namespace rocr {
 namespace AMD {
@@ -105,52 +212,26 @@ constexpr uint32_t DEV_ADDR_OFFSET_MASK = 0x02FFFFFF;
 /// @brief The driver places a structure before each command in a command chain.
 /// Need to increase the size of the command by the size of this structure.
 /// In the following xdna driver source can see where this is implemented:
-/// Commit hash: eddd92c0f61592c576a500f16efa24eb23667c23
-/// https://github.com/amd/xdna-driver/blob/main/src/driver/amdxdna/aie2_msg_priv.h#L387-L391
-/// https://github.com/amd/xdna-driver/blob/main/src/driver/amdxdna/aie2_message.c#L637
+/// https://github.com/amd/xdna-driver/blob/eddd92c0f61592c576a500f16efa24eb23667c23/src/driver/amdxdna/aie2_msg_priv.h#L387
+/// https://github.com/amd/xdna-driver/blob/eddd92c0f61592c576a500f16efa24eb23667c23/src/driver/amdxdna/aie2_message.c#L637
 constexpr uint32_t CMD_COUNT_SIZE_INCREASE = 3;
-
-/// @brief The size of an instruction in bytes
-constexpr uint32_t INSTR_SIZE_BYTES = 4;
-
-/// @brief Index of command payload where the instruction sequence
-/// address is located
-constexpr uint32_t CMD_PKT_PAYLOAD_INSTRUCTION_SEQUENCE_IDX = 2;
-constexpr uint32_t CMD_PKT_PAYLOAD_INSTRUCTION_SEQUENCE_SIZE_IDX = 4;
-
-/// @brief Index of the first operand in a command.
-///
-/// Before the operands there are:
-/// - 2 dwords for transaction op code
-/// - 2 dwords for the instructions BO address
-/// - 1 dword for the size of the instructions BO size
-constexpr uint32_t operand_starting_index = 5;
 
 /// @brief Default amdxdna_cu_config::cu_func when configuring a CU.
 constexpr uint32_t default_cu_func = 0;
 
-/// @brief Calculates the number of operands in a packet given the number of arguments in the
-///        packet.
-///
-/// Each operand is 3 dwords (hi, lo address, and size). The op code is not counted in @p arg_count
-/// but the instructions are.
-///
-/// @param arg_count number of arguments in the packet
-/// @return number of operands in the packet
-constexpr uint32_t GetOperandCount(uint32_t arg_count) { return (arg_count / 3) - 1; }
-
-/// @brief Flushes operands.
-static void FlushOperands(uint32_t count, hsa_amd_aie_ert_start_kernel_data_t* cmd_pkt_payload) {
-  // Going through all of the operands in the command and flushing them.
-  const uint32_t num_operands = GetOperandCount(count);
-  for (uint32_t operand_iter = 0; operand_iter < num_operands; operand_iter++) {
-    const uint32_t operand_index = operand_starting_index + 2 * operand_iter;
-    const uint64_t operand_addr = Concat<uint64_t>(cmd_pkt_payload->data[operand_index + 1],
-                                                   cmd_pkt_payload->data[operand_index]);
-    const uint32_t operand_size_starting_index = operand_starting_index + 2 * num_operands;
-    const uint32_t operand_bo_size =
-        cmd_pkt_payload->data[operand_size_starting_index + operand_iter];
-    FlushCpuCache(reinterpret_cast<void*>(operand_addr), 0, operand_bo_size);
+/**
+ * @brief Flushes the CPU cache for the packet's arguments.
+ *
+ * The sizes of the arguments are after the pointers of the arguments.
+ *
+ * @param pkt pointer to the packet
+ */
+static void FlushArguments(const hsa_amd_aie_kernel_dispatch_packet_t* pkt) {
+  auto* kernarg_address = static_cast<uint64_t*>(pkt->kernarg_address);
+  for (uint32_t kernarg_idx = 0; kernarg_idx < pkt->num_kernargs; ++kernarg_idx) {
+    void* ptr = reinterpret_cast<void*>(kernarg_address[kernarg_idx]);
+    size_t size = kernarg_address[kernarg_idx + pkt->num_kernargs];
+    FlushCpuCache(ptr, 0, size);
   }
 }
 
@@ -333,9 +414,9 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
 
   amdxdna_drm_create_bo create_bo_args = {};
   create_bo_args.size = size;
-  const bool use_bo_shmem = !m_region.IsDeviceSVM();
-  if (use_bo_shmem) {
-    create_bo_args.type = AMDXDNA_BO_SHMEM;
+  const bool use_bo_share = !m_region.IsDeviceSVM();
+  if (use_bo_share) {
+    create_bo_args.type = AMDXDNA_BO_SHARE;
   } else {
     // While this is already checked in MemoryRegion::AllocateImpl, the max size is
     // MemoryRegion::max_sysmem_alloc_size_ for HSA_HEAPTYPE_DEVICE_SVM which is incorrect
@@ -364,7 +445,7 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
     return HSA_STATUS_ERROR;
   }
 
-  if (use_bo_shmem) {
+  if (use_bo_share) {
     if (alloc_flags & core::MemoryRegion::AllocateMemoryOnly) {
       /// TODO: We create an anonymous mapping to get a unique virtual address since the memory
       /// handle mapping, i.e., Runtime::memory_handle_map_, is indexed using ThunkHandle which is
@@ -431,16 +512,48 @@ hsa_status_t XdnaDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint
                                      HSA::hsa_amd_queue_priority_internal_t priority, uint32_t sdma_engine_id,
                                      void* queue_addr, uint64_t queue_size_bytes, uint64_t queue_metadata_size_bytes,
                                      HsaEvent* event, HsaQueueResource& queue_resource) const {
-  queue_resource.QueueId = AMDXDNA_INVALID_CTX_HANDLE;
+  if (queue_resource.QueueId != AMDXDNA_INVALID_CTX_HANDLE) {
+    return HSA_STATUS_ERROR;
+  }
+
+  // Create QoS information. Currently we do not leverage this information.
+  amdxdna_qos_info qos_info = {};
+  amdxdna_drm_create_hwctx create_hwctx_args = {};
+  create_hwctx_args.qos_p = reinterpret_cast<uintptr_t>(&qos_info);
+  create_hwctx_args.max_opc = 0x800;
+  create_hwctx_args.num_tiles = 1;  // dummy context; use 1 core
+  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_HWCTX, &create_hwctx_args) < 0) {
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
+  auto queue_id = create_hwctx_args.handle;
+
+  // Create hardware context for the queue.
+  constexpr size_t cu_config_size =
+      sizeof(amdxdna_hwctx_param_config_cu) + sizeof(amdxdna_cu_config);
+  alignas(amdxdna_hwctx_param_config_cu) std::byte cu_config_buffer[cu_config_size];
+  auto* cu_config = reinterpret_cast<amdxdna_hwctx_param_config_cu*>(cu_config_buffer);
+  cu_config->num_cus = 1;
+  cu_config->cu_configs[0].cu_bo = 0;
+  cu_config->cu_configs[0].cu_func = default_cu_func;
+
+  amdxdna_drm_config_hwctx config_ctx{};
+  config_ctx.handle = queue_id;
+  config_ctx.param_type = DRM_AMDXDNA_HWCTX_CONFIG_CU;
+  config_ctx.param_val = reinterpret_cast<uint64_t>(cu_config);
+  config_ctx.param_val_size = static_cast<uint32_t>(cu_config_size);
+  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CONFIG_HWCTX, &config_ctx) < 0) {
+    return HSA_STATUS_ERROR;
+  }
+
+  queue_resource.QueueId = queue_id;
+
   return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t XdnaDriver::DestroyQueue(HSA_QUEUEID queue_id) const {
   auto hw_ctx_handle = static_cast<uint32_t>(queue_id);
   if (hw_ctx_handle == AMDXDNA_INVALID_CTX_HANDLE) {
-    // Queue was never created or already destroyed. We choose not to consider it an error since AIE
-    // queues are created with an invalid handle.
-    return HSA_STATUS_SUCCESS;
+    return HSA_STATUS_ERROR_INVALID_QUEUE;
   }
 
   // Drop PDI cache.
@@ -666,12 +779,11 @@ hsa_status_t XdnaDriver::FreeDeviceHeap() {
 hsa_status_t XdnaDriver::ExecCmdAndWait(const BOHandle& cmd_chain_bo_handle,
                                         const std::vector<uint32_t>& bo_handles,
                                         HSA_QUEUEID queue_id) {
-  if (queue_id == AMDXDNA_INVALID_CTX_HANDLE) {
-    return HSA_STATUS_ERROR_INVALID_QUEUE;
-  }
+  assert(queue_id != AMDXDNA_INVALID_CTX_HANDLE);
 
   auto hw_ctx_handle = static_cast<uint32_t>(queue_id);
-  // Submit command chain.
+
+  // Submit commands in a command chain.
   amdxdna_drm_exec_cmd exec_cmd = {};
   exec_cmd.hwctx = hw_ctx_handle;
   exec_cmd.type = AMDXDNA_CMD_SUBMIT_EXEC_BUF;
@@ -679,7 +791,6 @@ hsa_status_t XdnaDriver::ExecCmdAndWait(const BOHandle& cmd_chain_bo_handle,
   exec_cmd.args = reinterpret_cast<uint64_t>(bo_handles.data());
   exec_cmd.cmd_count = 1;
   exec_cmd.arg_count = bo_handles.size();
-
   if (ioctl(fd_, DRM_IOCTL_AMDXDNA_EXEC_CMD, &exec_cmd) < 0) {
     return HSA_STATUS_ERROR;
   }
@@ -689,60 +800,9 @@ hsa_status_t XdnaDriver::ExecCmdAndWait(const BOHandle& cmd_chain_bo_handle,
   wait_cmd.hwctx = hw_ctx_handle;
   wait_cmd.timeout = 0;  // no timeout, wait until the command finishes
   wait_cmd.seq = exec_cmd.seq;
-
   if (ioctl(fd_, DRM_IOCTL_AMDXDNA_WAIT_CMD, &wait_cmd) < 0) {
     return HSA_STATUS_ERROR;
   }
-
-  return HSA_STATUS_SUCCESS;
-}
-
-hsa_status_t XdnaDriver::PrepareBOs(uint32_t count,
-                                    hsa_amd_aie_ert_start_kernel_data_t* cmd_pkt_payload,
-                                    std::vector<uint32_t>& bo_handles) {
-  const uint64_t instr_addr =
-      Concat<uint64_t>(cmd_pkt_payload->data[CMD_PKT_PAYLOAD_INSTRUCTION_SEQUENCE_IDX + 1],
-                       cmd_pkt_payload->data[CMD_PKT_PAYLOAD_INSTRUCTION_SEQUENCE_IDX]);
-  auto instr_bo_handle = FindBOHandle(reinterpret_cast<void*>(instr_addr));
-  if (!instr_bo_handle.IsValid()) {
-    return HSA_STATUS_ERROR_INVALID_ALLOCATION;
-  }
-
-  // Keep track of the instruction sequence BO.
-  bo_handles.push_back(instr_bo_handle.handle);
-
-  // Flush the instruction sequence. The packet contains the number of instructions.
-  const uint32_t instr_bo_size =
-      cmd_pkt_payload->data[CMD_PKT_PAYLOAD_INSTRUCTION_SEQUENCE_SIZE_IDX] * INSTR_SIZE_BYTES;
-  FlushCpuCache(reinterpret_cast<void*>(instr_addr), 0, instr_bo_size);
-
-  // Going through all of the operands in the command, keeping track of the
-  // addresses and turning the addresses into handles. The starting index of
-  // the operands in a command is `operand_starting_index` and the fields
-  // are 32-bits we need to iterate over every two
-  const uint32_t num_operands = GetOperandCount(count);
-  for (uint32_t operand_iter = 0; operand_iter < num_operands; operand_iter++) {
-    const uint32_t operand_index = operand_starting_index + 2 * operand_iter;
-    const uint64_t operand_addr = Concat<uint64_t>(cmd_pkt_payload->data[operand_index + 1],
-                                                   cmd_pkt_payload->data[operand_index]);
-    auto operand_bo_handle = FindBOHandle(reinterpret_cast<void*>(operand_addr));
-    if (!operand_bo_handle.IsValid()) {
-      return HSA_STATUS_ERROR_INVALID_ALLOCATION;
-    }
-
-    // Keep track of the operand BO.
-    bo_handles.push_back(operand_bo_handle.handle);
-
-    // Flush the operand.
-    const uint32_t operand_size_starting_index = operand_starting_index + 2 * num_operands;
-    const uint32_t operand_bo_size =
-        cmd_pkt_payload->data[operand_size_starting_index + operand_iter];
-    FlushCpuCache(reinterpret_cast<void*>(operand_addr), 0, operand_bo_size);
-  }
-
-  // Transform the instruction sequence address into device address
-  cmd_pkt_payload->data[CMD_PKT_PAYLOAD_INSTRUCTION_SEQUENCE_IDX] =
-      DEV_ADDR_BASE | (instr_addr & DEV_ADDR_OFFSET_MASK);
 
   return HSA_STATUS_SUCCESS;
 }
@@ -783,12 +843,10 @@ hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) {
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uint32_t num_pkts,
-                                        HSA_QUEUEID& queue_id, uint32_t num_core_tiles) {
-  assert(num_pkts > 0);
-
-  // Instruction and operand BOs. Reserve space for instruction BOs and up to 3 operand BOs per
-  // packet.
+hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
+                                        uint64_t first_pkt_idx, uint64_t num_pkts,
+                                        uint32_t num_core_tiles) {
+  // Instruction and arguments BOs (performance hint: up to 3 argument BOs per packet).
   std::vector<uint32_t> bo_handles;
   bo_handles.reserve(num_pkts * 4);
 
@@ -802,62 +860,32 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
     }
   });
 
-  // PDI cache to avoid reconfiguration. If the queue is invalid or the cache is updated, a new
-  // hardware context will be created for the queue.
+  // PDI cache to avoid reconfiguration. If the cache is empty or updated, a new hardware context
+  // will be created for the queue.
   PDICache pdi_cache;
-  if (static_cast<uint32_t>(queue_id) != AMDXDNA_INVALID_CTX_HANDLE) {
-    auto pdi_cache_it = queue_pdi_map_.find(queue_id);
-    if (pdi_cache_it != queue_pdi_map_.end()) {
-      pdi_cache = pdi_cache_it->second;
-    }
+  auto pdi_cache_it = queue_pdi_map_.find(queue_id);
+  if (pdi_cache_it != queue_pdi_map_.end()) {
+    pdi_cache = pdi_cache_it->second;
   }
   bool reconfigure_queue = pdi_cache.empty();
 
-  // Iterating over all the contiguous HSA_AMD_AIE_ERT_CMD_CHAIN packets
-  for (uint32_t pkt_iter = 0; pkt_iter < num_pkts; pkt_iter++) {
-    // Getting the current command packet
-    hsa_amd_aie_ert_packet_t* pkt = first_pkt + pkt_iter;
-    auto* cmd_pkt_payload =
-        reinterpret_cast<hsa_amd_aie_ert_start_kernel_data_t*>(pkt->payload_data);
-
-    // Add the handles for all of the BOs to bo_handles and flush cache.
-    hsa_status_t status = PrepareBOs(pkt->count, cmd_pkt_payload, bo_handles);
-    if (status != HSA_STATUS_SUCCESS) {
-      assert(false && "Failed to prepare BOs for command packet.");
-      return status;
-    }
-
-    // Create packet that contains the command to execute the kernel.
-    const uint32_t cmd_size = sizeof(amdxdna_cmd) + pkt->count * sizeof(uint32_t);
-    BOHandle cmd_bo_handle;
-    status = CreateCmdBO(cmd_size, cmd_bo_handle);
-    if (status != HSA_STATUS_SUCCESS) {
-      assert(false && "Failed to create command BO.");
-      return status;
-    }
-    cmd_bo_handles.push_back(cmd_bo_handle);
-
-    auto* cmd = static_cast<amdxdna_cmd*>(cmd_bo_handle.vaddr);
-
-    // Filling in the fields of the command
-    cmd->state = pkt->state;
-    cmd->extra_cu_masks = 0;
-
-    // The driver places a structure before each command in a command chain.
-    // Need to increase the size of the command by the size of this structure.
-    cmd->count = pkt->count + CMD_COUNT_SIZE_INCREASE;
-    cmd->opcode = pkt->opcode;
+  // Process all packets in a single command chain.
+  auto* queue = static_cast<hsa_amd_aie_kernel_dispatch_packet_t*>(q.base_address);
+  const uint64_t mask = q.size - 1;
+  for (uint64_t i = 0; i < num_pkts; ++i) {
+    const auto pkt_idx = (first_pkt_idx + i) & mask;
+    auto* pkt = queue + pkt_idx;
 
     // Determine if the PDI is cached, if not it will be added to the PDI cache and the hardware
     // context will be reconfigured.
-    auto pdi_bo_handle = FindBOHandle(cmd_pkt_payload->pdi_addr);
+    auto pdi_bo_handle = FindBOHandle(pkt->pdi_addr);
     if (!pdi_bo_handle.IsValid()) {
       return HSA_STATUS_ERROR_INVALID_ALLOCATION;
     }
     auto cached_pdi_index = pdi_cache.GetIndex(pdi_bo_handle.handle);
     if (cached_pdi_index == PDICache::NotFound) {
       FlushCpuCache(pdi_bo_handle.vaddr, 0, pdi_bo_handle.size);
-      status = pdi_cache.SetNext(pdi_bo_handle, cached_pdi_index);
+      hsa_status_t status = pdi_cache.SetNext(pdi_bo_handle, cached_pdi_index);
       if (status != HSA_STATUS_SUCCESS) {
         assert(false && "Failed to set PDI in cache.");
         return status;
@@ -865,71 +893,134 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
       reconfigure_queue = true;
     }
 
-    cmd->data[0] = 0x1 << cached_pdi_index;
-    memcpy((cmd->data + 1), cmd_pkt_payload->data, 4 * pkt->count);
+    // Add the instruction sequence BO handle to bo_handles and flush cache.
+    void* insts_addr =
+        reinterpret_cast<void*>(Concat<uint64_t>(pkt->insts_addr_high, pkt->insts_addr_low));
+    auto instr_bo_handle = FindBOHandle(insts_addr);
+    if (!instr_bo_handle.IsValid()) {
+      assert(false && "Failed to find instruction sequence BO for command packet.");
+      return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+    }
+    bo_handles.push_back(instr_bo_handle.handle);
+    FlushCpuCache(insts_addr, 0, pkt->insts_size);
+
+    // Add the argument BO handles to bo_handles.
+    auto* kernarg_address = static_cast<uint64_t*>(pkt->kernarg_address);
+    for (uint32_t kernarg_idx = 0; kernarg_idx < pkt->num_kernargs; ++kernarg_idx) {
+      void* ptr = reinterpret_cast<void*>(kernarg_address[kernarg_idx]);
+      auto bo_handle = FindBOHandle(ptr);
+      if (!bo_handle.IsValid()) {
+        assert(false && "Failed to find argument BO for command packet.");
+        return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+      }
+      bo_handles.push_back(bo_handle.handle);
+    }
+
+    // Create command for the kernel.
+    const uint32_t cmd_dwords = (1 +  // CU mask
+                                 2 +  // txn opcode
+                                 3 +  // instruction sequence (address lo/hi + size)
+                                 2 * pkt->num_kernargs);  // arguments (address lo/hi)
+    const uint32_t cmd_data_bytesize = cmd_dwords * sizeof(uint32_t);
+    const uint32_t cmd_bytesize = sizeof(amdxdna_cmd) + cmd_data_bytesize;
+    BOHandle cmd_bo_handle;
+    hsa_status_t status = CreateCmdBO(cmd_bytesize, cmd_bo_handle);
+    if (status != HSA_STATUS_SUCCESS) {
+      assert(false && "Failed to create command BO.");
+      return status;
+    }
+    cmd_bo_handles.push_back(cmd_bo_handle);
+
+    auto* cmd = static_cast<amdxdna_cmd*>(cmd_bo_handle.vaddr);
+    cmd->state = ERT_START_CU;
+    cmd->extra_cu_masks = 0;
+    // The driver places a structure before each command in a command chain.
+    // Need to increase the size of the command by the size of this structure.
+    cmd->count = cmd_dwords + CMD_COUNT_SIZE_INCREASE;
+    cmd->opcode = pkt->opcode;
+    cmd->data[0] = 0x1 << cached_pdi_index;  // CU mask bit
+    cmd->data[1] = 0x3;                      // txn opcode
+    cmd->data[2] = 0x0;
+    cmd->data[3] = (DEV_ADDR_BASE |
+                    (reinterpret_cast<uintptr_t>(insts_addr) &
+                     DEV_ADDR_OFFSET_MASK));              // instruction sequence address (lo)
+    cmd->data[4] = 0x0;                                   // instruction sequence address (hi)
+    cmd->data[5] = (pkt->insts_size / sizeof(uint32_t));  // instruction sequence dword count
+    for (uint32_t kernarg_idx = 0; kernarg_idx < pkt->num_kernargs; ++kernarg_idx) {
+      const auto kernarg = kernarg_address[kernarg_idx];
+      cmd->data[6 + 2 * kernarg_idx] = (kernarg & 0xFFFFFFFF);  // argument address (lo)
+      cmd->data[6 + 2 * kernarg_idx + 1] = (kernarg >> 32);     // argument address (hi)
+    }
   }
 
+  // Reconfigure hardware context and update cache entry if a PDI was added to the cache.
   if (reconfigure_queue) {
-    // The hardware context needs to be reconfigured because a PDI was added to the cache.
+    if (pdi_cache_it != queue_pdi_map_.end()) {
+      queue_pdi_map_.erase(pdi_cache_it);
+    }
     hsa_status_t status = ConfigHwCtx(pdi_cache, queue_id, num_core_tiles);
     if (status != HSA_STATUS_SUCCESS) {
       assert(false && "Failed to configure hardware context for queue.");
       return status;
     }
-    queue_pdi_map_[queue_id] = pdi_cache;
+    queue_pdi_map_.emplace(queue_id, pdi_cache);
   }
 
-  assert(queue_id != AMDXDNA_INVALID_CTX_HANDLE &&
-         "Invalid queue ID after hardware context configuration.");
-
-  // Creating a packet that contains the command chain
-  const uint32_t cmd_chain_size = (cmd_bo_handles.size() + 1) * sizeof(uint32_t);
-  BOHandle cmd_chain_bo_handle;
-  hsa_status_t status = CreateCmdBO(cmd_chain_size, cmd_chain_bo_handle);
+  // Create command chain.
+  const uint32_t cmd_chain_data_bytesize = cmd_bo_handles.size() * sizeof(uint64_t);
+  const uint32_t cmd_data_bytesize = sizeof(amdxdna_cmd_chain) + cmd_chain_data_bytesize;
+  const uint32_t cmd_bytesize = sizeof(amdxdna_cmd) + cmd_data_bytesize;
+  BOHandle cmd_bo_handle;
+  hsa_status_t status = CreateCmdBO(cmd_bytesize, cmd_bo_handle);
   if (status != HSA_STATUS_SUCCESS) {
     assert(false && "Failed to create command chain BO.");
     return status;
   }
-  // Unmap and close the command chain BO in case of an error.
-  MAKE_NAMED_SCOPE_GUARD(cmd_chain_bo_handle_guard, [&] { DestroyBOHandle(cmd_chain_bo_handle); });
+  // Unmap and close the command chain BO at exit or in case of an error.
+  MAKE_NAMED_SCOPE_GUARD(cmd_bo_handle_guard, [&] { DestroyBOHandle(cmd_bo_handle); });
 
-  auto* cmd_chain = static_cast<amdxdna_cmd*>(cmd_chain_bo_handle.vaddr);
-
-  // Writing information to the command buffer
-  amdxdna_cmd_chain* cmd_chain_payload = reinterpret_cast<amdxdna_cmd_chain*>(cmd_chain->data);
-
-  // Creating a command chain
-  cmd_chain->state = HSA_AMD_AIE_ERT_STATE_NEW;
-  cmd_chain->extra_cu_masks = 0;
-  cmd_chain->count = sizeof(amdxdna_cmd_chain) + cmd_bo_handles.size() * sizeof(uint64_t);
-  cmd_chain->opcode = HSA_AMD_AIE_ERT_CMD_CHAIN;
-  cmd_chain_payload->command_count = cmd_bo_handles.size();
-  cmd_chain_payload->submit_index = 0;
-  cmd_chain_payload->error_index = 0;
+  // Create a command BO for the command chain.
+  auto* cmd = static_cast<amdxdna_cmd*>(cmd_bo_handle.vaddr);
+  cmd->state = ERT_CMD_STATE_NEW;
+  cmd->extra_cu_masks = 0;
+  cmd->count = cmd_data_bytesize / sizeof(uint32_t);
+  cmd->opcode = ERT_CMD_CHAIN;
+  auto* cmd_chain = reinterpret_cast<amdxdna_cmd_chain*>(cmd->data);
+  cmd_chain->command_count = cmd_bo_handles.size();
   for (size_t i = 0; i < cmd_bo_handles.size(); i++) {
-    cmd_chain_payload->data[i] = cmd_bo_handles[i].handle;
+    cmd_chain->data[i] = cmd_bo_handles[i].handle;
   }
 
-  // Removing duplicates in the bo container. The driver will report
-  // an error if we provide the same BO handle multiple times.
-  // This can happen if any of the BOs are the same across jobs
+  // Remove duplicate BOs, since the driver reports an error if the same BO handle is provided
+  // multiple times in the command chain. This can happen if any of the BOs are the same across
+  // packets.
   std::sort(bo_handles.begin(), bo_handles.end());
   bo_handles.erase(std::unique(bo_handles.begin(), bo_handles.end()), bo_handles.end());
 
-  // Executing all commands in the command chain
-  status = ExecCmdAndWait(cmd_chain_bo_handle, bo_handles, queue_id);
+  // Flush cache for the arguments.
+  for (uint32_t i = 0; i < num_pkts; ++i) {
+    const auto pkt_idx = (first_pkt_idx + i) & mask;
+    auto* pkt = queue + pkt_idx;
+    FlushArguments(pkt);
+  }
+
+  // Execute all commands in the command chain.
+  status = ExecCmdAndWait(cmd_bo_handle, bo_handles, queue_id);
   if (status != HSA_STATUS_SUCCESS) {
     assert(false && "Failed to dispatch command chain.");
     return status;
   }
 
-  for (uint32_t pkt_iter = 0; pkt_iter < num_pkts; pkt_iter++) {
-    hsa_amd_aie_ert_packet_t* pkt = first_pkt + pkt_iter;
-    auto* cmd_pkt_payload =
-        reinterpret_cast<hsa_amd_aie_ert_start_kernel_data_t*>(pkt->payload_data);
-    FlushOperands(pkt->count, cmd_pkt_payload);
+  // Flush cache for the arguments again to ensure visibility of any changes made by the AIE kernels
+  // and fire completion signal for each packet.
+  for (uint32_t i = 0; i < num_pkts; ++i) {
+    const auto pkt_idx = (first_pkt_idx + i) & mask;
+    auto* pkt = queue + pkt_idx;
 
-    // Fire completion signal for this packet
+    // Flush cache.
+    FlushArguments(pkt);
+
+    // Fire completion signal.
     if (pkt->completion_signal.handle != 0) {
       core::Signal* sig = core::Signal::Convert(pkt->completion_signal);
       sig->SubRelease(1);
@@ -1016,7 +1107,7 @@ XdnaDriver::BOHandle XdnaDriver::FindBOHandle(void* mem) const {
 }
 
 hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, HSA_QUEUEID& queue_id,
-                                     uint32_t num_core_tiles) {
+                                     uint32_t num_core_tiles) const {
   const size_t config_cu_param_size =
       sizeof(amdxdna_hwctx_param_config_cu) + pdi_bo_handles.size() * sizeof(amdxdna_cu_config);
 
@@ -1036,19 +1127,16 @@ hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, HSA_QUEUEID
 
   auto hw_ctx_handle = static_cast<uint32_t>(queue_id);
 
-  if (hw_ctx_handle != AMDXDNA_INVALID_CTX_HANDLE) {
-    // Destroy the hardware context
-    // Note: we can do this because we have forced synchronization between
-    // command chains. If we move to a more asynchronous model, we will need to
-    // figure out how hardware context destruction works while applications
-    // are running
-    amdxdna_drm_destroy_hwctx destroy_hwctx_args = {};
-    destroy_hwctx_args.handle = hw_ctx_handle;
-    if (ioctl(fd_, DRM_IOCTL_AMDXDNA_DESTROY_HWCTX, &destroy_hwctx_args) < 0) {
-      return HSA_STATUS_ERROR;
-    }
-    queue_id = AMDXDNA_INVALID_CTX_HANDLE;
+  // Destroy the hardware context
+  // Note: we can do this because we have forced synchronization between command chains. If we move
+  // to a more asynchronous model, we will need to figure out how hardware context destruction works
+  // while applications are running.
+  amdxdna_drm_destroy_hwctx destroy_hwctx_args = {};
+  destroy_hwctx_args.handle = hw_ctx_handle;
+  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_DESTROY_HWCTX, &destroy_hwctx_args) < 0) {
+    return HSA_STATUS_ERROR;
   }
+  queue_id = AMDXDNA_INVALID_CTX_HANDLE;
 
   // Create the new hardware context
   // Currently we do not leverage QoS information.
@@ -1057,7 +1145,6 @@ hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, HSA_QUEUEID
   create_hwctx_args.qos_p = reinterpret_cast<uintptr_t>(&qos_info);
   create_hwctx_args.max_opc = 0x800;
   create_hwctx_args.num_tiles = num_core_tiles;
-
   if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_HWCTX, &create_hwctx_args) < 0) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
@@ -1068,7 +1155,6 @@ hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, HSA_QUEUEID
   config_hw_ctx_args.param_type = DRM_AMDXDNA_HWCTX_CONFIG_CU;
   config_hw_ctx_args.param_val = reinterpret_cast<uint64_t>(xdna_config_cu_param);
   config_hw_ctx_args.param_val_size = static_cast<uint32_t>(config_cu_param_size);
-
   if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CONFIG_HWCTX, &config_hw_ctx_args) < 0) {
     return HSA_STATUS_ERROR;
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -918,6 +918,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
     cmd_bo_handles.push_back(cmd_bo_handle);
 
     auto* cmd = static_cast<ert_start_kernel_cmd*>(cmd_bo_handle.vaddr);
+    memset(cmd, 0, cmd_bytesize);
     cmd->state = ERT_START_CU;
     cmd->extra_cu_masks = 0;
     // The driver places a structure before each command in a command chain.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -121,7 +121,7 @@ enum ert_cmd_state {
 struct ert_start_kernel_cmd {
   union {
     struct {
-      /// @brief Current state of a command. Should be one @ref ERT_START_CU.
+      /// @brief Current state of a command. Should be one of the values in @ref ert_cmd_state.
       uint32_t state : 4;
       uint32_t unused : 6;
       /// @brief Extra CU masks in addition to mandatory mask. The number of extra CU masks is
@@ -219,6 +219,20 @@ static void FlushArguments(const hsa_amd_aie_kernel_dispatch_packet_t* pkt) {
     size_t size = kernarg_address[kernarg_idx + pkt->num_kernargs];
     FlushCpuCache(ptr, 0, size);
   }
+}
+
+/**
+ * @brief Destroys the amdxdna_hwctx with the given handle.
+ *
+ * @param[in] hw_ctx_handle handle of the hardware context to destroy
+ */
+static hsa_status_t DestroyHwCtx(int fd, uint32_t hw_ctx_handle) {
+  amdxdna_drm_destroy_hwctx args = {};
+  args.handle = hw_ctx_handle;
+  if (ioctl(fd, DRM_IOCTL_AMDXDNA_DESTROY_HWCTX, &args) < 0) {
+    return HSA_STATUS_ERROR;
+  }
+  return HSA_STATUS_SUCCESS;
 }
 
 XdnaDriver::XdnaDriver(std::string devnode_name)
@@ -511,27 +525,28 @@ hsa_status_t XdnaDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint
   if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_HWCTX, &create_hwctx_args) < 0) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
-  auto queue_id = create_hwctx_args.handle;
 
   // Create hardware context for the queue.
   constexpr size_t cu_config_size =
       sizeof(amdxdna_hwctx_param_config_cu) + sizeof(amdxdna_cu_config);
   alignas(amdxdna_hwctx_param_config_cu) std::byte cu_config_buffer[cu_config_size];
+  memset(cu_config_buffer, 0, cu_config_size);
   auto* cu_config = reinterpret_cast<amdxdna_hwctx_param_config_cu*>(cu_config_buffer);
   cu_config->num_cus = 1;
   cu_config->cu_configs[0].cu_bo = 0;
   cu_config->cu_configs[0].cu_func = default_cu_func;
 
   amdxdna_drm_config_hwctx config_ctx{};
-  config_ctx.handle = queue_id;
+  config_ctx.handle = create_hwctx_args.handle;
   config_ctx.param_type = DRM_AMDXDNA_HWCTX_CONFIG_CU;
   config_ctx.param_val = reinterpret_cast<uint64_t>(cu_config);
   config_ctx.param_val_size = static_cast<uint32_t>(cu_config_size);
   if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CONFIG_HWCTX, &config_ctx) < 0) {
+    DestroyHwCtx(fd_, create_hwctx_args.handle);
     return HSA_STATUS_ERROR;
   }
 
-  queue_resource.QueueId = queue_id;
+  queue_resource.QueueId = create_hwctx_args.handle;
 
   return HSA_STATUS_SUCCESS;
 }
@@ -546,14 +561,7 @@ hsa_status_t XdnaDriver::DestroyQueue(HSA_QUEUEID queue_id) const {
   const_cast<std::unordered_map<HSA_QUEUEID, PDICache>&>(queue_pdi_map_).erase(queue_id);
 
   // Destroy hardware context associated with the queue.
-  amdxdna_drm_destroy_hwctx destroy_hwctx_args = {};
-  destroy_hwctx_args.handle = hw_ctx_handle;
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_DESTROY_HWCTX, &destroy_hwctx_args) < 0) {
-    assert(false && "Failed to destroy hardware context for queue.");
-    return HSA_STATUS_ERROR;
-  }
-
-  return HSA_STATUS_SUCCESS;
+  return DestroyHwCtx(fd_, hw_ctx_handle);
 }
 
 hsa_status_t XdnaDriver::UpdateQueue(HSA_QUEUEID queue_id, uint32_t queue_pct,
@@ -692,7 +700,7 @@ hsa_status_t XdnaDriver::DestroyShareableHandle(core::ShareableHandle* handle) {
 }
 
 hsa_status_t XdnaDriver::QueryDriverVersion() {
-  amdxdna_drm_query_aie_version aie_version{0, 0};
+  amdxdna_drm_query_aie_version aie_version = {};
   amdxdna_drm_get_info args{DRM_AMDXDNA_QUERY_AIE_VERSION, sizeof(aie_version),
                             reinterpret_cast<uintptr_t>(&aie_version)};
 
@@ -1101,6 +1109,8 @@ hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, HSA_QUEUEID
 
   auto* xdna_config_cu_param =
       static_cast<amdxdna_hwctx_param_config_cu*>(malloc(config_cu_param_size));
+  memset(xdna_config_cu_param, 0, config_cu_param_size);
+
   if (xdna_config_cu_param == nullptr) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
@@ -1119,10 +1129,9 @@ hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, HSA_QUEUEID
   // Note: we can do this because we have forced synchronization between command chains. If we move
   // to a more asynchronous model, we will need to figure out how hardware context destruction works
   // while applications are running.
-  amdxdna_drm_destroy_hwctx destroy_hwctx_args = {};
-  destroy_hwctx_args.handle = hw_ctx_handle;
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_DESTROY_HWCTX, &destroy_hwctx_args) < 0) {
-    return HSA_STATUS_ERROR;
+  hsa_status_t status = DestroyHwCtx(fd_, hw_ctx_handle);
+  if (status != HSA_STATUS_SUCCESS) {
+    return status;
   }
   queue_id = AMDXDNA_INVALID_CTX_HANDLE;
 
@@ -1144,6 +1153,7 @@ hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, HSA_QUEUEID
   config_hw_ctx_args.param_val = reinterpret_cast<uint64_t>(xdna_config_cu_param);
   config_hw_ctx_args.param_val_size = static_cast<uint32_t>(config_cu_param_size);
   if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CONFIG_HWCTX, &config_hw_ctx_args) < 0) {
+    DestroyHwCtx(fd_, create_hwctx_args.handle);
     return HSA_STATUS_ERROR;
   }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -927,15 +927,15 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
 
     auto* cmd = static_cast<ert_start_kernel_cmd*>(cmd_bo_handle.vaddr);
     memset(cmd, 0, cmd_bytesize);
-    cmd->state = ERT_START_CU;
+    cmd->state = ERT_CMD_STATE_NEW;
     cmd->extra_cu_masks = 0;
     // The driver places a structure before each command in a command chain.
     // Need to increase the size of the command by the size of this structure.
     cmd->count = cmd_dwords + CMD_COUNT_SIZE_INCREASE;
-    cmd->opcode = pkt->opcode;
+    cmd->opcode = pkt->opcode;               // HSA_AMD_AIE_PACKET_OPCODE_KMQ == ERT_START_CU == 0x0
     cmd->data[0] = 0x1 << cached_pdi_index;  // CU mask bit
     cmd->data[1] = 0x3;                      // txn opcode
-    cmd->data[2] = 0x0;
+    cmd->data[2] = 0x0;                      // txn opcode
     cmd->data[3] = (DEV_ADDR_BASE |
                     (reinterpret_cast<uintptr_t>(insts_addr) &
                      DEV_ADDR_OFFSET_MASK));              // instruction sequence address (lo)

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -63,118 +63,104 @@
 #include "core/util/utils.h"
 #include "uapi/amdxdna_accel.h"
 
-// COPIED FROM
-// https://github.com/amd/xdna-driver/blob/c8d172716d2dbeb3063c6ca3805c5812d708bf47/drivers/accel/amdxdna/amdxdna_ctx.h
-
-/**
- * @brief Opcode types for commands
- *
- * ERT_INVALID_CMD:       invalid command
- * ERT_START_CU:          start a workgroup on a CU
- * ERT_START_DPU:         instruction buffer command format
- * ERT_CMD_CHAIN:         command chain
- * ERT_START_NPU:         instruction buffer command format on NPU format
- * ERT_START_NPU_PREEMPT: instruction buffer command with preemption format on NPU
- */
-enum ert_cmd_opcode {
-  ERT_INVALID_CMD = ~0U,
-  ERT_START_CU = 0,
-  ERT_START_DPU = 18,
-  ERT_CMD_CHAIN = 19,
-  ERT_START_NPU = 20,
-  ERT_START_NPU_PREEMPT = 21,
-  ERT_START_NPU_PREEMPT_ELF = 22,
-};
-
-/**
- * @brief ERT command state
- *
- * ERT_CMD_STATE_INVALID:     Invalid state
- * ERT_CMD_STATE_NEW:         Set by host before submitting a command to
- *                            scheduler
- * ERT_CMD_STATE_QUEUED:      Internal scheduler state
- * ERT_CMD_STATE_SUBMITTED:   Internal scheduler state
- * ERT_CMD_STATE_RUNNING:     Internal scheduler state
- * ERT_CMD_STATE_COMPLETED:   Set by scheduler when command completes
- * ERT_CMD_STATE_ERROR:       Set by scheduler if command failed
- * ERT_CMD_STATE_ABORT:       Set by scheduler if command abort
- * ERT_CMD_STATE_TIMEOUT:     Set by scheduler if command timeout and reset
- * ERT_CMD_STATE_NORESPONSE:  Set by scheduler if command timeout and fail to
- *                            reset
- */
-enum ert_cmd_state {
-  ERT_CMD_STATE_INVALID,
-  ERT_CMD_STATE_NEW,
-  ERT_CMD_STATE_QUEUED,
-  ERT_CMD_STATE_RUNNING,
-  ERT_CMD_STATE_COMPLETED,
-  ERT_CMD_STATE_ERROR,
-  ERT_CMD_STATE_ABORT,
-  ERT_CMD_STATE_SUBMITTED,
-  ERT_CMD_STATE_TIMEOUT,
-  ERT_CMD_STATE_NORESPONSE,
-};
-
-using u32 = uint32_t;
-using u64 = uint64_t;
-
-/**
- * ERT start kernel command format
- *
- * state:           [3-0]   current state of a command
- * unused:          [9-4]   unused bits
- * extra_cu_masks:  [11-10] extra CU masks in addition to mandatory mask
- * count:           [22-12] number of words following header for cmd data
- * opcode:          [27-23] 0, opcode for start_kernel
- * reserved:        [31-28] 0
- *
- * cu_mask:         first mandatory CU mask
- * data:            count-1 number of words representing interpreted payload
- *
- * The packet payload is comprised of reserved id field, a mandatory CU mask,
- * and extra_cu_masks per header field, followed by a CU register map of size
- * (count - (1 + extra_cu_masks)) uint32_t words.
- */
-struct amdxdna_cmd {
-  union {
-    struct {
-      u32 state : 4;
-      u32 unused : 6;
-      u32 extra_cu_masks : 2;
-      u32 count : 11;
-      u32 opcode : 5;
-      u32 reserved : 4;
-    };
-    u32 header;
-  };
-  u32 data[] __counted_by(count);
-};
-
-/**
- * @brief Interpretation of the beginning of data payload for ERT_CMD_CHAIN in
- * amdxdna_cmd. The rest of the payload in amdxdna_cmd is cmd BO handles.
- *
- * command_count: number of commands in chain
- * submit_index:  index of last successfully submitted command in chain
- * error_index:   index of failing command if cmd status is not completed
- * data[]:        address of each command in chain
- */
-struct amdxdna_cmd_chain {
-  u32 command_count;
-  u32 submit_index;
-  u32 error_index;
-  u32 reserved[3];
-  u64 data[] __counted_by(command_count);
-};
-
-// END OF COPIED FROM
-
 namespace rocr {
 namespace AMD {
 
 static_assert((sizeof(core::ShareableHandle::handle) >= sizeof(uint32_t)) &&
                   (alignof(core::ShareableHandle::handle) >= alignof(uint32_t)),
               "ShareableHandle cannot store a XDNA handle");
+
+/// @brief Opcode types for commands.
+///
+/// This should match the opcode types defined in xdna-driver and XRT ERT (ert_cmd_opcode).
+enum ert_cmd_opcode {
+  /// @brief Invalid command.
+  ERT_INVALID_CMD = ~0U,
+  /// @brief Start a workgroup on a CU.
+  ERT_START_CU = 0,
+  /// @brief Command chain.
+  ERT_CMD_CHAIN = 19,
+  /// @brief Instruction buffer command format on NPU format.
+  ERT_START_NPU = 20,
+  /// @brief Instruction buffer command with preemption format on NPU.
+  ERT_START_NPU_PREEMPT = 21,
+  /// @brief Instruction buffer command with preemption format on NPU using ELF.
+  ERT_START_NPU_PREEMPT_ELF = 22,
+};
+
+/// @brief Command state.
+///
+/// This should match the command states defined in xdna-driver and XRT ERT (ert_cmd_state).
+enum ert_cmd_state {
+  /// @brief Invalid state.
+  ERT_CMD_STATE_INVALID,
+  /// @brief Set by host before submitting a command to scheduler.
+  ERT_CMD_STATE_NEW,
+  /// @brief Internal scheduler state.
+  ERT_CMD_STATE_QUEUED,
+  /// @brief Internal scheduler state.
+  ERT_CMD_STATE_RUNNING,
+  /// @brief Set by scheduler when command completes.
+  ERT_CMD_STATE_COMPLETED,
+  /// @brief Set by scheduler if command failed.
+  ERT_CMD_STATE_ERROR,
+  /// @brief Set by scheduler if command abort.
+  ERT_CMD_STATE_ABORT,
+  /// @brief Internal scheduler state.
+  ERT_CMD_STATE_SUBMITTED,
+  /// @brief Set by scheduler if command timeout and reset.
+  ERT_CMD_STATE_TIMEOUT,
+  /// @brief Set by scheduler if command timeout and fail to reset.
+  ERT_CMD_STATE_NORESPONSE,
+};
+
+/// @brief Start kernel command packet.
+///
+/// This should match the command format defined in xdna-driver (amdxdna_cmd) and XRT ERT
+/// (ert_start_kernel_cmd).
+struct ert_start_kernel_cmd {
+  union {
+    struct {
+      /// @brief Current state of a command. Should be one @ref ERT_START_CU.
+      uint32_t state : 4;
+      uint32_t unused : 6;
+      /// @brief Extra CU masks in addition to mandatory mask. The number of extra CU masks is
+      /// determined by the value of this field, and the actual masks are included in the payload
+      /// after the mandatory cu_mask.
+      uint32_t extra_cu_masks : 2;
+      /// @brief Number of words following header for cmd data. Not include stat data. The actual
+      /// number of CU masks in the payload is (1 + extra_cu_masks) based on the header fields, and
+      /// the rest of the payload is data.
+      uint32_t count : 11;
+      /// @brief Opcode for the command. Should be one of the values in @ref ert_cmd_opcode.
+      uint32_t opcode : 5;
+      /// @brief Reserved. Must be 0.
+      uint32_t reserved : 4;
+    };
+    uint32_t header;
+  };
+  /// @brief 1 mandatory CU mask, up to 4 optional CU masks, determined by @ref extra_cu_masks. Rest
+  /// of data.
+  uint32_t data[] __counted_by(count);
+};
+
+/// @brief Command chain packet.
+///
+/// This should match the command format defined in xdna-driver (amdxdna_cmd_chain) and XRT ERT
+/// (ert_cmd_chain).
+struct ert_cmd_chain_data {
+  /// @brief Number of commands in the chain.
+  uint32_t command_count;
+  /// @brief Index of last successfully submitted command in chain.
+  uint32_t submit_index;
+  /// @brief Index of failing command if cmd status is not completed.
+  uint32_t error_index;
+  /// @brief Reserved. Must be 0.
+  uint32_t reserved[3];
+  /// @brief BO handles of each command in the chain. The number of BO handles is determined by @ref
+  /// command_count.
+  uint64_t data[] __counted_by(command_count);
+};
 
 /// @brief XDNA device type.
 enum class XDNADeviceType {
@@ -922,7 +908,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
                                  3 +  // instruction sequence (address lo/hi + size)
                                  2 * pkt->num_kernargs);  // arguments (address lo/hi)
     const uint32_t cmd_data_bytesize = cmd_dwords * sizeof(uint32_t);
-    const uint32_t cmd_bytesize = sizeof(amdxdna_cmd) + cmd_data_bytesize;
+    const uint32_t cmd_bytesize = sizeof(ert_start_kernel_cmd) + cmd_data_bytesize;
     BOHandle cmd_bo_handle;
     hsa_status_t status = CreateCmdBO(cmd_bytesize, cmd_bo_handle);
     if (status != HSA_STATUS_SUCCESS) {
@@ -931,7 +917,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
     }
     cmd_bo_handles.push_back(cmd_bo_handle);
 
-    auto* cmd = static_cast<amdxdna_cmd*>(cmd_bo_handle.vaddr);
+    auto* cmd = static_cast<ert_start_kernel_cmd*>(cmd_bo_handle.vaddr);
     cmd->state = ERT_START_CU;
     cmd->extra_cu_masks = 0;
     // The driver places a structure before each command in a command chain.
@@ -968,8 +954,8 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
 
   // Create command chain.
   const uint32_t cmd_chain_data_bytesize = cmd_bo_handles.size() * sizeof(uint64_t);
-  const uint32_t cmd_data_bytesize = sizeof(amdxdna_cmd_chain) + cmd_chain_data_bytesize;
-  const uint32_t cmd_bytesize = sizeof(amdxdna_cmd) + cmd_data_bytesize;
+  const uint32_t cmd_data_bytesize = sizeof(ert_cmd_chain_data) + cmd_chain_data_bytesize;
+  const uint32_t cmd_bytesize = sizeof(ert_start_kernel_cmd) + cmd_data_bytesize;
   BOHandle cmd_bo_handle;
   hsa_status_t status = CreateCmdBO(cmd_bytesize, cmd_bo_handle);
   if (status != HSA_STATUS_SUCCESS) {
@@ -980,12 +966,13 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
   MAKE_NAMED_SCOPE_GUARD(cmd_bo_handle_guard, [&] { DestroyBOHandle(cmd_bo_handle); });
 
   // Create a command BO for the command chain.
-  auto* cmd = static_cast<amdxdna_cmd*>(cmd_bo_handle.vaddr);
+  auto* cmd = static_cast<ert_start_kernel_cmd*>(cmd_bo_handle.vaddr);
+  memset(cmd, 0, cmd_bytesize);
   cmd->state = ERT_CMD_STATE_NEW;
   cmd->extra_cu_masks = 0;
   cmd->count = cmd_data_bytesize / sizeof(uint32_t);
   cmd->opcode = ERT_CMD_CHAIN;
-  auto* cmd_chain = reinterpret_cast<amdxdna_cmd_chain*>(cmd->data);
+  auto* cmd_chain = reinterpret_cast<ert_cmd_chain_data*>(cmd->data);
   cmd_chain->command_count = cmd_bo_handles.size();
   for (size_t i = 0; i < cmd_bo_handles.size(); i++) {
     cmd_chain->data[i] = cmd_bo_handles[i].handle;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/uapi/amdxdna_accel.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/uapi/amdxdna_accel.h
@@ -1,12 +1,16 @@
-/* SPDX-License-Identifier: NCSA */
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
 /*
- * Copyright (C) 2022-2024, Advanced Micro Devices, Inc.
+ * Copyright (C) 2022-2026, Advanced Micro Devices, Inc.
  */
 
 #ifndef AMDXDNA_ACCEL_H_
 #define AMDXDNA_ACCEL_H_
 
+#ifdef __KERNEL__
+#include <drm/drm.h>
+#else
 #include <libdrm/drm.h>
+#endif
 #include <linux/const.h>
 #include <linux/stddef.h>
 
@@ -14,17 +18,20 @@
 extern "C" {
 #endif
 
-#ifndef __counted_by
-#define __counted_by(cnt)
-#endif
+#define AMDXDNA_DRIVER_MAJOR		1
+#define AMDXDNA_DRIVER_MINOR		0
 
-#define AMDXDNA_DRIVER_MAJOR 1
-#define AMDXDNA_DRIVER_MINOR 0
+#define AMDXDNA_INVALID_ADDR		(~0UL)
+#define AMDXDNA_INVALID_CTX_HANDLE	0
+#define AMDXDNA_INVALID_BO_HANDLE	0
+#define AMDXDNA_INVALID_FENCE_HANDLE	0
+#define AMDXDNA_INVALID_DOORBELL_OFFSET	(~0U)
 
-#define AMDXDNA_INVALID_ADDR (~0UL)
-#define AMDXDNA_INVALID_CTX_HANDLE 0
-#define AMDXDNA_INVALID_BO_HANDLE 0
-#define AMDXDNA_INVALID_FENCE_HANDLE 0
+#define POWER_MODE_DEFAULT	0
+#define POWER_MODE_LOW		1
+#define POWER_MODE_MEDIUM	2
+#define POWER_MODE_HIGH		3
+#define POWER_MODE_TURBO	4
 
 /*
  * The interface can grow/extend over time.
@@ -41,48 +48,69 @@ extern "C" {
  * We don't have extension now. The extension struct will define in the future.
  */
 
-enum amdxdna_drm_ioctl_id {
-  DRM_AMDXDNA_CREATE_HWCTX,
-  DRM_AMDXDNA_DESTROY_HWCTX,
-  DRM_AMDXDNA_CONFIG_HWCTX,
-  DRM_AMDXDNA_CREATE_BO,
-  DRM_AMDXDNA_GET_BO_INFO,
-  DRM_AMDXDNA_SYNC_BO,
-  DRM_AMDXDNA_EXEC_CMD,
-  DRM_AMDXDNA_GET_INFO,
-  DRM_AMDXDNA_SET_STATE,
-  DRM_AMDXDNA_WAIT_CMD,
-  DRM_AMDXDNA_NUM_IOCTLS
-};
+#define	DRM_AMDXDNA_CREATE_HWCTX	0
+#define	DRM_AMDXDNA_DESTROY_HWCTX	1
+#define	DRM_AMDXDNA_CONFIG_HWCTX	2
+#define	DRM_AMDXDNA_CREATE_BO		3
+#define	DRM_AMDXDNA_GET_BO_INFO		4
+#define	DRM_AMDXDNA_SYNC_BO		5
+#define	DRM_AMDXDNA_EXEC_CMD		6
+#define	DRM_AMDXDNA_GET_INFO		7
+#define	DRM_AMDXDNA_SET_STATE		8
+#define	DRM_AMDXDNA_WAIT_CMD		9
+#define DRM_AMDXDNA_GET_ARRAY		10
 
-enum amdxdna_device_type {
-  AMDXDNA_DEV_TYPE_UNKNOWN = -1,
-  AMDXDNA_DEV_TYPE_KMQ,
-  AMDXDNA_DEV_TYPE_UMQ,
-};
+#define	AMDXDNA_DEV_TYPE_UNKNOWN	-1
+#define	AMDXDNA_DEV_TYPE_KMQ		0
+#define	AMDXDNA_DEV_TYPE_UMQ		1
+#define	AMDXDNA_DEV_TYPE_PF		2
+
+/*
+ * Define priority in application's QoS.
+ * AMDXDNA_QOS_REALTIME_PRIORITY: Real time clients.
+ * AMDXDNA_QOS_HIGH_PRIORITY: Best effort foreground clients.
+ * AMDXDNA_QOS_NORMAL_PRIORITY: Best effort or background clients.
+ * AMDXDNA_QOS_LOW_PRIORITY: Clients that can wait indefinite amount of time for
+ *                           completion.
+ *
+ * NOTE, if driver see value beyond above definition, it decides the priority of
+ * the context without error/warning.
+ */
+#define	AMDXDNA_QOS_REALTIME_PRIORITY	0x100
+#define	AMDXDNA_QOS_HIGH_PRIORITY	0x180
+#define	AMDXDNA_QOS_NORMAL_PRIORITY	0x200
+#define	AMDXDNA_QOS_LOW_PRIORITY	0x280
+/* The maximum number of priority */
+#define	AMDXDNA_NUM_PRIORITY		4
+/* user start column request or not */
+#define	USER_START_COL_NOT_REQUESTED	0xFF
 
 /**
- * struct qos_info - QoS information for driver.
- * @gops: Giga operations per second.
- * @fps: Frames per second.
- * @dma_bandwidth: DMA bandwidtha.
+ * struct amdxdna_qos_info - QoS information for driver.
+ * @gops: Giga operations per workload.
+ * @fps: Workload per second.
+ * @dma_bandwidth: DMA bandwidth.
  * @latency: Frame response latency.
  * @frame_exec_time: Frame execution time.
  * @priority: Request priority.
+ * @user_start_col: User preferred start column, or USER_START_COL_NOT_REQUESTED if not specified.
+ * @reserved: Padding for 64-bit alignment (MBZ, reserved for future use).
  *
  * User program can provide QoS hints to driver.
  */
 struct amdxdna_qos_info {
-  __u32 gops;
-  __u32 fps;
-  __u32 dma_bandwidth;
-  __u32 latency;
-  __u32 frame_exec_time;
-  __u32 priority;
+	__u32 gops;
+	__u32 fps;
+	__u32 dma_bandwidth;
+	__u32 latency;
+	__u32 frame_exec_time;
+	__u32 priority;
+	__u32 user_start_col;
+	__u32 reserved; /* ensure 64-bit alignment */
 };
 
 /**
- * struct amdxdna_drm_create_hwctx - Create hardware context.
+ * struct amdxdna_drm_create_hwctx - Create context.
  * @ext: MBZ.
  * @ext_flags: MBZ.
  * @qos_p: Address of QoS info.
@@ -92,31 +120,31 @@ struct amdxdna_qos_info {
  * @num_tiles: Number of AIE tiles.
  * @mem_size: Size of AIE tile memory.
  * @umq_doorbell: Returned offset of doorbell associated with UMQ.
- * @handle: Returned hardware context handle.
- * @pad: Structure padding.
+ * @handle: Returned context handle.
+ * @syncobj_handle: The drm timeline syncobj handle for command completion notification.
  */
 struct amdxdna_drm_create_hwctx {
-  __u64 ext;
-  __u64 ext_flags;
-  __u64 qos_p;
-  __u32 umq_bo;
-  __u32 log_buf_bo;
-  __u32 max_opc;
-  __u32 num_tiles;
-  __u32 mem_size;
-  __u32 umq_doorbell;
-  __u32 handle;
-  __u32 pad;
+	__u64 ext;
+	__u64 ext_flags;
+	__u64 qos_p;
+	__u32 umq_bo;
+	__u32 log_buf_bo;
+	__u32 max_opc;
+	__u32 num_tiles;
+	__u32 mem_size;
+	__u32 umq_doorbell;
+	__u32 handle;
+	__u32 syncobj_handle;
 };
 
 /**
- * struct amdxdna_drm_destroy_hwctx - Destroy hardware context.
- * @handle: Hardware context handle.
+ * struct amdxdna_drm_destroy_hwctx - Destroy context.
+ * @handle: Context handle.
  * @pad: Structure padding.
  */
 struct amdxdna_drm_destroy_hwctx {
-  __u32 handle;
-  __u32 pad;
+	__u32 handle;
+	__u32 pad;
 };
 
 /**
@@ -126,36 +154,60 @@ struct amdxdna_drm_destroy_hwctx {
  * @pad: Structure padding.
  */
 struct amdxdna_cu_config {
-  __u32 cu_bo;
-  __u8 cu_func;
-  __u8 pad[3];
+	__u32 cu_bo;
+	__u8  cu_func;
+	__u8  pad[3];
 };
 
 /**
- * struct amdxdna_hwctx_param_config_cu - configuration for CUs in hardware
- * context
+ * struct amdxdna_hwctx_param_config_cu - configuration for CUs in context
  * @num_cus: Number of CUs to configure.
  * @pad: Structure padding.
  * @cu_configs: Array of CU configurations of struct amdxdna_cu_config.
  */
 struct amdxdna_hwctx_param_config_cu {
-  __u16 num_cus;
-  __u16 pad[3];
-  struct amdxdna_cu_config cu_configs[] __counted_by(num_cus);
-};
-
-enum amdxdna_drm_config_hwctx_param {
-  DRM_AMDXDNA_HWCTX_CONFIG_CU,
-  DRM_AMDXDNA_HWCTX_ASSIGN_DBG_BUF,
-  DRM_AMDXDNA_HWCTX_REMOVE_DBG_BUF,
-  DRM_AMDXDNA_HWCTX_CONFIG_NUM
+	__u16 num_cus;
+	__u16 pad[3];
+	struct amdxdna_cu_config cu_configs[];
 };
 
 /**
- * struct amdxdna_drm_config_hwctx - Configure hardware context.
- * @handle: hardware context handle.
- * @param_type: Value in enum amdxdna_drm_config_hwctx_param. Specifies the
- *              structure passed in via param_val.
+ * struct uc_info_entry: Holds uc index & buffer size allotment info
+ * @index: uc index
+ *     On aie2ps, uc index is same to column index
+ *     On aie4, uc index is mapped as 0->0_A, 1->0_B, 2->1_A, 3->1_B, 4->2_A, 5->2_B
+ * @size: buffer size in bytes for this uc
+ */
+struct uc_info_entry {
+	__u32 index;
+	__u32 size;
+};
+
+/**
+ * struct fw_buffer_metadata - Holds buffer configuration.
+ * @buf_type: buffer type set to fw
+ * @num_ucs: total ucs to config
+ * @command_id: command id used for trace
+ * @bo_handle: actual bo handle
+ * @uc_info_entry: uc index & buffer size mapping info
+ */
+struct fw_buffer_metadata {
+#define AMDXDNA_FW_BUF_DEBUG	0
+#define AMDXDNA_FW_BUF_TRACE	1
+#define AMDXDNA_FW_BUF_DBG_Q	2
+#define AMDXDNA_FW_BUF_LOG	3
+	__u8 buf_type;
+	__u8 num_ucs;
+	__u8 pad[48];
+	__u64 command_id;
+	__u64 bo_handle;
+	struct uc_info_entry uc_info[];
+};
+
+/**
+ * struct amdxdna_drm_config_hwctx - Configure context.
+ * @handle: Context handle.
+ * @param_type: Specifies the structure passed in via param_val.
  * @param_val: A structure specified by the param_type struct member.
  * @param_val_size: Size of the parameter buffer pointed to by the param_val.
  *		    If param_val is not a pointer, driver can ignore this.
@@ -165,43 +217,60 @@ enum amdxdna_drm_config_hwctx_param {
  * of the buffer is 4KiB(PAGE_SIZE).
  */
 struct amdxdna_drm_config_hwctx {
-  __u32 handle;
-  __u32 param_type;
-  __u64 param_val;
-  __u32 param_val_size;
-  __u32 pad;
+	__u32 handle;
+#define DRM_AMDXDNA_HWCTX_CONFIG_CU		0
+#define DRM_AMDXDNA_HWCTX_ASSIGN_DBG_BUF	1
+#define DRM_AMDXDNA_HWCTX_REMOVE_DBG_BUF	2
+#define DRM_AMDXDNA_HWCTX_CONFIG_OPCODE_TIMEOUT	3
+	__u32 param_type;
+	__u64 param_val;
+	__u32 param_val_size;
+	__u32 pad;
 };
 
-/*
- * AMDXDNA_BO_SHMEM:	DRM GEM SHMEM bo
- * AMDXDNA_BO_DEV_HEAP: Shared host memory to device as heap memory
- * AMDXDNA_BO_DEV_BO:	Allocated from BO_DEV_HEAP
- * AMDXDNA_BO_CMD:	User and driver accessible bo
- * AMDXDNA_BO_DMA:	DRM GEM DMA bo
+/**
+ * struct amdxdna_drm_va_entry
+ * @vaddr: Virtual address.
+ * @len: Size of entry.
  */
-enum amdxdna_bo_type {
-  AMDXDNA_BO_INVALID = 0,
-  AMDXDNA_BO_SHMEM,
-  AMDXDNA_BO_DEV_HEAP,
-  AMDXDNA_BO_DEV,
-  AMDXDNA_BO_CMD,
-  AMDXDNA_BO_DMA,
+struct amdxdna_drm_va_entry {
+	__u64 vaddr;
+	__u64 len;
+};
+
+/**
+ * struct amdxdna_drm_va_tbl
+ * @udma_fd: UDMABUF fd.
+ * @num_entries: Number of va entries.
+ * @va_entries: Array of va entries.
+ */
+struct amdxdna_drm_va_tbl {
+	__s32 udma_fd;
+	__u32 num_entries;
+	struct amdxdna_drm_va_entry va_entries[];
 };
 
 /**
  * struct amdxdna_drm_create_bo - Create a buffer object.
- * @flags: Buffer flags. MBZ.
- * @vaddr: User VA of buffer if applied. MBZ.
+ * @flags: Buffer flags.
+ *         Bits [7:0] - CMA memory region index for allocation.
+ *         Bits [63:8] - Reserved for other flags.
+ * @vaddr: Pointer of va address table.
  * @size: Size in bytes.
  * @type: Buffer type.
  * @handle: Returned DRM buffer object handle.
  */
 struct amdxdna_drm_create_bo {
-  __u64 flags;
-  __u64 vaddr;
-  __u64 size;
-  __u32 type;
-  __u32 handle;
+	__u64	flags;
+	__u64	vaddr;
+	__u64	size;
+#define	AMDXDNA_BO_INVALID	0 /* Invalid BO type */
+#define	AMDXDNA_BO_SHARE	1 /* Regular BO shared between user and device */
+#define	AMDXDNA_BO_DEV_HEAP	2 /* Shared host memory to device as heap memory */
+#define	AMDXDNA_BO_DEV		3 /* Allocated from BO_DEV_HEAP */
+#define	AMDXDNA_BO_CMD		4 /* Same as share BO, used only by XRT internally */
+	__u32	type;
+	__u32	handle;
 };
 
 /**
@@ -215,13 +284,13 @@ struct amdxdna_drm_create_bo {
  * @xdna_addr: Returned XDNA device virtual address.
  */
 struct amdxdna_drm_get_bo_info {
-  __u64 ext;
-  __u64 ext_flags;
-  __u32 handle;
-  __u32 pad;
-  __u64 map_offset;
-  __u64 vaddr;
-  __u64 xdna_addr;
+	__u64 ext;
+	__u64 ext_flags;
+	__u32 handle;
+	__u32 pad;
+	__u64 map_offset;
+	__u64 vaddr;
+	__u64 xdna_addr;
 };
 
 /**
@@ -232,58 +301,55 @@ struct amdxdna_drm_get_bo_info {
  * @size: Size in bytes.
  */
 struct amdxdna_drm_sync_bo {
-  __u32 handle;
-#define SYNC_DIRECT_TO_DEVICE 0U
-#define SYNC_DIRECT_FROM_DEVICE 1U
-  __u32 direction;
-  __u64 offset;
-  __u64 size;
-};
-
-enum amdxdna_cmd_type {
-  AMDXDNA_CMD_SUBMIT_EXEC_BUF = 0,
-  AMDXDNA_CMD_SUBMIT_DEPENDENCY,
-  AMDXDNA_CMD_SUBMIT_SIGNAL,
+	__u32 handle;
+#define SYNC_DIRECT_TO_DEVICE	0U
+#define SYNC_DIRECT_FROM_DEVICE	1U
+	__u32 direction;
+	__u64 offset;
+	__u64 size;
 };
 
 /**
  * struct amdxdna_drm_exec_cmd - Execute command.
  * @ext: MBZ.
  * @ext_flags: MBZ.
- * @hwctx: Hardware context handle.
- * @type: One of command type in enum amdxdna_cmd_type.
+ * @ctx: Context handle.
+ * @type: Command type.
  * @cmd_handles: Array of command handles or the command handle itself
- * in case of just one.
+ *               in case of just one.
  * @args: Array of arguments for all command handles.
  * @cmd_count: Number of command handles in the cmd_handles array.
  * @arg_count: Number of arguments in the args array.
  * @seq: Returned sequence number for this command.
  */
 struct amdxdna_drm_exec_cmd {
-  __u64 ext;
-  __u64 ext_flags;
-  __u32 hwctx;
-  __u32 type;
-  __u64 cmd_handles;
-  __u64 args;
-  __u32 cmd_count;
-  __u32 arg_count;
-  __u64 seq;
+	__u64 ext;
+	__u64 ext_flags;
+	__u32 hwctx;
+#define	AMDXDNA_CMD_SUBMIT_EXEC_BUF	0
+#define	AMDXDNA_CMD_SUBMIT_DEPENDENCY	1
+#define	AMDXDNA_CMD_SUBMIT_SIGNAL	2
+	__u32 type;
+	__u64 cmd_handles;
+	__u64 args;
+	__u32 cmd_count;
+	__u32 arg_count;
+	__u64 seq;
 };
 
 /**
  * struct amdxdna_drm_wait_cmd - Wait exectuion command.
  *
- * @hwctx: hardware context handle.
+ * @ctx: Context handle.
  * @timeout: timeout in ms, 0 implies infinite wait.
  * @seq: sequence number of the command returned by execute command.
  *
  * Wait a command specified by seq to be completed.
  */
 struct amdxdna_drm_wait_cmd {
-  __u32 hwctx;
-  __u32 timeout;
-  __u64 seq;
+	__u32 hwctx;
+	__u32 timeout;
+	__u64 seq;
 };
 
 /**
@@ -293,9 +359,9 @@ struct amdxdna_drm_wait_cmd {
  * @cols_filled: A bitmap of AIE columns whose data has been returned in the buffer.
  */
 struct amdxdna_drm_query_aie_status {
-  __u64 buffer;      /* out */
-  __u32 buffer_size; /* in */
-  __u32 cols_filled; /* out */
+	__u64 buffer; /* out */
+	__u32 buffer_size; /* in */
+	__u32 cols_filled; /* out */
 };
 
 /**
@@ -304,13 +370,12 @@ struct amdxdna_drm_query_aie_status {
  * @minor: The minor version number.
  */
 struct amdxdna_drm_query_aie_version {
-  __u32 major; /* out */
-  __u32 minor; /* out */
+	__u32 major; /* out */
+	__u32 minor; /* out */
 };
 
 /**
- * struct amdxdna_drm_query_aie_tile_metadata - Query the metadata of AIE tile
- * (core, mem, shim)
+ * struct amdxdna_drm_query_aie_tile_metadata - Query the metadata of AIE tile (core, mem, shim)
  * @row_count: The number of rows.
  * @row_start: The starting row number.
  * @dma_channel_count: The number of dma channels.
@@ -319,12 +384,12 @@ struct amdxdna_drm_query_aie_version {
  * @pad: Structure padding.
  */
 struct amdxdna_drm_query_aie_tile_metadata {
-  __u16 row_count;
-  __u16 row_start;
-  __u16 dma_channel_count;
-  __u16 lock_count;
-  __u16 event_reg_count;
-  __u16 pad[3];
+	__u16 row_count;
+	__u16 row_start;
+	__u16 dma_channel_count;
+	__u16 lock_count;
+	__u16 event_reg_count;
+	__u16 pad[3];
 };
 
 /**
@@ -338,13 +403,13 @@ struct amdxdna_drm_query_aie_tile_metadata {
  * @shim: The metadata for all shim tiles.
  */
 struct amdxdna_drm_query_aie_metadata {
-  __u32 col_size;
-  __u16 cols;
-  __u16 rows;
-  struct amdxdna_drm_query_aie_version version;
-  struct amdxdna_drm_query_aie_tile_metadata core;
-  struct amdxdna_drm_query_aie_tile_metadata mem;
-  struct amdxdna_drm_query_aie_tile_metadata shim;
+	__u32 col_size;
+	__u16 cols;
+	__u16 rows;
+	struct amdxdna_drm_query_aie_version version;
+	struct amdxdna_drm_query_aie_tile_metadata core;
+	struct amdxdna_drm_query_aie_tile_metadata mem;
+	struct amdxdna_drm_query_aie_tile_metadata shim;
 };
 
 /**
@@ -354,9 +419,9 @@ struct amdxdna_drm_query_aie_metadata {
  * @pad: Structure padding.
  */
 struct amdxdna_drm_query_clock {
-  __u8 name[16];
-  __u32 freq_mhz;
-  __u32 pad;
+	__u8 name[16];
+	__u32 freq_mhz;
+	__u32 pad;
 };
 
 /**
@@ -365,11 +430,9 @@ struct amdxdna_drm_query_clock {
  * @h_clock: The metadata for H clock.
  */
 struct amdxdna_drm_query_clock_metadata {
-  struct amdxdna_drm_query_clock mp_npu_clock;
-  struct amdxdna_drm_query_clock h_clock;
+	struct amdxdna_drm_query_clock mp_npu_clock;
+	struct amdxdna_drm_query_clock h_clock;
 };
-
-enum amdxdna_sensor_type { AMDXDNA_SENSOR_TYPE_POWER };
 
 /**
  * struct amdxdna_drm_query_sensor - The data for single sensor.
@@ -381,20 +444,22 @@ enum amdxdna_sensor_type { AMDXDNA_SENSOR_TYPE_POWER };
  * @status: The sensor status.
  * @units: The sensor units.
  * @unitm: Translates value member variables into the correct unit via (pow(10, unitm) * value).
- * @type: The sensor type from enum amdxdna_sensor_type.
+ * @type: The sensor type.
  * @pad: Structure padding.
  */
 struct amdxdna_drm_query_sensor {
-  __u8 label[64];
-  __u32 input;
-  __u32 max;
-  __u32 average;
-  __u32 highest;
-  __u8 status[64];
-  __u8 units[16];
-  __s8 unitm;
-  __u8 type;
-  __u8 pad[6];
+	__u8  label[64];
+	__u32 input;
+	__u32 max;
+	__u32 average;
+	__u32 highest;
+	__u8  status[64];
+	__u8  units[16];
+	__s8  unitm;
+#define AMDXDNA_SENSOR_TYPE_POWER		0
+#define AMDXDNA_SENSOR_TYPE_COLUMN_UTILIZATION	1
+	__u8  type;
+	__u8  pad[6];
 };
 
 /**
@@ -410,18 +475,20 @@ struct amdxdna_drm_query_sensor {
  * @preemptions: The number of times this context has been preempted by another context in the
  *               same partition.
  * @errors: The errors for this context.
+ *
+ * !!! NOTE: Never expand this struct. Use amdxdna_drm_hwctx_entry instead. !!!
  */
 struct amdxdna_drm_query_hwctx {
-  __u32 context_id;
-  __u32 start_col;
-  __u32 num_col;
-  __u32 pad;
-  __s64 pid;
-  __u64 command_submissions;
-  __u64 command_completions;
-  __u64 migrations;
-  __u64 preemptions;
-  __u64 errors;
+	__u32 context_id;
+	__u32 start_col;
+	__u32 num_col;
+	__u32 pad;
+	__s64 pid;
+	__u64 command_submissions;
+	__u64 command_completions;
+	__u64 migrations;
+	__u64 preemptions;
+	__u64 errors;
 };
 
 /**
@@ -436,11 +503,11 @@ struct amdxdna_drm_query_hwctx {
  * parameters.
  */
 struct amdxdna_drm_aie_mem {
-  __u32 col;
-  __u32 row;
-  __u32 addr;
-  __u32 size;
-  __u64 buf_p;
+	__u32 col;
+	__u32 row;
+	__u32 addr;
+	__u32 size;
+	__u64 buf_p;
 };
 
 /**
@@ -454,28 +521,20 @@ struct amdxdna_drm_aie_mem {
  * parameters.
  */
 struct amdxdna_drm_aie_reg {
-  __u32 col;
-  __u32 row;
-  __u32 addr;
-  __u32 val;
-};
-
-enum amdxdna_power_mode_type {
-  POWER_MODE_DEFAULT, /**< Fallback to calculated DPM */
-  POWER_MODE_LOW,     /**< Set frequency to lowest DPM */
-  POWER_MODE_MEDIUM,  /**< Set frequency to medium DPM */
-  POWER_MODE_HIGH,    /**< Set frequency to highest DPM */
-  POWER_MODE_TURBO,   /**< More power, more performance */
+	__u32 col;
+	__u32 row;
+	__u32 addr;
+	__u32 val;
 };
 
 /**
  * struct amdxdna_drm_get_power_mode - Get the power mode of the AIE hardware
- * @power_mode: The sensor type from enum amdxdna_power_mode_type
+ * @power_mode: Returned current power mode
  * @pad: MBZ.
  */
 struct amdxdna_drm_get_power_mode {
-  __u8 power_mode;
-  __u8 pad[7];
+	__u8 power_mode;
+	__u8 pad[7];
 };
 
 /**
@@ -486,97 +545,372 @@ struct amdxdna_drm_get_power_mode {
  * @build: The build ID
  */
 struct amdxdna_drm_query_firmware_version {
-  __u32 major; /* out */
-  __u32 minor; /* out */
-  __u32 patch; /* out */
-  __u32 build; /* out */
+	__u32 major; /* out */
+	__u32 minor; /* out */
+	__u32 patch; /* out */
+	__u32 build; /* out */
 };
 
-enum amdxdna_drm_get_param {
-  DRM_AMDXDNA_QUERY_AIE_STATUS,
-  DRM_AMDXDNA_QUERY_AIE_METADATA,
-  DRM_AMDXDNA_QUERY_AIE_VERSION,
-  DRM_AMDXDNA_QUERY_CLOCK_METADATA,
-  DRM_AMDXDNA_QUERY_SENSORS,
-  DRM_AMDXDNA_QUERY_HW_CONTEXTS,
-  DRM_AMDXDNA_READ_AIE_MEM,
-  DRM_AMDXDNA_READ_AIE_REG,
-  DRM_AMDXDNA_QUERY_FIRMWARE_VERSION,
-  DRM_AMDXDNA_GET_POWER_MODE,
-  DRM_AMDXDNA_QUERY_TELEMETRY,
-  DRM_AMDXDNA_NUM_GET_PARAM,
+/**
+ * struct amdxdna_drm_get_resource_info - Get info on some resources within NPU
+ * @npu_clk_max: max H-Clocks
+ * @npu_tops_max: max TOPs
+ * @npu_task_max: max number of tasks
+ * @npu_tops_curr: current TOPs
+ * @npu_task_curr: current number of tasks
+ */
+struct amdxdna_drm_get_resource_info {
+	__u64 npu_clk_max;
+	__u64 npu_tops_max;
+	__u64 npu_task_max;
+	__u64 npu_tops_curr;
+	__u64 npu_task_curr;
+};
+
+/**
+ * struct amdxdna_drm_attribute_state - Represent buffer packing for the below
+ *					struct amdxdna_drm_<get/set>_state attributes,
+ *					Get:
+ *						DRM_AMDXDNA_GET_FORCE_PREEMPT_STATE
+ *						DRM_AMDXDNA_GET_FRAME_BOUNDARY_PREEMPT_STATE
+ *					Set:
+ *						DRM_AMDXDNA_SET_FORCE_PREEMPT
+ *						DRM_AMDXDNA_SET_FRAME_BOUNDARY_PREEMPT
+ * @state: 1 implies enabled/true. 0 implies disabled/false. Other value is invalid.
+ * @pad: MBZ.
+ */
+struct amdxdna_drm_attribute_state {
+	__u8 state;
+	__u8 pad[7];
+};
+
+/**
+ * struct amdxdna_drm_query_telemetry_header - Telemetry header to capture information shared
+ *					       between driver and shim. Followed by the telemetry
+ *					       data harvested from the firmware.
+ * @major: Firmware telemetry interface major version number. Based on firmware response message.
+ * @minor: Firmware telemetry interface minor version number. Based on firmware response message.
+ * @type: Telemetry query type. Set by the user.
+ *	  MBZ for NPU 1, 2, 4, 5, and 6. Non-zero for future generations.
+ * @map_num_elements: Total number of elements in the map table. Set by the driver.
+ * @map: Maps the firmware allocated context ID(key) to driver allocated context ID(value).
+ */
+struct amdxdna_drm_query_telemetry_header {
+	__u32 major;
+	__u32 minor;
+	__u32 type;
+	__u32 map_num_elements;
+	__u32 map[];
 };
 
 /**
  * struct amdxdna_drm_get_info - Get some information from the AIE hardware.
- * @param: Value in enum amdxdna_drm_get_param. Specifies the structure passed in the buffer.
+ * @param: Specifies the structure passed in the buffer.
  * @buffer_size: Size of the input buffer. Size needed/written by the kernel.
  * @buffer: A structure specified by the param struct member.
  */
 struct amdxdna_drm_get_info {
-  __u32 param;       /* in */
-  __u32 buffer_size; /* in/out */
-  __u64 buffer;      /* in/out */
+#define	DRM_AMDXDNA_QUERY_AIE_STATUS			0
+#define	DRM_AMDXDNA_QUERY_AIE_METADATA			1
+#define	DRM_AMDXDNA_QUERY_AIE_VERSION			2
+#define	DRM_AMDXDNA_QUERY_CLOCK_METADATA		3
+#define	DRM_AMDXDNA_QUERY_SENSORS			4
+#define	DRM_AMDXDNA_QUERY_HW_CONTEXTS			5
+#define	DRM_AMDXDNA_READ_AIE_MEM			6
+#define	DRM_AMDXDNA_READ_AIE_REG			7
+#define	DRM_AMDXDNA_QUERY_FIRMWARE_VERSION		8
+#define	DRM_AMDXDNA_GET_POWER_MODE			9
+#define	DRM_AMDXDNA_QUERY_TELEMETRY			10
+#define	DRM_AMDXDNA_GET_FORCE_PREEMPT_STATE		11
+#define	DRM_AMDXDNA_QUERY_RESOURCE_INFO			12
+#define	DRM_AMDXDNA_GET_FRAME_BOUNDARY_PREEMPT_STATE	13
+#define	DRM_AMDXDNA_QUERY_CERT_FIRMWARE_VERSION		14
+	__u32 param; /* in */
+	__u32 buffer_size; /* in/out */
+	__u64 buffer; /* in/out */
+};
+
+/**
+ * struct amdxdna_drm_hwctx_entry - The element of a context in array
+ * @context_id: The ID for this context.
+ * @start_col: The starting column for the partition assigned to this context.
+ * @num_col: The number of columns in the partition assigned to this context.
+ * @hwctx_id: Hardware context ID.
+ * @pid: The Process ID of the process that created this context.
+ * @command_submissions: The number of commands submitted to this context.
+ * @command_completions: The number of commands completed by this context.
+ * @migrations: The number of times this context has been moved to a different partition.
+ * @preemptions: The number of times this context has been preempted by another context in the
+ *               same partition.
+ * @errors: The errors for this context.
+ * @priority: Context priority.
+ * @heap_usage: The usage of heap buffer of the process
+ * @suspensions: Context suspension count
+ * @state: The state of context.
+ * @pasid: PASID for this process
+ * @gops: Giga operations per second
+ * @fps: Frames per second
+ * @dma_bandwidth: DMA bandwidth
+ * @latency: Frame response latency
+ * @frame_exec_time: Frame execution time
+ * @txn_op_idx: index of last TXN control code executed
+ * @ctx_pc: program counter for that context
+ * @fatal_error_type: the fatal error type if context crashes
+ * @fatal_error_exception_type: LX7 exception type
+ * @fatal_error_exception_pc: LX7 program counter at the time of the exception
+ * @fatal_error_app_module: module name where the exception occurred
+ */
+struct amdxdna_drm_hwctx_entry {
+	__u32 context_id;
+	__u32 start_col;
+	__u32 num_col;
+	__u32 hwctx_id;
+	__s64 pid;
+	__u64 command_submissions;
+	__u64 command_completions;
+	__u64 migrations;
+	__u64 preemptions;
+	__u64 errors;
+	__u64 priority;
+	__u64 heap_usage;
+	__u64 suspensions;
+#define AMDXDNA_HWCTX_STATE_IDLE	0
+#define AMDXDNA_HWCTX_STATE_ACTIVE	1
+	__u32 state;
+	__u32 pasid;
+	__u32 gops;
+	__u32 fps;
+	__u32 dma_bandwidth;
+	__u32 latency;
+	__u32 frame_exec_time;
+	__u32 txn_op_idx;
+	__u32 ctx_pc;
+	__u32 fatal_error_type;
+	__u32 fatal_error_exception_type;
+	__u32 fatal_error_exception_pc;
+	__u32 fatal_error_app_module;
+};
+
+/**
+ * struct amdxdna_async_error - XDNA async error structure
+ * @err_code: error code, ErrorNum + Driver + Severity + Module + Class
+ *            Refer to amdxnda_xrt_error.h for error code encoding details
+ * @ts_us: timestamp in us
+ * @ex_err_code: extra error code
+ *
+ * This structure definition refers to XRT error code definition
+ */
+struct amdxdna_async_error {
+	__u64 err_code;
+	__u64 ts_us;
+	__u64 ex_err_code;
+};
+
+/**
+ * struct amdxdna_dpt_metadata - DPT metadata shared between shim and driver
+ * @offset: ever increamenting DPT read pointer
+ * @size: size of the buffer
+ * @watch: boolean value to indicate if this request can wait in the kernel until new data is
+ *	   available
+ */
+struct amdxdna_dpt_metadata {
+	__u64 offset;
+	__u32 size;
+	__u8 watch;
+	__u8 reserved[3];
+};
+
+/**
+ * struct amdxdna_drm_set_dpt_state - Structure to configure DPT
+ * @action: 1 to enable. 0 to disable
+ * @config: for firmware logging this value indicates log level
+ */
+struct amdxdna_drm_set_dpt_state {
+	__u32 action;
+	__u32 config;
+	__u64 reserved;
+};
+
+/**
+ * struct amdxdna_drm_get_dpt_state - Structure to get current DPT state
+ * @version: Payload version
+ * @status: 1 implies enabled. 0 implies disabled
+ * @config: signifies log level for firmware logging or categories for firmware trace
+ */
+struct amdxdna_drm_get_dpt_state {
+	__u32 version;
+	__u32 status;
+	__u32 config;
+	__u32 reserved;
+};
+
+/**
+ * struct amdxdna_drm_aie_tile_access - The data for AIE memory/register read/write
+ * @pid: The Process ID of the process that created this context.
+ * @context_id: The hw context id.
+ * @col:   The AIE column index
+ * @row:   The AIE row index
+ * @addr:  The AIE memory address to read/write
+ * @size:  The size of bytes to read/write
+ *
+ * This is used for DRM_AMDXDNA_AIE_TILE_READ and DRM_AMDXDNA_AIE_TILE_WRITE
+ * parameters.
+ */
+struct amdxdna_drm_aie_tile_access {
+	__u64 pid;
+	__u32 context_id;
+	__u32 col;
+	__u32 row;
+	__u32 addr;
+	__u32 size;
+	__u32 pad;
+};
+
+/**
+ * struct amdxdna_drm_aie_coredump - The data for AIE coredump
+ * @pid: The Process ID of the process that created this context.
+ * @context_id: The hw context id.
+ *
+ * This is used for DRM_AMDXDNA_AIE_COREDUMP parameters.
+ */
+struct amdxdna_drm_aie_coredump {
+	__u64 pid;
+	__u32 context_id;
+	__u32 pad;
+};
+
+/**
+ * struct amdxdna_drm_bo_usage - The BO usage statistics
+ * @pid: The ID of the process to query from
+ * @total_usage: Total BO size used by process
+ * @internal_usage: Total internal BO size used by process
+ * @heap_usage: Total device BO size used by process
+ *
+ * This is used for DRM_AMDXDNA_BO_USAGE parameters.
+ *
+ * This is for querying BO mem foot print.
+ * BOs managed by XRT/SHIM/driver is counted as internal.
+ * Others are counted as external which are managed by applications.
+ *
+ * Among all types of BOs:
+ *   AMDXDNA_BO_DEV_HEAP - is counted for internal.
+ *   AMDXDNA_BO_SHARE    - is counted for external.
+ *   AMDXDNA_BO_CMD      - is counted for internal.
+ *   AMDXDNA_BO_DEV      - is counted by heap_usage only, not internal
+ *                         or external. It does not add to the total memory
+ *                         foot print since its mem comes from heap which is
+ *                         already accounted as internal.
+ */
+struct amdxdna_drm_bo_usage {
+	__s64 pid;
+	__u64 total_usage;
+	__u64 internal_usage;
+	__u64 heap_usage;
+};
+
+/**
+ * struct amdxdna_drm_get_array - Get some information from the AIE hardware, return array.
+ * @param: Specifies the structure passed in the buffer.
+ * @element_size: Size of each element in the array.
+ * @num_element: The number of elements.
+ * @buffer: Pointer to an array whose elements are structure specified by the param struct member.
+ */
+struct amdxdna_drm_get_array {
+#define DRM_AMDXDNA_HW_CONTEXT_ALL		0
+#define DRM_AMDXDNA_HW_CONTEXT_BY_ID		1
+#define DRM_AMDXDNA_HW_LAST_ASYNC_ERR		2
+#define DRM_AMDXDNA_FW_LOG			3
+#define DRM_AMDXDNA_FW_TRACE			4
+#define DRM_AMDXDNA_AIE_COREDUMP		5
+#define DRM_AMDXDNA_BO_USAGE			6
+#define DRM_AMDXDNA_FW_LOG_CONFIG		7
+#define DRM_AMDXDNA_FW_TRACE_CONFIG		8
+#define DRM_AMDXDNA_AIE_TILE_READ		9
+#define DRM_AMDXDNA_HWCTX_AIE_PART_FD		10
+#define DRM_AMDXDNA_HWCTX_MEM_BITMAP		11
+	__u32 param; /* in */
+#define AMDXDNA_MAX_ELEMENT_SIZE		(100U * 1024 * 1024)
+	__u32 element_size; /* in/out */
+#define AMDXDNA_MAX_NUM_ELEMENT			1024
+	__u32 num_element; /* in/out */
+	__u32 pad;
+	__u64 buffer; /* in/out */
 };
 
 /**
  * struct amdxdna_drm_set_power_mode - Set the power mode of the AIE hardware
- * @power_mode: The sensor type from enum amdxdna_power_mode_type
+ * @power_mode: The target power mode to be set
  * @pad: MBZ.
  */
 struct amdxdna_drm_set_power_mode {
-  __u8 power_mode;
-  __u8 pad[7];
-};
-
-enum amdxdna_drm_set_param {
-  DRM_AMDXDNA_SET_POWER_MODE,
-  DRM_AMDXDNA_WRITE_AIE_MEM,
-  DRM_AMDXDNA_WRITE_AIE_REG,
-  DRM_AMDXDNA_NUM_SET_PARAM,
+	__u8 power_mode;
+	__u8 pad[7];
 };
 
 /**
  * struct amdxdna_drm_set_state - Set the state of some component within the AIE hardware.
- * @param: Value in enum amdxdna_drm_set_param. Specifies the structure passed in the buffer.
+ * @param: Specifies the structure passed in the buffer.
  * @buffer_size: Size of the input buffer.
  * @buffer: A structure specified by the param struct member.
  */
 struct amdxdna_drm_set_state {
-  __u32 param;       /* in */
-  __u32 buffer_size; /* in */
-  __u64 buffer;      /* in */
+#define	DRM_AMDXDNA_SET_POWER_MODE		0
+#define	DRM_AMDXDNA_WRITE_AIE_MEM		1
+#define	DRM_AMDXDNA_WRITE_AIE_REG		2
+#define	DRM_AMDXDNA_SET_FORCE_PREEMPT		3
+#define	DRM_AMDXDNA_SET_FRAME_BOUNDARY_PREEMPT	4
+#define	DRM_AMDXDNA_SET_FW_LOG_STATE		5
+#define	DRM_AMDXDNA_SET_FW_TRACE_STATE		6
+#define	DRM_AMDXDNA_AIE_TILE_WRITE		7
+#define	DRM_AMDXDNA_SET_CLOCK_FREQ		8
+	__u32 param; /* in */
+	__u32 buffer_size; /* in */
+	__u64 buffer; /* in */
 };
 
-#define DRM_IOCTL_AMDXDNA_CREATE_HWCTX                                                             \
-  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_CREATE_HWCTX, struct amdxdna_drm_create_hwctx)
+#define DRM_IOCTL_AMDXDNA_CREATE_HWCTX \
+	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_CREATE_HWCTX, \
+		 struct amdxdna_drm_create_hwctx)
 
-#define DRM_IOCTL_AMDXDNA_DESTROY_HWCTX                                                            \
-  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_DESTROY_HWCTX, struct amdxdna_drm_destroy_hwctx)
+#define DRM_IOCTL_AMDXDNA_DESTROY_HWCTX \
+	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_DESTROY_HWCTX, \
+		 struct amdxdna_drm_destroy_hwctx)
 
-#define DRM_IOCTL_AMDXDNA_CONFIG_HWCTX                                                             \
-  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_CONFIG_HWCTX, struct amdxdna_drm_config_hwctx)
+#define DRM_IOCTL_AMDXDNA_CONFIG_HWCTX \
+	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_CONFIG_HWCTX, \
+		 struct amdxdna_drm_config_hwctx)
 
-#define DRM_IOCTL_AMDXDNA_CREATE_BO                                                                \
-  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_CREATE_BO, struct amdxdna_drm_create_bo)
+#define DRM_IOCTL_AMDXDNA_CREATE_BO \
+	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_CREATE_BO, \
+		 struct amdxdna_drm_create_bo)
 
-#define DRM_IOCTL_AMDXDNA_GET_BO_INFO                                                              \
-  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_GET_BO_INFO, struct amdxdna_drm_get_bo_info)
+#define DRM_IOCTL_AMDXDNA_GET_BO_INFO \
+	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_GET_BO_INFO, \
+		 struct amdxdna_drm_get_bo_info)
 
-#define DRM_IOCTL_AMDXDNA_SYNC_BO                                                                  \
-  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_SYNC_BO, struct amdxdna_drm_sync_bo)
+#define DRM_IOCTL_AMDXDNA_SYNC_BO \
+	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_SYNC_BO, \
+		 struct amdxdna_drm_sync_bo)
 
-#define DRM_IOCTL_AMDXDNA_EXEC_CMD                                                                 \
-  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_EXEC_CMD, struct amdxdna_drm_exec_cmd)
+#define DRM_IOCTL_AMDXDNA_EXEC_CMD \
+	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_EXEC_CMD, \
+		 struct amdxdna_drm_exec_cmd)
 
-#define DRM_IOCTL_AMDXDNA_WAIT_CMD                                                                 \
-  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_WAIT_CMD, struct amdxdna_drm_wait_cmd)
+#define DRM_IOCTL_AMDXDNA_WAIT_CMD \
+	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_WAIT_CMD, \
+		 struct amdxdna_drm_wait_cmd)
 
-#define DRM_IOCTL_AMDXDNA_GET_INFO                                                                 \
-  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_GET_INFO, struct amdxdna_drm_get_info)
+#define DRM_IOCTL_AMDXDNA_GET_INFO \
+	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_GET_INFO, \
+		 struct amdxdna_drm_get_info)
 
-#define DRM_IOCTL_AMDXDNA_SET_STATE                                                                \
-  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_SET_STATE, struct amdxdna_drm_set_state)
+#define DRM_IOCTL_AMDXDNA_GET_ARRAY \
+	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_GET_ARRAY, \
+		struct amdxdna_drm_get_array)
+
+#define DRM_IOCTL_AMDXDNA_SET_STATE \
+	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDXDNA_SET_STATE, \
+		 struct amdxdna_drm_set_state)
 
 #if defined(__cplusplus)
 } /* extern c end */

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -39,6 +39,7 @@
 // DEALINGS WITH THE SOFTWARE.
 //
 ////////////////////////////////////////////////////////////////////////////////
+
 #ifndef HSA_RUNTIME_CORE_INC_AMD_XDNA_DRIVER_H_
 #define HSA_RUNTIME_CORE_INC_AMD_XDNA_DRIVER_H_
 
@@ -48,50 +49,11 @@
 #include <memory>
 #include <unordered_map>
 
-#include "core/driver/xdna/uapi/amdxdna_accel.h"
 #include "core/inc/amd_aie_agent.h"
 #include "core/inc/driver.h"
 #include "core/inc/memory_region.h"
 
-/// @brief struct amdxdna_cmd_chain - Interpretation of data payload for
-/// ERT_CMD_CHAIN
-struct amdxdna_cmd_chain {
-  /// Number of commands in chain
-  __u32 command_count;
-  /// Index of last successfully submitted command in chain
-  __u32 submit_index;
-  /// Index of failing command if cmd status is not completed
-  __u32 error_index;
-  __u32 reserved[3];
-  /// Address of each command in chain
-  __u64 data[] __counted_by(command_count);
-};
-
-/// @brief struct amdxdna_cmd - Exec buffer command header format
-struct amdxdna_cmd {
-  union {
-    struct {
-      /// Current state of a command
-      __u32 state : 4;
-      __u32 unused : 6;
-      /// Extra CU masks in addition to mandatory mask
-      __u32 extra_cu_masks : 2;
-      /// Number of words in payload (data)
-      __u32 count : 11;
-      /// Opcode identifying specific command
-      __u32 opcode : 5;
-      __u32 reserved : 4;
-    };
-    __u32 header;
-  };
-  /// Count number of words representing packet payload
-  __u32 data[] __counted_by(count);
-};
-
 namespace rocr {
-namespace core {
-class Queue;
-}
 
 namespace AMD {
 
@@ -104,8 +66,8 @@ class XdnaDriver final : public core::Driver {
   struct BOHandle {
     /// Mapped address.
     void* vaddr = nullptr;
-    /// Handle returned by xdna.
-    uint32_t handle = AMDXDNA_INVALID_BO_HANDLE;
+    /// Handle returned by xdna. Same value as AMDXDNA_INVALID_BO_HANDLE.
+    uint32_t handle = 0;
     /// Size in bytes.
     size_t size = 0;
     /// True if @ref vaddr needs to be unmapped.
@@ -114,7 +76,7 @@ class XdnaDriver final : public core::Driver {
     constexpr BOHandle() = default;
     constexpr BOHandle(void* vaddr, uint32_t handle, size_t size)
         : vaddr{vaddr}, handle{handle}, size{size} {}
-    constexpr bool IsValid() const { return handle != AMDXDNA_INVALID_BO_HANDLE; }
+    constexpr bool IsValid() const { return handle != 0; }
   };
 
 
@@ -220,9 +182,18 @@ public:
                                      uint64_t* drm_fd_offset) override;
   hsa_status_t DestroyShareableHandle(core::ShareableHandle* handle) override;
 
-  /// @brief Submits @p num_pkts packets in a command chain.
-  hsa_status_t SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uint32_t num_pkts,
-                              HSA_QUEUEID& queue_id, uint32_t num_core_tiles);
+  /// @brief Submits a chain of command packets to the driver for execution.
+  ///
+  /// @note The packets are contiguous in index but not necessarily contiguous in memory.
+  ///
+  /// @param[in] q AIE KMQ queue with queued packets
+  /// @param[in,out] queue_id queue ID. It will be updated if the driver needs to create a new
+  /// hardware context for this command chain.
+  /// @param[in] first_pkt_idx index of the first packet in the queue
+  /// @param[in] num_pkts number of packets in the queue to be submitted
+  /// @param[in] num_core_tiles number of core tiles in the AIE device
+  hsa_status_t SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id, uint64_t first_pkt_idx,
+                              uint64_t num_pkts, uint32_t num_core_tiles);
 
   hsa_status_t SPMAcquire(uint32_t preferred_node_id) const override;
   hsa_status_t SPMRelease(uint32_t preferred_node_id) const override;
@@ -259,7 +230,7 @@ public:
 
   /// @brief Creates a new hardware context with the given PDI BO handles.
   hsa_status_t ConfigHwCtx(const PDICache& pdi_bo_handles, HSA_QUEUEID& queue_id,
-                           uint32_t num_core_tiles);
+                           uint32_t num_core_tiles) const;
 
   hsa_status_t QueryDriverVersion();
 
@@ -274,15 +245,6 @@ public:
   /// @param size size of memory to allocate
   /// @param bo_info allocated BO
   hsa_status_t CreateCmdBO(uint32_t size, BOHandle& bo_info);
-
-  /// @brief Gets all BOs from a command packet payload, flushes the caches associated with them and
-  /// replaces the instruction virtual address with the device address.
-  ///
-  /// @param count Number of entries in the command
-  /// @param cmd_pkt_payload A pointer to the payload of the command
-  /// @param bo_handles vector that contains all BO handles
-  hsa_status_t PrepareBOs(uint32_t count, hsa_amd_aie_ert_start_kernel_data_t* cmd_pkt_payload,
-                          std::vector<uint32_t>& bo_handles);
 
   /// @brief Executes a command and waits for its completion
   ///

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -146,6 +146,7 @@ public:
                                       void **mem, size_t size,
                                       uint32_t node_id) = 0;
 
+  /// @brief Free memory allocated by @ref AllocateMemory.
   virtual hsa_status_t FreeMemory(void *mem, size_t size) = 0;
 
   /// @brief Create an agent dispatch queue with user-mode access rights.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2023-2025, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2023-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -41,7 +41,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "core/inc/amd_aie_aql_queue.h"
-#include "core/inc/amd_xdna_driver.h"
 
 #ifdef __linux__
 #include <fcntl.h>
@@ -57,6 +56,7 @@
 #include <cassert>
 #include <cstring>
 
+#include "inc/hsa_ext_amd_aie.h"
 #include "core/inc/amd_xdna_driver.h"
 #include "core/inc/queue.h"
 #include "core/inc/runtime.h"
@@ -65,6 +65,9 @@
 
 namespace rocr {
 namespace AMD {
+
+static_assert(sizeof(hsa_amd_aie_kernel_dispatch_packet_t) == sizeof(core::AqlPacket),
+              "hsa_amd_aie_kernel_dispatch_packet_t must be the same size as core::AqlPacket");
 
 AieAqlQueue::AieAqlQueue(core::SharedQueue* shared_queue, AieAgent* agent, size_t req_size_pkts,
                          uint32_t node_id, uint64_t flags)
@@ -77,7 +80,7 @@ AieAqlQueue::AieAqlQueue(core::SharedQueue* shared_queue, AieAgent* agent, size_
     throw hsa_exception(HSA_STATUS_ERROR_INVALID_AGENT,
                         "Attempting to create an AIE queue on a non-AIE agent.");
   }
-  queue_size_bytes_ = req_size_pkts * sizeof(core::AqlPacket);
+  queue_size_bytes_ = req_size_pkts * sizeof(hsa_amd_aie_kernel_dispatch_packet_t);
   ring_buf_ = agent_.system_allocator()(queue_size_bytes_, 4096,
                                         core::MemoryRegion::AllocateNoFlags);
 
@@ -88,10 +91,12 @@ AieAqlQueue::AieAqlQueue(core::SharedQueue* shared_queue, AieAgent* agent, size_
 
   // Populate hsa_queue_t fields.
   amd_queue_.hsa_queue.type = HSA_QUEUE_TYPE_SINGLE;
-  amd_queue_.hsa_queue.id = INVALID_QUEUEID;
-  amd_queue_.hsa_queue.doorbell_signal = Signal::Convert(this);
+  amd_queue_.hsa_queue.features = 0;  // KMQ queues do not support any features.
   amd_queue_.hsa_queue.size = req_size_pkts;
   amd_queue_.hsa_queue.base_address = ring_buf_;
+  amd_queue_.hsa_queue.doorbell_signal = Signal::Convert(this);
+  amd_queue_.hsa_queue.id = GetQueueId();
+
   // Populate AMD queue fields.
   amd_queue_.write_dispatch_id = 0;
   amd_queue_.read_dispatch_id = 0;
@@ -108,9 +113,7 @@ AieAqlQueue::AieAqlQueue(core::SharedQueue* shared_queue, AieAgent* agent, size_
   if (status != HSA_STATUS_SUCCESS) {
     throw hsa_exception(status, "Failed to create a hardware context for an AIE queue.");
   }
-
   queue_id_ = queue_resource.QueueId;
-  amd_queue_.hsa_queue.id = GetQueueId();
 }
 
 AieAqlQueue::~AieAqlQueue() {
@@ -214,54 +217,23 @@ void AieAqlQueue::SubmitPackets() {
   }
 
   auto& driver = static_cast<XdnaDriver&>(agent_.driver());
-  void* queue_base = amd_queue_.hsa_queue.base_address;
-  const uint32_t queue_size = amd_queue_.hsa_queue.size;
 
-  uint64_t cur_id = LoadReadIndexRelaxed();
-  const uint64_t end = LoadWriteIndexAcquire();
-  while (cur_id < end) {
-    // Use modulo to properly index into the ring buffer
-    const uint64_t pkt_idx = cur_id % queue_size;
-    auto* pkt = static_cast<hsa_amd_aie_ert_packet_t*>(queue_base) + pkt_idx;
+  const uint64_t first_pkt_idx = LoadReadIndexRelaxed();
+  const uint64_t last_pkt_idx = LoadWriteIndexAcquire();
 
-    // Get the packet header information
-    if (pkt->header.header != HSA_PACKET_TYPE_VENDOR_SPECIFIC ||
-        pkt->header.AmdFormat != HSA_AMD_PACKET_TYPE_AIE_ERT ) {
-      throw hsa_exception(HSA_STATUS_ERROR_INVALID_PACKET_FORMAT, "Invalid packet header");
-    }
-
-    // Get the payload information
-    switch (pkt->opcode) {
-      case HSA_AMD_AIE_ERT_START_CU: {
-        // Iterating over future packets and seeing how many contiguous HSA_AMD_AIE_ERT_START_CU
-        // packets there are. All can be combined into a single chain.
-        uint64_t num_cont_start_cu_pkts = 1;
-        for (uint64_t peak_pkt_id = cur_id + 1; peak_pkt_id < end; peak_pkt_id++) {
-          const uint64_t peak_pkt_idx = peak_pkt_id % queue_size;
-          auto* peak_pkt = static_cast<hsa_amd_aie_ert_packet_t*>(queue_base) + peak_pkt_idx;
-          if (peak_pkt->opcode != HSA_AMD_AIE_ERT_START_CU) {
-            break;
-          }
-          num_cont_start_cu_pkts++;
-        }
-
-        // Call into the driver to submit from cur_id to write_dispatch_id.
-        // Submitting the command chain might create a new hardware context.
-        hsa_status_t status = driver.SubmitCmdChain(pkt, num_cont_start_cu_pkts, queue_id_,
-                                                    agent_.properties().NumNeuralCores);
-        if (status != HSA_STATUS_SUCCESS) {
-          throw hsa_exception(status, "Could not submit packets");
-        }
-
-        cur_id += num_cont_start_cu_pkts;
-        break;
-      }
-      default:
-        break;
-    }
+  if (first_pkt_idx >= last_pkt_idx) {
+    // No packets to submit.
+    return;
   }
 
-  atomic::Store(&amd_queue_.read_dispatch_id, cur_id, std::memory_order_release);
+  const auto num_pkts = last_pkt_idx - first_pkt_idx;
+  hsa_status_t status = driver.SubmitCmdChain(amd_queue_.hsa_queue, queue_id_, first_pkt_idx,
+                                              num_pkts, agent_.properties().NumNeuralCores);
+  if (status != HSA_STATUS_SUCCESS) {
+    throw hsa_exception(status, "Could not submit packets");
+  }
+
+  atomic::Store(&amd_queue_.read_dispatch_id, last_pkt_idx, std::memory_order_release);
 }
 
 void AieAqlQueue::StoreRelease(hsa_signal_value_t value) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/utils.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/utils.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2025, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -480,10 +480,11 @@ inline uint32_t LowPart(uint64_t value) { return (value & 0x00000000FFFFFFFF); }
 /// @param: lo(Input), To be placed in the lower bits of the output
 /// @return: OutType, Concatenation of hi and lo
 template <typename OutType, typename InType>
-typename std::enable_if<std::is_integral<OutType>::value && std::is_integral<InType>::value &&
-                            sizeof(OutType) >= 2 * sizeof(InType),
-                        OutType>::type
-Concat(InType hi, InType lo) {
+constexpr
+    typename std::enable_if<std::is_integral<OutType>::value && std::is_integral<InType>::value &&
+                                sizeof(OutType) >= 2 * sizeof(InType),
+                            OutType>::type
+    Concat(InType hi, InType lo) {
   OutType res = ((static_cast<OutType>(hi) << sizeof(InType) * 8) | static_cast<OutType>(lo));
   return res;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2025, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -126,8 +126,6 @@ typedef enum {
 
   /* Reserved for a packet that is not yet released */
   HSA_AMD_PACKET_TYPE_RESERVED200 = 200,
-  /* HSA_AMD_PACKET_TYPE_AIE_ERT packet was never released so value may change in the future */
-  HSA_AMD_PACKET_TYPE_AIE_ERT = 200,
 } hsa_amd_packet_type_t;
 
 /**
@@ -421,206 +419,6 @@ typedef struct hsa_amd_ext_kernel_dispatch_packet_s {
   hsa_signal_t completion_signal;
 } hsa_amd_ext_kernel_dispatch_packet_t;
 
-/*
- * State of an AIE ERT command.
- */
-typedef enum {
-  /**
-   * Set by the host before submitting a command to the scheduler.
-   */
-  HSA_AMD_AIE_ERT_STATE_NEW = 1,
-  /**
-   * Internal scheduler state.
-   */
-  HSA_AMD_AIE_ERT_STATE_QUEUED = 2,
-  /**
-   * Internal scheduler state.
-   */
-  HSA_AMD_AIE_ERT_STATE_RUNNING = 3,
-  /**
-   * Set by the scheduler when a command completes.
-   */
-  HSA_AMD_AIE_ERT_STATE_COMPLETED = 4,
-  /**
-   * Set by the scheduler if a command failed.
-   */
-  HSA_AMD_AIE_ERT_STATE_ERROR = 5,
-  /**
-   * Set by the scheduler if a command aborted.
-   */
-  HSA_AMD_AIE_ERT_STATE_ABORT = 6,
-  /**
-   * Internal scheduler state.
-   */
-  HSA_AMD_AIE_ERT_STATE_SUBMITTED = 7,
-  /**
-   * Set by the scheduler on a timeout and reset.
-   */
-  HSA_AMD_AIE_ERT_STATE_TIMEOUT = 8,
-  /**
-   * Set by the scheduler on a timeout and fail to reset.
-   */
-  HSA_AMD_AIE_ERT_STATE_NORESPONSE = 9,
-  HSA_AMD_AIE_ERT_STATE_SKERROR = 10,
-  HSA_AMD_AIE_ERT_STATE_SKCRASHED = 11,
-  HSA_AMD_AIE_ERT_STATE_MAX
-} hsa_amd_aie_ert_state;
-
-/**
- * Opcode types for HSA AIE ERT commands.
- */
-typedef enum {
-  /**
-   * Start a workgroup on a compute unit (CU).
-   */
-  HSA_AMD_AIE_ERT_START_CU = 0,
-  /**
-   * Currently aliased to HSA_AMD_AIE_ERT_START_CU.
-   */
-  HSA_AMD_AIE_ERT_START_KERNEL = 0,
-  /**
-   * Configure command scheduler.
-   */
-  HSA_AMD_AIE_ERT_CONFIGURE = 2,
-  HSA_AMD_AIE_ERT_EXIT = 3,
-  HSA_AMD_AIE_ERT_ABORT = 4,
-  /**
-   * Execute a specified CU after writing.
-   */
-  HSA_AMD_AIE_ERT_EXEC_WRITE = 5,
-  /**
-   * Get stats about a CU's execution.
-   */
-  HSA_AMD_AIE_ERT_CU_STAT = 6,
-  /**
-   * Start KDMA CU or P2P.
-   */
-  HSA_AMD_AIE_ERT_START_COPYBO = 7,
-  /**
-   * Configure a soft kernel.
-   */
-  HSA_AMD_AIE_ERT_SK_CONFIG = 8,
-  /**
-   * Start a soft kernel.
-   */
-  HSA_AMD_AIE_ERT_SK_START = 9,
-  /**
-   * Unconfigure a soft kernel.
-   */
-  HSA_AMD_AIE_ERT_SK_UNCONFIG = 10,
-  /**
-   * Initialize a CU.
-   */
-  HSA_AMD_AIE_ERT_INIT_CU = 11,
-  HSA_AMD_AIE_ERT_START_FA = 12,
-  HSA_AMD_AIE_ERT_CLK_CALIB = 13,
-  HSA_AMD_AIE_ERT_MB_VALIDATE = 14,
-  /**
-   * Same as HSA_AMD_AIE_ERT_START_CU but with a key-value pair.
-   */
-  HSA_AMD_AIE_ERT_START_KEY_VAL = 15,
-  HSA_AMD_AIE_ERT_ACCESS_TEST_C = 16,
-  HSA_AMD_AIE_ERT_ACCESS_TEST = 17,
-  /**
-   * Instruction buffer command format.
-   */
-  HSA_AMD_AIE_ERT_START_DPU = 18,
-  /**
-   * Command chain.
-   */
-  HSA_AMD_AIE_ERT_CMD_CHAIN = 19,
-  /**
-   * Instruction buffer command format on NPU.
-   */
-  HSA_AMD_AIE_ERT_START_NPU = 20,
-  /**
-   * Instruction buffer command with pre-emption format on the NPU.
-   */
-  HSA_AMD_AIE_ERT_START_NPU_PREEMPT = 21
-} hsa_amd_aie_ert_cmd_opcode_t;
-
-/**
- * Payload data for AIE ERT start kernel packets (i.e., when the opcode is
- * HSA_AMD_AIE_ERT_START_KERNEL).
- */
-typedef struct hsa_amd_aie_ert_start_kernel_data_s {
-  /**
-   * Address to the PDI.
-   */
-  void* pdi_addr;
-  /**
-   * Opcode, instructions and kernel arguments.
-   */
-  uint32_t data[];
-} hsa_amd_aie_ert_start_kernel_data_t;
-
-/**
- * AMD AIE ERT packet. Used for sending a command to an AIE agent.
- */
-typedef struct hsa_amd_aie_ert_packet_s {
-  /**
-   * AMD vendor specific packet header.
-   */
-  hsa_amd_vendor_packet_header_t header;
-  /**
-   * Format for packets interpreted by the ERT to understand the command and
-   * payload data.
-   */
-  struct {
-    /**
-     * Current state of a command.
-     */
-    uint32_t state : 4;
-    /**
-     * Flexible field that can be interpreted on a per-command basis.
-     */
-    uint32_t custom : 8;
-    /**
-     * Number of DWORDs in the payload data.
-     */
-    uint32_t count : 11;
-    /**
-     * Opcode identifying the command.
-     */
-    uint32_t opcode : 5;
-    /**
-     * Type of a command (currently 0).
-     */
-    uint32_t type : 4;
-  };
-  /**
-   * Reserved. Must be 0.
-   */
-  uint64_t reserved0;
-  /**
-   * Reserved. Must be 0.
-   */
-  uint64_t reserved1;
-  /**
-   * Reserved. Must be 0.
-   */
-  uint64_t reserved2;
-  /**
-   * Reserved. Must be 0.
-   */
-  uint64_t reserved3;
-  /**
-   * Reserved. Must be 0.
-   */
-  uint64_t reserved4;
-  /**
-   * Signal used to indicate completion of the command. When the command has
-   * finished, the runtime decrements the signal value. The application can use
-   * the special signal handle 0 to indicate that no completion signal is used.
-   */
-  hsa_signal_t completion_signal;
-  /**
-   * Address of packet data payload. ERT commands contain arbitrarily sized
-   * data payloads.
-   */
-  uint64_t payload_data;
-} hsa_amd_aie_ert_packet_t;
-
 /** @} */
 
 /** \defgroup error-codes Error codes
@@ -837,7 +635,7 @@ enum {
   HSA_STATUS_ERROR_NOT_SUPPORTED = 47,
 
   /**
-   * Xnack is disabled on this system, but required 
+   * Xnack is disabled on this system, but required
    * by the requested operation.
    */
   HSA_STATUS_ERROR_XNACK_DISABLED = 48,
@@ -3913,7 +3711,7 @@ hsa_status_t hsa_amd_svm_prefetch_async(void* ptr, size_t size, hsa_agent_t agen
  *
  * Only pointers allocated using ::hsa_amd_vmem_address_reserve can be discarded.
  *
- * 
+ *
  * @param[in] ptrs Array of @p count pointers to SVM memory ranges to discard.
  * Must not be NULL.
  *

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd_aie.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd_aie.h
@@ -1,46 +1,10 @@
-////////////////////////////////////////////////////////////////////////////////
-//
-// The University of Illinois/NCSA
-// Open Source License (NCSA)
-//
-// Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
-//
-// Developed by:
-//
-//                 AMD Research and AMD HSA Software Development
-//
-//                 Advanced Micro Devices, Inc.
-//
-//                 www.amd.com
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to
-// deal with the Software without restriction, including without limitation
-// the rights to use, copy, modify, merge, publish, distribute, sublicense,
-// and/or sell copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following conditions:
-//
-//  - Redistributions of source code must retain the above copyright notice,
-//    this list of conditions and the following disclaimers.
-//  - Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimers in
-//    the documentation and/or other materials provided with the distribution.
-//  - Neither the names of Advanced Micro Devices, Inc,
-//    nor the names of its contributors may be used to endorse or promote
-//    products derived from this Software without specific prior written
-//    permission.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-// THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-// DEALINGS WITH THE SOFTWARE.
-//
-////////////////////////////////////////////////////////////////////////////////
+/*
+ * Copyright © Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
 
-// HSA AMD extension.
+// HSA AMD extension for AIE agents.
 
 #ifndef HSA_RUNTIME_EXT_AMD_AIE_H_
 #define HSA_RUNTIME_EXT_AMD_AIE_H_

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd_aie.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd_aie.h
@@ -1,0 +1,184 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// The University of Illinois/NCSA
+// Open Source License (NCSA)
+//
+// Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Developed by:
+//
+//                 AMD Research and AMD HSA Software Development
+//
+//                 Advanced Micro Devices, Inc.
+//
+//                 www.amd.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal with the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+//  - Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimers.
+//  - Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimers in
+//    the documentation and/or other materials provided with the distribution.
+//  - Neither the names of Advanced Micro Devices, Inc,
+//    nor the names of its contributors may be used to endorse or promote
+//    products derived from this Software without specific prior written
+//    permission.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS WITH THE SOFTWARE.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// HSA AMD extension.
+
+#ifndef HSA_RUNTIME_EXT_AMD_AIE_H_
+#define HSA_RUNTIME_EXT_AMD_AIE_H_
+
+#include "hsa.h"
+
+/**
+ * - 1.0 - initial version
+ */
+#define HSA_AMD_AIE_INTERFACE_VERSION_MAJOR 1
+#define HSA_AMD_AIE_INTERFACE_VERSION_MINOR 0
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \addtogroup aql Architected Queuing Language
+ *  @{
+ */
+
+/**
+ * @brief HSA AIE packet type.
+ */
+typedef enum {
+  /**
+   * The packet is ready to be processed by the packet processor.
+   */
+  HSA_AMD_AIE_PACKET_TYPE_READY = 0,
+
+  /**
+   * The packet has been processed in the past, but has not been reassigned to
+   * the packet processor. A packet processor must not process a packet of this
+   * type.
+   */
+  HSA_AMD_AIE_PACKET_TYPE_INVALID = 1,
+} hsa_amd_aie_packet_type_t;
+
+/**
+ * @brief AMD AIE packet opcode.
+ */
+typedef enum {
+  /**
+   * AIE KMQ packet.
+   */
+  HSA_AMD_AIE_PACKET_OPCODE_KMQ = 0,
+} hsa_amd_aie_packet_opcode_t;
+
+/**
+ * @brief AMD AIE agent kernel dispatch packet.
+ */
+typedef struct hsa_amd_aie_kernel_dispatch_packet_s {
+  union {
+    struct {
+      /**
+       * Packet header. Used to configure multiple packet parameters such as the
+       * packet type. The parameters are described by ::hsa_packet_header_t.
+       */
+      uint16_t header;
+
+      /**
+       * Packet opcode. The parameters are described by ::hsa_amd_aie_packet_opcode_t.
+       */
+      uint16_t opcode;
+    };
+    uint32_t full_header;
+  };
+
+  /**
+   * Number of bytes in the packet after the completion signal in this packet. Must be 24.
+   */
+  uint16_t count;
+
+  /**
+   * Reserved. Must be 0.
+   */
+  uint8_t reserved0;
+
+  /**
+   * Reserved. Must be 0.
+   */
+  uint8_t reserved1;
+
+  /**
+   * Signal used to indicate completion of the job. The application can use the
+   * special signal handle 0 to indicate that no signal is used.​
+   */
+  hsa_signal_t completion_signal;
+
+  /**
+   * Reserved. Must be 0.
+   */
+  uint32_t reserved2;
+
+  /**
+   * Address of the instruction sequence.
+   */
+  uint32_t insts_addr_low;
+  uint32_t insts_addr_high;
+
+  /**
+   * Number of kernel arguments.
+   */
+  uint16_t num_kernargs;
+
+  /**
+   * Reserved. Must be 0.
+   */
+  uint16_t reserved3;
+
+  /**
+   * Pointer to a buffer containing the kernel arguments. May be NULL.
+   *
+   * The buffer must be allocated using ::hsa_memory_allocate, and must not be
+   * modified once the kernel dispatch packet is enqueued until the dispatch has
+   * completed execution.
+   */
+  void* kernarg_address;
+
+  /**
+   * Size of the instruction sequence in bytes.
+   */
+  uint64_t insts_size;
+
+  /**
+   * PDI address.
+   */
+  void* pdi_addr;
+
+  /**
+   * Reserved. Must be 0.
+   */
+  uint64_t reserved4;
+} hsa_amd_aie_kernel_dispatch_packet_t;
+
+/** @} */
+
+#ifdef __cplusplus
+}  // end extern "C" block
+#endif
+
+#endif  // header guard

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd_aie.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd_aie.h
@@ -109,7 +109,8 @@ typedef struct hsa_amd_aie_kernel_dispatch_packet_s {
   };
 
   /**
-   * Number of bytes in the packet after the completion signal in this packet. Must be 24.
+   * Number of bytes in the packet after the ::completion_signal and up to ::kernarg_address. Must
+   * be 24.
    */
   uint16_t count;
 
@@ -141,7 +142,8 @@ typedef struct hsa_amd_aie_kernel_dispatch_packet_s {
   uint32_t insts_addr_high;
 
   /**
-   * Number of kernel arguments.
+   * Number of kernel arguments. Must be 0 if ::kernarg_address is NULL, and must be greater than 0
+   * if ::kernarg_address is not NULL.
    */
   uint16_t num_kernargs;
 
@@ -151,11 +153,16 @@ typedef struct hsa_amd_aie_kernel_dispatch_packet_s {
   uint16_t reserved3;
 
   /**
-   * Pointer to a buffer containing the kernel arguments. May be NULL.
+   * Pointer to a buffer containing the kernel arguments. May be NULL only when num_kernargs is 0.
    *
    * The buffer must be allocated using ::hsa_memory_allocate, and must not be
    * modified once the kernel dispatch packet is enqueued until the dispatch has
    * completed execution.
+   *
+   * The buffer must contain exactly 2 * ::num_kernargs consecutive `uint64_t` entries:
+   * - entries [0 .. ::num_kernargs - 1] are the argument addresses
+   * - entries [::num_kernargs .. 2 * ::num_kernargs - 1] are the corresponding argument sizes in
+   * bytes
    */
   void* kernarg_address;
 


### PR DESCRIPTION
## Motivation

This PR changes the AIE queue packet format and fixes bugs in the command chain submission in `XdnaDriver`.

## Technical Details

This PR adopts the `host_queue_packet` packet format (https://github.com/amd/xdna-driver/blob/d12c5f0c95c570e631ad732cf11403e89958d5ce/src/shim/umq/host_queue.h#L248) for AIE queues.

For aie2/aie2p we still rely on KMQ, so an internal translation is still necessary to ioctls that submit `amdxdna_cmd` packets. For the UMQ supported by aie4, we'll be using the new packet format as-is.

The following changes were made:
1. The AIE AQL related structs were separated to their own header.
2. `XdnaDriver` and `AieAqlQueue` were modified to accept the new packet format and translate it to ioctls that submit `amdxdna_cmd` packets.
3. Driver interface was updated to the latest.

## JIRA ID

NA

## Test Plan

Dispatch tests where run from https://github.com/ROCm/rocm-systems/tree/users/ypapadop-amd/aie-tests/projects/rocr-runtime/rocrtst/suites/aie (not part of the official test harness yet).

Microbenchmarks where run from https://github.com/ROCm/rocm-systems/tree/users/ypapadop-amd/aie-tests/projects/rocr-runtime/rocrtst/suites/aie-performance

## Test Result

Successfully run all tests.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
