### PR TITLE
[rocprofiler-systems] [fork-runtime-instrument] Prevent `fork()` mid sampling

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
@@ -30,9 +30,9 @@ namespace component
 namespace
 {
 // these are used to prevent handlers from executing multiple times
-bool prefork_lock         = false;
-bool postfork_parent_lock = false;
-bool postfork_child_lock  = false;
+thread_local bool prefork_lock         = false;
+thread_local bool postfork_parent_lock = false;
+thread_local bool postfork_child_lock  = false;
 
 // this does a quick exit (no cleanup) on child processes
 // because perfetto has a tendency to access memory it
@@ -63,7 +63,11 @@ prefork_setup()
                 "may result is segmentation fault");
     // TIMEMORY_CONDITIONAL_DEMANGLED_BACKTRACE(get_debug_env(), 16);
 
-    if(config::get_use_sampling()) sampling::block_samples();
+    if(config::get_use_sampling())
+    {
+        sampling::block_samples();
+        sampling::prefork_lock_pmc_sampler();
+    }
 
     rocprofsys::categories::disable_categories(config::get_enabled_categories());
 
@@ -81,7 +85,11 @@ postfork_parent()
     // Reinitialize AMD SMI in parent process to get fresh device handles before
     // unblocking the shutdown/setup transition. AMD SMI device handles may be corrupted
     // after fork.
-    if(config::get_use_sampling()) sampling::postfork_parent_reinit();
+    if(config::get_use_sampling())
+    {
+        sampling::postfork_parent_unlock_pmc_sampler();
+        sampling::postfork_parent_reinit();
+    }
 
     rocprofsys::categories::enable_categories(config::get_enabled_categories());
 
@@ -107,7 +115,11 @@ postfork_child()
     set_state(State::Finalized);
 
     // Clean up AMD SMI in child process before other shutdowns
-    if(config::get_use_sampling()) sampling::postfork_child_cleanup();
+    if(config::get_use_sampling())
+    {
+        sampling::postfork_child_reset_pmc_sampler_lock();
+        sampling::postfork_child_cleanup();
+    }
 
     settings::enabled() = false;
     settings::verbose() = -127;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
@@ -87,8 +87,8 @@ postfork_parent()
     // after fork.
     if(config::get_use_sampling())
     {
-        sampling::postfork_parent_unlock_pmc_sampler();
         sampling::postfork_parent_reinit();
+        sampling::postfork_parent_unlock_pmc_sampler();
     }
 
     rocprofsys::categories::enable_categories(config::get_enabled_categories());

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.cpp
@@ -38,6 +38,8 @@
 
 #include <cassert>
 #include <memory>
+#include <mutex>
+#include <new>
 #include <sys/resource.h>
 #include <vector>
 
@@ -291,6 +293,37 @@ postfork_parent_reinit()
     // internally calls fork(), which would re-enter the postfork handler
     // chain while glibc still holds __fork_lock. Defer to next sample().
     g_reinit_pending.store(true);
+}
+
+void
+prefork_lock_sampler()
+{
+    // A raw lock must be used, as we must lock in one function and unlock in another
+    // Thread that calls this should use postfork_parent_unlock_sampler()
+    // Child that inherits the locked mutex needs to use
+    // postfork_child_reset_sampler_lock()
+    type_mutex<category::amd_smi>().lock();
+}
+
+void
+postfork_parent_unlock_sampler()
+{
+    // Same kernel tid as thread that called prefork_lock_sampler(),
+    // so the unlock succeeds
+    type_mutex<category::amd_smi>().unlock();
+}
+
+void
+postfork_child_reset_sampler_lock()
+{
+    // Overwrite the existing mutex with a new one of the same type (placement-new)
+    // We cannot unlock it in the child as it has been locked by the parent and has a
+    // different kernel TID then what was used to lock it. Destructor cannot be used
+    // either, as on a locked mutex, it is undefined behaviour
+    using mutex_type =
+        std::remove_reference<decltype(type_mutex<category::amd_smi>())>::type;
+    auto& _m = type_mutex<category::amd_smi>();
+    ::new(static_cast<void*>(&_m)) mutex_type{};
 }
 
 }  // namespace rocprofsys::pmc

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.hpp
@@ -38,4 +38,13 @@ postfork_child_cleanup();
 void
 postfork_parent_reinit();
 
+void
+prefork_lock_sampler();
+
+void
+postfork_parent_unlock_sampler();
+
+void
+postfork_child_reset_sampler_lock();
+
 }  // namespace rocprofsys::pmc

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
@@ -1939,6 +1939,27 @@ postfork_child_cleanup()
 }
 
 void
