### PR TITLE
[hipFile/CI] Add a new workflow for building & installing hipFile Python bindings

### DIFF
--- a/.github/workflows/hipfile-ci.yml
+++ b/.github/workflows/hipfile-ci.yml
@@ -95,6 +95,19 @@ jobs:
       platform: ${{ inputs.platform }}
       rocm_version: ${{ inputs.rocm_version }}
 
+  python_bindings:
+    # cancelled() needed. Otherwise success() implicitly added and fails if the chained
+    # dependency build_AIS_CI_image is skipped.
+    if: ${{ !cancelled() && needs.build_and_test.result == 'success' }}
+    needs: [build_and_test]
+    uses: ./.github/workflows/hipfile-python-bindings.yml
+    with:
+      ais_hipfile_pkg_dev_filename: ${{ needs.build_and_test.outputs.ais_hipfile_pkg_dev_filename }}
+      ais_hipfile_pkg_filename: ${{ needs.build_and_test.outputs.ais_hipfile_pkg_filename }}
+      ci_image: ${{ needs.build_and_test.outputs.ci_image }}
+      platform: ${{ inputs.platform }}
+      rocm_version: ${{ inputs.rocm_version }}
+
   AIS_system_tests:
     # cancelled() needed. Otherwise success() implicitly added and fails if the chained
     # dependency build_AIS_CI_image is skipped.

--- a/.github/workflows/hipfile-python-bindings.yml
+++ b/.github/workflows/hipfile-python-bindings.yml
@@ -10,7 +10,7 @@ env:
   AIS_INPUT_ROCM_VERSION: ${{ inputs.rocm_version }}
   AIS_PKG_MGR: >-
     ${{
-      inputs.platform == 'rocky' && 'dnf' ||
+      startsWith(inputs.platform, 'rocky') && 'dnf' ||
       inputs.platform == 'suse' && 'zypper' ||
       inputs.platform == 'ubuntu' && 'apt'
     }}

