### PR TITLE
[rocprof-systems]: Add profile pipeline for Timemory wall_clock migration

### DIFF
--- a/projects/rocprofiler-systems/source/bin/common/env_vars.hpp
+++ b/projects/rocprofiler-systems/source/bin/common/env_vars.hpp
@@ -37,8 +37,9 @@ constexpr std::string_view TRACE_THREAD_RW_LOCKS = "ROCPROFSYS_TRACE_THREAD_RW_L
 constexpr std::string_view TRACE_THREAD_SPIN_LOCKS = "ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS";
 
 // --- Profiling ---
-constexpr std::string_view PROFILE      = "ROCPROFSYS_PROFILE";
-constexpr std::string_view FLAT_PROFILE = "ROCPROFSYS_FLAT_PROFILE";
+constexpr std::string_view PROFILE        = "ROCPROFSYS_PROFILE";
+constexpr std::string_view PROFILE_LEGACY = "ROCPROFSYS_PROFILE_LEGACY";
+constexpr std::string_view FLAT_PROFILE   = "ROCPROFSYS_FLAT_PROFILE";
 
 // --- Sampling ---
 constexpr std::string_view USE_SAMPLING      = "ROCPROFSYS_USE_SAMPLING";

--- a/projects/rocprofiler-systems/source/bin/common/json_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/json_config.cpp
@@ -178,6 +178,9 @@ resolve_schema_config(const nlohmann::json& config)
     {
         const auto& profiling = config["profiling"];
         resolve_enabled(result, profiling, "enabled", env_vars::PROFILE);
+        if(profiling.contains("legacy"))
+            resolve_enabled(result, profiling["legacy"], "enabled",
+                            env_vars::PROFILE_LEGACY);
         if(profiling.contains("flat_profile"))
         {
             resolve_enabled(result, profiling["flat_profile"], "enabled",
@@ -858,6 +861,7 @@ env_vars_to_json_schema(const std::map<std::string, std::string>& env_map)
     export_tracing_section(config, env_map);
 
     export_section_enabled(config, env_map, env_vars::PROFILE, "profiling");
+    export_enabled(config, env_map, env_vars::PROFILE_LEGACY, "profiling", "legacy");
     export_enabled(config, env_map, env_vars::FLAT_PROFILE, "profiling", "flat_profile");
 
     export_sampling_section(config, env_map);

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
@@ -355,10 +355,10 @@ generate_config(std::string _config_file, const std::set<std::string>& _config_f
                 for(const auto* itr :
                     { "ROCPROFSYS_CONFIG", "ROCPROFSYS_MODE", "ROCPROFSYS_TRACE",
                       "ROCPROFSYS_TRACE_LEGACY", "ROCPROFSYS_PROFILE",
-                      "ROCPROFSYS_USE_SAMPLING", "ROCPROFSYS_USE_PROCESS_SAMPLING",
-                      "ROCPROFSYS_USE_AMD_SMI", "ROCPROFSYS_USE_AINIC",
-                      "ROCPROFSYS_USE_KOKKOSP", "ROCPROFSYS_USE_OMPT", "ROCPROFSYS_USE",
-                      "ROCPROFSYS_OUTPUT" })
+                      "ROCPROFSYS_PROFILE_LEGACY", "ROCPROFSYS_USE_SAMPLING",
+                      "ROCPROFSYS_USE_PROCESS_SAMPLING", "ROCPROFSYS_USE_AMD_SMI",
+                      "ROCPROFSYS_USE_AINIC", "ROCPROFSYS_USE_KOKKOSP",
+                      "ROCPROFSYS_USE_OMPT", "ROCPROFSYS_USE", "ROCPROFSYS_OUTPUT" })
                 {
                     if(_lhs->get_env_name().find(itr) == 0 &&
                        _rhs->get_env_name().find(itr) != 0)

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -318,6 +318,13 @@ configure_settings(bool _init)
         bool, "ROCPROFSYS_USE_TIMEMORY", "[DEPRECATED] Renamed to ROCPROFSYS_PROFILE",
         !_config->get<bool>("ROCPROFSYS_TRACE"), "backend", "timemory", "deprecated");
 
+    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_PROFILE_LEGACY",
+                              "When true, use legacy direct mode for timemory profiling "
+                              "instead of deferred trace-cache-backed reporting. When "
+                              "false (default), uses cached mode with deferred "
+                              "profile (trace-cache) processing.",
+                              false, "backend", "timemory");
+
     ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_CAUSAL",
                               "Enable causal profiling analysis", false, "backend",
                               "causal", "analysis");
@@ -2596,6 +2603,17 @@ get_caching_perfetto()
     auto&       _trace  = static_cast<tim::tsettings<bool>&>(*_trace_setting).get();
     auto&       _legacy = static_cast<tim::tsettings<bool>&>(*_legacy_setting).get();
     static bool _v      = _trace && !_legacy;
+    return _v;
+}
+
+bool&
+get_caching_profile()
+{
+    static auto _profile_setting = get_config()->at("ROCPROFSYS_PROFILE");
+    static auto _legacy_setting  = get_config()->at("ROCPROFSYS_PROFILE_LEGACY");
+    auto&       _profile = static_cast<tim::tsettings<bool>&>(*_profile_setting).get();
+    auto&       _legacy  = static_cast<tim::tsettings<bool>&>(*_legacy_setting).get();
+    static bool _v       = _profile && !_legacy;
     return _v;
 }
 

--- a/projects/rocprofiler-systems/source/lib/core/config.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.hpp
@@ -378,6 +378,9 @@ get_use_rocpd() ROCPROFSYS_HOT;
 bool&
 get_caching_perfetto() ROCPROFSYS_HOT;
 
