### PR TITLE
[hipFile] Python: Release GIL when calling into C library

### DIFF
--- a/projects/hipfile/python/hipfile/_chipfile.pxd
+++ b/projects/hipfile/python/hipfile/_chipfile.pxd
@@ -18,7 +18,7 @@ cdef extern from "hip/hip_runtime_api.h":
     ctypedef enum hipError_t:
         hipSuccess = 0
 
-    hipError_t hipPeekAtLastError()
+    hipError_t hipPeekAtLastError() nogil
 
 
 # ---------------------------------------------------------------------------
@@ -158,33 +158,33 @@ cdef extern from "hipfile.h":
     # -- Function declarations ----------------------------------------------
 
     # Error
-    const char *hipFileGetOpErrorString(hipFileOpError_t status)
+    const char *hipFileGetOpErrorString(hipFileOpError_t status) nogil
 
     # File handles
     hipFileError_t hipFileHandleRegister(hipFileHandle_t *fh,
-                                         hipFileDescr_t *descr)
-    void hipFileHandleDeregister(hipFileHandle_t fh)
+                                         hipFileDescr_t *descr) nogil
+    void hipFileHandleDeregister(hipFileHandle_t fh) nogil
 
     # Buffer registration
     hipFileError_t hipFileBufRegister(const void *buffer_base,
-                                      size_t length, int flags)
-    hipFileError_t hipFileBufDeregister(const void *buffer_base)
+                                      size_t length, int flags) nogil
+    hipFileError_t hipFileBufDeregister(const void *buffer_base) nogil
 
     # Synchronous I/O
     ssize_t hipFileRead(hipFileHandle_t fh, void *buffer_base, size_t size,
-                        hoff_t file_offset, hoff_t buffer_offset)
+                        hoff_t file_offset, hoff_t buffer_offset) nogil
     ssize_t hipFileWrite(hipFileHandle_t fh, const void *buffer_base,
                          size_t size, hoff_t file_offset,
-                         hoff_t buffer_offset)
+                         hoff_t buffer_offset) nogil
 
     # Driver lifecycle
-    hipFileError_t hipFileDriverOpen()
-    hipFileError_t hipFileDriverClose()
-    int64_t hipFileUseCount()
+    hipFileError_t hipFileDriverOpen() nogil
+    hipFileError_t hipFileDriverClose() nogil
+    int64_t hipFileUseCount() nogil
 
     # Driver properties
-    hipFileError_t hipFileDriverGetProperties(hipFileDriverProps_t *props)
+    hipFileError_t hipFileDriverGetProperties(hipFileDriverProps_t *props) nogil
 
     # Version
     hipFileError_t hipFileGetVersion(unsigned *major, unsigned *minor,
-                                      unsigned *patch)
+                                      unsigned *patch) nogil

--- a/projects/hipfile/python/hipfile/_hipfile.pyx
+++ b/projects/hipfile/python/hipfile/_hipfile.pyx
@@ -9,7 +9,7 @@ Functions that return ``hipFileError_t`` in C return a
 
 from libc.errno cimport errno
 from libc.string cimport memset
-from libc.stdint cimport uintptr_t
+from libc.stdint cimport int64_t, uintptr_t
 
 cimport hipfile._chipfile as _c
 
@@ -96,7 +96,9 @@ def is_hipfile_err(int err_code):
 
 def hipfile_errstr(int err_code):
     """Equivalent of the ``HIPFILE_ERRSTR`` C macro."""
-    cdef const char *s = _c.hipFileGetOpErrorString(<_c.hipFileOpError_t>abs(err_code))
+    cdef const char *s
+    with nogil:
+        s = _c.hipFileGetOpErrorString(<_c.hipFileOpError_t>abs(err_code))
     if s == NULL:
         return ""
     return s.decode("utf-8")
@@ -120,7 +122,9 @@ def hip_drv_err(tuple err):
 
 def hipFileGetOpErrorString(int status):
     """Wrapper for ``hipFileGetOpErrorString``."""
-    cdef const char *s = _c.hipFileGetOpErrorString(<_c.hipFileOpError_t>status)
+    cdef const char *s
+    with nogil:
+        s = _c.hipFileGetOpErrorString(<_c.hipFileOpError_t>status)
     if s == NULL:
         return ""
     return s.decode("utf-8")
@@ -132,17 +136,26 @@ def hipFileGetOpErrorString(int status):
 
 def hipFileDriverOpen():
     """Wrapper for ``hipFileDriverOpen``."""
