### PR TITLE
[rocprofiler-compute] nullify incomplete counters after data imputation

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -30,7 +30,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Fixed `inf` display for metrics with zero-denominator counters (e.g., L2-Fabric Write Latency when no write requests are issued). The metric evaluation path now catches `inf` scalar results and returns `"N/A"`, consistent with existing `NaN` handling.
 
-* Kernels with missing counter data after iteration multiplexing imputation are now excluded from metric calculations. A warning at analysis time lists the affected kernels. Their execution times remain visible in Top Stats, and affected metric values show as ``N/A`` in comparison tables.
+* Kernels with missing counter data after iteration multiplexing imputation are now excluded from metrics calculations. A warning at analysis time lists the affected kernels. Their execution times remain visible in Top Stats.
 
 * Fixed empirical roofline benchmark to correctly produce double the Matrix BF16 Gflop/s on gfx90a (MI 200 series) GPUs
 

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -30,6 +30,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Fixed `inf` display for metrics with zero-denominator counters (e.g., L2-Fabric Write Latency when no write requests are issued). The metric evaluation path now catches `inf` scalar results and returns `"N/A"`, consistent with existing `NaN` handling.
 
+* Kernels with missing counter data after iteration multiplexing imputation are now excluded from metric calculations. A warning at analysis time lists the affected kernels. Their execution times remain visible in Top Stats, and affected metric values show as ``N/A`` in comparison tables.
+
 * Fixed empirical roofline benchmark to correctly produce double the Matrix BF16 Gflop/s on gfx90a (MI 200 series) GPUs
 
 ### Upcoming changes

--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -1184,11 +1184,11 @@ Iteration multiplexing feature comes with some caveats to be considered when pro
 
 * **Minimum number of kernel dispatches required**
 
-  When using iteration multiplexing it is recommended to filter by kernel(s) of interest using ``-k`` (see :ref:`profiling-kernel-filtering`) and make sure these kernels are dispatched enough times (50 recommended) to cover all counter subsets (currently around 15); a warning is thrown for kernels with insufficient dispatch counts to warn the user about missing counter data for those kernels, and it is not possible to calculate some metrics for these kernels.
+  When using iteration multiplexing it is recommended to filter by kernel(s) of interest using ``-k`` (see :ref:`profiling-kernel-filtering`) and make sure these kernels are dispatched enough times (50 recommended) to cover all counter subsets (currently around 15).
 
 * **Kernels with missing counter data are excluded from metrics**
 
-  If a kernel does not have enough dispatches to cover all counter sets, its counter data cannot be fully imputed and is excluded from metric calculations. A warning at analysis time lists any affected kernels. Their execution times remain visible in the Top Stats section so their runtime impact is still apparent. To get more complete counter coverage, you may consider running the kernel more times, collecting fewer metric blocks or counter sets, or using application replay instead of iteration multiplexing.
+  If a kernel does not have enough dispatches to cover all counter sets, its counter data cannot be fully imputed and is excluded from metrics calculations. A warning at analysis time lists any affected kernels. Their execution times remain visible in the Top Stats section so their runtime impact is still apparent. To get more complete kernel coverage for metrics calculations, you may consider disabling iteration multiplexing to use application replay, or increasing the number of iterations for these kernels in the workload.
 
 * **Non-deterministic workloads**
 

--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -1186,6 +1186,10 @@ Iteration multiplexing feature comes with some caveats to be considered when pro
 
   When using iteration multiplexing it is recommended to filter by kernel(s) of interest using ``-k`` (see :ref:`profiling-kernel-filtering`) and make sure these kernels are dispatched enough times (50 recommended) to cover all counter subsets (currently around 15); a warning is thrown for kernels with insufficient dispatch counts to warn the user about missing counter data for those kernels, and it is not possible to calculate some metrics for these kernels.
 
+* **Kernels with missing counter data are excluded from metrics**
+
+  If a kernel does not have enough dispatches to cover all counter sets, its counter data cannot be fully imputed and is excluded from metric calculations. A warning at analysis time lists any affected kernels. Their execution times remain visible in the Top Stats section so their runtime impact is still apparent. To get more complete counter coverage, you may consider running the kernel more times, collecting fewer metric blocks or counter sets, or using application replay instead of iteration multiplexing.
+
 * **Non-deterministic workloads**
 
   Workloads which dispatch kernels with non-deterministic names and launch parameters may trigger warnings for insufficient dispatch counts because iteration multiplexing identifies unique kernels by their names and optionally by their launch parameters; this is especially true of large AI workloads that dispatch kernels non-deterministically based on the model layers being used for the current input, and in such cases kernel filtering (``-k``, see :ref:`profiling-kernel-filtering`) of common kernels is recommended.

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -71,54 +71,6 @@ def test_df_column_equality(df: pd.DataFrame) -> bool:
     return df.eq(df.iloc[:, 0], axis=0).all(1).all()
 
 
