### PR TITLE
rccl: add GIN unit tests (host-only)

### DIFF
--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -7,6 +7,7 @@ if(BUILD_TESTS)
 
   option(OPENMP_TESTS_ENABLED "Enable OpenMP for unit tests" OFF)
   option(ENABLE_MPI_TESTS "Enable MPI-based tests" OFF)
+  option(RCCL_HAS_GIN_IB_PROXY "Build the IB Proxy GIN transport-level tests" OFF)
 
   message("Building rccl unit tests (Installed in /test/rccl-UnitTests)")
   if(ENABLE_MPI_TESTS)
@@ -112,6 +113,9 @@ if(BUILD_TESTS)
   endif()
   if(ENABLE_MPI_TESTS)
     list(APPEND RCCL_COMMON_COMPILE_DEFS MPI_TESTS_ENABLED)
+    if(RCCL_HAS_GIN_IB_PROXY)
+      list(APPEND RCCL_COMMON_COMPILE_DEFS RCCL_HAS_GIN_IB_PROXY)
+    endif()
   endif()
   list(APPEND RCCL_COMMON_COMPILE_DEFS __HIP_PLATFORM_AMD__)
 
@@ -274,6 +278,7 @@ if(BUILD_TESTS)
       transport/NetIbMPI/GeneralTests.cpp
       transport/NetIbMPI/NicFusionTests.cpp
       transport/NetIbMPI/CastTests.cpp
+      transport/GinMPI/GinMPITests.cpp
       ImplicitLaunchOrderMPITests.cpp
       RegistrationMPITests.cpp
     )

--- a/projects/rccl/test/transport/GinMPI/GinMPITestBase.hpp
+++ b/projects/rccl/test/transport/GinMPI/GinMPITestBase.hpp
@@ -15,6 +15,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <string>
@@ -23,6 +24,7 @@
 #include <vector>
 
 #include "MPITestBase.hpp"
+#include "ResourceGuards.hpp"
 #include "TestChecks.hpp"
 #include "rccl/rccl.h"
 
@@ -91,7 +93,11 @@ protected:
     int worldRank_ = -1;
     int worldSize_ = 0;
 
+    // MRs registered through RegMr released via deregMrSym in TearDown
     std::vector<void*> registeredMhandles_;
+
+    // Device buffers allocated through AllocBuf released via hipFree in TearDown
+    std::vector<void*> allocatedDeviceBuffers_;
 
     virtual int GetNumContexts() const { return 1; }
 
@@ -113,7 +119,16 @@ protected:
                 }
             }
             registeredMhandles_.clear();
+        }
 
+        for(void* p : allocatedDeviceBuffers_)
+        {
+            RCCLTestGuards::hipFreeWrapper(p);   // null-safe + warns on hipFree errors
+        }
+        allocatedDeviceBuffers_.clear();
+
+        if(gin_ != nullptr)
+        {
             if(ginCtx_ != nullptr && gin_->destroyContext) {
                 (void)gin_->destroyContext(ginCtx_);
             }
@@ -307,6 +322,7 @@ protected:
             return nullptr;
         }
 
+        allocatedDeviceBuffers_.push_back(p);
         return p;
     }
 

