### PR TITLE
[rocprofiler-systems] align registration names with sampler emit site

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/cache_policy.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/cache_policy.hpp
@@ -23,12 +23,6 @@
 namespace rocprofsys::pmc::collectors::cpu
 {
 
-/**
- * @brief Output policy for writing CPU PMC samples to the trace cache.
- *
- * Handles registration of CPU-specific metadata (tracks, PMC info)
- * and serialization of CPU metric samples into the trace cache.
- */
 struct cache_policy
 {
     static void initialize_category_metadata()
@@ -37,23 +31,8 @@ struct cache_policy
             trait::name<category::cpu_freq>::value);
     }
 
-    static void initialize_tracks_metadata()
-    {
-        // Per-cpu cpu_frequency and cpu_load tracks are registered in
-        // initialize_pmc_metadata once the per-socket monitored_cpus set is
-        // known. The sampler at rocpd_processor.cpp:633-655 emits the
-        // per-cpu format "<base> [<device_id>] Core [<cpu_id>]"; that is
-        // also what we register on the receiving side.
-    }
+    static void initialize_tracks_metadata() {}
 
-    /**
-     * @brief Initialize per-CPU PMC metadata entries.
-     *
-     * @param socket_id Socket (physical package) ID for agent registration.
-     * @param monitored_cpus Set of CPU IDs being monitored on this socket.
-     * @param is_first_socket True if this is the first selected socket;
-     *        process-level metrics are registered only once, under this socket.
-     */
     static void initialize_pmc_metadata(size_t                  socket_id,
                                         const std::set<size_t>& monitored_cpus,
                                         bool                    is_first_socket)
@@ -66,10 +45,6 @@ struct cache_policy
         constexpr const char* EXPRESSION       = "";
         constexpr const char* TARGET_ARCH      = "CPU";
 
-        // Names registered here MUST match the names emitted by the sampler in
-        // rocpd_processor.cpp (lines 595-656). The sampler uses
-        // trait::name<category::*>::value; using those traits here keeps the
-        // two sites in sync. See AIPROFSYST-445.
         using ::tim::trait::name;
 
         const std::string freq_base = name<category::cpu_freq>::value;
@@ -98,7 +73,6 @@ struct cache_policy
                 { load_name, std::nullopt, "{}" });
         }
 
-        // Process-level metrics are process-wide; register under first selected socket
         if(!is_first_socket) return;
 
         auto add_process_pmc = [&](const char* metric_name, const char* symbol,
@@ -139,20 +113,9 @@ struct cache_policy
                         rocprofsys::trace_cache::ABSOLUTE);
     }
 
-    /**
-     * @brief Store a CPU PMC sample to the trace cache.
-     *
-     * Thread-safety: store_sample is called only from the sampler thread,
-     * serialized by type_mutex<category::amd_smi> in pmc::sample/pause.
-     * The static s_zero_entries is safe under this single-writer invariant.
-     *
-     * @param device_id Socket (physical package) ID.
-     * @param device_name Device name (unused for CPU).
-     * @param enabled_metrics_cfg Metrics enabled by configuration.
-     * @param supported_metrics Metrics supported by the device.
-     * @param metric_values Collected metric values.
-     * @param timestamp Sample timestamp in nanoseconds.
-     */
+    // Single-writer: called only from the sampler thread, serialized by
+    // type_mutex<category::amd_smi> in pmc::sample/pause. Required for the
+    // static s_zero_entries cache in get_effective_cpu_data.
     static void store_sample(size_t device_id, const std::string& /*device_name*/,
                              const enabled_metrics& enabled_metrics_cfg,
                              const enabled_metrics& supported_metrics,
@@ -170,14 +133,9 @@ struct cache_policy
     }
 
 private:
-    /**
-     * @brief Return cpu_data from the metrics, or cached zero entries on pause.
-     *
-     * During normal sampling, cpu_data is non-empty and we cache the CPU IDs.
-     * During pause, base::collector creates metrics_t{} which has empty cpu_data.
-     * In that case, we return zero entries for all previously-seen CPU IDs so
-     * that Perfetto counter tracks drop to zero.
-     */
+    // On pause, base::collector hands us metrics_t{} with empty cpu_data; emit
+    // zero entries for previously-seen CPU IDs so Perfetto tracks drop to zero
+    // instead of going stale.
     static const std::vector<per_cpu_metrics>& get_effective_cpu_data(
         const metrics& metric_values)
     {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/cache_policy.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/cache_policy.hpp
@@ -37,6 +37,8 @@ struct cache_policy
             trait::name<category::cpu_freq>::value);
     }
 
