### PR TITLE
[rocpd]: preload vendored libsqlite3 to avoid cross-library SIGSEGV

### DIFF
--- a/projects/rocprofiler-sdk/source/bin/rocpd.py
+++ b/projects/rocprofiler-sdk/source/bin/rocpd.py
@@ -30,6 +30,50 @@ Simple Python executable script for invoking `python3 -m @ROCPD_EXE_MODULE@`
 """
 
 
+def _find_sqlite_preload(this_dir):
+    """
+    Locate the rocm-sdk vendored libsqlite3 shipped alongside this binary
+    in TheRock wheel layout. Returns an absolute path or None.
+
+    Behavior can be overridden by the ROCPD_SQLITE_PRELOAD environment
+    variable: setting it to a path forces that file to be preloaded;
+    setting it to an empty string disables the preload entirely.
+    """
+    override = os.environ.get("ROCPD_SQLITE_PRELOAD")
+    if override is not None:
+        return override or None
+
+    path = os.path.normpath(
+        os.path.join(
+            this_dir, "..", "lib", "rocm_sysdeps", "lib", "librocm_sysdeps_sqlite3.so"
+        )
+    )
+    return os.path.realpath(path) if os.path.isfile(path) else None
+
+
+def _inject_sqlite_preload(this_dir, environ):
+    """
+    Prepend the rocm-sdk vendored libsqlite3 to LD_PRELOAD so that both
+    Python's stdlib `sqlite3` module and `libpyrocpd` resolve every
+    sqlite3_* symbol against the same SQLite version. This avoids the
+    cross-library struct-layout mismatch that occurs when the system
+    libsqlite3 (linked into CPython's _sqlite3.so) and the vendored
+    libsqlite3 (linked into libpyrocpd) are different versions.
+    """
+    preload = _find_sqlite_preload(this_dir)
+    if not preload:
+        return
+
+    existing = environ.get("LD_PRELOAD", "").strip()
+    parts = [preload]
+    if existing:
+        parts.append(existing)
+    environ["LD_PRELOAD"] = ":".join(parts)
+
+    if os.environ.get("ROCPD_SQLITE_PRELOAD_VERBOSE"):
+        sys.stderr.write(f"[@ROCPD_EXE_NAME@] LD_PRELOAD={environ['LD_PRELOAD']}\n")
+
+
 def main(argv=sys.argv[1:], environ=dict(os.environ)):
     """
     Executes {sys.executable} -m @ROCPD_EXE_MODULE@ @ROCPD_EXE_MODULE_ARGS@
@@ -63,6 +107,8 @@ def main(argv=sys.argv[1:], environ=dict(os.environ)):
 
     # update PYTHONPATH environment variable
     environ["PYTHONPATH"] = ":".join(python_path)
+
+    _inject_sqlite_preload(this_dir, environ)
 
     args = [f"{sys.executable}", "-m", "@ROCPD_EXE_MODULE@"] + ROCPD_MODULE_ARGS + argv
 

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/__init__.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/__init__.py
@@ -84,8 +84,8 @@ def _preload_vendored_sqlite():
 
 _preload_vendored_sqlite()
 
-from . import libpyrocpd
-from .importer import RocpdImportData
+from . import libpyrocpd  # noqa: E402
+from .importer import RocpdImportData  # noqa: E402
 
 __all__ = [
     "connect",

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/__init__.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/__init__.py
@@ -25,20 +25,64 @@
 import sys
 import os
 
-try:
-    import ctypes
 
-    # RTLD_GLOBAL so Python + librocpd bind the same SQLite, avoiding mixed-lib symbol collisions
-    sqlite3lib = ctypes.CDLL("libsqlite3.so", mode=ctypes.RTLD_GLOBAL)
-except Exception:
-    pass
+def _preload_vendored_sqlite():
+    """
+    Force-load the rocm-sdk vendored libsqlite3 with RTLD_GLOBAL *before*
+    `import sqlite3` happens. This makes Python's stdlib `_sqlite3.so`
+    resolve every sqlite3_* call into the vendored library, matching what
+    `libpyrocpd` is linked against, and avoids the cross-library
+    struct-layout SIGSEGV when the system and vendored SQLite versions
+    differ.
 
-try:
-    import sqlite3
+    Best-effort fallback for users who `import rocpd` from their own
+    Python scripts. Users who launch via the rocpd2pftrace / rocpd2csv /
+    etc. wrappers also get LD_PRELOAD set in the wrapper, which is the
+    more reliable path because it executes before any Python-level
+    import of sqlite3.
 
-    sqlite3.connect(":memory:")  # Test if sqlite3 is available
-except Exception:
-    pass
+    Override path with ROCPD_SQLITE_PRELOAD; set it to an empty string
+    to disable.
+    """
+    override = os.environ.get("ROCPD_SQLITE_PRELOAD")
+    if override is not None and not override:
+        return
+
+    if override:
+        path = override
+    else:
+        # rocpd/__init__.py lives at <prefix>/lib/python<ver>/site-packages/rocpd/.
+        # Three .. from here land in <prefix>/lib/, where the vendored
+        # libraries live under rocm_sysdeps/lib/ (matches the RPATH baked
+        # into libpyrocpd: $ORIGIN/../../../rocm_sysdeps/lib).
+        _here = os.path.dirname(os.path.abspath(__file__))
+        path = os.path.normpath(
+            os.path.join(
+                _here,
+                "..",
+                "..",
+                "..",
+                "rocm_sysdeps",
+                "lib",
+                "librocm_sysdeps_sqlite3.so",
+            )
+        )
+
+    if not os.path.isfile(path):
+        return
+
+    try:
+        import ctypes
+
+        ctypes.CDLL(path, mode=ctypes.RTLD_GLOBAL)
+    except (ImportError, OSError):
+        return
+
+    if os.environ.get("ROCPD_SQLITE_PRELOAD_VERBOSE"):
+        sys.stderr.write(f"[rocpd] preloaded sqlite3: {path}\n")
+
+
+_preload_vendored_sqlite()
 
 from . import libpyrocpd
 from .importer import RocpdImportData


### PR DESCRIPTION
## Motivation

`rocpd2pftrace` crashes with `SIGSEGV` inside `libpyrocpd` when the `libsqlite3` linked into Python's stdlib `sqlite3` module and the `libsqlite3` linked into `libpyrocpd` are different versions. The crash is hit reliably on systems where the system libsqlite3 is older than the rocm-sdk vendored copy.
## Technical Details

Two different `libsqlite3` shared objects get loaded into the same Python process:
| Module | Linked against |
| --- | --- |
| `_sqlite3.cpython-*.so` (CPython stdlib) | system `libsqlite3.so.0` |
| `libpyrocpd.cpython-*.so` (rocm-sdk wheel) | vendored `librocm_sysdeps_sqlite3.so` |

Python opens the database with `sqlite3.connect(...)`, allocating the `sqlite3*` handle in the system SQLite. `libpyrocpd.write_perfetto` then takes that raw `sqlite3*` and uses it with **its** SQLite's `sqlite3_prepare_v2` / `sqlite3_step` (for fast row reads via `cereal::SQLite3InputArchive`).
SQLite's public API treats `sqlite3*` as opaque, but the **internal struct layout** changes between minor versions (new fields added, the allocation grows). When the two libraries differ, the newer SQLite reads fields at offsets that are valid in its layout but past the end of the older library's allocation. A garbage / NULL function pointer read at those offsets crashes the process.

Reproducer trace:
| Step | What happens |
|---|---|
| 1 | `import sqlite3` → loads stdlib `_sqlite3.so` → `libsqlite3.so.0` (e.g. 3.45.1) |
| 2 | `import rocpd.*` → loads `libpyrocpd.so` → `DT_NEEDED` pulls `librocm_sysdeps_sqlite3.so` (e.g. 3.51.3) |
| 3 | `RocpdImportData.__init__` calls `sqlite3.connect(...)` → handle is a 3.45.1-sized `sqlite3` object |
| 4 | `libpyrocpd.write_perfetto` → `get_connection(...)` hands that 3.45.1 handle to `sqlite3_prepare_v2` resolved in 3.51.3 |
| 5 | 3.51.3 reads a function-pointer field at an offset valid in its larger struct but past the end of the 3.45.1 allocation → garbage/NULL → `call *0x0` → **SIGSEGV** |

### Fix 
Force the vendored libsqlite3 to win symbol resolution **before** Python's stdlib `_sqlite3.cpython-*.so` loads. All `sqlite3_*` calls in the process — from both Python and `libpyrocpd` — then go through the same library, on the same struct layout, with no cross-library handle sharing.
Two layers, intended to cover both invocation paths:
**1. `source/bin/rocpd.py` (the templated wrapper):**
The wrapper script (which CMake `configure_file()`'s into `rocpd`, `rocpd2csv`, `rocpd2otf2`, `rocpd2pftrace`, `rocpd2summary`) now locates `librocm_sysdeps_sqlite3.so` relative to its own location and prepends it to `LD_PRELOAD` in the env passed to `os.execvpe`. The new Python process is launched with that env, so the dynamic linker honors `LD_PRELOAD` at startup and the vendored SQLite's symbols win lookup before any user code runs. Existing `LD_PRELOAD` entries (sanitizers, jemalloc, etc.) are preserved.
**2. `source/lib/python/rocpd/__init__.py` (defense-in-depth):**
For callers that `import rocpd` directly (not via the wrapper), `__init__.py` does a `ctypes.CDLL(path, RTLD_GLOBAL)` of the same vendored library before `from . import libpyrocpd`. This makes the vendored SQLite's symbols win lookup for any subsequent `import sqlite3` in the same process — provided no `import sqlite3` has already happened earlier.
The previous broken preload attempt (`ctypes.CDLL("libsqlite3.so", ...)`) is replaced. It tried to load a file that only exists with `libsqlite3-dev` installed, and even when it succeeded it loaded the **system** SQLite — defeating the purpose.

## JIRA ID
https://amd-hub.atlassian.net/browse/ROCM-21400

## Test Plan

- Build with the change. 
- On a board where the system SQLite version differs from the vendored SQLite version, run `rocpd2pftrace -i <db> -o /tmp/out` and verify exit 0 and a non-empty `.pftrace` is produced.
- Re-run with `ROCPD_SQLITE_PRELOAD_VERBOSE=1` and confirm the preload line `[rocpd2pftrace] LD_PRELOAD=/.../librocm_sysdeps_sqlite3.so` appears on stderr.
- Re-run with `ROCPD_SQLITE_PRELOAD=` (empty, preload disabled) and confirm the original SIGSEGV reproduces, demonstrating the fix is what's protecting against the crash.
- Verify an existing user `LD_PRELOAD` is preserved: `LD_PRELOAD=/some/sanitizer.so ROCPD_SQLITE_PRELOAD_VERBOSE=1 rocpd2pftrace ...` shows both entries with the vendored libsqlite3 first.
- Smoke-test the `__init__.py` fallback: `ROCPD_SQLITE_PRELOAD_VERBOSE=1 python3 -c "import rocpd"` prints `[rocpd] preloaded sqlite3: ...`.

## Test Result

With the above changes, there is no segfault in rocpd2pftrace tool
<img width="1909" height="309" alt="image" src="https://github.com/user-attachments/assets/ff3a97ad-5cb6-411b-8824-8ec4b3dea8a5" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