-def detect_missing_counters(
-    df: pd.DataFrame,
-    workload_dir: Path,
-    join_type: str,
-) -> None:
-    """Detect missing counter values in joined dataframe.
-
-    Args:
-        df: Joined dataframe to check
-        workload_dir: Path to workload directory
-        join_type: Type of join performed ('kernel' or 'grid')
-    """
-    group_labels = ["Kernel_Name"]
-    if join_type == "grid":
-        group_labels.append("Grid_Size")
-
-    # Old workloads have *.txt, new workloads have pmc_perf_*.yaml
-    num_files = len(list(workload_dir.glob("perfmon/*.txt"))) + len(
-        list(workload_dir.glob("perfmon/pmc_perf_*.yaml"))
-    )
-    kernels_with_missing_counters = []
-    for _, groups in df.groupby(group_labels):
-        if groups["Dispatch_ID"].nunique() < num_files:
-            kernel_name = groups.iloc[0]["Kernel_Name"]
-            kernels_with_missing_counters.append(kernel_name)
-
-    if kernels_with_missing_counters:
-        unique_kernels = list(set(kernels_with_missing_counters))
-        kernel_list = "\n\n".join(
-            f"  Kernel {i}: {name}" for i, name in enumerate(unique_kernels, start=1)
-        )
-        console_warning(
-            "join_prof",
-            (
-                f"Insufficient number of kernel calls for kernels:\n\n"
-                f"{kernel_list}\n\n"
-                f"to collect all counters using iteration multiplexing. "
-                f"These kernels do not have enough dispatches to fill all "
-                f"{num_files} counter sets. Use kernel filtering (-k) to "
-                f"profile only the kernels of interest, e.g.: "
-                f"rocprof-compute profile -k <your_kernel> "
-                f"--iteration-multiplexing -- <app>. "
-                f"Alternatively, remove --iteration-multiplexing to use "
-                f"application replay instead."
-            ),
-        )
-
-
 class OmniAnalyze_Base:
     def __init__(
         self, args: argparse.Namespace, supported_archs: dict[str, str]
@@ -153,9 +105,9 @@ class OmniAnalyze_Base:
 
     @demarcate
     def iteration_multiplex_impute_counters(
-        self, df: pd.DataFrame, policy: str
+        self, df: pd.DataFrame, policy: str, workload_dir: Path
     ) -> pd.DataFrame:
-        return impute_counters_iteration_multiplex(df, policy)
+        return impute_counters_iteration_multiplex(df, policy, workload_dir)
 
     @demarcate
     def generate_configs(
@@ -454,7 +406,6 @@ class OmniAnalyze_Base:
         # Load profiling config from THIS workload directory (not args)
         profiling_config = file_io.load_profiling_config(str(workload_dir))
         format_rocprof = profiling_config.get("format_rocprof_output", "rocpd")
-        iteration_multiplexing = profiling_config.get("iteration_multiplexing", None)
         join_type = profiling_config.get("join_type", "grid")
         kokkos_trace = profiling_config.get("kokkos_trace", False)
 
@@ -482,10 +433,6 @@ class OmniAnalyze_Base:
                             writer.writerow(row)
 
             console_debug(f"Created file: {output_file}")
-
-            if iteration_multiplexing is not None:
-                df = pd.read_csv(output_file)
-                detect_missing_counters(df, workload_dir, join_type)
 
             return None
 
@@ -660,11 +607,6 @@ class OmniAnalyze_Base:
         # finally, join the drop key
         if "key" in df.columns:
             df = df.drop(columns=["key"])
-
-        console_debug("join_prof", "Checking for missing counter values...")
-
-        if iteration_multiplexing is not None:
-            detect_missing_counters(df, workload_dir, join_type)
 
         # save to file
         df.to_csv(output_file, index=False)

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -115,6 +115,7 @@ class cli_analysis(OmniAnalyze_Base):
                 workload.raw_pmc = self.iteration_multiplex_impute_counters(
                     workload.raw_pmc,
                     policy=self._profiling_config["iteration_multiplexing"],
+                    workload_dir=Path(path_info[0]),
                 )
 
             kernel_top_df, dispatch_info_df = file_io.create_df_kernel_top_stats(

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -313,6 +313,7 @@ class db_analysis(OmniAnalyze_Base):
                 raw_pmc = self.iteration_multiplex_impute_counters(
                     raw_pmc,
                     policy=self._profiling_config["iteration_multiplexing"],
+                    workload_dir=Path(workload_path),
                 )
 
             pmc_df_per_workload[workload_path] = raw_pmc["pmc_perf"]

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_webui.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_webui.py
@@ -171,6 +171,7 @@ class webui_analysis(OmniAnalyze_Base):
                     run_workload.raw_pmc = self.iteration_multiplex_impute_counters(
                         run_workload.raw_pmc,
                         policy=self._profiling_config["iteration_multiplexing"],
+                        workload_dir=Path(self.dest_dir),
                     )
 
                 # Apply filters to workload data
@@ -466,6 +467,7 @@ class webui_analysis(OmniAnalyze_Base):
             workload.raw_pmc = self.iteration_multiplex_impute_counters(
                 workload.raw_pmc,
                 policy=self._profiling_config["iteration_multiplexing"],
+                workload_dir=Path(self.dest_dir),
             )
 
         kernel_top_df, dispatch_info_df = file_io.create_df_kernel_top_stats(

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -687,12 +687,15 @@ def process_table_data(
                     if run_name != base_run:
                         # Calculate percent difference between current and
                         # base dataframe.
-                        base_series = pd.to_numeric(
+                        base_series_raw = pd.to_numeric(
                             base_df[header], errors="coerce"
-                        ).fillna(0.0)
-                        cur_series = pd.to_numeric(
-                            cur_df[header], errors="coerce"
-                        ).fillna(0.0)
+                        )
+                        cur_series_raw = pd.to_numeric(cur_df[header], errors="coerce")
+                        # Track which rows are NaN in either run so they can
+                        # be shown as "N/A" instead of being treated as zero.
+                        either_nan_mask = base_series_raw.isna() | cur_series_raw.isna()
+                        base_series = base_series_raw.fillna(0.0)
+                        cur_series = cur_series_raw.fillna(0.0)
 
                         # Calculate absolute and percent differences
                         absolute_diff = (cur_series - base_series).round(args.decimal)
@@ -709,6 +712,10 @@ def process_table_data(
                             + " ("
                             + percent_diff.astype(str)
                             + "%)"
+                        )
+                        # Replace entries where either run had NaN with "N/A"
+                        formatted_diff = formatted_diff.where(
+                            ~either_nan_mask, other="N/A"
                         )
 
                         result_df = pd.concat([result_df, formatted_diff], axis=1)

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -687,15 +687,12 @@ def process_table_data(
                     if run_name != base_run:
                         # Calculate percent difference between current and
                         # base dataframe.
-                        base_series_raw = pd.to_numeric(
+                        base_series = pd.to_numeric(
                             base_df[header], errors="coerce"
-                        )
-                        cur_series_raw = pd.to_numeric(cur_df[header], errors="coerce")
-                        # Track which rows are NaN in either run so they can
-                        # be shown as "N/A" instead of being treated as zero.
-                        either_nan_mask = base_series_raw.isna() | cur_series_raw.isna()
-                        base_series = base_series_raw.fillna(0.0)
-                        cur_series = cur_series_raw.fillna(0.0)
+                        ).fillna(0.0)
+                        cur_series = pd.to_numeric(
+                            cur_df[header], errors="coerce"
+                        ).fillna(0.0)
 
                         # Calculate absolute and percent differences
                         absolute_diff = (cur_series - base_series).round(args.decimal)
@@ -712,10 +709,6 @@ def process_table_data(
                             + " ("
                             + percent_diff.astype(str)
                             + "%)"
-                        )
-                        # Replace entries where either run had NaN with "N/A"
-                        formatted_diff = formatted_diff.where(
-                            ~either_nan_mask, other="N/A"
                         )
 
                         result_df = pd.concat([result_df, formatted_diff], axis=1)

--- a/projects/rocprofiler-compute/src/utils/utils_analysis.py
+++ b/projects/rocprofiler-compute/src/utils/utils_analysis.py
@@ -624,10 +624,17 @@ def reverse_multi_index_df_pmc(
 def impute_counters_iteration_multiplex(
     df_multi_index: pd.DataFrame,
     policy: str,
+    workload_dir: Path,
 ) -> pd.DataFrame:
     """
     Perform data imputation for missing counter values due to iteration multiplexing.
     """
+    # Counter buckets configured for the workload. A kernel needs at least
+    # this many dispatches to cover every bucket.
+    num_perfmon_files = len(list(workload_dir.glob("perfmon/*.txt"))) + len(
+        list(workload_dir.glob("perfmon/pmc_perf_*.yaml"))
+    )
+
     non_counter_column_index = [
         "Dispatch_ID",
         "GPU_ID",
@@ -677,6 +684,16 @@ def impute_counters_iteration_multiplex(
         incomplete_kernel_names: set[str] = set()
 
         for _, group in unique_occurences:
+            # Skip imputation entirely for undersampled kernels: nullify
+            # counters so metric evaluation excludes them. Non-counter columns
+            # are preserved for Top Stats (Block 1) timing.
+            if len(group) < num_perfmon_files:
+                group_copy = group.copy()
+                group_copy[counter_columns] = np.nan
+                incomplete_kernel_names.add(group_copy["Kernel_Name"].iloc[0])
+                group_dfs.append(group_copy)
+                continue
+
             # Identify counter buckets
             counter_groups: set[frozenset[str]] = set()
             for _, row in group.iterrows():
@@ -711,11 +728,6 @@ def impute_counters_iteration_multiplex(
                 .ffill()  # Propagate forward to end of subgroup
             )
 
-            group_copy, affected_kernels = _nullify_incomplete_dispatch_rows(
-                group_copy, counter_columns
-            )
-            incomplete_kernel_names.update(affected_kernels)
-
             group_dfs.append(group_copy)
 
         if incomplete_kernel_names:
@@ -732,26 +744,6 @@ def impute_counters_iteration_multiplex(
     return final_df
 
 
-def _nullify_incomplete_dispatch_rows(
-    group: pd.DataFrame,
-    counter_columns: list[str],
-) -> tuple[pd.DataFrame, set[str]]:
-    """
-    Nullify all counter columns for dispatch rows that still have NaN after imputation.
-
-    A dispatch row with any remaining NaN counter value cannot produce valid metrics.
-    Non-counter columns are preserved so that Top Stats timing data remains accurate.
-
-    Returns the group with nullified rows and the set of affected kernel names.
-    """
-    incomplete_mask = group[counter_columns].isnull().any(axis=1)
-    if not incomplete_mask.any():
-        return group, set()
-    group.loc[incomplete_mask, counter_columns] = np.nan
-    affected_kernels: set[str] = set(group.loc[incomplete_mask, "Kernel_Name"].unique())
-    return group, affected_kernels
-
-
 def _warn_kernels_with_incomplete_coverage(incomplete_kernel_names: set[str]) -> None:
     """
     Emit a warning listing kernels excluded from metrics due to missing counter data.
@@ -764,14 +756,14 @@ def _warn_kernels_with_incomplete_coverage(incomplete_kernel_names: set[str]) ->
         "imputation",
         (
             f"Some kernels have missing counter data after imputation and "
-            f"have been excluded from metric calculations:\n\n"
+            f"have been excluded from metrics calculations:\n\n"
             f"{kernel_list}\n\n"
-            f"Execution times for these kernels are still shown in Top Stats "
-            f"(Block 1).\n"
-            f"To get more complete counter coverage, you may consider:\n"
-            f"  - running the kernel more times\n"
-            f"  - collecting fewer metric blocks or counter sets\n"
-            f"  - using application replay instead of iteration multiplexing"
+            f"Execution times for these kernels are still shown in Top Stats.\n"
+            f"To get more complete kernel coverage for metrics calculations, "
+            f"you may consider:\n"
+            f"  - disabling iteration multiplexing to use application replay\n"
+            f"  - increasing the number of iterations for these kernels in "
+            f"the workload"
         ),
     )
 

--- a/projects/rocprofiler-compute/src/utils/utils_analysis.py
+++ b/projects/rocprofiler-compute/src/utils/utils_analysis.py
@@ -674,6 +674,8 @@ def impute_counters_iteration_multiplex(
             f"across {unique_occurences.ngroups} unique kernel configurations"
         )
 
+        incomplete_kernel_names: set[str] = set()
+
         for _, group in unique_occurences:
             # Identify counter buckets
             counter_groups: set[frozenset[str]] = set()
@@ -708,7 +710,16 @@ def impute_counters_iteration_multiplex(
                 .bfill()  # Propagate first valid value backward to start of subgroup
                 .ffill()  # Propagate forward to end of subgroup
             )
+
+            group_copy, affected_kernels = _nullify_incomplete_dispatch_rows(
+                group_copy, counter_columns
+            )
+            incomplete_kernel_names.update(affected_kernels)
+
             group_dfs.append(group_copy)
+
+        if incomplete_kernel_names:
+            _warn_kernels_with_incomplete_coverage(incomplete_kernel_names)
 
         # Create a new dataframe by concatenating all groups
         result_dfs.append(
@@ -719,6 +730,50 @@ def impute_counters_iteration_multiplex(
 
     final_df = pd.concat(result_dfs, keys=coll_levels, axis=1, copy=False)
     return final_df
+
+
+def _nullify_incomplete_dispatch_rows(
+    group: pd.DataFrame,
+    counter_columns: list[str],
+) -> tuple[pd.DataFrame, set[str]]:
+    """
+    Nullify all counter columns for dispatch rows that still have NaN after imputation.
+
+    A dispatch row with any remaining NaN counter value cannot produce valid metrics.
+    Non-counter columns are preserved so that Top Stats timing data remains accurate.
+
+    Returns the group with nullified rows and the set of affected kernel names.
+    """
+    incomplete_mask = group[counter_columns].isnull().any(axis=1)
+    if not incomplete_mask.any():
+        return group, set()
+    group.loc[incomplete_mask, counter_columns] = np.nan
+    affected_kernels: set[str] = set(group.loc[incomplete_mask, "Kernel_Name"].unique())
+    return group, affected_kernels
+
+
+def _warn_kernels_with_incomplete_coverage(incomplete_kernel_names: set[str]) -> None:
+    """
+    Emit a warning listing kernels excluded from metrics due to missing counter data.
+    """
+    kernel_list = "\n\n".join(
+        f"  Kernel {i}: {name}"
+        for i, name in enumerate(sorted(incomplete_kernel_names), start=1)
+    )
+    console_warning(
+        "imputation",
+        (
+            f"Some kernels have missing counter data after imputation and "
+            f"have been excluded from metric calculations:\n\n"
+            f"{kernel_list}\n\n"
+            f"Execution times for these kernels are still shown in Top Stats "
+            f"(Block 1).\n"
+            f"To get more complete counter coverage, you may consider:\n"
+            f"  - running the kernel more times\n"
+            f"  - collecting fewer metric blocks or counter sets\n"
+            f"  - using application replay instead of iteration multiplexing"
+        ),
+    )
 
 
 def merge_counters_spatial_multiplex(df_multi_index: pd.DataFrame) -> pd.DataFrame:

--- a/projects/rocprofiler-compute/tests/test_data_imputation.py
+++ b/projects/rocprofiler-compute/tests/test_data_imputation.py
@@ -1,6 +1,8 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
+from pathlib import Path
+
 import pandas as pd
 import pytest
 
@@ -22,7 +24,21 @@ def make_multilevel_df(data: dict) -> "pd.DataFrame":
     return df
 
 
-def test_impute_multiplex_kernel_policy():
+def seed_perfmon_files(tmp_path: Path, count: int) -> None:
+    """Create empty pmc_perf_*.yaml files so the imputation function sees the
+    expected number of counter buckets. Clears any existing perfmon files
+    first so the helper is safe to call multiple times in one test."""
+    perfmon = tmp_path / "perfmon"
+    perfmon.mkdir(exist_ok=True)
+    for stale in perfmon.glob("pmc_perf_*.yaml"):
+        stale.unlink()
+    for stale in perfmon.glob("*.txt"):
+        stale.unlink()
+    for i in range(count):
+        (perfmon / f"pmc_perf_{i}.yaml").touch()
+
+
+def test_impute_multiplex_kernel_policy(tmp_path: Path) -> None:
     """Test imputation with kernel policy on a single kernel."""
 
     data = {
@@ -45,7 +61,7 @@ def test_impute_multiplex_kernel_policy():
 
     df = make_multilevel_df(data)
 
-    result = utils.impute_counters_iteration_multiplex(df, "kernel")
+    result = utils.impute_counters_iteration_multiplex(df, "kernel", tmp_path)
 
     # Sort by Dispatch_ID to ensure consistent order
     result = result.sort_values(by=("file1", "Dispatch_ID"))
@@ -57,7 +73,7 @@ def test_impute_multiplex_kernel_policy():
     assert result[("file1", "Counter1")].iloc[1] == 100
 
 
-def test_impute_multiplex_kernel_launch_params_policy():
+def test_impute_multiplex_kernel_launch_params_policy(tmp_path: Path) -> None:
     """Test imputation with kernel_launch_params policy on a single kernel."""
 
     data = {
@@ -80,7 +96,9 @@ def test_impute_multiplex_kernel_launch_params_policy():
 
     df = make_multilevel_df(data)
 
-    result = utils.impute_counters_iteration_multiplex(df, "kernel_launch_params")
+    result = utils.impute_counters_iteration_multiplex(
+        df, "kernel_launch_params", tmp_path
+    )
 
     # Sort by Dispatch_ID to ensure consistent order
     result = result.sort_values(by=("file1", "Dispatch_ID"))
@@ -93,7 +111,7 @@ def test_impute_multiplex_kernel_launch_params_policy():
     assert len(result) == 3
 
 
-def test_impute_multiplex_kernel_launch_params_no_imputation():
+def test_impute_multiplex_kernel_launch_params_no_imputation(tmp_path: Path) -> None:
     """Test imputation with kernel_launch_params when no imputation is possible."""
 
     data = {
@@ -115,8 +133,13 @@ def test_impute_multiplex_kernel_launch_params_no_imputation():
     }
 
     df = make_multilevel_df(data)
+    # Counter1 and Counter2 form 2 round-robin buckets.
+    num_counter_bucket = 2
+    seed_perfmon_files(tmp_path, count=num_counter_bucket)
 
-    result = utils.impute_counters_iteration_multiplex(df, "kernel_launch_params")
+    result = utils.impute_counters_iteration_multiplex(
+        df, "kernel_launch_params", tmp_path
+    )
 
     # Sort by Dispatch_ID to ensure consistent order
     result = result.sort_values(by=("file1", "Dispatch_ID"))
@@ -134,7 +157,7 @@ def test_impute_multiplex_kernel_launch_params_no_imputation():
     assert pd.isna(result[("file1", "Counter2")].iloc[2])
 
 
-def test_impute_multiplex_multi_kernel_kernel_policy():
+def test_impute_multiplex_multi_kernel_kernel_policy(tmp_path: Path) -> None:
     """Test imputation with kernel policy on multiple kernels."""
 
     data = {
@@ -157,7 +180,7 @@ def test_impute_multiplex_multi_kernel_kernel_policy():
 
     df = make_multilevel_df(data)
 
-    result = utils.impute_counters_iteration_multiplex(df, "kernel")
+    result = utils.impute_counters_iteration_multiplex(df, "kernel", tmp_path)
 
     # Sort by Dispatch_ID to ensure consistent order
     result = result.sort_values(by=("file1", "Dispatch_ID"))
@@ -170,7 +193,9 @@ def test_impute_multiplex_multi_kernel_kernel_policy():
     assert len(result) == 3  # Ensure same number of rows
 
 
-def test_impute_multiplex_multi_kernel_kernel_launch_params_no_imputation():
+def test_impute_multiplex_multi_kernel_kernel_launch_params_no_imputation(
+    tmp_path: Path,
+) -> None:
     """Test imputation with kernel_launch_params when no imputation is possible."""
 
     data = {
@@ -192,8 +217,13 @@ def test_impute_multiplex_multi_kernel_kernel_launch_params_no_imputation():
     }
 
     df = make_multilevel_df(data)
+    # Counter1 and Counter2 form 2 round-robin buckets.
+    num_counter_bucket = 2
+    seed_perfmon_files(tmp_path, count=num_counter_bucket)
 
-    result = utils.impute_counters_iteration_multiplex(df, "kernel_launch_params")
+    result = utils.impute_counters_iteration_multiplex(
+        df, "kernel_launch_params", tmp_path
+    )
 
     # Sort by Dispatch_ID to ensure consistent order
     result = result.sort_values(by=("file1", "Dispatch_ID"))
@@ -211,7 +241,7 @@ def test_impute_multiplex_multi_kernel_kernel_launch_params_no_imputation():
     assert pd.isna(result[("file1", "Counter2")].iloc[2])
 
 
-def test_fewer_dispatches_single_kernel():
+def test_fewer_dispatches_single_kernel(tmp_path: Path) -> None:
     """
     Test imputation with kernel policy on a single kernel with
     fewer dispatches than buckets.
@@ -240,7 +270,10 @@ def test_fewer_dispatches_single_kernel():
     }
 
     df = make_multilevel_df(data)
-    result = utils.impute_counters_iteration_multiplex(df, "kernel")
+    # C1, C2, C3 form 3 round-robin buckets but the kernel only had 2 dispatches.
+    num_counter_bucket = 3
+    seed_perfmon_files(tmp_path, count=num_counter_bucket)
+    result = utils.impute_counters_iteration_multiplex(df, "kernel", tmp_path)
     result = result.sort_values(by=("file1", "Dispatch_ID"))
 
     assert isinstance(result, pd.DataFrame)
@@ -256,7 +289,7 @@ def test_fewer_dispatches_single_kernel():
     assert pd.isna(result[("file1", "C3")].iloc[1])
 
 
-def test_fewer_dispatches_multiple_kernels_both_incomplete():
+def test_fewer_dispatches_multiple_kernels_both_incomplete(tmp_path: Path) -> None:
     """
     Test imputation with kernel policy on multiple kernels, both incomplete.
 
@@ -284,7 +317,10 @@ def test_fewer_dispatches_multiple_kernels_both_incomplete():
     }
 
     df = make_multilevel_df(data)
-    result = utils.impute_counters_iteration_multiplex(df, "kernel")
+    # C1, C2, C3 form 3 round-robin buckets but each kernel has only 2 dispatches.
+    num_counter_bucket = 3
+    seed_perfmon_files(tmp_path, count=num_counter_bucket)
+    result = utils.impute_counters_iteration_multiplex(df, "kernel", tmp_path)
     result = result.sort_values(by=("file1", "Dispatch_ID"))
 
     assert isinstance(result, pd.DataFrame)
@@ -307,7 +343,7 @@ def test_fewer_dispatches_multiple_kernels_both_incomplete():
     assert pd.isna(result[("file1", "C3")].iloc[3])
 
 
-def test_fewer_dispatches_one_incomplete_one_complete():
+def test_fewer_dispatches_one_incomplete_one_complete(tmp_path: Path) -> None:
     """
     Test imputation with kernel policy on one kernel incomplete, second complete.
 
@@ -341,7 +377,10 @@ def test_fewer_dispatches_one_incomplete_one_complete():
     }
 
     df = make_multilevel_df(data)
-    result = utils.impute_counters_iteration_multiplex(df, "kernel")
+    # C1, C2, C3 form 3 round-robin buckets; kernel_a has only 2 dispatches.
+    num_counter_bucket = 3
+    seed_perfmon_files(tmp_path, count=num_counter_bucket)
+    result = utils.impute_counters_iteration_multiplex(df, "kernel", tmp_path)
     result = result.sort_values(by=("file1", "Dispatch_ID"))
 
     assert isinstance(result, pd.DataFrame)
@@ -367,7 +406,7 @@ def test_fewer_dispatches_one_incomplete_one_complete():
     assert result[("file1", "C3")].iloc[4] == 70
 
 
-def test_fewer_dispatches_same_kernel_different_launch_params():
+def test_fewer_dispatches_same_kernel_different_launch_params(tmp_path: Path) -> None:
     """
     Test imputation with kernel_launch_params on the same kernel
     with different launch params.
@@ -402,7 +441,12 @@ def test_fewer_dispatches_same_kernel_different_launch_params():
     }
 
     df = make_multilevel_df(data)
-    result = utils.impute_counters_iteration_multiplex(df, "kernel_launch_params")
+    # C1, C2, C3 form 3 round-robin buckets but each launch config has 2 dispatches.
+    num_counter_bucket = 3
+    seed_perfmon_files(tmp_path, count=num_counter_bucket)
+    result = utils.impute_counters_iteration_multiplex(
+        df, "kernel_launch_params", tmp_path
+    )
     result = result.sort_values(by=("file1", "Dispatch_ID"))
 
     assert isinstance(result, pd.DataFrame)
@@ -425,7 +469,9 @@ def test_fewer_dispatches_same_kernel_different_launch_params():
     assert pd.isna(result[("file1", "C3")].iloc[3])
 
 
-def test_fewer_dispatches_same_kernel_one_incomplete_one_complete():
+def test_fewer_dispatches_same_kernel_one_incomplete_one_complete(
+    tmp_path: Path,
+) -> None:
     """
     Test imputation with kernel_launch_params on one config incomplete, other complete.
 
@@ -460,7 +506,12 @@ def test_fewer_dispatches_same_kernel_one_incomplete_one_complete():
     }
 
     df = make_multilevel_df(data)
-    result = utils.impute_counters_iteration_multiplex(df, "kernel_launch_params")
+    # C1, C2, C3 form 3 round-robin buckets; the first launch config has 2 dispatches.
+    num_counter_bucket = 3
+    seed_perfmon_files(tmp_path, count=num_counter_bucket)
+    result = utils.impute_counters_iteration_multiplex(
+        df, "kernel_launch_params", tmp_path
+    )
     result = result.sort_values(by=("file1", "Dispatch_ID"))
 
     assert isinstance(result, pd.DataFrame)
@@ -486,7 +537,7 @@ def test_fewer_dispatches_same_kernel_one_incomplete_one_complete():
     assert result[("file1", "C3")].iloc[4] == 70
 
 
-def test_incomplete_last_group_single_kernel():
+def test_incomplete_last_group_single_kernel(tmp_path: Path) -> None:
     """
     Test imputation with kernel policy on a single kernel with incomplete last group.
 
@@ -513,7 +564,7 @@ def test_incomplete_last_group_single_kernel():
     }
 
     df = make_multilevel_df(data)
-    result = utils.impute_counters_iteration_multiplex(df, "kernel")
+    result = utils.impute_counters_iteration_multiplex(df, "kernel", tmp_path)
     result = result.sort_values(by=("file1", "Dispatch_ID"))
 
     assert isinstance(result, pd.DataFrame)
@@ -531,7 +582,7 @@ def test_incomplete_last_group_single_kernel():
     assert result[("file1", "C2")].iloc[2] == 20
 
 
-def test_incomplete_last_group_multiple_kernels_both_incomplete():
+def test_incomplete_last_group_multiple_kernels_both_incomplete(tmp_path: Path) -> None:
     """
     Test imputation with kernel policy on multiple kernels,
     both with incomplete last groups.
@@ -590,7 +641,7 @@ def test_incomplete_last_group_multiple_kernels_both_incomplete():
     }
 
     df = make_multilevel_df(data)
-    result = utils.impute_counters_iteration_multiplex(df, "kernel")
+    result = utils.impute_counters_iteration_multiplex(df, "kernel", tmp_path)
     result = result.sort_values(by=("file1", "Dispatch_ID"))
 
     assert isinstance(result, pd.DataFrame)
@@ -632,7 +683,7 @@ def test_incomplete_last_group_multiple_kernels_both_incomplete():
     assert result[("file1", "C3")].iloc[8] == 70
 
 
-def test_incomplete_last_group_one_incomplete_other_complete():
+def test_incomplete_last_group_one_incomplete_other_complete(tmp_path: Path) -> None:
     """
     Test imputation with kernel policy on one kernel incomplete, second kernel complete.
 
@@ -704,7 +755,7 @@ def test_incomplete_last_group_one_incomplete_other_complete():
     }
 
     df = make_multilevel_df(data)
-    result = utils.impute_counters_iteration_multiplex(df, "kernel")
+    result = utils.impute_counters_iteration_multiplex(df, "kernel", tmp_path)
     result = result.sort_values(by=("file1", "Dispatch_ID"))
 
     assert isinstance(result, pd.DataFrame)
@@ -749,7 +800,9 @@ def test_incomplete_last_group_one_incomplete_other_complete():
     assert result[("file1", "C3")].iloc[9] == 100
 
 
-def test_incomplete_last_group_same_kernel_different_launch_params():
+def test_incomplete_last_group_same_kernel_different_launch_params(
+    tmp_path: Path,
+) -> None:
     """
     Test imputation with kernel_launch_params on the same kernel
     with different launch params.
@@ -785,7 +838,9 @@ def test_incomplete_last_group_same_kernel_different_launch_params():
     }
 
     df = make_multilevel_df(data)
-    result = utils.impute_counters_iteration_multiplex(df, "kernel_launch_params")
+    result = utils.impute_counters_iteration_multiplex(
+        df, "kernel_launch_params", tmp_path
+    )
     result = result.sort_values(by=("file1", "Dispatch_ID"))
 
     assert isinstance(result, pd.DataFrame)
@@ -809,7 +864,9 @@ def test_incomplete_last_group_same_kernel_different_launch_params():
     assert result[("file1", "C2")].iloc[5] == 60
 
 
-def test_incomplete_last_group_same_kernel_one_incomplete_one_complete():
+def test_incomplete_last_group_same_kernel_one_incomplete_one_complete(
+    tmp_path: Path,
+) -> None:
     """
     Test imputation with kernel_launch_params on the same kernel
     with one config incomplete, other complete.
@@ -846,7 +903,9 @@ def test_incomplete_last_group_same_kernel_one_incomplete_one_complete():
     }
 
     df = make_multilevel_df(data)
-    result = utils.impute_counters_iteration_multiplex(df, "kernel_launch_params")
+    result = utils.impute_counters_iteration_multiplex(
+        df, "kernel_launch_params", tmp_path
+    )
     result = result.sort_values(by=("file1", "Dispatch_ID"))
 
     assert isinstance(result, pd.DataFrame)
@@ -872,7 +931,7 @@ def test_incomplete_last_group_same_kernel_one_incomplete_one_complete():
     assert result[("file1", "C2")].iloc[6] == 80
 
 
-def test_complete_last_group_single_kernel():
+def test_complete_last_group_single_kernel(tmp_path: Path) -> None:
     """
     Test imputation with kernel policy on a single kernel with complete last group.
 
@@ -900,7 +959,7 @@ def test_complete_last_group_single_kernel():
     }
 
     df = make_multilevel_df(data)
-    result = utils.impute_counters_iteration_multiplex(df, "kernel")
+    result = utils.impute_counters_iteration_multiplex(df, "kernel", tmp_path)
     result = result.sort_values(by=("file1", "Dispatch_ID"))
 
     assert isinstance(result, pd.DataFrame)
@@ -919,7 +978,7 @@ def test_complete_last_group_single_kernel():
     assert result[("file1", "C2")].iloc[3] == 40
 
 
-def test_complete_last_group_multiple_kernels_both_complete():
+def test_complete_last_group_multiple_kernels_both_complete(tmp_path: Path) -> None:
     """
     Test imputation with kernel policy on multiple kernels, both complete.
 
@@ -1051,7 +1110,7 @@ def test_complete_last_group_multiple_kernels_both_complete():
     }
 
     df = make_multilevel_df(data)
-    result = utils.impute_counters_iteration_multiplex(df, "kernel")
+    result = utils.impute_counters_iteration_multiplex(df, "kernel", tmp_path)
     result = result.sort_values(by=("file1", "Dispatch_ID"))
 
     assert isinstance(result, pd.DataFrame)
@@ -1102,7 +1161,9 @@ def test_complete_last_group_multiple_kernels_both_complete():
     assert result[("file1", "C3")].iloc[11] == 120
 
 
-def test_complete_last_group_same_kernel_different_launch_params():
+def test_complete_last_group_same_kernel_different_launch_params(
+    tmp_path: Path,
+) -> None:
     """
     Test imputation with kernel_launch_params on the same kernel
     with different launch params.
@@ -1140,7 +1201,9 @@ def test_complete_last_group_same_kernel_different_launch_params():
     }
 
     df = make_multilevel_df(data)
-    result = utils.impute_counters_iteration_multiplex(df, "kernel_launch_params")
+    result = utils.impute_counters_iteration_multiplex(
+        df, "kernel_launch_params", tmp_path
+    )
     result = result.sort_values(by=("file1", "Dispatch_ID"))
 
     assert isinstance(result, pd.DataFrame)
@@ -1171,7 +1234,9 @@ def test_complete_last_group_same_kernel_different_launch_params():
     assert result[("file1", "C2")].iloc[7] == 80
 
 
-def test_impute_counters_iteration_multiplex_incorrect_structure():
+def test_impute_counters_iteration_multiplex_incorrect_structure(
+    tmp_path: Path,
+) -> None:
     """Test imputation when the DataFrame is not a MultiIndex."""
 
     flat_df = pd.DataFrame({
@@ -1180,10 +1245,12 @@ def test_impute_counters_iteration_multiplex_incorrect_structure():
         "C1": [10],
     })
     with pytest.raises(ValueError, match="multi-index"):
-        utils.impute_counters_iteration_multiplex(flat_df, "kernel")
+        utils.impute_counters_iteration_multiplex(flat_df, "kernel", tmp_path)
 
 
-def test_impute_counters_iteration_multiplex_single_level_multiindex():
+def test_impute_counters_iteration_multiplex_single_level_multiindex(
+    tmp_path: Path,
+) -> None:
     """Test imputation when the DataFrame is a Single-level MultiIndex."""
 
     single_level_df = pd.DataFrame({
@@ -1195,10 +1262,12 @@ def test_impute_counters_iteration_multiplex_single_level_multiindex():
         ["Dispatch_ID", "Kernel_Name", "C1"]
     ])
     with pytest.raises(ValueError, match="multi-index"):
-        utils.impute_counters_iteration_multiplex(single_level_df, "kernel")
+        utils.impute_counters_iteration_multiplex(single_level_df, "kernel", tmp_path)
 
 
-def test_impute_counters_iteration_multiplex_missing_kernel_name():
+def test_impute_counters_iteration_multiplex_missing_kernel_name(
+    tmp_path: Path,
+) -> None:
     """
     Test imputation when the DataFrame is a valid 2-level MultiIndex
     but without the Kernel_Name column raises a KeyError.
@@ -1222,10 +1291,10 @@ def test_impute_counters_iteration_multiplex_missing_kernel_name():
     }
     df_no_kn = make_multilevel_df(data_no_kernel_name)
     with pytest.raises(KeyError):
-        utils.impute_counters_iteration_multiplex(df_no_kn, "kernel")
+        utils.impute_counters_iteration_multiplex(df_no_kn, "kernel", tmp_path)
 
 
-def test_impute_counters_iteration_multiplex_empty_dataframe():
+def test_impute_counters_iteration_multiplex_empty_dataframe(tmp_path: Path) -> None:
     """Test imputation when the DataFrame is a valid MultiIndex but has no data rows."""
 
     data_empty = {
@@ -1246,7 +1315,7 @@ def test_impute_counters_iteration_multiplex_empty_dataframe():
         ("file1", "C2"): [],
     }
     df_empty = make_multilevel_df(data_empty)
-    result = utils.impute_counters_iteration_multiplex(df_empty, "kernel")
+    result = utils.impute_counters_iteration_multiplex(df_empty, "kernel", tmp_path)
 
     # Empty-group fallback preserves the input schema with zero rows.
     assert isinstance(result, pd.DataFrame)
@@ -1254,7 +1323,7 @@ def test_impute_counters_iteration_multiplex_empty_dataframe():
     assert len(result) == 0
 
 
-def test_impute_counters_iteration_multiplex_all_counters_nan():
+def test_impute_counters_iteration_multiplex_all_counters_nan(tmp_path: Path) -> None:
     """
     Test imputation when all counter values are NaN.
 
@@ -1280,7 +1349,7 @@ def test_impute_counters_iteration_multiplex_all_counters_nan():
         ("file1", "C2"): [None, None, None],
     }
     df_all_nan = make_multilevel_df(data_all_nan)
-    result = utils.impute_counters_iteration_multiplex(df_all_nan, "kernel")
+    result = utils.impute_counters_iteration_multiplex(df_all_nan, "kernel", tmp_path)
 
     # Group was dropped (no valid counters) -- empty schema-aligned frame.
     assert isinstance(result, pd.DataFrame)
@@ -1288,7 +1357,7 @@ def test_impute_counters_iteration_multiplex_all_counters_nan():
     assert len(result) == 0
 
 
-def test_impute_counters_iteration_multiplex_no_counter_columns():
+def test_impute_counters_iteration_multiplex_no_counter_columns(tmp_path: Path) -> None:
     """
     Test imputation when the DataFrame contains only the 13 non-counter columns.
 
@@ -1312,7 +1381,9 @@ def test_impute_counters_iteration_multiplex_no_counter_columns():
         ("file1", "Kernel_ID"): [1, 1],
     }
     df_no_counters = make_multilevel_df(data_no_counters)
-    result = utils.impute_counters_iteration_multiplex(df_no_counters, "kernel")
+    result = utils.impute_counters_iteration_multiplex(
+        df_no_counters, "kernel", tmp_path
+    )
 
     # Group was dropped (no counter columns exist) -- empty schema-aligned frame.
     assert isinstance(result, pd.DataFrame)
@@ -1320,7 +1391,9 @@ def test_impute_counters_iteration_multiplex_no_counter_columns():
     assert len(result) == 0
 
 
-def test_impute_counters_iteration_multiplex_unrecognized_policy():
+def test_impute_counters_iteration_multiplex_unrecognized_policy(
+    tmp_path: Path,
+) -> None:
     """
     Test imputation when the policy is unrecognized.
     Any policy other than "kernel" falls through to the else branch
@@ -1346,10 +1419,10 @@ def test_impute_counters_iteration_multiplex_unrecognized_policy():
     }
     df_policy = make_multilevel_df(data_policy)
     result_invalid = utils.impute_counters_iteration_multiplex(
-        df_policy, "invalid_policy"
+        df_policy, "invalid_policy", tmp_path
     )
     result_klp = utils.impute_counters_iteration_multiplex(
-        df_policy, "kernel_launch_params"
+        df_policy, "kernel_launch_params", tmp_path
     )
     assert isinstance(result_invalid, pd.DataFrame)
     pd.testing.assert_frame_equal(
@@ -1358,7 +1431,7 @@ def test_impute_counters_iteration_multiplex_unrecognized_policy():
     )
 
 
-def test_impute_counters_iteration_multiplex_multi_file():
+def test_impute_counters_iteration_multiplex_multi_file(tmp_path: Path) -> None:
     """
     Test imputation when the DataFrame has multiple collection levels (multi-file).
 
@@ -1399,7 +1472,9 @@ def test_impute_counters_iteration_multiplex_multi_file():
         ("file2", "C2"): [None, 60],
     }
     df_multi_file = make_multilevel_df(data_multi_file)
-    result = utils.impute_counters_iteration_multiplex(df_multi_file, "kernel")
+    result = utils.impute_counters_iteration_multiplex(
+        df_multi_file, "kernel", tmp_path
+    )
     result = result.sort_values(by=("file1", "Dispatch_ID"))
 
     assert isinstance(result, pd.DataFrame)
@@ -1423,7 +1498,7 @@ def test_impute_counters_iteration_multiplex_multi_file():
     assert result[("file2", "C2")].iloc[1] == 60
 
 
-def test_incomplete_dispatches_nullify_counter_values():
+def test_incomplete_dispatches_nullify_counter_values(tmp_path: Path) -> None:
     """
     After imputation, any dispatch row that still has at least one NaN counter
     value should have ALL counter columns set to NaN (fully nullified).
@@ -1461,7 +1536,10 @@ def test_incomplete_dispatches_nullify_counter_values():
         ("file1", "C3"): [None, None],
     }
     df = make_multilevel_df(data)