+    // Required by base::collector contract; per-cpu tracks need monitored_cpus
+    // and are registered in initialize_pmc_metadata instead.
     static void initialize_tracks_metadata() {}
 
     /**

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/cache_policy.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/cache_policy.hpp
@@ -54,16 +54,16 @@ struct cache_policy
                                         const std::set<size_t>& monitored_cpus,
                                         bool                    is_first_socket)
     {
-        constexpr size_t      event_code       = 0;
-        constexpr size_t      instance_id      = 0;
-        constexpr const char* long_description = "";
-        constexpr const char* component        = "";
-        constexpr const char* block            = "";
-        constexpr const char* expression       = "";
-        constexpr const char* target_arch      = "CPU";
-        constexpr uint32_t    is_constant      = 0;
-        constexpr uint32_t    is_derived       = 0;
-        constexpr const char* extdata          = "{}";
+        constexpr size_t        event_code       = 0;
+        constexpr size_t        instance_id      = 0;
+        constexpr const char*   long_description = "";
+        constexpr const char*   component        = "";
+        constexpr const char*   block            = "";
+        constexpr const char*   expression       = "";
+        constexpr const char*   target_arch      = "CPU";
+        constexpr std::uint32_t is_constant      = 0;
+        constexpr std::uint32_t is_derived       = 0;
+        constexpr const char*   extdata          = "{}";
 
         using ::tim::trait::name;
         auto& registry = trace_cache::get_metadata_registry();
@@ -194,10 +194,10 @@ struct cache_policy
 
         const auto& cpu_data = get_effective_cpu_data(metric_values);
 
-        assert(device_id <= std::numeric_limits<uint32_t>::max() &&
+        assert(device_id <= std::numeric_limits<std::uint32_t>::max() &&
                "socket id exceeds cpu_pmc_sample::device_id width");
         trace_cache::get_buffer_storage().store(trace_cache::cpu_pmc_sample{
-            effective, static_cast<uint32_t>(device_id), timestamp,
+            effective, static_cast<std::uint32_t>(device_id), timestamp,
             metric_values.process_data, serialize_frequencies(cpu_data),
             serialize_loads(cpu_data) });
     }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/cache_policy.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/cache_policy.hpp
@@ -12,9 +12,10 @@
 
 #include <spdlog/fmt/fmt.h>
 
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
+#include <limits>
 #include <optional>
 #include <set>
 #include <string>
@@ -53,53 +54,93 @@ struct cache_policy
                                         const std::set<size_t>& monitored_cpus,
                                         bool                    is_first_socket)
     {
-        constexpr size_t      EVENT_CODE       = 0;
-        constexpr size_t      INSTANCE_ID      = 0;
-        constexpr const char* LONG_DESCRIPTION = "";
-        constexpr const char* COMPONENT        = "";
-        constexpr const char* BLOCK            = "";
-        constexpr const char* EXPRESSION       = "";
-        constexpr const char* TARGET_ARCH      = "CPU";
+        constexpr size_t      event_code       = 0;
+        constexpr size_t      instance_id      = 0;
+        constexpr const char* long_description = "";
+        constexpr const char* component        = "";
+        constexpr const char* block            = "";
+        constexpr const char* expression       = "";
+        constexpr const char* target_arch      = "CPU";
+        constexpr uint32_t    is_constant      = 0;
+        constexpr uint32_t    is_derived       = 0;
+        constexpr const char* extdata          = "{}";
 
         using ::tim::trait::name;
+        auto& registry = trace_cache::get_metadata_registry();
 
         const std::string freq_base = name<category::cpu_freq>::value;
         const std::string load_base = name<category::cpu_load>::value;
 
-        for(const auto cpu_id : monitored_cpus)
+        for(const size_t cpu_id : monitored_cpus)
         {
             const auto freq_name =
                 fmt::format("{} [{}] Core [{}]", freq_base, socket_id, cpu_id);
-            trace_cache::get_metadata_registry().add_pmc_info(
-                { agent_type::CPU, socket_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
-                  freq_name.c_str(), freq_name.c_str(), "CPU Core Frequency",
-                  LONG_DESCRIPTION, COMPONENT, "MHz", rocprofsys::trace_cache::ABSOLUTE,
-                  BLOCK, EXPRESSION, 0, 0, "{}" });
-            trace_cache::get_metadata_registry().add_track(
-                { freq_name, std::nullopt, "{}" });
+            registry.add_pmc_info(
+                { /* type             = */ agent_type::CPU,
+                  /* agent_type_index = */ socket_id,
+                  /* target_arch      = */ target_arch,
+                  /* event_code       = */ event_code,
+                  /* instance_id      = */ instance_id,
+                  /* name             = */ freq_name.c_str(),
+                  /* symbol           = */ freq_name.c_str(),
+                  /* description      = */ "CPU Core Frequency",
+                  /* long_description = */ long_description,
+                  /* component        = */ component,
+                  /* units            = */ "MHz",
+                  /* value_type       = */ rocprofsys::trace_cache::ABSOLUTE,
+                  /* block            = */ block,
+                  /* expression       = */ expression,
+                  /* is_constant      = */ is_constant,
+                  /* is_derived       = */ is_derived,
+                  /* extdata          = */ extdata });
+            registry.add_track({ freq_name, std::nullopt, extdata });
 
             const auto load_name =
                 fmt::format("{} [{}] Core [{}]", load_base, socket_id, cpu_id);