--- a/projects/rccl/test/transport/GinMPI/GinMPITestBase.hpp
+++ b/projects/rccl/test/transport/GinMPI/GinMPITestBase.hpp
@@ -1,0 +1,388 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#pragma once
+
+#ifdef MPI_TESTS_ENABLED
+#ifdef RCCL_HAS_GIN_IB_PROXY
+
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <mpi.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <tuple>
+#include <vector>
+
+#include "MPITestBase.hpp"
+#include "TestChecks.hpp"
+#include "rccl/rccl.h"
+
+#include "gin.h"
+#include "nccl_net.h"
+#include "nccl_gin.h"
+
+extern ncclGin_t ncclGinIbProxy;
+extern ncclGin_t IbCastGinIbProxy;
+
+namespace RCCLGinTests
+{
+
+using ::MPITestConstants::kMinProcessesForMPI;
+using ::MPITestConstants::kNoProcessLimit;
+using ::MPITestConstants::kNoPowerOfTwoRequired;
+using ::MPITestConstants::kNoNodeLimit;
+
+inline ncclGin_t* GetGinPlugin()
+{
+    const char* env = std::getenv("NCCL_GIN_PLUGIN");
+    if (env == nullptr || *env == '\0') {
+        return &ncclGinIbProxy;
+    }
+    if (std::strcmp(env, "GIN_IB_PROXY") == 0) {
+        return &ncclGinIbProxy;
+    }
+    if (std::strcmp(env, "CAST_GIN_IB_PROXY") == 0) {
+        return &IbCastGinIbProxy;
+    }
+
+    static bool warned = false;
+    if (!warned)
+    {
+        std::fprintf(stderr,
+                     "[GinMPITest] WARN: unknown NCCL_GIN_PLUGIN='%s', "
+                     "falling back to GIN_IB_PROXY\n", env);
+        warned = true;
+    }
+    return &ncclGinIbProxy;
+}
+
+class GinMPITestBase : public MPITestBase
+{
+protected:
+    int defaultDevice_  = 0;
+    int defaultSignals_ = 8;
+    int defaultCounters_ = 8;
+    int defaultQueueDepth_ = 0;
+
+    // Polling
+    static constexpr int kDefaultPollTimeoutMs = 5000;
+    static constexpr int kPollSleepUs          = 100;
+
+    // Plugin handle table under test (resolved in SetUp from env var).
+    ncclGin_t* gin_ = nullptr;
+
+    // Plugin / connection state (populated by SetUpFixture).
+    void* pluginCtx_  = nullptr;
+    void* listenComm_ = nullptr;
+    void* collComm_   = nullptr;
+    void* ginCtx_     = nullptr;
+    ncclNetDeviceHandle_v11_t* devHandle_ = nullptr;
+
+    int nDevices_  = 0;
+    int worldRank_ = -1;
+    int worldSize_ = 0;
+
+    std::vector<void*> registeredMhandles_;
+
+    virtual int GetNumContexts() const { return 1; }
+
+    void SetUp() override
+    {
+        MPITestBase::SetUp();
+        gin_ = GetGinPlugin();
+    }
+
+    void TearDown() override
+    {
+        if(gin_ != nullptr)
+        {
+            if(collComm_ != nullptr && gin_->deregMrSym)
+            {
+                for(void* mh : registeredMhandles_)
+                {
+                    if(mh != nullptr) (void)gin_->deregMrSym(collComm_, mh);
+                }
+            }
+            registeredMhandles_.clear();
+
+            if(ginCtx_ != nullptr && gin_->destroyContext) {
+                (void)gin_->destroyContext(ginCtx_);
+            }
+            if(collComm_ != nullptr && gin_->closeColl) {
+                (void)gin_->closeColl(collComm_);
+            }
+            if(listenComm_ != nullptr && gin_->closeListen) {
+                (void)gin_->closeListen(listenComm_);
+            }
+            if(pluginCtx_ != nullptr && gin_->finalize) {
+                (void)gin_->finalize(pluginCtx_);
+            }
+        }
+        ginCtx_ = nullptr;
+        collComm_ = nullptr;
+        devHandle_ = nullptr;
+        pluginCtx_ = nullptr;
+        listenComm_ = nullptr;
+
+        MPITestBase::TearDown();
+    }
+
+    bool SetUpFixture(int minProcesses = kMinProcessesForMPI,
+                      int maxProcesses = kNoProcessLimit,
+                      int minNodes = 1)
+    {
+        if(!validateTestPrerequisites(minProcesses, maxProcesses,
+                                      kNoPowerOfTwoRequired,
+                                      minNodes, kNoNodeLimit))
+        {
+            return false;
+        }
+
+        // GPU is a hard prerequisite — all buffers are device-allocated.
+        int nGpus = 0;
+        if(hipGetDeviceCount(&nGpus) != hipSuccess || nGpus <= 0)
+        {
+            GTEST_SKIP() << "No HIP devices visible; GIN tests require GPU";
+            return false;
+        }
+
+        worldRank_ = MPIEnvironment::world_rank;
+        worldSize_ = MPIEnvironment::world_size;
+
+        // 1. init
+        ncclResult_t r = gin_->init(&pluginCtx_, /*commId=*/0, nullptr);
+        if(r != ncclSuccess)
+        {
+            ADD_FAILURE() << "gin->init failed: " << r;
+            return false;
+        }
+
+        // 2. devices — skip if no IB hardware
+        r = gin_->devices(&nDevices_);
+        if(r != ncclSuccess)
+        {
+            ADD_FAILURE() << "gin->devices failed: " << r;
+            return false;
+        }
+        if(nDevices_ <= 0)
+        {
+            GTEST_SKIP() << "No IB GIN-capable devices on this host";
+            return false;
+        }
+
+        // 3. listen — produce this rank's listen handle
+        std::vector<char> localHandle(NCCL_NET_HANDLE_MAXSIZE, 0);
+        r = gin_->listen(pluginCtx_, defaultDevice_,
+                         localHandle.data(), &listenComm_);
+        if(r != ncclSuccess)
+        {
+            ADD_FAILURE() << "gin->listen failed: " << r;
+            return false;
+        }
+
+        // 4. allgather all listen handles
+        std::vector<char> allHandles(NCCL_NET_HANDLE_MAXSIZE * worldSize_, 0);
+        int mpiRet = MPI_Allgather(localHandle.data(), NCCL_NET_HANDLE_MAXSIZE, MPI_BYTE,
+                                   allHandles.data(),  NCCL_NET_HANDLE_MAXSIZE, MPI_BYTE,
+                                   MPI_COMM_WORLD);
+        if(mpiRet != MPI_SUCCESS)
+        {
+            ADD_FAILURE() << "MPI_Allgather of listen handles failed: " << mpiRet;
+            return false;
+        }
+
+        std::vector<void*> handlePtrs(worldSize_, nullptr);
+        for(int i = 0; i < worldSize_; ++i)
+        {
+            handlePtrs[i] = allHandles.data() + i * NCCL_NET_HANDLE_MAXSIZE;
+        }
+
+        // 5. connect (N-way collective)
+        r = gin_->connect(pluginCtx_, handlePtrs.data(),
+                          worldSize_, worldRank_,
+                          listenComm_, &collComm_);
+        if(r != ncclSuccess)
+        {
+            ADD_FAILURE() << "gin->connect failed: " << r;
+            return false;
+        }
+
+        // 6. createContext — number of contexts driven by the parameter
+        ncclGinConfig_t cfg = {};
+        cfg.nSignals = defaultSignals_;
+        cfg.nCounters = defaultCounters_;
+        cfg.nContexts = GetNumContexts();
+        cfg.queueDepth = defaultQueueDepth_;
+        cfg.trafficClass = -1;
+
+        r = gin_->createContext(collComm_, &cfg, &ginCtx_, &devHandle_);
+        if(r != ncclSuccess)
+        {
+            ADD_FAILURE() << "gin->createContext failed: " << r;
+            return false;
+        }
+
+        TEST_INFO("GinMPI fixture ready: rank=%d/%d nDevices=%d nContexts=%d",
+                  worldRank_, worldSize_, nDevices_, GetNumContexts());
+        return true;
+    }
+
+    ncclResult_t RegMr(void* data, size_t size,
+                       void** mhandle, void** ginHandle)
+    {
+        ncclResult_t r = gin_->regMrSym(collComm_, data, size,
+                                        NCCL_PTR_CUDA, /*mrFlags=*/0,
+                                        mhandle, ginHandle);
+        if(r == ncclSuccess && mhandle != nullptr && *mhandle != nullptr)
+        {
+            registeredMhandles_.push_back(*mhandle);
+        }
+        return r;
+    }
+
+    bool PollUntilDone(void* request, int timeoutMs = kDefaultPollTimeoutMs)
+    {
+        if(request == nullptr)
+        {
+            ADD_FAILURE() << "PollUntilDone called with null request "
+                             "(plugin returned ncclSuccess but did not "
+                             "produce a request handle)";
+            return false;
+        }
+
+        const auto deadline = std::chrono::steady_clock::now()
+                              + std::chrono::milliseconds(timeoutMs);
+        for(;;)
+        {
+            int done = 0;
+            ncclResult_t r = gin_->test(collComm_, request, &done);
+            if(r != ncclSuccess)
+            {
+                ADD_FAILURE() << "gin->test failed: " << r;
+                return false;
+            }
+            if(done) return true;
+
+            if(std::chrono::steady_clock::now() >= deadline)
+            {
+                ADD_FAILURE() << "PollUntilDone timed out after " << timeoutMs << " ms";
+                return false;
+            }
+            std::this_thread::sleep_for(std::chrono::microseconds(kPollSleepUs));
+        }
+    }
+
+    /** MPI barrier across the world communicator. */
+    void Barrier() { MPI_Barrier(MPI_COMM_WORLD); }
+
+    void* AllocBuf(size_t size)
+    {
+        void* p = nullptr;
+        if(hipMalloc(&p, size) != hipSuccess) return nullptr;
+        (void)hipMemset(p, 0, size);
+        (void)hipDeviceSynchronize();
+        return p;
+    }
+
+    /** Fill device `buf` with the byte pattern (seed + i) % 256. */
+    void FillBuf(void* buf, size_t size, int seed)
+    {
+        std::vector<uint8_t> tmp(size);
+        for(size_t i = 0; i < size; ++i)
+            tmp[i] = static_cast<uint8_t>((seed + i) % 256);
+        (void)hipMemcpy(buf, tmp.data(), size, hipMemcpyHostToDevice);
+        (void)hipDeviceSynchronize();
+    }
+
+    /** Return true iff device `buf` matches (seed + i) % 256 for all i. */
+    bool VerifyBuf(const void* buf, size_t size, int seed)
+    {
+        std::vector<uint8_t> staging(size);
+        if(hipMemcpy(staging.data(), buf, size, hipMemcpyDeviceToHost) != hipSuccess)
+            return false;
+        (void)hipDeviceSynchronize();
+        for(size_t i = 0; i < size; ++i)
+        {
+            if(staging[i] != static_cast<uint8_t>((seed + i) % 256)) return false;
+        }
+        return true;
+    }
+
+    /** Fill device `buf` with a constant byte (sentinel). */
+    void FillSentinel(void* buf, size_t size, uint8_t value)
+    {
+        (void)hipMemset(buf, value, size);
+        (void)hipDeviceSynchronize();
+    }
+
+    /** Return true iff every byte in device `buf` equals `value`. */
+    bool AllSentinel(const void* buf, size_t size, uint8_t value)
+    {
+        std::vector<uint8_t> staging(size);
+        if(hipMemcpy(staging.data(), buf, size, hipMemcpyDeviceToHost) != hipSuccess)
+            return false;
+        (void)hipDeviceSynchronize();
+        for(size_t i = 0; i < size; ++i)
+        {
+            if(staging[i] != value) return false;
+        }
+        return true;
+    }
+
+    /** Read a 64-bit value from device `signalBuf` at byte offset
+     *  `signalOff`. Returns 0 on copy failure. */
+    uint64_t ReadSignal(const void* signalBuf, size_t signalOff = 0)
+    {
+        uint64_t v = 0;
+        const auto* p = static_cast<const uint8_t*>(signalBuf) + signalOff;
+        if(hipMemcpy(&v, p, sizeof(v), hipMemcpyDeviceToHost) != hipSuccess)
+            return 0;
+        (void)hipDeviceSynchronize();
+        return v;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Parameterized fixture — sweep nContexts × messageSize.
+//
+// Used by the 8 tests where both axes are meaningful. The 2 tests
+// where the size is fixed by the test point itself (zero-size) or
+// irrelevant (invalid-op) use GinMPIFixedSizeTest instead so they
+// don't produce redundant size variants.
+// ---------------------------------------------------------------------------
+class GinMPITest : public GinMPITestBase,
+                   public ::testing::WithParamInterface<std::tuple<int, size_t>>
+{
+protected:
+    int    NumContexts() const { return std::get<0>(GetParam()); }
+    size_t MessageSize() const { return std::get<1>(GetParam()); }
+    int    GetNumContexts() const override { return NumContexts(); }
+};
+
+// ---------------------------------------------------------------------------
+// Parameterized fixture — sweep nContexts only.
+//
+// Used by IPutSignalZeroSize (size IS the test point) and
+// IPutSignalInvalidSignalOp (size is irrelevant to the assertion).
+// ---------------------------------------------------------------------------
+class GinMPIFixedSizeTest : public GinMPITestBase,
+                            public ::testing::WithParamInterface<int>
+{
+protected:
+    int NumContexts() const { return GetParam(); }
+    int GetNumContexts() const override { return NumContexts(); }
+};
+
+} // namespace RCCLGinTests
+
+#endif // RCCL_HAS_GIN_IB_PROXY
+#endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/transport/GinMPI/GinMPITestBase.hpp
+++ b/projects/rccl/test/transport/GinMPI/GinMPITestBase.hpp
@@ -288,8 +288,25 @@ protected:
     {
         void* p = nullptr;
         if(hipMalloc(&p, size) != hipSuccess) return nullptr;
-        (void)hipMemset(p, 0, size);
-        (void)hipDeviceSynchronize();
+
+        hipError_t err = hipMemset(p, 0, size);
+        if(err != hipSuccess)
+        {
+            ADD_FAILURE() << "hipMemset failed in AllocBuf: "
+                          << hipGetErrorString(err);
+            (void)hipFree(p);
+            return nullptr;
+        }
+
+        err = hipDeviceSynchronize();
+        if(err != hipSuccess)
+        {
+            ADD_FAILURE() << "hipDeviceSynchronize failed in AllocBuf: "
+                          << hipGetErrorString(err);
+            (void)hipFree(p);
+            return nullptr;
+        }
+
         return p;
     }
 

--- a/projects/rccl/test/transport/GinMPI/GinMPITestBase.hpp
+++ b/projects/rccl/test/transport/GinMPI/GinMPITestBase.hpp
@@ -415,6 +415,18 @@ protected:
     int GetNumContexts() const override { return NumContexts(); }
 };
 
+// ---------------------------------------------------------------------------
+// Non-parameterized fixture — used by long-running stress tests that have
+// their own internal "iterations" dimension and need predictable runtime.
+// Single context, fixed config; the iteration count IS the stress axis.
+// Filterable as a group via `--gtest_filter='*Stress*'`.
+// ---------------------------------------------------------------------------
+class GinMPIStressTest : public GinMPITestBase
+{
+protected:
+    int GetNumContexts() const override { return 1; }
+};
+
 } // namespace RCCLGinTests
 
 #endif // RCCL_HAS_GIN_IB_PROXY

