### PR TITLE
[rocdecode, rocjpeg] added applies to linux label to docs

### DIFF
--- a/projects/rocdecode/docs/conf.py
+++ b/projects/rocdecode/docs/conf.py
@@ -44,6 +44,9 @@ copyright = "Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights r
 version = version_number
 release = version_number
 
+setting_all_article_info = True
+all_article_info_os = ["linux"]
+
 external_toc_path = "./sphinx/_toc.yml"
 
 docs_core = ROCmDocs(left_nav_title)

--- a/projects/rocjpeg/docs/conf.py
+++ b/projects/rocjpeg/docs/conf.py
@@ -23,6 +23,9 @@ copyright = "Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights r
 version = version_number
 release = version_number
 
+setting_all_article_info = True
+all_article_info_os = ["linux"]
+
 external_toc_path = "./sphinx/_toc.yml"
 
 docs_core = ROCmDocs(left_nav_title)


### PR DESCRIPTION
## Motivation

rocdecode and rocjpeg are only available for Linux. Added the label in conf.py so that that's clear.