### PR TITLE
[CLR] Always defer DigestFatBinary in StatCO::Add{Fat,Kpack}Binary

### DIFF
--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -300,14 +300,8 @@ FatBinaryInfo** StatCO::AddFatBinary(const void* data, bool& success) {
   std::scoped_lock lock(sclock_);
   module_to_hostModule_.insert(std::make_pair(&modules_[data], data));
 
-  if (!owner_.IsInitialized()) {
-    success = true;
-    return &modules_[data];
-  }
-
-  hipError_t err = DigestFatBinary(data, modules_[data]);
-
-  success = (err == hipSuccess);
+  // Defer loading: modules_[data] is nullptr, DigestFatBinary will handle it later
+  success = true;
   return &modules_[data];
 }
 
@@ -319,15 +313,8 @@ FatBinaryInfo** StatCO::AddKpackBinary(const void* hipk_metadata, const void* wr
   // This allows DigestFatBinary to access the wrapper and detect HIPK magic
   module_to_hostModule_.insert(std::make_pair(&modules_[wrapper_addr], wrapper_addr));
 
-  if (!owner_.IsInitialized()) {
-    // Deferred loading: modules_[wrapper_addr] is nullptr, DigestFatBinary will handle it later
-    success = true;
-    return &modules_[wrapper_addr];
-  }
-
-  // Immediate loading: call DigestFatBinary which handles kpack detection
-  hipError_t err = DigestFatBinary(wrapper_addr, modules_[wrapper_addr]);
-  success = (err == hipSuccess);
+  // Defer loading: modules_[wrapper_addr] is nullptr, DigestFatBinary will handle it later
+  success = true;
   return &modules_[wrapper_addr];
 }
 


### PR DESCRIPTION
## Motivation

Follow-up to https://github.com/ROCm/rocm-systems/issues/5767. `dlopen("librccl.so")` blocks for many seconds when `hipInit()` has been called first in the process (~30 ms otherwise). Root-caused to `StatCO::AddFatBinary` and `StatCO::AddKpackBinary` synchronously call `DigestFatBinary` when `PlatformState::IsInitialized()` is true, doing the full per-device ELF parse from inside a global constructor.

## Technical Details

The `!owner_.IsInitialized()` branch already exists in both functions and is correct: lazy callers (`StatCO::GetFunc`, `GetFuncAttr`, `GetGlobalVar`, `InitManagedVarDevicePtr`) detect `*module == nullptr` and run `DigestFatBinary` on first use. This change takes that branch unconditionally so the heavy work runs lazily regardless of whether `hipInit()` has happened first. For workloads that don't call into the library, the cost is fully eliminated; for workloads that do, the cost moves to first kernel launch and total wall-clock is unchanged.

## JIRA ID

https://github.com/ROCm/rocm-systems/issues/5767

## Test Plan

I wasn't able to find existing tests that exercise `AddKpackBinary` (no kpack-aware hip-tests in the suite). `AddFatBinary` is hit by every hip-tests `Unit_hipModule*` case. Suggestions welcome on how to cover the kpack path.

## Test Result
```
ctest --test-dir TheRock/build/core/hip-tests/build -R "hipModule"
```
54 tests passed, 4 skipped:
```
        2375 - Unit_hipModuleGetTexRef_Positive_Basic (Skipped)
        2376 - Unit_hipModuleGetTexRef_Negative_Parameters (Skipped)
        2377 - Unit_hipModuleGetTexRef_Negative_Hmod_Is_Nullptr (Skipped)
        2378 - Unit_hipModuleGetTexRef_Negative_Name_Is_Empty_String (Skipped)
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
