### PR TITLE
rocjitsu: Implement s_getreg_b32 and s_setreg_b32

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -296,6 +296,11 @@ class CodeGenerator:
                     f' if ({size_condition})'
                     f' size_ += sizeof(MachineInst);'
                 )
+            if inst_enc.has_implied_literal_ops:
+                size_line += (
+                    ' if (hasImpliedLiteral())'
+                    ' literal_ = reinterpret_cast<const uint32_t *>(inst)[1];'
+                )
             if rule.use_flat_mnemonic:
                 # FLAT mnemonics are dynamically constructed ("scratch_*",
                 # "global_*"). Store the owned string in a member so the
@@ -419,6 +424,10 @@ class CodeGenerator:
                     'const OpEncoding inst_'
                 )
             )
+            if inst_enc.has_implied_literal_ops:
+                class_members.append(
+                    cgen.Statement('uint32_t literal_ = 0')
+                )
             # FLAT encoding bases need an owned string for the dynamic mnemonic.
             if rule.use_flat_mnemonic:
                 class_members.append(
@@ -769,6 +778,63 @@ class CodeGenerator:
             L.append(f'  {dst_ops[0]}.write_scalar64(wf, wf.pc + size_);')
             L.append(f'  int16_t offset = static_cast<int16_t>({src_ops[0]}.encoding_value_);')
             L.append('  wf.pc = wf.pc + static_cast<int64_t>(offset) * 4 - size_;')
+            return '\n'.join(L)
+
+        if cls == 'scalar_getreg':
+            L.append(f'  uint16_t hwreg = {src_ops[0]}.encoding_value_;')
+            L.append('  uint32_t reg_id = hwreg & 0x3Fu;')
+            L.append('  uint32_t offset = (hwreg >> 6) & 0x1Fu;')
+            L.append('  uint32_t size = ((hwreg >> 11) & 0x1Fu) + 1;')
+            L.append('  uint32_t reg_val = 0;')
+            L.append('  switch (reg_id) {')
+            L.append('  case 1: reg_val = wf.status_raw(); break;')
+            L.append('  case 4: reg_val = static_cast<uint32_t>(wf.cu().id()); break;')
+            L.append('  case 5: reg_val = static_cast<uint32_t>(wf.cu().id() >> 16); break;')
+            L.append('  case 6: reg_val = (wf.sgpr_alloc().count & 0xFFu) | ((wf.sgpr_alloc().base & 0xFFu) << 8); break;')
+            L.append('  case 7: reg_val = (wf.vgpr_alloc().count & 0xFFu) | ((wf.vgpr_alloc().base & 0xFFu) << 8); break;')
+            L.append('  default: util::Logger::warn("s_getreg_b32: unhandled hwreg id=", reg_id); break;')
+            L.append('  }')
+            L.append('  if (offset + size > 32) size = 32 - offset;')
+            L.append('  uint32_t mask = (size == 32) ? 0xFFFFFFFFu : ((1u << size) - 1u);')
+            L.append(f'  {dst_ops[0]}.write_scalar(wf, (reg_val >> offset) & mask);')
+            return '\n'.join(L)
+
+        if cls == 'scalar_setreg':
+            L.append(f'  uint16_t hwreg = {dst_ops[0]}.encoding_value_;')
+            L.append('  uint32_t reg_id = hwreg & 0x3Fu;')
+            L.append('  uint32_t offset = (hwreg >> 6) & 0x1Fu;')
+            L.append('  uint32_t size = ((hwreg >> 11) & 0x1Fu) + 1;')
+            L.append('  if (offset + size > 32) size = 32 - offset;')
+            L.append('  uint32_t mask = (size == 32) ? 0xFFFFFFFFu : ((1u << size) - 1u);')
+            L.append(f'  uint32_t src = {src_ops[0]}.read_scalar(wf);')
+            L.append('  switch (reg_id) {')
+            L.append('  case 1: {')
+            L.append('    uint32_t s = wf.status_raw();')
+            L.append('    s = (s & ~(mask << offset)) | ((src & mask) << offset);')
+            L.append('    wf.set_status_raw(s);')
+            L.append('    break;')
+            L.append('  }')
+            L.append('  default: util::Logger::warn("s_setreg_b32: unhandled hwreg id=", reg_id); break;')
+            L.append('  }')
+            return '\n'.join(L)
+
+        if cls == 'scalar_setreg_imm':
+            L.append(f'  uint16_t hwreg = {dst_ops[0]}.encoding_value_;')
+            L.append('  uint32_t reg_id = hwreg & 0x3Fu;')
+            L.append('  uint32_t offset = (hwreg >> 6) & 0x1Fu;')
+            L.append('  uint32_t size = ((hwreg >> 11) & 0x1Fu) + 1;')
+            L.append('  if (offset + size > 32) size = 32 - offset;')
+            L.append('  uint32_t mask = (size == 32) ? 0xFFFFFFFFu : ((1u << size) - 1u);')
+            L.append('  uint32_t src = inst.literal_;')
+            L.append('  switch (reg_id) {')
+            L.append('  case 1: {')
+            L.append('    uint32_t s = wf.status_raw();')
+            L.append('    s = (s & ~(mask << offset)) | ((src & mask) << offset);')
+            L.append('    wf.set_status_raw(s);')
+            L.append('    break;')
+            L.append('  }')
+            L.append('  default: util::Logger::warn("s_setreg_imm32_b32: unhandled hwreg id=", reg_id); break;')
+            L.append('  }')
             return '\n'.join(L)
 
         if cls == 'scalar_bitcmp':
@@ -4004,6 +4070,17 @@ class CodeGenerator:
                         ('util/log.h', False),
                         ('format', True),
                     ])
