### PR TITLE
ROCM-23527 - hipMemRetainAllocationHandle should return error for non VMM allocations

### DIFF
--- a/projects/clr/hipamd/src/hip_vm.cpp
+++ b/projects/clr/hipamd/src/hip_vm.cpp
@@ -330,8 +330,14 @@ hipError_t hipMemRetainAllocationHandle(hipMemGenericAllocationHandle_t* handle,
     HIP_RETURN(hipErrorInvalidValue);
   }
 
+  // hipMalloc and other non-VMM allocations do not have phys_mem_obj
+  amd::Memory* phys_mem_obj = mem->getUserData().phys_mem_obj;
+  if (phys_mem_obj == nullptr) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+
   auto ga = reinterpret_cast<hip::GenericAllocation*>(
-      mem->getUserData().phys_mem_obj->getUserData().data);
+      phys_mem_obj->getUserData().data);
   if (ga == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }


### PR DESCRIPTION
## Motivation

hipMemRetainAllocationHandle API was crashing when hipMalloc'd pointers are passed. It should return error gracefully instead.

## Technical Details

For Non VMM allocations, the physical mem obj doesn't exist for the pointers, and hence hipMemRetainAllocationHandle API   should check the phys_mem_obj instead of directly dereferencing it.

## JIRA ID

ROCM-23527

## Test Plan

Verified with the given reproducer.

## Test Result

PASS

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
