### PR TITLE
rocdbgapi: Fix narrowing error in kfd_driver_t::xfer_global_memory_pa…

### DIFF
--- a/projects/rocdbgapi/src/os_driver_kfd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kfd.cpp
@@ -1954,6 +1954,9 @@ kfd_driver_t::xfer_global_memory_partial (global_address_t address, void *read,
 
   ++(read != nullptr ? m_read_request_count : m_write_request_count);
 
+  if (address > std::numeric_limits<off_t>::max ())
+    return AMD_DBGAPI_STATUS_ERROR_MEMORY_ACCESS;
+
   auto offset = utils::narrow<off_t> (address);
   ssize_t ret = read != nullptr
                   ? pread (*m_proc_mem_fd, read, *size, offset)


### PR DESCRIPTION
…rtial

When doing a core dump, the debugger will enumerate all memory mappings, and will try to read each of those.  It is possible for the kernel to map "high addresses" (which when in their canonical fom have all of the top bits to 1).  For example, on a gfx942 system, running a HIP program can show:

    (gdb) info proc mappings
    [...]
    0xffffffffff600000 0xffffffffff601000 0x1000             0x0                --xp  [vsyscall]

When trying to do a coredump for this process, GDB will eventually try to read the data in this mapping.  When doing this while a CPU thread is selected gracefully reports a warning:

    (gdb) gcore
    warning: Memory read failed for corefile section, 4096 bytes at 0xffffffffff600000.
    Saved corefile core.155849

but when doing this when a GPU thread is selected produces an error:

    (gdb) gcore
    fatal error: narrowing error: overflow
    Backtrace:
        #0 0x000074134ade040f long amd::dbgapi::utils::narrow<long, amd::dbgapi::global_address_t>(amd::dbgapi::global_address_t)
        #1 0x000074134add5803 amd::dbgapi::kfd_driver_t::xfer_global_memory_partial(amd::dbgapi::global_address_t, void*, void const*, unsigned long*) const
        #2 0x000074134ac220a1 amd::dbgapi::process_t::xfer_global_memory(amd::dbgapi::global_address_t, void*, void const*, unsigned long) const
        #3 0x000074134ad1aacf amd::dbgapi::process_t::xfer_segment_memory(amd::dbgapi::address_space_t const&, unsigned long, void*, void const*, unsigned long) const
        #4 0x000074134acebbd9 xfer_memory
        ...

This comes from 28586157cf (dbgapi: Add -Wconversion and fix whole dbgapi codebase) which added:

    auto offset = utils::narrow<off_t> (address);

which tries to narrow the address (which is really an unsigned long) to off_t, which is a long (signed).  Given that the top bit of the address is set, such conversion would overflow.

Given that even if we used static_cast, we would end-up with a negative off_t to give to pread/pwrite which would be invalid, detect that the address we try to read is can be represented as an off_t, and gracefully return an error otherwise.