+                has_getreg = any(
+                    self.semantics
+                    and (s := self.semantics.instructions.get(i.name))
+                    and s.semantic_class in ('scalar_getreg', 'scalar_setreg')
+                    for i in all_insts
+                )
+                if has_getreg and not is_mem_enc:
+                    cpp_includes.extend([
+                        ('rocjitsu/vm/amdgpu/compute_unit.h', False),
+                        ('util/log.h', False),
+                    ])
 
                 # Include the unified shared execute template header when
                 # any instruction in this encoding delegates to a template.
@@ -4220,6 +4297,7 @@ class CodeGenerator:
             '#include "rocjitsu/isa/arch/amdgpu/shared/transcendental.h"',
             '#include "util/data_types.h"',
             '#include "util/except.h"',
+            '#include "util/log.h"',
             '#include <algorithm>',
             '#include <bit>',
             '#include <cmath>',

--- a/emulation/rocjitsu/lib/python/amdisa/semantics.py
+++ b/emulation/rocjitsu/lib/python/amdisa/semantics.py
@@ -439,7 +439,14 @@ def _derive_sopk(name: str) -> InstructionSemantics | None:
                                        operation=op,
                                        data_type=_DTYPE_MAP[dt_raw])
 
-    # Everything else (GETREG, SETREG, CBRANCH_I_FORK, …) → nop
+    if name == 'S_GETREG_B32':
+        return InstructionSemantics(name, 'scalar_getreg')
+    if name == 'S_SETREG_B32':
+        return InstructionSemantics(name, 'scalar_setreg')
+    if name == 'S_SETREG_IMM32_B32':
+        return InstructionSemantics(name, 'scalar_setreg_imm')
+
+    # Everything else (CBRANCH_I_FORK, …) → nop
     return InstructionSemantics(name, 'nop')
 
 # Map mnemonic stem → operation.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/encodings.cpp
