### PR TITLE
[rocprofiler-sdk] Add LZ4 compression for rocpd output

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -113,3 +113,6 @@
 [submodule "projects/rocprofiler-sdk/external/abseil-cpp"]
 	path = projects/rocprofiler-sdk/external/abseil-cpp
 	url = https://github.com/abseil/abseil-cpp.git
+[submodule "projects/rocprofiler-sdk/external/lz4"]
+	path = projects/rocprofiler-sdk/external/lz4
+	url = https://github.com/lz4/lz4.git

--- a/projects/rocprofiler-sdk/.gitmodules
+++ b/projects/rocprofiler-sdk/.gitmodules
@@ -34,6 +34,9 @@
 [submodule "external/sqlite"]
 	path = external/sqlite
 	url = https://github.com/sqlite/sqlite
+[submodule "external/lz4"]
+	path = external/lz4
+	url = https://github.com/lz4/lz4.git
 [submodule "external/pybind11"]
 	path = external/pybind11
 	url = https://github.com/pybind/pybind11.git

--- a/projects/rocprofiler-sdk/CHANGELOG.md
+++ b/projects/rocprofiler-sdk/CHANGELOG.md
@@ -30,6 +30,10 @@ Full documentation for ROCprofiler-SDK is available at [rocm.docs.amd.com/projec
 
 ### Changed
 
+**rocpd:**
+
+- rocpd schema version 4 stores `extdata`, `call_stack`, and `line_info` payloads as LZ4-compressed BLOBs by default. Use bundled rocpd views/tools or register the `lz4_decompress` SQLite UDF when reading raw UUID-suffixed tables. Set `ROCPROF_ROCPD_LZ4=false` or pass `rocprofv3 --no-rocpd-lz4` to emit the legacy schema version 3 layout.
+
 **Implementation:**
 
 - **Late-start architecture redesign**: Removed direct runtime symbol access in favor of proper rocprofiler-register integration

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_interfaces.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_interfaces.cmake
@@ -24,6 +24,7 @@ rocprofiler_add_interface_library(rocprofiler-sdk-cereal "Enables Cereal support
                                   INTERNAL)
 rocprofiler_add_interface_library(rocprofiler-sdk-sqlite3 "Enables SQLite3 support"
                                   INTERNAL)
+rocprofiler_add_interface_library(rocprofiler-sdk-lz4 "Enables LZ4 support" INTERNAL)
 rocprofiler_add_interface_library(rocprofiler-sdk-pybind11 "Enables PyBind11 support"
                                   INTERNAL)
 rocprofiler_add_interface_library(rocprofiler-sdk-gotcha "Enables GOTCHA support"

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_options.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_options.cmake
@@ -62,6 +62,8 @@ rocprofiler_add_option(
     "Enable building abseil-cpp (Abseil logging) library internally" ON)
 rocprofiler_add_option(ROCPROFILER_BUILD_SQLITE3
                        "Enable building sqlite3 library internally" OFF)
+rocprofiler_add_option(ROCPROFILER_BUILD_LZ4 "Enable building lz4 library internally"
+                       OFF)
 rocprofiler_add_option(ROCPROFILER_BUILD_PYBIND11
                        "Enable building pybind11 library internally" ON)
 rocprofiler_add_option(ROCPROFILER_BUILD_GOTCHA

--- a/projects/rocprofiler-sdk/external/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/external/CMakeLists.txt
@@ -291,6 +291,48 @@ else()
 endif()
 
 #
+# LZ4
+#
+if(ROCPROFILER_BUILD_LZ4)
+    rocprofiler_checkout_git_submodule(
+        RECURSIVE
+        RELATIVE_PATH external/lz4
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        TEST_FILE build/cmake/CMakeLists.txt
+        REPO_URL https://github.com/lz4/lz4.git
+        REPO_BRANCH "v1.10.0")
+
+    set(LZ4_BUILD_CLI OFF)
+    set(LZ4_BUILD_LEGACY_LZ4C OFF)
+    add_subdirectory(lz4/build/cmake EXCLUDE_FROM_ALL)
+
+    if(TARGET lz4_static)
+        target_link_libraries(rocprofiler-sdk-lz4 INTERFACE $<BUILD_INTERFACE:lz4_static>)
+    elseif(TARGET LZ4::lz4_static)
+        target_link_libraries(rocprofiler-sdk-lz4 INTERFACE $<BUILD_INTERFACE:LZ4::lz4_static>)
+    else()
+        message(FATAL_ERROR "Could not find lz4 static CMake target")
+    endif()
+
+    target_include_directories(
+        rocprofiler-sdk-lz4 SYSTEM
+        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/lz4/lib>)
+else()
+    find_package(lz4 QUIET)
+    if(TARGET LZ4::lz4)
+        target_link_libraries(rocprofiler-sdk-lz4 INTERFACE LZ4::lz4)
+    elseif(TARGET lz4::lz4)
+        target_link_libraries(rocprofiler-sdk-lz4 INTERFACE lz4::lz4)
+    elseif(TARGET lz4)
+        target_link_libraries(rocprofiler-sdk-lz4 INTERFACE lz4)
+    else()
+        find_package(PkgConfig REQUIRED)
+        pkg_check_modules(LZ4 REQUIRED IMPORTED_TARGET liblz4)
+        target_link_libraries(rocprofiler-sdk-lz4 INTERFACE PkgConfig::LZ4)
+    endif()
+endif()
+
+#
 # PyBind11
 #
 if(ROCPROFILER_BUILD_PYBIND11)

--- a/projects/rocprofiler-sdk/requirements.txt
+++ b/projects/rocprofiler-sdk/requirements.txt
@@ -6,6 +6,7 @@ cmake-format
 dataclasses
 flake8
 jinja2
+lz4>=4.0
 numpy
 otf2
 pandas

--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -418,6 +418,12 @@ For attachment profiling of running processes:
         choices=("csv", "json", "pftrace", "otf2", "rocpd"),
         type=str.lower,
     )
+    io_options.add_argument(
+        "--rocpd-lz4",
+        default=None,
+        action=argparse.BooleanOptionalAction,
+        help="Enable LZ4 compression for rocpd JSON payload columns (default: enabled). Use --no-rocpd-lz4 to disable.",
+    )
     add_parser_bool_argument(
         io_options,
         "--output-config",
@@ -1487,6 +1493,8 @@ def run(app_args, args, **kwargs):
 
     update_env("ROCPROF_OUTPUT_FILE_NAME", _output_file)
     update_env("ROCPROF_OUTPUT_PATH", _output_path)
+    if args.rocpd_lz4 is not None:
+        update_env("ROCPROF_ROCPD_LZ4", args.rocpd_lz4)
     update_env("ROCPROF_OUTPUT_CONFIG_FILE", args.output_config, overwrite_if_true=True)
     update_env("ROCPROF_ATTACH_OUTPUT_GENERATION_SYNC", args.attach_sync_output)
     if app_pass is not None and args.sub_directory is not None:

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocpd-output-format.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocpd-output-format.rst
@@ -46,6 +46,42 @@ The profiling session generates output files following the naming convention ``%
 
 - ``%pid%``: The process identifier of the profiled application.
 
+Compression
+-----------
+
+By default, ``rocprofv3`` stores high-volume rocpd JSON payload columns using
+LZ4-compressed SQLite BLOBs. This applies to ``extdata`` columns and the
+``rocpd_event`` ``call_stack`` and ``line_info`` columns. The public rocpd views
+decompress these payloads automatically, so bundled conversion and summary tools
+continue to read JSON text through the standard view names.
+
+To explicitly enable or disable compression, use:
+
+.. code-block:: bash
+
+   rocprofv3 --hip-trace --rocpd-lz4 -- <application>
+   rocprofv3 --hip-trace --no-rocpd-lz4 -- <application>
+
+The equivalent environment variable is ``ROCPROF_ROCPD_LZ4``. Set
+``ROCPROF_ROCPD_LZ4=false`` to produce the legacy uncompressed rocpd schema.
+
+Compressed databases report ``schema_version`` ``4`` and include the metadata
+row ``compression = lz4-frame-v1``. The BLOB wire format is:
+
+.. code-block:: text
+
+   [ 4 bytes magic = "LZ4F" ][ 4 bytes uncompressed_size LE ][ LZ4F frame payload ]
+
+When using raw SQLite queries against UUID-suffixed tables, register the
+``lz4_decompress`` SQLite function before reading compressed columns. The
+bundled rocpd Python tools do this automatically. For example:
+
+.. code-block:: sql
+
+   SELECT json(CAST(lz4_decompress(extdata) AS TEXT))
+   FROM rocpd_kernel_dispatch_<uuid>
+   LIMIT 1;
+
 Converting rocpd to alternative formats
 ---------------------------------------
 

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk-rocpd/sql.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk-rocpd/sql.h
@@ -69,6 +69,7 @@ typedef enum ROCPD_EXPERIMENTAL rocpd_sql_options_t
     ROCPD_SQL_OPTIONS_NONE                        = 0,
     ROCPD_SQL_OPTIONS_PERSIST_STRINGS             = 0x01,  ///< do not delete strings
     ROCPD_SQL_OPTIONS_SQLITE3_PRAGMA_FOREIGN_KEYS = 0x02,  ///< enable SQLite3 foreign keys
+    ROCPD_SQL_OPTIONS_SQLITE3_LZ4_COMPRESSION     = 0x04,  ///< use LZ4 schema variants
     ROCPD_SQL_OPTIONS_LAST                        = 0xFFFFFFFF,
 } rocpd_sql_options_t;
 

--- a/projects/rocprofiler-sdk/source/lib/output/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/output/CMakeLists.txt
@@ -72,7 +72,8 @@ target_link_libraries(
             rocprofiler-sdk::rocprofiler-sdk-amd-comgr
             rocprofiler-sdk::rocprofiler-sdk-dw
             rocprofiler-sdk::rocprofiler-sdk-elf
-            rocprofiler-sdk::rocprofiler-sdk-sqlite3)
+            rocprofiler-sdk::rocprofiler-sdk-sqlite3
+            rocprofiler-sdk::rocprofiler-sdk-lz4)
 
 target_compile_definitions(rocprofiler-sdk-output-library
                            PRIVATE PROJECT_BINARY_DIR="${PROJECT_BINARY_DIR}")

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -40,6 +40,7 @@
 #include "lib/common/utility.hpp"
 #include "lib/output/sql/common.hpp"
 #include "lib/output/sql/deferred_transaction.hpp"
+#include "lib/output/sql/lz4_extension.hpp"
 #include "lib/rocprofiler-sdk/agent.hpp"
 
 #include <rocprofiler-sdk/fwd.h>
@@ -136,10 +137,10 @@ struct rocpd_db
 
     rocpd_db() = default;
     ~rocpd_db();
-    rocpd_db(const rocpd_db&) = delete;
+    rocpd_db(const rocpd_db&)            = delete;
     rocpd_db& operator=(const rocpd_db&) = delete;
     rocpd_db(rocpd_db&&)                 = delete;
-    rocpd_db& operator=(rocpd_db&&) = delete;
+    rocpd_db& operator=(rocpd_db&&)      = delete;
 
     sqlite3*            conn                = nullptr;
     std::string         uuid                = {};
@@ -153,6 +154,7 @@ struct rocpd_db
     flushing_set_t      flushing_tables     = {};
     uint64_t            pending_touch_count = 0;
     batch_stats_map_t   batch_stats         = {};
+    bool                rocpd_lz4           = true;
 
     size_t get_event_id() { return ++event_id_counter; }
 };
@@ -255,7 +257,8 @@ std::string
 read_schema_file(rocpd_db& db, rocpd_sql_schema_kind_t schema_kind)
 {
     auto _variables = common::init_public_api_struct(rocpd_sql_schema_jinja_variables_t{});
-    auto _options   = ROCPD_SQL_OPTIONS_NONE;
+    auto _options =
+        (db.rocpd_lz4) ? ROCPD_SQL_OPTIONS_SQLITE3_LZ4_COMPRESSION : ROCPD_SQL_OPTIONS_NONE;
 
     _variables.uuid = db.uuid.c_str();
     _variables.guid = db.guid.c_str();
@@ -499,6 +502,13 @@ log_batch_flush_stats(const rocpd_db& db)
     }
 }
 
