### PR TITLE
Add TUI-only external workflow adapter import

### DIFF
--- a/experimental/python/perfxpert/CHANGELOG.md
+++ b/experimental/python/perfxpert/CHANGELOG.md
@@ -6,6 +6,11 @@ is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **External workflow adapters for `perfxpert-code`.** Active bundled TUI
+  sessions can inspect advisory local or explicitly approved HTTPS workflow
+  metadata, persist bounded manifests, and surface knowledge/MCP hints without
+  executing scripts, installing packages, importing modules, or registering MCP
+  servers.
 - **Advanced specialist tools — 8 new READ_ONLY MCP tools.** The
   specialist fences now consume eight additional deterministic
   tools surfaced on the MCP wire:

--- a/experimental/python/perfxpert/docs/guides/agentic-mode.md
+++ b/experimental/python/perfxpert/docs/guides/agentic-mode.md
@@ -215,6 +215,7 @@ Roughly:
 | Analyze with Claude | `perfxpert analyze -i trace.db --llm anthropic` |
 | Drive an optimization session conversationally | `perfxpert-code` |
 | Drive an optimization session non-interactively | `perfxpert-code run -m "optimize hot kernel"` |
+| Add an external workflow adapter to the active TUI session | `perfxpert workflow import ./tool` with the interactive consent flag |
 
 Under the hood, the batch CLI, Python API, MCP wrappers, and
 `perfxpert-code` backends all funnel into `build_session()` and the
@@ -233,3 +234,31 @@ an external TUI talks to those runners through MCP.
   [mcp-server.md](../integration/mcp-server.md).
 - **Scripted LLM runs** → `perfxpert-code run -m "..."` or
   `build_session(provider="anthropic")` in Python.
+
+## External workflow adapters
+
+Interactive TUI sessions can import external optimization workflows as
+advisory adapters. The command is accepted only from a `perfxpert-code`
+session environment:
+
+```bash
+# SKIP-SAMPLE — requires an active TUI session and explicit consent
+perfxpert workflow import ./external-tool <interactive-consent-flag> --json
+```
+
+The import performs bounded metadata inspection only. It can discover
+capabilities, knowledge files, and MCP server descriptors, then writes a
+manifest under `.perfxpert/external-workflows/` for the active TUI agent to
+read. It does not run external scripts, install packages, import external
+modules, or register MCP servers. A URL source requires both the TUI session marker and explicit
+`--allow-network` consent:
+
+```bash
+# SKIP-SAMPLE — requires an active TUI session and explicit network consent
+perfxpert workflow import https://github.com/example/tool <interactive-consent-flag> --allow-network --json
+```
+
+Adapter manifests are supplemental context. PerfXpert's measured counters,
+runtime GPU discovery, MCP gate, and correctness cascade remain
+authoritative. In SSH workflows, inspect target-dependent tools on the remote
+workload host so availability and paths match the machine being optimized.

--- a/experimental/python/perfxpert/docs/guides/agentic-mode.md
+++ b/experimental/python/perfxpert/docs/guides/agentic-mode.md
@@ -215,7 +215,7 @@ Roughly:
 | Analyze with Claude | `perfxpert analyze -i trace.db --llm anthropic` |
 | Drive an optimization session conversationally | `perfxpert-code` |
 | Drive an optimization session non-interactively | `perfxpert-code run -m "optimize hot kernel"` |
-| Add an external workflow adapter to the active TUI session | `perfxpert workflow import ./tool` with the interactive consent flag |
+| Add an external workflow adapter to the active TUI session | Ask inside `perfxpert-code`: "use `./tool` as an advisory workflow adapter" |
 
 Under the hood, the batch CLI, Python API, MCP wrappers, and
 `perfxpert-code` backends all funnel into `build_session()` and the
@@ -237,25 +237,27 @@ an external TUI talks to those runners through MCP.
 
 ## External workflow adapters
 
-Interactive TUI sessions can import external optimization workflows as
-advisory adapters. The command is accepted only from a `perfxpert-code`
-session environment:
+The bundled opencode TUI launched by `perfxpert-code` can import external
+optimization workflows as advisory adapters. This is not a normal shell workflow.
+Start `perfxpert-code` and ask inside the interactive TUI, for example:
 
-```bash
-# SKIP-SAMPLE — requires an active TUI session and explicit consent
-perfxpert workflow import ./external-tool <interactive-consent-flag> --json
+```text
+Use ./external-tool as an advisory workflow adapter for this optimization session.
 ```
+
+The TUI agent runs the gated import internally. Running the import from a
+normal shell, from `perfxpert-code run`, or from third-party backend dispatch
+is rejected.
 
 The import performs bounded metadata inspection only. It can discover
 capabilities, knowledge files, and MCP server descriptors, then writes a
 manifest under `.perfxpert/external-workflows/` for the active TUI agent to
 read. It does not run external scripts, install packages, import external
-modules, or register MCP servers. A URL source requires both the TUI session marker and explicit
-`--allow-network` consent:
+modules, or register MCP servers. A URL source requires both the live TUI
+session marker and explicit network consent:
 
-```bash
-# SKIP-SAMPLE — requires an active TUI session and explicit network consent
-perfxpert workflow import https://github.com/example/tool <interactive-consent-flag> --allow-network --json
+```text
+Use https://github.com/example/tool as an advisory workflow adapter for this session.
 ```
 
 Adapter manifests are supplemental context. PerfXpert's measured counters,

--- a/experimental/python/perfxpert/docs/guides/getting-started.md
+++ b/experimental/python/perfxpert/docs/guides/getting-started.md
@@ -1149,6 +1149,24 @@ Inside the TUI you describe your workload in natural language
 drives the Analysis → Recommendation → Specialist hierarchy behind the
 scenes.
 
