### PR TITLE
[hipfile] Update .readthedocs.yaml paths

### DIFF
--- a/projects/hipfile/.readthedocs.yaml
+++ b/projects/hipfile/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: projects/hipfile/docs/conf.py
 
 formats: []
 
 python:
   install:
-    - requirements: docs/sphinx/requirements.txt
+    - requirements: projects/hipfile/docs/sphinx/requirements.txt
 
 build:
   os: ubuntu-24.04


### PR DESCRIPTION
## Motivation

Brings hipFile in line with the rest of rocm-systems after PR #5834 merged.

## Technical Details

Adds `projects/hipfile` to .readthedocs.yaml paths

## JIRA ID

AIHIPFILE-41

## Test Plan

N/A (not online yet)

## Test Result

N/A

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
