### PR TITLE
libhsakmt: Fix APU detection in memory stress tests (issue #3635)

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.cpp
@@ -782,8 +782,9 @@ void KFDMemoryTest::SearchLargestBuffer(int allocNode, const HsaMemFlags &memFla
  */
 void KFDMemoryTest::LargestSysBufferTest(int gpuNode) {
 
-    if (!hsakmt_is_dgpu()) {
-        LOG() << "Skipping test: Running on APU fails and locks the system." << std::endl;
+    const HsaNodeProperties *pNodeProps = m_NodeInfo.GetNodeProperties(gpuNode);
+    if (pNodeProps && pNodeProps->Integrated) {
+        LOG() << "Skipping test on APU." << std::endl;
         return;
     }
 
@@ -823,8 +824,9 @@ TEST_F(KFDMemoryTest, LargestSysBufferTest) {
 
 void KFDMemoryTest::LargestVramBufferTest(int gpuNode) {
 
-    if (!hsakmt_is_dgpu()) {
-        LOG() << "Skipping test: Running on APU fails and locks the system." << std::endl;
+    const HsaNodeProperties *pNodeProps = m_NodeInfo.GetNodeProperties(gpuNode);
+    if (pNodeProps && pNodeProps->Integrated) {
+        LOG() << "Skipping test on APU." << std::endl;
         return;
     }
 
@@ -873,8 +875,9 @@ TEST_F(KFDMemoryTest, LargestVramBufferTest) {
  */
 void KFDMemoryTest::BigSysBufferStressTest(int gpuNode) {
 
-    if (!hsakmt_is_dgpu()) {
-        LOG() << "Skipping test: Running on APU fails and locks the system." << std::endl;
+    const HsaNodeProperties *pNodeProps = m_NodeInfo.GetNodeProperties(gpuNode);
+    if (pNodeProps && pNodeProps->Integrated) {
+        LOG() << "Skipping test on APU." << std::endl;
         return;
     }
 


### PR DESCRIPTION
## Motivation

KFDMemory stress tests (`LargestSysBufferTest`, `LargestVramBufferTest`, `BigSysBufferStressTest`) are designed to skip on iGPU/APU systems with the message "Running on APU fails and locks the system." However, on modern iGPUs (gfx1036, gfx1150, gfx1151), the APU detection fails, which causes tests to run instead of skip. This results in 128GB memory allocations that OOM-kill kfdtest and hang the system.

## Technical Details

The existing `!hsakmt_is_dgpu()` guard misclassifies modern iGPUs (gfx1036, gfx1150, gfx1151) as dGPUs because `NumCPUCores=0` on the GPU topology node, causing the check `if (NumCPUCores && NumFComputeCores)` to fail.

Solution: Check `HsaNodeProperties::Integrated` field (set from kernel's `AMD_IS_APU` flag) as the authoritative APU indicator. 
[outdated] Keep `hsakmt_is_dgpu()` as fallback for backward compatibility.

## JIRA ID

Resolves #3635

## Test Plan

  1. Verified on gfx1150 system that cpu_cores_count=0 causes misdetection
  2. Confirmed code compiles successfully and links without errors
  3. Logic verified: Integrated field correctly identifies iGPUs

## Test Result

```bash 
sudo ./kfdtest --gtest_filter="KFDMemoryTest.LargestSysBufferTest"             [  PASSED  ] 1 test.
sudo ./kfdtest --gtest_filter="KFDMemoryTest.LargestVramBufferTest"          [  PASSED  ] 1 test.
sudo ./kfdtest --gtest_filter="KFDMemoryTest.BigSysBufferStressTest"          [  PASSED  ] 1 test.

```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
