### PR TITLE
[RCCL] Bootstrap Large-scale: multiop bidirectional allgather

### DIFF
--- a/projects/rccl/src/bootstrap.cc
+++ b/projects/rccl/src/bootstrap.cc
@@ -325,8 +325,13 @@ static ncclResult_t socketSendRecv(struct ncclSocket* sendSock, void* sendData, 
 static ncclResult_t socketDoubleSendRecv(struct ncclSocketOp ops[4]) {
   // ops synchronously exchange size then asynchronously exchange data in send->recv->send->recv order
   int senderRecvSize1, senderRecvSize2;
-  NCCLCHECK(ncclSocketSendRecv(ops[0].sock, &ops[0].size, sizeof(int), ops[1].sock, &senderRecvSize1, sizeof(int)));
-  NCCLCHECK(ncclSocketSendRecv(ops[2].sock, &ops[2].size, sizeof(int), ops[3].sock, &senderRecvSize2, sizeof(int)));
+  struct ncclSocketOp sizeOps[4] = {
+    {NCCL_SOCKET_SEND, ops[0].sock, &ops[0].size, sizeof(int), 0},
+    {NCCL_SOCKET_RECV, ops[1].sock, &senderRecvSize1, sizeof(int), 0},
+    {NCCL_SOCKET_SEND, ops[2].sock, &ops[2].size, sizeof(int), 0},
+    {NCCL_SOCKET_RECV, ops[3].sock, &senderRecvSize2, sizeof(int), 0}
+  };
+  NCCLCHECK(ncclSocketMultiOp(sizeOps, 4));
   if (senderRecvSize1 > ops[1].size || senderRecvSize2 > ops[3].size) {
     WARN("Message truncated : received %d,%d bytes instead of %d,%d", senderRecvSize1, senderRecvSize2, ops[1].size, ops[3].size);
     return ncclInternalError;

--- a/projects/rccl/src/bootstrap.cc
+++ b/projects/rccl/src/bootstrap.cc
@@ -802,6 +802,77 @@ static ncclResult_t socketRingConnect(ncclSocketAddress* addr, struct ncclSocket
 // Socket OOB path no longer needs this: TCP is full-duplex and the new socketRingAllGather
 // drives both ring directions over the existing forward socket pair via socketDoubleSendRecv
 // (mirrors NCCL 2.28.7).
+// Step 1 of bidirectional setup: ensure rev listen exists and resolve prev's revHandle
+// (piggybacked or via forward-ring netSendRecv fallback). When it's a piggyback, also
+// kick off non-blocking connect()/accept() on the reverse QP so they can make progress
+// while the caller does its other local setup work. The actual completion polling is in
+// bootstrapBidirRingSetupFinish.
+//
+// Returns *prevRevHandleOut populated for callers that need it to call Finish later.
+// *startedOut == true means connect/accept were issued (Finish will only poll); false
+// means the caller chose to call the legacy one-shot bootstrapBidirRingSetup instead
+// (typically because piggyback wasn't available).
+static ncclResult_t bootstrapBidirRingSetupStart(struct ncclComm* comm, struct bootstrapState* state,
+                                                 const char* prevRevHandlePiggyback,
+                                                 char prevRevHandleOut[NCCL_NET_HANDLE_MAXSIZE],
+                                                 bool* startedOut) {
+  *startedOut = false;
+  bool wantNetBidir = bootstrapBidirEnabled(state->nranks, 1);
+  if (!wantNetBidir) return ncclSuccess;
+
+  // Listen on the reverse device. Eager listen in bootstrapInit normally already did
+  // this; fall back to in-place listen if some other caller didn't.
+  if (STATE_LISTEN(state, net.revComm) == NULL) {
+    NCCLCHECK(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev),
+                                 STATE_LISTEN(state, net.revHandle), &STATE_LISTEN(state, net.revComm)));
+  }
+
+  // Without a piggybacked prev revHandle we can't kick off connect() yet — the legacy
+  // path needs the forward ring up to do netSendRecv. Caller will fall back.
+  if (prevRevHandlePiggyback == NULL) return ncclSuccess;
+  char zeros[NCCL_NET_HANDLE_MAXSIZE]; memset(zeros, 0, NCCL_NET_HANDLE_MAXSIZE);
+  if (memcmp(prevRevHandlePiggyback, zeros, NCCL_NET_HANDLE_MAXSIZE) == 0) return ncclSuccess;
+  memcpy(prevRevHandleOut, prevRevHandlePiggyback, NCCL_NET_HANDLE_MAXSIZE);
+
+  // Issue the first non-blocking connect()/accept() so the IB QP transition starts now,
+  // overlapping with whatever local setup the caller does next (proxy/UDS/peer/RAS,
+  // and/or the forward-ring connect handshake).
+  NCCLCHECK(state->net->connect(comm->netContext, STATE_LISTEN(state, net.dev), prevRevHandleOut,
+                                &STATE_RING(state, net.revSendComm), &STATE_RING(state, net.revSendDevHandle)));
+  NCCLCHECK(state->net->accept(STATE_LISTEN(state, net.revComm),
+                               &STATE_RING(state, net.revRecvComm), &STATE_RING(state, net.revRecvDevHandle)));
+  *startedOut = true;
+  return ncclSuccess;
+}
+
+// Step 2: poll until the reverse ring connect/accept complete. Caller must have first
+// invoked bootstrapBidirRingSetupStart with started==true and saved prevRevHandle.
+static ncclResult_t bootstrapBidirRingSetupFinish(struct ncclComm* comm, struct bootstrapState* state,
+                                                  const char prevRevHandle[NCCL_NET_HANDLE_MAXSIZE]) {
+  bool wantNetBidir = bootstrapBidirEnabled(state->nranks, 1);
+  if (!wantNetBidir) return ncclSuccess;
+  int abortCounter = 0;
+  while (!STATE_RING(state, net.revSendComm) || !STATE_RING(state, net.revRecvComm)) {
+    NCCLCHECK(checkAbort(state->abortFlag, &abortCounter));
+    bool madeProgress = false;
+    if (!STATE_RING(state, net.revSendComm)) {
+      void* prev = STATE_RING(state, net.revSendComm);
+      NCCLCHECK(state->net->connect(comm->netContext, STATE_LISTEN(state, net.dev), (void*)prevRevHandle,
+                                    &STATE_RING(state, net.revSendComm), &STATE_RING(state, net.revSendDevHandle)));
+      if (STATE_RING(state, net.revSendComm) != prev) madeProgress = true;
+    }
+    if (!STATE_RING(state, net.revRecvComm)) {
+      void* prev = STATE_RING(state, net.revRecvComm);
+      NCCLCHECK(state->net->accept(STATE_LISTEN(state, net.revComm),
+                                   &STATE_RING(state, net.revRecvComm), &STATE_RING(state, net.revRecvDevHandle)));
+      if (STATE_RING(state, net.revRecvComm) != prev) madeProgress = true;
+    }
+    if (!madeProgress) sched_yield();
+  }
+  INFO(NCCL_BOOTSTRAP, "Bootstrap bidirectional ring (net) connected: nranks %d", state->nranks);
+  return ncclSuccess;
+}
+
 static ncclResult_t bootstrapBidirRingSetup(struct ncclComm* comm, struct bootstrapState* state,
                                             const char* prevRevHandlePiggyback) {
   // Cheap exit when bidirectional net bootstrap is disabled, pointless (≤2 ranks) or below
@@ -851,30 +922,7 @@ static ncclResult_t bootstrapBidirRingSetup(struct ncclComm* comm, struct bootst
     if (regRes != ncclSuccess) return regRes;
   }
 
-  // 3. Mirrored connect: revSendComm connects to prev's revHandle, revRecvComm accepts from next.
-  //    Both connect() and accept() are non-blocking on the IB plugin (they return NULL until
-  //    the QP transition completes). Yielding the CPU each round avoids a 100% spin while
-  //    waiting on the network; checkAbort still fires often enough to react to teardown.
-  int abortCounter = 0;
-  while (!STATE_RING(state, net.revSendComm) || !STATE_RING(state, net.revRecvComm)) {
-    NCCLCHECK(checkAbort(state->abortFlag, &abortCounter));
-    bool madeProgress = false;
-    if (!STATE_RING(state, net.revSendComm)) {
-      void* prev = STATE_RING(state, net.revSendComm);
-      NCCLCHECK(state->net->connect(comm->netContext, STATE_LISTEN(state, net.dev), prevRevHandle,
-                                    &STATE_RING(state, net.revSendComm), &STATE_RING(state, net.revSendDevHandle)));
-      if (STATE_RING(state, net.revSendComm) != prev) madeProgress = true;
-    }
-    if (!STATE_RING(state, net.revRecvComm)) {
-      void* prev = STATE_RING(state, net.revRecvComm);
-      NCCLCHECK(state->net->accept(STATE_LISTEN(state, net.revComm),
-                                   &STATE_RING(state, net.revRecvComm), &STATE_RING(state, net.revRecvDevHandle)));
-      if (STATE_RING(state, net.revRecvComm) != prev) madeProgress = true;
-    }
-    if (!madeProgress) sched_yield();
-  }
-  INFO(NCCL_BOOTSTRAP, "Bootstrap bidirectional ring (net) connected: nranks %d", state->nranks);
-  return ncclSuccess;
+  return bootstrapBidirRingSetupFinish(comm, state, prevRevHandle);
 }
 static ncclResult_t ringAllInfo(struct ncclComm* comm, struct bootstrapState* state,
                                 union ncclSocketAddress* peerAddresss,
@@ -951,6 +999,12 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm) {
   struct ringConnectInfo nextPeer;
   bool performRasAddRanks = true;
   struct rasRankInit* rasRanks = nullptr;
+  // Bidirectional IB OOB split-setup state. Stored at function scope so the prev
+  // revHandle survives across the local-setup overlap region between
+  // bootstrapBidirRingSetupStart and bootstrapBidirRingSetupFinish.
+  bool bidirSplitStarted = false;
+  char bidirPrevRevHandle[NCCL_NET_HANDLE_MAXSIZE];
+  memset(bidirPrevRevHandle, 0, NCCL_NET_HANDLE_MAXSIZE);
 
   uint64_t timers[BOOTSTRAP_INIT_TIME_N] = {0};
   // [RCCL] Whether to set up the IB-bidir reverse ring at all (gated by env + threshold +
@@ -1057,6 +1111,17 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm) {
     NCCLCHECK(socketRingConnectStart(&nextPeer.fwd.addr, &STATE_RING(state, socket.send), &STATE_LISTEN(state, socket.fwd), &STATE_RING(state, socket.recv), comm->magic, state->abortFlag));
   }
 
+  // [RCCL] Bidirectional IB OOB: kick off the reverse-ring connect()/accept() now so
+  // they overlap with both forward-ring connect and the local proxy/UDS/peer/RAS setup
+  // below. This requires a piggybacked prev revHandle (delivered via the root rendezvous
+  // or PMIx fast-path) so we can avoid the legacy netSendRecv handle exchange. When
+  // piggyback isn't available (shrunk/split comms) we fall back below to the one-shot
+  // bootstrapBidirRingSetup that does listen + handle exchange + connect/accept after
+  // the forward ring is up.
+  if (ncclParamBootstrapNetEnable()) {
+    NCCLCHECK(bootstrapBidirRingSetupStart(comm, state, nextPeer.revHandle, bidirPrevRevHandle, &bidirSplitStarted));
+  }
+
   // AllGather all listen handlers
   // in case of failure, those resources will be free'd when calling bootstrapDestroy, so we can return immediatly
   NCCLCHECK(ncclCalloc(&state->peerProxyAddresses, nranks));
@@ -1107,7 +1172,15 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm) {
   // AllGather. The reverse listen + handle are piggybacked through the root rendezvous
   // (nextPeer.revHandle = prev's reverse listen), so the heavy synchronous netSendRecv
   // handle exchange inside bootstrapBidirRingSetup is skipped on the hot path.
-  NCCLCHECKGOTO(bootstrapBidirRingSetup(comm, state, nextPeer.revHandle), result, fail);
+  // When the split-Start above already kicked off connect/accept (piggyback path), we
+  // only need to poll for completion here — it has been progressing in parallel with
+  // proxy/UDS/peer/RAS setup and the forward-ring handshake. Otherwise fall back to
+  // the legacy one-shot path which also does the listen + handle exchange.
+  if (bidirSplitStarted) {
+    NCCLCHECKGOTO(bootstrapBidirRingSetupFinish(comm, state, bidirPrevRevHandle), result, fail);
+  } else {
+    NCCLCHECKGOTO(bootstrapBidirRingSetup(comm, state, nextPeer.revHandle), result, fail);
+  }
 
   BOOTSTRAP_PROF_OPEN(timers[BOOTSTRAP_INIT_TIME_RING]);
   NCCLCHECKGOTO(ringAllInfo(comm, state, state->peerP2pAddresses, state->peerProxyAddresses, state->peerProxyAddressesUDS, rasRanks), result, fail);

--- a/projects/rccl/src/bootstrap.cc
+++ b/projects/rccl/src/bootstrap.cc
@@ -94,24 +94,25 @@ NCCL_PARAM(BootstrapNetEnable,"OOB_NET_ENABLE", 0);
 
 // Large-scale bootstrap: bidirectional ring AllGather (N/2 steps instead of N-1).
 // Both the socket and the IB (net) OOB paths support a bidirectional implementation;
-// each is gated by its own env var (default: enabled), so users can fall back to the
-// classic unidirectional ring without rebuilding.
+// each is gated by its own env var. Socket bidir is enabled by default; net bidir is
+// opt-in until it shows stable total-time wins.
 //
 // Socket path mirrors upstream NCCL 2.28.7 (socketDoubleSendRecv + ncclSocketMultiOp
 // over the same forward socket pair: TCP is full-duplex). Has no setup overhead, so
 // it does not consult BOOTSTRAP_BIDIR_THRESHOLD — it is enabled whenever N ≥ 3.
 NCCL_PARAM(BootstrapBidirAllGather, "BOOTSTRAP_BIDIR_ALLGATHER", 1);
 // IB path runs a parallel reverse ring on a separate QP pair, so it does pay for
-// extra regMr + connect + accept; threshold gates it on small comms.
-NCCL_PARAM(BootstrapBidirNet,       "BOOTSTRAP_BIDIR_NET",       1);
+// extra regMr + connect + accept. Keep it opt-in until the net path shows stable
+// total-time wins, while socket bidir remains enabled by BOOTSTRAP_BIDIR_ALLGATHER.
+NCCL_PARAM(BootstrapBidirNet,       "BOOTSTRAP_BIDIR_NET",       0);
 // Minimum nranks at which bidirectional IB bootstrap is worth its overhead.
 // Below the threshold the extra reverse-ring connect + regMr dominates the savings.
 // Measured on a 4-node MI300X cluster (RoCE + 10G TCP):
 //   N=8  single-node  : bidir ~40% slower in total bootstrap time → off
 //   N=16 (2 nodes)    : bidir ring_avg −58% IB                    → on
 //   N=32 (4 nodes)    : bidir ring_avg −23% IB                    → on
-// Force-enable on any N≥3 by setting BOOTSTRAP_BIDIR_THRESHOLD=0.
-// Force-disable per-path with BOOTSTRAP_BIDIR_ALLGATHER=0 / BOOTSTRAP_BIDIR_NET=0.
+// Force-enable on any N≥3 by setting NCCL_BOOTSTRAP_BIDIR_THRESHOLD=0.
+// Force-disable per-path with NCCL_BOOTSTRAP_BIDIR_ALLGATHER=0 / NCCL_BOOTSTRAP_BIDIR_NET=0.
 NCCL_PARAM(BootstrapBidirThreshold, "BOOTSTRAP_BIDIR_THRESHOLD", 16);
 
 // Single source of truth for the "should we run bidirectional bootstrap?" decision.
@@ -336,9 +337,20 @@ static ncclResult_t socketDoubleSendRecv(struct ncclSocketOp ops[4]) {
   return ncclSuccess;
 }
 
-union ringConnectInfo {
-  union ncclSocketAddress addr;
-  char handle[NCCL_NET_HANDLE_MAXSIZE];
+// [RCCL] Was a union; now a struct so we can piggyback the reverse-ring listen handle
+// for IB bidir bootstrap inside the existing root rendezvous (which is O(1) per rank
+// and incurs no extra RTT). The 'fwd' member is the forward-ring connection target as
+// before (socket address for socket OOB, net handle for IB OOB). The 'revHandle' member
+// is the reverse-ring listen handle this rank is offering; root forwards each rank's
+// revHandle to the next-1 rank in a single pass so that bootstrapBidirRingSetup can
+// connect/accept the reverse pair *without* an extra forward-ring netSendRecv exchange
+// (saving one full O(N)-latency step on the IB bidir init path).
+struct ringConnectInfo {
+  union {
+    union ncclSocketAddress addr;
+    char handle[NCCL_NET_HANDLE_MAXSIZE];
+  } fwd;
+  char revHandle[NCCL_NET_HANDLE_MAXSIZE];
 };
 
 struct extInfo {
@@ -347,7 +359,7 @@ struct extInfo {
   int iroot;                                 // current root index
   int nroots;                                // total number of roots
   union ncclSocketAddress listenRootAddress; // address of my listenSocket for the root
-  union ringConnectInfo connectInfo;
+  struct ringConnectInfo connectInfo;
 };
 #define NET_HANDLE(h, rank)    ((h) + (rank * NCCL_NET_HANDLE_MAXSIZE))
 #define BOOTSTRAP_HANDLE(h, i) ((struct ncclBootstrapHandle*)((char*)h + i * NCCL_UNIQUE_ID_BYTES))
@@ -383,12 +395,12 @@ static ncclResult_t bootstrapAccept(struct ncclSocket* sock, struct ncclSocket* 
   }
 }
 
-static ncclResult_t rootSend(union ncclSocketAddress* addr, uint64_t magic, union ringConnectInfo* info) {
+static ncclResult_t rootSend(union ncclSocketAddress* addr, uint64_t magic, struct ringConnectInfo* info) {
   ncclResult_t res = ncclSuccess;
   struct ncclSocket sock;
   NCCLCHECKGOTO(ncclSocketInit(&sock, addr, magic, ncclSocketTypeBootstrap), res, fail);
   NCCLCHECKGOTO(ncclSocketConnect(&sock), res, fail);
-  NCCLCHECKGOTO(socketSend(&sock, info, sizeof(union ringConnectInfo)), res, fail);
+  NCCLCHECKGOTO(socketSend(&sock, info, sizeof(struct ringConnectInfo)), res, fail);
   NCCLCHECK(ncclSocketClose(&sock));
   return res;
 fail:
@@ -405,15 +417,15 @@ static void* bootstrapRoot(void* rargs) {
   int iroot = 0, nroots = 0, localId = 0;
   int nrecv = 0, n2send = 0;
   struct extInfo info;
-  union ringConnectInfo* rankInfo = NULL;
+  struct ringConnectInfo* rankInfo = NULL;
   union ncclSocketAddress* rankAddressesRoot = NULL; // for initial rank <-> root information exchange
   // get zeros for comparison
   char zeroHandle[NCCL_NET_HANDLE_MAXSIZE];
   union ncclSocketAddress zeroAddress;
-  union ringConnectInfo zeroInfo;
+  struct ringConnectInfo zeroInfo;
   memset(&zeroAddress, 0, sizeof(union ncclSocketAddress));
   memset(&zeroHandle, 0, NCCL_NET_HANDLE_MAXSIZE);
-  memset(&zeroInfo, 0, sizeof(union ringConnectInfo));
+  memset(&zeroInfo, 0, sizeof(struct ringConnectInfo));
   setFilesLimit();
 
   TRACE(NCCL_BOOTSTRAP, "BEGIN");
@@ -446,25 +458,50 @@ static void* bootstrapRoot(void* rargs) {
 
     localId = localIdFromRoot(info.rank, iroot, nranks, nroots);
     if (memcmp(&zeroAddress, &rankAddressesRoot[localId], sizeof(union ncclSocketAddress)) != 0 ||
-        memcmp(&zeroInfo, &rankInfo[localId], sizeof(union ringConnectInfo)) != 0) {
+        memcmp(&zeroInfo, &rankInfo[localId], sizeof(struct ringConnectInfo)) != 0) {
       WARN("Bootstrap Root : rank %d of %d ranks has already checked in", info.rank, nranks);
       goto out;
     }
-    // if the previous has already checked in, send the newly received handle, if not save the handle for later
-    // if we have more than 1 root, I do not own the previous of local_id = 0
-    // if we have prev > n2send, we do not send anything
+    // [RCCL] Always store this rank's info immediately. Inline-send below conditions on
+    // having BOTH the recipient address AND the prev-of-recipient info already known —
+    // any rank that doesn't satisfy that condition gets its (combined) info via the
+    // final loop. This avoids partial-piggyback races where some ranks see a populated
+    // revHandle and others see zero (which would cause asymmetric fallback behaviour
+    // and deadlock in bootstrapBidirRingSetup).
+    memcpy(&rankInfo[localId], &info.connectInfo, sizeof(struct ringConnectInfo));
+
+    // Try to inline-send next-info to the just-arrived rank's previous (whose connection
+    // address we may already have). For bidir IB we additionally need prev-of-prev's
+    // revHandle to be available — otherwise defer to the final loop.
     int prev = (nroots > 1) ? (localId - 1) : BOOTSTRAP_PID(localId - 1, nrecv);
     if (prev >= 0 && prev < n2send && memcmp(&zeroAddress, &rankAddressesRoot[prev], sizeof(union ncclSocketAddress)) != 0) {
-      NCCLCHECKGOTO(rootSend(&rankAddressesRoot[prev], magic, &info.connectInfo), res, out);
-    } else {
-      memcpy(&rankInfo[localId], &info.connectInfo, sizeof(union ringConnectInfo));
+      int prevprev = (nroots > 1) ? (prev - 1) : BOOTSTRAP_PID(prev - 1, nrecv);
+      bool revKnown = (prevprev >= 0 && prevprev < nrecv &&
+                       memcmp(&zeroInfo, &rankInfo[prevprev], sizeof(struct ringConnectInfo)) != 0);
+      if (revKnown) {
+        struct ringConnectInfo outBound = rankInfo[localId];  // = info.connectInfo
+        memcpy(outBound.revHandle, rankInfo[prevprev].revHandle, NCCL_NET_HANDLE_MAXSIZE);
+        NCCLCHECKGOTO(rootSend(&rankAddressesRoot[prev], magic, &outBound), res, out);
+        // Mark as already-sent so the final loop skips it.
+        memset(&rankAddressesRoot[prev], 0, sizeof(union ncclSocketAddress));
+      }
+      // else: defer to final loop
     }
-    // if the next rank has checked in, send the newly received info, if not save the addr for later
-    // for nroots >=1, I will always own the information of the next connection
-    // if the local_id id must be [0 ; n2send[ otherwise we do not answer
+
+    // Try to inline-send next-info back to the just-arrived rank itself.
     int next = BOOTSTRAP_PID(localId + 1, nrecv);
-    if (localId >= 0 && localId < n2send && memcmp(&zeroInfo, &rankInfo[next], sizeof(union ringConnectInfo)) != 0) {
-      NCCLCHECKGOTO(rootSend(&info.listenRootAddress, magic, &rankInfo[next]), res, out);
+    if (localId >= 0 && localId < n2send && memcmp(&zeroInfo, &rankInfo[next], sizeof(struct ringConnectInfo)) != 0) {
+      int recvPrev = (nroots > 1) ? (localId - 1) : BOOTSTRAP_PID(localId - 1, nrecv);
+      bool revKnown = (recvPrev >= 0 && recvPrev < nrecv &&
+                       memcmp(&zeroInfo, &rankInfo[recvPrev], sizeof(struct ringConnectInfo)) != 0);
+      if (revKnown) {
+        struct ringConnectInfo outBound = rankInfo[next];
+        memcpy(outBound.revHandle, rankInfo[recvPrev].revHandle, NCCL_NET_HANDLE_MAXSIZE);
+        NCCLCHECKGOTO(rootSend(&info.listenRootAddress, magic, &outBound), res, out);
+      } else {
+        // We can't safely inline-send (prev's revHandle unknown); defer by saving the addr.
+        memcpy(rankAddressesRoot + localId, &info.listenRootAddress, sizeof(union ncclSocketAddress));
+      }
     } else {
       memcpy(rankAddressesRoot + localId, &info.listenRootAddress, sizeof(union ncclSocketAddress));
     }
@@ -481,8 +518,16 @@ static void* bootstrapRoot(void* rargs) {
     // use nrecv to periodize: if 1 root, we will send the first one to the last one, if >1 roots we will send the additional one we have received
     int next = BOOTSTRAP_PID(r + 1, nrecv);
     if (memcmp(&zeroAddress, &rankAddressesRoot[r], sizeof(union ncclSocketAddress)) != 0 &&
-        memcmp(&zeroInfo, &rankInfo[next], sizeof(union ringConnectInfo)) != 0) {
-      NCCLCHECKGOTO(rootSend(&rankAddressesRoot[r], magic, &rankInfo[next]), res, out);
+        memcmp(&zeroInfo, &rankInfo[next], sizeof(struct ringConnectInfo)) != 0) {
+      // [RCCL] Combined: next.fwd + prev.revHandle, where prev = rank r's previous.
+      struct ringConnectInfo outBound = rankInfo[next];
+      int prev = (nroots > 1) ? (r - 1) : BOOTSTRAP_PID(r - 1, nrecv);
+      if (prev >= 0 && prev < nrecv && memcmp(&zeroInfo, &rankInfo[prev], sizeof(struct ringConnectInfo)) != 0) {
+        memcpy(outBound.revHandle, rankInfo[prev].revHandle, NCCL_NET_HANDLE_MAXSIZE);
+      } else {
+        memset(outBound.revHandle, 0, NCCL_NET_HANDLE_MAXSIZE);
+      }
+      NCCLCHECKGOTO(rootSend(&rankAddressesRoot[r], magic, &outBound), res, out);
     }
   }
   BOOTSTRAP_PROF_CLOSE(timers[BOOTSTRAP_INIT_ROOT_SEND]);
@@ -560,7 +605,7 @@ struct bootstrapRing_t {
       void *sendComm, *recvComm;
       ncclNetDeviceHandle_t *sendDevHandle, *recvDevHandle;
       // Reverse ring (large-scale bidirectional IB OOB AllGather, opt-in via
-      // RCCL_BOOTSTRAP_BIDIR_NET). NULL when disabled. The socket OOB path is always
+      // NCCL_BOOTSTRAP_BIDIR_NET). NULL when disabled. The socket OOB path is always
       // bidirectional but does not need a reverse pair (TCP is full-duplex).
       void *revSendComm, *revRecvComm;
       ncclNetDeviceHandle_t *revSendDevHandle, *revRecvDevHandle;
@@ -674,7 +719,6 @@ static ncclResult_t netGetDevice(int rank, struct ncclComm* comm, int* dev) {
 static ncclResult_t netRingConnect(void* ctx, ncclNet_t* net, struct bootstrapListen_t* listen, char peerHandle[NCCL_NET_HANDLE_MAXSIZE],
                                    void** sendComm, ncclNetDeviceHandle_t** sendDevHandle,
                                    void** recvComm, ncclNetDeviceHandle_t** recvDevHandle, volatile uint32_t* abortFlag) {
-
   int abortCounter = 0;
   do {
     NCCLCHECK(checkAbort(abortFlag, &abortCounter));
@@ -685,10 +729,62 @@ static ncclResult_t netRingConnect(void* ctx, ncclNet_t* net, struct bootstrapLi
   } while (!*sendComm || !*recvComm);
   return ncclSuccess;
 }
-static ncclResult_t socketRingConnect(ncclSocketAddress* addr, struct ncclSocket* sendSocket, struct ncclSocket* listenSock, struct ncclSocket* recvSocket, uint64_t magic, volatile uint32_t* abortFlag) {
-  NCCLCHECK(ncclSocketInit(sendSocket, addr, magic, ncclSocketTypeBootstrap, abortFlag));
+
+static ncclResult_t netRingConnectProgress(void* ctx, ncclNet_t* net, struct bootstrapListen_t* listen, char peerHandle[NCCL_NET_HANDLE_MAXSIZE],
+                                           void** sendComm, ncclNetDeviceHandle_t** sendDevHandle,
+                                           void** recvComm, ncclNetDeviceHandle_t** recvDevHandle, int* done) {
+  if (!*sendComm)
+    NCCLCHECK(net->connect(ctx, listen->net.dev, peerHandle, sendComm, sendDevHandle));
+  if (!*recvComm)
+    NCCLCHECK(net->accept(listen->net.comm, recvComm, recvDevHandle));
+  *done = (*sendComm && *recvComm) ? 1 : 0;
+  return ncclSuccess;
+}
+
+static ncclResult_t netRingConnectFinish(void* ctx, ncclNet_t* net, struct bootstrapListen_t* listen, char peerHandle[NCCL_NET_HANDLE_MAXSIZE],
+                                         void** sendComm, ncclNetDeviceHandle_t** sendDevHandle,
+                                         void** recvComm, ncclNetDeviceHandle_t** recvDevHandle, volatile uint32_t* abortFlag) {
+  int abortCounter = 0, done = 0;
+  do {
+    NCCLCHECK(checkAbort(abortFlag, &abortCounter));
+    NCCLCHECK(netRingConnectProgress(ctx, net, listen, peerHandle, sendComm, sendDevHandle, recvComm, recvDevHandle, &done));
+    if (!done) sched_yield();
+  } while (!done);
+  return ncclSuccess;
+}
+
+// Start the socket ring connect in non-blocking mode. This lets bootstrapInit overlap
+// TCP connect/accept handshakes with local proxy/P2P socket setup, without adding
+// threads. socketRingConnect() below keeps the old blocking semantics for callers that
+// do not have useful work to overlap (notably bootstrapSplit).
+static ncclResult_t socketRingConnectStart(ncclSocketAddress* addr, struct ncclSocket* sendSocket, struct ncclSocket* listenSock, struct ncclSocket* recvSocket, uint64_t magic, volatile uint32_t* abortFlag) {
+  ncclResult_t ret = ncclSuccess;
+  NCCLCHECK(ncclSocketInit(sendSocket, addr, magic, ncclSocketTypeBootstrap, abortFlag, /*asyncFlag*/1));
   NCCLCHECK(ncclSocketConnect(sendSocket));
-  NCCLCHECK(bootstrapAccept(recvSocket, listenSock, abortFlag));
+  int oldAsync = listenSock->asyncFlag;
+  listenSock->asyncFlag = 1;
+  NCCLCHECKGOTO(ncclSocketInit(recvSocket), ret, exit);
+  NCCLCHECKGOTO(ncclSocketAccept(recvSocket, listenSock), ret, exit);
+exit:
+  listenSock->asyncFlag = oldAsync;
+  return ret;
+}
+
+static ncclResult_t socketRingConnectFinish(struct ncclSocket* sendSocket, struct ncclSocket* recvSocket, volatile uint32_t* abortFlag) {
+  int abortCounter = 0;
+  int sendReady = 0, recvReady = 0;
+  do {
+    NCCLCHECK(checkAbort(abortFlag, &abortCounter));
+    if (!sendReady) NCCLCHECK(ncclSocketReady(sendSocket, &sendReady));
+    if (!recvReady) NCCLCHECK(ncclSocketReady(recvSocket, &recvReady));
+    if (!sendReady || !recvReady) sched_yield();
+  } while (!sendReady || !recvReady);
+  return ncclSuccess;
+}
+
+static ncclResult_t socketRingConnect(ncclSocketAddress* addr, struct ncclSocket* sendSocket, struct ncclSocket* listenSock, struct ncclSocket* recvSocket, uint64_t magic, volatile uint32_t* abortFlag) {
+  NCCLCHECK(socketRingConnectStart(addr, sendSocket, listenSock, recvSocket, magic, abortFlag));
+  NCCLCHECK(socketRingConnectFinish(sendSocket, recvSocket, abortFlag));
   return ncclSuccess;
 }
 
@@ -701,26 +797,41 @@ static ncclResult_t socketRingConnect(ncclSocketAddress* addr, struct ncclSocket
 // Socket OOB path no longer needs this: TCP is full-duplex and the new socketRingAllGather
 // drives both ring directions over the existing forward socket pair via socketDoubleSendRecv
 // (mirrors NCCL 2.28.7).
-static ncclResult_t bootstrapBidirRingSetup(struct ncclComm* comm, struct bootstrapState* state) {
+static ncclResult_t bootstrapBidirRingSetup(struct ncclComm* comm, struct bootstrapState* state,
+                                            const char* prevRevHandlePiggyback) {
   // Cheap exit when bidirectional net bootstrap is disabled, pointless (≤2 ranks) or below
   // the BOOTSTRAP_BIDIR_THRESHOLD: the IB plugin's regMr/QP setup is heavy enough that
   // small comms regress without the threshold.
   bool wantNetBidir = bootstrapBidirEnabled(state->nranks, 1);
   if (!wantNetBidir) return ncclSuccess;
 
-  // 1. Create the reverse listen on the same OOB net device; share its handle with prev.
-  char myRevHandle[NCCL_NET_HANDLE_MAXSIZE];
   char prevRevHandle[NCCL_NET_HANDLE_MAXSIZE];
-  memset(myRevHandle,   0, NCCL_NET_HANDLE_MAXSIZE);
   memset(prevRevHandle, 0, NCCL_NET_HANDLE_MAXSIZE);
-  NCCLCHECK(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev),
-                               STATE_LISTEN(state, net.revHandle), &STATE_LISTEN(state, net.revComm)));
-  memcpy(myRevHandle, STATE_LISTEN(state, net.revHandle), NCCL_NET_HANDLE_MAXSIZE);
 
-  // 2. One forward-ring exchange of net handles using the existing forward sendComm/recvComm.
-  //    IB plugin requires registered memory for isend/irecv, so register both buffers
-  //    around the single exchange and unregister immediately.
-  {
+  // 1. Reverse listen: piggyback path creates it eagerly inside bootstrapInit so its
+  //    handle can ride along with the existing root rendezvous. If that didn't happen
+  //    (caller passed NULL prevRevHandlePiggyback or revComm wasn't set up), fall back
+  //    to the legacy in-place listen here.
+  if (STATE_LISTEN(state, net.revComm) == NULL) {
+    NCCLCHECK(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev),
+                                 STATE_LISTEN(state, net.revHandle), &STATE_LISTEN(state, net.revComm)));
+  }
+
+  // 2. Determine prev's revHandle. Best case: piggybacked through the root rendezvous
+  //    (zero-cost). Fallback: do the legacy forward-ring netSendRecv exchange (~20ms
+  //    on IB at N=64, dominated by 4× regMr/deregMr).
+  bool havePiggyback = false;
+  if (prevRevHandlePiggyback != NULL) {
+    char zeros[NCCL_NET_HANDLE_MAXSIZE];
+    memset(zeros, 0, NCCL_NET_HANDLE_MAXSIZE);
+    if (memcmp(prevRevHandlePiggyback, zeros, NCCL_NET_HANDLE_MAXSIZE) != 0) {
+      memcpy(prevRevHandle, prevRevHandlePiggyback, NCCL_NET_HANDLE_MAXSIZE);
+      havePiggyback = true;
+    }
+  }
+  if (!havePiggyback) {
+    char myRevHandle[NCCL_NET_HANDLE_MAXSIZE];
+    memcpy(myRevHandle, STATE_LISTEN(state, net.revHandle), NCCL_NET_HANDLE_MAXSIZE);
     void *sendH = NULL, *recvH = NULL;
     ncclResult_t regRes = netReg(state->net, STATE_RING(state, net.sendComm), myRevHandle,   NCCL_NET_HANDLE_MAXSIZE, &sendH);
     if (regRes == ncclSuccess) regRes = netReg(state->net, STATE_RING(state, net.recvComm), prevRevHandle, NCCL_NET_HANDLE_MAXSIZE, &recvH);
@@ -832,11 +943,15 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm) {
   struct ncclSocket* proxySocket;
   struct ncclSocket sock, listenSockRoot;
   struct extInfo info = {0};
-  union ringConnectInfo nextPeer;
+  struct ringConnectInfo nextPeer;
   bool performRasAddRanks = true;
   struct rasRankInit* rasRanks = nullptr;
 
   uint64_t timers[BOOTSTRAP_INIT_TIME_N] = {0};
+  // [RCCL] Whether to set up the IB-bidir reverse ring at all (gated by env + threshold +
+  // OOB net enabled). If true, we create the reverse listen *before* sendToRoot so its
+  // handle piggybacks the existing root rendezvous (no extra RTT).
+  bool wantNetBidir = ncclParamBootstrapNetEnable() && bootstrapBidirEnabled(nranks, 1);
 
   NCCLCHECK(ncclCalloc(&state, 1));
   state->rank = rank;
@@ -858,16 +973,26 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm) {
   info.nranks = nranks;
   info.nroots = nHandles;
   // get the ring connection info
-  memset(&nextPeer, 0, sizeof(union ringConnectInfo));
+  memset(&nextPeer, 0, sizeof(struct ringConnectInfo));
   BOOTSTRAP_PROF_OPEN(timers[BOOTSTRAP_INIT_TIME_CREATE]);
   if (ncclParamBootstrapNetEnable()) {
     // Create net interface for other ranks to contact me (all gather)
     NCCLCHECK(netGetDevice(rank, comm, &STATE_LISTEN(state, net.dev)));
     NCCLCHECK(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev), STATE_LISTEN(state, net.handle), &STATE_LISTEN(state, net.comm)));
-    memcpy(info.connectInfo.handle, STATE_LISTEN(state, net.handle), NCCL_NET_HANDLE_MAXSIZE);
+    memcpy(info.connectInfo.fwd.handle, STATE_LISTEN(state, net.handle), NCCL_NET_HANDLE_MAXSIZE);
+    // [RCCL] Eagerly create the reverse listen if we expect to use IB bidir bootstrap.
+    // The cost (one IB listen ≈ 1ms) is paid here in parallel with the staggered sendToRoot
+    // and the resulting handle is piggybacked into info.connectInfo.revHandle so that
+    // bootstrapBidirRingSetup can skip its own netSendRecv handle exchange (~20ms saving
+    // dominated by 4× regMr/deregMr on the IB plugin).
+    if (wantNetBidir) {
+      NCCLCHECK(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev),
+                                   STATE_LISTEN(state, net.revHandle), &STATE_LISTEN(state, net.revComm)));
+      memcpy(info.connectInfo.revHandle, STATE_LISTEN(state, net.revHandle), NCCL_NET_HANDLE_MAXSIZE);
+    }
   } else {
     // create socket for ring neightbor to contact mee
-    NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, socket.fwd), &info.connectInfo.addr, ncclSocketTypeBootstrap));
+    NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, socket.fwd), &info.connectInfo.fwd.addr, ncclSocketTypeBootstrap));
   }
   // Create socket for root to contact me using the root's magic
   int curr_root = rootIdFromRank(rank, nranks, nHandles);
@@ -914,19 +1039,18 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm) {
   NCCLCHECK(ncclSocketClose(&listenSockRoot));
   BOOTSTRAP_PROF_CLOSE(timers[BOOTSTRAP_INIT_TIME_RECV]);
 
-  // accept and connect the ring network
+  // Start the ring connect/accept as early as possible, then overlap its non-blocking
+  // progress with local proxy/P2P socket setup below. This is intentionally single-
+  // threaded: net connect/accept are plugin-level non-blocking calls, and socket uses
+  // ncclSocket async mode plus ncclSocketReady() in the finish step.
   if (ncclParamBootstrapNetEnable()) {
-    NCCLCHECK(netRingConnect(comm->netContext, state->net, &state->listen, nextPeer.handle,
-                             &STATE_RING(state, net.sendComm), &STATE_RING(state, net.sendDevHandle),
-                             &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle), state->abortFlag));
+    int ringConnectDone = 0;
+    NCCLCHECK(netRingConnectProgress(comm->netContext, state->net, &state->listen, nextPeer.fwd.handle,
+                                     &STATE_RING(state, net.sendComm), &STATE_RING(state, net.sendDevHandle),
+                                     &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle), &ringConnectDone));
   } else {
-    NCCLCHECK(socketRingConnect(&nextPeer.addr, &STATE_RING(state, socket.send), &STATE_LISTEN(state, socket.fwd), &STATE_RING(state, socket.recv), comm->magic, state->abortFlag));
+    NCCLCHECK(socketRingConnectStart(&nextPeer.fwd.addr, &STATE_RING(state, socket.send), &STATE_LISTEN(state, socket.fwd), &STATE_RING(state, socket.recv), comm->magic, state->abortFlag));
   }
-
-  // Optionally bring up the second (reverse) ring used by the bidirectional bootstrap
-  // AllGather. Symmetric across all ranks; the existing forward ring is reused for a
-  // single address-exchange step, so no root-side change is required.
-  NCCLCHECK(bootstrapBidirRingSetup(comm, state));
 
   // AllGather all listen handlers
   // in case of failure, those resources will be free'd when calling bootstrapDestroy, so we can return immediatly
@@ -962,6 +1086,24 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm) {
     }
   }
 