--- a/.github/workflows/hipfile-python-bindings.yml
+++ b/.github/workflows/hipfile-python-bindings.yml
@@ -1,0 +1,211 @@
+name: hipfile-python-bindings
+run-name: Build and install hipFile Python bindings
+
+env:
+  AIS_GHA_CMD_FILES_DOCKER_DIR: /root/github
+  AIS_INPUT_CI_IMAGE: ${{ inputs.ci_image }}
+  AIS_INPUT_HIPFILE_PKG_DEV_FILENAME: ${{ inputs.ais_hipfile_pkg_dev_filename }}
+  AIS_INPUT_HIPFILE_PKG_FILENAME: ${{ inputs.ais_hipfile_pkg_filename }}
+  AIS_INPUT_PLATFORM: ${{ inputs.platform }}
+  AIS_INPUT_ROCM_VERSION: ${{ inputs.rocm_version }}
+  AIS_PKG_MGR: >-
+    ${{
+      inputs.platform == 'rocky' && 'dnf' ||
+      inputs.platform == 'suse' && 'zypper' ||
+      inputs.platform == 'ubuntu' && 'apt'
+    }}
+
+on:
+  workflow_call:
+    inputs:
+      ais_hipfile_pkg_dev_filename:
+        required: true
+        type: string
+      ais_hipfile_pkg_filename:
+        required: true
+        type: string
+      ci_image:
+        required: true
+        type: string
+      platform:
+        required: true
+        type: string
+      rocm_version:
+        description: "Target ROCm MAJOR.MINOR.PATCH Version"
+        required: true
+        type: string
+    outputs:
+      hipfile_python_sdist_filename:
+        description: "Filename of the hipFile Python sdist artifact"
+        value: ${{ jobs.build_python_bindings.outputs.hipfile_python_sdist_filename }}
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build_python_bindings:
+    runs-on: [ubuntu-24.04]
+    outputs:
+      hipfile_python_sdist_filename: ${{ steps.sdist-metadata.outputs.HIPFILE_PYTHON_SDIST_FILENAME }}
+    steps:
+      - name: Set early AIS CI environment variables
+        run: |
+          echo "AIS_PR_NUMBER=$(echo "${GITHUB_REF}" | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
+          echo "AIS_GHA_CMD_FILES_DIR=${GITHUB_ENV%/*}" >> "${GITHUB_ENV}"
+      - name: Set AIS CI container name
+        run: |
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER:=${GITHUB_RUN_ID}}_${GITHUB_JOB}_${AIS_INPUT_PLATFORM}_${AIS_INPUT_ROCM_VERSION}" >> "${GITHUB_ENV}"
+      - name: Fetching code repository...
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          path: rocm-systems
+          sparse-checkout: |
+            projects/hipfile
+            .github/workflows
+      - name: Download hipFile runtime package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.ais_hipfile_pkg_filename }}
+      - name: Download hipFile development package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.ais_hipfile_pkg_dev_filename }}
+      - name: Authenticating to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Starting Docker Container
+        run: |
+          docker run \
+            -dt \
+            --rm \
+            --pull always \
+            -v ${GITHUB_WORKSPACE}:/mnt/ais:ro \
+            -v "${AIS_GHA_CMD_FILES_DIR}:${AIS_GHA_CMD_FILES_DOCKER_DIR}" \
+            --name "${AIS_CONTAINER_NAME}" \
+            "${AIS_INPUT_CI_IMAGE}"
+      - name: Make copy of the code repository
+        run: |
+          docker exec \
+            -t \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              cp -R /mnt/ais /ais
+            '
+      - name: Copy the hipFile packages into the container
+        run: |
+          docker cp \
+            "${GITHUB_WORKSPACE}/${AIS_INPUT_HIPFILE_PKG_FILENAME}" \
+            "${AIS_CONTAINER_NAME}:/root"
+          docker cp \
+            "${GITHUB_WORKSPACE}/${AIS_INPUT_HIPFILE_PKG_DEV_FILENAME}" \
+            "${AIS_CONTAINER_NAME}:/root"
+      - name: Install the hipFile packages
+        run: |
+          docker exec \
+            -t \
+            -w /root \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              ${{
+                format(
+                  env.AIS_PKG_MGR == 'apt' && 'apt install -y "./{0}" "./{1}"' ||
+                    env.AIS_PKG_MGR == 'dnf' && 'dnf install -y --cacheonly "./{0}" "./{1}"' ||
+                    env.AIS_PKG_MGR == 'zypper' && 'zypper --no-refresh install -y --allow-unsigned-rpm "./{0}" "./{1}"' ||
+                    'echo "Unknown platform."; exit 1',
+                  inputs.ais_hipfile_pkg_filename,
+                  inputs.ais_hipfile_pkg_dev_filename
+                )
+              }}
+            '
+      - name: Install Python and development headers
+        run: |
+          docker exec \
+            -t \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              ${{
+                inputs.platform == 'ubuntu' &&
+                  'apt update && apt install -y python3-venv python3-dev' ||
+                inputs.platform == 'rocky' &&
+                  'dnf install -y python3.12-devel' ||
+                inputs.platform == 'suse' &&
+                  'zypper --non-interactive install python312-devel'
+              }}
+            '
+      - name: Create Python virtual environment and install build dependencies
+        run: |
+          docker exec \
+            -t \
+            -w /ais/rocm-systems/projects/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              python3.12 -m venv .venv
+              .venv/bin/pip install --upgrade pip
+              .venv/bin/pip install build
+            '
+      - name: Build hipFile Python sdist
+        run: |
+          docker exec \
+            -t \
+            -w /ais/rocm-systems/projects/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              .venv/bin/python -m build --sdist ./python
+            '
+      - name: Install hipFile Python sdist into virtual environment
+        run: |
+          docker exec \
+            -t \
+            -w /ais/rocm-systems/projects/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              .venv/bin/pip install ./python/dist/hipfile-*.tar.gz
+            '
+      - name: Verify hipFile Python package installation
+        run: |
+          docker exec \
+            -t \
+            -w /ais/rocm-systems/projects/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              .venv/bin/python -c "import hipfile; print(f\"hipfile {hipfile.__version__} installed successfully\")"
+            '
+      - name: Capture sdist metadata
+        id: sdist-metadata
+        run: |
+          docker exec \
+            -e "AIS_GITHUB_OUTPUT=${{ env.AIS_GHA_CMD_FILES_DOCKER_DIR }}/${GITHUB_OUTPUT##*/}" \
+            -t \
+            -w /ais/rocm-systems/projects/hipfile/python/dist \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              shopt -s nullglob
+              HIPFILE_PYTHON_SDIST_FILENAME="$(echo hipfile-*.tar.gz)"
+              echo "HIPFILE_PYTHON_SDIST_FILENAME=${HIPFILE_PYTHON_SDIST_FILENAME}" >> "${AIS_GITHUB_OUTPUT}"
+            '
+      - name: Copy sdist out of the container
+        run: |
+          docker cp \
+            "${AIS_CONTAINER_NAME}:/ais/rocm-systems/projects/hipfile/python/dist/${{ steps.sdist-metadata.outputs.HIPFILE_PYTHON_SDIST_FILENAME }}" \
+            ${GITHUB_WORKSPACE}
+      - name: Upload hipFile Python sdist as an artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.sdist-metadata.outputs.HIPFILE_PYTHON_SDIST_FILENAME }}
+          path: ${{ format('{0}/{1}', github.workspace, steps.sdist-metadata.outputs.HIPFILE_PYTHON_SDIST_FILENAME) }}
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+      - name: Cleanup & Stop the Docker container
+        if: ${{ always() }}
+        run: |
+          if docker inspect "${AIS_CONTAINER_NAME}" >/dev/null 2>&1; then
+            docker stop "${AIS_CONTAINER_NAME}"
+          else
+            echo "Container ${AIS_CONTAINER_NAME} does not exist; skipping stop"
+          fi