+bool&
+get_caching_profile() ROCPROFSYS_HOT;
+
 bool
 get_merge_perfetto_files();
 

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/CMakeLists.txt
@@ -7,6 +7,7 @@ set(trace_cache_sources
     ${CMAKE_CURRENT_LIST_DIR}/metadata_registry.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rocpd_processor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/perfetto_processor.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/profile_report_processor.cpp
 )
 
 set(trace_cache_headers
@@ -19,6 +20,7 @@ set(trace_cache_headers
     ${CMAKE_CURRENT_LIST_DIR}/metadata_registry.hpp
     ${CMAKE_CURRENT_LIST_DIR}/rocpd_processor.hpp
     ${CMAKE_CURRENT_LIST_DIR}/perfetto_processor.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/profile_report_processor.hpp
     ${CMAKE_CURRENT_LIST_DIR}/sample_processor.hpp
     ${CMAKE_CURRENT_LIST_DIR}/sample_type.hpp
 )

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/cache_manager.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/cache_manager.cpp
@@ -6,6 +6,7 @@
 #include "core/output_file_registry.hpp"
 #include "core/trace_cache/metadata_registry.hpp"
 #include "core/trace_cache/perfetto_processor.hpp"
+#include "core/trace_cache/profile_report_processor.hpp"
 #include "core/trace_cache/rocpd_processor.hpp"
 #include "core/trace_cache/sample_processor.hpp"
 
@@ -48,7 +49,8 @@ struct format_t
 struct enabled_formats_t
 {
     std::vector<format_t> formats = { { true, get_use_rocpd(), "rocpd" },
-                                      { false, get_caching_perfetto(), "perfetto" } };
+                                      { false, get_caching_perfetto(), "perfetto" },
+                                      { false, get_caching_profile(), "profile" } };
 
     void print() const
     {
@@ -160,6 +162,14 @@ struct enabled_formats_t
         });
         return it != formats.end() && it->enabled;
     }
+
+    bool is_profile_enabled() const
+    {
+        auto it = std::find_if(formats.begin(), formats.end(), [](const auto& f) {
+            return std::strcmp(f.name, "profile") == 0;
+        });
+        return it != formats.end() && it->enabled;
+    }
 };
 
 struct processor_config_t
@@ -182,8 +192,9 @@ struct processor_config_t
 
 struct processor_storage_t
 {
-    std::shared_ptr<rocpd_processor_t>    rocpd_processor{ nullptr };
-    std::shared_ptr<perfetto_processor_t> perfetto_processor{ nullptr };
+    std::shared_ptr<rocpd_processor_t>          rocpd_processor{ nullptr };
+    std::shared_ptr<perfetto_processor_t>       perfetto_processor{ nullptr };
+    std::shared_ptr<profile_report_processor_t> profile_processor{ nullptr };
 };
 
 using directory_files_t    = std::vector<std::string>;
@@ -402,6 +413,13 @@ configure_processors(const std::shared_ptr<sample_processor_t>&       _type_proc
             _processor_config->_metadata_registry, _processor_config->_agent_manager,
             _processor_config->_pid, _processor_config->_ppid, _output_registry);
         _type_processing->add_handler(*processor_storage.perfetto_processor);
+    }
+    if(_enabled_formats.is_profile_enabled())
+    {
+        processor_storage.profile_processor =
+            std::make_shared<profile_report_processor_t>(
+                _processor_config->_pid, _processor_config->_ppid, _output_registry);
+        _type_processing->add_handler(*processor_storage.profile_processor);
     }
     return processor_storage;
 }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/cache_manager.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/cache_manager.hpp
@@ -20,12 +20,11 @@ namespace rocprofsys
 namespace trace_cache
 {
 
-using storage_parser_t =
-    storage_parser<type_identifier_t, kernel_dispatch_sample, memory_copy_sample,
-                   memory_allocate_sample, region_sample, in_time_sample,
-                   pmc_event_with_sample, pmc::collectors::gpu::sample,
-                   pmc::collectors::nic::sample, pmc::collectors::cpu::sample,
-                   backtrace_region_sample, scratch_memory_sample, kfd_sample>;
+using storage_parser_t = storage_parser<
+    type_identifier_t, kernel_dispatch_sample, memory_copy_sample, memory_allocate_sample,
+    region_sample, in_time_sample, pmc_event_with_sample, pmc::collectors::gpu::sample,
+    pmc::collectors::nic::sample, pmc::collectors::cpu::sample, backtrace_region_sample,
+    scratch_memory_sample, kfd_sample, wall_clock_event_sample>;
 
 using buffer_storage_t = buffer_storage<flush_worker_factory_t, type_identifier_t>;
 

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
@@ -1388,4 +1388,9 @@ perfetto_processor_t::handle(const kfd_sample& _kfd)
     else
         LOG_WARNING("Unknown KFD category: {}", _category);
 }
+
+void
+perfetto_processor_t::handle([[maybe_unused]] const wall_clock_event_sample&)
+{}
+
 }  // namespace rocprofsys::trace_cache

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.hpp
@@ -49,6 +49,7 @@ public:
     void handle(const cpu_pmc_sample& sample);
     void handle(const backtrace_region_sample& sample);
     void handle(const kfd_sample& sample);
