### PR TITLE
[clr] add fp16 header in OCP header

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_fp.hpp
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_fp.hpp
@@ -10,6 +10,7 @@
 #include "amd_hip_common.h"
 #include "host_defines.h"
 #include "amd_hip_ocp_types.h"
+#include "amd_hip_fp16.h"
 #include "amd_hip_bf16.h"
 #include "amd_hip_ocp_host.hpp"
 


### PR DESCRIPTION
## Motivation

Include fp16 header in ocp

## Technical Details

OCP header uses fp16 functionality, we need to include this header

## JIRA ID

NA

## Test Plan

Local file which just has OCP header should build fine now.

## Test Result

It builds fine.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
