### PR TITLE
clr: Avoid null free for unallocated ROCclr printf buffer

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -2311,9 +2311,6 @@ void* Device::deviceLocalAlloc(size_t size, const AllocationFlags& flags, bool a
 }
 
 void Device::memFree(void* ptr, size_t size) const {
-  if (ptr == nullptr) {
-    return;
-  }
   hsa_status_t stat = Hsa::memory_pool_free(ptr);
   ClPrint(amd::LOG_DEBUG, amd::LOG_MEM, "Free hsa memory %p", ptr);
   if (stat != HSA_STATUS_SUCCESS) {

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -2311,6 +2311,9 @@ void* Device::deviceLocalAlloc(size_t size, const AllocationFlags& flags, bool a
 }
 
 void Device::memFree(void* ptr, size_t size) const {
+  if (ptr == nullptr) {
+    return;
+  }
   hsa_status_t stat = Hsa::memory_pool_free(ptr);
   ClPrint(amd::LOG_DEBUG, amd::LOG_MEM, "Free hsa memory %p", ptr);
   if (stat != HSA_STATUS_SUCCESS) {

--- a/projects/clr/rocclr/device/rocm/rocprintf.cpp
+++ b/projects/clr/rocclr/device/rocm/rocprintf.cpp
@@ -29,7 +29,11 @@ namespace amd::roc {
 PrintfDbg::PrintfDbg(Device& device, FILE* file)
     : dbgBuffer_(nullptr), dbgBuffer_size_(0), dbgFile_(file), gpuDevice_(device) {}
 
-PrintfDbg::~PrintfDbg() { dev().hostFree(dbgBuffer_, dbgBuffer_size_); }
+PrintfDbg::~PrintfDbg() {
+  if (dbgBuffer_ != nullptr) {
+    dev().hostFree(dbgBuffer_, dbgBuffer_size_);
+  }
+}
 
 bool PrintfDbg::allocate(bool realloc) {
   if (nullptr == dbgBuffer_) {


### PR DESCRIPTION
## Motivation

- rocprofv3 memory allocation tracing can report FREE records with address `0` and `null` agent when HIP stream teardown calls into rocclr cleanup paths that eventually invoke `hsa_amd_memory_pool_free(nullptr)`. rocr treats freeing a null pointer as a successful no-op, but forwarding the call to HSA still creates misleading profiler records that look like real memory frees with missing allocation metadata.

## Technical Details

- `PrintfDbg::~PrintfDbg` now checks whether `dbgBuffer_` was allocated before calling `hostFree`.

- This prevents spurious rocprov3 memory allocation records with address = 0 / null agent from paths such as `hipStreamDestroy`, without changing the broader `Device::memFree` behavior for other ROCclr callers.

## JIRA ID

AIPROFSDK-118

## Test Plan

All current CI checks passes.

## Test Result

hip-tests passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
