### PR TITLE
[rocprofiler-systems] Fix per-attach output directory path for rocpd files

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -2480,41 +2480,47 @@ get_tmpdir()
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
 
+namespace
+{
+std::mutex  s_db_path_mutex;
+std::string s_db_path_memo;
+int         s_db_path_session_id = 0;
+}  // namespace
+
 std::string
 get_database_absolute_path(std::string_view database_name, std::string_view suffix)
 {
-    const auto*  pwd                   = getenv("PWD");
-    const auto*  existing_path         = std::getenv("ROCPROFSYS_DATABASE_DIR");
-    static auto* attach_add_session_id = getenv("ROCPROFSYS_REATTACH_ADD_SESSION_ID");
+    std::unique_lock<std::mutex> lk{ s_db_path_mutex };
 
-    auto dir = existing_path ? std::string{ existing_path } : std::string{};
-    auto ext = std::string{ "db" };
-
-    static auto session_id = 0;
-    auto        cfg =
-        attach_add_session_id
-                   ? settings::compose_filename_config{ settings::use_output_suffix(),
-                                                 fmt::format("%pid%-{}", session_id++),
-                                                 false, dir }
-                   : settings::compose_filename_config{ settings::use_output_suffix(), suffix,
-                                                 false, dir };
+    auto cfg = settings::compose_filename_config{
+        settings::use_output_suffix(),
+        fmt::format("{}-{}", suffix, s_db_path_session_id++), false, s_db_path_memo
+    };
 
     auto result =
-        settings::compose_output_filename(std::string{ database_name }, ext, cfg);
+        settings::compose_output_filename(std::string{ database_name }, "db", cfg);
 
     const auto get_dir = [](const std::string& path) {
         const auto last_slash = path.find_last_of("/\\");
         return (last_slash != std::string::npos) ? path.substr(0, last_slash + 1)
                                                  : std::string{};
     };
-
-    dir = get_dir(result);
-    setenv("ROCPROFSYS_DATABASE_DIR", dir.c_str(), 1);
+    s_db_path_memo = get_dir(result);
 
     if(!result.empty() && result.at(0) != '/')
+    {
+        const auto* pwd = getenv("PWD");
         return settings::format(fmt::format("{}/{}", pwd, result),
                                 get_config()->get_tag());
+    }
     return result;
+}
+
+void
+reset_database_path_memo()
+{
+    std::unique_lock<std::mutex> lk{ s_db_path_mutex };
+    s_db_path_memo.clear();
 }
 
 std::string

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -2482,6 +2482,10 @@ get_tmpdir()
 
 namespace
 {
+// s_db_path_memo and s_db_path_mutex are reset on each rocprof-sys-attach
+// re-attach via reset_database_path_memo(); s_db_path_session_id is NOT
+// reset and increments monotonically across attaches so that per-call
+// .db filenames stay unique within a single process lifetime.
 std::mutex  s_db_path_mutex;
 std::string s_db_path_memo;
 int         s_db_path_session_id = 0;
@@ -2510,7 +2514,7 @@ get_database_absolute_path(std::string_view database_name, std::string_view suff
     if(!result.empty() && result.at(0) != '/')
     {
         const auto* pwd = getenv("PWD");
-        return settings::format(fmt::format("{}/{}", pwd, result),
+        return settings::format(fmt::format("{}/{}", (pwd ? pwd : "."), result),
                                 get_config()->get_tag());
     }
     return result;

--- a/projects/rocprofiler-systems/source/lib/core/config.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.hpp
@@ -369,6 +369,9 @@ get_tmpdir();
 std::string
 get_database_absolute_path(std::string_view database_name, std::string_view tag);
 
+void
+reset_database_path_memo();
+
 std::string
 get_perfetto_output_filename_with_suffix(std::string_view suffix = "");
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -1293,6 +1293,7 @@ rocprofsys_reset_for_reattach_hidden(void)
     rocprofsys_finalization_done.store(false);
     rocprofsys_init_library_done.store(false);
     rocprofsys_init_tooling_done.store(0);
+    ::rocprofsys::reset_database_path_memo();
     ::rocprofsys::reset_state();
 }
 


### PR DESCRIPTION
## Motivation

On `rocprof-sys-attach` re-attach to the same PID, all `rocpd-*.db` files landed in the FIRST attach's timestamped output dir while `perfetto-trace-*.proto` files correctly went to each new per-attach dir.

`get_database_absolute_path` persisted the resolved output dir into the `ROCPROFSYS_DATABASE_DIR` env var, and `rocprofsys_reset_for_reattach_hidden` did not clear it. Subsequent attaches read the stale path and pinned all
`.db` output to the first attach's dir. Perfetto was unaffected because its resolver has no env-var writeback.

## Technical Details

- Replace the `ROCPROFSYS_DATABASE_DIR` env-var memo with a process-local mutex-protected `std::string`. Same intra-finalization co-location guarantee for multi-pid runs, no global env pollution.
- Expose `reset_database_path_memo()` and call it from `rocprofsys_reset_for_reattach_hidden` so each attach starts with a
  cleared memo. 
- Drop the `ROCPROFSYS_REATTACH_ADD_SESSION_ID` gate so the per-call session-id suffix is always appended, matching the unconditional behavior of `get_perfetto_output_filename`.

## JIRA

ROCM-23837

## Test Plan

- Build patched tree (`cmake --preset debug` + `ninja -C build/debug`)
- Run the burn workload long enough to span >1 minute:
  `ROCP_TOOL_ATTACH=1 /tmp/burn/burn 5000000 &`
- Attach twice with `rocprof-sys-attach -F perfetto,rocpd`, separated by enough wall clock for the timestamp dir to roll over (>= 1 min) 
- Verify each `rocpd-*.db` lands in its own per-attach dir alongside its `perfetto-trace-*.proto`

## Test Result

Local gfx1201 verification:

| | attach 1 dir | attach 2 dir | rocpd-0.db | rocpd-1.db |
|---|---|---|---|---|
| develop (unpatched) | `09.23` | `09.25` | `09.23/` | `09.23/` (BUG) |
| this branch | `09.21` | `09.22` | `09.21/` | `09.22/` (correct) |

Build clean, 883/883 targets, 0 errors.

## Checklist

- [x] Tested locally
- [x] Pre-commit hooks pass (clang-format)
- [x] No behavior change for single-attach
- [x] No new warnings

[ROCM-23837]: https://amd-hub.atlassian.net/browse/ROCM-23837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