### PR TITLE
clr+hip+rocr: POC for HIP graph conditional nodes via vendor AQL packets

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/hip_api_trace.hpp
+++ b/projects/clr/hipamd/include/hip/amd_detail/hip_api_trace.hpp
@@ -48,7 +48,7 @@
 #define HIP_API_TABLE_STEP_VERSION 0
 #define HIP_COMPILER_API_TABLE_STEP_VERSION 0
 #define HIP_TOOLS_API_TABLE_STEP_VERSION 1
-#define HIP_RUNTIME_API_TABLE_STEP_VERSION 27
+#define HIP_RUNTIME_API_TABLE_STEP_VERSION 28
 
 // HIP API interface
 // HIP compiler dispatch functions
@@ -292,6 +292,18 @@ typedef hipError_t (*t_hipGraphAddMemsetNode)(hipGraphNode_t* pGraphNode, hipGra
 typedef hipError_t (*t_hipGraphChildGraphNodeGetGraph)(hipGraphNode_t node, hipGraph_t* pGraph);
 typedef hipError_t (*t_hipGraphClone)(hipGraph_t* pGraphClone, hipGraph_t originalGraph);
 typedef hipError_t (*t_hipGraphCreate)(hipGraph_t* pGraph, unsigned int flags);
+typedef hipError_t (*t_hipGraphConditionalHandleCreate)(hipGraphConditionalHandle* pHandleOut,
+                                                       hipGraph_t hGraph,
+                                                       unsigned int defaultLaunchValue,
+                                                       unsigned int flags);
+typedef hipError_t (*t_hipGraphAddConditionalNode)(hipGraphNode_t* pGraphNode,
+                                                  hipGraph_t graph,
+                                                  const hipGraphNode_t* pDependencies,
+                                                  size_t numDependencies,
+                                                  hipGraphConditionalHandle handle,
+                                                  hipGraphConditionalType type,
+                                                  unsigned int numConditionalGraphs,
+                                                  hipGraph_t* phConditionalGraphs);
 typedef hipError_t (*t_hipGraphDebugDotPrint)(hipGraph_t graph, const char* path,
                                               unsigned int flags);
 typedef hipError_t (*t_hipGraphDestroy)(hipGraph_t graph);
@@ -1744,8 +1756,12 @@ struct HipDispatchTable {
   t_hipOccupancyMaxPotentialClusterSize hipOccupancyMaxPotentialClusterSize_fn;
   t_hipOccupancyMaxActiveClusters hipOccupancyMaxActiveClusters_fn;
 
-  // DO NOT EDIT ABOVE!
   // HIP_RUNTIME_API_TABLE_STEP_VERSION == 28
+  t_hipGraphConditionalHandleCreate hipGraphConditionalHandleCreate_fn;
+  t_hipGraphAddConditionalNode hipGraphAddConditionalNode_fn;
+
+  // DO NOT EDIT ABOVE!
+  // HIP_RUNTIME_API_TABLE_STEP_VERSION == 29
 
   // ******************************************************************************************* //
   //

--- a/projects/clr/hipamd/include/hip/amd_detail/hip_prof_str.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/hip_prof_str.h
@@ -485,7 +485,9 @@ enum hip_api_id_t {
   HIP_API_ID_hipMemPrefetchBatchAsync = 460,
   HIP_API_ID_hipOccupancyMaxActiveClusters = 461,
   HIP_API_ID_hipOccupancyMaxPotentialClusterSize = 462,
-  HIP_API_ID_LAST = 462,
+  HIP_API_ID_hipGraphConditionalHandleCreate = 463,
+  HIP_API_ID_hipGraphAddConditionalNode = 464,
+  HIP_API_ID_LAST = 464,
 
   HIP_API_ID_hipChooseDevice = HIP_API_ID_CONCAT(HIP_API_ID_,hipChooseDevice),
   HIP_API_ID_hipGetDeviceProperties = HIP_API_ID_CONCAT(HIP_API_ID_,hipGetDeviceProperties),
@@ -646,6 +648,7 @@ static inline const char* hip_api_name(const uint32_t id) {
     case HIP_API_ID_hipGetSymbolSize: return "hipGetSymbolSize";
     case HIP_API_ID_hipGraphAddBatchMemOpNode: return "hipGraphAddBatchMemOpNode";
     case HIP_API_ID_hipGraphAddChildGraphNode: return "hipGraphAddChildGraphNode";
+    case HIP_API_ID_hipGraphAddConditionalNode: return "hipGraphAddConditionalNode";
     case HIP_API_ID_hipGraphAddDependencies: return "hipGraphAddDependencies";
     case HIP_API_ID_hipGraphAddEmptyNode: return "hipGraphAddEmptyNode";
     case HIP_API_ID_hipGraphAddEventRecordNode: return "hipGraphAddEventRecordNode";
@@ -666,6 +669,7 @@ static inline const char* hip_api_name(const uint32_t id) {
     case HIP_API_ID_hipGraphBatchMemOpNodeSetParams: return "hipGraphBatchMemOpNodeSetParams";
     case HIP_API_ID_hipGraphChildGraphNodeGetGraph: return "hipGraphChildGraphNodeGetGraph";
     case HIP_API_ID_hipGraphClone: return "hipGraphClone";
+    case HIP_API_ID_hipGraphConditionalHandleCreate: return "hipGraphConditionalHandleCreate";
     case HIP_API_ID_hipGraphCreate: return "hipGraphCreate";
     case HIP_API_ID_hipGraphDebugDotPrint: return "hipGraphDebugDotPrint";
     case HIP_API_ID_hipGraphDestroy: return "hipGraphDestroy";
@@ -1102,6 +1106,7 @@ static inline uint32_t hipApiIdByName(const char* name) {
   if (strcmp("hipGetSymbolSize", name) == 0) return HIP_API_ID_hipGetSymbolSize;
   if (strcmp("hipGraphAddBatchMemOpNode", name) == 0) return HIP_API_ID_hipGraphAddBatchMemOpNode;
   if (strcmp("hipGraphAddChildGraphNode", name) == 0) return HIP_API_ID_hipGraphAddChildGraphNode;
+  if (strcmp("hipGraphAddConditionalNode", name) == 0) return HIP_API_ID_hipGraphAddConditionalNode;
   if (strcmp("hipGraphAddDependencies", name) == 0) return HIP_API_ID_hipGraphAddDependencies;
   if (strcmp("hipGraphAddEmptyNode", name) == 0) return HIP_API_ID_hipGraphAddEmptyNode;
   if (strcmp("hipGraphAddEventRecordNode", name) == 0) return HIP_API_ID_hipGraphAddEventRecordNode;
@@ -1122,6 +1127,7 @@ static inline uint32_t hipApiIdByName(const char* name) {
   if (strcmp("hipGraphBatchMemOpNodeSetParams", name) == 0) return HIP_API_ID_hipGraphBatchMemOpNodeSetParams;
   if (strcmp("hipGraphChildGraphNodeGetGraph", name) == 0) return HIP_API_ID_hipGraphChildGraphNodeGetGraph;
   if (strcmp("hipGraphClone", name) == 0) return HIP_API_ID_hipGraphClone;
+  if (strcmp("hipGraphConditionalHandleCreate", name) == 0) return HIP_API_ID_hipGraphConditionalHandleCreate;
   if (strcmp("hipGraphCreate", name) == 0) return HIP_API_ID_hipGraphCreate;
   if (strcmp("hipGraphDebugDotPrint", name) == 0) return HIP_API_ID_hipGraphDebugDotPrint;
   if (strcmp("hipGraphDestroy", name) == 0) return HIP_API_ID_hipGraphDestroy;
@@ -2059,6 +2065,19 @@ typedef struct hip_api_data_s {
       hipGraph_t childGraph;
     } hipGraphAddChildGraphNode;
     struct {
+      hipGraphNode_t* pGraphNode;
+      hipGraphNode_t pGraphNode__val;
+      hipGraph_t graph;
+      const hipGraphNode_t* pDependencies;
+      hipGraphNode_t pDependencies__val;
+      size_t numDependencies;
+      hipGraphConditionalHandle handle;
+      hipGraphConditionalType type;
+      unsigned int numConditionalGraphs;
+      hipGraph_t* phConditionalGraphs;
+      hipGraph_t phConditionalGraphs__val;
+    } hipGraphAddConditionalNode;
+    struct {
       hipGraph_t graph;
       const hipGraphNode_t* from;
       hipGraphNode_t from__val;
@@ -2239,6 +2258,13 @@ typedef struct hip_api_data_s {
       hipGraph_t pGraphClone__val;
       hipGraph_t originalGraph;
     } hipGraphClone;
+    struct {
+      hipGraphConditionalHandle* pHandleOut;
+      hipGraphConditionalHandle pHandleOut__val;
+      hipGraph_t hGraph;
+      unsigned int defaultLaunchValue;
+      unsigned int flags;
+    } hipGraphConditionalHandleCreate;
     struct {
       hipGraph_t* pGraph;
       hipGraph_t pGraph__val;
@@ -4819,6 +4845,17 @@ typedef struct hip_api_data_s {
   cb_data.args.hipGraphAddChildGraphNode.numDependencies = (size_t)numDependencies; \
   cb_data.args.hipGraphAddChildGraphNode.childGraph = (hipGraph_t)childGraph; \
 };
+// hipGraphAddConditionalNode[('hipGraphNode_t*', 'pGraphNode'), ('hipGraph_t', 'graph'), ('const hipGraphNode_t*', 'pDependencies'), ('size_t', 'numDependencies'), ('hipGraphConditionalHandle', 'handle'), ('hipGraphConditionalType', 'type'), ('unsigned int', 'numConditionalGraphs'), ('hipGraph_t*', 'phConditionalGraphs')]
+#define INIT_hipGraphAddConditionalNode_CB_ARGS_DATA(cb_data) { \
+  cb_data.args.hipGraphAddConditionalNode.pGraphNode = (hipGraphNode_t*)pGraphNode; \
+  cb_data.args.hipGraphAddConditionalNode.graph = (hipGraph_t)graph; \
+  cb_data.args.hipGraphAddConditionalNode.pDependencies = (const hipGraphNode_t*)pDependencies; \
+  cb_data.args.hipGraphAddConditionalNode.numDependencies = (size_t)numDependencies; \
+  cb_data.args.hipGraphAddConditionalNode.handle = (hipGraphConditionalHandle)handle; \
+  cb_data.args.hipGraphAddConditionalNode.type = (hipGraphConditionalType)type; \
+  cb_data.args.hipGraphAddConditionalNode.numConditionalGraphs = (unsigned int)numConditionalGraphs; \
+  cb_data.args.hipGraphAddConditionalNode.phConditionalGraphs = (hipGraph_t*)phConditionalGraphs; \
+};
 // hipGraphAddDependencies[('hipGraph_t', 'graph'), ('const hipGraphNode_t*', 'from'), ('const hipGraphNode_t*', 'to'), ('size_t', 'numDependencies')]
 #define INIT_hipGraphAddDependencies_CB_ARGS_DATA(cb_data) { \
   cb_data.args.hipGraphAddDependencies.graph = (hipGraph_t)graph; \
@@ -4975,6 +5012,13 @@ typedef struct hip_api_data_s {
 #define INIT_hipGraphClone_CB_ARGS_DATA(cb_data) { \
   cb_data.args.hipGraphClone.pGraphClone = (hipGraph_t*)pGraphClone; \
   cb_data.args.hipGraphClone.originalGraph = (hipGraph_t)originalGraph; \
+};
+// hipGraphConditionalHandleCreate[('hipGraphConditionalHandle*', 'pHandleOut'), ('hipGraph_t', 'hGraph'), ('unsigned int', 'defaultLaunchValue'), ('unsigned int', 'flags')]
+#define INIT_hipGraphConditionalHandleCreate_CB_ARGS_DATA(cb_data) { \
+  cb_data.args.hipGraphConditionalHandleCreate.pHandleOut = (hipGraphConditionalHandle*)pHandleOut; \
+  cb_data.args.hipGraphConditionalHandleCreate.hGraph = (hipGraph_t)hGraph; \
+  cb_data.args.hipGraphConditionalHandleCreate.defaultLaunchValue = (unsigned int)defaultLaunchValue; \
+  cb_data.args.hipGraphConditionalHandleCreate.flags = (unsigned int)flags; \
 };
 // hipGraphCreate[('hipGraph_t*', 'pGraph'), ('unsigned int', 'flags')]
 #define INIT_hipGraphCreate_CB_ARGS_DATA(cb_data) { \
@@ -7464,6 +7508,12 @@ static inline void hipApiArgsInit(hip_api_id_t id, hip_api_data_t* data) {
       if (data->args.hipGraphAddChildGraphNode.pGraphNode) data->args.hipGraphAddChildGraphNode.pGraphNode__val = *(data->args.hipGraphAddChildGraphNode.pGraphNode);
       if (data->args.hipGraphAddChildGraphNode.pDependencies) data->args.hipGraphAddChildGraphNode.pDependencies__val = *(data->args.hipGraphAddChildGraphNode.pDependencies);
       break;
+// hipGraphAddConditionalNode[('hipGraphNode_t*', 'pGraphNode'), ('hipGraph_t', 'graph'), ('const hipGraphNode_t*', 'pDependencies'), ('size_t', 'numDependencies'), ('hipGraphConditionalHandle', 'handle'), ('hipGraphConditionalType', 'type'), ('unsigned int', 'numConditionalGraphs'), ('hipGraph_t*', 'phConditionalGraphs')]
+    case HIP_API_ID_hipGraphAddConditionalNode:
+      if (data->args.hipGraphAddConditionalNode.pGraphNode) data->args.hipGraphAddConditionalNode.pGraphNode__val = *(data->args.hipGraphAddConditionalNode.pGraphNode);
+      if (data->args.hipGraphAddConditionalNode.pDependencies) data->args.hipGraphAddConditionalNode.pDependencies__val = *(data->args.hipGraphAddConditionalNode.pDependencies);
+      if (data->args.hipGraphAddConditionalNode.phConditionalGraphs) data->args.hipGraphAddConditionalNode.phConditionalGraphs__val = *(data->args.hipGraphAddConditionalNode.phConditionalGraphs);
+      break;
 // hipGraphAddDependencies[('hipGraph_t', 'graph'), ('const hipGraphNode_t*', 'from'), ('const hipGraphNode_t*', 'to'), ('size_t', 'numDependencies')]
     case HIP_API_ID_hipGraphAddDependencies:
       if (data->args.hipGraphAddDependencies.from) data->args.hipGraphAddDependencies.from__val = *(data->args.hipGraphAddDependencies.from);
@@ -7567,6 +7617,10 @@ static inline void hipApiArgsInit(hip_api_id_t id, hip_api_data_t* data) {
 // hipGraphClone[('hipGraph_t*', 'pGraphClone'), ('hipGraph_t', 'originalGraph')]
     case HIP_API_ID_hipGraphClone:
       if (data->args.hipGraphClone.pGraphClone) data->args.hipGraphClone.pGraphClone__val = *(data->args.hipGraphClone.pGraphClone);
+      break;
+// hipGraphConditionalHandleCreate[('hipGraphConditionalHandle*', 'pHandleOut'), ('hipGraph_t', 'hGraph'), ('unsigned int', 'defaultLaunchValue'), ('unsigned int', 'flags')]
+    case HIP_API_ID_hipGraphConditionalHandleCreate:
+      if (data->args.hipGraphConditionalHandleCreate.pHandleOut) data->args.hipGraphConditionalHandleCreate.pHandleOut__val = *(data->args.hipGraphConditionalHandleCreate.pHandleOut);
       break;
 // hipGraphCreate[('hipGraph_t*', 'pGraph'), ('unsigned int', 'flags')]
     case HIP_API_ID_hipGraphCreate:
@@ -9659,6 +9713,21 @@ static inline const char* hipApiString(hip_api_id_t id, const hip_api_data_t* da
       oss << ", childGraph="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddChildGraphNode.childGraph);
       oss << ")";
     break;
+    case HIP_API_ID_hipGraphAddConditionalNode:
+      oss << "hipGraphAddConditionalNode(";
+      if (data->args.hipGraphAddConditionalNode.pGraphNode == NULL) oss << "pGraphNode=NULL";
+      else { oss << "pGraphNode="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddConditionalNode.pGraphNode__val); }
+      oss << ", graph="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddConditionalNode.graph);
+      if (data->args.hipGraphAddConditionalNode.pDependencies == NULL) oss << ", pDependencies=NULL";
+      else { oss << ", pDependencies="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddConditionalNode.pDependencies__val); }
+      oss << ", numDependencies="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddConditionalNode.numDependencies);
+      oss << ", handle="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddConditionalNode.handle);
+      oss << ", type="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddConditionalNode.type);
+      oss << ", numConditionalGraphs="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddConditionalNode.numConditionalGraphs);
+      if (data->args.hipGraphAddConditionalNode.phConditionalGraphs == NULL) oss << ", phConditionalGraphs=NULL";
+      else { oss << ", phConditionalGraphs="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddConditionalNode.phConditionalGraphs__val); }
+      oss << ")";
+    break;
     case HIP_API_ID_hipGraphAddDependencies:
       oss << "hipGraphAddDependencies(";
       oss << "graph="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddDependencies.graph);
