### PR TITLE
[rocprofiler-systems] [avail] Add support for listing available operations for a given ROCm domain

### DIFF
--- a/projects/rocprofiler-systems/docs/how-to/general-tips-using-rocprof-sys.rst
+++ b/projects/rocprofiler-systems/docs/how-to/general-tips-using-rocprof-sys.rst
@@ -12,6 +12,9 @@ the :doc:`ROCm Systems Profiler glossary <../reference/rocprof-sys-glossary>`.
 * Use ``rocprof-sys-avail`` to look up configuration settings, hardware counters, and data collection components
 
   * Use the ``-d`` flag for descriptions
+  * Use ``--list-domains`` to see the available ROCm domains that expose operation lists
+  * Use ``--list-operations <domain>`` to see the operations available for a specific domain
+    (for example, ``rocprof-sys-avail --list-operations ompt``)
 
 * Generate a default configuration with ``rocprof-sys-avail -G ${HOME}/.rocprof-sys.cfg`` and adjust it
   to the desired default behavior

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
@@ -150,6 +150,9 @@ main(int argc, char** argv)
     _category_options.emplace("hw_counters::CPU");
     _category_options.emplace("hw_counters::GPU");
 
+    // Remove unused TIMEMORY third-party libraries
+    _category_options.erase("component::tpls::openmp");
+
     format_options fmt_opts{};
 
     array_t<bool, TOTAL> options    = { false, false, false, false, false, false, false };
@@ -259,6 +262,102 @@ main(int argc, char** argv)
         .action([_category_options](parser_t&) {
             std::cout << "Categories:\n";
             for(const auto& itr : _category_options)
+                std::cout << "    " << itr << "\n";
+        });
+    parser
+        .add_argument({ "--list-operations" },
+                      "List available operations for a specific ROCm domain, or "
+                      "list all available domains if no argument provided")
+        .max_count(1)
+        .dtype("string")
+        .action([](parser_t& p) {
+            auto _settings = tim::settings::shared_instance();
+
+            auto _extract_domain = [](const std::string& _name) -> std::string {
+                const std::string _prefix = "ROCPROFSYS_ROCM_";
+                const std::string _suffix = "_OPERATIONS";
+                if(_name.find(_prefix) == 0 &&
+                   _name.rfind(_suffix) == _name.length() - _suffix.length())
+                {
+                    auto _domain =
+                        _name.substr(_prefix.length(), _name.length() - _prefix.length() -
+                                                           _suffix.length());
+                    // Convert to lowercase
+                    std::transform(_domain.begin(), _domain.end(), _domain.begin(),
+                                   ::tolower);
+                    return _domain;
+                }
+                return _name;
+            };
+
+            // If no argument provided, list all domain names
+            if(p.get_count("list-operations") == 0)
+            {
+                std::cout << "Available ROCm domains with operations:\n";
+                std::vector<std::string> _domains;
+
+                for(const auto& itr : *_settings)
+                {
+                    auto _name = itr.second->get_env_name();
+                    // Match settings that end with _OPERATIONS (but not _EXCLUDE or
+                    // _ANNOTATE_BACKTRACE to avoid duplicates)
+                    if(_name.find("_OPERATIONS") != std::string::npos &&
+                       _name.find("_OPERATIONS_EXCLUDE") == std::string::npos &&
+                       _name.find("_OPERATIONS_ANNOTATE_BACKTRACE") == std::string::npos)
+                    {
+                        _domains.push_back(_extract_domain(_name));
+                    }
+                }
+
+                std::sort(_domains.begin(), _domains.end());
+                for(const auto& domain : _domains)
+                    std::cout << "    " << domain << "\n";
+
+                std::cout << "\nUse '--list-operations <domain_name>' to see operations "
+                             "for a specific domain.\n";
+                return;
+            }
+
+            // If argument provided, list filtered operations for the given domain
+            auto _domain_name_input = p.get<std::string>("list-operations");
+
+            // Lowercase for display, uppercase for env var lookup
+            auto _domain_name_lower = _domain_name_input;
+            std::transform(_domain_name_lower.begin(), _domain_name_lower.end(),
+                           _domain_name_lower.begin(), ::tolower);
+            auto _domain_name_upper = _domain_name_input;
+            std::transform(_domain_name_upper.begin(), _domain_name_upper.end(),
+                           _domain_name_upper.begin(), ::toupper);
+
+            // Reconstruct full env var name
+            auto _setting_name =
+                std::string("ROCPROFSYS_ROCM_") + _domain_name_upper + "_OPERATIONS";
+            auto _sitr = _settings->find(_setting_name);
+
+            if(_sitr == _settings->end())
+            {
+                std::cerr << "Error: Domain '" << _domain_name_lower << "' not found.\n";
+                std::cerr << "Use 'rocprof-sys-avail --list-operations' "
+                          << "to see available domains.\n";
+                return;
+            }
+            auto _choices = _sitr->second->get_choices();
+            if(_choices.empty())
+            {
+                std::cerr << "Domain '" << _domain_name_lower
+                          << "' has no operation choices.\n";
+                return;
+            }
+
+            filter_operations(_setting_name, _choices);
+
+            if(_choices.empty())
+            {
+                std::cerr << "Domain '" << _domain_name_lower << "' has no operations.\n";
+                return;
+            }
+            std::cout << "Operations for " << _domain_name_lower << ":\n";
+            for(const auto& itr : _choices)
                 std::cout << "    " << itr << "\n";
         });
     parser.add_argument({ "--list-keys" }, "List the output keys")
