### PR TITLE
[rocprofiler-systems] Add group_by_queue in perfetto_processor

### DIFF
--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -23,6 +23,7 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
 - JSON schema file (`share/rocprofiler-systems/presets/schema.json`) for preset validation.
 - Documentation (`docs/how-to/instrumenting-rewriting-binary-application.rst`) describing what to do when Dyninst reports a "Failed to transform trace" error during instrumentation.
 - Progress bars during trace cache post-processing: perfetto generation (`sequential dispatch`) shows one bar per buffered_storage file in turn; rocpd generation (`multithreaded dispatch`) shows a single aggregate bar accumulating updates from all worker threads.
+- Per-stream Perfetto tracks (`HIP Activity Stream {N}`) for kernel dispatch, scratch memory, and memory copy events in the trace-cache path, matching the buffered tracing behavior. Controlled via `ROCPROFSYS_ROCM_GROUP_BY_QUEUE` (default: `false` — group by HIP stream).
 
 ### Changed
 

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -2012,6 +2012,13 @@ get_use_ompt()
 }
 
 bool
+get_group_by_queue()
+{
+    return config::get_setting_value<bool>("ROCPROFSYS_ROCM_GROUP_BY_QUEUE")
+        .value_or(true);
+}
+
+bool
 get_use_code_coverage()
 {
     static auto _v = get_config()->find("ROCPROFSYS_USE_CODE_COVERAGE");

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -2014,6 +2014,8 @@ get_use_ompt()
 bool
 get_group_by_queue()
 {
+    // When the `hip_stream` domain is unavailable, the setting is not registered
+    // and there is no stream concept to attach to, so fall back to queue grouping.
     return config::get_setting_value<bool>("ROCPROFSYS_ROCM_GROUP_BY_QUEUE")
         .value_or(true);
 }

--- a/projects/rocprofiler-systems/source/lib/core/config.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.hpp
@@ -226,6 +226,9 @@ bool
 get_use_ompt();
 
 bool
+get_group_by_queue();
+
+bool
 get_use_code_coverage();
 
 bool

--- a/projects/rocprofiler-systems/source/lib/core/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/rocprofiler-sdk.cpp
@@ -633,16 +633,6 @@ get_rocm_events()
         " ,;\t\n");
 }
 
-bool
-get_group_by_queue(void)
-{
-    std::optional<bool> _group_by_queue =
-        config::get_setting_value<bool>("ROCPROFSYS_ROCM_GROUP_BY_QUEUE");
-    bool _ret = _group_by_queue.value_or(true);
-
-    return _ret;
-}
-
 std::vector<std::int32_t>
 get_operations(rocprofiler_callback_tracing_kind_t kindv)
 {

--- a/projects/rocprofiler-systems/source/lib/core/rocprofiler-sdk.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/rocprofiler-sdk.hpp
@@ -47,9 +47,6 @@ get_operations(rocprofiler_buffer_tracing_kind_t kindv);
 std::vector<std::string>
 get_rocm_events();
 
-bool
-get_group_by_queue();
-
 std::unordered_set<std::int32_t>
 get_backtrace_operations(rocprofiler_callback_tracing_kind_t kindv);
 

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
@@ -327,6 +327,30 @@ hip_activity_stream_track_desc(std::uint64_t _stream_id_v)
 {
     return fmt::format("HIP Activity Stream {}", _stream_id_v);
 }
+
+template <typename QueueCategory, typename QueueTrackFactory, typename Annotate>
+void
+emit_grouped_event(bool group_by_queue, QueueCategory queue_cat,
+                   QueueTrackFactory&& make_queue_track, std::uint64_t stream_id,
+                   const char* push_name, const char* pop_name, std::uint64_t beg_ts,
+                   std::uint64_t end_ts, std::uint64_t corr_id, const Annotate& annotate)
+{
+    const auto _flow = ::perfetto::Flow::ProcessScoped(corr_id);
+    if(group_by_queue)
+    {
+        const auto _track = std::forward<QueueTrackFactory>(make_queue_track)();
+        tracing::push_perfetto(queue_cat, push_name, _track, beg_ts, _flow, annotate);
+        tracing::pop_perfetto(queue_cat, pop_name, _track, end_ts);
+    }
+    else
+    {
+        const auto _track = tracing::get_perfetto_track(
+            category::rocm_hip_stream{}, hip_activity_stream_track_desc, stream_id);
+        tracing::push_perfetto(category::rocm_hip_stream{}, push_name, _track, beg_ts,
+                               _flow, annotate);
+        tracing::pop_perfetto(category::rocm_hip_stream{}, pop_name, _track, end_ts);
+    }
+}
 }  // namespace
 
 perfetto_processor_t::perfetto_processor_t(
@@ -617,31 +641,13 @@ perfetto_processor_t::handle(const kernel_dispatch_sample& _kds)
                                               _kds.grid_size_y, _kds.grid_size_z) } });
     };
 