+    void handle(const wall_clock_event_sample& sample);
 
 private:
     void       initialize_perfetto();

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/profile_report_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/profile_report_processor.cpp
@@ -1,0 +1,326 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "profile_report_processor.hpp"
+
+#include "core/config.hpp"
+#include "core/trace_cache/cacheable.hpp"
+#include "core/trace_cache/sample_type.hpp"
+
+#include "logger/debug.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <rocprofiler-sdk/version.h>
+
+namespace rocprofsys
+{
+namespace trace_cache
+{
+namespace
+{
+constexpr double NS_TO_SEC = 1e-9;
+
+const char*
+source_string(wall_clock_event_source s)
+{
+    switch(s)
+    {
+        case wall_clock_event_source::buffered_kernel_dispatch:
+            return "buffered_kernel_dispatch";
+        case wall_clock_event_source::buffered_scratch_memory:
+            return "buffered_scratch_memory";
+        case wall_clock_event_source::buffered_memory_copy: return "buffered_memory_copy";
+        case wall_clock_event_source::tool_callback_api: return "tool_callback_api";
+        case wall_clock_event_source::ompt_callback_api: return "ompt_callback_api";
+        default: return "unknown";
+    }
+}
+
+std::string
+format_timemory_style_label(uint64_t timemory_tid, const std::string& raw_label)
+{
+    return "|" + std::to_string(timemory_tid) + ">>> " + raw_label;
+}
+
+std::string
+fmt_fixed(double v, int prec)
+{
+    std::ostringstream os;
+    os << std::fixed << std::setprecision(prec) << v;
+    return os.str();
+}
+
+std::string
+horizontal_rule(size_t width)
+{
+    return std::string(width, '-');
+}
+
+}  // namespace
+
+profile_report_processor_t::profile_report_processor_t(
+    int pid, int ppid, output_file_registry& output_registry)
+: processor_t<profile_report_processor_t>()
+, m_pid(pid)
+, m_ppid(ppid)
+, m_output_registry(output_registry)
+{}
+
+void
+profile_report_processor_t::prepare_for_processing()
+{}
+
+void
+profile_report_processor_t::finalize_processing()
+{
+    auto _cfg       = settings::compose_filename_config{};
+    _cfg.use_suffix = config::get_use_pid();
+    _cfg.suffix     = settings::default_process_suffix();
+    // Default compose_filename_config::make_dir is false; without creating the directory,
+    // ofstream fails when the session path under ROCPROFSYS_OUTPUT_PATH does not exist.
+    _cfg.make_dir = true;
+
+    auto path = settings::compose_output_filename("wall_clock_cache", "txt", _cfg);
+    if(path.empty())
+    {
+        path = std::string{ trace_cache::tmp_directory } + "wall_clock_cache_" +
+               std::to_string(m_ppid) + "_" + std::to_string(m_pid) + ".txt";
+    }
+
+    std::ofstream ofs(path);
+    if(!ofs.good())
+    {
+        LOG_WARNING("Could not open trace_cache wall_clock report path: {}", path);
+        return;
+    }
+
+    using row_entry_t = std::pair<aggregate_key_t, aggregate_row>;
+    std::vector<row_entry_t> rows(m_aggregates.begin(), m_aggregates.end());
+    std::sort(rows.begin(), rows.end(), [](const row_entry_t& a, const row_entry_t& b) {
+        const auto& [la, sa, ra, ma, da] = a.first;
+        const auto& [lb, sb, rb, mb, db] = b.first;
+        if(la != lb) return la < lb;
+        if(da != db) return da < db;
+        if(ma != mb) return ma < mb;
+        if(ra != rb) return ra < rb;
+        if(sa != sb) return static_cast<int>(sa) < static_cast<int>(sb);
+        return false;
+    });
+
+    size_t max_label_display = 40;
+    for(const auto& [key, row] : rows)
+    {
+        if(row.count == 0) continue;
+        const auto& [label, src_unused, roc_unused, tim_tid, depth_unused] = key;
+        (void) src_unused;
+        (void) roc_unused;
+        (void) depth_unused;
+        (void) row;
+        const auto disp   = format_timemory_style_label(tim_tid, label);
+        max_label_display = std::max(max_label_display, disp.size());
+    }
+    max_label_display = std::min(max_label_display, size_t{ 120 });
+
+    constexpr size_t w_count  = 8;
+    constexpr size_t w_depth  = 7;
+    constexpr size_t w_metric = 11;
+    constexpr size_t w_units  = 7;
+    constexpr size_t w_float  = 12;
+    constexpr size_t w_pct    = 8;
+
+    const size_t inner_width = max_label_display + 3 + w_count + 3 + w_depth + 3 +
+                               w_metric + 3 + w_units + 3 + w_float * 7 + 3 + w_pct;
+
+    const std::string title =
+        "REAL-CLOCK TIMER (TRACE CACHE — rocprofiler timestamp durations)";
+    const size_t banner_w = std::max(inner_width, title.size() + 4);
+
+    ofs << '|' << horizontal_rule(banner_w - 2) << "|\n";
+    ofs << "| " << std::left << std::setw(static_cast<int>(banner_w - 4))
+        << std::setfill(' ') << title << " |\n";
+    ofs << '|' << horizontal_rule(banner_w - 2) << "|\n";
+
+    ofs << '|' << std::setw(static_cast<int>(max_label_display)) << std::left << "LABEL"
+        << " | " << std::setw(static_cast<int>(w_count)) << std::right << "COUNT"
+        << " | " << std::setw(static_cast<int>(w_depth)) << "DEPTH"
+        << " | " << std::setw(static_cast<int>(w_metric)) << std::left << "METRIC"
+        << " | " << std::setw(static_cast<int>(w_units)) << std::left << "UNITS"
+        << " | " << std::setw(static_cast<int>(w_float)) << std::right << "SUM"
+        << " | " << std::setw(static_cast<int>(w_float)) << "MEAN"
+        << " | " << std::setw(static_cast<int>(w_float)) << "MIN"
+        << " | " << std::setw(static_cast<int>(w_float)) << "MAX"
+        << " | " << std::setw(static_cast<int>(w_float)) << "VAR"
+        << " | " << std::setw(static_cast<int>(w_float)) << "STDDEV"
+        << " | " << std::setw(static_cast<int>(w_pct)) << "% SELF"
+        << " |\n";
+    ofs << '|' << horizontal_rule(banner_w - 2) << "|\n";
+
+    for(const auto& [key, row] : rows)
+    {
+        if(row.count == 0) continue;
+
+        const auto& [label, src_u2, roc_tid_u, tim_tid, depth_val] = key;
+        (void) src_u2;
+        (void) roc_tid_u;
+
+        const double sum_sec  = static_cast<double>(row.total_nsec) * NS_TO_SEC;
+        const double mean_sec = sum_sec / static_cast<double>(row.count);
+        const double min_sec  = static_cast<double>(row.min_nsec) * NS_TO_SEC;
+        const double max_sec  = static_cast<double>(row.max_nsec) * NS_TO_SEC;
+
+        double var_sec = 0.0;
+        if(row.count > 0)
+        {
+            const double mean_sq = row.sum_sq_sec / static_cast<double>(row.count);
+            var_sec              = mean_sq - mean_sec * mean_sec;
+            if(var_sec < 0.0 && var_sec > -1e-18) var_sec = 0.0;
+        }
+        const double stddev_sec =
+            (row.count > 0) ? std::sqrt(std::max(0.0, var_sec)) : 0.0;
+
+        double pct_self = 0.0;
+        if(row.total_nsec > 0)
+        {
+            pct_self = 100.0 * static_cast<double>(row.sum_exclusive_nsec) /
+                       static_cast<double>(row.total_nsec);
+            if(pct_self > 100.0) pct_self = 100.0;
+            if(pct_self < 0.0) pct_self = 0.0;
+        }
+
+        std::string disp_label = format_timemory_style_label(tim_tid, label);
+        if(disp_label.size() > max_label_display)
+        {
+            disp_label.resize(max_label_display > 3 ? max_label_display - 3
+                                                    : max_label_display);
+            disp_label += "...";
+        }
+
+        ofs << "| " << std::setw(static_cast<int>(max_label_display)) << std::left
+            << disp_label << " | " << std::setw(static_cast<int>(w_count)) << std::right
+            << row.count << " | " << std::setw(static_cast<int>(w_depth)) << std::right
+            << depth_val << " | " << std::setw(static_cast<int>(w_metric)) << std::left
+            << "wall_clock"
+            << " | " << std::setw(static_cast<int>(w_units)) << std::left << "sec"
+            << " | " << std::setw(static_cast<int>(w_float)) << std::right
+            << fmt_fixed(sum_sec, 6) << " | " << std::setw(static_cast<int>(w_float))
+            << fmt_fixed(mean_sec, 6) << " | " << std::setw(static_cast<int>(w_float))
+            << fmt_fixed(min_sec, 6) << " | " << std::setw(static_cast<int>(w_float))
+            << fmt_fixed(max_sec, 6) << " | " << std::setw(static_cast<int>(w_float))
+            << fmt_fixed(var_sec, 6) << " | " << std::setw(static_cast<int>(w_float))
+            << fmt_fixed(stddev_sec, 6) << " | " << std::setw(static_cast<int>(w_pct))
+            << std::right << fmt_fixed(pct_self, 1) << " |\n";
+    }
+
+    ofs << '|' << horizontal_rule(banner_w - 2) << "|\n";
+    ofs << "# DEPTH: instrumentation stack depth (rocprofiler-sdk) and/or nested "
+           "callback scope.\n";
+    ofs << "# % SELF: 100 * sum(exclusive_nsec) / sum(inclusive_nsec) per aggregate "
+           "bucket.\n";
+    ofs << "# Source dimension is listed in the debug lines below.\n\n";
+
+    ofs << "# --- aggregate keys (label, source, rocprofiler_thread_id, timemory_tid, "
+           "depth) ---\n";
+    for(const auto& [key, row] : rows)
+    {
+        if(row.count == 0) continue;
+        const auto& [lab, src, roc_tid, tim_tid, dep] = key;
+        ofs << '#' << " label=" << lab << " source=" << source_string(src)
+            << " rocprofiler_thread_id=" << roc_tid << " timemory_tid=" << tim_tid
+            << " depth=" << dep << " count=" << row.count
+            << " inclusive_nsec=" << row.total_nsec
+            << " exclusive_nsec=" << row.sum_exclusive_nsec << '\n';
+    }
+
+    m_output_registry.register_file(path, output_format::text, "trace_cache_wall_clock");
+    LOG_INFO("Wrote trace_cache wall_clock summary ({} aggregate rows): {}",
+             m_aggregates.size(), path);
+}
+
+void
+profile_report_processor_t::handle(const wall_clock_event_sample& sample)
+{
+    const aggregate_key_t key{ sample.label, sample.source, sample.thread_id,
+                               sample.timemory_tid, sample.depth };
+    auto&                 agg = m_aggregates[key];
+
+    const uint64_t dur =
+        (sample.end_ns > sample.begin_ns) ? (sample.end_ns - sample.begin_ns) : 0;
+
+    ++agg.count;
+    agg.total_nsec += dur;
+    agg.sum_exclusive_nsec += sample.exclusive_nsec;
+    const double d_sec = static_cast<double>(dur) * NS_TO_SEC;
+    agg.sum_sq_sec += d_sec * d_sec;
+
+    if(agg.count == 1u)
+    {
+        agg.min_nsec = agg.max_nsec = dur;
+    }
+    else
+    {
+        agg.min_nsec = std::min(agg.min_nsec, dur);
+        agg.max_nsec = std::max(agg.max_nsec, dur);
+    }
+}
+
+void
+profile_report_processor_t::handle(const kernel_dispatch_sample&)
+{}
+
+void
+profile_report_processor_t::handle(const scratch_memory_sample&)
+{}
+
+void
+profile_report_processor_t::handle(const memory_copy_sample&)
+{}
+
+#if(ROCPROFILER_VERSION >= 600)
+void
+profile_report_processor_t::handle(const memory_allocate_sample&)
+{}
+#endif
+
+void
+profile_report_processor_t::handle(const region_sample&)
+{}
+
+void
+profile_report_processor_t::handle(const in_time_sample&)
+{}
+
+void
+profile_report_processor_t::handle(const pmc_event_with_sample&)
+{}
+
+void
+profile_report_processor_t::handle(const gpu_pmc_sample&)
+{}
+
+void
+profile_report_processor_t::handle(const ainic_pmc_sample&)
+{}
+
+void
+profile_report_processor_t::handle(const cpu_pmc_sample&)
+{}
+
+void
+profile_report_processor_t::handle(const backtrace_region_sample&)
+{}
+
+void
+profile_report_processor_t::handle(const kfd_sample&)
+{}
+
+}  // namespace trace_cache
+}  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/profile_report_processor.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/profile_report_processor.hpp
@@ -2,26 +2,27 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
-#include "agent_manager.hpp"
-#include "core/node_info.hpp"
+
 #include "core/output_file_registry.hpp"
