### PR TITLE
Bump TheRock pin to pick up rocprofiler-compute RPATH build fix

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 903ee444eb935adf456bf5df724e1b6f5c2ce962 # 2026-05-03 commit
+          ref: fac13173de623cfb9df48cf514eb2c540fbff383 # 2026-05-07 commit
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 903ee444eb935adf456bf5df724e1b6f5c2ce962 # 2026-05-03 commit
+          ref: fac13173de623cfb9df48cf514eb2c540fbff383 # 2026-05-07 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 903ee444eb935adf456bf5df724e1b6f5c2ce962 # 2026-05-03 commit
+          ref: fac13173de623cfb9df48cf514eb2c540fbff383 # 2026-05-07 commit
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 903ee444eb935adf456bf5df724e1b6f5c2ce962 # 2026-05-03 commit
+          ref: fac13173de623cfb9df48cf514eb2c540fbff383 # 2026-05-07 commit
 
       # Centralized arch-specific configuration
       - name: Set arch-specific paths

--- a/.github/workflows/therock-rccl-test-packages-single-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-single-node.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 903ee444eb935adf456bf5df724e1b6f5c2ce962 # 2026-05-03 commit
+          ref: fac13173de623cfb9df48cf514eb2c540fbff383 # 2026-05-07 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 903ee444eb935adf456bf5df724e1b6f5c2ce962 # 2026-05-03 commit
+          ref: fac13173de623cfb9df48cf514eb2c540fbff383 # 2026-05-07 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 903ee444eb935adf456bf5df724e1b6f5c2ce962 # 2026-05-03 commit
+          ref: fac13173de623cfb9df48cf514eb2c540fbff383 # 2026-05-07 commit
 
       - name: Setting up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0


### PR DESCRIPTION
## Motivation

Bump the pinned `ROCm/TheRock` ref used by the rocm-systems TheRock
workflows to pick up [ROCm/TheRock#5108](https://github.com/ROCm/TheRock/commit/fac13173de623cfb9df48cf514eb2c540fbff383),
which fixes the install RPATH for the rocprofiler-compute native unit
test binary on TheRock builds.

Bugfix: unblocks the upstream rocprofiler-compute CTest registration of
`test-rocprofiler-compute-tool`, which previously failed on TheRock with
`librocprofiler-compute-tool.so: cannot open shared object file`.

This PR is required to merged in order to unblock the rocprofiler-compute PR https://github.com/ROCm/rocm-systems/pull/5721

## Technical Details

- Update all pinned `ROCm/TheRock` workflow refs from
  `903ee444eb935adf456bf5df724e1b6f5c2ce962` (2026-05-03) to
  `fac13173de623cfb9df48cf514eb2c540fbff383` (2026-05-07) across the
  seven `.github/workflows/therock-*.yml` files.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.