### PR TITLE
[hipfile] Update CMake Doxygen option comments

### DIFF
--- a/projects/hipfile/cmake/AISDocumentation.cmake
+++ b/projects/hipfile/cmake/AISDocumentation.cmake
@@ -3,13 +3,9 @@
 # SPDX-License-Identifier: MIT
 
 #-----------------------------------------------------------------------------
-# Option to build the hipFile documentation
-#
-# TODO: Consider turning this into two options, one of which just requires
-#       Doxygen and produces API docs, the other produces Sphinx/Breathe
-#       output
+# Option to build the hipFile API documentation
 #-----------------------------------------------------------------------------
-option(AIS_BUILD_DOCS "Build the hipFile docs (requires Doxygen, Sphinx, and Breathe)" OFF)
+option(AIS_BUILD_DOCS "Build hipFile API docs (requires Doxygen)" OFF)
 
 if(AIS_BUILD_DOCS)
     find_package(Doxygen REQUIRED)


### PR DESCRIPTION
## Motivation

The CMake documentation inaccurately states we require Sphinx & Breathe

## Technical Details

* Update comments in AISDocumentation.cmake
* Update the help text for the AIS_BUILD_DOCS option

## JIRA ID

AIHIPFILE-41

## Test Plan

N/A (comments only)

## Test Result

N/A

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
