### PR TITLE
[RCCL] Default NCCL_LOCAL_REGISTER to 0

### DIFF
--- a/projects/rccl/src/register/register.cc
+++ b/projects/rccl/src/register/register.cc
@@ -15,11 +15,7 @@
 
 using namespace rccl;
 
-#if HIP_VERSION >= 71260540
-NCCL_PARAM(LocalRegister, "LOCAL_REGISTER", 1);
-#else
 NCCL_PARAM(LocalRegister, "LOCAL_REGISTER", 0);
-#endif
 
 ncclResult_t ncclRegLocalIsValid(struct ncclReg *reg, bool *isValid) {
   if (reg && isValid) {


### PR DESCRIPTION
Sets the default of NCCL_LOCAL_REGISTER to 0 unconditionally; local buffer registration remains opt-in via NCCL_LOCAL_REGISTER=1.

Avoids ROCM-21756: a PyTorch training workload's eval phase hangs on the first out-of-place AllGather it issues on a freshly-created user stream after training collectives ran on the default stream. The hang lives in the local-registration path, so bypassing it by default keeps the workload running on stock RCCL.

The launch-stream sync gap that triggers the hang is being addressed separately in #5768 which incurs significant performance regressions; this is an independent, conservative default that doesn't depend on that fix landing.


## Test plan

- [x] PyTorch training workload on 8× MI355X / TheRock 1334: eval phase PASS, eval_loss matches the pre-regression baseline (eval_runtime ~25 s, eval_samples_per_second ~11.6).
- [ ] rccl-tests + maintainer regression suite.

## Refs

ROCM-21756, #5768
