### PR TITLE
[hipfile] Fix badges in README.md

### DIFF
--- a/projects/hipfile/README.md
+++ b/projects/hipfile/README.md
@@ -3,10 +3,8 @@
 > [!CAUTION] 
 > This release is an *early-access* software technology preview. Running production workloads is *not* recommended.
 
-[![MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/ROCm/hipFile/develop/LICENSE.md)
-[![CI](https://github.com/ROCm/hipFile/actions/workflows/root-ci.yml/badge.svg)](https://github.com/ROCm/hipFile/actions/workflows/root-ci.yml)
+[![MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE.md)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11458/badge)](https://www.bestpractices.dev/projects/11458)
-[![CodeQL](https://github.com/ROCm/hipFile/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/ROCm/hipFile/actions/workflows/github-code-scanning/codeql)
 [![Coverity](https://scan.coverity.com/projects/hipFile/badge.svg)](https://scan.coverity.com/projects/hipFile)
 [![clang-format](https://github.com/ROCm/rocm-systems/actions/workflows/hipfile-clang-format.yml/badge.svg?branch=develop)](https://github.com/ROCm/rocm-systems/actions/workflows/hipfile-clang-format.yml)
 [![cmakelint](https://github.com/ROCm/rocm-systems/actions/workflows/hipfile-cmakelint.yml/badge.svg?branch=develop)](https://github.com/ROCm/rocm-systems/actions/workflows/hipfile-cmakelint.yml)


### PR DESCRIPTION
## Motivation

The badges on our README.md file have not been fully updated since the move to rocm-systems.

## Technical Details

* Remove CI and CodeQL badges, which point to the old repo
* Point the license badge at the current license file

We can't add a CI badge until we have a push target and CodeQL isn't running on rocm-systems unless you set up advanced scanning. We'll address these issues in the future.

## JIRA ID

AIHIPFILE-87

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
