### PR TITLE
[rocprofiler-systems] [presets] Remove `HSA_API` from `preset=trace-openmp`

### DIFF
--- a/projects/rocprofiler-systems/docs/how-to/using-preset-profiles.rst
+++ b/projects/rocprofiler-systems/docs/how-to/using-preset-profiles.rst
@@ -175,7 +175,7 @@ RCCL ON, PAPI events ON, ROCm domains ON, GPU metrics ON
 --preset=trace-openmp
 ~~~~~~~~~~~~~~~~~~~~~
 
-**Purpose:** OpenMP offload with HSA domains and OMPT
+**Purpose:** OpenMP with kernel dispatches and memory copies (excludes HSA API)
 
 .. code-block:: shell
 

--- a/projects/rocprofiler-systems/source/bin/common/presets/trace-openmp.json
+++ b/projects/rocprofiler-systems/source/bin/common/presets/trace-openmp.json
@@ -14,7 +14,7 @@
                     "enabled": true
                 },
                 "hsa_api": {
-                    "enabled": true
+                    "enabled": false
                 },
                 "kernel_dispatch": {
                     "enabled": true
@@ -32,7 +32,7 @@
     "metadata": {
         "category": "hpc",
         "cli_flag": "--trace-openmp",
-        "description": "OpenMP offload workloads: tracing with HSA domains and OMPT enabled",
+        "description": "OpenMP offload workloads: tracing kernel dispatch, memory copy, and OMPT enabled",
         "name": "trace-openmp",
         "use_case": "OpenMP offload applications using target directives on AMD GPUs"
     },

--- a/projects/rocprofiler-systems/source/bin/common/presets/trace-openmp.json
+++ b/projects/rocprofiler-systems/source/bin/common/presets/trace-openmp.json
@@ -32,9 +32,9 @@
     "metadata": {
         "category": "hpc",
         "cli_flag": "--trace-openmp",
-        "description": "OpenMP offload workloads: tracing kernel dispatch, memory copy, and OMPT enabled",
+        "description": "OpenMP workloads: tracing kernel dispatch, memory copy, and OMPT enabled",
         "name": "trace-openmp",
-        "use_case": "OpenMP offload applications using target directives on AMD GPUs"
+        "use_case": "OpenMP applications using target directives on AMD GPUs"
     },
     "profiling": {
         "enabled": false


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

I consider `HSA_API` to be out of scope for the OpenMP preset:

**Arg 1**: 
OpenMP offload operations are internally translated by the compiler into HSA operations. The user, at least for the surface level OpenMP preset should have no real need to see this. If they do, prefer using the `hpc` preset (or just turning on `HSA_API`)

**Arg 2**:
Flow events from OMPT tracks to kernel dispatches/memory copy operations get lost. For example, consider following an `omp_target_submit_emi` track to the kernel execution. Currently:
<img width="1085" height="114" alt="image" src="https://github.com/user-attachments/assets/da7da3ad-0153-4158-b9d8-9ee8fef1c4e0" />

Then another `hsa` operation flows to the kernel dispatch
<img width="1071" height="129" alt="image" src="https://github.com/user-attachments/assets/86a61b1f-7875-4a94-a73b-ebd4325aa123" />

Vs without:

<img width="732" height="119" alt="image" src="https://github.com/user-attachments/assets/20ce4446-8791-46ef-97ae-973a9db7d5e6" />

This is a clean flow, which makes it easier for a person that is less familiar with `hsa` to understand.


**Arg 3**:
For offload OpenMP programs, the size of the trace file can explode depending on how heavily OpenMP offload directives are used. For example, the `jacobi-fortran-targetdata-markers` `.proto` file goes from `>100` mb to `<50` mb when `HSA_API` is disabled. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Set `enabled = false` in the `hsa_api` option.

Also, in the `using-preset-profiles.rst`, remove mention of OMPT. The official way to trace OpenMP operations is through the OMPT API. This is specified in the docs, so this is just assumed (no need to specify)

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

This came up as part of my work on AIPROFSYST-141 (Adding OpenMP offload document)

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Local testing

## Test Result

<!-- Briefly summarize test outcomes. -->

Exactly what you expect occurs, `HSA_API` is not seen.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
