### PR TITLE
hipFile: Add docstrings to the higher-level Python API

### DIFF
--- a/projects/hipfile/python/CHANGELOG.md
+++ b/projects/hipfile/python/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the hipFile Python bindings will be documented in this fi
 
 ## [Unreleased]
 
+### Added
+
+- Docstrings for the public Python API.
+
 ## [0.2.0.dev1]
 
 ### Fixed

--- a/projects/hipfile/python/hipfile/__init__.py
+++ b/projects/hipfile/python/hipfile/__init__.py
@@ -1,4 +1,4 @@
-# pylint: disable=C0114
+"""Python bindings for the hipFile GPU-accelerated file I/O library."""
 
 from hipfile._hipfile import (  # pylint: disable=E0401,E0611
     # Constants

--- a/projects/hipfile/python/hipfile/buffer.py
+++ b/projects/hipfile/python/hipfile/buffer.py
@@ -1,4 +1,5 @@
-# pylint: disable=C0114,C0115,C0116
+"""GPU memory buffer registration for hipFile I/O."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -16,22 +17,61 @@ if TYPE_CHECKING:
 
 
 class Buffer:
+    """Manage registration of a GPU memory buffer with hipFile.
+
+    ``Buffer`` does **not** own the underlying GPU allocation; it only
+    manages the hipFile registration lifetime.
+
+    Supports the context-manager protocol for automatic
+    ``register``/``deregister``::
+
+        with Buffer.from_ctypes_void_p(ptr, length, 0) as buf:
+            fh.read(buf, length, 0, 0)
+    """
 
     @classmethod
     def from_ctypes_void_p(
         cls, ctypes_void_p: c_void_p, length: int, flags: int
     ) -> Buffer:
+        """Create a ``Buffer`` from a ``ctypes.c_void_p``.
+
+        Parameters
+        ----------
+        ctypes_void_p : ctypes.c_void_p
+            Pointer to GPU memory.  Must not be null.
+        length : int
+            Size of the buffer in bytes.
+        flags : int
+            Registration flags (pass ``0`` for default behavior).
+
+        Raises
+        ------
+        ValueError
+            If *ctypes_void_p* is null.
+        """
         if ctypes_void_p.value is None:
             raise ValueError("Cannot pass in a null pointer.")
         return cls(ctypes_void_p.value, length, flags)
 
     def __init__(self, buffer_ptr: int, length: int, flags: int) -> None:
+        """Initialize a ``Buffer`` from a raw integer pointer.
+
+        Parameters
+        ----------
+        buffer_ptr : int
+            Integer address of the GPU memory.
+        length : int
+            Size of the buffer in bytes.
+        flags : int
+            Registration flags (pass ``0`` for default behavior).
+        """
         self._buffer_ptr = buffer_ptr
         self._flags = flags
         self._length = length
         self._registered = False
 
     def __del__(self) -> None:
+        """Deregister on garbage collection if still registered."""
         # We did not create the underlying buffer. Don't try to free it.
         try:
             self.deregister()
@@ -41,6 +81,7 @@ class Buffer:
             )
 
     def __enter__(self) -> Buffer:
+        """Register the buffer and return *self*."""
         self.register()
         return self
 
@@ -50,13 +91,24 @@ class Buffer:
         exc: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
+        """Deregister the buffer."""
         self.deregister()
 
     @property
     def ptr(self) -> int:
+        """Integer address of the GPU memory."""
         return self._buffer_ptr
 
     def deregister(self) -> None:
+        """Deregister the buffer from the hipFile driver.
+
+        This is a no-op if the buffer is not currently registered.
+
+        Raises
+        ------
+        HipFileException
+            If the deregistration call fails.
+        """
         if self._registered:
             err = hipFileBufDeregister(self._buffer_ptr)
             if err[0] != 0:
@@ -64,6 +116,13 @@ class Buffer:
             self._registered = False
 
     def register(self) -> None:
+        """Register the buffer with the hipFile driver.
+
+        Raises
+        ------
+        HipFileException
+            If the registration call fails.
+        """
         err = hipFileBufRegister(self._buffer_ptr, self._length, self._flags)
         if err[0] != 0:
             raise HipFileException(err[0], err[1])

--- a/projects/hipfile/python/hipfile/driver.py
+++ b/projects/hipfile/python/hipfile/driver.py
@@ -1,4 +1,5 @@
-# pylint: disable=C0114,C0115,C0116
+"""hipFile driver lifecycle management."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -15,12 +16,26 @@ if TYPE_CHECKING:
 
 
 class Driver:
+    """Manage the hipFile driver lifecycle.
+
+    Wraps the driver open/close calls and supports the
+    context-manager protocol::
+
+        with Driver() as drv:
+            ...  # driver is open
+        # driver is closed
+
+    The driver is reference-counted internally; multiple ``open``
+    calls are balanced by an equal number of ``close`` calls.
+    """
 
     @staticmethod
     def use_count() -> int:
+        """Return the current driver reference count."""
         return hipFileUseCount()
 
     def __enter__(self) -> Driver:
+        """Open the driver and return *self*."""
         self.open()
         return self
 
@@ -30,14 +45,29 @@ class Driver:
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
+        """Close the driver."""
         self.close()
 
     def close(self) -> None:
+        """Close the hipFile driver.
+
+        Raises
+        ------
+        HipFileException
+            If the close call fails.
+        """
         err = hipFileDriverClose()
         if err[0] != 0:
             raise HipFileException(err[0], err[1])
 
     def open(self) -> None:
+        """Open the hipFile driver.
+
+        Raises
+        ------
+        HipFileException
+            If the open call fails.
+        """
         err = hipFileDriverOpen()
         if err[0] != 0:
             raise HipFileException(err[0], err[1])

--- a/projects/hipfile/python/hipfile/enums.py
+++ b/projects/hipfile/python/hipfile/enums.py
@@ -1,4 +1,5 @@
-# pylint: disable=C0114,C0115,C0116
+"""Enumerations mirroring hipFile C types."""
+
 from enum import IntEnum
 
 from hipfile._hipfile import (  # pylint: disable=E0401,E0611

--- a/projects/hipfile/python/hipfile/error.py
+++ b/projects/hipfile/python/hipfile/error.py
@@ -1,4 +1,5 @@
-# pylint: disable=C0114,C0115,C0116
+"""Exception type for hipFile operations."""
+
 from __future__ import annotations
 
 from hipfile._hipfile import hipFileGetOpErrorString  # pylint: disable=E0401,E0611
@@ -6,19 +7,41 @@ from hipfile.enums import OpError
 
 
 class HipFileException(Exception):
+    """Exception raised when a hipFile operation fails.
+
+    Wraps both the ``hipFileOpError_t`` code and, when the error is
+    ``HIP_DRIVER_ERROR``, the underlying ``hipError_t`` from the HIP
+    runtime.
+
+    Parameters
+    ----------
+    hipfile_err : int
+        ``hipFileOpError_t`` value describing the failure.
+    hip_err : int
+        ``hipError_t`` value from the HIP runtime.  Only meaningful
+        when *hipfile_err* equals ``OpError.HIP_DRIVER_ERROR``.
+    """
+
     def __init__(self, hipfile_err: int, hip_err: int) -> None:
         self._hipfile_err = hipfile_err
         self._hip_err = hip_err
 
     @property
     def hipfile_err(self) -> int:
+        """``hipFileOpError_t`` code for this error."""
         return self._hipfile_err
 
     @property
     def hip_err(self) -> int:
+        """``hipError_t`` code from the HIP runtime.
+
+        Only meaningful when ``hipfile_err`` equals
+        ``OpError.HIP_DRIVER_ERROR``.
+        """
         return self._hip_err
 
     def __str__(self) -> str:
+        """Return a human-readable description of the error."""
         err_msg = f"{self._hipfile_err} - {hipFileGetOpErrorString(self._hipfile_err)}"
         if self._hipfile_err == OpError.HIP_DRIVER_ERROR:
             err_msg += f" {self._hip_err}"

--- a/projects/hipfile/python/hipfile/error.py
+++ b/projects/hipfile/python/hipfile/error.py
@@ -12,17 +12,19 @@ class HipFileException(Exception):
     Wraps both the ``hipFileOpError_t`` code and, when the error is
     ``HIP_DRIVER_ERROR``, the underlying ``hipError_t`` from the HIP
     runtime.
-
-    Parameters
-    ----------
-    hipfile_err : int
-        ``hipFileOpError_t`` value describing the failure.
-    hip_err : int
-        ``hipError_t`` value from the HIP runtime.  Only meaningful
-        when *hipfile_err* equals ``OpError.HIP_DRIVER_ERROR``.
     """
 
     def __init__(self, hipfile_err: int, hip_err: int) -> None:
+        """Initialize a ``HipFileException``.
+
+        Parameters
+        ----------
+        hipfile_err : int
+            ``hipFileOpError_t`` value describing the failure.
+        hip_err : int
+            ``hipError_t`` value from the HIP runtime.  Only meaningful
+            when *hipfile_err* equals ``OpError.HIP_DRIVER_ERROR``.
+        """
         self._hipfile_err = hipfile_err
         self._hip_err = hip_err
 

--- a/projects/hipfile/python/hipfile/file.py
+++ b/projects/hipfile/python/hipfile/file.py
@@ -1,4 +1,5 @@
-# pylint: disable=C0114,C0115,C0116
+"""GPU-accelerated file I/O through hipFile."""
+
 from __future__ import annotations
 
 import os
@@ -22,7 +23,21 @@ if TYPE_CHECKING:
 
 
 class FileHandle:
+    """Manage a file descriptor registered with the hipFile driver.
+
+    Wraps ``os.open``/``os.close`` together with hipFile handle
+    registration so that GPU-accelerated reads and writes can be
+    performed through a single object.
+
+    Supports the context-manager protocol for automatic
+    ``open``/``close``::
+
+        with FileHandle(path, os.O_RDONLY | os.O_DIRECT) as fh:
+            fh.read(buf, size, 0, 0)
+    """
+
     DEFAULT_MODE = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
+    """Default file creation mode (``0o644``)."""
 
     def __init__(
         self,
@@ -31,6 +46,24 @@ class FileHandle:
         mode: int = DEFAULT_MODE,
         handle_type: FileHandleType = FileHandleType.OPAQUE_FD,
     ) -> None:
+        """Initialize a ``FileHandle``.
+
+        The file is **not** opened until ``open`` is called (or the
+        context manager is entered).
+
+        Parameters
+        ----------
+        path : str or os.PathLike[str]
+            Filesystem path to open.
+        flags : int
+            Flags passed to ``os.open`` (e.g. ``os.O_RDONLY | os.O_DIRECT``).
+        mode : int, optional
+            Permission bits used when creating a file.  Defaults to
+            ``0o644``.
+        handle_type : FileHandleType, optional
+            Type of handle to register.  Defaults to
+            ``FileHandleType.OPAQUE_FD``.
+        """
         self._fd: int | None = None
         self._flags = flags
         self._handle: int | None = None
@@ -41,6 +74,7 @@ class FileHandle:
         self.handle_type = handle_type
 
     def __del__(self) -> None:
+        """Close on garbage collection if still open."""
         try:
             self.close()
         except Exception:  # pylint: disable=W0718  # Suppress exceptions in a dtor
@@ -50,6 +84,7 @@ class FileHandle:
             )
 
     def __enter__(self) -> FileHandle:
+        """Open the file and return *self*."""
         self.open()
         return self
 
@@ -59,22 +94,37 @@ class FileHandle:
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
+        """Close the file."""
         self.close()
 
     @property
     def flags(self) -> int:
+        """Flags passed to ``os.open``."""
         return self._flags
 
     @property
     def handle(self) -> int | None:
+        """Opaque hipFile handle, or ``None`` if not open."""
         return self._handle
 
     @property
     def handle_type(self) -> FileHandleType | None:
+        """Handle type used for registration."""
         return self._handle_type
 
     @handle_type.setter
     def handle_type(self, _handle_type: FileHandleType) -> None:
+        """Set the handle type.
+
+        Raises
+        ------
+        RuntimeError
+            If the file handle is already open.
+        ValueError
+            If *_handle_type* is not a ``FileHandleType`` member.
+        NotImplementedError
+            If *_handle_type* is ``OPAQUE_WIN32``.
+        """
         if self._handle is not None:
             raise RuntimeError("Cannot modify handle_type while FileHandle is open")
         if _handle_type not in FileHandleType:
@@ -87,13 +137,24 @@ class FileHandle:
 
     @property
     def mode(self) -> int:
+        """File creation permission bits."""
         return self._mode
 
     @property
     def path(self) -> str | os.PathLike[str]:
+        """Filesystem path."""
         return self._path
 
     def open(self) -> None:
+        """Open the file and register it with the hipFile driver.
+
+        Raises
+        ------
+        RuntimeError
+            If the file handle is already open.
+        HipFileException
+            If hipFile handle registration fails.
+        """
         if self._handle is not None:
             raise RuntimeError("The FileHandle is already open.")
         self._fd = os.open(self._path, self._flags, self._mode)
@@ -105,6 +166,10 @@ class FileHandle:
         self._handle = handle
 
     def close(self) -> None:
+        """Deregister the hipFile handle and close the file descriptor.
+
+        Safe to call multiple times; subsequent calls are no-ops.
+        """
         if self._handle is not None:
             hipFileHandleDeregister(self._handle)
             self._handle = None
@@ -115,6 +180,33 @@ class FileHandle:
     def read(
         self, buffer: Buffer, size: int, file_offset: int, buffer_offset: int
     ) -> int:
+        """Read from the file into a GPU buffer.
+
+        Parameters
+        ----------
+        buffer : Buffer
+            GPU buffer to read into.
+        size : int
+            Number of bytes to read.
+        file_offset : int
+            Byte offset within the file to start reading from.
+        buffer_offset : int
+            Byte offset within the GPU buffer to write to.
+
+        Returns
+        -------
+        int
+            Number of bytes actually read.
+
+        Raises
+        ------
+        RuntimeError
+            If the file handle is not open.
+        OSError
+            On a system-level I/O error (wraps ``errno``).
+        HipFileException
+            On a hipFile or HIP driver error.
+        """
         if self._handle is None:
             raise RuntimeError("The FileHandle is not open.")
         bytes_read, extra_err = hipFileRead(
@@ -133,6 +225,33 @@ class FileHandle:
     def write(
         self, buffer: Buffer, size: int, file_offset: int, buffer_offset: int
     ) -> int:
+        """Write from a GPU buffer into the file.
+
+        Parameters
+        ----------
+        buffer : Buffer
+            GPU buffer to read from.
+        size : int
+            Number of bytes to write.
+        file_offset : int
+            Byte offset within the file to start writing to.
+        buffer_offset : int
+            Byte offset within the GPU buffer to read from.
+
+        Returns
+        -------
+        int
+            Number of bytes actually written.
+
+        Raises
+        ------
+        RuntimeError
+            If the file handle is not open.
+        OSError
+            On a system-level I/O error (wraps ``errno``).
+        HipFileException
+            On a hipFile or HIP driver error.
+        """
         if self._handle is None:
             raise RuntimeError("The FileHandle is not open.")
         bytes_written, extra_err = hipFileWrite(

--- a/projects/hipfile/python/hipfile/file.py
+++ b/projects/hipfile/python/hipfile/file.py
@@ -36,8 +36,7 @@ class FileHandle:
             fh.read(buf, size, 0, 0)
     """
 
-    DEFAULT_MODE = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
-    """Default file creation mode (``0o644``)."""
+    DEFAULT_MODE = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH  # 0o644
 
     def __init__(
         self,

--- a/projects/hipfile/python/hipfile/file.py
+++ b/projects/hipfile/python/hipfile/file.py
@@ -191,7 +191,7 @@ class FileHandle:
         file_offset : int
             Byte offset within the file to start reading from.
         buffer_offset : int
-            Byte offset within the GPU buffer to write to.
+            Byte offset within the GPU buffer to read into.
 
         Returns
         -------
@@ -230,13 +230,13 @@ class FileHandle:
         Parameters
         ----------
         buffer : Buffer
-            GPU buffer to read from.
+            GPU buffer to write from.
         size : int
             Number of bytes to write.
         file_offset : int
             Byte offset within the file to start writing to.
         buffer_offset : int
-            Byte offset within the GPU buffer to read from.
+            Byte offset within the GPU buffer to write from.
 
         Returns
         -------

--- a/projects/hipfile/python/hipfile/hipMalloc.py
+++ b/projects/hipfile/python/hipfile/hipMalloc.py
@@ -28,6 +28,18 @@ _hip.hipFree.restype = ctypes.c_int
 
 
 def hipMalloc(size_bytes: int) -> ctypes.c_void_p:
+    """Allocate *size_bytes* of GPU device memory.
+
+    Returns
+    -------
+    ctypes.c_void_p
+        Pointer to the allocated device memory.
+
+    Raises
+    ------
+    RuntimeError
+        If the HIP runtime reports an error.
+    """
     d_ptr = ctypes.c_void_p()
     status = _hip.hipMalloc(ctypes.byref(d_ptr), ctypes.c_size_t(size_bytes))
     if status != 0:
@@ -36,6 +48,13 @@ def hipMalloc(size_bytes: int) -> ctypes.c_void_p:
 
 
 def hipFree(ptr: ctypes.c_void_p) -> None:
+    """Free GPU device memory previously allocated by ``hipMalloc``.
+
+    Raises
+    ------
+    RuntimeError
+        If the HIP runtime reports an error.
+    """
     status = _hip.hipFree(ptr)
     if status != 0:
         raise RuntimeError(f"hipFree failed ({status})")

--- a/projects/hipfile/python/hipfile/properties.py
+++ b/projects/hipfile/python/hipfile/properties.py
@@ -1,4 +1,5 @@
-# pylint: disable=C0114,C0116
+"""Query hipFile driver properties and version information."""
+
 from __future__ import annotations
 
 from hipfile._hipfile import (  # pylint: disable=E0401,E0611
@@ -9,6 +10,18 @@ from hipfile.error import HipFileException
 
 
 def driver_get_properties() -> dict[str, int]:
+    """Return the current hipFile driver properties.
+
+    Returns
+    -------
+    dict[str, int]
+        Property names mapped to their integer values.
+
+    Raises
+    ------
+    HipFileException
+        If the properties query fails.
+    """
     _props, err = hipFileDriverGetProperties()
     if err[0] != 0:
         raise HipFileException(err[0], err[1])
@@ -16,6 +29,18 @@ def driver_get_properties() -> dict[str, int]:
 
 
 def get_version() -> tuple[int, int, int]:
+    """Return the hipFile driver version.
+
+    Returns
+    -------
+    tuple[int, int, int]
+        ``(major, minor, patch)`` version components.
+
+    Raises
+    ------
+    HipFileException
+        If the version query fails.
+    """
     version_tuple, err = hipFileGetVersion()
     if err[0] != 0:
         raise HipFileException(err[0], err[1])


### PR DESCRIPTION
## Motivation
Add NumPy-style docstrings to the hipFile Python bindings' public API. This improves discoverability and IDE IntelliSense support for all exported classes, functions, and properties.

## Technical Details
Added docstrings to every module, class, method, property, and public function in the Pythonic API layer:

__init__.py — module docstring
enums.py — module docstring (class docstrings already existed)
error.py — module, HipFileException class, __init__, hipfile_err/hip_err properties, __str__
buffer.py — module, Buffer class, from_ctypes_void_p, __init__, ptr, register, deregister, context manager, destructor
driver.py — module, Driver class, use_count, open, close, context manager
file.py — module, FileHandle class, __init__, open, close, read, write, all properties including handle_type setter, context manager, destructor
properties.py — module, driver_get_properties, get_version
hipMalloc.py — hipMalloc, hipFree
Removed pylint C0114/C0115/C0116 disable comments from all files where docstrings were added. The hipMalloc.py blanket # pylint: disable=all is retained as it covers non-docstring issues.

Docstring style follows the NumPy convention already established in _hipfile.pyx (Parameters/Returns/Raises sections with underline separators).

## JIRA ID
AIHIPFILE-162

## Test Plan
Ran black --check on all modified files — all pass with no reformatting needed.
Ran pylint on all modified files (excluding hipMalloc.py) — scores 10.00/10 with no new warnings from the removed disable comments.
Docstrings are documentation-only additions; no runtime behavior is changed.

## Test Result
black --check: all 8 files unchanged
pylint: 10.00/10

## Submission Checklist
 Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
