### PR TITLE
[rocprofiler-compute] Republish ROCPROF* env vars for shell-script workloads

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -42,6 +42,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Fixed empirical roofline benchmark to correctly produce double the Matrix BF16 Gflop/s on gfx90a (MI 200 series) GPUs
 
+* Fixed empty native counter-collection configuration when profiling a shell or shell-script workload, by republishing all ``ROCPROF``-prefixed env vars (``ROCPROF_*``, ``ROCPROFILER_*``, etc.) across the shell's fork/exec. Env changes after the script setup isn't propagated to the profiler.
+
 ### Upcoming changes
 
 ### Known issues

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -654,6 +654,18 @@ add_test(
 )
 
 # -----------------------------------
+# Pure-Python utils.utils_profile unit tests
+# -----------------------------------
+
+add_test(
+    NAME test_utils_profile
+    COMMAND
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION}
+        --junitxml=tests/test_utils_profile.xml ${COV_OPTION} tests/test_utils_profile.py
+        ${WORKING_DIR_OPTION}
+)
+
+# -----------------------------------
 # Profiler base unit tests
 # -----------------------------------
 
@@ -710,6 +722,7 @@ if(${ENABLE_COVERAGE})
         test_num_xcds_spec_class
         test_num_xcds_cli_output
         test_utils
+        test_utils_profile
         test_mem_chart
         test_roofline_calc_ai_analyze
         test_data_imputation

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/CMakeLists.txt
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/CMakeLists.txt
@@ -14,6 +14,8 @@ add_library(
     input_parameters.cpp
     sdk_wrapper.h
     sdk_wrapper.cpp
+    tool_setup.h
+    tool_setup.cpp
 )
 
 target_include_directories(${target} PUBLIC .)

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
@@ -7,6 +7,7 @@
 #include "input_parameters.h"
 #include "sdk_callbacks.h"
 #include "sdk_wrapper.h"
+#include "tool_setup.h"
 
 #include <unistd.h>
 
@@ -21,6 +22,7 @@ static std::shared_ptr<SdkWrapper>      g_sdk_wrapper      = std::make_shared<Sd
 static std::shared_ptr<SdkCallbacks> g_sdk_callbacks = std::make_shared<SdkCallbacksImpl>(g_sdk_wrapper);
 static std::shared_ptr<CountersWriter> g_counters_writer = std::make_shared<CsvCountersWriter>();
 static std::shared_ptr<rocprofiler_tool_configure_result_t> g_cfg;
