### PR TITLE
[rocprofiler-compute] Add gfx1151 dual-issue VALU metric and RDNA SOL docs

### DIFF
--- a/projects/rocprofiler-compute/docs/conceptual/rdna/system-speed-of-light.rst
+++ b/projects/rocprofiler-compute/docs/conceptual/rdna/system-speed-of-light.rst
@@ -14,6 +14,58 @@ shipped gfx1151 analysis configuration.
 metrics for how your workload is performing on the target GPU, so you can spot
 bottlenecks before diving into block-specific panels.
 
+VALU FLOPs rows use aggregate VALU instruction counters (they do not split FP16,
+FP32, and FP64). WMMA follows a separate ISA path and is not broken out in this panel.
+
+Wavefronts and FLOPs accounting
+--------------------------------
+
+RDNA 3.5 supports both Wave32 (typical primary mode) and Wave64 wavefronts;
+wavefront size is fixed per kernel at compile time. The profiler’s ``$wave_size``
+comes from hardware discovery (for example ``rocminfo``), while the executing kernel
+may use a different size—treat peaks as approximate when those differ. VALU FLOPs
+in this panel scale roughly as ``wave_size × SQ_INSTS_VALU_sum / time``.
+
+Peak theoretical VALU rates (per CU, before multiplying by CU count and clock)
+---------------------------------------------------------------------------------
+
+These ceilings explain how POP (% of peak) is anchored for FLOPs-oriented rows:
+
+* FP32 FMA, single-issue: 128 FLOPs/CU/cycle — two SIMD32 lanes per CU
+  (``$simd_per_cu``), Wave32 (``$wave_size`` 32), times two for FMA.
+* FP32 VOPD dual-issue: 256 FLOPs/CU/cycle (paired dual-VALU ops such as
+  ``V_DUAL_ADD_F32`` / ``V_DUAL_MUL_F32``).
+* FP16 packed FMA, single-issue: 256 FLOPs/CU/cycle (packed half-rate vs FP32).
+* FP16 packed VOPD dual-issue: 512 FLOPs/CU/cycle (dual-issue packed half ops).
+* FP64 FMA: 4 FLOPs/CU/cycle — 1/32 of the FP32 single-issue FMA rate on RDNA.
+* Mixed FP32 single-issue plus FP16 packed dual-issue (illustrative ceiling):
+  about 384 FLOPs/CU/cycle combined (128 + 256).
+
+Scaling and clocks
+------------------
+
+``$cu_per_gpu`` is the total CU count from system info, not WGP count. On RDNA 3.5,
+each WGP pairs two CUs, so CU count is approximately twice the WGP count; peak
+FLOPs scale with CUs. ``$max_sclk`` is the shader/engine clock in MHz from profiler
+system specs.
+
+Bandwidth and cache POP rows
+----------------------------
+
+TCP, GL1C, GL2C, and SQC throughput POP values use heuristic ceilings (bytes per
+cycle × instance count × clock). They are not tied to a single public RDNA 3.5 table—
+treat Pct of Peak as indicative, not exact.
+
+Memory hierarchy (for context): GL0 (TCP) → GL1 → GL2 → system memory (GCEA).
+
+.. tip::
+
+   If Pct of Peak for VALU FLOPs goes above 100%, the assumed peak likely underestimates
+   achievable throughput—for example when the kernel uses VOPD dual-issue or heavy packed
+   FP16 instead of the single-issue FP32 FMA baseline. Inspect the ``Instructions - Dual VALU (VOPD)``
+   metric on the :doc:`wgp` panel (counter ``SQ_INSTS_DUAL_VALU_WAVE32``) to gauge dual-issue
+   activity and interpret POP accordingly.
+
 .. Note::
    For AMD Instinct accelerators (CDNA-CDNA4), see
    :doc:`../cdna/system-speed-of-light`.

--- a/projects/rocprofiler-compute/docs/conceptual/rdna/system-speed-of-light.rst
+++ b/projects/rocprofiler-compute/docs/conceptual/rdna/system-speed-of-light.rst
@@ -14,16 +14,16 @@ shipped gfx1151 analysis configuration.
 metrics for how your workload is performing on the target GPU, so you can spot
 bottlenecks before diving into block-specific panels.
 