+prefork_lock_pmc_sampler()
+{
+    if(config::get_use_process_sampling() && config::get_use_amd_smi())
+        pmc::prefork_lock_sampler();
+}
+
+void
+postfork_parent_unlock_pmc_sampler()
+{
+    if(config::get_use_process_sampling() && config::get_use_amd_smi())
+        pmc::postfork_parent_unlock_sampler();
+}
+
+void
+postfork_child_reset_pmc_sampler_lock()
+{
+    if(config::get_use_process_sampling() && config::get_use_amd_smi())
+        pmc::postfork_child_reset_sampler_lock();
+}
+
+void
 pause()
 {
     bool _expected = false;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.hpp
@@ -54,6 +54,15 @@ void
 postfork_child_cleanup();
 
 void
+prefork_lock_pmc_sampler();
+
+void
+postfork_parent_unlock_pmc_sampler();
+
+void
+postfork_child_reset_pmc_sampler_lock();
+
+void
 pause();
 
 void


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

`fork-runtime-instrument` is failing sporadically on both `TheRock` and on `rocm-systems`.

The root cause is heap corruption. `rocprofiler-systems` was calling `fork()` from a multi-threaded parent while the PMC sampler thread could be mid `fmt::format()` building `procfs` CPU `sysfs` path strings inside `pmc::sample()` (recall that sampling is disabled in a fork child, but not in the parent). The child inherited malloc arenas in an inconsistent state, where the string path allocation collided with the chunk holding `g_gpu_collector`. So during PMC sampler shutdown, it was walking down a corrupted list, causing a `SIGSEV`.

TLDR: If `fork` is called when we are mid sampling, things get corrupted.

**Solution**: The proposed solution is to block a `fork()` `syscall` until the sampler is done a single execution of `pmc::sample` (at which point `fork()` occurs, and during this, we block sampling)
 - Acquire the `type_mutex<category::amd_smi>` that is used to serialize `pmc::setup/shutdown/sample/pause` in the fork-calling thread. Do this at the `prefork` level so that the `fork()` is blocked.
 - Once the mutex is unlocked, acquire the lock and perform the `fork()` `syscall`, keeping ownership of the lock until all is done. 

When the `fork()` completes, the child will inherit a locked `amd_smi` mutex, which is *technically* fine as sampling is disabled. But incase the child itself needs to fork again, we need to "unlock" this mutex. To do so, we must replace it with a new one of the same type:
- We can't unlock it, as its owned by another TID
- We can't call its destructor on it, as calling a destructor on a locked mutex is undefined behavior per POSIX.

We use placement new. Essentially, construct an object at this exact address. In this case, we construct the same mutex (but unlocked) at the address of the locked one. This should be safe as the child has exactly one thread at this moment.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Make
`prefork_lock`, `postfork_parent_lock` and `postfork_child_lock` `thread_local`.
Add:
 - `prefork_lock_sampler()` = raw `lock()` on `type_mutex<category::amd_smi>()` that blocks the fork-calling thread until the sampler is idle.
 - `postfork_parent_unlock_sampler()` = raw `unlock()` from the parent's surviving thread (same kernel tid as the locker).
 - `postfork_child_reset_sampler_lock()` = resh mutex over the same storage (via placement-new), since the child's surviving thread can't `unlock()` a recursive mutex it didn't lock.
 - `sampling::prefork_lock_pmc_sampler()` / `postfork_parent_unlock_pmc_sampler()` / `postfork_child_reset_pmc_sampler_lock()` gate the corresponding `pmc::*` calls on `get_use_process_sampling() && get_use_amd_smi()`, mirroring the existing `postfork_parent_reinit` /` postfork_child_cleanup` pattern.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

AIPROFSYST-449
Part of AIPROFSYST-441
AIPROFSYST-208 (I have not observed any hangs in my ~650 runs of `fork-runtime-instrument`)

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Run:
```
i=0; while ctest --test-dir rocprof-sys-build -R fork-runtime-instrument; do i=$((i+1)); echo "=== PASS #$i ==="; done; echo "FAILED on iteration #$((i+1))"
```
For as long as I can.

## Test Result

<!-- Briefly summarize test outcomes. -->

After ~650 runs, not a single failure observed.

Edit: After 82 runs of running ALL `fork.*` tests, `fork-hipmallocconcurrencymproc-runtime-instrument` failed once. The odd part is that the WHOLE test ran, I even saw `Validation PASSED for gpu 0 from pid 3203472`, but the `returncode` is 0. Worth noting that `[rocprof-sys][exe] End of rocprof-sys` appears BEFORE the validation message... suggesting another, deeper issue, that is unrelated to this fix. `fork-runtime-instrument` passes fine. This new failure will be handled elsewhere

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
