### PR TITLE
ci(rocprofiler-systems): update GitHub Actions versions

### DIFF
--- a/.github/workflows/rocprofiler-systems-formatting.yml
+++ b/.github/workflows/rocprofiler-systems-formatting.yml
@@ -31,12 +31,6 @@ jobs:
         with:
           sparse-checkout: projects/rocprofiler-systems
 
-      - name: Fetch config
-        shell: sh
-        working-directory: projects/rocprofiler-systems/
-        run: |
-          test -f .markdownlint.yaml && echo "Using local config file" || curl --silent --show-error --fail --location https://raw.github.com/ROCm/rocm-docs-core/develop/.markdownlint.yaml -O
-
       - name: Use markdownlint-cli2
         uses: DavidAnson/markdownlint-cli2-action@6b51ade7a9e4a75a7ad929842dd298a3804ebe8b # v23.1.0
         with:

--- a/.github/workflows/rocprofiler-systems-formatting.yml
+++ b/.github/workflows/rocprofiler-systems-formatting.yml
@@ -38,7 +38,7 @@ jobs:
           test -f .markdownlint.yaml && echo "Using local config file" || curl --silent --show-error --fail --location https://raw.github.com/ROCm/rocm-docs-core/develop/.markdownlint.yaml -O
 
       - name: Use markdownlint-cli2
-        uses: DavidAnson/markdownlint-cli2-action@v10.0.1
+        uses: DavidAnson/markdownlint-cli2-action@6b51ade7a9e4a75a7ad929842dd298a3804ebe8b # v23.1.0
         with:
           globs: "projects/rocprofiler-systems/**/*.md"
 
@@ -62,7 +62,7 @@ jobs:
           sed -i "s|docs/\*\*/\*.md|projects/rocprofiler-systems/docs/**/*.md|g" .spellcheck.yaml
 
       - name: Run spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.46.0
+        uses: rojopolis/spellcheck-github-actions@e3cd8e9aec4587ec73bc0e60745aafd45c37aa2e # 0.60.0
 
       - name: On fail
         if: failure()
@@ -81,7 +81,7 @@ jobs:
         sparse-checkout: projects/rocprofiler-systems
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/rocprofiler-systems-formatting.yml
+++ b/.github/workflows/rocprofiler-systems-formatting.yml
@@ -8,7 +8,6 @@ on:
     paths:
       - '.github/workflows/rocprofiler-systems-formatting.yml'
       - 'projects/rocprofiler-systems/**'
-      - '!**/*.md'
       - '!**/*.rtf'
       - '!**/*.rst'
       - '!**/.markdownlint-ci2.yaml'

--- a/.github/workflows/rocprofiler-systems-python.yml
+++ b/.github/workflows/rocprofiler-systems-python.yml
@@ -49,7 +49,7 @@ jobs:
       with:
         sparse-checkout: projects/rocprofiler-systems
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/projects/rocprofiler-systems/.markdownlint.yaml
+++ b/projects/rocprofiler-systems/.markdownlint.yaml
@@ -1,0 +1,12 @@
+# Local markdownlint config — mirrors ROCm/rocm-docs-core develop/.markdownlint.yaml
+default: true
+MD013: false
+MD024:
+  siblings_only: true
+MD026:
+  punctuation: ".,;:!"
+MD029:
+  style: ordered
+MD033: false
+MD034: false
+MD041: false

--- a/projects/rocprofiler-systems/.markdownlint.yaml
+++ b/projects/rocprofiler-systems/.markdownlint.yaml
@@ -1,4 +1,4 @@
-# Local markdownlint config — mirrors ROCm/rocm-docs-core develop/.markdownlint.yaml
+# Based on rocm-docs-core; kept local for stability
 default: true
 MD013: false
 MD024:

--- a/projects/rocprofiler-systems/.pre-commit-config.yaml
+++ b/projects/rocprofiler-systems/.pre-commit-config.yaml
@@ -48,6 +48,11 @@ repos:
     hooks:
     - id: gersemi
 
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.22.1
+    hooks:
+      - id: markdownlint-cli2
+
   - repo: local
     hooks:
       - id: check-copyright

--- a/projects/rocprofiler-systems/.pre-commit-config.yaml
+++ b/projects/rocprofiler-systems/.pre-commit-config.yaml
@@ -52,6 +52,7 @@ repos:
     rev: v0.22.1
     hooks:
       - id: markdownlint-cli2
