### PR TITLE
perfxpert: redact SDK payload path fields

### DIFF
--- a/experimental/python/perfxpert/perfxpert/agents/framework.py
+++ b/experimental/python/perfxpert/perfxpert/agents/framework.py
@@ -21,6 +21,7 @@ Runtime guardrails:
 
 from __future__ import annotations
 
+from functools import wraps
 import inspect
 import json
 import logging
@@ -38,6 +39,7 @@ from perfxpert.providers._exceptions import (
     TimeoutError,
     TransientError,
 )
+from perfxpert.providers._sanitization import sanitize_value
 
 # SDK import is lazy + isolated to this file — never in agent modules.
 #
@@ -359,14 +361,19 @@ def _normalize_provider_exception(provider: str, exc: BaseException) -> Provider
     return _map_exception_by_message(provider, exc)
 
 
-def _serialize_input(input_payload: Any) -> str:
-    """Coerce an arbitrary payload into the string the SDK Runner expects."""
-    if isinstance(input_payload, str):
-        return input_payload
+def _serialize_input(
+    input_payload: Any,
+    *,
+    token_to_raw_path: Optional[Dict[str, str]] = None,
+) -> str:
+    """Render sanitized provider-bound input, optionally seeding SDK path tokens."""
+    sanitized = sanitize_value(input_payload, token_to_raw_path=token_to_raw_path)
+    if isinstance(sanitized, str):
+        return sanitized
     try:
-        return json.dumps(input_payload, default=str)
+        return json.dumps(sanitized, default=str)
     except (TypeError, ValueError):
-        return str(input_payload)
+        return str(sanitized)
 
 
 def _sanitize_tool_name(name: str) -> str:
@@ -376,20 +383,41 @@ def _sanitize_tool_name(name: str) -> str:
     return name.replace(".", "_")
 
 
-def _prepare_tool_callable_for_sdk(fn: Callable[..., Any], tool_name: str) -> Callable[..., Any]:
-    """Ensure SDK introspection has function metadata for bound callables."""
-    safe_name = _sanitize_tool_name(tool_name)
-    if inspect.isfunction(fn) or inspect.ismethod(fn):
-        if not getattr(fn, "__name__", None):
-            try:
-                setattr(fn, "__name__", safe_name)
-                setattr(fn, "__qualname__", safe_name)
-            except Exception:  # pragma: no cover - unusual callable object
-                pass
-        return fn
+def _restore_path_tokens(value: Any, token_to_raw_path: Optional[Dict[str, str]]) -> Any:
+    """Turn provider-visible path tokens back into local paths for tool calls."""
+    if not token_to_raw_path:
+        return value
+    if isinstance(value, str):
+        return token_to_raw_path.get(value, value)
+    if isinstance(value, list):
+        return [_restore_path_tokens(item, token_to_raw_path) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_restore_path_tokens(item, token_to_raw_path) for item in value)
+    if isinstance(value, dict):
+        return {
+            item_key: _restore_path_tokens(item, token_to_raw_path)
+            for item_key, item in value.items()
+        }
+    return value
 
+
+def _wrap_sdk_tool_boundary(
+    fn: Callable[..., Any],
+    tool_name: str,
+    *,
+    token_to_raw_path: Optional[Dict[str, str]] = None,
+) -> Callable[..., Any]:
+    """Restore inbound path tokens locally and redact outbound SDK tool results."""
+    safe_name = _sanitize_tool_name(tool_name)
+
+    @wraps(fn)
     def _sdk_tool_wrapper(*args: Any, **kwargs: Any) -> Any:
-        return fn(*args, **kwargs)
+        restored_args = tuple(_restore_path_tokens(arg, token_to_raw_path) for arg in args)
+        restored_kwargs = {
+            key: _restore_path_tokens(value, token_to_raw_path)
+            for key, value in kwargs.items()
+        }
+        return sanitize_value(fn(*restored_args, **restored_kwargs))
 
     _sdk_tool_wrapper.__name__ = safe_name
     _sdk_tool_wrapper.__qualname__ = safe_name
