### PR TITLE
[rocshmem] O(1) IPC availability check using pattern detection

### DIFF
--- a/projects/rocshmem/src/constmem.cpp
+++ b/projects/rocshmem/src/constmem.cpp
@@ -1,7 +1,10 @@
 #include "constmem.hpp"
+#include "backend_bc.hpp"
 #include "envvar.hpp"
 
 namespace rocshmem {
+
+extern Backend *backend;
 
 void init_constant_memory(void) {
   std::string envstr;
@@ -16,6 +19,13 @@ void init_constant_memory(void) {
   } else {
     constmem_values.alltoall_wg_algo = gda::ALLTOALLV_WG_ALGO_COPY;
   }
+
+  constmem_values.ipc_first_pe = backend->ipcImpl.ipc_first_pe;
+  constmem_values.ipc_stride = backend->ipcImpl.ipc_stride;
+  // ipc_shm_size == 0 means IPC disabled (fast early return on device).
+  // Non-zero when IPC is available, regardless of stride pattern.
+  constmem_values.ipc_shm_size = (backend->ipcImpl.pes_with_ipc_avail != nullptr)
+                                 ? backend->ipcImpl.shm_size : 0;
 
   CHECK_HIP(hipMemcpyToSymbol(HIP_SYMBOL(constmem), &constmem_values, sizeof(constmem_t)));
 }

--- a/projects/rocshmem/src/constmem.hpp
+++ b/projects/rocshmem/src/constmem.hpp
@@ -32,6 +32,9 @@ namespace rocshmem {
 
 struct constmem_t {
   uint64_t alltoall_wg_algo;
+  int ipc_first_pe;
+  int ipc_stride;    // 0 = pattern invalid (use fallback linear scan)
+  int ipc_shm_size;
 } __attribute__ ((aligned (16)));
 
 extern __constant__ constmem_t constmem;

--- a/projects/rocshmem/src/gda/context_gda_device.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device.cpp
@@ -72,7 +72,8 @@ __host__ GDAContext::GDAContext(Backend *b, unsigned int ctx_id, int gda_provide
   ipcImpl_.shm_size = backend->ipcImpl.shm_size;
   ipcImpl_.shm_rank = backend->ipcImpl.shm_rank;
   ipcImpl_.pes_with_ipc_avail = backend->ipcImpl.pes_with_ipc_avail;
-  gda_provider_ = gda_provider;
+  ipcImpl_.ipc_first_pe = backend->ipcImpl.ipc_first_pe;
+  ipcImpl_.ipc_stride = backend->ipcImpl.ipc_stride;
 }
 
 __host__ GDAContext::~GDAContext() {

--- a/projects/rocshmem/src/gda/context_gda_host.cpp
+++ b/projects/rocshmem/src/gda/context_gda_host.cpp
@@ -57,6 +57,9 @@ __host__ GDAHostContext::GDAHostContext(Backend *backend,
   ipcImpl_.ipc_bases = ipc_bases;
   ipcImpl_.shm_size = backend->ipcImpl.shm_size;
   ipcImpl_.shm_rank = backend->ipcImpl.shm_rank;
+  ipcImpl_.ipc_first_pe = backend->ipcImpl.ipc_first_pe;
+  ipcImpl_.ipc_stride = backend->ipcImpl.ipc_stride;
+
 }
 
 __host__ GDAHostContext::~GDAHostContext() {

--- a/projects/rocshmem/src/ipc/context_ipc_device.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.cpp
@@ -39,6 +39,9 @@ __host__ IPCContext::IPCContext(Backend *b, unsigned int ctx_id)
   IPCBackend *backend{static_cast<IPCBackend *>(b)};
   ipcImpl_.ipc_bases = b->ipcImpl.ipc_bases;
   ipcImpl_.shm_size = b->ipcImpl.shm_size;
+  ipcImpl_.ipc_first_pe = b->ipcImpl.ipc_first_pe;
+  ipcImpl_.ipc_stride = b->ipcImpl.ipc_stride;
+
 
   barrier_sync = backend->barrier_sync;
   fence_pool = backend->fence_pool;

--- a/projects/rocshmem/src/ipc_policy.cpp
+++ b/projects/rocshmem/src/ipc_policy.cpp
@@ -160,6 +160,7 @@ __host__ void IpcOnImpl::ipcHostInit(int my_pe, const HEAP_BASES_T &heap_bases,
 
     if (use_pod_detection) {
       // In pod detection path, ipc_ranks already contains global ranks
+      ipcDetectPattern(ipc_ranks.data(), shm_size);
       CHECK_HIP(hipMemcpy(pes_with_ipc_avail, ipc_ranks.data(), shm_size * sizeof(int), hipMemcpyHostToDevice));
     } else {
       // In fallback path, need to translate from shmcomm ranks to thread_comm ranks
@@ -173,6 +174,7 @@ __host__ void IpcOnImpl::ipcHostInit(int my_pe, const HEAP_BASES_T &heap_bases,
       for(int i = 0; i < shm_size; i++)
         seqranks[i] = i;
       mpilib_ftable_.Group_translate_ranks(shm_grp, shm_size, seqranks, thread_grp, host_pes_with_ipc_avail);
+      ipcDetectPattern(host_pes_with_ipc_avail, shm_size);
       CHECK_HIP(hipMemcpy(pes_with_ipc_avail, host_pes_with_ipc_avail, shm_size * sizeof(int), hipMemcpyHostToDevice));
       // since we delete host_pes_with_ipc_avail, want to make sure the data transfer is complete
       CHECK_HIP(hipStreamSynchronize(0));
@@ -262,6 +264,7 @@ __host__ void IpcOnImpl::ipcHostInit(int my_pe, const HEAP_BASES_T &heap_bases,
   auto disable_ipc = envvar::disable_mixed_ipc || envvar::ro::disable_ipc || envvar::disable_ipc;
   if (!disable_ipc) {
     CHECK_HIP(hipMalloc(reinterpret_cast<void**>(&pes_with_ipc_avail), shm_size * sizeof(int)));
+    ipcDetectPattern(shm_ranks.data(), shm_size);
     CHECK_HIP(hipMemcpy(pes_with_ipc_avail, shm_ranks.data(), shm_size * sizeof(int), hipMemcpyHostToDevice));
   }
 }

--- a/projects/rocshmem/src/ipc_policy.hpp
+++ b/projects/rocshmem/src/ipc_policy.hpp
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "constmem.hpp"
 #include "mpi_instance.hpp"
 #include "memory/std_allocator.hpp"
 #include "util.hpp"
@@ -54,6 +55,17 @@ class IpcOnImpl {
 
   int *pes_with_ipc_avail{nullptr};
 
+  /**
+   * @brief Fast O(1) IPC availability check.
+   *
+   * IPC-available PEs are either consecutive (e.g., [0,1,2,...,7]) or
+   * strided (e.g., [0,8,16,...]) in world rank. Detected at init time
+   * and stored as first_pe + stride, enabling arithmetic membership
+   * check with zero memory loads.
+   */
+  int ipc_first_pe{0};
+  int ipc_stride{0};    // 0 = pattern invalid
+
   __host__ void ipcHostInit(int my_pe, const HEAP_BASES_T &heap_bases,
                             MPI_Comm thread_comm);
 
@@ -62,17 +74,85 @@ class IpcOnImpl {
 
   __host__ void ipcHostStop();
 
-  __host__ __device__ bool isIpcAvailable([[maybe_unused]] int my_pe, int target_pe, int *local_target_pe) {
-    if (nullptr == pes_with_ipc_avail) { return false; }
+  /**
+   * @brief Detect consecutive or strided pattern from a host-accessible rank array.
+   * Must be called with host memory (not a hipMalloc'd device pointer).
+   * Sets ipc_stride:
+   *   > 0: consecutive (1) or strided pattern detected
+   *    0: irregular pattern (use linear scan fallback)
+   * IPC disabled is indicated by constmem.ipc_shm_size == 0.
+   */
+  __host__ void ipcDetectPattern(const int* host_ranks, int count) {
+    ipc_stride = 0;
+    if (host_ranks == nullptr || count <= 0) {
+      return;
+    }
+    ipc_first_pe = host_ranks[0];
+    int stride = (count > 1) ? (host_ranks[1] - host_ranks[0]) : 1;
+    if (stride <= 0) {
+      return;
+    }
+    for (int i = 0; i < count; i++) {
+      if (host_ranks[i] != ipc_first_pe + stride * i) {
+        return;
+      }
+    }
+    ipc_stride = stride;
+  }
 
+  __host__ bool isIpcAvailable([[maybe_unused]] int my_pe, int target_pe, int *local_target_pe) {
+    if (nullptr == pes_with_ipc_avail) { return false; }
     for (int i=0; i<shm_size; i++) {
       if (pes_with_ipc_avail[i] == target_pe) {
         *local_target_pe = i;
         return true;
       }
     }
-
     return false;
+  }
+
+  __device__ __attribute__((noinline))
+  bool isIpcAvailable_irregular(int target_pe, int *local_target_pe) {
+    for (int i = 0; i < shm_size; i++) {
+      if (pes_with_ipc_avail[i] == target_pe) {
+        *local_target_pe = i;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  __device__ __attribute__((noinline))
+  bool isIpcAvailable_strided(unsigned offset, int stride, int *local_target_pe) {
+    int idx = static_cast<int>(offset) / stride;
+    if (static_cast<unsigned>(idx) < static_cast<unsigned>(constmem.ipc_shm_size) &&
+        offset == static_cast<unsigned>(idx * stride)) {
+      *local_target_pe = idx;
+      return true;
+    }
+    return false;
+  }
+
+  __device__ bool isIpcAvailable([[maybe_unused]] int my_pe, int target_pe, int *local_target_pe) {
+    // IPC disabled: shm_size == 0
+    if (constmem.ipc_shm_size == 0) return false;
+
+    unsigned offset = static_cast<unsigned>(target_pe - constmem.ipc_first_pe);
+    int stride = constmem.ipc_stride;
+
+    if (stride == 1) {
+      // Consecutive PEs: branchless range check.
+      // Negative offsets wrap to large unsigned, failing the compare.
+      *local_target_pe = static_cast<int>(offset);
+      return offset < static_cast<unsigned>(constmem.ipc_shm_size);
+    }
+
+    if (stride > 1) {
+      return isIpcAvailable_strided(offset, stride, local_target_pe);
+    }
+
+    // stride == 0: irregular pattern (noinline linear scan)
+    return isIpcAvailable_irregular(target_pe, local_target_pe);
   }
 
   __device__ void ipcGpuInit(Backend *gpu_backend, Context *ctx, int thread_id);
@@ -178,6 +258,9 @@ class IpcOffImpl {
 
   int *pes_with_ipc_avail{nullptr};
 
+  int ipc_first_pe{0};
+  int ipc_stride{0};
+
   __host__ void ipcHostInit(int my_pe, const HEAP_BASES_T &heap_bases,
                             MPI_Comm thread_comm) {}
 
@@ -186,7 +269,8 @@ class IpcOffImpl {
 
   __host__ void ipcHostStop() {}
 
-  __host__ __device__ bool isIpcAvailable([[maybe_unused]] int my_pe, int target_pe, int *local_target_pe) { return false; }
+  __host__ bool isIpcAvailable([[maybe_unused]] int my_pe, int target_pe, int *local_target_pe) { return false; }
+  __device__ bool isIpcAvailable([[maybe_unused]] int my_pe, int target_pe, int *local_target_pe) { return false; }
 
   __device__ void ipcGpuInit(Backend *rocshmem_handle, Context *ctx,
                              int thread_id) {}

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
@@ -63,6 +63,9 @@ __host__ ROContext::ROContext(Backend *b,
   ipcImpl_.shm_size = b->ipcImpl.shm_size;
   ipcImpl_.shm_rank = b->ipcImpl.shm_rank;
   ipcImpl_.pes_with_ipc_avail = b->ipcImpl.pes_with_ipc_avail;
+  ipcImpl_.ipc_first_pe = b->ipcImpl.ipc_first_pe;
+  ipcImpl_.ipc_stride = b->ipcImpl.ipc_stride;
+
 }
 
 __device__ void ROContext::putmem(void *dest, const void *source, size_t nelems,

--- a/projects/rocshmem/src/reverse_offload/context_ro_host.cpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_host.cpp
@@ -57,6 +57,9 @@ __host__ ROHostContext::ROHostContext(Backend *backend, [[maybe_unused]] long op
   ipcImpl_.ipc_bases = ipc_bases;
   ipcImpl_.shm_size = backend->ipcImpl.shm_size;
   ipcImpl_.shm_rank = backend->ipcImpl.shm_rank;
+  ipcImpl_.ipc_first_pe = backend->ipcImpl.ipc_first_pe;
+  ipcImpl_.ipc_stride = backend->ipcImpl.ipc_stride;
+
 }
 
 __host__ ROHostContext::~ROHostContext() {


### PR DESCRIPTION
Replace the linear scan in isIpcAvailable with an arithmetic check. At init time, detect if pes_with_ipc_avail follows a consecutive (e.g., [0,1,2,...,7]) or strided (e.g., [0,8,16,...]) pattern.

When the pattern is valid (typical for all standard MPI rank placements), the membership check becomes:
  consecutive: target_pe - first_pe < shm_size
  strided: (target_pe - first_pe) % stride == 0

This replaces up to 8 HBM loads per call (~500-800ns) with pure ALU operations (~1-2ns). Falls back to linear scan if the pattern is irregular.

## Motivation

Improve performance (latency) in GDA+IPC,notably for system with high IPC PE counts.


## JIRA ID

AIROCSHMEM-370


## Test Plan

* [x] CI correctness
* [x] GDA+IPC communication on-node, off-node, latency. Notably latency at 16 PE/8 local PEs


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
