### PR TITLE
[ci] Skip regular TheRock CI on push when only RCCL changes

### DIFF
--- a/.github/scripts/tests/therock_configure_ci_test.py
+++ b/.github/scripts/tests/therock_configure_ci_test.py
@@ -357,6 +357,68 @@ class ConfigureCITest(unittest.TestCase):
         self.assertGreaterEqual(len(projects), 1)
         self.assertEqual(outputs["run_linux_rccl_ci"], "false")
 
+    # Tests for push event with RCCL changes
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_push_only_rccl_skips_regular_ci(self, mock_get_modified):
+        """Push with only RCCL changes should skip regular CI but run RCCL CI."""
+        args = {"is_push": True, "base_ref": "HEAD^", "platform": "linux"}
+
+        mock_get_modified.return_value = [
+            "projects/rccl/src/main.cpp",
+            "projects/rccl/test/test.cpp",
+        ]
+
+        outputs = therock_configure_ci.run(args)
+        projects = json.loads(outputs["projects"])
+        self.assertEqual(len(projects), 0)
+        self.assertEqual(outputs["run_linux_rccl_ci"], "true")
+
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_push_rccl_and_known_subtree_runs_both(self, mock_get_modified):
+        """Push with RCCL + known subtree changes should run both regular and RCCL CI."""
+        args = {"is_push": True, "base_ref": "HEAD^", "platform": "linux"}
+
+        mock_get_modified.return_value = [
+            "projects/rccl/src/main.cpp",
+            "projects/clr/src/clr.cpp",
+        ]
+
+        outputs = therock_configure_ci.run(args)
+        projects = json.loads(outputs["projects"])
+        self.assertGreaterEqual(len(projects), 1)
+        self.assertEqual(outputs["run_linux_rccl_ci"], "true")
+
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_push_rccl_and_unknown_runs_full_ci(self, mock_get_modified):
+        """Push with RCCL + unknown path changes should run full regular CI and RCCL CI."""
+        args = {"is_push": True, "base_ref": "HEAD^", "platform": "linux"}
+
+        mock_get_modified.return_value = [
+            "projects/rccl/src/main.cpp",
+            "unknown/path/file.cpp",
+        ]
+
+        outputs = therock_configure_ci.run(args)
+        projects = json.loads(outputs["projects"])
+        # Should run full CI due to unknown path
+        self.assertGreaterEqual(len(projects), 1)
+        self.assertEqual(outputs["run_linux_rccl_ci"], "true")
+
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_push_known_subtree_only_runs_regular_ci(self, mock_get_modified):
+        """Push with only known subtree changes should run regular CI, not RCCL CI."""
+        args = {"is_push": True, "base_ref": "HEAD^", "platform": "linux"}
+
+        mock_get_modified.return_value = [
+            "projects/clr/src/clr.cpp",
+            "projects/rocminfo/src/main.cpp",
+        ]
+
+        outputs = therock_configure_ci.run(args)
+        projects = json.loads(outputs["projects"])
+        self.assertGreaterEqual(len(projects), 1)
+        self.assertEqual(outputs["run_linux_rccl_ci"], "false")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -157,6 +157,27 @@ def check_rccl_changes(modified_paths: Optional[Iterable[str]]) -> bool:
     return any(path.startswith("projects/rccl/") for path in modified_paths)
 
 
+def is_rccl_path(path: str) -> bool:
+    """Returns true if path is under projects/rccl/."""
+    return path.startswith("projects/rccl/")
+
+
+def get_matched_subtree(path: str) -> Optional[str]:
+    """Returns the subtree that matches the path, or None if no match."""
+    for subtree in subtree_to_project_map:
+        if path.startswith(subtree):
+            return subtree
+    return None
+
+
+def check_only_rccl_changes(modified_paths: Iterable[str]) -> bool:
+    """Returns true if all modified paths are either RCCL or match known subtrees."""
+    for path in modified_paths:
+        if not is_rccl_path(path) and get_matched_subtree(path) is None:
+            return False
+    return check_rccl_changes(modified_paths)
+
+
 def retrieve_projects(args):
     # Nightly (schedule): use same test coverage as TheRock submodule bump PRs —
     # single nightly job with THEROCK_ENABLE_ALL=ON and full projects_to_test list.
@@ -188,9 +209,29 @@ def retrieve_projects(args):
             logging.info("Only skippable paths were modified, skipping CI")
             return []
 
-    # Push event → evaluate all subtrees
+    # Push event → check which subtrees were modified
     if args.get("is_push"):
-        subtrees = list(subtree_to_project_map.keys())
+        matched_subtrees = {get_matched_subtree(p) for p in modified_paths} - {None}
+
+        # Change in CI workflow triggers full subtree evaluation
+        if check_for_workflow_file_related_to_ci(modified_paths):
+            logging.info("CI workflow files changed, evaluating all subtrees")
+            subtrees = list(subtree_to_project_map.keys())
+        elif matched_subtrees:
+            # Known subtrees changed - run CI for those subtrees
+            subtrees = list(matched_subtrees)
+        elif check_only_rccl_changes(modified_paths):
+            # Only RCCL changes - skip regular CI, RCCL CI will handle it
+            logging.info("Only RCCL changes detected on push, skipping regular CI")
+            subtrees = []
+        elif modified_paths:
+            # Files changed but no known subtree matched (and not RCCL-only)
+            logging.info(
+                "Modified files did not match known subtrees, evaluating all projects"
+            )
+            subtrees = list(subtree_to_project_map.keys())
+        else:
+            subtrees = []
 
     # Manual workflow dispatch: respect explicit project selection, bypass CI file change detection
     elif args.get("is_workflow_dispatch"):


### PR DESCRIPTION
We noticed that TheRock CI was running even on RCCL push. This is a waste of resources, so changes:
- only run RCCL CI only if a RCCL change was made, no other CI is run (push / PR events)