@@ -601,7 +700,8 @@ main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    if(parser.exists("list-categories") || parser.exists("list-keys"))
+    if(parser.exists("list-categories") || parser.exists("list-keys") ||
+       parser.exists("list-operations"))
         return EXIT_SUCCESS;
 
     std::string _pos_regex{};

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
@@ -265,14 +265,15 @@ main(int argc, char** argv)
                 std::cout << "    " << itr << "\n";
         });
     parser
-        .add_argument({ "--list-operations" },
-                      "List available operations for a specific ROCm domain, or "
-                      "list all available domains if no argument provided")
-        .max_count(1)
-        .dtype("string")
-        .action([](parser_t& p) {
+        .add_argument({ "--list-domains" },
+                      "List the available ROCm domains that have operations")
+        .count(0)
+        .action([](parser_t&) {
             auto _settings = tim::settings::shared_instance();
 
+            // Extract the domain name from a setting's env-var name.
+            // A name matching ROCPROFSYS_ROCM_<DOMAIN>_OPERATIONS yields the
+            // lowercased <DOMAIN>. Any other name is returned unchanged.
             auto _extract_domain = [](const std::string& _name) -> std::string {
                 const std::string _prefix = "ROCPROFSYS_ROCM_";
                 const std::string _suffix = "_OPERATIONS";
@@ -282,52 +283,68 @@ main(int argc, char** argv)
                     auto _domain =
                         _name.substr(_prefix.length(), _name.length() - _prefix.length() -
                                                            _suffix.length());
-                    // Convert to lowercase
                     std::transform(_domain.begin(), _domain.end(), _domain.begin(),
-                                   ::tolower);
+                                   [](unsigned char c) { return std::tolower(c); });
                     return _domain;
                 }
                 return _name;
             };
 
-            // If no argument provided, list all domain names
+            std::cout << "Available ROCm domains with operations:\n";
+            std::vector<std::string> _domains;
+
+            // Domain discovery: scan all settings for env-var names of the
+            // form ROCPROFSYS_ROCM_<DOMAIN>_OPERATIONS and collect the
+            // lowercased <DOMAIN> from each match.
+            for(const auto& itr : *_settings)
+            {
+                auto _name = itr.second->get_env_name();
+                // Skip companion settings like _OPERATIONS_EXCLUDE and
+                // _OPERATIONS_ANNOTATE_BACKTRACE which share the domain but
+                // aren't operation lists.
+                constexpr std::string_view _suffix = "_OPERATIONS";
+                if(_name.size() >= _suffix.size() &&
+                   _name.compare(_name.size() - _suffix.size(), _suffix.size(),
+                                 _suffix) == 0)
+                {
+                    _domains.push_back(_extract_domain(_name));
+                }
+            }
+
+            std::sort(_domains.begin(), _domains.end());
+            for(const auto& domain : _domains)
+                std::cout << "    " << domain << "\n";
+
+            std::cout << "\nUse '--list-operations <domain_name>' to see operations "
+                         "for a specific domain.\n";
+        });
+    parser
+        .add_argument({ "--list-operations" },
+                      "List available operations for a specific ROCm domain")
+        .max_count(1)
+        .dtype("string")
+        .action([](parser_t& p) {
+            // No domain provided. Emit an error and hint at --list-domains
             if(p.get_count("list-operations") == 0)
             {
-                std::cout << "Available ROCm domains with operations:\n";
-                std::vector<std::string> _domains;
-
-                for(const auto& itr : *_settings)
-                {
-                    auto _name = itr.second->get_env_name();
-                    // Match settings that end with _OPERATIONS (but not _EXCLUDE or
-                    // _ANNOTATE_BACKTRACE to avoid duplicates)
-                    if(_name.find("_OPERATIONS") != std::string::npos &&
-                       _name.find("_OPERATIONS_EXCLUDE") == std::string::npos &&
-                       _name.find("_OPERATIONS_ANNOTATE_BACKTRACE") == std::string::npos)
-                    {
-                        _domains.push_back(_extract_domain(_name));
-                    }
-                }
-
-                std::sort(_domains.begin(), _domains.end());
-                for(const auto& domain : _domains)
-                    std::cout << "    " << domain << "\n";
-
-                std::cout << "\nUse '--list-operations <domain_name>' to see operations "
-                             "for a specific domain.\n";
+                std::cerr << "Error: '--list-operations' requires a domain name.\n";
+                std::cerr << "Use 'rocprof-sys-avail --list-domains' "
+                          << "to see available domains.\n";
                 return;
             }
 
-            // If argument provided, list filtered operations for the given domain
+            auto _settings          = tim::settings::shared_instance();
             auto _domain_name_input = p.get<std::string>("list-operations");
 
             // Lowercase for display, uppercase for env var lookup
             auto _domain_name_lower = _domain_name_input;
             std::transform(_domain_name_lower.begin(), _domain_name_lower.end(),
-                           _domain_name_lower.begin(), ::tolower);
+                           _domain_name_lower.begin(),
+                           [](unsigned char c) { return std::tolower(c); });
             auto _domain_name_upper = _domain_name_input;
             std::transform(_domain_name_upper.begin(), _domain_name_upper.end(),
-                           _domain_name_upper.begin(), ::toupper);
+                           _domain_name_upper.begin(),
+                           [](unsigned char c) { return std::toupper(c); });
 
             // Reconstruct full env var name
             auto _setting_name =