--- a/projects/rccl/test/transport/GinMPI/GinMPITestBase.hpp
+++ b/projects/rccl/test/transport/GinMPI/GinMPITestBase.hpp
@@ -18,6 +18,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <strings.h>
 #include <string>
 #include <thread>
 #include <tuple>
@@ -28,11 +29,9 @@
 #include "TestChecks.hpp"
 #include "rccl/rccl.h"
 
-#include "gin.h"
 #include "nccl_net.h"
 #include "nccl_gin.h"
 
-extern ncclGin_t ncclGinIbProxy;
 extern ncclGin_t IbCastGinIbProxy;
 
 namespace RCCLGinTests
@@ -45,26 +44,13 @@ using ::MPITestConstants::kNoNodeLimit;
 
 inline ncclGin_t* GetGinPlugin()
 {
-    const char* env = std::getenv("NCCL_GIN_PLUGIN");
-    if (env == nullptr || *env == '\0') {
-        return &ncclGinIbProxy;
-    }
-    if (std::strcmp(env, "GIN_IB_PROXY") == 0) {
-        return &ncclGinIbProxy;
-    }
-    if (std::strcmp(env, "CAST_GIN_IB_PROXY") == 0) {
-        return &IbCastGinIbProxy;
-    }
+    const char* envNet = std::getenv("NCCL_NET");
+    if (envNet == nullptr) return nullptr;
 
-    static bool warned = false;
-    if (!warned)
-    {
-        std::fprintf(stderr,
-                     "[GinMPITest] WARN: unknown NCCL_GIN_PLUGIN='%s', "
-                     "falling back to GIN_IB_PROXY\n", env);
-        warned = true;
-    }
-    return &ncclGinIbProxy;
+    if (strcasecmp(envNet, "IB-CAST") == 0) return &IbCastGinIbProxy;
+    // if (strcasecmp(envNet, "IB") == 0) return &ncclGinIbProxy;
+
+    return nullptr;
 }
 
 class GinMPITestBase : public MPITestBase
@@ -105,6 +91,25 @@ protected:
     {
         MPITestBase::SetUp();
         gin_ = GetGinPlugin();
+        if (gin_ == nullptr)
+        {
+            // GetGinPlugin() returned null -> NCCL_NET selects a transport
+            // with no GIN backend ported to this RCCL build (or is unset).
+            static bool warned = false;
+            if (!warned)
+            {
+                const char* envNet = std::getenv("NCCL_NET");
+                std::fprintf(stderr,
+                             "[GinMPITest] WARN: NCCL_NET=%s has no GIN "
+                             "backend in this RCCL build. Currently only "
+                             "NCCL_NET=ib-cast is supported. Skipping all "
+                             "GIN tests.\n",
+                             envNet ? envNet : "<unset>");
+                warned = true;
+            }
+            GTEST_SKIP() << "No GIN backend available for current NCCL_NET";
+            return;
+        }
     }
 
     void TearDown() override
