### PR TITLE
Add nvidia build

### DIFF
--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -54,8 +54,8 @@ jobs:
 
   nvidia-clr-build:
     name: "Build clr + hip-tests (NVIDIA)"
-    needs: setup
-    if: ${{ needs.setup.outputs.should_build == 'true' }}
+    needs: nvidia-clr-build-setup
+    if: ${{ needs.nvidia-clr-build-setup.outputs.should_build == 'true' }}
     runs-on: azure-linux-scale-rocm
     container:
       # CUDA 13.1.2 Ubuntu 24.04
@@ -129,7 +129,7 @@ jobs:
   nvidia-clr-build-ci-summary:
     name: "HIP NVIDIA CI Summary"
     if: always()
-    needs: [setup, build]
+    needs: [nvidia-clr-build-setup, nvidia-clr-build]
     runs-on: ubuntu-24.04
     steps:
       - name: Check results

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -88,8 +88,8 @@ jobs:
 
       - name: Fetch hipcc submodule
         run: |
-          pip install -r TheRock/requirements.txt
-          ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-systems
+          # pip install -r TheRock/requirements.txt
+          # ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-systems
           git config --global --add safe.directory "*"
           git -C "${GITHUB_WORKSPACE}/TheRock" submodule update --init --depth 1 compiler/amd-llvm
 

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -86,7 +86,9 @@ jobs:
           apt-get install -y --no-install-recommends git cmake ninja-build llvm-dev libnuma-dev libelf-dev libdrm-dev pkg-config
 
       - name: Fetch hipcc submodule
-        run: git -C TheRock submodule update --init --depth 1 compiler/amd-llvm
+        run: |
+          cd TheRock
+          git submodule update --init --depth 1 compiler/amd-llvm
 
       - name: Build hipconfig
         run: |

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -87,9 +87,7 @@ jobs:
 
       - name: Build hipconfig
         run: |
-          cmake -B "${BUILD_DIR}/hipcc" -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            TheRock/compiler/amd-llvm/amd/hipcc
+          cmake -B "${BUILD_DIR}/hipcc" -G Ninja -DCMAKE_BUILD_TYPE=Release TheRock/compiler/amd-llvm/amd/hipcc
           cmake --build "${BUILD_DIR}/hipcc" --parallel
           mkdir -p "${BUILD_DIR}/hipcc-install/bin"
           cp "${BUILD_DIR}/hipcc/hipconfig" "${BUILD_DIR}/hipcc-install/bin/"

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup:
+  nvidia-clr-build-setup:
     name: "Setup"
     runs-on: ubuntu-24.04
     env:
@@ -38,8 +38,8 @@ jobs:
         run: |
           SHOULD_BUILD=false
 
-          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            SHOULD_BUILD=true
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            SHOULD_BUILD=true;
           else
             CHANGED_FILES=$(git diff --name-only "${BASE_REF}")
             echo "Changed files:"
@@ -50,10 +50,9 @@ jobs:
               echo "No changes in clr/hip/hip-tests/hipother — skipping NVIDIA build"
             fi
           fi
-
           echo "should_build=${SHOULD_BUILD}" >> "${GITHUB_OUTPUT}"
 
-  build:
+  nvidia-clr-build:
     name: "Build clr + hip-tests (NVIDIA)"
     needs: setup
     if: ${{ needs.setup.outputs.should_build == 'true' }}
@@ -74,7 +73,7 @@ jobs:
             projects/hip-tests
             projects/hipother
 
-      - name: Checkout TheRock repository
+      - name: Checkout llvm-project repository # we only need hipcc to build HIP on nvidia platform
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/llvm-project"
@@ -127,7 +126,7 @@ jobs:
       - name: Build hip-tests
         run: cmake --build "${BUILD_DIR}/hip-tests" --parallel
 
-  ci-summary:
+  nvidia-clr-build-ci-summary:
     name: "HIP NVIDIA CI Summary"
     if: always()
     needs: [setup, build]

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -80,7 +80,7 @@ jobs:
           repository: "ROCm/llvm-project"
           path: "llvm-project"
           ref: 43215c73116c407735c85a180d174f718798c328 # 2026-04-14 bump in TheRock
-          sparse-checkout:
+          sparse-checkout: |
             amd/hipcc
 
       - name: Install system dependencies

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -1,3 +1,7 @@
+# NVIDIA build is separate from theRock CI due to multiple issues:
+# 1. We do not want to publish any CUDA based artifacts.
+# 2. CLR builds are parallel to the rest of the monorepo: we neither consume anything upstream, nor impact any downstream projects.
+# Hence, the check is independent from the rest of the CI
 name: HIP NVIDIA CI
 
 on:

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install system dependencies
         run: |
           apt-get update -q
-          apt-get install -y --no-install-recommends cmake ninja-build llvm-dev libnuma-dev libelf-dev libdrm-dev pkg-config
+          apt-get install -y --no-install-recommends git cmake ninja-build llvm-dev libnuma-dev libelf-dev libdrm-dev pkg-config
 
       - name: Build hipconfig
         run: |

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Checkout rocm-systems
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          path: rocm-systems
           sparse-checkout: |
             projects/clr
             projects/hip
@@ -87,6 +88,8 @@ jobs:
 
       - name: Fetch hipcc submodule
         run: |
+          pip install -r TheRock/requirements.txt
+          ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-systems
           git config --global --add safe.directory "*"
           git -C "${GITHUB_WORKSPACE}/TheRock" submodule update --init --depth 1 compiler/amd-llvm
 
@@ -105,11 +108,11 @@ jobs:
             -DHIP_PLATFORM=nvidia \
             -DCLR_BUILD_HIP=ON \
             -DCLR_BUILD_OCL=OFF \
