### PR TITLE
[RDC] Fix buffer overflow vulnerabilities in gRPC service and CLI

### DIFF
--- a/projects/rdc/include/rdc/rdc.h
+++ b/projects/rdc/include/rdc/rdc.h
@@ -155,6 +155,11 @@ typedef enum { INTEGER = 0, DOUBLE, STRING, BLOB } rdc_field_type_t;
 #define RDC_MAX_VERSION_STR_LENGTH 60
 
 /**
+ * @brief Max number of GPUs tracked per job
+ */
+#define RDC_MAX_NUM_GPUS_PER_JOB 16
+
+/**
  * @brief Max configuration can be collected using the configuration get
  */
 #define RDC_MAX_CONFIG_SETTINGS 32
@@ -551,11 +556,11 @@ typedef struct {
  * @brief The structure to hold the job stats
  */
 typedef struct {
-  uint32_t num_gpus;              //!< Number of GPUs used by job
-  rdc_gpu_usage_info_t summary;   //!< Job usage summary statistics
-                                  //!< (overall)
-  rdc_gpu_usage_info_t gpus[16];  //!< Job usage summary statistics by GPU
-  uint32_t num_processes;         //!< Number of processes tracked
+  uint32_t num_gpus;                                    //!< Number of GPUs used by job
+  rdc_gpu_usage_info_t summary;                         //!< Job usage summary statistics
+                                                        //!< (overall)
+  rdc_gpu_usage_info_t gpus[RDC_MAX_NUM_GPUS_PER_JOB];  //!< Job usage summary statistics by GPU
+  uint32_t num_processes;                               //!< Number of processes tracked
   rdc_process_status_info_t
       processes[RDC_MAX_NUM_PROCESSES_STATUS];  //!< Array to track process start/stop times
 } rdc_job_info_t;

--- a/projects/rdc/rdc_libs/rdc/src/RdcTopologyLinkImpl.cc
+++ b/projects/rdc/rdc_libs/rdc/src/RdcTopologyLinkImpl.cc
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #include "rdc_lib/impl/RdcTopologyLinkImpl.h"
 
 #include <assert.h>
+#include <string.h>
 #include <sys/time.h>
 #include <unistd.h>
 
@@ -49,6 +50,12 @@ RdcTopologyLinkImpl::~RdcTopologyLinkImpl() {}
 
 rdc_status_t RdcTopologyLinkImpl::rdc_device_topology_get(uint32_t gpu_index,
                                                           rdc_device_topology_t* results) {
+  if (results == nullptr) {
+    return RDC_ST_BAD_PARAMETER;
+  }
+  // Zero output: inner loop's i==j skip leaves link_infos[i] uninitialized.
+  memset(results, 0, sizeof(*results));
+
   rdc_status_t status = RDC_ST_NOT_FOUND;
   amdsmi_status_t err = AMDSMI_STATUS_SUCCESS;
   uint32_t gpu_index_list[RDC_MAX_NUM_DEVICES];
@@ -139,6 +146,12 @@ rdc_status_t RdcTopologyLinkImpl::rdc_device_topology_get(uint32_t gpu_index,
 }
 
 rdc_status_t RdcTopologyLinkImpl::rdc_link_status_get(rdc_link_status_t* results) {
+  if (results == nullptr) {
+    return RDC_ST_BAD_PARAMETER;
+  }
+  // Zero output: trailing gpus[]/link_states[] entries are otherwise unwritten.
+  memset(results, 0, sizeof(*results));
+
   rdc_status_t status = RDC_ST_NOT_FOUND;
   amdsmi_status_t err = AMDSMI_STATUS_SUCCESS;
   uint32_t gpu_index_list[RDC_MAX_NUM_DEVICES];

--- a/projects/rdc/rdc_libs/rdc_client/src/RdcStandaloneHandler.cc
+++ b/projects/rdc/rdc_libs/rdc_client/src/RdcStandaloneHandler.cc
@@ -164,6 +164,13 @@ rdc_status_t RdcStandaloneHandler::rdc_job_get_stats(const char job_id[64],
   rdc_status_t err_status = error_handle(status, reply.status());
   if (err_status != RDC_ST_OK) return err_status;
 
+  if (reply.gpus_size() > RDC_MAX_NUM_GPUS_PER_JOB) {
+    return RDC_ST_BAD_PARAMETER;
+  }
+  if (reply.num_processes() > RDC_MAX_NUM_PROCESSES_STATUS) {
+    return RDC_ST_BAD_PARAMETER;
+  }
+
   p_job_info->num_gpus = reply.num_gpus();
   copy_gpu_usage_info(reply.summary(), &(p_job_info->summary));
   for (int i = 0; i < reply.gpus_size(); i++) {
@@ -858,6 +865,9 @@ rdc_status_t RdcStandaloneHandler::rdc_policy_get(rdc_gpu_group_t group_id, uint
 
   auto response = reply.response();
   uint32_t policy_count = response.count();
+  if (policy_count > RDC_MAX_POLICY_SETTINGS) {
+    return RDC_ST_BAD_PARAMETER;
+  }
 
   for (uint32_t i = 0; i < policy_count; ++i) {
     const ::rdc::Policy& policy = response.policies(i);
@@ -1017,6 +1027,10 @@ rdc_status_t RdcStandaloneHandler::rdc_health_check(rdc_gpu_group_t group_id,
   if (err_status != RDC_ST_OK) return err_status;
 
   auto res = reply.response();
+  if (res.incidents_size() > HEALTH_MAX_ERROR_ITEMS) {
+    return RDC_ST_BAD_PARAMETER;
+  }
+
   response->overall_health = static_cast<rdc_health_result_t>(res.overall_health());
   response->incidents_count = res.incidents_count();
 
@@ -1061,6 +1075,10 @@ rdc_status_t RdcStandaloneHandler::rdc_device_topology_get(uint32_t gpu_index,
   if (err_status != RDC_ST_OK) return err_status;
 
   ::rdc::Topology Topology = reply.toppology();
+  if (Topology.num_of_gpus() > RDC_MAX_NUM_DEVICES) {
+    return RDC_ST_BAD_PARAMETER;
+  }
+
   results->num_of_gpus = Topology.num_of_gpus();
   results->numa_node = Topology.numa_node();
 
@@ -1088,10 +1106,17 @@ rdc_status_t RdcStandaloneHandler::rdc_link_status_get(rdc_link_status_t* result
   if (err_status != RDC_ST_OK) return err_status;
 
   ::rdc::LinkStatus LinkStatus = reply.linkstatus();
+  if (LinkStatus.num_of_gpus() > RDC_MAX_NUM_DEVICES) {
+    return RDC_ST_BAD_PARAMETER;
+  }
+
   results->num_of_gpus = LinkStatus.num_of_gpus();
 
   for (uint32_t i = 0; i < LinkStatus.num_of_gpus(); ++i) {
     ::rdc::GpuLinkStatus gpulinkstatus = LinkStatus.gpus(i);
+    if (gpulinkstatus.num_of_links() > RDC_MAX_NUM_OF_LINKS) {
+      return RDC_ST_BAD_PARAMETER;
+    }
     results->gpus[i].gpu_index = gpulinkstatus.gpu_index();
     results->gpus[i].num_of_links = gpulinkstatus.num_of_links();
     results->gpus[i].link_types = static_cast<rdc_topology_link_type_t>(gpulinkstatus.link_types());

--- a/projects/rdc/rdci/src/RdciDmonSubSystem.cc
+++ b/projects/rdc/rdci/src/RdciDmonSubSystem.cc
@@ -291,6 +291,10 @@ void RdciDmonSubSystem::create_temp_field_group() {
     return;
   }
 
+  if (field_ids_.size() > RDC_MAX_FIELD_IDS_PER_FIELD_GROUP) {
+    throw RdcException(RDC_ST_MAX_LIMIT, "Too many field IDs specified");
+  }
+
   const std::string field_group_name("rdci-dmon-field-group");
   rdc_field_grp_t group_id = 0;
   rdc_field_t field_ids[RDC_MAX_FIELD_IDS_PER_FIELD_GROUP];

--- a/projects/rdc/rdci/src/RdciFieldGroupSubSystem.cc
+++ b/projects/rdc/rdci/src/RdciFieldGroupSubSystem.cc
@@ -219,6 +219,9 @@ void RdciFieldGroupSubSystem::process() {
                            "Must specify the group name when create a field group");
       }
       std::vector<std::string> fields = split_string(field_ids_, ',');
+      if (fields.size() > RDC_MAX_FIELD_IDS_PER_FIELD_GROUP) {
+        throw RdcException(RDC_ST_MAX_LIMIT, "Too many field IDs specified");
+      }
       rdc_field_t field_ids[RDC_MAX_FIELD_IDS_PER_FIELD_GROUP];
       for (uint32_t i = 0; i < fields.size(); i++) {
         if (!IsNumber(fields[i])) {

--- a/projects/rdc/server/src/rdc_api_service.cc
+++ b/projects/rdc/server/src/rdc_api_service.cc
@@ -260,13 +260,21 @@ RdcAPIServiceImpl::~RdcAPIServiceImpl() {
     return ::grpc::Status(::grpc::StatusCode::INTERNAL, "Empty contents");
   }
 
+  // Reject requests exceeding the fixed-size stack array to prevent overflow.
+  const int request_count = request->field_ids_size();
+  if (request_count < 0 || request_count > RDC_MAX_FIELD_IDS_PER_FIELD_GROUP) {
+    reply->set_status(RDC_ST_BAD_PARAMETER);
+    return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
+                          "field_ids count exceeds RDC_MAX_FIELD_IDS_PER_FIELD_GROUP");
+  }
+
   rdc_field_grp_t field_group_id;
   rdc_field_t field_ids[RDC_MAX_FIELD_IDS_PER_FIELD_GROUP];
-  for (int i = 0; i < request->field_ids_size(); i++) {
+  for (int i = 0; i < request_count; i++) {
     field_ids[i] = static_cast<rdc_field_t>(request->field_ids(i));
   }
   rdc_status_t result =
-      rdc_group_field_create(rdc_handle_, request->field_ids_size(), &field_ids[0],
+      rdc_group_field_create(rdc_handle_, request_count, &field_ids[0],
                              request->field_group_name().c_str(), &field_group_id);
   reply->set_status(result);
   if (result != RDC_ST_OK) {
@@ -476,17 +484,22 @@ RdcAPIServiceImpl::~RdcAPIServiceImpl() {
     return ::grpc::Status::OK;
   }
 
-  reply->set_num_gpus(job_info.num_gpus);
+  uint32_t num_gpus =
+      (job_info.num_gpus > RDC_MAX_NUM_GPUS_PER_JOB) ? RDC_MAX_NUM_GPUS_PER_JOB : job_info.num_gpus;
+  uint32_t num_processes = (job_info.num_processes > RDC_MAX_NUM_PROCESSES_STATUS)
+                               ? RDC_MAX_NUM_PROCESSES_STATUS
+                               : job_info.num_processes;
+  reply->set_num_gpus(num_gpus);
   ::rdc::GpuUsageInfo* sinfo = reply->mutable_summary();
   copy_gpu_usage_info(job_info.summary, sinfo);
 
-  for (uint32_t i = 0; i < job_info.num_gpus; i++) {
+  for (uint32_t i = 0; i < num_gpus; i++) {
     ::rdc::GpuUsageInfo* ginfo = reply->add_gpus();
     copy_gpu_usage_info(job_info.gpus[i], ginfo);
   }
 
-  reply->set_num_processes(job_info.num_processes);
-  for (uint32_t i = 0; i < job_info.num_processes; i++) {
+  reply->set_num_processes(num_processes);
+  for (uint32_t i = 0; i < num_processes; i++) {
     ::rdc::RdcProcessStatsInfo* pinfo = reply->add_processes();
     pinfo->set_pid(job_info.processes[i].pid);
     pinfo->set_process_name(job_info.processes[i].process_name);
@@ -658,6 +671,11 @@ bool RdcAPIServiceImpl::copy_gpu_usage_info(const rdc_gpu_usage_info_t& src,
   }
 
   ::rdc::DiagnosticResponse* to_response = reply.mutable_response();
+  if (diag_response.results_count > MAX_TEST_CASES) {
+    reply.set_status(RDC_ST_BAD_PARAMETER);
+    writer->Write(reply);
+    return ::grpc::Status::OK;
+  }
   to_response->set_results_count(diag_response.results_count);
 
   for (uint32_t i = 0; i < diag_response.results_count; i++) {
@@ -676,7 +694,10 @@ bool RdcAPIServiceImpl::copy_gpu_usage_info(const rdc_gpu_usage_info_t& src,
     to_diag_info->set_per_gpu_result_count(test_result.per_gpu_result_count);
 
     // gpu_results
-    for (uint32_t j = 0; j < test_result.per_gpu_result_count; j++) {
+    uint32_t gpu_result_count = (test_result.per_gpu_result_count > RDC_MAX_NUM_DEVICES)
+                                    ? RDC_MAX_NUM_DEVICES
+                                    : test_result.per_gpu_result_count;
+    for (uint32_t j = 0; j < gpu_result_count; j++) {
       auto to_result = to_diag_info->add_gpu_results();
       const rdc_diag_per_gpu_result_t& cur_result = test_result.gpu_results[j];
       to_result->set_gpu_index(cur_result.gpu_index);
@@ -754,7 +775,10 @@ bool RdcAPIServiceImpl::copy_gpu_usage_info(const rdc_gpu_usage_info_t& src,
   to_diag_info->set_per_gpu_result_count(test_result.per_gpu_result_count);
 
   // gpu_results
-  for (uint32_t j = 0; j < test_result.per_gpu_result_count; j++) {
+  uint32_t gpu_result_count = (test_result.per_gpu_result_count > RDC_MAX_NUM_DEVICES)
+                                  ? RDC_MAX_NUM_DEVICES
+                                  : test_result.per_gpu_result_count;
+  for (uint32_t j = 0; j < gpu_result_count; j++) {
     auto to_result = to_diag_info->add_gpu_results();
     const rdc_diag_per_gpu_result_t& cur_result = test_result.gpu_results[j];
     to_result->set_gpu_index(cur_result.gpu_index);

--- a/projects/rdc/server/src/rdc_server_main.cc
+++ b/projects/rdc/server/src/rdc_server_main.cc
@@ -485,7 +485,7 @@ static const struct option long_options[] = {{"address", required_argument, null
 static const char* short_options = "a:p:uidvh";
 
 static void PrintHelp(void) {
-  std::cout << "Optional rdctst Arguments:\n"
+  std::cout << "Optional rdcd Arguments:\n"
                "--address, -a <IPv4 address> specify address on which to listen; "
                "default is 0.0.0.0\n"
                "--port, -p <port> specify port on which to listen; "

--- a/projects/rdc/tests/rdc_tests/test_common.cc
+++ b/projects/rdc/tests/rdc_tests/test_common.cc
@@ -101,7 +101,7 @@ static const struct option long_options[] = {
 static const char* short_options = "i:v:m:s:p:d:bfur";
 
 static void PrintHelp(void) {
-  std::cout << "Optional rdctst Arguments:\n"
+  std::cout << "Optional rdcd Arguments:\n"
                "--batch_mode, -b run in embedded mode with no interactive prompts\n"
                "--dont_fail, -f if set, don't fail test when individual test fails; "
                "default is to fail when an individual test fails\n"


### PR DESCRIPTION
## Summary

Fixes multiple buffer overflow vulnerabilities across the RDC server, client, and CLI where user-controlled or response-controlled counts are used to index fixed-size stack arrays without bounds checking.

### Critical — Server-side (exploitable by untrusted gRPC client)

- **`CreateFieldGroup` stack overflow** (`rdc_api_service.cc`): A malicious gRPC client could send a `CreateFieldGroupRequest` with more than 128 `field_ids`, overflowing the stack-allocated `rdc_field_t field_ids[RDC_MAX_FIELD_IDS_PER_FIELD_GROUP]` array before the backend validation in `rdc_group_field_create` is reached. Fixed by rejecting requests where `field_ids_size()` exceeds `RDC_MAX_FIELD_IDS_PER_FIELD_GROUP` before copying.

### High — Client-side (exploitable by malicious/compromised server)

Six missing bounds checks in `RdcStandaloneHandler.cc` where gRPC response data is copied into fixed-size arrays:

| Function | Array | Limit |
|----------|-------|-------|
| `rdc_job_get_stats` | `gpus[RDC_MAX_NUM_GPUS_PER_JOB]` | 16 |
| `rdc_job_get_stats` | `processes[RDC_MAX_NUM_PROCESSES_STATUS]` | 64 |
| `rdc_policy_get` | `policies[RDC_MAX_POLICY_SETTINGS]` | 32 |
| `rdc_health_check` | `incidents[HEALTH_MAX_ERROR_ITEMS]` | 64 |
| `rdc_device_topology_get` | `link_infos[RDC_MAX_NUM_DEVICES]` | 128 |
| `rdc_link_status_get` | `gpus[RDC_MAX_NUM_DEVICES]`, `link_states[RDC_MAX_NUM_OF_LINKS]` | 128, 16 |

### Medium — CLI stack overflows

- **`rdci dmon`** (`RdciDmonSubSystem.cc`): `field_ids_` vector copied into `field_ids[RDC_MAX_FIELD_IDS_PER_FIELD_GROUP]` without size check.
- **`rdci fieldgroup create`** (`RdciFieldGroupSubSystem.cc`): Parsed field list copied into `field_ids[RDC_MAX_FIELD_IDS_PER_FIELD_GROUP]` without size check.

### Defense-in-depth — Server-side internal struct reads

- `GetJobStats`: Clamp `num_gpus` / `num_processes` to array bounds before iterating `rdc_job_info_t`.
- `DiagnosticRun`: Validate `results_count` against `MAX_TEST_CASES` before iterating `rdc_diag_response_t`.
- `DiagnosticRun` / `DiagnosticTestCaseRun`: Clamp `per_gpu_result_count` to `RDC_MAX_NUM_DEVICES`.

### Housekeeping

- Added `RDC_MAX_NUM_GPUS_PER_JOB` constant to `rdc.h` replacing magic number `16` in `rdc_job_info_t.gpus`.
- Fixed typo in rdcd/rdctst help text (`"Optional rdctst Arguments"` → `"Optional rdcd Arguments"`).

## Test plan

- [x] Build RDC with `-DBUILD_TESTS=ON` and verify compilation succeeds
- [x] Run existing `rdctst` test suite — no regressions expected
- [x] Verify `rdci fieldgroup create` with >128 fields returns error instead of crashing
- [x] Verify `rdci dmon` with >128 field IDs returns error instead of crashing
