### PR TITLE
Fix Flaky Builds Due to Race Condition from Missing Build Dependency

### DIFF
--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -398,6 +398,10 @@ add_custom_target(copy_nccl_device_headers DEPENDS ${NCCL_DEVICE_HEADER})
 # available before compiling the unit tests executable(s)
 add_custom_target(hipify_all DEPENDS ${HIP_SOURCES})
 
+# Serialize copy after full hipify: prevents previous race condition where copying of nccl device headers
+# could proceed before hipify_all stage had completed.
+add_dependencies(copy_nccl_device_headers hipify_all)
+
 # Add the generated net_ib_rocm.cc file (created by rocmIb.cmake in the staging area)
 # This file is patched and transformed directly into HIPIFY_DIR, bypassing the hipify step
 list(APPEND HIP_SOURCES "${HIPIFY_DIR}/src/transport/net_ib_rocm.cc")


### PR DESCRIPTION
## Motivation

This PR fixes a race in the new parallel build pipeline using the device linker.  This bug would only manifest on certain systems and versions of ROCm and sometimes sporadically.

## Technical Details

The hipify_all stage must strictly complete before the copy_nccl_device_headers stage can begin.  

I noticed that ./install.sh -l would fail, but then a subsequent cd build/release && make would succeed.  This made it clear that there was a race.  I looked at the dependency chain and saw the race.

I had an agent looking at this initially, but it was struggling to debug it.  Concurrency is hard.

## JIRA ID

N/A, me being salty in the group chat because the build was flaky

## Test Plan

- Run with ./install.sh -l.  Verify that it no longer crashes.

## Test Result

./install.sh -l 
...
[ 81%] Linking CXX shared library ../librccl.so
Elapsed time (seconds): 0.0707989
[100%] Built target rccl
[100%] Building CXX object src/CMakeFiles/rcclras.dir/__/hipify/src/ras/client.cc.o
[100%] Linking CXX executable rcclras
[100%] Built target rcclras

## Submission Checklist