-            -DHIP_COMMON_DIR="${GITHUB_WORKSPACE}/projects/hip" \
-            -DHIPNV_DIR="${GITHUB_WORKSPACE}/projects/hipother/hipnv" \
+            -DHIP_COMMON_DIR="${GITHUB_WORKSPACE}/rocm-systems/projects/hip" \
+            -DHIPNV_DIR="${GITHUB_WORKSPACE}/rocm-systems/projects/hipother/hipnv" \
             -DHIPCC_BIN_DIR="${BUILD_DIR}/hipcc-install/bin" \
             -DCMAKE_INSTALL_PREFIX="${BUILD_DIR}/clr-install" \
-            "${GITHUB_WORKSPACE}/projects/clr/"
+            "${GITHUB_WORKSPACE}/rocm-systems/projects/clr/"
 
       - name: Build clr
         run: cmake --build "${BUILD_DIR}/clr" --parallel
@@ -124,7 +127,7 @@ jobs:
             -DHIP_PLATFORM=nvidia \
             -DHIPCC_BIN_DIR="${BUILD_DIR}/clr-install/bin" \
             -DCMAKE_PREFIX_PATH="${BUILD_DIR}/clr-install" \
-            "${GITHUB_WORKSPACE}/projects/hip-tests/catch"
+            "${GITHUB_WORKSPACE}/rocm-systems/projects/hip-tests/catch"
 
       - name: Build hip-tests
         run: cmake --build "${BUILD_DIR}/hip-tests" --parallel

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -59,7 +59,7 @@ jobs:
     if: ${{ needs.setup.outputs.should_build == 'true' }}
     runs-on: azure-linux-scale-rocm
     container:
-      # CUDA 13.1.2 Ubuntu 24.04 development image — update the digest when bumping
+      # CUDA 13.1.2 Ubuntu 24.04
       image: nvidia/cuda@sha256:08d6facb6a72f918beb3ffe5b57cff72402a203f44428831262e95c7466d4188
     env:
       BUILD_DIR: ${{ github.workspace }}/build
@@ -84,10 +84,8 @@ jobs:
         run: |
           apt-get update -q
           apt-get install -y --no-install-recommends \
-            cmake ninja-build llvm-dev libnuma \
-            libelf-dev libdrm-dev \
-            pkg-config
 
+          cmake ninja-build llvm-dev libnuma libelf-dev libdrm-dev pkg-config
       - name: Build hipconfig
         run: |
           cmake -B "${BUILD_DIR}/hipcc" -G Ninja \
@@ -109,7 +107,7 @@ jobs:
             -DHIPNV_DIR="${GITHUB_WORKSPACE}/projects/hipother/hipnv" \
             -DHIPCC_BIN_DIR="${BUILD_DIR}/hipcc-install/bin" \
             -DCMAKE_INSTALL_PREFIX="${BUILD_DIR}/clr-install" \
-            "${GITHUB_WORKSPACE}/projects/clr/hipamd"
+            "${GITHUB_WORKSPACE}/projects/clr/"
 
       - name: Build clr
         run: cmake --build "${BUILD_DIR}/clr" --parallel

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -88,8 +88,9 @@ jobs:
 
       - name: Fetch hipcc submodule
         run: |
-          # pip install -r TheRock/requirements.txt
-          # ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-systems
+
+          pip install --break-system-packages -r TheRock/requirements.txt
+          ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-systems
           git config --global --add safe.directory "*"
           git -C "${GITHUB_WORKSPACE}/TheRock" submodule update --init --depth 1 compiler/amd-llvm
 

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Build hipconfig
         run: |
-          cmake -B "${BUILD_DIR}/hipcc" -G Ninja -DCMAKE_BUILD_TYPE=Release TheRock/compiler/amd-llvm/amd/hipcc
+          cmake -S TheRock/compiler/amd-llvm/amd/hipcc -B "${BUILD_DIR}/hipcc" -G Ninja -DCMAKE_BUILD_TYPE=Release
           cmake --build "${BUILD_DIR}/hipcc" --parallel
           mkdir -p "${BUILD_DIR}/hipcc-install/bin"
           cp "${BUILD_DIR}/hipcc/hipconfig" "${BUILD_DIR}/hipcc-install/bin/"

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install system dependencies
         run: |
           apt-get update -q
-          apt-get install -y --no-install-recommends git cmake ninja-build llvm-dev libnuma-dev libelf-dev libdrm-dev pkg-config
+          apt-get install -y --no-install-recommends git cmake ninja-build llvm-dev libnuma-dev libelf-dev libdrm-dev python3-dev python3-pip pkg-config
 
       - name: Fetch hipcc submodule
         run: |

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -83,9 +83,8 @@ jobs:
       - name: Install system dependencies
         run: |
           apt-get update -q
-          apt-get install -y --no-install-recommends \
+          apt-get install -y --no-install-recommends cmake ninja-build llvm-dev libnuma libelf-dev libdrm-dev pkg-config
 
-          cmake ninja-build llvm-dev libnuma libelf-dev libdrm-dev pkg-config
       - name: Build hipconfig
         run: |
           cmake -B "${BUILD_DIR}/hipcc" -G Ninja \

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -77,26 +77,20 @@ jobs:
       - name: Checkout TheRock repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          repository: "ROCm/TheRock"
-          path: "TheRock"
-          ref: 903ee444eb935adf456bf5df724e1b6f5c2ce962 # 2026-05-03 commit
+          repository: "ROCm/llvm-project"
+          path: "llvm-project"
+          ref: 43215c73116c407735c85a180d174f718798c328 # 2026-04-14 bump in TheRock
+          sparse-checkout:
+            amd/hipcc
 
       - name: Install system dependencies
         run: |
           apt-get update -q
           apt-get install -y --no-install-recommends git cmake ninja-build llvm-dev libnuma-dev libelf-dev libdrm-dev python3-dev python3-pip pkg-config
 
-      - name: Fetch hipcc submodule
-        run: |
-
-          pip install --break-system-packages -r TheRock/requirements.txt
-          ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-systems
-          git config --global --add safe.directory "*"
-          git -C "${GITHUB_WORKSPACE}/TheRock" submodule update --init --depth 1 compiler/amd-llvm
-
       - name: Build hipconfig
         run: |
