### PR TITLE
[rocprofiler-compute] Validate --dispatch indices and guard missing native counter CSV

### DIFF
--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -338,8 +338,9 @@ Examples:
         dest="dispatch",
         required=False,
         help=(
-            "\t\t\tWhich dispatch iterations of the kernel to filter \n"
-            "\t\t\t(e.g. 1 3:5 captures 1st, 3rd, 4th and 5th iterations)."
+            "\t\t\tWhich dispatch iterations of each kernel to filter \n"
+            "\t\t\t(1-based; positive integer or 'start:end' range, \n"
+            "\t\t\te.g. 1 3:5 captures 1st, 3rd, 4th and 5th iterations)."
         ),
     )
     profile_group.add_argument(

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -184,6 +184,18 @@ class RocProfCompute_Base:
                     "options."
                 )
 
+        # Each --dispatch token must be a positive integer or a 'start:end'
+        # range with start <= end (1-based indexing).
+        if args.dispatch:
+            for token in args.dispatch:
+                m = re.fullmatch(r"([1-9]\d*)(?::([1-9]\d*))?", token)
+                if not m or (m.group(2) and int(m.group(2)) < int(m.group(1))):
+                    console_error(
+                        f"Invalid --dispatch value '{token}'. Expected a "
+                        "positive integer or 'start:end' range with "
+                        "start <= end (e.g. 1, 3:5)."
+                    )
+
         # verify correct formatting for application binary
         args.remaining = args.remaining[1:]
         resolved_exec_path: Optional[Path] = None

--- a/projects/rocprofiler-compute/src/utils/utils_profile.py
+++ b/projects/rocprofiler-compute/src/utils/utils_profile.py
@@ -212,10 +212,19 @@ def run_prof(
         ):
             for db_name in glob.glob(workload_dir + "/out/pmc_1/*/*.db"):
                 pid = Path(db_name).stem.split("_")[0]
-                # Read CSV as list of dicts instead of pandas DataFrame
-                counter_rows, _ = csv_ops.read_csv_as_dicts(
-                    f"{workload_dir}/out/pmc_1/{pid}_native_counter_collection.csv"
+                counter_csv = (
+                    Path(workload_dir)
+                    / "out"
+                    / "pmc_1"
+                    / f"{pid}_native_counter_collection.csv"
                 )
+                if not counter_csv.is_file():
+                    console_debug(
+                        f"No native counter CSV for pid {pid}; "
+                        f"skipping rocpd update for {db_name}."
+                    )
+                    continue
+                counter_rows, _ = csv_ops.read_csv_as_dicts(str(counter_csv))
                 rocpd_data.update_rocpd_pmc_events(
                     counter_rows,
                     db_name,

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -1742,6 +1742,28 @@ def test_dispatch_2(binary_handler_profile_rocprof_compute):
     common.clean_output_dir(config["cleanup"], workload_dir)
 
 
+@pytest.mark.dispatch
+@pytest.mark.parametrize(
+    "bad_value",
+    ["0", "-1", "abc", "1:0", "5:3", "1:", ":3", "1:2:3"],
+)
+def test_dispatch_invalid_rejected(binary_handler_profile_rocprof_compute, bad_value):
+    workload_dir = common.get_output_dir(
+        param_id=f"dispatch_{bad_value}".replace(":", "_")
+    )
+    returncode, stdout, stderr = binary_handler_profile_rocprof_compute(
+        config,
+        workload_dir,
+        ["--dispatch", bad_value],
+        check_success=False,
+        capture_output=True,
+    )
+    assert returncode == 1
+    output = stdout + stderr
+    assert f"Invalid --dispatch value '{bad_value}'" in output
+    common.clean_output_dir(config["cleanup"], workload_dir)
+
+
 @pytest.mark.join
 def test_join_type_grid(binary_handler_profile_rocprof_compute):
     options = ["--join-type", "grid"]

--- a/projects/rocprofiler-compute/tests/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/test_profiler_base.py
@@ -31,6 +31,7 @@ def _make_sanitize_args(remaining, torch_trace=False):
         spatial_multiplexing=None,
         remaining=["--"] + remaining,
         torch_trace=torch_trace,
+        dispatch=None,
     )
 
 

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -1082,6 +1082,56 @@ def test_run_prof_success_rocprofiler_sdk(tmp_path, monkeypatch):
     )
 
 
