### PR TITLE
kfdtest: Add missing printGpuNodelist function in run_kfdtest.sh

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/run_kfdtest.sh
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/run_kfdtest.sh
@@ -201,6 +201,14 @@ getNodeName() {
     echo "$gpuName"
 }
 
+printGpuNodelist() {
+    local hsaNodes=$(getHsaNodes)
+    for node in $hsaNodes; do
+        local name=$(getNodeName $node)
+        echo "Node $node: $name"
+    done
+}
+
 # Run KfdTest independently. Two global variables set by command-line
 # will influence the tests as indicated below
 #   PLATFORM - If set all tests will run with this platform filter


### PR DESCRIPTION


## Motivation

The -l/--list option called printGpuNodelist but the function was never defined. Add the implementation using the existing getHsaNodes and getNodeName helpers.

fixes https://github.com/ROCm/rocm-systems/issues/5713

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

locally verified.

## Test Result

```
./run_kfdtest.sh -l
Node 1: gfx1100
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