+  // Finish forward ring connect before using the ring in bootstrapBidirRingSetup and
+  // ringAllInfo. By this point the connection handshake has overlapped with the local
+  // setup above (proxy listen, UDS lookup, peer P2P listen and RAS payload creation).
+  if (ncclParamBootstrapNetEnable()) {
+    NCCLCHECKGOTO(netRingConnectFinish(comm->netContext, state->net, &state->listen, nextPeer.fwd.handle,
+                                       &STATE_RING(state, net.sendComm), &STATE_RING(state, net.sendDevHandle),
+                                       &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle), state->abortFlag),
+                  result, fail);
+  } else {
+    NCCLCHECKGOTO(socketRingConnectFinish(&STATE_RING(state, socket.send), &STATE_RING(state, socket.recv), state->abortFlag), result, fail);
+  }
+
+  // Optionally bring up the second (reverse) ring used by the bidirectional bootstrap
+  // AllGather. The reverse listen + handle are piggybacked through the root rendezvous
+  // (nextPeer.revHandle = prev's reverse listen), so the heavy synchronous netSendRecv
+  // handle exchange inside bootstrapBidirRingSetup is skipped on the hot path.
+  NCCLCHECKGOTO(bootstrapBidirRingSetup(comm, state, nextPeer.revHandle), result, fail);
+
   BOOTSTRAP_PROF_OPEN(timers[BOOTSTRAP_INIT_TIME_RING]);
   NCCLCHECKGOTO(ringAllInfo(comm, state, state->peerP2pAddresses, state->peerProxyAddresses, state->peerProxyAddressesUDS, rasRanks), result, fail);
   BOOTSTRAP_PROF_CLOSE(timers[BOOTSTRAP_INIT_TIME_RING]);
@@ -994,8 +1136,8 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   int rank = comm->rank;
   int nranks = comm->nRanks;
   int prev, next;
-  union ringConnectInfo info;
-  union ringConnectInfo nextPeer;
+  struct ringConnectInfo info;
+  struct ringConnectInfo nextPeer;
   struct ncclSocket* proxySocket = NULL;
   struct bootstrapState* state;
 
