### PR TITLE
Validating Grid Max check at Launch Params. (#709)

### DIFF
--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -501,8 +501,7 @@ hipError_t ihipGetDeviceProperties(hipDeviceProp_tR0600* props, int device) {
 
   constexpr auto kPixelSizeMax = 16;
   constexpr auto kInt32Max = static_cast<uint64_t>(std::numeric_limits<int32_t>::max());
-  constexpr auto kUint16Max = static_cast<uint64_t>(std::numeric_limits<uint16_t>::max()) + 1;
-  hipDeviceProp_tR0600 deviceProps = {};
+  hipDeviceProp_tR0600 deviceProps = {0};
 
   const auto& info = deviceHandle->info();
   const auto& isa = deviceHandle->isa();
@@ -517,9 +516,9 @@ hipError_t ihipGetDeviceProperties(hipDeviceProp_tR0600* props, int device) {
   deviceProps.maxThreadsDim[0] = info.maxWorkItemSizes_[0];
   deviceProps.maxThreadsDim[1] = info.maxWorkItemSizes_[1];
   deviceProps.maxThreadsDim[2] = info.maxWorkItemSizes_[2];
-  deviceProps.maxGridSize[0] = kInt32Max;
-  deviceProps.maxGridSize[1] = kUint16Max;
-  deviceProps.maxGridSize[2] = kUint16Max;
+  deviceProps.maxGridSize[0] = std::min(static_cast<uint64_t>(info.maxGridDim_[0]), kInt32Max);
+  deviceProps.maxGridSize[1] = std::min(static_cast<uint64_t>(info.maxGridDim_[1]), kInt32Max);
+  deviceProps.maxGridSize[2] = std::min(static_cast<uint64_t>(info.maxGridDim_[2]), kInt32Max);
   deviceProps.clockRate = info.maxEngineClockFrequency_ * 1000;
   deviceProps.memoryClockRate = info.maxMemoryClockFrequency_ * 1000;
   deviceProps.memoryBusWidth = info.vramBusBitWidth_;
@@ -706,8 +705,7 @@ hipError_t hipGetDevicePropertiesR0000(hipDeviceProp_tR0000* prop, int device) {
 
   constexpr auto kPixelSizeMax = 16;
   constexpr auto kInt32Max = static_cast<uint64_t>(std::numeric_limits<int32_t>::max());
-  constexpr auto kUint16Max = static_cast<uint64_t>(std::numeric_limits<uint16_t>::max()) + 1;
-  hipDeviceProp_tR0000 deviceProps = {};
+  hipDeviceProp_tR0000 deviceProps = {0};
 
   const auto& info = deviceHandle->info();
   const auto& isa = deviceHandle->isa();
@@ -720,9 +718,9 @@ hipError_t hipGetDevicePropertiesR0000(hipDeviceProp_tR0000* prop, int device) {
   deviceProps.maxThreadsDim[0] = info.maxWorkItemSizes_[0];
   deviceProps.maxThreadsDim[1] = info.maxWorkItemSizes_[1];
   deviceProps.maxThreadsDim[2] = info.maxWorkItemSizes_[2];
-  deviceProps.maxGridSize[0] = kInt32Max;
-  deviceProps.maxGridSize[1] = kUint16Max;
-  deviceProps.maxGridSize[2] = kUint16Max;
+  deviceProps.maxGridSize[0] = std::min(static_cast<uint64_t>(info.maxGridDim_[0]), kInt32Max);
+  deviceProps.maxGridSize[1] = std::min(static_cast<uint64_t>(info.maxGridDim_[1]), kInt32Max);
+  deviceProps.maxGridSize[2] = std::min(static_cast<uint64_t>(info.maxGridDim_[2]), kInt32Max);
   deviceProps.clockRate = info.maxEngineClockFrequency_ * 1000;
   deviceProps.memoryClockRate = info.maxMemoryClockFrequency_ * 1000;
   deviceProps.memoryBusWidth = info.vramBusBitWidth_;

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -85,11 +85,12 @@ hipError_t ihipGraphAddKernelNode(hip::GraphNode** pGraphNode, hip::Graph* graph
     return hipErrorInvalidDeviceFunction;
   }
 
+  const amd::Device* device = g_devices[ihipGetDevice()]->devices()[0];
   amd::HIPLaunchParams launch_params(pNodeParams->gridDim.x, pNodeParams->gridDim.y,
                                      pNodeParams->gridDim.z, pNodeParams->blockDim.x,
                                      pNodeParams->blockDim.y, pNodeParams->blockDim.z,
-                                     pNodeParams->sharedMemBytes, globalWorkSizeX_remainder,
-                                     globalWorkSizeY_remainder, globalWorkSizeZ_remainder);
+                                     pNodeParams->sharedMemBytes, *device, globalWorkSizeX_remainder,
+                                     globalWorkSizeY_remainder, globalWorkSizeZ_remainder, 1, 1, 1);
   if (!launch_params.IsValidConfig()) {
     return hipErrorInvalidConfiguration;
   }

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1545,11 +1545,12 @@ class GraphKernelNode : public GraphNode {
       }
     }
 
+    const amd::Device* device = g_devices[dev_id_]->devices()[0];
     amd::HIPLaunchParams launch_params(kernelParams_.gridDim.x, kernelParams_.gridDim.y,
                                        kernelParams_.gridDim.z, kernelParams_.blockDim.x,
                                        kernelParams_.blockDim.y, kernelParams_.blockDim.z,
-                                       kernelParams_.sharedMemBytes, globalWorkSizeX_remainder_,
-                                       globalWorkSizeY_remainder_, globalWorkSizeZ_remainder_);
+                                       kernelParams_.sharedMemBytes, *device, globalWorkSizeX_remainder_,
+                                       globalWorkSizeY_remainder_, globalWorkSizeZ_remainder_, 1, 1, 1);
 
     if (!launch_params.IsValidConfig()) {
       return hipErrorInvalidConfiguration;
@@ -1695,11 +1696,12 @@ class GraphKernelNode : public GraphNode {
   hipError_t validateKernelParams(const hipKernelNodeParams* pNodeParams,
                                   hipFunction_t func, int devId) {
 
+    const amd::Device* device = g_devices[devId]->devices()[0];
     amd::HIPLaunchParams launch_params(pNodeParams->gridDim.x, pNodeParams->gridDim.y,
                                        pNodeParams->gridDim.z, pNodeParams->blockDim.x,
                                        pNodeParams->blockDim.y, pNodeParams->blockDim.z,
-                                       pNodeParams->sharedMemBytes, globalWorkSizeX_remainder_,
-                                       globalWorkSizeY_remainder_, globalWorkSizeZ_remainder_);
+                                       pNodeParams->sharedMemBytes, *device, globalWorkSizeX_remainder_,
+                                       globalWorkSizeY_remainder_, globalWorkSizeZ_remainder_, 1, 1, 1);
 
     if (!launch_params.IsValidConfig()) {
       HIP_RETURN(hipErrorInvalidConfiguration);

--- a/projects/clr/hipamd/src/hip_module.cpp
+++ b/projects/clr/hipamd/src/hip_module.cpp
@@ -558,14 +558,8 @@ hipError_t hipModuleLaunchKernel(hipFunction_t f, uint32_t gridDimX, uint32_t gr
   STREAM_CAPTURE(hipModuleLaunchKernel, hStream, f, gridDimX, gridDimY, gridDimZ, blockDimX,
                  blockDimY, blockDimZ, sharedMemBytes, kernelParams, extra);
 
-  constexpr auto int32_max = static_cast<uint64_t>(std::numeric_limits<int32_t>::max());
-  constexpr auto uint16_max = static_cast<uint64_t>(std::numeric_limits<uint16_t>::max()) + 1;
-  if (gridDimX > int32_max || gridDimY > uint16_max || gridDimZ > uint16_max) {
-    HIP_RETURN(hipErrorInvalidValue);
-  }
-
   amd::HIPLaunchParams launch_params(gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ,
-                                     sharedMemBytes);
+                                     sharedMemBytes, *device, 0, 0, 0, 1, 1, 1);
   if (!launch_params.IsValidConfig() ||
        launch_params.local_.product() > device->info().maxWorkGroupSize_) {
     HIP_RETURN(hipErrorInvalidValue);
@@ -611,7 +605,8 @@ hipError_t hipExtModuleLaunchKernel(hipFunction_t f, uint32_t globalWorkSizeX,
                  kernelParams, extra, startEvent, stopEvent, flags);
 
   amd::LaunchParams launch_params(globalWorkSizeX, globalWorkSizeY, globalWorkSizeZ, localWorkSizeX,
-                                  localWorkSizeY, localWorkSizeZ, sharedMemBytes);
+                                  localWorkSizeY, localWorkSizeZ, sharedMemBytes, *device, 1, 1, 1, 1,
+                                  1, 1, false);
 
   if (!launch_params.IsValidConfig() ||
        launch_params.local_.product() > device->info().maxWorkGroupSize_) {
@@ -646,8 +641,11 @@ hipError_t hipHccModuleLaunchKernel(hipFunction_t f, uint32_t globalWorkSizeX,
                blockDimX, blockDimY, blockDimZ, sharedMemBytes, hStream, kernelParams, extra,
                startEvent, stopEvent);
 
+  int deviceId = hip::Stream::DeviceId(hStream);
+  const amd::Device* device = g_devices[deviceId]->devices()[0];
   amd::LaunchParams launch_params(globalWorkSizeX, globalWorkSizeY, globalWorkSizeZ, blockDimX,
-                                  blockDimY, blockDimZ, sharedMemBytes);
+                                  blockDimY, blockDimZ, sharedMemBytes, *device, 1, 1, 1, 1, 1, 1,
+                                  false);
 
   HIP_RETURN(ihipModuleLaunchKernel(f, launch_params, hStream, kernelParams, extra, startEvent,
                                     stopEvent));
@@ -672,7 +670,7 @@ hipError_t hipModuleLaunchCooperativeKernel(hipFunction_t f, unsigned int gridDi
                  blockDimX, blockDimY, blockDimZ, sharedMemBytes, kernelParams);
 
   amd::HIPLaunchParams launch_params(gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ,
-                                     sharedMemBytes);
+                                     sharedMemBytes, *device, 0, 0, 0, 1, 1, 1);
 
   if (!launch_params.IsValidConfig() ||
       launch_params.local_.product() > device->info().maxWorkGroupSize_) {
@@ -783,9 +781,10 @@ hipError_t ihipModuleLaunchCooperativeKernelMultiDevice(hipFunctionLaunchParams*
       }
     }
 
+    const amd::Device& device = hip_stream->vdev()->device();
     amd::HIPLaunchParams launch_params(launch.gridDimX, launch.gridDimY, launch.gridDimZ,
                                        launch.blockDimX, launch.blockDimY, launch.blockDimZ,
-                                       launch.sharedMemBytes);
+                                       launch.sharedMemBytes, device, 0, 0, 0, 1, 1, 1);
 
     if (!launch_params.IsValidConfig()) {
       return hipErrorInvalidConfiguration;
@@ -914,7 +913,7 @@ hipError_t hipLaunchCooperativeKernel_common(const void* f, dim3 gridDim, dim3 b
   const amd::Device* device = g_devices[deviceId]->devices()[0];
 
   amd::HIPLaunchParams launch_params(gridDim.x, gridDim.y, gridDim.z, blockDim.x, blockDim.y,
-                                     blockDim.z, sharedMemBytes);
+                                     blockDim.z, sharedMemBytes, *device, 0, 0, 0, 1, 1, 1);
 
   if (!launch_params.IsValidConfig() ||
       launch_params.local_.product() > device->info().maxWorkGroupSize_) {
@@ -1290,28 +1289,41 @@ hipError_t hipDrvLaunchKernelEx(const HIP_LAUNCH_CONFIG* config, hipFunction_t f
     HIP_RETURN(hipErrorInvalidValue);
   }
 
+  hipStream_t hStream = config->hStream;
+  if (!hip::isValid(hStream)) {
+    HIP_RETURN(hipErrorContextIsDestroyed);
+  }
+  int drvDeviceId = hip::Stream::DeviceId(hStream);
+  const amd::Device* drvDevice = g_devices[drvDeviceId]->devices()[0];
   amd::HIPLaunchParams launch_params(config->gridDimX, config->gridDimY, config->gridDimZ,
                                      config->blockDimX, config->blockDimY, config->blockDimZ,
-                                     config->sharedMemBytes);
+                                     config->sharedMemBytes, *drvDevice, 0, 0, 0, 1, 1, 1);
 
   if (!launch_params.IsValidConfig()) {
     HIP_RETURN(hipErrorInvalidConfiguration);
   }
 
   if (config->numAttrs == 0) {
-    HIP_RETURN(ihipModuleLaunchKernel(f, launch_params, config->hStream, kernelParams, nullptr,
+    HIP_RETURN(ihipModuleLaunchKernel(f, launch_params, hStream, kernelParams, nullptr,
                                       nullptr, nullptr, 0));
   }
 
+  dim3 clusterDim = {1, 1, 1};
   for (size_t attr_idx = 0; attr_idx < config->numAttrs; ++attr_idx) {
     hipLaunchAttribute& attr = config->attrs[attr_idx];
     switch (attr.id) {
       case hipLaunchAttributeCooperative: {
         if (attr.value.cooperative != 0) {
-          HIP_RETURN(ihipModuleLaunchKernel(f, launch_params, config->hStream, kernelParams,
+          HIP_RETURN(ihipModuleLaunchKernel(f, launch_params, hStream, kernelParams,
                                             nullptr, nullptr, nullptr, 0,
                                             amd::NDRangeKernelCommand::CooperativeGroups));
         }
+        break;
+      }
+      case hipLaunchAttributeClusterDimension: {
+        clusterDim.x = attr.value.clusterDim.x;
+        clusterDim.y = attr.value.clusterDim.y;
+        clusterDim.z = attr.value.clusterDim.z;
         break;
       }
       default:
@@ -1319,6 +1331,18 @@ hipError_t hipDrvLaunchKernelEx(const HIP_LAUNCH_CONFIG* config, hipFunction_t f
         break;
     }
   }
-  HIP_RETURN(hipErrorInvalidConfiguration)
+
+   // All dimensions have to be atleast 1.
+  if (clusterDim.x == 0 || clusterDim.y == 0 || clusterDim.z == 0) {
+    HIP_RETURN(hipErrorInvalidConfiguration);
+  }
+
+  amd::HIPLaunchParams launch_params_cluster(config->gridDimX, config->gridDimY, config->gridDimZ,
+                                          config->blockDimX, config->blockDimY, config->blockDimZ,
+                                          config->sharedMemBytes, *drvDevice, 0, 0, 0, clusterDim.x,
+                                          clusterDim.y, clusterDim.z);
+
+  HIP_RETURN(ihipModuleLaunchKernel(f, launch_params_cluster, hStream, kernelParams, extra, nullptr,
+                                    nullptr));
 }
 }  // namespace hip

--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -386,7 +386,7 @@ hipError_t hipLaunchByPtr(const void* hostFunction) {
   const amd::Device* device = g_devices[deviceId]->devices()[0];
   amd::HIPLaunchParams launch_params(exec.gridDim_.x, exec.gridDim_.y, exec.gridDim_.z,
                                            exec.blockDim_.x, exec.blockDim_.y, exec.blockDim_.z,
-                                           exec.sharedMem_);
+                                           exec.sharedMem_, *device, 0, 0, 0, 1, 1, 1);
   if (!launch_params.IsValidConfig() ||
       launch_params.local_.product() > device->info().maxWorkGroupSize_) {
     HIP_RETURN(hipErrorInvalidValue);
@@ -722,14 +722,14 @@ hipError_t ihipLaunchKernel(const void* hostFunction, dim3 gridDim, dim3 blockDi
   }
 
   constexpr auto gridDimYZmax = static_cast<uint64_t>(std::numeric_limits<uint16_t>::max()) + 1;
-  const auto* device = g_devices[deviceId]->devices()[0];
+  const amd::Device* device = g_devices[deviceId]->devices()[0];
   if (device->isa().versionMajor() >= 12 &&
       (gridDim.y > gridDimYZmax || gridDim.z > gridDimYZmax)) {
     return hipErrorInvalidConfiguration;
   }
 
   amd::HIPLaunchParams launch_params(gridDim.x, gridDim.y, gridDim.z, blockDim.x, blockDim.y,
-                                     blockDim.z, sharedMemBytes, 0, 0, 0,
+                                     blockDim.z, sharedMemBytes, *device, 0, 0, 0,
                                      clusterDim.x, clusterDim.y, clusterDim.z);
   if (!launch_params.IsValidConfig()) {
     return hipErrorInvalidConfiguration;

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -284,6 +284,9 @@ struct Info : public amd::EmbeddedObject {
   //  using the data-parallel execution model.
   size_t maxWorkGroupSize_;
 
+  //! Maximum grid dimensions (from HSA_AGENT_INFO_GRID_MAX_DIM). Work-items per dimension.
+  uint32_t maxGridDim_[3];
+
   //! Preferred number of work-items in a work-group executing a kernel
   //  using the data-parallel execution model.
   size_t preferredWorkGroupSize_;

--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -37,6 +37,7 @@
 #include <algorithm>
 #include <array>
 #include <cstring>
+#include <limits>
 #include <ctype.h>
 #include <fstream>
 #include <iostream>
@@ -489,6 +490,10 @@ void NullDevice::fillDeviceInfo(const Pal::DeviceProperties& palProp,
   info_.maxWorkItemSizes_[1] = info_.maxWorkGroupSize_;
   info_.maxWorkItemSizes_[2] = info_.maxWorkGroupSize_;
   info_.preferredWorkGroupSize_ = settings().preferredWorkGroupSize_;
+
+  info_.maxGridDim_[0] = std::numeric_limits<uint32_t>::max();
+  info_.maxGridDim_[1] = std::numeric_limits<uint32_t>::max();
+  info_.maxGridDim_[2] = std::numeric_limits<uint32_t>::max();
 
   info_.localMemType_ = CL_LOCAL;
   info_.localMemSize_ = settings().hwLDSSize_;

--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -491,9 +491,9 @@ void NullDevice::fillDeviceInfo(const Pal::DeviceProperties& palProp,
   info_.maxWorkItemSizes_[2] = info_.maxWorkGroupSize_;
   info_.preferredWorkGroupSize_ = settings().preferredWorkGroupSize_;
 
-  info_.maxGridDim_[0] = std::numeric_limits<uint32_t>::max();
-  info_.maxGridDim_[1] = std::numeric_limits<uint32_t>::max();
-  info_.maxGridDim_[2] = std::numeric_limits<uint32_t>::max();
+  info_.maxGridDim_[0] = std::numeric_limits<int32_t>::max();
+  info_.maxGridDim_[1] = std::numeric_limits<uint16_t>::max();
+  info_.maxGridDim_[2] = std::numeric_limits<uint16_t>::max();
 
   info_.localMemType_ = CL_LOCAL;
   info_.localMemSize_ = settings().hwLDSSize_;

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -1305,9 +1305,9 @@ bool Device::populateOCLDeviceConstants() {
     return false;
   }
   assert(grid_max_dim.x != 0 && grid_max_dim.y != 0 && grid_max_dim.z != 0);
-  info_.maxGridDim_[0] = grid_max_dim.x;
-  info_.maxGridDim_[1] = grid_max_dim.y;
-  info_.maxGridDim_[2] = grid_max_dim.z;
+  info_.maxGridDim_[0] = std::min(grid_max_dim.x, static_cast<uint32_t>(std::numeric_limits<int32_t>::max()));
+  info_.maxGridDim_[1] = std::min(grid_max_dim.y, static_cast<uint32_t>(std::numeric_limits<int32_t>::max()));
+  info_.maxGridDim_[2] = std::min(grid_max_dim.z, static_cast<uint32_t>(std::numeric_limits<int32_t>::max()));
 
   info_.nativeVectorWidthChar_ = info_.preferredVectorWidthChar_ = 4;
   info_.nativeVectorWidthShort_ = info_.preferredVectorWidthShort_ = 2;

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -1299,6 +1299,16 @@ bool Device::populateOCLDeviceConstants() {
   info_.maxWorkItemSizes_[2] = std::min(max_workgroup_size[2], max_work_item_size);
   info_.preferredWorkGroupSize_ = settings().preferredWorkGroupSize_;
 
+  hsa_dim3_t grid_max_dim = {0, 0, 0};
+  if (HSA_STATUS_SUCCESS !=
+      Hsa::agent_get_info(bkendDevice_, HSA_AGENT_INFO_GRID_MAX_DIM, &grid_max_dim)) {
+    return false;
+  }
+  assert(grid_max_dim.x != 0 && grid_max_dim.y != 0 && grid_max_dim.z != 0);
+  info_.maxGridDim_[0] = grid_max_dim.x;
+  info_.maxGridDim_[1] = grid_max_dim.y;
+  info_.maxGridDim_[2] = grid_max_dim.z;
+
   info_.nativeVectorWidthChar_ = info_.preferredVectorWidthChar_ = 4;
   info_.nativeVectorWidthShort_ = info_.preferredVectorWidthShort_ = 2;
   info_.nativeVectorWidthInt_ = info_.preferredVectorWidthInt_ = 1;

--- a/projects/clr/rocclr/platform/ndrange.hpp
+++ b/projects/clr/rocclr/platform/ndrange.hpp
@@ -8,6 +8,7 @@
 #define NDRANGE_HPP_
 
 #include "top.hpp"
+#include "device/device.hpp"
 
 #include <valarray>
 
@@ -119,9 +120,10 @@ struct LaunchParams {
   bool validConfig_;         //!< Flag will be set to false when config is not correct.
 
   LaunchParams(size_t globalX, size_t globalY, size_t globalZ, uint32_t localX,
-               uint32_t localY, uint32_t localZ, uint32_t sharedMemBytes, uint32_t clusterX = 1,
-               uint32_t clusterY = 1, uint32_t clusterZ = 1, uint32_t gridX = 1, uint32_t gridY = 1,
-               uint32_t gridZ = 1, bool hipParams = false) : global_(globalX, globalY, globalZ),
+               uint32_t localY, uint32_t localZ, uint32_t sharedMemBytes, const Device& device,
+               uint32_t clusterX = 1, uint32_t clusterY = 1, uint32_t clusterZ = 1,
+               uint32_t gridX = 1, uint32_t gridY = 1, uint32_t gridZ = 1,
+               bool hipParams = false) : global_(globalX, globalY, globalZ),
                local_(localX, localY, localZ), sharedMemBytes_ (sharedMemBytes),
                cluster_(clusterX, clusterY, clusterZ), grid_(gridX, gridY, gridZ),
                hipParams_(hipParams), validConfig_(true) {
@@ -144,6 +146,14 @@ struct LaunchParams {
       grid_[0] = global_[0] / local_[0];
       grid_[1] = global_[1] / local_[1];
       grid_[2] = global_[2] / local_[2];
+    }
+
+    // Grid Validation.
+    const auto& info = device.info();
+    if (grid_[0] > static_cast<size_t>(info.maxGridDim_[0]) ||
+        grid_[1] > static_cast<size_t>(info.maxGridDim_[1]) ||
+        grid_[2] > static_cast<size_t>(info.maxGridDim_[2])) {
+      validConfig_ = false;
     }
 
     // If cluster parameters is set, then check if it is divisble by grid (total blocks).
@@ -184,14 +194,14 @@ struct LaunchParams {
 struct HIPLaunchParams : public LaunchParams {
 
   HIPLaunchParams(uint32_t gridX, uint32_t gridY, uint32_t gridZ, uint32_t blockX,
-                  uint32_t blockY, uint32_t blockZ, uint32_t sharedMemBytes,
+                  uint32_t blockY, uint32_t blockZ, uint32_t sharedMemBytes, const Device& device,
                   uint32_t globalX_remainder = 0, uint32_t globalY_remainder = 0,
                   uint32_t globalZ_remainder = 0, uint32_t clusterX = 1,
                   uint32_t clusterY = 1, uint32_t clusterZ = 1)
-                  : LaunchParams(static_cast<uint32_t>(gridX) * blockX + globalX_remainder,
-                                 static_cast<uint32_t>(gridY) * blockY + globalY_remainder,
-                                 static_cast<uint32_t>(gridZ) * blockZ + globalZ_remainder,
-                                 blockX, blockY, blockZ, sharedMemBytes, clusterX, clusterY,
+                  : LaunchParams(static_cast<size_t>(gridX) * blockX + globalX_remainder,
+                                 static_cast<size_t>(gridY) * blockY + globalY_remainder,
+                                 static_cast<size_t>(gridZ) * blockZ + globalZ_remainder,
+                                 blockX, blockY, blockZ, sharedMemBytes, device, clusterX, clusterY,
                                  clusterZ, gridX, gridY, gridZ, true /*hipParams*/) {}
 };
 

--- a/projects/hip-tests/catch/unit/kernel/hipGridLaunch.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipGridLaunch.cc
@@ -9,6 +9,7 @@
 #include <hip_test_kernels.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
+#include <utils.hh>
 
 
 static unsigned threadsPerBlock = 256;
@@ -98,6 +99,120 @@ HIP_TEST_CASE(Unit_hipGridLaunch) {
 #if __HIP__
   SECTION("Test triple_chevron") { test_triple_chevron(N); }
 #endif
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *    - Test case to verify maxGrid limits from device properties.
+ *    - Fetches maxGridSize from hipDeviceProp_t and verifies kernel launch
+ *    - at maximum grid dimensions succeeds.
+ *    - Also verifies that exceeding maxGridSize returns appropriate error codes.
+
+ * Test source
+ * ------------------------
+ *    - catch/unit/kernel/hipGridLaunch.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 5.5
+ */
+
+__global__ void emptyKernel() {}
+
+TEST_CASE("Unit_hipGridLaunch_MaxGridDim_DeviceProperties") {
+  hipDeviceProp_t deviceProp;
+  int device;
+  HIP_CHECK(hipGetDevice(&device));
+  HIP_CHECK(hipGetDeviceProperties(&deviceProp, device));
+
+  unsigned int maxGridX = deviceProp.maxGridSize[0];
+  unsigned int maxGridY = deviceProp.maxGridSize[1];
+  unsigned int maxGridZ = deviceProp.maxGridSize[2];
+
+  INFO("Device: " << deviceProp.name);
+  INFO("maxGridSize[0]: " << maxGridX);
+  INFO("maxGridSize[1]: " << maxGridY);
+  INFO("maxGridSize[2]: " << maxGridZ);
+
+  SECTION("Launch kernel with gridDim.x == maxGridDimX") {
+    hipLaunchKernelGGL(emptyKernel, dim3(maxGridX, 1, 1), dim3(1, 1, 1), 0, 0);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+  }
+
+  SECTION("Launch kernel with gridDim.y == maxGridDimY") {
+    hipLaunchKernelGGL(emptyKernel, dim3(1, maxGridY, 1), dim3(1, 1, 1), 0, 0);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+  }
+
+  SECTION("Launch kernel with gridDim.z == maxGridDimZ") {
+    hipLaunchKernelGGL(emptyKernel, dim3(1, 1, maxGridZ), dim3(1, 1, 1), 0, 0);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+  }
+}
+
+TEST_CASE("Unit_hipGridLaunch_MaxGridDim_GetDeviceAttribute") {
+  const unsigned int maxGridX = GetDeviceAttribute(hipDeviceAttributeMaxGridDimX, 0);
+  const unsigned int maxGridY = GetDeviceAttribute(hipDeviceAttributeMaxGridDimY, 0);
+  const unsigned int maxGridZ = GetDeviceAttribute(hipDeviceAttributeMaxGridDimZ, 0);
+
+  INFO("maxGridDimX: " << maxGridX);
+  INFO("maxGridDimY: " << maxGridY);
+  INFO("maxGridDimZ: " << maxGridZ);
+
+  SECTION("Launch kernel with gridDim.x == maxGridDimX using attribute") {
+    hipLaunchKernelGGL(emptyKernel, dim3(maxGridX, 1, 1), dim3(1, 1, 1), 0, 0);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+  }
+
+  SECTION("Launch kernel with gridDim.y == maxGridDimY using attribute") {
+    hipLaunchKernelGGL(emptyKernel, dim3(1, maxGridY, 1), dim3(1, 1, 1), 0, 0);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+  }
+
+  SECTION("Launch kernel with gridDim.z == maxGridDimZ using attribute") {
+    hipLaunchKernelGGL(emptyKernel, dim3(1, 1, maxGridZ), dim3(1, 1, 1), 0, 0);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+  }
+}
+
+TEST_CASE("Unit_hipGridLaunch_ExceedMaxGridDim_Negative") {
+  const unsigned int maxGridX = GetDeviceAttribute(hipDeviceAttributeMaxGridDimX, 0);
+  const unsigned int maxGridY = GetDeviceAttribute(hipDeviceAttributeMaxGridDimY, 0);
+  const unsigned int maxGridZ = GetDeviceAttribute(hipDeviceAttributeMaxGridDimZ, 0);
+
+  SECTION("Launch kernel with gridDim.x > maxGridDimX returns error") {
+    // Only test if we can exceed the max (avoid overflow)
+    if (maxGridX < UINT_MAX) {
+      hipLaunchKernelGGL(emptyKernel, dim3(maxGridX + 1, 1, 1), dim3(1, 1, 1), 0, 0);
+      hipError_t err = hipGetLastError();
+      REQUIRE((err == hipErrorInvalidConfiguration || err == hipErrorLaunchFailure ||
+               err == hipSuccess));  // Some implementations may allow this
+    }
+  }
+
+  SECTION("Launch kernel with gridDim.y > maxGridDimY returns error") {
+    if (maxGridY < UINT_MAX) {
+      hipLaunchKernelGGL(emptyKernel, dim3(1, maxGridY + 1, 1), dim3(1, 1, 1), 0, 0);
+      hipError_t err = hipGetLastError();
+      REQUIRE((err == hipErrorInvalidConfiguration || err == hipErrorLaunchFailure ||
+               err == hipSuccess));
+    }
+  }
+
+  SECTION("Launch kernel with gridDim.z > maxGridDimZ returns error") {
+    if (maxGridZ < UINT_MAX) {
+      hipLaunchKernelGGL(emptyKernel, dim3(1, 1, maxGridZ + 1), dim3(1, 1, 1), 0, 0);
+      hipError_t err = hipGetLastError();
+      REQUIRE((err == hipErrorInvalidConfiguration || err == hipErrorLaunchFailure ||
+               err == hipSuccess));
+    }
+  }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/kernel/hipGridLaunch.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipGridLaunch.cc
@@ -191,8 +191,7 @@ TEST_CASE("Unit_hipGridLaunch_ExceedMaxGridDim_Negative") {
     if (maxGridX < UINT_MAX) {
       hipLaunchKernelGGL(emptyKernel, dim3(maxGridX + 1, 1, 1), dim3(1, 1, 1), 0, 0);
       hipError_t err = hipGetLastError();
-      REQUIRE((err == hipErrorInvalidConfiguration || err == hipErrorLaunchFailure ||
-               err == hipSuccess));  // Some implementations may allow this
+      REQUIRE(err == hipErrorInvalidConfiguration);
     }
   }
 
@@ -200,8 +199,7 @@ TEST_CASE("Unit_hipGridLaunch_ExceedMaxGridDim_Negative") {
     if (maxGridY < UINT_MAX) {
       hipLaunchKernelGGL(emptyKernel, dim3(1, maxGridY + 1, 1), dim3(1, 1, 1), 0, 0);
       hipError_t err = hipGetLastError();
-      REQUIRE((err == hipErrorInvalidConfiguration || err == hipErrorLaunchFailure ||
-               err == hipSuccess));
+      REQUIRE(err == hipErrorInvalidConfiguration);
     }
   }
 
@@ -209,8 +207,7 @@ TEST_CASE("Unit_hipGridLaunch_ExceedMaxGridDim_Negative") {
     if (maxGridZ < UINT_MAX) {
       hipLaunchKernelGGL(emptyKernel, dim3(1, 1, maxGridZ + 1), dim3(1, 1, 1), 0, 0);
       hipError_t err = hipGetLastError();
-      REQUIRE((err == hipErrorInvalidConfiguration || err == hipErrorLaunchFailure ||
-               err == hipSuccess));
+      REQUIRE(err == hipErrorInvalidConfiguration);
     }
   }
 }

--- a/projects/hip-tests/catch/unit/module/hip_module_launch_kernel_common.hh
+++ b/projects/hip-tests/catch/unit/module/hip_module_launch_kernel_common.hh
@@ -104,8 +104,6 @@ template <ExtModuleLaunchKernelSig* func> void ModuleLaunchKernelNegativeParamet
   hipFunction_t f = GetKernel(mg.module(), "NOPKernel");
   hipError_t expectedErrorLaunchParam = (extLaunch == true) ? hipErrorInvalidConfiguration
                                                              : hipErrorInvalidValue;
-  hipError_t expectedErrorOverCapacityGridDim = (extLaunch == true) ? hipSuccess
-                                                                    : hipErrorInvalidValue;
 
   SECTION("f == nullptr") {
     HIP_CHECK_ERROR(
@@ -146,19 +144,19 @@ template <ExtModuleLaunchKernelSig* func> void ModuleLaunchKernelNegativeParamet
   SECTION("gridDimX > maxGridDimX") {
     const unsigned int x = GetDeviceAttribute(hipDeviceAttributeMaxGridDimX, 0) + 1u;
     HIP_CHECK_ERROR(func(f, x, 1, 1, 1, 1, 1, 0, nullptr, nullptr, nullptr, nullptr, nullptr, 0u),
-                    expectedErrorOverCapacityGridDim);
+                    expectedErrorLaunchParam);
   }
 
   SECTION("gridDimY > maxGridDimY") {
     const unsigned int y = GetDeviceAttribute(hipDeviceAttributeMaxGridDimY, 0) + 1u;
     HIP_CHECK_ERROR(func(f, 1, y, 1, 1, 1, 1, 0, nullptr, nullptr, nullptr, nullptr, nullptr, 0u),
-                    expectedErrorOverCapacityGridDim);
+                    expectedErrorLaunchParam);
   }
 
   SECTION("gridDimZ > maxGridDimZ") {
     const unsigned int z = GetDeviceAttribute(hipDeviceAttributeMaxGridDimZ, 0) + 1u;
     HIP_CHECK_ERROR(func(f, 1, 1, z, 1, 1, 1, 0, nullptr, nullptr, nullptr, nullptr, nullptr, 0u),
-                    expectedErrorOverCapacityGridDim);
+                    expectedErrorLaunchParam);
   }
 
   SECTION("blockDimX > maxBlockDimX") {


### PR DESCRIPTION
## Motivation

Fix crash and incorrect validation when launching kernels with grid dimensions exceeding maximum limits. The test Unit_hipModuleLaunchKernel_Negative_Parameters was failing with segfault instead of returning hipErrorInvalidValue when gridDimX > maxGridDimX. Root cause: maxGridDim_[0] was incorrectly set to UINT32_MAX instead of INT32_MAX, causing validation to pass for invalid grid sizes.

## Technical Details

Changed maximum grid dimension X from UINT32_MAX to INT32_MAX for CUDA/HIP API compatibility:

- rocclr/device/rocm/rocdevice.cpp: Clamp HSA_AGENT_INFO_GRID_MAX_DIM.x to INT32_MAX
- rocclr/device/pal/paldevice.cpp: Set maxGridDim_[0] to INT32_MAX instead of UINT32_MAX

## JIRA ID

N/A

## Test Plan

1. Run ModuleTest Unit_hipModuleLaunchKernel_Negative_Parameters with custom HIP library.
2. Verify test section "gridDimX > maxGridDimX" returns hipErrorInvalidValue instead of crashing
3. Compare results with default ROCm library to ensure parity

## Test Result
CI Validation pass

## Submission Checklist

- [X ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
