### PR TITLE
[rocprofiler-sdk][CI] skip counter tests with incompatible firmware version

### DIFF
--- a/.github/workflows/rocprofiler-sdk-code_coverage.yml
+++ b/.github/workflows/rocprofiler-sdk-code_coverage.yml
@@ -219,6 +219,24 @@ jobs:
         ccache-key: ccache-${{ matrix.system.os }}-${{ matrix.system.runner }}-${{ matrix.system.gpu }}
         ccache-variant: ccache
 
+    - name: Check GPU Firmware
+      shell: bash
+      run: |
+        ROCPROFV3="${{ env.ROCM_PATH }}/bin/rocprofv3"
+        if [ -x "$ROCPROFV3" ]; then
+          fw_warnings=$("$ROCPROFV3" --list-avail 2>&1 >/dev/null | grep "below minimum required version" || true)
+          if [ -n "$fw_warnings" ]; then
+            echo "$fw_warnings" | while IFS= read -r line; do
+              echo "::warning::$line"
+            done
+            echo "::notice::Some tests may fail or be skipped. Please update GPU firmware on this runner."
+          else
+            echo "GPU firmware check passed: all agents meet minimum requirements"
+          fi
+        else
+          echo "GPU firmware check skipped: rocprofv3 not found at $ROCPROFV3"
+        fi
+
     - name: Configure, Build, and Test (Total Code Coverage)
       timeout-minutes: 30
       shell: bash

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -200,6 +200,24 @@ jobs:
           ccache-key: ccache-${{ matrix.system.os }}-${{ matrix.system.runner }}-${{ matrix.system.gpu }}
           ccache-variant: ccache
 
+      - name: Check GPU Firmware
+        shell: bash
+        run: |
+          ROCPROFV3="${{ env.ROCM_PATH }}/bin/rocprofv3"
+          if [ -x "$ROCPROFV3" ]; then
+            fw_warnings=$("$ROCPROFV3" --list-avail 2>&1 >/dev/null | grep "below minimum required version" || true)
+            if [ -n "$fw_warnings" ]; then
+              echo "$fw_warnings" | while IFS= read -r line; do
+                echo "::warning::$line"
+              done
+              echo "::notice::Some tests may fail or be skipped. Please update GPU firmware on this runner."
+            else
+              echo "GPU firmware check passed: all agents meet minimum requirements"
+            fi
+          else
+            echo "GPU firmware check skipped: rocprofv3 not found at $ROCPROFV3"
+          fi
+
       - name: Enable PC Sampling
         if: ${{ contains(matrix.system.gpu, 'mi200') || contains(matrix.system.gpu, 'mi300a') }}
         shell: bash
@@ -412,6 +430,24 @@ jobs:
           ccache-key: ccache-${{ matrix.system.os }}-${{ matrix.system.runner }}-${{ matrix.system.gpu }}
           ccache-variant: sccache
 
+      - name: Check GPU Firmware
+        shell: bash
+        run: |
+          ROCPROFV3="${{ env.ROCM_PATH }}/bin/rocprofv3"
+          if [ -x "$ROCPROFV3" ]; then
+            fw_warnings=$("$ROCPROFV3" --list-avail 2>&1 >/dev/null | grep "below minimum required version" || true)
+            if [ -n "$fw_warnings" ]; then
+              echo "$fw_warnings" | while IFS= read -r line; do
+                echo "::warning::$line"
+              done
+              echo "::notice::Some tests may fail or be skipped. Please update GPU firmware on this runner."
+            else
+              echo "GPU firmware check passed: all agents meet minimum requirements"
+            fi
+          else
+            echo "GPU firmware check skipped: rocprofv3 not found at $ROCPROFV3"
+          fi
+
       - name: Enable PC Sampling
         if: ${{ contains(matrix.system.gpu, 'mi200') || contains(matrix.system.gpu, 'mi300a') }}
         shell: bash
@@ -558,6 +594,24 @@ jobs:
         install-nightly-rocm: ${{ env.INSTALL_NIGHTLY_ROCM }}
         ccache-key: ccache-${{ matrix.system.os }}-${{ matrix.system.runner }}-${{ matrix.system.gpu }}-${{ matrix.system.sanitizer}}
         ccache-variant: ccache
+
+    - name: Check GPU Firmware
+      shell: bash
+      run: |
+        ROCPROFV3="${{ env.ROCM_PATH }}/bin/rocprofv3"
+        if [ -x "$ROCPROFV3" ]; then
+          fw_warnings=$("$ROCPROFV3" --list-avail 2>&1 >/dev/null | grep "below minimum required version" || true)
+          if [ -n "$fw_warnings" ]; then
+            echo "$fw_warnings" | while IFS= read -r line; do
+              echo "::warning::$line"
+            done
+            echo "::notice::Some tests may fail or be skipped. Please update GPU firmware on this runner."
+          else
+            echo "GPU firmware check passed: all agents meet minimum requirements"
+          fi
+        else
+          echo "GPU firmware check skipped: rocprofv3 not found at $ROCPROFV3"
+        fi
 
     - name: Configure, Build, and Test
       timeout-minutes: 45

--- a/projects/rocprofiler-sdk/tests/common/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/common/CMakeLists.txt
@@ -12,6 +12,10 @@ set(ROCPROFILER_DEFAULT_FAIL_REGEX
     "threw an exception|Permission denied|Could not create logging file|failed with error code|Subprocess aborted"
     CACHE INTERNAL "Default FAIL_REGULAR_EXPRESSION for tests")
 
+set(ROCPROFILER_DEFAULT_SKIP_REGEX
+    "firmware version.*below minimum required version"
+    CACHE INTERNAL "Default SKIP_REGULAR_EXPRESSION for tests")
+
 set(DEFAULT_GPU_TARGETS
     "gfx900"
     "gfx906"
@@ -257,6 +261,7 @@ function(rocprofiler_add_integration_execute_test NAME)
 
     # provide default
     set_arg_if_empty(arg_FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+    set_arg_if_empty(arg_SKIP_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_SKIP_REGEX}")
     set_arg_if_empty(arg_TIMEOUT 60)
     set_arg_if_empty(arg_FIXTURES_SETUP ${NAME})
 
@@ -438,6 +443,7 @@ function(rocprofiler_add_integration_validate_test NAME)
 
     # provide default
     set_arg_if_empty(arg_FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+    set_arg_if_empty(arg_SKIP_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_SKIP_REGEX}")
     set_arg_if_empty(arg_WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     set_arg_if_empty(arg_TIMEOUT 60)
     set_arg_if_empty(arg_FIXTURES_REQUIRED ${NAME})


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Skip tests when CI has older firmware version. Currently causing [some jobs](https://github.com/ROCm/rocm-systems/actions/runs/25521633366/job/74906876833?pr=5533) to fail. 

```
W0507 21:18:30.871619   61181 firmware_restrictions.cpp:218] Agent 2 (gfx942) has CP firmware version 185 which is below minimum required version 186. 
Reason: CP firmware below version 186 can cause device resets and VM Page Faults on MI3XX devices.
```

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