--- a/.github/workflows/hipfile-python-bindings.yml
+++ b/.github/workflows/hipfile-python-bindings.yml
@@ -121,6 +121,7 @@ jobs:
                   inputs.ais_hipfile_pkg_dev_filename
                 )
               }}
+              ldconfig
             '
       - name: Create Python virtual environment and install build dependencies
         run: |

--- a/.github/workflows/hipfile-python-bindings.yml
+++ b/.github/workflows/hipfile-python-bindings.yml
@@ -122,21 +122,6 @@ jobs:
                 )
               }}
             '
-      - name: Install Python and development headers
-        run: |
-          docker exec \
-            -t \
-            "${AIS_CONTAINER_NAME}" \
-            /bin/bash -c '
-              ${{
-                inputs.platform == 'ubuntu' &&
-                  'apt update && apt install -y python3-venv python3-dev' ||
-                inputs.platform == 'rocky' &&
-                  'dnf install -y python3.12-devel' ||
-                inputs.platform == 'suse' &&
-                  'zypper --non-interactive install python312-devel'
-              }}
-            '
       - name: Create Python virtual environment and install build dependencies
         run: |
           docker exec \

--- a/.github/workflows/hipfile-python-bindings.yml
+++ b/.github/workflows/hipfile-python-bindings.yml
@@ -134,14 +134,22 @@ jobs:
               .venv/bin/pip install --upgrade pip
               .venv/bin/pip install build
             '
-      - name: Build hipFile Python sdist
+      - name: Build hipFile Python sdist & capture metadata
+        id: sdist-metadata
         run: |
           docker exec \
+            -e "AIS_GITHUB_OUTPUT=${{ env.AIS_GHA_CMD_FILES_DOCKER_DIR }}/${GITHUB_OUTPUT##*/}" \
+            -e "_AIS_INPUT_PLATFORM=${AIS_INPUT_PLATFORM}" \
             -t \
             -w /ais/rocm-systems/projects/hipfile \
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               .venv/bin/python -m build --sdist ./python
+              shopt -s nullglob
+              OLD_FILENAME="$(basename ./python/dist/hipfile-*.tar.gz)"
+              NEW_FILENAME="${OLD_FILENAME%.tar.gz}-${_AIS_INPUT_PLATFORM}.tar.gz"
+              mv ./python/dist/${OLD_FILENAME} ./python/dist/${NEW_FILENAME}
+              echo "HIPFILE_PYTHON_SDIST_FILENAME=${NEW_FILENAME}" >> "${AIS_GITHUB_OUTPUT}"
             '
       - name: Install hipFile Python sdist into virtual environment
         run: |
