### PR TITLE
Adding realtime low32 bits to trace decoder

### DIFF
--- a/projects/rocprof-trace-decoder/include/trace_decoder_instrument.h
+++ b/projects/rocprof-trace-decoder/include/trace_decoder_instrument.h
@@ -27,13 +27,14 @@
 
 /**
  * This file describes the instrumentation format for rocprof trace decoder 0.1.5.
- * Instrumentation is optional for decoding, with the exception of rocprof_trace_decoder_gfx9_header_t.
- * Unless specified, all instrumentation packets are written to the USERDATA2 register.
- * This is an experimental feature, and as such the instrumentation may be changed without notice.
+ * Instrumentation is optional for decoding, with the exception of
+ * rocprof_trace_decoder_gfx9_header_t. Unless specified, all instrumentation packets are written to
+ * the USERDATA2 register. This is an experimental feature, and as such the instrumentation may be
+ * changed without notice.
  *
- * It is recommended to use code object instrumentation for long traces, to avoid overlapping address spaces
- * if code objects are loaded/unloaded during the trace.
- * When an ID is found, callbacks involving _trace_decoder_pc_t will return {id, vaddr} instead of {0, memory_address}.
+ * It is recommended to use code object instrumentation for long traces, to avoid overlapping
+ * address spaces if code objects are loaded/unloaded during the trace. When an ID is found,
+ * callbacks involving _trace_decoder_pc_t will return {id, vaddr} instead of {0, memory_address}.
  */
 
 /**
@@ -41,15 +42,16 @@
  */
 typedef union rocprof_trace_decoder_gfx9_header_t
 {
-    struct {
+    struct
+    {
         uint64_t legacy_version : 13; ///< Must be 0x0 or 0x11
-        uint64_t gfx9_version2 : 3;   ///< 4: MI200 or earlier - 5: MI300 - 6: MI350
-        uint64_t DSIMDM : 4;          ///< Bitmask of SIMDs active
-        uint64_t DCU : 5;             ///< Target CU
-        uint64_t DSA : 1;             ///< Must be zero
-        uint64_t SEID : 6;            ///< Optional: Shader engine ID
-        uint64_t double_buffer : 1;   ///< Double buffering mode enabled
-        uint64_t reserved2 : 31;
+        uint64_t gfx9_version2  : 3;  ///< 4: MI200 or earlier - 5: MI300 - 6: MI350
+        uint64_t DSIMDM         : 4;  ///< Bitmask of SIMDs active
+        uint64_t DCU            : 5;  ///< Target CU
+        uint64_t DSA            : 1;  ///< Must be zero
+        uint64_t SEID           : 6;  ///< Optional: Shader engine ID
+        uint64_t double_buffer  : 1;  ///< Double buffering mode enabled
+        uint64_t reserved2      : 31;
     };
     uint64_t raw;
 } rocprof_trace_decoder_gfx9_header_t;
@@ -61,11 +63,12 @@ typedef union rocprof_trace_decoder_gfx9_header_t
  */
 typedef union rocprof_trace_decoder_instrument_enable_t
 {
-    struct {
-        unsigned int char1 : 8;  ///< '\0'
-        unsigned int char2 : 8;  ///< 'R'
-        unsigned int char3 : 8;  ///< 'O'
-        unsigned int char4 : 8;  ///< 'C'
+    struct
+    {
+        unsigned int char1 : 8; ///< '\0'
+        unsigned int char2 : 8; ///< 'R'
+        unsigned int char3 : 8; ///< 'O'
+        unsigned int char4 : 8; ///< 'C'
     };
     unsigned int u32All;
 } rocprof_trace_decoder_instrument_enable_t;
@@ -73,24 +76,35 @@ typedef union rocprof_trace_decoder_instrument_enable_t
 /**
  * @brief Header packet for instrumentation.
  * Opcode defines the kind of instrumentation, and type (sometimes) defines a subtype.
- * Header packets are expected to be followed by a 32-bit payload on the same register, except where especified.
+ * Header packets are expected to be followed by a 32-bit payload on the same register, except where
+ * especified.
  */
 typedef union rocprof_trace_decoder_packet_header_t
 {
     struct
     {
         unsigned int opcode : 8;  ///< one of rocprof_trace_decoder_packet_opcode_t
-        unsigned int type : 4;    ///< one of rocprof_trace_decoder_agent_info_type_t or rocprof_trace_decoder_codeobj_marker_type_t
+        unsigned int type   : 4;  ///< one of rocprof_trace_decoder_agent_info_type_t or
+                                  ///< rocprof_trace_decoder_codeobj_marker_type_t
         unsigned int data20 : 20; ///< Agent data, if rocprof_trace_decoder_agent_info_type_t.
+                                  ///< For opcodes whose payload is a stream of writes on a
+                                  ///< separate register (e.g. RT_TIMESTAMP / RT_TIMESTAMP_LO32
+                                  ///< on USERDATA3), this carries the number of follow-up
+                                  ///< writes the producer will emit. Decoders should consume
+                                  ///< exactly that many writes — extra fields appended by
+                                  ///< future format revisions can then be skipped without
+                                  ///< breaking previous decoder versions. A value of 0 means
+                                  ///< "use the legacy fixed count for this opcode".
     };
     unsigned int u32All;
 } rocprof_trace_decoder_packet_header_t;
 
 typedef enum rocprof_trace_decoder_packet_opcode_t
 {
-    ROCPROF_TRACE_DECODER_PACKET_OPCODE_CODEOBJ = 4, 
+    ROCPROF_TRACE_DECODER_PACKET_OPCODE_CODEOBJ = 4,
     ROCPROF_TRACE_DECODER_PACKET_OPCODE_RT_TIMESTAMP,
-    ROCPROF_TRACE_DECODER_PACKET_OPCODE_AGENT_INFO     ///< Agent info, passed in data20. No payload.
+    ROCPROF_TRACE_DECODER_PACKET_OPCODE_AGENT_INFO, ///< Agent info, passed in data20. No payload.
+    ROCPROF_TRACE_DECODER_PACKET_OPCODE_RT_TIMESTAMP_LO32
 
     /// @var ROCPROF_TRACE_DECODER_PACKET_OPCODE_CODEOBJ
     /// @brief Followed by several rocprof_trace_decoder_codeobj_marker_t
@@ -99,29 +113,45 @@ typedef enum rocprof_trace_decoder_packet_opcode_t
     /// @var ROCPROF_TRACE_DECODER_PACKET_OPCODE_RT_TIMESTAMP
     /// @brief Realtime timestamp to correlate the trace with outside information.
     /// Notes: userdata--3--. Gfx9 only. Not necessary for gfx10+.
-    /// Instead of a single payload, must be followed by 3x USERDATA3 writes, in order:
+    /// Instead of a single payload, must be followed by USERDATA3 writes whose count is
+    /// reported by data20 (legacy producers emit data20=0, meaning the original fixed count
+    /// of 3). The first 3 writes carry, in order:
     /// 1) Timestamp low 64bits
     /// 2) Timestamp high 64bits
     /// 3) Instant sync timestamp, low 32 bits.
+    /// Any additional writes beyond the first 3 belong to future format revisions and should
+    /// be consumed and ignored by older decoders.
+
+    /// @var ROCPROF_TRACE_DECODER_PACKET_OPCODE_RT_TIMESTAMP_LO32
+    /// @brief Periodic realtime timestamp emitted from query_status packets in double/triple
+    /// buffer mode. Notes: userdata--3--. Gfx9 only. Not necessary for gfx10+.
+    /// Followed by USERDATA3 writes whose count is reported by data20 (legacy producers emit
+    /// data20=0, meaning the original fixed count of 1). The first write carries the low 32
+    /// bits of the GPU clock counter. The high 32 bits are extrapolated by the decoder from
+    /// the most recent full RT_TIMESTAMP, detecting wraps when the new low-32 is less than
+    /// the previous low-32. Additional writes belong to future revisions and should be
+    /// consumed and ignored by older decoders.
 } rocprof_trace_decoder_packet_opcode_t;
 
 typedef enum rocprof_trace_decoder_agent_info_type_t
 {
-    ROCPROF_TRACE_DECODER_AGENT_INFO_TYPE_RT_FREQUENCY_KHZ = 0,  ///< Realtime TS frequency in Khz
-    ROCPROF_TRACE_DECODER_AGENT_INFO_TYPE_COUNTER_INTERVAL,      ///< (gfx9) SQTT counter interval in cycles
+    ROCPROF_TRACE_DECODER_AGENT_INFO_TYPE_RT_FREQUENCY_KHZ = 0, ///< Realtime TS frequency in Khz
+    ROCPROF_TRACE_DECODER_AGENT_INFO_TYPE_COUNTER_INTERVAL,     ///< (gfx9) SQTT counter interval in
+                                                                ///< cycles
     ROCPROF_TRACE_DECODER_AGENT_INFO_TYPE_LAST
 } rocprof_trace_decoder_agent_info_type_t;
 
 /**
  * @brief Applies code object instrumentation. Sent as the last code object instrumentation packet.
  * Instead of _ID_LO and _ID_HI, the legacy_id field can be used for setting the ID.
- * IDs can be any (nonzero) user defined number, and will be used in callbacks involving _trace_decoder_pc_t.
- * The combination {id, offset} instead of {0, memory_address} is used to avoid overlapping
- * addresses when code objects are loaded/unloaded during the trace.
+ * IDs can be any (nonzero) user defined number, and will be used in callbacks involving
+ * _trace_decoder_pc_t. The combination {id, offset} instead of {0, memory_address} is used to avoid
+ * overlapping addresses when code objects are loaded/unloaded during the trace.
  */
 typedef union rocprof_trace_decoder_codeobj_marker_tail_t
 {
-    struct {
+    struct
+    {
         uint32_t isUnload   : 1;  // 0 if code object is being loaded, 1 for unload
         uint32_t bFromStart : 1;  // Has this code object been loaded before thread trace started?
         uint32_t legacy_id  : 30; // Nonzero: Code object ID, if it fits in 30 bits.

--- a/projects/rocprof-trace-decoder/source/gfx9/gfx9wave.cpp
+++ b/projects/rocprof-trace-decoder/source/gfx9/gfx9wave.cpp
@@ -638,22 +638,45 @@ void CSRegisterHandlerGFX9::HandleRealtimeClock(size_t time, size_t data)
 
     if (userdata3_count == 0)
     {
-        if (data == 0x5) userdata3_count = 3;
+        rocprof_trace_decoder_packet_header_t header{};
+        header.u32All = static_cast<uint32_t>(data);
+
+        if (header.opcode == ROCPROF_TRACE_DECODER_PACKET_OPCODE_RT_TIMESTAMP)
+        {
+            userdata3_count = header.data20 ? static_cast<int>(header.data20) : 3;
+            userdata3_known = true;
+        }
+        else if (header.opcode == ROCPROF_TRACE_DECODER_PACKET_OPCODE_RT_TIMESTAMP_LO32)
+        {
+            userdata3_count = header.data20 ? static_cast<int>(header.data20) : 1;
+            userdata3_known = true;
+            userdata3_values[RT_LOW] = userdata3_values[RT_DELTA];
+        }
+        else
+        {
+            userdata3_count = static_cast<int>(header.data20);
+            userdata3_known = false;
+        }
         return;
     }
 
     userdata3_count--;
-    userdata3_values[userdata3_count] = data;
+    if (!userdata3_known) return;
 
+    if (userdata3_count < RT_LAST) userdata3_values[userdata3_count] = data;
     if (userdata3_count > 0) return;
+
+    // Detect a 32-bit wrap of the realtime clock low half between consecutive
+    // RT_TIMESTAMP_LO32 emissions. RT_LOW is the previously latched low half
+    // and RT_DELTA is the freshly received one; both are GPU clock samples
+    // taken close in time, so they differ only by the elapsed cycles. A
+    // smaller new sample means the low 32 bits rolled over, so bump the high
+    // half by one to reconstruct the true 64-bit value.
+    if (userdata3_values[RT_DELTA] < userdata3_values[RT_LOW]) userdata3_values[RT_HI]++;
 
     att_decoder_realtime_t rt{};
     rt.shader_clock = time;
     rt.realtime_clock = userdata3_values[RT_DELTA] | (userdata3_values[RT_HI] << 32);
-
-    // handle wrapping of lowest 32 bits
-    if (userdata3_values[RT_DELTA] < userdata3_values[RT_LOW]) rt.realtime_clock += 1ul << 32;
-
     realtime.push_back(rt);
 }
 

--- a/projects/rocprof-trace-decoder/source/gfx9/gfx9wave.cpp
+++ b/projects/rocprof-trace-decoder/source/gfx9/gfx9wave.cpp
@@ -661,7 +661,7 @@ void CSRegisterHandlerGFX9::HandleRealtimeClock(size_t time, size_t data)
     }
 
     userdata3_count--;
-    if (!userdata3_known) return;
+    if (!userdata3_known || userdata3_count < 0) return;
 
     if (userdata3_count < RT_LAST) userdata3_values[userdata3_count] = data;
     if (userdata3_count > 0) return;

--- a/projects/rocprof-trace-decoder/source/gfx9/gfx9wave.h
+++ b/projects/rocprof-trace-decoder/source/gfx9/gfx9wave.h
@@ -72,6 +72,7 @@ public:
     };
 
     int userdata3_count = 0;
+    bool userdata3_known = false;
     std::array<size_t, RT_LAST> userdata3_values{};
 };
 


### PR DESCRIPTION
## Motivation

Currently, gfx9 only sends to realtime timestamps into thread trace.
In double buffer mode, we are periodically sending query packets in the order of ~1ms. We can reuse those packets to send the LOW32 bits of realtime into the trace for matching with external API events and SPM.

This is a decoder-only cherry pick of https://github.com/ROCm/rocm-systems/pull/5653

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