@@ -1015,10 +1157,10 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   if (ncclParamBootstrapNetEnable()) {
     NCCLCHECKGOTO(netGetDevice(rank, comm, &STATE_LISTEN(state, net.dev)), ret, fail);
     NCCLCHECKGOTO(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev), STATE_LISTEN(state, net.handle), &STATE_LISTEN(state, net.comm)), ret, fail);
-    memcpy(info.handle, STATE_LISTEN(state, net.handle), NCCL_NET_HANDLE_MAXSIZE);
+    memcpy(info.fwd.handle, STATE_LISTEN(state, net.handle), NCCL_NET_HANDLE_MAXSIZE);
   } else {
     // create socket for ring neightbor to contact mee
-    NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, socket.fwd), &info.addr, ncclSocketTypeBootstrap));
+    NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, socket.fwd), &info.fwd.addr, ncclSocketTypeBootstrap));
   }
   // create a socket for others to reach out (P2P)
   union ncclSocketAddress peerSocketAddress;
@@ -1030,20 +1172,22 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   }
 
   // Get addr from next rank using the parent's connections
-  NCCLCHECKGOTO(bootstrapSend(parent->bootstrap, prev, BOOTSTRAP_TAG_COMMSPLIT, &info, sizeof(union ringConnectInfo)), ret, fail);
-  NCCLCHECKGOTO(bootstrapRecv(parent->bootstrap, next, BOOTSTRAP_TAG_COMMSPLIT, &nextPeer, sizeof(union ringConnectInfo)), ret, fail);
+  NCCLCHECKGOTO(bootstrapSend(parent->bootstrap, prev, BOOTSTRAP_TAG_COMMSPLIT, &info, sizeof(struct ringConnectInfo)), ret, fail);
+  NCCLCHECKGOTO(bootstrapRecv(parent->bootstrap, next, BOOTSTRAP_TAG_COMMSPLIT, &nextPeer, sizeof(struct ringConnectInfo)), ret, fail);
   if (ncclParamBootstrapNetEnable()) {
-    NCCLCHECKGOTO(netRingConnect(comm->netContext, state->net, &state->listen, nextPeer.handle,
+    NCCLCHECKGOTO(netRingConnect(comm->netContext, state->net, &state->listen, nextPeer.fwd.handle,
                                  &STATE_RING(state, net.sendComm), &STATE_RING(state, net.sendDevHandle),
                                  &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle), state->abortFlag),
                   ret, fail);
   } else {
-    NCCLCHECK(socketRingConnect(&nextPeer.addr, &STATE_RING(state, socket.send), &STATE_LISTEN(state, socket.fwd), &STATE_RING(state, socket.recv), comm->magic, state->abortFlag));
+    NCCLCHECK(socketRingConnect(&nextPeer.fwd.addr, &STATE_RING(state, socket.send), &STATE_LISTEN(state, socket.fwd), &STATE_RING(state, socket.recv), comm->magic, state->abortFlag));
   }
 
   // Mirror the bidirectional ring setup done in bootstrapInit so that split communicators
-  // can also benefit from the N/2-step AllGather.
-  NCCLCHECKGOTO(bootstrapBidirRingSetup(comm, state), ret, fail);
+  // can also benefit from the N/2-step AllGather. bootstrapSplit doesn't go through the
+  // root rendezvous, so no piggybacked revHandle is available — pass NULL to use the
+  // legacy in-place handle exchange.
+  NCCLCHECKGOTO(bootstrapBidirRingSetup(comm, state, NULL), ret, fail);
 
   NCCLCHECKGOTO(ncclCalloc(&state->peerP2pAddresses, nranks), ret, fail);
   memcpy(state->peerP2pAddresses + rank, &peerSocketAddress, sizeof(union ncclSocketAddress));
@@ -1262,7 +1406,7 @@ static ncclResult_t socketRingAllGather(struct ncclSocket* nextSock, struct nccl
   TRACE(NCCL_BOOTSTRAP, "bidirectional bootstrap: totalSteps=%d", totalSteps);
   BOOTSTRAP_PROF_OPEN(tFirst);
   for (int step = 0; step < totalSteps; step++) {
-    // N ranks requires (N-1)/2 steps for the double ring  algorithm. If N is even, the last step is requires a single send/recv
+    // N ranks require (N-1)/2 steps for the double-ring algorithm. If N is even, the last step requires a single send/recv.
     bool isFinalUnidirectional = (step == totalSteps - 1) && (nranks % 2 == 0);
     // Ring0: ring from previous to next
     int sendSliceRing0 = (rank - step + nranks) % nranks;      // Send this slice to next neighbor

--- a/projects/rccl/src/bootstrap.cc
+++ b/projects/rccl/src/bootstrap.cc
@@ -94,31 +94,40 @@ static std::mutex bootstrapNetMutex;
 NCCL_PARAM(BootstrapNetEnable,"OOB_NET_ENABLE", 0);
 
 // Large-scale bootstrap: bidirectional ring AllGather (N/2 steps instead of N-1).
-// Honored by both NCCL_BOOTSTRAP_BIDIR_ALLGATHER (NCCL-style) and the RCCL_-prefixed env.
-// Defaults: enabled, but only kicks in for nranks >= BOOTSTRAP_BIDIR_THRESHOLD.
+// Both the socket and the IB (net) OOB paths support a bidirectional implementation;
+// each is gated by its own env var (default: enabled), so users can fall back to the
+// classic unidirectional ring without rebuilding.
+//
+// Socket path mirrors upstream NCCL 2.28.7 (socketDoubleSendRecv + ncclSocketMultiOp
+// over the same forward socket pair: TCP is full-duplex). Has no setup overhead, so
+// it does not consult BOOTSTRAP_BIDIR_THRESHOLD — it is enabled whenever N ≥ 3.
 NCCL_PARAM(BootstrapBidirAllGather, "BOOTSTRAP_BIDIR_ALLGATHER", 1);
-// Same optimization for the IB OOB / netRingAllGather path. Independently gated.
+// IB path runs a parallel reverse ring on a separate QP pair, so it does pay for
+// extra regMr + connect + accept; threshold gates it on small comms.
 NCCL_PARAM(BootstrapBidirNet,       "BOOTSTRAP_BIDIR_NET",       1);
-// Minimum nranks at which bidirectional bootstrap is worth its overhead.
-// Below the threshold the extra reverse-ring setup + std::thread fork dominates the
-// savings.  Measured on a 4-node MI300X cluster (RoCE + 10G TCP):
+// Minimum nranks at which bidirectional IB bootstrap is worth its overhead.
+// Below the threshold the extra reverse-ring connect + regMr dominates the savings.
+// Measured on a 4-node MI300X cluster (RoCE + 10G TCP):
 //   N=8  single-node  : bidir ~40% slower in total bootstrap time → off
-//   N=16 (2 nodes)    : bidir ring_avg −39% TCP, −58% IB           → on
-//   N=32 (4 nodes)    : bidir ring_avg −36% TCP, −23% IB           → on
+//   N=16 (2 nodes)    : bidir ring_avg −58% IB                    → on
+//   N=32 (4 nodes)    : bidir ring_avg −23% IB                    → on
 // Force-enable on any N≥3 by setting BOOTSTRAP_BIDIR_THRESHOLD=0.
 // Force-disable per-path with BOOTSTRAP_BIDIR_ALLGATHER=0 / BOOTSTRAP_BIDIR_NET=0.
 NCCL_PARAM(BootstrapBidirThreshold, "BOOTSTRAP_BIDIR_THRESHOLD", 16);
 
 // Single source of truth for the "should we run bidirectional bootstrap?" decision.
-// kind: 0 = socket OOB, 1 = net (IB) OOB. Returns true when the user opted in,
-// the underlying transport matches, and the rank count clears the threshold.
-// Setup, dispatch and cleanup all consult this so they cannot disagree.
+// kind: 0 = socket OOB (no threshold, no extra setup), 1 = net (IB) OOB (threshold-gated,
+// pays for an extra QP pair). Setup, dispatch and cleanup all consult this so they
+// cannot disagree.
 static inline bool bootstrapBidirEnabled(int nranks, int kind) {
   if (nranks < 3) return false;
-  int64_t thr = ncclParamBootstrapBidirThreshold();
-  if (thr > 0 && nranks < (int)thr) return false;
   if (kind == 0) return (ncclParamBootstrapBidirAllGather() != 0) && !ncclParamBootstrapNetEnable();
-  if (kind == 1) return (ncclParamBootstrapBidirNet()       != 0) &&  ncclParamBootstrapNetEnable();
+  if (kind == 1) {
+    if (!ncclParamBootstrapNetEnable()) return false;
+    int64_t thr = ncclParamBootstrapBidirThreshold();
+    if (thr > 0 && nranks < (int)thr) return false;
+    return ncclParamBootstrapBidirNet() != 0;
+  }
   return false;
 }
 
@@ -255,6 +264,21 @@ static ncclResult_t socketSendRecv(struct ncclSocket* sendSock, void* sendData, 
     return ncclInternalError;
   }
   NCCLCHECK(ncclSocketSendRecv(sendSock, sendData, sendSize, recvSock, recvData, std::min(recvSize, senderRecvSize)));
+  return ncclSuccess;
+}
+
+static ncclResult_t socketDoubleSendRecv(struct ncclSocketOp ops[4]) {
+  // ops synchronously exchange size then asynchronously exchange data in send->recv->send->recv order
+  int senderRecvSize1, senderRecvSize2;
+  NCCLCHECK(ncclSocketSendRecv(ops[0].sock, &ops[0].size, sizeof(int), ops[1].sock, &senderRecvSize1, sizeof(int)));
+  NCCLCHECK(ncclSocketSendRecv(ops[2].sock, &ops[2].size, sizeof(int), ops[3].sock, &senderRecvSize2, sizeof(int)));
+  if (senderRecvSize1 > ops[1].size || senderRecvSize2 > ops[3].size) {
+    WARN("Message truncated : received %d,%d bytes instead of %d,%d", senderRecvSize1, senderRecvSize2, ops[1].size, ops[3].size);
+    return ncclInternalError;
+  }
+  ops[1].size = std::min(ops[1].size, senderRecvSize1);
+  ops[3].size = std::min(ops[3].size, senderRecvSize2);
+  NCCLCHECK(ncclSocketMultiOp(ops, 4));
   return ncclSuccess;
 }
 
@@ -481,16 +505,15 @@ struct bootstrapRing_t {
     struct {
       void *sendComm, *recvComm;
       ncclNetDeviceHandle_t *sendDevHandle, *recvDevHandle;
-      // Reverse ring (large-scale bidirectional bootstrap AllGather, opt-in via
-      // RCCL_BOOTSTRAP_BIDIR_NET / RCCL_BOOTSTRAP_BIDIR_ALLGATHER). NULL when disabled.
+      // Reverse ring (large-scale bidirectional IB OOB AllGather, opt-in via
+      // RCCL_BOOTSTRAP_BIDIR_NET). NULL when disabled. The socket OOB path is always
+      // bidirectional but does not need a reverse pair (TCP is full-duplex).
       void *revSendComm, *revRecvComm;
       ncclNetDeviceHandle_t *revSendDevHandle, *revRecvDevHandle;
     } net;
     struct {
-      struct ncclSocket recv;     // recv from prev (forward, existing)
-      struct ncclSocket send;     // send to next  (forward, existing)
-      struct ncclSocket revRecv;  // recv from next (reverse, only initialized when bidir is on)
-      struct ncclSocket revSend;  // send to prev   (reverse, only initialized when bidir is on)
+      struct ncclSocket recv; // recv from prev
+      struct ncclSocket send; // send to next
     } socket;
   };
 };
@@ -501,13 +524,12 @@ struct bootstrapListen_t {
       int dev;
       void* comm;
       char handle[NCCL_NET_HANDLE_MAXSIZE];
-      // Second listen handle for the reverse ring (only valid in bidirectional bootstrap).
+      // Second listen handle for the reverse ring (only valid in bidirectional IB bootstrap).
       void* revComm;
       char  revHandle[NCCL_NET_HANDLE_MAXSIZE];
     } net;
     struct {
-      struct ncclSocket fwd; // forward ring listen (existing role)
-      struct ncclSocket rev; // reverse ring listen (only initialized when bidir is on)
+      struct ncclSocket fwd; // forward ring listen
     } socket;
   };
 };
@@ -616,96 +638,72 @@ static ncclResult_t socketRingConnect(ncclSocketAddress* addr, struct ncclSocket
   return ncclSuccess;
 }
 
-// Set up the reverse direction of the bootstrap ring (revSend → prev, revRecv ← next).
-// Must be called *after* the forward ring is fully connected (so socketSendRecv on the
-// existing send/recv sockets is safe). Uses one forward-ring step to circulate the
-// freshly-created reverse listen address to the previous rank, then performs a mirrored
-// connect/accept handshake — symmetric across all ranks, no deadlock by construction.
+// Set up the reverse direction of the bootstrap ring for the IB OOB (net) path:
+// revSendComm → prev, revRecvComm ← next. Must be called *after* the forward ring is
+// fully connected. Uses one forward-ring exchange to circulate the freshly-created
+// reverse listen handle to the previous rank, then performs a mirrored connect/accept —
+// symmetric across all ranks, no deadlock by construction.
 //
-// Net path (Day-3): does the same dance over the IB plugin, swapping handles instead of
-// addresses. Only invoked when the corresponding bidir env var is enabled.
+// Socket OOB path no longer needs this: TCP is full-duplex and the new socketRingAllGather
+// drives both ring directions over the existing forward socket pair via socketDoubleSendRecv
+// (mirrors NCCL 2.28.7).
 static ncclResult_t bootstrapBidirRingSetup(struct ncclComm* comm, struct bootstrapState* state) {
-  // Skip cheaply when bidirectional bootstrap is disabled, pointless (≤2 ranks)
-  // or below the BOOTSTRAP_BIDIR_THRESHOLD. The threshold guards against
-  // wasted setup work on small comms where the std::thread / extra connect
-  // overhead would outweigh the AllGather speedup.
-  bool wantSocketBidir = bootstrapBidirEnabled(state->nranks, 0);
-  bool wantNetBidir    = bootstrapBidirEnabled(state->nranks, 1);
-  if (!wantSocketBidir && !wantNetBidir) return ncclSuccess;
+  // Cheap exit when bidirectional net bootstrap is disabled, pointless (≤2 ranks) or below
+  // the BOOTSTRAP_BIDIR_THRESHOLD: the IB plugin's regMr/QP setup is heavy enough that
+  // small comms regress without the threshold.
+  bool wantNetBidir = bootstrapBidirEnabled(state->nranks, 1);
+  if (!wantNetBidir) return ncclSuccess;
 
-  if (wantSocketBidir) {
-    // 1. Create the reverse listen socket; remember its address for the prev-side rank.
-    union ncclSocketAddress myRevAddr, prevRevAddr;
-    memset(&myRevAddr,   0, sizeof(myRevAddr));
-    memset(&prevRevAddr, 0, sizeof(prevRevAddr));
-    NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, socket.rev), &myRevAddr, ncclSocketTypeBootstrap));
+  // 1. Create the reverse listen on the same OOB net device; share its handle with prev.
+  char myRevHandle[NCCL_NET_HANDLE_MAXSIZE];
+  char prevRevHandle[NCCL_NET_HANDLE_MAXSIZE];
+  memset(myRevHandle,   0, NCCL_NET_HANDLE_MAXSIZE);
+  memset(prevRevHandle, 0, NCCL_NET_HANDLE_MAXSIZE);
+  NCCLCHECK(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev),
+                               STATE_LISTEN(state, net.revHandle), &STATE_LISTEN(state, net.revComm)));
+  memcpy(myRevHandle, STATE_LISTEN(state, net.revHandle), NCCL_NET_HANDLE_MAXSIZE);
 
-    // 2. One forward-ring exchange: send my reverse-listen address to next, receive prev's.
-    //    After this step every rank knows the reverse-listen address of its predecessor.
-    NCCLCHECK(socketSendRecv(&STATE_RING(state, socket.send), &myRevAddr, (int)sizeof(myRevAddr),
-                             &STATE_RING(state, socket.recv), &prevRevAddr, (int)sizeof(prevRevAddr)));
-
-    // 3. Mirrored ring connect: revSend connects to prev's revListen, revRecv accepts from next.
-    NCCLCHECK(socketRingConnect(&prevRevAddr,
-                                &STATE_RING(state, socket.revSend),
-                                &STATE_LISTEN(state, socket.rev),
-                                &STATE_RING(state, socket.revRecv),
-                                comm->magic, state->abortFlag));
-    INFO(NCCL_BOOTSTRAP, "Bootstrap bidirectional ring (socket) connected: nranks %d", state->nranks);
+  // 2. One forward-ring exchange of net handles using the existing forward sendComm/recvComm.
+  //    IB plugin requires registered memory for isend/irecv, so register both buffers
+  //    around the single exchange and unregister immediately.
+  {
+    void *sendH = NULL, *recvH = NULL;
+    ncclResult_t regRes = netReg(state->net, STATE_RING(state, net.sendComm), myRevHandle,   NCCL_NET_HANDLE_MAXSIZE, &sendH);
+    if (regRes == ncclSuccess) regRes = netReg(state->net, STATE_RING(state, net.recvComm), prevRevHandle, NCCL_NET_HANDLE_MAXSIZE, &recvH);
+    if (regRes == ncclSuccess) {
+      regRes = netSendRecv(state->net,
+                           STATE_RING(state, net.sendComm), myRevHandle,   NCCL_NET_HANDLE_MAXSIZE, sendH,
+                           STATE_RING(state, net.recvComm), prevRevHandle, NCCL_NET_HANDLE_MAXSIZE, recvH,
+                           /*tag*/0x7E5E5EB1, state->abortFlag);
+    }
+    if (sendH) netDereg(state->net, STATE_RING(state, net.sendComm), &sendH);
+    if (recvH) netDereg(state->net, STATE_RING(state, net.recvComm), &recvH);
+    if (regRes != ncclSuccess) return regRes;
   }
 
-  if (wantNetBidir) {
-    // 1. Create the reverse listen on the same OOB net device; share its handle with prev.
-    char myRevHandle[NCCL_NET_HANDLE_MAXSIZE];
-    char prevRevHandle[NCCL_NET_HANDLE_MAXSIZE];
-    memset(myRevHandle,   0, NCCL_NET_HANDLE_MAXSIZE);
-    memset(prevRevHandle, 0, NCCL_NET_HANDLE_MAXSIZE);
-    NCCLCHECK(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev),
-                                 STATE_LISTEN(state, net.revHandle), &STATE_LISTEN(state, net.revComm)));
-    memcpy(myRevHandle, STATE_LISTEN(state, net.revHandle), NCCL_NET_HANDLE_MAXSIZE);
-
-    // 2. One forward-ring exchange of net handles using the existing forward sendComm/recvComm.
-    //    IB plugin requires registered memory for isend/irecv, so register both buffers
-    //    around the single exchange and unregister immediately.
-    {
-      void *sendH = NULL, *recvH = NULL;
-      ncclResult_t regRes = netReg(state->net, STATE_RING(state, net.sendComm), myRevHandle,   NCCL_NET_HANDLE_MAXSIZE, &sendH);
-      if (regRes == ncclSuccess) regRes = netReg(state->net, STATE_RING(state, net.recvComm), prevRevHandle, NCCL_NET_HANDLE_MAXSIZE, &recvH);
-      if (regRes == ncclSuccess) {
-        regRes = netSendRecv(state->net,
-                             STATE_RING(state, net.sendComm), myRevHandle,   NCCL_NET_HANDLE_MAXSIZE, sendH,
-                             STATE_RING(state, net.recvComm), prevRevHandle, NCCL_NET_HANDLE_MAXSIZE, recvH,
-                             /*tag*/0x7E5E5EB1, state->abortFlag);
-      }
-      if (sendH) netDereg(state->net, STATE_RING(state, net.sendComm), &sendH);
-      if (recvH) netDereg(state->net, STATE_RING(state, net.recvComm), &recvH);
-      if (regRes != ncclSuccess) return regRes;
+  // 3. Mirrored connect: revSendComm connects to prev's revHandle, revRecvComm accepts from next.
+  //    Both connect() and accept() are non-blocking on the IB plugin (they return NULL until
+  //    the QP transition completes). Yielding the CPU each round avoids a 100% spin while
+  //    waiting on the network; checkAbort still fires often enough to react to teardown.
+  int abortCounter = 0;
+  while (!STATE_RING(state, net.revSendComm) || !STATE_RING(state, net.revRecvComm)) {
+    NCCLCHECK(checkAbort(state->abortFlag, &abortCounter));
+    bool madeProgress = false;
+    if (!STATE_RING(state, net.revSendComm)) {
+      void* prev = STATE_RING(state, net.revSendComm);
+      NCCLCHECK(state->net->connect(comm->netContext, STATE_LISTEN(state, net.dev), prevRevHandle,
+                                    &STATE_RING(state, net.revSendComm), &STATE_RING(state, net.revSendDevHandle)));
+      if (STATE_RING(state, net.revSendComm) != prev) madeProgress = true;
     }
-
-    // 3. Mirrored connect: revSendComm connects to prev's revHandle, revRecvComm accepts from next.
-    //    Both connect() and accept() are non-blocking on the IB plugin (they return NULL until
-    //    the QP transition completes). Yielding the CPU each round avoids a 100% spin while
-    //    waiting on the network; checkAbort still fires often enough to react to teardown.
-    int abortCounter = 0;
-    while (!STATE_RING(state, net.revSendComm) || !STATE_RING(state, net.revRecvComm)) {
-      NCCLCHECK(checkAbort(state->abortFlag, &abortCounter));
-      bool madeProgress = false;
-      if (!STATE_RING(state, net.revSendComm)) {
-        void* prev = STATE_RING(state, net.revSendComm);
-        NCCLCHECK(state->net->connect(comm->netContext, STATE_LISTEN(state, net.dev), prevRevHandle,
-                                      &STATE_RING(state, net.revSendComm), &STATE_RING(state, net.revSendDevHandle)));
-        if (STATE_RING(state, net.revSendComm) != prev) madeProgress = true;
-      }
-      if (!STATE_RING(state, net.revRecvComm)) {
-        void* prev = STATE_RING(state, net.revRecvComm);
-        NCCLCHECK(state->net->accept(STATE_LISTEN(state, net.revComm),
-                                     &STATE_RING(state, net.revRecvComm), &STATE_RING(state, net.revRecvDevHandle)));
-        if (STATE_RING(state, net.revRecvComm) != prev) madeProgress = true;
-      }
-      if (!madeProgress) sched_yield();
+    if (!STATE_RING(state, net.revRecvComm)) {
+      void* prev = STATE_RING(state, net.revRecvComm);
+      NCCLCHECK(state->net->accept(STATE_LISTEN(state, net.revComm),
+                                   &STATE_RING(state, net.revRecvComm), &STATE_RING(state, net.revRecvDevHandle)));
+      if (STATE_RING(state, net.revRecvComm) != prev) madeProgress = true;
     }
-    INFO(NCCL_BOOTSTRAP, "Bootstrap bidirectional ring (net) connected: nranks %d", state->nranks);
+    if (!madeProgress) sched_yield();
   }
+  INFO(NCCL_BOOTSTRAP, "Bootstrap bidirectional ring (net) connected: nranks %d", state->nranks);
   return ncclSuccess;
 }
 static ncclResult_t ringAllInfo(struct ncclComm* comm, struct bootstrapState* state,
@@ -1175,14 +1173,12 @@ exit:
   if (recvDataHandle) netDereg(net, recvComm, &recvDataHandle);
   return res;
 }
-static ncclResult_t socketRingAllGather(struct ncclSocket* sendSock, struct ncclSocket* recvSock, int rank, int nranks, char* data, int size) {
+// Classic unidirectional ring AllGather over the socket OOB path (N-1 rounds).
+// Kept as the fallback when BOOTSTRAP_BIDIR_ALLGATHER=0 is set explicitly.
+static ncclResult_t socketRingAllGatherUnidir(struct ncclSocket* sendSock, struct ncclSocket* recvSock, int rank, int nranks, char* data, int size) {
   ncclResult_t res = ncclSuccess;
   uint64_t tFirst = 0, tRest = 0;
-  /* Simple ring based AllGather
-   * At each step i receive data from (rank-i-1) from prev
-   * and send previous step's data from (rank-i) to next
-   */
-  TRACE(NCCL_BOOTSTRAP, "socketRingAllGather started");
+  TRACE(NCCL_BOOTSTRAP, "socketRingAllGatherUnidir started");
   BOOTSTRAP_PROF_OPEN(tFirst);
   for (int i = 0; i < nranks - 1; i++) {
     size_t rslice = (rank - i - 1 + nranks) % nranks;
@@ -1196,63 +1192,51 @@ static ncclResult_t socketRingAllGather(struct ncclSocket* sendSock, struct nccl
     }
   }
   BOOTSTRAP_PROF_CLOSE(tRest);
-  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "socketRingAllGather first message in %f (%f MB/sec), rest in %f (%f MB/sec)", tFirst / 1e9, (size / 1e6) / (tFirst / 1e9), tRest / 1e9, (nranks - 1) * (size / 1e6) / (tRest / 1e9));
+  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "socketRingAllGatherUnidir first message in %f (%f MB/sec), rest in %f (%f MB/sec)", tFirst / 1e9, (size / 1e6) / (tFirst / 1e9), tRest / 1e9, (nranks - 1) * (size / 1e6) / (tRest / 1e9));
 exit:
   return res;
 }