@@ -73,6 +73,8 @@ Sopk::Sopk(std::string_view mnemonic, const SopkMachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (!default_encoding() || hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Sopk::default_encoding() { return true; }
@@ -162,6 +164,8 @@ Vop2::Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (!default_encoding() || hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Vop2::default_encoding() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/encodings.h
@@ -52,6 +52,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = SopkMachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
 };
 
 class Sop2 : public IsaInstruction<Isa> {
@@ -117,6 +118,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = Vop2MachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
   uint32_t dpp_ctrl_ = 0;
   uint32_t dpp_row_mask_ = 0xF;
   uint32_t dpp_bank_mask_ = 0xF;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/sopk.cpp
@@ -6,9 +6,11 @@
 
 #include "rocjitsu/isa/arch/amdgpu/cdna1/sopk.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/data_types.h"
 #include "util/except.h"
+#include "util/log.h"
 #include <algorithm>
 #include <bit>
 #include <cmath>
@@ -286,8 +288,7 @@ SGetregB32Sopk::SGetregB32Sopk(const MachineInst *inst)
 }
 
 void SGetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_getreg_b32_sopk(*this, wf);
 }
 
 SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
@@ -302,8 +303,7 @@ SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
 }
 
 void SSetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_setreg_b32_sopk(*this, wf);
 }
 
 SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
@@ -316,8 +316,7 @@ SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
 }
 
 void SSetregImm32B32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_setreg_imm32_b32_sopk(*this, wf);
 }
 
 SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/encodings.cpp
@@ -73,6 +73,8 @@ Sopk::Sopk(std::string_view mnemonic, const SopkMachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (!default_encoding() || hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Sopk::default_encoding() { return true; }
@@ -162,6 +164,8 @@ Vop2::Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (!default_encoding() || hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Vop2::default_encoding() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/encodings.h
@@ -52,6 +52,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = SopkMachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
 };
 
 class Sop2 : public IsaInstruction<Isa> {
@@ -117,6 +118,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = Vop2MachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
   uint32_t dpp_ctrl_ = 0;
   uint32_t dpp_row_mask_ = 0xF;
   uint32_t dpp_bank_mask_ = 0xF;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/sopk.cpp
@@ -6,9 +6,11 @@
 
 #include "rocjitsu/isa/arch/amdgpu/cdna2/sopk.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/data_types.h"
 #include "util/except.h"
+#include "util/log.h"
 #include <algorithm>
 #include <bit>
 #include <cmath>
@@ -286,8 +288,7 @@ SGetregB32Sopk::SGetregB32Sopk(const MachineInst *inst)
 }
 
 void SGetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_getreg_b32_sopk(*this, wf);
 }
 
 SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
@@ -302,8 +303,7 @@ SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
 }
 
 void SSetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_setreg_b32_sopk(*this, wf);
 }
 
 SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
@@ -316,8 +316,7 @@ SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
 }
 
 void SSetregImm32B32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_setreg_imm32_b32_sopk(*this, wf);
 }
 
 SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/encodings.cpp
@@ -73,6 +73,8 @@ Sopk::Sopk(std::string_view mnemonic, const SopkMachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (!default_encoding() || hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Sopk::default_encoding() { return true; }
@@ -162,6 +164,8 @@ Vop2::Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (!default_encoding() || hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Vop2::default_encoding() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/encodings.h
@@ -52,6 +52,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = SopkMachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
 };
 
 class Sop2 : public IsaInstruction<Isa> {
@@ -117,6 +118,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = Vop2MachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
   uint32_t dpp_ctrl_ = 0;
   uint32_t dpp_row_mask_ = 0xF;
   uint32_t dpp_bank_mask_ = 0xF;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/sopk.cpp
@@ -6,9 +6,11 @@
 
 #include "rocjitsu/isa/arch/amdgpu/cdna3/sopk.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/data_types.h"
 #include "util/except.h"
+#include "util/log.h"
 #include <algorithm>
 #include <bit>
 #include <cmath>
@@ -286,8 +288,7 @@ SGetregB32Sopk::SGetregB32Sopk(const MachineInst *inst)
 }
 
 void SGetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_getreg_b32_sopk(*this, wf);
 }
 
 SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
@@ -302,8 +303,7 @@ SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
 }
 
 void SSetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_setreg_b32_sopk(*this, wf);
 }
 
 SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
@@ -316,8 +316,7 @@ SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
 }
 
 void SSetregImm32B32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_setreg_imm32_b32_sopk(*this, wf);
 }
 
 SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/encodings.cpp
