### PR TITLE
opt-in env variable RCCL_PXN_OPT_QP_USAGE for reducing QP usage on AINIC

### DIFF
--- a/projects/rccl/src/channel.cc
+++ b/projects/rccl/src/channel.cc
@@ -9,7 +9,7 @@
 #include "gdrwrap.h"
 #include "transport.h"
 
-// When set to 1, ncclP2pChannelBaseForRound uses batch stride 8 instead of 1 when p2p-batching is not enabled
+// When RCCL_PXN_OPT_QP_USAGE is set to 1, ncclP2pChannelBaseForRound uses batch stride 8 instead of 1 when p2p-batching is not enabled
 RCCL_PARAM(PxnOptQpUsage, "PXN_OPT_QP_USAGE", 0);
 
 ncclResult_t initChannel(struct ncclComm* comm, int channelId) {

--- a/projects/rccl/src/channel.cc
+++ b/projects/rccl/src/channel.cc
@@ -9,7 +9,7 @@
 #include "gdrwrap.h"
 #include "transport.h"
 
-// When RCCL_PXN_OPT_QP_USAGE is set to 1, ncclP2pChannelBaseForRound uses batch stride 8 instead of 1 when p2p-batching is not enabled
+// When RCCL_PXN_OPT_QP_USAGE is set to 1, ncclP2pChannelBaseForRound uses batch stride of comm->maxLocalRanks instead of 1 when p2p-batching is not enabled
 RCCL_PARAM(PxnOptQpUsage, "PXN_OPT_QP_USAGE", 0);
 
 ncclResult_t initChannel(struct ncclComm* comm, int channelId) {

--- a/projects/rccl/src/channel.cc
+++ b/projects/rccl/src/channel.cc
@@ -9,6 +9,9 @@
 #include "gdrwrap.h"
 #include "transport.h"
 
+// When set to 1, ncclP2pChannelBaseForRound uses batch stride 8 instead of 1 when p2p-batching is not enabled
+RCCL_PARAM(PxnOptQpUsage, "PXN_OPT_QP_USAGE", 0);
+
 ncclResult_t initChannel(struct ncclComm* comm, int channelId) {
   struct ncclChannel* channel = &comm->channels[channelId];
   if (channel->id != -1) return ncclSuccess;

--- a/projects/rccl/src/include/channel.h
+++ b/projects/rccl/src/include/channel.h
@@ -9,7 +9,9 @@
 #include "comm.h"
 #include "utils.h"
 #include "param.h"
-#include "net.h"
+
+bool rcclUseAinic();
+
 RCCL_PARAM_DECLARE(PxnOptQpUsage);  // RCCL_PXN_OPT_QP_USAGE: uses batch stride 8 instead of 1 to reduce QP usage when p2p-batching is disabled
 
 #include <algorithm>

--- a/projects/rccl/src/include/channel.h
+++ b/projects/rccl/src/include/channel.h
@@ -8,6 +8,8 @@
 #define NCCL_CHANNEL_H_
 #include "comm.h"
 #include "utils.h"
+#include "param.h"
+RCCL_PARAM_DECLARE(PxnOptQpUsage);  // RCCL_PXN_OPT_QP_USAGE: uses batch stride 8 instead of 1 to reduce QP usage when p2p-batching is disabled
 
 #include <algorithm>
 
@@ -21,7 +23,10 @@ inline uint8_t ncclP2pChannelBaseForRound(struct ncclComm* comm, int p2pRound, i
   if (comm->nNodes > 1) {
     int nodeDelta = p2pRound/comm->maxLocalRanks;
     int localDelta = p2pRound%comm->maxLocalRanks;
-    int batchSize = (comm->nNodes > 2 && p2pBatchEnable) ? NCCL_MAX_DEV_WORK_P2P_PER_BATCH : 1;
+    int fallbackBatch = (rcclParamPxnOptQpUsage() == 1) ? 8 : 1;
+    int batchSize = (comm->nNodes > 2 && p2pBatchEnable)
+        ? NCCL_MAX_DEV_WORK_P2P_PER_BATCH
+        : fallbackBatch;
     base = nodeDelta*divUp(comm->maxLocalRanks, batchSize);
     base += localDelta/batchSize;
   } else {

--- a/projects/rccl/src/include/channel.h
+++ b/projects/rccl/src/include/channel.h
@@ -24,7 +24,7 @@ inline uint8_t ncclP2pChannelBaseForRound(struct ncclComm* comm, int p2pRound, i
   if (comm->nNodes > 1) {
     int nodeDelta = p2pRound/comm->maxLocalRanks;
     int localDelta = p2pRound%comm->maxLocalRanks;
-    int fallbackBatch = (rcclParamPxnOptQpUsage() && rcclUseAinic()) ? 8 : 1;
+    int fallbackBatch = (!ncclPxnDisable(comm) && rcclParamPxnOptQpUsage() && rcclUseAinic()) ? comm->maxLocalRanks : 1;
     int batchSize = (comm->nNodes > 2 && p2pBatchEnable)
         ? NCCL_MAX_DEV_WORK_P2P_PER_BATCH
         : fallbackBatch;

--- a/projects/rccl/src/include/channel.h
+++ b/projects/rccl/src/include/channel.h
@@ -12,7 +12,7 @@
 
 bool rcclUseAinic();
 
-RCCL_PARAM_DECLARE(PxnOptQpUsage);  // RCCL_PXN_OPT_QP_USAGE: uses batch stride 8 instead of 1 to reduce QP usage when p2p-batching is disabled
+RCCL_PARAM_DECLARE(PxnOptQpUsage);  // RCCL_PXN_OPT_QP_USAGE: uses batch stride of comm->maxLocalRanks instead of 1 to reduce QP usage when p2p-batching is disabled
 
 #include <algorithm>
 

--- a/projects/rccl/src/include/channel.h
+++ b/projects/rccl/src/include/channel.h
@@ -9,6 +9,7 @@
 #include "comm.h"
 #include "utils.h"
 #include "param.h"
+#include "net.h"
 RCCL_PARAM_DECLARE(PxnOptQpUsage);  // RCCL_PXN_OPT_QP_USAGE: uses batch stride 8 instead of 1 to reduce QP usage when p2p-batching is disabled
 
 #include <algorithm>
@@ -23,7 +24,7 @@ inline uint8_t ncclP2pChannelBaseForRound(struct ncclComm* comm, int p2pRound, i
   if (comm->nNodes > 1) {
     int nodeDelta = p2pRound/comm->maxLocalRanks;
     int localDelta = p2pRound%comm->maxLocalRanks;
-    int fallbackBatch = (rcclParamPxnOptQpUsage() == 1) ? 8 : 1;
+    int fallbackBatch = (rcclParamPxnOptQpUsage() && rcclUseAinic()) ? 8 : 1;
     int batchSize = (comm->nNodes > 2 && p2pBatchEnable)
         ? NCCL_MAX_DEV_WORK_P2P_PER_BATCH
         : fallbackBatch;


### PR DESCRIPTION
## Motivation

Enable the user to further reduce QP usage.

## Technical Details

The batch-size used when assigning channels in the rounds of the p2p-schedule, has a direct impact on the QP usage.
When PXN is enabled, QP usage is a reduced by a factor of batchSize.
As of this commit, batchSize is set to 1 by default, and can be increased to 2 when p2p-batching is enabled. 
This PR enables the use of  `PXN_OPT_QP_USAGE=1` to increase batchSize to `8` on AINIC systems. In all other cases it remains `1` or `2` depending on p2p-batching enablement.
However, larger batch sizes without p2p-batching enablement can degrade performance, particularly on lower node counts and smaller messages.

## JIRA ID

AICOMRCCL-937

## Test Plan

Verify adjustment of batchSize when env. variable `PXN_OPT_QP_USAGE` is set to `0` or `1`.

## Test Result

Verified adjustment.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
