### PR TITLE
[rocprofiler-sdk] Guard counter record memcpy when record list is empty

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/device_counting_service.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/device_counting_service.cpp
@@ -83,8 +83,10 @@ rocprofiler_sample_device_counting_service(rocprofiler_context_id_t      context
                 return ROCPROFILER_STATUS_ERROR_OUT_OF_RESOURCES;
             }
             *rec_count = recs.size();
-            std::memcpy(
-                output_records, recs.data(), sizeof(rocprofiler_counter_record_t) * recs.size());
+            if(!recs.empty())
+                std::memcpy(output_records,
+                            recs.data(),
+                            sizeof(rocprofiler_counter_record_t) * recs.size());
         }
         return status;
     }


### PR DESCRIPTION
## Motivation

Fix intermittent sanitizer failure https://github.com/ROCm/rocm-systems/actions/runs/25129338554/job/73662940087

## Technical Details

- Skip the memcpy when there are no counter records to copy.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
