### PR TITLE
rccl-tests: install test runner

### DIFF
--- a/projects/rccl-tests/CMakeLists.txt
+++ b/projects/rccl-tests/CMakeLists.txt
@@ -45,6 +45,7 @@ set(DEFAULT_GPUS
 # Get additional packages required
 include(CheckIncludeFiles)
 include(CheckSymbolExists)
+include(GNUInstallDirs)
 include(cmake/Dependencies.cmake) # rocm-cmake, rocm_local_targets
 include(cmake/CheckSymbolExistsNoWarn.cmake)
 
@@ -205,6 +206,11 @@ set(ROCM_USE_DEV_COMPONENT OFF)  # This repo doesn't have a dev component
 
 # Add all of the tests
 add_subdirectory(src)
+
+rocm_install(
+    PROGRAMS test/run_rccl_tests.py
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/rccl-tests/tests
+    COMPONENT tests)
 
 rocm_setup_version(VERSION "2.14.1")
 

--- a/projects/rccl-tests/test/run_rccl_tests.py
+++ b/projects/rccl-tests/test/run_rccl_tests.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Run the rccl-tests project's installed performance test suite.
+
+This runner is installed with rccl-tests and executes the installed collective
+performance binaries shipped by that project.
+"""
 
 import argparse
 import logging
@@ -28,6 +33,14 @@ TEST_EXECUTABLES = [
 
 logging.basicConfig(level=logging.INFO)
 
+HELP_EPILOG = f"""\
+This script runs the {PROJECT_NAME} project test suite from an installed ROCm
+payload. When run from an installed location, it discovers binaries such as:
+
+  <rocm-prefix>/bin/all_reduce_perf[.exe]
+  <rocm-prefix>/bin/broadcast_perf[.exe]
+"""
+
 
 def path_from_env(name: str) -> Optional[Path]:
     value = os.getenv(name)
@@ -37,12 +50,19 @@ def path_from_env(name: str) -> Optional[Path]:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run installed rccl-tests binaries.")
+    parser = argparse.ArgumentParser(
+        description=f"Run the {PROJECT_NAME} project performance test suite.",
+        epilog=HELP_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument(
         "--rocm-path",
         type=Path,
         default=path_from_env("ROCM_PATH"),
-        help="ROCm install prefix. Defaults to ROCM_PATH or the runner location.",
+        help=(
+            "ROCm install prefix used by the rccl-tests binaries. Defaults to "
+            "ROCM_PATH or the installed runner location."
+        ),
     )
     parser.add_argument(
         "--bin-dir",

--- a/projects/rccl-tests/test/run_rccl_tests.py
+++ b/projects/rccl-tests/test/run_rccl_tests.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
@@ -59,7 +60,7 @@ def get_rocm_path(script_path: Path, rocm_path: Path | None) -> Path:
     ):
         return script_path.parents[3].resolve()
 
-    raise SystemExit("ROCM_PATH is required when the runner is not installed.")
+    raise RuntimeError("ROCM_PATH is required when the runner is not installed.")
 
 
 def resolve_executable(bin_dir: Path, name: str) -> Path:
@@ -68,7 +69,7 @@ def resolve_executable(bin_dir: Path, name: str) -> Path:
         candidate = bin_dir / f"{name}{suffix}"
         if candidate.exists():
             return candidate.resolve()
-    raise SystemExit(f"{name} was not found in {bin_dir}")
+    raise FileNotFoundError(f"{name} was not found in {bin_dir}")
 
 
 def run_rccl_tests(bin_dir: Path, work_dir: Path) -> None:

--- a/projects/rccl-tests/test/run_rccl_tests.py
+++ b/projects/rccl-tests/test/run_rccl_tests.py
@@ -1,0 +1,94 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import argparse
+import logging
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+PROJECT_NAME = "rccl-tests"
+
+TEST_EXECUTABLES = [
+    "all_gather_perf",
+    "alltoallv_perf",
+    "broadcast_perf",
+    "alltoall_perf",
+    "all_reduce_perf",
+    "reduce_perf",
+    "hypercube_perf",
+    "gather_perf",
+    "scatter_perf",
+    "sendrecv_perf",
+    "reduce_scatter_perf",
+]
+
+logging.basicConfig(level=logging.INFO)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run installed rccl-tests binaries.")
+    parser.add_argument(
+        "--rocm-path",
+        type=Path,
+        default=os.getenv("ROCM_PATH"),
+        help="ROCm install prefix. Defaults to ROCM_PATH or the runner location.",
+    )
+    parser.add_argument(
+        "--bin-dir",
+        type=Path,
+        help="Directory containing rccl-tests binaries. Defaults to <rocm-path>/bin.",
+    )
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        help="Working directory for test execution. Defaults to <rocm-path>.",
+    )
+    return parser.parse_args()
+
+
+def get_rocm_path(script_path: Path, rocm_path: Path | None) -> Path:
+    if rocm_path is not None:
+        return rocm_path.resolve()
+
+    # Installed at <prefix>/share/rccl-tests/tests.
+    if (
+        script_path.parent.name == "tests"
+        and script_path.parents[1].name == PROJECT_NAME
+    ):
+        return script_path.parents[3].resolve()
+
+    raise SystemExit("ROCM_PATH is required when the runner is not installed.")
+
+
+def resolve_executable(bin_dir: Path, name: str) -> Path:
+    suffixes = [".exe", ""] if os.name == "nt" else ["", ".exe"]
+    for suffix in suffixes:
+        candidate = bin_dir / f"{name}{suffix}"
+        if candidate.exists():
+            return candidate.resolve()
+    raise SystemExit(f"{name} was not found in {bin_dir}")
+
+
+def run_rccl_tests(bin_dir: Path, work_dir: Path) -> None:
+    for executable in TEST_EXECUTABLES:
+        cmd = [str(resolve_executable(bin_dir, executable))]
+        logging.info("++ Exec [%s]$ %s", work_dir, shlex.join(cmd))
+        subprocess.run(cmd, cwd=work_dir, check=True)
+
+
+def main() -> None:
+    args = parse_args()
+    script_path = Path(__file__).resolve()
+    rocm_path = get_rocm_path(script_path, args.rocm_path)
+    bin_dir = args.bin_dir.resolve() if args.bin_dir is not None else rocm_path / "bin"
+    work_dir = (
+        args.work_dir.resolve() if args.work_dir is not None else rocm_path
+    )
+
+    run_rccl_tests(bin_dir, work_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/rccl-tests/test/run_rccl_tests.py
+++ b/projects/rccl-tests/test/run_rccl_tests.py
@@ -8,6 +8,7 @@ import os
 import shlex
 import subprocess
 from pathlib import Path
+from typing import Optional
 
 PROJECT_NAME = "rccl-tests"
 
@@ -28,12 +29,19 @@ TEST_EXECUTABLES = [
 logging.basicConfig(level=logging.INFO)
 
 
+def path_from_env(name: str) -> Optional[Path]:
+    value = os.getenv(name)
+    if not value:
+        return None
+    return Path(value)
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run installed rccl-tests binaries.")
     parser.add_argument(
         "--rocm-path",
         type=Path,
-        default=os.getenv("ROCM_PATH"),
+        default=path_from_env("ROCM_PATH"),
         help="ROCm install prefix. Defaults to ROCM_PATH or the runner location.",
     )
     parser.add_argument(
@@ -49,7 +57,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def get_rocm_path(script_path: Path, rocm_path: Path | None) -> Path:
+def get_rocm_path(script_path: Path, rocm_path: Optional[Path]) -> Path:
     if rocm_path is not None:
         return rocm_path.resolve()
 
@@ -57,6 +65,7 @@ def get_rocm_path(script_path: Path, rocm_path: Path | None) -> Path:
     if (
         script_path.parent.name == "tests"
         and script_path.parents[1].name == PROJECT_NAME
+        and script_path.parents[2].name == "share"
     ):
         return script_path.parents[3].resolve()
 


### PR DESCRIPTION
Installs a rccl-tests-owned Python test runner alongside the rccl-tests test payload.

This is motivated by TheRock/RFC0010 test-artifact packaging. TheRock needs to package and execute test runners from built artifacts, but instead of adding superproject-side script injection, this puts the runner in the owning project so it is available from standalone rccl-tests install layouts too.

This complements the rccl runner split by putting the rccl-tests perf/correctness executables under rccl-tests ownership.

Changes:
- add the runner at `projects/rccl-tests/test/run_rccl_tests.py`
- install the runner to `share/rccl-tests/tests`
- keep `test/therock/test_rccl.py` removal scoped to the companion rccl PR
- derive ROCm paths from `ROCM_PATH` or the installed script location instead of requiring `THEROCK_*` variables

Validation run:
- `python -m py_compile projects/rccl-tests/test/run_rccl_tests.py`
- `git diff --check origin/develop...HEAD`

Not run:
- full rccl-tests perf/correctness execution on a multi-GPU runner
- CMake configure/install packaging check