### PR TITLE
[ROCM-2950] Fix `amd-smi` default command output alignment

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -106,6 +106,11 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Fixed `cu_occupancy` displaying `0%` instead of `N/A` when file is unavailable**.  
   - Process `cu_occupancy` is now initialized to `INVALID` instead of zero, so `amd-smi process` displays `N/A` rather than a misleading `0%` when the sysfs file is not accessible.
 
+- **Fixed `amd-smi` default command alignment**.  
+  - Updated default `amd-smi` output to align values to the left for improved readability.
+    Several items were misaligned in the default output, and this change ensures a consistent left-aligned format across all fields.
+  - *This change is purely cosmetic and does not affect any functionality.*  
+
 ### Changed
 
 - **Renamed `lc_perf_other_end_recovery` to `lc_perf_other_end_recovery_count` in `amd-smi metric` CLI output for unification**.  

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -1229,6 +1229,12 @@ class AMDSMILogger:
         vbios_version = _trunc(vbios_version)
         kernel_version = _trunc(kernel_version)
 
+        #####################################################################################
+        # FORMATTING LOGIC:                                                                 #
+        # Each version field is left-aligned within a fixed _COL_WIDTH column. Fields that  #
+        # exceed the column width are truncated with "..." to keep the box border intact.   #
+        # Fields that are "N/A" are skipped entirely to avoid cluttering the output.        #
+        #####################################################################################
         # print GPU info
         print(default_line_1)
         print("| AMD-SMI            {0:<{w}s} |".format(amd_smi_version, w=_COL_WIDTH))

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -1222,24 +1222,24 @@ class AMDSMILogger:
         # print GPU info
         print(default_line_1)
         # Split the version line into 3 lines, each wrapping to the same width
-        print("| AMD-SMI          {0:40s} {1:19s}|".format(amd_smi_version.ljust(40), ""))
+        print("| AMD-SMI            {0:<57s} |".format(amd_smi_version[:57]))
 
         # Print amdgpu or kernel version based on availability, if neither then don't print
         if amdgpu_version.strip() != "N/A":
-            print("| amdgpu Version:  {0:40s} {1:19s}|".format(amdgpu_version, ""))
+            print("| amdgpu Version:    {0:<57s} |".format(amdgpu_version[:57]))
         elif kernel_version.strip() != "N/A":
-            print("| OS kernel Version:  {0:40s} {1:19s}|".format(kernel_version, ""))
+            print("| OS kernel Version: {0:<57s} |".format(kernel_version[:57]))
 
         if rocm_version != "N/A":
-            print("| ROCm Version:    {0:40s} {1:19s}|".format(rocm_version, ""))
+            print("| ROCm Version:      {0:<57s} |".format(rocm_version[:57]))
 
         # only print if the version is not "N/A"
         if vbios_version != "N/A":
-            print("| VBIOS Version:   {0:22s}  {1:35s} |".format(vbios_version, ""))
+            print("| VBIOS Version:     {0:<57s} |".format(vbios_version[:57]))
         if fw_pldm_version != "N/A":
-            print("| FW PLDM:         {0:15s}  {1:42s} |".format(fw_pldm_version, ""))
+            print("| FW PLDM:           {0:<57s} |".format(fw_pldm_version[:57]))
 
-        print("| Platform:        {0:25.25s} {1:34s}|".format(str(self.helpers.os_info()), ""))
+        print("| Platform:          {0:<57s} |".format(str(self.helpers.os_info())[:57]))
         print(default_line_2)
         print("| BDF                        GPU-Name | Mem-Uti   Temp   UEC       Power-Usage |")
         print("| GPU  HIP-ID  OAM-ID  Partition-Mode | GFX-Uti    Fan               Mem-Usage |")

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -1195,8 +1195,6 @@ class AMDSMILogger:
 
         # print the version information first
         amd_smi_version = str(output["version_info"]["amd-smi"])
-        if len(amd_smi_version) > 60:
-            amd_smi_version = amd_smi_version[:57] + "..."
         rocm_version = "N/A"
         if output["version_info"]["rocm version"][0]:
             rocm_version = str(output["version_info"]["rocm version"][1]).ljust(8)
@@ -1218,28 +1216,37 @@ class AMDSMILogger:
         fw_pldm_version = str(output["version_info"]["fw pldm version"])
         vbios_version = str(output["version_info"]["vbios version"])
         kernel_version = str(output["version_info"]["kernel version"])
