### PR TITLE
[clr] Fix hipGetFuncBySymbol failure in heterogeneous multi-GPU systems

### DIFF
--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -637,11 +637,14 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
           break;
         }
       } else {
-        // We found neither a compatible code object nor SPIRV
-        LogPrintfError(
-            "No compatible code objects found with HIP_FORCE_SPIRV_CODEOBJECT=%d. Rebuild the application with option --offload-arch=%s",
-             HIP_FORCE_SPIRV_CODEOBJECT, device->devices()[0]->isa().targetId());
-        break;
+        // No compatible code object for this device — skip it so that other
+        // devices in a heterogeneous multi-GPU system can still be served.
+        LogPrintfInfo(
+            "No compatible code objects found for %s with HIP_FORCE_SPIRV_CODEOBJECT=%d, skipping."
+            " Rebuild the application with option --offload-arch=%s to enable this device.",
+             device->devices()[0]->isa().targetId().c_str(), HIP_FORCE_SPIRV_CODEOBJECT,
+             device->devices()[0]->isa().targetId().c_str());
+        continue;
       }
     }
   } while (0);

--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -642,8 +642,8 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
         LogPrintfInfo(
             "No compatible code objects found for %s with HIP_FORCE_SPIRV_CODEOBJECT=%d, skipping."
             " Rebuild the application with option --offload-arch=%s to enable this device.",
-             device->devices()[0]->isa().targetId().c_str(), HIP_FORCE_SPIRV_CODEOBJECT,
-             device->devices()[0]->isa().targetId().c_str());
+             device->devices()[0]->isa().targetId(), HIP_FORCE_SPIRV_CODEOBJECT,
+             device->devices()[0]->isa().targetId());
         continue;
       }
     }

--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -693,8 +693,8 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
         LogPrintfInfo(
             "No compatible code objects found for %s with HIP_FORCE_SPIRV_CODEOBJECT=%d, skipping."
             " Rebuild the application with option --offload-arch=%s to enable this device.",
-             device->devices()[0]->isa().targetId().c_str(), HIP_FORCE_SPIRV_CODEOBJECT,
-             device->devices()[0]->isa().targetId().c_str());
+             device->devices()[0]->isa().targetId(), HIP_FORCE_SPIRV_CODEOBJECT,
+             device->devices()[0]->isa().targetId());
         continue;
       }
     }

--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -688,11 +688,14 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
           break;
         }
       } else {
-        // We found neither a compatible code object nor SPIRV
-        LogPrintfError(
-            "No compatible code objects found with HIP_FORCE_SPIRV_CODEOBJECT=%d. Rebuild the application with option --offload-arch=%s",
-             HIP_FORCE_SPIRV_CODEOBJECT, device->devices()[0]->isa().targetId());
-        break;
+        // No compatible code object for this device — skip it so that other
+        // devices in a heterogeneous multi-GPU system can still be served.
+        LogPrintfInfo(
+            "No compatible code objects found for %s with HIP_FORCE_SPIRV_CODEOBJECT=%d, skipping."
+            " Rebuild the application with option --offload-arch=%s to enable this device.",
+             device->devices()[0]->isa().targetId().c_str(), HIP_FORCE_SPIRV_CODEOBJECT,
+             device->devices()[0]->isa().targetId().c_str());
+        continue;
       }
     }
   } while (0);


### PR DESCRIPTION
## Motivation

In heterogeneous multi-GPU systems (different GPU architectures in the same machine), `hipGetFuncBySymbol` fails with `hipErrorInvalidDeviceFunction (error 98)` for ALL devices, even those with a compatible code object in the fat binary. This prevents any HIP application built with generic targets (such as `gfx11-generic`) from running on the matching GPU if another GPU in the system has no compatible code object.

This was discovered while investigating https://github.com/ROCm/rocm-jax/issues/390, where a mixed `gfx906` + `gfx908` system reported `Autotuning failed ... No valid config found!` for operations on `device 1`. The root cause is the same, being that the fat binary loop aborts on `device 0` (`gfx906`, no code object) before loading `device 1`'s code object (`gfx908`, explicitly present in the build). The reporter's workaround of `ROCR_VISIBLE_DEVICES` to isolate a single GPU works precisely because the isolated case bypasses the multi-device loop.

