### PR TITLE
[hipFile/CI] Create a multi-stage CI image

### DIFF
--- a/.github/workflows/hipfile-ci.yml
+++ b/.github/workflows/hipfile-ci.yml
@@ -126,6 +126,6 @@ jobs:
     needs: [AIS_CI_Pre-check, build_AIS_CI_image]
     uses: ./.github/workflows/hipfile-build-nvidia.yml
     with:
-      ci_image: ${{ needs.build_AIS_CI_image.outputs.ci_image }}
+      ci_image: ${{ needs.build_AIS_CI_image.outputs.ci_image_nvidia }}
       platform: ${{ inputs.platform }}
       rocm_version: ${{ inputs.rocm_version }}

--- a/.github/workflows/hipfile-image-build.yml
+++ b/.github/workflows/hipfile-image-build.yml
@@ -5,7 +5,6 @@ env:
   AIS_CI_IMAGE_NAME: ais_ci_${{ inputs.platform }}
   AIS_DOCKER_REGISTRY: ghcr.io/${{ github.repository_owner }}/hipfile
   AIS_INPUT_ROCM_VERSION: ${{ inputs.rocm_version }}
-  AIS_PR_BASE_URL: ${{ github.server_url }}/${{ github.repository }}/pull
 
 on:
   workflow_call:
@@ -97,7 +96,6 @@ jobs:
       - name: Set CI environment variables
         run: |
           echo "AIS_CI_IMAGE_TAG=$(echo "${GITHUB_REF}" | sed 's|[^a-zA-Z0-9]|-|g')-rocm${AIS_INPUT_ROCM_VERSION}" >> "${GITHUB_ENV}"
-          echo "AIS_PR_NUMBER=$(echo "${GITHUB_REF}" | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
 
       - name: Set target AIS CI Image
         id: ci-image
@@ -138,10 +136,6 @@ jobs:
           docker buildx build \
             -f "${GITHUB_WORKSPACE}/projects/hipfile/util/docker/DOCKERFILE.${AIS_CI_IMAGE_NAME}" \
             --target base \
-            --label "org.opencontainers.image.description= \
-              ${AIS_CI_IMAGE_NAME} Development Image for AIS CI using branch \
-              ${GITHUB_HEAD_REF} for PR #${AIS_PR_NUMBER}. \
-              PR URL: ${AIS_PR_BASE_URL}/${AIS_PR_NUMBER}" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --build-arg ROCM_VERSION=${AIS_INPUT_ROCM_VERSION} \
             --cache-from=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_IMAGE }}" \
@@ -155,10 +149,6 @@ jobs:
           docker buildx build \
             -f "${GITHUB_WORKSPACE}/projects/hipfile/util/docker/DOCKERFILE.${AIS_CI_IMAGE_NAME}" \
             --target nvidia \
-            --label "org.opencontainers.image.description= \
-              ${AIS_CI_IMAGE_NAME} NVIDIA Development Image for AIS CI using branch \
-              ${GITHUB_HEAD_REF} for PR #${AIS_PR_NUMBER}. \
-              PR URL: ${AIS_PR_BASE_URL}/${AIS_PR_NUMBER}" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --build-arg ROCM_VERSION=${AIS_INPUT_ROCM_VERSION} \
             --cache-from=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_IMAGE_NVIDIA }}" \

--- a/.github/workflows/hipfile-image-build.yml
+++ b/.github/workflows/hipfile-image-build.yml
@@ -32,9 +32,19 @@ on:
           If a new CI image is produced, returns the new CI image name & tag.
           Otherwise, returns the current CI image name & tag.
         value: >-
