### PR TITLE
rocprofiler-sdk: Constrain OpenMP target tests to one device

### DIFF
--- a/projects/rocprofiler-sdk/samples/openmp_target/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/samples/openmp_target/CMakeLists.txt
@@ -78,7 +78,8 @@ rocprofiler_samples_get_ld_library_path_env(
 
 set(openmp-target-sample-env
     ${PRELOAD_ENV} ${LIBRARY_PATH_ENV} "OMP_NUM_THREADS=2" "OMP_TARGET_OFFLOAD=mandatory"
-    "OMP_DISPLAY_ENV=1" "ROCR_VISIBLE_DEVICES=0")
+    "OMP_DISPLAY_ENV=1" "HSA_VISIBLE_DEVICES=0" "HIP_VISIBLE_DEVICES=0"
+    "ROCR_VISIBLE_DEVICES=0")
 
 add_test(NAME openmp-target-sample COMMAND $<TARGET_FILE:openmp-target-sample>)
 

--- a/projects/rocprofiler-sdk/tests/openmp-tools/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/openmp-tools/CMakeLists.txt
@@ -34,6 +34,8 @@ set(openmp-tools-env
     "OMP_NUM_THREADS=2"
     "OMP_DISPLAY_ENV=1"
     "OMP_TARGET_OFFLOAD=mandatory"
+    "HSA_VISIBLE_DEVICES=0"
+    "HIP_VISIBLE_DEVICES=0"
     "ROCR_VISIBLE_DEVICES=0"
     "ROCPROFILER_TOOL_OUTPUT_FILE=openmp-tools-test.json"
     "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"


### PR DESCRIPTION
Partial upstream split from ROCm/TheRock#3928.

Changes:

- Add HSA_VISIBLE_DEVICES=0 and HIP_VISIBLE_DEVICES=0 to the rocprofiler-sdk OpenMP tools test environment.

- Apply the same visibility clamp to the OpenMP target sample test environment, alongside the existing ROCR_VISIBLE_DEVICES=0.

Rationale:

- These tests assume a single visible target device. Multi-GPU CI runners can expose more than one device unless all ROCm/HIP visibility variables are constrained consistently.

Validation:

- Applied on current rocm-systems develop after git pull --ff-only origin develop.

- git diff --check.

- Verified both touched CMake test environments contain HSA_VISIBLE_DEVICES=0, HIP_VISIBLE_DEVICES=0, and ROCR_VISIBLE_DEVICES=0.

Generated with Codex
