### PR TITLE
[rocprofiler-sdk] Fix signal handler crash in forked child processes

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -130,6 +130,23 @@ namespace
 // Thread for safe cleanup output generation
 auto output_generation_thread = common::Synchronized<std::optional<std::thread>>{};
 
+// Track whether this process is a forked child of the original profiled process.
+// Forked children may inherit rocprofv3/ROCm state from the parent, so they should
+// not run normal rocprofv3 finalization from the signal handler.
+auto forked_child_process = std::atomic<bool>{false};
+
+void
+rocprofv3_atfork_child()
+{
+    forked_child_process.store(true, std::memory_order_relaxed);
+}
+
+bool
+is_forked_child_process()
+{
+    return forked_child_process.load(std::memory_order_relaxed);
+}
+
 using sigaction_t      = struct sigaction;
 using signal_func_t    = sighandler_t (*)(int signum, sighandler_t handler);
 using sigaction_func_t = int (*)(int signum,
@@ -2167,6 +2184,10 @@ tool_attach(rocprofiler_client_detach_t /*detach_func*/,
 int
 tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
 {
+    static auto _atfork_once = std::once_flag{};
+    std::call_once(_atfork_once,
+                   []() { pthread_atfork(nullptr, nullptr, rocprofv3_atfork_child); });
+
     static constexpr auto null_context_id = rocprofiler_context_id_t{.handle = 0};
     static constexpr auto null_buffer_id  = rocprofiler_buffer_id_t{.handle = 0};
 
@@ -3510,6 +3531,19 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
         {
             auto status = wait_pid(itr, WUNTRACED | WNOHANG);
             if(status) diagnose_status(itr, status.value());
+        }
+
+        if(is_forked_child_process())
+        {
+            ROCP_WARNING << fmt::format(
+                "[PPID={}][PID={}][TID={}][rocprofv3_error_signal_handler] "
+                "rocprofv3 skipping finalization in forked child process after signal {}",
+                getppid(),
+                getpid(),
+                common::get_tid(),
+                signo);
+
+            _Exit(signo == SIGTERM ? EXIT_SUCCESS : EXIT_FAILURE);
         }
 
         ROCP_WARNING << fmt::format(


### PR DESCRIPTION
## Motivation

This PR is to fix SEGFAULT which occurs when rocprofv3 profiling PyTorch Dataloaders w/ persistent workers.

## Technical Details

  Why This Use Case Triggers the Bug:

  1. PyTorch DataLoader forks worker processes
  2. Forked children inherit rocprofv3 state from the parent:
  3. When signal arrives in child (e.g., SIGTERM during cleanup):
    - Signal handler tries to finalize rocprofv3
    - Attempts to free/cleanup resources that belong to the parent process
    - Memory corruption / double-free / invalid pointer access
    - SEGFAULT

The PR fixes the signal handler for the child process:
  - Detects it's a fork via `pthread_atfork` callback
  - Skips all rocprofv3 finalization in the signal handler
  - Uses `_Exit()` to terminate immediately without atexit handlers
  - Doesn't touch any of the inherited parent state

Implementation details:
  ✅ pthread_atfork registration - catches the fork event
  ✅ Early exit in signal handler - before any finalization
  ✅ _Exit() usage - avoids atexit handlers that might also have issues
  ✅ Placement after child wait - ensures we don't interfere with parent's child management


## JIRA ID

AIPROFSDK-40

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
