### PR TITLE
topo: fix crash on cross-NUMA NIC configurations

### DIFF
--- a/projects/rccl/src/graph/topo.cc
+++ b/projects/rccl/src/graph/topo.cc
@@ -1362,7 +1362,22 @@ ncclResult_t ncclTopoGetVNicParent(struct ncclXml* xml, ncclResult_t (*getProper
         NCCLCHECK(ncclTopoMakePciParent(xml, parent, physNetNodes[0]));
       }
     } else if (strcmp((*parent)->name, "cpu") == 0) {
-      // If the common parent is a PCI switch, we must reparent the new NIC under a made up pci device with a unique busid
+      // If the common parent is a CPU node, we must reparent the new NIC under a made up pci device with a unique busid
+      NCCLCHECK(ncclTopoMakePciParent(xml, parent, physNetNodes[0]));
+    } else if (strcmp((*parent)->name, "system") == 0) {
+      // Cross-NUMA merge: common parent is the system root, which ncclTopoGetSystemFromXml
+      // does not traverse for NICs (only iterates <cpu> children). Reparent under the first
+      // physical NIC's CPU so the vNIC appears inside a proper <cpu> subtree.
+      *parent = physNetNodes[0]->parent; // <nic> node
+      while (*parent && strcmp((*parent)->name, "cpu") != 0) *parent = (*parent)->parent;
+      if (*parent == NULL) {
+        WARN("TOPO/NET : Cannot find CPU parent for cross-NUMA vNIC, attaching to first CPU");
+        NCCLCHECK(xmlFindTag(xml, "cpu", parent));
+        if (*parent == NULL) {
+          WARN("TOPO/NET : No CPU node found in topology, cannot place cross-NUMA vNIC");
+          return ncclInternalError;
+        }
+      }
       NCCLCHECK(ncclTopoMakePciParent(xml, parent, physNetNodes[0]));
     }
   }

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -2448,7 +2448,13 @@ exit:
   free(parentRanks);
   return res;
 fail:
-  // archName was allocated but won't be assigned to comm on failure, so free it
+  // archName is assigned to comm->archName before initTransportsRank is called.
+  // If failure occurs after that assignment, commFree() will free comm->archName,
+  // so freeing archName here as well would be a double free. Null it out so that
+  // commFree handles cleanup exclusively.
+  if (archName == comm->archName) {
+    archName = NULL;
+  }
   free(archName);
   comm->initState = res;
   goto exit;


### PR DESCRIPTION
## Motivation

When NCCL_NET_MERGE_LEVEL=SYS and a host has NICs on different NUMA
nodes (e.g. mlx5_0 numa=0, mlx5_1 numa=1), ncclCommInitRank crashes
with "free(): double free detected in tcache 2".

Add a <system> branch that walks up from the first physical NIC's XML node to its <cpu> ancestor and calls ncclTopoMakePciParent there, consistent with the existing handling for <cpu> common parents.

Null archName before free() if it already equals comm->archName, so commFree() handles cleanup exclusively.

## Technical Details

  Two bugs triggered in sequence:

  1. ncclTopoGetVNicParent (topo.cc): for cross-NUMA NICs, the lowest common ancestor in the XML tree is the <system> root node. The function handled <pci> and <cpu> common parents but had no branch for <system>, leaving the vNIC attached directly under <system>:

       <system>
         <nic><net name="mlx5_0+mlx5_1"/></nic>   ← wrong placement
         <cpu numa=0>...</cpu>
         <cpu numa=1>...</cpu>

     ncclTopoGetSystemFromXml only iterates direct <cpu> children of <system>, so the <nic> at the top level was silently ignored. Result: system->nodes[NET].count = 0. ncclTopoTrimSystem then called ncclTopoGetLocalNet, found gpu->paths[NET] == NULL, and returned ncclInternalError.

Fix: add a <system> branch that walks up from the first physical NIC's XML node to its <cpu> ancestor and calls ncclTopoMakePciParent there, consistent with the existing handling for <cpu> common parents.

  2. ncclCommInitRankFunc fail path (init.cc): archName is assigned to comm->archName before initTransportsRank (the failure point). On error, the fail: label freed archName directly, then commFree() freed comm->archName — both pointing to the same allocation.

Fix: null archName before free() if it already equals comm->archName, so commFree() handles cleanup exclusively.

## JIRA ID

AICOMNET-213

## Test Plan

AINIC cluster:
`mpirun -np 2 --host uswslocpm2m-106-667,uswslocpm2m-106-2313 --mca oob_tcp_if_include ens9np0 --mca btl_tcp_if_include ens9np0 -x NCCL_SOCKET_IFNAME=ens9np0 -x NCCL_IB_HCA=mlx5_0,mlx5_1 -x NCCL_NET_MERGE_LEVEL=SYS -x NCCL_DEBUG=WARN /home/ilkosare/development/rocm-systems/projects/rccl/build_debug_cov_on_tests_on/test/rccl-UnitTestsMPI --gtest_filter=NetTransportMPITest.NetGraphRegisterBufferTest`

Dell (Thor2) cluster:
`  mpirun -np 2 \
    --host dell300x-ccs-aus-k14-23,dell300x-ccs-aus-k13-15 \
    --mca oob_tcp_if_include eno8303 \
    --mca btl_tcp_if_include eno8303 \
    -x NCCL_SOCKET_IFNAME=eno8303 \
    -x NCCL_IB_HCA=rocep28s0,rocep158s0 \
    -x NCCL_NET_MERGE_LEVEL=SYS \
    -x NCCL_DEBUG=WARN \
    -x LD_PRELOAD=$BUILD/librccl.so \
    $BUILD/test/rccl-UnitTestsMPI --gtest_filter=NetTransportMPITest.NetGraphRegisterBufferTest`

## Test Result

Double free fail without fix in init.cc. ncclInternalError fail without fix in topo.cc. With bost fixes passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
