### PR TITLE
[Documentation] Correct Read the Docs config file path

### DIFF
--- a/projects/amdsmi/.readthedocs.yaml
+++ b/projects/amdsmi/.readthedocs.yaml
@@ -9,10 +9,10 @@ build:
     python: "3.12"
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/amdsmi/docs/conf.py
 
 formats: [htmlzip, pdf]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/amdsmi/docs/sphinx/requirements.txt

--- a/projects/aqlprofile/.readthedocs.yaml
+++ b/projects/aqlprofile/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/aqlprofile/docs/conf.py
 
 formats: [htmlzip]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/aqlprofile/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/hip/.readthedocs.yaml
+++ b/projects/hip/.readthedocs.yaml
@@ -4,16 +4,16 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/hip/docs/conf.py
 
 formats: []
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/hip/docs/sphinx/requirements.txt
 
 conda:
-   environment: docs/environment.yml # needed until ubuntu ships doxygen >= 1.9.8
+   environment: projects/hip/docs/environment.yml # needed until ubuntu ships doxygen >= 1.9.8
 
 build:
    os: ubuntu-22.04

--- a/projects/rccl/.readthedocs.yaml
+++ b/projects/rccl/.readthedocs.yaml
@@ -9,10 +9,10 @@ build:
       python: "3.10"
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/rccl/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/rccl/docs/sphinx/requirements.txt

--- a/projects/rdc/.readthedocs.yaml
+++ b/projects/rdc/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/rdc/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/rdc/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/rocdecode/.readthedocs.yaml
+++ b/projects/rocdecode/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/rocdecode/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/rocdecode/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/rocjpeg/.readthedocs.yaml
+++ b/projects/rocjpeg/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/rocjpeg/docs/conf.py
 
 formats: [htmlzip]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/rocjpeg/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/rocm-smi-lib/.readthedocs.yaml
+++ b/projects/rocm-smi-lib/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/rocm-smi-lib/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/rocm-smi-lib/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/rocminfo/.readthedocs.yaml
+++ b/projects/rocminfo/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: projects/rocminfo/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
   install:
-  - requirements: docs/sphinx/requirements.txt
+  - requirements: projects/rocminfo/docs/sphinx/requirements.txt
 
 build:
   os: ubuntu-22.04

--- a/projects/rocprofiler-compute/.readthedocs.yaml
+++ b/projects/rocprofiler-compute/.readthedocs.yaml
@@ -4,7 +4,7 @@
 version: 2
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: projects/rocprofiler-compute/docs/conf.py
 
 build:
   os: ubuntu-22.04
@@ -13,4 +13,4 @@ build:
 
 python:
   install:
-  - requirements: docs/sphinx/requirements.txt
+  - requirements: projects/rocprofiler-compute/docs/sphinx/requirements.txt

--- a/projects/rocprofiler-sdk/.readthedocs.yaml
+++ b/projects/rocprofiler-sdk/.readthedocs.yaml
@@ -9,16 +9,16 @@ build:
     python: "mambaforge-22.9"
   jobs:
     post_create_environment:
-      - ./source/scripts/update-doxygen.sh
+      - projects/rocprofiler-sdk/source/scripts/update-doxygen.sh
 
 conda:
-  environment: source/docs/environment.yml
+  environment: projects/rocprofiler-sdk/source/docs/environment.yml
 
 python:
   install:
-  - requirements: source/docs/sphinx/requirements.txt
+  - requirements: projects/rocprofiler-sdk/source/docs/sphinx/requirements.txt
 
 sphinx:
-  configuration: source/docs/conf.py
+  configuration: projects/rocprofiler-sdk/source/docs/conf.py
 
 formats: [htmlzip, pdf, epub]

--- a/projects/rocprofiler-systems/.readthedocs.yaml
+++ b/projects/rocprofiler-systems/.readthedocs.yaml
@@ -10,9 +10,9 @@ build:
 
 python:
   install:
-  - requirements: docs/sphinx/requirements.txt
+  - requirements: projects/rocprofiler-systems/docs/sphinx/requirements.txt
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: projects/rocprofiler-systems/docs/conf.py
 
 formats: []

--- a/projects/rocr-runtime/.readthedocs.yaml
+++ b/projects/rocr-runtime/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: runtime/docs/conf.py
+   configuration: projects/rocr-runtime/runtime/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: runtime/docs/sphinx/requirements.txt
+   - requirements: projects/rocr-runtime/runtime/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/rocshmem/.readthedocs.yaml
+++ b/projects/rocshmem/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/rocshmem/docs/conf.py
 
 formats: []
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/rocshmem/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04


### PR DESCRIPTION
## Motivation

`.readthedocs.yml` contains outdated file path from legacy repo. This PR aims to correct them.

## Technical Details

`.readthedocs.yml` indicates the location of conf.py and requirements.txt.

## JIRA ID

Not applicateable

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
