### PR TITLE
[hipfile] Doxygen tweaks for Sphinx

### DIFF
--- a/projects/hipfile/docs/doxygen/Doxyfile.in
+++ b/projects/hipfile/docs/doxygen/Doxyfile.in
@@ -1895,7 +1895,7 @@ MATHJAX_CODEFILE       =
 # The default value is: YES.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-SEARCHENGINE           = YES
+SEARCHENGINE           = NO
 
 # When the SERVER_BASED_SEARCH tag is enabled the search engine will be
 # implemented using a web server instead of a web client using JavaScript. There
@@ -2477,7 +2477,7 @@ TAGFILES               =
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = html/tagfile.xml
 
 # If the ALLEXTERNALS tag is set to YES, all external classes and namespaces
 # will be listed in the class and namespace index. If set to NO, only the
@@ -2739,7 +2739,7 @@ DIR_GRAPH_MAX_DEPTH    = 1
 # The default value is: png.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_IMAGE_FORMAT       = png
+DOT_IMAGE_FORMAT       = svg
 
 # If DOT_IMAGE_FORMAT is set to svg, then this option can be set to YES to
 # enable generation of interactive SVG images that allow zooming and panning.
@@ -2751,7 +2751,7 @@ DOT_IMAGE_FORMAT       = png
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-INTERACTIVE_SVG        = NO
+INTERACTIVE_SVG        = YES
 
 # The DOT_PATH tag can be used to specify the path where the dot tool can be
 # found. If left blank, it is assumed the dot tool can be found in the path.


### PR DESCRIPTION
## Motivation

These are suggestions emitted by Sphinx when building the docs.

Other rocm-systems projects use similar options.

## Technical Details

Sets:

SEARCHENGINE           = NO
GENERATE_TAGFILE       = html/tagfile.xml
DOT_IMAGE_FORMAT       = svg
INTERACTIVE_SVG        = YES

SEARCHENGINE should be set to NO for Sphinx builds since the default search engine can conflict with the one in Sphinx. Since that's the way we'll be generating the official docs, we'll set it to NO all the time.

## JIRA ID

AIHIPFILE-41

## Test Plan

Docs are built in CI

## Test Result

Passes

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