-VALU FLOPs rows use aggregate VALU instruction counters (they do not split FP16,
-FP32, and FP64). WMMA follows a separate ISA path and is not broken out in this panel.
+VALU FLOPs rows use aggregate VALU instruction counters (they include FP16, FP32,
+and FP64). WMMA follows a separate ISA path and is not broken out in this panel.
 
 Wavefronts and FLOPs accounting
 --------------------------------
 
 RDNA 3.5 supports both Wave32 (typical primary mode) and Wave64 wavefronts;
-wavefront size is fixed per kernel at compile time. The profiler’s ``$wave_size``
-comes from hardware discovery (for example ``rocminfo``), while the executing kernel
-may use a different size—treat peaks as approximate when those differ. VALU FLOPs
+wavefront size is fixed per kernel at compile time. The profiler's ``$wave_size``
+depends on the hardware architecture (i.e., ``rocminfo``), while the executing kernel
+may use a different size—treat peaks as an approximation when those differ. VALU FLOPs
 in this panel scale roughly as ``wave_size * SQ_INSTS_VALU_sum / time``.
 
 Peak theoretical VALU rates (per CU, before multiplying by CU count and clock)

--- a/projects/rocprofiler-compute/docs/conceptual/rdna/system-speed-of-light.rst
+++ b/projects/rocprofiler-compute/docs/conceptual/rdna/system-speed-of-light.rst
@@ -53,7 +53,7 @@ Bandwidth and cache POP rows
 ----------------------------
 
 TCP, GL1, GL2, and SQC throughput POP values use heuristic ceilings (bytes per
-cycle × instance count × clock). They are not tied to a single public RDNA 3.5 table—
+cycle * instance count * clock). They are not tied to a single public RDNA 3.5 table—
 treat Pct of Peak as indicative, not exact.
 
 Memory hierarchy (for context): GL0 (TCP) → GL1 → GL2 → system memory (GCEA).

--- a/projects/rocprofiler-compute/docs/conceptual/rdna/system-speed-of-light.rst
+++ b/projects/rocprofiler-compute/docs/conceptual/rdna/system-speed-of-light.rst
@@ -52,7 +52,7 @@ system specs.
 Bandwidth and cache POP rows
 ----------------------------
 