-// Bidirectional ring AllGather for the socket OOB path. Runs the existing forward loop
-// (rank → next, recv from prev) on a worker thread while the main thread runs a mirrored
-// backward loop (rank → prev, recv from next) on the second socket pair. Cuts the number
-// of latency-bound rounds from N-1 to ⌈(N-1)/2⌉, which is the dominant cost at >10k ranks.
-//
-// Step counts (provably cover all N slices, no duplicate work, no extra step needed):
-//   fwdSteps = N / 2          -- gathers slices [rank, rank-1, ..., rank-fwdSteps]
-//   bwdSteps = (N - 1) / 2    -- gathers slices [rank, rank+1, ..., rank+bwdSteps]
-// Sum: N - 1 for any N ≥ 1. Verified by hand for N ∈ {2,3,4,7,8,9}.
-static ncclResult_t socketBiDirRingAllGather(struct ncclSocket* sendSock, struct ncclSocket* recvSock,
-                                             struct ncclSocket* revSendSock, struct ncclSocket* revRecvSock,
-                                             int rank, int nranks, char* data, int size) {
-  ncclResult_t fwdRes = ncclSuccess;
-  ncclResult_t bwdRes = ncclSuccess;
+// Bidirectional ring AllGather (mirrors NCCL 2.28.7 socketRingAllGather):
+// each step exchanges two slices in opposite directions over the same forward
+// socket pair (TCP is full-duplex). Cuts latency from N-1 to N/2 rounds.
+static ncclResult_t socketRingAllGather(struct ncclSocket* nextSock, struct ncclSocket* prevSock, int rank, int nranks, char* data, int size) {
+  ncclResult_t res = ncclSuccess;
   uint64_t tFirst = 0, tRest = 0;
-  int fwdSteps = nranks / 2;
-  int bwdSteps = (nranks - 1) / 2;
-
-  TRACE(NCCL_BOOTSTRAP, "socketBiDirRingAllGather started: nranks=%d fwdSteps=%d bwdSteps=%d", nranks, fwdSteps, bwdSteps);
+  TRACE(NCCL_BOOTSTRAP, "socketRingAllGather started: rank=%d nranks=%d", rank, nranks);
+  int totalSteps = nranks / 2;
+  TRACE(NCCL_BOOTSTRAP, "bidirectional bootstrap: totalSteps=%d", totalSteps);
   BOOTSTRAP_PROF_OPEN(tFirst);
-
-  // Forward direction on a worker thread. We deliberately use std::thread (not std::async)
-  // so destructor semantics around exceptions don't surprise us; the lambda communicates
-  // failure exclusively via fwdRes (no exceptions thrown across the boundary).
-  std::thread fwdThread([&]() {
-    for (int i = 0; i < fwdSteps; i++) {
-      size_t sslice = (size_t)((rank - i + nranks) % nranks);
-      size_t rslice = (size_t)((rank - i - 1 + nranks) % nranks);
-      ncclResult_t r = socketSendRecv(sendSock, data + sslice * size, size,
-                                      recvSock, data + rslice * size, size);
-      if (r != ncclSuccess) { fwdRes = r; return; }
+  for (int step = 0; step < totalSteps; step++) {
+    // N ranks requires (N-1)/2 steps for the double ring algorithm. If N is even, the last step requires a single send/recv
+    bool isFinalUnidirectional = (step == totalSteps - 1) && (nranks % 2 == 0);
+    // Ring0: ring from previous to next
+    int sendSliceRing0 = (rank - step + nranks) % nranks;     // Send this slice to next neighbor
+    int recvSliceRing0 = (rank - step - 1 + nranks) % nranks; // Receive this slice from prev neighbor
+    // Ring1: ring from next to previous
+    int sendSliceRing1 = (rank + step) % nranks;              // Send this slice to prev neighbor
+    int recvSliceRing1 = (rank + step + 1) % nranks;          // Receive this slice from next neighbor
+    if (isFinalUnidirectional) {
+      // Final unidirectional step, only Ring0 is used
+      NCCLCHECKGOTO(socketSendRecv(nextSock, data + sendSliceRing0 * size, size, prevSock, data + recvSliceRing0 * size, size), res, exit);
+    } else {
+      // Bidirectional step: Ring0 and Ring1 are used simultaneously
+      struct ncclSocketOp ops[4] = {
+        {NCCL_SOCKET_SEND, nextSock, data + sendSliceRing0 * size, size, 0}, // Ring0: send to next
+        {NCCL_SOCKET_RECV, prevSock, data + recvSliceRing0 * size, size, 0}, // Ring0: recv from prev
+        {NCCL_SOCKET_SEND, prevSock, data + sendSliceRing1 * size, size, 0}, // Ring1: send to prev
+        {NCCL_SOCKET_RECV, nextSock, data + recvSliceRing1 * size, size, 0}  // Ring1: recv from next
+      };
+      NCCLCHECKGOTO(socketDoubleSendRecv(ops), res, exit);
     }
-  });
-
-  // Backward direction on the calling thread.
-  for (int i = 0; i < bwdSteps; i++) {
-    size_t sslice = (size_t)((rank + i) % nranks);
-    size_t rslice = (size_t)((rank + i + 1) % nranks);
-    ncclResult_t r = socketSendRecv(revSendSock, data + sslice * size, size,
-                                    revRecvSock, data + rslice * size, size);
-    if (i == 0) { BOOTSTRAP_PROF_CLOSE(tFirst); BOOTSTRAP_PROF_OPEN(tRest); }
-    if (r != ncclSuccess) { bwdRes = r; break; }
+    if (step == 0) {
+      BOOTSTRAP_PROF_CLOSE(tFirst);
+      BOOTSTRAP_PROF_OPEN(tRest);
+    }
   }
-  // If bwdSteps == 0 (N==2 fallback case below shouldn't reach here, but be safe) close
-  // the first-message timer using the forward thread's first step instead.
-  if (bwdSteps == 0) { BOOTSTRAP_PROF_CLOSE(tFirst); BOOTSTRAP_PROF_OPEN(tRest); }
-
-  fwdThread.join();
   BOOTSTRAP_PROF_CLOSE(tRest);
-  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE,
-        "socketBiDirRingAllGather first message in %f, rest in %f (steps fwd=%d bwd=%d)",
-        tFirst / 1e9, tRest / 1e9, fwdSteps, bwdSteps);
-  return (fwdRes != ncclSuccess) ? fwdRes : bwdRes;
+  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "socketRingAllGather first message in %f (%f MB/sec), rest in %f (%f MB/sec)", tFirst / 1e9, (size / 1e6) / (tFirst / 1e9), tRest / 1e9, (nranks - 1) * (size / 1e6) / (tRest / 1e9));
+exit:
+  return res;
 }
 
 // Net (IB OOB) variant of the bidirectional ring AllGather. Same step formula as above.
@@ -1362,15 +1346,10 @@ ncclResult_t bootstrapAllGather(void* commState, void* allData, int size) {
       NCCLCHECKGOTO(netRingAllGather(state->net, STATE_RING(state, net.sendComm), STATE_RING(state, net.recvComm), rank, nranks, (char*)allData, size, state->abortFlag), res, exit);
     }
   } else {
-    bool useBidir = bootstrapBidirEnabled(nranks, 0)
-                    && STATE_RING(state, socket.revSend).state == ncclSocketStateReady
-                    && STATE_RING(state, socket.revRecv).state == ncclSocketStateReady;
-    if (useBidir) {
-      NCCLCHECKGOTO(socketBiDirRingAllGather(&STATE_RING(state, socket.send), &STATE_RING(state, socket.recv),
-                                             &STATE_RING(state, socket.revSend), &STATE_RING(state, socket.revRecv),
-                                             rank, nranks, (char*)allData, size), res, exit);
-    } else {
+    if (bootstrapBidirEnabled(nranks, 0)) {
       NCCLCHECKGOTO(socketRingAllGather(&STATE_RING(state, socket.send), &STATE_RING(state, socket.recv), rank, nranks, (char*)allData, size), res, exit);
+    } else {
+      NCCLCHECKGOTO(socketRingAllGatherUnidir(&STATE_RING(state, socket.send), &STATE_RING(state, socket.recv), rank, nranks, (char*)allData, size), res, exit);
     }
   }
 exit:
@@ -1490,11 +1469,6 @@ ncclResult_t bootstrapClose(void* commState) {
     NCCLCHECK(ncclSocketClose(&STATE_RING(state, socket.send)));
     NCCLCHECK(ncclSocketClose(&STATE_RING(state, socket.recv)));
     NCCLCHECK(ncclSocketClose(&STATE_LISTEN(state, socket.fwd)));
-    // Reverse-ring sockets are only initialized when bidirectional bootstrap was set up;
-    // ncclSocketClose() is a no-op for sockets in state ncclSocketStateNone.
-    NCCLCHECK(ncclSocketClose(&STATE_RING(state, socket.revSend)));
-    NCCLCHECK(ncclSocketClose(&STATE_RING(state, socket.revRecv)));
-    NCCLCHECK(ncclSocketClose(&STATE_LISTEN(state, socket.rev)));
   }
   // close the p2p socket
   NCCLCHECK(ncclSocketClose(&STATE_LISTEN(state, peerSocket)));

--- a/projects/rccl/src/bootstrap.cc
+++ b/projects/rccl/src/bootstrap.cc
@@ -10,12 +10,14 @@
 #include "bootstrap.h"
 #include "net.h"
 #include <unistd.h>
+#include <sched.h>
 #include <sys/types.h>
 #include "proxy.h"
 #include "signals.h" // [RCCL]
 #include "param.h"
 #include "ras.h"
 #include <mutex>
+#include <thread>
 
 #define BOOTSTRAP_N_CHECK_ABORT           10000
 #define BOOTSTRAP_TAG_CONNECT             (0x1 << 31)
@@ -90,6 +92,35 @@ static int bootstrapNetInitDone = 0;
 static std::mutex bootstrapNetMutex;
 
 NCCL_PARAM(BootstrapNetEnable,"OOB_NET_ENABLE", 0);
+
+// Large-scale bootstrap: bidirectional ring AllGather (N/2 steps instead of N-1).
+// Honored by both NCCL_BOOTSTRAP_BIDIR_ALLGATHER (NCCL-style) and the RCCL_-prefixed env.
+// Defaults: enabled, but only kicks in for nranks >= BOOTSTRAP_BIDIR_THRESHOLD.
+NCCL_PARAM(BootstrapBidirAllGather, "BOOTSTRAP_BIDIR_ALLGATHER", 1);
+// Same optimization for the IB OOB / netRingAllGather path. Independently gated.
+NCCL_PARAM(BootstrapBidirNet,       "BOOTSTRAP_BIDIR_NET",       1);
+// Minimum nranks at which bidirectional bootstrap is worth its overhead.
+// Below the threshold the extra reverse-ring setup + std::thread fork dominates the
+// savings.  Measured on a 4-node MI300X cluster (RoCE + 10G TCP):
+//   N=8  single-node  : bidir ~40% slower in total bootstrap time → off
+//   N=16 (2 nodes)    : bidir ring_avg −39% TCP, −58% IB           → on
+//   N=32 (4 nodes)    : bidir ring_avg −36% TCP, −23% IB           → on
+// Force-enable on any N≥3 by setting BOOTSTRAP_BIDIR_THRESHOLD=0.
+// Force-disable per-path with BOOTSTRAP_BIDIR_ALLGATHER=0 / BOOTSTRAP_BIDIR_NET=0.
+NCCL_PARAM(BootstrapBidirThreshold, "BOOTSTRAP_BIDIR_THRESHOLD", 16);
+
+// Single source of truth for the "should we run bidirectional bootstrap?" decision.
+// kind: 0 = socket OOB, 1 = net (IB) OOB. Returns true when the user opted in,
+// the underlying transport matches, and the rank count clears the threshold.
+// Setup, dispatch and cleanup all consult this so they cannot disagree.
+static inline bool bootstrapBidirEnabled(int nranks, int kind) {
+  if (nranks < 3) return false;
+  int64_t thr = ncclParamBootstrapBidirThreshold();
+  if (thr > 0 && nranks < (int)thr) return false;
+  if (kind == 0) return (ncclParamBootstrapBidirAllGather() != 0) && !ncclParamBootstrapNetEnable();
+  if (kind == 1) return (ncclParamBootstrapBidirNet()       != 0) &&  ncclParamBootstrapNetEnable();
+  return false;
+}
 
 ncclResult_t bootstrapNetInit() {
   if (bootstrapNetInitDone == 0) {
@@ -450,10 +481,16 @@ struct bootstrapRing_t {
     struct {
       void *sendComm, *recvComm;
       ncclNetDeviceHandle_t *sendDevHandle, *recvDevHandle;
+      // Reverse ring (large-scale bidirectional bootstrap AllGather, opt-in via
+      // RCCL_BOOTSTRAP_BIDIR_NET / RCCL_BOOTSTRAP_BIDIR_ALLGATHER). NULL when disabled.
+      void *revSendComm, *revRecvComm;
+      ncclNetDeviceHandle_t *revSendDevHandle, *revRecvDevHandle;
     } net;
     struct {
-      struct ncclSocket recv;
-      struct ncclSocket send;
+      struct ncclSocket recv;     // recv from prev (forward, existing)
+      struct ncclSocket send;     // send to next  (forward, existing)
+      struct ncclSocket revRecv;  // recv from next (reverse, only initialized when bidir is on)
+      struct ncclSocket revSend;  // send to prev   (reverse, only initialized when bidir is on)
     } socket;
   };
 };
@@ -464,8 +501,14 @@ struct bootstrapListen_t {
       int dev;
       void* comm;
       char handle[NCCL_NET_HANDLE_MAXSIZE];
+      // Second listen handle for the reverse ring (only valid in bidirectional bootstrap).
+      void* revComm;
+      char  revHandle[NCCL_NET_HANDLE_MAXSIZE];
     } net;
-    struct ncclSocket socket; // socket to be used for the ring
+    struct {
+      struct ncclSocket fwd; // forward ring listen (existing role)
+      struct ncclSocket rev; // reverse ring listen (only initialized when bidir is on)
+    } socket;
   };
 };
 
@@ -570,6 +613,99 @@ static ncclResult_t socketRingConnect(ncclSocketAddress* addr, struct ncclSocket
   NCCLCHECK(ncclSocketInit(sendSocket, addr, magic, ncclSocketTypeBootstrap, abortFlag));
   NCCLCHECK(ncclSocketConnect(sendSocket));
   NCCLCHECK(bootstrapAccept(recvSocket, listenSock, abortFlag));
+  return ncclSuccess;
+}
+
+// Set up the reverse direction of the bootstrap ring (revSend → prev, revRecv ← next).
+// Must be called *after* the forward ring is fully connected (so socketSendRecv on the
+// existing send/recv sockets is safe). Uses one forward-ring step to circulate the
+// freshly-created reverse listen address to the previous rank, then performs a mirrored
+// connect/accept handshake — symmetric across all ranks, no deadlock by construction.
+//
+// Net path (Day-3): does the same dance over the IB plugin, swapping handles instead of
+// addresses. Only invoked when the corresponding bidir env var is enabled.
+static ncclResult_t bootstrapBidirRingSetup(struct ncclComm* comm, struct bootstrapState* state) {
+  // Skip cheaply when bidirectional bootstrap is disabled, pointless (≤2 ranks)
+  // or below the BOOTSTRAP_BIDIR_THRESHOLD. The threshold guards against
+  // wasted setup work on small comms where the std::thread / extra connect
+  // overhead would outweigh the AllGather speedup.
+  bool wantSocketBidir = bootstrapBidirEnabled(state->nranks, 0);
+  bool wantNetBidir    = bootstrapBidirEnabled(state->nranks, 1);
+  if (!wantSocketBidir && !wantNetBidir) return ncclSuccess;
+
+  if (wantSocketBidir) {
+    // 1. Create the reverse listen socket; remember its address for the prev-side rank.
+    union ncclSocketAddress myRevAddr, prevRevAddr;
+    memset(&myRevAddr,   0, sizeof(myRevAddr));
+    memset(&prevRevAddr, 0, sizeof(prevRevAddr));
+    NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, socket.rev), &myRevAddr, ncclSocketTypeBootstrap));
+
+    // 2. One forward-ring exchange: send my reverse-listen address to next, receive prev's.
+    //    After this step every rank knows the reverse-listen address of its predecessor.
+    NCCLCHECK(socketSendRecv(&STATE_RING(state, socket.send), &myRevAddr, (int)sizeof(myRevAddr),
+                             &STATE_RING(state, socket.recv), &prevRevAddr, (int)sizeof(prevRevAddr)));
+
+    // 3. Mirrored ring connect: revSend connects to prev's revListen, revRecv accepts from next.
+    NCCLCHECK(socketRingConnect(&prevRevAddr,
+                                &STATE_RING(state, socket.revSend),
+                                &STATE_LISTEN(state, socket.rev),
+                                &STATE_RING(state, socket.revRecv),
+                                comm->magic, state->abortFlag));
+    INFO(NCCL_BOOTSTRAP, "Bootstrap bidirectional ring (socket) connected: nranks %d", state->nranks);
+  }
+
+  if (wantNetBidir) {
+    // 1. Create the reverse listen on the same OOB net device; share its handle with prev.
+    char myRevHandle[NCCL_NET_HANDLE_MAXSIZE];
+    char prevRevHandle[NCCL_NET_HANDLE_MAXSIZE];
+    memset(myRevHandle,   0, NCCL_NET_HANDLE_MAXSIZE);
+    memset(prevRevHandle, 0, NCCL_NET_HANDLE_MAXSIZE);
+    NCCLCHECK(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev),
+                                 STATE_LISTEN(state, net.revHandle), &STATE_LISTEN(state, net.revComm)));
+    memcpy(myRevHandle, STATE_LISTEN(state, net.revHandle), NCCL_NET_HANDLE_MAXSIZE);
+
+    // 2. One forward-ring exchange of net handles using the existing forward sendComm/recvComm.
+    //    IB plugin requires registered memory for isend/irecv, so register both buffers
+    //    around the single exchange and unregister immediately.
+    {
+      void *sendH = NULL, *recvH = NULL;
+      ncclResult_t regRes = netReg(state->net, STATE_RING(state, net.sendComm), myRevHandle,   NCCL_NET_HANDLE_MAXSIZE, &sendH);
+      if (regRes == ncclSuccess) regRes = netReg(state->net, STATE_RING(state, net.recvComm), prevRevHandle, NCCL_NET_HANDLE_MAXSIZE, &recvH);
+      if (regRes == ncclSuccess) {
+        regRes = netSendRecv(state->net,
+                             STATE_RING(state, net.sendComm), myRevHandle,   NCCL_NET_HANDLE_MAXSIZE, sendH,
+                             STATE_RING(state, net.recvComm), prevRevHandle, NCCL_NET_HANDLE_MAXSIZE, recvH,
+                             /*tag*/0x7E5E5EB1, state->abortFlag);
+      }
+      if (sendH) netDereg(state->net, STATE_RING(state, net.sendComm), &sendH);
+      if (recvH) netDereg(state->net, STATE_RING(state, net.recvComm), &recvH);
+      if (regRes != ncclSuccess) return regRes;
+    }
+
+    // 3. Mirrored connect: revSendComm connects to prev's revHandle, revRecvComm accepts from next.
+    //    Both connect() and accept() are non-blocking on the IB plugin (they return NULL until
+    //    the QP transition completes). Yielding the CPU each round avoids a 100% spin while
+    //    waiting on the network; checkAbort still fires often enough to react to teardown.
+    int abortCounter = 0;
+    while (!STATE_RING(state, net.revSendComm) || !STATE_RING(state, net.revRecvComm)) {
+      NCCLCHECK(checkAbort(state->abortFlag, &abortCounter));
+      bool madeProgress = false;
+      if (!STATE_RING(state, net.revSendComm)) {
+        void* prev = STATE_RING(state, net.revSendComm);
+        NCCLCHECK(state->net->connect(comm->netContext, STATE_LISTEN(state, net.dev), prevRevHandle,
+                                      &STATE_RING(state, net.revSendComm), &STATE_RING(state, net.revSendDevHandle)));
+        if (STATE_RING(state, net.revSendComm) != prev) madeProgress = true;
+      }
+      if (!STATE_RING(state, net.revRecvComm)) {
+        void* prev = STATE_RING(state, net.revRecvComm);
+        NCCLCHECK(state->net->accept(STATE_LISTEN(state, net.revComm),
+                                     &STATE_RING(state, net.revRecvComm), &STATE_RING(state, net.revRecvDevHandle)));
+        if (STATE_RING(state, net.revRecvComm) != prev) madeProgress = true;
+      }
+      if (!madeProgress) sched_yield();
+    }
+    INFO(NCCL_BOOTSTRAP, "Bootstrap bidirectional ring (net) connected: nranks %d", state->nranks);
+  }
   return ncclSuccess;
 }
 static ncclResult_t ringAllInfo(struct ncclComm* comm, struct bootstrapState* state,
@@ -679,7 +815,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm) {
     memcpy(info.connectInfo.handle, STATE_LISTEN(state, net.handle), NCCL_NET_HANDLE_MAXSIZE);
   } else {
     // create socket for ring neightbor to contact mee
-    NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, socket), &info.connectInfo.addr, ncclSocketTypeBootstrap));
+    NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, socket.fwd), &info.connectInfo.addr, ncclSocketTypeBootstrap));
   }
   // Create socket for root to contact me using the root's magic
   int curr_root = rootIdFromRank(rank, nranks, nHandles);
