### PR TITLE
Adding ASAN build support

### DIFF
--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -73,6 +73,15 @@ option(BUILD_DEBUG_DEVICE "Compile in device-side logging (LOGD_WARN/INFO and GD
 option(GDA_IONIC "Build for AMD Pensando IONIC RDMA provider" OFF)
 option(GDA_BNXT "Build for Broadcom RDMA provider" OFF)
 option(GDA_MLX5 "Build for Mellanox MLX5 RDMA provider" OFF)
+option(ASAN "Enable AddressSanitizer" ON)
+
+if (ASAN)
+  execute_process(
+    COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libclang_rt.asan-x86_64.so
+    OUTPUT_VARIABLE ASAN_RUNTIME_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+  get_filename_component(ASAN_RUNTIME_DIR "${ASAN_RUNTIME_PATH}" DIRECTORY)
+  message(STATUS "ASAN runtime directory: ${ASAN_RUNTIME_DIR}")
+endif()
 
 set(USE_EXTERNAL_MPI AUTO CACHE STRING "Link with an external MPI (required if used MPI is ABI incompatible with Open MPI v5)")
 set_property(CACHE USE_EXTERNAL_MPI PROPERTY STRINGS AUTO ON OFF)
@@ -126,6 +135,24 @@ if(AMDSMI_LIBRARY)
   endif()
 else()
   message(STATUS "AMD SMI library not found - disabling pod-based IPC capability detection")
+endif()
+
+#############################################################################
+target_link_options(
+    ${PROJECT_NAME}
+    PUBLIC
+      $<$<BOOL:${ASAN}>:-fsanitize=address -g -shared-libsan>
+  )
+
+  target_compile_options(
+    ${PROJECT_NAME}
+    PUBLIC
+      $<$<BOOL:${ASAN}>:-fsanitize=address -g>
+  )
+
+if (ASAN)
+   message(STATUS "Removing xnack- from GPU_TARGET as these are invalid with ASAN address sanitizer")
+   list(FILTER GPU_TARGETS EXCLUDE REGEX ".*:xnack-$")
 endif()
 
 #############################################################################

--- a/projects/rocshmem/DEBUG.md
+++ b/projects/rocshmem/DEBUG.md
@@ -1,0 +1,47 @@
+Hacking and Debugging RocSHMEM
+==============================
+
+This documentation is mostly for core RocSHMEM developpers and contributors. Power users may still find it useful.
+
+How to debug parallel programs
+------------------------------
+
+When using Open MPI as the launch  mechanism, you can use `OMPI_MCA_mpi_abort_delay=-1` to keep parallel processes active after a crash. You can then use `ssh -t $nodename rocgdb -p $pid` to connect a `rocgdb` to the failed process. Sometimes errors are caught by UCX, `UCX_HANDLE_ERRORS=freeze` will have the same effect in such cases.
+
+Look into `scripts/functional_tests/GDB_README` about an alternative technique that deploys multiple `xterm` to gdb into parallel processes.
+
+How to use the address sanitizer (ASAN)
+---------------------------------------
+
+Refer to [General documentation for ASAN on AMD GPUs][1].
+
+### Compiling with ASAN
+
+If this is a fresh build directory, simply add `-DASAN=ON` to the `cmake` invocation.
+  `cmake . <...> -DASAN=ON`
+
+If you are enabling ASAN in a previously used build directory, use `ccmake` to alter the CMake Cache
+  `ccmake .`
+
+In the `ccmake` interface:
+1. find and toggle `ASAN` ON
+2. find and delete `COMPILING_TARGETS` (keybind `d`)
+
+Do not forget to delete `COMPILING_TARGETS` again when disabling ASAN (otherwise xnack will remain required, causing failure in production runs).
+
+### Running with ASAN
+
+You need to set environment variable `HSA_XNACK=1`. Do not forget to unset this variable when not using ASAN (it will impact performance).
+
+You may need to add the path to `libclang_rt.asan-x86_64.so` into `LD_LIBRARY_PATH` by hand. Depending on the ROCm version, it may be in an unusual place, e.g., `$ROCM_ROOT/lib/llvm/lib/clang/19/lib/linux/libclang_rt.asan-x86_64.so`; `find /opt/rocm -name libclang_rt.asan-x86_64.so` may be required to find it.
+
+ASAN may [crash when using Open MPI][2]. If that happens, set environment variable `OMPI_MCA_memory=^patcher`. Do not forget to unset this variable when not using ASAN (it will impact performance).
+
+When running the program, the behavior of ASAN can be controlled with the `ASAN_OPTIONS` environment variable.
+
+you can redude the amount of spurious leak reports by setting environment variable `LSAN_OPTIONS=suppressions=$ROCSHEM_SRC/scripts/lsan-suppressions.txt`.
+
+### References
+
+[1]: https://rocm.docs.amd.com/projects/llvm-project/en/docs-6.4.0/conceptual/using-gpu-sanitizer.html
+[2]: https://github.com/open-mpi/ompi/issues/13069

--- a/projects/rocshmem/scripts/build_configs/all_backends
+++ b/projects/rocshmem/scripts/build_configs/all_backends
@@ -51,3 +51,7 @@ cmake \
     $* $src_path
 cmake --build . --parallel 8
 cmake --install .
+
+if [[ "${ASAN}" == true ]]; then
+    export HSA_XNACK=1
+fi

--- a/projects/rocshmem/scripts/lsan-suppressions.txt
+++ b/projects/rocshmem/scripts/lsan-suppressions.txt
@@ -1,0 +1,5 @@
+leak:pmix.so
+leak:hwloc.so
+leak:open-pal.so
+leak:ucs.so
+leak:uct.so


### PR DESCRIPTION
## Motivation

Adding Address Sanitizer build support

## Technical Details
This change enables AddressSanitizer (ASan) support in the build system when passing -DASAN=ON. It updates the necessary compiler and linker flags to ensure proper instrumentation for detecting memory errors during runtime.

## JIRA ID
AIROCSHMEM-364
AIROCSHMEM-330

## Test Plan
Build the project with ASan enabled:

cmake -DASAN=ON <other-flags> ..
make -j

Run existing test suites and sample applications to verify:
Successful build with ASan enabled
No runtime crashes introduced by the changes
ASan correctly reports memory issues.

This PR has been tested on TheRock and is working as expected.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