+static std::shared_ptr<ToolSetUp>                           g_tool_setup;
 
 void test_knobs::set_input_parameters(const std::shared_ptr<InputParameters>& input_parameters)
 {
@@ -37,9 +39,19 @@ void test_knobs::set_csv_writer(const std::shared_ptr<CountersWriter>& csv_write
     g_counters_writer = csv_writer;
 }
 
+void test_knobs::set_tool_setup(const std::shared_ptr<ToolSetUp>& tool_setup)
+{
+    g_tool_setup = tool_setup;
+}
+
 void test_knobs::reset_cfg()
 {
     g_cfg.reset();
+}
+
+void test_knobs::reset_tool_setup()
+{
+    g_tool_setup.reset();
 }
 
 namespace rocprofiler_compute_tool
@@ -228,6 +240,14 @@ rocprofiler_tool_configure_result_t* rocprofiler_configure(uint32_t             
                                                            uint32_t                 priority,
                                                            rocprofiler_client_id_t* id)
 {
+    // create the tool setup
+    if (!g_tool_setup)
+    {
+        g_tool_setup = std::make_shared<EnvironmentSetUp>();
+    }
+    // setup the tool environment
+    g_tool_setup->set_up();
+
     // set the client name
     id->name = "[rocprofiler-compute]";
 

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.h
@@ -4,6 +4,7 @@
 #include "counters_writer.h"
 #include "input_parameters.h"
 #include "sdk_wrapper.h"
+#include "tool_setup.h"
 
 #include <rocprofiler-sdk/registration.h>
 
@@ -19,5 +20,7 @@ namespace rocprofiler_compute_tool::test_knobs
 void set_input_parameters(const std::shared_ptr<InputParameters>& parameters);
 void set_sdk_wrapper(const std::shared_ptr<SdkWrapper>& sdk_wrapper);
 void set_csv_writer(const std::shared_ptr<CountersWriter>& csv_writer);
+void set_tool_setup(const std::shared_ptr<ToolSetUp>& tool_setup);
 void reset_cfg();
+void reset_tool_setup();
 }  // namespace rocprofiler_compute_tool::test_knobs

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/CMakeLists.txt
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/CMakeLists.txt
@@ -8,6 +8,8 @@ add_executable(
     test_rocprofiler_compute_tool.cpp
     test_sdk_callbacks.h
     test_sdk_callbacks.cpp
+    test_tool_setup.h
+    test_tool_setup.cpp
     mocks.h
     mocks.cpp
     main.cpp

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
@@ -192,3 +192,43 @@ const std::vector<MockCountersWriter::write_counters_info>& MockCountersWriter::
 {
     return m_write_counters_args;
 }
+
+/////////////////////////////////////////////////////////////////////////
+// MockToolSetUp
+void MockToolSetUp::set_up()
+{
+    ++m_setup_call_count;
+}
+
+int MockToolSetUp::get_setup_call_count() const
+{
+    return m_setup_call_count;
+}
+
+/////////////////////////////////////////////////////////////////////////
+// MockEnvironmentSetUp
+void MockEnvironmentSetUp::set_test_env(const std::vector<std::string>& entries)
+{
+    m_test_env = entries;
+}
+
+std::vector<std::string> MockEnvironmentSetUp::get_env_entries() const
+{
+    ++m_build_env_cache_calls;
+    return m_test_env;
+}
+
+void MockEnvironmentSetUp::set_env_var(const std::string& key, const std::string& value) const
+{
+    m_set_env_calls.push_back(set_env_call{key, value});
+}
+
+const std::vector<MockEnvironmentSetUp::set_env_call>& MockEnvironmentSetUp::get_set_env_calls() const
+{
+    return m_set_env_calls;
+}
+
+int MockEnvironmentSetUp::get_build_env_cache_call_count() const
+{
+    return m_build_env_cache_calls;
+}

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
@@ -5,6 +5,7 @@
 #include "input_parameters.h"
 #include "sdk_callbacks.h"
 #include "sdk_wrapper.h"
+#include "tool_setup.h"
 
 #include <gmock/gmock.h>
 
@@ -116,4 +117,38 @@ public:
 
 private:
     std::vector<write_counters_info> m_write_counters_args;
+};
+
+class MockToolSetUp : public rocprofiler_compute_tool::ToolSetUp
+{
+public:
+    void set_up() override;
+    int  get_setup_call_count() const;
+
+private:
+    int m_setup_call_count = 0;
+};
+
+class MockEnvironmentSetUp : public rocprofiler_compute_tool::EnvironmentSetUp
+{
+public:
+    struct set_env_call
+    {
+        std::string key;
+        std::string value;
+    };
+
+    void set_test_env(const std::vector<std::string>& entries);
+
+    const std::vector<set_env_call>& get_set_env_calls() const;
+    int                              get_build_env_cache_call_count() const;
+
+protected:
+    std::vector<std::string> get_env_entries() const override;
+    void set_env_var(const std::string& key, const std::string& value) const override;
+
+private:
+    std::vector<std::string>          m_test_env;
+    mutable std::vector<set_env_call> m_set_env_calls;
+    mutable int                       m_build_env_cache_calls = 0;
 };

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
@@ -215,15 +215,18 @@ void TestRocprofilerComputeTool::SetUp()
     m_input_parameters = std::make_shared<MockInputParameters>();
     m_sdk_wrapper      = std::make_shared<MockSdkWrapper>();
     m_counters_writer  = std::make_shared<MockCountersWriter>();
+    m_tool_setup       = std::make_shared<MockToolSetUp>();
 
     test_knobs::set_input_parameters(m_input_parameters);
     test_knobs::set_sdk_wrapper(m_sdk_wrapper);
     test_knobs::set_csv_writer(m_counters_writer);
+    test_knobs::set_tool_setup(m_tool_setup);
 }
 
 void TestRocprofilerComputeTool::TearDown()
 {
     test_knobs::reset_cfg();
+    test_knobs::reset_tool_setup();
 }
 
 tool_data_t* TestRocprofilerComputeTool::get_tool_data(const rocprofiler_tool_configure_result_t* cfg)

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.h
@@ -21,4 +21,5 @@ protected:
     std::shared_ptr<MockInputParameters> m_input_parameters;
     std::shared_ptr<MockSdkWrapper>      m_sdk_wrapper;
     std::shared_ptr<MockCountersWriter>  m_counters_writer;