-    if(_group_by_queue)
-    {
-        const auto _track =
-            tracing::get_perfetto_track(category::rocm_kernel_dispatch{}, _track_desc,
-                                        _agent_device_id, _queue_id_handle);
-
-        tracing::push_perfetto(category::rocm_kernel_dispatch{}, kernel_name.c_str(),
-                               _track, _beg_ts, ::perfetto::Flow::ProcessScoped(_corr_id),
-                               add_annotations);
-
-        tracing::pop_perfetto(category::rocm_kernel_dispatch{}, kernel_name.c_str(),
-                              _track, _end_ts);
-    }
-    else
-    {
-        const auto _track = tracing::get_perfetto_track(
-            category::rocm_hip_stream{}, hip_activity_stream_track_desc, _stream_handle);
-
-        tracing::push_perfetto(category::rocm_hip_stream{}, kernel_name.c_str(), _track,
-                               _beg_ts, ::perfetto::Flow::ProcessScoped(_corr_id),
-                               add_annotations);
-
-        tracing::pop_perfetto(category::rocm_hip_stream{}, kernel_name.c_str(), _track,
-                              _end_ts);
-    }
+    auto _make_queue_track = [&] {
+        return tracing::get_perfetto_track(category::rocm_kernel_dispatch{}, _track_desc,
+                                           _agent_device_id, _queue_id_handle);
+    };
+    emit_grouped_event(_group_by_queue, category::rocm_kernel_dispatch{},
+                       _make_queue_track, _stream_handle, kernel_name.c_str(),
+                       kernel_name.c_str(), _beg_ts, _end_ts, _corr_id, add_annotations);
 }
 
 void
@@ -702,26 +708,13 @@ perfetto_processor_t::handle(const scratch_memory_sample& _sms)
                                  { "flags", _sms.flags } });
     };
 
-    if(_group_by_queue)
-    {
-        const auto _track = tracing::get_perfetto_track(category::rocm_scratch_memory{},
-                                                        _track_desc_events);
-
-        tracing::push_perfetto(category::rocm_scratch_memory{}, _name.c_str(), _track,
-                               _beg_ts, ::perfetto::Flow::ProcessScoped(_corr_id),
-                               add_perfetto_annotations);
-        tracing::pop_perfetto(category::rocm_scratch_memory{}, "", _track, _end_ts);
-    }
-    else
-    {
-        const auto _track = tracing::get_perfetto_track(
-            category::rocm_hip_stream{}, hip_activity_stream_track_desc, _stream_id);
-
-        tracing::push_perfetto(category::rocm_hip_stream{}, _name.c_str(), _track,
-                               _beg_ts, ::perfetto::Flow::ProcessScoped(_corr_id),
-                               add_perfetto_annotations);
-        tracing::pop_perfetto(category::rocm_hip_stream{}, "", _track, _end_ts);
-    }
+    auto _make_queue_track = [&] {
+        return tracing::get_perfetto_track(category::rocm_scratch_memory{},
+                                           _track_desc_events);
+    };
+    emit_grouped_event(_group_by_queue, category::rocm_scratch_memory{},
+                       _make_queue_track, _stream_id, _name.c_str(), "", _beg_ts, _end_ts,
+                       _corr_id, add_perfetto_annotations);
 }
 
 void
@@ -765,26 +758,13 @@ perfetto_processor_t::handle(const memory_copy_sample& _mcs)
                                  { "dst_address", _mcs.dst_address_value } });
     };
 