@@ -69,6 +69,8 @@ Sopk::Sopk(std::string_view mnemonic, const SopkMachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Sopk::hasImpliedLiteral() { return inst_.op == 20; }
@@ -156,6 +158,8 @@ Vop2::Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (!default_encoding() || hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Vop2::default_encoding() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/encodings.h
@@ -50,6 +50,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = SopkMachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
 };
 
 class Sop2 : public IsaInstruction<Isa> {
@@ -115,6 +116,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = Vop2MachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
   uint32_t dpp_ctrl_ = 0;
   uint32_t dpp_row_mask_ = 0xF;
   uint32_t dpp_bank_mask_ = 0xF;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/sopk.cpp
@@ -6,9 +6,11 @@
 
 #include "rocjitsu/isa/arch/amdgpu/cdna4/sopk.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/data_types.h"
 #include "util/except.h"
+#include "util/log.h"
 #include <algorithm>
 #include <bit>
 #include <cmath>
@@ -292,8 +294,7 @@ SGetregB32Sopk::SGetregB32Sopk(const MachineInst *inst)
 }
 
 void SGetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_getreg_b32_sopk(*this, wf);
 }
 
 SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
@@ -308,8 +309,7 @@ SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
 }
 
 void SSetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_setreg_b32_sopk(*this, wf);
 }
 
 SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
@@ -322,8 +322,7 @@ SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
 }
 
 void SSetregImm32B32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_setreg_imm32_b32_sopk(*this, wf);
 }
 
 SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/encodings.cpp
@@ -73,6 +73,8 @@ Sopk::Sopk(std::string_view mnemonic, const SopkMachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (!default_encoding() || hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Sopk::default_encoding() { return true; }
@@ -156,6 +158,8 @@ Vop2::Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (!default_encoding() || hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Vop2::default_encoding() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/encodings.h
@@ -52,6 +52,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = SopkMachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
 };
 
 class Sop2 : public IsaInstruction<Isa> {
@@ -112,6 +113,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = Vop2MachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
   uint32_t dpp_ctrl_ = 0;
   uint32_t dpp_row_mask_ = 0xF;
   uint32_t dpp_bank_mask_ = 0xF;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/sopk.cpp
@@ -6,9 +6,11 @@
 
 #include "rocjitsu/isa/arch/amdgpu/rdna1/sopk.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/data_types.h"
 #include "util/except.h"
+#include "util/log.h"
 #include <algorithm>
 #include <bit>
 #include <cmath>
@@ -283,8 +285,7 @@ SGetregB32Sopk::SGetregB32Sopk(const MachineInst *inst)
 }
 
 void SGetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_getreg_b32_sopk(*this, wf);
 }
 
 SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
@@ -299,8 +300,7 @@ SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
 }
 
 void SSetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_setreg_b32_sopk(*this, wf);
 }
 
 SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
@@ -313,8 +313,7 @@ SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
 }
 
 void SSetregImm32B32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_setreg_imm32_b32_sopk(*this, wf);
 }
 
 SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/encodings.cpp
@@ -73,6 +73,8 @@ Sopk::Sopk(std::string_view mnemonic, const SopkMachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (!default_encoding() || hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Sopk::default_encoding() { return true; }
@@ -156,6 +158,8 @@ Vop2::Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (!default_encoding() || hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Vop2::default_encoding() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/encodings.h
@@ -52,6 +52,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = SopkMachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
 };
 
 class Sop2 : public IsaInstruction<Isa> {
@@ -112,6 +113,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = Vop2MachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
   uint32_t dpp_ctrl_ = 0;
   uint32_t dpp_row_mask_ = 0xF;
   uint32_t dpp_bank_mask_ = 0xF;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/sopk.cpp
@@ -6,9 +6,11 @@
 
 #include "rocjitsu/isa/arch/amdgpu/rdna2/sopk.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/data_types.h"
 #include "util/except.h"
+#include "util/log.h"
 #include <algorithm>
 #include <bit>
 #include <cmath>
@@ -283,8 +285,7 @@ SGetregB32Sopk::SGetregB32Sopk(const MachineInst *inst)
 }
 
 void SGetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_getreg_b32_sopk(*this, wf);
 }
 
 SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
@@ -299,8 +300,7 @@ SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
 }
 
 void SSetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_setreg_b32_sopk(*this, wf);
 }
 
 SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
