### PR TITLE
[rocprofiler-compute] Migrate CSV output to database workflow

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -57,10 +57,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Changed
 
-* `--output-format csv` in analyze mode now uses the database analysis workflow.
-  * CSV output produces a folder (`rocprof_compute_<uuid>/` by default, or `<output_name>/` when `--output-name` is set) containing one CSV file per view defined in the analysis database schema (e.g. `kernel.csv`, `kernel_metric.csv`, `workload_metric.csv`).
-  * CSV output now requires rocpd profiling format (same requirement as database output): profile with `--format-rocprof-output rocpd`.
-  * `--output-format csv` no longer prints the analysis report to the terminal (matches the existing `db` format behavior).
+* `--output-format csv` in analyze mode now uses the database analysis workflow and produces one CSV per analysis view. Requires `--format-rocprof-output rocpd` and no longer prints the report to the terminal (matching `db` format).
 
 * Standalone roofline (`--roof-only` option) in profile mode now creates `roofline.csv` only. HTML roofline charts are generated via `rocprof-compute analyze`. The `calc_ai_profile()` function has been removed; `calc_ai_analyze()` is the single source of truth for arithmetic intensity calculation.
   * Roofline visualization options (`--sort`, `--mem-level`, `--roofline-data-type`) have moved from profile mode to analyze mode.

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -57,6 +57,11 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Changed
 
+* `--output-format csv` in analyze mode now uses the database analysis workflow.
+  * CSV output produces a folder (`rocprof_compute_<uuid>/` by default, or `<output_name>/` when `--output-name` is set) containing one CSV file per view defined in the analysis database schema (e.g. `kernel.csv`, `kernel_metric.csv`, `workload_metric.csv`).
+  * CSV output now requires rocpd profiling format (same requirement as database output): profile with `--format-rocprof-output rocpd`.
+  * `--output-format csv` no longer prints the analysis report to the terminal (matches the existing `db` format behavior).
+
 * Standalone roofline (`--roof-only` option) in profile mode now creates `roofline.csv` only. HTML roofline charts are generated via `rocprof-compute analyze`. The `calc_ai_profile()` function has been removed; `calc_ai_analyze()` is the single source of truth for arithmetic intensity calculation.
   * Roofline visualization options (`--sort`, `--mem-level`, `--roofline-data-type`) have moved from profile mode to analyze mode.
 

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -11,6 +11,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Changed
 
+* `--output-format csv` in analyze mode now uses the database analysis workflow and produces one CSV per analysis view. Requires `--format-rocprof-output rocpd` and no longer prints the report to the terminal (matching `db` format).
+
 * Changed ratio metric aggregation from `AVG(A/B)` (arithmetic mean of per-dispatch ratios) to `SUM(A)/SUM(B)` (ratio of totals) across all analysis YAML configurations and all GPU architectures. `SUM(A)/SUM(B)` is a weighted average where each dispatch contributes proportionally to its denominator magnitude (duration, access count, cycle count). Single-dispatch workloads are unaffected (mathematically identical). Multi-dispatch workloads with different kernels or varying durations will see corrected values.
 
 * Added operator statistics and per-operator summary table in the analysis output of torch operators profiling. Added the following statistics for every torch operators and its children:
@@ -56,8 +58,6 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 * Added EA memory bandwidth derived metrics under `--membw-analysis` to allow EA memory bandwidth specific profiling and analysis metric block 30.
 
 ### Changed
-
-* `--output-format csv` in analyze mode now uses the database analysis workflow and produces one CSV per analysis view. Requires `--format-rocprof-output rocpd` and no longer prints the report to the terminal (matching `db` format).
 
 * Standalone roofline (`--roof-only` option) in profile mode now creates `roofline.csv` only. HTML roofline charts are generated via `rocprof-compute analyze`. The `calc_ai_profile()` function has been removed; `calc_ai_analyze()` is the single source of truth for arithmetic intensity calculation.
   * Roofline visualization options (`--sort`, `--mem-level`, `--roofline-data-type`) have moved from profile mode to analyze mode.

--- a/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
+++ b/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
@@ -571,10 +571,11 @@ format is ``stdout``.
    * NOTE: This option will disable output of analysis report to terminal.
 
 * ``csv`` format:
+   * NOTE: This only works when provided workload paths are created using ``--format-rocprof-output rocpd`` profile mode option.
    * Generate a folder named ``rocprof_compute_<uuid>`` in the current working directory.
-   * This folder contains multiple csv files representing the data in each metric table in the analysis report.
+   * This folder contains one CSV file per view defined in the :ref:`analysis database schema <analysis-database>` (e.g. ``kernel.csv``, ``kernel_metric.csv``, ``workload_metric.csv``).
    * This is useful for further programmatic analysis of analysis reports.
-   * NOTE: This will print the analysis report to the terminal as well.
+   * NOTE: This option will disable output of analysis report to terminal.
 
 * ``db`` format:
    * NOTE: This only works when provided workload paths are created using ``--format-rocprof-output rocpd`` profile mode option.
@@ -583,7 +584,7 @@ format is ``stdout``.
    * This is useful for further programmatic analysis of analysis reports.
    * NOTE: This option will disable output of analysis report to terminal.
 
-Default file/folder name ``rocprofiler_compute_<uuid>`` can be overriden using ``--output-name <name>`` analyze mode option.
+Default file/folder name ``rocprofiler_compute_<uuid>`` can be overridden using ``--output-name <name>`` analyze mode option. For ``csv`` format the name is used as the output folder; for ``db`` format the name is used with a ``.db`` suffix.
 
 .. _analysis-database:
 

--- a/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
+++ b/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
@@ -584,7 +584,7 @@ format is ``stdout``.
    * This is useful for further programmatic analysis of analysis reports.
    * NOTE: This option will disable output of analysis report to terminal.
 
-Default file/folder name ``rocprofiler_compute_<uuid>`` can be overridden using ``--output-name <name>`` analyze mode option. For ``csv`` format the name is used as the output folder; for ``db`` format the name is used with a ``.db`` suffix.
+Default file/folder name ``rocprof_compute_<uuid>`` can be overridden using ``--output-name <name>`` analyze mode option. For ``csv`` format the name is used as the output folder; for ``db`` format the name is used with a ``.db`` suffix.
 
 .. _analysis-database:
 

