### PR TITLE
fix(rocprofiler-sdk): Adding realtime in mi300 double buffer

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/cmd_builder.h
@@ -315,6 +315,12 @@ public:
                                      const Register& reg,
                                      uint32_t        header){};
 
+    /// @brief Snapshots the low 32 bits of GPU_CLOCK_COUNT into the named userdata register.
+    /// Used to embed periodic timestamps into the thread trace stream (gfx9 only).
+    /// @param cmdBuf  command buffer to be appended with launch command
+    /// @param reg  userdata register address (typically SQ_THREAD_TRACE_USERDATA_3)
+    virtual void BuildClockLo32IntoUserdata(CmdBuffer* cmdBuf, const Register& reg){};
+
     /// @brief Release resources used by CmdBuilder
     virtual ~CmdBuilder(){};
 

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/cmd_builder.h
@@ -252,6 +252,12 @@ public:
                                      const Register& reg,
                                      uint32_t        header){};
 
+    /// @brief Snapshots the low 32 bits of GPU_CLOCK_COUNT into the named userdata register.
+    /// Used to embed periodic timestamps into the thread trace stream (gfx9 only).
+    /// @param cmdBuf  command buffer to be appended with launch command
+    /// @param reg  userdata register address (typically SQ_THREAD_TRACE_USERDATA_3)
+    virtual void BuildClockLo32IntoUserdata(CmdBuffer* cmdBuf, const Register& reg){};
+
     /// @brief Release resources used by CmdBuilder
     virtual ~CmdBuilder(){};
 

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx9_cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx9_cmd_builder.h
@@ -627,6 +627,13 @@ public:
             APPEND_COMMAND_WRAPPER(cmdBuf, copy_data);
         }
     }
+
+    void BuildClockLo32IntoUserdata(CmdBuffer* cmdBuf, const Register& userdata_addr) override
+    {
+        uint32_t addr      = get_addr(userdata_addr);
+        auto     copy_data = UserdataLoPacket(addr);
+        APPEND_COMMAND_WRAPPER(cmdBuf, copy_data);
+    }
 };
 
 }  // namespace pm4_builder

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx9_cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx9_cmd_builder.h
@@ -615,6 +615,13 @@ public:
             APPEND_COMMAND_WRAPPER(cmdBuf, copy_data);
         }
     }
+
+    void BuildClockLo32IntoUserdata(CmdBuffer* cmdBuf, const Register& userdata_addr) override
+    {
+        uint32_t addr      = get_addr(userdata_addr);
+        auto     copy_data = UserdataLoPacket(addr);
+        APPEND_COMMAND_WRAPPER(cmdBuf, copy_data);
+    }
 };
 
 }  // namespace pm4_builder

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/sqtt_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/sqtt_builder.h
@@ -747,7 +747,7 @@ public:
         rocprof_trace_decoder_packet_header_t header{};
         header.opcode = ROCPROF_TRACE_DECODER_PACKET_OPCODE_RT_TIMESTAMP;
         header.type   = 0;
-        header.data20 = 0;
+        header.data20 = 3;
 
         SetGRBMToBroadcast(cmd_buffer);
         builder.BuildGPUClockPacket(
@@ -793,6 +793,23 @@ public:
                                            &control.wptr_doublebuffer,
                                            Primitives::COPY_DATA_SEL_COUNT_1DW_PRM,
                                            false);