@@ -150,7 +158,7 @@ jobs:
             -w /ais/rocm-systems/projects/hipfile \
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
-              .venv/bin/pip install ./python/dist/hipfile-*.tar.gz
+              .venv/bin/pip install ./python/dist/${{ steps.sdist-metadata.outputs.HIPFILE_PYTHON_SDIST_FILENAME }}
             '
       - name: Verify hipFile Python package installation
         run: |
@@ -160,19 +168,6 @@ jobs:
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               .venv/bin/python -c "import hipfile; print(f\"hipfile {hipfile.__version__} installed successfully\")"
-            '
-      - name: Capture sdist metadata
-        id: sdist-metadata
-        run: |
-          docker exec \
-            -e "AIS_GITHUB_OUTPUT=${{ env.AIS_GHA_CMD_FILES_DOCKER_DIR }}/${GITHUB_OUTPUT##*/}" \
-            -t \
-            -w /ais/rocm-systems/projects/hipfile/python/dist \
-            "${AIS_CONTAINER_NAME}" \
-            /bin/bash -c '
-              shopt -s nullglob
-              HIPFILE_PYTHON_SDIST_FILENAME="$(echo hipfile-*.tar.gz)"
-              echo "HIPFILE_PYTHON_SDIST_FILENAME=${HIPFILE_PYTHON_SDIST_FILENAME}" >> "${AIS_GITHUB_OUTPUT}"
             '
       - name: Copy sdist out of the container
         run: |

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky
@@ -71,6 +71,7 @@ RUN dnf makecache && \
         hip-devel \
         libmount-devel \
         llvm-devel \
+        python3.12-devel \
         rpm-build
 
 # Configure system linker for ROCm

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky8
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky8
@@ -71,6 +71,7 @@ RUN dnf makecache && \
         hip-devel \
         libmount-devel \
         llvm-devel \
+        python3.12-devel \
         rpm-build
 
 # Configure system linker for ROCm

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_suse
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_suse
@@ -68,6 +68,7 @@ RUN zypper install -y \
         hip-devel \
         libmount-devel \
         llvm19-devel \
+        python312-devel \
         rocm-device-libs \
         rpm-build
 

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
@@ -51,6 +51,8 @@ RUN apt update && \
         libboost-program-options-dev \
         libmount-dev \
         llvm-dev \
+        python3.12-dev \
+        python3.12-venv \
         rocm-llvm-dev
 
 # Configure system linker for ROCm


### PR DESCRIPTION
## Motivation

There is currently no CI coverage for building the hipFile Python bindings. This PR adds a CI stage that builds an sdist, installs it, and verifies the package imports successfully. This also installs Python3.12 across the 3 distros our CI runs on to have a consistent Python version as the CI is not yet sophisticated enough to test across multiple Python versions.

We currently have no tests for the Python bindings, and we currently only build and test in an sdist format.

We could consider publishing binary wheels in an expanded CI environment; however this requires further thought/discussion.

## Technical Details

- New reusable workflow `.github/workflows/hipfile-python-bindings.yml`:
  - Runs inside the existing CI Docker container after the C++ build
  - Downloads and installs the hipFile dev+runtime packages so headers and libs are at `/opt/rocm/`
  - Installs Python and creates a venv for isolation
  - Builds an sdist via `python -m build --sdist`
  - Installs the sdist into the venv and verifies `import hipfile` succeeds
  - Uploads the sdist as a GitHub Actions artifact
- Modified `.github/workflows/hipfile-ci.yml`:
  - Added `python_bindings` job depending on `build_and_test`, running in parallel with `AIS_system_tests`

## JIRA ID

AIHIPFILE-166

## Test Plan

- CI pipeline runs the new `python_bindings` stage for all 3 platforms (ubuntu, rocky, suse)
- Verify the sdist builds, installs, and `import hipfile` passes
- Verify the sdist artifact is uploaded

## Test Result

Pending CI run on this PR.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.