-TCP, GL1C, GL2C, and SQC throughput POP values use heuristic ceilings (bytes per
+TCP, GL1, GL2, and SQC throughput POP values use heuristic ceilings (bytes per
 cycle × instance count × clock). They are not tied to a single public RDNA 3.5 table—
 treat Pct of Peak as indicative, not exact.
 

--- a/projects/rocprofiler-compute/docs/conceptual/rdna/system-speed-of-light.rst
+++ b/projects/rocprofiler-compute/docs/conceptual/rdna/system-speed-of-light.rst
@@ -24,7 +24,7 @@ RDNA 3.5 supports both Wave32 (typical primary mode) and Wave64 wavefronts;
 wavefront size is fixed per kernel at compile time. The profiler’s ``$wave_size``
 comes from hardware discovery (for example ``rocminfo``), while the executing kernel
 may use a different size—treat peaks as approximate when those differ. VALU FLOPs
-in this panel scale roughly as ``wave_size × SQ_INSTS_VALU_sum / time``.
+in this panel scale roughly as ``wave_size * SQ_INSTS_VALU_sum / time``.
 
 Peak theoretical VALU rates (per CU, before multiplying by CU count and clock)
 ---------------------------------------------------------------------------------

--- a/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
+++ b/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
@@ -288,6 +288,9 @@ Wave Instruction Mix:
   Instructions - LDS:
     rst: 'Number of Local Data Share instructions executed. LDS provides fast shared memory within a workgroup. High counts indicate active use of shared memory for inter-work-item communication.'
     unit: Count per Normalization Unit
+  Instructions - Dual VALU (VOPD):
+    rst: 'Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum), per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip interface); emulated counter.'
+    unit: Count per Normalization Unit
   Instructions - Internal:
     rst: 'Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit — bookkeeping or non-user-visible work attributed to the scheduler.'
     unit: Count per Normalization Unit

--- a/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
+++ b/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
@@ -282,14 +282,14 @@ Wave Instruction Mix:
   Instructions - SMEM:
     rst: 'Number of scalar memory instructions executed. SMEM loads constant and uniform data through the scalar cache. High counts may indicate heavy use of constant buffers or kernel arguments.'
     unit: Count per Normalization Unit
+  Instructions - Dual VALU (VOPD):
+    rst: 'Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum), per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip interface); emulated counter.'
+    unit: Count per Normalization Unit
   Instructions - VMEM:
     rst: 'Number of vector memory instructions executed, including global, buffer, and texture operations. High VMEM counts relative to VALU may indicate memory-bound workloads.'
     unit: Count per Normalization Unit
   Instructions - LDS:
     rst: 'Number of Local Data Share instructions executed. LDS provides fast shared memory within a workgroup. High counts indicate active use of shared memory for inter-work-item communication.'
-    unit: Count per Normalization Unit
-  Instructions - Dual VALU (VOPD):
-    rst: 'Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum), per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip interface); emulated counter.'
     unit: Count per Normalization Unit
   Instructions - Internal:
     rst: 'Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit — bookkeeping or non-user-visible work attributed to the scheduler.'

--- a/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
+++ b/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
@@ -273,6 +273,9 @@ Wave Instruction Mix:
   Total Instructions:
     rst: 'Total number of instructions executed across all wavefronts. This provides an overall measure of computational work. Compare with specific instruction types to understand the workload characteristics.'
     unit: Count per Normalization Unit
+  Instructions - Internal:
+    rst: 'Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit — bookkeeping or non-user-visible work attributed to the scheduler.'
+    unit: Count per Normalization Unit
   Instructions - VALU:
     rst: 'Number of Vector ALU instructions executed. VALU handles arithmetic and logic operations across all work-items in a wavefront. High VALU counts indicate compute-intensive kernels.'
     unit: Count per Normalization Unit
@@ -282,6 +285,9 @@ Wave Instruction Mix:
   Instructions - SMEM:
     rst: 'Number of scalar memory instructions executed. SMEM loads constant and uniform data through the scalar cache. High counts may indicate heavy use of constant buffers or kernel arguments.'
     unit: Count per Normalization Unit
+  Instructions - Transcendental:
+    rst: 'Transcendental VALU instructions (SQ_INSTS_VALU_TRANS), per normalization unit — e.g. sin/cos/log approximations on the vector ALU.'
+    unit: Count per Normalization Unit
   Instructions - Dual VALU (VOPD):
     rst: 'Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum), per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip interface); emulated counter.'
     unit: Count per Normalization Unit
@@ -290,12 +296,6 @@ Wave Instruction Mix:
     unit: Count per Normalization Unit
   Instructions - LDS:
     rst: 'Number of Local Data Share instructions executed. LDS provides fast shared memory within a workgroup. High counts indicate active use of shared memory for inter-work-item communication.'
-    unit: Count per Normalization Unit
-  Instructions - Internal:
-    rst: 'Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit — bookkeeping or non-user-visible work attributed to the scheduler.'
-    unit: Count per Normalization Unit
-  Instructions - Transcendental:
-    rst: 'Transcendental VALU instructions (SQ_INSTS_VALU_TRANS), per normalization unit — e.g. sin/cos/log approximations on the vector ALU.'
     unit: Count per Normalization Unit
 LDS Instruction Mix:
   LDS Direct Load Instructions:

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0700_workgroup_processor.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0700_workgroup_processor.yaml
@@ -154,6 +154,11 @@ Panel Config:
           min: MIN(SQ_INSTS_VALU_TRANS_sum / $denom)
           max: MAX(SQ_INSTS_VALU_TRANS_sum / $denom)
           unit: (Count + $normUnit)
+        Instructions - Dual VALU (VOPD):
+          avg: SUM(SQ_INSTS_DUAL_VALU_WAVE32_sum) / SUM($denom)
+          min: MIN(SQ_INSTS_DUAL_VALU_WAVE32_sum / $denom)
+          max: MAX(SQ_INSTS_DUAL_VALU_WAVE32_sum / $denom)
+          unit: (Count + $normUnit)
         Instructions - VMEM:
           avg: SUM(SQ_INSTS_TEX_sum) / SUM($denom)
           min: MIN(SQ_INSTS_TEX_sum / $denom)
@@ -340,6 +345,10 @@ Panel Config:
       Number of Local Data Share instructions executed. LDS provides fast shared memory
       within a workgroup. High counts indicate active use of shared memory for
       inter-work-item communication.
+    Instructions - Dual VALU (VOPD): >-
+      Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum),
+      per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip
+      interface); emulated counter.
     LDS Direct Load Instructions: >-
       Number of direct LDS load instructions. Direct loads fetch data from LDS without
       address indirection. These are typically faster than indexed LDS operations.

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0700_workgroup_processor.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0700_workgroup_processor.yaml
@@ -325,6 +325,9 @@ Panel Config:
       Total number of instructions executed across all wavefronts. This provides an
       overall measure of computational work. Compare with specific instruction types
       to understand the workload characteristics.
