### PR TITLE
[rocprofiler-sdk] Add query agent support in aqlprofile

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/aql_profile_v2.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/aql_profile_v2.h
@@ -656,7 +656,8 @@ typedef struct
 typedef enum
 {
     AQLPROFILE_SPM_PARAMETER_TYPE_BUFFER_SIZE = 0,
-    AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL,
+    AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL,  ///< Sample interval in clock cycles.
+                                                    ///< Must be a multiple of 32.
     AQLPROFILE_SPM_PARAMETER_TYPE_TIMEOUT,
     AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_MODE,
     AQLPROFILE_SPM_PARAMETER_TYPE_LAST,
@@ -673,6 +674,20 @@ typedef struct
     aqlprofile_spm_parameter_type_t type;
     uint64_t                        value;
 } aqlprofile_spm_parameter_t;
+
+typedef struct aqlprofile_spm_available_configuration_t
+{
+    aqlprofile_spm_parameter_type_t type;
+    union
+    {
+        struct
+        {
+            uint64_t                                 min_interval;
+            uint64_t                                 max_interval;
+            aqlprofile_spm_parameter_interval_mode_t mode;
+        } interval;  // interval in cycles
+    };
+} aqlprofile_spm_available_configuration_t;
 
 /**
  * @brief AQLprofile struct containing information for SPM counter events
@@ -811,6 +826,36 @@ aqlprofile_spm_decode_query(aqlprofile_spm_buffer_desc_t  desc,
 bool
 aqlprofile_spm_is_event_supported(aqlprofile_agent_handle_t agent, aqlprofile_pmc_event_t event);
 
+/**
+ * @brief Callback that provides the available SPM configurations for an agent.
+ *        The config array is only valid for the duration of the callback and
+ *        should not be freed or stored beyond the callback's return.
+ *
+ * @param[in] config     Array of available SPM configurations
+ * @param[in] num_config Number of configurations in the array
+ * @param[in] user_data  User data supplied by ::aqlprofile_spm_query_agent_configurations
+ */
+typedef hsa_status_t (*aqlprofile_spm_available_configurations_cb_t)(
+    const aqlprofile_spm_available_configuration_t* config,
+    size_t                                          num_config,
+    void*                                           user_data);
+
+/**
+ * @brief Query supported SPM configurations for a given agent.
+ *        Supported configurations (e.g. sample interval ranges) are returned
+ *        via the provided callback.
+ *
+ * @param[in] agent    Agent handle to query configurations for
+ * @param[in] cb       Callback in which configurations are returned
+ * @param[in] userdata User data passed back to the callback
+ * @retval HSA_STATUS_SUCCESS                if configurations were successfully queried
+ * @retval HSA_STATUS_ERROR_INVALID_ARGUMENT if cb is NULL
+ * @retval HSA_STATUS_ERROR_INVALID_AGENT    if agent is not found or does not support SPM
+ */
+hsa_status_t
+aqlprofile_spm_query_agent_configurations(aqlprofile_agent_handle_t                    agent,
+                                          aqlprofile_spm_available_configurations_cb_t cb,
+                                          void*                                        userdata);
 #ifdef __cplusplus
 }
 #endif

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
@@ -201,7 +201,7 @@ is_agent_supported_for_spm(const AgentInfo* agentInfo)
 std::vector<aqlprofile_spm_parameter_t> default_spm_params = {
     {AQLPROFILE_SPM_PARAMETER_TYPE_BUFFER_SIZE, 1 << 26},      // 64MB
     {AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL, 1 << 13},  // 4us
-    {AQLPROFILE_SPM_PARAMETER_TYPE_TIMEOUT, 100},              // 100ms
+    {AQLPROFILE_SPM_PARAMETER_TYPE_TIMEOUT, 0},                // 0ms
     {AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_MODE, AQLPROFILE_SPM_PARAMETER_SAMPLE_MODE_SCLK}};
 static_assert(AQLPROFILE_SPM_PARAMETER_TYPE_LAST == 4 && "Dont forget to add default param!");
 