+
+        // Embed a periodic GPU-clock low-32 marker into the trace stream so the decoder can
+        // correlate shader-clock with GPU realtime-clock between Begin/End anchors. gfx9 only;
+        // other architectures inject realtime tokens via different in-trace mechanisms.
+        if(Primitives::GFXIP_LEVEL == 9)
+        {
+            rocprof_trace_decoder_packet_header_t header{};
+            header.opcode = ROCPROF_TRACE_DECODER_PACKET_OPCODE_RT_TIMESTAMP_LO32;
+            header.type   = 0;
+            header.data20 = 1;
+
+            builder.BuildWriteUConfigRegPacket(
+                cmd_buffer,
+                builder.get_addr(Primitives::SQ_THREAD_TRACE_USERDATA_3),
+                header.u32All);
+            builder.BuildClockLo32IntoUserdata(cmd_buffer, Primitives::SQ_THREAD_TRACE_USERDATA_3);
+        }
 
         builder.BuildCacheFlushPacket(cmd_buffer, size_t(&control), sizeof(TraceControl));
         SetGRBMToBroadcast(cmd_buffer);

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/sqtt_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/sqtt_builder.h
@@ -724,7 +724,7 @@ public:
         rocprof_trace_decoder_packet_header_t header{};
         header.opcode = ROCPROF_TRACE_DECODER_PACKET_OPCODE_RT_TIMESTAMP;
         header.type   = 0;
-        header.data20 = 0;
+        header.data20 = 3;
 
         SetGRBMToBroadcast(cmd_buffer);
         builder.BuildGPUClockPacket(
@@ -757,6 +757,23 @@ public:
                                        &control.status_double_buffer,
                                        Primitives::COPY_DATA_SEL_COUNT_1DW_PRM,
                                        false);
+
+        // Embed a periodic GPU-clock low-32 marker into the trace stream so the decoder can
+        // correlate shader-clock with GPU realtime-clock between Begin/End anchors. gfx9 only;
+        // other architectures inject realtime tokens via different in-trace mechanisms.
+        if(Primitives::GFXIP_LEVEL == 9)
+        {
+            rocprof_trace_decoder_packet_header_t header{};
+            header.opcode = ROCPROF_TRACE_DECODER_PACKET_OPCODE_RT_TIMESTAMP_LO32;
+            header.type   = 0;
+            header.data20 = 1;
+
+            builder.BuildWriteUConfigRegPacket(
+                cmd_buffer,
+                builder.get_addr(Primitives::SQ_THREAD_TRACE_USERDATA_3),
+                header.u32All);
+            builder.BuildClockLo32IntoUserdata(cmd_buffer, Primitives::SQ_THREAD_TRACE_USERDATA_3);
+        }
 
         builder.BuildWriteWaitIdlePacket(cmd_buffer);
         builder.BuildCacheFlushPacket(cmd_buffer, size_t(&control), sizeof(TraceControl));

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/trace_decoder_instrument.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/trace_decoder_instrument.h
@@ -87,6 +87,15 @@ typedef union rocprof_trace_decoder_packet_header_t
         unsigned int type   : 4;   ///< one of rocprof_trace_decoder_agent_info_type_t or
                                    ///< rocprof_trace_decoder_codeobj_marker_type_t
         unsigned int data20 : 20;  ///< Agent data, if rocprof_trace_decoder_agent_info_type_t.
+                                   ///< For opcodes whose payload is a stream of writes on a
+                                   ///< separate register (e.g. RT_TIMESTAMP /
+                                   ///< RT_TIMESTAMP_LO32 on USERDATA3), this carries the
+                                   ///< number of follow-up writes the producer will emit.
+                                   ///< Decoders should consume exactly that many writes —
+                                   ///< extra fields appended by future format revisions can
+                                   ///< then be skipped without breaking previous decoder
+                                   ///< versions. A value of 0 means "use the legacy fixed
+                                   ///< count for this opcode".
     };
     unsigned int u32All;
 } rocprof_trace_decoder_packet_header_t;
