### PR TITLE
[rocprofiler-compute] Fix --dispatch indexing description in profile docs

### DIFF
--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -581,14 +581,17 @@ substring ``vecCopy``.
 Dispatch filtering
 ^^^^^^^^^^^^^^^^^^
 
-Dispatch filtering is based on the *global* dispatch index of kernels in a run.
+Dispatch filtering selects which iterations of each kernel to profile.
+Indices are 1-based, so the first dispatch of a kernel is ``1``. Each
+value is a positive integer or a ``start:end`` range with
+``start <= end`` (for example, ``1`` or ``3:5``).
 
-The following example profiles only the first kernel dispatch in the execution
-of the application (zero-based indexing).
+The following example profiles the first dispatch of each kernel in the
+application.
 
 .. code-block:: shell-session
 
-   $ rocprof-compute profile --name vcopy -d 0 -- ./vcopy -n 1048576 -b 256
+   $ rocprof-compute profile --name vcopy -d 1 -- ./vcopy -n 1048576 -b 256
 
                                     __                                       _
     _ __ ___   ___ _ __  _ __ ___  / _|       ___ ___  _ __ ___  _ __  _   _| |_ ___
@@ -603,7 +606,7 @@ of the application (zero-based indexing).
    INFO Target: MI325X
    INFO Command: ./vcopy -n 1048576 -b 256
    INFO Kernel Selection: None
-   INFO Dispatch Selection: ['0']
+   INFO Dispatch Selection: ['1']
    INFO Filtered sections: All
    INFO
    INFO ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Motivation

The Dispatch filtering section in the profile-mode docs described `--dispatch` as a global, zero-based index and used `-d 0` in the example. Both are incorrect: the option is 1-based, the rocprof backends reject `0`, and indices are scoped per-kernel. Update the docs to match actual behavior.

## Technical Details

- Rewrite the Dispatch filtering paragraph to describe 1-based per-kernel indexing.
- State the accepted forms: positive integer or `start:end` with `start <= end`.
- Update the worked example from `-d 0` to `-d 1` and the matching `Dispatch Selection` log line.

## JIRA ID

ROCM-24186

## Test Plan

- Sphinx build of the rocprofiler-compute docs renders the updated section without errors.
- Manual read-through of the rendered page.

## Test Result

- [x] Sphinx build clean
- [x] Rendered page reads correctly

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.