### PR TITLE
[rocprofiler-compute] Update rocprofiler-compute continuous CI runs to use Ubuntu 24.04

### DIFF
--- a/projects/rocprofiler-compute/.github/ci-matrix.yml
+++ b/projects/rocprofiler-compute/.github/ci-matrix.yml
@@ -12,6 +12,6 @@ matrix-ubuntu-nightly:
   - { os-release: '24.04', gpu: 'strix-halo', arch: 'gfx1151', runner: 'linux-strix-halo-gpu-rocm' }
 matrix-ubuntu-ci:
   # MI355
-  - { os-release: '22.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }
+  - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }
   # Strix Halo
-  - { os-release: '22.04', gpu: 'strix-halo', arch: 'gfx1151', runner: 'linux-strix-halo-gpu-rocm' }
+  - { os-release: '24.04', gpu: 'strix-halo', arch: 'gfx1151', runner: 'linux-strix-halo-gpu-rocm' }


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Switching continuous CI runs of rocprofiler-compute to use Ubuntu Noble (24.04) instead of Ubuntu Jammy (22.04)

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Update `projects/rocprofiler-compute/.github/ci-matrix.yml` to use Ubuntu 24.04 for continuous runs

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Ensure workflow from PR uses the new Ubuntu versions

## Test Result

<!-- Briefly summarize test outcomes. -->
Tests run with expected OS version and pass

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
