### PR TITLE
[rocjtisu] Implemented SpillManager

### DIFF
--- a/emulation/rocjitsu/docs/dbi-design.md
+++ b/emulation/rocjitsu/docs/dbi-design.md
@@ -1,0 +1,93 @@
+# DBI Design Document
+
+## Overview
+
+The Dynamic Binary Instrumentation (DBI) system patches AMDGPU HSA code objects in-place, before they are loaded into device memory, to inject calls into user-supplied instrumentation functions. Patched code objects can (will) then be loaded by either the simulated KMD (`SimulatedDriver`) or by real ROCR via the HSA tools layer (`HSA_TOOLS_LIB=librocjitsu_hooks.so`). DBI itself is (will be) target-agnostic.
+
+This document describes the DBI subsystem as currently implemented. Most of the planned DBI machinery (trampoline builder, probe registry, instrumentation pass, public C API) does not exist yet; it is tracked in `dbt_dbi_plan.md`. The pieces in tree today are the foundational analyses and resource managers that future instrumentation passes will consume.
+
+---
+
+## Architecture
+
+TODO. The shipped DBI surface is a set of foundational building blocks (liveness, register set, spill manager) rather than an end-to-end pipeline. A meaningful block diagram will land once the trampoline builder and instrumentation pass exist and there is a real flow to draw.
+
+---
+
+## Register Liveness Analysis [shared with DBT]
+
+**Files:** `analysis/liveness.h`, `analysis/liveness.cpp`, `analysis/def_use_chain.h`, `analysis/def_use_chain.cpp`
+**Used by:** DBT semantic translator (today); DBI passes (planned)
+
+Kernel-scoped backward register liveness over the CFG embedded in `BasicBlock`. Callers construct a `LivenessAnalysis` from one `KernelBlockScope` (the blocks reachable from one kernel descriptor entry). Successor/predecessor edges that leave the scope are ignored, so one decoded code object containing N kernels yields N independent analyses.
+
+### What it tracks
+
+Ordinary SGPRs, VGPRs, and AccVGPRs via `RegisterSet`. `InstDefUse` records explicit operand defs and uses plus instruction-level implicit hooks; the only implicit hook today is the FLAT `saddr` SGPR-pair use that does not appear as an explicit operand.
+
+### What it does NOT track
+
+- EXEC, VCC, SCC, M0, FLAT_SCRATCH, TTMP — special architectural state. The `RegClass` enum names these for future use, but they are not in the dataflow set.
+- Cross-kernel CFG. Edges that leave the kernel scope are silently dropped.
+- Memory dependencies. Liveness is purely register-based.
+
+---
+
+## SpillManager
+
+**Files:** `code/patch/spill_manager.h`, `code/patch/spill_manager.cpp`
+
+Per-kernel scratch-layout planner for DBI spill/fill slots. Future instrumentation passes will use it to reserve byte offsets within per-lane scratch where saved SGPRs / VGPRs / AccVGPRs go before a probe runs and from which they are restored after.
+
+### Responsibilities
+
+- Reserve a "DBI spill zone" appended above the kernel's existing `private_segment_fixed_size`, aligned to 16 bytes.
+- Hand out stable per-register byte offsets within that zone. Registers cannot get more than one offset.
+- Enforce a hard per-lane scratch cap. Allocations that would push the bumped total past the cap fail; on failure the manager state is unchanged.
+- Compute the bumped `private_segment_fixed_size` that the kernel descriptor patcher will write back.
+
+### What it is not
+
+- Not a memory allocator. SpillManager only computes layout.
+- Not the code generator. SpillManager hands out offsets; emitting the actual `scratch_store` / `scratch_load` (or equivalents) will be the trampoline builder's job.
+- Not an MFMA-clobber tracker. AccVGPR clobbering by long-latency MFMA is deferred
+
+### Public API
+
+```cpp
+class SpillManager final {
+public:
+  static constexpr uint32_t kSlotBytes = 4;         // one 32-bit lane per slot
+  static constexpr uint32_t kDbiZoneAlignment = 16; // zone start alignment
+
+  SpillManager(uint32_t original_private_bytes, uint32_t per_lane_scratch_limit);
+
+  std::optional<uint32_t> allocate_slot(RegisterRef reg);
+  std::optional<uint32_t> allocate_slots(RegisterRef reg, unsigned width);
+  bool                    reserve(const RegisterSet &set);
+  uint32_t                total_private_bytes() const;
+  std::optional<uint32_t> offset_for(RegisterRef reg) const;
+};
+```
+
+`allocate_slots` is the common multi-lane case (SGPR pair, 64-bit VGPR pair). `reserve` performs an upfront capacity check across the whole set so a partial allocation can never become visible. `offset_for` is the lookup used by code generators when emitting the matching `scratch_load` after a probe.
+
+---
+
+## Supporting Types
+
+### RegisterRef / RegisterSet [shared with DBT]
+
+**Files:** `isa/register_set.h`, `isa/register_set.cpp`
+**Used by:** DBT semantic translator, DBI SpillManager and liveness
+
+ISA-independent register-file model. `RegisterRef` is `(RegClass, uint16_t index, uint8_t width)` measured in 32-bit lanes. `RegisterSet` is three disjoint bitsets (SGPR / VGPR / ACC_VGPR) sized to the union of CDNA and RDNA hardware bounds (`REGISTER_SET_MAX_*`). For scratch selection across both families, `REGISTER_SET_ALLOCATABLE_SGPRS` gives the conservative `min(CDNA, RDNA)` bound.
+
+`RegisterSet` exposes `expand` / `erase` / `contains` / `none` / `size` / `intersects`, the standard set operators (`|=`, `&=`, `-=`), and a `for_each` visitor that yields tracked single-lane `RegisterRef`s in (SGPR, VGPR, AccVGPR) ascending-index order.
+
+---
+
+## Testing
+
+- `tests/patch/spill_manager_test.cpp` — SpillManager unit coverage: zone alignment, idempotent re-allocation, multi-lane allocation, `reserve` upfront capacity check, hard-cap enforcement, per-class hardware bounds, `offset_for` lookup.
+- Liveness coverage lives alongside the DBT semantic translator tests (the translator was the first consumer); see `tests/dbt/`.