@@ -9878,6 +9947,15 @@ static inline const char* hipApiString(hip_api_id_t id, const hip_api_data_t* da
       if (data->args.hipGraphClone.pGraphClone == NULL) oss << "pGraphClone=NULL";
       else { oss << "pGraphClone="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphClone.pGraphClone__val); }
       oss << ", originalGraph="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphClone.originalGraph);
+      oss << ")";
+    break;
+    case HIP_API_ID_hipGraphConditionalHandleCreate:
+      oss << "hipGraphConditionalHandleCreate(";
+      if (data->args.hipGraphConditionalHandleCreate.pHandleOut == NULL) oss << "pHandleOut=NULL";
+      else { oss << "pHandleOut="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphConditionalHandleCreate.pHandleOut__val); }
+      oss << ", hGraph="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphConditionalHandleCreate.hGraph);
+      oss << ", defaultLaunchValue="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphConditionalHandleCreate.defaultLaunchValue);
+      oss << ", flags="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphConditionalHandleCreate.flags);
       oss << ")";
     break;
     case HIP_API_ID_hipGraphCreate:

--- a/projects/clr/hipamd/src/hip_api_trace.cpp
+++ b/projects/clr/hipamd/src/hip_api_trace.cpp
@@ -237,6 +237,18 @@ hipError_t hipGraphAddNode(hipGraphNode_t* pGraphNode, hipGraph_t graph,
 hipError_t hipGraphChildGraphNodeGetGraph(hipGraphNode_t node, hipGraph_t* pGraph);
 hipError_t hipGraphClone(hipGraph_t* pGraphClone, hipGraph_t originalGraph);
 hipError_t hipGraphCreate(hipGraph_t* pGraph, unsigned int flags);
+hipError_t hipGraphConditionalHandleCreate(hipGraphConditionalHandle* pHandleOut,
+                                           hipGraph_t hGraph,
+                                           unsigned int defaultLaunchValue,
+                                           unsigned int flags);
+hipError_t hipGraphAddConditionalNode(hipGraphNode_t* pGraphNode,
+                                      hipGraph_t graph,
+                                      const hipGraphNode_t* pDependencies,
+                                      size_t numDependencies,
+                                      hipGraphConditionalHandle handle,
+                                      hipGraphConditionalType type,
+                                      unsigned int numConditionalGraphs,
+                                      hipGraph_t* phConditionalGraphs);
 hipError_t hipGraphDebugDotPrint(hipGraph_t graph, const char* path, unsigned int flags);
 hipError_t hipGraphDestroy(hipGraph_t graph);
 hipError_t hipGraphDestroyNode(hipGraphNode_t node);
@@ -1053,6 +1065,8 @@ void UpdateDispatchTable(HipDispatchTable* ptrDispatchTable) {
   ptrDispatchTable->hipGraphChildGraphNodeGetGraph_fn = hip::hipGraphChildGraphNodeGetGraph;
   ptrDispatchTable->hipGraphClone_fn = hip::hipGraphClone;
   ptrDispatchTable->hipGraphCreate_fn = hip::hipGraphCreate;
+  ptrDispatchTable->hipGraphConditionalHandleCreate_fn = hip::hipGraphConditionalHandleCreate;
+  ptrDispatchTable->hipGraphAddConditionalNode_fn = hip::hipGraphAddConditionalNode;
   ptrDispatchTable->hipGraphDebugDotPrint_fn = hip::hipGraphDebugDotPrint;
   ptrDispatchTable->hipGraphDestroy_fn = hip::hipGraphDestroy;
   ptrDispatchTable->hipGraphDestroyNode_fn = hip::hipGraphDestroyNode;
@@ -2157,6 +2171,9 @@ HIP_ENFORCE_ABI(HipDispatchTable, hipMemPrefetchBatchAsync_fn, 517);
 // HIP_RUNTIME_API_TABLE_STEP_VERSION == 27
 HIP_ENFORCE_ABI(HipDispatchTable, hipOccupancyMaxPotentialClusterSize_fn, 518);
 HIP_ENFORCE_ABI(HipDispatchTable, hipOccupancyMaxActiveClusters_fn, 519);
+// HIP_RUNTIME_API_TABLE_STEP_VERSION == 28
+HIP_ENFORCE_ABI(HipDispatchTable, hipGraphConditionalHandleCreate_fn, 520);
+HIP_ENFORCE_ABI(HipDispatchTable, hipGraphAddConditionalNode_fn, 521);
 
 // if HIP_ENFORCE_ABI entries are added for each new function pointer in the table, the number below
 // will be +1 of the number in the last HIP_ENFORCE_ABI line. E.g.:
@@ -2164,9 +2181,9 @@ HIP_ENFORCE_ABI(HipDispatchTable, hipOccupancyMaxActiveClusters_fn, 519);
 //  HIP_ENFORCE_ABI(<table>, <functor>, 8)
 //
 //  HIP_ENFORCE_ABI_VERSIONING(<table>, 9) <- 8 + 1 = 9
-HIP_ENFORCE_ABI_VERSIONING(HipDispatchTable, 520)
+HIP_ENFORCE_ABI_VERSIONING(HipDispatchTable, 522)
 
-static_assert(HIP_RUNTIME_API_TABLE_MAJOR_VERSION == 0 && HIP_RUNTIME_API_TABLE_STEP_VERSION == 27,
+static_assert(HIP_RUNTIME_API_TABLE_MAJOR_VERSION == 0 && HIP_RUNTIME_API_TABLE_STEP_VERSION == 28,
               "If you get this error, add new HIP_ENFORCE_ABI(...) code for the new function "
               "pointers and then update this check so it is true");
 #endif

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -11,6 +11,9 @@
 #include "hip_platform.hpp"
 #include "hip_event.hpp"
 #include "hip_mempool_impl.hpp"
+#include "device/devsignal.hpp"
+#include <hsa/amd_hsa_signal.h>
+#include <cstddef>
 
 namespace hip {
 
@@ -1299,6 +1302,135 @@ hipError_t hipGraphCreate(hipGraph_t* pGraph, unsigned int flags) {
     HIP_RETURN(hipErrorInvalidValue);
   }
   *pGraph = reinterpret_cast<hipGraph_t>(new hip::Graph(hip::getCurrentDevice()));
+  HIP_RETURN(hipSuccess);
+}
+
+// M1: conditional graph handle plumbing only (Option C).
+// Allocates a real device signal whose backing `amd_signal_t::value` cell is
+// exposed to user code via `pHandleOut->device_ptr = signal_handle + 8`. A
+// device kernel can then update the cell with a single store via
+// `hipGraphSetConditional`. In M2 this same cell drives CP-evaluated
+// conditional jump / loop_back packets.
+//
+// The `+8` shortcut is locked in by a static_assert so a future ROCR layout
+// change fails the build loudly instead of silently corrupting an unrelated
+// field of `amd_signal_t`.
+hipError_t hipGraphConditionalHandleCreate(hipGraphConditionalHandle* pHandleOut,
+                                           hipGraph_t hGraph,
+                                           unsigned int defaultLaunchValue,
+                                           unsigned int flags) {
+  HIP_INIT_API(hipGraphConditionalHandleCreate, pHandleOut, hGraph, defaultLaunchValue, flags);
+  static_assert(offsetof(amd_signal_t, value) == 8,
+                "Option C: hipGraphConditionalHandle::device_ptr = signal_handle + 8 "
+                "assumes amd_signal_t::value lives at offset 8");
+  if (pHandleOut == nullptr || flags != 0) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+  hip::Graph* g = reinterpret_cast<hip::Graph*>(hGraph);
+  if (!hip::Graph::isGraphValid(g)) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+  hip::Device* hipDev = hip::getCurrentDevice();
+  if (hipDev == nullptr || hipDev->devices().empty()) {
+    HIP_RETURN(hipErrorInvalidDevice);
+  }
+  amd::Device* dev = hipDev->devices()[0];
+  amd::device::Signal* sig = dev->createSignal();
+  if (sig == nullptr) {
+    HIP_RETURN(hipErrorOutOfMemory);
+  }
+  if (!sig->Init(*dev, static_cast<uint64_t>(defaultLaunchValue),
+                 amd::device::Signal::WaitState::Active)) {
+    delete sig;
+    HIP_RETURN(hipErrorOutOfMemory);
+  }
+  uint64_t signal_handle = reinterpret_cast<uint64_t>(sig->getHandle());
+  pHandleOut->signal_handle = signal_handle;
+  pHandleOut->device_ptr    = signal_handle + offsetof(amd_signal_t, value);
+  pHandleOut->default_value = defaultLaunchValue;
+  // TODO(M2): register `sig` with the graph so it is destroyed in
+  // hipGraphDestroy. For M1 the smoke test is short-lived and a one-off leak
+  // here is acceptable; lifetime work is tracked under m2_lifetime in the plan.
+  HIP_RETURN(hipSuccess);
+}
+
+// M2: conditional graph node creation.  Validates the requested conditional
+// shape, allocates the body graph(s) the caller will populate, constructs a
+// hip::GraphConditionalNode owning those bodies, and inserts it into the
+// parent graph with the standard dependency wiring.
+//
+// The runtime does not capture body packets here; that happens in
+// GraphExec::Init / IB build under m2_clr_ib_build.  The host-visible
+// hipGraph_t handles written into phConditionalGraphs are owned by the
+// GraphConditionalNode (and therefore by the parent graph).
+hipError_t hipGraphAddConditionalNode(hipGraphNode_t* pGraphNode,
+                                      hipGraph_t graph,
+                                      const hipGraphNode_t* pDependencies,
+                                      size_t numDependencies,
+                                      hipGraphConditionalHandle handle,
+                                      hipGraphConditionalType type,
+                                      unsigned int numConditionalGraphs,
+                                      hipGraph_t* phConditionalGraphs) {
+  HIP_INIT_API(hipGraphAddConditionalNode, pGraphNode, graph, pDependencies, numDependencies,
+               type, numConditionalGraphs, phConditionalGraphs);
+  if (pGraphNode == nullptr || graph == nullptr || phConditionalGraphs == nullptr ||
+      numConditionalGraphs == 0 || (numDependencies > 0 && pDependencies == nullptr)) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+  if (handle.signal_handle == 0 || handle.device_ptr == 0) {
+    // Caller must have populated the handle via hipGraphConditionalHandleCreate.
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+  hip::Graph* g = reinterpret_cast<hip::Graph*>(graph);
+  if (!hip::Graph::isGraphValid(g)) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+  // Validate body graph count vs. conditional type:
+  //  - WHILE                : exactly 1 body
+  //  - IF (with optional ELSE) : 1 or 2 bodies (laid out [else][if] in M2)
+  //  - SWITCH               : not yet supported
+  switch (type) {
+    case hipGraphCondTypeWhile:
+      if (numConditionalGraphs != 1) {
+        HIP_RETURN(hipErrorInvalidValue);
+      }
+      break;
+    case hipGraphCondTypeIf:
+      if (numConditionalGraphs != 1 && numConditionalGraphs != 2) {
+        HIP_RETURN(hipErrorInvalidValue);
+      }
+      break;
+    case hipGraphCondTypeSwitch:
+      HIP_RETURN(hipErrorNotSupported);
+    default:
+      HIP_RETURN(hipErrorInvalidValue);
+  }
+  hip::Device* hipDev = hip::getCurrentDevice();
+  if (hipDev == nullptr) {
+    HIP_RETURN(hipErrorInvalidDevice);
+  }
+  std::vector<hip::Graph*> bodies;
+  bodies.reserve(numConditionalGraphs);
+  for (unsigned int i = 0; i < numConditionalGraphs; ++i) {
+    hip::Graph* body = new hip::Graph(hipDev);
+    bodies.push_back(body);
+    phConditionalGraphs[i] = reinterpret_cast<hipGraph_t>(body);
+  }
+  hip::GraphNode* node = new hip::GraphConditionalNode(handle, type, std::move(bodies));
+  hipError_t status = ihipGraphAddNode(node, g,
+                                       reinterpret_cast<hip::GraphNode* const*>(pDependencies),
+                                       numDependencies, false);
+  if (status != hipSuccess) {
+    // ihipGraphAddNode does not take ownership on failure; reclaim the node
+    // (and via the destructor, the body graphs) so phConditionalGraphs entries
+    // are not left dangling.
+    delete node;
+    for (unsigned int i = 0; i < numConditionalGraphs; ++i) {
+      phConditionalGraphs[i] = nullptr;
+    }
+    HIP_RETURN(status);
+  }
+  *pGraphNode = reinterpret_cast<hipGraphNode_t>(node);
   HIP_RETURN(hipSuccess);
 }
 

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -6,6 +6,25 @@
 
 #include "hip_graph_internal.hpp"
 
+// The CLR build pins the in-tree ROCr headers via absolute paths so the new
+// vendor packet types (HSA_AMD_PACKET_TYPE_DISPATCH_IB_COND_JUMP,
+// HSA_AMD_PACKET_TYPE_AQL_LOOP_BACK, ...) resolve to the freshly modified
+// install copy.  /opt/rocm/include/hsa/hsa_ext_amd.h on this system is the
+// older release header and does not yet declare these vendor packet types.
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/hsa.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/hsa_ext_amd.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/amd_hsa_signal.h"
+
+#include <cstring>
+
+#include "device/device.hpp"
+// rocdevice.hpp must be the entry point that drags in rocvirtual.hpp; the
+// reverse order trips a circular-include / forward-declaration order issue
+// with amd::roc::Timestamp.  rocdevice.hpp's include of rocvirtual.hpp at
+// rocdevice.hpp:23 fully defines Timestamp before rocdevice.hpp uses it.
+#include "device/rocm/rocdevice.hpp"
+#include "device/rocm/rocvirtual.hpp"
+
 #define CASE_STRING(X, C)                                                                          \
   case X:                                                                                          \
     case_string = #C;                                                                              \
@@ -1457,6 +1476,26 @@ hipError_t GraphExec::CaptureAQLPackets() {
     return status;
   }
 
+  // Build IB buffers for any conditional nodes in the parent graph.
+  // BuildIB walks each body Graph, captures its kernel-dispatch packets,
+  // and assembles them (plus a vendor LOOP_BACK for WHILE) into a single
+  // contiguous IB.  Done here so the kernArgManager_ pool is already
+  // available for body-kernel kernarg allocation.  Conditional nodes
+  // remain non-captureable so the segment scheduler dispatches their
+  // CondJumpCommand via the legacy CreateCommand + EnqueueCommands path.
+  for (auto* node : topoOrder_) {
+    if (node != nullptr && node->GetType() == hipGraphNodeTypeConditional) {
+      auto* cond = static_cast<GraphConditionalNode*>(node);
+      hipError_t cstatus = cond->BuildIB(kernArgManager_, instantiateDeviceId_);
+      if (cstatus != hipSuccess) {
+        ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+                "[hipGraph][cond] BuildIB failed for conditional node "
+                "(status=%d)", static_cast<int>(cstatus));
+        return cstatus;
+      }
+    }
+  }
+
   kernArgManager_->ReadBackOrFlush();
   return hipSuccess;;
 }
@@ -2411,4 +2450,307 @@ void GraphKernelArgManager::ReadBackOrFlush() {
     }
   }
 }
