### PR TITLE
[rocprofiler-compute] Validate HBM data transfer instead of peak bandwidth

### DIFF
--- a/projects/rocprofiler-compute/tests/test_metric_validation.py
+++ b/projects/rocprofiler-compute/tests/test_metric_validation.py
@@ -5,49 +5,66 @@ import pandas as pd
 import pytest
 import test_utils
 
-config = {}
-config["memcopy"] = ["tests/memcopy"]
-config["cleanup"] = True
-
 _, soc = test_utils.gpu_soc()
+
+
+def get_hbm_data_transfer(analysis_workload_dir, data):
+    bw = pd.read_csv(f"{analysis_workload_dir}/{data['bw_csv']}")[
+        data["bw_column"]
+    ].values[0]
+    duration_ns = pd.read_csv(f"{analysis_workload_dir}/{data['duration_csv']}")[
+        data["duration_column"]
+    ].values[0]
+    return bw * duration_ns / 1e9
+
 
 # workload -> gfx -> metric definition
 VALIDATE_METRICS = {
     "memcopy": {
+        "command": ["tests/memcopy"],
         "MI200": [
             {
-                "name": "HBM Bandwidth",
-                "metric_id": "4.1.8",
-                "csv_file": "4.1_Roofline_Performance_Rates.csv",
-                "column": "Value",
-                "expected_values": [1389.17],
+                "name": "HBM Data Transfer",
+                "profile_metric_id": ["4.1.8"],
+                "expected_values": [4096.0],
+                "tolerance": 0.10,
+                "get_actual": get_hbm_data_transfer,
+                "get_actual_data": {
+                    "bw_csv": "4.1_Roofline_Performance_Rates.csv",
+                    "bw_column": "Value",
+                    "duration_csv": "0.1_Top_Kernels.csv",
+                    "duration_column": "Sum(ns)",
+                },
             },
         ],
         "MI300": [
             {
-                "name": "HBM Bandwidth",
-                "metric_id": "4.1.9",
-                "csv_file": "4.1_Roofline_Performance_Rates.csv",
-                "column": "Value",
-                # MI 300 series contains MI 325X GPU which
-                # uses improved HBM3E instead of HBM3 used in
-                # MI 300X GPU. Hence, multiple expected values
-                # to cover both cases.
-                # MI 300A CPX and MI 308 have lower bandwidth.
-                # MI 300X: 3910.62 GB/s
-                # MI 325X: 4287.31 GB/s
-                # MI 308: 2003.45 GB/s
-                # MI 300A CPX: 710.23 GB/s (per-partition, CPX/NPS1)
-                "expected_values": [710.23, 2003.45, 3910.62, 4287.31],
+                "name": "HBM Data Transfer",
+                "profile_metric_id": ["4.1.9"],
+                "expected_values": [4096.0],
+                "tolerance": 0.10,
+                "get_actual": get_hbm_data_transfer,
+                "get_actual_data": {
+                    "bw_csv": "4.1_Roofline_Performance_Rates.csv",
+                    "bw_column": "Value",
+                    "duration_csv": "0.1_Top_Kernels.csv",
+                    "duration_column": "Sum(ns)",
+                },
             },
         ],
         "MI350": [
             {
-                "name": "HBM Bandwidth",
-                "metric_id": "4.1.10",
-                "csv_file": "4.1_Roofline_Performance_Rates.csv",
-                "column": "Value",
-                "expected_values": [5690.42],
+                "name": "HBM Data Transfer",
+                "profile_metric_id": ["4.1.10"],
+                "expected_values": [4096.0],
+                "tolerance": 0.10,
+                "get_actual": get_hbm_data_transfer,
+                "get_actual_data": {
+                    "bw_csv": "4.1_Roofline_Performance_Rates.csv",
+                    "bw_column": "Value",
+                    "duration_csv": "0.1_Top_Kernels.csv",
+                    "duration_column": "Sum(ns)",
+                },
             },
         ],
         # Ignore warmup dispatch
@@ -62,9 +79,9 @@ VALIDATE_METRICS = {
 def test_validate_metrics(
     binary_handler_profile_rocprof_compute, binary_handler_analyze_rocprof_compute
 ):
-    for workload in VALIDATE_METRICS.keys():
+    for workload in VALIDATE_METRICS:
         metrics = VALIDATE_METRICS[workload].get(soc, [])
-        metric_ids = [metric["metric_id"] for metric in metrics]
+        metric_ids = [mid for metric in metrics for mid in metric["profile_metric_id"]]
         if not metric_ids:
             print(
                 f"Skipping metric validation for {workload} on {soc}. "
@@ -79,8 +96,9 @@ def test_validate_metrics(
         try:
             # Ensure non zero length of profile df
             options = VALIDATE_METRICS[workload].get("profile_options", [])
+            profile_config = {workload: VALIDATE_METRICS[workload]["command"]}
             _ = binary_handler_profile_rocprof_compute(
-                config,
+                profile_config,
                 profile_workload_dir,
                 options,
                 check_success=True,
@@ -103,24 +121,27 @@ def test_validate_metrics(
                 "--path",
                 profile_workload_dir,
             ])
-            assert code == 0
+            assert code == 0, (
+                f"rocprof-compute analyze failed for {workload} on {soc} "
+                f"with metric ids {metric_ids}: exit code {code}"
+            )
 
             for metric in metrics:
-                actual = pd.read_csv(f"{analysis_workload_dir}/{metric['csv_file']}")[
-                    metric["column"]
-                ].values[0]
+                actual = metric["get_actual"](
+                    analysis_workload_dir, metric["get_actual_data"]
+                )
                 expected_values = metric["expected_values"]
-                # 5% tolerance in checking - assert if actual matches any expected value
+                tolerance = metric["tolerance"]
                 matches = [
-                    abs(actual - expected) / expected <= 0.05
+                    abs(actual - expected) / expected <= tolerance
                     for expected in expected_values
                 ]
                 diffs = [(abs(actual - exp) / exp * 100) for exp in expected_values]
                 assert any(matches), (
-                    f"{metric['name']} ({metric['metric_id']}): "
+                    f"{metric['name']}: "
                     f"actual={actual}, expected_values={expected_values}, "
-                    f"diffs={diffs} (tolerance: 5%)"
+                    f"diffs={diffs} (tolerance: {tolerance * 100}%)"
                 )
         finally:
-            test_utils.clean_output_dir(config["cleanup"], analysis_workload_dir)
-            test_utils.clean_output_dir(config["cleanup"], profile_workload_dir)
+            test_utils.clean_output_dir(True, analysis_workload_dir)
+            test_utils.clean_output_dir(True, profile_workload_dir)

--- a/projects/rocprofiler-compute/tests/test_metric_validation.py
+++ b/projects/rocprofiler-compute/tests/test_metric_validation.py
@@ -23,13 +23,14 @@ VALIDATE_METRICS = {
     "memcopy": {
         "command": ["tests/memcopy"],
         "name": "HBM Data Transfer",
+        "get_actual_func": get_hbm_data_transfer,
         "MI200": [
             {
                 "profile_metric_id": ["4.1.8"],
                 "expected_values": [4096.0],
                 "tolerance": 0.10,
-                "get_actual": get_hbm_data_transfer,
                 "get_actual_data": {
+                    "soc": "MI200",
                     "bw_csv": "4.1_Roofline_Performance_Rates.csv",
                     "bw_column": "Value",
                     "duration_csv": "0.1_Top_Kernels.csv",
@@ -42,8 +43,8 @@ VALIDATE_METRICS = {
                 "profile_metric_id": ["4.1.9"],
                 "expected_values": [4096.0],
                 "tolerance": 0.10,
-                "get_actual": get_hbm_data_transfer,
                 "get_actual_data": {
+                    "soc": "MI300",
                     "bw_csv": "4.1_Roofline_Performance_Rates.csv",
                     "bw_column": "Value",
                     "duration_csv": "0.1_Top_Kernels.csv",
@@ -56,8 +57,8 @@ VALIDATE_METRICS = {
                 "profile_metric_id": ["4.1.10"],
                 "expected_values": [4096.0],
                 "tolerance": 0.10,
-                "get_actual": get_hbm_data_transfer,
                 "get_actual_data": {
+                    "soc": "MI350",
                     "bw_csv": "4.1_Roofline_Performance_Rates.csv",
                     "bw_column": "Value",
                     "duration_csv": "0.1_Top_Kernels.csv",
@@ -125,8 +126,9 @@ def test_validate_metrics(
                 f"with metric ids {metric_ids}: exit code {code}"
             )
 
+            get_actual_func = VALIDATE_METRICS[workload]["get_actual_func"]
             for metric in metrics:
-                actual = metric["get_actual"](
+                actual = get_actual_func(
                     analysis_workload_dir, metric["get_actual_data"]
                 )
                 expected_values = metric["expected_values"]

--- a/projects/rocprofiler-compute/tests/test_metric_validation.py
+++ b/projects/rocprofiler-compute/tests/test_metric_validation.py
@@ -22,9 +22,9 @@ def get_hbm_data_transfer(analysis_workload_dir, data):
 VALIDATE_METRICS = {
     "memcopy": {
         "command": ["tests/memcopy"],
+        "name": "HBM Data Transfer",
         "MI200": [
             {
-                "name": "HBM Data Transfer",
                 "profile_metric_id": ["4.1.8"],
                 "expected_values": [4096.0],
                 "tolerance": 0.10,
@@ -39,7 +39,6 @@ VALIDATE_METRICS = {
         ],
         "MI300": [
             {
-                "name": "HBM Data Transfer",
                 "profile_metric_id": ["4.1.9"],
                 "expected_values": [4096.0],
                 "tolerance": 0.10,
@@ -54,7 +53,6 @@ VALIDATE_METRICS = {
         ],
         "MI350": [
             {
-                "name": "HBM Data Transfer",
                 "profile_metric_id": ["4.1.10"],
                 "expected_values": [4096.0],
                 "tolerance": 0.10,
@@ -94,8 +92,8 @@ def test_validate_metrics(
             param_id=f"{workload}_analysis"
         )
         try:
-            # Ensure non zero length of profile df
-            options = VALIDATE_METRICS[workload].get("profile_options", [])
+            # Copy to prevent upstream global mutations
+            options = list(VALIDATE_METRICS[workload].get("profile_options", []))
             profile_config = {workload: VALIDATE_METRICS[workload]["command"]}
             _ = binary_handler_profile_rocprof_compute(
                 profile_config,
@@ -105,6 +103,7 @@ def test_validate_metrics(
                 roof=VALIDATE_METRICS[workload].get("roof", False),
                 app_name=workload,
             )
+            # Ensure non zero length of profile df
             _ = test_utils.check_csv_files(
                 profile_workload_dir, num_devices=1, num_kernels=1
             )
@@ -138,7 +137,7 @@ def test_validate_metrics(
                 ]
                 diffs = [(abs(actual - exp) / exp * 100) for exp in expected_values]
                 assert any(matches), (
-                    f"{metric['name']}: "
+                    f"{VALIDATE_METRICS[workload]['name']}: "
                     f"actual={actual}, expected_values={expected_values}, "
                     f"diffs={diffs} (tolerance: {tolerance * 100}%)"
                 )


### PR DESCRIPTION
## Motivation

Switch the validation target from peak HBM bandwidth to HBM data transfer (bandwidth × kernel duration). Peak bandwidth fluctuates run-to-run and varies per SKU, which made the test flaky and forced a per-SoC fan-out of expected values. Total data transferred is governed by the workload (a fixed memcopy) and is essentially constant across all supported SoCs — uniform 4096 GB at 10% tolerance.

Refactor `test_metric_validation` so per-SoC metric definitions drive what gets validated, making it straightforward to add future metrics without changing test logic.

## Technical Details

- Per-metric extractor exposed via `get_actual` callable + `get_actual_data` sub-dict.
- `profile_metric_id` is a list, flattened into a single analyze `-b` invocation.
- `tolerance` is per-metric.
- Kernel command moved into `VALIDATE_METRICS["memcopy"]["command"]`; standalone `config` dict removed.
- Failure message on analyze non-zero exit includes workload, soc, and metric ids.

## JIRA ID

AIPROFCOMP-580

## Test Plan

- `python -m pytest tests/test_metric_validation.py -s -v`

## Test Result

- [x] Passed locally on MI300X (1 passed in 108.90s).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
