### PR TITLE
tests: fix transpose ROCpd sampling validation

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/test_transpose.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_transpose.py
@@ -112,6 +112,12 @@ class TestTranspose(RocprofsysTest):
         "uniform_int_distribution",
     ]
     LOOPS_RUN_ARGS = ["2", "100", "50"]
+    SAMPLING_RUN_ARGS = ["4", "500", "100"]
+    SAMPLING_ENV = {
+        "ROCPROFSYS_SAMPLING_REALTIME": "ON",
+        "ROCPROFSYS_SAMPLING_REALTIME_FREQ": "300",
+        "ROCPROFSYS_SAMPLING_CPUTIME": "OFF",
+    }
 
     @pytest.mark.parametrize(
         "mode",
@@ -145,10 +151,13 @@ class TestTranspose(RocprofsysTest):
     @pytest.mark.timeout(120)
     @pytest.mark.rocpd("transpose_env")
     def test_sampling(self, transpose_env, transpose_rules, num_processes):
+        env = transpose_env.copy()
+        env.update(self.SAMPLING_ENV)
         result = self.run_test(
             "sampling",
             target="transpose",
-            env=transpose_env,
+            env=env,
+            run_args=self.SAMPLING_RUN_ARGS,
             check_target_arch=True,
             launcher="mpi",
             num_procs=num_processes,

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/transpose/timer-sampling-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/transpose/timer-sampling-rules.json
@@ -25,27 +25,28 @@
             ]
         },
         {
-            "name": "regions",
+            "name": "rocpd_sample",
             "required_columns": [
-                "guid",
-                "category",
                 "id",
-                "name"
+                "guid",
+                "track_id",
+                "timestamp",
+                "event_id"
             ],
             "validation_queries": [
                 {
                     "comparison": "greater_than",
-                    "description": "Check that category column contains more than 1000 'timer_sampling' entries",
-                    "error_message": "Less than 1001 'timer_sampling' entries found in category column of regions",
+                    "description": "Check that ROCpd contains more than 1000 timer_sampling samples",
+                    "error_message": "Less than 1001 'timer_sampling' entries found in rocpd_sample",
                     "expected_result": 1000,
-                    "query": "SELECT COUNT(*) FROM regions WHERE category = 'timer_sampling';"
+                    "query": "SELECT COUNT(*) FROM rocpd_sample R INNER JOIN rocpd_event E ON E.id = R.event_id AND E.guid = R.guid INNER JOIN rocpd_string S ON S.id = E.category_id AND S.guid = E.guid WHERE S.string = 'timer_sampling';"
                 },
                 {
                     "comparison": "equals",
                     "description": "Verify no NULL or empty values in guid column",
-                    "error_message": "NULL or empty guid values found in regions",
+                    "error_message": "NULL or empty guid values found in rocpd_sample",
                     "expected_result": 0,
-                    "query": "SELECT COUNT(*) FROM regions WHERE guid IS NULL OR TRIM(guid) = '';"
+                    "query": "SELECT COUNT(*) FROM rocpd_sample WHERE guid IS NULL OR TRIM(guid) = '';"
                 }
             ]
         }

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/transpose/validation-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/transpose/validation-rules.json
@@ -32,10 +32,10 @@
                     "query": "SELECT COUNT(*) FROM top_kernels WHERE name LIKE 'transpose%'"
                 },
                 {
-                    "comparison": "greater_than",
-                    "description": "Check that we have at least the expected number of kernel calls",
-                    "error_message": "Too few transpose kernel calls found in summary",
-                    "expected_result": 999,
+                    "comparison": "greater_than_or_equal",
+                    "description": "Check that we have at least 1000 kernel calls",
+                    "error_message": "Fewer than 1000 transpose kernel calls found in summary",
+                    "expected_result": 1000,
                     "query": "SELECT total_calls FROM top_kernels WHERE name LIKE 'transpose%'"
                 }
             ]
@@ -75,10 +75,10 @@
                     "query": "SELECT COUNT(*) as count FROM kernels WHERE (end - start) = 0"
                 },
                 {
-                    "comparison": "greater_than",
-                    "description": "Check that we have at least the expected number of transpose kernel entries",
-                    "error_message": "Too few transpose kernel entries found",
-                    "expected_result": 999,
+                    "comparison": "greater_than_or_equal",
+                    "description": "Check that we have at least 1000 transpose kernel entries",
+                    "error_message": "Fewer than 1000 transpose kernel entries found",
+                    "expected_result": 1000,
                     "query": "SELECT COUNT(*) as count FROM kernels WHERE name LIKE 'transpose%'"
                 }
             ]

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/transpose/validation-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/transpose/validation-rules.json
@@ -32,10 +32,10 @@
                     "query": "SELECT COUNT(*) FROM top_kernels WHERE name LIKE 'transpose%'"
                 },
                 {
-                    "comparison": "equals",
-                    "description": "Check that we have predefined number of kernel calls",
-                    "error_message": "No kernel calls found in summary",
-                    "expected_result": 1000,
+                    "comparison": "greater_than",
+                    "description": "Check that we have at least the expected number of kernel calls",
+                    "error_message": "Too few transpose kernel calls found in summary",
+                    "expected_result": 999,
                     "query": "SELECT total_calls FROM top_kernels WHERE name LIKE 'transpose%'"
                 }
             ]
@@ -75,10 +75,10 @@
                     "query": "SELECT COUNT(*) as count FROM kernels WHERE (end - start) = 0"
                 },
                 {
-                    "comparison": "equals",
-                    "description": "Check that we have number of kernel entries as expected number of calls",
-                    "error_message": "Mismatch in expected numbers of kernels entries",
-                    "expected_result": 1000,
+                    "comparison": "greater_than",
+                    "description": "Check that we have at least the expected number of transpose kernel entries",
+                    "error_message": "Too few transpose kernel entries found",
+                    "expected_result": 999,
                     "query": "SELECT COUNT(*) as count FROM kernels WHERE name LIKE 'transpose%'"
                 }
             ]


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
 Fix the transpose ROCpd sampling test so it validates the correct ROCpd data and uses a sampling configuration that is appropriate for a GPU-bound workload.
The existing transpose sampling path had two problems:
- the ROCpd timer-sampling rule queried regions, even though timer samples are recorded in rocpd_sample
- the test relied on a sampling configuration that was not robust for short GPU-dominated runs

This PR makes the transpose sampling test and its ROCpd validation more reliable without introducing any gfx-specific rule split.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
This PR updates three files:
- test_transpose.py
    - enables realtime sampling for TestTranspose::test_sampling
    - uses explicit sampling run args ["4", "500", "100"] for the develop default workload
- timer-sampling-rules.json
    - validates timer sampling from rocpd_sample instead of regions
    - checks the event category through rocpd_event and rocpd_string
- validation-rules.json
    - replaces exact 1000 transpose kernel-count checks with lower-bound checks (> 999)

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFSYST-420

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Validated the transpose sampling path on gfx90a using:
- local source/build tree for rocprofiler-systems
- transpose sampling execution with realtime sampling
- ROCpd validation using the updated transpose validation rules
- Perfetto HIP API validation

## Test Result

<!-- Briefly summarize test outcomes. -->
On gfx90a, TestTranspose::test_sampling passed with:
- regex validation passed
- Perfetto HIP API validation passed
- ROCpd validation passed

This supports the conclusion that the earlier failure was caused by test configuration and validation logic, rather than evidence for a gfx-specific AMD-SMI ROCpd rule change.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
