### PR TITLE
[hip-tests] Tag a 33-test smoke set with the [smoke] label

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/device.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/device.yaml
@@ -63,7 +63,7 @@ device:
     <<: *level_2
     # Disabling tests which no longer behave the same on nvidia platform
     disabled: [nvidia_windows]
-    tags: [synchronization]
+    tags: [synchronization, smoke]
   Unit_hipDeviceSynchronize_Functional:
     <<: *level_2
     # Disabling tests which no longer behave the same on nvidia platform
@@ -98,13 +98,13 @@ device:
     tags: [multigpu, query]
   Unit_hipGetDeviceProperties_ArchPropertiesTst:
     <<: *level_2
-    tags: [query]
+    tags: [query, smoke]
   Unit_hipGetDeviceProperties_NegTst:
     <<: *level_2
     tags: [query]
   Unit_hipRuntimeGetVersion_Positive:
     <<: *level_2
-    tags: [init]
+    tags: [init, smoke]
   Unit_hipRuntimeGetVersion_Negative:
     <<: *level_2
     tags: [init]
@@ -116,7 +116,7 @@ device:
     tags: [config]
   Unit_hipGetSetDeviceFlags_SetThenGet:
     <<: *level_2
-    tags: [config]
+    tags: [config, smoke]
   Unit_hipGetSetDeviceFlags_Threaded:
     <<: *level_2
     tags: [config]
@@ -131,7 +131,7 @@ device:
     tags: [config]
   Unit_hipSetDevice_BasicSetGet:
     <<: *level_2
-    tags: [query]
+    tags: [query, smoke]
   Unit_hipGetSetDevice_MultiThreaded:
     <<: *level_2
     tags: [query]
@@ -304,7 +304,7 @@ device:
     tags: [config]
   Unit_hipInit_Positive:
     <<: *level_2
-    tags: [init]
+    tags: [init, smoke]
   Unit_hipInit_Negative:
     <<: *level_2
     # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
@@ -313,7 +313,7 @@ device:
     tags: [init]
   Unit_hipDriverGetVersion_Positive:
     <<: *level_2
-    tags: [init]
+    tags: [init, smoke]
   Unit_hipDriverGetVersion_Negative:
     <<: *level_2
     tags: [init]

--- a/projects/hip-tests/catch/config/configs/unit/device.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/device.yaml
@@ -60,7 +60,7 @@ device:
     <<: *level_2
     # Disabling tests which no longer behave the same on nvidia platform
     disabled: [nvidia_windows]
-    tags: [synchronization]
+    tags: [synchronization, smoke]
   Unit_hipDeviceSynchronize_Functional:
     <<: *level_2
     # Disabling tests which no longer behave the same on nvidia platform
@@ -95,13 +95,13 @@ device:
     tags: [multigpu, query]
   Unit_hipGetDeviceProperties_ArchPropertiesTst:
     <<: *level_2
-    tags: [query]
+    tags: [query, smoke]
   Unit_hipGetDeviceProperties_NegTst:
     <<: *level_2
     tags: [query]
   Unit_hipRuntimeGetVersion_Positive:
     <<: *level_2
-    tags: [init]
+    tags: [init, smoke]
   Unit_hipRuntimeGetVersion_Negative:
     <<: *level_2
     tags: [init]
@@ -113,7 +113,7 @@ device:
     tags: [config]
   Unit_hipGetSetDeviceFlags_SetThenGet:
     <<: *level_2
-    tags: [config]
+    tags: [config, smoke]
   Unit_hipGetSetDeviceFlags_Threaded:
     <<: *level_2
     tags: [config]
@@ -128,7 +128,7 @@ device:
     tags: [config]
   Unit_hipSetDevice_BasicSetGet:
     <<: *level_2
-    tags: [query]
+    tags: [query, smoke]
   Unit_hipGetSetDevice_MultiThreaded:
     <<: *level_2
     tags: [query]
