### PR TITLE
Prevent a crash in case of an unsupported GPU

### DIFF
--- a/projects/rocdbgapi/src/process.cpp
+++ b/projects/rocdbgapi/src/process.cpp
@@ -743,7 +743,8 @@ process_t::insert_watchpoint (const watchpoint_t &watchpoint)
   try
     {
       for (auto &&agent : range<agent_t> ())
-        agent.insert_watchpoint (watchpoint);
+        if (agent.supports_debugging ())
+          agent.insert_watchpoint (watchpoint);
     }
   catch (...)
     {
@@ -752,7 +753,9 @@ process_t::insert_watchpoint (const watchpoint_t &watchpoint)
          the watchpoint and forward the exception.  Note: Removing a watchpoint
          that is not inserted is a no-op.  */
       for (auto &&agent : range<agent_t> ())
-        agent.remove_watchpoint (watchpoint);
+        if (agent.supports_debugging ())
+          agent.remove_watchpoint (watchpoint);
+
       throw;
     }
 }
@@ -761,7 +764,8 @@ void
 process_t::remove_watchpoint (const watchpoint_t &watchpoint)
 {
   for (auto &&agent : range<agent_t> ())
-    agent.remove_watchpoint (watchpoint);
+    if (agent.supports_debugging ())
+      agent.remove_watchpoint (watchpoint);
 
   const bool last_watchpoint = count<watchpoint_t> () == 1;
   if (last_watchpoint)

--- a/projects/rocdbgapi/src/watchpoint.cpp
+++ b/projects/rocdbgapi/src/watchpoint.cpp
@@ -112,7 +112,8 @@ watchpoint_t::watchpoint_t (amd_dbgapi_watchpoint_id_t watchpoint_id,
     std::numeric_limits<decltype (programmable_mask_bits)>::max ()
   };
   for (auto &&agent : process.range<agent_t> ())
-    programmable_mask_bits &= agent.os_info ().address_watch_mask_bits;
+    if (agent.supports_debugging ())
+      programmable_mask_bits &= agent.os_info ().address_watch_mask_bits;
 
   uint64_t field_B = programmable_mask_bits;
   uint64_t field_A = ~(field_B | (field_B - 1));


### PR DESCRIPTION
If there are multiple GPUs on the system and some are not supported, GDB crashes when setting a watchpoint on the GPU kernel address. The crash is caused by accessing an empty vector in the agent.cpp:agent_t::insert_watchpoint() function. The vector is empty because the "agent_t()" constructor skips allocation in case of an unsupported architecture.

This change prevents insert_watchpoint() from being called when the vector is empty. In addition, it prints a warning.

The behavior of the following GDB tests has changed:

gdb.rocm/aspace-watchpoint.exp
gdb.rocm/watchpoint-at-end-of-shader.exp
gdb.rocm/precise-memory-warning-watchpoint.exp

The tests still fail, but this time with the expected error.
