### PR TITLE
[rocshmem] Adding ASAN build support

### DIFF
--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -341,6 +341,7 @@ if (NOT BUILD_TESTS_ONLY)
     ${PROJECT_NAME}
     PUBLIC
       -fgpu-rdc
+      $<$<BOOL:${ASAN}>:-fsanitize=address -g>
     PRIVATE
       -Wall
       -Wextra
@@ -377,16 +378,10 @@ if (NOT BUILD_TESTS_ONLY)
       $<$<BOOL:${ASAN}>:-fsanitize=address -g -shared-libsan>
   )
 
-  target_compile_options(
-    ${PROJECT_NAME}
-    PUBLIC
-      $<$<BOOL:${ASAN}>:-fsanitize=address -g>
-  )
-
-if (ASAN)
-   message(STATUS "Removing xnack- from GPU_TARGET as these are invalid with ASAN address sanitizer")
-   list(FILTER GPU_TARGETS EXCLUDE REGEX ".*:xnack-$")
-endif()
+  if (ASAN)
+    message(STATUS "Removing xnack- from GPU_TARGET as these are invalid with ASAN address sanitizer")
+    list(FILTER GPU_TARGETS EXCLUDE REGEX ".*:xnack-$")
+  endif()
 
   if(${ROCM_MAJOR_VERSION} LESS 7)
     # ROCm 6.x requires us to explicitly enable warp sync builtins

--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -381,6 +381,13 @@ if (NOT BUILD_TESTS_ONLY)
   if (ASAN)
     message(STATUS "Removing xnack- from GPU_TARGET as these are invalid with ASAN address sanitizer")
     list(FILTER GPU_TARGETS EXCLUDE REGEX ".*:xnack-$")
+
+    # Add ASAN runtime directory to RPATH so executables can find libclang_rt.asan at runtime
+    target_link_options(
+      ${PROJECT_NAME}
+      PUBLIC
+        -Wl,-rpath,${ASAN_RUNTIME_DIR}
+    )
   endif()
 
   if(${ROCM_MAJOR_VERSION} LESS 7)