@@ -400,7 +428,11 @@ def _prepare_tool_callable_for_sdk(fn: Callable[..., Any], tool_name: str) -> Ca
     return _sdk_tool_wrapper
 
 
-def _translate_tools(tools: List[ToolBinding]) -> List[Any]:
+def _translate_tools(
+    tools: List[ToolBinding],
+    *,
+    token_to_raw_path: Optional[Dict[str, str]] = None,
+) -> List[Any]:
     """Wrap our ToolBinding list in openai-agents function_tool decorators.
 
     The SDK expects FunctionTool objects; we wrap each binding's plain
@@ -413,7 +445,11 @@ def _translate_tools(tools: List[ToolBinding]) -> List[Any]:
     wrapped: List[Any] = []
     for tb in tools:
         try:
-            sdk_callable = _prepare_tool_callable_for_sdk(tb.fn, tb.name)
+            sdk_callable = _wrap_sdk_tool_boundary(
+                tb.fn,
+                tb.name,
+                token_to_raw_path=token_to_raw_path,
+            )
             wrapped.append(
                 sdk_function_tool(
                     sdk_callable,
@@ -552,11 +588,14 @@ def _sdk_invoke(agent: "Agent", input_payload: Any, provider: str) -> FakeProvid
         )
 
     model = _resolve_model(provider)
-    tools = _translate_tools(list(agent.tools))
+    token_to_raw_path: Dict[str, str] = {}
+    input_str = _serialize_input(input_payload, token_to_raw_path=token_to_raw_path)
+    tools = _translate_tools(list(agent.tools), token_to_raw_path=token_to_raw_path)
     instructions = agent.fence_text or (
         f"You are the {agent.name} agent. "
         "Follow the JSON payload contract defined in the perfxpert fence."
     )
+    instructions = sanitize_value(instructions)
 
     try:
         sdk_agent = SdkAgent(
@@ -573,8 +612,6 @@ def _sdk_invoke(agent: "Agent", input_payload: Any, provider: str) -> FakeProvid
         max_turns = max(1, int(max_turns_env))
     except ValueError:
         max_turns = 10
-
-    input_str = _serialize_input(input_payload)
 
     try:
         run_config = _build_sdk_run_config(provider)

--- a/experimental/python/perfxpert/perfxpert/providers/_sanitization.py
+++ b/experimental/python/perfxpert/perfxpert/providers/_sanitization.py
@@ -7,8 +7,10 @@ These helpers are pure, deterministic, and unit-testable.
 
 from __future__ import annotations
 
+import dataclasses
+import os
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 _PATH_PATTERN = re.compile(
     r'(/home/[^\s,"\';>]+|/opt/[^\s,"\';>]+|/root/[^\s,"\';>]+|'
@@ -17,6 +19,16 @@ _PATH_PATTERN = re.compile(
 
 # Regex to match relative path traversal (e.g. ../../secret/file)
 _RELATIVE_PATH_PATTERN = re.compile(r'(?:\.\./)+\S+')
+
+_PATH_FIELD_NAMES = {
+    "att_dir",
+    "baseline_db",
+    "database_path",
+    "db_path",
+    "new_db",
+    "project_root",
+    "source_dir",
+}
 
 
 def redact_paths(value: str) -> str:
@@ -29,14 +41,72 @@ def redact_paths(value: str) -> str:
     return result
 
 
-def sanitize_value(value: Any) -> Any:
+def _is_path_field(key: Optional[str]) -> bool:
+    if key is None:
+        return False
+    normalized = key.lower()
+    return (
+        normalized in _PATH_FIELD_NAMES
+        or normalized.endswith("_path")
+        or normalized.endswith("_dir")
+    )
+
+
+def _path_redaction_value(
+    key: Optional[str],
+    value: str,
+    token_to_raw_path: Optional[Dict[str, str]],
+) -> str:
+    """Return a provider-safe redaction, optionally recording token -> raw path."""
+    if token_to_raw_path is None:
+        return "[REDACTED_PATH]"
+
+    token_name = re.sub(r"[^a-z0-9_]+", "_", (key or "path").lower()).strip("_")
+    token_name = token_name or "path"
+    token = f"[REDACTED_PATH:{token_name}]"
+    if token_to_raw_path.get(token) == value:
+        return token
+
+    suffix = 2
+    while token in token_to_raw_path:
+        token = f"[REDACTED_PATH:{token_name}_{suffix}]"
+        if token_to_raw_path.get(token) == value:
+            return token
+        suffix += 1
+
+    token_to_raw_path[token] = value
+    return token
+
+
+def sanitize_value(
+    value: Any,
+    *,
+    key: Optional[str] = None,
+    token_to_raw_path: Optional[Dict[str, str]] = None,
+) -> Any:
     """Recursively redact path-like strings in provider-bound payloads."""
+    if hasattr(value, "model_dump"):
+        return sanitize_value(value.model_dump(), key=key, token_to_raw_path=token_to_raw_path)
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return sanitize_value(dataclasses.asdict(value), key=key, token_to_raw_path=token_to_raw_path)
+    if isinstance(value, os.PathLike):
+        return _path_redaction_value(key, os.fspath(value), token_to_raw_path)
     if isinstance(value, str):
+        if _is_path_field(key) and value:
+            return _path_redaction_value(key, value, token_to_raw_path)
         return redact_paths(value)
-    if isinstance(value, list):
-        return [sanitize_value(item) for item in value]
+    if isinstance(value, (list, tuple)):
+        return [sanitize_value(item, key=key, token_to_raw_path=token_to_raw_path) for item in value]
+    if isinstance(value, (set, frozenset)):
+        return [
+            sanitize_value(item, key=key, token_to_raw_path=token_to_raw_path)
+            for item in sorted(value, key=repr)
+        ]
     if isinstance(value, dict):
-        return {key: sanitize_value(item) for key, item in value.items()}
+        return {
+            item_key: sanitize_value(item, key=str(item_key), token_to_raw_path=token_to_raw_path)
+            for item_key, item in value.items()
+        }
     return value
 
 

--- a/experimental/python/perfxpert/tests/test_agents/test_framework.py
+++ b/experimental/python/perfxpert/tests/test_agents/test_framework.py
@@ -1,7 +1,10 @@
 """Tests for perfxpert.agents.framework — the SDK facade."""
 
 import inspect
+import json
+from dataclasses import dataclass
 from functools import partial
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -14,6 +17,7 @@ from perfxpert.agents.framework import (
     ToolBinding,
     run_agent,
 )
+from perfxpert.agents.schemas import AnalysisInput
 
 # -- AgentSpec / Agent construction ----------------------------------------
 
@@ -356,12 +360,176 @@ def test_sdk_invoke_wires_openai_agents_sdk(monkeypatch):
     assert isinstance(resp, FakeProviderResponse)
     assert resp.structured_output == {"narrative": "hello", "recommendations": []}
     # The SDK receives a sanitized tool name (dots → underscores)
-    assert captured["tools"] == [{"name": "intent_classify", "fn": _noop}]
+    assert captured["tools"][0]["name"] == "intent_classify"
+    assert captured["tools"][0]["fn"].__name__ == "intent_classify"
     # Default max_turns=10 when PERFXPERT_AGENTS_MAX_TURNS unset
     assert captured["max_turns"] == 10
     # Model resolved from _DEFAULT_MODELS["openai"]
     assert captured["model"] == "gpt-4o-mini"
     assert captured["run_config"] == {"kwargs": {}}
+
+
+@pytest.mark.parametrize("provider", ["openai", "anthropic", "private", "ollama"])
+def test_sdk_invoke_redacts_path_fields_before_runner(monkeypatch, provider):
+    from perfxpert.agents import framework
+
+    captured = {}
+
+    class _FakeSdkAgent:
+        def __init__(self, **_kwargs):
+            pass
+
+    class _FakeRunner:
+        @staticmethod
+        def run_sync(*, starting_agent, input, max_turns, run_config):
+            captured["input"] = input
+            return SimpleNamespace(final_output='{"narrative": "ok"}', new_items=[])
+
+    monkeypatch.setattr(framework, "_SDK_AVAILABLE", True)
+    monkeypatch.setattr(framework, "SdkAgent", _FakeSdkAgent)
+    monkeypatch.setattr(framework, "SdkRunner", _FakeRunner)
+    monkeypatch.setattr(framework, "SdkRunConfig", lambda **kwargs: {"kwargs": kwargs})
+    monkeypatch.setattr(framework, "_build_sdk_run_config", lambda _provider: {"kwargs": {}})
+
+    agent = Agent(
+        name="T",
+        layer=1,
+        fence_path=None,
+        input_schema=dict,
+        output_schema=dict,
+        tools=[],
+    )
+    payload = {
+        "user_query": "Analyze this trace",
+        "database_path": "/home/example/private/trace.db",
+        "source_dir": "demo-app/customer-project",
+        "analysis_options": {"att_dir": "att-output"},
+    }
+
+    framework._sdk_invoke(agent, payload, provider=provider)
+
+    provider_input = captured["input"]
+    parsed = json.loads(provider_input)
+    assert parsed == {
+        "user_query": "Analyze this trace",
+        "database_path": "[REDACTED_PATH:database_path]",
+        "source_dir": "[REDACTED_PATH:source_dir]",
+        "analysis_options": {"att_dir": "[REDACTED_PATH:att_dir]"},
+    }
+    assert "/home/example/private/trace.db" not in provider_input
+    assert "demo-app/customer-project" not in provider_input
+    assert "att-output" not in provider_input
+    assert provider_input.count("[REDACTED_PATH:") == 3
+
+
+def test_sdk_invoke_redacts_instructions_before_sdk_agent(monkeypatch, tmp_path):
+    from perfxpert.agents import framework
+
+    captured = {}
+
+    class _FakeSdkAgent:
+        def __init__(self, *, name, instructions, tools, model):
+            captured["instructions"] = instructions
+
+    class _FakeRunner:
+        @staticmethod
+        def run_sync(*, starting_agent, input, max_turns, run_config):
+            return SimpleNamespace(final_output='{"narrative": "ok"}', new_items=[])
+
+    monkeypatch.setattr(framework, "_SDK_AVAILABLE", True)
+    monkeypatch.setattr(framework, "SdkAgent", _FakeSdkAgent)
+    monkeypatch.setattr(framework, "SdkRunner", _FakeRunner)
+    monkeypatch.setattr(framework, "SdkRunConfig", lambda **kwargs: {"kwargs": kwargs})
+    monkeypatch.setattr(framework, "_build_sdk_run_config", lambda _provider: {"kwargs": {}})
+
+    fence = tmp_path / "fence.md"
+    fence.write_text("Inspect /home/example/private/fence.md before responding.\n")
+    agent = Agent(
+        name="T",
+        layer=1,
+        fence_path=str(fence),
+        input_schema=dict,
+        output_schema=dict,
+        tools=[],
+    )
+
+    framework._sdk_invoke(agent, {"user_query": "?"}, provider="openai")
+
+    assert "/home/example/private/fence.md" not in captured["instructions"]
+    assert "[REDACTED]" in captured["instructions"]
+
+
+def test_sdk_serialize_redacts_pathlike_schema_payloads():
+    payload = AnalysisInput(
+        database_path="/home/example/private/trace.db",
+        att_dir="att-output",
+    )
+    rendered = framework._serialize_input(payload)
+
+    parsed = json.loads(rendered)
+    assert parsed["database_path"] == "[REDACTED_PATH]"
+    assert parsed["att_dir"] == "[REDACTED_PATH]"
+    assert "/home/example/private/trace.db" not in rendered
+    assert "att-output" not in rendered
+
+
+def test_sdk_serialize_redacts_pathlike_values_by_key():
+    rendered = framework._serialize_input(
+        {
+            "source_dir": Path("/home/example/private/source"),
+            "analysis_options": {"att_dir": Path("att-output")},
+        }
+    )
+
+    parsed = json.loads(rendered)
+    assert parsed == {
+        "source_dir": "[REDACTED_PATH]",
+        "analysis_options": {"att_dir": "[REDACTED_PATH]"},
+    }
+    assert "/home/example/private/source" not in rendered
+    assert "att-output" not in rendered
+
+
+def test_sdk_serialize_redacts_dataclass_payload_paths():
+    @dataclass(frozen=True)
+    class _Payload:
+        user_query: str
+        database_path: Path
+        source_dir: str
+
+    rendered = framework._serialize_input(
+        _Payload(
+            user_query="Analyze",
+            database_path=Path("/home/example/private/trace.db"),
+            source_dir="demo-app/customer-project",
+        )
+    )
+
+    parsed = json.loads(rendered)
+    assert parsed == {
+        "user_query": "Analyze",
+        "database_path": "[REDACTED_PATH]",
+        "source_dir": "[REDACTED_PATH]",
+    }
+    assert "/home/example/private/trace.db" not in rendered
+    assert "demo-app/customer-project" not in rendered
+
+
+def test_sdk_serialize_redacts_tuple_and_set_path_carriers():
+    rendered = framework._serialize_input(
+        {
+            "include_path": (Path("private/include"),),
+            "metadata": {Path("runs/new.db")},
+        }
+    )
+
+    parsed = json.loads(rendered)
+    assert parsed == {
+        "include_path": ["[REDACTED_PATH]"],
+        "metadata": ["[REDACTED_PATH]"],
+    }
+    assert "private/include" not in rendered
+    assert "runs/new.db" not in rendered
 
 
 def test_translate_tools_accepts_partial_callables(monkeypatch):
@@ -383,6 +551,85 @@ def test_translate_tools_accepts_partial_callables(monkeypatch):
     assert wrapped[0]["name"] == "tasks_create"
     assert wrapped[0]["fn"]("check") == "demo-app:check"
     assert str(inspect.signature(wrapped[0]["fn"])) == "(title)"
+
+
+def test_translate_tools_redacts_sdk_tool_return_paths(monkeypatch):
+    def _fake_function_tool(fn, *, name_override, strict_mode):
+        return {"name": name_override, "fn": fn}
+
+    def _diff_result():
+        return {
+            "baseline_db": "/home/example/private/baseline.db",
+            "new_db": Path("runs/new.db"),
+            "summary": "ok",
+        }
+
+    monkeypatch.setattr(framework, "sdk_function_tool", _fake_function_tool)
+
+    wrapped = framework._translate_tools(
+        [ToolBinding(name="trace_diff.diff_runs", fn=_diff_result)]
+    )
+    result = wrapped[0]["fn"]()
+
+    assert result == {
+        "baseline_db": "[REDACTED_PATH]",
+        "new_db": "[REDACTED_PATH]",
+        "summary": "ok",
+    }
+
+
+def test_translate_tools_redacts_top_level_pathlike_tool_return(monkeypatch):
+    def _fake_function_tool(fn, *, name_override, strict_mode):
+        return {"name": name_override, "fn": fn}
+
+    monkeypatch.setattr(framework, "sdk_function_tool", _fake_function_tool)
+
+    wrapped = framework._translate_tools(
+        [ToolBinding(name="trace_diff.latest_db", fn=lambda: Path("runs/new.db"))]
+    )
+
+    assert wrapped[0]["fn"]() == "[REDACTED_PATH]"
+
+
+def test_translate_tools_redacts_sequence_tool_return_paths(monkeypatch):
+    def _fake_function_tool(fn, *, name_override, strict_mode):
+        return {"name": name_override, "fn": fn}
+
+    monkeypatch.setattr(framework, "sdk_function_tool", _fake_function_tool)
+
+    wrapped = framework._translate_tools(
+        [
+            ToolBinding(
+                name="trace_diff.latest_dbs",
+                fn=lambda: (Path("runs/new.db"), {Path("runs/baseline.db")}),
+            )
+        ]
+    )
+
+    assert wrapped[0]["fn"]() == ["[REDACTED_PATH]", ["[REDACTED_PATH]"]]
+
+
+def test_translate_tools_restores_sdk_path_tokens_before_tool_call(monkeypatch):
+    captured = {}
+
+    def _fake_function_tool(fn, *, name_override, strict_mode):
+        return {"name": name_override, "fn": fn}
+
+    def _hotspots(database_path):
+        captured["database_path"] = database_path
+        return {"status": "ok"}
+
+    monkeypatch.setattr(framework, "sdk_function_tool", _fake_function_tool)
+
+    wrapped = framework._translate_tools(
+        [ToolBinding(name="analysis.hotspots", fn=_hotspots)],
+        token_to_raw_path={"[REDACTED_PATH:database_path]": "/home/example/private/trace.db"},
+    )
+
+    result = wrapped[0]["fn"]("[REDACTED_PATH:database_path]")
+
+    assert captured["database_path"] == "/home/example/private/trace.db"
+    assert result == {"status": "ok"}
 
 
 def test_sdk_invoke_raises_runtime_error_when_sdk_missing(monkeypatch):
@@ -677,11 +924,30 @@ def test_sdk_invoke_opencode_dispatches_to_subprocess_provider(monkeypatch):
         tools=[],
     )
 
-    response = framework._sdk_invoke(agent, {"user_query": "?"}, provider="opencode")
+    response = framework._sdk_invoke(
+        agent,
+        {
+            "user_query": "?",
+            "database_path": "/home/example/private/trace.db",
+            "source_dir": "demo-app/customer-project",
+            "analysis_options": {"att_dir": "att-output"},
+        },
+        provider="opencode",
+    )
 
     assert captured["model"] == "github-copilot/gpt-5"
     assert captured["messages"][0]["role"] == "user"
-    assert "user_query" in captured["messages"][0]["content"]
+    user_content = captured["messages"][0]["content"]
+    parsed = json.loads(user_content)
+    assert parsed == {
+        "user_query": "?",
+        "database_path": "[REDACTED_PATH]",
+        "source_dir": "[REDACTED_PATH]",
+        "analysis_options": {"att_dir": "[REDACTED_PATH]"},
+    }
+    assert "/home/example/private/trace.db" not in user_content
+    assert "demo-app/customer-project" not in user_content
+    assert "att-output" not in user_content
     assert "You are the T agent" in captured["system"]
     assert response.text == '{"narrative": "ok"}'
     assert response.structured_output == {"narrative": "ok"}

--- a/experimental/python/perfxpert/tests/test_providers/test_opencode_provider.py
+++ b/experimental/python/perfxpert/tests/test_providers/test_opencode_provider.py
@@ -124,6 +124,25 @@ def test_subprocess_output_parsed(monkeypatch):
         assert r.provider == "opencode"
 
 
+def test_system_prompt_paths_redacted_before_subprocess(monkeypatch):
+    monkeypatch.delenv("PERFXPERT_IN_OPENCODE_SESSION", raising=False)
+    from perfxpert.providers.opencode_provider import OpencodeProvider
+
+    with patch(
+        "perfxpert.providers.opencode_provider.subprocess.run",
+        return_value=_fake_completed(stdout="the-answer"),
+    ) as mr:
+        OpencodeProvider(opencode_path="/bin/opencode").complete(
+            [{"role": "user", "content": "hi"}],
+            system="Inspect /home/example/private/fence.md before replying.",
+        )
+
+    prompt = mr.call_args.kwargs["input"]
+    assert "/home/example/private/fence.md" not in prompt
+    assert "[REDACTED]" in prompt
+    assert "[system]" in prompt
+
+
 def test_timeout_mapped(monkeypatch):
     monkeypatch.delenv("PERFXPERT_IN_OPENCODE_SESSION", raising=False)
     import subprocess as sp

--- a/experimental/python/perfxpert/tests/test_providers/test_sanitization.py
+++ b/experimental/python/perfxpert/tests/test_providers/test_sanitization.py
@@ -56,3 +56,24 @@ def test_sanitize_messages_recurses_nested_content():
     assert "../../secret/file.hip" not in str(out)
     assert "[REDACTED]" in str(out)
     assert "[REDACTED_PATH]" in str(out)
+
+
+def test_sanitize_messages_redacts_path_field_values_by_key():
+    messages = [
+        {
+            "role": "user",
+            "content": {
+                "database_path": "relative/run.db",
+                "source_dir": "demo-app",
+                "include_path": ["private/include"],
+                "analysis_options": {"att_dir": "att-output"},
+            },
+        }
+    ]
+    out = sanitize_messages(messages)
+    rendered = str(out)
+    assert "relative/run.db" not in rendered
+    assert "demo-app" not in rendered
+    assert "private/include" not in rendered
+    assert "att-output" not in rendered
+    assert rendered.count("[REDACTED_PATH]") == 4


### PR DESCRIPTION
## Summary

- Redact provider-bound path fields before agent/provider serialization.
- Use SDK-only opaque path tokens so the model sees safe handles while local SDK tool wrappers can restore the original paths for local tool execution.
- Sanitize SDK tool outputs and SDK instructions before provider exposure.
- Cover string, `PathLike`, Pydantic/model-dump, dataclass, tuple, set, SDK, and OpenCode prompt paths.

## Review gate

Ran the comprehensive reviewer gate across design, implementation, test design, test implementation, code review, domain modeling, clean code, AMD alignment, and testing perspectives.

Reviewer findings addressed in this revision:

- Non-string path carriers could leak through `json.dumps(..., default=str)`.
- SDK tool outputs could leak path fields back to the model.
- Redacting path fields with a generic placeholder could break SDK tool calls that need local paths.
- SDK instructions needed the same provider-bound redaction boundary.
- Tuple/set path carriers needed recursive sanitization.
- OpenCode system prompts needed explicit subprocess-prompt coverage.
- Boundary naming/docs needed to make the token-to-raw-path contract clear.

## Validation

- `git diff --check`
- `python3 -m compileall -q experimental/python/perfxpert/perfxpert/agents/framework.py experimental/python/perfxpert/perfxpert/providers/_sanitization.py experimental/python/perfxpert/perfxpert/providers/opencode_provider.py`
- `env PYTHONPATH=experimental/python/perfxpert pytest -q experimental/python/perfxpert/tests/test_agents/test_framework.py experimental/python/perfxpert/tests/test_providers/test_sanitization.py experimental/python/perfxpert/tests/test_providers/test_opencode_provider.py` (`65 passed`)
- `env PYTHONPATH=experimental/python/perfxpert pytest -q experimental/python/perfxpert/tests/test_agents experimental/python/perfxpert/tests/test_providers` (`334 passed`)
- `env PYTHONPATH=experimental/python/perfxpert pytest -q experimental/python/perfxpert/tests/test_cli/test_analyze_args.py experimental/python/perfxpert/tests/test_cli/test_doctor_providers.py experimental/python/perfxpert/tests/test_integration/test_cli_dispatch.py` (`58 passed`)
- `custom-ai-secret-scan experimental/python/perfxpert/perfxpert/agents/framework.py experimental/python/perfxpert/perfxpert/providers/_sanitization.py experimental/python/perfxpert/tests/test_agents/test_framework.py experimental/python/perfxpert/tests/test_providers/test_opencode_provider.py experimental/python/perfxpert/tests/test_providers/test_sanitization.py`
- `custom-ai-secret-scan --repo-root /home/aelwazir/work/.worktrees/perfxpert-sdk-payload-redaction`

Note: this checkout does not contain `scripts/secret-scan.sh`, so the approved installed fallback scanner was used. A whole-worktree fallback scan hit the scanner's large-argument runtime limit before staging; staged-file mode scanned the exact outbound diff cleanly.