-            trace_cache::get_metadata_registry().add_pmc_info(
-                { agent_type::CPU, socket_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
-                  load_name.c_str(), load_name.c_str(), "CPU Core Load Percentage",
-                  LONG_DESCRIPTION, COMPONENT, trace_cache::PERCENTAGE,
-                  rocprofsys::trace_cache::ABSOLUTE, BLOCK, EXPRESSION, 0, 0, "{}" });
-            trace_cache::get_metadata_registry().add_track(
-                { load_name, std::nullopt, "{}" });
+            registry.add_pmc_info(
+                { /* type             = */ agent_type::CPU,
+                  /* agent_type_index = */ socket_id,
+                  /* target_arch      = */ target_arch,
+                  /* event_code       = */ event_code,
+                  /* instance_id      = */ instance_id,
+                  /* name             = */ load_name.c_str(),
+                  /* symbol           = */ load_name.c_str(),
+                  /* description      = */ "CPU Core Load Percentage",
+                  /* long_description = */ long_description,
+                  /* component        = */ component,
+                  /* units            = */ trace_cache::PERCENTAGE,
+                  /* value_type       = */ rocprofsys::trace_cache::ABSOLUTE,
+                  /* block            = */ block,
+                  /* expression       = */ expression,
+                  /* is_constant      = */ is_constant,
+                  /* is_derived       = */ is_derived,
+                  /* extdata          = */ extdata });
+            registry.add_track({ load_name, std::nullopt, extdata });
         }
 
         if(!is_first_socket) return;
 
