### PR TITLE
HIP: propagate GPU error without clearing global latch

### DIFF
--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -122,9 +122,12 @@ const char* ihipGetErrorName(hipError_t hip_error);
   HIP_CB_SPAWNER_OBJECT(cid);
 
 // This macro should be called at the beginning of every HIP API.
+// Device gpu_error_ is not cleared at API entry; once set by the runtime it stays latched.
+// We only mirror it into TLS for hipGetLastError. We do not return early on GPU error so APIs such
+// as hipStreamWaitEvent are not blocked after an async device failure.
 #define HIP_INIT_API(cid, ...)                                                                     \
   if (amd::Device::IsGPUInError()) {                                                               \
-    HIP_RETURN(ConvertCLErrorIntoHIPError(amd::Device::GetGPUError()));                            \
+    hip::tls.last_error_ = ConvertCLErrorIntoHIPError(amd::Device::GetGPUError());                 \
   }                                                                                                \
   HIP_INIT_API_INTERNAL(0, cid, __VA_ARGS__)                                                       \
   if (hip::g_devices.empty()) {                                                                    \
@@ -137,7 +140,7 @@ const char* ihipGetErrorName(hipError_t hip_error);
 // Version without logging for internal __hip* functions (high frequency, low value logs)
 #define HIP_INIT_API_NOLOG(cid)                                                                    \
   if (amd::Device::IsGPUInError()) {                                                              \
-    HIP_RETURN_NOLOG(ConvertCLErrorIntoHIPError(amd::Device::GetGPUError()));                      \
+    hip::tls.last_error_ = ConvertCLErrorIntoHIPError(amd::Device::GetGPUError());                 \
   }                                                                                                \
   HIP_INIT(0)                                                                                      \
   HIP_CB_SPAWNER_OBJECT(cid);                                                                      \
@@ -146,7 +149,7 @@ const char* ihipGetErrorName(hipError_t hip_error);
   }
 
 // Helper: update thread-local error state from a return code.
-// Overrides with GPU error if the device is in an error state.
+// Global GPU error overrides the per-call return while gpu_error_ remains latched.
 #define HIP_UPDATE_ERROR_STATE(ret)                                                                \
   hip::tls.last_command_error_ = ret;                                                              \
   if (amd::Device::IsGPUInError()) {                                                               \

--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -336,7 +336,7 @@ Context* Device::glb_ctx_ = nullptr;
 std::recursive_mutex Device::p2p_stage_ops_;
 Memory* Device::p2p_stage_ = nullptr;
 
-cl_int Device::gpu_error_ = CL_SUCCESS;
+std::atomic<cl_int> Device::gpu_error_{CL_SUCCESS};
 
 std::shared_mutex MemObjMap::AllocatedLock_ ROCCLR_INIT_PRIORITY(101);
 std::map<uintptr_t, amd::Memory*> MemObjMap::MemObjMap_ ROCCLR_INIT_PRIORITY(101);

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -32,6 +32,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <atomic>
 #include <string>
 #include <vector>
 #include <map>
@@ -1736,7 +1737,7 @@ class Device : public RuntimeObject {
   // Max Scratch size is based on ISA and thus per device.
   // Def value is as per GFX9 being the least among supported devices.
   size_t maxStackSize_ = kMaxStackSize9X;
-  static cl_int gpu_error_;  //!< Store the GPU error cause during kernel launch
+  static std::atomic<cl_int> gpu_error_;  //!< Store the GPU error cause during kernel launch
 
   typedef std::list<CommandQueue*> CommandQueues;
 
@@ -2312,8 +2313,8 @@ class Device : public RuntimeObject {
 #endif
 #endif
 
-  static bool IsGPUInError() { return (gpu_error_ != CL_SUCCESS); }
-  static cl_int GetGPUError() { return gpu_error_; }
+  static bool IsGPUInError() { return (gpu_error_.load(std::memory_order_acquire) != CL_SUCCESS); }
+  static cl_int GetGPUError() { return gpu_error_.load(std::memory_order_acquire); }
 
   bool GetHandleForAddressRange(void* dev_ptr, size_t size, void* handle);
 

--- a/projects/clr/rocclr/platform/commandqueue.cpp
+++ b/projects/clr/rocclr/platform/commandqueue.cpp
@@ -68,7 +68,7 @@ bool HostQueue::terminate() {
             lastCommand = command;
           }
         }
-        if (device_.gpu_error_ == CL_SUCCESS) {
+        if (!amd::Device::IsGPUInError()) {
           lastCommand->awaitCompletion();
         }
         // Note that if lastCommand isn't a marker, it may not be lastEnqueueCommand_ now


### PR DESCRIPTION
Make Device::gpu_error_ a std::atomic<cl_int> so async callbacks and API
threads can access it without data races.

HIP_INIT_API / HIP_INIT_API_NOLOG: if the device is in error, mirror
GetGPUError() into TLS last_error_ for hipGetLastError, but do not clear
gpu_error_ and do not early-return (so APIs such as hipStreamWaitEvent are
not blocked after an async failure).

HIP_UPDATE_ERROR_STATE: while gpu_error_ is latched, override the per-call
return with the converted device error in TLS.

HostQueue::terminate: use IsGPUInError() instead of reading gpu_error_
directly now that it is atomic.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