+External optimization toolkits can be imported into that active session as
+advisory workflow adapters. The command is accepted only from the
+`perfxpert-code` session environment, and the TUI agent runs:
+
+```bash
+# SKIP-SAMPLE — requires an active TUI session and explicit consent
+perfxpert workflow import ./external-tool <interactive-consent-flag> --json
+```
+
+For an HTTPS repository, it must ask for network consent before adding
+`--allow-network`. The adapter can contribute workflow hints, knowledge
+links, or MCP server descriptors, but PerfXpert does not run external scripts,
+install packages, import external modules, or register those MCP servers
+during import. PerfXpert's measured
+counters, runtime GPU discovery, MCP gate, and correctness cascade remain
+authoritative. In SSH workflows, inspect target-dependent tools on the remote
+workload host so availability and paths match the machine being optimized.
+
 ### What happens:
 
 1. **Workload detection** — identifies your binary type (HIP, Python ML,

--- a/experimental/python/perfxpert/docs/guides/getting-started.md
+++ b/experimental/python/perfxpert/docs/guides/getting-started.md
@@ -1150,17 +1150,18 @@ drives the Analysis → Recommendation → Specialist hierarchy behind the
 scenes.
 
 External optimization toolkits can be imported into that active session as
-advisory workflow adapters. The command is accepted only from the
-`perfxpert-code` session environment, and the TUI agent runs:
+advisory workflow adapters. This is only available from the bundled opencode
+TUI launched by `perfxpert-code`. Ask inside that TUI, for example:
 
-```bash
-# SKIP-SAMPLE — requires an active TUI session and explicit consent
-perfxpert workflow import ./external-tool <interactive-consent-flag> --json
+```text
+Use ./external-tool as an advisory workflow adapter for this optimization session.
 ```
 
-For an HTTPS repository, it must ask for network consent before adding
-`--allow-network`. The adapter can contribute workflow hints, knowledge
-links, or MCP server descriptors, but PerfXpert does not run external scripts,
+The TUI agent runs the gated import internally; running the import from a
+normal shell, from `perfxpert-code run`, or from third-party backend dispatch
+is rejected. For an HTTPS repository, the TUI agent must ask for explicit
+network consent before inspection. The adapter can contribute workflow hints,
+knowledge links, or MCP server descriptors, but PerfXpert does not run external scripts,
 install packages, import external modules, or register those MCP servers
 during import. PerfXpert's measured
 counters, runtime GPU discovery, MCP gate, and correctness cascade remain
@@ -1206,9 +1207,10 @@ Typical examples the TUI is designed to propose when the trace evidence matches:
 - suggest LDS tiling when a memory-bound stencil or GEMM-like kernel reloads
   the same neighborhood repeatedly from global memory
 
-If the edit causes compilation errors, the Correctness agent reverts the
-change automatically; see `docs/architecture/gate-cascade.md` for the full
-5-gate correctness/regression contract.
+If the edit causes compilation errors, the Correctness agent attempts to
+revert the change and reports the gate result for review; see
+`docs/architecture/gate-cascade.md` for the full 5-gate
+correctness/regression workflow.
 
 ---
 

--- a/experimental/python/perfxpert/perfxpert/__main__.py
+++ b/experimental/python/perfxpert/perfxpert/__main__.py
@@ -18,6 +18,7 @@ Usage
     perfxpert analyze -i trace.db --llm anthropic
     perfxpert diff baseline.db new.db --format text
     perfxpert ci baseline.db new.db --threshold 3.0
+    perfxpert workflow import ./external-tool --interactive
     perfxpert-code    (interactive TUI; launches the AMD-branded opencode session)
 """
 
@@ -182,6 +183,22 @@ def main(argv=None):
     )
     _ci_cmd.add_args(ci_parser)
 
+    # ------------------------------------------------------------------
+    # workflow subcommand
+    # ------------------------------------------------------------------
+    from perfxpert.cli import workflow_cmd as _workflow_cmd
+
+    workflow_parser = subparsers.add_parser(
+        "workflow",
+        help="TUI-only external workflow adapter inspection",
+        description=(
+            "Inspect external workflow repositories for advisory capabilities, "
+            "knowledge links, and MCP descriptors that can be used by an active "
+            "perfxpert-code session."
+        ),
+    )
+    _workflow_cmd.add_args(workflow_parser)
+
     if argv is None:
         argv = sys.argv[1:]
 
@@ -256,6 +273,8 @@ def main(argv=None):
         sys.exit(_diff_cmd.run_diff(args))
     elif args.subcommand == "ci":
         sys.exit(_ci_cmd.run_ci(args))
+    elif args.subcommand == "workflow":
+        sys.exit(_workflow_cmd.run_workflow(args))
     else:
         parser.print_help()
         sys.exit(1)

--- a/experimental/python/perfxpert/perfxpert/__main__.py
+++ b/experimental/python/perfxpert/perfxpert/__main__.py
@@ -18,7 +18,6 @@ Usage
     perfxpert analyze -i trace.db --llm anthropic
     perfxpert diff baseline.db new.db --format text
     perfxpert ci baseline.db new.db --threshold 3.0
-    perfxpert workflow import ./external-tool --interactive
     perfxpert-code    (interactive TUI; launches the AMD-branded opencode session)
 """
 
@@ -54,7 +53,11 @@ def main(argv=None):
         version="%(prog)s " + _get_version(),
     )
 
-    subparsers = parser.add_subparsers(dest="subcommand", title="subcommands")
+    subparsers = parser.add_subparsers(
+        dest="subcommand",
+        title="subcommands",
+        metavar="{analyze,config,providers,doctor,init,diff,ci}",
+    )
 
     # ------------------------------------------------------------------
     # analyze subcommand
@@ -190,7 +193,7 @@ def main(argv=None):
 
     workflow_parser = subparsers.add_parser(
         "workflow",
-        help="TUI-only external workflow adapter inspection",
+        help=argparse.SUPPRESS,
         description=(
             "Inspect external workflow repositories for advisory capabilities, "
             "knowledge links, and MCP descriptors that can be used by an active "
@@ -198,6 +201,9 @@ def main(argv=None):
         ),
     )
     _workflow_cmd.add_args(workflow_parser)
+    subparsers._choices_actions = [  # type: ignore[attr-defined]
+        action for action in subparsers._choices_actions if action.dest != "workflow"  # type: ignore[attr-defined]
+    ]
 
     if argv is None:
         argv = sys.argv[1:]
@@ -319,9 +325,9 @@ def _check_mcp_server() -> tuple[bool, str]:
         from mcp_server.server import build_server
         from mcp_server._registry import discover_read_only_tools
 
-        server = build_server()  # noqa: F841
-        n = len(discover_read_only_tools())
-        return True, f"MCP server reachable"
+        build_server()
+        discover_read_only_tools()
+        return True, "MCP server reachable"
     except Exception as e:
         return False, f"MCP server FAILED: {e}"
 

--- a/experimental/python/perfxpert/perfxpert/_bundled/opencode_config/AGENTS.md
+++ b/experimental/python/perfxpert/perfxpert/_bundled/opencode_config/AGENTS.md
@@ -147,10 +147,13 @@ If a user asks to use an external repository, tool, or workflow as
 PerfXpert optimization logic, keep the import inside the interactive TUI
 session:
 
-1. Run `perfxpert workflow import <source>` with the interactive consent flag
-   and JSON output enabled.
-   For `https://` sources, only add `--allow-network` after explicit user
-   consent.
+1. When the user asks inside `perfxpert-code`, invoke the gated internal
+   workflow-import helper with JSON output and the required interactive
+   consent option. This works only in the live bundled opencode TUI launched
+   by `perfxpert-code` because that launcher owns the active-session socket.
+   Do not present a copy-paste shell command, and do not use it from
+   `perfxpert-code run` or third-party backend dispatch.
+   For `https://` sources, only add network access after explicit user consent.
 2. Treat the adapter manifest as advisory context. It may add
    `workflow_hints`, `knowledge_links`, and discovered `mcp_servers`, but
    it must not override measured counters, GPU specs, the MCP gate, or the
@@ -160,8 +163,9 @@ session:
    approves that separate action inside the active session. Do not mutate
    global backend MCP configuration unless the user separately asks for
    persistent installation.
-4. For SSH or remote-workload sessions, inspect and run target-dependent
-   tools on the remote workload host, not on the local controller.
+4. For SSH or remote-workload sessions, inspect target-dependent tools on the
+   remote workload host, not on the local controller. Run remote commands only
+   after the user explicitly approves that separate remote action.
 
 ## Branding
 

--- a/experimental/python/perfxpert/perfxpert/_bundled/opencode_config/AGENTS.md
+++ b/experimental/python/perfxpert/perfxpert/_bundled/opencode_config/AGENTS.md
@@ -141,6 +141,28 @@ don't over-use Root if the user already gave you the bottleneck.
 6. **Stream responses.** Start your reply as soon as the first MCP
    call returns; do not wait for everything to complete.
 
+## External workflow adapters
+
+If a user asks to use an external repository, tool, or workflow as
+PerfXpert optimization logic, keep the import inside the interactive TUI
+session:
+
+1. Run `perfxpert workflow import <source>` with the interactive consent flag
+   and JSON output enabled.
+   For `https://` sources, only add `--allow-network` after explicit user
+   consent.
+2. Treat the adapter manifest as advisory context. It may add
+   `workflow_hints`, `knowledge_links`, and discovered `mcp_servers`, but
+   it must not override measured counters, GPU specs, the MCP gate, or the
+   correctness cascade.
+3. Do not run install commands, import external modules, execute external
+   scripts, or start newly discovered MCP servers until the user explicitly
+   approves that separate action inside the active session. Do not mutate
+   global backend MCP configuration unless the user separately asks for
+   persistent installation.
+4. For SSH or remote-workload sessions, inspect and run target-dependent
+   tools on the remote workload host, not on the local controller.
+
 ## Branding
 
 Every response ends with a thin rule line:

--- a/experimental/python/perfxpert/perfxpert/cli/_backend_dispatch.py
+++ b/experimental/python/perfxpert/perfxpert/cli/_backend_dispatch.py
@@ -29,6 +29,7 @@ __all__ = [
 # `perfxpert-code claude` from within an already-running agent session
 # refuses to launch).
 RECURSION_GUARD_ENV = "PERFXPERT_IN_AGENT_SESSION"
+INTERACTIVE_TUI_ENV = "PERFXPERT_TUI_INTERACTIVE"
 
 
 def is_help_request(remaining_argv: list[str]) -> bool:
@@ -170,6 +171,9 @@ def _run_adapter(adapter, remaining_argv: list[str]) -> int:
 
     env = dict(os.environ)
     env[RECURSION_GUARD_ENV] = adapter.name
+    if not flags.remaining:
+        env[INTERACTIVE_TUI_ENV] = "1"
+    env["PERFXPERT_WORKLOAD_CWD"] = str(Path.cwd())
     if not flags.quiet:
         sys.stderr.write(
             f"perfxpert-code {adapter.name}: MCP verified; launching "

--- a/experimental/python/perfxpert/perfxpert/cli/_backend_dispatch.py
+++ b/experimental/python/perfxpert/perfxpert/cli/_backend_dispatch.py
@@ -14,6 +14,7 @@ import sys
 from pathlib import Path
 from typing import Callable, Dict, List
 
+from perfxpert.cli._tui_session import clear_tui_session_env
 
 __all__ = [
     "_exec_backend",
@@ -29,7 +30,6 @@ __all__ = [
 # `perfxpert-code claude` from within an already-running agent session
 # refuses to launch).
 RECURSION_GUARD_ENV = "PERFXPERT_IN_AGENT_SESSION"
-INTERACTIVE_TUI_ENV = "PERFXPERT_TUI_INTERACTIVE"
 
 
 def is_help_request(remaining_argv: list[str]) -> bool:
@@ -136,6 +136,7 @@ def _run_adapter(adapter, remaining_argv: list[str]) -> int:
         # Just exec the backend with --help; adapter.spawn returns
         # the exit code if spawn_strategy == "subprocess".
         env = dict(os.environ)
+        clear_tui_session_env(env)
         env[RECURSION_GUARD_ENV] = adapter.name
         return adapter.spawn(remaining_argv, env, Path.cwd())
 
@@ -170,9 +171,8 @@ def _run_adapter(adapter, remaining_argv: list[str]) -> int:
         return 0
 
     env = dict(os.environ)
+    clear_tui_session_env(env)
     env[RECURSION_GUARD_ENV] = adapter.name
-    if not flags.remaining:
-        env[INTERACTIVE_TUI_ENV] = "1"
     env["PERFXPERT_WORKLOAD_CWD"] = str(Path.cwd())
     if not flags.quiet:
         sys.stderr.write(

--- a/experimental/python/perfxpert/perfxpert/cli/_backend_dispatch.py
+++ b/experimental/python/perfxpert/perfxpert/cli/_backend_dispatch.py
@@ -14,8 +14,6 @@ import sys
 from pathlib import Path
 from typing import Callable, Dict, List
 
-from perfxpert.cli._tui_session import clear_tui_session_env
-
 __all__ = [
     "_exec_backend",
     "is_help_request",
@@ -136,7 +134,7 @@ def _run_adapter(adapter, remaining_argv: list[str]) -> int:
         # Just exec the backend with --help; adapter.spawn returns
         # the exit code if spawn_strategy == "subprocess".
         env = dict(os.environ)
-        clear_tui_session_env(env)
+        _clear_tui_session_env(env)
         env[RECURSION_GUARD_ENV] = adapter.name
         return adapter.spawn(remaining_argv, env, Path.cwd())
 
@@ -159,28 +157,36 @@ def _run_adapter(adapter, remaining_argv: list[str]) -> int:
             quiet=flags.quiet,
         )
     except Exception as exc:
-        sys.stderr.write(
-            f"perfxpert-code {adapter.name}: install failed: {exc}\n"
-        )
+        sys.stderr.write(f"perfxpert-code {adapter.name}: install failed: {exc}\n")
         return 1
 
     if flags.dry_run:
-        sys.stderr.write(
-            f"[DRY-RUN] Would exec: {adapter.binary_name} {' '.join(flags.remaining)}\n"
-        )
+        sys.stderr.write(f"[DRY-RUN] Would exec: {adapter.binary_name} {' '.join(flags.remaining)}\n")
         return 0
 
     env = dict(os.environ)
-    clear_tui_session_env(env)
+    _clear_tui_session_env(env)
     env[RECURSION_GUARD_ENV] = adapter.name
     env["PERFXPERT_WORKLOAD_CWD"] = str(Path.cwd())
     if not flags.quiet:
-        sys.stderr.write(
-            f"perfxpert-code {adapter.name}: MCP verified; launching "
-            f"{adapter.binary_name} ...\n"
-        )
+        sys.stderr.write(f"perfxpert-code {adapter.name}: MCP verified; launching " f"{adapter.binary_name} ...\n")
         sys.stderr.flush()
     return adapter.spawn(flags.remaining, env, Path.cwd())
+
+
+def _clear_tui_session_env(env: dict[str, str]) -> None:
+    try:
+        from perfxpert.cli._tui_session import clear_tui_session_env
+
+        clear_tui_session_env(env)
+    except ImportError:
+        for key in (
+            "PERFXPERT_TUI_INTERACTIVE",
+            "PERFXPERT_TUI_SESSION_TOKEN",
+            "PERFXPERT_TUI_SESSION_SOCKET",
+            "PERFXPERT_TUI_SESSION_TOKEN_FILE",
+        ):
+            env.pop(key, None)
 
 
 def _exec_backend(name: str, remaining_argv: list[str]) -> int:
@@ -206,9 +212,7 @@ def _exec_backend(name: str, remaining_argv: list[str]) -> int:
 
     handler = BACKEND_REGISTRY.get(name)
     if handler is None:
-        sys.stderr.write(
-            f"perfxpert-code: no handler registered for backend {name!r}.\n"
-        )
+        sys.stderr.write(f"perfxpert-code: no handler registered for backend {name!r}.\n")
         return 2
 
     return handler(remaining_argv)

--- a/experimental/python/perfxpert/perfxpert/cli/_tui_session.py
+++ b/experimental/python/perfxpert/perfxpert/cli/_tui_session.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hmac
 import os
-import pwd
 import secrets
 import shutil
 import socket
@@ -16,6 +15,11 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
+
+try:
+    import pwd
+except ImportError:  # pragma: no cover - non-Unix import-safety guard
+    pwd = None  # type: ignore[assignment]
 
 
 INTERACTIVE_TUI_ENV = "PERFXPERT_TUI_INTERACTIVE"
@@ -63,6 +67,9 @@ def bind_tui_session_env(env: dict[str, str]) -> Path:
     The helper also validates that the socket peer is an ancestor process,
     preventing a shell-created sibling socket from satisfying the gate.
     """
+
+    if not _platform_supports_active_tui_session():
+        raise RuntimeError("active TUI workflow authorization requires Linux peer-credential sockets")
 
     token = secrets.token_urlsafe(32)
     session_dir = Path(tempfile.mkdtemp(prefix="perfxpert-tui-"))
@@ -139,6 +146,8 @@ def cleanup_tui_session_env(env: dict[str, str]) -> None:
 def has_active_tui_session(env: dict[str, str] | None = None) -> bool:
     """Return True when ``env`` carries a valid active TUI socket token."""
 
+    if not _platform_supports_active_tui_session():
+        return False
     env = os.environ if env is None else env
     if env.get(INTERACTIVE_TUI_ENV) != "1":
         return False
@@ -287,6 +296,11 @@ def _trusted_launcher_paths() -> tuple[Path, ...]:
 
 
 def _account_home() -> Path | None:
+    if pwd is None:
+        try:
+            return Path.home()
+        except RuntimeError:
+            return None
     try:
         return Path(pwd.getpwuid(os.getuid()).pw_dir)
     except KeyError:
@@ -319,6 +333,10 @@ def _peer_credentials(conn: socket.socket) -> tuple[int, int, int] | None:
         return struct.unpack("3i", raw)
     except struct.error:
         return None
+
+
+def _platform_supports_active_tui_session() -> bool:
+    return hasattr(socket, "AF_UNIX") and hasattr(socket, "SO_PEERCRED") and Path("/proc").is_dir()
 
 
 def _pid_in_current_ancestry(target_pid: int) -> bool:

--- a/experimental/python/perfxpert/perfxpert/cli/_tui_session.py
+++ b/experimental/python/perfxpert/perfxpert/cli/_tui_session.py
@@ -1,0 +1,384 @@
+"""Active TUI session authority helpers."""
+
+from __future__ import annotations
+
+import hmac
+import os
+import pwd
+import secrets
+import shutil
+import socket
+import stat
+import struct
+import sysconfig
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+INTERACTIVE_TUI_ENV = "PERFXPERT_TUI_INTERACTIVE"
+TUI_SESSION_TOKEN_ENV = "PERFXPERT_TUI_SESSION_TOKEN"
+TUI_SESSION_SOCKET_ENV = "PERFXPERT_TUI_SESSION_SOCKET"
+
+# Legacy env from the first implementation; always scrub it so stale shells do
+# not carry confusing authority-looking state into noninteractive commands.
+TUI_SESSION_TOKEN_FILE_ENV = "PERFXPERT_TUI_SESSION_TOKEN_FILE"
+
+_TOKEN_TTL_SECONDS = 12 * 60 * 60
+_SERVER_TIMEOUT_SECONDS = 0.25
+_CLIENT_TIMEOUT_SECONDS = 1.0
+_AUTH_OK = b"ok"
+_AUTH_NO = b"no"
+
+
+@dataclass(frozen=True)
+class _ServerRef:
+    listener: socket.socket
+    stop: threading.Event
+    thread: threading.Thread
+    session_dir: Path
+
+
+_SERVER_REGISTRY: dict[str, _ServerRef] = {}
+
+
+def clear_tui_session_env(env: dict[str, str]) -> None:
+    """Remove inherited active-TUI authority from an environment mapping."""
+
+    env.pop(INTERACTIVE_TUI_ENV, None)
+    env.pop(TUI_SESSION_TOKEN_ENV, None)
+    env.pop(TUI_SESSION_SOCKET_ENV, None)
+    env.pop(TUI_SESSION_TOKEN_FILE_ENV, None)
+
+
+def bind_tui_session_env(env: dict[str, str]) -> Path:
+    """Bind a launcher-owned active-session socket into ``env``.
+
+    ``perfxpert workflow import`` is intentionally an internal helper for a
+    live ``perfxpert-code`` TUI. A plain shell can set environment variables,
+    so the marker is backed by a private Unix socket whose server validates
+    that the caller is a descendant of the launcher process that created it.
+    The helper also validates that the socket peer is an ancestor process,
+    preventing a shell-created sibling socket from satisfying the gate.
+    """
+
+    token = secrets.token_urlsafe(32)
+    session_dir = Path(tempfile.mkdtemp(prefix="perfxpert-tui-"))
+    socket_path = session_dir / "auth.sock"
+    listener: socket.socket | None = None
+    try:
+        os.chmod(session_dir, 0o700)
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        listener.bind(str(socket_path))
+        os.chmod(socket_path, 0o600)
+        listener.listen(16)
+
+        stop = threading.Event()
+        owner_pid = os.getpid()
+        owner_uid = os.getuid()
+        created_at = int(time.time())
+        thread = threading.Thread(
+            target=_auth_server_main,
+            args=(listener, stop, owner_pid, owner_uid, token, created_at),
+            name="perfxpert-tui-auth",
+            daemon=True,
+        )
+        thread.start()
+        _SERVER_REGISTRY[str(socket_path)] = _ServerRef(
+            listener=listener,
+            stop=stop,
+            thread=thread,
+            session_dir=session_dir,
+        )
+        listener = None
+    except Exception:
+        if listener is not None:
+            try:
+                listener.close()
+            except OSError:
+                pass
+        shutil.rmtree(session_dir, ignore_errors=True)
+        raise
+
+    env[INTERACTIVE_TUI_ENV] = "1"
+    env[TUI_SESSION_TOKEN_ENV] = token
+    env[TUI_SESSION_SOCKET_ENV] = str(socket_path)
+    env.pop(TUI_SESSION_TOKEN_FILE_ENV, None)
+    return socket_path
+
+
+def cleanup_tui_session_env(env: dict[str, str]) -> None:
+    """Best-effort shutdown of the active-session socket server."""
+
+    raw_path = env.get(TUI_SESSION_SOCKET_ENV)
+    if raw_path:
+        ref = _SERVER_REGISTRY.pop(raw_path, None)
+        if ref is not None:
+            ref.stop.set()
+            try:
+                ref.listener.close()
+            except OSError:
+                pass
+            ref.thread.join(timeout=1.0)
+            shutil.rmtree(ref.session_dir, ignore_errors=True)
+        else:
+            path = Path(raw_path)
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            try:
+                path.parent.rmdir()
+            except OSError:
+                pass
+    clear_tui_session_env(env)
+
+
+def has_active_tui_session(env: dict[str, str] | None = None) -> bool:
+    """Return True when ``env`` carries a valid active TUI socket token."""
+
+    env = os.environ if env is None else env
+    if env.get(INTERACTIVE_TUI_ENV) != "1":
+        return False
+    token = env.get(TUI_SESSION_TOKEN_ENV)
+    raw_path = env.get(TUI_SESSION_SOCKET_ENV)
+    if not token or not raw_path:
+        return False
+    path = Path(raw_path)
+    try:
+        st = path.lstat()
+    except OSError:
+        return False
+    if stat.S_ISLNK(st.st_mode) or not stat.S_ISSOCK(st.st_mode):
+        return False
+    if st.st_mode & 0o077:
+        return False
+
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(_CLIENT_TIMEOUT_SECONDS)
+            client.connect(str(path))
+            credentials = _peer_credentials(client)
+            if not _peer_is_current_ancestor(credentials):
+                return False
+            client.sendall(token.encode("utf-8"))
+            response = client.recv(16)
+    except OSError:
+        return False
+    return response == _AUTH_OK
+
+
+def _auth_server_main(
+    listener: socket.socket,
+    stop: threading.Event,
+    owner_pid: int,
+    owner_uid: int,
+    token: str,
+    created_at: int,
+) -> None:
+    listener.settimeout(_SERVER_TIMEOUT_SECONDS)
+    token_bytes = token.encode("utf-8")
+    deadline = created_at + _TOKEN_TTL_SECONDS
+    while not stop.is_set():
+        now = int(time.time())
+        if now > deadline or not _process_alive(owner_pid):
+            break
+        try:
+            conn, _ = listener.accept()
+        except socket.timeout:
+            continue
+        except OSError:
+            break
+        with conn:
+            conn.settimeout(_CLIENT_TIMEOUT_SECONDS)
+            ok = _peer_is_launcher_descendant(conn, owner_pid, owner_uid)
+            try:
+                candidate = conn.recv(512).strip()
+            except OSError:
+                candidate = b""
+            if ok and hmac.compare_digest(candidate, token_bytes):
+                _send_auth_response(conn, _AUTH_OK)
+            else:
+                _send_auth_response(conn, _AUTH_NO)
+    try:
+        listener.close()
+    except OSError:
+        pass
+
+
+def _send_auth_response(conn: socket.socket, response: bytes) -> None:
+    try:
+        conn.sendall(response)
+    except OSError:
+        pass
+
+
+def _peer_is_launcher_descendant(conn: socket.socket, owner_pid: int, owner_uid: int) -> bool:
+    credentials = _peer_credentials(conn)
+    if credentials is None:
+        return False
+    client_pid, client_uid, _client_gid = credentials
+    if client_uid != owner_uid:
+        return False
+    if client_pid <= 1 or client_pid == owner_pid:
+        return False
+    return _pid_has_ancestor(client_pid, owner_pid)
+
+
+def _peer_is_current_ancestor(credentials: tuple[int, int, int] | None) -> bool:
+    if credentials is None:
+        return False
+    peer_pid, peer_uid, _peer_gid = credentials
+    if peer_uid != os.getuid():
+        return False
+    if peer_pid <= 1 or peer_pid == os.getpid():
+        return False
+    return _pid_in_current_ancestry(peer_pid) and _process_is_perfxpert_code_launcher(peer_pid)
+
+
+def _process_is_perfxpert_code_launcher(pid: int) -> bool:
+    script = _launcher_script_arg(_read_proc_args(pid))
+    if script is None:
+        return False
+    try:
+        resolved = Path(script).resolve(strict=True)
+    except OSError:
+        return False
+    if not any(_same_file(resolved, trusted) for trusted in _trusted_launcher_paths()):
+        return False
+    return _launcher_script_has_expected_entrypoint(resolved)
+
+
+def _launcher_script_arg(args: list[str]) -> str | None:
+    if not args:
+        return None
+    first = Path(args[0]).name.lower()
+    if first.startswith("python") and len(args) > 1:
+        return args[1]
+    return args[0]
+
+
+def _trusted_launcher_paths() -> tuple[Path, ...]:
+    candidates: list[Path] = []
+    scripts_dir = sysconfig.get_path("scripts")
+    if scripts_dir:
+        candidates.append(Path(scripts_dir) / "perfxpert-code")
+    home = _account_home()
+    if home is not None:
+        candidates.append(home / ".local" / "bin" / "perfxpert-code")
+    candidates.extend(
+        [
+            Path("/usr/local/bin/perfxpert-code"),
+            Path("/usr/bin/perfxpert-code"),
+        ]
+    )
+
+    resolved: list[Path] = []
+    for candidate in candidates:
+        try:
+            path = candidate.resolve(strict=True)
+        except OSError:
+            continue
+        if path not in resolved:
+            resolved.append(path)
+    return tuple(resolved)
+
+
+def _account_home() -> Path | None:
+    try:
+        return Path(pwd.getpwuid(os.getuid()).pw_dir)
+    except KeyError:
+        return None
+
+
+def _same_file(left: Path, right: Path) -> bool:
+    try:
+        return left.samefile(right)
+    except OSError:
+        return False
+
+
+def _launcher_script_has_expected_entrypoint(path: Path) -> bool:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return "perfxpert.cli.opencode_launcher" in text and "main" in text
+
+
+def _peer_credentials(conn: socket.socket) -> tuple[int, int, int] | None:
+    if not hasattr(socket, "SO_PEERCRED"):
+        return None
+    try:
+        raw = conn.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, struct.calcsize("3i"))
+    except OSError:
+        return None
+    try:
+        return struct.unpack("3i", raw)
+    except struct.error:
+        return None
+
+
+def _pid_in_current_ancestry(target_pid: int) -> bool:
+    pid = os.getppid()
+    seen: set[int] = set()
+    while pid > 1 and pid not in seen:
+        if pid == target_pid:
+            return True
+        seen.add(pid)
+        next_pid = _parent_pid(pid)
+        if next_pid is None or next_pid == pid:
+            break
+        pid = next_pid
+    return False
+
+
+def _pid_has_ancestor(pid: int, ancestor_pid: int) -> bool:
+    seen: set[int] = set()
+    current = _parent_pid(pid)
+    while current and current > 1 and current not in seen:
+        if current == ancestor_pid:
+            return True
+        seen.add(current)
+        current = _parent_pid(current)
+    return False
+
+
+def _process_alive(pid: int) -> bool:
+    if pid <= 1:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _parent_pid(pid: int) -> int | None:
+    stat_text = _read_proc_text(pid, "stat")
+    if not stat_text:
+        return None
+    try:
+        after_comm = stat_text.rsplit(")", 1)[1].strip()
+        fields = after_comm.split()
+        return int(fields[1])
+    except (IndexError, ValueError):
+        return None
+
+
+def _read_proc_text(pid: int, name: str) -> str:
+    try:
+        return Path("/proc").joinpath(str(pid), name).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _read_proc_args(pid: int) -> list[str]:
+    raw = _read_proc_text(pid, "cmdline")
+    return [arg for arg in raw.split("\x00") if arg]

--- a/experimental/python/perfxpert/perfxpert/cli/opencode_launcher.py
+++ b/experimental/python/perfxpert/perfxpert/cli/opencode_launcher.py
@@ -24,11 +24,6 @@ from importlib import resources
 from pathlib import Path
 from typing import Iterable
 
-from perfxpert.cli._tui_session import (
-    bind_tui_session_env,
-    cleanup_tui_session_env,
-    clear_tui_session_env,
-)
 from perfxpert.tools._tooldep import require_tool
 
 __all__ = [
@@ -46,31 +41,77 @@ _BRANDING_VERSION = "0.2.0"
 # Known opencode subcommands (v1.4.x) — a single bare positional that matches
 # one of these MUST be forwarded as a subcommand, not treated as the CWD.
 # Derived from opencode/packages/opencode/src/cli/cmd/*.ts.
-_OPENCODE_SUBCOMMANDS = frozenset({
-    "account",
-    "acp",
-    "agent",
-    "auth",      # legacy alias for account
-    "config",
-    "db",
-    "debug",
-    "export",
-    "generate",
-    "github",
-    "import",
-    "mcp",
-    "models",
-    "pr",
-    "plug",
-    "plugin",
-    "providers",
-    "run",
-    "serve",
-    "session",
-    "stats",
-    "tui",
-    "web",
-})
+_OPENCODE_SUBCOMMANDS = frozenset(
+    {
+        "account",
+        "acp",
+        "agent",
+        "auth",  # legacy alias for account
+        "completion",
+        "config",
+        "db",
+        "debug",
+        "export",
+        "generate",
+        "github",
+        "import",
+        "mcp",
+        "models",
+        "pr",
+        "plug",
+        "plugin",
+        "providers",
+        "run",
+        "serve",
+        "session",
+        "stats",
+        "upgrade",
+        "web",
+    }
+)
+_OPENCODE_VALUE_FLAGS = frozenset(
+    {
+        "--agent",
+        "--attach",
+        "--command",
+        "--config",
+        "--cors",
+        "--dir",
+        "--file",
+        "--format",
+        "--glob",
+        "--hostname",
+        "--limit",
+        "--log-level",
+        "--max-count",
+        "--mdns-domain",
+        "--method",
+        "--model",
+        "--models",
+        "--mode",
+        "--password",
+        "--path",
+        "--permission",
+        "--port",
+        "--prompt",
+        "--project",
+        "--provider",
+        "--query",
+        "--session",
+        "--theme",
+        "--thinking",
+        "--title",
+        "--token",
+        "--tool",
+        "--tools",
+        "--variant",
+        "-f",
+        "-m",
+        "-n",
+        "-p",
+        "-s",
+    }
+)
 
 # Subcommands the perfxpert launcher handles itself (does NOT exec opencode).
 # Kept in sync with `perfxpert/__main__.py`; descriptions are surfaced by
@@ -291,11 +332,38 @@ def _help_flag_precedes_subcommand(argv: Iterable[str]) -> bool:
     verbatim. Only the bare `perfxpert-code --help` case should print our
     banner.
     """
-    for tok in argv:
-        if tok in {"--help", "-h"}:
-            return True
-        if not tok.startswith("-"):
+    args = list(argv)
+    first_positional = _first_positional_index(args)
+    idx = 0
+    while idx < len(args):
+        token = args[idx]
+        if token == "--":
             return False
+        if _flag_takes_value(token):
+            if "=" not in token:
+                idx += 1
+            idx += 1
+            continue
+        if token in {"--help", "-h"}:
+            return first_positional is None or idx < first_positional
+        idx += 1
+    return False
+
+
+def _has_unconsumed_help_flag(argv: list[str]) -> bool:
+    idx = 0
+    while idx < len(argv):
+        token = argv[idx]
+        if token == "--":
+            return False
+        if _flag_takes_value(token):
+            if "=" not in token:
+                idx += 1
+            idx += 1
+            continue
+        if token in {"--help", "-h"}:
+            return True
+        idx += 1
     return False
 
 
@@ -334,12 +402,7 @@ def route_subcommand(argv: list[str]) -> tuple[str, list[str]]:
     "Failed to change directory to ...doctor" bug reported in session
     ses_25e1.
     """
-    # Find the first non-flag positional token (flags start with '-').
-    first_positional: str | None = None
-    for a in argv:
-        if not a.startswith("-"):
-            first_positional = a
-            break
+    first_positional = _first_positional(argv)
 
     if first_positional is None:
         return ("opencode_default", list(argv))
@@ -361,6 +424,9 @@ def route_subcommand(argv: list[str]) -> tuple[str, list[str]]:
                 break
         return ("user_opencode", out)
 
+    if first_positional == "tui":
+        return ("opencode_default", _strip_tui_alias(argv))
+
     if first_positional in _OPENCODE_SUBCOMMANDS:
         return ("opencode_subcommand", list(argv))
 
@@ -368,26 +434,126 @@ def route_subcommand(argv: list[str]) -> tuple[str, list[str]]:
 
 
 def _first_positional(argv: list[str]) -> str | None:
-    for token in argv:
-        if not token.startswith("-"):
-            return token
-    return None
+    positional = _first_positional_index(argv)
+    return argv[positional] if positional is not None else None
+
+
+def _positional_tokens(argv: list[str]) -> list[str]:
+    return [argv[idx] for idx in _positional_indices(argv)]
+
+
+def _first_positional_index(argv: list[str]) -> int | None:
+    indices = _positional_indices(argv)
+    return indices[0] if indices else None
+
+
+def _positional_indices(argv: list[str]) -> list[int]:
+    indices: list[int] = []
+    idx = 0
+    while idx < len(argv):
+        token = argv[idx]
+        if token == "--":
+            indices.extend(range(idx + 1, len(argv)))
+            break
+        if _flag_takes_value(token):
+            if "=" not in token:
+                idx += 1
+            idx += 1
+            continue
+        if token.startswith("-"):
+            idx += 1
+            continue
+        indices.append(idx)
+        idx += 1
+    return indices
+
+
+def _flag_takes_value(token: str) -> bool:
+    flag = token.split("=", 1)[0]
+    return flag in _OPENCODE_VALUE_FLAGS
+
+
+def _strip_tui_alias(argv: list[str]) -> list[str]:
+    out = list(argv)
+    tui_idx = _first_positional_index(out)
+    if tui_idx is None or out[tui_idx] != "tui":
+        return out
+    del out[tui_idx]
+
+    dir_value = _option_value(out, "--dir")
+    if dir_value:
+        out = _remove_option_value(out, "--dir")
+        if _first_positional_index(out) is None:
+            out.append(dir_value)
+    return out
 
 
 def _is_interactive_opencode_launch(kind: str, argv_out: list[str]) -> bool:
+    if _has_unconsumed_help_flag(argv_out):
+        return False
     if kind == "opencode_default":
         return True
-    return kind == "opencode_subcommand" and _first_positional(argv_out) == "tui"
+    positionals = _positional_tokens(argv_out)
+    return kind == "opencode_subcommand" and bool(positionals) and positionals[0] == "tui"
 
 
 def _resolve_workload_cwd(kind: str, argv_out: list[str]) -> Path:
+    dir_value = _option_value(argv_out, "--dir")
+    if dir_value:
+        candidate = Path(dir_value).expanduser()
+        if candidate.is_dir():
+            return candidate.resolve()
+    positionals = _positional_tokens(argv_out)
     if kind == "opencode_default":
-        first = _first_positional(argv_out)
-        if first:
-            candidate = Path(first).expanduser()
+        if positionals:
+            candidate = Path(positionals[0]).expanduser()
             if candidate.is_dir():
                 return candidate.resolve()
+    if kind == "opencode_subcommand" and len(positionals) >= 2 and positionals[0] == "tui":
+        candidate = Path(positionals[1]).expanduser()
+        if candidate.is_dir():
+            return candidate.resolve()
     return Path.cwd()
+
+
+def _option_value(argv: list[str], flag: str) -> str | None:
+    prefix = f"{flag}="
+    idx = 0
+    while idx < len(argv):
+        token = argv[idx]
+        if token == "--":
+            return None
+        if token == flag and idx + 1 < len(argv):
+            return argv[idx + 1]
+        if token.startswith(prefix):
+            return token[len(prefix) :]
+        if _flag_takes_value(token):
+            if "=" not in token:
+                idx += 1
+            idx += 1
+        else:
+            idx += 1
+    return None
+
+
+def _remove_option_value(argv: list[str], flag: str) -> list[str]:
+    prefix = f"{flag}="
+    out: list[str] = []
+    idx = 0
+    while idx < len(argv):
+        token = argv[idx]
+        if token == "--":
+            out.extend(argv[idx:])
+            break
+        if token == flag:
+            idx += 2
+            continue
+        if token.startswith(prefix):
+            idx += 1
+            continue
+        out.append(token)
+        idx += 1
+    return out
 
 
 def _run_install_patches(argv: list[str]) -> int:
@@ -403,7 +569,7 @@ def _run_install_patches(argv: list[str]) -> int:
     here = Path(__file__).resolve()
     candidates = [
         here.parent.parent.parent / "scripts" / "build-bundled-opencode.sh",  # editable install
-        Path.cwd() / "scripts" / "build-bundled-opencode.sh",                 # dev cwd
+        Path.cwd() / "scripts" / "build-bundled-opencode.sh",  # dev cwd
     ]
     script: Path | None = None
     for c in candidates:
@@ -461,21 +627,18 @@ def _inject_perfxpert_agent_for_run(argv_out: list[str]) -> list[str]:
         "yes",
     }:
         return argv_out
+    if _has_unconsumed_help_flag(argv_out):
+        return argv_out
 
-    # First non-flag positional must be "run".
-    run_idx: int | None = None
-    for i, tok in enumerate(argv_out):
-        if tok.startswith("-"):
-            continue
-        if tok == "run":
-            run_idx = i
-        break  # stop at first positional either way
+    run_idx = _first_positional_index(argv_out)
+    if run_idx is not None and argv_out[run_idx] != "run":
+        run_idx = None
 
     if run_idx is None:
         return argv_out
 
     # User already specified --agent somewhere?
-    if any(tok == "--agent" or tok.startswith("--agent=") for tok in argv_out):
+    if _has_unconsumed_option(argv_out, "--agent"):
         return argv_out
 
     # Insert after `run`. argv is [maybe-flags..., 'run', message_tokens...].
@@ -483,6 +646,24 @@ def _inject_perfxpert_agent_for_run(argv_out: list[str]) -> list[str]:
     new_argv.insert(run_idx + 1, "--agent")
     new_argv.insert(run_idx + 2, "perfxpert")
     return new_argv
+
+
+def _has_unconsumed_option(argv: list[str], option: str) -> bool:
+    idx = 0
+    while idx < len(argv):
+        token = argv[idx]
+        if token == "--":
+            return False
+        flag = token.split("=", 1)[0]
+        if flag == option:
+            return True
+        if _flag_takes_value(token):
+            if "=" not in token:
+                idx += 1
+            idx += 1
+        else:
+            idx += 1
+    return False
 
 
 def _exec_perfxpert_subcommand(argv: list[str]) -> int:
@@ -530,8 +711,7 @@ def _run_uninstall(remaining_argv: list[str]) -> int:
 
     if backend is None:
         sys.stderr.write(
-            "perfxpert-code uninstall: which backend?\n"
-            "  Usage: perfxpert-code uninstall {claude,gemini,codex}\n"
+            "perfxpert-code uninstall: which backend?\n" "  Usage: perfxpert-code uninstall {claude,gemini,codex}\n"
         )
         return 2
 
@@ -550,8 +730,7 @@ def _run_uninstall(remaining_argv: list[str]) -> int:
         adapter = CodexAdapter()
     else:
         sys.stderr.write(
-            f"perfxpert-code uninstall: unknown backend {backend!r}. "
-            "Expected one of: claude, gemini, codex.\n"
+            f"perfxpert-code uninstall: unknown backend {backend!r}. " "Expected one of: claude, gemini, codex.\n"
         )
         return 2
 
@@ -562,9 +741,7 @@ def _run_uninstall(remaining_argv: list[str]) -> int:
     # Dry-run preview + confirmation.
     plan = adapter.plan(cwd)
     if not quiet:
-        sys.stderr.write(
-            f"perfxpert-code uninstall {backend}: will remove\n"
-        )
+        sys.stderr.write(f"perfxpert-code uninstall {backend}: will remove\n")
         for action in plan.actions:
             sys.stderr.write(f"    - (reverse) {action}\n")
 
@@ -594,9 +771,7 @@ def _run_uninstall(remaining_argv: list[str]) -> int:
         for action in report.actions:
             sys.stderr.write(f"  {action}\n")
         if report.skipped_due_to_drift:
-            sys.stderr.write(
-                "\nRefused to remove these files (marker drift):\n"
-            )
+            sys.stderr.write("\nRefused to remove these files (marker drift):\n")
             for p in report.skipped_due_to_drift:
                 sys.stderr.write(f"  - {p}\n")
             return 1
@@ -658,7 +833,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"\033[31mperfxpert-code opencode: {e}\033[0m", file=sys.stderr)
             return 1
         env = dict(os.environ)
-        clear_tui_session_env(env)
+        _clear_tui_session_env(env)
         try:
             proc = subprocess.run([str(binary), *argv_out], env=env, check=False)
         except KeyboardInterrupt:
@@ -699,13 +874,20 @@ def main(argv: list[str] | None = None) -> int:
     # We do NOT use the EXECUTION-tool env whitelist here because opencode is the
     # user's interactive session and they explicitly consent to it.
     env = dict(os.environ)
-    clear_tui_session_env(env)
+    _clear_tui_session_env(env)
     # Recursion guard marker (spec §5.8 / R10)
     env["PERFXPERT_IN_OPENCODE_SESSION"] = "1"
     env["PERFXPERT_WORKLOAD_CWD"] = str(_resolve_workload_cwd(kind, argv_out))
     tui_token_bound = _is_interactive_opencode_launch(kind, argv_out)
     if tui_token_bound:
-        bind_tui_session_env(env)
+        try:
+            _bind_tui_session_env(env)
+        except (ImportError, OSError, RuntimeError) as exc:
+            print(
+                f"\033[31mperfxpert-code: cannot start TUI workflow import authority: {exc}\033[0m",
+                file=sys.stderr,
+            )
+            return 1
     # Disable opencode's auto-update check — it prompts with upstream branding
     # and, if confirmed, would replace our patched bundle with upstream.
     env.setdefault("OPENCODE_DISABLE_AUTOUPDATE", "1")
@@ -736,8 +918,38 @@ def main(argv: list[str] | None = None) -> int:
         return 130
     finally:
         if tui_token_bound:
-            cleanup_tui_session_env(env)
+            _cleanup_tui_session_env(env)
     return proc.returncode
+
+
+def _clear_tui_session_env(env: dict[str, str]) -> None:
+    try:
+        from perfxpert.cli._tui_session import clear_tui_session_env
+
+        clear_tui_session_env(env)
+    except ImportError:
+        for key in (
+            "PERFXPERT_TUI_INTERACTIVE",
+            "PERFXPERT_TUI_SESSION_TOKEN",
+            "PERFXPERT_TUI_SESSION_SOCKET",
+            "PERFXPERT_TUI_SESSION_TOKEN_FILE",
+        ):
+            env.pop(key, None)
+
+
+def _bind_tui_session_env(env: dict[str, str]) -> None:
+    from perfxpert.cli._tui_session import bind_tui_session_env
+
+    bind_tui_session_env(env)
+
+
+def _cleanup_tui_session_env(env: dict[str, str]) -> None:
+    try:
+        from perfxpert.cli._tui_session import cleanup_tui_session_env
+
+        cleanup_tui_session_env(env)
+    except ImportError:
+        _clear_tui_session_env(env)
 
 
 def _prepare_runtime_config_dir(src_config_dir: Path) -> Path:
@@ -761,9 +973,7 @@ def _prepare_runtime_config_dir(src_config_dir: Path) -> Path:
                 shutil.copy2(f, target)
         return runtime_dir
 
-    cache_root = Path(
-        os.environ.get("XDG_CACHE_HOME", str(Path.home() / ".cache"))
-    ).expanduser()
+    cache_root = Path(os.environ.get("XDG_CACHE_HOME", str(Path.home() / ".cache"))).expanduser()
     try:
         return _stage_into(cache_root / "perfxpert" / "opencode")
     except OSError:

--- a/experimental/python/perfxpert/perfxpert/cli/opencode_launcher.py
+++ b/experimental/python/perfxpert/perfxpert/cli/opencode_launcher.py
@@ -24,6 +24,11 @@ from importlib import resources
 from pathlib import Path
 from typing import Iterable
 
+from perfxpert.cli._tui_session import (
+    bind_tui_session_env,
+    cleanup_tui_session_env,
+    clear_tui_session_env,
+)
 from perfxpert.tools._tooldep import require_tool
 
 __all__ = [
@@ -81,7 +86,6 @@ _PERFXPERT_SUBCOMMANDS: "dict[str, str]" = {
     "opencode": "Run a user-owned upstream opencode binary explicitly",
     "providers": "List LLM providers and configuration status",
     "uninstall": "Reverse `perfxpert-code <backend>` install: remove MCP + AGENTS + gate hook",
-    "workflow": "Inspect external workflow adapters for the active TUI session",
 }
 
 # Subcommand names the launcher itself dispatches to `python -m perfxpert`
@@ -363,6 +367,29 @@ def route_subcommand(argv: list[str]) -> tuple[str, list[str]]:
     return ("opencode_default", list(argv))
 
 
+def _first_positional(argv: list[str]) -> str | None:
+    for token in argv:
+        if not token.startswith("-"):
+            return token
+    return None
+
+
+def _is_interactive_opencode_launch(kind: str, argv_out: list[str]) -> bool:
+    if kind == "opencode_default":
+        return True
+    return kind == "opencode_subcommand" and _first_positional(argv_out) == "tui"
+
+
+def _resolve_workload_cwd(kind: str, argv_out: list[str]) -> Path:
+    if kind == "opencode_default":
+        first = _first_positional(argv_out)
+        if first:
+            candidate = Path(first).expanduser()
+            if candidate.is_dir():
+                return candidate.resolve()
+    return Path.cwd()
+
+
 def _run_install_patches(argv: list[str]) -> int:
     """Run scripts/build-bundled-opencode.sh.
 
@@ -630,8 +657,10 @@ def main(argv: list[str] | None = None) -> int:
         except FileNotFoundError as e:
             print(f"\033[31mperfxpert-code opencode: {e}\033[0m", file=sys.stderr)
             return 1
+        env = dict(os.environ)
+        clear_tui_session_env(env)
         try:
-            proc = subprocess.run([str(binary), *argv_out], env=dict(os.environ), check=False)
+            proc = subprocess.run([str(binary), *argv_out], env=env, check=False)
         except KeyboardInterrupt:
             return 130
         return proc.returncode
@@ -670,11 +699,13 @@ def main(argv: list[str] | None = None) -> int:
     # We do NOT use the EXECUTION-tool env whitelist here because opencode is the
     # user's interactive session and they explicitly consent to it.
     env = dict(os.environ)
+    clear_tui_session_env(env)
     # Recursion guard marker (spec §5.8 / R10)
     env["PERFXPERT_IN_OPENCODE_SESSION"] = "1"
-    env["PERFXPERT_WORKLOAD_CWD"] = str(Path.cwd())
-    if kind == "opencode_default" or (kind == "opencode_subcommand" and argv_out[:1] == ["tui"]):
-        env["PERFXPERT_TUI_INTERACTIVE"] = "1"
+    env["PERFXPERT_WORKLOAD_CWD"] = str(_resolve_workload_cwd(kind, argv_out))
+    tui_token_bound = _is_interactive_opencode_launch(kind, argv_out)
+    if tui_token_bound:
+        bind_tui_session_env(env)
     # Disable opencode's auto-update check — it prompts with upstream branding
     # and, if confirmed, would replace our patched bundle with upstream.
     env.setdefault("OPENCODE_DISABLE_AUTOUPDATE", "1")
@@ -703,6 +734,9 @@ def main(argv: list[str] | None = None) -> int:
         proc = subprocess.run(cmd, env=env, cwd=exec_cwd, check=False)
     except KeyboardInterrupt:
         return 130
+    finally:
+        if tui_token_bound:
+            cleanup_tui_session_env(env)
     return proc.returncode
 
 

--- a/experimental/python/perfxpert/perfxpert/cli/opencode_launcher.py
+++ b/experimental/python/perfxpert/perfxpert/cli/opencode_launcher.py
@@ -81,13 +81,14 @@ _PERFXPERT_SUBCOMMANDS: "dict[str, str]" = {
     "opencode": "Run a user-owned upstream opencode binary explicitly",
     "providers": "List LLM providers and configuration status",
     "uninstall": "Reverse `perfxpert-code <backend>` install: remove MCP + AGENTS + gate hook",
+    "workflow": "Inspect external workflow adapters for the active TUI session",
 }
 
 # Subcommand names the launcher itself dispatches to `python -m perfxpert`
 # or handles inline. These must short-circuit BEFORE resolve_opencode_binary()
 # so they work on a fresh install without opencode on disk.
 _PERFXPERT_DISPATCH_SUBCOMMANDS = frozenset(
-    {"init", "diff", "ci", "doctor", "install-patches", "uninstall"}
+    {"init", "diff", "ci", "doctor", "install-patches", "uninstall", "workflow"}
 )
 
 
@@ -167,7 +168,8 @@ def resolve_opencode_binary() -> Path:
     raise FileNotFoundError(
         "bundled patched opencode binary not found. Reinstall perfxpert with the "
         "GitHub wrapper so the pinned opencode submodule is built:\n"
-        '  REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"\n'
+        '  REF=develop; curl -fsSL "https://raw.githubusercontent.com/ROCm/rocm-systems/${REF}/'
+        'experimental/python/perfxpert/scripts/pip-install-from-git.sh" | bash -s -- "${REF}"\n'
         "For a user-owned upstream opencode binary, run: perfxpert-code opencode [args]"
     )
 
@@ -550,7 +552,7 @@ def _run_uninstall(remaining_argv: list[str]) -> int:
                 "export PERFXPERT_ASSUME_CONSENT=1 to confirm.\n"
             )
             return 2
-        sys.stderr.write(f"\nProceed? [y/N] ")
+        sys.stderr.write("\nProceed? [y/N] ")
         sys.stderr.flush()
         try:
             answer = input().strip().lower()
@@ -670,6 +672,9 @@ def main(argv: list[str] | None = None) -> int:
     env = dict(os.environ)
     # Recursion guard marker (spec §5.8 / R10)
     env["PERFXPERT_IN_OPENCODE_SESSION"] = "1"
+    env["PERFXPERT_WORKLOAD_CWD"] = str(Path.cwd())
+    if kind == "opencode_default" or (kind == "opencode_subcommand" and argv_out[:1] == ["tui"]):
+        env["PERFXPERT_TUI_INTERACTIVE"] = "1"
     # Disable opencode's auto-update check — it prompts with upstream branding
     # and, if confirmed, would replace our patched bundle with upstream.
     env.setdefault("OPENCODE_DISABLE_AUTOUPDATE", "1")

--- a/experimental/python/perfxpert/perfxpert/cli/workflow_cmd.py
+++ b/experimental/python/perfxpert/perfxpert/cli/workflow_cmd.py
@@ -8,7 +8,6 @@ import os
 import sys
 from pathlib import Path
 
-from perfxpert.cli._tui_session import has_active_tui_session
 from perfxpert.integrations.external_workflow import (
     ExternalWorkflowError,
     ExternalWorkflowRuntimeError,
@@ -34,28 +33,28 @@ def add_args(parser: argparse.ArgumentParser) -> None:
     import_parser.add_argument(
         "--interactive",
         action="store_true",
-        help="Required consent marker; only perfxpert-code interactive sessions should pass it",
+        help=argparse.SUPPRESS,
     )
     import_parser.add_argument(
         "--allow-network",
         action="store_true",
-        help="Allow cloning an https:// source after interactive consent",
+        help=argparse.SUPPRESS,
     )
     import_parser.add_argument(
         "--cache-root",
         type=Path,
         default=None,
-        help="Adapter cache root (defaults to ./.perfxpert/external-workflows)",
+        help=argparse.SUPPRESS,
     )
     import_parser.add_argument(
         "--json",
         action="store_true",
-        help="Print the full adapter manifest as JSON",
+        help=argparse.SUPPRESS,
     )
     import_parser.add_argument(
         "--no-persist",
         action="store_true",
-        help="Inspect only; do not write the adapter manifest",
+        help=argparse.SUPPRESS,
     )
 
 
@@ -69,7 +68,7 @@ def run_workflow(args: argparse.Namespace) -> int:
     if not args.interactive or not _in_perfxpert_tui_session():
         print(
             "perfxpert workflow import: external workflow adapters are TUI-interactive only; "
-            "rerun inside perfxpert-code with --interactive.",
+            "start perfxpert-code and ask inside the TUI to import the adapter.",
             file=sys.stderr,
         )
         return 2
@@ -107,4 +106,8 @@ def _print_summary(plan: dict[str, object]) -> None:
 
 
 def _in_perfxpert_tui_session() -> bool:
+    try:
+        from perfxpert.cli._tui_session import has_active_tui_session
+    except ImportError:
+        return False
     return has_active_tui_session(os.environ)

--- a/experimental/python/perfxpert/perfxpert/cli/workflow_cmd.py
+++ b/experimental/python/perfxpert/perfxpert/cli/workflow_cmd.py
@@ -8,6 +8,7 @@ import os
 import sys
 from pathlib import Path
 
+from perfxpert.cli._tui_session import has_active_tui_session
 from perfxpert.integrations.external_workflow import (
     ExternalWorkflowError,
     ExternalWorkflowRuntimeError,
@@ -106,4 +107,4 @@ def _print_summary(plan: dict[str, object]) -> None:
 
 
 def _in_perfxpert_tui_session() -> bool:
-    return os.environ.get("PERFXPERT_TUI_INTERACTIVE") == "1"
+    return has_active_tui_session(os.environ)

--- a/experimental/python/perfxpert/perfxpert/cli/workflow_cmd.py
+++ b/experimental/python/perfxpert/perfxpert/cli/workflow_cmd.py
@@ -1,0 +1,109 @@
+"""CLI surface for TUI-only workflow adapter imports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from perfxpert.integrations.external_workflow import (
+    ExternalWorkflowError,
+    ExternalWorkflowRuntimeError,
+    inspect_external_workflow,
+)
+
+
+def add_args(parser: argparse.ArgumentParser) -> None:
+    """Register ``perfxpert workflow`` subcommands."""
+
+    sub = parser.add_subparsers(dest="workflow_action", required=True)
+    import_parser = sub.add_parser(
+        "import",
+        help="Inspect an external workflow adapter for the active TUI session",
+        description=(
+            "Inspect a local repo or user-approved HTTPS repo and emit an advisory "
+            "adapter manifest for perfxpert-code. This command is intentionally "
+            "TUI-interactive only; import does not install packages, run adapter "
+            "scripts, or start MCP servers."
+        ),
+    )
+    import_parser.add_argument("source", help="Local path or https:// repository URL to inspect")
+    import_parser.add_argument(
+        "--interactive",
+        action="store_true",
+        help="Required consent marker; only perfxpert-code interactive sessions should pass it",
+    )
+    import_parser.add_argument(
+        "--allow-network",
+        action="store_true",
+        help="Allow cloning an https:// source after interactive consent",
+    )
+    import_parser.add_argument(
+        "--cache-root",
+        type=Path,
+        default=None,
+        help="Adapter cache root (defaults to ./.perfxpert/external-workflows)",
+    )
+    import_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the full adapter manifest as JSON",
+    )
+    import_parser.add_argument(
+        "--no-persist",
+        action="store_true",
+        help="Inspect only; do not write the adapter manifest",
+    )
+
+
+def run_workflow(args: argparse.Namespace) -> int:
+    """Run the selected workflow subcommand."""
+
+    if args.workflow_action != "import":
+        print(f"perfxpert workflow: unknown action {args.workflow_action!r}", file=sys.stderr)
+        return 2
+
+    if not args.interactive or not _in_perfxpert_tui_session():
+        print(
+            "perfxpert workflow import: external workflow adapters are TUI-interactive only; "
+            "rerun inside perfxpert-code with --interactive.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        plan = inspect_external_workflow(
+            args.source,
+            interactive=True,
+            allow_network=bool(args.allow_network),
+            cache_root=args.cache_root,
+            persist=not bool(args.no_persist),
+        )
+    except ExternalWorkflowError as exc:
+        print(f"perfxpert workflow import: {exc}", file=sys.stderr)
+        return 1 if isinstance(exc, ExternalWorkflowRuntimeError) else 2
+
+    if args.json:
+        print(json.dumps(plan, indent=2, sort_keys=True))
+    else:
+        _print_summary(plan)
+    return 0
+
+
+def _print_summary(plan: dict[str, object]) -> None:
+    capabilities = plan.get("capabilities") or []
+    mcp_servers = plan.get("mcp_servers") or []
+    knowledge_links = plan.get("knowledge_links") or []
+    print(f"Imported external workflow adapter: {plan.get('adapter_id')}")
+    if plan.get("manifest_path"):
+        print(f"Manifest: {plan.get('manifest_path')}")
+    print(f"Capabilities: {len(capabilities)}")
+    print(f"MCP servers discovered: {len(mcp_servers)}")
+    print(f"Knowledge links: {len(knowledge_links)}")
+    print("Activation: advisory TUI context only; explicit consent required for execution or MCP registration")
+
+
+def _in_perfxpert_tui_session() -> bool:
+    return os.environ.get("PERFXPERT_TUI_INTERACTIVE") == "1"

--- a/experimental/python/perfxpert/perfxpert/integrations/__init__.py
+++ b/experimental/python/perfxpert/perfxpert/integrations/__init__.py
@@ -1,2 +1,1 @@
 """Integration helpers for optional PerfXpert workflow adapters."""
-

--- a/experimental/python/perfxpert/perfxpert/integrations/__init__.py
+++ b/experimental/python/perfxpert/perfxpert/integrations/__init__.py
@@ -1,0 +1,2 @@
+"""Integration helpers for optional PerfXpert workflow adapters."""
+

--- a/experimental/python/perfxpert/perfxpert/integrations/external_workflow.py
+++ b/experimental/python/perfxpert/perfxpert/integrations/external_workflow.py
@@ -1,0 +1,741 @@
+"""Safe inspection for TUI-only external workflow adapters.
+
+External workflow adapters are intentionally advisory. They can contribute
+capability hints, knowledge links, and MCP server descriptors to the active TUI
+session, but import never installs packages, runs adapter scripts, imports
+adapter modules, starts MCP servers, or overrides PerfXpert's gate, MCP, or
+correctness policy.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+MAX_CANDIDATE_FILES = 120
+MAX_SCANNED_DIRS = 512
+MAX_SCAN_DEPTH = 8
+MAX_CHILDREN_PER_DIR = 1024
+MAX_TEXT_BYTES = 256 * 1024
+_CLONE_COMPLETE_SENTINEL = ".perfxpert-adapter-clone-complete"
+_SKIP_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "test",
+    "tests",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+    ".venv",
+}
+_TEXT_SUFFIXES = {
+    ".md",
+    ".rst",
+    ".txt",
+    ".json",
+    ".toml",
+    ".yaml",
+    ".yml",
+    ".py",
+    ".sh",
+}
+_SPECIAL_NAMES = {
+    ".mcp.json",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "GEMINI.md",
+    "SKILL.md",
+    "README",
+    "README.md",
+    "README.rst",
+    "mcp.json",
+    "opencode.json",
+    "package.json",
+    "pyproject.toml",
+}
+_PRIORITY_DIR_NAMES = {"docs", "doc", "knowledge", "skills", "agents"}
+
+
+class ExternalWorkflowError(RuntimeError):
+    """Raised when an external workflow source cannot be safely inspected."""
+
+
+class ExternalWorkflowUsageError(ExternalWorkflowError):
+    """Raised for invalid user input or missing TUI consent."""
+
+
+class ExternalWorkflowRuntimeError(ExternalWorkflowError):
+    """Raised for IO, clone, cache, or manifest failures."""
+
+
+@dataclass(frozen=True)
+class ExternalWorkflowCapability:
+    """A capability discovered in an external workflow source."""
+
+    kind: str
+    name: str
+    source: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ExternalWorkflowKnowledgeLink:
+    """A candidate knowledge file the TUI agent may read as advisory context."""
+
+    path: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ExternalWorkflowMcpServer:
+    """A discovered MCP server descriptor. Registration still needs consent."""
+
+    name: str
+    command: str | None
+    args: list[str]
+    source: str
+    activation: str = (
+        "requires explicit active-session TUI consent before registration; "
+        "persistent or global MCP config changes require a separate persistent-install request"
+    )
+
+
+@dataclass
+class ExternalWorkflowAdapterPlan:
+    """Serializable adapter plan handed back to the active TUI session."""
+
+    adapter_id: str
+    source: str
+    source_kind: str
+    materialized_path: str | None
+    interactive_only: bool = True
+    execution_allowed: bool = False
+    authority: str = "advisory; PerfXpert MCP gate and correctness checks remain authoritative"
+    target_host_scope: str = (
+        "discover and run target-dependent tools on the workload host; for SSH workflows, "
+        "inspect the remote host instead of the local controller"
+    )
+    capabilities: list[ExternalWorkflowCapability] = field(default_factory=list)
+    workflow_hints: list[str] = field(default_factory=list)
+    knowledge_links: list[ExternalWorkflowKnowledgeLink] = field(default_factory=list)
+    mcp_servers: list[ExternalWorkflowMcpServer] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    inspected_files: list[str] = field(default_factory=list)
+    manifest_path: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable dictionary."""
+
+        return asdict(self)
+
+
+def inspect_external_workflow(
+    source: str,
+    *,
+    interactive: bool,
+    allow_network: bool = False,
+    cache_root: Path | None = None,
+    persist: bool = True,
+) -> dict[str, Any]:
+    """Inspect an external workflow source and return an advisory adapter plan.
+
+    The function performs bounded metadata inspection only. It does not import
+    Python modules from the source, run scripts, install packages, or register
+    discovered MCP servers.
+    """
+
+    if not interactive:
+        raise ExternalWorkflowUsageError(
+            "external workflow import is TUI-interactive only; pass --interactive from perfxpert-code"
+        )
+
+    root = _default_cache_root() if cache_root is None else Path(cache_root).expanduser()
+    materialized, source_kind, display_source, source_warnings = _materialize_source(
+        source,
+        cache_root=root,
+        interactive=interactive,
+        allow_network=allow_network,
+    )
+    adapter_id = _adapter_id(display_source)
+    plan = ExternalWorkflowAdapterPlan(
+        adapter_id=adapter_id,
+        source=display_source,
+        source_kind=source_kind,
+        materialized_path=str(materialized),
+        warnings=[
+            "External workflow adapters are advisory TUI context only.",
+            "PerfXpert does not execute install commands, scripts, or MCP servers during import.",
+            *source_warnings,
+        ],
+    )
+
+    files, scan_warnings = _candidate_files(materialized)
+    plan.warnings.extend(scan_warnings)
+    texts: list[tuple[Path, str]] = []
+    for path in files:
+        rel = _relpath(path, materialized)
+        text = _read_text_limited(path)
+        if text is None:
+            continue
+        plan.inspected_files.append(rel)
+        texts.append((path, text))
+
+    _detect_capabilities(plan, materialized, texts)
+    _detect_mcp_servers(plan, materialized, texts)
+    _detect_knowledge_links(plan, materialized, files)
+    _detect_risky_install_hints(plan, texts)
+    _derive_workflow_hints(plan)
+
+    if persist:
+        try:
+            plan.manifest_path = str(_write_manifest(root, plan))
+        except OSError as exc:
+            raise ExternalWorkflowRuntimeError(f"failed to write adapter manifest: {exc}") from exc
+
+    return plan.to_dict()
+
+
+def _default_cache_root() -> Path:
+    return _workflow_base_dir() / ".perfxpert" / "external-workflows"
+
+
+def _workflow_base_dir() -> Path:
+    return Path(os.environ.get("PERFXPERT_WORKLOAD_CWD", Path.cwd())).expanduser().resolve()
+
+
+def _materialize_source(
+    source: str,
+    *,
+    cache_root: Path,
+    interactive: bool,
+    allow_network: bool,
+) -> tuple[Path, str, str, list[str]]:
+    root = _safe_cache_root(cache_root)
+    parsed = urlparse(source)
+    if parsed.scheme in {"http", "https"}:
+        if parsed.scheme != "https":
+            raise ExternalWorkflowUsageError("external workflow URLs must use https://")
+        if parsed.username or parsed.password:
+            raise ExternalWorkflowUsageError("external workflow URLs must not contain embedded credentials")
+        if parsed.query or parsed.fragment:
+            raise ExternalWorkflowUsageError("external workflow URLs must not contain query strings or fragments")
+        if not allow_network:
+            raise ExternalWorkflowUsageError(
+                "URL inspection requires --allow-network after explicit TUI consent"
+            )
+        if not interactive:
+            raise ExternalWorkflowUsageError("URL inspection is TUI-interactive only")
+        display_source = _redact_url(source)
+        dest = _safe_cache_child(root, "sources", _adapter_id(display_source))
+        if _clone_is_complete(dest):
+            _verify_cached_remote(dest, display_source)
+            return dest, "https-url", display_source, [f"Reused cached source checkout at {dest}."]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        _run_git_clone(source, display_source, dest)
+        return dest, "https-url", display_source, [f"Cloned external source into {dest} for bounded inspection."]
+
+    path = Path(source).expanduser()
+    if not path.is_absolute():
+        path = _workflow_base_dir() / path
+    if not path.exists():
+        raise ExternalWorkflowUsageError(f"external workflow source not found: {source}")
+    if path.is_file():
+        path = path.parent
+    return path.resolve(), "local-path", str(path.resolve()), []
+
+
+def _clone_is_complete(dest: Path) -> bool:
+    return (
+        dest.is_dir()
+        and not dest.is_symlink()
+        and (dest / ".git").is_dir()
+        and (dest / _CLONE_COMPLETE_SENTINEL).is_file()
+    )
+
+
+def _verify_cached_remote(dest: Path, display_source: str) -> None:
+    cmd = ["git", "-C", str(dest), "remote", "get-url", "origin"]
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ExternalWorkflowRuntimeError(f"failed to verify cached external workflow source: {exc}") from exc
+    actual = _redact_url((proc.stdout or "").strip())
+    if proc.returncode != 0 or actual != display_source:
+        raise ExternalWorkflowRuntimeError("cached external workflow source does not match requested URL")
+
+
+def _run_git_clone(source: str, display_source: str, dest: Path) -> None:
+    if dest.exists():
+        try:
+            if dest.is_dir() and not dest.is_symlink():
+                shutil.rmtree(dest)
+            else:
+                dest.unlink()
+        except OSError as exc:
+            raise ExternalWorkflowRuntimeError(f"failed to replace cached external workflow source: {exc}") from exc
+    with tempfile.TemporaryDirectory(prefix=f"{dest.name}-", dir=str(dest.parent)) as tmp:
+        tmp_dest = Path(tmp) / "checkout"
+        _run_git_clone_to_tmp(source, display_source, tmp_dest)
+        try:
+            (tmp_dest / _CLONE_COMPLETE_SENTINEL).write_text("ok\n", encoding="utf-8")
+            tmp_dest.rename(dest)
+        except OSError as exc:
+            raise ExternalWorkflowRuntimeError(f"failed to finalize cached external workflow source: {exc}") from exc
+
+
+def _run_git_clone_to_tmp(source: str, display_source: str, dest: Path) -> None:
+    cmd = ["git", "clone", "--depth", "1", source, str(dest)]
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=120,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ExternalWorkflowRuntimeError(f"failed to clone external workflow source: {exc}") from exc
+    if proc.returncode != 0:
+        detail = _sanitize_clone_output((proc.stderr or proc.stdout or "").strip(), source, display_source)
+        raise ExternalWorkflowRuntimeError(f"git clone failed for external workflow source: {detail}")
+
+
+def _candidate_files(root: Path) -> tuple[list[Path], list[str]]:
+    files: list[Path] = []
+    deferred_files: list[Path] = []
+    warnings: list[str] = []
+    stack = [(root, 0)]
+    scanned_dirs = 0
+    while stack and len(files) < MAX_CANDIDATE_FILES:
+        current, depth = stack.pop()
+        scanned_dirs += 1
+        if scanned_dirs > MAX_SCANNED_DIRS:
+            warnings.append(
+                f"Stopped scanning after {MAX_SCANNED_DIRS} directories; adapter inspection is partial."
+            )
+            break
+        children, child_warnings = _bounded_children(current)
+        warnings.extend(child_warnings)
+        next_dirs: list[Path] = []
+        next_files: list[Path] = []
+        for child in children:
+            if child.is_symlink():
+                continue
+            if child.is_dir():
+                if child.name in _SKIP_DIRS:
+                    continue
+                if depth >= MAX_SCAN_DEPTH:
+                    warnings.append(
+                        f"Skipped directories deeper than {MAX_SCAN_DEPTH} levels; adapter inspection is partial."
+                    )
+                    continue
+                next_dirs.append(child)
+                continue
+            if _is_candidate_text_file(child):
+                next_files.append(child)
+        for child in sorted(next_files, key=_candidate_priority):
+            priority, _ = _candidate_priority(child)
+            if priority <= 2:
+                files.append(child)
+                if len(files) >= MAX_CANDIDATE_FILES:
+                    break
+            else:
+                deferred_files.append(child)
+        for child in sorted(next_dirs, key=_candidate_priority, reverse=True):
+            stack.append((child, depth + 1))
+
+    for child in sorted(deferred_files, key=_candidate_priority):
+        if len(files) >= MAX_CANDIDATE_FILES:
+            break
+        files.append(child)
+
+    if len(files) >= MAX_CANDIDATE_FILES:
+        warnings.append(
+            f"Stopped scanning after {MAX_CANDIDATE_FILES} candidate files; adapter inspection is partial."
+        )
+
+    return files, sorted(set(warnings))
+
+
+def _bounded_children(current: Path) -> tuple[list[Path], list[str]]:
+    warnings: list[str] = []
+    priority_children = []
+    seen: set[Path] = set()
+    for name in sorted(_SPECIAL_NAMES | _PRIORITY_DIR_NAMES):
+        child = current / name
+        if child.exists() and not child.is_symlink():
+            priority_children.append(child)
+            seen.add(child)
+
+    capped_children: list[Path] = []
+    try:
+        for child in current.iterdir():
+            if child in seen:
+                continue
+            if len(capped_children) >= MAX_CHILDREN_PER_DIR:
+                warnings.append(
+                    f"Stopped reading {current} after {MAX_CHILDREN_PER_DIR} children; "
+                    "adapter inspection is partial."
+                )
+                break
+            capped_children.append(child)
+    except OSError:
+        return [], warnings
+
+    children = priority_children + capped_children
+    return sorted(children, key=_candidate_priority), warnings
+
+
+def _candidate_priority(path: Path) -> tuple[int, str]:
+    parts = {part.lower() for part in path.parts}
+    if path.name in _SPECIAL_NAMES:
+        return (0, path.name)
+    if parts & _PRIORITY_DIR_NAMES:
+        return (1, path.as_posix())
+    if path.suffix.lower() in {".json", ".toml", ".yaml", ".yml"}:
+        return (2, path.as_posix())
+    return (3, path.as_posix())
+
+
+def _is_candidate_text_file(path: Path) -> bool:
+    try:
+        if path.stat().st_size > MAX_TEXT_BYTES:
+            return False
+    except OSError:
+        return False
+    return path.name in _SPECIAL_NAMES or path.suffix.lower() in _TEXT_SUFFIXES
+
+
+def _read_text_limited(path: Path) -> str | None:
+    try:
+        data = path.read_bytes()[:MAX_TEXT_BYTES]
+    except OSError:
+        return None
+    if b"\x00" in data[:4096]:
+        return None
+    return data.decode("utf-8", errors="replace")
+
+
+def _detect_capabilities(
+    plan: ExternalWorkflowAdapterPlan,
+    root: Path,
+    texts: list[tuple[Path, str]],
+) -> None:
+    combined = "\n".join(f"{_relpath(path, root)}\n{text}" for path, text in texts).lower()
+    detectors = [
+        (
+            "profiling",
+            "profiling and counter collection",
+            ("profile", "profiler", "rocprof", "rocprof-compute", "pmc", "counter"),
+        ),
+        (
+            "source_correlation",
+            "source-line performance attribution",
+            ("source line", "source mapping", "line attribution", "pc sampling"),
+        ),
+        (
+            "trace_inspection",
+            "packet and trace inspection",
+            ("packet", "trace inspection", "hsa packet", "aql", "assembly"),
+        ),
+        (
+            "kernel_isolation",
+            "kernel extraction and replay",
+            ("kernel extract", "extract kernel", "replay kernel", "kernel replay"),
+        ),
+        (
+            "correctness",
+            "optimization validation workflow",
+            ("correctness", "validate", "validation", "regression"),
+        ),
+        ("mcp_tools", "external MCP tools", ("mcpservers", "fastmcp", "mcp server", "-mcp")),
+        ("agent_skill", "agent skill or prompt package", ("skill.md", "agents.md", "agent workflow")),
+    ]
+    for kind, name, needles in detectors:
+        if any(needle in combined for needle in needles):
+            plan.capabilities.append(
+                ExternalWorkflowCapability(
+                    kind=kind,
+                    name=name,
+                    source="text-scan",
+                    details={"matched_keywords": [n for n in needles if n in combined]},
+                )
+            )
+
+    for path, text in texts:
+        if path.name == "pyproject.toml":
+            scripts = _parse_toml_scripts(text)
+            for script in scripts:
+                lowered = script.lower()
+                if "mcp" in lowered or "perf" in lowered or "prof" in lowered:
+                    plan.capabilities.append(
+                        ExternalWorkflowCapability(
+                            kind="entry_point",
+                            name=script,
+                            source=_relpath(path, root),
+                            details={"type": "project script"},
+                        )
+                    )
+        if path.name == "package.json":
+            for script in _parse_package_bins(text):
+                plan.capabilities.append(
+                    ExternalWorkflowCapability(
+                        kind="entry_point",
+                        name=script,
+                        source=_relpath(path, root),
+                        details={"type": "package bin"},
+                    )
+                )
+
+
+def _detect_mcp_servers(
+    plan: ExternalWorkflowAdapterPlan,
+    root: Path,
+    texts: list[tuple[Path, str]],
+) -> None:
+    for path, text in texts:
+        if path.name not in {".mcp.json", "mcp.json", "opencode.json"}:
+            continue
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            continue
+        servers = data.get("mcpServers") if isinstance(data, dict) else None
+        if not isinstance(servers, dict):
+            continue
+        for name, raw in sorted(servers.items()):
+            if not isinstance(raw, dict):
+                continue
+            args = raw.get("args", [])
+            if not isinstance(args, list) or not all(isinstance(arg, str) for arg in args):
+                args = []
+            command = raw.get("command")
+            if command is not None and not _is_safe_mcp_command(command):
+                plan.warnings.append(
+                    f"Ignored unsafe MCP command for {name!r}; review manually before registration."
+                )
+                command = None
+            plan.mcp_servers.append(
+                ExternalWorkflowMcpServer(
+                    name=str(name),
+                    command=command,
+                    args=args,
+                    source=_relpath(path, root),
+                )
+            )
+
+
+def _detect_knowledge_links(
+    plan: ExternalWorkflowAdapterPlan,
+    root: Path,
+    files: list[Path],
+) -> None:
+    for path in files:
+        rel = _relpath(path, root)
+        rel_lower = rel.lower()
+        if "knowledge" in rel_lower or "/docs/" in rel_lower or rel_lower.startswith("docs/"):
+            plan.knowledge_links.append(
+                ExternalWorkflowKnowledgeLink(
+                    path=rel,
+                    reason="candidate advisory knowledge for the active optimization session",
+                )
+            )
+        elif path.name in {"SKILL.md", "AGENTS.md"}:
+            plan.knowledge_links.append(
+                ExternalWorkflowKnowledgeLink(
+                    path=rel,
+                    reason="agent instructions that may describe reusable workflow logic",
+                )
+            )
+
+
+def _detect_risky_install_hints(
+    plan: ExternalWorkflowAdapterPlan,
+    texts: list[tuple[Path, str]],
+) -> None:
+    risky = (
+        "pip install",
+        "uv tool install",
+        "npm install",
+        "curl -",
+        "| bash",
+        "bash <(",
+        "docker run",
+    )
+    hits: list[str] = []
+    for path, text in texts:
+        lowered = text.lower()
+        if any(token in lowered for token in risky):
+            hits.append(path.name)
+    if hits:
+        plan.warnings.append(
+            "Install or execution snippets were found in "
+            + ", ".join(sorted(set(hits)))
+            + "; do not run them until the user explicitly approves."
+        )
+
+
+def _derive_workflow_hints(plan: ExternalWorkflowAdapterPlan) -> None:
+    kinds = {cap.kind for cap in plan.capabilities}
+    if "profiling" in kinds:
+        plan.workflow_hints.append(
+            "Map discovered profiling logic to PerfXpert's profile/analyze/reprofile phases; "
+            "do not replace rocprofv3 validation."
+        )
+    if "source_correlation" in kinds:
+        plan.workflow_hints.append(
+            "Use source-correlation hints to prioritize files and kernels for inspection after MCP analysis."
+        )
+    if "kernel_isolation" in kinds:
+        plan.workflow_hints.append(
+            "Treat kernel replay or extraction tools as optional execution steps that require user consent."
+        )
+    if "correctness" in kinds:
+        plan.workflow_hints.append(
+            "Fold external validation ideas into the PerfXpert correctness gate; "
+            "the gate verdict remains authoritative."
+        )
+    if plan.mcp_servers:
+        plan.workflow_hints.append(
+            "Discovered MCP servers can be added to the active TUI backend only after explicit registration consent."
+        )
+    if plan.knowledge_links:
+        plan.workflow_hints.append(
+            "Read knowledge links as supplemental context; they must not override measured counters or GPU specs."
+        )
+    if not plan.workflow_hints:
+        plan.workflow_hints.append(
+            "No specific optimization workflow hooks were detected; use inspected files as advisory context only."
+        )
+
+
+def _parse_toml_scripts(text: str) -> list[str]:
+    scripts: list[str] = []
+    in_scripts = False
+    header_re = re.compile(r"^\s*\[([^\]]+)\]\s*$")
+    entry_re = re.compile(r"^\s*([A-Za-z0-9_.-]+)\s*=\s*[\"']")
+    for line in text.splitlines():
+        header = header_re.match(line)
+        if header:
+            in_scripts = header.group(1) in {"project.scripts", "tool.poetry.scripts"}
+            continue
+        if not in_scripts:
+            continue
+        match = entry_re.match(line)
+        if match:
+            scripts.append(match.group(1))
+    return scripts
+
+
+def _parse_package_bins(text: str) -> list[str]:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return []
+    raw = data.get("bin") if isinstance(data, dict) else None
+    if isinstance(raw, str):
+        return [Path(raw).name]
+    if isinstance(raw, dict):
+        return sorted(str(name) for name in raw)
+    return []
+
+
+def _is_safe_mcp_command(command: object) -> bool:
+    if not isinstance(command, str):
+        return False
+    if not command.strip():
+        return False
+    return not any(ch in command for ch in "|&;<>()`$\n\r")
+
+
+def _write_manifest(cache_root: Path, plan: ExternalWorkflowAdapterPlan) -> Path:
+    root = _safe_cache_root(cache_root)
+    manifest_dir = _safe_cache_child(root, "adapters")
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    path = manifest_dir / f"{plan.adapter_id}.json"
+    path.write_text(json.dumps(plan.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _safe_cache_root(cache_root: Path) -> Path:
+    root = Path(cache_root).expanduser()
+    for candidate in _existing_cache_paths(root):
+        if candidate.is_symlink():
+            raise ExternalWorkflowRuntimeError(f"cache path must not be a symlink: {candidate}")
+    return root
+
+
+def _safe_cache_child(cache_root: Path, *parts: str) -> Path:
+    root_abs = cache_root.resolve(strict=False)
+    child = cache_root.joinpath(*parts)
+    for existing in [child, child.parent]:
+        if existing.exists() and existing.is_symlink():
+            raise ExternalWorkflowRuntimeError(f"cache path must not be a symlink: {existing}")
+    child_abs = child.resolve(strict=False)
+    try:
+        child_abs.relative_to(root_abs)
+    except ValueError as exc:
+        raise ExternalWorkflowRuntimeError("cache path escapes adapter cache root") from exc
+    return child
+
+
+def _existing_cache_paths(path: Path) -> list[Path]:
+    paths: list[Path] = []
+    current = path
+    while current != current.parent:
+        if current.exists():
+            paths.append(current)
+        current = current.parent
+    return paths
+
+
+def _adapter_id(source: str) -> str:
+    parsed = urlparse(source)
+    base = Path(parsed.path if parsed.scheme else source).name or "workflow"
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", base).strip("-._").lower() or "workflow"
+    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()[:12]
+    return f"{slug}-{digest}"
+
+
+def _redact_url(source: str) -> str:
+    parsed = urlparse(source)
+    if parsed.username or parsed.password:
+        return source.replace(parsed.netloc, parsed.hostname or "<redacted-host>")
+    return source
+
+
+def _sanitize_clone_output(detail: str, source: str, display_source: str) -> str:
+    if not detail:
+        return "no diagnostic output"
+    sanitized = detail.replace(source, display_source)
+    sanitized = re.sub(r"https://[^/\s:@]+:[^@\s]+@", "https://<redacted>@", sanitized)
+    return sanitized
+
+
+def _relpath(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()

--- a/experimental/python/perfxpert/perfxpert/integrations/external_workflow.py
+++ b/experimental/python/perfxpert/perfxpert/integrations/external_workflow.py
@@ -21,10 +21,11 @@ import tempfile
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 
 MAX_CANDIDATE_FILES = 120
+MAX_DEFERRED_FILES = MAX_CANDIDATE_FILES
 MAX_SCANNED_DIRS = 512
 MAX_SCAN_DEPTH = 8
 MAX_CHILDREN_PER_DIR = 1024
@@ -72,6 +73,30 @@ _SPECIAL_NAMES = {
     "pyproject.toml",
 }
 _PRIORITY_DIR_NAMES = {"docs", "doc", "knowledge", "skills", "agents"}
+_SPARSE_TREE_PATTERNS = tuple(sorted(_SPECIAL_NAMES | _PRIORITY_DIR_NAMES))
+_GIT_ENV_PASSTHROUGH = {
+    "ALL_PROXY",
+    "CURL_CA_BUNDLE",
+    "GIT_SSL_CAINFO",
+    "HTTPS_PROXY",
+    "HTTP_PROXY",
+    "NO_PROXY",
+    "REQUESTS_CA_BUNDLE",
+    "SSL_CERT_FILE",
+    "all_proxy",
+    "https_proxy",
+    "http_proxy",
+    "no_proxy",
+}
+_ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
+_SECRET_KV_RE = re.compile(
+    r"(?i)\b([A-Za-z0-9_.-]*(?:token|api[_-]?key|password|passwd|secret|credential|authorization)"
+    r"[A-Za-z0-9_.-]*)=([^&\s#]+)"
+)
+_SECRET_HEADER_RE = re.compile(
+    r"(?im)\b((?:proxy-)?authorization|[A-Za-z0-9_.-]*(?:token|api[_-]?key|secret)[A-Za-z0-9_.-]*)" r"\s*:\s*([^\r\n]+)"
+)
+_URL_USERINFO_RE = re.compile(r"(?i)\b([a-z][a-z0-9+.-]*://)[^/\s@]+@")
 
 
 class ExternalWorkflowError(RuntimeError):
@@ -132,8 +157,8 @@ class ExternalWorkflowAdapterPlan:
     execution_allowed: bool = False
     authority: str = "advisory; PerfXpert MCP gate and correctness checks remain authoritative"
     target_host_scope: str = (
-        "discover and run target-dependent tools on the workload host; for SSH workflows, "
-        "inspect the remote host instead of the local controller"
+        "inspect advisory metadata on the workload host; any target-dependent tool execution "
+        "requires a separate explicit approval"
     )
     capabilities: list[ExternalWorkflowCapability] = field(default_factory=list)
     workflow_hints: list[str] = field(default_factory=list)
@@ -167,7 +192,11 @@ def inspect_external_workflow(
 
     if not interactive:
         raise ExternalWorkflowUsageError(
-            "external workflow import is TUI-interactive only; pass --interactive from perfxpert-code"
+            "external workflow import is TUI-interactive only; start perfxpert-code and ask inside the TUI"
+        )
+    if not _has_active_tui_session():
+        raise ExternalWorkflowUsageError(
+            "external workflow import is available only from an active perfxpert-code TUI session"
         )
 
     root = _default_cache_root() if cache_root is None else Path(cache_root).expanduser()
@@ -246,9 +275,7 @@ def _materialize_source(
         if parsed.query or parsed.fragment:
             raise ExternalWorkflowUsageError("external workflow URLs must not contain query strings or fragments")
         if not allow_network:
-            raise ExternalWorkflowUsageError(
-                "URL inspection requires --allow-network after explicit TUI consent"
-            )
+            raise ExternalWorkflowUsageError("URL inspection requires explicit network consent from the active TUI")
         if not interactive:
             raise ExternalWorkflowUsageError("URL inspection is TUI-interactive only")
         display_source = _redact_url(source)
@@ -265,12 +292,15 @@ def _materialize_source(
         path = _workflow_base_dir() / path
     if not path.exists():
         raise ExternalWorkflowUsageError(f"external workflow source not found: {source}")
+    _reject_symlink_ancestry(path)
     if path.is_symlink():
         raise ExternalWorkflowUsageError("external workflow source must not be a symlink")
     if path.is_file():
-        path = path.parent
+        raise ExternalWorkflowUsageError(
+            "external workflow source must be a directory; pass the adapter root instead of a file"
+        )
     elif not path.is_dir():
-        raise ExternalWorkflowUsageError("external workflow source must be a directory or regular file")
+        raise ExternalWorkflowUsageError("external workflow source must be a directory")
     return path.resolve(), "local-path", str(path.resolve()), []
 
 
@@ -337,31 +367,18 @@ def _run_git_clone_to_tmp(source: str, display_source: str, dest: Path) -> None:
         str(dest),
     ]
     _run_git_command(cmd, source, display_source, "clone")
+    sparse_paths = _select_sparse_checkout_paths(dest, source, display_source)
+    if not sparse_paths:
+        return
     _run_git_command(
-        [
-            "git",
-            "-c",
-            "credential.helper=",
-            "-c",
-            "core.askPass=",
+        _git_command_prefix()
+        + [
             "-C",
             str(dest),
             "sparse-checkout",
             "set",
             "--no-cone",
-            "README",
-            "README.md",
-            "README.rst",
-            ".mcp.json",
-            "mcp.json",
-            "opencode.json",
-            "pyproject.toml",
-            "package.json",
-            "docs",
-            "doc",
-            "knowledge",
-            "skills",
-            "agents",
+            *sparse_paths,
         ],
         source,
         display_source,
@@ -375,7 +392,34 @@ def _run_git_clone_to_tmp(source: str, display_source: str, dest: Path) -> None:
     )
 
 
+def _select_sparse_checkout_paths(dest: Path, source: str, display_source: str) -> list[str]:
+    cmd = _git_command_prefix() + [
+        "-C",
+        str(dest),
+        "ls-tree",
+        "-r",
+        "--name-only",
+        "HEAD",
+        "--",
+        *_SPARSE_TREE_PATTERNS,
+    ]
+    output = _run_git_command_output(cmd, source, display_source, "list source tree")
+    candidates: list[str] = []
+    for raw in output.splitlines():
+        rel = raw.strip()
+        if not _is_safe_repo_relative_path(rel):
+            continue
+        if not _is_candidate_repo_text_path(rel):
+            continue
+        candidates.append(rel)
+    return _top_candidate_relative_paths(candidates)
+
+
 def _run_git_command(cmd: list[str], source: str, display_source: str, action: str) -> None:
+    _run_git_command_output(cmd, source, display_source, action)
+
+
+def _run_git_command_output(cmd: list[str], source: str, display_source: str, action: str) -> str:
     try:
         proc = subprocess.run(
             cmd,
@@ -391,6 +435,7 @@ def _run_git_command(cmd: list[str], source: str, display_source: str, action: s
     if proc.returncode != 0:
         detail = _sanitize_clone_output((proc.stderr or proc.stdout or "").strip(), source, display_source)
         raise ExternalWorkflowRuntimeError(f"git {action} failed for external workflow source: {detail}")
+    return proc.stdout or ""
 
 
 def _git_command_prefix() -> list[str]:
@@ -409,7 +454,16 @@ def _git_env() -> dict[str, str]:
     env = {
         key: value
         for key, value in os.environ.items()
-        if key in {"PATH", "LANG", "LC_ALL", "LC_CTYPE", "TERM", "TMPDIR"}
+        if key
+        in {
+            "PATH",
+            "LANG",
+            "LC_ALL",
+            "LC_CTYPE",
+            "TERM",
+            "TMPDIR",
+            *_GIT_ENV_PASSTHROUGH,
+        }
     }
     env.update(
         {
@@ -431,6 +485,7 @@ def _git_env() -> dict[str, str]:
 def _candidate_files(root: Path) -> tuple[list[Path], list[str]]:
     files: list[Path] = []
     deferred_files: list[Path] = []
+    deferred_capped = False
     warnings: list[str] = []
     stack = [(root, 0)]
     scanned_dirs = 0
@@ -438,11 +493,9 @@ def _candidate_files(root: Path) -> tuple[list[Path], list[str]]:
         current, depth = stack.pop()
         scanned_dirs += 1
         if scanned_dirs > MAX_SCANNED_DIRS:
-            warnings.append(
-                f"Stopped scanning after {MAX_SCANNED_DIRS} directories; adapter inspection is partial."
-            )
+            warnings.append(f"Stopped scanning after {MAX_SCANNED_DIRS} directories; adapter inspection is partial.")
             break
-        children, child_warnings = _bounded_children(current)
+        children, child_warnings = _bounded_children(root, current)
         warnings.extend(child_warnings)
         next_dirs: list[Path] = []
         next_files: list[Path] = []
@@ -461,31 +514,37 @@ def _candidate_files(root: Path) -> tuple[list[Path], list[str]]:
                 continue
             if _is_candidate_text_file(child):
                 next_files.append(child)
-        for child in sorted(next_files, key=_candidate_priority):
-            priority, _ = _candidate_priority(child)
+        for child in sorted(next_files, key=lambda path: _candidate_priority(path, root)):
+            priority, _ = _candidate_priority(child, root)
             if priority <= 2:
                 files.append(child)
                 if len(files) >= MAX_CANDIDATE_FILES:
                     break
             else:
-                deferred_files.append(child)
-        for child in sorted(next_dirs, key=_candidate_priority, reverse=True):
+                if len(deferred_files) < MAX_DEFERRED_FILES:
+                    deferred_files.append(child)
+                else:
+                    deferred_capped = True
+        for child in sorted(next_dirs, key=lambda path: _candidate_priority(path, root), reverse=True):
             stack.append((child, depth + 1))
 
-    for child in sorted(deferred_files, key=_candidate_priority):
+    for child in sorted(deferred_files, key=lambda path: _candidate_priority(path, root)):
         if len(files) >= MAX_CANDIDATE_FILES:
             break
         files.append(child)
 
-    if len(files) >= MAX_CANDIDATE_FILES:
+    if deferred_capped:
         warnings.append(
-            f"Stopped scanning after {MAX_CANDIDATE_FILES} candidate files; adapter inspection is partial."
+            f"Stopped collecting low-priority files after {MAX_DEFERRED_FILES}; adapter inspection is partial."
         )
+
+    if len(files) >= MAX_CANDIDATE_FILES:
+        warnings.append(f"Stopped scanning after {MAX_CANDIDATE_FILES} candidate files; adapter inspection is partial.")
 
     return files, sorted(set(warnings))
 
 
-def _bounded_children(current: Path) -> tuple[list[Path], list[str]]:
+def _bounded_children(root: Path, current: Path) -> tuple[list[Path], list[str]]:
     warnings: list[str] = []
     priority_children = []
     seen: set[Path] = set()
@@ -512,18 +571,19 @@ def _bounded_children(current: Path) -> tuple[list[Path], list[str]]:
         return [], warnings
 
     children = priority_children + capped_children
-    return sorted(children, key=_candidate_priority), warnings
+    return sorted(children, key=lambda path: _candidate_priority(path, root)), warnings
 
 
-def _candidate_priority(path: Path) -> tuple[int, str]:
-    parts = {part.lower() for part in path.parts}
+def _candidate_priority(path: Path, root: Path | None = None) -> tuple[int, str]:
+    rel = _relative_candidate_path(path, root)
+    parts = {part.lower() for part in rel.parts}
     if path.name in _SPECIAL_NAMES:
-        return (0, path.name)
+        return (0, rel.as_posix())
     if parts & _PRIORITY_DIR_NAMES:
-        return (1, path.as_posix())
+        return (1, rel.as_posix())
     if path.suffix.lower() in {".json", ".toml", ".yaml", ".yml"}:
-        return (2, path.as_posix())
-    return (3, path.as_posix())
+        return (2, rel.as_posix())
+    return (3, rel.as_posix())
 
 
 def _is_candidate_text_file(path: Path) -> bool:
@@ -656,9 +716,7 @@ def _detect_mcp_servers(
                 continue
             command, arg_count = _mcp_command_and_arg_count(raw)
             if command is not None and not _is_safe_mcp_command(command):
-                plan.warnings.append(
-                    f"Ignored unsafe MCP command for {name!r}; review manually before registration."
-                )
+                plan.warnings.append(f"Ignored unsafe MCP command for {name!r}; review manually before registration.")
                 command = None
             if arg_count:
                 plan.warnings.append(
@@ -688,28 +746,58 @@ def _mcp_command_and_arg_count(raw: dict[str, object]) -> tuple[str | None, int]
     command = raw.get("command")
     args = raw.get("args", [])
     arg_count = 0
+    command_parts: list[str] = []
+    arg_parts = [arg for arg in args if isinstance(arg, str)] if isinstance(args, list) else []
     if isinstance(command, list):
         command_parts = [part for part in command if isinstance(part, str)]
-        if command_parts:
-            command = command_parts[0]
-            arg_count += max(0, len(command_parts) - 1)
-        else:
-            command = None
     elif isinstance(command, str):
         try:
             command_parts = shlex.split(command)
         except ValueError:
             command_parts = []
-        if command_parts:
-            command = command_parts[0]
-            arg_count += max(0, len(command_parts) - 1)
-        else:
-            command = None
-    if isinstance(args, list):
-        arg_count += sum(1 for arg in args if isinstance(arg, str))
-    else:
-        args = []
+    command = None
+    if command_parts and command_parts[0] == "env":
+        env_command, env_arg_count = _mcp_env_wrapped_command(command_parts + arg_parts)
+        return env_command, env_arg_count
+    for idx, token in enumerate(command_parts):
+        if _is_env_assignment_token(token) or _token_contains_secret_kv(token):
+            arg_count += 1
+            continue
+        command = token
+        arg_count += max(0, len(command_parts) - idx - 1)
+        break
+    arg_count += len(arg_parts)
     return command if isinstance(command, str) else None, arg_count
+
+
+def _mcp_env_wrapped_command(command_parts: list[str]) -> tuple[str | None, int]:
+    arg_count = 1
+    idx = 1
+    while idx < len(command_parts):
+        token = command_parts[idx]
+        if token == "--":
+            arg_count += 1
+            idx += 1
+            break
+        if token in {"-i", "--ignore-environment"}:
+            arg_count += 1
+            idx += 1
+            continue
+        if token in {"-u", "--unset"}:
+            arg_count += 1
+            idx += 1
+            if idx < len(command_parts):
+                arg_count += 1
+                idx += 1
+            continue
+        if _is_env_assignment_token(token) or _token_contains_secret_kv(token):
+            arg_count += 1
+            idx += 1
+            continue
+        if token.startswith("-"):
+            return None, len(command_parts)
+        return token, arg_count + max(0, len(command_parts) - idx - 1)
+    return None, arg_count
 
 
 def _detect_knowledge_links(
@@ -720,7 +808,8 @@ def _detect_knowledge_links(
     for path in files:
         rel = _relpath(path, root)
         rel_lower = rel.lower()
-        if "knowledge" in rel_lower or "/docs/" in rel_lower or rel_lower.startswith("docs/"):
+        rel_parts = set(rel_lower.split("/"))
+        if rel_parts & {"doc", "docs", "knowledge"}:
             plan.knowledge_links.append(
                 ExternalWorkflowKnowledgeLink(
                     path=rel,
@@ -842,6 +931,7 @@ def _write_manifest(cache_root: Path, plan: ExternalWorkflowAdapterPlan) -> Path
     path = _safe_cache_child(root, "adapters", f"{plan.adapter_id}.json")
     if path.is_symlink():
         raise ExternalWorkflowRuntimeError(f"manifest path must not be a symlink: {path}")
+    plan.manifest_path = str(path)
     payload = json.dumps(plan.to_dict(), indent=2, sort_keys=True) + "\n"
     fd, raw_tmp = tempfile.mkstemp(prefix=f".{plan.adapter_id}.", suffix=".tmp", dir=str(manifest_dir))
     tmp_path = Path(raw_tmp)
@@ -905,18 +995,26 @@ def _adapter_id(source: str) -> str:
 
 def _redact_url(source: str) -> str:
     parsed = urlparse(source)
-    if parsed.username or parsed.password:
-        return source.replace(parsed.netloc, parsed.hostname or "<redacted-host>")
-    return source
+    if parsed.scheme and parsed.netloc:
+        host = parsed.hostname or "<redacted-host>"
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        try:
+            port = parsed.port
+        except ValueError:
+            port = None
+        netloc = f"{host}:{port}" if port else host
+        source = urlunparse((parsed.scheme, netloc, parsed.path, "", "", ""))
+    return _redact_secret_kv(source)
 
 
 def _sanitize_clone_output(detail: str, source: str, display_source: str) -> str:
     if not detail:
         return "no diagnostic output"
     sanitized = detail.replace(source, display_source)
-    sanitized = re.sub(r"https://[^/\s:@]+:[^@\s]+@", "https://<redacted>@", sanitized)
-    sanitized = re.sub(r"(?i)(token|api[_-]?key|password|secret)=([^&\s]+)", r"\1=<redacted>", sanitized)
-    return sanitized
+    sanitized = _redact_url_userinfo(sanitized)
+    sanitized = _redact_secret_headers(sanitized)
+    return _redact_secret_kv(sanitized)
 
 
 def _read_git_provenance(root: Path) -> dict[str, str]:
@@ -950,3 +1048,82 @@ def _relpath(path: Path, root: Path) -> str:
         return path.relative_to(root).as_posix()
     except ValueError:
         return path.as_posix()
+
+
+def _has_active_tui_session() -> bool:
+    try:
+        from perfxpert.cli._tui_session import has_active_tui_session
+    except ImportError:
+        return False
+    return has_active_tui_session(os.environ)
+
+
+def _reject_symlink_ancestry(path: Path) -> None:
+    for candidate in [*reversed(path.parents), path]:
+        if not candidate.exists():
+            continue
+        try:
+            if candidate.is_symlink():
+                raise ExternalWorkflowUsageError("external workflow source path must not contain symlinks")
+        except OSError as exc:
+            raise ExternalWorkflowUsageError(f"could not inspect external workflow source path: {exc}") from exc
+
+
+def _relative_candidate_path(path: Path, root: Path | None) -> Path:
+    if root is None:
+        return path
+    try:
+        return path.relative_to(root)
+    except ValueError:
+        return path
+
+
+def _is_safe_repo_relative_path(path: str) -> bool:
+    if not path or path.startswith("/") or "\x00" in path:
+        return False
+    if any(ch in path for ch in "*?[\\"):
+        return False
+    parts = path.split("/")
+    return all(part not in {"", ".", ".."} for part in parts)
+
+
+def _is_candidate_repo_text_path(path: str) -> bool:
+    pure = Path(path)
+    return pure.name in _SPECIAL_NAMES or pure.suffix.lower() in _TEXT_SUFFIXES
+
+
+def _top_candidate_relative_paths(paths: list[str]) -> list[str]:
+    unique = sorted(set(paths), key=_relative_path_priority)
+    return unique[:MAX_CANDIDATE_FILES]
+
+
+def _relative_path_priority(path: str) -> tuple[int, str]:
+    pure = Path(path)
+    parts = {part.lower() for part in pure.parts}
+    if pure.name in _SPECIAL_NAMES:
+        return (0, path)
+    if parts & _PRIORITY_DIR_NAMES:
+        return (1, path)
+    if pure.suffix.lower() in {".json", ".toml", ".yaml", ".yml"}:
+        return (2, path)
+    return (3, path)
+
+
+def _is_env_assignment_token(token: str) -> bool:
+    return bool(_ENV_ASSIGNMENT_RE.match(token))
+
+
+def _token_contains_secret_kv(token: str) -> bool:
+    return bool(_SECRET_KV_RE.search(token))
+
+
+def _redact_secret_kv(text: str) -> str:
+    return _SECRET_KV_RE.sub(r"\1=<redacted>", text)
+
+
+def _redact_secret_headers(text: str) -> str:
+    return _SECRET_HEADER_RE.sub(r"\1: <redacted>", text)
+
+
+def _redact_url_userinfo(text: str) -> str:
+    return _URL_USERINFO_RE.sub(r"\1<redacted>@", text)

--- a/experimental/python/perfxpert/perfxpert/integrations/external_workflow.py
+++ b/experimental/python/perfxpert/perfxpert/integrations/external_workflow.py
@@ -13,7 +13,9 @@ import hashlib
 import json
 import os
 import re
+import shlex
 import shutil
+import stat
 import subprocess
 import tempfile
 from dataclasses import asdict, dataclass, field
@@ -110,6 +112,8 @@ class ExternalWorkflowMcpServer:
     command: str | None
     args: list[str]
     source: str
+    arg_count: int = 0
+    args_redacted: bool = True
     activation: str = (
         "requires explicit active-session TUI consent before registration; "
         "persistent or global MCP config changes require a separate persistent-install request"
@@ -137,6 +141,7 @@ class ExternalWorkflowAdapterPlan:
     mcp_servers: list[ExternalWorkflowMcpServer] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     inspected_files: list[str] = field(default_factory=list)
+    provenance: dict[str, str] = field(default_factory=dict)
     manifest_path: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -184,6 +189,7 @@ def inspect_external_workflow(
             *source_warnings,
         ],
     )
+    plan.provenance.update(_read_git_provenance(materialized))
 
     files, scan_warnings = _candidate_files(materialized)
     plan.warnings.extend(scan_warnings)
@@ -231,6 +237,10 @@ def _materialize_source(
     if parsed.scheme in {"http", "https"}:
         if parsed.scheme != "https":
             raise ExternalWorkflowUsageError("external workflow URLs must use https://")
+        if not parsed.hostname:
+            raise ExternalWorkflowUsageError("external workflow URLs must include a hostname")
+        if any(ord(ch) < 32 or ch.isspace() for ch in source):
+            raise ExternalWorkflowUsageError("external workflow URLs must not contain whitespace or control characters")
         if parsed.username or parsed.password:
             raise ExternalWorkflowUsageError("external workflow URLs must not contain embedded credentials")
         if parsed.query or parsed.fragment:
@@ -255,8 +265,12 @@ def _materialize_source(
         path = _workflow_base_dir() / path
     if not path.exists():
         raise ExternalWorkflowUsageError(f"external workflow source not found: {source}")
+    if path.is_symlink():
+        raise ExternalWorkflowUsageError("external workflow source must not be a symlink")
     if path.is_file():
         path = path.parent
+    elif not path.is_dir():
+        raise ExternalWorkflowUsageError("external workflow source must be a directory or regular file")
     return path.resolve(), "local-path", str(path.resolve()), []
 
 
@@ -278,6 +292,7 @@ def _verify_cached_remote(dest: Path, display_source: str) -> None:
             check=False,
             text=True,
             timeout=10,
+            env=_git_env(),
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise ExternalWorkflowRuntimeError(f"failed to verify cached external workflow source: {exc}") from exc
@@ -301,12 +316,66 @@ def _run_git_clone(source: str, display_source: str, dest: Path) -> None:
         try:
             (tmp_dest / _CLONE_COMPLETE_SENTINEL).write_text("ok\n", encoding="utf-8")
             tmp_dest.rename(dest)
+        except FileExistsError:
+            if _clone_is_complete(dest):
+                _verify_cached_remote(dest, display_source)
+                return
+            raise ExternalWorkflowRuntimeError("cached external workflow source changed during clone")
         except OSError as exc:
             raise ExternalWorkflowRuntimeError(f"failed to finalize cached external workflow source: {exc}") from exc
 
 
 def _run_git_clone_to_tmp(source: str, display_source: str, dest: Path) -> None:
-    cmd = ["git", "clone", "--depth", "1", source, str(dest)]
+    cmd = _git_command_prefix() + [
+        "clone",
+        "--depth",
+        "1",
+        "--filter",
+        "blob:none",
+        "--no-checkout",
+        source,
+        str(dest),
+    ]
+    _run_git_command(cmd, source, display_source, "clone")
+    _run_git_command(
+        [
+            "git",
+            "-c",
+            "credential.helper=",
+            "-c",
+            "core.askPass=",
+            "-C",
+            str(dest),
+            "sparse-checkout",
+            "set",
+            "--no-cone",
+            "README",
+            "README.md",
+            "README.rst",
+            ".mcp.json",
+            "mcp.json",
+            "opencode.json",
+            "pyproject.toml",
+            "package.json",
+            "docs",
+            "doc",
+            "knowledge",
+            "skills",
+            "agents",
+        ],
+        source,
+        display_source,
+        "configure sparse checkout",
+    )
+    _run_git_command(
+        _git_command_prefix() + ["-C", str(dest), "checkout", "--quiet"],
+        source,
+        display_source,
+        "checkout sparse source",
+    )
+
+
+def _run_git_command(cmd: list[str], source: str, display_source: str, action: str) -> None:
     try:
         proc = subprocess.run(
             cmd,
@@ -314,12 +383,49 @@ def _run_git_clone_to_tmp(source: str, display_source: str, dest: Path) -> None:
             check=False,
             text=True,
             timeout=120,
+            env=_git_env(),
+            stdin=subprocess.DEVNULL,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
-        raise ExternalWorkflowRuntimeError(f"failed to clone external workflow source: {exc}") from exc
+        raise ExternalWorkflowRuntimeError(f"failed to {action} external workflow source: {exc}") from exc
     if proc.returncode != 0:
         detail = _sanitize_clone_output((proc.stderr or proc.stdout or "").strip(), source, display_source)
-        raise ExternalWorkflowRuntimeError(f"git clone failed for external workflow source: {detail}")
+        raise ExternalWorkflowRuntimeError(f"git {action} failed for external workflow source: {detail}")
+
+
+def _git_command_prefix() -> list[str]:
+    return [
+        "git",
+        "-c",
+        "credential.helper=",
+        "-c",
+        "core.askPass=",
+        "-c",
+        "http.extraHeader=",
+    ]
+
+
+def _git_env() -> dict[str, str]:
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key in {"PATH", "LANG", "LC_ALL", "LC_CTYPE", "TERM", "TMPDIR"}
+    }
+    env.update(
+        {
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_ASKPASS": "false",
+            "SSH_ASKPASS": "false",
+            "GCM_INTERACTIVE": "never",
+            "GIT_LFS_SKIP_SMUDGE": "1",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_SYSTEM": os.devnull,
+            "HOME": tempfile.gettempdir(),
+            "XDG_CONFIG_HOME": tempfile.gettempdir(),
+        }
+    )
+    return env
 
 
 def _candidate_files(root: Path) -> tuple[list[Path], list[str]]:
@@ -401,7 +507,8 @@ def _bounded_children(current: Path) -> tuple[list[Path], list[str]]:
                 )
                 break
             capped_children.append(child)
-    except OSError:
+    except OSError as exc:
+        warnings.append(f"Could not read {current}: {exc}; adapter inspection is partial.")
         return [], warnings
 
     children = priority_children + capped_children
@@ -421,7 +528,10 @@ def _candidate_priority(path: Path) -> tuple[int, str]:
 
 def _is_candidate_text_file(path: Path) -> bool:
     try:
-        if path.stat().st_size > MAX_TEXT_BYTES:
+        st = path.lstat()
+        if not stat.S_ISREG(st.st_mode):
+            return False
+        if st.st_size > MAX_TEXT_BYTES:
             return False
     except OSError:
         return False
@@ -429,9 +539,25 @@ def _is_candidate_text_file(path: Path) -> bool:
 
 
 def _read_text_limited(path: Path) -> str | None:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = None
     try:
-        data = path.read_bytes()[:MAX_TEXT_BYTES]
+        fd = os.open(path, flags)
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode) or st.st_size > MAX_TEXT_BYTES:
+            return None
+        data = os.read(fd, MAX_TEXT_BYTES + 1)
     except OSError:
+        return None
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+    if len(data) > MAX_TEXT_BYTES:
         return None
     if b"\x00" in data[:4096]:
         return None
@@ -522,29 +648,68 @@ def _detect_mcp_servers(
             data = json.loads(text)
         except json.JSONDecodeError:
             continue
-        servers = data.get("mcpServers") if isinstance(data, dict) else None
+        servers = _extract_mcp_servers(data, path.name)
         if not isinstance(servers, dict):
             continue
         for name, raw in sorted(servers.items()):
             if not isinstance(raw, dict):
                 continue
-            args = raw.get("args", [])
-            if not isinstance(args, list) or not all(isinstance(arg, str) for arg in args):
-                args = []
-            command = raw.get("command")
+            command, arg_count = _mcp_command_and_arg_count(raw)
             if command is not None and not _is_safe_mcp_command(command):
                 plan.warnings.append(
                     f"Ignored unsafe MCP command for {name!r}; review manually before registration."
                 )
                 command = None
+            if arg_count:
+                plan.warnings.append(
+                    f"Redacted {arg_count} MCP argument(s) for {name!r}; review source before registration."
+                )
             plan.mcp_servers.append(
                 ExternalWorkflowMcpServer(
                     name=str(name),
                     command=command,
-                    args=args,
+                    args=[],
+                    arg_count=arg_count,
+                    args_redacted=arg_count > 0,
                     source=_relpath(path, root),
                 )
             )
+
+
+def _extract_mcp_servers(data: object, filename: str) -> object:
+    if not isinstance(data, dict):
+        return None
+    if filename == "opencode.json" and "mcp" in data:
+        return data.get("mcp")
+    return data.get("mcpServers")
+
+
+def _mcp_command_and_arg_count(raw: dict[str, object]) -> tuple[str | None, int]:
+    command = raw.get("command")
+    args = raw.get("args", [])
+    arg_count = 0
+    if isinstance(command, list):
+        command_parts = [part for part in command if isinstance(part, str)]
+        if command_parts:
+            command = command_parts[0]
+            arg_count += max(0, len(command_parts) - 1)
+        else:
+            command = None
+    elif isinstance(command, str):
+        try:
+            command_parts = shlex.split(command)
+        except ValueError:
+            command_parts = []
+        if command_parts:
+            command = command_parts[0]
+            arg_count += max(0, len(command_parts) - 1)
+        else:
+            command = None
+    if isinstance(args, list):
+        arg_count += sum(1 for arg in args if isinstance(arg, str))
+    else:
+        args = []
+    return command if isinstance(command, str) else None, arg_count
 
 
 def _detect_knowledge_links(
@@ -674,8 +839,27 @@ def _write_manifest(cache_root: Path, plan: ExternalWorkflowAdapterPlan) -> Path
     root = _safe_cache_root(cache_root)
     manifest_dir = _safe_cache_child(root, "adapters")
     manifest_dir.mkdir(parents=True, exist_ok=True)
-    path = manifest_dir / f"{plan.adapter_id}.json"
-    path.write_text(json.dumps(plan.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path = _safe_cache_child(root, "adapters", f"{plan.adapter_id}.json")
+    if path.is_symlink():
+        raise ExternalWorkflowRuntimeError(f"manifest path must not be a symlink: {path}")
+    payload = json.dumps(plan.to_dict(), indent=2, sort_keys=True) + "\n"
+    fd, raw_tmp = tempfile.mkstemp(prefix=f".{plan.adapter_id}.", suffix=".tmp", dir=str(manifest_dir))
+    tmp_path = Path(raw_tmp)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(payload)
+        os.replace(tmp_path, path)
+    except OSError:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise
     return path
 
 
@@ -731,7 +915,34 @@ def _sanitize_clone_output(detail: str, source: str, display_source: str) -> str
         return "no diagnostic output"
     sanitized = detail.replace(source, display_source)
     sanitized = re.sub(r"https://[^/\s:@]+:[^@\s]+@", "https://<redacted>@", sanitized)
+    sanitized = re.sub(r"(?i)(token|api[_-]?key|password|secret)=([^&\s]+)", r"\1=<redacted>", sanitized)
     return sanitized
+
+
+def _read_git_provenance(root: Path) -> dict[str, str]:
+    if not (root / ".git").exists():
+        return {}
+    provenance: dict[str, str] = {}
+    for key, cmd in {
+        "commit": ["git", "-C", str(root), "rev-parse", "HEAD"],
+        "remote": ["git", "-C", str(root), "remote", "get-url", "origin"],
+    }.items():
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=10,
+                env=_git_env(),
+                stdin=subprocess.DEVNULL,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        if proc.returncode == 0 and proc.stdout.strip():
+            value = proc.stdout.strip()
+            provenance[key] = _redact_url(value) if key == "remote" else value
+    return provenance
 
 
 def _relpath(path: Path, root: Path) -> str:

--- a/experimental/python/perfxpert/tests/test_cli/test_backend_dispatch.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_backend_dispatch.py
@@ -14,6 +14,8 @@ Covers:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from perfxpert.cli import _backend_dispatch, opencode_launcher
@@ -201,6 +203,60 @@ def test_recursion_guard_empty_env_does_not_trigger(
     monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
     rc = _backend_dispatch._exec_backend("codex", [])
     assert rc == 77
+
+
+def test_backend_spawn_sets_interactive_tui_marker_for_live_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import perfxpert.cli._backend.codex as codex_mod
+
+    captured_env = {}
+    monkeypatch.delenv(RECURSION_GUARD_ENV, raising=False)
+    monkeypatch.setattr(
+        codex_mod.CodexAdapter,
+        "install",
+        lambda self, cwd, **kw: _make_install_report(self.name),
+    )
+
+    def fake_spawn(self, argv, env, cwd):
+        captured_env.update(env)
+        return 0
+
+    monkeypatch.setattr(codex_mod.CodexAdapter, "spawn", fake_spawn)
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    rc = _backend_dispatch._exec_backend("codex", ["--quiet"])
+
+    assert rc == 0
+    assert captured_env["PERFXPERT_TUI_INTERACTIVE"] == "1"
+    assert captured_env["PERFXPERT_WORKLOAD_CWD"] == str(Path.cwd())
+
+
+def test_backend_prompt_args_do_not_set_interactive_tui_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import perfxpert.cli._backend.codex as codex_mod
+
+    captured_env = {}
+    monkeypatch.delenv(RECURSION_GUARD_ENV, raising=False)
+    monkeypatch.setattr(
+        codex_mod.CodexAdapter,
+        "install",
+        lambda self, cwd, **kw: _make_install_report(self.name),
+    )
+
+    def fake_spawn(self, argv, env, cwd):
+        captured_env.update(env)
+        return 0
+
+    monkeypatch.setattr(codex_mod.CodexAdapter, "spawn", fake_spawn)
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    rc = _backend_dispatch._exec_backend("codex", ["--quiet", "optimize ./app"])
+
+    assert rc == 0
+    assert "PERFXPERT_TUI_INTERACTIVE" not in captured_env
+    assert captured_env["PERFXPERT_WORKLOAD_CWD"] == str(Path.cwd())
 
 
 def _make_install_report(name: str):
@@ -552,6 +608,7 @@ def test_consent_denied_returns_rc_nonzero(monkeypatch: pytest.MonkeyPatch) -> N
 
     monkeypatch.setattr(claude_mod.ClaudeCodeAdapter, "install", _fake_install)
     # spawn should NEVER be called after a consent denial.
+
     def _no_spawn(self, a, e, c):
         raise AssertionError("spawn must not be called when consent denied")
 

--- a/experimental/python/perfxpert/tests/test_cli/test_backend_dispatch.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_backend_dispatch.py
@@ -100,9 +100,7 @@ def test_codex_adapter_dispatches_cleanly(monkeypatch) -> None:
 
 
 @pytest.mark.parametrize("name", ["claude", "gemini", "codex"])
-def test_real_adapters_registered_for_all_three_backends(
-    name: str, monkeypatch
-) -> None:
+def test_real_adapters_registered_for_all_three_backends(name: str, monkeypatch) -> None:
     """Task 6 (claude, gemini) + PR-2 Task 10 (codex): real adapter
     runners replace the Task-2 stubs. Invoking the handler reaches
     the install flow (we don't verify the full install here — other
@@ -143,9 +141,7 @@ def test_real_adapters_registered_for_all_three_backends(
 # ---------------------------------------------------------------------------
 
 
-def test_recursion_guard_refuses_when_env_set(
-    capsys, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_recursion_guard_refuses_when_env_set(capsys, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(RECURSION_GUARD_ENV, "claude")
     rc = _backend_dispatch._exec_backend("claude", [])
     assert rc == 3
@@ -169,9 +165,7 @@ def test_recursion_guard_force_overrides(monkeypatch: pytest.MonkeyPatch) -> Non
         "install",
         lambda self, cwd, **kw: _make_install_report(self.name),
     )
-    monkeypatch.setattr(
-        codex_mod.CodexAdapter, "spawn", lambda self, a, e, c: 77
-    )
+    monkeypatch.setattr(codex_mod.CodexAdapter, "spawn", lambda self, a, e, c: 77)
     monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
     rc = _backend_dispatch._exec_backend("codex", ["--force", "hello"])
     # rc==77 proves the spawn ran (guard was bypassed), rc==3 would
@@ -179,9 +173,7 @@ def test_recursion_guard_force_overrides(monkeypatch: pytest.MonkeyPatch) -> Non
     assert rc == 77
 
 
-def test_recursion_guard_does_not_treat_backend_args_as_force(
-    capsys, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_recursion_guard_does_not_treat_backend_args_as_force(capsys, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(RECURSION_GUARD_ENV, "claude")
     rc = _backend_dispatch._exec_backend("claude", ["explain", "--force"])
     assert rc == 3
@@ -201,9 +193,7 @@ def test_recursion_guard_empty_env_does_not_trigger(
         "install",
         lambda self, cwd, **kw: _make_install_report(self.name),
     )
-    monkeypatch.setattr(
-        codex_mod.CodexAdapter, "spawn", lambda self, a, e, c: 77
-    )
+    monkeypatch.setattr(codex_mod.CodexAdapter, "spawn", lambda self, a, e, c: 77)
     monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
     rc = _backend_dispatch._exec_backend("codex", [])
     assert rc == 77
@@ -336,9 +326,7 @@ def test_is_help_request_false_for_empty() -> None:
 
 
 @pytest.mark.parametrize("name", ["claude", "codex", "gemini"])
-def test_main_dispatches_backend_to_stub(
-    name: str, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_main_dispatches_backend_to_stub(name: str, monkeypatch: pytest.MonkeyPatch) -> None:
     """`perfxpert-code <backend>` reaches _exec_backend (not opencode)."""
     monkeypatch.delenv(RECURSION_GUARD_ENV, raising=False)
     calls: list[tuple[str, list[str]]] = []
@@ -347,9 +335,7 @@ def test_main_dispatches_backend_to_stub(
         calls.append((backend_name, remaining_argv))
         return 0
 
-    monkeypatch.setattr(
-        "perfxpert.cli._backend_dispatch._exec_backend", _fake_exec_backend
-    )
+    monkeypatch.setattr("perfxpert.cli._backend_dispatch._exec_backend", _fake_exec_backend)
     rc = main([name, "arg1", "arg2"])
     assert rc == 0
     assert calls == [(name, ["arg1", "arg2"])]
@@ -364,9 +350,7 @@ def test_main_backend_path_does_not_resolve_opencode(
     def _fake_exec_backend(_name, _argv):
         return 0
 
-    monkeypatch.setattr(
-        "perfxpert.cli._backend_dispatch._exec_backend", _fake_exec_backend
-    )
+    monkeypatch.setattr("perfxpert.cli._backend_dispatch._exec_backend", _fake_exec_backend)
 
     def _no_binary():
         raise AssertionError("resolve_opencode_binary should NOT be called")
@@ -407,9 +391,7 @@ def test_parse_dispatcher_flags_all() -> None:
 
 def test_parse_dispatcher_flags_stops_at_first_non_flag() -> None:
     """Anything after the first non-dispatcher token stays intact for the backend."""
-    f = _backend_dispatch.parse_dispatcher_flags(
-        ["--quiet", "hello", "--dry-run"]
-    )
+    f = _backend_dispatch.parse_dispatcher_flags(["--quiet", "hello", "--dry-run"])
     assert f.quiet is True
     assert f.remaining == ["hello", "--dry-run"]
 
@@ -455,9 +437,7 @@ def test_quiet_flag_forwarded_to_install(monkeypatch: pytest.MonkeyPatch) -> Non
         return InstallReport(backend=self.name)
 
     monkeypatch.setattr(claude_mod.ClaudeCodeAdapter, "install", _fake_install)
-    monkeypatch.setattr(
-        claude_mod.ClaudeCodeAdapter, "spawn", lambda self, a, e, c: 0
-    )
+    monkeypatch.setattr(claude_mod.ClaudeCodeAdapter, "spawn", lambda self, a, e, c: 0)
     monkeypatch.delenv(RECURSION_GUARD_ENV, raising=False)
 
     _backend_dispatch._exec_backend("claude", ["--quiet", "--dry-run"])
@@ -476,14 +456,10 @@ def test_allow_agents_md_append_forwarded(monkeypatch: pytest.MonkeyPatch) -> No
         return InstallReport(backend=self.name)
 
     monkeypatch.setattr(claude_mod.ClaudeCodeAdapter, "install", _fake_install)
-    monkeypatch.setattr(
-        claude_mod.ClaudeCodeAdapter, "spawn", lambda self, a, e, c: 0
-    )
+    monkeypatch.setattr(claude_mod.ClaudeCodeAdapter, "spawn", lambda self, a, e, c: 0)
     monkeypatch.delenv(RECURSION_GUARD_ENV, raising=False)
 
-    _backend_dispatch._exec_backend(
-        "claude", ["--allow-agents-md-append", "--dry-run"]
-    )
+    _backend_dispatch._exec_backend("claude", ["--allow-agents-md-append", "--dry-run"])
     assert captured["allow_agents_md_append"] is True
 
 
@@ -513,9 +489,7 @@ def test_recursion_guard_env_set_before_spawn(
     assert captured_env.get(RECURSION_GUARD_ENV) == "claude"
 
 
-def test_successful_install_logs_launch_handoff(
-    capsys, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_successful_install_logs_launch_handoff(capsys, monkeypatch: pytest.MonkeyPatch) -> None:
     import perfxpert.cli._backend.codex as codex_mod
 
     def _fake_install(self, cwd, **kw):
@@ -538,9 +512,7 @@ def test_successful_install_logs_launch_handoff(
     assert "MCP verified; launching codex" in err
 
 
-def test_quiet_successful_install_suppresses_launch_handoff(
-    capsys, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_quiet_successful_install_suppresses_launch_handoff(capsys, monkeypatch: pytest.MonkeyPatch) -> None:
     import perfxpert.cli._backend.codex as codex_mod
 
     def _fake_install(self, cwd, **kw):
@@ -590,9 +562,7 @@ def test_help_passthrough_does_not_install(
     assert install_calls == []
 
 
-def test_main_default_still_uses_opencode(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
-) -> None:
+def test_main_default_still_uses_opencode(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     """Regression: bare `perfxpert-code` still stages the runtime cfg dir
     and launches the opencode binary (Task 2 must not regress this path)."""
     fake_bin = tmp_path / "opencode"
@@ -605,12 +575,8 @@ def test_main_default_still_uses_opencode(
     runtime_cfg.mkdir()
     (runtime_cfg / "opencode.json").write_text("{}")
 
-    monkeypatch.setattr(
-        "perfxpert.cli.opencode_launcher.resolve_opencode_binary", lambda: fake_bin
-    )
-    monkeypatch.setattr(
-        "perfxpert.cli.opencode_launcher.resolve_config_dir", lambda: fake_cfg
-    )
+    monkeypatch.setattr("perfxpert.cli.opencode_launcher.resolve_opencode_binary", lambda: fake_bin)
+    monkeypatch.setattr("perfxpert.cli.opencode_launcher.resolve_config_dir", lambda: fake_cfg)
     monkeypatch.setattr(
         "perfxpert.cli.opencode_launcher._prepare_runtime_config_dir",
         lambda _: runtime_cfg,
@@ -626,8 +592,10 @@ def test_main_default_still_uses_opencode(
         calls.append((cmd, kwargs))
         return _FakeProc()
 
+    monkeypatch.setattr("perfxpert.cli.opencode_launcher.subprocess.run", _fake_run)
     monkeypatch.setattr(
-        "perfxpert.cli.opencode_launcher.subprocess.run", _fake_run
+        "perfxpert.cli.opencode_launcher._bind_tui_session_env",
+        lambda env: env.update({"PERFXPERT_TUI_INTERACTIVE": "1"}),
     )
     rc = main([])
     assert rc == 0
@@ -663,6 +631,5 @@ def test_consent_denied_returns_rc_nonzero(monkeypatch: pytest.MonkeyPatch) -> N
 
     rc = _backend_dispatch._exec_backend("claude", ["--quiet", "--dry-run", "hello"])
     assert rc == 1, (
-        "consent-declined install must return rc=1 so CI pipelines "
-        "don't green-light a failed install (Blocker 5)"
+        "consent-declined install must return rc=1 so CI pipelines " "don't green-light a failed install (Blocker 5)"
     )

--- a/experimental/python/perfxpert/tests/test_cli/test_backend_dispatch.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_backend_dispatch.py
@@ -19,6 +19,10 @@ from pathlib import Path
 import pytest
 
 from perfxpert.cli import _backend_dispatch, opencode_launcher
+from perfxpert.cli._tui_session import (
+    TUI_SESSION_SOCKET_ENV,
+    TUI_SESSION_TOKEN_ENV,
+)
 from perfxpert.cli._backend_dispatch import RECURSION_GUARD_ENV, is_help_request
 from perfxpert.cli.opencode_launcher import main, route_subcommand
 
@@ -205,7 +209,40 @@ def test_recursion_guard_empty_env_does_not_trigger(
     assert rc == 77
 
 
-def test_backend_spawn_sets_interactive_tui_marker_for_live_backend(
+def test_backend_spawn_scrubs_interactive_tui_marker_for_live_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import perfxpert.cli._backend.codex as codex_mod
+
+    captured_env = {}
+    monkeypatch.delenv(RECURSION_GUARD_ENV, raising=False)
+    monkeypatch.setattr(
+        codex_mod.CodexAdapter,
+        "install",
+        lambda self, cwd, **kw: _make_install_report(self.name),
+    )
+
+    def fake_spawn(self, argv, env, cwd):
+        captured_env.update(env)
+        return 0
+
+    monkeypatch.setattr(codex_mod.CodexAdapter, "spawn", fake_spawn)
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+    monkeypatch.setenv("PERFXPERT_TUI_INTERACTIVE", "1")
+    monkeypatch.setenv("PERFXPERT_TUI_SESSION_TOKEN", "stale")
+    monkeypatch.setenv("PERFXPERT_TUI_SESSION_SOCKET", "/tmp/stale")
+    monkeypatch.setenv("PERFXPERT_TUI_SESSION_TOKEN_FILE", "/tmp/old-stale")
+
+    rc = _backend_dispatch._exec_backend("codex", ["--quiet"])
+
+    assert rc == 0
+    assert "PERFXPERT_TUI_INTERACTIVE" not in captured_env
+    assert TUI_SESSION_TOKEN_ENV not in captured_env
+    assert TUI_SESSION_SOCKET_ENV not in captured_env
+    assert "PERFXPERT_TUI_SESSION_TOKEN_FILE" not in captured_env
+
+
+def test_backend_option_only_args_do_not_set_interactive_tui_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import perfxpert.cli._backend.codex as codex_mod
@@ -225,11 +262,12 @@ def test_backend_spawn_sets_interactive_tui_marker_for_live_backend(
     monkeypatch.setattr(codex_mod.CodexAdapter, "spawn", fake_spawn)
     monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
 
-    rc = _backend_dispatch._exec_backend("codex", ["--quiet"])
+    rc = _backend_dispatch._exec_backend("codex", ["--quiet", "--model", "gpt-5"])
 
     assert rc == 0
-    assert captured_env["PERFXPERT_TUI_INTERACTIVE"] == "1"
-    assert captured_env["PERFXPERT_WORKLOAD_CWD"] == str(Path.cwd())
+    assert "PERFXPERT_TUI_INTERACTIVE" not in captured_env
+    assert TUI_SESSION_TOKEN_ENV not in captured_env
+    assert TUI_SESSION_SOCKET_ENV not in captured_env
 
 
 def test_backend_prompt_args_do_not_set_interactive_tui_marker(
@@ -251,11 +289,18 @@ def test_backend_prompt_args_do_not_set_interactive_tui_marker(
 
     monkeypatch.setattr(codex_mod.CodexAdapter, "spawn", fake_spawn)
     monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+    monkeypatch.setenv("PERFXPERT_TUI_INTERACTIVE", "1")
+    monkeypatch.setenv("PERFXPERT_TUI_SESSION_TOKEN", "stale")
+    monkeypatch.setenv("PERFXPERT_TUI_SESSION_SOCKET", "/tmp/stale")
+    monkeypatch.setenv("PERFXPERT_TUI_SESSION_TOKEN_FILE", "/tmp/old-stale")
 
     rc = _backend_dispatch._exec_backend("codex", ["--quiet", "optimize ./app"])
 
     assert rc == 0
     assert "PERFXPERT_TUI_INTERACTIVE" not in captured_env
+    assert TUI_SESSION_TOKEN_ENV not in captured_env
+    assert TUI_SESSION_SOCKET_ENV not in captured_env
+    assert "PERFXPERT_TUI_SESSION_TOKEN_FILE" not in captured_env
     assert captured_env["PERFXPERT_WORKLOAD_CWD"] == str(Path.cwd())
 
 

--- a/experimental/python/perfxpert/tests/test_cli/test_launcher_subcommands.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_launcher_subcommands.py
@@ -40,7 +40,7 @@ def _disable_repo_local_patched_binary(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-class TestHelpFlag:
+class TestHelpFlagRouting:
     """Bare `perfxpert-code --help` must print the perfxpert-owned banner.
 
     Per review I4: help flag discovery must list the documented
@@ -48,10 +48,9 @@ class TestHelpFlag:
     """
 
     @pytest.mark.parametrize("flag", ["--help", "-h"])
-    def test_help_flag_prints_perfxpert_banner_and_lists_subcommands(
-        self, flag, capsys, monkeypatch
-    ):
+    def test_help_flag_prints_perfxpert_banner_and_lists_subcommands(self, flag, capsys, monkeypatch):
         """--help / -h before any subcommand prints the perfxpert help banner."""
+
         # Force resolve_opencode_binary to fail so we exit early after the banner
         # instead of spawning the real opencode process.
         def _no_binary():
@@ -85,12 +84,7 @@ class TestHelpFlag:
 
     def test_help_flag_with_only_flags_preceding_is_still_help(self):
         """`perfxpert-code --verbose --help` — verbose is a flag, not a positional."""
-        assert (
-            opencode_launcher._help_flag_precedes_subcommand(
-                ["--verbose", "--help"]
-            )
-            is True
-        )
+        assert opencode_launcher._help_flag_precedes_subcommand(["--verbose", "--help"]) is True
 
     def test_help_flag_missing_returns_false(self):
         assert opencode_launcher._help_flag_precedes_subcommand([]) is False
@@ -148,6 +142,18 @@ def test_route_unknown_positional_is_default() -> None:
     assert out == ["/tmp/my-project"]
 
 
+def test_route_tui_alias_strips_nonexistent_opencode_subcommand() -> None:
+    kind, out = route_subcommand(["tui", "/tmp/my-project"])
+    assert kind == "opencode_default"
+    assert out == ["/tmp/my-project"]
+
+
+def test_route_tui_alias_maps_dir_option_to_default_project() -> None:
+    kind, out = route_subcommand(["--dir", "/tmp/my-project", "tui"])
+    assert kind == "opencode_default"
+    assert out == ["/tmp/my-project"]
+
+
 def test_route_flags_are_skipped_when_finding_first_positional() -> None:
     # `--print-logs stats` => stats is the first positional and must route.
     kind, out = route_subcommand(["--print-logs", "stats"])
@@ -199,9 +205,7 @@ class TestBundledPriority:
     ~/.opencode/bin/opencode (upstream, unpatched).
     """
 
-    def test_bundled_wins_over_wellknown(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path
-    ) -> None:
+    def test_bundled_wins_over_wellknown(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
         """If both bundled and upstream exist, we pick bundled."""
         # Stub importlib.resources so _bundled/opencode is "present".
         bundled = tmp_path / "bundled" / "opencode"
@@ -236,9 +240,7 @@ class TestBundledPriority:
             def is_file(self):
                 return True
 
-        monkeypatch.setattr(
-            opencode_launcher.resources, "as_file", _fake_as_file
-        )
+        monkeypatch.setattr(opencode_launcher.resources, "as_file", _fake_as_file)
         monkeypatch.setattr(
             opencode_launcher.resources,
             "files",
@@ -247,13 +249,9 @@ class TestBundledPriority:
         monkeypatch.delenv("PERFXPERT_OPENCODE_PATH", raising=False)
 
         resolved = opencode_launcher.resolve_opencode_binary()
-        assert resolved == bundled, (
-            f"bundled must win over upstream; got {resolved}"
-        )
+        assert resolved == bundled, f"bundled must win over upstream; got {resolved}"
 
-    def test_env_override_does_not_replace_default_bundle(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path
-    ) -> None:
+    def test_env_override_does_not_replace_default_bundle(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
         """PERFXPERT_OPENCODE_PATH is not a replacement for the default bundle."""
         explicit = tmp_path / "mycustom" / "opencode"
         explicit.parent.mkdir(parents=True)
@@ -313,9 +311,7 @@ class TestBundledPriority:
         def _fake_as_file(p):
             yield tmp_path / "bundled" / "missing"
 
-        monkeypatch.setattr(
-            opencode_launcher.resources, "as_file", _fake_as_file
-        )
+        monkeypatch.setattr(opencode_launcher.resources, "as_file", _fake_as_file)
         monkeypatch.setattr(
             opencode_launcher.resources,
             "files",
@@ -331,9 +327,7 @@ class TestBundledPriority:
         with pytest.raises(FileNotFoundError, match="bundled patched opencode"):
             opencode_launcher.resolve_opencode_binary()
 
-    def test_explicit_opencode_escape_hatch_uses_env_override(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path
-    ) -> None:
+    def test_explicit_opencode_escape_hatch_uses_env_override(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
         explicit = tmp_path / "mycustom" / "opencode"
         explicit.parent.mkdir(parents=True)
         explicit.write_text("#!/bin/sh\nexit 0\n")
@@ -376,9 +370,7 @@ class TestBundledPriority:
         assert seen["cmd"] == [str(explicit), "models"]
         assert "PERFXPERT_IN_OPENCODE_SESSION" not in seen["env"]
 
-    def test_explicit_opencode_help_does_not_require_user_binary(
-        self, monkeypatch: pytest.MonkeyPatch, capsys
-    ) -> None:
+    def test_explicit_opencode_help_does_not_require_user_binary(self, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
         monkeypatch.setattr(
             opencode_launcher,
             "resolve_user_opencode_binary",
@@ -401,44 +393,30 @@ class TestRunAutoAgentInject:
     """
 
     def test_inject_adds_agent_perfxpert_for_run(self) -> None:
-        out = opencode_launcher._inject_perfxpert_agent_for_run(
-            ["run", "optimize kernel X"]
-        )
+        out = opencode_launcher._inject_perfxpert_agent_for_run(["run", "optimize kernel X"])
         assert out == ["run", "--agent", "perfxpert", "optimize kernel X"]
 
     def test_inject_preserves_explicit_agent(self) -> None:
-        out = opencode_launcher._inject_perfxpert_agent_for_run(
-            ["run", "--agent", "build", "explain this"]
-        )
+        out = opencode_launcher._inject_perfxpert_agent_for_run(["run", "--agent", "build", "explain this"])
         # User override wins — inject is a no-op.
         assert out == ["run", "--agent", "build", "explain this"]
 
     def test_inject_handles_agent_equals_form(self) -> None:
-        out = opencode_launcher._inject_perfxpert_agent_for_run(
-            ["run", "--agent=plan", "my message"]
-        )
+        out = opencode_launcher._inject_perfxpert_agent_for_run(["run", "--agent=plan", "my message"])
         assert out == ["run", "--agent=plan", "my message"]
 
     def test_inject_noop_for_non_run_subcommand(self) -> None:
         # stats / auth / models don't take --agent; we must NOT inject.
-        assert opencode_launcher._inject_perfxpert_agent_for_run(["stats"]) == [
-            "stats"
-        ]
-        assert opencode_launcher._inject_perfxpert_agent_for_run(
-            ["models", "anthropic"]
-        ) == ["models", "anthropic"]
+        assert opencode_launcher._inject_perfxpert_agent_for_run(["stats"]) == ["stats"]
+        assert opencode_launcher._inject_perfxpert_agent_for_run(["models", "anthropic"]) == ["models", "anthropic"]
 
     def test_inject_honors_opt_out_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("PERFXPERT_NO_AUTO_AGENT", "1")
-        out = opencode_launcher._inject_perfxpert_agent_for_run(
-            ["run", "explain"]
-        )
+        out = opencode_launcher._inject_perfxpert_agent_for_run(["run", "explain"])
         # Opt-out → no inject.
         assert out == ["run", "explain"]
 
-    def test_main_run_sets_opencode_config_env(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path
-    ) -> None:
+    def test_main_run_sets_opencode_config_env(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
         """The launcher must set OPENCODE_CONFIG so opencode loads our
         bundled opencode.json even when `run` keeps the user's CWD."""
         fake_bin = tmp_path / "opencode"
@@ -465,9 +443,7 @@ class TestRunAutoAgentInject:
             captured["env"] = kwargs.get("env", {})
             return _FakeProc(0)
 
-        monkeypatch.setattr(
-            "perfxpert.cli.opencode_launcher.subprocess.run", _fake_run
-        )
+        monkeypatch.setattr("perfxpert.cli.opencode_launcher.subprocess.run", _fake_run)
         rc = main(["run", "hello"])
         assert rc == 0
         env = captured["env"]
@@ -476,9 +452,7 @@ class TestRunAutoAgentInject:
         assert cfg is not None
         assert cfg.endswith("opencode.json"), cfg
 
-    def test_main_run_preserves_user_opencode_config(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path
-    ) -> None:
+    def test_main_run_preserves_user_opencode_config(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
         """If user already exported OPENCODE_CONFIG, don't clobber it."""
         fake_bin = tmp_path / "opencode"
         fake_bin.write_text("#!/bin/sh\nexit 0\n")
@@ -504,9 +478,7 @@ class TestRunAutoAgentInject:
             captured["env"] = kwargs.get("env", {})
             return _FakeProc(0)
 
-        monkeypatch.setattr(
-            "perfxpert.cli.opencode_launcher.subprocess.run", _fake_run
-        )
+        monkeypatch.setattr("perfxpert.cli.opencode_launcher.subprocess.run", _fake_run)
         rc = main(["run", "hello"])
         assert rc == 0
         env = captured["env"]
@@ -524,9 +496,7 @@ def test_main_install_patches_dispatches_inline(
         captured["cmd"] = cmd
         return _FakeProc(0)
 
-    monkeypatch.setattr(
-        "perfxpert.cli.opencode_launcher.subprocess.run", _fake_run
-    )
+    monkeypatch.setattr("perfxpert.cli.opencode_launcher.subprocess.run", _fake_run)
     rc = main(["install-patches"])
     assert rc == 0
     cmd = captured["cmd"]
@@ -559,14 +529,10 @@ def test_main_doctor_invokes_python_m_perfxpert(monkeypatch: pytest.MonkeyPatch)
     assert rc == 0
     cmd = captured["cmd"]
     assert isinstance(cmd, list)
-    assert cmd[1:] == ["-m", "perfxpert", "doctor"], (
-        "expected python -m perfxpert doctor; got " + repr(cmd)
-    )
+    assert cmd[1:] == ["-m", "perfxpert", "doctor"], "expected python -m perfxpert doctor; got " + repr(cmd)
 
 
-def test_main_stats_is_passthrough_without_cwd_override(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
-) -> None:
+def test_main_stats_is_passthrough_without_cwd_override(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     """Issue 2: `perfxpert-code stats` must NOT be interpreted as CWD."""
     # Fake binary + config dir so resolve_* succeeds.
     fake_bin = tmp_path / "opencode"
@@ -612,10 +578,16 @@ def test_main_run_passes_prompt_through(monkeypatch: pytest.MonkeyPatch, tmp_pat
     fake_cfg.mkdir()
 
     monkeypatch.setattr(
-        "perfxpert.cli.opencode_launcher.resolve_opencode_binary", lambda: fake_bin,
+        "perfxpert.cli.opencode_launcher.resolve_opencode_binary",
+        lambda: fake_bin,
     )
     monkeypatch.setattr(
-        "perfxpert.cli.opencode_launcher.resolve_config_dir", lambda: fake_cfg,
+        "perfxpert.cli.opencode_launcher.resolve_config_dir",
+        lambda: fake_cfg,
+    )
+    monkeypatch.setattr(
+        "perfxpert.cli.opencode_launcher._bind_tui_session_env",
+        lambda env: env.update({"PERFXPERT_TUI_INTERACTIVE": "1"}),
     )
     monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
 
@@ -637,9 +609,7 @@ def test_main_run_passes_prompt_through(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert captured["kwargs"].get("cwd") is None  # type: ignore[union-attr]
 
 
-def test_main_default_invocation_stages_runtime_cfg_dir(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
-) -> None:
+def test_main_default_invocation_stages_runtime_cfg_dir(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     """Default (interactive) mode still cd's into the bundled runtime dir."""
     fake_bin = tmp_path / "opencode"
     fake_bin.write_text("#!/bin/sh\nexit 0\n")
@@ -649,10 +619,16 @@ def test_main_default_invocation_stages_runtime_cfg_dir(
     (fake_cfg / "opencode.json").write_text("{}")
 
     monkeypatch.setattr(
-        "perfxpert.cli.opencode_launcher.resolve_opencode_binary", lambda: fake_bin,
+        "perfxpert.cli.opencode_launcher.resolve_opencode_binary",
+        lambda: fake_bin,
     )
     monkeypatch.setattr(
-        "perfxpert.cli.opencode_launcher.resolve_config_dir", lambda: fake_cfg,
+        "perfxpert.cli.opencode_launcher.resolve_config_dir",
+        lambda: fake_cfg,
+    )
+    monkeypatch.setattr(
+        "perfxpert.cli.opencode_launcher._bind_tui_session_env",
+        lambda env: env.update({"PERFXPERT_TUI_INTERACTIVE": "1"}),
     )
     monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
 
@@ -684,16 +660,15 @@ class TestHelpFlag:
     """
 
     @pytest.mark.parametrize("flag", ["--help", "-h"])
-    def test_bare_help_flag_prints_perfxpert_banner(
-        self, flag: str, capsys, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_bare_help_flag_prints_perfxpert_banner(self, flag: str, capsys, monkeypatch: pytest.MonkeyPatch) -> None:
         # Ensure opencode is unresolved so main() short-circuits after
         # printing the banner (per the composed fallback behavior).
         def _raise(*_args, **_kwargs):
             raise FileNotFoundError("opencode not installed")
 
         monkeypatch.setattr(
-            "perfxpert.cli.opencode_launcher.resolve_opencode_binary", _raise,
+            "perfxpert.cli.opencode_launcher.resolve_opencode_binary",
+            _raise,
         )
         rc = main([flag])
         out = capsys.readouterr().out
@@ -732,27 +707,28 @@ class TestHelpFlag:
             return _FakeProc(0)
 
         monkeypatch.setattr(
-            "perfxpert.cli.opencode_launcher.subprocess.run", _fake_run,
+            "perfxpert.cli.opencode_launcher.subprocess.run",
+            _fake_run,
         )
         rc = main(["run", flag])
         assert rc == 0
         # The help flag was forwarded to opencode verbatim (not stripped).
-        assert flag in captured["cmd"]  # type: ignore[operator]
+        assert captured["cmd"][1:] == ["run", flag]  # type: ignore[index]
         # And because `run` is a known opencode subcommand, cwd is None
         # (user's project CWD preserved).
         assert captured["kwargs"].get("cwd") is None  # type: ignore[union-attr]
 
     def test_bare_help_short_circuits_before_opencode_missing_error(
-        self, capsys, monkeypatch: pytest.MonkeyPatch,
+        self,
+        capsys,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """If opencode isn't installed, bare --help MUST still print our
         banner and return 0 (per the composed fallback behavior).
         """
         monkeypatch.setattr(
             "perfxpert.cli.opencode_launcher.resolve_opencode_binary",
-            lambda: (_ for _ in ()).throw(
-                FileNotFoundError("opencode binary not found.")
-            ),
+            lambda: (_ for _ in ()).throw(FileNotFoundError("opencode binary not found.")),
         )
         rc = main(["--help"])
         assert rc == 0

--- a/experimental/python/perfxpert/tests/test_cli/test_main_help.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_main_help.py
@@ -15,7 +15,16 @@ def test_top_level_help_lists_documented_subcommands(capsys) -> None:
 
     assert exc.value.code == 0
     out = capsys.readouterr().out
-    for subcommand in ("analyze", "config", "providers", "doctor", "init", "diff", "ci"):
+    for subcommand in (
+        "analyze",
+        "config",
+        "providers",
+        "doctor",
+        "init",
+        "diff",
+        "ci",
+        "workflow",
+    ):
         assert subcommand in out
 
 
@@ -25,6 +34,11 @@ def test_top_level_help_lists_documented_subcommands(capsys) -> None:
         (["init"], "perfxpert.cli.init_cmd", "run_init"),
         (["diff", "baseline.db", "candidate.db"], "perfxpert.cli.diff_cmd", "run_diff"),
         (["ci", "baseline.db", "candidate.db"], "perfxpert.cli.ci_cmd", "run_ci"),
+        (
+            ["workflow", "import", ".", "--interactive"],
+            "perfxpert.cli.workflow_cmd",
+            "run_workflow",
+        ),
     ],
 )
 def test_main_dispatches_restored_subcommands(monkeypatch, argv, module_name, func_name) -> None:

--- a/experimental/python/perfxpert/tests/test_cli/test_main_help.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_main_help.py
@@ -23,9 +23,9 @@ def test_top_level_help_lists_documented_subcommands(capsys) -> None:
         "init",
         "diff",
         "ci",
-        "workflow",
     ):
         assert subcommand in out
+    assert "workflow" not in out
 
 
 @pytest.mark.parametrize(

--- a/experimental/python/perfxpert/tests/test_cli/test_workflow_cmd.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_workflow_cmd.py
@@ -13,7 +13,6 @@ import pytest
 
 from perfxpert import __main__ as main_mod
 from perfxpert.cli._tui_session import (
-    _trusted_launcher_paths,
     bind_tui_session_env,
     cleanup_tui_session_env,
 )
@@ -22,7 +21,40 @@ from perfxpert.integrations.external_workflow import ExternalWorkflowRuntimeErro
 
 @pytest.fixture
 def tui_session(monkeypatch) -> None:
-    monkeypatch.setattr("perfxpert.cli.workflow_cmd.has_active_tui_session", lambda env: True)
+    monkeypatch.setattr("perfxpert.cli.workflow_cmd._in_perfxpert_tui_session", lambda: True)
+    monkeypatch.setattr(
+        "perfxpert.integrations.external_workflow._has_active_tui_session",
+        lambda: True,
+    )
+
+
+def _unix_socket_available(tmp_path: Path) -> bool:
+    socket_path = tmp_path / "probe.sock"
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        listener.bind(str(socket_path))
+    except OSError:
+        return False
+    finally:
+        listener.close()
+        try:
+            socket_path.unlink()
+        except OSError:
+            pass
+    return True
+
+
+def test_workflow_import_help_hides_internal_controls(capsys) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main(["workflow", "import", "--help"])
+
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "--interactive" not in out
+    assert "--allow-network" not in out
+    assert "--cache-root" not in out
+    assert "--json" not in out
+    assert "--no-persist" not in out
 
 
 def test_workflow_import_refuses_without_interactive(tmp_path, capsys, tui_session) -> None:
@@ -44,7 +76,7 @@ def test_workflow_import_refuses_outside_tui_session(tmp_path, capsys, monkeypat
 
     assert exc.value.code == 2
     captured = capsys.readouterr()
-    assert "inside perfxpert-code" in captured.err
+    assert "inside the TUI" in captured.err
 
 
 def test_workflow_import_rejects_agent_session_without_tui_marker(tmp_path, capsys, monkeypatch) -> None:
@@ -56,7 +88,7 @@ def test_workflow_import_rejects_agent_session_without_tui_marker(tmp_path, caps
 
     assert exc.value.code == 2
     captured = capsys.readouterr()
-    assert "inside perfxpert-code" in captured.err
+    assert "inside the TUI" in captured.err
 
 
 def test_workflow_import_rejects_forged_tui_marker_without_token(tmp_path, capsys, monkeypatch) -> None:
@@ -70,12 +102,12 @@ def test_workflow_import_rejects_forged_tui_marker_without_token(tmp_path, capsy
 
     assert exc.value.code == 2
     captured = capsys.readouterr()
-    assert "inside perfxpert-code" in captured.err
+    assert "inside the TUI" in captured.err
 
 
-def test_workflow_import_rejects_forged_token_without_launcher_ancestor(
-    tmp_path, capsys, monkeypatch
-) -> None:
+def test_workflow_import_rejects_forged_token_without_launcher_ancestor(tmp_path, capsys, monkeypatch) -> None:
+    if not _unix_socket_available(tmp_path):
+        pytest.skip("Unix socket bind is not available in this test sandbox")
     env: dict[str, str] = {}
     bind_tui_session_env(env)
     for key, value in env.items():
@@ -87,12 +119,14 @@ def test_workflow_import_rejects_forged_token_without_launcher_ancestor(
 
         assert exc.value.code == 2
         captured = capsys.readouterr()
-        assert "inside perfxpert-code" in captured.err
+        assert "inside the TUI" in captured.err
     finally:
         cleanup_tui_session_env(env)
 
 
 def test_workflow_import_rejects_socket_that_only_replies_ok(tmp_path, capsys, monkeypatch) -> None:
+    if not _unix_socket_available(tmp_path):
+        pytest.skip("Unix socket bind is not available in this test sandbox")
     socket_path = tmp_path / "fake.sock"
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     listener.bind(str(socket_path))
@@ -131,10 +165,12 @@ def test_workflow_import_rejects_socket_that_only_replies_ok(tmp_path, capsys, m
 
     assert exc.value.code == 2
     captured = capsys.readouterr()
-    assert "inside perfxpert-code" in captured.err
+    assert "inside the TUI" in captured.err
 
 
 def test_workflow_import_rejects_path_shadowed_parent_socket(tmp_path) -> None:
+    if not _unix_socket_available(tmp_path):
+        pytest.skip("Unix socket bind is not available in this test sandbox")
     source = tmp_path / "external"
     source.mkdir()
     (source / "README.md").write_text("The adapter can use rocprof-compute counters.\n", encoding="utf-8")
@@ -224,18 +260,25 @@ raise SystemExit(proc.returncode)
     )
 
     assert proc.returncode == 2
-    assert "inside perfxpert-code" in proc.stderr
+    assert "inside the TUI" in proc.stderr
 
 
 def test_workflow_import_accepts_real_launcher_descendant_tui_session(tmp_path) -> None:
-    trusted_launchers = _trusted_launcher_paths()
-    if not trusted_launchers:
-        pytest.skip("perfxpert-code launcher is not installed in a trusted script location")
-    launcher = trusted_launchers[0]
-
+    if not _unix_socket_available(tmp_path):
+        pytest.skip("Unix socket bind is not available in this test sandbox")
     source = tmp_path / "external"
     source.mkdir()
     (source / "README.md").write_text("The adapter can use rocprof-compute counters.\n", encoding="utf-8")
+    launcher = tmp_path / "perfxpert-code"
+    launcher.write_text(
+        """#!/usr/bin/env python3
+from perfxpert.cli.opencode_launcher import main
+
+raise SystemExit(main())
+""",
+        encoding="utf-8",
+    )
+    launcher.chmod(0o755)
     fake_opencode = tmp_path / "fake-opencode"
     fake_config = tmp_path / "fake-config"
     fake_config.mkdir()
@@ -274,14 +317,20 @@ raise SystemExit(proc.returncode)
 
     sitecustomize = tmp_path / "sitecustomize.py"
     sitecustomize.write_text(
-        """import os
-from pathlib import Path
-
-from perfxpert.cli import opencode_launcher
-
-opencode_launcher.resolve_opencode_binary = lambda: Path(os.environ["PERFXPERT_TEST_FAKE_OPENCODE"])
-opencode_launcher.resolve_config_dir = lambda: Path(os.environ["PERFXPERT_TEST_CONFIG_DIR"])
-""",
+        "\n".join(
+            [
+                "import os",
+                "from pathlib import Path",
+                "",
+                "from perfxpert.cli import _tui_session",
+                "from perfxpert.cli import opencode_launcher",
+                "",
+                'opencode_launcher.resolve_opencode_binary = lambda: Path(os.environ["PERFXPERT_TEST_FAKE_OPENCODE"])',
+                'opencode_launcher.resolve_config_dir = lambda: Path(os.environ["PERFXPERT_TEST_CONFIG_DIR"])',
+                '_tui_session._trusted_launcher_paths = lambda: (Path(os.environ["PERFXPERT_TEST_TRUSTED_LAUNCHER"]),)',
+                "",
+            ]
+        ),
         encoding="utf-8",
     )
 
@@ -297,6 +346,7 @@ opencode_launcher.resolve_config_dir = lambda: Path(os.environ["PERFXPERT_TEST_C
     env["PERFXPERT_TEST_FAKE_OPENCODE"] = str(fake_opencode)
     env["PERFXPERT_TEST_CONFIG_DIR"] = str(fake_config)
     env["PERFXPERT_TEST_SOURCE"] = str(source)
+    env["PERFXPERT_TEST_TRUSTED_LAUNCHER"] = str(launcher)
 
     proc = subprocess.run(
         [str(launcher)],
@@ -383,7 +433,8 @@ def test_workflow_import_url_without_network_consent_is_usage_error(capsys, tui_
 
     assert exc.value.code == 2
     captured = capsys.readouterr()
-    assert "--allow-network" in captured.err
+    assert "explicit network consent" in captured.err
+    assert "--allow-network" not in captured.err
 
 
 def test_workflow_import_url_with_network_consent_forwards_to_inspector(

--- a/experimental/python/perfxpert/tests/test_cli/test_workflow_cmd.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_workflow_cmd.py
@@ -3,16 +3,29 @@
 from __future__ import annotations
 
 import json
+import os
+import socket
+import subprocess
+import threading
+from pathlib import Path
 
 import pytest
 
 from perfxpert import __main__ as main_mod
+from perfxpert.cli._tui_session import (
+    _trusted_launcher_paths,
+    bind_tui_session_env,
+    cleanup_tui_session_env,
+)
 from perfxpert.integrations.external_workflow import ExternalWorkflowRuntimeError
 
 
-def test_workflow_import_refuses_without_interactive(tmp_path, capsys, monkeypatch) -> None:
-    monkeypatch.setenv("PERFXPERT_TUI_INTERACTIVE", "1")
+@pytest.fixture
+def tui_session(monkeypatch) -> None:
+    monkeypatch.setattr("perfxpert.cli.workflow_cmd.has_active_tui_session", lambda env: True)
 
+
+def test_workflow_import_refuses_without_interactive(tmp_path, capsys, tui_session) -> None:
     with pytest.raises(SystemExit) as exc:
         main_mod.main(["workflow", "import", str(tmp_path)])
 
@@ -46,8 +59,260 @@ def test_workflow_import_rejects_agent_session_without_tui_marker(tmp_path, caps
     assert "inside perfxpert-code" in captured.err
 
 
-def test_workflow_import_json_for_local_adapter(tmp_path, capsys, monkeypatch) -> None:
+def test_workflow_import_rejects_forged_tui_marker_without_token(tmp_path, capsys, monkeypatch) -> None:
     monkeypatch.setenv("PERFXPERT_TUI_INTERACTIVE", "1")
+    monkeypatch.delenv("PERFXPERT_TUI_SESSION_TOKEN", raising=False)
+    monkeypatch.delenv("PERFXPERT_TUI_SESSION_SOCKET", raising=False)
+    monkeypatch.delenv("PERFXPERT_TUI_SESSION_TOKEN_FILE", raising=False)
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main(["workflow", "import", str(tmp_path), "--interactive"])
+
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert "inside perfxpert-code" in captured.err
+
+
+def test_workflow_import_rejects_forged_token_without_launcher_ancestor(
+    tmp_path, capsys, monkeypatch
+) -> None:
+    env: dict[str, str] = {}
+    bind_tui_session_env(env)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    try:
+        with pytest.raises(SystemExit) as exc:
+            main_mod.main(["workflow", "import", str(tmp_path), "--interactive"])
+
+        assert exc.value.code == 2
+        captured = capsys.readouterr()
+        assert "inside perfxpert-code" in captured.err
+    finally:
+        cleanup_tui_session_env(env)
+
+
+def test_workflow_import_rejects_socket_that_only_replies_ok(tmp_path, capsys, monkeypatch) -> None:
+    socket_path = tmp_path / "fake.sock"
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(str(socket_path))
+    socket_path.chmod(0o600)
+    listener.listen(1)
+    stop = threading.Event()
+
+    def fake_server() -> None:
+        listener.settimeout(0.2)
+        while not stop.is_set():
+            try:
+                conn, _ = listener.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            with conn:
+                try:
+                    conn.recv(512)
+                    conn.sendall(b"ok")
+                except OSError:
+                    pass
+
+    thread = threading.Thread(target=fake_server, daemon=True)
+    thread.start()
+    monkeypatch.setenv("PERFXPERT_TUI_INTERACTIVE", "1")
+    monkeypatch.setenv("PERFXPERT_TUI_SESSION_TOKEN", "forged")
+    monkeypatch.setenv("PERFXPERT_TUI_SESSION_SOCKET", str(socket_path))
+    try:
+        with pytest.raises(SystemExit) as exc:
+            main_mod.main(["workflow", "import", str(tmp_path), "--interactive"])
+    finally:
+        stop.set()
+        listener.close()
+        thread.join(timeout=1.0)
+
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert "inside perfxpert-code" in captured.err
+
+
+def test_workflow_import_rejects_path_shadowed_parent_socket(tmp_path) -> None:
+    source = tmp_path / "external"
+    source.mkdir()
+    (source / "README.md").write_text("The adapter can use rocprof-compute counters.\n", encoding="utf-8")
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_parent = fake_bin / "perfxpert-code"
+    socket_path = tmp_path / "fake-parent.sock"
+    package_root = Path(__file__).resolve().parents[2]
+    fake_parent.write_text(
+        f"""#!/usr/bin/env python3
+import os
+import socket
+import subprocess
+import sys
+import threading
+
+# Include the expected entrypoint strings to prove PATH shadowing alone is not
+# enough to satisfy the launcher identity check.
+_entrypoint_reference = "perfxpert.cli.opencode_launcher:main"
+
+listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+listener.bind({str(socket_path)!r})
+os.chmod({str(socket_path)!r}, 0o600)
+listener.listen(1)
+stop = threading.Event()
+
+def server():
+    listener.settimeout(0.2)
+    while not stop.is_set():
+        try:
+            conn, _ = listener.accept()
+        except socket.timeout:
+            continue
+        except OSError:
+            break
+        with conn:
+            try:
+                conn.recv(512)
+                conn.sendall(b"ok")
+            except OSError:
+                pass
+
+thread = threading.Thread(target=server, daemon=True)
+thread.start()
+env = os.environ.copy()
+env["PYTHONPATH"] = {str(package_root)!r}
+env["PERFXPERT_TUI_INTERACTIVE"] = "1"
+env["PERFXPERT_TUI_SESSION_TOKEN"] = "forged"
+env["PERFXPERT_TUI_SESSION_SOCKET"] = {str(socket_path)!r}
+try:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "perfxpert",
+            "workflow",
+            "import",
+            sys.argv[1],
+            "--interactive",
+            "--no-persist",
+        ],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+finally:
+    stop.set()
+    listener.close()
+    thread.join(timeout=1.0)
+print(proc.stdout, end="")
+print(proc.stderr, end="", file=sys.stderr)
+raise SystemExit(proc.returncode)
+""",
+        encoding="utf-8",
+    )
+    fake_parent.chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = os.pathsep.join([str(fake_bin), env.get("PATH", "")])
+
+    proc = subprocess.run(
+        [str(fake_parent), str(source)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert "inside perfxpert-code" in proc.stderr
+
+
+def test_workflow_import_accepts_real_launcher_descendant_tui_session(tmp_path) -> None:
+    trusted_launchers = _trusted_launcher_paths()
+    if not trusted_launchers:
+        pytest.skip("perfxpert-code launcher is not installed in a trusted script location")
+    launcher = trusted_launchers[0]
+
+    source = tmp_path / "external"
+    source.mkdir()
+    (source / "README.md").write_text("The adapter can use rocprof-compute counters.\n", encoding="utf-8")
+    fake_opencode = tmp_path / "fake-opencode"
+    fake_config = tmp_path / "fake-config"
+    fake_config.mkdir()
+    for name in ("opencode.json", "AGENTS.md", "mcp.json", "amd-theme.json"):
+        (fake_config / name).write_text("{}\n", encoding="utf-8")
+    fake_opencode.write_text(
+        """#!/usr/bin/env python3
+import os
+import subprocess
+import sys
+
+proc = subprocess.run(
+    [
+        sys.executable,
+        "-m",
+        "perfxpert",
+        "workflow",
+        "import",
+        os.environ["PERFXPERT_TEST_SOURCE"],
+        "--interactive",
+        "--no-persist",
+        "--json",
+    ],
+    env=os.environ.copy(),
+    text=True,
+    capture_output=True,
+    check=False,
+)
+print(proc.stdout, end="")
+print(proc.stderr, end="", file=sys.stderr)
+raise SystemExit(proc.returncode)
+""",
+        encoding="utf-8",
+    )
+    fake_opencode.chmod(0o755)
+
+    sitecustomize = tmp_path / "sitecustomize.py"
+    sitecustomize.write_text(
+        """import os
+from pathlib import Path
+
+from perfxpert.cli import opencode_launcher
+
+opencode_launcher.resolve_opencode_binary = lambda: Path(os.environ["PERFXPERT_TEST_FAKE_OPENCODE"])
+opencode_launcher.resolve_config_dir = lambda: Path(os.environ["PERFXPERT_TEST_CONFIG_DIR"])
+""",
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    package_root = Path(__file__).resolve().parents[2]
+    existing_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        os.pathsep.join([str(tmp_path), str(package_root)])
+        if not existing_pythonpath
+        else os.pathsep.join([str(tmp_path), str(package_root), existing_pythonpath])
+    )
+    env["PERFXPERT_CODE_NO_BANNER"] = "1"
+    env["PERFXPERT_TEST_FAKE_OPENCODE"] = str(fake_opencode)
+    env["PERFXPERT_TEST_CONFIG_DIR"] = str(fake_config)
+    env["PERFXPERT_TEST_SOURCE"] = str(source)
+
+    proc = subprocess.run(
+        [str(launcher)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    plan = json.loads(proc.stdout)
+    assert plan["interactive_only"] is True
+    assert plan["execution_allowed"] is False
+
+
+def test_workflow_import_json_for_local_adapter(tmp_path, capsys, tui_session) -> None:
     source = tmp_path / "external"
     source.mkdir()
     (source / "README.md").write_text(
@@ -81,8 +346,7 @@ def test_workflow_import_json_for_local_adapter(tmp_path, capsys, monkeypatch) -
     assert plan["manifest_path"]
 
 
-def test_workflow_import_summary_for_local_adapter(tmp_path, capsys, monkeypatch) -> None:
-    monkeypatch.setenv("PERFXPERT_TUI_INTERACTIVE", "1")
+def test_workflow_import_summary_for_local_adapter(tmp_path, capsys, tui_session) -> None:
     source = tmp_path / "external"
     source.mkdir()
     (source / "README.md").write_text("The adapter can replay kernel launches.\n", encoding="utf-8")
@@ -106,8 +370,60 @@ def test_workflow_import_summary_for_local_adapter(tmp_path, capsys, monkeypatch
     assert "Activation: advisory TUI context only" in out
 
 
-def test_workflow_import_runtime_error_returns_one(tmp_path, capsys, monkeypatch) -> None:
-    monkeypatch.setenv("PERFXPERT_TUI_INTERACTIVE", "1")
+def test_workflow_import_url_without_network_consent_is_usage_error(capsys, tui_session) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main(
+            [
+                "workflow",
+                "import",
+                "https://github.com/example/perf-workflow",
+                "--interactive",
+            ]
+        )
+
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert "--allow-network" in captured.err
+
+
+def test_workflow_import_url_with_network_consent_forwards_to_inspector(
+    tmp_path, capsys, monkeypatch, tui_session
+) -> None:
+    captured = {}
+
+    def fake_import(source, **kwargs):
+        captured["source"] = source
+        captured.update(kwargs)
+        return {
+            "adapter_id": "adapter-123",
+            "capabilities": [],
+            "mcp_servers": [],
+            "knowledge_links": [],
+            "manifest_path": None,
+        }
+
+    monkeypatch.setattr("perfxpert.cli.workflow_cmd.inspect_external_workflow", fake_import)
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main(
+            [
+                "workflow",
+                "import",
+                "https://github.com/example/perf-workflow",
+                "--interactive",
+                "--allow-network",
+                "--cache-root",
+                str(tmp_path / "cache"),
+            ]
+        )
+
+    assert exc.value.code == 0
+    assert captured["source"] == "https://github.com/example/perf-workflow"
+    assert captured["allow_network"] is True
+    assert captured["interactive"] is True
+
+
+def test_workflow_import_runtime_error_returns_one(tmp_path, capsys, monkeypatch, tui_session) -> None:
 
     def fail_import(*args, **kwargs):
         raise ExternalWorkflowRuntimeError("clone failed")

--- a/experimental/python/perfxpert/tests/test_cli/test_workflow_cmd.py
+++ b/experimental/python/perfxpert/tests/test_cli/test_workflow_cmd.py
@@ -1,0 +1,122 @@
+"""CLI tests for ``perfxpert workflow``."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from perfxpert import __main__ as main_mod
+from perfxpert.integrations.external_workflow import ExternalWorkflowRuntimeError
+
+
+def test_workflow_import_refuses_without_interactive(tmp_path, capsys, monkeypatch) -> None:
+    monkeypatch.setenv("PERFXPERT_TUI_INTERACTIVE", "1")
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main(["workflow", "import", str(tmp_path)])
+
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert "TUI-interactive only" in captured.err
+
+
+def test_workflow_import_refuses_outside_tui_session(tmp_path, capsys, monkeypatch) -> None:
+    monkeypatch.delenv("PERFXPERT_IN_OPENCODE_SESSION", raising=False)
+    monkeypatch.delenv("PERFXPERT_IN_AGENT_SESSION", raising=False)
+    monkeypatch.delenv("PERFXPERT_TUI_INTERACTIVE", raising=False)
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main(["workflow", "import", str(tmp_path), "--interactive"])
+
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert "inside perfxpert-code" in captured.err
+
+
+def test_workflow_import_rejects_agent_session_without_tui_marker(tmp_path, capsys, monkeypatch) -> None:
+    monkeypatch.setenv("PERFXPERT_IN_AGENT_SESSION", "codex")
+    monkeypatch.delenv("PERFXPERT_TUI_INTERACTIVE", raising=False)
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main(["workflow", "import", str(tmp_path), "--interactive"])
+
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert "inside perfxpert-code" in captured.err
+
+
+def test_workflow_import_json_for_local_adapter(tmp_path, capsys, monkeypatch) -> None:
+    monkeypatch.setenv("PERFXPERT_TUI_INTERACTIVE", "1")
+    source = tmp_path / "external"
+    source.mkdir()
+    (source / "README.md").write_text(
+        "The profiler uses rocprof-compute counters and maps stalls to source line.\n",
+        encoding="utf-8",
+    )
+    (source / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"adapter": {"command": "adapter-mcp", "args": ["serve"]}}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main(
+            [
+                "workflow",
+                "import",
+                str(source),
+                "--interactive",
+                "--cache-root",
+                str(tmp_path / "cache"),
+                "--json",
+            ]
+        )
+
+    assert exc.value.code == 0
+    plan = json.loads(capsys.readouterr().out)
+    assert plan["interactive_only"] is True
+    assert plan["execution_allowed"] is False
+    assert plan["mcp_servers"][0]["name"] == "adapter"
+    assert any(cap["kind"] == "profiling" for cap in plan["capabilities"])
+    assert plan["manifest_path"]
+
+
+def test_workflow_import_summary_for_local_adapter(tmp_path, capsys, monkeypatch) -> None:
+    monkeypatch.setenv("PERFXPERT_TUI_INTERACTIVE", "1")
+    source = tmp_path / "external"
+    source.mkdir()
+    (source / "README.md").write_text("The adapter can replay kernel launches.\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main(
+            [
+                "workflow",
+                "import",
+                str(source),
+                "--interactive",
+                "--cache-root",
+                str(tmp_path / "cache"),
+            ]
+        )
+
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "Imported external workflow adapter:" in out
+    assert "Capabilities:" in out
+    assert "Activation: advisory TUI context only" in out
+
+
+def test_workflow_import_runtime_error_returns_one(tmp_path, capsys, monkeypatch) -> None:
+    monkeypatch.setenv("PERFXPERT_TUI_INTERACTIVE", "1")
+
+    def fail_import(*args, **kwargs):
+        raise ExternalWorkflowRuntimeError("clone failed")
+
+    monkeypatch.setattr("perfxpert.cli.workflow_cmd.inspect_external_workflow", fail_import)
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main(["workflow", "import", str(tmp_path), "--interactive"])
+
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "clone failed" in captured.err

--- a/experimental/python/perfxpert/tests/test_docs_tooling/test_ship_readiness.py
+++ b/experimental/python/perfxpert/tests/test_docs_tooling/test_ship_readiness.py
@@ -24,6 +24,9 @@ _LINT_SH = _SCRIPTS / "lint.sh"
 _LINK_CHECKER = _SCRIPTS / "link-checker.py"
 _TEST_SAMPLES = _SCRIPTS / "test-samples.py"
 _PERFXPERT_ROOT = "experimental/python/perfxpert"
+_AGENTIC_MODE = _REPO_ROOT / _PERFXPERT_ROOT / "docs" / "guides" / "agentic-mode.md"
+_GETTING_STARTED = _REPO_ROOT / _PERFXPERT_ROOT / "docs" / "guides" / "getting-started.md"
+_BUNDLED_AGENTS = _REPO_ROOT / _PERFXPERT_ROOT / "perfxpert" / "_bundled" / "opencode_config" / "AGENTS.md"
 
 
 def _fmt(result: subprocess.CompletedProcess) -> str:
@@ -73,3 +76,22 @@ def test_test_samples_strict_exits_clean():
         "scripts/test-samples.py --strict reported failing samples:\n"
         + _fmt(result)
     )
+
+
+def test_external_workflow_docs_are_tui_only():
+    """Adapter docs must not regress into copy-paste shell examples."""
+
+    text = (
+        _AGENTIC_MODE.read_text(encoding="utf-8")
+        + "\n"
+        + _GETTING_STARTED.read_text(encoding="utf-8")
+        + "\n"
+        + _BUNDLED_AGENTS.read_text(encoding="utf-8")
+    )
+    assert "Ask inside `perfxpert-code`" in text
+    assert "This is not a normal shell workflow" in text
+    assert "from `perfxpert-code run`" in text
+    assert "third-party backend dispatch" in text
+    assert "perfxpert workflow import ./external-tool" not in text
+    assert "perfxpert workflow import <source>" not in text
+    assert "<interactive-consent-flag>" not in text

--- a/experimental/python/perfxpert/tests/test_integrations/test_external_workflow.py
+++ b/experimental/python/perfxpert/tests/test_integrations/test_external_workflow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -12,6 +13,14 @@ from perfxpert.integrations.external_workflow import (
     ExternalWorkflowError,
     inspect_external_workflow,
 )
+
+
+def _is_clone_cmd(cmd: list[str]) -> bool:
+    return "clone" in cmd
+
+
+def _git_checkout_from_clone_cmd(cmd: list[str]) -> Path:
+    return Path(cmd[-1])
 
 
 def _write_adapter_fixture(root):
@@ -125,6 +134,22 @@ def test_url_source_requires_interactive_network_consent(tmp_path) -> None:
             cache_root=tmp_path / "cache",
         )
 
+    with pytest.raises(ExternalWorkflowError, match="hostname"):
+        inspect_external_workflow(
+            "https:///perf-workflow",
+            interactive=True,
+            allow_network=True,
+            cache_root=tmp_path / "cache",
+        )
+
+    with pytest.raises(ExternalWorkflowError, match="whitespace"):
+        inspect_external_workflow(
+            "https://github.com/example/perf workflow",
+            interactive=True,
+            allow_network=True,
+            cache_root=tmp_path / "cache",
+        )
+
 
 def test_https_source_clone_and_cache_reuse(tmp_path, monkeypatch) -> None:
     source_url = "https://github.com/example/perf-workflow"
@@ -132,12 +157,23 @@ def test_https_source_clone_and_cache_reuse(tmp_path, monkeypatch) -> None:
 
     def fake_run(cmd, **kwargs):
         calls.append(list(cmd))
-        if cmd[:3] == ["git", "clone", "--depth"]:
-            checkout = Path(cmd[-1])
+        assert kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+        assert kwargs["env"]["GIT_CONFIG_NOSYSTEM"] == "1"
+        assert kwargs["env"]["GIT_CONFIG_GLOBAL"] == os.devnull
+        assert "GIT_CONFIG_COUNT" not in kwargs["env"]
+        if "clone" in cmd or "checkout" in cmd:
+            assert "http.extraHeader=" in cmd
+            assert "credential.helper=" in cmd
+        if _is_clone_cmd(cmd):
+            checkout = _git_checkout_from_clone_cmd(cmd)
             checkout.mkdir(parents=True)
             (checkout / ".git").mkdir()
             (checkout / "README.md").write_text("Profiler and validation workflow.\n", encoding="utf-8")
             return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "sparse-checkout" in cmd or "checkout" in cmd:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd[0] == "git" and cmd[3:5] == ["rev-parse", "HEAD"]:
+            return SimpleNamespace(returncode=0, stdout="abc123\n", stderr="")
         if cmd[0] == "git" and cmd[3:6] == ["remote", "get-url", "origin"]:
             return SimpleNamespace(returncode=0, stdout=source_url + "\n", stderr="")
         raise AssertionError(f"unexpected command: {cmd!r}")
@@ -159,12 +195,15 @@ def test_https_source_clone_and_cache_reuse(tmp_path, monkeypatch) -> None:
         persist=False,
     )
 
-    clone_calls = [cmd for cmd in calls if cmd[:3] == ["git", "clone", "--depth"]]
+    clone_calls = [cmd for cmd in calls if _is_clone_cmd(cmd)]
     assert len(clone_calls) == 1
-    assert clone_calls[0][3] == "1"
-    assert clone_calls[0][4] == source_url
+    assert "--filter" in clone_calls[0]
+    assert "blob:none" in clone_calls[0]
+    assert "--no-checkout" in clone_calls[0]
+    assert source_url in clone_calls[0]
     assert first["materialized_path"] == second["materialized_path"]
     assert first["source"] == source_url
+    assert first["provenance"]["commit"] == "abc123"
 
 
 def test_https_clone_failure_is_runtime_error(tmp_path, monkeypatch) -> None:
@@ -190,12 +229,18 @@ def test_corrupt_file_cache_is_replaced_for_url_source(tmp_path, monkeypatch) ->
     corrupt.write_text("not a checkout\n", encoding="utf-8")
 
     def fake_run(cmd, **kwargs):
-        if cmd[:3] == ["git", "clone", "--depth"]:
-            checkout = Path(cmd[-1])
+        if _is_clone_cmd(cmd):
+            checkout = _git_checkout_from_clone_cmd(cmd)
             checkout.mkdir(parents=True)
             (checkout / ".git").mkdir()
             (checkout / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
             return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "sparse-checkout" in cmd or "checkout" in cmd:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd[0] == "git" and cmd[3:5] == ["rev-parse", "HEAD"]:
+            return SimpleNamespace(returncode=0, stdout="abc123\n", stderr="")
+        if cmd[0] == "git" and cmd[3:6] == ["remote", "get-url", "origin"]:
+            return SimpleNamespace(returncode=0, stdout=source_url + "\n", stderr="")
         raise AssertionError(f"unexpected command: {cmd!r}")
 
     monkeypatch.setattr("perfxpert.integrations.external_workflow.subprocess.run", fake_run)
@@ -212,15 +257,76 @@ def test_corrupt_file_cache_is_replaced_for_url_source(tmp_path, monkeypatch) ->
     assert (Path(plan["materialized_path"]) / ".git").is_dir()
 
 
+def test_completed_cache_with_wrong_remote_is_rejected(tmp_path, monkeypatch) -> None:
+    source_url = "https://github.com/example/perf-workflow"
+    cache_root = tmp_path / "cache"
+    cached = cache_root / "sources" / "perf-workflow-dd6c86ae6ab1"
+    (cached / ".git").mkdir(parents=True)
+    (cached / ".perfxpert-adapter-clone-complete").write_text("ok\n", encoding="utf-8")
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "git" and cmd[3:6] == ["remote", "get-url", "origin"]:
+            return SimpleNamespace(returncode=0, stdout="https://github.com/other/repo\n", stderr="")
+        raise AssertionError(f"unexpected command: {cmd!r}")
+
+    monkeypatch.setattr("perfxpert.integrations.external_workflow.subprocess.run", fake_run)
+
+    with pytest.raises(ExternalWorkflowError, match="does not match requested URL"):
+        inspect_external_workflow(
+            source_url,
+            interactive=True,
+            allow_network=True,
+            cache_root=cache_root,
+            persist=False,
+        )
+
+
+def test_partial_cache_without_sentinel_is_replaced(tmp_path, monkeypatch) -> None:
+    source_url = "https://github.com/example/perf-workflow"
+    cache_root = tmp_path / "cache"
+    partial = cache_root / "sources" / "perf-workflow-dd6c86ae6ab1"
+    (partial / ".git").mkdir(parents=True)
+
+    def fake_run(cmd, **kwargs):
+        if _is_clone_cmd(cmd):
+            checkout = _git_checkout_from_clone_cmd(cmd)
+            checkout.mkdir(parents=True)
+            (checkout / ".git").mkdir()
+            (checkout / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "sparse-checkout" in cmd or "checkout" in cmd:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd[0] == "git" and cmd[3:5] == ["rev-parse", "HEAD"]:
+            return SimpleNamespace(returncode=0, stdout="abc123\n", stderr="")
+        if cmd[0] == "git" and cmd[3:6] == ["remote", "get-url", "origin"]:
+            return SimpleNamespace(returncode=0, stdout=source_url + "\n", stderr="")
+        raise AssertionError(f"unexpected command: {cmd!r}")
+
+    monkeypatch.setattr("perfxpert.integrations.external_workflow.subprocess.run", fake_run)
+
+    plan = inspect_external_workflow(
+        source_url,
+        interactive=True,
+        allow_network=True,
+        cache_root=cache_root,
+        persist=False,
+    )
+
+    assert Path(plan["materialized_path"]).is_dir()
+    assert (Path(plan["materialized_path"]) / ".perfxpert-adapter-clone-complete").is_file()
+
+
 def test_clone_finalize_failure_is_runtime_error(tmp_path, monkeypatch) -> None:
     source_url = "https://github.com/example/perf-workflow"
 
     def fake_run(cmd, **kwargs):
-        if cmd[:3] == ["git", "clone", "--depth"]:
-            checkout = Path(cmd[-1])
+        if _is_clone_cmd(cmd):
+            checkout = _git_checkout_from_clone_cmd(cmd)
             checkout.mkdir(parents=True)
             (checkout / ".git").mkdir()
             (checkout / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "sparse-checkout" in cmd or "checkout" in cmd:
             return SimpleNamespace(returncode=0, stdout="", stderr="")
         raise AssertionError(f"unexpected command: {cmd!r}")
 
@@ -434,6 +540,32 @@ def test_cache_symlink_is_rejected(tmp_path) -> None:
         )
 
 
+def test_manifest_symlink_is_rejected(tmp_path) -> None:
+    source = tmp_path / "adapter"
+    source.mkdir()
+    (source / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
+
+    first = inspect_external_workflow(
+        str(source),
+        interactive=True,
+        cache_root=tmp_path / "cache",
+        persist=False,
+    )
+    manifest_dir = tmp_path / "cache" / "adapters"
+    manifest_dir.mkdir(parents=True)
+    target = tmp_path / "target.json"
+    target.write_text("do not overwrite\n", encoding="utf-8")
+    (manifest_dir / f"{first['adapter_id']}.json").symlink_to(target)
+
+    with pytest.raises(ExternalWorkflowError, match="symlink"):
+        inspect_external_workflow(
+            str(source),
+            interactive=True,
+            cache_root=tmp_path / "cache",
+        )
+    assert target.read_text(encoding="utf-8") == "do not overwrite\n"
+
+
 def test_malformed_mcp_descriptors_are_sanitized(tmp_path) -> None:
     source = tmp_path / "adapter"
     source.mkdir()
@@ -444,6 +576,7 @@ def test_malformed_mcp_descriptors_are_sanitized(tmp_path) -> None:
                     "bad": "not-an-object",
                     "dangerous": {"command": "adapter-mcp; rm -rf /", "args": ["serve"]},
                     "invalid": {"command": 42, "args": "serve"},
+                    "string_secret": {"command": "adapter-mcp --token secret-value"},
                     "valid": {"command": "valid-mcp", "args": ["serve"]},
                 }
             }
@@ -459,12 +592,67 @@ def test_malformed_mcp_descriptors_are_sanitized(tmp_path) -> None:
     )
 
     servers = {server["name"]: server for server in plan["mcp_servers"]}
-    assert set(servers) == {"dangerous", "invalid", "valid"}
+    assert set(servers) == {"dangerous", "invalid", "string_secret", "valid"}
     assert servers["dangerous"]["command"] is None
     assert servers["invalid"]["command"] is None
     assert servers["invalid"]["args"] == []
+    assert servers["string_secret"]["command"] == "adapter-mcp"
+    assert servers["string_secret"]["args"] == []
+    assert servers["string_secret"]["arg_count"] == 2
+    assert servers["valid"]["args"] == []
+    assert servers["valid"]["arg_count"] == 1
+    assert servers["valid"]["args_redacted"] is True
     assert servers["valid"]["command"] == "valid-mcp"
+    assert "secret-value" not in json.dumps(plan)
     assert any("unsafe MCP command" in warning for warning in plan["warnings"])
+    assert any("Redacted 1 MCP argument" in warning for warning in plan["warnings"])
+
+
+def test_opencode_mcp_shape_is_discovered_and_args_redacted(tmp_path) -> None:
+    source = tmp_path / "adapter"
+    source.mkdir()
+    (source / "opencode.json").write_text(
+        json.dumps({"mcp": {"adapter": {"command": ["adapter-mcp", "--token", "secret"]}}}),
+        encoding="utf-8",
+    )
+
+    plan = inspect_external_workflow(
+        str(source),
+        interactive=True,
+        cache_root=tmp_path / "cache",
+        persist=False,
+    )
+
+    assert plan["mcp_servers"][0]["name"] == "adapter"
+    assert plan["mcp_servers"][0]["command"] == "adapter-mcp"
+    assert plan["mcp_servers"][0]["args"] == []
+    assert plan["mcp_servers"][0]["arg_count"] == 2
+    assert "secret" not in json.dumps(plan)
+
+
+def test_source_tree_symlinks_and_fifos_are_skipped(tmp_path) -> None:
+    source = tmp_path / "adapter"
+    source.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.md").write_text("secret outside root\n", encoding="utf-8")
+    (source / "docs").symlink_to(outside, target_is_directory=True)
+    (source / ".mcp.json").symlink_to(outside / "secret.md")
+    if hasattr(os, "mkfifo"):
+        os.mkfifo(source / "fifo.json")
+    (source / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
+
+    plan = inspect_external_workflow(
+        str(source),
+        interactive=True,
+        cache_root=tmp_path / "cache",
+        persist=False,
+    )
+
+    assert "README.md" in plan["inspected_files"]
+    assert "docs/secret.md" not in plan["inspected_files"]
+    assert ".mcp.json" not in plan["inspected_files"]
+    assert "fifo.json" not in plan["inspected_files"]
 
 
 def test_invalid_mcp_json_and_non_dict_servers_are_ignored(tmp_path) -> None:

--- a/experimental/python/perfxpert/tests/test_integrations/test_external_workflow.py
+++ b/experimental/python/perfxpert/tests/test_integrations/test_external_workflow.py
@@ -54,6 +54,32 @@ def _write_adapter_fixture(root):
     (skill / "SKILL.md").write_text("Use this skill for optimization workflow.\n", encoding="utf-8")
 
 
+@pytest.fixture(autouse=True)
+def active_tui_session(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "perfxpert.integrations.external_workflow._has_active_tui_session",
+        lambda: True,
+    )
+
+
+def test_inspect_external_workflow_requires_active_tui_session(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "adapter"
+    source.mkdir()
+    (source / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "perfxpert.integrations.external_workflow._has_active_tui_session",
+        lambda: False,
+    )
+
+    with pytest.raises(ExternalWorkflowError, match="active perfxpert-code TUI session"):
+        inspect_external_workflow(
+            str(source),
+            interactive=True,
+            cache_root=tmp_path / "cache",
+            persist=False,
+        )
+
+
 def test_inspect_external_workflow_discovers_advisory_hooks(tmp_path) -> None:
     source = tmp_path / "adapter"
     _write_adapter_fixture(source)
@@ -83,6 +109,7 @@ def test_inspect_external_workflow_discovers_advisory_hooks(tmp_path) -> None:
     assert plan["manifest_path"]
     manifest = json.loads(Path(plan["manifest_path"]).read_text(encoding="utf-8"))
     assert manifest["adapter_id"] == plan["adapter_id"]
+    assert manifest["manifest_path"] == plan["manifest_path"]
     assert Path(plan["manifest_path"]).parent == tmp_path / "cache" / "adapters"
 
 
@@ -94,7 +121,7 @@ def test_url_source_requires_interactive_network_consent(tmp_path) -> None:
             cache_root=tmp_path / "cache",
         )
 
-    with pytest.raises(ExternalWorkflowError, match="--allow-network"):
+    with pytest.raises(ExternalWorkflowError, match="explicit network consent"):
         inspect_external_workflow(
             "https://github.com/example/perf-workflow",
             interactive=True,
@@ -158,9 +185,9 @@ def test_https_source_clone_and_cache_reuse(tmp_path, monkeypatch) -> None:
     def fake_run(cmd, **kwargs):
         calls.append(list(cmd))
         assert kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+        assert "GIT_CONFIG_COUNT" not in kwargs["env"]
         assert kwargs["env"]["GIT_CONFIG_NOSYSTEM"] == "1"
         assert kwargs["env"]["GIT_CONFIG_GLOBAL"] == os.devnull
-        assert "GIT_CONFIG_COUNT" not in kwargs["env"]
         if "clone" in cmd or "checkout" in cmd:
             assert "http.extraHeader=" in cmd
             assert "credential.helper=" in cmd
@@ -168,9 +195,16 @@ def test_https_source_clone_and_cache_reuse(tmp_path, monkeypatch) -> None:
             checkout = _git_checkout_from_clone_cmd(cmd)
             checkout.mkdir(parents=True)
             (checkout / ".git").mkdir()
-            (checkout / "README.md").write_text("Profiler and validation workflow.\n", encoding="utf-8")
             return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "ls-tree" in cmd:
+            return SimpleNamespace(returncode=0, stdout="README.md\n", stderr="")
         if "sparse-checkout" in cmd or "checkout" in cmd:
+            if "sparse-checkout" in cmd:
+                assert "README.md" in cmd
+                assert "docs" not in cmd
+            if "checkout" in cmd:
+                checkout = Path(cmd[cmd.index("-C") + 1])
+                (checkout / "README.md").write_text("Profiler and validation workflow.\n", encoding="utf-8")
             return SimpleNamespace(returncode=0, stdout="", stderr="")
         if cmd[0] == "git" and cmd[3:5] == ["rev-parse", "HEAD"]:
             return SimpleNamespace(returncode=0, stdout="abc123\n", stderr="")
@@ -196,7 +230,9 @@ def test_https_source_clone_and_cache_reuse(tmp_path, monkeypatch) -> None:
     )
 
     clone_calls = [cmd for cmd in calls if _is_clone_cmd(cmd)]
+    checkout_calls = [cmd for cmd in calls if "checkout" in cmd and "sparse-checkout" not in cmd]
     assert len(clone_calls) == 1
+    assert len(checkout_calls) == 1
     assert "--filter" in clone_calls[0]
     assert "blob:none" in clone_calls[0]
     assert "--no-checkout" in clone_calls[0]
@@ -204,6 +240,134 @@ def test_https_source_clone_and_cache_reuse(tmp_path, monkeypatch) -> None:
     assert first["materialized_path"] == second["materialized_path"]
     assert first["source"] == source_url
     assert first["provenance"]["commit"] == "abc123"
+
+
+def test_https_sparse_checkout_rejects_glob_pattern_paths(tmp_path, monkeypatch) -> None:
+    source_url = "https://github.com/example/perf-workflow"
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if _is_clone_cmd(cmd):
+            checkout = _git_checkout_from_clone_cmd(cmd)
+            checkout.mkdir(parents=True)
+            (checkout / ".git").mkdir()
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "ls-tree" in cmd:
+            return SimpleNamespace(returncode=0, stdout="docs/*.md\ndocs/safe.md\n", stderr="")
+        if "sparse-checkout" in cmd:
+            assert "docs/*.md" not in cmd
+            assert "docs/safe.md" in cmd
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "checkout" in cmd:
+            checkout = Path(cmd[cmd.index("-C") + 1])
+            docs = checkout / "docs"
+            docs.mkdir()
+            (docs / "safe.md").write_text("Profiler workflow.\n", encoding="utf-8")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd[0] == "git" and cmd[3:5] == ["rev-parse", "HEAD"]:
+            return SimpleNamespace(returncode=0, stdout="abc123\n", stderr="")
+        if cmd[0] == "git" and cmd[3:6] == ["remote", "get-url", "origin"]:
+            return SimpleNamespace(returncode=0, stdout=source_url + "\n", stderr="")
+        raise AssertionError(f"unexpected command: {cmd!r}")
+
+    monkeypatch.setattr("perfxpert.integrations.external_workflow.subprocess.run", fake_run)
+
+    plan = inspect_external_workflow(
+        source_url,
+        interactive=True,
+        allow_network=True,
+        cache_root=tmp_path / "cache",
+        persist=False,
+    )
+
+    assert "docs/safe.md" in plan["inspected_files"]
+    assert "docs/*.md" not in plan["inspected_files"]
+
+
+def test_git_error_redacts_proxy_url_credentials(tmp_path, monkeypatch) -> None:
+    def fake_run(cmd, **kwargs):
+        return SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr=(
+                "fatal: unable to access proxy http://user:secret-proxy@example.com:8080\n"
+                "fatal: unable to access proxy https://ghp_tokenonly@example.com\n"
+            ),
+        )
+
+    monkeypatch.setattr("perfxpert.integrations.external_workflow.subprocess.run", fake_run)
+
+    with pytest.raises(ExternalWorkflowError) as exc:
+        inspect_external_workflow(
+            "https://github.com/example/perf-workflow",
+            interactive=True,
+            allow_network=True,
+            cache_root=tmp_path / "cache",
+        )
+
+    assert "secret-proxy" not in str(exc.value)
+    assert "ghp_tokenonly" not in str(exc.value)
+    assert "http://<redacted>@" in str(exc.value)
+    assert "https://<redacted>@" in str(exc.value)
+
+
+def test_git_error_redacts_compound_secret_keys(tmp_path, monkeypatch) -> None:
+    def fake_run(cmd, **kwargs):
+        return SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr="fatal: access_token=secret-token client_secret=secret-client api-key=secret-api\n",
+        )
+
+    monkeypatch.setattr("perfxpert.integrations.external_workflow.subprocess.run", fake_run)
+
+    with pytest.raises(ExternalWorkflowError) as exc:
+        inspect_external_workflow(
+            "https://github.com/example/perf-workflow",
+            interactive=True,
+            allow_network=True,
+            cache_root=tmp_path / "cache",
+        )
+
+    message = str(exc.value)
+    assert "secret-token" not in message
+    assert "secret-client" not in message
+    assert "secret-api" not in message
+    assert "access_token=<redacted>" in message
+    assert "client_secret=<redacted>" in message
+    assert "api-key=<redacted>" in message
+
+
+def test_git_error_redacts_authorization_headers(tmp_path, monkeypatch) -> None:
+    def fake_run(cmd, **kwargs):
+        return SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr=(
+                "Proxy-Authorization: Bearer secret-bearer\n"
+                "Authorization: Basic secret-basic\n"
+                "X-Api-Token: secret-header\n"
+            ),
+        )
+
+    monkeypatch.setattr("perfxpert.integrations.external_workflow.subprocess.run", fake_run)
+
+    with pytest.raises(ExternalWorkflowError) as exc:
+        inspect_external_workflow(
+            "https://github.com/example/perf-workflow",
+            interactive=True,
+            allow_network=True,
+            cache_root=tmp_path / "cache",
+        )
+
+    message = str(exc.value)
+    assert "secret-bearer" not in message
+    assert "secret-basic" not in message
+    assert "secret-header" not in message
+    assert "Proxy-Authorization: <redacted>" in message
+    assert "Authorization: <redacted>" in message
+    assert "X-Api-Token: <redacted>" in message
 
 
 def test_https_clone_failure_is_runtime_error(tmp_path, monkeypatch) -> None:
@@ -235,6 +399,8 @@ def test_corrupt_file_cache_is_replaced_for_url_source(tmp_path, monkeypatch) ->
             (checkout / ".git").mkdir()
             (checkout / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
             return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "ls-tree" in cmd:
+            return SimpleNamespace(returncode=0, stdout="README.md\n", stderr="")
         if "sparse-checkout" in cmd or "checkout" in cmd:
             return SimpleNamespace(returncode=0, stdout="", stderr="")
         if cmd[0] == "git" and cmd[3:5] == ["rev-parse", "HEAD"]:
@@ -294,6 +460,8 @@ def test_partial_cache_without_sentinel_is_replaced(tmp_path, monkeypatch) -> No
             (checkout / ".git").mkdir()
             (checkout / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
             return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "ls-tree" in cmd:
+            return SimpleNamespace(returncode=0, stdout="README.md\n", stderr="")
         if "sparse-checkout" in cmd or "checkout" in cmd:
             return SimpleNamespace(returncode=0, stdout="", stderr="")
         if cmd[0] == "git" and cmd[3:5] == ["rev-parse", "HEAD"]:
@@ -326,6 +494,8 @@ def test_clone_finalize_failure_is_runtime_error(tmp_path, monkeypatch) -> None:
             (checkout / ".git").mkdir()
             (checkout / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
             return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "ls-tree" in cmd:
+            return SimpleNamespace(returncode=0, stdout="README.md\n", stderr="")
         if "sparse-checkout" in cmd or "checkout" in cmd:
             return SimpleNamespace(returncode=0, stdout="", stderr="")
         raise AssertionError(f"unexpected command: {cmd!r}")
@@ -461,7 +631,7 @@ def test_scan_depth_cap_warns(tmp_path, monkeypatch) -> None:
     assert any("deeper than 1 levels" in warning for warning in plan["warnings"])
 
 
-def test_file_source_uses_parent_directory_and_package_bins(tmp_path) -> None:
+def test_directory_source_discovers_package_bins(tmp_path) -> None:
     source = tmp_path / "adapter"
     source.mkdir()
     (source / "README.md").write_text("A profiler helper.\n", encoding="utf-8")
@@ -471,7 +641,7 @@ def test_file_source_uses_parent_directory_and_package_bins(tmp_path) -> None:
     )
 
     plan = inspect_external_workflow(
-        str(source / "README.md"),
+        str(source),
         interactive=True,
         cache_root=tmp_path / "cache",
         persist=False,
@@ -480,6 +650,37 @@ def test_file_source_uses_parent_directory_and_package_bins(tmp_path) -> None:
     names = {cap["name"] for cap in plan["capabilities"] if cap["kind"] == "entry_point"}
     assert names == {"adapter-mcp", "adapter-prof"}
     assert plan["materialized_path"] == str(source)
+
+
+def test_file_source_is_rejected_instead_of_widening_to_parent(tmp_path) -> None:
+    source = tmp_path / "adapter"
+    source.mkdir()
+    (source / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
+
+    with pytest.raises(ExternalWorkflowError, match="must be a directory"):
+        inspect_external_workflow(
+            str(source / "README.md"),
+            interactive=True,
+            cache_root=tmp_path / "cache",
+            persist=False,
+        )
+
+
+def test_local_source_rejects_symlink_parent(tmp_path) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "adapter").mkdir()
+    (target / "adapter" / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
+    linked = tmp_path / "linked"
+    linked.symlink_to(target, target_is_directory=True)
+
+    with pytest.raises(ExternalWorkflowError, match="symlinks"):
+        inspect_external_workflow(
+            str(linked / "adapter"),
+            interactive=True,
+            cache_root=tmp_path / "cache",
+            persist=False,
+        )
 
 
 def test_relative_source_and_default_cache_use_workload_cwd(tmp_path, monkeypatch) -> None:
@@ -575,6 +776,10 @@ def test_malformed_mcp_descriptors_are_sanitized(tmp_path) -> None:
                 "mcpServers": {
                     "bad": "not-an-object",
                     "dangerous": {"command": "adapter-mcp; rm -rf /", "args": ["serve"]},
+                    "env_args": {"command": "env", "args": ["TOKEN=secret-value", "adapter-mcp", "serve"]},
+                    "env_secret": {"command": "TOKEN=secret-value adapter-mcp", "args": ["serve"]},
+                    "env_wrapper": {"command": "env TOKEN=secret-value adapter-mcp"},
+                    "empty_env": {"command": "TOKEN= adapter-mcp"},
                     "invalid": {"command": 42, "args": "serve"},
                     "string_secret": {"command": "adapter-mcp --token secret-value"},
                     "valid": {"command": "valid-mcp", "args": ["serve"]},
@@ -592,8 +797,24 @@ def test_malformed_mcp_descriptors_are_sanitized(tmp_path) -> None:
     )
 
     servers = {server["name"]: server for server in plan["mcp_servers"]}
-    assert set(servers) == {"dangerous", "invalid", "string_secret", "valid"}
+    assert set(servers) == {
+        "dangerous",
+        "empty_env",
+        "env_args",
+        "env_secret",
+        "env_wrapper",
+        "invalid",
+        "string_secret",
+        "valid",
+    }
     assert servers["dangerous"]["command"] is None
+    assert servers["empty_env"]["command"] == "adapter-mcp"
+    assert servers["env_args"]["command"] == "adapter-mcp"
+    assert servers["env_args"]["arg_count"] == 3
+    assert servers["env_secret"]["command"] == "adapter-mcp"
+    assert servers["env_secret"]["arg_count"] == 2
+    assert servers["env_wrapper"]["command"] == "adapter-mcp"
+    assert servers["env_wrapper"]["arg_count"] == 2
     assert servers["invalid"]["command"] is None
     assert servers["invalid"]["args"] == []
     assert servers["string_secret"]["command"] == "adapter-mcp"
@@ -606,6 +827,38 @@ def test_malformed_mcp_descriptors_are_sanitized(tmp_path) -> None:
     assert "secret-value" not in json.dumps(plan)
     assert any("unsafe MCP command" in warning for warning in plan["warnings"])
     assert any("Redacted 1 MCP argument" in warning for warning in plan["warnings"])
+
+
+def test_local_git_provenance_redacts_query_secrets(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "adapter"
+    source.mkdir()
+    (source / ".git").mkdir()
+    (source / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "git" and cmd[3:5] == ["rev-parse", "HEAD"]:
+            return SimpleNamespace(returncode=0, stdout="abc123\n", stderr="")
+        if cmd[0] == "git" and cmd[3:6] == ["remote", "get-url", "origin"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="https://example.com/repo.git?token=secret-value#frag\n",
+                stderr="",
+            )
+        raise AssertionError(f"unexpected command: {cmd!r}")
+
+    monkeypatch.setattr("perfxpert.integrations.external_workflow.subprocess.run", fake_run)
+
+    plan = inspect_external_workflow(
+        str(source),
+        interactive=True,
+        cache_root=tmp_path / "cache",
+        persist=True,
+    )
+    manifest = Path(plan["manifest_path"]).read_text(encoding="utf-8")
+
+    assert plan["provenance"]["remote"] == "https://example.com/repo.git"
+    assert "secret-value" not in json.dumps(plan)
+    assert "secret-value" not in manifest
 
 
 def test_opencode_mcp_shape_is_discovered_and_args_redacted(tmp_path) -> None:

--- a/experimental/python/perfxpert/tests/test_integrations/test_external_workflow.py
+++ b/experimental/python/perfxpert/tests/test_integrations/test_external_workflow.py
@@ -1,0 +1,500 @@
+"""Unit tests for external workflow adapter inspection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from perfxpert.integrations.external_workflow import (
+    ExternalWorkflowError,
+    inspect_external_workflow,
+)
+
+
+def _write_adapter_fixture(root):
+    root.mkdir()
+    (root / "README.md").write_text(
+        "\n".join(
+            [
+                "The profiler runner uses rocprof-compute PMC counters.",
+                "Source mapping provides source line PC sampling attribution.",
+                "Trace inspection reads HSA packet traces and AQL assembly.",
+                "Kernel replay can extract kernel launches.",
+                "Validation checks correctness and regression behavior.",
+                "Install with: pip install external-tool",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (root / "pyproject.toml").write_text(
+        '[project.scripts]\nadapter-mcp = "adapter.server:main"\n',
+        encoding="utf-8",
+    )
+    (root / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"adapter": {"command": "adapter-mcp", "args": ["serve"]}}}),
+        encoding="utf-8",
+    )
+    docs = root / "docs" / "knowledge"
+    docs.mkdir(parents=True)
+    (docs / "optimization.md").write_text("Prefer measured counters.\n", encoding="utf-8")
+    skill = root / "skills" / "optimizer"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("Use this skill for optimization workflow.\n", encoding="utf-8")
+
+
+def test_inspect_external_workflow_discovers_advisory_hooks(tmp_path) -> None:
+    source = tmp_path / "adapter"
+    _write_adapter_fixture(source)
+
+    plan = inspect_external_workflow(
+        str(source),
+        interactive=True,
+        cache_root=tmp_path / "cache",
+    )
+
+    kinds = {cap["kind"] for cap in plan["capabilities"]}
+    assert {
+        "profiling",
+        "source_correlation",
+        "trace_inspection",
+        "kernel_isolation",
+        "correctness",
+        "mcp_tools",
+        "agent_skill",
+        "entry_point",
+    } <= kinds
+    assert plan["interactive_only"] is True
+    assert plan["execution_allowed"] is False
+    assert plan["mcp_servers"][0]["activation"].startswith("requires explicit active-session TUI consent")
+    assert any(link["path"] == "docs/knowledge/optimization.md" for link in plan["knowledge_links"])
+    assert any("do not run them" in warning for warning in plan["warnings"])
+    assert plan["manifest_path"]
+    manifest = json.loads(Path(plan["manifest_path"]).read_text(encoding="utf-8"))
+    assert manifest["adapter_id"] == plan["adapter_id"]
+    assert Path(plan["manifest_path"]).parent == tmp_path / "cache" / "adapters"
+
+
+def test_url_source_requires_interactive_network_consent(tmp_path) -> None:
+    with pytest.raises(ExternalWorkflowError, match="TUI-interactive"):
+        inspect_external_workflow(
+            "https://github.com/example/perf-workflow",
+            interactive=False,
+            cache_root=tmp_path / "cache",
+        )
+
+    with pytest.raises(ExternalWorkflowError, match="--allow-network"):
+        inspect_external_workflow(
+            "https://github.com/example/perf-workflow",
+            interactive=True,
+            allow_network=False,
+            cache_root=tmp_path / "cache",
+        )
+
+    with pytest.raises(ExternalWorkflowError, match="https://"):
+        inspect_external_workflow(
+            "http://example.com/perf-workflow",
+            interactive=True,
+            allow_network=True,
+            cache_root=tmp_path / "cache",
+        )
+
+    with pytest.raises(ExternalWorkflowError, match="embedded credentials"):
+        inspect_external_workflow(
+            "https://user:token@example.com/perf-workflow",
+            interactive=True,
+            allow_network=True,
+            cache_root=tmp_path / "cache",
+        )
+
+    with pytest.raises(ExternalWorkflowError, match="query strings or fragments"):
+        inspect_external_workflow(
+            "https://github.com/example/perf-workflow?token=secret",
+            interactive=True,
+            allow_network=True,
+            cache_root=tmp_path / "cache",
+        )
+
+    with pytest.raises(ExternalWorkflowError, match="query strings or fragments"):
+        inspect_external_workflow(
+            "https://github.com/example/perf-workflow#secret",
+            interactive=True,
+            allow_network=True,
+            cache_root=tmp_path / "cache",
+        )
+
+
+def test_https_source_clone_and_cache_reuse(tmp_path, monkeypatch) -> None:
+    source_url = "https://github.com/example/perf-workflow"
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:3] == ["git", "clone", "--depth"]:
+            checkout = Path(cmd[-1])
+            checkout.mkdir(parents=True)
+            (checkout / ".git").mkdir()
+            (checkout / "README.md").write_text("Profiler and validation workflow.\n", encoding="utf-8")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd[0] == "git" and cmd[3:6] == ["remote", "get-url", "origin"]:
+            return SimpleNamespace(returncode=0, stdout=source_url + "\n", stderr="")
+        raise AssertionError(f"unexpected command: {cmd!r}")
+
+    monkeypatch.setattr("perfxpert.integrations.external_workflow.subprocess.run", fake_run)
+
+    first = inspect_external_workflow(
+        source_url,
+        interactive=True,
+        allow_network=True,
+        cache_root=tmp_path / "cache",
+        persist=False,
+    )
+    second = inspect_external_workflow(
+        source_url,
+        interactive=True,
+        allow_network=True,
+        cache_root=tmp_path / "cache",
+        persist=False,
+    )
+
+    clone_calls = [cmd for cmd in calls if cmd[:3] == ["git", "clone", "--depth"]]
+    assert len(clone_calls) == 1
+    assert clone_calls[0][3] == "1"
+    assert clone_calls[0][4] == source_url
+    assert first["materialized_path"] == second["materialized_path"]
+    assert first["source"] == source_url
+
+
+def test_https_clone_failure_is_runtime_error(tmp_path, monkeypatch) -> None:
+    def fake_run(cmd, **kwargs):
+        return SimpleNamespace(returncode=1, stdout="", stderr="fatal: could not read token\n")
+
+    monkeypatch.setattr("perfxpert.integrations.external_workflow.subprocess.run", fake_run)
+
+    with pytest.raises(ExternalWorkflowError, match="git clone failed"):
+        inspect_external_workflow(
+            "https://github.com/example/perf-workflow",
+            interactive=True,
+            allow_network=True,
+            cache_root=tmp_path / "cache",
+        )
+
+
+def test_corrupt_file_cache_is_replaced_for_url_source(tmp_path, monkeypatch) -> None:
+    source_url = "https://github.com/example/perf-workflow"
+    cache_root = tmp_path / "cache"
+    corrupt = cache_root / "sources" / "perf-workflow-dd6c86ae6ab1"
+    corrupt.parent.mkdir(parents=True)
+    corrupt.write_text("not a checkout\n", encoding="utf-8")
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["git", "clone", "--depth"]:
+            checkout = Path(cmd[-1])
+            checkout.mkdir(parents=True)
+            (checkout / ".git").mkdir()
+            (checkout / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        raise AssertionError(f"unexpected command: {cmd!r}")
+
+    monkeypatch.setattr("perfxpert.integrations.external_workflow.subprocess.run", fake_run)
+
+    plan = inspect_external_workflow(
+        source_url,
+        interactive=True,
+        allow_network=True,
+        cache_root=cache_root,
+        persist=False,
+    )
+
+    assert Path(plan["materialized_path"]).is_dir()
+    assert (Path(plan["materialized_path"]) / ".git").is_dir()
+
+
+def test_clone_finalize_failure_is_runtime_error(tmp_path, monkeypatch) -> None:
+    source_url = "https://github.com/example/perf-workflow"
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["git", "clone", "--depth"]:
+            checkout = Path(cmd[-1])
+            checkout.mkdir(parents=True)
+            (checkout / ".git").mkdir()
+            (checkout / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        raise AssertionError(f"unexpected command: {cmd!r}")
+
+    original_write_text = Path.write_text
+
+    def fail_sentinel_write(self, *args, **kwargs):
+        if self.name == ".perfxpert-adapter-clone-complete":
+            raise PermissionError("read-only cache")
+        return original_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr("perfxpert.integrations.external_workflow.subprocess.run", fake_run)
+    monkeypatch.setattr(Path, "write_text", fail_sentinel_write)
+
+    with pytest.raises(ExternalWorkflowError, match="failed to finalize cached external workflow source"):
+        inspect_external_workflow(
+            source_url,
+            interactive=True,
+            allow_network=True,
+            cache_root=tmp_path / "cache",
+            persist=False,
+        )
+
+
+def test_inspection_prioritizes_docs_over_large_test_tree(tmp_path) -> None:
+    source = tmp_path / "adapter"
+    source.mkdir()
+    (source / "README.md").write_text("External workflow with advisory knowledge.\n", encoding="utf-8")
+    tests = source / "tests"
+    tests.mkdir()
+    for idx in range(180):
+        (tests / f"test_noise_{idx}.py").write_text("def test_noise(): pass\n", encoding="utf-8")
+    knowledge = source / "docs" / "knowledge"
+    knowledge.mkdir(parents=True)
+    (knowledge / "critical.md").write_text("Important workflow hint.\n", encoding="utf-8")
+
+    plan = inspect_external_workflow(
+        str(source),
+        interactive=True,
+        cache_root=tmp_path / "cache",
+        persist=False,
+    )
+
+    assert "docs/knowledge/critical.md" in plan["inspected_files"]
+    assert not any(path.startswith("tests/") for path in plan["inspected_files"])
+
+
+def test_scan_caps_noisy_root_but_keeps_docs(tmp_path) -> None:
+    source = tmp_path / "adapter"
+    source.mkdir()
+    for idx in range(180):
+        (source / f"noise_{idx:03d}.txt").write_text("noise\n", encoding="utf-8")
+    docs = source / "docs"
+    docs.mkdir()
+    (docs / "workflow.md").write_text("Profiler workflow knowledge.\n", encoding="utf-8")
+    oversized = source / "large.md"
+    oversized.write_bytes(b"x" * (256 * 1024 + 1))
+
+    plan = inspect_external_workflow(
+        str(source),
+        interactive=True,
+        cache_root=tmp_path / "cache",
+        persist=False,
+    )
+
+    assert "docs/workflow.md" in plan["inspected_files"]
+    assert "large.md" not in plan["inspected_files"]
+    assert len(plan["inspected_files"]) == 120
+    assert any("candidate files" in warning for warning in plan["warnings"])
+
+
+def test_child_cap_prioritizes_special_files_and_docs(tmp_path) -> None:
+    source = tmp_path / "adapter"
+    source.mkdir()
+    for idx in range(1200):
+        (source / f"noise_{idx:04d}.txt").write_text("noise\n", encoding="utf-8")
+    (source / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
+    (source / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"adapter": {"command": "adapter-mcp", "args": []}}}),
+        encoding="utf-8",
+    )
+    docs = source / "docs"
+    docs.mkdir()
+    (docs / "workflow.md").write_text("Workflow knowledge.\n", encoding="utf-8")
+
+    plan = inspect_external_workflow(
+        str(source),
+        interactive=True,
+        cache_root=tmp_path / "cache",
+        persist=False,
+    )
+
+    assert "README.md" in plan["inspected_files"]
+    assert ".mcp.json" in plan["inspected_files"]
+    assert "docs/workflow.md" in plan["inspected_files"]
+    assert plan["mcp_servers"][0]["name"] == "adapter"
+    assert any("1024 children" in warning for warning in plan["warnings"])
+
+
+def test_scan_directory_count_cap_warns(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("perfxpert.integrations.external_workflow.MAX_SCANNED_DIRS", 4)
+    source = tmp_path / "adapter"
+    source.mkdir()
+    for idx in range(10):
+        child = source / f"dir_{idx}"
+        child.mkdir()
+        (child / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
+
+    plan = inspect_external_workflow(
+        str(source),
+        interactive=True,
+        cache_root=tmp_path / "cache",
+        persist=False,
+    )
+
+    assert any("4 directories" in warning for warning in plan["warnings"])
+
+
+def test_scan_depth_cap_warns(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("perfxpert.integrations.external_workflow.MAX_SCAN_DEPTH", 1)
+    source = tmp_path / "adapter"
+    deep = source / "level1" / "level2"
+    deep.mkdir(parents=True)
+    (deep / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
+
+    plan = inspect_external_workflow(
+        str(source),
+        interactive=True,
+        cache_root=tmp_path / "cache",
+        persist=False,
+    )
+
+    assert any("deeper than 1 levels" in warning for warning in plan["warnings"])
+
+
+def test_file_source_uses_parent_directory_and_package_bins(tmp_path) -> None:
+    source = tmp_path / "adapter"
+    source.mkdir()
+    (source / "README.md").write_text("A profiler helper.\n", encoding="utf-8")
+    (source / "package.json").write_text(
+        json.dumps({"bin": {"adapter-prof": "bin/prof.js", "adapter-mcp": "bin/mcp.js"}}),
+        encoding="utf-8",
+    )
+
+    plan = inspect_external_workflow(
+        str(source / "README.md"),
+        interactive=True,
+        cache_root=tmp_path / "cache",
+        persist=False,
+    )
+
+    names = {cap["name"] for cap in plan["capabilities"] if cap["kind"] == "entry_point"}
+    assert names == {"adapter-mcp", "adapter-prof"}
+    assert plan["materialized_path"] == str(source)
+
+
+def test_relative_source_and_default_cache_use_workload_cwd(tmp_path, monkeypatch) -> None:
+    workload = tmp_path / "workload"
+    source = workload / "adapter"
+    source.mkdir(parents=True)
+    (source / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
+    staged_tui = tmp_path / "staged-tui"
+    staged_tui.mkdir()
+    monkeypatch.chdir(staged_tui)
+    monkeypatch.setenv("PERFXPERT_WORKLOAD_CWD", str(workload))
+
+    plan = inspect_external_workflow("adapter", interactive=True)
+
+    assert plan["materialized_path"] == str(source)
+    assert Path(plan["manifest_path"]).parent == workload / ".perfxpert" / "external-workflows" / "adapters"
+
+
+def test_no_persist_omits_manifest_and_stable_adapter_id(tmp_path) -> None:
+    source = tmp_path / "adapter"
+    source.mkdir()
+    (source / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
+
+    first = inspect_external_workflow(
+        str(source),
+        interactive=True,
+        cache_root=tmp_path / "cache",
+        persist=False,
+    )
+    second = inspect_external_workflow(
+        str(source),
+        interactive=True,
+        cache_root=tmp_path / "cache",
+        persist=False,
+    )
+
+    assert first["manifest_path"] is None
+    assert second["manifest_path"] is None
+    assert first["adapter_id"] == second["adapter_id"]
+    assert not (tmp_path / "cache" / "adapters").exists()
+
+
+def test_cache_symlink_is_rejected(tmp_path) -> None:
+    cache = tmp_path / "cache"
+    target = tmp_path / "target"
+    target.mkdir()
+    cache.symlink_to(target, target_is_directory=True)
+
+    source = tmp_path / "adapter"
+    source.mkdir()
+    (source / "README.md").write_text("Profiler workflow.\n", encoding="utf-8")
+
+    with pytest.raises(ExternalWorkflowError, match="symlink"):
+        inspect_external_workflow(
+            str(source),
+            interactive=True,
+            cache_root=cache,
+        )
+
+
+def test_malformed_mcp_descriptors_are_sanitized(tmp_path) -> None:
+    source = tmp_path / "adapter"
+    source.mkdir()
+    (source / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "bad": "not-an-object",
+                    "dangerous": {"command": "adapter-mcp; rm -rf /", "args": ["serve"]},
+                    "invalid": {"command": 42, "args": "serve"},
+                    "valid": {"command": "valid-mcp", "args": ["serve"]},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    plan = inspect_external_workflow(
+        str(source),
+        interactive=True,
+        cache_root=tmp_path / "cache",
+        persist=False,
+    )
+
+    servers = {server["name"]: server for server in plan["mcp_servers"]}
+    assert set(servers) == {"dangerous", "invalid", "valid"}
+    assert servers["dangerous"]["command"] is None
+    assert servers["invalid"]["command"] is None
+    assert servers["invalid"]["args"] == []
+    assert servers["valid"]["command"] == "valid-mcp"
+    assert any("unsafe MCP command" in warning for warning in plan["warnings"])
+
+
+def test_invalid_mcp_json_and_non_dict_servers_are_ignored(tmp_path) -> None:
+    invalid_json = tmp_path / "invalid-json"
+    invalid_json.mkdir()
+    (invalid_json / ".mcp.json").write_text("{not-json", encoding="utf-8")
+    invalid_plan = inspect_external_workflow(
+        str(invalid_json),
+        interactive=True,
+        cache_root=tmp_path / "cache-invalid",
+        persist=False,
+    )
+    assert invalid_plan["mcp_servers"] == []
+
+    non_dict = tmp_path / "non-dict"
+    non_dict.mkdir()
+    (non_dict / ".mcp.json").write_text(json.dumps({"mcpServers": []}), encoding="utf-8")
+    non_dict_plan = inspect_external_workflow(
+        str(non_dict),
+        interactive=True,
+        cache_root=tmp_path / "cache-non-dict",
+        persist=False,
+    )
+    assert non_dict_plan["mcp_servers"] == []
+
+
+def test_missing_source_is_rejected(tmp_path) -> None:
+    with pytest.raises(ExternalWorkflowError, match="not found"):
+        inspect_external_workflow(
+            str(tmp_path / "missing"),
+            interactive=True,
+            cache_root=tmp_path / "cache",
+        )

--- a/experimental/python/perfxpert/tests/test_tools/test_opencode_launcher.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_opencode_launcher.py
@@ -19,6 +19,18 @@ def _disable_repo_local_patched_binary(monkeypatch):
     )
 
 
+@pytest.fixture(autouse=True)
+def _stub_tui_session_socket_binding(monkeypatch, tmp_path):
+    def fake_bind(env):
+        env["PERFXPERT_TUI_INTERACTIVE"] = "1"
+        env[TUI_SESSION_TOKEN_ENV] = "test-token"
+        env[TUI_SESSION_SOCKET_ENV] = str(tmp_path / "auth.sock")
+        return True
+
+    monkeypatch.setattr(opencode_launcher, "_bind_tui_session_env", fake_bind)
+    monkeypatch.setattr(opencode_launcher, "_cleanup_tui_session_env", lambda env: None)
+
+
 def test_version_flag_short_circuit(capsys):
     rc = opencode_launcher.main(["--version"])
     assert rc == 0
@@ -47,9 +59,7 @@ def test_perfxpert_code_help_hides_workflow(capsys, monkeypatch):
 
 
 def test_route_workflow_import_to_perfxpert_dispatch():
-    kind, argv = opencode_launcher.route_subcommand(
-        ["workflow", "import", "./tool", "--interactive"]
-    )
+    kind, argv = opencode_launcher.route_subcommand(["workflow", "import", "./tool", "--interactive"])
 
     assert kind == "perfxpert"
     assert argv == ["workflow", "import", "./tool", "--interactive"]
@@ -105,9 +115,7 @@ def test_resolve_user_binary_raises_when_override_missing(tmp_path: Path, monkey
         opencode_launcher.resolve_user_opencode_binary()
 
 
-def test_resolve_user_binary_raises_when_override_not_executable(
-    tmp_path: Path, monkeypatch
-):
+def test_resolve_user_binary_raises_when_override_not_executable(tmp_path: Path, monkeypatch):
     """The explicit upstream-opencode escape hatch validates execute bit."""
     fake_bin = tmp_path / "fake-opencode"
     fake_bin.write_text("#!/bin/sh\necho fake\n")
@@ -224,8 +232,10 @@ def test_default_tui_sets_interactive_marker(monkeypatch):
 
 def test_tui_subcommand_sets_interactive_marker(monkeypatch):
     captured_env = {}
+    captured_cmd = []
 
     def fake_run(cmd, **kwargs):
+        captured_cmd.extend(cmd)
         captured_env.update(kwargs.get("env") or {})
         return mock.MagicMock(returncode=0)
 
@@ -238,6 +248,346 @@ def test_tui_subcommand_sets_interactive_marker(monkeypatch):
     assert captured_env.get("PERFXPERT_TUI_INTERACTIVE") == "1"
     assert captured_env.get(TUI_SESSION_TOKEN_ENV)
     assert not Path(captured_env[TUI_SESSION_SOCKET_ENV]).exists()
+    assert captured_cmd[1:] == []
+
+
+def test_interactive_launch_fails_when_tui_authority_cannot_bind(monkeypatch, capsys):
+    run_called = False
+
+    def fake_run(cmd, **kwargs):
+        nonlocal run_called
+        run_called = True
+        return mock.MagicMock(returncode=0)
+
+    def fail_bind(env):
+        raise RuntimeError("Linux peer-credential sockets unavailable")
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: Path("/bin/true"))
+    monkeypatch.setattr(opencode_launcher, "_bind_tui_session_env", fail_bind)
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    rc = opencode_launcher.main(["tui"])
+
+    assert rc == 1
+    assert run_called is False
+    assert "cannot start TUI workflow import authority" in capsys.readouterr().err
+
+
+def test_option_value_tui_does_not_select_tui_subcommand(monkeypatch):
+    captured_env = {}
+    captured_cmd = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.extend(cmd)
+        captured_env.update(kwargs.get("env") or {})
+        return mock.MagicMock(returncode=0)
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: Path("/bin/true"))
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    opencode_launcher.main(["--model", "tui", "run", "optimize ./app"])
+
+    assert "PERFXPERT_TUI_INTERACTIVE" not in captured_env
+    assert TUI_SESSION_TOKEN_ENV not in captured_env
+    assert captured_cmd[1:] == ["--model", "tui", "run", "--agent", "perfxpert", "optimize ./app"]
+
+
+def test_value_flags_do_not_route_or_inject_from_their_values(monkeypatch):
+    captured_env = {}
+    captured_cmd = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.extend(cmd)
+        captured_env.update(kwargs.get("env") or {})
+        return mock.MagicMock(returncode=0)
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: Path("/bin/true"))
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    opencode_launcher.main(
+        [
+            "--prompt",
+            "doctor",
+            "-m",
+            "tui",
+            "--command",
+            "claude",
+            "--cors",
+            "http://localhost:3000",
+            "--mdns-domain",
+            "tui.local",
+            "--password",
+            "run",
+            "-p",
+            "tui",
+            "run",
+            "optimize ./app",
+        ]
+    )
+
+    assert "PERFXPERT_TUI_INTERACTIVE" not in captured_env
+    assert captured_cmd[1:] == [
+        "--prompt",
+        "doctor",
+        "-m",
+        "tui",
+        "--command",
+        "claude",
+        "--cors",
+        "http://localhost:3000",
+        "--mdns-domain",
+        "tui.local",
+        "--password",
+        "run",
+        "-p",
+        "tui",
+        "run",
+        "--agent",
+        "perfxpert",
+        "optimize ./app",
+    ]
+
+
+def test_format_flag_before_run_still_routes_and_injects_agent(monkeypatch):
+    captured_env = {}
+    captured_cmd = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.extend(cmd)
+        captured_env.update(kwargs.get("env") or {})
+        return mock.MagicMock(returncode=0)
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: Path("/bin/true"))
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    rc = opencode_launcher.main(["--format", "json", "run", "optimize ./app"])
+
+    assert rc == 0
+    assert "PERFXPERT_TUI_INTERACTIVE" not in captured_env
+    assert captured_cmd[1:] == ["--format", "json", "run", "--agent", "perfxpert", "optimize ./app"]
+
+
+def test_bare_help_passthrough_does_not_require_tui_authority(monkeypatch):
+    captured_env = {}
+    captured_cmd = []
+    bind_called = False
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.extend(cmd)
+        captured_env.update(kwargs.get("env") or {})
+        return mock.MagicMock(returncode=0)
+
+    def fail_bind(env):
+        nonlocal bind_called
+        bind_called = True
+        raise RuntimeError("Linux peer-credential sockets unavailable")
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: Path("/bin/true"))
+    monkeypatch.setattr(opencode_launcher, "_bind_tui_session_env", fail_bind)
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    rc = opencode_launcher.main(["--help"])
+
+    assert rc == 0
+    assert bind_called is False
+    assert captured_cmd[1:] == ["--help"]
+    assert "PERFXPERT_TUI_INTERACTIVE" not in captured_env
+
+
+def test_tui_help_passthrough_does_not_require_tui_authority(monkeypatch):
+    captured_env = {}
+    captured_cmd = []
+    bind_called = False
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.extend(cmd)
+        captured_env.update(kwargs.get("env") or {})
+        return mock.MagicMock(returncode=0)
+
+    def fail_bind(env):
+        nonlocal bind_called
+        bind_called = True
+        raise RuntimeError("Linux peer-credential sockets unavailable")
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: Path("/bin/true"))
+    monkeypatch.setattr(opencode_launcher, "_bind_tui_session_env", fail_bind)
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    rc = opencode_launcher.main(["tui", "--help"])
+
+    assert rc == 0
+    assert bind_called is False
+    assert captured_cmd[1:] == ["--help"]
+    assert "PERFXPERT_TUI_INTERACTIVE" not in captured_env
+
+
+def test_help_shaped_option_value_does_not_trigger_wrapper_help(monkeypatch, capsys):
+    captured_cmd = []
+    captured_env = {}
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.extend(cmd)
+        captured_env.update(kwargs.get("env") or {})
+        return mock.MagicMock(returncode=0)
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: Path("/bin/true"))
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    rc = opencode_launcher.main(["--model", "--help", "run", "optimize ./app"])
+
+    assert rc == 0
+    assert "AMD ROCm PerfXpert" not in capsys.readouterr().out
+    assert "PERFXPERT_TUI_INTERACTIVE" not in captured_env
+    assert captured_cmd[1:] == ["--model", "--help", "run", "--agent", "perfxpert", "optimize ./app"]
+
+
+def test_agent_shaped_option_value_does_not_suppress_run_agent_injection(monkeypatch):
+    captured_cmd = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.extend(cmd)
+        return mock.MagicMock(returncode=0)
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: Path("/bin/true"))
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    rc = opencode_launcher.main(["--model", "--agent", "run", "optimize ./app"])
+
+    assert rc == 0
+    assert captured_cmd[1:] == ["--model", "--agent", "run", "--agent", "perfxpert", "optimize ./app"]
+
+
+def test_run_help_is_forwarded_without_agent_injection(monkeypatch):
+    captured_cmd = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.extend(cmd)
+        return mock.MagicMock(returncode=0)
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: Path("/bin/true"))
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    rc = opencode_launcher.main(["run", "--help"])
+
+    assert rc == 0
+    assert captured_cmd[1:] == ["run", "--help"]
+
+
+@pytest.mark.parametrize("subcommand", ["completion", "upgrade"])
+def test_opencode_maintenance_subcommands_do_not_bind_tui_authority(subcommand, monkeypatch):
+    captured_cmd = []
+    bind_called = False
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.extend(cmd)
+        return mock.MagicMock(returncode=0)
+
+    def fail_bind(env):
+        nonlocal bind_called
+        bind_called = True
+        raise RuntimeError("Linux peer-credential sockets unavailable")
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: Path("/bin/true"))
+    monkeypatch.setattr(opencode_launcher, "_bind_tui_session_env", fail_bind)
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    rc = opencode_launcher.main([subcommand])
+
+    assert rc == 0
+    assert bind_called is False
+    assert captured_cmd[1:] == [subcommand]
+
+
+def test_upgrade_method_flag_before_subcommand_does_not_bind_tui_authority(monkeypatch):
+    captured_cmd = []
+    bind_called = False
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.extend(cmd)
+        return mock.MagicMock(returncode=0)
+
+    def fail_bind(env):
+        nonlocal bind_called
+        bind_called = True
+        raise RuntimeError("Linux peer-credential sockets unavailable")
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: Path("/bin/true"))
+    monkeypatch.setattr(opencode_launcher, "_bind_tui_session_env", fail_bind)
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    rc = opencode_launcher.main(["--method", "npm", "upgrade"])
+
+    assert rc == 0
+    assert bind_called is False
+    assert captured_cmd[1:] == ["--method", "npm", "upgrade"]
+
+
+def test_tui_subcommand_workload_arg_sets_workload_cwd(tmp_path: Path, monkeypatch):
+    captured_env = {}
+    captured_cmd = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.extend(cmd)
+        captured_env.update(kwargs.get("env") or {})
+        return mock.MagicMock(returncode=0)
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: Path("/bin/true"))
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    opencode_launcher.main(["tui", str(tmp_path)])
+
+    assert captured_env.get("PERFXPERT_TUI_INTERACTIVE") == "1"
+    assert captured_env.get("PERFXPERT_WORKLOAD_CWD") == str(tmp_path)
+    assert captured_cmd[1:] == [str(tmp_path)]
+
+
+def test_dir_option_sets_workload_cwd(tmp_path: Path, monkeypatch):
+    captured_env = {}
+    captured_cmd = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.extend(cmd)
+        captured_env.update(kwargs.get("env") or {})
+        return mock.MagicMock(returncode=0)
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: Path("/bin/true"))
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    opencode_launcher.main(["--dir", str(tmp_path), "tui"])
+
+    assert captured_env.get("PERFXPERT_TUI_INTERACTIVE") == "1"
+    assert captured_env.get("PERFXPERT_WORKLOAD_CWD") == str(tmp_path)
+    assert captured_cmd[1:] == [str(tmp_path)]
+
+
+def test_dir_shaped_option_value_does_not_set_workload_cwd(tmp_path: Path, monkeypatch):
+    captured_env = {}
+    cwd = Path.cwd()
+
+    def fake_run(cmd, **kwargs):
+        captured_env.update(kwargs.get("env") or {})
+        return mock.MagicMock(returncode=0)
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: Path("/bin/true"))
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    opencode_launcher.main(["--model", "--dir", "run", "optimize ./app"])
+
+    assert captured_env.get("PERFXPERT_WORKLOAD_CWD") == str(cwd)
 
 
 def test_opencode_default_cwd_override_sets_workload_cwd(tmp_path: Path, monkeypatch):
@@ -374,9 +724,7 @@ def test_resolve_user_binary_autodiscovers_home_opencode_bin(tmp_path: Path, mon
         ".local/bin/opencode",
     ],
 )
-def test_resolve_user_binary_autodiscovers_multiple_wellknown_paths(
-    tmp_path: Path, monkeypatch, subpath
-):
+def test_resolve_user_binary_autodiscovers_multiple_wellknown_paths(tmp_path: Path, monkeypatch, subpath):
     """Each well-known upstream location must be auto-discovered for the escape hatch."""
     fake_home = tmp_path
     fake_bin = fake_home / subpath
@@ -422,9 +770,7 @@ def test_resolve_default_binary_missing_suggests_wrapper(monkeypatch, tmp_path: 
     assert "perfxpert-code opencode" in msg
 
 
-def test_resolve_user_binary_missing_suggests_upstream_install(
-    monkeypatch, tmp_path: Path
-):
+def test_resolve_user_binary_missing_suggests_upstream_install(monkeypatch, tmp_path: Path):
     """The explicit upstream-opencode escape hatch gives upstream install help."""
     monkeypatch.delenv("PERFXPERT_OPENCODE_PATH", raising=False)
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))

--- a/experimental/python/perfxpert/tests/test_tools/test_opencode_launcher.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_opencode_launcher.py
@@ -1,6 +1,5 @@
 """Unit tests for perfxpert.cli.opencode_launcher."""
 
-import os
 from importlib.metadata import version
 from pathlib import Path
 from unittest import mock
@@ -30,6 +29,15 @@ def test_version_flag_short_circuit(capsys):
 def test_v_short_flag(capsys):
     rc = opencode_launcher.main(["-V"])
     assert rc == 0
+
+
+def test_route_workflow_import_to_perfxpert_dispatch():
+    kind, argv = opencode_launcher.route_subcommand(
+        ["workflow", "import", "./tool", "--interactive"]
+    )
+
+    assert kind == "perfxpert"
+    assert argv == ["workflow", "import", "./tool", "--interactive"]
 
 
 def test_resolve_config_dir_returns_bundled_path():
@@ -177,6 +185,77 @@ def test_recursion_guard_env_set(monkeypatch):
     monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
     opencode_launcher.main([])
     assert captured_env.get("PERFXPERT_IN_OPENCODE_SESSION") == "1"
+
+
+def test_default_tui_sets_interactive_marker(monkeypatch):
+    captured_env = {}
+    cwd = Path.cwd()
+
+    def fake_run(cmd, **kwargs):
+        captured_env.update(kwargs.get("env") or {})
+        return mock.MagicMock(returncode=0)
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: Path("/bin/true"))
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    opencode_launcher.main([])
+
+    assert captured_env.get("PERFXPERT_TUI_INTERACTIVE") == "1"
+    assert captured_env.get("PERFXPERT_WORKLOAD_CWD") == str(cwd)
+
+
+def test_tui_subcommand_sets_interactive_marker(monkeypatch):
+    captured_env = {}
+
+    def fake_run(cmd, **kwargs):
+        captured_env.update(kwargs.get("env") or {})
+        return mock.MagicMock(returncode=0)
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: Path("/bin/true"))
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    opencode_launcher.main(["tui"])
+
+    assert captured_env.get("PERFXPERT_TUI_INTERACTIVE") == "1"
+
+
+def test_noninteractive_run_does_not_set_interactive_marker(monkeypatch):
+    captured_env = {}
+
+    def fake_run(cmd, **kwargs):
+        captured_env.update(kwargs.get("env") or {})
+        return mock.MagicMock(returncode=0)
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: Path("/bin/true"))
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    opencode_launcher.main(["run", "optimize ./app"])
+
+    assert captured_env.get("PERFXPERT_IN_OPENCODE_SESSION") == "1"
+    assert "PERFXPERT_TUI_INTERACTIVE" not in captured_env
+
+
+def test_workflow_subcommand_dispatches_without_resolving_opencode(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return mock.MagicMock(returncode=0)
+
+    def fail_resolve():
+        raise AssertionError("workflow dispatch should not resolve opencode")
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", fail_resolve)
+
+    rc = opencode_launcher.main(["workflow", "import", "./adapter", "--interactive"])
+
+    assert rc == 0
+    assert calls
+    assert calls[0][1:4] == ["-m", "perfxpert", "workflow"]
 
 
 def test_amd_red_in_banner(monkeypatch):

--- a/experimental/python/perfxpert/tests/test_tools/test_opencode_launcher.py
+++ b/experimental/python/perfxpert/tests/test_tools/test_opencode_launcher.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import pytest
 
+from perfxpert.cli._tui_session import TUI_SESSION_SOCKET_ENV, TUI_SESSION_TOKEN_ENV
 from perfxpert.cli import opencode_launcher
 
 
@@ -29,6 +30,20 @@ def test_version_flag_short_circuit(capsys):
 def test_v_short_flag(capsys):
     rc = opencode_launcher.main(["-V"])
     assert rc == 0
+
+
+def test_perfxpert_code_help_hides_workflow(capsys, monkeypatch):
+    def fail_resolve():
+        raise FileNotFoundError("missing bundled opencode")
+
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", fail_resolve)
+
+    rc = opencode_launcher.main(["--help"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "perfxpert-owned subcommands" in out
+    assert "workflow" not in out
 
 
 def test_route_workflow_import_to_perfxpert_dispatch():
@@ -202,6 +217,8 @@ def test_default_tui_sets_interactive_marker(monkeypatch):
     opencode_launcher.main([])
 
     assert captured_env.get("PERFXPERT_TUI_INTERACTIVE") == "1"
+    assert captured_env.get(TUI_SESSION_TOKEN_ENV)
+    assert not Path(captured_env[TUI_SESSION_SOCKET_ENV]).exists()
     assert captured_env.get("PERFXPERT_WORKLOAD_CWD") == str(cwd)
 
 
@@ -219,6 +236,24 @@ def test_tui_subcommand_sets_interactive_marker(monkeypatch):
     opencode_launcher.main(["tui"])
 
     assert captured_env.get("PERFXPERT_TUI_INTERACTIVE") == "1"
+    assert captured_env.get(TUI_SESSION_TOKEN_ENV)
+    assert not Path(captured_env[TUI_SESSION_SOCKET_ENV]).exists()
+
+
+def test_opencode_default_cwd_override_sets_workload_cwd(tmp_path: Path, monkeypatch):
+    captured_env = {}
+
+    def fake_run(cmd, **kwargs):
+        captured_env.update(kwargs.get("env") or {})
+        return mock.MagicMock(returncode=0)
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: Path("/bin/true"))
+    monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+
+    opencode_launcher.main([str(tmp_path)])
+
+    assert captured_env.get("PERFXPERT_WORKLOAD_CWD") == str(tmp_path)
 
 
 def test_noninteractive_run_does_not_set_interactive_marker(monkeypatch):
@@ -231,11 +266,44 @@ def test_noninteractive_run_does_not_set_interactive_marker(monkeypatch):
     monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
     monkeypatch.setattr(opencode_launcher, "resolve_opencode_binary", lambda: Path("/bin/true"))
     monkeypatch.setenv("PERFXPERT_CODE_NO_BANNER", "1")
+    monkeypatch.setenv("PERFXPERT_TUI_INTERACTIVE", "1")
+    monkeypatch.setenv("PERFXPERT_TUI_SESSION_TOKEN", "stale")
+    monkeypatch.setenv("PERFXPERT_TUI_SESSION_SOCKET", "/tmp/stale")
+    monkeypatch.setenv("PERFXPERT_TUI_SESSION_TOKEN_FILE", "/tmp/old-stale")
 
     opencode_launcher.main(["run", "optimize ./app"])
 
     assert captured_env.get("PERFXPERT_IN_OPENCODE_SESSION") == "1"
     assert "PERFXPERT_TUI_INTERACTIVE" not in captured_env
+    assert TUI_SESSION_TOKEN_ENV not in captured_env
+    assert TUI_SESSION_SOCKET_ENV not in captured_env
+    assert "PERFXPERT_TUI_SESSION_TOKEN_FILE" not in captured_env
+
+
+def test_user_opencode_path_scrubs_stale_tui_env(tmp_path: Path, monkeypatch):
+    captured_env = {}
+    fake_bin = tmp_path / "opencode"
+    fake_bin.write_text("#!/bin/sh\nexit 0\n")
+    fake_bin.chmod(0o755)
+
+    def fake_run(cmd, **kwargs):
+        captured_env.update(kwargs.get("env") or {})
+        return mock.MagicMock(returncode=0)
+
+    monkeypatch.setenv("PERFXPERT_OPENCODE_PATH", str(fake_bin))
+    monkeypatch.setenv("PERFXPERT_TUI_INTERACTIVE", "1")
+    monkeypatch.setenv("PERFXPERT_TUI_SESSION_TOKEN", "stale")
+    monkeypatch.setenv("PERFXPERT_TUI_SESSION_SOCKET", "/tmp/stale")
+    monkeypatch.setenv("PERFXPERT_TUI_SESSION_TOKEN_FILE", "/tmp/old-stale")
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", fake_run)
+
+    rc = opencode_launcher.main(["opencode", "run", "hello"])
+
+    assert rc == 0
+    assert "PERFXPERT_TUI_INTERACTIVE" not in captured_env
+    assert TUI_SESSION_TOKEN_ENV not in captured_env
+    assert TUI_SESSION_SOCKET_ENV not in captured_env
+    assert "PERFXPERT_TUI_SESSION_TOKEN_FILE" not in captured_env
 
 
 def test_workflow_subcommand_dispatches_without_resolving_opencode(monkeypatch):


### PR DESCRIPTION
## Summary
- add a hidden `perfxpert workflow import` helper for advisory external workflow metadata inspection from the active bundled `perfxpert-code` TUI only
- inspect local paths or explicitly approved HTTPS sources without executing adapter code, installing packages, importing modules, or registering MCP servers
- keep adapter metadata import GPU-agnostic: it does not require a local GPU or ROCm runtime, and target-dependent tools remain scoped to the workload host for SSH/remote-machine workflows
- harden adapter discovery with bounded file reads, symlink/special-file rejection, redacted MCP args, isolated git clone configuration, and atomic manifest writes
- bind TUI-only import authority to a launcher-owned Unix socket and scrub inherited TUI authority from noninteractive, user-opencode, and third-party backend dispatch paths
- update docs and bundled TUI guidance so users ask inside `perfxpert-code` instead of copying a shell command

## Validation
- `env PYTHONPATH=experimental/python/perfxpert python3 -m pytest experimental/python/perfxpert/tests/test_integrations/test_external_workflow.py experimental/python/perfxpert/tests/test_cli/test_workflow_cmd.py experimental/python/perfxpert/tests/test_cli/test_main_help.py experimental/python/perfxpert/tests/test_tools/test_opencode_launcher.py experimental/python/perfxpert/tests/test_cli/test_backend_dispatch.py experimental/python/perfxpert/tests/test_integration/test_mcp_exposure.py experimental/python/perfxpert/tests/test_docs_tooling/test_ship_readiness.py -q` - 115 passed; covers socket-gated TUI authority and does not require a GPU
- `python3 -m flake8 --max-line-length=120 ...` on changed Python/test files
- `python3 -m compileall -q ...` on changed Python modules
- `git diff --check` and `git diff --cached --check`
- live smoke: forged shell TUI env rejected, hidden workflow omitted from top-level help, forbidden local-test source strings absent
- GitHub checks: `labeler`, `Setup`, and `TheRock CI Summary` passed; project matrix jobs were skipped