-    if(_group_by_queue)
-    {
-        const auto _track = tracing::get_perfetto_track(
-            category::rocm_memory_copy{}, _track_desc, _dst_agent_log_node_id, _thrd_id);
-
-        tracing::push_perfetto(category::rocm_memory_copy{}, _name.c_str(), _track,
-                               _beg_ts, ::perfetto::Flow::ProcessScoped(_corr_id),
-                               add_perfetto_annotations);
-        tracing::pop_perfetto(category::rocm_memory_copy{}, "", _track, _end_ts);
-    }
-    else
-    {
-        const auto _track = tracing::get_perfetto_track(
-            category::rocm_hip_stream{}, hip_activity_stream_track_desc, _stream_id);
-
-        tracing::push_perfetto(category::rocm_hip_stream{}, _name.c_str(), _track,
-                               _beg_ts, ::perfetto::Flow::ProcessScoped(_corr_id),
-                               add_perfetto_annotations);
-        tracing::pop_perfetto(category::rocm_hip_stream{}, "", _track, _end_ts);
-    }
+    auto _make_queue_track = [&] {
+        return tracing::get_perfetto_track(category::rocm_memory_copy{}, _track_desc,
+                                           _dst_agent_log_node_id, _thrd_id);
+    };
+    emit_grouped_event(_group_by_queue, category::rocm_memory_copy{}, _make_queue_track,
+                       _stream_id, _name.c_str(), "", _beg_ts, _end_ts, _corr_id,
+                       add_perfetto_annotations);
 }
 
 void

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
@@ -594,6 +594,19 @@ perfetto_processor_t::finalize_processing()
     }
 }
 
+template <typename CategoryT, typename FuncT, typename... Args>
+::perfetto::Track
+perfetto_processor_t::get_or_create_track(CategoryT, FuncT&& desc_gen, Args&&... args)
+{
+    const auto _uuid = tracing::get_perfetto_category_uuid<CategoryT>(args...);
+    auto       it    = m_track_cache.find(_uuid);
+    if(it != m_track_cache.end()) return it->second;
+    auto _track = tracing::get_perfetto_track(CategoryT{}, std::forward<FuncT>(desc_gen),
+                                              std::forward<Args>(args)...);
+    m_track_cache.emplace(_uuid, _track);
+    return _track;
+}
+
 void
 perfetto_processor_t::handle(const kernel_dispatch_sample& _kds)
 {
@@ -642,8 +655,8 @@ perfetto_processor_t::handle(const kernel_dispatch_sample& _kds)
     };
 
     auto _make_queue_track = [&] {
-        return tracing::get_perfetto_track(category::rocm_kernel_dispatch{}, _track_desc,
-                                           _agent_device_id, _queue_id_handle);
+        return get_or_create_track(category::rocm_kernel_dispatch{}, _track_desc,
+                                   _agent_device_id, _queue_id_handle);
     };
     emit_grouped_event(_group_by_queue, category::rocm_kernel_dispatch{},
                        _make_queue_track, _stream_handle, kernel_name.c_str(),
@@ -709,8 +722,7 @@ perfetto_processor_t::handle(const scratch_memory_sample& _sms)
     };
 
     auto _make_queue_track = [&] {
-        return tracing::get_perfetto_track(category::rocm_scratch_memory{},
-                                           _track_desc_events);
+        return get_or_create_track(category::rocm_scratch_memory{}, _track_desc_events);
     };
     emit_grouped_event(_group_by_queue, category::rocm_scratch_memory{},
                        _make_queue_track, _stream_id, _name.c_str(), "", _beg_ts, _end_ts,
@@ -759,8 +771,8 @@ perfetto_processor_t::handle(const memory_copy_sample& _mcs)
     };
 
     auto _make_queue_track = [&] {
-        return tracing::get_perfetto_track(category::rocm_memory_copy{}, _track_desc,
-                                           _dst_agent_log_node_id, _thrd_id);
+        return get_or_create_track(category::rocm_memory_copy{}, _track_desc,
+                                   _dst_agent_log_node_id, _thrd_id);
     };
     emit_grouped_event(_group_by_queue, category::rocm_memory_copy{}, _make_queue_track,
                        _stream_id, _name.c_str(), "", _beg_ts, _end_ts, _corr_id,

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
@@ -321,6 +321,12 @@ dispatch_in_time_sample(size_t category_enum_id, const in_time_sample& _sample,
         category_enum_id, _sample, use_annotations,
         rocprofsys::utility::make_index_sequence_range<1, ROCPROFSYS_CATEGORY_LAST>{});
 }