@@ -155,6 +160,11 @@ protected:
                       int maxProcesses = kNoProcessLimit,
                       int minNodes = 1)
     {
+        // SetUp() already recorded the skip + warning when NCCL_NET wasn't
+        // ib-cast. Short-circuit so the per-test body doesn't proceed to
+        // dereference gin_->init() etc.
+        if (gin_ == nullptr) return false;
+
         if(!validateTestPrerequisites(minProcesses, maxProcesses,
                                       kNoPowerOfTwoRequired,
                                       minNodes, kNoNodeLimit))
@@ -166,7 +176,12 @@ protected:
         int nGpus = 0;
         if(hipGetDeviceCount(&nGpus) != hipSuccess || nGpus <= 0)
         {
-            GTEST_SKIP() << "No HIP devices visible; GIN tests require GPU";
+            // GTEST_SKIP() expands to `return <void>`, which we cannot do
+            // from this bool-returning helper. Execute it inside a void
+            // lambda so the return is consumed there, then bail to the
+            // caller normally — the skip status is still registered on
+            // the active test.
+            [&]() { GTEST_SKIP() << "No HIP devices visible; GIN tests require GPU"; }();
             return false;
         }
 
@@ -190,7 +205,8 @@ protected:
         }
         if(nDevices_ <= 0)
         {
-            GTEST_SKIP() << "No IB GIN-capable devices on this host";
+            // See comment above on the bool-vs-void GTEST_SKIP wrapping.
+            [&]() { GTEST_SKIP() << "No IB GIN-capable devices on this host"; }();
             return false;
         }
 

