### PR TITLE
[RCCL] Add net-ib branch-coverage stress tests

### DIFF
--- a/projects/rccl/.claude/skills/feature-unit-testing/SKILL.md
+++ b/projects/rccl/.claude/skills/feature-unit-testing/SKILL.md
@@ -69,17 +69,19 @@ calculate the realistic branch ceiling for your cluster before committing to thi
 
 ---
 
-## Test Plan as Feature Contract
+## Domain 1: Requirements & Planning
 
-Write the plan **before** implementation. It must answer:
-- What scenarios are covered, what are explicitly out of scope
-- Which edge cases and error paths are targeted
-- Hardware dependencies (RoCE vs IB, GDR, AINIC, QP count, cluster)
-- Which coverage tier is the merge bar
+Before writing any test code, create a test plan that defines:
+
+1. **Feature scope** — which internal API surface is being tested, what is explicitly out of scope
+2. **Scenario inventory** — happy path, error paths, edge cases, concurrency patterns
+3. **Hardware scope** — which NIC model, how many ports, GDR/DMA-buf availability, single-node
+   vs cross-host. Discovering that a test requires unavailable hardware after writing it wastes effort.
+4. **Coverage tier** — agree on a branch coverage target (Basic/Standard/Thorough/Critical) as
+   the merge acceptance criterion. This is the "red" phase in TDD: the bar is set before code exists.
 
 The plan becomes the PR description's Test Plan section — reviewable alongside code.
-Hardware scope assessment at planning time prevents discovering a test requires
-unavailable hardware only after it is written.
+It is a planning artifact — do not commit it as a file; keep it in the PR body.
 
 ---
 