-#include "core/rocpd/data_processor.hpp"
-#include "core/trace_cache/metadata_registry.hpp"
 #include "core/trace_cache/sample_processor.hpp"
 
-#include "trace_cache/sample_type.hpp"
+#include <rocprofiler-sdk/version.h>
+
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <string>
+#include <tuple>
 
 namespace rocprofsys
 {
 namespace trace_cache
 {
 
-class rocpd_processor_t : public processor_t<rocpd_processor_t>
+class profile_report_processor_t : public processor_t<profile_report_processor_t>
 {
 public:
-    rocpd_processor_t(const std::shared_ptr<metadata_registry>& metadata,
-                      const std::shared_ptr<agent_manager>& agent_mngr, int pid, int ppid,
-                      output_file_registry& output_registry);
+    profile_report_processor_t(int pid, int ppid, output_file_registry& output_registry);
 
     void prepare_for_processing();
     void finalize_processing();
@@ -29,7 +30,9 @@ public:
     void handle(const kernel_dispatch_sample& sample);
     void handle(const scratch_memory_sample& sample);
     void handle(const memory_copy_sample& sample);
+#if(ROCPROFILER_VERSION >= 600)
     void handle(const memory_allocate_sample& sample);
+#endif
     void handle(const region_sample& sample);
     void handle(const in_time_sample& sample);
     void handle(const pmc_event_with_sample& sample);
@@ -41,17 +44,23 @@ public:
     void handle(const wall_clock_event_sample& sample);
 
 private:
-    using primary_key = size_t;
+    struct aggregate_row
+    {
+        uint64_t count              = 0;
+        uint64_t total_nsec         = 0;
+        uint64_t sum_exclusive_nsec = 0;
+        uint64_t min_nsec           = std::numeric_limits<uint64_t>::max();
+        uint64_t max_nsec           = 0;
+        double   sum_sq_sec         = 0.0;
+    };
 
-    void        post_process_metadata();
-    inline void insert_thread_id(info::thread& t_info, const node_info& n_info,
-                                 const info::process& process_info);
+    using aggregate_key_t =
+        std::tuple<std::string, wall_clock_event_source, uint64_t, uint64_t, uint32_t>;
 
-    std::shared_ptr<metadata_registry>     m_metadata;
-    std::shared_ptr<agent_manager>         m_agent_manager;
-    std::shared_ptr<rocpd::data_processor> m_data_processor;
-    output_file_registry&                  m_output_registry;
-    std::string                            m_db_output_path;
+    int                                      m_pid;
+    int                                      m_ppid;
+    output_file_registry&                    m_output_registry;
+    std::map<aggregate_key_t, aggregate_row> m_aggregates;
 };
 
 }  // namespace trace_cache

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.cpp
@@ -704,6 +704,10 @@ rocpd_processor_t::handle(const kfd_sample& _kfd)
     }
 }
 
