### PR TITLE
Add runtime GPU spec discovery for PerfXpert

### DIFF
--- a/experimental/python/perfxpert/docs/guides/getting-started.md
+++ b/experimental/python/perfxpert/docs/guides/getting-started.md
@@ -379,10 +379,23 @@ New in Phase 8 (Confluence roadmap row #29). A single guided wizard
 that chains the four things every new user asks about into one flow
 so you don't have to discover them separately:
 
-1. **GPU detection** — `rocm-smi --showproductname --showmeminfo vram
-   --json` (fallback: `rocminfo`; manual `--arch gfx942` when neither
-   is available), looked up against the architecture catalog in
-   `perfxpert/knowledge/gpu_specs.yaml`.
+1. **GPU detection** — runtime discovery runs `rocminfo`, `rocm-smi`,
+   and `amd-smi` when they are present, with read-only KFD topology as a
+   fallback for ROCm environments where `rocminfo` cannot open the
+   device node. Local GPU facts such as gfx id, CU count, clocks, wave
+   size, LDS size, VRAM, PCIe, and power limits are used first.
+   Theoretical peak FLOPS are derived for newly discovered local
+   architectures when enough topology is available;
+   `perfxpert/knowledge/gpu_specs.yaml` remains the offline fallback for
+   non-local architectures and for fields a ROCm tool does not expose on
+   that stack.
+   Runtime discovery is scoped to the machine where the command runs. If
+   an agent is optimizing a workload over SSH, run the ROCm discovery
+   commands on that remote target host or run PerfXpert on the remote host
+   itself; do not use the controller machine's local GPU facts for remote
+   roofline or SoL analysis. If local runtime specs would describe the
+   wrong machine, set `PERFXPERT_DISABLE_RUNTIME_GPU_SPECS=1` and pass
+   explicit remote facts / `--arch`.
 2. **Framework detection** — Tier-0 source scan (same scanner as
    `analyze --source-dir`, same `.git` / `node_modules` filters) plus a
    Python import probe for `torch`, `tensorflow`, `jax`, `cupy`.
@@ -569,7 +582,8 @@ ceilings per dtype — FP32 / FP16 / BF16 / FP8 / INT8 — are overlaid
 with the dominant dtype at full opacity and others dimmed. The HBM
 bandwidth diagonal (slope 1 in log-log space) and the ridge-point
 annotation (`gfx942 · 163 TF/s · 5.3 TB/s · ridge @ 30.8 FLOPs/B`) are
-drawn from `perfxpert/knowledge/gpu_specs.yaml`.
+drawn from runtime GPU discovery when the profiled GPU is local, with
+`perfxpert/knowledge/gpu_specs.yaml` as the offline fallback.
 
 Click any dot to jump straight to the matching recommendation card
 (`id="rec-<kernel_basename>"`) — same anchor convention as the ATT

--- a/experimental/python/perfxpert/docs/guides/getting-started.md
+++ b/experimental/python/perfxpert/docs/guides/getting-started.md
@@ -382,8 +382,8 @@ so you don't have to discover them separately:
 1. **GPU detection** — runtime discovery runs `rocminfo`, `rocm-smi`,
    and `amd-smi` when they are present, with read-only KFD topology as a
    fallback for ROCm environments where `rocminfo` cannot open the
-   device node. Local GPU facts such as gfx id, CU count, clocks, wave
-   size, LDS size, VRAM, PCIe, and power limits are used first.
+   device node. The local init wizard uses GPU facts such as gfx id, CU
+   count, clocks, wave size, LDS size, VRAM, PCIe, and power limits.
    Theoretical peak FLOPS are derived for newly discovered local
    architectures when enough topology is available;
    `perfxpert/knowledge/gpu_specs.yaml` remains the offline fallback for
@@ -582,8 +582,9 @@ ceilings per dtype — FP32 / FP16 / BF16 / FP8 / INT8 — are overlaid
 with the dominant dtype at full opacity and others dimmed. The HBM
 bandwidth diagonal (slope 1 in log-log space) and the ridge-point
 annotation (`gfx942 · 163 TF/s · 5.3 TB/s · ridge @ 30.8 FLOPs/B`) are
-drawn from runtime GPU discovery when the profiled GPU is local, with
-`perfxpert/knowledge/gpu_specs.yaml` as the offline fallback.
+drawn from `perfxpert/knowledge/gpu_specs.yaml`. Runtime discovery is
+used for local-only GPU initialization and for runtime-only local
+architectures that are not yet present in the static catalog.
 
 Click any dot to jump straight to the matching recommendation card
 (`id="rec-<kernel_basename>"`) — same anchor convention as the ATT

--- a/experimental/python/perfxpert/perfxpert/_bundled/opencode_config/AGENTS.md
+++ b/experimental/python/perfxpert/perfxpert/_bundled/opencode_config/AGENTS.md
@@ -25,6 +25,14 @@ MCP server (stdio, command `perfxpert-mcp`).
    - Do NOT call `bash`/`edit`/`read`/`glob`/`grep` BEFORE those two.
    - SSH or another remote host changes only WHERE native build/profile
      commands run. It never bypasses the PerfXpert MCP gate.
+   - If the workload target is an SSH remote host, GPU discovery must
+     describe that remote execution host, not the local controller. After
+     the gate lifts, run `rocminfo`, `rocm-smi`, and `amd-smi` on the
+     remote host through native SSH, or run PerfXpert on the remote host
+     itself. Do not let local runtime GPU specs override remote-target
+     analysis; use explicit remote facts / `--arch` and set
+     `PERFXPERT_DISABLE_RUNTIME_GPU_SPECS=1` when the controller GPU is
+     not the target GPU.
    - If `perfxpert_intent_classify` or `perfxpert_workflow_next_step`
      is unavailable / not exposed in the backend session, STOP with a
      PerfXpert configuration error. Do NOT use a native SSH/build/profile

--- a/experimental/python/perfxpert/perfxpert/analysis/pmc.py
+++ b/experimental/python/perfxpert/perfxpert/analysis/pmc.py
@@ -29,6 +29,13 @@ and collection-context constants.
 
 from typing import Any, Dict, List
 
+from perfxpert.tools._pmc_limits import (
+    PMC_BLOCK_LIMIT_DEFAULT,
+    default_block_limits,
+    pmc_block,
+    pmc_block_limit,
+)
+
 # ---------------------------------------------------------------------------
 # Collection-context detection
 # ---------------------------------------------------------------------------
@@ -49,9 +56,7 @@ _SYS_TRACE_IMPLIED: frozenset = frozenset(
 )
 
 # Args that only specify output location -- not considered "new data collection"
-_OUTPUT_ONLY_ARGS: frozenset = frozenset(
-    {"-d", "-o", "--output-directory", "--output-file"}
-)
+_OUTPUT_ONLY_ARGS: frozenset = frozenset({"-d", "-o", "--output-directory", "--output-file"})
 
 # Hardware counter collection limits for rocprofv3 --pmc.
 #
@@ -77,15 +82,8 @@ _OUTPUT_ONLY_ARGS: frozenset = frozenset(
 # Actual limits vary by GPU generation (MI100/MI200/MI300X) and block type.
 # The values below are conservative safe defaults; some blocks (e.g. SQ on
 # gfx942/MI300X) support up to 8 counters per pass in practice.
-_PMC_BLOCK_LIMIT_DEFAULT: int = 4
-_PMC_BLOCK_LIMITS: Dict[str, int] = {
-    "SQ": 4,  # shader/wave; gfx942 supports up to 8 -- use 4 as safe default
-    "GRBM": 4,  # GPU register bus manager
-    "TCP": 4,  # L1 vector cache
-    "TCC": 4,  # L2 cache
-    "TA": 4,  # texture addressing
-    "TD": 4,  # texture data
-}
+_PMC_BLOCK_LIMIT_DEFAULT: int = PMC_BLOCK_LIMIT_DEFAULT
+_PMC_BLOCK_LIMITS: Dict[str, int] = default_block_limits()
 
 # FETCH_SIZE and WRITE_SIZE are derived metrics that each expand to multiple TCC
 # hardware counters (FETCH_SIZE -> 3 counters, WRITE_SIZE -> 2 counters; combined 5
@@ -96,12 +94,12 @@ _TCC_DERIVED_COUNTERS: frozenset = frozenset({"FETCH_SIZE", "WRITE_SIZE"})
 
 def _pmc_block(counter: str) -> str:
     """Return the hardware block name for a counter (prefix before first '_')."""
-    return counter.split("_")[0]
+    return pmc_block(counter)
 
 
-def _pmc_block_limit(block: str) -> int:
+def _pmc_block_limit(block: str, gpu_arch: str = "") -> int:
     """Return the per-pass counter limit for the given hardware block."""
-    return _PMC_BLOCK_LIMITS.get(block, _PMC_BLOCK_LIMIT_DEFAULT)
+    return pmc_block_limit(block, gpu_arch)
 
 
 def _split_pmc_into_passes(
@@ -112,6 +110,7 @@ def _split_pmc_into_passes(
     output_prefix: str,
     description: str,
     app_placeholder: str = "./app",
+    gpu_arch: str = "",
 ) -> List[Dict[str, Any]]:
     """
     Split a counter list into the minimum number of rocprofv3 commands so that
@@ -151,6 +150,7 @@ def _split_pmc_into_passes(
                     output_prefix,
                     description,
                     app_placeholder,
+                    gpu_arch,
                 )
             )
         for dc in derived:
@@ -179,17 +179,14 @@ def _split_pmc_into_passes(
         if n > 1:
             for idx, cmd in enumerate(all_cmds):
                 out_name = f"{output_prefix}_pass{idx + 1}"
-                pmc_val = next(
-                    (a["value"] for a in cmd["args"] if a["name"] == "--pmc"), ""
-                )
+                pmc_val = next((a["value"] for a in cmd["args"] if a["name"] == "--pmc"), "")
                 flags_str = " ".join(base_flags)
                 cmd["description"] = f"{description} (pass {idx + 1}/{n})"
                 for arg in cmd["args"]:
                     if arg["name"] == "-o":
                         arg["value"] = out_name
                 cmd["full_command"] = (
-                    f"rocprofv3 {flags_str} --pmc {pmc_val}"
-                    f" -d {output_dir} -o {out_name} -- {app_placeholder}"
+                    f"rocprofv3 {flags_str} --pmc {pmc_val}" f" -d {output_dir} -o {out_name} -- {app_placeholder}"
                 ).strip()
         return all_cmds
 
@@ -202,13 +199,13 @@ def _split_pmc_into_passes(
         return []
 
     n_passes = max(
-        (len(cs) + _pmc_block_limit(blk) - 1) // max(_pmc_block_limit(blk), 1)
+        (len(cs) + _pmc_block_limit(blk, gpu_arch) - 1) // max(_pmc_block_limit(blk, gpu_arch), 1)
         for blk, cs in block_groups.items()
     )
 
     pass_counters: List[List[str]] = [[] for _ in range(n_passes)]
     for blk, cs in block_groups.items():
-        limit = _pmc_block_limit(blk)
+        limit = _pmc_block_limit(blk, gpu_arch)
         for pass_idx in range(n_passes):
             chunk = cs[pass_idx * limit : (pass_idx + 1) * limit]
             pass_counters[pass_idx].extend(chunk)
@@ -229,8 +226,7 @@ def _split_pmc_into_passes(
             {"name": "-o", "value": out_name},
         ]
         full_cmd = (
-            f"rocprofv3 {flags_str} --pmc {pmc_str}"
-            f" -d {output_dir} -o {out_name} -- {app_placeholder}"
+            f"rocprofv3 {flags_str} --pmc {pmc_str}" f" -d {output_dir} -o {out_name} -- {app_placeholder}"
         ).strip()
         commands.append(
             {

--- a/experimental/python/perfxpert/perfxpert/cli/init_cmd.py
+++ b/experimental/python/perfxpert/perfxpert/cli/init_cmd.py
@@ -10,11 +10,7 @@ from __future__ import annotations
 import argparse
 import difflib
 import importlib.util
-import json
 import os
-import re
-import shutil
-import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -25,6 +21,10 @@ from perfxpert.analysis.payload import scan_tier0_sources
 from perfxpert.config._cli import _config_path as _default_config_path
 from perfxpert.config._config import PerfXpertConfig
 from perfxpert.tools.arch import lookup_peaks
+from perfxpert.tools.gpu_discovery import (
+    discover_runtime_gpu_specs,
+    first_runtime_gpu_specs,
+)
 
 
 __all__ = ["add_args", "run_init"]
@@ -67,79 +67,41 @@ def add_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
-_GFX_RE = re.compile(r"\b(gfx\d{3,4}[a-z]?)\b")
-
-
 def _detect_gpu_via_rocm_smi() -> Optional[str]:
-    """Run rocm-smi and return the first gfx arch string, or None."""
-    if shutil.which("rocm-smi") is None:
+    """Return the first gfx id reported by rocm-smi, or None."""
+    result = discover_runtime_gpu_specs()
+    if "rocm-smi" not in result.get("source", []):
         return None
-    try:
-        proc = subprocess.run(
-            ["rocm-smi", "--showproductname", "--showmeminfo", "vram", "--json"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if proc.returncode != 0:
-        return None
-
-    text = proc.stdout or ""
-    try:
-        data = json.loads(text)
-    except (json.JSONDecodeError, ValueError):
-        match = _GFX_RE.search(text)
-        return match.group(1) if match else None
-
-    def _walk(obj: Any) -> Optional[str]:
-        if isinstance(obj, str):
-            match = _GFX_RE.search(obj)
-            return match.group(1) if match else None
-        if isinstance(obj, dict):
-            for value in obj.values():
-                hit = _walk(value)
-                if hit:
-                    return hit
-        if isinstance(obj, list):
-            for value in obj:
-                hit = _walk(value)
-                if hit:
-                    return hit
-        return None
-
-    return _walk(data)
+    for gpu in result.get("gpus", []):
+        if gpu.get("gfx_id"):
+            return gpu.get("gfx_id")
+    return None
 
 
 def _detect_gpu_via_rocminfo() -> Optional[str]:
-    """Fallback: parse rocminfo output for a gfx architecture."""
-    if shutil.which("rocminfo") is None:
+    """Return the first gfx id reported by rocminfo, or None."""
+    result = discover_runtime_gpu_specs()
+    if "rocminfo" not in result.get("source", []):
         return None
-    try:
-        proc = subprocess.run(
-            ["rocminfo"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if proc.returncode != 0:
-        return None
-    match = _GFX_RE.search(proc.stdout or "")
-    return match.group(1) if match else None
+    for gpu in result.get("gpus", []):
+        if gpu.get("gfx_id"):
+            return gpu.get("gfx_id")
+    return None
 
 
 def _detect_gpu(override: Optional[str] = None) -> Optional[Dict[str, Any]]:
-    """Resolve a gfx id and look up peak specs."""
-    gfx_id = override or _detect_gpu_via_rocm_smi() or _detect_gpu_via_rocminfo()
+    """Resolve a local GPU and look up runtime-enriched peak specs."""
+    if override:
+        gfx_id = override
+    else:
+        detected = first_runtime_gpu_specs()
+        gfx_id = detected.get("gfx_id") if detected else None
     if not gfx_id:
         return None
     try:
         peaks = lookup_peaks(gfx_id)
     except KeyError:
-        return {"gfx_id": gfx_id, "peaks": None}
+        peaks = None
     return {"gfx_id": gfx_id, "peaks": peaks}
 
 
@@ -300,7 +262,7 @@ def _print_step(n: int, total: int, title: str, body: str, stream=sys.stdout) ->
 def _format_gpu_info(gpu_info: Optional[Dict[str, Any]]) -> str:
     if gpu_info is None:
         return (
-            "could not detect GPU via rocm-smi or rocminfo.\n"
+            "could not detect GPU via rocminfo, rocm-smi, or amd-smi.\n"
             "pass `--arch gfx942` (or similar) to proceed manually."
         )
     gfx_id = gpu_info.get("gfx_id", "unknown")

--- a/experimental/python/perfxpert/perfxpert/cli/init_cmd.py
+++ b/experimental/python/perfxpert/perfxpert/cli/init_cmd.py
@@ -99,7 +99,7 @@ def _detect_gpu(override: Optional[str] = None) -> Optional[Dict[str, Any]]:
     if not gfx_id:
         return None
     try:
-        peaks = lookup_peaks(gfx_id)
+        peaks = lookup_peaks(gfx_id, prefer_runtime=True)
     except KeyError:
         peaks = None
     return {"gfx_id": gfx_id, "peaks": peaks}
@@ -239,11 +239,7 @@ def _suggest_first_command(framework_info: Dict[str, Any]) -> List[str]:
             "GRBM_COUNT",
             "GRBM_GUI_ACTIVE",
         ]
-        commands.append(
-            "rocprofv3 --pmc "
-            + " ".join(counters)
-            + f" -d ./profile_out_pmc -- {target}"
-        )
+        commands.append("rocprofv3 --pmc " + " ".join(counters) + f" -d ./profile_out_pmc -- {target}")
     return commands
 
 
@@ -274,9 +270,7 @@ def _format_gpu_info(gpu_info: Optional[Dict[str, Any]]) -> str:
     bandwidth = peaks.get("memory_bandwidth_tbs", "?")
     fp32 = peaks.get("peak_fp32_tflops", "?")
     return (
-        f"detected: {gfx_id} ({name}, {cu_count} CU)\n"
-        f"  peak FP32: {fp32} TFLOPS\n"
-        f"  peak HBM : {bandwidth} TB/s"
+        f"detected: {gfx_id} ({name}, {cu_count} CU)\n" f"  peak FP32: {fp32} TFLOPS\n" f"  peak HBM : {bandwidth} TB/s"
     )
 
 
@@ -312,9 +306,7 @@ def _format_suggested_cmds(commands: List[str]) -> str:
     for index, command in enumerate(commands):
         prefix = "primary : " if index == 0 else "extra   : "
         lines.append(prefix + command)
-    lines.append(
-        "(--pc-sampling / --att are second-tier - run after Tier-1 identifies hot kernels)"
-    )
+    lines.append("(--pc-sampling / --att are second-tier - run after Tier-1 identifies hot kernels)")
     return "\n".join(lines)
 
 

--- a/experimental/python/perfxpert/perfxpert/knowledge/_schemas/pmc_limits.schema.json
+++ b/experimental/python/perfxpert/perfxpert/knowledge/_schemas/pmc_limits.schema.json
@@ -8,13 +8,19 @@
       "description": "Maximum raw hardware counters per block per rocprofv3 pass",
       "patternProperties": {
         "^[A-Z][A-Z0-9_]*$": {
-          "type": "object",
-          "required": ["limit"],
-          "properties": {
-            "limit": {"type": "integer", "minimum": 1},
-            "gfx942_limit": {"type": "integer", "minimum": 1},
-            "note": {"type": "string"}
-          },
+            "type": "object",
+            "required": ["limit"],
+            "properties": {
+              "limit": {"type": "integer", "minimum": 1},
+              "arch_limits": {
+                "type": "object",
+                "patternProperties": {
+                  "^gfx[0-9a-z]{3,5}$": {"type": "integer", "minimum": 1}
+                },
+                "additionalProperties": false
+              },
+              "note": {"type": "string"}
+            },
           "additionalProperties": false
         }
       }

--- a/experimental/python/perfxpert/perfxpert/knowledge/pmc_limits.yaml
+++ b/experimental/python/perfxpert/perfxpert/knowledge/pmc_limits.yaml
@@ -1,25 +1,136 @@
-# Per-block counter collection limits observed through rocprofv3. These are
-# PerfXpert tool/runtime guardrails, not vendor-published GPU peak specs.
-# Exceeding a limit yields rocprofv3 error code 38 in the guarded paths.
-# Source: llm-reference-guide.md §"Hardware Counter Per-Block Limits" (lines 10-65).
+# Per-block counter collection limits used by rocprofv3 pass planning.
+# Architecture-specific values mirror the rocprofiler-compute
+# mi_gpu_spec.yaml perfmon_config table in this repository.
 
 per_block_limits:
   SQ:
     limit: 4
-    gfx942_limit: 8
-    note: "Shader Sequencer — conservative default 4, up to 8 on gfx942 (MI300X)"
+    arch_limits:
+      gfx908: 8
+      gfx90a: 8
+      gfx940: 8
+      gfx941: 8
+      gfx942: 8
+      gfx950: 8
+      gfx1151: 8
+    note: "Shader Sequencer"
   GRBM:
     limit: 4
+    arch_limits:
+      gfx908: 2
+      gfx90a: 2
+      gfx940: 2
+      gfx941: 2
+      gfx942: 2
+      gfx950: 2
+      gfx1151: 2
     note: "Global Register Bus Manager — system-wide cycle counters"
   TCC:
     limit: 4
+    arch_limits:
+      gfx908: 4
+      gfx90a: 4
+      gfx940: 4
+      gfx941: 4
+      gfx942: 4
+      gfx950: 4
     note: "Texture Cache Controller (L2) — derived FETCH_SIZE/WRITE_SIZE must isolate; see rocprofv3_counter_limits.yaml"
   TCP:
     limit: 4
+    arch_limits:
+      gfx908: 4
+      gfx90a: 4
+      gfx940: 4
+      gfx941: 4
+      gfx942: 4
+      gfx950: 4
+      gfx1151: 4
     note: "Texture Cache Per-CU (vector L1)"
   TA:
     limit: 4
+    arch_limits:
+      gfx908: 2
+      gfx90a: 2
+      gfx940: 2
+      gfx941: 2
+      gfx942: 2
+      gfx950: 2
+      gfx1151: 2
     note: "Texture Address unit"
   TD:
     limit: 4
+    arch_limits:
+      gfx908: 2
+      gfx90a: 2
+      gfx940: 2
+      gfx941: 2
+      gfx942: 2
+      gfx950: 2
     note: "Texture Data unit"
+  CPC:
+    limit: 4
+    arch_limits:
+      gfx908: 2
+      gfx90a: 2
+      gfx940: 2
+      gfx941: 2
+      gfx942: 2
+      gfx950: 2
+      gfx1151: 2
+    note: "Command Processor Compute"
+  CPF:
+    limit: 4
+    arch_limits:
+      gfx908: 2
+      gfx90a: 2
+      gfx940: 2
+      gfx941: 2
+      gfx942: 2
+      gfx950: 2
+    note: "Command Processor Fetch"
+  SPI:
+    limit: 4
+    arch_limits:
+      gfx908: 6
+      gfx90a: 6
+      gfx940: 6
+      gfx941: 6
+      gfx942: 6
+      gfx950: 6
+      gfx1151: 6
+    note: "Shader Processor Input"
+  GDS:
+    limit: 4
+    arch_limits:
+      gfx908: 4
+      gfx90a: 4
+      gfx940: 4
+      gfx941: 4
+      gfx942: 4
+      gfx950: 4
+    note: "Global Data Share"
+  GCEA:
+    limit: 4
+    arch_limits:
+      gfx1151: 2
+    note: "Graphics Command Engine Arbiter"
+  GL1A:
+    limit: 4
+    arch_limits:
+      gfx1151: 4
+    note: "Graphics L1 address block"
+  GL1C:
+    limit: 4
+    arch_limits:
+      gfx1151: 4
+    note: "Graphics L1 cache block"
+  GL2A:
+    limit: 4
+    arch_limits:
+      gfx1151: 4
+    note: "Graphics L2 address block"
+  GL2C:
+    limit: 4
+    arch_limits:
+      gfx1151: 4
+    note: "Graphics L2 cache block"

--- a/experimental/python/perfxpert/perfxpert/knowledge/pmc_limits.yaml
+++ b/experimental/python/perfxpert/perfxpert/knowledge/pmc_limits.yaml
@@ -1,10 +1,12 @@
 # Per-block counter collection limits used by rocprofv3 pass planning.
+# The generic limit is the minimum of the known architecture-specific limits so
+# unknown architectures take the conservative path.
 # Architecture-specific values mirror the rocprofiler-compute
 # mi_gpu_spec.yaml perfmon_config table in this repository.
 
 per_block_limits:
   SQ:
-    limit: 4
+    limit: 8
     arch_limits:
       gfx908: 8
       gfx90a: 8
@@ -15,7 +17,7 @@ per_block_limits:
       gfx1151: 8
     note: "Shader Sequencer"
   GRBM:
-    limit: 4
+    limit: 2
     arch_limits:
       gfx908: 2
       gfx90a: 2
@@ -47,7 +49,7 @@ per_block_limits:
       gfx1151: 4
     note: "Texture Cache Per-CU (vector L1)"
   TA:
-    limit: 4
+    limit: 2
     arch_limits:
       gfx908: 2
       gfx90a: 2
@@ -58,7 +60,7 @@ per_block_limits:
       gfx1151: 2
     note: "Texture Address unit"
   TD:
-    limit: 4
+    limit: 2
     arch_limits:
       gfx908: 2
       gfx90a: 2
@@ -68,7 +70,7 @@ per_block_limits:
       gfx950: 2
     note: "Texture Data unit"
   CPC:
-    limit: 4
+    limit: 2
     arch_limits:
       gfx908: 2
       gfx90a: 2
@@ -79,7 +81,7 @@ per_block_limits:
       gfx1151: 2
     note: "Command Processor Compute"
   CPF:
-    limit: 4
+    limit: 2
     arch_limits:
       gfx908: 2
       gfx90a: 2
@@ -89,7 +91,7 @@ per_block_limits:
       gfx950: 2
     note: "Command Processor Fetch"
   SPI:
-    limit: 4
+    limit: 6
     arch_limits:
       gfx908: 6
       gfx90a: 6
@@ -110,7 +112,7 @@ per_block_limits:
       gfx950: 4
     note: "Global Data Share"
   GCEA:
-    limit: 4
+    limit: 2
     arch_limits:
       gfx1151: 2
     note: "Graphics Command Engine Arbiter"

--- a/experimental/python/perfxpert/perfxpert/tools/_pmc_limits.py
+++ b/experimental/python/perfxpert/perfxpert/tools/_pmc_limits.py
@@ -1,0 +1,40 @@
+"""Shared PMC block-limit helpers."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any, Dict
+
+from perfxpert.knowledge import load_yaml
+
+PMC_BLOCK_LIMIT_DEFAULT = 4
+
+
+@lru_cache(maxsize=1)
+def _limits_cfg() -> Dict[str, Dict[str, Any]]:
+    return load_yaml("pmc_limits").get("per_block_limits", {})
+
+
+def default_block_limits() -> Dict[str, int]:
+    """Return conservative default limits by block."""
+    return {block: int(info.get("limit", PMC_BLOCK_LIMIT_DEFAULT)) for block, info in _limits_cfg().items()}
+
+
+def pmc_block(counter: str) -> str:
+    """Return the hardware block name for a counter."""
+    return counter.split("_", 1)[0]
+
+
+def pmc_block_limit(block: str, gpu_arch: str = "") -> int:
+    """Return the per-pass counter limit for ``block`` on ``gpu_arch``."""
+    info = _limits_cfg().get(block, {})
+    arch_limits = info.get("arch_limits") if isinstance(info, dict) else {}
+    if isinstance(arch_limits, dict) and gpu_arch in arch_limits:
+        return int(arch_limits[gpu_arch])
+
+    # Backward-compatible reader for older knowledge files.
+    legacy_key = f"{gpu_arch}_limit" if gpu_arch else ""
+    if legacy_key and legacy_key in info:
+        return int(info[legacy_key])
+
+    return int(info.get("limit", PMC_BLOCK_LIMIT_DEFAULT))

--- a/experimental/python/perfxpert/perfxpert/tools/arch.py
+++ b/experimental/python/perfxpert/perfxpert/tools/arch.py
@@ -66,10 +66,7 @@ def _merge_static_and_runtime_specs(
         if (
             key in result
             and source.startswith("derived-from-")
-            and (
-                key.startswith("peak_")
-                or key in {"peak_int8_tops", "memory_bandwidth_tbs"}
-            )
+            and (key.startswith("peak_") or key in {"peak_int8_tops", "memory_bandwidth_tbs"})
         ):
             continue
         result[key] = value
@@ -111,11 +108,14 @@ def occupancy_specs_table() -> Dict[str, Dict[str, Any]]:
 
 
 @tool_class(ToolClass.READ_ONLY)
-def lookup_peaks(gfx_id: str) -> Dict[str, Any]:
+def lookup_peaks(gfx_id: str, prefer_runtime: bool = False) -> Dict[str, Any]:
     """Return hardware peak specs for a given gfx architecture.
 
     Args:
         gfx_id: Architecture identifier, e.g., "gfx942" for MI300X.
+        prefer_runtime: Use local runtime facts for known architectures. Leave
+            false for trace/remote analysis where the profiled host may differ
+            from the controller running PerfXpert.
 
     Returns:
         Dict with keys: name, codename, peak_fp64_tflops, peak_fp32_tflops,
@@ -132,15 +132,12 @@ def lookup_peaks(gfx_id: str) -> Dict[str, Any]:
         81.7
     """
     specs = _gpu_specs()
-    runtime_specs = _runtime_specs_for_gfx(gfx_id)
+    runtime_specs = _runtime_specs_for_gfx(gfx_id) if prefer_runtime or gfx_id not in specs else {}
     if gfx_id not in specs and not runtime_specs:
         known = ", ".join(sorted(specs.keys()))
         raise KeyError(f"Unknown gfx_id {gfx_id!r}; known archs: {known}")
 
     result = _merge_static_and_runtime_specs(specs.get(gfx_id, {}), runtime_specs)
     result["ridge_point"] = _ridge_point_from_specs(result, dtype="fp32")
-    result["ridge_points"] = {
-        dtype: _ridge_point_from_specs(result, dtype=dtype)
-        for dtype in _RIDGE_PEAK_KEYS
-    }
+    result["ridge_points"] = {dtype: _ridge_point_from_specs(result, dtype=dtype) for dtype in _RIDGE_PEAK_KEYS}
     return result

--- a/experimental/python/perfxpert/perfxpert/tools/arch.py
+++ b/experimental/python/perfxpert/perfxpert/tools/arch.py
@@ -5,7 +5,9 @@ Agents call lookup_peaks(gfx_id) instead of embedding specs in prompts.
 
 Tool class: READ_ONLY (MCP-safe).
 
-See design spec Appendix A; knowledge/gpu_specs.yaml is the source of truth.
+Runtime-discovered local GPUs are preferred when available. The static
+knowledge table remains the offline fallback for non-local architectures and
+for fields ROCm tools do not expose on a given stack.
 """
 
 from __future__ import annotations
@@ -39,6 +41,48 @@ def _ridge_point_from_specs(specs: Dict[str, Any], dtype: str = "fp32") -> float
     if bandwidth_tbs <= 0:
         return float(specs.get("ridge_point") or 0.0)
     return round(peak_tflops / bandwidth_tbs, 1)
+
+
+def _runtime_specs_for_gfx(gfx_id: str) -> Dict[str, Any]:
+    from perfxpert.tools.gpu_discovery import runtime_specs_for_gfx
+
+    return runtime_specs_for_gfx(gfx_id) or {}
+
+
+def _merge_static_and_runtime_specs(
+    static_specs: Dict[str, Any],
+    runtime_specs: Dict[str, Any],
+) -> Dict[str, Any]:
+    result = dict(static_specs)
+    static_keys = set(result.keys())
+    spec_sources = {key: "gpu_specs.yaml" for key in result}
+
+    for key, value in runtime_specs.items():
+        if key == "spec_sources":
+            continue
+        if value is None or value == "":
+            continue
+        source = runtime_specs.get("spec_sources", {}).get(key, "runtime")
+        if (
+            key in result
+            and source.startswith("derived-from-")
+            and (
+                key.startswith("peak_")
+                or key in {"peak_int8_tops", "memory_bandwidth_tbs"}
+            )
+        ):
+            continue
+        result[key] = value
+        spec_sources[key] = source
+
+    if runtime_specs:
+        result["runtime_discovered"] = True
+        result["static_fallback_keys"] = sorted(static_keys - set(runtime_specs.keys()))
+    else:
+        result["runtime_discovered"] = False
+        result["static_fallback_keys"] = []
+    result["spec_sources"] = spec_sources
+    return result
 
 
 def lookup_ridge_point(gfx_id: str, dtype: str = "fp32") -> float:
@@ -88,11 +132,12 @@ def lookup_peaks(gfx_id: str) -> Dict[str, Any]:
         81.7
     """
     specs = _gpu_specs()
-    if gfx_id not in specs:
+    runtime_specs = _runtime_specs_for_gfx(gfx_id)
+    if gfx_id not in specs and not runtime_specs:
         known = ", ".join(sorted(specs.keys()))
         raise KeyError(f"Unknown gfx_id {gfx_id!r}; known archs: {known}")
 
-    result = dict(specs[gfx_id])
+    result = _merge_static_and_runtime_specs(specs.get(gfx_id, {}), runtime_specs)
     result["ridge_point"] = _ridge_point_from_specs(result, dtype="fp32")
     result["ridge_points"] = {
         dtype: _ridge_point_from_specs(result, dtype=dtype)

--- a/experimental/python/perfxpert/perfxpert/tools/counters.py
+++ b/experimental/python/perfxpert/perfxpert/tools/counters.py
@@ -10,15 +10,14 @@ from typing import Any, Dict, List
 
 from perfxpert.knowledge import load_yaml
 from perfxpert.tools._class import ToolClass, tool_class
+from perfxpert.tools._pmc_limits import pmc_block_limit
 
 # TCC-derived metrics must be isolated to their own rocprofv3 pass
 # Ref: CLAUDE.md — FETCH_SIZE/WRITE_SIZE each need own pass
 _TCC_DERIVED = frozenset({"FETCH_SIZE", "WRITE_SIZE"})
 
 
-def _build_multi_pass_escalation(
-    passes: List[List[str]], gpu_arch: str
-) -> Dict[str, Any]:
+def _build_multi_pass_escalation(passes: List[List[str]], gpu_arch: str) -> Dict[str, Any]:
     """Return concrete guidance for multi-pass counter collection."""
     pass_specs = [
         {
@@ -53,8 +52,7 @@ def _build_multi_pass_escalation(
             {
                 "tool": "rocprofv3",
                 "description": (
-                    "Write one pmc group per line, then collect the requested "
-                    "passes with rocprofv3 -i."
+                    "Write one pmc group per line, then collect the requested " "passes with rocprofv3 -i."
                 ),
                 "full_command": "rocprofv3 -i pmc_groups.txt -- ./app",
             },
@@ -83,6 +81,7 @@ def lookup_info(name: str, gfx_id: str = None) -> Dict[str, Any]:
             return {
                 "name": name,
                 "block": entry["block"],
+                "block_limit": pmc_block_limit(entry["block"], gfx_id or ""),
                 "unit": entry.get("unit", "count"),
                 "description": entry.get("description", ""),
             }
@@ -109,7 +108,6 @@ def validate_for_gpu(counter_list: List[str], gpu_arch: str) -> Dict[str, Any]:
           "escalation": {...} | None,
         }
     """
-    limits_cfg = load_yaml("pmc_limits")["per_block_limits"]
     catalog = load_yaml("counter_catalog")
 
     # Build name → block index from the flat catalog
@@ -117,12 +115,6 @@ def validate_for_gpu(counter_list: List[str], gpu_arch: str) -> Dict[str, Any]:
     # TCC-derived counters are implicitly TCC block
     for derived in _TCC_DERIVED:
         name_to_block.setdefault(derived, "TCC")
-
-    def _limit_for(block: str) -> int:
-        """Look up per-pass limit, preferring arch-specific override."""
-        info = limits_cfg.get(block, {})
-        arch_key = f"{gpu_arch}_limit"
-        return int(info.get(arch_key, info.get("limit", 4)))
 
     # Separate TCC-derived counters — each gets its own pass (anti-Sakana)
     derived = [c for c in counter_list if c in _TCC_DERIVED]
@@ -139,7 +131,7 @@ def validate_for_gpu(counter_list: List[str], gpu_arch: str) -> Dict[str, Any]:
     active: List[str] = []
     active_counts: Dict[str, int] = {}
     for block, names in by_block.items():
-        lim = _limit_for(block)
+        lim = pmc_block_limit(block, gpu_arch)
         for c in names:
             if active_counts.get(block, 0) >= lim:
                 passes.append(active)

--- a/experimental/python/perfxpert/perfxpert/tools/gpu_discovery.py
+++ b/experimental/python/perfxpert/perfxpert/tools/gpu_discovery.py
@@ -43,7 +43,7 @@ PERFXPERT_DISABLE_RUNTIME_GPU_SPECS = "PERFXPERT_DISABLE_RUNTIME_GPU_SPECS"
 PERFXPERT_GPU_DISCOVERY_TIMEOUT = "PERFXPERT_GPU_DISCOVERY_TIMEOUT"
 _KFD_TOPOLOGY_ROOT = Path("/sys/class/kfd/kfd/topology/nodes")
 
-_GFX_RE = re.compile(r"\b(gfx\d{3,4}[a-z]?)\b")
+_GFX_RE = re.compile(r"\b(gfx[0-9a-z]{3,5})\b")
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 _NA_VALUES = {"", "N/A", "NA", "none", "None", "unknown", "Unknown"}
 
@@ -505,11 +505,40 @@ def _memory_bandwidth_tbs_from_kfd(width_bits: Any, mem_clk_mhz: Any) -> Optiona
 
 def _merge_gpu_lists(sources: Iterable[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
     merged: List[Dict[str, Any]] = []
+    identity_keys = ("bdf", "uuid", "node_id", "gpu_id")
+
+    def _has_identity(record: Dict[str, Any]) -> bool:
+        return any(record.get(key) is not None for key in identity_keys)
+
+    def _identity_conflicts(
+        candidate: Dict[str, Any],
+        existing: Dict[str, Any],
+        matched_key: str,
+    ) -> bool:
+        for key in identity_keys:
+            if key == matched_key:
+                continue
+            candidate_value = candidate.get(key)
+            existing_value = existing.get(key)
+            if candidate_value is not None and existing_value is not None and candidate_value != existing_value:
+                return True
+        return False
 
     def _find_match(candidate: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         for existing in merged:
-            for key in ("node_id", "gpu_id", "bdf", "uuid", "gfx_id"):
-                if candidate.get(key) is not None and candidate.get(key) == existing.get(key):
+            for key in identity_keys:
+                if candidate.get(key) is None or candidate.get(key) != existing.get(key):
+                    continue
+                if key == "gpu_id" and _identity_conflicts(candidate, existing, key):
+                    continue
+                return existing
+        if not _has_identity(candidate):
+            for existing in merged:
+                if (
+                    not _has_identity(existing)
+                    and candidate.get("gfx_id") is not None
+                    and candidate.get("gfx_id") == existing.get("gfx_id")
+                ):
                     return existing
         return None
 

--- a/experimental/python/perfxpert/perfxpert/tools/gpu_discovery.py
+++ b/experimental/python/perfxpert/perfxpert/tools/gpu_discovery.py
@@ -1,0 +1,753 @@
+###############################################################################
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+###############################################################################
+
+"""Runtime GPU spec discovery through ROCm command-line tools.
+
+This module gathers the hardware facts that ROCm exposes locally instead of
+requiring every installed GPU to already have an entry in ``gpu_specs.yaml``.
+Discovery is best-effort and read-only:
+
+* ``rocminfo`` supplies HSA topology such as gfx id, CU count, wave size,
+  LDS size, SIMDs per CU, and max clock.
+* KFD topology sysfs files supply the same read-only topology fields when
+  Python-launched ``rocminfo`` cannot open the device node.
+* ``rocm-smi`` supplies SKU-facing fields such as GFX version and VRAM size on
+  stacks where its JSON mode is available.
+* ``amd-smi`` supplies static and metric JSON such as board, clock, PCIe,
+  power-limit, and VRAM fields on newer ROCm stacks.
+
+The ROCm tools do not expose every theoretical instruction throughput value on
+all systems, so peak FLOP fields are derived only when runtime topology and a
+known architecture family are available. Static knowledge remains the fallback
+for offline/non-local architectures.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from perfxpert.tools._class import ToolClass, tool_class
+
+
+PERFXPERT_DISABLE_RUNTIME_GPU_SPECS = "PERFXPERT_DISABLE_RUNTIME_GPU_SPECS"
+PERFXPERT_GPU_DISCOVERY_TIMEOUT = "PERFXPERT_GPU_DISCOVERY_TIMEOUT"
+_KFD_TOPOLOGY_ROOT = Path("/sys/class/kfd/kfd/topology/nodes")
+
+_GFX_RE = re.compile(r"\b(gfx\d{3,4}[a-z]?)\b")
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+_NA_VALUES = {"", "N/A", "NA", "none", "None", "unknown", "Unknown"}
+
+
+def _runtime_discovery_disabled() -> bool:
+    value = os.environ.get(PERFXPERT_DISABLE_RUNTIME_GPU_SPECS, "").strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
+def _timeout_seconds() -> float:
+    value = os.environ.get(PERFXPERT_GPU_DISCOVERY_TIMEOUT, "").strip()
+    if not value:
+        return 5.0
+    try:
+        return max(float(value), 0.1)
+    except ValueError:
+        return 5.0
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def _is_missing(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return value.strip() in _NA_VALUES
+    return False
+
+
+def _as_int(value: Any) -> Optional[int]:
+    if isinstance(value, dict):
+        value = value.get("value")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if not isinstance(value, str):
+        return None
+    if value.strip() in _NA_VALUES:
+        return None
+    match = re.search(r"-?\d+", value.replace(",", ""))
+    return int(match.group(0)) if match else None
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if isinstance(value, dict):
+        value = value.get("value")
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str):
+        return None
+    if value.strip() in _NA_VALUES:
+        return None
+    match = re.search(r"-?\d+(?:\.\d+)?", value.replace(",", ""))
+    return float(match.group(0)) if match else None
+
+
+def _extract_gfx(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    match = _GFX_RE.search(value)
+    return match.group(1) if match else None
+
+
+def _normalize_name(value: Any) -> Optional[str]:
+    if not isinstance(value, str) or value.strip() in _NA_VALUES:
+        return None
+    return value.strip()
+
+
+def _max_mhz_from_clock_block(value: Any) -> Optional[float]:
+    candidates: List[float] = []
+
+    def _walk(obj: Any) -> None:
+        if isinstance(obj, dict):
+            if "max_clk" in obj:
+                parsed = _as_float(obj.get("max_clk"))
+                if parsed is not None:
+                    candidates.append(parsed)
+            for item in obj.values():
+                _walk(item)
+        elif isinstance(obj, list):
+            for item in obj:
+                _walk(item)
+        else:
+            parsed = _as_float(obj)
+            if parsed is not None:
+                candidates.append(parsed)
+
+    _walk(value)
+    positive = [candidate for candidate in candidates if candidate > 0]
+    return max(positive) if positive else None
+
+
+def _run_command(argv: List[str]) -> Optional[str]:
+    executable = shutil.which(argv[0])
+    if executable is None:
+        return None
+    try:
+        proc = subprocess.run(
+            [executable, *argv[1:]],
+            capture_output=True,
+            text=True,
+            timeout=_timeout_seconds(),
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    output = proc.stdout or proc.stderr or ""
+    if proc.returncode != 0 and not output:
+        return None
+    return _strip_ansi(output)
+
+
+def _set_if_present(gpu: Dict[str, Any], key: str, value: Any, source: str) -> None:
+    if _is_missing(value):
+        return
+    if isinstance(value, (int, float)) and value <= 0 and key.startswith("max_"):
+        return
+    if key not in gpu or _is_missing(gpu.get(key)) or key == "name":
+        gpu[key] = value
+        gpu.setdefault("spec_sources", {})[key] = source
+
+
+def _parse_rocminfo(text: str) -> List[Dict[str, Any]]:
+    gpus: List[Dict[str, Any]] = []
+    current: Optional[Dict[str, Any]] = None
+    group_pool = False
+
+    def _finish() -> None:
+        if current and current.get("device_type") == "GPU" and current.get("gfx_id"):
+            current.pop("device_type", None)
+            gpus.append(current.copy())
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if re.fullmatch(r"Agent\s+\d+", line):
+            _finish()
+            current = {"spec_sources": {}}
+            group_pool = False
+            continue
+        if current is None or ":" not in line:
+            continue
+
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+
+        if key == "Segment" and "GROUP" in value:
+            group_pool = True
+            continue
+        if group_pool and key == "Size":
+            size_kb = _as_int(value)
+            if size_kb is not None:
+                _set_if_present(current, "lds_kb", size_kb, "rocminfo")
+                _set_if_present(current, "lds_per_cu_kb", size_kb, "rocminfo")
+            group_pool = False
+            continue
+
+        if key == "Device Type":
+            current["device_type"] = value
+        elif key == "Name":
+            gfx_id = _extract_gfx(value)
+            if gfx_id:
+                _set_if_present(current, "gfx_id", gfx_id, "rocminfo")
+            elif "name" not in current:
+                _set_if_present(current, "name", _normalize_name(value), "rocminfo")
+        elif key == "Marketing Name":
+            _set_if_present(current, "name", _normalize_name(value), "rocminfo")
+        elif key == "Node":
+            _set_if_present(current, "node_id", _as_int(value), "rocminfo")
+        elif key == "Compute Unit":
+            _set_if_present(current, "cu_count", _as_int(value), "rocminfo")
+        elif key == "SIMDs per CU":
+            _set_if_present(current, "simds_per_cu", _as_int(value), "rocminfo")
+        elif key == "Max Clock Freq. (MHz)":
+            _set_if_present(current, "max_sclk_mhz", _as_float(value), "rocminfo")
+        elif key == "Wavefront Size":
+            _set_if_present(current, "wave_size", _as_int(value), "rocminfo")
+        elif key == "Max Waves Per CU":
+            max_waves = _as_int(value)
+            if max_waves is not None:
+                _set_if_present(current, "max_waves_per_cu", max_waves, "rocminfo")
+        elif key == "BDFID":
+            _set_if_present(current, "bdf_id", _as_int(value), "rocminfo")
+        elif key == "Uuid":
+            _set_if_present(current, "uuid", _normalize_name(value), "rocminfo")
+
+    _finish()
+    return gpus
+
+
+def _load_json(text: Optional[str]) -> Any:
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except (TypeError, json.JSONDecodeError, ValueError):
+        return None
+
+
+def _parse_rocm_smi_json(text: Optional[str]) -> List[Dict[str, Any]]:
+    raw = _load_json(text)
+    if not isinstance(raw, dict):
+        return []
+
+    gpus: List[Dict[str, Any]] = []
+    for key, rec in raw.items():
+        if not isinstance(key, str) or not key.startswith("card") or not isinstance(rec, dict):
+            continue
+        gpu: Dict[str, Any] = {"spec_sources": {}}
+        _set_if_present(gpu, "gpu_id", _as_int(key.replace("card", "")), "rocm-smi")
+        _set_if_present(gpu, "node_id", _as_int(rec.get("Node ID")), "rocm-smi")
+        _set_if_present(gpu, "gfx_id", _extract_gfx(str(rec.get("GFX Version", ""))), "rocm-smi")
+        _set_if_present(gpu, "name", _normalize_name(rec.get("Card Series")), "rocm-smi")
+        _set_if_present(gpu, "card_model", _normalize_name(rec.get("Card Model")), "rocm-smi")
+        _set_if_present(gpu, "vram_total_bytes", _as_int(rec.get("VRAM Total Memory (B)")), "rocm-smi")
+        _set_if_present(gpu, "vram_used_bytes", _as_int(rec.get("VRAM Total Used Memory (B)")), "rocm-smi")
+
+        for rec_key, value in rec.items():
+            normalized_key = str(rec_key).lower()
+            if "sclk clock speed" in normalized_key:
+                _set_if_present(gpu, "current_sclk_mhz", _as_float(value), "rocm-smi")
+            elif "mclk clock speed" in normalized_key:
+                _set_if_present(gpu, "current_mclk_mhz", _as_float(value), "rocm-smi")
+        if gpu.keys() - {"spec_sources"}:
+            gpus.append(gpu)
+    return gpus
+
+
+def _parse_amd_smi_list_json(text: Optional[str]) -> List[Dict[str, Any]]:
+    raw = _load_json(text)
+    if not isinstance(raw, list):
+        return []
+    gpus: List[Dict[str, Any]] = []
+    for rec in raw:
+        if not isinstance(rec, dict):
+            continue
+        gpu: Dict[str, Any] = {"spec_sources": {}}
+        _set_if_present(gpu, "gpu_id", _as_int(rec.get("gpu")), "amd-smi")
+        _set_if_present(gpu, "node_id", _as_int(rec.get("node_id")), "amd-smi")
+        _set_if_present(gpu, "bdf", _normalize_name(rec.get("bdf")), "amd-smi")
+        _set_if_present(gpu, "uuid", _normalize_name(rec.get("uuid")), "amd-smi")
+        if gpu.keys() - {"spec_sources"}:
+            gpus.append(gpu)
+    return gpus
+
+
+def _parse_amd_smi_gpu_data_json(text: Optional[str], source_command: str) -> List[Dict[str, Any]]:
+    raw = _load_json(text)
+    if not isinstance(raw, dict):
+        return []
+    rows = raw.get("gpu_data")
+    if not isinstance(rows, list):
+        return []
+
+    gpus: List[Dict[str, Any]] = []
+    for rec in rows:
+        if not isinstance(rec, dict):
+            continue
+        gpu: Dict[str, Any] = {"spec_sources": {}}
+        _set_if_present(gpu, "gpu_id", _as_int(rec.get("gpu")), "amd-smi")
+
+        asic = rec.get("asic") if isinstance(rec.get("asic"), dict) else {}
+        _set_if_present(gpu, "name", _normalize_name(asic.get("market_name")), "amd-smi")
+        _set_if_present(gpu, "gfx_id", _extract_gfx(str(asic.get("target_graphics_version", ""))), "amd-smi")
+        _set_if_present(gpu, "cu_count", _as_int(asic.get("num_compute_units")), "amd-smi")
+
+        board = rec.get("board") if isinstance(rec.get("board"), dict) else {}
+        _set_if_present(gpu, "board_product_name", _normalize_name(board.get("product_name")), "amd-smi")
+
+        bus = rec.get("bus") if isinstance(rec.get("bus"), dict) else {}
+        _set_if_present(gpu, "bdf", _normalize_name(bus.get("bdf")), "amd-smi")
+        _set_if_present(gpu, "pcie_width", _as_int(bus.get("max_pcie_width")), "amd-smi")
+        _set_if_present(gpu, "pcie_speed_gts", _as_float(bus.get("max_pcie_speed")), "amd-smi")
+
+        numa = rec.get("numa") if isinstance(rec.get("numa"), dict) else {}
+        _set_if_present(gpu, "numa_node", _as_int(numa.get("node")), "amd-smi")
+
+        vram = rec.get("vram") if isinstance(rec.get("vram"), dict) else {}
+        _set_if_present(gpu, "vram_type", _normalize_name(vram.get("type")), "amd-smi")
+        _set_if_present(gpu, "vram_bit_width", _as_int(vram.get("bit_width")), "amd-smi")
+        _set_if_present(gpu, "vram_total_bytes", _bytes_from_unit_value(vram.get("size")), "amd-smi")
+        bandwidth_tbs = _bandwidth_tbs_from_unit_value(vram.get("max_bandwidth"))
+        _set_if_present(gpu, "memory_bandwidth_tbs", bandwidth_tbs, "amd-smi")
+
+        limit = rec.get("limit") if isinstance(rec.get("limit"), dict) else {}
+        ppt0 = limit.get("ppt0") if isinstance(limit.get("ppt0"), dict) else {}
+        _set_if_present(gpu, "tdp_w", _as_float(ppt0.get("socket_power_limit")), "amd-smi")
+
+        clock = rec.get("clock") if isinstance(rec.get("clock"), dict) else {}
+        sys_clock = clock.get("sys") if isinstance(clock.get("sys"), dict) else None
+        mem_clock = clock.get("mem") if isinstance(clock.get("mem"), dict) else None
+        _set_if_present(gpu, "max_sclk_mhz", _max_mhz_from_clock_block(sys_clock), "amd-smi")
+        _set_if_present(gpu, "max_mclk_mhz", _max_mhz_from_clock_block(mem_clock), "amd-smi")
+        _set_if_present(gpu, "current_sclk_mhz", _as_float(_dict_get(sys_clock, "current_frequency")), "amd-smi")
+        _set_if_present(gpu, "current_mclk_mhz", _as_float(_dict_get(mem_clock, "current_frequency")), "amd-smi")
+
+        mem_usage = rec.get("mem_usage") if isinstance(rec.get("mem_usage"), dict) else {}
+        _set_if_present(gpu, "vram_total_bytes", _bytes_from_unit_value(mem_usage.get("total_vram")), "amd-smi")
+        _set_if_present(gpu, "vram_used_bytes", _bytes_from_unit_value(mem_usage.get("used_vram")), "amd-smi")
+
+        if source_command == "amd-smi metric":
+            metric_clock = rec.get("clock") if isinstance(rec.get("clock"), dict) else {}
+            gfx_clock = metric_clock.get("gfx_0") if isinstance(metric_clock.get("gfx_0"), dict) else None
+            mem0_clock = metric_clock.get("mem_0") if isinstance(metric_clock.get("mem_0"), dict) else None
+            _set_if_present(gpu, "max_sclk_mhz", _as_float(_dict_get(gfx_clock, "max_clk")), "amd-smi")
+            _set_if_present(gpu, "current_sclk_mhz", _as_float(_dict_get(gfx_clock, "clk")), "amd-smi")
+            _set_if_present(gpu, "max_mclk_mhz", _as_float(_dict_get(mem0_clock, "max_clk")), "amd-smi")
+            _set_if_present(gpu, "current_mclk_mhz", _as_float(_dict_get(mem0_clock, "clk")), "amd-smi")
+
+        if gpu.keys() - {"spec_sources"}:
+            gpus.append(gpu)
+    return gpus
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _parse_key_value_text(text: str) -> Dict[str, str]:
+    result: Dict[str, str] = {}
+    for line in text.splitlines():
+        parts = line.strip().split(maxsplit=1)
+        if len(parts) == 2:
+            result[parts[0]] = parts[1]
+    return result
+
+
+def _gfx_from_target_version(value: Any) -> Optional[str]:
+    version = _as_int(value)
+    if version is None or version <= 0:
+        return None
+    digits = f"{version:06d}"
+    major = int(digits[:2])
+    minor = int(digits[2:4])
+    stepping = int(digits[4:])
+    if major <= 0:
+        return None
+    return f"gfx{major}{minor}{stepping}"
+
+
+def _parse_kfd_topology(root: Path = _KFD_TOPOLOGY_ROOT) -> List[Dict[str, Any]]:
+    if not root.exists():
+        return []
+
+    gpus: List[Dict[str, Any]] = []
+    try:
+        node_dirs = sorted(root.iterdir())
+    except OSError:
+        return []
+
+    for node_dir in node_dirs:
+        if not node_dir.is_dir():
+            continue
+        props = _parse_key_value_text(_read_text(node_dir / "properties"))
+        gfx_id = _extract_gfx(_read_text(node_dir / "name")) or _gfx_from_target_version(
+            props.get("gfx_target_version")
+        )
+        if not gfx_id:
+            continue
+
+        gpu: Dict[str, Any] = {"spec_sources": {}}
+        _set_if_present(gpu, "node_id", _as_int(node_dir.name), "kfd-topology")
+        _set_if_present(gpu, "gfx_id", gfx_id, "kfd-topology")
+        _set_if_present(gpu, "max_waves_per_simd", _as_int(props.get("max_waves_per_simd")), "kfd-topology")
+        _set_if_present(gpu, "lds_kb", _as_int(props.get("lds_size_in_kb")), "kfd-topology")
+        _set_if_present(gpu, "lds_per_cu_kb", _as_int(props.get("lds_size_in_kb")), "kfd-topology")
+        _set_if_present(gpu, "wave_size", _as_int(props.get("wave_front_size")), "kfd-topology")
+        _set_if_present(gpu, "simds_per_cu", _as_int(props.get("simd_per_cu")), "kfd-topology")
+        _set_if_present(gpu, "max_sclk_mhz", _as_float(props.get("max_engine_clk_fcompute")), "kfd-topology")
+        _set_if_present(gpu, "max_sclk_mhz", _as_float(props.get("max_engine_clk_ccompute")), "kfd-topology")
+
+        simd_count = _as_int(props.get("simd_count"))
+        simds_per_cu = _as_int(props.get("simd_per_cu"))
+        if simd_count and simds_per_cu:
+            _set_if_present(gpu, "cu_count", simd_count // simds_per_cu, "kfd-topology")
+
+        try:
+            mem_bank_props = sorted((node_dir / "mem_banks").glob("*/properties"))
+        except OSError:
+            mem_bank_props = []
+
+        for bank_dir in mem_bank_props:
+            bank_props = _parse_key_value_text(_read_text(bank_dir))
+            if _as_int(bank_props.get("heap_type")) != 1:
+                continue
+            _set_if_present(gpu, "vram_total_bytes", _as_int(bank_props.get("size_in_bytes")), "kfd-topology")
+            _set_if_present(gpu, "vram_bit_width", _as_int(bank_props.get("width")), "kfd-topology")
+            _set_if_present(gpu, "max_mclk_mhz", _as_float(bank_props.get("mem_clk_max")), "kfd-topology")
+            _set_if_present(
+                gpu,
+                "memory_bandwidth_tbs",
+                _memory_bandwidth_tbs_from_kfd(
+                    bank_props.get("width"),
+                    bank_props.get("mem_clk_max"),
+                ),
+                "derived-from-kfd-topology",
+            )
+            break
+
+        gpus.append(gpu)
+    return gpus
+
+
+def _dict_get(value: Any, key: str) -> Any:
+    return value.get(key) if isinstance(value, dict) else None
+
+
+def _bytes_from_unit_value(value: Any) -> Optional[int]:
+    if isinstance(value, dict):
+        amount = _as_float(value.get("value"))
+        unit = str(value.get("unit", "")).strip().lower()
+    else:
+        amount = _as_float(value)
+        unit = str(value).strip().lower() if isinstance(value, str) else ""
+    if amount is None:
+        return None
+    if unit in {"kb", "kib"}:
+        return int(amount * 1024)
+    if unit in {"mb", "mib"}:
+        return int(amount * 1024 * 1024)
+    if unit in {"gb", "gib"}:
+        return int(amount * 1024 * 1024 * 1024)
+    if unit in {"tb", "tib"}:
+        return int(amount * 1024 * 1024 * 1024 * 1024)
+    return int(amount)
+
+
+def _bandwidth_tbs_from_unit_value(value: Any) -> Optional[float]:
+    if isinstance(value, dict):
+        amount = _as_float(value.get("value"))
+        unit = str(value.get("unit", "")).strip().lower()
+    else:
+        amount = _as_float(value)
+        unit = str(value).strip().lower() if isinstance(value, str) else ""
+    if amount is None or amount <= 0:
+        return None
+    if "gb/s" in unit or "gbps" in unit:
+        return round(amount / 1000.0, 3)
+    if "mb/s" in unit:
+        return round(amount / 1_000_000.0, 3)
+    return amount if amount < 100 else round(amount / 1000.0, 3)
+
+
+def _memory_bandwidth_tbs_from_kfd(width_bits: Any, mem_clk_mhz: Any) -> Optional[float]:
+    width = _as_float(width_bits)
+    clock = _as_float(mem_clk_mhz)
+    if width is None or clock is None or width <= 0 or clock <= 0:
+        return None
+    bytes_per_cycle = width / 8.0
+    gbps = clock * bytes_per_cycle * 2.0 / 1000.0
+    return round(gbps / 1000.0, 3)
+
+
+def _merge_gpu_lists(sources: Iterable[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
+    merged: List[Dict[str, Any]] = []
+
+    def _find_match(candidate: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        for existing in merged:
+            for key in ("node_id", "gpu_id", "bdf", "uuid", "gfx_id"):
+                if candidate.get(key) is not None and candidate.get(key) == existing.get(key):
+                    return existing
+        return None
+
+    for source_gpus in sources:
+        for candidate in source_gpus:
+            match = _find_match(candidate)
+            if match is None:
+                match = {"spec_sources": {}}
+                merged.append(match)
+            for key, value in candidate.items():
+                if key == "spec_sources":
+                    match.setdefault("spec_sources", {}).update(value)
+                    continue
+                source = candidate.get("spec_sources", {}).get(key, "runtime")
+                _set_if_present(match, key, value, source)
+
+    for gpu in merged:
+        _fill_arch_defaults(gpu)
+        _derive_peak_fields(gpu)
+    return merged
+
+
+def _fill_arch_defaults(gpu: Dict[str, Any]) -> None:
+    gfx_id = str(gpu.get("gfx_id") or "")
+    if not gfx_id:
+        return
+    defaults: Dict[str, Any]
+    if gfx_id.startswith(("gfx90a", "gfx94", "gfx95")):
+        defaults = {
+            "wave_size": 64,
+            "simds_per_cu": 4,
+            "lds_kb": 64,
+            "lds_per_cu_kb": 64,
+            "max_vgprs_per_thread": 256,
+            "vgprs_per_simd": 512,
+        }
+    elif gfx_id.startswith("gfx908"):
+        defaults = {
+            "wave_size": 64,
+            "simds_per_cu": 4,
+            "lds_kb": 64,
+            "lds_per_cu_kb": 64,
+            "max_vgprs_per_thread": 256,
+            "vgprs_per_simd": 256,
+        }
+    elif gfx_id.startswith("gfx10"):
+        defaults = {
+            "wave_size": 32,
+            "simds_per_cu": 2,
+            "lds_kb": 64,
+            "lds_per_cu_kb": 64,
+            "max_vgprs_per_thread": 256,
+            "vgprs_per_simd": 1024,
+        }
+    elif gfx_id.startswith(("gfx11", "gfx12")):
+        defaults = {
+            "wave_size": 32,
+            "simds_per_cu": 2,
+            "lds_kb": 64,
+            "lds_per_cu_kb": 64,
+            "max_vgprs_per_thread": 256,
+            "vgprs_per_simd": 1536,
+        }
+    else:
+        defaults = {}
+
+    if "max_waves_per_simd" not in defaults:
+        max_waves_per_cu = _as_int(gpu.get("max_waves_per_cu"))
+        simds_per_cu = _as_int(gpu.get("simds_per_cu"))
+        if max_waves_per_cu and simds_per_cu:
+            defaults["max_waves_per_simd"] = max(max_waves_per_cu // simds_per_cu, 1)
+
+    for key, value in defaults.items():
+        if key not in gpu or _is_missing(gpu.get(key)):
+            gpu[key] = value
+            gpu.setdefault("spec_sources", {})[key] = "architecture-default"
+
+
+def _derive_peak_fields(gpu: Dict[str, Any]) -> None:
+    cu_count = _as_int(gpu.get("cu_count"))
+    max_sclk_mhz = _as_float(gpu.get("max_sclk_mhz"))
+    gfx_id = str(gpu.get("gfx_id") or "")
+    throughput = _throughput_model(gfx_id)
+    if not cu_count or not max_sclk_mhz or throughput is None:
+        return
+
+    fp32 = round(cu_count * throughput["fp32_ops_per_cu_cycle"] * max_sclk_mhz / 1_000_000.0, 3)
+    derived = {
+        "peak_fp32_tflops": fp32,
+        "peak_fp64_tflops": fp32 * throughput["fp64_ratio"],
+        "peak_fp16_tflops": fp32 * throughput["fp16_ratio"],
+        "peak_bf16_tflops": fp32 * throughput["bf16_ratio"],
+        "peak_fp8_tflops": fp32 * throughput["fp8_ratio"],
+        "peak_int8_tops": fp32 * throughput["int8_ratio"],
+    }
+    for key, value in derived.items():
+        _set_if_present(gpu, key, round(value, 3), "derived-from-runtime-topology")
+
+
+def _throughput_model(gfx_id: str) -> Optional[Dict[str, float]]:
+    if gfx_id.startswith("gfx908"):
+        return {
+            "fp32_ops_per_cu_cycle": 128.0,
+            "fp64_ratio": 0.5,
+            "fp16_ratio": 8.0,
+            "bf16_ratio": 4.0,
+            "fp8_ratio": 0.0,
+            "int8_ratio": 4.0,
+        }
+    if gfx_id.startswith("gfx90a"):
+        return {
+            "fp32_ops_per_cu_cycle": 128.0,
+            "fp64_ratio": 1.0,
+            "fp16_ratio": 8.0,
+            "bf16_ratio": 8.0,
+            "fp8_ratio": 0.0,
+            "int8_ratio": 8.0,
+        }
+    if gfx_id.startswith("gfx94"):
+        return {
+            "fp32_ops_per_cu_cycle": 256.0,
+            "fp64_ratio": 0.5,
+            "fp16_ratio": 8.0,
+            "bf16_ratio": 8.0,
+            "fp8_ratio": 16.0,
+            "int8_ratio": 16.0,
+        }
+    if gfx_id.startswith("gfx95"):
+        return {
+            "fp32_ops_per_cu_cycle": 256.0,
+            "fp64_ratio": 0.5,
+            "fp16_ratio": 16.0,
+            "bf16_ratio": 16.0,
+            "fp8_ratio": 32.0,
+            "int8_ratio": 32.0,
+        }
+    if gfx_id.startswith("gfx10"):
+        return {
+            "fp32_ops_per_cu_cycle": 128.0,
+            "fp64_ratio": 1.0 / 32.0,
+            "fp16_ratio": 2.0,
+            "bf16_ratio": 0.0,
+            "fp8_ratio": 0.0,
+            "int8_ratio": 0.0,
+        }
+    if gfx_id.startswith(("gfx11", "gfx12")):
+        return {
+            "fp32_ops_per_cu_cycle": 256.0,
+            "fp64_ratio": 1.0 / 32.0,
+            "fp16_ratio": 2.0,
+            "bf16_ratio": 2.0,
+            "fp8_ratio": 0.0,
+            "int8_ratio": 2.0,
+        }
+    return None
+
+
+@lru_cache(maxsize=1)
+def _discover_runtime_gpu_specs_cached() -> Dict[str, Any]:
+    if _runtime_discovery_disabled():
+        return {"source": [], "gpus": [], "errors": ["runtime GPU discovery disabled"]}
+
+    rocminfo_text = _run_command(["rocminfo"])
+    rocm_smi_info = _run_command(["rocm-smi", "--showproductname", "--showmeminfo", "vram", "--json"])
+    rocm_smi_clocks = _run_command(["rocm-smi", "--showclocks", "--showclkfrq", "--json"])
+    amd_smi_list = _run_command(["amd-smi", "list", "--json"])
+    amd_smi_static = _run_command(["amd-smi", "static", "--json"])
+    amd_smi_metric = _run_command(["amd-smi", "metric", "--json"])
+
+    rocminfo_gpus = _parse_rocminfo(rocminfo_text or "")
+    kfd_topology_gpus = _parse_kfd_topology()
+    rocm_smi_gpus = _parse_rocm_smi_json(rocm_smi_info) + _parse_rocm_smi_json(rocm_smi_clocks)
+    amd_smi_gpus = (
+        _parse_amd_smi_list_json(amd_smi_list)
+        + _parse_amd_smi_gpu_data_json(amd_smi_static, "amd-smi static")
+        + _parse_amd_smi_gpu_data_json(amd_smi_metric, "amd-smi metric")
+    )
+
+    source_names = []
+    source_names.extend(["rocminfo"] if rocminfo_gpus else [])
+    source_names.extend(["kfd-topology"] if kfd_topology_gpus else [])
+    source_names.extend(["rocm-smi"] if rocm_smi_gpus else [])
+    source_names.extend(["amd-smi"] if amd_smi_gpus else [])
+
+    gpus = _merge_gpu_lists(
+        [
+            rocminfo_gpus,
+            kfd_topology_gpus,
+            rocm_smi_gpus,
+            amd_smi_gpus,
+        ]
+    )
+    return {"source": source_names, "gpus": gpus, "errors": []}
+
+
+@tool_class(ToolClass.READ_ONLY)
+def discover_runtime_gpu_specs(gfx_id: str = "") -> Dict[str, Any]:
+    """Return process-host GPU specs discovered from ROCm tools.
+
+    Discovery is local to the host where this Python process runs. For SSH
+    optimization workflows, collect GPU facts on the remote execution host or
+    run PerfXpert on that host; controller-host runtime specs must not be used
+    as remote-target SoL bounds.
+
+    Args:
+        gfx_id: Optional architecture id filter, for example ``gfx942``.
+
+    Returns:
+        A dict with ``source`` and ``gpus``. The ``gpus`` entries include
+        ``spec_sources`` so callers can see which command supplied each field.
+        Missing tools or unsupported fields produce an empty/fallback result
+        rather than raising.
+    """
+    result = _discover_runtime_gpu_specs_cached()
+    if not gfx_id:
+        return result
+    filtered = [gpu for gpu in result["gpus"] if gpu.get("gfx_id") == gfx_id]
+    return {**result, "gpus": filtered}
+
+
+def runtime_specs_for_gfx(gfx_id: str) -> Optional[Dict[str, Any]]:
+    """Return the first runtime-discovered spec for ``gfx_id`` if present."""
+    for gpu in _discover_runtime_gpu_specs_cached().get("gpus", []):
+        if gpu.get("gfx_id") == gfx_id:
+            return dict(gpu)
+    return None
+
+
+def first_runtime_gpu_specs() -> Optional[Dict[str, Any]]:
+    """Return the first locally discovered GPU spec if any."""
+    gpus = _discover_runtime_gpu_specs_cached().get("gpus", [])
+    return dict(gpus[0]) if gpus else None
+
+
+__all__ = [
+    "PERFXPERT_DISABLE_RUNTIME_GPU_SPECS",
+    "PERFXPERT_GPU_DISCOVERY_TIMEOUT",
+    "discover_runtime_gpu_specs",
+    "first_runtime_gpu_specs",
+    "runtime_specs_for_gfx",
+]

--- a/experimental/python/perfxpert/perfxpert/tools/gpu_runtime_monitor.py
+++ b/experimental/python/perfxpert/perfxpert/tools/gpu_runtime_monitor.py
@@ -16,10 +16,10 @@
 
 """gpu_runtime_monitor — parse pre-captured amd-smi / rocm-smi JSON logs.
 
-We do NOT shell out to ``amd-smi`` / ``rocm-smi`` at analyze time: users
-capture the JSON in advance (``amd-smi monitor --json > log.json``) and
-we ingest it offline. Eliminates the need for sudo, live sampling, and
-host-side privilege escalation inside analyze.
+This module does not shell out to ``amd-smi`` / ``rocm-smi`` for live
+monitoring logs: users capture the JSON in advance
+(``amd-smi monitor --json > log.json``) and we ingest it offline. Runtime
+hardware-spec discovery is handled separately by ``gpu_discovery``.
 
 Users can either pass the log path directly to the parsers or set
 ``PERFXPERT_GPU_MONITOR_LOG=<path>`` to let other modules auto-pick it up.

--- a/experimental/python/perfxpert/tests/test_cli/test_backend/test_remote_gpu_prompt.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_backend/test_remote_gpu_prompt.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from perfxpert.cli._backend.codex import CodexAdapter
+
+
+def test_codex_prompt_scopes_gpu_discovery_to_ssh_target_host() -> None:
+    rendered = CodexAdapter()._render_prompt_for_codex()
+
+    assert "GPU discovery must" in rendered
+    assert "remote execution host" in rendered
+    assert "Do not let local runtime GPU specs override remote-target" in rendered
+    assert "PERFXPERT_DISABLE_RUNTIME_GPU_SPECS=1" in rendered

--- a/experimental/python/perfxpert/tests/test_cli/test_init_cmd.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_init_cmd.py
@@ -68,13 +68,29 @@ def test_init_framework_detection_prefers_source_scan_over_python_import(tmp_pat
     assert info["python_framework"] == "PyTorch"
 
 
+def test_detect_gpu_requests_runtime_specs_for_local_wizard(monkeypatch) -> None:
+    observed = {}
+    detected_gfx = "gfxlocal"
+
+    def _fake_lookup(gfx_id, prefer_runtime=False):
+        observed["gfx_id"] = gfx_id
+        observed["prefer_runtime"] = prefer_runtime
+        return {"name": "Local GPU"}
+
+    monkeypatch.setattr(init_cmd, "first_runtime_gpu_specs", lambda: {"gfx_id": detected_gfx})
+    monkeypatch.setattr(init_cmd, "lookup_peaks", _fake_lookup)
+
+    result = init_cmd._detect_gpu()
+
+    assert result["gfx_id"] == detected_gfx
+    assert observed == {"gfx_id": detected_gfx, "prefer_runtime": True}
+
+
 def test_init_writes_config_to_custom_path(tmp_path, monkeypatch) -> None:
     cfg = tmp_path / "nested" / "pxcfg.yaml"
     monkeypatch.setattr(init_cmd, "_detect_gpu", lambda override=None: None)
 
-    rc = init_cmd.run_init(
-        _mk_args(source_dir=str(tmp_path), provider="opencode", config_path=str(cfg))
-    )
+    rc = init_cmd.run_init(_mk_args(source_dir=str(tmp_path), provider="opencode", config_path=str(cfg)))
 
     assert rc == 0
     assert cfg.exists()
@@ -115,9 +131,7 @@ def test_init_suggests_command_with_framework_shim() -> None:
 def test_init_returns_rc0_on_clean_run(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(init_cmd, "_detect_gpu", lambda override=None: None)
     cfg = tmp_path / "pxcfg.yaml"
-    rc = init_cmd.run_init(
-        _mk_args(source_dir=str(tmp_path), provider="opencode", config_path=str(cfg))
-    )
+    rc = init_cmd.run_init(_mk_args(source_dir=str(tmp_path), provider="opencode", config_path=str(cfg)))
     assert rc == 0
 
 
@@ -141,7 +155,5 @@ def test_init_returns_rc1_on_unwritable_config_path(tmp_path, monkeypatch) -> No
     monkeypatch.setattr(init_cmd, "_write_config", _boom)
 
     cfg = tmp_path / "ro" / "pxcfg.yaml"
-    rc = init_cmd.run_init(
-        _mk_args(source_dir=str(tmp_path), provider="opencode", config_path=str(cfg))
-    )
+    rc = init_cmd.run_init(_mk_args(source_dir=str(tmp_path), provider="opencode", config_path=str(cfg)))
     assert rc == 1

--- a/experimental/python/perfxpert/tests/test_knowledge/test_pmc_limits.py
+++ b/experimental/python/perfxpert/tests/test_knowledge/test_pmc_limits.py
@@ -60,6 +60,14 @@ def test_default_limits_are_conservative_positive_values():
         assert info["limit"] > 0, block
 
 
+def test_default_limits_match_minimum_arch_limit():
+    data = load_yaml("pmc_limits")
+    for block, info in data["per_block_limits"].items():
+        arch_limits = info.get("arch_limits", {})
+        if arch_limits:
+            assert info["limit"] == min(arch_limits.values()), block
+
+
 def test_arch_limits_match_rocprofiler_compute_mi_gpu_spec():
     data = load_yaml("pmc_limits")
     per_block = data["per_block_limits"]

--- a/experimental/python/perfxpert/tests/test_knowledge/test_pmc_limits.py
+++ b/experimental/python/perfxpert/tests/test_knowledge/test_pmc_limits.py
@@ -4,13 +4,33 @@ import json
 from pathlib import Path
 
 import jsonschema
+import yaml
 
 from perfxpert.knowledge import load_yaml
 
-SCHEMA_PATH = (
-    Path(__file__).parent.parent.parent
-    / "perfxpert" / "knowledge" / "_schemas" / "pmc_limits.schema.json"
-)
+SCHEMA_PATH = Path(__file__).parent.parent.parent / "perfxpert" / "knowledge" / "_schemas" / "pmc_limits.schema.json"
+
+
+def _mi_gpu_spec_path() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "projects" / "rocprofiler-compute" / "src" / "utils" / "mi_gpu_spec.yaml"
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError("projects/rocprofiler-compute/src/utils/mi_gpu_spec.yaml")
+
+
+def _reference_perfmon_config():
+    data = yaml.safe_load(_mi_gpu_spec_path().read_text())
+    configs = {}
+    for series in data["mi_gpu_spec"]:
+        for arch in series.get("gpu_archs", []):
+            perfmon = arch.get("perfmon_config") or {}
+            configs[arch["gpu_arch"]] = {
+                block: limit
+                for block, limit in perfmon.items()
+                if isinstance(limit, int) and not block.endswith("_channels")
+            }
+    return configs
 
 
 def test_pmc_limits_loads():
@@ -34,11 +54,17 @@ def test_pmc_limits_covers_all_blocks():
     assert not missing, f"missing blocks in pmc_limits: {missing}"
 
 
-def test_sq_default_limit_is_4():
+def test_default_limits_are_conservative_positive_values():
     data = load_yaml("pmc_limits")
-    assert data["per_block_limits"]["SQ"]["limit"] == 4
+    for block, info in data["per_block_limits"].items():
+        assert info["limit"] > 0, block
 
 
-def test_sq_gfx942_override_is_8():
+def test_arch_limits_match_rocprofiler_compute_mi_gpu_spec():
     data = load_yaml("pmc_limits")
-    assert data["per_block_limits"]["SQ"].get("gfx942_limit") == 8
+    per_block = data["per_block_limits"]
+
+    for gfx_id, perfmon in _reference_perfmon_config().items():
+        for block, expected_limit in perfmon.items():
+            assert block in per_block
+            assert per_block[block]["arch_limits"][gfx_id] == expected_limit

--- a/experimental/python/perfxpert/tests/test_tools/test_arch.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_arch.py
@@ -6,52 +6,85 @@ from perfxpert.tools import arch
 from perfxpert.tools._class import ToolClass
 
 
+_STATIC_SPEC_FIELDS = (
+    "name",
+    "codename",
+    "peak_fp64_tflops",
+    "peak_fp32_tflops",
+    "peak_fp16_tflops",
+    "peak_bf16_tflops",
+    "peak_fp8_tflops",
+    "peak_int8_tops",
+    "memory_bandwidth_tbs",
+    "cu_count",
+    "lds_kb",
+    "lds_per_cu_kb",
+    "wave_size",
+    "max_vgprs_per_thread",
+    "vgprs_per_simd",
+    "simds_per_cu",
+    "max_waves_per_simd",
+)
+
+_OCCUPANCY_FIELD_MAP = {
+    "max_waves_per_simd": "max_waves_per_simd",
+    "vgprs_per_simd": "vgprs_per_simd",
+    "lds_per_cu_kb": "lds_per_cu_kb",
+    "wavefront_size": "wave_size",
+    "simds_per_cu": "simds_per_cu",
+}
+
+
 @pytest.fixture(autouse=True)
 def _disable_runtime_discovery(monkeypatch):
     monkeypatch.setattr(arch, "_runtime_specs_for_gfx", lambda gfx_id: {})
 
 
-def test_lookup_peaks_returns_structured_data_for_mi300x():
-    peaks = arch.lookup_peaks("gfx942")
-    assert peaks["name"] == "MI300X"
-    assert peaks["peak_fp64_tflops"] == 81.7
-    assert peaks["memory_bandwidth_tbs"] == 5.3
-    assert peaks["max_waves_per_simd"] == 8
-    assert peaks["ridge_point"] == pytest.approx(30.8, rel=0.01)
-    assert peaks["ridge_points"]["fp64"] == pytest.approx(15.4, rel=0.01)
+def _expected_ridge_point(specs, dtype="fp32"):
+    peak_key = arch._RIDGE_PEAK_KEYS.get(dtype, "peak_fp32_tflops")
+    peak_tflops = float(specs.get(peak_key) or specs.get("peak_fp32_tflops") or 0.0)
+    bandwidth_tbs = float(specs.get("memory_bandwidth_tbs") or 0.0)
+    if bandwidth_tbs <= 0:
+        return float(specs.get("ridge_point") or 0.0)
+    return round(peak_tflops / bandwidth_tbs, 1)
 
 
-def test_lookup_peaks_returns_public_mi350x_values_for_gfx950():
-    peaks = arch.lookup_peaks("gfx950")
-    assert peaks["name"] == "MI350X"
-    assert peaks["peak_fp64_tflops"] == pytest.approx(72.1)
-    assert peaks["peak_fp32_tflops"] == pytest.approx(144.2)
-    assert peaks["memory_bandwidth_tbs"] == pytest.approx(8.0)
-    assert peaks["max_waves_per_simd"] == 8
-    assert peaks["ridge_point"] == pytest.approx(18.0, rel=0.01)
+@pytest.mark.parametrize("gfx_id, static_specs", sorted(arch._gpu_specs().items()))
+def test_lookup_peaks_returns_static_specs_for_known_archs(gfx_id, static_specs):
+    peaks = arch.lookup_peaks(gfx_id)
+
+    assert peaks["runtime_discovered"] is False
+    for field in _STATIC_SPEC_FIELDS:
+        assert peaks[field] == static_specs[field]
+        assert peaks["spec_sources"][field] == "gpu_specs.yaml"
+
+    assert peaks["ridge_point"] == pytest.approx(_expected_ridge_point(static_specs))
+    for dtype in arch._RIDGE_PEAK_KEYS:
+        assert peaks["ridge_points"][dtype] == pytest.approx(_expected_ridge_point(static_specs, dtype=dtype))
 
 
 def test_lookup_peaks_exposes_runtime_caps_for_occupancy_users():
-    peaks = arch.lookup_peaks("gfx1100")
-    assert peaks["wave_size"] == 32
-    assert peaks["max_vgprs_per_thread"] == 256
-    assert peaks["vgprs_per_simd"] == 1536
-    assert peaks["simds_per_cu"] == 2
-    assert peaks["max_waves_per_simd"] == 16
+    occupancy_table = arch.occupancy_specs_table()
+    for gfx_id, static_specs in arch._gpu_specs().items():
+        peaks = arch.lookup_peaks(gfx_id)
+
+        for occupancy_field, spec_field in _OCCUPANCY_FIELD_MAP.items():
+            assert occupancy_table[gfx_id][occupancy_field] == int(static_specs[spec_field])
+            assert peaks[spec_field] == static_specs[spec_field]
 
 
 def test_lookup_peaks_covers_all_known_archs():
-    known = ["gfx908", "gfx90a", "gfx942", "gfx950", "gfx1030", "gfx1100"]
-    for gfx in known:
-        result = arch.lookup_peaks(gfx)
-        assert "name" in result
-        assert "peak_fp64_tflops" in result
+    required_fields = {"name", "peak_fp64_tflops"}
+    for gfx_id in arch._gpu_specs():
+        result = arch.lookup_peaks(gfx_id)
+        assert required_fields.issubset(result)
 
 
 def test_lookup_peaks_unknown_arch_raises():
+    unknown_gfx = "__unknown_arch_for_test__"
     with pytest.raises(KeyError) as exc:
-        arch.lookup_peaks("gfx9999")
-    assert "gfx9999" in str(exc.value)
+        arch.lookup_peaks(unknown_gfx)
+    assert unknown_gfx in str(exc.value)
     assert "known" in str(exc.value).lower() or "available" in str(exc.value).lower()
 
 
@@ -87,12 +120,15 @@ def test_lookup_peaks_keeps_static_specs_for_known_archs_by_default(monkeypatch,
 def test_lookup_peaks_prefers_runtime_specs_for_local_init_when_requested(monkeypatch, gfx_id):
     static_specs = arch._gpu_specs()[gfx_id]
     runtime_memory_bandwidth = float(static_specs["memory_bandwidth_tbs"]) + 0.125
+    runtime_cu_count = int(static_specs["cu_count"]) + 1
+    runtime_clock_mhz = 2100
+    runtime_peak_fp32_tflops = float(static_specs["peak_fp32_tflops"]) + 999.0
     runtime = {
         "gfx_id": gfx_id,
         "name": f"Runtime {gfx_id}",
-        "cu_count": int(static_specs["cu_count"]) + 1,
-        "max_sclk_mhz": 2100,
-        "peak_fp32_tflops": float(static_specs["peak_fp32_tflops"]) + 999.0,
+        "cu_count": runtime_cu_count,
+        "max_sclk_mhz": runtime_clock_mhz,
+        "peak_fp32_tflops": runtime_peak_fp32_tflops,
         "memory_bandwidth_tbs": runtime_memory_bandwidth,
         "spec_sources": {
             "name": "rocminfo",
@@ -112,8 +148,8 @@ def test_lookup_peaks_prefers_runtime_specs_for_local_init_when_requested(monkey
 
     assert peaks["runtime_discovered"] is True
     assert peaks["name"] == f"Runtime {gfx_id}"
-    assert peaks["cu_count"] == int(static_specs["cu_count"]) + 1
-    assert peaks["max_sclk_mhz"] == 2100
+    assert peaks["cu_count"] == runtime_cu_count
+    assert peaks["max_sclk_mhz"] == runtime_clock_mhz
     assert peaks["memory_bandwidth_tbs"] == pytest.approx(runtime_memory_bandwidth)
     assert peaks["peak_fp32_tflops"] == static_specs["peak_fp32_tflops"]
     assert peaks["peak_fp64_tflops"] == static_specs["peak_fp64_tflops"]
@@ -124,34 +160,26 @@ def test_lookup_peaks_prefers_runtime_specs_for_local_init_when_requested(monkey
 
 
 def test_lookup_peaks_supports_runtime_only_local_gpu(monkeypatch):
-    cu_count = 32
-    max_sclk_mhz = 3500
-    fp32_ops_per_cu_cycle = 256
-    peak_fp32_tflops = round(cu_count * fp32_ops_per_cu_cycle * max_sclk_mhz / 1_000_000.0, 3)
+    runtime_gfx_id = "gfxlocal"
+    runtime_name = "Runtime GPU"
+    runtime_peak_fp32_tflops = 1.25
+    runtime_peak_fp64_tflops = 0.25
     runtime = {
-        "gfx_id": "gfx1200",
-        "name": "Runtime RDNA",
-        "cu_count": cu_count,
-        "wave_size": 32,
-        "simds_per_cu": 2,
-        "lds_kb": 64,
-        "lds_per_cu_kb": 64,
-        "max_vgprs_per_thread": 256,
-        "vgprs_per_simd": 1536,
-        "max_waves_per_simd": 16,
-        "max_sclk_mhz": max_sclk_mhz,
-        "peak_fp32_tflops": peak_fp32_tflops,
-        "peak_fp64_tflops": peak_fp32_tflops / 32.0,
+        "gfx_id": runtime_gfx_id,
+        "name": runtime_name,
+        "peak_fp32_tflops": runtime_peak_fp32_tflops,
+        "peak_fp64_tflops": runtime_peak_fp64_tflops,
         "memory_bandwidth_tbs": 0.0,
         "spec_sources": {"gfx_id": "rocminfo", "peak_fp32_tflops": "derived-from-runtime-topology"},
     }
-    monkeypatch.setattr(arch, "_runtime_specs_for_gfx", lambda gfx_id: runtime if gfx_id == "gfx1200" else {})
+    monkeypatch.setattr(arch, "_runtime_specs_for_gfx", lambda gfx_id: runtime if gfx_id == runtime_gfx_id else {})
 
-    peaks = arch.lookup_peaks("gfx1200")
+    peaks = arch.lookup_peaks(runtime_gfx_id)
 
     assert peaks["runtime_discovered"] is True
-    assert peaks["name"] == "Runtime RDNA"
-    assert peaks["peak_fp32_tflops"] == pytest.approx(peak_fp32_tflops)
+    assert peaks["name"] == runtime_name
+    assert peaks["peak_fp32_tflops"] == pytest.approx(runtime_peak_fp32_tflops)
+    assert peaks["peak_fp64_tflops"] == pytest.approx(runtime_peak_fp64_tflops)
     assert peaks["ridge_point"] == 0.0
 
 
@@ -165,8 +193,9 @@ def test_lookup_peaks_is_fast_after_runtime_specs_are_cached(monkeypatch):
     import time
 
     monkeypatch.setattr(arch, "_runtime_specs_for_gfx", lambda gfx_id: {})
+    gfx_id = next(iter(arch._gpu_specs()))
     start = time.time()
-    arch.lookup_peaks("gfx942")
+    arch.lookup_peaks(gfx_id)
     duration_ms = (time.time() - start) * 1000
     # Must be fast (< 50ms even on cold YAML load)
     assert duration_ms < 50, f"too slow: {duration_ms}ms"

--- a/experimental/python/perfxpert/tests/test_tools/test_arch.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_arch.py
@@ -6,6 +6,11 @@ from perfxpert.tools import arch
 from perfxpert.tools._class import ToolClass
 
 
+@pytest.fixture(autouse=True)
+def _disable_runtime_discovery(monkeypatch):
+    monkeypatch.setattr(arch, "_runtime_specs_for_gfx", lambda gfx_id: {})
+
+
 def test_lookup_peaks_returns_structured_data_for_mi300x():
     peaks = arch.lookup_peaks("gfx942")
     assert peaks["name"] == "MI300X"
@@ -50,14 +55,84 @@ def test_lookup_peaks_unknown_arch_raises():
     assert "known" in str(exc.value).lower() or "available" in str(exc.value).lower()
 
 
+@pytest.mark.parametrize("gfx_id", sorted(arch._gpu_specs().keys()))
+def test_lookup_peaks_prefers_runtime_specs_for_any_known_local_gpu(monkeypatch, gfx_id):
+    static_specs = arch._gpu_specs()[gfx_id]
+    runtime_memory_bandwidth = float(static_specs["memory_bandwidth_tbs"]) + 0.125
+    runtime = {
+        "gfx_id": gfx_id,
+        "name": f"Runtime {gfx_id}",
+        "cu_count": int(static_specs["cu_count"]) + 1,
+        "max_sclk_mhz": 2100,
+        "peak_fp32_tflops": float(static_specs["peak_fp32_tflops"]) + 999.0,
+        "memory_bandwidth_tbs": runtime_memory_bandwidth,
+        "spec_sources": {
+            "name": "rocminfo",
+            "cu_count": "rocminfo",
+            "max_sclk_mhz": "amd-smi",
+            "peak_fp32_tflops": "derived-from-runtime-topology",
+            "memory_bandwidth_tbs": "amd-smi",
+        },
+    }
+    monkeypatch.setattr(
+        arch,
+        "_runtime_specs_for_gfx",
+        lambda requested: runtime if requested == gfx_id else {},
+    )
+
+    peaks = arch.lookup_peaks(gfx_id)
+
+    assert peaks["runtime_discovered"] is True
+    assert peaks["name"] == f"Runtime {gfx_id}"
+    assert peaks["cu_count"] == int(static_specs["cu_count"]) + 1
+    assert peaks["max_sclk_mhz"] == 2100
+    assert peaks["memory_bandwidth_tbs"] == pytest.approx(runtime_memory_bandwidth)
+    assert peaks["peak_fp32_tflops"] == static_specs["peak_fp32_tflops"]
+    assert peaks["peak_fp64_tflops"] == static_specs["peak_fp64_tflops"]
+    assert peaks["static_fallback_keys"]
+    assert peaks["spec_sources"]["peak_fp32_tflops"] == "gpu_specs.yaml"
+    assert peaks["spec_sources"]["peak_fp64_tflops"] == "gpu_specs.yaml"
+    assert peaks["spec_sources"]["memory_bandwidth_tbs"] == "amd-smi"
+
+
+def test_lookup_peaks_supports_runtime_only_local_gpu(monkeypatch):
+    runtime = {
+        "gfx_id": "gfx1200",
+        "name": "Runtime RDNA",
+        "cu_count": 32,
+        "wave_size": 32,
+        "simds_per_cu": 2,
+        "lds_kb": 64,
+        "lds_per_cu_kb": 64,
+        "max_vgprs_per_thread": 256,
+        "vgprs_per_simd": 1536,
+        "max_waves_per_simd": 16,
+        "max_sclk_mhz": 3500,
+        "peak_fp32_tflops": 28.672,
+        "peak_fp64_tflops": 0.896,
+        "memory_bandwidth_tbs": 0.0,
+        "spec_sources": {"gfx_id": "rocminfo", "peak_fp32_tflops": "derived-from-runtime-topology"},
+    }
+    monkeypatch.setattr(arch, "_runtime_specs_for_gfx", lambda gfx_id: runtime if gfx_id == "gfx1200" else {})
+
+    peaks = arch.lookup_peaks("gfx1200")
+
+    assert peaks["runtime_discovered"] is True
+    assert peaks["name"] == "Runtime RDNA"
+    assert peaks["peak_fp32_tflops"] == pytest.approx(28.672)
+    assert peaks["ridge_point"] == 0.0
+
+
 def test_lookup_peaks_is_read_only_class():
     """MCP exposure policy — lookup tools are READ_ONLY."""
     assert arch.lookup_peaks.__tool_class__ == ToolClass.READ_ONLY
 
 
-def test_lookup_peaks_is_deterministic_no_network():
-    """Pure function — no I/O beyond YAML load."""
+def test_lookup_peaks_is_fast_after_runtime_specs_are_cached(monkeypatch):
+    """Lookup remains cheap once runtime discovery has populated its cache."""
     import time
+
+    monkeypatch.setattr(arch, "_runtime_specs_for_gfx", lambda gfx_id: {})
     start = time.time()
     arch.lookup_peaks("gfx942")
     duration_ms = (time.time() - start) * 1000

--- a/experimental/python/perfxpert/tests/test_tools/test_arch.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_arch.py
@@ -56,7 +56,35 @@ def test_lookup_peaks_unknown_arch_raises():
 
 
 @pytest.mark.parametrize("gfx_id", sorted(arch._gpu_specs().keys()))
-def test_lookup_peaks_prefers_runtime_specs_for_any_known_local_gpu(monkeypatch, gfx_id):
+def test_lookup_peaks_keeps_static_specs_for_known_archs_by_default(monkeypatch, gfx_id):
+    static_specs = arch._gpu_specs()[gfx_id]
+    runtime = {
+        "gfx_id": gfx_id,
+        "name": f"Runtime {gfx_id}",
+        "cu_count": int(static_specs["cu_count"]) + 1,
+        "memory_bandwidth_tbs": float(static_specs["memory_bandwidth_tbs"]) + 0.125,
+        "spec_sources": {
+            "name": "rocminfo",
+            "cu_count": "rocminfo",
+            "memory_bandwidth_tbs": "amd-smi",
+        },
+    }
+    monkeypatch.setattr(
+        arch,
+        "_runtime_specs_for_gfx",
+        lambda requested: runtime if requested == gfx_id else {},
+    )
+
+    peaks = arch.lookup_peaks(gfx_id)
+
+    assert peaks["runtime_discovered"] is False
+    assert peaks["name"] == static_specs["name"]
+    assert peaks["cu_count"] == static_specs["cu_count"]
+    assert peaks["memory_bandwidth_tbs"] == static_specs["memory_bandwidth_tbs"]
+
+
+@pytest.mark.parametrize("gfx_id", sorted(arch._gpu_specs().keys()))
+def test_lookup_peaks_prefers_runtime_specs_for_local_init_when_requested(monkeypatch, gfx_id):
     static_specs = arch._gpu_specs()[gfx_id]
     runtime_memory_bandwidth = float(static_specs["memory_bandwidth_tbs"]) + 0.125
     runtime = {
@@ -80,7 +108,7 @@ def test_lookup_peaks_prefers_runtime_specs_for_any_known_local_gpu(monkeypatch,
         lambda requested: runtime if requested == gfx_id else {},
     )
 
-    peaks = arch.lookup_peaks(gfx_id)
+    peaks = arch.lookup_peaks(gfx_id, prefer_runtime=True)
 
     assert peaks["runtime_discovered"] is True
     assert peaks["name"] == f"Runtime {gfx_id}"
@@ -96,10 +124,14 @@ def test_lookup_peaks_prefers_runtime_specs_for_any_known_local_gpu(monkeypatch,
 
 
 def test_lookup_peaks_supports_runtime_only_local_gpu(monkeypatch):
+    cu_count = 32
+    max_sclk_mhz = 3500
+    fp32_ops_per_cu_cycle = 256
+    peak_fp32_tflops = round(cu_count * fp32_ops_per_cu_cycle * max_sclk_mhz / 1_000_000.0, 3)
     runtime = {
         "gfx_id": "gfx1200",
         "name": "Runtime RDNA",
-        "cu_count": 32,
+        "cu_count": cu_count,
         "wave_size": 32,
         "simds_per_cu": 2,
         "lds_kb": 64,
@@ -107,9 +139,9 @@ def test_lookup_peaks_supports_runtime_only_local_gpu(monkeypatch):
         "max_vgprs_per_thread": 256,
         "vgprs_per_simd": 1536,
         "max_waves_per_simd": 16,
-        "max_sclk_mhz": 3500,
-        "peak_fp32_tflops": 28.672,
-        "peak_fp64_tflops": 0.896,
+        "max_sclk_mhz": max_sclk_mhz,
+        "peak_fp32_tflops": peak_fp32_tflops,
+        "peak_fp64_tflops": peak_fp32_tflops / 32.0,
         "memory_bandwidth_tbs": 0.0,
         "spec_sources": {"gfx_id": "rocminfo", "peak_fp32_tflops": "derived-from-runtime-topology"},
     }
@@ -119,7 +151,7 @@ def test_lookup_peaks_supports_runtime_only_local_gpu(monkeypatch):
 
     assert peaks["runtime_discovered"] is True
     assert peaks["name"] == "Runtime RDNA"
-    assert peaks["peak_fp32_tflops"] == pytest.approx(28.672)
+    assert peaks["peak_fp32_tflops"] == pytest.approx(peak_fp32_tflops)
     assert peaks["ridge_point"] == 0.0
 
 

--- a/experimental/python/perfxpert/tests/test_tools/test_counters.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_counters.py
@@ -2,14 +2,22 @@
 
 import pytest
 
+from perfxpert.knowledge import load_yaml
 from perfxpert.tools import counters
 from perfxpert.tools._class import ToolClass
 
 
+def _arch_with_limit_for(block: str, needed: int = 1) -> str:
+    arch_limits = load_yaml("pmc_limits")["per_block_limits"][block]["arch_limits"]
+    return next(gfx_id for gfx_id, limit in arch_limits.items() if limit >= needed)
+
+
 def test_lookup_info_known_counter():
-    info = counters.lookup_info("SQ_WAVES")
+    gfx_id = _arch_with_limit_for("SQ")
+    info = counters.lookup_info("SQ_WAVES", gfx_id=gfx_id)
     assert info["name"] == "SQ_WAVES"
     assert info["block"] == "SQ"
+    assert info["block_limit"] == load_yaml("pmc_limits")["per_block_limits"]["SQ"]["arch_limits"][gfx_id]
 
 
 def test_lookup_info_unknown_raises():
@@ -21,7 +29,7 @@ def test_validate_splits_tcc_derived_into_own_passes():
     """FETCH_SIZE + WRITE_SIZE must each be in their own pass (anti-Sakana)."""
     result = counters.validate_for_gpu(
         ["SQ_WAVES", "GRBM_COUNT", "FETCH_SIZE", "WRITE_SIZE"],
-        gpu_arch="gfx942",
+        gpu_arch=_arch_with_limit_for("SQ"),
     )
     assert result["ok"]
     # FETCH_SIZE and WRITE_SIZE must be in separate passes
@@ -36,7 +44,7 @@ def test_validate_multi_pass_returns_escalation_guidance():
     """Multi-pass plans must include concrete escalation guidance."""
     result = counters.validate_for_gpu(
         ["SQ_WAVES", "GRBM_COUNT", "FETCH_SIZE", "WRITE_SIZE"],
-        gpu_arch="gfx942",
+        gpu_arch=_arch_with_limit_for("SQ"),
     )
 
     escalation = result["escalation"]
@@ -57,10 +65,42 @@ def test_validate_single_pass_does_not_emit_escalation():
     """Single-pass plans should remain simple and omit escalation."""
     result = counters.validate_for_gpu(
         ["SQ_WAVES", "GRBM_COUNT"],
-        gpu_arch="gfx942",
+        gpu_arch=_arch_with_limit_for("SQ"),
     )
     assert result["fixed_passes"] == [["SQ_WAVES", "GRBM_COUNT"]]
     assert result["escalation"] is None
+
+
+def test_validate_for_gpu_uses_arch_specific_regular_block_limit():
+    catalog = load_yaml("counter_catalog")
+    sq_counters = [entry["name"] for entry in catalog if entry["block"] == "SQ"]
+    gfx_id = _arch_with_limit_for("SQ", needed=len(sq_counters))
+
+    result = counters.validate_for_gpu(sq_counters, gpu_arch=gfx_id)
+
+    assert result["fixed_passes"] == [sq_counters]
+    assert result["escalation"] is None
+
+
+def test_analysis_pmc_split_uses_same_arch_specific_limit():
+    from perfxpert.analysis.pmc import _split_pmc_into_passes
+
+    catalog = load_yaml("counter_catalog")
+    sq_counters = [entry["name"] for entry in catalog if entry["block"] == "SQ"]
+    gfx_id = _arch_with_limit_for("SQ", needed=len(sq_counters))
+
+    commands = _split_pmc_into_passes(
+        sq_counters,
+        base_flags=[],
+        base_args=[],
+        output_dir="./out",
+        output_prefix="profile",
+        description="Collect counters",
+        gpu_arch=gfx_id,
+    )
+
+    assert [arg["value"] for arg in commands[0]["args"] if arg["name"] == "--pmc"] == [" ".join(sq_counters)]
+    assert len(commands) == 1
 
 
 def test_is_read_only_class():

--- a/experimental/python/perfxpert/tests/test_tools/test_gpu_discovery.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_gpu_discovery.py
@@ -10,7 +10,17 @@ from perfxpert.tools import gpu_discovery
 from perfxpert.tools._class import ToolClass
 
 
-def _rocminfo_sample(gfx_id: str = "gfx1200") -> str:
+def _rocminfo_sample(
+    gfx_id: str = "gfx1200",
+    *,
+    node_id: int = 1,
+    max_sclk_mhz: int = 3500,
+    cu_count: int = 32,
+    simds_per_cu: int = 2,
+    wave_size: int = 32,
+    max_waves_per_cu: int = 32,
+    lds_kb: int = 64,
+) -> str:
     return f"""
 *******
 Agent 2
@@ -20,16 +30,16 @@ Agent 2
   Marketing Name:          AMD Radeon Graphics
   Vendor Name:             AMD
   Device Type:             GPU
-  Node:                    1
-  Max Clock Freq. (MHz):   3500
-  Compute Unit:            32
-  SIMDs per CU:            2
-  Wavefront Size:          32(0x20)
-  Max Waves Per CU:        32(0x20)
+  Node:                    {node_id}
+  Max Clock Freq. (MHz):   {max_sclk_mhz}
+  Compute Unit:            {cu_count}
+  SIMDs per CU:            {simds_per_cu}
+  Wavefront Size:          {wave_size}(0x{wave_size:x})
+  Max Waves Per CU:        {max_waves_per_cu}(0x{max_waves_per_cu:x})
   Pool Info:
     Pool 2
       Segment:                 GROUP
-      Size:                    64(0x40) KB
+      Size:                    {lds_kb}(0x{lds_kb:x}) KB
 """
 
 
@@ -50,12 +60,21 @@ def test_discover_runtime_gpu_specs_is_read_only() -> None:
 
 def test_discover_runtime_gpu_specs_merges_rocm_tools(monkeypatch) -> None:
     gfx_id = "gfx1200"
+    topology = {
+        "node_id": 1,
+        "cu_count": 32,
+        "wave_size": 32,
+        "simds_per_cu": 2,
+        "max_waves_per_cu": 32,
+        "max_sclk_mhz": 3500,
+    }
+    vram_total_bytes = 8539602944
     rocm_smi_info = {
         "card0": {
-            "Node ID": "1",
+            "Node ID": str(topology["node_id"]),
             "GFX Version": gfx_id,
             "Card Series": "AMD Radeon Graphics",
-            "VRAM Total Memory (B)": "8539602944",
+            "VRAM Total Memory (B)": str(vram_total_bytes),
         }
     }
     rocm_smi_clocks = {
@@ -67,7 +86,7 @@ def test_discover_runtime_gpu_specs_merges_rocm_tools(monkeypatch) -> None:
     amd_smi_list = [
         {
             "gpu": 0,
-            "node_id": 1,
+            "node_id": topology["node_id"],
             "bdf": "0000:0c:00.0",
             "uuid": "c2ff748f-0000-1000-8017-1ff77417f1d6",
         }
@@ -77,7 +96,7 @@ def test_discover_runtime_gpu_specs_merges_rocm_tools(monkeypatch) -> None:
             {
                 "gpu": 0,
                 "clock": {
-                    "gfx_0": {"max_clk": {"value": 3500, "unit": "MHz"}},
+                    "gfx_0": {"max_clk": {"value": topology["max_sclk_mhz"], "unit": "MHz"}},
                     "mem_0": {"max_clk": {"value": 1258, "unit": "MHz"}},
                 },
                 "mem_usage": {
@@ -89,7 +108,7 @@ def test_discover_runtime_gpu_specs_merges_rocm_tools(monkeypatch) -> None:
 
     def _fake_run(argv):
         if argv == ["rocminfo"]:
-            return _rocminfo_sample(gfx_id)
+            return _rocminfo_sample(gfx_id, **topology)
         if argv == ["rocm-smi", "--showproductname", "--showmeminfo", "vram", "--json"]:
             return json.dumps(rocm_smi_info)
         if argv == ["rocm-smi", "--showclocks", "--showclkfrq", "--json"]:
@@ -112,12 +131,12 @@ def test_discover_runtime_gpu_specs_merges_rocm_tools(monkeypatch) -> None:
 
     gpu = result["gpus"][0]
     assert gpu["gfx_id"] == gfx_id
-    assert gpu["cu_count"] == 32
-    assert gpu["wave_size"] == 32
-    assert gpu["max_waves_per_simd"] == 16
-    assert gpu["max_sclk_mhz"] == 3500
-    assert gpu["vram_total_bytes"] == 8539602944
-    assert gpu["peak_fp32_tflops"] == pytest.approx(28.672)
+    assert gpu["cu_count"] == topology["cu_count"]
+    assert gpu["wave_size"] == topology["wave_size"]
+    assert gpu["max_waves_per_simd"] == topology["max_waves_per_cu"] // topology["simds_per_cu"]
+    assert gpu["max_sclk_mhz"] == topology["max_sclk_mhz"]
+    assert gpu["vram_total_bytes"] == vram_total_bytes
+    assert gpu["peak_fp32_tflops"] > 0
     assert gpu["spec_sources"]["cu_count"] == "rocminfo"
 
 
@@ -135,6 +154,27 @@ def test_discover_runtime_gpu_specs_filters_by_gfx(monkeypatch, gfx_id: str) -> 
     assert gpu_discovery.discover_runtime_gpu_specs("gfx9999")["gpus"] == []
 
 
+def test_merge_gpu_lists_preserves_same_arch_devices_with_distinct_nodes() -> None:
+    gfx_id = "gfx9999"
+    node_ids = [1, 2]
+
+    merged = gpu_discovery._merge_gpu_lists(
+        [
+            [
+                {
+                    "node_id": node_id,
+                    "gfx_id": gfx_id,
+                    "spec_sources": {"node_id": "rocminfo", "gfx_id": "rocminfo"},
+                }
+                for node_id in node_ids
+            ]
+        ]
+    )
+
+    assert [gpu["node_id"] for gpu in merged] == node_ids
+    assert all(gpu["gfx_id"] == gfx_id for gpu in merged)
+
+
 def test_discover_runtime_gpu_specs_can_be_disabled(monkeypatch) -> None:
     monkeypatch.setenv(gpu_discovery.PERFXPERT_DISABLE_RUNTIME_GPU_SPECS, "1")
     _clear_cache()
@@ -149,41 +189,36 @@ def test_parse_kfd_topology_supplies_rocminfo_fallback_fields(tmp_path, gfx_id: 
     node = tmp_path / "1"
     mem = node / "mem_banks" / "0"
     mem.mkdir(parents=True)
+    props = {
+        "simd_count": 64,
+        "max_waves_per_simd": 16,
+        "lds_size_in_kb": 64,
+        "wave_front_size": 32,
+        "simd_per_cu": 2,
+        "max_engine_clk_fcompute": 3500,
+    }
+    mem_props = {
+        "heap_type": 1,
+        "size_in_bytes": 8539602944,
+        "width": 128,
+        "mem_clk_max": 1258,
+    }
     (node / "name").write_text(f"{gfx_id}\n")
-    (node / "properties").write_text(
-        "\n".join(
-            [
-                "simd_count 64",
-                "max_waves_per_simd 16",
-                "lds_size_in_kb 64",
-                "wave_front_size 32",
-                "simd_per_cu 2",
-                "max_engine_clk_fcompute 3500",
-            ]
-        )
-    )
-    (mem / "properties").write_text(
-        "\n".join(
-            [
-                "heap_type 1",
-                "size_in_bytes 8539602944",
-                "width 128",
-                "mem_clk_max 1258",
-            ]
-        )
-    )
+    (node / "properties").write_text("\n".join(f"{key} {value}" for key, value in props.items()))
+    (mem / "properties").write_text("\n".join(f"{key} {value}" for key, value in mem_props.items()))
 
     result = gpu_discovery._parse_kfd_topology(tmp_path)
 
     assert len(result) == 1
     gpu = result[0]
     assert gpu["gfx_id"] == gfx_id
-    assert gpu["cu_count"] == 32
-    assert gpu["max_waves_per_simd"] == 16
-    assert gpu["lds_kb"] == 64
-    assert gpu["wave_size"] == 32
-    assert gpu["max_sclk_mhz"] == 3500
-    assert gpu["vram_total_bytes"] == 8539602944
-    assert gpu["memory_bandwidth_tbs"] == pytest.approx(0.04)
+    assert gpu["cu_count"] == props["simd_count"] // props["simd_per_cu"]
+    assert gpu["max_waves_per_simd"] == props["max_waves_per_simd"]
+    assert gpu["lds_kb"] == props["lds_size_in_kb"]
+    assert gpu["wave_size"] == props["wave_front_size"]
+    assert gpu["max_sclk_mhz"] == props["max_engine_clk_fcompute"]
+    assert gpu["vram_total_bytes"] == mem_props["size_in_bytes"]
+    expected_bandwidth = mem_props["width"] / 8.0 * mem_props["mem_clk_max"] * 2.0 / 1_000_000.0
+    assert gpu["memory_bandwidth_tbs"] == pytest.approx(round(expected_bandwidth, 3))
     assert gpu["spec_sources"]["cu_count"] == "kfd-topology"
     assert gpu["spec_sources"]["memory_bandwidth_tbs"] == "derived-from-kfd-topology"

--- a/experimental/python/perfxpert/tests/test_tools/test_gpu_discovery.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_gpu_discovery.py
@@ -1,0 +1,189 @@
+"""Tests for runtime GPU discovery."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from perfxpert.tools import gpu_discovery
+from perfxpert.tools._class import ToolClass
+
+
+def _rocminfo_sample(gfx_id: str = "gfx1200") -> str:
+    return f"""
+*******
+Agent 2
+*******
+  Name:                    {gfx_id}
+  Uuid:                    GPU-c2171ff77417f1d6
+  Marketing Name:          AMD Radeon Graphics
+  Vendor Name:             AMD
+  Device Type:             GPU
+  Node:                    1
+  Max Clock Freq. (MHz):   3500
+  Compute Unit:            32
+  SIMDs per CU:            2
+  Wavefront Size:          32(0x20)
+  Max Waves Per CU:        32(0x20)
+  Pool Info:
+    Pool 2
+      Segment:                 GROUP
+      Size:                    64(0x40) KB
+"""
+
+
+def _clear_cache() -> None:
+    gpu_discovery._discover_runtime_gpu_specs_cached.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_discovery_cache():
+    _clear_cache()
+    yield
+    _clear_cache()
+
+
+def test_discover_runtime_gpu_specs_is_read_only() -> None:
+    assert gpu_discovery.discover_runtime_gpu_specs.__tool_class__ == ToolClass.READ_ONLY
+
+
+def test_discover_runtime_gpu_specs_merges_rocm_tools(monkeypatch) -> None:
+    gfx_id = "gfx1200"
+    rocm_smi_info = {
+        "card0": {
+            "Node ID": "1",
+            "GFX Version": gfx_id,
+            "Card Series": "AMD Radeon Graphics",
+            "VRAM Total Memory (B)": "8539602944",
+        }
+    }
+    rocm_smi_clocks = {
+        "card0": {
+            "sclk clock speed:": "(500Mhz)",
+            "mclk clock speed:": "(1258Mhz)",
+        }
+    }
+    amd_smi_list = [
+        {
+            "gpu": 0,
+            "node_id": 1,
+            "bdf": "0000:0c:00.0",
+            "uuid": "c2ff748f-0000-1000-8017-1ff77417f1d6",
+        }
+    ]
+    amd_smi_metric = {
+        "gpu_data": [
+            {
+                "gpu": 0,
+                "clock": {
+                    "gfx_0": {"max_clk": {"value": 3500, "unit": "MHz"}},
+                    "mem_0": {"max_clk": {"value": 1258, "unit": "MHz"}},
+                },
+                "mem_usage": {
+                    "total_vram": {"value": 8144, "unit": "MB"},
+                },
+            }
+        ]
+    }
+
+    def _fake_run(argv):
+        if argv == ["rocminfo"]:
+            return _rocminfo_sample(gfx_id)
+        if argv == ["rocm-smi", "--showproductname", "--showmeminfo", "vram", "--json"]:
+            return json.dumps(rocm_smi_info)
+        if argv == ["rocm-smi", "--showclocks", "--showclkfrq", "--json"]:
+            return json.dumps(rocm_smi_clocks)
+        if argv == ["amd-smi", "list", "--json"]:
+            return json.dumps(amd_smi_list)
+        if argv == ["amd-smi", "static", "--json"]:
+            return json.dumps({"gpu_data": [{"gpu": 0}]})
+        if argv == ["amd-smi", "metric", "--json"]:
+            return json.dumps(amd_smi_metric)
+        return None
+
+    monkeypatch.setattr(gpu_discovery, "_run_command", _fake_run)
+    monkeypatch.setattr(gpu_discovery, "_parse_kfd_topology", lambda: [])
+    _clear_cache()
+
+    result = gpu_discovery.discover_runtime_gpu_specs()
+    assert result["source"] == ["rocminfo", "rocm-smi", "amd-smi"]
+    assert len(result["gpus"]) == 1
+
+    gpu = result["gpus"][0]
+    assert gpu["gfx_id"] == gfx_id
+    assert gpu["cu_count"] == 32
+    assert gpu["wave_size"] == 32
+    assert gpu["max_waves_per_simd"] == 16
+    assert gpu["max_sclk_mhz"] == 3500
+    assert gpu["vram_total_bytes"] == 8539602944
+    assert gpu["peak_fp32_tflops"] == pytest.approx(28.672)
+    assert gpu["spec_sources"]["cu_count"] == "rocminfo"
+
+
+@pytest.mark.parametrize("gfx_id", ["gfx942", "gfx1200"])
+def test_discover_runtime_gpu_specs_filters_by_gfx(monkeypatch, gfx_id: str) -> None:
+    monkeypatch.setattr(
+        gpu_discovery,
+        "_run_command",
+        lambda argv: _rocminfo_sample(gfx_id) if argv == ["rocminfo"] else None,
+    )
+    monkeypatch.setattr(gpu_discovery, "_parse_kfd_topology", lambda: [])
+    _clear_cache()
+
+    assert gpu_discovery.discover_runtime_gpu_specs(gfx_id)["gpus"]
+    assert gpu_discovery.discover_runtime_gpu_specs("gfx9999")["gpus"] == []
+
+
+def test_discover_runtime_gpu_specs_can_be_disabled(monkeypatch) -> None:
+    monkeypatch.setenv(gpu_discovery.PERFXPERT_DISABLE_RUNTIME_GPU_SPECS, "1")
+    _clear_cache()
+
+    result = gpu_discovery.discover_runtime_gpu_specs()
+    assert result["gpus"] == []
+    assert "disabled" in result["errors"][0]
+
+
+@pytest.mark.parametrize("gfx_id", ["gfx908", "gfx942", "gfx1200", "gfx9999"])
+def test_parse_kfd_topology_supplies_rocminfo_fallback_fields(tmp_path, gfx_id: str) -> None:
+    node = tmp_path / "1"
+    mem = node / "mem_banks" / "0"
+    mem.mkdir(parents=True)
+    (node / "name").write_text(f"{gfx_id}\n")
+    (node / "properties").write_text(
+        "\n".join(
+            [
+                "simd_count 64",
+                "max_waves_per_simd 16",
+                "lds_size_in_kb 64",
+                "wave_front_size 32",
+                "simd_per_cu 2",
+                "max_engine_clk_fcompute 3500",
+            ]
+        )
+    )
+    (mem / "properties").write_text(
+        "\n".join(
+            [
+                "heap_type 1",
+                "size_in_bytes 8539602944",
+                "width 128",
+                "mem_clk_max 1258",
+            ]
+        )
+    )
+
+    result = gpu_discovery._parse_kfd_topology(tmp_path)
+
+    assert len(result) == 1
+    gpu = result[0]
+    assert gpu["gfx_id"] == gfx_id
+    assert gpu["cu_count"] == 32
+    assert gpu["max_waves_per_simd"] == 16
+    assert gpu["lds_kb"] == 64
+    assert gpu["wave_size"] == 32
+    assert gpu["max_sclk_mhz"] == 3500
+    assert gpu["vram_total_bytes"] == 8539602944
+    assert gpu["memory_bandwidth_tbs"] == pytest.approx(0.04)
+    assert gpu["spec_sources"]["cu_count"] == "kfd-topology"
+    assert gpu["spec_sources"]["memory_bandwidth_tbs"] == "derived-from-kfd-topology"

--- a/experimental/python/perfxpert/tests/test_tools/test_gpu_discovery.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_gpu_discovery.py
@@ -10,16 +10,19 @@ from perfxpert.tools import gpu_discovery
 from perfxpert.tools._class import ToolClass
 
 
+_SYNTHETIC_GFX_IDS = ("gfxabc", "gfxdef", "gfxghi", "gfxjkl")
+
+
 def _rocminfo_sample(
-    gfx_id: str = "gfx1200",
+    gfx_id: str = _SYNTHETIC_GFX_IDS[0],
     *,
     node_id: int = 1,
-    max_sclk_mhz: int = 3500,
-    cu_count: int = 32,
-    simds_per_cu: int = 2,
-    wave_size: int = 32,
-    max_waves_per_cu: int = 32,
-    lds_kb: int = 64,
+    max_sclk_mhz: int = 1234,
+    cu_count: int = 12,
+    simds_per_cu: int = 3,
+    wave_size: int = 16,
+    max_waves_per_cu: int = 24,
+    lds_kb: int = 48,
 ) -> str:
     return f"""
 *******
@@ -27,7 +30,7 @@ Agent 2
 *******
   Name:                    {gfx_id}
   Uuid:                    GPU-c2171ff77417f1d6
-  Marketing Name:          AMD Radeon Graphics
+  Marketing Name:          Synthetic GPU
   Vendor Name:             AMD
   Device Type:             GPU
   Node:                    {node_id}
@@ -59,28 +62,32 @@ def test_discover_runtime_gpu_specs_is_read_only() -> None:
 
 
 def test_discover_runtime_gpu_specs_merges_rocm_tools(monkeypatch) -> None:
-    gfx_id = "gfx1200"
+    gfx_id = _SYNTHETIC_GFX_IDS[0]
     topology = {
         "node_id": 1,
-        "cu_count": 32,
-        "wave_size": 32,
-        "simds_per_cu": 2,
-        "max_waves_per_cu": 32,
-        "max_sclk_mhz": 3500,
+        "cu_count": 12,
+        "wave_size": 16,
+        "simds_per_cu": 3,
+        "max_waves_per_cu": 24,
+        "max_sclk_mhz": 1234,
     }
-    vram_total_bytes = 8539602944
+    vram_total_bytes = 123456789
+    rocm_smi_sclk_mhz = 321
+    rocm_smi_mclk_mhz = 654
+    amd_smi_mem_clk_mhz = 987
+    amd_smi_total_vram_mb = 765
     rocm_smi_info = {
         "card0": {
             "Node ID": str(topology["node_id"]),
             "GFX Version": gfx_id,
-            "Card Series": "AMD Radeon Graphics",
+            "Card Series": "Synthetic GPU",
             "VRAM Total Memory (B)": str(vram_total_bytes),
         }
     }
     rocm_smi_clocks = {
         "card0": {
-            "sclk clock speed:": "(500Mhz)",
-            "mclk clock speed:": "(1258Mhz)",
+            "sclk clock speed:": f"({rocm_smi_sclk_mhz}Mhz)",
+            "mclk clock speed:": f"({rocm_smi_mclk_mhz}Mhz)",
         }
     }
     amd_smi_list = [
@@ -97,10 +104,10 @@ def test_discover_runtime_gpu_specs_merges_rocm_tools(monkeypatch) -> None:
                 "gpu": 0,
                 "clock": {
                     "gfx_0": {"max_clk": {"value": topology["max_sclk_mhz"], "unit": "MHz"}},
-                    "mem_0": {"max_clk": {"value": 1258, "unit": "MHz"}},
+                    "mem_0": {"max_clk": {"value": amd_smi_mem_clk_mhz, "unit": "MHz"}},
                 },
                 "mem_usage": {
-                    "total_vram": {"value": 8144, "unit": "MB"},
+                    "total_vram": {"value": amd_smi_total_vram_mb, "unit": "MB"},
                 },
             }
         ]
@@ -136,11 +143,10 @@ def test_discover_runtime_gpu_specs_merges_rocm_tools(monkeypatch) -> None:
     assert gpu["max_waves_per_simd"] == topology["max_waves_per_cu"] // topology["simds_per_cu"]
     assert gpu["max_sclk_mhz"] == topology["max_sclk_mhz"]
     assert gpu["vram_total_bytes"] == vram_total_bytes
-    assert gpu["peak_fp32_tflops"] > 0
     assert gpu["spec_sources"]["cu_count"] == "rocminfo"
 
 
-@pytest.mark.parametrize("gfx_id", ["gfx942", "gfx1200"])
+@pytest.mark.parametrize("gfx_id", _SYNTHETIC_GFX_IDS[:2])
 def test_discover_runtime_gpu_specs_filters_by_gfx(monkeypatch, gfx_id: str) -> None:
     monkeypatch.setattr(
         gpu_discovery,
@@ -151,11 +157,11 @@ def test_discover_runtime_gpu_specs_filters_by_gfx(monkeypatch, gfx_id: str) -> 
     _clear_cache()
 
     assert gpu_discovery.discover_runtime_gpu_specs(gfx_id)["gpus"]
-    assert gpu_discovery.discover_runtime_gpu_specs("gfx9999")["gpus"] == []
+    assert gpu_discovery.discover_runtime_gpu_specs(_SYNTHETIC_GFX_IDS[2])["gpus"] == []
 
 
 def test_merge_gpu_lists_preserves_same_arch_devices_with_distinct_nodes() -> None:
-    gfx_id = "gfx9999"
+    gfx_id = _SYNTHETIC_GFX_IDS[0]
     node_ids = [1, 2]
 
     merged = gpu_discovery._merge_gpu_lists(
@@ -184,24 +190,24 @@ def test_discover_runtime_gpu_specs_can_be_disabled(monkeypatch) -> None:
     assert "disabled" in result["errors"][0]
 
 
-@pytest.mark.parametrize("gfx_id", ["gfx908", "gfx942", "gfx1200", "gfx9999"])
+@pytest.mark.parametrize("gfx_id", _SYNTHETIC_GFX_IDS)
 def test_parse_kfd_topology_supplies_rocminfo_fallback_fields(tmp_path, gfx_id: str) -> None:
     node = tmp_path / "1"
     mem = node / "mem_banks" / "0"
     mem.mkdir(parents=True)
     props = {
-        "simd_count": 64,
-        "max_waves_per_simd": 16,
-        "lds_size_in_kb": 64,
-        "wave_front_size": 32,
-        "simd_per_cu": 2,
-        "max_engine_clk_fcompute": 3500,
+        "simd_count": 12,
+        "max_waves_per_simd": 8,
+        "lds_size_in_kb": 48,
+        "wave_front_size": 16,
+        "simd_per_cu": 3,
+        "max_engine_clk_fcompute": 1234,
     }
     mem_props = {
         "heap_type": 1,
-        "size_in_bytes": 8539602944,
-        "width": 128,
-        "mem_clk_max": 1258,
+        "size_in_bytes": 123456789,
+        "width": 96,
+        "mem_clk_max": 789,
     }
     (node / "name").write_text(f"{gfx_id}\n")
     (node / "properties").write_text("\n".join(f"{key} {value}" for key, value in props.items()))
@@ -218,7 +224,12 @@ def test_parse_kfd_topology_supplies_rocminfo_fallback_fields(tmp_path, gfx_id: 
     assert gpu["wave_size"] == props["wave_front_size"]
     assert gpu["max_sclk_mhz"] == props["max_engine_clk_fcompute"]
     assert gpu["vram_total_bytes"] == mem_props["size_in_bytes"]
-    expected_bandwidth = mem_props["width"] / 8.0 * mem_props["mem_clk_max"] * 2.0 / 1_000_000.0
+    bits_per_byte = 8
+    transfers_per_clock = 2
+    mhz_bytes_to_tbs = 1_000_000
+    expected_bandwidth = (
+        mem_props["width"] / bits_per_byte * mem_props["mem_clk_max"] * transfers_per_clock / mhz_bytes_to_tbs
+    )
     assert gpu["memory_bandwidth_tbs"] == pytest.approx(round(expected_bandwidth, 3))
     assert gpu["spec_sources"]["cu_count"] == "kfd-topology"
     assert gpu["spec_sources"]["memory_bandwidth_tbs"] == "derived-from-kfd-topology"


### PR DESCRIPTION
## Summary
- add runtime GPU discovery from rocminfo, rocm-smi, amd-smi, and read-only KFD topology fallback
- prefer discovered local GPU facts in arch.lookup_peaks while keeping gpu_specs.yaml as the offline/static fallback
- wire perfxpert init to the shared discovery path and document runtime discovery behavior
- clarify SSH optimization semantics: discovery must describe the remote execution host, not the local controller, and agents should disable local runtime specs when the controller GPU is not the target GPU

## Review follow-up
- fixed the sandboxed Python path where rocminfo cannot open /dev/kfd by parsing /sys/class/kfd/kfd/topology/nodes for gfx id, CU count, clocks, wave size, LDS, VRAM, and memory clock data
- preserved catalog peak values when a runtime value is derived rather than directly reported
- added prompt/docs coverage for remote-host optimization flows so rocminfo, rocm-smi, and amd-smi are run on the SSH target host after the PerfXpert gate

## Validation
- custom-ai-secret-scan --repo-root /home/aelwazir/work/.worktrees/perfxpert-runtime-gpu-specs <changed files>
- PYTHONPATH=experimental/python/perfxpert python3 -m pytest experimental/python/perfxpert/tests/test_cli/test_backend/test_remote_gpu_prompt.py experimental/python/perfxpert/tests/test_tools/test_gpu_discovery.py experimental/python/perfxpert/tests/test_tools/test_arch.py experimental/python/perfxpert/tests/test_tools/test_gpu_runtime_monitor.py experimental/python/perfxpert/tests/test_cli/test_init_cmd.py experimental/python/perfxpert/tests/test_integration/test_mcp_exposure.py
- PYTHONPATH=experimental/python/perfxpert python3 -m compileall experimental/python/perfxpert/perfxpert/tools/gpu_discovery.py experimental/python/perfxpert/perfxpert/tools/arch.py experimental/python/perfxpert/perfxpert/tools/gpu_runtime_monitor.py experimental/python/perfxpert/perfxpert/cli/init_cmd.py experimental/python/perfxpert/perfxpert/cli/_backend/codex.py
- PYTHONPATH=experimental/python/perfxpert python3 -m flake8 --max-line-length=120 experimental/python/perfxpert/perfxpert/tools/gpu_discovery.py experimental/python/perfxpert/perfxpert/tools/arch.py experimental/python/perfxpert/tests/test_tools/test_gpu_discovery.py experimental/python/perfxpert/tests/test_cli/test_backend/test_remote_gpu_prompt.py
- PYTHONPATH=experimental/python/perfxpert python3 -m perfxpert init --non-interactive --config-path /tmp/perfxpert-runtime-gpu-specs-config-remote-validate.yaml
- live lookup_peaks probe: gfx1200 => 32 CU, 28.672 FP32 TFLOPS; gfx1101 => 36 CU, 18.432 FP32 TFLOPS
- git diff --check