### PR TITLE
[hipfile] Update pinned GitHub action hashes

### DIFF
--- a/.github/workflows/hipfile-build-nvidia.yml
+++ b/.github/workflows/hipfile-build-nvidia.yml
@@ -54,7 +54,7 @@ jobs:
             projects/hipfile
             .github/workflows
       - name: Authenticating to GitHub Container Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/hipfile-build.yml
+++ b/.github/workflows/hipfile-build.yml
@@ -114,7 +114,7 @@ jobs:
             projects/hipfile
             .github/workflows
       - name: Authenticating to GitHub Container Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -302,7 +302,7 @@ jobs:
             ${GITHUB_WORKSPACE}
       - name: Upload development hipFile Package as an Artifact
         if: ${{ inputs.upload_artifacts }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME }}
           path: ${{ format('{0}/{1}', github.workspace, steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_DEV_FILENAME) }}
@@ -311,7 +311,7 @@ jobs:
           compression-level: 0
       - name: Upload runtime hipFile Package as an Artifact
         if: ${{ inputs.upload_artifacts }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME }}
           path: ${{ format('{0}/{1}', github.workspace, steps.pkg-metadata.outputs.AIS_HIPFILE_PKG_FILENAME) }}
@@ -330,7 +330,7 @@ jobs:
             ${GITHUB_WORKSPACE}/hipfile-build-dir
       - name: Upload runtime hipFile package as an artifact
         if: ${{ inputs.upload_artifacts }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: hipfile-build-dir-${{ inputs.platform }}
           path: ${{ github.workspace }}/hipfile-build-dir

--- a/.github/workflows/hipfile-ci-system.yml
+++ b/.github/workflows/hipfile-ci-system.yml
@@ -81,7 +81,7 @@ jobs:
           name: hipfile-build-dir-${{ inputs.platform }}
           path: ${{ github.workspace }}/hipfile-build-dir
       - name: Authenticating to GitHub Container Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -282,7 +282,7 @@ jobs:
 #            }}
 #          merge-multiple: true
 #      - name: Authenticating to GitHub Container Registry
-#        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+#        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
 #        with:
 #          registry: ghcr.io
 #          username: ${{ github.actor }}

--- a/.github/workflows/hipfile-image-build.yml
+++ b/.github/workflows/hipfile-image-build.yml
@@ -103,7 +103,7 @@ jobs:
             .github/workflows
 
       - name: Authenticating to GitHub Container Registry.
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/hipfile-image-update.yml
+++ b/.github/workflows/hipfile-image-update.yml
@@ -59,7 +59,7 @@ jobs:
             .github/workflows
 
       - name: Authenticating to GitHub Container Registry.
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Motivation

Dependabot keeps triggering but nobody merges the PRs. This updates hipFile's pinned hashes.

## Technical Details

* docker/login-action     4.0.0 --> 4.1.0
* actions/upload-artifact 7.0.0 --> 7.0.1

## JIRA ID

N/A

## Test Plan

Run normal CI

## Test Result

CI passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
