### PR TITLE
[rccl][test] AICOMRCCL-598: add RCCL Device API unit tests (LSA symmetric path)

### DIFF
--- a/projects/rccl/CHANGELOG.md
+++ b/projects/rccl/CHANGELOG.md
@@ -13,6 +13,8 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 * Added `RCCL_IB_P2P_DISABLE_CTS` to disable CTS offload for P2P connections on AINIC. Defaults to 1 (disabled). When `RCCL_CTS_OFFLOAD_ENABLED=1` is explicitly set, it overrides this flag and forces CTS on all connections including P2P.
 * Merged `RCCL_CTS_INLINE_DATA` into `RCCL_CTS_OFFLOAD_ENABLED`. CTS offload and CTS inline data are now controlled by a single tri-state variable: `-1` (default, auto-enable on AINIC), `0` (force disable), `1` (force enable for all connections).
 * Added Pythonic API bindings under `bindings/nccl4py/` (RCCL fork of NVIDIA `nccl4py` v0.2.0). Provides Python access to RCCL collectives via Cython bindings, an on-disk `cuda.core` HIP shim for ROCm hosts without `cuda-bindings` / `cuda-core`, and RCCL-only collective wrappers (`ncclAllReduceWithBias`, `ncclAllToAllv`).
+* Added unit tests for the RCCL Device API in `rccl-UnitTestsFixtures` (`DeviceApi.LsaRemoteRead`, `DeviceApi.CuMemDisabled`, `DeviceApi.WinDisabled`) covering LSA symmetric remote read and `ncclDevCommCreate` gating under `NCCL_CUMEM_ENABLE` / `NCCL_WIN_ENABLE`.
+* `ProcessIsolatedTestRunner`: opt-in `TestConfig::withExec(true)` mode that runs an isolated child via `fork()+execve()` of the same binary instead of plain `fork()`. Required for HIP-using tests when the binary may have already initialized HIP in earlier tests of the same process (fork-after-init is unsafe for the HIP/ROCm runtime).
 
 ### Changed
 * Compatibility with NCCL 2.28.3.

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -209,6 +209,7 @@ if(BUILD_TESTS)
       RomeTopoConsensusTests.cpp
       EnqueueCountTests.cpp
       device/TestOp128.cpp
+      DeviceApiTests.cpp
       common/main_fixtures.cpp
       common/EnvVars.cpp
       common/ProcessIsolatedTestRunner.cpp

--- a/projects/rccl/test/DeviceApiTests.cpp
+++ b/projects/rccl/test/DeviceApiTests.cpp
@@ -120,11 +120,35 @@ struct DeviceApiResources
     std::vector<DeviceApiRankResources> ranks;
 };
 
+// Intentionally leaked: see TODO below.
 static DeviceApiResources& createProcessLifetimeResources(int rankCount)
 {
-    // These tests run in a fresh exec-isolated child process and exit immediately
-    // after the test body completes. Keep resources process-lifetime to avoid the
-    // known communicator teardown crash tracked separately in the debugging notes.
+    // TODO(AICOMRCCL-835): Restore normal RAII cleanup once the Device API
+    // teardown segfault is fixed.
+    //
+    // ncclCommDestroy() currently crashes in the Device API teardown path:
+    //
+    //     ncclCommDestroy_impl
+    //       -> ncclGroupEndInternal
+    //         -> groupLaunch
+    //           -> asyncJobLaunch
+    //             -> commReclaim
+    //               -> ncclCudaFree<void>
+    //                 -> ncclCuMemFree
+    //                   -> hipMemRetainAllocationHandle  <-- SIGSEGV
+    //
+    // Reproduces on rccl-tests positive Device API runs too (not unit-test
+    // specific). The DeviceApi tests work around this by:
+    //   1. Running each test in a fresh fork()+execve() child process (see
+    //      ProcessIsolatedTestRunner::TestConfig::withExec()), and
+    //   2. Allocating DeviceApiResources with `new` and never deleting them
+    //      so DeviceApiResources::~DeviceApiResources() never calls
+    //      ncclCommDestroy(). The child process _exit()s immediately after
+    //      the test body, so the OS reclaims everything.
+    //
+    // When AICOMRCCL-835 is resolved, delete this helper, give each test a
+    // stack-allocated DeviceApiResources, and re-enable the destructor's
+    // ncclDevCommDestroy / ncclCommWindowDeregister / ncclCommDestroy path.
     return *new DeviceApiResources(rankCount);
 }
 

