### PR TITLE
rocdecode: install test runner

### DIFF
--- a/.github/workflows/therock-media-test-packages.yml
+++ b/.github/workflows/therock-media-test-packages.yml
@@ -32,7 +32,7 @@ jobs:
           "job_name": "rocdecode",
           "fetch_artifact_args": "--rocdecode --tests",
           "timeout_minutes": 10,
-          "test_script": "python build_tools/github_actions/test_executable_scripts/test_rocdecode.py",
+          "test_script": "python ./build/share/rocdecode/test/run_rocdecode.py",
           "shard_arr": [1],
           "total_shards": 1,
           "test_type": "full",

--- a/projects/rocdecode/CMakeLists.txt
+++ b/projects/rocdecode/CMakeLists.txt
@@ -237,6 +237,7 @@ if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND AND Threads_FOUND)
   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_DOCDIR})
   # install test cmake
   install(FILES test/CMakeLists.txt DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/test)
+  install(PROGRAMS test/run_rocdecode.py DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/test)
   install(DIRECTORY test/testScripts DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/test)
   install(FILES test/rocDecodeNegativeApiTests/CMakeLists.txt test/rocDecodeNegativeApiTests/README.md test/rocDecodeNegativeApiTests/rocdecode_api_negative_tests.cpp test/rocDecodeNegativeApiTests/rocdecode_api_negative_tests.h test/rocDecodeNegativeApiTests/rocdecodenegativetest.cpp DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/test/rocDecodeNegativeApiTests)
 

--- a/projects/rocdecode/test/run_rocdecode.py
+++ b/projects/rocdecode/test/run_rocdecode.py
@@ -9,6 +9,7 @@ import re
 import shlex
 import subprocess
 from pathlib import Path
+from typing import Dict
 
 logging.basicConfig(level=logging.INFO)
 
@@ -17,17 +18,25 @@ def derive_rocm_path(script_dir: Path) -> Path:
     if script_dir.name == "test" and script_dir.parent.name == "rocdecode":
         if script_dir.parent.parent.name == "share":
             return script_dir.parent.parent.parent
-    rocm_path = os.getenv("ROCM_PATH")
-    if rocm_path:
-        return Path(rocm_path)
-    return script_dir.parent.parent.parent
+    raise RuntimeError(
+        "Could not derive ROCM_PATH from an installed rocdecode test layout. "
+        "Set ROCM_PATH explicitly."
+    )
 
 
-def setup_env(env: dict[str, str], rocm_path: Path) -> bool:
+def get_rocm_lib_dir(rocm_path: Path) -> Path:
+    for name in ("lib", "lib64"):
+        candidate = rocm_path / name
+        if candidate.is_dir():
+            return candidate
+    raise FileNotFoundError(f"Could not find ROCm library directory under {rocm_path}")
+
+
+def setup_env(env: Dict[str, str], rocm_path: Path) -> bool:
     env["ROCM_PATH"] = str(rocm_path)
     logging.info(f"++ rocdecode setting ROCM_PATH={rocm_path}")
     if platform.system() == "Linux":
-        hip_lib_path = rocm_path / "lib"
+        hip_lib_path = get_rocm_lib_dir(rocm_path)
         logging.info(f"++ rocdecode setting LD_LIBRARY_PATH={hip_lib_path}")
         if "LD_LIBRARY_PATH" in env:
             env["LD_LIBRARY_PATH"] = f"{hip_lib_path}:{env['LD_LIBRARY_PATH']}"
@@ -39,7 +48,7 @@ def setup_env(env: dict[str, str], rocm_path: Path) -> bool:
         return False
 
 
-def execute_tests(env: dict[str, str], test_source_dir: Path, build_dir: Path) -> None:
+def execute_tests(env: Dict[str, str], test_source_dir: Path, build_dir: Path) -> None:
     if not test_source_dir.is_dir():
         raise FileNotFoundError(f"rocdecode tests not found in {test_source_dir}")
 