+        _COL_WIDTH = 57  # inner column width for the default output table
+        def _trunc(s):
+            """Truncate string to _COL_WIDTH chars, appending '...' if it was cut."""
+            return s[:_COL_WIDTH - 3] + "..." if len(s) > _COL_WIDTH else s
+        amd_smi_version = _trunc(amd_smi_version)
+        rocm_version = _trunc(rocm_version)
+        amdgpu_version = _trunc(amdgpu_version)
+        fw_pldm_version = _trunc(fw_pldm_version)
+        vbios_version = _trunc(vbios_version)
+        kernel_version = _trunc(kernel_version)
 
         # print GPU info
         print(default_line_1)
-        # Split the version line into 3 lines, each wrapping to the same width
-        print("| AMD-SMI            {0:<57s} |".format(amd_smi_version[:57]))
+        print("| AMD-SMI            {0:<{w}s} |".format(amd_smi_version, w=_COL_WIDTH))
 
         # Print amdgpu or kernel version based on availability, if neither then don't print
         if amdgpu_version.strip() != "N/A":
-            print("| amdgpu Version:    {0:<57s} |".format(amdgpu_version[:57]))
+            print("| amdgpu Version:    {0:<{w}s} |".format(amdgpu_version, w=_COL_WIDTH))
         elif kernel_version.strip() != "N/A":
-            print("| OS kernel Version: {0:<57s} |".format(kernel_version[:57]))
+            print("| OS kernel Version: {0:<{w}s} |".format(kernel_version, w=_COL_WIDTH))
 
         if rocm_version != "N/A":
-            print("| ROCm Version:      {0:<57s} |".format(rocm_version[:57]))
+            print("| ROCm Version:      {0:<{w}s} |".format(rocm_version, w=_COL_WIDTH))
 
         # only print if the version is not "N/A"
         if vbios_version != "N/A":
-            print("| VBIOS Version:     {0:<57s} |".format(vbios_version[:57]))
+            print("| VBIOS Version:     {0:<{w}s} |".format(vbios_version, w=_COL_WIDTH))
         if fw_pldm_version != "N/A":
-            print("| FW PLDM:           {0:<57s} |".format(fw_pldm_version[:57]))
+            print("| FW PLDM:           {0:<{w}s} |".format(fw_pldm_version, w=_COL_WIDTH))
 
-        print("| Platform:          {0:<57s} |".format(str(self.helpers.os_info())[:57]))
+        print("| Platform:          {0:<{w}s} |".format(_trunc(str(self.helpers.os_info())), w=_COL_WIDTH))
         print(default_line_2)
         print("| BDF                        GPU-Name | Mem-Uti   Temp   UEC       Power-Usage |")
         print("| GPU  HIP-ID  OAM-ID  Partition-Mode | GFX-Uti    Fan               Mem-Usage |")

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -1217,9 +1217,11 @@ class AMDSMILogger:
         vbios_version = str(output["version_info"]["vbios version"])
         kernel_version = str(output["version_info"]["kernel version"])
         _COL_WIDTH = 57  # inner column width for the default output table
+
         def _trunc(s):
             """Truncate string to _COL_WIDTH chars, appending '...' if it was cut."""
-            return s[:_COL_WIDTH - 3] + "..." if len(s) > _COL_WIDTH else s
+            return s[: _COL_WIDTH - 3] + "..." if len(s) > _COL_WIDTH else s
+
         amd_smi_version = _trunc(amd_smi_version)
         rocm_version = _trunc(rocm_version)
         amdgpu_version = _trunc(amdgpu_version)
@@ -1246,7 +1248,11 @@ class AMDSMILogger:
         if fw_pldm_version != "N/A":
             print("| FW PLDM:           {0:<{w}s} |".format(fw_pldm_version, w=_COL_WIDTH))
 
-        print("| Platform:          {0:<{w}s} |".format(_trunc(str(self.helpers.os_info())), w=_COL_WIDTH))
+        print(
+            "| Platform:          {0:<{w}s} |".format(
+                _trunc(str(self.helpers.os_info())), w=_COL_WIDTH
+            )
+        )
         print(default_line_2)
         print("| BDF                        GPU-Name | Mem-Uti   Temp   UEC       Power-Usage |")
         print("| GPU  HIP-ID  OAM-ID  Partition-Mode | GFX-Uti    Fan               Mem-Usage |")


### PR DESCRIPTION
## Summary

Fix misaligned field values in the default `amd-smi` output.

## Changes

- Updated all format strings in `amdsmi_logger.py` to use consistent left-aligned (`:<width>`) formatting with a uniform column width
- Affected fields: AMD-SMI version, amdgpu/kernel version, ROCm version, VBIOS version, FW PLDM, Platform
- Purely cosmetic — no functional impact

## Changelog

### Resolved Issues

- **Fixed `amd-smi` default command alignment**.
  - Updated default `amd-smi` output to align values to the left for improved readability. Several items were misaligned in the default output, and this change ensures a consistent left-aligned format across all fields.
  - *This change is purely cosmetic and does not affect any functionality.*