### PR TITLE
ROCM-21854 - Cache memory agent

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -617,6 +617,8 @@ inline void DmaBlitManager::resolveAgents(const Memory& srcMem, const Memory& ds
           Hsa::pointer_info(const_cast<address>(srcAddr), &info, nullptr, nullptr, nullptr)) {
         srcAgent = info.agentOwner;
       }
+    } else {
+        srcAgent = srcMem.isHostMemDirectAccess() ? srcMem.dev().getCpuAgent() : srcMem.dev().getBackendDevice();
     }
   }
   if (dstAgent.handle == 0) {
@@ -627,6 +629,8 @@ inline void DmaBlitManager::resolveAgents(const Memory& srcMem, const Memory& ds
       if (HSA_STATUS_SUCCESS == Hsa::pointer_info(dstAddr, &info, nullptr, nullptr, nullptr)) {
         dstAgent = info.agentOwner;
       }
+    } else {
+        dstAgent = dstMem.isHostMemDirectAccess() ? dstMem.dev().getCpuAgent() : dstMem.dev().getBackendDevice();
     }
   }
 }

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -603,16 +603,9 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
 inline void DmaBlitManager::resolveAgents(const Memory& srcMem, const Memory& dstMem,
                                           address srcAddr, address dstAddr,
                                           hsa_agent_t& srcAgent, hsa_agent_t& dstAgent) const {
-  if (&srcMem.dev() == &dstMem.dev()) {
-    // Different devices -- use each memory's device backend agent
-    srcAgent = srcMem.dev().getBackendDevice();
-    dstAgent = dstMem.dev().getBackendDevice();
-  } else {
-    // Use agents stored in memory objects during creation
-    srcAgent = srcMem.getOwningAgent();
-    dstAgent = dstMem.getOwningAgent();
-
-  }
+  // Use agents stored in memory objects during creation
+  srcAgent = srcMem.getOwningAgent();
+  dstAgent = dstMem.getOwningAgent();
 
   // Handle invalid agent (shouldn't happen if create() properly initialized)
   if (srcAgent.handle == 0) {

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -604,12 +604,19 @@ inline void DmaBlitManager::resolveAgents(const Memory& srcMem, const Memory& ds
                                           address srcAddr, address dstAddr,
                                           hsa_agent_t& srcAgent, hsa_agent_t& dstAgent) const {
   if (&srcMem.dev() == &dstMem.dev()) {
-    // Same device -- detect agents from memory access type
-    srcAgent = srcMem.isHostMemDirectAccess() ? dev().getCpuAgent() : dev().getBackendDevice();
-    dstAgent = dstMem.isHostMemDirectAccess() ? dev().getCpuAgent() : dev().getBackendDevice();
+    // Different devices -- use each memory's device backend agent
+    srcAgent = srcMem.dev().getBackendDevice();
+    dstAgent = dstMem.dev().getBackendDevice();
+  } else {
+    // Use agents stored in memory objects during creation
+    srcAgent = srcMem.getOwningAgent();
+    dstAgent = dstMem.getOwningAgent();
 
-    // IPC/VMM-imported buffers: the runtime doesn't know the real owning agent,
-    // so query pointer_info to resolve the true agent.
+  }
+
+  // Handle invalid agent (shouldn't happen if create() properly initialized)
+  if (srcAgent.handle == 0) {
+    srcAgent = srcMem.isHostMemDirectAccess() ? dev().getCpuAgent() : dev().getBackendDevice();
     if (static_cast<const amd::Memory*>(srcMem.owner())->ipcShared() ||
         static_cast<const amd::Memory*>(srcMem.owner())->vmmImported()) {
       hsa_amd_pointer_info_t info = {sizeof(hsa_amd_pointer_info_t)};
@@ -618,6 +625,9 @@ inline void DmaBlitManager::resolveAgents(const Memory& srcMem, const Memory& ds
         srcAgent = info.agentOwner;
       }
     }
+  }
+  if (dstAgent.handle == 0) {
+    dstAgent = dstMem.isHostMemDirectAccess() ? dev().getCpuAgent() : dev().getBackendDevice();
     if (static_cast<const amd::Memory*>(dstMem.owner())->ipcShared() ||
         static_cast<const amd::Memory*>(dstMem.owner())->vmmImported()) {
       hsa_amd_pointer_info_t info = {sizeof(hsa_amd_pointer_info_t)};
@@ -625,10 +635,6 @@ inline void DmaBlitManager::resolveAgents(const Memory& srcMem, const Memory& ds
         dstAgent = info.agentOwner;
       }
     }
-  } else {
-    // Different devices -- use each memory's device backend agent
-    srcAgent = srcMem.dev().getBackendDevice();
-    dstAgent = dstMem.dev().getBackendDevice();
   }
 }
 

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -603,32 +603,16 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
 inline void DmaBlitManager::resolveAgents(const Memory& srcMem, const Memory& dstMem,
                                           address srcAddr, address dstAddr,
                                           hsa_agent_t& srcAgent, hsa_agent_t& dstAgent) const {
-  if (&srcMem.dev() == &dstMem.dev()) {
-    // Same device -- detect agents from memory access type
-    srcAgent = srcMem.isHostMemDirectAccess() ? dev().getCpuAgent() : dev().getBackendDevice();
-    dstAgent = dstMem.isHostMemDirectAccess() ? dev().getCpuAgent() : dev().getBackendDevice();
+  // Use agents stored in memory objects during creation
+  srcAgent = srcMem.getOwningAgent();
+  dstAgent = dstMem.getOwningAgent();
 
-    // IPC/VMM-imported buffers: the runtime doesn't know the real owning agent,
-    // so query pointer_info to resolve the true agent.
-    if (static_cast<const amd::Memory*>(srcMem.owner())->ipcShared() ||
-        static_cast<const amd::Memory*>(srcMem.owner())->vmmImported()) {
-      hsa_amd_pointer_info_t info = {sizeof(hsa_amd_pointer_info_t)};
-      if (HSA_STATUS_SUCCESS ==
-          Hsa::pointer_info(const_cast<address>(srcAddr), &info, nullptr, nullptr, nullptr)) {
-        srcAgent = info.agentOwner;
-      }
-    }
-    if (static_cast<const amd::Memory*>(dstMem.owner())->ipcShared() ||
-        static_cast<const amd::Memory*>(dstMem.owner())->vmmImported()) {
-      hsa_amd_pointer_info_t info = {sizeof(hsa_amd_pointer_info_t)};
-      if (HSA_STATUS_SUCCESS == Hsa::pointer_info(dstAddr, &info, nullptr, nullptr, nullptr)) {
-        dstAgent = info.agentOwner;
-      }
-    }
-  } else {
-    // Different devices -- use each memory's device backend agent
-    srcAgent = srcMem.dev().getBackendDevice();
-    dstAgent = dstMem.dev().getBackendDevice();
+  // Handle invalid agent (shouldn't happen if create() properly initialized)
+  if (srcAgent.handle == 0) {
+    srcAgent = srcMem.isHostMemDirectAccess() ? dev().getCpuAgent() : dev().getBackendDevice();
+  }
+  if (dstAgent.handle == 0) {
+    dstAgent = dstMem.isHostMemDirectAccess() ? dev().getCpuAgent() : dev().getBackendDevice();
   }
 }
 
@@ -668,12 +652,9 @@ bool DmaBlitManager::hsaCopyBatch(const std::vector<amd::BatchCopyOp>& copyOps,
     return true;
   }
 
-  // Build the array of HSA copy operation descriptors
-  std::vector<hsa_amd_memory_copy_op_t> hsaCopyOps;
-  hsaCopyOps.reserve(copyOps.size());
-
-  hsa_agent_t cpuAgent = dev().getCpuAgent();
-  hsa_agent_t backendDevice = dev().getBackendDevice();
+  // Resolve agents for each operation, then delegate to hsaCopyBatchWithAgents
+  std::vector<ResolvedAgents> resolvedAgents;
+  resolvedAgents.reserve(copyOps.size());
 
   for (const auto& op : copyOps) {
     const Memory& srcMem = gpuMem(*op.srcMemory->getDeviceMemory(
@@ -684,53 +665,12 @@ bool DmaBlitManager::hsaCopyBatch(const std::vector<amd::BatchCopyOp>& copyOps,
     address src = reinterpret_cast<address>(srcMem.getDeviceMemory()) + op.srcOffset;
     address dst = reinterpret_cast<address>(dstMem.getDeviceMemory()) + op.dstOffset;
 
-    hsa_agent_t srcAgent;
-    hsa_agent_t dstAgent;
-    resolveAgents(srcMem, dstMem, src, dst, srcAgent, dstAgent);
-
-    // Normalize agents to ensure the calling device's SDMA engines are used,
-    // matching the rocrCopyBuffer agent selection logic.
-    if (srcAgent.handle != dstAgent.handle &&
-        srcAgent.handle != cpuAgent.handle && dstAgent.handle != cpuAgent.handle) {
-      // P2P: force calling device's backend as src_agent, peer as dst_agent.
-      // ROCr selects copy_agent from src_agent, so this ensures the calling
-      // device's SDMA engines are used.
-      dstAgent = (srcAgent.handle == backendDevice.handle) ? dstAgent : srcAgent;
-      srcAgent = backendDevice;
-    }
-
-    hsa_amd_memory_copy_op_t hsaOp = {};
-    hsaOp.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
-    hsaOp.src = src;
-    hsaOp.src_agent = srcAgent;
-    hsaOp.dst = dst;
-    hsaOp.dst_agent = dstAgent;
-    hsaOp.size = op.size;
-
-    switch (op.metadata.copyOpType_) {
-    case amd::CopyMetadata::kCopyOpSwap:
-      hsaOp.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP;
-      hsaOp.src_size = op.size;
-      hsaOp.dst_size = op.size;
-      break;
-    case amd::CopyMetadata::kCopyOpIndirectSrc:
-      hsaOp.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRC;
-      break;
-    case amd::CopyMetadata::kCopyOpIndirectDst:
-      hsaOp.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_DST;
-      break;
-    case amd::CopyMetadata::kCopyOpIndirectSrcDst:
-      hsaOp.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST;
-      break;
-    default:
-      hsaOp.type = HSA_AMD_MEMORY_COPY_OP_LINEAR;
-      break;
-    }
-
-    hsaCopyOps.push_back(hsaOp);
+    ResolvedAgents agents;
+    resolveAgents(srcMem, dstMem, src, dst, agents.srcAgent, agents.dstAgent);
+    resolvedAgents.push_back(agents);
   }
 
-  return rocrCopyBufferBatch(hsaCopyOps, externalWaitEvents, outBatchSignals);
+  return hsaCopyBatchWithAgents(copyOps, resolvedAgents, externalWaitEvents, outBatchSignals);
 }
 
 // ================================================================================================
@@ -748,14 +688,13 @@ bool DmaBlitManager::hsaCopyBatchWithAgents(
   }
 
   // Build the array of HSA copy operation descriptors
-  std::vector<hsa_amd_memory_copy_op_t> hsaCopyOps;
-  hsaCopyOps.reserve(copyOps.size());
+  std::vector<hsa_amd_memory_copy_op_t> hsaCopyOps(copyOps.size());
 
   hsa_agent_t cpuAgent = dev().getCpuAgent();
   hsa_agent_t backendDevice = dev().getBackendDevice();
 
-  for (size_t i = 0; i < copyOps.size(); ++i) {
-    const auto& op = copyOps[i];
+  size_t i = 0;
+  for (const auto& op: copyOps) {
     const Memory& srcMem = gpuMem(*op.srcMemory->getDeviceMemory(
         *op.srcMemory->getContext().devices()[0]));
     const Memory& dstMem = gpuMem(*op.dstMemory->getDeviceMemory(
@@ -807,7 +746,7 @@ bool DmaBlitManager::hsaCopyBatchWithAgents(
       break;
     }
 
-    hsaCopyOps.push_back(hsaOp);
+    hsaCopyOps[i++] = hsaOp;
   }
 
   return rocrCopyBufferBatch(hsaCopyOps, externalWaitEvents, outBatchSignals);

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -734,6 +734,86 @@ bool DmaBlitManager::hsaCopyBatch(const std::vector<amd::BatchCopyOp>& copyOps,
 }
 
 // ================================================================================================
+bool DmaBlitManager::hsaCopyBatchWithAgents(
+    const std::vector<amd::BatchCopyOp>& copyOps,
+    const std::vector<ResolvedAgents>& resolvedAgents,
+    const std::vector<hsa_signal_t>* externalWaitEvents,
+    std::vector<ProfilingSignal*>* outBatchSignals) const {
+
+  assert(copyOps.size() == resolvedAgents.size() &&
+         "copyOps and resolvedAgents must have same size");
+
+  if (copyOps.empty()) {
+    return true;
+  }
+
+  // Build the array of HSA copy operation descriptors
+  std::vector<hsa_amd_memory_copy_op_t> hsaCopyOps;
+  hsaCopyOps.reserve(copyOps.size());
+
+  hsa_agent_t cpuAgent = dev().getCpuAgent();
+  hsa_agent_t backendDevice = dev().getBackendDevice();
+
+  for (size_t i = 0; i < copyOps.size(); ++i) {
+    const auto& op = copyOps[i];
+    const Memory& srcMem = gpuMem(*op.srcMemory->getDeviceMemory(
+        *op.srcMemory->getContext().devices()[0]));
+    const Memory& dstMem = gpuMem(*op.dstMemory->getDeviceMemory(
+        *op.dstMemory->getContext().devices()[0]));
+
+    address src = reinterpret_cast<address>(srcMem.getDeviceMemory()) + op.srcOffset;
+    address dst = reinterpret_cast<address>(dstMem.getDeviceMemory()) + op.dstOffset;
+
+    // Use pre-resolved agents instead of calling resolveAgents()
+    hsa_agent_t srcAgent = resolvedAgents[i].srcAgent;
+    hsa_agent_t dstAgent = resolvedAgents[i].dstAgent;
+
+    // Normalize agents to ensure the calling device's SDMA engines are used,
+    // matching the rocrCopyBuffer agent selection logic.
+    if (srcAgent.handle != dstAgent.handle &&
+        srcAgent.handle != cpuAgent.handle && dstAgent.handle != cpuAgent.handle) {
+      // P2P: force calling device's backend as src_agent, peer as dst_agent.
+      // ROCr selects copy_agent from src_agent, so this ensures the calling
+      // device's SDMA engines are used.
+      dstAgent = (srcAgent.handle == backendDevice.handle) ? dstAgent : srcAgent;
+      srcAgent = backendDevice;
+    }
+
+    hsa_amd_memory_copy_op_t hsaOp = {};
+    hsaOp.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
+    hsaOp.src = src;
+    hsaOp.src_agent = srcAgent;
+    hsaOp.dst = dst;
+    hsaOp.dst_agent = dstAgent;
+    hsaOp.size = op.size;
+
+    switch (op.metadata.copyOpType_) {
+    case amd::CopyMetadata::kCopyOpSwap:
+      hsaOp.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP;
+      hsaOp.src_size = op.size;
+      hsaOp.dst_size = op.size;
+      break;
+    case amd::CopyMetadata::kCopyOpIndirectSrc:
+      hsaOp.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRC;
+      break;
+    case amd::CopyMetadata::kCopyOpIndirectDst:
+      hsaOp.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_DST;
+      break;
+    case amd::CopyMetadata::kCopyOpIndirectSrcDst:
+      hsaOp.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST;
+      break;
+    default:
+      hsaOp.type = HSA_AMD_MEMORY_COPY_OP_LINEAR;
+      break;
+    }
+
+    hsaCopyOps.push_back(hsaOp);
+  }
+
+  return rocrCopyBufferBatch(hsaCopyOps, externalWaitEvents, outBatchSignals);
+}
+
+// ================================================================================================
 bool DmaBlitManager::rocrCopyBufferBatch(const std::vector<hsa_amd_memory_copy_op_t>& copyOps,
                                          const std::vector<hsa_signal_t>* externalWaitEvents,
                                          std::vector<ProfilingSignal*>* outBatchSignals) const {
@@ -2610,6 +2690,7 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
   // Partition into intra-device (kernel blit) and inter-device (DMA batch) groups.
   std::vector<amd::BatchCopyOp> d2dCopyOps;
   std::vector<amd::BatchCopyOp> p2pCopyOps;
+  std::vector<ResolvedAgents> p2pResolvedAgents;
 
   for (const auto& op : copyOps) {
     device::Memory* srcDevMem = op.srcMemory->getDeviceMemory(
@@ -2636,6 +2717,9 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
       d2dCopyOps.push_back(op);
     } else {
       p2pCopyOps.push_back(op);
+      // Cache the resolved agents for the p2p operation to avoid duplicate resolveAgents() call
+      ResolvedAgents agents{srcAgent, dstAgent};
+      p2pResolvedAgents.push_back(agents);
     }
   }
 
@@ -2645,7 +2729,7 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
   ProfilingSignal* lastBatchSignal = nullptr;
   if (!p2pCopyOps.empty()) {
     // Always pass prior wait events to maintain stream ordering for the batch.
-    if (!hsaCopyBatch(p2pCopyOps, &priorWaitEvents, &batchSignals)) {
+    if (!hsaCopyBatchWithAgents(p2pCopyOps, p2pResolvedAgents, &priorWaitEvents, &batchSignals)) {
       LogWarning(
           "KernelBlitManager::copyBufferBatch: Batch copy failed, falling back to copyBuffer");
       d2dCopyOps.insert(d2dCopyOps.end(), p2pCopyOps.begin(), p2pCopyOps.end());

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -211,7 +211,6 @@ class DmaBlitManager : public device::HostBlitManager {
     amd::Memory* pinnedMem_;  //!< Pinned Memory
     size_t copySize_;         //!< last copy size
   };
-
   //! Synchronizes the blit operations if necessary
   inline void synchronize() const;
 

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -211,6 +211,7 @@ class DmaBlitManager : public device::HostBlitManager {
     amd::Memory* pinnedMem_;  //!< Pinned Memory
     size_t copySize_;         //!< last copy size
   };
+
   //! Synchronizes the blit operations if necessary
   inline void synchronize() const;
 

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -211,6 +211,12 @@ class DmaBlitManager : public device::HostBlitManager {
     amd::Memory* pinnedMem_;  //!< Pinned Memory
     size_t copySize_;         //!< last copy size
   };
+
+  //! Structure to hold pre-resolved HSA agents for batch operations
+  struct ResolvedAgents {
+    hsa_agent_t srcAgent;
+    hsa_agent_t dstAgent;
+  };
   //! Synchronizes the blit operations if necessary
   inline void synchronize() const;
 
@@ -248,6 +254,12 @@ class DmaBlitManager : public device::HostBlitManager {
   bool hsaCopyBatch(const std::vector<amd::BatchCopyOp>& copyOps,
                     const std::vector<hsa_signal_t>* externalWaitEvents = nullptr,
                     std::vector<ProfilingSignal*>* outBatchSignals = nullptr) const;
+
+  //! Internal variant that accepts pre-resolved agents to avoid duplicate resolveAgents() calls
+  bool hsaCopyBatchWithAgents(const std::vector<amd::BatchCopyOp>& copyOps,
+                              const std::vector<ResolvedAgents>& resolvedAgents,
+                              const std::vector<hsa_signal_t>* externalWaitEvents = nullptr,
+                              std::vector<ProfilingSignal*>* outBatchSignals = nullptr) const;
 
   //! Batch version of rocrCopyBuffer
   bool rocrCopyBufferBatch(

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -24,6 +24,19 @@
 
 namespace amd::roc {
 
+// RAII guard to ensure owning agent is set on successful buffer creation
+class OwningAgentGuard {
+  Buffer* buffer_;
+  bool* success_;
+public:
+  OwningAgentGuard(Buffer* buf, bool* success) : buffer_(buf), success_(success) {}
+  ~OwningAgentGuard() {
+    if (success_ && *success_ && buffer_->getDeviceMemory() != nullptr) {
+      buffer_->computeAndSetOwningAgent();
+    }
+  }
+};
+
 // ======================================= roc::Memory ============================================
 Memory::Memory(const roc::Device& dev, amd::Memory& owner)
     : device::Memory(owner),
@@ -32,7 +45,8 @@ Memory::Memory(const roc::Device& dev, amd::Memory& owner)
       kind_(MEMORY_KIND_NORMAL),
       amdImageDesc_(nullptr),
       persistent_host_ptr_(nullptr),
-      pinnedMemory_(nullptr) {}
+      pinnedMemory_(nullptr),
+      owningAgentHandle_(0) {}
 
 Memory::Memory(const roc::Device& dev, size_t size)
     : device::Memory(size),
@@ -41,7 +55,8 @@ Memory::Memory(const roc::Device& dev, size_t size)
       kind_(MEMORY_KIND_NORMAL),
       amdImageDesc_(nullptr),
       persistent_host_ptr_(nullptr),
-      pinnedMemory_(nullptr) {}
+      pinnedMemory_(nullptr),
+      owningAgentHandle_(0) {}
 
 Memory::~Memory() {
   // Destory pinned memory
@@ -748,18 +763,21 @@ void Buffer::destroy() {
 
 // ================================================================================================
 bool Buffer::create(bool alloc_local) {
+  bool success = false;
+  OwningAgentGuard guard(this, &success);
+
   if (owner() == nullptr) {
     if (alloc_local) {
       deviceMemory_ = dev().deviceLocalAlloc(size());
       if (deviceMemory_ != nullptr) {
         flags_ |= HostMemoryDirectAccess;
-        return true;
+        return (success = true);
       }
     } else {
       deviceMemory_ = dev().hostAlloc(size(), 1, Device::MemorySegment::kNoAtomics);
       if (deviceMemory_ != nullptr) {
         flags_ |= HostMemoryDirectAccess;
-        return true;
+        return (success = true);
       }
     }
     return false;
@@ -807,7 +825,7 @@ bool Buffer::create(bool alloc_local) {
 
     owner()->setSvmPtr(reinterpret_cast<void*>(owner()->getUserData().hsa_handle));
 
-    return true;
+    return (success = true);
   }
 
   if ((owner()->parent() == nullptr) && (owner()->getSvmPtr() != nullptr)) {
@@ -903,7 +921,7 @@ bool Buffer::create(bool alloc_local) {
       const_cast<Device&>(dev()).updateFreeMemory(size(), false);
     }
 
-    return deviceMemory_ != nullptr;
+    return (success = (deviceMemory_ != nullptr));
   }
 
   // Interop buffer
@@ -919,9 +937,9 @@ bool Buffer::create(bool alloc_local) {
           ext_memory->Type() == amd::ExternalMemory::HandleType::D3D11ResourceKmt) {
         map_flags = HSA_INTEROP_MAP_FLAG_KMT_HANDLE;
       }
-      return interopMapBuffer(ext_memory->Handle(), map_flags) == HSA_STATUS_SUCCESS;
+      return (success = (interopMapBuffer(ext_memory->Handle(), map_flags) == HSA_STATUS_SUCCESS));
     } else if (glObject != nullptr) {
-      return createInteropBuffer(GL_ARRAY_BUFFER, 0);
+      return (success = createInteropBuffer(GL_ARRAY_BUFFER, 0));
     }
   }
   if (nullptr != owner()->parent()) {
@@ -948,7 +966,7 @@ bool Buffer::create(bool alloc_local) {
       owner()->setHostMem(nullptr);
     }
 
-    return true;
+    return (success = true);
   }
 
 #ifdef WITH_AMDGPU_PRO
@@ -959,7 +977,7 @@ bool Buffer::create(bool alloc_local) {
       return false;
     }
     persistent_host_ptr_ = host_ptr;
-    return true;
+    return (success = true);
   }
 #endif
 
@@ -1010,10 +1028,11 @@ bool Buffer::create(bool alloc_local) {
       // Release host memory, since runtime copied data
       owner()->setHostMem(nullptr);
       bufferView->release();
-      return ret;
+
+      return (success = ret);
     }
 
-    return deviceMemory_ != nullptr;
+    return (success = (deviceMemory_ != nullptr));
   }
   assert(owner()->getHostMem() != nullptr || (owner()->getContext().devices().size() == 1));
 
@@ -1026,7 +1045,7 @@ bool Buffer::create(bool alloc_local) {
       Hsa::memory_register(deviceMemory_, size());
     }
 
-    return deviceMemory_ != nullptr;
+    return (success = (deviceMemory_ != nullptr));
   }
 
   // Just one device and allocation must be done in the backend
@@ -1048,7 +1067,54 @@ bool Buffer::create(bool alloc_local) {
     deviceMemory_ = owner()->getHostMem();
   }
 
-  return deviceMemory_ != nullptr;
+  return (success = (deviceMemory_ != nullptr));
+}
+
+// Helper function to compute and cache the owning agent
+void Buffer::computeAndSetOwningAgent() {
+  hsa_agent_t agent;
+
+  // Sub-buffers must inherit agent from parent, not recompute it
+  if (owner() != nullptr && owner()->parent() != nullptr) {
+    const Memory* parentMemory = static_cast<const Memory*>(
+        owner()->parent()->getDeviceMemory(dev_));
+    if (parentMemory != nullptr) {
+      agent = parentMemory->getOwningAgent();
+      setOwningAgent(agent);
+      return;
+    }
+    // Fallback if parent not available (shouldn't happen)
+    LogWarning("Sub-buffer parent not available for agent inheritance");
+  }
+
+  // Check if this is IPC shared memory that needs pointer_info query
+  if (owner() != nullptr && (owner()->ipcShared() || owner()->vmmImported())) {
+    hsa_amd_pointer_info_t info = {};
+    info.size = sizeof(info);
+    hsa_status_t err = hsa_amd_pointer_info(
+        reinterpret_cast<address>(deviceMemory_), &info, nullptr, nullptr, nullptr);
+
+    if (err == HSA_STATUS_SUCCESS && info.type == HSA_EXT_POINTER_TYPE_IPC) {
+      agent = info.agentOwner;
+    } else {
+      // Fallback to backend device
+      agent = dev().getBackendDevice();
+    }
+  } else if (kind_ == MEMORY_KIND_ARENA || kind_ == MEMORY_KIND_HOST) {
+    // Arena and host memory use CPU agent
+    agent = dev().getCpuAgent();
+  } else if (kind_ == MEMORY_KIND_INTEROP) {
+    // Interop memory uses backend device
+    agent = dev().getBackendDevice();
+  } else if (flags_ & HostMemoryDirectAccess) {
+    // Host-accessible memory uses CPU agent
+    agent = dev().getCpuAgent();
+  } else {
+    // Normal device memory uses backend device agent
+    agent = dev().getBackendDevice();
+  }
+
+  setOwningAgent(agent);
 }
 
 // ================================================================================================
@@ -1317,6 +1383,8 @@ bool Image::create(bool alloc_local) {
     deviceMemory_ = orgImage->deviceMemory_;
     hsaImageObject_ = orgImage->hsaImageObject_;
     ownsHsaImageObject_ = false;
+    // Inherit agent from original image
+    setOwningAgent(orgImage->getOwningAgent());
     return true;
   }
 
@@ -1365,6 +1433,13 @@ bool Image::create(bool alloc_local) {
   if (status != HSA_STATUS_SUCCESS) {
     LogPrintfError("[OCL] Fail to allocate image memory, failed with hsa_status: %d \n", status);
     return false;
+  }
+
+  // Set the owning agent after successful creation
+  if (kind_ == MEMORY_KIND_HOST) {
+    setOwningAgent(dev().getCpuAgent());
+  } else {
+    setOwningAgent(dev().getBackendDevice());
   }
 
   return true;
@@ -1498,6 +1573,9 @@ bool Image::createView(const Memory& parent) {
   } else {
     owner()->setHostMem(nullptr);
   }
+
+  // Image view inherits agent from parent
+  setOwningAgent(parent.getOwningAgent());
 
   return true;
 }

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -24,6 +24,21 @@
 
 namespace amd::roc {
 
+namespace {
+// RAII guard to ensure owning agent is set on successful buffer creation
+class OwningAgentGuard {
+  Buffer* buffer_;
+  bool* success_;
+public:
+  OwningAgentGuard(Buffer* buf, bool* success) : buffer_(buf), success_(success) {}
+  ~OwningAgentGuard() {
+    if (success_ && *success_ && buffer_->getDeviceMemory() != nullptr) {
+      buffer_->computeAndSetOwningAgent();
+    }
+  }
+};
+} // anonymous namespace
+
 // ======================================= roc::Memory ============================================
 Memory::Memory(const roc::Device& dev, amd::Memory& owner)
     : device::Memory(owner),
@@ -32,7 +47,8 @@ Memory::Memory(const roc::Device& dev, amd::Memory& owner)
       kind_(MEMORY_KIND_NORMAL),
       amdImageDesc_(nullptr),
       persistent_host_ptr_(nullptr),
-      pinnedMemory_(nullptr) {}
+      pinnedMemory_(nullptr),
+      owningAgent_({0}) {}
 
 Memory::Memory(const roc::Device& dev, size_t size)
     : device::Memory(size),
@@ -41,7 +57,8 @@ Memory::Memory(const roc::Device& dev, size_t size)
       kind_(MEMORY_KIND_NORMAL),
       amdImageDesc_(nullptr),
       persistent_host_ptr_(nullptr),
-      pinnedMemory_(nullptr) {}
+      pinnedMemory_(nullptr),
+      owningAgent_({0}) {}
 
 Memory::~Memory() {
   // Destory pinned memory
@@ -748,18 +765,21 @@ void Buffer::destroy() {
 
 // ================================================================================================
 bool Buffer::create(bool alloc_local) {
+  bool success = false;
+  OwningAgentGuard guard(this, &success);
+
   if (owner() == nullptr) {
     if (alloc_local) {
       deviceMemory_ = dev().deviceLocalAlloc(size());
       if (deviceMemory_ != nullptr) {
         flags_ |= HostMemoryDirectAccess;
-        return true;
+        return (success = true);
       }
     } else {
       deviceMemory_ = dev().hostAlloc(size(), 1, Device::MemorySegment::kNoAtomics);
       if (deviceMemory_ != nullptr) {
         flags_ |= HostMemoryDirectAccess;
-        return true;
+        return (success = true);
       }
     }
     return false;
@@ -807,7 +827,7 @@ bool Buffer::create(bool alloc_local) {
 
     owner()->setSvmPtr(reinterpret_cast<void*>(owner()->getUserData().hsa_handle));
 
-    return true;
+    return (success = true);
   }
 
   if ((owner()->parent() == nullptr) && (owner()->getSvmPtr() != nullptr)) {
@@ -903,7 +923,7 @@ bool Buffer::create(bool alloc_local) {
       const_cast<Device&>(dev()).updateFreeMemory(size(), false);
     }
 
-    return deviceMemory_ != nullptr;
+    return (success = (deviceMemory_ != nullptr));
   }
 
   // Interop buffer
@@ -912,9 +932,9 @@ bool Buffer::create(bool alloc_local) {
     auto ext_memory = interop->asExternalMemory();
     amd::GLObject* glObject = interop->asGLObject();
     if (ext_memory != nullptr) {
-      return interopMapBuffer(ext_memory->Handle()) == HSA_STATUS_SUCCESS;
+      return (success = (interopMapBuffer(ext_memory->Handle()) == HSA_STATUS_SUCCESS));
     } else if (glObject != nullptr) {
-      return createInteropBuffer(GL_ARRAY_BUFFER, 0);
+      return (success = createInteropBuffer(GL_ARRAY_BUFFER, 0));
     }
   }
   if (nullptr != owner()->parent()) {
@@ -941,7 +961,7 @@ bool Buffer::create(bool alloc_local) {
       owner()->setHostMem(nullptr);
     }
 
-    return true;
+    return (success = true);
   }
 
 #ifdef WITH_AMDGPU_PRO
@@ -952,7 +972,7 @@ bool Buffer::create(bool alloc_local) {
       return false;
     }
     persistent_host_ptr_ = host_ptr;
-    return true;
+    return (success = true);
   }
 #endif
 
@@ -1003,10 +1023,11 @@ bool Buffer::create(bool alloc_local) {
       // Release host memory, since runtime copied data
       owner()->setHostMem(nullptr);
       bufferView->release();
-      return ret;
+
+      return (success = ret);
     }
 
-    return deviceMemory_ != nullptr;
+    return (success = (deviceMemory_ != nullptr));
   }
   assert(owner()->getHostMem() != nullptr || (owner()->getContext().devices().size() == 1));
 
@@ -1019,7 +1040,7 @@ bool Buffer::create(bool alloc_local) {
       Hsa::memory_register(deviceMemory_, size());
     }
 
-    return deviceMemory_ != nullptr;
+    return (success = (deviceMemory_ != nullptr));
   }
 
   // Just one device and allocation must be done in the backend
@@ -1041,7 +1062,41 @@ bool Buffer::create(bool alloc_local) {
     deviceMemory_ = owner()->getHostMem();
   }
 
-  return deviceMemory_ != nullptr;
+  return (success = (deviceMemory_ != nullptr));
+}
+
+// Helper function to compute and cache the owning agent
+void Buffer::computeAndSetOwningAgent() {
+  hsa_agent_t agent;
+
+  // Check if this is IPC shared memory that needs pointer_info query
+  if (owner() != nullptr && (owner()->ipcShared() || owner()->vmmImported())) {
+    hsa_amd_pointer_info_t info = {};
+    info.size = sizeof(info);
+    hsa_status_t err = hsa_amd_pointer_info(
+        reinterpret_cast<address>(deviceMemory_), &info, nullptr, nullptr, nullptr);
+
+    if (err == HSA_STATUS_SUCCESS && info.type == HSA_EXT_POINTER_TYPE_IPC) {
+      agent = info.agentOwner;
+    } else {
+      // Fallback to backend device
+      agent = dev().getBackendDevice();
+    }
+  } else if (kind_ == MEMORY_KIND_ARENA || kind_ == MEMORY_KIND_HOST) {
+    // Arena and host memory use CPU agent
+    agent = dev().getCpuAgent();
+  } else if (kind_ == MEMORY_KIND_INTEROP) {
+    // Interop memory uses backend device
+    agent = dev().getBackendDevice();
+  } else if (flags_ & HostMemoryDirectAccess) {
+    // Host-accessible memory uses CPU agent
+    agent = dev().getCpuAgent();
+  } else {
+    // Normal device memory uses backend device agent
+    agent = dev().getBackendDevice();
+  }
+
+  setOwningAgent(agent);
 }
 
 // ================================================================================================
@@ -1310,6 +1365,8 @@ bool Image::create(bool alloc_local) {
     deviceMemory_ = orgImage->deviceMemory_;
     hsaImageObject_ = orgImage->hsaImageObject_;
     ownsHsaImageObject_ = false;
+    // Inherit agent from original image
+    setOwningAgent(orgImage->getOwningAgent());
     return true;
   }
 
@@ -1358,6 +1415,13 @@ bool Image::create(bool alloc_local) {
   if (status != HSA_STATUS_SUCCESS) {
     LogPrintfError("[OCL] Fail to allocate image memory, failed with hsa_status: %d \n", status);
     return false;
+  }
+
+  // Set the owning agent after successful creation
+  if (kind_ == MEMORY_KIND_HOST) {
+    setOwningAgent(dev().getCpuAgent());
+  } else {
+    setOwningAgent(dev().getBackendDevice());
   }
 
   return true;
@@ -1491,6 +1555,9 @@ bool Image::createView(const Memory& parent) {
   } else {
     owner()->setHostMem(nullptr);
   }
+
+  // Image view inherits agent from parent
+  setOwningAgent(parent.getOwningAgent());
 
   return true;
 }

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -48,7 +48,7 @@ Memory::Memory(const roc::Device& dev, amd::Memory& owner)
       amdImageDesc_(nullptr),
       persistent_host_ptr_(nullptr),
       pinnedMemory_(nullptr),
-      owningAgent_({0}) {}
+      owningAgentHandle_(0) {}
 
 Memory::Memory(const roc::Device& dev, size_t size)
     : device::Memory(size),
@@ -58,7 +58,7 @@ Memory::Memory(const roc::Device& dev, size_t size)
       amdImageDesc_(nullptr),
       persistent_host_ptr_(nullptr),
       pinnedMemory_(nullptr),
-      owningAgent_({0}) {}
+      owningAgentHandle_(0) {}
 
 Memory::~Memory() {
   // Destory pinned memory

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -1069,6 +1069,19 @@ bool Buffer::create(bool alloc_local) {
 void Buffer::computeAndSetOwningAgent() {
   hsa_agent_t agent;
 
+  // Sub-buffers must inherit agent from parent, not recompute it
+  if (owner() != nullptr && owner()->parent() != nullptr) {
+    const Memory* parentMemory = static_cast<const Memory*>(
+        owner()->parent()->getDeviceMemory(dev_));
+    if (parentMemory != nullptr) {
+      agent = parentMemory->getOwningAgent();
+      setOwningAgent(agent);
+      return;
+    }
+    // Fallback if parent not available (shouldn't happen)
+    LogWarning("Sub-buffer parent not available for agent inheritance");
+  }
+
   // Check if this is IPC shared memory that needs pointer_info query
   if (owner() != nullptr && (owner()->ipcShared() || owner()->vmmImported())) {
     hsa_amd_pointer_info_t info = {};

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -24,7 +24,6 @@
 
 namespace amd::roc {
 
-namespace {
 // RAII guard to ensure owning agent is set on successful buffer creation
 class OwningAgentGuard {
   Buffer* buffer_;
@@ -37,7 +36,6 @@ public:
     }
   }
 };
-} // anonymous namespace
 
 // ======================================= roc::Memory ============================================
 Memory::Memory(const roc::Device& dev, amd::Memory& owner)

--- a/projects/clr/rocclr/device/rocm/rocmemory.hpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "top.hpp"
 #include "platform/memory.hpp"
 #include "utils/debug.hpp"
@@ -13,6 +15,10 @@
 #include "device/rocm/rocglinterop.hpp"
 
 namespace amd::roc {
+
+// Forward declaration for friend access
+class OwningAgentGuard;
+
 class Memory : public device::Memory {
  public:
   enum MEMORY_KIND {
@@ -101,6 +107,13 @@ class Memory : public device::Memory {
 
   void* PersistentHostPtr() const { return persistent_host_ptr_; }
 
+  //! Get the owning HSA agent for this memory (computed during create(), thread-safe)
+  hsa_agent_t getOwningAgent() const {
+    hsa_agent_t agent;
+    agent.handle = owningAgentHandle_.load(std::memory_order_acquire);
+    return agent;
+  }
+
   //! Validates allocated memory for possible workarounds
   virtual bool ValidateMemory() { return true; }
 
@@ -109,6 +122,11 @@ class Memory : public device::Memory {
 
   // Decrement map count
   void decIndMapCount() override;
+
+  //! Set the owning agent (called during create() after allocation, thread-safe)
+  void setOwningAgent(hsa_agent_t agent) {
+    owningAgentHandle_.store(agent.handle, std::memory_order_release);
+  }
 
   // Free / deregister device memory.
   virtual void destroy() = 0;
@@ -155,10 +173,14 @@ class Memory : public device::Memory {
   // Disable operator=
   Memory& operator=(const Memory&);
 
-  amd::Memory* pinnedMemory_;  //!< Memory used as pinned system memory
+  amd::Memory* pinnedMemory_;        //!< Memory used as pinned system memory
+  std::atomic<uint64_t> owningAgentHandle_;  //!< HSA agent handle (atomic for thread-safety)
 };
 
 class Buffer : public roc::Memory {
+  // Allow guard to call computeAndSetOwningAgent()
+  friend class OwningAgentGuard;
+
  public:
   Buffer(const roc::Device& dev, amd::Memory& owner);
   Buffer(const roc::Device& dev, size_t size);
@@ -190,6 +212,9 @@ class Buffer : public roc::Memory {
 
   // Free device memory.
   void destroy();
+
+  // Compute and cache the owning HSA agent
+  void computeAndSetOwningAgent();
 };
 
 class Image : public roc::Memory {

--- a/projects/clr/rocclr/device/rocm/rocmemory.hpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.hpp
@@ -101,6 +101,9 @@ class Memory : public device::Memory {
 
   void* PersistentHostPtr() const { return persistent_host_ptr_; }
 
+  //! Get the owning HSA agent for this memory (computed during create())
+  hsa_agent_t getOwningAgent() const { return owningAgent_; }
+
   //! Validates allocated memory for possible workarounds
   virtual bool ValidateMemory() { return true; }
 
@@ -109,6 +112,9 @@ class Memory : public device::Memory {
 
   // Decrement map count
   void decIndMapCount() override;
+
+  //! Set the owning agent (called during create() after allocation)
+  void setOwningAgent(hsa_agent_t agent) { owningAgent_ = agent; }
 
   // Free / deregister device memory.
   virtual void destroy() = 0;
@@ -156,6 +162,7 @@ class Memory : public device::Memory {
   Memory& operator=(const Memory&);
 
   amd::Memory* pinnedMemory_;  //!< Memory used as pinned system memory
+  hsa_agent_t owningAgent_;    //!< HSA agent for this memory, computed once during creation
 };
 
 class Buffer : public roc::Memory {
@@ -190,6 +197,9 @@ class Buffer : public roc::Memory {
 
   // Free device memory.
   void destroy();
+
+  // Compute and cache the owning HSA agent
+  void computeAndSetOwningAgent();
 };
 
 class Image : public roc::Memory {

--- a/projects/clr/rocclr/device/rocm/rocmemory.hpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "top.hpp"
 #include "platform/memory.hpp"
 #include "utils/debug.hpp"
@@ -101,8 +103,12 @@ class Memory : public device::Memory {
 
   void* PersistentHostPtr() const { return persistent_host_ptr_; }
 
-  //! Get the owning HSA agent for this memory (computed during create())
-  hsa_agent_t getOwningAgent() const { return owningAgent_; }
+  //! Get the owning HSA agent for this memory (computed during create(), thread-safe)
+  hsa_agent_t getOwningAgent() const {
+    hsa_agent_t agent;
+    agent.handle = owningAgentHandle_.load(std::memory_order_acquire);
+    return agent;
+  }
 
   //! Validates allocated memory for possible workarounds
   virtual bool ValidateMemory() { return true; }
@@ -113,8 +119,10 @@ class Memory : public device::Memory {
   // Decrement map count
   void decIndMapCount() override;
 
-  //! Set the owning agent (called during create() after allocation)
-  void setOwningAgent(hsa_agent_t agent) { owningAgent_ = agent; }
+  //! Set the owning agent (called during create() after allocation, thread-safe)
+  void setOwningAgent(hsa_agent_t agent) {
+    owningAgentHandle_.store(agent.handle, std::memory_order_release);
+  }
 
   // Free / deregister device memory.
   virtual void destroy() = 0;
@@ -161,8 +169,8 @@ class Memory : public device::Memory {
   // Disable operator=
   Memory& operator=(const Memory&);
 
-  amd::Memory* pinnedMemory_;  //!< Memory used as pinned system memory
-  hsa_agent_t owningAgent_;    //!< HSA agent for this memory, computed once during creation
+  amd::Memory* pinnedMemory_;        //!< Memory used as pinned system memory
+  std::atomic<uint64_t> owningAgentHandle_;  //!< HSA agent handle (atomic for thread-safety)
 };
 
 class Buffer : public roc::Memory {

--- a/projects/clr/rocclr/device/rocm/rocmemory.hpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.hpp
@@ -15,6 +15,10 @@
 #include "device/rocm/rocglinterop.hpp"
 
 namespace amd::roc {
+
+// Forward declaration for friend access
+class OwningAgentGuard;
+
 class Memory : public device::Memory {
  public:
   enum MEMORY_KIND {
@@ -174,6 +178,9 @@ class Memory : public device::Memory {
 };
 
 class Buffer : public roc::Memory {
+  // Allow guard to call computeAndSetOwningAgent()
+  friend class OwningAgentGuard;
+
  public:
   Buffer(const roc::Device& dev, amd::Memory& owner);
   Buffer(const roc::Device& dev, size_t size);


### PR DESCRIPTION
## Motivation

This PR adds methods to record the hsa agent during the construction of the memory object

## Technical Details

Currently for batched memory copies we have to figure out which agent owns the memory for each query. This is expensive, and in a hot-path. Instead we record the agent during memory creation, which is a less critical path and use that during the batched copy.

## JIRA ID

ROCM-21854

## Test Plan

Existing testing is suitable

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