+def test_run_prof_rocpd_skips_pid_without_native_csv(tmp_path, monkeypatch):
+    """run_prof skips per-pid rocpd update when its native counter CSV is missing."""
+    fname = tmp_path / "pmc_perf_test.yaml"
+    fname.write_text("jobs:\n  - pmc:\n    - SQ_WAVES\n")
+    workload_dir = tmp_path / "workload"
+
+    # rocprofiler-sdk backend with native-tool counter collection writes a
+    # per-pid .db here; child pids that never touched the GPU have no CSV.
+    pmc1 = workload_dir / "out" / "pmc_1"
+    (pmc1 / "12345").mkdir(parents=True)
+    (pmc1 / "12345" / "12345.db").touch()
+
+    options = {
+        "APP_CMD": ["./test_app"],
+        "ROCPROF_OUTPUT_PATH": str(workload_dir),
+        "ROCPROF_COUNTER_COLLECTION": "0",  # native tool collects, not SDK
+        "ROCP_TOOL_LIBRARIES": "",
+    }
+
+    update_calls: list = []
+    debug_msgs: list[str] = []
+
+    monkeypatch.setattr("utils.utils_common._rocprof_cmd", "rocprofiler-sdk")
+    monkeypatch.setattr(
+        "utils.utils_profile.capture_subprocess_output",
+        lambda *a, **k: (True, "success"),
+    )
+    monkeypatch.setattr(
+        "utils.utils_profile.rocpd_data.update_rocpd_pmc_events",
+        lambda *a, **k: update_calls.append(a),
+    )
+    monkeypatch.setattr(
+        "utils.utils_profile.rocpd_data.convert_dbs_to_csv",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "utils.utils_profile.console_debug",
+        lambda msg, *a, **k: debug_msgs.append(msg),
+    )
+    monkeypatch.setattr("utils.utils_profile.console_log", lambda *a, **k: None)
+    monkeypatch.setattr("utils.utils_profile.console_warning", lambda *a, **k: None)
+
+    utils_profile.run_prof(
+        str(fname), options, str(workload_dir), logging.INFO, "rocpd"
+    )
+
+    assert update_calls == []
+    assert any("No native counter CSV for pid 12345" in m for m in debug_msgs)
+
+
 def test_run_prof_with_yaml_config(tmp_path, monkeypatch):
     """
     Test run_prof with additional YAML configuration file.


### PR DESCRIPTION
## Motivation

Bugfix: `--dispatch` accepted any string (including `0`, negatives, malformed ranges) and forwarded them to the rocprofv3/rocprofiler-sdkbackends, which silently produced empty profiles. Validate the input in `sanitize()` so users get a clear error.

Bugfix: when a workload spawns child processes that do not use the GPU, the rocpd path produces a `.db` without a matching `native_counter_collection.csv`. Reading the CSV unconditionally raised `FileNotFoundError` and aborted the run.

## Technical Details

- `profiler_base.sanitize()`: regex check on each `--dispatch` token; positive integer or `start:end` with `start <= end`. Fails via `console_error` with the offending value and accepted form.
- `argparser.py`: `-d/--dispatch` help text now states 1-based and the accepted forms.
- `tests/test_profile_general.py`: parametrized `test_dispatch_invalid_rejected` covering 8 invalid inputs; asserts `returncode == 1` and the error message in captured output, matching the existing `capture_output=True` convention.
- `utils_profile.py`: when iterating `*.db` files for the rocpd native-tool path, skip and `console_debug` if the per-pid `native_counter_collection.csv` is absent rather than raising.

## JIRA ID

ROCM-24186

## Test Plan

- `pytest tests/test_profile_general.py -k "dispatch and not invalid"` (existing dispatch tests, GPU required).
- `pytest tests/test_profile_general.py::test_dispatch_invalid_rejected` (new, no GPU required).

## Test Result

- [x] New `test_dispatch_invalid_rejected` passes (8/8 parametrizations, no GPU).
- [x] Existing dispatch tests pass on GPU (`test_dispatch_0`, `test_dispatch_0_1`, `test_dispatch_2`, `test_roof_sort_dispatches`, `test_iteration_multiplexing_insufficient_dispatches`).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.