+
+inline std::string
+hip_activity_stream_track_desc(std::uint64_t _stream_id_v)
+{
+    return fmt::format("HIP Activity Stream {}", _stream_id_v);
+}
 }  // namespace
 
 perfetto_processor_t::perfetto_processor_t(
@@ -335,6 +341,7 @@ perfetto_processor_t::perfetto_processor_t(
 , m_tmp_file(nullptr)
 , m_tracing_session(nullptr)
 , m_use_annotations(config::get_perfetto_annotations())
+, m_default_group_by_queue(config::get_group_by_queue())
 , m_output_registry(output_registry)
 {}
 
@@ -587,9 +594,8 @@ perfetto_processor_t::handle(const kernel_dispatch_sample& _kds)
 
     auto kernel_name = rocprofsys::utility::demangle(kernel_symbol->kernel_name);
 
-    const auto _track =
-        tracing::get_perfetto_track(category::rocm_kernel_dispatch{}, _track_desc,
-                                    _agent_device_id, _queue_id_handle);
+    // Force queue grouping when sample is not associated with a HIP stream
+    const bool _group_by_queue = m_default_group_by_queue || _stream_handle == 0;
 
     auto add_annotations = [&](::perfetto::EventContext ctx) {
         if(!m_use_annotations) return;
@@ -611,12 +617,31 @@ perfetto_processor_t::handle(const kernel_dispatch_sample& _kds)
                                               _kds.grid_size_y, _kds.grid_size_z) } });
     };
 
-    tracing::push_perfetto(category::rocm_kernel_dispatch{}, kernel_name.c_str(), _track,
-                           _beg_ts, ::perfetto::Flow::ProcessScoped(_corr_id),
-                           add_annotations);
+    if(_group_by_queue)
+    {
+        const auto _track =
+            tracing::get_perfetto_track(category::rocm_kernel_dispatch{}, _track_desc,
+                                        _agent_device_id, _queue_id_handle);
 
-    tracing::pop_perfetto(category::rocm_kernel_dispatch{}, kernel_name.c_str(), _track,
-                          _end_ts);
+        tracing::push_perfetto(category::rocm_kernel_dispatch{}, kernel_name.c_str(),
+                               _track, _beg_ts, ::perfetto::Flow::ProcessScoped(_corr_id),
+                               add_annotations);
+
+        tracing::pop_perfetto(category::rocm_kernel_dispatch{}, kernel_name.c_str(),
+                              _track, _end_ts);
+    }
+    else
+    {
+        const auto _track = tracing::get_perfetto_track(
+            category::rocm_hip_stream{}, hip_activity_stream_track_desc, _stream_handle);
+
+        tracing::push_perfetto(category::rocm_hip_stream{}, kernel_name.c_str(), _track,
+                               _beg_ts, ::perfetto::Flow::ProcessScoped(_corr_id),
+                               add_annotations);
+
+        tracing::pop_perfetto(category::rocm_hip_stream{}, kernel_name.c_str(), _track,
+                              _end_ts);
+    }
 }
 
 void
@@ -660,8 +685,8 @@ perfetto_processor_t::handle(const scratch_memory_sample& _sms)
         return fmt::format("GPU Scratch Memory Events Thread {}", _thread_id_sequent);
     };
 
-    const auto _track =
-        tracing::get_perfetto_track(category::rocm_scratch_memory{}, _track_desc_events);
+    // Force queue grouping when sample is not associated with a HIP stream
+    const bool _group_by_queue = m_default_group_by_queue || _stream_id == 0;
 
     auto add_perfetto_annotations = [&](::perfetto::EventContext ctx) {
         if(!m_use_annotations) return;
@@ -677,10 +702,26 @@ perfetto_processor_t::handle(const scratch_memory_sample& _sms)
                                  { "flags", _sms.flags } });
     };
 