-          ${{ 
+          ${{
             jobs.build_AIS_image.result == 'skipped' && jobs.get_latest_AIS_image.outputs.new_ci_image ||
             jobs.build_AIS_image.result == 'success' && jobs.build_AIS_image.outputs.new_ci_image ||
+            null
+          }}
+      ci_image_nvidia:
+        description: |
+          The full name & tag of the NVIDIA CI image to use.
+          Same as ci_image but with CUDA SDK and NVIDIA drivers installed.
+        value: >-
+          ${{
+            jobs.build_AIS_image.result == 'skipped' && jobs.get_latest_AIS_image.outputs.new_ci_image_nvidia ||
+            jobs.build_AIS_image.result == 'success' && jobs.build_AIS_image.outputs.new_ci_image_nvidia ||
             null
           }}
       ci_image_build_satisfied:
@@ -59,7 +69,6 @@ permissions:
   packages: write
 
 jobs:
-
   # GitHub Actions does not have a built-in toLower() function which has made a lot of
   # people sad. https://github.com/orgs/community/discussions/25768
   get_latest_AIS_image:
@@ -67,12 +76,15 @@ jobs:
     runs-on: [ubuntu-24.04]
     outputs:
       new_ci_image: ${{ steps.ci-image.outputs.AIS_CI_IMAGE }}
+      new_ci_image_nvidia: ${{ steps.ci-image.outputs.AIS_CI_IMAGE_NVIDIA }}
     steps:
       - name: Set default CI image
         id: ci-image
         run: |
           AIS_CI_IMAGE="${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:latest-rocm${AIS_INPUT_ROCM_VERSION}"
           echo "AIS_CI_IMAGE=$(printf '%s' "${AIS_CI_IMAGE}" | tr '[:upper:]' '[:lower:]')" >> "${GITHUB_OUTPUT}"
+          AIS_CI_IMAGE_NVIDIA="${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:latest-rocm${AIS_INPUT_ROCM_VERSION}-nvidia"
+          echo "AIS_CI_IMAGE_NVIDIA=$(printf '%s' "${AIS_CI_IMAGE_NVIDIA}" | tr '[:upper:]' '[:lower:]')" >> "${GITHUB_OUTPUT}"
 
   build_AIS_image:
     if: ${{ inputs.dockerfile_changed }}
@@ -80,6 +92,7 @@ jobs:
     container: docker:28.5
     outputs:
       new_ci_image: ${{ steps.ci-image.outputs.AIS_CI_IMAGE }}
+      new_ci_image_nvidia: ${{ steps.ci-image.outputs.AIS_CI_IMAGE_NVIDIA }}
     steps:
       - name: Set CI environment variables
         run: |
@@ -91,8 +104,12 @@ jobs:
         run: |
           AIS_CI_IMAGE="${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:${AIS_CI_IMAGE_TAG}"
           echo "AIS_CI_IMAGE=$(printf '%s' "${AIS_CI_IMAGE}" | tr '[:upper:]' '[:lower:]')" >> "${GITHUB_OUTPUT}"
+          AIS_CI_IMAGE_NVIDIA="${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:${AIS_CI_IMAGE_TAG}-nvidia"
+          echo "AIS_CI_IMAGE_NVIDIA=$(printf '%s' "${AIS_CI_IMAGE_NVIDIA}" | tr '[:upper:]' '[:lower:]')" >> "${GITHUB_OUTPUT}"
           AIS_CI_LATEST_CACHE="${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:latest-rocm${AIS_INPUT_ROCM_VERSION}-cache"
           echo "AIS_CI_LATEST_CACHE=$(printf '%s' "${AIS_CI_LATEST_CACHE}" | tr '[:upper:]' '[:lower:]')" >> "${GITHUB_OUTPUT}"
+          AIS_CI_LATEST_CACHE_NVIDIA="${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:latest-rocm${AIS_INPUT_ROCM_VERSION}-nvidia-cache"
+          echo "AIS_CI_LATEST_CACHE_NVIDIA=$(printf '%s' "${AIS_CI_LATEST_CACHE_NVIDIA}" | tr '[:upper:]' '[:lower:]')" >> "${GITHUB_OUTPUT}"
 
       - name: Fetching code repository...
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -120,6 +137,7 @@ jobs:
         run: |
           docker buildx build \
             -f "${GITHUB_WORKSPACE}/projects/hipfile/util/docker/DOCKERFILE.${AIS_CI_IMAGE_NAME}" \
+            --target base \
             --label "org.opencontainers.image.description= \
               ${AIS_CI_IMAGE_NAME} Development Image for AIS CI using branch \
               ${GITHUB_HEAD_REF} for PR #${AIS_PR_NUMBER}. \
@@ -130,4 +148,21 @@ jobs:
             --cache-from=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_LATEST_CACHE }}" \
             --push \
             -t "${{ steps.ci-image.outputs.AIS_CI_IMAGE }}" \
+            "${GITHUB_WORKSPACE}/projects/hipfile/util/docker"
+
+      - name: Build NVIDIA image for AIS CI
+        run: |
+          docker buildx build \
+            -f "${GITHUB_WORKSPACE}/projects/hipfile/util/docker/DOCKERFILE.${AIS_CI_IMAGE_NAME}" \
+            --target nvidia \
+            --label "org.opencontainers.image.description= \
+              ${AIS_CI_IMAGE_NAME} NVIDIA Development Image for AIS CI using branch \
+              ${GITHUB_HEAD_REF} for PR #${AIS_PR_NUMBER}. \
+              PR URL: ${AIS_PR_BASE_URL}/${AIS_PR_NUMBER}" \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --build-arg ROCM_VERSION=${AIS_INPUT_ROCM_VERSION} \
+            --cache-from=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_IMAGE_NVIDIA }}" \
+            --cache-from=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_LATEST_CACHE_NVIDIA }}" \
+            --push \
+            -t "${{ steps.ci-image.outputs.AIS_CI_IMAGE_NVIDIA }}" \
             "${GITHUB_WORKSPACE}/projects/hipfile/util/docker"

