### PR TITLE
[hip-tests] Fix Unit_hipEventIpc_shm_cleanup build failure and add IP…

### DIFF
--- a/projects/hip-tests/catch/unit/event/Unit_hipEventIpc_shm_cleanup.cc
+++ b/projects/hip-tests/catch/unit/event/Unit_hipEventIpc_shm_cleanup.cc
@@ -49,7 +49,13 @@ std::set<std::string> get_hip_ipc_shm_files() {
 }
 
 HIP_TEST_CASE(Unit_hipEventIpc_shm_cleanup) {
-  // This test validates /dev/shm cleanup for the emulated IPC event path.
+  hipDeviceProp_t props{};
+  HIP_CHECK(hipGetDeviceProperties(&props, 0));
+  if (!props.ipcEventSupported) {
+    HipTest::HIP_SKIP_TEST("IPC events are not supported on this device.");
+    return;
+  }
+
   // Skip when the device uses native IPC signals (no /dev/shm involved).
   {
     auto shm_before = get_hip_ipc_shm_files();


### PR DESCRIPTION
…C support guard

The CI build was failing with:
  error: expected identifier
  HipTest::HIP_SKIP_TEST("Device uses native IPC signals; ...");

Root cause: commit f9c46632 replaced the HipTest::HIP_SKIP_TEST static inline function with a preprocessor macro. When code calls HipTest::HIP_SKIP_TEST(...), the preprocessor expands the macro token *after* the :: scope-resolution operator, producing syntactically invalid code (a brace-block after ::). Clang reports this as "expected identifier". The revert commit dba16d3d0f restored HIP_SKIP_TEST to a function, fixing all namespace-qualified call sites.

Additionally, add a runtime guard at the top of the test using hipDeviceProp_t.ipcEventSupported. On devices that do not support IPC events (e.g. gfx1010 / RDNA1), hipIpcGetEventHandle would otherwise fail and abort the test instead of skipping it cleanly.

Fixes: https://github.com/ROCm/rocm-systems/issues/5915

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