+
+// ================================================================================================
+// GraphConditionalNode: lazy IB build + cond_jump command (M2 IB path).
+//
+// BuildIB() is called from GraphExec::CaptureAQLPackets() at instantiate time
+// after the parent's GraphKernelArgManager pool has been allocated.  It walks
+// each body Graph (POC: kernel-only, insertion-order) and captures the body's
+// AQL kernel-dispatch packets via the same machinery that the segmented
+// scheduler uses for regular nodes (GraphNode::CaptureAndFormPacket).  For
+// WHILE we append a vendor LOOP_BACK packet so the CP re-evaluates the cond
+// signal after every iteration.  The IB lives in coarse-grain VRAM on
+// largeBar systems (so the CP fetches without PCIe round-trips) and in
+// pinned host memory otherwise.
+//
+// CondJumpCommand::submit() runs at launch on the launch stream's
+// roc::VirtualGPU.  It resets the cond cell back to the handle's default
+// value (otherwise iteration N would observe value=0 left by iteration N-1)
+// and emits a single vendor cond_jump packet via the new
+// dispatchCondJumpPacket helper.  The CP follows the cond_jump into the IB,
+// runs the body, and (for WHILE) loops via LOOP_BACK until the kernel zeroes
+// the cond cell.
+
+GraphConditionalNode::~GraphConditionalNode() {
+  for (auto* body : bodies_) {
+    delete body;
+  }
+  bodies_.clear();
+  if (ib_addr_ != nullptr && ib_device_ != nullptr) {
+    ib_device_->hostFree(ib_addr_, ib_size_bytes_);
+    ib_addr_ = nullptr;
+    ib_size_bytes_ = 0;
+  }
+}
+
+hipError_t GraphConditionalNode::BuildIB(GraphKernelArgManager* kernArgMgr,
+                                        int devId) {
+  if (ib_built_) {
+    return hipSuccess;
+  }
+  if (kernArgMgr == nullptr) {
+    return hipErrorInvalidValue;
+  }
+  if (cond_type_ != hipGraphCondTypeIf && cond_type_ != hipGraphCondTypeWhile) {
+    return hipErrorNotSupported;
+  }
+  if (bodies_.empty()) {
+    return hipErrorInvalidValue;
+  }
+  if (cond_type_ == hipGraphCondTypeWhile && bodies_.size() != 1) {
+    return hipErrorInvalidValue;
+  }
+  if (cond_type_ == hipGraphCondTypeIf &&
+      bodies_.size() != 1 && bodies_.size() != 2) {
+    return hipErrorInvalidValue;
+  }
+  if (devId < 0 || static_cast<size_t>(devId) >= g_devices.size()) {
+    return hipErrorInvalidValue;
+  }
+
+  amd::Device* device = g_devices[devId]->devices()[0];
+
+  // GraphExec::GetKernelArgSizeForGraph only sums kernarg sizes for the
+  // parent graph's segments, not for kernels nested in conditional bodies.
+  // Bootstrap a kernarg pool sized for our bodies (plus a chunk of
+  // headroom) so the per-kernel CaptureAndFormPacket -> AllocKernArg path
+  // can always find a backing chunk on the first call.
+  size_t cond_kernarg_reserve = 0;
+  for (size_t bi = 0; bi < bodies_.size(); ++bi) {
+    Graph* body = bodies_[bi];
+    if (body == nullptr) {
+      return hipErrorInvalidValue;
+    }
+    for (auto* node : body->GetNodes()) {
+      if (node != nullptr && node->GetType() == hipGraphNodeTypeKernel) {
+        cond_kernarg_reserve += node->GetKerArgSize();
+      }
+    }
+  }
+  if (cond_kernarg_reserve > 0) {
+    const size_t pool_size = cond_kernarg_reserve + kKernArgChunkSize;
+    if (!kernArgMgr->AllocGraphKernargPool(pool_size, device)) {
+      ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+              "[hipGraph][cond] kernarg pool allocation of %zu bytes failed",
+              pool_size);
+      return hipErrorMemoryAllocation;
+    }
+  }
+
+  // Capture each body's kernel-dispatch packets into a local byte buffer.
+  // body_pkt_count[i] is the number of 64-byte packets emitted by body i.
+  std::vector<std::vector<uint8_t>> body_bytes(bodies_.size());
+  std::vector<size_t> body_pkt_count(bodies_.size(), 0);
+
+  for (size_t bi = 0; bi < bodies_.size(); ++bi) {
+    Graph* body = bodies_[bi];
+    if (body == nullptr) {
+      return hipErrorInvalidValue;
+    }
+    for (auto* node : body->GetNodes()) {
+      if (node == nullptr) {
+        continue;
+      }
+      if (node->GetType() != hipGraphNodeTypeKernel) {
+        ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+                "[hipGraph][cond] body graph contains non-kernel node "
+                "(type=%d); POC supports kernel-only bodies",
+                static_cast<int>(node->GetType()));
+        return hipErrorNotSupported;
+      }
+
+      std::vector<uint8_t*> nodePackets;
+      std::vector<const std::string*> nodeKernelNames;
+      hipError_t status = node->CaptureAndFormPacket(kernArgMgr, &nodePackets,
+                                                     &nodeKernelNames);
+      if (status != hipSuccess) {
+        ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+                "[hipGraph][cond] body kernel CaptureAndFormPacket failed "
+                "(status=%d)", static_cast<int>(status));
+        return status;
+      }
+      if (nodePackets.empty()) {
+        ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+                "[hipGraph][cond] body kernel produced 0 packets");
+        return hipErrorUnknown;
+      }
+      for (auto* pkt : nodePackets) {
+        // Zero the captured packet's completion_signal (offset 56) so the
+        // body kernel inside the IB does not try to signal a per-packet
+        // completion.  Aggregation (if any) is handled at the cond_jump
+        // entry packet level.
+        std::memset(pkt + 56, 0, 8);
+        body_bytes[bi].insert(body_bytes[bi].end(), pkt, pkt + 64);
+      }
+      body_pkt_count[bi] += nodePackets.size();
+    }
+  }
+
+  // Compute IB layout + cond_jump arguments per cond_type.
+  size_t total_pkts = 0;
+  size_t fall_pkts = 0;
+  size_t jump_off_pkts = 0;
+  size_t jump_pkts = 0;
+
+  if (cond_type_ == hipGraphCondTypeWhile) {
+    // Layout: [body | loop_back].  cond_jump runs body+loop_back if cond != 0;
+    // skips entirely if cond == 0 (handles 0-iteration WHILE).
+    total_pkts = body_pkt_count[0] + 1;  // +1 for trailing loop_back
+    fall_pkts = 0;
+    jump_off_pkts = 0;
+    jump_pkts = total_pkts;
+  } else {
+    if (bodies_.size() == 1) {
+      // IF (1 body).  Layout: [body].  Run body if cond != 0, skip otherwise.
+      total_pkts = body_pkt_count[0];
+      fall_pkts = 0;
+      jump_off_pkts = 0;
+      jump_pkts = body_pkt_count[0];
+    } else {
+      // IF / ELSE (2 bodies).  CUDA convention: body[0] = "if" (TRUE),
+      // body[1] = "else" (FALSE).  IB layout is [false_arm | true_arm], so
+      // jump_offset/fall point to body[1] = false_arm at the start.
+      total_pkts = body_pkt_count[0] + body_pkt_count[1];
+      fall_pkts = body_pkt_count[1];
+      jump_off_pkts = body_pkt_count[1];
+      jump_pkts = body_pkt_count[0];
+    }
+  }
+
+  if (total_pkts == 0) {
+    // Empty conditional with empty body and no loop_back -- nothing to
+    // dispatch.  Mark as built and let CondJumpCommand::submit() be a no-op.
+    ib_addr_ = nullptr;
+    ib_size_bytes_ = 0;
+    ib_size_pkts_ = 0;
+    fall_pkts_ = 0;
+    jump_off_pkts_ = 0;
+    jump_pkts_ = 0;
+    ib_built_ = true;
+    return hipSuccess;
+  }
+
+  // Allocate IB in device-accessible memory.  Mirror GraphKernelArgManager's
+  // allocation strategy: largeBar -> coarse-grain VRAM (executable kernarg
+  // pool flavor, GPU-local + host-writable on largeBar), else pinned host.
+  const size_t ib_bytes = total_pkts * 64;
+  void* ib = nullptr;
+  if (device->info().largeBar_) {
+    amd::Device::AllocationFlags flags = {};
+    flags.executable_ = true;
+    ib = device->deviceLocalAlloc(ib_bytes, flags);
+  } else {
+    ib = device->hostAlloc(ib_bytes, 64,
+                           amd::Device::MemorySegment::kKernArg);
+  }
+  if (ib == nullptr) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+            "[hipGraph][cond] IB allocation of %zu bytes failed", ib_bytes);
+    return hipErrorMemoryAllocation;
+  }
+
+  // Memcpy captured body packets, then (WHILE only) build + memcpy loop_back.
+  uint8_t* dst = static_cast<uint8_t*>(ib);
+  if (cond_type_ == hipGraphCondTypeWhile) {
+    if (!body_bytes[0].empty()) {
+      std::memcpy(dst, body_bytes[0].data(), body_bytes[0].size());
+      dst += body_bytes[0].size();
+    }
+    hsa_amd_aql_loop_back_t lb;
+    std::memset(&lb, 0, sizeof(lb));
+    constexpr uint16_t kVendorH = static_cast<uint16_t>(
+        HSA_PACKET_TYPE_VENDOR_SPECIFIC << HSA_PACKET_HEADER_TYPE);
+    constexpr uint16_t kBarrierH =
+        static_cast<uint16_t>(1 << HSA_PACKET_HEADER_BARRIER);
+    constexpr uint16_t kSysScopeH = static_cast<uint16_t>(
+        (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE) |
+        (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE));
+    lb.header.header = static_cast<uint16_t>(kVendorH | kBarrierH | kSysScopeH);
+    lb.header.AmdFormat = HSA_AMD_PACKET_TYPE_AQL_LOOP_BACK;
+    lb.condition_signal.handle = handle_.signal_handle;
+    lb.test_value = static_cast<hsa_signal_value_t>(handle_.default_value);
+    lb.cond_op = HSA_SIGNAL_CONDITION_NE;
+    lb.ib_size_packets = static_cast<uint32_t>(total_pkts);
+    lb.completion_signal.handle = 0;
+    std::memcpy(dst, &lb, sizeof(lb));
+    dst += sizeof(lb);
+  } else if (bodies_.size() == 1) {
+    if (!body_bytes[0].empty()) {
+      std::memcpy(dst, body_bytes[0].data(), body_bytes[0].size());
+      dst += body_bytes[0].size();
+    }
+  } else {
+    // IF / ELSE: memcpy false_arm (body[1]) first, then true_arm (body[0]).
+    if (!body_bytes[1].empty()) {
+      std::memcpy(dst, body_bytes[1].data(), body_bytes[1].size());
+      dst += body_bytes[1].size();
+    }
+    if (!body_bytes[0].empty()) {
+      std::memcpy(dst, body_bytes[0].data(), body_bytes[0].size());
+      dst += body_bytes[0].size();
+    }
+  }
+
+  ib_addr_ = ib;
+  ib_size_bytes_ = ib_bytes;
+  ib_size_pkts_ = total_pkts;
+  fall_pkts_ = static_cast<uint32_t>(fall_pkts);
+  jump_off_pkts_ = static_cast<uint32_t>(jump_off_pkts);
+  jump_pkts_ = static_cast<uint32_t>(jump_pkts);
+  ib_device_ = device;
+  ib_built_ = true;
+
+  ClPrint(amd::LOG_INFO, amd::LOG_CODE,
+          "[hipGraph][cond] BuildIB type=%d ib=%p bytes=%zu pkts=%zu "
+          "fall=%u jump_off=%u jump=%u",
+          static_cast<int>(cond_type_), ib_addr_, ib_size_bytes_,
+          ib_size_pkts_, fall_pkts_, jump_off_pkts_, jump_pkts_);
+  return hipSuccess;
+}
+
+GraphConditionalNode::CondJumpCommand::CondJumpCommand(
+    amd::HostQueue& queue, GraphConditionalNode& node)
+    : amd::Command(queue, CL_COMMAND_MARKER, EventWaitList{}, /*commandWaitBits=*/0,
+                   /*waitingEvent=*/nullptr),
+      node_(node) {}
+
+void GraphConditionalNode::CondJumpCommand::submit(device::VirtualDevice& device) {
+  if (!node_.IsIbBuilt()) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+            "[hipGraph][cond] CondJumpCommand::submit() before BuildIB()");
+    setStatus(CL_INVALID_OPERATION);
+    return;
+  }
+
+  if (node_.GetIbAddr() == nullptr || node_.ib_size_pkts_ == 0) {
+    // Empty conditional: nothing to dispatch.  Treat as a no-op marker.
+    setStatus(CL_COMPLETE);
+    return;
+  }
+
+  hsa_signal_t cond_sig{};
+  cond_sig.handle = node_.GetHandle().signal_handle;
+  hsa_signal_value_t default_value = static_cast<hsa_signal_value_t>(
+      node_.GetHandle().default_value);
+
+  // Reset the cond cell to its default value before re-entering the
+  // conditional.  Required so iteration N+1 doesn't observe the value left
+  // by iteration N inside the kernel.  Relaxed is fine because the cond_jump
+  // packet itself carries SYSTEM acquire/release fences.
+  hsa_signal_store_relaxed(cond_sig, default_value);
+
+  auto& vgpu = static_cast<amd::roc::VirtualGPU&>(device);
+  vgpu.dispatchCondJumpPacket(
+      cond_sig,
+      default_value,
+      HSA_SIGNAL_CONDITION_NE,
+      reinterpret_cast<uint64_t>(node_.GetIbAddr()),
+      node_.GetFallPkts(),
+      node_.GetJumpOffPkts(),
+      node_.GetJumpPkts());
+
+  setStatus(CL_COMPLETE);
+}
+
 }  // namespace hip

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -2772,6 +2772,125 @@ class GraphEmptyNode : public GraphNode {
 };
 
 // ================================================================================================