-    tracing::push_perfetto(category::rocm_scratch_memory{}, _name.c_str(), _track,
-                           _beg_ts, ::perfetto::Flow::ProcessScoped(_corr_id),
-                           add_perfetto_annotations);
-    tracing::pop_perfetto(category::rocm_scratch_memory{}, "", _track, _end_ts);
+    if(_group_by_queue)
+    {
+        const auto _track = tracing::get_perfetto_track(category::rocm_scratch_memory{},
+                                                        _track_desc_events);
+
+        tracing::push_perfetto(category::rocm_scratch_memory{}, _name.c_str(), _track,
+                               _beg_ts, ::perfetto::Flow::ProcessScoped(_corr_id),
+                               add_perfetto_annotations);
+        tracing::pop_perfetto(category::rocm_scratch_memory{}, "", _track, _end_ts);
+    }
+    else
+    {
+        const auto _track = tracing::get_perfetto_track(
+            category::rocm_hip_stream{}, hip_activity_stream_track_desc, _stream_id);
+
+        tracing::push_perfetto(category::rocm_hip_stream{}, _name.c_str(), _track,
+                               _beg_ts, ::perfetto::Flow::ProcessScoped(_corr_id),
+                               add_perfetto_annotations);
+        tracing::pop_perfetto(category::rocm_hip_stream{}, "", _track, _end_ts);
+    }
 }
 
 void
@@ -706,8 +747,8 @@ perfetto_processor_t::handle(const memory_copy_sample& _mcs)
                            _tid_v->index_data->sequent_value);
     };
 
-    const auto _track = tracing::get_perfetto_track(
-        category::rocm_memory_copy{}, _track_desc, _dst_agent_log_node_id, _thrd_id);
+    // Force queue grouping when sample is not associated with a HIP stream
+    const bool _group_by_queue = m_default_group_by_queue || _stream_id == 0;
 
     auto add_perfetto_annotations = [&](::perfetto::EventContext ctx) {
         if(!m_use_annotations) return;
@@ -724,10 +765,26 @@ perfetto_processor_t::handle(const memory_copy_sample& _mcs)
                                  { "dst_address", _mcs.dst_address_value } });
     };
 
-    tracing::push_perfetto(category::rocm_memory_copy{}, _name.c_str(), _track, _beg_ts,
-                           ::perfetto::Flow::ProcessScoped(_corr_id),
-                           add_perfetto_annotations);
-    tracing::pop_perfetto(category::rocm_memory_copy{}, "", _track, _end_ts);
+    if(_group_by_queue)
+    {
+        const auto _track = tracing::get_perfetto_track(
+            category::rocm_memory_copy{}, _track_desc, _dst_agent_log_node_id, _thrd_id);
+
+        tracing::push_perfetto(category::rocm_memory_copy{}, _name.c_str(), _track,
+                               _beg_ts, ::perfetto::Flow::ProcessScoped(_corr_id),
+                               add_perfetto_annotations);
+        tracing::pop_perfetto(category::rocm_memory_copy{}, "", _track, _end_ts);
+    }
+    else
+    {
+        const auto _track = tracing::get_perfetto_track(
+            category::rocm_hip_stream{}, hip_activity_stream_track_desc, _stream_id);
+
+        tracing::push_perfetto(category::rocm_hip_stream{}, _name.c_str(), _track,
+                               _beg_ts, ::perfetto::Flow::ProcessScoped(_corr_id),
+                               add_perfetto_annotations);
+        tracing::pop_perfetto(category::rocm_hip_stream{}, "", _track, _end_ts);
+    }
 }
 
 void

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.hpp
@@ -13,6 +13,7 @@
 #include <functional>
 #include <memory>
 #include <perfetto.h>
