### PR TITLE
[rocprofiler-systems] docs: add oshrun 5.0+ workaround for stripped -- separator

### DIFF
--- a/projects/rocprofiler-systems/docs/how-to/communication-runtime-profiling.rst
+++ b/projects/rocprofiler-systems/docs/how-to/communication-runtime-profiling.rst
@@ -391,6 +391,22 @@ Run with your OpenSHMEM launcher (e.g., ``oshrun``) and ``rocprof-sys-sample`` o
 
    oshrun -n 4 rocprof-sys-sample -- ./my_shmem_app
 
+.. note::
+
+   PRRTE-based ``oshrun`` (Open MPI 5.0 and later) strips the first literal ``--``
+   from the program's argument list before passing it to the target application. This
+   breaks commands like ``rocprof-sys-run -- <binary>`` because ``rocprof-sys-run``
+   never receives the ``--`` separator and misinterprets its arguments. Older ORTE-based
+   ``oshrun`` (4.x and earlier) preserves ``--`` and is not affected.
+
+   As a workaround, pass ``-- --`` (two separate ``--`` delimiters) so that ``oshrun``
+   consumes the first one and the second reaches ``rocprof-sys-sample`` or
+   ``rocprof-sys-run`` as expected:
+
+   .. code-block:: shell
+
+      oshrun -n 4 rocprof-sys-sample -- -- ./my_shmem_app
+
 
 Multi-Layer Communication Analysis
 ===================================


### PR DESCRIPTION
## Motivation

PRRTE-based oshrun (Open MPI 5.0+) silently strips the first -- separator from the command line before forwarding arguments to the target application. This breaks rocprof-sys-sample and rocprof-sys-run invocations under oshrun, since the tools never receive the -- delimiter and misinterpret their arguments. This PR documents the issue and the -- -- workaround so users can work around it without needing to debug the argument parsing themselves.

## Technical Details

Adds a .. note:: block to the OpenSHMEM usage section of docs/how-to/communication-runtime-profiling.rst explaining:
  - PRRTE-based oshrun (5.0+) strips the first --; ORTE-based oshrun (4.x) is unaffected
  - Workaround: use -- -- so oshrun consumes the first and the second reaches rocprof-sys-run/rocprof-sys-sample

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFSYST-439

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
N/A
## Test Result

<!-- Briefly summarize test outcomes. -->
N/A
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