+        exclude: ^external/
 
   - repo: local
     hooks:

--- a/projects/rocprofiler-systems/README.md
+++ b/projects/rocprofiler-systems/README.md
@@ -436,7 +436,7 @@ for `foo` via the direct call within `spam`. There will be no entries for `bar` 
 Perfetto tracing with the system backend supports multiple processes writing to the same
 output file. Thus, it is a useful technique if rocprofiler-systems is built with partial MPI support
 because all the perfetto output will be coalesced into a single file. The
-installation docs for perfetto can be found [here](https://perfetto.dev/docs/contributing/build-instructions).
+installation docs for perfetto can be found in the [Perfetto build instructions](https://perfetto.dev/docs/contributing/build-instructions).
 If you are building rocprofiler-systems from source, you can configure CMake with `ROCPROFSYS_INSTALL_PERFETTO_TOOLS=ON`
 and the `perfetto` and `traced` applications will be installed as part of the build process. However,
 it should be noted that to prevent this option from accidentally overwriting an existing perfetto install,

--- a/projects/rocprofiler-systems/examples/README.md
+++ b/projects/rocprofiler-systems/examples/README.md
@@ -7,7 +7,7 @@ This directory contains example applications demonstrating various profiling sce
 ### GPU Compute
 
 | Example | Description | Dependencies |
-|---------|-------------|--------------|
+| --------- | ------------- | -------------- |
 | [transpose](transpose/) | Tiled matrix transpose on GPU with multi-threaded stream execution | HIP |
 | [scratch-memory](scratch-memory/) | GPU scratch memory allocation stress test across primary and overflow slots | HIP, HSA |
 | [sdma_test](sdma_test/) | SDMA engine bandwidth benchmark for H2D, D2D, and D2H transfers | HIP |
@@ -16,7 +16,7 @@ This directory contains example applications demonstrating various profiling sce
 ### Profiler API
 
 | Example | Description | Dependencies |
-|---------|-------------|--------------|
+| --------- | ------------- | -------------- |
 | [user-api](user-api/) | User API for named regions, annotations, and selective thread tracing | rocprofiler-systems user library |
 | [roctx](roctx/) | ROCTx range/marker API with thread naming, pause/resume, and device labeling | rocprofiler-sdk-roctx, HIP |
 | [causal](causal/) | Causal profiling with slow/fast parallel workloads and progress point tracking | rocprofiler-systems user library |
@@ -26,7 +26,7 @@ This directory contains example applications demonstrating various profiling sce
 ### CPU Threading
 
 | Example | Description | Dependencies |
-|---------|-------------|--------------|
+| --------- | ------------- | -------------- |
 | [thread-limit](thread-limit/) | Thread scaling stress test with batched Fibonacci workers | pthreads |
 | [parallel-overhead](parallel-overhead/) | Mutex vs. atomic synchronization overhead comparison | pthreads |
 | [code-coverage](code-coverage/) | Dual code-path execution for coverage analysis testing | pthreads |
@@ -35,7 +35,7 @@ This directory contains example applications demonstrating various profiling sce
 ### Distributed Computing
 
 | Example | Description | Dependencies |
-|---------|-------------|--------------|
+| --------- | ------------- | -------------- |
 | [mpi](mpi/) | MPI collective and point-to-point operations with communicator patterns | MPI |
 | [rccl](rccl/) | RCCL collective communication performance tests across GPUs | HIP, RCCL |
 | [shmem](shmem/) | OpenSHMEM hello world and ping-pong latency benchmark | OpenSHMEM (oshcc) |
@@ -43,27 +43,27 @@ This directory contains example applications demonstrating various profiling sce
 ### OpenMP
 
 | Example | Description | Dependencies |
-|---------|-------------|--------------|
+| --------- | ------------- | -------------- |
 | [openmp](openmp/) | NAS Parallel Benchmarks (CG, LU) with OpenMP threading | OpenMP |
 
 ### GPU Libraries
 
 | Example | Description | Dependencies |
-|---------|-------------|--------------|
+| --------- | ------------- | -------------- |
 | [jpegdecode](jpegdecode/) | Batch JPEG decoding performance benchmark using rocJPEG | HIP, rocJPEG |
 | [videodecode](videodecode/) | Batch video decoding benchmark using ROCDecode with VCN hardware | HIP, ROCDecode, FFmpeg |
 
 ### HPC
 
 | Example | Description | Dependencies |
-|---------|-------------|--------------|
+| --------- | ------------- | -------------- |
 | [lulesh](lulesh/) | LULESH shock hydrodynamics mini-app with Kokkos parallelism | Kokkos, optional MPI |
 | [hpc](hpc/) | Six HPC training examples covering Jacobi solvers, matrix exponentials, and stream overlap | HIP, rocBLAS, Fortran (varies) |
 
 ### Python
 
 | Example | Description | Dependencies |
-|---------|-------------|--------------|
+| --------- | ------------- | -------------- |
 | [python](python/) | Python profiling with decorators, user regions, and selective tracing | Python 3, optional NumPy |
 
 ## Building All Examples
@@ -110,7 +110,7 @@ cmake -B <build_dir> -DROCPROFSYS_GFX_TARGETS="gfx90a;gfx942" ...
 rocprofiler-systems supports several instrumentation modes:
 
 | Mode | Command | Description |
-|------|---------|-------------|
+| ------ | --------- | ------------- |
 | System-level | `rocprof-sys-run -- ./app` | Lightweight tracing via `LD_PRELOAD`, no binary modification |
 | Binary rewrite | `rocprof-sys-instrument -o app.inst -- ./app` then `rocprof-sys-run -- ./app.inst` | Statically rewrite the binary for repeated profiling |
 | Runtime instrument | `rocprof-sys-instrument -- ./app` | Dynamically instrument at launch without modifying the binary |
@@ -120,7 +120,7 @@ rocprofiler-systems supports several instrumentation modes:
 ### Common Environment Variables
 
 | Variable | Description | Default |
-|----------|-------------|---------|
+| ---------- | ------------- | --------- |
 | `ROCPROFSYS_TRACE` | Enable Perfetto trace output | `true` |
 | `ROCPROFSYS_PROFILE` | Enable call-stack profile output | `true` |
 | `ROCPROFSYS_USE_ROCPD` | Generate `rocpd` database output | `false` |

--- a/projects/rocprofiler-systems/examples/causal/README.md
+++ b/projects/rocprofiler-systems/examples/causal/README.md
@@ -80,7 +80,7 @@ rocprof-sys-causal --mode line -- ./causal-cpu-rocprofsys 70 10 432525 100000000
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_CAUSAL_RANDOM_SEED` | `1342342` | Fixed seed for reproducible causal experiments |
 | `ROCPROFSYS_TIME_OUTPUT` | `OFF` | Disable timestamped output directories |
 | `ROCPROFSYS_FILE_OUTPUT` | `ON` | Enable file output |
@@ -88,7 +88,7 @@ rocprof-sys-causal --mode line -- ./causal-cpu-rocprofsys 70 10 432525 100000000
 **Causal CLI flags:**
 
 | Flag | Description |
-|------|-------------|
+| ------ | ------------- |
 | `-n` | Number of causal experiment iterations |
 | `-w` | Number of warmup iterations |
 | `-d` | Virtual speedup delta (percentage steps) |

--- a/projects/rocprofiler-systems/examples/causal/README.md
+++ b/projects/rocprofiler-systems/examples/causal/README.md
@@ -38,7 +38,7 @@ The build generates multiple variants of each executable:
 **Targets:**
 
 | Target | Description |
-|--------|-------------|
+| ------ | ----------- |
 | `causal-both` | Both RNG and CPU workloads |
 | `causal-rng` | RNG-based workload only |
 | `causal-cpu` | CPU-based workload only |
@@ -58,7 +58,7 @@ The build generates multiple variants of each executable:
 **Arguments:**
 
 | Position | Description | Default |
-|----------|-------------|---------|
+| -------- | ----------- | ------- |
 | 1 | Work fraction (percentage ratio fast/slow) | 70 |
 | 2 | Number of iterations | 50 |
 | 3 | Random seed | random |

--- a/projects/rocprofiler-systems/examples/code-coverage/README.md
+++ b/projects/rocprofiler-systems/examples/code-coverage/README.md
@@ -46,7 +46,7 @@ CODE_COVERAGE_USE_FAKE=1 ./code-coverage
 **Arguments:**
 
 | Position | Description | Default |
-|----------|-------------|---------|
+| ---------- | ------------- | --------- |
 | 1 | Fibonacci number to compute | 10 |
 | 2 | Number of threads | min(16, hardware concurrency) |
 | 3 | Number of iterations per thread | 5000 |
@@ -54,7 +54,7 @@ CODE_COVERAGE_USE_FAKE=1 ./code-coverage
 **Environment:**
 
 | Variable | Description |
-|----------|-------------|
+| ---------- | ------------- |
 | `CODE_COVERAGE_USE_FAKE` | If set, switches to `run_fake()` code path |
 
 ## Profiling with rocprofiler-systems
@@ -70,7 +70,7 @@ rocprof-sys-run -e CODE_COVERAGE_USE_FAKE=1 -- ./code-coverage 10 4 2000
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace |
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile showing exercised functions |
 | `ROCPROFSYS_USE_SAMPLING` | `ON` | Enable sampling for coverage correlation |

--- a/projects/rocprofiler-systems/examples/fork/README.md
+++ b/projects/rocprofiler-systems/examples/fork/README.md
@@ -45,7 +45,7 @@ cmake --build build --target fork-example
 **Arguments:**
 
 | Position | Description | Default |
-|----------|-------------|---------|
+| ---------- | ------------- | --------- |
 | 1 | Number of child processes to fork | 4 |
 | 2 | Number of fork/wait cycles to repeat | 1 |
 
@@ -58,7 +58,7 @@ rocprof-sys-run -- ./fork-example 4 2
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace with cross-process events |
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile |
 | `ROCPROFSYS_USE_SAMPLING` | `ON` | Sample call stacks in parent and child processes |

--- a/projects/rocprofiler-systems/examples/hpc/README.md
+++ b/projects/rocprofiler-systems/examples/hpc/README.md
@@ -95,7 +95,7 @@ rocprof-sys-run -- ./matrix-exponential-streams-sync-hip
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_ROCM_DOMAINS` | `hip_runtime_api,kernel_dispatch,memory_copy` | Trace HIP API and GPU operations |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace for stream overlap analysis |
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile |

--- a/projects/rocprofiler-systems/examples/jpegdecode/README.md
+++ b/projects/rocprofiler-systems/examples/jpegdecode/README.md
@@ -46,7 +46,7 @@ cmake --build <build_dir> --target jpegdecode
 **Key parameters:**
 
 | Parameter | Description |
-|-----------|-------------|
+| ----------- | ------------- |
 | `-i` | Input directory containing JPEG files |
 | `-b` | Batch size (images per decode batch) |
 | `-d` | GPU device ID |
@@ -61,7 +61,7 @@ rocprof-sys-run -- ./jpegdecode -i /path/to/images/ -b 4
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_ROCM_DOMAINS` | `hip_runtime_api,kernel_dispatch,memory_copy` | Trace HIP API and GPU operations |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace |
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile |

--- a/projects/rocprofiler-systems/examples/lulesh/README.md
+++ b/projects/rocprofiler-systems/examples/lulesh/README.md
@@ -42,7 +42,7 @@ cmake --build <build_dir> --target lulesh
 **Targets:**
 
 | Target | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `lulesh` | Standard build with debug symbols |
 | `lulesh-rocprofsys` | Linked with rocprofiler-systems user library |
 | `lulesh-coz` | Linked with COZ profiler (if available) |
@@ -69,7 +69,7 @@ mpirun -np 8 ./lulesh -i 35 -s 30 -p
 **Arguments:**
 
 | Flag | Description |
-|------|-------------|
+| ------ | ------------- |
 | `-i` | Number of iterations |
 | `-s` | Problem size (elements per edge) |
 | `-p` | Print progress |
@@ -89,7 +89,7 @@ rocprof-sys-causal -- ./lulesh-rocprofsys -i 35 -s 50 -p
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace |
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile |
 | `ROCPROFSYS_USE_SAMPLING` | `ON` | Enable statistical sampling |

--- a/projects/rocprofiler-systems/examples/mpi/README.md
+++ b/projects/rocprofiler-systems/examples/mpi/README.md
@@ -40,7 +40,7 @@ cmake --build <build_dir> --target mpi-example
 **Targets:**
 
 | Target | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `mpi-example` | C++ benchmark (send/recv + all2all with communicator ops) |
 | `mpi-allgather` | C allgather example |
 | `mpi-allreduce` | C allreduce example |
@@ -64,7 +64,7 @@ mpirun -np 4 ./mpi-scatter-gather
 **Arguments (mpi-example):**
 
 | Position | Description | Default |
-|----------|-------------|---------|
+| ---------- | ------------- | --------- |
 | 1 | Number of iterations | 1 |
 
 ## Profiling with rocprofiler-systems
@@ -76,7 +76,7 @@ mpirun -np 2 rocprof-sys-run -- ./mpi-example
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_USE_MPIP` | `ON` | Enable MPI profiling interposition |
 | `ROCPROFSYS_USE_MPI` | `ON` | Enable MPI-aware output merging |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace |

--- a/projects/rocprofiler-systems/examples/openmp/README.md
+++ b/projects/rocprofiler-systems/examples/openmp/README.md
@@ -43,7 +43,7 @@ cmake --build <build_dir> --target openmp-cg openmp-lu
 **Targets:**
 
 | Target | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `openmp-cg` | NAS Conjugate Gradient benchmark |
 | `openmp-lu` | NAS LU Gauss-Seidel benchmark |
 
@@ -63,7 +63,7 @@ export OMP_NUM_THREADS=4
 **Recommended OpenMP settings:**
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `OMP_NUM_THREADS` | `2`-`N` | Number of OpenMP threads |
 | `OMP_PROC_BIND` | `spread` | Thread placement policy |
 | `OMP_PLACES` | `threads` | Thread affinity granularity |
@@ -77,7 +77,7 @@ OMP_NUM_THREADS=4 rocprof-sys-run -- ./openmp-cg
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace with OpenMP regions |
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile |
 | `ROCPROFSYS_USE_SAMPLING` | `ON` | Enable statistical sampling |

--- a/projects/rocprofiler-systems/examples/parallel-overhead/README.md
+++ b/projects/rocprofiler-systems/examples/parallel-overhead/README.md
@@ -30,7 +30,7 @@ cmake --build <build_dir> --target parallel-overhead parallel-overhead-locks
 ```
 
 | Target | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `parallel-overhead` | Lock-free atomic accumulation |
 | `parallel-overhead-locks` | Mutex-based accumulation (`USE_LOCKS=1`) |
 
@@ -50,7 +50,7 @@ cmake --build <build_dir> --target parallel-overhead parallel-overhead-locks
 **Arguments:**
 
 | Position | Description | Default |
-|----------|-------------|---------|
+| ---------- | ------------- | --------- |
 | 1 | Fibonacci number to compute | 10 |
 | 2 | Number of threads | min(16, hardware concurrency) |
 | 3 | Number of iterations per thread | 50000 |
@@ -70,7 +70,7 @@ rocprof-sys-run -- ./parallel-overhead-locks 10 8 10000
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace for timeline analysis |
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile |
 | `ROCPROFSYS_USE_SAMPLING` | `ON` | Enable statistical sampling |

--- a/projects/rocprofiler-systems/examples/python/README.md
+++ b/projects/rocprofiler-systems/examples/python/README.md
@@ -40,7 +40,7 @@ rocprof-sys-python -- ./source-numpy.py -n 3 -v 20
 **Common arguments:**
 
 | Flag | Description | Default |
-|------|-------------|---------|
+| ------ | ------------- | --------- |
 | `-n, --num-iterations` | Number of iterations | 3 |
 | `-v, --value` | Starting Fibonacci value | 20 |
 | `-s, --stop-profile` | Stop tracing after N iterations (0 = never) | 0 |
@@ -54,7 +54,7 @@ rocprof-sys-python -- ./source.py -n 5 -v 20
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace with Python call stacks |
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile |
 | `ROCPROFSYS_USE_SAMPLING` | `ON` | Enable statistical sampling |

--- a/projects/rocprofiler-systems/examples/rccl/README.md
+++ b/projects/rocprofiler-systems/examples/rccl/README.md
@@ -34,7 +34,7 @@ cmake --build <build_dir> --target all_reduce_perf
 **Targets:**
 
 | Target | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `all_gather_perf` | AllGather performance test |
 | `all_reduce_perf` | AllReduce performance test |
 | `alltoall_perf` | AllToAll performance test |
@@ -65,7 +65,7 @@ rocprof-sys-run -- ./all_reduce_perf -b 8 -e 128M -f 2 -g 2
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_ROCM_DOMAINS` | `hip_runtime_api,kernel_dispatch,memory_copy` | Trace HIP API and GPU operations |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace for timeline analysis |
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile |

--- a/projects/rocprofiler-systems/examples/rewrite-caller/README.md
+++ b/projects/rocprofiler-systems/examples/rewrite-caller/README.md
@@ -44,7 +44,7 @@ cmake --build <build_dir> --target rewrite-caller
 **Arguments:**
 
 | Position | Description | Default |
-|----------|-------------|---------|
+| ---------- | ------------- | --------- |
 | 1 | Number of calls to outer() | 10 |
 
 ## Profiling with rocprofiler-systems
@@ -68,7 +68,7 @@ rocprof-sys-instrument -- ./rewrite-caller 100
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace showing call chain |
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile with call counts |
 | `ROCPROFSYS_USE_SAMPLING` | `ON` | Enable sampling alongside instrumentation |

--- a/projects/rocprofiler-systems/examples/roctx/README.md
+++ b/projects/rocprofiler-systems/examples/roctx/README.md
@@ -55,7 +55,7 @@ rocprof-sys-run -- ./roctx
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_ROCM_DOMAINS` | `hip_runtime_api,marker_api,kernel_dispatch` | Trace HIP API, ROCTx markers, and kernel launches |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace with ROCTx annotations |
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile |

--- a/projects/rocprofiler-systems/examples/scratch-memory/README.md
+++ b/projects/rocprofiler-systems/examples/scratch-memory/README.md
@@ -47,7 +47,7 @@ rocprof-sys-run -- ./scratch-memory
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_ROCM_DOMAINS` | `hip_api,hsa_api,kernel_dispatch,scratch_memory` | Trace HIP/HSA API and scratch memory events |
 | `ROCPROFSYS_ROCM_EVENTS` | `SQ_WAVES` | Sample GPU wave occupancy |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace |

--- a/projects/rocprofiler-systems/examples/sdma_test/README.md
+++ b/projects/rocprofiler-systems/examples/sdma_test/README.md
@@ -45,7 +45,7 @@ cmake --build <build_dir> --target sdma_test
 **Flags:**
 
 | Flag | Description | Default |
-|------|-------------|---------|
+| ------ | ------------- | --------- |
 | `-s, --size` | Transfer size in MB (supports K/M/G suffixes) | 512 |
 | `-n, --iterations` | Number of iterations (0 = infinite) | 10 |
 | `-c, --copies` | Number of copies per iteration | 10 |
@@ -60,7 +60,7 @@ rocprof-sys-run -- ./sdma_test -s 256 -n 5
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_ROCM_DOMAINS` | `hip_runtime_api,kernel_dispatch,memory_copy` | Trace HIP API and memory copy operations |
 | `ROCPROFSYS_ROCM_EVENTS` | `SQ_WAVES,GRBM_COUNT` | Sample GPU hardware counters |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace for timeline analysis |

--- a/projects/rocprofiler-systems/examples/shmem/README.md
+++ b/projects/rocprofiler-systems/examples/shmem/README.md
@@ -33,7 +33,7 @@ cmake --build <build_dir> --target shmem_hello shmem_pingpong
 **Targets:**
 
 | Target | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `shmem_hello` | Basic SHMEM hello world |
 | `shmem_pingpong` | Ping-pong latency benchmark |
 
@@ -50,7 +50,7 @@ oshrun -np 2 ./shmem_pingpong
 **shmem_pingpong flags:**
 
 | Flag | Description | Default |
-|------|-------------|---------|
+| ------ | ------------- | --------- |
 | `-n` | Number of iterations | 10000 |
 | `-s` | Message size in bytes | 4 |
 | `-w` | Use `shmem_wait_until()` instead of polling | off |
@@ -67,7 +67,7 @@ oshrun -np 2 rocprof-sys-run -- ./shmem_pingpong -n 1000
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace |
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile |
 | `ROCPROFSYS_USE_SAMPLING` | `ON` | Enable statistical sampling |

--- a/projects/rocprofiler-systems/examples/thread-limit/README.md
+++ b/projects/rocprofiler-systems/examples/thread-limit/README.md
@@ -42,7 +42,7 @@ cmake --build <build_dir> --target thread-limit
 **Arguments:**
 
 | Position | Description | Default |
-|----------|-------------|---------|
+| ---------- | ------------- | --------- |
 | 1 | Fibonacci number to compute | 35 |
 | 2 | Concurrency (threads per batch) | hardware_concurrency() |
 | 3 | Total number of threads to launch | 2 * MAX_THREADS (8000) |
@@ -56,7 +56,7 @@ rocprof-sys-run -- ./thread-limit 30 4 500
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace showing thread lifecycle |
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile |
 | `ROCPROFSYS_USE_SAMPLING` | `ON` | Enable statistical sampling of thread stacks |

--- a/projects/rocprofiler-systems/examples/trace-time-window/README.md
+++ b/projects/rocprofiler-systems/examples/trace-time-window/README.md
@@ -44,7 +44,7 @@ cmake --build <build_dir> --target trace-time-window
 **Arguments:**
 
 | Position | Description | Default |
-|----------|-------------|---------|
+| ---------- | ------------- | --------- |
 | 1 | Number of repeat iterations | 1 |
 
 ## Profiling with rocprofiler-systems
@@ -56,7 +56,7 @@ rocprof-sys-run -- ./trace-time-window 2
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace for timeline visualization |
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile |
 | `ROCPROFSYS_VERBOSE` | `2` | Verbose output for debugging trace windows |

--- a/projects/rocprofiler-systems/examples/transferBench/README.md
+++ b/projects/rocprofiler-systems/examples/transferBench/README.md
@@ -41,7 +41,7 @@ cmake --build <build_dir> --target transferBench
 TransferBench is primarily configured through environment variables. Key settings:
 
 | Variable | Description | Default |
-|----------|-------------|---------|
+| ---------- | ------------- | --------- |
 | `NUM_ITERATIONS` | Number of benchmark iterations | varies |
 | `BLOCK_BYTES` | Transfer block size in bytes | 256 |
 | `GFX_BLOCK_SIZE` | GPU compute block size | 256 |
@@ -57,7 +57,7 @@ rocprof-sys-run -- ./transferBench
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_ROCM_DOMAINS` | `hip_runtime_api,kernel_dispatch,memory_copy,memory_allocation` | Trace all GPU memory operations |
 | `ROCPROFSYS_ROCM_EVENTS` | `SQ_WAVES,GRBM_COUNT` | Sample GPU hardware counters |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace |

--- a/projects/rocprofiler-systems/examples/transpose/README.md
+++ b/projects/rocprofiler-systems/examples/transpose/README.md
@@ -50,7 +50,7 @@ cmake --build build
 **Arguments:**
 
 | Position | Description | Default |
-|----------|-------------|---------|
+| ---------- | ------------- | --------- |
 | 1 | Number of CPU threads (each gets a HIP stream) | 2 |
 | 2 | Number of kernel iterations | 500 |
 | 3 | Synchronize every N iterations | 10 |
@@ -64,7 +64,7 @@ rocprof-sys-run -- ./transpose 4 200 10
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_ROCM_DOMAINS` | `hip_runtime_api,kernel_dispatch,memory_copy` | Trace HIP API calls, kernel launches, and memory transfers |
 | `ROCPROFSYS_ROCM_EVENTS` | `SQ_WAVES,GRBM_COUNT` | Sample GPU hardware counters |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace |

--- a/projects/rocprofiler-systems/examples/user-api/README.md
+++ b/projects/rocprofiler-systems/examples/user-api/README.md
@@ -43,7 +43,7 @@ cmake --build <build_dir> --target user-api
 **Arguments:**
 
 | Position | Description | Default |
-|----------|-------------|---------|
+| ---------- | ------------- | --------- |
 | 1 | Fibonacci number to compute | 10 |
 | 2 | Number of threads | min(16, hardware concurrency) |
 | 3 | Number of iterations per thread | 50000 |
@@ -57,7 +57,7 @@ rocprof-sys-run -- ./user-api 10 4 1000
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace with user regions |
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile |
 | `ROCPROFSYS_USE_SAMPLING` | `ON` | Enable statistical sampling |
@@ -71,7 +71,7 @@ rocprof-sys-instrument -l --min-instructions=8 -E custom_push_region \
 ```
 
 | Option | Purpose |
-|--------|---------|
+| -------- | --------- |
 | `-l` | Instrument at the loop level so the Fibonacci loop in `run()` is profiled |
 | `--min-instructions=8` | Lower the default threshold (1024) so small functions like `run()` are included |
 | `-E custom_push_region` | Exclude the user callback from instrumentation to avoid recursion and trace noise (the callback runs on every region push; instrumenting it would profile the profiler rather than the workload) |

--- a/projects/rocprofiler-systems/examples/videodecode/README.md
+++ b/projects/rocprofiler-systems/examples/videodecode/README.md
@@ -54,7 +54,7 @@ rocprof-sys-run -- ./videodecode -i /path/to/video.mp4
 ### Recommended Configuration
 
 | Variable | Value | Purpose |
-|----------|-------|---------|
+| ---------- | ------- | --------- |
 | `ROCPROFSYS_ROCM_DOMAINS` | `hip_runtime_api,kernel_dispatch,memory_copy` | Trace HIP API and GPU operations |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace for timeline analysis |
 | `ROCPROFSYS_PROFILE` | `true` | Generate call-stack profile |

--- a/projects/rocprofiler-systems/tests/README.md
+++ b/projects/rocprofiler-systems/tests/README.md
@@ -46,7 +46,7 @@ For example, in a venv, passing `ROCPROFSYS_TEST_EXECUTABLE=$(which python3)` sh
 ### Environment Variables
 
 | Variable | Description | Default |
-|----------|-------------|---------|
+| ---------- | ------------- | --------- |
 | `ROCPROFSYS_TEST_DIR` | Path to test package directory or .pyz file | Auto-detected |
 | `ROCPROFSYS_TEST_EXECUTABLE` | Python (install mode) or pytest (build mode) executable to use | Auto-detected |
 | `ROCPROFSYS_PYTHON_HINTS` | Additional search paths for versioned Python interpreters | Not set |

--- a/projects/rocprofiler-systems/tests/pytest/DEVELOPMENT.md
+++ b/projects/rocprofiler-systems/tests/pytest/DEVELOPMENT.md
@@ -43,7 +43,7 @@ Contains wrappers for the validation scripts and other helper functions that can
 These fixtures run as **subtests**, meaning multiple validations within a single test are independently reported (one can fail without blocking others). They are automatically injected into `RocprofsysTest` via its `_setup` fixture, so test methods access them as `self.assert_regex(...)`, `self.assert_perfetto(...)`, etc.
 
 | Fixture | Description |
-|---------|-------------|
+| --------- | ------------- |
 | `assert_regex` | Validates test output against pass/fail regex patterns. Patterns can be per-mode (e.g., different patterns for `binary_rewrite` vs `sampling`). |
 | `assert_file_regex` | Like `assert_regex` but validates against a file's contents. |
 | `assert_perfetto` | Validates that a Perfetto trace was generated and optionally checks its contents. |


### PR DESCRIPTION
  ## Motivation
                                                                                                                                                                                                                     
Update GitHub Actions versions for `rocprofiler-systems` workflows to prepare for the [Node.js 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).
                                                                                                                                                                                                                     
  ## Technical Details                                                                                                                                                                                               
                                                                                                                                                                                                                     
  **Action version updates:**                                                                                                                                                                                        
  - `actions/setup-python`: v5 → v6                                    
  - `DavidAnson/markdownlint-cli2-action`: v10.0.1 → v23.1.0 (SHA-pinned)                                                                                                                                            
  - `rojopolis/spellcheck-github-actions`: 0.46.0 → 0.60.0 (SHA-pinned)                                                                                                                                              
                                                                                                                                                                                                                     
  **Markdown tooling:**                                                                                                                                                                                              
  - Add `.markdownlint.yaml` local config mirroring `rocm-docs-core`, so CI no                                                                                                                                       
    longer fetches config at runtime                                                                                                                                                                                 
  - Add `markdownlint-cli2` pre-commit hook for local parity with CI
                                                                                                                                                                                                                     
  **Markdown fixes:**                                                  
  - Fix MD060 (table-column-style) violations across 25 example/test READMEs —                                                                                                                                       
    `markdownlint v0.40` (bundled in cli2-action v23) introduced this rule                                                                                                                                           
  - Fix MD059 (descriptive-link-text) in top-level README (`[here]` → descriptive text)                                                                                                                              
                                                                                                                                                                                                                     
  ## Test Plan                                                                                                                                                                                                       
                                                                                                                                                                                                                     
  - [x] Markdown CI job passes                                                                                                                                                                                       
  - [x] Python linting CI passes                                       
  - [ ] Full build matrix (pending)                                                                                                                                                                                  
                                         

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