--- a/projects/rccl/test/DeviceApiTests.cpp
+++ b/projects/rccl/test/DeviceApiTests.cpp
@@ -1,0 +1,422 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <rccl/rccl.h>
+
+#include <array>
+#include <chrono>
+#include <cstdlib>
+#include <functional>
+#include <string>
+#include <vector>
+
+#define NCCL_ENABLE_DEVICE_HELPERS 1
+#include "nccl_device/impl/core__funcs.h"
+#include "nccl_device/impl/mem_barrier__funcs.h"
+#undef NCCL_ENABLE_DEVICE_HELPERS
+
+#include "common/ProcessIsolatedTestRunner.hpp"
+
+// Match RCCL's platform-portable memory_order selection (see src/include/sym_kernels.h).
+// On AMD/HIP, RCCL's device headers use std::memory_order; on CUDA, cuda::memory_order.
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+#define RCCL_TEST_MEM_ORDER_RELAXED std::memory_order_relaxed
+#define RCCL_TEST_MEM_ORDER_RELEASE std::memory_order_release
+#else
+#define RCCL_TEST_MEM_ORDER_RELAXED cuda::memory_order_relaxed
+#define RCCL_TEST_MEM_ORDER_RELEASE cuda::memory_order_release
+#endif
+
+namespace RcclUnitTesting
+{
+
+namespace
+{
+
+constexpr int    kPositiveRanks    = 2;
+constexpr int    kNegativeRanks    = 1;
+constexpr int    kBlocksPerRank    = 1;
+constexpr int    kThreadsPerBlock  = 64;
+constexpr size_t kBufferBytes      = sizeof(int);
+constexpr int    kNegativeTestSeed = 7;
+
+// Each rank reads one integer from its peer through a symmetric window.
+__global__ void lsaReadPeerValueKernel(
+    ncclWindow_t inputWindow, int* outputValue, ncclDevComm_t devComm
+)
+{
+    ncclLsaBarrierSession<ncclCoopCta> barrier(
+        ncclCoopCta(), devComm, ncclTeamLsa(devComm), devComm.lsaBarrier, blockIdx.x
+    );
+    barrier.sync(ncclCoopCta(), RCCL_TEST_MEM_ORDER_RELAXED);
+
+    if(threadIdx.x == 0)
+    {
+        const int peer = (devComm.rank + 1) % devComm.nRanks;
+        int*      peerInput
+            = reinterpret_cast<int*>(ncclGetLsaPointer(inputWindow, 0, peer));
+        outputValue[0] = peerInput[0];
+    }
+
+    barrier.sync(ncclCoopCta(), RCCL_TEST_MEM_ORDER_RELEASE);
+}
+
+struct DeviceApiRankResources
+{
+    int            device         = -1;
+    ncclComm_t     comm           = nullptr;
+    hipStream_t    stream         = nullptr;
+    int*           inputBuffer    = nullptr;
+    int*           outputBuffer   = nullptr;
+    ncclWindow_t   inputWindow    = nullptr;
+    ncclDevComm_t  devComm        = {};
+    bool           devCommCreated = false;
+};
+
+struct DeviceApiResources
+{
+    explicit DeviceApiResources(int rankCount)
+        : ranks(static_cast<size_t>(rankCount))
+    {
+        for(int rank = 0; rank < rankCount; ++rank)
+            ranks[rank].device = rank;
+    }
+
+    ~DeviceApiResources()
+    {
+        for(auto& rank : ranks)
+        {
+            if(rank.device >= 0)
+                (void)hipSetDevice(rank.device);
+
+            if(rank.stream != nullptr)
+                (void)hipStreamSynchronize(rank.stream);
+
+            if(rank.devCommCreated && rank.comm != nullptr)
+                (void)ncclDevCommDestroy(rank.comm, &rank.devComm);
+
+            if(rank.inputWindow != nullptr && rank.comm != nullptr)
+                (void)ncclCommWindowDeregister(rank.comm, rank.inputWindow);
+
+            if(rank.outputBuffer != nullptr)
+                (void)hipFree(rank.outputBuffer);
+
+            if(rank.inputBuffer != nullptr)
+                (void)ncclMemFree(rank.inputBuffer);
+
+            if(rank.stream != nullptr)
+                (void)hipStreamDestroy(rank.stream);
+
+            if(rank.comm != nullptr)
+                (void)ncclCommDestroy(rank.comm);
+        }
+    }
+
+    std::vector<DeviceApiRankResources> ranks;
+};
+
+static DeviceApiResources& createProcessLifetimeResources(int rankCount)
+{
+    // These tests run in a fresh exec-isolated child process and exit immediately
+    // after the test body completes. Keep resources process-lifetime to avoid the
+    // known communicator teardown crash tracked separately in the debugging notes.
+    return *new DeviceApiResources(rankCount);
+}
+
+static int getVisibleGpuCount()
+{
+    int gpuCount = 0;
+    return hipGetDeviceCount(&gpuCount) == hipSuccess ? gpuCount : 0;
+}
+
+static bool hasFullDirectP2p(int gpuCount)
+{
+    for(int src = 0; src < gpuCount; ++src)
+    {
+        for(int dst = 0; dst < gpuCount; ++dst)
+        {
+            if(src == dst)
+                continue;
+
+            int canAccessPeer = 0;
+            if(hipDeviceCanAccessPeer(&canAccessPeer, src, dst) != hipSuccess || !canAccessPeer)
+                return false;
+        }
+    }
+
+    return true;
+}
+
+static void initializeCommunicators(DeviceApiResources& resources)
+{
+    std::vector<ncclComm_t> comms(resources.ranks.size(), nullptr);
+
+    ASSERT_EQ(
+        ncclCommInitAll(comms.data(), static_cast<int>(comms.size()), nullptr), ncclSuccess
+    );
+
+    for(size_t rank = 0; rank < resources.ranks.size(); ++rank)
+        resources.ranks[rank].comm = comms[rank];
+}
+
+static void allocateInputBuffer(DeviceApiRankResources& rank, int inputValue)
+{
+    ASSERT_EQ(hipSetDevice(rank.device), hipSuccess);
+
+    void* rawInput = nullptr;
+    ASSERT_EQ(ncclMemAlloc(&rawInput, kBufferBytes), ncclSuccess);
+    rank.inputBuffer = static_cast<int*>(rawInput);
+
+    ASSERT_EQ(
+        hipMemcpy(rank.inputBuffer, &inputValue, kBufferBytes, hipMemcpyHostToDevice),
+        hipSuccess
+    );
+}
+
+static void allocatePositiveBuffers(
+    DeviceApiResources& resources, const std::array<int, kPositiveRanks>& inputValues
+)
+{
+    for(size_t rankIdx = 0; rankIdx < resources.ranks.size(); ++rankIdx)
+    {
+        auto& rank = resources.ranks[rankIdx];
+        ASSERT_EQ(hipSetDevice(rank.device), hipSuccess);
+        ASSERT_EQ(hipStreamCreate(&rank.stream), hipSuccess);
+
+        allocateInputBuffer(rank, inputValues[rankIdx]);
+
+        ASSERT_EQ(hipMalloc(reinterpret_cast<void**>(&rank.outputBuffer), kBufferBytes), hipSuccess);
+        ASSERT_EQ(hipMemset(rank.outputBuffer, 0, kBufferBytes), hipSuccess);
+    }
+}
+
+static void registerInputWindows(DeviceApiResources& resources)
+{
+    ASSERT_EQ(ncclGroupStart(), ncclSuccess);
+
+    std::vector<ncclResult_t> results(resources.ranks.size(), ncclSuccess);
+    for(size_t rankIdx = 0; rankIdx < resources.ranks.size(); ++rankIdx)
+    {
+        auto& rank   = resources.ranks[rankIdx];
+        results[rankIdx] = ncclCommWindowRegister(
+            rank.comm,
+            rank.inputBuffer,
+            kBufferBytes,
+            &rank.inputWindow,
+            NCCL_WIN_COLL_SYMMETRIC
+        );
+    }
+
+    const ncclResult_t groupResult = ncclGroupEnd();
+
+    for(const auto& result : results)
+        ASSERT_EQ(result, ncclSuccess);
+    ASSERT_EQ(groupResult, ncclSuccess);
+}
+
+static void clearHipErrorState()
+{
+    (void)hipGetLastError();
+}
+
+static void runPositiveLsaRemoteReadTest()
+{
+    if(getVisibleGpuCount() < kPositiveRanks)
+        GTEST_SKIP() << "This test requires at least 2 visible GPUs.";
+
+    if(!hasFullDirectP2p(kPositiveRanks))
+        GTEST_SKIP() << "This test requires direct P2P access between the first 2 GPUs.";
+
+    DeviceApiResources& resources = createProcessLifetimeResources(kPositiveRanks);
+    initializeCommunicators(resources);
+
+    const std::array<int, kPositiveRanks> inputValues = {7, 11};
+    allocatePositiveBuffers(resources, inputValues);
+
+    registerInputWindows(resources);
+
+    for(const auto& rank : resources.ranks)
+    {
+        if(rank.inputWindow == nullptr)
+            GTEST_SKIP() << "Symmetric window registration is unavailable on this configuration.";
+    }
+
+    ncclDevCommRequirements_t requirements = {};
+    requirements.lsaBarrierCount           = kBlocksPerRank;
+
+    ASSERT_EQ(ncclGroupStart(), ncclSuccess);
+
+    std::vector<ncclResult_t> createResults(resources.ranks.size(), ncclSuccess);
+    for(size_t rankIdx = 0; rankIdx < resources.ranks.size(); ++rankIdx)
+    {
+        auto& rank          = resources.ranks[rankIdx];
+        createResults[rankIdx] = ncclDevCommCreate(rank.comm, &requirements, &rank.devComm);
+    }
+
+    const ncclResult_t groupResult = ncclGroupEnd();
+
+    for(size_t rankIdx = 0; rankIdx < resources.ranks.size(); ++rankIdx)
+    {
+        if(createResults[rankIdx] == ncclSuccess)
+            resources.ranks[rankIdx].devCommCreated = true;
+    }
+
+    bool unsupportedConfiguration = (groupResult == ncclInvalidUsage);
+    for(const auto& result : createResults)
+        unsupportedConfiguration |= (result == ncclInvalidUsage);
+
+    if(unsupportedConfiguration)
+        GTEST_SKIP() << "Symmetric device API is unsupported on this configuration.";
+
+    for(const auto& result : createResults)
+        ASSERT_EQ(result, ncclSuccess);
+    ASSERT_EQ(groupResult, ncclSuccess);
+
+    for(auto& rank : resources.ranks)
+    {
+        ASSERT_EQ(hipSetDevice(rank.device), hipSuccess);
+        clearHipErrorState();
+
+        hipLaunchKernelGGL(
+            lsaReadPeerValueKernel,
+            dim3(kBlocksPerRank),
+            dim3(kThreadsPerBlock),
+            0,
+            rank.stream,
+            rank.inputWindow,
+            rank.outputBuffer,
+            rank.devComm
+        );
+        const hipError_t launchError = hipGetLastError();
+        ASSERT_EQ(launchError, hipSuccess)
+            << "lsaReadPeerValueKernel launch failed on device " << rank.device << ": "
+            << hipGetErrorString(launchError);
+    }
+
+    for(auto& rank : resources.ranks)
+    {
+        ASSERT_EQ(hipSetDevice(rank.device), hipSuccess);
+        ASSERT_EQ(hipStreamSynchronize(rank.stream), hipSuccess);
+    }
+
+    const std::array<int, kPositiveRanks> expectedOutputs = {inputValues[1], inputValues[0]};
+
+    for(size_t rankIdx = 0; rankIdx < resources.ranks.size(); ++rankIdx)
+    {
+        auto& rank = resources.ranks[rankIdx];
+        int   hostOutput = 0;
+
+        ASSERT_EQ(hipSetDevice(rank.device), hipSuccess);
+        ASSERT_EQ(
+            hipMemcpy(&hostOutput, rank.outputBuffer, kBufferBytes, hipMemcpyDeviceToHost),
+            hipSuccess
+        );
+        EXPECT_EQ(hostOutput, expectedOutputs[rankIdx]);
+    }
+}
+
+static void runDevCommCreateFailureTest()
+{
+    if(getVisibleGpuCount() < kNegativeRanks)
+        GTEST_SKIP() << "This test requires at least 1 visible GPU.";
+
+    DeviceApiResources& resources = createProcessLifetimeResources(kNegativeRanks);
+    initializeCommunicators(resources);
+    allocateInputBuffer(resources.ranks[0], kNegativeTestSeed);
+    registerInputWindows(resources);
+
+    ncclDevCommRequirements_t requirements = {};
+    requirements.lsaBarrierCount           = kBlocksPerRank;
+
+    const ncclResult_t createResult
+        = ncclDevCommCreate(resources.ranks[0].comm, &requirements, &resources.ranks[0].devComm);
+
+    EXPECT_EQ(createResult, ncclInvalidUsage);
+    if(createResult == ncclSuccess)
+        resources.ranks[0].devCommCreated = true;
+}
+
+// Per-test config notes:
+//   - These are single-process multi-GPU tests (ncclCommInitAll). All rank-to-
+//     rank bootstrap traffic is intra-host by construction, so we pin NCCL's
+//     bootstrap socket to loopback. This makes the tests self-contained on
+//     any host network configuration (single-NIC, multi-NIC, containers with
+//     shared host netns, etc.) without relying on the caller to set
+//     NCCL_SOCKET_IFNAME.
+//   - .withExec() runs each isolated child via fork()+execve() of the same
+//     binary instead of plain fork(). This is required when the binary may
+//     have already initialized HIP in earlier tests of the same process
+//     (e.g. PackRoundtripTest in rccl-UnitTestsFixtures): a forked child
+//     would inherit an unusable HIP runtime state and fail the first GPU
+//     allocation with 'out of memory'.
+static ProcessIsolatedTestRunner::TestConfig makeDeviceApiEnabledConfig(
+    const std::string& name, std::function<void()> testFn
+)
+{
+    return ProcessIsolatedTestRunner::TestConfig(name, testFn)
+        .withEnvironment({{"NCCL_CUMEM_ENABLE", "1"},
+                          {"NCCL_WIN_ENABLE", "1"},
+                          {"NCCL_SOCKET_IFNAME", "lo"}})
+        .withTimeout(std::chrono::seconds(60))
+        .withExec();
+}
+
+static ProcessIsolatedTestRunner::TestConfig makeCuMemDisabledConfig(
+    const std::string& name, std::function<void()> testFn
+)
+{
+    return ProcessIsolatedTestRunner::TestConfig(name, testFn)
+        .withEnvironment({{"NCCL_CUMEM_ENABLE", "0"},
+                          {"NCCL_WIN_ENABLE", "1"},
+                          {"NCCL_SOCKET_IFNAME", "lo"}})
+        .withTimeout(std::chrono::seconds(60))
+        .withExec();
+}
+
+static ProcessIsolatedTestRunner::TestConfig makeWinDisabledConfig(
+    const std::string& name, std::function<void()> testFn
+)
+{
+    return ProcessIsolatedTestRunner::TestConfig(name, testFn)
+        .withEnvironment({{"NCCL_CUMEM_ENABLE", "1"},
+                          {"NCCL_WIN_ENABLE", "0"},
+                          {"NCCL_SOCKET_IFNAME", "lo"}})
+        .withTimeout(std::chrono::seconds(60))
+        .withExec();
+}
+
+} // namespace
+
+TEST(DeviceApi, LsaRemoteRead)
+{
+    RUN_ISOLATED_TESTS(
+        makeDeviceApiEnabledConfig(
+            "DeviceApi.LsaRemoteRead", []() { runPositiveLsaRemoteReadTest(); }
+        )
+    );
+}
+
+TEST(DeviceApi, CuMemDisabled)
+{
+    RUN_ISOLATED_TESTS(
+        makeCuMemDisabledConfig(
+            "DeviceApi.CuMemDisabled", []() { runDevCommCreateFailureTest(); }
+        )
+    );
+}
+
+TEST(DeviceApi, WinDisabled)
+{
+    RUN_ISOLATED_TESTS(
+        makeWinDisabledConfig(
+            "DeviceApi.WinDisabled", []() { runDevCommCreateFailureTest(); }
+        )
+    );
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/DeviceApiTests.cpp
+++ b/projects/rccl/test/DeviceApiTests.cpp
@@ -120,38 +120,6 @@ struct DeviceApiResources
     std::vector<DeviceApiRankResources> ranks;
 };
 
-// Intentionally leaked: see TODO below.
-static DeviceApiResources& createProcessLifetimeResources(int rankCount)
-{
-    // TODO(AICOMRCCL-835): Restore normal RAII cleanup once the Device API
-    // teardown segfault is fixed.
-    //
-    // ncclCommDestroy() currently crashes in the Device API teardown path:
-    //
-    //     ncclCommDestroy_impl
-    //       -> ncclGroupEndInternal
-    //         -> groupLaunch
-    //           -> asyncJobLaunch
-    //             -> commReclaim
-    //               -> ncclCudaFree<void>
-    //                 -> ncclCuMemFree
-    //                   -> hipMemRetainAllocationHandle  <-- SIGSEGV
-    //
-    // Reproduces on rccl-tests positive Device API runs too (not unit-test
-    // specific). The DeviceApi tests work around this by:
-    //   1. Running each test in a fresh fork()+execve() child process (see
-    //      ProcessIsolatedTestRunner::TestConfig::withExec()), and
-    //   2. Allocating DeviceApiResources with `new` and never deleting them
-    //      so DeviceApiResources::~DeviceApiResources() never calls
-    //      ncclCommDestroy(). The child process _exit()s immediately after
-    //      the test body, so the OS reclaims everything.
-    //
-    // When AICOMRCCL-835 is resolved, delete this helper, give each test a
-    // stack-allocated DeviceApiResources, and re-enable the destructor's
-    // ncclDevCommDestroy / ncclCommWindowDeregister / ncclCommDestroy path.
-    return *new DeviceApiResources(rankCount);
-}
-
 static int getVisibleGpuCount()
 {
     int gpuCount = 0;
@@ -256,7 +224,7 @@ static void runPositiveLsaRemoteReadTest()
     if(!hasFullDirectP2p(kPositiveRanks))
         GTEST_SKIP() << "This test requires direct P2P access between the first 2 GPUs.";
 
-    DeviceApiResources& resources = createProcessLifetimeResources(kPositiveRanks);
+    DeviceApiResources resources(kPositiveRanks);
     initializeCommunicators(resources);
 
     const std::array<int, kPositiveRanks> inputValues = {7, 11};
@@ -349,7 +317,7 @@ static void runDevCommCreateFailureTest()
     if(getVisibleGpuCount() < kNegativeRanks)
         GTEST_SKIP() << "This test requires at least 1 visible GPU.";
 
-    DeviceApiResources& resources = createProcessLifetimeResources(kNegativeRanks);
+    DeviceApiResources resources(kNegativeRanks);
     initializeCommunicators(resources);
     allocateInputBuffer(resources.ranks[0], kNegativeTestSeed);
     registerInputWindows(resources);

--- a/projects/rccl/test/common/ProcessIsolatedTestFramework.md
+++ b/projects/rccl/test/common/ProcessIsolatedTestFramework.md
@@ -7,6 +7,7 @@ A lightweight C++ testing framework for running Google Test cases in isolated pr
 - [Why Use Process Isolation?](#why-use-process-isolation)
 - [Quick Start](#quick-start)
 - [Core Concepts](#core-concepts)
+- [Isolation Modes: `fork()` vs `fork()+execve()`](#isolation-modes-fork-vs-forkexecve)
 - [API Reference](#api-reference)
 - [Examples](#examples)
 - [Best Practices](#best-practices)
@@ -18,8 +19,11 @@ A lightweight C++ testing framework for running Google Test cases in isolated pr
 
 `ProcessIsolatedTestRunner` is a framework that executes tests in separate processes using `fork()`. This ensures complete isolation between tests, particularly useful when testing code with static variables or environment-dependent behavior.
 
+By default the child is created with plain `fork()`. For tests that need a *fresh process image* (e.g. HIP-using tests when the binary may have already initialized HIP in earlier tests of the same process), opt in to `fork()+execve()` mode by adding `.withExec()` to the `TestConfig`. See [Mode 2: fork() + execve() (`.withExec()`)](#mode-2-fork--execve-withexec) and [Best Practice 9 (HIP/ROCm: prefer `.withExec()`)](#9-hiproccm-using-tests-prefer-withexec-over-plain-fork).
+
 **Key Features:**
 - ✅ Process-based test isolation (each test runs in its own process)
+- ✅ Two isolation modes: plain `fork()` (default) and `fork()+execve()` for fresh process images (`.withExec()`)
 - ✅ Per-test environment variable management
 - ✅ Configurable timeouts
 - ✅ Sequential or stop-on-failure execution
@@ -263,6 +267,67 @@ struct TestResult {
 
 ---
 
+## Isolation Modes: `fork()` vs `fork()+execve()`
+
+`ProcessIsolatedTestRunner` supports two ways of spawning the per-test child. They differ only in *how* the child process is created; everything else (env vars, timeout, result reporting, gtest integration) is identical.
+
+### Mode 1: `fork()` (default)
+
+The runner forks the test-runner process. The child inherits the parent's full address space (copy-on-write), open file descriptors, and any runtime state the parent has already established.
+
+- ✅ Cheap: no relink, no static init, no gtest re-discovery.
+- ✅ Sufficient for host-only tests: env-var-driven behavior, static-variable resets, configuration caches, etc.
+- ⚠️ Fragile when the parent has touched runtime state that is *not safe to inherit across `fork()`*. The canonical case in RCCL is the **HIP/ROCm runtime**: if any earlier test in the same binary initialized HIP (e.g. via `hipSetDevice` / `hipMalloc` / launching a kernel), the forked child inherits an inconsistent HIP context and its first GPU allocation will typically fail with `HIP failure: 'out of memory'` followed by a crash.
+
+Default behavior — nothing to enable.
+
+### Mode 2: `fork()+execve()` (`.withExec()`)
+
+Opt in via `TestConfig::withExec()`. The runner still forks, but the child immediately `execve()`s `/proc/self/exe` with `--gtest_filter` set to the currently running TEST(). The new process image:
+
+- starts gtest from scratch (no inherited HIP/ROCm state, no inherited address-space pollution),
+- re-runs the same `TEST()` body, which calls `RUN_ISOLATED_TESTS(...)` / `executeAllTests()` again,
+- detects an internal sentinel env var (`RCCL_PIT_REEXEC_TEST=<config-name>`) set by the runner, finds the matching test lambda, runs it inline (no further fork/exec), and `_exit()`s with the test result.
+
+```cpp
+ProcessIsolatedTestRunner::TestConfig("DeviceApi.LsaRemoteRead",
+    []() { runPositiveLsaRemoteReadTest(); })
+    .withEnvironment({{"NCCL_CUMEM_ENABLE", "1"},
+                      {"NCCL_WIN_ENABLE",   "1"}})
+    .withExec()                                  // <-- fresh process image
+    .withTimeout(std::chrono::seconds(60))
+```
+
+When you need it:
+
+- The test uses HIP/ROCm (or any other runtime/library that is unsafe to inherit across `fork()`) **and** the same binary contains earlier tests that already initialized that runtime in the parent process.
+- A concrete example in this repo: `DeviceApiTests.cpp` shares `rccl-UnitTestsFixtures` with `PackRoundtripTest` (`device/TestOp128.cpp`). `PackRoundtripTest` runs `TEST_F`s inline in the parent and calls `hipSetDevice(0)` + `hipMalloc` / `hipFree`. Without `.withExec()`, the DeviceApi tests' forked child inherits that HIP context and crashes.
+
+What it costs:
+
+- Each isolated child pays the cost of a fresh process startup (relink, gtest init, banner). On this codebase that's a few hundred milliseconds per test, dominated by gtest startup.
+- The new process re-runs the same `TEST()` body, so its stdout/stderr (gtest "[ RUN ]" / "[ OK ]" lines, banner, env-var summary) appears in the captured child output. The parent then prints its own "[ RUN ]" / "[ OK ]" for the outer TEST. Slightly noisier logs; nothing else changes.
+
+What it does **not** do:
+
+- It does not change the test-discovery mechanism — tests are still discovered by gtest in the usual way.
+- It does not affect any other test in the binary that doesn't opt in.
+- It does not enable parallel execution; tests still run sequentially.
+
+### Cheat sheet
+
+| Situation                                          | Use            |
+| -------------------------------------------------- | -------------- |
+| Host-only test, env-var / static-variable behavior | plain `fork()` |
+| Code under test reads env into static state        | plain `fork()` |
+| Test uses HIP/ROCm and is the **only** test in the binary that does | plain `fork()` |
+| Test uses HIP/ROCm and other tests in the same binary may have already initialized HIP | `.withExec()` |
+| Test relies on a fresh address space or pristine library state for any other reason | `.withExec()` |
+
+When in doubt for a HIP-using test that lives alongside other HIP-using tests in the same binary, prefer `.withExec()`.
+
+---
+
 ## API Reference
 
 ### Macros (Recommended)
@@ -453,6 +518,21 @@ TestConfig& withCleanEnvironment(bool inherit = true);
 
 **Default:** `true` (inherits parent environment)
 
+#### `withExec()`
+Run the isolated child via `fork()+execve()` of the same binary instead of plain `fork()`. The child starts as a fresh process image (no inherited HIP/ROCm state, no inherited address-space pollution). See [Isolation Modes](#isolation-modes-fork-vs-forkexecve) for the full mechanism and trade-offs.
+
+```cpp
+TestConfig& withExec(bool exec = true);
+```
+
+**Default:** `false` (plain `fork()`).
+
+**Requires:** the calling `TEST()` body must be running under gtest at the time `executeAllTests()` is invoked. The runner reads the current `::testing::TestInfo` to build the `--gtest_filter` for the re-exec'd process. (This is true for all normal `RUN_ISOLATED_TESTS` / `RUN_ISOLATED_TEST_*` callers; you only need to worry about this if you are driving the runner manually from somewhere other than a gtest TEST body.)
+
+**Reserved environment variable:** the runner uses `RCCL_PIT_REEXEC_TEST` internally to mark the re-exec'd child and route it back to the right test lambda. Don't set it yourself.
+
+**When to use:** HIP/ROCm-using tests that share a binary with other tests that may have already initialized HIP in the parent process. Concrete example: `test/DeviceApiTests.cpp` in `rccl-UnitTestsFixtures` (which also runs `PackRoundtripTest`, an inline HIP user).
+
 ---
 
 ## Examples
@@ -626,6 +706,47 @@ TEST(Rcclwrap, CriticalTests) {
   bool passed = ProcessIsolatedTestRunner::executeAllTests(options);
   EXPECT_TRUE(passed) << "Critical test suite failed";
 }
+```
+
+### Example 5: HIP-using test sharing a binary with other HIP tests (`.withExec()`)
+
+`rccl-UnitTestsFixtures` runs `PackRoundtripTest` (from `device/TestOp128.cpp`) before the DeviceApi tests. `PackRoundtripTest` calls `hipSetDevice(0)` and `hipMalloc`/`hipFree` inline in the parent process, so by the time the DeviceApi tests run, the parent already has a live HIP context. Plain `fork()` is unsafe in that situation; use `.withExec()` to give each DeviceApi test a fresh process image.
+
+```cpp
+// From test/DeviceApiTests.cpp
+static ProcessIsolatedTestRunner::TestConfig makeDeviceApiEnabledConfig(
+    const std::string& name, std::function<void()> testFn)
+{
+    return ProcessIsolatedTestRunner::TestConfig(name, testFn)
+        .withEnvironment({{"NCCL_CUMEM_ENABLE",  "1"},
+                          {"NCCL_WIN_ENABLE",    "1"},
+                          {"NCCL_SOCKET_IFNAME", "lo"}})
+        .withTimeout(std::chrono::seconds(60))
+        .withExec();  // fresh process image, HIP runtime starts clean
+}
+
+TEST(DeviceApi, LsaRemoteRead) {
+    RUN_ISOLATED_TESTS(
+        makeDeviceApiEnabledConfig(
+            "DeviceApi.LsaRemoteRead",
+            []() { runPositiveLsaRemoteReadTest(); }
+        )
+    );
+}
+```
+
+Without `.withExec()`, the first GPU allocation in the forked child fails:
+
+```
+cv350-rck-g03-e06-08:33002:33003 [0] [FATAL ERROR]: HIP failure: 'out of memory'
+[ INFO     ] Test 'DeviceApi.LsaRemoteRead' (PID: 33002) terminated by signal 11 after 382 ms
+```
+
+With `.withExec()` the same test passes:
+
+```
+[ INFO     ] Running isolated test 'DeviceApi.LsaRemoteRead' (PID: 48083) with env: NCCL_SOCKET_IFNAME=lo, NCCL_WIN_ENABLE=1, NCCL_CUMEM_ENABLE=1
+[ INFO     ] Test 'DeviceApi.LsaRemoteRead' PASSED (4399 ms)
 ```
 
 ---
@@ -827,35 +948,52 @@ RUN_ISOLATED_TEST("GPUTest", []() {
 });
 ```
 
-### 9. Avoid GPU Initialization in Test Fixtures
+### 9. HIP/ROCm-using tests: prefer `.withExec()` over plain `fork()`
 
-When using process isolation, avoid initializing GPU resources in test fixture `SetUp()` methods:
+When the test binary contains *any* test that initializes HIP in the parent process (typically inline `TEST_F`s that call `hipSetDevice` / `hipMalloc` / launch a kernel), every other HIP-using test in the same binary that uses plain `fork()` will inherit that HIP context and fail. The symptoms are usually:
+
+- `HIP failure: 'out of memory'` on the first GPU allocation in the child, or
+- corrupted heap diagnostics like `malloc(): unaligned tcache chunk detected` / `free(): invalid pointer`, or
+- `duplicate GPU detection` during `ncclCommInitAll`,
+
+all followed by a SIGSEGV / SIGABRT in the child.
+
+There are two complementary ways to defend against this:
 
 ```cpp
-// ❌ BAD: GPU initialization in fixture (runs in parent process)
-class GPUTests : public ::testing::Test {
-protected:
-  void SetUp() override {
-    hipMalloc(&gpuBuffer, 1024);  // Parent process - will pollute fork()!
-  }
-  void* gpuBuffer;
-};
-
-// ✅ GOOD: GPU initialization inside isolated test
-class GPUTests : public ::testing::Test {
-  // Empty fixture or only CPU resources in SetUp()
-};
+// (a) Keep HIP out of the parent process. Don't init HIP in fixture SetUp()
+//     or at static-init time. Initialize inside the isolated child instead.
+class GPUTests : public ::testing::Test { /* no GPU work in SetUp() */ };
 
 TEST_F(GPUTests, MyTest) {
   RUN_ISOLATED_TEST("GPUOperation", []() {
     void* gpuBuffer;
-    hipMalloc(&gpuBuffer, 1024);  // Child process only - safe!
+    hipMalloc(&gpuBuffer, 1024);   // Child process only
     // ... test logic ...
     hipFree(gpuBuffer);
   });
 }
 
-// ✅ EVEN BETTER: Use RAII + helper structure
+// (b) When you can't control the rest of the binary -- e.g. the suite is
+//     pinned to rccl-UnitTestsFixtures which includes other tests that DO
+//     initialize HIP in the parent (PackRoundtripTest etc.) -- opt your
+//     test into fork()+execve() isolation.
+TEST(DeviceApi, LsaRemoteRead) {
+  RUN_ISOLATED_TESTS(
+    ProcessIsolatedTestRunner::TestConfig(
+        "DeviceApi.LsaRemoteRead",
+        []() { runPositiveLsaRemoteReadTest(); })
+      .withEnvironment({{"NCCL_CUMEM_ENABLE", "1"}, {"NCCL_WIN_ENABLE", "1"}})
+      .withExec()                  // <-- fresh process image; immune to parent HIP state
+      .withTimeout(std::chrono::seconds(60))
+  );
+}
+```
+
+(a) is the cheapest and should always be your first choice. Reach for (b) when (a) is not under your control, or when you specifically need a pristine process image for any other reason (loaded shared libraries, atexit handlers, global constructors, etc.). See [Isolation Modes](#isolation-modes-fork-vs-forkexecve) for details.
+
+```cpp
+// ✅ EVEN BETTER: Use RAII + helper structure for resource lifetime
 struct GPUTestEnvironment {
   void* buffer;
   void setup() { hipMalloc(&buffer, 1024); }
@@ -919,6 +1057,26 @@ TEST_F(GPUTests, MyTest) {
 1. Check system resource limits: `ulimit -u` (max processes)
 2. Reduce number of tests or run in smaller batches
 3. Check for resource leaks in parent process
+
+### Child crashes immediately with HIP / heap errors
+
+**Symptom:** The isolated child terminates almost instantly (a few hundred ms) with one or more of:
+
+- `[FATAL ERROR]: HIP failure: 'out of memory'` on the first `hipMalloc` / `ncclMemAlloc`,
+- `malloc(): unaligned tcache chunk detected` or `free(): invalid pointer`,
+- `duplicate GPU detection` during `ncclCommInitAll`,
+- terminated by signal 6 (SIGABRT) or 11 (SIGSEGV) shortly after launch.
+
+**Cause:** The parent test-runner process initialized HIP / ROCm runtime state before this test forked. Plain `fork()` inherits that state, but the inherited HIP context is not usable in the child.
+
+This commonly happens when your test sits in a binary alongside other tests that touch HIP inline in the parent (e.g. `TEST_F`s with `hipSetDevice` in `SetUp()` or `DeviceTestBase`-style fixtures).
+
+**Solution:** Add `.withExec()` to the offending `TestConfig` so the child is created via `fork()+execve()` and starts from a fresh process image with no inherited HIP state. See [Isolation Modes](#isolation-modes-fork-vs-forkexecve) and [Best Practice 9](#9-hiproccm-using-tests-prefer-withexec-over-plain-fork).
+
+```cpp
+ProcessIsolatedTestRunner::TestConfig("MyHipTest", []() { /* ... */ })
+    .withExec()    // <-- adds fresh process image
+```
 
 ### Test Results Not Available
 
@@ -991,10 +1149,10 @@ EXPECT_EQ(results.size(), expectedTestCount)
    - Parent process iterates through registered tests
    - For each test:
      - `fork()` creates a child process
-     - Child applies environment variables
-     - Child executes test logic
-     - Parent waits for child to complete
-     - Result is collected and stored
+     - **If `withExec()` is NOT set (default):** child applies environment variables and executes the test logic directly, then `_exit()`s with the result.
+     - **If `withExec()` is set:** child applies environment variables, sets a sentinel env var (`RCCL_PIT_REEXEC_TEST=<config-name>`), then `execve("/proc/self/exe", { "/proc/self/exe", "--gtest_filter=<current_test>" })`. The re-exec'd process starts gtest from scratch, re-runs the same `TEST()` body, which calls `RUN_ISOLATED_TESTS` / `executeAllTests()` again; the runner detects the sentinel at the top of `executeAllTests()`, finds the matching `TestConfig` by name, runs its lambda inline (no further fork/exec), and `_exit()`s with the result.
+     - Parent waits for child to complete (in both modes).
+     - Result is collected and stored.
 
 3. **Result Collection:**
    - Exit codes are captured from child processes
@@ -1028,11 +1186,12 @@ The framework uses mutexes for thread-safe operations:
 
 ## Limitations
 
-1. **Process Overhead:** Each test creates a new process (fork overhead)
-2. **Sequential Execution:** Tests run one at a time (not parallel)
-3. **Linux/Unix Only:** Uses `fork()` - not available on Windows
-4. **Memory Duplication:** Each forked process duplicates memory
-5. **No Shared State:** Tests cannot share data between processes
+1. **Process Overhead:** Each test creates a new process (`fork()` overhead, plus a relink / gtest re-init if `.withExec()` is enabled).
+2. **Sequential Execution:** Tests run one at a time (not parallel).
+3. **Linux/Unix Only:** Uses `fork()` and `execve()` — not available on Windows.
+4. **Memory Duplication:** Each forked process duplicates memory (less of an issue with `.withExec()` since the child's memory image is the freshly-loaded binary).
+5. **No Shared State:** Tests cannot share data between processes.
+6. **`.withExec()` requires a gtest context:** `withExec()` reads the currently-running `::testing::TestInfo` to build the re-exec'd child's `--gtest_filter`. If you call `executeAllTests()` outside a gtest TEST body, `.withExec()` will fail. This is rarely a concern — all the `RUN_ISOLATED_TEST*` macros are designed to be used from inside `TEST()` / `TEST_F()` bodies.
 
 ---
 
@@ -1064,6 +1223,14 @@ A:
 3. Temporarily run the test logic outside the framework
 4. Use GDB
 
+**Q: My HIP test crashes immediately with `HIP failure: 'out of memory'` or `duplicate GPU detection`. Why?**
+
+A: Another test in the same binary almost certainly initialized HIP/ROCm in the parent process before yours forked. Plain `fork()` inherits that state, but the inherited HIP context isn't usable in the child. Add `.withExec()` to your `TestConfig` so the child is created via `fork()+execve()` with a fresh process image. See [Best Practice 9](#9-hiproccm-using-tests-prefer-withexec-over-plain-fork) and [Isolation Modes](#isolation-modes-fork-vs-forkexecve) for the full mechanism.
+
+**Q: When should I prefer `.withExec()` over plain `fork()`?**
+
+A: Whenever the test binary contains *any* code that may have already initialized a runtime that is unsafe to inherit across `fork()` — most commonly HIP/ROCm, but also some GPU driver shims, MPI runtimes (when not using the MPI test runner), and certain library global constructors. If your test is the only HIP-using test in the binary, plain `fork()` is fine; if it shares a binary with others, use `.withExec()`. See the cheat sheet under [Isolation Modes](#isolation-modes-fork-vs-forkexecve).
+
 **Q: Can I run tests in parallel?**
 
 A: No, the current implementation only supports sequential execution.
@@ -1078,6 +1245,10 @@ A: Use the macros (`RUN_ISOLATED_TEST`, `RUN_ISOLATED_TESTS`, etc.) for most cas
 - Dynamically generating test configurations at runtime
 - Sharing test registration logic across multiple TEST blocks
 - Advanced control flow scenarios
+
+**Q: Does `withExec()` affect other tests in my suite that don't use it?**
+
+A: No. `withExec()` is a per-`TestConfig` opt-in. Every other test continues to use plain `fork()` as before. The runner's default behavior is unchanged; the only thing that's new is that you can ask for a fresh process image on a per-test basis.
 
 **Q: Do tests run automatically after registration, or do I need to call executeAllTests()?**
 

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -44,11 +44,17 @@ ProcessIsolatedTestRunner::TestResult::TestResult()
     : passed(false), skipped(false), exitCode(-1), processId(-1), duration(0)
 {}
 
+// Sentinel environment variable used to mark a re-exec'd child process. When
+// set, executeAllTests() finds the matching TestConfig by name and runs its
+// lambda inline (no further fork/exec) before _exit()ing with the test result.
+// Only consulted when a TestConfig opts in via withExec(true).
+static constexpr const char* kReexecMarkerEnvVar = "RCCL_PIT_REEXEC_TEST";
+
 // TestConfig implementation
 ProcessIsolatedTestRunner::TestConfig::TestConfig(
     const std::string& testName, std::function<void()> logic
 )
-    : name(testName), testLogic(logic), timeout(30), inheritParentEnv(true)
+    : name(testName), testLogic(logic), timeout(30), inheritParentEnv(true), useExec(false)
 {}
 
 ProcessIsolatedTestRunner::TestConfig& ProcessIsolatedTestRunner::TestConfig::withEnvironment(
@@ -85,6 +91,13 @@ ProcessIsolatedTestRunner::TestConfig& ProcessIsolatedTestRunner::TestConfig::se
 )
 {
     environmentVariables[name] = value;
+    return *this;
+}
+
+ProcessIsolatedTestRunner::TestConfig&
+    ProcessIsolatedTestRunner::TestConfig::withExec(bool exec)
+{
+    useExec = exec;
     return *this;
 }
 
@@ -389,6 +402,31 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
         testResults_.clear();
     }
 
+    // Re-exec child entrypoint. When a TestConfig opts into withExec(true), the
+    // runner spawns the test via fork()+execve() of the same binary; the
+    // re-exec'd process restarts gtest under --gtest_filter so the same TEST()
+    // body runs again and calls RUN_ISOLATED_TESTS, which lands here. The
+    // sentinel env var tells us to run the matching lambda inline (no further
+    // fork/exec) and exit with its result.
+    if(const char* target = std::getenv(kReexecMarkerEnvVar))
+    {
+        // Unset so any nested RUN_ISOLATED_TESTS in the lambda doesn't recurse.
+        unsetenv(kReexecMarkerEnvVar);
+        for(const auto& testConfig : testsToRun)
+        {
+            if(testConfig.name == target)
+            {
+                int result = runTestInProcess(testConfig);
+                fflush(NULL);
+                _exit(result);
+            }
+        }
+        std::cerr << "ProcessIsolatedTestRunner: re-exec target '" << target
+                  << "' not found in registered tests" << std::endl;
+        fflush(NULL);
+        _exit(RCCL_TEST_INVALID);
+    }
+
     // Sequential execution
     for(const auto& testConfig : testsToRun)
     {
@@ -410,6 +448,37 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
         if(pid == 0)
         {
             redirectOutputToPipes(stdout_fd, stderr_fd);
+            if(testConfig.useExec)
+            {
+                // Fresh-process self-exec. Required for HIP-using tests when
+                // earlier tests in the same binary may have initialized HIP
+                // (fork-after-init leaves the HIP/ROCm runtime unusable in
+                // the child).
+                applyEnvironmentVariables(testConfig);
+                setenv(kReexecMarkerEnvVar, testConfig.name.c_str(), 1);
+
+                const ::testing::TestInfo* info
+                    = ::testing::UnitTest::GetInstance()->current_test_info();
+                if(info == nullptr)
+                {
+                    std::cerr << "ProcessIsolatedTestRunner: withExec() requires the "
+                                 "TEST() body to be running under gtest; "
+                                 "no current_test_info available."
+                              << std::endl;
+                    fflush(NULL);
+                    _exit(RCCL_TEST_INVALID);
+                }
+                std::string filterArg = std::string("--gtest_filter=")
+                                        + info->test_suite_name() + "." + info->name();
+                char  argv0[] = "/proc/self/exe";
+                char* argv[]  = {argv0, filterArg.data(), nullptr};
+                execv("/proc/self/exe", argv);
+                // execv only returns on error.
+                std::cerr << "ProcessIsolatedTestRunner: execv(/proc/self/exe) failed: "
+                          << strerror(errno) << std::endl;
+                fflush(NULL);
+                _exit(RCCL_TEST_INVALID);
+            }
             int result = runTestInProcess(testConfig);
             // Use _exit() instead of exit() to avoid atexit handlers
             // This prevents GPU runtime cleanup issues after fork

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.hpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.hpp
@@ -61,6 +61,12 @@ public:
         std::chrono::seconds     timeout;              ///< Test timeout
         bool                     inheritParentEnv;     ///< Whether to inherit parent environment
         std::vector<std::string> clearEnvVars; ///< Environment variables to explicitly clear
+        bool                     useExec;              ///< Use fork()+execve() instead of plain
+                                                       ///<  fork(). Required for HIP-using tests
+                                                       ///<  when the binary may have initialized
+                                                       ///<  HIP in earlier tests of the same
+                                                       ///<  process (fork-after-init is unsafe
+                                                       ///<  for the HIP/ROCm runtime).
 
         /**
          * @brief Constructor
@@ -104,6 +110,26 @@ public:
          * @return Reference to this TestConfig for method chaining
          */
         TestConfig& setVariable(const std::string& name, const std::string& value);
+
+        /**
+         * @brief Run the isolated child via fork()+execve() of the same binary
+         *        rather than plain fork().
+         *
+         * This produces a fresh process image and is required when the test
+         * binary may have already initialized HIP/ROCm (or other resources
+         * that are unsafe to inherit across fork) in tests that ran earlier
+         * in the same process.
+         *
+         * The re-exec'd child is launched with --gtest_filter set to the
+         * currently running gtest TEST() name. Inside that fresh process,
+         * when the TEST() body calls RUN_ISOLATED_TESTS again, the runner
+         * detects a sentinel environment variable, runs the matching test
+         * lambda inline (no further fork/exec), and exits with the result.
+         *
+         * @param exec  Whether to enable exec mode (default true)
+         * @return Reference to this TestConfig for method chaining
+         */
+        TestConfig& withExec(bool exec = true);
     };
 
     /**

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -370,6 +370,11 @@
           "test_filter": "PackRoundtripTest.LoadStorePack_*:PackRoundtripTest.L2_StorePackBoundary:PackRoundtripTest.Store16Load16Global_Direct"
         },
         {
+          "name": "DeviceApi",
+          "description": "Verify RCCL Device API: symmetric window registration and ncclDevCommCreate gating",
+          "test_filter": "DeviceApi.*"
+        },
+        {
           "name": "Fixtures_All",
           "description": "All release fixture tests"
         }


### PR DESCRIPTION
  ## Summary
  Unit-test for the RCCL device API (`AICOMRCCL-598`). Targets the single-node, direct-P2P, symmetric-memory, LSA-based path — the minimum surface needed to lock down
  `ncclCommWindowRegister(NCCL_WIN_COLL_SYMMETRIC)` + `ncclDevCommCreate` plus a real device kernel exercising `ncclLsaBarrierSession` / `ncclGetLsaPointer`.
  JIRA: [AICOMRCCL-598](https://amd-hub.atlassian.net/browse/AICOMRCCL-598)
  ## What is exercised
  Three GoogleTests, all driven through `ProcessIsolatedTestRunner` so that env-cached RCCL params (`NCCL_CUMEM_ENABLE`, `NCCL_WIN_ENABLE`) are applied to a fresh child process per case.
  ### `DeviceApi.LsaRemoteRead` — positive
  End-to-end host + device path:
  1. Skips unless ≥2 visible GPUs with full direct-P2P between the first two.
  2. Builds 2 ranks via `ncclCommInitAll`, one stream + one `int` device buffer per rank allocated with `ncclMemAlloc`.
  3. Each rank seeds its input with a distinct known value.
  4. Registers each input as a symmetric window: `ncclCommWindowRegister(..., NCCL_WIN_COLL_SYMMETRIC)`.
  5. Builds `ncclDevCommRequirements{ .lsaBarrierCount = 1 }` and creates one `ncclDevComm` per rank.
  6. Launches `lsaReadPeerValueKernel` (1 block, 64 threads) on each rank. The kernel:
     - opens an `ncclLsaBarrierSession<ncclCoopCta>` over `ncclTeamLsa(devComm)`,
     - syncs (relaxed),
     - thread 0 calls `ncclGetLsaPointer(inputWindow, 0, peerRank)` and writes the peer's input into the local output,
     - syncs again with `memory_order_release`.
  7. Copies outputs back and asserts rank 0's output == rank 1's seed and vice versa, proving the remote load actually went over the symmetric window.
  8. Tears down dev comms, deregisters windows, frees `ncclMemAlloc` buffers, destroys comms.
  This is the smallest test that simultaneously proves: symmetric-window registration succeeded, `ncclDevCommCreate` succeeded, the LSA barrier on device works, and peer-pointer lookup returns a usable
  address.
  ### `DeviceApi.CuMemDisabled` — negative gate
  Child env: `NCCL_CUMEM_ENABLE=0`, `NCCL_WIN_ENABLE=1`. `ncclCommWindowRegister(SYMMETRIC)` may still return `ncclSuccess` (falls back to a local registration handle), so the assertion is on
  `ncclDevCommCreate` returning `ncclInvalidUsage` because `comm->symmetricSupport` is false.
  ### `DeviceApi.WinDisabled` — negative gate
  Child env: `NCCL_CUMEM_ENABLE=1`, `NCCL_WIN_ENABLE=0`. Same expected failure on `ncclDevCommCreate`. Together these two pin down the gate computed in `src/init.cc`:

  comm->symmetricSupport = comm->isAllDirectP2p && comm->nNodes == 1
                           && ncclParamWinEnable() && ncclCuMemEnable();

  ## Build / packaging
  - One entry added to `unit_tests_standard` in `tools/scripts/test_runner/configs/mi300x_mellanox_ib.json` (filter `DeviceApi.*`).
  ## Files changed
  - `projects/rccl/test/DeviceApiTests.cpp` (new, 390 lines)
  - `projects/rccl/test/CMakeLists.txt` (+15)
  - `projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json` (+1 entry)
  ## Out of scope
  Multi-node, GIN, perf, `LLA2A` coverage, `TestBed` refactor, RCCL-internal symmetric-kernel selection. Tracked for follow-up.
  ## Test plan
  - [x] CI green on a 2× MI300X node with direct P2P (`unit_tests_standard` → `DeviceApi.*`)
  - [x] `DeviceApi.LsaRemoteRead` passes under `NCCL_CUMEM_ENABLE=1 NCCL_WIN_ENABLE=1`
  - [x] `DeviceApi.CuMemDisabled` and `DeviceApi.WinDisabled` both observe `ncclDevCommCreate -> ncclInvalidUsage`
  - [x] Manual cross-check with `rccl-tests`: `all_reduce_perf -g 2 -R 2 -D 1` and `-D 2` work in the same env

  ## Notes for reviewers
  - Branch is rebased onto current `develop` (`de1fb5ed1c`); original branch - https://github.com/ROCm/rocm-systems/tree/users/speriasw/rccl-device-api-tests
  - Develop has since refactored away the `#undef __CUDACC__` workaround in `nccl_device/*.h`, so the `NCCL_ENABLE_DEVICE_HELPERS` define around the impl includes in `DeviceApiTests.cpp` is currently a no-op.
   Left in place as a forward-compatible guard; can be removed in a follow-up if preferred.

[AICOMRCCL-598]: https://amd-hub.atlassian.net/browse/AICOMRCCL-598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