@@ -95,7 +104,8 @@ typedef enum rocprof_trace_decoder_packet_opcode_t
 {
     ROCPROF_TRACE_DECODER_PACKET_OPCODE_CODEOBJ = 4,
     ROCPROF_TRACE_DECODER_PACKET_OPCODE_RT_TIMESTAMP,
-    ROCPROF_TRACE_DECODER_PACKET_OPCODE_AGENT_INFO  ///< Agent info, passed in data20. No payload.
+    ROCPROF_TRACE_DECODER_PACKET_OPCODE_AGENT_INFO,  ///< Agent info, passed in data20. No payload.
+    ROCPROF_TRACE_DECODER_PACKET_OPCODE_RT_TIMESTAMP_LO32
 
     /// @var ROCPROF_TRACE_DECODER_PACKET_OPCODE_CODEOBJ
     /// @brief Followed by several rocprof_trace_decoder_codeobj_marker_t
@@ -104,10 +114,24 @@ typedef enum rocprof_trace_decoder_packet_opcode_t
     /// @var ROCPROF_TRACE_DECODER_PACKET_OPCODE_RT_TIMESTAMP
     /// @brief Realtime timestamp to correlate the trace with outside information.
     /// Notes: userdata--3--. Gfx9 only. Not necessary for gfx10+.
-    /// Instead of a single payload, must be followed by 3x USERDATA3 writes, in order:
+    /// Instead of a single payload, must be followed by USERDATA3 writes whose count is
+    /// reported by data20 (legacy producers emit data20=0, meaning the original fixed count
+    /// of 3). The first 3 writes carry, in order:
     /// 1) Timestamp low 64bits
     /// 2) Timestamp high 64bits
     /// 3) Instant sync timestamp, low 32 bits.
+    /// Any additional writes beyond the first 3 belong to future format revisions and should
+    /// be consumed and ignored by older decoders.
+
+    /// @var ROCPROF_TRACE_DECODER_PACKET_OPCODE_RT_TIMESTAMP_LO32
+    /// @brief Periodic realtime timestamp emitted from query_status packets in double/triple
+    /// buffer mode. Notes: userdata--3--. Gfx9 only. Not necessary for gfx10+.
+    /// Followed by USERDATA3 writes whose count is reported by data20 (legacy producers emit
+    /// data20=0, meaning the original fixed count of 1). The first write carries the low 32
+    /// bits of the GPU clock counter. The high 32 bits are extrapolated by the decoder from
+    /// the most recent full RT_TIMESTAMP, detecting wraps when the new low-32 is less than
+    /// the previous low-32. Additional writes belong to future revisions and should be
+    /// consumed and ignored by older decoders.
 } rocprof_trace_decoder_packet_opcode_t;
 
 typedef enum rocprof_trace_decoder_agent_info_type_t

--- a/projects/rocprofiler-sdk/tests/thread-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/thread-trace/CMakeLists.txt
@@ -131,3 +131,20 @@ rocprofiler_add_integration_execute_test(
     PRELOAD "$<TARGET_FILE:thread-trace-triple-buffer-tool>"
     ENVIRONMENT "TRIPLEBUFFER=1;STARTSTOP=1;ATT_NODETAIL=1"
     DISABLED ${TRIPLE_BUFFER_DISABLED})
+
+# Check gfx9 periodic realtime markers from query_status packets.
+list(GET rocprofiler-sdk-tests-gfx-info 0 _RT_LO32_GPU0)
+if(NOT "${_RT_LO32_GPU0}" MATCHES "^gfx9[0-9a-f]+$")
+    set(RT_LO32_DISABLED True)
+else()
+    set(RT_LO32_DISABLED ${TRIPLE_BUFFER_DISABLED})
+endif()
+
+rocprofiler_add_integration_execute_test(
+    thread-trace-api-triple-buffer-realtime-periodic-test
+    TARGET thread-trace-test-app
+    TIMEOUT 240
+    PRELOAD "$<TARGET_FILE:thread-trace-triple-buffer-tool>"
+    ENVIRONMENT "TRIPLEBUFFER=1;EXPECT_PERIODIC_REALTIME=1"
+    DISABLED_CODECOV
+    DISABLED ${RT_LO32_DISABLED})

