### PR TITLE
[rocprofiler-systems] Make elfutils GCC15 patch step idempotent

### DIFF
--- a/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
@@ -180,18 +180,21 @@ else()
     # Backport elfutils commit 7508696d (released in 0.192) to fix GCC 15
     # -Werror=unterminated-string-initialization in the i386/x86_64 register
     # tables. Only applied to versions older than 0.192 where the upstream
-    # fix is missing.
+    # fix is missing. The patch invocation is wrapped in
+    # apply_patch_idempotent.cmake because CMake regenerates
+    # *-patch-info.txt on every reconfigure, retriggering the patch step
+    # against already-patched source - vanilla `patch` aborts in that case.
     set(_eu_patch_args)
     if(ELFUTILS_DOWNLOAD_VERSION VERSION_LESS 0.192)
         find_program(PATCH_EXECUTABLE NAMES patch REQUIRED)
         set(_eu_patch_args
             PATCH_COMMAND
-            ${PATCH_EXECUTABLE}
-            -p1
-            -d
-            <SOURCE_DIR>
-            -i
-            ${CMAKE_CURRENT_LIST_DIR}/elfutils-0.188-gcc15-regs.patch
+            ${CMAKE_COMMAND}
+            -DSRC=<SOURCE_DIR>
+            -DPATCH=${CMAKE_CURRENT_LIST_DIR}/elfutils-0.188-gcc15-regs.patch
+            -DPATCH_EXE=${PATCH_EXECUTABLE}
+            -P
+            ${CMAKE_CURRENT_LIST_DIR}/apply_patch_idempotent.cmake
         )
     endif()
 

--- a/projects/rocprofiler-systems/cmake/apply_patch_idempotent.cmake
+++ b/projects/rocprofiler-systems/cmake/apply_patch_idempotent.cmake
@@ -1,3 +1,6 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
 # Apply a patch idempotently.
 #
 # CMake's ExternalProject regenerates `*-patch-info.txt` on every reconfigure,
@@ -13,9 +16,14 @@
 #     -DPATCH_EXE=${PATCH_EXECUTABLE}
 #     -P ${CMAKE_CURRENT_LIST_DIR}/apply_patch_idempotent.cmake
 
-if(NOT SRC OR NOT PATCH OR NOT PATCH_EXE)
-    message(FATAL_ERROR "apply_patch_idempotent: requires -DSRC, -DPATCH, -DPATCH_EXE")
-endif()
+foreach(_arg SRC PATCH PATCH_EXE)
+    if(NOT DEFINED ${_arg} OR "${${_arg}}" STREQUAL "")
+        message(
+            FATAL_ERROR
+            "apply_patch_idempotent: -D${_arg}=<value> is required"
+        )
+    endif()
+endforeach()
 
 execute_process(
     COMMAND ${PATCH_EXE} --dry-run --reverse --silent --force -p1 -d ${SRC} -i ${PATCH}

--- a/projects/rocprofiler-systems/cmake/apply_patch_idempotent.cmake
+++ b/projects/rocprofiler-systems/cmake/apply_patch_idempotent.cmake
@@ -18,10 +18,7 @@
 
 foreach(_arg SRC PATCH PATCH_EXE)
     if(NOT DEFINED ${_arg} OR "${${_arg}}" STREQUAL "")
-        message(
-            FATAL_ERROR
-            "apply_patch_idempotent: -D${_arg}=<value> is required"
-        )
+        message(FATAL_ERROR "apply_patch_idempotent: -D${_arg}=<value> is required")
     endif()
 endforeach()
 

--- a/projects/rocprofiler-systems/cmake/apply_patch_idempotent.cmake
+++ b/projects/rocprofiler-systems/cmake/apply_patch_idempotent.cmake
@@ -1,0 +1,39 @@
+# Apply a patch idempotently.
+#
+# CMake's ExternalProject regenerates `*-patch-info.txt` on every reconfigure,
+# which makes the patch step appear out-of-date and re-runs it. Vanilla
+# `patch -p1` errors when its target is already patched, so subsequent
+# reconfigures fail. Wrap the patch invocation with a reverse-dry-run probe
+# so an already-applied patch is treated as success.
+#
+# Usage (from PATCH_COMMAND):
+#   ${CMAKE_COMMAND}
+#     -DSRC=<SOURCE_DIR>
+#     -DPATCH=<absolute path to patch file>
+#     -DPATCH_EXE=${PATCH_EXECUTABLE}
+#     -P ${CMAKE_CURRENT_LIST_DIR}/apply_patch_idempotent.cmake
+
+if(NOT SRC OR NOT PATCH OR NOT PATCH_EXE)
+    message(FATAL_ERROR "apply_patch_idempotent: requires -DSRC, -DPATCH, -DPATCH_EXE")
+endif()
+
+execute_process(
+    COMMAND ${PATCH_EXE} --dry-run --reverse --silent --force -p1 -d ${SRC} -i ${PATCH}
+    RESULT_VARIABLE _reverse_check
+    OUTPUT_QUIET
+    ERROR_QUIET
+)
+
+if(_reverse_check EQUAL 0)
+    message(STATUS "Patch already applied, skipping: ${PATCH}")
+    return()
+endif()
+
+execute_process(
+    COMMAND ${PATCH_EXE} -p1 -d ${SRC} -i ${PATCH}
+    RESULT_VARIABLE _apply_result
+)
+
+if(NOT _apply_result EQUAL 0)
+    message(FATAL_ERROR "Failed to apply patch ${PATCH} (exit ${_apply_result})")
+endif()


### PR DESCRIPTION
Follow-up to #5574. The patch step we added wires `PATCH_COMMAND patch -p1 -d <SOURCE_DIR> -i ...` directly. CMake's ExternalProject regenerates `*-patch-info.txt` on every reconfigure, which marks the patch step out-of-date and re-runs it. Vanilla `patch` aborts on already-applied source:

```
Reversed (or previously applied) patch detected!  Assume -R? [n]
Apply anyway? [n]
Skipping patch.
1 out of 1 hunk ignored -- saving rejects to file backends/i386_regs.c.rej
```

So any rebuild after the first successful build fails. Reproduces locally on every reconfigure.

Wrap the patch invocation in `apply_patch_idempotent.cmake` (a `cmake -P` helper). The helper does a `patch --dry-run --reverse --silent --force` probe first; if that succeeds, the patch is already applied and the step is a no-op. Otherwise it applies normally. Other patch failure modes still propagate via `FATAL_ERROR`.

Tested locally across four cases: already-applied (skips), repeated calls (idempotent), reverse-then-reapply (applies cleanly), unchanged source after fresh-apply (skips again).