### PR TITLE
[rocshmem] Implement rocshmem_buffer_register/unregister for GDA

### DIFF
--- a/projects/rocshmem/docs/env_variables.rst
+++ b/projects/rocshmem/docs/env_variables.rst
@@ -172,6 +172,14 @@ control the behavior of rocSHMEM.
       - ``1``
       - Number of QPs per PE for each user context.
 
+
+    * - | ``ROCSHMEM_GDA_NUM_USER_BUFFERS``
+        | Allocates the number of user buffers an application shall register with
+        | ``rocshmem_buffer_register``. If the application uses more user buffers than what is
+        | defined with the variable, then the behaviour is undefined.
+      - ``4``
+      - Number of user buffer registations
+
     * - | ``ROCSHMEM_MAX_WF_BUFFERS``
         | Maximum number of wavefront buffer arrays in default context (determines size of status, return, and atomic return buffers)
       - ``1024``

--- a/projects/rocshmem/docs/env_variables.rst
+++ b/projects/rocshmem/docs/env_variables.rst
@@ -174,11 +174,13 @@ control the behavior of rocSHMEM.
 
 
     * - | ``ROCSHMEM_GDA_NUM_USER_BUFFERS``
-        | Allocates the number of user buffers an application shall register with
-        | ``rocshmem_buffer_register``. If the application uses more user buffers than what is
-        | defined with the variable, then the behaviour is undefined.
+        | GDA supports ``rocshmem_buffer_register`` and ``rocshmem_buffer_unregister``
+        | for user buffers. This variable sets the number of user buffers an
+        | application may register when using the GDA backend.
+        | If the application uses more user buffers than what is defined with
+        | this variable, then the behavior is undefined.
       - ``4``