@@ -633,4 +633,37 @@ aqlprofile_spm_is_event_supported(aqlprofile_agent_handle_t agent, aqlprofile_pm
     if(event.block_name >= blocks.size()) return false;
 
     return blocks.at(event.block_name);
+}
+
+PUBLIC_API hsa_status_t
+aqlprofile_spm_query_agent_configurations(aqlprofile_agent_handle_t                    agent,
+                                          aqlprofile_spm_available_configurations_cb_t cb,
+                                          void*                                        userdata)
+{
+    if(!cb) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+    aql_profile::Pm4Factory* pm4_factory = nullptr;
+    try
+    {
+        pm4_factory = aql_profile::Pm4Factory::Create(agent);
+        if(!pm4_factory) return HSA_STATUS_ERROR_INVALID_AGENT;
+    } catch(...)
+    {
+        return HSA_STATUS_ERROR_INVALID_AGENT;
+    }
+
+    if(!aqlprofile::spm::is_agent_supported_for_spm(aql_profile::GetAgentInfo(agent)))
+        return HSA_STATUS_ERROR_INVALID_AGENT;
+
+    auto configs = std::vector<aqlprofile_spm_available_configuration_t>{};
+
+    auto& interval_config = configs.emplace_back();
+    interval_config.type  = AQLPROFILE_SPM_PARAMETER_TYPE_SAMPLE_INTERVAL;
+    interval_config.interval.min_interval =
+        32;  // Sample interval time in sclks. Minimum is 32 clocks by HW design
+    interval_config.interval.max_interval =
+        (1 << 16) - 32;  // Maximum value by HW design. Must be multiples of 32.
+    interval_config.interval.mode = AQLPROFILE_SPM_PARAMETER_SAMPLE_MODE_SCLK;
+
+    return cb(configs.data(), configs.size(), userdata);
 }

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/tests/aql_profile_v2_c_test.c
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/tests/aql_profile_v2_c_test.c
@@ -13,8 +13,17 @@ aql_profile_v2_c_compatibility_test(void)
     aqlprofile_spm_parameter_t     parameter = {AQLPROFILE_SPM_PARAMETER_TYPE_BUFFER_SIZE, 0};
     aqlprofile_spm_decode_query_t  query     = AQLPROFILE_SPM_DECODE_QUERY_LAST;
 
+    aqlprofile_spm_available_configuration_t     spm_config = {0};
+    aqlprofile_spm_available_configurations_cb_t spm_cb     = NULL;
+    typedef hsa_status_t (*spm_query_fn_t)(
+        aqlprofile_agent_handle_t, aqlprofile_spm_available_configurations_cb_t, void*);
+    spm_query_fn_t spm_query_fn = &aqlprofile_spm_query_agent_configurations;
+
     (void) status;
     (void) parameter;
     (void) query;
+    (void) spm_config;
+    (void) spm_cb;
+    (void) spm_query_fn;
     return 0;
 }

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/tests/aql_profile_v2_tests.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/tests/aql_profile_v2_tests.cpp
@@ -623,4 +623,33 @@ int         AqlProfileV2ApiTest::callback_call_count_ = 0;
 int         AqlProfileV2ApiTest::last_callback_id_    = -1;
 std::string AqlProfileV2ApiTest::last_callback_name_  = "";
 
+TEST_F(AqlProfileV2ApiTest, SpmQueryAgentConfigurations_NullCallback)
+{
+    aqlprofile_agent_info_v1_t info{};
+    info.agent_gfxip          = "gfx900";
+    info.xcc_num              = 1;
+    info.se_num               = 4;
+    info.cu_num               = 64;
+    info.shader_arrays_per_se = 2;
+    info.domain               = 0;
+    info.location_id          = 0x1234;
+    auto agent                = aql_profile::RegisterAgent(&info);
+
+    EXPECT_EQ(aqlprofile_spm_query_agent_configurations(agent, nullptr, nullptr),
+              HSA_STATUS_ERROR_INVALID_ARGUMENT);
+}
+
+TEST_F(AqlProfileV2ApiTest, SpmQueryAgentConfigurations_InvalidAgent)
+{
+    aqlprofile_agent_handle_t agent{};
+    agent.handle = 99999;
+
+    aqlprofile_spm_available_configurations_cb_t cb =
+        [](const aqlprofile_spm_available_configuration_t*, size_t, void*) -> hsa_status_t {
+        return HSA_STATUS_SUCCESS;
+    };
+
+    EXPECT_EQ(aqlprofile_spm_query_agent_configurations(agent, cb, nullptr),
+              HSA_STATUS_ERROR_INVALID_AGENT);
+}
 }  // namespace aql_profile_v2_tests


### PR DESCRIPTION
## Motivation

Add query agent support

## Technical Details

Adds a new API aqlprofile_spm_query_agent_configurations that allows querying supported SPM sampling       
  configurations (interval range and mode) for a given GPU agent

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