+    std::shared_ptr<MockToolSetUp>       m_tool_setup;
 };

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_tool_setup.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_tool_setup.cpp
@@ -1,0 +1,169 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#include "test_tool_setup.h"
+
+#include "rocprofiler_compute_tool.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <string>
+
+using namespace rocprofiler_compute_tool;
+
+namespace
+{
+bool contains_set_env_call(const std::vector<MockEnvironmentSetUp::set_env_call>& calls,
+                           const std::string&                                     key,
+                           const std::string&                                     value)
+{
+    return std::any_of(calls.begin(),
+                       calls.end(),
+                       [&](const MockEnvironmentSetUp::set_env_call& call)
+                       { return call.key == key && call.value == value; });
+}
+
+bool contains_set_env_key(const std::vector<MockEnvironmentSetUp::set_env_call>& calls,
+                          const std::string&                                     key)
+{
+    return std::any_of(calls.begin(),
+                       calls.end(),
+                       [&](const MockEnvironmentSetUp::set_env_call& call)
+                       { return call.key == key; });
+}
+}  // namespace
+
+TEST_F(TestToolSetUp, OnConfigure_InvokesToolSetupSetUp)
+{
+    rocprofiler_configure(1, "", 1, &m_client_id);
+    EXPECT_EQ(m_tool_setup->get_setup_call_count(), 1);
+}
+
+TEST_F(TestToolSetUp, OnConfigureCalledTwice_InvokesSetUpEachTime)
+{
+    rocprofiler_configure(1, "", 1, &m_client_id);
+    rocprofiler_configure(1, "", 1, &m_client_id);
+    EXPECT_EQ(m_tool_setup->get_setup_call_count(), 2);
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// TestToolSetUp
+void TestToolSetUp::SetUp()
+{
+    m_input_parameters = std::make_shared<MockInputParameters>();
+    m_sdk_wrapper      = std::make_shared<MockSdkWrapper>();
+    m_counters_writer  = std::make_shared<MockCountersWriter>();
+    m_tool_setup       = std::make_shared<MockToolSetUp>();
+
+    test_knobs::set_input_parameters(m_input_parameters);
+    test_knobs::set_sdk_wrapper(m_sdk_wrapper);
+    test_knobs::set_csv_writer(m_counters_writer);
+    test_knobs::set_tool_setup(m_tool_setup);
+}
+
+void TestToolSetUp::TearDown()
+{
+    test_knobs::reset_cfg();
+    test_knobs::reset_tool_setup();
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// TestEnvironmentSetUp
+void TestEnvironmentSetUp::SetUp()
+{
+    m_tool_setup = std::make_shared<MockEnvironmentSetUp>();
+}
+
+TEST_F(TestEnvironmentSetUp, IsShellTarget_WhenRocprofShellTargetIsOne_ReturnsTrue)
+{
+    m_tool_setup->set_test_env({"ROCPROF_SHELL_TARGET=1"});
+    m_tool_setup->set_up();
+    EXPECT_TRUE(m_tool_setup->is_shell_target());
+}
+
+TEST_F(TestEnvironmentSetUp, IsShellTarget_WhenRocprofShellTargetIsZero_ReturnsFalse)
+{
+    for (const auto* shell_target_value : {"0", "", "true", "yes", " 1", "1 "})
+    {
+        SCOPED_TRACE(std::string{"ROCPROF_SHELL_TARGET="} + shell_target_value);
+        m_tool_setup->set_test_env({std::string{"ROCPROF_SHELL_TARGET="} + shell_target_value});
+        m_tool_setup->set_up();
+        EXPECT_FALSE(m_tool_setup->is_shell_target());
+    }
+}
+
+TEST_F(TestEnvironmentSetUp, IsShellTarget_WhenRocprofShellTargetMissing_ReturnsFalse)
+{
+    m_tool_setup->set_test_env({"HOME=/home/user", "ROCPROF_FOO=bar"});
+    m_tool_setup->set_up();
+    EXPECT_FALSE(m_tool_setup->is_shell_target());
+}
+
+TEST_F(TestEnvironmentSetUp, RepublishRocprofEnv_RepublishesAllRocprofVars)
+{
+    m_tool_setup->set_test_env({"ROCPROF_FOO=bar", "ROCPROF_BAZ=qux", "HOME=/x"});
+    m_tool_setup->set_up();
+    m_tool_setup->republish_rocprof_env();
+
+    const auto& calls = m_tool_setup->get_set_env_calls();
+    EXPECT_TRUE(contains_set_env_call(calls, "ROCPROF_FOO", "bar"));
+    EXPECT_TRUE(contains_set_env_call(calls, "ROCPROF_BAZ", "qux"));
+    EXPECT_FALSE(contains_set_env_key(calls, "HOME"));
+}
+
+TEST_F(TestEnvironmentSetUp, RepublishRocprofEnv_AlsoRepublishesRocprofilerPrefixedVars)
+{
+    m_tool_setup->set_test_env({
+        "ROCPROFILER_TOOL_PATH=/path/to/tool.so",
+        "ROCPROFILER_PC_SAMPLING_BETA_ENABLED=1",
+        "ROCPROF_FOO=bar",
+        "PATH=/usr/bin",
+    });
+    m_tool_setup->set_up();
+    m_tool_setup->republish_rocprof_env();
+
+    const auto& calls = m_tool_setup->get_set_env_calls();
+    EXPECT_TRUE(contains_set_env_call(calls, "ROCPROFILER_TOOL_PATH", "/path/to/tool.so"));
+    EXPECT_TRUE(contains_set_env_call(calls, "ROCPROFILER_PC_SAMPLING_BETA_ENABLED", "1"));
+    EXPECT_TRUE(contains_set_env_call(calls, "ROCPROF_FOO", "bar"));
+    EXPECT_FALSE(contains_set_env_key(calls, "PATH"));
+}
+
+TEST_F(TestEnvironmentSetUp, RepublishRocprofEnv_UsesValuesFromCache)
+{
+    m_tool_setup->set_test_env({"ROCPROF_FOO=original"});
+    m_tool_setup->set_up();
+    m_tool_setup->republish_rocprof_env();
+
+    const auto& calls = m_tool_setup->get_set_env_calls();
+    ASSERT_EQ(calls.size(), 1u);
+    EXPECT_EQ(calls[0].key, "ROCPROF_FOO");
+    EXPECT_EQ(calls[0].value, "original");
+}
+
+TEST_F(TestEnvironmentSetUp, SetUp_WhenShellTarget_InvokesRepublish)
+{
+    m_tool_setup->set_test_env({"ROCPROF_SHELL_TARGET=1", "ROCPROF_FOO=bar"});
+    m_tool_setup->set_up();
+
+    const auto& calls = m_tool_setup->get_set_env_calls();
+    EXPECT_TRUE(contains_set_env_call(calls, "ROCPROF_SHELL_TARGET", "1"));
+    EXPECT_TRUE(contains_set_env_call(calls, "ROCPROF_FOO", "bar"));
+}
+
+TEST_F(TestEnvironmentSetUp, SetUp_WhenNotShellTarget_DoesNotInvokeRepublish)
+{
+    m_tool_setup->set_test_env({"ROCPROF_FOO=bar"});
+    m_tool_setup->set_up();
+
+    EXPECT_TRUE(m_tool_setup->get_set_env_calls().empty());
+}
+
+TEST_F(TestEnvironmentSetUp, SetUp_AlwaysBuildsEnvCache)
+{
+    m_tool_setup->set_test_env({"ROCPROF_FOO=bar"});
+    m_tool_setup->set_up();
+    m_tool_setup->set_up();
+
+    EXPECT_EQ(m_tool_setup->get_build_env_cache_call_count(), 2);
+}

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_tool_setup.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_tool_setup.h
@@ -1,0 +1,28 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+#include "mocks.h"
+#include "rocprofiler_compute_tool.h"
+
+#include <memory>
+
+class TestToolSetUp : public ::testing::Test
+{
+protected:
+    void SetUp() override;
+    void TearDown() override;
+
+    rocprofiler_client_id_t              m_client_id{};
+    std::shared_ptr<MockInputParameters> m_input_parameters;
+    std::shared_ptr<MockSdkWrapper>      m_sdk_wrapper;
+    std::shared_ptr<MockCountersWriter>  m_counters_writer;
+    std::shared_ptr<MockToolSetUp>       m_tool_setup;
+};
+
+class TestEnvironmentSetUp : public ::testing::Test
+{
+protected:
+    void SetUp() override;
+
+    std::shared_ptr<MockEnvironmentSetUp> m_tool_setup;
+};

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tool_setup.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tool_setup.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#include "tool_setup.h"
+
+#include <stdlib.h>
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+extern "C" char** environ;
+
+using namespace rocprofiler_compute_tool;
+
+std::vector<std::string> EnvironmentSetUp::get_env_entries() const
+{
+    std::vector<std::string> entries;
+    for (char** entry_ptr = ::environ; entry_ptr != nullptr && *entry_ptr != nullptr; ++entry_ptr)
+    {
+        entries.emplace_back(*entry_ptr);
+    }
+    return entries;
+}
+
+void EnvironmentSetUp::set_env_var(const std::string& key, const std::string& value) const
+{
+    ::setenv(key.c_str(), value.c_str(), /*overwrite=*/1);
+}
+
+void EnvironmentSetUp::build_env_cache()
+{
+    m_env_cache.clear();
+    for (const auto& entry : get_env_entries())
+    {
+        const auto eq_pos = entry.find('=');
+        if (eq_pos == std::string::npos)
+            continue;
+
+        // Store the key and value in the cache
+        m_env_cache.try_emplace(entry.substr(0, eq_pos), entry.substr(eq_pos + 1));
+    }
+}
+
+bool EnvironmentSetUp::is_shell_target() const
+{
+    const auto it = m_env_cache.find("ROCPROF_SHELL_TARGET");
+    return it != m_env_cache.end() && it->second == "1";
+}
+
+void EnvironmentSetUp::republish_rocprof_env() const
+{
+    constexpr std::string_view rocprof_prefix = "ROCPROF";
+
+    for (const auto& [key, value] : m_env_cache)
+    {
+        if (std::string_view{key}.substr(0, rocprof_prefix.size()) != rocprof_prefix)
+            continue;
+
+        set_env_var(key, value);
+    }
+}
+
+void EnvironmentSetUp::set_up()
+{
+    build_env_cache();
+    if (is_shell_target())
+    {
+        republish_rocprof_env();
+    }
+}

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tool_setup.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tool_setup.h
@@ -1,0 +1,37 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace rocprofiler_compute_tool
+{
+
+class ToolSetUp
+{
+public:
+    virtual void set_up() = 0;
+    virtual ~ToolSetUp()  = default;
+};
+
+class EnvironmentSetUp : public ToolSetUp
+{
+public:
+    EnvironmentSetUp() = default;
+
+    void set_up() override;
+    bool is_shell_target() const;
+    /// Republish every cached env var whose key starts with "ROCPROF".
+    void republish_rocprof_env() const;
+
+protected:
+    virtual std::vector<std::string> get_env_entries() const;
+    virtual void set_env_var(const std::string& key, const std::string& value) const;
+    void         build_env_cache();
+
+    std::unordered_map<std::string, std::string> m_env_cache;
+};
+
+}  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
@@ -11,6 +11,7 @@ from rocprof_compute_profile.profiler_base import RocProfCompute_Base
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import console_debug, console_error, console_log, demarcate
 from utils.utils_common import resolve_rocm_library_path
+from utils.utils_profile import is_shell_target
 
 
 class rocprofiler_sdk_profiler(RocProfCompute_Base):
@@ -58,6 +59,9 @@ class rocprofiler_sdk_profiler(RocProfCompute_Base):
             options["ROCPROF_MARKER_API_TRACE"] = "1"
         # Create folder pointed by ROCPROF_OUTPUT_PATH
         Path(options["ROCPROF_OUTPUT_PATH"]).mkdir(parents=True, exist_ok=True)
+
+        if native_tool_path and is_shell_target(args.remaining):
+            options["ROCPROF_SHELL_TARGET"] = "1"
 
         if args.iteration_multiplexing:
             options.update({

--- a/projects/rocprofiler-compute/src/utils/utils_profile.py
+++ b/projects/rocprofiler-compute/src/utils/utils_profile.py
@@ -1,6 +1,7 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
+import functools
 import glob
 import importlib
 import os
@@ -913,3 +914,67 @@ def process_kokkos_trace_output(workload_dir: str, fbase: str) -> None:
             f"{workload_dir}/out/pmc_1/results_{fbase}_marker_api_trace.csv",
             f"{workload_dir}/{fbase}_marker_api_trace.csv",
         )
+
+
+SHELL_EXTS = frozenset({".sh", ".bash", ".zsh", ".ksh", ".csh"})
+ETC_SHELLS_PATH = Path("/etc/shells")
+WELL_KNOWN_SHELLS = frozenset({
+    "bash",
+    "sh",
+    "dash",
+    "zsh",
+    "ksh",
+    "fish",
+    "csh",
+    "tcsh",
+})
+
+
+def read_etc_shells_basenames() -> frozenset[str]:
+    """
+    Read and return shell basenames listed in /etc/shells (lowercased).
+
+    Returns an empty set when /etc/shells is missing or unreadable so callers
+    degrade gracefully on platforms that do not provide it.
+    """
+    try:
+        content = ETC_SHELLS_PATH.read_text()
+    except OSError:
+        return frozenset()
+
+    basenames: set[str] = set()
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        basename = Path(line).stem.lower()
+        if basename:
+            basenames.add(basename)
+    return frozenset(basenames)
+
+
+@functools.lru_cache(maxsize=1)
+def shell_basenames() -> frozenset[str]:
+    """Cached union of well-known shells with /etc/shells (lowercased)."""
+    return WELL_KNOWN_SHELLS | read_etc_shells_basenames()
+
+
+def is_shell_target(target: str) -> bool:
+    """
+    Check if ``target``'s argv[0] looks like a shell or shell script.
+
+    Shell basenames are sourced from /etc/shells; script extensions come from
+    SHELL_EXTS. ``target`` is parsed with ``shlex.split`` so quoted paths
+    (e.g. ``"/path with spaces/run.sh"``) are handled correctly.
+    """
+    try:
+        tokens = shlex.split(target)
+    except ValueError:
+        return False
+
+    if not tokens:
+        return False
+
+    argv0 = Path(tokens[0])
+    return argv0.stem.lower() in shell_basenames() or argv0.suffix.lower() in SHELL_EXTS

--- a/projects/rocprofiler-compute/tests/conftest.py
+++ b/projects/rocprofiler-compute/tests/conftest.py
@@ -7,12 +7,15 @@ import random
 import shutil
 import subprocess
 import sys
+from collections.abc import Generator
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from common import ROOT
+
+from utils.utils_profile import shell_basenames
 
 # Determine script path
 rocprof_compute_script_path = Path(ROOT) / "src/rocprof-compute"
@@ -225,6 +228,35 @@ def skip_monkeypatch_with_binary(request):
         pytest.skip(
             "Test uses monkeypatch which is incompatible with --call-binary mode"
         )
+
+
+FAKE_ETC_SHELLS = """\
+# /etc/shells: valid login shells
+/bin/sh
+/bin/bash
+/usr/bin/zsh
+/usr/bin/ksh
+/usr/bin/fish
+/usr/bin/csh
+/usr/bin/tcsh
+/usr/bin/dash
+"""
+
+
+@pytest.fixture
+def mock_etc_shells(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+    """Force /etc/shells to a known content for shell-target tests."""
+    real_read_text = Path.read_text
+
+    def fake_read_text(self: Path, *args, **kwargs) -> str:
+        if str(self) == "/etc/shells":
+            return FAKE_ETC_SHELLS
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+    shell_basenames.cache_clear()
+    yield
+    shell_basenames.cache_clear()
 
 
 @pytest.fixture

--- a/projects/rocprofiler-compute/tests/test_categories.yaml
+++ b/projects/rocprofiler-compute/tests/test_categories.yaml
@@ -23,6 +23,7 @@ test_categories:
       - test_profiler_base
       - test_num_xcds_cli_output
       - test_utils_profile_csv
+      - test_utils_profile
       - test_autogen_config
       - test_import_guard
       - test_mem_chart
@@ -67,6 +68,7 @@ test_categories:
       - test_analysis_db
       - test_pc_sampling_analysis
       - test_utils_profile_csv
+      - test_utils_profile
       - test_profiler_base
       - test_mem_chart
       - test_native_tool_finder
@@ -113,6 +115,7 @@ test_categories:
       - test_analysis_db
       - test_pc_sampling_analysis
       - test_utils_profile_csv
+      - test_utils_profile
       - test_profiler_base
       - test_mem_chart
       - test_native_tool_finder
@@ -159,6 +162,7 @@ test_categories:
       - test_analysis_db
       - test_pc_sampling_analysis
       - test_utils_profile_csv
+      - test_utils_profile
       - test_profiler_base
       - test_mem_chart
       - test_native_tool_finder

--- a/projects/rocprofiler-compute/tests/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/test_profiler_base.py
@@ -283,3 +283,67 @@ def test_attach_library_resolution_with_fallback():
     with patch(resolve_target, side_effect=[str(new_lib), str(old_lib)]):
         with pytest.raises(SystemExit):
             profiler.get_profiler_options()
+
+
+# ---------------------------------------------------------------------------
+# get_profiler_options(): ROCPROF_SHELL_TARGET injection
+# ---------------------------------------------------------------------------
+def _make_sdk_profiler_options_args(
+    tmp_path: Path, remaining: str
+) -> argparse.Namespace:
+    """Build a minimal Namespace for get_profiler_options() unit tests."""
+    return argparse.Namespace(
+        remaining=remaining,
+        rocprofiler_sdk_tool_path="/opt/rocm/lib/rocprofiler-sdk/librocprofiler-sdk-tool.so",
+        format_rocprof_output="csv",
+        output_directory=str(tmp_path),
+        iteration_multiplexing=None,
+        attach_pid=None,
+        attach_duration_msec=None,
+        kokkos_trace=False,
+        kernel=None,
+        dispatch=None,
+        torch_trace=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "remaining",
+    [
+        pytest.param("bash script.sh", id="bash_with_script"),
+        pytest.param("./run.sh", id="relative_shell_script"),
+        pytest.param("/usr/bin/zsh -c true", id="absolute_zsh_dash_c"),
+    ],
+)
+def test_shell_target_set_with_native_tool(tmp_path, remaining, mock_etc_shells):
+    """ROCPROF_SHELL_TARGET=1 when native tool is used and command is shell-like."""
+    args = _make_sdk_profiler_options_args(tmp_path, remaining)
+    profiler = rocprofiler_sdk_profiler(args, profiler_mode="rocprofiler-sdk", soc=None)
+    options = profiler.get_profiler_options(native_tool_path="/path/to/native_tool.so")
+    assert options.get("ROCPROF_SHELL_TARGET") == "1"
+
+
+@pytest.mark.parametrize(
+    "remaining",
+    [
+        pytest.param("/bin/true", id="non_shell_binary"),
+        pytest.param("python3 app.py", id="python_script"),
+        pytest.param("./vcopy -n 1024", id="custom_binary"),
+    ],
+)
+def test_shell_target_absent_with_native_tool_non_shell(
+    tmp_path, remaining, mock_etc_shells
+):
+    """ROCPROF_SHELL_TARGET is omitted when the workload is not a shell target."""
+    args = _make_sdk_profiler_options_args(tmp_path, remaining)
+    profiler = rocprofiler_sdk_profiler(args, profiler_mode="rocprofiler-sdk", soc=None)
+    options = profiler.get_profiler_options(native_tool_path="/path/to/native_tool.so")
+    assert "ROCPROF_SHELL_TARGET" not in options
+
+
+def test_shell_target_absent_without_native_tool(tmp_path, mock_etc_shells):
+    """Even with a shell-like command, no flag is set without a native tool."""
+    args = _make_sdk_profiler_options_args(tmp_path, "bash script.sh")
+    profiler = rocprofiler_sdk_profiler(args, profiler_mode="rocprofiler-sdk", soc=None)
+    options = profiler.get_profiler_options()
+    assert "ROCPROF_SHELL_TARGET" not in options

--- a/projects/rocprofiler-compute/tests/test_utils_profile.py
+++ b/projects/rocprofiler-compute/tests/test_utils_profile.py
@@ -1,0 +1,107 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+"""Unit tests for helpers in utils.utils_profile."""
+
+from pathlib import Path
+from typing import Any, NoReturn
+
+import pytest
+
+from utils import utils_profile
+from utils.utils_profile import is_shell_target
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param("bash", id="bare_bash"),
+        pytest.param("/usr/bin/bash -c true", id="bash_dash_c"),
+        pytest.param("sh script.sh", id="sh_with_script"),
+        pytest.param("./run.sh", id="relative_shell_script"),
+        pytest.param("job.bash", id="bash_extension"),
+        pytest.param("RUN.SH", id="uppercase_extension"),
+        pytest.param("/opt/tools/zsh", id="absolute_zsh_path"),
+        pytest.param("fish -i", id="fish_shell"),
+        pytest.param("tcsh", id="tcsh_basename"),
+        pytest.param('"/path with spaces/run.sh"', id="quoted_path_with_spaces"),
+        pytest.param("'/opt/my tools/zsh' -c true", id="quoted_shell_binary_path"),
+        pytest.param('bash -c "echo hi"', id="bash_with_quoted_arg"),
+    ],
+)
+def test_is_shell_target_true(target: str, mock_etc_shells: None) -> None:
+    assert is_shell_target(target) is True
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param("/bin/true", id="bin_true"),
+        pytest.param("python3 app.py", id="python3_script"),
+        pytest.param("./vcopy", id="custom_binary"),
+        pytest.param("-- /bin/true", id="leading_dash_dash"),
+        pytest.param("/usr/local/bin/my_app --flag", id="binary_with_flag"),
+        pytest.param("python3 -m json.tool", id="python_module"),
+        pytest.param("", id="empty_string"),
+        pytest.param('"unterminated', id="malformed_quoting"),
+    ],
+)
+def test_is_shell_target_false(target: str, mock_etc_shells: None) -> None:
+    assert is_shell_target(target) is False
+
+
+def test_is_shell_target_falls_back_to_extensions_when_etc_shells_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When /etc/shells is unavailable, well-known shells still work."""
+
+    def raise_missing(self: Path, *_args: Any, **_kwargs: Any) -> NoReturn:
+        raise FileNotFoundError(self)
+
+    monkeypatch.setattr(Path, "read_text", raise_missing)
+    utils_profile.shell_basenames.cache_clear()
+
+    assert is_shell_target("./run.sh") is True
+    assert is_shell_target("bash") is True
+
+
+def test_well_known_shells_recognised_when_etc_shells_is_minimal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """zsh/fish/tcsh must work even if /etc/shells lists only sh + bash."""
+
+    def fake_read_text(self: Path, *_args: Any, **_kwargs: Any) -> str:
+        return "/bin/sh\n/bin/bash\n"
+
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+    utils_profile.shell_basenames.cache_clear()
+
+    for cmd in ("zsh -c true", "fish", "tcsh", "csh script.csh", "ksh"):
+        assert is_shell_target(cmd) is True, cmd
+
+
+def test_etc_shells_parser_skips_comments_and_blank_lines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_read_text(self: Path, *_args: Any, **_kwargs: Any) -> str:
+        return "# header comment\n\n/bin/sh\n   \n/bin/bash\n"
+
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+    utils_profile.shell_basenames.cache_clear()
+
+    assert utils_profile.read_etc_shells_basenames() == frozenset({"sh", "bash"})
+
+
+def test_etc_shells_includes_arbitrary_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whatever /etc/shells advertises is treated as a shell."""
+
+    def fake_read_text(self: Path, *_args: Any, **_kwargs: Any) -> str:
+        return "/usr/bin/xonsh\n/usr/local/bin/elvish\n"
+
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+    utils_profile.shell_basenames.cache_clear()
+
+    assert is_shell_target("xonsh -c 'true'") is True
+    assert is_shell_target("/usr/local/bin/elvish") is True