-    result = utils.impute_counters_iteration_multiplex(df, "kernel")
+    # C1, C2, C3 form 3 round-robin buckets but the kernel only had 2 dispatches.
+    num_counter_bucket = 3
+    seed_perfmon_files(tmp_path, count=num_counter_bucket)
+    result = utils.impute_counters_iteration_multiplex(df, "kernel", tmp_path)
     result = result.sort_values(by=("file1", "Dispatch_ID")).reset_index(drop=True)
 
     assert isinstance(result, pd.DataFrame)
@@ -1484,3 +1562,48 @@ def test_incomplete_dispatches_nullify_counter_values():
     assert result[("file1", "Start_Timestamp")].iloc[1] == 1200
     assert result[("file1", "End_Timestamp")].iloc[1] == 1700
     assert result[("file1", "Kernel_Name")].iloc[1] == "kernel_a"
+
+
+def test_undersampled_kernel_nullified_against_perfmon_file_count(
+    tmp_path: Path,
+) -> None:
+    """
+    A kernel whose dispatch count is below the number of configured perfmon
+    files must be nullified even when its visible counter columns are fully
+    imputed. This guards the degenerate case where some buckets never reached
+    the joined dataframe at all.
+    """
+    # 5 perfmon buckets configured, kernel only has 2 dispatches; the visible
+    # counters look fully populated but bucket coverage is incomplete.
+    num_counter_bucket = 5
+    seed_perfmon_files(tmp_path, count=num_counter_bucket)
+
+    data = {
+        ("file1", "Dispatch_ID"): [1, 2],
+        ("file1", "GPU_ID"): [0, 0],
+        ("file1", "Grid_Size"): [1024, 1024],
+        ("file1", "Workgroup_Size"): [64, 64],
+        ("file1", "LDS_Per_Workgroup"): [32, 32],
+        ("file1", "Scratch_Per_Workitem"): [0, 0],
+        ("file1", "Arch_VGPR"): [16, 16],
+        ("file1", "Accum_VGPR"): [0, 0],
+        ("file1", "SGPR"): [32, 32],
+        ("file1", "Kernel_Name"): ["kernel_a", "kernel_a"],
+        ("file1", "Start_Timestamp"): [1000, 1200],
+        ("file1", "End_Timestamp"): [1500, 1700],
+        ("file1", "Kernel_ID"): [1, 1],
+        ("file1", "C1"): [10, 30],
+        ("file1", "C2"): [20, 40],
+    }
+    df = make_multilevel_df(data)
+    result = utils.impute_counters_iteration_multiplex(df, "kernel", tmp_path)
+    result = result.sort_values(by=("file1", "Dispatch_ID")).reset_index(drop=True)
+
+    assert pd.isna(result[("file1", "C1")].iloc[0])
+    assert pd.isna(result[("file1", "C2")].iloc[0])
+    assert pd.isna(result[("file1", "C1")].iloc[1])
+    assert pd.isna(result[("file1", "C2")].iloc[1])
+
+    # Timestamps and kernel name preserved for Top Stats.
+    assert result[("file1", "Start_Timestamp")].iloc[0] == 1000
+    assert result[("file1", "Kernel_Name")].iloc[0] == "kernel_a"

