### PR TITLE
[RCCL] Harden proxy RPC setup against malformed peer input

### DIFF
--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -243,6 +243,7 @@ struct ncclProxyConnector {
   int tpRank;
   int tpLocalRank;
   int sameProcess;
+  int connId; // Server-issued integer handle, used as the wire identifier on subsequent proxy RPCs.
   struct ncclProxyConnection* connection;
   ncclResult_t (*proxyProgress)(struct ncclProxyState* proxyState, struct ncclProxyArgs*); // Copied from transport if necessary
 };

--- a/projects/rccl/src/include/proxy.h
+++ b/projects/rccl/src/include/proxy.h
@@ -422,6 +422,17 @@ struct ncclProxyConnection {
   int needsProxyProgress;
 };
 
+#define NCCL_PROXY_CONN_POOL_SIZE_POW2 7
+#define NCCL_PROXY_CONN_POOL_SIZE      (1 << NCCL_PROXY_CONN_POOL_SIZE_POW2)
+#define NCCL_PROXY_CONN_POOL_MASK      (NCCL_PROXY_CONN_POOL_SIZE - 1)
+struct ncclProxyConnectionPool {
+  struct ncclProxyConnection** pools;
+  int banks;
+  int offset;
+};
+ncclResult_t ncclProxyGetConnection(struct ncclProxyConnectionPool* pool, int id, struct ncclProxyConnection** conn);
+ncclResult_t ncclProxyNewConnection(struct ncclProxyConnectionPool* pool, int* id);
+
 typedef ncclResult_t (*threadFunc_t)(struct ncclProxyArgs*);
 
 enum proxyMode {

--- a/projects/rccl/src/proxy.cc
+++ b/projects/rccl/src/proxy.cc
@@ -1097,16 +1097,7 @@ ncclResult_t ncclProxyProgressDestroy(struct ncclProxyState* proxyState) {
   return ncclSuccess;
 }
 
-#define NCCL_PROXY_CONN_POOL_SIZE_POW2 7
-#define NCCL_PROXY_CONN_POOL_SIZE (1<<(NCCL_PROXY_CONN_POOL_SIZE_POW2))
-#define NCCL_PROXY_CONN_POOL_MASK ((NCCL_PROXY_CONN_POOL_SIZE)-1)
-struct ncclProxyConnectionPool {
-  struct ncclProxyConnection** pools;
-  int banks;
-  int offset;
-};
-
-static ncclResult_t ncclProxyNewConnection(struct ncclProxyConnectionPool* pool, int* id) {
+ncclResult_t ncclProxyNewConnection(struct ncclProxyConnectionPool* pool, int* id) {
   if (pool->offset == NCCL_PROXY_CONN_POOL_SIZE) {
     NCCLCHECK(ncclRealloc(&pool->pools, pool->banks, pool->banks+1));
     NCCLCHECK(ncclCalloc(pool->pools+pool->banks, NCCL_PROXY_CONN_POOL_SIZE));
@@ -1118,10 +1109,13 @@ static ncclResult_t ncclProxyNewConnection(struct ncclProxyConnectionPool* pool,
   return ncclSuccess;
 }
 
-static ncclResult_t ncclProxyGetConnection(struct ncclProxyConnectionPool* pool, int id, struct ncclProxyConnection** conn) {
+ncclResult_t ncclProxyGetConnection(struct ncclProxyConnectionPool* pool, int id, struct ncclProxyConnection** conn) {
+  if (id < 0) return ncclInvalidArgument;
   int bank = id>>NCCL_PROXY_CONN_POOL_SIZE_POW2;
   int offset = id&NCCL_PROXY_CONN_POOL_MASK;
-  if ((pool->pools == NULL) || (bank > pool->banks) || (pool->pools[bank] == NULL)) return ncclInternalError;
+  if ((pool->pools == NULL) || (bank >= pool->banks) || (pool->pools[bank] == NULL)) return ncclInvalidArgument;
+  // Last bank's high-water mark is pool->offset; reject IDs past it so callers can't index uninitialized slots.
+  if (bank == pool->banks - 1 && offset >= pool->offset) return ncclInvalidArgument;
   *conn = pool->pools[bank]+offset;
   return ncclSuccess;
 }
@@ -1166,6 +1160,7 @@ struct ncclProxyInitReq {
 
 struct ncclProxyInitResp {
   ncclProxyConnection* connection;
+  int connId; // Server-issued integer handle. Sent on subsequent RPCs in place of the raw pointer.
   char devShmPath[6]; // "XXXXXX" - May or may not be set
 };
 
@@ -1179,6 +1174,7 @@ ncclResult_t ncclProxyConnect(struct ncclComm* comm, int transport, int send, in
                             (comm->peerInfo[proxyRank].pidHash == comm->peerInfo[comm->rank].pidHash)) ? 1 : 0;
   // Keep one connection per local rank
   proxyConn->connection = NULL;
+  proxyConn->connId = -1;
   proxyConn->tpRank = tpProxyRank;
   proxyConn->rank = proxyRank;
   if (sharedProxyState->peerSocks == NULL) {
@@ -1206,10 +1202,11 @@ ncclResult_t ncclProxyConnect(struct ncclComm* comm, int transport, int send, in
   req.sameProcess = proxyConn->sameProcess;
 
   struct ncclProxyInitResp resp = {0};
-  // This usually sends proxyConn->connection to identify which connection this is.
-  // However, this is part of the response and therefore is ignored
+  // The Init RPC ignores the wire connId field (no connection exists yet); the response carries the
+  // server-assigned connId, which we echo back on every subsequent RPC for this connection.
   NCCLCHECK(ncclProxyCallBlocking(comm, proxyConn, ncclProxyMsgInit, &req, sizeof(req), &resp, sizeof(resp)));
   proxyConn->connection = resp.connection;
+  proxyConn->connId = resp.connId;
 
   // If we need proxy progress, map progress ops
   struct ncclTransportComm* tcomm = send ? &ncclTransports[transport]->send : &ncclTransports[transport]->recv;
@@ -1223,7 +1220,7 @@ ncclResult_t ncclProxyConnect(struct ncclComm* comm, int transport, int send, in
     }
   }
   proxyConn->initialized = true;
-  INFO(NCCL_NET|NCCL_PROXY, "Connected to proxy localRank %d -> connection %p", proxyConn->tpLocalRank, proxyConn->connection);
+  INFO(NCCL_NET|NCCL_PROXY, "Connected to proxy localRank %d -> connection %p (connId %d)", proxyConn->tpLocalRank, proxyConn->connection, proxyConn->connId);
   return ncclSuccess;
 }
 
@@ -1327,7 +1324,9 @@ ncclResult_t ncclProxyCallAsync(struct ncclComm* comm, struct ncclProxyConnector
   sock = sharedProxyState->peerSocks + proxyConn->tpLocalRank;
 
   NCCLCHECKGOTO(ncclSocketSend(sock, &type, sizeof(int)), ret, error);
-  NCCLCHECKGOTO(ncclSocketSend(sock, &proxyConn->connection, sizeof(void*)), ret, error);
+  // Send the server-issued integer connId rather than the raw pointer. Server resolves to a
+  // pool-bounds-checked ncclProxyConnection* via ncclProxyGetConnection at the recv site.
+  NCCLCHECKGOTO(ncclSocketSend(sock, &proxyConn->connId, sizeof(int)), ret, error);
   NCCLCHECKGOTO(ncclSocketSend(sock, &reqSize, sizeof(int)), ret, error);
   NCCLCHECKGOTO(ncclSocketSend(sock, &respSize, sizeof(int)), ret, error);
   if (reqSize) NCCLCHECKGOTO(ncclSocketSend(sock, reqBuff, reqSize), ret, error);
@@ -1497,6 +1496,7 @@ static ncclResult_t proxyConnInit(struct ncclProxyLocalPeer* peer, struct ncclPr
   peer->tpRank = req->tpRank;
 
   resp->connection = *connection;
+  resp->connId = id;
 
   (*connection)->tcomm = (*connection)->send ? &ncclTransports[(*connection)->transport]->send : &ncclTransports[(*connection)->transport]->recv;
   // If we need proxy progress, let's allocate ops and start the thread
@@ -1624,7 +1624,20 @@ static ncclResult_t proxyServiceInitOp(int type, struct ncclProxyLocalPeer* peer
   NCCLCHECK(ncclCalloc(&asyncOp, 1));
 
   asyncOp->type = type;
-  NCCLCHECKGOTO(ncclSocketRecv(sock, &asyncOp->connection, sizeof(void*)), ret, fail);
+  // Read the integer connId from the wire and resolve it through the bounds-checked pool accessor.
+  // Replaces the prior pattern of reading a raw `void*` off the socket and dereferencing it as `this`,
+  // which let any peer that knew the comm magic dispatch an indirect call through an arbitrary pointer.
+  // Init is the exception: no connection exists yet, so we accept the wire sentinel and let
+  // proxyConnInit allocate one and bind it to asyncOp->connection via its out-param.
+  {
+    int connId;
+    NCCLCHECKGOTO(ncclSocketRecv(sock, &connId, sizeof(int)), ret, fail);
+    if (type == ncclProxyMsgInit) {
+      asyncOp->connection = NULL;
+    } else {
+      NCCLCHECKGOTO(ncclProxyGetConnection(connectionPool, connId, &asyncOp->connection), ret, fail);
+    }
+  }
 
   NCCLCHECKGOTO(ncclSocketRecv(sock, &asyncOp->reqSize, sizeof(int)), ret, fail);
   NCCLCHECKGOTO(ncclSocketRecv(sock, &asyncOp->respSize, sizeof(int)), ret, fail);

--- a/projects/rccl/src/proxy.cc
+++ b/projects/rccl/src/proxy.cc
@@ -1487,6 +1487,10 @@ static ncclResult_t proxyConnInit(struct ncclProxyLocalPeer* peer, struct ncclPr
   NCCLCHECK(ncclProxyNewConnection(connectionPool, &id));
   NCCLCHECK(ncclProxyGetConnection(connectionPool, id, connection));
 
+  if ((unsigned)req->tpLocalRank >= (unsigned)proxyState->tpLocalnRanks) {
+    WARN("proxyConnInit: tpLocalRank %d out of range [0,%d)", req->tpLocalRank, proxyState->tpLocalnRanks);
+    return ncclInvalidArgument;
+  }
   (*connection)->sock = &peer->sock;
   (*connection)->transport = req->transport;
   (*connection)->send = req->send;

--- a/projects/rccl/src/proxy.cc
+++ b/projects/rccl/src/proxy.cc
@@ -1484,13 +1484,14 @@ ncclResult_t ncclProxyShmUnlink(struct ncclComm* comm) {
 
 static ncclResult_t proxyConnInit(struct ncclProxyLocalPeer* peer, struct ncclProxyConnectionPool* connectionPool, struct ncclProxyState* proxyState, ncclProxyInitReq* req, ncclProxyInitResp* resp, struct ncclProxyConnection** connection) {
   int id;
-  NCCLCHECK(ncclProxyNewConnection(connectionPool, &id));
-  NCCLCHECK(ncclProxyGetConnection(connectionPool, id, connection));
 
   if ((unsigned)req->tpLocalRank >= (unsigned)proxyState->tpLocalnRanks) {
     WARN("proxyConnInit: tpLocalRank %d out of range [0,%d)", req->tpLocalRank, proxyState->tpLocalnRanks);
     return ncclInvalidArgument;
   }
+
+  NCCLCHECK(ncclProxyNewConnection(connectionPool, &id));
+  NCCLCHECK(ncclProxyGetConnection(connectionPool, id, connection));
   (*connection)->sock = &peer->sock;
   (*connection)->transport = req->transport;
   (*connection)->send = req->send;

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -814,6 +814,10 @@ static ncclResult_t sharedNetBuffersInit(struct ncclProxyState* proxyState, int 
       WARN("PXN should not use host buffers for data");
       return ncclInternalError;
   }
+  if ((unsigned)tpLocalRank >= (unsigned)proxyState->tpLocalnRanks) {
+    WARN("sharedNetBuffersInit: tpLocalRank %d out of range [0,%d)", tpLocalRank, proxyState->tpLocalnRanks);
+    return ncclInvalidArgument;
+  }
   struct ncclProxyProgressState* progressState = &proxyState->progressState;
   if (progressState->localPeers == NULL) {
     NCCLCHECK(ncclCalloc(&progressState->localPeers, proxyState->tpLocalnRanks));
@@ -868,6 +872,10 @@ static ncclResult_t sharedBuffersGet(struct ncclProxyState* proxyState, int chan
 }
 
 static ncclResult_t sharedNetBuffersDestroy(struct ncclProxyState* proxyState, int tpLocalRank, int type, struct ncclProxyConnection* connection) {
+  if ((unsigned)tpLocalRank >= (unsigned)proxyState->tpLocalnRanks) {
+    WARN("sharedNetBuffersDestroy: tpLocalRank %d out of range [0,%d)", tpLocalRank, proxyState->tpLocalnRanks);
+    return ncclInvalidArgument;
+  }
   if (proxyState->progressState.localPeers == NULL) NCCLCHECK(ncclInternalError);
   struct ncclProxyPeer* peer = proxyState->progressState.localPeers[tpLocalRank];
   if (peer == NULL) NCCLCHECK(ncclInternalError);
@@ -907,6 +915,10 @@ static ncclResult_t proxySharedInit(struct ncclProxyConnection* connection, stru
 static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   struct setupReq* req = (struct setupReq*) reqBuff;
   if (reqSize != sizeof(struct setupReq)) return ncclInternalError;
+  if ((unsigned)req->tpLocalRank >= (unsigned)proxyState->tpLocalnRanks) {
+    WARN("sendProxySetup: tpLocalRank %d out of range [0,%d)", req->tpLocalRank, proxyState->tpLocalnRanks);
+    return ncclInvalidArgument;
+  }
 
   struct sendNetResources* resources;
   NCCLCHECK(ncclCalloc(&resources, 1));
@@ -956,6 +968,10 @@ static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struc
 static ncclResult_t recvProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   struct setupReq* req = (struct setupReq*) reqBuff;
   if (reqSize != sizeof(struct setupReq)) return ncclInternalError;
+  if ((unsigned)req->tpLocalRank >= (unsigned)proxyState->tpLocalnRanks) {
+    WARN("recvProxySetup: tpLocalRank %d out of range [0,%d)", req->tpLocalRank, proxyState->tpLocalnRanks);
+    return ncclInvalidArgument;
+  }
 
   struct recvNetResources* resources;
   NCCLCHECK(ncclCalloc(&resources, 1));

--- a/projects/rccl/test/ProxyTests.cpp
+++ b/projects/rccl/test/ProxyTests.cpp
@@ -3,6 +3,7 @@
  *
  * See LICENSE.txt for license information
  ************************************************************************/
+#include <climits>
 #include "collectives.h"
 #include "comm.h"
 #include "gtest/gtest.h"
@@ -479,6 +480,50 @@ TEST(ProxyTests, ncclProxyClientQueryFdBlocking)
             TEST_INFO("Test 'ncclProxyClientQueryFdBlocking' PASSED");
         }
     );
+}
+
+// Regression tests for proxy connection pool bounds checking.
+// Bug 1: before the fix, the wire sent a raw void* that the server dereferenced directly.
+// These tests verify that ncclProxyGetConnection rejects every malformed integer ID that an
+// attacker could substitute for a legitimate connId received over the proxy socket.
+TEST(ProxyTests, ProxyConnectionPoolBoundsCheck)
+{
+    TEST_INFO("[ProxyTests] ProxyConnectionPoolBoundsCheck start");
+
+    // Build a minimal pool manually: 1 bank, 2 initialized slots (offset = 2).
+    // We bypass ncclProxyNewConnection so the test has no runtime dependencies.
+    struct ncclProxyConnection conns[NCCL_PROXY_CONN_POOL_SIZE] = {};
+    struct ncclProxyConnection* bank0 = conns;
+    struct ncclProxyConnectionPool pool;
+    pool.pools  = &bank0;
+    pool.banks  = 1;
+    pool.offset = 2; // slots 0 and 1 are valid
+
+    struct ncclProxyConnection* out = nullptr;
+
+    // Valid IDs must succeed.
+    EXPECT_EQ(ncclProxyGetConnection(&pool, 0, &out), ncclSuccess);
+    EXPECT_EQ(out, &conns[0]);
+    EXPECT_EQ(ncclProxyGetConnection(&pool, 1, &out), ncclSuccess);
+    EXPECT_EQ(out, &conns[1]);
+
+    // Negative ID — primary regression: wire attacker sends e.g. -1 to force arbitrary deref.
+    EXPECT_EQ(ncclProxyGetConnection(&pool, -1, &out), ncclInvalidArgument);
+    EXPECT_EQ(ncclProxyGetConnection(&pool, INT_MIN, &out), ncclInvalidArgument);
+
+    // ID at or past high-water mark — slot was allocated but never initialized.
+    EXPECT_EQ(ncclProxyGetConnection(&pool, 2, &out), ncclInvalidArgument);
+    EXPECT_EQ(ncclProxyGetConnection(&pool, NCCL_PROXY_CONN_POOL_SIZE - 1, &out), ncclInvalidArgument);
+
+    // ID whose bank index exceeds the number of allocated banks.
+    EXPECT_EQ(ncclProxyGetConnection(&pool, NCCL_PROXY_CONN_POOL_SIZE, &out), ncclInvalidArgument);
+    EXPECT_EQ(ncclProxyGetConnection(&pool, INT_MAX, &out), ncclInvalidArgument);
+
+    // Null pool (no banks allocated).
+    struct ncclProxyConnectionPool emptyPool = {nullptr, 0, 0};
+    EXPECT_EQ(ncclProxyGetConnection(&emptyPool, 0, &out), ncclInvalidArgument);
+
+    TEST_INFO("[ProxyTests] ProxyConnectionPoolBoundsCheck PASSED");
 }
 
 } // namespace RcclUnitTesting


### PR DESCRIPTION
## Summary
Tightens input validation on the RCCL proxy RPC setup path so a malformed message from a peer can't be turned into an out-of-bounds read or an arbitrary indirect call. Tracked under ROCM-24271.

**Why.** The proxy setup handler trusted two values that arrive over the wire: an opaque connection identifier that it dereferenced, and a peer-rank index it used directly into a fixed-size table. Either one, if forged, gave a peer more reach into the local process than it should have. Both are inherited from the upstream NCCL design.

**How.**
- Replace the wire-side connection identifier with a small integer handle that the server resolves through the existing connection-pool accessor. The accessor already validates the handle and rejects anything out of range, so no value from the peer is dereferenced directly anymore.
- Bounds-check the peer-rank index against the known local-rank count at every site that uses it to index the per-peer table. Any value that doesn't fit returns an error instead of indexing past the end.

Both changes live in setup paths that run once per channel x peer at communicator init, so there is no hot-path impact.

## Test plan
- [x] New gtest covers valid handles, negatives, boundary, and overflow cases for the connection-pool accessor.
- [x] rccl-tests on 2 nodes — exercises the proxy connection path end to end; no regressions.
- [ ] Full RCCL UT suite on MI300