@@ -301,7 +301,7 @@ device:
     tags: [config]
   Unit_hipInit_Positive:
     <<: *level_2
-    tags: [init]
+    tags: [init, smoke]
   Unit_hipInit_Negative:
     <<: *level_2
     # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
@@ -310,7 +310,7 @@ device:
     tags: [init]
   Unit_hipDriverGetVersion_Positive:
     <<: *level_2
-    tags: [init]
+    tags: [init, smoke]
   Unit_hipDriverGetVersion_Negative:
     <<: *level_2
     tags: [init]

--- a/projects/hip-tests/catch/config/configs/unit/errorHandling.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/errorHandling.yaml
@@ -1,14 +1,20 @@
 ---
 errorHandling:
-  Unit_hipGetErrorName_Positive_Basic: *level_2
+  Unit_hipGetErrorName_Positive_Basic:
+    <<: *level_2
+    tags: [smoke]
   Unit_hipGetErrorName_Negative_Parameters: *level_2
-  Unit_hipGetErrorString_Positive_Basic: *level_2
+  Unit_hipGetErrorString_Positive_Basic:
+    <<: *level_2
+    tags: [smoke]
   Unit_hipGetErrorString_Negative_Parameters: *level_2
   Unit_hipDrvGetErrorName_Positive_Basic: *level_2
   Unit_hipDrvGetErrorName_Negative_Parameters: *level_2
   Unit_hipDrvGetErrorString_Positive_Basic: *level_2
   Unit_hipDrvGetErrorString_Negative_Parameters: *level_2
-  Unit_hipGetLastError_Positive_Basic: *level_2
+  Unit_hipGetLastError_Positive_Basic:
+    <<: *level_2
+    tags: [smoke]
   Unit_hipGetLastError_Positive_Threaded: *level_2
   Unit_hipGetLastError_with_hipMemcpyPeerAsync:
     <<: *level_2
@@ -40,7 +46,9 @@ errorHandling:
   Unit_hipGetLastError_With_Thread: *level_2
   Unit_hipGetLastError_MultiProcess: *level_2
   Unit_hipGetLastError_Kernel_Invalid_Config: *level_2
-  Unit_hipPeekAtLastError_Positive_Basic: *level_2
+  Unit_hipPeekAtLastError_Positive_Basic:
+    <<: *level_2
+    tags: [smoke]
   Unit_hipPeekAtLastError_Positive_Threaded: *level_2
   Unit_hipPeekAtLastError_Positive: *level_2
   Unit_hipPeekAtLastError_Chk_Updated_Status: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/event.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/event.yaml
@@ -39,14 +39,14 @@ event:
     tags: [synchronization]
   Unit_hipEventElapsedTime:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, smoke]
   Unit_hipEventElapsedTime_Verify_Capture:
     <<: *level_2
     tags: [synchronization]
   Unit_hipEventRecord:
     <<: *level_2
     disabled: [amd_windows]
-    tags: [synchronization]
+    tags: [synchronization, smoke]
   Unit_hipEventRecord_Negative:
     <<: *level_2
     tags: [synchronization]
@@ -73,7 +73,7 @@ event:
     tags: [lifecycle]
   Unit_hipEventCreate_Positive:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, smoke]
   Unit_hipEventCreate_Verify_Capture:
     <<: *level_2
     tags: [lifecycle]
@@ -116,7 +116,7 @@ event:
     tags: [lifecycle]
   Unit_hipEventSynchronize_Default_Positive:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, smoke]
   Unit_hipEventSynchronize_NoEventRecord_Positive:
     <<: *level_2
     tags: [synchronization]

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -475,7 +475,7 @@ graph:
     tags: [lifecycle]
   Unit_hipGraphInstantiate_Basic:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, smoke]
   Unit_hipGraphInstantiate_InvalidCyclicGraph:
     <<: *level_2
     tags: [lifecycle]
@@ -1088,7 +1088,7 @@ graph:
     tags: [exec]
   Unit_hipGraphLaunch_Positive:
     <<: *level_2