@@ -313,8 +313,7 @@ SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
 }
 
 void SSetregImm32B32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_setreg_imm32_b32_sopk(*this, wf);
 }
 
 SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/encodings.cpp
@@ -73,6 +73,8 @@ Sopk::Sopk(std::string_view mnemonic, const SopkMachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (!default_encoding() || hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Sopk::default_encoding() { return true; }
@@ -154,6 +156,8 @@ Vop2::Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (!default_encoding() || hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Vop2::default_encoding() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/encodings.h
@@ -52,6 +52,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = SopkMachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
 };
 
 class Sop2 : public IsaInstruction<Isa> {
@@ -112,6 +113,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = Vop2MachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
   uint32_t dpp_ctrl_ = 0;
   uint32_t dpp_row_mask_ = 0xF;
   uint32_t dpp_bank_mask_ = 0xF;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/sopk.cpp
@@ -6,9 +6,11 @@
 
 #include "rocjitsu/isa/arch/amdgpu/rdna3/sopk.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/data_types.h"
 #include "util/except.h"
+#include "util/log.h"
 #include <algorithm>
 #include <bit>
 #include <cmath>
@@ -283,8 +285,7 @@ SGetregB32Sopk::SGetregB32Sopk(const MachineInst *inst)
 }
 
 void SGetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_getreg_b32_sopk(*this, wf);
 }
 
 SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
@@ -299,8 +300,7 @@ SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
 }
 
 void SSetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_setreg_b32_sopk(*this, wf);
 }
 
 SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
@@ -313,8 +313,7 @@ SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
 }
 
 void SSetregImm32B32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_setreg_imm32_b32_sopk(*this, wf);
 }
 
 SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/encodings.cpp
@@ -73,6 +73,8 @@ Sopk::Sopk(std::string_view mnemonic, const SopkMachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (!default_encoding() || hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Sopk::default_encoding() { return true; }
@@ -87,6 +89,8 @@ Sop2::Sop2(std::string_view mnemonic, const Sop2MachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (!default_encoding() || hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Sop2::default_encoding() { return inst_.ssrc0 != 255 && inst_.ssrc1 != 255; }
@@ -156,6 +160,8 @@ Vop2::Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (!default_encoding() || hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Vop2::default_encoding() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/encodings.h
@@ -52,6 +52,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = SopkMachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
 };
 
 class Sop2 : public IsaInstruction<Isa> {
@@ -64,6 +65,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = Sop2MachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
 };
 
 class Smem : public IsaInstruction<Isa> {
@@ -113,6 +115,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = Vop2MachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
   uint32_t dpp_ctrl_ = 0;
   uint32_t dpp_row_mask_ = 0xF;
   uint32_t dpp_bank_mask_ = 0xF;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/sopk.cpp
@@ -6,9 +6,11 @@
 
 #include "rocjitsu/isa/arch/amdgpu/rdna3_5/sopk.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/data_types.h"
 #include "util/except.h"
+#include "util/log.h"
 #include <algorithm>
 #include <bit>
 #include <cmath>
@@ -283,8 +285,7 @@ SGetregB32Sopk::SGetregB32Sopk(const MachineInst *inst)
 }
 
 void SGetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_getreg_b32_sopk(*this, wf);
 }
 
 SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
@@ -299,8 +300,7 @@ SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
 }
 
 void SSetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_setreg_b32_sopk(*this, wf);
 }
 
 SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
@@ -313,8 +313,7 @@ SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
 }
 
 void SSetregImm32B32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_setreg_imm32_b32_sopk(*this, wf);
 }
 
 SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/encodings.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/encodings.cpp
