### PR TITLE
Windows/MSVC build fixes

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocglinterop_windows.cpp
+++ b/projects/clr/rocclr/device/rocm/rocglinterop_windows.cpp
@@ -170,7 +170,7 @@ bool Export(amd::Memory* mem, GLenum targetType, int miplevel, hsa_handle_t* han
       type = GL_RESOURCE_ATTACH_TEXTURE_AMD;
       break;
     default:
-      LogError("Unknown OpenGL interop type: 0x%x", obj->getCLGLObjectType());
+      LogPrintfError("Unknown OpenGL interop type: 0x%x", obj->getCLGLObjectType());
       return false;
   }
 
@@ -186,8 +186,8 @@ bool Export(amd::Memory* mem, GLenum targetType, int miplevel, hsa_handle_t* han
   if (image_srd_size >= glResourceData.textureSRDSize) {
     std::memcpy(image_srd, glResourceData.textureSRD, glResourceData.textureSRDSize);
   } else {
-    LogError("image_srd_size %u < glResourceData.textureSRDSize %u", image_srd_size,
-             glResourceData.textureSRDSize);
+    LogPrintfError("image_srd_size %u < glResourceData.textureSRDSize %u", image_srd_size,
+                   glResourceData.textureSRDSize);
     return false;
   }
   return true;
@@ -218,7 +218,7 @@ bool Detach(amd::Memory* mem, hsa_handle_t handle) {
       type = GL_RESOURCE_ATTACH_TEXTURE_AMD;
       break;
     default:
-      LogError("Unknown OpenGL interop type: 0x%x", obj->getCLGLObjectType());
+      LogPrintfError("Unknown OpenGL interop type: 0x%x", obj->getCLGLObjectType());
       return false;
   }
 

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -192,7 +192,7 @@ hsa_status_t Memory::interopMapBuffer(hsa_handle_t fdn, hsa_interop_map_flag_t f
   hsa_agent_t agent = dev().getBackendDevice();
   size_t size;
   size_t metadata_size = 0;
-  void* metadata;
+  void* metadata = nullptr;
   auto fd = fdn;
   hsa_status_t status = Hsa::interop_map_buffer(1, &agent, fd, flags, &size, &interop_deviceMemory_,
 #if IS_WINDOWS
@@ -258,7 +258,7 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
 
   deviceMemory_ = static_cast<char*>(interop_deviceMemory_) + offset;
   if(!GlInterop::Detach(owner(), resHandle)) {
-    LogError("GlInterop::Detach(handle %p) failed", resHandle);
+    LogPrintfError("GlInterop::Detach(handle %p) failed", resHandle);
   }
   return true;
 #else

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1277,7 +1277,7 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
                                      ? [this]() -> const char* {
                                          if (!roc_device_.settings().queue_pipe_dist_) return "";
                                          static thread_local char buf[32];
-                                         snprintf(buf, sizeof(buf), " virtual_pipe_id=%lu,",
+                                         snprintf(buf, sizeof(buf), " virtual_pipe_id=%zu,",
                                                   gpu_queue_->id % roc_device_.NumHwPipes());
                                          return buf;
                                        }()
@@ -1642,7 +1642,7 @@ void VirtualGPU::dispatchBarrierPacket(uint16_t packetHeader, bool skipSignal,
                         ? [this]() -> const char* {
                             if (!roc_device_.settings().queue_pipe_dist_) return "";
                             static thread_local char buf[32];
-                            snprintf(buf, sizeof(buf), " virtual_pipe_id=%lu,",
+                            snprintf(buf, sizeof(buf), " virtual_pipe_id=%zu,",
                                      gpu_queue_->id % roc_device_.NumHwPipes());
                             return buf;
                           }()
@@ -1727,7 +1727,7 @@ void VirtualGPU::dispatchBarrierValuePacket(uint16_t packetHeader, bool resolveD
                              ? [this]() -> const char* {
                                  if (!roc_device_.settings().queue_pipe_dist_) return "";
                                  static thread_local char buf[32];
-                                 snprintf(buf, sizeof(buf), " virtual_pipe_id=%lu,",
+                                 snprintf(buf, sizeof(buf), " virtual_pipe_id=%zu,",
                                           gpu_queue_->id % roc_device_.NumHwPipes());
                                  return buf;
                                }()

--- a/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
+#include <cinttypes>
 #include <sys/types.h>
 #if defined(__linux__)
 #include <sys/mman.h>
@@ -550,14 +551,14 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtRegisterGraphicsHandleToNodesExt(HSAuint64 Graphic
     RegisterFlags.ui32.requiresVAddr = 1;
   }
 
-  pr_debug("number of nodes %lu\n", NumberOfNodes);
+  pr_debug("number of nodes %" PRIu64 "\n", NumberOfNodes);
   wsl::thunk::GpuMemoryHandle mem_handle;
 
   ret = import_dmabuf_fd(GraphicsResourceHandle, NodeArray[0], RegisterFlags.ui32.requiresVAddr,
                          false, &mem_handle, RegisterFlags.ui32.kmtHandle);
   if (ret != HSAKMT_STATUS_SUCCESS) {
     pr_err("hsaKmtRegisterGraphicsHandleToNodesExt: import_dmabuf_fd failed, "
-           "GraphicsResourceHandle: %lu, NodeId: %u\n",
+           "GraphicsResourceHandle: %" PRIu64 ", NodeId: %u\n",
            GraphicsResourceHandle, NodeArray[0]);
     return ret;
   }
@@ -641,7 +642,7 @@ HSAKMT_STATUS import_dmabuf_fd(uint64_t DMABufFd, uint32_t NodeId, bool alloc_va
     std::lock_guard<std::mutex> gard(*allocation_map_lock_);
     auto it = allocation_map_->find((void*)gpu_va);
     if (it == allocation_map_->end()) {
-      pr_err("where's the conflict buffer? va %#lx\n", create_info.va_hint);
+      pr_err("where's the conflict buffer? va %#" PRIx64 "\n", create_info.va_hint);
       return HSAKMT_STATUS_ERROR;
     }
     wsl::thunk::GpuMemory *conflict_mem = wsl::thunk::GpuMemory::Convert(it->second.handle);

--- a/projects/rocr-runtime/libhsakmt/src/dxg/openclose.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/openclose.cpp
@@ -27,6 +27,7 @@
 #include <cstring>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <cinttypes>
 #include <cstdint>
 #if defined(__linux__)
 #include <sys/mman.h>
@@ -446,7 +447,7 @@ bool hsakmtRuntime::InitHandleApertureSpace() {
 
             j++;
         }
-        pr_debug("handle aperture start %lx, size %lx\n", handle_aperture_start_, handle_aperture_size_);
+        pr_debug("handle aperture start %" PRIx64 ", size %" PRIx64 "\n", handle_aperture_start_, handle_aperture_size_);
         return true;
     }
 

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
@@ -179,7 +179,7 @@ void ComputeQueue::HandleError(hsa_status_t status) {
   for (std::size_t i = 0; i < sizeof(QueueErrors) / sizeof(QueueErrors[0]); ++i) {
     if (QueueErrors[i].status == status) {
       val = QueueErrors[i].code;
-      pr_err("error %d, sig_val %ld\n", status, val);
+      pr_err("error %d, sig_val %" PRId64 "\n", status, val);
       break;
     }
   }
@@ -482,7 +482,7 @@ bool ComputeQueue::UpdateScratch(uint32_t private_segment_size, bool wave32) {
   if (scratch_size_ >= scratch_size)
     return true;
 
-  pr_debug("need realloc scratch buffer, size %" PRIx64 " -> %" PRIx32 "\n",
+  pr_debug("need realloc scratch buffer, size %" PRIx64 " -> %" PRIx64 "\n",
            scratch_size_, scratch_size);
 
   GpuMemoryCreateInfo create_info{};
@@ -755,7 +755,7 @@ hsa_status_t ComputeQueue::KernelDispatchAqlToPm4(char* cpu, hsa_kernel_dispatch
 
   // Check if we exceeded the frame size
   if ((i - ib_size) > cmdbuf_aql_frame_size) {
-    pr_err("PM4 command buffer overflow in KernelDispatch: used %d bytes, limit %d bytes\n",
+    pr_err("PM4 command buffer overflow in KernelDispatch: used %" PRIu64 " bytes, limit %u bytes\n",
            i - ib_size, cmdbuf_aql_frame_size);
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
@@ -844,7 +844,7 @@ hsa_status_t ComputeQueue::BarrierGenericAqlToPm4(char* cpu, hsa_barrier_and_pac
 
   // Check if we exceeded the frame size
   if ((i - ib_size) > cmdbuf_aql_frame_size) {
-    pr_err("PM4 command buffer overflow in BarrierGeneric: used %d bytes, limit %d bytes\n",
+    pr_err("PM4 command buffer overflow in BarrierGeneric: used %" PRIu64 " bytes, limit %u bytes\n",
            i - ib_size, cmdbuf_aql_frame_size);
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
@@ -923,7 +923,7 @@ hsa_status_t ComputeQueue::VendorSpecificAqlToPm4(char* cpu, amd_aql_pm4_ib* pac
 
   // Check if we exceeded the frame size
   if ((i - ib_size) > cmdbuf_aql_frame_size) {
-    pr_err("PM4 command buffer overflow in VendorSpecific: used %d bytes, limit %d bytes\n",
+    pr_err("PM4 command buffer overflow in VendorSpecific: used %" PRIu64 " bytes, limit %u bytes\n",
            i - ib_size, cmdbuf_aql_frame_size);
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
@@ -1038,7 +1038,7 @@ void SDMAQueue::SdmaThread(SDMAQueue* queue) {
     }
 
     for (const auto [start, end] : pendings) {
-      pr_debug("wptr %lx %lx\n", start, end);
+      pr_debug("wptr %" PRIx64 " %" PRIx64 "\n", start, end);
 
       SDMA_PKT_POLL_REGMEM* poll_pkt = reinterpret_cast<SDMA_PKT_POLL_REGMEM*>(
           queue->cmdbuf_addr + queue->WrapIntoRocrRing(start));
@@ -1064,7 +1064,7 @@ void SDMAQueue::SdmaThread(SDMAQueue* queue) {
 
         amd_signal_t* signal = (amd_signal_t*)((char*)poll_addr - offsetof(amd_signal_t, value));
         uint64_t signal_handle = reinterpret_cast<uint64_t>(signal);
-        pr_debug("poll signal %#lx addr %#lx val %ld\n", signal_handle, poll_addr, poll_val);
+        pr_debug("poll signal %#" PRIx64 " addr %#" PRIx64 " val %" PRId64 "\n", signal_handle, poll_addr, poll_val);
         hsa_signal_t hsa_signal = {signal_handle};
         hsa_signal_value_t value = hsakmt_hsa_signal_wait_relaxed(
             hsa_signal, HSA_SIGNAL_CONDITION_EQ, poll_val, UINT64_MAX, HSA_WAIT_STATE_BLOCKED);
@@ -1108,7 +1108,7 @@ SDMAQueue::~SDMAQueue() {
 }
 
 void SDMAQueue::RingDoorbell(uint64_t value) {
-  pr_debug("ringdoorbell %#lx %#lx\n", wptr_pre_, wptr_next_);
+  pr_debug("ringdoorbell %#" PRIx64 " %#" PRIx64 "\n", wptr_pre_, wptr_next_);
   thread_cond_lock_.lock();
 
   wptr_queue_.emplace_back(wptr_pre_, wptr_next_);

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/va_mgr.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/va_mgr.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <cassert>
+#include <cinttypes>
 #include <map>
 #include <algorithm>
 #include "impl/wddm/va_mgr.h"
@@ -23,9 +24,9 @@ VaMgr::VaMgr(uint64_t start, uint64_t size, uint64_t min_align) {
 VaMgr::~VaMgr() {
 
   if (free_list_.size() != 1)
-    pr_warn("free_list_ size:%ld which should be 1.\n", free_list_.size());
+    pr_warn("free_list_ size:%" PRId64 " which should be 1.\n", free_list_.size());
   if (frag_map_.size() != 1)
-    pr_warn("frag_map_ size:%ld which should be 1.\n", frag_map_.size());
+    pr_warn("frag_map_ size:%" PRId64 " which should be 1.\n", frag_map_.size());
 
   free_list_.clear();
   frag_map_.clear();

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -582,12 +582,12 @@ void *KfdDriver::AllocateKfdMemory(const HsaMemFlags &flags, uint32_t node_id,
 
 bool KfdDriver::FreeKfdMemory(void *mem, size_t size) {
   if (mem == nullptr || size == 0) {
-    debug_print("Invalid free ptr:%p size:%lu\n", mem, size);
+    debug_print("Invalid free ptr:%p size:%zu\n", mem, size);
     return false;
   }
 
   if (HSAKMT_CALL(hsaKmtFreeMemory(mem, size)) != HSAKMT_STATUS_SUCCESS) {
-    debug_print("Failed to free ptr:%p size:%lu\n", mem, size);
+    debug_print("Failed to free ptr:%p size:%zu\n", mem, size);
     return false;
   }
   return true;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/scratch_cache.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/scratch_cache.h
@@ -267,7 +267,7 @@ class ScratchCache {
 
   bool use_reserved(ScratchInfo& info) {
     if (!reserved_.second.isFree() || info.main_size > reserved_.first) {
-      debug_print("reserved node is already in use or too small (requested:%ld reserved:%ld)\n",
+      debug_print("reserved node is already in use or too small (requested:%zd reserved:%zd)\n",
                   info.main_size, reserved_.first);
       return false;
     }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -206,7 +206,7 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
 
   queue_scratch_.use_once_limit = core::Runtime::runtime_singleton_->flag().scratch_single_limit();
   if (queue_scratch_.use_once_limit > agent_->MaxScratchDevice()) {
-    fprintf(stdout, "User specified scratch limit exceeds device limits (requested:%lu max:%lu)!\n",
+    fprintf(stdout, "User specified scratch limit exceeds device limits (requested:%zu max:%zu)!\n",
                     queue_scratch_.use_once_limit, agent_->MaxScratchDevice());
     queue_scratch_.use_once_limit = agent_->MaxScratchDevice();
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -44,8 +44,9 @@
 
 #include <algorithm>
 #include <atomic>
-#include <cstring>
+#include <cinttypes>
 #include <climits>
+#include <cstring>
 #include <map>
 #include <set>
 #include <string>
@@ -593,7 +594,7 @@ void GpuAgent::ReserveScratch()
 {
   size_t reserved_sz = core::Runtime::runtime_singleton_->flag().scratch_single_limit();
   if (reserved_sz > MaxScratchDevice()) {
-    fprintf(stdout, "User specified scratch limit exceeds device limits (requested:%lu max:%lu)!\n",
+    fprintf(stdout, "User specified scratch limit exceeds device limits (requested:%zu max:%zu)!\n",
                     reserved_sz, MaxScratchDevice());
     reserved_sz = MaxScratchDevice();
   }
@@ -2422,7 +2423,7 @@ void GpuAgent::AcquireQueueMainScratch(ScratchInfo& scratch) {
 
     // Attempt to trim the maximum number of concurrent waves to allow scratch to fit.
     if (core::Runtime::runtime_singleton_->flag().enable_queue_fault_message())
-      debug_print("Failed to map requested scratch (%ld) - reducing queue occupancy.\n",
+      debug_print("Failed to map requested scratch (%zd) - reducing queue occupancy.\n",
                   scratch.main_size);
     const uint64_t num_cus = properties_.NumFComputeCores / properties_.NumSIMDPerCU;
     const uint64_t se_per_xcc = properties_.NumShaderBanks / properties_.NumXcc;
@@ -2444,7 +2445,7 @@ void GpuAgent::AcquireQueueMainScratch(ScratchInfo& scratch) {
         scratch_used_large_ += scratch.main_size;
         scratch_cache_.insertMain(scratch);
         if (core::Runtime::runtime_singleton_->flag().enable_queue_fault_message())
-          debug_print("  %ld scratch mapped, %.2f%% occupancy.\n", scratch.main_size,
+          debug_print("  %zd scratch mapped, %.2f%% occupancy.\n", scratch.main_size,
                       float(waves_per_cu * num_cus) / scratch.dispatch_slots * 100.0f);
         return;
       }
@@ -2598,7 +2599,7 @@ void GpuAgent::TranslateTime(core::Signal* signal, hsa_amd_profiling_dispatch_ti
   signal->GetRawTs(false, start, end);
 
   if ((start == 0) || (end == 0) || (start < t0_.GPUClockCounter) || (end < t0_.GPUClockCounter)) {
-    debug_print("Signal %p time stamps may be invalid (start=%lu, end=%lu, t0=%lu).\n",
+    debug_print("Signal %p time stamps may be invalid (start=%" PRIu64 ", end=%" PRIu64 ", t0=%" PRIu64 ").\n",
                 &signal->signal_, start, end, t0_.GPUClockCounter);
     time.start = 0;
     time.end = 0;
@@ -2616,7 +2617,7 @@ void GpuAgent::TranslateTime(core::Signal* signal, hsa_amd_profiling_async_copy_
   signal->GetRawTs(true, start, end);
 
   if ((start == 0) || (end == 0) || (start < t0_.GPUClockCounter) || (end < t0_.GPUClockCounter)) {
-    debug_print("Signal %p async copy time stamps may be invalid (start=%lu, end=%lu, t0=%lu).\n",
+    debug_print("Signal %p async copy time stamps may be invalid (start=%" PRIu64 ", end=%" PRIu64 ", t0=%" PRIu64 ").\n",
                 &signal->signal_, start, end, t0_.GPUClockCounter);
     time.start = 0;
     time.end = 0;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -49,8 +49,6 @@
 #include <dlfcn.h>
 #include <amdgpu_drm.h>
 #include <sys/mman.h>
-#else
-#define debug_warning(__VA_ARGS__)
 #endif
 
 #include "core/inc/runtime.h"

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -1927,7 +1927,7 @@ void Runtime::AsyncEventsPool::clear() {
     size_t capacity = 0;
     for (auto& block : block_list_) capacity += block.second;
     if (capacity != free_list_.size())
-      debug_print("Warning: Resource leak detected by AsyncEventsPool, %ld items leaked.\n",
+      debug_print("Warning: Resource leak detected by AsyncEventsPool, %zd items leaked.\n",
                   capacity - free_list_.size());
   }
 
@@ -2268,7 +2268,7 @@ void Runtime::PrintMemoryMapNear(void* ptr) {
       else if (region->IsLDS())
         kind = "LDS";
     }
-    fprintf(stderr, "%p, 0x%lx, %s\n", it->first, it->second.size, kind.c_str());
+    fprintf(stderr, "%p, 0x%zx, %s\n", it->first, it->second.size, kind.c_str());
     it++;
   }
   fprintf(stderr, "\n");
@@ -2285,14 +2285,14 @@ void Runtime::PrintMemoryMapNear(void* ptr) {
     hsa_status_t err = runtime_singleton_->PtrInfo(const_cast<void*>(it->first), &info, malloc,
                                                    &count, &canAccess, &block);
     if (err == HSA_STATUS_SUCCESS) {
-      fprintf(stderr, "PtrInfo:\n\tAddress: %p-%p/%p-%p\n\tSize: 0x%lx\n\tType: %u\n\tOwner: %p\n",
+      fprintf(stderr, "PtrInfo:\n\tAddress: %p-%p/%p-%p\n\tSize: 0x%zx\n\tType: %u\n\tOwner: %p\n",
               info.agentBaseAddress, (char*)info.agentBaseAddress + info.sizeInBytes,
               info.hostBaseAddress, (char*)info.hostBaseAddress + info.sizeInBytes, info.sizeInBytes,
               info.type, reinterpret_cast<void*>(info.agentOwner.handle));
       fprintf(stderr, "\tCanAccess: %u\n", count);
       for (int t = 0; t < count; t++)
         fprintf(stderr, "\t\t%p\n", reinterpret_cast<void*>(canAccess[t].handle));
-      fprintf(stderr, "\tIn block: %p, 0x%lx\n", block.base, block.length);
+      fprintf(stderr, "\tIn block: %p, 0x%zx\n", block.base, block.length);
       free(canAccess);
     }
     it++;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/signal.cpp
@@ -66,7 +66,7 @@ void SharedSignalPool_t::clear() {
     size_t capacity = 0;
     for (auto& block : block_list_) capacity += block.second;
     if (capacity != free_list_.size())
-      debug_print("Warning: Resource leak detected by SharedSignalPool, %ld Signals leaked.\n",
+      debug_print("Warning: Resource leak detected by SharedSignalPool, %zd Signals leaked.\n",
                   capacity - free_list_.size());
   }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/svm_profiler.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/svm_profiler.cpp
@@ -42,7 +42,8 @@
 
 #include "core/inc/svm_profiler.h"
 
-#include <stdint.h>
+#include <cinttypes>
+#include <cstdint>
 #include <algorithm>
 #if defined(__linux__)
 #include <sys/eventfd.h>
@@ -221,7 +222,7 @@ void SvmProfileControl::PollSmi() {
             uint64_t time;
             int pid;
             int offset = 0;
-            int args = sscanf(cursor, "%x %lu -%u%n", &event_id, &time, &pid, &offset);
+            int args = sscanf(cursor, "%x %" SCNu64 " -%u%n", &event_id, &time, &pid, &offset);
             assert(args == 3 && "Parsing error!");
 
             std::string detail;
@@ -234,7 +235,7 @@ void SvmProfileControl::PollSmi() {
                 uint32_t from, to;
                 uint32_t trigger = 0;
                 uint32_t fetch, pref;
-                args = sscanf(cursor, "@%lx(%x) %x->%x %x:%x %u", &addr, &size, &from, &to, &fetch,
+                args = sscanf(cursor, "@%" SCNx64 "(%x) %x->%x %x:%x %u", &addr, &size, &from, &to, &fetch,
                               &pref, &trigger);
                 assert(args == 7 && "Parsing error!");
 
@@ -254,7 +255,7 @@ void SvmProfileControl::PollSmi() {
                 uint32_t size;
                 uint32_t from, to;
                 uint32_t trigger;
-                args = sscanf(cursor, "@%lx(%x) %x->%x %u", &addr, &size, &from, &to, &trigger);
+                args = sscanf(cursor, "@%" SCNx64 "(%x) %x->%x %u", &addr, &size, &from, &to, &trigger);
                 assert(args == 5 && "Parsing error!");
 
                 addr *= 4096;
@@ -272,7 +273,7 @@ void SvmProfileControl::PollSmi() {
                 uint64_t addr;
                 uint32_t gpuid;
                 char mode;
-                args = sscanf(cursor, "@%lx(%x) %c", &addr, &gpuid, &mode);
+                args = sscanf(cursor, "@%" SCNx64 "(%x) %c", &addr, &gpuid, &mode);
 
                 addr *= 4096;
 
@@ -288,7 +289,7 @@ void SvmProfileControl::PollSmi() {
                 uint64_t addr;
                 uint32_t gpuid;
                 char mode;
-                args = sscanf(cursor, "@%lx(%x) %c", &addr, &gpuid, &mode);
+                args = sscanf(cursor, "@%" SCNx64 "(%x) %c", &addr, &gpuid, &mode);
                 assert(args == 3 && "Parsing error!");
 
                 addr *= 4096;
@@ -325,7 +326,7 @@ void SvmProfileControl::PollSmi() {
                 uint32_t size;
                 uint32_t gpuid;
                 uint32_t trigger;
-                args = sscanf(cursor, "@%lx(%x) %x %u", &addr, &size, &gpuid, &trigger);
+                args = sscanf(cursor, "@%" SCNx64 "(%x) %x %u", &addr, &size, &gpuid, &trigger);
                 assert(args == 4 && "Parsing error!");
 
                 addr *= 4096;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/utils.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/utils.h
@@ -141,8 +141,8 @@ static __forceinline unsigned long long int strtoull(const char* str,
   do {                                                                                             \
     static std::atomic<int> count(0);                                                              \
     if (!(exp) && (limit == 0 || count < limit)) {                                                 \
-      fprintf(stderr, "Warning: " STRING(exp) " in %s, " __FILE__ ":" STRING(__LINE__) "\n"        \
-              );                                                                \
+      fprintf(stderr, "Warning: " STRING(exp) " in %s, " __FILE__ ":" STRING(__LINE__) "\n",       \
+              __FUNCSIG__);                                                                        \
       count++;                                                                                     \
     }                                                                                              \
   } while (false)

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/blit_kernel.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/blit_kernel.cpp
@@ -895,8 +895,8 @@ hsa_status_t BlitKernel::ConvertImage(const Image& original_image,
   }
 
   hsa_ext_image_format_t new_format = {
-      static_cast<hsa_ext_image_channel_type_t>(converted_type),
-      static_cast<hsa_ext_image_channel_order_t>(converted_order)};
+      static_cast<hsa_ext_image_channel_type32_t>(converted_type),
+      static_cast<hsa_ext_image_channel_order32_t>(converted_order)};
 
   Image* new_image_handle = Image::Create(original_image.component);
   *new_image_handle=original_image;

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_ai.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_ai.cpp
@@ -45,6 +45,7 @@
 #include <assert.h>
 
 #include <algorithm>
+#include <cinttypes>
 #include <climits>
 
 #include "core/inc/runtime.h"
@@ -892,7 +893,7 @@ void ImageManagerAi::printSRDDetailed(const uint32_t* srd) const {
   
   // Calculate full address (GFX9 uses 40-bit shifted by 8)
   uint64_t base_addr = ((uint64_t)word1.f.base_address_hi << 32) | ((uint64_t)word0.f.base_address << 8);
-  printf("        → Full Base Address    = 0x%016lx\n", base_addr);
+  printf("        → Full Base Address    = 0x%016" PRIx64 "\n", base_addr);
   
   // WORD 2: WIDTH, HEIGHT, PERF_MOD
   sq_img_rsrc_word2_u word2;

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_gfx11.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_gfx11.cpp
@@ -45,6 +45,7 @@
 #include <assert.h>
 
 #include <algorithm>
+#include <cinttypes>
 #include <climits>
 
 #include "core/inc/runtime.h"
@@ -1087,7 +1088,7 @@ void ImageManagerGfx11::printSRDDetailed(const uint32_t* srd) const {
   
   // Calculate full address (GFX11 uses 40-bit shifted by 8)
   uint64_t base_addr = ((uint64_t)word1.f.BASE_ADDRESS_HI << 32) | ((uint64_t)word0.f.BASE_ADDRESS << 8);
-  printf("        → Full Base Address    = 0x%016lx\n", base_addr);
+  printf("        → Full Base Address    = 0x%016" PRIx64 "\n", base_addr);
   
   // WORD 2: WIDTH_HI, HEIGHT
   SQ_IMG_RSRC_WORD2 word2;

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_gfx12.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_gfx12.cpp
@@ -45,6 +45,7 @@
 #include <assert.h>
 
 #include <algorithm>
+#include <cinttypes>
 #include <climits>
 
 #include "core/inc/runtime.h"
@@ -1252,7 +1253,7 @@ void ImageManagerGfx12::printSRDDetailed(const uint32_t* srd) const {
 
   // Calculate full address (GFX12 uses 40-bit shifted by 8)
   uint64_t base_addr = ((uint64_t)word1.f.BASE_ADDRESS_HI << 40) | ((uint64_t)word0.f.BASE_ADDRESS << 8);
-  printf("        → Full Base Address    = 0x%016lx\n", base_addr);
+  printf("        → Full Base Address    = 0x%016" PRIx64 "\n", base_addr);
 
   // WORD 2: SQ_IMG_RSRC_WORD2
   SQ_IMG_RSRC_WORD2 word2;

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_kv.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_kv.cpp
@@ -45,6 +45,7 @@
 #include <assert.h>
 
 #include <algorithm>
+#include <cinttypes>
 #include <climits>
 
 #include "core/inc/runtime.h"
@@ -769,7 +770,7 @@ void ImageManagerKv::printSRDDetailed(const uint32_t* srd) const {
   
   // Calculate full address (KV uses 40-bit shifted by 8)
   uint64_t base_addr = ((uint64_t)word1.bits.base_address_hi << 40) | ((uint64_t)word0.bits.base_address << 8);
-  printf("        → Full Base Address    = 0x%016lx\n", base_addr);
+  printf("        → Full Base Address    = 0x%016" PRIx64 "\n", base_addr);
   
   // WORD 2: WIDTH, HEIGHT, PERF_MOD, INTERLACED
   SQ_IMG_RSRC_WORD2 word2;

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_nv.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_nv.cpp
@@ -45,6 +45,7 @@
 #include <assert.h>
 
 #include <algorithm>
+#include <cinttypes>
 #include <climits>
 
 #include "core/inc/runtime.h"
@@ -1002,7 +1003,7 @@ void ImageManagerNv::printSRDDetailed(const uint32_t* srd) const {
   
   // Calculate full address (NV uses 40-bit shifted by 8)
   uint64_t base_addr = ((uint64_t)word1.f.BASE_ADDRESS_HI << 40) | ((uint64_t)word0.f.BASE_ADDRESS << 8);
-  printf("        → Full Base Address    = 0x%016lx\n", base_addr);
+  printf("        → Full Base Address    = 0x%016" PRIx64 "\n", base_addr);
   
   // WORD 2: WIDTH_HI, HEIGHT, RESOURCE_LEVEL
   SQ_IMG_RSRC_WORD2 word2;

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_runtime.cpp
@@ -43,6 +43,7 @@
 #include "image_runtime.h"
 
 #include <assert.h>
+#include <cinttypes>
 #include <climits>
 #include <cstring>
 #include <vector>
@@ -789,7 +790,7 @@ hsa_status_t ImageRuntime::CreateMipmapArrayHandle(
     debug_print("Populating mipmapped array SRD...");
     mipmap_array->printSRD();
     manager->printSRDDetailed(mipmap_array->srd);
-    debug_print("output handle = %lu", image_handle.handle);
+    debug_print("output handle = %" PRIu64, image_handle.handle);
   }
 
   return HSA_STATUS_SUCCESS;


### PR DESCRIPTION
clr/hsa-runtime: fix MSVC warnings (narrowing, macro args, uninit var)

    - blit_kernel.cpp: use correct hsa_ext_image_channel_{type,order}32_t
      types to avoid narrowing conversion warnings (C4838).
    - rocglinterop_windows.cpp, rocmemory.cpp: replace LogError() with
      LogPrintfError() at call sites that pass printf-style format arguments,
      since LogError is a single-argument macro (C4002).
    - rocmemory.cpp: initialize `metadata` pointer to nullptr (C4700).

hsa-runtime: fix printf format specifiers for 64-bit types on Windows

    On Windows, long is 32-bit, so %lu/%ld/%lx are wrong for uint64_t and
    size_t arguments. Use portable format specifiers:
    - %zu/%zd/%zx for size_t
    - PRIu64/PRId64/PRIx64 for uint64_t (fprintf)
    - SCNu64/SCNx64 for uint64_t (sscanf)

hsa-runtime: fix debug_warning crash on Windows due to missing format argument

    The non-Linux debug_warning_n macro in utils.h had a %s format specifier
    but no corresponding argument (__PRETTY_FUNCTION__ was omitted since it's
    a GCC/Clang extension). This caused crashes in fprintf when debug_warning
    was reached at runtime. runtime.cpp worked around this by redefining
    debug_warning to a no-op, but other translation units were unprotected.

    Fix by using __FUNCSIG__ (MSVC equivalent of __PRETTY_FUNCTION__) and
    removing the now-unnecessary override in runtime.cpp.