-    tags: [exec]
+    tags: [exec, smoke]
   Unit_hipGraphLaunch_Negative_Parameters:
     <<: *level_2
     tags: [exec]
@@ -1176,10 +1176,10 @@ graph:
     tags: [lifecycle]
   Unit_hipGraphCreate_Positive_Basic:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, smoke]
   Unit_hipGraphDestroy_Positive_Basic:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, smoke]
   Unit_hipGraphDestroy_Negative_Parameters:
     <<: *level_2
     tags: [lifecycle]

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -466,7 +466,7 @@ graph:
     tags: [lifecycle]
   Unit_hipGraphInstantiate_Basic:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, smoke]
   Unit_hipGraphInstantiate_InvalidCyclicGraph:
     <<: *level_2
     tags: [lifecycle]
@@ -1076,7 +1076,7 @@ graph:
     tags: [exec]
   Unit_hipGraphLaunch_Positive:
     <<: *level_2
-    tags: [exec]
+    tags: [exec, smoke]
   Unit_hipGraphLaunch_Negative_Parameters:
     <<: *level_2
     tags: [exec]
@@ -1164,10 +1164,10 @@ graph:
     tags: [lifecycle]
   Unit_hipGraphCreate_Positive_Basic:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, smoke]
   Unit_hipGraphDestroy_Positive_Basic:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, smoke]
   Unit_hipGraphDestroy_Negative_Parameters:
     <<: *level_2
     tags: [lifecycle]

--- a/projects/hip-tests/catch/config/configs/unit/kernel.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/kernel.yaml
@@ -19,10 +19,10 @@ kernel:
     tags: [memory]
   Unit_hipEmptyKernel:
     <<: *level_2
-    tags: [language]
+    tags: [language, smoke]
   Unit_hipGridLaunch:
     <<: *level_2
-    tags: [launch]
+    tags: [launch, smoke]
   Unit_hipLanguageExtensions:
     <<: *level_2
     tags: [language]
@@ -43,7 +43,7 @@ kernel:
     tags: [memory]
   Unit_kernel_LaunchBounds_Functional:
     <<: *level_2
-    tags: [attributes]
+    tags: [attributes, smoke]
   Unit_kernel_Assign_threadIdx_to_auto:
     <<: *level_2
     tags: [language]

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -490,7 +490,7 @@ memory:
     tags: [memset]
   Unit_hipMemset_SetMemoryWithOffset:
     <<: *level_2
-    tags: [memset]
+    tags: [memset, smoke]
   Unit_hipMemsetAsync_SetMemoryWithOffset:
     <<: *level_2
     tags: [memset]
@@ -590,7 +590,7 @@ memory:
     tags: [query]
   Unit_hipMallocManaged_Basic:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, smoke]
   Unit_hipMallocManaged_Advanced:
     <<: *level_2
     # Note: Windows disabled
@@ -1309,7 +1309,7 @@ memory:
     tags: [multigpu, transfer]
   Unit_hipHostMalloc_Basic:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, smoke]
   Unit_hipHostMalloc_Negative:
     <<: *level_2
     tags: [alloc]
@@ -1364,7 +1364,7 @@ memory:
     tags: [transfer]
   Unit_hipMemcpyAsync_Positive_Basic:
     <<: *level_2
-    tags: [transfer]
+    tags: [transfer, smoke]
   Unit_hipMemcpyAsync_Positive_Synchronization_Behavior:
     <<: *level_2
     tags: [transfer]
@@ -1490,13 +1490,13 @@ memory:
     tags: [memset]
   Unit_hipMalloc_Positive_Basic:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, smoke]
   Unit_hipMalloc_Positive_Zero_Size:
     <<: *level_2
     tags: [alloc]
   Unit_hipMalloc_Positive_Alignment:
     <<: *level_2
-    tags: [alloc]
+    tags: [alloc, smoke]
   Unit_hipMalloc_Negative_Parameters:
     <<: *level_2
     tags: [alloc]

