### PR TITLE
rocr/aie: Robustness fixes

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -1168,30 +1168,30 @@ hsa_status_t XdnaDriver::IsModelEnabled(bool* enable) const {
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::DestroyBOHandle(BOHandle& handle) {
-  if (!handle.IsValid()) {
+hsa_status_t XdnaDriver::DestroyBOHandle(BOHandle& bo_handle) {
+  if (!bo_handle.IsValid()) {
     return HSA_STATUS_SUCCESS;
   }
 
   hsa_status_t unmap_err = HSA_STATUS_SUCCESS;
 
   // Unmap the memory.
-  if (handle.unmap_vaddr) {
-    if (munmap(handle.vaddr, handle.size) != 0) {
+  if (bo_handle.unmap_vaddr) {
+    if (munmap(bo_handle.vaddr, bo_handle.size) != 0) {
       unmap_err = HSA_STATUS_ERROR;
       assert(false && "Failed to unmap BO memory.");
     } else {
-      handle.unmap_vaddr = false;
-      handle.vaddr = nullptr;
-      handle.size = 0;
+      bo_handle.unmap_vaddr = false;
+      bo_handle.vaddr = nullptr;
+      bo_handle.size = 0;
     }
   }
 
   // Close the BO handle.
   drm_gem_close close_bo_args = {};
-  close_bo_args.handle = handle.handle;
+  close_bo_args.handle = bo_handle.handle;
   hsa_status_t ioctl_err = xdna_ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
-  handle.handle = AMDXDNA_INVALID_BO_HANDLE;
+  bo_handle.handle = AMDXDNA_INVALID_BO_HANDLE;
 
   if (ioctl_err != HSA_STATUS_SUCCESS) {
     return ioctl_err;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -42,6 +42,7 @@
 
 #include "core/inc/amd_xdna_driver.h"
 
+#include <cerrno>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
@@ -210,6 +211,20 @@ constexpr uint32_t CMD_COUNT_SIZE_INCREASE = 3;
 /// @brief Default amdxdna_cu_config::cu_func when configuring a CU.
 constexpr uint32_t default_cu_func = 0;
 
+/// @brief Calls ioctl with the given request and argument, and retries if the call is interrupted
+/// by a signal or if it returns EAGAIN.
+///
+/// @param[in] fd file descriptor
+/// @param[in] request ioctl request code
+/// @param[in] arg pointer to the argument for the ioctl call
+static int xdna_ioctl(int fd, unsigned long request, void* arg) {
+  int ret;
+  do {
+    ret = ioctl(fd, request, arg);
+  } while (ret < 0 && (errno == EINTR || errno == EAGAIN));
+  return ret;
+}
+
 /**
  * @brief Flushes the CPU cache for the packet's arguments.
  *
@@ -237,7 +252,7 @@ static hsa_status_t DestroyHwCtx(int fd, uint32_t hw_ctx_handle) {
 
   amdxdna_drm_destroy_hwctx args = {};
   args.handle = hw_ctx_handle;
-  if (ioctl(fd, DRM_IOCTL_AMDXDNA_DESTROY_HWCTX, &args) < 0) {
+  if (xdna_ioctl(fd, DRM_IOCTL_AMDXDNA_DESTROY_HWCTX, &args) < 0) {
     return HSA_STATUS_ERROR;
   }
   return HSA_STATUS_SUCCESS;
@@ -264,7 +279,7 @@ static hsa_status_t SubmitCommand(int fd, uint32_t cmd_bo_handle,
   exec_cmd.args = reinterpret_cast<uint64_t>(bo_handles.data());
   exec_cmd.cmd_count = 1;
   exec_cmd.arg_count = static_cast<uint32_t>(bo_handles.size());
-  if (ioctl(fd, DRM_IOCTL_AMDXDNA_EXEC_CMD, &exec_cmd) < 0) {
+  if (xdna_ioctl(fd, DRM_IOCTL_AMDXDNA_EXEC_CMD, &exec_cmd) < 0) {
     return HSA_STATUS_ERROR;
   }
 
@@ -306,7 +321,7 @@ static hsa_status_t WaitCommand(int fd, ert_start_kernel_cmd* cmd, uint32_t hw_c
   wait_cmd.hwctx = hw_ctx_handle;
   wait_cmd.timeout = 0;  // no timeout, wait until the command finishes
   wait_cmd.seq = seq;
-  if (ioctl(fd, DRM_IOCTL_AMDXDNA_WAIT_CMD, &wait_cmd) < 0) {
+  if (xdna_ioctl(fd, DRM_IOCTL_AMDXDNA_WAIT_CMD, &wait_cmd) < 0) {
     return HSA_STATUS_ERROR;
   }
 
@@ -390,7 +405,7 @@ hsa_status_t XdnaDriver::GetNodeProperties(HsaNodeProperties& node_props, uint32
   get_info_args.buffer_size = sizeof(aie_metadata);
   get_info_args.buffer = reinterpret_cast<uintptr_t>(&aie_metadata);
 
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_INFO, &get_info_args) < 0) {
+  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_INFO, &get_info_args) < 0) {
     return HSA_STATUS_ERROR;
   }
 
@@ -511,7 +526,7 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
     create_bo_args.type = AMDXDNA_BO_DEV;
   }
 
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_BO, &create_bo_args) < 0) {
+  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_BO, &create_bo_args) < 0) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
@@ -524,7 +539,7 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
 
   amdxdna_drm_get_bo_info get_bo_info_args = {};
   get_bo_info_args.handle = create_bo_args.handle;
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &get_bo_info_args) < 0) {
+  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &get_bo_info_args) < 0) {
     return HSA_STATUS_ERROR;
   }
 
@@ -581,7 +596,7 @@ hsa_status_t XdnaDriver::FreeMemory(void *mem, size_t size) {
   // Close the BO.
   drm_gem_close close_args = {};
   close_args.handle = bo_handle.handle;
-  if (ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_args) < 0) {
+  if (xdna_ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_args) < 0) {
     return HSA_STATUS_ERROR;
   }
   bo_handle.handle = AMDXDNA_INVALID_BO_HANDLE;
@@ -605,7 +620,7 @@ hsa_status_t XdnaDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint
   create_hwctx_args.qos_p = reinterpret_cast<uintptr_t>(&qos_info);
   create_hwctx_args.max_opc = 0x800;
   create_hwctx_args.num_tiles = 1;  // dummy context; use 1 core
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_HWCTX, &create_hwctx_args) < 0) {
+  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_HWCTX, &create_hwctx_args) < 0) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
@@ -624,12 +639,12 @@ hsa_status_t XdnaDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint
   config_ctx.param_type = DRM_AMDXDNA_HWCTX_CONFIG_CU;
   config_ctx.param_val = reinterpret_cast<uint64_t>(cu_config);
   config_ctx.param_val_size = static_cast<uint32_t>(cu_config_size);
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CONFIG_HWCTX, &config_ctx) < 0) {
+  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CONFIG_HWCTX, &config_ctx) < 0) {
     DestroyHwCtx(fd_, create_hwctx_args.handle);
     return HSA_STATUS_ERROR;
   }
 
-  queue_resource.QueueId = create_hwctx_args.handle;
+  queue_resource.QueueId = static_cast<HSA_QUEUEID>(create_hwctx_args.handle);
 
   return HSA_STATUS_SUCCESS;
 }
@@ -676,7 +691,7 @@ hsa_status_t XdnaDriver::ExportDMABuf(void* mem, size_t size, int* dmabuf_fd, si
   export_params.handle = bo_handle.handle;
   export_params.flags = DRM_RDWR;
   export_params.fd = -1;
-  if (ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &export_params) < 0) {
+  if (xdna_ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &export_params) < 0) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
@@ -691,8 +706,7 @@ hsa_status_t XdnaDriver::ImportDMABuf(int dmabuf_fd, const core::Agent& agent,
   drm_prime_handle import_params = {};
   import_params.handle = AMDXDNA_INVALID_BO_HANDLE;
   import_params.fd = dmabuf_fd;
-  if (ioctl(fd_, DRM_IOCTL_PRIME_FD_TO_HANDLE, &import_params) < 0)
-    return HSA_STATUS_ERROR;
+  if (xdna_ioctl(fd_, DRM_IOCTL_PRIME_FD_TO_HANDLE, &import_params) < 0) return HSA_STATUS_ERROR;
 
   *handle = core::ShareableHandle{import_params.handle};
   return HSA_STATUS_SUCCESS;
@@ -710,7 +724,7 @@ hsa_status_t XdnaDriver::Map(core::ShareableHandle handle, void *mem,
   drm_prime_handle params = {};
   params.handle = handle.handle;
   params.fd = -1;
-  if (ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &params) < 0) {
+  if (xdna_ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &params) < 0) {
     return HSA_STATUS_ERROR;
   }
 
@@ -745,7 +759,7 @@ hsa_status_t XdnaDriver::CreateShareableHandle(void* va, void* mem, size_t size,
   // Get offset.
   amdxdna_drm_get_bo_info get_bo_info_args = {};
   get_bo_info_args.handle = bo_handle.handle;
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &get_bo_info_args) < 0) {
+  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &get_bo_info_args) < 0) {
     return HSA_STATUS_ERROR;
   }
 
@@ -754,7 +768,7 @@ hsa_status_t XdnaDriver::CreateShareableHandle(void* va, void* mem, size_t size,
   params.handle = bo_handle.handle;
   params.flags = DRM_RDWR;
   params.fd = -1;
-  if (ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &params) < 0) {
+  if (xdna_ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &params) < 0) {
     return HSA_STATUS_ERROR;
   }
 
@@ -776,8 +790,9 @@ hsa_status_t XdnaDriver::CreateShareableHandle(void* va, void* mem, size_t size,
 hsa_status_t XdnaDriver::DestroyShareableHandle(core::ShareableHandle* handle) {
   drm_gem_close close_params = {};
   close_params.handle = handle->handle;
-  if (ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_params) < 0)
+  if (xdna_ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_params) < 0) {
     return HSA_STATUS_ERROR;
+  }
 
   *handle = {};
 
@@ -789,7 +804,7 @@ hsa_status_t XdnaDriver::QueryDriverVersion() {
   amdxdna_drm_get_info args{DRM_AMDXDNA_QUERY_AIE_VERSION, sizeof(aie_version),
                             reinterpret_cast<uintptr_t>(&aie_version)};
 
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_INFO, &args) < 0) {
+  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_INFO, &args) < 0) {
     return HSA_STATUS_ERROR;
   }
 
@@ -803,7 +818,7 @@ hsa_status_t XdnaDriver::InitDeviceHeap() {
   amdxdna_drm_create_bo create_bo_args = {};
   create_bo_args.size = dev_heap_size;
   create_bo_args.type = AMDXDNA_BO_DEV_HEAP;
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_BO, &create_bo_args) < 0) {
+  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_BO, &create_bo_args) < 0) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
@@ -814,7 +829,7 @@ hsa_status_t XdnaDriver::InitDeviceHeap() {
 
   amdxdna_drm_get_bo_info get_bo_info_args = {};
   get_bo_info_args.handle = dev_heap_handle.handle;
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &get_bo_info_args) < 0) {
+  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &get_bo_info_args) < 0) {
     return HSA_STATUS_ERROR;
   }
 
@@ -859,7 +874,7 @@ hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) {
   amdxdna_drm_create_bo create_cmd_bo = {};
   create_cmd_bo.type = AMDXDNA_BO_CMD;
   create_cmd_bo.size = size;
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_BO, &create_cmd_bo) < 0) {
+  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_BO, &create_cmd_bo) < 0) {
     return HSA_STATUS_ERROR;
   }
 
@@ -872,7 +887,7 @@ hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) {
 
   amdxdna_drm_get_bo_info cmd_bo_get_bo_info = {};
   cmd_bo_get_bo_info.handle = tmp_cmd_bo_handle.handle;
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &cmd_bo_get_bo_info) < 0) {
+  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &cmd_bo_get_bo_info) < 0) {
     return HSA_STATUS_ERROR;
   }
 
@@ -1141,7 +1156,7 @@ void XdnaDriver::DestroyBOHandle(BOHandle& handle) {
   if (handle.IsValid()) {
     drm_gem_close close_bo_args = {};
     close_bo_args.handle = handle.handle;
-    if (ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args) < 0) {
+    if (xdna_ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args) < 0) {
       assert(false && "Failed to close BO handle.");
     }
     handle.handle = AMDXDNA_INVALID_BO_HANDLE;
@@ -1217,7 +1232,7 @@ hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, HSA_QUEUEID
   create_hwctx_args.qos_p = reinterpret_cast<uintptr_t>(&qos_info);
   create_hwctx_args.max_opc = 0x800;
   create_hwctx_args.num_tiles = num_core_tiles;
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_HWCTX, &create_hwctx_args) < 0) {
+  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_HWCTX, &create_hwctx_args) < 0) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
@@ -1227,7 +1242,7 @@ hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, HSA_QUEUEID
   config_hw_ctx_args.param_type = DRM_AMDXDNA_HWCTX_CONFIG_CU;
   config_hw_ctx_args.param_val = reinterpret_cast<uint64_t>(xdna_config_cu_param);
   config_hw_ctx_args.param_val_size = static_cast<uint32_t>(config_cu_param_size);
-  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_CONFIG_HWCTX, &config_hw_ctx_args) < 0) {
+  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CONFIG_HWCTX, &config_hw_ctx_args) < 0) {
     DestroyHwCtx(fd_, create_hwctx_args.handle);
     return HSA_STATUS_ERROR;
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -217,12 +217,27 @@ constexpr uint32_t default_cu_func = 0;
 /// @param[in] fd file descriptor
 /// @param[in] request ioctl request code
 /// @param[in] arg pointer to the argument for the ioctl call
-static int xdna_ioctl(int fd, unsigned long request, void* arg) {
+static hsa_status_t xdna_ioctl(int fd, unsigned long request, void* arg) {
   int ret;
   do {
     ret = ioctl(fd, request, arg);
-  } while (ret < 0 && (errno == EINTR || errno == EAGAIN));
-  return ret;
+    if (ret >= 0) {
+      return HSA_STATUS_SUCCESS;
+    }
+  } while (errno == EINTR || errno == EAGAIN);
+
+  // Map errno to appropriate HSA status code.
+  switch (errno) {
+    case EINVAL:
+      return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+    case ENOENT:
+      return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+    case ENOMEM:
+    case ENOSPC:
+      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+    default:
+      return HSA_STATUS_ERROR;
+  }
 }
 
 /**
@@ -252,10 +267,7 @@ static hsa_status_t DestroyHwCtx(int fd, uint32_t hw_ctx_handle) {
 
   amdxdna_drm_destroy_hwctx args = {};
   args.handle = hw_ctx_handle;
-  if (xdna_ioctl(fd, DRM_IOCTL_AMDXDNA_DESTROY_HWCTX, &args) < 0) {
-    return HSA_STATUS_ERROR;
-  }
-  return HSA_STATUS_SUCCESS;
+  return xdna_ioctl(fd, DRM_IOCTL_AMDXDNA_DESTROY_HWCTX, &args);
 }
 
 /**
@@ -279,8 +291,9 @@ static hsa_status_t SubmitCommand(int fd, uint32_t cmd_bo_handle,
   exec_cmd.args = reinterpret_cast<uint64_t>(bo_handles.data());
   exec_cmd.cmd_count = 1;
   exec_cmd.arg_count = static_cast<uint32_t>(bo_handles.size());
-  if (xdna_ioctl(fd, DRM_IOCTL_AMDXDNA_EXEC_CMD, &exec_cmd) < 0) {
-    return HSA_STATUS_ERROR;
+  hsa_status_t err = xdna_ioctl(fd, DRM_IOCTL_AMDXDNA_EXEC_CMD, &exec_cmd);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
   }
 
   seq_out = exec_cmd.seq;
@@ -321,12 +334,13 @@ static hsa_status_t WaitCommand(int fd, ert_start_kernel_cmd* cmd, uint32_t hw_c
   wait_cmd.hwctx = hw_ctx_handle;
   wait_cmd.timeout = 0;  // no timeout, wait until the command finishes
   wait_cmd.seq = seq;
-  if (xdna_ioctl(fd, DRM_IOCTL_AMDXDNA_WAIT_CMD, &wait_cmd) < 0) {
-    return HSA_STATUS_ERROR;
+  hsa_status_t err = xdna_ioctl(fd, DRM_IOCTL_AMDXDNA_WAIT_CMD, &wait_cmd);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
   }
 
+  // Check if command failed.
   if (cmd_ref.state != ERT_CMD_STATE_COMPLETED) {
-    // Command is in an error state.
     return HSA_STATUS_ERROR;
   }
   return HSA_STATUS_SUCCESS;
@@ -405,8 +419,9 @@ hsa_status_t XdnaDriver::GetNodeProperties(HsaNodeProperties& node_props, uint32
   get_info_args.buffer_size = sizeof(aie_metadata);
   get_info_args.buffer = reinterpret_cast<uintptr_t>(&aie_metadata);
 
-  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_INFO, &get_info_args) < 0) {
-    return HSA_STATUS_ERROR;
+  hsa_status_t err = xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_INFO, &get_info_args);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
   }
 
   const std::string sysfs_device_path = std::string(sysfs_path) + "/" + devnode_name_ + "/device";
@@ -526,8 +541,9 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
     create_bo_args.type = AMDXDNA_BO_DEV;
   }
 
-  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_BO, &create_bo_args) < 0) {
-    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  hsa_status_t err = xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_BO, &create_bo_args);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
   }
 
   BOHandle bo_handle;
@@ -539,8 +555,9 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
 
   amdxdna_drm_get_bo_info get_bo_info_args = {};
   get_bo_info_args.handle = create_bo_args.handle;
-  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &get_bo_info_args) < 0) {
-    return HSA_STATUS_ERROR;
+  err = xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &get_bo_info_args);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
   }
 
   if (use_bo_share) {
@@ -605,8 +622,9 @@ hsa_status_t XdnaDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint
   create_hwctx_args.qos_p = reinterpret_cast<uintptr_t>(&qos_info);
   create_hwctx_args.max_opc = 0x800;
   create_hwctx_args.num_tiles = 1;  // dummy context; use 1 core
-  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_HWCTX, &create_hwctx_args) < 0) {
-    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  hsa_status_t err = xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_HWCTX, &create_hwctx_args);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
   }
 
   // Create hardware context for the queue.
@@ -624,9 +642,10 @@ hsa_status_t XdnaDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint
   config_ctx.param_type = DRM_AMDXDNA_HWCTX_CONFIG_CU;
   config_ctx.param_val = reinterpret_cast<uint64_t>(cu_config);
   config_ctx.param_val_size = static_cast<uint32_t>(cu_config_size);
-  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CONFIG_HWCTX, &config_ctx) < 0) {
+  err = xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CONFIG_HWCTX, &config_ctx);
+  if (err != HSA_STATUS_SUCCESS) {
     DestroyHwCtx(fd_, create_hwctx_args.handle);
-    return HSA_STATUS_ERROR;
+    return err;
   }
 
   queue_resource.QueueId = static_cast<HSA_QUEUEID>(create_hwctx_args.handle);
@@ -676,8 +695,9 @@ hsa_status_t XdnaDriver::ExportDMABuf(void* mem, size_t size, int* dmabuf_fd, si
   export_params.handle = bo_handle.handle;
   export_params.flags = DRM_RDWR;
   export_params.fd = -1;
-  if (xdna_ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &export_params) < 0) {
-    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  hsa_status_t err = xdna_ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &export_params);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
   }
 
   *dmabuf_fd = export_params.fd;
@@ -691,8 +711,9 @@ hsa_status_t XdnaDriver::ImportDMABuf(int dmabuf_fd, const core::Agent& agent,
   drm_prime_handle import_params = {};
   import_params.handle = AMDXDNA_INVALID_BO_HANDLE;
   import_params.fd = dmabuf_fd;
-  if (xdna_ioctl(fd_, DRM_IOCTL_PRIME_FD_TO_HANDLE, &import_params) < 0) {
-    return HSA_STATUS_ERROR;
+  hsa_status_t err = xdna_ioctl(fd_, DRM_IOCTL_PRIME_FD_TO_HANDLE, &import_params);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
   }
 
   *handle = core::ShareableHandle{import_params.handle};
@@ -711,8 +732,9 @@ hsa_status_t XdnaDriver::Map(core::ShareableHandle handle, void *mem,
   drm_prime_handle params = {};
   params.handle = handle.handle;
   params.fd = -1;
-  if (xdna_ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &params) < 0) {
-    return HSA_STATUS_ERROR;
+  hsa_status_t err = xdna_ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &params);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
   }
 
   // Change permissions.
@@ -748,8 +770,9 @@ hsa_status_t XdnaDriver::CreateShareableHandle(void* va, void* mem, size_t size,
   // Get offset.
   amdxdna_drm_get_bo_info get_bo_info_args = {};
   get_bo_info_args.handle = bo_handle.handle;
-  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &get_bo_info_args) < 0) {
-    return HSA_STATUS_ERROR;
+  hsa_status_t err = xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &get_bo_info_args);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
   }
 
   // Get fd associated with the handle.
@@ -757,8 +780,9 @@ hsa_status_t XdnaDriver::CreateShareableHandle(void* va, void* mem, size_t size,
   params.handle = bo_handle.handle;
   params.flags = DRM_RDWR;
   params.fd = -1;
-  if (xdna_ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &params) < 0) {
-    return HSA_STATUS_ERROR;
+  err = xdna_ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &params);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
   }
 
   // Map memory to the virtual address.
@@ -780,8 +804,9 @@ hsa_status_t XdnaDriver::CreateShareableHandle(void* va, void* mem, size_t size,
 hsa_status_t XdnaDriver::DestroyShareableHandle(core::ShareableHandle* handle) {
   drm_gem_close close_params = {};
   close_params.handle = handle->handle;
-  if (xdna_ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_params) < 0) {
-    return HSA_STATUS_ERROR;
+  hsa_status_t err = xdna_ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_params);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
   }
 
   *handle = {};
@@ -794,8 +819,9 @@ hsa_status_t XdnaDriver::QueryDriverVersion() {
   amdxdna_drm_get_info args{DRM_AMDXDNA_QUERY_AIE_VERSION, sizeof(aie_version),
                             reinterpret_cast<uintptr_t>(&aie_version)};
 
-  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_INFO, &args) < 0) {
-    return HSA_STATUS_ERROR;
+  hsa_status_t err = xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_INFO, &args);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
   }
 
   version_.KernelInterfaceMajorVersion = aie_version.major;
@@ -808,8 +834,9 @@ hsa_status_t XdnaDriver::InitDeviceHeap() {
   amdxdna_drm_create_bo create_bo_args = {};
   create_bo_args.size = dev_heap_size;
   create_bo_args.type = AMDXDNA_BO_DEV_HEAP;
-  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_BO, &create_bo_args) < 0) {
-    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  hsa_status_t err = xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_BO, &create_bo_args);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
   }
 
   dev_heap_handle.handle = create_bo_args.handle;
@@ -819,8 +846,9 @@ hsa_status_t XdnaDriver::InitDeviceHeap() {
 
   amdxdna_drm_get_bo_info get_bo_info_args = {};
   get_bo_info_args.handle = dev_heap_handle.handle;
-  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &get_bo_info_args) < 0) {
-    return HSA_STATUS_ERROR;
+  err = xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &get_bo_info_args);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
   }
 
   const size_t size = dev_heap_align * 2 - 1;
@@ -870,8 +898,9 @@ hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) {
   amdxdna_drm_create_bo create_cmd_bo = {};
   create_cmd_bo.type = AMDXDNA_BO_CMD;
   create_cmd_bo.size = size;
-  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_BO, &create_cmd_bo) < 0) {
-    return HSA_STATUS_ERROR;
+  hsa_status_t err = xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_BO, &create_cmd_bo);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
   }
 
   BOHandle tmp_cmd_bo_handle;
@@ -883,8 +912,9 @@ hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) {
 
   amdxdna_drm_get_bo_info cmd_bo_get_bo_info = {};
   cmd_bo_get_bo_info.handle = tmp_cmd_bo_handle.handle;
-  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &cmd_bo_get_bo_info) < 0) {
-    return HSA_STATUS_ERROR;
+  err = xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &cmd_bo_get_bo_info);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
   }
 
   void* mem = mmap(nullptr, tmp_cmd_bo_handle.size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_,
@@ -1143,28 +1173,30 @@ hsa_status_t XdnaDriver::DestroyBOHandle(BOHandle& handle) {
     return HSA_STATUS_SUCCESS;
   }
 
-  hsa_status_t err = HSA_STATUS_SUCCESS;
+  hsa_status_t unmap_err = HSA_STATUS_SUCCESS;
 
   // Unmap the memory.
   if (handle.unmap_vaddr) {
     if (munmap(handle.vaddr, handle.size) != 0) {
-      err = HSA_STATUS_ERROR;
+      unmap_err = HSA_STATUS_ERROR;
       assert(false && "Failed to unmap BO memory.");
+    } else {
+      handle.unmap_vaddr = false;
+      handle.vaddr = nullptr;
+      handle.size = 0;
     }
-    handle.unmap_vaddr = false;
   }
-  handle.vaddr = nullptr;
-  handle.size = 0;
 
   // Close the BO handle.
   drm_gem_close close_bo_args = {};
   close_bo_args.handle = handle.handle;
-  if (xdna_ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args) < 0) {
-    err = HSA_STATUS_ERROR;
-  }
+  hsa_status_t ioctl_err = xdna_ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
   handle.handle = AMDXDNA_INVALID_BO_HANDLE;
 
-  return err;
+  if (ioctl_err != HSA_STATUS_SUCCESS) {
+    return ioctl_err;
+  }
+  return unmap_err;
 }
 
 XdnaDriver::BOHandle XdnaDriver::FindBOHandle(void* mem) const {
@@ -1223,9 +1255,9 @@ hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, HSA_QUEUEID
   // Note: we can do this because we have forced synchronization between command chains. If we move
   // to a more asynchronous model, we will need to figure out how hardware context destruction works
   // while applications are running.
-  hsa_status_t status = DestroyHwCtx(fd_, hw_ctx_handle);
-  if (status != HSA_STATUS_SUCCESS) {
-    return status;
+  hsa_status_t err = DestroyHwCtx(fd_, hw_ctx_handle);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
   }
   queue_id = AMDXDNA_INVALID_CTX_HANDLE;
 
@@ -1236,8 +1268,9 @@ hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, HSA_QUEUEID
   create_hwctx_args.qos_p = reinterpret_cast<uintptr_t>(&qos_info);
   create_hwctx_args.max_opc = 0x800;
   create_hwctx_args.num_tiles = num_core_tiles;
-  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_HWCTX, &create_hwctx_args) < 0) {
-    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  err = xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_HWCTX, &create_hwctx_args);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
   }
 
   // Configure the new hardware context
@@ -1246,9 +1279,10 @@ hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, HSA_QUEUEID
   config_hw_ctx_args.param_type = DRM_AMDXDNA_HWCTX_CONFIG_CU;
   config_hw_ctx_args.param_val = reinterpret_cast<uint64_t>(xdna_config_cu_param);
   config_hw_ctx_args.param_val_size = static_cast<uint32_t>(config_cu_param_size);
-  if (xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CONFIG_HWCTX, &config_hw_ctx_args) < 0) {
+  err = xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CONFIG_HWCTX, &config_hw_ctx_args);
+  if (err != HSA_STATUS_SUCCESS) {
     DestroyHwCtx(fd_, create_hwctx_args.handle);
-    return HSA_STATUS_ERROR;
+    return err;
   }
 
   queue_id = create_hwctx_args.handle;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -877,20 +877,9 @@ hsa_status_t XdnaDriver::InitDeviceHeap() {
 }
 
 hsa_status_t XdnaDriver::FreeDeviceHeap() {
-  hsa_status_t err = HSA_STATUS_SUCCESS;
-
-  if (dev_heap_aligned) {
-    if (munmap(dev_heap_aligned, dev_heap_size) != 0) {
-      err = HSA_STATUS_ERROR;
-    } else {
-      dev_heap_aligned = nullptr;
-    }
-  }
-
-  if (DestroyBOHandle(dev_heap_handle) != HSA_STATUS_SUCCESS) {
-    err = HSA_STATUS_ERROR;
-  }
-
+  hsa_status_t err = DestroyBOHandle(dev_heap_handle);
+  assert(err == HSA_STATUS_SUCCESS && "Failed to destroy device heap BO handle.");
+  dev_heap_aligned = nullptr;
   return err;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -579,31 +579,16 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::FreeMemory(void *mem, size_t size) {
+hsa_status_t XdnaDriver::FreeMemory(void* mem, size_t size) {
   auto it = vmem_addr_mappings.find(mem);
-  if (it == vmem_addr_mappings.end()) return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+  if (it == vmem_addr_mappings.end()) {
+    return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+  }
 
   auto& bo_handle = it->second;
-  if (bo_handle.unmap_vaddr) {
-    if (munmap(bo_handle.vaddr, bo_handle.size) != 0) {
-      return HSA_STATUS_ERROR;
-    }
-    bo_handle.unmap_vaddr = false;
-  }
-  bo_handle.vaddr = nullptr;
-  bo_handle.size = 0;
-
-  // Close the BO.
-  drm_gem_close close_args = {};
-  close_args.handle = bo_handle.handle;
-  if (xdna_ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_args) < 0) {
-    return HSA_STATUS_ERROR;
-  }
-  bo_handle.handle = AMDXDNA_INVALID_BO_HANDLE;
-
+  hsa_status_t err = DestroyBOHandle(bo_handle);
   vmem_addr_mappings.erase(it);
-
-  return HSA_STATUS_SUCCESS;
+  return err;
 }
 
 hsa_status_t XdnaDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,
@@ -706,7 +691,9 @@ hsa_status_t XdnaDriver::ImportDMABuf(int dmabuf_fd, const core::Agent& agent,
   drm_prime_handle import_params = {};
   import_params.handle = AMDXDNA_INVALID_BO_HANDLE;
   import_params.fd = dmabuf_fd;
-  if (xdna_ioctl(fd_, DRM_IOCTL_PRIME_FD_TO_HANDLE, &import_params) < 0) return HSA_STATUS_ERROR;
+  if (xdna_ioctl(fd_, DRM_IOCTL_PRIME_FD_TO_HANDLE, &import_params) < 0) {
+    return HSA_STATUS_ERROR;
+  }
 
   *handle = core::ShareableHandle{import_params.handle};
   return HSA_STATUS_SUCCESS;
@@ -731,6 +718,7 @@ hsa_status_t XdnaDriver::Map(core::ShareableHandle handle, void *mem,
   // Change permissions.
   void *mapped_ptr = mmap(mem, size, PermissionsToMmapFlags(perms),
                           MAP_FIXED | MAP_SHARED, params.fd, offset);
+  close(params.fd);
   if (mapped_ptr == MAP_FAILED) {
     return HSA_STATUS_ERROR;
   }
@@ -740,8 +728,9 @@ hsa_status_t XdnaDriver::Map(core::ShareableHandle handle, void *mem,
 
 hsa_status_t XdnaDriver::Unmap(core::ShareableHandle handle, void *mem,
                                size_t offset, size_t size) {
-  if (munmap(mem, size) != 0)
+  if (munmap(mem, size) != 0) {
     return HSA_STATUS_ERROR;
+  }
 
   return HSA_STATUS_SUCCESS;
 }
@@ -776,6 +765,7 @@ hsa_status_t XdnaDriver::CreateShareableHandle(void* va, void* mem, size_t size,
   void* mapped_ptr = mmap(va, size, PROT_READ | PROT_WRITE, MAP_FIXED | MAP_SHARED, fd_,
                           get_bo_info_args.map_offset);
   if (mapped_ptr == MAP_FAILED) {
+    close(params.fd);
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
@@ -839,6 +829,7 @@ hsa_status_t XdnaDriver::InitDeviceHeap() {
   if (dev_heap_handle.vaddr == MAP_FAILED) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
+  dev_heap_handle.unmap_vaddr = true;
   dev_heap_handle.size = size;
 
   void* addr_aligned = reinterpret_cast<void*>(
@@ -858,16 +849,21 @@ hsa_status_t XdnaDriver::InitDeviceHeap() {
 }
 
 hsa_status_t XdnaDriver::FreeDeviceHeap() {
+  hsa_status_t err = HSA_STATUS_SUCCESS;
+
   if (dev_heap_aligned) {
     if (munmap(dev_heap_aligned, dev_heap_size) != 0) {
-      return HSA_STATUS_ERROR;
+      err = HSA_STATUS_ERROR;
+    } else {
+      dev_heap_aligned = nullptr;
     }
-    dev_heap_aligned = nullptr;
   }
 
-  DestroyBOHandle(dev_heap_handle);
+  if (DestroyBOHandle(dev_heap_handle) != HSA_STATUS_SUCCESS) {
+    err = HSA_STATUS_ERROR;
+  }
 
-  return HSA_STATUS_SUCCESS;
+  return err;
 }
 
 hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) {
@@ -1142,10 +1138,17 @@ hsa_status_t XdnaDriver::IsModelEnabled(bool* enable) const {
   return HSA_STATUS_SUCCESS;
 }
 
-void XdnaDriver::DestroyBOHandle(BOHandle& handle) {
+hsa_status_t XdnaDriver::DestroyBOHandle(BOHandle& handle) {
+  if (!handle.IsValid()) {
+    return HSA_STATUS_SUCCESS;
+  }
+
+  hsa_status_t err = HSA_STATUS_SUCCESS;
+
+  // Unmap the memory.
   if (handle.unmap_vaddr) {
-    // Unmap the memory.
     if (munmap(handle.vaddr, handle.size) != 0) {
+      err = HSA_STATUS_ERROR;
       assert(false && "Failed to unmap BO memory.");
     }
     handle.unmap_vaddr = false;
@@ -1153,14 +1156,15 @@ void XdnaDriver::DestroyBOHandle(BOHandle& handle) {
   handle.vaddr = nullptr;
   handle.size = 0;
 
-  if (handle.IsValid()) {
-    drm_gem_close close_bo_args = {};
-    close_bo_args.handle = handle.handle;
-    if (xdna_ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args) < 0) {
-      assert(false && "Failed to close BO handle.");
-    }
-    handle.handle = AMDXDNA_INVALID_BO_HANDLE;
+  // Close the BO handle.
+  drm_gem_close close_bo_args = {};
+  close_bo_args.handle = handle.handle;
+  if (xdna_ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args) < 0) {
+    err = HSA_STATUS_ERROR;
   }
+  handle.handle = AMDXDNA_INVALID_BO_HANDLE;
+
+  return err;
 }
 
 XdnaDriver::BOHandle XdnaDriver::FindBOHandle(void* mem) const {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aie_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aie_aql_queue.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2023-2025, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2023-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -42,8 +42,6 @@
 
 #ifndef HSA_RUNTIME_CORE_INC_AMD_HW_AQL_AIE_COMMAND_PROCESSOR_H_
 #define HSA_RUNTIME_CORE_INC_AMD_HW_AQL_AIE_COMMAND_PROCESSOR_H_
-
-#include <limits>
 
 #include "core/inc/amd_aie_agent.h"
 #include "core/inc/queue.h"
@@ -100,32 +98,25 @@ class AieAqlQueue : public core::Queue,
   void ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope_t acquireFence,
                   hsa_fence_scope_t releaseFence, hsa_signal_t* signal) override;
 
- private:
-  HSA_QUEUEID queue_id_ = INVALID_QUEUEID;
-  /// @brief ID of AIE device on which this queue has been mapped.
-  uint32_t node_id_ = std::numeric_limits<uint32_t>::max();
-  /// @brief Queue size in bytes.
-  uint32_t queue_size_bytes_ = std::numeric_limits<uint32_t>::max();
-
  protected:
   bool _IsA(Queue::rtti_t id) const override { return id == &rtti_id(); }
 
  private:
-  AieAgent &agent_;
-
-  /// @brief Base of the queue's ring buffer storage.
-  void *ring_buf_ = nullptr;
-
   /// @brief Called when the doorbell is rung to submit all queued packets.
   void SubmitPackets();
 
-  /// @brief Indicates if queue is active.
-  std::atomic<bool> active_;
   static __forceinline int& rtti_id() {
     static int rtti_id_ = 0;
     return rtti_id_;
   }
 
+  HSA_QUEUEID queue_id_ = INVALID_QUEUEID;
+  /// @brief Queue size in bytes.
+  uint32_t queue_size_bytes_ = 0;
+  /// @brief Base of the queue's ring buffer storage.
+  void* ring_buf_ = nullptr;
+  /// @brief Indicates if queue is active.
+  std::atomic<bool> active_ = false;
 };
 
 } // namespace AMD

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -224,10 +224,10 @@ public:
  private:
   /// @brief Destroys @p bo_handle.
   ///
-  /// This function will unmap the virtual address and close the BO, but will not return any status.
+  /// @note This function will unmap the virtual address and close the BO, even if the former fails.
   ///
   /// @param[in,out] bo_handle BO handle to destroy.
-  void DestroyBOHandle(BOHandle& bo_handle);
+  hsa_status_t DestroyBOHandle(BOHandle& bo_handle);
 
   /// @brief Returns the BO associated with the address.
   ///

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -74,6 +74,7 @@ AieAqlQueue::AieAqlQueue(core::SharedQueue* shared_queue, AieAgent* agent, size_
     throw hsa_exception(HSA_STATUS_ERROR_INVALID_QUEUE_CREATION,
                         "Could not allocate a ring buffer for an AIE queue.");
   }
+  MAKE_NAMED_SCOPE_GUARD(ring_buf_guard, [&] { agent->system_deallocator()(ring_buf_); });
 
   // Populate hsa_queue_t fields.
   amd_queue_.hsa_queue.type = HSA_QUEUE_TYPE_SINGLE;
@@ -101,6 +102,8 @@ AieAqlQueue::AieAqlQueue(core::SharedQueue* shared_queue, AieAgent* agent, size_
   queue_id_ = queue_resource.QueueId;
 
   active_ = true;
+
+  ring_buf_guard.Dismiss();
 }
 
 AieAqlQueue::~AieAqlQueue() {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -42,26 +42,14 @@
 
 #include "core/inc/amd_aie_aql_queue.h"
 
-#ifdef __linux__
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#endif
-
-#ifdef _WIN32
-#include <Windows.h>
-#endif
-
 #include <atomic>
 #include <cassert>
-#include <cstring>
 
 #include "inc/hsa_ext_amd_aie.h"
 #include "core/inc/amd_xdna_driver.h"
 #include "core/inc/queue.h"
 #include "core/inc/runtime.h"
 #include "core/inc/signal.h"
-#include "core/util/utils.h"
 
 namespace rocr {
 namespace AMD {
@@ -74,16 +62,14 @@ AieAqlQueue::AieAqlQueue(core::SharedQueue* shared_queue, AieAgent* agent, size_
     : Queue(shared_queue, flags, agent),
       LocalSignal(0, false),
       DoorbellSignal(signal()),
-      agent_(*agent),
-      active_(false) {
-  if (agent_.device_type() != core::Agent::DeviceType::kAmdAieDevice) {
+      queue_size_bytes_(req_size_pkts * sizeof(hsa_amd_aie_kernel_dispatch_packet_t)) {
+  if (agent->device_type() != core::Agent::DeviceType::kAmdAieDevice) {
     throw hsa_exception(HSA_STATUS_ERROR_INVALID_AGENT,
                         "Attempting to create an AIE queue on a non-AIE agent.");
   }
-  queue_size_bytes_ = req_size_pkts * sizeof(hsa_amd_aie_kernel_dispatch_packet_t);
-  ring_buf_ = agent_.system_allocator()(queue_size_bytes_, 4096,
-                                        core::MemoryRegion::AllocateNoFlags);
 
+  ring_buf_ =
+      agent->system_allocator()(queue_size_bytes_, 4096, core::MemoryRegion::AllocateNoFlags);
   if (!ring_buf_) {
     throw hsa_exception(HSA_STATUS_ERROR_INVALID_QUEUE_CREATION,
                         "Could not allocate a ring buffer for an AIE queue.");
@@ -104,22 +90,24 @@ AieAqlQueue::AieAqlQueue(core::SharedQueue* shared_queue, AieAgent* agent, size_
   signal_.hardware_doorbell_ptr = nullptr;
   signal_.kind = AMD_SIGNAL_KIND_DOORBELL;
   signal_.queue_ptr = &amd_queue_;
-  active_ = true;
 
   HsaQueueResource queue_resource = {};
-  hsa_status_t status =
-      agent_.driver().CreateQueue(node_id, HSA_QUEUE_COMPUTE_AQL, 0, rocr::HSA::HSA_AMD_QUEUE_PRIORITY_NORMAL, 0,
-                                  nullptr, queue_size_bytes_, 0, nullptr, queue_resource);
+  hsa_status_t status = agent->driver().CreateQueue(
+      node_id, HSA_QUEUE_COMPUTE_AQL, 0, rocr::HSA::HSA_AMD_QUEUE_PRIORITY_NORMAL, 0, nullptr,
+      queue_size_bytes_, 0, nullptr, queue_resource);
   if (status != HSA_STATUS_SUCCESS) {
     throw hsa_exception(status, "Failed to create a hardware context for an AIE queue.");
   }
   queue_id_ = queue_resource.QueueId;
+
+  active_ = true;
 }
 
 AieAqlQueue::~AieAqlQueue() {
   AieAqlQueue::Inactivate();
   if (ring_buf_) {
-    agent_.system_deallocator()(ring_buf_);
+    auto& agent = static_cast<AieAgent&>(*GetAgent());
+    agent.system_deallocator()(ring_buf_);
   }
   if (shared_queue_) {
     core::Runtime::runtime_singleton_->system_deallocator()(shared_queue_);
@@ -129,8 +117,9 @@ AieAqlQueue::~AieAqlQueue() {
 hsa_status_t AieAqlQueue::Inactivate() {
   bool active = active_.exchange(false, std::memory_order_relaxed);
   if (active) {
-    auto err = agent_.driver().DestroyQueue(queue_id_);
+    auto err = GetAgent()->driver().DestroyQueue(queue_id_);
     assert(err == HSA_STATUS_SUCCESS && "Destroy queue failed.");
+    (void)err;
     atomic::Fence(std::memory_order_acquire);
   }
   return HSA_STATUS_SUCCESS;
@@ -216,7 +205,8 @@ void AieAqlQueue::SubmitPackets() {
     return;
   }
 
-  auto& driver = static_cast<XdnaDriver&>(agent_.driver());
+  auto& agent = static_cast<AieAgent&>(*GetAgent());
+  auto& driver = static_cast<XdnaDriver&>(agent.driver());
 
   const uint64_t first_pkt_idx = LoadReadIndexRelaxed();
   const uint64_t last_pkt_idx = LoadWriteIndexAcquire();
@@ -228,7 +218,7 @@ void AieAqlQueue::SubmitPackets() {
 
   const auto num_pkts = last_pkt_idx - first_pkt_idx;
   hsa_status_t status = driver.SubmitCmdChain(amd_queue_.hsa_queue, queue_id_, first_pkt_idx,
-                                              num_pkts, agent_.properties().NumNeuralCores);
+                                              num_pkts, agent.properties().NumNeuralCores);
   if (status != HSA_STATUS_SUCCESS) {
     throw hsa_exception(status, "Could not submit packets");
   }
@@ -244,7 +234,7 @@ void AieAqlQueue::StoreRelease(hsa_signal_value_t value) {
 hsa_status_t AieAqlQueue::GetInfo(hsa_queue_info_attribute_t attribute, void* value) {
   switch (attribute) {
     case HSA_AMD_QUEUE_INFO_AGENT:
-      *static_cast<hsa_agent_t*>(value) = agent_.public_handle();
+      *static_cast<hsa_agent_t*>(value) = GetAgent()->public_handle();
       break;
     case HSA_AMD_QUEUE_INFO_DOORBELL_ID:
       // Hardware doorbell supports AQL semantics.


### PR DESCRIPTION
## Motivation

This PR makes some robustness improvements to the AIE support.

## Technical Details

- The ioctl calls are wrapped and the proper `hsa_status_t` is returned to avoid collapsing errors to the generic `HSA_STATUS_ERROR`.
- Some fd and mmaps that were not properly released are now released (happening during errors and shutdown).
- Redundant members are removed from the AIE queue.

## JIRA ID

NA

## Test Plan

Dispatch tests where run from https://github.com/ROCm/rocm-systems/tree/users/ypapadop-amd/aie-tests/projects/rocr-runtime/rocrtst/suites/aie (not part of the official test harness yet).

Microbenchmarks where run from https://github.com/ROCm/rocm-systems/tree/users/ypapadop-amd/aie-tests/projects/rocr-runtime/rocrtst/suites/aie-performance

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