@@ -732,8 +868,13 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm) {
                              &STATE_RING(state, net.sendComm), &STATE_RING(state, net.sendDevHandle),
                              &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle), state->abortFlag));
   } else {
-    NCCLCHECK(socketRingConnect(&nextPeer.addr, &STATE_RING(state, socket.send), &STATE_LISTEN(state, socket), &STATE_RING(state, socket.recv), comm->magic, state->abortFlag));
+    NCCLCHECK(socketRingConnect(&nextPeer.addr, &STATE_RING(state, socket.send), &STATE_LISTEN(state, socket.fwd), &STATE_RING(state, socket.recv), comm->magic, state->abortFlag));
   }
+
+  // Optionally bring up the second (reverse) ring used by the bidirectional bootstrap
+  // AllGather. Symmetric across all ranks; the existing forward ring is reused for a
+  // single address-exchange step, so no root-side change is required.
+  NCCLCHECK(bootstrapBidirRingSetup(comm, state));
 
   // AllGather all listen handlers
   // in case of failure, those resources will be free'd when calling bootstrapDestroy, so we can return immediatly
@@ -825,7 +966,7 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
     memcpy(info.handle, STATE_LISTEN(state, net.handle), NCCL_NET_HANDLE_MAXSIZE);
   } else {
     // create socket for ring neightbor to contact mee
-    NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, socket), &info.addr, ncclSocketTypeBootstrap));
+    NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, socket.fwd), &info.addr, ncclSocketTypeBootstrap));
   }
   // create a socket for others to reach out (P2P)
   union ncclSocketAddress peerSocketAddress;
@@ -845,8 +986,12 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
                                  &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle), state->abortFlag),
                   ret, fail);
   } else {
-    NCCLCHECK(socketRingConnect(&nextPeer.addr, &STATE_RING(state, socket.send), &STATE_LISTEN(state, socket), &STATE_RING(state, socket.recv), comm->magic, state->abortFlag));
+    NCCLCHECK(socketRingConnect(&nextPeer.addr, &STATE_RING(state, socket.send), &STATE_LISTEN(state, socket.fwd), &STATE_RING(state, socket.recv), comm->magic, state->abortFlag));
   }
+
+  // Mirror the bidirectional ring setup done in bootstrapInit so that split communicators
+  // can also benefit from the N/2-step AllGather.
+  NCCLCHECKGOTO(bootstrapBidirRingSetup(comm, state), ret, fail);
 
   NCCLCHECKGOTO(ncclCalloc(&state->peerP2pAddresses, nranks), ret, fail);
   memcpy(state->peerP2pAddresses + rank, &peerSocketAddress, sizeof(union ncclSocketAddress));
@@ -1055,6 +1200,142 @@ static ncclResult_t socketRingAllGather(struct ncclSocket* sendSock, struct nccl
 exit:
   return res;
 }
