### PR TITLE
ROCM-21854. - Add getMemoryObjectBatch

### DIFF
--- a/projects/clr/hipamd/src/hip_hmm.cpp
+++ b/projects/clr/hipamd/src/hip_hmm.cpp
@@ -429,18 +429,25 @@ hipError_t ihipMemPrefetchBatchAsync(void** dev_ptrs, size_t* sizes, size_t coun
     std::vector<size_t> sizes_vec(count);
     std::vector<amd::Device*> devices_vec(count);
 
+    // Validate input pointers
+    for (size_t op_idx = 0; op_idx < count; op_idx++) {
+      if (sizes[op_idx] == 0 || dev_ptrs[op_idx] == nullptr) {
+        return hipErrorInvalidValue;
+      }
+    }
+
+    // Batched memory object lookup with single lock acquisition
+    std::vector<size_t> offsets;
+    std::vector<amd::Memory*> mem_objs = getMemoryObjectBatch(dev_ptrs, count, offsets);
+
     // Validate and prepare each operation
     size_t current_loc = 0;
     for (size_t op_idx = 0; op_idx < count; op_idx++) {
       void* dev_ptr = dev_ptrs[op_idx];
       size_t size = sizes[op_idx];
+      amd::Memory* mem_obj = mem_objs[op_idx];
+      size_t offset = offsets[op_idx];
 
-      if (size == 0 || dev_ptr == nullptr) {
-        return hipErrorInvalidValue;
-      }
-
-      size_t offset = 0;
-      amd::Memory* mem_obj = getMemoryObject(dev_ptr, offset);
       if ((mem_obj == nullptr) || (size > (mem_obj->getSize() - offset))) {
         return hipErrorInvalidValue;
       }

--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -19,6 +19,7 @@
 #include <mutex>
 #include <iterator>
 #include <algorithm>
+#include <vector>
 #ifdef _WIN32
 #include <process.h>
 #else
@@ -616,6 +617,16 @@ namespace hip {
   extern hipError_t ihipHostMalloc(void** ptr, size_t sizeBytes, unsigned int flags);
   extern hipError_t ihipMemGetInfo(size_t* free, size_t* total);
   extern amd::Memory* getMemoryObject(const void* ptr, size_t& offset, size_t size = 0);
+  extern std::vector<amd::Memory*> getMemoryObjectBatch(void* const* ptrs, size_t count,
+                                                         std::vector<size_t>& offsets);
+  extern void getMemoryObjectBatchPairs(void* const* srcs, void* const* dsts, size_t count,
+                                         std::vector<amd::Memory*>& src_memories,
+                                         std::vector<amd::Memory*>& dst_memories,
+                                         std::vector<size_t>& src_offsets,
+                                         std::vector<size_t>& dst_offsets);
+  extern void getMemoryObjectPairs(const void* src, const void* dst,
+                                    amd::Memory*& src_memory, amd::Memory*& dst_memory,
+                                    size_t& src_offset, size_t& dst_offset);
   extern amd::Memory* getMemoryObjectWithOffset(const void* ptr, const size_t size = 0);
   extern void getStreamPerThread(hipStream_t& stream);
   extern hipStream_t getPerThreadDefaultStream();

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -20,31 +20,103 @@ namespace hip {
 amd::Monitor hipArraySetLock{};
 std::unordered_set<hipArray*> hipArraySet;
 
+namespace {
+  // Helper function to apply arena memory fallback if memory object not found
+  inline void applyArenaFallback(const void* ptr, amd::Memory*& memory, size_t& offset, size_t size) {
+    if (memory == nullptr) {
+      hip::Device* device = hip::getCurrentDevice();
+      if (device != nullptr) {
+        memory = (device->asContext()->svmDevices()[0])->GetArenaMemObj(ptr, offset, size);
+      }
+    }
+  }
+
+  // Helper function to apply Windows-specific offset adjustment
+  inline void applyWindowsOffsetAdjustment(const void* ptr, amd::Memory*& memory, size_t& offset) {
+    if (!IS_WINDOWS || memory == nullptr) return;
+    if (!(memory->getMemFlags() & CL_MEM_USE_HOST_PTR)) return;
+
+    hip::Device* device = hip::getCurrentDevice();
+    amd::Device* currentDev = (device != nullptr) ? device->devices()[0] : nullptr;
+    if (currentDev == nullptr) return;
+
+    device::Memory* currentDevMem = memory->getDeviceMemory(*currentDev, false);
+    if (currentDevMem != nullptr) {
+      size_t currentDevOffset = reinterpret_cast<uint64_t>(ptr) - currentDevMem->virtualAddress();
+      if (currentDevOffset < memory->getSize()) {
+        offset = currentDevOffset;
+      }
+    }
+  }
+}
+
 // ================================================================================================
 amd::Memory* getMemoryObject(const void* ptr, size_t& offset, size_t size) {
   hip::Device* device = hip::getCurrentDevice();
   amd::Device* currentDev = (device != nullptr) ? device->devices()[0] : nullptr;
   auto memObj = amd::MemObjMap::FindMemObj(ptr, &offset, currentDev);
 
-  if (memObj == nullptr && device != nullptr) {
-    // If memObj not found, use arena_mem_obj. arena_mem_obj is null, if HMM is disabled.
-    memObj = (device->asContext()->svmDevices()[0])->GetArenaMemObj(ptr, offset, size);
+  applyArenaFallback(ptr, memObj, offset, size);
+  applyWindowsOffsetAdjustment(ptr, memObj, offset);
+
+  return memObj;
+}
+
+std::vector<amd::Memory*> getMemoryObjectBatch(void* const* ptrs, size_t count,
+                                                std::vector<size_t>& offsets) {
+  hip::Device* device = hip::getCurrentDevice();
+  amd::Device* currentDev = (device != nullptr) ? device->devices()[0] : nullptr;
+
+  std::vector<amd::Memory*> memories;
+  amd::MemObjMap::FindMemObjBatch(reinterpret_cast<const void* const*>(ptrs), count, memories,
+                                   offsets, currentDev);
+
+  // Process each result for arena memory and Windows-specific offset adjustments
+  for (size_t i = 0; i < count; ++i) {
+    applyArenaFallback(ptrs[i], memories[i], offsets[i], 0);
+    applyWindowsOffsetAdjustment(ptrs[i], memories[i], offsets[i]);
   }
 
-  // On Windows, when using hipHostRegister, the map may contain a single memory object for
-  // multiple devices. This is because device addresses can overlap.
-  // The offset needs to be calculated relative to the memory of the current device.
-  if (IS_WINDOWS && (memObj != nullptr) && (memObj->getMemFlags() & CL_MEM_USE_HOST_PTR) &&
-      currentDev != nullptr) {
-    device::Memory* currentDevMem = memObj->getDeviceMemory(*currentDev, false);
-    if (currentDevMem != nullptr) {
-      size_t currentDevOffset = reinterpret_cast<uint64_t>(ptr) - currentDevMem->virtualAddress();
-      if (currentDevOffset < memObj->getSize()) {
-        offset = currentDevOffset;
-      }
-    }
+  return memories;
+}
+
+void getMemoryObjectBatchPairs(void* const* srcs, void* const* dsts, size_t count,
+                                std::vector<amd::Memory*>& src_memories,
+                                std::vector<amd::Memory*>& dst_memories,
+                                std::vector<size_t>& src_offsets,
+                                std::vector<size_t>& dst_offsets) {
+  hip::Device* device = hip::getCurrentDevice();
+  amd::Device* currentDev = (device != nullptr) ? device->devices()[0] : nullptr;
+
+  amd::MemObjMap::FindMemObjBatchPairs(reinterpret_cast<const void* const*>(srcs),
+                                        reinterpret_cast<const void* const*>(dsts), count,
+                                        src_memories, dst_memories, src_offsets, dst_offsets,
+                                        currentDev);
+
+  // Process each result for arena memory and Windows-specific offset adjustments
+  for (size_t i = 0; i < count; ++i) {
+    applyArenaFallback(srcs[i], src_memories[i], src_offsets[i], 0);
+    applyWindowsOffsetAdjustment(srcs[i], src_memories[i], src_offsets[i]);
+
+    applyArenaFallback(dsts[i], dst_memories[i], dst_offsets[i], 0);
+    applyWindowsOffsetAdjustment(dsts[i], dst_memories[i], dst_offsets[i]);
   }
-  return memObj;
+}
+
+void getMemoryObjectPairs(const void* src, const void* dst,
+                          amd::Memory*& src_memory, amd::Memory*& dst_memory,
+                          size_t& src_offset, size_t& dst_offset) {
+  hip::Device* device = hip::getCurrentDevice();
+  amd::Device* currentDev = (device != nullptr) ? device->devices()[0] : nullptr;
+
+  amd::MemObjMap::FindMemObjPairs(src, dst, src_memory, dst_memory, src_offset, dst_offset,
+                                   currentDev);
+
+  applyArenaFallback(src, src_memory, src_offset, 0);
+  applyWindowsOffsetAdjustment(src, src_memory, src_offset);
+
+  applyArenaFallback(dst, dst_memory, dst_offset, 0);
+  applyWindowsOffsetAdjustment(dst, dst_memory, dst_offset);
 }
 
 hipMemoryType getMemoryType(const amd::Memory* memory) {
@@ -420,9 +492,10 @@ hipError_t ihipHostMalloc(void** ptr, size_t sizeBytes, unsigned int flags) {
 // ================================================================================================
 bool IsHtoHMemcpyValid(void* dst, const void* src, hipMemcpyKind kind) {
   size_t sOffset = 0;
-  amd::Memory* srcMemory = getMemoryObject(src, sOffset);
   size_t dOffset = 0;
-  amd::Memory* dstMemory = getMemoryObject(dst, dOffset);
+  amd::Memory* srcMemory = nullptr;
+  amd::Memory* dstMemory = nullptr;
+  getMemoryObjectPairs(src, dst, srcMemory, dstMemory, sOffset, dOffset);
   if (src && dst && srcMemory == nullptr && dstMemory == nullptr) {
     if (!g_devices[0]->devices()[0]->info().hmmCpuMemoryAccessible_ &&
         kind != hipMemcpyHostToHost && kind != hipMemcpyDefault) {
@@ -623,9 +696,10 @@ hipError_t ihipMemcpyCommand(amd::Command*& command, amd::Memory* dstMemory, amd
 // ================================================================================================
 bool IsHtoHMemcpy(void* dst, const void* src) {
   size_t sOffset = 0;
-  amd::Memory* srcMemory = getMemoryObject(src, sOffset);
   size_t dOffset = 0;
-  amd::Memory* dstMemory = getMemoryObject(dst, dOffset);
+  amd::Memory* srcMemory = nullptr;
+  amd::Memory* dstMemory = nullptr;
+  getMemoryObjectPairs(src, dst, srcMemory, dstMemory, sOffset, dOffset);
   if (srcMemory == nullptr && dstMemory == nullptr) {
     return true;
   }
@@ -656,9 +730,10 @@ hipError_t ihipMemcpy(void* dst, const void* src, size_t sizeBytes, hipMemcpyKin
   }
 
   size_t sOffset = 0;
-  amd::Memory* srcDeviceMemory = getMemoryObject(src, sOffset);
   size_t dOffset = 0;
-  amd::Memory* dstDeviceMemory = getMemoryObject(dst, dOffset);
+  amd::Memory* srcDeviceMemory = nullptr;
+  amd::Memory* dstDeviceMemory = nullptr;
+  getMemoryObjectPairs(src, dst, srcDeviceMemory, dstDeviceMemory, sOffset, dOffset);
   
   // Handle kind vs memobject miss matches
   if (kind == hipMemcpyDeviceToHost && srcDeviceMemory == nullptr) {
@@ -1740,9 +1815,10 @@ hipError_t ihipMemcpyDtoDCommand(amd::Command*& command, void* dstDevice, void* 
                                  amd::Coord3D copyRegion, amd::BufferRect srcRect,
                                  amd::BufferRect dstRect, hip::Stream* stream) {
   size_t srcOffset = 0;
-  amd::Memory* srcMemory = getMemoryObject(srcDevice, srcOffset);
   size_t dstOffset = 0;
-  amd::Memory* dstMemory = getMemoryObject(dstDevice, dstOffset);
+  amd::Memory* srcMemory = nullptr;
+  amd::Memory* dstMemory = nullptr;
+  getMemoryObjectPairs(srcDevice, dstDevice, srcMemory, dstMemory, srcOffset, dstOffset);
 
   amd::Command::EventWaitList waitList;
   amd::CopyMemoryCommand* copyCommand;
@@ -1816,9 +1892,10 @@ hipError_t ihipMemcpyDtoHCommand(amd::Command*& command, void* dstHost, amd::Coo
                                  amd::BufferRect srcRect, amd::BufferRect dstRect,
                                  hip::Stream* stream, bool isAsync = false) {
   size_t sOffset = 0;
-  amd::Memory* srcMemory = getMemoryObject(srcDevice, sOffset);
   size_t dOffset = 0;
-  amd::Memory* dstMemory = getMemoryObject(dstHost, dOffset);
+  amd::Memory* srcMemory = nullptr;
+  amd::Memory* dstMemory = nullptr;
+  getMemoryObjectPairs(srcDevice, dstHost, srcMemory, dstMemory, sOffset, dOffset);
 
   amd::Coord3D srcStart(srcRect.start_, 0, 0);
   amd::CopyMetadata copyMetadata(isAsync, amd::CopyMetadata::CopyEnginePreference::NONE);
@@ -1863,10 +1940,11 @@ hipError_t ihipMemcpyHtoDCommand(amd::Command*& command, void* dstDevice, amd::C
                                  amd::Coord3D copyRegion, amd::BufferRect srcRect,
                                  amd::BufferRect dstRect, hip::Stream* stream,
                                  bool isAsync = false) {
-  size_t dOffset = 0;
-  amd::Memory* dstMemory = getMemoryObject(dstDevice, dOffset);
   size_t sOffset = 0;
-  amd::Memory* srcMemory = getMemoryObject(srcHost, sOffset);
+  size_t dOffset = 0;
+  amd::Memory* srcMemory = nullptr;
+  amd::Memory* dstMemory = nullptr;
+  getMemoryObjectPairs(srcHost, dstDevice, srcMemory, dstMemory, sOffset, dOffset);
 
   amd::Coord3D dstStart(dstRect.start_, 0, 0);
   amd::CopyMetadata copyMetadata(isAsync, amd::CopyMetadata::CopyEnginePreference::NONE);
@@ -2852,8 +2930,12 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
     if (dsts[i] == nullptr || srcs[i] == nullptr) {
       return hipErrorInvalidValue;
     }
-    srcMemories[i] = getMemoryObject(srcs[i], srcOffsets[i]);
-    dstMemories[i] = getMemoryObject(dsts[i], dstOffsets[i]);
+  }
+
+  // Batched memory object lookup for src/dst pairs with single lock acquisition
+  getMemoryObjectBatchPairs(srcs, dsts, count, srcMemories, dstMemories, srcOffsets, dstOffsets);
+
+  for (size_t i = 0; i < count; ++i) {
 
     // Host-to-host (both pointers have no associated memory object) is always
     // valid for hipMemcpyDefault.

--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -360,31 +360,49 @@ void MemObjMap::RemoveMemObj(const void* k) {
   guarantee(rval == 1, "Memobj map does not have ptr: 0x%x", reinterpret_cast<uintptr_t>(k));
 }
 
-amd::Memory* MemObjMap::FindMemObj(const void* k, size_t* offset, Device* dev) {
-  std::shared_lock lock(AllocatedLock_);
-  uintptr_t key = reinterpret_cast<uintptr_t>(k);
+MemObjMap::LookupResult MemObjMap::findMemObjNoLock(const void* ptr, Device* dev) {
+  uintptr_t key = reinterpret_cast<uintptr_t>(ptr);
 
-  // First search the global map
-  auto it = FindMemObjIter(key);
-  if (it != MemObjMap_.end()) {
-    if (offset != nullptr) {
-      *offset = key - it->first;
+  // First search the global map using upper_bound
+  auto it = MemObjMap_.upper_bound(key);
+  if (it != MemObjMap_.begin()) {
+    --it;
+    amd::Memory* mem = it->second;
+    size_t mem_size = (mem->getMemFlags() & ROCCLR_MEM_PHYMEM)
+                          ? sizeof(mem->getUserData().hsa_handle)
+                          : mem->getSize();
+    if (key >= it->first && key < (it->first + mem_size)) {
+      return {it->second, key - it->first};
     }
-    return it->second;
   }
 
   // Search per-device va maps on Windows (due to overlapping ranges)
   if (IS_WINDOWS && dev != nullptr) {
-    return dev->FindDevMemObj(k, offset);
+    size_t offset = 0;
+    amd::Memory* mem = dev->FindDevMemObj(ptr, &offset);
+    return {mem, offset};
   }
 
-  return nullptr;
+  return {nullptr, 0};
 }
 
-std::map<uintptr_t, amd::Memory*>::iterator MemObjMap::FindMemObjIter(uintptr_t key) {
+amd::Memory* MemObjMap::FindMemObj(const void* k, size_t* offset, Device* dev) {
+  std::shared_lock lock(AllocatedLock_);
+  auto result = findMemObjNoLock(k, dev);
+  if (offset != nullptr) {
+    *offset = result.offset;
+  }
+  return result.memory;
+}
+
+amd::Memory* MemObjMap::FindAndRemoveMemObj(const void* k) {
+  std::unique_lock lock(AllocatedLock_);
+  uintptr_t key = reinterpret_cast<uintptr_t>(k);
+
+  // Find the memory object in the map using upper_bound
   auto it = MemObjMap_.upper_bound(key);
   if (it == MemObjMap_.begin()) {
-    return MemObjMap_.end();
+    return nullptr;
   }
   --it;
   amd::Memory* mem = it->second;
@@ -392,21 +410,77 @@ std::map<uintptr_t, amd::Memory*>::iterator MemObjMap::FindMemObjIter(uintptr_t 
                         ? sizeof(mem->getUserData().hsa_handle)
                         : mem->getSize();
   if (key < it->first || key >= (it->first + mem_size)) {
-    return MemObjMap_.end();
-  }
-  return it;
-}
-
-amd::Memory* MemObjMap::FindAndRemoveMemObj(const void* k) {
-  std::unique_lock lock(AllocatedLock_);
-  uintptr_t key = reinterpret_cast<uintptr_t>(k);
-  auto it = FindMemObjIter(key);
-  if (it == MemObjMap_.end()) {
     return nullptr;
   }
-  amd::Memory* mem = it->second;
+
+  // Found - remove and return
   MemObjMap_.erase(it);
   return mem;
+}
+
+void MemObjMap::FindMemObjBatch(const void* const* ptrs, size_t count,
+                                 std::vector<amd::Memory*>& memories,
+                                 std::vector<size_t>& offsets, Device* dev) {
+  if (memories.size() != count) {
+    memories.resize(count);
+  }
+  if (offsets.size() != count) {
+    offsets.resize(count);
+  }
+
+  std::shared_lock lock(AllocatedLock_);
+
+  for (size_t i = 0; i < count; ++i) {
+    auto result = findMemObjNoLock(ptrs[i], dev);
+    memories[i] = result.memory;
+    offsets[i] = result.offset;
+  }
+}
+
+void MemObjMap::FindMemObjBatchPairs(const void* const* srcs, const void* const* dsts,
+                                      size_t count,
+                                      std::vector<amd::Memory*>& src_memories,
+                                      std::vector<amd::Memory*>& dst_memories,
+                                      std::vector<size_t>& src_offsets,
+                                      std::vector<size_t>& dst_offsets, Device* dev) {
+  if (src_memories.size() != count) {
+    src_memories.resize(count);
+  }
+  if (dst_memories.size() != count) {
+    dst_memories.resize(count);
+  }
+  if (src_offsets.size() != count) {
+    src_offsets.resize(count);
+  }
+  if (dst_offsets.size() != count) {
+    dst_offsets.resize(count);
+  }
+
+  std::shared_lock lock(AllocatedLock_);
+
+  for (size_t i = 0; i < count; ++i) {
+    auto src_result = findMemObjNoLock(srcs[i], dev);
+    src_memories[i] = src_result.memory;
+    src_offsets[i] = src_result.offset;
+
+    auto dst_result = findMemObjNoLock(dsts[i], dev);
+    dst_memories[i] = dst_result.memory;
+    dst_offsets[i] = dst_result.offset;
+  }
+}
+
+void MemObjMap::FindMemObjPairs(const void* src, const void* dst,
+                                 amd::Memory*& src_memory, amd::Memory*& dst_memory,
+                                 size_t& src_offset, size_t& dst_offset, Device* dev) {
+  std::shared_lock lock(AllocatedLock_);
+
+  auto src_result = findMemObjNoLock(src, dev);
+  src_memory = src_result.memory;
+  src_offset = src_result.offset;
+
+  auto dst_result = findMemObjNoLock(dst, dev);
+  dst_memory = dst_result.memory;
+  dst_offset = dst_result.offset;
 }
 
 void MemObjMap::UpdateAccess(amd::Device* peerDev) {

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1454,6 +1454,23 @@ class MemObjMap : public AllStatic {
 
   //!< Find the mem object based on the input pointer, outputs the offset
   static amd::Memory* FindMemObj(const void* k, size_t* offset = nullptr, Device* dev = nullptr);
+  //!< Batched version: find multiple mem objects in one lock acquisition
+  static void FindMemObjBatch(const void* const* ptrs, size_t count,
+                              std::vector<amd::Memory*>& memories,
+                              std::vector<size_t>& offsets, Device* dev = nullptr);
+  //!< Batched pairs version: find src/dst pairs in one lock acquisition
+  static void FindMemObjBatchPairs(const void* const* srcs, const void* const* dsts,
+                                   size_t count,
+                                   std::vector<amd::Memory*>& src_memories,
+                                   std::vector<amd::Memory*>& dst_memories,
+                                   std::vector<size_t>& src_offsets,
+                                   std::vector<size_t>& dst_offsets,
+                                   Device* dev = nullptr);
+  //!< Single pair version: find one src/dst pair in one lock acquisition
+  static void FindMemObjPairs(const void* src, const void* dst,
+                              amd::Memory*& src_memory, amd::Memory*& dst_memory,
+                              size_t& src_offset, size_t& dst_offset,
+                              Device* dev = nullptr);
   static void UpdateAccess(amd::Device* peerDev);
   //!< Purge all user allocated memories on the given device
   static void Purge(amd::Device* dev);
@@ -1479,9 +1496,14 @@ class MemObjMap : public AllStatic {
   static std::shared_mutex AllocatedLock_;
 
  private:
-  //!< Lookup helper shared by FindMemObj and FindAndRemoveMemObj. Caller must hold AllocatedLock_.
-  //!< Returns an iterator to the matching entry, or MemObjMap_.end() if not found.
-  static std::map<uintptr_t, amd::Memory*>::iterator FindMemObjIter(uintptr_t key);
+  // Helper struct for memory object lookup results
+  struct LookupResult {
+    amd::Memory* memory;
+    size_t offset;
+  };
+
+  //!< Core lookup helper used by all FindMemObj* functions. Caller must hold AllocatedLock_.
+  static LookupResult findMemObjNoLock(const void* ptr, Device* dev);
 
   //!< the mem object<->hostptr information container
   static std::map<uintptr_t, amd::Memory*> MemObjMap_;


### PR DESCRIPTION
## Motivation

Reduce the amount of lock/unlocking we perform when retrieving memory objects.

## Technical Details

Add the FindMemObjBatchPairs and FindMemObjBatch functions which allow us to retrieve multiple memory objects in a single pass without repeated locking and unlocking the shared mutex. This drops latency and reduces cache-invalidation in multithreaded environments

## JIRA ID

ROCM-21854

## Test Plan

Regular tests satisfactory

## Test Result

Profiling shows drop in lock/unlock and reduced submission costs

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
