### PR TITLE
[RCCL] MemManager: wire allocators and transport free callbacks

### DIFF
--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SRC_FILES
   channel.cc
   collectives.cc
   commDump.cc
+  mem_manager.cc
   debug.cc
   dev_runtime.cc
   enqueue.cc
@@ -103,6 +104,7 @@ set(SRC_FILES
   include/ibvwrap.h
   include/info.h
   include/ipcsocket.h
+  include/mem_manager.h
   include/mnnvl.h
   include/nccl_common.h
   include/nccl_device.h

--- a/projects/rccl/src/allocator.cc
+++ b/projects/rccl/src/allocator.cc
@@ -126,7 +126,8 @@ ncclResult_t  ncclMemFree_impl(void *ptr) {
   CUCHECKGOTO(cuPointerGetAttribute((void*)&ptrDev, CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL, (CUdeviceptr)ptr), ret, fail);
   CUDACHECKGOTO(cudaSetDevice((int)ptrDev), ret, fail);
   if (ncclCuMemEnable()) {
-    NCCLCHECKGOTO(ncclCuMemFree(ptr), ret, fail);
+    // User facing API: memManager does not need to track user memory.
+    NCCLCHECKGOTO(ncclCuMemFree(ptr, /*manager=*/nullptr), ret, fail);
     goto exit;
   }
 

--- a/projects/rccl/src/channel.cc
+++ b/projects/rccl/src/channel.cc
@@ -39,10 +39,10 @@ ncclResult_t initChannel(struct ncclComm* comm, int channelId) {
 
   if (channel->devPeers == NULL) {
     if (sharedRes->devPeers[channelId] == NULL) {
-      NCCLCHECK(ncclCudaCallocAsync(sharedRes->devPeers + channelId, sharedRes->tpNRanks, deviceStream));
+      NCCLCHECK(ncclCudaCallocAsync(sharedRes->devPeers + channelId, sharedRes->tpNRanks, deviceStream, comm->memManager, ncclMemOffload));
     }
     /* channel->devPeers is not shared, so just free it when calling commFree() */
-    NCCLCHECK(ncclCudaCallocAsync(&channel->devPeers, nPeers, deviceStream));
+    NCCLCHECK(ncclCudaCallocAsync(&channel->devPeers, nPeers, deviceStream, comm->memManager, ncclMemOffload));
     ncclCommPushCudaFree(comm, channel->devPeers);
     NCCLCHECK(ncclCalloc(&channel->devPeersHostPtr, nPeers));
     for (int r = 0; r < nRanks; r++) {
@@ -53,7 +53,7 @@ ncclResult_t initChannel(struct ncclComm* comm, int channelId) {
   }
 
   channel->ring.userRanks = ncclMemoryStackAlloc<int>(&comm->memPermanent, nRanks);
-  NCCLCHECK(ncclCudaCallocAsync(&channel->devRingUserRanks, nRanks, deviceStream));
+  NCCLCHECK(ncclCudaCallocAsync(&channel->devRingUserRanks, nRanks, deviceStream, comm->memManager, ncclMemOffload));
   ncclCommPushCudaFree(comm, channel->devRingUserRanks);
 
   /* guarantee addr has been copied into channel->devPeers */
@@ -90,7 +90,7 @@ ncclResult_t initNvlsChannel(struct ncclComm* comm, int channelId, struct ncclCo
     }
   } else {
     NCCLCHECK(ncclCalloc(&channel->nvlsPeers, nvlsRanks));
-    NCCLCHECK(ncclCudaCallocAsync(&channel->nvlsDevPeers, nvlsRanks, deviceStream));
+    NCCLCHECK(ncclCudaCallocAsync(&channel->nvlsDevPeers, nvlsRanks, deviceStream, comm->memManager));
     for (int r = 0; r < nvlsRanks; ++r) {
       uintptr_t addr = (uintptr_t)(channel->nvlsDevPeers + r);
       channel->peers[comm->nRanks + 1 + r] = channel->nvlsPeers + r;
@@ -130,7 +130,7 @@ ncclResult_t initCollnetChannel(struct ncclComm* comm, int channelId, struct ncc
     ncclAtomicRefCountIncrement(&parent->channels[channelId].collnetPeers->refCount);
   } else {
     NCCLCHECK(ncclCalloc(&channel->collnetPeers, 1));
-    NCCLCHECK(ncclCudaCallocAsync(&channel->collnetDevPeers, 1, deviceStream));
+    NCCLCHECK(ncclCudaCallocAsync(&channel->collnetDevPeers, 1, deviceStream, comm->memManager));
     addr = (uintptr_t)channel->collnetDevPeers;
     channel->peers[comm->nRanks] = channel->collnetPeers;
     NCCLCHECK(ncclCudaMemcpyAsync((uintptr_t*)(channel->devPeers + comm->nRanks), (uintptr_t*)&addr, 1, deviceStream));
@@ -144,7 +144,7 @@ ncclResult_t initCollnetChannel(struct ncclComm* comm, int channelId, struct ncc
   return ncclSuccess;
 }
 
-ncclResult_t freeChannel(struct ncclChannel* channel, int nRanks, int collnetNRanks, int nvlsNRanks) {
+ncclResult_t freeChannel(struct ncclChannel* channel, int nRanks, int collnetNRanks, int nvlsNRanks, struct ncclComm* comm) {
   int nPeers = nRanks + collnetNRanks + nvlsNRanks;
   /* channel peers are only valid when async init thread completes commAlloc() and
    * the channel is initialized with initChannel(); if either is not done, this channel
@@ -158,15 +158,15 @@ ncclResult_t freeChannel(struct ncclChannel* channel, int nRanks, int collnetNRa
     if (peer) {
       if (ncclAtomicRefCountDecrement(&peer->refCount) == 0) {
         for (int b=0; b<NCCL_MAX_CONNS; b++) {
-          if (peer->send[b].transportComm) NCCLCHECK(peer->send[b].transportComm->free(peer->send+b));
-          if (peer->recv[b].transportComm) NCCLCHECK(peer->recv[b].transportComm->free(peer->recv+b));
+          if (peer->send[b].transportComm) NCCLCHECK(peer->send[b].transportComm->free(comm, peer->send+b));
+          if (peer->recv[b].transportComm) NCCLCHECK(peer->recv[b].transportComm->free(comm, peer->recv+b));
         }
         if (r == nRanks) {
           free(channel->collnetPeers);
-          ncclCudaFree(channel->collnetDevPeers);
+          ncclCudaFree(channel->collnetDevPeers, comm->memManager);
         } else if (r == nPeers - 1) {
           free(channel->nvlsPeers);
-          ncclCudaFree(channel->nvlsDevPeers);
+          ncclCudaFree(channel->nvlsDevPeers, comm->memManager);
         }
       }
     }

--- a/projects/rccl/src/include/alloc.h
+++ b/projects/rccl/src/include/alloc.h
@@ -313,6 +313,22 @@ extern struct allocationTracker allocTracker[];
 
 #include "rocmwrap.h"
 
+// Helper function to map memory and set access permissions for a device
+static inline ncclResult_t ncclCuMemMapAndSetAccess(void *ptr, size_t size,
+  CUmemGenericAllocationHandle handle,
+  int cudaDev) {
+  ncclResult_t result = ncclSuccess;
+  // Map the virtual address range to the physical allocation
+  CUCHECK(cuMemMap((CUdeviceptr)ptr, size, 0, handle, 0));
+  // Set access permissions for the device
+  CUmemAccessDesc accessDesc = {};
+  accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  accessDesc.location.id = cudaDev;
+  accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  CUCHECK(cuMemSetAccess((CUdeviceptr)ptr, size, &accessDesc, 1));
+  return result;
+}
+
 // ncclCuMemAllocAddr takes memory handle and size and returns the mapped address pointer
 static inline ncclResult_t ncclCuMemAllocAddr(void **ptr, CUmemGenericAllocationHandle *handleIn, size_t size) {
   ncclResult_t result = ncclSuccess;
@@ -516,6 +532,12 @@ static inline ncclResult_t ncclCuMemAllocAddr(void **ptr, CUmemGenericAllocation
 }
 
 static inline ncclResult_t ncclCuMemFreeAddr(void *ptr) {
+  WARN("CUMEM requires ROCM_VERSION >= 7.0.0");
+  return ncclInternalError;
+}
+
+static inline ncclResult_t ncclCuMemMapAndSetAccess(void *ptr, size_t size,
+  CUmemGenericAllocationHandle handle, int cudaDev) {
   WARN("CUMEM requires ROCM_VERSION >= 7.0.0");
   return ncclInternalError;
 }

--- a/projects/rccl/src/include/alloc.h
+++ b/projects/rccl/src/include/alloc.h
@@ -13,6 +13,7 @@
 #include "bitops.h"
 #include "utils.h"
 #include "p2p.h"
+#include "mem_manager.h"
 #include <sys/mman.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -368,7 +369,7 @@ fail:
   return result;
 }
 
-static inline ncclResult_t ncclCuMemFreeAddr(void *ptr) {
+static inline ncclResult_t ncclCuMemFreeAddr(void *ptr, struct ncclMemManager* manager, int numSegments = 1) {
   if (ptr == NULL) return ncclSuccess;
   // Check if process is shutting down to avoid use-after-free in HIP runtime
   if (rcclShutdownFlag().load(std::memory_order_acquire)) {
@@ -376,26 +377,39 @@ static inline ncclResult_t ncclCuMemFreeAddr(void *ptr) {
     return ncclSuccess;
   }
   ncclResult_t result = ncclSuccess;
-  size_t size = 0;
-  // ROCM-2696: Proper initialization of base and size is required for cuMemGetAddressRange
-  // base is dereferenced in cuMemGetAddressRange without checking for nullptr
-  CUdeviceptr base = nullptr;
-  CUCHECK(cuMemGetAddressRange(&base, &size, (CUdeviceptr)ptr));
-  CUCHECK(cuMemUnmap((CUdeviceptr)ptr, size));
-  CUCHECK(cuMemAddressFree((CUdeviceptr)ptr, size));
+  size_t totalSize = 0;
+  for (int segment = 0; segment < numSegments; segment++) {
+    size_t segmentSize = 0;
+    // ROCM-2696: Proper initialization of base and size is required for cuMemGetAddressRange
+    // base is dereferenced in cuMemGetAddressRange without checking for nullptr
+    CUdeviceptr base = nullptr;
+    // RCCL: cast through char* before pointer arithmetic
+    CUCHECK(cuMemGetAddressRange(&base, &segmentSize, (CUdeviceptr)((char*)ptr + totalSize)));
+    CUCHECK(cuMemUnmap((CUdeviceptr)((char*)ptr + totalSize), segmentSize));
+    totalSize += segmentSize;
+  }
+
+  // Untrack from memory manager
+  if (manager != nullptr) {
+    NCCLCHECK(ncclMemUntrack(manager, ptr, totalSize));
+  }
+
+  CUCHECK(cuMemAddressFree((CUdeviceptr)ptr, totalSize));
 
   int dev;
-  size *= -1;
   CUDACHECK(hipGetDevice(&dev));
   if (dev < MAX_ALLOC_TRACK_NGPU) {
      __atomic_fetch_add(&allocTracker[dev].totalAlloc, -1, __ATOMIC_RELAXED);
-     __atomic_fetch_add(&allocTracker[dev].totalAllocSize, size, __ATOMIC_RELAXED);
+     __atomic_fetch_add(&allocTracker[dev].totalAllocSize, -(int64_t)totalSize, __ATOMIC_RELAXED);
   }
   INFO(NCCL_ALLOC, "ncclCuMemFreeAddr: Memory used = %ld on device = %d", allocTracker[dev].totalAllocSize, dev);
   return result;
 }
 
-static inline ncclResult_t ncclCuMemAlloc(void **ptr, CUmemGenericAllocationHandle *handlep, CUmemAllocationHandleType type, size_t size) {
+static inline ncclResult_t ncclCuMemAlloc(void **ptr, CUmemGenericAllocationHandle *handlep,
+                                          CUmemAllocationHandleType type, size_t size,
+                                          struct ncclMemManager* manager,
+                                          ncclMemType_t memType = ncclMemPersist) {
   ncclResult_t result = ncclSuccess;
   size_t granularity = 0;
   CUdevice currentDev;
@@ -466,7 +480,12 @@ restoreCapMode:
     if (result != ncclSuccess) goto fail;
   }
   TRACE(NCCL_ALLOC, "CuMem Alloc Size %zu pointer %p handle %p", size, *ptr, (void*)(uintptr_t)handle);
-  
+
+  /* Track allocation in memory manager */
+  if (manager != nullptr) {
+    NCCLCHECKGOTO(ncclMemTrack(manager, *ptr, size, handle, type, memType), result, fail);
+  }
+
   if (cudaDev < MAX_ALLOC_TRACK_NGPU) {
      __atomic_fetch_add(&allocTracker[cudaDev].totalAlloc, 1, __ATOMIC_RELAXED);
      __atomic_fetch_add(&allocTracker[cudaDev].totalAllocSize, size, __ATOMIC_RELAXED);
@@ -483,7 +502,7 @@ fail:
   return result;
 }
 
-static inline ncclResult_t ncclCuMemFree(void *ptr) {
+static inline ncclResult_t ncclCuMemFree(void *ptr, struct ncclMemManager* manager, int numSegments = 1) {
   if (ptr == NULL) return ncclSuccess;
   // Check if process is shutting down to avoid use-after-free in HIP runtime
   if (rcclShutdownFlag().load(std::memory_order_acquire)) {
@@ -491,23 +510,36 @@ static inline ncclResult_t ncclCuMemFree(void *ptr) {
     return ncclSuccess;
   }
   ncclResult_t result = ncclSuccess;
-  CUmemGenericAllocationHandle handle;
-  size_t size = 0;
-  CUCHECK(cuMemRetainAllocationHandle(&handle, ptr));
-  CUCHECK(cuMemRelease(handle));
-  CUdeviceptr base = nullptr;
-  CUCHECK(cuMemGetAddressRange(&base, &size, (CUdeviceptr)ptr));
-  TRACE(NCCL_ALLOC, "CuMem Free Size %zu pointer %p handle %p", size, ptr, (void*)(uintptr_t)handle);
-  CUCHECK(cuMemUnmap((CUdeviceptr)ptr, size));
-  CUCHECK(cuMemRelease(handle));
-  CUCHECK(cuMemAddressFree((CUdeviceptr)ptr, size));
+  size_t totalSize = 0;
+  for (int segment = 0; segment < numSegments; segment++) {
+    CUmemGenericAllocationHandle handle;
+    size_t segmentSize = 0;
+    CUCHECK(cuMemRetainAllocationHandle(&handle, (void*)((char*)ptr + totalSize)));
+    CUCHECK(cuMemRelease(handle));
+    // ROCM-2696: Proper initialization of base and size is required for cuMemGetAddressRange
+    // base is dereferenced in cuMemGetAddressRange without checking for nullptr
+    CUdeviceptr base = nullptr;
+    // RCCL: cast through char* before pointer arithmetic 
+    CUCHECK(cuMemGetAddressRange(&base, &segmentSize, (CUdeviceptr)((char*)ptr + totalSize)));
+    TRACE(NCCL_ALLOC, "CuMem Free Size %zu pointer %p handle %p segment %d numSegments %d",
+          segmentSize, ptr, (void*)(uintptr_t)handle, segment, numSegments);
+    CUCHECK(cuMemUnmap((CUdeviceptr)((char*)ptr + totalSize), segmentSize));
+    CUCHECK(cuMemRelease(handle));
+    totalSize += segmentSize;
+  }
+
+  // Update tracking with total size after processing all segments
+  if (manager != nullptr) {
+    NCCLCHECK(ncclMemUntrack(manager, ptr, totalSize));
+  }
+
+  CUCHECK(cuMemAddressFree((CUdeviceptr)ptr, totalSize));
 
   int dev;
-  size *= -1;
   CUDACHECK(hipGetDevice(&dev));
   if (dev < MAX_ALLOC_TRACK_NGPU) {
      __atomic_fetch_add(&allocTracker[dev].totalAlloc, -1, __ATOMIC_RELAXED);
-     __atomic_fetch_add(&allocTracker[dev].totalAllocSize, size, __ATOMIC_RELAXED);
+     __atomic_fetch_add(&allocTracker[dev].totalAllocSize, -(int64_t)totalSize, __ATOMIC_RELAXED);
   }
   INFO(NCCL_ALLOC, "ncclCuMemFree: Memory used = %ld on device = %d", allocTracker[dev].totalAllocSize, dev);
   return result;
@@ -517,11 +549,13 @@ static inline ncclResult_t ncclCuMemFree(void *ptr) {
 
 extern int ncclCuMemEnable();
 
-static inline ncclResult_t ncclCuMemAlloc(void **ptr, void *handlep, int type, size_t size) {
+static inline ncclResult_t ncclCuMemAlloc(void **ptr, void *handlep, int type, size_t size,
+                                          struct ncclMemManager* manager,
+                                          ncclMemType_t memType = ncclMemPersist) {
   WARN("CUMEM requires ROCM_VERSION >= 7.0.0");
   return ncclInternalError;
 }
-static inline ncclResult_t ncclCuMemFree(void *ptr) {
+static inline ncclResult_t ncclCuMemFree(void *ptr, struct ncclMemManager* manager, int numSegments = 1) {
   WARN("CUMEM requires ROCM_VERSION >= 7.0.0");
   return ncclInternalError;
 }
@@ -531,7 +565,7 @@ static inline ncclResult_t ncclCuMemAllocAddr(void **ptr, CUmemGenericAllocation
   return ncclInternalError;
 }
 
-static inline ncclResult_t ncclCuMemFreeAddr(void *ptr) {
+static inline ncclResult_t ncclCuMemFreeAddr(void *ptr, struct ncclMemManager* manager, int numSegments = 1) {
   WARN("CUMEM requires ROCM_VERSION >= 7.0.0");
   return ncclInternalError;
 }
@@ -544,14 +578,17 @@ static inline ncclResult_t ncclCuMemMapAndSetAccess(void *ptr, size_t size,
 #endif
 
 template <typename T>
-ncclResult_t ncclCudaMallocDebug(const char *filefunc, int line, T** ptr, size_t nelem, unsigned int flags = hipDeviceMallocDefault) {
+ncclResult_t ncclCudaMallocDebug(T** ptr, size_t nelem, const char *filefunc, int line,
+                                 struct ncclMemManager* manager,
+                                 ncclMemType_t memType = ncclMemPersist,
+                                 unsigned int flags = hipDeviceMallocDefault) {
   ncclResult_t result = ncclSuccess;
   cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
   *ptr = nullptr;
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
   if (nelem > 0) {
     if (ncclCuMemEnable()) {
-      NCCLCHECKGOTO(ncclCuMemAlloc((void **)ptr, NULL, ncclCuMemHandleType, nelem*ncclSizeOfT<T>()), result, finish);
+      NCCLCHECKGOTO(ncclCuMemAlloc((void **)ptr, NULL, ncclCuMemHandleType, nelem*ncclSizeOfT<T>(), manager, memType), result, finish);
     } else {
       CUDACHECKGOTO(hipExtMallocWithFlags((void**)ptr, nelem*ncclSizeOfT<T>(), flags), result, finish);
     }
@@ -571,10 +608,13 @@ finish:
   INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p flags %d", filefunc, line, nelem*ncclSizeOfT<T>(), *ptr, flags);
   return result;
 }
-#define ncclCudaMalloc(...) ncclCudaMallocDebug( __FILE__, __LINE__, __VA_ARGS__)
+#define ncclCudaMalloc(ptr, nelem, ...) ncclCudaMallocDebug(ptr, nelem, __FILE__, __LINE__, ##__VA_ARGS__)
 
 template <typename T>
-ncclResult_t ncclCudaCallocDebug(const char *filefunc, int line, T** ptr, size_t nelem, unsigned int flags = hipDeviceMallocDefault) {
+ncclResult_t ncclCudaCallocDebug(T** ptr, size_t nelem, const char *filefunc, int line,
+                                 struct ncclMemManager* manager,
+                                 ncclMemType_t memType = ncclMemPersist,
+                                 unsigned int flags = hipDeviceMallocDefault) {
   ncclResult_t result = ncclSuccess;
   cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
   *ptr = nullptr;
@@ -589,7 +629,7 @@ ncclResult_t ncclCudaCallocDebug(const char *filefunc, int line, T** ptr, size_t
     if (sidestream == nullptr)
       CUDACHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
     if (ncclCuMemEnable()) {
-      NCCLCHECKGOTO(ncclCuMemAlloc((void **)ptr, NULL, ncclCuMemHandleType, nelem*ncclSizeOfT<T>()), result, finish);
+      NCCLCHECKGOTO(ncclCuMemAlloc((void **)ptr, NULL, ncclCuMemHandleType, nelem*ncclSizeOfT<T>(), manager, memType), result, finish);
     } else {
       CUDACHECKGOTO(hipExtMallocWithFlags((void**)ptr, nelem*ncclSizeOfT<T>(), flags), result, finish);
     }
@@ -612,10 +652,13 @@ finish:
   INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p flags %d", filefunc, line, nelem*ncclSizeOfT<T>(), *ptr, flags);
   return result;
 }
-#define ncclCudaCalloc(...) ncclCudaCallocDebug(__FILE__, __LINE__, __VA_ARGS__)
+#define ncclCudaCalloc(ptr, nelem, ...) ncclCudaCallocDebug(ptr, nelem, __FILE__, __LINE__, ##__VA_ARGS__)
 
 template <typename T>
-ncclResult_t ncclCudaCallocAsyncDebug(const char *filefunc, int line, T** ptr, size_t nelem, hipStream_t stream, unsigned int flags = hipDeviceMallocDefault) {
+ncclResult_t ncclCudaCallocAsyncDebug(T** ptr, size_t nelem, hipStream_t stream, const char *filefunc, int line,
+                                      struct ncclMemManager* manager,
+                                      ncclMemType_t memType = ncclMemPersist,
+                                      unsigned int flags = hipDeviceMallocDefault) {
   ncclResult_t result = ncclSuccess;
   cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
   *ptr = nullptr;
@@ -624,11 +667,11 @@ ncclResult_t ncclCudaCallocAsyncDebug(const char *filefunc, int line, T** ptr, s
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
   if (nelem > 0) {
     if (ncclCuMemEnable()) {
-      NCCLCHECKGOTO(ncclCuMemAlloc((void **)ptr, NULL, ncclCuMemHandleType, nelem*ncclSizeOfT<T>()), result, finish);
+      NCCLCHECKGOTO(ncclCuMemAlloc((void **)ptr, NULL, ncclCuMemHandleType, nelem*ncclSizeOfT<T>(), manager, memType), result, finish);
     } else {
       CUDACHECKGOTO(hipExtMallocWithFlags((void**)ptr, nelem*ncclSizeOfT<T>(), flags), result, finish);
     }
-    CUDACHECKGOTO(cudaMemsetAsync(*ptr, 0, nelem*ncclSizeOfT<T>(), stream), result, finish); 
+    CUDACHECKGOTO(cudaMemsetAsync(*ptr, 0, nelem*ncclSizeOfT<T>(), stream), result, finish);
   }
 finish:
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
@@ -644,7 +687,7 @@ finish:
   INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p flags %d", filefunc, line, nelem*ncclSizeOfT<T>(), *ptr, flags);
   return result;
 }
-#define ncclCudaCallocAsync(...) ncclCudaCallocAsyncDebug(__FILE__, __LINE__, __VA_ARGS__)
+#define ncclCudaCallocAsync(ptr, nelem, stream, ...) ncclCudaCallocAsyncDebug(ptr, nelem, stream, __FILE__, __LINE__, ##__VA_ARGS__)
 
 template <typename T>
 ncclResult_t ncclCudaMemcpy(T* dst, T* src, size_t nelem) {
@@ -678,7 +721,7 @@ finish:
 }
 
 template <typename T>
-ncclResult_t ncclCudaFree(T* ptr) {
+ncclResult_t ncclCudaFree(T* ptr, struct ncclMemManager* manager, int numSegments = 1) {
   if (ptr == NULL) return ncclSuccess;
 
   // Check if process is shutting down. The atexit handler sets this flag
@@ -714,7 +757,7 @@ ncclResult_t ncclCudaFree(T* ptr) {
 
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
   if (ncclCuMemEnable()) {
-    NCCLCHECKGOTO(ncclCuMemFree((void *)ptr), result, finish);
+    NCCLCHECKGOTO(ncclCuMemFree((void *)ptr, manager, numSegments), result, finish);
   } else {
     CUDACHECKGOTO(cudaFree(ptr), result, finish);
   }

--- a/projects/rccl/src/include/channel.h
+++ b/projects/rccl/src/include/channel.h
@@ -14,7 +14,7 @@
 ncclResult_t initChannel(struct ncclComm* comm, int channelid);
 ncclResult_t initNvlsChannel(struct ncclComm* comm, int channelId, struct ncclComm* parent, bool share);
 ncclResult_t initCollnetChannel(struct ncclComm* comm, int channelId, struct ncclComm* parent, bool share);
-ncclResult_t freeChannel(struct ncclChannel* channel, int nRanks, int collnetNRanks, int nvlsNRanks);
+ncclResult_t freeChannel(struct ncclChannel* channel, int nRanks, int collnetNRanks, int nvlsNRanks, struct ncclComm* comm);
 
 inline uint8_t ncclP2pChannelBaseForRound(struct ncclComm* comm, int p2pRound, int p2pBatchEnable = 0) {
   int base;

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -27,6 +27,7 @@
 #include "latency_profiler/CollTrace.h"
 #include "rccl_common.h"
 #include "recorder.h"
+#include "mem_manager.h"
 
 #ifdef ENABLE_ROCSHMEM
 #include <rocshmem/rocshmem.hpp>
@@ -116,6 +117,7 @@ struct cliqueInfo {
 struct ncclDestructor {
   struct ncclDestructor* next;
   void* obj;
+  struct ncclComm* comm;
   ncclResult_t(*fn)(struct ncclDestructor* me);
 };
 
@@ -788,6 +790,8 @@ struct ncclComm {
   bool enableDirectReduceScatter;
   // Temporary Buffer [RCCL]
   void* tempBuff;
+
+  struct ncclMemManager* memManager;  // Memory manager
 
   uint64_t endMagic;
 };

--- a/projects/rccl/src/include/gdrwrap.h
+++ b/projects/rccl/src/include/gdrwrap.h
@@ -180,7 +180,9 @@ static gdr_t ncclGdrInit() {
 }
 
 template <typename T>
-static ncclResult_t ncclGdrCudaCalloc(T** ptr, T** devPtr, size_t nelem, void** gdrHandle) {
+static ncclResult_t ncclGdrCudaCalloc(T** ptr, T** devPtr, size_t nelem, void** gdrHandle,
+                                      struct ncclMemManager* manager,
+                                      ncclMemType_t memType = ncclMemPersist) {
   // gdr_info_t info; // unused variable - compiler warning
   size_t mapSize;
   // gdr_mh_t mh;     // unused variable - compiler warning
@@ -193,9 +195,9 @@ static ncclResult_t ncclGdrCudaCalloc(T** ptr, T** devPtr, size_t nelem, void** 
   ALIGN_SIZE(mapSize, GPU_PAGE_SIZE);
   // GDRCOPY Pinned buffer has to be GPU_PAGE_SIZE aligned too
 #if defined(HIP_UNCACHED_MEMORY)
-  NCCLCHECK(ncclCudaCalloc(&devMem, mapSize+GPU_PAGE_SIZE-1, hipDeviceMallocUncached));
+  NCCLCHECK(ncclCudaCalloc(&devMem, mapSize+GPU_PAGE_SIZE-1, manager, memType, hipDeviceMallocUncached));
 #else
-  NCCLCHECK(ncclCudaCalloc(&devMem, mapSize+GPU_PAGE_SIZE-1, hipDeviceMallocFinegrained));
+  NCCLCHECK(ncclCudaCalloc(&devMem, mapSize+GPU_PAGE_SIZE-1, manager, memType, hipDeviceMallocFinegrained));
 #endif
   gdr_mem_desc_t* md;
   NCCLCHECK(ncclCalloc(&md, 1));
@@ -222,9 +224,9 @@ static ncclResult_t ncclGdrCudaCopy(void *gdrHandle, T* dst, T* src, size_t nele
   return ncclSuccess;
 }
 
-static ncclResult_t ncclGdrCudaFree(void* gdrHandle) {
+static ncclResult_t ncclGdrCudaFree(void* gdrHandle, struct ncclMemManager* manager) {
   gdr_mem_desc_t *md = (gdr_mem_desc_t*)gdrHandle;
-  CUDACHECK(cudaFree(md->gdrDevMem));
+  NCCLCHECK(ncclCudaFree(md->gdrDevMem, manager));
   free(md);
 
   return ncclSuccess;
@@ -261,7 +263,9 @@ error:
 }
 
 template <typename T>
-static ncclResult_t ncclGdrCudaCalloc(T** ptr, T** devPtr, size_t nelem, void** gdrHandle) {
+static ncclResult_t ncclGdrCudaCalloc(T** ptr, T** devPtr, size_t nelem, void** gdrHandle,
+                                      struct ncclMemManager* manager,
+                                      ncclMemType_t memType = ncclMemPersist) {
   gdr_info_t info;
   size_t mapSize;
   gdr_mh_t mh;
@@ -273,7 +277,7 @@ static ncclResult_t ncclGdrCudaCalloc(T** ptr, T** devPtr, size_t nelem, void** 
   // GDRCOPY Pinned buffer has to be a minimum of a GPU_PAGE_SIZE
   ALIGN_SIZE(mapSize, GPU_PAGE_SIZE);
   // GDRCOPY Pinned buffer has to be GPU_PAGE_SIZE aligned too
-  NCCLCHECK(ncclCudaCalloc(&devMem, mapSize+GPU_PAGE_SIZE-1));
+  NCCLCHECK(ncclCudaCalloc(&devMem, mapSize+GPU_PAGE_SIZE-1, manager, memType));
   uint64_t alignedAddr = (((uint64_t) devMem) + GPU_PAGE_OFFSET) & GPU_PAGE_MASK;
   size_t align = alignedAddr - (uint64_t)devMem;
 
@@ -313,11 +317,11 @@ static ncclResult_t ncclGdrCudaCopy(void *gdrHandle, T* dst, T* src, size_t nele
   return ncclSuccess;
 }
 
-static ncclResult_t ncclGdrCudaFree(void* gdrHandle) {
+static ncclResult_t ncclGdrCudaFree(void* gdrHandle, struct ncclMemManager* manager) {
   gdr_mem_desc_t *md = (gdr_mem_desc_t*)gdrHandle;
   NCCLCHECK(wrap_gdr_unmap(ncclGdrCopy, md->gdrMh, md->gdrMap, md->gdrMapSize));
   NCCLCHECK(wrap_gdr_unpin_buffer(ncclGdrCopy, md->gdrMh));
-  NCCLCHECK(ncclCudaFree(md->gdrDevMem));
+  NCCLCHECK(ncclCudaFree(md->gdrDevMem, manager));
   free(md);
 
   return ncclSuccess;

--- a/projects/rccl/src/include/mem_manager.h
+++ b/projects/rccl/src/include/mem_manager.h
@@ -171,6 +171,10 @@ ncclResult_t ncclMemUntrack(struct ncclMemManager* manager, void* ptr, size_t si
 // Add peer info for buffers in the linked list entries (only for dynamic memory: scratch/offload)
 ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* ptr, int peerRank);
 
+ncclResult_t ncclCommMemSuspend(struct ncclComm* comm);
+ncclResult_t ncclCommMemResume(struct ncclComm* comm);
+ncclResult_t ncclCommMemStats(struct ncclComm* comm, ncclCommMemStat_t stat, uint64_t* value);
+
 #ifdef __cplusplus
 }
 #endif

--- a/projects/rccl/src/include/mem_manager.h
+++ b/projects/rccl/src/include/mem_manager.h
@@ -30,6 +30,15 @@ typedef struct hipMemFabricHandle_st {
 } hipMemFabricHandle_compat_t;
 #else
 typedef hipMemFabricHandle_t hipMemFabricHandle_compat_t;
+#ifdef __cplusplus
+// Guard against silent ABI drift if HIP ever changes the FABRIC handle layout:
+// our compat type is hard-coded to 64 bytes (HIP_IPC_HANDLE_SIZE), so any
+// future divergence in the real hipMemFabricHandle_t size must trip this
+// assert and be addressed explicitly.
+static_assert(sizeof(hipMemFabricHandle_compat_t) == 64,
+              "hipMemFabricHandle_t size diverged from the 64-byte compat layout; "
+              "update HIP_IPC_HANDLE_SIZE / serialization code in mem_manager.{h,cc}");
+#endif
 #endif
 
 struct ncclComm;

--- a/projects/rccl/src/include/mem_manager.h
+++ b/projects/rccl/src/include/mem_manager.h
@@ -1,0 +1,178 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2015-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Modifications Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#ifndef NCCL_MEM_MANAGER_H_
+#define NCCL_MEM_MANAGER_H_
+
+#include "nccl.h"
+#include <hip/hip_runtime.h>
+#include <hip/hip_runtime_api.h>
+#include <stdbool.h>
+#include <mutex>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef HIP_FABRIC_API
+// FABRIC handle support lifted for HIP runtimes that do not expose it yet
+#ifndef HIP_IPC_HANDLE_SIZE
+#define HIP_IPC_HANDLE_SIZE 64
+#endif
+typedef struct hipMemFabricHandle_st {
+    unsigned char data[HIP_IPC_HANDLE_SIZE];
+} hipMemFabricHandle_compat_t;
+#else
+typedef hipMemFabricHandle_t hipMemFabricHandle_compat_t;
+#endif
+
+struct ncclComm;
+
+// Initial capacity for exported peers array
+#define NCCL_MEM_EXPORT_PEERS_INIT 8
+
+// Memory Type for NCCL allocations
+typedef enum {
+  ncclMemPersist  = 0,  // Persistent memory - track stats only, never release/offload
+  ncclMemScratch  = 1,  // Free without saving
+  ncclMemOffload  = 2   // Copy to CPU before free, restore on resume
+} ncclMemType_t;
+
+// Memory entry state
+typedef enum {
+  ncclDynMemStateActive   = 0,  // Memory is allocated and usable
+  ncclDynMemStateReleased = 1   // Memory has been released
+} ncclDynMemState_t;
+
+// Local owned memory descriptor
+typedef struct ncclDynMemLocalDesc {
+  // Shareable handle for P2P exports
+  // TODO: Remove the 'fd' field - POSIX FD handles are converted on-demand via proxy
+  // (ncclProxyClientGetFdBlocking), so we no longer export them upfront. Only FABRIC
+  // handles need upfront export since they can be shared directly via messaging.
+  union {
+    int                          fd;            // For POSIX_FILE_DESCRIPTOR (unused)
+    hipMemFabricHandle_compat_t  fabricHandle;  // For FABRIC
+  } shareableHandle;
+  bool                           shareableHandleValid;
+  // Peer tracking for P2P exports
+  int                            numExportedPeers;
+  int                            exportedPeersCapacity;
+  int*                           exportedPeerRanks;
+} ncclDynMemLocalDesc;
+
+// Imported from peer memory descriptor
+typedef struct ncclDynMemImportDesc {
+  int                            ownerRank;     // Rank that owns the original buffer
+  int                            ownerDev;      // CUDA device of the owner
+  void*                          ownerPtr;      // Owner's virtual address
+} ncclDynMemImportDesc;
+
+// Individual tracked memory entry (only track scratch and offload allocations)
+typedef struct ncclDynMemEntry {
+  void*                            ptr;           // GPU virtual address
+  size_t                           size;          // Allocation size
+  hipMemGenericAllocationHandle_t  handle;        // Physical memory handle
+  hipMemAllocationHandleType       handleType;
+  ncclMemType_t                    memType;
+  ncclDynMemState_t                state;
+  int                              cudaDev;
+
+  // CPU backup for OFFLOAD type memory
+  void*                            cpuBackup;     // Host memory for offloaded data
+
+  // Ownership type and type-specific data
+  bool                             isImportedFromPeer;  // true if this is a peer-imported buffer
+  union {
+    ncclDynMemLocalDesc            local;
+    ncclDynMemImportDesc           imported;
+  } desc;
+
+  // Linked list pointer
+  struct ncclDynMemEntry*          next;
+} ncclDynMemEntry;
+
+// P2P Handle Exchange Structure
+typedef struct ncclDynMemP2pHandleInfo {
+  void*    ptr;
+  int      ownerRank;
+  int      ownerDev;
+  size_t   size;
+  int      handleType;
+  union {
+    uint64_t                     handleData;
+    hipMemFabricHandle_compat_t  fabricHandle;
+  };
+} ncclDynMemP2pHandleInfo;
+
+// Memory manager attached to ncclComm
+typedef struct ncclMemManager {
+  ncclDynMemEntry*  entries;  // Linked list of tracked allocations, only track scratch and offload allocations
+  int               numEntries;
+  std::mutex        lock;
+  int               released;
+  int               initialized;
+  int               refCount;
+
+  size_t            totalPersist;
+  size_t            totalPersistImported;
+  size_t            totalScratch;
+  size_t            totalScratchImported;
+  size_t            totalOffload;
+  size_t            totalOffloadImported;
+  size_t            cpuBackupUsage;
+
+  int               commCudaDev;
+} ncclMemManager;
+
+struct ncclMemManagerTask {
+  struct ncclMemManagerTask* next;
+  struct ncclComm* comm;
+};
+
+// Initialize memory manager
+ncclResult_t ncclMemManagerInit(struct ncclComm* comm);
+
+// Destroy memory manager and free all resources
+ncclResult_t ncclMemManagerDestroy(struct ncclComm* comm);
+
+// Track a new allocation
+ncclResult_t ncclMemTrack(
+  struct ncclMemManager* manager,
+  void* ptr,
+  size_t size,
+  hipMemGenericAllocationHandle_t handle,
+  hipMemAllocationHandleType handleType,
+  ncclMemType_t memType
+);
+
+// Track imported allocation from peer
+ncclResult_t ncclMemTrackImportFromPeer(
+  struct ncclMemManager* manager,
+  void* ptr,
+  size_t size,
+  hipMemGenericAllocationHandle_t handle,
+  hipMemAllocationHandleType handleType,
+  ncclMemType_t memType,
+  int ownerRank,
+  int ownerDev,
+  void* ownerPtr
+);
+
+// Untrack allocation
+ncclResult_t ncclMemUntrack(struct ncclMemManager* manager, void* ptr, size_t size);
+
+// Add peer info for buffers in the linked list entries (only for dynamic memory: scratch/offload)
+ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* ptr, int peerRank);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NCCL_MEM_MANAGER_H_ */

--- a/projects/rccl/src/include/p2p.h
+++ b/projects/rccl/src/include/p2p.h
@@ -13,6 +13,7 @@
 #include <cuda_runtime.h>
 
 #include "core.h"
+#include "mem_manager.h"
 
 
 // #define HIP_FABRIC_API
@@ -64,7 +65,7 @@ struct ncclIpcRegInfo {
   struct ncclIpcImpInfo impInfo;
 };
 
-ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int directMap, ncclIpcDesc *ipcDesc, void **ptr);
+ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int directMap, ncclIpcDesc *ipcDesc, void **ptr, struct ncclMemManager* manager = nullptr, ncclMemType_t memtype = ncclMemPersist);
 ncclResult_t ncclP2pFreeShareableBuffer(ncclIpcDesc *ipcDesc);
 ncclResult_t ncclP2pImportShareableBuffer(struct ncclComm *comm, int peer, size_t size, ncclIpcDesc *ipcDesc, void **devMemPtr);
 ncclResult_t ncclIpcLocalRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize, int* peerRanks, int nPeers, ncclIpcRegType type, int* regBufFlag, uintptr_t* offsetOut, uintptr_t** peerRmtAddrsOut);

--- a/projects/rccl/src/include/proxy.h
+++ b/projects/rccl/src/include/proxy.h
@@ -353,7 +353,6 @@ struct ncclProxyState {
   ncclCollNet_t* ncclCollNet;
   uint32_t* abortFlag;
   bool directMode;
-  struct ncclMemManager* memManager;  // Shared memory manager for proxy allocations
   // Service threads
   pthread_t thread;
   pthread_t threadUDS;

--- a/projects/rccl/src/include/proxy.h
+++ b/projects/rccl/src/include/proxy.h
@@ -353,6 +353,7 @@ struct ncclProxyState {
   ncclCollNet_t* ncclCollNet;
   uint32_t* abortFlag;
   bool directMode;
+  struct ncclMemManager* memManager;  // Shared memory manager for proxy allocations
   // Service threads
   pthread_t thread;
   pthread_t threadUDS;

--- a/projects/rccl/src/include/transport.h
+++ b/projects/rccl/src/include/transport.h
@@ -91,7 +91,7 @@ struct ncclCollNetSharedRes {
 struct ncclTransportComm {
   ncclResult_t (*setup)(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo*, struct ncclPeerInfo*, struct ncclConnect*, struct ncclConnector*, int channelId, int connIndex);
   ncclResult_t (*connect)(struct ncclComm* comm, struct ncclConnect*, int nranks, int rank, struct ncclConnector*);
-  ncclResult_t (*free)(struct ncclConnector*);
+  ncclResult_t (*free)(struct ncclComm* comm, struct ncclConnector*);
   ncclResult_t (*proxySharedInit)(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, int nChannels);
   ncclResult_t (*proxySetup)(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done);
   ncclResult_t (*proxyConnect)(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done);

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -426,6 +426,7 @@ void ncclCommPushFree(struct ncclComm* comm, void* obj) {
   struct ncclDestructor* dtor = ncclMemoryStackAlloc<struct ncclDestructor>(&comm->memPermanent);
   dtor->fn = ncclDestructorFnFree;
   dtor->obj = obj;
+  dtor->comm = comm;
   dtor->next = comm->destructorHead;
   comm->destructorHead = dtor;
 }
@@ -438,6 +439,7 @@ void ncclCommPushCudaFree(struct ncclComm* comm, void* obj) {
   struct ncclDestructor* dtor = ncclMemoryStackAlloc<struct ncclDestructor>(&comm->memPermanent);
   dtor->fn = ncclDestructorFnCudaFree;
   dtor->obj = obj;
+  dtor->comm = comm;
   dtor->next = comm->destructorHead;
   comm->destructorHead = dtor;
 }
@@ -450,6 +452,7 @@ void ncclCommPushCudaHostFree(struct ncclComm* comm, void* obj) {
   struct ncclDestructor* dtor = ncclMemoryStackAlloc<struct ncclDestructor>(&comm->memPermanent);
   dtor->fn = ncclDestructorFnCudaHostFree;
   dtor->obj = obj;
+  dtor->comm = comm;
   dtor->next = comm->destructorHead;
   comm->destructorHead = dtor;
 }
@@ -462,6 +465,7 @@ void ncclCommPushCudaGdrFree(struct ncclComm* comm, void* handle) {
   struct ncclDestructor* dtor = ncclMemoryStackAlloc<struct ncclDestructor>(&comm->memPermanent);
   dtor->fn = ncclDestructorFnCudaGdrFree;
   dtor->obj = handle;
+  dtor->comm = comm;
   dtor->next = comm->destructorHead;
   comm->destructorHead = dtor;
 }
@@ -512,6 +516,9 @@ static ncclResult_t commFree(ncclComm_t comm) {
       PTHREADCHECK(pthread_join(comm->proxyState->threadUDS, nullptr), "pthread_join");
     }
   }
+
+  // Destroy dynamic memory manager only after all proxy threads have been joined
+  NCCLCHECK(ncclMemManagerDestroy(comm));
 
   if (comm->memPool) CUDACHECK(cudaMemPoolDestroy(comm->memPool));
 
@@ -765,6 +772,18 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
 
   comm->checkPointers = ncclParamCheckPointers() == 1 ? true : false;
   comm->dmaBufSupport = (dmaBufSupported(comm) == ncclSuccess) ? true : false;
+
+  // Initialize memory manager
+  if (parent && parent->shareResources && parent->memManager) {
+    // Share parent's memory manager
+    comm->memManager = parent->memManager;
+    ncclAtomicRefCountIncrement(&comm->memManager->refCount);
+    INFO(NCCL_INIT, "MemManager: Shared from parent, refCount=%d",
+         comm->memManager->refCount);
+  } else {
+    // Create new memory manager
+    NCCLCHECK(ncclMemManagerInit(comm));
+  }
 
 #ifdef ENABLE_COLLTRACE
   NCCLCHECK(ncclCudaHostCalloc(&comm->collTraceTail, MAXCHANNELS));

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -432,7 +432,7 @@ void ncclCommPushFree(struct ncclComm* comm, void* obj) {
 }
 
 static ncclResult_t ncclDestructorFnCudaFree(struct ncclDestructor* dtor) {
-  NCCLCHECK(ncclCudaFree(dtor->obj));
+  NCCLCHECK(ncclCudaFree(dtor->obj, dtor->comm->memManager));
   return ncclSuccess;
 }
 void ncclCommPushCudaFree(struct ncclComm* comm, void* obj) {
@@ -458,7 +458,7 @@ void ncclCommPushCudaHostFree(struct ncclComm* comm, void* obj) {
 }
 
 static ncclResult_t ncclDestructorFnCudaGdrFree(struct ncclDestructor* dtor) {
-  NCCLCHECK(ncclGdrCudaFree(dtor->obj));
+  NCCLCHECK(ncclGdrCudaFree(dtor->obj, dtor->comm->memManager));
   return ncclSuccess;
 }
 void ncclCommPushCudaGdrFree(struct ncclComm* comm, void* handle) {
@@ -481,13 +481,13 @@ static ncclResult_t commFree(ncclComm_t comm) {
   // tempBuff is allocated per-communicator for direct ReduceScatter on gfx950.
   // It is owned by the communicator; free it during communicator teardown.
   if (comm->tempBuff) {
-    NCCLCHECK(ncclCudaFree(comm->tempBuff));
+    NCCLCHECK(ncclCudaFree(comm->tempBuff, comm->memManager));
     comm->tempBuff = nullptr;
   }
 
   // Free hierarchical AG resources
   if (comm->hierarchicalAGTempBuffer) {
-    NCCLCHECK(ncclCudaFree(comm->hierarchicalAGTempBuffer));
+    NCCLCHECK(ncclCudaFree(comm->hierarchicalAGTempBuffer, comm->memManager));
     comm->hierarchicalAGTempBuffer = nullptr;
   }
   if (comm->hierarchicalIntraComm) {
@@ -566,7 +566,7 @@ skip_profiling:
     else
       ncclCommThreadMain((void *)comm);
   }
-  NCCLCHECK(ncclCudaFree((void *)comm->collTrace));
+  NCCLCHECK(ncclCudaFree((void *)comm->collTrace, comm->memManager));
   NCCLCHECK(ncclCudaHostFree((void *)comm->collTraceTail));
 #endif
 
@@ -586,7 +586,7 @@ skip_profiling:
     NCCLCHECK(bootstrapClose(comm->bootstrap));
 
   for (int channel=0; channel<MAXCHANNELS; channel++)
-    NCCLCHECK(freeChannel(comm->channels+channel, comm->nRanks, 1, comm->localRanks));
+    NCCLCHECK(freeChannel(comm->channels+channel, comm->nRanks, 1, comm->localRanks, comm));
 
   if (comm->doneEvent != NULL)
     CUDACHECK(hipEventDestroy(comm->doneEvent));
@@ -595,7 +595,7 @@ skip_profiling:
     if (ncclAtomicRefCountDecrement(&comm->sharedRes->refCount) == 0) {
       for (int c=0; c<MAXCHANNELS; c++) {
         if (comm->sharedRes->peers[c]) free(comm->sharedRes->peers[c]);
-        if (comm->sharedRes->devPeers[c]) ncclCudaFree(comm->sharedRes->devPeers[c]);
+        if (comm->sharedRes->devPeers[c]) ncclCudaFree(comm->sharedRes->devPeers[c], comm->memManager);
       }
       free(comm->sharedRes->tpRankToLocalRank);
       NCCLCHECK(ncclStrongStreamDestruct(&comm->sharedRes->hostStream));
@@ -788,9 +788,9 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
 #ifdef ENABLE_COLLTRACE
   NCCLCHECK(ncclCudaHostCalloc(&comm->collTraceTail, MAXCHANNELS));
 #if defined(HIP_UNCACHED_MEMORY)
-  NCCLCHECK(ncclCudaCalloc(&comm->collTrace, COLLTRACE_NUM_ITEMS*MAXCHANNELS, hipDeviceMallocUncached));
+  NCCLCHECK(ncclCudaCalloc(&comm->collTrace, COLLTRACE_NUM_ITEMS*MAXCHANNELS, comm->memManager, ncclMemPersist, hipDeviceMallocUncached));
 #else
-  NCCLCHECK(ncclCudaCalloc(&comm->collTrace, COLLTRACE_NUM_ITEMS*MAXCHANNELS));
+  NCCLCHECK(ncclCudaCalloc(&comm->collTrace, COLLTRACE_NUM_ITEMS*MAXCHANNELS, comm->memManager, ncclMemPersist));
 #endif
   comm->collTraceExit = 0;
   comm->collTraceEnabled = false; // we can enable colltrace without starting a thread
@@ -888,9 +888,9 @@ static ncclResult_t devCommSetup(ncclComm_t comm) {
 
   memset(&tmpCommAndChans, '\0', sizeof(tmpCommAndChans));
   NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(), &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream), ret, fail);
-  NCCLCHECKGOTO(ncclCudaCallocAsync(&devCommAndChans, 1, deviceStream), ret, fail);
+  NCCLCHECKGOTO(ncclCudaCallocAsync(&devCommAndChans, 1, deviceStream, comm->memManager), ret, fail);
   ncclCommPushCudaFree(comm, devCommAndChans);
-  NCCLCHECKGOTO(ncclCudaCallocAsync(&tmpCommAndChans.comm.rankToLocalRank, comm->nRanks, deviceStream), ret, fail);
+  NCCLCHECKGOTO(ncclCudaCallocAsync(&tmpCommAndChans.comm.rankToLocalRank, comm->nRanks, deviceStream, comm->memManager), ret, fail);
   ncclCommPushCudaFree(comm, tmpCommAndChans.comm.rankToLocalRank);
   NCCLCHECKGOTO(ncclCudaMemcpyAsync(tmpCommAndChans.comm.rankToLocalRank, comm->rankToLocalRank, comm->nRanks, deviceStream), ret, fail);
   comm->devComm = &devCommAndChans->comm;
@@ -938,7 +938,7 @@ static ncclResult_t devCommSetup(ncclComm_t comm) {
 
   if (ncclGdrCopy != NULL && ncclParamGdrCopyFifoEnable() == 1) {
     // The workFifoBuf lives in GDR mapped CUDA memory.
-    NCCLCHECKGOTO(ncclGdrCudaCalloc(&comm->workFifoBuf, &comm->workFifoBufDev, comm->workFifoBytes, &comm->workFifoBufGdrHandle), ret, fail);
+    NCCLCHECKGOTO(ncclGdrCudaCalloc(&comm->workFifoBuf, &comm->workFifoBufDev, comm->workFifoBytes, &comm->workFifoBufGdrHandle, comm->memManager), ret, fail);
     ncclCommPushCudaGdrFree(comm, comm->workFifoBufGdrHandle);
   } else {
     // The workFifoBuf lives in cudaHost memory.
@@ -961,7 +961,7 @@ static ncclResult_t devCommSetup(ncclComm_t comm) {
   ncclCommPushCudaHostFree(comm, comm->profiler.workCompleted);
 
   if (comm->collNetDenseToUserRank != nullptr) {
-    NCCLCHECKGOTO(ncclCudaCallocAsync(&tmpCommAndChans.comm.collNetDenseToUserRank, nRanks, deviceStream), ret, fail);
+    NCCLCHECKGOTO(ncclCudaCallocAsync(&tmpCommAndChans.comm.collNetDenseToUserRank, nRanks, deviceStream, comm->memManager), ret, fail);
     ncclCommPushCudaFree(comm, tmpCommAndChans.comm.collNetDenseToUserRank);
     NCCLCHECKGOTO(ncclCudaMemcpyAsync(tmpCommAndChans.comm.collNetDenseToUserRank, comm->collNetDenseToUserRank, nRanks, deviceStream), ret, fail);
   }
@@ -996,7 +996,7 @@ static ncclResult_t devCommSetup(ncclComm_t comm) {
 #endif
 
 #ifdef ENABLE_PROFILING
-  NCCLCHECK(ncclCudaCalloc(&tmpCommAndChans.comm.devProf, MAXCHANNELS*PROFILE_NUM_LAUNCHES));
+  NCCLCHECK(ncclCudaCalloc(&tmpCommAndChans.comm.devProf, MAXCHANNELS*PROFILE_NUM_LAUNCHES, comm->memManager, ncclMemPersist));
 #endif
 
 #ifdef ENABLE_FAULT_INJECTION
@@ -2366,7 +2366,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
 
   // Allocate Temp Buffer for Direct Reduce Scatter
   if (IsArchMatch(archName,"gfx950")) {
-    NCCLCHECK(ncclCudaMalloc(&(comm->tempBuff), TEMP_BUFF_SIZE));
+    NCCLCHECK(ncclCudaMalloc(&(comm->tempBuff), TEMP_BUFF_SIZE, comm->memManager));
   }
 
   NCCLCHECKGOTO(latency_profiler::collTraceInit(comm), res, fail);
@@ -2385,7 +2385,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
       NCCLCHECKGOTO(ncclCommSplit(comm, local_rank, node_id, &comm->hierarchicalInterComm, NULL), res, fail);
       comm->forcePatEnable = false;
       size_t tempBufSize = (comm->nNodes >= 16) ? HIERARCHICAL_AG_TEMP_BUFFER_SIZE : HIERARCHICAL_AG_TEMP_BUFFER_SIZE / 2;
-      NCCLCHECKGOTO(ncclCudaMalloc(&(comm->hierarchicalAGTempBuffer), tempBufSize), res, fail);
+      NCCLCHECKGOTO(ncclCudaMalloc(&(comm->hierarchicalAGTempBuffer), tempBufSize, comm->memManager), res, fail);
       comm->hierarchicalCommsInitialized = true;
       INFO(NCCL_INIT, "Hierarchical AllGather: intraComm (nRanks=%d) and interComm (nRanks=%d) Initialized",
         comm->hierarchicalIntraComm->nRanks, comm->hierarchicalInterComm->nRanks);

--- a/projects/rccl/src/mem_manager.cc
+++ b/projects/rccl/src/mem_manager.cc
@@ -1,0 +1,415 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2015-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Modifications Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#include "comm.h"
+#include "alloc.h"
+#include "checks.h"
+#include "argcheck.h"
+#include "rocmwrap.h"
+#include "debug.h"
+#include "bootstrap.h"
+#include "proxy.h"
+#include "transport.h"
+#include "nvtx.h"
+#include "param.h"
+#include "group.h"
+#include <string.h>
+#include <stdlib.h>
+#include <mutex>
+
+// Internal parameter to disable memory manager for testing
+NCCL_PARAM(MemManagerDisable, "DISABLE_MEM_MANAGER", 0);
+
+// Initialize memory manager
+ncclResult_t ncclMemManagerInit(struct ncclComm* comm) {
+  if (ncclParamMemManagerDisable()) return ncclSuccess;
+  if (comm == nullptr) return ncclInvalidArgument;
+
+  ncclMemManager* mgr;
+  NCCLCHECK(ncclCalloc(&mgr, 1));
+  // Explicitly construct std::mutex using placement new
+  new (&mgr->lock) std::mutex();
+
+  mgr->entries = nullptr;
+  mgr->numEntries = 0;
+  mgr->released = 0;
+  mgr->refCount = 1;
+  mgr->totalPersist = 0;
+  mgr->totalPersistImported = 0;
+  mgr->totalScratch = 0;
+  mgr->totalScratchImported = 0;
+  mgr->totalOffload = 0;
+  mgr->totalOffloadImported = 0;
+  mgr->cpuBackupUsage = 0;
+  mgr->commCudaDev = comm->cudaDev;
+
+  __atomic_store_n(&mgr->initialized, 1, __ATOMIC_RELEASE);
+
+  comm->memManager = mgr;
+
+  INFO(NCCL_ALLOC, "MemManager: Initialized for device %d", comm->cudaDev);
+  return ncclSuccess;
+}
+
+// Destroy memory manager and free all resources
+ncclResult_t ncclMemManagerDestroy(struct ncclComm* comm) {
+  if (ncclParamMemManagerDisable()) return ncclSuccess;
+  if (comm == nullptr) return ncclInvalidArgument;
+  if (comm->memManager == nullptr) return ncclSuccess;
+
+  ncclMemManager* mgr = comm->memManager;
+
+  if (!__atomic_load_n(&mgr->initialized, __ATOMIC_ACQUIRE)) {
+    comm->memManager = nullptr;
+    return ncclSuccess;
+  }
+
+  // Decrement reference count
+  int refCount = ncclAtomicRefCountDecrement(&mgr->refCount);
+
+  if (refCount > 0) {
+    // Other comms still using this manager
+    INFO(NCCL_ALLOC, "MemManager: Decremented refCount to %d", refCount);
+    comm->memManager = nullptr;  // Clear this comm's pointer
+    return ncclSuccess;
+  }
+
+  // refCount == 0, at this point proxy threads should be joined
+  INFO(NCCL_ALLOC, "MemManager: Destroying (refCount=0)");
+  __atomic_store_n(&mgr->initialized, 0, __ATOMIC_RELEASE);
+
+  ncclDynMemEntry* entry = mgr->entries;
+  while (entry != nullptr) {
+    ncclDynMemEntry* next = entry->next;
+
+    // Free CPU backup if exists
+    if (entry->cpuBackup != nullptr) {
+      ncclCudaHostFree(entry->cpuBackup);
+    }
+
+    // Close shareable FD if valid (defensive cleanup for POSIX FD handle type)
+    if (!entry->isImportedFromPeer &&
+        entry->desc.local.shareableHandleValid &&
+        entry->handleType == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR &&
+        entry->desc.local.shareableHandle.fd >= 0) {
+      close(entry->desc.local.shareableHandle.fd);
+      entry->desc.local.shareableHandle.fd = -1;
+      entry->desc.local.shareableHandleValid = false;
+    }
+
+    // Only local entries have exportedPeerRanks (imported entries use desc.imported union member)
+    if (!entry->isImportedFromPeer && entry->desc.local.exportedPeerRanks != nullptr) {
+      free(entry->desc.local.exportedPeerRanks);
+    }
+
+    // Free the entry itself
+    free(entry);
+    entry = next;
+  }
+
+  mgr->entries = nullptr;
+  mgr->numEntries = 0;
+
+  // Explicitly call destructor for std::mutex
+  mgr->lock.~mutex();
+  // Free the manager struct
+  free(mgr);
+  comm->memManager = nullptr;
+
+  INFO(NCCL_ALLOC, "MemManager: Destroyed");
+  return ncclSuccess;
+}
+
+// Internal helper to create and track memory entry
+static ncclResult_t ncclMemTrackInternal(
+  struct ncclMemManager* manager,
+  void* ptr,
+  size_t size,
+  CUmemGenericAllocationHandle handle,
+  CUmemAllocationHandleType handleType,
+  ncclMemType_t memType,
+  bool isImportedFromPeer,
+  int ownerRank,
+  int ownerDev,
+  void* ownerPtr
+) {
+  if (ncclParamMemManagerDisable()) return ncclSuccess;
+  if (manager == nullptr || ptr == nullptr) return ncclInternalError;
+  if (!__atomic_load_n(&manager->initialized, __ATOMIC_ACQUIRE)) {
+    WARN("MemManager: Cannot track allocation ptr=%p, manager not initialized", ptr);
+    return ncclInternalError;
+  }
+
+  // Persistent memory: atomic update only
+  if (memType == ncclMemPersist) {
+    if (isImportedFromPeer) {
+      (void)__atomic_add_fetch(&manager->totalPersistImported, size, __ATOMIC_RELAXED);
+      TRACE(NCCL_ALLOC, "MemManager: Track Persistent Import ptr=%p size=%zu from rank=%d",
+            ptr, size, ownerRank);
+    } else {
+      (void)__atomic_add_fetch(&manager->totalPersist, size, __ATOMIC_RELAXED);
+      TRACE(NCCL_ALLOC, "MemManager: Track Persistent ptr=%p size=%zu dev=%d",
+            ptr, size, manager->commCudaDev);
+    }
+    return ncclSuccess;
+  }
+
+  // Scratch/Offload: create linked list entry
+  ncclDynMemEntry* entry = (ncclDynMemEntry*)malloc(sizeof(ncclDynMemEntry));
+  if (entry == nullptr) {
+    WARN("MemManager: Failed to allocate memory entry");
+    return ncclSystemError;
+  }
+
+  // Initialize common fields
+  memset(entry, 0, sizeof(ncclDynMemEntry));
+  entry->ptr = ptr;
+  entry->size = size;
+  entry->handle = handle;
+  entry->handleType = handleType;
+  entry->memType = memType;
+  entry->state = ncclDynMemStateActive;
+  entry->cudaDev = manager->commCudaDev;
+  entry->cpuBackup = nullptr;
+  entry->isImportedFromPeer = isImportedFromPeer;
+
+  // Initialize ownership-specific fields
+  if (isImportedFromPeer) {
+    entry->desc.imported.ownerRank = ownerRank;
+    entry->desc.imported.ownerDev = ownerDev;
+    entry->desc.imported.ownerPtr = ownerPtr;
+  } else {
+    if (handleType == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
+      entry->desc.local.shareableHandle.fd = -1;  // avoid using 0 which is stdin
+    }
+    entry->desc.local.shareableHandleValid = false;
+    entry->desc.local.numExportedPeers = 0;
+    entry->desc.local.exportedPeersCapacity = 0;
+    entry->desc.local.exportedPeerRanks = nullptr;
+  }
+
+  { // lock the mutex to add the entry to the linked list
+    std::lock_guard<std::mutex> lock(manager->lock);
+    // Add to linked list (prepend)
+    entry->next = manager->entries;
+    manager->entries = entry;
+    manager->numEntries++;
+  } // lock_guard automatically releases mutex
+
+  // Update statistics
+  if (isImportedFromPeer) {
+    if (memType == ncclMemScratch) {
+      (void)__atomic_add_fetch(&manager->totalScratchImported, size, __ATOMIC_RELAXED);
+    } else if (memType == ncclMemOffload) {
+      (void)__atomic_add_fetch(&manager->totalOffloadImported, size, __ATOMIC_RELAXED);
+    }
+    TRACE(NCCL_ALLOC, "MemManager: Track imported ptr=%p size=%zu type=%d from rank=%d entries=%d",
+          ptr, size, memType, ownerRank, manager->numEntries);
+  } else {
+    if (memType == ncclMemScratch) {
+      (void)__atomic_add_fetch(&manager->totalScratch, size, __ATOMIC_RELAXED);
+    } else if (memType == ncclMemOffload) {
+      (void)__atomic_add_fetch(&manager->totalOffload, size, __ATOMIC_RELAXED);
+    }
+    TRACE(NCCL_ALLOC, "MemManager: Track ptr=%p size=%zu type=%d dev=%d entries=%d",
+          ptr, size, memType, manager->commCudaDev, manager->numEntries);
+  }
+
+  return ncclSuccess;
+}
+
+// Track a new allocation
+ncclResult_t ncclMemTrack(
+  struct ncclMemManager* manager,
+  void* ptr,
+  size_t size,
+  CUmemGenericAllocationHandle handle,
+  CUmemAllocationHandleType handleType,
+  ncclMemType_t memType
+) {
+  return ncclMemTrackInternal(manager, ptr, size, handle, handleType, memType,
+                              false, -1, -1, nullptr);
+}
+
+// Track imported allocation from peer
+ncclResult_t ncclMemTrackImportFromPeer(
+  struct ncclMemManager* manager,
+  void* ptr,
+  size_t size,
+  CUmemGenericAllocationHandle handle,
+  CUmemAllocationHandleType handleType,
+  ncclMemType_t memType,
+  int ownerRank,
+  int ownerDev,
+  void* ownerPtr
+) {
+  return ncclMemTrackInternal(manager, ptr, size, handle, handleType, memType,
+                              true, ownerRank, ownerDev, ownerPtr);
+}
+
+// Untrack allocation
+ncclResult_t ncclMemUntrack(struct ncclMemManager* manager, void* ptr, size_t size) {
+  if (ncclParamMemManagerDisable()) return ncclSuccess;
+  if (manager == nullptr || ptr == nullptr) return ncclInternalError;
+
+  // Atomic check to avoid locking destroyed mutex
+  if (!__atomic_load_n(&manager->initialized, __ATOMIC_ACQUIRE)) {
+    WARN("MemManager: Cannot untrack allocation ptr=%p, manager not initialized", ptr);
+    return ncclInternalError;
+  }
+
+  // Variables to save values before releasing lock
+  size_t entrySize = 0;
+  [[maybe_unused]] int numEntries = 0;  // May be unused if TRACE compiled out
+  bool isImportedFromPeer = false;
+  ncclMemType_t memType = ncclMemScratch;
+
+  {
+    std::lock_guard<std::mutex> lock(manager->lock);
+
+    ncclDynMemEntry* prev = nullptr;
+    ncclDynMemEntry* entry = manager->entries;
+
+    while (entry != nullptr) {
+      if (entry->ptr == ptr) {
+        // Remove from linked list
+        if (prev == nullptr) {
+          manager->entries = entry->next;
+        } else {
+          prev->next = entry->next;
+        }
+        manager->numEntries--;
+
+        // Free CPU backup if exists
+        if (entry->cpuBackup != nullptr) {
+          manager->cpuBackupUsage -= entry->size;
+          ncclCudaHostFree(entry->cpuBackup);
+        }
+
+        // Close shareable FD if valid (defensive cleanup for POSIX FD handle type)
+        if (!entry->isImportedFromPeer &&
+            entry->desc.local.shareableHandleValid &&
+            entry->handleType == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR &&
+            entry->desc.local.shareableHandle.fd >= 0) {
+          close(entry->desc.local.shareableHandle.fd);
+          entry->desc.local.shareableHandle.fd = -1;
+          entry->desc.local.shareableHandleValid = false;
+        }
+
+        // Only local entries have exportedPeerRanks (imported entries use desc.imported union member)
+        if (!entry->isImportedFromPeer && entry->desc.local.exportedPeerRanks != nullptr) {
+          free(entry->desc.local.exportedPeerRanks);
+        }
+
+        // Save values before unlock for logging (may be unused if TRACE is compiled out)
+        entrySize = entry->size;
+        numEntries = manager->numEntries;
+        isImportedFromPeer = entry->isImportedFromPeer;
+        memType = entry->memType;
+
+        // Safety check: log if tracked size doesn't match passed size
+        if (entrySize != size) {
+          INFO(NCCL_ALLOC, "MemManager: Untrack size mismatch ptr=%p tracked=%zu passed=%zu", ptr, entrySize, size);
+        }
+
+        free(entry);
+        break;
+      }
+      prev = entry;
+      entry = entry->next;
+    }
+  } // lock_guard automatically releases mutex
+
+  // Update statistics
+  if (entrySize > 0) {
+    // Entry found in linked list
+    if (isImportedFromPeer) {
+      if (memType == ncclMemScratch) {
+        (void)__atomic_sub_fetch(&manager->totalScratchImported, entrySize, __ATOMIC_RELAXED);
+      } else if (memType == ncclMemOffload) {
+        (void)__atomic_sub_fetch(&manager->totalOffloadImported, entrySize, __ATOMIC_RELAXED);
+      }
+    } else {
+      if (memType == ncclMemScratch) {
+        (void)__atomic_sub_fetch(&manager->totalScratch, entrySize, __ATOMIC_RELAXED);
+      } else if (memType == ncclMemOffload) {
+        (void)__atomic_sub_fetch(&manager->totalOffload, entrySize, __ATOMIC_RELAXED);
+      }
+    }
+
+    TRACE(NCCL_ALLOC, "MemManager: Untrack ptr=%p size=%zu entries=%d",
+          ptr, entrySize, numEntries);
+  } else {
+    // Entry not found in linked list - must be persistent memory
+    (void)__atomic_sub_fetch(&manager->totalPersist, size, __ATOMIC_RELAXED);
+    TRACE(NCCL_ALLOC, "MemManager: Untrack Persistent ptr=%p size=%zu", ptr, size);
+  }
+
+  return ncclSuccess;
+}
+
+// Track that a buffer is being shared with a peer (for suspend/resume coordination)
+// NOTE: Only for dynamic memory (scratch/offload) that's in the linked list.
+// Persistent memory doesn't need export tracking since it's never suspended.
+// Call this after allocating dynamic memory and the peer imports it.
+ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* ptr, int peerRank) {
+  if (ncclParamMemManagerDisable()) return ncclSuccess;
+  if (manager == nullptr || ptr == nullptr) return ncclInternalError;
+  if (!__atomic_load_n(&manager->initialized, __ATOMIC_ACQUIRE)) {
+    WARN("MemManager: Cannot mark export for ptr=%p, manager not initialized", ptr);
+    return ncclInternalError;
+  }
+  std::lock_guard<std::mutex> lock(manager->lock);
+
+  // Find entry in linked list (only contains scratch/offload, not persistent)
+  ncclDynMemEntry* entry = manager->entries;
+  while (entry != nullptr && entry->ptr != ptr) {
+    entry = entry->next;
+  }
+
+  if (entry == nullptr) {
+    WARN("MemManager: Cannot mark export for ptr=%p - not found in tracked entries. "
+         "Only dynamic memory (scratch/offload) needs export tracking for suspend/resume.", ptr);
+    return ncclInternalError;
+  }
+
+  // Verify this is a local entry, not an imported one
+  if (entry->isImportedFromPeer) {
+    WARN("MemManager: Cannot mark export for ptr=%p - this is an imported buffer, not a local one", ptr);
+    return ncclInternalError;
+  }
+
+  // Check if peer already exists
+  for (int i = 0; i < entry->desc.local.numExportedPeers; i++) {
+    if (entry->desc.local.exportedPeerRanks[i] == peerRank) {
+      WARN("MemManager: Buffer ptr=%p already exported to peer rank %d", ptr, peerRank);
+      return ncclInternalError;
+    }
+  }
+
+  if (entry->desc.local.numExportedPeers >= entry->desc.local.exportedPeersCapacity) {
+    int newCapacity = entry->desc.local.exportedPeersCapacity == 0 ? NCCL_MEM_EXPORT_PEERS_INIT :
+                      entry->desc.local.exportedPeersCapacity * 2;
+    ncclResult_t ret = ncclRealloc(&entry->desc.local.exportedPeerRanks,
+                                   entry->desc.local.exportedPeersCapacity,
+                                   newCapacity);
+    if (ret != ncclSuccess) {
+      WARN("MemManager: Failed to grow exportedPeerRanks array for ptr=%p", ptr);
+      return ret;
+    }
+    entry->desc.local.exportedPeersCapacity = newCapacity;
+  }
+
+  // Add peer to export list
+  entry->desc.local.exportedPeerRanks[entry->desc.local.numExportedPeers++] = peerRank;
+
+  TRACE(NCCL_ALLOC, "MemManager: ExportToPeer ptr=%p peerRank=%d numExportedPeers=%d",
+        ptr, peerRank, entry->desc.local.numExportedPeers);
+  return ncclSuccess;
+}

--- a/projects/rccl/src/mem_manager.cc
+++ b/projects/rccl/src/mem_manager.cc
@@ -109,6 +109,12 @@ ncclResult_t ncclMemManagerDestroy(struct ncclComm* comm) {
       free(entry->desc.local.exportedPeerRanks);
     }
 
+    // RCCL: release VA reservation for entries that were Suspended
+    // (state == Released) but never Resumed before Destroy.
+    if (entry->state == ncclDynMemStateReleased && entry->ptr != nullptr) {
+      CUCHECKIGNORE(cuMemAddressFree((CUdeviceptr)entry->ptr, entry->size));
+    }
+
     // Free the entry itself
     free(entry);
     entry = next;
@@ -267,7 +273,7 @@ ncclResult_t ncclMemUntrack(struct ncclMemManager* manager, void* ptr, size_t si
 
   // Variables to save values before releasing lock
   size_t entrySize = 0;
-  [[maybe_unused]] int numEntries = 0;  // May be unused if TRACE compiled out
+  int numEntries = 0; // May be unused if TRACE compiled out (silenced via (void) below)
   bool isImportedFromPeer = false;
   ncclMemType_t memType = ncclMemScratch;
 
@@ -346,6 +352,7 @@ ncclResult_t ncclMemUntrack(struct ncclMemManager* manager, void* ptr, size_t si
 
     TRACE(NCCL_ALLOC, "MemManager: Untrack ptr=%p size=%zu entries=%d",
           ptr, entrySize, numEntries);
+    (void)numEntries; // suppress unused-variable warning when TRACE expands to no-op in Release
   } else {
     // Entry not found in linked list - must be persistent memory
     (void)__atomic_sub_fetch(&manager->totalPersist, size, __ATOMIC_RELAXED);
@@ -423,8 +430,7 @@ ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* pt
  * 2. Second pass: Offload local buffers to CPU and suspend physical memory
  */
 ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
-  if (ncclParamMemManagerDisable())
-  {
+  if (ncclParamMemManagerDisable()) {
     WARN("MemManager: Suspend failed, memory manager is disabled");
     return ncclInvalidUsage;
   }
@@ -449,6 +455,10 @@ ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
   NCCLCHECKGOTO(bootstrapBarrier(comm->bootstrap, comm->rank, comm->nRanks, 0xBEEF), ret, fail);
 
   // Step 1: Unmap all peer-imported buffers first
+  // RCCL: surface unmap failures instead of swallowing
+  // them with CUCHECKIGNORE. If unmap fails the mapping is still live, so we leave
+  // the entry in Active state so Resume will not try to remap on top of it; the
+  // function returns the first error after best-effort teardown of the rest.
   entry = manager->entries;
   while (entry != nullptr) {
     if (entry->isImportedFromPeer && entry->state == ncclDynMemStateActive) {
@@ -456,12 +466,24 @@ ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
             entry->ptr, entry->desc.imported.ownerRank);
 
       // Unmap our local mapping of the peer's memory
-      CUCHECKIGNORE(cuMemUnmap((CUdeviceptr)entry->ptr, entry->size));
+      hipError_t unmapErr = cuMemUnmap((CUdeviceptr)entry->ptr, entry->size);
+      if (unmapErr != hipSuccess) {
+        WARN("MemManager: cuMemUnmap failed during Suspend for peer-imported ptr=%p size=%zu from rank=%d: '%s' (entry kept Active, handle preserved)",
+             entry->ptr, entry->size, entry->desc.imported.ownerRank, hipGetErrorString(unmapErr));
+        if (ret == ncclSuccess) ret = ncclUnhandledCudaError;
+        entry = entry->next;
+        continue;
+      }
 
       // Release our reference to the peer's handle if we have one
       // For same-process imports, handle may be 0 if the reference was already released after mapping
       if (entry->handle != 0) {
-        CUCHECKIGNORE(cuMemRelease(entry->handle));
+        hipError_t relErr = cuMemRelease(entry->handle);
+        if (relErr != hipSuccess) {
+          WARN("MemManager: cuMemRelease failed during Suspend for peer-imported ptr=%p handle=%llu: '%s' (handle ref leaked in driver, marking Released)",
+               entry->ptr, (unsigned long long)entry->handle, hipGetErrorString(relErr));
+          if (ret == ncclSuccess) ret = ncclUnhandledCudaError;
+        }
         entry->handle = 0;  // Clear invalid handle
       }
 
@@ -521,11 +543,27 @@ ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
       entry->desc.local.shareableHandleValid = false;
     }
 
-    // Unmap physical memory but keep virtual address reservation
-    CUCHECKIGNORE(cuMemUnmap((CUdeviceptr)entry->ptr, entry->size));
+    // Unmap physical memory but keep virtual address reservation.
+    // RCCL: if unmap fails the physical handle is still mapped and
+    // any cpuBackup we just produced is still meaningful.
+    // Leave the entry Active so Resume will skip it (no re-create on top
+    // of a live mapping); cpuBackup will be freed by Destroy.
+    hipError_t unmapErr = cuMemUnmap((CUdeviceptr)entry->ptr, entry->size);
+    if (unmapErr != hipSuccess) {
+      WARN("MemManager: cuMemUnmap failed during Suspend for local ptr=%p size=%zu type=%d: '%s' (entry kept Active, handle preserved)",
+           entry->ptr, entry->size, entry->memType, hipGetErrorString(unmapErr));
+      if (ret == ncclSuccess) ret = ncclUnhandledCudaError;
+      entry = entry->next;
+      continue;
+    }
 
     // Release physical memory handle
-    CUCHECKIGNORE(cuMemRelease(entry->handle));
+    hipError_t relErr = cuMemRelease(entry->handle);
+    if (relErr != hipSuccess) {
+      WARN("MemManager: cuMemRelease failed during Suspend for local ptr=%p handle=%llu: '%s' (handle ref leaked in driver, marking Released)",
+           entry->ptr, (unsigned long long)entry->handle, hipGetErrorString(relErr));
+      if (ret == ncclSuccess) ret = ncclUnhandledCudaError;
+    }
     entry->handle = 0;  // Clear invalid handle
 
     entry->state = ncclDynMemStateReleased;
@@ -534,12 +572,19 @@ ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
     entry = entry->next;
   }
 
-  manager->released = 1;
+  // RCCL: Only mark the manager as released if every entry was successfully torn
+  // down. Otherwise leave released=0 so the caller can either retry Suspend
+  // (Active entries that failed will be revisited) or fall through to Destroy.
+  if (ret == ncclSuccess) {
+    manager->released = 1;
+    INFO(NCCL_ALLOC, "MemManager: rank %d suspended %d local + %d peer entries (scratch=%zu, offload=%zu, peerImport=%zu, cpuBackup=%zu)",
+         comm->rank, releasedCount, peerImportCount, releasedScratch, releasedOffload, releasedPeerImport, manager->cpuBackupUsage);
+  } else {
+    WARN("MemManager: rank %d Suspend completed with errors (released %d local + %d peer entries before first failure); manager left in unsuspended state, retry Suspend or call Destroy",
+         comm->rank, releasedCount, peerImportCount);
+  }
 
-  INFO(NCCL_ALLOC, "MemManager: rank %d suspended %d local + %d peer entries (scratch=%zu, offload=%zu, peerImport=%zu, cpuBackup=%zu)",
-       comm->rank, releasedCount, peerImportCount, releasedScratch, releasedOffload, releasedPeerImport, manager->cpuBackupUsage);
-
-  return ncclSuccess;
+  return ret;
 
 fail:
   return ret;
@@ -554,8 +599,7 @@ fail:
  * 3. Second pass: Re-import peer buffers using new handles
  */
 ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
-  if (ncclParamMemManagerDisable())
-  {
+  if (ncclParamMemManagerDisable()) {
     WARN("MemManager: Resume failed, memory manager is disabled");
     return ncclInvalidUsage;
   }
@@ -857,6 +901,8 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
       if (matchedInfo == nullptr) {
         WARN("MemManager: Could not find matching handle info for ptr=%p from rank %d",
              entry->ptr, entry->desc.imported.ownerRank);
+        // RCCL: surface partial-failure so released stays 1 below
+        if (ret == ncclSuccess) ret = ncclSystemError;
         entry = entry->next;
         continue;
       }
@@ -873,6 +919,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
             comm->peerInfo[entry->desc.imported.ownerRank].hostHash != comm->peerInfo[comm->rank].hostHash) {
           WARN("MemManager: Cannot re-import peer buffer from rank %d (different node) using POSIX FD - skipping",
                entry->desc.imported.ownerRank);
+          if (ret == ncclSuccess) ret = ncclInvalidUsage;
           entry = entry->next;
           continue;
         }
@@ -887,6 +934,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
         if (ret != ncclSuccess || fd < 0) {
           WARN("MemManager: Failed to get FD from rank %d for ptr=%p",
                entry->desc.imported.ownerRank, entry->ptr);
+          if (ret == ncclSuccess) ret = ncclSystemError;  // fd < 0 with success ret
           entry = entry->next;
           continue;
         }
@@ -900,6 +948,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
                                                 CU_MEM_HANDLE_TYPE_FABRIC));
       } else {
         WARN("MemManager: Unknown handle type %d for peer import", matchedInfo->handleType);
+        if (ret == ncclSuccess) ret = ncclInvalidUsage;
         entry = entry->next;
         continue;
       }
@@ -907,6 +956,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
       if (curet != CUDA_SUCCESS) {
         WARN("MemManager: cuMemImportFromShareableHandle failed for ptr=%p (curet=%d)",
              entry->ptr, curet);
+        if (ret == ncclSuccess) ret = ncclUnhandledCudaError;
         entry = entry->next;
         continue;
       }
@@ -917,6 +967,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
         CUCHECKIGNORE(cuMemRelease(newHandle));
         entry->handle = 0;
         WARN("MemManager: ncclCuMemMapAndSetAccess failed for re-imported ptr=%p", entry->ptr);
+        if (ret == ncclSuccess) ret = mapResult;
         entry = entry->next;
         continue;
       }
@@ -932,14 +983,26 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
     entry = entry->next;
   }
 
-  manager->released = 0;
+  // RCCL: only flip released back to 0 when every entry was restored. Each
+  // failing peer-import branch above leaves the entry in ncclDynMemStateReleased
+  if(ret == ncclSuccess) {
+    manager->released = 0;
+  } else {
+    WARN("MemManager: rank %d Resume completed with errors "
+         "(restored %d local + %d peer entries before first failure); "
+         "manager left in suspended state, retry Resume or call Destroy",
+         comm->rank, restoredLocalCount, restoredPeerCount);
+    manager->released = 1;
+  }
 
   // Final barrier to ensure all ranks have completed peer import setup
   if (comm->bootstrap != nullptr) {
     INFO(NCCL_ALLOC, "MemManager: rank %d resumed %d local + %d peer entries (%zu + %zu bytes)",
          comm->rank, restoredLocalCount, restoredPeerCount, restoredLocalBytes, restoredPeerBytes);
-    ret = bootstrapBarrier(comm->bootstrap, comm->rank, comm->nRanks, 0xCAFE);
-    if (ret != ncclSuccess) {
+    ncclResult_t barrierRet = bootstrapBarrier(comm->bootstrap, comm->rank, 
+                                               comm->nRanks, 0xCAFE);
+    if (barrierRet != ncclSuccess) {
+      if (ret == ncclSuccess) ret = barrierRet;
       // Cleanup
       if (allCounts) free(allCounts);
       if (localInfos) free(localInfos);
@@ -954,7 +1017,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
   if (localInfos) free(localInfos);
   if (allInfos) free(allInfos);
 
-  return ncclSuccess;
+  return ret;
 
 fail:
   if (allCounts) free(allCounts);
@@ -996,7 +1059,7 @@ ncclResult_t ncclCommMemStats(struct ncclComm* comm, ncclCommMemStat_t stat, uin
       return ncclSuccess;
     case ncclStatGpuMemSuspended:
       // Boolean: 0=active, 1=suspended
-      *value = manager->released ? 1 : 0;
+      *value = __atomic_load_n(&manager->released, __ATOMIC_ACQUIRE) ? 1 : 0;
       return ncclSuccess;
     default:
       return ncclInvalidArgument;

--- a/projects/rccl/src/mem_manager.cc
+++ b/projects/rccl/src/mem_manager.cc
@@ -19,6 +19,7 @@
 #include "nvtx.h"
 #include "param.h"
 #include "group.h"
+#include "p2p.h"  // For CU_MEM_HANDLE_TYPE_FABRIC alias used by ncclCommMemResume
 #include <string.h>
 #include <stdlib.h>
 #include <mutex>
@@ -412,4 +413,581 @@ ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* pt
   TRACE(NCCL_ALLOC, "MemManager: ExportToPeer ptr=%p peerRank=%d numExportedPeers=%d",
         ptr, peerRank, entry->desc.local.numExportedPeers);
   return ncclSuccess;
+}
+
+/*
+ * Internal: Suspend all dynamic memory with P2P coordination
+ *
+ * Order of operations:
+ * 1. First pass: Unmap all peer-imported buffers
+ * 2. Second pass: Offload local buffers to CPU and suspend physical memory
+ */
+ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
+  if (ncclParamMemManagerDisable())
+  {
+    WARN("MemManager: Suspend failed, memory manager is disabled");
+    return ncclInvalidUsage;
+  }
+  if (comm == nullptr) return ncclInvalidArgument;
+  if (comm->memManager == nullptr) return ncclInvalidUsage;
+  ncclMemManager* manager = comm->memManager;
+
+  if (manager->released) {
+    WARN("MemManager: Already suspended");
+    return ncclInvalidUsage;
+  }
+
+  ncclResult_t ret = ncclSuccess;
+  size_t releasedScratch = 0;
+  size_t releasedOffload = 0;
+  size_t releasedPeerImport = 0;
+  int releasedCount = 0;
+  int peerImportCount = 0;
+  ncclDynMemEntry* entry = nullptr;
+
+  CUDACHECK(cudaDeviceSynchronize());
+  NCCLCHECKGOTO(bootstrapBarrier(comm->bootstrap, comm->rank, comm->nRanks, 0xBEEF), ret, fail);
+
+  // Step 1: Unmap all peer-imported buffers first
+  entry = manager->entries;
+  while (entry != nullptr) {
+    if (entry->isImportedFromPeer && entry->state == ncclDynMemStateActive) {
+      TRACE(NCCL_ALLOC, "MemManager: Unmapping peer-imported buffer ptr=%p from rank %d",
+            entry->ptr, entry->desc.imported.ownerRank);
+
+      // Unmap our local mapping of the peer's memory
+      CUCHECKIGNORE(cuMemUnmap((CUdeviceptr)entry->ptr, entry->size));
+
+      // Release our reference to the peer's handle if we have one
+      // For same-process imports, handle may be 0 if the reference was already released after mapping
+      if (entry->handle != 0) {
+        CUCHECKIGNORE(cuMemRelease(entry->handle));
+        entry->handle = 0;  // Clear invalid handle
+      }
+
+      entry->state = ncclDynMemStateReleased;
+      releasedPeerImport += entry->size;
+      peerImportCount++;
+    }
+    entry = entry->next;
+  }
+
+  // Step 2: Offload and release local memory
+  entry = manager->entries;
+  while (entry != nullptr) {
+    // Skip buffer imported from peer
+    if (entry->isImportedFromPeer) {
+      entry = entry->next;
+      continue;
+    }
+
+    // Skip already released
+    if (entry->state == ncclDynMemStateReleased) {
+      entry = entry->next;
+      continue;
+    }
+
+    // For OFFLOAD type: copy to CPU backup first
+    if (entry->memType == ncclMemOffload) {
+      NCCLCHECKGOTO(ncclCudaHostCalloc((char**)&entry->cpuBackup, entry->size), ret, fail);
+      if (entry->cpuBackup == nullptr) {
+        WARN("MemManager: Failed to allocate CPU backup for offload");
+        ret = ncclSystemError;
+        goto fail;
+      }
+
+      // Copy GPU to CPU
+      cudaError_t err = cudaMemcpy(entry->cpuBackup, entry->ptr, entry->size, cudaMemcpyDeviceToHost);
+      if (err != cudaSuccess) {
+        ncclCudaHostFree(entry->cpuBackup);
+        entry->cpuBackup = nullptr;
+        WARN("MemManager: Failed to copy to CPU backup: %s", cudaGetErrorString(err));
+        ret = ncclUnhandledCudaError;
+        goto fail;
+      }
+
+      manager->cpuBackupUsage += entry->size;
+      releasedOffload += entry->size;
+    } else {
+      releasedScratch += entry->size;
+    }
+
+    // Close the shareable FD if valid (for POSIX handles)
+    if (entry->desc.local.shareableHandleValid &&
+        entry->handleType == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR &&
+        entry->desc.local.shareableHandle.fd >= 0) {
+      close(entry->desc.local.shareableHandle.fd);
+      entry->desc.local.shareableHandle.fd = -1;
+      entry->desc.local.shareableHandleValid = false;
+    }
+
+    // Unmap physical memory but keep virtual address reservation
+    CUCHECKIGNORE(cuMemUnmap((CUdeviceptr)entry->ptr, entry->size));
+
+    // Release physical memory handle
+    CUCHECKIGNORE(cuMemRelease(entry->handle));
+    entry->handle = 0;  // Clear invalid handle
+
+    entry->state = ncclDynMemStateReleased;
+    releasedCount++;
+
+    entry = entry->next;
+  }
+
+  manager->released = 1;
+
+  INFO(NCCL_ALLOC, "MemManager: rank %d suspended %d local + %d peer entries (scratch=%zu, offload=%zu, peerImport=%zu, cpuBackup=%zu)",
+       comm->rank, releasedCount, peerImportCount, releasedScratch, releasedOffload, releasedPeerImport, manager->cpuBackupUsage);
+
+  return ncclSuccess;
+
+fail:
+  return ret;
+}
+
+/*
+ * Internal: Resume previously suspended dynamic memory with P2P coordination
+ *
+ * Order of operations:
+ * 1. First pass: Resume local memory (re-allocate, re-map, restore offloaded data)
+ * 2. Exchange: AllGather new handle info for P2P buffers
+ * 3. Second pass: Re-import peer buffers using new handles
+ */
+ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
+  if (ncclParamMemManagerDisable())
+  {
+    WARN("MemManager: Resume failed, memory manager is disabled");
+    return ncclInvalidUsage;
+  }
+  if (comm == nullptr) return ncclInvalidArgument;
+  if (comm->memManager == nullptr) return ncclInvalidUsage;
+  ncclMemManager* manager = comm->memManager;
+
+  if (!manager->released) {
+    WARN("MemManager: Not in suspended state");
+    return ncclInvalidUsage;
+  }
+
+  ncclResult_t ret = ncclSuccess;
+  int restoredLocalCount = 0;
+  int restoredPeerCount = 0;
+  size_t restoredLocalBytes = 0;
+  size_t restoredPeerBytes = 0;
+
+  int localBroadcastCount = 0;
+  int* allCounts = nullptr;
+  int totalInfoCount = 0;
+  ncclDynMemP2pHandleInfo* localInfos = nullptr;
+  ncclDynMemP2pHandleInfo* allInfos = nullptr;
+
+  // Step 1: Restore all local memory
+  ncclDynMemEntry* entry = manager->entries;
+  while (entry != nullptr) {
+    // Skip peer-imported entries
+    if (entry->isImportedFromPeer) {
+      entry = entry->next;
+      continue;
+    }
+
+    // Skip entries that weren't released
+    if (entry->state != ncclDynMemStateReleased) {
+      entry = entry->next;
+      continue;
+    }
+
+    // Re-create physical allocation
+    CUmemAllocationProp prop = {};
+    prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    prop.location.id = entry->cudaDev;
+    prop.requestedHandleTypes = entry->handleType;
+
+    CUmemGenericAllocationHandle newHandle;
+    CUCHECKGOTO(cuMemCreate(&newHandle, entry->size, &prop, 0), ret, fail);
+
+    // Re-map to the same virtual address and set access permissions for local device
+    ret = ncclCuMemMapAndSetAccess(entry->ptr, entry->size, newHandle, entry->cudaDev);
+    if (ret != ncclSuccess) {
+      CUCHECKIGNORE(cuMemRelease(newHandle));
+      entry->handle = 0;  // Clear to avoid dangling handle
+      goto fail;
+    }
+
+    // Restore peer access for all previously exported peers
+    for (int i = 0; i < entry->desc.local.numExportedPeers; i++) {
+      int peerRank = entry->desc.local.exportedPeerRanks[i];
+      if (peerRank >= 0 && peerRank < comm->nRanks) {
+        // Only set access for peers on the same node and same process
+        if (comm->peerInfo[peerRank].pidHash == comm->peerInfo[comm->rank].pidHash && comm->peerInfo[peerRank].hostHash == comm->peerInfo[comm->rank].hostHash){
+          int peerDev = comm->peerInfo[peerRank].cudaDev;
+          CUmemAccessDesc peerAccessDesc = {};
+          peerAccessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+          peerAccessDesc.location.id = peerDev;
+          peerAccessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+          CUCHECKIGNORE(cuMemSetAccess((CUdeviceptr)entry->ptr, entry->size, &peerAccessDesc, 1));
+          TRACE(NCCL_ALLOC, "MemManager: Restored peer access for ptr=%p to rank %d dev %d",
+                entry->ptr, peerRank, peerDev);
+        }
+      }
+    }
+
+    // Update handle
+    entry->handle = newHandle;
+
+    // For OFFLOAD type: restore data from CPU backup
+    if (entry->memType == ncclMemOffload && entry->cpuBackup != NULL) {
+      cudaError_t err = cudaMemcpy(entry->ptr, entry->cpuBackup, entry->size, cudaMemcpyHostToDevice);
+      if (err != cudaSuccess) {
+        WARN("MemManager: Failed to restore from CPU backup: %s (backup preserved)", cudaGetErrorString(err));
+        ret = ncclUnhandledCudaError;
+        goto fail;
+      }
+      // Free CPU backup on successful restore
+      ncclCudaHostFree(entry->cpuBackup);
+      entry->cpuBackup = nullptr;
+      manager->cpuBackupUsage -= entry->size;
+    }
+
+    entry->desc.local.shareableHandleValid = false;
+    if (entry->handleType == CU_MEM_HANDLE_TYPE_FABRIC) {
+      CUresult exportRet = CUPFN(cuMemExportToShareableHandle(&entry->desc.local.shareableHandle.fabricHandle, newHandle,
+                                                               CU_MEM_HANDLE_TYPE_FABRIC, 0));
+      if (exportRet != CUDA_SUCCESS) {
+        WARN("MemManager: cuMemExportToShareableHandle (FABRIC) failed for ptr=%p", entry->ptr);
+        CUCHECKIGNORE(cuMemUnmap((CUdeviceptr)entry->ptr, entry->size));
+        CUCHECKIGNORE(cuMemRelease(newHandle));
+        entry->handle = 0;
+        ret = ncclUnhandledCudaError;
+        goto fail;
+      }
+      entry->desc.local.shareableHandleValid = true;
+    }
+
+    entry->state = ncclDynMemStateActive;
+    restoredLocalCount++;
+    restoredLocalBytes += entry->size;
+
+    TRACE(NCCL_ALLOC, "MemManager: Resumed local buffer ptr=%p size=%zu numExportedPeers=%d",
+          entry->ptr, entry->size, entry->desc.local.numExportedPeers);
+
+    entry = entry->next;
+  }
+
+  // Step 2: Barrier to ensure all ranks have resumed their local memory
+  if (comm->bootstrap != nullptr) {
+    INFO(NCCL_ALLOC, "MemManager: rank %d resumed %d local entries, waiting at barrier",
+         comm->rank, restoredLocalCount);
+    ret = bootstrapBarrier(comm->bootstrap, comm->rank, comm->nRanks, 0xBEEF);
+    if (ret != ncclSuccess) {
+      WARN("MemManager: Barrier failed during resume");
+      return ret;
+    }
+  }
+
+  /*
+   * Step 3: Exchange new handle info for P2P coordination
+   *
+   * Each rank broadcasts info about its local buffers that have peers.
+   * We use a simple approach: each rank sends to all peers that imported its buffers.
+   */
+
+  // Count local buffers that have peers (need to broadcast new handle info)
+  localBroadcastCount = 0;
+  entry = manager->entries;
+  while (entry != nullptr) {
+    if (!entry->isImportedFromPeer && entry->desc.local.numExportedPeers > 0 && entry->state == ncclDynMemStateActive) {
+      localBroadcastCount++;
+    }
+    entry = entry->next;
+  }
+
+  // Gather counts from all ranks using AllGather
+  if (comm->bootstrap != nullptr && comm->nRanks > 1) {
+    // Allocate buffer for all counts
+    allCounts = (int*)malloc(comm->nRanks * sizeof(int));
+    if (allCounts == nullptr) {
+      WARN("MemManager: Failed to allocate allCounts");
+      return ncclSystemError;
+    }
+    memset(allCounts, 0, comm->nRanks * sizeof(int));
+    allCounts[comm->rank] = localBroadcastCount;
+
+    // AllGather counts: each rank contributes sizeof(int) at its position
+    ret = bootstrapAllGather(comm->bootstrap, allCounts, sizeof(int));
+    if (ret != ncclSuccess) {
+      free(allCounts);
+      WARN("MemManager: AllGather counts failed");
+      return ret;
+    }
+
+    // Calculate total and offsets
+    int* offsets = (int*)malloc(comm->nRanks * sizeof(int));
+    if (offsets == nullptr) {
+      free(allCounts);
+      return ncclSystemError;
+    }
+
+    totalInfoCount = 0;
+    for (int r = 0; r < comm->nRanks; r++) {
+      offsets[r] = totalInfoCount;
+      totalInfoCount += allCounts[r];
+    }
+
+    if (totalInfoCount > 0) {
+      // Prepare local info to send
+      int localAllocCount = localBroadcastCount > 0 ? localBroadcastCount : 1;
+      localInfos = (ncclDynMemP2pHandleInfo*)malloc(localAllocCount * sizeof(ncclDynMemP2pHandleInfo));
+      if (localInfos == nullptr) {
+        free(allCounts);
+        free(offsets);
+        return ncclSystemError;
+      }
+
+      int idx = 0;
+      entry = manager->entries;
+      while (entry != nullptr && idx < localBroadcastCount) {
+        if (!entry->isImportedFromPeer && entry->desc.local.numExportedPeers > 0 && entry->state == ncclDynMemStateActive) {
+          localInfos[idx].ptr = entry->ptr;
+          localInfos[idx].ownerRank = comm->rank;
+          localInfos[idx].ownerDev = entry->cudaDev;
+          localInfos[idx].size = entry->size;
+          localInfos[idx].handleType = entry->handleType;
+
+          if (entry->handleType == CU_MEM_HANDLE_TYPE_FABRIC) {
+            // For FABRIC: copy the exported fabric handle (can be shared directly)
+            if (entry->desc.local.shareableHandleValid) {
+              memcpy(&localInfos[idx].fabricHandle, &entry->desc.local.shareableHandle.fabricHandle, sizeof(hipMemFabricHandle_compat_t));
+            } else {
+              WARN("MemManager: FABRIC handle not valid for entry ptr=%p", entry->ptr);
+            }
+          } else {
+            // For POSIX FD: store the cuMem handle (for FD conversion via proxy)
+            memcpy(&localInfos[idx].handleData, &entry->handle, sizeof(CUmemGenericAllocationHandle));
+          }
+
+          idx++;
+        }
+        entry = entry->next;
+      }
+
+      // Allocate buffer for all infos
+      allInfos = (ncclDynMemP2pHandleInfo*)malloc(totalInfoCount * sizeof(ncclDynMemP2pHandleInfo));
+      if (allInfos == nullptr) {
+        free(allCounts);
+        free(offsets);
+        free(localInfos);
+        return ncclSystemError;
+      }
+
+      // Copy local data to correct position
+      if (localBroadcastCount > 0) {
+        memcpy(allInfos + offsets[comm->rank], localInfos,
+               localBroadcastCount * sizeof(ncclDynMemP2pHandleInfo));
+      }
+
+      // Exchange using Send/Recv (send first, then receive to avoid deadlock)
+      for (int r = 0; r < comm->nRanks; r++) {
+        if (r != comm->rank && localBroadcastCount > 0) {
+          ret = bootstrapSend(comm->bootstrap, r, 0xFEED,
+                              localInfos,
+                              localBroadcastCount * sizeof(ncclDynMemP2pHandleInfo));
+          if (ret != ncclSuccess) {
+            WARN("MemManager: Send to rank %d failed - handle exchange incomplete", r);
+            free(offsets);
+            free(allCounts);
+            free(localInfos);
+            free(allInfos);
+            return ret;
+          }
+        }
+      }
+
+      for (int r = 0; r < comm->nRanks; r++) {
+        if (r != comm->rank && allCounts[r] > 0) {
+          ret = bootstrapRecv(comm->bootstrap, r, 0xFEED,
+                              allInfos + offsets[r],
+                              allCounts[r] * sizeof(ncclDynMemP2pHandleInfo));
+          if (ret != ncclSuccess) {
+            WARN("MemManager: Recv from rank %d failed - handle exchange incomplete", r);
+            free(offsets);
+            free(allCounts);
+            free(localInfos);
+            free(allInfos);
+            return ret;
+          }
+        }
+      }
+    }
+
+    free(offsets);
+  }
+
+  /*
+   * Step 4: Re-import peer buffers using exchanged handle info
+   */
+
+  entry = manager->entries;
+  while (entry != nullptr) {
+    if (entry->isImportedFromPeer && entry->state == ncclDynMemStateReleased) {
+      // Find matching info from AllGather results
+      ncclDynMemP2pHandleInfo* matchedInfo = nullptr;
+
+      if (allInfos != nullptr) {
+        for (int i = 0; i < totalInfoCount; i++) {
+          if (allInfos[i].ownerRank == entry->desc.imported.ownerRank &&
+              allInfos[i].ptr == entry->desc.imported.ownerPtr &&
+              allInfos[i].size == entry->size) {
+            matchedInfo = &allInfos[i];
+            break;
+          }
+        }
+      }
+
+      if (matchedInfo == nullptr) {
+        WARN("MemManager: Could not find matching handle info for ptr=%p from rank %d",
+             entry->ptr, entry->desc.imported.ownerRank);
+        entry = entry->next;
+        continue;
+      }
+
+      TRACE(NCCL_ALLOC, "MemManager: Re-importing peer buffer ptr=%p from rank %d (owner ptr=%p)",
+            entry->ptr, entry->desc.imported.ownerRank, matchedInfo->ptr);
+
+      CUmemGenericAllocationHandle newHandle;
+      CUresult curet;
+
+      if (matchedInfo->handleType == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
+        // POSIX FD handles only work within the same node - check hostHash
+        if (comm->peerInfo && comm->peerInfoValid &&
+            comm->peerInfo[entry->desc.imported.ownerRank].hostHash != comm->peerInfo[comm->rank].hostHash) {
+          WARN("MemManager: Cannot re-import peer buffer from rank %d (different node) using POSIX FD - skipping",
+               entry->desc.imported.ownerRank);
+          entry = entry->next;
+          continue;
+        }
+
+        // For POSIX FD: We need to get the FD from the owner
+        // Use proxy to convert cuMem handle to FD
+        int fd = -1;
+
+        // The handleData contains the cuMem handle - request FD conversion
+        ret = ncclProxyClientGetFdBlocking(comm, entry->desc.imported.ownerRank,
+                                           &matchedInfo->handleData, &fd);
+        if (ret != ncclSuccess || fd < 0) {
+          WARN("MemManager: Failed to get FD from rank %d for ptr=%p",
+               entry->desc.imported.ownerRank, entry->ptr);
+          entry = entry->next;
+          continue;
+        }
+
+        curet = CUPFN(cuMemImportFromShareableHandle(&newHandle, (void*)(uintptr_t)fd,
+                                                CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR));
+        close(fd);
+      } else if (matchedInfo->handleType == CU_MEM_HANDLE_TYPE_FABRIC) {
+        // For FABRIC: Import directly using the fabric handle
+        curet = CUPFN(cuMemImportFromShareableHandle(&newHandle, &matchedInfo->fabricHandle,
+                                                CU_MEM_HANDLE_TYPE_FABRIC));
+      } else {
+        WARN("MemManager: Unknown handle type %d for peer import", matchedInfo->handleType);
+        entry = entry->next;
+        continue;
+      }
+
+      if (curet != CUDA_SUCCESS) {
+        WARN("MemManager: cuMemImportFromShareableHandle failed for ptr=%p (curet=%d)",
+             entry->ptr, curet);
+        entry = entry->next;
+        continue;
+      }
+
+      // Re-map to the same virtual address and set access permissions
+      ncclResult_t mapResult = ncclCuMemMapAndSetAccess(entry->ptr, entry->size, newHandle, comm->cudaDev);
+      if (mapResult != ncclSuccess) {
+        CUCHECKIGNORE(cuMemRelease(newHandle));
+        entry->handle = 0;
+        WARN("MemManager: ncclCuMemMapAndSetAccess failed for re-imported ptr=%p", entry->ptr);
+        entry = entry->next;
+        continue;
+      }
+
+      entry->handle = newHandle;
+      entry->state = ncclDynMemStateActive;
+      restoredPeerCount++;
+      restoredPeerBytes += entry->size;
+
+      TRACE(NCCL_ALLOC, "MemManager: Successfully re-imported peer buffer ptr=%p from rank %d",
+            entry->ptr, entry->desc.imported.ownerRank);
+    }
+    entry = entry->next;
+  }
+
+  manager->released = 0;
+
+  // Final barrier to ensure all ranks have completed peer import setup
+  if (comm->bootstrap != nullptr) {
+    INFO(NCCL_ALLOC, "MemManager: rank %d resumed %d local + %d peer entries (%zu + %zu bytes)",
+         comm->rank, restoredLocalCount, restoredPeerCount, restoredLocalBytes, restoredPeerBytes);
+    ret = bootstrapBarrier(comm->bootstrap, comm->rank, comm->nRanks, 0xCAFE);
+    if (ret != ncclSuccess) {
+      // Cleanup
+      if (allCounts) free(allCounts);
+      if (localInfos) free(localInfos);
+      if (allInfos) free(allInfos);
+      WARN("MemManager: Final barrier failed during resume");
+      return ret;
+    }
+  }
+
+  // Cleanup
+  if (allCounts) free(allCounts);
+  if (localInfos) free(localInfos);
+  if (allInfos) free(allInfos);
+
+  return ncclSuccess;
+
+fail:
+  if (allCounts) free(allCounts);
+  if (localInfos) free(localInfos);
+  if (allInfos) free(allInfos);
+  return ret;
+}
+
+ncclResult_t ncclCommMemStats(struct ncclComm* comm, ncclCommMemStat_t stat, uint64_t* value) {
+  NCCL_NVTX3_FUNC_RANGE;
+
+  NCCLCHECK(CommCheck(comm, "ncclCommMemStats", "comm"));
+  NCCLCHECK(ncclCommEnsureReady(comm));
+  if (value == nullptr) return ncclInvalidArgument;
+
+  if (ncclParamMemManagerDisable()) {
+    WARN("MemManager: MemStats not supported, memory manager is disabled");
+    return ncclInvalidUsage;
+  }
+
+  if (comm->memManager == nullptr) {
+    *value = 0;
+    return ncclSuccess;
+  }
+
+  ncclMemManager* manager = comm->memManager;
+  switch (stat) {
+    case ncclStatGpuMemTotal:
+      *value = __atomic_load_n(&manager->totalPersist, __ATOMIC_RELAXED) +
+               __atomic_load_n(&manager->totalScratch, __ATOMIC_RELAXED) +
+               __atomic_load_n(&manager->totalOffload, __ATOMIC_RELAXED);
+      return ncclSuccess;
+    case ncclStatGpuMemPersist:
+      *value = __atomic_load_n(&manager->totalPersist, __ATOMIC_RELAXED);
+      return ncclSuccess;
+    case ncclStatGpuMemSuspend:
+      *value = __atomic_load_n(&manager->totalScratch, __ATOMIC_RELAXED) +
+               __atomic_load_n(&manager->totalOffload, __ATOMIC_RELAXED);
+      return ncclSuccess;
+    case ncclStatGpuMemSuspended:
+      // Boolean: 0=active, 1=suspended
+      *value = manager->released ? 1 : 0;
+      return ncclSuccess;
+    default:
+      return ncclInvalidArgument;
+  }
 }

--- a/projects/rccl/src/mem_manager.cc
+++ b/projects/rccl/src/mem_manager.cc
@@ -596,11 +596,22 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
     }
 
     // Re-create physical allocation
+    // RCCL adaptation: mirror ncclCuMemAlloc's prop init so Resume's cuMemCreate
+    // matches the original allocation. Required on AMD because of ROCM-2550
+    // (hipMemMap SIGSEGV without gpuDirectRDMACapable=1) and to honor the
+    // HIP_VMM_UNCACHED_MEMORY build flag.
     CUmemAllocationProp prop = {};
+#if defined(HIP_VMM_UNCACHED_MEMORY)
+    prop.type = hipMemAllocationTypeUncached;
+#else
     prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+#endif
     prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
     prop.location.id = entry->cudaDev;
     prop.requestedHandleTypes = entry->handleType;
+#if defined(__HIP_PLATFORM_AMD__)
+    prop.allocFlags.gpuDirectRDMACapable = 1;
+#endif
 
     CUmemGenericAllocationHandle newHandle;
     CUCHECKGOTO(cuMemCreate(&newHandle, entry->size, &prop, 0), ret, fail);

--- a/projects/rccl/src/misc/npkit.cc
+++ b/projects/rccl/src/misc/npkit.cc
@@ -46,9 +46,9 @@ ncclResult_t NpKit::Init(int rank) {
 
   // Init event data structures
   NCCLCHECK(ncclCalloc(&gpu_event_buffers_, kNumGpuEventBuffers));
-  NCCLCHECK(ncclCudaCalloc(&gpu_collect_contexts_, kNumGpuEventBuffers));
+  NCCLCHECK(ncclCudaCalloc(&gpu_collect_contexts_, kNumGpuEventBuffers, /*manager=*/nullptr));
   for (i = 0; i < kNumGpuEventBuffers; i++) {
-    NCCLCHECK(ncclCudaCalloc(gpu_event_buffers_ + i, kMaxNumGpuEventsPerBuffer));
+    NCCLCHECK(ncclCudaCalloc(gpu_event_buffers_ + i, kMaxNumGpuEventsPerBuffer, /*manager=*/nullptr));
     ctx.event_buffer = gpu_event_buffers_[i];
     NCCLCHECK(ncclCudaMemcpy(gpu_collect_contexts_ + i, &ctx, 1));
   }

--- a/projects/rccl/src/mnnvl.cc
+++ b/projects/rccl/src/mnnvl.cc
@@ -70,7 +70,7 @@ ncclResult_t ncclMnnvlCheck(struct ncclComm* comm) {
     CUresult err;
 
     // Allocate FABRIC handle compatible memory
-    ncclResult_t ret = ncclCuMemAlloc(&ptr, &handle, CU_MEM_HANDLE_TYPE_FABRIC, CUDA_IPC_MIN);
+    ncclResult_t ret = ncclCuMemAlloc(&ptr, &handle, CU_MEM_HANDLE_TYPE_FABRIC, CUDA_IPC_MIN, comm->memManager, ncclMemOffload);
     if (ret != ncclSuccess) {
       // Return an error if this is a MNNVL capable system but FABRIC handles are not supported
       WARN("MNNVL (cliqueSize %d) is available but not working on this system. Check the IMEX channel configuration (/dev/nvidia-caps-imex-channels). Set NCCL_MNNVL_ENABLE=0 to ignore this issue.",
@@ -82,13 +82,13 @@ ncclResult_t ncclMnnvlCheck(struct ncclComm* comm) {
         (err = cuMemImportFromShareableHandle(&handle, &cuDesc, CU_MEM_HANDLE_TYPE_FABRIC)) != CUDA_SUCCESS) {
       const char *errStr;
       (void) cuGetErrorString(err, &errStr);
-      NCCLCHECK(ncclCuMemFree(ptr));
+      NCCLCHECK(ncclCuMemFree(ptr, comm->memManager));
       // Return an error if this is a MNNVL capable system but it's not working
       WARN("MNNVL (cliqueSize %d) is available but not working on this system. Check the IMEX configuration (nvidia-imex-ctl -N). Set NCCL_MNNVL_ENABLE=0 to ignore this issue.",
           comm->clique.size);
       return ncclSystemError;
     }
-    NCCLCHECK(ncclCuMemFree(ptr));
+    NCCLCHECK(ncclCuMemFree(ptr, comm->memManager));
 
     // Force the CUMEM handle type to be FABRIC for MNNVL
     ncclCuMemHandleType = CU_MEM_HANDLE_TYPE_FABRIC;

--- a/projects/rccl/src/nccl.h.in
+++ b/projects/rccl/src/nccl.h.in
@@ -372,6 +372,13 @@ ncclResult_t  ncclCommGetAsyncError(ncclComm_t comm, ncclResult_t *asyncError);
 /*! @cond       include_hidden */
 ncclResult_t pncclCommGetAsyncError(ncclComm_t comm, ncclResult_t *asyncError);
 /*! @endcond */
+
+typedef enum {
+  ncclStatGpuMemSuspend      = 0,  // Allocated GPU memory that can be suspended (bytes)
+  ncclStatGpuMemSuspended    = 1,   // GPU memory suspended? (0=active, 1=suspended)
+  ncclStatGpuMemPersist      = 2,  // Allocated GPU memory that cannot be suspended (bytes)
+  ncclStatGpuMemTotal        = 3  // Total allocated GPU memory tracked by NCCL (bytes)
+} ncclCommMemStat_t;
 /*! @} */
 
 /*! @defgroup   rccl_api_comminfo Communicator Information

--- a/projects/rccl/src/plugin/net.cc
+++ b/projects/rccl/src/plugin/net.cc
@@ -438,7 +438,7 @@ ncclResult_t ncclGpuGdrSupport(struct ncclComm* comm, int* gdrSupport) {
       connected = (rComm != NULL) && (sComm != NULL);
     }
 
-    NCCLCHECKGOTO(ncclCudaMalloc(&gpuPtr, GPU_BUF_SIZE), ret, cleanup2);
+    NCCLCHECKGOTO(ncclCudaMalloc(&gpuPtr, GPU_BUF_SIZE, comm->memManager), ret, cleanup2);
     if (comm->ncclNet->regMr(sComm, gpuPtr, GPU_BUF_SIZE, NCCL_PTR_CUDA, &mHandle) == ncclSuccess) {
       NCCLCHECK(comm->ncclNet->deregMr(sComm, mHandle));
       NCCLCHECK(comm->ncclNet->regMr(rComm, gpuPtr, GPU_BUF_SIZE, NCCL_PTR_CUDA, &mHandle));
@@ -446,7 +446,7 @@ ncclResult_t ncclGpuGdrSupport(struct ncclComm* comm, int* gdrSupport) {
       gdrSupportMatrix[comm->cudaDev] = 1;
     }
     ncclDebugNoWarn = 0;
-    NCCLCHECK(ncclCudaFree(gpuPtr));
+    NCCLCHECK(ncclCudaFree(gpuPtr, comm->memManager));
 cleanup2:
     if (rComm != NULL)
       NCCLCHECK(comm->ncclNet->closeRecv(rComm));

--- a/projects/rccl/src/proxy.cc
+++ b/projects/rccl/src/proxy.cc
@@ -1955,6 +1955,7 @@ ncclResult_t ncclProxyCreate(struct ncclComm* comm) {
   struct ncclProxyState* proxyState = comm->proxyState;
   if (proxyState->refCount == 1) {
     /* we have to make sure all following fields in comm have been initialized. */
+    proxyState->memManager = comm->memManager;  // Set shared memory manager for proxy allocations
     proxyState->tpRank = comm->rank;
     proxyState->tpnRanks = comm->nRanks;
     proxyState->tpLocalnRanks = comm->localRanks;

--- a/projects/rccl/src/proxy.cc
+++ b/projects/rccl/src/proxy.cc
@@ -1955,7 +1955,6 @@ ncclResult_t ncclProxyCreate(struct ncclComm* comm) {
   struct ncclProxyState* proxyState = comm->proxyState;
   if (proxyState->refCount == 1) {
     /* we have to make sure all following fields in comm have been initialized. */
-    proxyState->memManager = comm->memManager;  // Set shared memory manager for proxy allocations
     proxyState->tpRank = comm->rank;
     proxyState->tpnRanks = comm->nRanks;
     proxyState->tpLocalnRanks = comm->localRanks;

--- a/projects/rccl/src/register/register.cc
+++ b/projects/rccl/src/register/register.cc
@@ -103,7 +103,7 @@ static ncclResult_t regCleanup(struct ncclComm* comm, struct ncclReg* reg) {
         free(reg->ipcInfos[i]);
       }
     if (reg->regIpcAddrs.hostPeerRmtAddrs) free(reg->regIpcAddrs.hostPeerRmtAddrs);
-    if (reg->regIpcAddrs.devPeerRmtAddrs) NCCLCHECK(ncclCudaFree(reg->regIpcAddrs.devPeerRmtAddrs));
+    if (reg->regIpcAddrs.devPeerRmtAddrs) NCCLCHECK(ncclCudaFree(reg->regIpcAddrs.devPeerRmtAddrs, comm->memManager));
   }
   return ncclSuccess;
 }

--- a/projects/rccl/src/transport.cc
+++ b/projects/rccl/src/transport.cc
@@ -442,12 +442,12 @@ ncclResult_t ncclTransportCollNetFree(struct ncclComm* comm) {
       if (ncclAtomicRefCountDecrement(&peer->refCount) == 0) {
         for (int b=0; b<NCCL_MAX_CONNS; b++) {
           struct ncclConnector* send = peer->send + b;
-          if (send->transportResources && send->transportComm) NCCLCHECK(send->transportComm->free(send));
+          if (send->transportResources && send->transportComm) NCCLCHECK(send->transportComm->free(comm, send));
           send->transportResources = NULL; // avoid double free
         }
         for (int b=0; b<NCCL_MAX_CONNS; b++) {
           struct ncclConnector* recv = peer->recv + b;
-          if (recv->transportResources && recv->transportComm) NCCLCHECK(recv->transportComm->free(recv));
+          if (recv->transportResources && recv->transportComm) NCCLCHECK(recv->transportComm->free(comm, recv));
           recv->transportResources = NULL; // avoid double free
         }
       }

--- a/projects/rccl/src/transport/coll_net.cc
+++ b/projects/rccl/src/transport/coll_net.cc
@@ -311,11 +311,11 @@ static ncclResult_t recvConnect(struct ncclComm* comm, struct ncclConnect* conne
   return ncclSuccess;
 }
 
-static ncclResult_t sendFree(struct ncclConnector* send) {
+static ncclResult_t sendFree(struct ncclComm* comm, struct ncclConnector* send) {
   return ncclSuccess;
 }
 
-static ncclResult_t recvFree(struct ncclConnector* recv) {
+static ncclResult_t recvFree(struct ncclComm* comm, struct ncclConnector* recv) {
   return ncclSuccess;
 }
 
@@ -400,7 +400,7 @@ static ncclResult_t sharedFree(struct ncclProxyState* proxyState, struct ncclCol
   return ncclSuccess;
 }
 
-static ncclResult_t sharedBuffersInit(struct ncclCollNetSharedRes* collNet, int cuda, char** gpuPtr, char** cpuPtr, int* size) {
+static ncclResult_t sharedBuffersInit(struct ncclCollNetSharedRes* collNet, int cuda, char** gpuPtr, char** cpuPtr, int* size, struct ncclMemManager* manager) {
   if (collNet->size == 0) {
     collNet->size = 2 * collNet->nChannels * collNet->buffSize;
   }
@@ -409,9 +409,9 @@ static ncclResult_t sharedBuffersInit(struct ncclCollNetSharedRes* collNet, int 
 
   if (cuda && collNet->cudaBuff == NULL) {
 #if defined(HIP_UNCACHED_MEMORY)
-    NCCLCHECK(ncclCudaCalloc(&collNet->cudaBuff, *size, cuda ? hipDeviceMallocUncached : hipDeviceMallocDefault));
+    NCCLCHECK(ncclCudaCalloc(&collNet->cudaBuff, *size, manager, ncclMemPersist, cuda ? hipDeviceMallocUncached : hipDeviceMallocDefault));
 #else
-    NCCLCHECK(ncclCudaCalloc(&collNet->cudaBuff, *size, cuda ? hipDeviceMallocFinegrained : hipDeviceMallocDefault));
+    NCCLCHECK(ncclCudaCalloc(&collNet->cudaBuff, *size, manager, ncclMemPersist, cuda ? hipDeviceMallocFinegrained : hipDeviceMallocDefault));
 #endif
   }
   if (!cuda && collNet->hostBuff == NULL) {
@@ -429,9 +429,9 @@ static ncclResult_t sharedBuffersGet(struct ncclCollNetSharedRes* collNet, int t
   return ncclSuccess;
 }
 
-static ncclResult_t sharedBuffersDestroy(struct ncclCollNetSharedRes* collNet) {
+static ncclResult_t sharedBuffersDestroy(struct ncclCollNetSharedRes* collNet, struct ncclProxyState* proxyState) {
   if (collNet->size == 0) return ncclSuccess;
-  NCCLCHECK(ncclCudaFree(collNet->cudaBuff));
+  NCCLCHECK(ncclCudaFree(collNet->cudaBuff, proxyState->memManager));
   NCCLCHECK(ncclCudaHostFree(collNet->hostBuff));
   // This will be called multiple times, with multiple channels and send/recv. Make sure we only do it once.
   collNet->size = 0;
@@ -504,7 +504,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   map->mems[NCCL_NET_MAP_HOSTMEM].gpuPtr = map->mems[NCCL_NET_MAP_HOSTMEM].cpuPtr;
   if (ncclGdrCopy && ncclParamGdrCopySyncEnable()) {
     uint64_t *cpuPtr, *gpuPtr;
-    NCCLCHECK(ncclGdrCudaCalloc(&cpuPtr, &gpuPtr, 1, &resources->gdrDesc));
+    NCCLCHECK(ncclGdrCudaCalloc(&cpuPtr, &gpuPtr, 1, &resources->gdrDesc, proxyState->memManager));
 
     resources->gdcSync = cpuPtr;
     struct connectMapMem* gdcMem = map->mems+NCCL_NET_MAP_GDCMEM;
@@ -521,7 +521,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   // Allocate & Register shared buffers for the Simple protocol
   int bank = resources->useGdr ? NCCL_NET_MAP_SHARED_DEVMEM : NCCL_NET_MAP_SHARED_HOSTMEM;
   struct connectMapMem* mapMem = map->mems+bank;
-  NCCLCHECK(sharedBuffersInit(connection->collNet, resources->useGdr, &mapMem->gpuPtr, &mapMem->cpuPtr, &mapMem->size));
+  NCCLCHECK(sharedBuffersInit(connection->collNet, resources->useGdr, &mapMem->gpuPtr, &mapMem->cpuPtr, &mapMem->size, proxyState->memManager));
   NCCL_NET_MAP_ADD_POINTER(map, 1, resources->useGdr ? 1 : 0, mapMem->size, buffs[NCCL_PROTO_SIMPLE]);
 
   int dmabuf_fd = -1;
@@ -597,7 +597,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   map->mems[NCCL_NET_MAP_HOSTMEM].gpuPtr = map->mems[NCCL_NET_MAP_HOSTMEM].cpuPtr;
   if (ncclGdrCopy) {
     uint64_t *cpuPtr, *gpuPtr;
-    NCCLCHECK(ncclGdrCudaCalloc(&cpuPtr, &gpuPtr, 2, &resources->gdrDesc));
+    NCCLCHECK(ncclGdrCudaCalloc(&cpuPtr, &gpuPtr, 2, &resources->gdrDesc, proxyState->memManager));
 
     if (ncclParamGdrCopySyncEnable()) {
       resources->gdcSync = cpuPtr;
@@ -615,7 +615,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   // Allocate & Register shared buffers for the Simple protocol
   int bank = resources->useGdr ? NCCL_NET_MAP_SHARED_DEVMEM : NCCL_NET_MAP_SHARED_HOSTMEM;
   struct connectMapMem* mapMem = map->mems+bank;
-  NCCLCHECK(sharedBuffersInit(connection->collNet, resources->useGdr, &mapMem->gpuPtr, &mapMem->cpuPtr, &mapMem->size));
+  NCCLCHECK(sharedBuffersInit(connection->collNet, resources->useGdr, &mapMem->gpuPtr, &mapMem->cpuPtr, &mapMem->size, proxyState->memManager));
   NCCL_NET_MAP_ADD_POINTER(map, 1, resources->useGdr ? 1 : 0, mapMem->size, buffs[NCCL_PROTO_SIMPLE]);
   
   int dmabuf_fd = -1;
@@ -680,9 +680,9 @@ static ncclResult_t sendProxyFree(struct ncclProxyConnection* connection, struct
     }
     struct connectMapMem* mems = resources->map.mems;
     NCCLCHECK(ncclCudaHostFree(mems[NCCL_NET_MAP_HOSTMEM].cpuPtr));
-    NCCLCHECK(ncclCudaFree(mems[NCCL_NET_MAP_DEVMEM].cpuPtr));
-    if (mems[NCCL_NET_MAP_GDCMEM].cpuPtr) NCCLCHECK(ncclGdrCudaFree(resources->gdrDesc));
-    NCCLCHECK(sharedBuffersDestroy(connection->collNet));
+    NCCLCHECK(ncclCudaFree(mems[NCCL_NET_MAP_DEVMEM].cpuPtr, proxyState->memManager));
+    if (mems[NCCL_NET_MAP_GDCMEM].cpuPtr) NCCLCHECK(ncclGdrCudaFree(resources->gdrDesc, proxyState->memManager));
+    NCCLCHECK(sharedBuffersDestroy(connection->collNet, proxyState));
     NCCLCHECK(sharedFree(proxyState, connection->collNet, resources->netDev));
     if (ncclAtomicRefCountDecrement(&connection->collNet->refCount) == 0) free(connection->collNet);
     free(connection->transportResources);
@@ -701,9 +701,9 @@ static ncclResult_t recvProxyFree(struct ncclProxyConnection* connection, struct
     }
     struct connectMapMem* mems = resources->map.mems;
     NCCLCHECK(ncclCudaHostFree(mems[NCCL_NET_MAP_HOSTMEM].cpuPtr));
-    NCCLCHECK(ncclCudaFree(mems[NCCL_NET_MAP_DEVMEM].cpuPtr));
-    if (mems[NCCL_NET_MAP_GDCMEM].cpuPtr) NCCLCHECK(ncclGdrCudaFree(resources->gdrDesc));
-    NCCLCHECK(sharedBuffersDestroy(connection->collNet));
+    NCCLCHECK(ncclCudaFree(mems[NCCL_NET_MAP_DEVMEM].cpuPtr, proxyState->memManager));
+    if (mems[NCCL_NET_MAP_GDCMEM].cpuPtr) NCCLCHECK(ncclGdrCudaFree(resources->gdrDesc, proxyState->memManager));
+    NCCLCHECK(sharedBuffersDestroy(connection->collNet, proxyState));
     NCCLCHECK(sharedFree(proxyState, connection->collNet, resources->netDev));
     if (ncclAtomicRefCountDecrement(&connection->collNet->refCount) == 0) free(connection->collNet);
     free(connection->transportResources);

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -778,7 +778,7 @@ static ncclResult_t recvConnect(struct ncclComm* comm, struct ncclConnect* conne
   return ncclSuccess;
 }
 
-static ncclResult_t sendFree(struct ncclConnector* send) {
+static ncclResult_t sendFree(struct ncclComm* comm, struct ncclConnector* send) {
   struct connectMap* map = (struct connectMap*)(send->transportResources);
   if (map) {
     int cudaDev;
@@ -787,7 +787,7 @@ static ncclResult_t sendFree(struct ncclConnector* send) {
       if (ncclCuMemEnable()) {
         // cuMem API support
         NCCLCHECK(ncclP2pFreeShareableBuffer(&map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc));
-        NCCLCHECK(ncclCuMemFree(map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr));
+        NCCLCHECK(ncclCuMemFree(map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, comm->memManager));
       } else {
         // Legacy CUDA IPC support
         CUDACHECK(cudaIpcCloseMemHandle(map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr));
@@ -802,7 +802,7 @@ static ncclResult_t sendFree(struct ncclConnector* send) {
   return ncclSuccess;
 }
 
-static ncclResult_t recvFree(struct ncclConnector* recv) {
+static ncclResult_t recvFree(struct ncclComm* comm, struct ncclConnector* recv) {
   if (recv->transportResources) free(recv->transportResources);
   return ncclSuccess;
 }
@@ -834,18 +834,18 @@ static ncclResult_t sharedNetBuffersInit(struct ncclProxyState* proxyState, int 
 
   if (cuda && state->cudaBuff == NULL) {
     if (sameProcess == 0 || ncclCuMemEnable()) {
-      NCCLCHECK(ncclP2pAllocateShareableBuffer(state->size, 0, &state->ipcDesc, (void**)&state->cudaBuff));
+      NCCLCHECK(ncclP2pAllocateShareableBuffer(state->size, 0, &state->ipcDesc, (void**)&state->cudaBuff, proxyState->memManager, ncclMemPersist));
     } else {
 #if defined(HIP_UNCACHED_MEMORY)
 #if defined(HIP_CONTIGUOUS_MEMORY)
-      NCCLCHECK(ncclCudaCalloc(&state->cudaBuff, state->size,
+      NCCLCHECK(ncclCudaCalloc(&state->cudaBuff, state->size, proxyState->memManager, ncclMemPersist,
         cuda ? (rcclParamNetContiguousMem() ? hipDeviceMallocContiguous : hipDeviceMallocUncached) : hipDeviceMallocDefault));
 #else
-      NCCLCHECK(ncclCudaCalloc(&state->cudaBuff, state->size,
+      NCCLCHECK(ncclCudaCalloc(&state->cudaBuff, state->size, proxyState->memManager, ncclMemPersist,
         cuda ? hipDeviceMallocUncached : hipDeviceMallocDefault));
 #endif
 #else
-      NCCLCHECK(ncclCudaCalloc(&state->cudaBuff, state->size,
+      NCCLCHECK(ncclCudaCalloc(&state->cudaBuff, state->size, proxyState->memManager, ncclMemPersist,
         cuda ? hipDeviceMallocFinegrained : hipDeviceMallocDefault));
 #endif
     }
@@ -878,7 +878,7 @@ static ncclResult_t sharedNetBuffersDestroy(struct ncclProxyState* proxyState, i
       if (!connection->sameProcess || ncclCuMemEnable()) {
         NCCLCHECK(ncclP2pFreeShareableBuffer(&state->ipcDesc));
       }
-      NCCLCHECK(ncclCudaFree(state->cudaBuff));
+      NCCLCHECK(ncclCudaFree(state->cudaBuff, proxyState->memManager));
     }
     if (state->hostBuff) NCCLCHECK(ncclCudaHostFree(state->hostBuff));
   }
@@ -1157,7 +1157,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
       if (!map->sameProcess || ncclCuMemEnable()) {
         ALIGN_SIZE(map->mems[NCCL_NET_MAP_DEVMEM].size, CUDA_IPC_MIN);
         NCCLCHECK(ncclP2pAllocateShareableBuffer(map->mems[NCCL_NET_MAP_DEVMEM].size, 0, &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,
-                                                (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr));
+                                                (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, proxyState->memManager, ncclMemPersist));
 #if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
         // Get DMA-BUF fd for cuMem VMM allocations via cuMemGetHandleForAddressRange.
         // Required even when DMA-BUF is globally disabled: ibv_reg_mr on cuMem RDMA
@@ -1174,14 +1174,14 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
       } else {
 #if defined(HIP_UNCACHED_MEMORY)
 #if defined(HIP_CONTIGUOUS_MEMORY)
-        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size,
+        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size, proxyState->memManager, ncclMemPersist,
           resources->useGdr ? (rcclParamNetContiguousMem() ? hipDeviceMallocContiguous : hipDeviceMallocUncached) : hipDeviceMallocDefault));
 #else
-        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size,
+        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size, proxyState->memManager, ncclMemPersist,
           resources->useGdr ? hipDeviceMallocUncached : hipDeviceMallocDefault));
 #endif
 #else
-        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size,
+        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size, proxyState->memManager, ncclMemPersist,
           resources->useGdr ? hipDeviceMallocFinegrained : hipDeviceMallocDefault));
 #endif
       }
@@ -1200,7 +1200,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   }
   if (ncclGdrCopy && map->sameProcess && ncclParamGdrCopySyncEnable()) {
     uint64_t *cpuPtr, *gpuPtr;
-    NCCLCHECK(ncclGdrCudaCalloc(&cpuPtr, &gpuPtr, 1, &resources->gdrDesc));
+    NCCLCHECK(ncclGdrCudaCalloc(&cpuPtr, &gpuPtr, 1, &resources->gdrDesc, proxyState->memManager));
 
     resources->gdcSync = cpuPtr;
     struct connectMapMem* gdcMem = map->mems+NCCL_NET_MAP_GDCMEM;
@@ -1383,7 +1383,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
     if (resources->shared == 0) {
       if (ncclCuMemEnable()) {
         NCCLCHECK(ncclP2pAllocateShareableBuffer(map->mems[NCCL_NET_MAP_DEVMEM].size, 0, &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,
-                                                (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr));
+                                                (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, proxyState->memManager, ncclMemPersist));
 #if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
         // Get DMA-BUF fd for cuMem VMM allocations. Required even when DMA-BUF is
         // globally disabled to avoid ibv_reg_mr on VMM memory.
@@ -1398,14 +1398,14 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
       } else {
 #if defined(HIP_UNCACHED_MEMORY)
 #if defined(HIP_CONTIGUOUS_MEMORY)
-        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size,
+        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size, proxyState->memManager, ncclMemPersist,
           resources->useGdr ? (rcclParamNetContiguousMem() ? hipDeviceMallocContiguous : hipDeviceMallocUncached) : hipDeviceMallocDefault));
 #else
-        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size,
+        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size, proxyState->memManager, ncclMemPersist,
           resources->useGdr ? hipDeviceMallocUncached : hipDeviceMallocDefault));
 #endif
 #else
-        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size,
+        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size, proxyState->memManager, ncclMemPersist,
           resources->useGdr ? hipDeviceMallocFinegrained : hipDeviceMallocDefault));
 #endif
       }
@@ -1416,7 +1416,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   map->mems[NCCL_NET_MAP_HOSTMEM].gpuPtr = map->mems[NCCL_NET_MAP_HOSTMEM].cpuPtr;
   if (ncclGdrCopy && map->sameProcess) {
     uint64_t *cpuPtr, *gpuPtr;
-    NCCLCHECK(ncclGdrCudaCalloc(&cpuPtr, &gpuPtr, 2, &resources->gdrDesc));
+    NCCLCHECK(ncclGdrCudaCalloc(&cpuPtr, &gpuPtr, 2, &resources->gdrDesc, proxyState->memManager));
 
     if (ncclParamGdrCopySyncEnable()) {
       resources->gdcSync = cpuPtr;
@@ -1502,14 +1502,14 @@ static ncclResult_t sendProxyFree(struct ncclProxyConnection* connection, struct
       (void)close(mems[NCCL_NET_MAP_DEVMEM].dmaBufFd);
       mems[NCCL_NET_MAP_DEVMEM].dmaBufFd = -1;
     }
-    NCCLCHECK(ncclCudaFree(mems[NCCL_NET_MAP_DEVMEM].cpuPtr));
+    NCCLCHECK(ncclCudaFree(mems[NCCL_NET_MAP_DEVMEM].cpuPtr, proxyState->memManager));
     if (!resources->map.sameProcess || ncclCuMemEnable()) {
       // cuMem API support
       if (mems[NCCL_NET_MAP_DEVMEM].size) {
         NCCLCHECK(ncclP2pFreeShareableBuffer(&mems[NCCL_NET_MAP_DEVMEM].ipcDesc));
       }
     }
-    if (mems[NCCL_NET_MAP_GDCMEM].cpuPtr) NCCLCHECK(ncclGdrCudaFree(resources->gdrDesc));
+    if (mems[NCCL_NET_MAP_GDCMEM].cpuPtr) NCCLCHECK(ncclGdrCudaFree(resources->gdrDesc, proxyState->memManager));
     if (resources->shared) {
       NCCLCHECK(sharedNetBuffersDestroy(proxyState, resources->tpLocalRank, 0, connection));
       if (resources->maxRecvs > 1 && ncclParamNetSharedComms()) {
@@ -1548,14 +1548,14 @@ static ncclResult_t recvProxyFree(struct ncclProxyConnection* connection, struct
       (void)close(mems[NCCL_NET_MAP_DEVMEM].dmaBufFd);
       mems[NCCL_NET_MAP_DEVMEM].dmaBufFd = -1;
     }
-    NCCLCHECK(ncclCudaFree(mems[NCCL_NET_MAP_DEVMEM].cpuPtr));
+    NCCLCHECK(ncclCudaFree(mems[NCCL_NET_MAP_DEVMEM].cpuPtr, proxyState->memManager));
     if (!resources->map.sameProcess || ncclCuMemEnable()) {
       // cuMem API support
       if (mems[NCCL_NET_MAP_DEVMEM].size) {
         NCCLCHECK(ncclP2pFreeShareableBuffer(&mems[NCCL_NET_MAP_DEVMEM].ipcDesc));
       }
     }
-    if (mems[NCCL_NET_MAP_GDCMEM].cpuPtr) NCCLCHECK(ncclGdrCudaFree(resources->gdrDesc));
+    if (mems[NCCL_NET_MAP_GDCMEM].cpuPtr) NCCLCHECK(ncclGdrCudaFree(resources->gdrDesc, proxyState->memManager));
     if (resources->shared) {
       NCCLCHECK(sharedNetBuffersDestroy(proxyState, resources->tpLocalRank, 1, connection));
       if (resources->maxRecvs > 1 && ncclParamNetSharedComms()) {

--- a/projects/rccl/src/transport/net_ib.cc
+++ b/projects/rccl/src/transport/net_ib.cc
@@ -2096,9 +2096,9 @@ cumem_flush_hsa:
         }
 #else
 #if defined(HIP_UNCACHED_MEMORY)
-        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), hipDeviceMallocUncached), ret, fail);
+        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), /*manager=*/nullptr, ncclMemPersist, hipDeviceMallocUncached), ret, fail);
 #else
-        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), hipDeviceMallocFinegrained), ret, fail);
+        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), /*manager=*/nullptr, ncclMemPersist, hipDeviceMallocFinegrained), ret, fail);
 #endif
         if (useDmaBuf)
         {
@@ -2122,7 +2122,7 @@ peermem_flush:
 flush_reg_done:
         if (!gpuFlushRegistered) {
           if (rCommDev->gpuFlush.gpuFlushGpuMem) {
-            ncclCudaFree(rCommDev->gpuFlush.gpuFlushGpuMem);
+            ncclCudaFree(rCommDev->gpuFlush.gpuFlushGpuMem, /*manager=*/nullptr);
             rCommDev->gpuFlush.gpuFlushGpuMem = nullptr;
           }
           rCommDev->gpuFlush.gpuMr = nullptr;
@@ -3090,7 +3090,7 @@ ncclResult_t ncclIbCloseRecv(void* recvComm) {
       struct ncclIbRecvCommDev* commDev = comm->devs + i;
       if (comm->flushEnabled) {
         if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
-          NCCLCHECK(ncclCudaFree(commDev->gpuFlush.gpuFlushGpuMem));
+          NCCLCHECK(ncclCudaFree(commDev->gpuFlush.gpuFlushGpuMem, /*manager=*/nullptr));
           commDev->gpuFlush.gpuFlushGpuMem = nullptr;
           if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
           commDev->gpuFlush.gpuMr = nullptr;

--- a/projects/rccl/src/transport/net_ib_cast.cc
+++ b/projects/rccl/src/transport/net_ib_cast.cc
@@ -2474,9 +2474,9 @@ ib_recv:
     if (rComm->flushEnabled) {
       if (rcclParamIbCastGdrFlushGpuMemNoRelaxedOrdering()) {
 #if defined(HIP_UNCACHED_MEMORY)
-        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), hipDeviceMallocUncached), ret, fail);
+        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), /*manager=*/nullptr, ncclMemPersist, hipDeviceMallocUncached), ret, fail);
 #else
-        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), hipDeviceMallocFinegrained), ret, fail);
+        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), /*manager=*/nullptr, ncclMemPersist, hipDeviceMallocFinegrained), ret, fail);
 #endif
         if (useDmaBuf)
         {
@@ -3808,7 +3808,7 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
       struct ncclIbRecvCommDev* commDev = comm->devs + i;
       if (comm->flushEnabled) {
         if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
-          NCCLCHECK(ncclCudaFree(commDev->gpuFlush.gpuFlushGpuMem));
+          NCCLCHECK(ncclCudaFree(commDev->gpuFlush.gpuFlushGpuMem, /*manager=*/nullptr));
           commDev->gpuFlush.gpuFlushGpuMem = nullptr;
           if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
           commDev->gpuFlush.gpuMr = nullptr;

--- a/projects/rccl/src/transport/p2p.cc
+++ b/projects/rccl/src/transport/p2p.cc
@@ -195,12 +195,12 @@ ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph
     // Check that legacy IPC support is available (WSL WAR)
     char *dummy;
     cudaIpcMemHandle_t ipc;
-    NCCLCHECK(ncclCudaMalloc(&dummy, CUDA_IPC_MIN));
+    NCCLCHECK(ncclCudaMalloc(&dummy, CUDA_IPC_MIN, comm->memManager, ncclMemOffload));
     if (cudaIpcGetMemHandle(&ipc, dummy) != cudaSuccess) {
       INFO(NCCL_INIT|NCCL_P2P,"Legacy IPC not supported");
       *ret = 0;
     }
-    NCCLCHECK(ncclCudaFree(dummy));
+    NCCLCHECK(ncclCudaFree(dummy, comm->memManager));
     legacyIPC = *ret;
     return ncclSuccess;
   }
@@ -223,14 +223,14 @@ ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph
   } while (0)
 
 // cuMem API support
-ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int refcount, ncclIpcDesc *ipcDesc, void **ptr) {
+ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int refcount, ncclIpcDesc *ipcDesc, void **ptr, struct ncclMemManager* manager, ncclMemType_t memtype) {
   if (ncclCuMemEnable()) {
 #if ROCM_VERSION >= 70000
     CUmemAllocationHandleType type = ncclCuMemHandleType;
 
     // cuMem API support
     CUmemGenericAllocationHandle handle;
-    NCCLCHECK(ncclCuMemAlloc(ptr, &handle, type, size));
+    NCCLCHECK(ncclCuMemAlloc(ptr, &handle, type, size, manager, memtype));
     if (type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
       // Return the native cuMem handle for later Export/Import via UDS
       memcpy(&ipcDesc->cuDesc.data, &handle, sizeof(handle));
@@ -247,14 +247,14 @@ ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int refcount, ncclIpcDe
   } else {
     // Allocate a CUDA buffer and generate an IPC handle for it
 #if defined(HIP_UNCACHED_MEMORY)
-    NCCLCHECK(ncclCudaCalloc((char **)ptr, size, hipDeviceMallocUncached));
+    NCCLCHECK(ncclCudaCalloc((char **)ptr, size, manager, memtype, hipDeviceMallocUncached));
 #else
-    NCCLCHECK(ncclCudaCalloc((char **)ptr, size, hipDeviceMallocFinegrained));
+    NCCLCHECK(ncclCudaCalloc((char **)ptr, size, manager, memtype, hipDeviceMallocFinegrained));
 #endif
     cudaError_t res = cudaIpcGetMemHandle(&ipcDesc->devIpc, *ptr);
     if (res != cudaSuccess) {
       WARN("cudaIpcGetMemHandle failed : %s", cudaGetErrorString(res));
-      ncclCudaFree(*ptr);
+      ncclCudaFree(*ptr, manager);
       CUDACHECK(res);
     }
   }
@@ -598,24 +598,24 @@ ncclResult_t p2pRecvConnect(struct ncclComm* comm, struct ncclConnect* connectIn
   return ncclSuccess;
 }
 
-ncclResult_t p2pSendFree(struct ncclConnector* send) {
+ncclResult_t p2pSendFree(struct ncclComm* comm, struct ncclConnector* send) {
   struct p2pResources* resources = (struct p2pResources*)send->transportResources;
   if (resources) {
     if (ncclCuMemEnable()) {
       // cuMem API support
       if (resources->sendMemIpc) {
         if (resources->sendMemSameProc) {
-          NCCLCHECK(ncclCuMemFreeAddr(resources->sendMemIpc));
+          NCCLCHECK(ncclCuMemFreeAddr(resources->sendMemIpc, comm->memManager));
         } else {
-          NCCLCHECK(ncclCudaFree(resources->sendMemIpc));
+          NCCLCHECK(ncclCudaFree(resources->sendMemIpc, comm->memManager));
         }
       }
 
       if (resources->recvMemIpc) {
         if (resources->recvMemSameProc) {
-          NCCLCHECK(ncclCuMemFreeAddr(resources->recvMemIpc));
+          NCCLCHECK(ncclCuMemFreeAddr(resources->recvMemIpc, comm->memManager));
         } else {
-          NCCLCHECK(ncclCudaFree(resources->recvMemIpc));
+          NCCLCHECK(ncclCudaFree(resources->recvMemIpc, comm->memManager));
         }
       }
     }
@@ -628,24 +628,24 @@ ncclResult_t p2pSendFree(struct ncclConnector* send) {
   return ncclSuccess;
 }
 
-ncclResult_t p2pRecvFree(struct ncclConnector* recv) {
+ncclResult_t p2pRecvFree(struct ncclComm* comm, struct ncclConnector* recv) {
   struct p2pResources* resources = (struct p2pResources*)recv->transportResources;
   if (resources) {
     if (ncclCuMemEnable()) {
       // cuMem API support
       if (resources->sendMemIpc) {
         if (resources->sendMemSameProc) {
-          NCCLCHECK(ncclCuMemFreeAddr(resources->sendMemIpc));
+          NCCLCHECK(ncclCuMemFreeAddr(resources->sendMemIpc, comm->memManager));
         } else {
-          NCCLCHECK(ncclCudaFree(resources->sendMemIpc));
+          NCCLCHECK(ncclCudaFree(resources->sendMemIpc, comm->memManager));
         }
       }
 
       if (resources->recvMemIpc) {
         if (resources->recvMemSameProc) {
-          NCCLCHECK(ncclCuMemFreeAddr(resources->recvMemIpc));
+          NCCLCHECK(ncclCuMemFreeAddr(resources->recvMemIpc, comm->memManager));
         } else {
-          NCCLCHECK(ncclCudaFree(resources->recvMemIpc));
+          NCCLCHECK(ncclCudaFree(resources->recvMemIpc, comm->memManager));
         }
       }
     }
@@ -672,9 +672,9 @@ static ncclResult_t p2pSendProxySetup(struct ncclProxyConnection* connection, st
     connection->transportResources = proxyInfo;
 
 #if defined(HIP_UNCACHED_MEMORY)
-    NCCLCHECK(ncclCudaCalloc(&proxyInfo->ceDevBuff, proxyState->buffSizes[NCCL_PROTO_SIMPLE], hipDeviceMallocUncached));
+    NCCLCHECK(ncclCudaCalloc(&proxyInfo->ceDevBuff, proxyState->buffSizes[NCCL_PROTO_SIMPLE], proxyState->memManager, ncclMemPersist, hipDeviceMallocUncached));
 #else
-    NCCLCHECK(ncclCudaCalloc(&proxyInfo->ceDevBuff, proxyState->buffSizes[NCCL_PROTO_SIMPLE], hipDeviceMallocFinegrained));
+    NCCLCHECK(ncclCudaCalloc(&proxyInfo->ceDevBuff, proxyState->buffSizes[NCCL_PROTO_SIMPLE], proxyState->memManager, ncclMemPersist, hipDeviceMallocFinegrained));
 #endif
 
     // Create a SHM segment for the peer to attach to
@@ -689,7 +689,7 @@ static ncclResult_t p2pSendProxySetup(struct ncclProxyConnection* connection, st
     int size = req->size;
     if (respSize != sizeof(struct ncclP2pBuff)) return ncclInternalError;
     struct ncclP2pBuff* p2pBuff = (struct ncclP2pBuff*)respBuff;
-    NCCLCHECK(ncclP2pAllocateShareableBuffer(size, req->refcount, &p2pBuff->ipcDesc, &p2pBuff->directPtr));
+    NCCLCHECK(ncclP2pAllocateShareableBuffer(size, req->refcount, &p2pBuff->ipcDesc, &p2pBuff->directPtr, proxyState->memManager, ncclMemOffload));
     p2pBuff->size = size;
     if (ncclCuMemEnable()) {
       // cuMem API support
@@ -711,7 +711,7 @@ static ncclResult_t p2pRecvProxySetup(struct ncclProxyConnection* connection, st
   int size = req->size;
   if (respSize != sizeof(struct ncclP2pBuff)) return ncclInternalError;
   struct ncclP2pBuff* p2pBuff = (struct ncclP2pBuff*)respBuff;
-  NCCLCHECK(ncclP2pAllocateShareableBuffer(size, req->refcount, &p2pBuff->ipcDesc, &p2pBuff->directPtr));
+  NCCLCHECK(ncclP2pAllocateShareableBuffer(size, req->refcount, &p2pBuff->ipcDesc, &p2pBuff->directPtr, proxyState->memManager, ncclMemOffload));
   p2pBuff->size = size;
   if (ncclCuMemEnable()) {
     // cuMem API support
@@ -747,7 +747,7 @@ static ncclResult_t p2pSendProxyFree(struct ncclProxyConnection* connection, str
     if (proxyInfo) {
       NCCLCHECK(ncclShmIpcClose(&proxyInfo->desc));
       NCCLCHECK(ncclCudaHostFree(proxyInfo->ceRecvMem));
-      NCCLCHECK(ncclCudaFree(proxyInfo->ceDevBuff));
+      NCCLCHECK(ncclCudaFree(proxyInfo->ceDevBuff, proxyState->memManager));
       CUDACHECK(cudaStreamDestroy(proxyInfo->stream));
       for (int i=0; i<NCCL_STEPS; i++) {
         CUDACHECK(cudaEventDestroy(proxyInfo->events[i]));
@@ -761,12 +761,12 @@ static ncclResult_t p2pSendProxyFree(struct ncclProxyConnection* connection, str
       if (proxyInfo) {
         struct ncclP2pBuff *p2pBuff = &proxyInfo->p2pBuff;
         ncclP2pFreeShareableBuffer(&p2pBuff->ipcDesc);
-        ncclCudaFree(p2pBuff->directPtr);
+        ncclCudaFree(p2pBuff->directPtr, proxyState->memManager);
         free(proxyInfo);
       }
     } else {
       // Do not check return code as CUDA may have already shut down
-      ncclCudaFree(connection->transportResources);
+      ncclCudaFree(connection->transportResources, proxyState->memManager);
     }
   }
   return ncclSuccess;
@@ -778,12 +778,12 @@ static ncclResult_t p2pRecvProxyFree(struct ncclProxyConnection* connection, str
     if (proxyInfo) {
       struct ncclP2pBuff *p2pBuff = &proxyInfo->p2pBuff;
       ncclP2pFreeShareableBuffer(&p2pBuff->ipcDesc);
-      ncclCudaFree(p2pBuff->directPtr);
+      ncclCudaFree(p2pBuff->directPtr, proxyState->memManager);
       free(proxyInfo);
     }
   } else {
     // Do not check return code as CUDA may have already shut down
-    ncclCudaFree(connection->transportResources);
+    ncclCudaFree(connection->transportResources, proxyState->memManager);
   }
   return ncclSuccess;
 }
@@ -974,7 +974,7 @@ ncclResult_t ret = ncclSuccess;
           NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(), &comm->sharedRes->hostStream, /*concurrent=*/false, &hostStream), ret, fail);
           NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(), &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream), ret, fail);
           if (regRecord->regIpcAddrs.devPeerRmtAddrs == NULL)
-            NCCLCHECKGOTO(ncclCudaCallocAsync(&regRecord->regIpcAddrs.devPeerRmtAddrs, comm->localRanks, hostStream), ret, fail);
+            NCCLCHECKGOTO(ncclCudaCallocAsync(&regRecord->regIpcAddrs.devPeerRmtAddrs, comm->localRanks, hostStream, comm->memManager), ret, fail);
           if (needUpdate)
             NCCLCHECKGOTO(ncclCudaMemcpyAsync(regRecord->regIpcAddrs.devPeerRmtAddrs, regRecord->regIpcAddrs.hostPeerRmtAddrs, comm->localRanks, hostStream), ret, fail);
           NCCLCHECKGOTO(ncclStreamWaitStream(deviceStream, hostStream, comm->sharedRes->scratchEvent), ret, fail);
@@ -1169,9 +1169,9 @@ static ncclResult_t p2pProxyDeregister(struct ncclProxyConnection* connection, s
     CUDACHECKGOTO(cudaIpcCloseMemHandle((void*)((uintptr_t)ipcInfo->rmtRegAddr - ipcInfo->offset)), ret, fail);
   } else {
     if (connection->sameProcess) {
-      NCCLCHECKGOTO(ncclCuMemFreeAddr((void*)((uintptr_t)ipcInfo->rmtRegAddr - ipcInfo->offset)), ret, fail);
+      NCCLCHECKGOTO(ncclCuMemFreeAddr((void*)((uintptr_t)ipcInfo->rmtRegAddr - ipcInfo->offset), nullptr), ret, fail);
     } else {
-      NCCLCHECKGOTO(ncclCudaFree((void*)((uintptr_t)ipcInfo->rmtRegAddr - ipcInfo->offset)), ret, fail);
+      NCCLCHECKGOTO(ncclCudaFree((void*)((uintptr_t)ipcInfo->rmtRegAddr - ipcInfo->offset), nullptr), ret, fail);
     }
   }
 

--- a/projects/rccl/src/transport/shm.cc
+++ b/projects/rccl/src/transport/shm.cc
@@ -224,7 +224,7 @@ static ncclResult_t shmRecvConnect(struct ncclComm* comm, struct ncclConnect* co
   return ncclSuccess;
 }
 
-static ncclResult_t shmSendFree(struct ncclConnector* send) {
+static ncclResult_t shmSendFree(struct ncclComm* comm, struct ncclConnector* send) {
   struct shmRecvResources* resources = (struct shmRecvResources*)send->transportResources;
   if (resources) {
     NCCLCHECK(ncclShmIpcClose(&resources->remDesc));
@@ -234,7 +234,7 @@ static ncclResult_t shmSendFree(struct ncclConnector* send) {
   return ncclSuccess;
 }
 
-static ncclResult_t shmRecvFree(struct ncclConnector* recv) {
+static ncclResult_t shmRecvFree(struct ncclComm* comm, struct ncclConnector* recv) {
   struct shmRecvResources* resources = (struct shmRecvResources*)recv->transportResources;
   if (resources) {
     NCCLCHECK(ncclShmIpcClose(&resources->remDesc));
@@ -254,7 +254,7 @@ static ncclResult_t shmSendProxyConnect(struct ncclProxyConnection* connection, 
   proxyInfo->shmFifo = reqInfo->shmFifo;
   proxyInfo->sendMem = reqInfo->sendMem;
   proxyInfo->recvMem = reqInfo->recvMem;
-  NCCLCHECKGOTO(ncclCudaCalloc(&proxyInfo->devFifo, proxyState->buffSizes[NCCL_PROTO_SIMPLE]), ret, fail);
+  NCCLCHECKGOTO(ncclCudaCalloc(&proxyInfo->devFifo, proxyState->buffSizes[NCCL_PROTO_SIMPLE], proxyState->memManager), ret, fail);
   NCCLCHECKGOTO(ncclCudaHostCalloc(&proxyInfo->ceRecvMem, 1), ret, fail);
   CUDACHECKGOTO(cudaStreamCreateWithFlags(&proxyInfo->stream, cudaStreamNonBlocking), ret, fail);
   for (int i=0; i<NCCL_STEPS; i++) {
@@ -269,7 +269,7 @@ exit:
   return ret;
 fail:
   if (proxyInfo->ceRecvMem) ncclCudaHostFree(proxyInfo->ceRecvMem);
-  if (proxyInfo->devFifo) (void)ncclCudaFree(proxyInfo->devFifo);
+  if (proxyInfo->devFifo) (void)ncclCudaFree(proxyInfo->devFifo, proxyState->memManager);
   free(proxyInfo);
   goto exit;
 }
@@ -284,7 +284,7 @@ static ncclResult_t shmRecvProxyConnect(struct ncclProxyConnection* connection, 
   proxyInfo->shmFifo = reqInfo->shmFifo;
   proxyInfo->sendMem = reqInfo->sendMem;
   proxyInfo->recvMem = reqInfo->recvMem;
-  NCCLCHECKGOTO(ncclCudaCalloc(&proxyInfo->devFifo, proxyState->buffSizes[NCCL_PROTO_SIMPLE]), ret, fail);
+  NCCLCHECKGOTO(ncclCudaCalloc(&proxyInfo->devFifo, proxyState->buffSizes[NCCL_PROTO_SIMPLE], proxyState->memManager), ret, fail);
   NCCLCHECKGOTO(ncclCudaHostCalloc(&proxyInfo->ceRecvMem, 1), ret, fail);
   CUDACHECKGOTO(cudaStreamCreateWithFlags(&proxyInfo->stream, cudaStreamNonBlocking), ret, fail);
   for (int i=0; i<NCCL_STEPS; i++) {
@@ -297,7 +297,7 @@ exit:
   return ret;
 fail:
   if (proxyInfo->ceRecvMem) ncclCudaHostFree(proxyInfo->ceRecvMem);
-  if (proxyInfo->devFifo) (void)ncclCudaFree(proxyInfo->devFifo);
+  if (proxyInfo->devFifo) (void)ncclCudaFree(proxyInfo->devFifo, proxyState->memManager);
   free(proxyInfo);
   goto exit;
 }
@@ -308,7 +308,7 @@ static ncclResult_t shmSendProxyFree(struct ncclProxyConnection* connection, str
   if (resources) {
     if (useMemcpySend) {
       CUDACHECK(cudaStreamDestroy(resources->stream));
-      NCCLCHECK(ncclCudaFree(resources->devFifo));
+      NCCLCHECK(ncclCudaFree(resources->devFifo, proxyState->memManager));
       NCCLCHECK(ncclCudaHostFree(resources->ceRecvMem));
       for (int i=0; i<NCCL_STEPS; i++) {
         CUDACHECK(cudaEventDestroy(resources->events[i]));
@@ -327,7 +327,7 @@ static ncclResult_t shmRecvProxyFree(struct ncclProxyConnection* connection, str
   if (resources) {
     if (useMemcpyRecv) {
       CUDACHECK(cudaStreamDestroy(resources->stream));
-      NCCLCHECK(ncclCudaFree(resources->devFifo));
+      NCCLCHECK(ncclCudaFree(resources->devFifo, proxyState->memManager));
       NCCLCHECK(ncclCudaHostFree(resources->ceRecvMem));
       for (int i=0; i<NCCL_STEPS; i++) {
         CUDACHECK(cudaEventDestroy(resources->events[i]));

--- a/projects/rccl/test/AllocTests.cpp
+++ b/projects/rccl/test/AllocTests.cpp
@@ -85,7 +85,7 @@ TEST(Alloc, ncclCuMemAlloc)
             void*                      handle = reinterpret_cast<void*>(0x5678);
             size_t                     size   = 1024;
             hipMemAllocationHandleType type   = hipMemHandleTypeNone;
-            ncclResult_t               result = ncclCuMemAlloc(&ptr, &handle, type, size);
+            ncclResult_t               result = ncclCuMemAlloc(&ptr, &handle, type, size, /*manager=*/nullptr);
             EXPECT_EQ(result, ncclInternalError);
         }
     );
@@ -98,7 +98,7 @@ TEST(Alloc, ncclCuMemFree)
         []()
         {
             void*        dummyPtr = reinterpret_cast<void*>(0xdeadbeef);
-            ncclResult_t result   = ncclCuMemFree(dummyPtr);
+            ncclResult_t result   = ncclCuMemFree(dummyPtr, /*manager=*/nullptr);
             EXPECT_EQ(result, ncclInternalError);
         }
     );
@@ -127,7 +127,7 @@ TEST(Alloc, ncclCuMemFreeAddr)
         []()
         {
             void*        testPtr = reinterpret_cast<void*>(0xbeefcafe);
-            ncclResult_t result  = ncclCuMemFreeAddr(testPtr);
+            ncclResult_t result  = ncclCuMemFreeAddr(testPtr, /*manager=*/nullptr);
             ASSERT_EQ(result, ncclInternalError);
         }
     );

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -275,6 +275,7 @@ if(BUILD_TESTS)
       transport/NetIbMPI/NicFusionTests.cpp
       ImplicitLaunchOrderMPITests.cpp
       RegistrationMPITests.cpp
+      mem_manager/SuspendResumeMPITests.cpp
     )
 
     add_executable(rccl-UnitTestsMPI ${MPI_TEST_SOURCE_FILES})

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -230,6 +230,7 @@ if(BUILD_TESTS)
       ProxyTests.cpp
       RcclWrapTests.cpp
       TransportTests.cpp
+      mem_manager/MemManagerTests.cpp
       graph/XmlTests.cpp
       common/main_fixtures.cpp
       common/EnvVars.cpp

--- a/projects/rccl/test/TransportTests.cpp
+++ b/projects/rccl/test/TransportTests.cpp
@@ -200,7 +200,7 @@ TEST(TransportTest, CollNetFreeTest) {
 
   // Setup dummy ncclTransportComm with only `free` implemented
   static ncclTransportComm dummyTransportComm = {};
-  dummyTransportComm.free = [](ncclConnector* conn) -> ncclResult_t {
+  dummyTransportComm.free = [](ncclComm* /*comm*/, ncclConnector* conn) -> ncclResult_t {
     if (conn && conn->transportResources) {
       free(conn->transportResources);
       conn->transportResources = nullptr;

--- a/projects/rccl/test/mem_manager/MemManagerTests.cpp
+++ b/projects/rccl/test/mem_manager/MemManagerTests.cpp
@@ -1054,4 +1054,163 @@ TEST(MemManagerRealMem, Destroy_FreesPopulatedEntries)
     });
 }
 
+// ---------------------------------------------------------------------------
+// Suspend / Resume - early-return error paths (no HIP, no bootstrap)
+//
+// All of these exercise the validation block at the top of ncclCommMemSuspend /
+// ncclCommMemResume, which returns before touching any HIP API or bootstrap.
+// ---------------------------------------------------------------------------
+
+TEST_F(MemManagerTest, Suspend_NullComm)
+{
+    EXPECT_EQ(ncclCommMemSuspend(nullptr), ncclInvalidArgument);
+}
+
+TEST_F(MemManagerTest, Suspend_NullManager)
+{
+    ASSERT_EQ(comm->memManager, nullptr);
+    EXPECT_EQ(ncclCommMemSuspend(comm), ncclInvalidUsage);
+}
+
+TEST_F(MemManagerTest, Suspend_AlreadyReleased)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    comm->memManager->released = 1;
+    EXPECT_EQ(ncclCommMemSuspend(comm), ncclInvalidUsage);
+}
+
+TEST_F(MemManagerTest, Resume_NullComm)
+{
+    EXPECT_EQ(ncclCommMemResume(nullptr), ncclInvalidArgument);
+}
+
+TEST_F(MemManagerTest, Resume_NullManager)
+{
+    ASSERT_EQ(comm->memManager, nullptr);
+    EXPECT_EQ(ncclCommMemResume(comm), ncclInvalidUsage);
+}
+
+TEST_F(MemManagerTest, Resume_NotReleased)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ASSERT_EQ(comm->memManager->released, 0);
+    EXPECT_EQ(ncclCommMemResume(comm), ncclInvalidUsage);
+}
+
+// ---------------------------------------------------------------------------
+// MemStats fixture: ncclCommMemStats calls CommCheck + ncclCommEnsureReady, so
+// the comm needs valid magic markers and a non-null abortFlag. We still avoid
+// any HIP/bootstrap activity - all paths in MemStats are purely manager-state.
+// ---------------------------------------------------------------------------
+
+class MemManagerStatsTest : public ::testing::Test
+{
+protected:
+    ncclComm* comm     = nullptr;
+    uint32_t  abortVal = 0;
+
+    void SetUp() override
+    {
+        comm             = new ncclComm();
+        comm->cudaDev    = 0;
+        comm->startMagic = NCCL_MAGIC;
+        comm->endMagic   = NCCL_MAGIC;
+        comm->abortFlag  = &abortVal;
+    }
+
+    void TearDown() override
+    {
+        if(comm && comm->memManager) {
+            ncclMemManagerDestroy(comm);
+        }
+        delete comm;
+        comm = nullptr;
+    }
+
+    uint64_t readStat(ncclCommMemStat_t s)
+    {
+        uint64_t v = ~0ULL;
+        EXPECT_EQ(ncclCommMemStats(comm, s, &v), ncclSuccess);
+        return v;
+    }
+};
+
+TEST_F(MemManagerStatsTest, Empty)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+    EXPECT_EQ(readStat(ncclStatGpuMemTotal), 0u);
+    EXPECT_EQ(readStat(ncclStatGpuMemPersist), 0u);
+    EXPECT_EQ(readStat(ncclStatGpuMemSuspend), 0u);
+    EXPECT_EQ(readStat(ncclStatGpuMemSuspended), 0u);
+}
+
+TEST_F(MemManagerStatsTest, Counters_PersistScratchOffload)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+    constexpr size_t kPersist = 1024;
+    constexpr size_t kScratch = 4096;
+    constexpr size_t kOffload = 2048;
+
+    ASSERT_EQ(ncclMemTrack(comm->memManager, fakePtr(1), kPersist,
+                           fakeHandle(), kFakeHandleType, ncclMemPersist),
+              ncclSuccess);
+    ASSERT_EQ(ncclMemTrack(comm->memManager, fakePtr(2), kScratch,
+                           fakeHandle(), kFakeHandleType, ncclMemScratch),
+              ncclSuccess);
+    ASSERT_EQ(ncclMemTrack(comm->memManager, fakePtr(3), kOffload,
+                           fakeHandle(), kFakeHandleType, ncclMemOffload),
+              ncclSuccess);
+
+    EXPECT_EQ(readStat(ncclStatGpuMemPersist), kPersist);
+    EXPECT_EQ(readStat(ncclStatGpuMemSuspend), kScratch + kOffload);
+    EXPECT_EQ(readStat(ncclStatGpuMemTotal),   kPersist + kScratch + kOffload);
+    EXPECT_EQ(readStat(ncclStatGpuMemSuspended), 0u);
+
+    ASSERT_EQ(ncclMemUntrack(comm->memManager, fakePtr(2), kScratch), ncclSuccess);
+    ASSERT_EQ(ncclMemUntrack(comm->memManager, fakePtr(3), kOffload), ncclSuccess);
+
+    EXPECT_EQ(readStat(ncclStatGpuMemSuspend), 0u);
+    EXPECT_EQ(readStat(ncclStatGpuMemPersist), kPersist);
+    EXPECT_EQ(readStat(ncclStatGpuMemTotal),   kPersist);
+}
+
+TEST_F(MemManagerStatsTest, NullManager_ReturnsZero)
+{
+    ASSERT_EQ(comm->memManager, nullptr);
+    uint64_t v = ~0ULL;
+    EXPECT_EQ(ncclCommMemStats(comm, ncclStatGpuMemTotal, &v), ncclSuccess);
+    EXPECT_EQ(v, 0u);
+}
+
+TEST_F(MemManagerStatsTest, NullValue_Rejected)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    EXPECT_EQ(ncclCommMemStats(comm, ncclStatGpuMemTotal, nullptr),
+              ncclInvalidArgument);
+}
+
+TEST_F(MemManagerStatsTest, InvalidStat_Rejected)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    uint64_t v = 0;
+    EXPECT_EQ(ncclCommMemStats(comm, static_cast<ncclCommMemStat_t>(99), &v),
+              ncclInvalidArgument);
+}
+
+TEST_F(MemManagerStatsTest, SuspendedFlag_FlipsWithReleased)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    EXPECT_EQ(readStat(ncclStatGpuMemSuspended), 0u);
+
+    // Simulate ncclCommMemSuspend's only externally observable effect on stats
+    // without paying for the bootstrap+VMM round-trip (covered by the MPI suite).
+    comm->memManager->released = 1;
+    EXPECT_EQ(readStat(ncclStatGpuMemSuspended), 1u);
+
+    comm->memManager->released = 0;
+    EXPECT_EQ(readStat(ncclStatGpuMemSuspended), 0u);
+}
+
 } // namespace RcclUnitTesting

--- a/projects/rccl/test/mem_manager/MemManagerTests.cpp
+++ b/projects/rccl/test/mem_manager/MemManagerTests.cpp
@@ -1,0 +1,1057 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cerrno>
+#include <fcntl.h>
+#include <random>
+#include <thread>
+#include <unistd.h>
+#include <unordered_map>
+#include <vector>
+
+#include "alloc.h"
+#include "comm.h"
+#include "mem_manager.h"
+#include "utils.h"
+
+#include "ProcessIsolatedTestRunner.hpp"
+
+namespace RcclUnitTesting
+{
+
+// Synthetic constants used by pure-state tests. The manager only stores and
+// compares ptr / handle, so any sufficiently distinct value works.
+namespace
+{
+constexpr uintptr_t              kFakePtrBase    = 0xDEAD0000ULL;
+const hipMemAllocationHandleType kFakeHandleType = hipMemHandleTypePosixFileDescriptor;
+
+hipMemGenericAllocationHandle_t fakeHandle()
+{
+    return reinterpret_cast<hipMemGenericAllocationHandle_t>(0xCAFEF00DULL);
+}
+
+void* fakePtr(uintptr_t i) { return reinterpret_cast<void*>(kFakePtrBase + i); }
+} // namespace
+
+// Pure-state fixture: no HIP init, no real allocations. Suitable for fast logic
+// checks against the manager's bookkeeping (counters, linked-list, refCount).
+class MemManagerTest : public ::testing::Test
+{
+protected:
+    ncclComm* comm = nullptr;
+
+    void SetUp() override
+    {
+        comm = new ncclComm();
+        comm->cudaDev = 0;
+    }
+
+    void TearDown() override
+    {
+        if(comm && comm->memManager) {
+            ncclMemManagerDestroy(comm);
+        }
+        delete comm;
+        comm = nullptr;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Init / Destroy (pure state)
+// ---------------------------------------------------------------------------
+
+TEST_F(MemManagerTest, Init_Success)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ASSERT_NE(comm->memManager, nullptr);
+
+    ncclMemManager* m = comm->memManager;
+    EXPECT_EQ(m->initialized, 1);
+    EXPECT_EQ(m->refCount, 1);
+    EXPECT_EQ(m->numEntries, 0);
+    EXPECT_EQ(m->entries, nullptr);
+    EXPECT_EQ(m->commCudaDev, 0);
+    EXPECT_EQ(m->totalPersist, 0u);
+    EXPECT_EQ(m->totalPersistImported, 0u);
+    EXPECT_EQ(m->totalScratch, 0u);
+    EXPECT_EQ(m->totalScratchImported, 0u);
+    EXPECT_EQ(m->totalOffload, 0u);
+    EXPECT_EQ(m->totalOffloadImported, 0u);
+    EXPECT_EQ(m->cpuBackupUsage, 0u);
+}
+
+TEST_F(MemManagerTest, Init_NullComm)
+{
+    EXPECT_EQ(ncclMemManagerInit(nullptr), ncclInvalidArgument);
+}
+
+TEST_F(MemManagerTest, Destroy_NullComm)
+{
+    EXPECT_EQ(ncclMemManagerDestroy(nullptr), ncclInvalidArgument);
+}
+
+TEST_F(MemManagerTest, Destroy_NullManager)
+{
+    ASSERT_EQ(comm->memManager, nullptr);
+    EXPECT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+}
+
+TEST_F(MemManagerTest, Destroy_RefCountDecrement)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* shared = comm->memManager;
+
+    // Simulate parent->shareResources path: bump refCount and reuse manager.
+    ncclComm* child   = new ncclComm();
+    child->cudaDev    = 0;
+    child->memManager = shared;
+    ncclAtomicRefCountIncrement(&shared->refCount);
+    ASSERT_EQ(shared->refCount, 2);
+
+    ASSERT_EQ(ncclMemManagerDestroy(child), ncclSuccess);
+    EXPECT_EQ(child->memManager, nullptr);
+    EXPECT_EQ(shared->refCount, 1);
+    EXPECT_EQ(shared->initialized, 1);
+    delete child;
+
+    ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+    EXPECT_EQ(comm->memManager, nullptr);
+}
+
+TEST_F(MemManagerTest, RefCount_MultipleChildren_VariousDestroyOrder)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* shared = comm->memManager;
+
+    constexpr int          kChildren = 3;
+    std::vector<ncclComm*> children;
+    for(int i = 0; i < kChildren; ++i) {
+        ncclComm* c   = new ncclComm();
+        c->cudaDev    = 0;
+        c->memManager = shared;
+        ncclAtomicRefCountIncrement(&shared->refCount);
+        children.push_back(c);
+    }
+    ASSERT_EQ(shared->refCount, 1 + kChildren);
+
+    // Destroy children in non-sequential order: 0, 2, 1. Manager must stay
+    // alive until refCount drops to 0 (only parent left).
+    const int order[kChildren] = {0, 2, 1};
+    int       expectedRefCount = 1 + kChildren;
+    for(int idx : order) {
+        ASSERT_EQ(ncclMemManagerDestroy(children[idx]), ncclSuccess);
+        EXPECT_EQ(children[idx]->memManager, nullptr);
+        --expectedRefCount;
+        EXPECT_EQ(shared->refCount, expectedRefCount);
+        EXPECT_EQ(shared->initialized, 1) << "shared manager freed prematurely";
+    }
+    for(auto* c : children) {
+        delete c;
+    }
+
+    ASSERT_EQ(shared->refCount, 1);
+    ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+    EXPECT_EQ(comm->memManager, nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// Track / Untrack (pure state, synthetic pointers)
+// ---------------------------------------------------------------------------
+
+TEST_F(MemManagerTest, Track_PersistOnlyUpdatesCounter)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* m = comm->memManager;
+
+    constexpr size_t kSize = 4096;
+    ASSERT_EQ(ncclMemTrack(m, fakePtr(1), kSize, fakeHandle(), kFakeHandleType, ncclMemPersist),
+              ncclSuccess);
+
+    EXPECT_EQ(m->numEntries, 0);
+    EXPECT_EQ(m->entries, nullptr);
+    EXPECT_EQ(m->totalPersist, kSize);
+    EXPECT_EQ(m->totalScratch, 0u);
+    EXPECT_EQ(m->totalOffload, 0u);
+}
+
+TEST_F(MemManagerTest, TrackImportFromPeer_FillsImportedDesc)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* m = comm->memManager;
+
+    constexpr size_t kSize     = 2048;
+    constexpr int    kOwnerRk  = 7;
+    constexpr int    kOwnerDev = 3;
+    void*            p         = fakePtr(4);
+    void*            ownerPtr  = fakePtr(0xABCD);
+
+    ASSERT_EQ(ncclMemTrackImportFromPeer(m, p, kSize, fakeHandle(), kFakeHandleType,
+                                         ncclMemScratch, kOwnerRk, kOwnerDev, ownerPtr),
+              ncclSuccess);
+
+    ASSERT_NE(m->entries, nullptr);
+    EXPECT_EQ(m->numEntries, 1);
+    EXPECT_TRUE(m->entries->isImportedFromPeer);
+    EXPECT_EQ(m->entries->desc.imported.ownerRank, kOwnerRk);
+    EXPECT_EQ(m->entries->desc.imported.ownerDev, kOwnerDev);
+    EXPECT_EQ(m->entries->desc.imported.ownerPtr, ownerPtr);
+    EXPECT_EQ(m->totalScratchImported, kSize);
+    EXPECT_EQ(m->totalScratch, 0u);
+
+    ASSERT_EQ(ncclMemTrackImportFromPeer(m, fakePtr(5), kSize, fakeHandle(), kFakeHandleType,
+                                         ncclMemPersist, kOwnerRk, kOwnerDev, ownerPtr),
+              ncclSuccess);
+    EXPECT_EQ(m->totalPersistImported, kSize);
+    EXPECT_EQ(m->totalPersist, 0u);
+}
+
+TEST_F(MemManagerTest, TrackImport_CountersIncrement_AllMemTypes)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* m = comm->memManager;
+
+    constexpr size_t kP = 1024;
+    constexpr size_t kS = 2048;
+    constexpr size_t kO = 4096;
+
+    ASSERT_EQ(ncclMemTrackImportFromPeer(m, fakePtr(0x40), kP, fakeHandle(), kFakeHandleType,
+                                         ncclMemPersist, /*ownerRank=*/1, /*ownerDev=*/0,
+                                         /*ownerPtr=*/fakePtr(0x140)),
+              ncclSuccess);
+    ASSERT_EQ(ncclMemTrackImportFromPeer(m, fakePtr(0x41), kS, fakeHandle(), kFakeHandleType,
+                                         ncclMemScratch, /*ownerRank=*/2, /*ownerDev=*/0,
+                                         /*ownerPtr=*/fakePtr(0x141)),
+              ncclSuccess);
+    ASSERT_EQ(ncclMemTrackImportFromPeer(m, fakePtr(0x42), kO, fakeHandle(), kFakeHandleType,
+                                         ncclMemOffload, /*ownerRank=*/3, /*ownerDev=*/0,
+                                         /*ownerPtr=*/fakePtr(0x142)),
+              ncclSuccess);
+
+    EXPECT_EQ(m->totalPersistImported, kP);
+    EXPECT_EQ(m->totalScratchImported, kS);
+    EXPECT_EQ(m->totalOffloadImported, kO);
+    // Local counters stay untouched: imported allocations don't bump them.
+    EXPECT_EQ(m->totalPersist, 0u);
+    EXPECT_EQ(m->totalScratch, 0u);
+    EXPECT_EQ(m->totalOffload, 0u);
+    // Persist isn't kept in the linked list, only Scratch and Offload are.
+    EXPECT_EQ(m->numEntries, 2);
+
+    ASSERT_EQ(ncclMemUntrack(m, fakePtr(0x41), kS), ncclSuccess);
+    ASSERT_EQ(ncclMemUntrack(m, fakePtr(0x42), kO), ncclSuccess);
+    EXPECT_EQ(m->totalScratchImported, 0u);
+    EXPECT_EQ(m->totalOffloadImported, 0u);
+}
+
+TEST_F(MemManagerTest, Untrack_PersistPath)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* m = comm->memManager;
+
+    constexpr size_t kSize = 1024;
+    void*            p     = fakePtr(7);
+    ASSERT_EQ(ncclMemTrack(m, p, kSize, fakeHandle(), kFakeHandleType, ncclMemPersist),
+              ncclSuccess);
+    ASSERT_EQ(m->totalPersist, kSize);
+
+    // Persistent allocations are not in the linked list; Untrack falls into
+    // the "not found" branch which decrements totalPersist by the passed size.
+    ASSERT_EQ(ncclMemUntrack(m, p, kSize), ncclSuccess);
+    EXPECT_EQ(m->totalPersist, 0u);
+    EXPECT_EQ(m->numEntries, 0);
+}
+
+TEST_F(MemManagerTest, Untrack_NullManagerReturnsError)
+{
+    EXPECT_EQ(ncclMemUntrack(nullptr, fakePtr(8), 1024), ncclInternalError);
+}
+
+TEST_F(MemManagerTest, Untrack_NullPtrReturnsError)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    EXPECT_EQ(ncclMemUntrack(comm->memManager, nullptr, 1024), ncclInternalError);
+}
+
+TEST_F(MemManagerTest, Untrack_HeadMiddleTail_LinkedListRemoval)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* m = comm->memManager;
+
+    // Track A,B,C,D in order. Track prepends, so the list is
+    // head=D -> C -> B -> A=tail.
+    constexpr size_t kSize = 1024;
+    void*            a     = fakePtr(0x300);
+    void*            b     = fakePtr(0x301);
+    void*            c     = fakePtr(0x302);
+    void*            d     = fakePtr(0x303);
+    for(void* p : {a, b, c, d}) {
+        ASSERT_EQ(ncclMemTrack(m, p, kSize, fakeHandle(), kFakeHandleType, ncclMemScratch),
+                  ncclSuccess);
+    }
+    ASSERT_EQ(m->numEntries, 4);
+    ASSERT_EQ(m->entries->ptr, d);                                // head
+    ASSERT_EQ(m->entries->next->ptr, c);
+    ASSERT_EQ(m->entries->next->next->ptr, b);
+    ASSERT_EQ(m->entries->next->next->next->ptr, a);              // tail
+
+    // 1) Untrack the head: hits the prev == nullptr branch.
+    ASSERT_EQ(ncclMemUntrack(m, d, kSize), ncclSuccess);
+    EXPECT_EQ(m->numEntries, 3);
+    EXPECT_EQ(m->entries->ptr, c);
+
+    // 2) Untrack the middle: prev != nullptr, entry->next != nullptr.
+    ASSERT_EQ(ncclMemUntrack(m, b, kSize), ncclSuccess);
+    EXPECT_EQ(m->numEntries, 2);
+    EXPECT_EQ(m->entries->ptr, c);
+    EXPECT_EQ(m->entries->next->ptr, a);
+
+    // 3) Untrack the tail: prev != nullptr, entry->next == nullptr.
+    ASSERT_EQ(ncclMemUntrack(m, a, kSize), ncclSuccess);
+    EXPECT_EQ(m->numEntries, 1);
+    EXPECT_EQ(m->entries->ptr, c);
+    EXPECT_EQ(m->entries->next, nullptr);
+
+    // 4) Untrack the singleton: prev == nullptr AND head becomes nullptr.
+    ASSERT_EQ(ncclMemUntrack(m, c, kSize), ncclSuccess);
+    EXPECT_EQ(m->numEntries, 0);
+    EXPECT_EQ(m->entries, nullptr);
+    EXPECT_EQ(m->totalScratch, 0u);
+}
+
+TEST_F(MemManagerTest, Untrack_SizeMismatchUsesTrackedSize)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* m = comm->memManager;
+
+    constexpr size_t kTracked = 4096;
+    void*            p        = fakePtr(0x310);
+    ASSERT_EQ(ncclMemTrack(m, p, kTracked, fakeHandle(), kFakeHandleType, ncclMemScratch),
+              ncclSuccess);
+    ASSERT_EQ(m->totalScratch, kTracked);
+
+    // Pass a wildly wrong size: manager logs a mismatch but uses the tracked
+    // entry->size for accounting. This documents the contract — callers may
+    // pass 0 or a stale size and the totals stay consistent.
+    ASSERT_EQ(ncclMemUntrack(m, p, /*passedSize=*/123), ncclSuccess);
+    EXPECT_EQ(m->totalScratch, 0u);
+    EXPECT_EQ(m->numEntries, 0);
+}
+
+TEST_F(MemManagerTest, Track_DuplicatePtr_CreatesTwoEntries)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* m = comm->memManager;
+
+    // Manager doesn't dedupe Track — two entries with the same ptr can legally
+    // co-exist (e.g. recycled VA after Untrack/Track in flight). Removal is
+    // LIFO because Track prepends.
+    constexpr size_t kSizeA = 1024;
+    constexpr size_t kSizeB = 2048;
+    void*            p      = fakePtr(0x320);
+
+    ASSERT_EQ(ncclMemTrack(m, p, kSizeA, fakeHandle(), kFakeHandleType, ncclMemScratch),
+              ncclSuccess);
+    ASSERT_EQ(ncclMemTrack(m, p, kSizeB, fakeHandle(), kFakeHandleType, ncclMemScratch),
+              ncclSuccess);
+    EXPECT_EQ(m->numEntries, 2);
+    EXPECT_EQ(m->totalScratch, kSizeA + kSizeB);
+
+    // First Untrack hits the head (prepended last) — kSizeB.
+    ASSERT_EQ(ncclMemUntrack(m, p, kSizeB), ncclSuccess);
+    EXPECT_EQ(m->numEntries, 1);
+    EXPECT_EQ(m->totalScratch, kSizeA);
+    EXPECT_EQ(m->entries->size, kSizeA);
+
+    // Second Untrack hits the remaining (originally first) entry.
+    ASSERT_EQ(ncclMemUntrack(m, p, kSizeA), ncclSuccess);
+    EXPECT_EQ(m->numEntries, 0);
+    EXPECT_EQ(m->totalScratch, 0u);
+}
+
+// ---------------------------------------------------------------------------
+// MarkExportToPeer
+// ---------------------------------------------------------------------------
+
+TEST_F(MemManagerTest, MarkExport_AddsPeer)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* m = comm->memManager;
+
+    void* p = fakePtr(9);
+    ASSERT_EQ(ncclMemTrack(m, p, 4096, fakeHandle(), kFakeHandleType, ncclMemScratch),
+              ncclSuccess);
+
+    ASSERT_EQ(ncclDynMemMarkExportToPeer(m, p, /*peerRank=*/1), ncclSuccess);
+    EXPECT_EQ(m->entries->desc.local.numExportedPeers, 1);
+    EXPECT_EQ(m->entries->desc.local.exportedPeersCapacity, NCCL_MEM_EXPORT_PEERS_INIT);
+    EXPECT_EQ(m->entries->desc.local.exportedPeerRanks[0], 1);
+}
+
+TEST_F(MemManagerTest, MarkExport_GrowsCapacity)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* m = comm->memManager;
+
+    void* p = fakePtr(10);
+    ASSERT_EQ(ncclMemTrack(m, p, 4096, fakeHandle(), kFakeHandleType, ncclMemScratch),
+              ncclSuccess);
+
+    constexpr int kPeers = NCCL_MEM_EXPORT_PEERS_INIT + 1;
+    for(int peer = 0; peer < kPeers; ++peer) {
+        ASSERT_EQ(ncclDynMemMarkExportToPeer(m, p, peer), ncclSuccess) << "peer=" << peer;
+    }
+    EXPECT_EQ(m->entries->desc.local.numExportedPeers, kPeers);
+    EXPECT_EQ(m->entries->desc.local.exportedPeersCapacity, NCCL_MEM_EXPORT_PEERS_INIT * 2);
+    for(int peer = 0; peer < kPeers; ++peer) {
+        EXPECT_EQ(m->entries->desc.local.exportedPeerRanks[peer], peer);
+    }
+}
+
+TEST_F(MemManagerTest, MarkExport_DuplicatePeerRejected)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* m = comm->memManager;
+
+    void* p = fakePtr(11);
+    ASSERT_EQ(ncclMemTrack(m, p, 4096, fakeHandle(), kFakeHandleType, ncclMemScratch),
+              ncclSuccess);
+
+    ASSERT_EQ(ncclDynMemMarkExportToPeer(m, p, 2), ncclSuccess);
+    EXPECT_EQ(ncclDynMemMarkExportToPeer(m, p, 2), ncclInternalError);
+    EXPECT_EQ(m->entries->desc.local.numExportedPeers, 1);
+}
+
+TEST_F(MemManagerTest, MarkExport_PersistRejected)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* m = comm->memManager;
+
+    void* p = fakePtr(12);
+    ASSERT_EQ(ncclMemTrack(m, p, 4096, fakeHandle(), kFakeHandleType, ncclMemPersist),
+              ncclSuccess);
+    EXPECT_EQ(ncclDynMemMarkExportToPeer(m, p, 1), ncclInternalError);
+}
+
+TEST_F(MemManagerTest, MarkExport_ImportedRejected)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* m = comm->memManager;
+
+    void* p = fakePtr(13);
+    ASSERT_EQ(ncclMemTrackImportFromPeer(m, p, 4096, fakeHandle(), kFakeHandleType,
+                                         ncclMemScratch, /*ownerRank=*/4, /*ownerDev=*/0,
+                                         /*ownerPtr=*/fakePtr(0xBEEF)),
+              ncclSuccess);
+    EXPECT_EQ(ncclDynMemMarkExportToPeer(m, p, 1), ncclInternalError);
+}
+
+TEST_F(MemManagerTest, MarkExport_GrowsCapacity_LargeN)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* m = comm->memManager;
+
+    void* p = fakePtr(0x330);
+    ASSERT_EQ(ncclMemTrack(m, p, 4096, fakeHandle(), kFakeHandleType, ncclMemScratch),
+              ncclSuccess);
+
+    // 65 unique peer ranks. Capacity grows 0 -> 8 -> 16 -> 32 -> 64 -> 128 as
+    // ncclRealloc doubles each time numExportedPeers reaches the cap.
+    constexpr int kPeers = 65;
+    for(int peer = 0; peer < kPeers; ++peer) {
+        ASSERT_EQ(ncclDynMemMarkExportToPeer(m, p, peer), ncclSuccess) << "peer=" << peer;
+    }
+    EXPECT_EQ(m->entries->desc.local.numExportedPeers, kPeers);
+    EXPECT_EQ(m->entries->desc.local.exportedPeersCapacity, 128);
+    for(int peer = 0; peer < kPeers; ++peer) {
+        EXPECT_EQ(m->entries->desc.local.exportedPeerRanks[peer], peer) << "peer=" << peer;
+    }
+}
+
+TEST_F(MemManagerTest, MarkExport_FreedOnUntrack)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* m = comm->memManager;
+
+    void* p = fakePtr(0x340);
+    ASSERT_EQ(ncclMemTrack(m, p, 4096, fakeHandle(), kFakeHandleType, ncclMemScratch),
+              ncclSuccess);
+    for(int peer = 0; peer < 4; ++peer) {
+        ASSERT_EQ(ncclDynMemMarkExportToPeer(m, p, peer), ncclSuccess);
+    }
+    ASSERT_NE(m->entries->desc.local.exportedPeerRanks, nullptr);
+    ASSERT_EQ(m->entries->desc.local.numExportedPeers, 4);
+
+    // Untrack must free the exportedPeerRanks array along with the entry.
+    // ASan/leak-sanitizer would flag a missed free here.
+    ASSERT_EQ(ncclMemUntrack(m, p, 4096), ncclSuccess);
+    EXPECT_EQ(m->numEntries, 0);
+    EXPECT_EQ(m->entries, nullptr);
+
+    // Re-track the same ptr: the new entry must start with a clean slate, no
+    // stale capacity carried over from the freed entry.
+    ASSERT_EQ(ncclMemTrack(m, p, 4096, fakeHandle(), kFakeHandleType, ncclMemScratch),
+              ncclSuccess);
+    EXPECT_EQ(m->entries->desc.local.numExportedPeers, 0);
+    EXPECT_EQ(m->entries->desc.local.exportedPeersCapacity, 0);
+    EXPECT_EQ(m->entries->desc.local.exportedPeerRanks, nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency smoke (pure state)
+// ---------------------------------------------------------------------------
+
+TEST_F(MemManagerTest, ConcurrentTrackUntrack)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* m = comm->memManager;
+
+    constexpr int    kThreads   = 8;
+    constexpr int    kPerThread = 256;
+    constexpr size_t kSize      = 64;
+    std::atomic<int> trackFailures{0};
+    std::atomic<int> untrackFailures{0};
+
+    auto worker = [&](int tid) {
+        for(int i = 0; i < kPerThread; ++i) {
+            void* p = fakePtr(static_cast<uintptr_t>(tid) * 0x10000ULL + i + 1);
+            if(ncclMemTrack(m, p, kSize, fakeHandle(), kFakeHandleType, ncclMemScratch)
+               != ncclSuccess) {
+                ++trackFailures;
+            }
+            if(ncclMemUntrack(m, p, kSize) != ncclSuccess) {
+                ++untrackFailures;
+            }
+        }
+    };
+
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+    for(int t = 0; t < kThreads; ++t) {
+        threads.emplace_back(worker, t);
+    }
+    for(auto& th : threads) {
+        th.join();
+    }
+
+    EXPECT_EQ(trackFailures.load(), 0);
+    EXPECT_EQ(untrackFailures.load(), 0);
+    EXPECT_EQ(m->numEntries, 0);
+    EXPECT_EQ(m->entries, nullptr);
+    EXPECT_EQ(m->totalScratch, 0u);
+}
+
+TEST_F(MemManagerTest, ConcurrentTrackUntrackMarkExport)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* m = comm->memManager;
+
+    // A long-lived scratch entry that MarkExport workers hammer with disjoint
+    // peer ranks. Track/Untrack workers operate on private synthetic ptrs.
+    // All three paths share the same manager mutex.
+    void* shared = fakePtr(0x500);
+    ASSERT_EQ(ncclMemTrack(m, shared, 4096, fakeHandle(), kFakeHandleType, ncclMemScratch),
+              ncclSuccess);
+
+    constexpr int    kTrackThreads   = 4;
+    constexpr int    kExportThreads  = 4;
+    constexpr int    kPerThread      = 256;
+    constexpr int    kRanksPerThread = 32;
+    std::atomic<int> trackFailures{0};
+    std::atomic<int> untrackFailures{0};
+    std::atomic<int> exportFailures{0};
+
+    auto trackWorker = [&](int tid) {
+        for(int i = 0; i < kPerThread; ++i) {
+            void* p = fakePtr(0x10000ULL + static_cast<uintptr_t>(tid) * 0x10000ULL + i + 1);
+            if(ncclMemTrack(m, p, 64, fakeHandle(), kFakeHandleType, ncclMemScratch)
+               != ncclSuccess) {
+                ++trackFailures;
+            }
+            if(ncclMemUntrack(m, p, 64) != ncclSuccess) {
+                ++untrackFailures;
+            }
+        }
+    };
+
+    auto exportWorker = [&](int tid) {
+        for(int i = 0; i < kRanksPerThread; ++i) {
+            // Unique rank across all export threads — no duplicate-rejection.
+            int rank = tid * kRanksPerThread + i + 1;
+            if(ncclDynMemMarkExportToPeer(m, shared, rank) != ncclSuccess) {
+                ++exportFailures;
+            }
+        }
+    };
+
+    std::vector<std::thread> threads;
+    threads.reserve(kTrackThreads + kExportThreads);
+    for(int t = 0; t < kTrackThreads; ++t) {
+        threads.emplace_back(trackWorker, t);
+    }
+    for(int t = 0; t < kExportThreads; ++t) {
+        threads.emplace_back(exportWorker, t);
+    }
+    for(auto& th : threads) {
+        th.join();
+    }
+
+    EXPECT_EQ(trackFailures.load(), 0);
+    EXPECT_EQ(untrackFailures.load(), 0);
+    EXPECT_EQ(exportFailures.load(), 0);
+    EXPECT_EQ(m->numEntries, 1);                 // only `shared` survived
+    EXPECT_EQ(m->entries->ptr, shared);
+    EXPECT_EQ(m->entries->desc.local.numExportedPeers, kExportThreads * kRanksPerThread);
+
+    ASSERT_EQ(ncclMemUntrack(m, shared, 4096), ncclSuccess);
+    EXPECT_EQ(m->numEntries, 0);
+    EXPECT_EQ(m->totalScratch, 0u);
+}
+
+TEST_F(MemManagerTest, StressFuzz_RandomOps_TotalsZeroAfterTeardown)
+{
+    ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+    ncclMemManager* m = comm->memManager;
+
+    // Deterministic seed for reproducible fuzz.
+    std::mt19937                       rng(0xC0FFEEu);
+    std::uniform_int_distribution<int> ptrDist(0, 127);
+    std::uniform_int_distribution<int> opDist(0, 99);
+    std::uniform_int_distribution<int> sizeDist(1, 4096);
+
+    struct LiveEntry
+    {
+        size_t        size;
+        ncclMemType_t type;
+        int           nextRank;
+    };
+    std::unordered_map<void*, LiveEntry> live;
+
+    constexpr int kIterations = 10000;
+    for(int it = 0; it < kIterations; ++it) {
+        void* p  = fakePtr(0xFAFA0000ULL + ptrDist(rng));
+        int   op = opDist(rng);
+
+        auto found = live.find(p);
+        if(found == live.end()) {
+            // Not currently tracked → Track. Persist intentionally omitted: its
+            // Untrack semantics use the passed size and a single counter, which
+            // would skew the invariants we check at the end.
+            ncclMemType_t type = (op < 60) ? ncclMemScratch : ncclMemOffload;
+            size_t        sz   = static_cast<size_t>(sizeDist(rng));
+            ASSERT_EQ(ncclMemTrack(m, p, sz, fakeHandle(), kFakeHandleType, type), ncclSuccess);
+            live.emplace(p, LiveEntry{sz, type, /*nextRank=*/0});
+        } else if(op < 50) {
+            ASSERT_EQ(ncclMemUntrack(m, p, found->second.size), ncclSuccess);
+            live.erase(found);
+        } else {
+            // Fresh peer rank → no duplicate rejection.
+            int rank = found->second.nextRank++;
+            ASSERT_EQ(ncclDynMemMarkExportToPeer(m, p, rank), ncclSuccess);
+        }
+    }
+
+    // Drain whatever is still tracked.
+    for(auto& [p, e] : live) {
+        ASSERT_EQ(ncclMemUntrack(m, p, e.size), ncclSuccess);
+    }
+
+    EXPECT_EQ(m->numEntries, 0);
+    EXPECT_EQ(m->entries, nullptr);
+    EXPECT_EQ(m->totalScratch, 0u);
+    EXPECT_EQ(m->totalOffload, 0u);
+    EXPECT_EQ(m->totalPersist, 0u);
+    EXPECT_EQ(m->cpuBackupUsage, 0u);
+}
+
+// ---------------------------------------------------------------------------
+// Real GPU memory flow: hipMalloc + Track + Untrack + hipFree
+// ---------------------------------------------------------------------------
+
+TEST(MemManagerRealMem, Track_RealHipMalloc_Scratch)
+{
+    RUN_ISOLATED_TEST("MemManager_Track_RealHipMalloc_Scratch", []() {
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        constexpr size_t kSize = 4096;
+        void*            p     = nullptr;
+        ASSERT_EQ(hipMalloc(&p, kSize), hipSuccess);
+        ASSERT_NE(p, nullptr);
+
+        ASSERT_EQ(ncclMemTrack(comm->memManager, p, kSize, fakeHandle(), kFakeHandleType,
+                               ncclMemScratch),
+                  ncclSuccess);
+        EXPECT_EQ(comm->memManager->numEntries, 1);
+        ASSERT_NE(comm->memManager->entries, nullptr);
+        EXPECT_EQ(comm->memManager->entries->ptr, p);
+        EXPECT_EQ(comm->memManager->entries->size, kSize);
+        EXPECT_EQ(comm->memManager->entries->memType, ncclMemScratch);
+        EXPECT_EQ(comm->memManager->entries->state, ncclDynMemStateActive);
+        EXPECT_EQ(comm->memManager->totalScratch, kSize);
+
+        ASSERT_EQ(ncclMemUntrack(comm->memManager, p, kSize), ncclSuccess);
+        EXPECT_EQ(comm->memManager->numEntries, 0);
+        EXPECT_EQ(comm->memManager->totalScratch, 0u);
+
+        ASSERT_EQ(hipFree(p), hipSuccess);
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+TEST(MemManagerRealMem, Track_RealHipMalloc_Offload)
+{
+    RUN_ISOLATED_TEST("MemManager_Track_RealHipMalloc_Offload", []() {
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        constexpr size_t kSize = 16384;
+        void*            p     = nullptr;
+        ASSERT_EQ(hipMalloc(&p, kSize), hipSuccess);
+
+        ASSERT_EQ(ncclMemTrack(comm->memManager, p, kSize, fakeHandle(), kFakeHandleType,
+                               ncclMemOffload),
+                  ncclSuccess);
+        EXPECT_EQ(comm->memManager->entries->memType, ncclMemOffload);
+        EXPECT_EQ(comm->memManager->entries->cpuBackup, nullptr);
+        EXPECT_EQ(comm->memManager->totalOffload, kSize);
+
+        ASSERT_EQ(ncclMemUntrack(comm->memManager, p, kSize), ncclSuccess);
+        EXPECT_EQ(comm->memManager->totalOffload, 0u);
+
+        ASSERT_EQ(hipFree(p), hipSuccess);
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+TEST(MemManagerRealMem, Track_RealHipMalloc_MultipleEntries)
+{
+    RUN_ISOLATED_TEST("MemManager_Track_RealHipMalloc_Multiple", []() {
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        constexpr int    kN       = 4;
+        constexpr size_t kSize    = 1024;
+        void*            ptrs[kN] = {};
+
+        for(int i = 0; i < kN; ++i) {
+            ASSERT_EQ(hipMalloc(&ptrs[i], kSize), hipSuccess);
+            ASSERT_EQ(ncclMemTrack(comm->memManager, ptrs[i], kSize, fakeHandle(),
+                                   kFakeHandleType, ncclMemScratch),
+                      ncclSuccess);
+        }
+        EXPECT_EQ(comm->memManager->numEntries, kN);
+        EXPECT_EQ(comm->memManager->totalScratch, kN * kSize);
+
+        // Untrack in original Track order: ptrs[0] is at the tail (Track
+        // prepends), so the first Untrack walks the full list and exercises
+        // the prev != nullptr branch in the linked-list removal.
+        for(int i = 0; i < kN; ++i) {
+            ASSERT_EQ(ncclMemUntrack(comm->memManager, ptrs[i], kSize), ncclSuccess);
+        }
+        EXPECT_EQ(comm->memManager->numEntries, 0);
+        EXPECT_EQ(comm->memManager->totalScratch, 0u);
+
+        for(int i = 0; i < kN; ++i) {
+            ASSERT_EQ(hipFree(ptrs[i]), hipSuccess);
+        }
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Real VMM flow: hipMemCreate(POSIX_FD) + Track + Untrack + hipMemUnmap/Release.
+// Bypasses ncclCuMemAlloc/Free wrappers and talks to HIP VMM directly so the
+// test exercises the manager against a real handle without depending on the
+// RCCL allocator implementation.
+// ---------------------------------------------------------------------------
+
+namespace
+{
+struct VmmPosixAllocation
+{
+    void*                           ptr    = nullptr;
+    hipDeviceptr_t                  pdev   = 0;
+    size_t                          size   = 0;
+    hipMemGenericAllocationHandle_t handle = 0;
+};
+
+// Allocates a chunk of device memory via the HIP VMM API with a POSIX-fd
+// shareable handle. Mirrors the prop layout of ncclCuMemAlloc:
+//   - Pinned + Device location
+//   - requestedHandleTypes = POSIX_FILE_DESCRIPTOR
+//   - allocFlags.gpuDirectRDMACapable = 1 (ROCM-2550 workaround; without it
+//     hipMemMap can SIGSEGV on AMD)
+// `requestedSize` is rounded up to the minimum granularity reported by HIP.
+// Caller must pass the result to ReleaseVmmPosixFd().
+inline void AllocateVmmPosixFd(int dev, size_t requestedSize, VmmPosixAllocation* out)
+{
+    ASSERT_NE(out, nullptr);
+
+    hipMemAllocationProp prop            = {};
+    prop.type                            = hipMemAllocationTypePinned;
+    prop.location.type                   = hipMemLocationTypeDevice;
+    prop.location.id                     = dev;
+    prop.requestedHandleTypes            = hipMemHandleTypePosixFileDescriptor;
+    prop.allocFlags.gpuDirectRDMACapable = 1;
+
+    size_t granularity = 0;
+    ASSERT_EQ(hipMemGetAllocationGranularity(&granularity, &prop,
+                                             hipMemAllocationGranularityMinimum),
+              hipSuccess);
+    ASSERT_GT(granularity, 0u);
+    size_t size = ((requestedSize + granularity - 1) / granularity) * granularity;
+
+    hipMemGenericAllocationHandle_t handle = 0;
+    ASSERT_EQ(hipMemCreate(&handle, size, &prop, 0), hipSuccess);
+
+    hipDeviceptr_t pdev = 0;
+    ASSERT_EQ(hipMemAddressReserve(&pdev, size, granularity, 0, 0), hipSuccess);
+    ASSERT_EQ(hipMemMap(pdev, size, 0, handle, 0), hipSuccess);
+
+    hipMemAccessDesc accessDesc = {};
+    accessDesc.location.type    = hipMemLocationTypeDevice;
+    accessDesc.location.id      = dev;
+    accessDesc.flags            = hipMemAccessFlagsProtReadWrite;
+    ASSERT_EQ(hipMemSetAccess(pdev, size, &accessDesc, 1), hipSuccess);
+
+    out->ptr    = reinterpret_cast<void*>(pdev);
+    out->pdev   = pdev;
+    out->size   = size;
+    out->handle = handle;
+}
+
+// Releases a VmmPosixAllocation in HIP-required order:
+//   hipMemUnmap -> hipMemRelease(handle) -> hipMemAddressFree(va).
+inline void ReleaseVmmPosixFd(const VmmPosixAllocation& a)
+{
+    ASSERT_EQ(hipMemUnmap(a.pdev, a.size), hipSuccess);
+    ASSERT_EQ(hipMemRelease(a.handle), hipSuccess);
+    ASSERT_EQ(hipMemAddressFree(a.pdev, a.size), hipSuccess);
+}
+} // namespace
+
+TEST(MemManagerRealMem, Track_RealVmm_PosixFd)
+{
+    RUN_ISOLATED_TEST("MemManager_Track_RealVmm_PosixFd", []() {
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+        int dev = 0;
+        ASSERT_EQ(hipGetDevice(&dev), hipSuccess);
+
+        VmmPosixAllocation va;
+        AllocateVmmPosixFd(dev, /*requestedSize=*/65536, &va);
+        ASSERT_NE(va.ptr, nullptr);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = dev;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        ASSERT_EQ(ncclMemTrack(comm->memManager, va.ptr, va.size, va.handle,
+                               hipMemHandleTypePosixFileDescriptor, ncclMemScratch),
+                  ncclSuccess);
+        EXPECT_EQ(comm->memManager->numEntries, 1);
+        ASSERT_NE(comm->memManager->entries, nullptr);
+        EXPECT_EQ(comm->memManager->entries->ptr, va.ptr);
+        EXPECT_EQ(comm->memManager->entries->handle, va.handle);
+        EXPECT_EQ(comm->memManager->entries->handleType, hipMemHandleTypePosixFileDescriptor);
+        EXPECT_EQ(comm->memManager->totalScratch, va.size);
+
+        ASSERT_EQ(ncclMemUntrack(comm->memManager, va.ptr, va.size), ncclSuccess);
+        EXPECT_EQ(comm->memManager->numEntries, 0);
+        EXPECT_EQ(comm->memManager->totalScratch, 0u);
+
+        ReleaseVmmPosixFd(va);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Real VMM allocation + MarkExport to several peers + Destroy. Exercises the
+// exportedPeerRanks free path on Destroy with a real handle attached to the
+// entry. We own the lifetime of the underlying VMM resources and release them
+// after Destroy, since the manager only tracks bookkeeping (not the mapping).
+// ---------------------------------------------------------------------------
+
+TEST(MemManagerRealMem, MarkExport_OnRealVmmAllocation_AndDestroy)
+{
+    RUN_ISOLATED_TEST("MemManager_MarkExport_OnRealVmmAllocation_AndDestroy", []() {
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+        int dev = 0;
+        ASSERT_EQ(hipGetDevice(&dev), hipSuccess);
+
+        VmmPosixAllocation va;
+        AllocateVmmPosixFd(dev, /*requestedSize=*/65536, &va);
+        ASSERT_NE(va.ptr, nullptr);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = dev;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        ASSERT_EQ(ncclMemTrack(comm->memManager, va.ptr, va.size, va.handle,
+                               hipMemHandleTypePosixFileDescriptor, ncclMemScratch),
+                  ncclSuccess);
+        for(int peer : {1, 2, 3, 5, 8, 13}) {
+            ASSERT_EQ(ncclDynMemMarkExportToPeer(comm->memManager, va.ptr, peer), ncclSuccess);
+        }
+        EXPECT_EQ(comm->memManager->entries->desc.local.numExportedPeers, 6);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        EXPECT_EQ(comm->memManager, nullptr);
+        delete comm;
+
+        // Caller still owns the VMM resources — manager only tracks
+        // bookkeeping, not the mapping itself.
+        ReleaseVmmPosixFd(va);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup branches: cpuBackup free + shareableHandle.fd close.
+// We populate these fields manually to mirror what ncclCommSuspend (PR5) and
+// ncclCuMemAlloc (PR2) will set, and verify the manager's destructors release
+// the underlying real resources (cudaFreeHost / close).
+// ---------------------------------------------------------------------------
+
+TEST(MemManagerRealMem, Untrack_FreesCpuBackup)
+{
+    RUN_ISOLATED_TEST("MemManager_Untrack_FreesCpuBackup", []() {
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        constexpr size_t kSize = 4096;
+        void*            p     = fakePtr(0x100);
+        ASSERT_EQ(ncclMemTrack(comm->memManager, p, kSize, fakeHandle(), kFakeHandleType,
+                               ncclMemOffload),
+                  ncclSuccess);
+
+        // Simulate ncclCommSuspend attaching a host-side backup buffer.
+        char* backup = nullptr;
+        ASSERT_EQ(ncclCudaHostCalloc(&backup, kSize), ncclSuccess);
+        ASSERT_NE(backup, nullptr);
+        comm->memManager->entries->cpuBackup = backup;
+        comm->memManager->cpuBackupUsage += kSize;
+
+        ASSERT_EQ(ncclMemUntrack(comm->memManager, p, kSize), ncclSuccess);
+        // Manager calls ncclCudaHostFree(backup) and decrements usage.
+        // Address sanitizer would catch a double-free or leak here.
+        EXPECT_EQ(comm->memManager->cpuBackupUsage, 0u);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+TEST(MemManagerRealMem, Untrack_ClosesShareableFd)
+{
+    RUN_ISOLATED_TEST("MemManager_Untrack_ClosesShareableFd", []() {
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        constexpr size_t kSize = 4096;
+        void*            p     = fakePtr(0x101);
+        ASSERT_EQ(ncclMemTrack(comm->memManager, p, kSize, fakeHandle(),
+                               hipMemHandleTypePosixFileDescriptor, ncclMemScratch),
+                  ncclSuccess);
+
+        // Simulate ncclCuMemAlloc populating the shareable POSIX fd.
+        int fd = dup(STDOUT_FILENO);
+        ASSERT_GE(fd, 0);
+        ASSERT_NE(fcntl(fd, F_GETFD), -1);
+
+        comm->memManager->entries->desc.local.shareableHandle.fd   = fd;
+        comm->memManager->entries->desc.local.shareableHandleValid = true;
+
+        ASSERT_EQ(ncclMemUntrack(comm->memManager, p, kSize), ncclSuccess);
+
+        // fd must be closed by the manager.
+        errno = 0;
+        EXPECT_EQ(fcntl(fd, F_GETFD), -1);
+        EXPECT_EQ(errno, EBADF);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+TEST(MemManagerRealMem, Destroy_FreesPopulatedEntries)
+{
+    RUN_ISOLATED_TEST("MemManager_Destroy_FreesPopulatedEntries", []() {
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        constexpr size_t kSize = 4096;
+
+        // Entry 1: scratch with cpuBackup (simulates suspended scratch buffer).
+        void* p1 = fakePtr(0x200);
+        ASSERT_EQ(ncclMemTrack(comm->memManager, p1, kSize, fakeHandle(),
+                               hipMemHandleTypePosixFileDescriptor, ncclMemScratch),
+                  ncclSuccess);
+        char* backup1 = nullptr;
+        ASSERT_EQ(ncclCudaHostCalloc(&backup1, kSize), ncclSuccess);
+        comm->memManager->entries->cpuBackup = backup1;
+        comm->memManager->cpuBackupUsage += kSize;
+
+        // Entry 2: offload with a real shareable fd. Track prepends, so this
+        // becomes the new head and we patch desc.local on the head entry.
+        void* p2 = fakePtr(0x201);
+        ASSERT_EQ(ncclMemTrack(comm->memManager, p2, kSize, fakeHandle(),
+                               hipMemHandleTypePosixFileDescriptor, ncclMemOffload),
+                  ncclSuccess);
+        int fd2 = dup(STDOUT_FILENO);
+        ASSERT_GE(fd2, 0);
+        comm->memManager->entries->desc.local.shareableHandle.fd   = fd2;
+        comm->memManager->entries->desc.local.shareableHandleValid = true;
+
+        // Entry 3: scratch with exported peers (exercises exportedPeerRanks free).
+        void* p3 = fakePtr(0x202);
+        ASSERT_EQ(ncclMemTrack(comm->memManager, p3, kSize, fakeHandle(),
+                               hipMemHandleTypePosixFileDescriptor, ncclMemScratch),
+                  ncclSuccess);
+        ASSERT_EQ(ncclDynMemMarkExportToPeer(comm->memManager, p3, 1), ncclSuccess);
+        ASSERT_EQ(ncclDynMemMarkExportToPeer(comm->memManager, p3, 2), ncclSuccess);
+
+        EXPECT_EQ(comm->memManager->numEntries, 3);
+
+        // Destroy walks the full list and releases every attached resource.
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        EXPECT_EQ(comm->memManager, nullptr);
+
+        // fd2 must now be closed.
+        errno = 0;
+        EXPECT_EQ(fcntl(fd2, F_GETFD), -1);
+        EXPECT_EQ(errno, EBADF);
+
+        delete comm;
+    });
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/mem_manager/MemManagerTests.cpp
+++ b/projects/rccl/test/mem_manager/MemManagerTests.cpp
@@ -8,6 +8,7 @@
 
 #include <atomic>
 #include <cerrno>
+#include <cstdlib>
 #include <fcntl.h>
 #include <random>
 #include <thread>
@@ -794,6 +795,31 @@ struct VmmPosixAllocation
     hipMemGenericAllocationHandle_t handle = 0;
 };
 
+inline void AllocateViaNcclCuMemAlloc(int dev, size_t requestedSize, VmmPosixAllocation* out)
+{
+    ASSERT_NE(out, nullptr);
+    ASSERT_EQ(hipSetDevice(dev), hipSuccess);
+
+    void*                      ptr    = nullptr;
+    hipMemGenericAllocationHandle_t handle = 0;
+    ncclResult_t               r      = ncclCuMemAlloc(&ptr, &handle, hipMemHandleTypePosixFileDescriptor,
+                                        requestedSize, /*manager=*/nullptr);
+    ASSERT_EQ(r, ncclSuccess);
+    ASSERT_NE(ptr, nullptr);
+    ASSERT_NE(reinterpret_cast<void*>(handle), nullptr);
+
+    out->ptr    = ptr;
+    out->pdev   = reinterpret_cast<hipDeviceptr_t>(ptr);
+    out->size   = requestedSize; // ncclCuMemAlloc aligns internally; size is only used for bookkeeping in tests
+    out->handle = handle;
+}
+
+inline void ReleaseViaNcclCuMemFree(const VmmPosixAllocation& a)
+{
+    ASSERT_NE(a.ptr, nullptr);
+    ASSERT_EQ(ncclCuMemFree(a.ptr, /*manager=*/nullptr), ncclSuccess);
+}
+
 // Allocates a chunk of device memory via the HIP VMM API with a POSIX-fd
 // shareable handle. Mirrors the prop layout of ncclCuMemAlloc:
 //   - Pinned + Device location
@@ -848,6 +874,38 @@ inline void ReleaseVmmPosixFd(const VmmPosixAllocation& a)
     ASSERT_EQ(hipMemAddressFree(a.pdev, a.size), hipSuccess);
 }
 } // namespace
+
+TEST(MemManagerRealMem, Track_RealCuMemAlloc_PosixFd)
+{
+    RUN_ISOLATED_TEST("MemManager_Track_RealCuMemAlloc_PosixFd", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 - ncclCuMemAlloc wrapper bypassed";
+        }
+
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+        int dev = 0;
+        ASSERT_EQ(hipGetDevice(&dev), hipSuccess);
+
+        VmmPosixAllocation va;
+        AllocateViaNcclCuMemAlloc(dev, /*requestedSize=*/65536, &va);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = dev;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        // Note: ncclCuMemAlloc does not surface the aligned size. Use the same
+        // requestedSize for Track/Untrack to exercise the list bookkeeping.
+        ASSERT_EQ(ncclMemTrack(comm->memManager, va.ptr, /*size=*/65536, va.handle,
+                               hipMemHandleTypePosixFileDescriptor, ncclMemScratch),
+                  ncclSuccess);
+        ASSERT_EQ(ncclMemUntrack(comm->memManager, va.ptr, /*size=*/65536), ncclSuccess);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+
+        ReleaseViaNcclCuMemFree(va);
+    });
+}
 
 TEST(MemManagerRealMem, Track_RealVmm_PosixFd)
 {
@@ -1211,6 +1269,334 @@ TEST_F(MemManagerStatsTest, SuspendedFlag_FlipsWithReleased)
 
     comm->memManager->released = 0;
     EXPECT_EQ(readStat(ncclStatGpuMemSuspended), 0u);
+}
+
+// ---------------------------------------------------------------------------
+// Allocator round-trip: verify ncclCuMemAlloc/Free, ncclCudaCalloc/Free,
+// ncclCudaMalloc/Free and ncclCudaCallocAsync/Free keep ncclMemManager
+// bookkeeping consistent end-to-end. Real HIP allocations require process
+// isolation (RUN_ISOLATED_TEST).
+// VMM-dependent tests gate on ncclCuMemEnable() — the same RCCL helper used
+// throughout src/ to honor NCCL_CUMEM_ENABLE plus runtime CuMem support.
+// ---------------------------------------------------------------------------
+
+TEST(MemManagerAllocator, CuMemAlloc_Persist_TracksAndUntracks)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_CuMemAlloc_Persist_TracksAndUntracks", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 or VMM unsupported by runtime";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        constexpr size_t                kSize = 1u << 20; // 1 MiB
+        void*                           ptr   = nullptr;
+        hipMemGenericAllocationHandle_t handle{};
+        ASSERT_EQ(ncclCuMemAlloc(&ptr, &handle, hipMemHandleTypePosixFileDescriptor,
+                                 kSize, comm->memManager, ncclMemPersist),
+                  ncclSuccess);
+        ASSERT_NE(ptr, nullptr);
+
+        EXPECT_EQ(comm->memManager->numEntries, 1);
+        ASSERT_NE(comm->memManager->entries, nullptr);
+        EXPECT_EQ(comm->memManager->entries->ptr, ptr);
+        EXPECT_EQ(comm->memManager->entries->memType, ncclMemPersist);
+        EXPECT_GE(comm->memManager->totalPersist, kSize);
+        const size_t recordedSize = comm->memManager->entries->size;
+
+        ASSERT_EQ(ncclCuMemFree(ptr, comm->memManager), ncclSuccess);
+        EXPECT_EQ(comm->memManager->numEntries, 0);
+        EXPECT_EQ(comm->memManager->totalPersist, 0u);
+        EXPECT_GT(recordedSize, 0u);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+TEST(MemManagerAllocator, CuMemAlloc_Scratch_AccountedSeparately)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_CuMemAlloc_Scratch_AccountedSeparately", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 or VMM unsupported by runtime";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        constexpr size_t                kSize = 2u << 20;
+        void*                           ptr   = nullptr;
+        hipMemGenericAllocationHandle_t handle{};
+        ASSERT_EQ(ncclCuMemAlloc(&ptr, &handle, hipMemHandleTypePosixFileDescriptor,
+                                 kSize, comm->memManager, ncclMemScratch),
+                  ncclSuccess);
+
+        EXPECT_EQ(comm->memManager->numEntries, 1);
+        EXPECT_EQ(comm->memManager->entries->memType, ncclMemScratch);
+        EXPECT_GE(comm->memManager->totalScratch, kSize);
+        EXPECT_EQ(comm->memManager->totalPersist, 0u);
+        EXPECT_EQ(comm->memManager->totalOffload, 0u);
+
+        ASSERT_EQ(ncclCuMemFree(ptr, comm->memManager), ncclSuccess);
+        EXPECT_EQ(comm->memManager->totalScratch, 0u);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+TEST(MemManagerAllocator, CuMemAlloc_NullManager_NoTracking)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_CuMemAlloc_NullManager_NoTracking", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 or VMM unsupported by runtime";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        void*                           ptr = nullptr;
+        hipMemGenericAllocationHandle_t handle{};
+        ASSERT_EQ(ncclCuMemAlloc(&ptr, &handle, hipMemHandleTypePosixFileDescriptor,
+                                 1u << 20, /*manager=*/nullptr, ncclMemPersist),
+                  ncclSuccess);
+        EXPECT_EQ(comm->memManager->numEntries, 0);
+        EXPECT_EQ(comm->memManager->totalPersist, 0u);
+
+        ASSERT_EQ(ncclCuMemFree(ptr, /*manager=*/nullptr), ncclSuccess);
+        EXPECT_EQ(comm->memManager->numEntries, 0);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+TEST(MemManagerAllocator, CuMemAlloc_MultipleEntries_AllTracked)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_CuMemAlloc_MultipleEntries_AllTracked", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 or VMM unsupported by runtime";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        constexpr int                   kN          = 4;
+        constexpr size_t                kSize       = 256u << 10; // 256 KiB
+        void*                           ptrs[kN]    = {};
+        hipMemGenericAllocationHandle_t handles[kN] = {};
+
+        for(int i = 0; i < kN; ++i) {
+            ASSERT_EQ(ncclCuMemAlloc(&ptrs[i], &handles[i],
+                                     hipMemHandleTypePosixFileDescriptor, kSize,
+                                     comm->memManager, ncclMemPersist),
+                      ncclSuccess);
+        }
+        EXPECT_EQ(comm->memManager->numEntries, kN);
+        EXPECT_GE(comm->memManager->totalPersist, kN * kSize);
+
+        for(int i = 0; i < kN; ++i) {
+            ASSERT_EQ(ncclCuMemFree(ptrs[i], comm->memManager), ncclSuccess);
+        }
+        EXPECT_EQ(comm->memManager->numEntries, 0);
+        EXPECT_EQ(comm->memManager->totalPersist, 0u);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+TEST(MemManagerAllocator, CudaCalloc_DispatchesToCuMem_AndTracks)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_CudaCalloc_Tracks", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 - ncclCudaCalloc bypasses manager";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        constexpr size_t kElems = 1024;
+        int*             ptr    = nullptr;
+        ASSERT_EQ(ncclCudaCalloc(&ptr, kElems, comm->memManager, ncclMemPersist),
+                  ncclSuccess);
+        ASSERT_NE(ptr, nullptr);
+
+        EXPECT_EQ(comm->memManager->numEntries, 1);
+        EXPECT_GE(comm->memManager->totalPersist, kElems * sizeof(int));
+
+        ASSERT_EQ(ncclCudaFree(ptr, comm->memManager), ncclSuccess);
+        EXPECT_EQ(comm->memManager->numEntries, 0);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+TEST(MemManagerAllocator, CudaMalloc_DispatchesToCuMem_AndTracks)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_CudaMalloc_Tracks", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 - ncclCudaMalloc bypasses manager";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        constexpr size_t kBytes = 64 << 10; // 64 KiB
+        char*            ptr    = nullptr;
+        ASSERT_EQ(ncclCudaMalloc(&ptr, kBytes, comm->memManager, ncclMemScratch),
+                  ncclSuccess);
+
+        EXPECT_EQ(comm->memManager->numEntries, 1);
+        EXPECT_EQ(comm->memManager->entries->memType, ncclMemScratch);
+
+        ASSERT_EQ(ncclCudaFree(ptr, comm->memManager), ncclSuccess);
+        EXPECT_EQ(comm->memManager->numEntries, 0);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+TEST(MemManagerAllocator, CudaCallocAsync_DispatchesToCuMem_AndTracks)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_CudaCallocAsync_Tracks", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 - ncclCudaCallocAsync bypasses manager";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        hipStream_t stream;
+        ASSERT_EQ(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking), hipSuccess);
+
+        constexpr size_t kElems = 256;
+        uint64_t*        ptr    = nullptr;
+        ASSERT_EQ(ncclCudaCallocAsync(&ptr, kElems, stream, comm->memManager,
+                                      ncclMemPersist),
+                  ncclSuccess);
+        ASSERT_EQ(hipStreamSynchronize(stream), hipSuccess);
+
+        EXPECT_EQ(comm->memManager->numEntries, 1);
+        EXPECT_GE(comm->memManager->totalPersist, kElems * sizeof(uint64_t));
+
+        ASSERT_EQ(ncclCudaFree(ptr, comm->memManager), ncclSuccess);
+        EXPECT_EQ(comm->memManager->numEntries, 0);
+
+        ASSERT_EQ(hipStreamDestroy(stream), hipSuccess);
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+TEST(MemManagerAllocator, MixedMemTypes_BookkeepingIndependent)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_MixedMemTypes_BookkeepingIndependent", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 or VMM unsupported by runtime";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        constexpr size_t                kSize = 512u << 10; // 512 KiB
+        void*                           pPer  = nullptr;
+        void*                           pScr  = nullptr;
+        void*                           pOff  = nullptr;
+        hipMemGenericAllocationHandle_t hPer{};
+        hipMemGenericAllocationHandle_t hScr{};
+        hipMemGenericAllocationHandle_t hOff{};
+
+        ASSERT_EQ(ncclCuMemAlloc(&pPer, &hPer, hipMemHandleTypePosixFileDescriptor,
+                                 kSize, comm->memManager, ncclMemPersist),
+                  ncclSuccess);
+        ASSERT_EQ(ncclCuMemAlloc(&pScr, &hScr, hipMemHandleTypePosixFileDescriptor,
+                                 kSize, comm->memManager, ncclMemScratch),
+                  ncclSuccess);
+        ASSERT_EQ(ncclCuMemAlloc(&pOff, &hOff, hipMemHandleTypePosixFileDescriptor,
+                                 kSize, comm->memManager, ncclMemOffload),
+                  ncclSuccess);
+
+        EXPECT_EQ(comm->memManager->numEntries, 3);
+        EXPECT_GE(comm->memManager->totalPersist, kSize);
+        EXPECT_GE(comm->memManager->totalScratch, kSize);
+        EXPECT_GE(comm->memManager->totalOffload, kSize);
+
+        ASSERT_EQ(ncclCuMemFree(pScr, comm->memManager), ncclSuccess);
+        EXPECT_EQ(comm->memManager->totalScratch, 0u);
+        EXPECT_GE(comm->memManager->totalPersist, kSize); // unaffected
+        EXPECT_GE(comm->memManager->totalOffload, kSize); // unaffected
+        EXPECT_EQ(comm->memManager->numEntries, 2);
+
+        ASSERT_EQ(ncclCuMemFree(pPer, comm->memManager), ncclSuccess);
+        ASSERT_EQ(ncclCuMemFree(pOff, comm->memManager), ncclSuccess);
+        EXPECT_EQ(comm->memManager->numEntries, 0);
+        EXPECT_EQ(comm->memManager->totalPersist, 0u);
+        EXPECT_EQ(comm->memManager->totalOffload, 0u);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+TEST(MemManagerAllocator, AllocTrackerAndManager_AreIndependent)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_AllocTrackerAndManager_AreIndependent", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 or VMM unsupported by runtime";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        const uint64_t allocBefore     = __atomic_load_n(
+            &allocTracker[0].totalAlloc, __ATOMIC_RELAXED);
+        const uint64_t allocSizeBefore = __atomic_load_n(
+            &allocTracker[0].totalAllocSize, __ATOMIC_RELAXED);
+
+        constexpr size_t                kSize = 1u << 20;
+        void*                           ptr   = nullptr;
+        hipMemGenericAllocationHandle_t handle{};
+        ASSERT_EQ(ncclCuMemAlloc(&ptr, &handle, hipMemHandleTypePosixFileDescriptor,
+                                 kSize, comm->memManager, ncclMemPersist),
+                  ncclSuccess);
+
+        EXPECT_GT(__atomic_load_n(&allocTracker[0].totalAlloc, __ATOMIC_RELAXED),
+                  allocBefore);
+        EXPECT_GT(__atomic_load_n(&allocTracker[0].totalAllocSize, __ATOMIC_RELAXED),
+                  allocSizeBefore);
+        EXPECT_EQ(comm->memManager->numEntries, 1);
+
+        ASSERT_EQ(ncclCuMemFree(ptr, comm->memManager), ncclSuccess);
+
+        EXPECT_EQ(__atomic_load_n(&allocTracker[0].totalAlloc, __ATOMIC_RELAXED),
+                  allocBefore);
+        EXPECT_EQ(comm->memManager->numEntries, 0);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
 }
 
 } // namespace RcclUnitTesting

--- a/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp
+++ b/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp
@@ -1,0 +1,1105 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+/**
+ * @file SuspendResumeMPITests.cpp
+ * @brief Multi-process tests for ncclCommMemSuspend / ncclCommMemResume / ncclCommMemStats.
+ *
+ * The single-process unit-test suite in `test/mem_manager/MemManagerTests.cpp`
+ * covers all early-return error paths, `ncclCommMemStats`, and the manager
+ * state machine via fake / real-VMM entries that don't need a bootstrap.
+ *
+ * This file extends coverage to the bootstrap-coupled paths in
+ * `ncclCommMemSuspend` / `ncclCommMemResume`:
+ *   - Cross-rank `bootstrapBarrier(0xBEEF)` on entry to Suspend.
+ *   - Cross-rank `bootstrapBarrier(0xBEEF)` after local restore in Resume.
+ *   - `bootstrapAllGather` of per-rank export counts in Resume Step 3.
+ *   - `bootstrapSend`/`bootstrapRecv(0xFEED)` handle-info exchange.
+ *   - Final `bootstrapBarrier(0xCAFE)` after peer re-import.
+ *   - The peer-import matching loop in Step 4 (both positive and negative).
+ *   - `ncclProxyClientGetFdBlocking` round-trip used by Step 4 to convert
+ *     a peer's CUmemGenericAllocationHandle into a POSIX FD via UDS.
+ *   - End-to-end data preservation: rank 0 fills an `ncclMemOffload` buffer
+ *     with a canary, both ranks Suspend (CPU backup) + Resume (restore from
+ *     backup, re-export, peer re-import), rank 1 reads the canary back
+ *     through its imported VA.
+ *
+ * The tests allocate VMM directly via raw HIP (hipMemCreate / Reserve / Map /
+ * SetAccess) instead of going through ncclCuMemAlloc - the wrapper has its
+ * own issues on ROCm 7.0/7.2 and the goal is to exercise mem_manager logic,
+ * not the allocator. If the runtime really lacks raw VMM, hipMemCreate fails
+ * with an explicit HIP error code instead of a misleading version skip.
+ *
+ * Two suites:
+ *   - MemManagerAnyRanks - each rank runs the same local Suspend/Resume
+ *     scenario in lockstep. The cross-rank bootstrapBarrier inside
+ *     ncclCommMemSuspend / ncclCommMemResume keeps all ranks in sync, so
+ *     every test in this suite passes on any np >= 1.
+ *   - MemManagerTwoRank   - peer-coupled scenarios that need exactly 2 ranks
+ *     (rank 0 exporter, rank 1 importer).
+ *
+ * Run (a single mpirun -np 2 invocation runs the entire file):
+ *   mpirun -np 2 ./rccl-UnitTestsMPI --gtest_filter='MemManager*'
+ *
+ * Or, if you want to focus on one suite:
+ *   mpirun -np 1 ./rccl-UnitTestsMPI --gtest_filter='MemManagerAnyRanks.*'
+ *   mpirun -np 2 ./rccl-UnitTestsMPI --gtest_filter='MemManagerTwoRank.*'
+ */
+
+#include "MPITestBase.hpp"
+#include "TestChecks.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <iomanip>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+#ifdef MPI_TESTS_ENABLED
+
+#include "bootstrap.h"
+#include "comm.h"
+#include "mem_manager.h"
+#include "proxy.h"
+
+using namespace MPITestConstants;
+
+// ---------------------------------------------------------------------------
+// VMM helpers
+//
+// We talk to the HIP driver directly (hipMemCreate / Reserve / Map / SetAccess)
+// instead of going through ncclCuMemAlloc. The wrapper has rollback paths and
+// a ROCm-2550 zero-fill memset that hide the actual VMM call site, and it
+// segfaults inside cuMemCreate on ROCm 7.0/7.2 even when raw VMM works.
+// Same approach the standalone unit test takes (Track_RealVmm_PosixFd).
+// ---------------------------------------------------------------------------
+
+namespace
+{
+struct VmmAlloc
+{
+    void*                           ptr    = nullptr;
+    hipDeviceptr_t                  pdev   = 0;
+    size_t                          size   = 0;
+    hipMemGenericAllocationHandle_t handle = 0;
+};
+
+void allocateVmmPosixFd(int dev, size_t requestedSize, VmmAlloc* out)
+{
+    ASSERT_NE(out, nullptr);
+
+    hipMemAllocationProp prop            = {};
+    prop.type                            = hipMemAllocationTypePinned;
+    prop.location.type                   = hipMemLocationTypeDevice;
+    prop.location.id                     = dev;
+    prop.requestedHandleTypes            = hipMemHandleTypePosixFileDescriptor;
+    prop.allocFlags.gpuDirectRDMACapable = 1;
+
+    size_t granularity = 0;
+    ASSERT_EQ(hipMemGetAllocationGranularity(&granularity, &prop,
+                                             hipMemAllocationGranularityMinimum),
+              hipSuccess);
+    ASSERT_GT(granularity, 0u);
+    size_t size = ((requestedSize + granularity - 1) / granularity) * granularity;
+
+    hipMemGenericAllocationHandle_t handle = 0;
+    ASSERT_EQ(hipMemCreate(&handle, size, &prop, 0), hipSuccess);
+
+    hipDeviceptr_t pdev = 0;
+    ASSERT_EQ(hipMemAddressReserve(&pdev, size, granularity, 0, 0), hipSuccess);
+    ASSERT_EQ(hipMemMap(pdev, size, 0, handle, 0), hipSuccess);
+
+    hipMemAccessDesc accessDesc = {};
+    accessDesc.location.type    = hipMemLocationTypeDevice;
+    accessDesc.location.id      = dev;
+    accessDesc.flags            = hipMemAccessFlagsProtReadWrite;
+    ASSERT_EQ(hipMemSetAccess(pdev, size, &accessDesc, 1), hipSuccess);
+
+    out->ptr    = reinterpret_cast<void*>(pdev);
+    out->pdev   = pdev;
+    out->size   = size;
+    out->handle = handle;
+}
+
+// Reserve only (no physical handle / no map). Used to set up a "released" VA
+// region as if Suspend had already torn the physical backing down. Lets a test
+// drive Resume's restore path without needing a Suspend/Resume roundtrip.
+void reserveVaOnly(int dev, size_t requestedSize, VmmAlloc* out)
+{
+    ASSERT_NE(out, nullptr);
+
+    hipMemAllocationProp prop            = {};
+    prop.type                            = hipMemAllocationTypePinned;
+    prop.location.type                   = hipMemLocationTypeDevice;
+    prop.location.id                     = dev;
+    prop.requestedHandleTypes            = hipMemHandleTypePosixFileDescriptor;
+    prop.allocFlags.gpuDirectRDMACapable = 1;
+
+    size_t granularity = 0;
+    ASSERT_EQ(hipMemGetAllocationGranularity(&granularity, &prop,
+                                             hipMemAllocationGranularityMinimum),
+              hipSuccess);
+    size_t size = ((requestedSize + granularity - 1) / granularity) * granularity;
+
+    hipDeviceptr_t pdev = 0;
+    ASSERT_EQ(hipMemAddressReserve(&pdev, size, granularity, 0, 0), hipSuccess);
+
+    out->ptr    = reinterpret_cast<void*>(pdev);
+    out->pdev   = pdev;
+    out->size   = size;
+    out->handle = 0;
+}
+
+// Tear down whatever Resume / the test left mapped at out->pdev. Safe whether
+// the entry is in the Active state (mapped) or Released state (unmapped) -
+// hipMemUnmap returns an error on a reserved-but-unmapped VA which we ignore.
+void releaseVmm(VmmAlloc* a)
+{
+    if (a == nullptr || a->pdev == 0) return;
+    (void)hipMemUnmap(a->pdev, a->size);
+    if (a->handle != 0) (void)hipMemRelease(a->handle);
+    (void)hipMemAddressFree(a->pdev, a->size);
+    a->pdev   = 0;
+    a->handle = 0;
+    a->ptr    = nullptr;
+    a->size   = 0;
+}
+
+// Grant local-device RW access to a previously reserved + mapped VA range.
+// Used after hipMemMap on an imported handle to make the VA usable.
+void applyDeviceRwAccess(int dev, hipDeviceptr_t pdev, size_t size)
+{
+    hipMemAccessDesc accessDesc = {};
+    accessDesc.location.type    = hipMemLocationTypeDevice;
+    accessDesc.location.id      = dev;
+    accessDesc.flags            = hipMemAccessFlagsProtReadWrite;
+    ASSERT_EQ(hipMemSetAccess(pdev, size, &accessDesc, 1), hipSuccess);
+}
+
+// Pour `pattern` over the entire VA on the device, then DToH + verify every
+// byte equals `pattern`. Uses bulk std::all_of so failures don't spam gtest
+// with millions of EXPECT_EQ lines on big buffers. `what` is taken by const-
+// reference so callers can pass either a string literal or a `std::to_string`-
+// composed message without forcing a `.c_str()` everywhere.
+void verifyCanaryReadback(void* ptr, size_t size, uint8_t pattern, const std::string& what)
+{
+    std::vector<uint8_t> host(size, static_cast<uint8_t>(~pattern));
+    ASSERT_EQ(hipMemcpy(host.data(), ptr, size, hipMemcpyDeviceToHost), hipSuccess) << what;
+    bool ok = std::all_of(host.begin(), host.end(),
+                          [pattern](uint8_t b) { return b == pattern; });
+    EXPECT_TRUE(ok) << what << ": canary 0x" << std::hex << static_cast<int>(pattern)
+                    << " not preserved";
+}
+
+// Cleanup pattern shared by every test that does Track + later Untrack on a
+// VMM entry that may have gone through Suspend/Resume:
+//   - Resume installs a NEW handle into entry->handle (the original one we
+//     created via hipMemCreate is long gone after Suspend's hipMemRelease).
+//   - ncclMemUntrack drops the linked-list entry but does NOT unmap or release
+//     anything HIP-side.
+// So we snapshot the live handle out of the entry FIRST, then Untrack, then
+// releaseVmm() with that handle.
+void untrackAndRelease(struct ncclComm* comm, void* ptr, VmmAlloc* a)
+{
+    ncclMemManager* mgr = comm->memManager;
+    ASSERT_NE(mgr, nullptr);
+    ncclDynMemEntry* entry = mgr->entries;
+    while (entry != nullptr && entry->ptr != ptr) entry = entry->next;
+    if (entry != nullptr) a->handle = entry->handle;
+    ASSERT_EQ(ncclMemUntrack(mgr, ptr, a->size), ncclSuccess);
+    releaseVmm(a);
+}
+
+// ---------------------------------------------------------------------------
+// Peer export/import helpers - shared by the multi-rank tests.
+//
+// PeerMeta is what the owner ships over bootstrapSend so the importer can
+// reconstruct the matching ncclMemTrackImportFromPeer call: handle value
+// (round-tripped through the proxy GetFd UDS for FD conversion), VA address
+// (matched verbatim by Resume Step 4's matching loop), aligned size, and the
+// owner's cudaDev.
+// ---------------------------------------------------------------------------
+
+struct PeerMeta
+{
+    uint64_t handleVal;  // owner's hipMemGenericAllocationHandle_t value
+    uint64_t ownerPtr;   // owner's VA (uintptr_t) - matched verbatim in Step 4
+    uint64_t size;       // owner's aligned size  - matched verbatim
+    int      ownerDev;   // owner's cudaDev       - stored in entry.desc.imported
+};
+
+// Owner side: Track the buffer, MarkExportToPeer, and ship the metadata over
+// bootstrapSend. The owner keeps `vmm` alive through Suspend/Resume.
+// Each (peerRank, tag) pair must be unique across concurrent calls.
+void exportAndShipMeta(struct ncclComm* comm, const VmmAlloc& vmm, int peerRank,
+                       ncclMemType_t memType, int tag)
+{
+    ASSERT_EQ(ncclMemTrack(comm->memManager, vmm.ptr, vmm.size, vmm.handle,
+                           hipMemHandleTypePosixFileDescriptor, memType),
+              ncclSuccess);
+    ASSERT_EQ(ncclDynMemMarkExportToPeer(comm->memManager, vmm.ptr, peerRank), ncclSuccess);
+
+    PeerMeta meta{};
+    meta.handleVal = (uint64_t)(uintptr_t)vmm.handle;
+    meta.ownerPtr  = reinterpret_cast<uintptr_t>(vmm.ptr);
+    meta.size      = static_cast<uint64_t>(vmm.size);
+    meta.ownerDev  = comm->cudaDev;
+    ASSERT_EQ(bootstrapSend(comm->bootstrap, peerRank, tag, &meta, sizeof(meta)),
+              ncclSuccess);
+}
+
+// Importer side: bootstrapRecv the metadata, ask owner's proxy for a POSIX
+// FD, import + map + setAccess into a fresh local VA, then Track as imported.
+// Fills `out` with VA + size + the imported handle so untrackAndRelease() can
+// free everything later.
+void recvAndImportPeerBuffer(struct ncclComm* comm, int ownerRank, ncclMemType_t memType,
+                             int tag, VmmAlloc* out)
+{
+    PeerMeta meta{};
+    ASSERT_EQ(bootstrapRecv(comm->bootstrap, ownerRank, tag, &meta, sizeof(meta)),
+              ncclSuccess);
+    ASSERT_GT(meta.size, 0u);
+    ASSERT_NE(meta.ownerPtr, 0u);
+
+    int                             fd       = -1;
+    hipMemGenericAllocationHandle_t peerHval =
+        (hipMemGenericAllocationHandle_t)(uintptr_t)meta.handleVal;
+    ASSERT_EQ(ncclProxyClientGetFdBlocking(comm, ownerRank, &peerHval, &fd), ncclSuccess);
+    ASSERT_GE(fd, 0) << "proxy GetFd from rank " << ownerRank << " returned invalid FD";
+
+    hipMemGenericAllocationHandle_t imported = 0;
+    ASSERT_EQ(hipMemImportFromShareableHandle(&imported, (void*)(uintptr_t)fd,
+                                              hipMemHandleTypePosixFileDescriptor),
+              hipSuccess);
+    close(fd);
+
+    reserveVaOnly(comm->cudaDev, static_cast<size_t>(meta.size), out);
+    ASSERT_EQ(hipMemMap(out->pdev, out->size, 0, imported, 0), hipSuccess);
+    applyDeviceRwAccess(comm->cudaDev, out->pdev, out->size);
+    out->handle = imported;
+
+    ASSERT_EQ(ncclMemTrackImportFromPeer(comm->memManager, out->ptr, out->size, imported,
+                                         hipMemHandleTypePosixFileDescriptor, memType,
+                                         ownerRank, meta.ownerDev,
+                                         reinterpret_cast<void*>(meta.ownerPtr)),
+              ncclSuccess);
+}
+} // namespace
+
+// ===========================================================================
+// AnyRanks suite (np >= 1) - local-only Suspend/Resume scenarios.
+//
+// Every test here only touches its own rank's manager (no cross-rank exports).
+// The bootstrapBarrier(0xBEEF/0xCAFE) inside ncclCommMemSuspend/Resume keeps
+// all ranks in sync, AllGather/Send-Recv in Resume Step 3 short-circuits when
+// nobody has exports, so the same body works identically on np=1, np=2, np=N.
+// ===========================================================================
+
+class MemManagerAnyRanks : public MPITestBase
+{
+protected:
+    void SetUp() override
+    {
+        MPITestBase::SetUp();
+        if (!validateTestPrerequisites(/*min_processes=*/1, kNoProcessLimit)) {
+            GTEST_SKIP() << "AnyRanks suite needs at least 1 rank";
+        }
+        ASSERT_EQ(createTestCommunicator(), ncclSuccess);
+    }
+};
+
+TEST_F(MemManagerAnyRanks, SuspendResume_LocalScratch)
+{
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_NE(comm, nullptr);
+    ASSERT_NE(comm->memManager, nullptr);
+
+    VmmAlloc a{};
+    allocateVmmPosixFd(comm->cudaDev, 1 << 20, &a);
+
+    ASSERT_EQ(ncclMemTrack(comm->memManager, a.ptr, a.size, a.handle,
+                           hipMemHandleTypePosixFileDescriptor, ncclMemScratch),
+              ncclSuccess);
+
+    ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+    EXPECT_EQ(comm->memManager->released, 1);
+
+    // The single tracked entry is the one we just added.
+    ncclDynMemEntry* entry = comm->memManager->entries;
+    ASSERT_NE(entry, nullptr);
+    EXPECT_EQ(entry->state, ncclDynMemStateReleased);
+    EXPECT_EQ(static_cast<void*>(entry->handle), nullptr);
+
+    ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+    EXPECT_EQ(comm->memManager->released, 0);
+    EXPECT_EQ(entry->state, ncclDynMemStateActive);
+    EXPECT_NE(static_cast<void*>(entry->handle), nullptr);
+
+    // Verify the VA is mapped again - a roundtrip memset/D2H must succeed.
+    ASSERT_EQ(hipMemset(a.ptr, 0xAA, a.size), hipSuccess);
+    std::vector<uint8_t> host(a.size, 0);
+    ASSERT_EQ(hipMemcpy(host.data(), a.ptr, a.size, hipMemcpyDeviceToHost), hipSuccess);
+    EXPECT_EQ(host[0], 0xAA);
+    EXPECT_EQ(host[a.size - 1], 0xAA);
+
+    ASSERT_EQ(ncclMemUntrack(comm->memManager, a.ptr, a.size), ncclSuccess);
+    releaseVmm(&a);
+}
+
+TEST_F(MemManagerAnyRanks, SuspendResume_LocalOffload_DataPreserved)
+{
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_NE(comm->memManager, nullptr);
+
+    VmmAlloc a{};
+    allocateVmmPosixFd(comm->cudaDev, 64 * 1024, &a);
+
+    ASSERT_EQ(ncclMemTrack(comm->memManager, a.ptr, a.size, a.handle,
+                           hipMemHandleTypePosixFileDescriptor, ncclMemOffload),
+              ncclSuccess);
+
+    // Pre-fill device buffer with a recognisable pattern so we can verify that
+    // Suspend's D2H copy and Resume's H2D restore round-trip the bytes.
+    std::vector<uint8_t> pattern(a.size);
+    for (size_t i = 0; i < a.size; i++) pattern[i] = static_cast<uint8_t>(i * 31u);
+    ASSERT_EQ(hipMemcpy(a.ptr, pattern.data(), a.size, hipMemcpyHostToDevice), hipSuccess);
+
+    ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+
+    ncclDynMemEntry* entry = comm->memManager->entries;
+    ASSERT_NE(entry, nullptr);
+    EXPECT_EQ(entry->state, ncclDynMemStateReleased);
+    EXPECT_NE(entry->cpuBackup, nullptr);
+    EXPECT_EQ(comm->memManager->cpuBackupUsage, a.size);
+
+    ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+    EXPECT_EQ(entry->state, ncclDynMemStateActive);
+    EXPECT_EQ(entry->cpuBackup, nullptr);
+    EXPECT_EQ(comm->memManager->cpuBackupUsage, 0u);
+
+    std::vector<uint8_t> roundtrip(a.size, 0);
+    ASSERT_EQ(hipMemcpy(roundtrip.data(), a.ptr, a.size, hipMemcpyDeviceToHost), hipSuccess);
+    EXPECT_EQ(std::memcmp(roundtrip.data(), pattern.data(), a.size), 0);
+
+    ASSERT_EQ(ncclMemUntrack(comm->memManager, a.ptr, a.size), ncclSuccess);
+    releaseVmm(&a);
+}
+
+TEST_F(MemManagerAnyRanks, SuspendResume_PersistUntouched)
+{
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_NE(comm->memManager, nullptr);
+
+    constexpr size_t persistSize = 8192;
+    void* persistPtr             = reinterpret_cast<void*>(0xDEADBEEF00ULL);
+    ASSERT_EQ(ncclMemTrack(comm->memManager, persistPtr, persistSize,
+                           /*handle=*/0, hipMemHandleTypePosixFileDescriptor,
+                           ncclMemPersist),
+              ncclSuccess);
+
+    uint64_t persistBefore = 0;
+    ASSERT_EQ(ncclCommMemStats(comm, ncclStatGpuMemPersist, &persistBefore), ncclSuccess);
+    EXPECT_EQ(persistBefore, persistSize);
+
+    ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+
+    uint64_t persistAfter = 0;
+    ASSERT_EQ(ncclCommMemStats(comm, ncclStatGpuMemPersist, &persistAfter), ncclSuccess);
+    EXPECT_EQ(persistAfter, persistSize);
+
+    uint64_t suspended = 0;
+    ASSERT_EQ(ncclCommMemStats(comm, ncclStatGpuMemSuspended, &suspended), ncclSuccess);
+    EXPECT_EQ(suspended, 1u);
+
+    ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+
+    ASSERT_EQ(ncclMemUntrack(comm->memManager, persistPtr, persistSize), ncclSuccess);
+}
+
+TEST_F(MemManagerAnyRanks, SuspendResume_DoubleCalls_Rejected)
+{
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_NE(comm->memManager, nullptr);
+
+    ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+    EXPECT_EQ(ncclCommMemSuspend(comm), ncclInvalidUsage);
+
+    ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+    EXPECT_EQ(ncclCommMemResume(comm), ncclInvalidUsage);
+}
+
+TEST_F(MemManagerAnyRanks, MemStats_FlipsAcrossSuspendResume)
+{
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_NE(comm->memManager, nullptr);
+
+    uint64_t suspended = ~0ULL;
+    ASSERT_EQ(ncclCommMemStats(comm, ncclStatGpuMemSuspended, &suspended), ncclSuccess);
+    EXPECT_EQ(suspended, 0u);
+
+    ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+    ASSERT_EQ(ncclCommMemStats(comm, ncclStatGpuMemSuspended, &suspended), ncclSuccess);
+    EXPECT_EQ(suspended, 1u);
+
+    ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+    ASSERT_EQ(ncclCommMemStats(comm, ncclStatGpuMemSuspended, &suspended), ncclSuccess);
+    EXPECT_EQ(suspended, 0u);
+}
+
+// ===========================================================================
+// Two-rank suite (-np 2) - exercises bootstrap-coupled paths
+// ===========================================================================
+
+class MemManagerTwoRank : public MPITestBase
+{
+protected:
+    void SetUp() override
+    {
+        MPITestBase::SetUp();
+        if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2)) {
+            GTEST_SKIP() << "Two-rank suite, run with mpirun -np 2";
+        }
+        ASSERT_EQ(createTestCommunicator(), ncclSuccess);
+    }
+};
+
+// Both ranks own only local entries. No exports, no peer imports.
+// Verifies:
+//   - bootstrapBarrier(0xBEEF) on Suspend entry succeeds across ranks.
+//   - bootstrapBarrier(0xBEEF) after Resume Step 1 succeeds.
+//   - Resume Step 3 short-circuits when nobody has exports
+//     (allCounts all zero, totalInfoCount == 0, no Send/Recv).
+//   - Final bootstrapBarrier(0xCAFE) succeeds.
+TEST_F(MemManagerTwoRank, SuspendResume_LocalOnly)
+{
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_NE(comm->memManager, nullptr);
+
+    VmmAlloc a{};
+    allocateVmmPosixFd(comm->cudaDev, 1 << 20, &a);
+    ASSERT_EQ(ncclMemTrack(comm->memManager, a.ptr, a.size, a.handle,
+                           hipMemHandleTypePosixFileDescriptor, ncclMemScratch),
+              ncclSuccess);
+
+    ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+    EXPECT_EQ(comm->memManager->released, 1);
+    ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+    EXPECT_EQ(comm->memManager->released, 0);
+
+    // VA must be live again on both ranks.
+    ASSERT_EQ(hipMemset(a.ptr, 0x55, a.size), hipSuccess);
+
+    ASSERT_EQ(ncclMemUntrack(comm->memManager, a.ptr, a.size), ncclSuccess);
+    releaseVmm(&a);
+}
+
+// Inject a synthetic stale peer-imported entry on rank 1 with an ownerPtr
+// that rank 0 does not own. Resume Step 3 will gather (allCounts == 0, since
+// neither rank has exports), Step 4's matching loop on rank 1 will fail to
+// find a matching ncclDynMemP2pHandleInfo, log a WARN, and skip the entry
+// without crashing. Verifies the negative branch of the matching loop.
+TEST_F(MemManagerTwoRank, Resume_PeerImport_NoMatch_SkipsGracefully)
+{
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_NE(comm->memManager, nullptr);
+    int rank = comm->rank;
+
+    // Rank 1 reserves a VA region (no physical backing) and registers it as
+    // a peer import that points at a fake ownerPtr on rank 0. Rank 0 does
+    // nothing - it'll have no exports to broadcast.
+    VmmAlloc fakeImport{};
+    if (rank == 1) {
+        reserveVaOnly(comm->cudaDev, 64 * 1024, &fakeImport);
+        void* fakeOwnerPtr = reinterpret_cast<void*>(0xFEEDFACE0000ULL);
+        ASSERT_EQ(ncclMemTrackImportFromPeer(
+                      comm->memManager, fakeImport.ptr, fakeImport.size,
+                      /*handle=*/0, hipMemHandleTypePosixFileDescriptor,
+                      ncclMemScratch, /*ownerRank=*/0, /*ownerDev=*/0, fakeOwnerPtr),
+                  ncclSuccess);
+
+        // Pretend Suspend already ran for this entry so Resume Step 4 considers
+        // it a candidate for re-import (which is then expected to no-match).
+        ncclDynMemEntry* entry = comm->memManager->entries;
+        ASSERT_NE(entry, nullptr);
+        entry->state = ncclDynMemStateReleased;
+    }
+
+    // Drive the full Suspend / Resume cycle. We expect:
+    //   - Suspend on both ranks succeeds (rank 1's "released" entry is skipped
+    //     in Pass 1 since state already == Released; rank 0 has no entries).
+    //   - Resume on both ranks succeeds; rank 1's Step 4 logs a WARN and
+    //     leaves the entry in the Released state.
+    ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+    ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+
+    if (rank == 1) {
+        ncclDynMemEntry* entry = comm->memManager->entries;
+        ASSERT_NE(entry, nullptr);
+        EXPECT_EQ(entry->state, ncclDynMemStateReleased)
+            << "Resume must NOT mark a no-match peer entry Active";
+
+        // Cleanup: drop the fake entry and free the VA reservation.
+        ASSERT_EQ(ncclMemUntrack(comm->memManager, fakeImport.ptr, fakeImport.size),
+                  ncclSuccess);
+        releaseVmm(&fakeImport);
+    }
+}
+
+// End-to-end happy path of the Suspend/Resume P2P protocol with a real,
+// mutual peer import driven through the proxy:
+//
+//   Setup (before Suspend):
+//     rank 0:  hipMemCreate(POSIX_FD) -> hipMemMap -> hipMemSetAccess
+//              -> ncclMemTrack(..., ncclMemOffload)
+//              -> ncclDynMemMarkExportToPeer(peer=1)
+//              -> hipMemset(canary)
+//              -> bootstrapSend(meta = {handleVal, ownerPtr, size, ownerDev}, tag=0xC0FFEE)
+//
+//     rank 1:  bootstrapRecv(meta, tag=0xC0FFEE)
+//              -> ncclProxyClientGetFdBlocking(rank 0, &handleVal, &fd)   <-- UDS round-trip
+//              -> hipMemImportFromShareableHandle(fd) -> hipMemMap + SetAccess
+//              -> ncclMemTrackImportFromPeer(..., ncclMemOffload, owner=rank 0)
+//              -> (sanity) hipMemcpy DToH and verify canary on imported VA
+//
+//   Drive Suspend then Resume on both ranks. This exercises:
+//     - Suspend Step 1: rank 1 unmaps the imported entry, releases its handle.
+//     - Suspend Step 2: rank 0 copies the offload buffer to CPU backup,
+//       closes the shareable FD, unmaps + releases the physical handle.
+//     - Resume Step 1: rank 0 re-creates a fresh physical handle, re-maps to
+//       the same VA, re-applies POSIX-FD path's empty same-process peer-ACL
+//       loop (cross-process here, so no cuMemSetAccess), and restores data
+//       from the CPU backup. rank 1 has no local entries to restore.
+//     - Resume Step 3: AllGather counts (rank 0 reports 1 export, rank 1
+//       reports 0), Send/Recv the new ncclDynMemP2pHandleInfo, both ranks
+//       end up with allInfos[0] == rank 0's new handle.
+//     - Resume Step 4 (positive matching): rank 1 finds the matching entry
+//       (ownerRank/ownerPtr/size all match), calls ncclProxyClientGetFdBlocking
+//       on the new handle, hipMemImportFromShareableHandle, ncclCuMemMapAndSetAccess
+//       to the same imported VA. Entry transitions Released -> Active.
+//     - Final 0xCAFE barrier completes.
+//
+//   Verify: rank 1 hipMemcpy DToH from imported VA -> canary preserved.
+//
+// Failure of any step short-circuits and asserts so we get a precise diagnosis
+// instead of a silent stale-data success.
+TEST_F(MemManagerTwoRank, SuspendResume_PeerExportImport_RoundtripCanary)
+{
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_NE(comm->memManager, nullptr);
+
+    constexpr size_t  kRequestedSize = 1u << 20;
+    constexpr uint8_t kCanary        = 0xAB;
+    constexpr int     kMetaTag       = 0xC0FFEE;
+
+    if (comm->rank == 0) {
+        VmmAlloc owner{};
+        allocateVmmPosixFd(comm->cudaDev, kRequestedSize, &owner);
+        ASSERT_EQ(hipMemset(owner.ptr, kCanary, owner.size), hipSuccess);
+        ASSERT_EQ(hipDeviceSynchronize(), hipSuccess);
+
+        exportAndShipMeta(comm, owner, /*peerRank=*/1, ncclMemOffload, kMetaTag);
+
+        ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+        EXPECT_EQ(comm->memManager->released, 1);
+        ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+        EXPECT_EQ(comm->memManager->released, 0);
+
+        untrackAndRelease(comm, owner.ptr, &owner);
+        return;
+    }
+
+    ASSERT_EQ(comm->rank, 1);
+    VmmAlloc imp{};
+    recvAndImportPeerBuffer(comm, /*ownerRank=*/0, ncclMemOffload, kMetaTag, &imp);
+
+    // Sanity-check the primary import path BEFORE Suspend/Resume - if this
+    // fails, the GetFd / import / map chain is broken and any post-Resume
+    // verification would be a stale-data success.
+    verifyCanaryReadback(imp.ptr, imp.size, kCanary, "primary peer import");
+
+    ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+    EXPECT_EQ(comm->memManager->released, 1);
+    {
+        ncclDynMemEntry* e = comm->memManager->entries;
+        ASSERT_NE(e, nullptr);
+        EXPECT_EQ(e->state, ncclDynMemStateReleased);
+        EXPECT_EQ(static_cast<void*>(e->handle), nullptr)
+            << "Suspend must release imported handle";
+    }
+
+    ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+    EXPECT_EQ(comm->memManager->released, 0);
+
+    ncclDynMemEntry* entry = comm->memManager->entries;
+    ASSERT_NE(entry, nullptr);
+    EXPECT_EQ(entry->state, ncclDynMemStateActive)
+        << "Resume Step 4 must transition the matched peer entry back to Active";
+    EXPECT_NE(static_cast<void*>(entry->handle), nullptr)
+        << "Resume must install the re-imported handle";
+
+    verifyCanaryReadback(imp.ptr, imp.size, kCanary,
+                         "post-Resume imported VA (rank 0's offload data)");
+
+    untrackAndRelease(comm, imp.ptr, &imp);
+}
+
+// ===========================================================================
+// Stress / coverage tests for AnyRanks (np >= 1)
+// ===========================================================================
+
+// A: empty manager - no entries tracked, but Suspend/Resume must still drive
+// all the bootstrap barriers and toggle the released flag. Catches a corner
+// case where Pass 1 / Pass 2 / Step 1 / Step 4 loops crash on a null entries
+// pointer (manager->entries == nullptr from start).
+TEST_F(MemManagerAnyRanks, EmptyManager_SuspendResume_NoOp)
+{
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_NE(comm->memManager, nullptr);
+    ASSERT_EQ(comm->memManager->entries, nullptr);
+    ASSERT_EQ(comm->memManager->numEntries, 0);
+
+    ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+    EXPECT_EQ(comm->memManager->released, 1);
+    EXPECT_EQ(comm->memManager->entries, nullptr) << "Suspend must not invent entries";
+
+    ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+    EXPECT_EQ(comm->memManager->released, 0);
+    EXPECT_EQ(comm->memManager->entries, nullptr) << "Resume must not invent entries";
+    EXPECT_EQ(comm->memManager->cpuBackupUsage, 0u);
+}
+
+// B: Persist + Scratch + Offload tracked together. Suspend / Resume releases
+// + restores Scratch and Offload but Persist is invisible to it (lives outside
+// the linked list). Verifies stat invariants:
+//   - Total = Persist + Scratch + Offload    (constant before and after)
+//   - Persist                                 (constant)
+//   - Suspend = Scratch + Offload            (constant - tracked, not freed)
+//   - Suspended toggles 0 -> 1 -> 0
+TEST_F(MemManagerAnyRanks, MixedMemTypes_StatsConsistent)
+{
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_NE(comm->memManager, nullptr);
+
+    constexpr size_t  kPersistReq  = 8 * 1024;
+    constexpr size_t  kScratchReq  = 256 * 1024;
+    constexpr size_t  kOffloadReq  = 128 * 1024;
+    constexpr uint8_t kPersistByte = 0xC1;
+
+    VmmAlloc persistVmm{};
+    allocateVmmPosixFd(comm->cudaDev, kPersistReq, &persistVmm);
+    ASSERT_EQ(hipMemset(persistVmm.ptr, kPersistByte, persistVmm.size), hipSuccess);
+    ASSERT_EQ(ncclMemTrack(comm->memManager, persistVmm.ptr, persistVmm.size,
+                           persistVmm.handle, hipMemHandleTypePosixFileDescriptor,
+                           ncclMemPersist),
+              ncclSuccess);
+
+    VmmAlloc scratchVmm{};
+    allocateVmmPosixFd(comm->cudaDev, kScratchReq, &scratchVmm);
+    ASSERT_EQ(ncclMemTrack(comm->memManager, scratchVmm.ptr, scratchVmm.size,
+                           scratchVmm.handle, hipMemHandleTypePosixFileDescriptor,
+                           ncclMemScratch),
+              ncclSuccess);
+
+    VmmAlloc offloadVmm{};
+    allocateVmmPosixFd(comm->cudaDev, kOffloadReq, &offloadVmm);
+    ASSERT_EQ(ncclMemTrack(comm->memManager, offloadVmm.ptr, offloadVmm.size,
+                           offloadVmm.handle, hipMemHandleTypePosixFileDescriptor,
+                           ncclMemOffload),
+              ncclSuccess);
+
+    auto readStat = [&](ncclCommMemStat_t s) {
+        uint64_t v = ~0ULL;
+        EXPECT_EQ(ncclCommMemStats(comm, s, &v), ncclSuccess);
+        return v;
+    };
+
+    const uint64_t expectedTotal   = persistVmm.size + scratchVmm.size + offloadVmm.size;
+    const uint64_t expectedPersist = persistVmm.size;
+    const uint64_t expectedDynamic = scratchVmm.size + offloadVmm.size;
+
+    EXPECT_EQ(readStat(ncclStatGpuMemTotal),     expectedTotal);
+    EXPECT_EQ(readStat(ncclStatGpuMemPersist),   expectedPersist);
+    EXPECT_EQ(readStat(ncclStatGpuMemSuspend),   expectedDynamic);
+    EXPECT_EQ(readStat(ncclStatGpuMemSuspended), 0u);
+
+    ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+
+    // Tracked sizes don't change across Suspend - the entries are still in the
+    // linked list, just with state == Released. Persist counter is independent.
+    EXPECT_EQ(readStat(ncclStatGpuMemTotal),     expectedTotal);
+    EXPECT_EQ(readStat(ncclStatGpuMemPersist),   expectedPersist);
+    EXPECT_EQ(readStat(ncclStatGpuMemSuspend),   expectedDynamic);
+    EXPECT_EQ(readStat(ncclStatGpuMemSuspended), 1u);
+
+    ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+    EXPECT_EQ(readStat(ncclStatGpuMemTotal),     expectedTotal);
+    EXPECT_EQ(readStat(ncclStatGpuMemPersist),   expectedPersist);
+    EXPECT_EQ(readStat(ncclStatGpuMemSuspend),   expectedDynamic);
+    EXPECT_EQ(readStat(ncclStatGpuMemSuspended), 0u);
+
+    // Persist physical memory must still be readable with its canary intact.
+    verifyCanaryReadback(persistVmm.ptr, persistVmm.size, kPersistByte,
+                         "persist after Suspend/Resume");
+
+    untrackAndRelease(comm, scratchVmm.ptr, &scratchVmm);
+    untrackAndRelease(comm, offloadVmm.ptr, &offloadVmm);
+    // Persist isn't in the linked list - Untrack only adjusts the counter.
+    ASSERT_EQ(ncclMemUntrack(comm->memManager, persistVmm.ptr, persistVmm.size),
+              ncclSuccess);
+    releaseVmm(&persistVmm);
+
+    EXPECT_EQ(readStat(ncclStatGpuMemTotal), 0u);
+}
+
+// C: multiple Suspend/Resume cycles on the same Offload buffer. Verifies that
+// the CPU-backup -> GPU restore loop is idempotent across many cycles - no
+// cpuBackup leaks, no handle leaks, canary preserved every iteration.
+TEST_F(MemManagerAnyRanks, MultipleSuspendResumeCycles_DataPreserved)
+{
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_NE(comm->memManager, nullptr);
+
+    constexpr size_t  kSize    = 64 * 1024;
+    constexpr int     kCycles  = 5;
+    constexpr uint8_t kInitial = 0x5A;
+
+    VmmAlloc a{};
+    allocateVmmPosixFd(comm->cudaDev, kSize, &a);
+
+    std::vector<uint8_t> seed(a.size);
+    for (size_t i = 0; i < a.size; ++i) {
+        seed[i] = static_cast<uint8_t>(kInitial ^ (i & 0xFFu));
+    }
+    ASSERT_EQ(hipMemcpy(a.ptr, seed.data(), a.size, hipMemcpyHostToDevice), hipSuccess);
+
+    ASSERT_EQ(ncclMemTrack(comm->memManager, a.ptr, a.size, a.handle,
+                           hipMemHandleTypePosixFileDescriptor, ncclMemOffload),
+              ncclSuccess);
+
+    for (int cycle = 0; cycle < kCycles; ++cycle) {
+        SCOPED_TRACE("cycle=" + std::to_string(cycle));
+
+        ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+        EXPECT_EQ(comm->memManager->cpuBackupUsage, a.size)
+            << "Suspend must allocate exactly one CPU backup";
+
+        ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+        EXPECT_EQ(comm->memManager->cpuBackupUsage, 0u)
+            << "Resume must free the CPU backup after restore";
+
+        std::vector<uint8_t> readback(a.size, 0u);
+        ASSERT_EQ(hipMemcpy(readback.data(), a.ptr, a.size, hipMemcpyDeviceToHost),
+                  hipSuccess);
+        EXPECT_EQ(std::memcmp(readback.data(), seed.data(), a.size), 0)
+            << "data corrupted after cycle " << cycle;
+    }
+
+    untrackAndRelease(comm, a.ptr, &a);
+}
+
+// D: stress - many small Scratch + Offload entries tracked together, single
+// Suspend/Resume cycle. Catches O(n^2) regressions in the linked-list scan,
+// cumulative leaks, granularity-padding bugs, and quietly-skipped entries.
+TEST_F(MemManagerAnyRanks, Suspend_LargeNumberOfEntries_AllRestored)
+{
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_NE(comm->memManager, nullptr);
+
+    constexpr int kNumEntries = 32;
+    constexpr int kNumOffload = 8;  // first kNumOffload are Offload, rest are Scratch
+
+    std::vector<VmmAlloc> entries(kNumEntries);
+    std::vector<uint8_t>  canaries(kNumEntries);
+    uint64_t              expectedDynamicBytes = 0;
+    uint64_t              expectedOffloadBytes = 0;
+
+    for (int i = 0; i < kNumEntries; ++i) {
+        // Mix sizes from 4 KiB to ~256 KiB - granularity rounding still applies.
+        size_t requested = (4 * 1024) + (i * 8 * 1024);
+        allocateVmmPosixFd(comm->cudaDev, requested, &entries[i]);
+
+        canaries[i] = static_cast<uint8_t>(0x40 + i);
+        ASSERT_EQ(hipMemset(entries[i].ptr, canaries[i], entries[i].size), hipSuccess);
+
+        bool          isOffload = (i < kNumOffload);
+        ncclMemType_t type      = isOffload ? ncclMemOffload : ncclMemScratch;
+        ASSERT_EQ(ncclMemTrack(comm->memManager, entries[i].ptr, entries[i].size,
+                               entries[i].handle,
+                               hipMemHandleTypePosixFileDescriptor, type),
+                  ncclSuccess);
+        expectedDynamicBytes += entries[i].size;
+        if (isOffload) expectedOffloadBytes += entries[i].size;
+    }
+    ASSERT_EQ(hipDeviceSynchronize(), hipSuccess);
+    EXPECT_EQ(comm->memManager->numEntries, kNumEntries);
+
+    ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+    EXPECT_EQ(comm->memManager->cpuBackupUsage, expectedOffloadBytes)
+        << "CPU backup pool must equal sum of Offload sizes";
+
+    ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+    EXPECT_EQ(comm->memManager->cpuBackupUsage, 0u);
+
+    // Every Offload entry must come back with its canary preserved. Scratch
+    // entries lose data by design - just check the VA is mapped + writable.
+    for (int i = 0; i < kNumEntries; ++i) {
+        SCOPED_TRACE("entry=" + std::to_string(i));
+        if (i < kNumOffload) {
+            verifyCanaryReadback(entries[i].ptr, entries[i].size, canaries[i],
+                                 "offload after Resume");
+        } else {
+            ASSERT_EQ(hipMemset(entries[i].ptr, 0xAA, entries[i].size), hipSuccess);
+        }
+    }
+
+    auto readStat = [&](ncclCommMemStat_t s) {
+        uint64_t v = ~0ULL;
+        EXPECT_EQ(ncclCommMemStats(comm, s, &v), ncclSuccess);
+        return v;
+    };
+    EXPECT_EQ(readStat(ncclStatGpuMemSuspend), expectedDynamicBytes);
+
+    for (auto& e : entries) untrackAndRelease(comm, e.ptr, &e);
+    EXPECT_EQ(comm->memManager->numEntries, 0);
+}
+
+// E: Persist physical memory must survive Suspend/Resume completely untouched
+// (it lives outside the linked list, so neither Pass nor Step iterates over
+// it). PersistUntouched (counter-only) leaves room for a regression where the
+// VA gets accidentally unmapped; this catches it via canary roundtrip.
+TEST_F(MemManagerAnyRanks, Persist_PhysicalMemoryUntouched)
+{
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_NE(comm->memManager, nullptr);
+
+    constexpr size_t  kSize   = 32 * 1024;
+    constexpr uint8_t kCanary = 0xE7;
+
+    VmmAlloc persistVmm{};
+    allocateVmmPosixFd(comm->cudaDev, kSize, &persistVmm);
+    ASSERT_EQ(hipMemset(persistVmm.ptr, kCanary, persistVmm.size), hipSuccess);
+    ASSERT_EQ(hipDeviceSynchronize(), hipSuccess);
+
+    ASSERT_EQ(ncclMemTrack(comm->memManager, persistVmm.ptr, persistVmm.size,
+                           persistVmm.handle, hipMemHandleTypePosixFileDescriptor,
+                           ncclMemPersist),
+              ncclSuccess);
+
+    EXPECT_EQ(comm->memManager->numEntries, 0)
+        << "Persist must not enter the linked list (only counter)";
+
+    ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+    EXPECT_EQ(comm->memManager->cpuBackupUsage, 0u)
+        << "Persist must NOT be CPU-backed up";
+
+    // VA must still be live - manager skipped it, so handle/map are untouched.
+    verifyCanaryReadback(persistVmm.ptr, persistVmm.size, kCanary, "persist mid-suspend");
+
+    ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+    verifyCanaryReadback(persistVmm.ptr, persistVmm.size, kCanary, "persist post-resume");
+
+    ASSERT_EQ(ncclMemUntrack(comm->memManager, persistVmm.ptr, persistVmm.size),
+              ncclSuccess);
+    releaseVmm(&persistVmm);
+}
+
+// ===========================================================================
+// Stress / coverage tests for TwoRank (np == 2)
+// ===========================================================================
+
+// F: rank 0 exports N=3 distinct buffers, rank 1 imports all of them, full
+// Suspend/Resume cycle, every canary preserved. Exercises:
+//   - Suspend Step 1: rank 1's Pass-1 unmap loop iterates over multiple
+//     peer-imported entries.
+//   - Suspend Step 2: rank 0's Pass-2 offload loop runs CPU-backup over N
+//     distinct entries.
+//   - Resume Step 3: rank 0's localBroadcastCount = N, localInfos buffer
+//     holds N elements, AllGather counts come out as [N, 0].
+//   - Resume Step 4: rank 1's matching loop matches N times in the same
+//     allInfos array (positive branch, multiple iterations).
+TEST_F(MemManagerTwoRank, Multiple_PeerEntries_RoundtripCanary)
+{
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_NE(comm->memManager, nullptr);
+
+    constexpr int     kNumBuffers  = 3;
+    constexpr int     kBaseTag     = 0xC0FFEE;
+    const     size_t  kSizes[kNumBuffers]    = { 64 * 1024, 96 * 1024, 128 * 1024 };
+    const     uint8_t kCanaries[kNumBuffers] = { 0xA1, 0xB2, 0xC3 };
+
+    if (comm->rank == 0) {
+        std::vector<VmmAlloc> owners(kNumBuffers);
+        for (int i = 0; i < kNumBuffers; ++i) {
+            allocateVmmPosixFd(comm->cudaDev, kSizes[i], &owners[i]);
+            ASSERT_EQ(hipMemset(owners[i].ptr, kCanaries[i], owners[i].size), hipSuccess);
+        }
+        ASSERT_EQ(hipDeviceSynchronize(), hipSuccess);
+
+        for (int i = 0; i < kNumBuffers; ++i) {
+            exportAndShipMeta(comm, owners[i], /*peerRank=*/1,
+                              ncclMemOffload, kBaseTag + i);
+        }
+
+        ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+        ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+
+        for (auto& o : owners) untrackAndRelease(comm, o.ptr, &o);
+        return;
+    }
+
+    ASSERT_EQ(comm->rank, 1);
+    std::vector<VmmAlloc> imports(kNumBuffers);
+    for (int i = 0; i < kNumBuffers; ++i) {
+        recvAndImportPeerBuffer(comm, /*ownerRank=*/0, ncclMemOffload, kBaseTag + i,
+                                &imports[i]);
+        verifyCanaryReadback(imports[i].ptr, imports[i].size, kCanaries[i],
+                             "primary import of buffer #" + std::to_string(i));
+    }
+
+    ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+    ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+
+    int activeCount = 0;
+    for (auto* e = comm->memManager->entries; e != nullptr; e = e->next) {
+        EXPECT_EQ(e->state, ncclDynMemStateActive);
+        EXPECT_TRUE(e->isImportedFromPeer);
+        ++activeCount;
+    }
+    EXPECT_EQ(activeCount, kNumBuffers);
+
+    for (int i = 0; i < kNumBuffers; ++i) {
+        verifyCanaryReadback(imports[i].ptr, imports[i].size, kCanaries[i],
+                             "post-Resume import of buffer #" + std::to_string(i));
+    }
+    for (auto& imp : imports) untrackAndRelease(comm, imp.ptr, &imp);
+}
+
+// G: bidirectional - both ranks export to each other. Each rank has BOTH a
+// local exported buffer AND an imported one. Exercises Resume Step 3 with
+// localBroadcastCount > 0 on EVERY rank simultaneously: localInfos contains
+// our own export, allInfos receives both ranks' contributions, allCounts
+// comes out as [1, 1] (not [N, 0] like in F).
+TEST_F(MemManagerTwoRank, Bidirectional_PeerExchange_RoundtripCanary)
+{
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_NE(comm->memManager, nullptr);
+    int rank = comm->rank;
+    int peer = 1 - rank;
+
+    constexpr size_t kSize       = 64 * 1024;
+    const     uint8_t myCanary   = (rank == 0) ? 0xD1 : 0xD2;
+    const     uint8_t peerCanary = (rank == 0) ? 0xD2 : 0xD1;
+    // One tag per sender so the two bootstrapSends can race in flight without
+    // collision at the bootstrap layer.
+    const int myExportTag   = 0xC0FFEE0 + rank;
+    const int peerExportTag = 0xC0FFEE0 + peer;
+
+    VmmAlloc myExport{};
+    allocateVmmPosixFd(comm->cudaDev, kSize, &myExport);
+    ASSERT_EQ(hipMemset(myExport.ptr, myCanary, myExport.size), hipSuccess);
+    ASSERT_EQ(hipDeviceSynchronize(), hipSuccess);
+
+    // Send my export's metadata BEFORE the recv to avoid deadlock - both ranks
+    // do the same so each side's bootstrapSend buffers up at the bootstrap
+    // layer until the matching bootstrapRecv fires.
+    exportAndShipMeta(comm, myExport, peer, ncclMemOffload, myExportTag);
+
+    VmmAlloc peerImport{};
+    recvAndImportPeerBuffer(comm, peer, ncclMemOffload, peerExportTag, &peerImport);
+    verifyCanaryReadback(peerImport.ptr, peerImport.size, peerCanary,
+                         "primary import of peer's buffer");
+
+    EXPECT_EQ(comm->memManager->numEntries, 2)
+        << "Each rank should now own 1 local + 1 imported entry";
+
+    ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+    ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+
+    verifyCanaryReadback(peerImport.ptr, peerImport.size, peerCanary,
+                         "post-Resume import of peer's buffer");
+
+    untrackAndRelease(comm, myExport.ptr,   &myExport);
+    untrackAndRelease(comm, peerImport.ptr, &peerImport);
+}
+
+// H: rank 0 exports 2 buffers, but rank 1 only does a real import for the
+// FIRST one - the second is a synthetic stale import that points at a fake
+// ownerPtr (nothing actually exported with that VA). Resume Step 4 must
+// successfully match buffer #0 (positive branch) AND skip-with-WARN buffer
+// #1 (negative branch), in the SAME matching-loop pass.
+TEST_F(MemManagerTwoRank, PartialPeerImport_MixedMatch)
+{
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_NE(comm->memManager, nullptr);
+
+    constexpr size_t  kSize       = 64 * 1024;
+    constexpr uint8_t kCanary     = 0x9E;
+    constexpr int     kRealTag    = 0xC0FFEE;
+
+    if (comm->rank == 0) {
+        VmmAlloc realOwner{};
+        allocateVmmPosixFd(comm->cudaDev, kSize, &realOwner);
+        ASSERT_EQ(hipMemset(realOwner.ptr, kCanary, realOwner.size), hipSuccess);
+        ASSERT_EQ(hipDeviceSynchronize(), hipSuccess);
+
+        exportAndShipMeta(comm, realOwner, /*peerRank=*/1, ncclMemOffload, kRealTag);
+
+        ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+        ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+
+        untrackAndRelease(comm, realOwner.ptr, &realOwner);
+        return;
+    }
+
+    ASSERT_EQ(comm->rank, 1);
+    VmmAlloc realImport{};
+    recvAndImportPeerBuffer(comm, /*ownerRank=*/0, ncclMemOffload, kRealTag, &realImport);
+
+    // Inject a synthetic "stale" peer-imported entry that points at an
+    // ownerPtr rank 0 doesn't have. Step 4 will gather rank 0's only
+    // localInfo (matching realImport), the matching loop will then hit our
+    // stale entry, fail to find a match, and WARN+skip it.
+    VmmAlloc stale{};
+    reserveVaOnly(comm->cudaDev, kSize, &stale);
+    void* fakeOwnerPtr = reinterpret_cast<void*>(0xDEADBEEF000ULL);
+    ASSERT_EQ(ncclMemTrackImportFromPeer(
+                  comm->memManager, stale.ptr, stale.size, /*handle=*/0,
+                  hipMemHandleTypePosixFileDescriptor, ncclMemOffload,
+                  /*ownerRank=*/0, /*ownerDev=*/0, fakeOwnerPtr),
+              ncclSuccess);
+
+    // Pretend Suspend already ran for the stale entry so Step 4 considers it
+    // a candidate. realImport will go through the normal Suspend/Resume path.
+    for (auto* e = comm->memManager->entries; e != nullptr; e = e->next) {
+        if (e->ptr == stale.ptr) {
+            e->state = ncclDynMemStateReleased;
+            break;
+        }
+    }
+
+    ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+    ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+
+    int activeCount   = 0;
+    int releasedCount = 0;
+    for (auto* e = comm->memManager->entries; e != nullptr; e = e->next) {
+        if      (e->state == ncclDynMemStateActive)   ++activeCount;
+        else if (e->state == ncclDynMemStateReleased) ++releasedCount;
+    }
+    EXPECT_EQ(activeCount,   1) << "Resume must match-and-restore exactly the real import";
+    EXPECT_EQ(releasedCount, 1) << "Stale entry must remain Released (no-match WARN branch)";
+
+    verifyCanaryReadback(realImport.ptr, realImport.size, kCanary,
+                         "real import survived mixed-match Resume");
+
+    ASSERT_EQ(ncclMemUntrack(comm->memManager, stale.ptr, stale.size), ncclSuccess);
+    releaseVmm(&stale);
+    untrackAndRelease(comm, realImport.ptr, &realImport);
+}
+
+#endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp
+++ b/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp
@@ -498,12 +498,11 @@ TEST_F(MemManagerTwoRank, SuspendResume_LocalOnly)
     releaseVmm(&a);
 }
 
-// Inject a synthetic stale peer-imported entry on rank 1 with an ownerPtr
-// that rank 0 does not own. Resume Step 3 will gather (allCounts == 0, since
-// neither rank has exports), Step 4's matching loop on rank 1 will fail to
-// find a matching ncclDynMemP2pHandleInfo, log a WARN, and skip the entry
-// without crashing. Verifies the negative branch of the matching loop.
-TEST_F(MemManagerTwoRank, Resume_PeerImport_NoMatch_SkipsGracefully)
+// Inject a synthetic peer-imported entry on rank 1 whose ownerPtr has no
+// matching local export on rank 0. Resume Step 4 must surface this as
+// ncclSystemError on rank 1 (RCCL divergence from NCCL upstream silent skip)
+// and leave the entry in Released state. Rank 0 has no entries -> ncclSuccess.
+TEST_F(MemManagerTwoRank, Resume_PeerImport_NoMatch_ReturnsErrorEntryStaysReleased)
 {
     ncclComm_t comm = getActiveCommunicator();
     ASSERT_NE(comm->memManager, nullptr);
@@ -532,16 +531,27 @@ TEST_F(MemManagerTwoRank, Resume_PeerImport_NoMatch_SkipsGracefully)
     // Drive the full Suspend / Resume cycle. We expect:
     //   - Suspend on both ranks succeeds (rank 1's "released" entry is skipped
     //     in Pass 1 since state already == Released; rank 0 has no entries).
-    //   - Resume on both ranks succeeds; rank 1's Step 4 logs a WARN and
-    //     leaves the entry in the Released state.
+    //   - Resume on rank 0 succeeds (no peer-imports to re-map).
+    //   - Resume on rank 1 returns ncclSystemError because the fake entry has
+    //     no matching broadcast info; entry stays Released so caller can clean
+    //     up via Destroy.
     ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
-    ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+    ncclResult_t resumeRet = ncclCommMemResume(comm);
 
-    if (rank == 1) {
+    if (rank == 0) {
+        ASSERT_EQ(resumeRet, ncclSuccess) << "Rank 0 has no entries, Resume must succeed";
+    } else {
+        ASSERT_EQ(resumeRet, ncclSystemError)
+            << "Rank 1 has a no-match peer-import; Resume must surface the error";
+
         ncclDynMemEntry* entry = comm->memManager->entries;
         ASSERT_NE(entry, nullptr);
         EXPECT_EQ(entry->state, ncclDynMemStateReleased)
-            << "Resume must NOT mark a no-match peer entry Active";
+            << "Resume must leave a no-match peer entry in Released state";
+
+        // released flag must remain set so the manager is in a clearly
+        // suspended state and the caller knows to retry or Destroy.
+        EXPECT_EQ(comm->memManager->released, 1);
 
         // Cleanup: drop the fake entry and free the VA reservation.
         ASSERT_EQ(ncclMemUntrack(comm->memManager, fakeImport.ptr, fakeImport.size),

--- a/projects/rccl/test/transport/ShmMPITests.cpp
+++ b/projects/rccl/test/transport/ShmMPITests.cpp
@@ -845,14 +845,16 @@ TEST_F(ShmMPITest, ShmCleanup_DoubleCleanup)
     // First cleanup
     if(connector->transportResources)
     {
-        const auto result1
-            = is_sender ? shmTransport.send.free(connector) : shmTransport.recv.free(connector);
+        const auto result1 = is_sender
+                                 ? shmTransport.send.free(/*comm=*/nullptr, connector)
+                                 : shmTransport.recv.free(/*comm=*/nullptr, connector);
         EXPECT_EQ(ncclSuccess, result1) << "Rank " << config.world_rank << ": First cleanup failed";
     }
 
     // Second cleanup (should handle gracefully since resources are already freed)
-    [[maybe_unused]] const auto result2
-        = is_sender ? shmTransport.send.free(connector) : shmTransport.recv.free(connector);
+    [[maybe_unused]] const auto result2 = is_sender
+                                              ? shmTransport.send.free(/*comm=*/nullptr, connector)
+                                              : shmTransport.recv.free(/*comm=*/nullptr, connector);
 
     // Mark as cleaned up
     connector->transportResources = nullptr;
@@ -969,8 +971,9 @@ TEST_F(ShmMPITest, ShmConnect_CorruptedConnectInfo)
     // Cleanup properly allocated resources
     if(connector->transportResources)
     {
-        const auto cleanup_result
-            = is_sender ? shmTransport.send.free(connector) : shmTransport.recv.free(connector);
+        const auto cleanup_result = is_sender
+                                        ? shmTransport.send.free(/*comm=*/nullptr, connector)
+                                        : shmTransport.recv.free(/*comm=*/nullptr, connector);
         (void)cleanup_result; // Ignore result as we're in error path
         connector->transportResources = nullptr;
     }

--- a/projects/rccl/test/transport/TransportMPIBase.cpp
+++ b/projects/rccl/test/transport/TransportMPIBase.cpp
@@ -139,15 +139,15 @@ void TransportTestBase::TearDown()
     {
         if(initialized_transport == TransportType::P2P)
         {
-            p2pTransport.send.free(&send_connector);
+            p2pTransport.send.free(/*comm=*/nullptr, &send_connector);
         }
         else if(initialized_transport == TransportType::SHM)
         {
-            shmTransport.send.free(&send_connector);
+            shmTransport.send.free(/*comm=*/nullptr, &send_connector);
         }
         else if(initialized_transport == TransportType::Network)
         {
-            netTransport.send.free(&send_connector);
+            netTransport.send.free(/*comm=*/nullptr, &send_connector);
         }
         send_connector.transportResources = nullptr;
     }
@@ -155,15 +155,15 @@ void TransportTestBase::TearDown()
     {
         if(initialized_transport == TransportType::P2P)
         {
-            p2pTransport.recv.free(&recv_connector);
+            p2pTransport.recv.free(/*comm=*/nullptr, &recv_connector);
         }
         else if(initialized_transport == TransportType::SHM)
         {
-            shmTransport.recv.free(&recv_connector);
+            shmTransport.recv.free(/*comm=*/nullptr, &recv_connector);
         }
         else if(initialized_transport == TransportType::Network)
         {
-            netTransport.recv.free(&recv_connector);
+            netTransport.recv.free(/*comm=*/nullptr, &recv_connector);
         }
         recv_connector.transportResources = nullptr;
     }

--- a/projects/rccl/test/transport/TransportMPIBase.hpp
+++ b/projects/rccl/test/transport/TransportMPIBase.hpp
@@ -42,7 +42,7 @@ struct TransportSendResourceDeleter
     {
         if(connector && transport)
         {
-            transport->send.free(connector);
+            transport->send.free(/*comm=*/nullptr, connector);
         }
     }
 };
@@ -55,7 +55,7 @@ struct TransportRecvResourceDeleter
     {
         if(connector && transport)
         {
-            transport->recv.free(connector);
+            transport->recv.free(/*comm=*/nullptr, connector);
         }
     }
 };
@@ -79,11 +79,11 @@ public:
     {
         if(recv_connector_ && transport_)
         {
-            transport_->recv.free(recv_connector_);
+            transport_->recv.free(/*comm=*/nullptr, recv_connector_);
         }
         if(send_connector_ && transport_)
         {
-            transport_->send.free(send_connector_);
+            transport_->send.free(/*comm=*/nullptr, send_connector_);
         }
     }
 

--- a/projects/rccl/tools/topo_expl/src/topo_expl_impl.cpp
+++ b/projects/rccl/tools/topo_expl/src/topo_expl_impl.cpp
@@ -697,12 +697,12 @@ ncclResult_t ncclTransportCollNetFree(struct ncclComm* comm) {
       if (ncclAtomicRefCountDecrement(&peer->refCount) == 0) {
         for (int b=0; b<NCCL_MAX_CONNS; b++) {
           struct ncclConnector* send = peer->send + b;
-          if (send->transportResources && send->transportComm) NCCLCHECK(send->transportComm->free(send));
+          if (send->transportResources && send->transportComm) NCCLCHECK(send->transportComm->free(comm, send));
           send->transportResources = NULL; // avoid double free
         }
         for (int b=0; b<NCCL_MAX_CONNS; b++) {
           struct ncclConnector* recv = peer->recv + b;
-          if (recv->transportResources && recv->transportComm) NCCLCHECK(recv->transportComm->free(recv));
+          if (recv->transportResources && recv->transportComm) NCCLCHECK(recv->transportComm->free(comm, recv));
           recv->transportResources = NULL; // avoid double free
         }
       }


### PR DESCRIPTION
## Motivation

Thread ncclMemManager through ncclCuMemAlloc/Free, ncclCudaCalloc/ Malloc/CallocAsync, ncclCuMemFreeAddr, ncclGdrCudaCalloc/Free so VMM buffers are Tracked at alloc and Untracked at free. Required for ncclCommMemSuspend/Resume.
- transport->free() now takes (ncclComm*, ncclConnector*); all transports updated.
- p2pSend/RecvProxySetup, p2p dummy IPC probe, channel devPeers/ devRingUserRanks and mnnvl FABRIC probe marked ncclMemOffload.
- ~50 call sites in init/channel/transport/register/plugin/mnnvl pass comm->memManager or proxyState->memManager.
- 9 new MemManagerAllocator round-trip tests; all VMM-paths gate on ncclCuMemEnable().

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