@@ -164,6 +166,35 @@ EXPECT_EQ(PostRecv(…), ncclSuccess);
 // …
 MPI_Barrier(MPI_COMM_WORLD);  // unconditional — always reached
 ```
+
+**Timeout in poll loops (never spin forever):**
+```cpp
+// Poll loops that wait for async completion MUST have a timeout.
+// An infinite loop masks the real bug (e.g. unroutable NIC) as "test hung".
+auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+while (!comm && std::chrono::steady_clock::now() < deadline) {
+    ncclResult_t r = AcceptConnection(listenComm, &comm);
+    if (r != ncclSuccess) break;
+}
+if (!comm) { /* handle timeout — GTEST_SKIP or fail with diagnostic */ }
+```
+Track the return value of each poll iteration separately from the NULL-comm check.
+A loop that only checks `!comm` cannot distinguish "still in progress" from "API returned
+an error 10 iterations ago and will never succeed".
+
+**GTEST_SKIP() synchronization across ranks:**
+```cpp
+// When one rank detects a condition requiring SKIP (e.g. QP connect failed),
+// it MUST broadcast this to all ranks BEFORE calling GTEST_SKIP().
+// GTEST_SKIP() does a return — if rank 0 returns, rank 1 hangs on MPI_Recv.
+int skipFlag = (connectFailed ? 1 : 0);
+MPI_Allreduce(MPI_IN_PLACE, &skipFlag, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+if (skipFlag) {
+    GTEST_SKIP() << "QP connect failed on at least one rank";
+}
+```
+Without the Allreduce, a unilateral `GTEST_SKIP()` in one rank leaves the other
+rank blocked forever at its next MPI call or poll loop.
 
 ---
 
@@ -252,13 +283,13 @@ A branch is covered only when **both sides** of a conditional have been exercise
 if (result != ncclSuccess) goto fail;   // ← "fail" branch: count = 0
 ```
 
-**Real numbers from net_ib.cc** (same binary, same test run):
+**Example from net_ib.cc** (single MI300x node, Mellanox CX-7 — numbers will differ on other hardware):
 
 ```
 Metric          Before stress tests    After 14 stress tests
 ────────────────────────────────────────────────────────────
-Line coverage       71.7%                  71.9%   Δ +0.2 pp
-Branch coverage     40.6%                  41.6%   Δ +1.0 pp
+Line coverage       ~72%                   ~72%    Δ +0.2 pp
+Branch coverage     ~41%                   ~42%    Δ +1.0 pp
 ```
 
 Line coverage looks healthy at 71%. Branch coverage at 40% reveals that roughly
@@ -294,19 +325,9 @@ BRDA:1234,0,1,0  ← block 0, branch 1: taken 0 times ← THIS IS THE GAP
 A line with `DA` count > 0 but a `BRDA` count of 0 on one arm is the exact pattern
 of "line covered, branch not covered" — the most common source of false confidence.
 
-**Agreement on branch coverage tier at planning time** (not line coverage):
-
-| Tier | Branch coverage | Notes |
-|------|:--------------:|-------|
-| Basic | ≥ 35% | Minimal — only happy path exercised |
-| Standard | ≥ 50% | Main error paths and env-var configs covered |
-| Thorough | ≥ 65% | Fault injection required to proceed further |
-| Critical | ≥ 80% | Reserved for safety-critical subsystems |
-
-Branch coverage ceilings are lower than line ceilings. ~155 branches in
-`ncclIbConnect`/`ncclIbAccept` state machine require cross-host runs; ~25 require GDR
-hardware. Establish a **realistic ceiling** (branches reachable on your hardware) before
-setting a target — otherwise the target is unachievable by design.
+Agree on a branch coverage tier at planning time (see *Coverage Acceptance Tiers* above).
+Branch coverage ceilings are hardware-dependent — establish a **realistic ceiling**
+(branches reachable on your hardware) before setting a target.
 
 ---
 
@@ -366,23 +387,46 @@ Classify every uncovered branch before deciding whether to test it:
 **Ceiling calculation:** count only Trivial + Structural (with infra) + Fault injection.
 Never include Dead branches in projected delta.
 
-**What moves coverage in net_ib.cc (measured):**
+**What moves coverage in net_ib.cc (measured on one cluster — verify on yours):**
 - Multi-QP split (`NCCL_IB_SPLIT_DATA_ON_QPS=1`) — split alignment branches, QP distribution
 - MR cache stress (many `regMr`/`deregMr` cycles) — binary-search insert/expand/deref
 - Shuffled multi-recv (`PostRecv(n=8)` + non-FIFO send order) — FIFO slot scan for r > 0
 
-**Structural ceiling without special infra (~155 branches):** `ncclIbConnect`/`ncclIbAccept`
-state machine — only reachable when `ncclSocketConnect` returns before socket ready.
-On loopback this never happens. Requires cross-host (`srun -N 2`) or `tc qdisc netem`.
+**Structural ceiling without special infra:** `ncclIbConnect`/`ncclIbAccept`
+state machine branches — only reachable when `ncclSocketConnect` returns before socket
+ready. On loopback this never happens. Requires cross-host (`srun -N 2`) or `tc qdisc netem`.
+The exact count depends on the source version; use BRDA analysis to find these in your build.
 
 ---
 
 ## Hardware Capability Gating
 
+**Env-var gating:**
 ```cpp
 // Graceful SKIP (not FAIL) when hardware feature absent
 if (!getenv("NCCL_IB_GDR_LEVEL") || atoi(getenv("NCCL_IB_GDR_LEVEL")) == 0)
     GTEST_SKIP() << "GDR not enabled on this node";
+```
+
+**Network topology gating (routable GID check):**
+
+A NIC with only link-local GIDs (`fe80::`) or all-zero GIDs will pass `ibv_modify_qp`
+INIT→RTR without error — RoCE QP setup does not validate routing. But RDMA packets
+are silently dropped cross-node: no CQE, no error, just a timeout. This is a common
+source of "recv timed out" failures that look like bugs but are hardware topology.
+
+Gate on routable GIDs by reading `/sys/class/infiniband/<dev>/ports/1/gids`:
+```cpp
+// Check that the NIC has at least one routable GID (IPv4-mapped or global IPv6).
+// Skip test if the NIC can set up QPs but cannot actually deliver RDMA traffic.
+static bool HasRoutableGid(const char* devName) {
+    // Read /sys/class/infiniband/<devName>/ports/1/gids/<index>
+    // A GID is routable if it is NOT all-zero and NOT fe80:: (link-local).
+    // IPv4-mapped: 0000:0000:0000:0000:0000:ffff:xxxx:xxxx — routable.
+    ...
+}
+if (!HasRoutableGid(props.name))
+    GTEST_SKIP() << devName << " has no routable GID (link-local only)";
 ```
 
 Makes the same test suite portable across clusters. Hardware-specific gaps are
@@ -409,23 +453,32 @@ expected error codes. AI's highest value is at requirements and gap-analysis pha
 
 ## MPI + SLURM Execution (this codebase)
 
+MPI/SLURM flags are **cluster-specific** — interface names, MCA parameters, GPU resource
+requests, and HPC-X paths differ across environments. The example below is a template;
+adapt to your cluster.
+
+**Reference scripts** (actual working configurations):
+- `test/transport/NetIbMPI/configs/` — runner configs per cluster/NIC combination
+- Build & test runner scripts used during development (check `~/run_*.sh` on the node)
+
 ```bash
-srun --nodelist=<NODE> --gres=gpu:<N> \
-  mpirun -np <N> --oversubscribe \
-  --mca plm_rsh_agent srun \
-  --mca oob_tcp_if_include eno8303 \
-  --mca btl_tcp_if_include eno8303 \
-  --mca btl ^openib \
+# Template — adapt interface, MCA, and path values to your cluster
+sbatch --nodes=2 --ntasks-per-node=1 --exclusive --time=00:10:00 \
+  --wrap='mpirun -np 2 --host "$NODE1,$NODE2" \
+  --mca pml ob1 --mca btl tcp,self --mca btl_tcp_if_include <IFACE> \
+  --mca coll_hcoll_enable 0 --mca coll_ucc_enable 0 \
   --bind-to none \
-  -x LLVM_PROFILE_FILE=/path/to/%p.profraw \
   -x LD_LIBRARY_PATH=<build>:/opt/rocm/lib \
-  <build>/test/rccl-UnitTestsMPI --gtest_filter='NetIbMPITest.X'
+  -x LLVM_PROFILE_FILE=/path/to/%p.profraw \
+  <build>/test/rccl-UnitTestsMPI --gtest_filter="NetIbMPITest.X"'
 ```
 
-- `--gres=gpu:N` **required** — without it `/dev/kfd` absent, HIP fails, tests report SKIPPED
+- Interface name (`<IFACE>`) varies: `eth0`, `eno8303`, etc. — check `ip link` on the node
+- `--gres=gpu:N` is required only for tests that use GPU/HIP; net-ib MPI transport tests
+  do not need it — they test the IB verbs layer directly
 - `%p` in `LLVM_PROFILE_FILE` → one `.profraw` per MPI rank
-- `--mca plm_rsh_agent srun` replaces SSH for process launch on SLURM nodes
-- `--mca btl ^openib` disables legacy OpenMPI IB verbs (use TCP for MPI control plane)
+- `--mca pml ob1 --mca btl tcp,self` — use TCP for MPI control plane, not IB verbs
+- HPC-X paths (`OPAL_PREFIX`, `LD_PRELOAD` for UCX) depend on the installed version
 
 ### Background builds and cron monitoring
 
@@ -436,12 +489,14 @@ Then set a `CronCreate` job to poll for completion.
 ```bash
 # 1. Submit build as sbatch, output to NFS log
 BUILDLOG=<build_dir>/build_$(date +%Y%m%d_%H%M%S).log
-sbatch --nodelist=<NODE> --gres=gpu:1 --cpus-per-task=64 \
+sbatch --nodelist=<NODE> --cpus-per-task=64 \
   --output="$BUILDLOG" \
   --wrap='cd <build_dir> && cmake --build . --target rccl-UnitTestsMPI -- -j64'
 # → prints "Submitted batch job <JOBID>"
+```
 
-# 2. Create cron to monitor (every 2 min)
+Then create a Claude `CronCreate` tool call (not a shell command) to monitor:
+```
 CronCreate(
   cron="*/2 * * * *",
   prompt="Check job <JOBID>: run squeue --me. If gone, read last 30 lines of $BUILDLOG
@@ -449,9 +504,9 @@ CronCreate(
           'still building, N min elapsed' silently.",
   recurring=true
 )
-
-# 3. When done, CronDelete the monitoring job
 ```
+
+When the job completes, `CronDelete` the monitoring job.
 
 **Always specify `-j64` (or `-- -j64` after `cmake --build`)** — SLURM allocates 1 CPU by
 default; without `--cpus-per-task=64` and `-j64`, `$(nproc)` returns 1 and the build
@@ -459,9 +514,10 @@ serialises. The `-- -j64` form passes the flag through cmake to the underlying m
 
 **Same pattern for test runs** — any `mpirun`/`srun` that takes > 30 s:
 ```bash
-sbatch --nodelist=<NODE> --gres=gpu:<N> --cpus-per-task=8 \
+sbatch --nodes=2 --ntasks-per-node=1 --exclusive --time=00:10:00 \
   --output=<logfile> \
-  --wrap='mpirun -np <N> ... rccl-UnitTestsMPI --gtest_filter=...'
+  --wrap='mpirun -np 2 ... rccl-UnitTestsMPI --gtest_filter=...'
+# Add --gres=gpu:<N> only for GPU-using tests.
 ```
 
 ---
@@ -473,13 +529,14 @@ sbatch --nodelist=<NODE> --gres=gpu:<N> --cpus-per-task=8 \
 | Assume branch uncovered without reading BRDA | Write redundant test | Check `count` in lcov first |
 | `ASSERT_NE(req, nullptr)` after `isend` | Spurious failures | Use retry loop; NULL is normal |
 | `ASSERT_` before `MPI_Barrier` in multi-rank helper | Deadlock on failure | `EXPECT_` + unconditional barrier |
-| Forget `--gres=gpu:N` in srun | All tests SKIPPED silently | Always include GPU resource request |
+| Forget `--gres=gpu:N` in srun (GPU tests) | GPU tests SKIPPED silently | Include GPU resource request for HIP-using tests; net-ib MPI tests don't need it |
 | Mix profraws from different builds | Corrupt coverage data | One build dir per coverage run |
 | Wrong binary path in srun/mpirun | "No such file" on remote node | Binary is in `build/test/`, not `build/`; NFS not mounted on all nodes |
 | `llvm-profdata` version mismatch | "unsupported profile format" | Use `/opt/rocm-X.Y.Z/lib/llvm/bin/llvm-profdata` matching the compiler |
 | Run tests expecting to cover already-covered paths | +0 delta, wasted effort | Check BRDA count field before writing — if >0, path is already covered |
 | Count structural/dead branches in projected delta | Overestimate ceiling | Classify before projecting |
 | Read line number without source context | Wrong technique chosen | Always read ±10 lines |
+| `GTEST_SKIP()` in one rank without MPI sync | Other rank hangs at next barrier/recv | `MPI_Allreduce` a skip flag across all ranks before any `GTEST_SKIP()` |
 | Write tests before test plan | No merge criterion | Plan first, including hardware scope |
 
 ---
@@ -504,44 +561,55 @@ sbatch --nodelist=<NODE> --gres=gpu:<N> --cpus-per-task=8 \
 
 Updated after each testing iteration. Add new patterns and anti-patterns here as they emerge.
 
-**Current baseline** (2026-05-07, `build_debug_fault_inject`, net_ib.cc, 1821 lcov branches excluding exception pseudobranches):
+**Coverage numbers below are approximate.** Exact values depend on hardware (NIC model,
+number of ports, GDR/DMA-buf support), cluster topology (single-node loopback vs cross-host),
+compiler version (affects branch count — C++ exception pseudobranches inflate the denominator),
+and which env-var combinations were exercised. Re-measure on your hardware; do not treat
+these numbers as universal targets.
 
-| Milestone | Branch | Line | Notes |
-|-----------|-------:|-----:|-------|
-| Before stress tests | 40.6% (740/1821) | 71.7% | 18 GeneralTests |
-| After 14 stress tests | 41.6% (757/1821) | 71.9% | +17 branches |
-| After MultiRecv (standalone) | ~42.5% (774/1821) | — | nreqs>1 path covered: BRDA:2387,0,1,255 |
-| After SendSizeClamping (E2) | 42.5% (773+1=774/1821) | — | BRDA:2544,0,0 — size clamping |
-| After NullCommClose (E3) | 42.6% (776/1821) | 72.7% | BRDA:3064,3084,3114 — NULL comm guards |
-| After SetNetAttrNoOp (E5) | 42.6% (776/1821) | 72.9% | FNDA:2 ncclIbSetNetAttr — 0 branch delta |
-| After NCCL_IB_SL=2 + NCCL_IB_TC=5 | 42.7% (778/1821) | — | BRDA:1716,0,0 + 1717,0,0 |
-| After tc netem delay 200ms (loopback) | 42.8% (780/1821) | — | BRDA:1566,0,0 (SendDevList reentry) |
-| After NCCL_IB_ECE_ENABLE=0 | 42.9% (781/1821) | — | BRDA:1652,0,1 — ECE disabled path |
-| After NCCL_IB_MERGE_VFS=0 | 43.0% (783/1821) | — | BRDA:492,0,1 + 512,0,1 — VFS merge disabled |
-| After RCCL_FORCE_ENABLE_DMABUF=1 | 43.8% (797/1821) | 74.1% | misc init branches |
-| After 4-rank loopback (k13-41 single node) | 43.88% (799/1821) | 74.4% | FanIn/FanOut/AllToAll/Bidirectional/LongRunning |
-| After env-var batch 2 (RELAXED_ORDERING, INLINE, TIMEOUT, FIFO_TC, AR=0, HCA, DISABLE) | **44.54% (811/1821)** | **74.5%** | +14 branches, +8 lines |
+**Approximate baseline progression** (net_ib.cc, ~1800 lcov branches, single MI300x node with Mellanox CX-7):
 
-**Total tests in StressTests.cpp: 27** (14 stress + 13 branch-coverage)
+| Phase | Branch (approx) | Line (approx) | What moved the needle |
+|-------|:---------------:|:--------------:|----------------------|
+| GeneralTests only | ~40% | ~72% | 18 basic functional tests |
+| + 14 stress tests | ~42% | ~72% | Resource churn, multi-connection, bidirectional |
+| + branch-coverage tests | ~43% | ~73% | Targeted BRDA gaps: size clamping, NULL comm, nreqs>1 |
+| + env-var sweeps | ~44–45% | ~74–75% | MERGE_VFS, ECE, SL/TC, DMABUF, RELAXED_ORDERING, etc. |
+| + multi-rank (4-rank loopback) | ~44–45% | ~74–75% | FanIn/FanOut/AllToAll — diminishing returns on loopback |
 
-**Reference files on k13-41:** `~/coverage/dmabuf/with_dmabuf_netib.lcov.info` — current best.
+**Total tests:** ~27 in StressTests.cpp (14 stress + 13 branch-coverage) + GeneralTests.
 
-**Note on denominators**: genhtml `--branch-coverage` shows 1821 (exception pseudobranches excluded); raw lcov export has 1954. Use consistent tool.
+**Note on denominators**: genhtml `--branch-coverage` shows ~1821 branches (exception
+pseudobranches excluded); raw `llvm-cov export` shows ~1954. Use one tool consistently
+within a comparison — mixing denominators makes deltas meaningless.
 
-**Resolved puzzle** (documented 2026-05-07): `BRDA:2387,0,1` (nreqs>1 in `ncclIbMultiSend`) showed 0 in `full_combined.profdata` because that profdata was built from runs that didn't include a proper `MultiRecv` execution. Running `MultiRecv` standalone showed `BRDA:2387,0,1,255`. The branch IS covered — the old profdata was incomplete.
+**Resolved puzzle**: Always verify BRDA counts against a profdata that actually includes the
+relevant test execution. A branch showing `count=0` may just mean the profdata was built
+from an incomplete run — not that the branch is uncovered.
 
-**Coverage ceiling analysis** (1821 total branches, 797 covered):
-- ~30 uncovered: State machine mid-transitions (`ncclIbConnect` L1567,1569,1571; `ncclIbAccept` L1881,1883,1885) — require real cross-host run or `tc netem` on recv path
-- ~100 uncovered: RoCE/GID selection paths (L408-479) — require RoCE hardware  
-- ~50 uncovered: GDR/DMA-buf paths (L2035-2177) — require GDR kernel module
-- ~30 uncovered: WC error / fatal-error paths (L2916,2921,2968) — require LD_PRELOAD shim
-- ~600 uncovered: NCCLCHECK error fallback branches — require injected failures
-- Realistic ceiling without LD_PRELOAD or cross-host or GDR: **~44-45%**
+### Hardware-dependent coverage ceiling
 
-**Env-var technique summary** — run existing tests with these env vars to cover new branches:
-- `NCCL_IB_SL=N NCCL_IB_TC=N` — covers ternary in ncclIbConnect L1715-1716
-- `NCCL_IB_ECE_ENABLE=0` — covers ECE disabled path in connect loop
-- `NCCL_IB_MERGE_VFS=0` — covers VFS merge disabled paths in init
-- `RCCL_FORCE_ENABLE_DMABUF=1` — covers forceDmaBuf branch in accept
-- `sudo tc qdisc add dev lo root netem delay Xms` + remove after — covers SendDevList reentry on loopback
-- Each env-var run should be merged with the existing profdata, not treated as a standalone baseline.
+The coverage ceiling is determined by what hardware and infrastructure are available.
+Most uncovered branches fall into categories that require specific capabilities:
+
+| Category | Approx branches | Requirement |
+|----------|:--------------:|-------------|
+| Connect/Accept state machine mid-transitions | ~30 | Cross-host run or `tc netem` latency injection |
+| RoCE/GID selection paths | ~100 | Multiple RoCE port types or IB fabric |
+| GDR/DMA-buf paths | ~50 | GDR kernel module + GPU direct RDMA support |
+| WC error / fatal-error paths | ~30 | LD_PRELOAD shim to inject bad work completions |
+| NCCLCHECK error fallback branches | ~600 | Systematic fault injection at each call site |
+
+**Realistic ceiling without LD_PRELOAD shims or GDR hardware: ~44–45%.** This is not a
+quality problem — it reflects that ~55% of branches are error/fault/hardware paths that
+cannot be reached without special infrastructure. Establish the ceiling for your specific
+hardware before setting a target; otherwise the target is unachievable by design.
+
+**Env-var technique** — run existing tests with specific env vars to cover additional branches
+without writing new tests:
+- `NCCL_IB_SL=N NCCL_IB_TC=N` — SL/TC configuration branches
+- `NCCL_IB_ECE_ENABLE=0` — ECE disabled path in connect loop
+- `NCCL_IB_MERGE_VFS=0` — VFS merge disabled paths in init
+- `RCCL_FORCE_ENABLE_DMABUF=1` — forceDmaBuf branch in accept
+- `sudo tc qdisc add dev lo root netem delay Xms` — SendDevList reentry on loopback
+- Each env-var run should be merged with the existing profdata, not treated as standalone.

--- a/projects/rccl/.claude/skills/feature-unit-testing/SKILL.md
+++ b/projects/rccl/.claude/skills/feature-unit-testing/SKILL.md
@@ -1,0 +1,547 @@
+---
+name: feature-unit-testing
+description: Use when writing, planning, or improving unit tests for low-level transport or systems code — especially when reasoning about branch coverage, test gaps, identifying which uncovered paths are worth pursuing, or deciding when a feature's test suite is ready to merge.
+---
+
+# Feature-Centric Unit Testing
+
+## Overview
+
+One test = one transport feature. Tests live at the internal API boundary, not at the
+system level (`ncclAllReduce`). This localizes failures immediately: broken test → broken
+feature, no stack archaeology. The suite is the acceptance criterion for every PR.
+
+**Central discipline:** measure coverage first, plan second. Verify assumptions against
+real data before writing a single test.
+
+---
+
+## Feature Testing Lifecycle
+
+```
+Feature spec / integration plan
+         │
+         ▼
+  DOMAIN 1 — Requirements & Planning
+  • Write test plan at spec time (before any code)
+  • Hardware scope: which cluster, NIC model, GDR, AINIC, QP count
+  • Agree on coverage tier as merge acceptance criterion
+         │
+         ▼
+  DOMAIN 2 — Basic Scenarios
+  • Happy path, functional correctness, data integrity
+  • Whitebox: direct internal API calls, scheduler inspection
+  • Typically reaches ~50% line coverage
+         │
+         ▼
+  DOMAIN 3 — Bottleneck & Edge Case Discovery
+  • Fault injection, stress, boundary sizes, concurrent connections
+  • Parametric sweeps, async data mutation, multidirectional patterns
+  • Pushes coverage from 50% toward 70–90%+
+         │
+         ▼
+  ACCEPTANCE — Coverage Measurement
+  • Measure → classify gap → add tests → re-measure
+  • below target ──► identify gap ──► add tests ──► re-measure
+  • at target    ──► merge
+```
+
+**TDD analogy:** test plan = "red" phase written before code exists; Domain 2+3 = "green";
+coverage measurement = objective acceptance signal.
+
+---
+
+## Coverage Acceptance Tiers
+
+Prefer **branch coverage** as the primary merge criterion. Line coverage is a secondary
+signal; function coverage is informational only. See the *Why Branch Coverage* section.
+
+| Tier | Line coverage | Branch coverage | When to target |
+|------|:------------:|:---------------:|----------------|
+| **Basic** | ≥ 50% | ≥ 35% | New feature, first PR — core path exercised |
+| **Standard** | ≥ 70% | ≥ 50% | Feature complete — error paths and main branches covered |
+| **Thorough** | ≥ 90% | ≥ 65% | Stable, high-impact — fault injection required |
+| **Critical** | ≥ 95% | ≥ 80% | Safety-critical: fatal-error handling, data integrity |
+
+**Cost of moving between tiers:** Standard→Thorough (branch) requires fault injection and
+parametric sweeps. Thorough→Critical is expensive — hardware-specific paths and rare races;
+calculate the realistic branch ceiling for your cluster before committing to this tier.
+
+---
+
+## Test Plan as Feature Contract
+
+Write the plan **before** implementation. It must answer:
+- What scenarios are covered, what are explicitly out of scope
+- Which edge cases and error paths are targeted
+- Hardware dependencies (RoCE vs IB, GDR, AINIC, QP count, cluster)
+- Which coverage tier is the merge bar
+
+The plan becomes the PR description's Test Plan section — reviewable alongside code.
+Hardware scope assessment at planning time prevents discovering a test requires
+unavailable hardware only after it is written.
+
+---
+
+## Commit Convention
+
+**One commit per test.** Each test gets its own atomic commit so reviewers can
+evaluate test intent and scope individually, and bisect targets a single test on regression.
+
+**Title format:** `<subsystem>: add <test name> test` (lowercase, no brackets)
+
+```
+net-ib: add test infrastructure (StressTests harness)   ← CMakeLists + base fixture
+net-ib: add InvalidRecvCount test                       ← repeated ×N (test name verbatim)
+net-ib: update feature-unit-testing skill               ← skill update last
+```
+
+**Body (required):** one short paragraph — what the test does, what path it covers, BRDA ref:
+
+```
+Call ncclIbIrecv with n=9 (> NCCL_NET_IB_MAX_RECVS=8). Verifies the early-return
+branch returns ncclInternalError without crashing (net_ib.cc:2731, BRDA:2731,0,1).
+```
+
+**What to NOT commit:**
+- Test plans (`TEST_PLAN.md`) — planning artifact, not part of the test suite
+- Coverage shell scripts (`run_*.sh`, `merge_coverage.sh`) — operational, not source
+- Profraw / profdata files — build artifacts
+
+---
+
+## Domain 2: Basic Scenario Patterns
+
+### Whitebox testing — bypass the public API
+
+Call internal APIs directly. No `ncclCommInit` overhead. Example:
+```cpp
+// Direct internal call — not through ncclAllReduce
+IbCastIsend(sendComm, buf, size, tag, mh, nullptr, &req);
+
+// Read scheduler state directly to verify internal invariants
+ncclIbCastGetSchedState(sendComm, &state);
+EXPECT_GT(state.activeQpTokens[0], 0);
+```
+
+Whitebox lets a test assert that WRR correctly redistributed tokens when one link is
+slow — something a blackbox allreduce test cannot verify.
+
+### Structural patterns (MPI transport tests)
+
+**Double-barrier around every send/recv iteration:**
+```cpp
+// rank 0: post recv  |  rank 1: post send
+MPI_Barrier(MPI_COMM_WORLD);   // after both sides post
+// both: wait for completion
+MPI_Barrier(MPI_COMM_WORLD);   // after both sides complete
+```
+Without the second barrier, one rank reuses request slots before the other finishes.
+
+**Retry loop for NULL send request (FIFO backpressure is normal):**
+```cpp
+do {
+    ASSERT_EQ(net_->isend(sendComm, data, size, tag, mh, nullptr, &req), ncclSuccess);
+    if (req) break;
+    usleep(10000);
+} while (true);
+// Never ASSERT_NE(req, nullptr) immediately after isend.
+```
+
+**RAII guard declaration order:**
+```cpp
+NetConnectionGuard connGuard(net_);          // 1st — connection
+auto bufGuard = makeHostBufferAutoGuard(…);  // 2nd — buffers
+NetMHandleGuard mhGuard(mh, …);             // 3rd — memory registration
+// Destruction runs in reverse: MR deregistered before connection closed.
+```
+
+**Non-fatal checks in multi-rank helpers** (fan-in, fan-out, all-to-all):
+```cpp
+// Use EXPECT_ (non-fatal), not ASSERT_ (fatal), before any MPI_Barrier.
+// A fatal assert in rank 0 leaves all other ranks hanging at the barrier.
+EXPECT_EQ(PostRecv(…), ncclSuccess);
+// …
+MPI_Barrier(MPI_COMM_WORLD);  // unconditional — always reached
+```
+
+---
+
+## Domain 3: Fault Injection
+
+**Deliberately break one component — verify the system response.**
+
+Compile-guarded (`-DENABLE_FAULT_INJECTION=ON`), zero cost in production:
+```cpp
+ncclIbCastFaultSetQpDelay(comm, qpIdx, delayUs);   // artificial latency on one QP
+ncclIbCastFaultSetQpError(comm, qpIdx, true);       // force ncclSystemError
+ncclIbCastFaultClear(comm);                         // reset for recovery test
+```
+
+**Test categories fault injection enables:**
+- Fatal event propagation — all QPs faulted simultaneously
+- Single link failure — one QP faulted, WRR steered away deterministically
+- Scheduler rebalancing — artificial delay → WRR redistributes tokens
+- Data integrity under delay — sends complete correctly despite latency
+- Recovery — fault → clear → fresh connection completes cleanly
+
+**When fault injection is the only option:** `wc.status != IBV_WC_SUCCESS` paths in
+`ncclIbTest`, `fatalErrorCount` threshold branches, async error processing — all show
+zero hits in coverage until a fault injection hook exists.
+
+**Without a compile-time hook:** use LD_PRELOAD to intercept at the dynamic linker level:
+```c
+// libibverbs_mock.so — intercepts ibv_poll_cq, injects bad WC after N calls
+int ibv_poll_cq(struct ibv_cq *cq, int num, struct ibv_wc *wc) {
+    static int calls = 0;
+    if (++calls == INJECT_AT) { wc->status = IBV_WC_REM_ACCESS_ERR; return 1; }
+    return real_ibv_poll_cq(cq, num, wc);
+}
+```
+
+---
+
+## Domain 3: Stress Testing
+
+**Resource leak detection:**
+```
+100 × (listen → connect → transfer → close)
+Assert QP / PD / CQ / MR counts return to baseline after every cycle.
+```
+
+**Transfer size coverage:**
+- Minimum: 1-byte messages — exposes framing bugs invisible at larger sizes
+- Non-powers-of-two: 3, 7, 1023, 4097, 65537 — alignment and boundary conditions
+- Maximum: up to 64 MB — exercises large MR registration and buffer management
+
+**Multidirectional patterns:** allgather, alltoall, hypercube topologies; bidirectional
+simultaneous send/recv on the same connection; many concurrent connections open
+simultaneously (stress QP allocation limits).
+
+**Async data mutation:** mutate the send buffer *after* posting the send. Verifies the
+NIC captured data before mutation — detects use-after-post bugs in buffer registration.
+
+---
+
+## Domain 3: Parametric Configuration Matrix
+
+One test body swept over a grid of env-var combinations:
+```
+WRR on/off × QPS count × split threshold × adaptive routing threshold
+```
+Surfaces interactions between features that per-feature tests miss. Implement with
+`GTEST_SKIP()` when a required env var is absent:
+```cpp
+const char* v = getenv("NCCL_IB_QPS_PER_CONNECTION");
+if (!v) GTEST_SKIP() << "Set NCCL_IB_QPS_PER_CONNECTION to run this test";
+```
+
+---
+
+## Why Branch Coverage, Not Lines or Functions
+
+**Line coverage lies. Branch coverage tells the truth.**
+
+A line is "covered" if it executed at least once — regardless of which path through it was taken.
+A function is "covered" if it was called — regardless of what happened inside.
+A branch is covered only when **both sides** of a conditional have been exercised.
+
+```
+// Line coverage: 100% (line executes in every test)
+// Branch coverage: 50% (error path never taken)
+if (result != ncclSuccess) goto fail;   // ← "fail" branch: count = 0
+```
+
+**Real numbers from net_ib.cc** (same binary, same test run):
+
+```
+Metric          Before stress tests    After 14 stress tests
+────────────────────────────────────────────────────────────
+Line coverage       71.7%                  71.9%   Δ +0.2 pp
+Branch coverage     40.6%                  41.6%   Δ +1.0 pp
+```
+
+Line coverage looks healthy at 71%. Branch coverage at 40% reveals that roughly
+**6 in 10 decision points** are only partially tested. For transport code where the
+uncovered side is usually the error path or the hardware-specific path, this gap
+directly maps to bugs that tests cannot catch.
+
+**Functions coverage is the least informative metric for systems code.** A function
+called once with the happy-path arguments appears fully covered even if it contains
+20 conditional branches that were never exercised.
+
+### Branch coverage in practice
+
+**Use `--branch-coverage` in genhtml:**
+```bash
+genhtml --branch-coverage merged.lcov.info -o html/
+# Without this flag, the HTML report does not show per-branch hit counts.
+```
+
+**lcov vs llvm-cov branch counts differ:**
+- lcov (BRDA parsing): 1821 branches for net_ib.cc
+- `llvm-cov report`: 1954 branches (includes C++ exception pseudo-branches)
+
+Use one tool consistently within a comparison. Mixing denominators makes deltas
+meaningless. lcov/genhtml is preferred for branch-level HTML drill-down.
+
+**Read BRDA lines, not DA lines, when hunting gaps:**
+```
+DA:1234,5        ← line 1234 executed 5 times (line coverage)
+BRDA:1234,0,0,5  ← block 0, branch 0: taken 5 times (covered)
+BRDA:1234,0,1,0  ← block 0, branch 1: taken 0 times ← THIS IS THE GAP
+```
+A line with `DA` count > 0 but a `BRDA` count of 0 on one arm is the exact pattern
+of "line covered, branch not covered" — the most common source of false confidence.
+
+**Agreement on branch coverage tier at planning time** (not line coverage):
+
+| Tier | Branch coverage | Notes |
+|------|:--------------:|-------|
+| Basic | ≥ 35% | Minimal — only happy path exercised |
+| Standard | ≥ 50% | Main error paths and env-var configs covered |
+| Thorough | ≥ 65% | Fault injection required to proceed further |
+| Critical | ≥ 80% | Reserved for safety-critical subsystems |
+
+Branch coverage ceilings are lower than line ceilings. ~155 branches in
+`ncclIbConnect`/`ncclIbAccept` state machine require cross-host runs; ~25 require GDR
+hardware. Establish a **realistic ceiling** (branches reachable on your hardware) before
+setting a target — otherwise the target is unachievable by design.
+
+---
+
+## Coverage Analysis Workflow
+
+> **STOP — mandatory before writing any test to cover a gap:**
+> 1. Export BRDA data and find the exact branch at the target line.
+> 2. Confirm the count field is `0`. If it is `> 0`, the branch is already covered — do not write a test.
+> 3. Read ±10 lines of source context to classify the branch (Trivial / Structural / Hardware / Fault injection / Dead).
+> 4. Only then write or run a test.
+>
+> Skipping this check is the single most common cause of zero-delta test additions.
+
+### 1. Get the raw BRDA data
+
+```bash
+llvm-profdata merge -sparse *.profraw -o merged.profdata
+llvm-cov export -format=lcov -instr-profile=merged.profdata ./binary \
+    -sources src/your_file.cc > merged.lcov.info
+genhtml --branch-coverage merged.lcov.info -o html/
+
+# Extract uncovered branches (count == 0)
+awk -F: '/^SF:.*your_file/{found=1} found && /^BRDA:/ && $NF==0 \
+    {print} /^end_of_record/{found=0}' merged.lcov.info | sort -t: -k2 -n
+```
+
+### 2. Read source context around every uncovered line
+
+Read ±10 lines. A branch at a given line may be a trivial env-var check or a
+hardware-only fault path — the line number tells you nothing without context.
+
+### 3. Verify existing tests before claiming a gap
+
+**Anti-pattern:** "All tests call `PostRecv(n=1)`, so the `nreqs > 1` path is uncovered."
+
+**What actually happened:** `MultiRecv` and `MultiRecvShuffled` already called
+`PostRecv(n=8)` with shuffled tag order, covering the FIFO slot scan for r > 0.
+The BRDA count showed > 0. The assumption was wrong.
+
+**Rule:** Before adding a test to cover branch X, check the BRDA count for that exact
+line in the merged profile. If count > 0, it is already covered.
+
+---
+
+## Branch Classification
+
+Classify every uncovered branch before deciding whether to test it:
+
+| Class | Description | Technique |
+|-------|-------------|-----------|
+| **Trivial** | One env var or API param change | Set `NCCL_IB_X=1`, call with `n=9` |
+| **Structural** | State the harness can't easily create | Cross-host run, `tc qdisc netem delay` |
+| **Hardware** | Needs specific HW (GDR, >1 NIC, non-loopback) | Different node, or `GTEST_SKIP()` |
+| **Fault injection** | Needs a mock/shim returning errors | LD_PRELOAD, compile-time hook |
+| **Dead/unreachable** | Kernel or driver guarantees make it impossible | Document and skip |
+
+**Ceiling calculation:** count only Trivial + Structural (with infra) + Fault injection.
+Never include Dead branches in projected delta.
+
+**What moves coverage in net_ib.cc (measured):**
+- Multi-QP split (`NCCL_IB_SPLIT_DATA_ON_QPS=1`) — split alignment branches, QP distribution
+- MR cache stress (many `regMr`/`deregMr` cycles) — binary-search insert/expand/deref
+- Shuffled multi-recv (`PostRecv(n=8)` + non-FIFO send order) — FIFO slot scan for r > 0
+
+**Structural ceiling without special infra (~155 branches):** `ncclIbConnect`/`ncclIbAccept`
+state machine — only reachable when `ncclSocketConnect` returns before socket ready.
+On loopback this never happens. Requires cross-host (`srun -N 2`) or `tc qdisc netem`.
+
+---
+
+## Hardware Capability Gating
+
+```cpp
+// Graceful SKIP (not FAIL) when hardware feature absent
+if (!getenv("NCCL_IB_GDR_LEVEL") || atoi(getenv("NCCL_IB_GDR_LEVEL")) == 0)
+    GTEST_SKIP() << "GDR not enabled on this node";
+```
+
+Makes the same test suite portable across clusters. Hardware-specific gaps are
+**documented**, not faked. A SKIP that explains its reason is useful; a disabled test
+with no explanation is technical debt.
+
+---
+
+## AI Assistance at Each Phase
+
+| Phase | AI role |
+|-------|---------|
+| Requirements | Identify corner cases from spec; flag hardware dependencies; draft test plan |
+| Domain 2 | Generate test boilerplate, MPI rank structure, buffer helpers |
+| Domain 3 | Propose non-obvious parameter combinations; identify race-prone paths |
+| Gap analysis | Map uncovered functions to test categories; suggest fault injection targets |
+| Iteration | Generate new tests for specific uncovered branches; validate fixes |
+
+**AI proposes, engineer validates** — especially for hardware-specific behaviour and
+expected error codes. AI's highest value is at requirements and gap-analysis phases:
+"what are we missing?" rather than "how do we write this loop?".
+
+---
+
+## MPI + SLURM Execution (this codebase)
+
+```bash
+srun --nodelist=<NODE> --gres=gpu:<N> \
+  mpirun -np <N> --oversubscribe \
+  --mca plm_rsh_agent srun \
+  --mca oob_tcp_if_include eno8303 \
+  --mca btl_tcp_if_include eno8303 \
+  --mca btl ^openib \
+  --bind-to none \
+  -x LLVM_PROFILE_FILE=/path/to/%p.profraw \
+  -x LD_LIBRARY_PATH=<build>:/opt/rocm/lib \
+  <build>/test/rccl-UnitTestsMPI --gtest_filter='NetIbMPITest.X'
+```
+
+- `--gres=gpu:N` **required** — without it `/dev/kfd` absent, HIP fails, tests report SKIPPED
+- `%p` in `LLVM_PROFILE_FILE` → one `.profraw` per MPI rank
+- `--mca plm_rsh_agent srun` replaces SSH for process launch on SLURM nodes
+- `--mca btl ^openib` disables legacy OpenMPI IB verbs (use TCP for MPI control plane)
+
+### Background builds and cron monitoring
+
+Builds and long test runs block the conversation when run in the foreground.
+Use `sbatch` (not `srun`) so the job runs detached and writes output to an NFS log file.
+Then set a `CronCreate` job to poll for completion.
+
+```bash
+# 1. Submit build as sbatch, output to NFS log
+BUILDLOG=<build_dir>/build_$(date +%Y%m%d_%H%M%S).log
+sbatch --nodelist=<NODE> --gres=gpu:1 --cpus-per-task=64 \
+  --output="$BUILDLOG" \
+  --wrap='cd <build_dir> && cmake --build . --target rccl-UnitTestsMPI -- -j64'
+# → prints "Submitted batch job <JOBID>"
+
+# 2. Create cron to monitor (every 2 min)
+CronCreate(
+  cron="*/2 * * * *",
+  prompt="Check job <JOBID>: run squeue --me. If gone, read last 30 lines of $BUILDLOG
+          and report result to user. If still running, tail -3 log for errors and note
+          'still building, N min elapsed' silently.",
+  recurring=true
+)
+
+# 3. When done, CronDelete the monitoring job
+```
+
+**Always specify `-j64` (or `-- -j64` after `cmake --build`)** — SLURM allocates 1 CPU by
+default; without `--cpus-per-task=64` and `-j64`, `$(nproc)` returns 1 and the build
+serialises. The `-- -j64` form passes the flag through cmake to the underlying make/ninja.
+
+**Same pattern for test runs** — any `mpirun`/`srun` that takes > 30 s:
+```bash
+sbatch --nodelist=<NODE> --gres=gpu:<N> --cpus-per-task=8 \
+  --output=<logfile> \
+  --wrap='mpirun -np <N> ... rccl-UnitTestsMPI --gtest_filter=...'
+```
+
+---
+
+## Common Mistakes
+
+| Mistake | Consequence | Fix |
+|---------|-------------|-----|
+| Assume branch uncovered without reading BRDA | Write redundant test | Check `count` in lcov first |
+| `ASSERT_NE(req, nullptr)` after `isend` | Spurious failures | Use retry loop; NULL is normal |
+| `ASSERT_` before `MPI_Barrier` in multi-rank helper | Deadlock on failure | `EXPECT_` + unconditional barrier |
+| Forget `--gres=gpu:N` in srun | All tests SKIPPED silently | Always include GPU resource request |
+| Mix profraws from different builds | Corrupt coverage data | One build dir per coverage run |
+| Wrong binary path in srun/mpirun | "No such file" on remote node | Binary is in `build/test/`, not `build/`; NFS not mounted on all nodes |
+| `llvm-profdata` version mismatch | "unsupported profile format" | Use `/opt/rocm-X.Y.Z/lib/llvm/bin/llvm-profdata` matching the compiler |
+| Run tests expecting to cover already-covered paths | +0 delta, wasted effort | Check BRDA count field before writing — if >0, path is already covered |
+| Count structural/dead branches in projected delta | Overestimate ceiling | Classify before projecting |
+| Read line number without source context | Wrong technique chosen | Always read ±10 lines |
+| Write tests before test plan | No merge criterion | Plan first, including hardware scope |
+
+---
+
+## Key Principles (summary)
+
+| Principle | Applied as |
+|-----------|------------|
+| Feature-centric | One test = one transport feature |
+| Plan first | Written at spec time, part of integration plan |
+| TDD analogy | Coverage tier agreed upfront; measure → iterate until met |
+| Whitebox | Direct internal API + inspect scheduler state |
+| Fault injection | Controlled failures; compile-guarded, zero production cost |
+| Stress | Resource leaks, extreme sizes, concurrent, async mutation |
+| Coverage-driven | Branch coverage primary; tiered acceptance; realistic ceiling per cluster |
+| Portable | Hardware gaps documented, graceful SKIP |
+| AI-assisted | Agents at each phase; engineer validates |
+
+---
+
+## Living Document
+
+Updated after each testing iteration. Add new patterns and anti-patterns here as they emerge.
+
+**Current baseline** (2026-05-07, `build_debug_fault_inject`, net_ib.cc, 1821 lcov branches excluding exception pseudobranches):
+
+| Milestone | Branch | Line | Notes |
+|-----------|-------:|-----:|-------|
+| Before stress tests | 40.6% (740/1821) | 71.7% | 18 GeneralTests |
+| After 14 stress tests | 41.6% (757/1821) | 71.9% | +17 branches |
+| After MultiRecv (standalone) | ~42.5% (774/1821) | — | nreqs>1 path covered: BRDA:2387,0,1,255 |
+| After SendSizeClamping (E2) | 42.5% (773+1=774/1821) | — | BRDA:2544,0,0 — size clamping |
+| After NullCommClose (E3) | 42.6% (776/1821) | 72.7% | BRDA:3064,3084,3114 — NULL comm guards |
+| After SetNetAttrNoOp (E5) | 42.6% (776/1821) | 72.9% | FNDA:2 ncclIbSetNetAttr — 0 branch delta |
+| After NCCL_IB_SL=2 + NCCL_IB_TC=5 | 42.7% (778/1821) | — | BRDA:1716,0,0 + 1717,0,0 |
+| After tc netem delay 200ms (loopback) | 42.8% (780/1821) | — | BRDA:1566,0,0 (SendDevList reentry) |
+| After NCCL_IB_ECE_ENABLE=0 | 42.9% (781/1821) | — | BRDA:1652,0,1 — ECE disabled path |
+| After NCCL_IB_MERGE_VFS=0 | 43.0% (783/1821) | — | BRDA:492,0,1 + 512,0,1 — VFS merge disabled |
+| After RCCL_FORCE_ENABLE_DMABUF=1 | 43.8% (797/1821) | 74.1% | misc init branches |
+| After 4-rank loopback (k13-41 single node) | 43.88% (799/1821) | 74.4% | FanIn/FanOut/AllToAll/Bidirectional/LongRunning |
+| After env-var batch 2 (RELAXED_ORDERING, INLINE, TIMEOUT, FIFO_TC, AR=0, HCA, DISABLE) | **44.54% (811/1821)** | **74.5%** | +14 branches, +8 lines |
+
+**Total tests in StressTests.cpp: 27** (14 stress + 13 branch-coverage)
+
+**Reference files on k13-41:** `~/coverage/dmabuf/with_dmabuf_netib.lcov.info` — current best.
+
+**Note on denominators**: genhtml `--branch-coverage` shows 1821 (exception pseudobranches excluded); raw lcov export has 1954. Use consistent tool.
+
+**Resolved puzzle** (documented 2026-05-07): `BRDA:2387,0,1` (nreqs>1 in `ncclIbMultiSend`) showed 0 in `full_combined.profdata` because that profdata was built from runs that didn't include a proper `MultiRecv` execution. Running `MultiRecv` standalone showed `BRDA:2387,0,1,255`. The branch IS covered — the old profdata was incomplete.
+
+**Coverage ceiling analysis** (1821 total branches, 797 covered):
+- ~30 uncovered: State machine mid-transitions (`ncclIbConnect` L1567,1569,1571; `ncclIbAccept` L1881,1883,1885) — require real cross-host run or `tc netem` on recv path
+- ~100 uncovered: RoCE/GID selection paths (L408-479) — require RoCE hardware  
+- ~50 uncovered: GDR/DMA-buf paths (L2035-2177) — require GDR kernel module
+- ~30 uncovered: WC error / fatal-error paths (L2916,2921,2968) — require LD_PRELOAD shim
+- ~600 uncovered: NCCLCHECK error fallback branches — require injected failures
+- Realistic ceiling without LD_PRELOAD or cross-host or GDR: **~44-45%**
+
+**Env-var technique summary** — run existing tests with these env vars to cover new branches:
+- `NCCL_IB_SL=N NCCL_IB_TC=N` — covers ternary in ncclIbConnect L1715-1716
+- `NCCL_IB_ECE_ENABLE=0` — covers ECE disabled path in connect loop
+- `NCCL_IB_MERGE_VFS=0` — covers VFS merge disabled paths in init
+- `RCCL_FORCE_ENABLE_DMABUF=1` — covers forceDmaBuf branch in accept
+- `sudo tc qdisc add dev lo root netem delay Xms` + remove after — covers SendDevList reentry on loopback
+- Each env-var run should be merged with the existing profdata, not treated as a standalone baseline.

--- a/projects/rccl/src/transport/net_ib_cast/net_ib_cast_inspect.h
+++ b/projects/rccl/src/transport/net_ib_cast/net_ib_cast_inspect.h
@@ -19,10 +19,8 @@ extern "C" {
 
 /*
  * Test-only introspection API for the net-ib-cast WRR scheduler.
- *
- * Implementation lives in src/transport/net_ib_cast/scheduler.cc and is
- * compiled into librccl.so.  Both the library and the unit tests include this
- * one header so the struct layout and function signatures can never diverge.
+ * Shared between librccl.so and the unit tests so the struct layout
+ * and signatures cannot diverge.
  */
 
 struct ncclIbCastSchedState {
@@ -39,18 +37,15 @@ struct ncclIbCastSchedState {
   bool     splitData;
 };
 
-/* Copy WRR scheduler state out of a sendComm.
- * sendComm must be a valid ncclIbSendComm* from IbCastConnect/IbCastAccept.
- * Returns ncclInvalidArgument if either pointer is null. */
+/* Copy scheduler state out of a connected sendComm.
+ * Returns ncclInvalidArgument on null pointers. */
 ncclResult_t ncclIbCastGetSchedState(void* sendComm, struct ncclIbCastSchedState* out);
 
-/* Force-initialize the WRR token table, bypassing RTT-based scheduling.
- * Immediately sets qpTxSchedInit=true.
- * nqps must equal the connection's actual nqps (base->nqps). */
+/* Force-initialize the WRR token table, bypassing RTT-driven scheduling.
+ * nqps must match the connection's nqps. */
 ncclResult_t ncclIbCastSetTokens(void* sendComm, const int* qpTokens, int nqps);
 
-/* Override schedParms fields for mid-test toggling.
- * Takes effect on the very next isend; does not require re-connection. */
+/* Override schedParms; takes effect on the next isend, no reconnect needed. */
 ncclResult_t ncclIbCastSetSchedParms(void* sendComm,
                                       bool schedEnable,
                                       bool doWrr,

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -283,6 +283,7 @@ if(BUILD_TESTS)
       transport/NetIbMPI/CastTests.cpp
       transport/NetIbMPI/FaultInjectTests.cpp
       transport/GinMPI/GinMPITests.cpp
+      transport/NetIbMPI/StressTests.cpp
       ImplicitLaunchOrderMPITests.cpp
       CommMPITests.cpp
       RegistrationMPITests.cpp

--- a/projects/rccl/test/transport/NetIbMPI/CastTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/CastTests.cpp
@@ -86,6 +86,7 @@ TEST_F(NetIbMPITest, CastWeightsDistributionOneRound) {
     const int rank = MPIEnvironment::world_rank;
 
     CAST_ENV_CHECK_OR_SKIP();
+    CAST_REQUIRE_UPDATE_INTERVAL_OR_SKIP(10000000);
     net_ = &netIbCast;
     AssertInitAndGetDevices(nullptr);
 
@@ -150,6 +151,32 @@ TEST_F(NetIbMPITest, CastWeightsDistributionOneRound) {
         ASSERT_EQ(ncclIbCastGetSchedState(sendComm, &state), ncclSuccess);
         ASSERT_TRUE(state.schedInit);
         EXPECT_EQ(state.activeTotTokens, 0) << "unequal weights: after one full round active tokens must be 0";
+    }
+
+    // Forward rank-1 gtest failures to rank 0 so the test's exit code reflects them.
+    // (rank 1 has its default gtest listeners detached by main_mpi.cpp.)
+    {
+        int total_failed = 0; std::string msg;
+        if (rank == 1) {
+            auto* r = ::testing::UnitTest::GetInstance()->current_test_info()->result();
+            for (int i = 0; i < r->total_part_count(); i++) {
+                const auto& p = r->GetTestPartResult(i);
+                if (p.failed()) { total_failed++; msg += std::string("  - ") + (p.summary() ? p.summary() : "") + "\n"; }
+            }
+            int len = (int)msg.size();
+            MPI_Send(&total_failed, 1, MPI_INT, 0, 9620, MPI_COMM_WORLD);
+            MPI_Send(&len,          1, MPI_INT, 0, 9621, MPI_COMM_WORLD);
+            if (len > 0) MPI_Send(msg.data(), len, MPI_CHAR, 0, 9622, MPI_COMM_WORLD);
+        } else if (rank == 0) {
+            int len = 0;
+            MPI_Recv(&total_failed, 1, MPI_INT, 1, 9620, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            MPI_Recv(&len,          1, MPI_INT, 1, 9621, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            if (len > 0) {
+                msg.assign(len, '\0');
+                MPI_Recv(msg.data(), len, MPI_CHAR, 1, 9622, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                ADD_FAILURE() << "rank 1 reported " << total_failed << " failure(s):\n" << msg;
+            }
+        }
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
@@ -655,6 +682,7 @@ TEST_F(NetIbMPITest, CastAlternatingWrrNonWrr) {
     const int rank = MPIEnvironment::world_rank;
 
     CAST_ENV_CHECK_OR_SKIP();
+    CAST_REQUIRE_UPDATE_INTERVAL_OR_SKIP(10000000);
     net_ = &netIbCast;
     AssertInitAndGetDevices(nullptr);
 
@@ -739,6 +767,31 @@ TEST_F(NetIbMPITest, CastAlternatingWrrNonWrr) {
         EXPECT_EQ(consumed, kPhase) << "phase 3: expected " << kPhase << " WRR selections";
     }
 
+    // Forward rank-1 gtest failures to rank 0 (default listeners detached on non-zero ranks).
+    {
+        int total_failed = 0; std::string msg;
+        if (rank == 1) {
+            auto* r = ::testing::UnitTest::GetInstance()->current_test_info()->result();
+            for (int i = 0; i < r->total_part_count(); i++) {
+                const auto& p = r->GetTestPartResult(i);
+                if (p.failed()) { total_failed++; msg += std::string("  - ") + (p.summary() ? p.summary() : "") + "\n"; }
+            }
+            int len = (int)msg.size();
+            MPI_Send(&total_failed, 1, MPI_INT, 0, 9630, MPI_COMM_WORLD);
+            MPI_Send(&len,          1, MPI_INT, 0, 9631, MPI_COMM_WORLD);
+            if (len > 0) MPI_Send(msg.data(), len, MPI_CHAR, 0, 9632, MPI_COMM_WORLD);
+        } else if (rank == 0) {
+            int len = 0;
+            MPI_Recv(&total_failed, 1, MPI_INT, 1, 9630, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            MPI_Recv(&len,          1, MPI_INT, 1, 9631, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            if (len > 0) {
+                msg.assign(len, '\0');
+                MPI_Recv(msg.data(), len, MPI_CHAR, 1, 9632, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                ADD_FAILURE() << "rank 1 reported " << total_failed << " failure(s):\n" << msg;
+            }
+        }
+    }
+
     MPI_Barrier(MPI_COMM_WORLD);
     TeardownConnection(recvComm, listenComm, sendComm, mhandle);
 }
@@ -760,6 +813,7 @@ TEST_F(NetIbMPITest, CastEnableDisableSplitData) {
     const int rank = MPIEnvironment::world_rank;
 
     CAST_ENV_CHECK_OR_SKIP();
+    CAST_REQUIRE_UPDATE_INTERVAL_OR_SKIP(10000000);
     net_ = &netIbCast;
     AssertInitAndGetDevices(nullptr);
 
@@ -868,6 +922,7 @@ TEST_F(NetIbMPITest, CastEnableDisableSched) {
     const int rank = MPIEnvironment::world_rank;
 
     CAST_ENV_CHECK_OR_SKIP();
+    CAST_REQUIRE_UPDATE_INTERVAL_OR_SKIP(10000000);
     net_ = &netIbCast;
     AssertInitAndGetDevices(nullptr);
 

--- a/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
@@ -691,10 +691,22 @@ TEST_F(NetIbMPITest, ListenCloseListen) {
                      MPI_COMM_WORLD, MPI_STATUS_IGNORE);
         }
 
+        int connectFailed = 0;
         if (rank == 0) {
-            while (!pair.recvComm) AcceptConnection(pair.listenComm, &pair.recvComm);
+            ncclResult_t r = ncclSuccess;
+            while (!pair.recvComm && r == ncclSuccess)
+                r = AcceptConnection(pair.listenComm, &pair.recvComm);
+            if (r != ncclSuccess || !pair.recvComm) connectFailed = 1;
         } else {
-            while (!pair.sendComm) ConnectToRemote(mergedDev, &handle, &pair.sendComm);
+            ncclResult_t r = ncclSuccess;
+            while (!pair.sendComm && r == ncclSuccess)
+                r = ConnectToRemote(mergedDev, &handle, &pair.sendComm);
+            if (r != ncclSuccess || !pair.sendComm) connectFailed = 1;
+        }
+        MPI_Allreduce(MPI_IN_PLACE, &connectFailed, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+        if (connectFailed) {
+            if (rank == 0 && pair.listenComm) CloseListenComm(pair.listenComm);
+            FAIL() << "IB QP connect/accept failed (cross-subnet node pair)";
         }
 
         // Close: data comms first, then listen
@@ -806,14 +818,27 @@ TEST_F(NetIbMPITest, MultipleSimultaneousListens) {
     }
 
     // === Phase 2: ALL connect + accept ===
+    int phase2Failed = 0;
     if (rank == 0) {
-        for (int i = 0; i < kNumListens; i++)
-            while (!recvComms[i])
-                AcceptConnection(listenComms[i], &recvComms[i]);
+        for (int i = 0; i < kNumListens && !phase2Failed; i++) {
+            ncclResult_t r = ncclSuccess;
+            while (!recvComms[i] && r == ncclSuccess)
+                r = AcceptConnection(listenComms[i], &recvComms[i]);
+            if (r != ncclSuccess || !recvComms[i])
+                phase2Failed = 1;
+        }
     } else {
-        for (int i = 0; i < kNumListens; i++)
-            while (!sendComms[i])
-                ConnectToRemote(listens[i].dev, &handles[i], &sendComms[i]);
+        for (int i = 0; i < kNumListens && !phase2Failed; i++) {
+            ncclResult_t r = ncclSuccess;
+            while (!sendComms[i] && r == ncclSuccess)
+                r = ConnectToRemote(listens[i].dev, &handles[i], &sendComms[i]);
+            if (r != ncclSuccess || !sendComms[i])
+                phase2Failed = 1;
+        }
+    }
+    MPI_Allreduce(MPI_IN_PLACE, &phase2Failed, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+    if (phase2Failed) {
+        GTEST_SKIP() << "IB QP connect/accept failed (cross-subnet node pair)";
     }
 
     // === Phase 3: Transfer on ALL 4 connections ===

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -648,7 +648,11 @@ protected:
                            const RdmaResourceCounts& after,
                            const char* label = "") {
         int rank = MPIEnvironment::world_rank;
-        if (!before.valid() || !after.valid()) return; // skip silently
+        if (!before.valid() || !after.valid()) {
+            GTEST_LOG_(WARNING) << "RDMA resource counting unavailable on this node; "
+                                << "leak check skipped for: " << label;
+            return;
+        }
         EXPECT_EQ(after.qp, before.qp)
             << label << " QP leak on rank " << rank
             << ": before=" << before.qp << " after=" << after.qp;

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -25,11 +25,13 @@
 #include <cstdio>
 #include <cstdlib>
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <map>
+#include <sstream>
 #include <string>
 #include <dirent.h>
 #include <unistd.h>
@@ -564,6 +566,313 @@ protected:
             PostSendWithRetry(sendComm, buf, size, tag, mhandle, &req);
             int sz = 0;
             ASSERT_EQ(WaitForCompletion(req, &sz, 10000), ncclSuccess);
+        }
+    }
+
+    // ===============================================================
+    // Stress test infrastructure
+    // ===============================================================
+
+    // Process count for multi-rank tests
+    static constexpr int kMinFourProcesses = 4;
+    // Timeouts for stress/endurance tests
+    static constexpr int kStressTimeoutMs  = 60000;   // 60s
+    static constexpr int kEnduranceTimeoutMs = 300000; // 5 min
+
+    // ── RDMA resource leak detection ─────────────────────────────────
+    struct RdmaResourceCounts {
+        int qp = -1;
+        int cq = -1;
+        int mr = -1;
+        int pd = -1;
+        bool valid() const { return qp >= 0 && cq >= 0 && mr >= 0 && pd >= 0; }
+    };
+
+    static std::string ExecShellCommand(const char* cmd) {
+        std::array<char, 256> buf{};
+        std::string out;
+        FILE* pipe = popen(cmd, "r");
+        if (!pipe) return out;
+        while (fgets(buf.data(), buf.size(), pipe) != nullptr)
+            out += buf.data();
+        pclose(pipe);
+        return out;
+    }
+
+    static int CountNonEmptyLines(const std::string& text) {
+        std::istringstream iss(text);
+        std::string line;
+        int count = 0;
+        while (std::getline(iss, line))
+            if (!line.empty()) count++;
+        return count;
+    }
+
+    RdmaResourceCounts CaptureRdmaResources() {
+        RdmaResourceCounts counts;
+        std::string probe =
+            ExecShellCommand("sh -c 'rdma resource show qp >/dev/null 2>&1 && "
+                             "rdma resource show cq >/dev/null 2>&1 && "
+                             "rdma resource show mr >/dev/null 2>&1 && "
+                             "rdma resource show pd >/dev/null 2>&1 && echo OK'");
+        if (probe.find("OK") == std::string::npos) return counts;
+        // Filter to objects owned by this PID so concurrent processes on shared
+        // nodes do not cause spurious leak reports.
+        // `rdma resource show` lines contain "pid <N>"; grep for our PID.
+        // If the output format doesn't include "pid", fall back to system-wide count.
+        const std::string pid = std::to_string(getpid());
+        const std::string pidFilter = " pid " + pid + " ";
+        auto countOwned = [&](const char* resource) -> int {
+            std::string raw = ExecShellCommand(
+                (std::string("rdma resource show ") + resource + " 2>/dev/null").c_str());
+            // If any line contains our pid, count only those lines.
+            if (raw.find(pidFilter) != std::string::npos) {
+                std::istringstream iss(raw);
+                std::string line;
+                int n = 0;
+                while (std::getline(iss, line))
+                    if (!line.empty() && line.find(pidFilter) != std::string::npos) n++;
+                return n;
+            }
+            // PID not in output — fall back to system-wide count.
+            return CountNonEmptyLines(raw);
+        };
+        counts.qp = countOwned("qp");
+        counts.cq = countOwned("cq");
+        counts.mr = countOwned("mr");
+        counts.pd = countOwned("pd");
+        return counts;
+    }
+
+    void AssertNoRdmaLeaks(const RdmaResourceCounts& before,
+                           const RdmaResourceCounts& after,
+                           const char* label = "") {
+        int rank = MPIEnvironment::world_rank;
+        if (!before.valid() || !after.valid()) return; // skip silently
+        EXPECT_EQ(after.qp, before.qp)
+            << label << " QP leak on rank " << rank
+            << ": before=" << before.qp << " after=" << after.qp;
+        EXPECT_EQ(after.cq, before.cq)
+            << label << " CQ leak on rank " << rank
+            << ": before=" << before.cq << " after=" << after.cq;
+        EXPECT_EQ(after.mr, before.mr)
+            << label << " MR leak on rank " << rank
+            << ": before=" << before.mr << " after=" << after.mr;
+        EXPECT_EQ(after.pd, before.pd)
+            << label << " PD leak on rank " << rank
+            << ": before=" << before.pd << " after=" << after.pd;
+    }
+
+    // ── DoSendRecv: single-iteration pattern-verified transfer ──────
+    // Both ranks call together. Rank 0 recvs, rank 1 sends.
+    // patternSeed is used for both fill and verify.
+    void DoSendRecv(void* sendComm, void* recvComm,
+                    void* sendBuf, void* recvBuf,
+                    size_t size, int tag,
+                    void* sendMh, void* recvMh,
+                    int patternSeed, int timeoutMs = kDefaultTimeoutMs) {
+        const int rank = MPIEnvironment::world_rank;
+        void* req = nullptr;
+
+        if (rank == 0) {
+            PostSingleRecv(recvComm, recvBuf, size, tag, recvMh, &req);
+        } else {
+            if (size > 0)
+                fillHostBufferWithPattern<uint8_t>(sendBuf, size, makeBytePattern(patternSeed));
+            PostSendWithRetry(sendComm, sendBuf, size, tag, sendMh, &req);
+        }
+
+        int sz = 0;
+        ASSERT_EQ(WaitForCompletion(req, &sz, timeoutMs), ncclSuccess)
+            << "WaitForCompletion failed on rank " << rank << " tag=" << tag;
+
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        if (rank == 0 && size > 0) {
+            size_t errIdx; uint8_t errExp, errGot;
+            bool ok = verifyHostBufferData<uint8_t>(
+                recvBuf, size, makeBytePattern(patternSeed),
+                0, 0.0, &errIdx, &errExp, &errGot);
+            ASSERT_TRUE(ok) << "Data mismatch at byte " << errIdx
+                            << " (tag=" << tag << " seed=" << patternSeed << ")";
+        }
+    }
+
+    // ── Multi-rank connection helpers ────────────────────────────────
+    struct DirectedConnection {
+        int senderRank   = -1;
+        int receiverRank = -1;
+        void* sendComm   = nullptr;  // non-null on senderRank
+        void* recvComm   = nullptr;  // non-null on receiverRank
+        void* listenComm = nullptr;  // non-null on receiverRank
+    };
+
+    // Setup a point-to-point connection between two specific ranks.
+    // All ranks must call this together; non-participating ranks only hit the barrier.
+    void SetupDirectedConnection(int dev, DirectedConnection& conn,
+                                 int senderRank, int receiverRank,
+                                 int mpiTag = 0) {
+        const int rank = MPIEnvironment::world_rank;
+        conn.senderRank   = senderRank;
+        conn.receiverRank = receiverRank;
+        ncclNetHandle_t handle;
+        memset(&handle, 0, sizeof(handle));
+
+        // Use EXPECT_/ADD_FAILURE instead of ASSERT_ so that all ranks always
+        // reach MPI_Barrier even when a connection step fails.  ASSERT_ returns
+        // immediately on the failing rank, which leaves the other ranks stuck
+        // at the barrier indefinitely.
+        bool ok = true;
+        if (rank == receiverRank) {
+            ncclResult_t r = CreateListenComm(dev, &handle, &conn.listenComm);
+            EXPECT_EQ(r, ncclSuccess) << "CreateListenComm failed, rank=" << rank;
+            EXPECT_NE(conn.listenComm, nullptr);
+            ok = (r == ncclSuccess && conn.listenComm != nullptr);
+            if (ok) {
+                MPI_Send(&handle, sizeof(handle), MPI_BYTE, senderRank, mpiTag, MPI_COMM_WORLD);
+                for (int i = 0; i < kMaxRetryAttempts && conn.recvComm == nullptr; i++) {
+                    r = AcceptConnection(conn.listenComm, &conn.recvComm);
+                    EXPECT_EQ(r, ncclSuccess) << "AcceptConnection failed, rank=" << rank;
+                    if (!conn.recvComm) usleep(kPollIntervalUs);
+                }
+                EXPECT_NE(conn.recvComm, nullptr);
+            } else {
+                // Send a zeroed handle so the sender doesn't block on MPI_Recv.
+                MPI_Send(&handle, sizeof(handle), MPI_BYTE, senderRank, mpiTag, MPI_COMM_WORLD);
+            }
+        } else if (rank == senderRank) {
+            MPI_Recv(&handle, sizeof(handle), MPI_BYTE, receiverRank, mpiTag,
+                     MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            for (int i = 0; i < kMaxRetryAttempts && conn.sendComm == nullptr; i++) {
+                ncclResult_t r = ConnectToRemote(dev, &handle, &conn.sendComm);
+                EXPECT_EQ(r, ncclSuccess) << "ConnectToRemote failed, rank=" << rank;
+                if (!conn.sendComm) usleep(kPollIntervalUs);
+            }
+            EXPECT_NE(conn.sendComm, nullptr);
+        }
+        // All ranks synchronize — must be reached unconditionally.
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+
+    void CloseDirectedConnection(DirectedConnection& conn) {
+        const int rank = MPIEnvironment::world_rank;
+        if (rank == conn.senderRank && conn.sendComm) {
+            CloseSendComm(conn.sendComm);
+            conn.sendComm = nullptr;
+        }
+        if (rank == conn.receiverRank) {
+            if (conn.recvComm) {
+                CloseRecvComm(conn.recvComm);
+                conn.recvComm = nullptr;
+            }
+            if (conn.listenComm) {
+                CloseListenComm(conn.listenComm);
+                conn.listenComm = nullptr;
+            }
+        }
+    }
+
+    // Fan-in: multiple senders → one receiver
+    void SetupFanIn(int dev, int receiverRank,
+                    const std::vector<int>& senderRanks,
+                    std::vector<DirectedConnection>& conns) {
+        conns.resize(senderRanks.size());
+        for (size_t i = 0; i < senderRanks.size(); i++) {
+            SetupDirectedConnection(dev, conns[i], senderRanks[i], receiverRank,
+                                    /*mpiTag=*/100 + static_cast<int>(i));
+        }
+    }
+
+    // Fan-out: one sender → multiple receivers
+    void SetupFanOut(int dev, int senderRank,
+                     const std::vector<int>& receiverRanks,
+                     std::vector<DirectedConnection>& conns) {
+        conns.resize(receiverRanks.size());
+        for (size_t i = 0; i < receiverRanks.size(); i++) {
+            SetupDirectedConnection(dev, conns[i], senderRank, receiverRanks[i],
+                                    /*mpiTag=*/200 + static_cast<int>(i));
+        }
+    }
+
+    // All-to-all: N*(N-1) directed connections among numRanks
+    void SetupAllToAll(int dev, int numRanks,
+                       std::vector<DirectedConnection>& conns) {
+        conns.clear();
+        for (int src = 0; src < numRanks; src++) {
+            for (int dst = 0; dst < numRanks; dst++) {
+                if (src == dst) continue;
+                DirectedConnection c;
+                SetupDirectedConnection(dev, c, src, dst,
+                                        /*mpiTag=*/300 + src * numRanks + dst);
+                conns.push_back(std::move(c));
+            }
+        }
+    }
+
+    // Do a send/recv on a DirectedConnection. Both ranks call together.
+    // senderBuf is used on senderRank; receiverBuf on receiverRank.
+    void DoDirectedSendRecv(DirectedConnection& conn,
+                            void* senderBuf, void* receiverBuf,
+                            size_t size, int tag,
+                            void* senderMh, void* receiverMh,
+                            int patternSeed, int timeoutMs = kStressTimeoutMs) {
+        const int rank = MPIEnvironment::world_rank;
+        void* req = nullptr;
+        bool postOk = true;
+
+        // Post recv/send with non-fatal checks so we always reach MPI_Barrier.
+        // Using ASSERT_ here would skip the barrier on failure, deadlocking
+        // all other ranks that are not sender/receiver for this connection.
+        if (rank == conn.receiverRank) {
+            void*  bufs[1]    = {receiverBuf};
+            size_t sizes[1]   = {size};
+            int    tags[1]    = {tag};
+            void*  handles[1] = {receiverMh};
+            ncclResult_t r = PostRecv(conn.recvComm, 1, bufs, sizes, tags, handles, &req);
+            EXPECT_EQ(r, ncclSuccess) << "PostRecv failed, rank=" << rank;
+            postOk = (r == ncclSuccess && req != nullptr);
+        }
+        if (rank == conn.senderRank) {
+            if (size > 0)
+                fillHostBufferWithPattern<uint8_t>(senderBuf, size, makeBytePattern(patternSeed));
+            // Retry until FIFO slot is available (receiver hasn't posted yet).
+            int attempts = 0;
+            ncclResult_t r = ncclSuccess;
+            do {
+                r = PostSend(conn.sendComm, senderBuf, size, tag, senderMh, &req);
+                if (r != ncclSuccess || req != nullptr) break;
+                if (++attempts >= kMaxRetryAttempts) {
+                    ADD_FAILURE() << "PostSend NULL after " << attempts
+                                  << " retries, rank=" << rank << " tag=" << tag;
+                    postOk = false;
+                    break;
+                }
+                usleep(kPollIntervalUs);
+            } while (req == nullptr);
+            if (r != ncclSuccess) {
+                ADD_FAILURE() << "PostSend error " << r << ", rank=" << rank;
+                postOk = false;
+            }
+        }
+
+        // Wait for completion — non-fatal so MPI_Barrier is always reached.
+        if (req && postOk) {
+            int sz = 0;
+            ncclResult_t r = WaitForCompletion(req, &sz, timeoutMs);
+            EXPECT_EQ(r, ncclSuccess)
+                << "DoDirectedSendRecv timeout, rank=" << rank << " tag=" << tag;
+        }
+
+        // Unconditional barrier — every rank must reach this even on failure.
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        if (rank == conn.receiverRank && size > 0 && postOk) {
+            size_t errIdx; uint8_t errExp, errGot;
+            bool ok = verifyHostBufferData<uint8_t>(
+                receiverBuf, size, makeBytePattern(patternSeed),
+                0, 0.0, &errIdx, &errExp, &errGot);
+            EXPECT_TRUE(ok) << "Data mismatch at byte " << errIdx
+                            << " (tag=" << tag << " seed=" << patternSeed << ")";
         }
     }
 

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -8,6 +8,18 @@
 #define RCCL_TEST_NET_IB_MPI_TEST_BASE_HPP_
 
 #include <gtest/gtest.h>
+// Pre-seed the bf16 guard macros and pull in the new hip_bf16.h before
+// hip_runtime.h transitively includes the old hip_bfloat16.h. Otherwise
+// device.h's #error guard fires during the device-pass compile (the test
+// include path exposes the hipified librccl device.h via
+// ${PROJECT_BINARY_DIR}/hipify/src/include).
+#if defined(ROCM_VERSION) && ROCM_VERSION >= 60000
+  #if !defined(_HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BFLOAT16_H_) && !defined(_HIP_BFLOAT16_H_)
+    #define _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BFLOAT16_H_
+    #define _HIP_BFLOAT16_H_
+    #include <hip/hip_bf16.h>
+  #endif
+#endif
 #include <hip/hip_runtime.h>
 #include "MPITestBase.hpp"
 #include "NetIbCastInspect.hpp"
@@ -68,6 +80,18 @@ using namespace RCCLTestHelpers;
                              << " (expected: " << (_v.required ? _v.required : "<any>") \
                              << "). Use cast_* configs in net_ib_transport.json.";       \
             }                                                                            \
+        }                                                                                \
+    } while (0)
+
+// Skip when RCCL_IB_QP_SCHED_UPDATE_INTERVAL is below min_us: tests that
+// assert exact per-send token state need the RTT-driven update suspended.
+#define CAST_REQUIRE_UPDATE_INTERVAL_OR_SKIP(min_us)                                     \
+    do {                                                                                 \
+        const char* _ui = getenv("RCCL_IB_QP_SCHED_UPDATE_INTERVAL");                    \
+        long long _v = (_ui && _ui[0]) ? std::atoll(_ui) : 0;                            \
+        if (_v < (long long)(min_us)) {                                                  \
+            GTEST_SKIP() << "Requires RCCL_IB_QP_SCHED_UPDATE_INTERVAL >= "             \
+                         << (long long)(min_us) << " us (current: " << _v << ")";        \
         }                                                                                \
     } while (0)
 
@@ -414,13 +438,42 @@ protected:
         ASSERT_EQ(PostRecv(recvComm, 1, bufs, sizes, tags, handles, request), ncclSuccess);
     }
 
+    // Returns true if the IB device has at least one routable GID (non-zero IPv4-mapped
+    // or global-scope IPv6). NICs with only link-local GIDs cannot do cross-node RDMA.
+    static bool HasRoutableGid(const char* devName) {
+        char path[PATH_MAX];
+        if (snprintf(path, sizeof(path), "/sys/class/infiniband/%s/ports/1/gids", devName) >= PATH_MAX)
+            return false;
+        DIR* d = opendir(path);
+        if (!d) return false;
+        struct dirent* ent;
+        bool found = false;
+        while ((ent = readdir(d)) != nullptr) {
+            if (ent->d_name[0] == '.') continue;
+            char gidPath[PATH_MAX];
+            snprintf(gidPath, sizeof(gidPath), "%s/%s", path, ent->d_name);
+            FILE* f = fopen(gidPath, "r");
+            if (!f) continue;
+            char gid[64] = {};
+            fscanf(f, "%63s", gid);
+            fclose(f);
+            // Skip all-zero GIDs and link-local (fe80::) GIDs
+            bool allZero = (strcmp(gid, "0000:0000:0000:0000:0000:0000:0000:0000") == 0);
+            bool linkLocal = (strncmp(gid, "fe80:", 5) == 0);
+            if (!allZero && !linkLocal) { found = true; break; }
+        }
+        closedir(d);
+        return found;
+    }
+
     // Helper: create a merged device from N physical NICs.
-    // Returns merged device index, or -1 if not enough devices / merge failed.
-    // physDevs: indices of physical (non-merged) devices
-    // props: device properties (indexed by device index)
-    // nNicsToMerge: how many NICs to merge (e.g., 2, 3, 4)
+    // Returns merged device index, or -1 if no suitable group found.
+    // Iterates speed groups (fastest-first by enumeration order). Within each
+    // group, slides a window of nNicsToMerge; skips windows containing a NIC
+    // without a routable GID (those can set up QPs but drop RDMA traffic cross-node).
+    // speedGroupStart: index into physDevs indicating which speed group to try first.
     // rank: MPI rank of this process
-    int CreateMergedDevice(int nNicsToMerge, int rank, int offset = 0)
+    int CreateMergedDevice(int nNicsToMerge, int rank, int speedGroupStart = 0)
     {
         if (nNicsToMerge <= 0 || nNicsToMerge > NCCL_NET_MAX_DEVS_PER_NIC) {
             fprintf(stderr,
@@ -428,8 +481,6 @@ protected:
                     rank, nNicsToMerge, NCCL_NET_MAX_DEVS_PER_NIC);
             return -1;
         }
-
-        int outMergedDev = -1;
 
         int ndev = 0;
         RCCL_TEST_CHECK(GetDeviceCount(&ndev));
@@ -444,38 +495,41 @@ protected:
                 physDevs.push_back(i);
         }
 
-        if (physDevs.size() < offset + 1) {
-            return -1;
-        }
+        if (speedGroupStart >= (int)physDevs.size()) return -1;
 
-        int targetSpeed = props[physDevs[offset]].speed;
+        // Build the speed group starting at speedGroupStart
+        int targetSpeed = props[physDevs[speedGroupStart]].speed;
         std::vector<int> compat;
         for (int d : physDevs)
             if (props[d].speed == targetSpeed) compat.push_back(d);
 
-        if ((int)compat.size() < nNicsToMerge * 2) {
-            return CreateMergedDevice(nNicsToMerge, rank, offset + 1);
+        // Try each consecutive window of nNicsToMerge within this speed group
+        for (int w = 0; w + nNicsToMerge <= (int)compat.size(); w++) {
+            bool routable = true;
+            for (int i = 0; i < nNicsToMerge; i++) {
+                const char* name = props[compat[w + i]].name;
+                if (name && !HasRoutableGid(name)) { routable = false; break; }
+            }
+            if (!routable) continue;
+
+            ncclNetVDeviceProps_t vProps;
+            memset(&vProps, 0, sizeof(vProps));
+            vProps.ndevs = nNicsToMerge;
+            for (int i = 0; i < nNicsToMerge; i++)
+                vProps.devs[i] = compat[w + i];
+
+            int outMergedDev = -1;
+            if (MakeVirtualDevice(&outMergedDev, &vProps) == ncclSuccess && outMergedDev >= 0)
+                return outMergedDev;
         }
 
-        int baseOffset = (rank % 2) ? nNicsToMerge : 0;
-        int finalOffset = baseOffset + offset;
+        // This speed group exhausted — advance to the next one
+        int nextStart = speedGroupStart;
+        while (nextStart < (int)physDevs.size() &&
+               props[physDevs[nextStart]].speed == targetSpeed)
+            nextStart++;
 
-        if (finalOffset + nNicsToMerge > (int)compat.size()) return -1;
-
-        ncclNetVDeviceProps_t vProps;
-        memset(&vProps, 0, sizeof(vProps));
-        vProps.ndevs = nNicsToMerge;
-        for (int i = 0; i < nNicsToMerge; i++)
-            vProps.devs[i] = compat[finalOffset + i];
-
-        if (MakeVirtualDevice(&outMergedDev, &vProps) != ncclSuccess || outMergedDev < 0) {
-            fprintf(stderr,
-                    "Rank %d failed to create %d-NIC merged device at offset %d, retrying with offset %d\n",
-                    rank, nNicsToMerge, offset, offset + 1);
-            return CreateMergedDevice(nNicsToMerge, rank, offset + 1);
-        }
-
-        return outMergedDev;
+        return CreateMergedDevice(nNicsToMerge, rank, nextStart);
     }
 
 
@@ -575,9 +629,8 @@ protected:
 
     // Process count for multi-rank tests
     static constexpr int kMinFourProcesses = 4;
-    // Timeouts for stress/endurance tests
+    // Timeout for stress tests
     static constexpr int kStressTimeoutMs  = 60000;   // 60s
-    static constexpr int kEnduranceTimeoutMs = 300000; // 5 min
 
     // ── RDMA resource leak detection ─────────────────────────────────
     struct RdmaResourceCounts {
@@ -687,7 +740,10 @@ protected:
         }
 
         int sz = 0;
-        ASSERT_EQ(WaitForCompletion(req, &sz, timeoutMs), ncclSuccess)
+        // Use EXPECT_ (non-fatal) so both ranks always reach MPI_Barrier.
+        // ASSERT_ here would exit the failing rank before the barrier,
+        // leaving the other rank hung indefinitely.
+        EXPECT_EQ(WaitForCompletion(req, &sz, timeoutMs), ncclSuccess)
             << "WaitForCompletion failed on rank " << rank << " tag=" << tag;
 
         MPI_Barrier(MPI_COMM_WORLD);
@@ -697,7 +753,7 @@ protected:
             bool ok = verifyHostBufferData<uint8_t>(
                 recvBuf, size, makeBytePattern(patternSeed),
                 0, 0.0, &errIdx, &errExp, &errGot);
-            ASSERT_TRUE(ok) << "Data mismatch at byte " << errIdx
+            EXPECT_TRUE(ok) << "Data mismatch at byte " << errIdx
                             << " (tag=" << tag << " seed=" << patternSeed << ")";
         }
     }

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -159,5 +159,19 @@ TEST_F(NetIbMPITest, SendSizeClamping) {
 //      Covers the ncclIbCloseSend/ncclIbCloseRecv null-guard branch
 //      (net_ib.cc:3063 and 3083: if (comm) {...}).
 //      The API must return ncclSuccess without crashing.
+TEST_F(NetIbMPITest, NullCommClose) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    AssertInitAndGetDevices(nullptr);
+
+    EXPECT_EQ(CloseSendComm(nullptr), ncclSuccess);
+    EXPECT_EQ(CloseRecvComm(nullptr), ncclSuccess);
+    EXPECT_EQ(CloseListenComm(nullptr), ncclSuccess);
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// E4.  TagZeroReuse — 50 messages all sent with tag=0.
+//      Verifies FIFO ordering: messages arrive in send order because
+//      the FIFO is a strict ring (slot = fifoHead % MAX_REQUESTS).
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -22,5 +22,35 @@
 // E0.  InvalidRecvCount — calls ncclIbIrecv with n > NCCL_NET_IB_MAX_RECVS (8).
 //      Covers the early-return branch at net_ib.cc:2731.
 //      Requires a live recvComm (ready==1); the call must not crash.
+TEST_F(NetIbMPITest, InvalidRecvCount) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
 
+    ConnectionPair cp;
+    NetConnectionGuard guard(net_);
+    SetupConnectionWithGuard(/*dev=*/0, cp, guard);
 
+    if (rank == 0) {
+        // n=9 > NCCL_NET_IB_MAX_RECVS (8) — must return ncclInternalError
+        static constexpr int kOverLimit = 9;
+        void*  data[kOverLimit]     = {};
+        size_t sizes[kOverLimit]    = {};
+        int    tags[kOverLimit]     = {};
+        void*  mhandles[kOverLimit] = {};
+        void*  req                  = nullptr;
+        ncclResult_t r = PostRecv(cp.recvComm, kOverLimit, data, sizes, tags, mhandles, &req);
+        EXPECT_EQ(r, ncclInternalError);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// E1.  MrCacheRefCount — registers the same host buffer twice on the same comm.
+//      On the second RegisterMemory call the MR cache finds the range and increments
+//      refs to 2 (ncclIbRegMrDmaBufInternal L2276). The first DeregMr decrements
+//      refs to 1 without freeing (ncclIbDeregMrInternal refs>0 branch). The second
+//      DeregMr decrements to 0 and actually calls wrap_ibv_dereg_mr.
+//      Covers ncclIbDeregMrInternal L2326 "refs > 0" path.
+
+#endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -90,5 +90,74 @@ TEST_F(NetIbMPITest, MrCacheRefCount) {
 // E2.  SendSizeClamping — sender posts a buffer larger than the receiver's posted size.
 //      Covers the ncclIbIsend L2543 branch: if (size > slots[r].size) size = slots[r].size.
 //      The transfer should complete cleanly; only recv_size bytes are transferred.
+TEST_F(NetIbMPITest, SendSizeClamping) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    ConnectionPair cp;
+    NetConnectionGuard guard(net_);
+    SetupConnectionWithGuard(/*dev=*/0, cp, guard);
+
+    static constexpr size_t kRecvSize = 4096;
+    static constexpr size_t kSendSize = 65536;  // larger than kRecvSize — will be clamped
+    static constexpr int    kTag      = 9900;
+
+    auto sendBuf = makeHostBufferAutoGuard(malloc(kSendSize));
+    auto recvBuf = makeHostBufferAutoGuard(malloc(kRecvSize));
+    ASSERT_NE(sendBuf.get(), nullptr);
+    ASSERT_NE(recvBuf.get(), nullptr);
+
+    void* recvMh = nullptr;
+    void* sendMh = nullptr;
+
+    if (rank == 0) {
+        // Register only kRecvSize — this sets slots[r].size = kRecvSize in the FIFO
+        ASSERT_EQ(RegisterMemory(cp.recvComm, recvBuf.get(), kRecvSize, NCCL_PTR_HOST, &recvMh), ncclSuccess);
+        ASSERT_NE(recvMh, nullptr);
+    } else {
+        // Sender registers larger buffer
+        ASSERT_EQ(RegisterMemory(cp.sendComm, sendBuf.get(), kSendSize, NCCL_PTR_HOST, &sendMh), ncclSuccess);
+        ASSERT_NE(sendMh, nullptr);
+        fillHostBufferWithPattern<uint8_t>(sendBuf.get(), kSendSize, makeBytePattern(42));
+    }
+
+    void* req = nullptr;
+    if (rank == 0) {
+        PostSingleRecv(cp.recvComm, recvBuf.get(), kRecvSize, kTag, recvMh, &req);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (rank == 1) {
+        // Post send with kSendSize > kRecvSize — ncclIbIsend will clamp to kRecvSize
+        PostSendWithRetry(cp.sendComm, sendBuf.get(), kSendSize, kTag, sendMh, &req);
+        ASSERT_NE(req, nullptr);
+    }
+
+    int sizes[1] = {0};
+    ASSERT_EQ(WaitForCompletion(req, sizes, kLargeTransferTimeoutMs), ncclSuccess)
+        << "WaitForCompletion failed on rank " << rank;
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (rank == 0) {
+        // Verify: recv reports kRecvSize bytes (clamped), not kSendSize
+        EXPECT_EQ(sizes[0], static_cast<int>(kRecvSize))
+            << "Expected recv size to be clamped to " << kRecvSize;
+        // Verify first kRecvSize bytes match the sender's pattern
+        bool ok = verifyHostBufferData<uint8_t>(recvBuf.get(), kRecvSize, makeBytePattern(42));
+        EXPECT_TRUE(ok) << "Data mismatch in clamped receive";
+    }
+
+    if (rank == 0 && recvMh) DeregisterMemory(cp.recvComm, recvMh);
+    if (rank == 1 && sendMh) DeregisterMemory(cp.sendComm, sendMh);
+}
+
+// E3.  NullCommClose — closes a NULL send/recv comm pointer.
+//      Covers the ncclIbCloseSend/ncclIbCloseRecv null-guard branch
+//      (net_ib.cc:3063 and 3083: if (comm) {...}).
+//      The API must return ncclSuccess without crashing.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -1167,5 +1167,65 @@ TEST_F(NetIbMPITest, MultiQpFanIn) {
 }
 
 // G2.  BidirectionalMultiRank — all pairs bidirectional, 4 ranks, 50 iters.
+TEST_F(NetIbMPITest, BidirectionalMultiRank) {
+    ASSERT_TRUE(validateTestPrerequisites(kMinFourProcesses, kMinFourProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    int nranks = MPIEnvironment::world_size;
+    AssertInitAndGetDevices(nullptr);
+
+    // All-to-all gives us both directions for every pair
+    std::vector<DirectedConnection> conns;
+    SetupAllToAll(0, nranks, conns);
+
+    const size_t sz = kSmallBufferSize;
+    auto buf = makeHostBufferAutoGuard(malloc(sz));
+    ASSERT_NE(buf.get(), nullptr);
+
+    std::vector<void*> mhandles;
+    for (auto& c : conns) {
+        void* comm = nullptr;
+        if (rank == c.senderRank)   comm = c.sendComm;
+        if (rank == c.receiverRank) comm = c.recvComm;
+        void* mh = nullptr;
+        if (comm) {
+            ASSERT_EQ(RegisterMemory(comm, buf.get(), sz, NCCL_PTR_HOST, &mh), ncclSuccess);
+        }
+        mhandles.push_back(mh);
+    }
+    auto mrCleanup = makeScopeGuard([&]() {
+        for (size_t i = 0; i < conns.size(); i++) {
+            if (!mhandles[i]) continue;
+            void* comm = nullptr;
+            if (rank == conns[i].senderRank)   comm = conns[i].sendComm;
+            if (rank == conns[i].receiverRank) comm = conns[i].recvComm;
+            if (comm) DeregisterMemory(comm, mhandles[i]);
+        }
+    });
+
+    static constexpr int kIters = 50;
+    for (int iter = 0; iter < kIters; iter++) {
+        for (size_t c = 0; c < conns.size(); c++) {
+            int seed = iter * 100 + conns[c].senderRank * 10 + conns[c].receiverRank;
+            DoDirectedSendRecv(conns[c], buf.get(), buf.get(), sz,
+                               /*tag=*/iter, mhandles[c], mhandles[c], seed);
+        }
+    }
+
+    // Deregister memory before closing connections (comm must be valid for DeregMr).
+    for (size_t i = 0; i < conns.size(); i++) {
+        if (!mhandles[i]) continue;
+        void* comm = nullptr;
+        if (rank == conns[i].senderRank)   comm = conns[i].sendComm;
+        if (rank == conns[i].receiverRank) comm = conns[i].recvComm;
+        if (comm) DeregisterMemory(comm, mhandles[i]);
+        mhandles[i] = nullptr;
+    }
+    mrCleanup.dismiss();
+
+    for (auto& c : conns) CloseDirectedConnection(c);
+}
+
+// F2.  LongRunningMultiRank — fan-in 3→1, 1000 iterations, RDMA checkpoints.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -1401,5 +1401,73 @@ TEST_F(NetIbMPITest, LongRunningEndurance) {
 // =====================================================================
 
 // H1.  GpuMemoryTransferStress — 5 alloc/transfer/flush/verify/free cycles.
+TEST_F(NetIbMPITest, GpuMemoryTransferStress) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    // Check GDR support
+    ncclNetProperties_t props;
+    ASSERT_EQ(GetDeviceProperties(0, &props), ncclSuccess);
+    if (!(props.ptrSupport & NCCL_PTR_CUDA)) {
+        GTEST_SKIP() << "No GPU Direct RDMA support";
+    }
+
+    ConnectionPair cp;
+    NetConnectionGuard guard(net_);
+    SetupConnectionWithGuard(0, cp, guard);
+
+    static constexpr int kCycles = 5;
+    const size_t sizes[] = {512 * 1024, 1024 * 1024, 2 * 1024 * 1024, 4 * 1024 * 1024, 1024 * 1024};
+
+    for (int cycle = 0; cycle < kCycles; cycle++) {
+        size_t sz = sizes[cycle];
+        void* devBuf = nullptr;
+        ASSERT_EQ(hipMalloc(&devBuf, sz), hipSuccess);
+        auto devGuard = makeDeviceBufferAutoGuard(devBuf);
+
+        void* comm = (rank == 0) ? cp.recvComm : cp.sendComm;
+        void* mh = nullptr;
+        ASSERT_EQ(RegisterMemory(comm, devBuf, sz, NCCL_PTR_CUDA, &mh), ncclSuccess);
+        NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+
+        if (rank == 1) {
+            ASSERT_EQ(initializeBufferWithPattern<uint8_t>(devBuf, sz, makeBytePattern(cycle)), hipSuccess);
+        }
+
+        void* req = nullptr;
+        if (rank == 0) {
+            PostSingleRecv(cp.recvComm, devBuf, sz, /*tag=*/cycle, mh, &req);
+        } else {
+            PostSendWithRetry(cp.sendComm, devBuf, sz, /*tag=*/cycle, mh, &req);
+        }
+
+        int rsz = 0;
+        ASSERT_EQ(WaitForCompletion(req, &rsz, kLargeTransferTimeoutMs), ncclSuccess);
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        // Flush on receiver
+        if (rank == 0) {
+            void* flushReq = nullptr;
+            int flushSz = static_cast<int>(sz);
+            ncclResult_t fr = FlushRecv(cp.recvComm, 1, &devBuf, &flushSz, &mh, &flushReq);
+            if (fr == ncclSuccess && flushReq) {
+                int fsz = 0;
+                ASSERT_EQ(WaitForCompletion(flushReq, &fsz, kLargeTransferTimeoutMs), ncclSuccess);
+            }
+            // Verify
+            bool ok = verifyBufferData<uint8_t>(devBuf, sz, makeBytePattern(cycle));
+            ASSERT_TRUE(ok) << "GPU data mismatch at cycle " << cycle;
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+}
+
+// =====================================================================
+//  Group J: Rapid recycling (2-rank)
+// =====================================================================
+
+// J1.  RapidRecvPostDrain — 100 cycles of post-32-recv → send-32 → drain.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -384,5 +384,68 @@ TEST_F(NetIbMPITest, FifoPressureSenderFast) {
 
 // A1.  RequestSlotExhaustion — post NCCL_NET_MAX_REQUESTS (32) irecvs,
 //      then drain all via matching sends, then verify slots are recycled.
+TEST_F(NetIbMPITest, RequestSlotExhaustion) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    ConnectionPair cp;
+    NetConnectionGuard guard(net_);
+    SetupConnectionWithGuard(0, cp, guard);
+
+    static constexpr int kMaxReqs = 32; // NCCL_NET_MAX_REQUESTS
+    const size_t sz = 256;
+    auto buf = makeHostBufferAutoGuard(malloc(sz * kMaxReqs));
+    ASSERT_NE(buf.get(), nullptr);
+
+    void* comm = (rank == 0) ? cp.recvComm : cp.sendComm;
+    void* mh = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf.get(), sz * kMaxReqs, NCCL_PTR_HOST, &mh), ncclSuccess);
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+
+    if (rank == 0) {
+        // Post all 32 irecvs
+        std::vector<void*> reqs(kMaxReqs, nullptr);
+        for (int i = 0; i < kMaxReqs; i++) {
+            char* p = static_cast<char*>(buf.get()) + i * sz;
+            PostSingleRecv(cp.recvComm, p, sz, /*tag=*/i, mh, &reqs[i]);
+        }
+        // Signal rank 1 that all recvs are posted
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        // Wait for all completions
+        for (int i = 0; i < kMaxReqs; i++) {
+            int rsz = 0;
+            ASSERT_EQ(WaitForCompletion(reqs[i], &rsz, kStressTimeoutMs), ncclSuccess)
+                << "Completion failed for recv " << i;
+        }
+    } else {
+        // Wait for rank 0 to post all recvs
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        // Send all 32
+        for (int i = 0; i < kMaxReqs; i++) {
+            char* p = static_cast<char*>(buf.get()) + i * sz;
+            fillHostBufferWithPattern<uint8_t>(p, sz, makeBytePattern(i));
+            void* req = nullptr;
+            PostSendWithRetry(cp.sendComm, p, sz, /*tag=*/i, mh, &req);
+            int rsz = 0;
+            ASSERT_EQ(WaitForCompletion(req, &rsz, kStressTimeoutMs), ncclSuccess)
+                << "Completion failed for send " << i;
+        }
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Verify recycling: post and drain one more round
+    for (int i = 0; i < 4; i++) {
+        DoSendRecv(cp.sendComm, cp.recvComm,
+                   buf.get(), buf.get(), sz,
+                   /*tag=*/100 + i, mh, mh, 100 + i);
+    }
+}
+
+// A3.  MemoryRegistrationStorm — register/deregister 512 unique buffers
+//      in various patterns to stress the MR cache.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -1103,5 +1103,69 @@ TEST_F(NetIbMPITest, AllToAllStress) {
 }
 
 // D3.  MultiQpFanIn — fan-in 3→1 with QPS=4, SPLIT=1.
+TEST_F(NetIbMPITest, MultiQpFanIn) {
+    const char* qps  = getenv("NCCL_IB_QPS_PER_CONNECTION");
+    const char* split = getenv("NCCL_IB_SPLIT_DATA_ON_QPS");
+    if (!qps || atoi(qps) < 2 || !split || strcmp(split, "1") != 0) {
+        GTEST_SKIP() << "Requires NCCL_IB_QPS_PER_CONNECTION>=2, NCCL_IB_SPLIT_DATA_ON_QPS=1";
+    }
+
+    ASSERT_TRUE(validateTestPrerequisites(kMinFourProcesses, kMinFourProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    std::vector<DirectedConnection> conns;
+    SetupFanIn(0, 0, {1, 2, 3}, conns);
+
+    const size_t sz = 16384;
+    auto buf = makeHostBufferAutoGuard(malloc(sz));
+    ASSERT_NE(buf.get(), nullptr);
+
+    std::vector<void*> mhandles;
+    for (auto& c : conns) {
+        void* comm = nullptr;
+        if (rank == c.senderRank)   comm = c.sendComm;
+        if (rank == c.receiverRank) comm = c.recvComm;
+        void* mh = nullptr;
+        if (comm) {
+            ASSERT_EQ(RegisterMemory(comm, buf.get(), sz, NCCL_PTR_HOST, &mh), ncclSuccess);
+        }
+        mhandles.push_back(mh);
+    }
+    auto mrCleanup = makeScopeGuard([&]() {
+        for (size_t i = 0; i < conns.size(); i++) {
+            if (!mhandles[i]) continue;
+            void* comm = nullptr;
+            if (rank == conns[i].senderRank)   comm = conns[i].sendComm;
+            if (rank == conns[i].receiverRank) comm = conns[i].recvComm;
+            if (comm) DeregisterMemory(comm, mhandles[i]);
+        }
+    });
+
+    static constexpr int kIters = 100;
+    for (int iter = 0; iter < kIters; iter++) {
+        for (size_t c = 0; c < conns.size(); c++) {
+            int seed = iter * 10 + conns[c].senderRank;
+            DoDirectedSendRecv(conns[c], buf.get(), buf.get(), sz,
+                               /*tag=*/iter, mhandles[c], mhandles[c], seed);
+        }
+    }
+
+    // Deregister memory before closing connections (comm must be valid for DeregMr).
+    for (size_t i = 0; i < conns.size(); i++) {
+        if (!mhandles[i]) continue;
+        void* comm = nullptr;
+        if (rank == conns[i].senderRank)   comm = conns[i].sendComm;
+        if (rank == conns[i].receiverRank) comm = conns[i].recvComm;
+        if (comm) DeregisterMemory(comm, mhandles[i]);
+        mhandles[i] = nullptr;
+    }
+    mrCleanup.dismiss();
+
+    for (auto& c : conns) CloseDirectedConnection(c);
+}
+
+// G2.  BidirectionalMultiRank — all pairs bidirectional, 4 ranks, 50 iters.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -201,12 +201,16 @@ TEST_F(NetIbMPITest, TagZeroReuse) {
     }
 }
 
-// E6.  AdaptiveRoutingThresholdBoundary — sizes around AR_THRESHOLD (8192).
+// E5.  AdaptiveRoutingThresholdBoundary — sizes around AR_THRESHOLD (8192).
 //      When AR is enabled and size > threshold, ncclIbMultiSend adds a
 //      0-byte RDMA_WRITE_WITH_IMM work request (net_ib.cc:2396).
 TEST_F(NetIbMPITest, AdaptiveRoutingThresholdBoundary) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
+    const char* arEnv = getenv("NCCL_IB_ADAPTIVE_ROUTING");
+    if (!arEnv || atoi(arEnv) == 0) {
+        GTEST_SKIP() << "Set NCCL_IB_ADAPTIVE_ROUTING=1 to run this test";
+    }
     int rank = MPIEnvironment::world_rank;
     AssertInitAndGetDevices(nullptr);
 
@@ -238,7 +242,7 @@ TEST_F(NetIbMPITest, AdaptiveRoutingThresholdBoundary) {
     }
 }
 
-// E7.  InlineSendBoundary — CTS inline path (NCCL_IB_USE_INLINE=1).
+// E6.  InlineSendBoundary — CTS inline path (NCCL_IB_USE_INLINE=1).
 //      Exercises IBV_SEND_INLINE for the FIFO CTS write.
 TEST_F(NetIbMPITest, InlineSendBoundary) {
     const char* env = getenv("NCCL_IB_USE_INLINE");
@@ -273,7 +277,7 @@ TEST_F(NetIbMPITest, InlineSendBoundary) {
     }
 }
 
-// E8.  MixedSizeBarrage — 25 sizes from 1B to 64MB on a single connection.
+// E7.  MixedSizeBarrage — 25 sizes from 1B to 64MB on a single connection.
 //      Exercises alignment boundaries, AR threshold, inline paths, and
 //      large-MR registration.
 TEST_F(NetIbMPITest, MixedSizeBarrage) {
@@ -1525,7 +1529,7 @@ TEST_F(NetIbMPITest, RapidRecvPostDrain) {
     }
 }
 
-// E5.  SetNetAttrNoOp — calls ncclIbSetNetAttr (the last entry in ncclNet_t).
+// E8.  SetNetAttrNoOp — calls ncclIbSetNetAttr (the last entry in ncclNet_t).
 //      The function is a pure no-op (two (void) casts + return ncclSuccess).
 //      All it needs is a call to reach its body; FNDA shows 0 hits without this test.
 TEST_F(NetIbMPITest, SetNetAttrNoOp) {

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -204,5 +204,41 @@ TEST_F(NetIbMPITest, TagZeroReuse) {
 // E6.  AdaptiveRoutingThresholdBoundary — sizes around AR_THRESHOLD (8192).
 //      When AR is enabled and size > threshold, ncclIbMultiSend adds a
 //      0-byte RDMA_WRITE_WITH_IMM work request (net_ib.cc:2396).
+TEST_F(NetIbMPITest, AdaptiveRoutingThresholdBoundary) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    ConnectionPair cp;
+    NetConnectionGuard guard(net_);
+    SetupConnectionWithGuard(0, cp, guard);
+
+    const size_t maxSz = 16384;
+    auto buf = makeHostBufferAutoGuard(malloc(maxSz));
+    ASSERT_NE(buf.get(), nullptr);
+
+    void* comm = (rank == 0) ? cp.recvComm : cp.sendComm;
+    void* mh = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf.get(), maxSz, NCCL_PTR_HOST, &mh), ncclSuccess);
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+
+    // Sizes that straddle the default AR threshold of 8192
+    const size_t sizes[] = {8190, 8191, 8192, 8193, 8194};
+    static constexpr int kRepeats = 10;
+
+    for (size_t sz : sizes) {
+        for (int r = 0; r < kRepeats; r++) {
+            int tag = static_cast<int>(sz) + r;
+            DoSendRecv(cp.sendComm, cp.recvComm,
+                       buf.get(), buf.get(), sz,
+                       tag, mh, mh,
+                       /*patternSeed=*/tag);
+        }
+    }
+}
+
+// E7.  InlineSendBoundary — CTS inline path (NCCL_IB_USE_INLINE=1).
+//      Exercises IBV_SEND_INLINE for the FIFO CTS write.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -1044,5 +1044,64 @@ TEST_F(NetIbMPITest, FanOutStress) {
 }
 
 // B3.  AllToAllStress — full mesh (12 connections for 4 ranks), 50 iters.
+TEST_F(NetIbMPITest, AllToAllStress) {
+    ASSERT_TRUE(validateTestPrerequisites(kMinFourProcesses, kMinFourProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    int nranks = MPIEnvironment::world_size;
+    AssertInitAndGetDevices(nullptr);
+
+    std::vector<DirectedConnection> conns;
+    SetupAllToAll(/*dev=*/0, nranks, conns);
+
+    const size_t sz = kSmallBufferSize;
+    auto buf = makeHostBufferAutoGuard(malloc(sz));
+    ASSERT_NE(buf.get(), nullptr);
+
+    std::vector<void*> mhandles;
+    for (auto& c : conns) {
+        void* comm = nullptr;
+        if (rank == c.senderRank)   comm = c.sendComm;
+        if (rank == c.receiverRank) comm = c.recvComm;
+        void* mh = nullptr;
+        if (comm) {
+            ASSERT_EQ(RegisterMemory(comm, buf.get(), sz, NCCL_PTR_HOST, &mh), ncclSuccess);
+        }
+        mhandles.push_back(mh);
+    }
+    auto mrCleanup = makeScopeGuard([&]() {
+        for (size_t i = 0; i < conns.size(); i++) {
+            if (!mhandles[i]) continue;
+            void* comm = nullptr;
+            if (rank == conns[i].senderRank)   comm = conns[i].sendComm;
+            if (rank == conns[i].receiverRank) comm = conns[i].recvComm;
+            if (comm) DeregisterMemory(comm, mhandles[i]);
+        }
+    });
+
+    static constexpr int kIters = 50;
+    for (int iter = 0; iter < kIters; iter++) {
+        for (size_t c = 0; c < conns.size(); c++) {
+            int seed = iter * 100 + conns[c].senderRank * 10 + conns[c].receiverRank;
+            DoDirectedSendRecv(conns[c], buf.get(), buf.get(), sz,
+                               /*tag=*/iter, mhandles[c], mhandles[c], seed);
+        }
+    }
+
+    // Deregister memory before closing connections (comm must be valid for DeregMr).
+    for (size_t i = 0; i < conns.size(); i++) {
+        if (!mhandles[i]) continue;
+        void* comm = nullptr;
+        if (rank == conns[i].senderRank)   comm = conns[i].sendComm;
+        if (rank == conns[i].receiverRank) comm = conns[i].recvComm;
+        if (comm) DeregisterMemory(comm, mhandles[i]);
+        mhandles[i] = nullptr;
+    }
+    mrCleanup.dismiss();
+
+    for (auto& c : conns) CloseDirectedConnection(c);
+}
+
+// D3.  MultiQpFanIn — fan-in 3→1 with QPS=4, SPLIT=1.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -19,9 +19,8 @@
 //  Group E: Branch-coverage (2-rank)
 // =====================================================================
 
-// E0.  InvalidRecvCount — calls ncclIbIrecv with n > NCCL_NET_IB_MAX_RECVS (8).
-//      Covers the early-return branch at net_ib.cc:2731.
-//      Requires a live recvComm (ready==1); the call must not crash.
+// E0.  InvalidRecvCount — ncclIbIrecv with n > NCCL_NET_IB_MAX_RECVS (8)
+//      must reject the request without crashing on a live recvComm.
 TEST_F(NetIbMPITest, InvalidRecvCount) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
@@ -46,12 +45,9 @@ TEST_F(NetIbMPITest, InvalidRecvCount) {
     MPI_Barrier(MPI_COMM_WORLD);
 }
 
-// E1.  MrCacheRefCount — registers the same host buffer twice on the same comm.
-//      On the second RegisterMemory call the MR cache finds the range and increments
-//      refs to 2 (ncclIbRegMrDmaBufInternal L2276). The first DeregMr decrements
-//      refs to 1 without freeing (ncclIbDeregMrInternal refs>0 branch). The second
-//      DeregMr decrements to 0 and actually calls wrap_ibv_dereg_mr.
-//      Covers ncclIbDeregMrInternal L2326 "refs > 0" path.
+// E1.  MrCacheRefCount — registers the same host buffer twice on the same
+//      comm: cache hit bumps refs to 2, two Dereg calls bring it back to 0
+//      (covers the refs>0 branch in ncclIbDeregMrInternal).
 TEST_F(NetIbMPITest, MrCacheRefCount) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
@@ -87,9 +83,8 @@ TEST_F(NetIbMPITest, MrCacheRefCount) {
     MPI_Barrier(MPI_COMM_WORLD);
 }
 
-// E2.  SendSizeClamping — sender posts a buffer larger than the receiver's posted size.
-//      Covers the ncclIbIsend L2543 branch: if (size > slots[r].size) size = slots[r].size.
-//      The transfer should complete cleanly; only recv_size bytes are transferred.
+// E2.  SendSizeClamping — sender posts a buffer larger than the receiver's
+//      posted size; isend must clamp to recv_size and complete cleanly.
 TEST_F(NetIbMPITest, SendSizeClamping) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
@@ -131,9 +126,11 @@ TEST_F(NetIbMPITest, SendSizeClamping) {
     MPI_Barrier(MPI_COMM_WORLD);
 
     if (rank == 1) {
-        // Post send with kSendSize > kRecvSize — ncclIbIsend will clamp to kRecvSize
+        // Post send with kSendSize > kRecvSize — ncclIbIsend will clamp to kRecvSize.
+        // PostSendWithRetry already calls FAIL() internally if it exhausts retries;
+        // a redundant ASSERT_NE here would exit rank 1 before MPI_Barrier, leaving
+        // rank 0 hung on WaitForCompletion.
         PostSendWithRetry(cp.sendComm, sendBuf.get(), kSendSize, kTag, sendMh, &req);
-        ASSERT_NE(req, nullptr);
     }
 
     int sizes[1] = {0};
@@ -155,10 +152,8 @@ TEST_F(NetIbMPITest, SendSizeClamping) {
     if (rank == 1 && sendMh) DeregisterMemory(cp.sendComm, sendMh);
 }
 
-// E3.  NullCommClose — closes a NULL send/recv comm pointer.
-//      Covers the ncclIbCloseSend/ncclIbCloseRecv null-guard branch
-//      (net_ib.cc:3063 and 3083: if (comm) {...}).
-//      The API must return ncclSuccess without crashing.
+// E3.  NullCommClose — ncclIbCloseSend/Recv on NULL must return
+//      ncclSuccess without crashing (null-guard branch).
 TEST_F(NetIbMPITest, NullCommClose) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
@@ -202,8 +197,8 @@ TEST_F(NetIbMPITest, TagZeroReuse) {
 }
 
 // E5.  AdaptiveRoutingThresholdBoundary — sizes around AR_THRESHOLD (8192).
-//      When AR is enabled and size > threshold, ncclIbMultiSend adds a
-//      0-byte RDMA_WRITE_WITH_IMM work request (net_ib.cc:2396).
+//      When AR is enabled and size > threshold, ncclIbMultiSend appends a
+//      0-byte RDMA_WRITE_WITH_IMM work request.
 TEST_F(NetIbMPITest, AdaptiveRoutingThresholdBoundary) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
@@ -324,9 +319,9 @@ TEST_F(NetIbMPITest, MixedSizeBarrage) {
 //  Group A: Resource exhaustion (2-rank)
 // =====================================================================
 
-// A2.  FifoPressureSenderFast — receiver deliberately slow, sender in
+// A1.  FifoPressureSenderFast — receiver deliberately slow, sender in
 //      tight loop.  Verifies that isend returns *request==NULL when the
-//      FIFO slot is not ready (backpressure, net_ib.cc:2535).
+//      FIFO slot is not ready (backpressure).
 TEST_F(NetIbMPITest, FifoPressureSenderFast) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
@@ -349,6 +344,10 @@ TEST_F(NetIbMPITest, FifoPressureSenderFast) {
     static constexpr int kMsgs = 50;
     static constexpr int kRecvDelayUs = 200000; // 200ms
 
+    // Both ranks operate in independent loops with only one MPI_Barrier at the end.
+    // ASSERT_ inside these loops would cause one rank to exit before the final barrier,
+    // leaving the other rank hung (deadlock) or waiting up to kStressTimeoutMs per
+    // unmatched recv (long hang). Use EXPECT_ throughout so both ranks reach the barrier.
     if (rank == 0) {
         // Receiver: deliberately slow
         for (int i = 0; i < kMsgs; i++) {
@@ -356,7 +355,7 @@ TEST_F(NetIbMPITest, FifoPressureSenderFast) {
             void* req = nullptr;
             PostSingleRecv(cp.recvComm, buf.get(), sz, /*tag=*/i, mh, &req);
             int rsz = 0;
-            ASSERT_EQ(WaitForCompletion(req, &rsz, kStressTimeoutMs), ncclSuccess);
+            EXPECT_EQ(WaitForCompletion(req, &rsz, kStressTimeoutMs), ncclSuccess);
         }
     } else {
         // Sender: tight loop, count NULL-request returns
@@ -367,18 +366,23 @@ TEST_F(NetIbMPITest, FifoPressureSenderFast) {
             void* req = nullptr;
             int attempts = 0;
             do {
-                ASSERT_EQ(PostSend(cp.sendComm, buf.get(), sz, /*tag=*/i, mh, &req), ncclSuccess);
+                ncclResult_t r = PostSend(cp.sendComm, buf.get(), sz, /*tag=*/i, mh, &req);
+                EXPECT_EQ(r, ncclSuccess);
+                if (r != ncclSuccess) break;
                 if (!req) {
                     nullCount++;
                     usleep(1000); // 1ms
                 }
                 if (++attempts > 100000) {
-                    FAIL() << "PostSend stuck at msg " << i;
+                    ADD_FAILURE() << "PostSend stuck at msg " << i;
+                    break;
                 }
             } while (!req);
 
-            int rsz = 0;
-            ASSERT_EQ(WaitForCompletion(req, &rsz, kStressTimeoutMs), ncclSuccess);
+            if (req) {
+                int rsz = 0;
+                EXPECT_EQ(WaitForCompletion(req, &rsz, kStressTimeoutMs), ncclSuccess);
+            }
         }
         // Backpressure must have been observed at least once
         EXPECT_GT(nullCount, 0) << "Expected at least one NULL-request (FIFO backpressure)";
@@ -386,7 +390,7 @@ TEST_F(NetIbMPITest, FifoPressureSenderFast) {
     MPI_Barrier(MPI_COMM_WORLD);
 }
 
-// A1.  RequestSlotExhaustion — post NCCL_NET_MAX_REQUESTS (32) irecvs,
+// A2.  RequestSlotExhaustion — post NCCL_NET_MAX_REQUESTS (32) irecvs,
 //      then drain all via matching sends, then verify slots are recycled.
 TEST_F(NetIbMPITest, RequestSlotExhaustion) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
@@ -546,32 +550,56 @@ TEST_F(NetIbMPITest, ConcurrentMultiConnectionStress) {
         void* mh  = nullptr;
     };
     std::vector<ConnInfo> conns(kNumConns);
+    // Track per-connection setup success so the transfer loop can skip broken
+    // connections without rank skew on MPI_Barrier counts.
+    std::vector<bool> conn_ok(kNumConns, false);
 
-    // Setup all connections with unique MPI tags
+    // Setup all connections with unique MPI tags.
+    // Use EXPECT_ (non-fatal) throughout so both ranks always reach MPI_Barrier.
+    // On rank 0 failure we still call MPI_Send (with a zeroed handle) to unblock
+    // rank 1 which is waiting on MPI_Recv — ASSERT_ before MPI_Send would leave
+    // rank 1 hung indefinitely.
     for (int c = 0; c < kNumConns; c++) {
+        bool ok = true;
         if (rank == 0) {
-            ASSERT_EQ(CreateListenComm(0, &conns[c].pair.handle, &conns[c].pair.listenComm), ncclSuccess);
+            ncclResult_t r = CreateListenComm(0, &conns[c].pair.handle, &conns[c].pair.listenComm);
+            EXPECT_EQ(r, ncclSuccess) << "CreateListenComm failed for conn " << c;
+            ok = (r == ncclSuccess && conns[c].pair.listenComm != nullptr);
+            // Always send handle to unblock rank 1; zeroed handle causes ConnectToRemote
+            // to fail on rank 1 so both ranks end up with ok=false consistently.
+            if (!ok) memset(&conns[c].pair.handle, 0, sizeof(conns[c].pair.handle));
             MPI_Send(&conns[c].pair.handle, sizeof(ncclNetHandle_t), MPI_BYTE, 1, 500 + c, MPI_COMM_WORLD);
-            for (int a = 0; a < kMaxRetryAttempts && !conns[c].pair.recvComm; a++) {
-                AcceptConnection(conns[c].pair.listenComm, &conns[c].pair.recvComm);
-                if (!conns[c].pair.recvComm) usleep(kPollIntervalUs);
+            if (ok) {
+                for (int a = 0; a < kMaxRetryAttempts && !conns[c].pair.recvComm; a++) {
+                    AcceptConnection(conns[c].pair.listenComm, &conns[c].pair.recvComm);
+                    if (!conns[c].pair.recvComm) usleep(kPollIntervalUs);
+                }
+                EXPECT_NE(conns[c].pair.recvComm, nullptr) << "Accept failed for conn " << c;
+                ok = (conns[c].pair.recvComm != nullptr);
             }
-            ASSERT_NE(conns[c].pair.recvComm, nullptr);
         } else {
             MPI_Recv(&conns[c].pair.handle, sizeof(ncclNetHandle_t), MPI_BYTE, 0, 500 + c, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
             for (int a = 0; a < kMaxRetryAttempts && !conns[c].pair.sendComm; a++) {
                 ConnectToRemote(0, &conns[c].pair.handle, &conns[c].pair.sendComm);
                 if (!conns[c].pair.sendComm) usleep(kPollIntervalUs);
             }
-            ASSERT_NE(conns[c].pair.sendComm, nullptr);
+            EXPECT_NE(conns[c].pair.sendComm, nullptr) << "Connect failed for conn " << c;
+            ok = (conns[c].pair.sendComm != nullptr);
         }
         MPI_Barrier(MPI_COMM_WORLD);
 
-        // Allocate + register buffer per connection
-        conns[c].buf = malloc(sz);
-        ASSERT_NE(conns[c].buf, nullptr);
-        void* comm = (rank == 0) ? conns[c].pair.recvComm : conns[c].pair.sendComm;
-        ASSERT_EQ(RegisterMemory(comm, conns[c].buf, sz, NCCL_PTR_HOST, &conns[c].mh), ncclSuccess);
+        if (ok) {
+            conns[c].buf = malloc(sz);
+            EXPECT_NE(conns[c].buf, nullptr) << "malloc failed for conn " << c;
+            ok = (conns[c].buf != nullptr);
+        }
+        if (ok) {
+            void* comm = (rank == 0) ? conns[c].pair.recvComm : conns[c].pair.sendComm;
+            EXPECT_EQ(RegisterMemory(comm, conns[c].buf, sz, NCCL_PTR_HOST, &conns[c].mh), ncclSuccess)
+                << "RegisterMemory failed for conn " << c;
+            ok = (conns[c].mh != nullptr);
+        }
+        conn_ok[c] = ok;
     }
 
     auto cleanup = makeScopeGuard([&]() {
@@ -588,11 +616,18 @@ TEST_F(NetIbMPITest, ConcurrentMultiConnectionStress) {
         }
     });
 
-    // Transfer on all 4 connections per iteration
+    // Transfer on all 4 connections per iteration.
+    // Skip connections that failed during setup; both ranks must take the same
+    // branch to keep MPI_Barrier counts consistent (DoSendRecv has one barrier,
+    // the explicit MPI_Barrier below substitutes it when skipping).
     for (int iter = 0; iter < kIters; iter++) {
         for (int c = 0; c < kNumConns; c++) {
             int tag  = iter * kNumConns + c;
             int seed = tag + 1000;
+            if (!conn_ok[c]) {
+                MPI_Barrier(MPI_COMM_WORLD);  // matches the barrier inside DoSendRecv
+                continue;
+            }
             DoSendRecv(conns[c].pair.sendComm, conns[c].pair.recvComm,
                        conns[c].buf, conns[c].buf, sz,
                        tag, conns[c].mh, conns[c].mh, seed);
@@ -600,7 +635,7 @@ TEST_F(NetIbMPITest, ConcurrentMultiConnectionStress) {
     }
 }
 
-// C3.  ConnectionChurnUnderLoad — 1000 connect→transfer→close cycles,
+// C2.  ConnectionChurnUnderLoad — 1000 connect→transfer→close cycles,
 //      with RDMA resource leak detection.
 TEST_F(NetIbMPITest, ConnectionChurnUnderLoad) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
@@ -625,8 +660,9 @@ TEST_F(NetIbMPITest, ConnectionChurnUnderLoad) {
         static constexpr int kWarmupTag = 599;
         ConnectionPair wcp;
         if (rank == 0) {
-            ASSERT_EQ(CreateListenComm(0, &wcp.handle, &wcp.listenComm), ncclSuccess);
+            ncclResult_t r = CreateListenComm(0, &wcp.handle, &wcp.listenComm);
             MPI_Send(&wcp.handle, sizeof(ncclNetHandle_t), MPI_BYTE, 1, kWarmupTag, MPI_COMM_WORLD);
+            ASSERT_EQ(r, ncclSuccess) << "Warmup CreateListenComm failed";
             for (int a = 0; a < kMaxRetryAttempts && !wcp.recvComm; a++) {
                 AcceptConnection(wcp.listenComm, &wcp.recvComm);
                 if (!wcp.recvComm) usleep(kPollIntervalUs);
@@ -661,8 +697,9 @@ TEST_F(NetIbMPITest, ConnectionChurnUnderLoad) {
         // Setup connection
         ConnectionPair cp;
         if (rank == 0) {
-            ASSERT_EQ(CreateListenComm(0, &cp.handle, &cp.listenComm), ncclSuccess);
+            ncclResult_t r = CreateListenComm(0, &cp.handle, &cp.listenComm);
             MPI_Send(&cp.handle, sizeof(ncclNetHandle_t), MPI_BYTE, 1, 600 + (iter % 1000), MPI_COMM_WORLD);
+            ASSERT_EQ(r, ncclSuccess) << "CreateListenComm failed at iter " << iter;
             for (int a = 0; a < kMaxRetryAttempts && !cp.recvComm; a++) {
                 AcceptConnection(cp.listenComm, &cp.recvComm);
                 if (!cp.recvComm) usleep(kPollIntervalUs);
@@ -709,7 +746,7 @@ TEST_F(NetIbMPITest, ConnectionChurnUnderLoad) {
     AssertNoRdmaLeaks(before, after, "final");
 }
 
-// C2.  ConnectionBatchCreateDestroy — create 10 connections, transfer on
+// C3.  ConnectionBatchCreateDestroy — create 10 connections, transfer on
 //      all, close all, repeat 100 times (1000 lifecycles total).
 //      RDMA checkpoints at batches 25, 50, 75, 100.
 TEST_F(NetIbMPITest, ConnectionBatchCreateDestroy) {
@@ -732,8 +769,9 @@ TEST_F(NetIbMPITest, ConnectionBatchCreateDestroy) {
         static constexpr int kWarmupTag = 699;
         ConnectionPair wcp;
         if (rank == 0) {
-            ASSERT_EQ(CreateListenComm(0, &wcp.handle, &wcp.listenComm), ncclSuccess);
+            ncclResult_t r = CreateListenComm(0, &wcp.handle, &wcp.listenComm);
             MPI_Send(&wcp.handle, sizeof(ncclNetHandle_t), MPI_BYTE, 1, kWarmupTag, MPI_COMM_WORLD);
+            ASSERT_EQ(r, ncclSuccess) << "Warmup CreateListenComm failed";
             for (int a = 0; a < kMaxRetryAttempts && !wcp.recvComm; a++) {
                 AcceptConnection(wcp.listenComm, &wcp.recvComm);
                 if (!wcp.recvComm) usleep(kPollIntervalUs);
@@ -775,8 +813,9 @@ TEST_F(NetIbMPITest, ConnectionBatchCreateDestroy) {
         for (int c = 0; c < kPerBatch; c++) {
             int mpiTag = 700 + batch * kPerBatch + c;
             if (rank == 0) {
-                ASSERT_EQ(CreateListenComm(0, &conns[c].cp.handle, &conns[c].cp.listenComm), ncclSuccess);
+                ncclResult_t r = CreateListenComm(0, &conns[c].cp.handle, &conns[c].cp.listenComm);
                 MPI_Send(&conns[c].cp.handle, sizeof(ncclNetHandle_t), MPI_BYTE, 1, mpiTag, MPI_COMM_WORLD);
+                ASSERT_EQ(r, ncclSuccess) << "CreateListenComm failed at batch " << batch << " conn " << c;
                 for (int a = 0; a < kMaxRetryAttempts && !conns[c].cp.recvComm; a++) {
                     AcceptConnection(conns[c].cp.listenComm, &conns[c].cp.recvComm);
                     if (!conns[c].cp.recvComm) usleep(kPollIntervalUs);
@@ -836,7 +875,7 @@ TEST_F(NetIbMPITest, ConnectionBatchCreateDestroy) {
 // =====================================================================
 
 // D1.  MultiQpSplitDataStress — QPS=8, SPLIT=1, alignment boundary sizes.
-//      Exercises the split logic at net_ib.cc:2436-2441.
+//      Exercises the per-QP split logic.
 TEST_F(NetIbMPITest, MultiQpSplitDataStress) {
     const char* qps  = getenv("NCCL_IB_QPS_PER_CONNECTION");
     const char* split = getenv("NCCL_IB_SPLIT_DATA_ON_QPS");
@@ -881,8 +920,7 @@ TEST_F(NetIbMPITest, MultiQpSplitDataStress) {
     }
 }
 
-// D2.  MultiQpNoSplitStress — QPS=4, SPLIT=0.
-//      Exercises the nDataQps path (net_ib.cc:2417).
+// D2.  MultiQpNoSplitStress — QPS=4, SPLIT=0; exercises the nDataQps path.
 TEST_F(NetIbMPITest, MultiQpNoSplitStress) {
     const char* qps  = getenv("NCCL_IB_QPS_PER_CONNECTION");
     const char* split = getenv("NCCL_IB_SPLIT_DATA_ON_QPS");
@@ -928,6 +966,8 @@ TEST_F(NetIbMPITest, MultiQpNoSplitStress) {
 
 // =====================================================================
 //  Group B: Multi-rank patterns (4 ranks)
+//  B1 FanInStress, B2 FanOutStress, B3 AllToAllStress,
+//  B4 MultiQpFanIn, B5 BidirectionalMultiRank, B6 LongRunningMultiRank
 // =====================================================================
 
 // B1.  FanInStress — ranks 1,2,3 each send to rank 0, 100 iterations.
@@ -1106,7 +1146,7 @@ TEST_F(NetIbMPITest, AllToAllStress) {
     for (auto& c : conns) CloseDirectedConnection(c);
 }
 
-// D3.  MultiQpFanIn — fan-in 3→1 with QPS=4, SPLIT=1.
+// B4.  MultiQpFanIn — fan-in 3→1 with QPS=4, SPLIT=1.
 TEST_F(NetIbMPITest, MultiQpFanIn) {
     const char* qps  = getenv("NCCL_IB_QPS_PER_CONNECTION");
     const char* split = getenv("NCCL_IB_SPLIT_DATA_ON_QPS");
@@ -1170,7 +1210,7 @@ TEST_F(NetIbMPITest, MultiQpFanIn) {
     for (auto& c : conns) CloseDirectedConnection(c);
 }
 
-// G2.  BidirectionalMultiRank — all pairs bidirectional, 4 ranks, 50 iters.
+// B5.  BidirectionalMultiRank — all pairs bidirectional, 4 ranks, 50 iters.
 TEST_F(NetIbMPITest, BidirectionalMultiRank) {
     ASSERT_TRUE(validateTestPrerequisites(kMinFourProcesses, kMinFourProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
@@ -1230,7 +1270,7 @@ TEST_F(NetIbMPITest, BidirectionalMultiRank) {
     for (auto& c : conns) CloseDirectedConnection(c);
 }
 
-// F2.  LongRunningMultiRank — fan-in 3→1, 1000 iterations, RDMA checkpoints.
+// B6.  LongRunningMultiRank — fan-in 3→1, 1000 iterations, RDMA checkpoints.
 TEST_F(NetIbMPITest, LongRunningMultiRank) {
     ASSERT_TRUE(validateTestPrerequisites(kMinFourProcesses, kMinFourProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));
@@ -1447,8 +1487,11 @@ TEST_F(NetIbMPITest, GpuMemoryTransferStress) {
             PostSendWithRetry(cp.sendComm, devBuf, sz, /*tag=*/cycle, mh, &req);
         }
 
+        // Use EXPECT_ (non-fatal) so both ranks always reach MPI_Barrier.
+        // ASSERT_ here would exit the failing rank before the barrier, leaving
+        // the other rank hung indefinitely.
         int rsz = 0;
-        ASSERT_EQ(WaitForCompletion(req, &rsz, kLargeTransferTimeoutMs), ncclSuccess);
+        EXPECT_EQ(WaitForCompletion(req, &rsz, kLargeTransferTimeoutMs), ncclSuccess);
         MPI_Barrier(MPI_COMM_WORLD);
 
         // Flush on receiver
@@ -1458,11 +1501,11 @@ TEST_F(NetIbMPITest, GpuMemoryTransferStress) {
             ncclResult_t fr = FlushRecv(cp.recvComm, 1, &devBuf, &flushSz, &mh, &flushReq);
             if (fr == ncclSuccess && flushReq) {
                 int fsz = 0;
-                ASSERT_EQ(WaitForCompletion(flushReq, &fsz, kLargeTransferTimeoutMs), ncclSuccess);
+                EXPECT_EQ(WaitForCompletion(flushReq, &fsz, kLargeTransferTimeoutMs), ncclSuccess);
             }
             // Verify
             bool ok = verifyBufferData<uint8_t>(devBuf, sz, makeBytePattern(cycle));
-            ASSERT_TRUE(ok) << "GPU data mismatch at cycle " << cycle;
+            EXPECT_TRUE(ok) << "GPU data mismatch at cycle " << cycle;
         }
         MPI_Barrier(MPI_COMM_WORLD);
     }
@@ -1532,6 +1575,8 @@ TEST_F(NetIbMPITest, RapidRecvPostDrain) {
 // E8.  SetNetAttrNoOp — calls ncclIbSetNetAttr (the last entry in ncclNet_t).
 //      The function is a pure no-op (two (void) casts + return ncclSuccess).
 //      All it needs is a call to reach its body; FNDA shows 0 hits without this test.
+//      Placed after Group J (not adjacent to E0-E7) because it was added in a later
+//      coverage iteration; the test number is kept to preserve git blame continuity.
 TEST_F(NetIbMPITest, SetNetAttrNoOp) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit));

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -1299,5 +1299,66 @@ TEST_F(NetIbMPITest, LongRunningMultiRank) {
 
 // G1.  BidirectionalSaturation — two opposing connections, full-duplex,
 //      50 iterations.
+TEST_F(NetIbMPITest, BidirectionalSaturation) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    // Forward: rank 1 → rank 0
+    DirectedConnection fwd;
+    SetupDirectedConnection(0, fwd, /*sender=*/1, /*receiver=*/0, /*mpiTag=*/800);
+
+    // Backward: rank 0 → rank 1
+    DirectedConnection bwd;
+    SetupDirectedConnection(0, bwd, /*sender=*/0, /*receiver=*/1, /*mpiTag=*/801);
+
+    const size_t sz = kSmallBufferSize;
+
+    // Separate buffers per connection — MR handles are not cross-comm portable
+    auto fwdBuf = makeHostBufferAutoGuard(malloc(sz));
+    auto bwdBuf = makeHostBufferAutoGuard(malloc(sz));
+    ASSERT_NE(fwdBuf.get(), nullptr);
+    ASSERT_NE(bwdBuf.get(), nullptr);
+
+    // Register for each connection this rank uses
+    void* fwdMh = nullptr;
+    void* bwdMh = nullptr;
+    {
+        void* fwdComm = (rank == fwd.senderRank) ? fwd.sendComm : fwd.recvComm;
+        void* bwdComm = (rank == bwd.senderRank) ? bwd.sendComm : bwd.recvComm;
+        if (fwdComm) ASSERT_EQ(RegisterMemory(fwdComm, fwdBuf.get(), sz, NCCL_PTR_HOST, &fwdMh), ncclSuccess);
+        if (bwdComm) ASSERT_EQ(RegisterMemory(bwdComm, bwdBuf.get(), sz, NCCL_PTR_HOST, &bwdMh), ncclSuccess);
+    }
+    static constexpr int kIters = 50;
+    for (int iter = 0; iter < kIters; iter++) {
+        // Forward direction
+        DoDirectedSendRecv(fwd, fwdBuf.get(), fwdBuf.get(), sz,
+                           /*tag=*/iter, fwdMh, fwdMh, iter * 2);
+        // Backward direction
+        DoDirectedSendRecv(bwd, bwdBuf.get(), bwdBuf.get(), sz,
+                           /*tag=*/iter, bwdMh, bwdMh, iter * 2 + 1);
+    }
+
+    // Deregister MR before closing connections
+    if (fwdMh) {
+        void* c = (rank == fwd.senderRank) ? fwd.sendComm : fwd.recvComm;
+        DeregisterMemory(c, fwdMh);
+    }
+    if (bwdMh) {
+        void* c = (rank == bwd.senderRank) ? bwd.sendComm : bwd.recvComm;
+        DeregisterMemory(c, bwdMh);
+    }
+
+    CloseDirectedConnection(fwd);
+    CloseDirectedConnection(bwd);
+}
+
+// =====================================================================
+//  Group F: Endurance (2-rank)
+// =====================================================================
+
+// F1.  LongRunningEndurance — 10000 transfers on a single connection,
+//      tag cycling, RDMA checkpoints.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -598,5 +598,115 @@ TEST_F(NetIbMPITest, ConcurrentMultiConnectionStress) {
 
 // C3.  ConnectionChurnUnderLoad — 1000 connect→transfer→close cycles,
 //      with RDMA resource leak detection.
+TEST_F(NetIbMPITest, ConnectionChurnUnderLoad) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    static constexpr int kIters = 1000;
+    const size_t sz = 1024;
+
+    auto buf = makeHostBufferAutoGuard(malloc(sz));
+    ASSERT_NE(buf.get(), nullptr);
+
+    // Run one warmup connection+close before capturing the baseline.
+    // The mlx5 driver lazily allocates internal CQs (e.g. for async-event
+    // bookkeeping) the first time a user-space CQ is created under a given
+    // ibv_context.  Those driver-internal objects survive until ibv_close_device
+    // and therefore show up as a stable "+N" in rdma resource show after the
+    // first connection.  By warming up first we let those objects settle so that
+    // the baseline reflects steady-state, not pre-first-connection state.
+    {
+        static constexpr int kWarmupTag = 599;
+        ConnectionPair wcp;
+        if (rank == 0) {
+            ASSERT_EQ(CreateListenComm(0, &wcp.handle, &wcp.listenComm), ncclSuccess);
+            MPI_Send(&wcp.handle, sizeof(ncclNetHandle_t), MPI_BYTE, 1, kWarmupTag, MPI_COMM_WORLD);
+            for (int a = 0; a < kMaxRetryAttempts && !wcp.recvComm; a++) {
+                AcceptConnection(wcp.listenComm, &wcp.recvComm);
+                if (!wcp.recvComm) usleep(kPollIntervalUs);
+            }
+            ASSERT_NE(wcp.recvComm, nullptr) << "Warmup accept failed";
+        } else {
+            MPI_Recv(&wcp.handle, sizeof(ncclNetHandle_t), MPI_BYTE, 0, kWarmupTag, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            for (int a = 0; a < kMaxRetryAttempts && !wcp.sendComm; a++) {
+                ConnectToRemote(0, &wcp.handle, &wcp.sendComm);
+                if (!wcp.sendComm) usleep(kPollIntervalUs);
+            }
+            ASSERT_NE(wcp.sendComm, nullptr) << "Warmup connect failed";
+        }
+        void* wcomm = (rank == 0) ? wcp.recvComm : wcp.sendComm;
+        void* wmh   = nullptr;
+        ASSERT_EQ(RegisterMemory(wcomm, buf.get(), sz, NCCL_PTR_HOST, &wmh), ncclSuccess);
+        DoSendRecv(wcp.sendComm, wcp.recvComm, buf.get(), buf.get(), sz, kWarmupTag, wmh, wmh, /*seed=*/0);
+        ASSERT_EQ(DeregisterMemory(wcomm, wmh), ncclSuccess);
+        if (rank == 0) {
+            ASSERT_EQ(CloseRecvComm(wcp.recvComm), ncclSuccess);
+            ASSERT_EQ(CloseListenComm(wcp.listenComm), ncclSuccess);
+        } else {
+            ASSERT_EQ(CloseSendComm(wcp.sendComm), ncclSuccess);
+        }
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    RdmaResourceCounts before = CaptureRdmaResources();
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    for (int iter = 0; iter < kIters; iter++) {
+        // Setup connection
+        ConnectionPair cp;
+        if (rank == 0) {
+            ASSERT_EQ(CreateListenComm(0, &cp.handle, &cp.listenComm), ncclSuccess);
+            MPI_Send(&cp.handle, sizeof(ncclNetHandle_t), MPI_BYTE, 1, 600 + (iter % 1000), MPI_COMM_WORLD);
+            for (int a = 0; a < kMaxRetryAttempts && !cp.recvComm; a++) {
+                AcceptConnection(cp.listenComm, &cp.recvComm);
+                if (!cp.recvComm) usleep(kPollIntervalUs);
+            }
+            ASSERT_NE(cp.recvComm, nullptr) << "Accept failed at iter " << iter;
+        } else {
+            MPI_Recv(&cp.handle, sizeof(ncclNetHandle_t), MPI_BYTE, 0, 600 + (iter % 1000), MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            for (int a = 0; a < kMaxRetryAttempts && !cp.sendComm; a++) {
+                ConnectToRemote(0, &cp.handle, &cp.sendComm);
+                if (!cp.sendComm) usleep(kPollIntervalUs);
+            }
+            ASSERT_NE(cp.sendComm, nullptr) << "Connect failed at iter " << iter;
+        }
+
+        // Register, transfer, verify
+        void* comm = (rank == 0) ? cp.recvComm : cp.sendComm;
+        void* mh = nullptr;
+        ASSERT_EQ(RegisterMemory(comm, buf.get(), sz, NCCL_PTR_HOST, &mh), ncclSuccess);
+
+        DoSendRecv(cp.sendComm, cp.recvComm,
+                   buf.get(), buf.get(), sz,
+                   /*tag=*/iter % 1000, mh, mh, iter);
+
+        ASSERT_EQ(DeregisterMemory(comm, mh), ncclSuccess);
+
+        // Close
+        if (rank == 0) {
+            ASSERT_EQ(CloseRecvComm(cp.recvComm), ncclSuccess);
+            ASSERT_EQ(CloseListenComm(cp.listenComm), ncclSuccess);
+        } else {
+            ASSERT_EQ(CloseSendComm(cp.sendComm), ncclSuccess);
+        }
+
+        // RDMA checkpoint at midpoint
+        if (iter == 499) {
+            MPI_Barrier(MPI_COMM_WORLD);
+            RdmaResourceCounts mid = CaptureRdmaResources();
+            AssertNoRdmaLeaks(before, mid, "midpoint");
+        }
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    RdmaResourceCounts after = CaptureRdmaResources();
+    AssertNoRdmaLeaks(before, after, "final");
+}
+
+// C2.  ConnectionBatchCreateDestroy — create 10 connections, transfer on
+//      all, close all, repeat 100 times (1000 lifecycles total).
+//      RDMA checkpoints at batches 25, 50, 75, 100.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -323,5 +323,66 @@ TEST_F(NetIbMPITest, MixedSizeBarrage) {
 // A2.  FifoPressureSenderFast — receiver deliberately slow, sender in
 //      tight loop.  Verifies that isend returns *request==NULL when the
 //      FIFO slot is not ready (backpressure, net_ib.cc:2535).
+TEST_F(NetIbMPITest, FifoPressureSenderFast) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    ConnectionPair cp;
+    NetConnectionGuard guard(net_);
+    SetupConnectionWithGuard(0, cp, guard);
+
+    const size_t sz = kSmallBufferSize;
+    auto buf = makeHostBufferAutoGuard(malloc(sz));
+    ASSERT_NE(buf.get(), nullptr);
+
+    void* comm = (rank == 0) ? cp.recvComm : cp.sendComm;
+    void* mh = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf.get(), sz, NCCL_PTR_HOST, &mh), ncclSuccess);
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+
+    static constexpr int kMsgs = 50;
+    static constexpr int kRecvDelayUs = 200000; // 200ms
+
+    if (rank == 0) {
+        // Receiver: deliberately slow
+        for (int i = 0; i < kMsgs; i++) {
+            if (i > 0) usleep(kRecvDelayUs);
+            void* req = nullptr;
+            PostSingleRecv(cp.recvComm, buf.get(), sz, /*tag=*/i, mh, &req);
+            int rsz = 0;
+            ASSERT_EQ(WaitForCompletion(req, &rsz, kStressTimeoutMs), ncclSuccess);
+        }
+    } else {
+        // Sender: tight loop, count NULL-request returns
+        int nullCount = 0;
+        for (int i = 0; i < kMsgs; i++) {
+            fillHostBufferWithPattern<uint8_t>(buf.get(), sz, makeBytePattern(i));
+
+            void* req = nullptr;
+            int attempts = 0;
+            do {
+                ASSERT_EQ(PostSend(cp.sendComm, buf.get(), sz, /*tag=*/i, mh, &req), ncclSuccess);
+                if (!req) {
+                    nullCount++;
+                    usleep(1000); // 1ms
+                }
+                if (++attempts > 100000) {
+                    FAIL() << "PostSend stuck at msg " << i;
+                }
+            } while (!req);
+
+            int rsz = 0;
+            ASSERT_EQ(WaitForCompletion(req, &rsz, kStressTimeoutMs), ncclSuccess);
+        }
+        // Backpressure must have been observed at least once
+        EXPECT_GT(nullCount, 0) << "Expected at least one NULL-request (FIFO backpressure)";
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// A1.  RequestSlotExhaustion — post NCCL_NET_MAX_REQUESTS (32) irecvs,
+//      then drain all via matching sends, then verify slots are recycled.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -52,5 +52,43 @@ TEST_F(NetIbMPITest, InvalidRecvCount) {
 //      refs to 1 without freeing (ncclIbDeregMrInternal refs>0 branch). The second
 //      DeregMr decrements to 0 and actually calls wrap_ibv_dereg_mr.
 //      Covers ncclIbDeregMrInternal L2326 "refs > 0" path.
+TEST_F(NetIbMPITest, MrCacheRefCount) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    ConnectionPair cp;
+    NetConnectionGuard guard(net_);
+    SetupConnectionWithGuard(/*dev=*/0, cp, guard);
+
+    void* comm = (rank == 0) ? cp.recvComm : cp.sendComm;
+
+    const size_t sz = 4096;
+    auto buf = makeHostBufferAutoGuard(malloc(sz));
+    ASSERT_NE(buf.get(), nullptr);
+
+    // First registration — inserts into cache with refs=1
+    void* mh1 = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf.get(), sz, NCCL_PTR_HOST, &mh1), ncclSuccess);
+    ASSERT_NE(mh1, nullptr);
+
+    // Second registration of the same buffer — hits cache, bumps refs to 2
+    void* mh2 = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf.get(), sz, NCCL_PTR_HOST, &mh2), ncclSuccess);
+    ASSERT_NE(mh2, nullptr);
+
+    // First deregMr — refs drops to 1; underlying MR stays alive
+    ASSERT_EQ(DeregisterMemory(comm, mh1), ncclSuccess);
+
+    // Second deregMr — refs drops to 0; underlying MR is freed
+    ASSERT_EQ(DeregisterMemory(comm, mh2), ncclSuccess);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// E2.  SendSizeClamping — sender posts a buffer larger than the receiver's posted size.
+//      Covers the ncclIbIsend L2543 branch: if (size > slots[r].size) size = slots[r].size.
+//      The transfer should complete cleanly; only recv_size bytes are transferred.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -1528,5 +1528,14 @@ TEST_F(NetIbMPITest, RapidRecvPostDrain) {
 // E5.  SetNetAttrNoOp — calls ncclIbSetNetAttr (the last entry in ncclNet_t).
 //      The function is a pure no-op (two (void) casts + return ncclSuccess).
 //      All it needs is a call to reach its body; FNDA shows 0 hits without this test.
+TEST_F(NetIbMPITest, SetNetAttrNoOp) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    AssertInitAndGetDevices(nullptr);
+    ASSERT_NE(net_->setNetAttr, nullptr);
+    EXPECT_EQ(net_->setNetAttr(initCtx_, nullptr), ncclSuccess);
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -1227,5 +1227,77 @@ TEST_F(NetIbMPITest, BidirectionalMultiRank) {
 }
 
 // F2.  LongRunningMultiRank — fan-in 3→1, 1000 iterations, RDMA checkpoints.
+TEST_F(NetIbMPITest, LongRunningMultiRank) {
+    ASSERT_TRUE(validateTestPrerequisites(kMinFourProcesses, kMinFourProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    std::vector<DirectedConnection> conns;
+    SetupFanIn(0, 0, {1, 2, 3}, conns);
+
+    const size_t sz = kSmallBufferSize;
+    auto buf = makeHostBufferAutoGuard(malloc(sz));
+    ASSERT_NE(buf.get(), nullptr);
+
+    std::vector<void*> mhandles;
+    for (auto& c : conns) {
+        void* comm = nullptr;
+        if (rank == c.senderRank)   comm = c.sendComm;
+        if (rank == c.receiverRank) comm = c.recvComm;
+        void* mh = nullptr;
+        if (comm) {
+            ASSERT_EQ(RegisterMemory(comm, buf.get(), sz, NCCL_PTR_HOST, &mh), ncclSuccess);
+        }
+        mhandles.push_back(mh);
+    }
+    auto mrCleanup = makeScopeGuard([&]() {
+        for (size_t i = 0; i < conns.size(); i++) {
+            if (!mhandles[i]) continue;
+            void* comm = nullptr;
+            if (rank == conns[i].senderRank)   comm = conns[i].sendComm;
+            if (rank == conns[i].receiverRank) comm = conns[i].recvComm;
+            if (comm) DeregisterMemory(comm, mhandles[i]);
+        }
+    });
+
+    RdmaResourceCounts before = CaptureRdmaResources();
+
+    static constexpr int kIters = 1000;
+    for (int iter = 0; iter < kIters; iter++) {
+        for (size_t c = 0; c < conns.size(); c++) {
+            int seed = iter * 10 + conns[c].senderRank;
+            DoDirectedSendRecv(conns[c], buf.get(), buf.get(), sz,
+                               /*tag=*/iter % 1000, mhandles[c], mhandles[c], seed);
+        }
+        if ((iter + 1) % 250 == 0) {
+            MPI_Barrier(MPI_COMM_WORLD);
+            RdmaResourceCounts cp = CaptureRdmaResources();
+            char label[64];
+            snprintf(label, sizeof(label), "iter %d", iter + 1);
+            AssertNoRdmaLeaks(before, cp, label);
+        }
+    }
+
+    // Deregister memory before closing connections (comm must be valid for DeregMr).
+    for (size_t i = 0; i < conns.size(); i++) {
+        if (!mhandles[i]) continue;
+        void* comm = nullptr;
+        if (rank == conns[i].senderRank)   comm = conns[i].sendComm;
+        if (rank == conns[i].receiverRank) comm = conns[i].recvComm;
+        if (comm) DeregisterMemory(comm, mhandles[i]);
+        mhandles[i] = nullptr;
+    }
+    mrCleanup.dismiss();
+
+    for (auto& c : conns) CloseDirectedConnection(c);
+}
+
+// =====================================================================
+//  Group G: Bidirectional (2-rank)
+// =====================================================================
+
+// G1.  BidirectionalSaturation — two opposing connections, full-duplex,
+//      50 iterations.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -276,5 +276,52 @@ TEST_F(NetIbMPITest, InlineSendBoundary) {
 // E8.  MixedSizeBarrage — 25 sizes from 1B to 64MB on a single connection.
 //      Exercises alignment boundaries, AR threshold, inline paths, and
 //      large-MR registration.
+TEST_F(NetIbMPITest, MixedSizeBarrage) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    ConnectionPair cp;
+    NetConnectionGuard guard(net_);
+    SetupConnectionWithGuard(0, cp, guard);
+
+    const size_t maxSz = 64 * 1024 * 1024; // 64 MB
+    auto buf = makeHostBufferAutoGuard(malloc(maxSz));
+    ASSERT_NE(buf.get(), nullptr);
+
+    void* comm = (rank == 0) ? cp.recvComm : cp.sendComm;
+    void* mh = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf.get(), maxSz, NCCL_PTR_HOST, &mh), ncclSuccess);
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+
+    const size_t sizes[] = {
+        1, 7, 13, 64, 127, 128, 129, 255, 256, 512,
+        1023, 1024, 4095, 4096, 8191, 8192, 8193,
+        16384, 32768, 65536, 131072,
+        1048576,   // 1 MB
+        4194304,   // 4 MB
+        16777216,  // 16 MB
+        67108864   // 64 MB
+    };
+
+    int tag = 0;
+    for (size_t sz : sizes) {
+        int timeout = (sz > 1024 * 1024) ? kLargeTransferTimeoutMs : kDefaultTimeoutMs;
+        DoSendRecv(cp.sendComm, cp.recvComm,
+                   buf.get(), buf.get(), sz,
+                   tag, mh, mh,
+                   /*patternSeed=*/tag, timeout);
+        tag++;
+    }
+}
+
+// =====================================================================
+//  Group A: Resource exhaustion (2-rank)
+// =====================================================================
+
+// A2.  FifoPressureSenderFast — receiver deliberately slow, sender in
+//      tight loop.  Verifies that isend returns *request==NULL when the
+//      FIFO slot is not ready (backpressure, net_ib.cc:2535).
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -833,5 +833,51 @@ TEST_F(NetIbMPITest, ConnectionBatchCreateDestroy) {
 
 // D1.  MultiQpSplitDataStress — QPS=8, SPLIT=1, alignment boundary sizes.
 //      Exercises the split logic at net_ib.cc:2436-2441.
+TEST_F(NetIbMPITest, MultiQpSplitDataStress) {
+    const char* qps  = getenv("NCCL_IB_QPS_PER_CONNECTION");
+    const char* split = getenv("NCCL_IB_SPLIT_DATA_ON_QPS");
+    if (!qps || atoi(qps) < 2 || !split || strcmp(split, "1") != 0) {
+        GTEST_SKIP() << "Requires NCCL_IB_QPS_PER_CONNECTION>=2, NCCL_IB_SPLIT_DATA_ON_QPS=1";
+    }
+
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    ConnectionPair cp;
+    NetConnectionGuard guard(net_);
+    SetupConnectionWithGuard(0, cp, guard);
+
+    const size_t maxSz = 1024 * 1024; // 1 MB
+    auto buf = makeHostBufferAutoGuard(malloc(maxSz));
+    ASSERT_NE(buf.get(), nullptr);
+
+    void* comm = (rank == 0) ? cp.recvComm : cp.sendComm;
+    void* mh = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf.get(), maxSz, NCCL_PTR_HOST, &mh), ncclSuccess);
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+
+    // Alignment boundary sizes (128B is the split threshold)
+    const size_t sizes[] = {
+        127, 128, 129, 255, 256, 257,
+        1023, 1024, 1025, 4095, 4096, 4097,
+        65535, 65536, 65537
+    };
+
+    static constexpr int kRepeats = 10;
+    int tag = 0;
+    for (size_t sz : sizes) {
+        for (int r = 0; r < kRepeats; r++) {
+            DoSendRecv(cp.sendComm, cp.recvComm,
+                       buf.get(), buf.get(), sz,
+                       tag, mh, mh, tag);
+            tag++;
+        }
+    }
+}
+
+// D2.  MultiQpNoSplitStress — QPS=4, SPLIT=0.
+//      Exercises the nDataQps path (net_ib.cc:2417).
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -1469,5 +1469,64 @@ TEST_F(NetIbMPITest, GpuMemoryTransferStress) {
 // =====================================================================
 
 // J1.  RapidRecvPostDrain — 100 cycles of post-32-recv → send-32 → drain.
+TEST_F(NetIbMPITest, RapidRecvPostDrain) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    ConnectionPair cp;
+    NetConnectionGuard guard(net_);
+    SetupConnectionWithGuard(0, cp, guard);
+
+    static constexpr int kCycles = 100;
+    static constexpr int kBatch  = 32;
+    const size_t sz = 256;
+
+    auto buf = makeHostBufferAutoGuard(malloc(sz * kBatch));
+    ASSERT_NE(buf.get(), nullptr);
+
+    void* comm = (rank == 0) ? cp.recvComm : cp.sendComm;
+    void* mh = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf.get(), sz * kBatch, NCCL_PTR_HOST, &mh), ncclSuccess);
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+
+    for (int cycle = 0; cycle < kCycles; cycle++) {
+        if (rank == 0) {
+            // Post all recvs
+            std::vector<void*> reqs(kBatch, nullptr);
+            for (int i = 0; i < kBatch; i++) {
+                char* p = static_cast<char*>(buf.get()) + i * sz;
+                PostSingleRecv(cp.recvComm, p, sz, /*tag=*/i, mh, &reqs[i]);
+            }
+            // Signal sender
+            MPI_Barrier(MPI_COMM_WORLD);
+            // Drain all
+            for (int i = 0; i < kBatch; i++) {
+                int rsz = 0;
+                ASSERT_EQ(WaitForCompletion(reqs[i], &rsz, kStressTimeoutMs), ncclSuccess)
+                    << "Drain failed cycle=" << cycle << " msg=" << i;
+            }
+        } else {
+            // Wait for recvs to be posted
+            MPI_Barrier(MPI_COMM_WORLD);
+            // Send all
+            for (int i = 0; i < kBatch; i++) {
+                char* p = static_cast<char*>(buf.get()) + i * sz;
+                fillHostBufferWithPattern<uint8_t>(p, sz, makeBytePattern(cycle * kBatch + i));
+                void* req = nullptr;
+                PostSendWithRetry(cp.sendComm, p, sz, /*tag=*/i, mh, &req);
+                int rsz = 0;
+                ASSERT_EQ(WaitForCompletion(req, &rsz, kStressTimeoutMs), ncclSuccess)
+                    << "Send failed cycle=" << cycle << " msg=" << i;
+            }
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+}
+
+// E5.  SetNetAttrNoOp — calls ncclIbSetNetAttr (the last entry in ncclNet_t).
+//      The function is a pure no-op (two (void) casts + return ncclSuccess).
+//      All it needs is a call to reach its body; FNDA shows 0 hits without this test.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -986,5 +986,63 @@ TEST_F(NetIbMPITest, FanInStress) {
 }
 
 // B2.  FanOutStress — rank 0 sends to ranks 1,2,3, 100 iterations.
+TEST_F(NetIbMPITest, FanOutStress) {
+    ASSERT_TRUE(validateTestPrerequisites(kMinFourProcesses, kMinFourProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    std::vector<DirectedConnection> conns;
+    SetupFanOut(/*dev=*/0, /*senderRank=*/0, {1, 2, 3}, conns);
+
+    const size_t sz = kSmallBufferSize;
+    auto buf = makeHostBufferAutoGuard(malloc(sz));
+    ASSERT_NE(buf.get(), nullptr);
+
+    std::vector<void*> mhandles;
+    for (auto& c : conns) {
+        void* comm = nullptr;
+        if (rank == c.senderRank)   comm = c.sendComm;
+        if (rank == c.receiverRank) comm = c.recvComm;
+        void* mh = nullptr;
+        if (comm) {
+            ASSERT_EQ(RegisterMemory(comm, buf.get(), sz, NCCL_PTR_HOST, &mh), ncclSuccess);
+        }
+        mhandles.push_back(mh);
+    }
+    auto mrCleanup = makeScopeGuard([&]() {
+        for (size_t i = 0; i < conns.size(); i++) {
+            if (!mhandles[i]) continue;
+            void* comm = nullptr;
+            if (rank == conns[i].senderRank)   comm = conns[i].sendComm;
+            if (rank == conns[i].receiverRank) comm = conns[i].recvComm;
+            if (comm) DeregisterMemory(comm, mhandles[i]);
+        }
+    });
+
+    static constexpr int kIters = 100;
+    for (int iter = 0; iter < kIters; iter++) {
+        for (size_t c = 0; c < conns.size(); c++) {
+            int seed = iter * 10 + conns[c].receiverRank;
+            DoDirectedSendRecv(conns[c], buf.get(), buf.get(), sz,
+                               /*tag=*/iter, mhandles[c], mhandles[c], seed);
+        }
+    }
+
+    // Deregister memory before closing connections (comm must be valid for DeregMr).
+    for (size_t i = 0; i < conns.size(); i++) {
+        if (!mhandles[i]) continue;
+        void* comm = nullptr;
+        if (rank == conns[i].senderRank)   comm = conns[i].sendComm;
+        if (rank == conns[i].receiverRank) comm = conns[i].recvComm;
+        if (comm) DeregisterMemory(comm, mhandles[i]);
+        mhandles[i] = nullptr;
+    }
+    mrCleanup.dismiss();
+
+    for (auto& c : conns) CloseDirectedConnection(c);
+}
+
+// B3.  AllToAllStress — full mesh (12 connections for 4 ranks), 50 iters.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -526,5 +526,77 @@ TEST_F(NetIbMPITest, MemoryRegistrationStorm) {
 
 // C1.  ConcurrentMultiConnectionStress — 4 connections on same device,
 //      concurrent I/O with independent tag spaces.
+TEST_F(NetIbMPITest, ConcurrentMultiConnectionStress) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    static constexpr int kNumConns = 4;
+    static constexpr int kIters = 10;
+    const size_t sz = kSmallBufferSize;
+
+    struct ConnInfo {
+        ConnectionPair pair;
+        void* buf = nullptr;
+        void* mh  = nullptr;
+    };
+    std::vector<ConnInfo> conns(kNumConns);
+
+    // Setup all connections with unique MPI tags
+    for (int c = 0; c < kNumConns; c++) {
+        if (rank == 0) {
+            ASSERT_EQ(CreateListenComm(0, &conns[c].pair.handle, &conns[c].pair.listenComm), ncclSuccess);
+            MPI_Send(&conns[c].pair.handle, sizeof(ncclNetHandle_t), MPI_BYTE, 1, 500 + c, MPI_COMM_WORLD);
+            for (int a = 0; a < kMaxRetryAttempts && !conns[c].pair.recvComm; a++) {
+                AcceptConnection(conns[c].pair.listenComm, &conns[c].pair.recvComm);
+                if (!conns[c].pair.recvComm) usleep(kPollIntervalUs);
+            }
+            ASSERT_NE(conns[c].pair.recvComm, nullptr);
+        } else {
+            MPI_Recv(&conns[c].pair.handle, sizeof(ncclNetHandle_t), MPI_BYTE, 0, 500 + c, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            for (int a = 0; a < kMaxRetryAttempts && !conns[c].pair.sendComm; a++) {
+                ConnectToRemote(0, &conns[c].pair.handle, &conns[c].pair.sendComm);
+                if (!conns[c].pair.sendComm) usleep(kPollIntervalUs);
+            }
+            ASSERT_NE(conns[c].pair.sendComm, nullptr);
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        // Allocate + register buffer per connection
+        conns[c].buf = malloc(sz);
+        ASSERT_NE(conns[c].buf, nullptr);
+        void* comm = (rank == 0) ? conns[c].pair.recvComm : conns[c].pair.sendComm;
+        ASSERT_EQ(RegisterMemory(comm, conns[c].buf, sz, NCCL_PTR_HOST, &conns[c].mh), ncclSuccess);
+    }
+
+    auto cleanup = makeScopeGuard([&]() {
+        for (auto& ci : conns) {
+            void* comm = (rank == 0) ? ci.pair.recvComm : ci.pair.sendComm;
+            if (ci.mh) DeregisterMemory(comm, ci.mh);
+            free(ci.buf);
+            if (rank == 0) {
+                if (ci.pair.recvComm)   CloseRecvComm(ci.pair.recvComm);
+                if (ci.pair.listenComm) CloseListenComm(ci.pair.listenComm);
+            } else {
+                if (ci.pair.sendComm) CloseSendComm(ci.pair.sendComm);
+            }
+        }
+    });
+
+    // Transfer on all 4 connections per iteration
+    for (int iter = 0; iter < kIters; iter++) {
+        for (int c = 0; c < kNumConns; c++) {
+            int tag  = iter * kNumConns + c;
+            int seed = tag + 1000;
+            DoSendRecv(conns[c].pair.sendComm, conns[c].pair.recvComm,
+                       conns[c].buf, conns[c].buf, sz,
+                       tag, conns[c].mh, conns[c].mh, seed);
+        }
+    }
+}
+
+// C3.  ConnectionChurnUnderLoad — 1000 connect→transfer→close cycles,
+//      with RDMA resource leak detection.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -1,0 +1,26 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Stress and branch-coverage unit tests for the base net-ib transport
+// (src/transport/net_ib.cc).  These target paths not exercised by the
+// happy-path functional tests in GeneralTests.cpp: resource exhaustion,
+// FIFO backpressure, multi-QP striping, adaptive routing thresholds,
+// multi-rank fan-in / fan-out / all-to-all, connection lifecycle stress,
+// and endurance.
+
+#include "NetIbMPITestBase.hpp"
+
+#ifdef MPI_TESTS_ENABLED
+
+// =====================================================================
+//  Group E: Branch-coverage (2-rank)
+// =====================================================================
+
+// E0.  InvalidRecvCount — calls ncclIbIrecv with n > NCCL_NET_IB_MAX_RECVS (8).
+//      Covers the early-return branch at net_ib.cc:2731.
+//      Requires a live recvComm (ready==1); the call must not crash.
+
+

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -447,5 +447,84 @@ TEST_F(NetIbMPITest, RequestSlotExhaustion) {
 
 // A3.  MemoryRegistrationStorm — register/deregister 512 unique buffers
 //      in various patterns to stress the MR cache.
+TEST_F(NetIbMPITest, MemoryRegistrationStorm) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    ConnectionPair cp;
+    NetConnectionGuard guard(net_);
+    SetupConnectionWithGuard(0, cp, guard);
+
+    void* comm = (rank == 0) ? cp.recvComm : cp.sendComm;
+
+    static constexpr int kNumBufs = 512;
+    static constexpr size_t kBufSz = 4096;
+
+    // Allocate all buffers
+    std::vector<void*> bufs(kNumBufs);
+    for (int i = 0; i < kNumBufs; i++) {
+        bufs[i] = malloc(kBufSz);
+        ASSERT_NE(bufs[i], nullptr) << "malloc failed at buffer " << i;
+    }
+    auto bufCleanup = makeScopeGuard([&]() {
+        for (auto* p : bufs) free(p);
+    });
+
+    // Phase 1: register all forward
+    std::vector<void*> handles(kNumBufs, nullptr);
+    for (int i = 0; i < kNumBufs; i++) {
+        ASSERT_EQ(RegisterMemory(comm, bufs[i], kBufSz, NCCL_PTR_HOST, &handles[i]), ncclSuccess)
+            << "regMr failed at " << i;
+    }
+
+    // Phase 2: deregister in reverse
+    for (int i = kNumBufs - 1; i >= 0; i--) {
+        ASSERT_EQ(DeregisterMemory(comm, handles[i]), ncclSuccess)
+            << "deregMr (reverse) failed at " << i;
+        handles[i] = nullptr;
+    }
+
+    // Phase 3: re-register all forward
+    for (int i = 0; i < kNumBufs; i++) {
+        ASSERT_EQ(RegisterMemory(comm, bufs[i], kBufSz, NCCL_PTR_HOST, &handles[i]), ncclSuccess)
+            << "re-regMr failed at " << i;
+    }
+
+    // Phase 4: deregister in shuffled order (deterministic)
+    std::vector<int> order(kNumBufs);
+    for (int i = 0; i < kNumBufs; i++) order[i] = i;
+    // Simple deterministic shuffle (seed=42)
+    for (int i = kNumBufs - 1; i > 0; i--) {
+        int j = (i * 42 + 17) % (i + 1);
+        std::swap(order[i], order[j]);
+    }
+    for (int idx : order) {
+        ASSERT_EQ(DeregisterMemory(comm, handles[idx]), ncclSuccess)
+            << "deregMr (shuffled) failed at idx " << idx;
+        handles[idx] = nullptr;
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Phase 5: verify connection is still alive with one transfer
+    auto tbuf = makeHostBufferAutoGuard(malloc(kBufSz));
+    ASSERT_NE(tbuf.get(), nullptr);
+    void* mh = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, tbuf.get(), kBufSz, NCCL_PTR_HOST, &mh), ncclSuccess);
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+
+    DoSendRecv(cp.sendComm, cp.recvComm,
+               tbuf.get(), tbuf.get(), kBufSz,
+               /*tag=*/0, mh, mh, /*patternSeed=*/999);
+}
+
+// =====================================================================
+//  Group C: Connection concurrency (2-rank)
+// =====================================================================
+
+// C1.  ConcurrentMultiConnectionStress — 4 connections on same device,
+//      concurrent I/O with independent tag spaces.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -173,5 +173,36 @@ TEST_F(NetIbMPITest, NullCommClose) {
 // E4.  TagZeroReuse — 50 messages all sent with tag=0.
 //      Verifies FIFO ordering: messages arrive in send order because
 //      the FIFO is a strict ring (slot = fifoHead % MAX_REQUESTS).
+TEST_F(NetIbMPITest, TagZeroReuse) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    ConnectionPair cp;
+    NetConnectionGuard guard(net_);
+    SetupConnectionWithGuard(/*dev=*/0, cp, guard);
+
+    const size_t sz = kSmallBufferSize;
+    auto buf = makeHostBufferAutoGuard(malloc(sz));
+    ASSERT_NE(buf.get(), nullptr);
+
+    void* comm = (rank == 0) ? cp.recvComm : cp.sendComm;
+    void* mh   = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf.get(), sz, NCCL_PTR_HOST, &mh), ncclSuccess);
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+
+    static constexpr int kIters = 50;
+    for (int i = 0; i < kIters; i++) {
+        DoSendRecv(cp.sendComm, cp.recvComm,
+                   buf.get(), buf.get(), sz,
+                   /*tag=*/0, mh, mh,
+                   /*patternSeed=*/i);
+    }
+}
+
+// E6.  AdaptiveRoutingThresholdBoundary — sizes around AR_THRESHOLD (8192).
+//      When AR is enabled and size > threshold, ncclIbMultiSend adds a
+//      0-byte RDMA_WRITE_WITH_IMM work request (net_ib.cc:2396).
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -879,5 +879,53 @@ TEST_F(NetIbMPITest, MultiQpSplitDataStress) {
 
 // D2.  MultiQpNoSplitStress — QPS=4, SPLIT=0.
 //      Exercises the nDataQps path (net_ib.cc:2417).
+TEST_F(NetIbMPITest, MultiQpNoSplitStress) {
+    const char* qps  = getenv("NCCL_IB_QPS_PER_CONNECTION");
+    const char* split = getenv("NCCL_IB_SPLIT_DATA_ON_QPS");
+    if (!qps || atoi(qps) < 2 || !split || strcmp(split, "0") != 0) {
+        GTEST_SKIP() << "Requires NCCL_IB_QPS_PER_CONNECTION>=2, NCCL_IB_SPLIT_DATA_ON_QPS=0";
+    }
+
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    ConnectionPair cp;
+    NetConnectionGuard guard(net_);
+    SetupConnectionWithGuard(0, cp, guard);
+
+    const size_t maxSz = 1024 * 1024;
+    auto buf = makeHostBufferAutoGuard(malloc(maxSz));
+    ASSERT_NE(buf.get(), nullptr);
+
+    void* comm = (rank == 0) ? cp.recvComm : cp.sendComm;
+    void* mh = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf.get(), maxSz, NCCL_PTR_HOST, &mh), ncclSuccess);
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+
+    const size_t sizes[] = {
+        127, 128, 129, 255, 256, 257,
+        1023, 1024, 1025, 4095, 4096, 4097,
+        65535, 65536, 65537
+    };
+
+    static constexpr int kRepeats = 10;
+    int tag = 0;
+    for (size_t sz : sizes) {
+        for (int r = 0; r < kRepeats; r++) {
+            DoSendRecv(cp.sendComm, cp.recvComm,
+                       buf.get(), buf.get(), sz,
+                       tag, mh, mh, tag);
+            tag++;
+        }
+    }
+}
+
+// =====================================================================
+//  Group B: Multi-rank patterns (4 ranks)
+// =====================================================================
+
+// B1.  FanInStress — ranks 1,2,3 each send to rank 0, 100 iterations.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -240,5 +240,41 @@ TEST_F(NetIbMPITest, AdaptiveRoutingThresholdBoundary) {
 
 // E7.  InlineSendBoundary — CTS inline path (NCCL_IB_USE_INLINE=1).
 //      Exercises IBV_SEND_INLINE for the FIFO CTS write.
+TEST_F(NetIbMPITest, InlineSendBoundary) {
+    const char* env = getenv("NCCL_IB_USE_INLINE");
+    if (!env || strcmp(env, "1") != 0) {
+        GTEST_SKIP() << "Requires NCCL_IB_USE_INLINE=1";
+    }
+
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    ConnectionPair cp;
+    NetConnectionGuard guard(net_);
+    SetupConnectionWithGuard(0, cp, guard);
+
+    const size_t maxSz = 1024 * 1024; // 1 MB
+    auto buf = makeHostBufferAutoGuard(malloc(maxSz));
+    ASSERT_NE(buf.get(), nullptr);
+
+    void* comm = (rank == 0) ? cp.recvComm : cp.sendComm;
+    void* mh = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf.get(), maxSz, NCCL_PTR_HOST, &mh), ncclSuccess);
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+
+    const size_t sizes[] = {1, 64, 128, 4096, maxSz};
+    int tag = 0;
+    for (size_t sz : sizes) {
+        DoSendRecv(cp.sendComm, cp.recvComm,
+                   buf.get(), buf.get(), sz,
+                   tag++, mh, mh, static_cast<int>(sz));
+    }
+}
+
+// E8.  MixedSizeBarrage — 25 sizes from 1B to 64MB on a single connection.
+//      Exercises alignment boundaries, AR threshold, inline paths, and
+//      large-MR registration.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -708,5 +708,130 @@ TEST_F(NetIbMPITest, ConnectionChurnUnderLoad) {
 // C2.  ConnectionBatchCreateDestroy — create 10 connections, transfer on
 //      all, close all, repeat 100 times (1000 lifecycles total).
 //      RDMA checkpoints at batches 25, 50, 75, 100.
+TEST_F(NetIbMPITest, ConnectionBatchCreateDestroy) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    static constexpr int kBatches  = 100;
+    static constexpr int kPerBatch = 10;
+    const size_t sz = 512;
+
+    auto buf = makeHostBufferAutoGuard(malloc(sz));
+    ASSERT_NE(buf.get(), nullptr);
+
+    // Warmup: one connect+transfer+close to let the driver settle its
+    // internal CQs before we capture the baseline (same reason as in
+    // ConnectionChurnUnderLoad — see comment there).
+    {
+        static constexpr int kWarmupTag = 699;
+        ConnectionPair wcp;
+        if (rank == 0) {
+            ASSERT_EQ(CreateListenComm(0, &wcp.handle, &wcp.listenComm), ncclSuccess);
+            MPI_Send(&wcp.handle, sizeof(ncclNetHandle_t), MPI_BYTE, 1, kWarmupTag, MPI_COMM_WORLD);
+            for (int a = 0; a < kMaxRetryAttempts && !wcp.recvComm; a++) {
+                AcceptConnection(wcp.listenComm, &wcp.recvComm);
+                if (!wcp.recvComm) usleep(kPollIntervalUs);
+            }
+            ASSERT_NE(wcp.recvComm, nullptr) << "Warmup accept failed";
+        } else {
+            MPI_Recv(&wcp.handle, sizeof(ncclNetHandle_t), MPI_BYTE, 0, kWarmupTag, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            for (int a = 0; a < kMaxRetryAttempts && !wcp.sendComm; a++) {
+                ConnectToRemote(0, &wcp.handle, &wcp.sendComm);
+                if (!wcp.sendComm) usleep(kPollIntervalUs);
+            }
+            ASSERT_NE(wcp.sendComm, nullptr) << "Warmup connect failed";
+        }
+        void* wcomm = (rank == 0) ? wcp.recvComm : wcp.sendComm;
+        void* wmh   = nullptr;
+        ASSERT_EQ(RegisterMemory(wcomm, buf.get(), sz, NCCL_PTR_HOST, &wmh), ncclSuccess);
+        DoSendRecv(wcp.sendComm, wcp.recvComm, buf.get(), buf.get(), sz, kWarmupTag, wmh, wmh, /*seed=*/0);
+        ASSERT_EQ(DeregisterMemory(wcomm, wmh), ncclSuccess);
+        if (rank == 0) {
+            ASSERT_EQ(CloseRecvComm(wcp.recvComm), ncclSuccess);
+            ASSERT_EQ(CloseListenComm(wcp.listenComm), ncclSuccess);
+        } else {
+            ASSERT_EQ(CloseSendComm(wcp.sendComm), ncclSuccess);
+        }
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    RdmaResourceCounts before = CaptureRdmaResources();
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    for (int batch = 0; batch < kBatches; batch++) {
+        // Create kPerBatch connections
+        struct BatchConn {
+            ConnectionPair cp;
+            void* mh = nullptr;
+        };
+        std::vector<BatchConn> conns(kPerBatch);
+
+        for (int c = 0; c < kPerBatch; c++) {
+            int mpiTag = 700 + batch * kPerBatch + c;
+            if (rank == 0) {
+                ASSERT_EQ(CreateListenComm(0, &conns[c].cp.handle, &conns[c].cp.listenComm), ncclSuccess);
+                MPI_Send(&conns[c].cp.handle, sizeof(ncclNetHandle_t), MPI_BYTE, 1, mpiTag, MPI_COMM_WORLD);
+                for (int a = 0; a < kMaxRetryAttempts && !conns[c].cp.recvComm; a++) {
+                    AcceptConnection(conns[c].cp.listenComm, &conns[c].cp.recvComm);
+                    if (!conns[c].cp.recvComm) usleep(kPollIntervalUs);
+                }
+                ASSERT_NE(conns[c].cp.recvComm, nullptr);
+            } else {
+                MPI_Recv(&conns[c].cp.handle, sizeof(ncclNetHandle_t), MPI_BYTE, 0, mpiTag, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                for (int a = 0; a < kMaxRetryAttempts && !conns[c].cp.sendComm; a++) {
+                    ConnectToRemote(0, &conns[c].cp.handle, &conns[c].cp.sendComm);
+                    if (!conns[c].cp.sendComm) usleep(kPollIntervalUs);
+                }
+                ASSERT_NE(conns[c].cp.sendComm, nullptr);
+            }
+            MPI_Barrier(MPI_COMM_WORLD);
+
+            void* comm = (rank == 0) ? conns[c].cp.recvComm : conns[c].cp.sendComm;
+            ASSERT_EQ(RegisterMemory(comm, buf.get(), sz, NCCL_PTR_HOST, &conns[c].mh), ncclSuccess);
+        }
+
+        // Transfer on each connection
+        for (int c = 0; c < kPerBatch; c++) {
+            int seed = batch * kPerBatch + c;
+            DoSendRecv(conns[c].cp.sendComm, conns[c].cp.recvComm,
+                       buf.get(), buf.get(), sz,
+                       /*tag=*/c, conns[c].mh, conns[c].mh, seed);
+        }
+
+        // Close all in this batch
+        for (int c = 0; c < kPerBatch; c++) {
+            void* comm = (rank == 0) ? conns[c].cp.recvComm : conns[c].cp.sendComm;
+            ASSERT_EQ(DeregisterMemory(comm, conns[c].mh), ncclSuccess);
+            if (rank == 0) {
+                ASSERT_EQ(CloseRecvComm(conns[c].cp.recvComm), ncclSuccess);
+                ASSERT_EQ(CloseListenComm(conns[c].cp.listenComm), ncclSuccess);
+            } else {
+                ASSERT_EQ(CloseSendComm(conns[c].cp.sendComm), ncclSuccess);
+            }
+        }
+
+        // RDMA checkpoints
+        if ((batch + 1) % 25 == 0) {
+            MPI_Barrier(MPI_COMM_WORLD);
+            RdmaResourceCounts cp = CaptureRdmaResources();
+            char label[64];
+            snprintf(label, sizeof(label), "batch %d", batch + 1);
+            AssertNoRdmaLeaks(before, cp, label);
+        }
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    RdmaResourceCounts after = CaptureRdmaResources();
+    AssertNoRdmaLeaks(before, after, "final");
+}
+
+// =====================================================================
+//  Group D: Multi-QP outside CAST (2-rank)
+// =====================================================================
+
+// D1.  MultiQpSplitDataStress — QPS=8, SPLIT=1, alignment boundary sizes.
+//      Exercises the split logic at net_ib.cc:2436-2441.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -1360,5 +1360,46 @@ TEST_F(NetIbMPITest, BidirectionalSaturation) {
 
 // F1.  LongRunningEndurance — 10000 transfers on a single connection,
 //      tag cycling, RDMA checkpoints.
+TEST_F(NetIbMPITest, LongRunningEndurance) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    ConnectionPair cp;
+    NetConnectionGuard guard(net_);
+    SetupConnectionWithGuard(0, cp, guard);
+
+    const size_t sz = kSmallBufferSize;
+    auto buf = makeHostBufferAutoGuard(malloc(sz));
+    ASSERT_NE(buf.get(), nullptr);
+
+    void* comm = (rank == 0) ? cp.recvComm : cp.sendComm;
+    void* mh = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf.get(), sz, NCCL_PTR_HOST, &mh), ncclSuccess);
+    NetMHandleGuard mhGuard(mh, NetMHandleDeleter(net_, comm));
+
+    RdmaResourceCounts before = CaptureRdmaResources();
+
+    static constexpr int kIters = 10000;
+    for (int i = 0; i < kIters; i++) {
+        DoSendRecv(cp.sendComm, cp.recvComm,
+                   buf.get(), buf.get(), sz,
+                   /*tag=*/i % 1000, mh, mh, i);
+
+        if ((i + 1) % 2500 == 0) {
+            RdmaResourceCounts cp2 = CaptureRdmaResources();
+            char label[64];
+            snprintf(label, sizeof(label), "iter %d", i + 1);
+            AssertNoRdmaLeaks(before, cp2, label);
+        }
+    }
+}
+
+// =====================================================================
+//  Group H: GPU/GDR (2-rank)
+// =====================================================================
+
+// H1.  GpuMemoryTransferStress — 5 alloc/transfer/flush/verify/free cycles.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/StressTests.cpp
@@ -927,5 +927,64 @@ TEST_F(NetIbMPITest, MultiQpNoSplitStress) {
 // =====================================================================
 
 // B1.  FanInStress — ranks 1,2,3 each send to rank 0, 100 iterations.
+TEST_F(NetIbMPITest, FanInStress) {
+    ASSERT_TRUE(validateTestPrerequisites(kMinFourProcesses, kMinFourProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit));
+    int rank = MPIEnvironment::world_rank;
+    AssertInitAndGetDevices(nullptr);
+
+    std::vector<DirectedConnection> conns;
+    SetupFanIn(/*dev=*/0, /*receiverRank=*/0, {1, 2, 3}, conns);
+
+    const size_t sz = kSmallBufferSize;
+    auto buf = makeHostBufferAutoGuard(malloc(sz));
+    ASSERT_NE(buf.get(), nullptr);
+
+    // Register buffer for each connection this rank participates in
+    std::vector<void*> mhandles;
+    for (auto& c : conns) {
+        void* comm = nullptr;
+        if (rank == c.senderRank)   comm = c.sendComm;
+        if (rank == c.receiverRank) comm = c.recvComm;
+        void* mh = nullptr;
+        if (comm) {
+            ASSERT_EQ(RegisterMemory(comm, buf.get(), sz, NCCL_PTR_HOST, &mh), ncclSuccess);
+        }
+        mhandles.push_back(mh);
+    }
+    auto mrCleanup = makeScopeGuard([&]() {
+        for (size_t i = 0; i < conns.size(); i++) {
+            if (!mhandles[i]) continue;
+            void* comm = nullptr;
+            if (rank == conns[i].senderRank)   comm = conns[i].sendComm;
+            if (rank == conns[i].receiverRank) comm = conns[i].recvComm;
+            if (comm) DeregisterMemory(comm, mhandles[i]);
+        }
+    });
+
+    static constexpr int kIters = 100;
+    for (int iter = 0; iter < kIters; iter++) {
+        for (size_t c = 0; c < conns.size(); c++) {
+            int seed = iter * 10 + conns[c].senderRank;
+            DoDirectedSendRecv(conns[c], buf.get(), buf.get(), sz,
+                               /*tag=*/iter, mhandles[c], mhandles[c], seed);
+        }
+    }
+
+    // Deregister memory before closing connections (comm must be valid for DeregMr).
+    for (size_t i = 0; i < conns.size(); i++) {
+        if (!mhandles[i]) continue;
+        void* comm = nullptr;
+        if (rank == conns[i].senderRank)   comm = conns[i].sendComm;
+        if (rank == conns[i].receiverRank) comm = conns[i].recvComm;
+        if (comm) DeregisterMemory(comm, mhandles[i]);
+        mhandles[i] = nullptr;
+    }
+    mrCleanup.dismiss();
+
+    for (auto& c : conns) CloseDirectedConnection(c);
+}
+
+// B2.  FanOutStress — rank 0 sends to ranks 1,2,3, 100 iterations.
 
 #endif /* MPI_TESTS_ENABLED */

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -11,6 +11,7 @@
   "env_variables": {
     "HSA_NO_SCRATCH_RECLAIM": "1",
     "NCCL_SOCKET_IFNAME": "eth0,eth1",
+    "NCCL_IB_HCA": "^mlx5_1,mlx5_6",
     "NCCL_DEBUG": "INFO"
   },
   "build_configuration": {
@@ -797,7 +798,10 @@
         {
           "name": "Cast_EnableDisableSched",
           "description": "Toggle schedEnable mid-connection: enabled=1 token, disabled=0 tokens, re-enabled=1 token",
-          "test_filter": "NetIbMPITest.CastEnableDisableSched"
+          "test_filter": "NetIbMPITest.CastEnableDisableSched",
+          "env_variables": {
+            "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "60000000"
+          }
         },
         {
           "name": "Cast_SendRecvMultipleSizes",
@@ -828,7 +832,10 @@
         {
           "name": "Cast_WeightsDistributionOneRound",
           "description": "Two-phase WRR distribution: equal then triangular weights — both exhaust all active tokens after one full round",
-          "test_filter": "NetIbMPITest.CastWeightsDistributionOneRound"
+          "test_filter": "NetIbMPITest.CastWeightsDistributionOneRound",
+          "env_variables": {
+            "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "60000000"
+          }
         },
         {
           "name": "Cast_SchedParmsReflectEnvVars",
@@ -838,12 +845,18 @@
         {
           "name": "Cast_AlternatingWrrNonWrr",
           "description": "Toggle doWrr mid-connection (3×10 sends): WRR consumes tokens in phases 1&3, zero in phase 2",
-          "test_filter": "NetIbMPITest.CastAlternatingWrrNonWrr"
+          "test_filter": "NetIbMPITest.CastAlternatingWrrNonWrr",
+          "env_variables": {
+            "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "60000000"
+          }
         },
         {
           "name": "Cast_EnableDisableSplitData",
           "description": "Toggle splitData mid-connection at threshold boundary: WRR/split path alternates, 1/0/1 tokens consumed",
-          "test_filter": "NetIbMPITest.CastEnableDisableSplitData"
+          "test_filter": "NetIbMPITest.CastEnableDisableSplitData",
+          "env_variables": {
+            "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "60000000"
+          }
         }
       ]
     },
@@ -1262,6 +1275,12 @@
       "name": "NET IB - Stress (2-rank)",
       "description": "Resource exhaustion, connection lifecycle, endurance, bidirectional, GPU stress",
       "config": "net_ib_stress",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Branch Coverage",
+      "description": "Targeted branch-coverage tests: irecv overflow, MR cache ref-count, send-size clamping, null-comm close, setAttr no-op",
+      "config": "net_ib_branch_coverage",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -986,6 +986,113 @@
           "test_filter": "GraphCapture_AllReduce.MultiNode"
         }
       ]
+    },
+
+    "net_ib_stress": {
+      "extends": "net_ib_base",
+      "timeout": 600,
+      "tests": [
+        { "name": "NetIB_Stress_TagZeroReuse",                "description": "50 messages with tag=0, verify FIFO ordering",                          "test_filter": "NetIbMPITest.TagZeroReuse" },
+        { "name": "NetIB_Stress_FifoPressureSenderFast",      "description": "Receiver slow, sender tight loop, verify FIFO backpressure",            "test_filter": "NetIbMPITest.FifoPressureSenderFast" },
+        { "name": "NetIB_Stress_MixedSizeBarrage",            "description": "25 sizes from 1B to 64MB on single connection",                         "test_filter": "NetIbMPITest.MixedSizeBarrage" },
+        { "name": "NetIB_Stress_RequestSlotExhaustion",       "description": "Post 32 concurrent irecvs, drain, verify recycling",                    "test_filter": "NetIbMPITest.RequestSlotExhaustion" },
+        { "name": "NetIB_Stress_MemoryRegistrationStorm",     "description": "512 reg/dereg cycles in various orders",                                "test_filter": "NetIbMPITest.MemoryRegistrationStorm" },
+        { "name": "NetIB_Stress_ConcurrentMultiConnection",   "description": "4 parallel connections, concurrent I/O",                                "test_filter": "NetIbMPITest.ConcurrentMultiConnectionStress" },
+        { "name": "NetIB_Stress_ConnectionChurn",             "description": "1000 connect/transfer/close cycles, RDMA leak detection",               "test_filter": "NetIbMPITest.ConnectionChurnUnderLoad" },
+        { "name": "NetIB_Stress_ConnectionBatch",             "description": "100 batches x 10 connections, RDMA checkpoints",                        "test_filter": "NetIbMPITest.ConnectionBatchCreateDestroy" },
+        { "name": "NetIB_Stress_BidirectionalSaturation",     "description": "Two opposing connections, full-duplex, 50 iterations",                   "test_filter": "NetIbMPITest.BidirectionalSaturation" },
+        { "name": "NetIB_Stress_LongRunningEndurance",        "description": "10000 transfers, tag cycling, RDMA checkpoints",                        "test_filter": "NetIbMPITest.LongRunningEndurance" },
+        { "name": "NetIB_Stress_GpuMemoryTransfer",           "description": "5 GPU alloc/transfer/flush/verify/free cycles",                         "test_filter": "NetIbMPITest.GpuMemoryTransferStress" },
+        { "name": "NetIB_Stress_RapidRecvPostDrain",          "description": "100 cycles of post-32-recv/drain (6400 ops)",                           "test_filter": "NetIbMPITest.RapidRecvPostDrain" }
+      ]
+    },
+
+    "net_ib_stress_4rank": {
+      "extends": "net_ib_base",
+      "num_ranks": 4,
+      "timeout": 600,
+      "tests": [
+        { "name": "NetIB_Stress_FanIn",                 "description": "Fan-in 3->1, 100 iterations",            "test_filter": "NetIbMPITest.FanInStress" },
+        { "name": "NetIB_Stress_FanOut",                "description": "Fan-out 1->3, 100 iterations",           "test_filter": "NetIbMPITest.FanOutStress" },
+        { "name": "NetIB_Stress_AllToAll",              "description": "Full mesh, 50 iterations",               "test_filter": "NetIbMPITest.AllToAllStress" },
+        { "name": "NetIB_Stress_BidirectionalMultiRank","description": "All pairs bidirectional, 50 iterations",  "test_filter": "NetIbMPITest.BidirectionalMultiRank" },
+        { "name": "NetIB_Stress_LongRunningMultiRank",  "description": "Fan-in 3->1, 1000 iterations",           "test_filter": "NetIbMPITest.LongRunningMultiRank" }
+      ]
+    },
+
+    "net_ib_stress_multi_qp_split": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "1",
+        "NCCL_IB_MERGE_VFS": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_IB_QPS_PER_CONNECTION": "8",
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1"
+      },
+      "tests": [
+        { "name": "NetIB_Stress_MultiQpSplitData", "description": "Multi-QP split alignment boundaries (QPS=8, SPLIT=1)", "test_filter": "NetIbMPITest.MultiQpSplitDataStress" }
+      ]
+    },
+
+    "net_ib_stress_multi_qp_nosplit": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "1",
+        "NCCL_IB_MERGE_VFS": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_IB_QPS_PER_CONNECTION": "4",
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "0"
+      },
+      "tests": [
+        { "name": "NetIB_Stress_MultiQpNoSplit", "description": "Multi-QP no-split path (QPS=4, SPLIT=0)", "test_filter": "NetIbMPITest.MultiQpNoSplitStress" }
+      ]
+    },
+
+    "net_ib_stress_multi_qp_fanin": {
+      "extends": "net_ib_base",
+      "num_ranks": 4,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "1",
+        "NCCL_IB_MERGE_VFS": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_IB_QPS_PER_CONNECTION": "4",
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1"
+      },
+      "tests": [
+        { "name": "NetIB_Stress_MultiQpFanIn", "description": "Multi-QP fan-in 3->1 (QPS=4, SPLIT=1)", "test_filter": "NetIbMPITest.MultiQpFanIn" }
+      ]
+    },
+
+    "net_ib_stress_ar": {
+      "extends": "net_ib_base",
+      "timeout": 120,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "1",
+        "NCCL_IB_MERGE_VFS": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_IB_ADAPTIVE_ROUTING": "1",
+        "NCCL_IB_AR_THRESHOLD": "8192"
+      },
+      "tests": [
+        { "name": "NetIB_Stress_ARThreshold", "description": "AR threshold boundary (sizes around 8192)", "test_filter": "NetIbMPITest.AdaptiveRoutingThresholdBoundary" }
+      ]
+    },
+
+    "net_ib_stress_inline": {
+      "extends": "net_ib_base",
+      "timeout": 120,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "1",
+        "NCCL_IB_MERGE_VFS": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_IB_USE_INLINE": "1"
+      },
+      "tests": [
+        { "name": "NetIB_Stress_InlineSend", "description": "CTS inline send boundary (USE_INLINE=1)", "test_filter": "NetIbMPITest.InlineSendBoundary" }
+      ]
     }
   },
   "test_suites": [
@@ -1149,6 +1256,48 @@
       "name": "NET IB - Fault Injection (CAST path, QPS=4, splitData=1)",
       "description": "Per-QP fault injection on CAST multi-QP path: error propagation, RTT rebalancing, data integrity under delay",
       "config": "fault_inject_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress (2-rank)",
+      "description": "Resource exhaustion, connection lifecycle, endurance, bidirectional, GPU stress",
+      "config": "net_ib_stress",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress (4-rank)",
+      "description": "Fan-in, fan-out, all-to-all, multi-rank endurance",
+      "config": "net_ib_stress_4rank",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress Multi-QP Split",
+      "description": "Multi-QP striping with split alignment boundaries",
+      "config": "net_ib_stress_multi_qp_split",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress Multi-QP NoSplit",
+      "description": "Multi-QP no-split (nDataQps) path",
+      "config": "net_ib_stress_multi_qp_nosplit",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress Multi-QP Fan-In",
+      "description": "Multi-QP fan-in 3->1 with 4 ranks",
+      "config": "net_ib_stress_multi_qp_fanin",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress AR Threshold",
+      "description": "Adaptive routing threshold boundary tests",
+      "config": "net_ib_stress_ar",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress Inline CTS",
+      "description": "CTS inline send boundary tests",
+      "config": "net_ib_stress_inline",
       "enabled": true
     }
   ]

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -654,6 +654,113 @@
           "test_filter": "NetIbMPITest.FaultInjCastQpErrorClearRecovers"
         }
       ]
+    },
+
+    "net_ib_stress": {
+      "extends": "net_ib_base",
+      "timeout": 600,
+      "tests": [
+        { "name": "NetIB_Stress_TagZeroReuse",                "description": "50 messages with tag=0, verify FIFO ordering",                          "test_filter": "NetIbMPITest.TagZeroReuse" },
+        { "name": "NetIB_Stress_FifoPressureSenderFast",      "description": "Receiver slow, sender tight loop, verify FIFO backpressure (NULL req)", "test_filter": "NetIbMPITest.FifoPressureSenderFast" },
+        { "name": "NetIB_Stress_MixedSizeBarrage",            "description": "25 sizes from 1B to 64MB on single connection",                         "test_filter": "NetIbMPITest.MixedSizeBarrage" },
+        { "name": "NetIB_Stress_RequestSlotExhaustion",       "description": "Post 32 concurrent irecvs, drain, verify recycling",                    "test_filter": "NetIbMPITest.RequestSlotExhaustion" },
+        { "name": "NetIB_Stress_MemoryRegistrationStorm",     "description": "512 reg/dereg cycles in forward, reverse, shuffled order",              "test_filter": "NetIbMPITest.MemoryRegistrationStorm" },
+        { "name": "NetIB_Stress_ConcurrentMultiConnection",   "description": "4 parallel connections, concurrent I/O",                                "test_filter": "NetIbMPITest.ConcurrentMultiConnectionStress" },
+        { "name": "NetIB_Stress_ConnectionChurn",             "description": "1000 connect/transfer/close cycles, RDMA leak detection",               "test_filter": "NetIbMPITest.ConnectionChurnUnderLoad" },
+        { "name": "NetIB_Stress_ConnectionBatch",             "description": "100 batches x 10 connections, RDMA checkpoints",                        "test_filter": "NetIbMPITest.ConnectionBatchCreateDestroy" },
+        { "name": "NetIB_Stress_BidirectionalSaturation",     "description": "Two opposing connections, full-duplex, 50 iterations",                   "test_filter": "NetIbMPITest.BidirectionalSaturation" },
+        { "name": "NetIB_Stress_LongRunningEndurance",        "description": "10000 transfers, tag cycling, RDMA checkpoints",                        "test_filter": "NetIbMPITest.LongRunningEndurance" },
+        { "name": "NetIB_Stress_GpuMemoryTransfer",           "description": "5 GPU alloc/transfer/flush/verify/free cycles (skip if no GDR)",        "test_filter": "NetIbMPITest.GpuMemoryTransferStress" },
+        { "name": "NetIB_Stress_RapidRecvPostDrain",          "description": "100 cycles of post-32-recv/drain (6400 ops)",                           "test_filter": "NetIbMPITest.RapidRecvPostDrain" }
+      ]
+    },
+
+    "net_ib_stress_4rank": {
+      "extends": "net_ib_base",
+      "num_ranks": 4,
+      "timeout": 600,
+      "tests": [
+        { "name": "NetIB_Stress_FanIn",                 "description": "Fan-in 3->1, 100 iterations, data integrity per sender",          "test_filter": "NetIbMPITest.FanInStress" },
+        { "name": "NetIB_Stress_FanOut",                "description": "Fan-out 1->3, 100 iterations, receiver-specific patterns",        "test_filter": "NetIbMPITest.FanOutStress" },
+        { "name": "NetIB_Stress_AllToAll",              "description": "Full mesh (12 connections), 50 iterations, data integrity",       "test_filter": "NetIbMPITest.AllToAllStress" },
+        { "name": "NetIB_Stress_BidirectionalMultiRank","description": "All pairs bidirectional, 4 ranks, 50 iterations",                 "test_filter": "NetIbMPITest.BidirectionalMultiRank" },
+        { "name": "NetIB_Stress_LongRunningMultiRank",  "description": "Fan-in 3->1, 1000 iterations, RDMA checkpoints",                 "test_filter": "NetIbMPITest.LongRunningMultiRank" }
+      ]
+    },
+
+    "net_ib_stress_multi_qp_split": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "1",
+        "NCCL_IB_MERGE_VFS": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_IB_QPS_PER_CONNECTION": "8",
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1"
+      },
+      "tests": [
+        { "name": "NetIB_Stress_MultiQpSplitData", "description": "Multi-QP split data at alignment boundaries (QPS=8, SPLIT=1)", "test_filter": "NetIbMPITest.MultiQpSplitDataStress" }
+      ]
+    },
+
+    "net_ib_stress_multi_qp_nosplit": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "1",
+        "NCCL_IB_MERGE_VFS": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_IB_QPS_PER_CONNECTION": "4",
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "0"
+      },
+      "tests": [
+        { "name": "NetIB_Stress_MultiQpNoSplit", "description": "Multi-QP no-split path (QPS=4, SPLIT=0)", "test_filter": "NetIbMPITest.MultiQpNoSplitStress" }
+      ]
+    },
+
+    "net_ib_stress_multi_qp_fanin": {
+      "extends": "net_ib_base",
+      "num_ranks": 4,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "1",
+        "NCCL_IB_MERGE_VFS": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_IB_QPS_PER_CONNECTION": "4",
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1"
+      },
+      "tests": [
+        { "name": "NetIB_Stress_MultiQpFanIn", "description": "Multi-QP fan-in 3->1 (QPS=4, SPLIT=1)", "test_filter": "NetIbMPITest.MultiQpFanIn" }
+      ]
+    },
+
+    "net_ib_stress_ar": {
+      "extends": "net_ib_base",
+      "timeout": 120,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "1",
+        "NCCL_IB_MERGE_VFS": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_IB_ADAPTIVE_ROUTING": "1",
+        "NCCL_IB_AR_THRESHOLD": "8192"
+      },
+      "tests": [
+        { "name": "NetIB_Stress_ARThreshold", "description": "Adaptive routing threshold boundary (sizes around 8192)", "test_filter": "NetIbMPITest.AdaptiveRoutingThresholdBoundary" }
+      ]
+    },
+
+    "net_ib_stress_inline": {
+      "extends": "net_ib_base",
+      "timeout": 120,
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "1",
+        "NCCL_IB_MERGE_VFS": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_IB_USE_INLINE": "1"
+      },
+      "tests": [
+        { "name": "NetIB_Stress_InlineSend", "description": "CTS inline send boundary (USE_INLINE=1)", "test_filter": "NetIbMPITest.InlineSendBoundary" }
+      ]
     }
   },
   "test_suites": [
@@ -829,6 +936,48 @@
       "name": "NET IB - Fault Injection (CAST path)",
       "description": "Per-QP fault injection: error detection, WRR rebalancing under artificial delay, data integrity on CAST multi-QP path",
       "config": "fault_inject_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress (2-rank)",
+      "description": "Resource exhaustion, connection lifecycle, endurance, bidirectional, GPU stress",
+      "config": "net_ib_stress",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress (4-rank)",
+      "description": "Fan-in, fan-out, all-to-all, multi-rank endurance",
+      "config": "net_ib_stress_4rank",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress Multi-QP Split",
+      "description": "Multi-QP striping with split alignment boundaries",
+      "config": "net_ib_stress_multi_qp_split",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress Multi-QP NoSplit",
+      "description": "Multi-QP no-split (nDataQps) path",
+      "config": "net_ib_stress_multi_qp_nosplit",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress Multi-QP Fan-In",
+      "description": "Multi-QP fan-in 3->1 with 4 ranks",
+      "config": "net_ib_stress_multi_qp_fanin",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress AR Threshold",
+      "description": "Adaptive routing threshold boundary tests",
+      "config": "net_ib_stress_ar",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress Inline CTS",
+      "description": "CTS inline send boundary tests",
+      "config": "net_ib_stress_inline",
       "enabled": true
     }
   ]

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -675,6 +675,18 @@
       ]
     },
 
+    "net_ib_branch_coverage": {
+      "extends": "net_ib_base",
+      "timeout": 60,
+      "tests": [
+        { "name": "NetIB_Branch_InvalidRecvCount",  "description": "irecv n>8 returns ncclInternalError (net_ib.cc early-return branch)",               "test_filter": "NetIbMPITest.InvalidRecvCount" },
+        { "name": "NetIB_Branch_MrCacheRefCount",   "description": "Double-register same buffer: refs reach 2, first dereg keeps MR, second frees it",  "test_filter": "NetIbMPITest.MrCacheRefCount" },
+        { "name": "NetIB_Branch_SendSizeClamping",  "description": "isend with size > maxRecvs*maxSize is clamped to maxSize, data integrity verified",  "test_filter": "NetIbMPITest.SendSizeClamping" },
+        { "name": "NetIB_Branch_NullCommClose",     "description": "closeSend/closeRecv/closeListen on NULL comm returns ncclSuccess without crash",     "test_filter": "NetIbMPITest.NullCommClose" },
+        { "name": "NetIB_Branch_SetNetAttrNoOp",    "description": "ncclNetPlugin_v9.setAttr returns ncclSuccess for all known attribute types",         "test_filter": "NetIbMPITest.SetNetAttrNoOp" }
+      ]
+    },
+
     "net_ib_stress_4rank": {
       "extends": "net_ib_base",
       "num_ranks": 4,
@@ -942,6 +954,12 @@
       "name": "NET IB - Stress (2-rank)",
       "description": "Resource exhaustion, connection lifecycle, endurance, bidirectional, GPU stress",
       "config": "net_ib_stress",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Branch Coverage",
+      "description": "Targeted branch-coverage tests: irecv overflow, MR cache ref-count, send-size clamping, null-comm close, setAttr no-op",
+      "config": "net_ib_branch_coverage",
       "enabled": true
     },
     {


### PR DESCRIPTION
## Motivation

  Add `StressTests.cpp` with 27 MPI unit tests for `src/transport/net_ib.cc` targeting branch coverage of paths not exercised by the existing `GeneralTests`.

  New tests and techniques:
  - **14 stress tests:** resource leak detection, FIFO backpressure, multi-QP striping, fan-in/fan-out/alltoall topologies, concurrent connections, endurance
  - **`SendSizeClamping`:** sender posts larger buffer than receiver, exercises the `ncclIbIsend` L2543 size-clamp branch (`BRDA:2544,0,0`)
  - **`NullCommClose`:** calls `closeSend`/`closeRecv`/`closeListen` with NULL pointer, covers the null-guard branches at L3063/3083/3113
  - **`SetNetAttrNoOp`:** exercises `ncclIbSetNetAttr` (FNDA was 0 before)
  - **`MultiRecvAggregation`:** `ncclIbIrecv` with `n=8` covers the `nreqs>1` path in `ncclIbMultiSend` (`BRDA:2387,0,1,255` verified)
  - `InvalidRecvCount`, `MrCacheRefCount`, `TagZeroReuse`, `AdaptiveRoutingThresholdBoundary`, `InlineSendBoundary`, `MixedSizeBarrage`, and more

  Extend `NetIbMPITestBase.hpp` with stress test infrastructure: multi-rank connection helpers, parametric send/recv, RDMA resource snapshot for leak detection, fan-in/fan-out/alltoall
  topology builders.

  ## JIRA ID and Test Plan

  AICOMNET-215

  ## Test Plan

  ### 1. Rank topology (2-rank and 4-rank)

  The suite runs at two process counts. 2-rank tests (`kExactTwoProcesses`) run on a
  single node via loopback IB. 4-rank tests (`kMinFourProcesses`) use `kNoNodeLimit`
  and also run on a single node via loopback IB; they self-skip when `world_size < 4`.

  **2-rank tests (22):** all E-group branch-coverage tests, all A-group resource tests,
  B-saturation, C-churn, D-multiQP, F-endurance, G-bidirectional, H-GPU, J-drain.

  **4-rank tests (5):** `FanInStress` (3→1), `FanOutStress` (1→3), `AllToAllStress`
  (4-rank full mesh), `BidirectionalMultiRank` (all-pairs bidirectional),
  `LongRunningMultiRank` (fan-in 3→1, 1000 iters).

  Architecture change to support N > 4 ranks is tracked separately (requires
  parameterising `SetupDirectedConnection` and a multi-node MPI allocation).

  ---

  ### 2. Three measurement axes

  Each multi-rank test records at completion:

  | Axis | How measured |
  |---|---|
  | **Ranks** | `MPIEnvironment::world_size` printed via `TEST_INFO` at test start |
  | **Fan-in / fan-out** | explicit in test name and comment (e.g. FanIn 3→1, FanOut 1→3, AllToAll 4×4) |
  | **Active connections** | `CaptureRdmaResources()` snapshot before and after; `AssertNoRdmaLeaks()` checks QP/CQ/MR/PD delta |

  `MultiQpSplitDataStress` (QPS=8, SPLIT=1) and `MultiQpNoSplitStress` (QPS=4, SPLIT=0)
  exercise multiQP paths without the CAST/WRR scheduler — they use
  `NCCL_IB_QPS_PER_CONNECTION` and `NCCL_IB_SPLIT_DATA_ON_QPS` directly and skip if
  those vars are absent.

  ---

  | Function | Primary tests |
  |---|---|
  | `ncclIbMultiSend` (~CC 22) | `MultiQpSplitDataStress`, `MixedSizeBarrage`, `AdaptiveRoutingThresholdBoundary`, `MultiQpFanIn` |
  | `ncclIbConnect` (~CC 20) | `ConnectionChurnUnderLoad`, `ConcurrentMultiConnectionStress` |
  | `ncclIbTest` (~CC 18) | `LongRunningEndurance`, `FifoPressureSenderFast`, `ConnectionChurnUnderLoad` |
  | `ncclIbRegMrDmaBufInternal` (~CC 16) | `MrCacheRefCount`, `MemoryRegistrationStorm`, `GpuMemoryTransferStress` |

  ---

  ### 7. Call tracing in complex tests

  Tests with non-trivial call chains document the sequence inline:

  - **`FifoPressureSenderFast`** — `ncclIbIsend → ncclIbPostFifo (backpressure, req=NULL) → retry → ncclIbTest (drain)`
  - **`ConnectionChurnUnderLoad`** — `listen → connect (async poll) → accept (async poll) → isend + irecv → ncclIbTest → closeSend → closeRecv → closeListen`
  - **`MultiQpSplitDataStress`** — `ncclIbIsend → ncclIbMultiSend → QP round-robin (i % nDataQps) → split at L2436`
  - **`LongRunningMultiRank`** — `SetupFanIn (3 directed connections) → DoDirectedSendRecv (all senders parallel) → MPI_Barrier → RDMA checkpoint`

  ---

  ### 8. Suite separation

  Tests are separated by timeout class and rank requirement:

  | Tier | GTest filter | Max runtime |
  |---|---|---|
  | **Fast** (branch-coverage) | `*InvalidRecv*:*MrCache*:*SendSize*:*NullComm*:*TagZero*:*AdaptiveRouting*:*InlineSend*:*MixedSize*:*SetNetAttr*` | 30 s |
  | **Stress** (single-node) | `*Endurance*:*LongRunning*:*Churn*:*Batch*:*Storm*:*Saturation*:*FifoPressure*:*RapidRecv*:*GpuMemory*:*Concurrent*` | 5 min |
  | **MultiRank** (4-rank) | `*FanIn*:*FanOut*:*AllToAll*:*MultiRank*:*MultiQp*:*Bidirectional*` | 2 min |

  Nightly CI runs all three tiers. Pre-commit runs the Fast tier only.

  ---

  ### 9. Optional recv completion (planned, not in this PR)

  **`OptRecvFlagSimple`** — post `ncclIbIrecv`, discard the request pointer, busy-wait
  on a flag word at a known offset in the receive buffer set by the IMM data field.
  Verifies the transport writes completion without going through `ncclIbTest`.

  **`OptRecvFlagLL128`** — same with a 128-byte aligned device buffer; the last 8 bytes
  serve as the LL128 flag word. Env-gated on `NCCL_PROTO=LL128`, skipped in CI unless
  explicitly enabled.

  ## Submission Checklist

  - [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.