### PR TITLE
ROCM-21854 - Factor out TLS look up when retrieving and validating memory objects

### DIFF
--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -196,7 +196,7 @@ hipError_t ihipGraphAddMemsetNode(hip::GraphNode** pGraphNode, hip::Graph* graph
   }
   if (pMemsetParams->height == 1) {
     size_t offset = 0;
-    amd::Memory* memObj = getMemoryObject(pMemsetParams->dst, offset);
+    amd::Memory* memObj = getMemoryObjectForCurrentDevice(pMemsetParams->dst, offset);
     if (memObj == nullptr) {
       return hipErrorInvalidValue;
     }
@@ -209,7 +209,7 @@ hipError_t ihipGraphAddMemsetNode(hip::GraphNode** pGraphNode, hip::Graph* graph
     auto sizeBytes =
         pMemsetParams->width * pMemsetParams->height * depth * pMemsetParams->elementSize;
     size_t offset = 0;
-    amd::Memory* memObj = getMemoryObject(pMemsetParams->dst, offset, sizeBytes);
+    amd::Memory* memObj = getMemoryObjectForCurrentDevice(pMemsetParams->dst, offset, sizeBytes);
     if (memObj == nullptr) {
       return hipErrorInvalidValue;
     }
@@ -2811,7 +2811,7 @@ hipError_t ihipGraphAddMemFreeNode(hip::GraphNode** graphNode, hip::Graph* graph
                                    void* dptr) {
   // Is memory passed to be free'd valid
   size_t offset = 0;
-  auto memory = getMemoryObject(dptr, offset);
+  auto memory = getMemoryObjectForCurrentDevice(dptr, offset);
   if (memory == nullptr) {
     if (HIP_MEM_POOL_USE_VM) {
       // When VM is on the address must be valid and may point to a VA object
@@ -3290,7 +3290,7 @@ hipError_t hipGraphAddNode(hipGraphNode_t* pGraphNode, hipGraph_t graph,
       }
       // Is memory passed to be free'd valid
       offset = 0;
-      memory = getMemoryObject(nodeParams->free.dptr, offset);
+      memory = getMemoryObjectForCurrentDevice(nodeParams->free.dptr, offset);
       if (memory == nullptr) {
         if (HIP_MEM_POOL_USE_VM) {
           // When VM is on the address must be valid and may point to a VA object
@@ -3435,7 +3435,7 @@ hipError_t hipDrvGraphAddMemFreeNode(hipGraphNode_t* phGraphNode, hipGraph_t hGr
   }
   // Is memory passed to be free'd valid
   size_t offset = 0;
-  auto memory = getMemoryObject(dptr, offset);
+  auto memory = getMemoryObjectForCurrentDevice(dptr, offset);
   if (memory == nullptr) {
     if (HIP_MEM_POOL_USE_VM) {
       // When VM is on the address must be valid and may point to a VA object

--- a/projects/clr/hipamd/src/hip_graph_helper.hpp
+++ b/projects/clr/hipamd/src/hip_graph_helper.hpp
@@ -16,20 +16,6 @@ hipError_t hipMemcpy2DValidateArray(hipArray_const_t arr, size_t wOffset, size_t
 
 hipError_t hipMemcpy2DValidateBuffer(const void* buf, size_t pitch, size_t width);
 
-hipError_t ihipMemcpy_validate(void* dst, const void* src, size_t sizeBytes, hipMemcpyKind kind);
-
-hipError_t ihipMemcpy_validate_memory(amd::Memory* memObj, size_t sizeBytes, size_t offset,
-                                      bool read_write);
-
-hipError_t ihipMemcpy_validate(amd::Memory* dstMemory, amd::Memory* srcMemory, size_t sizeBytes,
-                                size_t dstOffset, size_t srcOffset);
-
-// Two-size variant used by the batch memcpy path: indirect copies place a
-// sizeof(void*) pointer-holder on one side and the real data buffer on the other,
-// so src and dst must be validated against independent region sizes.
-hipError_t ihipMemcpy_validate(amd::Memory* dstMemory, amd::Memory* srcMemory, size_t srcSizeBytes,
-                               size_t dstSizeBytes, size_t dstOffset, size_t srcOffset);
-
 hipError_t ihipMemcpyCommand(amd::Command*& command, amd::Memory* dstMemory, const void* srcMemory,
                              size_t sizeBytes, hipMemcpyKind kind, hip::Stream& stream,
                              size_t dstOffset, bool isAsync = true);

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -68,9 +68,9 @@ hipError_t GraphMemcpyNode1D::ValidateParams(void* dst, const void* src, size_t 
     return hipErrorInvalidMemcpyDirection;
   }
   size_t sOffset = 0;
-  amd::Memory* srcMemory = getMemoryObject(src, sOffset);
+  amd::Memory* srcMemory = getMemoryObjectForCurrentDevice(src, sOffset);
   size_t dOffset = 0;
-  amd::Memory* dstMemory = getMemoryObject(dst, dOffset);
+  amd::Memory* dstMemory = getMemoryObjectForCurrentDevice(dst, dOffset);
 
   if ((srcMemory == nullptr) && (dstMemory != nullptr)) {  // host to device
     if ((kind != hipMemcpyHostToDevice) && (kind != hipMemcpyDefault)) {
@@ -82,16 +82,25 @@ hipError_t GraphMemcpyNode1D::ValidateParams(void* dst, const void* src, size_t 
     }
   }
 
-  if (srcMemory != nullptr) {
-    hipError_t status = ihipMemcpy_validate_memory(srcMemory, count, sOffset, /*read_write*/ false);
-    if (status != hipSuccess) {
-      return status;
+  if (srcMemory != nullptr || dstMemory != nullptr) {
+    hip::Device* dev = hip::getCurrentDevice();
+    if (dev == nullptr) {
+      return hipErrorInvalidDevice;
     }
-  }
-  if (dstMemory != nullptr) {
-    hipError_t status = ihipMemcpy_validate_memory(dstMemory, count, dOffset, /*read_write*/ true);
-    if (status != hipSuccess) {
-      return status;
+    amd::Device& amdDev = *dev->devices()[0];
+    if (srcMemory != nullptr) {
+      hipError_t status =
+          ihipMemcpy_validate_memory(amdDev, srcMemory, count, sOffset, /*read_write*/ false);
+      if (status != hipSuccess) {
+        return status;
+      }
+    }
+    if (dstMemory != nullptr) {
+      hipError_t status =
+          ihipMemcpy_validate_memory(amdDev, dstMemory, count, dOffset, /*read_write*/ true);
+      if (status != hipSuccess) {
+        return status;
+      }
     }
   }
 

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -2874,7 +2874,7 @@ class GraphMemAllocNode final : public GraphNode {
             // The old memory is in busy_heap_ (owned by whoever took it from free_heap_).
             // DecrementRefCount is lock-protected and checks both heaps.
             size_t old_offset = 0;
-            auto* old_memory = getMemoryObject(*phys_ptr_ref_, old_offset);
+            auto* old_memory = getMemoryObjectForCurrentDevice(*phys_ptr_ref_, old_offset);
             if (old_memory != nullptr) {
               pool->DecrementRefCount(old_memory);
             }

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -820,7 +820,7 @@ class Graph {
 
   void FreeMemory(void* dev_ptr, hip::Stream* stream) const {
     size_t offset = 0;
-    auto memory = getMemoryObject(dev_ptr, offset);
+    auto memory = getMemoryObjectForCurrentDevice(dev_ptr, offset);
     if (memory != nullptr) {
       auto device_id = memory->getUserData().deviceId;
       // Skip event marker for non-DD path when pool frees memory
@@ -833,7 +833,7 @@ class Graph {
 
   bool ProbeMemory(void* dev_ptr) const {
     size_t offset = 0;
-    auto memory = getMemoryObject(dev_ptr, offset);
+    auto memory = getMemoryObjectForCurrentDevice(dev_ptr, offset);
     if (memory != nullptr) {
       return mem_pool_->IsBusyMemory(memory);
     }
@@ -1811,24 +1811,24 @@ class GraphMemcpyNode : public GraphNode {
     hipMemoryType srcMemoryType = pCopy.srcMemoryType;
     if (srcMemoryType == hipMemoryTypeUnified) {
       srcMemoryType =
-          getMemoryObject(pCopy.srcDevice, offset) ? hipMemoryTypeDevice : hipMemoryTypeHost;
+          getMemoryObjectForCurrentDevice(pCopy.srcDevice, offset) ? hipMemoryTypeDevice : hipMemoryTypeHost;
     }
     offset = 0;
     hipMemoryType dstMemoryType = pCopy.dstMemoryType;
     if (dstMemoryType == hipMemoryTypeUnified) {
       dstMemoryType =
-          getMemoryObject(pCopy.dstDevice, offset) ? hipMemoryTypeDevice : hipMemoryTypeHost;
+          getMemoryObjectForCurrentDevice(pCopy.dstDevice, offset) ? hipMemoryTypeDevice : hipMemoryTypeHost;
     }
 
     // If {src/dst}MemoryType is hipMemoryTypeHost, check if the memory was prepinned.
     // In that case upgrade the copy type to hipMemoryTypeDevice to avoid extra pinning.
     offset = 0;
     if (srcMemoryType == hipMemoryTypeHost) {
-      amd::Memory* mem = getMemoryObject(pCopy.srcHost, offset);
+      amd::Memory* mem = getMemoryObjectForCurrentDevice(pCopy.srcHost, offset);
       srcMemoryType = mem ? hipMemoryTypeDevice : hipMemoryTypeHost;
     }
     if (dstMemoryType == hipMemoryTypeHost) {
-      amd::Memory* mem = getMemoryObject(pCopy.dstHost, offset);
+      amd::Memory* mem = getMemoryObjectForCurrentDevice(pCopy.dstHost, offset);
       dstMemoryType = mem ? hipMemoryTypeDevice : hipMemoryTypeHost;
     }
     std::string memcpyDirection;
@@ -1921,10 +1921,10 @@ class GraphMemcpyNode1D : public GraphMemcpyNode {
   // id accordingly so that node can be executed on dev1.
   void UpdateDevId() {
     size_t sOffset = 0;
-    amd::Memory* srcMemory = getMemoryObject(src_, sOffset);
+    amd::Memory* srcMemory = getMemoryObjectForCurrentDevice(src_, sOffset);
     size_t dOffset = 0;
-    amd::Memory* dstMemory = getMemoryObject(dst_, dOffset);
-
+    amd::Memory* dstMemory = getMemoryObjectForCurrentDevice(dst_, dOffset);
+    
     hip::MemcpyType memType = hipHostToHost;
     if (srcMemory != nullptr && dstMemory == nullptr) {
         memType = ihipGetMemcpyType(srcMemory, dst_);
@@ -1989,8 +1989,8 @@ class GraphMemcpyNode1D : public GraphMemcpyNode {
 
     hip::MemcpyType type = hipHostToHost;
     size_t dOffset, sOffset;
-    amd::Memory* dstMemory = getMemoryObject(dst_, dOffset);
-    amd::Memory* srcMemory = getMemoryObject(src_, sOffset);
+    amd::Memory* dstMemory = getMemoryObjectForCurrentDevice(dst_, dOffset);
+    amd::Memory* srcMemory = getMemoryObjectForCurrentDevice(src_, sOffset);
 
     if (dstMemory != nullptr && srcMemory != nullptr) {
       status = ihipMemcpyCommand(command, dstMemory, srcMemory, count_, kind_, *stream, dOffset,
@@ -2107,14 +2107,14 @@ class GraphMemcpyNode1D : public GraphMemcpyNode {
   static hipError_t ValidateParams(void* dst, const void* src, size_t count, hipMemcpyKind kind);
   virtual std::string GetLabel(hipGraphDebugDotFlags flag) override {
     size_t sOffsetOrig = 0;
-    amd::Memory* origSrcMemory = getMemoryObject(src_, sOffsetOrig);
+    amd::Memory* origSrcMemory = getMemoryObjectForCurrentDevice(src_, sOffsetOrig);
     size_t dOffsetOrig = 0;
-    amd::Memory* origDstMemory = getMemoryObject(dst_, dOffsetOrig);
+    amd::Memory* origDstMemory = getMemoryObjectForCurrentDevice(dst_, dOffsetOrig);
 
     size_t sOffset = 0;
-    amd::Memory* srcMemory = getMemoryObject(src_, sOffset);
+    amd::Memory* srcMemory = getMemoryObjectForCurrentDevice(src_, sOffset);
     size_t dOffset = 0;
-    amd::Memory* dstMemory = getMemoryObject(dst_, dOffset);
+    amd::Memory* dstMemory = getMemoryObjectForCurrentDevice(dst_, dOffset);
     std::string memcpyDirection;
     if ((srcMemory == nullptr) && (dstMemory != nullptr)) {  // host to device
       memcpyDirection = "HtoD";
@@ -2163,8 +2163,8 @@ class GraphMemcpyNode1D : public GraphMemcpyNode {
       hip::MemcpyType type = hipHostToHost;
 
       size_t dOffset, sOffset;
-      amd::Memory* dstMemory = getMemoryObject(dst_, dOffset);
-      amd::Memory* srcMemory = getMemoryObject(src_, sOffset);
+      amd::Memory* dstMemory = getMemoryObjectForCurrentDevice(dst_, dOffset);
+      amd::Memory* srcMemory = getMemoryObjectForCurrentDevice(src_, sOffset);
 
       // The case below is only interested in hipCopyBuffer,
       // which is only valid for device to device copies.
@@ -2218,8 +2218,8 @@ class GraphMemcpyNodeFromSymbol : public GraphMemcpyNode1D {
     }
 
     size_t devOffset, dOffset;
-    amd::Memory* devMemory = getMemoryObject(device_ptr, devOffset);
-    amd::Memory* dstMemory = getMemoryObject(dst_, dOffset);
+    amd::Memory* devMemory = getMemoryObjectForCurrentDevice(device_ptr, devOffset);
+    amd::Memory* dstMemory = getMemoryObjectForCurrentDevice(dst_, dOffset);
 
     if (devMemory == nullptr) {
         return hipErrorInvalidValue;
@@ -2242,9 +2242,9 @@ class GraphMemcpyNodeFromSymbol : public GraphMemcpyNode1D {
                        hipMemcpyKind kind, bool isExec = false) {
     if (isExec) {
       size_t discardOffset = 0;
-      amd::Memory* memObj = getMemoryObject(dst, discardOffset);
+      amd::Memory* memObj = getMemoryObjectForCurrentDevice(dst, discardOffset);
       if (memObj != nullptr) {
-        amd::Memory* memObjOri = getMemoryObject(dst_, discardOffset);
+        amd::Memory* memObjOri = getMemoryObjectForCurrentDevice(dst_, discardOffset);
         if (memObjOri != nullptr) {
           if (memObjOri->getUserData().deviceId != memObj->getUserData().deviceId) {
             return hipErrorInvalidValue;
@@ -2265,7 +2265,7 @@ class GraphMemcpyNodeFromSymbol : public GraphMemcpyNode1D {
     }
 
     size_t dOffset = 0;
-    amd::Memory* dstMemory = getMemoryObject(dst, dOffset);
+    amd::Memory* dstMemory = getMemoryObjectForCurrentDevice(dst, dOffset);
     if (dstMemory == nullptr && kind != hipMemcpyDeviceToHost && kind != hipMemcpyDefault) {
       return hipErrorInvalidMemcpyDirection;
     } else if (dstMemory != nullptr && dstMemory->getMemFlags() == 0 &&
@@ -2332,8 +2332,8 @@ class GraphMemcpyNodeToSymbol : public GraphMemcpyNode1D {
     }
 
     size_t devOffset, sOffset;
-    amd::Memory* devMemory = getMemoryObject(device_ptr, devOffset);
-    amd::Memory* srcMemory = getMemoryObject(src_, sOffset);
+    amd::Memory* devMemory = getMemoryObjectForCurrentDevice(device_ptr, devOffset);
+    amd::Memory* srcMemory = getMemoryObjectForCurrentDevice(src_, sOffset);
 
     if (devMemory == nullptr) {
         return hipErrorInvalidValue;
@@ -2356,9 +2356,9 @@ class GraphMemcpyNodeToSymbol : public GraphMemcpyNode1D {
                        hipMemcpyKind kind, bool isExec = false) {
     if (isExec) {
       size_t discardOffset = 0;
-      amd::Memory* memObj = getMemoryObject(src, discardOffset);
+      amd::Memory* memObj = getMemoryObjectForCurrentDevice(src, discardOffset);
       if (memObj != nullptr) {
-        amd::Memory* memObjOri = getMemoryObject(src_, discardOffset);
+        amd::Memory* memObjOri = getMemoryObjectForCurrentDevice(src_, discardOffset);
         if (memObjOri != nullptr) {
           if (memObjOri->getUserData().deviceId != memObj->getUserData().deviceId) {
             return hipErrorInvalidValue;
@@ -2378,7 +2378,7 @@ class GraphMemcpyNodeToSymbol : public GraphMemcpyNode1D {
       return status;
     }
     size_t dOffset = 0;
-    amd::Memory* srcMemory = getMemoryObject(src, dOffset);
+    amd::Memory* srcMemory = getMemoryObjectForCurrentDevice(src, dOffset);
     cl_mem_flags srcFlag = 0;
     if (srcMemory != nullptr) {
       srcFlag = srcMemory->getMemFlags();
@@ -2492,7 +2492,7 @@ class GraphMemsetNode : public GraphNode {
     if (memsetParams_.height == 1 && depth_ == 1) {
       size_t sizeBytes = memsetParams_.width * memsetParams_.elementSize;
       size_t offset = 0;
-      amd::Memory* memObj = getMemoryObject(memsetParams_.dst, offset);
+      amd::Memory* memObj = getMemoryObjectForCurrentDevice(memsetParams_.dst, offset);
       if (memObj == nullptr) {
         return hipErrorInvalidValue;
       }
@@ -2502,7 +2502,7 @@ class GraphMemsetNode : public GraphNode {
       auto sizeBytes =
           memsetParams_.width * memsetParams_.elementSize * memsetParams_.height * depth_;
       size_t offset = 0;
-      amd::Memory* memObj = getMemoryObject(memsetParams_.dst, offset);
+      amd::Memory* memObj = getMemoryObjectForCurrentDevice(memsetParams_.dst, offset);
       if (memObj == nullptr) {
         return hipErrorInvalidValue;
       }
@@ -2532,9 +2532,9 @@ class GraphMemsetNode : public GraphNode {
     }
     if (isExec) {
       size_t discardOffset = 0;
-      amd::Memory* memObj = getMemoryObject(params->dst, discardOffset);
+      amd::Memory* memObj = getMemoryObjectForCurrentDevice(params->dst, discardOffset);
       if (memObj != nullptr) {
-        amd::Memory* memObjOri = getMemoryObject(memsetParams_.dst, discardOffset);
+        amd::Memory* memObjOri = getMemoryObjectForCurrentDevice(memsetParams_.dst, discardOffset);
         if (memObjOri != nullptr) {
           if (memObjOri->getUserData().deviceId != memObj->getUserData().deviceId) {
             return hipErrorInvalidValue;
@@ -2547,7 +2547,7 @@ class GraphMemsetNode : public GraphNode {
       // 1D - for hipGraphMemsetNodeSetParams & hipGraphExecMemsetNodeSetParams, They return
       // invalid value if new width is more than actual allocation.
       size_t offset = 0;
-      amd::Memory* memObj = getMemoryObject(params->dst, offset);
+      amd::Memory* memObj = getMemoryObjectForCurrentDevice(params->dst, offset);
       if (memObj == nullptr) {
         return hipErrorInvalidValue;
       }
@@ -2573,7 +2573,7 @@ class GraphMemsetNode : public GraphNode {
         // hipMalloc3D; for plain hipMalloc (and similar flat allocators) they are 0, in which case
         // the size-based check in ihipMemset3D_validate below is authoritative.
         size_t discardOffset = 0;
-        amd::Memory* memObj = getMemoryObject(params->dst, discardOffset);
+        amd::Memory* memObj = getMemoryObjectForCurrentDevice(params->dst, discardOffset);
         if (memObj != nullptr && memObj->getUserData().width_ != 0) {
           if (params->width * params->elementSize > memObj->getUserData().width_ ||
               params->height > memObj->getUserData().height_ ||
@@ -2584,7 +2584,7 @@ class GraphMemsetNode : public GraphNode {
       }
       sizeBytes = params->width * params->elementSize * params->height * depth;
       size_t offset = 0;
-      amd::Memory* memObj = getMemoryObject(params->dst, offset, sizeBytes);
+      amd::Memory* memObj = getMemoryObjectForCurrentDevice(params->dst, offset, sizeBytes);
       if (memObj == nullptr) {
         return hipErrorInvalidValue;
       }
@@ -2828,7 +2828,7 @@ class GraphMemAllocNode final : public GraphNode {
         return;
       }
       size_t offset = 0;
-      memory_ = getMemoryObject(dptr, offset);
+      memory_ = getMemoryObjectForCurrentDevice(dptr, offset);
       if (!AMD_DIRECT_DISPATCH) {
         memory_->retain();
       }
@@ -2975,7 +2975,7 @@ class GraphMemAllocNode final : public GraphNode {
         commands_.push_back(cmd);
         size_t offset = 0;
         // Check if memory was already added after first reserve
-        if (getMemoryObject(node_params_.dptr, offset) == nullptr) {
+        if (getMemoryObjectForCurrentDevice(node_params_.dptr, offset) == nullptr) {
           // Map VA in the accessible space because the graph execution still has
           // pointers validation and must find a valid object
           // @note: Memory can be released outside of the graph and

--- a/projects/clr/hipamd/src/hip_hmm.cpp
+++ b/projects/clr/hipamd/src/hip_hmm.cpp
@@ -207,7 +207,7 @@ hipError_t hipMemRangeGetAttributes(void** data, size_t* data_sizes,
   }
 
   size_t offset = 0;
-  amd::Memory* memObj = getMemoryObject(dev_ptr, offset);
+  amd::Memory* memObj = getMemoryObject(hip::getCurrentDevice(), dev_ptr, offset);
   if (memObj) {
     if (!(memObj->getMemFlags() & (CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_ALLOC_HOST_PTR))) {
       HIP_RETURN(hipErrorInvalidValue);
@@ -248,11 +248,12 @@ hipError_t hipStreamAttachMemAsync(hipStream_t stream, void* dev_ptr, size_t len
   // host-accessible region of system-allocated pageable memory.
   // This type of memory may only be specified if the device associated with the
   // stream reports a non-zero value for the device attribute hipDevAttrPageableMemoryAccess.
+  hip::Device* dev = hip::getCurrentDevice();
   hip::Stream* hip_stream = (stream == nullptr || stream == hipStreamLegacy)
-                                ? hip::getCurrentDevice()->NullStream()
+                                ? dev->NullStream()
                                 : hip::getStream(stream);
   size_t offset = 0;
-  amd::Memory* memObj = getMemoryObject(dev_ptr, offset);
+  amd::Memory* memObj = getMemoryObject(dev, dev_ptr, offset);
   if (memObj == nullptr) {
     if (hip_stream->GetDevice()->devices()[0]->info().hmmCpuMemoryAccessible_ == 0) {
       HIP_RETURN(hipErrorInvalidValue);
@@ -301,12 +302,13 @@ hipError_t ihipMallocManaged(void** ptr, size_t size, size_t align, bool use_hos
     return hipErrorMemoryAllocation;
   }
   size_t offset = 0;  // this is ignored
-  amd::Memory* memObj = getMemoryObject(*ptr, offset);
+  hip::Device* hipDev = hip::getCurrentDevice();
+  amd::Memory* memObj = getMemoryObject(hipDev, *ptr, offset);
   if (memObj == nullptr) {
     return hipErrorMemoryAllocation;
   }
   // saves the current device id so that it can be accessed later
-  memObj->getUserData().deviceId = hip::getCurrentDevice()->deviceId();
+  memObj->getUserData().deviceId = hipDev->deviceId();
 
   ClPrint(amd::LOG_INFO, amd::LOG_API, "ihipMallocManaged ptr=0x%zx", *ptr);
   return hipSuccess;
@@ -321,7 +323,7 @@ hipError_t ihipMemPrefetchAsync(const void* dev_ptr, size_t count, hipMemLocatio
   getStreamPerThread(stream);
 
   size_t offset = 0;
-  amd::Memory* memObj = getMemoryObject(dev_ptr, offset);
+  amd::Memory* memObj = getMemoryObject(hip::getCurrentDevice(), dev_ptr, offset);
   if ((memObj != nullptr) && (count > (memObj->getSize() - offset))) {
     return hipErrorInvalidValue;
   }
@@ -438,7 +440,8 @@ hipError_t ihipMemPrefetchBatchAsync(void** dev_ptrs, size_t* sizes, size_t coun
 
     // Batched memory object lookup with single lock acquisition
     std::vector<size_t> offsets;
-    std::vector<amd::Memory*> mem_objs = getMemoryObjectBatch(dev_ptrs, count, offsets);
+    std::vector<amd::Memory*> mem_objs =
+        getMemoryObjectBatch(hip::getCurrentDevice(), dev_ptrs, count, offsets);
 
     // Validate and prepare each operation
     size_t current_loc = 0;
@@ -536,7 +539,7 @@ hipError_t ihipMemAdvise(const void* dev_ptr, size_t count, hipMemoryAdvise advi
   }
 
   size_t offset = 0;
-  amd::Memory* memObj = getMemoryObject(dev_ptr, offset);
+  amd::Memory* memObj = getMemoryObject(hip::getCurrentDevice(), dev_ptr, offset);
   if (memObj && count > (memObj->getSize() - offset)) {
     return hipErrorInvalidValue;
   }

--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -676,18 +676,30 @@ namespace hip {
   extern hipError_t ihipMalloc(void** ptr, size_t sizeBytes, unsigned int flags);
   extern hipError_t ihipHostMalloc(void** ptr, size_t sizeBytes, unsigned int flags);
   extern hipError_t ihipMemGetInfo(size_t* free, size_t* total);
-  extern amd::Memory* getMemoryObject(const void* ptr, size_t& offset, size_t size = 0);
-  extern std::vector<amd::Memory*> getMemoryObjectBatch(void* const* ptrs, size_t count,
+  extern amd::Memory* getMemoryObject(hip::Device* device, const void* ptr, size_t& offset,
+                                       size_t size = 0);
+  extern std::vector<amd::Memory*> getMemoryObjectBatch(hip::Device* device, void* const* ptrs,
+                                                         size_t count,
                                                          std::vector<size_t>& offsets);
-  extern void getMemoryObjectBatchPairs(void* const* srcs, void* const* dsts, size_t count,
+  extern void getMemoryObjectBatchPairs(hip::Device* device, void* const* srcs, void* const* dsts,
+                                         size_t count,
                                          std::vector<amd::Memory*>& src_memories,
                                          std::vector<amd::Memory*>& dst_memories,
                                          std::vector<size_t>& src_offsets,
                                          std::vector<size_t>& dst_offsets);
-  extern void getMemoryObjectPairs(const void* src, const void* dst,
+  extern void getMemoryObjectPairs(hip::Device* device, const void* src, const void* dst,
                                     amd::Memory*& src_memory, amd::Memory*& dst_memory,
                                     size_t& src_offset, size_t& dst_offset);
-  extern amd::Memory* getMemoryObjectWithOffset(const void* ptr, const size_t size = 0);
+  extern amd::Memory* getMemoryObjectWithOffset(hip::Device* device, const void* ptr,
+                                                 const size_t size = 0);
+
+  /// Convenience wrapper for use in Command::submit() bodies (graph and non-graph) where
+  /// hoisting hip::getCurrentDevice() across worker-thread state is unsafe. Re-fetches TLS
+  /// each call. Do NOT use from API entry points — use the explicit-device getMemoryObject.
+  inline amd::Memory* getMemoryObjectForCurrentDevice(const void* ptr, size_t& offset,
+                                                       size_t size = 0) {
+    return getMemoryObject(getCurrentDevice(), ptr, offset, size);
+  }
   extern void getStreamPerThread(hipStream_t& stream);
   extern hipStream_t getPerThreadDefaultStream();
   extern hipError_t ihipUnbindTexture(textureReference* texRef);
@@ -703,6 +715,36 @@ namespace hip {
                         hip::Stream& stream, bool isHostAsync = false, bool isGPUAsync = true);
   hipError_t ihipMemcpy3D(const hipMemcpy3DParms* p, hipStream_t stream = nullptr,
                           bool isAsync = false);
+
+  extern hipError_t ihipMemcpy_validate_memory(amd::Device& device, amd::Memory* memObj,
+                                                size_t sizeBytes, size_t offset, bool read_write);
+
+  inline hipError_t ihipMemcpy_validate(amd::Device& device, amd::Memory* dstMemory,
+                                         amd::Memory* srcMemory, size_t sizeBytes,
+                                         size_t dstOffset, size_t srcOffset) {
+    hipError_t status =
+        ihipMemcpy_validate_memory(device, srcMemory, sizeBytes, srcOffset, /*read_write*/ false);
+    if (status != hipSuccess) return status;
+    status =
+        ihipMemcpy_validate_memory(device, dstMemory, sizeBytes, dstOffset, /*read_write*/ true);
+    if (status != hipSuccess) return status;
+    return hipSuccess;
+  }
+
+  // Two-size variant used by the batch memcpy path: indirect copies place a
+  // sizeof(void*) pointer-holder on one side and the real data buffer on the other,
+  // so src and dst must be validated against independent region sizes.
+  inline hipError_t ihipMemcpy_validate(amd::Device& device, amd::Memory* dstMemory,
+                                         amd::Memory* srcMemory, size_t srcSizeBytes,
+                                         size_t dstSizeBytes, size_t dstOffset, size_t srcOffset) {
+    hipError_t status = ihipMemcpy_validate_memory(device, srcMemory, srcSizeBytes, srcOffset,
+                                                    /*read_write*/ false);
+    if (status != hipSuccess) return status;
+    status = ihipMemcpy_validate_memory(device, dstMemory, dstSizeBytes, dstOffset,
+                                         /*read_write*/ true);
+    if (status != hipSuccess) return status;
+    return hipSuccess;
+  }
 
   constexpr bool kMarkerDisableFlush = true;  //!< Avoids command batch flush in ROCclr
 

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -22,9 +22,9 @@ std::unordered_set<hipArray*> hipArraySet;
 
 namespace {
   // Helper function to apply arena memory fallback if memory object not found
-  inline void applyArenaFallback(const void* ptr, amd::Memory*& memory, size_t& offset, size_t size) {
+  inline void applyArenaFallback(hip::Device* device, const void* ptr, amd::Memory*& memory,
+                                  size_t& offset, size_t size) {
     if (memory == nullptr) {
-      hip::Device* device = hip::getCurrentDevice();
       if (device != nullptr) {
         memory = (device->asContext()->svmDevices()[0])->GetArenaMemObj(ptr, offset, size);
       }
@@ -32,11 +32,11 @@ namespace {
   }
 
   // Helper function to apply Windows-specific offset adjustment
-  inline void applyWindowsOffsetAdjustment(const void* ptr, amd::Memory*& memory, size_t& offset) {
+  inline void applyWindowsOffsetAdjustment(hip::Device* device, const void* ptr,
+                                            amd::Memory*& memory, size_t& offset) {
     if (!IS_WINDOWS || memory == nullptr) return;
     if (!(memory->getMemFlags() & CL_MEM_USE_HOST_PTR)) return;
 
-    hip::Device* device = hip::getCurrentDevice();
     amd::Device* currentDev = (device != nullptr) ? device->devices()[0] : nullptr;
     if (currentDev == nullptr) return;
 
@@ -51,20 +51,18 @@ namespace {
 }
 
 // ================================================================================================
-amd::Memory* getMemoryObject(const void* ptr, size_t& offset, size_t size) {
-  hip::Device* device = hip::getCurrentDevice();
+amd::Memory* getMemoryObject(hip::Device* device, const void* ptr, size_t& offset, size_t size) {
   amd::Device* currentDev = (device != nullptr) ? device->devices()[0] : nullptr;
   auto memObj = amd::MemObjMap::FindMemObj(ptr, &offset, currentDev);
 
-  applyArenaFallback(ptr, memObj, offset, size);
-  applyWindowsOffsetAdjustment(ptr, memObj, offset);
+  applyArenaFallback(device, ptr, memObj, offset, size);
+  applyWindowsOffsetAdjustment(device, ptr, memObj, offset);
 
   return memObj;
 }
 
-std::vector<amd::Memory*> getMemoryObjectBatch(void* const* ptrs, size_t count,
+std::vector<amd::Memory*> getMemoryObjectBatch(hip::Device* device, void* const* ptrs, size_t count,
                                                 std::vector<size_t>& offsets) {
-  hip::Device* device = hip::getCurrentDevice();
   amd::Device* currentDev = (device != nullptr) ? device->devices()[0] : nullptr;
 
   std::vector<amd::Memory*> memories;
@@ -73,19 +71,19 @@ std::vector<amd::Memory*> getMemoryObjectBatch(void* const* ptrs, size_t count,
 
   // Process each result for arena memory and Windows-specific offset adjustments
   for (size_t i = 0; i < count; ++i) {
-    applyArenaFallback(ptrs[i], memories[i], offsets[i], 0);
-    applyWindowsOffsetAdjustment(ptrs[i], memories[i], offsets[i]);
+    applyArenaFallback(device, ptrs[i], memories[i], offsets[i], 0);
+    applyWindowsOffsetAdjustment(device, ptrs[i], memories[i], offsets[i]);
   }
 
   return memories;
 }
 
-void getMemoryObjectBatchPairs(void* const* srcs, void* const* dsts, size_t count,
+void getMemoryObjectBatchPairs(hip::Device* device, void* const* srcs, void* const* dsts,
+                                size_t count,
                                 std::vector<amd::Memory*>& src_memories,
                                 std::vector<amd::Memory*>& dst_memories,
                                 std::vector<size_t>& src_offsets,
                                 std::vector<size_t>& dst_offsets) {
-  hip::Device* device = hip::getCurrentDevice();
   amd::Device* currentDev = (device != nullptr) ? device->devices()[0] : nullptr;
 
   amd::MemObjMap::FindMemObjBatchPairs(reinterpret_cast<const void* const*>(srcs),
@@ -95,28 +93,27 @@ void getMemoryObjectBatchPairs(void* const* srcs, void* const* dsts, size_t coun
 
   // Process each result for arena memory and Windows-specific offset adjustments
   for (size_t i = 0; i < count; ++i) {
-    applyArenaFallback(srcs[i], src_memories[i], src_offsets[i], 0);
-    applyWindowsOffsetAdjustment(srcs[i], src_memories[i], src_offsets[i]);
+    applyArenaFallback(device, srcs[i], src_memories[i], src_offsets[i], 0);
+    applyWindowsOffsetAdjustment(device, srcs[i], src_memories[i], src_offsets[i]);
 
-    applyArenaFallback(dsts[i], dst_memories[i], dst_offsets[i], 0);
-    applyWindowsOffsetAdjustment(dsts[i], dst_memories[i], dst_offsets[i]);
+    applyArenaFallback(device, dsts[i], dst_memories[i], dst_offsets[i], 0);
+    applyWindowsOffsetAdjustment(device, dsts[i], dst_memories[i], dst_offsets[i]);
   }
 }
 
-void getMemoryObjectPairs(const void* src, const void* dst,
+void getMemoryObjectPairs(hip::Device* device, const void* src, const void* dst,
                           amd::Memory*& src_memory, amd::Memory*& dst_memory,
                           size_t& src_offset, size_t& dst_offset) {
-  hip::Device* device = hip::getCurrentDevice();
   amd::Device* currentDev = (device != nullptr) ? device->devices()[0] : nullptr;
 
   amd::MemObjMap::FindMemObjPairs(src, dst, src_memory, dst_memory, src_offset, dst_offset,
                                    currentDev);
 
-  applyArenaFallback(src, src_memory, src_offset, 0);
-  applyWindowsOffsetAdjustment(src, src_memory, src_offset);
+  applyArenaFallback(device, src, src_memory, src_offset, 0);
+  applyWindowsOffsetAdjustment(device, src, src_memory, src_offset);
 
-  applyArenaFallback(dst, dst_memory, dst_offset, 0);
-  applyWindowsOffsetAdjustment(dst, dst_memory, dst_offset);
+  applyArenaFallback(device, dst, dst_memory, dst_offset, 0);
+  applyWindowsOffsetAdjustment(device, dst, dst_memory, dst_offset);
 }
 
 hipMemoryType getMemoryType(const amd::Memory* memory) {
@@ -130,9 +127,9 @@ hipMemoryType getMemoryType(const amd::Memory* memory) {
 }
 
 // ================================================================================================
-amd::Memory* getMemoryObjectWithOffset(const void* ptr, const size_t size) {
+amd::Memory* getMemoryObjectWithOffset(hip::Device* device, const void* ptr, const size_t size) {
   size_t offset = 0;
-  amd::Memory* memObj = getMemoryObject(ptr, offset);
+  amd::Memory* memObj = getMemoryObject(device, ptr, offset);
 
   if (memObj != nullptr) {
     if (size > (memObj->getSize() - offset)) {
@@ -155,7 +152,7 @@ hipError_t ihipFree(void* ptr) {
   }
 
   size_t offset = 0;
-  amd::Memory* memory_object = getMemoryObject(ptr, offset);
+  amd::Memory* memory_object = getMemoryObject(hip::getCurrentDevice(), ptr, offset);
   if (memory_object != nullptr) {
     auto device_id = memory_object->getUserData().deviceId;
 
@@ -423,9 +420,10 @@ hipError_t ihipMalloc(void** ptr, size_t sizeBytes, unsigned int flags) {
     return hipErrorOutOfMemory;
   }
   size_t offset = 0;  // this is ignored
-  amd::Memory* memObj = getMemoryObject(*ptr, offset);
+  hip::Device* dev = hip::getCurrentDevice();
+  amd::Memory* memObj = getMemoryObject(dev, *ptr, offset);
   // saves the current device id so that it can be accessed later
-  memObj->getUserData().deviceId = hip::getCurrentDevice()->deviceId();
+  memObj->getUserData().deviceId = dev->deviceId();
   return hipSuccess;
 }
 
@@ -481,7 +479,7 @@ hipError_t ihipHostMalloc(void** ptr, size_t sizeBytes, unsigned int flags) {
 
   if ((status == hipSuccess) && ((*ptr) != nullptr)) {
     size_t offset = 0;  // This is ignored
-    amd::Memory* svmMem = getMemoryObject(*ptr, offset);
+    amd::Memory* svmMem = getMemoryObject(hip::getCurrentDevice(), *ptr, offset);
     // Save the HIP memory flags so that they can be accessed later
     svmMem->getUserData().flags = flags;
   }
@@ -495,7 +493,7 @@ bool IsHtoHMemcpyValid(void* dst, const void* src, hipMemcpyKind kind) {
   size_t dOffset = 0;
   amd::Memory* srcMemory = nullptr;
   amd::Memory* dstMemory = nullptr;
-  getMemoryObjectPairs(src, dst, srcMemory, dstMemory, sOffset, dOffset);
+  getMemoryObjectPairs(hip::getCurrentDevice(), src, dst, srcMemory, dstMemory, sOffset, dOffset);
   if (src && dst && srcMemory == nullptr && dstMemory == nullptr) {
     if (!g_devices[0]->devices()[0]->info().hmmCpuMemoryAccessible_ &&
         kind != hipMemcpyHostToHost && kind != hipMemcpyDefault) {
@@ -506,10 +504,10 @@ bool IsHtoHMemcpyValid(void* dst, const void* src, hipMemcpyKind kind) {
 }
 
 // ================================================================================================
-hipError_t ihipMemcpy_validate_memory(amd::Memory* memObj, size_t sizeBytes, size_t offset,
-                                      bool read_write) {
+hipError_t ihipMemcpy_validate_memory(amd::Device& device, amd::Memory* memObj, size_t sizeBytes,
+                                      size_t offset, bool read_write) {
   // Validate Mem Access in case of VMM Memory
-  if (!memObj->ValidateMemAccess(*hip::getCurrentDevice()->devices()[0], read_write)) {
+  if (!memObj->ValidateMemAccess(device, read_write)) {
     return hipErrorUnknown;
   }
 
@@ -524,24 +522,6 @@ hipError_t ihipMemcpy_validate_memory(amd::Memory* memObj, size_t sizeBytes, siz
     return hipErrorInvalidValue;
   }
   return hipSuccess;
-}
-
-hipError_t ihipMemcpy_validate(amd::Memory* dstMemory, amd::Memory* srcMemory, size_t srcSizeBytes,
-                               size_t dstSizeBytes, size_t dstOffset, size_t srcOffset) {
-  hipError_t status;
-
-  status = ihipMemcpy_validate_memory(srcMemory, srcSizeBytes, srcOffset, /*read_write*/ false);
-  if (status != hipSuccess) return status;
-  status = ihipMemcpy_validate_memory(dstMemory, dstSizeBytes, dstOffset, /*read_write*/ true);
-  if (status != hipSuccess) return status;
-
-  return hipSuccess;
-}
-
-// ================================================================================================
-hipError_t ihipMemcpy_validate(amd::Memory* dstMemory, amd::Memory* srcMemory, size_t sizeBytes,
-                               size_t dstOffset, size_t srcOffset) {
-  return ihipMemcpy_validate(dstMemory, srcMemory, sizeBytes, sizeBytes, dstOffset, srcOffset);
 }
 
 // ================================================================================================
@@ -704,7 +684,7 @@ bool IsHtoHMemcpy(void* dst, const void* src) {
   size_t dOffset = 0;
   amd::Memory* srcMemory = nullptr;
   amd::Memory* dstMemory = nullptr;
-  getMemoryObjectPairs(src, dst, srcMemory, dstMemory, sOffset, dOffset);
+  getMemoryObjectPairs(hip::getCurrentDevice(), src, dst, srcMemory, dstMemory, sOffset, dOffset);
   if (srcMemory == nullptr && dstMemory == nullptr) {
     return true;
   }
@@ -734,11 +714,18 @@ hipError_t ihipMemcpy(void* dst, const void* src, size_t sizeBytes, hipMemcpyKin
     return hipSuccess;
   }
 
+  // Hoisted device fetch — feeds the lookup and per-branch validation below.
+  hip::Device* dev = hip::getCurrentDevice();
+  if (dev == nullptr) {
+    return hipErrorInvalidDevice;
+  }
+  amd::Device& amdDev = *dev->devices()[0];
+
   size_t sOffset = 0;
   size_t dOffset = 0;
   amd::Memory* srcDeviceMemory = nullptr;
   amd::Memory* dstDeviceMemory = nullptr;
-  getMemoryObjectPairs(src, dst, srcDeviceMemory, dstDeviceMemory, sOffset, dOffset);
+  getMemoryObjectPairs(dev, src, dst, srcDeviceMemory, dstDeviceMemory, sOffset, dOffset);
 
   // Handle kind vs memobject miss matches
   if (kind == hipMemcpyDeviceToHost && srcDeviceMemory == nullptr) {
@@ -760,10 +747,10 @@ hipError_t ihipMemcpy(void* dst, const void* src, size_t sizeBytes, hipMemcpyKin
     // wait at top level except for MT path
     isHostAsync &= AMD_DIRECT_DISPATCH ? true : false;
     if (dstDeviceMemory != nullptr) {
-      IHIP_RETURN_ONFAIL(ihipMemcpy_validate_memory(dstDeviceMemory, sizeBytes, dOffset, /*read_write*/ true));
+      IHIP_RETURN_ONFAIL(ihipMemcpy_validate_memory(amdDev, dstDeviceMemory, sizeBytes, dOffset, /*read_write*/ true));
       IHIP_RETURN_ONFAIL(ihipMemcpyCommand(command, dstDeviceMemory, src, sizeBytes, kind, stream, dOffset, isHostAsync));
     } else {
-      IHIP_RETURN_ONFAIL(ihipMemcpy_validate_memory(srcDeviceMemory, sizeBytes, sOffset, /*read_write*/ false));
+      IHIP_RETURN_ONFAIL(ihipMemcpy_validate_memory(amdDev, srcDeviceMemory, sizeBytes, sOffset, /*read_write*/ false));
       IHIP_RETURN_ONFAIL(ihipMemcpyCommand(command, dst, srcDeviceMemory, sizeBytes, kind, stream, sOffset, isHostAsync));
     }
   } else {
@@ -771,7 +758,7 @@ hipError_t ihipMemcpy(void* dst, const void* src, size_t sizeBytes, hipMemcpyKin
     hipMemoryType srcMemoryType = getMemoryType(srcDeviceMemory);
     hipMemoryType dstMemoryType = getMemoryType(dstDeviceMemory);
 
-    IHIP_RETURN_ONFAIL(ihipMemcpy_validate(dstDeviceMemory, srcDeviceMemory, sizeBytes, dOffset, sOffset));
+    IHIP_RETURN_ONFAIL(ihipMemcpy_validate(amdDev, dstDeviceMemory, srcDeviceMemory, sizeBytes, dOffset, sOffset));
 
     if (srcDeviceMemory->GetDeviceById() == dstDeviceMemory->GetDeviceById()) {
       // Device to Device copies do not need to host side synchronization.
@@ -845,7 +832,7 @@ hipError_t hipExtMallocWithFlags(void** ptr, size_t sizeBytes, unsigned int flag
 
   if ((status == hipSuccess) && ((*ptr) != nullptr)) {
     size_t offset = 0;  // This is ignored
-    amd::Memory* svmMem = getMemoryObject(*ptr, offset);
+    amd::Memory* svmMem = getMemoryObject(hip::getCurrentDevice(), *ptr, offset);
     // Save the HIP memory flags so that they can be accessed later
     svmMem->getUserData().flags = flags;
   }
@@ -932,7 +919,7 @@ hipError_t hipMemPtrGetInfo(void* ptr, size_t* size) {
   }
 
   size_t offset = 0;
-  amd::Memory* svmMem = getMemoryObject(ptr, offset);
+  amd::Memory* svmMem = getMemoryObject(hip::getCurrentDevice(), ptr, offset);
 
   if (svmMem == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
@@ -947,7 +934,7 @@ hipError_t hipHostFree(void* ptr) {
   HIP_INIT_API(hipHostFree, ptr);
   CHECK_STREAM_CAPTURE_SUPPORTED();
   size_t offset = 0;
-  amd::Memory* memory_object = getMemoryObject(ptr, offset);
+  amd::Memory* memory_object = getMemoryObject(hip::getCurrentDevice(), ptr, offset);
   if (memory_object != nullptr) {
     if (memory_object->getSvmPtr() == nullptr) {
       HIP_RETURN(hipErrorInvalidValue);
@@ -994,7 +981,7 @@ hipError_t hipMemGetAddressRange(hipDeviceptr_t* pbase, size_t* psize, hipDevice
   // Since we are using SVM buffer DevicePtr and HostPtr is the same
   void* ptr = dptr;
   size_t offset = 0;
-  amd::Memory* svmMem = getMemoryObject(ptr, offset);
+  amd::Memory* svmMem = getMemoryObject(hip::getCurrentDevice(), ptr, offset);
   if (svmMem == nullptr) {
     HIP_RETURN(hipErrorNotFound);
   }
@@ -1073,7 +1060,7 @@ hipError_t ihipMallocPitch(void** ptr, size_t* pitch, size_t width, size_t heigh
     return hipErrorOutOfMemory;
   }
   size_t offset = 0;  // this is ignored
-  amd::Memory* memObj = getMemoryObject(*ptr, offset);
+  amd::Memory* memObj = getMemoryObject(hip::getCurrentDevice(), *ptr, offset);
   memObj->getUserData().pitch_ = *pitch;
   memObj->getUserData().width_ = width;
   memObj->getUserData().height_ = height;
@@ -1366,7 +1353,7 @@ hipError_t hipHostGetFlags(unsigned int* flagsPtr, void* hostPtr) {
   }
 
   size_t offset = 0;
-  amd::Memory* svmMem = getMemoryObject(hostPtr, offset);
+  amd::Memory* svmMem = getMemoryObject(hip::getCurrentDevice(), hostPtr, offset);
 
   if (svmMem == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
@@ -1455,7 +1442,7 @@ hipError_t ihipHostUnregister(void* hostPtr) {
     return hipErrorInvalidValue;
   }
   size_t offset = 0;
-  amd::Memory* mem = getMemoryObject(hostPtr, offset);
+  amd::Memory* mem = getMemoryObject(hip::getCurrentDevice(), hostPtr, offset);
 
   if (mem != nullptr) {
     // Wait on the device, associated with the current memory object during allocation
@@ -1783,7 +1770,7 @@ hipError_t ihipMemcpyAtoDCommand(amd::Command*& command, void* dstDevice, amd::C
                                  amd::Coord3D copyRegion, amd::BufferRect srcRect,
                                  amd::BufferRect dstRect, hip::Stream* stream) {
   size_t dOffset = 0;
-  amd::Memory* dstMemory = getMemoryObject(dstDevice, dOffset);
+  amd::Memory* dstMemory = getMemoryObject(hip::getCurrentDevice(), dstDevice, dOffset);
 
   amd::CopyMemoryCommand* cpyMemCmd = new amd::CopyMemoryCommand(
       *stream, CL_COMMAND_COPY_IMAGE_TO_BUFFER, amd::Command::EventWaitList{}, *srcImage,
@@ -1802,7 +1789,7 @@ hipError_t ihipMemcpyDtoACommand(amd::Command*& command, amd::Image* dstImage,
                                  amd::Coord3D copyRegion, amd::BufferRect srcRect,
                                  amd::BufferRect dstRect, hip::Stream* stream) {
   size_t sOffset = 0;
-  amd::Memory* srcMemory = getMemoryObject(srcDevice, sOffset);
+  amd::Memory* srcMemory = getMemoryObject(hip::getCurrentDevice(), srcDevice, sOffset);
 
   amd::CopyMemoryCommand* cpyMemCmd = new amd::CopyMemoryCommand(
       *stream, CL_COMMAND_COPY_BUFFER_TO_IMAGE, amd::Command::EventWaitList{}, *srcMemory,
@@ -1823,7 +1810,7 @@ hipError_t ihipMemcpyDtoDCommand(amd::Command*& command, void* dstDevice, void* 
   size_t dstOffset = 0;
   amd::Memory* srcMemory = nullptr;
   amd::Memory* dstMemory = nullptr;
-  getMemoryObjectPairs(srcDevice, dstDevice, srcMemory, dstMemory, srcOffset, dstOffset);
+  getMemoryObjectPairs(hip::getCurrentDevice(), srcDevice, dstDevice, srcMemory, dstMemory, srcOffset, dstOffset);
 
   amd::Command::EventWaitList waitList;
   amd::CopyMemoryCommand* copyCommand;
@@ -1900,7 +1887,7 @@ hipError_t ihipMemcpyDtoHCommand(amd::Command*& command, void* dstHost, amd::Coo
   size_t dOffset = 0;
   amd::Memory* srcMemory = nullptr;
   amd::Memory* dstMemory = nullptr;
-  getMemoryObjectPairs(srcDevice, dstHost, srcMemory, dstMemory, sOffset, dOffset);
+  getMemoryObjectPairs(hip::getCurrentDevice(), srcDevice, dstHost, srcMemory, dstMemory, sOffset, dOffset);
 
   amd::Coord3D srcStart(srcRect.start_, 0, 0);
   amd::CopyMetadata copyMetadata(isAsync, amd::CopyMetadata::CopyEnginePreference::NONE);
@@ -1949,7 +1936,7 @@ hipError_t ihipMemcpyHtoDCommand(amd::Command*& command, void* dstDevice, amd::C
   size_t dOffset = 0;
   amd::Memory* srcMemory = nullptr;
   amd::Memory* dstMemory = nullptr;
-  getMemoryObjectPairs(srcHost, dstDevice, srcMemory, dstMemory, sOffset, dOffset);
+  getMemoryObjectPairs(hip::getCurrentDevice(), srcHost, dstDevice, srcMemory, dstMemory, sOffset, dOffset);
 
   amd::Coord3D dstStart(dstRect.start_, 0, 0);
   amd::CopyMetadata copyMetadata(isAsync, amd::CopyMetadata::CopyEnginePreference::NONE);
@@ -2028,7 +2015,7 @@ hipError_t ihipMemcpyHtoACommand(amd::Command*& command, amd::Image* dstImage,
                                  size_t srcRowPitch, size_t srcSlicePitch, hip::Stream* stream,
                                  bool isAsync = false) {
   size_t sOffset = 0;
-  amd::Memory* srcMemory = getMemoryObject(srcHost, sOffset);
+  amd::Memory* srcMemory = getMemoryObject(hip::getCurrentDevice(), srcHost, sOffset);
   size_t start = ihipGetbufferStart(static_cast<size_t*>(srcOrigin),
                                     static_cast<size_t*>(copyRegion), srcRowPitch, srcSlicePitch);
 
@@ -2072,7 +2059,7 @@ hipError_t ihipMemcpyAtoHCommand(amd::Command*& command, void* dstHost, amd::Coo
                                  amd::Coord3D copyRegion, size_t dstRowPitch, size_t dstSlicePitch,
                                  hip::Stream* stream, bool isAsync = false) {
   size_t dOffset = 0;
-  amd::Memory* dstMemory = getMemoryObject(dstHost, dOffset);
+  amd::Memory* dstMemory = getMemoryObject(hip::getCurrentDevice(), dstHost, dOffset);
   size_t start = ihipGetbufferStart(static_cast<size_t*>(dstOrigin),
                                     static_cast<size_t*>(copyRegion), dstRowPitch, dstSlicePitch);
 
@@ -2119,7 +2106,7 @@ void ihipCopyMemParamSet(const HIP_MEMCPY3D* pCopy, hipMemoryType& srcMemType,
   // base address of the source data and the bytes per row to apply. {src/dst}Array is ignored.
   hipMemoryType srcMemoryType = pCopy->srcMemoryType;
   if (srcMemoryType == hipMemoryTypeUnified) {
-    amd::Memory* memObj = getMemoryObject(pCopy->srcDevice, offset);
+    amd::Memory* memObj = getMemoryObject(hip::getCurrentDevice(), pCopy->srcDevice, offset);
     srcMemoryType = getMemoryType(memObj);
     if (memObj == nullptr) {
       const_cast<HIP_MEMCPY3D*>(pCopy)->srcXInBytes += offset;
@@ -2136,7 +2123,7 @@ void ihipCopyMemParamSet(const HIP_MEMCPY3D* pCopy, hipMemoryType& srcMemType,
   offset = 0;
   hipMemoryType dstMemoryType = pCopy->dstMemoryType;
   if (dstMemoryType == hipMemoryTypeUnified) {
-    amd::Memory* memObj = getMemoryObject(pCopy->dstDevice, offset);
+    amd::Memory* memObj = getMemoryObject(hip::getCurrentDevice(), pCopy->dstDevice, offset);
     dstMemoryType = getMemoryType(memObj);
     if (memObj == nullptr) {
       const_cast<HIP_MEMCPY3D*>(pCopy)->dstXInBytes += offset;
@@ -2153,7 +2140,7 @@ void ihipCopyMemParamSet(const HIP_MEMCPY3D* pCopy, hipMemoryType& srcMemType,
   // In that case upgrade the copy type to hipMemoryTypeDevice to avoid extra pinning.
   if (srcMemoryType == hipMemoryTypeHost) {
     srcMemoryType =
-        getMemoryObject(pCopy->srcHost, offset) ? hipMemoryTypeDevice : hipMemoryTypeHost;
+        getMemoryObject(hip::getCurrentDevice(), pCopy->srcHost, offset) ? hipMemoryTypeDevice : hipMemoryTypeHost;
 
     if (srcMemoryType == hipMemoryTypeDevice) {
       const_cast<HIP_MEMCPY3D*>(pCopy)->srcDevice = const_cast<void*>(pCopy->srcHost);
@@ -2162,7 +2149,7 @@ void ihipCopyMemParamSet(const HIP_MEMCPY3D* pCopy, hipMemoryType& srcMemType,
   offset = 0;
   if (dstMemoryType == hipMemoryTypeHost) {
     dstMemoryType =
-        getMemoryObject(pCopy->dstHost, offset) ? hipMemoryTypeDevice : hipMemoryTypeHost;
+        getMemoryObject(hip::getCurrentDevice(), pCopy->dstHost, offset) ? hipMemoryTypeDevice : hipMemoryTypeHost;
 
     if (dstMemoryType == hipMemoryTypeDevice) {
       const_cast<HIP_MEMCPY3D*>(pCopy)->dstDevice = const_cast<void*>(pCopy->dstHost);
@@ -2210,7 +2197,7 @@ hipError_t validateMemoryObject(const void* ptr, bool isDeviceMemory, amd::Coord
 
   size_t offset = 0;
   amd::Memory* memory = nullptr;
-  memory = getMemoryObject(ptr, offset);
+  memory = getMemoryObject(hip::getCurrentDevice(), ptr, offset);
   if (memory == nullptr && isDeviceMemory) {
     return hipErrorInvalidValue;
   }
@@ -2769,8 +2756,8 @@ hipError_t ihipMemcpy3D_validate(const hipMemcpy3DParms* p) {
     auto totalExtentBytes = p->extent.width * p->extent.height * p->extent.depth;
     // get memory obj of the PitchPtr
     size_t offset = 0;
-    amd::Memory* srcPtrMemObj = getMemoryObject(p->srcPtr.ptr, offset);
-    amd::Memory* dstPtrMemObj = getMemoryObject(p->dstPtr.ptr, offset);
+    amd::Memory* srcPtrMemObj = getMemoryObject(hip::getCurrentDevice(), p->srcPtr.ptr, offset);
+    amd::Memory* dstPtrMemObj = getMemoryObject(hip::getCurrentDevice(), p->dstPtr.ptr, offset);
 
     if (dstPtrMemObj != nullptr && (p->dstPtr.xsize != 0 && p->dstPtr.ysize != 0)) {
       // Use the memoryObj to get 3d data
@@ -2959,8 +2946,17 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
     }
   }
 
+  // Hoisted device fetch: avoid repeated TLS lookups inside the batched lookup and per-iteration
+  // validation below. Do NOT insert hip::setCurrentDevice() between this point and the loop end.
+  hip::Device* dev = hip::getCurrentDevice();
+  if (dev == nullptr) {
+    return hipErrorInvalidDevice;
+  }
+  amd::Device& amdDev = *dev->devices()[0];
+
   // Batched memory object lookup for src/dst pairs with single lock acquisition
-  getMemoryObjectBatchPairs(srcs, dsts, count, srcMemories, dstMemories, srcOffsets, dstOffsets);
+  getMemoryObjectBatchPairs(dev, srcs, dsts, count, srcMemories, dstMemories, srcOffsets,
+                            dstOffsets);
 
   size_t validateAttrIdx = 0;
   for (size_t i = 0; i < count; ++i) {
@@ -2982,13 +2978,13 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
 
     hipError_t status;
     if (srcMemories[i] != nullptr && dstMemories[i] != nullptr) {
-      status = ihipMemcpy_validate(dstMemories[i], srcMemories[i], actualSrcSize, actualDstSize,
-                                   dstOffsets[i], srcOffsets[i]);
+      status = ihipMemcpy_validate(amdDev, dstMemories[i], srcMemories[i], actualSrcSize,
+                                   actualDstSize, dstOffsets[i], srcOffsets[i]);
     } else if (srcMemories[i] != nullptr) {
-      status = ihipMemcpy_validate_memory(srcMemories[i], actualSrcSize, srcOffsets[i],
+      status = ihipMemcpy_validate_memory(amdDev, srcMemories[i], actualSrcSize, srcOffsets[i],
                                           /*read_write*/ false);
     } else {
-      status = ihipMemcpy_validate_memory(dstMemories[i], actualDstSize, dstOffsets[i],
+      status = ihipMemcpy_validate_memory(amdDev, dstMemories[i], actualDstSize, dstOffsets[i],
                                           /*read_write*/ true);
     }
     if (status != hipSuccess) {
@@ -3276,7 +3272,7 @@ hipError_t ihipGraphMemsetParams_validate(const hipMemsetParams* pNodeParams) {
   }
 
   size_t discardOffset = 0;
-  amd::Memory* memObj = getMemoryObject(pNodeParams->dst, discardOffset);
+  amd::Memory* memObj = getMemoryObject(hip::getCurrentDevice(), pNodeParams->dst, discardOffset);
   if (memObj != nullptr) {
     // Validate Mem Access in case of VMM Memory
     if (!memObj->ValidateMemAccess(*hip::getCurrentDevice()->devices()[0], true)) {
@@ -3331,7 +3327,7 @@ hipError_t ihipMemset(void* dst, int64_t value, size_t valueSize, size_t sizeByt
   }
 
   size_t offset = 0;
-  amd::Memory* memObj = getMemoryObject(dst, offset);
+  amd::Memory* memObj = getMemoryObject(hip::getCurrentDevice(), dst, offset);
   if (memObj == nullptr) {
     return hipErrorInvalidValue;
   }
@@ -3507,7 +3503,7 @@ hipError_t ihipMemset3D(hipPitchedPtr pitchedDevPtr, int value, hipExtent extent
     return hipSuccess;
   }
   size_t offset = 0;
-  amd::Memory* memory = getMemoryObject(pitchedDevPtr.ptr, offset, sizeBytes);
+  amd::Memory* memory = getMemoryObject(hip::getCurrentDevice(), pitchedDevPtr.ptr, offset, sizeBytes);
   if (memory == nullptr) {
     return hipErrorInvalidValue;
   }
@@ -3744,7 +3740,7 @@ hipError_t hipIpcOpenMemHandle(void** dev_ptr, hipIpcMemHandle_t handle, unsigne
           ihandle->psize, ihandle->poffset, flags);
       HIP_RETURN(hipErrorInvalidDevicePointer);
     }
-    amd_mem_obj = getMemoryObject(*dev_ptr, offset);
+    amd_mem_obj = getMemoryObject(hip::getCurrentDevice(), *dev_ptr, offset);
     amd::MemObjMap::AddIpcHandleMemObj(*ihandle, amd_mem_obj);
   } else {
     // Handle was already opened by the same process
@@ -3806,7 +3802,7 @@ hipError_t hipHostGetDevicePointer(void** devicePointer, void* hostPointer, unsi
 
   size_t offset = 0;
 
-  amd::Memory* memObj = getMemoryObject(hostPointer, offset);
+  amd::Memory* memObj = getMemoryObject(hip::getCurrentDevice(), hostPointer, offset);
   if (!memObj) {
     HIP_RETURN(hipErrorInvalidValue);
   }
@@ -3824,7 +3820,7 @@ hipError_t hipPointerGetAttributes(hipPointerAttribute_t* attributes, const void
     HIP_RETURN(hipErrorInvalidValue);
   }
   size_t offset = 0;
-  amd::Memory* memObj = (ptr != nullptr) ? getMemoryObject(ptr, offset) : nullptr;
+  amd::Memory* memObj = (ptr != nullptr) ? getMemoryObject(hip::getCurrentDevice(), ptr, offset) : nullptr;
   int device = 0;
   device::Memory* devMem = nullptr;
   memset(attributes, 0, sizeof(hipPointerAttribute_t));
@@ -3899,7 +3895,7 @@ hipError_t ihipPointerSetAttribute(const void* value, hipPointer_attribute attri
   }
 
   size_t offset = 0;
-  amd::Memory* memObj = getMemoryObject(ptr, offset);
+  amd::Memory* memObj = getMemoryObject(hip::getCurrentDevice(), ptr, offset);
   if (memObj == nullptr) {
     return hipErrorInvalidDevicePointer;
   }
@@ -3913,7 +3909,7 @@ hipError_t ihipPointerSetAttribute(const void* value, hipPointer_attribute attri
 hipError_t ihipPointerGetAttributes(void* data, hipPointer_attribute attribute,
                                     hipDeviceptr_t ptr) {
   size_t offset = 0;
-  amd::Memory* memObj = getMemoryObject(ptr, offset);
+  amd::Memory* memObj = getMemoryObject(hip::getCurrentDevice(), ptr, offset);
   amd::Memory* vaddr_mem_obj = amd::MemObjMap::FindVirtualMemObj(ptr);
   constexpr uint32_t kHipMallocManagedFlags =
       CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_ALLOC_HOST_PTR;
@@ -4519,7 +4515,7 @@ hipError_t hipFreeHost(void* ptr) {
   HIP_INIT_API(hipFreeHost, ptr);
   CHECK_STREAM_CAPTURE_SUPPORTED();
   size_t offset = 0;
-  amd::Memory* memory_object = getMemoryObject(ptr, offset);
+  amd::Memory* memory_object = getMemoryObject(hip::getCurrentDevice(), ptr, offset);
   if (memory_object != nullptr) {
     if (memory_object->getSvmPtr() == nullptr) {
       HIP_RETURN(hipErrorInvalidValue);

--- a/projects/clr/hipamd/src/hip_mempool.cpp
+++ b/projects/clr/hipamd/src/hip_mempool.cpp
@@ -116,7 +116,9 @@ class FreeAsyncCommand : public amd::Command {
 
   virtual void submit(device::VirtualDevice& device) final {
     size_t offset = 0;
-    auto memory = getMemoryObject(ptr_, offset);
+    // Worker-thread submit body: do NOT hoist hip::getCurrentDevice(); use the convenience
+    // wrapper that re-fetches TLS each call.
+    auto memory = getMemoryObjectForCurrentDevice(ptr_, offset);
     if (memory != nullptr) {
       auto id = memory->getUserData().deviceId;
       if (!g_devices[id]->FreeMemory(memory, static_cast<hip::Stream*>(queue()), event_)) {
@@ -167,7 +169,7 @@ hipError_t hipFreeAsync(void* dev_ptr, hipStream_t stream) {
 
   if (!graph_in_use) {
     size_t offset = 0;
-    auto memory = getMemoryObject(dev_ptr, offset);
+    auto memory = getMemoryObject(hip::getCurrentDevice(), dev_ptr, offset);
     if (memory != nullptr) {
       auto id = memory->getUserData().deviceId;
       if (!g_devices[id]->FreeMemory(memory, hip_stream, event)) {
@@ -435,7 +437,7 @@ hipError_t hipMemPoolExportPointer(hipMemPoolPtrExportData* export_data, void* p
   }
 
   size_t offset = 0;
-  auto memory = getMemoryObject(ptr, offset);
+  auto memory = getMemoryObject(hip::getCurrentDevice(), ptr, offset);
   if (memory != nullptr) {
     auto id = memory->getUserData().deviceId;
     // Note: export_data must point to 64 bytes of shared memory
@@ -465,7 +467,7 @@ hipError_t hipMemPoolImportPointer(void** ptr, hipMemPool_t mem_pool,
     HIP_RETURN(hipErrorOutOfMemory);
   }
   size_t offset = 0;
-  auto memory = getMemoryObject(*ptr, offset);
+  auto memory = getMemoryObject(hip::getCurrentDevice(), *ptr, offset);
   mpool->AddBusyMemory(memory);
   mpool->retain();
   HIP_RETURN(hipSuccess);

--- a/projects/clr/hipamd/src/hip_mempool_impl.cpp
+++ b/projects/clr/hipamd/src/hip_mempool_impl.cpp
@@ -211,7 +211,7 @@ void* MemoryPool::AllocateMemory(size_t size, Stream* stream, void* dptr) {
     }
 
     size_t offset = 0;
-    memory = getMemoryObject(dev_ptr, offset);
+    memory = getMemoryObject(device_, dev_ptr, offset);
     // Saves the current device id so that it can be accessed later
     memory->getUserData().deviceId = device_->deviceId();
 

--- a/projects/clr/hipamd/src/hip_stream_ops.cpp
+++ b/projects/clr/hipamd/src/hip_stream_ops.cpp
@@ -53,7 +53,7 @@ hipError_t ihipStreamOperation(hipStream_t stream, cl_command_type cmdType, void
     return hipErrorContextIsDestroyed;
   }
 
-  amd::Memory* memory = getMemoryObject(ptr, offset);
+  amd::Memory* memory = getMemoryObject(hip::getCurrentDevice(), ptr, offset);
   if (!memory) {
     return hipErrorInvalidValue;
   }

--- a/projects/clr/hipamd/src/hip_texture.cpp
+++ b/projects/clr/hipamd/src/hip_texture.cpp
@@ -303,8 +303,9 @@ hipError_t ihipCreateTextureObject(hipTextureObject_t* pTexObject, const hipReso
       const amd::Image::Format imageFormat({channelOrder, channelType});
       const cl_mem_object_type imageType = hip::getCLMemObjectType(pResDesc->resType);
       const size_t imageSizeInBytes = pResDesc->res.linear.sizeInBytes;
-      amd::Memory* buffer =
-          getMemoryObjectWithOffset(pResDesc->res.linear.devPtr, imageSizeInBytes);
+      amd::Memory* buffer = getMemoryObjectWithOffset(hip::getCurrentDevice(),
+                                                       pResDesc->res.linear.devPtr,
+                                                       imageSizeInBytes);
       hipError_t status = hipSuccess;
       image = ihipImageCreate(channelOrder, channelType, imageType,
                               imageSizeInBytes / imageFormat.getElementSize(), /* imageWidth */
@@ -340,8 +341,9 @@ hipError_t ihipCreateTextureObject(hipTextureObject_t* pTexObject, const hipReso
       if (!ValidateDevicePointer(pResDesc->res.pitch2D.devPtr)) {
         return hipErrorInvalidValue;
       }
-      amd::Memory* buffer =
-          getMemoryObjectWithOffset(pResDesc->res.pitch2D.devPtr, imageSizeInBytes);
+      amd::Memory* buffer = getMemoryObjectWithOffset(hip::getCurrentDevice(),
+                                                       pResDesc->res.pitch2D.devPtr,
+                                                       imageSizeInBytes);
 
       hipError_t status = hipSuccess;
       image = ihipImageCreate(channelOrder, channelType, imageType,

--- a/projects/clr/hipamd/src/hip_vm.cpp
+++ b/projects/clr/hipamd/src/hip_vm.cpp
@@ -95,7 +95,8 @@ hipError_t hipMemCreate(hipMemGenericAllocationHandle_t* handle, size_t size,
   }
 
   bool useHostDevice = (prop->location.type == hipMemLocationTypeHost);
-  amd::Context* curDevContext = hip::getCurrentDevice()->asContext();
+  hip::Device* dev = hip::getCurrentDevice();
+  amd::Context* curDevContext = dev->asContext();
   amd::Context* amdContext = useHostDevice ? hip::host_context : curDevContext;
 
   if (amdContext == nullptr) {
@@ -129,7 +130,7 @@ hipError_t hipMemCreate(hipMemGenericAllocationHandle_t* handle, size_t size,
 
   // Add this to amd::Memory object, so this ptr is accesible for other hipmemory operations.
   size_t offset = 0;  // this is ignored
-  amd::Memory* phys_mem_obj = getMemoryObject(ptr, offset);
+  amd::Memory* phys_mem_obj = getMemoryObject(dev, ptr, offset);
   // saves the current device id so that it can be accessed later
   phys_mem_obj->getUserData().deviceId = prop->location.id;
   phys_mem_obj->getUserData().locationType = prop->location.type;


### PR DESCRIPTION
## Motivation

This PR factors out thread local storage calls to getCurrentDevice, to reduce the amount this is called and improve submission latency.

## Technical Details

getMemoryObject  and ihipMemcpy_validate both internally call getCurrentDevice (which uses thread local storage). This can be expensive in cases such as hipMemcpyBatch where they are called in a loop. However in general we to call it the fewest times possible. I have refactored accessing and validating memory objects so that getCurrentDevice is called once for our hot-paths.

## JIRA ID

ROCM-21854

## Test Plan

Existing testing is suitable

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