### PR DESCRIPTION
## Motivation

When users profile a shell-launched workload such as bash run.sh or ./script.sh with the rocprofiler-compute native counter-collection tool, the intermediate shell process can drop or fail to forward the ROCPROF* environment variables that drive the LD_PRELOADed librocprofiler-compute-tool.so inside the real workload. Because the tool only sees a subset of its configuration when it is loaded into the workload child, native counter collection runs with default or partial settings and silently produces incorrect or empty results, which is hard for users to diagnose without inspecting child env. This is a real blocker for any workflow that wraps the GPU executable in a shell script, including most CI launchers and environment-setup wrappers. We need to address it now so shell-driven workloads produce the same profile output as binary-launched ones, regardless of how the entrypoint is structured.

## Technical Details

This change introduces an explicit environment-republish step inside the rocprofiler-compute SDK tool, gated by a new ROCPROF_SHELL_TARGET signal that the Python launcher sets only when it can prove both that the native counter tool is in use and that the workload command looks shell-like. The republish snapshots environ once at tool initialization, then re-setenvs every key whose name starts with ROCPROF when the shell flag is observed, so downstream child processes inherit the full configuration even if an intermediate shell strips it.

- Add a new EnvironmentSetUp class in src/lib/rocprofiler_compute_tool/tool_setup.{h,cpp} that builds an env cache from extern environ, exposes is_shell_target() against ROCPROF_SHELL_TARGET=1, and republishes every env var whose key starts with ROCPROF (including ROCPROF_* and ROCPROFILER_*) via setenv with overwrite=1.
- Update rocprofiler_configure in src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp to lazily construct the default EnvironmentSetUp and invoke setUp() before configuring callbacks, with a test_knobs::set_tool_setup hook that allows gtest fixtures to inject a mock implementation.
- Add is_shell_target(target: str) helper in src/utils/utils_profile.py that recognises common POSIX shells (bash, sh, dash, zsh, ksh, fish, csh, tcsh) and shell script extensions (.sh, .bash, .zsh, .ksh, .csh) by inspecting both basename and suffix.
- In src/rocprof_compute_profile/profiler_rocprofiler_sdk.py, set ROCPROF_SHELL_TARGET=1 in the SDK options only when a native_tool_path is configured AND is_shell_target(args.remaining) returns true, so the republish behavior never activates for non-shell launches.
- Cover the C++ side with a TestEnvironmentSetUp gtest fixture in src/lib/rocprofiler_compute_tool/tests/test_tool_setup.cpp plus supporting MockEnvironmentSetUp scaffolding, validating env-cache construction, the shell-detect predicate, the prefix-filtered republish, and the setUp branching for shell vs non-shell targets.
- Cover the Python side with parameterised tests in tests/test_utils_profile.py for is_shell_target, plus new cases in tests/test_profiler_base.py asserting that ROCPROF_SHELL_TARGET is injected only when both the native tool path and a shell-like command are present.
- Register the new pytest module test_utils_profile in CMakeLists.txt and add it to the quick, standard, comprehensive, and full categories in tests/test_categories.yaml so it runs in CI alongside the existing suites.

## JIRA ID

ROCM-21212

## Test Plan


- [x] Run gtest
- [x] Run pytest
- [x] CI 

## Test Result

- [X] Gtests pass
- [X] pytests pass
- [X] CI passed, except test_autogen_config, which is failing for the past few hours in CI.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.