### PR TITLE
AIRUNTIME-1973 - [libhsakmt][wddm] Fix SEGFAULT for SDMA queues in CreateHwQueue

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -757,9 +757,18 @@ bool WDDMDevice::CreateHwQueue(WDDMQueue *queue) {
   memset(priv_data, 0, priv_size);
   bool FwManagedGfxState = SupportStateShadowingByCpFw();
   uint32_t* doorbell_loc = nullptr;
-  auto queue_memory = static_cast<ComputeQueue*>(queue)->GetAmdQueueMemory();
-  auto resource = queue_memory->KmtHandle();
-  Wkmi::FillinHwQueuePrivData(priv_data, FwManagedGfxState, queue->prio, IsAqlSupported(),
+  // amd_queue_memory_ / KmtHandle and AQL parameters only apply when the queue
+  // is an AQL ComputeQueue. SDMAQueue (and SwsCompute non-AQL queues) must not
+  // be down-cast to ComputeQueue here -- doing so reads garbage and crashes.
+  ComputeQueue* compute_queue = dynamic_cast<ComputeQueue*>(queue);
+  D3DKMT_HANDLE resource = 0;
+  bool is_aql = false;
+  if (compute_queue != nullptr && IsAqlSupported()) {
+    auto queue_memory = compute_queue->GetAmdQueueMemory();
+    resource = queue_memory->KmtHandle();
+    is_aql = true;
+  }
+  Wkmi::FillinHwQueuePrivData(priv_data, FwManagedGfxState, queue->prio, is_aql,
       queue->cmdbuf_addr, queue->cmdbuf_size, reinterpret_cast<uintptr_t>(queue->ring_wptr),
       reinterpret_cast<uintptr_t>(queue->ring_rptr), resource, &doorbell_loc);
 


### PR DESCRIPTION
## Motivation

Fix the ~290 `0xC0000005` SEGFAULTs in HIP `catch_tests` on Windows + ROCr backend, NAVI 48 (`gfx1201`).

## Technical Details

`WDDMDevice::CreateHwQueue` `static_cast`-ed every `WDDMQueue*` to `ComputeQueue*` and dereferenced `GetAmdQueueMemory()`. `SDMAQueue` has no `amd_queue_memory_`, so SDMA queue creation read garbage and crashed in `librocdxg`. Replaced with `dynamic_cast`; `resource` / `is_aql` are now only set for actual AQL `ComputeQueue`s, and SDMA / non-AQL queues pass `resource = 0`, `is_aql = false`.

Linux is unaffected — `libhsakmt`'s Linux build does not compile `src/dxg/wddm/*`.

## JIRA ID

Resolves AIRUNTIME-1973.

## Test Plan

Windows 11 + NAVI 48, HIP built from this branch: reran the 291 originally-SEGFAULTing `catch_tests` and sanity-sampled other categories.

## Test Result

288/291 now pass. The 3 remaining failures (`Unit_Warp_Ballot_Positive_Basic`, `Unit_Warp_Vote_Any_Positive_Basic`, `Unit_Warp_Vote_All_Positive_Basic`) are unrelated kernel-dispatch hangs previously masked by the SEGFAULT; tracked separately. `HSA_ENABLE_SDMA=0` workaround no longer needed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
