### PR TITLE
[hipfile] Fix isValidBufferRegion check.

### DIFF
--- a/projects/hipfile/src/amd_detail/buffer.cpp
+++ b/projects/hipfile/src/amd_detail/buffer.cpp
@@ -11,7 +11,6 @@
 
 #include <cstdint>
 #include <hip/hip_runtime_api.h>
-#include <limits>
 #include <stdexcept>
 #include <syslog.h>
 #include <utility>
@@ -29,17 +28,16 @@ isValidBufferRegion(void *ptr, size_t length)
         HipMemAddressRange buffer_range = Context<Hip>::get()->hipMemGetAddressRange(ptr);
         uintptr_t          base         = reinterpret_cast<uintptr_t>(buffer_range.base);
 
-        // Overflow check
-        // Do this before the addition, so the sanitizers don't complain
-        // about integer overflow
-        if (length > std::numeric_limits<uintptr_t>::max() - uptr) {
+        if (uptr < base) {
             return false;
         }
 
-        // Don't need to check base + buffer_range.size since
-        // HIP shouldn't give us invalid values
+        uintptr_t offset = uptr - base;
+        if (offset >= buffer_range.size) {
+            return false;
+        }
 
-        if (uptr + length > base + buffer_range.size) {
+        if (length > buffer_range.size - offset) {
             return false;
         }
     }

--- a/projects/hipfile/test/amd_detail/buffer.cpp
+++ b/projects/hipfile/test/amd_detail/buffer.cpp
@@ -18,6 +18,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <hip/hip_runtime_api.h>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 
@@ -136,6 +137,43 @@ TEST_F(HipFileBuffer, registerOversizeRangeReturnsError)
     EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Return(attrs));
     ASSERT_EQ(hipFileBufRegister(reinterpret_cast<void *>(0x1), 101, 0),
               HipFileOpError(hipFileHipPointerRangeError));
+}
+
+TEST_F(HipFileBuffer, registerRangeEndingAtUintptrMaxSucceeds)
+{
+    StrictMock<MHip>   mhip;
+    const uintptr_t    base_addr = std::numeric_limits<uintptr_t>::max() - 99;
+    void              *buffer    = reinterpret_cast<void *>(base_addr);
+    HipMemAddressRange range{buffer, 100};
+    EXPECT_CALL(mhip, hipMemGetAddressRange).WillOnce(testing::Return(range));
+    hipPointerAttribute_t attrs{};
+    attrs.type = hipMemoryTypeDevice;
+    EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Return(attrs));
+    ASSERT_EQ(hipFileBufRegister(buffer, 100, 0), HIPFILE_SUCCESS);
+}
+
+TEST_F(HipFileBuffer, registerPointerBeforeAddressRangeBaseReturnsError)
+{
+    StrictMock<MHip>   mhip;
+    void              *buffer = reinterpret_cast<void *>(0x1FFF);
+    HipMemAddressRange range{reinterpret_cast<void *>(0x2000), 0x100};
+    EXPECT_CALL(mhip, hipMemGetAddressRange).WillOnce(testing::Return(range));
+    hipPointerAttribute_t attrs{};
+    attrs.type = hipMemoryTypeDevice;
+    EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Return(attrs));
+    ASSERT_EQ(hipFileBufRegister(buffer, 1, 0), HipFileOpError(hipFileHipPointerRangeError));
+}
+
+TEST_F(HipFileBuffer, registerPointerAtOffsetPastEndReturnsError)
+{
+    StrictMock<MHip>   mhip;
+    void              *buffer = reinterpret_cast<void *>(0x2100);
+    HipMemAddressRange range{reinterpret_cast<void *>(0x2000), 0x100};
+    EXPECT_CALL(mhip, hipMemGetAddressRange).WillOnce(testing::Return(range));
+    hipPointerAttribute_t attrs{};
+    attrs.type = hipMemoryTypeDevice;
+    EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Return(attrs));
+    ASSERT_EQ(hipFileBufRegister(buffer, 1, 0), HipFileOpError(hipFileHipPointerRangeError));
 }
 
 TEST_F(HipFileBuffer, registerHipMemGetAddressRangeThrowReturnsError)


### PR DESCRIPTION
Should now work for all values and not trigger sanitizer.
