### PR TITLE
Fix PMC counter collection returning zeros on multi-GPU systems

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
@@ -1039,14 +1039,17 @@ get_aql_handles()
             std::vector<aqlprofile_agent_handle_t> agent_handles;
             for(auto& agent : get_agents())
             {
-                aqlprofile_agent_info_t agent_info = {
+                aqlprofile_agent_info_v1_t agent_info = {
                     .agent_gfxip          = agent->name,
                     .xcc_num              = agent->num_xcc,
                     .se_num               = agent->num_shader_banks,
                     .cu_num               = agent->cu_count,
-                    .shader_arrays_per_se = agent->simd_arrays_per_engine};
+                    .shader_arrays_per_se = agent->simd_arrays_per_engine,
+                    .domain               = agent->domain,
+                    .location_id          = agent->location_id};
                 aqlprofile_agent_handle_t handle = {.handle = 0};
-                if(aqlprofile_register_agent(&handle, &agent_info) != HSA_STATUS_SUCCESS)
+                if(aqlprofile_register_agent_info(
+                       &handle, &agent_info, AQLPROFILE_AGENT_VERSION_V1) != HSA_STATUS_SUCCESS)
                 {
                     ROCP_WARNING << "Failed to register agent " << agent->name;
                 }


### PR DESCRIPTION
## Motivation

Resolves https://github.com/ROCm/rocm-systems/issues/5683. 

gfx1100+gfx900 and `HIP_VISIBLE_DEVICES=1 rocprofv3 --pmc SQ_INSTS_VALU SQ_INSTS_SALU --output-format csv -- ./a.out` results in zero values for performance counters on latest nightlies and ROCm 7.2.2.
```  "Correlation_Id","Dispatch_Id","Agent_Id","Queue_Id","Process_Id","Thread_Id","Grid_Size","Kernel_Id","Kernel_Name","Workgroup_Size","LDS_Block_Size","Scratch_Size","VGPR_Count","Accum_VGPR_Count","SGPR_Count","Counter_Name","Counter_Value","Start_Timestamp","End_Timestamp"           
  1,1,"Agent 2",1,98698,98698,1048576,17,"vectoradd_float(float*, float const*, float const*, int, int)",256,0,0,8,0,16,"SQ_INSTS_SALU",0.00000000e+00,75091568704259,75091568797438                                                                                                           
  1,1,"Agent 2",1,98698,98698,1048576,17,"vectoradd_float(float*, float const*, float const*, int, int)",256,0,0,8,0,16,"SQ_INSTS_VALU",0.00000000e+00,75091568704259,75091568797438 
  ```


## Technical Details

Use [aqlprofile V1 agent registration](https://github.com/ROCm/rocm-systems/blob/develop/projects/rocprofiler-sdk/source/lib/aqlprofile/aql_profile_v2.h#L219-L233) to pass PCI domain and location_id when registering agents.

Without `domain` and `location_id`, aqlprofile can't properly distinguish GPUs in multi-GPU configuration leading to zero values for all performance counters. 

The V1 struct and aqlprofile_register_agent_info() already exist in aqlprofile and in rocprofilers copy `projects/rocprofiler-sdk/source/lib/aqlprofile/aql_profile_v2.h`.

 This change switches the registration call from V0 to V1.

## JIRA ID

N/A

## Test Plan

Apply patch and rerun ``HIP_VISIBLE_DEVICES=1 rocprofv3 --pmc SQ_INSTS_VALU SQ_INSTS_SALU --output-format csv -- ./a.out`` - we'd expect non zero values for performance counters

## Test Result

- Before (zeros):                                                                                                                                                                                                                                                                              

 ``` "Correlation_Id","Dispatch_Id","Agent_Id","Queue_Id","Process_Id","Thread_Id","Grid_Size","Kernel_Id","Kernel_Name","Workgroup_Size","LDS_Block_Size","Scratch_Size","VGPR_Count","Accum_VGPR_Count","SGPR_Count","Counter_Name","Counter_Value","Start_Timestamp","End_Timestamp"           
  1,1,"Agent 2",1,98698,98698,1048576,17,"vectoradd_float(float*, float const*, float const*, int, int)",256,0,0,8,0,16,"SQ_INSTS_SALU",0.00000000e+00,75091568704259,75091568797438                                                                                                           
  1,1,"Agent 2",1,98698,98698,1048576,17,"vectoradd_float(float*, float const*, float const*, int, int)",256,0,0,8,0,16,"SQ_INSTS_VALU",0.00000000e+00,75091568704259,75091568797438                                                                                                           
```                                                                                                                                                                                                                                                                                               

- After (fix applied):                                                                                                                                                                                                                                                                         

 ``` "Correlation_Id","Dispatch_Id","Agent_Id","Queue_Id","Process_Id","Thread_Id","Grid_Size","Kernel_Id","Kernel_Name","Workgroup_Size","LDS_Block_Size","Scratch_Size","VGPR_Count","Accum_VGPR_Count","SGPR_Count","Counter_Name","Counter_Value","Start_Timestamp","End_Timestamp"           
  1,1,"Agent 2",1,158478,158478,1048576,19,"vectoradd_float(float*, float const*, float const*, int, int)",256,0,0,8,0,16,"SQ_INSTS_SALU",98304.000000,79861667939740,79861668193498                                                                                                           
  1,1,"Agent 2",1,158478,158478,1048576,19,"vectoradd_float(float*, float const*, float const*, int, int)",256,0,0,8,0,16,"SQ_INSTS_VALU",262144.000000,79861667939740,79861668193498                                                                                                          
 ```                                                                                                                                                                                                                                                                                              
Both runs: HIP_VISIBLE_DEVICES=1 on a gfx1100+gfx900 system, kernel dispatched to Agent 2 (gfx900). The 98304/262144 values match what a single-GPU gfx900 system produces.
  
Still seeing zero value counters when HIP_VISIBLE_DEVICES=0 (pointing to gfx1100). Need to run base case here to see if gfx1100 is passing single GPU in the first place.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