## Technical Details

`ExtractFatBinaryUsingCOMGR` iterates over all devices to load code objects from a fat binary. Previously, if any device had no compatible code object (native, generic, or SPIR-V), the loop would break immediately, preventing code objects from being loaded for remaining devices that do have compatible binaries.

Change the `break` to `continue` so that devices without compatible code objects are skipped with an informational log, while remaining devices are still processed. Devices with no code object will get `hipErrorNoBinaryForGpu` when their kernels are actually invoked, which is the expected per-device behavior.

For example, with a fat binary containing `gfx908` + `gfx11-generic` on a system with `gfx906` as `device 0` and `gfx1101` as `device 1`:
  - Device 0: no native match, no generic match (`gfx9-generic` not in binary) -> `break`
  - Device 1: never processed, despite `gfx11-generic` being present

The same `gfx11-generic` binary works correctly when the `gfx1101` is isolated with `ROCR_VISIBLE_DEVICES=1`.

## JIRA ID

N/A

## Test Plan

Verify before and after this fix with a minimal HIP reproducer:

```
#include <hip/hip_runtime.h>
#include <cstdio>

  __global__ void TestKernel(float* out, int n) {
    int i = blockIdx.x * blockDim.x + threadIdx.x;
    if (i < n) out[i] = 1.0f;
  }

  int main() {
    int device_count = 0;
    hipGetDeviceCount(&device_count);
    printf("Device count: %d\n", device_count);

    for (int dev = 0; dev < device_count; dev++) {
      hipDeviceProp_t props;
      hipGetDeviceProperties(&props, dev);
      printf("\nDevice %d: %s (gcnArchName: %s)\n", dev, props.name, props.gcnArchName);

      hipSetDevice(dev);

      hipFunction_t func = nullptr;
      hipError_t err = hipGetFuncBySymbol(&func, (const void*)TestKernel);
      printf("  hipGetFuncBySymbol: %s (error %d)\n",
             err == hipSuccess ? "OK" : hipGetErrorString(err), err);

      if (err == hipSuccess) {
        float* d_out = nullptr;
        hipMalloc(&d_out, 256 * sizeof(float));
        TestKernel<<<1, 256>>>(d_out, 256);
        err = hipDeviceSynchronize();
        printf("  Kernel launch: %s\n", err == hipSuccess ? "OK" : hipGetErrorString(err));
        hipFree(d_out);
      }
    }

    return 0;
  }
```

Also verify end-to-end with JAX/XLA: `matmul` on `device 1` (`gfx1101`) now succeeds with the default generic build targets, where previously it crashed with `FATAL: Could not load RepeatBufferKernel` with the following workload:

```
import jax, jax.numpy as jnp
print('Devices:', [(d.id, d.device_kind) for d in jax.devices()])
d1 = jax.devices()[1]
print('Matmul on device 1...')
a = jax.device_put(jnp.ones((256, 256)), d1)
c = (a @ a).block_until_ready()
print(f'OK: {float(c[0,0])}')
```

## Test Result

Minimal HIP reproducer:

| Binary targets | Before fix (both GPUs visible) | After fix (both GPUs visible) | Isolated gfx1101 |
  |---|---|---|---|
  | `gfx11-generic` only | error 98 for both devices | Device 0: error 98 (expected), Device 1: OK | OK |
  | `gfx908 + gfx11-generic` | error 98 for both devices | Device 0: error 98 (expected), Device 1: OK | OK |
  | `gfx906 + gfx1101` (explicit) | OK for both | OK for both | OK |

For the JAX workload, using the PJRT plugin built with default generic targets (`gfx908`, `gfx90a`, `gfx9-4-generic`, `gfx10-3-generic`, `gfx11-generic`, `gfx12-generic`):

```
Devices: [(0, 'AMD Radeon VII'), (1, 'AMD Radeon PRO W7700')]
  Matmul on device 1...
  OK: 256.0
```

Without the fix, the same workload crashes with:

```
F0505 15:32:49.126035 stream_executor_util.cc:522] Could not load RepeatBufferKernel:
INTERNAL: Failed call to hipGetFuncBySymbol: hipError_t(98)
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.