--- a/projects/rocprofiler-compute/tests/test_data_imputation.py
+++ b/projects/rocprofiler-compute/tests/test_data_imputation.py
@@ -124,9 +124,13 @@ def test_impute_multiplex_kernel_launch_params_no_imputation():
     assert isinstance(result, pd.DataFrame)
     assert len(result) == 3  # Ensure same number of rows
 
-    # No imputation possible
+    # Each dispatch still has NaN in the other counter after imputation,
+    # so all counter columns are nullified for all dispatches.
+    assert pd.isna(result[("file1", "Counter1")].iloc[0])
     assert pd.isna(result[("file1", "Counter2")].iloc[0])
     assert pd.isna(result[("file1", "Counter1")].iloc[1])
+    assert pd.isna(result[("file1", "Counter2")].iloc[1])
+    assert pd.isna(result[("file1", "Counter1")].iloc[2])
     assert pd.isna(result[("file1", "Counter2")].iloc[2])
 
 
@@ -197,10 +201,14 @@ def test_impute_multiplex_multi_kernel_kernel_launch_params_no_imputation():
     assert isinstance(result, pd.DataFrame)
     assert len(result) == 3  # Ensure same number of rows
 
-    # No imputation possible
+    # Each dispatch still has NaN in the other counter after imputation,
+    # so all counter columns are nullified for all dispatches.
+    assert pd.isna(result[("file1", "Counter1")].iloc[0])
     assert pd.isna(result[("file1", "Counter2")].iloc[0])
     assert pd.isna(result[("file1", "Counter1")].iloc[1])
