### PR TITLE
Fix broken dumping of assembly

### DIFF
--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -65,6 +65,16 @@ if(CMAKE_BUILD_TYPE MATCHES "Debug")
   set(DL_OPT_FLAGS -O1 -g)
 else()
   set(DL_OPT_FLAGS -O3)
+  if(DUMP_ASM)
+    # Release device objects otherwise carry no DWARF; llvm-objdump --source needs -g.
+    list(APPEND DL_OPT_FLAGS -g)
+  endif()
+endif()
+
+if(DUMP_ASM)
+  set(DL_IR_DEBUG_FLAG -g)
+else()
+  set(DL_IR_DEBUG_FLAG -gline-tables-only)
 endif()
 
 # ---------------------------------------------------------------------------
@@ -341,7 +351,7 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
         ${_link_inc_flags}
         -x hip --offload-device-only --offload-arch=${DL_GPU_TARGET}
         ${DL_HIP_COMPILER_FLAGS}
-        -gline-tables-only
+        ${DL_IR_DEBUG_FLAG}
         -std=c++17 -w ${DL_OPT_FLAGS}
         -emit-llvm -S
         -o ${IR_OUT}
@@ -363,7 +373,7 @@ set(DEVICE_HIPFB "${DEVICE_BUILD_DIR}/device.hipfb")
 list(JOIN DL_BUNDLER_TARGETS "," _bundler_targets_str)
 
 set(DL_BUNDLER_COMPRESS "")
-if(ENABLE_COMPRESS)
+if(ENABLE_COMPRESS AND NOT DUMP_ASM)
   set(DL_BUNDLER_COMPRESS "--compress")
 endif()
 