-    return _err(_c.hipFileDriverOpen())
+    cdef _c.hipFileError_t e
+    with nogil:
+        e = _c.hipFileDriverOpen()
+    return _err(e)
 
 
 def hipFileDriverClose():
     """Wrapper for ``hipFileDriverClose``."""
-    return _err(_c.hipFileDriverClose())
+    cdef _c.hipFileError_t e
+    with nogil:
+        e = _c.hipFileDriverClose()
+    return _err(e)
 
 
 def hipFileUseCount():
     """Wrapper for ``hipFileUseCount``."""
-    return <int>_c.hipFileUseCount()
+    cdef int64_t count
+    with nogil:
+        count = _c.hipFileUseCount()
+    return <int>count
 
 
 # ---------------------------------------------------------------------------
@@ -155,7 +168,9 @@ def hipFileGetVersion():
     Returns ``((major, minor, patch), error_tuple)``.
     """
     cdef unsigned major = 0, minor = 0, patch = 0
-    cdef _c.hipFileError_t e = _c.hipFileGetVersion(&major, &minor, &patch)
+    cdef _c.hipFileError_t e
+    with nogil:
+        e = _c.hipFileGetVersion(&major, &minor, &patch)
     return ((major, minor, patch), _err(e))
 
 
@@ -178,19 +193,22 @@ def hipFileHandleRegister(uintptr_t handle_value, int handle_type):
     """
     cdef _c.hipFileHandle_t fh = NULL
     cdef _c.hipFileDescr_t descr
-    memset(&descr, 0, sizeof(descr))
-    descr.type = <_c.hipFileFileHandleType_t>handle_type
-    if handle_type == <int>_c.hipFileHandleTypeOpaqueWin32:
-        descr.hFile = <void *>handle_value
-    else:
-        descr.fd = <int>handle_value
-    cdef _c.hipFileError_t e = _c.hipFileHandleRegister(&fh, &descr)
+    cdef _c.hipFileError_t e
+    with nogil:
+        memset(&descr, 0, sizeof(descr))
+        descr.type = <_c.hipFileFileHandleType_t>handle_type
+        if handle_type == <int>_c.hipFileHandleTypeOpaqueWin32:
+            descr.hFile = <void *>handle_value
+        else:
+            descr.fd = <int>handle_value
+        e = _c.hipFileHandleRegister(&fh, &descr)
     return (<uintptr_t>fh, _err(e))
 
 
 def hipFileHandleDeregister(uintptr_t handle):
     """Wrapper for ``hipFileHandleDeregister``."""
-    _c.hipFileHandleDeregister(<_c.hipFileHandle_t>handle)
+    with nogil:
+        _c.hipFileHandleDeregister(<_c.hipFileHandle_t>handle)
 
 
 # ---------------------------------------------------------------------------
@@ -199,12 +217,18 @@ def hipFileHandleDeregister(uintptr_t handle):
 
 def hipFileBufRegister(uintptr_t buffer_base, size_t length, int flags=0):
     """Wrapper for ``hipFileBufRegister``."""
-    return _err(_c.hipFileBufRegister(<const void *>buffer_base, length, flags))
+    cdef _c.hipFileError_t e
+    with nogil:
+        e = _c.hipFileBufRegister(<const void *>buffer_base, length, flags)
+    return _err(e)
 
 
 def hipFileBufDeregister(uintptr_t buffer_base):
     """Wrapper for ``hipFileBufDeregister``."""
-    return _err(_c.hipFileBufDeregister(<const void *>buffer_base))
+    cdef _c.hipFileError_t e
+    with nogil:
+        e = _c.hipFileBufDeregister(<const void *>buffer_base)
+    return _err(e)
 
 
 # ---------------------------------------------------------------------------