--- a/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
+++ b/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
@@ -573,7 +573,7 @@ format is ``stdout``.
 * ``csv`` format:
    * NOTE: This only works when provided workload paths are created using ``--format-rocprof-output rocpd`` profile mode option.
    * Generate a folder named ``rocprof_compute_<uuid>`` in the current working directory.
-   * This folder contains one CSV file per view defined in the :ref:`analysis database schema <analysis-database>` (e.g. ``kernel.csv``, ``kernel_metric.csv``, ``workload_metric.csv``).
+   * This folder contains one CSV file per view defined in the :ref:`analysis database schema <analysis-database>`.
    * This is useful for further programmatic analysis of analysis reports.
    * NOTE: This option will disable output of analysis report to terminal.
 

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -711,12 +711,19 @@ Examples:
         choices=["stdout", "txt", "csv", "db"],
         default="stdout",
         help=(
-            "\t\tSet the format of output file or folder containing analysis data.\n"
-            "\t\tBy default, file or folder created will "
-            "have the name rocprof_compute_<uuid>.\n"
-            "\t\tFile or folder name can be overriden using --output-name.\n"
-            "\t\tDefault output format is stdout which will not "
-            "generate any file/folder.\n"
+            "\t\tFormat of the analysis output. One of: stdout, txt, csv, db.\n"
+            "\t\t  stdout - print report to the terminal (no file/folder created).\n"
+            "\t\t  txt    - write report to <name>.txt; disables terminal output.\n"
+            "\t\t  csv    - write one CSV per analysis view into a folder <name>/.\n"
+            "\t\t           Requires profiles collected with\n"
+            "\t\t           --format-rocprof-output rocpd. Disables terminal output.\n"
+            "\t\t  db     - write a SQLite database <name>.db (see analysis\n"
+            "\t\t           database schema in the docs). Requires profiles\n"
+            "\t\t           collected with --format-rocprof-output rocpd.\n"
+            "\t\t           Disables terminal output.\n"
+            "\t\tDefault <name> is rocprof_compute_<uuid>; override with"
+            " --output-name.\n"
+            "\t\tDefault format is stdout.\n"
         ),
     )
     analyze_group.add_argument(

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -15,7 +15,7 @@ import utils.analysis_orm as orm
 from config import rocprof_compute_home
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
 from utils import utils_analysis
-from utils.analysis_orm import Database, get_views
+from utils.analysis_orm import Database
 from utils.file_io import process_pc_sampling_kernel_trace
 from utils.logger import (
     console_debug,
@@ -208,8 +208,7 @@ class db_analysis(OmniAnalyze_Base):
             Database.commit()
             Database.write_csv_dir(Path(db_name).with_suffix(""))
         else:
-            for view_stmt in get_views():
-                Database.get_session().execute(view_stmt)
+            Database.create_views()
             Database.commit()
             Database.write()
 

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier:  MIT
 
 import ast
-import csv
 import json
 import re
 from pathlib import Path
@@ -16,7 +15,7 @@ import utils.analysis_orm as orm
 from config import rocprof_compute_home
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
 from utils import utils_analysis
-from utils.analysis_orm import Database, get_view_definitions, get_views
+from utils.analysis_orm import Database, get_views
 from utils.file_io import process_pc_sampling_kernel_trace
 from utils.logger import (
     console_debug,
@@ -206,42 +205,13 @@ class db_analysis(OmniAnalyze_Base):
             )
 
         if self.get_args().output_format == "csv":
-            self._save_views_as_csv_files(Path(db_name).with_suffix(""))
+            Database.commit()
+            Database.write_csv_dir(Path(db_name).with_suffix(""))
         else:
             for view_stmt in get_views():
                 Database.get_session().execute(view_stmt)
+            Database.commit()
             Database.write()
-            console_debug("Completed writing database")
-            console_warning(f"Created file: {db_name}")
-
-    def _save_views_as_csv_files(self, csv_dir: Path) -> None:
-        """Stream each view's rows directly into a CSV file in csv_dir.
-
-        Uses the raw sqlite3 cursor and csv.writer so the full result set
-        is never held in memory at once.
-        """
-        csv_dir.mkdir(parents=True, exist_ok=True)
-        session = Database.get_session()
-        # session.connection() is a SQLAlchemy Connection; its .connection
-        # attribute is the underlying sqlite3.Connection.
-        raw_conn = session.connection().connection
-        for view_name, stmt in get_view_definitions().items():
-            # Render the Select as a self-contained SQL string so the raw
-            # cursor can execute it without parameter binding.
-            sql = str(
-                stmt.compile(
-                    dialect=session.bind.dialect,
-                    compile_kwargs={"literal_binds": True},
-                )
-            )
-            cursor = raw_conn.execute(sql)
-            csv_path = csv_dir / f"{view_name}.csv"
-            with csv_path.open("w", newline="") as f:
-                writer = csv.writer(f)
-                writer.writerow([column[0] for column in cursor.description])
-                writer.writerows(cursor)
-            console_warning(f"Created file: {csv_path}")
-        session.close()
 
     def run_analysis_metrics(
         self,

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -15,7 +15,7 @@ import utils.analysis_orm as orm
 from config import rocprof_compute_home
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
 from utils import utils_analysis
-from utils.analysis_orm import Database, get_views
+from utils.analysis_orm import Database, get_view_definitions, get_views
 from utils.file_io import process_pc_sampling_kernel_trace
 from utils.logger import (
     console_debug,
@@ -204,14 +204,26 @@ class db_analysis(OmniAnalyze_Base):
                 )
             )
 
-        # Create views
-        for view_stmt in get_views():
-            Database.get_session().execute(view_stmt)
+        if self.get_args().output_format == "csv":
+            self._save_views_as_csv_files(Path(db_name).with_suffix(""))
+        else:
+            for view_stmt in get_views():
+                Database.get_session().execute(view_stmt)
+            Database.write()
+            console_debug("Completed writing database")
+            console_warning(f"Created file: {db_name}")
 
-        # Write database
-        Database.write()
-        console_debug("Completed writing database")
-        console_warning(f"Created file: {db_name}")
+    def _save_views_as_csv_files(self, csv_dir: Path) -> None:
+        """Execute view selects and write one CSV per view into ``csv_dir``."""
+        csv_dir.mkdir(parents=True, exist_ok=True)
+        session = Database.get_session()
+        for view_name, stmt in get_view_definitions().items():
+            rows = session.execute(stmt).fetchall()
+            view_df = pd.DataFrame(rows, columns=stmt.selected_columns.keys())
+            csv_path = csv_dir / f"{view_name}.csv"
+            view_df.to_csv(csv_path, index=False)
+            console_warning(f"Created file: {csv_path}")
+        session.close()
 
     def run_analysis_metrics(
         self,

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier:  MIT
 
 import ast
+import csv
 import json
 import re
 from pathlib import Path
@@ -214,14 +215,31 @@ class db_analysis(OmniAnalyze_Base):
             console_warning(f"Created file: {db_name}")
 
     def _save_views_as_csv_files(self, csv_dir: Path) -> None:
-        """Execute view selects and write one CSV per view into csv_dir."""
+        """Stream each view's rows directly into a CSV file in csv_dir.
+
+        Uses the raw sqlite3 cursor and csv.writer so the full result set
+        is never held in memory at once.
+        """
         csv_dir.mkdir(parents=True, exist_ok=True)
         session = Database.get_session()
+        # session.connection() is a SQLAlchemy Connection; its .connection
+        # attribute is the underlying sqlite3.Connection.
+        raw_conn = session.connection().connection
         for view_name, stmt in get_view_definitions().items():
-            rows = session.execute(stmt).fetchall()
-            view_df = pd.DataFrame(rows, columns=stmt.selected_columns.keys())
+            # Render the Select as a self-contained SQL string so the raw
+            # cursor can execute it without parameter binding.
+            sql = str(
+                stmt.compile(
+                    dialect=session.bind.dialect,
+                    compile_kwargs={"literal_binds": True},
+                )
+            )
+            cursor = raw_conn.execute(sql)
             csv_path = csv_dir / f"{view_name}.csv"
-            view_df.to_csv(csv_path, index=False)
+            with csv_path.open("w", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow([column[0] for column in cursor.description])
+                writer.writerows(cursor)
             console_warning(f"Created file: {csv_path}")
         session.close()
 

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -214,7 +214,7 @@ class db_analysis(OmniAnalyze_Base):
             console_warning(f"Created file: {db_name}")
 
     def _save_views_as_csv_files(self, csv_dir: Path) -> None:
-        """Execute view selects and write one CSV per view into ``csv_dir``."""
+        """Execute view selects and write one CSV per view into csv_dir."""
         csv_dir.mkdir(parents=True, exist_ok=True)
         session = Database.get_session()
         for view_name, stmt in get_view_definitions().items():

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -135,7 +135,7 @@ class RocProfCompute:
             self.__analyze_mode = "web_ui"
         elif self.__args.tui:
             self.__analyze_mode = "tui"
-        elif self.__args.output_format == "db":
+        elif self.__args.output_format in ("db", "csv"):
             self.__analyze_mode = "db"
         else:
             self.__analyze_mode = "cli"

--- a/projects/rocprofiler-compute/src/utils/analysis_orm.py
+++ b/projects/rocprofiler-compute/src/utils/analysis_orm.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier:  MIT
 
 import sqlite3
+from contextlib import closing
 from typing import Any, Optional
 
 from sqlalchemy import (
@@ -20,6 +21,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, declarative_base, relationship, sessionmaker
+from sqlalchemy.pool import StaticPool
 from sqlalchemy.sql import Select
 
 from utils.logger import console_debug, console_error
@@ -220,7 +222,13 @@ class Database:
 
     @classmethod
     def init(cls, db_name: str) -> str:
-        cls._engine = create_engine("sqlite:///:memory:")
+        # StaticPool pins the engine to a single sqlite3 connection so the
+        # session and the backup in write() share the same in-memory DB.
+        cls._engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
         Base.metadata.create_all(cls._engine)
         cls._session = sessionmaker(bind=cls._engine)()
         cls._db_name = db_name
@@ -240,10 +248,11 @@ class Database:
             cls._session.commit()
             # Writing to disk is slow, so we built the database in memory.
             # Now copy the finished database to disk in one step.
-            memory_conn = cls._engine.raw_connection()
-            disk_conn = sqlite3.connect(cls._db_name)
-            memory_conn.backup(disk_conn)
-            disk_conn.close()
+            with (
+                closing(cls._engine.raw_connection()) as memory_conn,
+                closing(sqlite3.connect(cls._db_name)) as disk_conn,
+            ):
+                memory_conn.backup(disk_conn)
         except Exception as e:
             cls._session.rollback()
             console_error(f"Error writing analysis database: {e}")

--- a/projects/rocprofiler-compute/src/utils/analysis_orm.py
+++ b/projects/rocprofiler-compute/src/utils/analysis_orm.py
@@ -224,7 +224,7 @@ class Database:
         Base.metadata.create_all(cls._engine)
         cls._session = sessionmaker(bind=cls._engine)()
         cls._db_name = db_name
-        console_debug(f"SQLite database initialized in memory (target file: {db_name})")
+        console_debug("SQLite database initialized in memory")
         return db_name
 
     @classmethod
@@ -238,6 +238,8 @@ class Database:
 
         try:
             cls._session.commit()
+            # Writing to disk is slow, so we built the database in memory.
+            # Now copy the finished database to disk in one step.
             memory_conn = cls._engine.raw_connection()
             disk_conn = sqlite3.connect(cls._db_name)
             memory_conn.backup(disk_conn)

--- a/projects/rocprofiler-compute/src/utils/analysis_orm.py
+++ b/projects/rocprofiler-compute/src/utils/analysis_orm.py
@@ -1,8 +1,10 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
+import csv
 import sqlite3
 from contextlib import closing
+from pathlib import Path
 from typing import Any, Optional
 
 from sqlalchemy import (
@@ -24,7 +26,7 @@ from sqlalchemy.orm import Session, declarative_base, relationship, sessionmaker
 from sqlalchemy.pool import StaticPool
 from sqlalchemy.sql import Select
 
-from utils.logger import console_debug, console_error
+from utils.logger import console_debug, console_error, console_warning
 
 PREFIX = "compute_"
 SCHEMA_VERSION = "1.3.0"
@@ -240,12 +242,22 @@ class Database:
         return cls._session
 
     @classmethod
-    def write(cls) -> None:
+    def commit(cls) -> None:
+        """Seal pending session writes. Must be called before any export."""
         if cls._session is None:
             console_error("No active database session")
-
         try:
             cls._session.commit()
+        except Exception as e:
+            cls._session.rollback()
+            console_error(f"Error committing analysis database: {e}")
+
+    @classmethod
+    def write(cls) -> None:
+        """Back up the in-memory database to disk at the configured path."""
+        if cls._session is None:
+            console_error("No active database session")
+        try:
             # Writing to disk is slow, so we built the database in memory.
             # Now copy the finished database to disk in one step.
             with (
@@ -253,9 +265,44 @@ class Database:
                 closing(sqlite3.connect(cls._db_name)) as disk_conn,
             ):
                 memory_conn.backup(disk_conn)
+            console_debug("Completed writing database")
+            console_warning(f"Created file: {cls._db_name}")
         except Exception as e:
-            cls._session.rollback()
             console_error(f"Error writing analysis database: {e}")
+        finally:
+            cls._session.close()
+            cls._session = None
+
+    @classmethod
+    def write_csv_dir(cls, csv_dir: Path) -> None:
+        """Stream each view's rows directly into a CSV file in csv_dir.
+
+        Uses the raw sqlite3 cursor and csv.writer so the full result set
+        is never held in memory at once.
+        """
+        if cls._session is None:
+            console_error("No active database session")
+        try:
+            csv_dir.mkdir(parents=True, exist_ok=True)
+            # session.connection() is a SQLAlchemy Connection; its .connection
+            # attribute is the underlying sqlite3.Connection.
+            raw_conn = cls._session.connection().connection
+            for view_name, stmt in get_view_definitions().items():
+                # Render the Select as a self-contained SQL string so the raw
+                # cursor can execute it without parameter binding.
+                sql = str(
+                    stmt.compile(
+                        dialect=cls._engine.dialect,
+                        compile_kwargs={"literal_binds": True},
+                    )
+                )
+                cursor = raw_conn.execute(sql)
+                csv_path = csv_dir / f"{view_name}.csv"
+                with csv_path.open("w", newline="") as f:
+                    writer = csv.writer(f)
+                    writer.writerow([column[0] for column in cursor.description])
+                    writer.writerows(cursor)
+                console_warning(f"Created file: {csv_path}")
         finally:
             cls._session.close()
             cls._session = None

--- a/projects/rocprofiler-compute/src/utils/analysis_orm.py
+++ b/projects/rocprofiler-compute/src/utils/analysis_orm.py
@@ -1,6 +1,7 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
+import sqlite3
 from typing import Any, Optional
 
 from sqlalchemy import (
@@ -215,13 +216,15 @@ class Metadata(Base):
 class Database:
     _session: Optional[Session] = None
     _engine: Optional[Engine] = None
+    _db_name: Optional[str] = None
 
     @classmethod
     def init(cls, db_name: str) -> str:
-        cls._engine = create_engine(f"sqlite:///{db_name}")
+        cls._engine = create_engine("sqlite:///:memory:")
         Base.metadata.create_all(cls._engine)
         cls._session = sessionmaker(bind=cls._engine)()
-        console_debug(f"SQLite database initialized with name: {db_name}")
+        cls._db_name = db_name
+        console_debug(f"SQLite database initialized in memory (target file: {db_name})")
         return db_name
 
     @classmethod
@@ -235,6 +238,10 @@ class Database:
 
         try:
             cls._session.commit()
+            memory_conn = cls._engine.raw_connection()
+            disk_conn = sqlite3.connect(cls._db_name)
+            memory_conn.backup(disk_conn)
+            disk_conn.close()
         except Exception as e:
             cls._session.rollback()
             console_error(f"Error writing analysis database: {e}")
@@ -243,7 +250,7 @@ class Database:
             cls._session = None
 
 
-def get_views() -> list[TextClause]:
+def get_view_definitions() -> dict[str, Select[Any]]:
     median_sort_subquery = (
         select(
             Kernel.kernel_uuid,
@@ -277,8 +284,8 @@ def get_views() -> list[TextClause]:
         .group_by(median_sort_subquery.c.kernel_uuid)
     ).subquery()
 
-    views: dict[str, Select[Any]] = {
-        "kernel_view": select(
+    return {
+        "kernel": select(
             Kernel.kernel_uuid.label("kernel_uuid"),
             Kernel.workload_id.label("workload_id"),
             Workload.name.label("workload_name"),
@@ -308,7 +315,7 @@ def get_views() -> list[TextClause]:
         .group_by(
             Kernel.kernel_uuid, Kernel.workload_id, Workload.name, Kernel.kernel_name
         ),
-        "kernel_metric_view": select(
+        "kernel_metric": select(
             Workload.workload_id.label("workload_id"),
             Workload.name.label("workload_name"),
             Kernel.kernel_uuid.label("kernel_uuid"),
@@ -331,7 +338,7 @@ def get_views() -> list[TextClause]:
             MetricDefinition.metric_uuid == KernelMetricValue.metric_uuid,
         )
         .join(Kernel, KernelMetricValue.kernel_uuid == Kernel.kernel_uuid),
-        "workload_metric_view": select(
+        "workload_metric": select(
             Workload.workload_id.label("workload_id"),
             Workload.name.label("workload_name"),
             MetricDefinition.metric_uuid.label("metric_uuid"),
@@ -353,10 +360,12 @@ def get_views() -> list[TextClause]:
         ),
     }
 
+
+def get_views() -> list[TextClause]:
     return [
         text(
-            f"CREATE VIEW {PREFIX}{view_name} AS "
+            f"CREATE VIEW {PREFIX}{name}_view AS "
             f"{stmt.compile(compile_kwargs={'literal_binds': True})}"
         )
-        for view_name, stmt in views.items()
+        for name, stmt in get_view_definitions().items()
     ]

--- a/projects/rocprofiler-compute/src/utils/analysis_orm.py
+++ b/projects/rocprofiler-compute/src/utils/analysis_orm.py
@@ -15,12 +15,12 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
-    TextClause,
     create_engine,
     func,
     select,
     text,
 )
+from sqlalchemy.dialects import sqlite
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, declarative_base, relationship, sessionmaker
 from sqlalchemy.pool import StaticPool
@@ -221,6 +221,7 @@ class Database:
     _session: Optional[Session] = None
     _engine: Optional[Engine] = None
     _db_name: Optional[str] = None
+    _view_sql_cache: Optional[dict[str, str]] = None
 
     @classmethod
     def init(cls, db_name: str) -> str:
@@ -234,6 +235,8 @@ class Database:
         Base.metadata.create_all(cls._engine)
         cls._session = sessionmaker(bind=cls._engine)()
         cls._db_name = db_name
+        # Compile views eagerly so a broken definition fails at init time.
+        cls._view_sql_cache = cls._compile_view_sql()
         console_debug("SQLite database initialized in memory")
         return db_name
 
@@ -287,15 +290,7 @@ class Database:
             # session.connection() is a SQLAlchemy Connection; its .connection
             # attribute is the underlying sqlite3.Connection.
             raw_conn = cls._session.connection().connection
-            for view_name, stmt in get_view_definitions().items():
-                # Render the Select as a self-contained SQL string so the raw
-                # cursor can execute it without parameter binding.
-                sql = str(
-                    stmt.compile(
-                        dialect=cls._engine.dialect,
-                        compile_kwargs={"literal_binds": True},
-                    )
-                )
+            for view_name, sql in cls.get_view_sql().items():
                 cursor = raw_conn.execute(sql)
                 csv_path = csv_dir / f"{view_name}.csv"
                 with csv_path.open("w", newline="") as f:
@@ -307,123 +302,143 @@ class Database:
             cls._session.close()
             cls._session = None
 
+    @classmethod
+    def create_views(cls) -> None:
+        """Materialize CREATE VIEW statements in the in-memory DB."""
+        for name, sql in cls.get_view_sql().items():
+            cls._session.execute(text(f"CREATE VIEW {PREFIX}{name}_view AS {sql}"))
 
-def get_view_definitions() -> dict[str, Select[Any]]:
-    median_sort_subquery = (
-        select(
-            Kernel.kernel_uuid,
-            (Dispatch.end_timestamp - Dispatch.start_timestamp).label("duration"),
-            func
-            .row_number()
-            .over(
-                partition_by=Kernel.kernel_uuid,
-                order_by=Dispatch.end_timestamp - Dispatch.start_timestamp,
+    @classmethod
+    def get_view_sql(cls) -> dict[str, str]:
+        """Return {bare_view_name: compiled SELECT SQL} for analysis views.
+
+        Returns a shallow copy of the cache populated in init() so callers
+        can't poison it.
+        """
+        return dict(cls._view_sql_cache)
+
+    @staticmethod
+    def _compile_view_sql() -> dict[str, str]:
+        """Build and compile the analysis views to SQLite SQL strings."""
+        median_sort_subquery = (
+            select(
+                Kernel.kernel_uuid,
+                (Dispatch.end_timestamp - Dispatch.start_timestamp).label("duration"),
+                func
+                .row_number()
+                .over(
+                    partition_by=Kernel.kernel_uuid,
+                    order_by=Dispatch.end_timestamp - Dispatch.start_timestamp,
+                )
+                .label("row_num"),
+                func.count().over(partition_by=Kernel.kernel_uuid).label("total_count"),
             )
-            .label("row_num"),
-            func.count().over(partition_by=Kernel.kernel_uuid).label("total_count"),
-        )
-        .select_from(Dispatch)
-        .join(Kernel, Dispatch.kernel_uuid == Kernel.kernel_uuid)
-    ).subquery()
+            .select_from(Dispatch)
+            .join(Kernel, Dispatch.kernel_uuid == Kernel.kernel_uuid)
+        ).subquery()
 
-    median_calc_subquery = (
-        select(
-            median_sort_subquery.c.kernel_uuid,
-            func.avg(median_sort_subquery.c.duration).label("duration_ns_median"),
-        )
-        .where(
-            # For odd counts: get the middle row
-            # For even counts: get the two middle rows and average them
-            median_sort_subquery.c.row_num.in_([
-                func.cast((median_sort_subquery.c.total_count + 1) / 2, Integer),
-                func.cast((median_sort_subquery.c.total_count + 2) / 2, Integer),
-            ])
-        )
-        .group_by(median_sort_subquery.c.kernel_uuid)
-    ).subquery()
+        median_calc_subquery = (
+            select(
+                median_sort_subquery.c.kernel_uuid,
+                func.avg(median_sort_subquery.c.duration).label("duration_ns_median"),
+            )
+            .where(
+                # For odd counts: get the middle row
+                # For even counts: get the two middle rows and average them
+                median_sort_subquery.c.row_num.in_([
+                    func.cast((median_sort_subquery.c.total_count + 1) / 2, Integer),
+                    func.cast((median_sort_subquery.c.total_count + 2) / 2, Integer),
+                ])
+            )
+            .group_by(median_sort_subquery.c.kernel_uuid)
+        ).subquery()
 
-    return {
-        "kernel": select(
-            Kernel.kernel_uuid.label("kernel_uuid"),
-            Kernel.workload_id.label("workload_id"),
-            Workload.name.label("workload_name"),
-            Kernel.kernel_name,
-            func.count(Dispatch.dispatch_id).label("dispatch_count"),
-            func.sum(Dispatch.end_timestamp - Dispatch.start_timestamp).label(
-                "duration_ns_sum"
+        definitions: dict[str, Select[Any]] = {
+            "kernel": select(
+                Kernel.kernel_uuid.label("kernel_uuid"),
+                Kernel.workload_id.label("workload_id"),
+                Workload.name.label("workload_name"),
+                Kernel.kernel_name,
+                func.count(Dispatch.dispatch_id).label("dispatch_count"),
+                func.sum(Dispatch.end_timestamp - Dispatch.start_timestamp).label(
+                    "duration_ns_sum"
+                ),
+                func.min(Dispatch.end_timestamp - Dispatch.start_timestamp).label(
+                    "duration_ns_min"
+                ),
+                func.max(Dispatch.end_timestamp - Dispatch.start_timestamp).label(
+                    "duration_ns_max"
+                ),
+                median_calc_subquery.c.duration_ns_median,
+                func.avg(Dispatch.end_timestamp - Dispatch.start_timestamp).label(
+                    "duration_ns_mean"
+                ),
+            )
+            .select_from(Dispatch)
+            .join(Kernel, Dispatch.kernel_uuid == Kernel.kernel_uuid)
+            .join(Workload, Kernel.workload_id == Workload.workload_id)
+            .join(
+                median_calc_subquery,
+                Kernel.kernel_uuid == median_calc_subquery.c.kernel_uuid,
+            )
+            .group_by(
+                Kernel.kernel_uuid,
+                Kernel.workload_id,
+                Workload.name,
+                Kernel.kernel_name,
             ),
-            func.min(Dispatch.end_timestamp - Dispatch.start_timestamp).label(
-                "duration_ns_min"
+            "kernel_metric": select(
+                Workload.workload_id.label("workload_id"),
+                Workload.name.label("workload_name"),
+                Kernel.kernel_uuid.label("kernel_uuid"),
+                Kernel.kernel_name,
+                MetricDefinition.metric_uuid.label("metric_uuid"),
+                MetricDefinition.name.label("metric_name"),
+                MetricDefinition.metric_id,
+                MetricDefinition.description,
+                MetricDefinition.table_name,
+                MetricDefinition.sub_table_name,
+                MetricDefinition.unit,
+                KernelMetricValue.value_uuid.label("value_uuid"),
+                KernelMetricValue.value_name,
+                KernelMetricValue.value,
+            )
+            .select_from(MetricDefinition)
+            .join(Workload, MetricDefinition.workload_id == Workload.workload_id)
+            .join(
+                KernelMetricValue,
+                MetricDefinition.metric_uuid == KernelMetricValue.metric_uuid,
+            )
+            .join(Kernel, KernelMetricValue.kernel_uuid == Kernel.kernel_uuid),
+            "workload_metric": select(
+                Workload.workload_id.label("workload_id"),
+                Workload.name.label("workload_name"),
+                MetricDefinition.metric_uuid.label("metric_uuid"),
+                MetricDefinition.name.label("metric_name"),
+                MetricDefinition.metric_id,
+                MetricDefinition.description,
+                MetricDefinition.table_name,
+                MetricDefinition.sub_table_name,
+                MetricDefinition.unit,
+                WorkloadMetricValue.value_uuid.label("value_uuid"),
+                WorkloadMetricValue.value_name,
+                WorkloadMetricValue.value,
+            )
+            .select_from(MetricDefinition)
+            .join(Workload, MetricDefinition.workload_id == Workload.workload_id)
+            .join(
+                WorkloadMetricValue,
+                MetricDefinition.metric_uuid == WorkloadMetricValue.metric_uuid,
             ),
-            func.max(Dispatch.end_timestamp - Dispatch.start_timestamp).label(
-                "duration_ns_max"
-            ),
-            median_calc_subquery.c.duration_ns_median,
-            func.avg(Dispatch.end_timestamp - Dispatch.start_timestamp).label(
-                "duration_ns_mean"
-            ),
-        )
-        .select_from(Dispatch)
-        .join(Kernel, Dispatch.kernel_uuid == Kernel.kernel_uuid)
-        .join(Workload, Kernel.workload_id == Workload.workload_id)
-        .join(
-            median_calc_subquery,
-            Kernel.kernel_uuid == median_calc_subquery.c.kernel_uuid,
-        )
-        .group_by(
-            Kernel.kernel_uuid, Kernel.workload_id, Workload.name, Kernel.kernel_name
-        ),
-        "kernel_metric": select(
-            Workload.workload_id.label("workload_id"),
-            Workload.name.label("workload_name"),
-            Kernel.kernel_uuid.label("kernel_uuid"),
-            Kernel.kernel_name,
-            MetricDefinition.metric_uuid.label("metric_uuid"),
-            MetricDefinition.name.label("metric_name"),
-            MetricDefinition.metric_id,
-            MetricDefinition.description,
-            MetricDefinition.table_name,
-            MetricDefinition.sub_table_name,
-            MetricDefinition.unit,
-            KernelMetricValue.value_uuid.label("value_uuid"),
-            KernelMetricValue.value_name,
-            KernelMetricValue.value,
-        )
-        .select_from(MetricDefinition)
-        .join(Workload, MetricDefinition.workload_id == Workload.workload_id)
-        .join(
-            KernelMetricValue,
-            MetricDefinition.metric_uuid == KernelMetricValue.metric_uuid,
-        )
-        .join(Kernel, KernelMetricValue.kernel_uuid == Kernel.kernel_uuid),
-        "workload_metric": select(
-            Workload.workload_id.label("workload_id"),
-            Workload.name.label("workload_name"),
-            MetricDefinition.metric_uuid.label("metric_uuid"),
-            MetricDefinition.name.label("metric_name"),
-            MetricDefinition.metric_id,
-            MetricDefinition.description,
-            MetricDefinition.table_name,
-            MetricDefinition.sub_table_name,
-            MetricDefinition.unit,
-            WorkloadMetricValue.value_uuid.label("value_uuid"),
-            WorkloadMetricValue.value_name,
-            WorkloadMetricValue.value,
-        )
-        .select_from(MetricDefinition)
-        .join(Workload, MetricDefinition.workload_id == Workload.workload_id)
-        .join(
-            WorkloadMetricValue,
-            MetricDefinition.metric_uuid == WorkloadMetricValue.metric_uuid,
-        ),
-    }
+        }
 
-
-def get_views() -> list[TextClause]:
-    return [
-        text(
-            f"CREATE VIEW {PREFIX}{name}_view AS "
-            f"{stmt.compile(compile_kwargs={'literal_binds': True})}"
-        )
-        for name, stmt in get_view_definitions().items()
-    ]
+        dialect = sqlite.dialect()
+        return {
+            name: str(
+                stmt.compile(
+                    dialect=dialect,
+                    compile_kwargs={"literal_binds": True},
+                )
+            )
+            for name, stmt in definitions.items()
+        }

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -6,7 +6,6 @@ import copy
 import math
 import shutil
 import textwrap
-from pathlib import Path
 from typing import Any, Optional, TextIO
 
 import pandas as pd
@@ -29,7 +28,6 @@ from utils.utils_common import (
     METRIC_ID_RE,
     convert_metric_id_to_panel_info,
     get_panel_alias,
-    get_uuid,
 )
 
 
@@ -763,7 +761,6 @@ def format_table_output(
     df: pd.DataFrame,
     table_type: str,
     runs: dict[str, Any],
-    csv_dir: Optional[Path] = None,
     gpu_arch: Optional[str] = None,
     mem_data_override: Optional[dict[str, Any]] = None,
 ) -> str:
@@ -791,14 +788,6 @@ def format_table_output(
     ) == "mem_chart" and not _tty_view_is_table(args)
     if "title" in table_config and table_config["title"] and not skip_mem_chart_title:
         content += f"{table_id_str} {table_config['title']}\n"
-
-    if args.output_format == "csv" and csv_dir and csv_dir.is_dir():
-        if "title" in table_config and table_config["title"]:
-            table_id_str += f"_{table_config['title']}"
-
-        csv_filename = csv_dir / f"{table_id_str.replace(' ', '_')}.csv"
-        df.to_csv(csv_filename, index=False)
-        console_warning(f"Created file: {csv_filename}")
 
     # Only show top N kernels (as specified in --max-kernel-num)
     # in "Top Stats" section
@@ -879,7 +868,6 @@ def show_all(
     """
     comparable_columns = parser.build_comparable_columns(args.time_unit)
     raw_filter_panel_ids = profiling_config.get("filter_blocks", [])
-    csv_dir = None
 
     # Get gpu_arch from the first run's sys_info
     first_run = next(iter(runs.values()))
@@ -918,14 +906,6 @@ def show_all(
         hidden_cols = list(set(config.HIDDEN_COLUMNS_CLI) - set(args.include_cols))
     else:
         hidden_cols = config.HIDDEN_COLUMNS_CLI
-
-    if args.output_format == "csv":
-        if args.output_name:
-            csv_dir = Path(f"{args.output_name}")
-        else:
-            csv_dir = Path(f"rocprof_compute_{get_uuid()}")
-        if not csv_dir.exists():
-            csv_dir.mkdir()
 
     # Check for valid roofline data once (used to skip roofline tables in the loop)
     has_valid_roofline = any(
@@ -1060,7 +1040,6 @@ def show_all(
                     processed_df,
                     table_type,
                     runs,
-                    csv_dir,
                     gpu_arch,
                 )
 

--- a/projects/rocprofiler-compute/tests/test_TCP_counters.py
+++ b/projects/rocprofiler-compute/tests/test_TCP_counters.py
@@ -17,23 +17,11 @@ config["METRIC_LOGGING"] = False
 
 
 def load_metrics(csv_file_path):
-    """
-    Reads the CSV file into a dictionary of dictionaries:
-        {
-            "Metric_1": {
-                    "Avg": value,
-                    "Min": value,
-                    "Max": value,
-                    "Unit": "unit"
-                },
-            "Metric_2": { ... },
-            ...
-        }
-    N/A values (unevaluable metrics) are parsed as NaN by pandas.
-    """
-    df = pd.read_csv(csv_file_path, na_values=["N/A"])
-    df["Metric"] = df["Metric"].str.strip()
-    return df.set_index("Metric").to_dict(orient="index")
+    """Read workload_metric.csv and return {metric_name: {value_name: value}}."""
+    df = pd.read_csv(csv_file_path)
+    return df.pivot(index="metric_name", columns="value_name", values="value").to_dict(
+        orient="index"
+    )
 
 
 _, soc = common.gpu_soc()
@@ -84,9 +72,7 @@ def test_L1_cache_counters(
         assert return_code == 0
 
         # 3. save results in local
-
-        # FIXME: customize file name to avoid hardcode
-        csv_path = workload_dir_output + "/16.3_vL1D_cache_access_metrics.csv"
+        csv_path = workload_dir_output + "/workload_metric.csv"
         data = load_metrics(csv_path)
 
         for metric in metrics:

--- a/projects/rocprofiler-compute/tests/test_analyze_commands.py
+++ b/projects/rocprofiler-compute/tests/test_analyze_commands.py
@@ -968,32 +968,6 @@ def test_decimal_3(binary_handler_analyze_rocprof_compute):
         common.clean_output_dir(config["cleanup"], workload_dir)
 
 
-@pytest.mark.misc
-def test_save_dfs(binary_handler_analyze_rocprof_compute):
-    output_path = common.get_output_dir()
-    for dir in indirs:
-        workload_dir = common.setup_workload_dir(dir)
-        code = binary_handler_analyze_rocprof_compute([
-            "analyze",
-            "--path",
-            workload_dir,
-            "--output-format",
-            "csv",
-            "--output-name",
-            output_path,
-        ])
-        assert code == 0
-
-        files_in_workload = os.listdir(output_path)
-        for file_name in files_in_workload:
-            df = pd.read_csv(output_path + "/" + file_name)
-            assert len(df.index) >= 1
-
-        common.clean_output_dir(True, output_path)
-        common.clean_output_dir(config["cleanup"], workload_dir)
-    common.clean_output_dir(config["cleanup"], output_path)
-
-
 @pytest.mark.col
 def test_col_1(binary_handler_analyze_rocprof_compute):
     for dir in indirs:

--- a/projects/rocprofiler-compute/tests/test_metric_validation.py
+++ b/projects/rocprofiler-compute/tests/test_metric_validation.py
@@ -9,16 +9,22 @@ _, soc = common.gpu_soc()
 
 
 def get_hbm_data_transfer(analysis_workload_dir, data):
-    bw = pd.read_csv(f"{analysis_workload_dir}/{data['bw_csv']}")[
-        data["bw_column"]
-    ].values[0]
+    bw_df = pd.read_csv(f"{analysis_workload_dir}/{data['bw_csv']}")
+    bw_rows = bw_df[
+        (bw_df["metric_id"] == data["bw_metric_id"])
+        & (bw_df["value_name"] == data["bw_value_name"])
+    ]
+    bw = bw_rows["value"].values[0]
     duration_ns = pd.read_csv(f"{analysis_workload_dir}/{data['duration_csv']}")[
         data["duration_column"]
     ].values[0]
     return bw * duration_ns / 1e9
 
 
-# workload -> gfx -> metric definition
+# workload -> gfx -> metric definition. CSV references point at the per-view
+# CSVs produced by analyze: workload/kernel-level metric values live in
+# workload_metric.csv / kernel_metric.csv (filter by metric_id + value_name),
+# kernel-level dispatch durations live in kernel.csv.
 VALIDATE_METRICS = {
     "memcopy": {
         "command": ["tests/memcopy"],
@@ -31,10 +37,11 @@ VALIDATE_METRICS = {
                 "tolerance": 0.10,
                 "get_actual_data": {
                     "soc": "MI200",
-                    "bw_csv": "4.1_Roofline_Performance_Rates.csv",
-                    "bw_column": "Value",
-                    "duration_csv": "0.1_Top_Kernels.csv",
-                    "duration_column": "Sum(ns)",
+                    "bw_csv": "workload_metric.csv",
+                    "bw_metric_id": "4.1.8",
+                    "bw_value_name": "Value",
+                    "duration_csv": "kernel.csv",
+                    "duration_column": "duration_ns_sum",
                 },
             },
         ],
@@ -45,10 +52,11 @@ VALIDATE_METRICS = {
                 "tolerance": 0.10,
                 "get_actual_data": {
                     "soc": "MI300",
-                    "bw_csv": "4.1_Roofline_Performance_Rates.csv",
-                    "bw_column": "Value",
-                    "duration_csv": "0.1_Top_Kernels.csv",
-                    "duration_column": "Sum(ns)",
+                    "bw_csv": "workload_metric.csv",
+                    "bw_metric_id": "4.1.9",
+                    "bw_value_name": "Value",
+                    "duration_csv": "kernel.csv",
+                    "duration_column": "duration_ns_sum",
                 },
             },
         ],
@@ -59,10 +67,11 @@ VALIDATE_METRICS = {
                 "tolerance": 0.10,
                 "get_actual_data": {
                     "soc": "MI350",
-                    "bw_csv": "4.1_Roofline_Performance_Rates.csv",
-                    "bw_column": "Value",
-                    "duration_csv": "0.1_Top_Kernels.csv",
-                    "duration_column": "Sum(ns)",
+                    "bw_csv": "workload_metric.csv",
+                    "bw_metric_id": "4.1.10",
+                    "bw_value_name": "Value",
+                    "duration_csv": "kernel.csv",
+                    "duration_column": "duration_ns_sum",
                 },
             },
         ],

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -5,7 +5,6 @@ import csv
 import inspect
 import os
 import re
-import shutil
 import socket
 import sqlite3
 import subprocess
@@ -1142,23 +1141,23 @@ def test_analyze_rocpd(
 def test_save_csv(
     binary_handler_profile_rocprof_compute, binary_handler_analyze_rocprof_compute
 ):
-    workload_dir = common.get_output_dir()
-    options = ["--device", "0", "--format-rocprof-output", "rocpd"]
+    workload_dir = common.get_output_dir(param_id="profile")
+    analysis_workload_dir = common.get_output_dir(param_id="analysis")
+    options = ["--format-rocprof-output", "rocpd"]
     binary_handler_profile_rocprof_compute(config, workload_dir, options)
 
-    output_name = "test_csv_output"
     code = binary_handler_analyze_rocprof_compute([
         "analyze",
         "--output-format",
         "csv",
         "--output-name",
-        output_name,
+        analysis_workload_dir,
         "--path",
         workload_dir,
     ])
     assert code == 0
 
-    csv_dir = Path(output_name)
+    csv_dir = Path(analysis_workload_dir)
     assert csv_dir.is_dir()
 
     expected_view_csvs = ["kernel.csv", "kernel_metric.csv", "workload_metric.csv"]
@@ -1168,9 +1167,9 @@ def test_save_csv(
         df = pd.read_csv(csv_path)
         assert len(df.index) >= 1, f"Per-view CSV is empty: {csv_path}"
 
-    assert not Path(f"{output_name}.db").exists()
+    assert not Path(f"{analysis_workload_dir}.db").exists()
 
-    shutil.rmtree(csv_dir)
+    common.clean_output_dir(config["cleanup"], analysis_workload_dir)
     common.clean_output_dir(config["cleanup"], workload_dir)
 
 

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -5,6 +5,7 @@ import csv
 import inspect
 import os
 import re
+import shutil
 import socket
 import sqlite3
 import subprocess
@@ -1134,6 +1135,42 @@ def test_analyze_rocpd(
         check_cols(table_name, orm_obj)
 
     os.remove(f"{db_name}.db")
+    common.clean_output_dir(config["cleanup"], workload_dir)
+
+
+@pytest.mark.misc
+def test_save_csv(
+    binary_handler_profile_rocprof_compute, binary_handler_analyze_rocprof_compute
+):
+    workload_dir = common.get_output_dir()
+    options = ["--device", "0", "--format-rocprof-output", "rocpd"]
+    binary_handler_profile_rocprof_compute(config, workload_dir, options)
+
+    output_name = "test_csv_output"
+    code = binary_handler_analyze_rocprof_compute([
+        "analyze",
+        "--output-format",
+        "csv",
+        "--output-name",
+        output_name,
+        "--path",
+        workload_dir,
+    ])
+    assert code == 0
+
+    csv_dir = Path(output_name)
+    assert csv_dir.is_dir()
+
+    expected_view_csvs = ["kernel.csv", "kernel_metric.csv", "workload_metric.csv"]
+    for csv_name in expected_view_csvs:
+        csv_path = csv_dir / csv_name
+        assert csv_path.is_file(), f"Missing per-view CSV: {csv_path}"
+        df = pd.read_csv(csv_path)
+        assert len(df.index) >= 1, f"Per-view CSV is empty: {csv_path}"
+
+    assert not Path(f"{output_name}.db").exists()
+
+    shutil.rmtree(csv_dir)
     common.clean_output_dir(config["cleanup"], workload_dir)
 
 


### PR DESCRIPTION
## Motivation

Routes `--output-format csv` through the database analysis workflow so CSV and DB outputs share one data model. CSV mode now produces a directory containing one CSV per analysis view, which removes the duplicated CSV plumbing in the CLI display layer.

## Technical Details

- **CSV output format**: `--output-format csv` writes one CSV per view into a directory (`rocprof_compute_&lt;uuid&gt;/` by default, or `&lt;output_name&gt;/` when `--output-name` is set).
- **View definitions split from CREATE VIEW compilation**: new `get_view_definitions()` returns a `{bare_name: Select}` mapping reused by both the CSV writer and `get_views()`. `get_views()` becomes a thin wrapper that adds the `_view` suffix only at SQL compile time. `CREATE VIEW` SQL is byte-identical to before.
- **Database workflow integration**: both `--output-format csv` and `--output-format db` now use the database analysis path.
- **In-memory database**: the analysis `Database` runs in-memory SQLite and backs up to disk in `Database.write()`. CSV mode never calls `write()`, so no `.db` artifact is produced.
- **CLI layer cleanup**: removed the `csv_dir` parameter from `tty.format_table_output()` and the related per-table CSV plumbing in `tty.show_all()`.
- **rocpd requirement**: CSV output now requires rocpd profiling format (same requirement as DB output).

Roofline view CSV is intentionally out of scope and will land in a follow-up.

## JIRA ID

AIPROFCOMP-213

## Test Plan

- `test_save_csv` (added) — verify directory layout and per-view CSVs each have at least one row, and that no `.db` file is produced.
- `test_analyze_rocpd` — DB-mode regression guard; `CREATE VIEW` SQL must remain byte-identical after the view-definition split.
- `test_validate_metrics` (reworked) — read per-view CSV inside the output directory and filter by `metric_id` and `value_name`.

## Test Result

All three tests passed locally on MI300X:
- `test_save_csv`
- `test_analyze_rocpd`
- `test_validate_metrics`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
