### PR TITLE
[rocjitsu] Fix DirectToLDS missing workgroup LDS base offset

### DIFF
--- a/experimental/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/experimental/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -3862,7 +3862,7 @@ class CodeGenerator:
             L.append(f'    d->num_elems = {ne};')
             L.append('    d->is_load = true;')
             L.append('    d->lds_dst = true;')
-            L.append('    d->lds_base = wf.m0();')
+            L.append('    d->lds_base = wf.m0() + wf.lds_base();')
             L.append(f'    d->mtype = {self._mtype_expr()};')
             L.append(f'    d->non_temporal = {nt};')
             L.append(f'    {addr_fn}(inst_, wf, *d);')

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/mubuf.cpp
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/mubuf.cpp
@@ -382,7 +382,7 @@ void BufferLoadUbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -424,7 +424,7 @@ void BufferLoadSbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -467,7 +467,7 @@ void BufferLoadUshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -509,7 +509,7 @@ void BufferLoadSshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -552,7 +552,7 @@ void BufferLoadDwordMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -594,7 +594,7 @@ void BufferLoadDwordx2Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 2;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -636,7 +636,7 @@ void BufferLoadDwordx3Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 3;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -678,7 +678,7 @@ void BufferLoadDwordx4Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 4;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1030,7 +1030,7 @@ void BufferLoadUbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1073,7 +1073,7 @@ void BufferLoadUbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1116,7 +1116,7 @@ void BufferLoadSbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1160,7 +1160,7 @@ void BufferLoadSbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1204,7 +1204,7 @@ void BufferLoadShortD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1247,7 +1247,7 @@ void BufferLoadShortD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/mubuf.cpp
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/mubuf.cpp
@@ -399,7 +399,7 @@ void BufferLoadUbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -442,7 +442,7 @@ void BufferLoadSbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -486,7 +486,7 @@ void BufferLoadUshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -529,7 +529,7 @@ void BufferLoadSshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -573,7 +573,7 @@ void BufferLoadDwordMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -616,7 +616,7 @@ void BufferLoadDwordx2Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 2;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -659,7 +659,7 @@ void BufferLoadDwordx3Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 3;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -702,7 +702,7 @@ void BufferLoadDwordx4Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 4;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1077,7 +1077,7 @@ void BufferLoadUbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1121,7 +1121,7 @@ void BufferLoadUbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1165,7 +1165,7 @@ void BufferLoadSbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1210,7 +1210,7 @@ void BufferLoadSbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1255,7 +1255,7 @@ void BufferLoadShortD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1299,7 +1299,7 @@ void BufferLoadShortD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx9(inst_.glc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/mubuf.cpp
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/mubuf.cpp
@@ -400,7 +400,7 @@ void BufferLoadUbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -443,7 +443,7 @@ void BufferLoadSbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -487,7 +487,7 @@ void BufferLoadUshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -530,7 +530,7 @@ void BufferLoadSshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -574,7 +574,7 @@ void BufferLoadDwordMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -617,7 +617,7 @@ void BufferLoadDwordx2Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 2;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -660,7 +660,7 @@ void BufferLoadDwordx3Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 3;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -703,7 +703,7 @@ void BufferLoadDwordx4Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 4;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1078,7 +1078,7 @@ void BufferLoadUbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1122,7 +1122,7 @@ void BufferLoadUbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1166,7 +1166,7 @@ void BufferLoadSbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1211,7 +1211,7 @@ void BufferLoadSbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1256,7 +1256,7 @@ void BufferLoadShortD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1300,7 +1300,7 @@ void BufferLoadShortD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/mubuf.cpp
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/mubuf.cpp
@@ -400,7 +400,7 @@ void BufferLoadUbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -443,7 +443,7 @@ void BufferLoadSbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -487,7 +487,7 @@ void BufferLoadUshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -530,7 +530,7 @@ void BufferLoadSshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -574,7 +574,7 @@ void BufferLoadDwordMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -617,7 +617,7 @@ void BufferLoadDwordx2Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 2;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -660,7 +660,7 @@ void BufferLoadDwordx3Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 3;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -703,7 +703,7 @@ void BufferLoadDwordx4Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 4;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1078,7 +1078,7 @@ void BufferLoadUbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1122,7 +1122,7 @@ void BufferLoadUbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1166,7 +1166,7 @@ void BufferLoadSbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1211,7 +1211,7 @@ void BufferLoadSbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1256,7 +1256,7 @@ void BufferLoadShortD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1300,7 +1300,7 @@ void BufferLoadShortD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx940(inst_.sc0, inst_.sc1, inst_.nt);
     d->non_temporal = inst_.nt;
     mubuf_calculate_addresses(inst_, wf, *d);

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/mubuf.cpp
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/mubuf.cpp
@@ -214,7 +214,7 @@ void BufferLoadUbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -256,7 +256,7 @@ void BufferLoadSbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -299,7 +299,7 @@ void BufferLoadUshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -341,7 +341,7 @@ void BufferLoadSshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -384,7 +384,7 @@ void BufferLoadDwordMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -426,7 +426,7 @@ void BufferLoadDwordx2Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 2;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -468,7 +468,7 @@ void BufferLoadDwordx4Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 4;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -510,7 +510,7 @@ void BufferLoadDwordx3Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 3;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -862,7 +862,7 @@ void BufferLoadUbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -905,7 +905,7 @@ void BufferLoadUbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -948,7 +948,7 @@ void BufferLoadSbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -992,7 +992,7 @@ void BufferLoadSbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1036,7 +1036,7 @@ void BufferLoadShortD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1079,7 +1079,7 @@ void BufferLoadShortD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);