@@ -91,11 +100,10 @@ def execute_tests(env: dict[str, str], test_source_dir: Path, build_dir: Path) -
 
 def main() -> None:
     script_dir = Path(__file__).resolve().parent
-    rocm_path = Path(
-        os.environ.get("ROCM_PATH", derive_rocm_path(script_dir))
-    ).resolve()
+    rocm_path_env = os.getenv("ROCM_PATH")
+    rocm_path = Path(rocm_path_env).resolve() if rocm_path_env else derive_rocm_path(script_dir)
     test_source_dir = rocm_path / "share" / "rocdecode" / "test"
-    build_dir = Path(os.environ.get("TEST_BUILD_DIR", Path.cwd() / "rocdecode-test"))
+    build_dir = Path(os.getenv("TEST_BUILD_DIR") or Path.cwd() / "rocdecode-test")
     build_dir = build_dir.resolve()
 
     env = os.environ.copy()

--- a/projects/rocdecode/test/run_rocdecode.py
+++ b/projects/rocdecode/test/run_rocdecode.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
@@ -7,7 +8,6 @@ import platform
 import re
 import shlex
 import subprocess
-import sys
 from pathlib import Path
 
 logging.basicConfig(level=logging.INFO)
@@ -23,7 +23,7 @@ def derive_rocm_path(script_dir: Path) -> Path:
     return script_dir.parent.parent.parent
 
 
-def setup_env(env: dict[str, str], rocm_path: Path) -> None:
+def setup_env(env: dict[str, str], rocm_path: Path) -> bool:
     env["ROCM_PATH"] = str(rocm_path)
     logging.info(f"++ rocdecode setting ROCM_PATH={rocm_path}")
     if platform.system() == "Linux":
@@ -33,9 +33,10 @@ def setup_env(env: dict[str, str], rocm_path: Path) -> None:
             env["LD_LIBRARY_PATH"] = f"{hip_lib_path}:{env['LD_LIBRARY_PATH']}"
         else:
             env["LD_LIBRARY_PATH"] = str(hip_lib_path)
+        return True
     else:
         logging.info("++ rocdecode tests only supported on Linux")
-        sys.exit(0)
+        return False
 
 
 def execute_tests(env: dict[str, str], test_source_dir: Path, build_dir: Path) -> None:
@@ -48,7 +49,7 @@ def execute_tests(env: dict[str, str], test_source_dir: Path, build_dir: Path) -
     # machine. This serves two purposes:
     # 1. Verifies that the installed rocdecode headers and libraries are functional.
     # 2. Some test dependencies (e.g. video codec libraries) are not bundled in the
