### PR TITLE
test_runner: gate code coverage instrumentation behind --coverage-report

### DIFF
--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -369,8 +369,14 @@ class TestExecutor:
             lib_path = os.path.join(self.build_dir, "librccl.so")
             if not os.path.isfile(lib_path):
                 errors.append(f"RCCL library not found: {lib_path}")
-            elif self.args.verbose:
-                print(f"Found RCCL library: {lib_path}")
+            else:
+                if self.args.verbose:
+                    print(f"Found RCCL library: {lib_path}")
+                # Fail fast: --coverage-report requires an instrumented library,
+                # but with --no-build / custom lib we cannot rebuild it ourselves.
+                if self.args.coverage_report and not self._check_coverage_instrumentation(lib_path):
+                    self._print_coverage_missing_error(lib_path)
+                    return False
 
         if errors:
             print("ERROR: Environment check failed:")
@@ -381,6 +387,52 @@ class TestExecutor:
         if self.args.verbose:
             print("Environment validation passed")
         return True
+
+    def _check_coverage_instrumentation(self, lib_path):
+        """
+        Verify librccl.so was built with LLVM source-based code coverage
+        instrumentation by looking for the ``__llvm_prf_*`` ELF sections that
+        clang adds when ``-fprofile-instr-generate -fcoverage-mapping`` is in
+        effect (i.e. when RCCL was built with -DENABLE_CODE_COVERAGE=ON).
+
+        Returns:
+            bool: True if instrumented; True (with warning) if the check could
+                not be performed (e.g. readelf missing); False if confirmed
+                non-instrumented.
+        """
+        try:
+            result = subprocess.run(
+                ['readelf', '-S', lib_path],
+                capture_output=True, text=True, timeout=30
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+            print(f"WARNING: Could not run 'readelf -S {lib_path}' to verify "
+                  f"coverage instrumentation: {e}")
+            print("         Proceeding under the assumption it is instrumented.")
+            return True
+        if result.returncode != 0:
+            print(f"WARNING: 'readelf -S {lib_path}' exited with "
+                  f"{result.returncode}; skipping coverage instrumentation check.")
+            return True
+        return '__llvm_prf_' in result.stdout
+
+    def _print_coverage_missing_error(self, lib_path):
+        """Emit a clear, actionable message when --coverage-report is requested
+        but the RCCL library lacks LLVM coverage instrumentation."""
+        print("=" * 80)
+        print("ERROR: --coverage-report was requested, but the RCCL library is")
+        print("       not instrumented for LLVM source-based code coverage:")
+        print(f"           {lib_path}")
+        print()
+        print("Rebuild RCCL with coverage instrumentation, then retry. Options:")
+        print("  - Use install.sh directly:")
+        print("        ./install.sh --enable-code-coverage <other flags...>")
+        print("  - Or have the runner build it by adding the flag to your")
+        print("    config's 'build_configuration.install_flags':")
+        print('        "--enable-code-coverage"')
+        print("  - Or pass the CMake option through install.sh:")
+        print('        ./install.sh --cmake-options "-DENABLE_CODE_COVERAGE=ON" ...')
+        print("=" * 80)
 
     def build_rccl(self):
         """
@@ -428,6 +480,21 @@ class TestExecutor:
             else:
                 cmake_options = "-DENABLE_MPI_TESTS=OFF"
             print("NOTE: MPI tests disabled in build (--skip-mpi-check)")
+
+        # Drop code coverage instrumentation when no coverage report is requested.
+        # Coverage instrumentation slows down both runtime (counter updates) and
+        # process exit (profraw file write per PID), which is significant when
+        # many short-lived test processes are spawned.
+        if not self.args.coverage_report:
+            if "--enable-code-coverage" in install_flags:
+                install_flags.remove("--enable-code-coverage")
+            # Explicitly disable to override any cached CMake value from prior builds
+            if cmake_options:
+                cmake_options += " -DENABLE_CODE_COVERAGE=OFF"
+            else:
+                cmake_options = "-DENABLE_CODE_COVERAGE=OFF"
+            print("NOTE: Code coverage instrumentation disabled in build "
+                  "(use --coverage-report to enable)")
 
         # Build install.sh command
         install_script = os.path.join(workdir, "install.sh")
@@ -478,6 +545,18 @@ class TestExecutor:
                 return False
 
             print("Build completed successfully")
+
+            # If --coverage-report was requested, verify the freshly built library
+            # actually contains coverage instrumentation. The user's build_configuration
+            # in the JSON config may not include --enable-code-coverage, in which
+            # case we must abort before running tests (otherwise no profraw files
+            # would be produced and the coverage step would silently produce nothing).
+            if self.args.coverage_report:
+                lib_path = os.path.join(self.build_dir, "librccl.so")
+                if os.path.isfile(lib_path) and not self._check_coverage_instrumentation(lib_path):
+                    self._print_coverage_missing_error(lib_path)
+                    return False
+
             return True
 
         except Exception as e:
@@ -670,8 +749,13 @@ class TestExecutor:
             ld_library_path_parts.append(env.get('LD_LIBRARY_PATH'))
         env['LD_LIBRARY_PATH'] = ":".join(ld_library_path_parts)
 
-        # Set LLVM_PROFILE_FILE for code coverage (prevents default.profraw collision)
-        env['LLVM_PROFILE_FILE'] = "rccl_tests_%p_%m.profraw"
+        # Set LLVM_PROFILE_FILE for code coverage (prevents default.profraw
+        # collision). Only do this when coverage reporting is requested -- with
+        # an instrumented binary, writing per-PID profraw files on every process
+        # exit is a significant overhead when many short-lived test processes
+        # are spawned.
+        if self.args.coverage_report:
+            env['LLVM_PROFILE_FILE'] = "rccl_tests_%p_%m.profraw"
 
         # Add test-specific env vars
         for key, value in merged_env.items():
@@ -756,7 +840,10 @@ class TestExecutor:
                 mpi_args += " " + env_fmt.format(key=key, value=value)
 
             mpi_args += " " + env_fmt.format(key="LD_LIBRARY_PATH", value=env['LD_LIBRARY_PATH'])
-            mpi_args += " " + env_fmt.format(key="LLVM_PROFILE_FILE", value="rccl_tests_%p_%m.profraw")
+            if self.args.coverage_report:
+                mpi_args += " " + env_fmt.format(
+                    key="LLVM_PROFILE_FILE", value="rccl_tests_%p_%m.profraw"
+                )
 
             # Forward LD_PRELOAD so UCX core libraries are preloaded with
             # global visibility on remote ranks (required for UCX PML)
@@ -1063,7 +1150,14 @@ class TestExecutor:
             print("="*120)
 
     def generate_coverage_report(self):
-        """Generate code coverage report"""
+        """Generate code coverage report.
+
+        Supports the report-only workflow: when invoked with
+        ``--no-build --skip-tests --coverage-report`` after a previous run that
+        executed an instrumented binary, this method picks up the existing
+        ``*.profraw`` files left in ``<build_dir>/test/`` and produces a fresh
+        HTML/text report under the current run's workspace ``report/``.
+        """
         if not self.args.coverage_report:
             return
 
@@ -1075,10 +1169,29 @@ class TestExecutor:
         import glob
         import shutil
 
+        # Tests run with cwd=<build_dir>/test, so profraw files are written
+        # there. A recursive glob also picks up any files written elsewhere
+        # under the build tree (e.g. by ad-hoc runs).
         profraw_files = glob.glob(os.path.join(self.build_dir, "**/*.profraw"), recursive=True)
 
         if not profraw_files:
-            print("WARNING: No profraw files found. Cannot generate coverage report.")
+            print("ERROR: No .profraw files found under the build directory:")
+            print(f"           {self.build_dir}")
+            if self.args.skip_tests:
+                print()
+                print("--coverage-report --skip-tests was requested, so this run did")
+                print("not execute any tests. Run the tests at least once with")
+                print("--coverage-report (without --skip-tests) so the instrumented")
+                print("binary writes .profraw files, then re-run with")
+                print("--no-build --skip-tests --coverage-report to regenerate the")
+                print("report from those files.")
+            else:
+                print()
+                print("Tests ran but produced no coverage data. Confirm that the RCCL")
+                print("library and test binaries were built with coverage instrumentation")
+                print("(--enable-code-coverage / -DENABLE_CODE_COVERAGE=ON) and that the")
+                print("test processes terminated cleanly so the runtime could flush the")
+                print("profraw files.")
             return
 
         print(f"Found {len(profraw_files)} profraw files")


### PR DESCRIPTION
LLVM source-based coverage instrumentation has a non-trivial cost on every test process: counter table init at startup and a profraw file write at exit. The runner was paying this cost on every run regardless of whether a coverage report was actually requested.

Changes in lib/test_executor.py:

- build_rccl(): when --coverage-report is not set, strip --enable-code-coverage from install_flags and append -DENABLE_CODE_COVERAGE=OFF to the cmake options (overriding any cached CMake value from an earlier build), and log the override.
- run_test(): only set LLVM_PROFILE_FILE (and only forward it through mpirun's -x/-env) when --coverage-report is set. Without coverage, no profraw files are written at all.
- New _check_coverage_instrumentation() helper: uses 'readelf -S' to detect the __llvm_prf_* ELF sections that clang adds when building with -DENABLE_CODE_COVERAGE=ON. Falls back to "assume instrumented" with a warning if readelf is unavailable.
- New _print_coverage_missing_error() helper: prints a clear, actionable message telling the user how to rebuild with instrumentation (install.sh --enable-code-coverage, the build_configuration.install_flags entry, or --cmake-options "-DENABLE_CODE_COVERAGE=ON").
- check_environment(): when --coverage-report is set together with --no-build / a custom build dir (so the runner cannot rebuild itself), verify the existing librccl.so is instrumented and fail fast with the rebuild instructions if not.
- build_rccl(): after a successful build, if --coverage-report was requested but the user's build_configuration didn't include coverage flags, the freshly built library is also verified and the same fail-fast error is emitted.
- generate_coverage_report(): document the report-only workflow (--no-build --skip-tests --coverage-report picks up *.profraw left in <build_dir>/test/ from a prior run). The previous silent "WARNING: No profraw files found" is replaced with two distinct actionable error branches: one for the --skip-tests case (telling the user to first run tests with coverage), one for the case where tests ran but produced no coverage data (pointing at instrumentation flags / clean process exit).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
