### PR TITLE
rocr: Restore historical-ratio path in TranslateTime for ticks predating t0_

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -2596,12 +2596,18 @@ void GpuAgent::TranslateTime(core::Signal* signal, hsa_amd_profiling_dispatch_ti
   uint64_t start, end;
   signal->GetRawTs(false, start, end);
 
-  if ((start == 0) || (end == 0) || (start < t0_.GPUClockCounter) || (end < t0_.GPUClockCounter)) {
-    debug_print("Signal %p time stamps may be invalid (start=%lu, end=%lu, t0=%lu).\n",
-                &signal->signal_, start, end, t0_.GPUClockCounter);
+  if(start == 0 || end == 0 || end < start) {
+    debug_print("Signal %p time stamps may be invalid (start=%lu, end=%lu).\n",
+                &signal->signal_, start, end);
     time.start = 0;
     time.end = 0;
     return;
+  }
+
+  if ((start < t0_.GPUClockCounter) || (end < t0_.GPUClockCounter)) {
+    debug_print("Signal %p time stamps predate t0 (start=%lu, end=%lu, t0=%lu) — using historical ratio.\n",
+      &signal->signal_, start, end, t0_.GPUClockCounter);
+    // fall through to TranslateTime() which handles the historical case
   }
 
   // Order is important, we want to translate the end time first to ensure that packet duration is
@@ -2614,12 +2620,18 @@ void GpuAgent::TranslateTime(core::Signal* signal, hsa_amd_profiling_async_copy_
   uint64_t start, end;
   signal->GetRawTs(true, start, end);
 
-  if ((start == 0) || (end == 0) || (start < t0_.GPUClockCounter) || (end < t0_.GPUClockCounter)) {
-    debug_print("Signal %p async copy time stamps may be invalid (start=%lu, end=%lu, t0=%lu).\n",
-                &signal->signal_, start, end, t0_.GPUClockCounter);
+  if(start == 0 || end == 0 || end < start) {
+    debug_print("Signal %p time stamps may be invalid (start=%lu, end=%lu).\n",
+                &signal->signal_, start, end);
     time.start = 0;
     time.end = 0;
     return;
+  }
+
+  if ((start < t0_.GPUClockCounter) || (end < t0_.GPUClockCounter)) {
+    debug_print("Signal %p time stamps predate t0 (start=%lu, end=%lu, t0=%lu) — using historical ratio.\n",
+      &signal->signal_, start, end, t0_.GPUClockCounter);
+    // fall through to TranslateTime() which handles the historical case
   }
 
   // Order is important, we want to translate the end time first to ensure that packet duration is


### PR DESCRIPTION
## Motivation

PR #5093 added an early return in TranslateTime that zeroes timestamps whenever start/end is 0 or below t0_.GPUClockCounter. On gfx1151 every kernel/copy timestamp lies a fixed offset below t0_, so the early return zeroes every signal and hipEventElapsedTime returns 0 ms.

[ reproducer.cpp](https://gist.github.com/venkat1361/665b2da301a25b737f3bf7bfbd9b3cab) RESULT: hipEventElapsedTime always reports 0 ms.

## Technical Details

TranslateTime(uint64_t tick) already handles ticks below t0_ via the historical_clock_ratio_ branch, which extrapolates from t0_ with a frozen ratio. Both endpoints share the same anchor, so end_sys - start_sys == ratio * (end - start) — interval timing is preserved even though absolute host time is best-effort. 
The fix splits the guard:
```  
if (start == 0 || end == 0 || end < start) {
    // genuinely missing/corrupt — bail out
    time.start = time.end = 0;
    return;
  }
  if (start < t0_.GPUClockCounter || end < t0_.GPUClockCounter) {
    // different counter epoch — fall through to historical_clock_ratio_
  }
  time.end   = TranslateTime(end);
  time.start = TranslateTime(start);
```

assigned ticket to rocr team: ROCM-24026
## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