--- a/.github/workflows/hipfile-image-update.yml
+++ b/.github/workflows/hipfile-image-update.yml
@@ -105,8 +105,6 @@ jobs:
           docker buildx build \
             -f "${GITHUB_WORKSPACE}/projects/hipfile/util/docker/DOCKERFILE.${AIS_CI_IMAGE_NAME}" \
             --target base \
-            --label "org.opencontainers.image.description= \
-              Latest AIS CI Image for ${AIS_INPUT_PLATFORM} using ROCm ${{ matrix.rocm_versions }}." \
             --build-arg ROCM_VERSION=${{ matrix.rocm_versions }} \
             --cache-to=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_IMAGE }}-cache" \
             ${{ steps.use-cache.outputs.CACHE_FROM_CMD }} \
@@ -119,8 +117,6 @@ jobs:
           docker buildx build \
             -f "${GITHUB_WORKSPACE}/projects/hipfile/util/docker/DOCKERFILE.${AIS_CI_IMAGE_NAME}" \
             --target nvidia \
-            --label "org.opencontainers.image.description= \
-              Latest NVIDIA AIS CI Image for ${AIS_INPUT_PLATFORM} using ROCm ${{ matrix.rocm_versions }}." \
             --build-arg ROCM_VERSION=${{ matrix.rocm_versions }} \
             --cache-to=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_IMAGE_NVIDIA }}-cache" \
             ${{ steps.use-cache.outputs.CACHE_FROM_CMD_NVIDIA }} \

--- a/.github/workflows/hipfile-image-update.yml
+++ b/.github/workflows/hipfile-image-update.yml
@@ -71,6 +71,8 @@ jobs:
         run: |
           AIS_CI_IMAGE="${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:latest-rocm${{ matrix.rocm_versions }}"
           echo "AIS_CI_IMAGE=$(printf '%s' "${AIS_CI_IMAGE}" | tr '[:upper:]' '[:lower:]')" >> "${GITHUB_OUTPUT}"