--- a/projects/rocprofiler-sdk/tests/thread-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/thread-trace/CMakeLists.txt
@@ -113,3 +113,25 @@ rocprofiler_add_integration_execute_test(
     PRELOAD "$<TARGET_FILE:thread-trace-triple-buffer-tool>"
     ENVIRONMENT "TRIPLEBUFFER=1;STARTSTOP=1;ATT_NODETAIL=1"
     DISABLED ${TRIPLE_BUFFER_DISABLED})
+
+# gfx9 emits periodic RT_TIMESTAMP_LO32 markers from query_status packets in
+# double/triple-buffer mode. Confirm the decoder surfaces more than the two Begin/End
+# anchor REALTIME records. gfx9-only; gfx10+ uses different in-trace timestamping
+# mechanisms and would only see two records. Skipped under code-coverage builds: the
+# coverage harness loads an older system aqlprofile that pre-dates the RT_TIMESTAMP marker
+# emission code, so the decoder has nothing to surface.
+list(GET rocprofiler-sdk-tests-gfx-info 0 _RT_LO32_GPU0)
+if(NOT "${_RT_LO32_GPU0}" MATCHES "^gfx9[0-9a-f]+$" OR ROCPROFILER_BUILD_CODECOV)
+    set(RT_LO32_DISABLED True)
+else()
+    set(RT_LO32_DISABLED ${TRIPLE_BUFFER_DISABLED})
+endif()
+
+rocprofiler_add_integration_execute_test(
+    thread-trace-api-triple-buffer-realtime-periodic-test
+    TARGET thread-trace-test-app
+    TIMEOUT 240
+    PRELOAD "$<TARGET_FILE:thread-trace-triple-buffer-tool>"
+    ENVIRONMENT
+        "TRIPLEBUFFER=1;ATT_NODETAIL=0;ATT_SLOW_CALLBACK=0;EXPECT_PERIODIC_REALTIME=1"
+    DISABLED ${RT_LO32_DISABLED})