@@ -386,7 +396,7 @@ add_custom_command(
 set(COMMON_FAT_OBJ "${DEVICE_BUILD_DIR}/common.o")
 
 set(DL_HOST_COMPRESS "")
-if(ENABLE_COMPRESS)
+if(ENABLE_COMPRESS AND NOT DUMP_ASM)
   set(DL_HOST_COMPRESS "--offload-compress")
 endif()
 

--- a/projects/rccl/cmake/scripts/dump_rccl_asm.cmake
+++ b/projects/rccl/cmake/scripts/dump_rccl_asm.cmake
@@ -1,0 +1,113 @@
+# Invoked with: cmake -DRCCL_SO=<path-to-librccl.so> -DLLVM_OBJDUMP=<llvm-objdump> -P dump_rccl_asm.cmake
+# RCCL_SO must be an absolute path to the linked shared library (or a symlink to it).
+if(NOT DEFINED RCCL_SO OR NOT DEFINED LLVM_OBJDUMP)
+  message(FATAL_ERROR "dump_rccl_asm.cmake: set RCCL_SO and LLVM_OBJDUMP")
+endif()
+if(NOT EXISTS "${RCCL_SO}")
+  message(FATAL_ERROR "dump_rccl_asm.cmake: RCCL_SO does not exist: ${RCCL_SO}")
+endif()
+
+get_filename_component(_bindir "${RCCL_SO}" DIRECTORY)
+get_filename_component(_realso "${RCCL_SO}" REALPATH)
+get_filename_component(_basename "${_realso}" NAME)
+
+file(GLOB _oldasm "${_bindir}/librccl.gfx*.s" "${_bindir}/librccl.host*.s")
+if(_oldasm)
+  file(REMOVE ${_oldasm})
+endif()
+
+execute_process(
+  COMMAND "${LLVM_OBJDUMP}" --offloading "${_realso}"
+  WORKING_DIRECTORY "${_bindir}"
+  RESULT_VARIABLE _ex
+  OUTPUT_VARIABLE _out
+  ERROR_VARIABLE _err
+)
+if(NOT _ex EQUAL 0)
+  message(FATAL_ERROR "llvm-objdump --offloading failed (${_ex}): ${_err}\n${_out}")
+endif()
+
+# Collect AMDGPU bundle paths with a stable group key (e.g. gfx942 and gfx942:sramecc+ -> gfx942).
+set(_pairs "")
+file(GLOB _cand "${_bindir}/${_basename}.*")
+list(SORT _cand)
+foreach(_full ${_cand})
+  get_filename_component(_fn "${_full}" NAME)
+  if(_fn STREQUAL _basename)
+    continue()
+  endif()
+  if(_fn MATCHES "\\.host-")
+    file(REMOVE "${_full}")
+    continue()
+  endif()
+  if(NOT _fn MATCHES "hipv4-amdgcn")
+    continue()
+  endif()
+  file(SIZE "${_full}" _sz)
+  if(_sz EQUAL 0)
+    file(REMOVE "${_full}")
+    continue()
+  endif()
+  if(NOT _fn MATCHES "hipv4-amdgcn-amd-amdhsa--(.+)$")
+    continue()
+  endif()
+  set(_tail "${CMAKE_MATCH_1}")
+  string(REGEX REPLACE ":.*" "" _gkey "${_tail}")
+  string(REGEX REPLACE "-+$" "" _gkey "${_gkey}")
+  if(_gkey STREQUAL "")
+    continue()
+  endif()
+  list(APPEND _pairs "${_gkey}@@${_full}")
+endforeach()
+
+# Unique group keys (preserve sorted order of first occurrence).
+set(_keys "")
+foreach(_p ${_pairs})
+  string(REGEX MATCH "^([^@]+)@@" _m "${_p}")
+  set(_k "${CMAKE_MATCH_1}")
+  list(FIND _keys "${_k}" _fi)
+  if(_fi EQUAL -1)
+    list(APPEND _keys "${_k}")
+  endif()
+endforeach()
+
+foreach(_k ${_keys})
+  set(_out "${_bindir}/librccl.${_k}.s")
+  file(WRITE "${_out}" "; librccl AMDGPU disassembly (llvm-objdump), combined slices for ${_k}\n")
+  foreach(_p ${_pairs})
+    string(REGEX MATCH "^([^@]+)@@(.*)$" _m "${_p}")
+    set(_pk "${CMAKE_MATCH_1}")
+    set(_full "${CMAKE_MATCH_2}")
+    if(NOT _pk STREQUAL _k)
+      continue()
+    endif()
+    get_filename_component(_slice "${_full}" NAME)
+    message(STATUS "DUMP_ASM: librccl.${_k}.s <- ${_slice}")
+    execute_process(
+      COMMAND bash -c "printf '\n\n;;; offload slice: %s\n\n' \"${_slice}\" >> \"${_out}\""
+      RESULT_VARIABLE _bret
+    )
+    if(NOT _bret EQUAL 0)
+      message(FATAL_ERROR "append banner failed (${_bret})")
+    endif()
+    execute_process(
+      COMMAND bash -c "\"${LLVM_OBJDUMP}\" -d -l --source --symbolize-operands \"${_full}\" >> \"${_out}\""
+      RESULT_VARIABLE _dret
+    )
+    if(NOT _dret EQUAL 0)
+      message(FATAL_ERROR "llvm-objdump disassembly failed for ${_slice} (${_dret})")
+    endif()
+    file(REMOVE "${_full}")
+  endforeach()
+endforeach()
+
+execute_process(COMMAND uname -m OUTPUT_VARIABLE _hostm OUTPUT_STRIP_TRAILING_WHITESPACE)
+set(_hostasm "librccl.host-${_hostm}.s")
+message(STATUS "DUMP_ASM: ${_hostasm} <- ${_basename} (host ELF)")
+execute_process(
+  COMMAND bash -c "\"${LLVM_OBJDUMP}\" -d -l --source --symbolize-operands \"${_realso}\" >\"${_bindir}/${_hostasm}\""
+  RESULT_VARIABLE _hret
+)
+if(NOT _hret EQUAL 0)
+  message(FATAL_ERROR "llvm-objdump host disassembly failed (${_hret})")
+endif()

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -751,10 +751,15 @@ if (HAVE_PARALLEL_JOBS)
   target_compile_options(rccl PRIVATE -parallel-jobs=12)
 endif()
 
-if (ROCM_VERSION VERSION_GREATER_EQUAL "60200")
-  target_compile_options(rccl PRIVATE --offload-compress)    # Compress GPU code at compile time.
-  target_link_libraries(rccl PRIVATE --offload-compress)     # Compress GPU code at link time.
-  message(STATUS "--offload-compress enabled - ROCm version >= 6.2.0")
+if(ROCM_VERSION VERSION_GREATER_EQUAL "60200")
+  if(DUMP_ASM)
+    # llvm-objdump --offloading does not handle compressed offload bundles reliably.
+    message(STATUS "--offload-compress disabled (DUMP_ASM needs uncompressed bundles)")
+  else()
+    target_compile_options(rccl PRIVATE --offload-compress)    # Compress GPU code at compile time.
+    target_link_libraries(rccl PRIVATE --offload-compress)     # Compress GPU code at link time.
+    message(STATUS "--offload-compress enabled - ROCm version >= 6.2.0")
+  endif()
 else()
   message(STATUS "--offload-compress disabled - ROCm version < 6.2.0")
 endif()
@@ -828,24 +833,28 @@ if (REPORT_KERNEL_RESOURCE_USE)
   target_link_options(rccl PRIVATE -Rpass-analysis=kernel-resource-usage)
 endif()
 
-if (DUMP_ASM) # Save temporary files from kernel compilation
-  message(STATUS "Disassembling librccl.so to asm")
-  # Maintain symbols but without changing code.  Keep additional data in dwarf section of binary.
-  target_compile_options(rccl PRIVATE -gline-tables-only)
-  set(OBJ_DUMP ${ROCM_PATH}/llvm/bin/llvm-objdump)
-
-  add_custom_command(TARGET rccl POST_BUILD
-    COMMENT "Disassembling RCCL library"
-    COMMAND /bin/bash -c "${OBJ_DUMP} --offload-fatbin librccl.so"
-    VERBATIM
-  )
-  foreach(GPUARCH ${GPU_TARGETS})
+if(DUMP_ASM)
+  if(NOT BUILD_SHARED_LIBS)
+    message(WARNING "DUMP_ASM requires a shared librccl; skipping assembly dump.")
+  else()
+    # POST_BUILD runs in src's CMAKE_CURRENT_BINARY_DIR by default; librccl.so is in
+    # PROJECT_BINARY_DIR (see root CMakeLists). Pass an absolute path and run the script
+    # with WORKING_DIRECTORY set to the library directory (no missing link dependency).
+    message(STATUS "Disassembling librccl.so offload bundles to librccl.{gfx*,host*}.s")
+    # -gline-tables-only is not enough for llvm-objdump --source (needs .debug_info, etc.)
+    target_compile_options(rccl PRIVATE -g)
+    find_program(DUMP_ASM_LLVM_OBJDUMP NAMES llvm-objdump REQUIRED
+      HINTS "${ROCM_PATH}/llvm/bin" "$ENV{ROCM_PATH}/llvm/bin")
+    set(_rccl_so "${PROJECT_BINARY_DIR}/librccl.so")
     add_custom_command(TARGET rccl POST_BUILD
-        COMMENT "Disassembling RCCL library to dump assembly for ${GPUARCH}"
-        COMMAND /bin/bash -c "${OBJ_DUMP} -d -l --source --symbolize-operands librccl.so.0.hipv4-amdgcn-amd-amdhsa--${GPUARCH} > librccl.${GPUARCH}.s"
-        VERBATIM
-    )
-  endforeach()
+      COMMENT "Disassembling RCCL offload bundles (llvm-objdump)"
+      COMMAND "${CMAKE_COMMAND}"
+        "-DRCCL_SO=${_rccl_so}"
+        "-DLLVM_OBJDUMP=${DUMP_ASM_LLVM_OBJDUMP}"
+        -P "${RCCL_SOURCE_DIR}/cmake/scripts/dump_rccl_asm.cmake"
+      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
+      VERBATIM)
+  endif()
 endif()
 
 ## NOTE: This is currently being handled by rocm-cmake, however may need to be re-enabled in the future


### PR DESCRIPTION
## Motivation

Fix broken assembly dumping workflow (tested on ROCm 7.2)

## Technical Details

The flag name to llvm-objdump changed from --offload to --offloading.  The flag --offload-compress no longer works with this dumping, so we have to disable that too.

## JIRA ID

N/A

## Test Plan

Need to test on 7.0.2 too

## Test Result

Dumps files successfully with source code interlaced.  Verified that it appears to work with the symmetric memory code too.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