+          AIS_CI_IMAGE_NVIDIA="${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:latest-rocm${{ matrix.rocm_versions }}-nvidia"
+          echo "AIS_CI_IMAGE_NVIDIA=$(printf '%s' "${AIS_CI_IMAGE_NVIDIA}" | tr '[:upper:]' '[:lower:]')" >> "${GITHUB_OUTPUT}"
 
       - name: Set Docker Cache Instruction
         id: use-cache
@@ -79,10 +81,15 @@ jobs:
         # for 'null'.
         # See: https://docs.github.com/en/actions/reference/workflows-and-actions/expressions
         # for how null gets converted when compared to non-null, and converted into a string.
-        run: >-
+        run: |
           echo "CACHE_FROM_CMD=${{
             ( format('{0}', inputs.pull_from_cache) == '' || inputs.pull_from_cache ) &&
             format('--cache-from=type=registry,ref=\"{0}-cache\"', steps.ci-image.outputs.AIS_CI_IMAGE) ||
+            ''
+          }}" >> "${GITHUB_OUTPUT}"
+          echo "CACHE_FROM_CMD_NVIDIA=${{
+            ( format('{0}', inputs.pull_from_cache) == '' || inputs.pull_from_cache ) &&
+            format('--cache-from=type=registry,ref=\"{0}-cache\"', steps.ci-image.outputs.AIS_CI_IMAGE_NVIDIA) ||
             ''
           }}" >> "${GITHUB_OUTPUT}"
 
@@ -93,10 +100,11 @@ jobs:
           driver: docker-container
           cache-binary: false # True uses the GHA Cache Backend
 
-      - name: Build & Push latest image for AIS CI
+      - name: Build & Push latest base image for AIS CI
         run: |
           docker buildx build \
             -f "${GITHUB_WORKSPACE}/projects/hipfile/util/docker/DOCKERFILE.${AIS_CI_IMAGE_NAME}" \
+            --target base \
             --label "org.opencontainers.image.description= \
               Latest AIS CI Image for ${AIS_INPUT_PLATFORM} using ROCm ${{ matrix.rocm_versions }}." \
             --build-arg ROCM_VERSION=${{ matrix.rocm_versions }} \
@@ -104,4 +112,18 @@ jobs:
             ${{ steps.use-cache.outputs.CACHE_FROM_CMD }} \
             --push \
             -t "${{ steps.ci-image.outputs.AIS_CI_IMAGE }}" \
+            "${GITHUB_WORKSPACE}/projects/hipfile/util/docker"
+
+      - name: Build & Push latest NVIDIA image for AIS CI
+        run: |
+          docker buildx build \
+            -f "${GITHUB_WORKSPACE}/projects/hipfile/util/docker/DOCKERFILE.${AIS_CI_IMAGE_NAME}" \
+            --target nvidia \
+            --label "org.opencontainers.image.description= \
+              Latest NVIDIA AIS CI Image for ${AIS_INPUT_PLATFORM} using ROCm ${{ matrix.rocm_versions }}." \
+            --build-arg ROCM_VERSION=${{ matrix.rocm_versions }} \
+            --cache-to=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_IMAGE_NVIDIA }}-cache" \
+            ${{ steps.use-cache.outputs.CACHE_FROM_CMD_NVIDIA }} \
+            --push \
+            -t "${{ steps.ci-image.outputs.AIS_CI_IMAGE_NVIDIA }}" \
             "${GITHUB_WORKSPACE}/projects/hipfile/util/docker"

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky
@@ -4,7 +4,7 @@
 
 ARG ROCKY_MAJOR_VERSION=9
 ARG ROCKY_VERSION=${ROCKY_MAJOR_VERSION}.6
-FROM rockylinux/rockylinux:${ROCKY_VERSION}-minimal
+FROM rockylinux/rockylinux:${ROCKY_VERSION}-minimal AS base
 LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 # Brings ROCKY_VERSION in-scope
 ARG ROCKY_MAJOR_VERSION