+//
+// Conditional graph node (HIP graph IF / WHILE).  Owns 1 (WHILE / IF-no-else)
+// or 2 (IF/ELSE) empty body graphs that the caller populates after node
+// creation.  The runtime reads the bodies at GraphExec::Init time to build
+// the per-conditional indirect buffer (see m2_clr_ib_build), and at
+// GraphExec::Run time emits a single vendor cond_jump AQL packet on the
+// launch stream's HW queue (see m2_clr_packet_emit + m2_clr_launch_reset).
+//
+// The CreateCommand override currently emits an amd::Marker as a stand-in so
+// segment scheduling and dependency edges work end-to-end while the IB / packet
+// emission path is still under construction.
+//
+// Lifetime: parent graph owns the GraphConditionalNode, which owns the body
+// hip::Graph objects; ~GraphConditionalNode() deletes the bodies.  The
+// underlying hsa_signal_t in the handle is owned by hipGraphConditionalHandle
+// and freed under m2_lifetime.
+class GraphConditionalNode : public GraphNode {
+ protected:
+  // Copy ctor: deep-clones the body graphs so the GraphExec returned by
+  // hipGraphInstantiate has its own independent body Graph hierarchy.  The
+  // hipGraphConditionalHandle (cond signal) and the conditional type are POD
+  // and shared by value.  IB metadata stays at its default-initialised state
+  // (ib_built_ == false) so the clone's first BuildIB() will materialise a
+  // fresh IB on the GraphExec's kernArgManager pool rather than aliasing the
+  // original's IB allocation.
+  GraphConditionalNode(const GraphConditionalNode& rhs)
+      : GraphNode(rhs),
+        handle_(rhs.handle_),
+        cond_type_(rhs.cond_type_) {
+    bodies_.reserve(rhs.bodies_.size());
+    for (auto* body : rhs.bodies_) {
+      auto* newBody = new Graph(body->Device(), body);
+      body->clone(newBody, /*cloneNodes=*/true);
+      bodies_.push_back(newBody);
+    }
+  }
+
+ public:
+  // Custom amd::Command emitted at graph launch.  submit() resets the cond
+  // signal to its default and rings out one vendor cond_jump AQL packet on
+  // the launch stream's HW queue.  Defined out-of-line in
+  // hip_graph_internal.cpp because submit() needs HSA + rocvirtual headers.
+  class CondJumpCommand : public amd::Command {
+   public:
+    CondJumpCommand(amd::HostQueue& queue, GraphConditionalNode& node);
+    void submit(device::VirtualDevice& device) final;
+
+   private:
+    GraphConditionalNode& node_;
+  };
+
+  GraphConditionalNode(hipGraphConditionalHandle handle,
+                       hipGraphConditionalType cond_type,
+                       std::vector<Graph*> bodies)
+      : GraphNode(hipGraphNodeTypeConditional, "solid", "diamond", "CONDITIONAL"),
+        handle_(handle),
+        cond_type_(cond_type),
+        bodies_(std::move(bodies)) {}
+
+  ~GraphConditionalNode() override;
+
+  GraphConditionalNode& operator=(const GraphConditionalNode&) = delete;
+
+  GraphNode* clone() const override { return new GraphConditionalNode(*this); }
+
+  hipError_t SetParams(GraphNode* node) override {
+    // No mutable parameters yet -- the handle and conditional type are fixed
+    // at node creation time.  Body graphs are mutated by the user via the
+    // hipGraph_t handles returned from hipGraphAddConditionalNode.
+    (void)node;
+    return hipSuccess;
+  }
+
+  // Walks each body Graph, captures kernel-dispatch packets via
+  // GraphNode::CaptureAndFormPacket(kernArgMgr), and assembles a contiguous
+  // IB in coarse-grain VRAM (or pinned host memory on non-largeBar systems).
+  // For WHILE, an hsa_amd_aql_loop_back_t is appended so the CP re-evaluates
+  // the cond signal at the tail of every iteration.  POC: bodies must contain
+  // only kernel nodes.  Idempotent across launches; first call wins.
+  hipError_t BuildIB(GraphKernelArgManager* kernArgMgr, int devId);
+
+  hipError_t CreateCommand(hip::Stream* stream) override {
+    hipError_t status = GraphNode::CreateCommand(stream);
+    if (status != hipSuccess) {
+      return status;
+    }
+    commands_.reserve(1);
+    commands_.emplace_back(new CondJumpCommand(*stream, *this));
+    return hipSuccess;
+  }
+
+  const hipGraphConditionalHandle& GetHandle() const { return handle_; }
+  hipGraphConditionalType GetCondType() const { return cond_type_; }
+  const std::vector<Graph*>& GetBodies() const { return bodies_; }
+
+  // Used by CondJumpCommand::submit().
+  void* GetIbAddr() const { return ib_addr_; }
+  uint32_t GetFallPkts() const { return fall_pkts_; }
+  uint32_t GetJumpOffPkts() const { return jump_off_pkts_; }
+  uint32_t GetJumpPkts() const { return jump_pkts_; }
+  bool IsIbBuilt() const { return ib_built_; }
+
+ private:
+  hipGraphConditionalHandle handle_;
+  hipGraphConditionalType cond_type_;
+  std::vector<Graph*> bodies_;  //!< Owned; deleted in destructor.
+
+  // IB metadata, populated by BuildIB() at instantiate time.
+  void* ib_addr_ = nullptr;        //!< Base of the IB in device-accessible memory.
+  size_t ib_size_bytes_ = 0;       //!< Allocation size for ib_addr_, used by hostFree.
+  size_t ib_size_pkts_ = 0;        //!< Total IB packets including loop_back (WHILE).
+  uint32_t fall_pkts_ = 0;         //!< cond_jump.fallthrough_ib_size_packets
+  uint32_t jump_off_pkts_ = 0;     //!< cond_jump.jump_offset_packets
+  uint32_t jump_pkts_ = 0;         //!< cond_jump.jump_ib_size_packets
+  amd::Device* ib_device_ = nullptr;  //!< Device that allocated ib_addr_.
+  bool ib_built_ = false;
+};
+
+// ================================================================================================
 class GraphMemAllocNode final : public GraphNode {
   hipMemAllocNodeParams node_params_;  // Node parameters for memory allocation
   amd::Memory* va_ = nullptr;          // Memory object, which holds a virtual address

--- a/projects/clr/hipamd/src/hip_hcc.map.in
+++ b/projects/clr/hipamd/src/hip_hcc.map.in
@@ -657,6 +657,8 @@ global:
     hipKernelSetAttribute;
     hipKernelGetFunction;
     hipMemPrefetchBatchAsync;
+    hipGraphConditionalHandleCreate;
+    hipGraphAddConditionalNode;
 local:
     *;
 } hip_7.1;