--- a/projects/rccl/test/transport/GinMPI/GinMPITests.cpp
+++ b/projects/rccl/test/transport/GinMPI/GinMPITests.cpp
@@ -1,0 +1,669 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifdef MPI_TESTS_ENABLED
+
+#ifdef RCCL_HAS_GIN_IB_PROXY
+
+#include "GinMPITestBase.hpp"
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace RCCLGinTests
+{
+
+namespace
+{
+
+constexpr size_t kSignalSize = 64;
+constexpr size_t kBlockSize  = 256;
+constexpr int    kInflightN  = 16;
+
+} // namespace
+
+TEST_P(GinMPITest, IPutBasic)
+{
+    if(!SetUpFixture(/*minProcs=*/2, /*maxProcs=*/2))
+    {
+        return;
+    }
+
+    const size_t kSize = MessageSize();
+
+    void* sendBuf = AllocBuf(kSize);
+    void* recvBuf = AllocBuf(kSize);
+    ASSERT_NE(sendBuf, nullptr);
+    ASSERT_NE(recvBuf, nullptr);
+
+    if(worldRank_ == 0)
+    {
+        FillBuf(sendBuf, kSize, /*seed=*/0xA0);
+    }
+
+    void *sendMh = nullptr, *sendGh = nullptr;
+    void *recvMh = nullptr, *recvGh = nullptr;
+    ASSERT_EQ(ncclSuccess, RegMr(sendBuf, kSize, &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(recvBuf, kSize, &recvMh, &recvGh));
+
+    Barrier();
+
+    if(worldRank_ == 0)
+    {
+        void* req = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  gin_->iput(ginCtx_, /*context=*/0,
+                             /*srcOff=*/0, sendMh, kSize,
+                             /*dstOff=*/0, recvMh,
+                             /*peerRank=*/1, &req));
+        ASSERT_TRUE(PollUntilDone(req));
+    }
+    Barrier();
+
+    if(worldRank_ == 1)
+    {
+        EXPECT_TRUE(VerifyBuf(recvBuf, kSize, /*seed=*/0xA0));
+    }
+}
+
+TEST_P(GinMPITest, IGetBasic)
+{
+    if(!SetUpFixture(2, 2))
+    {
+        return;
+    }
+
+    const size_t kSize = MessageSize();
+
+    void* buf = AllocBuf(kSize);
+    ASSERT_NE(buf, nullptr);
+    if(worldRank_ == 1)
+    {
+        FillBuf(buf, kSize, /*seed=*/0xC3);
+    }
+
+    void *mh = nullptr, *gh = nullptr;
+    ASSERT_EQ(ncclSuccess, RegMr(buf, kSize, &mh, &gh));
+
+    Barrier();
+    if(worldRank_ == 0)
+    {
+        void* req = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  gin_->iget(ginCtx_, /*context=*/0,
+                             /*remoteOff=*/0, mh, kSize,
+                             /*localOff=*/0,  mh,
+                             /*peerRank=*/1, &req));
+        ASSERT_TRUE(PollUntilDone(req));
+        EXPECT_TRUE(VerifyBuf(buf, kSize, /*seed=*/0xC3));
+    }
+    Barrier();
+}
+
+TEST_P(GinMPITest, IPutSignalInc)
+{
+    if(!SetUpFixture(2, 2))
+    {
+        return;
+    }
+
+    const size_t kSize = MessageSize();
+
+    void* sendBuf = AllocBuf(kSize);
+    void* recvBuf = AllocBuf(kSize);
+    void* sigBuf  = AllocBuf(kSignalSize);
+    ASSERT_NE(sendBuf, nullptr);
+    ASSERT_NE(recvBuf, nullptr);
+    ASSERT_NE(sigBuf,  nullptr);
+
+    if(worldRank_ == 0)
+    {
+        FillBuf(sendBuf, kSize, /*seed=*/0x55);
+    }
+
+    void *sendMh, *sendGh, *recvMh, *recvGh, *sigMh, *sigGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sendBuf, kSize,       &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(recvBuf, kSize,       &recvMh, &recvGh));
+    ASSERT_EQ(ncclSuccess, RegMr(sigBuf,  kSignalSize, &sigMh,  &sigGh));
+
+    Barrier();
+    if(worldRank_ == 0)
+    {
+        void* req = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  gin_->iputSignal(ginCtx_, /*context=*/0,
+                                   /*srcOff=*/0, sendMh, kSize,
+                                   /*dstOff=*/0, recvMh,
+                                   /*peerRank=*/1,
+                                   /*signalOff=*/0, sigMh,
+                                   /*signalValue=*/0, // unused for INC
+                                   NCCL_NET_SIGNAL_OP_INC,
+                                   &req));
+        ASSERT_TRUE(PollUntilDone(req));
+    }
+    Barrier();
+
+    if(worldRank_ == 1)
+    {
+        EXPECT_TRUE(VerifyBuf(recvBuf, kSize, /*seed=*/0x55));
+        EXPECT_EQ(ReadSignal(sigBuf), 1u);
+    }
+}
+
+TEST_P(GinMPITest, IPutSignalAdd)
+{
+    if(!SetUpFixture(2, 2))
+    {
+        return;
+    }
+
+    constexpr uint64_t kAddValue = 42;
+    const size_t       kSize     = MessageSize();
+
+    void* sendBuf = AllocBuf(kSize);
+    void* recvBuf = AllocBuf(kSize);
+    void* sigBuf  = AllocBuf(kSignalSize);
+    ASSERT_NE(sendBuf, nullptr);
+    ASSERT_NE(recvBuf, nullptr);
+    ASSERT_NE(sigBuf,  nullptr);
+
+    if(worldRank_ == 0)
+    {
+        FillBuf(sendBuf, kSize, /*seed=*/0xE7);
+    }
+
+    void *sendMh, *sendGh, *recvMh, *recvGh, *sigMh, *sigGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sendBuf, kSize,       &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(recvBuf, kSize,       &recvMh, &recvGh));
+    ASSERT_EQ(ncclSuccess, RegMr(sigBuf,  kSignalSize, &sigMh,  &sigGh));
+
+    Barrier();
+    if(worldRank_ == 0)
+    {
+        void* req = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  gin_->iputSignal(ginCtx_, 0,
+                                   0, sendMh, kSize,
+                                   0, recvMh, 1,
+                                   /*signalOff=*/0, sigMh,
+                                   kAddValue,
+                                   NCCL_NET_SIGNAL_OP_ADD,
+                                   &req));
+        ASSERT_TRUE(PollUntilDone(req));
+    }
+    Barrier();
+
+    if(worldRank_ == 1)
+    {
+        EXPECT_TRUE(VerifyBuf(recvBuf, kSize, /*seed=*/0xE7));
+        EXPECT_EQ(ReadSignal(sigBuf), kAddValue);
+    }
+}
+
+TEST_P(GinMPITest, IPutSignalAtOffset)
+{
+    if(!SetUpFixture(2, 2))
+    {
+        return;
+    }
+
+    const size_t      kSize       = MessageSize();
+    const size_t      kSrcOff     = kSize / 2;
+    const size_t      kDstOff     = kSize / 2;
+    const size_t      kSigOff     = 64;
+    const size_t      kBufSize    = kSize * 2;
+    const size_t      kSigBufSize = kSignalSize * 2;
+    constexpr uint8_t kSentinel   = 0xCC;
+
+    void* sendBuf = AllocBuf(kBufSize);
+    void* recvBuf = AllocBuf(kBufSize);
+    void* sigBuf  = AllocBuf(kSigBufSize);
+    ASSERT_NE(sendBuf, nullptr);
+    ASSERT_NE(recvBuf, nullptr);
+    ASSERT_NE(sigBuf,  nullptr);
+
+    if(worldRank_ == 0)
+    {
+        FillBuf(static_cast<uint8_t*>(sendBuf) + kSrcOff, kSize, /*seed=*/0xA5);
+    }
+    if(worldRank_ == 1)
+    {
+        FillSentinel(recvBuf, kBufSize,    kSentinel);
+        FillSentinel(sigBuf,  kSigBufSize, kSentinel);
+    }
+
+    void *sendMh, *sendGh, *recvMh, *recvGh, *sigMh, *sigGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sendBuf, kBufSize,    &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(recvBuf, kBufSize,    &recvMh, &recvGh));
+    ASSERT_EQ(ncclSuccess, RegMr(sigBuf,  kSigBufSize, &sigMh,  &sigGh));
+
+    Barrier();
+    if(worldRank_ == 0)
+    {
+        void* req = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  gin_->iputSignal(ginCtx_, /*context=*/0,
+                                   /*srcOff=*/kSrcOff, sendMh, kSize,
+                                   /*dstOff=*/kDstOff, recvMh,
+                                   /*peerRank=*/1,
+                                   /*signalOff=*/kSigOff, sigMh,
+                                   /*signalValue=*/0,
+                                   NCCL_NET_SIGNAL_OP_INC,
+                                   &req));
+        ASSERT_TRUE(PollUntilDone(req));
+    }
+    Barrier();
+
+    if(worldRank_ == 1)
+    {
+        // Data window: pattern at dstOff
+        EXPECT_TRUE(VerifyBuf(static_cast<uint8_t*>(recvBuf) + kDstOff,
+                              kSize, /*seed=*/0xA5))
+            << "data did not land at dstOff=" << kDstOff;
+        // Bytes BEFORE dstOff: untouched
+        EXPECT_TRUE(AllSentinel(recvBuf, kDstOff, kSentinel))
+            << "recvBuf[0.." << kDstOff << ") was thrashed "
+            << "(dstOff likely treated as 0)";
+        // Bytes AFTER dstOff + kSize: untouched
+        EXPECT_TRUE(AllSentinel(static_cast<uint8_t*>(recvBuf) + kDstOff + kSize,
+                                kBufSize - (kDstOff + kSize), kSentinel))
+            << "recvBuf[" << (kDstOff + kSize) << ".." << kBufSize
+            << ") was thrashed (write extended past size)";
+
+        // Signal: incremented at signalOff
+        EXPECT_EQ(ReadSignal(sigBuf, kSigOff), 1u)
+            << "signal at signalOff=" << kSigOff << " not incremented";
+        // Bytes BEFORE signalOff: untouched
+        EXPECT_TRUE(AllSentinel(sigBuf, kSigOff, kSentinel))
+            << "sigBuf[0.." << kSigOff << ") was thrashed "
+            << "(signalOff likely treated as 0)";
+        // Bytes AFTER signalOff + 8: untouched
+        EXPECT_TRUE(AllSentinel(static_cast<uint8_t*>(sigBuf) + kSigOff + sizeof(uint64_t),
+                                kSigBufSize - (kSigOff + sizeof(uint64_t)), kSentinel))
+            << "sigBuf[" << (kSigOff + sizeof(uint64_t)) << ".." << kSigBufSize
+            << ") was thrashed (atomic wrote past 8 bytes)";
+    }
+}
+
+TEST_P(GinMPITest, IFlushAfterIGet)
+{
+    if(!SetUpFixture(2, 2))
+    {
+        return;
+    }
+
+    const size_t kSize = MessageSize();
+
+    void* buf = AllocBuf(kSize);
+    ASSERT_NE(buf, nullptr);
+    if(worldRank_ == 1)
+    {
+        FillBuf(buf, kSize, /*seed=*/0x71);
+    }
+
+    void *mh = nullptr, *gh = nullptr;
+    ASSERT_EQ(ncclSuccess, RegMr(buf, kSize, &mh, &gh));
+
+    Barrier();
+    if(worldRank_ == 0)
+    {
+        void* getReq = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  gin_->iget(ginCtx_, 0, 0, mh, kSize, 0, mh, 1, &getReq));
+        ASSERT_TRUE(PollUntilDone(getReq));
+
+        // iflush is the actual unit under test here: post a flush request
+        // for the remote MR and verify it completes.
+        void* flushReq = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  gin_->iflush(ginCtx_, /*context=*/0,
+                               /*mhandle=*/mh, /*peerRank=*/1, &flushReq));
+        EXPECT_TRUE(PollUntilDone(flushReq));
+
+        EXPECT_TRUE(VerifyBuf(buf, kSize, /*seed=*/0x71));
+    }
+    Barrier();
+}
+
+TEST_P(GinMPITest, MultipleInflightIPuts)
+{
+    if(!SetUpFixture(2, 2))
+    {
+        return;
+    }
+
+    const size_t kBlock   = MessageSize();
+    const size_t kBufSize = kInflightN * kBlock;
+    const int    nCtx     = NumContexts();
+
+    void* sendBuf = AllocBuf(kBufSize);
+    void* recvBuf = AllocBuf(kBufSize);
+    ASSERT_NE(sendBuf, nullptr);
+    ASSERT_NE(recvBuf, nullptr);
+
+    if(worldRank_ == 0)
+    {
+        for(int i = 0; i < kInflightN; ++i)
+        {
+            FillBuf(static_cast<uint8_t*>(sendBuf) + i * kBlock, kBlock, /*seed=*/i);
+        }
+    }
+
+    void *sendMh, *sendGh, *recvMh, *recvGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sendBuf, kBufSize, &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(recvBuf, kBufSize, &recvMh, &recvGh));
+
+    Barrier();
+    if(worldRank_ == 0)
+    {
+        std::vector<void*> reqs(kInflightN, nullptr);
+        for(int i = 0; i < kInflightN; ++i)
+        {
+            const int ctx = i % nCtx;
+            ASSERT_EQ(ncclSuccess,
+                      gin_->iput(ginCtx_, /*context=*/ctx,
+                                 /*srcOff=*/i * kBlock, sendMh, kBlock,
+                                 /*dstOff=*/i * kBlock, recvMh,
+                                 /*peerRank=*/1, &reqs[i]));
+        }
+        for(int i = 0; i < kInflightN; ++i)
+        {
+            EXPECT_TRUE(PollUntilDone(reqs[i]))
+                << "request " << i << " (ctx " << (i % nCtx) << ") did not complete";
+        }
+    }
+    Barrier();
+
+    if(worldRank_ == 1)
+    {
+        for(int i = 0; i < kInflightN; ++i)
+        {
+            EXPECT_TRUE(VerifyBuf(static_cast<uint8_t*>(recvBuf) + i * kBlock,
+                                  kBlock, /*seed=*/i))
+                << "block " << i << " (ctx " << (i % nCtx) << ") mismatched";
+        }
+    }
+}
+
+TEST_P(GinMPITest, MultipleInflightIGets)
+{
+    if(!SetUpFixture(2, 2))
+    {
+        return;
+    }
+
+    const size_t kBlock   = MessageSize();
+    const size_t kBufSize = kInflightN * kBlock;
+    const int    nCtx     = NumContexts();
+
+    void* buf = AllocBuf(kBufSize);
+    ASSERT_NE(buf, nullptr);
+    if(worldRank_ == 1)
+    {
+        for(int i = 0; i < kInflightN; ++i)
+        {
+            FillBuf(static_cast<uint8_t*>(buf) + i * kBlock, kBlock, /*seed=*/i);
+        }
+    }
+
+    void *mh = nullptr, *gh = nullptr;
+    ASSERT_EQ(ncclSuccess, RegMr(buf, kBufSize, &mh, &gh));
+
+    Barrier();
+    if(worldRank_ == 0)
+    {
+        std::vector<void*> reqs(kInflightN, nullptr);
+        for(int i = 0; i < kInflightN; ++i)
+        {
+            const int ctx = i % nCtx;
+            ASSERT_EQ(ncclSuccess,
+                      gin_->iget(ginCtx_, /*context=*/ctx,
+                                 /*remoteOff=*/i * kBlock, mh, kBlock,
+                                 /*localOff=*/ i * kBlock, mh,
+                                 /*peerRank=*/1, &reqs[i]));
+        }
+        for(int i = 0; i < kInflightN; ++i)
+        {
+            EXPECT_TRUE(PollUntilDone(reqs[i]))
+                << "request " << i << " (ctx " << (i % nCtx) << ") did not complete";
+        }
+        for(int i = 0; i < kInflightN; ++i)
+        {
+            EXPECT_TRUE(VerifyBuf(static_cast<uint8_t*>(buf) + i * kBlock,
+                                  kBlock, /*seed=*/i))
+                << "block " << i << " (ctx " << (i % nCtx) << ") mismatched";
+        }
+    }
+    Barrier();
+}
+
+TEST_P(GinMPITest, MixedIPutIGetIPutSignal)
+{
+    if(!SetUpFixture(2, 2))
+    {
+        return;
+    }
+
+    const size_t kSize = MessageSize();
+    const int    nCtx  = NumContexts();
+
+    void* putSendBuf = AllocBuf(kSize);
+    void* putRecvBuf = AllocBuf(kSize);
+    void* getBuf     = AllocBuf(kSize);
+    void* psSendBuf  = AllocBuf(kSize);
+    void* psRecvBuf  = AllocBuf(kSize);
+    void* sigBuf     = AllocBuf(kSignalSize);
+    ASSERT_NE(putSendBuf, nullptr);
+    ASSERT_NE(putRecvBuf, nullptr);
+    ASSERT_NE(getBuf,     nullptr);
+    ASSERT_NE(psSendBuf,  nullptr);
+    ASSERT_NE(psRecvBuf,  nullptr);
+    ASSERT_NE(sigBuf,     nullptr);
+
+    if(worldRank_ == 0)
+    {
+        FillBuf(putSendBuf, kSize, /*seed=*/0x10);
+        FillBuf(psSendBuf,  kSize, /*seed=*/0x30);
+    }
+    if(worldRank_ == 1)
+    {
+        FillBuf(getBuf, kSize, /*seed=*/0x20);
+    }
+
+    void *putSendMh, *putSendGh, *putRecvMh, *putRecvGh;
+    void *getMh, *getGh;
+    void *psSendMh, *psSendGh, *psRecvMh, *psRecvGh;
+    void *sigMh, *sigGh;
+
+    ASSERT_EQ(ncclSuccess, RegMr(putSendBuf, kSize,       &putSendMh, &putSendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(putRecvBuf, kSize,       &putRecvMh, &putRecvGh));
+    ASSERT_EQ(ncclSuccess, RegMr(getBuf,     kSize,       &getMh,     &getGh));
+    ASSERT_EQ(ncclSuccess, RegMr(psSendBuf,  kSize,       &psSendMh,  &psSendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(psRecvBuf,  kSize,       &psRecvMh,  &psRecvGh));
+    ASSERT_EQ(ncclSuccess, RegMr(sigBuf,     kSignalSize, &sigMh,     &sigGh));
+
+    Barrier();
+    if(worldRank_ == 0)
+    {
+        void *putReq = nullptr, *getReq = nullptr, *psReq = nullptr;
+
+        ASSERT_EQ(ncclSuccess,
+                  gin_->iput(ginCtx_, /*context=*/0 % nCtx,
+                             0, putSendMh, kSize, 0, putRecvMh, 1, &putReq));
+        ASSERT_EQ(ncclSuccess,
+                  gin_->iget(ginCtx_, /*context=*/1 % nCtx,
+                             0, getMh, kSize, 0, getMh, 1, &getReq));
+        ASSERT_EQ(ncclSuccess,
+                  gin_->iputSignal(ginCtx_, /*context=*/2 % nCtx,
+                                   0, psSendMh, kSize,
+                                   0, psRecvMh, 1,
+                                   0, sigMh, /*signalValue=*/0,
+                                   NCCL_NET_SIGNAL_OP_INC, &psReq));
+
+        EXPECT_TRUE(PollUntilDone(putReq));
+        EXPECT_TRUE(PollUntilDone(getReq));
+        EXPECT_TRUE(PollUntilDone(psReq));
+
+        // iget result is visible locally on rank 0 once the request completes.
+        EXPECT_TRUE(VerifyBuf(getBuf, kSize, /*seed=*/0x20));
+    }
+    Barrier();
+
+    if(worldRank_ == 1)
+    {
+        EXPECT_TRUE(VerifyBuf(putRecvBuf, kSize, /*seed=*/0x10));
+        EXPECT_TRUE(VerifyBuf(psRecvBuf,  kSize, /*seed=*/0x30));
+        EXPECT_EQ(ReadSignal(sigBuf), 1u);
+    }
+}
+
+TEST_P(GinMPIFixedSizeTest, IPutSignalZeroSize)
+{
+    if(!SetUpFixture(2, 2))
+    {
+        return;
+    }
+
+    constexpr size_t  kPayload  = 4096;
+    constexpr uint8_t kSentinel = 0xCC;
+
+    void* sendBuf = AllocBuf(kPayload);
+    void* recvBuf = AllocBuf(kPayload);
+    void* sigBuf  = AllocBuf(kSignalSize);
+    ASSERT_NE(sendBuf, nullptr);
+    ASSERT_NE(recvBuf, nullptr);
+    ASSERT_NE(sigBuf,  nullptr);
+
+    FillSentinel(recvBuf, kPayload, kSentinel);
+
+    void *sendMh, *sendGh, *recvMh, *recvGh, *sigMh, *sigGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sendBuf, kPayload,    &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(recvBuf, kPayload,    &recvMh, &recvGh));
+    ASSERT_EQ(ncclSuccess, RegMr(sigBuf,  kSignalSize, &sigMh,  &sigGh));
+
+    Barrier();
+    if(worldRank_ == 0)
+    {
+        void* req = nullptr;
+        ASSERT_EQ(ncclSuccess,
+                  gin_->iputSignal(ginCtx_, /*context=*/0,
+                                   0, sendMh, /*size=*/0,
+                                   0, recvMh, /*peerRank=*/1,
+                                   /*signalOff=*/0, sigMh,
+                                   /*signalValue=*/0,
+                                   NCCL_NET_SIGNAL_OP_INC,
+                                   &req));
+        ASSERT_TRUE(PollUntilDone(req));
+    }
+    Barrier();
+
+    if(worldRank_ == 1)
+    {
+        EXPECT_TRUE(AllSentinel(recvBuf, kPayload, kSentinel))
+            << "recvBuf was mutated by zero-size iputSignal";
+        EXPECT_EQ(ReadSignal(sigBuf), 1u);
+    }
+}
+
+TEST_P(GinMPIFixedSizeTest, IPutSignalInvalidSignalOp)
+{
+    if(!SetUpFixture(2, 2))
+    {
+        return;
+    }
+
+    constexpr size_t kPayload = 4096;
+
+    void* sendBuf = AllocBuf(kPayload);
+    void* recvBuf = AllocBuf(kPayload);
+    void* sigBuf  = AllocBuf(kSignalSize);
+    ASSERT_NE(sendBuf, nullptr);
+    ASSERT_NE(recvBuf, nullptr);
+    ASSERT_NE(sigBuf,  nullptr);
+
+    void *sendMh, *sendGh, *recvMh, *recvGh, *sigMh, *sigGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sendBuf, kPayload,    &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(recvBuf, kPayload,    &recvMh, &recvGh));
+    ASSERT_EQ(ncclSuccess, RegMr(sigBuf,  kSignalSize, &sigMh,  &sigGh));
+
+    Barrier();
+    if(worldRank_ == 0)
+    {
+        void*              req      = nullptr;
+        constexpr uint32_t kBogusOp = 0x99;
+        ncclResult_t       r        = gin_->iputSignal(ginCtx_, /*context=*/0,
+                                                       0, sendMh, kPayload,
+                                                       0, recvMh, 1,
+                                                       0, sigMh, /*signalValue=*/1,
+                                                       kBogusOp, &req);
+        EXPECT_EQ(r, ncclInvalidArgument)
+            << "iputSignal accepted invalid signalOp 0x99 (returned " << r << ")";
+    }
+    Barrier();
+}
+
+namespace
+{
+
+// Pretty per-instance suffix: e.g. "Ctx2_64KiB"
+inline std::string CtxSizeName(const ::testing::TestParamInfo<std::tuple<int, size_t>>& info)
+{
+    const int    nCtx = std::get<0>(info.param);
+    const size_t sz   = std::get<1>(info.param);
+    std::string  sizeStr;
+    if(sz % (1024 * 1024) == 0)
+    {
+        sizeStr = std::to_string(sz / (1024 * 1024)) + "MiB";
+    }
+    else if(sz % 1024 == 0)
+    {
+        sizeStr = std::to_string(sz / 1024) + "KiB";
+    }
+    else
+    {
+        sizeStr = std::to_string(sz) + "B";
+    }
+    return "Ctx" + std::to_string(nCtx) + "_" + sizeStr;
+}
+
+inline std::string CtxOnlyName(const ::testing::TestParamInfo<int>& info)
+{
+    return "Ctx" + std::to_string(info.param);
+}
+
+} // namespace
+
+INSTANTIATE_TEST_SUITE_P(
+    CtxAndSize,
+    GinMPITest,
+    ::testing::Combine(
+        ::testing::Values(1, 2),
+        ::testing::Values(static_cast<size_t>(4 * 1024),
+                          static_cast<size_t>(64 * 1024),
+                          static_cast<size_t>(1 * 1024 * 1024))),
+    CtxSizeName);
+
+INSTANTIATE_TEST_SUITE_P(
+    CtxOnly,
+    GinMPIFixedSizeTest,
+    ::testing::Values(1, 2),
+    CtxOnlyName);
+
+} // namespace RCCLGinTests
+
+#else // !RCCL_HAS_GIN_IB_PROXY
+
+#include <gtest/gtest.h>
+
+TEST(GinMPITest, BuildSkipped)
+{
+    GTEST_SKIP() << "IB Proxy GIN backend not built into this binary. Skipping GIN tests...";
+}
+
+#endif // RCCL_HAS_GIN_IB_PROXY
+
+#endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/transport/GinMPI/GinMPITests.cpp
+++ b/projects/rccl/test/transport/GinMPI/GinMPITests.cpp
@@ -606,6 +606,117 @@ TEST_P(GinMPIFixedSizeTest, IPutSignalInvalidSignalOp)
     Barrier();
 }
 