@@ -81,27 +81,8 @@ RUN cat <<EOF > /etc/ld.so.conf.d/rocm.conf
 EOF
 RUN ldconfig
 
-# Install a minimal CUDA SDK
-# HIP depends on the ROCm libraries being installed.
-# This means we are unable to have a separate CUDA+HIP image
-# without ROCm.
-RUN curl https://developer.download.nvidia.com/compute/cuda/repos/rhel${ROCKY_MAJOR_VERSION}/x86_64/cuda-rhel${ROCKY_MAJOR_VERSION}.repo \
-        -o /etc/yum.repos.d/cuda-rhel${ROCKY_MAJOR_VERSION}.repo && \
-    dnf makecache
-
-# https://gitlab.com/nvidia/container-images/cuda/blob/master/dist/12.6.1/ubuntu2404/devel/Dockerfile
-# Attempt a "minimal" CUDA Dev install.
-# libcufile-dev-X.Y == libcufile-devel-X.Y
-# libnvidia-compute-570-server == nvidia-driver-cuda + kmod-nvidia-open-dkms
-RUN dnf module enable -y nvidia-driver:570-open && \
-    dnf install -y \
-        cuda-minimal-build-12-9 \
-        kmod-nvidia-open-dkms \
-        libcufile-devel-12-9 \
-        nvidia-driver-cuda
-
-# Add ROCm and CUDA bin directories to the path
-ENV PATH=/usr/local/cuda/bin:/opt/rocm/bin:${PATH}
+# Add ROCm bin directory to the path
+ENV PATH=/opt/rocm/bin:${PATH}
 
 # Environment Build Arg for ROCm
 ENV ROCM_VERSION="${ROCM_VERSION}"
@@ -119,3 +100,28 @@ VOLUME /mnt/ais
 
 # Generic Mount point for container to access AIS-capable storage.
 VOLUME /mnt/ais-fs
+
+# ---- Stage 2: NVIDIA (extends base with CUDA SDK) ----
+# The HIP runtime must be present to use hipFile with NVIDIA GPUs,
+# which is why this stage inherits from base rather than a bare CUDA image.
+FROM base AS nvidia
+ARG ROCKY_MAJOR_VERSION=9
+
+# Install a minimal CUDA SDK
+RUN curl https://developer.download.nvidia.com/compute/cuda/repos/rhel${ROCKY_MAJOR_VERSION}/x86_64/cuda-rhel${ROCKY_MAJOR_VERSION}.repo \
+        -o /etc/yum.repos.d/cuda-rhel${ROCKY_MAJOR_VERSION}.repo && \
+    dnf makecache
+
+# https://gitlab.com/nvidia/container-images/cuda/blob/master/dist/12.6.1/ubuntu2404/devel/Dockerfile
+# Attempt a "minimal" CUDA Dev install.
+# libcufile-dev-X.Y == libcufile-devel-X.Y
+# libnvidia-compute-570-server == nvidia-driver-cuda + kmod-nvidia-open-dkms
+RUN dnf module enable -y nvidia-driver:570-open && \
+    dnf install -y \
+        cuda-minimal-build-12-9 \
+        kmod-nvidia-open-dkms \
+        libcufile-devel-12-9 \
+        nvidia-driver-cuda
+
+# Add CUDA bin directory to the path
+ENV PATH=/usr/local/cuda/bin:${PATH}

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky8
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky8
@@ -4,7 +4,7 @@
 
 ARG ROCKY_MAJOR_VERSION=8
 ARG ROCKY_VERSION=${ROCKY_MAJOR_VERSION}.10
-FROM rockylinux/rockylinux:${ROCKY_VERSION}-minimal
+FROM rockylinux/rockylinux:${ROCKY_VERSION}-minimal AS base
 LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 # Brings ROCKY_VERSION in-scope
 ARG ROCKY_MAJOR_VERSION
