### PR TITLE
[ROCM-2950] Fix manufacturer name display for AMD GPUs

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -34,9 +34,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Resolved Issues
 
-- **Fixed manufacturer name display for AMD GPUs**.  
-  - `amdsmi_get_gpu_board_info()` now translates the AMD PCI vendor ID (`0x1002`) into the human-readable `Advanced Micro Devices, Inc. [AMD/ATI]` when the host `pci.ids` lookup is unavailable and `manufacturer_name` is returned as the raw ID, matching the value shown when the lookup succeeds.
-  - Fixes `amd-smi static --board` displaying `0x1002` instead of the vendor name.
+- **Fixed AMD GPU manufacturer name display in `amd-smi static --board`**.  
+  - The CLI now displays the canonical vendor name `Advanced Micro Devices, Inc. [AMD/ATI]` when the board manufacturer name is reported as the raw AMD PCI vendor ID (`0x1002`) because the host `pci.ids` lookup is unavailable. The C and Python APIs continue to return the raw value unchanged.
+  - Standardized the hardcoded AMD vendor string on the canonical `pci.ids` spelling (with the comma) so `VENDOR_NAME` and `MANUFACTURER_NAME` are consistent with `lspci`.
 
 - **Fixed `amdsmi_get_gpu_cper_entries()` crash (`free(): invalid pointer` / `SIGABRT`) when the CPER node reports zero bytes**.  
   - debugfs CPER nodes (`/sys/kernel/debug/dri/<N>/amdgpu_ring_cper`) report `st_size == 0` because their content is generated on read. The previous `std::ifstream`-based read allocated a zero-byte buffer and left an STL `basic_filebuf` whose destructor could perform an invalid free across the library boundary when `libamd_smi.so` is `LD_PRELOAD`-ed alongside a different host libstdc++ (the device-metrics-exporter / `gpuagent` scenario), aborting the process and zeroing all GPU metrics.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -34,6 +34,10 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Resolved Issues
 
+- **Fixed manufacturer name display for AMD GPUs**.  
+  - `amdsmi_get_gpu_board_info()` now translates the AMD PCI vendor ID (`0x1002`) into the human-readable `Advanced Micro Devices, Inc. [AMD/ATI]` when the host `pci.ids` lookup is unavailable and `manufacturer_name` is returned as the raw ID, matching the value shown when the lookup succeeds.
+  - Fixes `amd-smi static --board` displaying `0x1002` instead of the vendor name.
+
 - **Fixed `amdsmi_get_gpu_cper_entries()` crash (`free(): invalid pointer` / `SIGABRT`) when the CPER node reports zero bytes**.  
   - debugfs CPER nodes (`/sys/kernel/debug/dri/<N>/amdgpu_ring_cper`) report `st_size == 0` because their content is generated on read. The previous `std::ifstream`-based read allocated a zero-byte buffer and left an STL `basic_filebuf` whose destructor could perform an invalid free across the library boundary when `libamd_smi.so` is `LD_PRELOAD`-ed alongside a different host libstdc++ (the device-metrics-exporter / `gpuagent` scenario), aborting the process and zeroing all GPU metrics.
   - Reverted the CPER file read to POSIX `open`/`read`/`close`, which performs no STL allocation across the library boundary and returns `AMDSMI_STATUS_FILE_ERROR` cleanly on zero-byte or short reads. The file descriptor is now closed on every exit path, also fixing a latent fd leak on the short-read branch.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -4,6 +4,15 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ***All information listed below is for reference and subject to change.***
 
+## amd_smi_lib for ROCm 7.14.0
+
+### Resolved Issues
+
+- **Fixed manufacturer name display for AMD GPUs**.  
+  - Updated `amdsmi_get_gpu_board_info()` to correctly detect vendor ID `0x1002` and display
+    "Advanced Micro Devices Inc. [AMD/ATI]" instead of the raw ID.
+  - Fixes `amd-smi static --board` output.
+
 ## amd_smi_lib for ROCm 7.13.0
 
 ### Changed

--- a/projects/amdsmi/amdsmi_cli/subcommands/static.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/static.py
@@ -29,6 +29,13 @@ from amdsmi_helpers import AMDSMIHelpers
 from amdsmi import amdsmi_exception, amdsmi_interface
 
 
