### PR TITLE
[AMD-SMI] Add amdsmi_get_afids_from_cper to Python API init

### DIFF
--- a/projects/amdsmi/py-interface/__init__.py
+++ b/projects/amdsmi/py-interface/__init__.py
@@ -172,6 +172,7 @@ from .amdsmi_interface import amdsmi_get_gpu_board_info
 from .amdsmi_interface import amdsmi_get_gpu_ras_feature_info
 from .amdsmi_interface import amdsmi_get_gpu_ras_block_features_enabled
 from .amdsmi_interface import amdsmi_get_gpu_cper_entries
+from .amdsmi_interface import amdsmi_get_afids_from_cper
 from .amdsmi_interface import amdsmi_gpu_validate_ras_eeprom
 
 # # Unsupported Functions In Virtual Environment


### PR DESCRIPTION
## Motivation

There is an API missing in the python project file and is not being exported properly

## Technical Details

Add the missing cper API to the project file __init__.py