@@ -81,27 +81,8 @@ RUN cat <<EOF > /etc/ld.so.conf.d/rocm.conf
 EOF
 RUN ldconfig
 
-# Install a minimal CUDA SDK
-# HIP depends on the ROCm libraries being installed.
-# This means we are unable to have a separate CUDA+HIP image
-# without ROCm.
-RUN curl https://developer.download.nvidia.com/compute/cuda/repos/rhel${ROCKY_MAJOR_VERSION}/x86_64/cuda-rhel${ROCKY_MAJOR_VERSION}.repo \
-        -o /etc/yum.repos.d/cuda-rhel${ROCKY_MAJOR_VERSION}.repo && \
-    dnf makecache
-
-# https://gitlab.com/nvidia/container-images/cuda/blob/master/dist/12.6.1/ubuntu2404/devel/Dockerfile
-# Attempt a "minimal" CUDA Dev install.
-# libcufile-dev-X.Y == libcufile-devel-X.Y
-# libnvidia-compute-570-server == nvidia-driver-cuda + kmod-nvidia-open-dkms
-RUN dnf module enable -y nvidia-driver:570-open && \
-    dnf install -y \
-        cuda-minimal-build-12-9 \
-        kmod-nvidia-open-dkms \
-        libcufile-devel-12-9 \
-        nvidia-driver-cuda
-
-# Add ROCm and CUDA bin directories to the path
-ENV PATH=/usr/local/cuda/bin:/opt/rocm/bin:${PATH}
+# Add ROCm bin directory to the path
+ENV PATH=/opt/rocm/bin:${PATH}
 
 # Environment Build Arg for ROCm
 ENV ROCM_VERSION="${ROCM_VERSION}"
@@ -119,3 +100,28 @@ VOLUME /mnt/ais
 
 # Generic Mount point for container to access AIS-capable storage.
 VOLUME /mnt/ais-fs
+
+# ---- Stage 2: NVIDIA (extends base with CUDA SDK) ----
+# The HIP runtime must be present to use hipFile with NVIDIA GPUs,
+# which is why this stage inherits from base rather than a bare CUDA image.
+FROM base AS nvidia
+ARG ROCKY_MAJOR_VERSION=8
+
+# Install a minimal CUDA SDK
+RUN curl https://developer.download.nvidia.com/compute/cuda/repos/rhel${ROCKY_MAJOR_VERSION}/x86_64/cuda-rhel${ROCKY_MAJOR_VERSION}.repo \
+        -o /etc/yum.repos.d/cuda-rhel${ROCKY_MAJOR_VERSION}.repo && \
+    dnf makecache
+
+# https://gitlab.com/nvidia/container-images/cuda/blob/master/dist/12.6.1/ubuntu2404/devel/Dockerfile
+# Attempt a "minimal" CUDA Dev install.
+# libcufile-dev-X.Y == libcufile-devel-X.Y
+# libnvidia-compute-570-server == nvidia-driver-cuda + kmod-nvidia-open-dkms
+RUN dnf module enable -y nvidia-driver:570-open && \
+    dnf install -y \
+        cuda-minimal-build-12-9 \
+        kmod-nvidia-open-dkms \
+        libcufile-devel-12-9 \
+        nvidia-driver-cuda
+
+# Add CUDA bin directory to the path
+ENV PATH=/usr/local/cuda/bin:${PATH}

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_suse
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_suse
@@ -4,7 +4,7 @@
 
 ARG SUSE_MAJOR_VERSION=15
 ARG SUSE_MINOR_VERSION=6
-FROM opensuse/leap:${SUSE_MAJOR_VERSION}.${SUSE_MINOR_VERSION}
+FROM opensuse/leap:${SUSE_MAJOR_VERSION}.${SUSE_MINOR_VERSION} AS base
 LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 ARG SUSE_MAJOR_VERSION
 ARG SUSE_MINOR_VERSION