+    assert pd.isna(result[("file1", "Counter2")].iloc[1])
     assert pd.isna(result[("file1", "Counter1")].iloc[2])
+    assert pd.isna(result[("file1", "Counter2")].iloc[2])
 
 
 def test_fewer_dispatches_single_kernel():
@@ -238,14 +246,13 @@ def test_fewer_dispatches_single_kernel():
     assert isinstance(result, pd.DataFrame)
     assert len(result) == 2
 
-    # C1 and C2 are imputed across both dispatches
-    assert result[("file1", "C1")].iloc[0] == 10
-    assert result[("file1", "C2")].iloc[0] == 20
-    assert result[("file1", "C1")].iloc[1] == 10
-    assert result[("file1", "C2")].iloc[1] == 20
-
-    # C3 remains NaN (no dispatch provided a value)
+    # C3 was never collected (NaN on all rows after imputation), so all rows are
+    # nullified — C1 and C2 are also set to NaN to fully exclude these dispatches.
+    assert pd.isna(result[("file1", "C1")].iloc[0])
+    assert pd.isna(result[("file1", "C2")].iloc[0])
     assert pd.isna(result[("file1", "C3")].iloc[0])
+    assert pd.isna(result[("file1", "C1")].iloc[1])
+    assert pd.isna(result[("file1", "C2")].iloc[1])
     assert pd.isna(result[("file1", "C3")].iloc[1])
 
 