+# Canonical human-readable AMD vendor string, matching `lspci` / pci.ids (vendor 0x1002).
+# The board manufacturer name is reported as the raw AMD PCI vendor ID ("0x1002") when
+# the host pci.ids lookup is unavailable; the CLI translates it to this string for display
+# while the C/Python APIs continue to return the raw value unchanged.
+AMD_VENDOR_DISPLAY_NAME = "Advanced Micro Devices, Inc. [AMD/ATI]"
+
+
 class StaticCommands:
     def static_cpu(self, args, multiple_devices=False, cpu=None, interface_ver=None):
         """Get Static information for target cpu
@@ -715,6 +722,12 @@ class StaticCommands:
                     if isinstance(value, str):
                         if value.strip() == "":
                             board_info[key] = "N/A"
+                # manufacturer_name falls back to the raw AMD PCI vendor ID ("0x1002")
+                # when the host pci.ids lookup is unavailable. Translate it to the
+                # canonical vendor string for display, matching `lspci` / pci.ids.
+                manufacturer_name = board_info.get("manufacturer_name")
+                if isinstance(manufacturer_name, str) and manufacturer_name.strip() == "0x1002":
+                    board_info["manufacturer_name"] = AMD_VENDOR_DISPLAY_NAME
                 static_dict["board"] = board_info
             except amdsmi_exception.AmdSmiLibraryException as e:
                 logging.debug(

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -1044,7 +1044,7 @@ GPU: 0
     ASIC:
         MARKET_NAME: AMD Instinct MI300A
         VENDOR_ID: 0x1002
-        VENDOR_NAME: Advanced Micro Devices Inc. [AMD/ATI]
+        VENDOR_NAME: Advanced Micro Devices, Inc. [AMD/ATI]
         SUBVENDOR_ID: 0x1002
         DEVICE_ID: 0x74a0
         SUBSYSTEM_ID: 0x74a0

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
@@ -36,7 +36,6 @@
 #include <queue>
 #include <sstream>
 #include <string>
-#include <string_view>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -56,12 +55,6 @@
 #endif
 
 namespace amd::smi {
-
-// Human-readable AMD vendor name for amdsmi_get_gpu_asic_info()'s vendor_name field.
-constexpr std::string_view kAmdVendorName = "Advanced Micro Devices Inc. [AMD/ATI]";
-// Human-readable AMD manufacturer name for amdsmi_get_gpu_board_info()'s
-// manufacturer_name field (canonical pci.ids spelling, includes the comma).
-constexpr std::string_view kAmdManufacturerName = "Advanced Micro Devices, Inc. [AMD/ATI]";
 
 pthread_mutex_t* GetMutex(uint32_t dv_ind);
 int SameFile(const std::string fileA, const std::string fileB);

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
@@ -56,6 +56,9 @@
 
 namespace amd::smi {
 
+// Human-readable AMD vendor name, shared across board/GPU info functions
+constexpr std::string_view kAmdVendorName = "Advanced Micro Devices Inc. [AMD/ATI]";
+
 pthread_mutex_t* GetMutex(uint32_t dv_ind);
 int SameFile(const std::string fileA, const std::string fileB);
 bool FileExists(char const* filename);

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
@@ -36,6 +36,7 @@
 #include <queue>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -56,8 +57,11 @@
 
 namespace amd::smi {
 
-// Human-readable AMD vendor name, shared across board/GPU info functions
+// Human-readable AMD vendor name for amdsmi_get_gpu_asic_info()'s vendor_name field.
 constexpr std::string_view kAmdVendorName = "Advanced Micro Devices Inc. [AMD/ATI]";
+// Human-readable AMD manufacturer name for amdsmi_get_gpu_board_info()'s
+// manufacturer_name field (canonical pci.ids spelling, includes the comma).
+constexpr std::string_view kAmdManufacturerName = "Advanced Micro Devices, Inc. [AMD/ATI]";
 
 pthread_mutex_t* GetMutex(uint32_t dv_ind);
 int SameFile(const std::string fileA, const std::string fileB);

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -1482,7 +1482,7 @@ amdsmi_status_t amdsmi_get_gpu_board_info(amdsmi_processor_handle processor_hand
   }
 
   if (amd::smi::trim(std::string(board_info->manufacturer_name)) == "0x1002") {
-    std::string amd_name(amd::smi::kAmdVendorName);
+    std::string amd_name(amd::smi::kAmdManufacturerName);
     smi_clear_char_and_reinitialize(board_info->manufacturer_name, AMDSMI_MAX_STRING_LENGTH,
                                     amd_name);
   }

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -1481,6 +1481,12 @@ amdsmi_status_t amdsmi_get_gpu_board_info(amdsmi_processor_handle processor_hand
     LOG_INFO(ss);
   }
 
+  if (std::string(board_info->manufacturer_name) == "0x1002") {
+    std::string amd_name = "Advanced Micro Devices Inc. [AMD/ATI]";
+    smi_clear_char_and_reinitialize(board_info->manufacturer_name, AMDSMI_MAX_STRING_LENGTH,
+                                    amd_name);
+  }
+
   ss << __PRETTY_FUNCTION__ << " | [After rocm smi correction] "
      << "Returning status = AMDSMI_STATUS_SUCCESS"
      << "\n; info->model_number: |" << board_info->model_number << "|"

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -1481,8 +1481,8 @@ amdsmi_status_t amdsmi_get_gpu_board_info(amdsmi_processor_handle processor_hand
     LOG_INFO(ss);
   }
 
-  if (std::string(board_info->manufacturer_name) == "0x1002") {
-    std::string amd_name = "Advanced Micro Devices Inc. [AMD/ATI]";
+  if (amd::smi::trim(std::string(board_info->manufacturer_name)) == "0x1002") {
+    std::string amd_name(amd::smi::kAmdVendorName);
     smi_clear_char_and_reinitialize(board_info->manufacturer_name, AMDSMI_MAX_STRING_LENGTH,
                                     amd_name);
   }
@@ -2400,7 +2400,7 @@ amdsmi_status_t amdsmi_get_gpu_asic_info(amdsmi_processor_handle processor_handl
 
   // If vendor name is empty and the vendor id is 0x1002, set vendor name to AMD vendor string
   if ((info->vendor_name[0] == '\0') && info->vendor_id == 0x1002) {
-    std::string amd_name = "Advanced Micro Devices Inc. [AMD/ATI]";
+    std::string amd_name(amd::smi::kAmdVendorName);
     smi_clear_char_and_reinitialize(info->vendor_name, AMDSMI_MAX_STRING_LENGTH, amd_name);
   }
 

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -1481,12 +1481,6 @@ amdsmi_status_t amdsmi_get_gpu_board_info(amdsmi_processor_handle processor_hand
     LOG_INFO(ss);
   }
 
-  if (amd::smi::trim(std::string(board_info->manufacturer_name)) == "0x1002") {
-    std::string amd_name(amd::smi::kAmdManufacturerName);
-    smi_clear_char_and_reinitialize(board_info->manufacturer_name, AMDSMI_MAX_STRING_LENGTH,
-                                    amd_name);
-  }
-
   ss << __PRETTY_FUNCTION__ << " | [After rocm smi correction] "
      << "Returning status = AMDSMI_STATUS_SUCCESS"
      << "\n; info->model_number: |" << board_info->model_number << "|"
@@ -2400,7 +2394,7 @@ amdsmi_status_t amdsmi_get_gpu_asic_info(amdsmi_processor_handle processor_handl
 
   // If vendor name is empty and the vendor id is 0x1002, set vendor name to AMD vendor string
   if ((info->vendor_name[0] == '\0') && info->vendor_id == 0x1002) {
-    std::string amd_name(amd::smi::kAmdVendorName);
+    std::string amd_name = "Advanced Micro Devices, Inc. [AMD/ATI]";
     smi_clear_char_and_reinitialize(info->vendor_name, AMDSMI_MAX_STRING_LENGTH, amd_name);
   }
 

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -1526,6 +1526,12 @@ amdsmi_status_t amdsmi_get_gpu_board_info(amdsmi_processor_handle processor_hand
     LOG_INFO(ss);
   }
 
+  if (std::string(board_info->manufacturer_name) == "0x1002") {
+    std::string amd_name = "Advanced Micro Devices Inc. [AMD/ATI]";
+    smi_clear_char_and_reinitialize(board_info->manufacturer_name, AMDSMI_MAX_STRING_LENGTH,
+                                    amd_name);
+  }
+
   ss << __PRETTY_FUNCTION__ << " | [After rocm smi correction] "
      << "Returning status = AMDSMI_STATUS_SUCCESS"
      << "\n; info->model_number: |" << board_info->model_number << "|"

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -1526,8 +1526,8 @@ amdsmi_status_t amdsmi_get_gpu_board_info(amdsmi_processor_handle processor_hand
     LOG_INFO(ss);
   }
 
-  if (std::string(board_info->manufacturer_name) == "0x1002") {
-    std::string amd_name = "Advanced Micro Devices Inc. [AMD/ATI]";
+  if (amd::smi::trim(std::string(board_info->manufacturer_name)) == "0x1002") {
+    std::string amd_name(amd::smi::kAmdVendorName);
     smi_clear_char_and_reinitialize(board_info->manufacturer_name, AMDSMI_MAX_STRING_LENGTH,
                                     amd_name);
   }
@@ -2445,7 +2445,7 @@ amdsmi_status_t amdsmi_get_gpu_asic_info(amdsmi_processor_handle processor_handl
 
   // If vendor name is empty and the vendor id is 0x1002, set vendor name to AMD vendor string
   if ((info->vendor_name[0] == '\0') && info->vendor_id == 0x1002) {
-    std::string amd_name = "Advanced Micro Devices Inc. [AMD/ATI]";
+    std::string amd_name(amd::smi::kAmdVendorName);
     smi_clear_char_and_reinitialize(info->vendor_name, AMDSMI_MAX_STRING_LENGTH, amd_name);
   }
 

--- a/projects/amdsmi/tests/python_unittest/README.md
+++ b/projects/amdsmi/tests/python_unittest/README.md
@@ -93,7 +93,7 @@ test_asic_kfd_info (__main__.TestAmdSmiPythonInterface) ...
 
   asic_info['market_name'] is: NAVI21
   asic_info['vendor_id'] is: 0x1002
-  asic_info['vendor_name'] is: Advanced Micro Devices Inc. [AMD/ATI]
+  asic_info['vendor_name'] is: Advanced Micro Devices, Inc. [AMD/ATI]
   asic_info['device_id'] is: 0x73bf
   asic_info['rev_id'] is: 0xc1
   asic_info['asic_serial'] is: 0xF8FFEB47A027DE4D
@@ -507,7 +507,7 @@ test_walkthrough (__main__.TestAmdSmiPythonInterface) ...
 
   asic_info['market_name'] is: NAVI21
   asic_info['vendor_id'] is: 0x1002
-  asic_info['vendor_name'] is: Advanced Micro Devices Inc. [AMD/ATI]
+  asic_info['vendor_name'] is: Advanced Micro Devices, Inc. [AMD/ATI]
   asic_info['device_id'] is: 0x73bf
   asic_info['rev_id'] is: 0xc1
   asic_info['subsystem_id'] is: 0xc34
@@ -649,7 +649,7 @@ test_asic_kfd_info (__main__.TestAmdSmiPythonInterface) ...
 
   asic_info['market_name'] is: NAVI21
   asic_info['vendor_id'] is: 0x1002
-  asic_info['vendor_name'] is: Advanced Micro Devices Inc. [AMD/ATI]
+  asic_info['vendor_name'] is: Advanced Micro Devices, Inc. [AMD/ATI]
   asic_info['device_id'] is: 0x73bf
   asic_info['rev_id'] is: 0xc1
   asic_info['asic_serial'] is: 0xF8FFEB47A027DE4D


### PR DESCRIPTION
## Summary

Fix `amdsmi_get_gpu_board_info()` to correctly display the AMD vendor name instead of the raw vendor ID.

## Changes

- When `manufacturer_name` is reported as `"0x1002"` (AMD vendor ID), replace it with the human-readable string `"Advanced Micro Devices Inc. [AMD/ATI]"`
- Fixes `amd-smi static --board` output on AMD GPUs where the vendor name was not resolved by the ROCm-SMI layer

## Changelog

### Resolved Issues

- **Fixed manufacturer name display for AMD GPUs**.
  - Updated `amdsmi_get_gpu_board_info()` to correctly detect vendor ID `0x1002` and display "Advanced Micro Devices Inc. [AMD/ATI]" instead of the raw ID.
  - Fixes `amd-smi static --board` output.