### PR TITLE
tests: use gfx1250-specific rocprofiler-counters in pytest

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/gpu.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/gpu.py
@@ -39,8 +39,16 @@ class GPUInfo:
         return False
 
     @property
+    def _is_gfx1250(self) -> bool:
+        """Check if any detected GPU uses the gfx1250 architecture."""
+        return "gfx1250" in self.architectures
+
+    @property
     def rocm_events_for_test(self) -> str:
         """Get appropriate ROCm events for testing based on architecture."""
+        if self._is_gfx1250:
+            return "GRBM_COUNT,SQ_WAVES,SQ_INSTS_VALU,TX_VCA_VCA_BUSY"
+
         mi300_or_later = self._is_mi300_or_later
         if mi300_or_later:
             return "GRBM_COUNT,SQ_WAVES,SQ_INSTS_VALU,TA_TA_BUSY"
@@ -49,6 +57,9 @@ class GPUInfo:
     @property
     def counter_names(self) -> list[str]:
         """Get counter names for validation based on architecture"""
+        if self._is_gfx1250:
+            return ["GRBM_COUNT", "SQ_WAVES", "SQ_INSTS_VALU", "TX_VCA_VCA_BUSY"]
+
         mi300_or_later = self._is_mi300_or_later
         if mi300_or_later:
             return ["GRBM_COUNT", "SQ_WAVES", "SQ_INSTS_VALU", "TA_TA_BUSY"]

--- a/projects/rocprofiler-systems/tests/pytest/test_gpu_info.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_gpu_info.py
@@ -1,0 +1,69 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Unit tests for GPU-specific test counter selection.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rocprofsys import GPUInfo
+
+pytestmark = [pytest.mark.unit_tests]
+
+
+def test_gfx1250_uses_gfx1250_counter_set():
+    gpu_info = GPUInfo(
+        available=True,
+        architectures=["gfx1250"],
+        device_count=1,
+        categories={"instinct"},
+    )
+
+    assert (
+        gpu_info.rocm_events_for_test
+        == "GRBM_COUNT,SQ_WAVES,SQ_INSTS_VALU,TX_VCA_VCA_BUSY"
+    )
+    assert gpu_info.counter_names == [
+        "GRBM_COUNT",
+        "SQ_WAVES",
+        "SQ_INSTS_VALU",
+        "TX_VCA_VCA_BUSY",
+    ]
+    assert gpu_info.expected_counter_files == [
+        "rocprof-device-[0-9]-GRBM_COUNT.txt",
+        "rocprof-device-[0-9]-SQ_WAVES.txt",
+        "rocprof-device-[0-9]-SQ_INSTS_VALU.txt",
+        "rocprof-device-[0-9]-TX_VCA_VCA_BUSY.txt",
+    ]
+
+
+def test_mi300_and_later_keep_ta_ta_busy():
+    gpu_info = GPUInfo(
+        available=True,
+        architectures=["gfx942"],
+        device_count=1,
+        categories={"instinct"},
+    )
+
+    assert gpu_info.rocm_events_for_test == "GRBM_COUNT,SQ_WAVES,SQ_INSTS_VALU,TA_TA_BUSY"
+    assert gpu_info.counter_names == [
+        "GRBM_COUNT",
+        "SQ_WAVES",
+        "SQ_INSTS_VALU",
+        "TA_TA_BUSY",
+    ]
+
+
+def test_non_mi300_non_gfx1250_keep_single_counter():
+    gpu_info = GPUInfo(
+        available=True,
+        architectures=["gfx1201"],
+        device_count=1,
+        categories={"radeon"},
+    )
+
+    assert gpu_info.rocm_events_for_test == "SQ_WAVES"
+    assert gpu_info.counter_names == ["SQ_WAVES"]


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fix the pytest rocprofiler counter selection for gfx1250. gfx1250 needs a different counter set than the existing MI300+ path, so the transpose rocprofiler pytest tests should request and validate the correct counters for that architecture.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Update the pytest GPU counter helper to add a gfx1250-specific branch.
Changes:
- use GRBM_COUNT,SQ_WAVES,SQ_INSTS_VALU,TX_VCA_VCA_BUSY for gfx1250
- keep the existing MI300+ path unchanged
- keep the existing fallback path unchanged
- add unit coverage for the counter-selection helper

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFSYST-158

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- ran a targeted MI300 regression check for transpose rocprofiler ctests
- validated the gfx1250 counter path on gfx1250 hardware
- confirmed backend counter support for SQ_INSTS_VALU and TX_VCA_VCA_BUSY
- verified the pytest-side counter mapping and unit coverage in this PR

## Test Result

<!-- Briefly summarize test outcomes. -->
- MI300 regression check passed
- gfx1250 internal validation passed for the transpose rocprofiler counter path
- internal validation(amd-npi) also needed a CTest-only .cmake change, but that file is not part of develop
- this public PR only updates tests/pytest/rocprofsys/gpu.py and tests/pytest/test_gpu_info.py

Passed:
  - `transpose-rocprofiler-sampling`
  - `validate-transpose-rocprofiler-sampling-rocprof-device-0-GRBM_COUNT.txt-exists`
  - `validate-transpose-rocprofiler-sampling-rocprof-device-0-SQ_WAVES.txt-exists`
  - `validate-transpose-rocprofiler-sampling-rocprof-device-0-SQ_INSTS_VALU.txt-exists`
  - `validate-transpose-rocprofiler-sampling-rocprof-device-0-TX_VCA_VCA_BUSY.txt-exists`
  - `validate-transpose-rocprofiler-sampling-perfetto`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