@@ -283,20 +290,20 @@ def test_fewer_dispatches_multiple_kernels_both_incomplete():
     assert isinstance(result, pd.DataFrame)
     assert len(result) == 4
 
-    # kernel_a (dispatches 1-2): C1 and C2 imputed, C3 remains NaN
-    assert result[("file1", "C1")].iloc[0] == 10
-    assert result[("file1", "C2")].iloc[0] == 20
+    # kernel_a (dispatches 1-2): C3 never collected → all rows nullified
+    assert pd.isna(result[("file1", "C1")].iloc[0])
+    assert pd.isna(result[("file1", "C2")].iloc[0])
     assert pd.isna(result[("file1", "C3")].iloc[0])
-    assert result[("file1", "C1")].iloc[1] == 10
-    assert result[("file1", "C2")].iloc[1] == 20
+    assert pd.isna(result[("file1", "C1")].iloc[1])
+    assert pd.isna(result[("file1", "C2")].iloc[1])
     assert pd.isna(result[("file1", "C3")].iloc[1])
 
-    # kernel_b (dispatches 3-4): C1 and C2 imputed, C3 remains NaN
-    assert result[("file1", "C1")].iloc[2] == 40
-    assert result[("file1", "C2")].iloc[2] == 60
+    # kernel_b (dispatches 3-4): C3 never collected → all rows nullified
+    assert pd.isna(result[("file1", "C1")].iloc[2])
+    assert pd.isna(result[("file1", "C2")].iloc[2])
     assert pd.isna(result[("file1", "C3")].iloc[2])
-    assert result[("file1", "C1")].iloc[3] == 40
-    assert result[("file1", "C2")].iloc[3] == 60
+    assert pd.isna(result[("file1", "C1")].iloc[3])
+    assert pd.isna(result[("file1", "C2")].iloc[3])
     assert pd.isna(result[("file1", "C3")].iloc[3])
 
 
@@ -340,15 +347,15 @@ def test_fewer_dispatches_one_incomplete_one_complete():
     assert isinstance(result, pd.DataFrame)
     assert len(result) == 5
 