+void
+rocpd_processor_t::handle([[maybe_unused]] const wall_clock_event_sample&)
+{}
+
 rocpd_processor_t::rocpd_processor_t(const std::shared_ptr<metadata_registry>& md,
                                      const std::shared_ptr<agent_manager>&     agent_mngr,
                                      int pid, int ppid,

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_processor.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_processor.hpp
@@ -66,6 +66,11 @@ struct processor_t
 
     void handle(const kfd_sample& sample) { static_cast<T*>(this)->handle(sample); }
 
+    void handle(const wall_clock_event_sample& sample)
+    {
+        static_cast<T*>(this)->handle(sample);
+    }
+
     void prepare_for_processing() { static_cast<T*>(this)->prepare_for_processing(); }
 
     void finalize_processing() { static_cast<T*>(this)->finalize_processing(); }
@@ -91,6 +96,8 @@ struct processor_view_t
     using backtrace_region_fn_t = void (*)(void*,
                                            const backtrace_region_sample&) noexcept;
     using kfd_sample_fn_t       = void (*)(void*, const kfd_sample&) noexcept;
+    using wall_clock_event_fn_t = void (*)(void*,
+                                           const wall_clock_event_sample&) noexcept;
     using prepare_for_processing_fn_t = void (*)(void*) noexcept;
     using finalize_processing_fn_t    = void (*)(void*) noexcept;
 
@@ -110,6 +117,7 @@ struct processor_view_t
         cpu_pmc_sample_fn_t         handle_cpu_pmc_sample;
         backtrace_region_fn_t       handle_backtrace_region;
         kfd_sample_fn_t             handle_kfd_sample;
+        wall_clock_event_fn_t       handle_wall_clock_event;
         prepare_for_processing_fn_t prepare_for_processing;
         finalize_processing_fn_t    finalize_processing;
     };
