### PR TITLE
[rocprofiler-sdk] PCS tests: uknown line number filtering

### DIFF
--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/exec_mask_manipulation/json.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/exec_mask_manipulation/json.py
@@ -203,9 +203,22 @@ def validate_json_exec_mask_manipulation(
                 # validate instruction decoding
                 inst = instructions[inst_index]
                 comm = comments[inst_index]
-                # The instruction comment is isually in the following format:
+                # The instruction comment is usually in the following format:
                 # /path/to/source/file.cpp:line_num
-                line_num = int(comm.split(":")[-1])
+                # However, compiler-generated control-flow instructions
+                # (e.g., s_andn2_saveexec, s_or_b64, s_cbranch_execz,
+                # s_branch, v_mov_b32) used for SIMD divergence may have
+                # DWARF line number 0, rendered as "?". These instructions
+                # are not v_rcp_f64/v_rcp_f32 and have no meaningful source
+                # line or exec mask to validate — skip them.
+                line_num_str = comm.split(":")[-1]
+                if line_num_str == "?":
+                    assert not inst.startswith("v_rcp_f64") and not inst.startswith(
+                        "v_rcp_f32"
+                    ), f"v_rcp instruction unexpectedly has unknown source line: {inst}"
+                    continue
+
+                line_num = int(line_num_str)
                 if inst.startswith("v_rcp_f64"):
                     # even SIMD lanes active
                     # assert np.uint64(exec_mask) == even_simds_active_exec_mask


### PR DESCRIPTION
Dropping samples with uknown line numbers in checks that require line numbers.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
                # The instruction comment is usually in the following format:
                # /path/to/source/file.cpp:line_num
                # However, compiler-generated control-flow instructions
                # (e.g., s_andn2_saveexec, s_or_b64, s_cbranch_execz,
                # s_branch, v_mov_b32) used for SIMD divergence may have
                # DWARF line number 0, rendered as "?". These instructions
                # are not v_rcp_f64/v_rcp_f32 and have no meaningful source
                # line or exec mask to validate — skip them.
## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