-          cmake -S TheRock/compiler/amd-llvm/amd/hipcc -B "${BUILD_DIR}/hipcc" -G Ninja -DCMAKE_BUILD_TYPE=Release
+          cmake -S llvm-project/amd/hipcc -B "${BUILD_DIR}/hipcc" -G Ninja -DCMAKE_BUILD_TYPE=Release
           cmake --build "${BUILD_DIR}/hipcc" --target hipconfig --parallel
           mkdir -p "${BUILD_DIR}/hipcc-install/bin"
           cp "${BUILD_DIR}/hipcc/hipconfig" "${BUILD_DIR}/hipcc-install/bin/"

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -62,8 +62,8 @@ jobs:
     if: ${{ needs.nvidia-clr-build-setup.outputs.should_build == 'true' }}
     runs-on: azure-linux-scale-rocm
     container:
-      # CUDA 13.2.0 Ubuntu 24.04
-      image: nvidia/cuda@sha256:b66239c62d5aa5481cb8151c7ff410e0d8d3d4a75cb4c90e66e89639ded490f4
+      # CUDA 13.2.0 devel Ubuntu 24.04
+      image: nvidia/cuda@sha256:d266e59b88c295bc5fa0e4cef9064eaff84939381b09e2c3d76a5532a303e42d
     env:
       BUILD_DIR: ${{ github.workspace }}/build
     steps:

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -87,6 +87,7 @@ jobs:
 
       - name: Fetch hipcc submodule
         run: |
+          ls -la
           cd TheRock
           git submodule update --init --depth 1 compiler/amd-llvm
 

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install system dependencies
         run: |
           apt-get update -q
-          apt-get install -y --no-install-recommends cmake ninja-build llvm-dev libnuma libelf-dev libdrm-dev pkg-config
+          apt-get install -y --no-install-recommends cmake ninja-build llvm-dev libnuma-dev libelf-dev libdrm-dev pkg-config
 
       - name: Build hipconfig
         run: |

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -1,0 +1,147 @@
+name: HIP NVIDIA CI
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - develop
+      - release/therock-*
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  setup:
+    name: "Setup"
+    runs-on: ubuntu-24.04
+    env:
+      BASE_REF: HEAD^
+    outputs:
+      should_build: ${{ steps.check_paths.outputs.should_build }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 2
+
+      - name: Check if relevant paths changed
+        id: check_paths
+        run: |
+          SHOULD_BUILD=false
+
+          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            SHOULD_BUILD=true
+          else
+            CHANGED_FILES=$(git diff --name-only "${BASE_REF}")
+            echo "Changed files:"
+            echo "${CHANGED_FILES}"
+            if echo "${CHANGED_FILES}" | grep -qE '^projects/(clr|hip|hip-tests|hipother)/|^\.github/workflows/hip-nvidia-ci\.yml'; then
+              SHOULD_BUILD=true
+            else
+              echo "No changes in clr/hip/hip-tests/hipother — skipping NVIDIA build"
+            fi
+          fi
+
+          echo "should_build=${SHOULD_BUILD}" >> "${GITHUB_OUTPUT}"
+
+  build:
+    name: "Build clr + hip-tests (NVIDIA)"
+    needs: setup
+    if: ${{ needs.setup.outputs.should_build == 'true' }}
+    runs-on: azure-linux-scale-rocm
+    container:
+      # CUDA 13.1.2 Ubuntu 24.04 development image — update the digest when bumping
+      image: nvidia/cuda@sha256:08d6facb6a72f918beb3ffe5b57cff72402a203f44428831262e95c7466d4188
+    env:
+      BUILD_DIR: ${{ github.workspace }}/build
+    steps:
+      - name: Checkout rocm-systems
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          sparse-checkout: |
+            projects/clr
+            projects/hip
+            projects/hip-tests
+            projects/hipother
+
+      - name: Checkout TheRock repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: "ROCm/TheRock"
+          path: "TheRock"
+          ref: 903ee444eb935adf456bf5df724e1b6f5c2ce962 # 2026-05-03 commit
+
+      - name: Install system dependencies
+        run: |
+          apt-get update -q
+          apt-get install -y --no-install-recommends \
+            cmake ninja-build \
+            libelf-dev libdrm-dev \
+            pkg-config
+
+      - name: Build hipconfig
+        run: |
+          cmake -B "${BUILD_DIR}/hipcc" -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            TheRock/compiler/amd-llvm/amd/hipcc
+          cmake --build "${BUILD_DIR}/hipcc" --target hipconfig --parallel
+          mkdir -p "${BUILD_DIR}/hipcc-install/bin"
+          cp "${BUILD_DIR}/hipcc/hipconfig" "${BUILD_DIR}/hipcc-install/bin/"
+
+      - name: Configure clr (NVIDIA platform)
+        run: |
+          cmake -B "${BUILD_DIR}/clr" -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DHIP_PLATFORM=nvidia \
+            -DCLR_BUILD_HIP=ON \
+            -DCLR_BUILD_OCL=OFF \
+            -DHIP_COMMON_DIR="${GITHUB_WORKSPACE}/projects/hip" \
+            -DHIPNV_DIR="${GITHUB_WORKSPACE}/projects/hipother/hipnv" \
+            -DHIPCC_BIN_DIR="${BUILD_DIR}/hipcc-install/bin" \
+            -DCMAKE_INSTALL_PREFIX="${BUILD_DIR}/clr-install" \
+            "${GITHUB_WORKSPACE}/projects/clr/hipamd"
+
+      - name: Build clr
+        run: cmake --build "${BUILD_DIR}/clr" --parallel
+
+      - name: Install clr
+        run: cmake --install "${BUILD_DIR}/clr"
+
+      - name: Configure hip-tests (NVIDIA platform)
+        run: |
+          cmake -B "${BUILD_DIR}/hip-tests" -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DHIP_PLATFORM=nvidia \
+            -DHIPCC_BIN_DIR="${BUILD_DIR}/clr-install/bin" \
+            -DCMAKE_PREFIX_PATH="${BUILD_DIR}/clr-install" \
+            "${GITHUB_WORKSPACE}/projects/hip-tests/catch"
+
+      - name: Build hip-tests
+        run: cmake --build "${BUILD_DIR}/hip-tests" --parallel
+
+  ci-summary:
+    name: "HIP NVIDIA CI Summary"
+    if: always()
+    needs: [setup, build]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check results
+        run: |
+          echo '${{ toJson(needs) }}'
+          FAILED_JOBS="$(echo '${{ toJson(needs) }}' \
+            | jq --raw-output \
+            'map_values(select(.result != "success" and .result != "skipped")) | keys | join(",")'
+          )"
+          if [[ "${FAILED_JOBS}" != "" ]]; then
+            echo "The following jobs failed: ${FAILED_JOBS}"
+            exit 1
+          fi

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Fetch hipcc submodule
         run: |
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}/TheRock"
+          git config --global --add safe.directory "*"
           git -C "${GITHUB_WORKSPACE}/TheRock" submodule update --init --depth 1 compiler/amd-llvm
 
       - name: Build hipconfig

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           apt-get update -q
           apt-get install -y --no-install-recommends \