+    Instructions - Internal: >-
+      Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit — bookkeeping
+      or non-user-visible work attributed to the scheduler.
     Instructions - VALU: >-
       Number of Vector ALU instructions executed. VALU handles arithmetic and logic
       operations across all work-items in a wavefront. High VALU counts indicate
@@ -337,6 +340,9 @@ Panel Config:
       Number of scalar memory instructions executed. SMEM loads constant and uniform
       data through the scalar cache. High counts may indicate heavy use of constant
       buffers or kernel arguments.
+    Instructions - Transcendental: >-
+      Transcendental VALU instructions (SQ_INSTS_VALU_TRANS), per normalization unit —
+      e.g. sin/cos/log approximations on the vector ALU.
     Instructions - Dual VALU (VOPD): >-
       Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum),
       per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0700_workgroup_processor.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0700_workgroup_processor.yaml
@@ -337,6 +337,10 @@ Panel Config:
       Number of scalar memory instructions executed. SMEM loads constant and uniform
       data through the scalar cache. High counts may indicate heavy use of constant
       buffers or kernel arguments.
+    Instructions - Dual VALU (VOPD): >-
+      Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum),
+      per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip
+      interface); emulated counter.
     Instructions - VMEM: >-
       Number of vector memory instructions executed, including global, buffer, and
       texture operations. High VMEM counts relative to VALU may indicate memory-bound
@@ -345,10 +349,6 @@ Panel Config:
       Number of Local Data Share instructions executed. LDS provides fast shared memory
       within a workgroup. High counts indicate active use of shared memory for
       inter-work-item communication.
-    Instructions - Dual VALU (VOPD): >-
-      Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum),
-      per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip
-      interface); emulated counter.
     LDS Direct Load Instructions: >-
       Number of direct LDS load instructions. Direct loads fetch data from LDS without
       address indirection. These are typically faster than indexed LDS operations.

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/sdk_config.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/sdk_config.yaml
@@ -2551,6 +2551,15 @@ rocprofiler-sdk:
       - gfx1152
       block: SQ
       event: 173
+  - name: SQ_INSTS_DUAL_VALU_WAVE32
+    description: >-
+      Number of dual VALU (VOPD) instructions issued in wave32 mode. {emulated} Matches SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 in Strix2 chip interface public RAI.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      block: SQ
+      event: 178
   - name: SQ_ITEMS
     description: Number of valid items per wave. This value is returned on a per-SE (aggregate of values in SIMDs in the SE)
       basis.
@@ -4042,6 +4051,13 @@ rocprofiler-sdk:
       - gfx1151
       - gfx1152
       expression: reduce(SQ_INSTS_WAVE32_LDS_PARAM_LOAD,sum)
+  - name: SQ_INSTS_DUAL_VALU_WAVE32_sum
+    description: sum of SQ INSTS DUAL VALU WAVE32.
+    properties: []
+    definitions:
+    - architectures:
+      - gfx1151
+      expression: reduce(SQ_INSTS_DUAL_VALU_WAVE32,sum)
   - name: SQ_ITEMS_sum
     description: ''
     properties: []

