### PR TITLE
[rocshmem] check if numalib is available at runtime for GDA

### DIFF
--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -200,6 +200,25 @@ if (NOT BUILD_TESTS_ONLY)
   #############################################################################
   # PACKAGE DEPENDENCIES
   #############################################################################
+  # GDA Requires libnuma
+  if(USE_GDA)
+    find_path(NUMA_INCLUDE_DIR NAMES numa.h)
+    find_library(NUMA_LIBRARY NAMES numa)
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(NUMA DEFAULT_MSG NUMA_LIBRARY NUMA_INCLUDE_DIR)
+
+    # Usually you would have to add libnuma to target but we use dlopen
+
+    if (NOT NUMA_FOUND)
+      message(STATUS "libnuma not found. Unable to build GDA")
+      set(USE_GDA OFF)
+      set(GDA_IONIC OFF)
+      set(GDA_BNXT OFF)
+      set(GDA_MLX5 OFF)
+    endif()
+  endif()
+
   if (NOT USE_EXTERNAL_MPI STREQUAL "OFF")
     find_package(MPI)
   else()

--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -195,7 +195,6 @@ message(STATUS "Compiling for ${GPU_TARGETS}")
 if (NOT BUILD_TESTS_ONLY)
   add_library(${PROJECT_NAME})
   add_library(roc::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
-  add_subdirectory(src)
 
   #############################################################################
   # PACKAGE DEPENDENCIES
@@ -409,6 +408,13 @@ if (NOT BUILD_TESTS_ONLY)
     DESCRIPTION "ROCm OpenSHMEM (rocSHMEM)"
     MAINTAINER "rocSHMEM Maintainer <rocshmem-maintainer@amd.com>"
   )
+endif (NOT BUILD_TESTS_ONLY)
+
+###############################################################################
+# TEST SUBDIRECTORIES
+###############################################################################
+if (NOT BUILD_TESTS_ONLY)
+  add_subdirectory(src)
 endif (NOT BUILD_TESTS_ONLY)
 
 ###############################################################################

--- a/projects/rocshmem/src/CMakeLists.txt
+++ b/projects/rocshmem/src/CMakeLists.txt
@@ -91,7 +91,7 @@ set_property(
 ###############################################################################
 # ROCSHMEM TARGET FOR BACKENDS
 ###############################################################################
-if (USE_GDA AND NUMA_FOUND)
+if (USE_GDA)
 add_subdirectory(gda)
 endif()
 if (USE_RO)

--- a/projects/rocshmem/src/CMakeLists.txt
+++ b/projects/rocshmem/src/CMakeLists.txt
@@ -91,7 +91,7 @@ set_property(
 ###############################################################################
 # ROCSHMEM TARGET FOR BACKENDS
 ###############################################################################
-if (USE_GDA)
+if (USE_GDA AND NUMA_FOUND)
 add_subdirectory(gda)
 endif()
 if (USE_RO)

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -889,6 +889,9 @@ int GDABackend::backend_can_run() {
   void *handle{nullptr};
   GDAProvider requested = requested_provider();
 
+  /* Libnuma ? */
+  if (!numa.is_available()) return ROCSHMEM_ERROR;
+
   /* Basic verbs? */
   if (!ibv.is_initialized) return ROCSHMEM_ERROR;
 

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -890,7 +890,10 @@ int GDABackend::backend_can_run() {
   GDAProvider requested = requested_provider();
 
   /* Libnuma ? */
-  if (!numa.is_available()) return ROCSHMEM_ERROR;
+  if (!numa.is_available()) {
+    LOG_WARN("GDA backend unavailable: libnuma support is missing");
+    return ROCSHMEM_ERROR;
+  }
 
   /* Basic verbs? */
   if (!ibv.is_initialized) return ROCSHMEM_ERROR;

--- a/projects/rocshmem/src/gda/numa_wrapper.cpp
+++ b/projects/rocshmem/src/gda/numa_wrapper.cpp
@@ -45,19 +45,27 @@ NUMAWrapper::NUMAWrapper() {
   numa_handle = dlopen("libnuma.so", RTLD_NOW);
 
   if (!numa_handle) {
-    LOG_ERROR_EXIT("Could not open libnuma. Returning");
+    LOG_ERROR("Could not open libnuma. Returning");
+    return;
   }
 
   err = init_function_table();
   if (err != ROCSHMEM_SUCCESS) {
-    LOG_ERROR_EXIT("Could not construct libnuma function table");
+    LOG_ERROR("Could not construct libnuma function table");
+    return;
   }
+
+  numalib_available = true;
 }
 
 NUMAWrapper::~NUMAWrapper() {
   if (numa_handle != nullptr) {
     dlclose(numa_handle);
   }
+}
+
+bool NUMAWrapper::is_available() {
+  return numalib_available;
 }
 
 int NUMAWrapper::init_function_table() {

--- a/projects/rocshmem/src/gda/numa_wrapper.hpp
+++ b/projects/rocshmem/src/gda/numa_wrapper.hpp
@@ -50,6 +50,8 @@ class NUMAWrapper {
                     const int nodes[count], int status[count], int flags);
     int distance(int node1, int node2);
 
+    bool is_available();
+
   private:
     struct numa_funcs_t {
       int (*bitmask_isbitset)(const struct bitmask *bmp, unsigned int n);
@@ -78,6 +80,11 @@ class NUMAWrapper {
      * @brief initialize function table
      */
     int init_function_table();
+
+    /**
+     * @brief Does the system have libnuma
+     */
+    bool numalib_available = false;
 };
 
 #pragma clang diagnostic pop


### PR DESCRIPTION
## Motivation

If numa lib is not installed, rocSHMEM still thinks it can run GDA. This is not true.

## Technical Details

Set a flag if numalib is available and check it as a part of `backend_can_run()`

## JIRA ID

AIROCSHMEM-407

## Test Plan

- [ ] Validate with pytorch