--- a/projects/hip-tests/catch/config/configs/unit/stream.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/stream.yaml
@@ -2,7 +2,7 @@
 stream:
   Unit_hipStreamCreate_default:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, smoke]
   Unit_hipStreamCreate_Negative:
     <<: *level_2
     tags: [lifecycle]
@@ -103,7 +103,7 @@ stream:
     tags: [lifecycle]
   Unit_hipStreamDestroy_Default:
     <<: *level_2
-    tags: [lifecycle]
+    tags: [lifecycle, smoke]
   Unit_hipStreamDestroy_Negative_NullStream:
     <<: *level_2
     tags: [lifecycle]
@@ -148,7 +148,7 @@ stream:
     <<: *level_2
     # Note: TDR (pass)
     disabled: [amd_wsl]
-    tags: [synchronization]
+    tags: [synchronization, smoke]
   Unit_hipStreamSynchronize_NullStreamSynchronization:
     <<: *level_2
     # (amd_windows) mlsejenkins_Window_Failures_on_gfx1201
@@ -170,7 +170,7 @@ stream:
     <<: *level_2
     # Note: Windows disabled
     disabled: [amd_windows, amd_wsl]
-    tags: [synchronization]
+    tags: [synchronization, smoke]
   Unit_hipStreamQuery_SubmitWorkOnStreamAndQueryNullStream:
     <<: *level_2
     # Note: TDR (pass)
@@ -338,7 +338,7 @@ stream:
     tags: [synchronization]
   Unit_hipStreamWaitEvent_Default:
     <<: *level_2
-    tags: [synchronization]
+    tags: [synchronization, smoke]
   Unit_hipStreamWaitEvent_DifferentStreams:
     <<: *level_2
     # Note: Windows disabled


### PR DESCRIPTION
## Motivation

Other teams that depend on HIP/CLR want a tiny, fast test set they can run on their own CI to confirm a change in their library hasn't broken HIP in an obvious way. Running the full hip-tests suite is too slow and too noisy for that purpose; we need a curated subset that is small enough to run on every PR yet broad enough to catch gross regressions across the major subsystems.

## Technical Details

Adds a `smoke` tag to 33 tests in the unit YAML configs across device, errorHandling, memory, stream, event, kernel, and graph. Tests were chosen for breadth over depth — init, error handling, allocation/copy/memset, stream and event lifecycle and synchronization, basic kernel launch, and graph create/instantiate/launch/destroy — and filtered to fast tests (each well under 5s, sub-second median).

`cmake/hip-tests.cmake` already passes `ADD_TAGS_AS_LABELS` to `catch_discover_tests`, so the YAML `smoke` tag becomes a Catch2 tag in the generated test header (via `config/parse_config.py`) and a ctest label of the same name. Consumers select the set with:

    ctest -L smoke

This also lets us evolve the smoke set in the background by retagging in YAML — downstream CI commands stay the same.

Files changed (all under `projects/hip-tests/catch/config/configs/unit/`): device.yaml (+7), errorHandling.yaml (+4, expanded compact `*level_2` form), memory.yaml (+6), stream.yaml (+5), event.yaml (+4), kernel.yaml (+3), graph.yaml (+4).

## JIRA ID

NA

## Test Plan

Built CLR and the affected hip-tests targets (DeviceTest, ErrorHandlingTest, EventTest, StreamTest, KernelTest, MemoryTest1, MemoryTest2, GraphsTest1, GraphsTest2, LaunchBoundsTest) and verified:

- `ctest -N -L smoke` lists exactly the 33 expected tests.
- `ctest -L smoke` runs them and reports each test's runtime.

## Test Result

All 33 tests passed on gfx1201 (Radeon RX 9070 XT). Slowest test was `Unit_hipMemset_SetMemoryWithOffset` at 2.22s; every other test was under 1s. Total wall-clock for the set was 9.4s serial.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Co-Authored-By: Claude Opus 4 <noreply@anthropic.com>