+#include <unordered_map>
 
 namespace rocprofsys
 {
@@ -59,6 +60,12 @@ private:
     void       flush(bool& perfetto_output_error);
     char_vec_t get_session_data();
 
+    // Returns a cached ::perfetto::Track for the given (category, args...) key,
+    // calling get_perfetto_track only on the first encounter to avoid the global
+    // mutex on every event in high-frequency handle() paths.
+    template <typename CategoryT, typename FuncT, typename... Args>
+    ::perfetto::Track get_or_create_track(CategoryT, FuncT&& desc_gen, Args&&... args);
+
     metadata_registry&                          m_metadata;
     std::uint64_t                               m_process_id;
     std::uint64_t                               m_parrent_pid;
@@ -69,8 +76,9 @@ private:
     bool                                        m_use_annotations{ false };
     bool                                        m_default_group_by_queue{ true };
 
-    std::unordered_map<size_t, pmc_track_info> m_pmc_track_map;
-    output_file_registry&                      m_output_registry;
+    std::unordered_map<size_t, pmc_track_info>           m_pmc_track_map;
+    std::unordered_map<std::uint64_t, ::perfetto::Track> m_track_cache;
+    output_file_registry&                                m_output_registry;
 };
 }  // namespace trace_cache
 }  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.hpp
@@ -67,6 +67,7 @@ private:
     std::shared_ptr<tmp_file>                   m_tmp_file{ nullptr };
     std::unique_ptr<::perfetto::TracingSession> m_tracing_session{ nullptr };
     bool                                        m_use_annotations{ false };
+    bool                                        m_default_group_by_queue{ true };
 
     std::unordered_map<size_t, pmc_track_info> m_pmc_track_map;
     output_file_registry&                      m_output_registry;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -1694,7 +1694,7 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
         return fmt::format("HIP Activity Stream {}", _stream_id);
     };
 
-    const bool _default_group_by_queue = get_group_by_queue();
+    const bool _default_group_by_queue = config::get_group_by_queue();
 
     static auto _mtx = std::mutex{};
     auto        _lk  = std::unique_lock<std::mutex>{ _mtx };

--- a/projects/rocprofiler-systems/tests/pytest/test_hpc.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_hpc.py
@@ -273,6 +273,7 @@ class TestSplitCopyComputeHWQueues(RocprofsysTest):
         env = hpc_hip_environment.copy()
         env["ROCPROFSYS_ROCM_DOMAINS"] = "hip_api,hsa_api,kernel_dispatch,memory_copy"
         env["ROCPROFSYS_COUT_OUTPUT"] = "OFF"
+        env["ROCPROFSYS_ROCM_GROUP_BY_QUEUE"] = "ON"
 
         result = self.run_test(
             mode,
@@ -283,11 +284,11 @@ class TestSplitCopyComputeHWQueues(RocprofsysTest):
         )
         self.assert_regex(result)
 
-        # We expect to see "nstreams" HIP Stream tracks, each with a cube kernel
+        # We expect to see "nstreams" amount of GPU Kernel Dispatch tracks, each with a cube kernel
         self.assert_perfetto(
             result,
             subtest_name="Stream Count Validation",
-            categories=["rocm_hip_stream"],
+            categories=["rocm_kernel_dispatch"],
             label_substrings=["cube"],
             counts=[self.nstreams],
             depths=[0],

--- a/projects/rocprofiler-systems/tests/pytest/test_hpc.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_hpc.py
@@ -283,11 +283,11 @@ class TestSplitCopyComputeHWQueues(RocprofsysTest):
         )
         self.assert_regex(result)
 