-            cmake ninja-build \
+            cmake ninja-build llvm-dev libnuma \
             libelf-dev libdrm-dev \
             pkg-config
 
@@ -93,9 +93,10 @@ jobs:
           cmake -B "${BUILD_DIR}/hipcc" -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             TheRock/compiler/amd-llvm/amd/hipcc
-          cmake --build "${BUILD_DIR}/hipcc" --target hipconfig --parallel
+          cmake --build "${BUILD_DIR}/hipcc" --parallel
           mkdir -p "${BUILD_DIR}/hipcc-install/bin"
           cp "${BUILD_DIR}/hipcc/hipconfig" "${BUILD_DIR}/hipcc-install/bin/"
+          ln -s "$(which nvcc)" "${BUILD_DIR}/hipcc-install/bin/hipcc"
 
       - name: Configure clr (NVIDIA platform)
         run: |

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -80,6 +80,9 @@ jobs:
           path: "TheRock"
           ref: 903ee444eb935adf456bf5df724e1b6f5c2ce962 # 2026-05-03 commit
 
+      - name: Fetch hipcc submodule
+        run: git -C TheRock submodule update --init --depth 1 compiler/amd-llvm
+
       - name: Install system dependencies
         run: |
           apt-get update -q
@@ -88,7 +91,7 @@ jobs:
       - name: Build hipconfig
         run: |
           cmake -S TheRock/compiler/amd-llvm/amd/hipcc -B "${BUILD_DIR}/hipcc" -G Ninja -DCMAKE_BUILD_TYPE=Release
-          cmake --build "${BUILD_DIR}/hipcc" --parallel
+          cmake --build "${BUILD_DIR}/hipcc" --target hipconfig --parallel
           mkdir -p "${BUILD_DIR}/hipcc-install/bin"
           cp "${BUILD_DIR}/hipcc/hipconfig" "${BUILD_DIR}/hipcc-install/bin/"
           ln -s "$(which nvcc)" "${BUILD_DIR}/hipcc-install/bin/hipcc"

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -87,9 +87,8 @@ jobs:
 
       - name: Fetch hipcc submodule
         run: |
-          ls -la
-          cd TheRock
-          git submodule update --init --depth 1 compiler/amd-llvm
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}/TheRock"
+          git -C "${GITHUB_WORKSPACE}/TheRock" submodule update --init --depth 1 compiler/amd-llvm
 
       - name: Build hipconfig
         run: |

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -62,8 +62,8 @@ jobs:
     if: ${{ needs.nvidia-clr-build-setup.outputs.should_build == 'true' }}
     runs-on: azure-linux-scale-rocm
     container:
-      # CUDA 13.1.2 Ubuntu 24.04
-      image: nvidia/cuda@sha256:08d6facb6a72f918beb3ffe5b57cff72402a203f44428831262e95c7466d4188
+      # CUDA 13.2.0 Ubuntu 24.04
+      image: nvidia/cuda@sha256:b66239c62d5aa5481cb8151c7ff410e0d8d3d4a75cb4c90e66e89639ded490f4
     env:
       BUILD_DIR: ${{ github.workspace }}/build
     steps:

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -80,13 +80,13 @@ jobs:
           path: "TheRock"
           ref: 903ee444eb935adf456bf5df724e1b6f5c2ce962 # 2026-05-03 commit
 
-      - name: Fetch hipcc submodule
-        run: git -C TheRock submodule update --init --depth 1 compiler/amd-llvm
-
       - name: Install system dependencies
         run: |
           apt-get update -q
           apt-get install -y --no-install-recommends git cmake ninja-build llvm-dev libnuma-dev libelf-dev libdrm-dev pkg-config
+
+      - name: Fetch hipcc submodule
+        run: git -C TheRock submodule update --init --depth 1 compiler/amd-llvm
 
       - name: Build hipconfig
         run: |

--- a/projects/hip-tests/catch/include/warp_common.hh
+++ b/projects/hip-tests/catch/include/warp_common.hh
@@ -286,6 +286,7 @@ const char* opToString()
     return "logical_or";
   else if constexpr (std::is_same<Op, XorOp<T>>::value)
     return "logical_xor";
+#if HT_AMD
   else if constexpr (std::is_same<Op, cooperative_groups::plus<T>>::value)
     return "cooperative_groups::plus";
   else if constexpr (std::is_same<Op, cooperative_groups::less<T>>::value)
@@ -298,6 +299,7 @@ const char* opToString()
     return "cooperative_groups::bit_or";
   else if constexpr (std::is_same<Op, cooperative_groups::bit_xor<T>>::value)
     return "cooperative_groups::bit_xor";