--- a/projects/clr/hipamd/src/hip_table_interface.cpp
+++ b/projects/clr/hipamd/src/hip_table_interface.cpp
@@ -902,6 +902,29 @@ hipError_t hipGraphCreate(hipGraph_t* pGraph, unsigned int flags) {
   return hip::GetHipDispatchTable()->hipGraphCreate_fn(pGraph, flags);
   CATCH;
 }
+hipError_t hipGraphConditionalHandleCreate(hipGraphConditionalHandle* pHandleOut,
+                                           hipGraph_t hGraph,
+                                           unsigned int defaultLaunchValue,
+                                           unsigned int flags) {
+  TRY;
+  return hip::GetHipDispatchTable()->hipGraphConditionalHandleCreate_fn(
+      pHandleOut, hGraph, defaultLaunchValue, flags);
+  CATCH;
+}
+hipError_t hipGraphAddConditionalNode(hipGraphNode_t* pGraphNode,
+                                      hipGraph_t graph,
+                                      const hipGraphNode_t* pDependencies,
+                                      size_t numDependencies,
+                                      hipGraphConditionalHandle handle,
+                                      hipGraphConditionalType type,
+                                      unsigned int numConditionalGraphs,
+                                      hipGraph_t* phConditionalGraphs) {
+  TRY;
+  return hip::GetHipDispatchTable()->hipGraphAddConditionalNode_fn(
+      pGraphNode, graph, pDependencies, numDependencies, handle, type,
+      numConditionalGraphs, phConditionalGraphs);
+  CATCH;
+}
 hipError_t hipGraphDebugDotPrint(hipGraph_t graph, const char* path, unsigned int flags) {
   TRY;
   return hip::GetHipDispatchTable()->hipGraphDebugDotPrint_fn(graph, path, flags);

--- a/projects/clr/rocclr/device/blitcl.cpp
+++ b/projects/clr/rocclr/device/blitcl.cpp
@@ -154,6 +154,15 @@ const char* BlitLinearSourceCode = BLIT_KERNELS(
       __amd_batchMemOp(params, count);
     });
 
