### PR TITLE
Fix missing synchronization for child graphs in classic execution path

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -2030,8 +2030,11 @@ bool Graph::RunOneNode(Node node) {
   for (auto depNode : node->GetDependencies()) {
     // Process only the nodes that have been submitted
     if (depNode->launch_id_ != -1) {
-      // If it's the same stream then skip the signal, since it's in order
-      if (depNode->stream_id_ != node->stream_id_) {
+      // Child graph nodes may internally dispatch work on streams other
+      // than their assigned stream_id_, so the same-stream in-order
+      // assumption does not hold.  Always treat them as cross-stream deps.
+      if (depNode->stream_id_ != node->stream_id_ ||
+          depNode->GetType() == hipGraphNodeTypeGraph) {
         // If there is no wait node on the stream, then assign one
         if ((wait_order_[depNode->stream_id_] == nullptr) ||
             // If another node executed on the same stream, then use the latest launch only,
@@ -2057,11 +2060,8 @@ bool Graph::RunOneNode(Node node) {
   // Create a wait list from the last launches of all dependencies
   for (auto dep : wait_order_) {
     if (dep != nullptr) {
-      // Add all commands in the wait list
-      if (dep->GetType() != hipGraphNodeTypeGraph) {
-        for (auto command : dep->GetCommands()) {
-          waitList.push_back(command);
-        }
+      for (auto command : dep->GetCommands()) {
+        waitList.push_back(command);
       }
     }
   }
@@ -2070,6 +2070,19 @@ bool Graph::RunOneNode(Node node) {
     auto child = reinterpret_cast<hip::ChildGraphNode*>(node)->GetChildGraph();
     if (!reinterpret_cast<hip::ChildGraphNode*>(node)->GetGraphCaptureStatus()) {
       child->RunNodes(node->stream_id_, &streams_, &waitList);
+      // Store the child graph's completion command so that downstream
+      // dependency handling can use node->GetCommands() directly,
+      // instead of querying getLastQueuedCommand at dependency time
+      // (which could return unrelated later work on the same stream).
+      auto completion = streams_[node->stream_id_]->getLastQueuedCommand(true);
+      if (completion != nullptr) {
+        // Release any previously stored completion command (from prior launches)
+        for (auto cmd : node->GetCommands()) {
+          cmd->release();
+        }
+        node->GetCommands().clear();
+        node->GetCommands().push_back(completion);
+      }
     }
   } else {
     // Assing a stream to the current node
@@ -2093,11 +2106,8 @@ bool Graph::RunOneNode(Node node) {
   // Release commands of dependency nodes that were included in the wait list after enqueue
   for (auto dep : wait_order_) {
     if (dep != nullptr) {
-      // Add all commands in the wait list
-      if (dep->GetType() != hipGraphNodeTypeGraph) {
-        for (auto command : dep->GetCommands()) {
-          command->release();
-        }
+      for (auto command : dep->GetCommands()) {
+        command->release();
       }
     }
   }
@@ -2125,10 +2135,10 @@ bool Graph::RunOneNode(Node node) {
     leafs_[node->stream_id_] = node;
     // An extra retain is needed for the leaves in order to be able to later enqueue a marker
     // on the app stream that has these commands in the waitlist.
-    if (node->GetType() != hipGraphNodeTypeGraph) {
-      for (auto command : node->GetCommands()) {
-        command->retain();
-      }
+    // Child graph nodes now have completion commands stored via GetCommands(),
+    // so they participate in the leaf retain/release cycle like regular nodes.
+    for (auto command : node->GetCommands()) {
+      command->retain();
     }
   }
 
@@ -2168,6 +2178,16 @@ bool Graph::RunNodes(int32_t base_stream, const std::vector<hip::Stream*>* paral
         start_marker->release();
       }
     }
+    // For child graphs launched on a non-zero base_stream, the root nodes
+    // are on stream 0 (roots_[0] is never set because scheduling always
+    // assigns the first root to stream 0 and skips it in root recording).
+    // Sync stream 0 with base_stream so the child's work waits for the
+    // parent's dependencies.
+    if (base_stream != 0) {
+      auto start_marker = new amd::Marker(*streams_[0], true, wait_list);
+      start_marker->enqueue();
+      start_marker->release();
+    }
     last_command->release();
   }
 
@@ -2181,8 +2201,7 @@ bool Graph::RunNodes(int32_t base_stream, const std::vector<hip::Stream*>* paral
   wait_list.clear();
   // Check if the graph has multiple leaf nodes
   for (uint32_t i = 0; i < DEBUG_HIP_FORCE_GRAPH_QUEUES; ++i) {
-    if ((leafs_[i] != nullptr) && (leafs_[i]->GetType() != hipGraphNodeTypeGraph)) {
-      // Add all commands in the wait list
+    if (leafs_[i] != nullptr) {
       for (auto command : leafs_[i]->GetCommands()) {
         if (base_stream != i) {
           wait_list.push_back(command);


### PR DESCRIPTION

## Motivation
 The classic graph execution path (RunOneNode/RunNodes) has missing synchronization for child graph nodes, causing data races and incorrect results when graphs with child nodes are executed with multi-stream   
  parallelism.
                                                                                                                                                                                                                   
  Discovered investigating ROCM-23631 (PyFR segfault on MI300X). The segfault was fixed by #5276, but the underlying sync issues in the classic path remained, producing silent data corruption.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

  1. Completion command stored on child graph node: child graph nodes originally had no commands_ vector, making them invisible to the dependency tracking, barrier, and leaf sync mechanisms. Now stores the child
   graph completion command (end marker from RunNodes) on the node immediately after execution, and removes the hipGraphNodeTypeGraph filters from the wait list builder, dep release loop, leaf retain, and leaf
  sync — so child graph nodes participate in all these mechanisms like regular nodes. Previous completion commands are released before storing new ones to prevent leaks on repeated launches.                     
  2. Child graph start sync on stream 0: when a child graph runs with base_stream != 0, its nodes execute on streams_[0] but roots_[0] is never set (scheduling skips stream_id_==0 for root recording), so the
  existing root sync loop never synced stream 0 with the parent dependencies. Now explicitly syncs stream 0 with base_stream.                                                                                      
  3. Leaf child graph nodes included in end-of-graph barrier: removed the hipGraphNodeTypeGraph filter from both the leaf retain and the leaf sync loop, so child graph leaf nodes on parallel streams are properly
   waited on at graph end.

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
ROCM-23631 
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
  - Reproduced with PyFR on MI300X in Docker (1332_gfx94X_7.13.0a20260430)                                                                                                                                         
  - Tested all DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING values (0, 1, 2)
  - Ran GraphsTest1 (236 tests), GraphsTest2 (30 tests) with =0 forced                                                                                                                                             
  - No regressions: same pre-existing failures (32+1) with and without fix  
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
No regressions in graph tests. Fixes the issue in PyFR
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
