### PR TITLE
ROCM-23631 - Fix HIP graph segfault when segment scheduling falls back to classic

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -241,6 +241,25 @@ void Graph::ScheduleOneNode(Node start, int stream_id) {
 }
 
 // ================================================================================================
+void Graph::DisableSegmentSchedulingRecursive() {
+  segments_.clear();
+  node_to_segment_id_.clear();
+  segments_per_level_.clear();
+  max_dependency_level_ = -1;
+  use_segment_scheduling_ = false;
+
+  for (auto node : vertices_) {
+    node->segment_id_ = -1;
+    if (node->GetType() == hipGraphNodeTypeGraph) {
+      auto child = reinterpret_cast<hip::ChildGraphNode*>(node)->GetChildGraph();
+      if (child != nullptr) {
+        child->DisableSegmentSchedulingRecursive();
+      }
+    }
+  }
+}
+
+// ================================================================================================
 hipError_t Graph::ScheduleNodes() {
   if (use_segment_scheduling_) {
     // Segment packet scheduling logic
@@ -251,13 +270,10 @@ hipError_t Graph::ScheduleNodes() {
     if (result == hipErrorNotReady) {
       ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_CODE,
               "[hipGraph] Falling back to classic scheduling for complex graph");
-      // Clear any partial segment data that might have been created
-      segments_.clear();
-      node_to_segment_id_.clear();
-      segments_per_level_.clear();
-      max_dependency_level_ = -1;
-      // Disable segment scheduling for this graph permanently
-      use_segment_scheduling_ = false;
+      // Clear segment state on this graph and all descendant child graphs
+      // so that classic ScheduleOneNode -> child->ScheduleNodes() assigns
+      // stream_id_ to every node at all nesting levels.
+      DisableSegmentSchedulingRecursive();
 
       // Continue to classic scheduling logic below
     } else {

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -276,7 +276,12 @@ class GraphNode : public hipGraphNodeDOTAttribute {
   void SetStream(
       const std::vector<hip::Stream*>& streams  //!< A pool of streams to use in graph's execution
   ) {
-    assert(stream_id_ != -1 && "Stream ID wasn't initialized");
+    assert(stream_id_ >= 0 &&
+           static_cast<size_t>(stream_id_) < streams.size() &&
+           "Stream ID wasn't initialized or is out of bounds");
+    if (stream_id_ < 0 || static_cast<size_t>(stream_id_) >= streams.size()) {
+      stream_id_ = 0;
+    }
     stream_ = streams[stream_id_];
     // Reset the launch ID after the stream assignment
     launch_id_ = -1;
@@ -637,6 +642,10 @@ class Graph {
   bool IsSegmentSchedulingEnabled() const { return use_segment_scheduling_; }
   // Enable or disable segment scheduling for this graph
   void SetSegmentScheduling(bool segmentScheduling) {use_segment_scheduling_ = segmentScheduling;}
+  /// Recursively clears segment scheduling state on this graph and all
+  /// descendant child graphs, so that classic scheduling can assign
+  /// stream_id_ to every node.
+  void DisableSegmentSchedulingRecursive();
   // returns the original graph ptr if cloned
   const Graph* getOriginalGraph() const { return pOriginalGraph_; }
   // Add user obj resource to graph


### PR DESCRIPTION
## Motivation

When a parent graph falls back from segment to classic scheduling
(triggered by the complexity threshold in ScheduleNodesIntoBatches),
child graphs retained use_segment_scheduling_=true. The child's
ScheduleNodes() then used segment scheduling, which does not assign
stream_id_ to nodes. At launch time, the parent's classic execution
path (RunNodes -> RunOneNode -> SetStream(streams_)) indexed into the
streams vector with stream_id_=-1, causing an OOB read and segfault
at hipGraphLaunch.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Changes:
- Propagate scheduling fallback to child graphs by clearing their
  segment state and setting use_segment_scheduling_=false when the
  parent falls back
- Harden SetStream with a bounds check that falls back to stream 0
  in release builds, while keeping a debug assert for development
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
ROCM-23631
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