-        # We expect to see "nstreams" amount of GPU Kernel Dispatch tracks, each with a cube kernel
+        # We expect to see "nstreams" HIP Stream tracks, each with a cube kernel
         self.assert_perfetto(
             result,
             subtest_name="Stream Count Validation",
-            categories=["rocm_kernel_dispatch"],
+            categories=["rocm_hip_stream"],
             label_substrings=["cube"],
             counts=[self.nstreams],
             depths=[0],

--- a/projects/rocprofiler-systems/tests/pytest/test_selective_regions.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_selective_regions.py
@@ -129,7 +129,7 @@ class TestSelectiveRegion(RocprofsysTest):
         self.assert_perfetto(
             result,
             subtest_name="All kernels present",
-            categories=["rocm_kernel_dispatch"],
+            categories=["rocm_hip_stream"],
             pass_regex=[
                 "CodeBlock_A",
                 "CodeBlock_B",
@@ -166,7 +166,7 @@ class TestSelectiveRegion(RocprofsysTest):
         self.assert_perfetto(
             result,
             subtest_name="Region1 filtered kernels",
-            categories=["rocm_kernel_dispatch"],
+            categories=["rocm_hip_stream"],
             pass_regex=["CodeBlock_B", "CodeBlock_C", "CodeBlock_D", "CodeBlock_F"],
             fail_regex=["CodeBlock_A", "CodeBlock_E", "CodeBlock_G"],
         )
@@ -197,7 +197,7 @@ class TestSelectiveRegion(RocprofsysTest):
         self.assert_perfetto(
             result,
             subtest_name="Region2+3 filtered kernels",
-            categories=["rocm_kernel_dispatch"],
+            categories=["rocm_hip_stream"],
             pass_regex=["CodeBlock_C", "CodeBlock_E"],
             fail_regex=[
                 "CodeBlock_A",
@@ -394,7 +394,7 @@ class TestSelectiveRegionNoMarker(RocprofsysTest):
         self.assert_perfetto(
             result,
             subtest_name="Region1 filtered kernels (no marker_api)",
-            categories=["rocm_kernel_dispatch"],
+            categories=["rocm_hip_stream"],
             pass_regex=["CodeBlock_B", "CodeBlock_C", "CodeBlock_D", "CodeBlock_F"],
             fail_regex=["CodeBlock_A", "CodeBlock_E", "CodeBlock_G"],
         )


### PR DESCRIPTION
## Motivation

Trace cache `perfetto_processor` was missing the HIP Stream Activity feature (`group_by_queue`) that is present in the legacy `library/rocprofiler-sdk.cpp` buffered tracing path. Without it, kernel dispatch / scratch memory / memory copy events captured via the trace cache always fell back to the per-queue tracks, so users could not get per-stream Perfetto tracks (`HIP Activity Stream {N}`) when running with `ROCPROFSYS_ROCM_GROUP_BY_QUEUE=true`.

## Technical Details

- Added group-by-queue branching to three trace-cache handlers in `perfetto_processor.cpp`:
  - `handle(kernel_dispatch_sample)`
  - `handle(scratch_memory_sample)`
  - `handle(memory_copy_sample)`
- Each handler now resolves the grouping mode with:
  ```cpp
  const bool _group_by_queue = m_default_group_by_queue || _stream_id == 0;
  ```
  matching the semantics in `library/rocprofiler-sdk.cpp` (force queue grouping when the sample is not associated with a HIP stream).
- When `_group_by_queue` is true, the handler emits the slice on the existing per-queue track. When false, the handler emits the slice on a `category::rocm_hip_stream` track named `"HIP Activity Stream {N}"`. The branching logic is shared via a single anonymous-namespace helper `emit_grouped_event(...)` across all three handlers; the hip-stream track descriptor is provided by `hip_activity_stream_track_desc(std::uint64_t)`.
- Cached `m_default_group_by_queue` once in the `perfetto_processor_t` constructor to avoid a per-sample config lookup.
- Refactor: moved `get_group_by_queue()` from `rocprofsys::rocprofiler_sdk` (`core/rocprofiler-sdk.{hpp,cpp}`) to `rocprofsys::config` (`core/config.{hpp,cpp}`). The body only depends on `config::get_setting_value<bool>("ROCPROFSYS_ROCM_GROUP_BY_QUEUE")`, so it belongs with the other config getters. Updated callers in `library/rocprofiler-sdk.cpp` and `perfetto_processor.cpp`; the latter no longer needs to include `core/rocprofiler-sdk.hpp`.

## JIRA ID

AIPROFSYST-442

## Test Plan

- Whole-project build.
- Run a workload with multiple non-default HIP streams (e.g. `examples/transpose/transpose.cpp`, default `nthreads=2` -> 2 streams) under both modes:
  - `ROCPROFSYS_ROCM_GROUP_BY_QUEUE=false` (default) — expect one `HIP Activity Stream {N}` track per non-zero stream id, and default-stream work still falls back to the queue track.
  - `ROCPROFSYS_ROCM_GROUP_BY_QUEUE=true` — expect existing `GPU Kernel Dispatch [N] Queue M` tracks only.
- Inspect generated Perfetto trace and confirm slices for kernel dispatch, scratch memory and memory copy events appear on the expected tracks.

## Test Result

- Build: success.
- Functional verification on Perfetto trace pending hardware run.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.