--- a/projects/rocprofiler-compute/src/utils/.config_hashes.json
+++ b/projects/rocprofiler-compute/src/utils/.config_hashes.json
@@ -1,8 +1,4 @@
 {
-  "metric_descriptions": {
-    "docs/data/metrics/gfx1151_metrics.yaml": "b6f21005715adda9c273fa25136fb653",
-    "tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml": "80e425def77f6f498f8e20c5159b5967"
-  },
   "archs": {
     "gfx1151": {
       "delta_hash": null,
@@ -14,7 +10,7 @@
         "0400_roofline.yaml": "17b62eb17edee43abd833576a7c142a4",
         "0500_command_processor_cpc.yaml": "9de95259d153357dde907a7a410aa1a3",
         "0600_workgroup_manager_spi.yaml": "e0fb474a8a5e97cf26467578f7b5c316",
-        "0700_workgroup_processor.yaml": "387623621a8b785069acb92b0b4e307a",
+        "0700_workgroup_processor.yaml": "067de05bc8013b66d8f74610d300237e",
         "0900_l0_cache.yaml": "1cbfbc0badeed8ec0caa178faec2f231",
         "1100_l1_cache.yaml": "7403eeb9b47f69f73cf42eccb984cdf7",
         "1300_l2_cache.yaml": "dd34f4b6cbdbb8afbafa059b58ba9839",
@@ -161,5 +157,9 @@
         "3000_mem_bw.yaml": "bdc167a85a3bffd439fb4d651b3c2df8"
       }
     }
+  },
+  "metric_descriptions": {
+    "docs/data/metrics/gfx1151_metrics.yaml": "b27756a33c53826c70f4e5d1edf9f884",
+    "tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml": "c19b9cdeb2ee3dfea1ed1a7b8c1a923f"
   }
 }

--- a/projects/rocprofiler-compute/src/utils/.config_hashes.json
+++ b/projects/rocprofiler-compute/src/utils/.config_hashes.json
@@ -1,4 +1,8 @@
 {
+  "metric_descriptions": {
+    "docs/data/metrics/gfx1151_metrics.yaml": "b6f21005715adda9c273fa25136fb653",
+    "tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml": "80e425def77f6f498f8e20c5159b5967"
+  },
   "archs": {
     "gfx1151": {
       "delta_hash": null,
@@ -10,7 +14,7 @@
         "0400_roofline.yaml": "17b62eb17edee43abd833576a7c142a4",
         "0500_command_processor_cpc.yaml": "9de95259d153357dde907a7a410aa1a3",
         "0600_workgroup_manager_spi.yaml": "e0fb474a8a5e97cf26467578f7b5c316",
-        "0700_workgroup_processor.yaml": "b897fd049e35b9198be1a2b0ca237a78",
+        "0700_workgroup_processor.yaml": "387623621a8b785069acb92b0b4e307a",
         "0900_l0_cache.yaml": "1cbfbc0badeed8ec0caa178faec2f231",
         "1100_l1_cache.yaml": "7403eeb9b47f69f73cf42eccb984cdf7",
         "1300_l2_cache.yaml": "dd34f4b6cbdbb8afbafa059b58ba9839",

--- a/projects/rocprofiler-compute/src/utils/.config_hashes.json
+++ b/projects/rocprofiler-compute/src/utils/.config_hashes.json
@@ -10,7 +10,7 @@
         "0400_roofline.yaml": "17b62eb17edee43abd833576a7c142a4",
         "0500_command_processor_cpc.yaml": "9de95259d153357dde907a7a410aa1a3",
         "0600_workgroup_manager_spi.yaml": "e0fb474a8a5e97cf26467578f7b5c316",
-        "0700_workgroup_processor.yaml": "067de05bc8013b66d8f74610d300237e",
+        "0700_workgroup_processor.yaml": "1a4d1286cb2a55e55b3475c95258e309",
         "0900_l0_cache.yaml": "1cbfbc0badeed8ec0caa178faec2f231",
         "1100_l1_cache.yaml": "7403eeb9b47f69f73cf42eccb984cdf7",
         "1300_l2_cache.yaml": "dd34f4b6cbdbb8afbafa059b58ba9839",
@@ -159,7 +159,7 @@
     }
   },
   "metric_descriptions": {
-    "docs/data/metrics/gfx1151_metrics.yaml": "b27756a33c53826c70f4e5d1edf9f884",
-    "tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml": "c19b9cdeb2ee3dfea1ed1a7b8c1a923f"
+    "docs/data/metrics/gfx1151_metrics.yaml": "c54d280f0154875bfd647607c8c9accc",
+    "tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml": "7b463b26f61901a6098cd10ccae476db"
   }
 }

