### PR TITLE
[ATT] [CI fix] warmup async copies before starting the trace

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -258,6 +258,21 @@ ThreadTracerAgent::start_thread_trace(std::shared_ptr<std::atomic<int>> _flag)
     control_packet_copy->populate_before();
     control_packet_copy->populate_after();
 
+    // Warmup the async copy so we dont wait too long for the flip.
+    if(params.triple_buffering)
+    {
+        auto& buffer = queue->triple_buffer_memory;
+        auto  signal = signal_create();
+        copy_data_sync(buffer.at(0),
+                       buffer.at(1),
+                       queue->near_cpu,
+                       queue->hsa_agent,
+                       MIN_BUFFER_SIZE,
+                       &signal);
+        signal_wait(signal);
+        signal_destroy(signal);
+    }
+
     // Submit the start packets without waiting: the producer thread (triple-buffer
     // path) and DeviceThreadTracer::start_context (single-buffer path) wait on the
     // returned signal so multiple agents can be launched in parallel.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/hsa_util.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/hsa_util.hpp
@@ -115,7 +115,7 @@ att_queue_submit_signal_last(const att_queue_t& q, VecType& vec)
 /// waiting on the last signal guarantees the entire batch has drained.
 template <typename VecType>
 signal_ptr_t
-att_queue_submit_and_signal_last(const att_queue_t& q, VecType& vec)
+att_queue_submit_and_wait_last(const att_queue_t& q, VecType& vec)
 {
     auto sig = att_queue_submit_signal_last(q, vec);
     if(sig) signal_wait(*sig);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/threading.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/threading.cpp
@@ -203,7 +203,7 @@ producer_loop(
 
     auto stop_trace = [&]() {
         ROCP_INFO << "Stopping the trace";
-        att_queue_submit_and_signal_last(queue, parameters.control_packet->after_krn_pkt);
+        att_queue_submit_and_wait_last(queue, parameters.control_packet->after_krn_pkt);
     };
 
     auto iterate_trace = [&]() {
@@ -265,8 +265,8 @@ producer_loop(
                                          ROCPROFILER_THREAD_TRACE_SHADER_DATA_FLAGS_NONE,
                                          true);
 
-                    att_queue_submit_and_signal_last(queue,
-                                                     parameters.control_packet->before_krn_pkt);
+                    att_queue_submit_and_wait_last(queue,
+                                                   parameters.control_packet->before_krn_pkt);
                 }
             }
             // The status_query test verifies we immediately poll again after consuming a


### PR DESCRIPTION
## Motivation

Adds a warmup to async copies before starting thread trace. This avoids data loss in the first buffer flip.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