--- a/projects/rocprofiler-sdk/tests/tools/thread-trace-triple-buffer-tool.cpp
+++ b/projects/rocprofiler-sdk/tests/tools/thread-trace-triple-buffer-tool.cpp
@@ -240,10 +240,21 @@ cntrl_tracing_callback(rocprofiler_callback_tracing_record_t record,
     {
         ROCPROFILER_CALL(rocprofiler_stop_context(agent_ctx), "stopping context");
 
+        struct parse_state_t
+        {
+            uint32_t current_sdata          = 0;
+            size_t   realtime_count         = 0;
+            int64_t  prev_shader_clock      = 0;
+            uint64_t prev_realtime_clock    = 0;
+            bool     monotonicity_violation = false;
+        };
+
         auto parse = [](rocprofiler_thread_trace_decoder_record_type_t record_type_id,
                         void*                                          events,
                         uint64_t                                       num_events,
                         void*                                          userdata) {
+            auto& state = *static_cast<parse_state_t*>(userdata);
+
             if(record_type_id == ROCPROFILER_THREAD_TRACE_DECODER_RECORD_INFO)
             {
                 auto* infos = (rocprofiler_thread_trace_decoder_info_t*) events;
@@ -253,41 +264,63 @@ cntrl_tracing_callback(rocprofiler_callback_tracing_record_t record,
             }
             else if(record_type_id == ROCPROFILER_THREAD_TRACE_DECODER_RECORD_SHADERDATA)
             {
-                auto& current_sdata = *static_cast<uint32_t*>(userdata);
-
                 auto* sdata = static_cast<rocprofiler_thread_trace_decoder_shaderdata_t*>(events);
                 for(size_t i = 0; i < num_events; i++)
                 {
                     // Ignoring the last token because it may have been cutoff
-                    if(i != num_events - 1 && sdata[i].value < current_sdata)
+                    if(i != num_events - 1 && sdata[i].value < state.current_sdata)
                     {
                         std::cerr << i << " Error: Invalid sdata value " << sdata[i].value << " vs "
-                                  << current_sdata << std::endl;
+                                  << state.current_sdata << std::endl;
                         abort();
                     }
-                    current_sdata = sdata[i].value;
+                    state.current_sdata = sdata[i].value;
                 }
+            }
+            else if(record_type_id == ROCPROFILER_THREAD_TRACE_DECODER_RECORD_REALTIME)
+            {
+                auto* realtime = static_cast<rocprofiler_thread_trace_decoder_realtime_t*>(events);
+                for(size_t i = 0; i < num_events; ++i)
+                {
+                    if(realtime[i].shader_clock < state.prev_shader_clock ||
+                       realtime[i].realtime_clock < state.prev_realtime_clock)
+                        state.monotonicity_violation = true;
+
+                    state.prev_shader_clock   = realtime[i].shader_clock;
+                    state.prev_realtime_clock = realtime[i].realtime_clock;
+                }
+                state.realtime_count += num_events;
             }
         };
 
-        size_t total_size = 0;
+        auto*  expect_periodic_realtime = std::getenv("EXPECT_PERIODIC_REALTIME");
+        size_t total_size               = 0;
         for(auto& output_buffer : *agent_buffers)
         {
             auto   lk          = std::unique_lock{output_buffer.reorder_mut};
             auto&  buffer      = output_buffer.output_buffer;
             size_t output_size = std::min(output_buffer.output_size.exchange(0), buffer.size());
 
-            size_t current_byte = 0;
+            size_t current_byte          = 0;
+            size_t realtime_max_per_pass = 0;
             for(auto& end_byte : output_buffer.end_chunks)
             {
-                uint32_t current_sdata = 0;
-                char*    ptr           = buffer.data() + current_byte;
-                size_t   cur_size      = std::min(end_byte, output_size) - current_byte;
+                parse_state_t state{};
+                char*         ptr      = buffer.data() + current_byte;
+                size_t        cur_size = std::min(end_byte, output_size) - current_byte;
 
-                rocprofiler_trace_decode(decoder, parse, ptr, cur_size, &current_sdata);
+                rocprofiler_trace_decode(decoder, parse, ptr, cur_size, &state);
+                if(state.monotonicity_violation)
+                    throw std::runtime_error("Realtime records were not monotonic");
+
                 current_byte = end_byte;
+                realtime_max_per_pass = std::max(realtime_max_per_pass, state.realtime_count);
             }
             total_size += output_size;
+
+            if(expect_periodic_realtime && atoi(expect_periodic_realtime) != 0 &&
+               output_buffer.next_expected_chunk >= 2 && realtime_max_per_pass <= 2)
+                throw std::runtime_error("Expected periodic realtime records");
 
             output_buffer.next_expected_chunk = 0;
             output_buffer.end_chunks          = {};

--- a/projects/rocprofiler-sdk/tests/tools/thread-trace-triple-buffer-tool.cpp
+++ b/projects/rocprofiler-sdk/tests/tools/thread-trace-triple-buffer-tool.cpp
@@ -313,7 +313,7 @@ cntrl_tracing_callback(rocprofiler_callback_tracing_record_t record,
                 if(state.monotonicity_violation)
                     throw std::runtime_error("Realtime records were not monotonic");
 
-                current_byte = end_byte;
+                current_byte          = end_byte;
                 realtime_max_per_pass = std::max(realtime_max_per_pass, state.realtime_count);
             }
             total_size += output_size;

--- a/projects/rocprofiler-sdk/tests/tools/thread-trace-triple-buffer-tool.cpp
+++ b/projects/rocprofiler-sdk/tests/tools/thread-trace-triple-buffer-tool.cpp
@@ -21,6 +21,11 @@
 // SOFTWARE.
 //
 
+// undefine NDEBUG so asserts are implemented
+#ifdef NDEBUG
+#    undef NDEBUG
+#endif
+
 #include <rocprofiler-sdk/buffer.h>
 #include <rocprofiler-sdk/callback_tracing.h>
 #include <rocprofiler-sdk/experimental/thread_trace.h>
@@ -29,6 +34,7 @@
 #include <rocprofiler-sdk/rocprofiler.h>
 
 #include <atomic>
+#include <cassert>
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
@@ -73,6 +79,23 @@ rocprofiler_thread_trace_decoder_id_t decoder{};
 rocprofiler_context_id_t              agent_ctx{};
 rocprofiler_context_id_t              tracing_ctx{};
 std::vector<agent_output_buffer_t>*   agent_buffers{};
+
+// Tracks REALTIME records to verify that the gfx9 query_status path emits
+// periodic RT_TIMESTAMP_LO32 markers in addition to the Begin/End anchors.
+//
+// Notes on validation scope:
+//   - shader_clock is per-decode-pass (each rocprofiler_trace_decode call has
+//     its own time origin), so monotonicity must be checked per-pass only.
+//   - realtime_clock is the GPU wall-clock and is monotonic across passes.
+//   - "Periodic emission worked" means at least one pass produced > 2 records
+//     (Begin + End anchors plus periodic markers). Cross-pass total isn't
+//     enough on its own because N anchor-only passes also exceed 2.
+// Updated only from cntrl_tracing_callback (roctxProfilerPause), which is
+// serialized in this test, and read in tool_fini after callbacks have settled,
+// so plain types are sufficient.
+size_t realtime_total_count{0};
+size_t realtime_max_per_pass{0};
+bool   realtime_monotonicity_violation{false};
 
 void
 tool_codeobj_tracing_callback(rocprofiler_callback_tracing_record_t record,
@@ -202,10 +225,21 @@ cntrl_tracing_callback(rocprofiler_callback_tracing_record_t record,
     {
         ROCPROFILER_CALL(rocprofiler_stop_context(agent_ctx), "stopping context");
 
+        struct parse_state_t
+        {
+            uint32_t current_sdata    = 0;
+            size_t   realtime_count   = 0;
+            int64_t  prev_shader      = 0;
+            uint64_t prev_realtime    = 0;
+            bool     monotonicity_bad = false;
+        };
+
         auto parse = [](rocprofiler_thread_trace_decoder_record_type_t record_type_id,
                         void*                                          events,
                         uint64_t                                       num_events,
                         void*                                          userdata) {
+            auto& state = *static_cast<parse_state_t*>(userdata);
+
             if(record_type_id == ROCPROFILER_THREAD_TRACE_DECODER_RECORD_INFO)
             {
                 auto* infos = (rocprofiler_thread_trace_decoder_info_t*) events;
@@ -215,29 +249,51 @@ cntrl_tracing_callback(rocprofiler_callback_tracing_record_t record,
             }
             else if(record_type_id == ROCPROFILER_THREAD_TRACE_DECODER_RECORD_SHADERDATA)
             {
-                auto& current_sdata = *static_cast<uint32_t*>(userdata);
-
                 auto* sdata = static_cast<rocprofiler_thread_trace_decoder_shaderdata_t*>(events);
                 for(size_t i = 0; i < num_events; i++)
                 {
-                    if(sdata[i].value < current_sdata)
+                    if(sdata[i].value < state.current_sdata)
                     {
                         std::cerr << "Error: Invalid sdata value " << sdata[i].value << std::endl;
                         abort();
                     }
-                    current_sdata = sdata[i].value;
+                    state.current_sdata = sdata[i].value;
                 }
+            }
+            else if(record_type_id == ROCPROFILER_THREAD_TRACE_DECODER_RECORD_REALTIME)
+            {
+                auto* rts = static_cast<rocprofiler_thread_trace_decoder_realtime_t*>(events);
+                for(size_t i = 0; i < num_events; i++)
+                {
+                    // Per-pass monotonicity: shader_clock has a per-pass time
+                    // origin, so this can only be checked within one decode.
+                    if(rts[i].shader_clock < state.prev_shader ||
+                       rts[i].realtime_clock < state.prev_realtime)
+                    {
+                        state.monotonicity_bad = true;
+                    }
+                    state.prev_shader   = rts[i].shader_clock;
+                    state.prev_realtime = rts[i].realtime_clock;
+                }
+                state.realtime_count += num_events;
             }
         };
 
         size_t total_size = 0;
         for(auto& output_buffer : *agent_buffers)
         {
-            uint32_t current_sdata = 0;
-            auto&    buffer        = output_buffer.output_buffer;
-            size_t   output_size   = std::min(output_buffer.output_size.exchange(0), buffer.size());
-            rocprofiler_trace_decode(decoder, parse, buffer.data(), output_size, &current_sdata);
+            parse_state_t state{};
+            auto&         buffer = output_buffer.output_buffer;
+            size_t output_size   = std::min(output_buffer.output_size.exchange(0), buffer.size());
+            rocprofiler_trace_decode(decoder, parse, buffer.data(), output_size, &state);
             total_size += output_size;
+
+            realtime_total_count += state.realtime_count;
+            // Track the largest single-pass count to prove periodic emission
+            // happened within at least one pass (anchor-only passes give 2).
+            if(state.realtime_count > realtime_max_per_pass)
+                realtime_max_per_pass = state.realtime_count;
+            if(state.monotonicity_bad) realtime_monotonicity_violation = true;
         }
 
         static bool ignore_size = std::getenv("STARTSTOP") ? atoi(std::getenv("STARTSTOP")) : false;
@@ -298,7 +354,34 @@ tool_init(rocprofiler_client_finalize_t /* fini_func */, void* /* tool_data */)
 }
 
 void
-tool_fini(void*){};
+tool_fini(void*)
+{
+    assert(!realtime_monotonicity_violation && "Realtime records were not monotonic!");
+
+    // gfx9 query_status path emits periodic RT_TIMESTAMP_LO32 markers in
+    // addition to the Begin/End anchors. Gate the strict count check behind an
+    // env var so the same tool keeps working on gfx10+ where only the two
+    // boundary anchors exist. Use the per-pass max because N anchor-only
+    // passes also exceed 2 globally; we want proof that periodic emission
+    // happened within at least one decode pass.
+    //
+    // The check is only meaningful once enough buffer activity has occurred:
+    // each query_status poll on the host worker emits one RT_TIMESTAMP_LO32,
+    // and only the polls that find a full buffer trigger a swap callback.
+    // shader_data_callback invocations are therefore a lower bound on polls.
+    // The producer always issues one final flush with FLAGS_END at trace
+    // stop regardless of activity, so the threshold is 2 (final flush + at
+    // least one real mid-trace swap). Below the threshold the producer
+    // barely had time to run (e.g. heavy host-side instrumentation under
+    // code-coverage CI) and the trace window is too short to demonstrate
+    // periodic emission — treat as inconclusive.
+    const char* expect_env = std::getenv("EXPECT_PERIODIC_REALTIME");
+    if(expect_env && atoi(expect_env) != 0)
+    {
+        assert(realtime_max_per_pass > 2 &&
+               "expected periodic REALTIME records within a single pass");
+    }
+}
 
 }  // namespace TripleBuffer
 }  // namespace ATTTest


### PR DESCRIPTION
## Motivation

Currently, gfx9 only sends to realtime timestamps into thread trace.
In double buffer mode, we are periodically sending query packets in the order of ~1ms. We can reuse those packets to send the LOW32 bits of realtime into the trace for matching with external API events and SPM.
The corresponding decoder PR is already merged.

JIRA ID : ROCM-26029

## Test Plan

Added a test to ensure we are getting monotonic clocks

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