@@ -189,6 +197,11 @@ struct processor_view_t
         m_vtable->handle_kfd_sample(m_object, sample);
     }
 
+    ROCPROFSYS_INLINE void handle(const wall_clock_event_sample& sample) const noexcept
+    {
+        m_vtable->handle_wall_clock_event(m_object, sample);
+    }
+
     ROCPROFSYS_INLINE void prepare_for_processing() const noexcept
     {
         m_vtable->prepare_for_processing(m_object);
@@ -240,6 +253,9 @@ private:
                 static_cast<T*>(obj)->handle(sample);
             },
             +[](void* obj, const kfd_sample& sample) noexcept {
+                static_cast<T*>(obj)->handle(sample);
+            },
+            +[](void* obj, const wall_clock_event_sample& sample) noexcept {
                 static_cast<T*>(obj)->handle(sample);
             },
             +[](void* obj) noexcept { static_cast<T*>(obj)->prepare_for_processing(); },
@@ -328,6 +344,9 @@ struct sample_processor_t
                 break;
             case type_identifier_t::kfd_sample:
                 handle_sample(static_cast<const kfd_sample&>(sample));
+                break;
+            case type_identifier_t::wall_clock_event:
+                handle_sample(static_cast<const wall_clock_event_sample&>(sample));
                 break;
             default: throw std::runtime_error("Unsupported sample type");
         }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
@@ -30,7 +30,22 @@ enum class type_identifier_t : uint32_t
     scratch_memory          = 0x0009,
     ainic_pmc_sample        = 0x000A,
     kfd_sample              = 0x000B,
+    wall_clock_event        = 0x000C,
     fragmented_space        = 0xFFFF
+};
+
+enum class wall_clock_event_source : uint8_t
+{
+    buffered_kernel_dispatch = 0,
+    buffered_scratch_memory  = 1,
+    buffered_memory_copy     = 2,
+    tool_callback_api        = 3,
+    ompt_callback_api        = 4,
+};
+
+enum class wall_clock_clock_domain : uint8_t
+{
+    rocprofiler_timestamp = 0,
 };
 
 struct kernel_dispatch_sample : cacheable_t
@@ -754,6 +769,80 @@ get_size(const kfd_sample& item)
         std::string_view(item.category), std::string_view(item.track_name),
         std::string_view(item.event_metadata), item.device_id, item.device_type,
         std::string_view(item.pmc_info_name), item.value, item.system_tid);
+}
+
+struct wall_clock_event_sample : cacheable_t
+{
+    static constexpr type_identifier_t type_identifier =
+        type_identifier_t::wall_clock_event;
+
+    wall_clock_event_sample() = default;
+    wall_clock_event_sample(uint64_t _begin_ns, uint64_t _end_ns, uint64_t _thread_id,
+                            uint64_t _timemory_tid, uint64_t _correlation_id,
+                            wall_clock_event_source _source,
+                            wall_clock_clock_domain _clock_domain, uint32_t _depth,
+                            uint64_t _exclusive_nsec, std::string _label)
+    : begin_ns(_begin_ns)
+    , end_ns(_end_ns)
+    , thread_id(_thread_id)
+    , timemory_tid(_timemory_tid)
+    , correlation_id(_correlation_id)
+    , source(_source)
+    , clock_domain(_clock_domain)
+    , depth(_depth)
+    , exclusive_nsec(_exclusive_nsec)
+    , label(std::move(_label))
+    {}
+
+    uint64_t                begin_ns{};
+    uint64_t                end_ns{};
+    uint64_t                thread_id{};
+    uint64_t                timemory_tid{};
+    uint64_t                correlation_id{};
+    wall_clock_event_source source{};
+    wall_clock_clock_domain clock_domain{};
+    uint32_t                depth{};
+    uint64_t                exclusive_nsec{};
+    std::string             label{};
+};
+
+template <>
+inline void
+serialize(uint8_t* buffer, const wall_clock_event_sample& item)
+{
+    utility::store_value(buffer, item.begin_ns, item.end_ns, item.thread_id,
+                         item.timemory_tid, item.correlation_id,
+                         static_cast<uint8_t>(item.source),
+                         static_cast<uint8_t>(item.clock_domain), item.depth,
+                         item.exclusive_nsec, std::string_view(item.label));
+}
+
+template <>
+inline wall_clock_event_sample
+deserialize(uint8_t*& buffer)
+{
+    wall_clock_event_sample item;
+    uint8_t                 src_u8{};
+    uint8_t                 domain_u8{};
+    std::string_view        label_view;
+    utility::parse_value(buffer, item.begin_ns, item.end_ns, item.thread_id,
+                         item.timemory_tid, item.correlation_id, src_u8, domain_u8,
+                         item.depth, item.exclusive_nsec, label_view);
+    item.source       = static_cast<wall_clock_event_source>(src_u8);
+    item.clock_domain = static_cast<wall_clock_clock_domain>(domain_u8);
+    item.label        = std::string(label_view);
+    return item;
+}
+
+template <>
+inline size_t
+get_size(const wall_clock_event_sample& item)
+{
+    return utility::get_size(item.begin_ns, item.end_ns, item.thread_id,
+                             item.timemory_tid, item.correlation_id,
+                             static_cast<uint8_t>(item.source),
+                             static_cast<uint8_t>(item.clock_domain), item.depth,
+                             item.exclusive_nsec, std::string_view(item.label));
 }
 
 }  // namespace trace_cache

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -1174,12 +1174,6 @@ rocprofsys_finalize_hidden(void)
                                            _perfetto_output_error, _output_registry);
     }
 