+// ===========================================================================
+// GinMPIStressTest — non-parameterized stress fixture
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// IPutSignalStress10k
+//   10000 iterations of iputSignal(INC), pipelined with a sliding window of
+//   16 inflight requests. The signal counter on the receiver acts as the
+//   correctness oracle: it MUST equal kIterations after all ops drain — if
+//   even one op was lost on the wire, the counter under-counts.
+//
+//   Stresses (vs functional tests):
+//     - Sustained CQ draining concurrent with WR posting
+//     - Request slot recycling (10000 / 16 = 625 reuse cycles)
+//     - GFD ring management under continuous pressure
+//     - Cumulative state correctness (one drop = test failure)
+//
+//   Payload is small (256 B) and constant across iterations to maximize
+//   ops/sec — we are stressing the post/complete machinery, not bandwidth.
+//   Expected runtime: well under 1 s on production hardware.
+// ---------------------------------------------------------------------------
+TEST_F(GinMPIStressTest, IPutSignalStress10k)
+{
+    if(!SetUpFixture(/*minProcs=*/2, /*maxProcs=*/2)) return;
+
+    constexpr int    kIterations = 10000;
+    constexpr int    kInflight   = 16;
+    constexpr size_t kPayload    = 256;
+
+    void* sendBuf = AllocBuf(kPayload);
+    void* recvBuf = AllocBuf(kPayload);
+    void* sigBuf  = AllocBuf(kSignalSize);
+    ASSERT_NE(sendBuf, nullptr);
+    ASSERT_NE(recvBuf, nullptr);
+    ASSERT_NE(sigBuf,  nullptr);
+
+    if(worldRank_ == 0)
+    {
+        // Constant pattern across iterations; we are stressing the post/complete
+        // machinery, not data correctness per-iteration. The signal counter
+        // proves all 10k landed; the final payload check proves the last write
+        // settled correctly.
+        FillBuf(sendBuf, kPayload, /*seed=*/0x33);
+    }
+
+    void *sendMh, *sendGh, *recvMh, *recvGh, *sigMh, *sigGh;
+    ASSERT_EQ(ncclSuccess, RegMr(sendBuf, kPayload,    &sendMh, &sendGh));
+    ASSERT_EQ(ncclSuccess, RegMr(recvBuf, kPayload,    &recvMh, &recvGh));
+    ASSERT_EQ(ncclSuccess, RegMr(sigBuf,  kSignalSize, &sigMh,  &sigGh));
+
+    Barrier();
+
+    if(worldRank_ == 0)
+    {
+        // Sliding window: inflight[next] holds either nullptr (slot free) or
+        // a pending request. Before posting, drain whatever currently sits in
+        // the slot we are about to overwrite.
+        std::vector<void*> inflight(kInflight, nullptr);
+        int                next = 0;
+
+        for(int i = 0; i < kIterations; ++i)
+        {
+            if(inflight[next] != nullptr)
+            {
+                ASSERT_TRUE(PollUntilDone(inflight[next]))
+                    << "iteration " << i << " (slot " << next << ") drain failed";
+                inflight[next] = nullptr;
+            }
+
+            ASSERT_EQ(ncclSuccess,
+                      gin_->iputSignal(ginCtx_, /*context=*/0,
+                                       /*srcOff=*/0, sendMh, kPayload,
+                                       /*dstOff=*/0, recvMh,
+                                       /*peerRank=*/1,
+                                       /*signalOff=*/0, sigMh,
+                                       /*signalValue=*/0,
+                                       NCCL_NET_SIGNAL_OP_INC,
+                                       &inflight[next]))
+                << "iteration " << i << " post failed";
+            next = (next + 1) % kInflight;
+        }
+
+        // Final drain: any slot still holding a request must complete.
+        for(int s = 0; s < kInflight; ++s)
+        {
+            if(inflight[s] != nullptr)
+            {
+                EXPECT_TRUE(PollUntilDone(inflight[s]))
+                    << "final drain of slot " << s << " failed";
+            }
+        }
+    }
+
+    Barrier();
+
+    if(worldRank_ == 1)
+    {
+        // PRIMARY ORACLE: signal counter must equal exactly kIterations.
+        // counter < kIterations => some ops were lost
+        // counter > kIterations => test bug or duplicate delivery (shouldn't happen with reliable IB)
+        EXPECT_EQ(ReadSignal(sigBuf), static_cast<uint64_t>(kIterations))
+            << "Signal counter mismatch — signal != " << kIterations
+            << " means some iputSignal ops did not land on receiver";
+
+        // SECONDARY: final payload bytes match what was sent. Every iteration
+        // wrote the same 256 bytes, so the final state is the seed pattern.
+        EXPECT_TRUE(VerifyBuf(recvBuf, kPayload, /*seed=*/0x33))
+            << "Final payload mismatch — last successful write left wrong contents";
+    }
+}
+
 namespace
 {
 


### PR DESCRIPTION
## Motivation

This PR adds host-only tests for GIN network transport.

Shift-left for validation of https://github.com/ROCm/rocm-systems/pull/5619

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Tests are guarded by RCCL_HAS_GIN_IB_PROXY, can be integrated ahead of implementation.

Test summary (11 tests → 9 × 2 ctx × 3 sizes + 2 × 2 ctx = **58 instances per backend**)

| #  | Test                          | Op(s)                | Primary side effect verified                                       |
| -- | ----------------------------- | -------------------- | ------------------------------------------------------------------ |
| 1  | `IPutBasic`                   | `iput`               | Payload landed on receiver                                         |
| 2  | `IGetBasic`                   | `iget`               | Payload landed on initiator                                        |
| 3  | `IPutSignalInc`               | `iputSignal` (INC)   | Payload + signal += 1                                              |
| 4  | `IPutSignalAdd`               | `iputSignal` (ADD)   | Payload + signal += N                                              |
| 5  | `IPutSignalAtOffset`          | `iputSignal`         | Non-zero `srcOff`/`dstOff`/`signalOff` honored; neighbours intact  |
| 6  | `IFlushAfterIGet`             | `iget` + `iflush`    | Flush request completes                                            |
| 7  | `MultipleInflightIPuts`       | 16 × `iput`          | All 16 blocks landed in correct slots; CQ draining                 |
| 8  | `MultipleInflightIGets`       | 16 × `iget`          | All 16 blocks landed in correct slots; CQ draining                 |
| 9  | `MixedIPutIGetIPutSignal`     | mixed                | Each op type completes with correct side effect                    |
| 10 | `IPutSignalZeroSize`          | `iputSignal` size=0  | Signal increments, payload untouched                               |
| 11 | `IPutSignalInvalidSignalOp`   | `iputSignal`         | Returns `ncclInvalidArgument`                                      |


```
# Build (post-GIN-integration; pre-integration omit RCCL_HAS_GIN_IB_PROXY)
cmake -B build -S . \
      -DBUILD_TESTS=ON \
      -DENABLE_MPI_TESTS=ON \
      -DRCCL_HAS_GIN_IB_PROXY=ON \
      -DMPI_PATH=/opt/ompi
cmake --build build -j$(nproc) --target rccl-UnitTestsMPI

# Run all GIN tests (both fixtures) against the default backend
# (ncclGinIbProxy). 2 ranks, 1 node, GPU + IB required.
mpirun -np 2 --bind-to none \
       ./build/test/rccl-UnitTestsMPI \
       --gtest_filter='*GinMPI*'

# Run against the CAST backend
NCCL_GIN_PLUGIN=CAST_GIN_IB_PROXY \
mpirun -np 2 --bind-to none \
       ./build/test/rccl-UnitTestsMPI \
       --gtest_filter='*GinMPI*'
```

## JIRA ID

AICOMNET-185
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

N/A

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

N/A

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
