### PR TITLE
RCCL: skip preset topo matching when ranks per host differ

### DIFF
--- a/projects/rccl/src/graph/search.cc
+++ b/projects/rccl/src/graph/search.cc
@@ -1087,7 +1087,7 @@ ncclResult_t ncclTopoCompute(ncclTopoSystem* system, struct ncclTopoGraph* graph
         system->type |= RCCL_TOPO_4P2H_ROME;
       }
     }
-  } else if (!rcclParamModelMatchingDisable() && !graph->collNet) {
+  } else if (!rcclParamModelMatchingDisable() && !graph->collNet && !system->skipPresetTopoMatching) {
     // try to match 8P6L
     NCCLCHECK(parseChordalRing(system, graph));
     if (graph->nChannels) return ncclSuccess;

--- a/projects/rccl/src/graph/topo.h
+++ b/projects/rccl/src/graph/topo.h
@@ -223,6 +223,8 @@ struct ncclTopoSystem {
   bool useRailOptimizedTrees;
   /* RCCL Rome / GIO preset: RCCL_ROME_TOPO_PRESET_MODEL_IDX_* sentinels or romeTopoModels[] index */
   int romeTopoModelIdx;
+  /* Preset matchers assume uniform ranks per host; otherwise use generic search in ncclTopoCompute */
+  bool skipPresetTopoMatching;
 };
 
 ncclResult_t ncclTopoGetNode(struct ncclTopoSystem* system, struct ncclTopoNode** node, int type, uint64_t id);

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -1489,6 +1489,8 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     }
   }
 
+  comm->topo->skipPresetTopoMatching = !uniformRanksPerHost(comm, nranks);
+
   timers[TIMER_INIT_GRAPHS] = clockNano();
   // Get rings and trees
   memset(ringGraph, 0, sizeof(struct ncclTopoGraph));


### PR DESCRIPTION
## Motivation

In cases of non-uniform ranks per host, some hosts may use model matching, others may use search. RCCL will hang during init.

## Technical Details

Set ncclTopoSystem.skipPresetTopoMatching when uniformRanksPerHost is false so ncclTopoCompute uses generic search instead of chordal/Rome/GIO preset matchers.

## JIRA ID

## Test Plan

Test non-uniform number of ranks per host, i.e. mpirun -np 27 on 4 nodes 32 ranks allocation.

## Test Result

RCCL tests should pass normally.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
