### PR TITLE
[rocprofiler-systems] make nic_traits driver_t overridable via template param

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/nic_traits.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/nic_traits.hpp
@@ -34,12 +34,12 @@ using ::rocprofsys::pmc::nic_device_filter;
  *
  * @tparam Driver The AMD SMI driver type (real or mock for testing)
  */
-template <typename DriverProvider>
+template <typename DriverProvider, typename Driver = pmc::collectors::nic::nic_driver>
 struct nic_traits
 {
     using metrics_t         = pmc::collectors::nic::metrics;
     using enabled_metrics_t = pmc::collectors::nic::enabled_metrics;
-    using driver_t          = pmc::collectors::nic::nic_driver;
+    using driver_t          = Driver;
     using device_t          = device<driver_t>;
     using device_ptr_t      = std::shared_ptr<device_t>;
     using container_t       = std::vector<device_ptr_t>;


### PR DESCRIPTION
Mirrors the gpu_traits fix from #5334 (review by @mradosav-amd) onto the NIC collector.

The second template parameter `Driver` defaults to `pmc::collectors::nic::nic_driver`, so the existing single-arg call site `nic_traits<DeviceProvider>` in `collectors/nic/collector.hpp` keeps resolving `driver_t` to `nic_driver` (no behavioural change in production). Tests / future providers can override via `nic_traits<Provider, mock_nic_driver>`.

Chose this default-template-param approach over `using driver_t = typename DriverProvider::nic_driver_t` because the latter would force `device_providers/amd_smi/provider.hpp` to include `library/pmc/collectors/nic/nic_driver.hpp`, re-coupling the provider layer to the collector layer (the inverse of the dependency direction we want).

## Validation

Local debug build, `rocprof-sys-unit-tests` 622/622 pass.

## Related

- Sibling change for GPU: #5334 (commit 6a67ef678d)