--- a/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/mubuf.cpp
+++ b/experimental/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/mubuf.cpp
@@ -214,7 +214,7 @@ void BufferLoadUbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -256,7 +256,7 @@ void BufferLoadSbyteMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -299,7 +299,7 @@ void BufferLoadUshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -341,7 +341,7 @@ void BufferLoadSshortMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -384,7 +384,7 @@ void BufferLoadDwordMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -426,7 +426,7 @@ void BufferLoadDwordx2Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 2;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -468,7 +468,7 @@ void BufferLoadDwordx4Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 4;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -510,7 +510,7 @@ void BufferLoadDwordx3Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 3;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -862,7 +862,7 @@ void BufferLoadUbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -905,7 +905,7 @@ void BufferLoadUbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -948,7 +948,7 @@ void BufferLoadSbyteD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -992,7 +992,7 @@ void BufferLoadSbyteD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1036,7 +1036,7 @@ void BufferLoadShortD16Mubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);
@@ -1079,7 +1079,7 @@ void BufferLoadShortD16HiMubuf::execute_impl(amdgpu::Wavefront &wf) {
     d->num_elems = 1;
     d->is_load = true;
     d->lds_dst = true;
-    d->lds_base = wf.m0();
+    d->lds_base = wf.m0() + wf.lds_base();
     d->mtype = amdgpu::mtype_from_flags_gfx10(inst_.glc, inst_.dlc, inst_.slc);
     d->non_temporal = 0;
     mubuf_calculate_addresses(inst_, wf, *d);


### PR DESCRIPTION
Fixes: https://github.com/ROCm/rocm-systems/issues/5716

DirectToLDS buffer loads (buffer_load with lds=1) write data from global memory directly into LDS. The emulator computed the LDS write address as M0 + lane_id * data_size, but omitted the workgroup's LDS base offset. DS instructions (ds_read/ds_write) correctly add wf.lds_base() to every address (addr_calc_scalar.h:73). This mismatch meant DirectToLDS writes from workgroup N>0 landed in workgroup 0's LDS region, while DS reads from the correct region found stale data.

The bug only manifests when multiple workgroups share a CU. The emulator config's simd_count controls this: simd_count=1024 (default) packs more workgroups per CU, triggering the bug. simd_count=256 masks it.

The fix adds wf.lds_base() to the DirectToLDS base address in all ISA generations (cdna1-4, rdna1-2).

**Note:** I have not actually regenerated the .cpp files, is this possible on my end yet?

Reproducer described in: https://github.com/ROCm/rocm-systems/issues/5716 is fixed

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
