### PR TITLE
[kfdtest] - skip dGPU-only memory stress tests on APUs

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.cpp
@@ -782,9 +782,11 @@ void KFDMemoryTest::SearchLargestBuffer(int allocNode, const HsaMemFlags &memFla
  */
 void KFDMemoryTest::LargestSysBufferTest(int gpuNode) {
 
+    /* Integrated flag is the authoritative APU indicator (hsakmt_is_dgpu()
+     * misreports on APUs like gfx1151 where CPU/GPU are separate nodes). */
     const HsaNodeProperties *pNodeProps = m_NodeInfo.GetNodeProperties(gpuNode);
-    if (pNodeProps && pNodeProps->Integrated) {
-        LOG() << "Skipping test on APU." << std::endl;
+    if ((pNodeProps && pNodeProps->Integrated) || !hsakmt_is_dgpu()) {
+        LOG() << "Skipping test: Running on APU fails and locks the system." << std::endl;
         return;
     }
 
@@ -824,9 +826,11 @@ TEST_F(KFDMemoryTest, LargestSysBufferTest) {
 
 void KFDMemoryTest::LargestVramBufferTest(int gpuNode) {
 
+    /* Integrated flag is the authoritative APU indicator (hsakmt_is_dgpu()
+     * misreports on APUs like gfx1151 where CPU/GPU are separate nodes). */
     const HsaNodeProperties *pNodeProps = m_NodeInfo.GetNodeProperties(gpuNode);
-    if (pNodeProps && pNodeProps->Integrated) {
-        LOG() << "Skipping test on APU." << std::endl;
+    if ((pNodeProps && pNodeProps->Integrated) || !hsakmt_is_dgpu()) {
+        LOG() << "Skipping test: Running on APU fails and locks the system." << std::endl;
         return;
     }
 
@@ -875,9 +879,11 @@ TEST_F(KFDMemoryTest, LargestVramBufferTest) {
  */
 void KFDMemoryTest::BigSysBufferStressTest(int gpuNode) {
 
+    /* Integrated flag is the authoritative APU indicator (hsakmt_is_dgpu()
+     * misreports on APUs like gfx1151 where CPU/GPU are separate nodes). */
     const HsaNodeProperties *pNodeProps = m_NodeInfo.GetNodeProperties(gpuNode);
-    if (pNodeProps && pNodeProps->Integrated) {
-        LOG() << "Skipping test on APU." << std::endl;
+    if ((pNodeProps && pNodeProps->Integrated) || !hsakmt_is_dgpu()) {
+        LOG() << "Skipping test: Running on APU fails and locks the system." << std::endl;
         return;
     }
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.cpp
@@ -782,7 +782,10 @@ void KFDMemoryTest::SearchLargestBuffer(int allocNode, const HsaMemFlags &memFla
  */
 void KFDMemoryTest::LargestSysBufferTest(int gpuNode) {
 
-    if (!hsakmt_is_dgpu()) {
+    /* Integrated flag is the authoritative APU indicator (hsakmt_is_dgpu()
+     * misreports on APUs like gfx1151 where CPU/GPU are separate nodes). */
+    const HsaNodeProperties *pNodeProps = m_NodeInfo.GetNodeProperties(gpuNode);
+    if ((pNodeProps && pNodeProps->Integrated) || !hsakmt_is_dgpu()) {
         LOG() << "Skipping test: Running on APU fails and locks the system." << std::endl;
         return;
     }
@@ -823,7 +826,10 @@ TEST_F(KFDMemoryTest, LargestSysBufferTest) {
 
 void KFDMemoryTest::LargestVramBufferTest(int gpuNode) {
 
-    if (!hsakmt_is_dgpu()) {
+    /* Integrated flag is the authoritative APU indicator (hsakmt_is_dgpu()
+     * misreports on APUs like gfx1151 where CPU/GPU are separate nodes). */
+    const HsaNodeProperties *pNodeProps = m_NodeInfo.GetNodeProperties(gpuNode);
+    if ((pNodeProps && pNodeProps->Integrated) || !hsakmt_is_dgpu()) {
         LOG() << "Skipping test: Running on APU fails and locks the system." << std::endl;
         return;
     }
@@ -873,7 +879,10 @@ TEST_F(KFDMemoryTest, LargestVramBufferTest) {
  */
 void KFDMemoryTest::BigSysBufferStressTest(int gpuNode) {
 
-    if (!hsakmt_is_dgpu()) {
+    /* Integrated flag is the authoritative APU indicator (hsakmt_is_dgpu()
+     * misreports on APUs like gfx1151 where CPU/GPU are separate nodes). */
+    const HsaNodeProperties *pNodeProps = m_NodeInfo.GetNodeProperties(gpuNode);
+    if ((pNodeProps && pNodeProps->Integrated) || !hsakmt_is_dgpu()) {
         LOG() << "Skipping test: Running on APU fails and locks the system." << std::endl;
         return;
     }


### PR DESCRIPTION
@skip-pr-bot

## Motivation

LargestSysBufferTest, LargestVramBufferTest, and BigSysBufferStressTest allocate buffers sized near total system RAM. On APUs the GPU shares system RAM, so these allocations OOM-kill kfdtest or hang the system.

## Technical Details

The existing `!hsakmt_is_dgpu()` guard misclassifies APUs as dGPUs on platforms where KFD exposes CPU and GPU as separate topology nodes, so the guard is skipped and the tests run on hardware they shouldn't.

Also check HsaNodeProperties::Integrated (set from the kernel AMD_IS_APU flag) as the authoritative APU indicator. The legacy hsakmt_is_dgpu() check is kept as a fallback so behavior on existing dGPU and older APU platforms is unchanged.

JIRA ID : ROCM-21587

## Test Plan

Built and ran kfdtest on an APU target before and after the fix.

## Test Result

- Before fix: kfdtest is OOM-killed mid-run.
- After fix:  175/175 PASS, no OOM, no regressions.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