+bool
+should_lz4_compress_column(const rocpd_db& db, std::string_view field)
+{
+    if(!db.rocpd_lz4) return false;
+    return (field == "extdata" || field == "call_stack" || field == "line_info");
+}
+
 sqlite3_stmt*&
 get_or_prepare_batch_statement(rocpd_db&                   db,
                                const pending_insert_batch& pending,
@@ -510,7 +520,10 @@ get_or_prepare_batch_statement(rocpd_db&                   db,
     auto& stmt = db.statements[batch_key];
     if(stmt) return stmt;
 
-    const auto placeholders     = std::vector(pending.fields.size(), std::string{"?"});
+    auto placeholders = std::vector<std::string>{};
+    placeholders.reserve(pending.fields.size());
+    for(const auto& field : pending.fields)
+        placeholders.emplace_back(should_lz4_compress_column(db, field) ? "lz4_compress(?)" : "?");
     const auto row_placeholder  = fmt::format("({})", fmt::join(placeholders, ", "));
     const auto row_placeholders = std::vector(rows_per_exec, row_placeholder);
     const auto values_clause    = fmt::format("{}", fmt::join(row_placeholders, ", "));
@@ -884,7 +897,7 @@ extract_flags_field(const Tp& _data)
 
 #define GENERATE_FIELD_ACCESSOR(FUNC_NAME, FIELD_NAME, DATA_TYPE, ...)                             \
     template <typename Tp, typename Up = Tp>                                                       \
-    auto FUNC_NAME(const Tp& _data, int)->decltype(std::declval<Up>().FIELD_NAME, DATA_TYPE{})     \
+    auto FUNC_NAME(const Tp& _data, int) -> decltype(std::declval<Up>().FIELD_NAME, DATA_TYPE{})   \
     {                                                                                              \
         return _data.FIELD_NAME;                                                                   \
     }                                                                                              \
@@ -1044,6 +1057,7 @@ write_rocpd(
 
     auto      db   = rocpd_db{};
     sqlite3*& conn = db.conn;
+    db.rocpd_lz4   = cfg.rocpd_lz4;
 
     {
         const auto& mach_id = tool_metadata.node_data.machine_id;
@@ -1062,6 +1076,7 @@ write_rocpd(
         SQLITE3_CHECK(sqlite3_open_v2(
             output_file.c_str(), &conn, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr));
         SQLITE3_CHECK(sqlite3_busy_handler(conn, &sql::busy_handler, nullptr));
+        if(db.rocpd_lz4) sql::register_lz4_functions(conn);
 
         ROCP_ERROR << fmt::format("Opened result file: {} (UUID={})", output_file, uuid_v7);
 

--- a/projects/rocprofiler-sdk/source/lib/output/output_config.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/output_config.cpp
@@ -61,6 +61,7 @@ output_config::parse_env()
     output_path    = common::get_env("ROCPROF_OUTPUT_PATH", output_path);
     output_file    = common::get_env("ROCPROF_OUTPUT_FILE_NAME", output_file);
     tmp_directory  = common::get_env("ROCPROF_TMPDIR", tmp_directory);
+    rocpd_lz4      = common::get_env("ROCPROF_ROCPD_LZ4", rocpd_lz4);
     kernel_rename  = common::get_env("ROCPROF_KERNEL_RENAME", false);
     group_by_queue = common::get_env("ROCPROF_GROUP_BY_QUEUE", false);
     annotate_args  = common::get_env("ROCPROF_ANNOTATE_ARGS", false);

--- a/projects/rocprofiler-sdk/source/lib/output/output_config.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/output_config.hpp
@@ -68,6 +68,7 @@ struct output_config
     bool                     pftrace_output              = false;
     bool                     otf2_output                 = false;
     bool                     rocpd_output                = false;
+    bool                     rocpd_lz4                   = true;
     bool                     summary_output              = false;
     bool                     kernel_rename               = false;
     bool                     group_by_queue              = false;
@@ -134,6 +135,7 @@ output_config::save(ArchiveT& ar) const
     CFG_SERIALIZE_MEMBER(otf2_output);
     CFG_SERIALIZE_MEMBER(summary_output);
     CFG_SERIALIZE_MEMBER(rocpd_output);
+    CFG_SERIALIZE_MEMBER(rocpd_lz4);
     CFG_SERIALIZE_MEMBER(kernel_rename);
     CFG_SERIALIZE_MEMBER(group_by_queue);
     CFG_SERIALIZE_MEMBER(annotate_args);

--- a/projects/rocprofiler-sdk/source/lib/output/sql/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/output/sql/CMakeLists.txt
@@ -1,8 +1,9 @@
 #
 # add sql common sources to output library target
 #
-set(output_sql_headers common.hpp deferred_transaction.hpp extract_data_type.hpp)
-set(output_sql_sources common.cpp deferred_transaction.cpp)
+set(output_sql_headers common.hpp deferred_transaction.hpp extract_data_type.hpp
+                       lz4_extension.hpp)
+set(output_sql_sources common.cpp deferred_transaction.cpp lz4_extension.cpp)
 
 target_sources(rocprofiler-sdk-output-library PRIVATE ${output_sql_sources}
                                                       ${output_sql_headers})

--- a/projects/rocprofiler-sdk/source/lib/output/sql/lz4_extension.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/sql/lz4_extension.cpp
@@ -1,0 +1,220 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/output/sql/lz4_extension.hpp"
+
+#include "lib/common/logging.hpp"
+
+#include <fmt/format.h>
+
+#include <lz4frame.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+
+namespace rocprofiler
+{
+namespace tool
+{
+namespace sql
+{
+namespace
+{
+constexpr auto magic       = std::array<char, 4>{'L', 'Z', '4', 'F'};
+constexpr auto header_size = size_t{8};
+
+void
+throw_lz4_error(std::string_view operation, size_t code)
+{
+    if(LZ4F_isError(code) != 0)
+        throw std::runtime_error{fmt::format("{} failed: {}", operation, LZ4F_getErrorName(code))};
+}
+
+void
+write_u32_le(std::vector<std::byte>& data, uint32_t value)
+{
+    data.emplace_back(static_cast<std::byte>(value & 0xffU));
+    data.emplace_back(static_cast<std::byte>((value >> 8U) & 0xffU));
+    data.emplace_back(static_cast<std::byte>((value >> 16U) & 0xffU));
+    data.emplace_back(static_cast<std::byte>((value >> 24U) & 0xffU));
+}
+
+uint32_t
+read_u32_le(std::string_view data)
+{
+    const auto* ptr = reinterpret_cast<const unsigned char*>(data.data());
+    return (static_cast<uint32_t>(ptr[0]) | (static_cast<uint32_t>(ptr[1]) << 8U) |
+            (static_cast<uint32_t>(ptr[2]) << 16U) | (static_cast<uint32_t>(ptr[3]) << 24U));
+}
+
+std::string_view
+sqlite_value_bytes(sqlite3_value* value)
+{
+    if(value == nullptr || sqlite3_value_type(value) == SQLITE_NULL) return {};
+
+    const auto size = sqlite3_value_bytes(value);
+    if(size <= 0) return {};
+
+    const auto* data = sqlite3_value_blob(value);
+    if(data == nullptr) return {};
+
+    return {static_cast<const char*>(data), static_cast<size_t>(size)};
+}
+
+int
+sqlite_value_level(sqlite3_value* value)
+{
+    if(value == nullptr || sqlite3_value_type(value) == SQLITE_NULL) return 1;
+    return std::clamp(sqlite3_value_int(value), 1, 12);
+}
+
+void
+sqlite_lz4_compress(sqlite3_context* ctx, int argc, sqlite3_value** argv)
+{
+    try
+    {
+        const auto input = sqlite_value_bytes(argv[0]);
+        const auto level = (argc > 1) ? sqlite_value_level(argv[1]) : 1;
+        auto       data  = lz4_compress_buffer(input, level);
+        sqlite3_result_blob(ctx, data.data(), static_cast<int>(data.size()), SQLITE_TRANSIENT);
+    } catch(const std::exception& e)
+    {
+        sqlite3_result_error(ctx, e.what(), -1);
+    }
+}
+
+void
+sqlite_lz4_decompress(sqlite3_context* ctx, int /*argc*/, sqlite3_value** argv)
+{
+    try
+    {
+        const auto input = sqlite_value_bytes(argv[0]);
+        auto       data  = lz4_decompress_buffer(input);
+        sqlite3_result_blob(ctx, data.data(), static_cast<int>(data.size()), SQLITE_TRANSIENT);
+    } catch(const std::exception& e)
+    {
+        sqlite3_result_error(ctx, e.what(), -1);
+    }
+}
+}  // namespace
+
+std::vector<std::byte>
+lz4_compress_buffer(std::string_view input, int level)
+{
+    if(input.empty()) return {};
+
+    if(input.size() > std::numeric_limits<uint32_t>::max())
+        throw std::runtime_error{"lz4 payload exceeds 4 GiB wire-format limit"};
+
+    auto preferences                          = LZ4F_preferences_t{};
+    preferences.frameInfo.blockMode           = LZ4F_blockIndependent;
+    preferences.frameInfo.contentChecksumFlag = LZ4F_contentChecksumEnabled;
+    preferences.compressionLevel              = level;
+
+    const auto bound = LZ4F_compressFrameBound(input.size(), &preferences);
+    throw_lz4_error("LZ4F_compressFrameBound", bound);
+
+    auto output = std::vector<std::byte>{};
+    output.reserve(header_size + bound);
+    output.insert(output.end(),
+                  reinterpret_cast<const std::byte*>(magic.data()),
+                  reinterpret_cast<const std::byte*>(magic.data() + magic.size()));
+    write_u32_le(output, static_cast<uint32_t>(input.size()));
+
+    const auto compressed_offset = output.size();
+    output.resize(output.size() + bound);
+
+    const auto compressed_size = LZ4F_compressFrame(
+        output.data() + compressed_offset, bound, input.data(), input.size(), &preferences);
+    throw_lz4_error("LZ4F_compressFrame", compressed_size);
+    output.resize(compressed_offset + compressed_size);
+    return output;
+}
+
+std::string
+lz4_decompress_buffer(std::string_view input)
+{
+    if(input.empty()) return {};
+
+    if(input.size() < header_size || std::memcmp(input.data(), magic.data(), magic.size()) != 0)
+        throw std::runtime_error{"invalid lz4 blob magic"};
+
+    const auto uncompressed_size = read_u32_le(input.substr(magic.size(), sizeof(uint32_t)));
+    auto       output            = std::string(uncompressed_size, '\0');
+    auto       payload           = input.substr(header_size);
+
+    LZ4F_dctx* ctx = nullptr;
+    throw_lz4_error("LZ4F_createDecompressionContext",
+                    LZ4F_createDecompressionContext(&ctx, LZ4F_VERSION));
+
+    auto cleanup = std::unique_ptr<LZ4F_dctx, decltype(&LZ4F_freeDecompressionContext)>{
+        ctx, LZ4F_freeDecompressionContext};
+
+    size_t     dst_size = output.size();
+    size_t     src_size = payload.size();
+    const auto rc =
+        LZ4F_decompress(ctx, output.data(), &dst_size, payload.data(), &src_size, nullptr);
+    throw_lz4_error("LZ4F_decompress", rc);
+
+    if(rc != 0 || src_size != payload.size() || dst_size != output.size())
+        throw std::runtime_error{"truncated lz4 blob"};
+
+    return output;
+}
+
+void
+register_lz4_functions(sqlite3* conn)
+{
+    ROCP_FATAL_IF(conn == nullptr) << "Cannot register LZ4 SQLite functions on null connection";
+
+    constexpr auto flags = SQLITE_UTF8 | SQLITE_DETERMINISTIC;
+
+    auto rc = sqlite3_create_function_v2(
+        conn, "lz4_compress", 1, flags, nullptr, sqlite_lz4_compress, nullptr, nullptr, nullptr);
+    ROCP_FATAL_IF(rc != SQLITE_OK)
+        << "sqlite3_create_function_v2(lz4_compress) failed: " << sqlite3_errmsg(conn);
+
+    rc = sqlite3_create_function_v2(
+        conn, "lz4_compress", 2, flags, nullptr, sqlite_lz4_compress, nullptr, nullptr, nullptr);
+    ROCP_FATAL_IF(rc != SQLITE_OK)
+        << "sqlite3_create_function_v2(lz4_compress) failed: " << sqlite3_errmsg(conn);
+
+    rc = sqlite3_create_function_v2(conn,
+                                    "lz4_decompress",
+                                    1,
+                                    flags,
+                                    nullptr,
+                                    sqlite_lz4_decompress,
+                                    nullptr,
+                                    nullptr,
+                                    nullptr);
+    ROCP_FATAL_IF(rc != SQLITE_OK)
+        << "sqlite3_create_function_v2(lz4_decompress) failed: " << sqlite3_errmsg(conn);
+}
+}  // namespace sql
+}  // namespace tool
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/output/sql/lz4_extension.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/sql/lz4_extension.hpp
@@ -1,0 +1,48 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <sqlite3.h>
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace rocprofiler
+{
+namespace tool
+{
+namespace sql
+{
+void
+register_lz4_functions(sqlite3* conn);
+
+std::vector<std::byte>
+lz4_compress_buffer(std::string_view input, int level = 1);
+
+std::string
+lz4_decompress_buffer(std::string_view input);
+}  // namespace sql
+}  // namespace tool
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/_lz4.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/_lz4.py
@@ -1,0 +1,75 @@
+###############################################################################
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+###############################################################################
+
+import struct
+
+import lz4.frame
+
+MAGIC = b"LZ4F"
+
+
+def lz4_compress(value, level=1):
+    if value is None:
+        return b""
+    if isinstance(value, str):
+        value = value.encode("utf-8")
+    value = bytes(value)
+    if not value:
+        return b""
+    return MAGIC + struct.pack("<I", len(value)) + lz4.frame.compress(
+        value, compression_level=int(level)
+    )
+
+
+def lz4_decompress(value):
+    if value is None:
+        return b""
+    value = bytes(value)
+    if not value:
+        return b""
+    if len(value) < 8 or value[:4] != MAGIC:
+        raise ValueError("invalid lz4 blob magic")
+    expected = struct.unpack("<I", value[4:8])[0]
+    output = lz4.frame.decompress(value[8:])
+    if len(output) != expected:
+        raise ValueError("lz4 length mismatch")
+    return output
+
+
+def register(connection):
+    try:
+        connection.create_function("lz4_compress", 1, lz4_compress, deterministic=True)
+        connection.create_function("lz4_compress", 2, lz4_compress, deterministic=True)
+        connection.create_function("lz4_decompress", 1, lz4_decompress, deterministic=True)
+    except TypeError:
+        connection.create_function("lz4_compress", 1, lz4_compress)
+        connection.create_function("lz4_compress", 2, lz4_compress)
+        connection.create_function("lz4_decompress", 1, lz4_decompress)
+    return connection
+
+
+def connect(*args, **kwargs):
+    import sqlite3
+
+    return register(sqlite3.connect(*args, **kwargs))

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/importer.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/importer.py
@@ -33,6 +33,7 @@ import sqlite3
 
 from .schema import RocpdSchema
 from . import libpyrocpd
+from . import _lz4
 
 __all__ = ["RocpdImportData", "execute_statement"]
 
@@ -48,6 +49,7 @@ def internal_init(_input, _output, skip_auto_merge, automerge_limit):
         _input
     ), "RocpdImportData error, invalid SQLite3 database provided"
     _connection = libpyrocpd.connect(_output)
+    _lz4.register(_connection)
     _connection.execute("PRAGMA foreign_keys = ON")
     _table_info = _create_temp_views(_connection, _input)
     _create_meta_views(_connection)

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/libpyrocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/libpyrocpd.cpp
@@ -135,9 +135,9 @@ struct RocpdImportData
     RocpdImportData()  = default;
     ~RocpdImportData() = default;
 
-    RocpdImportData(const RocpdImportData&)     = default;
-    RocpdImportData(RocpdImportData&&) noexcept = default;
-    RocpdImportData& operator=(const RocpdImportData&) = default;
+    RocpdImportData(const RocpdImportData&)                = default;
+    RocpdImportData(RocpdImportData&&) noexcept            = default;
+    RocpdImportData& operator=(const RocpdImportData&)     = default;
     RocpdImportData& operator=(RocpdImportData&&) noexcept = default;
 
     RocpdImportData(const py::object& _obj, const std::vector<std::string>& _dbs)
@@ -216,7 +216,8 @@ PYBIND11_MODULE(libpyrocpd, pyrocpd)
 
     py::enum_<rocpd_sql_options_t>(pyrocpd, "sql_option", "Load schema options")
         .value("none", ROCPD_SQL_OPTIONS_NONE)
-        .value("sqlite3_pragma_foreign_keys", ROCPD_SQL_OPTIONS_SQLITE3_PRAGMA_FOREIGN_KEYS);
+        .value("sqlite3_pragma_foreign_keys", ROCPD_SQL_OPTIONS_SQLITE3_PRAGMA_FOREIGN_KEYS)
+        .value("sqlite3_lz4_compression", ROCPD_SQL_OPTIONS_SQLITE3_LZ4_COMPRESSION);
 
     py::enum_<tool::agent_indexing>(pyrocpd, "agent_indexing", "enum.Enum")
         .value("node", tool::agent_indexing::node)

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/merge.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/merge.py
@@ -25,10 +25,11 @@
 
 import argparse
 import os
-import sqlite3
 import time
 
 from typing import List, Dict, Iterable, Optional, Callable, Any
+
+from . import _lz4
 
 
 def merge_sqlite_dbs(
@@ -70,7 +71,7 @@ def merge_sqlite_dbs(
     data_views = []
     schema_versions = []
 
-    with sqlite3.connect(str(dest_path)) as conn:
+    with _lz4.connect(str(dest_path)) as conn:
         conn.execute("PRAGMA journal_mode = WAL;")
         conn.execute("PRAGMA synchronous = NORMAL;")
         conn.execute("PRAGMA foreign_keys = OFF;")  # defer FK checks until end

--- a/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
+++ b/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
@@ -167,6 +167,7 @@ function(rocprofiler_rocpd_python_bindings _VERSION)
         ${PROJECT_BINARY_DIR}/${rocpd_PYTHON_INSTALL_DIRECTORY})
     set(rocpd_PYTHON_SOURCES
         csv.py
+        _lz4.py
         importer.py
         __init__.py
         __main__.py

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocpd/sql.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocpd/sql.cpp
@@ -133,6 +133,10 @@ rocpd_sql_load_schema(rocpd_sql_engine_t                        engine,
         }
     }
 
+    const auto lz4_enabled =
+        ((options & ROCPD_SQL_OPTIONS_SQLITE3_LZ4_COMPRESSION) ==
+         ROCPD_SQL_OPTIONS_SQLITE3_LZ4_COMPRESSION);
+
     const auto kind_file_names = std::unordered_map<rocpd_sql_schema_kind_t, std::string_view>{
         {ROCPD_SQL_SCHEMA_ROCPD_TABLES, "rocpd_tables.sql"},
         {ROCPD_SQL_SCHEMA_ROCPD_INDEXES, "rocpd_indexes.sql"},
@@ -141,6 +145,15 @@ rocpd_sql_load_schema(rocpd_sql_engine_t                        engine,
         {ROCPD_SQL_SCHEMA_ROCPD_SUMMARY_VIEWS, "summary_views.sql"},
         {ROCPD_SQL_SCHEMA_ROCPD_MARKER_VIEWS, "marker_views.sql"},
     };
+
+    const auto kind_lz4_file_names =
+        std::unordered_map<rocpd_sql_schema_kind_t, std::string_view>{
+            {ROCPD_SQL_SCHEMA_ROCPD_TABLES, "rocpd_tables_lz4.sql"},
+            {ROCPD_SQL_SCHEMA_ROCPD_VIEWS, "rocpd_views_lz4.sql"},
+            {ROCPD_SQL_SCHEMA_ROCPD_DATA_VIEWS, "data_views_lz4.sql"},
+            {ROCPD_SQL_SCHEMA_ROCPD_SUMMARY_VIEWS, "summary_views_lz4.sql"},
+            {ROCPD_SQL_SCHEMA_ROCPD_MARKER_VIEWS, "marker_views_lz4.sql"},
+        };
 
     const auto _lib_schema_path = rocpd::sql::get_install_path();
     const auto _env_schema_path = rocprofiler::common::get_env("ROCPD_SCHEMA_PATH", "");
@@ -155,10 +168,14 @@ rocpd_sql_load_schema(rocpd_sql_engine_t                        engine,
 
     if(kind_file_names.count(kind) == 0) return ROCPD_STATUS_ERROR_SQL_INVALID_SCHEMA_KIND;
 
+    const auto schema_file_name =
+        (lz4_enabled && kind_lz4_file_names.count(kind) > 0) ? kind_lz4_file_names.at(kind)
+                                                             : kind_file_names.at(kind);
+
     auto _schema_file = std::optional<std::string>{};
     for(const auto& itr : rocprofiler::sdk::parse::tokenize(_schema_paths, ":"))
     {
-        auto _fpath = fs::path{itr} / kind_file_names.at(kind);
+        auto _fpath = fs::path{itr} / schema_file_name;
         ROCP_TRACE << fmt::format("[rocprofiler-sdk-rocpd] Searching for schema file: '{}'",
                                   _fpath.string());
         if(fs::exists(_fpath))

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/CMakeLists.txt
@@ -20,7 +20,6 @@ target_link_libraries(
             rocprofiler-sdk::rocprofiler-sdk-common-library
             rocprofiler-sdk::rocprofiler-sdk-output-library
             rocprofiler-sdk::rocprofiler-sdk-cereal
-            rocprofiler-sdk::rocprofiler-sdk-perfetto
             rocprofiler-sdk::rocprofiler-sdk-otf2
             rocprofiler-sdk::rocprofiler-sdk-dw
             rocprofiler-sdk::rocprofiler-sdk-amd-comgr

--- a/projects/rocprofiler-sdk/source/lib/tests/common/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/tests/common/CMakeLists.txt
@@ -8,6 +8,7 @@ set(common_sources
     demangling.cpp
     dl.cpp
     environment.cpp
+    lz4_extension.cpp
     md5sum.cpp
     mpl.cpp
     parse.cpp

--- a/projects/rocprofiler-sdk/source/lib/tests/common/lz4_extension.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/common/lz4_extension.cpp
@@ -1,0 +1,75 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/output/sql/lz4_extension.hpp"
+
+#include <sqlite3.h>
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <string>
+
+namespace sql = rocprofiler::tool::sql;
+
+TEST(lz4_extension, buffer_round_trip)
+{
+    const auto input = std::string(1024, 'x') + R"({"key":"value","nested":[1,2,3]})";
+    const auto blob  = sql::lz4_compress_buffer(input);
+
+    ASSERT_GT(blob.size(), 8);
+    EXPECT_EQ(sql::lz4_decompress_buffer({reinterpret_cast<const char*>(blob.data()), blob.size()}),
+              input);
+}
+
+TEST(lz4_extension, empty_round_trip)
+{
+    auto blob = sql::lz4_compress_buffer({});
+    EXPECT_TRUE(blob.empty());
+    EXPECT_TRUE(sql::lz4_decompress_buffer({}).empty());
+}
+
+TEST(lz4_extension, invalid_magic_throws)
+{
+    EXPECT_THROW(sql::lz4_decompress_buffer("not-lz4"), std::runtime_error);
+}
+
+TEST(lz4_extension, sqlite_udf_round_trip)
+{
+    sqlite3* conn = nullptr;
+    ASSERT_EQ(sqlite3_open(":memory:", &conn), SQLITE_OK);
+    ASSERT_NE(conn, nullptr);
+
+    sql::register_lz4_functions(conn);
+
+    sqlite3_stmt* stmt = nullptr;
+    ASSERT_EQ(sqlite3_prepare_v2(conn,
+                                 "SELECT CAST(lz4_decompress(lz4_compress('{\"a\":1}')) AS TEXT)",
+                                 -1,
+                                 &stmt,
+                                 nullptr),
+              SQLITE_OK);
+    ASSERT_EQ(sqlite3_step(stmt), SQLITE_ROW);
+    EXPECT_STREQ(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0)), "{\"a\":1}");
+    EXPECT_EQ(sqlite3_finalize(stmt), SQLITE_OK);
+    EXPECT_EQ(sqlite3_close(conn), SQLITE_OK);
+}

--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk-rocpd/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk-rocpd/CMakeLists.txt
@@ -2,8 +2,18 @@
 #
 #
 
-set(rocpd_schemas data_views.sql marker_views.sql rocpd_indexes.sql rocpd_tables.sql
-                  rocpd_views.sql summary_views.sql)
+set(rocpd_schemas
+    data_views.sql
+    data_views_lz4.sql
+    marker_views.sql
+    marker_views_lz4.sql
+    rocpd_indexes.sql
+    rocpd_tables.sql
+    rocpd_tables_lz4.sql
+    rocpd_views.sql
+    rocpd_views_lz4.sql
+    summary_views.sql
+    summary_views_lz4.sql)
 
 foreach(_FILE ${rocpd_schemas})
     configure_file(${_FILE} ${PROJECT_BINARY_DIR}/share/rocprofiler-sdk-rocpd/${_FILE}

--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk-rocpd/data_views_lz4.sql
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk-rocpd/data_views_lz4.sql
@@ -1,0 +1,726 @@
+--
+-- Useful views
+--
+-- Code objects
+CREATE VIEW IF NOT EXISTS
+    `code_objects` AS
+SELECT
+    CO.id,
+    CO.guid,
+    CO.nid,
+    P.pid,
+    A.absolute_index AS agent_abs_index,
+    CO.uri,
+    CO.load_base,
+    CO.load_size,
+    CO.load_delta,
+    CO.storage_type AS storage_type_str,
+    JSON_EXTRACT(CO.extdata, '$.size') AS code_object_size,
+    JSON_EXTRACT(CO.extdata, '$.storage_type') AS storage_type,
+    JSON_EXTRACT(CO.extdata, '$.memory_base') AS memory_base,
+    JSON_EXTRACT(CO.extdata, '$.memory_size') AS memory_size
+FROM
+    `rocpd_info_code_object` CO
+    INNER JOIN `rocpd_info_agent` A ON CO.agent_id = A.id
+    AND CO.guid = A.guid
+    INNER JOIN `rocpd_info_process` P ON CO.pid = P.id
+    AND CO.guid = P.guid;
+
+CREATE VIEW IF NOT EXISTS
+    `kernel_symbols` AS
+SELECT
+    KS.id,
+    KS.guid,
+    KS.nid,
+    P.pid,
+    KS.code_object_id,
+    KS.kernel_name,
+    KS.display_name,
+    KS.kernel_object,
+    KS.kernarg_segment_size,
+    KS.kernarg_segment_alignment,
+    KS.group_segment_size,
+    KS.private_segment_size,
+    KS.sgpr_count,
+    KS.arch_vgpr_count,
+    KS.accum_vgpr_count,
+    JSON_EXTRACT(KS.extdata, '$.size') AS kernel_symbol_size,
+    JSON_EXTRACT(KS.extdata, '$.kernel_id') AS kernel_id,
+    JSON_EXTRACT(KS.extdata, '$.kernel_code_entry_byte_offset') AS kernel_code_entry_byte_offset,
+    JSON_EXTRACT(KS.extdata, '$.formatted_kernel_name') AS formatted_kernel_name,
+    JSON_EXTRACT(KS.extdata, '$.demangled_kernel_name') AS demangled_kernel_name,
+    JSON_EXTRACT(KS.extdata, '$.truncated_kernel_name') AS truncated_kernel_name,
+    JSON_EXTRACT(KS.extdata, '$.kernel_address.handle') AS kernel_address
+FROM
+    `rocpd_info_kernel_symbol` KS
+    INNER JOIN `rocpd_info_process` P ON KS.pid = P.id
+    AND KS.guid = P.guid;
+
+-- Processes
+CREATE VIEW IF NOT EXISTS
+    `processes` AS
+SELECT
+    N.id AS nid,
+    N.machine_id,
+    N.system_name,
+    N.hostname,
+    N.release AS system_release,
+    N.version AS system_version,
+    P.guid,
+    P.ppid,
+    P.pid,
+    P.init,
+    P.start,
+    P.end,
+    P.fini,
+    P.command
+FROM
+    `rocpd_info_process` P
+    INNER JOIN `rocpd_info_node` N ON N.id = P.nid
+    AND N.guid = P.guid;
+
+-- Threads
+CREATE VIEW IF NOT EXISTS
+    `threads` AS
+SELECT
+    N.id AS nid,
+    N.machine_id,
+    N.system_name,
+    N.hostname,
+    N.release AS system_release,
+    N.version AS system_version,
+    P.guid,
+    P.ppid,
+    P.pid,
+    T.tid,
+    T.start,
+    T.end,
+    T.name
+FROM
+    `rocpd_info_thread` T
+    INNER JOIN `rocpd_info_process` P ON P.id = T.pid
+    AND N.guid = T.guid
+    INNER JOIN `rocpd_info_node` N ON N.id = T.nid
+    AND N.guid = T.guid;
+
+-- CPU regions
+CREATE VIEW IF NOT EXISTS
+    `regions` AS
+SELECT
+    R.id,
+    R.guid,
+    (
+        SELECT
+            string
+        FROM
+            `rocpd_string` RS
+        WHERE
+            RS.id = E.category_id
+            AND RS.guid = E.guid
+    ) AS category,
+    S.string AS name,
+    R.nid,
+    P.pid,
+    T.tid,
+    R.start,
+    R.end,
+    (R.end - R.start) AS duration,
+    R.event_id,
+    E.stack_id,
+    E.parent_stack_id,
+    E.correlation_id AS corr_id,
+    E.extdata,
+    E.call_stack,
+    E.line_info
+FROM
+    `rocpd_region` R
+    INNER JOIN `rocpd_event` E ON E.id = R.event_id
+    AND E.guid = R.guid
+    INNER JOIN `rocpd_string` S ON S.id = R.name_id
+    AND S.guid = R.guid
+    INNER JOIN `rocpd_info_process` P ON P.id = R.pid
+    AND P.guid = R.guid
+    INNER JOIN `rocpd_info_thread` T ON T.id = R.tid
+    AND T.guid = R.guid;
+
+CREATE VIEW IF NOT EXISTS
+    `region_args` AS
+SELECT
+    R.id,
+    R.guid,
+    R.nid,
+    P.pid,
+    A.type,
+    A.name,
+    A.value
+FROM
+    `rocpd_region` R
+    INNER JOIN `rocpd_event` E ON E.id = R.event_id
+    AND E.guid = R.guid
+    INNER JOIN `rocpd_arg` A ON A.event_id = E.id
+    AND A.guid = R.guid
+    INNER JOIN `rocpd_info_process` P ON P.id = R.pid
+    AND P.guid = R.guid;
+
+--
+-- Samples
+CREATE VIEW IF NOT EXISTS
+    `samples` AS
+SELECT
+    R.id,
+    R.guid,
+    (
+        SELECT
+            string
+        FROM
+            `rocpd_string` RS
+        WHERE
+            RS.id = E.category_id
+            AND RS.guid = E.guid
+    ) AS category,
+    (
+        SELECT
+            string
+        FROM
+            `rocpd_string` RS
+        WHERE
+            RS.id = T.name_id
+            AND RS.guid = T.guid
+    ) AS name,
+    T.nid,
+    P.pid,
+    TH.tid,
+    R.timestamp,
+    R.event_id,
+    E.stack_id AS stack_id,
+    E.parent_stack_id AS parent_stack_id,
+    E.correlation_id AS corr_id,
+    E.extdata AS extdata,
+    E.call_stack AS call_stack,
+    E.line_info AS line_info
+FROM
+    `rocpd_sample` R
+    INNER JOIN `rocpd_track` T ON T.id = R.track_id
+    AND T.guid = R.guid
+    INNER JOIN `rocpd_event` E ON E.id = R.event_id
+    AND E.guid = R.guid
+    INNER JOIN `rocpd_info_process` P ON P.id = T.pid
+    AND P.guid = T.guid
+    INNER JOIN `rocpd_info_thread` TH ON TH.id = T.tid
+    AND TH.guid = T.guid;
+
+--
+-- Provides samples view with the same columns as regions view
+CREATE VIEW IF NOT EXISTS
+    `sample_regions` AS
+SELECT
+    R.id,
+    R.guid,
+    (
+        SELECT
+            string
+        FROM
+            `rocpd_string` RS
+        WHERE
+            RS.id = E.category_id
+            AND RS.guid = E.guid
+    ) AS category,
+    (
+        SELECT
+            string
+        FROM
+            `rocpd_string` RS
+        WHERE
+            RS.id = T.name_id
+            AND RS.guid = T.guid
+    ) AS name,
+    T.nid,
+    P.pid,
+    TH.tid,
+    R.timestamp AS start,
+    R.timestamp AS END,
+    (R.timestamp - R.timestamp) AS duration,
+    R.event_id,
+    E.stack_id AS stack_id,
+    E.parent_stack_id AS parent_stack_id,
+    E.correlation_id AS corr_id,
+    E.extdata AS extdata,
+    E.call_stack AS call_stack,
+    E.line_info AS line_info
+FROM
+    `rocpd_sample` R
+    INNER JOIN `rocpd_track` T ON T.id = R.track_id
+    AND T.guid = R.guid
+    INNER JOIN `rocpd_event` E ON E.id = R.event_id
+    AND E.guid = R.guid
+    INNER JOIN `rocpd_info_process` P ON P.id = T.pid
+    AND P.guid = T.guid
+    INNER JOIN `rocpd_info_thread` TH ON TH.id = T.tid
+    AND TH.guid = T.guid;
+
+--
+-- Provides a unified view of the regions and samples
+CREATE VIEW IF NOT EXISTS
+    `regions_and_samples` AS
+SELECT
+    *
+FROM
+    `regions`
+UNION ALL
+SELECT
+    *
+FROM
+    `sample_regions`;
+
+--
+-- Kernel information
+CREATE VIEW
+    `kernels` AS
+SELECT
+    K.id,
+    K.guid,
+    T.tid,
+    (
+        SELECT
+            string
+        FROM
+            `rocpd_string` RS
+        WHERE
+            RS.id = E.category_id
+            AND RS.guid = E.guid
+    ) AS category,
+    R.string AS region,
+    S.display_name AS name,
+    K.nid,
+    P.pid,
+    A.absolute_index AS agent_abs_index,
+    A.logical_index AS agent_log_index,
+    A.type_index AS agent_type_index,
+    A.type AS agent_type,
+    S.code_object_id AS code_object_id,
+    K.kernel_id,
+    K.dispatch_id,
+    K.stream_id,
+    K.queue_id,
+    Q.name AS queue,
+    ST.name AS stream,
+    K.start,
+    K.end,
+    (K.end - K.start) AS duration,
+    K.grid_size_x AS grid_x,
+    K.grid_size_y AS grid_y,
+    K.grid_size_z AS grid_z,
+    K.workgroup_size_x AS workgroup_x,
+    K.workgroup_size_y AS workgroup_y,
+    K.workgroup_size_z AS workgroup_z,
+    K.group_segment_size AS lds_size,
+    K.private_segment_size AS scratch_size,
+    S.arch_vgpr_count AS vgpr_count,
+    S.accum_vgpr_count,
+    S.sgpr_count,
+    S.group_segment_size AS static_lds_size,
+    S.private_segment_size AS static_scratch_size,
+    E.stack_id,
+    E.parent_stack_id,
+    E.correlation_id AS corr_id
+FROM
+    `rocpd_kernel_dispatch` K
+    INNER JOIN `rocpd_info_agent` A ON A.id = K.agent_id
+    AND A.guid = K.guid
+    INNER JOIN `rocpd_event` E ON E.id = K.event_id
+    AND E.guid = K.guid
+    INNER JOIN `rocpd_string` R ON R.id = K.region_name_id
+    AND R.guid = K.guid
+    INNER JOIN `rocpd_info_kernel_symbol` S ON S.id = K.kernel_id
+    AND S.guid = K.guid
+    LEFT JOIN `rocpd_info_stream` ST ON ST.id = K.stream_id
+    AND ST.guid = K.guid
+    LEFT JOIN `rocpd_info_queue` Q ON Q.id = K.queue_id
+    AND Q.guid = K.guid
+    INNER JOIN `rocpd_info_process` P ON P.id = Q.pid
+    AND P.guid = Q.guid
+    INNER JOIN `rocpd_info_thread` T ON T.id = K.tid
+    AND T.guid = K.guid;
+
+--
+-- Performance Monitoring Counters (PMC)
+CREATE VIEW IF NOT EXISTS
+    `pmc_info` AS
+SELECT
+    PMC_I.id,
+    PMC_I.guid,
+    PMC_I.nid,
+    P.pid,
+    A.absolute_index AS agent_abs_index,
+    PMC_I.is_constant,
+    PMC_I.is_derived,
+    PMC_I.name,
+    PMC_I.description,
+    PMC_I.block,
+    PMC_I.expression
+FROM
+    `rocpd_info_pmc` PMC_I
+    INNER JOIN `rocpd_info_agent` A ON PMC_I.agent_id = A.id
+    AND PMC_I.guid = A.guid
+    INNER JOIN `rocpd_info_process` P ON P.id = PMC_I.pid
+    AND PMC_I.guid = P.guid;
+
+CREATE VIEW IF NOT EXISTS
+    `pmc_events` AS
+SELECT
+    PMC_E.id,
+    PMC_E.guid,
+    PMC_E.pmc_id,
+    E.id AS event_id,
+    (
+        SELECT
+            string
+        FROM
+            `rocpd_string` RS
+        WHERE
+            RS.id = E.category_id
+            AND RS.guid = E.guid
+    ) AS category,
+    (
+        SELECT
+            display_name
+        FROM
+            `rocpd_info_kernel_symbol` KS
+        WHERE
+            KS.id = K.kernel_id
+            AND KS.guid = K.guid
+    ) AS name,
+    K.nid,
+    P.pid,
+    K.dispatch_id,
+    K.start,
+    K.end,
+    (K.end - K.start) AS duration,
+    PMC_I.name AS counter_name,
+    PMC_E.value AS counter_value
+FROM
+    `rocpd_pmc_event` PMC_E
+    INNER JOIN `rocpd_info_pmc` PMC_I ON PMC_I.id = PMC_E.pmc_id
+    AND PMC_I.guid = PMC_E.guid
+    INNER JOIN `rocpd_event` E ON E.id = PMC_E.event_id
+    AND E.guid = PMC_E.guid
+    INNER JOIN `rocpd_kernel_dispatch` K ON K.event_id = PMC_E.event_id
+    AND K.guid = PMC_E.guid
+    INNER JOIN `rocpd_info_process` P ON P.id = K.pid
+    AND P.guid = K.guid;
+
+-- events with arguments ---
+CREATE VIEW IF NOT EXISTS
+    `events_args` AS
+SELECT
+    E.id AS event_id,
+    (
+        SELECT
+            string
+        FROM
+            `rocpd_string` RS
+        WHERE
+            RS.id = E.category_id
+            AND RS.guid = E.guid
+    ) AS category,
+    E.stack_id,
+    E.parent_stack_id,
+    E.correlation_id,
+    A.position AS arg_position,
+    A.type AS arg_type,
+    A.name AS arg_name,
+    A.value AS arg_value,
+    E.call_stack,
+    E.line_info,
+    A.extdata
+FROM
+    `rocpd_event` E
+    INNER JOIN `rocpd_arg` A ON A.event_id = E.id
+    AND A.guid = E.guid;
+
+-- list of astream arguments enriched by the corresponding stream descriptions
+CREATE VIEW IF NOT EXISTS
+    `stream_args` AS
+SELECT
+    A.id AS argument_id,
+    A.event_id AS event_id,
+    A.position AS arg_position,
+    A.type AS arg_type,
+    A.value AS arg_value,
+    JSON_EXTRACT(A.extdata, '$.stream_id') AS stream_id,
+    S.nid,
+    P.pid,
+    S.name AS stream_name,
+    S.extdata AS extdata
+FROM
+    `rocpd_arg` A
+    INNER JOIN `rocpd_info_stream` S ON JSON_EXTRACT(A.extdata, '$.stream_id') = S.id
+    AND A.guid = S.guid
+    INNER JOIN `rocpd_info_process` P ON P.id = S.pid
+    AND P.guid = S.guid
+WHERE
+    A.name = 'stream';
+
+--
+--
+CREATE VIEW IF NOT EXISTS
+    `memory_copies` AS
+SELECT
+    M.id,
+    M.guid,
+    (
+        SELECT
+            string
+        FROM
+            `rocpd_string` RS
+        WHERE
+            RS.id = E.category_id
+            AND RS.guid = E.guid
+    ) AS category,
+    M.nid,
+    P.pid,
+    T.tid,
+    M.start,
+    M.end,
+    (M.end - M.start) AS duration,
+    S.string AS name,
+    R.string AS region_name,
+    M.stream_id,
+    M.queue_id,
+    ST.name AS stream_name,
+    Q.name AS queue_name,
+    M.size,
+    dst_agent.name AS dst_device,
+    dst_agent.absolute_index AS dst_agent_abs_index,
+    dst_agent.logical_index AS dst_agent_log_index,
+    dst_agent.type_index AS dst_agent_type_index,
+    dst_agent.type AS dst_agent_type,
+    M.dst_address,
+    src_agent.name AS src_device,
+    src_agent.absolute_index AS src_agent_abs_index,
+    src_agent.logical_index AS src_agent_log_index,
+    src_agent.type_index AS src_agent_type_index,
+    src_agent.type AS src_agent_type,
+    M.src_address,
+    E.stack_id,
+    E.parent_stack_id,
+    E.correlation_id AS corr_id
+FROM
+    `rocpd_memory_copy` M
+    INNER JOIN `rocpd_string` S ON S.id = M.name_id
+    AND S.guid = M.guid
+    LEFT JOIN `rocpd_string` R ON R.id = M.region_name_id
+    AND R.guid = M.guid
+    INNER JOIN `rocpd_info_agent` dst_agent ON dst_agent.id = M.dst_agent_id
+    AND dst_agent.guid = M.guid
+    INNER JOIN `rocpd_info_agent` src_agent ON src_agent.id = M.src_agent_id
+    AND src_agent.guid = M.guid
+    LEFT JOIN `rocpd_info_queue` Q ON Q.id = M.queue_id
+    AND Q.guid = M.guid
+    LEFT JOIN `rocpd_info_stream` ST ON ST.id = M.stream_id
+    AND ST.guid = M.guid
+    INNER JOIN `rocpd_event` E ON E.id = M.event_id
+    AND E.guid = M.guid
+    INNER JOIN `rocpd_info_process` P ON P.id = M.pid
+    AND P.guid = M.guid
+    INNER JOIN `rocpd_info_thread` T ON T.id = M.tid
+    AND T.guid = M.guid;
+
+--
+--
+CREATE VIEW IF NOT EXISTS
+    `memory_allocations` AS
+SELECT
+    M.id,
+    M.guid,
+    (
+        SELECT
+            string
+        FROM
+            `rocpd_string` RS
+        WHERE
+            RS.id = E.category_id
+            AND RS.guid = E.guid
+    ) AS category,
+    M.nid,
+    P.pid,
+    T.tid,
+    M.start,
+    M.end,
+    (M.end - M.start) AS duration,
+    M.type,
+    M.level,
+    A.name AS agent_name,
+    A.absolute_index AS agent_abs_index,
+    A.logical_index AS agent_log_index,
+    A.type_index AS agent_type_index,
+    A.type AS agent_type,
+    M.address,
+    M.size,
+    M.queue_id,
+    Q.name AS queue_name,
+    M.stream_id,
+    ST.name AS stream_name,
+    E.stack_id,
+    E.parent_stack_id,
+    E.correlation_id AS corr_id
+FROM
+    `rocpd_memory_allocate` M
+    LEFT JOIN `rocpd_info_agent` A ON M.agent_id = A.id
+    AND M.guid = A.guid
+    LEFT JOIN `rocpd_info_queue` Q ON Q.id = M.queue_id
+    AND Q.guid = M.guid
+    LEFT JOIN `rocpd_info_stream` ST ON ST.id = M.stream_id
+    AND ST.guid = M.guid
+    INNER JOIN `rocpd_event` E ON E.id = M.event_id
+    AND E.guid = M.guid
+    INNER JOIN `rocpd_info_process` P ON P.id = M.pid
+    AND P.guid = M.guid
+    INNER JOIN `rocpd_info_thread` T ON T.id = M.tid
+    AND P.guid = M.guid;
+
+--
+--
+CREATE VIEW IF NOT EXISTS
+    `scratch_memory` AS
+SELECT
+    M.id,
+    M.guid,
+    M.nid,
+    P.pid,
+    M.type AS operation,
+    A.name AS agent_name,
+    A.absolute_index AS agent_abs_index,
+    A.logical_index AS agent_log_index,
+    A.type_index AS agent_type_index,
+    A.type AS agent_type,
+    M.queue_id,
+    T.tid,
+    JSON_EXTRACT(M.extdata, '$.flags') AS alloc_flags,
+    M.start,
+    M.end,
+    (M.end - M.start) AS duration,
+    M.size,
+    M.address,
+    E.correlation_id,
+    E.stack_id,
+    E.parent_stack_id,
+    E.correlation_id AS corr_id,
+    (
+        SELECT
+            string
+        FROM
+            `rocpd_string` RS
+        WHERE
+            RS.id = E.category_id
+            AND RS.guid = E.guid
+    ) AS category,
+    E.extdata AS event_extdata
+FROM
+    `rocpd_memory_allocate` M
+    LEFT JOIN `rocpd_info_agent` A ON M.agent_id = A.id
+    AND M.guid = A.guid
+    LEFT JOIN `rocpd_info_queue` Q ON Q.id = M.queue_id
+    AND Q.guid = M.guid
+    INNER JOIN `rocpd_event` E ON E.id = M.event_id
+    AND E.guid = M.guid
+    INNER JOIN `rocpd_info_process` P ON P.id = M.pid
+    AND P.guid = M.guid
+    INNER JOIN `rocpd_info_thread` T ON T.id = M.tid
+    AND T.guid = M.guid
+WHERE
+    M.level = 'SCRATCH'
+ORDER BY
+    M.start ASC;
+
+--
+--
+CREATE VIEW IF NOT EXISTS
+    `counters_collection` AS
+SELECT
+    MIN(PMC_E.id) AS id,
+    PMC_E.guid,
+    K.dispatch_id,
+    K.kernel_id,
+    E.id AS event_id,
+    E.correlation_id,
+    E.stack_id,
+    E.parent_stack_id,
+    P.pid,
+    T.tid,
+    K.agent_id,
+    A.absolute_index AS agent_abs_index,
+    A.logical_index AS agent_log_index,
+    A.type_index AS agent_type_index,
+    A.type AS agent_type,
+    K.queue_id,
+    k.grid_size_x AS grid_size_x,
+    k.grid_size_y AS grid_size_y,
+    k.grid_size_z AS grid_size_z,
+    (K.grid_size_x * K.grid_size_y * K.grid_size_z) AS grid_size,
+    S.display_name AS kernel_name,
+    (
+        SELECT
+            string
+        FROM
+            `rocpd_string` RS
+        WHERE
+            RS.id = K.region_name_id
+            AND RS.guid = K.guid
+    ) AS kernel_region,
+    K.workgroup_size_x AS workgroup_size_x,
+    K.workgroup_size_y AS workgroup_size_y,
+    K.workgroup_size_z AS workgroup_size_z,
+    (K.workgroup_size_x * K.workgroup_size_y * K.workgroup_size_z) AS workgroup_size,
+    K.group_segment_size AS lds_block_size,
+    K.private_segment_size AS scratch_size,
+    S.arch_vgpr_count AS vgpr_count,
+    S.accum_vgpr_count,
+    S.sgpr_count,
+    PMC_I.name AS counter_name,
+    PMC_I.symbol AS counter_symbol,
+    PMC_I.component,
+    PMC_I.description,
+    PMC_I.block,
+    PMC_I.expression,
+    PMC_I.value_type,
+    PMC_I.id AS counter_id,
+    SUM(PMC_E.value) AS value,
+    K.start,
+    K.end,
+    PMC_I.is_constant,
+    PMC_I.is_derived,
+    (K.end - K.start) AS duration,
+    (
+        SELECT
+            string
+        FROM
+            `rocpd_string` RS
+        WHERE
+            RS.id = E.category_id
+            AND RS.guid = E.guid
+    ) AS category,
+    K.nid,
+    E.extdata,
+    S.code_object_id
+FROM
+    `rocpd_pmc_event` PMC_E
+    INNER JOIN `rocpd_info_pmc` PMC_I ON PMC_I.id = PMC_E.pmc_id
+    AND PMC_I.guid = PMC_E.guid
+    INNER JOIN `rocpd_event` E ON E.id = PMC_E.event_id
+    AND E.guid = PMC_E.guid
+    INNER JOIN `rocpd_kernel_dispatch` K ON K.event_id = PMC_E.event_id
+    AND K.guid = PMC_E.guid
+    INNER JOIN `rocpd_info_agent` A ON A.id = K.agent_id
+    AND A.guid = K.guid
+    INNER JOIN `rocpd_info_kernel_symbol` S ON S.id = K.kernel_id
+    AND S.guid = K.guid
+    INNER JOIN `rocpd_info_process` P ON P.id = K.pid
+    AND P.guid = K.guid
+    INNER JOIN `rocpd_info_thread` T ON T.id = K.tid
+    AND T.guid = K.guid
+GROUP BY
+    PMC_E.guid,
+    K.dispatch_id,
+    PMC_I.name,
+    K.agent_id;

--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk-rocpd/marker_views_lz4.sql
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk-rocpd/marker_views_lz4.sql
@@ -1,0 +1,3 @@
+--
+-- Views related to markers
+--

--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk-rocpd/rocpd_tables_lz4.sql
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk-rocpd/rocpd_tables_lz4.sql
@@ -1,0 +1,374 @@
+-- Enable foreign key support for cascading
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS
+    "rocpd_metadata{{uuid}}" (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "tag" TEXT NOT NULL,
+        "value" TEXT NOT NULL
+    );
+
+CREATE TABLE IF NOT EXISTS
+    `rocpd_string{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "string" TEXT NOT NULL UNIQUE ON CONFLICT ABORT
+    );
+
+CREATE TABLE IF NOT EXISTS
+    `rocpd_info_node{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "hash" BIGINT NOT NULL UNIQUE,
+        "machine_id" TEXT NOT NULL UNIQUE,
+        "system_name" TEXT,
+        "hostname" TEXT,
+        "release" TEXT,
+        "version" TEXT,
+        "hardware_name" TEXT,
+        "domain_name" TEXT
+    );
+
+CREATE TABLE IF NOT EXISTS
+    `rocpd_info_process{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "nid" INTEGER NOT NULL,
+        "ppid" INTEGER,
+        "pid" INTEGER NOT NULL,
+        "init" BIGINT,
+        "fini" BIGINT,
+        "start" BIGINT,
+        "end" BIGINT,
+        "command" TEXT,
+        "environment" JSONB DEFAULT "{}" NOT NULL,
+        "extdata" BLOB DEFAULT X'' NOT NULL,
+        FOREIGN KEY (nid) REFERENCES `rocpd_info_node{{uuid}}` (id) ON UPDATE CASCADE
+    );
+
+CREATE TABLE IF NOT EXISTS
+    `rocpd_info_thread{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "nid" INTEGER NOT NULL,
+        "ppid" INTEGER,
+        "pid" INTEGER NOT NULL,
+        "tid" INTEGER NOT NULL,
+        "name" TEXT,
+        "start" BIGINT,
+        "end" BIGINT,
+        "extdata" BLOB DEFAULT X'' NOT NULL,
+        FOREIGN KEY (nid) REFERENCES `rocpd_info_node{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (pid) REFERENCES `rocpd_info_process{{uuid}}` (id) ON UPDATE CASCADE
+    );
+
+CREATE TABLE IF NOT EXISTS
+    `rocpd_info_agent{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "nid" INTEGER NOT NULL,
+        "pid" INTEGER NOT NULL,
+        "type" TEXT CHECK ("type" IN ('CPU', 'GPU')),
+        "absolute_index" INTEGER,
+        "logical_index" INTEGER,
+        "type_index" INTEGER,
+        "uuid" INTEGER,
+        "name" TEXT,
+        "model_name" TEXT,
+        "vendor_name" TEXT,
+        "product_name" TEXT,
+        "user_name" TEXT,
+        "extdata" BLOB DEFAULT X'' NOT NULL,
+        FOREIGN KEY (nid) REFERENCES `rocpd_info_node{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (pid) REFERENCES `rocpd_info_process{{uuid}}` (id) ON UPDATE CASCADE
+    );
+
+CREATE TABLE IF NOT EXISTS
+    `rocpd_info_queue{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "nid" INTEGER NOT NULL,
+        "pid" INTEGER NOT NULL,
+        "name" TEXT,
+        "extdata" BLOB DEFAULT X'' NOT NULL,
+        FOREIGN KEY (nid) REFERENCES `rocpd_info_node{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (pid) REFERENCES `rocpd_info_process{{uuid}}` (id) ON UPDATE CASCADE
+    );
+
+CREATE TABLE IF NOT EXISTS
+    `rocpd_info_stream{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "nid" INTEGER NOT NULL,
+        "pid" INTEGER NOT NULL,
+        "name" TEXT,
+        "extdata" BLOB DEFAULT X'' NOT NULL,
+        FOREIGN KEY (nid) REFERENCES `rocpd_info_node{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (pid) REFERENCES `rocpd_info_process{{uuid}}` (id) ON UPDATE CASCADE
+    );
+
+-- 2993533, 2269219937, 2993533
+-- 2993533, 2269219937, 2993533
+-- Performance monitoring counters (PMC) descriptions
+CREATE TABLE IF NOT EXISTS
+    `rocpd_info_pmc{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "nid" INTEGER NOT NULL,
+        "pid" INTEGER NOT NULL,
+        "agent_id" INTEGER,
+        "target_arch" TEXT CHECK ("target_arch" IN ('CPU', 'GPU')),
+        "event_code" INT,
+        "instance_id" INTEGER,
+        "name" TEXT NOT NULL,
+        "symbol" TEXT NOT NULL,
+        "description" TEXT,
+        "long_description" TEXT DEFAULT "",
+        "component" TEXT,
+        "units" TEXT DEFAULT "",
+        "value_type" TEXT CHECK ("value_type" IN ('ABS', 'ACCUM', 'RELATIVE')),
+        "block" TEXT,
+        "expression" TEXT,
+        "is_constant" INTEGER,
+        "is_derived" INTEGER,
+        "extdata" BLOB DEFAULT X'' NOT NULL,
+        FOREIGN KEY (nid) REFERENCES `rocpd_info_node{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (pid) REFERENCES `rocpd_info_process{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (agent_id) REFERENCES `rocpd_info_agent{{uuid}}` (id) ON UPDATE CASCADE
+    );
+
+CREATE TABLE IF NOT EXISTS
+    `rocpd_info_code_object{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "nid" INTEGER NOT NULL,
+        "pid" INTEGER NOT NULL,
+        "agent_id" INTEGER,
+        "uri" TEXT,
+        "load_base" BIGINT,
+        "load_size" BIGINT,
+        "load_delta" BIGINT,
+        "storage_type" TEXT CHECK ("storage_type" IN ('FILE', 'MEMORY')),
+        "extdata" BLOB DEFAULT X'' NOT NULL,
+        FOREIGN KEY (nid) REFERENCES `rocpd_info_node{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (pid) REFERENCES `rocpd_info_process{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (agent_id) REFERENCES `rocpd_info_agent{{uuid}}` (id) ON UPDATE CASCADE
+    );
+
+CREATE TABLE IF NOT EXISTS
+    `rocpd_info_kernel_symbol{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "nid" INTEGER NOT NULL,
+        "pid" INTEGER NOT NULL,
+        "code_object_id" INTEGER NOT NULL,
+        "kernel_name" TEXT,
+        "display_name" TEXT,
+        "kernel_object" INTEGER,
+        "kernarg_segment_size" INTEGER,
+        "kernarg_segment_alignment" INTEGER,
+        "group_segment_size" INTEGER,
+        "private_segment_size" INTEGER,
+        "sgpr_count" INTEGER,
+        "arch_vgpr_count" INTEGER,
+        "accum_vgpr_count" INTEGER,
+        "extdata" BLOB DEFAULT X'' NOT NULL,
+        FOREIGN KEY (nid) REFERENCES `rocpd_info_node{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (pid) REFERENCES `rocpd_info_process{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (code_object_id) REFERENCES `rocpd_info_code_object{{uuid}}` (id) ON UPDATE CASCADE
+    );
+
+-- Stores repetitive info for samples
+CREATE TABLE IF NOT EXISTS
+    `rocpd_track{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "nid" INTEGER NOT NULL,
+        "pid" INTEGER,
+        "tid" INTEGER,
+        "name_id" INTEGER,
+        "extdata" BLOB DEFAULT X'' NOT NULL,
+        FOREIGN KEY (nid) REFERENCES `rocpd_info_node{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (pid) REFERENCES `rocpd_info_process{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (tid) REFERENCES `rocpd_info_thread{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (name_id) REFERENCES `rocpd_string{{uuid}}` (id) ON UPDATE CASCADE
+    );
+
+-- Storage for a region, instant, and counter
+CREATE TABLE IF NOT EXISTS
+    `rocpd_event{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "category_id" INTEGER,
+        "stack_id" INTEGER,
+        "parent_stack_id" INTEGER,
+        "correlation_id" INTEGER,
+        "call_stack" BLOB DEFAULT X'' NOT NULL,
+        "line_info" BLOB DEFAULT X'' NOT NULL,
+        "extdata" BLOB DEFAULT X'' NOT NULL,
+        FOREIGN KEY (category_id) REFERENCES `rocpd_string{{uuid}}` (id) ON UPDATE CASCADE
+    );
+
+-- stores arguments for events
+CREATE TABLE IF NOT EXISTS
+    `rocpd_arg{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "event_id" INTEGER NOT NULL,
+        "position" INTEGER NOT NULL,
+        "type" TEXT NOT NULL,
+        "name" TEXT NOT NULL,
+        "value" TEXT, -- TODO: discuss make it value_id and integer, refer to string table --
+        "extdata" BLOB DEFAULT X'' NOT NULL,
+        FOREIGN KEY (event_id) REFERENCES `rocpd_event{{uuid}}` (id) ON UPDATE CASCADE
+    );
+
+-- Region with a start/stop on the same thread (CPU)
+CREATE TABLE IF NOT EXISTS
+    `rocpd_pmc_event{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "event_id" INTEGER,
+        "pmc_id" INTEGER NOT NULL,
+        "value" REAL DEFAULT 0.0,
+        "extdata" BLOB DEFAULT X'',
+        FOREIGN KEY (pmc_id) REFERENCES `rocpd_info_pmc{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (event_id) REFERENCES `rocpd_event{{uuid}}` (id) ON UPDATE CASCADE
+    );
+
+-- Region with a start/stop on the same thread (CPU)
+CREATE TABLE IF NOT EXISTS
+    `rocpd_region{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "nid" INTEGER NOT NULL,
+        "pid" INTEGER NOT NULL,
+        "tid" INTEGER NOT NULL,
+        "start" BIGINT NOT NULL,
+        "end" BIGINT NOT NULL,
+        "name_id" INTEGER NOT NULL,
+        "event_id" INTEGER,
+        "extdata" BLOB DEFAULT X'' NOT NULL,
+        FOREIGN KEY (nid) REFERENCES `rocpd_info_node{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (pid) REFERENCES `rocpd_info_process{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (tid) REFERENCES `rocpd_info_thread{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (name_id) REFERENCES `rocpd_string{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (event_id) REFERENCES `rocpd_event{{uuid}}` (id) ON UPDATE CASCADE
+    );
+
+-- Instantaneous sample
+CREATE TABLE IF NOT EXISTS
+    `rocpd_sample{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "track_id" INTEGER NOT NULL,
+        "timestamp" BIGINT NOT NULL,
+        "event_id" INTEGER,
+        "extdata" BLOB DEFAULT X'' NOT NULL,
+        FOREIGN KEY (track_id) REFERENCES `rocpd_track{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (event_id) REFERENCES `rocpd_event{{uuid}}` (id) ON UPDATE CASCADE
+    );
+
+CREATE TABLE IF NOT EXISTS
+    `rocpd_kernel_dispatch{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "nid" INTEGER NOT NULL,
+        "pid" INTEGER NOT NULL,
+        "tid" INTEGER,
+        "agent_id" INTEGER NOT NULL,
+        "kernel_id" INTEGER NOT NULL,
+        "dispatch_id" INTEGER NOT NULL,
+        "queue_id" INTEGER NOT NULL,
+        "stream_id" INTEGER NOT NULL,
+        "start" BIGINT NOT NULL,
+        "end" BIGINT NOT NULL,
+        "private_segment_size" INTEGER,
+        "group_segment_size" INTEGER,
+        "workgroup_size_x" INTEGER NOT NULL,
+        "workgroup_size_y" INTEGER NOT NULL,
+        "workgroup_size_z" INTEGER NOT NULL,
+        "grid_size_x" INTEGER NOT NULL,
+        "grid_size_y" INTEGER NOT NULL,
+        "grid_size_z" INTEGER NOT NULL,
+        "region_name_id" INTEGER,
+        "event_id" INTEGER,
+        "extdata" BLOB DEFAULT X'' NOT NULL,
+        FOREIGN KEY (nid) REFERENCES `rocpd_info_node{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (pid) REFERENCES `rocpd_info_process{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (tid) REFERENCES `rocpd_info_thread{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (agent_id) REFERENCES `rocpd_info_agent{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (kernel_id) REFERENCES `rocpd_info_kernel_symbol{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (queue_id) REFERENCES `rocpd_info_queue{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (stream_id) REFERENCES `rocpd_info_stream{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (region_name_id) REFERENCES `rocpd_string{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (event_id) REFERENCES `rocpd_event{{uuid}}` (id) ON UPDATE CASCADE
+    );
+
+CREATE TABLE IF NOT EXISTS
+    `rocpd_memory_copy{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "nid" INTEGER NOT NULL,
+        "pid" INTEGER NOT NULL,
+        "tid" INTEGER,
+        "start" BIGINT NOT NULL,
+        "end" BIGINT NOT NULL,
+        "name_id" INTEGER NOT NULL,
+        "dst_agent_id" INTEGER,
+        "dst_address" INTEGER,
+        "src_agent_id" INTEGER,
+        "src_address" INTEGER,
+        "size" INTEGER NOT NULL,
+        "queue_id" INTEGER,
+        "stream_id" INTEGER,
+        "region_name_id" INTEGER,
+        "event_id" INTEGER,
+        "extdata" BLOB DEFAULT X'' NOT NULL,
+        FOREIGN KEY (nid) REFERENCES `rocpd_info_node{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (pid) REFERENCES `rocpd_info_process{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (tid) REFERENCES `rocpd_info_thread{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (name_id) REFERENCES `rocpd_string{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (dst_agent_id) REFERENCES `rocpd_info_agent{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (src_agent_id) REFERENCES `rocpd_info_agent{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (stream_id) REFERENCES `rocpd_info_stream{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (queue_id) REFERENCES `rocpd_info_queue{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (region_name_id) REFERENCES `rocpd_string{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (event_id) REFERENCES `rocpd_event{{uuid}}` (id) ON UPDATE CASCADE
+    );
+
+-- Memory allocations (real memory, virtual memory, and scratch memory)
+CREATE TABLE IF NOT EXISTS
+    `rocpd_memory_allocate{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "nid" INTEGER NOT NULL,
+        "pid" INTEGER NOT NULL,
+        "tid" INTEGER,
+        "agent_id" INTEGER,
+        "type" TEXT CHECK ("type" IN ('ALLOC', 'FREE', 'REALLOC', 'RECLAIM')),
+        "level" TEXT CHECK ("level" IN ('REAL', 'VIRTUAL', 'SCRATCH')),
+        "start" BIGINT NOT NULL,
+        "end" BIGINT NOT NULL,
+        "address" INTEGER,
+        "size" INTEGER NOT NULL,
+        "queue_id" INTEGER,
+        "stream_id" INTEGER,
+        "event_id" INTEGER,
+        "extdata" BLOB DEFAULT X'' NOT NULL,
+        FOREIGN KEY (nid) REFERENCES `rocpd_info_node{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (pid) REFERENCES `rocpd_info_process{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (tid) REFERENCES `rocpd_info_thread{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (agent_id) REFERENCES `rocpd_info_agent{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (stream_id) REFERENCES `rocpd_info_stream{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (queue_id) REFERENCES `rocpd_info_queue{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (event_id) REFERENCES `rocpd_event{{uuid}}` (id) ON UPDATE CASCADE
+    );
+
+INSERT INTO
+    `rocpd_metadata{{uuid}}` ("tag", "value")
+VALUES
+    ("schema_version", "4"),
+    ("uuid", "{{uuid}}"),
+    ("guid", "{{guid}}"),
+    ("compression", "lz4-frame-v1");

--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk-rocpd/rocpd_views_lz4.sql
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk-rocpd/rocpd_views_lz4.sql
@@ -1,0 +1,334 @@
+CREATE VIEW IF NOT EXISTS
+    `rocpd_metadata` AS
+SELECT
+    "id",
+    "tag",
+    "value"
+FROM
+    `rocpd_metadata{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_string` AS
+SELECT
+    "id",
+    "guid",
+    "string"
+FROM
+    `rocpd_string{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_info_node` AS
+SELECT
+    "id",
+    "guid",
+    "hash",
+    "machine_id",
+    "system_name",
+    "hostname",
+    "release",
+    "version",
+    "hardware_name",
+    "domain_name"
+FROM
+    `rocpd_info_node{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_info_process` AS
+SELECT
+    "id",
+    "guid",
+    "nid",
+    "ppid",
+    "pid",
+    "init",
+    "fini",
+    "start",
+    "end",
+    "command",
+    "environment",
+    CAST(lz4_decompress("extdata") AS TEXT) AS "extdata"
+FROM
+    `rocpd_info_process{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_info_thread` AS
+SELECT
+    "id",
+    "guid",
+    "nid",
+    "ppid",
+    "pid",
+    "tid",
+    "name",
+    "start",
+    "end",
+    CAST(lz4_decompress("extdata") AS TEXT) AS "extdata"
+FROM
+    `rocpd_info_thread{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_info_agent` AS
+SELECT
+    "id",
+    "guid",
+    "nid",
+    "pid",
+    "type",
+    "absolute_index",
+    "logical_index",
+    "type_index",
+    "uuid",
+    "name",
+    "model_name",
+    "vendor_name",
+    "product_name",
+    "user_name",
+    CAST(lz4_decompress("extdata") AS TEXT) AS "extdata"
+FROM
+    `rocpd_info_agent{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_info_queue` AS
+SELECT
+    "id",
+    "guid",
+    "nid",
+    "pid",
+    "name",
+    CAST(lz4_decompress("extdata") AS TEXT) AS "extdata"
+FROM
+    `rocpd_info_queue{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_info_stream` AS
+SELECT
+    "id",
+    "guid",
+    "nid",
+    "pid",
+    "name",
+    CAST(lz4_decompress("extdata") AS TEXT) AS "extdata"
+FROM
+    `rocpd_info_stream{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_info_pmc` AS
+SELECT
+    "id",
+    "guid",
+    "nid",
+    "pid",
+    "agent_id",
+    "target_arch",
+    "event_code",
+    "instance_id",
+    "name",
+    "symbol",
+    "description",
+    "long_description",
+    "component",
+    "units",
+    "value_type",
+    "block",
+    "expression",
+    "is_constant",
+    "is_derived",
+    CAST(lz4_decompress("extdata") AS TEXT) AS "extdata"
+FROM
+    `rocpd_info_pmc{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_info_code_object` AS
+SELECT
+    "id",
+    "guid",
+    "nid",
+    "pid",
+    "agent_id",
+    "uri",
+    "load_base",
+    "load_size",
+    "load_delta",
+    "storage_type",
+    CAST(lz4_decompress("extdata") AS TEXT) AS "extdata"
+FROM
+    `rocpd_info_code_object{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_info_kernel_symbol` AS
+SELECT
+    "id",
+    "guid",
+    "nid",
+    "pid",
+    "code_object_id",
+    "kernel_name",
+    "display_name",
+    "kernel_object",
+    "kernarg_segment_size",
+    "kernarg_segment_alignment",
+    "group_segment_size",
+    "private_segment_size",
+    "sgpr_count",
+    "arch_vgpr_count",
+    "accum_vgpr_count",
+    CAST(lz4_decompress("extdata") AS TEXT) AS "extdata"
+FROM
+    `rocpd_info_kernel_symbol{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_track` AS
+SELECT
+    "id",
+    "guid",
+    "nid",
+    "pid",
+    "tid",
+    "name_id",
+    CAST(lz4_decompress("extdata") AS TEXT) AS "extdata"
+FROM
+    `rocpd_track{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_event` AS
+SELECT
+    "id",
+    "guid",
+    "category_id",
+    "stack_id",
+    "parent_stack_id",
+    "correlation_id",
+    CAST(lz4_decompress("call_stack") AS TEXT) AS "call_stack",
+    CAST(lz4_decompress("line_info") AS TEXT) AS "line_info",
+    CAST(lz4_decompress("extdata") AS TEXT) AS "extdata"
+FROM
+    `rocpd_event{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_arg` AS
+SELECT
+    "id",
+    "guid",
+    "event_id",
+    "position",
+    "type",
+    "name",
+    "value",
+    CAST(lz4_decompress("extdata") AS TEXT) AS "extdata"
+FROM
+    `rocpd_arg{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_pmc_event` AS
+SELECT
+    "id",
+    "guid",
+    "event_id",
+    "pmc_id",
+    "value",
+    CAST(lz4_decompress("extdata") AS TEXT) AS "extdata"
+FROM
+    `rocpd_pmc_event{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_region` AS
+SELECT
+    "id",
+    "guid",
+    "nid",
+    "pid",
+    "tid",
+    "start",
+    "end",
+    "name_id",
+    "event_id",
+    CAST(lz4_decompress("extdata") AS TEXT) AS "extdata"
+FROM
+    `rocpd_region{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_sample` AS
+SELECT
+    "id",
+    "guid",
+    "track_id",
+    "timestamp",
+    "event_id",
+    CAST(lz4_decompress("extdata") AS TEXT) AS "extdata"
+FROM
+    `rocpd_sample{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_kernel_dispatch` AS
+SELECT
+    "id",
+    "guid",
+    "nid",
+    "pid",
+    "tid",
+    "agent_id",
+    "kernel_id",
+    "dispatch_id",
+    "queue_id",
+    "stream_id",
+    "start",
+    "end",
+    "private_segment_size",
+    "group_segment_size",
+    "workgroup_size_x",
+    "workgroup_size_y",
+    "workgroup_size_z",
+    "grid_size_x",
+    "grid_size_y",
+    "grid_size_z",
+    "region_name_id",
+    "event_id",
+    CAST(lz4_decompress("extdata") AS TEXT) AS "extdata"
+FROM
+    `rocpd_kernel_dispatch{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_memory_copy` AS
+SELECT
+    "id",
+    "guid",
+    "nid",
+    "pid",
+    "tid",
+    "start",
+    "end",
+    "name_id",
+    "dst_agent_id",
+    "dst_address",
+    "src_agent_id",
+    "src_address",
+    "size",
+    "queue_id",
+    "stream_id",
+    "region_name_id",
+    "event_id",
+    CAST(lz4_decompress("extdata") AS TEXT) AS "extdata"
+FROM
+    `rocpd_memory_copy{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_memory_allocate` AS
+SELECT
+    "id",
+    "guid",
+    "nid",
+    "pid",
+    "tid",
+    "agent_id",
+    "type",
+    "level",
+    "start",
+    "end",
+    "address",
+    "size",
+    "queue_id",
+    "stream_id",
+    "event_id",
+    CAST(lz4_decompress("extdata") AS TEXT) AS "extdata"
+FROM
+    `rocpd_memory_allocate{{uuid}}`;

--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk-rocpd/summary_views_lz4.sql
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk-rocpd/summary_views_lz4.sql
@@ -1,0 +1,153 @@
+--
+-- Useful summary views
+--
+--
+-- Sorted list of kernels which consume the most overall time
+CREATE VIEW IF NOT EXISTS
+    `top_kernels` AS
+SELECT
+    S.display_name AS name,
+    COUNT(K.kernel_id) AS total_calls,
+    SUM(K.end - K.start) / 1000.0 AS total_duration,
+    (SUM(K.end - K.start) / COUNT(K.kernel_id)) / 1000.0 AS average,
+    SUM(K.end - K.start) * 100.0 / (
+        SELECT
+            SUM(A.end - A.start)
+        FROM
+            `rocpd_kernel_dispatch` A
+    ) AS percentage
+FROM
+    `rocpd_kernel_dispatch` K
+    INNER JOIN `rocpd_info_kernel_symbol` S ON S.id = K.kernel_id
+    AND S.guid = K.guid
+GROUP BY
+    name
+ORDER BY
+    total_duration DESC;
+
+--
+-- GPU utilization metrics including kernels and memory copy operations
+CREATE VIEW IF NOT EXISTS
+    `busy` AS
+SELECT
+    A.agent_id,
+    AG.type,
+    GpuTime,
+    WallTime,
+    GpuTime * 1.0 / WallTime AS Busy
+FROM
+    (
+        SELECT
+            agent_id,
+            guid,
+            SUM(END - start) AS GpuTime
+        FROM
+            (
+                SELECT
+                    agent_id,
+                    guid,
+                    END,
+                    start
+                FROM
+                    `rocpd_kernel_dispatch`
+                UNION ALL
+                SELECT
+                    dst_agent_id AS agent_id,
+                    guid,
+                    END,
+                    start
+                FROM
+                    `rocpd_memory_copy`
+            )
+        GROUP BY
+            agent_id,
+            guid
+    ) A
+    INNER JOIN (
+        SELECT
+            MAX(END) - MIN(start) AS WallTime
+        FROM
+            (
+                SELECT
+                    END,
+                    start
+                FROM
+                    `rocpd_kernel_dispatch`
+                UNION ALL
+                SELECT
+                    END,
+                    start
+                FROM
+                    `rocpd_memory_copy`
+            )
+    ) W ON 1 = 1
+    INNER JOIN `rocpd_info_agent` AG ON AG.id = A.agent_id
+    AND AG.guid = A.guid;
+
+--
+-- Overall performance summary including kernels and memory copy operations
+CREATE VIEW
+    `top` AS
+SELECT
+    name,
+    COUNT(*) AS total_calls,
+    SUM(duration) / 1000.0 AS total_duration,
+    (SUM(duration) / COUNT(*)) / 1000.0 AS average,
+    SUM(duration) * 100.0 / total_time AS percentage
+FROM
+    (
+        -- Kernel operations
+        SELECT
+            ks.display_name AS name,
+            (kd.end - kd.start) AS duration
+        FROM
+            `rocpd_kernel_dispatch` kd
+            INNER JOIN `rocpd_info_kernel_symbol` ks ON kd.kernel_id = ks.id
+            AND kd.guid = ks.guid
+        UNION ALL
+        -- Memory operations
+        SELECT
+            rs.string AS name,
+            (END - start) AS duration
+        FROM
+            `rocpd_memory_copy` mc
+            INNER JOIN `rocpd_string` rs ON rs.id = mc.name_id
+            AND rs.guid = mc.guid
+        UNION ALL
+        -- Regions
+        SELECT
+            rs.string AS name,
+            (END - start) AS duration
+        FROM
+            `rocpd_region` rr
+            INNER JOIN `rocpd_string` rs ON rs.id = rr.name_id
+            AND rs.guid = rr.guid
+    ) operations
+    CROSS JOIN (
+        SELECT
+            SUM(END - start) AS total_time
+        FROM
+            (
+                SELECT
+                    END,
+                    start
+                FROM
+                    `rocpd_kernel_dispatch`
+                UNION ALL
+                SELECT
+                    END,
+                    start
+                FROM
+                    `rocpd_memory_copy`
+                UNION ALL
+                SELECT
+                    END,
+                    start
+                FROM
+                    `rocpd_region`
+            )
+    ) TOTAL
+GROUP BY
+    name
+ORDER BY
+    total_duration DESC;

--- a/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/CMakeLists.txt
@@ -72,14 +72,36 @@ rocprofiler_add_integration_execute_test(
     COMMAND
         $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -d
         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data -o out2 --output-format rocpd
-        --runtime-trace --kernel-rename --pmc SQ_WAVES --
+        --no-rocpd-lz4 --runtime-trace --kernel-rename --pmc SQ_WAVES --
         $<TARGET_FILE:reproducible-dispatch-count> 500 2
     DEPENDS reproducible-dispatch-count
     TIMEOUT 120
     LABELS "integration-tests;rocpd"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
-    FIXTURES_SETUP rocprofv3-test-rocpd)
+    FIXTURES_SETUP rocprofv3-test-rocpd-no-lz4)
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-rocpd-lz4-schema
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/validate_lz4_schema.py
+            ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data/out_results.db --expect-lz4
+    DEPENDS rocprofiler-sdk::rocprofv3
+    TIMEOUT 45
+    LABELS "integration-tests;rocpd"
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
+    ENVIRONMENT "${rocprofv3-rocpd-env}"
+    FIXTURES_REQUIRED rocprofv3-test-rocpd)
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-rocpd-legacy-schema
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/validate_lz4_schema.py
+            ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data/out2_results.db --expect-legacy
+    DEPENDS rocprofiler-sdk::rocprofv3
+    TIMEOUT 45
+    LABELS "integration-tests;rocpd"
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
+    ENVIRONMENT "${rocprofv3-rocpd-env}"
+    FIXTURES_REQUIRED rocprofv3-test-rocpd-no-lz4)
 
 #########################################################################################
 #

--- a/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/validate_lz4_schema.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/validate_lz4_schema.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+###############################################################################
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+###############################################################################
+
+import argparse
+import sqlite3
+
+from rocpd import _lz4
+
+
+COMPRESSED_TABLES = (
+    "rocpd_event",
+    "rocpd_kernel_dispatch",
+    "rocpd_memory_copy",
+    "rocpd_memory_allocate",
+    "rocpd_info_code_object",
+    "rocpd_info_kernel_symbol",
+)
+
+
+def metadata(conn):
+    return dict(conn.execute("SELECT tag, value FROM rocpd_metadata").fetchall())
+
+
+def raw_table(conn, base):
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE ? ORDER BY name",
+        (f"{base}_%",),
+    ).fetchall()
+    if not rows:
+        raise AssertionError(f"raw table for {base} not found")
+    return rows[0][0]
+
+
+def first_nonempty_raw_table(conn):
+    for base in COMPRESSED_TABLES:
+        table = raw_table(conn, base)
+        count = conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+        if count > 0:
+            return base, table
+    raise AssertionError("no compressed raw table contained rows")
+
+
+def validate(db_path, expect_lz4):
+    conn = sqlite3.connect(db_path)
+    _lz4.register(conn)
+
+    meta = metadata(conn)
+    expected_version = "4" if expect_lz4 else "3"
+    if meta.get("schema_version") != expected_version:
+        raise AssertionError(
+            f"expected schema_version={expected_version}, got {meta.get('schema_version')}"
+        )
+
+    if expect_lz4:
+        if meta.get("compression") != "lz4-frame-v1":
+            raise AssertionError("missing lz4 compression metadata")
+    elif "compression" in meta:
+        raise AssertionError("legacy rocpd DB unexpectedly has compression metadata")
+
+    base, table = first_nonempty_raw_table(conn)
+    raw_type = conn.execute(f'SELECT typeof(extdata) FROM "{table}" LIMIT 1').fetchone()[0]
+    expected_type = "blob" if expect_lz4 else "text"
+    if raw_type != expected_type:
+        raise AssertionError(f"expected raw extdata typeof={expected_type}, got {raw_type}")
+
+    view_value = conn.execute(f"SELECT extdata FROM {base} LIMIT 1").fetchone()[0]
+    if expect_lz4 and not isinstance(view_value, str):
+        raise AssertionError(f"expected decompressed view extdata as str, got {type(view_value)}")
+    if not expect_lz4 and not isinstance(view_value, str):
+        raise AssertionError(f"expected legacy view extdata as str, got {type(view_value)}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("database")
+    parser.add_argument("--expect-lz4", action="store_true")
+    parser.add_argument("--expect-legacy", action="store_true")
+    args = parser.parse_args()
+
+    if args.expect_lz4 == args.expect_legacy:
+        raise ValueError("select exactly one of --expect-lz4 or --expect-legacy")
+
+    validate(args.database, args.expect_lz4)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- ***Adds LZ4 compression (default ON) for rocpd output. The `extdata`, `call_stack`, and `line_info` payloads are stored as LZ4-compressed BLOBs.***
- Registers a SQLite UDF `lz4_decompress` (`source/lib/output/sql/lz4_extension.cpp`) and ships a parallel set of LZ4-aware SQL views (`share/rocprofiler-sdk-rocpd/*_lz4.sql`) plus a Python helper (`source/lib/python/rocpd/_lz4.py`) so existing tooling keeps working transparently.
- Provides an opt-out: `rocprofv3 --no-rocpd-lz4` or `ROCPROF_ROCPD_LZ4=false` falls back to the existing schema v3 layout.
- Vendors `lz4` as a new git submodule under `projects/rocprofiler-sdk/external/lz4` and wires it into the build (`external/CMakeLists.txt`, `cmake/rocprofiler_options.cmake`).
- Updates the changelog and adds a how-to section in `docs/how-to/using-rocpd-output-format.rst`.

## Test plan

- [ ] New unit test compiles and passes: `source/lib/tests/common/lz4_extension.cpp`
- [ ] New rocprofv3 schema test passes: `tests/rocprofv3/rocpd/validate_lz4_schema.py`
- [ ] Run rocprofv3 end-to-end with default settings; confirm schema v4 and that bundled views decompress correctly
- [ ] Run rocprofv3 with `--no-rocpd-lz4` (and with `ROCPROF_ROCPD_LZ4=false`); confirm schema v3 fallback
- [ ] Full CI green on PR

Made with [Cursor](https://cursor.com)