@@ -79,10 +79,32 @@ RUN cat <<EOF > /etc/ld.so.conf.d/rocm.conf
 EOF
 RUN ldconfig
 
+# Add ROCm bin directory to the path
+ENV PATH=/opt/rocm/bin:${PATH}
+
+# Environment Build Arg for ROCm Packaging
+ENV ROCM_VERSION="${ROCM_VERSION}"
+ENV SLES_BUILD_ID_PREFIX="opensuse${SUSE_MAJOR_VERSION}${SUSE_MINOR_VERSION}."
+
+# Configure SUSE to use GCC-13 by default
+RUN update-alternatives \
+        --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 \
+        --slave /usr/bin/cc cc /usr/bin/gcc-13 \
+        --slave /usr/bin/g++ g++ /usr/bin/g++-13
+
+# AIS Code Repository Mount Point
+VOLUME /mnt/ais
+
+# Generic Mount point for container to access AIS-capable storage.
+VOLUME /mnt/ais-fs
+
+# ---- Stage 2: NVIDIA (extends base with CUDA SDK) ----
+# The HIP runtime must be present to use hipFile with NVIDIA GPUs,
+# which is why this stage inherits from base rather than a bare CUDA image.
+FROM base AS nvidia
+ARG SUSE_MAJOR_VERSION=15
+
 # Install a minimal CUDA SDK
-# HIP depends on the ROCm libraries being installed.
-# This means we are unable to have a separate CUDA+HIP image
-# without ROCm.
 RUN curl https://developer.download.nvidia.com/compute/cuda/repos/opensuse${SUSE_MAJOR_VERSION}/$(uname -m)/cuda-opensuse${SUSE_MAJOR_VERSION}.repo \
         -o /etc/zypp/repos.d/cuda-opensuse${SUSE_MAJOR_VERSION}.repo && \
     zypper --gpg-auto-import-keys refresh
@@ -100,21 +122,5 @@ RUN zypper install -y \
         nvidia-compute-G06=575.57.08-1 \
         nvidia-open-driver-G06=575.57.08-1
 
-# Add ROCm and CUDA bin directories to the path
-ENV PATH=/usr/local/cuda/bin:/opt/rocm/bin:${PATH}
-
-# Environment Build Arg for ROCm Packaging
-ENV ROCM_VERSION="${ROCM_VERSION}"
-ENV SLES_BUILD_ID_PREFIX="opensuse${SUSE_MAJOR_VERSION}${SUSE_MINOR_VERSION}."
-
-# Configure SUSE to use GCC-13 by default
-RUN update-alternatives \
-        --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 \
-        --slave /usr/bin/cc cc /usr/bin/gcc-13 \
-        --slave /usr/bin/g++ g++ /usr/bin/g++-13
-
-# AIS Code Repository Mount Point
-VOLUME /mnt/ais
-
-# Generic Mount point for container to access AIS-capable storage.
-VOLUME /mnt/ais-fs
+# Add CUDA bin directory to the path
+ENV PATH=/usr/local/cuda/bin:${PATH}

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_suse
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_suse
@@ -122,5 +122,9 @@ RUN zypper install -y \
         nvidia-compute-G06=575.57.08-1 \
         nvidia-open-driver-G06=575.57.08-1
 
+# Repair set alternative in case above zypper install
+# broke the symlink.
+RUN update-alternatives --auto gcc
+
 # Add CUDA bin directory to the path
 ENV PATH=/usr/local/cuda/bin:${PATH}

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 ARG UBUNTU_CODENAME=noble
-FROM ubuntu:${UBUNTU_CODENAME}
+FROM ubuntu:${UBUNTU_CODENAME} AS base
 LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 ARG UBUNTU_CODENAME
 ARG UBUNTU_MAJOR_VERSION=24
