### PR TITLE
[RCCL] Fix AllGather hang under UBR and single-stream (ROCM-21756)

### DIFF
--- a/projects/rccl/src/device/prims_simple.h
+++ b/projects/rccl/src/device/prims_simple.h
@@ -56,12 +56,6 @@ class Primitives<
   struct ncclConnFifo* connFifo = NULL;
   T* connEltsFifo;
   T* directBuff = NULL;
-  // ROCM-21756: cached host-side intent flag from ncclDevWorkColl::regUsed
-  // (or the OR of p2p sendIpcReg/recvIpcReg). When 0, setDataPtrs never
-  // assigned directBuff, so waitPeer must not dereference it. Used in lieu
-  // of a per-thread `directBuff != NULL` check because it (a) mirrors the
-  // existing `Direct && fn.work->regUsed` gate in process() below, (b) is
-  // decided once on the host and survives any future change to setDataPtrs.
   int regUsed = 0;
   uint64_t *connStepPtr;
   uint64_t connStepCache; // Cache last seen value of (*connStepPtr)
@@ -201,7 +195,7 @@ private:
       } else if (!isSendNotRecv && DirectRecv) {
         if ((flags & DirectRead) && regUsed && directBuff != nullptr) {
           ptrs[index] = directBuff + srcIx + offset;
-        } else if ((flags & DirectWrite) && directBuff != nullptr) {
+        } else if ((flags & DirectWrite) && regUsed && directBuff != nullptr) {
           ptrs[index] = directBuff + dstIx + offset;  // send to next from my output buffer
         } else {
           ptrs[index] = connEltsFifo + (step%NCCL_STEPS)*connStepSize;
@@ -515,7 +509,7 @@ public:
           if ((flags & ConnFifoEnabled) && connFifo[step%NCCL_STEPS].mode == NCCL_MODE_OFFSET) {
             int offset = loadInt(&connFifo[step%NCCL_STEPS].offset);
             ptrs[index] = connEltsFifo + offset/sizeof(T);
-          } else if (Direct && regUsed) {  // ROCM-21756: cached; was fn.work->regUsed
+          } else if (Direct && regUsed) {
             if (isSendNotRecv) {
               if (flags & DirectWrite) {
                 ptrs[index] = directBuff;
@@ -834,11 +828,7 @@ public:
       // coverity[negative_returns:FALSE] => coverity thinks that index could be -1 but that's not actually the case
       // coverity[var_deref_model] => coverity thinks work can dereferenced if NULL but this is not the case
       setDataPtrs(inputBuf, outputBuf, redOpArg, (struct ncclDevWorkCollReg*)collWork, sendIpcReg || recvIpcReg, peer, collWork != nullptr ? collWork->acc : nullptr);
-      // ROCM-21756: cache the same gate setDataPtrs used to decide whether
-      // to assign directBuff. waitPeer reads this flag to avoid dereferencing
-      // an unassigned (NULL) directBuff when the unsafe single-stream fast
-      // path in enqueue.cc lets the kernel run before IPC registration is
-      // visible to it.
+      // cached host-side intent flag from ncclDevWorkColl::regUsed
       regUsed = (sendIpcReg || recvIpcReg) ? 1 : 0;
       // coverity[uninit_member] => coverity thinks fan.n is not initialized
     } else if (mode == primsModePatRs || mode == primsModePatAg) { // Connect to all ranks +/- 2^n

--- a/projects/rccl/src/device/prims_simple.h
+++ b/projects/rccl/src/device/prims_simple.h
@@ -56,6 +56,13 @@ class Primitives<
   struct ncclConnFifo* connFifo = NULL;
   T* connEltsFifo;
   T* directBuff = NULL;
+  // ROCM-21756: cached host-side intent flag from ncclDevWorkColl::regUsed
+  // (or the OR of p2p sendIpcReg/recvIpcReg). When 0, setDataPtrs never
+  // assigned directBuff, so waitPeer must not dereference it. Used in lieu
+  // of a per-thread `directBuff != NULL` check because it (a) mirrors the
+  // existing `Direct && fn.work->regUsed` gate in process() below, (b) is
+  // decided once on the host and survives any future change to setDataPtrs.
+  int regUsed = 0;
   uint64_t *connStepPtr;
   uint64_t connStepCache; // Cache last seen value of (*connStepPtr)
   int      connStepSize; // Connection step size
@@ -184,7 +191,7 @@ private:
         // directBuff is only assigned by setDataPtrs when (Direct && ipcReg);
         // when Direct=1 but no buffer was registered, it stays NULL and using
         // it as a base would compute an invalid GPU address.
-        if ((flags & DirectWrite) && directBuff != nullptr) {
+        if ((flags & DirectWrite) && regUsed && directBuff != nullptr) {
           ptrs[index] = directBuff + dstIx + offset;
         } else if ((flags & DirectRead) && directBuff != nullptr) {  // empty send
           ptrs[index] = nullptr;
@@ -192,7 +199,7 @@ private:
           ptrs[index] = connEltsFifo + (step%NCCL_STEPS)*connStepSize;
         }
       } else if (!isSendNotRecv && DirectRecv) {
-        if ((flags & DirectRead) && directBuff != nullptr) {
+        if ((flags & DirectRead) && regUsed && directBuff != nullptr) {
           ptrs[index] = directBuff + srcIx + offset;
         } else if ((flags & DirectWrite) && directBuff != nullptr) {
           ptrs[index] = directBuff + dstIx + offset;  // send to next from my output buffer
@@ -508,7 +515,7 @@ public:
           if ((flags & ConnFifoEnabled) && connFifo[step%NCCL_STEPS].mode == NCCL_MODE_OFFSET) {
             int offset = loadInt(&connFifo[step%NCCL_STEPS].offset);
             ptrs[index] = connEltsFifo + offset/sizeof(T);
-          } else if (Direct && fn.work->regUsed) {
+          } else if (Direct && regUsed) {  // ROCM-21756: cached; was fn.work->regUsed
             if (isSendNotRecv) {
               if (flags & DirectWrite) {
                 ptrs[index] = directBuff;
@@ -827,6 +834,12 @@ public:
       // coverity[negative_returns:FALSE] => coverity thinks that index could be -1 but that's not actually the case
       // coverity[var_deref_model] => coverity thinks work can dereferenced if NULL but this is not the case
       setDataPtrs(inputBuf, outputBuf, redOpArg, (struct ncclDevWorkCollReg*)collWork, sendIpcReg || recvIpcReg, peer, collWork != nullptr ? collWork->acc : nullptr);
+      // ROCM-21756: cache the same gate setDataPtrs used to decide whether
+      // to assign directBuff. waitPeer reads this flag to avoid dereferencing
+      // an unassigned (NULL) directBuff when the unsafe single-stream fast
+      // path in enqueue.cc lets the kernel run before IPC registration is
+      // visible to it.
+      regUsed = (sendIpcReg || recvIpcReg) ? 1 : 0;
       // coverity[uninit_member] => coverity thinks fan.n is not initialized
     } else if (mode == primsModePatRs || mode == primsModePatAg) { // Connect to all ranks +/- 2^n
       flags |= PatMode;

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -1802,18 +1802,13 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
     cudaStream_t deviceStream, launchOrder;
     NCCLCHECKGOTO(ncclStrongStreamAcquire(planner->capturingGraph, &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream), result, failure);
 
-    if (persistent || planner->numStreams != 1) {
-      // userStream[0] waits on each userStream[i]...
-      for (struct ncclCudaStreamList* l=planner->streams->next; l != nullptr; l = l->next) {
-        CUDACHECKGOTO(cudaEventRecord(comm->sharedRes->scratchEvent, l->stream), result, failure);
-        CUDACHECKGOTO(cudaStreamWaitEvent(launchStream, comm->sharedRes->scratchEvent, 0), result, failure);
-      }
-      // userStream[0] waits on deviceStream
-      NCCLCHECKGOTO(ncclStreamWaitStream(launchStream, deviceStream, comm->sharedRes->scratchEvent), result, failure);
-    } else if (planner->streams->stream != comm->lastStream && comm->lastStream != nullptr && !persistent) {
-      // Stream changed from last call, create dependency against last NCCL kernel launch
-      CUDACHECKGOTO(hipStreamWaitEvent(planner->streams->stream, comm->doneEvent, 0), result, failure);
+    // userStream[0] waits on each userStream[i]...
+    for (struct ncclCudaStreamList* l=planner->streams->next; l != nullptr; l = l->next) {
+      CUDACHECKGOTO(cudaEventRecord(comm->sharedRes->scratchEvent, l->stream), result, failure);
+      CUDACHECKGOTO(cudaStreamWaitEvent(launchStream, comm->sharedRes->scratchEvent, 0), result, failure);
     }
+    // userStream[0] waits on deviceStream
+    NCCLCHECKGOTO(ncclStreamWaitStream(launchStream, deviceStream, comm->sharedRes->scratchEvent), result, failure);
 
     bool capturing = ncclCudaGraphValid(planner->capturingGraph);
     enum ncclImplicitOrder implicitOrder;
@@ -1906,14 +1901,6 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
 
   CUfunction fn;
   CUDACHECKGOTO(cudaGetFuncBySymbol(&fn, sym), ret, do_return);
-
-  if (planner->numStreams == 1 && !plan->persistent) {
-    latency_profiler::collTraceRecordStartEvent(comm, launchStream, event.get());
-    comm->lastStream = planner->streams->stream;
-    CUCHECKGOTO(cuLaunchKernel(fn, grid.x, grid.y, grid.z, block.x, block.y, block.z, smem, launchStream, nullptr, extra), ret, do_return);
-    latency_profiler::collTraceRecordEndEvent(comm, plan, launchStream, std::move(event));
-    return ncclSuccess;
-  }
 
 #if !defined(__HIP_PLATFORM_AMD__) || !defined(__HIPCC__)
   if (CUDART_VERSION >= 11080 && driverVersion >= 11080) {
@@ -2041,7 +2028,6 @@ ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
     // back to us for reclaiming via callbackQueue.
     ncclIntruQueueConstruct(&planner->planQueue);
 
-    bool capturing = ncclCudaGraphValid(planner->capturingGraph);
     cudaStream_t launchStream = planner->streams->stream; // First user stream gets launch
     cudaStream_t deviceStream, launchOrder;
     cudaEvent_t finishedEvent = comm->sharedRes->scratchEvent;
@@ -2058,25 +2044,24 @@ ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
       CUDACHECK(cudaEventCreateWithFlags(&comm->sharedRes->scratchEvent, cudaEventDisableTiming));
     }
 
-    if (capturing || planner->numStreams != 1 || ncclParamLaunchOrderImplicit()) {
-      CUDACHECK(cudaEventRecord(finishedEvent, launchStream));
-      // deviceStream waits on userStream[0]
-      NCCLCHECK(ncclStrongStreamAcquiredWorkStream(planner->capturingGraph, &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream));
+    CUDACHECK(cudaEventRecord(finishedEvent, launchStream));
+    // deviceStream waits on userStream[0]
+    NCCLCHECK(ncclStrongStreamAcquiredWorkStream(planner->capturingGraph, &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream));
 
-      // We know that deviceStream is strictly behind the launchStream because launchStream
-      // synced with it before kernel launch. This allows us to to see deviceStream waiting
-      // on launchStream as a fast-forward. When building CUDA graphs fast forwards should
-      // be handled specially so as not to create graphs with a blowup in the number of edges.
-      // So we could do this:
-      //   CUDACHECK(cudaStreamWaitEvent(deviceStream, finishedEvent, 0));
-      // But instead we do:
-      NCCLCHECK(ncclStreamAdvanceToEvent(planner->capturingGraph, deviceStream, finishedEvent));
+    // We know that deviceStream is strictly behind the launchStream because launchStream
+    // synced with it before kernel launch. This allows us to to see deviceStream waiting
+    // on launchStream as a fast-forward. When building CUDA graphs fast forwards should
+    // be handled specially so as not to create graphs with a blowup in the number of edges.
+    // So we could do this:
+    //   CUDACHECK(cudaStreamWaitEvent(deviceStream, finishedEvent, 0));
+    // But instead we do:
+    NCCLCHECK(ncclStreamAdvanceToEvent(planner->capturingGraph, deviceStream, finishedEvent));
 
-      // Each userStream[i] waits on userStream[0]
-      for (struct ncclCudaStreamList* l=planner->streams->next; l != nullptr; l = l->next) {
-        CUDACHECK(cudaStreamWaitEvent(l->stream, finishedEvent, 0));
-      }
+    // Each userStream[i] waits on userStream[0]
+    for (struct ncclCudaStreamList* l=planner->streams->next; l != nullptr; l = l->next) {
+      CUDACHECK(cudaStreamWaitEvent(l->stream, finishedEvent, 0));
     }
+    bool capturing = ncclCudaGraphValid(planner->capturingGraph);
     enum ncclImplicitOrder implicitOrder;
     NCCLCHECK(getImplicitOrder(&implicitOrder, capturing));
     if (implicitOrder != ncclImplicitOrderNone) {
@@ -2865,7 +2850,6 @@ static ncclResult_t ncclPlannerSetCapturingGraph(struct ncclComm* comm, struct n
         l->stream = info->stream;
         l->next = planner->streams;
         planner->streams = l;
-        planner->numStreams++;
         break;
       }
       if (l->stream == info->stream)

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -409,8 +409,6 @@ struct ncclKernelPlanner {
   bool persistent;
   // The list of user streams aggregated over all tasks present.
   struct ncclCudaStreamList* streams;
-  // Keep track of the number of user streams
-  int numStreams;
   // The most recent user stream. Ignored if streams==nullptr
   cudaStream_t streamRecent;
   // The graph capturing all user streams or invalid if none. Thus we restrict the


### PR DESCRIPTION
## Motivation

DeepSpeed ZeRO-3 training workloads (e.g., Llama-2-70B via `HSA_NO_SCRATCH_RECLAIM=1 NCCL_DEBUG=INFO bash run_clm_wikitext.sh --model_name_or_path=meta-llama/Llama-2-70b-chat-hf --deepspeed=ds_config_zero_3.json`) hang during evaluation on ROCm 7.12+. The hang reproduces under three independent triggers:

- Default environment — UBR changes the default of `NCCL_LOCAL_REGISTER` to `1` starting HIP `>= 71260540`, which routes large AllGathers through the registered Direct path.
- `NCCL_LOCAL_REGISTER=1` (explicit) — same path.
- `RCCL_DIRECT_ALLGATHER_DISABLE=1` — forces the ring kernel.

Goal: restore functional correctness of AllGather for ZeRO-3 workloads across all three configurations on current RCCL develop.

## Technical Details

Two independent defects cause the hang. Both are fixed by this PR:

**1. Host-side: drop the unsafe single-stream fast-path in `enqueue.cc` (re-apply NCCL PR [#3001](https://github.com/NVIDIA/nccl/pull/3001))**

Commit `fa361248fc` ("Fix p2p_batching, revert PR 3001, disable warpSpeed on gfx942") reverted upstream PR #3001 and re-introduced a `planner->numStreams == 1 && !plan->persistent` fast-path in `ncclLaunchPrepare` / `ncclLaunchKernel` / `ncclLaunchFinish`. That fast-path skips the launchStream↔deviceStream synchronization (`cudaEventRecord` + `cudaStreamWaitEvent` / `ncclStreamAdvanceToEvent`) and bypasses `ncclLaunchFinish`'s userStream bookkeeping. For single-user-stream, non-persistent callers (ZeRO-3), this deadlocks the ring AllGather kernel against the proxy thread.

- Always take the safe userStream / deviceStream sync in `ncclLaunchPrepare`.
- Remove the early-return single-stream launch path in `ncclLaunchKernel`.
- Always run the full sync sequence in `ncclLaunchFinish`.
- Remove the now-unused `numStreams` field from `ncclKernelPlanner` in `src/include/comm.h`.

**2. Device-side: harden `directBuff` access in `Primitives::waitPeer` (`prims_simple.h`)**

On the IPC-registered `Direct=1` kernel specialization, `waitPeer` reads `directBuff` based only on the `DirectRead` / `DirectWrite` flags. With `NCCL_LOCAL_REGISTER=1`, there is a race window where `regBufType` is set but `directBuff` has not yet been published by the peer (or is cleared during abort / spin-wait). The NULL read faults and, combined with defect #1, manifests as a hang.

- Add a cached `int regUsed` member to `Primitives` initialized from `ncclDevWorkColl::regUsed` in the constructor. This mirrors the host-side intent flag without the per-iteration pointer chase through `collWork`.
- Gate the three `directBuff` accesses in `waitPeer` on `regUsed && directBuff != nullptr`. `regUsed` closes the common registration race; the explicit null defense covers the ring/IPC edge cases where `regUsed=1` can still coincide with `directBuff==NULL` (partial peer setup during transport bring-up, abort path mid spin-wait, torn cache view of the handshake).

Related upstream fix targeting the same device-side defect: [ROCm/rocm-systems#5448](https://github.com/ROCm/rocm-systems/pull/5448).

## JIRA ID

Resolves ROCM-21756.

## Test Plan

Workload:

```bash
HSA_NO_SCRATCH_RECLAIM=1 NCCL_DEBUG=INFO \
  bash run_clm_wikitext.sh \
  --model_name_or_path=meta-llama/Llama-2-70b-chat-hf \
  --deepspeed=ds_config_zero_3.json
```

Run in container provided in the ticket against a clean rebuild of the PR branch.

| Cell | Extra environment |
|---|---|
| 1 | *(default)* |
| 2 | `NCCL_LOCAL_REGISTER=1` |
| 3 | `RCCL_DIRECT_ALLGATHER_DISABLE=1` |

## Test Result

| Cell | Result | eval_samples_per_second | Wall |
|---|---|---|---|
| 1 default | PASS | 11.716 | 80s |
| 2 `NCCL_LOCAL_REGISTER=1` | PASS | 12.059 | 75s |
| 3 `RCCL_DIRECT_ALLGATHER_DISABLE=1` | PASS | 11.77 | 80s |

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
