### PR TITLE
[DNM][test] Bump timemory pin to validate C++20 work (ROCm/timemory#35)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -64,7 +64,7 @@
 [submodule "projects/rocprofiler-systems/external/timemory"]
 	path = projects/rocprofiler-systems/external/timemory
 	url = https://github.com/ROCm/timemory.git
-	branch = rocprofiler-systems
+	branch = users/adjordje-amd/cpp20-iter-disambiguate
 [submodule "projects/rocprofiler-systems/external/perfetto"]
 	path = projects/rocprofiler-systems/external/perfetto
 	url = https://github.com/google/perfetto.git

--- a/projects/rocprofiler-systems/cmake/Packages.cmake
+++ b/projects/rocprofiler-systems/cmake/Packages.cmake
@@ -919,7 +919,7 @@ rocprofiler_systems_checkout_git_submodule(
     RELATIVE_PATH external/timemory
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     REPO_URL https://github.com/ROCm/timemory.git
-    REPO_BRANCH omnitrace
+    REPO_BRANCH users/adjordje-amd/cpp20-iter-disambiguate
 )
 
 rocprofiler_systems_save_variables(


### PR DESCRIPTION
## Motivation

Validate that bumping the timemory submodule pin to the C++20 work in flight (ROCm/timemory#35) does not regress rocm-systems CI on `develop`.

This is a **test PR** - not for merge. Goal: see if the rocprofiler-systems C++17 build succeeds against a timemory whose own CMakeLists has been bumped to C++20. If CI is green, ROCm/timemory#35 is safe to merge into the rocprofiler-systems consumer branch and propagate downstream.

## Technical Details

Single-file change: `projects/rocprofiler-systems/external/timemory` submodule pin moves from `6b967ed7` to `5d798b5d` (tip of the timemory branch `users/adjordje-amd/cpp20-iter-disambiguate`).

That timemory branch contains:
- `bfc886f5` Update C++ standard from C++17 to C++20
- `5844c990` Disambiguate cross-type iterator comparisons under C++20
- `0634814d` Avoid GCC 12 -Wrestrict false positive in storage::get_shared_manager
- `eab3a175` Drop braces on while-body in get_shared_manager
- `5d798b5d` Avoid GCC 12 -Wrestrict false positive in filepath.cpp

`develop`'s own `CMAKE_CXX_STANDARD` for rocprofiler-systems remains 17 - this PR does not bump the standard in rocm-systems itself.

## JIRA ID

Tracks AIPROFSYST-448 (Phase 1 dependency check).

## Test Plan

CI matrix on this branch is the test.

## Test Result

Awaiting CI.

## Submission Checklist

- [x] Look over the contributing guidelines.

## Note

Do **not** merge. This PR exists to validate ROCm/timemory#35 against `develop`. The actual integration goes through PR #4080 once the timemory side lands on the rocprofiler-systems branch.