-    # kernel_a (dispatches 1-2): C1 and C2 imputed, C3 remains NaN
-    assert result[("file1", "C1")].iloc[0] == 10
-    assert result[("file1", "C2")].iloc[0] == 20
+    # kernel_a (dispatches 1-2): C3 never collected → all rows nullified
+    assert pd.isna(result[("file1", "C1")].iloc[0])
+    assert pd.isna(result[("file1", "C2")].iloc[0])
     assert pd.isna(result[("file1", "C3")].iloc[0])
-    assert result[("file1", "C1")].iloc[1] == 10
-    assert result[("file1", "C2")].iloc[1] == 20
+    assert pd.isna(result[("file1", "C1")].iloc[1])
+    assert pd.isna(result[("file1", "C2")].iloc[1])
     assert pd.isna(result[("file1", "C3")].iloc[1])
 
-    # kernel_b (dispatches 3-5): all 3 counters fully imputed
+    # kernel_b (dispatches 3-5): all 3 counters fully imputed, no NaN → not nullified
     assert result[("file1", "C1")].iloc[2] == 50
     assert result[("file1", "C2")].iloc[2] == 60
     assert result[("file1", "C3")].iloc[2] == 70
@@ -401,20 +408,20 @@ def test_fewer_dispatches_same_kernel_different_launch_params():
     assert isinstance(result, pd.DataFrame)
     assert len(result) == 4
 
-    # Config 1 (dispatches 1-2): C1 and C2 imputed, C3 remains NaN
-    assert result[("file1", "C1")].iloc[0] == 10
-    assert result[("file1", "C2")].iloc[0] == 20
+    # Config 1 (dispatches 1-2): C3 never collected → all rows nullified
+    assert pd.isna(result[("file1", "C1")].iloc[0])
+    assert pd.isna(result[("file1", "C2")].iloc[0])
     assert pd.isna(result[("file1", "C3")].iloc[0])
-    assert result[("file1", "C1")].iloc[1] == 10
-    assert result[("file1", "C2")].iloc[1] == 20
+    assert pd.isna(result[("file1", "C1")].iloc[1])
+    assert pd.isna(result[("file1", "C2")].iloc[1])
     assert pd.isna(result[("file1", "C3")].iloc[1])
 
-    # Config 2 (dispatches 3-4): C1 and C2 imputed, C3 remains NaN
-    assert result[("file1", "C1")].iloc[2] == 30
-    assert result[("file1", "C2")].iloc[2] == 40
+    # Config 2 (dispatches 3-4): C3 never collected → all rows nullified
+    assert pd.isna(result[("file1", "C1")].iloc[2])
+    assert pd.isna(result[("file1", "C2")].iloc[2])
     assert pd.isna(result[("file1", "C3")].iloc[2])
-    assert result[("file1", "C1")].iloc[3] == 30
-    assert result[("file1", "C2")].iloc[3] == 40
+    assert pd.isna(result[("file1", "C1")].iloc[3])
+    assert pd.isna(result[("file1", "C2")].iloc[3])
     assert pd.isna(result[("file1", "C3")].iloc[3])
 
 
@@ -459,15 +466,15 @@ def test_fewer_dispatches_same_kernel_one_incomplete_one_complete():
     assert isinstance(result, pd.DataFrame)
     assert len(result) == 5
 
-    # Config 1 (dispatches 1-2): C1 and C2 imputed, C3 remains NaN
-    assert result[("file1", "C1")].iloc[0] == 10
-    assert result[("file1", "C2")].iloc[0] == 20
+    # Config 1 (dispatches 1-2): C3 never collected → all rows nullified
+    assert pd.isna(result[("file1", "C1")].iloc[0])
+    assert pd.isna(result[("file1", "C2")].iloc[0])
     assert pd.isna(result[("file1", "C3")].iloc[0])
-    assert result[("file1", "C1")].iloc[1] == 10
-    assert result[("file1", "C2")].iloc[1] == 20
+    assert pd.isna(result[("file1", "C1")].iloc[1])
+    assert pd.isna(result[("file1", "C2")].iloc[1])
     assert pd.isna(result[("file1", "C3")].iloc[1])
 
-    # Config 2 (dispatches 3-5): all 3 counters fully imputed
+    # Config 2 (dispatches 3-5): all 3 counters fully imputed, no NaN → not nullified
     assert result[("file1", "C1")].iloc[2] == 50
     assert result[("file1", "C2")].iloc[2] == 60
     assert result[("file1", "C3")].iloc[2] == 70
@@ -518,7 +525,8 @@ def test_incomplete_last_group_single_kernel():
     assert result[("file1", "C1")].iloc[1] == 10
     assert result[("file1", "C2")].iloc[1] == 20
 
-    # Subgroup 2 (dispatch 3, incomplete): C2 filled from previous_fill_values
+    # Subgroup 2 (dispatch 3, incomplete): C2 filled from previous subgroup
+    # via cross-subgroup ffill; no NaN remains so the row is kept as valid.
     assert result[("file1", "C1")].iloc[2] == 30
     assert result[("file1", "C2")].iloc[2] == 20
 
@@ -599,7 +607,7 @@ def test_incomplete_last_group_multiple_kernels_both_incomplete():
     assert result[("file1", "C2")].iloc[2] == 20
     assert result[("file1", "C3")].iloc[2] == 30
 
-    # kernel_a subgroup 2 (dispatch 4, incomplete): C2 and C3 from previous_fill_values
+    # kernel_a subgroup 2 (dispatch 4, incomplete): filled via cross-subgroup ffill
     assert result[("file1", "C1")].iloc[3] == 40
     assert result[("file1", "C2")].iloc[3] == 20
     assert result[("file1", "C3")].iloc[3] == 30
@@ -615,7 +623,7 @@ def test_incomplete_last_group_multiple_kernels_both_incomplete():
     assert result[("file1", "C2")].iloc[6] == 60
     assert result[("file1", "C3")].iloc[6] == 70
 
-    # kernel_b subgroup 2 (dispatches 8-9, incomplete): C3 from previous_fill_values
+    # kernel_b subgroup 2 (dispatches 8-9, incomplete): filled via cross-subgroup ffill
     assert result[("file1", "C1")].iloc[7] == 80
     assert result[("file1", "C2")].iloc[7] == 90
     assert result[("file1", "C3")].iloc[7] == 70
@@ -713,7 +721,7 @@ def test_incomplete_last_group_one_incomplete_other_complete():
     assert result[("file1", "C2")].iloc[2] == 20
     assert result[("file1", "C3")].iloc[2] == 30
 
-    # kernel_a subgroup 2 (dispatch 4, incomplete): C2 and C3 from previous_fill_values
+    # kernel_a subgroup 2 (dispatch 4, incomplete): filled via cross-subgroup ffill
     assert result[("file1", "C1")].iloc[3] == 40
     assert result[("file1", "C2")].iloc[3] == 20
     assert result[("file1", "C3")].iloc[3] == 30
@@ -729,7 +737,7 @@ def test_incomplete_last_group_one_incomplete_other_complete():
     assert result[("file1", "C2")].iloc[6] == 60
     assert result[("file1", "C3")].iloc[6] == 70
 
-    # kernel_b subgroup 2 (dispatches 8-10): complete round, no fallback needed
+    # kernel_b subgroup 2 (dispatches 8-10): complete round, no nullification
     assert result[("file1", "C1")].iloc[7] == 80
     assert result[("file1", "C2")].iloc[7] == 90
     assert result[("file1", "C3")].iloc[7] == 100
@@ -783,7 +791,8 @@ def test_incomplete_last_group_same_kernel_different_launch_params():
     assert isinstance(result, pd.DataFrame)
     assert len(result) == 6
 
-    # Config 1 (dispatches 1-3): incomplete last, C2 from previous_fill_values
+    # Config 1 (dispatches 1-3): subgroup 0 (1-2) complete, subgroup 1 (3) filled
+    # via cross-subgroup ffill; no NaN remains so dispatch 3 is kept as valid.
     assert result[("file1", "C1")].iloc[0] == 10
     assert result[("file1", "C2")].iloc[0] == 20
     assert result[("file1", "C1")].iloc[1] == 10
@@ -791,7 +800,7 @@ def test_incomplete_last_group_same_kernel_different_launch_params():
     assert result[("file1", "C1")].iloc[2] == 30
     assert result[("file1", "C2")].iloc[2] == 20
 
-    # Config 2 (dispatches 4-6): incomplete last, C1 from previous_fill_values
+    # Config 2 (dispatches 4-6): subgroup 0 (4-5) complete, subgroup 1 (6) filled
     assert result[("file1", "C1")].iloc[3] == 50
     assert result[("file1", "C2")].iloc[3] == 60
     assert result[("file1", "C1")].iloc[4] == 50
@@ -843,7 +852,8 @@ def test_incomplete_last_group_same_kernel_one_incomplete_one_complete():
     assert isinstance(result, pd.DataFrame)
     assert len(result) == 7
 