--- a/projects/rocprofiler-compute/src/utils/.config_hashes.json
+++ b/projects/rocprofiler-compute/src/utils/.config_hashes.json
@@ -157,9 +157,5 @@
         "3000_mem_bw.yaml": "bdc167a85a3bffd439fb4d651b3c2df8"
       }
     }
-  },
-  "metric_descriptions": {
-    "docs/data/metrics/gfx1151_metrics.yaml": "c54d280f0154875bfd647607c8c9accc",
-    "tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml": "7b463b26f61901a6098cd10ccae476db"
   }
 }

--- a/projects/rocprofiler-compute/tests/test_autogen_config.py
+++ b/projects/rocprofiler-compute/tests/test_autogen_config.py
@@ -10,6 +10,7 @@ import pytest
 
 HASH_DB = Path(common.SRC) / "utils/.config_hashes.json"
 ANALYSIS_CONFIGS = Path(common.SRC) / "rocprof_compute_soc/analysis_configs"
+REPO_ROOT = Path(common.ROOT)
 
 
 def md5(path: Path) -> str:
@@ -90,3 +91,34 @@ def test_config_hashes_match_files() -> None:
 
     if failures:
         pytest.fail("Hash consistency failures:\n\n" + "\n".join(failures))
+
+
+def test_metric_description_hashes_match_files() -> None:
+    """Tracked metric-description artifacts (per-arch YAML + generated docs)."""
+    assert HASH_DB.exists(), f"Missing hash DB: {HASH_DB}"
+
+    with HASH_DB.open() as f:
+        data = json.load(f)
+
+    tracked = data.get("metric_descriptions") or {}
+    if not tracked:
+        return
+
+    failures: list[str] = []
+    for rel_path, expected_hash in tracked.items():
+        artifact_path = REPO_ROOT / rel_path
+        if not artifact_path.exists():
+            failures.append(f"Missing metric description file: {artifact_path}")
+            continue
+        actual_hash = md5(artifact_path)
+        if actual_hash != expected_hash:
+            failures.append(
+                f"Metric description hash mismatch: {artifact_path}\n"
+                f"  expected: {expected_hash}\n"
+                f"  actual:   {actual_hash}"
+            )
+
+    if failures:
+        pytest.fail(
+            "Metric description hash failures:\n\n" + "\n".join(failures)
+        )

--- a/projects/rocprofiler-compute/tests/test_autogen_config.py
+++ b/projects/rocprofiler-compute/tests/test_autogen_config.py
@@ -119,6 +119,4 @@ def test_metric_description_hashes_match_files() -> None:
             )
 
     if failures:
-        pytest.fail(
-            "Metric description hash failures:\n\n" + "\n".join(failures)
-        )
+        pytest.fail("Metric description hash failures:\n\n" + "\n".join(failures))

--- a/projects/rocprofiler-compute/tools/config_management/README.md
+++ b/projects/rocprofiler-compute/tools/config_management/README.md
@@ -288,10 +288,10 @@ Panel YAMLs (src/) → Per-Arch YAMLs (tools/) → Docs YAMLs (docs/) → Sphinx
 **Files:**
 ```bash
 tools/per_arch_metric_definitions/
-  ├── gfx{908,90a,942,950}_metrics_description.yaml   # plain + rst + unit
+  ├── gfx{908,90a,942,950,1151}_metrics_description.yaml   # plain + rst + unit
 
 docs/data/metrics/
-  └── gfx{908,90a,942,950}_metrics.yaml               # rst + unit (generated)
+  └── gfx{908,90a,942,950,1151}_metrics.yaml               # rst + unit (generated)
 ```
 
 **After editing panel `metrics_description` sections:**
