### PR TITLE
rocr/aie: Reduce ioctls during dispatch and wait

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -770,18 +770,15 @@ hsa_status_t XdnaDriver::FreeDeviceHeap() {
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::ExecCmdAndWait(const BOHandle& cmd_chain_bo_handle,
-                                        const std::vector<uint32_t>& bo_handles,
-                                        HSA_QUEUEID queue_id) {
+hsa_status_t XdnaDriver::ExecCmd(const BOHandle& cmd_bo_handle,
+                                 const std::vector<uint32_t>& bo_handles, HSA_QUEUEID queue_id,
+                                 uint64_t& seq_out) {
   assert(queue_id != AMDXDNA_INVALID_CTX_HANDLE);
 
-  auto hw_ctx_handle = static_cast<uint32_t>(queue_id);
-
-  // Submit commands in a command chain.
   amdxdna_drm_exec_cmd exec_cmd = {};
-  exec_cmd.hwctx = hw_ctx_handle;
+  exec_cmd.hwctx = static_cast<uint32_t>(queue_id);
   exec_cmd.type = AMDXDNA_CMD_SUBMIT_EXEC_BUF;
-  exec_cmd.cmd_handles = cmd_chain_bo_handle.handle;
+  exec_cmd.cmd_handles = cmd_bo_handle.handle;
   exec_cmd.args = reinterpret_cast<uint64_t>(bo_handles.data());
   exec_cmd.cmd_count = 1;
   exec_cmd.arg_count = bo_handles.size();
@@ -789,11 +786,26 @@ hsa_status_t XdnaDriver::ExecCmdAndWait(const BOHandle& cmd_chain_bo_handle,
     return HSA_STATUS_ERROR;
   }
 
-  // Waiting for command chain to finish.
+  seq_out = exec_cmd.seq;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t XdnaDriver::WaitCmd(const BOHandle& cmd_bo_handle, HSA_QUEUEID queue_id,
+                                 uint64_t seq) {
+  assert(queue_id != AMDXDNA_INVALID_CTX_HANDLE);
+
+  // Check command status before waiting to avoid unnecessary ioctl if the command has already
+  // completed.
+  auto& cmd = *static_cast<volatile ert_start_kernel_cmd*>(cmd_bo_handle.vaddr);
+  if (cmd.state >= ERT_CMD_STATE_COMPLETED) {
+    return HSA_STATUS_SUCCESS;
+  }
+
+  // Wait for command completion.
   amdxdna_drm_wait_cmd wait_cmd = {};
-  wait_cmd.hwctx = hw_ctx_handle;
+  wait_cmd.hwctx = static_cast<uint32_t>(queue_id);
   wait_cmd.timeout = 0;  // no timeout, wait until the command finishes
-  wait_cmd.seq = exec_cmd.seq;
+  wait_cmd.seq = seq;
   if (ioctl(fd_, DRM_IOCTL_AMDXDNA_WAIT_CMD, &wait_cmd) < 0) {
     return HSA_STATUS_ERROR;
   }
@@ -961,35 +973,8 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
     queue_pdi_map_.emplace(queue_id, pdi_cache);
   }
 
-  // Create command chain.
-  const uint32_t cmd_chain_data_bytesize = cmd_bo_handles.size() * sizeof(uint64_t);
-  const uint32_t cmd_data_bytesize = sizeof(ert_cmd_chain_data) + cmd_chain_data_bytesize;
-  const uint32_t cmd_bytesize = sizeof(ert_start_kernel_cmd) + cmd_data_bytesize;
-  BOHandle cmd_bo_handle;
-  hsa_status_t status = CreateCmdBO(cmd_bytesize, cmd_bo_handle);
-  if (status != HSA_STATUS_SUCCESS) {
-    assert(false && "Failed to create command chain BO.");
-    return status;
-  }
-  // Unmap and close the command chain BO at exit or in case of an error.
-  MAKE_NAMED_SCOPE_GUARD(cmd_bo_handle_guard, [&] { DestroyBOHandle(cmd_bo_handle); });
-
-  // Create a command BO for the command chain.
-  auto* cmd = static_cast<ert_start_kernel_cmd*>(cmd_bo_handle.vaddr);
-  memset(cmd, 0, cmd_bytesize);
-  cmd->state = ERT_CMD_STATE_NEW;
-  cmd->extra_cu_masks = 0;
-  cmd->count = cmd_data_bytesize / sizeof(uint32_t);
-  cmd->opcode = ERT_CMD_CHAIN;
-  auto* cmd_chain = reinterpret_cast<ert_cmd_chain_data*>(cmd->data);
-  cmd_chain->command_count = cmd_bo_handles.size();
-  for (size_t i = 0; i < cmd_bo_handles.size(); i++) {
-    cmd_chain->data[i] = cmd_bo_handles[i].handle;
-  }
-
-  // Remove duplicate BOs, since the driver reports an error if the same BO handle is provided
-  // multiple times in the command chain. This can happen if any of the BOs are the same across
-  // packets.
+  // Remove duplicate BOs, since the driver reports an error if the same BO is provided multiple
+  // times.
   std::sort(bo_handles.begin(), bo_handles.end());
   bo_handles.erase(std::unique(bo_handles.begin(), bo_handles.end()), bo_handles.end());
 
@@ -1000,11 +985,55 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
     FlushArguments(pkt);
   }
 
-  // Execute all commands in the command chain.
-  status = ExecCmdAndWait(cmd_bo_handle, bo_handles, queue_id);
-  if (status != HSA_STATUS_SUCCESS) {
-    assert(false && "Failed to dispatch command chain.");
-    return status;
+  if (num_pkts == 1) {
+    // Single packet: submit the per-kernel cmd BO directly, no chain wrapper.
+    uint64_t seq = 0;
+    hsa_status_t status = ExecCmd(cmd_bo_handles[0], bo_handles, queue_id, seq);
+    if (status != HSA_STATUS_SUCCESS) {
+      assert(false && "Failed to dispatch command.");
+      return status;
+    }
+    status = WaitCmd(cmd_bo_handles[0], queue_id, seq);
+    if (status != HSA_STATUS_SUCCESS) {
+      assert(false && "Failed waiting for command.");
+      return status;
+    }
+  } else {
+    // Create command chain for multi-packet dispatches.
+    const size_t cmd_chain_data_bytesize = cmd_bo_handles.size() * sizeof(uint64_t);
+    const size_t cmd_data_bytesize = sizeof(ert_cmd_chain_data) + cmd_chain_data_bytesize;
+    const size_t cmd_bytesize = sizeof(ert_start_kernel_cmd) + cmd_data_bytesize;
+    BOHandle cmd_bo_handle;
+    hsa_status_t status = CreateCmdBO(cmd_bytesize, cmd_bo_handle);
+    if (status != HSA_STATUS_SUCCESS) {
+      assert(false && "Failed to create command chain BO.");
+      return status;
+    }
+    MAKE_NAMED_SCOPE_GUARD(cmd_bo_handle_guard, [&] { DestroyBOHandle(cmd_bo_handle); });
+
+    auto* cmd = static_cast<ert_start_kernel_cmd*>(cmd_bo_handle.vaddr);
+    memset(cmd, 0, cmd_bytesize);
+    cmd->state = ERT_CMD_STATE_NEW;
+    cmd->count = static_cast<uint32_t>(cmd_data_bytesize / sizeof(uint32_t));
+    cmd->opcode = ERT_CMD_CHAIN;
+    auto* cmd_chain = reinterpret_cast<ert_cmd_chain_data*>(cmd->data);
+    cmd_chain->command_count = static_cast<uint32_t>(cmd_bo_handles.size());
+    for (size_t i = 0; i < cmd_bo_handles.size(); i++) {
+      cmd_chain->data[i] = cmd_bo_handles[i].handle;
+    }
+
+    // Execute all commands in the command chain.
+    uint64_t seq = 0;
+    status = ExecCmd(cmd_bo_handle, bo_handles, queue_id, seq);
+    if (status != HSA_STATUS_SUCCESS) {
+      assert(false && "Failed to dispatch command chain.");
+      return status;
+    }
+    status = WaitCmd(cmd_bo_handle, queue_id, seq);
+    if (status != HSA_STATUS_SUCCESS) {
+      assert(false && "Failed waiting for command chain.");
+      return status;
+    }
   }
 
   // Flush cache for the arguments again to ensure visibility of any changes made by the AIE kernels
@@ -1036,7 +1065,7 @@ hsa_status_t XdnaDriver::SPMAcquire(uint32_t preferred_node_id) const {
 hsa_status_t XdnaDriver::SPMRelease(uint32_t preferred_node_id) const {
   // AIE does not support streaming performance monitor.
   return HSA_STATUS_ERROR_INVALID_AGENT;
-};
+}
 
 hsa_status_t XdnaDriver::SPMSetDestBuffer(uint32_t preferred_node_id, uint32_t size_bytes,
                                           uint32_t* timeout, uint32_t* size_copied,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -258,7 +258,7 @@ static hsa_status_t SubmitCommand(int fd, uint32_t cmd_bo_handle,
   exec_cmd.cmd_handles = cmd_bo_handle;
   exec_cmd.args = reinterpret_cast<uint64_t>(bo_handles.data());
   exec_cmd.cmd_count = 1;
-  exec_cmd.arg_count = bo_handles.size();
+  exec_cmd.arg_count = static_cast<uint32_t>(bo_handles.size());
   if (ioctl(fd, DRM_IOCTL_AMDXDNA_EXEC_CMD, &exec_cmd) < 0) {
     return HSA_STATUS_ERROR;
   }
@@ -1022,16 +1022,19 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
     FlushArguments(pkt);
   }
 
+  auto hw_ctx_handle = static_cast<uint32_t>(queue_id);
+
   if (num_pkts == 1) {
     // Single packet: submit the per-kernel cmd BO directly, no chain wrapper.
     uint64_t seq = 0;
-    hsa_status_t status = SubmitCommand(fd_, cmd_bo_handles[0].handle, bo_handles, queue_id, seq);
+    hsa_status_t status =
+        SubmitCommand(fd_, cmd_bo_handles[0].handle, bo_handles, hw_ctx_handle, seq);
     if (status != HSA_STATUS_SUCCESS) {
       assert(false && "Failed to submit command.");
       return status;
     }
-    status = WaitCommand(fd_, static_cast<ert_start_kernel_cmd*>(cmd_bo_handles[0].vaddr), queue_id,
-                         seq);
+    status = WaitCommand(fd_, static_cast<ert_start_kernel_cmd*>(cmd_bo_handles[0].vaddr),
+                         hw_ctx_handle, seq);
     if (status != HSA_STATUS_SUCCESS) {
       assert(false && "Failed waiting for command.");
       return status;
@@ -1062,13 +1065,13 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
 
     // Execute all commands in the command chain.
     uint64_t seq = 0;
-    status = SubmitCommand(fd_, cmd_bo_handle.handle, bo_handles, queue_id, seq);
+    status = SubmitCommand(fd_, cmd_bo_handle.handle, bo_handles, hw_ctx_handle, seq);
     if (status != HSA_STATUS_SUCCESS) {
       assert(false && "Failed to submit command chain.");
       return status;
     }
-    status =
-        WaitCommand(fd_, static_cast<ert_start_kernel_cmd*>(cmd_bo_handle.vaddr), queue_id, seq);
+    status = WaitCommand(fd_, static_cast<ert_start_kernel_cmd*>(cmd_bo_handle.vaddr),
+                         hw_ctx_handle, seq);
     if (status != HSA_STATUS_SUCCESS) {
       assert(false && "Failed waiting for command chain.");
       return status;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -797,8 +797,18 @@ hsa_status_t XdnaDriver::WaitCmd(const BOHandle& cmd_bo_handle, HSA_QUEUEID queu
   // Check command status before waiting to avoid unnecessary ioctl if the command has already
   // completed.
   auto& cmd = *static_cast<volatile ert_start_kernel_cmd*>(cmd_bo_handle.vaddr);
-  if (cmd.state >= ERT_CMD_STATE_COMPLETED) {
-    return HSA_STATUS_SUCCESS;
+  switch (cmd.state) {
+    case ERT_CMD_STATE_NEW:
+    case ERT_CMD_STATE_QUEUED:
+    case ERT_CMD_STATE_RUNNING:
+      // Command is still in progress, need to wait.
+      break;
+    case ERT_CMD_STATE_COMPLETED:
+      // Command has completed, no need to wait.
+      return HSA_STATUS_SUCCESS;
+    default:
+      // Command is in an error state.
+      return HSA_STATUS_ERROR;
   }
 
   // Wait for command completion.
@@ -810,6 +820,10 @@ hsa_status_t XdnaDriver::WaitCmd(const BOHandle& cmd_bo_handle, HSA_QUEUEID queu
     return HSA_STATUS_ERROR;
   }
 
+  if (cmd.state != ERT_CMD_STATE_COMPLETED) {
+    // Command is in an error state.
+    return HSA_STATUS_ERROR;
+  }
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -224,9 +224,12 @@ static void FlushArguments(const hsa_amd_aie_kernel_dispatch_packet_t* pkt) {
 /**
  * @brief Destroys the amdxdna_hwctx with the given handle.
  *
+ * @param[in] fd driver file descriptor
  * @param[in] hw_ctx_handle handle of the hardware context to destroy
  */
 static hsa_status_t DestroyHwCtx(int fd, uint32_t hw_ctx_handle) {
+  assert(hw_ctx_handle != AMDXDNA_INVALID_CTX_HANDLE);
+
   amdxdna_drm_destroy_hwctx args = {};
   args.handle = hw_ctx_handle;
   if (ioctl(fd, DRM_IOCTL_AMDXDNA_DESTROY_HWCTX, &args) < 0) {
@@ -234,6 +237,81 @@ static hsa_status_t DestroyHwCtx(int fd, uint32_t hw_ctx_handle) {
   }
   return HSA_STATUS_SUCCESS;
 }
+
+/**
+ * @brief Submits a command for execution.
+ *
+ * @param[in] fd driver file descriptor
+ * @param[in] cmd_bo_handle BO handle of the command to execute
+ * @param[in] bo_handles handles associated with the command
+ * @param[in] hw_ctx_handle hardware context handle
+ * @param[out] seq_out sequence number of the command
+ */
+static hsa_status_t SubmitCommand(int fd, uint32_t cmd_bo_handle,
+                                  const std::vector<uint32_t>& bo_handles, uint32_t hw_ctx_handle,
+                                  uint64_t& seq_out) {
+  assert(hw_ctx_handle != AMDXDNA_INVALID_CTX_HANDLE);
+
+  amdxdna_drm_exec_cmd exec_cmd = {};
+  exec_cmd.hwctx = hw_ctx_handle;
+  exec_cmd.type = AMDXDNA_CMD_SUBMIT_EXEC_BUF;
+  exec_cmd.cmd_handles = cmd_bo_handle;
+  exec_cmd.args = reinterpret_cast<uint64_t>(bo_handles.data());
+  exec_cmd.cmd_count = 1;
+  exec_cmd.arg_count = bo_handles.size();
+  if (ioctl(fd, DRM_IOCTL_AMDXDNA_EXEC_CMD, &exec_cmd) < 0) {
+    return HSA_STATUS_ERROR;
+  }
+
+  seq_out = exec_cmd.seq;
+  return HSA_STATUS_SUCCESS;
+}
+
+/**
+ * @brief Waits for a command to finish.
+ *
+ * @param[in] fd driver file descriptor
+ * @param[in] cmd command to wait for
+ * @param[in] hw_ctx_handle hardware context handle
+ * @param[in] seq sequence number of the command
+ */
+static hsa_status_t WaitCommand(int fd, ert_start_kernel_cmd* cmd, uint32_t hw_ctx_handle,
+                                uint64_t seq) {
+  assert(hw_ctx_handle != AMDXDNA_INVALID_CTX_HANDLE);
+
+  // Check command status before waiting to avoid unnecessary ioctl if the command has already
+  // completed.
+  auto& cmd_ref = *static_cast<volatile ert_start_kernel_cmd*>(cmd);
+  switch (cmd_ref.state) {
+    case ERT_CMD_STATE_NEW:
+    case ERT_CMD_STATE_QUEUED:
+    case ERT_CMD_STATE_RUNNING:
+      // Command is still in progress, need to wait.
+      break;
+    case ERT_CMD_STATE_COMPLETED:
+      // Command has completed, no need to wait.
+      return HSA_STATUS_SUCCESS;
+    default:
+      // Command is in an error state.
+      return HSA_STATUS_ERROR;
+  }
+
+  // Wait for command completion.
+  amdxdna_drm_wait_cmd wait_cmd = {};
+  wait_cmd.hwctx = hw_ctx_handle;
+  wait_cmd.timeout = 0;  // no timeout, wait until the command finishes
+  wait_cmd.seq = seq;
+  if (ioctl(fd, DRM_IOCTL_AMDXDNA_WAIT_CMD, &wait_cmd) < 0) {
+    return HSA_STATUS_ERROR;
+  }
+
+  if (cmd_ref.state != ERT_CMD_STATE_COMPLETED) {
+    // Command is in an error state.
+    return HSA_STATUS_ERROR;
+  }
+  return HSA_STATUS_SUCCESS;
+}
+
 
 XdnaDriver::XdnaDriver(std::string devnode_name)
     : core::Driver(core::DriverType::XDNA, std::move(devnode_name)) {}
@@ -627,14 +705,16 @@ hsa_status_t XdnaDriver::Map(core::ShareableHandle handle, void *mem,
   drm_prime_handle params = {};
   params.handle = handle.handle;
   params.fd = -1;
-  if (ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &params) < 0)
+  if (ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &params) < 0) {
     return HSA_STATUS_ERROR;
+  }
 
   // Change permissions.
   void *mapped_ptr = mmap(mem, size, PermissionsToMmapFlags(perms),
                           MAP_FIXED | MAP_SHARED, params.fd, offset);
-  if (mapped_ptr == MAP_FAILED)
+  if (mapped_ptr == MAP_FAILED) {
     return HSA_STATUS_ERROR;
+  }
 
   return HSA_STATUS_SUCCESS;
 }
@@ -694,7 +774,7 @@ hsa_status_t XdnaDriver::DestroyShareableHandle(core::ShareableHandle* handle) {
   if (ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_params) < 0)
     return HSA_STATUS_ERROR;
 
-  handle = {};
+  *handle = {};
 
   return HSA_STATUS_SUCCESS;
 }
@@ -767,63 +847,6 @@ hsa_status_t XdnaDriver::FreeDeviceHeap() {
 
   DestroyBOHandle(dev_heap_handle);
 
-  return HSA_STATUS_SUCCESS;
-}
-
-hsa_status_t XdnaDriver::ExecCmd(const BOHandle& cmd_bo_handle,
-                                 const std::vector<uint32_t>& bo_handles, HSA_QUEUEID queue_id,
-                                 uint64_t& seq_out) {
-  assert(queue_id != AMDXDNA_INVALID_CTX_HANDLE);
-
-  amdxdna_drm_exec_cmd exec_cmd = {};
-  exec_cmd.hwctx = static_cast<uint32_t>(queue_id);
-  exec_cmd.type = AMDXDNA_CMD_SUBMIT_EXEC_BUF;
-  exec_cmd.cmd_handles = cmd_bo_handle.handle;
-  exec_cmd.args = reinterpret_cast<uint64_t>(bo_handles.data());
-  exec_cmd.cmd_count = 1;
-  exec_cmd.arg_count = bo_handles.size();
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_EXEC_CMD, &exec_cmd) < 0) {
-    return HSA_STATUS_ERROR;
-  }
-
-  seq_out = exec_cmd.seq;
-  return HSA_STATUS_SUCCESS;
-}
-
-hsa_status_t XdnaDriver::WaitCmd(const BOHandle& cmd_bo_handle, HSA_QUEUEID queue_id,
-                                 uint64_t seq) {
-  assert(queue_id != AMDXDNA_INVALID_CTX_HANDLE);
-
-  // Check command status before waiting to avoid unnecessary ioctl if the command has already
-  // completed.
-  auto& cmd = *static_cast<volatile ert_start_kernel_cmd*>(cmd_bo_handle.vaddr);
-  switch (cmd.state) {
-    case ERT_CMD_STATE_NEW:
-    case ERT_CMD_STATE_QUEUED:
-    case ERT_CMD_STATE_RUNNING:
-      // Command is still in progress, need to wait.
-      break;
-    case ERT_CMD_STATE_COMPLETED:
-      // Command has completed, no need to wait.
-      return HSA_STATUS_SUCCESS;
-    default:
-      // Command is in an error state.
-      return HSA_STATUS_ERROR;
-  }
-
-  // Wait for command completion.
-  amdxdna_drm_wait_cmd wait_cmd = {};
-  wait_cmd.hwctx = static_cast<uint32_t>(queue_id);
-  wait_cmd.timeout = 0;  // no timeout, wait until the command finishes
-  wait_cmd.seq = seq;
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_WAIT_CMD, &wait_cmd) < 0) {
-    return HSA_STATUS_ERROR;
-  }
-
-  if (cmd.state != ERT_CMD_STATE_COMPLETED) {
-    // Command is in an error state.
-    return HSA_STATUS_ERROR;
-  }
   return HSA_STATUS_SUCCESS;
 }
 
@@ -1002,12 +1025,13 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
   if (num_pkts == 1) {
     // Single packet: submit the per-kernel cmd BO directly, no chain wrapper.
     uint64_t seq = 0;
-    hsa_status_t status = ExecCmd(cmd_bo_handles[0], bo_handles, queue_id, seq);
+    hsa_status_t status = SubmitCommand(fd_, cmd_bo_handles[0].handle, bo_handles, queue_id, seq);
     if (status != HSA_STATUS_SUCCESS) {
-      assert(false && "Failed to dispatch command.");
+      assert(false && "Failed to submit command.");
       return status;
     }
-    status = WaitCmd(cmd_bo_handles[0], queue_id, seq);
+    status = WaitCommand(fd_, static_cast<ert_start_kernel_cmd*>(cmd_bo_handles[0].vaddr), queue_id,
+                         seq);
     if (status != HSA_STATUS_SUCCESS) {
       assert(false && "Failed waiting for command.");
       return status;
@@ -1038,12 +1062,13 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
 
     // Execute all commands in the command chain.
     uint64_t seq = 0;
-    status = ExecCmd(cmd_bo_handle, bo_handles, queue_id, seq);
+    status = SubmitCommand(fd_, cmd_bo_handle.handle, bo_handles, queue_id, seq);
     if (status != HSA_STATUS_SUCCESS) {
-      assert(false && "Failed to dispatch command chain.");
+      assert(false && "Failed to submit command chain.");
       return status;
     }
-    status = WaitCmd(cmd_bo_handle, queue_id, seq);
+    status =
+        WaitCommand(fd_, static_cast<ert_start_kernel_cmd*>(cmd_bo_handle.vaddr), queue_id, seq);
     if (status != HSA_STATUS_SUCCESS) {
       assert(false && "Failed waiting for command chain.");
       return status;
@@ -1152,12 +1177,11 @@ hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, HSA_QUEUEID
 
   auto* xdna_config_cu_param =
       static_cast<amdxdna_hwctx_param_config_cu*>(malloc(config_cu_param_size));
-  memset(xdna_config_cu_param, 0, config_cu_param_size);
-
   if (xdna_config_cu_param == nullptr) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
   MAKE_SCOPE_GUARD([xdna_config_cu_param] { free(xdna_config_cu_param); });
+  memset(xdna_config_cu_param, 0, config_cu_param_size);
 
   xdna_config_cu_param->num_cus = pdi_bo_handles.size();
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -71,7 +71,7 @@ class KfdDriver final : public core::Driver {
 public:
   KfdDriver(std::string devnode_name);
 
-  /// @brief Determine of the KFD is present on the system and attemp to open it if found.
+  /// @brief Determine if the KFD is present on the system and attempt to open it if found.
   ///
   /// @param[out] Driver object for the KFD.
   /// @return HSA_STATUS_SUCCESS if driver found and opened.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -258,22 +258,6 @@ public:
   /// @param[out] bo_info allocated BO
   hsa_status_t CreateCmdBO(uint32_t size, BOHandle& bo_info);
 
-  /// @brief Executes a command.
-  ///
-  /// @param[in] cmd_bo_handle BO handle of the command to execute
-  /// @param[in] bo_handles handles associated with the command
-  /// @param[in] aie_queue queue to submit to
-  /// @param[out] seq_out sequence number of the command
-  hsa_status_t ExecCmd(const BOHandle& cmd_bo_handle, const std::vector<uint32_t>& bo_handles,
-                       HSA_QUEUEID queue_id, uint64_t& seq_out);
-
-  /// @brief Waits for a command to finish.
-  ///
-  /// @param[in] cmd_bo_handle BO handle of the command to wait for
-  /// @param[in] aie_queue queue the command was submitted to
-  /// @param[in] seq sequence number of the command
-  hsa_status_t WaitCmd(const BOHandle& cmd_bo_handle, HSA_QUEUEID queue_id, uint64_t seq);
-
   std::map<void*, BOHandle> vmem_addr_mappings;
 
   /// @brief Queue to PDI cache map.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -133,6 +133,9 @@ class XdnaDriver final : public core::Driver {
 public:
   XdnaDriver(std::string devnode_name);
 
+  /// @brief Determine if the xdna-driver is present on the system and attempt to open it if found.
+  ///
+  /// @param[out] driver object
   static hsa_status_t DiscoverDriver(std::unique_ptr<core::Driver>& driver);
 
   /// @brief Returns the size of the dev heap in bytes.
@@ -141,7 +144,6 @@ public:
   hsa_status_t Init() override;
   hsa_status_t ShutDown() override;
   hsa_status_t QueryKernelModeDriver(core::DriverQuery query) override;
-
   hsa_status_t Open() override;
   hsa_status_t Close() override;
   hsa_status_t GetSystemProperties(HsaSystemProperties& sys_props) const override;
@@ -223,36 +225,54 @@ public:
   /// @brief Destroys @p bo_handle.
   ///
   /// This function will unmap the virtual address and close the BO, but will not return any status.
+  ///
+  /// @param[in,out] bo_handle BO handle to destroy.
   void DestroyBOHandle(BOHandle& bo_handle);
 
   /// @brief Returns the BO associated with the address.
+  ///
+  /// @param[in] mem virtual address to query.
   BOHandle FindBOHandle(void* mem) const;
 
   /// @brief Creates a new hardware context with the given PDI BO handles.
+  ///
+  /// @param[in] pdi_bo_handles PDI BO handles to use for the new hardware context.
+  /// @param[in,out] queue_id queue ID. It will be updated if the driver needs to create a new
+  /// hardware context for this command chain.
+  /// @param[in] num_core_tiles number of core tiles in the AIE device
   hsa_status_t ConfigHwCtx(const PDICache& pdi_bo_handles, HSA_QUEUEID& queue_id,
                            uint32_t num_core_tiles) const;
 
+  /// @brief Queries the driver version and updates internal state.
   hsa_status_t QueryDriverVersion();
 
-  /// @brief Allocate device accesible heap space.
-  ///
-  /// Allocate and map a buffer object (BO) that the AIE device can access.
+  /// @brief Allocate device accessible heap space.
   hsa_status_t InitDeviceHeap();
+
+  /// @brief Free device accessible heap space.
   hsa_status_t FreeDeviceHeap();
 
   /// @brief Creates a command BO and returns it to @p bo_info.
   ///
-  /// @param size size of memory to allocate
-  /// @param bo_info allocated BO
+  /// @param[in] size size of memory to allocate
+  /// @param[out] bo_info allocated BO
   hsa_status_t CreateCmdBO(uint32_t size, BOHandle& bo_info);
 
-  /// @brief Executes a command and waits for its completion
+  /// @brief Executes a command.
   ///
-  /// @param cmd_chain_bo_handle command to execute
-  /// @param bo_handles handles associated with the command
-  /// @param aie_queue queue to submit to
-  hsa_status_t ExecCmdAndWait(const BOHandle& cmd_chain_bo_handle,
-                              const std::vector<uint32_t>& bo_handles, HSA_QUEUEID queue_id);
+  /// @param[in] cmd_bo_handle BO handle of the command to execute
+  /// @param[in] bo_handles handles associated with the command
+  /// @param[in] aie_queue queue to submit to
+  /// @param[out] seq_out sequence number of the command
+  hsa_status_t ExecCmd(const BOHandle& cmd_bo_handle, const std::vector<uint32_t>& bo_handles,
+                       HSA_QUEUEID queue_id, uint64_t& seq_out);
+
+  /// @brief Waits for a command to finish.
+  ///
+  /// @param[in] cmd_bo_handle BO handle of the command to wait for
+  /// @param[in] aie_queue queue the command was submitted to
+  /// @param[in] seq sequence number of the command
+  hsa_status_t WaitCmd(const BOHandle& cmd_bo_handle, HSA_QUEUEID queue_id, uint64_t seq);
 
   std::map<void*, BOHandle> vmem_addr_mappings;
 


### PR DESCRIPTION
## Motivation

We are using more ioctls than XRT for simple dispatches.

## Technical Details

**Note:** This PR will be merged after https://github.com/ROCm/rocm-systems/pull/5595 as it contains some of the same changes.

This PR reduces ioctls in two different cases:

1. When a single packet dispatch happens, we do not need to create a command chain, as the driver is ok to do single command BO dispatches.
2. When waiting, we can check first if the packet has been processed before issuing an expensive ioctl to wait.

## JIRA ID

NA

## Test Plan

Dispatch tests where run from https://github.com/ROCm/rocm-systems/tree/users/ypapadop-amd/aie-tests/projects/rocr-runtime/rocrtst/suites/aie (not part of the official test harness yet).

Microbenchmarks where run from https://github.com/ROCm/rocm-systems/tree/users/ypapadop-amd/aie-tests/projects/rocr-runtime/rocrtst/suites/aie-performance

## Test Result

Tests where successful. Single dispatch overhead was reduced by 20us on Phoenix.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
