### PR TITLE
update gfx1151 memory reporting correctly for Rocr backend

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -1218,7 +1218,7 @@ bool Device::populateOCLDeviceConstants() {
     info_.hostUnifiedMemory_ = 1;
   }
 
-  if (settings().enableLocalMemory_ && gpuvm_segment_.handle != 0) {
+  if (settings().enableLocalMemory_ && gpuvm_segment_.handle != 0 && info_.hostUnifiedMemory_ != 1) {
     size_t global_segment_size = 0;
     if (HSA_STATUS_SUCCESS != Hsa::memory_pool_get_info(gpuvm_segment_,
                                                         HSA_AMD_MEMORY_POOL_INFO_SIZE,
@@ -1253,7 +1253,7 @@ bool Device::populateOCLDeviceConstants() {
     assert(alloc_granularity_ > 0);
   } else {
     // We suppose half of physical memory can be used by GPU in APU system
-    info_.globalMemSize_ = amd::Os::hostTotalPhysicalMemory() / 2;
+    info_.globalMemSize_ = amd::Os::hostTotalPhysicalMemory() ; // / 2;
     info_.globalMemSize_ = std::max(info_.globalMemSize_, uint64_t(1 * Gi));
     info_.globalMemSize_ = (static_cast<uint64_t>(std::min(GPU_MAX_HEAP_SIZE, 100u)) *
                             static_cast<uint64_t>(info_.globalMemSize_)) /

--- a/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
@@ -767,10 +767,9 @@ HSAKMT_STATUS topology_sysfs_get_node_props(uint32_t node_id, HsaNodeProperties&
   /*
    * In Native Linux, if the asic is APU, this value will be set to 1,
    * if the asic is dGPU, this value will be set to 0. clr use this info
-   * to set hostUnifiedMemory_, but for now wsl does not support this feature.
-   * Therefore, force vaule to 0 temporarily.
+   * to set hostUnifiedMemory_.
    */
-  props.Integrated = 0;
+  props.Integrated = !device->IsDgpu();
   props.Domain = device->Domain();
   props.UniqueID = device->Uuid();
   props.NumXcc = device->NumXcc();

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -154,11 +154,13 @@ bool WDDMDevice::QuerySegmentInfo()
     info.segment_id = i;
 
     if (seg.Aperture) {
-      info.kind = SegmentKind::kAperture;
+      info.kind = SegmentKind::kSystemMemory;
+      device_info_.non_local_heap_size += seg.CommitLimit;
     } else {
-      info.kind = seg.SegmentProperties.SystemMemory
-                      ? SegmentKind::kSystemMemory
-                      : SegmentKind::kLocalMemory;
+
+        info.kind = seg.SegmentProperties.SystemMemory
+                        ? SegmentKind::kSystemMemory
+                        : SegmentKind::kLocalMemory;
     }
 
     segment_infos_.push_back(info);
@@ -239,21 +241,18 @@ hsa_status_t WDDMDevice::VramAvail(uint64_t* available_bytes) {
 
     *available_bytes = LocalHeapSize() - usedVis - usedInv;
   } else {
-    // APU - NonLocal memory
-    if (!FindSegmentId(SegmentKind::kSystemMemory, &segmentId))
-      return HSA_STATUS_ERROR;
-
-    memset(&stats, 0, sizeof(D3DKMT_QUERYSTATISTICS));
-    stats.Type = D3DKMT_QUERYSTATISTICS_SEGMENT;
-    stats.AdapterLuid = adapter_luid_;
-    stats.QuerySegment.SegmentId = segmentId;
-    ret = DXCORE_CALL(D3DKMTQueryStatistics(&stats));
-    if (ret == 0)
-      usedNonLocal = stats.QueryResult.SegmentInformation.BytesResident;
-
+    for (const auto& seg_info : segment_infos_) {
+        // APU - NonLocal memory
+        memset(&stats, 0, sizeof(D3DKMT_QUERYSTATISTICS));
+        stats.Type = D3DKMT_QUERYSTATISTICS_SEGMENT;
+        stats.AdapterLuid = adapter_luid_;
+        stats.QuerySegment.SegmentId = segmentId;
+        ret = DXCORE_CALL(D3DKMTQueryStatistics(&stats));
+        if (ret == 0)
+          usedNonLocal += stats.QueryResult.SegmentInformation.BytesResident;
+    }
     *available_bytes = NonLocalHeapSize() - usedNonLocal;
   }
-
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -241,8 +241,8 @@ hsa_status_t WDDMDevice::VramAvail(uint64_t* available_bytes) {
 
     *available_bytes = LocalHeapSize() - usedVis - usedInv;
   } else {
+    // APU count all segments
     for (const auto& seg_info : segment_infos_) {
-        // APU - NonLocal memory
         memset(&stats, 0, sizeof(D3DKMT_QUERYSTATISTICS));
         stats.Type = D3DKMT_QUERYSTATISTICS_SEGMENT;
         stats.AdapterLuid = adapter_luid_;

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -246,7 +246,7 @@ hsa_status_t WDDMDevice::VramAvail(uint64_t* available_bytes) {
         memset(&stats, 0, sizeof(D3DKMT_QUERYSTATISTICS));
         stats.Type = D3DKMT_QUERYSTATISTICS_SEGMENT;
         stats.AdapterLuid = adapter_luid_;
-        stats.QuerySegment.SegmentId = segmentId;
+        stats.QuerySegment.SegmentId = seg_info.segment_id;
         ret = DXCORE_CALL(D3DKMTQueryStatistics(&stats));
         if (ret == 0)
           usedNonLocal += stats.QueryResult.SegmentInformation.BytesResident;


### PR DESCRIPTION
## Motivation
Fix memory reporting for APU using Rocr backend

## Technical Details
Memory reporting for APUs were failing. So this PR fixes the issue

## JIRA ID
AIRUNTIME-1992

## Test Plan
Need to verify hipInfo and all hip-tests pass with this PR

## Test Result
in-progress

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
