### PR TITLE
[ROCM-2950] Optimize rsmi_dev_device_identifiers_get()

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -76,6 +76,13 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Updated memory API documentation**  
     Added note that the sum of per-process memory usage is not expected to equal total usage.
 
+### Optimized
+
+- **Optimized `rsmi_dev_device_identifiers_get()` in the ROCm-SMI device layer**.  
+  - Removed unnecessary iteration by directly indexing the device list.
+  - Added bounds checking for `device_id`, with clearer error handling/logging.
+  - Improves performance for device identifier queries.
+
 ### Resolved Issues
 
 - **Fixed `amd-smi metric` crashing with `TypeError` on MI300A when no CPU flags are specified**.  

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
@@ -1919,7 +1919,6 @@ std::string Device::readBootPartitionState<rsmi_memory_partition_type_t>(uint32_
 
 rsmi_status_t Device::get_smi_device_identifiers(uint32_t device_id,
                                                  rsmi_device_identifiers_t* device_identifiers) {
-  bool found_device = false;
   std::ostringstream ss;
   rsmi_status_t ret = RSMI_STATUS_NOT_SUPPORTED;
   if (device_identifiers == nullptr) {
@@ -1930,40 +1929,27 @@ rsmi_status_t Device::get_smi_device_identifiers(uint32_t device_id,
   auto devices = smi.devices();
   ss << __PRETTY_FUNCTION__ << " | device_id = " << device_id
      << "; devices.size() = " << devices.size();
-  // std::cout << ss.str() << "\n";
   LOG_DEBUG(ss);
 
-  for (uint32_t i = 0; i < devices.size(); i++) {
-    if (i != device_id) {
-      continue;
-    }
+  if (device_id >= static_cast<uint32_t>(devices.size())) {
+    ss << __PRETTY_FUNCTION__ << " | Invalid device_id: " << device_id
+       << "; devices.size(): " << devices.size();
+    LOG_INFO(ss);
+    return RSMI_STATUS_INVALID_ARGS;
+  }
 
-    device_identifiers->card_index = devices[i]->index();
-    device_identifiers->drm_render_minor = devices[i]->drm_render_minor();
-    device_identifiers->bdfid = devices[i]->bdfid();
-    device_identifiers->kfd_gpu_id = devices[i]->kfd_gpu_id();
-    uint32_t temp_partition_id = 0;
-    rsmi_status_t ret = rsmi_dev_partition_id_get(i, &temp_partition_id);
-    if (ret != RSMI_STATUS_SUCCESS) {
-      temp_partition_id = 0;
-    }
-    device_identifiers->partition_id = temp_partition_id;
-    device_identifiers->smi_device_id = i;
-    found_device = true;
-    ss << __PRETTY_FUNCTION__ << " | Found device: "
-       << "card_index = " << device_identifiers->card_index
-       << "; drm_render_minor = " << device_identifiers->drm_render_minor
-       << "; bdfid = " << std::hex << "0x" << device_identifiers->bdfid
-       << "; kfd_gpu_id = " << std::dec << device_identifiers->kfd_gpu_id
-       << "; partition_id = " << device_identifiers->partition_id
-       << "; smi_device_id = " << device_identifiers->smi_device_id;
-    // std::cout << ss.str() << "\n";
-    LOG_DEBUG(ss);
-    break;
+  device_identifiers->card_index = devices[device_id]->index();
+  device_identifiers->drm_render_minor = devices[device_id]->drm_render_minor();
+  device_identifiers->bdfid = devices[device_id]->bdfid();
+  device_identifiers->kfd_gpu_id = devices[device_id]->kfd_gpu_id();
+  uint32_t temp_partition_id = 0;
+  rsmi_status_t partition_id_ret = rsmi_dev_partition_id_get(device_id, &temp_partition_id);
+  if (partition_id_ret != RSMI_STATUS_SUCCESS) {
+    temp_partition_id = 0;
   }
-  if (found_device) {
-    ret = RSMI_STATUS_SUCCESS;
-  }
+  device_identifiers->partition_id = temp_partition_id;
+  device_identifiers->smi_device_id = device_id;
+  ret = RSMI_STATUS_SUCCESS;
   return ret;
 }
 

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
@@ -1931,10 +1931,10 @@ rsmi_status_t Device::get_smi_device_identifiers(uint32_t device_id,
      << "; devices.size() = " << devices.size();
   LOG_DEBUG(ss);
 
-  if (device_id >= static_cast<uint32_t>(devices.size())) {
+  if (static_cast<size_t>(device_id) >= devices.size()) {
     ss << __PRETTY_FUNCTION__ << " | Invalid device_id: " << device_id
        << "; devices.size(): " << devices.size();
-    LOG_INFO(ss);
+    LOG_ERROR(ss);
     return RSMI_STATUS_INVALID_ARGS;
   }
 


### PR DESCRIPTION
## Summary

Optimize `rsmi_dev_device_identifiers_get()` in the ROCm-SMI device layer.

## Changes

- Removed unnecessary loop iteration by directly indexing into the device list using `device_id`
- Added bounds checking for `device_id` with clearer error handling and logging (`RSMI_STATUS_INVALID_ARGS` returned when out of range)
- Removes leftover commented-out debug lines

## Changelog

### Optimized

- **Optimized `rsmi_dev_device_identifiers_get()` in the ROCm-SMI device layer**.
  - Removed unnecessary iteration by directly indexing the device list.
  - Added bounds checking for `device_id`, with clearer error handling/logging.
  - Improves performance for device identifier queries.