### PR TITLE
[rocprofiler-systems] Fix kfd tests

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/test_kfd.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_kfd.py
@@ -84,7 +84,7 @@ class TestKFD(RocprofsysTest):
         self.assert_regex(
             result,
             subtest_name="Unified-memory completion check",
-            pass_regex=[r"\b6 tests completed\b"],
+            pass_regex=[r"6 tests completed"],
         )
 
         self.assert_perfetto(
@@ -146,7 +146,7 @@ class TestKFD(RocprofsysTest):
         self.assert_regex(
             result,
             subtest_name="Unified-memory completion check",
-            pass_regex=[r"\b6 tests completed\b"],
+            pass_regex=[r"6 tests completed"],
         )
 
         self.assert_perfetto(
@@ -202,7 +202,7 @@ class TestKFD(RocprofsysTest):
         self.assert_regex(
             result,
             subtest_name="Unified-memory completion check",
-            pass_regex=[r"\b6 tests completed\b"],
+            pass_regex=[r"6 tests completed"],
         )
 
         self.assert_perfetto(

--- a/projects/rocprofiler-systems/tests/pytest/test_kfd.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_kfd.py
@@ -84,7 +84,7 @@ class TestKFD(RocprofsysTest):
         self.assert_regex(
             result,
             subtest_name="Unified-memory completion check",
-            pass_regex=[r"All 16 tests completed"],
+            pass_regex=[r"\b6 tests completed\b"],
         )
 
         self.assert_perfetto(
@@ -108,7 +108,6 @@ class TestKFD(RocprofsysTest):
             subtest_name="Perfetto KFD queue validation",
             categories=["rocm_kfd_queue"],
             print_output=True,
-            pass_regex=[r"QUEUE_EVICT"],
         )
 
         self.assert_perfetto(
@@ -147,7 +146,7 @@ class TestKFD(RocprofsysTest):
         self.assert_regex(
             result,
             subtest_name="Unified-memory completion check",
-            pass_regex=[r"All 16 tests completed"],
+            pass_regex=[r"\b6 tests completed\b"],
         )
 
         self.assert_perfetto(
@@ -163,7 +162,6 @@ class TestKFD(RocprofsysTest):
             subtest_name="Perfetto KFD queue validation",
             categories=["rocm_kfd_queue"],
             print_output=True,
-            pass_regex=[r"QUEUE_EVICT"],
         )
 
         self.assert_perfetto(
@@ -204,7 +202,7 @@ class TestKFD(RocprofsysTest):
         self.assert_regex(
             result,
             subtest_name="Unified-memory completion check",
-            pass_regex=[r"All 16 tests completed"],
+            pass_regex=[r"\b6 tests completed\b"],
         )
 
         self.assert_perfetto(
@@ -228,7 +226,6 @@ class TestKFD(RocprofsysTest):
             subtest_name="Perfetto KFD queue validation (pressure)",
             categories=["rocm_kfd_queue"],
             print_output=True,
-            pass_regex=[r"QUEUE_EVICT"],
         )
 
         self.assert_perfetto(

--- a/projects/rocprofiler-systems/tests/pytest/test_kfd.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_kfd.py
@@ -195,14 +195,14 @@ class TestKFD(RocprofsysTest):
             mode,
             target="unified-memory",
             env=env,
-            run_args=["-s", "64", "-p", "512", "-i", "4"],
+            run_args=["-a", "-s", "64", "-p", "512", "-i", "4"],
             check_target_arch=True,
         )
 
         self.assert_regex(
             result,
             subtest_name="Unified-memory completion check",
-            pass_regex=[r"6 tests completed"],
+            pass_regex=[r"16 tests completed"],
         )
 
         self.assert_perfetto(


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

https://github.com/ROCm/rocm-systems/pull/4036 had inconsistent pytest code that did not match the CMake code that was added in the same PR. 

The goal here it to make these pytests pass locally on an instinct system.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Fix pass regex. It should not be 16, it should be 6 (old CMake code checked `[0-9]+`, we fix this as 6 as that is how many tests exist) for `kfd-events-sys-run` and `kfd-prefetch-events-sys-run`.
For `kfd-memory-pressure-sys-run`, we add the `-a` flag and force the extra tests (making it 16).

Remove `QUEUE_EVICT` regex check as mandatory. This event may or may not be generated depending on VRAM pressure, driver behavior, and whether an eviction/restore pair is observed.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

Technically part of AIPROFSYST-251

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Tested locally

## Test Result

<!-- Briefly summarize test outcomes. -->

Pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
