### PR TITLE
[rocprofiler-sdk] disable flaky attach ci

### DIFF
--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/CMakeLists.txt
@@ -31,6 +31,9 @@ set(attachment-env
     "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
     )
 
+# Unconditionally disabled: intermittent failure caused by test app abort
+set(IS_DISABLED ON)
+
 # Test that launches the app and attaches to it (CSV format)
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-attachment-attach-once

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/CMakeLists.txt
@@ -31,6 +31,9 @@ set(attachment-env
     "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
     )
 
+# Unconditionally disabled: intermittent failure caused by test app abort
+set(IS_DISABLED ON)
+
 # Test that launches the app and attaches to it and all its children via --attach-children
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-attachment-attach-tree


### PR DESCRIPTION
## Motivation

Disable tests temporarily to unblock CI, issue #5544

Attach test coverage still available through rocattach.
rocprofv3 attach coverage is disabled.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Will fix in later PR, unblocking CI for other teams.
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Ran locally.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
