### PR TITLE
[RCCL][AICOMNET-191] Revoke Tests - Destroy Fix to Resolve 64np+ Hang 

### DIFF
--- a/projects/rccl/test/RevokeMPITests.cpp
+++ b/projects/rccl/test/RevokeMPITests.cpp
@@ -151,7 +151,6 @@ TEST_F(RevokeMPITest, RevokeThenShrink_ChildWorks)
                                  &child, nullptr, NCCL_SHRINK_DEFAULT));
 
         ASSERT_NE(child, nullptr);
-        auto child_guard = makeCommAutoGuard(child);
 
         void* send_buf = nullptr;
         void* recv_buf = nullptr;
@@ -167,6 +166,15 @@ TEST_F(RevokeMPITest, RevokeThenShrink_ChildWorks)
                   ncclAllReduce(send_buf, recv_buf, 1, ncclFloat, ncclSum, child, stream));
 
         HIP_TEST_CHECK_GTEST_FAIL(hipStreamSynchronize(stream));
+    }
+
+    // Barrier before child destruction ensures all participating ranks
+    // complete their operations before any rank starts destroying
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if(!isExcluded)
+    {
+        ASSERT_EQ(ncclSuccess, ncclCommDestroy(child));
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
@@ -259,11 +267,18 @@ TEST_F(RevokeMPITest, Collective_Revoke_Shrink_Collective)
 
     if(!isExcluded)
     {
-        auto child_guard = makeCommAutoGuard(child);
-
         ASSERT_EQ(ncclSuccess,
                   ncclAllReduce(send_buf, recv_buf, kCount, ncclFloat, ncclSum, child, stream));
         HIP_TEST_CHECK_GTEST_FAIL(hipStreamSynchronize(stream));
+    }
+
+    // Barrier before child destruction ensures all participating ranks
+    // complete their operations before any rank starts destroying
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if(!isExcluded)
+    {
+        ASSERT_EQ(ncclSuccess, ncclCommDestroy(child));
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
@@ -338,8 +353,6 @@ TEST_F(RevokeMPITest, P2P_Revoke_Shrink_P2P)
 
     if(!isExcluded)
     {
-        auto child_guard = makeCommAutoGuard(child);
-
         int child_rank = -1;
         int child_size = 0;
         ASSERT_EQ(ncclSuccess, ncclCommUserRank(child, &child_rank));
@@ -359,6 +372,15 @@ TEST_F(RevokeMPITest, P2P_Revoke_Shrink_P2P)
         ASSERT_EQ(ncclSuccess, ncclGroupEnd());
 
         HIP_TEST_CHECK_GTEST_FAIL(hipStreamSynchronize(stream));
+    }
+
+    // Barrier before child destruction ensures all participating ranks
+    // complete their operations before any rank starts destroying
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if(!isExcluded)
+    {
+        ASSERT_EQ(ncclSuccess, ncclCommDestroy(child));
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
@@ -499,11 +521,18 @@ TEST_F(RevokeMPITest, IncompleteCollective_Revoke_Shrink_Collective)
 
     if(!isExcluded)
     {
-        auto child_guard = makeCommAutoGuard(child);
-
         ASSERT_EQ(ncclSuccess,
                   ncclAllReduce(send_buf, recv_buf, kCount, ncclFloat, ncclSum, child, stream));
         HIP_TEST_CHECK_GTEST_FAIL(hipStreamSynchronize(stream));
+    }
+
+    // Barrier before child destruction ensures all participating ranks
+    // complete their operations before any rank starts destroying
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if(!isExcluded)
+    {
+        ASSERT_EQ(ncclSuccess, ncclCommDestroy(child));
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
@@ -595,11 +624,18 @@ TEST_F(RevokeMPITest, Collective_Revoke_AsymmetricShrink_Collective)
 
     if(!isExcluded)
     {
-        auto child_guard = makeCommAutoGuard(child);
-
         ASSERT_EQ(ncclSuccess,
                   ncclAllReduce(send_buf, recv_buf, kCount, ncclFloat, ncclSum, child, stream));
         HIP_TEST_CHECK_GTEST_FAIL(hipStreamSynchronize(stream));
+    }
+
+    // Barrier before child destruction ensures all participating ranks
+    // complete their operations before any rank starts destroying
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if(!isExcluded)
+    {
+        ASSERT_EQ(ncclSuccess, ncclCommDestroy(child));
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
@@ -668,11 +704,18 @@ TEST_F(RevokeMPITest, ShrinkAbort_InFlight_ChildWorks_RankRenumbering)
 
     if(!isExcluded)
     {
-        auto child_guard = makeCommAutoGuard(child);
-
         ASSERT_EQ(ncclSuccess,
                   ncclAllReduce(send_buf, recv_buf, kCount, ncclFloat, ncclSum, child, stream));
         HIP_TEST_CHECK_GTEST_FAIL(hipStreamSynchronize(stream));
+    }
+
+    // Barrier before child destruction ensures all participating ranks
+    // complete their operations before any rank starts destroying
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if(!isExcluded)
+    {
+        ASSERT_EQ(ncclSuccess, ncclCommDestroy(child));
     }
 
     MPI_Barrier(MPI_COMM_WORLD);


### PR DESCRIPTION
## Motivation

When testing the revoke tests at 64 ranks+, the following test hangs: RevokeMPITest.P2P_Revoke_Shrink_P2P. Add barriers before child destruction to ensure all participating ranks complete their operations before any rank starts destroying in newly added revoke tests. 

## Technical Details

When running tests at scale (64 processes across 8 nodes), some tests create a child communicator that only includes some ranks (e.g., 56 out of 64). The 56 ranks finish their work and destroy the child comm at slightly different times. Meanwhile, the 8 excluded ranks are already waiting at the MPI_Barrier. Add an MPI_Barrier before destroying, so all ranks sync up first. All 64 ranks hit the first barrier together. Then all 56 participating ranks start ncclCommDestroy at roughly the same time. 

## JIRA ID

AICOMNET-191

## Test Plan

Tested on 2,4,8,16 nodes. 

## Test Result

Results on 64 ranks: 

[----------] Global test environment tear-down
[==========] 15 tests from 1 test suite ran. (41640 ms total)
[  PASSED  ] 15 tests.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