+// Bidirectional ring AllGather for the socket OOB path. Runs the existing forward loop
+// (rank → next, recv from prev) on a worker thread while the main thread runs a mirrored
+// backward loop (rank → prev, recv from next) on the second socket pair. Cuts the number
+// of latency-bound rounds from N-1 to ⌈(N-1)/2⌉, which is the dominant cost at >10k ranks.
+//
+// Step counts (provably cover all N slices, no duplicate work, no extra step needed):
+//   fwdSteps = N / 2          -- gathers slices [rank, rank-1, ..., rank-fwdSteps]
+//   bwdSteps = (N - 1) / 2    -- gathers slices [rank, rank+1, ..., rank+bwdSteps]
+// Sum: N - 1 for any N ≥ 1. Verified by hand for N ∈ {2,3,4,7,8,9}.
+static ncclResult_t socketBiDirRingAllGather(struct ncclSocket* sendSock, struct ncclSocket* recvSock,
+                                             struct ncclSocket* revSendSock, struct ncclSocket* revRecvSock,
+                                             int rank, int nranks, char* data, int size) {
+  ncclResult_t fwdRes = ncclSuccess;
+  ncclResult_t bwdRes = ncclSuccess;
+  uint64_t tFirst = 0, tRest = 0;
+  int fwdSteps = nranks / 2;
+  int bwdSteps = (nranks - 1) / 2;
+
+  TRACE(NCCL_BOOTSTRAP, "socketBiDirRingAllGather started: nranks=%d fwdSteps=%d bwdSteps=%d", nranks, fwdSteps, bwdSteps);
+  BOOTSTRAP_PROF_OPEN(tFirst);
+
+  // Forward direction on a worker thread. We deliberately use std::thread (not std::async)
+  // so destructor semantics around exceptions don't surprise us; the lambda communicates
+  // failure exclusively via fwdRes (no exceptions thrown across the boundary).
+  std::thread fwdThread([&]() {
+    for (int i = 0; i < fwdSteps; i++) {
+      size_t sslice = (size_t)((rank - i + nranks) % nranks);
+      size_t rslice = (size_t)((rank - i - 1 + nranks) % nranks);
+      ncclResult_t r = socketSendRecv(sendSock, data + sslice * size, size,
+                                      recvSock, data + rslice * size, size);
+      if (r != ncclSuccess) { fwdRes = r; return; }
+    }
+  });
+
+  // Backward direction on the calling thread.
+  for (int i = 0; i < bwdSteps; i++) {
+    size_t sslice = (size_t)((rank + i) % nranks);
+    size_t rslice = (size_t)((rank + i + 1) % nranks);
+    ncclResult_t r = socketSendRecv(revSendSock, data + sslice * size, size,
+                                    revRecvSock, data + rslice * size, size);
+    if (i == 0) { BOOTSTRAP_PROF_CLOSE(tFirst); BOOTSTRAP_PROF_OPEN(tRest); }
+    if (r != ncclSuccess) { bwdRes = r; break; }
+  }
+  // If bwdSteps == 0 (N==2 fallback case below shouldn't reach here, but be safe) close
+  // the first-message timer using the forward thread's first step instead.
+  if (bwdSteps == 0) { BOOTSTRAP_PROF_CLOSE(tFirst); BOOTSTRAP_PROF_OPEN(tRest); }
+
+  fwdThread.join();
+  BOOTSTRAP_PROF_CLOSE(tRest);
+  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE,
+        "socketBiDirRingAllGather first message in %f, rest in %f (steps fwd=%d bwd=%d)",
+        tFirst / 1e9, tRest / 1e9, fwdSteps, bwdSteps);
+  return (fwdRes != ncclSuccess) ? fwdRes : bwdRes;
+}
+
+// Net (IB OOB) variant of the bidirectional ring AllGather. Same step formula as above.
+//
+// IB-specific design notes:
+// - regMr is the dominant per-call cost on IB plugins (syscall + RNIC interaction).
+//   We register the four MRs concurrently (two per thread), so they pipeline with
+//   the connect/handshake of the very first netSendRecv on the other thread.
+// - Each comm owns its own QP (and PD on most plugins), so MRs are not shareable
+//   across comms; we must register the same data buffer four times.
+// - Forward-thread writes target slices [rank - N/2 .. rank - 1] (mod N), reverse
+//   target slices [rank + 1 .. rank + (N-1)/2]; rank itself is untouched. The two
+//   write sets are disjoint by construction, so the threads never race on memory.
+// - On any failure we still attempt to dereg every successfully-registered handle
+//   to avoid leaking pinned host memory; previous code path returned on the first
+//   regMr failure with prior MRs leaked.
+static ncclResult_t netBiDirRingAllGather(ncclNet_t* net,
+                                          void* sendComm, void* recvComm,
+                                          void* revSendComm, void* revRecvComm,
+                                          int rank, int nranks, char* data, int size,
+                                          volatile uint32_t* abortFlag) {
+  ncclResult_t fwdRes = ncclSuccess;
+  ncclResult_t bwdRes = ncclSuccess;
+  uint64_t tFirst = 0, tRest = 0;
+  int fwdSteps = nranks / 2;
+  int bwdSteps = (nranks - 1) / 2;
+
+  TRACE(NCCL_BOOTSTRAP, "netBiDirRingAllGather started: nranks=%d fwdSteps=%d bwdSteps=%d", nranks, fwdSteps, bwdSteps);
+  BOOTSTRAP_PROF_OPEN(tFirst);
+
+  // Forward direction: registers its own send/recv MRs and runs fwdSteps iterations.
+  std::thread fwdThread([&]() {
+    void *sendH = NULL, *recvH = NULL;
+    fwdRes = netReg(net, sendComm, data, nranks * size, &sendH);
+    if (fwdRes == ncclSuccess) fwdRes = netReg(net, recvComm, data, nranks * size, &recvH);
+    if (fwdRes == ncclSuccess) {
+      for (int i = 0; i < fwdSteps; i++) {
+        int tag = i; // forward tags stay 0..fwdSteps-1 (compatible with old netRingAllGather)
+        size_t sslice = (size_t)((rank - i + nranks) % nranks);
+        size_t rslice = (size_t)((rank - i - 1 + nranks) % nranks);
+        ncclResult_t r = netSendRecv(net, sendComm, data + sslice * size, size, sendH,
+                                     recvComm, data + rslice * size, size, recvH,
+                                     tag, abortFlag);
+        if (r != ncclSuccess) { fwdRes = r; break; }
+      }
+    }
+    if (sendH) netDereg(net, sendComm, &sendH);
+    if (recvH) netDereg(net, recvComm, &recvH);
+  });
+
+  // Reverse direction on the calling thread.
+  {
+    void *revSendH = NULL, *revRecvH = NULL;
+    bwdRes = netReg(net, revSendComm, data, nranks * size, &revSendH);
+    if (bwdRes == ncclSuccess) bwdRes = netReg(net, revRecvComm, data, nranks * size, &revRecvH);
+    if (bwdRes == ncclSuccess) {
+      for (int i = 0; i < bwdSteps; i++) {
+        // Tag space is per-QP, but we still keep them disjoint from forward tags
+        // (defensive against future plugin changes that may share a tag table).
+        int tag = i + fwdSteps + 1;
+        size_t sslice = (size_t)((rank + i) % nranks);
+        size_t rslice = (size_t)((rank + i + 1) % nranks);
+        ncclResult_t r = netSendRecv(net, revSendComm, data + sslice * size, size, revSendH,
+                                     revRecvComm, data + rslice * size, size, revRecvH,
+                                     tag, abortFlag);
+        if (i == 0) { BOOTSTRAP_PROF_CLOSE(tFirst); BOOTSTRAP_PROF_OPEN(tRest); }
+        if (r != ncclSuccess) { bwdRes = r; break; }
+      }
+    }
+    if (bwdSteps == 0) { BOOTSTRAP_PROF_CLOSE(tFirst); BOOTSTRAP_PROF_OPEN(tRest); }
+    if (revSendH) netDereg(net, revSendComm, &revSendH);
+    if (revRecvH) netDereg(net, revRecvComm, &revRecvH);
+  }
+
+  fwdThread.join();
+  BOOTSTRAP_PROF_CLOSE(tRest);
+  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE,
+        "netBiDirRingAllGather first message in %f, rest in %f (steps fwd=%d bwd=%d)",
+        tFirst / 1e9, tRest / 1e9, fwdSteps, bwdSteps);
+
+  return (fwdRes != ncclSuccess) ? fwdRes : bwdRes;
+}
+
 ncclResult_t bootstrapAllGather(void* commState, void* allData, int size) {
   ncclResult_t res = ncclSuccess;
   struct bootstrapState* state = (struct bootstrapState*)commState;
@@ -1066,9 +1347,31 @@ ncclResult_t bootstrapAllGather(void* commState, void* allData, int size) {
   uint64_t time = 0;
   BOOTSTRAP_PROF_OPEN(time);
   if (ncclParamBootstrapNetEnable()) {
-    NCCLCHECKGOTO(netRingAllGather(state->net, STATE_RING(state, net.sendComm), STATE_RING(state, net.recvComm), rank, nranks, (char*)allData, size, state->abortFlag), res, exit);
+    // Take the bidirectional path only when bootstrapBidirEnabled() agrees AND the
+    // reverse comms were actually set up (defensive against future code paths that
+    // may bypass bootstrapBidirRingSetup, e.g. shrunk/split comms).
+    bool useBidir = bootstrapBidirEnabled(nranks, 1)
+                    && STATE_RING(state, net.revSendComm) != NULL
+                    && STATE_RING(state, net.revRecvComm) != NULL;
+    if (useBidir) {
+      NCCLCHECKGOTO(netBiDirRingAllGather(state->net,
+                                          STATE_RING(state, net.sendComm), STATE_RING(state, net.recvComm),
+                                          STATE_RING(state, net.revSendComm), STATE_RING(state, net.revRecvComm),
+                                          rank, nranks, (char*)allData, size, state->abortFlag), res, exit);
+    } else {
+      NCCLCHECKGOTO(netRingAllGather(state->net, STATE_RING(state, net.sendComm), STATE_RING(state, net.recvComm), rank, nranks, (char*)allData, size, state->abortFlag), res, exit);
+    }
   } else {
-    NCCLCHECKGOTO(socketRingAllGather(&STATE_RING(state, socket.send), &STATE_RING(state, socket.recv), rank, nranks, (char*)allData, size), res, exit);
+    bool useBidir = bootstrapBidirEnabled(nranks, 0)
+                    && STATE_RING(state, socket.revSend).state == ncclSocketStateReady
+                    && STATE_RING(state, socket.revRecv).state == ncclSocketStateReady;
+    if (useBidir) {
+      NCCLCHECKGOTO(socketBiDirRingAllGather(&STATE_RING(state, socket.send), &STATE_RING(state, socket.recv),
+                                             &STATE_RING(state, socket.revSend), &STATE_RING(state, socket.revRecv),
+                                             rank, nranks, (char*)allData, size), res, exit);
+    } else {
+      NCCLCHECKGOTO(socketRingAllGather(&STATE_RING(state, socket.send), &STATE_RING(state, socket.recv), rank, nranks, (char*)allData, size), res, exit);
+    }
   }
 exit:
   BOOTSTRAP_PROF_CLOSE(time);
@@ -1179,10 +1482,19 @@ ncclResult_t bootstrapClose(void* commState) {
     NCCLCHECK(state->net->closeSend(STATE_RING(state, net.sendComm)));
     NCCLCHECK(state->net->closeRecv(STATE_RING(state, net.recvComm)));
     NCCLCHECK(state->net->closeListen(STATE_LISTEN(state, net.comm)));
+    // Reverse-direction net comms only exist when bidirectional bootstrap was enabled.
+    if (STATE_RING(state, net.revSendComm)) NCCLCHECK(state->net->closeSend(STATE_RING(state, net.revSendComm)));
+    if (STATE_RING(state, net.revRecvComm)) NCCLCHECK(state->net->closeRecv(STATE_RING(state, net.revRecvComm)));
+    if (STATE_LISTEN(state, net.revComm))   NCCLCHECK(state->net->closeListen(STATE_LISTEN(state, net.revComm)));
   } else {
     NCCLCHECK(ncclSocketClose(&STATE_RING(state, socket.send)));
     NCCLCHECK(ncclSocketClose(&STATE_RING(state, socket.recv)));
-    NCCLCHECK(ncclSocketClose(&STATE_LISTEN(state, socket)));
+    NCCLCHECK(ncclSocketClose(&STATE_LISTEN(state, socket.fwd)));
+    // Reverse-ring sockets are only initialized when bidirectional bootstrap was set up;
+    // ncclSocketClose() is a no-op for sockets in state ncclSocketStateNone.
+    NCCLCHECK(ncclSocketClose(&STATE_RING(state, socket.revSend)));
+    NCCLCHECK(ncclSocketClose(&STATE_RING(state, socket.revRecv)));
+    NCCLCHECK(ncclSocketClose(&STATE_LISTEN(state, socket.rev)));
   }
   // close the p2p socket
   NCCLCHECK(ncclSocketClose(&STATE_LISTEN(state, peerSocket)));

--- a/projects/rccl/src/bootstrap.cc
+++ b/projects/rccl/src/bootstrap.cc
@@ -23,6 +23,11 @@
 #define BOOTSTRAP_TAG_ALLGATHER           (0x1 << 30)
 #define BOOTSTRAP_TAG_COMMSPLIT           (0x1 << 29)
 #define BOOTSTRAP_TAG_INTRANODE_ALLGATHER (0x1 << 28)
+// Tag used to exchange reverse-ring listen handles during bidirectional NET
+// bootstrap setup (fallback path when no piggybacked handle is available).
+// Picked from the non-bit-shifted space so it cannot collide with the
+// BOOTSTRAP_TAG_* one-hot tags above.
+static constexpr uint32_t BOOTSTRAP_TAG_BIDIR_REV_HANDLE = 0x7E5E5EB1;
 
 #define BOOTSTRAP_INIT_TIME_CREATE 0
 #define BOOTSTRAP_INIT_TIME_SEND   1
@@ -90,43 +95,42 @@ static union ncclSocketAddress bootstrapNetIfAddr;
 static int bootstrapNetInitDone = 0;
 static std::mutex bootstrapNetMutex;
 
+// Net OOB transport (IB/OFI via net plugin): tristate (-1 auto by threshold, 0 off, 1 on).
+// Off by default; opt in explicitly via env var or set to -1 to use the threshold gate.
 NCCL_PARAM(BootstrapNetEnable,"OOB_NET_ENABLE", 0);
 
-// Large-scale bootstrap: bidirectional ring AllGather (N/2 steps instead of N-1).
-// Both the socket and the IB (net) OOB paths support a bidirectional implementation;
-// each is gated by its own env var. Socket bidir is enabled by default; net bidir is
-// opt-in until it shows stable total-time wins.
-//
-// Socket path mirrors upstream NCCL 2.28.7 (socketDoubleSendRecv + ncclSocketMultiOp
-// over the same forward socket pair: TCP is full-duplex). Has no setup overhead, so
-// it does not consult BOOTSTRAP_BIDIR_THRESHOLD — it is enabled whenever N ≥ 3.
-NCCL_PARAM(BootstrapBidirAllGather, "BOOTSTRAP_BIDIR_ALLGATHER", 1);
-// IB path runs a parallel reverse ring on a separate QP pair, so it does pay for
-// extra regMr + connect + accept. Keep it opt-in until the net path shows stable
-// total-time wins, while socket bidir remains enabled by BOOTSTRAP_BIDIR_ALLGATHER.
-NCCL_PARAM(BootstrapBidirNet,       "BOOTSTRAP_BIDIR_NET",       0);
-// Minimum nranks at which bidirectional IB bootstrap is worth its overhead.
-// Below the threshold the extra reverse-ring connect + regMr dominates the savings.
-// Measured on a 4-node MI300X cluster (RoCE + 10G TCP):
-//   N=8  single-node  : bidir ~40% slower in total bootstrap time → off
-//   N=16 (2 nodes)    : bidir ring_avg −58% IB                    → on
-//   N=32 (4 nodes)    : bidir ring_avg −23% IB                    → on
-// Force-enable on any N≥3 by setting NCCL_BOOTSTRAP_BIDIR_THRESHOLD=0.
-// Force-disable per-path with NCCL_BOOTSTRAP_BIDIR_ALLGATHER=0 / NCCL_BOOTSTRAP_BIDIR_NET=0.
-NCCL_PARAM(BootstrapBidirThreshold, "BOOTSTRAP_BIDIR_THRESHOLD", 16);
+// Bidirectional ring AllGather (N/2 steps). All three knobs are opt-in: socket-bidir
+// (BOOTSTRAP_BIDIR_ALLGATHER) is an on/off flag; net-bidir (BOOTSTRAP_BIDIR_NET) is a
+// tristate (-1 auto by threshold, 0 off, 1 on) and additionally requires net OOB to be
+// on. Defaults are all off; the threshold is consulted only when the corresponding
+// knob is set to -1 (auto).
+NCCL_PARAM(BootstrapBidirAllGather, "BOOTSTRAP_BIDIR_ALLGATHER",  0);
+NCCL_PARAM(BootstrapBidirNet,       "BOOTSTRAP_BIDIR_NET",        0);
+NCCL_PARAM(BootstrapBidirThreshold, "BOOTSTRAP_BIDIR_THRESHOLD", 128);
 
-// Single source of truth for the "should we run bidirectional bootstrap?" decision.
-// kind: 0 = socket OOB (no threshold, no extra setup), 1 = net (IB) OOB (threshold-gated,
-// pays for an extra QP pair). Setup, dispatch and cleanup all consult this so they
-// cannot disagree.
+// Returns true when net OOB transport (IB/OFI via net plugin) should be used.
+// Tristate: 1 = on, 0 = off (even above threshold), -1 = auto (threshold-gated).
+static inline bool bootstrapNetEnabledEffective(int nranks) {
+  int64_t v = ncclParamBootstrapNetEnable();
+  if (v == 0) return false;
+  if (v >= 1) return true;
+  // -1 (auto): threshold-gated
+  int64_t thr = ncclParamBootstrapBidirThreshold();
+  return thr > 0 && nranks >= (int)thr;
+}
+
+// kind: 0 = socket OOB, 1 = net (IB) OOB. Setup, dispatch and cleanup all consult this.
 static inline bool bootstrapBidirEnabled(int nranks, int kind) {
   if (nranks < 3) return false;
-  if (kind == 0) return (ncclParamBootstrapBidirAllGather() != 0) && !ncclParamBootstrapNetEnable();
+  bool netOn = bootstrapNetEnabledEffective(nranks);
+  if (kind == 0) return (ncclParamBootstrapBidirAllGather() != 0) && !netOn;
   if (kind == 1) {
-    if (!ncclParamBootstrapNetEnable()) return false;
+    if (!netOn) return false;
+    int64_t v = ncclParamBootstrapBidirNet();
+    if (v == 0) return false;
+    if (v >= 1) return true;
     int64_t thr = ncclParamBootstrapBidirThreshold();
-    if (thr > 0 && nranks < (int)thr) return false;
-    return ncclParamBootstrapBidirNet() != 0;
+    return thr > 0 && nranks >= (int)thr;
   }
   return false;
 }
@@ -181,7 +185,7 @@ static ncclResult_t checkAbort(volatile uint32_t* flag, int* cntr) {
   return ncclSuccess;
 }
 // send/recv functions
-static ncclResult_t netReg(ncclNet_t* net, void* comm, void* data, int size, void** handle) {
+static ncclResult_t netReg(ncclNet_t* net, void* comm, void* data, size_t size, void** handle) {
   NCCLCHECK(net->regMr(comm, data, size, NCCL_PTR_HOST, handle));
   return ncclSuccess;
 }
@@ -262,10 +266,25 @@ static ncclResult_t netMultiOp(ncclNet_t* net, struct ncclNetOp* ops, int numOps
     return ncclInvalidArgument;
   }
   for (int i = 0; i < numOps; i++) {
+    if (ops[i].op != NCCL_NET_OP_SEND && ops[i].op != NCCL_NET_OP_RECV) {
+      WARN("netMultiOp: invalid op %d at index %d", ops[i].op, i);
+      return ncclInvalidArgument;
+    }
     if (ops[i].comm == NULL) {
       WARN("netMultiOp: invalid comm at index %d", i);
       return ncclInvalidArgument;
     }
+    if (ops[i].size < 0) {
+      WARN("netMultiOp: invalid size %d at index %d", ops[i].size, i);
+      return ncclInvalidArgument;
+    }
+    if (ops[i].size > 0 && ops[i].data == NULL) {
+      WARN("netMultiOp: NULL data with size %d at index %d", ops[i].size, i);
+      return ncclInvalidArgument;
+    }
+    // Note: handle is allowed to be NULL — the Socket NET plugin's regMr returns
+    // success without populating mhandle (no MR concept on TCP). IB/OFI plugins
+    // produce a real handle. The plugin's isend/irecv handle this consistently.
     ops[i].req = NULL;
     ops[i].done = 0;
   }
@@ -273,10 +292,10 @@ static ncclResult_t netMultiOp(ncclNet_t* net, struct ncclNetOp* ops, int numOps
   int completed = 0;
   while (completed < numOps) {
     NCCLCHECK(checkAbort(abortFlag, &abortCounter));
-    bool madeProgress = false;
+    bool allIssued = true, madeProgress = false;
     for (int i = 0; i < numOps; i++) {
       if (ops[i].done) continue;
-      int prevDone = ops[i].done;
+      void* prevReq = ops[i].req;
       if (ops[i].op == NCCL_NET_OP_SEND) {
         NCCLCHECK(netIsend(net, ops[i].comm, ops[i].data, ops[i].size,
                            ops[i].handle, ops[i].tag, &ops[i].req, &ops[i].done));
@@ -284,9 +303,11 @@ static ncclResult_t netMultiOp(ncclNet_t* net, struct ncclNetOp* ops, int numOps
         NCCLCHECK(netIrecv(net, ops[i].comm, ops[i].data, ops[i].size,
                            ops[i].handle, ops[i].tag, &ops[i].req, &ops[i].done));
       }
-      if (ops[i].done && !prevDone) { completed++; madeProgress = true; }
+      if (ops[i].done) { completed++; madeProgress = true; }
+      else if (ops[i].req != prevReq) madeProgress = true;
+      if (!ops[i].done && ops[i].req == NULL) allIssued = false;
     }
-    if (!madeProgress) sched_yield();
+    if (allIssued && !madeProgress) sched_yield();
   }
   return ncclSuccess;
 }
@@ -343,13 +364,13 @@ static ncclResult_t socketDoubleSendRecv(struct ncclSocketOp ops[4]) {
 }
 
 // [RCCL] Was a union; now a struct so we can piggyback the reverse-ring listen handle
-// for IB bidir bootstrap inside the existing root rendezvous (which is O(1) per rank
+// for net bidir bootstrap inside the existing root rendezvous (which is O(1) per rank
 // and incurs no extra RTT). The 'fwd' member is the forward-ring connection target as
-// before (socket address for socket OOB, net handle for IB OOB). The 'revHandle' member
+// before (socket address for socket OOB, net handle for net OOB). The 'revHandle' member
 // is the reverse-ring listen handle this rank is offering; root forwards each rank's
 // revHandle to the next-1 rank in a single pass so that bootstrapBidirRingSetup can
 // connect/accept the reverse pair *without* an extra forward-ring netSendRecv exchange
-// (saving one full O(N)-latency step on the IB bidir init path).
+// (saving one full O(N)-latency step on the net bidir init path).
 struct ringConnectInfo {
   union {
     union ncclSocketAddress addr;
@@ -609,7 +630,7 @@ struct bootstrapRing_t {
     struct {
       void *sendComm, *recvComm;
       ncclNetDeviceHandle_t *sendDevHandle, *recvDevHandle;
-      // Reverse ring (large-scale bidirectional IB OOB AllGather, opt-in via
+      // Reverse ring (large-scale bidirectional net OOB AllGather, opt-in via
       // NCCL_BOOTSTRAP_BIDIR_NET). NULL when disabled. The socket OOB path is always
       // bidirectional but does not need a reverse pair (TCP is full-duplex).
       void *revSendComm, *revRecvComm;
@@ -793,7 +814,7 @@ static ncclResult_t socketRingConnect(ncclSocketAddress* addr, struct ncclSocket
   return ncclSuccess;
 }
 
-// Set up the reverse direction of the bootstrap ring for the IB OOB (net) path:
+// Set up the reverse direction of the bootstrap ring for the net OOB path:
 // revSendComm → prev, revRecvComm ← next. Must be called *after* the forward ring is
 // fully connected. Uses one forward-ring exchange to circulate the freshly-created
 // reverse listen handle to the previous rank, then performs a mirrored connect/accept —
@@ -817,6 +838,7 @@ static ncclResult_t bootstrapBidirRingSetupStart(struct ncclComm* comm, struct b
                                                  char prevRevHandleOut[NCCL_NET_HANDLE_MAXSIZE],
                                                  bool* startedOut) {
   *startedOut = false;
+  memset(prevRevHandleOut, 0, NCCL_NET_HANDLE_MAXSIZE);
   bool wantNetBidir = bootstrapBidirEnabled(state->nranks, 1);
   if (!wantNetBidir) return ncclSuccess;
 
@@ -834,9 +856,9 @@ static ncclResult_t bootstrapBidirRingSetupStart(struct ncclComm* comm, struct b
   if (memcmp(prevRevHandlePiggyback, zeros, NCCL_NET_HANDLE_MAXSIZE) == 0) return ncclSuccess;
   memcpy(prevRevHandleOut, prevRevHandlePiggyback, NCCL_NET_HANDLE_MAXSIZE);
 
-  // Issue the first non-blocking connect()/accept() so the IB QP transition starts now,
-  // overlapping with whatever local setup the caller does next (proxy/UDS/peer/RAS,
-  // and/or the forward-ring connect handshake).
+  // Issue the first non-blocking connect()/accept() so the transport-layer handshake
+  // starts now, overlapping with whatever local setup the caller does next
+  // (proxy/UDS/peer/RAS, and/or the forward-ring connect handshake).
   NCCLCHECK(state->net->connect(comm->netContext, STATE_LISTEN(state, net.dev), prevRevHandleOut,
                                 &STATE_RING(state, net.revSendComm), &STATE_RING(state, net.revSendDevHandle)));
   NCCLCHECK(state->net->accept(STATE_LISTEN(state, net.revComm),
@@ -856,16 +878,16 @@ static ncclResult_t bootstrapBidirRingSetupFinish(struct ncclComm* comm, struct 
     NCCLCHECK(checkAbort(state->abortFlag, &abortCounter));
     bool madeProgress = false;
     if (!STATE_RING(state, net.revSendComm)) {
-      void* prev = STATE_RING(state, net.revSendComm);
+      void* prevPtr = STATE_RING(state, net.revSendComm);
       NCCLCHECK(state->net->connect(comm->netContext, STATE_LISTEN(state, net.dev), (void*)prevRevHandle,
                                     &STATE_RING(state, net.revSendComm), &STATE_RING(state, net.revSendDevHandle)));
-      if (STATE_RING(state, net.revSendComm) != prev) madeProgress = true;
+      if (STATE_RING(state, net.revSendComm) != prevPtr) madeProgress = true;
     }
     if (!STATE_RING(state, net.revRecvComm)) {
-      void* prev = STATE_RING(state, net.revRecvComm);
+      void* prevPtr = STATE_RING(state, net.revRecvComm);
       NCCLCHECK(state->net->accept(STATE_LISTEN(state, net.revComm),
                                    &STATE_RING(state, net.revRecvComm), &STATE_RING(state, net.revRecvDevHandle)));
-      if (STATE_RING(state, net.revRecvComm) != prev) madeProgress = true;
+      if (STATE_RING(state, net.revRecvComm) != prevPtr) madeProgress = true;
     }
     if (!madeProgress) sched_yield();
   }
@@ -876,7 +898,7 @@ static ncclResult_t bootstrapBidirRingSetupFinish(struct ncclComm* comm, struct 
 static ncclResult_t bootstrapBidirRingSetup(struct ncclComm* comm, struct bootstrapState* state,
                                             const char* prevRevHandlePiggyback) {
   // Cheap exit when bidirectional net bootstrap is disabled, pointless (≤2 ranks) or below
-  // the BOOTSTRAP_BIDIR_THRESHOLD: the IB plugin's regMr/QP setup is heavy enough that
+  // the BOOTSTRAP_BIDIR_THRESHOLD: the net plugin's regMr/connect setup is heavy enough that
   // small comms regress without the threshold.
   bool wantNetBidir = bootstrapBidirEnabled(state->nranks, 1);
   if (!wantNetBidir) return ncclSuccess;
@@ -906,8 +928,7 @@ static ncclResult_t bootstrapBidirRingSetup(struct ncclComm* comm, struct bootst
     }
   }
   if (!havePiggyback) {
-    char myRevHandle[NCCL_NET_HANDLE_MAXSIZE];
-    memcpy(myRevHandle, STATE_LISTEN(state, net.revHandle), NCCL_NET_HANDLE_MAXSIZE);
+    char* myRevHandle = STATE_LISTEN(state, net.revHandle);
     void *sendH = NULL, *recvH = NULL;
     ncclResult_t regRes = netReg(state->net, STATE_RING(state, net.sendComm), myRevHandle,   NCCL_NET_HANDLE_MAXSIZE, &sendH);
     if (regRes == ncclSuccess) regRes = netReg(state->net, STATE_RING(state, net.recvComm), prevRevHandle, NCCL_NET_HANDLE_MAXSIZE, &recvH);
@@ -915,7 +936,7 @@ static ncclResult_t bootstrapBidirRingSetup(struct ncclComm* comm, struct bootst
       regRes = netSendRecv(state->net,
                            STATE_RING(state, net.sendComm), myRevHandle,   NCCL_NET_HANDLE_MAXSIZE, sendH,
                            STATE_RING(state, net.recvComm), prevRevHandle, NCCL_NET_HANDLE_MAXSIZE, recvH,
-                           /*tag*/0x7E5E5EB1, state->abortFlag);
+                           BOOTSTRAP_TAG_BIDIR_REV_HANDLE, state->abortFlag);
     }
     if (sendH) netDereg(state->net, STATE_RING(state, net.sendComm), &sendH);
     if (recvH) netDereg(state->net, STATE_RING(state, net.recvComm), &recvH);
@@ -924,6 +945,7 @@ static ncclResult_t bootstrapBidirRingSetup(struct ncclComm* comm, struct bootst
 
   return bootstrapBidirRingSetupFinish(comm, state, prevRevHandle);
 }
+
 static ncclResult_t ringAllInfo(struct ncclComm* comm, struct bootstrapState* state,
                                 union ncclSocketAddress* peerAddresss,
                                 union ncclSocketAddress* peerProxy, uint64_t* peerUDS,
@@ -966,7 +988,7 @@ static ncclResult_t ringAllInfo(struct ncclComm* comm, struct bootstrapState* st
 
 exit:
   free(ringData);
-  return ncclSuccess;
+  return res;
 }
 
 static ncclResult_t sendToRoot(struct ncclBootstrapHandle* handle, struct ncclComm* comm, struct extInfo* info) {
@@ -999,7 +1021,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm) {
   struct ringConnectInfo nextPeer;
   bool performRasAddRanks = true;
   struct rasRankInit* rasRanks = nullptr;
-  // Bidirectional IB OOB split-setup state. Stored at function scope so the prev
+  // Bidirectional net OOB split-setup state. Stored at function scope so the prev
   // revHandle survives across the local-setup overlap region between
   // bootstrapBidirRingSetupStart and bootstrapBidirRingSetupFinish.
   bool bidirSplitStarted = false;
@@ -1007,10 +1029,8 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm) {
   memset(bidirPrevRevHandle, 0, NCCL_NET_HANDLE_MAXSIZE);
 
   uint64_t timers[BOOTSTRAP_INIT_TIME_N] = {0};
-  // [RCCL] Whether to set up the IB-bidir reverse ring at all (gated by env + threshold +
-  // OOB net enabled). If true, we create the reverse listen *before* sendToRoot so its
-  // handle piggybacks the existing root rendezvous (no extra RTT).
-  bool wantNetBidir = ncclParamBootstrapNetEnable() && bootstrapBidirEnabled(nranks, 1);
+  // Multi-root rendezvous can't propagate revHandle cross-root; bidir requires nHandles==1.
+  bool wantNetBidir = (nHandles == 1) && bootstrapBidirEnabled(nranks, 1);
 
   NCCLCHECK(ncclCalloc(&state, 1));
   state->rank = rank;
@@ -1034,23 +1054,22 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm) {
   // get the ring connection info
   memset(&nextPeer, 0, sizeof(struct ringConnectInfo));
   BOOTSTRAP_PROF_OPEN(timers[BOOTSTRAP_INIT_TIME_CREATE]);
-  if (ncclParamBootstrapNetEnable()) {
+  if (bootstrapNetEnabledEffective(nranks)) {
     // Create net interface for other ranks to contact me (all gather)
     NCCLCHECK(netGetDevice(rank, comm, &STATE_LISTEN(state, net.dev)));
     NCCLCHECK(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev), STATE_LISTEN(state, net.handle), &STATE_LISTEN(state, net.comm)));
     memcpy(info.connectInfo.fwd.handle, STATE_LISTEN(state, net.handle), NCCL_NET_HANDLE_MAXSIZE);
-    // [RCCL] Eagerly create the reverse listen if we expect to use IB bidir bootstrap.
+    // [RCCL] Eagerly create the reverse listen if we expect to use net bidir bootstrap.
     // The cost (one IB listen ≈ 1ms) is paid here in parallel with the staggered sendToRoot
     // and the resulting handle is piggybacked into info.connectInfo.revHandle so that
     // bootstrapBidirRingSetup can skip its own netSendRecv handle exchange (~20ms saving
-    // dominated by 4× regMr/deregMr on the IB plugin).
+    // dominated by 4× regMr/deregMr on the net plugin).
     if (wantNetBidir) {
       NCCLCHECK(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev),
                                    STATE_LISTEN(state, net.revHandle), &STATE_LISTEN(state, net.revComm)));
       memcpy(info.connectInfo.revHandle, STATE_LISTEN(state, net.revHandle), NCCL_NET_HANDLE_MAXSIZE);
     }
   } else {
-    // create socket for ring neightbor to contact mee
     NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, socket.fwd), &info.connectInfo.fwd.addr, ncclSocketTypeBootstrap));
   }
   // Create socket for root to contact me using the root's magic
@@ -1102,7 +1121,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm) {
   // progress with local proxy/P2P socket setup below. This is intentionally single-
   // threaded: net connect/accept are plugin-level non-blocking calls, and socket uses
   // ncclSocket async mode plus ncclSocketReady() in the finish step.
-  if (ncclParamBootstrapNetEnable()) {
+  if (bootstrapNetEnabledEffective(nranks)) {
     int ringConnectDone = 0;
     NCCLCHECK(netRingConnectProgress(comm->netContext, state->net, &state->listen, nextPeer.fwd.handle,
                                      &STATE_RING(state, net.sendComm), &STATE_RING(state, net.sendDevHandle),
@@ -1111,14 +1130,14 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm) {
     NCCLCHECK(socketRingConnectStart(&nextPeer.fwd.addr, &STATE_RING(state, socket.send), &STATE_LISTEN(state, socket.fwd), &STATE_RING(state, socket.recv), comm->magic, state->abortFlag));
   }
 
-  // [RCCL] Bidirectional IB OOB: kick off the reverse-ring connect()/accept() now so
+  // [RCCL] Bidirectional net OOB: kick off the reverse-ring connect()/accept() now so
   // they overlap with both forward-ring connect and the local proxy/UDS/peer/RAS setup
   // below. This requires a piggybacked prev revHandle (delivered via the root rendezvous
   // or PMIx fast-path) so we can avoid the legacy netSendRecv handle exchange. When
   // piggyback isn't available (shrunk/split comms) we fall back below to the one-shot
   // bootstrapBidirRingSetup that does listen + handle exchange + connect/accept after
   // the forward ring is up.
-  if (ncclParamBootstrapNetEnable()) {
+  if (wantNetBidir) {
     NCCLCHECK(bootstrapBidirRingSetupStart(comm, state, nextPeer.revHandle, bidirPrevRevHandle, &bidirSplitStarted));
   }
 
@@ -1159,7 +1178,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm) {
   // Finish forward ring connect before using the ring in bootstrapBidirRingSetup and
   // ringAllInfo. By this point the connection handshake has overlapped with the local
   // setup above (proxy listen, UDS lookup, peer P2P listen and RAS payload creation).
-  if (ncclParamBootstrapNetEnable()) {
+  if (bootstrapNetEnabledEffective(nranks)) {
     NCCLCHECKGOTO(netRingConnectFinish(comm->netContext, state->net, &state->listen, nextPeer.fwd.handle,
                                        &STATE_RING(state, net.sendComm), &STATE_RING(state, net.sendDevHandle),
                                        &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle), state->abortFlag),
@@ -1178,7 +1197,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm) {
   // the legacy one-shot path which also does the listen + handle exchange.
   if (bidirSplitStarted) {
     NCCLCHECKGOTO(bootstrapBidirRingSetupFinish(comm, state, bidirPrevRevHandle), result, fail);
-  } else {
+  } else if (wantNetBidir) {
     NCCLCHECKGOTO(bootstrapBidirRingSetup(comm, state, nextPeer.revHandle), result, fail);
   }
 
@@ -1214,8 +1233,8 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   int rank = comm->rank;
   int nranks = comm->nRanks;
   int prev, next;
-  struct ringConnectInfo info;
-  struct ringConnectInfo nextPeer;
+  struct ringConnectInfo info = {};
+  struct ringConnectInfo nextPeer = {};
   struct ncclSocket* proxySocket = NULL;
   struct bootstrapState* state;
 
@@ -1232,12 +1251,12 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   next = parentRanks[(rank + 1) % nranks];
 
   // create a handle for the others to reach out to me
-  if (ncclParamBootstrapNetEnable()) {
+  if (bootstrapNetEnabledEffective(nranks)) {
     NCCLCHECKGOTO(netGetDevice(rank, comm, &STATE_LISTEN(state, net.dev)), ret, fail);
     NCCLCHECKGOTO(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev), STATE_LISTEN(state, net.handle), &STATE_LISTEN(state, net.comm)), ret, fail);
     memcpy(info.fwd.handle, STATE_LISTEN(state, net.handle), NCCL_NET_HANDLE_MAXSIZE);
   } else {
-    // create socket for ring neightbor to contact mee
+    // create socket for ring neighbor to contact me
     NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, socket.fwd), &info.fwd.addr, ncclSocketTypeBootstrap));
   }
   // create a socket for others to reach out (P2P)
@@ -1252,7 +1271,7 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   // Get addr from next rank using the parent's connections
   NCCLCHECKGOTO(bootstrapSend(parent->bootstrap, prev, BOOTSTRAP_TAG_COMMSPLIT, &info, sizeof(struct ringConnectInfo)), ret, fail);
   NCCLCHECKGOTO(bootstrapRecv(parent->bootstrap, next, BOOTSTRAP_TAG_COMMSPLIT, &nextPeer, sizeof(struct ringConnectInfo)), ret, fail);
-  if (ncclParamBootstrapNetEnable()) {
+  if (bootstrapNetEnabledEffective(nranks)) {
     NCCLCHECKGOTO(netRingConnect(comm->netContext, state->net, &state->listen, nextPeer.fwd.handle,
                                  &STATE_RING(state, net.sendComm), &STATE_RING(state, net.sendDevHandle),
                                  &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle), state->abortFlag),
@@ -1421,8 +1440,8 @@ static ncclResult_t netRingAllGather(ncclNet_t* net, void* sendComm, void* recvC
   uint64_t tFirst = 0, tRest = 0;
   void* sendDataHandle = NULL;
   void* recvDataHandle = NULL;
-  NCCLCHECKGOTO(netReg(net, sendComm, data, nranks * size, &sendDataHandle), res, exit);
-  NCCLCHECKGOTO(netReg(net, recvComm, data, nranks * size, &recvDataHandle), res, exit);
+  NCCLCHECKGOTO(netReg(net, sendComm, data, (size_t)nranks * size, &sendDataHandle), res, exit);
+  NCCLCHECKGOTO(netReg(net, recvComm, data, (size_t)nranks * size, &recvDataHandle), res, exit);
   /* Simple ring based AllGather
    * At each step i receive data from (rank-i-1) from prev
    * and send previous step's data from (rank-i) to next
@@ -1472,36 +1491,32 @@ static ncclResult_t socketRingAllGatherUnidir(struct ncclSocket* sendSock, struc
 exit:
   return res;
 }
-static ncclResult_t socketRingAllGather(struct ncclSocket* nextSock, struct ncclSocket* prevSock, int rank, int nranks, char* data, int size) {
+// Bidirectional ring AllGather over sockets, mirrors NCCL 2.28.7.
+// Single shared forward pair drives both ring directions via socketDoubleSendRecv
+// (TCP is full-duplex). Algorithmic ⌊N/2⌋ steps vs N-1 for unidirectional
+// (for even N the final step is single-directional, so total slices == N-1
+// in both even and odd cases).
+static ncclResult_t socketRingAllGather(struct ncclSocket* nextSock, struct ncclSocket* prevSock,
+                                        int rank, int nranks, char* data, int size) {
   ncclResult_t res = ncclSuccess;
   uint64_t tFirst = 0, tRest = 0;
-  /* Simple ring based AllGather
-   * At each step i receive data from (rank-i-1) from prev
-   * and send previous step's data from (rank-i) to next
-   */
   TRACE(NCCL_BOOTSTRAP, "socketRingAllGather started: rank=%d nranks=%d", rank, nranks);
   int totalSteps = nranks / 2;
-  TRACE(NCCL_BOOTSTRAP, "bidirectional bootstrap: totalSteps=%d", totalSteps);
   BOOTSTRAP_PROF_OPEN(tFirst);
   for (int step = 0; step < totalSteps; step++) {
-    // N ranks require (N-1)/2 steps for the double-ring algorithm. If N is even, the last step requires a single send/recv.
     bool isFinalUnidirectional = (step == totalSteps - 1) && (nranks % 2 == 0);
-    // Ring0: ring from previous to next
-    int sendSliceRing0 = (rank - step + nranks) % nranks;      // Send this slice to next neighbor
-    int recvSliceRing0 = (rank - step - 1 + nranks) % nranks;  // Receive this slice from prev neighbor
-    // Ring1: ring from next to previous
-    int sendSliceRing1 = (rank + step) % nranks;               // Send this slice to prev neighbor
-    int recvSliceRing1 = (rank + step + 1) % nranks;           // Receive this slice from next neighbor
+    int sendSliceRing0 = (rank - step + nranks) % nranks;
+    int recvSliceRing0 = (rank - step - 1 + nranks) % nranks;
+    int sendSliceRing1 = (rank + step) % nranks;
+    int recvSliceRing1 = (rank + step + 1) % nranks;
     if (isFinalUnidirectional) {
-      // Final unidirectional step, only Ring0 is used
       NCCLCHECKGOTO(socketSendRecv(nextSock, data + sendSliceRing0 * size, size, prevSock, data + recvSliceRing0 * size, size), res, exit);
     } else {
-      // Bidirectional step: Ring0 and Ring1 are used simultaneously
       struct ncclSocketOp ops[4] = {
-        {NCCL_SOCKET_SEND, nextSock, data + sendSliceRing0 * size, size, 0},  // Ring0: send to next
-        {NCCL_SOCKET_RECV, prevSock, data + recvSliceRing0 * size, size, 0},  // Ring0: recv from prev
-        {NCCL_SOCKET_SEND, prevSock, data + sendSliceRing1 * size, size, 0},  // Ring1: send to prev
-        {NCCL_SOCKET_RECV, nextSock, data + recvSliceRing1 * size, size, 0}   // Ring1: recv from next
+        {NCCL_SOCKET_SEND, nextSock, data + sendSliceRing0 * size, size, 0},
+        {NCCL_SOCKET_RECV, prevSock, data + recvSliceRing0 * size, size, 0},
+        {NCCL_SOCKET_SEND, prevSock, data + sendSliceRing1 * size, size, 0},
+        {NCCL_SOCKET_RECV, nextSock, data + recvSliceRing1 * size, size, 0}
       };
       NCCLCHECKGOTO(socketDoubleSendRecv(ops), res, exit);
     }
@@ -1511,12 +1526,17 @@ static ncclResult_t socketRingAllGather(struct ncclSocket* nextSock, struct nccl
     }
   }
   BOOTSTRAP_PROF_CLOSE(tRest);
-  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "socketRingAllGather first message in %f (%f MB/sec), rest in %f (%f MB/sec)", tFirst / 1e9, (size / 1e6) / (tFirst / 1e9), tRest / 1e9, (nranks - 1) * (size / 1e6) / (tRest / 1e9));
+  // Reported numerator is per-rank "useful AllGather payload" (N-1 slices), not wire bytes,
+  // so it stays comparable across the unidir/bidir variants (which exchange the same total
+  // payload, just split across one vs two directions). For the first-step bandwidth we count
+  // the two slices actually delivered in that step (vs one in the unidir variant), otherwise
+  // the bidir "first MB/sec" would read as half of the true rate.
+  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "socketRingAllGather first message in %f (%f MB/sec), rest in %f (%f MB/sec)", tFirst / 1e9, (2.0 * size / 1e6) / (tFirst / 1e9), tRest / 1e9, (nranks - 1) * (size / 1e6) / (tRest / 1e9));
 exit:
   return res;
 }
 
-// Net (IB OOB) variant of the bidirectional ring AllGather. Mirrors the structure
+// Net OOB variant of the bidirectional ring AllGather. Mirrors the structure
 // of socketRingAllGather (the upstream NCCL 2.28.7 socket variant): totalSteps = N/2,
 // each step exchanges two slices in opposite directions, last step is a single
 // netSendRecv when N is even.
@@ -1547,10 +1567,10 @@ static ncclResult_t netBiDirRingAllGather(ncclNet_t* net,
 
   TRACE(NCCL_BOOTSTRAP, "netBiDirRingAllGather started: rank=%d nranks=%d totalSteps=%d", rank, nranks, totalSteps);
 
-  res = netReg(net, sendComm, data, nranks * size, &sendH);
-  if (res == ncclSuccess) res = netReg(net, recvComm, data, nranks * size, &recvH);
-  if (res == ncclSuccess) res = netReg(net, revSendComm, data, nranks * size, &revSendH);
-  if (res == ncclSuccess) res = netReg(net, revRecvComm, data, nranks * size, &revRecvH);
+  res = netReg(net, sendComm, data, (size_t)nranks * size, &sendH);
+  if (res == ncclSuccess) res = netReg(net, recvComm, data, (size_t)nranks * size, &recvH);
+  if (res == ncclSuccess) res = netReg(net, revSendComm, data, (size_t)nranks * size, &revSendH);
+  if (res == ncclSuccess) res = netReg(net, revRecvComm, data, (size_t)nranks * size, &revRecvH);
   if (res != ncclSuccess) goto cleanup;
 
   BOOTSTRAP_PROF_OPEN(tFirst);
@@ -1585,9 +1605,12 @@ static ncclResult_t netBiDirRingAllGather(ncclNet_t* net,
     }
   }
   BOOTSTRAP_PROF_CLOSE(tRest);
+  // Numerator convention matches socketRingAllGather: per-rank useful AllGather payload
+  // (N-1 slices), so the metric is comparable across unidir/bidir variants. First-step
+  // numerator is 2*size because the first bidir step delivers two slices (one per direction).
   TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE,
         "netBiDirRingAllGather first message in %f (%f MB/sec), rest in %f (%f MB/sec)",
-        tFirst / 1e9, (size / 1e6) / (tFirst / 1e9), tRest / 1e9, (nranks - 1) * (size / 1e6) / (tRest / 1e9));
+        tFirst / 1e9, (2.0 * size / 1e6) / (tFirst / 1e9), tRest / 1e9, (nranks - 1) * (size / 1e6) / (tRest / 1e9));
 
 cleanup:
   // Best-effort cleanup: try every dereg even if some failed (avoids leaking pinned memory).
@@ -1608,7 +1631,7 @@ ncclResult_t bootstrapAllGather(void* commState, void* allData, int size) {
 
   uint64_t time = 0;
   BOOTSTRAP_PROF_OPEN(time);
-  if (ncclParamBootstrapNetEnable()) {
+  if (bootstrapNetEnabledEffective(nranks)) {
     // Take the bidirectional path only when bootstrapBidirEnabled() agrees AND the
     // reverse comms were actually set up (defensive against future code paths that
     // may bypass bootstrapBidirRingSetup, e.g. shrunk/split comms).
@@ -1625,14 +1648,15 @@ ncclResult_t bootstrapAllGather(void* commState, void* allData, int size) {
     }
   } else {
     if (bootstrapBidirEnabled(nranks, 0)) {
-      NCCLCHECKGOTO(socketRingAllGather(&STATE_RING(state, socket.send), &STATE_RING(state, socket.recv), rank, nranks, (char*)allData, size), res, exit);
+      NCCLCHECKGOTO(socketRingAllGather(&STATE_RING(state, socket.send), &STATE_RING(state, socket.recv),
+                                        rank, nranks, (char*)allData, size), res, exit);
     } else {
       NCCLCHECKGOTO(socketRingAllGatherUnidir(&STATE_RING(state, socket.send), &STATE_RING(state, socket.recv), rank, nranks, (char*)allData, size), res, exit);
     }
   }
 exit:
   BOOTSTRAP_PROF_CLOSE(time);
-  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "bootstrapAllGather for %d B done in %f sec: %f MB/sec", size, time / 1e9, (nranks * size / 1e6) / (time / 1e9));
+  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "bootstrapAllGather for %d B done in %f sec: %f MB/sec", size, time / 1e9, ((size_t)nranks * size / 1e6) / (time / 1e9));
   TRACE(NCCL_BOOTSTRAP, "rank %d nranks %d size %d - AllGather DONE", rank, nranks, size);
   return res;
 }
@@ -1684,7 +1708,16 @@ ncclResult_t bootstrapIntraNodeAllGather(void* commState, int* ranks, int rank, 
   NCCLCHECK(socketConnect(commState, nextRank, BOOTSTRAP_TAG_INTRANODE_ALLGATHER, &sendSocket));
   NCCLCHECK(socketAccept(commState, prevRank, BOOTSTRAP_TAG_INTRANODE_ALLGATHER, &recvSocket));
 
-  NCCLCHECK(socketRingAllGather(&sendSocket, &recvSocket, rank, nranks, (char*)allData, size));
+  // Intra-node AllGather is socket-only and so cannot reuse bootstrapBidirEnabled
+  // (its `!netOn` clause is geared to inter-node OOB selection). Gate purely on the
+  // BOOTSTRAP_BIDIR_ALLGATHER opt-in; socketRingAllGather handles nranks<3 itself
+  // (nranks==2 → single bidirectional socketSendRecv; nranks==1 is short-circuited
+  // earlier in this function).
+  if (ncclParamBootstrapBidirAllGather() != 0) {
+    NCCLCHECK(socketRingAllGather(&sendSocket, &recvSocket, rank, nranks, (char*)allData, size));
+  } else {
+    NCCLCHECK(socketRingAllGatherUnidir(&sendSocket, &recvSocket, rank, nranks, (char*)allData, size));
+  }
 
   NCCLCHECK(ncclSocketClose(&sendSocket));
   NCCLCHECK(ncclSocketClose(&recvSocket));
@@ -1711,7 +1744,7 @@ ncclResult_t bootstrapIntraNodeBroadcast(void* commState, int* ranks, int rank, 
   BOOTSTRAP_PROF_OPEN(time);
   NCCLCHECK(bootstrapP2PBroadcast(commState, ranks, rank, nranks, root, bcastData, size));
   BOOTSTRAP_PROF_CLOSE(time);
-  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "bootstrapIntraNodeBroadcast for %d B done in %f sec: %f MB/sec", size, time / 1e9, (nranks * size / 1e6) / (time / 1e9));
+  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "bootstrapIntraNodeBroadcast for %d B done in %f sec: %f MB/sec", size, time / 1e9, ((size_t)nranks * size / 1e6) / (time / 1e9));
   return ncclSuccess;
 }
 ncclResult_t bootstrapBroadcast(void* commState, int rank, int nranks, int root, void* bcastData, int size) {
@@ -1727,6 +1760,7 @@ ncclResult_t bootstrapClose(void* commState) {
   if (commState == NULL)
     return ncclSuccess;
   struct bootstrapState* state = (struct bootstrapState*)commState;
+  int nranks = state->nranks;
   // close unexpected and return an error if we are not aborting and still operations in the pipe
   if (state->unexpectedConnections != NULL) {
     unexpectedFree(state);
@@ -1735,7 +1769,7 @@ ncclResult_t bootstrapClose(void* commState) {
       return ncclInternalError;
     }
   }
-  if (ncclParamBootstrapNetEnable()) {
+  if (bootstrapNetEnabledEffective(nranks)) {
     NCCLCHECK(state->net->closeSend(STATE_RING(state, net.sendComm)));
     NCCLCHECK(state->net->closeRecv(STATE_RING(state, net.recvComm)));
     NCCLCHECK(state->net->closeListen(STATE_LISTEN(state, net.comm)));

--- a/projects/rccl/src/bootstrap.cc
+++ b/projects/rccl/src/bootstrap.cc
@@ -17,7 +17,6 @@
 #include "param.h"
 #include "ras.h"
 #include <mutex>
-#include <thread>
 
 #define BOOTSTRAP_N_CHECK_ABORT           10000
 #define BOOTSTRAP_TAG_CONNECT             (0x1 << 31)
@@ -233,6 +232,61 @@ static ncclResult_t netSendRecv(ncclNet_t* net, void* sendComm, void* sendData, 
       NCCLCHECK(netIsend(net, sendComm, sendData, sendSize, sendDataHandle, tag, &sendReq, &doneSend));
     }
   } while (!doneSend || !doneRecv);
+  return ncclSuccess;
+}
+
+#define NCCL_NET_OP_SEND 0
+#define NCCL_NET_OP_RECV 1
+
+// Net analogue of struct ncclSocketOp / ncclSocketMultiOp: drives an arbitrary number of
+// non-blocking netIsend/netIrecv operations to completion in a single thread by round-robin
+// polling. Used by the bidirectional bootstrap AllGather to overlap send/recv on both ring
+// directions across the four IB comms (forward sendComm/recvComm + reverse pair) without
+// spawning std::thread. MRs must be pre-registered by the caller (handle field).
+struct ncclNetOp {
+  int op;        // NCCL_NET_OP_SEND or NCCL_NET_OP_RECV
+  void* comm;    // send or recv comm to operate on
+  void* data;    // data pointer (must lie inside the buffer registered as 'handle')
+  int size;      // payload size
+  void* handle;  // pre-registered MR handle for 'data'
+  int tag;       // IB tag
+  void* req;     // in-flight NCCL net request (set internally)
+  int done;      // completion flag (set internally)
+};
+
+static ncclResult_t netMultiOp(ncclNet_t* net, struct ncclNetOp* ops, int numOps,
+                               volatile uint32_t* abortFlag) {
+  if (ops == NULL || numOps <= 0) {
+    WARN("netMultiOp: invalid arguments ops=%p numOps=%d", ops, numOps);
+    return ncclInvalidArgument;
+  }
+  for (int i = 0; i < numOps; i++) {
+    if (ops[i].comm == NULL) {
+      WARN("netMultiOp: invalid comm at index %d", i);
+      return ncclInvalidArgument;
+    }
+    ops[i].req = NULL;
+    ops[i].done = 0;
+  }
+  int abortCounter = 0;
+  int completed = 0;
+  while (completed < numOps) {
+    NCCLCHECK(checkAbort(abortFlag, &abortCounter));
+    bool madeProgress = false;
+    for (int i = 0; i < numOps; i++) {
+      if (ops[i].done) continue;
+      int prevDone = ops[i].done;
+      if (ops[i].op == NCCL_NET_OP_SEND) {
+        NCCLCHECK(netIsend(net, ops[i].comm, ops[i].data, ops[i].size,
+                           ops[i].handle, ops[i].tag, &ops[i].req, &ops[i].done));
+      } else {
+        NCCLCHECK(netIrecv(net, ops[i].comm, ops[i].data, ops[i].size,
+                           ops[i].handle, ops[i].tag, &ops[i].req, &ops[i].done));
+      }
+      if (ops[i].done && !prevDone) { completed++; madeProgress = true; }
+    }
+    if (!madeProgress) sched_yield();
+  }
   return ncclSuccess;
 }
 
@@ -1196,35 +1250,36 @@ static ncclResult_t socketRingAllGatherUnidir(struct ncclSocket* sendSock, struc
 exit:
   return res;
 }
-// Bidirectional ring AllGather (mirrors NCCL 2.28.7 socketRingAllGather):
-// each step exchanges two slices in opposite directions over the same forward
-// socket pair (TCP is full-duplex). Cuts latency from N-1 to N/2 rounds.
 static ncclResult_t socketRingAllGather(struct ncclSocket* nextSock, struct ncclSocket* prevSock, int rank, int nranks, char* data, int size) {
   ncclResult_t res = ncclSuccess;
   uint64_t tFirst = 0, tRest = 0;
+  /* Simple ring based AllGather
+   * At each step i receive data from (rank-i-1) from prev
+   * and send previous step's data from (rank-i) to next
+   */
   TRACE(NCCL_BOOTSTRAP, "socketRingAllGather started: rank=%d nranks=%d", rank, nranks);
   int totalSteps = nranks / 2;
   TRACE(NCCL_BOOTSTRAP, "bidirectional bootstrap: totalSteps=%d", totalSteps);
   BOOTSTRAP_PROF_OPEN(tFirst);
   for (int step = 0; step < totalSteps; step++) {
-    // N ranks requires (N-1)/2 steps for the double ring algorithm. If N is even, the last step requires a single send/recv
+    // N ranks requires (N-1)/2 steps for the double ring  algorithm. If N is even, the last step is requires a single send/recv
     bool isFinalUnidirectional = (step == totalSteps - 1) && (nranks % 2 == 0);
     // Ring0: ring from previous to next
-    int sendSliceRing0 = (rank - step + nranks) % nranks;     // Send this slice to next neighbor
-    int recvSliceRing0 = (rank - step - 1 + nranks) % nranks; // Receive this slice from prev neighbor
+    int sendSliceRing0 = (rank - step + nranks) % nranks;      // Send this slice to next neighbor
+    int recvSliceRing0 = (rank - step - 1 + nranks) % nranks;  // Receive this slice from prev neighbor
     // Ring1: ring from next to previous
-    int sendSliceRing1 = (rank + step) % nranks;              // Send this slice to prev neighbor
-    int recvSliceRing1 = (rank + step + 1) % nranks;          // Receive this slice from next neighbor
+    int sendSliceRing1 = (rank + step) % nranks;               // Send this slice to prev neighbor
+    int recvSliceRing1 = (rank + step + 1) % nranks;           // Receive this slice from next neighbor
     if (isFinalUnidirectional) {
       // Final unidirectional step, only Ring0 is used
       NCCLCHECKGOTO(socketSendRecv(nextSock, data + sendSliceRing0 * size, size, prevSock, data + recvSliceRing0 * size, size), res, exit);
     } else {
       // Bidirectional step: Ring0 and Ring1 are used simultaneously
       struct ncclSocketOp ops[4] = {
-        {NCCL_SOCKET_SEND, nextSock, data + sendSliceRing0 * size, size, 0}, // Ring0: send to next
-        {NCCL_SOCKET_RECV, prevSock, data + recvSliceRing0 * size, size, 0}, // Ring0: recv from prev
-        {NCCL_SOCKET_SEND, prevSock, data + sendSliceRing1 * size, size, 0}, // Ring1: send to prev
-        {NCCL_SOCKET_RECV, nextSock, data + recvSliceRing1 * size, size, 0}  // Ring1: recv from next
+        {NCCL_SOCKET_SEND, nextSock, data + sendSliceRing0 * size, size, 0},  // Ring0: send to next
+        {NCCL_SOCKET_RECV, prevSock, data + recvSliceRing0 * size, size, 0},  // Ring0: recv from prev
+        {NCCL_SOCKET_SEND, prevSock, data + sendSliceRing1 * size, size, 0},  // Ring1: send to prev
+        {NCCL_SOCKET_RECV, nextSock, data + recvSliceRing1 * size, size, 0}   // Ring1: recv from next
       };
       NCCLCHECKGOTO(socketDoubleSendRecv(ops), res, exit);
     }
@@ -1239,85 +1294,86 @@ exit:
   return res;
 }
 
-// Net (IB OOB) variant of the bidirectional ring AllGather. Same step formula as above.
+// Net (IB OOB) variant of the bidirectional ring AllGather. Mirrors the structure
+// of socketRingAllGather (the upstream NCCL 2.28.7 socket variant): totalSteps = N/2,
+// each step exchanges two slices in opposite directions, last step is a single
+// netSendRecv when N is even.
 //
 // IB-specific design notes:
-// - regMr is the dominant per-call cost on IB plugins (syscall + RNIC interaction).
-//   We register the four MRs concurrently (two per thread), so they pipeline with
-//   the connect/handshake of the very first netSendRecv on the other thread.
 // - Each comm owns its own QP (and PD on most plugins), so MRs are not shareable
-//   across comms; we must register the same data buffer four times.
-// - Forward-thread writes target slices [rank - N/2 .. rank - 1] (mod N), reverse
-//   target slices [rank + 1 .. rank + (N-1)/2]; rank itself is untouched. The two
-//   write sets are disjoint by construction, so the threads never race on memory.
+//   across comms; we must register the same data buffer four times (forward+reverse
+//   send and recv). MRs are registered upfront and torn down once the loop completes.
+// - The four ops per step (ring0_send/ring0_recv on forward QP + ring1_send/ring1_recv
+//   on reverse QP) are driven via netMultiOp, which round-robin polls netIsend/netIrecv
+//   in a single thread. This replaces the previous std::thread-based forward/reverse
+//   split: both directions now share one CPU but progress concurrently in the kernel.
+// - Forward and reverse writes target disjoint slice sets (forward → [rank - N/2 ..
+//   rank - 1], reverse → [rank + 1 .. rank + (N-1)/2]; rank itself is untouched), so
+//   even though both ring0 and ring1 ops are in-flight at the same time, they cannot
+//   race on memory.
 // - On any failure we still attempt to dereg every successfully-registered handle
-//   to avoid leaking pinned host memory; previous code path returned on the first
-//   regMr failure with prior MRs leaked.
+//   to avoid leaking pinned host memory.
 static ncclResult_t netBiDirRingAllGather(ncclNet_t* net,
                                           void* sendComm, void* recvComm,
                                           void* revSendComm, void* revRecvComm,
                                           int rank, int nranks, char* data, int size,
                                           volatile uint32_t* abortFlag) {
-  ncclResult_t fwdRes = ncclSuccess;
-  ncclResult_t bwdRes = ncclSuccess;
+  ncclResult_t res = ncclSuccess;
   uint64_t tFirst = 0, tRest = 0;
-  int fwdSteps = nranks / 2;
-  int bwdSteps = (nranks - 1) / 2;
+  void *sendH = NULL, *recvH = NULL, *revSendH = NULL, *revRecvH = NULL;
+  int totalSteps = nranks / 2;
 
-  TRACE(NCCL_BOOTSTRAP, "netBiDirRingAllGather started: nranks=%d fwdSteps=%d bwdSteps=%d", nranks, fwdSteps, bwdSteps);
+  TRACE(NCCL_BOOTSTRAP, "netBiDirRingAllGather started: rank=%d nranks=%d totalSteps=%d", rank, nranks, totalSteps);
+
+  res = netReg(net, sendComm, data, nranks * size, &sendH);
+  if (res == ncclSuccess) res = netReg(net, recvComm, data, nranks * size, &recvH);
+  if (res == ncclSuccess) res = netReg(net, revSendComm, data, nranks * size, &revSendH);
+  if (res == ncclSuccess) res = netReg(net, revRecvComm, data, nranks * size, &revRecvH);
+  if (res != ncclSuccess) goto cleanup;
+
   BOOTSTRAP_PROF_OPEN(tFirst);
-
-  // Forward direction: registers its own send/recv MRs and runs fwdSteps iterations.
-  std::thread fwdThread([&]() {
-    void *sendH = NULL, *recvH = NULL;
-    fwdRes = netReg(net, sendComm, data, nranks * size, &sendH);
-    if (fwdRes == ncclSuccess) fwdRes = netReg(net, recvComm, data, nranks * size, &recvH);
-    if (fwdRes == ncclSuccess) {
-      for (int i = 0; i < fwdSteps; i++) {
-        int tag = i; // forward tags stay 0..fwdSteps-1 (compatible with old netRingAllGather)
-        size_t sslice = (size_t)((rank - i + nranks) % nranks);
-        size_t rslice = (size_t)((rank - i - 1 + nranks) % nranks);
-        ncclResult_t r = netSendRecv(net, sendComm, data + sslice * size, size, sendH,
-                                     recvComm, data + rslice * size, size, recvH,
-                                     tag, abortFlag);
-        if (r != ncclSuccess) { fwdRes = r; break; }
-      }
+  for (int step = 0; step < totalSteps; step++) {
+    bool isFinalUnidirectional = (step == totalSteps - 1) && (nranks % 2 == 0);
+    int sendSliceRing0 = (rank - step + nranks) % nranks;     // Ring0 send to next
+    int recvSliceRing0 = (rank - step - 1 + nranks) % nranks; // Ring0 recv from prev
+    int sendSliceRing1 = (rank + step) % nranks;              // Ring1 send to prev
+    int recvSliceRing1 = (rank + step + 1) % nranks;          // Ring1 recv from next
+    if (isFinalUnidirectional) {
+      // Final step on even N: only ring0 over the forward QP pair.
+      res = netSendRecv(net, sendComm, data + sendSliceRing0 * size, size, sendH,
+                        recvComm, data + recvSliceRing0 * size, size, recvH,
+                        /*tag*/step, abortFlag);
+    } else {
+      // Bidirectional step: 4 in-flight ops driven by single-threaded round-robin polling.
+      // Tags are kept identical inside one MultiOp call (each comm has its own tag space
+      // on IB; collisions between forward/reverse are impossible because they live on
+      // different QPs).
+      struct ncclNetOp ops[4] = {
+        {NCCL_NET_OP_SEND, sendComm,    data + sendSliceRing0 * size, size, sendH,    /*tag*/step, NULL, 0},
+        {NCCL_NET_OP_RECV, recvComm,    data + recvSliceRing0 * size, size, recvH,    /*tag*/step, NULL, 0},
+        {NCCL_NET_OP_SEND, revSendComm, data + sendSliceRing1 * size, size, revSendH, /*tag*/step, NULL, 0},
+        {NCCL_NET_OP_RECV, revRecvComm, data + recvSliceRing1 * size, size, revRecvH, /*tag*/step, NULL, 0}
+      };
+      res = netMultiOp(net, ops, 4, abortFlag);
     }
-    if (sendH) netDereg(net, sendComm, &sendH);
-    if (recvH) netDereg(net, recvComm, &recvH);
-  });
-
-  // Reverse direction on the calling thread.
-  {
-    void *revSendH = NULL, *revRecvH = NULL;
-    bwdRes = netReg(net, revSendComm, data, nranks * size, &revSendH);
-    if (bwdRes == ncclSuccess) bwdRes = netReg(net, revRecvComm, data, nranks * size, &revRecvH);
-    if (bwdRes == ncclSuccess) {
-      for (int i = 0; i < bwdSteps; i++) {
-        // Tag space is per-QP, but we still keep them disjoint from forward tags
-        // (defensive against future plugin changes that may share a tag table).
-        int tag = i + fwdSteps + 1;
-        size_t sslice = (size_t)((rank + i) % nranks);
-        size_t rslice = (size_t)((rank + i + 1) % nranks);
-        ncclResult_t r = netSendRecv(net, revSendComm, data + sslice * size, size, revSendH,
-                                     revRecvComm, data + rslice * size, size, revRecvH,
-                                     tag, abortFlag);
-        if (i == 0) { BOOTSTRAP_PROF_CLOSE(tFirst); BOOTSTRAP_PROF_OPEN(tRest); }
-        if (r != ncclSuccess) { bwdRes = r; break; }
-      }
+    if (res != ncclSuccess) break;
+    if (step == 0) {
+      BOOTSTRAP_PROF_CLOSE(tFirst);
+      BOOTSTRAP_PROF_OPEN(tRest);
     }
-    if (bwdSteps == 0) { BOOTSTRAP_PROF_CLOSE(tFirst); BOOTSTRAP_PROF_OPEN(tRest); }
-    if (revSendH) netDereg(net, revSendComm, &revSendH);
-    if (revRecvH) netDereg(net, revRecvComm, &revRecvH);
   }
-
-  fwdThread.join();
   BOOTSTRAP_PROF_CLOSE(tRest);
   TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE,
-        "netBiDirRingAllGather first message in %f, rest in %f (steps fwd=%d bwd=%d)",
-        tFirst / 1e9, tRest / 1e9, fwdSteps, bwdSteps);
+        "netBiDirRingAllGather first message in %f (%f MB/sec), rest in %f (%f MB/sec)",
+        tFirst / 1e9, (size / 1e6) / (tFirst / 1e9), tRest / 1e9, (nranks - 1) * (size / 1e6) / (tRest / 1e9));
 
-  return (fwdRes != ncclSuccess) ? fwdRes : bwdRes;
+cleanup:
+  // Best-effort cleanup: try every dereg even if some failed (avoids leaking pinned memory).
+  if (sendH)    netDereg(net, sendComm,    &sendH);
+  if (recvH)    netDereg(net, recvComm,    &recvH);
+  if (revSendH) netDereg(net, revSendComm, &revSendH);
+  if (revRecvH) netDereg(net, revRecvComm, &revRecvH);
+  return res;
 }
 
 ncclResult_t bootstrapAllGather(void* commState, void* allData, int size) {

--- a/projects/rccl/src/include/socket.h
+++ b/projects/rccl/src/include/socket.h
@@ -68,6 +68,14 @@ struct ncclSocket {
   char finalizeBuffer[sizeof(uint64_t)]; // Used to keep track of initial handshake for async sockets.
 };
 
+struct ncclSocketOp {
+  int op;                  // NCCL_SOCKET_SEND or NCCL_SOCKET_RECV
+  struct ncclSocket* sock; // Socket to operate on
+  void* ptr;               // Data pointer
+  int size;                // Size of data
+  int offset;              // Current progress offset
+};
+
 const char *ncclSocketToString(const union ncclSocketAddress *addr, char *buf, const int numericHostForm = 1);
 ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char* ip_port_pair);
 ncclResult_t ncclFindInterfaceMatchSubnet(char* ifName, union ncclSocketAddress* localAddr,
@@ -97,6 +105,7 @@ ncclResult_t ncclSocketWait(int op, struct ncclSocket* sock, void* ptr, int size
 ncclResult_t ncclSocketSend(struct ncclSocket* sock, void* ptr, int size);
 ncclResult_t ncclSocketRecv(struct ncclSocket* sock, void* ptr, int size);
 ncclResult_t ncclSocketSendRecv(struct ncclSocket* sendSock, void* sendPtr, int sendSize, struct ncclSocket* recvSock, void* recvPtr, int recvSize);
+ncclResult_t ncclSocketMultiOp(struct ncclSocketOp* ops, int numOps);
 ncclResult_t ncclSocketTryRecv(struct ncclSocket* sock, void* ptr, int size, int* closed, bool blocking);
 ncclResult_t ncclSocketShutdown(struct ncclSocket* sock, int how);
 ncclResult_t ncclSocketClose(struct ncclSocket* sock, bool wait = false);

--- a/projects/rccl/src/misc/socket.cc
+++ b/projects/rccl/src/misc/socket.cc
@@ -927,6 +927,30 @@ ncclResult_t ncclSocketSendRecv(struct ncclSocket* sendSock, void* sendPtr, int 
   return ncclSuccess;
 }
 
+ncclResult_t ncclSocketMultiOp(struct ncclSocketOp* ops, int numOps) {
+  if (ops == NULL || numOps <= 0) {
+    WARN("ncclSocketMultiOp: invalid arguments ops=%p numOps=%d", ops, numOps);
+    return ncclInvalidArgument;
+  }
+
+  for (int i = 0; i < numOps; i++) {
+    if (ops[i].sock == NULL) {
+      WARN("ncclSocketMultiOp: invalid socket at index %d", i);
+      return ncclInvalidArgument;
+    }
+    ops[i].offset = 0;
+  }
+  int completedOps=0, i=0;
+  while(completedOps < numOps){
+    if (ops[i].offset < ops[i].size){
+      NCCLCHECK(socketProgress(ops[i].op, ops[i].sock, ops[i].ptr, ops[i].size, &ops[i].offset));
+      if(ops[i].offset >= ops[i].size) completedOps++;
+    }
+    i=(i+1)%numOps;
+  }
+  return ncclSuccess;
+}
+
 
 // Receive or detect connection closed
 ncclResult_t ncclSocketTryRecv(struct ncclSocket* sock, void* ptr, int size, int* closed, bool blocking) {

--- a/projects/rccl/src/misc/socket.cc
+++ b/projects/rccl/src/misc/socket.cc
@@ -933,20 +933,27 @@ ncclResult_t ncclSocketMultiOp(struct ncclSocketOp* ops, int numOps) {
     return ncclInvalidArgument;
   }
 
+  int completedOps = 0;
   for (int i = 0; i < numOps; i++) {
     if (ops[i].sock == NULL) {
       WARN("ncclSocketMultiOp: invalid socket at index %d", i);
       return ncclInvalidArgument;
     }
-    ops[i].offset = 0;
-  }
-  int completedOps=0, i=0;
-  while(completedOps < numOps){
-    if (ops[i].offset < ops[i].size){
-      NCCLCHECK(socketProgress(ops[i].op, ops[i].sock, ops[i].ptr, ops[i].size, &ops[i].offset));
-      if(ops[i].offset >= ops[i].size) completedOps++;
+    if (ops[i].op != NCCL_SOCKET_SEND && ops[i].op != NCCL_SOCKET_RECV) {
+      WARN("ncclSocketMultiOp: invalid op %d at index %d", ops[i].op, i);
+      return ncclInvalidArgument;
     }
-    i=(i+1)%numOps;
+    ops[i].offset = 0;
+    if (ops[i].size == 0) completedOps++;
+  }
+
+  int i = 0;
+  while (completedOps < numOps) {
+    if (ops[i].offset < ops[i].size) {
+      NCCLCHECK(socketProgress(ops[i].op, ops[i].sock, ops[i].ptr, ops[i].size, &ops[i].offset));
+      if (ops[i].offset >= ops[i].size) completedOps++;
+    }
+    i = (i + 1) % numOps;
   }
   return ncclSuccess;
 }

--- a/projects/rccl/src/misc/socket.cc
+++ b/projects/rccl/src/misc/socket.cc
@@ -943,6 +943,14 @@ ncclResult_t ncclSocketMultiOp(struct ncclSocketOp* ops, int numOps) {
       WARN("ncclSocketMultiOp: invalid op %d at index %d", ops[i].op, i);
       return ncclInvalidArgument;
     }
+    if (ops[i].size < 0) {
+      WARN("ncclSocketMultiOp: invalid size %d at index %d", ops[i].size, i);
+      return ncclInvalidArgument;
+    }
+    if (ops[i].size > 0 && ops[i].ptr == NULL) {
+      WARN("ncclSocketMultiOp: NULL ptr with size %d at index %d", ops[i].size, i);
+      return ncclInvalidArgument;
+    }
     ops[i].offset = 0;
     if (ops[i].size == 0) completedOps++;
   }


### PR DESCRIPTION
## Motivation

RCCL bootstrap AllGather uses a ring requiring N-1 sequential steps, a latency bottleneck at large rank counts. This PR halves the step count to ceil(N/2) by running forward and reverse rings concurrently, aligned with NCCL 2.28.7's design.

Also see https://amd.atlassian.net/wiki/spaces/MLSE/pages/1642418917/Bootstrap+Large-scale+WS

## Technical Details

**Socket OOB** (`NCCL_BOOTSTRAP_BIDIR_ALLGATHER=1`, off by default (0)):
- Back-ported `ncclSocketMultiOp` from NCCL 2.28.7 (threadless round-robin
  polling, `socket.cc`/`socket.h`)
- `socketRingAllGather` mirrors upstream NCCL 2.28.7: `socketDoubleSendRecv`
  drives both directions over the existing full-duplex TCP pair — no reverse
  socket pair needed
- Bidirectional size exchange driven through `ncclSocketMultiOp` — one
  overlapped handshake instead of two sequential send/recv exchanges

**IB/net OOB** (`NCCL_BOOTSTRAP_BIDIR_NET=1`, off by default (0)):
- `netMultiOp` — threadless analogue of `ncclSocketMultiOp` for
  `netIsend`/`netIrecv`; eliminates `std::thread` overhead.
  NET bidir bootstrap is absent in NCCL (including 2.30.4) — RCCL extension.
- Reverse-ring listen handle piggybacked through root rendezvous
  (`ringConnectInfo` with `fwd`+`revHandle`), eliminating a dedicated
  reverse handle exchange RTT
- Reverse net comm setup split into Start/Finish and overlapped with
  forward-ring connect, proxy listen, UDS, and peer P2P listen

**Defaults and thresholds:**

Feature is disabled by default. `OOB_NET_ENABLE` and `BIDIR_NET` are tristate (`-1` auto by threshold, `0` force off, `1` force on), both defaulting to `0`. `NCCL_BOOTSTRAP_BIDIR_THRESHOLD` (default **128**) is only consulted when a knob is explicitly set to `-1`.

## JIRA ID

AICOMNET-181, AICOMNET-183

## Test Plan

At least up to 32-node × 8 ranks/node

Reference command used for 4 nodes: `( for i in $(seq 1 42); do
    mpirun --hostfile /home/ilkosare/fast-init-feature/hostfile.txt -np 32 \
      --map-by ppr:8:node -mca btl_tcp_if_include eno8303 \
      -x LD_LIBRARY_PATH=/home/ilkosare/development/rocm-systems/projects/rccl/build_release:/opt/rocm/lib \
      -x NCCL_DEBUG=INFO -x NCCL_DEBUG_SUBSYS=BOOTSTRAP \
      -x NCCL_BOOTSTRAP_BIDIR_NET=0 -x NCCL_OOB_NET_ENABLE=0 \
      -x NCCL_BOOTSTRAP_BIDIR_ALLGATHER=0 -x NCCL_BOOTSTRAP_BIDIR_THRESHOLD=16 \
      /home/ilkosare/rccl-tests/build/all_gather_perf -b 1K -e 1K -f 4 -g 1 2>&1 \
    | awk 'match($0,/total ([0-9.]+).*ring ([0-9.]+).*delay/,m){t+=m[1]; r+=m[2]; n++}
           END{ if(n>0) printf "iter=%d total_avg=%.4fs ring_avg=%.4fs n=%d\n", '"$i"', t/n, r/n, n;
                else    printf "iter=%d FAIL\n", '"$i"' }';
  done ) | tee /tmp/bench.txt | awk '{print}' \
  && awk '
    /total_avg/{
      gsub("s","",$2); gsub("s","",$3);
      split($2,a,"="); split($3,b,"=");
      tv[NR]=a[2]; rv[NR]=b[2];
      ts+=a[2]; rs+=b[2]; n++
    }
    END{
      asort(tv); asort(rv);
      tmed = (n%2) ? tv[(n+1)/2] : (tv[n/2]+tv[n/2+1])/2;
      rmed = (n%2) ? rv[(n+1)/2] : (rv[n/2]+rv[n/2+1])/2;
      printf "\n=== SUMMARY (%d iters) ===\n", n;
      printf "%-7s  %-8s %-8s %-8s %-8s\n", "metric", "mean", "median", "min", "max";
      printf "%-7s  %-8.4f %-8.4f %-8.4f %-8.4f  (s)\n", "total",  ts/n, tmed, tv[1], tv[n];
      printf "%-7s  %-8.4f %-8.4f %-8.4f %-8.4f  (s)\n", "ring",   rs/n, rmed, rv[1], rv[n];
    }' /tmp/bench.txt`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.