@@ -299,5 +299,18 @@ docs/data/metrics/
 python tools/config_management/metric_description_manager.py --sync-all src/rocprof_compute_soc/analysis_configs
 python tools/config_management/metric_description_manager.py --generate-docs
 ```
+
+To regenerate **only selected** docs metrics (for example gfx1151 without rewriting CDNA YAMLs):
+
+```bash
+python tools/config_management/metric_description_manager.py --generate-docs --docs-arch gfx1151
+```
+
+Then refresh **MD5 entries** under `metric_descriptions` in `src/utils/.config_hashes.json` for:
+
+- `tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml`
+- `docs/data/metrics/gfx1151_metrics.yaml`
+
+(`tests/test_autogen_config.py::test_metric_description_hashes_match_files` enforces these when present.)
 
 **RST enhancement:** Edit per-arch YAMLs directly. Framework preserves manual edits (detects when `rst != plain`).

--- a/projects/rocprofiler-compute/tools/config_management/metric_description_manager.py
+++ b/projects/rocprofiler-compute/tools/config_management/metric_description_manager.py
@@ -18,6 +18,7 @@ Usage (paths relative to project root):
     python $SCRIPT --sync-all $CONFIGS
     python $SCRIPT --validate <arch_name> $CONFIGS
     python $SCRIPT --generate-docs
+    python $SCRIPT --generate-docs --docs-arch gfx1151
 """
 
 from __future__ import annotations
@@ -574,6 +575,16 @@ def main() -> int:
         help="Generate per-arch docs YAMLs from per-arch definitions",
     )
     parser.add_argument(
+        "--docs-arch",
+        action="append",
+        metavar="ARCH",
+        dest="docs_archs",
+        help=(
+            "With --generate-docs, only emit docs for these architectures "
+            "(repeatable). Default: all per-arch *_metrics_description.yaml files."
+        ),
+    )
+    parser.add_argument(
         "configs_dir", nargs="?", help="Path to analysis_configs directory"
     )
     parser.add_argument(
@@ -590,7 +601,10 @@ def main() -> int:
     args = parser.parse_args()
 
     if args.generate_docs:
-        ok = generate_docs_from_per_arch(args.per_arch_output, args.docs_output_dir)
+        target_archs = args.docs_archs if args.docs_archs else None
+        ok = generate_docs_from_per_arch(
+            args.per_arch_output, args.docs_output_dir, target_archs
+        )
         return 0 if ok else 1
 
     if args.sync_arch:

--- a/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml
+++ b/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml
@@ -378,6 +378,10 @@ Wave Instruction Mix:
     plain: Number of Local Data Share instructions executed. LDS provides fast shared memory within a workgroup. High counts indicate active use of shared memory for inter-work-item communication.
     rst: Number of Local Data Share instructions executed. LDS provides fast shared memory within a workgroup. High counts indicate active use of shared memory for inter-work-item communication.
     unit: Count per Normalization Unit
+  Instructions - Dual VALU (VOPD):
+    plain: Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum), per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip interface); emulated counter.
+    rst: Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum), per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip interface); emulated counter.
+    unit: Count per Normalization Unit
   Instructions - Internal:
     plain: Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit — bookkeeping or non-user-visible work attributed to the scheduler.
     rst: Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit — bookkeeping or non-user-visible work attributed to the scheduler.

--- a/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml
+++ b/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml
@@ -370,6 +370,10 @@ Wave Instruction Mix:
     plain: Number of scalar memory instructions executed. SMEM loads constant and uniform data through the scalar cache. High counts may indicate heavy use of constant buffers or kernel arguments.
     rst: Number of scalar memory instructions executed. SMEM loads constant and uniform data through the scalar cache. High counts may indicate heavy use of constant buffers or kernel arguments.
     unit: Count per Normalization Unit
+  Instructions - Dual VALU (VOPD):
+    plain: Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum), per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip interface); emulated counter.
+    rst: Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum), per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip interface); emulated counter.
+    unit: Count per Normalization Unit
   Instructions - VMEM:
     plain: Number of vector memory instructions executed, including global, buffer, and texture operations. High VMEM counts relative to VALU may indicate memory-bound workloads.
     rst: Number of vector memory instructions executed, including global, buffer, and texture operations. High VMEM counts relative to VALU may indicate memory-bound workloads.
@@ -377,10 +381,6 @@ Wave Instruction Mix:
   Instructions - LDS:
     plain: Number of Local Data Share instructions executed. LDS provides fast shared memory within a workgroup. High counts indicate active use of shared memory for inter-work-item communication.
     rst: Number of Local Data Share instructions executed. LDS provides fast shared memory within a workgroup. High counts indicate active use of shared memory for inter-work-item communication.
-    unit: Count per Normalization Unit
-  Instructions - Dual VALU (VOPD):
-    plain: Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum), per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip interface); emulated counter.
-    rst: Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum), per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip interface); emulated counter.
     unit: Count per Normalization Unit
   Instructions - Internal:
     plain: Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit — bookkeeping or non-user-visible work attributed to the scheduler.

--- a/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml
+++ b/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml
@@ -358,6 +358,10 @@ Wave Instruction Mix:
     plain: Total number of instructions executed across all wavefronts. This provides an overall measure of computational work. Compare with specific instruction types to understand the workload characteristics.
     rst: Total number of instructions executed across all wavefronts. This provides an overall measure of computational work. Compare with specific instruction types to understand the workload characteristics.
     unit: Count per Normalization Unit
+  Instructions - Internal:
+    plain: Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit — bookkeeping or non-user-visible work attributed to the scheduler.
+    rst: Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit — bookkeeping or non-user-visible work attributed to the scheduler.
+    unit: Count per Normalization Unit
   Instructions - VALU:
     plain: Number of Vector ALU instructions executed. VALU handles arithmetic and logic operations across all work-items in a wavefront. High VALU counts indicate compute-intensive kernels.
     rst: Number of Vector ALU instructions executed. VALU handles arithmetic and logic operations across all work-items in a wavefront. High VALU counts indicate compute-intensive kernels.
@@ -370,6 +374,10 @@ Wave Instruction Mix:
     plain: Number of scalar memory instructions executed. SMEM loads constant and uniform data through the scalar cache. High counts may indicate heavy use of constant buffers or kernel arguments.
     rst: Number of scalar memory instructions executed. SMEM loads constant and uniform data through the scalar cache. High counts may indicate heavy use of constant buffers or kernel arguments.
     unit: Count per Normalization Unit
+  Instructions - Transcendental:
+    plain: Transcendental VALU instructions (SQ_INSTS_VALU_TRANS), per normalization unit — e.g. sin/cos/log approximations on the vector ALU.
+    rst: Transcendental VALU instructions (SQ_INSTS_VALU_TRANS), per normalization unit — e.g. sin/cos/log approximations on the vector ALU.
+    unit: Count per Normalization Unit
   Instructions - Dual VALU (VOPD):
     plain: Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum), per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip interface); emulated counter.
     rst: Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum), per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip interface); emulated counter.
@@ -381,14 +389,6 @@ Wave Instruction Mix:
   Instructions - LDS:
     plain: Number of Local Data Share instructions executed. LDS provides fast shared memory within a workgroup. High counts indicate active use of shared memory for inter-work-item communication.
     rst: Number of Local Data Share instructions executed. LDS provides fast shared memory within a workgroup. High counts indicate active use of shared memory for inter-work-item communication.
-    unit: Count per Normalization Unit
-  Instructions - Internal:
-    plain: Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit — bookkeeping or non-user-visible work attributed to the scheduler.
-    rst: Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit — bookkeeping or non-user-visible work attributed to the scheduler.
-    unit: Count per Normalization Unit
-  Instructions - Transcendental:
-    plain: Transcendental VALU instructions (SQ_INSTS_VALU_TRANS), per normalization unit — e.g. sin/cos/log approximations on the vector ALU.
-    rst: Transcendental VALU instructions (SQ_INSTS_VALU_TRANS), per normalization unit — e.g. sin/cos/log approximations on the vector ALU.
     unit: Count per Normalization Unit
 LDS Instruction Mix:
   LDS Direct Load Instructions:


### PR DESCRIPTION
## Motivation

Surface VOPD dual-issue on gfx1151 (SQ_INSTS_DUAL_VALU_WAVE32) and document how RDNA System Speed-of-Light peak FLOPs and POP relate to single-issue vs dual-issue VALU.

## Technical Details

- Wire SQ_INSTS_DUAL_VALU_WAVE32 into profiling config and WGP panel; refresh metric description hashes and autogen tests
- Expand RDNA System Speed-of-Light conceptual doc (peak model, heuristic bandwidth POP, cache path; tip when POP exceeds 100% to check dual-issue)
- Add optional `--docs-arch` to metric description manager for arch-scoped docs metric YAML sync

## JIRA ID



## Test Plan

- From repo root: `pytest projects/rocprofiler-compute/tests/test_autogen_config.py`

## Test Result

Pending

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


Made with [Cursor](https://cursor.com)