-    {
-        auto& _manager = rocprofsys::trace_cache::cache_manager::get_instance();
-        _manager.shutdown();
-        _manager.post_process_bulk(_output_registry);
-    }
-
     if(_timemory_manager && _timemory_manager != nullptr)
     {
         _timemory_manager->add_metadata([](auto& ar) {
@@ -1240,6 +1234,15 @@ rocprofsys_finalize_hidden(void)
                     output_format::json, _comp_name);
             }
         }
+    }
+
+    // Trace-cache post-processing (e.g. profile_report_processor) writes under the same
+    // ROCPROFSYS_OUTPUT_PATH session directory as timemory. Run after timemory_finalize
+    // so that directory creation and component outputs have established the tree first.
+    {
+        auto& _manager = rocprofsys::trace_cache::cache_manager::get_instance();
+        _manager.shutdown();
+        _manager.post_process_bulk(_output_registry);
     }
 
     _output_registry.print_summary();

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -90,6 +90,54 @@ using tool_agent_vec_t                         = std::vector<tool_agent>;
 client_data*                    tool_data      = new client_data{};
 std::shared_ptr<roctx_client<>> g_roctx_client = {};
 
+struct wall_clock_callback_scope_frame
+{
+    uint64_t begin_ns               = 0;
+    uint64_t child_inclusive_acc_ns = 0;
+};
+
+thread_local std::vector<wall_clock_callback_scope_frame> tl_wall_clock_callback_scope;
+
+void
+wall_clock_callback_scope_enter(uint64_t begin_ns)
+{
+    tl_wall_clock_callback_scope.push_back(
+        wall_clock_callback_scope_frame{ begin_ns, 0 });
+}
+
+void
+wall_clock_callback_scope_exit(uint64_t begin_ns, uint64_t end_ns,
+                               uint32_t* scope_depth_out, uint64_t* inclusive_out,
+                               uint64_t* exclusive_out)
+{
+    (void) begin_ns;
+    const uint64_t inclusive   = (end_ns > begin_ns) ? (end_ns - begin_ns) : 0;
+    uint64_t       exclusive   = inclusive;
+    uint32_t       scope_depth = 0;
+
+    if(!tl_wall_clock_callback_scope.empty())
+    {
+        exclusive =
+            inclusive - tl_wall_clock_callback_scope.back().child_inclusive_acc_ns;
+        scope_depth = static_cast<uint32_t>(tl_wall_clock_callback_scope.size() - 1);
+        tl_wall_clock_callback_scope.pop_back();
+        if(!tl_wall_clock_callback_scope.empty())
+            tl_wall_clock_callback_scope.back().child_inclusive_acc_ns += inclusive;
+    }
+
+    *scope_depth_out = scope_depth;
+    *inclusive_out   = inclusive;
+    *exclusive_out   = exclusive;
+}
+
+uint32_t
+wall_clock_instrumentation_stack_depth()
+{
+    auto& bundles_ptr = tracing::get_instrumentation_bundles();
+    if(!bundles_ptr || bundles_ptr->empty()) return 0;
+    return static_cast<uint32_t>(bundles_ptr->size() - 1);
+}
+
 std::shared_ptr<roctx_client<>>
 get_roctx_client()
 {
@@ -717,7 +765,28 @@ tool_tracing_callback_stop(
 
     if(get_use_timemory())
     {
+        uint32_t scope_depth  = 0;
+        uint64_t inclusive_ns = 0;
+        uint64_t exclusive_ns = 0;
+        wall_clock_callback_scope_exit(begin_ts, ts, &scope_depth, &inclusive_ns,
+                                       &exclusive_ns);
+
+        const uint32_t inst_depth = wall_clock_instrumentation_stack_depth();
+        const uint32_t depth_u32  = std::max(scope_depth, inst_depth);
+
         tracing::pop_timemory(CategoryT{}, _name);
+
+        uint64_t    end_ts       = ts;
+        const auto& _tinfo       = thread_info::get(record.thread_id, SystemTID);
+        auto        timemory_tid = _tinfo->index_data->sequent_value;
+        std::string lbl{ tool_data->callback_tracing_info.at(record.kind,
+                                                             record.operation) };
+        trace_cache::get_buffer_storage().store(trace_cache::wall_clock_event_sample{
+            begin_ts, end_ts, record.thread_id, static_cast<uint64_t>(timemory_tid),
+            record.correlation_id.internal,
+            trace_cache::wall_clock_event_source::tool_callback_api,
+            trace_cache::wall_clock_clock_domain::rocprofiler_timestamp, depth_u32,
+            exclusive_ns, std::move(lbl) });
     }
 
     if(get_use_perfetto())
@@ -1227,15 +1296,37 @@ ompt_tracing_callback_start(rocprofiler_callback_tracing_record_t record,
 
 void
 ompt_tracing_callback_stop(
-    rocprofiler_callback_tracing_record_t record, rocprofiler_user_data_t* /*user_data*/,
-    rocprofiler_timestamp_t               ts,
+    rocprofiler_callback_tracing_record_t record, rocprofiler_user_data_t* user_data,
+    rocprofiler_timestamp_t                                   ts,
     std::optional<std::vector<tim::unwind::processed_entry>>& _bt_data)
 {
     std::string_view _name = ompt_get_unified_name(record);
 
     if(get_use_timemory())
     {
+        uint64_t begin_ts = user_data->value;
+
+        uint32_t scope_depth  = 0;
+        uint64_t inclusive_ns = 0;
+        uint64_t exclusive_ns = 0;
+        wall_clock_callback_scope_exit(begin_ts, ts, &scope_depth, &inclusive_ns,
+                                       &exclusive_ns);
+
+        const uint32_t inst_depth = wall_clock_instrumentation_stack_depth();
+        const uint32_t depth_u32  = std::max(scope_depth, inst_depth);
+
         tracing::pop_timemory(category::rocm_ompt_api{}, _name);
+
+        uint64_t    end_ts       = ts;
+        const auto& _tinfo       = thread_info::get(record.thread_id, SystemTID);
+        auto        timemory_tid = _tinfo->index_data->sequent_value;
+        std::string lbl{ _name };
+        trace_cache::get_buffer_storage().store(trace_cache::wall_clock_event_sample{
+            begin_ts, end_ts, record.thread_id, static_cast<uint64_t>(timemory_tid),
+            record.correlation_id.internal,
+            trace_cache::wall_clock_event_source::ompt_callback_api,
+            trace_cache::wall_clock_clock_domain::rocprofiler_timestamp, depth_u32,
+            exclusive_ns, std::move(lbl) });
     }
 
     if(get_use_perfetto())
@@ -1387,6 +1478,7 @@ tool_tracing_callback(rocprofiler_callback_tracing_record_t record,
     if(record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER)
     {
         user_data->value = ts;
+        wall_clock_callback_scope_enter(ts);
         switch(record.kind)
         {
             case ROCPROFILER_CALLBACK_TRACING_HSA_CORE_API:
@@ -1751,6 +1843,18 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
                         _wc->set_accum(_end_ns - _beg_ns);
                     });
                     _bundle.pop();
+
+                    const uint64_t dur_ns = (_end_ns > _beg_ns) ? (_end_ns - _beg_ns) : 0;
+                    const uint32_t depth_u32 = wall_clock_instrumentation_stack_depth();
+
+                    trace_cache::get_buffer_storage().store(
+                        trace_cache::wall_clock_event_sample{
+                            _beg_ns, _end_ns, record->thread_id,
+                            static_cast<uint64_t>(_tid), record->correlation_id.internal,
+                            trace_cache::wall_clock_event_source::
+                                buffered_kernel_dispatch,
+                            trace_cache::wall_clock_clock_domain::rocprofiler_timestamp,
+                            depth_u32, dur_ns, _name });
                 }
 
                 if(get_use_perfetto())
@@ -1872,6 +1976,18 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
                         _wc->set_accum(_end_ns - _beg_ns);
                     });
                     _bundle.pop();
+
+                    const uint64_t dur_sn = (_end_ns > _beg_ns) ? (_end_ns - _beg_ns) : 0;
+                    const uint32_t depth_sn = wall_clock_instrumentation_stack_depth();
+
+                    trace_cache::get_buffer_storage().store(
+                        trace_cache::wall_clock_event_sample{
+                            _beg_ns, _end_ns, record->thread_id,
+                            static_cast<uint64_t>(thread_id_sequent),
+                            record->correlation_id.internal,
+                            trace_cache::wall_clock_event_source::buffered_scratch_memory,
+                            trace_cache::wall_clock_clock_domain::rocprofiler_timestamp,
+                            depth_sn, dur_sn, std::string{ _name } });
                 }
 
                 if(get_use_perfetto())
@@ -1992,6 +2108,17 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
                         _wc->set_accum(_end_ns - _beg_ns);
                     });
                     _bundle.pop();