@@ -62,10 +62,26 @@ RUN cat <<EOF > /etc/ld.so.conf.d/rocm.conf
 EOF
 RUN ldconfig
 
+# Add ROCm bin directory to the path
+ENV PATH=/opt/rocm/bin:${PATH}
+
+# Environment Build Arg for ROCm
+ENV ROCM_VERSION="${ROCM_VERSION}"
+
+# AIS Code Repository Mount Point
+VOLUME /mnt/ais
+
+# Generic Mount point for container to access AIS-capable storage.
+VOLUME /mnt/ais-fs
+
+# ---- Stage 2: NVIDIA (extends base with CUDA SDK) ----
+# The HIP runtime must be present to use hipFile with NVIDIA GPUs,
+# which is why this stage inherits from base rather than a bare CUDA image.
+FROM base AS nvidia
+ARG UBUNTU_MAJOR_VERSION=24
+ARG UBUNTU_MINOR_VERSION=04
+
 # Install a minimal CUDA SDK
-# HIP depends on the ROCm libraries being installed.
-# This means we are unable to have a separate CUDA+HIP image
-# without ROCm.
 RUN curl https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_MAJOR_VERSION}${UBUNTU_MINOR_VERSION}/x86_64/cuda-keyring_1.1-1_all.deb \
     -o cuda-repo-install.deb
 RUN apt install ./cuda-repo-install.deb
@@ -77,14 +93,5 @@ RUN apt update && \
     libcufile-dev-12-9 \
     libnvidia-compute-570-server
 
-# Add ROCm and CUDA bin directories to the path
-ENV PATH=/usr/local/cuda/bin:/opt/rocm/bin:${PATH}
-
-# Environment Build Arg for ROCm
-ENV ROCM_VERSION="${ROCM_VERSION}"
-
-# AIS Code Repository Mount Point
-VOLUME /mnt/ais
-
-# Generic Mount point for container to access AIS-capable storage.
-VOLUME /mnt/ais-fs
+# Add CUDA bin directory to the path
+ENV PATH=/usr/local/cuda/bin:${PATH}


### PR DESCRIPTION
## Motivation

Separate NVIDIA (CUDA SDK, drivers) dependencies from the base CI Docker images. Currently, all CI jobs — including AMD builds, Python bindings, and system tests — pull a single image that bundles both ROCm and NVIDIA packages. The NVIDIA packages are only needed by the hipfile-build-nvidia workflow, so this adds unnecessary bloat to the majority of CI jobs.

## Technical Details

Converts the 3 platform Dockerfiles into multi-stage builds with a base stage (ROCm + dev tools) and a nvidia stage (FROM base + CUDA SDK + drivers). The base image retains its current tag naming (no suffix); the nvidia variant gets a -nvidia suffix.

| Image | ID | Disk Usage |
|---|---|---|
| ais_ci_rocky:latest | 657f480ad6ea | 4.74GB |
| ais_ci_rocky:latest-nvidia | 0210140536c8 | 5.74GB |
| ais_ci_suse:latest | 893ba87305bd | 4.39GB |
| ais_ci_suse:latest-nvidia | 5052618c21e6 | 5.64GB |
| ais_ci_ubuntu:latest | 6a0f61de517f | 10.3GB |
| ais_ci_ubuntu:latest-nvidia | c3c4039c9ab5 | 11.2GB |

So in essence it cuts about 1GB of data out of the ROCm only image.

## Test Plan

As determined by CI passing, as well as certain CI workflows passing after a PR has been merged.
(May try to get CI to run in a fork first.)

## Test Result

PR CI passing on a fork: https://github.com/riley-dixon/rocm-systems/actions/runs/25580684674?pr=2
Merged PR CI passing on a fork:  https://github.com/riley-dixon/rocm-systems/actions/runs/25581307976
Updating Image via dispatch trigger on a fork: https://github.com/riley-dixon/rocm-systems/actions/runs/25581750514

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
