### PR TITLE
build(rocjitsu): downgrade cmake_minimum_required(VERSION 3.22)

### DIFF
--- a/experimental/rocjitsu/CMakeLists.txt
+++ b/experimental/rocjitsu/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.27)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(rj_default_compiler)

--- a/experimental/rocjitsu/CMakeLists.txt
+++ b/experimental/rocjitsu/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required(VERSION 3.27)
+cmake_minimum_required(VERSION 3.22)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(rj_default_compiler)


### PR DESCRIPTION
## Motivation
therock-ci has cmake 3.27 installed

## Technical Details

`cmake_minimum_required(VERSION 3.22)` because that's version ubuntu 22.04 has

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

build

## Test Result

should build

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
