### PR TITLE
[RCCL] Fix ZeRO-3 AllGather hang: re-apply PR #3001, drop redundant #5448 (ROCM-21756)

### DIFF
--- a/projects/rccl/src/device/prims_simple.h
+++ b/projects/rccl/src/device/prims_simple.h
@@ -184,17 +184,17 @@ private:
         // directBuff is only assigned by setDataPtrs when (Direct && ipcReg);
         // when Direct=1 but no buffer was registered, it stays NULL and using
         // it as a base would compute an invalid GPU address.
-        if ((flags & DirectWrite) && directBuff != nullptr) {
+        if (flags & DirectWrite) {
           ptrs[index] = directBuff + dstIx + offset;
-        } else if ((flags & DirectRead) && directBuff != nullptr) {  // empty send
+        } else if (flags & DirectRead) {  // empty send
           ptrs[index] = nullptr;
         } else {
           ptrs[index] = connEltsFifo + (step%NCCL_STEPS)*connStepSize;
         }
       } else if (!isSendNotRecv && DirectRecv) {
-        if ((flags & DirectRead) && directBuff != nullptr) {
+        if (flags & DirectRead) {
           ptrs[index] = directBuff + srcIx + offset;
-        } else if ((flags & DirectWrite) && directBuff != nullptr) {
+        } else if (flags & DirectWrite) {
           ptrs[index] = directBuff + dstIx + offset;  // send to next from my output buffer
         } else {
           ptrs[index] = connEltsFifo + (step%NCCL_STEPS)*connStepSize;

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -1802,18 +1802,13 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
     cudaStream_t deviceStream, launchOrder;
     NCCLCHECKGOTO(ncclStrongStreamAcquire(planner->capturingGraph, &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream), result, failure);
 
-    if (persistent || planner->numStreams != 1) {
-      // userStream[0] waits on each userStream[i]...
-      for (struct ncclCudaStreamList* l=planner->streams->next; l != nullptr; l = l->next) {
-        CUDACHECKGOTO(cudaEventRecord(comm->sharedRes->scratchEvent, l->stream), result, failure);
-        CUDACHECKGOTO(cudaStreamWaitEvent(launchStream, comm->sharedRes->scratchEvent, 0), result, failure);
-      }
-      // userStream[0] waits on deviceStream
-      NCCLCHECKGOTO(ncclStreamWaitStream(launchStream, deviceStream, comm->sharedRes->scratchEvent), result, failure);
-    } else if (planner->streams->stream != comm->lastStream && comm->lastStream != nullptr && !persistent) {
-      // Stream changed from last call, create dependency against last NCCL kernel launch
-      CUDACHECKGOTO(hipStreamWaitEvent(planner->streams->stream, comm->doneEvent, 0), result, failure);
+    // userStream[0] waits on each userStream[i]...
+    for (struct ncclCudaStreamList* l=planner->streams->next; l != nullptr; l = l->next) {
+      CUDACHECKGOTO(cudaEventRecord(comm->sharedRes->scratchEvent, l->stream), result, failure);
+      CUDACHECKGOTO(cudaStreamWaitEvent(launchStream, comm->sharedRes->scratchEvent, 0), result, failure);
     }
+    // userStream[0] waits on deviceStream
+    NCCLCHECKGOTO(ncclStreamWaitStream(launchStream, deviceStream, comm->sharedRes->scratchEvent), result, failure);
 
     bool capturing = ncclCudaGraphValid(planner->capturingGraph);
     enum ncclImplicitOrder implicitOrder;
@@ -1906,14 +1901,6 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
 
   CUfunction fn;
   CUDACHECKGOTO(cudaGetFuncBySymbol(&fn, sym), ret, do_return);
-
-  if (planner->numStreams == 1 && !plan->persistent) {
-    latency_profiler::collTraceRecordStartEvent(comm, launchStream, event.get());
-    comm->lastStream = planner->streams->stream;
-    CUCHECKGOTO(cuLaunchKernel(fn, grid.x, grid.y, grid.z, block.x, block.y, block.z, smem, launchStream, nullptr, extra), ret, do_return);
-    latency_profiler::collTraceRecordEndEvent(comm, plan, launchStream, std::move(event));
-    return ncclSuccess;
-  }
 
 #if !defined(__HIP_PLATFORM_AMD__) || !defined(__HIPCC__)
   if (CUDART_VERSION >= 11080 && driverVersion >= 11080) {
@@ -2041,7 +2028,6 @@ ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
     // back to us for reclaiming via callbackQueue.
     ncclIntruQueueConstruct(&planner->planQueue);
 
-    bool capturing = ncclCudaGraphValid(planner->capturingGraph);
     cudaStream_t launchStream = planner->streams->stream; // First user stream gets launch
     cudaStream_t deviceStream, launchOrder;
     cudaEvent_t finishedEvent = comm->sharedRes->scratchEvent;
@@ -2058,25 +2044,24 @@ ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
       CUDACHECK(cudaEventCreateWithFlags(&comm->sharedRes->scratchEvent, cudaEventDisableTiming));
     }
 
-    if (capturing || planner->numStreams != 1 || ncclParamLaunchOrderImplicit()) {
-      CUDACHECK(cudaEventRecord(finishedEvent, launchStream));
-      // deviceStream waits on userStream[0]
-      NCCLCHECK(ncclStrongStreamAcquiredWorkStream(planner->capturingGraph, &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream));
+    CUDACHECK(cudaEventRecord(finishedEvent, launchStream));
+    // deviceStream waits on userStream[0]
+    NCCLCHECK(ncclStrongStreamAcquiredWorkStream(planner->capturingGraph, &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream));
 
-      // We know that deviceStream is strictly behind the launchStream because launchStream
-      // synced with it before kernel launch. This allows us to to see deviceStream waiting
-      // on launchStream as a fast-forward. When building CUDA graphs fast forwards should
-      // be handled specially so as not to create graphs with a blowup in the number of edges.
-      // So we could do this:
-      //   CUDACHECK(cudaStreamWaitEvent(deviceStream, finishedEvent, 0));
-      // But instead we do:
-      NCCLCHECK(ncclStreamAdvanceToEvent(planner->capturingGraph, deviceStream, finishedEvent));
+    // We know that deviceStream is strictly behind the launchStream because launchStream
+    // synced with it before kernel launch. This allows us to to see deviceStream waiting
+    // on launchStream as a fast-forward. When building CUDA graphs fast forwards should
+    // be handled specially so as not to create graphs with a blowup in the number of edges.
+    // So we could do this:
+    //   CUDACHECK(cudaStreamWaitEvent(deviceStream, finishedEvent, 0));
+    // But instead we do:
+    NCCLCHECK(ncclStreamAdvanceToEvent(planner->capturingGraph, deviceStream, finishedEvent));
 
-      // Each userStream[i] waits on userStream[0]
-      for (struct ncclCudaStreamList* l=planner->streams->next; l != nullptr; l = l->next) {
-        CUDACHECK(cudaStreamWaitEvent(l->stream, finishedEvent, 0));
-      }
+    // Each userStream[i] waits on userStream[0]
+    for (struct ncclCudaStreamList* l=planner->streams->next; l != nullptr; l = l->next) {
+      CUDACHECK(cudaStreamWaitEvent(l->stream, finishedEvent, 0));
     }
+    bool capturing = ncclCudaGraphValid(planner->capturingGraph);
     enum ncclImplicitOrder implicitOrder;
     NCCLCHECK(getImplicitOrder(&implicitOrder, capturing));
     if (implicitOrder != ncclImplicitOrderNone) {
@@ -2865,7 +2850,6 @@ static ncclResult_t ncclPlannerSetCapturingGraph(struct ncclComm* comm, struct n
         l->stream = info->stream;
         l->next = planner->streams;
         planner->streams = l;
-        planner->numStreams++;
         break;
       }
       if (l->stream == info->stream)

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -409,8 +409,6 @@ struct ncclKernelPlanner {
   bool persistent;
   // The list of user streams aggregated over all tasks present.
   struct ncclCudaStreamList* streams;
-  // Keep track of the number of user streams
-  int numStreams;
   // The most recent user stream. Ignored if streams==nullptr
   cudaStream_t streamRecent;
   // The graph capturing all user streams or invalid if none. Thus we restrict the


### PR DESCRIPTION
## Motivation

DeepSpeed ZeRO-3 training workloads (e.g., Llama-2-70B via `HSA_NO_SCRATCH_RECLAIM=1 NCCL_DEBUG=INFO bash run_clm_wikitext.sh --model_name_or_path=meta-llama/Llama-2-70b-chat-hf --deepspeed=ds_config_zero_3.json`) hang during evaluation on RCCL `develop` post-`fa361248fc`. The hang reproduces under three independent triggers:

- Default environment — UBR sets `NCCL_LOCAL_REGISTER=1` by default for HIP `>= 71260540`, routing large AllGathers through the registered Direct path.
- `NCCL_LOCAL_REGISTER=1` (explicit) — same path.
- `RCCL_DIRECT_ALLGATHER_DISABLE=1` — forces the unregistered ring kernel.

Goal: restore functional correctness of AllGather / ReduceScatter for ZeRO-3 (single user-stream, non-persistent) workloads, and keep the hot path minimal.

## Technical Details

This PR contains two commits.

**1. `[RCCL] Re-add PR #3001: drop unsafe single-stream fast-path in enqueue`**

Commit `fa361248fc` ("Fix p2p_batching, revert PR 3001, disable warpSpeed on gfx942", PR [#3254](https://github.com/ROCm/rocm-systems/pull/3254)) reverted PR [#3001](https://github.com/ROCm/rocm-systems/pull/3001) and re-introduced a `planner->numStreams == 1 && !plan->persistent` fast-path in `ncclLaunchPrepare` / `ncclLaunchKernel` / `ncclLaunchFinish`. That fast-path skips the launchStream↔deviceStream synchronization (`cudaEventRecord` + `ncclStreamWaitStream` / `ncclStreamAdvanceToEvent`) and bypasses `ncclLaunchFinish`'s userStream bookkeeping. For single-user-stream, non-persistent callers (ZeRO-3), this deadlocks the ring AllGather / ReduceScatter kernel against the proxy thread.

Re-applies PR #3001:
- Always take the safe userStream / deviceStream sync in `ncclLaunchPrepare` (drop the `numStreams != 1 || persistent` guard).
- Remove the early-return single-stream launch path in `ncclLaunchKernel`.
- Always run the full sync sequence in `ncclLaunchFinish`.
- Remove the now-unused `numStreams` field from `ncclKernelPlanner` in `src/include/comm.h`.

**2. `[RCCL] Revert PR #5448 directBuff null guards in waitPeer`**

PR [#5448](https://github.com/ROCm/rocm-systems/pull/5448) ([commit `0e0a6bac41`](https://github.com/ROCm/rocm-systems/commit/0e0a6bac41)) added `directBuff != nullptr` checks to the four `DirectRead` / `DirectWrite` branches in `Primitives::waitPeer` as a device-side defense for the same hang. Empirical ablation (see Test Result) shows the guard is dead code once the host-side fix in commit 1 lands: `directBuff` is reliably published by `setDataPtrs` before any branch reads it, because the launchStream↔deviceStream sync now ensures a clean ordering. Revert the device-side check to keep the kernel hot path minimal.

## JIRA ID

Resolves ROCM-21756.

## Test Plan

Workload:

```bash
HSA_NO_SCRATCH_RECLAIM=1 NCCL_DEBUG=INFO \
  bash run_clm_wikitext.sh \
  --model_name_or_path=meta-llama/Llama-2-70b-chat-hf \
  --deepspeed=ds_config_zero_3.json
```

Ran in provided container against a clean rebuild of each candidate.

Three-cell matrix:

| Cell | Extra environment |
|---|---|
| 1 | *(default)* |
| 2 | `NCCL_LOCAL_REGISTER=1` |
| 3 | `RCCL_DIRECT_ALLGATHER_DISABLE=1` |

## Test Result

Per-cell results across the four ablation rows:

| Variant | Cell 1 default | Cell 2 `NCCL_LOCAL_REGISTER=1` | Cell 3 `RCCL_DIRECT_ALLGATHER_DISABLE=1` |
|---|---|---|---|
| Stock develop (no fix) | HANG | HANG | HANG |
| Device-side only (#5448 alone) | HANG | HANG | HANG |
| Host-side fix + #5448 | PASS 11.716 | PASS 12.059 | PASS 11.77 |
| **This PR (host-side fix, #5448 reverted)** | **PASS 11.374** | **PASS 9.691** | **PASS 11.839** |

Throughput in `eval_samples_per_second`. Variation between the two PASS rows is within run-to-run noise of the workload (~10–25% per single eval run on a shared host).

Conclusions:
- Host-side commit is necessary and sufficient: rows 1→3 confirm necessity, rows 4→3 confirm device-side guards add no correctness margin once host-side is in place.
- Reverting PR #5448 does not regress any of the three configurations.