+// Local workaround (DEV ENV ONLY): the system /opt/rocm device runtime
+// bitcode (opencl.bc) on this branch only ships __amd_streamOpsWrite and
+// __amd_streamOpsWait; __amd_streamOpsIncrement and __amd_streamOpsDecrement
+// are not yet provided.  To keep the develop CLR's BlitManager init from
+// failing on stale ROCm installs, the wrapper kernels below stub out the
+// missing extern calls (no-op).  Anyone exercising
+// hipExtStreamWriteValue{Increment,Decrement} on this build will get a no-op
+// instead of a runtime crash; revert this once the device runtime catches up
+// and the externs are available again.
 const char* HipExtraSourceCode = BLIT_KERNELS(
     __kernel void __amd_rocclr_streamOpsWrite(__global uint* ptrInt, __global ulong* ptrUlong,
                                               ulong value) {
@@ -162,12 +171,12 @@ const char* HipExtraSourceCode = BLIT_KERNELS(
 
     __kernel void __amd_rocclr_streamOpsIncrement(__global uint* ptrInt, __global ulong* ptrUlong,
                                                   ulong value) {
-      __amd_streamOpsIncrement(ptrInt, ptrUlong, value);
+      (void)ptrInt; (void)ptrUlong; (void)value;
     }
 
     __kernel void __amd_rocclr_streamOpsDecrement(__global uint* ptrInt, __global ulong* ptrUlong,
                                                   ulong value) {
-      __amd_streamOpsDecrement(ptrInt, ptrUlong, value);
+      (void)ptrInt; (void)ptrUlong; (void)value;
     }
 
     __kernel void __amd_rocclr_streamOpsWait(__global uint* ptrInt, __global ulong* ptrUlong,
@@ -190,12 +199,12 @@ const char* HipExtraSourceCodeNoGWS = BLIT_KERNELS(
 
     __kernel void __amd_rocclr_streamOpsIncrement(__global uint* ptrInt, __global ulong* ptrUlong,
                                                   ulong value) {
-      __amd_streamOpsIncrement(ptrInt, ptrUlong, value);
+      (void)ptrInt; (void)ptrUlong; (void)value;
     }
 
     __kernel void __amd_rocclr_streamOpsDecrement(__global uint* ptrInt, __global ulong* ptrUlong,
                                                   ulong value) {
-      __amd_streamOpsDecrement(ptrInt, ptrUlong, value);
+      (void)ptrInt; (void)ptrUlong; (void)value;
     }
 
     __kernel void __amd_rocclr_streamOpsWait(__global uint* ptrInt, __global ulong* ptrUlong,

--- a/projects/clr/rocclr/device/rocm/rocrctx.hpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.hpp
@@ -10,19 +10,19 @@
 #include "top.hpp"
 
 #if defined(ROCR_DYN_DLL) || defined(ROCR_STATIC_OPEN)
-#include "hsa.h"
-#include "hsa_ext_image.h"
-#include "hsa_ext_amd.h"
-#include "amd_hsa_signal.h"
-#include "hsa_ven_amd_loader.h"
-#include "hsa_ven_amd_aqlprofile.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/hsa.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/hsa_ext_image.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/hsa_ext_amd.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/amd_hsa_signal.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/hsa_ven_amd_loader.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/hsa_ven_amd_aqlprofile.h"
 #else
-#include "hsa/hsa.h"
-#include "hsa/hsa_ext_image.h"
-#include "hsa/hsa_ext_amd.h"
-#include "hsa/amd_hsa_signal.h"
-#include "hsa/hsa_ven_amd_loader.h"
-#include "hsa/hsa_ven_amd_aqlprofile.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/hsa.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/hsa_ext_image.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/hsa_ext_amd.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/amd_hsa_signal.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/hsa_ven_amd_loader.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/hsa_ven_amd_aqlprofile.h"
 #endif
 
 namespace amd {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1737,6 +1737,75 @@ void VirtualGPU::dispatchBarrierValuePacket(uint16_t packetHeader, bool resolveD
 }
 
 // ================================================================================================
+// HIP graph conditional node entry packet.  Mirrors dispatchBarrierValuePacket
+// but emits a vendor HSA_AMD_PACKET_TYPE_DISPATCH_IB_COND_JUMP instead.
+//
+// The CP is expected to:
+//   - read cond_signal.value (the cond cell at amd_signal_t +8)
+//   - compare it against test_value with cond_op
+//   - if TRUE, fetch jump_pkts packets from
+//       ib_base_addr + jump_offset_pkts * 64
+//   - if FALSE, fetch fallthrough_pkts packets from ib_base_addr
+//   - then resume from this queue
+//
+// barrier=1 + SYSTEM acquire/release on the header ensures any prior packet
+// (including a kernel that wrote the cond cell) has retired and its store is
+// visible to the CP before the cond load.
+void VirtualGPU::dispatchCondJumpPacket(hsa_signal_t cond_signal,
+                                        hsa_signal_value_t test_value,
+                                        hsa_signal_condition32_t cond_op,
+                                        uint64_t ib_base_addr,
+                                        uint32_t fallthrough_pkts,
+                                        uint32_t jump_offset_pkts,
+                                        uint32_t jump_pkts) {
+  const uint32_t queueSize = gpu_queue_->size;
+  const uint32_t queueMask = queueSize - 1;
+
+  // Header bits: VENDOR_SPECIFIC + barrier + SYSTEM acquire/release fences.
+  // Identical scope choice as barrier_value to make any prior write to the
+  // cond cell visible to the CP load.
+  constexpr uint16_t kVendorSpecificHBits =
+      (HSA_PACKET_TYPE_VENDOR_SPECIFIC << HSA_PACKET_HEADER_TYPE);
+  constexpr uint16_t kBarrierHBits = (1 << HSA_PACKET_HEADER_BARRIER);
+  constexpr uint16_t kSystemScopeHBits =
+      (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE) |
+      (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
+  const uint16_t header = kVendorSpecificHBits | kBarrierHBits | kSystemScopeHBits;
+  const uint16_t rest = HSA_AMD_PACKET_TYPE_DISPATCH_IB_COND_JUMP;
+
+  // Build the packet body on the stack first; the slot starts as INVALID and
+  // we publish the real header last via release-store.
+  hsa_amd_dispatch_indirect_buffer_conditional_jump_t pkt;
+  std::memset(&pkt, 0, sizeof(pkt));
+  pkt.condition_signal = cond_signal;
+  pkt.test_value = test_value;
+  pkt.cond_op = cond_op;
+  pkt.fallthrough_ib_size_packets = fallthrough_pkts;
+  pkt.ib_base_addr = ib_base_addr;
+  pkt.jump_offset_packets = jump_offset_pkts;
+  pkt.jump_ib_size_packets = jump_pkts;
+  pkt.completion_signal = hsa_signal_t{0};
+
+  setFenceDirty(true);
+
+  uint64_t index = Hsa::queue_add_write_index_screlease(gpu_queue_, 1);
+  while ((index - Hsa::queue_load_read_index_scacquire(gpu_queue_)) >= queueMask);
+
+  auto* aql_loc = &(reinterpret_cast<hsa_amd_dispatch_indirect_buffer_conditional_jump_t*>(
+      gpu_queue_->base_address))[index & queueMask];
+  *aql_loc = pkt;
+  packet_store_release(reinterpret_cast<uint32_t*>(aql_loc), header, rest);
+  Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, index);
+
+  ClPrint(amd::LOG_INFO, amd::LOG_AQL,
+          "[cond_jump] queue=%p index=%lu ib=0x%lx jump_off=%u jump_pkts=%u "
+          "fall_pkts=%u cond_sig=0x%lx test=%ld cond_op=%u",
+          gpu_queue_, index, ib_base_addr, jump_offset_pkts, jump_pkts,
+          fallthrough_pkts, cond_signal.handle, static_cast<long>(test_value),
+          cond_op);
+}
+
+// ================================================================================================
 void VirtualGPU::ResetQueueStates() {
   // Release all memory dependencies
   memoryDependency().clear();

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -615,6 +615,24 @@ class VirtualGPU : public device::VirtualDevice {
                                   hsa_signal_condition32_t cond = HSA_SIGNAL_CONDITION_EQ,
                                   bool skipTs = false,
                                   hsa_signal_t completionSignal = hsa_signal_t{0});
+
+ public:
+  //! Emit one vendor cond_jump (HSA_AMD_PACKET_TYPE_DISPATCH_IB_COND_JUMP) on
+  //! gpu_queue_ pointing at @a ib_base_addr.  The CP loads
+  //! @a cond_signal.value, evaluates it against @a test_value with @a cond_op,
+  //! and either runs @a fallthrough_pkts starting at ib_base_addr (FALSE) or
+  //! runs @a jump_pkts starting at ib_base_addr + jump_offset_pkts*64 (TRUE).
+  //! Used by HIP graph IF / WHILE conditional nodes; see
+  //! [hipamd/src/hip_graph_internal.hpp] GraphConditionalNode.
+  void dispatchCondJumpPacket(hsa_signal_t cond_signal,
+                              hsa_signal_value_t test_value,
+                              hsa_signal_condition32_t cond_op,
+                              uint64_t ib_base_addr,
+                              uint32_t fallthrough_pkts,
+                              uint32_t jump_offset_pkts,
+                              uint32_t jump_pkts);
+
+ private:
   void initializeDispatchPacket(hsa_kernel_dispatch_packet_t* packet, amd::NDRangeContainer& sizes);
 
   void resetKernArgPool() { managed_kernarg_buffer_.ResetPool(); }

--- a/projects/hip/include/hip/hip_runtime_api.h
+++ b/projects/hip/include/hip/hip_runtime_api.h
@@ -1502,8 +1502,44 @@ typedef enum hipGraphNodeType {
   hipGraphNodeTypeMemcpyFromSymbol = 12,   ///< MemcpyFromSymbol node
   hipGraphNodeTypeMemcpyToSymbol = 13,     ///< MemcpyToSymbol node
   hipGraphNodeTypeBatchMemOp = 14,         ///< BatchMemOp node
+  hipGraphNodeTypeConditional = 15,        ///< Conditional (IF / WHILE) node
   hipGraphNodeTypeCount
 } hipGraphNodeType;
+
+/**
+ * Conditional graph handle (M1: handle plumbing only; node support is M2).
+ *
+ * On the AMD path the handle is backed by a real `hsa_signal_t` (Option C):
+ *   `device_ptr   == signal_handle + offsetof(amd_signal_t, value)`
+ * so that a single device-side store via `hipGraphSetConditional` updates
+ * the same cell the GPU CP firmware reads in M2 conditional packets.
+ *
+ * - `device_ptr`: GPU-visible address of the value cell. Kernels write here
+ *   via `hipGraphSetConditional`.
+ * - `default_value`: initial value the runtime stamps into the cell at
+ *   handle-create time and (in M2) at every `hipGraphLaunch`.
+ * - `signal_handle`: opaque `hsa_signal_t.handle` used by the runtime to
+ *   address the underlying signal in M2. Not consumed by user code.
+ */
+typedef struct hipGraphConditionalHandle_st {
+  uint64_t device_ptr;       ///< Device-visible address of the conditional value cell
+  uint64_t default_value;    ///< Initial value of the cell at handle creation
+  uint64_t signal_handle;    ///< Backing hsa_signal_t.handle (runtime-internal)
+} hipGraphConditionalHandle;
+
+/**
+ * @brief Type of conditional graph node.
+ *
+ * Mirrors CUDA's conditional node taxonomy.  AMD currently implements
+ * IF and WHILE via three vendor AQL packets (cond_jump entry packet plus
+ * an optional loop_back tail).  SWITCH is reserved and currently returns
+ * #hipErrorNotSupported from #hipGraphAddConditionalNode.
+ */
+typedef enum hipGraphConditionalType {
+  hipGraphCondTypeIf = 0,        ///< Conditional IF node (1 or 2 body graphs)
+  hipGraphCondTypeWhile = 1,     ///< Conditional WHILE node (1 body graph)
+  hipGraphCondTypeSwitch = 2,    ///< Conditional SWITCH node (not yet supported)
+} hipGraphConditionalType;
 
 typedef void (*hipHostFn_t)(void* userData);
 typedef struct hipHostNodeParams {
@@ -8250,6 +8286,74 @@ hipError_t hipThreadExchangeStreamCaptureMode(hipStreamCaptureMode* mode);
 hipError_t hipGraphCreate(hipGraph_t* pGraph, unsigned int flags);
 
 /**
+ * @brief Creates a conditional graph handle (M1: handle plumbing only).
+ *
+ * Allocates a runtime-managed cell whose address is exposed via
+ * `pHandleOut->device_ptr` so that a kernel can update the cell by calling
+ * `hipGraphSetConditional`. In M2 the same cell will be polled by the GPU
+ * CP firmware to drive conditional graph nodes (IF / WHILE).
+ *
+ * In M1, `hGraph` is validated but the handle is not yet registered with the
+ * graph for destruction; the backing signal is leaked at process exit. This
+ * is sufficient for the M1 smoke test and is fixed in the M2 lifetime work.
+ *
+ * @param [out] pHandleOut         - Conditional handle to fill in.
+ * @param [in]  hGraph             - Graph that will own this handle (validated only in M1).
+ * @param [in]  defaultLaunchValue - Initial value of the cell.
+ * @param [in]  flags              - Reserved, must be 0.
+ *
+ * @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorOutOfMemory,
+ *          #hipErrorInvalidDevice
+ */
+hipError_t hipGraphConditionalHandleCreate(hipGraphConditionalHandle* pHandleOut,
+                                           hipGraph_t hGraph,
+                                           unsigned int defaultLaunchValue,
+                                           unsigned int flags);
+
+/**
+ * @brief Adds a conditional (IF / WHILE) node to a graph.
+ *
+ * The node owns @a numConditionalGraphs empty body graph(s) returned via
+ * @a phConditionalGraphs that the caller then populates.  At
+ * @ref hipGraphInstantiate time the runtime captures the body graph(s)
+ * into one indirect-buffer per conditional, and at @ref hipGraphLaunch the
+ * runtime resets @a handle's value to its `default_value` and emits a
+ * vendor cond_jump AQL packet so the GPU CP picks the right arm or loop
+ * count (M2).
+ *
+ * Body graph counts:
+ *  - @ref hipGraphCondTypeWhile  : exactly 1.
+ *  - @ref hipGraphCondTypeIf     : 1 (no-else IF) or 2 (IF / ELSE, laid out
+ *                                  as `[else_body][if_body]` in the IB).
+ *  - @ref hipGraphCondTypeSwitch : not currently supported -- returns
+ *                                  #hipErrorNotSupported.
+ *
+ * @param [out] pGraphNode           Created conditional node.
+ * @param [in]  graph                Parent graph.
+ * @param [in]  pDependencies        Dependencies of the new node, may be NULL.
+ * @param [in]  numDependencies      Number of dependencies.
+ * @param [in]  handle               Conditional handle previously created via
+ *                                   @ref hipGraphConditionalHandleCreate.
+ * @param [in]  type                 Conditional node type
+ *                                   (@ref hipGraphConditionalType).
+ * @param [in]  numConditionalGraphs Number of body graphs to create
+ *                                   (1 for WHILE, 1 or 2 for IF).
+ * @param [out] phConditionalGraphs  Caller-provided array of size
+ *                                   @a numConditionalGraphs into which the
+ *                                   runtime writes new empty body graphs.
+ *
+ * @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorNotSupported
+ */
+hipError_t hipGraphAddConditionalNode(hipGraphNode_t* pGraphNode,
+                                      hipGraph_t graph,
+                                      const hipGraphNode_t* pDependencies,
+                                      size_t numDependencies,
+                                      hipGraphConditionalHandle handle,
+                                      hipGraphConditionalType type,
+                                      unsigned int numConditionalGraphs,
+                                      hipGraph_t* phConditionalGraphs);
+
+/**
  * @brief Destroys a graph
  *
  * @param [in] graph - instance of graph to destroy.
@@ -9907,6 +10011,15 @@ template <typename T> static hipError_t __host__ inline hipOccupancyMaxPotential
   (void)flags;
   return hipOccupancyMaxPotentialBlockSize(gridSize, blockSize, reinterpret_cast<const void*>(f),
                                            dynSharedMemPerBlk, blockSizeLimit);
+}
+
+// Device-side helper to update the conditional cell from a kernel.
+// Single global store at the address the runtime exposed via
+// `hipGraphConditionalHandleCreate`. In M2 the GPU CP firmware reads this
+// same cell to drive conditional graph nodes.
+__device__ static inline void
+hipGraphSetConditional(hipGraphConditionalHandle handle, unsigned long long value) {
+  *reinterpret_cast<volatile unsigned long long*>(handle.device_ptr) = value;
 }
 #endif  // defined(__clang__) && defined(__HIP__)
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/queue.h
@@ -195,6 +195,12 @@ struct AqlPacket {
                  << "\nkernel_object: " << ext_dispatch.kernel_object
                  << "\nkern_arg: " << ext_dispatch.kernarg_address
                  << "\nsignal: " << ext_dispatch.completion_signal.handle;
+        } else if (amd_vendor.format == HSA_AMD_PACKET_TYPE_AQL_INDIRECT_BUFFER) {
+          string << "\nformat: HSA_AMD_PACKET_TYPE_AQL_INDIRECT_BUFFER";
+        } else if (amd_vendor.format == HSA_AMD_PACKET_TYPE_DISPATCH_IB_COND_JUMP) {
+          string << "\nformat: HSA_AMD_PACKET_TYPE_DISPATCH_IB_COND_JUMP";
+        } else if (amd_vendor.format == HSA_AMD_PACKET_TYPE_AQL_LOOP_BACK) {
+          string << "\nformat: HSA_AMD_PACKET_TYPE_AQL_LOOP_BACK";
         }
         break;
       case HSA_PACKET_TYPE_BARRIER_AND:

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -124,6 +124,29 @@ typedef enum {
    */
   HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH = 3,
 
+  /**
+   * Indirect buffer dispatch packet. Causes the packet processor to execute
+   * a contiguous sequence of AQL packets located in a separate (indirect)
+   * buffer. Used as a building block for conditional graph execution.
+   */
+  HSA_AMD_PACKET_TYPE_AQL_INDIRECT_BUFFER = 4,
+
+  /**
+   * Conditional jump-into-IB packet. Reads a signal value, applies a
+   * comparison, and either falls through to one segment of an indirect
+   * buffer or jumps to another segment within the same IB.  Used as the
+   * entry packet for HIP graph IF and WHILE conditional nodes.
+   */
+  HSA_AMD_PACKET_TYPE_DISPATCH_IB_COND_JUMP = 5,
+
+  /**
+   * Loop-back packet. When encountered inside an indirect buffer, the CP
+   * re-evaluates the supplied condition signal; if the condition is still
+   * true, execution restarts at the top of the IB (used for WHILE bodies),
+   * otherwise execution falls through and the parent stream resumes.
+   */
+  HSA_AMD_PACKET_TYPE_AQL_LOOP_BACK = 6,
+
   /* Reserved for a packet that is not yet released */
   HSA_AMD_PACKET_TYPE_RESERVED200 = 200,
 } hsa_amd_packet_type_t;
@@ -215,6 +238,229 @@ typedef struct hsa_amd_barrier_value_packet_s {
    */
   hsa_signal_t completion_signal;
 } hsa_amd_barrier_value_packet_t;
+
+/**
+ * @brief AMD AQL indirect-buffer packet.  Causes the CP to execute
+ * @a ib_size_packets contiguous AQL packets starting at @a ib_base_addr,
+ * then resume the parent queue.  Reserved for future child-graph use; the
+ * IF/WHILE conditional node implementation does not emit this packet.
+ *
+ * Total size: 64 bytes.
+ */
+typedef struct hsa_amd_aql_indirect_buffer_s {
+  /**
+   * AMD vendor-specific packet header.  AmdFormat must be
+   * ::HSA_AMD_PACKET_TYPE_AQL_INDIRECT_BUFFER.
+   */
+  hsa_amd_vendor_packet_header_t header;
+
+  /**
+   * Reserved. Must be 0.
+   */
+  uint32_t reserved0;
+
+  /**
+   * Address of the first AQL packet in the indirect buffer.  Must be
+   * 64-byte aligned and reside in memory accessible to the CP.
+   */
+  uint64_t ib_base_addr;
+
+  /**
+   * Number of 64-byte AQL packets to execute starting at @a ib_base_addr.
+   */
+  uint32_t ib_size_packets;
+
+  /**
+   * Reserved. Must be 0.
+   */
+  uint32_t reserved1;
+
+  /**
+   * Reserved. Must be 0.
+   */
+  uint64_t reserved2;
+
+  /**
+   * Reserved. Must be 0.
+   */
+  uint64_t reserved3;
+
+  /**
+   * Reserved. Must be 0.
+   */
+  uint64_t reserved4;
+
+  /**
+   * Reserved. Must be 0.
+   */
+  uint64_t reserved5;
+
+  /**
+   * Signal used to indicate completion of the IB. The application can use the
+   * special signal handle 0 to indicate that no signal is used.
+   */
+  hsa_signal_t completion_signal;
+} hsa_amd_aql_indirect_buffer_t;
+
+/**
+ * @brief AMD conditional jump-into-IB packet.  Reads the value of
+ * @a condition_signal, evaluates @a cond_op against @a test_value, and:
+ *  - if the comparison is FALSE, executes
+ *    @a fallthrough_ib_size_packets packets starting at @a ib_base_addr;
+ *  - if the comparison is TRUE, executes @a jump_ib_size_packets packets
+ *    starting at @a ib_base_addr + @a jump_offset_packets * 64.
+ *
+ * For HIP graph IF nodes, the IB is laid out as
+ * <tt>[false_arm][true_arm]</tt> with @a cond_op == NE and
+ * @a test_value == 0.  For HIP graph WHILE nodes, the IB is laid out as
+ * <tt>[body][loop_back]</tt> with @a fallthrough_ib_size_packets == 0
+ * (so a 0-iteration WHILE exits without entering the body).
+ *
+ * Total size: 64 bytes.
+ */
+typedef struct hsa_amd_dispatch_indirect_buffer_conditional_jump_s {
+  /**
+   * AMD vendor-specific packet header.  AmdFormat must be
+   * ::HSA_AMD_PACKET_TYPE_DISPATCH_IB_COND_JUMP.
+   */
+  hsa_amd_vendor_packet_header_t header;
+
+  /**
+   * Reserved. Must be 0.
+   */
+  uint32_t reserved0;
+
+  /**
+   * Signal whose value is read by the CP to decide which IB segment to
+   * execute.  A handle of 0 is invalid for this packet.
+   */
+  hsa_signal_t condition_signal;
+
+  /**
+   * Value to compare @a condition_signal's loaded value against.
+   */
+  hsa_signal_value_t test_value;
+
+  /**
+   * Comparison operation.  See ::hsa_signal_condition_t.
+   */
+  hsa_signal_condition32_t cond_op;
+
+  /**
+   * Number of 64-byte AQL packets to execute starting at @a ib_base_addr
+   * when the condition evaluates FALSE.  May be 0 (no-op fall-through,
+   * used by WHILE nodes for the 0-iteration case).
+   */
+  uint32_t fallthrough_ib_size_packets;
+
+  /**
+   * Address of the indirect buffer.  Must be 64-byte aligned and reside in
+   * memory accessible to the CP.
+   */
+  uint64_t ib_base_addr;
+
+  /**
+   * Offset, in 64-byte packets, from @a ib_base_addr to the first packet
+   * executed when the condition evaluates TRUE.
+   */
+  uint32_t jump_offset_packets;
+
+  /**
+   * Number of 64-byte AQL packets to execute starting at
+   * @a ib_base_addr + @a jump_offset_packets * 64 when the condition
+   * evaluates TRUE.
+   */
+  uint32_t jump_ib_size_packets;
+
+  /**
+   * Reserved. Must be 0.
+   */
+  uint64_t reserved1;
+
+  /**
+   * Signal used to indicate completion of the IB.  The application can use
+   * the special signal handle 0 to indicate that no signal is used.
+   */
+  hsa_signal_t completion_signal;
+} hsa_amd_dispatch_indirect_buffer_conditional_jump_t;
+
+/**
+ * @brief AMD AQL loop-back packet.  Placed at the end of an indirect
+ * buffer body, the CP re-loads @a condition_signal and re-evaluates
+ * @a cond_op against @a test_value.  If the comparison is TRUE, the CP
+ * restarts execution at the start of the same IB (the IB is identified by
+ * its size, @a ib_size_packets, and the CP's running PC).  If FALSE, the
+ * CP exits the IB and resumes the parent queue.
+ *
+ * Total size: 64 bytes.
+ */
+typedef struct hsa_amd_aql_loop_back_s {
+  /**
+   * AMD vendor-specific packet header.  AmdFormat must be
+   * ::HSA_AMD_PACKET_TYPE_AQL_LOOP_BACK.
+   */
+  hsa_amd_vendor_packet_header_t header;
+
+  /**
+   * Reserved. Must be 0.
+   */
+  uint32_t reserved0;
+
+  /**
+   * Signal whose value is re-read by the CP each loop iteration.  Must be
+   * the same signal that the entry conditional-jump packet used.
+   */
+  hsa_signal_t condition_signal;
+
+  /**
+   * Value to compare @a condition_signal's loaded value against.
+   */
+  hsa_signal_value_t test_value;
+
+  /**
+   * Comparison operation.  See ::hsa_signal_condition_t.
+   */
+  hsa_signal_condition32_t cond_op;
+
+  /**
+   * Total size, in 64-byte packets, of the IB this loop-back closes
+   * (including this loop-back packet itself).  The CP uses this to compute
+   * the address of the IB's first packet when the loop continues.
+   */
+  uint32_t ib_size_packets;
+
+  /**
+   * Reserved. Must be 0.
+   */
+  uint64_t reserved1;
+
+  /**
+   * Reserved. Must be 0.
+   */
+  uint64_t reserved2;
+
+  /**
+   * Reserved. Must be 0.
+   */
+  uint64_t reserved3;
+
+  /**
+   * Signal used to indicate completion when the loop exits (FALSE branch).
+   * The application can use the special signal handle 0 to indicate that
+   * no signal is used.
+   */
+  hsa_signal_t completion_signal;
+} hsa_amd_aql_loop_back_t;
+
+#ifdef __cplusplus
+static_assert(sizeof(hsa_amd_aql_indirect_buffer_t) == 64,
+              "hsa_amd_aql_indirect_buffer_t must be a 64-byte AQL packet");
+static_assert(sizeof(hsa_amd_dispatch_indirect_buffer_conditional_jump_t) == 64,
+              "hsa_amd_dispatch_indirect_buffer_conditional_jump_t must be a "
+              "64-byte AQL packet");
+static_assert(sizeof(hsa_amd_aql_loop_back_t) == 64,
+              "hsa_amd_aql_loop_back_t must be a 64-byte AQL packet");
+#endif
 
 /**
  * @brief Enumeration constants corresponding to the sub-fields of


### PR DESCRIPTION
Adds an end-to-end proof-of-concept that lets HIP graphs express WHILE loops and IF branches by having the GPU command processor walk an instruction buffer (IB) of pre-built kernel-dispatch packets, gated by a new vendor AQL packet that consumes a hsa_signal_t value as the loop condition.

ROCr (vendor packet ABI):
* Add three 64-byte vendor AQL packet formats in hsa_ext_amd.h:
    HSA_AMD_PACKET_TYPE_AQL_INDIRECT_BUFFER          (4)
    HSA_AMD_PACKET_TYPE_DISPATCH_IB_COND_JUMP        (5)
    HSA_AMD_PACKET_TYPE_AQL_LOOP_BACK                (6)
  with static_asserts for size and alignment.
* Extend AqlPacket::string() (core/inc/queue.h) so logs print the new
  formats by name.

HIP API surface:
* Declare hipGraphAddConditionalNode and hipGraphConditionalType (hipGraphCondTypeIf / While / Switch) in hip_runtime_api.h, plus the matching hipGraphNodeTypeConditional enum.
* Wire hipGraphConditionalHandleCreate + hipGraphAddConditionalNode through HipDispatchTable, hip_api_trace, hip_table_interface, the hcc.map version script, and hip_prof_str.h profiler IDs.

CLR conditional node implementation:
* hip_graph_internal.{hpp,cpp}: GraphConditionalNode owns the cond signal handle, the conditional type and the body Graph(s).  Adds BuildIB() which during hipGraphInstantiate (a) bootstraps a GraphKernelArgManager pool large enough for every kernel in the body graphs, (b) calls CaptureAndFormPacket on each body kernel node, (c) zeroes the captured completion signals, (d) lays the packets out in a contiguous device-accessible IB (VRAM via deviceLocalAlloc, fallback to pinned host) and (e) for WHILE appends a hand-built hsa_amd_aql_loop_back_t.  IF/ELSE arrange [false_arm][true_arm].
* CondJumpCommand (nested in GraphConditionalNode): legacy command path that resets the cond cell to default_value via hsa_signal_store_relaxed and dispatches the cond_jump packet.
* GraphExec::CaptureAQLPackets calls BuildIB on every conditional node after the regular packet capture pass and before kernarg flush.
* Real GraphConditionalNode copy ctor + clone() so hipGraphInstantiate's internal Graph::clone deep-copies the body Graph hierarchy into the GraphExec instead of asserting.

CLR queue helper:
* roc::VirtualGPU::dispatchCondJumpPacket assembles hsa_amd_dispatch_indirect_buffer_conditional_jump_t with the right scacquire/screlease fence scopes, reserves the slot, writes the packet and rings the doorbell.

Status / open items:
* The CLR + ROCr side compiles and instantiates conditional graphs end to end.  At hipGraphLaunch the cond_jump packet is emitted on the HW queue and is rejected by the CP firmware on this part with HSA_STATUS_ERROR_INVALID_PACKET_FORMAT (0x1009) -- vendor types 5 and 6 are not yet recognised by CP microcode.  This is expected for the POC; runtime execution will become valid once the matching CP firmware ships.

DEV-ENV-ONLY workarounds (must NOT be merged to develop as-is):
* projects/clr/rocclr/device/rocm/rocrctx.hpp temporarily hard-codes the HSA include paths to this workspace's ROCr install (/home/amd/anusha_latest_clr/...).  Required because the system /opt/rocm hsa headers don't yet have the new vendor packet types.
* projects/clr/rocclr/device/blitcl.cpp stubs the __amd_rocclr_streamOpsIncrement / Decrement bodies to no-op so BlitManager init doesn't fail against the stale opencl.bc shipped in /opt/rocm.

Smoke / validation harness lives outside this repo at the workspace root: hip_graph_conditional_ib_test.cpp, adapted from projects/hip-tests/catch/unit/graph/hipGraphConditionalNode.cc on users/agodavar/conditionalGraphsPOC.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