--- a/emulation/rocjitsu/docs/dbt_dbi_plan.md
+++ b/emulation/rocjitsu/docs/dbt_dbi_plan.md
@@ -467,6 +467,9 @@ The per-lane address formulas are implemented in `shared/addr_calc_scalar.h` (SM
 
 Additionally, when calculating the spill set at a patch site containing an MFMA instruction on **CDNA2+ targets** (GFX90A, GFX940/941/942, GFX950), `SpillManager` must account for AccVGPR ranges clobbered by the MFMA. The clobbered output registers are identified by calling `mfma_exec.h`'s `output_loc_32()` / `output_loc_64()` with the MFMA dimensions extracted from the `Vop3pMachineInst` encoding — these functions return the exact `{reg, lane}` pairs written, from which the AccVGPR range can be derived and added to the spill set. On CDNA1 (GFX908/MI100), MFMA instructions write to regular VGPRs (not AccVGPRs); there is no AccVGPR range to account for.
 
+NOTE (05/06/2026): SpillManager was implemented in Phase 5. Accounting for 
+AccVGPR ranges clobbered by the MFMA has been deferred.
+
 The per-lane base address is:
 
 ```
@@ -4896,7 +4899,7 @@ No public C API additions — `LivenessAnalysis` is consumed internally by `Spil
 
 ---
 
-### Phase 5: SpillManager (3–5 days)
+### Phase 5: SpillManager (3–5 days) ✅
 
 **Depends on:** Phase 1, Phase 4
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
@@ -13,4 +13,5 @@ rj_add_object_library(rocjitsu_code
     dbt/lane_permutation.cpp
     dbt/semantic_translator.cpp
     patch/code_object_patcher.cpp
+    patch/spill_manager.cpp
 )

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.cpp
@@ -3,6 +3,8 @@
 
 #include "rocjitsu/code/patch/spill_manager.h"
 
+#include "util/bit.h"
+
 #include <cassert>
 #include <cstddef>
 #include <limits>
@@ -11,14 +13,6 @@
 namespace rocjitsu {
 
 namespace {
-
-[[nodiscard]] constexpr uint32_t round_up(uint32_t value, uint32_t alignment) {
-  // Use uint64_t internally so (value + alignment - 1) cannot overflow when
-  // value is near UINT32_MAX. The result still fits in uint32_t for any
-  // realistic kernel scratch size.
-  const uint64_t bumped = static_cast<uint64_t>(value) + alignment - 1;
-  return static_cast<uint32_t>((bumped / alignment) * alignment);
-}
 
 /// Per-class hardware bound. Indices >= this are not representable in
 /// RegisterSet's bitsets and indicate either a programming error or a class
@@ -39,8 +33,8 @@ namespace {
 } // namespace
 
 SpillManager::SpillManager(uint32_t original_private_bytes, uint32_t per_lane_scratch_limit)
-    : base_offset_(round_up(original_private_bytes, kDbiZoneAlignment)), total_bytes_(base_offset_),
-      limit_(per_lane_scratch_limit), next_offset_(base_offset_) {}
+    : base_offset_(util::align_up(original_private_bytes, kDbiZoneAlignment)),
+      total_bytes_(base_offset_), limit_(per_lane_scratch_limit), next_offset_(base_offset_) {}
 
 std::optional<uint32_t> SpillManager::allocate_slot(RegisterRef reg) {
   // Reject indices past the per-class hardware bound (or unsupported classes

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.cpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/patch/spill_manager.h"
+
+#include <cassert>
+#include <cstddef>
+#include <limits>
+#include <utility> // for std::pair
+
+namespace rocjitsu {
+
+namespace {
+
+[[nodiscard]] constexpr uint32_t round_up(uint32_t value, uint32_t alignment) {
+  // Use uint64_t internally so (value + alignment - 1) cannot overflow when
+  // value is near UINT32_MAX. The result still fits in uint32_t for any
+  // realistic kernel scratch size.
+  const uint64_t bumped = static_cast<uint64_t>(value) + alignment - 1;
+  return static_cast<uint32_t>((bumped / alignment) * alignment);
+}
+
+/// Per-class hardware bound. Indices >= this are not representable in
+/// RegisterSet's bitsets and indicate either a programming error or a class
+/// that RegisterSet doesn't track (EXEC, VCC, etc.).
+[[nodiscard]] size_t per_class_max(RegClass cls) {
+  switch (cls) {
+  case RegClass::SGPR:
+    return REGISTER_SET_MAX_SGPRS;
+  case RegClass::VGPR:
+    return REGISTER_SET_MAX_VGPRS;
+  case RegClass::ACC_VGPR:
+    return REGISTER_SET_MAX_ACC_VGPRS;
+  default:
+    return 0; // class not tracked — every index rejected
+  }
+}
+
+} // namespace
+
+SpillManager::SpillManager(uint32_t original_private_bytes, uint32_t per_lane_scratch_limit)
+    : base_offset_(round_up(original_private_bytes, kDbiZoneAlignment)), total_bytes_(base_offset_),
+      limit_(per_lane_scratch_limit), next_offset_(base_offset_) {}
+
+std::optional<uint32_t> SpillManager::allocate_slot(RegisterRef reg) {
+  // Reject indices past the per-class hardware bound (or unsupported classes
+  // like EXEC/VCC). The cache lookup happens first so an idempotent re-alloc
+  // of an already-cached register cannot fail this check (it never could have
+  // been cached without passing the check the first time).
+  const std::pair<RegClass, uint16_t> key{reg.cls, reg.index};
+  auto it = reg_to_offset_.find(key);
+  if (it != reg_to_offset_.end()) {
+    return it->second;
+  }
+  if (reg.index >= per_class_max(reg.cls)) {
+    return std::nullopt;
+  }
+  // Overflow-safe equivalent of `next_offset_ + kSlotBytes > limit_`.
+  if (static_cast<uint64_t>(next_offset_) + kSlotBytes > limit_) {
+    return std::nullopt;
+  }
+  const uint32_t offset = next_offset_;
+  next_offset_ += kSlotBytes;
+  total_bytes_ = next_offset_;
+  reg_to_offset_.emplace(key, offset);
+  return offset;
+}
+
+std::optional<uint32_t> SpillManager::allocate_slots(RegisterRef reg, unsigned width) {
+  if (width == 0)
+    return std::nullopt;
+  // Reject ranges that would wrap the uint16_t register index space.
+  if (static_cast<uint32_t>(reg.index) + width - 1 > std::numeric_limits<uint16_t>::max()) {
+    return std::nullopt;
+  }
+  // RegisterRef::width is uint8_t; reject anything that wouldn't fit.
+  if (width > std::numeric_limits<uint8_t>::max()) {
+    return std::nullopt;
+  }
+  // Reject ranges that would extend past the per-class hardware bound —
+  // RegisterSet::expand would silently truncate them, leaving the caller
+  // with a short allocation and no error.
+  if (static_cast<size_t>(reg.index) + width > per_class_max(reg.cls)) {
+    return std::nullopt;
+  }
+
+  // Build a width-N range and reserve
+  RegisterSet set;
+  set.expand(RegisterRef{reg.cls, reg.index, static_cast<uint8_t>(width)});
+  if (!reserve(set))
+    return std::nullopt;
+  // width=1 is irrelevant here; offset_for keys on (cls, index) only.
+  return offset_for(RegisterRef{reg.cls, reg.index, 1});
+}
+
+bool SpillManager::reserve(const RegisterSet &set) {
+  // Count NEW registers (cache misses) so we can size-check upfront.
+  unsigned num_new = 0;
+  set.for_each([&](RegisterRef reg) {
+    const std::pair<RegClass, uint16_t> key{reg.cls, reg.index};
+    if (!reg_to_offset_.contains(key))
+      ++num_new;
+  });
+  if (num_new > 0 && static_cast<uint64_t>(next_offset_) + kSlotBytes * num_new > limit_) {
+    return false;
+  }
+
+  // Capacity check passed — no failure possible from here. Every reg from
+  // for_each is within per-class bounds (the bitset itself enforces that),
+  // and we just verified there's enough room.
+  set.for_each([this](RegisterRef reg) {
+    [[maybe_unused]] auto off = allocate_slot(reg);
+    assert(off.has_value() && "allocate_slot failed after capacity check");
+  });
+  return true;
+}
+
+std::optional<uint32_t> SpillManager::offset_for(RegisterRef reg) const {
+  const std::pair<RegClass, uint16_t> key{reg.cls, reg.index};
+  auto it = reg_to_offset_.find(key);
+  if (it == reg_to_offset_.end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.h
@@ -1,0 +1,90 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file spill_manager.h
+/// @brief Per-kernel scratch reservation for DBI spill/fill slots.
+
+#ifndef ROCJITSU_CODE_PATCH_SPILL_MANAGER_H_
+#define ROCJITSU_CODE_PATCH_SPILL_MANAGER_H_
+
+#include "rocjitsu/isa/register_set.h"
+
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <utility> // for std::pair
+
+namespace rocjitsu {
+
+/// @brief Per-kernel scratch reservation for DBI spill/fill slots.
+///
+/// Appends a "DBI spill zone" to the kernel's existing per-lane scratch
+/// segment and hands out stable byte offsets within per-lane scratch for
+/// each spilled register. Allocation is idempotent: spilling the same
+/// register twice returns the same offset.
+class SpillManager final {
+public:
+  /// @brief Slot unit in bytes. Every spilled register occupies one slot per
+  ///        32-bit lane (a 64-bit pair gets two consecutive slots).
+  static constexpr uint32_t kSlotBytes = 4;
+
+  /// @brief DBI spill zone is appended at the next multiple of this alignment
+  ///        above the kernel's existing private_segment_fixed_size.
+  static constexpr uint32_t kDbiZoneAlignment = 16;
+
+  /// @param original_private_bytes  Existing private_segment_fixed_size from
+  ///                                the kernel descriptor.
+  /// @param per_lane_scratch_limit  Hard cap (bytes) for the bumped per-lane
+  ///                                scratch. Allocations that would push
+  ///                                total_private_bytes() past this cap fail.
+  /// @note If @p original_private_bytes (rounded up to @c kDbiZoneAlignment)
+  ///       already exceeds @p per_lane_scratch_limit, every allocation will
+  ///       fail; the manager is constructible but unusable.
+  SpillManager(uint32_t original_private_bytes, uint32_t per_lane_scratch_limit);
+
+  /// @brief Allocate a single 32-bit slot for @p reg.
+  /// @returns Byte offset within per-lane scratch of the slot for @p reg, or
+  ///          nullopt if allocation would exceed @c per_lane_scratch_limit, or
+  ///          if @p reg.cls is not tracked by RegisterSet, or if @p reg.index
+  ///          is past the per-class hardware bound.
+  ///          Idempotent for the same @p reg (cache hit returns the existing
+  ///          offset even when the limit is otherwise exhausted).
+  /// @note The @c width field of @p reg is IGNORED — only @c (cls, index)
+  ///       determines the slot key. Use @c allocate_slots for multi-lane refs.
+  [[nodiscard]] std::optional<uint32_t> allocate_slot(RegisterRef reg);
+
+  /// @brief Allocate @p width consecutive 32-bit slots starting at @p reg.
+  /// @param width Number of consecutive 32-bit slots; must be >= 1. Width 0
+  ///              returns nullopt.
+  /// @returns Byte offset of the first slot, or nullopt on overflow or if
+  ///          @p reg.index + @p width would exceed UINT16_MAX.
+  /// @note width=2 is the common case (SGPR pair, 64-bit VGPR pair).
+  ///       On any sub-allocation failure, the manager is rolled back to its
+  ///       state at entry (no partial allocation is retained).
+  [[nodiscard]] std::optional<uint32_t> allocate_slots(RegisterRef reg, unsigned width);
+
+  /// @brief Allocate slots for every register in @p set.
+  /// @returns true on success. On failure, the manager is rolled back to its
+  ///          state at entry (no register from this call is retained).
+  /// @note An empty set or a set whose registers are all already cached
+  ///       returns true even on an over-limit manager — no new bytes are
+  ///       requested, so no capacity check fires.
+  [[nodiscard]] bool reserve(const RegisterSet &set);
+
+  /// @returns The bumped total per-lane scratch bytes.
+  [[nodiscard]] uint32_t total_private_bytes() const { return total_bytes_; }
+
+  /// @returns Slot offset previously allocated for @p reg, or nullopt.
+  [[nodiscard]] std::optional<uint32_t> offset_for(RegisterRef reg) const;
+
+private:
+  uint32_t base_offset_; ///< First DBI slot. round_up(orig, 16).
+  uint32_t total_bytes_; ///< Bumped private_segment_fixed_size.
+  uint32_t limit_;       ///< Hard per-lane scratch cap (inclusive: offset+kSlotBytes <= limit OK).
+  uint32_t next_offset_; ///< Next free byte within DBI zone.
+  std::map<std::pair<RegClass, uint16_t>, uint32_t> reg_to_offset_;
+};
+
+} // namespace rocjitsu
+
+#endif // ROCJITSU_CODE_PATCH_SPILL_MANAGER_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/spill_manager.h
@@ -9,9 +9,10 @@
 
 #include "rocjitsu/isa/register_set.h"
 
+#include <cstddef>
 #include <cstdint>
-#include <map>
 #include <optional>
+#include <unordered_map>
 #include <utility> // for std::pair
 
 namespace rocjitsu {
@@ -59,13 +60,15 @@ public:
   /// @returns Byte offset of the first slot, or nullopt on overflow or if
   ///          @p reg.index + @p width would exceed UINT16_MAX.
   /// @note width=2 is the common case (SGPR pair, 64-bit VGPR pair).
-  ///       On any sub-allocation failure, the manager is rolled back to its
-  ///       state at entry (no partial allocation is retained).
+  ///       On failure the manager is unchanged: the underlying @c reserve
+  ///       call performs an upfront capacity check before mutating, so a
+  ///       partially-completed allocation never becomes visible.
   [[nodiscard]] std::optional<uint32_t> allocate_slots(RegisterRef reg, unsigned width);
 
   /// @brief Allocate slots for every register in @p set.
-  /// @returns true on success. On failure, the manager is rolled back to its
-  ///          state at entry (no register from this call is retained).
+  /// @returns true on success. On failure the manager is unchanged — the
+  ///          capacity check runs upfront across all new registers, so no
+  ///          partial commit is possible.
   /// @note An empty set or a set whose registers are all already cached
   ///       returns true even on an over-limit manager — no new bytes are
   ///       requested, so no capacity check fires.
@@ -78,11 +81,19 @@ public:
   [[nodiscard]] std::optional<uint32_t> offset_for(RegisterRef reg) const;
 
 private:
-  uint32_t base_offset_; ///< First DBI slot. round_up(orig, 16).
+  /// Hash for (RegClass, register-index). RegClass fits in 8 bits and the
+  /// index in 16, so the combined key is collision-free in 32 bits.
+  struct RegKeyHash {
+    size_t operator()(const std::pair<RegClass, uint16_t> &k) const noexcept {
+      return (static_cast<size_t>(k.first) << 16) | k.second;
+    }
+  };
+
+  uint32_t base_offset_; ///< First DBI slot. align_up(orig, 16).
   uint32_t total_bytes_; ///< Bumped private_segment_fixed_size.
   uint32_t limit_;       ///< Hard per-lane scratch cap (inclusive: offset+kSlotBytes <= limit OK).
   uint32_t next_offset_; ///< Next free byte within DBI zone.
-  std::map<std::pair<RegClass, uint16_t>, uint32_t> reg_to_offset_;
+  std::unordered_map<std::pair<RegClass, uint16_t>, uint32_t, RegKeyHash> reg_to_offset_;
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.cpp
@@ -100,6 +100,8 @@ bool RegisterSet::contains(RegisterRef ref) const {
 
 bool RegisterSet::none() const { return sgprs_.none() && vgprs_.none() && acc_vgprs_.none(); }
 
+size_t RegisterSet::size() const { return sgprs_.count() + vgprs_.count() + acc_vgprs_.count(); }
+
 bool RegisterSet::intersects(const RegisterSet &rhs) const {
   return (sgprs_ & rhs.sgprs_).any() || (vgprs_ & rhs.vgprs_).any() ||
          (acc_vgprs_ & rhs.acc_vgprs_).any();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/register_set.h
@@ -97,6 +97,10 @@ public:
   /// @brief Return true when no register class contains any live bits.
   [[nodiscard]] bool none() const;
 
+  /// @brief Return the total number of single-lane registers tracked across
+  ///        all classes (SGPR + VGPR + AccVGPR).
+  [[nodiscard]] size_t size() const;
+
   /// @brief Return true if any register lane is present in both sets.
   [[nodiscard]] bool intersects(const RegisterSet &rhs) const;
 
@@ -118,6 +122,26 @@ public:
   }
 
   friend bool operator==(const RegisterSet &, const RegisterSet &) = default;
+
+  /// @brief Invoke @p f with each tracked single-lane register in the set.
+  ///
+  /// @details Visits SGPRs, then VGPRs, then AccVGPRs in ascending index
+  /// order. Each yielded RegisterRef has @c width=1 — multi-lane refs that
+  /// were inserted via @c expand are visited as their constituent lanes.
+  template <typename F> void for_each(F &&f) const {
+    for (size_t i = 0; i < sgprs_.size(); ++i) {
+      if (sgprs_.test(i))
+        f(RegisterRef{RegClass::SGPR, static_cast<uint16_t>(i), 1});
+    }
+    for (size_t i = 0; i < vgprs_.size(); ++i) {
+      if (vgprs_.test(i))
+        f(RegisterRef{RegClass::VGPR, static_cast<uint16_t>(i), 1});
+    }
+    for (size_t i = 0; i < acc_vgprs_.size(); ++i) {
+      if (acc_vgprs_.test(i))
+        f(RegisterRef{RegClass::ACC_VGPR, static_cast<uint16_t>(i), 1});
+    }
+  }
 
 private:
   std::bitset<REGISTER_SET_MAX_SGPRS> sgprs_;

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(rocjitsu_tests
     shared_infra_test.cpp
     transcendental_test.cpp
     analysis/liveness_test.cpp
+    patch/spill_manager_test.cpp
     dbt/translate_test.cpp
     mtype_flags_test.cpp
     kfd_ioctl_test.cpp

--- a/emulation/rocjitsu/tests/patch/spill_manager_test.cpp
+++ b/emulation/rocjitsu/tests/patch/spill_manager_test.cpp
@@ -561,10 +561,10 @@ TEST(SpillManager, IntegrationFromLiveBefore) {
   SpillManager m(kOrigPrivateBytes, /*limit=*/16384);
   EXPECT_TRUE(m.reserve(live));
 
-  // total = round_up(orig, 16) + kSlotBytes * |live|. round_up(100, 16) == 112.
-  constexpr uint32_t kExpectedBase = 112;
-  EXPECT_EQ(m.total_private_bytes(),
-            kExpectedBase + SpillManager::kSlotBytes * static_cast<uint32_t>(live.size()));
+  // total = align_up(orig, 16) + kSlotBytes * |live|. align_up(100, 16) == 112.
+  constexpr size_t kExpectedBase = 112;
+  EXPECT_EQ(static_cast<size_t>(m.total_private_bytes()),
+            kExpectedBase + SpillManager::kSlotBytes * live.size());
 
   // Every live register has an offset; collect them to check pairwise distinct.
   std::vector<uint32_t> offsets;

--- a/emulation/rocjitsu/tests/patch/spill_manager_test.cpp
+++ b/emulation/rocjitsu/tests/patch/spill_manager_test.cpp
@@ -1,0 +1,586 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/patch/spill_manager.h"
+
+#include "rocjitsu/analysis/liveness.h"
+#include "rocjitsu/code/basic_block.h"
+#include "rocjitsu/code/code_object.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/isa/operand.h"
+#include "rocjitsu/isa/register_set.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <initializer_list>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <vector>
+
+namespace rocjitsu {
+namespace {
+
+constexpr uint32_t kBigLimit = 16384;
+
+RegisterRef sgpr(uint16_t i) { return RegisterRef{RegClass::SGPR, i, 1}; }
+RegisterRef vgpr(uint16_t i) { return RegisterRef{RegClass::VGPR, i, 1}; }
+RegisterRef accvgpr(uint16_t i) { return RegisterRef{RegClass::ACC_VGPR, i, 1}; }
+
+// Minimal synthetic Operand/Instruction/CodeObject/Decoder for integration
+// tests. Mirrors the pattern in tests/analysis/liveness_test.cpp;
+// duplicated here rather than shared to keep this test self-contained.
+class TestOperand : public Operand {
+public:
+  TestOperand() = default;
+  explicit TestOperand(RegisterRef ref) : Operand(ref.width * 32, ref.index), ref_(ref) {}
+  std::optional<RegisterRef> to_register_ref() const override { return ref_; }
+
+private:
+  std::optional<RegisterRef> ref_;
+};
+
+class TestInstruction : public Instruction {
+public:
+  TestInstruction(std::string_view mnemonic, std::initializer_list<RegisterRef> defs,
+                  std::initializer_list<RegisterRef> uses, uint64_t flags = 0)
+      : Instruction(mnemonic, nullptr) {
+    size_ = 4;
+    flags_ = flags;
+    for (RegisterRef ref : defs) {
+      dst_storage_[num_dst_] = TestOperand(ref);
+      dst_operands_[num_dst_] = &dst_storage_[num_dst_];
+      ++num_dst_;
+    }
+    for (RegisterRef ref : uses) {
+      src_storage_[num_src_] = TestOperand(ref);
+      src_operands_[num_src_] = &src_storage_[num_src_];
+      ++num_src_;
+    }
+  }
+
+private:
+  std::array<TestOperand, 2> dst_storage_{};
+  std::array<TestOperand, 4> src_storage_{};
+};
+
+class TestTextSection : public Section {
+public:
+  TestTextSection(std::unique_ptr<char[]> data, std::size_t size)
+      : Section(".text", std::move(data)), size_(size) {}
+  std::size_t size() const override { return size_; }
+  uint32_t sectionHeaderNameIdx() const override { return 0; }
+  uint64_t sectionOffset() const override { return 0; }
+
+private:
+  std::size_t size_;
+};
+
+class TestCodeObject : public CodeObject {
+public:
+  explicit TestCodeObject(std::vector<uint32_t> words) {
+    const auto byte_size = words.size() * sizeof(uint32_t);
+    image_.resize(byte_size);
+    std::memcpy(image_.data(), words.data(), byte_size);
+
+    auto data = std::make_unique<char[]>(byte_size);
+    std::memcpy(data.get(), words.data(), byte_size);
+    sections_.push_back(std::make_unique<TestTextSection>(std::move(data), byte_size));
+    text_sections_.push_back(sections_.back().get());
+  }
+};
+
+// Tiny opcode set just for the integration test. Each opcode maps to one
+// TestInstruction with a fixed def/use pattern.
+enum class IntegOpcode : uint32_t {
+  Def_Vgpr0_Sgpr4 = 0,
+  Def_Vgpr1 = 1,
+  Use_Vgpr0_Sgpr4 = 2, // probe site
+  Use_Vgpr1 = 3,
+  End = 4,
+};
+
+class IntegDecoder : public Decoder {
+public:
+  Instruction *decode(const rj_code_binary_inst_t *inst) override {
+    auto op = static_cast<IntegOpcode>(*inst);
+    switch (op) {
+    case IntegOpcode::Def_Vgpr0_Sgpr4:
+      return new TestInstruction("i0_def", {vgpr(0), sgpr(4)}, {});
+    case IntegOpcode::Def_Vgpr1:
+      return new TestInstruction("i1_def", {vgpr(1)}, {});
+    case IntegOpcode::Use_Vgpr0_Sgpr4:
+      return new TestInstruction("i2_probe_site", {}, {vgpr(0), sgpr(4)});
+    case IntegOpcode::Use_Vgpr1:
+      return new TestInstruction("i3_use", {}, {vgpr(1)});
+    case IntegOpcode::End:
+      return new TestInstruction("end", {}, {}, PROGRAM_TERMINATOR);
+    }
+    return new TestInstruction("end", {}, {}, PROGRAM_TERMINATOR);
+  }
+};
+
+// Start SpillManager Tests
+
+TEST(SpillManager, BaseOffsetIsRoundedUpTo16) {
+  {
+    SpillManager m(0, kBigLimit);
+    EXPECT_EQ(m.total_private_bytes(), 0u);
+  }
+  {
+    SpillManager m(1, kBigLimit);
+    auto off = m.allocate_slot(sgpr(0));
+    ASSERT_TRUE(off.has_value());
+    EXPECT_EQ(*off, 16u);
+    EXPECT_EQ(m.total_private_bytes(), 20u);
+  }
+  {
+    SpillManager m(20, kBigLimit);
+    auto off = m.allocate_slot(sgpr(0));
+    ASSERT_TRUE(off.has_value());
+    EXPECT_EQ(*off, 32u);
+    EXPECT_EQ(m.total_private_bytes(), 36u);
+  }
+}
+
+TEST(SpillManager, AllocateSgprReturnsAscendingOffsets) {
+  SpillManager m(0, kBigLimit);
+  auto a = m.allocate_slot(sgpr(0));
+  auto b = m.allocate_slot(sgpr(1));
+  auto c = m.allocate_slot(sgpr(2));
+  ASSERT_TRUE(a.has_value());
+  ASSERT_TRUE(b.has_value());
+  ASSERT_TRUE(c.has_value());
+  EXPECT_EQ(*a, 0u);
+  EXPECT_EQ(*b, 4u);
+  EXPECT_EQ(*c, 8u);
+  EXPECT_EQ(m.total_private_bytes(), 12u);
+}
+
+TEST(SpillManager, AllocateIsIdempotentForSameRegister) {
+  SpillManager m(0, kBigLimit);
+  auto first = m.allocate_slot(sgpr(7));
+  ASSERT_TRUE(first.has_value());
+  const uint32_t bytes_after_first = m.total_private_bytes();
+
+  auto second = m.allocate_slot(sgpr(7));
+  ASSERT_TRUE(second.has_value());
+  EXPECT_EQ(*first, *second);
+  EXPECT_EQ(m.total_private_bytes(), bytes_after_first);
+}
+
+TEST(SpillManager, OffsetForReturnsNulloptForUnknown) {
+  SpillManager m(0, kBigLimit);
+  EXPECT_EQ(m.offset_for(sgpr(0)), std::nullopt);
+}
+
+TEST(SpillManager, OffsetForReturnsAllocatedOffset) {
+  SpillManager m(0, kBigLimit);
+  auto allocated = m.allocate_slot(sgpr(3));
+  ASSERT_TRUE(allocated.has_value());
+  auto looked_up = m.offset_for(sgpr(3));
+  ASSERT_TRUE(looked_up.has_value());
+  EXPECT_EQ(*looked_up, *allocated);
+}
+
+TEST(SpillManager, AllocateSlotsReturnsContiguousOffsets) {
+  SpillManager m(0, kBigLimit);
+  auto first = m.allocate_slots(sgpr(4), 2);
+  ASSERT_TRUE(first.has_value());
+  auto s4 = m.offset_for(sgpr(4));
+  auto s5 = m.offset_for(sgpr(5));
+  ASSERT_TRUE(s4.has_value());
+  ASSERT_TRUE(s5.has_value());
+  EXPECT_EQ(*s4, *first);
+  EXPECT_EQ(*s5, *first + 4u);
+  EXPECT_EQ(m.total_private_bytes(), 8u);
+}
+
+TEST(SpillManager, AllocateSlotsThenSingleSlotInterleaves) {
+  SpillManager m(0, kBigLimit);
+  auto pair1 = m.allocate_slots(sgpr(4), 2);
+  auto single = m.allocate_slot(sgpr(7));
+  auto pair2 = m.allocate_slots(vgpr(10), 2);
+  ASSERT_TRUE(pair1.has_value());
+  ASSERT_TRUE(single.has_value());
+  ASSERT_TRUE(pair2.has_value());
+  EXPECT_EQ(*pair1, 0u);
+  EXPECT_EQ(*m.offset_for(sgpr(5)), 4u);
+  EXPECT_EQ(*single, 8u);
+  EXPECT_EQ(*pair2, 12u);
+  EXPECT_EQ(*m.offset_for(vgpr(11)), 16u);
+  EXPECT_EQ(m.total_private_bytes(), 20u);
+}
+
+TEST(SpillManager, AllocateSlotsIsIdempotent) {
+  SpillManager m(0, kBigLimit);
+  auto first = m.allocate_slots(sgpr(4), 2);
+  ASSERT_TRUE(first.has_value());
+  const uint32_t bytes_after_first = m.total_private_bytes();
+
+  auto second = m.allocate_slots(sgpr(4), 2);
+  ASSERT_TRUE(second.has_value());
+  EXPECT_EQ(*first, *second);
+  EXPECT_EQ(m.total_private_bytes(), bytes_after_first);
+}
+
+TEST(SpillManager, TestSyntheticSet) {
+  SpillManager m(0, kBigLimit);
+  const std::vector<RegisterRef> regs = {
+      sgpr(2), vgpr(7), sgpr(0), sgpr(11), vgpr(3), sgpr(5),
+  };
+
+  std::vector<uint32_t> offsets;
+  for (auto reg : regs) {
+    auto off = m.allocate_slot(reg);
+    ASSERT_TRUE(off.has_value());
+    offsets.push_back(*off);
+  }
+
+  // Each slot occupies [offset, offset+4); assert no two slot ranges overlap.
+  for (size_t i = 0; i < offsets.size(); ++i) {
+    for (size_t j = i + 1; j < offsets.size(); ++j) {
+      const uint32_t lo = std::min(offsets[i], offsets[j]);
+      const uint32_t hi = std::max(offsets[i], offsets[j]);
+      EXPECT_GE(hi - lo, 4u) << "slots " << i << " (offset " << offsets[i] << ") and " << j
+                             << " (offset " << offsets[j] << ") overlap";
+    }
+  }
+
+  // Every slot's full [offset, offset+4) range lies within the reported
+  // per-lane scratch bytes — no slot extends past the cursor.
+  for (size_t i = 0; i < offsets.size(); ++i) {
+    EXPECT_LE(offsets[i] + 4u, m.total_private_bytes())
+        << "slot " << i << " (offset " << offsets[i] << ") past total_private_bytes "
+        << m.total_private_bytes();
+  }
+
+  // 6 non-overlapping 4-byte slots fit in exactly 24 bytes — implies tight
+  // packing with each slot exactly 4 bytes wide and no padding.
+  EXPECT_EQ(m.total_private_bytes(), 24u);
+}
+
+TEST(SpillManager, VgprSlotIsFourBytesNotWaveSizeTimesFour) {
+  SpillManager m(0, kBigLimit);
+  const uint32_t before = m.total_private_bytes();
+  ASSERT_TRUE(m.allocate_slot(vgpr(0)).has_value());
+  EXPECT_EQ(m.total_private_bytes() - before, 4u);
+}
+
+TEST(SpillManager, AccVgprAndVgprSameIndexHaveDistinctSlots) {
+  SpillManager m(0, kBigLimit);
+  auto v_off = m.allocate_slot(vgpr(5));
+  auto a_off = m.allocate_slot(accvgpr(5));
+  ASSERT_TRUE(v_off.has_value());
+  ASSERT_TRUE(a_off.has_value());
+  EXPECT_NE(*v_off, *a_off);
+  EXPECT_EQ(m.offset_for(vgpr(5)), v_off);
+}
+
+TEST(SpillManager, AccVgprIs4Bytes) {
+  SpillManager m(0, kBigLimit);
+  const uint32_t before = m.total_private_bytes();
+  ASSERT_TRUE(m.allocate_slot(accvgpr(0)).has_value());
+  EXPECT_EQ(m.total_private_bytes() - before, 4u);
+}
+
+// Pins the contract that allocate_slot returns a per-lane *byte offset* that
+// composes additively with the per-lane flat-scratch addressing formula
+//   flat_scratch_base_byte_addr[lane] = FLAT_SCRATCH_INIT
+//                                     + lane * private_segment_fixed_size
+// If this test ever needs editing, the trampoline emitter (Phase 6) is also
+// broken. We use a *non-zero* slot so the `+ slot_offset` term is exercised
+// (the lane=0/slot=0 case alone is a tautology).
+TEST(SpillManager, SlotAddressMatchesFlatScratchFormula) {
+  SpillManager m(/*orig=*/0, /*limit=*/16384);
+  ASSERT_TRUE(m.allocate_slot(sgpr(0)).has_value());
+  auto slot1 = m.allocate_slot(sgpr(1));
+  ASSERT_TRUE(slot1.has_value());
+  EXPECT_EQ(*slot1, 4u);
+
+  constexpr uint64_t kFlatScratchInit = 0xCAFEBA5Eull;
+  const uint32_t per_lane_bytes = m.total_private_bytes();
+
+  {
+    constexpr uint32_t lane = 0;
+    const uint64_t addr = kFlatScratchInit + lane * per_lane_bytes + *slot1;
+    EXPECT_EQ(addr, kFlatScratchInit + 4u);
+  }
+  {
+    constexpr uint32_t lane = 1;
+    const uint64_t addr = kFlatScratchInit + lane * per_lane_bytes + *slot1;
+    EXPECT_EQ(addr, kFlatScratchInit + per_lane_bytes + 4u);
+  }
+}
+
+TEST(SpillManager, ReserveSet_AddsAllRegisters) {
+  RegisterSet set;
+  for (uint16_t i : {0, 2, 5, 11})
+    set.expand(sgpr(i));
+  for (uint16_t i : {3, 7})
+    set.expand(vgpr(i));
+
+  SpillManager m(0, kBigLimit);
+  EXPECT_TRUE(m.reserve(set));
+  EXPECT_EQ(m.total_private_bytes(), 24u);
+
+  for (uint16_t i : {0, 2, 5, 11})
+    EXPECT_TRUE(m.offset_for(sgpr(i)).has_value());
+  for (uint16_t i : {3, 7})
+    EXPECT_TRUE(m.offset_for(vgpr(i)).has_value());
+}
+
+TEST(SpillManager, ReserveSet_IsIdempotent) {
+  RegisterSet set;
+  for (uint16_t i : {0, 2, 5, 11})
+    set.expand(sgpr(i));
+  for (uint16_t i : {3, 7})
+    set.expand(vgpr(i));
+
+  SpillManager m(0, kBigLimit);
+  ASSERT_TRUE(m.reserve(set));
+  const uint32_t bytes_after_first = m.total_private_bytes();
+
+  EXPECT_TRUE(m.reserve(set));
+  EXPECT_EQ(m.total_private_bytes(), bytes_after_first);
+}
+
+TEST(SpillManager, ReserveSet_HandlesEmpty) {
+  SpillManager m(0, kBigLimit);
+  const uint32_t before = m.total_private_bytes();
+  EXPECT_TRUE(m.reserve(RegisterSet{}));
+  EXPECT_EQ(m.total_private_bytes(), before);
+}
+
+TEST(SpillManager, AllocateSlotReturnsNulloptOnOverflow) {
+  SpillManager m(0, /*limit=*/8);
+  EXPECT_TRUE(m.allocate_slot(sgpr(0)).has_value());
+  EXPECT_TRUE(m.allocate_slot(sgpr(1)).has_value());
+
+  EXPECT_EQ(m.allocate_slot(sgpr(2)), std::nullopt);
+  EXPECT_EQ(m.total_private_bytes(), 8u);
+  EXPECT_EQ(m.offset_for(sgpr(2)), std::nullopt);
+}
+
+// Limit chosen so the first sub-slot fits at offset 8 (8+4 = 12 <= 12) but the
+// second fails at offset 12 (12+4 = 16 > 12) — exercises the partial-rollback
+// path.
+TEST(SpillManager, AllocateSlotsRollsBackOnPartialOverflow) {
+  SpillManager m(0, /*limit=*/12);
+  ASSERT_TRUE(m.allocate_slots(sgpr(4), 2).has_value());
+  ASSERT_EQ(m.total_private_bytes(), 8u);
+
+  EXPECT_EQ(m.allocate_slots(sgpr(6), 2), std::nullopt);
+  EXPECT_EQ(m.total_private_bytes(), 8u);
+  EXPECT_EQ(m.offset_for(sgpr(6)), std::nullopt);
+  EXPECT_EQ(m.offset_for(sgpr(7)), std::nullopt);
+
+  // Proves next_offset_ was actually rewound (not just total_bytes_): a
+  // subsequent single-slot allocation lands at the rolled-back cursor.
+  auto recovered = m.allocate_slot(sgpr(6));
+  ASSERT_TRUE(recovered.has_value());
+  EXPECT_EQ(*recovered, 8u);
+}
+
+TEST(SpillManager, ReserveRollsBackOnOverflow) {
+  RegisterSet set;
+  for (uint16_t i : {0, 1, 2})
+    set.expand(sgpr(i));
+
+  SpillManager m(0, /*limit=*/8);
+  EXPECT_FALSE(m.reserve(set));
+  EXPECT_EQ(m.total_private_bytes(), 0u);
+  for (uint16_t i : {0, 1, 2})
+    EXPECT_EQ(m.offset_for(sgpr(i)), std::nullopt);
+}
+
+TEST(SpillManager, LimitBoundaryFitsExactly) {
+  SpillManager m(0, /*limit=*/8);
+  auto a = m.allocate_slot(sgpr(0));
+  auto b = m.allocate_slot(sgpr(1));
+  ASSERT_TRUE(a.has_value());
+  ASSERT_TRUE(b.has_value());
+  EXPECT_EQ(*a, 0u);
+  EXPECT_EQ(*b, 4u);
+  EXPECT_EQ(m.total_private_bytes(), 8u);
+
+  EXPECT_EQ(m.allocate_slot(sgpr(2)), std::nullopt);
+}
+
+// At limit=4, exactly one slot fits. A second NEW allocation would fail, but
+// re-allocating the same register must hit the cache before the limit check.
+TEST(SpillManager, IdempotentReallocationUnderTightLimit) {
+  SpillManager m(0, /*limit=*/4);
+  auto first = m.allocate_slot(sgpr(0));
+  ASSERT_TRUE(first.has_value());
+  EXPECT_EQ(*first, 0u);
+  EXPECT_EQ(m.total_private_bytes(), 4u);
+
+  // A new register would fail.
+  EXPECT_EQ(m.allocate_slot(sgpr(1)), std::nullopt);
+
+  // But re-alloc of the same register hits the cache and succeeds.
+  auto second = m.allocate_slot(sgpr(0));
+  ASSERT_TRUE(second.has_value());
+  EXPECT_EQ(*second, *first);
+}
+
+TEST(SpillManager, AllocateSlotsWidth1EqualsAllocateSlot) {
+  SpillManager m(0, kBigLimit);
+  auto via_slots = m.allocate_slots(sgpr(0), 1);
+  ASSERT_TRUE(via_slots.has_value());
+  EXPECT_EQ(*via_slots, 0u);
+  EXPECT_EQ(m.total_private_bytes(), 4u);
+  EXPECT_EQ(m.offset_for(sgpr(0)), via_slots);
+}
+
+TEST(SpillManager, AllocateSlotsWidth0ReturnsNullopt) {
+  SpillManager m(0, kBigLimit);
+  EXPECT_EQ(m.allocate_slots(sgpr(0), 0), std::nullopt);
+  EXPECT_EQ(m.total_private_bytes(), 0u);
+  EXPECT_EQ(m.offset_for(sgpr(0)), std::nullopt);
+}
+
+TEST(SpillManager, AllocateSlotsRejectsIndexOverflow) {
+  SpillManager m(0, kBigLimit);
+  // reg.index + width - 1 = 0xFFFE + 4 - 1 = 0x10001 > UINT16_MAX.
+  EXPECT_EQ(m.allocate_slots(sgpr(0xFFFE), 4), std::nullopt);
+  EXPECT_EQ(m.total_private_bytes(), 0u);
+  EXPECT_EQ(m.offset_for(sgpr(0xFFFE)), std::nullopt);
+}
+
+// `allocate_slots` rejects ranges that would extend past the per-class
+// hardware bound, rather than silently truncating via RegisterSet::expand.
+TEST(SpillManager, AllocateSlotsRejectsPerClassOverflow) {
+  SpillManager m(0, kBigLimit);
+  // base + width = REGISTER_SET_MAX_SGPRS + 1 → past bound.
+  const uint16_t base = static_cast<uint16_t>(REGISTER_SET_MAX_SGPRS - 1);
+  EXPECT_EQ(m.allocate_slots(sgpr(base), 2), std::nullopt);
+  EXPECT_EQ(m.total_private_bytes(), 0u);
+  EXPECT_EQ(m.offset_for(sgpr(base)), std::nullopt);
+
+  // A within-bound width-1 allocation at the last index still works.
+  auto last = m.allocate_slot(sgpr(base));
+  ASSERT_TRUE(last.has_value());
+  EXPECT_EQ(*last, 0u);
+
+  // And a width-1 allocate_slots at the last index is also fine (within bound).
+  // Width 2 is the smallest that overflows here.
+  auto last_via_slots = m.allocate_slots(sgpr(base), 1);
+  ASSERT_TRUE(last_via_slots.has_value());
+  EXPECT_EQ(*last_via_slots, *last); // idempotent
+}
+
+// reserve() called twice with overlapping sets only consumes new bytes for
+// registers that weren't already cached.
+TEST(SpillManager, ReserveSet_PartialOverlap) {
+  SpillManager m(0, kBigLimit);
+
+  RegisterSet first;
+  for (uint16_t i : {0, 1})
+    first.expand(sgpr(i));
+  ASSERT_TRUE(m.reserve(first));
+  EXPECT_EQ(m.total_private_bytes(), 8u);
+
+  // Superset: 0 and 1 are cached; 2 and 3 are new. Only 8 more bytes expected.
+  RegisterSet second;
+  for (uint16_t i : {0, 1, 2, 3})
+    second.expand(sgpr(i));
+  EXPECT_TRUE(m.reserve(second));
+  EXPECT_EQ(m.total_private_bytes(), 16u);
+
+  for (uint16_t i : {0, 1, 2, 3})
+    EXPECT_TRUE(m.offset_for(sgpr(i)).has_value());
+  // Cached registers kept their original offsets.
+  EXPECT_EQ(m.offset_for(sgpr(0)), 0u);
+  EXPECT_EQ(m.offset_for(sgpr(1)), 4u);
+}
+
+// If the original private segment already exceeds the per-lane cap (rounded up
+// to the DBI alignment), the manager is constructible but every allocation
+// must fail — there's no room to append a DBI zone.
+TEST(SpillManager, ConstructorOverLimitFailsAllAllocations) {
+  SpillManager m(/*orig=*/100, /*limit=*/8);
+  EXPECT_EQ(m.allocate_slot(sgpr(0)), std::nullopt);
+  EXPECT_EQ(m.allocate_slots(sgpr(1), 2), std::nullopt);
+
+  RegisterSet set;
+  set.expand(sgpr(2));
+  EXPECT_FALSE(m.reserve(set));
+}
+
+// End-to-end smoke test: feed a real LivenessAnalysis result into SpillManager.
+TEST(SpillManager, IntegrationFromLiveBefore) {
+  // Build a tiny single-block kernel:
+  //   I0: def vgpr 0, def sgpr 4
+  //   I1: def vgpr 1
+  //   I2: use vgpr 0, use sgpr 4   <-- probe site (vgpr 1 stays live across)
+  //   I3: use vgpr 1
+  //   I4: end
+  std::vector<uint32_t> words = {
+      static_cast<uint32_t>(IntegOpcode::Def_Vgpr0_Sgpr4),
+      static_cast<uint32_t>(IntegOpcode::Def_Vgpr1),
+      static_cast<uint32_t>(IntegOpcode::Use_Vgpr0_Sgpr4),
+      static_cast<uint32_t>(IntegOpcode::Use_Vgpr1),
+      static_cast<uint32_t>(IntegOpcode::End),
+  };
+  TestCodeObject co(std::move(words));
+  IntegDecoder decoder;
+  auto blocks = BasicBlock::build(co, decoder, std::span<const uint64_t>{});
+  ASSERT_FALSE(blocks.empty());
+
+  // Pick the probe-site instruction by mnemonic match.
+  const Instruction *probe = nullptr;
+  for (const auto &block : blocks) {
+    for (const auto &inst : block->instructions()) {
+      if (inst.disassemble().find("i2_probe_site") != std::string::npos) {
+        probe = &inst;
+        break;
+      }
+    }
+    if (probe)
+      break;
+  }
+  ASSERT_NE(probe, nullptr);
+
+  std::vector<BasicBlock *> scope;
+  for (const auto &b : blocks)
+    scope.push_back(b.get());
+  LivenessAnalysis liveness{KernelBlockScope(scope)};
+  const RegisterSet &live = liveness.live_before(*probe);
+  ASSERT_FALSE(live.none()) << "expected at least one live register at probe site";
+
+  // Make up the private scratch size
+  constexpr uint32_t kOrigPrivateBytes = 100;
+  SpillManager m(kOrigPrivateBytes, /*limit=*/16384);
+  EXPECT_TRUE(m.reserve(live));
+
+  // total = round_up(orig, 16) + kSlotBytes * |live|. round_up(100, 16) == 112.
+  constexpr uint32_t kExpectedBase = 112;
+  EXPECT_EQ(m.total_private_bytes(),
+            kExpectedBase + SpillManager::kSlotBytes * static_cast<uint32_t>(live.size()));
+
+  // Every live register has an offset; collect them to check pairwise distinct.
+  std::vector<uint32_t> offsets;
+  live.for_each([&](RegisterRef r) {
+    auto off = m.offset_for(r);
+    EXPECT_TRUE(off.has_value()) << "missing offset for live register";
+    if (off.has_value())
+      offsets.push_back(*off);
+  });
+  for (size_t i = 0; i < offsets.size(); ++i) {
+    for (size_t j = i + 1; j < offsets.size(); ++j) {
+      EXPECT_NE(offsets[i], offsets[j]) << "alias: live registers at indices " << i << " and " << j
+                                        << " share offset " << offsets[i];
+    }
+  }
+}
+
+} // namespace
+} // namespace rocjitsu


### PR DESCRIPTION
## Motivation

Implemented the SpillManager as described in Section 2.3 and Phase 5 of the DBT/DBI plan. Simple SpillManager which will be used to update the private segment so that there is enough room for instrumentation to spill registers there. Users (the Instrumentor) can allocate a spill slot for a register or a set of registers. The SpillManager keeps track of which registers have already been allocated a slot so it will not allocate new slots if the same registers are requested multiple times.

## Technical Details

There was not too much deviation from the DBT/DBI plan. The one thing to note is that a part of section 2.3 discusses clobbered AccVGPRs and offline discussion decided that this could/should be resolved later. Another deviation is that the SpillManager is constructed with a limit, since that seemed prudent at the time, but it can be undone.  Very few changes were required outside of the class.

There are two defined members of the class: 1) slot size (set to 4 bytes) and 2) how much to round the base offset to (called kDbiZoneAlignment and is set to 16). I made them class members because that's where I thought those values belonged and I chose those numbers since that was what was described in the document. LMK if I should make them more configurable.

AI helped with generating, commenting, and reviewing the code/tests.

## Test Plan

Added a series of tests to test the class as well as an integration test that uses the results of LivenessAnalysis.

Run all other python and c++ test suites.

## Test Result

Tests pass!

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