@@ -62,6 +62,8 @@ Sopk::Sopk(std::string_view mnemonic, const SopkMachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (!default_encoding() || hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Sopk::default_encoding() { return true; }
@@ -76,6 +78,8 @@ Sop2::Sop2(std::string_view mnemonic, const Sop2MachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (!default_encoding() || hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Sop2::default_encoding() { return inst_.ssrc0 != 255 && inst_.ssrc1 != 255; }
@@ -143,6 +147,8 @@ Vop2::Vop2(std::string_view mnemonic, const Vop2MachineInst *inst, ExecuteFn exe
   opcode_ = inst_.op;
   if (!default_encoding() || hasImpliedLiteral())
     size_ += sizeof(MachineInst);
+  if (hasImpliedLiteral())
+    literal_ = reinterpret_cast<const uint32_t *>(inst)[1];
 }
 
 bool Vop2::default_encoding() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/encodings.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/encodings.h
@@ -52,6 +52,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = SopkMachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
 };
 
 class Sop2 : public IsaInstruction<Isa> {
@@ -64,6 +65,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = Sop2MachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
 };
 
 class Smem : public IsaInstruction<Isa> {
@@ -113,6 +115,7 @@ public:
   bool hasImpliedLiteral();
   using OpEncoding = Vop2MachineInst;
   const OpEncoding inst_;
+  uint32_t literal_ = 0;
   uint32_t dpp_ctrl_ = 0;
   uint32_t dpp_row_mask_ = 0xF;
   uint32_t dpp_bank_mask_ = 0xF;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/sopk.cpp
@@ -6,9 +6,11 @@
 
 #include "rocjitsu/isa/arch/amdgpu/rdna4/sopk.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/data_types.h"
 #include "util/except.h"
+#include "util/log.h"
 #include <algorithm>
 #include <bit>
 #include <cmath>
@@ -105,8 +107,7 @@ SGetregB32Sopk::SGetregB32Sopk(const MachineInst *inst)
 }
 
 void SGetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_getreg_b32_sopk(*this, wf);
 }
 
 SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
@@ -121,8 +122,7 @@ SSetregB32Sopk::SSetregB32Sopk(const MachineInst *inst)
 }
 
 void SSetregB32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_setreg_b32_sopk(*this, wf);
 }
 
 SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
@@ -135,8 +135,7 @@ SSetregImm32B32Sopk::SSetregImm32B32Sopk(const MachineInst *inst)
 }
 
 void SSetregImm32B32Sopk::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_setreg_imm32_b32_sopk(*this, wf);
 }
 
 SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -14,6 +14,7 @@
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/data_types.h"
 #include "util/except.h"
+#include "util/log.h"
 #include <algorithm>
 #include <bit>
 #include <cmath>