+
+                    const uint64_t dur_mc = (_end_ns > _beg_ns) ? (_end_ns - _beg_ns) : 0;
+                    const uint32_t depth_mc = wall_clock_instrumentation_stack_depth();
+
+                    trace_cache::get_buffer_storage().store(
+                        trace_cache::wall_clock_event_sample{
+                            _beg_ns, _end_ns, record->thread_id,
+                            static_cast<uint64_t>(_tid), record->correlation_id.internal,
+                            trace_cache::wall_clock_event_source::buffered_memory_copy,
+                            trace_cache::wall_clock_clock_domain::rocprofiler_timestamp,
+                            depth_mc, dur_mc, std::string{ _name } });
                 }
 
                 if(get_use_perfetto())


### PR DESCRIPTION
## Motivation

Reconstruct wall_clock data from trace cache, so profiling can move from timemory path without losing nested timing and depth.

## Technical Details

- New trace-cache sample `wall_clock_event_sample` (timestamps, label, thread/correlation ids, depth, exclusive duration, source, clock domain) and serialization updates for the buffer format.
- Capture path (e.g. HIP/OMPT/callback and buffered dispatches) stores these events when the profile/trace-cache path is active; nested API callbacks use a small thread-local scope stack so exclusive time matches nested enter/exit semantics.
- Post-process via `profile_report_processor_t`: replays wall-clock events, aggregates (sum/mean/min/max/var/stddev, % self), writes `wall_clock_cache-<pid>.txt` under the session output tree and registers it in the output summary.
- Config / wiring: gating with `ROCPROFSYS_PROFILE` and `ROCPROFSYS_PROFILE_LEGACY` .
- Timemory remains enabled for legacy parity while the new path is adopted; 


## JIRA ID

AIPROFSYST-401

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