+#endif
   else if constexpr (std::is_same<Op, MaxOfAbsolute<T>>::value)
     return "MaxOfAbsolute";
   else {
@@ -397,7 +399,11 @@ T calculateExpected(const T* input, Op& op, unsigned long long mask)
   T result;
   int wavefrontSize = getWarpSize();
 
-  if constexpr (std::is_same<Op, std::plus<T>>::value || std::is_same<Op, cooperative_groups::plus<T>>::value) {
+  if constexpr (std::is_same<Op, std::plus<T>>::value
+#if HT_AMD
+      || std::is_same<Op, cooperative_groups::plus<T>>::value
+#endif
+  ) {
     T tmp[64] = { 0 };
 
     for (int i = 0; i < wavefrontSize; i++) {
@@ -415,6 +421,7 @@ T calculateExpected(const T* input, Op& op, unsigned long long mask)
       }
     }
     result = tmp[0];
+#if HT_AMD
   } else if constexpr (std::is_same<Op, cooperative_groups::less<T>>::value) {
     MinOp<T> minOp;
     return calculateExpected(input, minOp, mask);
@@ -430,6 +437,7 @@ T calculateExpected(const T* input, Op& op, unsigned long long mask)
   } else if constexpr (std::is_same<Op, cooperative_groups::bit_and<T>>::value) {
     std::bit_and<T> andOp;
     return calculateExpected(input, andOp, mask);
+#endif
   } else {
     bool initialized = false;
 

--- a/projects/hip-tests/catch/unit/cooperativeGrps/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/CMakeLists.txt
@@ -33,6 +33,7 @@ set(AMD_TEST_SRC
 if(HIP_PLATFORM STREQUAL "nvidia")
   set(COMPUTE_ARCH "-arch=compute_75")
   set(EXPERIMENTAL_ABI "-D_CG_ABI_EXPERIMENTAL")
+  set_source_files_properties(thread_block_tile.cc PROPERTIES COMPILE_FLAGS "--expt-relaxed-constexpr")
   set(GENCODE_PARAMS "-rdc=true -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=compute_75 -gencode arch=compute_80,code=sm_80")
   set_source_files_properties(hipCGMultiGridGroupType_old.cc PROPERTIES COMPILE_FLAGS "${EXPERIMENTAL_ABI} ${GENCODE_PARAMS}")
   set_source_files_properties(hipLaunchCooperativeKernelMultiDevice_old.cc PROPERTIES COMPILE_FLAGS "${EXPERIMENTAL_ABI} ${GENCODE_PARAMS}")

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -974,7 +974,7 @@ struct Point {
     int x;
     int y;
 
-    __host__ __device__ Point operator+(const Point& rhs)
+    __host__ __device__ Point operator+(const Point& rhs) const
     {
       return { x + rhs.x, y + rhs.y };
     }

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -974,7 +974,7 @@ struct Point {
     int x;
     int y;
 
-    __device__ Point operator+(const Point& rhs)
+    __host__ __device__ Point operator+(const Point& rhs)
     {
       return { x + rhs.x, y + rhs.y };
     }

--- a/projects/hip-tests/catch/unit/deviceLib/deviceAllocation.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/deviceAllocation.cc
@@ -1141,7 +1141,6 @@ HIP_TEST_CASE(Unit_deviceAllocation_CodeObjects) {
   SECTION("MulCodeObj - new") {
     REQUIRE(true == TestAlloc_Load_MultKernels(TEST_NEW_DELETE, INT_MAX));
   }
-}
 
 #if HT_NVIDIA
 /**
@@ -1188,8 +1187,8 @@ HIP_TEST_CASE(Unit_deviceAllocation_CodeObjects) {
   SECTION("double with new") {
     REQUIRE(true == TestMemoryAcrossMulKernels<double>(TEST_NEW_DELETE, true));
   }
-}
 #endif
+}
 
 /**
  * Scenario: This test validates device allocation and deallocation

--- a/projects/hip-tests/catch/unit/executionContext/hipExecutionCtxStreamDetached.cc
+++ b/projects/hip-tests/catch/unit/executionContext/hipExecutionCtxStreamDetached.cc
@@ -451,7 +451,7 @@ HIP_TEST_CASE(Unit_hipExecutionCtxStreamDetached_HmmAsync_Negative) {
 
   SECTION("hipStreamAttachMemAsync") {
     HIP_CHECK_ERROR(
-        hipStreamAttachMemAsync(detached, managed_ptr, kBytes, hipMemAttachSingle),
+        hipStreamAttachMemAsync(detached, reinterpret_cast<hipDeviceptr_t*>(managed_ptr), kBytes, hipMemAttachSingle),
         hipErrorStreamDetached);
   }
 

--- a/projects/hip-tests/catch/unit/stream/hipStreamAttachMemAsync.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamAttachMemAsync.cc
@@ -32,7 +32,7 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Negative) {
   SECTION("Invalid Resource Handle") {
     int definitelyNotAManagedVariable = 0;
     HIP_CHECK_ERROR(
-        hipStreamAttachMemAsync(stream, reinterpret_cast<void*>(&definitelyNotAManagedVariable),
+        hipStreamAttachMemAsync(stream, reinterpret_cast<hipDeviceptr_t*>(&definitelyNotAManagedVariable),
                                 sizeof(int), hipMemAttachSingle),
         hipErrorInvalidValue);
   }
@@ -43,14 +43,14 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Negative) {
   }
 
   SECTION("Invalid Resource Size") {
-    HIP_CHECK_ERROR(hipStreamAttachMemAsync(stream, reinterpret_cast<void*>(&var), sizeof(int) - 1,
+    HIP_CHECK_ERROR(hipStreamAttachMemAsync(stream, reinterpret_cast<hipDeviceptr_t*>(&var), sizeof(int) - 1,
                                             hipMemAttachSingle),
                     hipErrorInvalidValue);
   }
 
   SECTION("Invalid Flags") {
     HIP_CHECK_ERROR(
-        hipStreamAttachMemAsync(stream, reinterpret_cast<void*>(&var), sizeof(int) - 1,
+        hipStreamAttachMemAsync(stream, reinterpret_cast<hipDeviceptr_t*>(&var), sizeof(int) - 1,
                                 hipMemAttachSingle | hipMemAttachHost | hipMemAttachGlobal),
         hipErrorInvalidValue);
   }
@@ -88,7 +88,7 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_UseCase) {
     int* d_memory{nullptr};
     HIP_CHECK(hipMallocManaged(&d_memory, sizeof(int) * size, hipMemAttachHost));
     HIP_CHECK(
-        hipStreamAttachMemAsync(stream, reinterpret_cast<void*>(d_memory), 0, hipMemAttachHost));
+        hipStreamAttachMemAsync(stream, reinterpret_cast<hipDeviceptr_t*>(d_memory), 0, hipMemAttachHost));
     HIP_CHECK(hipStreamSynchronize(stream));  // Wait for command to complete
     HIP_CHECK(hipFree(d_memory));
   }
@@ -99,7 +99,7 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_UseCase) {
     HIP_CHECK(hipMallocManaged(&d_memory, sizeof(int) * size, hipMemAttachHost));
     HIP_CHECK(hipMemset(d_memory, 0, sizeof(int) * size));
     HIP_CHECK(
-        hipStreamAttachMemAsync(stream, reinterpret_cast<void*>(d_memory), 0, hipMemAttachHost));
+        hipStreamAttachMemAsync(stream, reinterpret_cast<hipDeviceptr_t*>(d_memory), 0, hipMemAttachHost));
     HIP_CHECK(hipStreamSynchronize(stream));  // Wait for the command to complete
 
     kernel<<<1, size, 0, stream>>>(d_memory, size);
@@ -116,7 +116,7 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_UseCase) {
   SECTION("Access ManagedMemory") {
     HIP_CHECK(hipMemset(m_memory, 0, sizeof(int) * size));
     HIP_CHECK(
-        hipStreamAttachMemAsync(stream, reinterpret_cast<void*>(m_memory), 0, hipMemAttachHost));
+        hipStreamAttachMemAsync(stream, reinterpret_cast<hipDeviceptr_t*>(m_memory), 0, hipMemAttachHost));
     HIP_CHECK(hipStreamSynchronize(stream));  // Wait for the command to complete
 
     kernel<<<1, size, 0, stream>>>(m_memory, size);

--- a/projects/hip-tests/catch/unit/stream/hipStreamValue.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamValue.cc
@@ -660,6 +660,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipStreamWriteValue_Default, uint32_t, uint64_t) {
   HIP_CHECK(hipStreamDestroy(stream));
 }
 
+#if HT_AMD
 TEMPLATE_TEST_CASE("Unit_hipStreamWriteValue_Increment_Default", "", uint32_t, uint64_t) {
   if (!streamWaitValueSupported()) {
     HIP_SKIP_TEST("hipStreamWriteValue not supported on this device.");
@@ -709,7 +710,6 @@ TEMPLATE_TEST_CASE("Unit_hipStreamWriteValue_Decrement_Default", "", uint32_t, u
   HIP_CHECK(hipHostFree(mem));
 }
 
-#if HT_AMD // stream decrement/increment are not supported on CUDA
 template <typename TestType>
 void testIncrementDecrementMultiStreamMultiDevice(uint32_t operationFlag) {
   if (!streamWaitValueSupported()) {
@@ -788,7 +788,6 @@ void testIncrementDecrementMultiStreamMultiDevice(uint32_t operationFlag) {
 
   HIP_CHECK(hipHostFree(mem));
 }
-#endif
 
 TEMPLATE_TEST_CASE("Unit_hipStreamWriteValue_Increment_MultiStream_MultiDevice", "", uint32_t,
                    uint64_t) {
@@ -800,6 +799,7 @@ TEMPLATE_TEST_CASE("Unit_hipStreamWriteValue_Decrement_MultiStream_MultiDevice",
                    uint64_t) {
   testIncrementDecrementMultiStreamMultiDevice<TestType>(hipExtStreamWriteValueDecrement);
 }
+#endif
 
 template <typename T> __global__ void add(T* a, T* b, T* c, size_t size) {
   size_t i = threadIdx.x;

--- a/projects/hip-tests/catch/unit/stream/hipStreamValue.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamValue.cc
@@ -709,6 +709,7 @@ TEMPLATE_TEST_CASE("Unit_hipStreamWriteValue_Decrement_Default", "", uint32_t, u
   HIP_CHECK(hipHostFree(mem));
 }
 
+#if HT_AMD // stream decrement/increment are not supported on CUDA
 template <typename TestType>
 void testIncrementDecrementMultiStreamMultiDevice(uint32_t operationFlag) {
   if (!streamWaitValueSupported()) {
@@ -787,6 +788,7 @@ void testIncrementDecrementMultiStreamMultiDevice(uint32_t operationFlag) {
 
   HIP_CHECK(hipHostFree(mem));
 }
+#endif
 
 TEMPLATE_TEST_CASE("Unit_hipStreamWriteValue_Increment_MultiStream_MultiDevice", "", uint32_t,
                    uint64_t) {

--- a/projects/hip-tests/catch/unit/texture/hipMipmappedArrayGetMemoryRequirements.cc
+++ b/projects/hip-tests/catch/unit/texture/hipMipmappedArrayGetMemoryRequirements.cc
@@ -39,4 +39,10 @@ HIP_TEST_CASE(Unit_hipMipmappedArrayGetMemoryRequirements_Negative_Parameters) {
   SECTION("mipmap is nullptr") {
     HIP_CHECK_ERROR(hipMipmappedArrayGetMemoryRequirements(&memoryRequirements, nullptr, device_id), hipErrorInvalidHandle);
   }
+
+#if HT_AMD
+  HIP_CHECK(hipMipmappedArrayDestroy(array));
+#elif HT_NVIDIA
+  HIP_CHECK(hipFreeMipmappedArray(array));
+#endif
 }

--- a/projects/hip-tests/catch/unit/texture/hipMipmappedArrayGetMemoryRequirements.cc
+++ b/projects/hip-tests/catch/unit/texture/hipMipmappedArrayGetMemoryRequirements.cc
@@ -12,7 +12,11 @@ HIP_TEST_CASE(Unit_hipMipmappedArrayGetMemoryRequirements_Negative_Parameters) {
 
   const int device_id = 0;
   hipArrayMemoryRequirements memoryRequirements{};
-  hipmipmappedArray array;
+  hipMipmappedArray_t array;
+  unsigned int levels = 1 + std::log2(6);
+
+  HIP_CHECK(hipFree(0));
+#if HT_AMD
   HIP_ARRAY3D_DESCRIPTOR desc = {};
   using vec_info = vector_info<float>;
   desc.Format = vec_info::format;
@@ -21,11 +25,12 @@ HIP_TEST_CASE(Unit_hipMipmappedArrayGetMemoryRequirements_Negative_Parameters) {
   desc.Height = 4;
   desc.Depth = 6;
   desc.Flags = 0;
-
-  unsigned int levels = 1 + std::log2(desc.Depth);
-
-  HIP_CHECK(hipFree(0));
   HIP_CHECK(hipMipmappedArrayCreate(&array, &desc, levels));
+#elif HT_NVIDIA
+  hipChannelFormatDesc desc = hipCreateChannelDesc<float>();
+  hipExtent extent = make_hipExtent(4, 4, 6);
+  HIP_CHECK(hipMallocMipmappedArray(&array, &desc, extent, levels));
+#endif
 
   SECTION("memoryRequirements is nullptr") {
     HIP_CHECK_ERROR(hipMipmappedArrayGetMemoryRequirements(nullptr, array, device_id), hipErrorInvalidValue);

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemExportToShareableHandle.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemExportToShareableHandle.cc
@@ -189,17 +189,17 @@ TEST_CASE("Unit_hipMemExportFabricHandleToStdout_Positive_Basic") {
   allocSize = ((granularity + allocSize -1) / granularity) * granularity;
 
   hipDeviceptr_t addr = 0;
-  HIP_CHECK(hipMemAddressReserve(&addr, allocSize, 0, 0, 0));
+  HIP_CHECK(hipMemAddressReserve(reinterpret_cast<void**>(&addr), allocSize, 0, 0, 0));
 
   hipMemGenericAllocationHandle_t allocHandle;
   HIP_CHECK(hipMemCreate(&allocHandle, granularity * 2, &prop, 0));
 
-  HIP_CHECK(hipMemMap(addr, allocSize, 0, allocHandle, 0));
+  HIP_CHECK(hipMemMap(reinterpret_cast<void*>(addr), allocSize, 0, allocHandle, 0));
 
   hipMemAccessDesc accessDesc{};
   accessDesc.location = prop.location;
   accessDesc.flags = hipMemAccessFlagsProtReadWrite;
-  HIP_CHECK(hipMemSetAccess(addr, allocSize, &accessDesc, 1));
+  HIP_CHECK(hipMemSetAccess(reinterpret_cast<void*>(addr), allocSize, &accessDesc, 1));
 
   int fabrichandle;
   HIP_CHECK(hipMemExportToShareableHandle(reinterpret_cast<void*>(&fabrichandle), allocHandle,
@@ -207,9 +207,9 @@ TEST_CASE("Unit_hipMemExportFabricHandleToStdout_Positive_Basic") {
 
   REQUIRE(fabrichandle != 0);
 
-  HIP_CHECK(hipMemUnmap(addr, allocSize));
+  HIP_CHECK(hipMemUnmap(reinterpret_cast<void*>(addr), allocSize));
   HIP_CHECK(hipMemRelease(allocHandle));
-  HIP_CHECK(hipMemAddressFree(addr, allocSize));
+  HIP_CHECK(hipMemAddressFree(reinterpret_cast<void*>(addr), allocSize));
 
   CTX_DESTROY();
 }

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
@@ -844,9 +844,9 @@ HIP_TEST_CASE(Unit_hipMemMap_Positive_APU_LargeAllocSpill) {
   HIP_CHECK(hipMemAddressReserve(&va, size, 0, nullptr, 0));
   REQUIRE(va != nullptr);
 
-  hipMemGenericAllocationHandle_t handle = nullptr;
+  hipMemGenericAllocationHandle_t handle = reinterpret_cast<hipMemGenericAllocationHandle_t>(nullptr);
   HIP_CHECK(hipMemCreate(&handle, size, &aprop, 0));
-  REQUIRE(handle != nullptr);
+  REQUIRE(handle != reinterpret_cast<hipMemGenericAllocationHandle_t>(nullptr));
 
   HIP_CHECK(hipMemMap(va, size, 0, handle, 0));
 

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
@@ -844,9 +844,9 @@ HIP_TEST_CASE(Unit_hipMemMap_Positive_APU_LargeAllocSpill) {
   HIP_CHECK(hipMemAddressReserve(&va, size, 0, nullptr, 0));
   REQUIRE(va != nullptr);
 
-  hipMemGenericAllocationHandle_t handle = reinterpret_cast<hipMemGenericAllocationHandle_t>(nullptr);
+  hipMemGenericAllocationHandle_t handle{};
   HIP_CHECK(hipMemCreate(&handle, size, &aprop, 0));
-  REQUIRE(handle != reinterpret_cast<hipMemGenericAllocationHandle_t>(nullptr));
+  REQUIRE(handle != hipMemGenericAllocationHandle_t{});
 
   HIP_CHECK(hipMemMap(va, size, 0, handle, 0));
 

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
@@ -912,7 +912,7 @@ HIP_TEST_CASE(Unit_hipMemMap_Retrieve_AllocationHandle) {
   HIP_CHECK(hipMemMap(ptr, size_mem, 0, handle, 0));
 
   // Confirm hipMemRetainAllocationHandle retrieves correct base handle
-  hipMemGenericAllocationHandle_t retrieved = nullptr;
+  hipMemGenericAllocationHandle_t retrieved = 0;  // 0 instead of nullptr: handle is an integer type on CUDA
   HIP_CHECK(hipMemRetainAllocationHandle(&retrieved, ptr));
   REQUIRE(retrieved == handle);
   HIP_CHECK(hipMemRelease(retrieved));
@@ -963,7 +963,7 @@ HIP_TEST_CASE(Unit_hipMemMap_Retrieve_MultiAllocationHandle) {
 
   // Every alias must resolve sub_obj -> phys -> ga back to handle.
   for (int i = 0; i < num_buf; ++i) {
-    hipMemGenericAllocationHandle_t retrieved = nullptr;
+    hipMemGenericAllocationHandle_t retrieved = 0;  // 0 instead of nullptr: handle is an integer type on CUDA
     HIP_CHECK(hipMemRetainAllocationHandle(&retrieved, ptrs[i]));
     REQUIRE(retrieved == handle);
     HIP_CHECK(hipMemRelease(retrieved));
@@ -1012,7 +1012,7 @@ HIP_TEST_CASE(Unit_hipMemMap_CheckAddMemObj) {
   HIP_CHECK(hipMemAddressReserve(&ptr, size_mem, 0, 0, 0));
 
   // Before map: retainAllocationHandle must fail.
-  hipMemGenericAllocationHandle_t retrieved = nullptr;
+  hipMemGenericAllocationHandle_t retrieved = 0;  // 0 instead of nullptr: handle is an integer type on CUDA
   REQUIRE(hipMemRetainAllocationHandle(&retrieved, ptr) == hipErrorInvalidValue);
 
   HIP_CHECK(hipMemMap(ptr, size_mem, 0, handle, 0));
@@ -1091,7 +1091,7 @@ HIP_TEST_CASE(Unit_hipMemMap_RoundTrip) {
 
   // Bookkeeping cross-link must be wired by the direct path (lean on the
   // dedicated bookkeeping tests for finer-grained assertions).
-  hipMemGenericAllocationHandle_t retrieved = nullptr;
+  hipMemGenericAllocationHandle_t retrieved = 0;  // 0 instead of nullptr: handle is an integer type on CUDA
   HIP_CHECK(hipMemRetainAllocationHandle(&retrieved, ptr));
   REQUIRE(retrieved == handle);
   HIP_CHECK(hipMemRelease(retrieved));

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemUnmap.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemUnmap.cc
@@ -168,7 +168,7 @@ HIP_TEST_CASE(Unit_hipMemUnmap_CrossLinksTornDown) {
   HIP_CHECK(hipMemMap(ptr, size_mem, 0, handle, 0));
 
   // Sanity: cross-link is wired pre-unmap.
-  hipMemGenericAllocationHandle_t retrieved = nullptr;
+  hipMemGenericAllocationHandle_t retrieved = 0;  // 0 instead of nullptr: handle is an integer type on CUDA
   HIP_CHECK(hipMemRetainAllocationHandle(&retrieved, ptr));
   REQUIRE(retrieved == handle);
   HIP_CHECK(hipMemRelease(retrieved));
@@ -223,7 +223,7 @@ HIP_TEST_CASE(Unit_hipMemUnmap_RemapCrossLinks) {
   HIP_CHECK(hipMemAddressReserve(&ptr, size_mem, 0, 0, 0));
 
   HIP_CHECK(hipMemMap(ptr, size_mem, 0, handle1, 0));
-  hipMemGenericAllocationHandle_t retrieved = nullptr;
+  hipMemGenericAllocationHandle_t retrieved = 0;  // 0 instead of nullptr: handle is an integer type on CUDA
   HIP_CHECK(hipMemRetainAllocationHandle(&retrieved, ptr));
   REQUIRE(retrieved == handle1);
   HIP_CHECK(hipMemRelease(retrieved));

--- a/projects/hipother/hipnv/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
+++ b/projects/hipother/hipnv/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
@@ -125,6 +125,7 @@ typedef enum hipMemoryAdvise {
 #define hipStreamWaitValueEq CU_STREAM_WAIT_VALUE_EQ
 #define hipStreamWaitValueAnd CU_STREAM_WAIT_VALUE_AND
 #define hipStreamWaitValueNor CU_STREAM_WAIT_VALUE_NOR
+#define hipStreamWriteValueDefault CU_STREAM_WRITE_VALUE_DEFAULT
 
 // hipLibraryPropertyType
 #define hipLibraryPropertyType libraryPropertyType

--- a/projects/hipother/hipnv/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
+++ b/projects/hipother/hipnv/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
@@ -367,6 +367,7 @@ typedef enum cudaResourceViewFormat hipResourceViewFormat;
 #define hipHostMallocWriteCombined cudaHostAllocWriteCombined
 #define hipHostMallocCoherent 0x0
 #define hipHostMallocNonCoherent 0x0
+#define hipMallocSignalMemory 0x0
 
 #define hipHostAllocDefault cudaHostAllocDefault
 #define hipHostAllocPortable cudaHostAllocPortable


### PR DESCRIPTION
## Motivation
While not building any of the Nvidia artifacts, we want to ensure that the existing CLR and HIP-tests are buildable for every of CLR changes. This PR adds corresponding check, which will become blocking.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
This PR adds the build workflow, exclusive to only rocm-systems. It will run on changes to clr, hipother, hip and hip-tests. On rest of the projects it will skip workflow and mark it as a success. Workflow will eventually be marked as a requirement.
Currently latest cuda docker, 13.1.2 is used.
Hip-tests build is a validating check, because CLR build for NVidia is simply a headers pre-process, so we utilize actual usage code in hip-tests for build errors validation.
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
NA
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
New workflow should pass correctly
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Waiting for PSDB
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