@@ -1238,6 +1239,39 @@ inline void execute_s_floor_f32_sop1([[maybe_unused]] Inst &inst, [[maybe_unused
 }
 
 template <typename Inst>
+inline void execute_s_getreg_b32_sopk([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
+  uint16_t hwreg = inst.simm16.encoding_value_;
+  uint32_t reg_id = hwreg & 0x3Fu;
+  uint32_t offset = (hwreg >> 6) & 0x1Fu;
+  uint32_t size = ((hwreg >> 11) & 0x1Fu) + 1;
+  uint32_t reg_val = 0;
+  switch (reg_id) {
+  case 1:
+    reg_val = wf.status_raw();
+    break;
+  case 4:
+    reg_val = static_cast<uint32_t>(wf.cu().id());
+    break;
+  case 5:
+    reg_val = static_cast<uint32_t>(wf.cu().id() >> 16);
+    break;
+  case 6:
+    reg_val = (wf.sgpr_alloc().count & 0xFFu) | ((wf.sgpr_alloc().base & 0xFFu) << 8);
+    break;
+  case 7:
+    reg_val = (wf.vgpr_alloc().count & 0xFFu) | ((wf.vgpr_alloc().base & 0xFFu) << 8);
+    break;
+  default:
+    util::Logger::warn("s_getreg_b32: unhandled hwreg id=", reg_id);
+    break;
+  }
+  if (offset + size > 32)
+    size = 32 - offset;
+  uint32_t mask = (size == 32) ? 0xFFFFFFFFu : ((1u << size) - 1u);
+  inst.sdst.write_scalar(wf, (reg_val >> offset) & mask);
+}
+
+template <typename Inst>
 inline void execute_s_gl1_inv_smem([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   wf.cu().l1_vector().invalidate_all();
 }
@@ -1839,6 +1873,53 @@ inline void execute_s_setkill_sopp([[maybe_unused]] Inst &inst, [[maybe_unused]]
 
 template <typename Inst>
 inline void execute_s_setprio_sopp([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {}
+
+template <typename Inst>
+inline void execute_s_setreg_b32_sopk([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
+  uint16_t hwreg = inst.simm16.encoding_value_;
+  uint32_t reg_id = hwreg & 0x3Fu;
+  uint32_t offset = (hwreg >> 6) & 0x1Fu;
+  uint32_t size = ((hwreg >> 11) & 0x1Fu) + 1;
+  if (offset + size > 32)
+    size = 32 - offset;
+  uint32_t mask = (size == 32) ? 0xFFFFFFFFu : ((1u << size) - 1u);
+  uint32_t src = inst.sdst.read_scalar(wf);
+  switch (reg_id) {
+  case 1: {
+    uint32_t s = wf.status_raw();
+    s = (s & ~(mask << offset)) | ((src & mask) << offset);
+    wf.set_status_raw(s);
+    break;
+  }
+  default:
+    util::Logger::warn("s_setreg_b32: unhandled hwreg id=", reg_id);
+    break;
+  }
+}
+
+template <typename Inst>
+inline void execute_s_setreg_imm32_b32_sopk([[maybe_unused]] Inst &inst,
+                                            [[maybe_unused]] Wavefront &wf) {
+  uint16_t hwreg = inst.simm16.encoding_value_;
+  uint32_t reg_id = hwreg & 0x3Fu;
+  uint32_t offset = (hwreg >> 6) & 0x1Fu;
+  uint32_t size = ((hwreg >> 11) & 0x1Fu) + 1;
+  if (offset + size > 32)
+    size = 32 - offset;
+  uint32_t mask = (size == 32) ? 0xFFFFFFFFu : ((1u << size) - 1u);
+  uint32_t src = inst.literal_;
+  switch (reg_id) {
+  case 1: {
+    uint32_t s = wf.status_raw();
+    s = (s & ~(mask << offset)) | ((src & mask) << offset);
+    wf.set_status_raw(s);
+    break;
+  }
+  default:
+    util::Logger::warn("s_setreg_imm32_b32: unhandled hwreg id=", reg_id);
+    break;
+  }
+}
 
 template <typename Inst>
 inline void execute_s_sext_i32_i16_sop1([[maybe_unused]] Inst &inst,

--- a/emulation/rocjitsu/lib/util/include/util/log.h
+++ b/emulation/rocjitsu/lib/util/include/util/log.h
@@ -128,6 +128,15 @@ public:
     }
   }
 
+  /// @brief Emit a warning unconditionally (always enabled, not group-gated).
+  template <typename... Args> static void warn(Args &&...args) {
+    std::ostringstream buf;
+    buf << "[rj warn] ";
+    (buf << ... << args);
+    buf << '\n';
+    emit(buf.str());
+  }
+
   /// @brief Convenience for logging in GROUP_VM, variadic.
   template <typename... Args> static void vm(Args &&...args) {
     print<GROUP_VM>(std::forward<Args>(args)...);

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -224,4 +224,91 @@ TEST(InstructionExecutionHarness, Rdna4) { RUN_HARNESS(rdna4, ROCJITSU_CODE_ARCH
 
 #undef RUN_HARNESS
 
+/// @brief Targeted test for s_setreg_imm32_b32: verifies that the imm32
+/// literal is correctly read from the instruction encoding and written to
+/// the STATUS register bitfield.
+TEST(HwregTest, SetregImm32WritesStatus) {
+  amdgpu::GpuMemory gpu_mem("hwreg_test_mem");
+  amdgpu::L2Cache l2("hwreg_test_l2");
+
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 106;
+  cfg.vgprs_per_wf = 256;
+  cfg.lds_size_kb = 64;
+
+  auto cu = amdgpu::ComputeUnitCore::create("cdna4", cfg, &gpu_mem, &l2);
+  ASSERT_NE(cu, nullptr);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+
+  // Encode s_setreg_imm32_b32 targeting STATUS (hwreg=1), offset=0, size=32.
+  // SOPK encoding: [31:28]=0xB, [27:23]=op(20), [22:16]=sdst(0), [15:0]=simm16(hwreg)
+  // hwreg encoding: reg_id | (offset << 6) | ((size-1) << 11)
+  //               = 1 | (0 << 6) | (31 << 11) = 0xF801
+  // Word 1: imm32 literal value to write
+  constexpr uint32_t kSopkEncoding = 0xBu << 28;
+  constexpr uint32_t kSetregImm32Op = 20u << 23;
+  constexpr uint32_t kHwregStatus32 = 1u | (0u << 6) | (31u << 11);
+  constexpr uint32_t kImm32Value = 0xDEADBEEF;
+  const uint32_t words[] = {kSopkEncoding | kSetregImm32Op | kHwregStatus32, kImm32Value};
+
+  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  ASSERT_NE(inst, nullptr) << "Failed to decode s_setreg_imm32_b32";
+  EXPECT_EQ(std::string_view(inst->mnemonic()).substr(0, 16), "s_setreg_imm32_b");
+
+  auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(wf, nullptr);
+
+  wf->set_status_raw(0);
+  cu->execute_instruction(inst.get(), *wf);
+  EXPECT_EQ(wf->status_raw(), kImm32Value)
+      << "s_setreg_imm32_b32 did not write imm32 to STATUS register";
+
+  cu->reset_all_wf();
+}
+
+/// @brief Targeted test for s_setreg_imm32_b32 with partial bitfield write.
+TEST(HwregTest, SetregImm32PartialBitfield) {
+  amdgpu::GpuMemory gpu_mem("hwreg_partial_mem");
+  amdgpu::L2Cache l2("hwreg_partial_l2");
+
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 106;
+  cfg.vgprs_per_wf = 256;
+  cfg.lds_size_kb = 64;
+
+  auto cu = amdgpu::ComputeUnitCore::create("cdna4", cfg, &gpu_mem, &l2);
+  ASSERT_NE(cu, nullptr);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+
+  // Write bits[11:8] of STATUS (offset=8, size=4).
+  // hwreg = 1 | (8 << 6) | (3 << 11) = 1 | 0x200 | 0x1800 = 0x1A01
+  constexpr uint32_t kSopk = 0xBu << 28;
+  constexpr uint32_t kOp = 20u << 23;
+  constexpr uint32_t kHwreg = 1u | (8u << 6) | (3u << 11);
+  constexpr uint32_t kImm32 = 0xFFFFFFFF;
+  const uint32_t words[] = {kSopk | kOp | kHwreg, kImm32};
+
+  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  ASSERT_NE(inst, nullptr);
+
+  auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(wf, nullptr);
+
+  wf->set_status_raw(0xAAAAAAAA);
+  cu->execute_instruction(inst.get(), *wf);
+  // Bits[11:8] should be 0xF (from imm32=0xFFFFFFFF masked to 4 bits),
+  // all other bits should be unchanged from 0xAAAAAAAA.
+  EXPECT_EQ(wf->status_raw(), 0xAAAAAfAAu) << "Partial bitfield write to STATUS incorrect";
+
+  cu->reset_all_wf();
+}
+
 } // namespace


### PR DESCRIPTION
## Motivation
Fixes vLLM crash at dispatch 346 on unimplemented s_getreg_b32.

## Technical Details
Add scalar_getreg and scalar_setreg semantic classes for hardware register access instructions. s_getreg_b32 reads HW_REG by ID with bit offset/size extraction; s_setreg_b32 writes to HW_REG_STATUS.

## JIRA ID
N/A

## Test Plan
Run all tests.

## Test Result
All tests pass. OPT125 doesn't crash at dispatch 346 any longer.

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.