@@ -222,14 +246,16 @@ def hipFileRead(uintptr_t handle, uintptr_t buffer_base, size_t size,
         ``-hipFileHipDriverError``, ``extra = hipError_t`` from
         ``hipPeekAtLastError()``, otherwise ``extra = 0``
     """
-    cdef ssize_t ret = _c.hipFileRead(<_c.hipFileHandle_t>handle,
-                                      <void *>buffer_base, size,
-                                      file_offset, buffer_offset)
+    cdef ssize_t ret
     cdef int extra = 0
-    if ret == -1:
-        extra = errno
-    elif ret == -<int>_c.hipFileHipDriverError:
-        extra = <int>_c.hipPeekAtLastError()
+    with nogil:
+        ret = _c.hipFileRead(<_c.hipFileHandle_t>handle,
+                             <void *>buffer_base, size,
+                             file_offset, buffer_offset)
+        if ret == -1:
+            extra = errno
+        elif ret == -<int>_c.hipFileHipDriverError:
+            extra = <int>_c.hipPeekAtLastError()
     return (ret, extra)
 
 
@@ -244,14 +270,16 @@ def hipFileWrite(uintptr_t handle, uintptr_t buffer_base, size_t size,
         ``-hipFileHipDriverError``, ``extra = hipError_t`` from
         ``hipPeekAtLastError()``, otherwise ``extra = 0``
     """
-    cdef ssize_t ret = _c.hipFileWrite(<_c.hipFileHandle_t>handle,
-                                       <const void *>buffer_base, size,
-                                       file_offset, buffer_offset)
+    cdef ssize_t ret
     cdef int extra = 0
-    if ret == -1:
-        extra = errno
-    elif ret == -<int>_c.hipFileHipDriverError:
-        extra = <int>_c.hipPeekAtLastError()
+    with nogil:
+        ret = _c.hipFileWrite(<_c.hipFileHandle_t>handle,
+                              <const void *>buffer_base, size,
+                              file_offset, buffer_offset)
+        if ret == -1:
+            extra = errno
+        elif ret == -<int>_c.hipFileHipDriverError:
+            extra = <int>_c.hipPeekAtLastError()
     return (ret, extra)
 
 
@@ -265,8 +293,10 @@ def hipFileDriverGetProperties():
     Returns ``(props_dict, error_tuple)``.
     """
     cdef _c.hipFileDriverProps_t props
-    memset(&props, 0, sizeof(props))
-    cdef _c.hipFileError_t e = _c.hipFileDriverGetProperties(&props)
+    cdef _c.hipFileError_t e
+    with nogil:
+        memset(&props, 0, sizeof(props))
+        e = _c.hipFileDriverGetProperties(&props)
     d = {
         "nvfs_major_version":        props.nvfs_major_version,
         "nvfs_minor_version":        props.nvfs_minor_version,


### PR DESCRIPTION
This improves the performance of multi-threaded benchmarks while the C hipFile library has control of a given thread.

## Motivation

The Cython hipFile bindings were holding the Python GIL (Global Interpreter Lock) for the entire duration of every C function call, including blocking IO operations like `hipFileRead` and `hipFileWrite`. In multi-threaded applications such as LMCache/vLLM, this effectively serialized the entire Python process during GPU IO — all other Python threads were blocked until each C call returned.

The previous ctypes-based hipFile bindings did not exhibit this behavior because ctypes automatically releases the GIL when calling foreign functions. Switching from ctypes to the Cython bindings introduced a 10-20% regression in Time To First Token (TTFT) due to this GIL contention.

## Technical Details

- Added `nogil` to all C function declarations in `_chipfile.pxd` so they can be called without holding the GIL
- Wrapped all C function calls in `_hipfile.pyx` with `with nogil:` blocks to release the GIL during C execution
- Moved pure C operations (`memset`, struct field assignments) inside `nogil` blocks where applicable (`hipFileHandleRegister`, `hipFileDriverGetProperties`)
- Added `int64_t` cimport to support the `hipFileUseCount` nogil wrapper

Affected functions: `hipFileDriverOpen`, `hipFileDriverClose`, `hipFileUseCount`, `hipFileGetVersion`, `hipFileHandleRegister`, `hipFileHandleDeregister`, `hipFileBufRegister`, `hipFileBufDeregister`, `hipFileRead`, `hipFileWrite`, `hipFileDriverGetProperties`, `hipFileGetOpErrorString`, `hipfile_errstr`

## Test Plan

- Built and ran a Cython vs ctypes microbenchmark comparing per-step timings for a full read/write workflow (7 GiB file, 16 MiB chunks, 100 iterations). Confirmed IO bandwidth and call overhead are consistent between the two binding approaches.
- Verified TTFT results on LMCache benchmark are in line with the previous ctypes-based hipFile module, confirming the GIL regression is resolved.

## Test Result

Microbenchmark confirmed identical IO throughput (~6.07 GiB/s read, ~5.56 GiB/s write) between Cython and ctypes. LMCache TTFT results returned to baseline levels previously observed with the ctypes-based module.

AIHIPFILE-167