--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -78,6 +78,15 @@ option(BUILD_DEBUG_DEVICE "Compile in device-side logging (LOGD_WARN/INFO and GD
 option(GDA_IONIC "Build for AMD Pensando IONIC RDMA provider" OFF)
 option(GDA_BNXT "Build for Broadcom RDMA provider" OFF)
 option(GDA_MLX5 "Build for Mellanox MLX5 RDMA provider" OFF)
+option(ASAN "Enable AddressSanitizer" OFF)
+
+if (ASAN)
+  execute_process(
+    COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libclang_rt.asan-x86_64.so
+    OUTPUT_VARIABLE ASAN_RUNTIME_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+  get_filename_component(ASAN_RUNTIME_DIR "${ASAN_RUNTIME_PATH}" DIRECTORY)
+  message(STATUS "ASAN runtime directory: ${ASAN_RUNTIME_DIR}")
+endif()
 
 set(USE_EXTERNAL_MPI AUTO CACHE STRING "Link with an external MPI (required if used MPI is ABI incompatible with Open MPI v5)")
 set_property(CACHE USE_EXTERNAL_MPI PROPERTY STRINGS AUTO ON OFF)
@@ -361,6 +370,23 @@ if (NOT BUILD_TESTS_ONLY)
       $<$<NOT:$<BOOL:${FILESYSTEM_NO_LINK_NEEDED}>>:stdc++fs>
       $<$<BOOL:${USE_SDMA}>:hsakmt::hsakmt>
   )
+
+  target_link_options(
+    ${PROJECT_NAME}
+    PUBLIC
+      $<$<BOOL:${ASAN}>:-fsanitize=address -g -shared-libsan>
+  )
+
+  target_compile_options(
+    ${PROJECT_NAME}
+    PUBLIC
+      $<$<BOOL:${ASAN}>:-fsanitize=address -g>
+  )
+
+if (ASAN)
+   message(STATUS "Removing xnack- from GPU_TARGET as these are invalid with ASAN address sanitizer")
+   list(FILTER GPU_TARGETS EXCLUDE REGEX ".*:xnack-$")
+endif()
 
   if(${ROCM_MAJOR_VERSION} LESS 7)
     # ROCm 6.x requires us to explicitly enable warp sync builtins

--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -78,7 +78,7 @@ option(BUILD_DEBUG_DEVICE "Compile in device-side logging (LOGD_WARN/INFO and GD
 option(GDA_IONIC "Build for AMD Pensando IONIC RDMA provider" OFF)
 option(GDA_BNXT "Build for Broadcom RDMA provider" OFF)
 option(GDA_MLX5 "Build for Mellanox MLX5 RDMA provider" OFF)
-option(ASAN "Enable AddressSanitizer" OFF)
+option(ASAN "Enable AddressSanitizer" ${ASAN})
 
 if (ASAN)
   execute_process(

--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -73,6 +73,15 @@ option(BUILD_DEBUG_DEVICE "Compile in device-side logging (LOGD_WARN/INFO and GD
 option(GDA_IONIC "Build for AMD Pensando IONIC RDMA provider" OFF)
 option(GDA_BNXT "Build for Broadcom RDMA provider" OFF)
 option(GDA_MLX5 "Build for Mellanox MLX5 RDMA provider" OFF)
+option(ASAN "Enable AddressSanitizer" OFF)
+
+if (ASAN)
+  execute_process(
+    COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libclang_rt.asan-x86_64.so
+    OUTPUT_VARIABLE ASAN_RUNTIME_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+  get_filename_component(ASAN_RUNTIME_DIR "${ASAN_RUNTIME_PATH}" DIRECTORY)
+  message(STATUS "ASAN runtime directory: ${ASAN_RUNTIME_DIR}")
+endif()
 
 set(USE_EXTERNAL_MPI AUTO CACHE STRING "Link with an external MPI (required if used MPI is ABI incompatible with Open MPI v5)")
 set_property(CACHE USE_EXTERNAL_MPI PROPERTY STRINGS AUTO ON OFF)
@@ -332,6 +341,23 @@ if (NOT BUILD_TESTS_ONLY)
       -fgpu-rdc
       $<$<NOT:$<BOOL:${FILESYSTEM_NO_LINK_NEEDED}>>:stdc++fs>
   )
+
+  target_link_options(
+    ${PROJECT_NAME}
+    PUBLIC
+      $<$<BOOL:${ASAN}>:-fsanitize=address -g -shared-libsan>
+  )
+
+  target_compile_options(
+    ${PROJECT_NAME}
+    PUBLIC
+      $<$<BOOL:${ASAN}>:-fsanitize=address -g>
+  )
+
+if (ASAN)
+   message(STATUS "Removing xnack- from GPU_TARGET as these are invalid with ASAN address sanitizer")
+   list(FILTER GPU_TARGETS EXCLUDE REGEX ".*:xnack-$")
+endif()
 
   if(${ROCM_MAJOR_VERSION} LESS 7)
     # ROCm 6.x requires us to explicitly enable warp sync builtins

--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -313,6 +313,7 @@ if (NOT BUILD_TESTS_ONLY)
     ${PROJECT_NAME}
     PUBLIC
       -fgpu-rdc
+      $<$<BOOL:${ASAN}>:-fsanitize=address -g>
     PRIVATE
       -Wall
       -Wextra
@@ -348,16 +349,10 @@ if (NOT BUILD_TESTS_ONLY)
       $<$<BOOL:${ASAN}>:-fsanitize=address -g -shared-libsan>
   )
 
-  target_compile_options(
-    ${PROJECT_NAME}
-    PUBLIC
-      $<$<BOOL:${ASAN}>:-fsanitize=address -g>
-  )
-
-if (ASAN)
-   message(STATUS "Removing xnack- from GPU_TARGET as these are invalid with ASAN address sanitizer")
-   list(FILTER GPU_TARGETS EXCLUDE REGEX ".*:xnack-$")
-endif()
+  if (ASAN)
+    message(STATUS "Removing xnack- from GPU_TARGET as these are invalid with ASAN address sanitizer")
+    list(FILTER GPU_TARGETS EXCLUDE REGEX ".*:xnack-$")
+  endif()
 
   if(${ROCM_MAJOR_VERSION} LESS 7)
     # ROCm 6.x requires us to explicitly enable warp sync builtins

--- a/projects/rocshmem/DEBUG.md
+++ b/projects/rocshmem/DEBUG.md
@@ -1,0 +1,47 @@
+Hacking and Debugging RocSHMEM
+==============================
+
+This documentation is mostly for core RocSHMEM developpers and contributors. Power users may still find it useful.
+
+How to debug parallel programs
+------------------------------
+
+When using Open MPI as the launch  mechanism, you can use `OMPI_MCA_mpi_abort_delay=-1` to keep parallel processes active after a crash. You can then use `ssh -t $nodename rocgdb -p $pid` to connect a `rocgdb` to the failed process. Sometimes errors are caught by UCX, `UCX_HANDLE_ERRORS=freeze` will have the same effect in such cases.
+
+Look into `scripts/functional_tests/GDB_README` about an alternative technique that deploys multiple `xterm` to gdb into parallel processes.
+
+How to use the address sanitizer (ASAN)
+---------------------------------------
+
+Refer to [General documentation for ASAN on AMD GPUs][1].
+
+### Compiling with ASAN
+
+If this is a fresh build directory, simply add `-DASAN=ON` to the `cmake` invocation.
+  `cmake . <...> -DASAN=ON`
+
+If you are enabling ASAN in a previously used build directory, use `ccmake` to alter the CMake Cache
+  `ccmake .`
+
+In the `ccmake` interface:
+1. find and toggle `ASAN` ON
+2. find and delete `COMPILING_TARGETS` (keybind `d`)
+
+Do not forget to delete `COMPILING_TARGETS` again when disabling ASAN (otherwise xnack will remain required, causing failure in production runs).
+
+### Running with ASAN
+
+You need to set environment variable `HSA_XNACK=1`. Do not forget to unset this variable when not using ASAN (it will impact performance).
+
+You may need to add the path to `libclang_rt.asan-x86_64.so` into `LD_LIBRARY_PATH` by hand. Depending on the ROCm version, it may be in an unusual place, e.g., `$ROCM_ROOT/lib/llvm/lib/clang/19/lib/linux/libclang_rt.asan-x86_64.so`; `find /opt/rocm -name libclang_rt.asan-x86_64.so` may be required to find it.
+
+ASAN may [crash when using Open MPI][2]. If that happens, set environment variable `OMPI_MCA_memory=^patcher`. Do not forget to unset this variable when not using ASAN (it will impact performance).
+
+When running the program, the behavior of ASAN can be controlled with the `ASAN_OPTIONS` environment variable.
+
+you can redude the amount of spurious leak reports by setting environment variable `LSAN_OPTIONS=suppressions=$ROCSHEM_SRC/scripts/lsan-suppressions.txt`.
+
+### References
+
+[1]: https://rocm.docs.amd.com/projects/llvm-project/en/docs-6.4.0/conceptual/using-gpu-sanitizer.html
+[2]: https://github.com/open-mpi/ompi/issues/13069

--- a/projects/rocshmem/scripts/build_configs/all_backends
+++ b/projects/rocshmem/scripts/build_configs/all_backends
@@ -27,9 +27,7 @@ set -e
 
 src_path=$(dirname "$(realpath $0)")/../../
 
-ASAN_FLAG=""
 if [[ "${ASAN}" == true ]]; then
-    ASAN_FLAG="-DASAN=ON"
     export HSA_XNACK=1
 fi
 
@@ -55,7 +53,7 @@ cmake \
     -DUSE_WF_COAL=OFF \
     -DUSE_HDP_FLUSH=OFF \
     -DUSE_HDP_FLUSH_HOST_SIDE=OFF \
-    ${ASAN_FLAG} \
+    -DASAN=${ASAN:-OFF} \
     $* $src_path
 cmake --build . --parallel 8
 cmake --install .

--- a/projects/rocshmem/scripts/build_configs/all_backends
+++ b/projects/rocshmem/scripts/build_configs/all_backends
@@ -52,3 +52,7 @@ cmake \
     $* $src_path
 cmake --build . --parallel 8
 cmake --install .
+
+if [[ "${ASAN}" == true ]]; then
+    export HSA_XNACK=1
+fi

--- a/projects/rocshmem/scripts/build_configs/all_backends
+++ b/projects/rocshmem/scripts/build_configs/all_backends
@@ -27,6 +27,12 @@ set -e
 
 src_path=$(dirname "$(realpath $0)")/../../
 
+ASAN_FLAG=""
+if [[ "${ASAN}" == true ]]; then
+    ASAN_FLAG="-DASAN=ON"
+    export HSA_XNACK=1
+fi
+
 cmake \
     -DBUILD_CODE_COVERAGE=${CODE_COV:-OFF} \
     -DCMAKE_BUILD_TYPE=${BUILD_TYPE:-Release} \
@@ -49,10 +55,8 @@ cmake \
     -DUSE_WF_COAL=OFF \
     -DUSE_HDP_FLUSH=OFF \
     -DUSE_HDP_FLUSH_HOST_SIDE=OFF \
+    ${ASAN_FLAG} \
     $* $src_path
 cmake --build . --parallel 8
 cmake --install .
 
-if [[ "${ASAN}" == true ]]; then
-    export HSA_XNACK=1
-fi

--- a/projects/rocshmem/scripts/build_configs/all_backends
+++ b/projects/rocshmem/scripts/build_configs/all_backends
@@ -51,3 +51,7 @@ cmake \
     $* $src_path
 cmake --build . --parallel 8
 cmake --install .
+
+if [[ "${ASAN}" == true ]]; then
+    export HSA_XNACK=1
+fi

--- a/projects/rocshmem/scripts/build_configs/gda
+++ b/projects/rocshmem/scripts/build_configs/gda
@@ -26,9 +26,7 @@
 set -e
 
 src_path=$(dirname "$(realpath $0)")/../../
-ASAN_FLAG=""
 if [[ "${ASAN}" == true ]]; then
-    ASAN_FLAG="-DASAN=ON"
     export HSA_XNACK=1
 fi
 
@@ -50,7 +48,7 @@ cmake \
     -DUSE_WF_COAL=OFF \
     -DUSE_HDP_FLUSH=OFF \
     -DUSE_HDP_FLUSH_HOST_SIDE=OFF \
-    ${ASAN_FLAG} \
+    -DASAN=${ASAN:-OFF} \
     $* $src_path
 cmake --build . --parallel 8
 cmake --install .

--- a/projects/rocshmem/scripts/build_configs/gda
+++ b/projects/rocshmem/scripts/build_configs/gda
@@ -26,6 +26,11 @@
 set -e
 
 src_path=$(dirname "$(realpath $0)")/../../
+ASAN_FLAG=""
+if [[ "${ASAN}" == true ]]; then
+    ASAN_FLAG="-DASAN=ON"
+    export HSA_XNACK=1
+fi
 
 cmake \
     -DBUILD_CODE_COVERAGE=${CODE_COV:-OFF} \
@@ -45,6 +50,7 @@ cmake \
     -DUSE_WF_COAL=OFF \
     -DUSE_HDP_FLUSH=OFF \
     -DUSE_HDP_FLUSH_HOST_SIDE=OFF \
+    ${ASAN_FLAG} \
     $* $src_path
 cmake --build . --parallel 8
 cmake --install .

--- a/projects/rocshmem/scripts/build_configs/ipc_single
+++ b/projects/rocshmem/scripts/build_configs/ipc_single
@@ -26,6 +26,11 @@
 set -e
 
 src_path=$(dirname "$(realpath $0)")/../../
+ASAN_FLAG=""
+if [[ "${ASAN}" == true ]]; then
+    ASAN_FLAG="-DASAN=ON"
+    export HSA_XNACK=1
+fi
 
 cmake \
     -DBUILD_CODE_COVERAGE=${CODE_COV:-OFF} \
@@ -47,6 +52,7 @@ cmake \
     -DUSE_HDP_FLUSH=OFF \
     -DUSE_HDP_FLUSH_HOST_SIDE=OFF \
     -DUSE_SINGLE_NODE=ON \
+    ${ASAN_FLAG} \
     $* $src_path
 cmake --build . --parallel 8
 cmake --install .

--- a/projects/rocshmem/scripts/build_configs/ipc_single
+++ b/projects/rocshmem/scripts/build_configs/ipc_single
@@ -26,9 +26,7 @@
 set -e
 
 src_path=$(dirname "$(realpath $0)")/../../
-ASAN_FLAG=""
 if [[ "${ASAN}" == true ]]; then
-    ASAN_FLAG="-DASAN=ON"
     export HSA_XNACK=1
 fi
 
@@ -52,7 +50,7 @@ cmake \
     -DUSE_HDP_FLUSH=OFF \
     -DUSE_HDP_FLUSH_HOST_SIDE=OFF \
     -DUSE_SINGLE_NODE=ON \
-    ${ASAN_FLAG} \
+    -DASAN=${ASAN:-OFF} \
     $* $src_path
 cmake --build . --parallel 8
 cmake --install .

--- a/projects/rocshmem/scripts/build_configs/ipc_tests_only
+++ b/projects/rocshmem/scripts/build_configs/ipc_tests_only
@@ -26,6 +26,11 @@
 set -e
 
 src_path=$(dirname "$(realpath $0)")/../../
+ASAN_FLAG=""
+if [[ "${ASAN}" == true ]]; then
+    ASAN_FLAG="-DASAN=ON"
+    export HSA_XNACK=1
+fi
 
 cmake \
     -DBUILD_CODE_COVERAGE=${CODE_COV:-OFF} \
@@ -48,5 +53,6 @@ cmake \
     -DUSE_HDP_FLUSH=OFF \
     -DUSE_HDP_FLUSH_HOST_SIDE=OFF \
     -DBUILD_TESTS_ONLY=ON \
+    ${ASAN_FLAG} \
     $* $src_path
 cmake --build . --parallel 8

--- a/projects/rocshmem/scripts/build_configs/ipc_tests_only
+++ b/projects/rocshmem/scripts/build_configs/ipc_tests_only
@@ -26,9 +26,7 @@
 set -e
 
 src_path=$(dirname "$(realpath $0)")/../../
-ASAN_FLAG=""
 if [[ "${ASAN}" == true ]]; then
-    ASAN_FLAG="-DASAN=ON"
     export HSA_XNACK=1
 fi
 
@@ -53,6 +51,5 @@ cmake \
     -DUSE_HDP_FLUSH=OFF \
     -DUSE_HDP_FLUSH_HOST_SIDE=OFF \
     -DBUILD_TESTS_ONLY=ON \
-    ${ASAN_FLAG} \
     $* $src_path
 cmake --build . --parallel 8

--- a/projects/rocshmem/scripts/build_configs/ro_ipc
+++ b/projects/rocshmem/scripts/build_configs/ro_ipc
@@ -26,9 +26,7 @@
 set -e
 
 src_path=$(dirname "$(realpath $0)")/../../
-ASAN_FLAG=""
 if [[ "${ASAN}" == true ]]; then
-    ASAN_FLAG="-DASAN=ON"
     export HSA_XNACK=1
 fi
 
@@ -51,7 +49,7 @@ cmake \
     -DUSE_WF_COAL=OFF \
     -DUSE_HDP_FLUSH=OFF \
     -DUSE_HDP_FLUSH_HOST_SIDE=OFF \
-    ${ASAN_FLAG} \
+    -DASAN=${ASAN:-OFF} \
     $* $src_path
 cmake --build . --parallel 8
 cmake --install .

--- a/projects/rocshmem/scripts/build_configs/ro_ipc
+++ b/projects/rocshmem/scripts/build_configs/ro_ipc
@@ -26,6 +26,11 @@
 set -e
 
 src_path=$(dirname "$(realpath $0)")/../../
+ASAN_FLAG=""
+if [[ "${ASAN}" == true ]]; then
+    ASAN_FLAG="-DASAN=ON"
+    export HSA_XNACK=1
+fi
 
 cmake \
     -DBUILD_CODE_COVERAGE=${CODE_COV:-OFF} \
@@ -46,6 +51,7 @@ cmake \
     -DUSE_WF_COAL=OFF \
     -DUSE_HDP_FLUSH=OFF \
     -DUSE_HDP_FLUSH_HOST_SIDE=OFF \
+    ${ASAN_FLAG} \
     $* $src_path
 cmake --build . --parallel 8
 cmake --install .

--- a/projects/rocshmem/scripts/build_configs/ro_net
+++ b/projects/rocshmem/scripts/build_configs/ro_net
@@ -26,9 +26,7 @@
 set -e
 
 src_path=$(dirname "$(realpath $0)")/../../
-ASAN_FLAG=""
 if [[ "${ASAN}" == true ]]; then
-    ASAN_FLAG="-DASAN=ON"
     export HSA_XNACK=1
 fi
 
@@ -51,7 +49,7 @@ cmake \
     -DUSE_WF_COAL=OFF \
     -DUSE_HDP_FLUSH=OFF \
     -DUSE_HDP_FLUSH_HOST_SIDE=OFF \
-    ${ASAN_FLAG} \
+    -DASAN=${ASAN:-OFF} \
     $* $src_path
 cmake --build . --parallel 8
 cmake --install .

--- a/projects/rocshmem/scripts/build_configs/ro_net
+++ b/projects/rocshmem/scripts/build_configs/ro_net
@@ -26,6 +26,11 @@
 set -e
 
 src_path=$(dirname "$(realpath $0)")/../../
+ASAN_FLAG=""
+if [[ "${ASAN}" == true ]]; then
+    ASAN_FLAG="-DASAN=ON"
+    export HSA_XNACK=1
+fi
 
 cmake \
     -DBUILD_CODE_COVERAGE=${CODE_COV:-OFF} \
@@ -46,6 +51,7 @@ cmake \
     -DUSE_WF_COAL=OFF \
     -DUSE_HDP_FLUSH=OFF \
     -DUSE_HDP_FLUSH_HOST_SIDE=OFF \
+    ${ASAN_FLAG} \
     $* $src_path
 cmake --build . --parallel 8
 cmake --install .

--- a/projects/rocshmem/scripts/lsan-suppressions.txt
+++ b/projects/rocshmem/scripts/lsan-suppressions.txt
@@ -1,0 +1,5 @@
+leak:pmix.so
+leak:hwloc.so
+leak:open-pal.so
+leak:ucs.so
+leak:uct.so

--- a/projects/rocshmem/tests/functional_tests/CMakeLists.txt
+++ b/projects/rocshmem/tests/functional_tests/CMakeLists.txt
@@ -31,9 +31,7 @@ include(${CMAKE_SOURCE_DIR}/cmake/setup_project.cmake)
 project(rocshmem_functional_tests VERSION 1.0.0 LANGUAGES CXX)
 
 # ASAN option (if not already defined by parent project)
-if (NOT DEFINED ASAN)
-  option(ASAN "Enable AddressSanitizer" OFF)
-endif()
+option(ASAN "Enable AddressSanitizer" ${ASAN})
 
 ###############################################################################
 # SOURCES

--- a/projects/rocshmem/tests/functional_tests/CMakeLists.txt
+++ b/projects/rocshmem/tests/functional_tests/CMakeLists.txt
@@ -30,6 +30,11 @@ cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
 include(${CMAKE_SOURCE_DIR}/cmake/setup_project.cmake)
 project(rocshmem_functional_tests VERSION 1.0.0 LANGUAGES CXX)
 
+# ASAN option (if not already defined by parent project)
+if (NOT DEFINED ASAN)
+  option(ASAN "Enable AddressSanitizer" OFF)
+endif()
+
 ###############################################################################
 # SOURCES
 ###############################################################################
@@ -112,6 +117,21 @@ target_link_libraries(
     $<TARGET_NAME_IF_EXISTS:MPI::MPI_CXX>
     $<TARGET_NAME_IF_EXISTS:PMIx::pmix>
     hiprtc
+)
+
+###############################################################################
+# ASAN SETTINGS
+###############################################################################
+target_compile_options(
+  ${PROJECT_NAME}
+  PRIVATE
+    $<$<BOOL:${ASAN}>:-fsanitize=address -g>
+)
+
+target_link_options(
+  ${PROJECT_NAME}
+  PRIVATE
+    $<$<BOOL:${ASAN}>:-fsanitize=address -g -shared-libsan>
 )
 
 ###############################################################################

--- a/projects/rocshmem/tests/functional_tests/CMakeLists.txt
+++ b/projects/rocshmem/tests/functional_tests/CMakeLists.txt
@@ -30,6 +30,11 @@ cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
 include(${CMAKE_SOURCE_DIR}/cmake/setup_project.cmake)
 project(rocshmem_functional_tests VERSION 1.0.0 LANGUAGES CXX)
 
+# ASAN option (if not already defined by parent project)
+if (NOT DEFINED ASAN)
+  option(ASAN "Enable AddressSanitizer" OFF)
+endif()
+
 ###############################################################################
 # SOURCES
 ###############################################################################
@@ -111,6 +116,21 @@ target_link_libraries(
     $<TARGET_NAME_IF_EXISTS:MPI::MPI_CXX>
     $<TARGET_NAME_IF_EXISTS:PMIx::pmix>
     hiprtc
+)
+
+###############################################################################
+# ASAN SETTINGS
+###############################################################################
+target_compile_options(
+  ${PROJECT_NAME}
+  PRIVATE
+    $<$<BOOL:${ASAN}>:-fsanitize=address -g>
+)
+
+target_link_options(
+  ${PROJECT_NAME}
+  PRIVATE
+    $<$<BOOL:${ASAN}>:-fsanitize=address -g -shared-libsan>
 )
 
 ###############################################################################

--- a/projects/rocshmem/tests/unit_tests/CMakeLists.txt
+++ b/projects/rocshmem/tests/unit_tests/CMakeLists.txt
@@ -31,9 +31,7 @@ include(${CMAKE_SOURCE_DIR}/cmake/setup_project.cmake)
 project(rocshmem_unit_tests VERSION 1.0.0 LANGUAGES CXX)
 
 # ASAN option (if not already defined by parent project)
-if (NOT DEFINED ASAN)
-  option(ASAN "Enable AddressSanitizer" OFF)
-endif()
+option(ASAN "Enable AddressSanitizer" ${ASAN})
 
 ###############################################################################
 # SOURCES

--- a/projects/rocshmem/tests/unit_tests/CMakeLists.txt
+++ b/projects/rocshmem/tests/unit_tests/CMakeLists.txt
@@ -30,6 +30,11 @@ cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
 include(${CMAKE_SOURCE_DIR}/cmake/setup_project.cmake)
 project(rocshmem_unit_tests VERSION 1.0.0 LANGUAGES CXX)
 
+# ASAN option (if not already defined by parent project)
+if (NOT DEFINED ASAN)
+  option(ASAN "Enable AddressSanitizer" OFF)
+endif()
+
 ###############################################################################
 # SOURCES
 ###############################################################################
@@ -204,3 +209,16 @@ endif()
 # For backward compatibility, the shell script is still available
 # Usage: rocshmem_unit_driver.sh <binary> all
 # Usage: rocshmem_unit_driver.sh <binary> custom <ranks> <filter>
+# ASAN SETTINGS
+###############################################################################
+target_compile_options(
+  ${PROJECT_NAME}
+  PRIVATE
+    $<$<BOOL:${ASAN}>:-fsanitize=address -g>
+)
+
+target_link_options(
+  ${PROJECT_NAME}
+  PRIVATE
+    $<$<BOOL:${ASAN}>:-fsanitize=address -g -shared-libsan>
+)

--- a/projects/rocshmem/tests/unit_tests/CMakeLists.txt
+++ b/projects/rocshmem/tests/unit_tests/CMakeLists.txt
@@ -30,6 +30,11 @@ cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
 include(${CMAKE_SOURCE_DIR}/cmake/setup_project.cmake)
 project(rocshmem_unit_tests VERSION 1.0.0 LANGUAGES CXX)
 
+# ASAN option (if not already defined by parent project)
+if (NOT DEFINED ASAN)
+  option(ASAN "Enable AddressSanitizer" OFF)
+endif()
+
 ###############################################################################
 # SOURCES
 ###############################################################################
@@ -133,4 +138,19 @@ target_link_libraries(
   PRIVATE
     gtest
     gtest_main
+)
+
+###############################################################################
+# ASAN SETTINGS
+###############################################################################
+target_compile_options(
+  ${PROJECT_NAME}
+  PRIVATE
+    $<$<BOOL:${ASAN}>:-fsanitize=address -g>
+)
+
+target_link_options(
+  ${PROJECT_NAME}
+  PRIVATE
+    $<$<BOOL:${ASAN}>:-fsanitize=address -g -shared-libsan>
 )


### PR DESCRIPTION
## Motivation
Add support for building with AddressSanitizer (ASAN) to enable detection of memory-related issues

## Technical Details
Adds the required compiler and linker flags for ASAN instrumentation
Ensures compatibility with existing build configurations
Updates build logic to correctly handle ASAN-specific requirements
Maintains default behavior when ASAN is not enabled

## JIRA ID
AIROCSHMEM-364
AIROCSHMEM-330

## Test Plan
cmake -DASAN=ON <other-flags> ..
make -j

## Test Result
Build completed successfully with -DASAN=ON
It has been tested in TheRock.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
