### PR TITLE
[hipFile/Python] Update hipFile Python bindings to 0.2.0.dev1

### DIFF
--- a/projects/hipfile/python/CHANGELOG.md
+++ b/projects/hipfile/python/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to the hipFile Python bindings will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0.dev1]
+
+### Fixed
+
+- Release the Python GIL during all C function calls to prevent blocking other
+  threads during GPU IO operations. This resolves a performance regression
+  observed in multi-threaded applications (e.g., LMCache) when switching from
+  ctypes-based bindings to the Cython bindings.
+
+### Added
+
+- Complete typing hints for the public API.
+
+## [0.2.0.dev0]
+
+### Added
+
+- Initial release of the hipFile Python bindings.
+- Cython-based low-level wrappers for the hipFile C API (`_hipfile.pyx`).
+- High-level Pythonic API: `Driver`, `FileHandle`, `Buffer` classes with
+  context manager support.
+- `hipMalloc` / `hipFree` helpers for GPU memory allocation.
+- Error handling via `HipFileException` with hipFile and HIP driver error codes.
+- `FileHandleType` and `OpError` enums.
+- `get_version()` and `driver_get_properties()` utility functions.
+- scikit-build-core based build system.

--- a/projects/hipfile/python/CHANGELOG.md
+++ b/projects/hipfile/python/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 All notable changes to the hipFile Python bindings will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
 ## [Unreleased]
 
 ## [0.2.0.dev1]

--- a/projects/hipfile/python/pyproject.toml
+++ b/projects/hipfile/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "hipfile"
-version = "0.2.0.dev0"
+version = "0.2.0.dev1"
 classifiers = [
     "Development Status :: 3 - Alpha",
 ]
@@ -20,6 +20,7 @@ requires-python = ">=3.10"
 
 [project.urls]
 Homepage = "https://github.com/ROCm/rocm-systems/tree/develop/projects/hipfile"
+Changelog = "https://github.com/ROCm/rocm-systems/blob/develop/projects/hipfile/python/CHANGELOG.md"
 
 [tool.scikit-build]
 cmake.build-type = "Release"


### PR DESCRIPTION
The package will be updated after this PR is accepted.

## Motivation

Adds a changelog specific to the Python hipFile package & updates the early release version to `dev1`.

## Technical Details

See #5517 & #5704 .

## Test Plan

Passes the simple Pythonic aiscp.

## Test Result

```
$ python ./main.py
hipFile Version: (0, 2, 0)
Driver Use Count Before: 0
Buffer located at: 126573200015360 | 0x731e1ea00000
Driver Use Count After: 1
Transferring 2097152 bytes...
Bytes Read: 2097152
Bytes Written: 2097152
Input File Hash: 26fd72266b955c025641b92aa528f8f480762937e220ef8978249e2301282dd5
Output File Hash: 26fd72266b955c025641b92aa528f8f480762937e220ef8978249e2301282dd5
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