-    # Config 1 (dispatches 1-3): incomplete last, C2 from previous_fill_values
+    # Config 1 (dispatches 1-3): subgroup 0 (1-2) complete, subgroup 1 (3) filled
+    # via cross-subgroup ffill; no NaN remains so dispatch 3 is kept as valid.
     assert result[("file1", "C1")].iloc[0] == 10
     assert result[("file1", "C2")].iloc[0] == 20
     assert result[("file1", "C1")].iloc[1] == 10
@@ -851,7 +861,7 @@ def test_incomplete_last_group_same_kernel_one_incomplete_one_complete():
     assert result[("file1", "C1")].iloc[2] == 30
     assert result[("file1", "C2")].iloc[2] == 20
 
-    # Config 2 (dispatches 4-7): 2 complete rounds, no fallback needed
+    # Config 2 (dispatches 4-7): 2 complete rounds, no nullification
     assert result[("file1", "C1")].iloc[3] == 50
     assert result[("file1", "C2")].iloc[3] == 60
     assert result[("file1", "C1")].iloc[4] == 50
@@ -1411,3 +1421,66 @@ def test_impute_counters_iteration_multiplex_multi_file():
     assert result[("file2", "C2")].iloc[0] == 60
     assert result[("file2", "C1")].iloc[1] == 50
     assert result[("file2", "C2")].iloc[1] == 60
+
+
+def test_incomplete_dispatches_nullify_counter_values():
+    """
+    After imputation, any dispatch row that still has at least one NaN counter
+    value should have ALL counter columns set to NaN (fully nullified).
+    Non-counter columns (timestamps, kernel name, etc.) must be preserved so
+    that Top Stats (Block 1) timing data remains accurate.
+
+    Scenario:
+      kernel_a: 2 dispatches, 3 counter buckets {C1}, {C2}, {C3}.
+      Only 2 dispatches are available so the {C3} bucket is never reached:
+        - Dispatch 1: C1=10, C2=NaN, C3=NaN
+        - Dispatch 2: C1=NaN, C2=20, C3=NaN
+      After bfill/ffill imputation:
+        - C1 and C2 are filled for both dispatches (C1=10, C2=20)
+        - C3 remains NaN for both dispatches (never collected)
+      Post-imputation nullification:
+        - Both dispatches have C3=NaN -> all counter columns set to NaN
+        - Timestamp and Kernel_Name columns are preserved
+    """
+    data = {
+        ("file1", "Dispatch_ID"): [1, 2],
+        ("file1", "GPU_ID"): [0, 0],
+        ("file1", "Grid_Size"): [1024, 1024],
+        ("file1", "Workgroup_Size"): [64, 64],
+        ("file1", "LDS_Per_Workgroup"): [32, 32],
+        ("file1", "Scratch_Per_Workitem"): [0, 0],
+        ("file1", "Arch_VGPR"): [16, 16],
+        ("file1", "Accum_VGPR"): [0, 0],
+        ("file1", "SGPR"): [32, 32],
+        ("file1", "Kernel_Name"): ["kernel_a", "kernel_a"],
+        ("file1", "Start_Timestamp"): [1000, 1200],
+        ("file1", "End_Timestamp"): [1500, 1700],
+        ("file1", "Kernel_ID"): [1, 1],
+        ("file1", "C1"): [10, None],
+        ("file1", "C2"): [None, 20],
+        ("file1", "C3"): [None, None],
+    }
+    df = make_multilevel_df(data)
+    result = utils.impute_counters_iteration_multiplex(df, "kernel")
+    result = result.sort_values(by=("file1", "Dispatch_ID")).reset_index(drop=True)
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 2
+
+    # Both dispatches: C3 was never collected so it remains NaN after imputation,
+    # triggering nullification of all counter columns on both rows.
+    assert pd.isna(result[("file1", "C1")].iloc[0])
+    assert pd.isna(result[("file1", "C2")].iloc[0])
+    assert pd.isna(result[("file1", "C3")].iloc[0])
+    assert pd.isna(result[("file1", "C1")].iloc[1])
+    assert pd.isna(result[("file1", "C2")].iloc[1])
+    assert pd.isna(result[("file1", "C3")].iloc[1])
+
+    # Non-counter columns must still be populated on both dispatches
+    # (preserved for Top Stats / Block 1 timing display).
+    assert result[("file1", "Start_Timestamp")].iloc[0] == 1000
+    assert result[("file1", "End_Timestamp")].iloc[0] == 1500
+    assert result[("file1", "Kernel_Name")].iloc[0] == "kernel_a"
+    assert result[("file1", "Start_Timestamp")].iloc[1] == 1200
+    assert result[("file1", "End_Timestamp")].iloc[1] == 1700
+    assert result[("file1", "Kernel_Name")].iloc[1] == "kernel_a"

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -5960,7 +5960,7 @@ def test_amdsmi_get_gpu_memory_partition():
 # =============================================================================
 
 
-def test_impute_counters_iteration_multiplex():
+def test_impute_counters_iteration_multiplex(tmp_path: Path) -> None:
     """Test impute_counters_iteration_multiplex with sample DataFrame."""
     import pandas as pd
 
@@ -5986,7 +5986,7 @@ def test_impute_counters_iteration_multiplex():
     df.columns = pd.MultiIndex.from_tuples(df.columns)
 
     # For "kernel" policy
-    result = utils_analysis.impute_counters_iteration_multiplex(df, "kernel")
+    result = utils_analysis.impute_counters_iteration_multiplex(df, "kernel", tmp_path)
     # Sort by Dispatch_ID to ensure consistent order
     result = result.sort_values(by=("file1", "Dispatch_ID"))
     assert isinstance(result, pd.DataFrame)
@@ -5997,7 +5997,7 @@ def test_impute_counters_iteration_multiplex():
 
     # For "kernel_launch_params" policy
     result = utils_analysis.impute_counters_iteration_multiplex(
-        df, "kernel_launch_params"
+        df, "kernel_launch_params", tmp_path
     )
     # Sort by Dispatch_ID to ensure consistent order
     result = result.sort_values(by=("file1", "Dispatch_ID"))
@@ -6030,7 +6030,7 @@ def test_impute_counters_iteration_multiplex():
     df.columns = pd.MultiIndex.from_tuples(df.columns)
 
     result = utils_analysis.impute_counters_iteration_multiplex(
-        df, "kernel_launch_params"
+        df, "kernel_launch_params", tmp_path
     )
     # Sort by Dispatch_ID to ensure consistent order
     result = result.sort_values(by=("file1", "Dispatch_ID"))
@@ -6065,7 +6065,7 @@ def test_impute_counters_iteration_multiplex():
     df.columns = pd.MultiIndex.from_tuples(df.columns)
 
     # For "kernel" policy
-    result = utils_analysis.impute_counters_iteration_multiplex(df, "kernel")
+    result = utils_analysis.impute_counters_iteration_multiplex(df, "kernel", tmp_path)
     # Sort by Dispatch_ID to ensure consistent order
     result = result.sort_values(by=("file1", "Dispatch_ID"))
     # Assert Counter1 and Counter2 imputed for first and last dispatches
@@ -6098,7 +6098,7 @@ def test_impute_counters_iteration_multiplex():
     df.columns = pd.MultiIndex.from_tuples(df.columns)
 
     result = utils_analysis.impute_counters_iteration_multiplex(
-        df, "kernel_launch_params"
+        df, "kernel_launch_params", tmp_path
     )
     # Sort by Dispatch_ID to ensure consistent order
     result = result.sort_values(by=("file1", "Dispatch_ID"))
@@ -6136,7 +6136,7 @@ def test_impute_counters_iteration_multiplex():
     df = pd.DataFrame(data)
     df.columns = pd.MultiIndex.from_tuples(df.columns)
     result = utils_analysis.impute_counters_iteration_multiplex(
-        df, "kernel_launch_params"
+        df, "kernel_launch_params", tmp_path
     )
     result = result.sort_values(by=("file1", "Dispatch_ID"))
 


### PR DESCRIPTION
## Motivation

Iteration multiplexing collects counters round-robin across dispatches. Kernels with fewer dispatches than counter buckets (incidental kernels, or single-dispatch groups under `kernel_launch_params`) end up with some `NaN` counters. Aggregations then run over different dispatch sets per counter, giving inconsistent metrics.

## Technical Details

### `src/utils/utils_analysis.py`

`impute_counters_iteration_multiplex` now takes `workload_dir` and counts buckets itself (`perfmon/*.txt` + `perfmon/pmc_perf_*.yaml`). Before the bfill/ffill pass, any group where `len(group) < num_perfmon_files` has its counter columns set to `NaN` and is skipped. Non-counter columns are kept so Top Stats (Block 1) timing still shows the kernel. Affected kernel names are reported once via `_warn_kernels_with_incomplete_coverage`.

### `src/rocprof_compute_analyze/analysis_base.py`

`detect_missing_counters` and its two `join_prof` call sites are removed; the imputation pass owns the warning now. `analysis_cli.py`, `analysis_db.py`, and `analysis_webui.py` pass `workload_dir` through.

## JIRA ID

AIPROFCOMP-466

## Test Plan

- ctest

## Test Result

- [x] ctest

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.