@@ -337,7 +354,7 @@ main(int argc, char** argv)
             if(_sitr == _settings->end())
             {
                 std::cerr << "Error: Domain '" << _domain_name_lower << "' not found.\n";
-                std::cerr << "Use 'rocprof-sys-avail --list-operations' "
+                std::cerr << "Use 'rocprof-sys-avail --list-domains' "
                           << "to see available domains.\n";
                 return;
             }
@@ -701,7 +718,7 @@ main(int argc, char** argv)
     }
 
     if(parser.exists("list-categories") || parser.exists("list-keys") ||
-       parser.exists("list-operations"))
+       parser.exists("list-operations") || parser.exists("list-domains"))
         return EXIT_SUCCESS;
 
     std::string _pos_regex{};

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
@@ -271,49 +271,17 @@ main(int argc, char** argv)
         .action([](parser_t&) {
             auto _settings = tim::settings::shared_instance();
 
-            // Extract the domain name from a setting's env-var name.
-            // A name matching ROCPROFSYS_ROCM_<DOMAIN>_OPERATIONS yields the
-            // lowercased <DOMAIN>. Any other name is returned unchanged.
-            auto _extract_domain = [](const std::string& _name) -> std::string {
-                const std::string _prefix = "ROCPROFSYS_ROCM_";
-                const std::string _suffix = "_OPERATIONS";
-                if(_name.find(_prefix) == 0 &&
-                   _name.rfind(_suffix) == _name.length() - _suffix.length())
-                {
-                    auto _domain =
-                        _name.substr(_prefix.length(), _name.length() - _prefix.length() -
-                                                           _suffix.length());
-                    std::transform(_domain.begin(), _domain.end(), _domain.begin(),
-                                   [](unsigned char c) { return std::tolower(c); });
-                    return _domain;
-                }
-                return _name;
-            };
-
-            std::cout << "Available ROCm domains with operations:\n";
-            std::vector<std::string> _domains;
-
-            // Domain discovery: scan all settings for env-var names of the
-            // form ROCPROFSYS_ROCM_<DOMAIN>_OPERATIONS and collect the
-            // lowercased <DOMAIN> from each match.
+            std::set<std::string> _domains;
             for(const auto& itr : *_settings)
             {
-                auto _name = itr.second->get_env_name();
-                // Skip companion settings like _OPERATIONS_EXCLUDE and
-                // _OPERATIONS_ANNOTATE_BACKTRACE which share the domain but
-                // aren't operation lists.
-                constexpr std::string_view _suffix = "_OPERATIONS";
-                if(_name.size() >= _suffix.size() &&
-                   _name.compare(_name.size() - _suffix.size(), _suffix.size(),
-                                 _suffix) == 0)
-                {
-                    _domains.push_back(_extract_domain(_name));
-                }
+                if(auto _domain =
+                       rocm_domain_from_setting_name(itr.second->get_env_name()))
+                    _domains.insert(std::move(*_domain));
             }
 
-            std::sort(_domains.begin(), _domains.end());
-            for(const auto& domain : _domains)
-                std::cout << "    " << domain << "\n";
+            std::cout << "Available ROCm domains with operations:\n";
+            for(const auto& _domain : _domains)
+                std::cout << "    " << _domain << "\n";
 
             std::cout << "\nUse '--list-operations <domain_name>' to see operations "
                          "for a specific domain.\n";
@@ -324,56 +292,40 @@ main(int argc, char** argv)
         .max_count(1)
         .dtype("string")
         .action([](parser_t& p) {
-            // No domain provided. Emit an error and hint at --list-domains
             if(p.get_count("list-operations") == 0)
             {
-                std::cerr << "Error: '--list-operations' requires a domain name.\n";
-                std::cerr << "Use 'rocprof-sys-avail --list-domains' "
-                          << "to see available domains.\n";
+                std::cerr << "Error: '--list-operations' requires a domain name.\n"
+                          << "Use 'rocprof-sys-avail --list-domains' "
+                             "to see available domains.\n";
                 return;
             }
 
-            auto _settings          = tim::settings::shared_instance();
-            auto _domain_name_input = p.get<std::string>("list-operations");
-
-            // Lowercase for display, uppercase for env var lookup
-            auto _domain_name_lower = _domain_name_input;
-            std::transform(_domain_name_lower.begin(), _domain_name_lower.end(),
-                           _domain_name_lower.begin(),
+            auto _domain = p.get<std::string>("list-operations");
+            std::transform(_domain.begin(), _domain.end(), _domain.begin(),
                            [](unsigned char c) { return std::tolower(c); });
-            auto _domain_name_upper = _domain_name_input;
-            std::transform(_domain_name_upper.begin(), _domain_name_upper.end(),
-                           _domain_name_upper.begin(),
-                           [](unsigned char c) { return std::toupper(c); });
 
-            // Reconstruct full env var name
-            auto _setting_name =
-                std::string("ROCPROFSYS_ROCM_") + _domain_name_upper + "_OPERATIONS";
-            auto _sitr = _settings->find(_setting_name);
+            auto _settings     = tim::settings::shared_instance();
+            auto _setting_name = rocm_setting_name_for_domain(_domain);
+            auto _sitr         = _settings->find(_setting_name);
 
             if(_sitr == _settings->end())
             {
-                std::cerr << "Error: Domain '" << _domain_name_lower << "' not found.\n";
-                std::cerr << "Use 'rocprof-sys-avail --list-domains' "
-                          << "to see available domains.\n";
-                return;
-            }
-            auto _choices = _sitr->second->get_choices();
-            if(_choices.empty())
-            {
-                std::cerr << "Domain '" << _domain_name_lower
-                          << "' has no operation choices.\n";
+                std::cerr << "Error: Domain '" << _domain << "' not found.\n"
+                          << "Use 'rocprof-sys-avail --list-domains' "
+                             "to see available domains.\n";
                 return;
             }
 
+            auto _choices = _sitr->second->get_choices();
             filter_operations(_setting_name, _choices);
 
             if(_choices.empty())
             {
-                std::cerr << "Domain '" << _domain_name_lower << "' has no operations.\n";
+                std::cerr << "Domain '" << _domain << "' has no operations.\n";
                 return;
             }
-            std::cout << "Operations for " << _domain_name_lower << ":\n";
+
+            std::cout << "Operations for " << _domain << ":\n";
             for(const auto& itr : _choices)
                 std::cout << "    " << itr << "\n";
         });

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
@@ -415,11 +415,56 @@ file_exists(const std::string& _fname)
 
 //--------------------------------------------------------------------------------------//
 
+namespace
+{
+constexpr std::string_view _rocm_op_prefix = "ROCPROFSYS_ROCM_";
+constexpr std::string_view _rocm_op_suffix = "_OPERATIONS";
+}  // namespace
+
+std::optional<std::string>
+rocm_domain_from_setting_name(std::string_view _env_var_name)
+{
+    // Check if the environment variable name matches the expected shape
+    // ROCPROFSYS_ROCM_<DOMAIN>_OPERATIONS.
+    if(_env_var_name.size() <= _rocm_op_prefix.size() + _rocm_op_suffix.size() ||
+       _env_var_name.compare(0, _rocm_op_prefix.size(), _rocm_op_prefix) != 0 ||
+       _env_var_name.compare(_env_var_name.size() - _rocm_op_suffix.size(),
+                             _rocm_op_suffix.size(), _rocm_op_suffix) != 0)
+        return std::nullopt;
+
+    // Extract the domain name from the environment variable name, then convert it to
+    // lowercase.
+    std::string _domain{ _env_var_name.substr(
+        _rocm_op_prefix.size(),
+        _env_var_name.size() - _rocm_op_prefix.size() - _rocm_op_suffix.size()) };
+    std::transform(_domain.begin(), _domain.end(), _domain.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    return _domain;
+}
+
+std::string
+rocm_setting_name_for_domain(std::string_view _domain)
+{
+    std::string _result;
+    _result.reserve(_rocm_op_prefix.size() + _domain.size() + _rocm_op_suffix.size());
+    _result.append(_rocm_op_prefix);
+    _result.append(_domain);
+    _result.append(_rocm_op_suffix);
+    std::transform(_result.begin() + _rocm_op_prefix.size(),
+                   _result.end() - _rocm_op_suffix.size(),
+                   _result.begin() + _rocm_op_prefix.size(),
+                   [](unsigned char c) { return std::toupper(c); });
+    return _result;
+}
+
 void
 filter_operations(const std::string& env_var_name, std::vector<std::string>& choices)
 {
-    // Filter out internal/unsupported callbacks
-    if(env_var_name.find("ROCPROFSYS_ROCM_OMPT_OPERATIONS") == 0)
+    auto _domain = rocm_domain_from_setting_name(env_var_name);
+    if(!_domain) return;
+
+    // Filter out unsupported operations for the OMPT domain.
+    if(*_domain == "ompt")
     {
         choices.erase(
             std::remove_if(choices.begin(), choices.end(),

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
@@ -14,6 +14,7 @@
 #include <string_view>
 #include <sys/stat.h>
 #include <unordered_map>
+#include <unordered_set>
 
 using settings = ::tim::settings;
 
@@ -411,6 +412,24 @@ file_exists(const std::string& _fname)
     if(stat(_fname.c_str(), &_buffer) == 0)
         return (S_ISREG(_buffer.st_mode) != 0 || S_ISLNK(_buffer.st_mode) != 0);
     return false;
+}
+
+//--------------------------------------------------------------------------------------//
+
+void
+filter_operations(const std::string& env_var_name, std::vector<std::string>& choices)
+{
+    // Filter out internal/unsupported callbacks
+    if(env_var_name.find("ROCPROFSYS_ROCM_OMPT_OPERATIONS") == 0)
+    {
+        choices.erase(
+            std::remove_if(choices.begin(), choices.end(),
+                           [](const std::string& op) {
+                               return op == "omp_callback_functions" ||  // internal
+                                      op == "omp_thread_end";            // unsupported
+                           }),
+            choices.end());
+    }
 }
 
 //--------------------------------------------------------------------------------------//

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
@@ -14,7 +14,6 @@
 #include <string_view>
 #include <sys/stat.h>
 #include <unordered_map>
-#include <unordered_set>
 
 using settings = ::tim::settings;
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.hpp
@@ -131,6 +131,9 @@ remove(std::string inp, const std::set<std::string>& entries);
 bool
 file_exists(const std::string&);
 
+void
+filter_operations(const std::string& env_var_name, std::vector<std::string>& choices);
+
 // control debug printf statements
 #define errprintf(LEVEL, ...)                                                            \
     {                                                                                    \

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.hpp
@@ -15,10 +15,12 @@
 
 #include <array>
 #include <cstddef>
+#include <optional>
 #include <regex>
 #include <set>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 //--------------------------------------------------------------------------------------//
@@ -130,6 +132,20 @@ remove(std::string inp, const std::set<std::string>& entries);
 
 bool
 file_exists(const std::string&);
+
+// ROCm operation-list settings follow the env-var shape
+// ROCPROFSYS_ROCM_<DOMAIN>_OPERATIONS. These helpers are the single source of
+// truth for that mapping; do not reconstruct the prefix/suffix elsewhere.
+
+// Returns the lowercased <DOMAIN> if _env_var_name matches the shape exactly,
+// or std::nullopt otherwise (e.g. companion settings such as
+// _OPERATIONS_EXCLUDE return nullopt).
+std::optional<std::string>
+rocm_domain_from_setting_name(std::string_view _env_var_name);
+
+// Builds ROCPROFSYS_ROCM_<DOMAIN>_OPERATIONS from any-case domain name.
+std::string
+rocm_setting_name_for_domain(std::string_view _domain);
 
 void
 filter_operations(const std::string& env_var_name, std::vector<std::string>& choices);

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
@@ -423,10 +423,16 @@ generate_config(std::string _config_file, const std::set<std::string>& _config_f
             }
             if((_options[VAL] || fmt_opts.all_info) && !itr->get_choices().empty())
             {
-                _ss << "# choices:\n";
-                for(const auto& iitr : itr->get_choices())
-                    _ss << "#    " << iitr << "\n";
-                _ss << "#\n";
+                auto _choices = itr->get_choices();
+                filter_operations(itr->get_env_name(), _choices);
+
+                if(!_choices.empty())
+                {
+                    _ss << "# choices:\n";
+                    for(const auto& iitr : _choices)
+                        _ss << "#    " << iitr << "\n";
+                    _ss << "#\n";
+                }
             }
             if(_has_info) _ss << "\n";
             _ss << std::left << std::setw(_w + 10) << itr->get_env_name() << " = ";

--- a/projects/rocprofiler-systems/tests/pytest/test_binaries.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_binaries.py
@@ -706,7 +706,8 @@ class TestRocprofilerSystemsAvail(RocprofsysTest):
             run_args=["--list-domains"],
         )
         self.assert_regex(
-            result, pass_regex=["Available ROCm domains with operations:", "ompt"]
+            result,
+            pass_regex=["Available ROCm domains with operations:", "scratch_memory"],
         )
 
     @pytest.mark.timeout(45)
@@ -719,8 +720,8 @@ class TestRocprofilerSystemsAvail(RocprofsysTest):
                 id="no-domain",
             ),
             pytest.param(
-                ["--list-operations", "ompt"],
-                ["omp_thread_begin"],
+                ["--list-operations", "scratch_memory"],
+                ["SCRATCH_MEMORY_ALLOC"],
                 id="found",
             ),
             pytest.param(

--- a/projects/rocprofiler-systems/tests/pytest/test_binaries.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_binaries.py
@@ -698,6 +698,49 @@ class TestRocprofilerSystemsAvail(RocprofsysTest):
         self.assert_regex(result, pass_regex=pass_regex)
 
     @pytest.mark.timeout(45)
+    def test_list_domains(self):
+        """Test that list-domains command works."""
+        result = self.run_test(
+            "baseline",
+            target=self.target,
+            run_args=["--list-domains"],
+        )
+        self.assert_regex(
+            result, pass_regex=["Available ROCm domains with operations:", "ompt"]
+        )
+
+    @pytest.mark.timeout(45)
+    @pytest.mark.parametrize(
+        "run_args, pass_regex",
+        [
+            pytest.param(
+                ["--list-operations"],
+                ["Error: '--list-operations' requires a domain name."],
+                id="no-domain",
+            ),
+            pytest.param(
+                ["--list-operations", "ompt"],
+                ["omp_thread_begin"],
+                id="found",
+            ),
+            pytest.param(
+                ["--list-operations", "megaman"],
+                ["Error: Domain 'megaman' not found."],
+                id="error",
+            ),
+        ],
+    )
+    def test_list_operations(self, run_args, pass_regex):
+        """Test that list-operations command works."""
+        result = self.run_test(
+            "baseline",
+            target=self.target,
+            run_args=run_args,
+            fail_on_not_found=True,
+        )
+        self.assert_regex(result, pass_regex=pass_regex)
+
+    @pytest.mark.timeout(45)
     def test_settings_no_gpu(self):
         """Test that settings query works without GPU initialization.
 


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Currently, `rocprof-sys-avail` does not have a clean way to display to the user the supported operations for a given domain.
The only way to do so it to use the cumbersome `rocprof-sys-avail -G config.cfg --categories settings::rocprofiler-sdk -all --advanced` to generate a large config file that contains the information.
Even so, there is no way to filter the operations to remove some that we do not want to show to the user (such as `omp_callback_functions` or `omp_thread_end` callbacks from `ROCPROFSYS_ROCM_OMPT_OPERATIONS`, `ROCPROFSYS_ROCM_OMPT_OPERATIONS_EXCLUDE` and `ROCPROFSYS_ROCM_OMPT_OPERATIONS_ANNOTATE_BACKTRACE`.

This PR aims to fix this by adding two new flags:
 - `--list-domains`: List out all domains that have operations (used in `--list-operations <domain>`)
 - `--list-operations`: List out all operations (if used incorrectly, hints to `--list-domains`)

**Note**: This PR is required for the OpenMP Documentation PR that will follow

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

 - Removed relic `component::tpls::openmp`
 - Added `--list-domains` flag
 - Added `--list-operations` flag
 - Added `filter_operations(...)` function. This is used both in` --list-operations` and when the user generates a config file (it will list the operations, and we need to apply the filter there).
 - Added 4 end-to-end tests
 - Added note in tips to point users to `--list-domains` and `--list-operations`

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

AIPROFSYST-139

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Ran the following:
1. `rocprof-sys-avail --list-operations ompt`
2. `rocprof-sys-avail --list-domains`
3. `rocprof-sys-avail -G config.cfg --categories settings::rocprofiler-sdk --all --advanced`

Also added four new tests:
 - `rocprofiler-systems-avail-list-domains` (tests `--list-domains` and checks that expected output is present)
 - `rocprofiler-systems-avail-list-operations-no-domain` (tests `--list-operations` with no extra arg... checks that it errors out)
 - `rocprofiler-systems-avail-list-operations-found` (tests `--list-operations scratch_memory` and verifies that `SCRATCH_MEMORY_ALLOC` is present)
 - `rocprofiler-systems-avail-list-operations-error` (tests `--list-operations <non-existing-domain>` and verifies that it errors out)

## Test Result

<!-- Briefly summarize test outcomes. -->

1. `rocprof-sys-avail --list-operations ompt`

Result:
```
Operations for ompt:
    omp_thread_begin
    omp_parallel_begin
    omp_parallel_end
    omp_task_create
    omp_task_schedule
    omp_implicit_task
    omp_device_initialize
    omp_device_finalize
    omp_device_load
    omp_sync_region_wait
    omp_mutex_released
    omp_dependences
    omp_task_dependence
    omp_work
    omp_masked
    omp_sync_region
    omp_lock_init
    omp_lock_destroy
    omp_mutex_acquire
    omp_mutex_acquired
    omp_nest_lock
    omp_flush
    omp_cancel
    omp_reduction
    omp_dispatch
    omp_target_emi
    omp_target_data_op_emi
    omp_target_submit_emi
    omp_error
```
`omp_thread_end` is not present, as it should be.

2. `rocprof-sys-avail --list-operations`

Result:
```
Available ROCm domains with operations:
    hip_compiler_api
    hip_compiler_api_ext
    hip_runtime_api
    hip_runtime_api_ext
    hip_stream
    hsa_amd_ext_api
    hsa_core_api
    hsa_finalize_ext_api
    hsa_image_ext_api
    kfd_event_dropped_events
    kfd_event_page_fault
    kfd_event_page_migrate
    kfd_event_queue
    kfd_event_unmap_from_gpu
    kfd_page_fault
    kfd_page_migrate
    kfd_queue
    marker_api
    marker_core_range_api
    memory_allocation
    memory_copy
    ompt
    rccl_api
    rocdecode_api
    rocdecode_api_ext
    rocjpeg_api
    runtime_initialization
    scratch_memory

Use '--list-operations <domain_name>' to see operations for a specific domain.
```
The "use" message at the end is present. Perfect

3. `rocprof-sys-avail -G config.cfg --categories settings::rocprofiler-sdk --all --advanced`

Result:
```

# name:
#    rocm_ompt_operations
#
# description:
#    Inclusive filter for domain operations (for API domains, this
#    selects the functions to trace) [regex supported]
#
# categories:
#    advanced
#    custom
#    librocprof-sys
#    rocm
#    rocprofiler-sdk
#    rocprofsys
#
# choices:
#    omp_thread_begin
#    omp_parallel_begin
#    omp_parallel_end
#    omp_task_create
#    omp_task_schedule
#    omp_implicit_task
#    omp_device_initialize
#    omp_device_finalize
#    omp_device_load
#    omp_sync_region_wait
#    omp_mutex_released
#    omp_dependences
#    omp_task_dependence
#    omp_work
#    omp_masked
#    omp_sync_region
#    omp_lock_init
#    omp_lock_destroy
#    omp_mutex_acquire
#    omp_mutex_acquired
#    omp_nest_lock
#    omp_flush
#    omp_cancel
#    omp_reduction
#    omp_dispatch
#    omp_target_emi
#    omp_target_data_op_emi
#    omp_target_submit_emi
#    omp_error
#

ROCPROFSYS_ROCM_OMPT_OPERATIONS       
```
`omp_thread_end` has been filtered out 


**New tests pass**

```
    Start  27: rocprofiler-systems-avail-list-domains
5/9 Test  #27: rocprofiler-systems-avail-list-domains ................   Passed    0.19 sec
    Start  28: rocprofiler-systems-avail-list-operations-no-domain
6/9 Test  #28: rocprofiler-systems-avail-list-operations-no-domain ...   Passed    0.17 sec
    Start  29: rocprofiler-systems-avail-list-operations-found
7/9 Test  #29: rocprofiler-systems-avail-list-operations-found .......   Passed    0.20 sec
    Start  30: rocprofiler-systems-avail-list-operations-error
8/9 Test  #30: rocprofiler-systems-avail-list-operations-error .......   Passed    0.20 sec
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests._