-        auto add_process_pmc = [&](const char* metric_name, const char* symbol,
-                                   const char* description, const char* units,
-                                   const char* value_type) {
-            trace_cache::get_metadata_registry().add_pmc_info(
-                { agent_type::CPU, socket_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
-                  metric_name, symbol, description, LONG_DESCRIPTION, COMPONENT, units,
-                  value_type, BLOCK, EXPRESSION, 0, 0, "{}" });
-            trace_cache::get_metadata_registry().add_track(
-                { metric_name, std::nullopt, "{}" });
+        auto add_process_pmc = [&, socket_id](const char* metric_name, const char* symbol,
+                                              const char* description, const char* units,
+                                              const char* value_type) {
+            registry.add_pmc_info({ /* type             = */ agent_type::CPU,
+                                    /* agent_type_index = */ socket_id,
+                                    /* target_arch      = */ target_arch,
+                                    /* event_code       = */ event_code,
+                                    /* instance_id      = */ instance_id,
+                                    /* name             = */ metric_name,
+                                    /* symbol           = */ symbol,
+                                    /* description      = */ description,
+                                    /* long_description = */ long_description,
+                                    /* component        = */ component,
+                                    /* units            = */ units,
+                                    /* value_type       = */ value_type,
+                                    /* block            = */ block,
+                                    /* expression       = */ expression,
+                                    /* is_constant      = */ is_constant,
+                                    /* is_derived       = */ is_derived,
+                                    /* extdata          = */ extdata });
+            registry.add_track({ metric_name, std::nullopt, extdata });
         };
 
         add_process_pmc(name<category::process_page>::value, "Page RSS",
@@ -153,6 +194,8 @@ struct cache_policy
 
         const auto& cpu_data = get_effective_cpu_data(metric_values);
 
+        assert(device_id <= std::numeric_limits<uint32_t>::max() &&
+               "socket id exceeds cpu_pmc_sample::device_id width");
         trace_cache::get_buffer_storage().store(trace_cache::cpu_pmc_sample{
             effective, static_cast<uint32_t>(device_id), timestamp,
             metric_values.process_data, serialize_frequencies(cpu_data),
@@ -163,10 +206,14 @@ private:
     /**
      * @brief Return cpu_data from the metrics, or cached zero entries on pause.
      *
-     * During normal sampling, cpu_data is non-empty and we cache the CPU IDs.
-     * During pause, base::collector creates metrics_t{} which has empty cpu_data.
-     * In that case, we return zero entries for all previously-seen CPU IDs so
-     * that Perfetto counter tracks drop to zero.
+     * During normal sampling, cpu_data is non-empty and we refresh the cached
+     * zero set only when the CPU set changes (size or first/last cpu_id
+     * differs). During pause, base::collector creates metrics_t{} with empty
+     * cpu_data; we return the cached zero set so Perfetto counter tracks drop
+     * to zero.
+     *
+     * @warning The returned reference is valid only until the next call to
+     *          get_effective_cpu_data on this thread.
      */
     static const std::vector<per_cpu_metrics>& get_effective_cpu_data(
         const metrics& metric_values)
@@ -175,11 +222,20 @@ private:
 
         if(!metric_values.cpu_data.empty())
         {
-            s_zero_entries.clear();
-            s_zero_entries.reserve(metric_values.cpu_data.size());
-            for(const auto& cpu : metric_values.cpu_data)
-                s_zero_entries.push_back({ cpu.cpu_id, 0.0f, 0.0 });
-            return metric_values.cpu_data;
+            const auto& src = metric_values.cpu_data;
+            const bool  set_changed =
+                s_zero_entries.size() != src.size() ||
+                (!s_zero_entries.empty() &&
+                 (s_zero_entries.front().cpu_id != src.front().cpu_id ||
+                  s_zero_entries.back().cpu_id != src.back().cpu_id));
+            if(set_changed)
+            {
+                s_zero_entries.clear();
+                s_zero_entries.reserve(src.size());
+                for(const auto& cpu : src)
+                    s_zero_entries.push_back({ cpu.cpu_id, 0.0f, 0.0 });
+            }
+            return src;
         }
         return s_zero_entries;
     }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/cache_policy.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/cache_policy.hpp
@@ -23,6 +23,12 @@
 namespace rocprofsys::pmc::collectors::cpu
 {
 
+/**
+ * @brief Output policy for writing CPU PMC samples to the trace cache.
+ *
+ * Handles registration of CPU-specific metadata (tracks, PMC info)
+ * and serialization of CPU metric samples into the trace cache.
+ */
 struct cache_policy
 {
     static void initialize_category_metadata()
@@ -33,6 +39,14 @@ struct cache_policy
 
     static void initialize_tracks_metadata() {}
 
+    /**
+     * @brief Initialize per-CPU PMC metadata entries.
+     *
+     * @param socket_id Socket (physical package) ID for agent registration.
+     * @param monitored_cpus Set of CPU IDs being monitored on this socket.
+     * @param is_first_socket True if this is the first selected socket;
+     *        process-level metrics are registered only once, under this socket.
+     */
     static void initialize_pmc_metadata(size_t                  socket_id,
                                         const std::set<size_t>& monitored_cpus,
                                         bool                    is_first_socket)
@@ -113,9 +127,20 @@ struct cache_policy
                         rocprofsys::trace_cache::ABSOLUTE);
     }
 
-    // Single-writer: called only from the sampler thread, serialized by
-    // type_mutex<category::amd_smi> in pmc::sample/pause. Required for the
-    // static s_zero_entries cache in get_effective_cpu_data.
+    /**
+     * @brief Store a CPU PMC sample to the trace cache.
+     *
+     * Thread-safety: store_sample is called only from the sampler thread,
+     * serialized by type_mutex<category::amd_smi> in pmc::sample/pause.
+     * The static s_zero_entries is safe under this single-writer invariant.
+     *
+     * @param device_id Socket (physical package) ID.
+     * @param device_name Device name (unused for CPU).
+     * @param enabled_metrics_cfg Metrics enabled by configuration.
+     * @param supported_metrics Metrics supported by the device.
+     * @param metric_values Collected metric values.
+     * @param timestamp Sample timestamp in nanoseconds.
+     */
     static void store_sample(size_t device_id, const std::string& /*device_name*/,
                              const enabled_metrics& enabled_metrics_cfg,
                              const enabled_metrics& supported_metrics,
@@ -133,9 +158,14 @@ struct cache_policy
     }
 
 private:
-    // On pause, base::collector hands us metrics_t{} with empty cpu_data; emit
-    // zero entries for previously-seen CPU IDs so Perfetto tracks drop to zero
-    // instead of going stale.
+    /**
+     * @brief Return cpu_data from the metrics, or cached zero entries on pause.
+     *
+     * During normal sampling, cpu_data is non-empty and we cache the CPU IDs.
+     * During pause, base::collector creates metrics_t{} which has empty cpu_data.
+     * In that case, we return zero entries for all previously-seen CPU IDs so
+     * that Perfetto counter tracks drop to zero.
+     */
     static const std::vector<per_cpu_metrics>& get_effective_cpu_data(
         const metrics& metric_values)
     {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/cache_policy.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/cache_policy.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "core/categories.hpp"
 #include "core/config.hpp"
 #include "core/trace_cache/cache_manager.hpp"
 #include "core/trace_cache/metadata_registry.hpp"
@@ -38,11 +39,11 @@ struct cache_policy
 
     static void initialize_tracks_metadata()
     {
-        const auto thread_id = std::nullopt;
-
-        trace_cache::get_metadata_registry().add_track(
-            { "cpu_frequency", thread_id, "{}" });
-        trace_cache::get_metadata_registry().add_track({ "cpu_load", thread_id, "{}" });
+        // Per-cpu cpu_frequency and cpu_load tracks are registered in
+        // initialize_pmc_metadata once the per-socket monitored_cpus set is
+        // known. The sampler at rocpd_processor.cpp:633-655 emits the
+        // per-cpu format "<base> [<device_id>] Core [<cpu_id>]"; that is
+        // also what we register on the receiving side.
     }
 
     /**
@@ -50,7 +51,7 @@ struct cache_policy
      *
      * @param socket_id Socket (physical package) ID for agent registration.
      * @param monitored_cpus Set of CPU IDs being monitored on this socket.
-     * @param is_first_socket True if this is the first selected socket —
+     * @param is_first_socket True if this is the first selected socket;
      *        process-level metrics are registered only once, under this socket.
      */
     static void initialize_pmc_metadata(size_t                  socket_id,
@@ -65,55 +66,77 @@ struct cache_policy
         constexpr const char* EXPRESSION       = "";
         constexpr const char* TARGET_ARCH      = "CPU";
 
+        // Names registered here MUST match the names emitted by the sampler in
+        // rocpd_processor.cpp (lines 595-656). The sampler uses
+        // trait::name<category::*>::value; using those traits here keeps the
+        // two sites in sync. See AIPROFSYST-445.
+        using ::tim::trait::name;
+
+        const std::string freq_base = name<category::cpu_freq>::value;
+        const std::string load_base = name<category::cpu_load>::value;
+
         for(const auto cpu_id : monitored_cpus)
         {
-            const auto freq_name = fmt::format("cpu{}_frequency", cpu_id);
+            const auto freq_name =
+                fmt::format("{} [{}] Core [{}]", freq_base, socket_id, cpu_id);
             trace_cache::get_metadata_registry().add_pmc_info(
                 { agent_type::CPU, socket_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
                   freq_name.c_str(), freq_name.c_str(), "CPU Core Frequency",
                   LONG_DESCRIPTION, COMPONENT, "MHz", rocprofsys::trace_cache::ABSOLUTE,
                   BLOCK, EXPRESSION, 0, 0, "{}" });
+            trace_cache::get_metadata_registry().add_track(
+                { freq_name, std::nullopt, "{}" });
 
-            const auto load_name = fmt::format("cpu{}_load", cpu_id);
+            const auto load_name =
+                fmt::format("{} [{}] Core [{}]", load_base, socket_id, cpu_id);
             trace_cache::get_metadata_registry().add_pmc_info(
                 { agent_type::CPU, socket_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
                   load_name.c_str(), load_name.c_str(), "CPU Core Load Percentage",
                   LONG_DESCRIPTION, COMPONENT, trace_cache::PERCENTAGE,
                   rocprofsys::trace_cache::ABSOLUTE, BLOCK, EXPRESSION, 0, 0, "{}" });
+            trace_cache::get_metadata_registry().add_track(
+                { load_name, std::nullopt, "{}" });
         }
 
         // Process-level metrics are process-wide; register under first selected socket
         if(!is_first_socket) return;
 
-        trace_cache::get_metadata_registry().add_pmc_info(
-            { agent_type::CPU, socket_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
-              "process_page_rss", "Page RSS", "Process Physical Memory (RSS)",
-              LONG_DESCRIPTION, COMPONENT, "bytes", rocprofsys::trace_cache::ABSOLUTE,
-              BLOCK, EXPRESSION, 0, 0, "{}" });
+        auto add_process_pmc = [&](const char* metric_name, const char* symbol,
+                                   const char* description, const char* units,
+                                   const char* value_type) {
+            trace_cache::get_metadata_registry().add_pmc_info(
+                { agent_type::CPU, socket_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
+                  metric_name, symbol, description, LONG_DESCRIPTION, COMPONENT, units,
+                  value_type, BLOCK, EXPRESSION, 0, 0, "{}" });
+            trace_cache::get_metadata_registry().add_track(
+                { metric_name, std::nullopt, "{}" });
+        };
 
-        trace_cache::get_metadata_registry().add_pmc_info(
-            { agent_type::CPU, socket_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
-              "process_virt_mem", "Virt Mem", "Process Virtual Memory", LONG_DESCRIPTION,
-              COMPONENT, "bytes", rocprofsys::trace_cache::ABSOLUTE, BLOCK, EXPRESSION, 0,
-              0, "{}" });
+        add_process_pmc(name<category::process_page>::value, "Page RSS",
+                        "Process Physical Memory (RSS)", "MB",
+                        rocprofsys::trace_cache::ABSOLUTE);
 
-        trace_cache::get_metadata_registry().add_pmc_info(
-            { agent_type::CPU, socket_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
-              "process_peak_rss", "Peak RSS", "Process Peak Memory (HWM)",
-              LONG_DESCRIPTION, COMPONENT, "bytes", rocprofsys::trace_cache::ABSOLUTE,
-              BLOCK, EXPRESSION, 0, 0, "{}" });
+        add_process_pmc(name<category::process_virt>::value, "Virt Mem",
+                        "Process Virtual Memory", "MB",
+                        rocprofsys::trace_cache::ABSOLUTE);
 
-        trace_cache::get_metadata_registry().add_pmc_info(
-            { agent_type::CPU, socket_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
-              "process_ctx_switches", "Ctx Switches", "Context Switches",
-              LONG_DESCRIPTION, COMPONENT, "count", rocprofsys::trace_cache::ABSOLUTE,
-              BLOCK, EXPRESSION, 0, 0, "{}" });
+        add_process_pmc(name<category::process_peak>::value, "Peak RSS",
+                        "Process Peak Memory (HWM)", "MB",
+                        rocprofsys::trace_cache::ABSOLUTE);
 
-        trace_cache::get_metadata_registry().add_pmc_info(
-            { agent_type::CPU, socket_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
-              "process_page_faults", "Page Faults", "Page Faults", LONG_DESCRIPTION,
-              COMPONENT, "count", rocprofsys::trace_cache::ABSOLUTE, BLOCK, EXPRESSION, 0,
-              0, "{}" });
+        add_process_pmc(name<category::process_context_switch>::value, "Ctx Switches",
+                        "Context Switches", "count", rocprofsys::trace_cache::ABSOLUTE);
+
+        add_process_pmc(name<category::process_page_fault>::value, "Page Faults",
+                        "Page Faults", "count", rocprofsys::trace_cache::ABSOLUTE);
+
+        add_process_pmc(name<category::process_user_mode_time>::value, "User Time",
+                        "Process CPU Time in User Mode", "sec",
+                        rocprofsys::trace_cache::ABSOLUTE);
+
+        add_process_pmc(name<category::process_kernel_mode_time>::value, "Kernel Time",
+                        "Process CPU Time in Kernel Mode", "sec",
+                        rocprofsys::trace_cache::ABSOLUTE);
     }
 
     /**

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(
 
 target_link_libraries(
     pmc-cpu-collector-tests
-    PUBLIC
+    PRIVATE
         rocprofiler-systems-pmc-library
         rocprofiler-systems-googletest-library
         rocprofiler-systems-logger

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/tests/CMakeLists.txt
@@ -1,7 +1,13 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
-add_library(pmc-cpu-collector-tests OBJECT test_device.cpp test_sample.cpp)
+add_library(
+    pmc-cpu-collector-tests
+    OBJECT
+    test_device.cpp
+    test_sample.cpp
+    test_rocpd_round_trip.cpp
+)
 
 target_link_libraries(
     pmc-cpu-collector-tests
@@ -9,6 +15,8 @@ target_link_libraries(
         rocprofiler-systems-pmc-library
         rocprofiler-systems-googletest-library
         rocprofiler-systems-logger
+        rocprofiler-systems-common-library
+        rocprofiler-systems-user-library
 )
 
 target_include_directories(

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/tests/test_rocpd_round_trip.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/tests/test_rocpd_round_trip.cpp
@@ -9,8 +9,6 @@
 
 #include <gtest/gtest.h>
 
-#include <cstring>
-
 namespace rocprofsys::pmc::collectors::cpu::testing
 {
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/tests/test_rocpd_round_trip.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/tests/test_rocpd_round_trip.cpp
@@ -1,27 +1,9 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 // SPDX-License-Identifier:  MIT
 
-// Regression test for AIPROFSYST-445.
-//
-// PR #4612 split the CPU sampler emit site (rocpd_processor.cpp) and the
-// metadata registration site (cache_policy.hpp) but registered metric names
-// as hard-coded literals while the sampler emits trait::name<category::*>.
-// The two name sets did not overlap, producing
-//   data_processor.cpp:201 "non-existing PMC description"
-//   data_processor.cpp:221 "Unexisting track"
-// on every sample, with empty rocpd_pmc_event rows.
-//
-// Verifying the fix would normally require driving cache_policy and asserting
-// against the global metadata_registry singleton, but pulling
-// cache_manager.hpp into the test brings in perfetto_processor whose object
-// references binary-only symbols (see source/tests/CMakeLists.txt for the
-// reason rocprof-sys-unit-tests deliberately omits the binary library).
-//
-// Instead we pin the trait names that drive both sides of the contract.
-// rocpd_processor.cpp (sampler) and cache_policy.hpp (registration) both
-// look up these traits, so locking the values down here ensures the two
-// sites stay in sync. Any future rename to a category trait without a
-// matching update on both sides will fail this test.
+// Pins the trait::name values that the sampler (rocpd_processor.cpp) and
+// the registration site (cache_policy.hpp) both look up. Renaming a category
+// trait without updating both sides will fail this test.
 
 #include "core/categories.hpp"
 
@@ -73,8 +55,6 @@ TEST(cpu_pmc_name_contract, process_kernel_mode_time_trait_matches_sampler_contr
 
 TEST(cpu_pmc_name_contract, cpu_freq_trait_matches_sampler_contract)
 {
-    // Sampler at rocpd_processor.cpp:633-637 builds per-cpu names as
-    //   "<trait::name<cpu_freq>::value> [<device_id>] Core [<cpu_id>]"
     EXPECT_STREQ(name<category::cpu_freq>::value, "cpu_frequency");
 }
 
@@ -83,10 +63,6 @@ TEST(cpu_pmc_name_contract, cpu_load_trait_matches_sampler_contract)
     EXPECT_STREQ(name<category::cpu_load>::value, "cpu_load");
 }
 
-// Pin the literal-vs-trait contract that broke in AIPROFSYST-445.
-// If anyone ever brings back a hard-coded literal in cache_policy.hpp
-// (e.g. "process_page_rss") this test will catch it: those literals are
-// NOT what the trait resolves to, and the sampler will silently drop rows.
 TEST(cpu_pmc_name_contract, old_pre_fix_literals_do_not_match_traits)
 {
     EXPECT_STRNE(name<category::process_page>::value, "process_page_rss");

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/tests/test_rocpd_round_trip.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/cpu/tests/test_rocpd_round_trip.cpp
@@ -1,0 +1,99 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+
+// Regression test for AIPROFSYST-445.
+//
+// PR #4612 split the CPU sampler emit site (rocpd_processor.cpp) and the
+// metadata registration site (cache_policy.hpp) but registered metric names
+// as hard-coded literals while the sampler emits trait::name<category::*>.
+// The two name sets did not overlap, producing
+//   data_processor.cpp:201 "non-existing PMC description"
+//   data_processor.cpp:221 "Unexisting track"
+// on every sample, with empty rocpd_pmc_event rows.
+//
+// Verifying the fix would normally require driving cache_policy and asserting
+// against the global metadata_registry singleton, but pulling
+// cache_manager.hpp into the test brings in perfetto_processor whose object
+// references binary-only symbols (see source/tests/CMakeLists.txt for the
+// reason rocprof-sys-unit-tests deliberately omits the binary library).
+//
+// Instead we pin the trait names that drive both sides of the contract.
+// rocpd_processor.cpp (sampler) and cache_policy.hpp (registration) both
+// look up these traits, so locking the values down here ensures the two
+// sites stay in sync. Any future rename to a category trait without a
+// matching update on both sides will fail this test.
+
+#include "core/categories.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+namespace rocprofsys::pmc::collectors::cpu::testing
+{
+
+using ::tim::trait::name;
+namespace category = ::tim::category;
+
+TEST(cpu_pmc_name_contract, process_page_trait_matches_sampler_contract)
+{
+    EXPECT_STREQ(name<category::process_page>::value, "process_physical_memory");
+}
+
+TEST(cpu_pmc_name_contract, process_virt_trait_matches_sampler_contract)
+{
+    EXPECT_STREQ(name<category::process_virt>::value, "process_virtual_memory");
+}
+
+TEST(cpu_pmc_name_contract, process_peak_trait_matches_sampler_contract)
+{
+    EXPECT_STREQ(name<category::process_peak>::value, "process_memory_hwm");
+}
+
+TEST(cpu_pmc_name_contract, process_context_switch_trait_matches_sampler_contract)
+{
+    EXPECT_STREQ(name<category::process_context_switch>::value, "process_context_switch");
+}
+
+TEST(cpu_pmc_name_contract, process_page_fault_trait_matches_sampler_contract)
+{
+    EXPECT_STREQ(name<category::process_page_fault>::value, "process_page_fault");
+}
+
+TEST(cpu_pmc_name_contract, process_user_mode_time_trait_matches_sampler_contract)
+{
+    EXPECT_STREQ(name<category::process_user_mode_time>::value, "process_user_cpu_time");
+}
+
+TEST(cpu_pmc_name_contract, process_kernel_mode_time_trait_matches_sampler_contract)
+{
+    EXPECT_STREQ(name<category::process_kernel_mode_time>::value,
+                 "process_kernel_cpu_time");
+}
+
+TEST(cpu_pmc_name_contract, cpu_freq_trait_matches_sampler_contract)
+{
+    // Sampler at rocpd_processor.cpp:633-637 builds per-cpu names as
+    //   "<trait::name<cpu_freq>::value> [<device_id>] Core [<cpu_id>]"
+    EXPECT_STREQ(name<category::cpu_freq>::value, "cpu_frequency");
+}
+
+TEST(cpu_pmc_name_contract, cpu_load_trait_matches_sampler_contract)
+{
+    EXPECT_STREQ(name<category::cpu_load>::value, "cpu_load");
+}
+
+// Pin the literal-vs-trait contract that broke in AIPROFSYST-445.
+// If anyone ever brings back a hard-coded literal in cache_policy.hpp
+// (e.g. "process_page_rss") this test will catch it: those literals are
+// NOT what the trait resolves to, and the sampler will silently drop rows.
+TEST(cpu_pmc_name_contract, old_pre_fix_literals_do_not_match_traits)
+{
+    EXPECT_STRNE(name<category::process_page>::value, "process_page_rss");
+    EXPECT_STRNE(name<category::process_virt>::value, "process_virt_mem");
+    EXPECT_STRNE(name<category::process_peak>::value, "process_peak_rss");
+    EXPECT_STRNE(name<category::process_context_switch>::value, "process_ctx_switches");
+    EXPECT_STRNE(name<category::process_page_fault>::value, "process_page_faults");
+}
+
+}  // namespace rocprofsys::pmc::collectors::cpu::testing


### PR DESCRIPTION
## Motivation

Closes AIPROFSYST-445. PR #4612 (d192aa1e21) introduced a regression: the new CPU PMC collector registers metric names as hard-coded literals while the rocpd_processor sampler emits the same metrics under their `trait::name<category::*>::value` names. The two name sets do not overlap, so `data_processor.cpp:201` and `:221` warn on every sample, and the `rocpd_pmc_event` rows for these metrics are dropped.

## Technical Details

- `source/lib/rocprof-sys/library/pmc/collectors/cpu/cache_policy.hpp`:   registration now uses `trait::name<category::process_*>::value`. 
- Adds `process_user_mode_time` and `process_kernel_mode_time` (previously unregistered, sampler emitted them anyway).
- Per-cpu `cpu_frequency [<dev>] Core [<cpu>]` and `cpu_load [<dev>] Core [<cpu>]` tracks now registered to match the sampler's `get_freq_track_name` / `get_load_track_name` format (`rocpd_processor.cpp:633-655`).
- Each PMC info is registered alongside its track so both `insert_pmc_event` (PMC desc lookup) and `insert_sample` (track lookup) succeed.
- Categories trait names in `categories.hpp:131-137` left unchanged (perfetto path consumes them).
- Unit test added under `source/lib/rocprof-sys/library/pmc/collectors/cpu/tests/` asserting that every name emitted by the sampler resolves to the expected post-fix value, and that the old hard-coded literals do NOT match the traits (catches any regression to the old pattern).

## JIRA

- AIPROFSYST-445

## Test Plan

- New unit test pins the trait-name contract that drives both the sampler emit site and cache_policy registration.

## Test Result

```bash
$ ./bin/rocprof-sys-unit-tests --gtest_filter='cpu_pmc_name_contract.*'
[==========] Running 10 tests from 1 test suite.
...
[==========] 10 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 10 tests.
```

## Checklist

- [x] Pre-commit hooks pass
- [x] No em dash anywhere (ASCII hyphen only)
- [x] Build verified locally
- [x] Unit test added
- [x] Manual stderr grep verified