-    #    TheRock artifacts and must be linked from the system at build time.
+    #    installed test payload and must be linked from the system at build time.
     cmd = [
         "cmake",
         "-GNinja",
@@ -98,7 +99,8 @@ def main() -> None:
     build_dir = build_dir.resolve()
 
     env = os.environ.copy()
-    setup_env(env, rocm_path)
+    if not setup_env(env, rocm_path):
+        return
     execute_tests(env, test_source_dir, build_dir)
 
 

--- a/projects/rocdecode/test/run_rocdecode.py
+++ b/projects/rocdecode/test/run_rocdecode.py
@@ -11,36 +11,23 @@ import sys
 from pathlib import Path
 
 logging.basicConfig(level=logging.INFO)
-THEROCK_BIN_DIR_STR = os.getenv("THEROCK_BIN_DIR")
-if THEROCK_BIN_DIR_STR is None:
-    logging.info(
-        "++ Error: env(THEROCK_BIN_DIR) is not set. Please set it before executing tests."
-    )
-    sys.exit(1)
-THEROCK_BIN_DIR = Path(THEROCK_BIN_DIR_STR)
-SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(
-    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
-).resolve()
-THEROCK_TEST_DIR = THEROCK_DIR / "build"
-
-ROCDECODE_TEST_PATH = str(
-    THEROCK_BIN_DIR.resolve().parent / "share" / "rocdecode" / "test"
-)
-if not os.path.isdir(ROCDECODE_TEST_PATH):
-    logging.info(f"++ Error: rocdecode tests not found in {ROCDECODE_TEST_PATH}")
-    sys.exit(1)
-else:
-    logging.info(f"++ INFO: rocdecode tests found in {ROCDECODE_TEST_PATH}")
-env = os.environ.copy()
 
 
-def setup_env(env):
-    ROCM_PATH = THEROCK_BIN_DIR.resolve().parent
-    env["ROCM_PATH"] = str(ROCM_PATH)
-    logging.info(f"++ rocdecode setting ROCM_PATH={ROCM_PATH}")
+def derive_rocm_path(script_dir: Path) -> Path:
+    if script_dir.name == "test" and script_dir.parent.name == "rocdecode":
+        if script_dir.parent.parent.name == "share":
+            return script_dir.parent.parent.parent
+    rocm_path = os.getenv("ROCM_PATH")
+    if rocm_path:
+        return Path(rocm_path)
+    return script_dir.parent.parent.parent
+
+
+def setup_env(env: dict[str, str], rocm_path: Path) -> None:
+    env["ROCM_PATH"] = str(rocm_path)
+    logging.info(f"++ rocdecode setting ROCM_PATH={rocm_path}")
     if platform.system() == "Linux":
-        hip_lib_path = THEROCK_BIN_DIR.resolve().parent / "lib"
+        hip_lib_path = rocm_path / "lib"
         logging.info(f"++ rocdecode setting LD_LIBRARY_PATH={hip_lib_path}")
         if "LD_LIBRARY_PATH" in env:
             env["LD_LIBRARY_PATH"] = f"{hip_lib_path}:{env['LD_LIBRARY_PATH']}"
@@ -51,10 +38,11 @@ def setup_env(env):
         sys.exit(0)
 
 
-def execute_tests(env):
-    rocdecode_test_dir = THEROCK_TEST_DIR / "rocdecode-test"
+def execute_tests(env: dict[str, str], test_source_dir: Path, build_dir: Path) -> None:
+    if not test_source_dir.is_dir():
+        raise FileNotFoundError(f"rocdecode tests not found in {test_source_dir}")
 
-    rocdecode_test_dir.mkdir(parents=True, exist_ok=True)
+    build_dir.mkdir(parents=True, exist_ok=True)
 
     # rocdecode tests are shipped as CMake source and must be built on the target
     # machine. This serves two purposes:
@@ -64,19 +52,19 @@ def execute_tests(env):
     cmd = [
         "cmake",
         "-GNinja",
-        ROCDECODE_TEST_PATH,
+        str(test_source_dir),
     ]
-    logging.info(f"++ Exec [{rocdecode_test_dir}]$ {shlex.join(cmd)}")
-    subprocess.run(cmd, cwd=rocdecode_test_dir, check=True, env=env)
+    logging.info(f"++ Exec [{build_dir}]$ {shlex.join(cmd)}")
+    subprocess.run(cmd, cwd=build_dir, check=True, env=env)
 
     cmd = [
         "ctest",
         "-N",
     ]
-    logging.info(f"++ Exec [{rocdecode_test_dir}]$ {shlex.join(cmd)}")
+    logging.info(f"++ Exec [{build_dir}]$ {shlex.join(cmd)}")
     ctest_list = subprocess.run(
         cmd,
-        cwd=rocdecode_test_dir,
+        cwd=build_dir,
         check=True,
         env=env,
         capture_output=True,
@@ -96,10 +84,23 @@ def execute_tests(env):
         "--extra-verbose",
         "--output-on-failure",
     ]
-    logging.info(f"++ Exec [{rocdecode_test_dir}]$ {shlex.join(cmd)}")
-    subprocess.run(cmd, cwd=rocdecode_test_dir, check=True, env=env)
+    logging.info(f"++ Exec [{build_dir}]$ {shlex.join(cmd)}")
+    subprocess.run(cmd, cwd=build_dir, check=True, env=env)
+
+
+def main() -> None:
+    script_dir = Path(__file__).resolve().parent
+    rocm_path = Path(
+        os.environ.get("ROCM_PATH", derive_rocm_path(script_dir))
+    ).resolve()
+    test_source_dir = rocm_path / "share" / "rocdecode" / "test"
+    build_dir = Path(os.environ.get("TEST_BUILD_DIR", Path.cwd() / "rocdecode-test"))
+    build_dir = build_dir.resolve()
+
+    env = os.environ.copy()
+    setup_env(env, rocm_path)
+    execute_tests(env, test_source_dir, build_dir)
 
 
 if __name__ == "__main__":
-    setup_env(env)
-    execute_tests(env)
+    main()

--- a/projects/rocdecode/test/run_rocdecode.py
+++ b/projects/rocdecode/test/run_rocdecode.py
@@ -2,6 +2,14 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
+"""Build and run the rocdecode project's installed test suite.
+
+This runner is installed with the rocdecode test source payload. It configures
+and builds those installed tests on the target machine, then executes the
+generated CTest suite.
+"""
+
+import argparse
 import logging
 import os
 import platform
@@ -13,9 +21,34 @@ from typing import Dict
 
 logging.basicConfig(level=logging.INFO)
 
+PROJECT_NAME = "rocdecode"
+
+HELP_EPILOG = f"""\
+This script runs the {PROJECT_NAME} project test suite from an installed ROCm
+payload. When run from an installed location, it discovers:
+
+  <rocm-prefix>/share/{PROJECT_NAME}/test
+
+The installed tests are CMake source files, so the runner configures and builds
+them before invoking CTest.
+
+Environment variables:
+  ROCM_PATH          ROCm install prefix override.
+  TEST_BUILD_DIR     Build directory for the installed test source.
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=f"Build and run the {PROJECT_NAME} project test suite.",
+        epilog=HELP_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    return parser.parse_args()
+
 
 def derive_rocm_path(script_dir: Path) -> Path:
-    if script_dir.name == "test" and script_dir.parent.name == "rocdecode":
+    if script_dir.name == "test" and script_dir.parent.name == PROJECT_NAME:
         if script_dir.parent.parent.name == "share":
             return script_dir.parent.parent.parent
     raise RuntimeError(
@@ -99,10 +132,11 @@ def execute_tests(env: Dict[str, str], test_source_dir: Path, build_dir: Path) -
 
 
 def main() -> None:
+    parse_args()
     script_dir = Path(__file__).resolve().parent
     rocm_path_env = os.getenv("ROCM_PATH")
     rocm_path = Path(rocm_path_env).resolve() if rocm_path_env else derive_rocm_path(script_dir)
-    test_source_dir = rocm_path / "share" / "rocdecode" / "test"
+    test_source_dir = rocm_path / "share" / PROJECT_NAME / "test"
     build_dir = Path(os.getenv("TEST_BUILD_DIR") or Path.cwd() / "rocdecode-test")
     build_dir = build_dir.resolve()
 


### PR DESCRIPTION
Installs a rocdecode-owned Python test runner alongside the rocdecode test payload.

This is motivated by TheRock/RFC0010 test-artifact packaging. TheRock needs to package and execute test runners from built artifacts, but instead of adding superproject-side script injection, this puts the runner in the owning project so it is available from standalone rocdecode install layouts too.

The runner configures and runs the installed rocdecode CTest payload from a caller-provided or temporary build directory.

Changes:
- add the runner at `projects/rocdecode/test/run_rocdecode.py`
- install the runner to `share/rocdecode/test`
- remove the old copied `test/therock/test_rocdecode.py` script
- derive ROCm paths from `ROCM_PATH` or the installed script location instead of requiring `THEROCK_*` variables

Validation run:
- `python -m py_compile projects/rocdecode/test/run_rocdecode.py`
- `git diff --check origin/develop...HEAD`

Not run:
- full rocdecode test build/execution on a GPU runner
- CMake configure/install packaging check