-      - Number of user buffer registations
+      - Maximum number of user buffer registrations for GDA
 
     * - | ``ROCSHMEM_MAX_WF_BUFFERS``
         | Maximum number of wavefront buffer arrays in default context (determines size of status, return, and atomic return buffers)

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -308,27 +308,25 @@ TestRMAPut() {
   ExecTest  "waveputnbi"       2       16           128       8
 
   ################################ User Buffer Tests ################################
-  if [[ $TEST != gda* ]]; then # AIROCSHMEM-383
-    export LOCALBUFTYPE=host
-    ExecTest  "putnbi"           2       32           128       512
-    unset LOCALBUFTYPE
+  export LOCALBUFTYPE=host
+  ExecTest  "putnbi"           2       32           128       512
+  unset LOCALBUFTYPE
 
-    export LOCALBUFTYPE=device
-    ExecTest  "putnbi"           2       32           128       512
-    unset LOCALBUFTYPE
+  export LOCALBUFTYPE=device
+  ExecTest  "putnbi"           2       32           128       512
+  unset LOCALBUFTYPE
 
-    export LOCALBUFTYPE=fine
-    ExecTest  "putnbi"           2       32           128       512
-    unset LOCALBUFTYPE
+  export LOCALBUFTYPE=fine
+  ExecTest  "putnbi"           2       32           128       512
+  unset LOCALBUFTYPE
 
-    export LOCALBUFTYPE=uncached
-    ExecTest  "putnbi"           2       32           128       512
-    unset LOCALBUFTYPE
+  export LOCALBUFTYPE=uncached
+  ExecTest  "putnbi"           2       32           128       512
+  unset LOCALBUFTYPE
 
-    export LOCALBUFTYPE=managed
-    ExecTest  "putnbi"           2       32           128       512
-    unset LOCALBUFTYPE
-  fi
+  export LOCALBUFTYPE=managed
+  ExecTest  "putnbi"           2       32           128       512
+  unset LOCALBUFTYPE
 }
 
 TestRMAGet() {
@@ -386,9 +384,8 @@ TestRMAGet() {
   else echo "Skip:   get_* (AIROCSHMEM-120: RO get tests abort)"; fi
 
   ################################ User Buffer Tests ################################
-  # AIROCSHMEM-383 for GDA
   # AIROCSHMEM-120 for RO
-  if [[ $TEST != gda* && $TEST != ro* ]]; then
+  if [[ $TEST != ro* ]]; then
     export LOCALBUFTYPE=host
     ExecTest  "getnbi"           2       32           128       512
     unset LOCALBUFTYPE

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -210,7 +210,7 @@ namespace envvar {
       "ROUND_ROBIN");
     const var<size_t> num_user_buffers("NUM_USER_BUFFERS",
       "Allocates the number of user buffers an application shall register with "
-      "rocshmem_buffer_register. The default value is 4");
+      "rocshmem_buffer_register. The default value is 4", 4);
   }  // namespace gda
 
   namespace _detail {

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -208,6 +208,9 @@ namespace envvar {
       "NIC-to-QP binding mode. ROUND_ROBIN: QPs within a context spread across NICs; "
       "PER_CONTEXT: all QPs in a context use one NIC, multi-NIC via multiple contexts",
       "ROUND_ROBIN");
+    const var<size_t> num_user_buffers("NUM_USER_BUFFERS",
+      "Allocates the number of user buffers an application shall register with "
+      "rocshmem_buffer_register. The default value is 4");
   }  // namespace gda
 
   namespace _detail {

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -208,8 +208,8 @@ namespace envvar {
       "NIC-to-QP binding mode. ROUND_ROBIN: QPs within a context spread across NICs; "
       "PER_CONTEXT: all QPs in a context use one NIC, multi-NIC via multiple contexts",
       "ROUND_ROBIN");
-    const var<size_t> num_user_buffers("NUM_USER_BUFFERS",
-      "Allocates the number of user buffers an application shall register with "
+    const var<size_t> num_user_buffers("MAX_NUM_USER_BUFFERS",
+      "Maximum number of user buffers an application can register with "
       "rocshmem_buffer_register. The default value is 4", 4);
   }  // namespace gda
 

--- a/projects/rocshmem/src/envvar.hpp
+++ b/projects/rocshmem/src/envvar.hpp
@@ -552,6 +552,7 @@ namespace envvar {
     extern const var<std::string> net_merge_level;
     extern const var<std::string> net_force_merge;
     extern const var<std::string> nic_policy;
+    extern const var<size_t> num_user_buffers;
   }  // namespace gda
 
   /**

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -566,7 +566,7 @@ void GDABackend::ctx_destroy(Context *ctx) {
 }
 
 int GDABackend::buffer_register(void *addr, size_t length) {
-  int err;
+  int err = ROCSHMEM_SUCCESS;
 
   /* Register in ptr cache */
   err = Backend::buffer_register(addr, length);
@@ -588,14 +588,21 @@ int GDABackend::buffer_register(void *addr, size_t length) {
 }
 
 int GDABackend::buffer_unregister(void *addr) {
-  int err;
+  int err = ROCSHMEM_SUCCESS;
 
   /* Deregister in ptr cache */
   err = Backend::buffer_unregister(addr);
 
+  if (ROCSHMEM_SUCCESS != err) {
+    return ROCSHMEM_ERROR;
+  }
+
   /* Deregister with QPs */
   for (size_t i = 0; i < num_qps; i++) {
     err = host_qps[i].buffer_unregister((uintptr_t)addr);
+    if (ROCSHMEM_SUCCESS != err) {
+      return ROCSHMEM_ERROR;
+    }
   }
 
   return err;

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -565,15 +565,40 @@ void GDABackend::ctx_destroy(Context *ctx) {
   delete gda_host_ctx;
 }
 
-int GDABackend::buffer_register([[maybe_unused]] void *addr,
-                                [[maybe_unused]] size_t length) {
-  LOG_ERROR("GDABackend::buffer_register not supported");
-  return ROCSHMEM_ERROR;
+int GDABackend::buffer_register(void *addr, size_t length) {
+  int err;
+
+  /* Register in ptr cache */
+  err = Backend::buffer_register(addr, length);
+
+  if (ROCSHMEM_SUCCESS != err) {
+    return ROCSHMEM_ERROR;
+  }
+
+  /* Register with QPs */
+  for (size_t i = 0; i < num_qps; i++) {
+    err = host_qps[i].buffer_register((uintptr_t)addr, length);
+    if (ROCSHMEM_SUCCESS != err) {
+      Backend::buffer_unregister(addr);
+      return ROCSHMEM_ERROR;
+    }
+  }
+
+  return err;
 }
 
-int GDABackend::buffer_unregister([[maybe_unused]] void *addr) {
-  LOG_ERROR("GDABackend::buffer_unregister not supported");
-  return ROCSHMEM_ERROR;
+int GDABackend::buffer_unregister(void *addr) {
+  int err;
+
+  /* Deregister in ptr cache */
+  err = Backend::buffer_unregister(addr);
+
+  /* Deregister with QPs */
+  for (size_t i = 0; i < num_qps; i++) {
+    err = host_qps[i].buffer_unregister((uintptr_t)addr);
+  }
+
+  return err;
 }
 
 void GDABackend::reset_backend_stats() {

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -567,6 +567,7 @@ void GDABackend::ctx_destroy(Context *ctx) {
 
 int GDABackend::buffer_register(void *addr, size_t length) {
   int err = ROCSHMEM_SUCCESS;
+  bool qp_registration_failed = false;
 
   /* Register in ptr cache */
   err = Backend::buffer_register(addr, length);
@@ -579,12 +580,15 @@ int GDABackend::buffer_register(void *addr, size_t length) {
   for (size_t i = 0; i < num_qps; i++) {
     err = host_qps[i].buffer_register((uintptr_t)addr, length);
     if (ROCSHMEM_SUCCESS != err) {
-      Backend::buffer_unregister(addr);
-      return ROCSHMEM_ERROR;
+      qp_registration_failed = true;
     }
   }
 
-  return err;
+  if (qp_registration_failed) {
+    Backend::buffer_unregister(addr);
+    return ROCSHMEM_ERROR;
+  }
+  return ROCSHMEM_SUCCESS;
 }
 
 int GDABackend::buffer_unregister(void *addr) {

--- a/projects/rocshmem/src/gda/backend_gda.hpp
+++ b/projects/rocshmem/src/gda/backend_gda.hpp
@@ -146,7 +146,7 @@ class GDABackend : public Backend {
    *        Populates nic_devices_ (always at least 1 entry).
    */
   void select_nics();
-  
+
   void configure_nic_policy();
   void log_ctx_nics(unsigned int ctx_id, size_t qps_per_pe, int qp_offset);
 

--- a/projects/rocshmem/src/gda/bnxt/backend_gda_bnxt.cpp
+++ b/projects/rocshmem/src/gda/bnxt/backend_gda_bnxt.cpp
@@ -88,6 +88,10 @@ void GDABackend::bnxt_initialize_gpu_qp(QueuePair* gpu_qp, int conn_num) {
 
   /* Export Inline Threshold */
   gpu_qp->inline_threshold = inline_threshold;
+
+  /* Base Heap information */
+  gpu_qp->base_heap = (uintptr_t) heap.get_local_heap_base();
+  gpu_qp->base_heap_size = heap.get_size();
 }
 
 void GDABackend::bnxt_create_cqs(int cqe) {

--- a/projects/rocshmem/src/gda/bnxt/queue_pair_bnxt.cpp
+++ b/projects/rocshmem/src/gda/bnxt/queue_pair_bnxt.cpp
@@ -267,7 +267,7 @@ __device__ void QueuePair::bnxt_write_rma_wqe(uintptr_t raddr, uintptr_t laddr, 
   if (!inline_msg) {
     /* Populate SG Segment */
     sge.pa     = laddr;
-    sge.lkey   = lkey;
+    sge.lkey   = get_lkey(laddr);
     sge.length = length;
   }
 

--- a/projects/rocshmem/src/gda/context_gda_device.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device.cpp
@@ -64,11 +64,6 @@ __host__ GDAContext::GDAContext(Backend *b, unsigned int ctx_id, int gda_provide
                       num_qps * sizeof(QueuePair),
                       hipMemcpyDefault));
 
-  for (uint32_t i = 0; i < num_qps; i++) {
-    qps[i].base_heap = (uintptr_t) base_heap[my_pe];
-    qps[i].base_heap_size = backend->heap.get_size();
-  }
-
   ipcImpl_.ipc_bases = backend->ipcImpl.ipc_bases;
   ipcImpl_.shm_size = backend->ipcImpl.shm_size;
   ipcImpl_.shm_rank = backend->ipcImpl.shm_rank;

--- a/projects/rocshmem/src/gda/context_gda_device.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device.cpp
@@ -65,7 +65,8 @@ __host__ GDAContext::GDAContext(Backend *b, unsigned int ctx_id, int gda_provide
                       hipMemcpyDefault));
 
   for (uint32_t i = 0; i < num_qps; i++) {
-    qps[i].base_heap = base_heap;
+    qps[i].base_heap = (uintptr_t) base_heap[my_pe];
+    qps[i].base_heap_size = backend->heap.get_size();
   }
 
   ipcImpl_.ipc_bases = backend->ipcImpl.ipc_bases;

--- a/projects/rocshmem/src/gda/ibv_wrapper.cpp
+++ b/projects/rocshmem/src/gda/ibv_wrapper.cpp
@@ -225,7 +225,14 @@ int IBVWrapper::dealloc_pd(struct ibv_pd *pd) {
 }
 
 struct ibv_mr* IBVWrapper::reg_mr(struct ibv_pd* pd, void* addr, size_t length, int access, HIPAllocator *allocator) {
-  if (is_dmabuf_supported()) {
+  hipPointerAttribute_t attr;
+  bool is_device_ptr = false;
+
+  CHECK_HIP(hipPointerGetAttributes(&attr, addr));
+
+  is_device_ptr = attr.type == hipMemoryTypeDevice;
+
+  if (is_dmabuf_supported() && is_device_ptr) {
     struct ibv_mr *mr;
     uint64_t offset = 0;
     int fd = 0;

--- a/projects/rocshmem/src/gda/ionic/backend_gda_ionic.cpp
+++ b/projects/rocshmem/src/gda/ionic/backend_gda_ionic.cpp
@@ -116,6 +116,10 @@ void GDABackend::ionic_initialize_gpu_qp(QueuePair* gpu_qp, int conn_num) {
   gpu_qp->lkey = nic.heap_mr->lkey;
   gpu_qp->rkey = heap_rkey[pe * num_nics_ + nic_idx];
   gpu_qp->inline_threshold = 32;
+
+  /* Base Heap information */
+  gpu_qp->base_heap = (uintptr_t) heap.get_local_heap_base();
+  gpu_qp->base_heap_size = heap.get_size();
 }
 
 void GDABackend::ionic_setup_parent_domain(NicDevice &nic, struct ibv_parent_domain_init_attr* pattr) {

--- a/projects/rocshmem/src/gda/ionic/queue_pair_ionic.cpp
+++ b/projects/rocshmem/src/gda/ionic/queue_pair_ionic.cpp
@@ -337,7 +337,7 @@ __device__ void QueuePair::ionic_post_wqe_rma(int32_t size, uintptr_t laddr,
     } else {
       wqe->common.pld.sgl[0].va = byteswap<uint64_t>(laddr);
       wqe->common.pld.sgl[0].len = byteswap<uint32_t>(size);
-      wqe->common.pld.sgl[0].lkey = byteswap<uint32_t>(lkey);
+      wqe->common.pld.sgl[0].lkey = byteswap<uint32_t>(get_lkey(laddr));
     }
   }
 
@@ -389,7 +389,7 @@ __device__ void QueuePair::ionic_post_wqe_rma_single(int32_t size,
     } else {
       wqe->common.pld.sgl[0].va = byteswap<uint64_t>(laddr);
       wqe->common.pld.sgl[0].len = byteswap<uint32_t>(size);
-      wqe->common.pld.sgl[0].lkey = byteswap<uint32_t>(lkey);
+      wqe->common.pld.sgl[0].lkey = byteswap<uint32_t>(get_lkey(laddr));
     }
   }
 

--- a/projects/rocshmem/src/gda/mlx5/backend_gda_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/backend_gda_mlx5.cpp
@@ -118,6 +118,10 @@ void GDABackend::mlx5_initialize_gpu_qp(QueuePair* gpu_qp, int conn_num) {
   gpu_qp->lkey = htobe32(nic.heap_mr->lkey);
   gpu_qp->qp_num = qp.qpn;
   gpu_qp->inline_threshold = inline_threshold;
+
+  /* Base Heap information */
+  gpu_qp->base_heap = (uintptr_t) heap.get_local_heap_base();
+  gpu_qp->base_heap_size = heap.get_size();
 }
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
@@ -271,7 +271,7 @@ __device__ void QueuePair::mlx5_post_wqe_rma(int32_t length, uintptr_t laddr, ui
 
   // construct the WQE on the stack
   gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, MLX5_WQE_CTRL_CQ_UPDATE,
-                   raddr, rkey, laddr, lkey, static_cast<uint32_t>(length), send_inline};
+                   raddr, rkey, laddr, get_lkey(laddr), static_cast<uint32_t>(length), send_inline};
 
   // copy to SQ
   mlx5_sq.buf[sq_idx] = wqe;
@@ -303,7 +303,7 @@ __device__ void QueuePair::mlx5_post_wqe_rma_single(int32_t length, uintptr_t la
 
   // construct the WQE on the stack
   gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, MLX5_WQE_CTRL_CQ_UPDATE,
-                   raddr, rkey, laddr, lkey, static_cast<uint32_t>(length), send_inline};
+                   raddr, rkey, laddr, get_lkey(laddr), static_cast<uint32_t>(length), send_inline};
 
   // copy to SQ
   mlx5_sq.buf[sq_idx] = wqe;

--- a/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
@@ -271,7 +271,9 @@ __device__ void QueuePair::mlx5_post_wqe_rma(int32_t length, uintptr_t laddr, ui
 
   // construct the WQE on the stack
   gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, MLX5_WQE_CTRL_CQ_UPDATE,
-                   raddr, rkey, laddr, get_lkey(laddr), static_cast<uint32_t>(length), send_inline};
+                   raddr, rkey, laddr,
+                   send_inline ? 0 : get_lkey(laddr),
+                   static_cast<uint32_t>(length), send_inline};
 
   // copy to SQ
   mlx5_sq.buf[sq_idx] = wqe;

--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -372,7 +372,13 @@ int QueuePair::buffer_register(uintptr_t addr, size_t length) {
     if (user_buf_info[i].addr == 0) {
       user_buf_info[i].addr   = addr;
       user_buf_info[i].length = length;
-      user_buf_info[i].lkey   = mr->lkey;
+
+      if (gda_provider_ == GDAProvider::MLX5) {
+        user_buf_info[i].lkey = htobe32(mr->lkey);
+      } else {
+        user_buf_info[i].lkey = mr->lkey;
+      }
+
       break;
     }
   }
@@ -399,7 +405,6 @@ int QueuePair::buffer_unregister(uintptr_t addr) {
 }
 
 __device__ uint32_t QueuePair::get_lkey(uintptr_t addr) {
-
   /* Check if in heap */
   if (is_ptr_in_range(base_heap, base_heap_size, addr)) {
     return lkey;
@@ -407,7 +412,10 @@ __device__ uint32_t QueuePair::get_lkey(uintptr_t addr) {
 
   /* Get the correct lkey for the user buffer */
   for (size_t i=0; i<num_user_buffers; i++) {
-    if (is_ptr_in_range(user_buf_info[i].addr, user_buf_info[i].length, addr)) {
+    uintptr_t uaddr = user_buf_info[i].addr;
+    size_t uaddr_len = user_buf_info[i].length;
+
+    if (is_ptr_in_range(uaddr, uaddr_len, addr)) {
       return user_buf_info[i].lkey;
     }
   }

--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -398,4 +398,22 @@ int QueuePair::buffer_unregister(uintptr_t addr) {
   return ROCSHMEM_SUCCESS;
 }
 
+__device__ uint32_t QueuePair::get_lkey(uintptr_t addr) {
+
+  /* Check if in heap */
+  if (is_ptr_in_range(base_heap, base_heap_size, addr)) {
+    return lkey;
+  }
+
+  /* Get the correct lkey for the user buffer */
+  for (size_t i=0; i<num_user_buffers; i++) {
+    if (is_ptr_in_range(user_buf_info[i].addr, user_buf_info[i].length, addr)) {
+      return user_buf_info[i].lkey;
+    }
+  }
+
+  LOGD_ERROR_ABORT("Valid lkey buffer not found");
+  return 0;
+}
+
 }  // namespace rocshmem

--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -100,6 +100,13 @@ QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider) {
     assert(false /* invalid nic provider */);
   }
   gda_provider_ = gda_provider;
+
+  /* Setup User Buffer Registration Mechanism */
+  pd_ = pd;
+  num_user_buffers = envvar::gda::num_user_buffers;
+
+  CHECK_HIP(hipMalloc(&user_buf_info, sizeof(struct user_buf_info_t) *  num_user_buffers));
+  CHECK_HIP(hipMemset(user_buf_info, 0, sizeof(struct user_buf_info_t) *  num_user_buffers));
 }
 
 QueuePair::~QueuePair() {
@@ -116,6 +123,11 @@ QueuePair::~QueuePair() {
 
   fetching_atomic_freelist->~FreeListT();
   allocator.deallocate((void*)fetching_atomic_freelist);
+
+  if (user_buf_info) {
+    CHECK_HIP(hipFree(user_buf_info));
+    user_buf_info = nullptr;
+  }
 }
 
 __device__ uint64_t QueuePair::get_same_qp_lane_mask() {
@@ -330,6 +342,60 @@ __device__ void QueuePair::atomic_nofetch(void *dest, int64_t atomic_data,
 __device__ void QueuePair::atomic_nofetch_single(void *dest, int64_t value) {
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
   post_wqe_amo_single(dst, gda_op_atomic_fa, value, 0, false);
+}
+
+int QueuePair::buffer_register(uintptr_t addr, size_t length) {
+  struct ibv_mr *mr = nullptr;
+  int access = 0;
+
+  if (user_buffer_mrs.size() >= num_user_buffers) {
+    LOG_WARN("Unable to register user buffer with QP. "
+             "Please increase the value of ROCSHMEM_GDA_NUM_USER_BUFFERS");
+    return ROCSHMEM_ERROR;
+  }
+
+  access = IBV_ACCESS_LOCAL_WRITE
+         | IBV_ACCESS_REMOTE_WRITE
+         | IBV_ACCESS_REMOTE_READ
+         | IBV_ACCESS_REMOTE_ATOMIC;
+
+  if (envvar::gda::pcie_relaxed_ordering) {
+    access |= IBV_ACCESS_RELAXED_ORDERING;
+  }
+
+  mr = ibv.reg_mr(pd_, (void*)addr, length, access, &allocator);
+  CHECK_NNULL(mr, "ibv_reg_mr (buffer_register)");
+
+  user_buffer_mrs[addr] = mr;
+
+  for (size_t i=0; i<num_user_buffers; i++) {
+    if (user_buf_info[i].addr == 0) {
+      user_buf_info[i].addr   = addr;
+      user_buf_info[i].length = length;
+      user_buf_info[i].lkey   = mr->lkey;
+      break;
+    }
+  }
+
+  return ROCSHMEM_SUCCESS;
+}
+
+int QueuePair::buffer_unregister(uintptr_t addr) {
+  int err;
+
+  for (size_t i=0; i<num_user_buffers; i++) {
+    if (is_ptr_in_range(user_buf_info[i].addr, user_buf_info[i].length, addr)) {
+      CHECK_HIP(hipMemset(&user_buf_info[i], 0, sizeof(struct user_buf_info_t)));
+      break;
+    }
+  }
+
+  err = ibv.dereg_mr(user_buffer_mrs[addr]);
+  CHECK_ZERO(err, "ibv_dereg_mr (buffer_unregister)");
+
+  user_buffer_mrs.erase(addr);
+
+  return ROCSHMEM_SUCCESS;
 }
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -254,7 +254,8 @@ class QueuePair {
   __device__ int64_t atomic_cas_nofetch(void *dest, int64_t atomic_data,
       int64_t atomic_cmp, ActiveWFInfo &wf_info);
 
-  char *const *base_heap{nullptr};
+  uintptr_t base_heap = 0;
+  size_t base_heap_size = 0;
 
  private:
   /**
@@ -487,6 +488,8 @@ class QueuePair {
 
   int buffer_register(uintptr_t addr, size_t length);
   int buffer_unregister(uintptr_t addr);
+
+  __device__ uint32_t get_lkey(uintptr_t addr);
 };
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -48,9 +48,17 @@
 #include "containers/free_list.hpp"
 #include "memory/hip_allocator.hpp"
 
+#include <map>
+
 namespace rocshmem {
 
 class GDABackend;
+
+struct user_buf_info_t {
+  uintptr_t addr;
+  size_t    length;
+  uint32_t  lkey;
+};
 
 /**
  * @brief Scope at which WQEs are issued and completed. This is used to
@@ -470,6 +478,15 @@ class QueuePair {
   uint8_t gda_op_rdma_read;
   uint8_t gda_op_atomic_fa;
   uint8_t gda_op_atomic_cs;
+
+  struct ibv_pd* pd_;
+  std::map<uintptr_t, struct ibv_mr*> user_buffer_mrs;
+
+  struct user_buf_info_t *user_buf_info = nullptr;
+  size_t num_user_buffers = 0;
+
+  int buffer_register(uintptr_t addr, size_t length);
+  int buffer_unregister(uintptr_t addr);
 };
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -484,6 +484,14 @@ __device__ __forceinline__ bool is_last_active_lane() {
   }
 }
 
+/* Is ptr_b in range [ptr_a, ptr_a + len_a] */
+[[maybe_unused]]
+__host__ __device__ static bool
+is_ptr_in_range(uintptr_t ptr_a, size_t len_a, uintptr_t ptr_b) {
+  uintptr_t ptr_a_end = ptr_a + len_a;
+  return (ptr_a <= ptr_b) && (ptr_b <= ptr_a_end);
+}
+
 int rocm_init();
 
 void rocm_memory_lock_to_fine_grain(void* ptr, size_t size, void** gpu_ptr, int gpu_id);

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -484,12 +484,16 @@ __device__ __forceinline__ bool is_last_active_lane() {
   }
 }
 
-/* Is ptr_b in range [ptr_a, ptr_a + len_a] */
+/* Is ptr_b in range [ptr_a, ptr_a + len_a) */
 [[maybe_unused]]
 __host__ __device__ static bool
 is_ptr_in_range(uintptr_t ptr_a, size_t len_a, uintptr_t ptr_b) {
-  uintptr_t ptr_a_end = ptr_a + len_a;
-  return (ptr_a <= ptr_b) && (ptr_b <= ptr_a_end);
+
+  if ((len_a == 0) || (ptr_b < ptr_a)) {
+    return false;
+  }
+
+  return static_cast<size_t>(ptr_b - ptr_a) < len_a;
 }
 
 int rocm_init();

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -874,6 +874,8 @@ double Tester::timerAvgInMicroseconds() {
 
 void* Tester::alloc_test_buffer(size_t size, enum UserBufType user_buf_type) {
   void *buffer;
+  int err = ROCSHMEM_SUCCESS;
+
   switch (user_buf_type) {
     case USER_BUF_TYPE_HOST:
       CHECK_HIP(hipHostMalloc(&buffer, size));
@@ -904,25 +906,40 @@ void* Tester::alloc_test_buffer(size_t size, enum UserBufType user_buf_type) {
         std::cerr << "buffer: " << (uintptr_t) buffer << std::endl;
         exit(-1);
       }
-      break;
+      return buffer;
   }
+
+  err = rocshmem_buffer_register(buffer, size);
+
+  if (ROCSHMEM_SUCCESS != err) {
+    return nullptr;
+  }
+
   return buffer;
 }
 
 void Tester::free_test_buffer(void *buffer, enum UserBufType user_buf_type) {
+  int err = ROCSHMEM_SUCCESS;
+
   switch (user_buf_type) {
     case USER_BUF_TYPE_HOST:
+      err = rocshmem_buffer_unregister(buffer);
       CHECK_HIP(hipHostFree(buffer));
       break;
     case USER_BUF_TYPE_DEVICE:
     case USER_BUF_TYPE_FINE:
     case USER_BUF_TYPE_UNCACHED:
     case USER_BUF_TYPE_MANAGED:
+      err = rocshmem_buffer_unregister(buffer);
       CHECK_HIP(hipFree(buffer));
       break;
     case USER_BUF_TYPE_HEAP:
     default:
       rocshmem_free(buffer);
       break;
+  }
+
+  if (ROCSHMEM_SUCCESS != err) {
+    fprintf(stderr, "Deregistration Error");
   }
 }


### PR DESCRIPTION
## Motivation

Implement rocshmem_buffer_register/unregister for GDA

## Technical Details

- Use existing registration checking used for IPC and RO
- Register an MR for the user buffer and create a new lkey
- At runtime check if pointer is in heap, if so, return default lkey, otherwise search for the correct lkey

## JIRA ID

AIROCSHMEM-383

## Test Plan

Test unit tests and functional tests

- [x] mlx5
- [x] bnxt
- [x] ionic
