### PR TITLE
rocrtst: Fail memory async copy tests on data corruption

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy.cc
+++ b/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy.cc
@@ -568,10 +568,12 @@ void MemoryAsyncCopy::DisplayBenchmark(Transaction *t) const {
     printf("Skipped...\n");
     return;
   }
+
   if (verified_) {
     std::cout << "Verification: Pass" << std::endl;
   } else {
     std::cout << "Verification: Fail" << std::endl;
+    FAIL();
   }
 
   if (verbosity() < VERBOSE_STANDARD) {


### PR DESCRIPTION
Memory copy tests should fail when there is data corruption

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
