### PR TITLE
Revert "[hip-tests] Replace HIP_SKIP_THIS_TEST with Catch2 SKIP macro"

### DIFF
--- a/projects/hip-tests/catch/README.md
+++ b/projects/hip-tests/catch/README.md
@@ -161,14 +161,15 @@ Please also note that you can not return values in functions calling ```HIP_CHEC
 ### Skipping Tests if certain criteria is not met
 If there arises a condition where certain flag is disabled and due to which a test can not run at that time, the following macro can be of use. It will highlight the test in ctest report as well.
 
-- ```HIP_SKIP_TEST``` : The API takes in an input of the reason as well and prints out the line HIP_SKIP_THIS_TEST. This causes ctest to mark the test as skipped and the test shows up in the report as skipped prompting proper response from the team. Internally uses the Catch2 SKIP macro to actually end the test execution and report the status as skipped. ctest also marks the test as skipped
+- ```HIP_SKIP_TEST``` : The API takes in an input of the reason as well and prints out the line HIP_SKIP_THIS_TEST. This causes ctest to mark the test as skipped and the test shows up in the report as skipped prompting proper response from the team.
 
   Usage:
 
   ```cpp
   TEST_CASE("TestOnlyOnXnack") {
     if(!XNACKEnabled) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
+      return;
     }
     // Rest of test functionality
   }

--- a/projects/hip-tests/catch/TypeQualifiers/hipManagedKeyword.cc
+++ b/projects/hip-tests/catch/TypeQualifiers/hipManagedKeyword.cc
@@ -32,7 +32,8 @@ HIP_TEST_CASE(Unit_hipManagedKeyword_SingleGpu) {
     int managed_memory = 0;
     HIP_CHECK(hipDeviceGetAttribute(&managed_memory, hipDeviceAttributeManagedMemory, i));
     if (!managed_memory) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+      return;
     }
   }
 
@@ -62,7 +63,8 @@ HIP_TEST_CASE(Unit_hipManagedKeyword_MultiGpu) {
     int managed_memory = 0;
     HIP_CHECK(hipDeviceGetAttribute(&managed_memory, hipDeviceAttributeManagedMemory, i));
     if (!managed_memory) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+      return;
     }
   }
 

--- a/projects/hip-tests/catch/cmake/hip-tests.cmake
+++ b/projects/hip-tests/catch/cmake/hip-tests.cmake
@@ -119,7 +119,9 @@ function(hip_gen_exe_target)
     endforeach()
     # add binary to global list of binaries to install
     set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS ${_EXE_NAME})
-    set(_DISCOVER_PROPERTIES "")
+    set(_DISCOVER_PROPERTIES
+      SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST"
+    )
     if (DEFINED HIP_TEST_LABELS)
       list(APPEND _DISCOVER_PROPERTIES LABELS "${HIP_TEST_LABELS}")
     endif()

--- a/projects/hip-tests/catch/hipTestMain/main.cc
+++ b/projects/hip-tests/catch/hipTestMain/main.cc
@@ -7,6 +7,7 @@
 #define CATCH_CONFIG_RUNNER
 #include <cmd_options.hh>
 #include <hip_test_common.hh>
+#include <iostream>
 
 CmdOptions cmd_options;
 

--- a/projects/hip-tests/catch/include/hip_test_checkers.hh
+++ b/projects/hip-tests/catch/include/hip_test_checkers.hh
@@ -376,7 +376,7 @@ static bool assemblyFile_Verification(std::string assemfilename, std::string ins
     }
   } else {
     result = true;
-    HIP_SKIP_TEST("expected assembly file not found.");
+    HipTest::HIP_SKIP_TEST("expected assembly file not found.");
   }
   return result;
 }

--- a/projects/hip-tests/catch/include/hip_test_common.hh
+++ b/projects/hip-tests/catch/include/hip_test_common.hh
@@ -222,13 +222,6 @@
     abort();                                                                                       \
   }
 
-// Causes the test to stop and be skipped at runtime.
-#define HIP_SKIP_TEST(reason)                                                                      \
-  {                                                                                                \
-    std::cout << "HIP_SKIP_THIS_TEST" << std::endl;                                                \
-    SKIP(reason);                                                                                  \
-  }
-
 #if HT_NVIDIA
 #define CTX_CREATE()                                                                               \
   hipCtx_t context;                                                                                \
@@ -488,7 +481,7 @@ inline bool isKernelArgPrefetchSupported() {
 }
 
 /**
- * Canonical skip reasons for HIP_SKIP_TEST (stable strings for logs / ctest filters).
+ * Canonical skip reasons for HipTest::HIP_SKIP_TEST (stable strings for logs / ctest filters).
  * Use these instead of duplicating slightly different wording for the same condition.
  */
 namespace SkipReason {
@@ -552,6 +545,15 @@ inline constexpr char const kNotEnoughFreeHostMemory[] =
     "not enough free host memory";
 inline constexpr char const kRequiresLinux[] = "this test requires Linux.";
 }  // namespace SkipReason
+
+/**
+ * Causes the test to stop and be skipped at runtime.
+ * reason: Message describing the reason the test has been skipped.
+ */
+static inline void HIP_SKIP_TEST(char const* const reason) noexcept {
+  // ctest is setup to parse for "HIP_SKIP_THIS_TEST", at which point it will skip the test.
+  std::cout << "Skipping test. Reason: " << reason << '\n' << "HIP_SKIP_THIS_TEST" << std::endl;
+}
 
 /**
  * @brief Helper template that returns the expected arguments of a kernel.
@@ -712,7 +714,8 @@ class BlockingContext {
 // is supported on the current device.
 #define CHECK_IMAGE_SUPPORT                                                                        \
   if (!HipTest::isImageSupported()) {                                                              \
-    HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);                                  \
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);                         \
+    return;                                                                                        \
   }
 
 // Call at the start of tests that require managed memory support to indicate
@@ -721,12 +724,14 @@ class BlockingContext {
   int current_device_ = 0;                                                     \
   HIP_CHECK(hipGetDevice(&current_device_));                                   \
   if (!HipTest::isManagedMemorySupportedOnDevice(current_device_)) {           \
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);             \
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);    \
+    return;                                                                    \
   }
 
 #define CHECK_PCIE_ATOMIC_SUPPORT                                                                 \
   if (!HipTest::isPcieAtomicSupported()) {                                                        \
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);                                   \
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);                         \
+    return;                                                                                        \
   }
 
 #define CHECK_P2P_SUPPORT                                                                          \
@@ -734,13 +739,15 @@ class BlockingContext {
   if (!HipTest::isP2PSupported(d1,d2)) {                                                           \
     std::string msg = "P2P access check failed between dev1:" + std::to_string(d1) + ",dev2:" +    \
                                                                 std::to_string(d2);                \
-    HIP_SKIP_TEST(msg.c_str());                                                                    \
+    HipTest::HIP_SKIP_TEST(msg.c_str());                                                           \
+    return;                                                                                        \
   }                                                                                                \
 // Use this before running tests that rely on warp match functions to check device support and
 // skip the current test if they are not available.
 #define CHECK_WARP_MATCH_FUNCTIONS_SUPPORT                                                         \
   if (!HipTest::areWarpMatchFunctionsSupported()) {                                                \
-    HIP_SKIP_TEST("warp match functions are not supported on this device.");                       \
+    HipTest::HIP_SKIP_TEST("warp match functions are not supported on this device.");      \
+    return;                                                                                        \
   }
 
 // Call GENERATE_CAPTURE macro at the start of the test, before using BEGIN/END_CAPTURE.

--- a/projects/hip-tests/catch/include/hip_test_context.hh
+++ b/projects/hip-tests/catch/include/hip_test_context.hh
@@ -100,7 +100,6 @@ class TestContext {
   bool isLinux() const;
   bool isNvidia() const;
   bool isAmd() const;
-  bool skipTest() const;
 
   std::string currentPath() const;
 

--- a/projects/hip-tests/catch/include/memcpy1d_tests_common.hh
+++ b/projects/hip-tests/catch/include/memcpy1d_tests_common.hh
@@ -123,7 +123,8 @@ void MemcpyDeviceToDeviceShell(F memcpy_func, const hipStream_t kernel_stream = 
     int can_access_peer = 0;
     HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, src_device, dst_device));
     if (!can_access_peer) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      return;
     }
     if constexpr (enable_peer_access) {
       HIP_CHECK(hipDeviceEnablePeerAccess(dst_device, 0));

--- a/projects/hip-tests/catch/include/memcpy3d_tests_common.hh
+++ b/projects/hip-tests/catch/include/memcpy3d_tests_common.hh
@@ -173,10 +173,11 @@ void Memcpy3DDeviceToDeviceShell(F memcpy_func, hipStream_t kernel_stream = null
     int can_access_peer = 0;
     HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, src_device, dst_device));
     if (!can_access_peer) {
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
       if (device_count > 0 && kernel_stream != nullptr && kernel_stream != hipStreamPerThread) {
-          HIP_CHECK(hipStreamDestroy(kernel_stream));
+        HIP_CHECK(hipStreamDestroy(kernel_stream));
       }
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      return;
     }
     HIP_CHECK(hipDeviceEnablePeerAccess(dst_device, 0));
   }

--- a/projects/hip-tests/catch/multiproc/hipDeviceComputeCapabilityMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipDeviceComputeCapabilityMproc.cc
@@ -138,7 +138,7 @@ HIP_TEST_CASE(Unit_hipDeviceGet_MaskedDevices) {
     ret = runMaskedDeviceTest(count);
     REQUIRE(ret == true);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 

--- a/projects/hip-tests/catch/multiproc/hipDeviceGetPCIBusIdMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipDeviceGetPCIBusIdMproc.cc
@@ -152,7 +152,7 @@ HIP_TEST_CASE(Unit_hipDeviceGetPCIBusId_MaskedDevices) {
     ret = hipDeviceGetPCIBusIdTests::testWithMaskedDevices(count);
     REQUIRE(ret == true);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 
@@ -178,7 +178,7 @@ HIP_TEST_CASE(Unit_hipDeviceGetPCIBusId_CheckPciBusIDWithLspci) {
   }();
 
   if (are_devices_hidden) {
-    HIP_SKIP_TEST(
+    HipTest::HIP_SKIP_TEST(
         "There are hidden devices, which means lscpi might report something different than what we "
         "have here");
   }
@@ -198,7 +198,8 @@ HIP_TEST_CASE(Unit_hipDeviceGetPCIBusId_CheckPciBusIDWithLspci) {
     pclose(fpipe);
 
     if (lspciCheck == nullptr) {
-      HIP_SKIP_TEST("lspci is not available on this system.");
+      HipTest::HIP_SKIP_TEST("lspci is not available on this system.");
+      return;
     }
   }
 

--- a/projects/hip-tests/catch/multiproc/hipDeviceTotalMemMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipDeviceTotalMemMproc.cc
@@ -150,7 +150,7 @@ HIP_TEST_CASE(Unit_hipDeviceTotalMem_MaskedDevices) {
     ret = getTotalMemoryOfMaskedDevices(count);
     REQUIRE(ret == true);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 

--- a/projects/hip-tests/catch/multiproc/hipGetDeviceAttributeMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipGetDeviceAttributeMproc.cc
@@ -141,7 +141,7 @@ HIP_TEST_CASE(Unit_hipDeviceGetAttribute_MaskedDevices) {
     ret = validateGetAttributeOfMaskedDevices(count);
     REQUIRE(ret == true);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 #endif

--- a/projects/hip-tests/catch/multiproc/hipGetDevicePropertiesMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipGetDevicePropertiesMproc.cc
@@ -140,7 +140,7 @@ HIP_TEST_CASE(Unit_hipGetDeviceProperties_MaskedDevices) {
     ret = validateGetPropsOfMaskedDevices(count);
     REQUIRE(ret == true);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
   }
 }
 #endif

--- a/projects/hip-tests/catch/multiproc/hipIpcEventHandle.cc
+++ b/projects/hip-tests/catch/multiproc/hipIpcEventHandle.cc
@@ -235,7 +235,8 @@ HIP_TEST_CASE(Unit_hipIpcEventHandle_Functional) {
   getDevices(shmDevices);
 
   if (shmDevices->count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   g_processCnt = (shmDevices->count > MAX_DEVICES) ? MAX_DEVICES : shmDevices->count;

--- a/projects/hip-tests/catch/multiproc/hipMemCoherencyTstMProc.cc
+++ b/projects/hip-tests/catch/multiproc/hipMemCoherencyTstMProc.cc
@@ -109,7 +109,7 @@ HIP_TEST_CASE(Unit_malloc_CoherentTst) {
       REQUIRE(ret);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
   }
 }
 #endif
@@ -142,7 +142,7 @@ HIP_TEST_CASE(Unit_malloc_CoherentTstWthAdvise) {
       free(Ptr);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
   }
 }
 #endif
@@ -176,7 +176,7 @@ HIP_TEST_CASE(Unit_mmap_CoherentTst) {
       REQUIRE(ret);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
   }
 }
 #endif
@@ -220,7 +220,7 @@ HIP_TEST_CASE(Unit_mmap_CoherentTstWthAdvise) {
       HIP_CHECK(hipStreamDestroy(strm));
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
   }
 }
 #endif

--- a/projects/hip-tests/catch/multiproc/hipSetGetDeviceMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipSetGetDeviceMproc.cc
@@ -156,7 +156,8 @@ static void testValidDevices(int numDevices, bool useRocrEnv, int* deviceList,
   std::string visibleDeviceString;
 
   if ((NULL == deviceList) || ((deviceListLength < 1) || deviceListLength > numDevices)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
+    return;
   }
 
   for (int i = 0; i < deviceListLength; i++) {

--- a/projects/hip-tests/catch/performance/kernelLaunch/hipLaunchCooperativeKernel.cc
+++ b/projects/hip-tests/catch/performance/kernelLaunch/hipLaunchCooperativeKernel.cc
@@ -81,7 +81,8 @@ template <KernelType kernel_type, bool timer_type> static void RunBenchmark(bool
  */
 HIP_TEST_CASE(Performance_hipLaunchCooperativeKernel) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   bool sync = GENERATE(true, false);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy.cc
@@ -34,6 +34,9 @@ static void RunBenchmark(LinearAllocs dst_allocation_type, LinearAllocs src_allo
   } else {
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
+    if (src_device == -1 && dst_device == -1) {
+      return;
+    }
 
     LinearAllocGuard<int> src_allocation(src_allocation_type, size);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -140,7 +143,8 @@ HIP_TEST_CASE(Performance_hipMemcpy_HostToHost) {
  */
 HIP_TEST_CASE(Performance_hipMemcpy_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto src_allocation_type = LinearAllocs::hipMalloc;

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy2D.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy2D.cc
@@ -50,6 +50,9 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
+    if (src_device == -1 && dst_device == -1) {
+      return;
+    }
 
     LinearAllocGuard2D<int> src_allocation(width, height);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -160,7 +163,8 @@ HIP_TEST_CASE(Performance_hipMemcpy2D_DeviceToDevice_DisablePeerAccess) {
  */
 HIP_TEST_CASE(Performance_hipMemcpy2D_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DAsync.cc
@@ -54,6 +54,9 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
+    if (src_device == -1 && dst_device == -1) {
+      return;
+    }
 
     LinearAllocGuard2D<int> src_allocation(width, height);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -165,7 +168,8 @@ HIP_TEST_CASE(Performance_hipMemcpy2DAsync_DeviceToDevice_DisablePeerAccess) {
  */
 HIP_TEST_CASE(Performance_hipMemcpy2DAsync_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DFromArray.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DFromArray.cc
@@ -37,6 +37,9 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
+    if (src_device == -1 && dst_device == -1) {
+      return;
+    }
 
     LinearAllocGuard2D<int> device_allocation(width, height);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -112,7 +115,8 @@ HIP_TEST_CASE(Performance_hipMemcpy2DFromArray_DeviceToDevice_EnablePeerAccess) 
   CHECK_IMAGE_SUPPORT
 
   if (HipTest::getDeviceCount() < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   const auto width = GENERATE(4_KB, 8_KB, 16_KB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DFromArrayAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DFromArrayAsync.cc
@@ -41,6 +41,9 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
+    if (src_device == -1 && dst_device == -1) {
+      return;
+    }
 
     LinearAllocGuard2D<int> device_allocation(width, height);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -117,7 +120,8 @@ HIP_TEST_CASE(Performance_hipMemcpy2DFromArrayAsync_DeviceToDevice_EnablePeerAcc
   CHECK_IMAGE_SUPPORT
 
   if (HipTest::getDeviceCount() < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   const auto width = GENERATE(4_KB, 8_KB, 16_KB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DToArray.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DToArray.cc
@@ -37,6 +37,9 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
+    if (src_device == -1 && dst_device == -1) {
+      return;
+    }
 
     LinearAllocGuard2D<int> device_allocation(width, height);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -112,7 +115,8 @@ HIP_TEST_CASE(Performance_hipMemcpy2DToArray_DeviceToDevice_EnablePeerAccess) {
   CHECK_IMAGE_SUPPORT
 
   if (HipTest::getDeviceCount() < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   const auto width = GENERATE(4_KB, 8_KB, 16_KB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DToArrayAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy2DToArrayAsync.cc
@@ -41,6 +41,9 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
+    if (src_device == -1 && dst_device == -1) {
+      return;
+    }
 
     LinearAllocGuard2D<int> device_allocation(width, height);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -117,7 +120,8 @@ HIP_TEST_CASE(Performance_hipMemcpy2DToArrayAsync_DeviceToDevice_EnablePeerAcces
   CHECK_IMAGE_SUPPORT
 
   if (HipTest::getDeviceCount() < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   const auto width = GENERATE(4_KB, 8_KB, 16_KB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy3D.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy3D.cc
@@ -60,6 +60,9 @@ static void RunBenchmark(const hipExtent extent, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
+    if (src_device == -1 && dst_device == -1) {
+      return;
+    }
 
     LinearAllocGuard3D<int> src_allocation(extent);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -170,7 +173,8 @@ HIP_TEST_CASE(Performance_hipMemcpy3D_DeviceToDevice_DisablePeerAccess) {
  */
 HIP_TEST_CASE(Performance_hipMemcpy3D_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(make_hipExtent(width, 16, 4), hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpy3DAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpy3DAsync.cc
@@ -64,6 +64,9 @@ static void RunBenchmark(const hipExtent extent, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
+    if (src_device == -1 && dst_device == -1) {
+      return;
+    }
 
     LinearAllocGuard3D<int> src_allocation(extent);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -171,7 +174,8 @@ HIP_TEST_CASE(Performance_hipMemcpy3DAsync_DeviceToDevice_DisablePeerAccess) {
  */
 HIP_TEST_CASE(Performance_hipMemcpy3DAsync_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(make_hipExtent(width, 16, 4), hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyAsync.cc
@@ -39,6 +39,9 @@ static void RunBenchmark(LinearAllocs dst_allocation_type, LinearAllocs src_allo
   } else {
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
+    if (src_device == -1 && dst_device == -1) {
+      return;
+    }
 
     LinearAllocGuard<int> src_allocation(src_allocation_type, size);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -170,7 +173,8 @@ HIP_TEST_CASE(Performance_hipMemcpyAsync_DeviceToDevice_DisablePeerAccess) {
  */
 HIP_TEST_CASE(Performance_hipMemcpyAsync_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto src_allocation_type = LinearAllocs::hipMalloc;

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyDtoD.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyDtoD.cc
@@ -25,6 +25,9 @@ static void RunBenchmark(size_t size, bool enable_peer_access = false) {
 
   int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
   int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
+  if (src_device == -1 && dst_device == -1) {
+    return;
+  }
 
   LinearAllocGuard<int> src_allocation(LinearAllocs::hipMalloc, size);
   HIP_CHECK(hipSetDevice(dst_device));
@@ -57,7 +60,8 @@ static void RunBenchmark(size_t size, bool enable_peer_access = false) {
  */
 HIP_TEST_CASE(Performance_hipMemcpyDtoD_PeerAccessEnabled) {
   if (HipTest::getDeviceCount() < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(allocation_size, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyDtoDAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyDtoDAsync.cc
@@ -31,6 +31,9 @@ static void RunBenchmark(size_t size, bool enable_peer_access = false) {
   const hipStream_t stream = stream_guard.stream();
   int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
   int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
+  if (src_device == -1 && dst_device == -1) {
+    return;
+  }
 
   LinearAllocGuard<int> src_allocation(LinearAllocs::hipMalloc, size);
   HIP_CHECK(hipSetDevice(dst_device));
@@ -62,7 +65,8 @@ static void RunBenchmark(size_t size, bool enable_peer_access = false) {
  */
 HIP_TEST_CASE(Performance_hipMemcpyDtoDAsync_PeerAccessEnabled) {
   if (HipTest::getDeviceCount() < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(allocation_size, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyParam2D.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyParam2D.cc
@@ -49,6 +49,9 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
+    if (src_device == -1 && dst_device == -1) {
+      return;
+    }
 
     LinearAllocGuard2D<int> src_allocation(width, height);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -163,7 +166,8 @@ HIP_TEST_CASE(Performance_hipMemcpyParam2D_DeviceToDevice_DisablePeerAccess) {
  */
 HIP_TEST_CASE(Performance_hipMemcpyParam2D_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyParam2DAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyParam2DAsync.cc
@@ -53,6 +53,9 @@ static void RunBenchmark(size_t width, size_t height, hipMemcpyKind kind,
     // hipMemcpyDeviceToDevice
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
+    if (src_device == -1 && dst_device == -1) {
+      return;
+    }
 
     LinearAllocGuard2D<int> src_allocation(width, height);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -167,7 +170,8 @@ HIP_TEST_CASE(Performance_hipMemcpyParam2DAsync_DeviceToDevice_DisablePeerAccess
  */
 HIP_TEST_CASE(Performance_hipMemcpyParam2DAsync_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   const auto width = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(width, 32, hipMemcpyDeviceToDevice, true);

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyWithStream.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyWithStream.cc
@@ -36,6 +36,9 @@ static void RunBenchmark(LinearAllocs dst_allocation_type, LinearAllocs src_allo
   } else {
     int src_device = std::get<0>(GetDeviceIds(enable_peer_access));
     int dst_device = std::get<1>(GetDeviceIds(enable_peer_access));
+    if (src_device == -1 && dst_device == -1) {
+      return;
+    }
 
     LinearAllocGuard<int> src_allocation(LinearAllocs::hipMalloc, size);
     HIP_CHECK(hipSetDevice(dst_device));
@@ -167,7 +170,8 @@ HIP_TEST_CASE(Performance_hipMemcpyWithStream_DeviceToDevice_DisablePeerAccess) 
  */
 HIP_TEST_CASE(Performance_hipMemcpyWithStream_DeviceToDevice_EnablePeerAccess) {
   if (HipTest::getDeviceCount() < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   const auto allocation_size = GENERATE(4_KB, 4_MB, 16_MB);
   const auto src_allocation_type = LinearAllocs::hipMalloc;

--- a/projects/hip-tests/catch/performance/memcpy/memcpy_performance_common.hh
+++ b/projects/hip-tests/catch/performance/memcpy/memcpy_performance_common.hh
@@ -80,7 +80,8 @@ static std::tuple<int, int> GetDeviceIds(bool enable_peer_access) {
     int can_access_peer = 0;
     HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, src_device, dst_device));
     if (!can_access_peer) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      return {-1, -1};
     }
     HIP_CHECK(hipDeviceEnablePeerAccess(dst_device, 0));
   } else {

--- a/projects/hip-tests/catch/performance/stream/hipMallocFromPoolAsync.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMallocFromPoolAsync.cc
@@ -60,7 +60,8 @@ static void RunBenchmark(const size_t array_size) {
  */
 HIP_TEST_CASE(Performance_hipMallocFromPoolAsync) {
   if (!AreMemPoolsSupported(0)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   size_t array_size = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(array_size);

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolCreate.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolCreate.cc
@@ -48,7 +48,8 @@ static void RunBenchmark() {
  */
 HIP_TEST_CASE(Performance_hipMemPoolCreate) {
   if (!AreMemPoolsSupported(0)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   RunBenchmark();
 }

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolDestroy.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolDestroy.cc
@@ -47,7 +47,8 @@ static void RunBenchmark() {
  */
 HIP_TEST_CASE(Performance_hipMemPoolDestroy) {
   if (!AreMemPoolsSupported(0)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   RunBenchmark();
 }

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolExportPointer.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolExportPointer.cc
@@ -60,7 +60,8 @@ static void RunBenchmark(const size_t array_size) {
  */
 HIP_TEST_CASE(Performance_hipMemPoolExportPointer) {
   if (!AreMemPoolsSupported(0)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   size_t array_size = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(array_size);

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolExportToShareableHandle.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolExportToShareableHandle.cc
@@ -54,7 +54,8 @@ static void RunBenchmark() {
  */
 HIP_TEST_CASE(Performance_hipMemPoolExportToShareableHandle) {
   if (!AreMemPoolsSupported(0)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   RunBenchmark();
 }

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolGetAccess.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolGetAccess.cc
@@ -50,7 +50,8 @@ static void RunBenchmark() {
  */
 HIP_TEST_CASE(Performance_hipMemPoolGetAccess) {
   if (!AreMemPoolsSupported(0)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   RunBenchmark();
 }

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolGetAttribute.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolGetAttribute.cc
@@ -56,7 +56,8 @@ static void RunBenchmark(const hipMemPoolAttr attribute) {
  */
 HIP_TEST_CASE(Performance_hipMemPoolGetAttribute) {
   if (!AreMemPoolsSupported(0)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   hipMemPoolAttr attribute =
       GENERATE(hipMemPoolAttrReleaseThreshold, hipMemPoolReuseFollowEventDependencies,

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolImportFromShareableHandle.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolImportFromShareableHandle.cc
@@ -62,7 +62,8 @@ static void RunBenchmark() {
  */
 HIP_TEST_CASE(Performance_hipMemPoolImportFromShareableHandle) {
   if (!AreMemPoolsSupported(0)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   RunBenchmark();
 }

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolImportPointer.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolImportPointer.cc
@@ -66,7 +66,8 @@ static void RunBenchmark(const size_t array_size) {
  */
 HIP_TEST_CASE(Performance_hipMemPoolImportPointer) {
   if (!AreMemPoolsSupported(0)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   size_t array_size = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(array_size);

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolSetAccess.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolSetAccess.cc
@@ -50,7 +50,8 @@ static void RunBenchmark() {
  */
 HIP_TEST_CASE(Performance_hipMemPoolSetAccess) {
   if (!AreMemPoolsSupported(0)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   RunBenchmark();
 }

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolSetAttribute.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolSetAttribute.cc
@@ -64,7 +64,8 @@ static void RunBenchmark(const hipMemPoolAttr attribute) {
  */
 HIP_TEST_CASE(Performance_hipMemPoolSetAttribute) {
   if (!AreMemPoolsSupported(0)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   hipMemPoolAttr attribute =
       GENERATE(hipMemPoolAttrReleaseThreshold, hipMemPoolReuseFollowEventDependencies,

--- a/projects/hip-tests/catch/performance/stream/hipMemPoolTrimTo.cc
+++ b/projects/hip-tests/catch/performance/stream/hipMemPoolTrimTo.cc
@@ -53,7 +53,8 @@ static void RunBenchmark(const size_t min_bytes_to_hold) {
  */
 HIP_TEST_CASE(Performance_hipMemPoolTrimTo) {
   if (!AreMemPoolsSupported(0)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   size_t min_bytes_to_hold = GENERATE(4_KB, 4_MB, 16_MB);
   RunBenchmark(min_bytes_to_hold);

--- a/projects/hip-tests/catch/performance/stream/hipStreamWaitValue.cc
+++ b/projects/hip-tests/catch/performance/stream/hipStreamWaitValue.cc
@@ -111,9 +111,10 @@ static void RunBenchmark(const size_t array_size, unsigned int flag) {
 HIP_TEST_CASE(Performance_hipStreamWaitValue32) {
 #if HT_AMD
   if (!IsStreamWaitValueSupported(0)) {
-    HIP_SKIP_TEST(
+    HipTest::HIP_SKIP_TEST(
         "GPU 0 doesn't support hipStreamWaitValue32() function. "
-        "Hence skipping the testing with Pass result.");
+        "Hence skipping the testing with Pass result.\n");
+    return;
   }
 
   size_t array_size = GENERATE(4_KB, 4_MB, 16_MB);
@@ -146,9 +147,10 @@ HIP_TEST_CASE(Performance_hipStreamWaitValue32) {
  */
 HIP_TEST_CASE(Performance_hipStreamWaitValue64) {
   if (!IsStreamWaitValueSupported(0)) {
-    HIP_SKIP_TEST(
+    HipTest::HIP_SKIP_TEST(
         "GPU 0 doesn't support hipStreamWaitValue64() function. "
-        "Hence skipping the testing with Pass result.");
+        "Hence skipping the testing with Pass result.\n");
+    return;
   }
   size_t array_size = GENERATE(4_KB, 4_MB, 16_MB);
   unsigned int flag = GENERATE(hipStreamWaitValueGte, hipStreamWaitValueEq, hipStreamWaitValueAnd,

--- a/projects/hip-tests/catch/performance/stream/hipStreamWriteValue.cc
+++ b/projects/hip-tests/catch/performance/stream/hipStreamWriteValue.cc
@@ -99,9 +99,10 @@ HIP_TEST_CASE(Performance_hipStreamWriteValue32) {
 HIP_TEST_CASE(Performance_hipStreamWriteValue64) {
 #if HT_NVIDIA
   if (!IsStreamWriteValueSupported(0)) {
-    HIP_SKIP_TEST(
+    HipTest::HIP_SKIP_TEST(
         "GPU 0 doesn't support hipStreamWriteValue64() function. "
-        "Hence skipping the testing with Pass result.");
+        "Hence skipping the testing with Pass result.\n");
+    return;
   }
 #endif
   size_t array_size = GENERATE(4_KB, 4_MB, 16_MB);

--- a/projects/hip-tests/catch/perftests/compute/hipPerfDotProduct.cc
+++ b/projects/hip-tests/catch/perftests/compute/hipPerfDotProduct.cc
@@ -223,7 +223,8 @@ HIP_TEST_CASE(Perf_hipPerfDotProduct) {
   HIP_CHECK(hipGetDeviceCount(&nGpu));
 
   if (nGpu < 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    return;
   }
   hipDeviceProp_t props;
   HIP_CHECK(hipSetDevice(p_gpuDevice));

--- a/projects/hip-tests/catch/perftests/compute/hipPerfMandelbrot.cc
+++ b/projects/hip-tests/catch/perftests/compute/hipPerfMandelbrot.cc
@@ -355,7 +355,8 @@ void hipPerfMandelBrot::open(int deviceId) {
   int nGpu = 0;
   HIP_CHECK(hipGetDeviceCount(&nGpu));
   if (nGpu < 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    return;
   }
   HIP_CHECK(hipSetDevice(deviceId));
   hipDeviceProp_t props;

--- a/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopyInterGpuPerformance.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopyInterGpuPerformance.cc
@@ -41,7 +41,8 @@ HIP_TEST_CASE(Perf_PerfBufferCopySpeedAll2All_Inter_GPU) {
   int nGpus = 0;
   HIP_CHECK(hipGetDeviceCount(&nGpus));
   if (nGpus < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   int** ArrayOfDevicePointers = reinterpret_cast<int**>(malloc(nGpus * sizeof(int*)));
 

--- a/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopyRectSpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopyRectSpeed.cc
@@ -208,7 +208,7 @@ HIP_TEST_CASE(Perf_hipPerfBufferCopyRectSpeed_test) {
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
   if (numDevices <= 0) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   } else {
     int deviceId = 0;
     HIP_CHECK(hipSetDevice(deviceId));

--- a/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeed.cc
@@ -373,7 +373,7 @@ HIP_TEST_CASE(Perf_hipPerfBufferCopySpeed_test) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices <= 0) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   } else {
     int deviceId = 0;
     HIP_CHECK(hipSetDevice(deviceId));

--- a/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeedAll2All.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeedAll2All.cc
@@ -85,7 +85,8 @@ static void testCopyPerf(bool toRemote, bool kernelCopy, bool onOneGpu, DEV_MEM_
   unsigned int blocks = 16;  // DEBUG_CLR_LIMIT_BLIT_WG
   HIP_CHECK(hipGetDeviceCount(&nGpus));
   if (nGpus < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 #if 0
   if (kernelCopy) {

--- a/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeedP2P.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeedP2P.cc
@@ -120,7 +120,8 @@ static void testP2PUniDirMemPerf(const int iterations, const TIMING_MODE timingM
   int gpuCount = 0;
   HIP_CHECK(hipGetDeviceCount(&gpuCount));
   if (gpuCount < 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    return;
   }
   vector<double> timeMs(gpuCount * gpuCount, 0.);
   vector<double> bandWidth(gpuCount * gpuCount, 0.);
@@ -262,7 +263,8 @@ static void testP2PBiDirMemPerf(const int iterations, const bool useHipMemcpyAsy
   int gpuCount = 0;
   HIP_CHECK(hipGetDeviceCount(&gpuCount));
   if (gpuCount < 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    return;
   }
   vector<double> timeMs(gpuCount * gpuCount, 0.);
   vector<double> bandWidth(gpuCount * gpuCount, 0.);

--- a/projects/hip-tests/catch/perftests/memory/hipPerfDevMemReadSpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfDevMemReadSpeed.cc
@@ -133,7 +133,7 @@ HIP_TEST_CASE(Perf_hipPerfDevMemReadSpeed_test) {
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
   if (numDevices <= 0) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   } else {
     REQUIRE(true == hipPerfDevMemReadSpeed_test());
   }

--- a/projects/hip-tests/catch/perftests/memory/hipPerfDevMemWriteSpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfDevMemWriteSpeed.cc
@@ -125,7 +125,7 @@ HIP_TEST_CASE(Perf_hipPerfDevMemWriteSpeed_test) {
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
   if (numDevices <= 0) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   } else {
     REQUIRE(true == hipPerfDevMemWriteSpeed_test());
   }

--- a/projects/hip-tests/catch/perftests/memory/hipPerfHostNumaAlloc.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfHostNumaAlloc.cc
@@ -138,7 +138,8 @@ HIP_TEST_CASE(Perf_hipPerfHostNumaAlloc_test) {
   CONSOLE_PRINT("Cpu count %d, Gpu count %d, page_size %d\n", cpuCount, gpuCount, page_size);
 
   if (cpuCount < 0 || gpuCount < 0) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    return;
   }
 
   REQUIRE(true == runTest(cpuCount, gpuCount, hipHostMallocDefault | hipHostMallocNumaUser,

--- a/projects/hip-tests/catch/perftests/memory/hipPerfHostNumaAllocWin.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfHostNumaAllocWin.cc
@@ -292,7 +292,8 @@ HIP_TEST_CASE(Perf_hipPerfHostNumaAlloc_test_preferred_host_numa_node_on_each_GP
   int numaNode = -1;
   HIP_CHECK(hipDeviceGetAttribute(&numaNode, hipDeviceAttributeHostNumaId, 0));
   if (numaNode == -1) {
-    HIP_SKIP_TEST("host NUMA is not supported.");
+    HipTest::HIP_SKIP_TEST("host NUMA is not supported.");
+    return;
   }
   HIP_CHECK(hipSetDevice(0));
   // In windows, it is the same with / without hipHostMallocNumaUser

--- a/projects/hip-tests/catch/perftests/memory/hipPerfMemMallocCpyFree.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfMemMallocCpyFree.cc
@@ -123,7 +123,7 @@ HIP_TEST_CASE(Perf_hipPerfMemMallocCpyFree_test) {
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
   if (numDevices <= 0) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   } else {
     REQUIRE(true == hipPerfMemMallocCpyFree_test());
   }

--- a/projects/hip-tests/catch/perftests/memory/hipPerfMemcpy.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfMemcpy.cc
@@ -200,7 +200,7 @@ HIP_TEST_CASE(Perf_hipPerfMemcpy_test) {
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
   if (numDevices <= 0) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   } else {
     int deviceId = 0;
     HIP_CHECK(hipSetDevice(deviceId));

--- a/projects/hip-tests/catch/perftests/memory/hipPerfMempool.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfMempool.cc
@@ -55,7 +55,8 @@ HIP_TEST_CASE(Perf_MempoolManager_hipMallocAsync_hipFreeAsync) {
   size_t free = 0, total = 0;
   HIP_CHECK(hipMemGetInfo(&free, &total));
   if (free < 30_GB) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNotEnoughFreeGpuMemory);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNotEnoughFreeGpuMemory);
+    return;
   }
 
   hipMemPool_t pool;

--- a/projects/hip-tests/catch/perftests/memory/hipPerfSharedMemReadSpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfSharedMemReadSpeed.cc
@@ -238,7 +238,7 @@ HIP_TEST_CASE(Perf_hipPerfSharedMemReadSpeed_test) {
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
   if (numDevices <= 0) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   } else {
     REQUIRE(true == hipPerfSharedMemReadSpeed_test());
   }

--- a/projects/hip-tests/catch/perftests/stream/hipPerfDeviceConcurrency.cc
+++ b/projects/hip-tests/catch/perftests/stream/hipPerfDeviceConcurrency.cc
@@ -79,7 +79,8 @@ void hipPerfDeviceConcurrency::open(void) {
   HIP_CHECK(hipGetDeviceCount(&nGpu));
   setNumGpus(nGpu);
   if (nGpu < 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    return;
   }
 }
 

--- a/projects/hip-tests/catch/perftests/stream/hipPerfStreamConcurrency.cc
+++ b/projects/hip-tests/catch/perftests/stream/hipPerfStreamConcurrency.cc
@@ -199,7 +199,8 @@ bool hipPerfStreamConcurrency::open(int deviceId) {
   int nGpu = 0;
   HIP_CHECK(hipGetDeviceCount(&nGpu));
   if (nGpu < 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    return false;
   }
 
   HIP_CHECK(hipSetDevice(deviceId));

--- a/projects/hip-tests/catch/perftests/stream/hipPerfStreamCreateCopyDestroy.cc
+++ b/projects/hip-tests/catch/perftests/stream/hipPerfStreamCreateCopyDestroy.cc
@@ -44,7 +44,8 @@ bool hipPerfStreamCreateCopyDestroy::open(int deviceId) {
   int nGpu = 0;
   HIP_CHECK(hipGetDeviceCount(&nGpu));
   if (nGpu < 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    return false;
   }
   HIP_CHECK(hipSetDevice(deviceId));
   hipDeviceProp_t props;

--- a/projects/hip-tests/catch/perftests/vmm/hipPerfVMMAlloc.cc
+++ b/projects/hip-tests/catch/perftests/vmm/hipPerfVMMAlloc.cc
@@ -276,7 +276,7 @@ HIP_TEST_CASE(Perf_hipPerfVMMAllocSpeed_test) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices <= 0) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   } else {
     // Test on Primary Device first
     int deviceId = 0;

--- a/projects/hip-tests/catch/stress/memory/hipHmmOvrSubscriptionTst.cc
+++ b/projects/hip-tests/catch/stress/memory/hipHmmOvrSubscriptionTst.cc
@@ -93,6 +93,6 @@ HIP_TEST_CASE(Stress_HMM_OverSubscriptionTst) {
     HIP_CHECK_THREAD_FINALIZE();
     REQUIRE(proc.wait() == 0);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
   }
 }

--- a/projects/hip-tests/catch/stress/memory/hipHostMallocStress.cc
+++ b/projects/hip-tests/catch/stress/memory/hipHostMallocStress.cc
@@ -66,7 +66,7 @@ HIP_TEST_CASE(Stress_hipHostMalloc_MaxAllocation_AllGpu) {
       HIP_CHECK(hipMemset((A + allocsize - 1 - samplesize), val, samplesize));
       HIP_CHECK(hipHostFree(A));
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kNotEnoughFreeHostMemory);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNotEnoughFreeHostMemory);
     }
   }
 }

--- a/projects/hip-tests/catch/stress/memory/hipHostRegisterStress.cc
+++ b/projects/hip-tests/catch/stress/memory/hipHostRegisterStress.cc
@@ -45,7 +45,8 @@ HIP_TEST_CASE(Stress_hipHostRegister_Oversubscription) {
   std::string arch = prop.gcnArchName;
 #if HT_AMD
   if (std::string::npos == arch.find("xnack+")) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
+    return;
   }
 #endif
   size_t maxGpuMem = 0, availableMem = 0;
@@ -67,7 +68,8 @@ HIP_TEST_CASE(Stress_hipHostRegister_Oversubscription) {
   INFO("Free Host Memory = " << hostMemFree);
   // Ensure that allocsize < hostMemFree
   if (allocsize >= hostMemFree) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNotEnoughFreeHostMemory);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNotEnoughFreeHostMemory);
+    return;
   }
   uint8_t* A = reinterpret_cast<uint8_t*>(malloc(allocsize));
   uint8_t* ptr;

--- a/projects/hip-tests/catch/stress/memory/hipMallocManagedStress.cc
+++ b/projects/hip-tests/catch/stress/memory/hipMallocManagedStress.cc
@@ -172,7 +172,7 @@ HIP_TEST_CASE(Stress_hipMallocManaged_MultiSize) {
     }
     HIP_CHECK(hipStreamDestroy(strm));
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -215,7 +215,7 @@ HIP_TEST_CASE(Stress_hipMallocManaged_KrnlWth2MemTypes) {
     delete[] Hptr;
     REQUIRE(IfTestPassed);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -228,7 +228,7 @@ HIP_TEST_CASE(Stress_hipMallocManaged_MultiKrnlHmmAccess) {
     int InitVal = 123, NumElms = (1024 * 1024);
     LaunchKrnl4(NumElms, InitVal);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -308,6 +308,6 @@ HIP_TEST_CASE(Stress_hipMallocManaged_ExtremeSizes) {
     }
     REQUIRE(IfTestPassed);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }

--- a/projects/hip-tests/catch/stress/memory/hipMemPrftchAsyncStressTst.cc
+++ b/projects/hip-tests/catch/stress/memory/hipMemPrftchAsyncStressTst.cc
@@ -116,6 +116,6 @@ HIP_TEST_CASE(Stress_hipMemPrefetchAsyncOneToAll) {
     // Releasing the resources in case all the scenarios passed
     HIP_CHECK(hipFree(Hmm1));
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }

--- a/projects/hip-tests/catch/stress/printf/Stress_printf_ComplexKernels.cc
+++ b/projects/hip-tests/catch/stress/printf/Stress_printf_ComplexKernels.cc
@@ -398,7 +398,7 @@ HIP_TEST_CASE(Stress_printf_ComplexKernelMultStream) {
   REQUIRE(TestPassed);
   printf("Test - Stress_printf_ComplexKernelMultStream completed \n");
 #else
-  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }
 
@@ -414,7 +414,8 @@ HIP_TEST_CASE(Stress_printf_ComplexKernelMultStreamMultGpu) {
   int numOfGPUs = 0;
   HIP_CHECK(hipGetDeviceCount(&numOfGPUs));
   if (numOfGPUs < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   // num_blocks is calculated using an approximate formula to arrive at
   // the required print data quantity. CONST_WEIGHTING_FACT1 and
@@ -428,6 +429,6 @@ HIP_TEST_CASE(Stress_printf_ComplexKernelMultStreamMultGpu) {
   REQUIRE(TestPassed);
   printf("Test - Stress_printf_ComplexKernelMultStreamMultGpu end \n");
 #else
-  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }

--- a/projects/hip-tests/catch/stress/printf/Stress_printf_SimpleKernels.cc
+++ b/projects/hip-tests/catch/stress/printf/Stress_printf_SimpleKernels.cc
@@ -588,7 +588,7 @@ HIP_TEST_CASE(Stress_printf_ConstStr) {
       hipPrintfStressTest::test_printf_conststr(num_blocks, threads_per_block, print_limit);
   REQUIRE(TestPassed);
 #else
-  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }
 
@@ -605,7 +605,7 @@ HIP_TEST_CASE(Stress_printf_IfElseConditionalStr) {
                                                                    print_limit);
   REQUIRE(TestPassed);
 #else
-  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }
 
@@ -622,7 +622,7 @@ HIP_TEST_CASE(Stress_printf_IfConditionalStr) {
                                                                       print_limit);
   REQUIRE(TestPassed);
 #else
-  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }
 
@@ -638,7 +638,7 @@ HIP_TEST_CASE(Stress_printf_VariableStr) {
       hipPrintfStressTest::EmpiricalValues1);
   REQUIRE(TestPassed);
 #else
-  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }
 
@@ -654,7 +654,7 @@ HIP_TEST_CASE(Stress_printf_DependentCalc) {
                                                       hipPrintfStressTest::EmpiricalValues2);
   REQUIRE(TestPassed);
 #else
-  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }
 
@@ -670,7 +670,7 @@ HIP_TEST_CASE(Stress_printf_DecimalStr) {
   TestPassed = hipPrintfStressTest::test_decimal_str(num_blocks, threads_per_block, print_limit);
   REQUIRE(TestPassed);
 #else
-  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }
 
@@ -686,7 +686,7 @@ HIP_TEST_CASE(Stress_printf_SharedMem) {
   TestPassed = hipPrintfStressTest::test_shared_mem(num_blocks, threads_per_block, print_limit);
   REQUIRE(TestPassed);
 #else
-  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }
 
@@ -701,7 +701,7 @@ HIP_TEST_CASE(Stress_printf_SynchronizedPrintf) {
   TestPassed = hipPrintfStressTest::test_synchronized_printf(1, threads_per_block, print_limit);
   REQUIRE(TestPassed);
 #else
-  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }
 
@@ -717,6 +717,6 @@ HIP_TEST_CASE(Stress_printf_AtomicCalc) {
       hipPrintfStressTest::EmpiricalValues2);
   REQUIRE(TestPassed);
 #else
-  HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiresLinux);
 #endif
 }

--- a/projects/hip-tests/catch/stress/printf/printf_common.h
+++ b/projects/hip-tests/catch/stress/printf/printf_common.h
@@ -35,9 +35,10 @@ static inline bool gpuCompositorLikelyActive() {
 
 #define SKIP_IF_GPU_COMPOSITOR_ACTIVE()                                                         \
   if (gpuCompositorLikelyActive()) {                                                            \
-    HIP_SKIP_TEST(                                                                              \
+    HipTest::HIP_SKIP_TEST(                                                                     \
         "likely running under a GPU compositor; long printf kernels may trigger a GPU reset. "  \
         "Run from a VT (chvt 3) or over SSH, or set HIP_PRINTF_STRESS_FORCE_RUN=1 to bypass."); \
+    return;                                                                                     \
   }
 
 #ifdef __linux__

--- a/projects/hip-tests/catch/stress/stream/streamEnqueue.cc
+++ b/projects/hip-tests/catch/stress/stream/streamEnqueue.cc
@@ -115,7 +115,8 @@ HIP_TEST_CASE(Stress_StreamEnqueue_DifferentThreads_MultiGPU) {
 
   // Skip the test if devices less than 2
   if (deviceCount <= 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   constexpr size_t streamPerGPU{3};  // Stream per gpu

--- a/projects/hip-tests/catch/unit/assertion/assert.cc
+++ b/projects/hip-tests/catch/unit/assertion/assert.cc
@@ -63,12 +63,15 @@ bool isAbortOnErrorEnabled() {
 HIP_TEST_CASE(Unit_Assert_Positive_Basic_KernelPass) {
 
 #ifdef NDEBUG
-  HIP_SKIP_TEST(HipTest::SkipReason::kAssertionsDisabled);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kAssertionsDisabled);
+  return;
 #endif
 
 #if HT_AMD
   if (isAbortOnErrorEnabled()) {
-    HIP_SKIP_TEST("Test incompatible with aborts enabled through HIP_SKIP_ABORT_ON_GPU_ERROR.");
+    HipTest::HIP_SKIP_TEST(
+        "Test incompatible with aborts enabled through HIP_SKIP_ABORT_ON_GPU_ERROR.");
+    return;
   }
 #endif
 
@@ -102,12 +105,15 @@ HIP_TEST_CASE(Unit_Assert_Positive_Basic_KernelPass) {
 HIP_TEST_CASE(Unit_Assert_Positive_Basic_KernelFail) {
 
 #ifdef NDEBUG
-  HIP_SKIP_TEST(HipTest::SkipReason::kAssertionsDisabled);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kAssertionsDisabled);
+  return;
 #endif
 
 #if HT_AMD
   if (isAbortOnErrorEnabled()) {
-    HIP_SKIP_TEST("Test incompatible with aborts enabled through HIP_SKIP_ABORT_ON_GPU_ERROR.");
+    HipTest::HIP_SKIP_TEST(
+        "Test incompatible with aborts enabled through HIP_SKIP_ABORT_ON_GPU_ERROR.");
+    return;
   }
 #endif
 

--- a/projects/hip-tests/catch/unit/atomics/arithmetic_common.hh
+++ b/projects/hip-tests/catch/unit/atomics/arithmetic_common.hh
@@ -518,7 +518,8 @@ void SingleDeviceMultipleKernelTest(const unsigned int kernel_count, const unsig
   int concurrent_kernels = 0;
   HIP_CHECK(hipDeviceGetAttribute(&concurrent_kernels, hipDeviceAttributeConcurrentKernels, 0));
   if (!concurrent_kernels) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
+    return;
   }
 
   TestParams params;
@@ -548,12 +549,14 @@ void MultipleDeviceMultipleKernelAndHostTest(const unsigned int num_devices,
                                              const unsigned int host_thread_count = 0u) {
   if (num_devices > 1) {
     if (HipTest::getDeviceCount() < num_devices) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
+      return;
     }
   }
 
   if (!HipTest::checkConcurrentKernels(num_devices)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
+    return;
   }
 
   TestParams params;

--- a/projects/hip-tests/catch/unit/atomics/atomicExch_common.hh
+++ b/projects/hip-tests/catch/unit/atomics/atomicExch_common.hh
@@ -342,7 +342,8 @@ void AtomicExchSingleDeviceMultipleKernelTest(const unsigned int kernel_count,
   int concurrent_kernels = 0;
   HIP_CHECK(hipDeviceGetAttribute(&concurrent_kernels, hipDeviceAttributeConcurrentKernels, 0));
   if (!concurrent_kernels) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
+    return;
   }
 
   AtomicExchParams params;
@@ -371,12 +372,14 @@ void AtomicExchMultipleDeviceMultipleKernelAndHostTest(const unsigned int num_de
                                                        const unsigned int host_thread_count = 0u) {
   if (num_devices > 1) {
     if (HipTest::getDeviceCount() < num_devices) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
+      return;
     }
   }
 
   if (!HipTest::checkConcurrentKernels(num_devices)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
+    return;
   }
 
   AtomicExchParams params;

--- a/projects/hip-tests/catch/unit/atomics/bitwise_common.hh
+++ b/projects/hip-tests/catch/unit/atomics/bitwise_common.hh
@@ -345,7 +345,8 @@ void SingleDeviceMultipleKernelTest(const unsigned int kernel_count, const unsig
   int concurrent_kernels = 0;
   HIP_CHECK(hipDeviceGetAttribute(&concurrent_kernels, hipDeviceAttributeConcurrentKernels, 0));
   if (!concurrent_kernels) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
+    return;
   }
 
   TestParams params;
@@ -372,12 +373,14 @@ void MultipleDeviceMultipleKernelTest(const unsigned int num_devices,
                                       const unsigned int pitch) {
   if (num_devices > 1) {
     if (HipTest::getDeviceCount() < num_devices) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
+      return;
     }
   }
 
   if (!HipTest::checkConcurrentKernels(num_devices)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
+    return;
   }
 
   TestParams params;

--- a/projects/hip-tests/catch/unit/atomics/min_max_common.hh
+++ b/projects/hip-tests/catch/unit/atomics/min_max_common.hh
@@ -366,7 +366,8 @@ void SingleDeviceMultipleKernelTest(const unsigned int kernel_count, const unsig
   int concurrent_kernels = 0;
   HIP_CHECK(hipDeviceGetAttribute(&concurrent_kernels, hipDeviceAttributeConcurrentKernels, 0));
   if (!concurrent_kernels) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
+    return;
   }
 
   TestParams params;
@@ -393,11 +394,13 @@ void MultipleDeviceMultipleKernelTest(const unsigned int num_devices,
                                       const unsigned int pitch) {
   if (num_devices > 1) {
     if (HipTest::getDeviceCount() < num_devices) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kRequiredDeviceCountNotMet);
+      return;
     }
   }
   if (!HipTest::checkConcurrentKernels(num_devices)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kConcurrentKernelExecutionUnsupported);
+    return;
   }
   TestParams params;
   params.num_devices = num_devices;

--- a/projects/hip-tests/catch/unit/clock/hipClockCheck.cc
+++ b/projects/hip-tests/catch/unit/clock/hipClockCheck.cc
@@ -133,7 +133,8 @@ void execute_clock_kernels(void (*kernel)(long long*, long long*, float*, float*
 
 HIP_TEST_CASE(Unit_hipClock64_Positive_Basic) {
   if (IsGfx11()) {
-    HIP_SKIP_TEST("clock64() issue on gfx11 devices.");
+    HipTest::HIP_SKIP_TEST("clock64() issue on gfx11 devices.");
+    return;
   }
 
   execute_clock_kernels(reduce_c64);
@@ -154,7 +155,8 @@ HIP_TEST_CASE(Unit_hipClock64_Positive_Basic) {
  */
 HIP_TEST_CASE(Unit_hipClock_Positive_Basic) {
   if (IsGfx11()) {
-    HIP_SKIP_TEST("clock() issue on gfx11 devices.");
+    HipTest::HIP_SKIP_TEST("clock() issue on gfx11 devices.");
+    return;
   }
 
   execute_clock_kernels(reduce_c);

--- a/projects/hip-tests/catch/unit/compiler/hipSquareGenericTarget.cc
+++ b/projects/hip-tests/catch/unit/compiler/hipSquareGenericTarget.cc
@@ -24,7 +24,8 @@ HIP_TEST_CASE(Unit_test_generic_target_in_compressed_fatbin) {
 HIP_TEST_CASE(Unit_test_generic_target_in_regular_fatbin) {
 #endif
   if (!isGenericTargetSupported()) {
-    HIP_SKIP_TEST("generic target is not supported on this device.");
+    HipTest::HIP_SKIP_TEST("generic target is not supported on this device.");
+    return;
   }
   float *A_d, *C_d;
   float *A_h, *C_h;

--- a/projects/hip-tests/catch/unit/cooperativeGrps/grid_group.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/grid_group.cc
@@ -107,7 +107,8 @@ HIP_TEST_CASE(Unit_Grid_Group_Getters_Positive_Basic) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   const auto blocks = GenerateBlockDimensions();
@@ -186,7 +187,8 @@ HIP_TEST_CASE(Unit_Grid_Group_Getters_Via_Non_Member_Functions_Positive_Basic) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   const auto blocks = GenerateBlockDimensions();
@@ -254,7 +256,8 @@ HIP_TEST_CASE(Unit_Grid_Group_Sync_Positive_Basic) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   auto loops = GENERATE(2, 4, 8, 16);

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGGridGroupType_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGGridGroupType_old.cc
@@ -316,7 +316,8 @@ HIP_TEST_CASE(Unit_hipCGGridGroupType_Basic) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   void* kernel_func;
@@ -361,7 +362,8 @@ HIP_TEST_CASE(Unit_hipCGGridGroupType_DataSharing) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   int loops = GENERATE(1, 2, 3, 4);
@@ -440,7 +442,8 @@ HIP_TEST_CASE(Unit_hipCGGridGroupType_Barrier) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   uint32_t loops = GENERATE(1, 2, 3, 4);

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGMultiGridGroupType_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGMultiGridGroupType_old.cc
@@ -374,7 +374,8 @@ HIP_TEST_CASE(Unit_hipCGMultiGridGroupType_Basic) {
   for (int i = 0; i < num_devices; i++) {
     HIP_CHECK(hipGetDeviceProperties(&device_properties, i));
     if (!device_properties.cooperativeMultiDeviceLaunch) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+      return;
     }
     max_threads_per_blk = min(max_threads_per_blk, device_properties.maxThreadsPerBlock);
   }
@@ -417,14 +418,16 @@ HIP_TEST_CASE(Unit_hipCGMultiGridGroupType_Barrier) {
 
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   if (num_devices < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   std::vector<hipDeviceProp_t> device_properties(num_devices);
   for (int i = 0; i < num_devices; i++) {
     HIP_CHECK(hipGetDeviceProperties(&device_properties[i], i));
     if (!device_properties[i].cooperativeMultiDeviceLaunch) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+      return;
     }
   }
 

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGThreadBlockTileTypeShfl_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGThreadBlockTileTypeShfl_old.cc
@@ -169,7 +169,8 @@ HIP_TEST_CASE(Unit_hipCGThreadBlockTileType_Shfl) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   TiledGroupShflTests shfl_test = GENERATE(

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGThreadBlockType_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGThreadBlockType_old.cc
@@ -183,7 +183,8 @@ HIP_TEST_CASE(Unit_hipCGThreadBlockType) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   ThreadBlockTypeTests test_type = ThreadBlockTypeTests::basicApi;

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGTiledPartitionType_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGTiledPartitionType_old.cc
@@ -331,7 +331,8 @@ HIP_TEST_CASE(Unit_hipCGThreadBlockTileType) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   bool use_global_mem = GENERATE(true, false);

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipLaunchCooperativeKernelMultiDevice_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipLaunchCooperativeKernelMultiDevice_old.cc
@@ -134,7 +134,8 @@ HIP_TEST_CASE(Unit_hipLaunchCooperativeKernelMultiDevice_Basic) {
     // Calculate the device occupancy to know how many blocks can be run concurrently
     HIP_CHECK(hipGetDeviceProperties(&device_properties[i], 0));
     if (!device_properties[i].cooperativeMultiDeviceLaunch) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+      return;
     }
   }
 

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipLaunchCooperativeKernel_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipLaunchCooperativeKernel_old.cc
@@ -55,7 +55,8 @@ HIP_TEST_CASE(Unit_hipLaunchCooperativeKernel_Basic) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.cooperativeLaunch) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   size_t buffer_size = kBufferLen * sizeof(int);

--- a/projects/hip-tests/catch/unit/cooperativeGrps/multi_grid_group.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/multi_grid_group.cc
@@ -152,7 +152,8 @@ HIP_TEST_CASE(Unit_Multi_Grid_Group_Getters_Positive_Basic) {
   for (int i = 0; i < num_devices; i++) {
     HIP_CHECK(hipGetDeviceProperties(&device_properties[i], i));
     if (!device_properties[i].cooperativeMultiDeviceLaunch) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+      return;
     }
   }
   const auto test_case = GENERATE(range(0, 20));
@@ -298,7 +299,8 @@ HIP_TEST_CASE(Unit_Multi_Grid_Group_Getters_Positive_Base_Type) {
   for (int i = 0; i < num_devices; i++) {
     HIP_CHECK(hipGetDeviceProperties(&device_properties[i], i));
     if (!device_properties[i].cooperativeMultiDeviceLaunch) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+      return;
     }
   }
 
@@ -419,7 +421,8 @@ HIP_TEST_CASE(Unit_Multi_Grid_Group_Getters_Positive_Non_Member_Functions) {
   for (int i = 0; i < num_devices; i++) {
     HIP_CHECK(hipGetDeviceProperties(&device_properties[i], i));
     if (!device_properties[i].cooperativeMultiDeviceLaunch) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+      return;
     }
   }
   const auto test_case = GENERATE(range(0, 20));
@@ -530,7 +533,8 @@ HIP_TEST_CASE(Unit_Multi_Grid_Group_Positive_Sync) {
   for (int i = 0; i < num_devices; i++) {
     HIP_CHECK(hipGetDeviceProperties(&device_properties[i], i));
     if (!device_properties[i].cooperativeMultiDeviceLaunch) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+      return;
     }
   }
   auto loops = GENERATE(2, 4, 8);

--- a/projects/hip-tests/catch/unit/device/hipDeviceAPUCheck.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceAPUCheck.cc
@@ -29,7 +29,8 @@ HIP_TEST_CASE(Unit_hipDeviceAPUCheck) {
   hipDeviceProp_t prop;
   HIP_CHECK(hipGetDeviceProperties(&prop, 0));
   if (!prop.integrated) {
-    HIP_SKIP_TEST("test requires integrated APU; discrete GPU detected.");
+    HipTest::HIP_SKIP_TEST("test requires integrated APU; discrete GPU detected.");
+    return;
   } else {
     std::cout << "This device is an APU" << std::endl;
   }

--- a/projects/hip-tests/catch/unit/device/hipDeviceCanAccessPeer.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceCanAccessPeer.cc
@@ -31,7 +31,8 @@ HIP_TEST_CASE(Unit_hipDeviceCanAccessPeer_positive) {
   int canAccessPeer = 0;
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   int dev = GENERATE(range(0, HipTest::getGeviceCount()));
@@ -74,7 +75,8 @@ HIP_TEST_CASE(Unit_hipDeviceCanAccessPeer_negative) {
   int canAccessPeer = 0;
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   SECTION("canAccessPeer is nullptr") {

--- a/projects/hip-tests/catch/unit/device/hipDeviceComputeCapability.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceComputeCapability.cc
@@ -60,7 +60,8 @@ HIP_TEST_CASE(Unit_hipDeviceComputeCapability_Negative) {
       REQUIRE_FALSE(hipDeviceComputeCapability(&major, &minor, numDevices) == hipSuccess);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    return;
   }
 }
 

--- a/projects/hip-tests/catch/unit/device/hipDeviceEnableDisablePeerAccess.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceEnableDisablePeerAccess.cc
@@ -34,7 +34,8 @@ HIP_TEST_CASE(Unit_hipDeviceEnableDisablePeerAccess_positive) {
   int canAccessPeer = 0;
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   int dev = GENERATE(range(0, HipTest::getGeviceCount()));
@@ -52,7 +53,8 @@ HIP_TEST_CASE(Unit_hipDeviceEnableDisablePeerAccess_positive) {
     HIP_CHECK(hipStreamDestroy(stream));
 
     if (canAccessPeer == 0) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      return;
     }
     HIP_CHECK(hipDeviceEnablePeerAccess(peerDev, 0));
     HIP_CHECK(hipDeviceDisablePeerAccess(peerDev));
@@ -80,7 +82,8 @@ HIP_TEST_CASE(Unit_hipDeviceEnableDisablePeerAccess_positive) {
 HIP_TEST_CASE(Unit_hipDeviceEnablePeerAccess_negative) {
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   SECTION("peerDeviceId is invalid") {
@@ -143,7 +146,8 @@ HIP_TEST_CASE(Unit_hipDeviceEnablePeerAccess_negative) {
 HIP_TEST_CASE(Unit_hipDeviceDisablePeerAccess_negative) {
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   SECTION("peerDeviceId is invalid") {
@@ -155,7 +159,8 @@ HIP_TEST_CASE(Unit_hipDeviceDisablePeerAccess_negative) {
     int canAccessPeer = 0;
     HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, 0, 1));
     if (canAccessPeer == 0) {
-      HIP_SKIP_TEST("Skipping because no P2P support between device 0 and 1");
+      HipTest::HIP_SKIP_TEST("Skipping because no P2P support between device 0 and 1");
+      return;
     }
     HIP_CHECK_ERROR(hipDeviceDisablePeerAccess(1), hipErrorPeerAccessNotEnabled);
   }

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetDefaultMemPool.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetDefaultMemPool.cc
@@ -33,7 +33,8 @@ HIP_TEST_CASE(Unit_hipDeviceGetDefaultMemPool_Positive_Basic) {
   HIP_CHECK(
       hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, device));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
 
   hipMemPool_t mem_pool;

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetName.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetName.cc
@@ -197,13 +197,15 @@ HIP_TEST_CASE(Unit_hipDeviceName_gcnArchName_And_rocm_agent_enumerator) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount <= 0) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    return;
   }
 
   FILE* fpipe;
   fpipe = popen("rocm_agent_enumerator", "r");
   if (fpipe == nullptr) {
-    HIP_SKIP_TEST("unable to create command file.");
+    HipTest::HIP_SKIP_TEST("unable to create command file.");
+    return;
   }
   char command_op[BUFFER_LEN];
   const char* defCpu = "gfx000";

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
@@ -467,7 +467,7 @@ HIP_TEST_CASE(Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES) {
     }
 #endif
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);  // NOLINT
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);  // NOLINT
   }
 }
 
@@ -521,6 +521,7 @@ void setEnv() {
     setenv("HIP_VISIBLE_DEVICES", uuidEnv.c_str(), 1);
   } else {
     tState = 2;
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);  // NOLINT
   }
 }
 /**
@@ -541,9 +542,6 @@ HIP_TEST_CASE(Unit_UUID_setEnv_Thread) {
   // Create Thread one
   std::thread t1(setEnv);
   t1.join();
-  if (tState == 2) {
-    HIP_SKIP_TEST("Skipping because this machine has total GPUs < 2");
-  }
   // Create Thread two
   std::thread t2(ChkUUID);
   t2.join();

--- a/projects/hip-tests/catch/unit/device/hipDeviceSetGetLimit.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceSetGetLimit.cc
@@ -246,9 +246,10 @@ HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_Negative) {
  */
 HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_SetMinAndMaxAsCurrent) {
   if (!isSetScratchLimitSupported()) {
-    HIP_SKIP_TEST(
+    HipTest::HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."
         " Only Mi300+ and Linux supports");
+    return;
   }
 
   size_t scratchLimitCurrent = 0;
@@ -285,9 +286,10 @@ HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_SetMinAndMaxAsCurrent) {
  */
 HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_DecreaseIncrease) {
   if (!isSetScratchLimitSupported()) {
-    HIP_SKIP_TEST(
+    HipTest::HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."
         " Only Mi300+ and Linux supports");
+    return;
   }
 
   // Get the current scratch
@@ -363,9 +365,10 @@ __global__ void addOneKernelUseScratch(int* arr) {
  */
 HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_SetBeforeKernelLaunch) {
   if (!isSetScratchLimitSupported()) {
-    HIP_SKIP_TEST(
+    HipTest::HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."
         " Only Mi300+ and Linux supports");
+    return;
   }
 
   hipStream_t stream;
@@ -447,13 +450,15 @@ HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_MultiDevice) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   if (!isSetScratchLimitSupported()) {
-    HIP_SKIP_TEST(
+    HipTest::HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."
         " Only Mi300+ and Linux supports");
+    return;
   }
 
   for (int deviceId = 0; deviceId < deviceCount; deviceId++) {
@@ -479,9 +484,10 @@ HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_MultiDevice) {
  */
 HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_InThread) {
   if (!isSetScratchLimitSupported()) {
-    HIP_SKIP_TEST(
+    HipTest::HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."
         " Only Mi300+ and Linux supports");
+    return;
   }
 
   std::thread threadObj(getMinMaxCurrentAndSetCurrent);
@@ -504,9 +510,10 @@ HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_InThread) {
  */
 HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_InChildProcess) {
   if (!isSetScratchLimitSupported()) {
-    HIP_SKIP_TEST(
+    HipTest::HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."
         " Only Mi300+ and Linux supports");
+    return;
   }
 
   hip::SpawnProc proc("hipDeviceSetGetScratchExe", true);
@@ -549,9 +556,10 @@ void getScratchCurrent(size_t checkValue) {
  */
 HIP_TEST_CASE(Unit_hipDeviceGetSetLimit_Scratch_SetGetThreads) {
   if (!isSetScratchLimitSupported()) {
-    HIP_SKIP_TEST(
+    HipTest::HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."
         " Only Mi300+ and Linux supports");
+    return;
   }
 
   size_t max = 0, orgCurrent = 0;

--- a/projects/hip-tests/catch/unit/device/hipDeviceSetGetMemPool.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceSetGetMemPool.cc
@@ -18,13 +18,15 @@
  * The memory pool must be local to the specified device.
  */
 
-static inline void CheckMemPoolSupport(const int device) {
+static inline bool CheckMemPoolSupport(const int device) {
   int mem_pool_support = 0;
   HIP_CHECK(
       hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, device));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return false;
   }
+  return true;
 }
 
 static inline hipMemPool_t CreateMemPool(const int device) {
@@ -57,7 +59,9 @@ static inline hipMemPool_t CreateMemPool(const int device) {
 HIP_TEST_CASE(Unit_hipDeviceSetMemPool_Positive_Basic) {
   const int device = GENERATE(range(0, HipTest::getDeviceCount()));
 
-  CheckMemPoolSupport(device);
+  if (!CheckMemPoolSupport(device)) {
+    return;
+  }
 
   hipMemPool_t mem_pool = CreateMemPool(device);
   HIP_CHECK(hipDeviceSetMemPool(device, mem_pool));
@@ -128,7 +132,9 @@ HIP_TEST_CASE(Unit_hipDeviceSetMemPool_Negative_Parameters) {
 HIP_TEST_CASE(Unit_hipDeviceGetMemPool_Positive_Default) {
   const int device = GENERATE(range(0, HipTest::getDeviceCount()));
 
-  CheckMemPoolSupport(device);
+  if (!CheckMemPoolSupport(device)) {
+    return;
+  }
 
   hipMemPool_t default_mem_pool;
   HIP_CHECK(hipDeviceGetDefaultMemPool(&default_mem_pool, device));
@@ -154,7 +160,9 @@ HIP_TEST_CASE(Unit_hipDeviceGetMemPool_Positive_Default) {
 HIP_TEST_CASE(Unit_hipDeviceGetMemPool_Positive_Basic) {
   const int device = GENERATE(range(0, HipTest::getDeviceCount()));
 
-  CheckMemPoolSupport(device);
+  if (!CheckMemPoolSupport(device)) {
+    return;
+  }
 
   hipMemPool_t mem_pool = CreateMemPool(device);
   HIP_CHECK(hipDeviceSetMemPool(device, mem_pool));
@@ -198,7 +206,9 @@ HIP_TEST_CASE(Unit_hipDeviceGetMemPool_Positive_Threaded) {
     hipMemPool_t mem_pool_;
   };
 
-  CheckMemPoolSupport(0);
+  if (!CheckMemPoolSupport(0)) {
+    return;
+  }
 
   HipDeviceGetMemPoolTest test;
   test.run();

--- a/projects/hip-tests/catch/unit/device/hipDeviceTotalMem.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceTotalMem.cc
@@ -105,7 +105,8 @@ HIP_TEST_CASE(Unit_hipDeviceTotalMem_ValidateTotalMem) {
 HIP_TEST_CASE(Unit_hipDeviceTotalMem_NonSelectedDevice) {
   auto deviceCount = HipTest::getDeviceCount();
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   for (int i = 1; i < deviceCount; i++) {

--- a/projects/hip-tests/catch/unit/device/hipExtGetLinkTypeAndHopCount.cc
+++ b/projects/hip-tests/catch/unit/device/hipExtGetLinkTypeAndHopCount.cc
@@ -40,7 +40,8 @@ HIP_TEST_CASE(Unit_hipExtGetLinkTypeAndHopCount_Positive_Basic) {
   int can_access_peer = 0;
   HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, device1, device2));
   if (!can_access_peer) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    return;
   }
 
   uint32_t link_type1 = -1, hop_count1 = -1;

--- a/projects/hip-tests/catch/unit/device/hipGetDeviceAttribute.cc
+++ b/projects/hip-tests/catch/unit/device/hipGetDeviceAttribute.cc
@@ -260,9 +260,10 @@ HIP_TEST_CASE(Unit_hipGetDeviceAttribute_hipDevAttrHostRegisterSupported) {
     HIP_CHECK(hipHostUnregister(x.get()));
     HIP_CHECK_ERROR(hipHostGetDevicePointer(&device_memory, x.get(), 0), hipErrorInvalidValue);
   } else {
-    HIP_SKIP_TEST(
+    HipTest::HIP_SKIP_TEST(
         "Skipping the test as GPU 0 doesn't support "
         "hipDeviceAttributeHostRegisterSupported attribute.\n");
+    return;
   }
 }
 

--- a/projects/hip-tests/catch/unit/device/hipGetDeviceCount.cc
+++ b/projects/hip-tests/catch/unit/device/hipGetDeviceCount.cc
@@ -46,7 +46,8 @@ HIP_TEST_CASE(Unit_hipGetDeviceCount_NegTst) {
 HIP_TEST_CASE(Unit_hipGetDeviceCount_HideDevices) {
   int deviceCount = HipTest::getDeviceCount();
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   for (int i = deviceCount; i >= 1; i--) {

--- a/projects/hip-tests/catch/unit/device/hipGetProcAddressDevMgmt.cc
+++ b/projects/hip-tests/catch/unit/device/hipGetProcAddressDevMgmt.cc
@@ -393,7 +393,8 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_PeerDeviceAccessAPIs) {
     int canAccessPeer_ptr = 0, canAccessPeer = 0, devCount = 0;
     HIP_CHECK(hipGetDeviceCount(&devCount));
     if (devCount < 2) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+      return;
     }
     // hipDeviceCanAccessPeer API
     int devId{};
@@ -417,7 +418,8 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_PeerDeviceAccessAPIs) {
         HIP_CHECK(hipSetDevice(dev));
         HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, dev, peerDev));
         if (canAccessPeer == 0) {
-          HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+          HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+          return;
         }
         HIP_CHECK(hipDeviceEnablePeerAccess(peerDev, 0));
         HIP_CHECK_ERROR(dyn_hipDeviceEnablePeerAccess_ptr(peerDev, 0),
@@ -428,13 +430,15 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_PeerDeviceAccessAPIs) {
     }
   }
 }
-void CheckMemPoolSupport(const int device) {
+bool CheckMemPoolSupport(const int device) {
   int mem_pool_support = 0;
   HIP_CHECK(
       hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, device));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return false;
   }
+  return true;
 }
 
 HIP_TEST_CASE(Unit_hipGetProcAddress_SetGetMemPoolAPIs) {
@@ -454,16 +458,23 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_SetGetMemPoolAPIs) {
   int devCount = 0;
   HIP_CHECK(hipGetDeviceCount(&devCount));
   if (devCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   // hipDeviceSetMemPool API
   hipMemPool_t getMemPool = nullptr, getMemPool_ptr = nullptr;
   HIP_CHECK(hipSetDevice(0));
-  CheckMemPoolSupport(0);
-  CreateMemPool(0, getMemPool);
+  if (!CheckMemPoolSupport(0)) {
+    return;
+  } else {
+    CreateMemPool(0, getMemPool);
+  }
   HIP_CHECK(hipSetDevice(1));
-  CheckMemPoolSupport(1);
-  CreateMemPool(1, getMemPool_ptr);
+  if (!CheckMemPoolSupport(1)) {
+    return;
+  } else {
+    CreateMemPool(1, getMemPool_ptr);
+  }
   HIP_CHECK(hipDeviceSetMemPool(0, getMemPool));
   HIP_CHECK(dyn_hipDeviceSetMemPool_ptr(1, getMemPool_ptr));
   REQUIRE(getMemPool != nullptr);

--- a/projects/hip-tests/catch/unit/device/hipIpcOpenMemHandle.cc
+++ b/projects/hip-tests/catch/unit/device/hipIpcOpenMemHandle.cc
@@ -202,7 +202,8 @@ HIP_TEST_CASE(Unit_hipIpcOpenMemHandle_Multiproc) {
 HIP_TEST_CASE(Unit_hipIpcOpenMemHandle_Multiproc_Child) {
   const char* hex = std::getenv("HIP_IPC_HANDLE");
   if (hex == nullptr || hex[0] == '\0') {
-    HIP_SKIP_TEST("This test must be launched by parent multiprocess test.");
+    HipTest::HIP_SKIP_TEST("This test must be launched by parent multiprocess test.");
+    return;
   }
 
   hipIpcMemHandle_t handle = hexToIpcHandle(hex);

--- a/projects/hip-tests/catch/unit/device/hipSetGetDevice.cc
+++ b/projects/hip-tests/catch/unit/device/hipSetGetDevice.cc
@@ -141,7 +141,8 @@ HIP_TEST_CASE(Unit_hipSetGetDevice_Positive_Threaded_Basic) {
   };
 
   if (HipTest::getDeviceCount() < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   HipSetGetDeviceThreadedTest test;

--- a/projects/hip-tests/catch/unit/device/hipSetValidDevices.cc
+++ b/projects/hip-tests/catch/unit/device/hipSetValidDevices.cc
@@ -145,7 +145,8 @@ HIP_TEST_CASE(Unit_hipSetValidDevices_Negative_Length_Lessthan_DeviceArrSize) {
 HIP_TEST_CASE(Unit_hipSetValidDevices_Positive_Basic) {
   int totalDevices = HipTest::getDeviceCount();
   if (totalDevices < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   // By default, without setting any device, validate that 0th device is being used
@@ -246,7 +247,8 @@ HIP_TEST_CASE(Unit_hipSetValidDevices_WithAllDevicesInSystem) {
 HIP_TEST_CASE(Unit_hipSetValidDevices_Positive_Cases) {
   int deviceCount = HipTest::getDeviceCount();
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   SECTION("length is 0 and deviceArr is nullPtr") {
@@ -301,7 +303,8 @@ HIP_TEST_CASE(Unit_hipSetValidDevices_Positive_Cases) {
 HIP_TEST_CASE(Unit_hipSetValidDevices_MultiProcess) {
   int deviceCount = HipTest::getDeviceCount();
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   auto pid = fork();
@@ -366,7 +369,8 @@ void launchFunction(int deviceId) {
 HIP_TEST_CASE(Unit_hipSetValidDevices_MultiThread) {
   int deviceCount = HipTest::getDeviceCount();
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   REQUIRE(getCurrentDevice() == 0);
@@ -407,12 +411,14 @@ HIP_TEST_CASE(Unit_hipSetValidDevices_MultiThread) {
 HIP_TEST_CASE(Unit_hipSetValidDevices_with_hipMemcpyPeer) {
   int deviceCount = HipTest::getDeviceCount();
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   int canAccessPeer = -1;
   HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, 1, 0));
   if (!canAccessPeer) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    return;
   }
   REQUIRE(canAccessPeer == 1);
   HIP_CHECK(hipDeviceEnablePeerAccess(1, 0));

--- a/projects/hip-tests/catch/unit/deviceLib/AtomicAdd_Coherent.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/AtomicAdd_Coherent.cc
@@ -149,7 +149,7 @@ TEST_CASE(Unit_AtomicAdd_Coherent) {
 
   if (CheckIfFeatSupported(CTFeatures::CT_FEATURE_FINEGRAIN_HWSUPPORT, gfxName)) {
     if (prop.canMapHostMemory != 1) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       SECTION("with -mno-unsafe-atomics flag") {
         SECTION("float") { runAtomicAddCoherentNoUnsafeFlagTest<float>(); }
@@ -167,6 +167,6 @@ TEST_CASE(Unit_AtomicAdd_Coherent) {
       }
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }

--- a/projects/hip-tests/catch/unit/deviceLib/AtomicAdd_NonCoherent.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/AtomicAdd_NonCoherent.cc
@@ -143,7 +143,7 @@ TEST_CASE(Unit_AtomicAdd_NonCoherent) {
 
   if (CheckIfFeatSupported(CTFeatures::CT_FEATURE_FINEGRAIN_HWSUPPORT, gfxName)) {
     if (prop.canMapHostMemory != 1) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       SECTION("with -mno-unsafe-atomics flag") {
         SECTION("float") { runAtomicAddNonCoherentNoUnsafeFlagTest<float>(); }
@@ -161,6 +161,6 @@ TEST_CASE(Unit_AtomicAdd_NonCoherent) {
       }
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }

--- a/projects/hip-tests/catch/unit/deviceLib/BuiltIns_fmax.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/BuiltIns_fmax.cc
@@ -69,7 +69,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomics_fmaxCoherentGlobalMem) {
   std::string gfxName(prop.gcnArchName);
   if ((gfxName == "gfx90a" || gfxName.find("gfx90a:")) == 0) {
     if (prop.canMapHostMemory != 1) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       double *A_h, *B_h;
       double* A_d;
@@ -97,7 +97,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomics_fmaxCoherentGlobalMem) {
           "Memory model feature is only supported for gfx90a, Hence"
           "skipping the testcase for this GPU ") +
           std::to_string(device);
-      HIP_SKIP_TEST(skip_gfx_msg.c_str());
+      HipTest::HIP_SKIP_TEST(skip_gfx_msg.c_str());
     }
   }
 }
@@ -120,7 +120,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomics_fmaxNonCoherentGlobalFlatMem) {
   std::string gfxName(prop.gcnArchName);
   if ((gfxName == "gfx90a" || gfxName.find("gfx90a:")) == 0) {
     if (prop.canMapHostMemory != 1) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       double *A_h, *B_h;
       double* A_d;
@@ -154,7 +154,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomics_fmaxNonCoherentGlobalFlatMem) {
           "Memory model feature is only supported for gfx90a, Hence"
           "skipping the testcase for this GPU ") +
           std::to_string(device);
-      HIP_SKIP_TEST(skip_gfx_msg.c_str());
+      HipTest::HIP_SKIP_TEST(skip_gfx_msg.c_str());
     }
   }
 }
@@ -173,7 +173,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomicsRTC_fmaxCoherentGlobalMem) {
   std::string gfxName(prop.gcnArchName);
   if ((gfxName == "gfx90a" || gfxName.find("gfx90a:")) == 0) {
     if (prop.canMapHostMemory != 1) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       hiprtcProgram prog;
       hiprtcCreateProgram(&prog,          // prog
@@ -236,7 +236,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomicsRTC_fmaxCoherentGlobalMem) {
           "Memory model feature is only supported for gfx90a, Hence"
           "skipping the testcase for this GPU ") +
           std::to_string(device);
-      HIP_SKIP_TEST(skip_gfx_msg.c_str());
+      HipTest::HIP_SKIP_TEST(skip_gfx_msg.c_str());
     }
   }
 }
@@ -258,7 +258,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomicsRTC_fmaxNonCoherentGlobalFlatMem) {
   std::string gfxName(prop.gcnArchName);
   if ((gfxName == "gfx90a" || gfxName.find("gfx90a:")) == 0) {
     if (prop.canMapHostMemory != 1) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       hiprtcProgram prog;
       if (mem_type) {
@@ -331,7 +331,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomicsRTC_fmaxNonCoherentGlobalFlatMem) {
           "Memory model feature is only supported for gfx90a, Hence"
           "skipping the testcase for this GPU ") +
           std::to_string(device);
-      HIP_SKIP_TEST(skip_gfx_msg.c_str());
+      HipTest::HIP_SKIP_TEST(skip_gfx_msg.c_str());
     }
   }
 }

--- a/projects/hip-tests/catch/unit/deviceLib/BuiltIns_fmin.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/BuiltIns_fmin.cc
@@ -69,7 +69,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomics_fminCoherentGlobalMem) {
   std::string gfxName(prop.gcnArchName);
   if ((gfxName == "gfx90a" || gfxName.find("gfx90a:")) == 0) {
     if (prop.canMapHostMemory != 1) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       double *A_h, *B_h;
       double* A_d;
@@ -97,7 +97,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomics_fminCoherentGlobalMem) {
           "Memory model feature is only supported for gfx90a, Hence"
           "skipping the testcase for this GPU ") +
           std::to_string(device);
-      HIP_SKIP_TEST(skip_gfx_msg.c_str());
+      HipTest::HIP_SKIP_TEST(skip_gfx_msg.c_str());
     }
   }
 }
@@ -120,7 +120,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomics_fminNonCoherentGlobalFlatMem) {
   std::string gfxName(prop.gcnArchName);
   if ((gfxName == "gfx90a" || gfxName.find("gfx90a:")) == 0) {
     if (prop.canMapHostMemory != 1) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       double *A_h, *B_h;
       double* A_d;
@@ -154,7 +154,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomics_fminNonCoherentGlobalFlatMem) {
           "Memory model feature is only supported for gfx90a, Hence"
           "skipping the testcase for this GPU ") +
           std::to_string(device);
-      HIP_SKIP_TEST(skip_gfx_msg.c_str());
+      HipTest::HIP_SKIP_TEST(skip_gfx_msg.c_str());
     }
   }
 }
@@ -174,7 +174,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomicsRTC__fminCoherentGlobalMem) {
   std::string gfxName(prop.gcnArchName);
   if ((gfxName == "gfx90a" || gfxName.find("gfx90a:")) == 0) {
     if (prop.canMapHostMemory != 1) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       hiprtcProgram prog;
       hiprtcCreateProgram(&prog,          // prog
@@ -237,7 +237,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomicsRTC__fminCoherentGlobalMem) {
           "Memory model feature is only supported for gfx90a, Hence"
           "skipping the testcase for this GPU ") +
           std::to_string(device);
-      HIP_SKIP_TEST(skip_gfx_msg.c_str());
+      HipTest::HIP_SKIP_TEST(skip_gfx_msg.c_str());
     }
   }
 }
@@ -260,7 +260,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomicsRTC_fminNonCoherentGlobalFlatMem) {
   std::string gfxName(prop.gcnArchName);
   if ((gfxName == "gfx90a" || gfxName.find("gfx90a:")) == 0) {
     if (prop.canMapHostMemory != 1) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       hiprtcProgram prog;
       if (mem_type) {
@@ -334,7 +334,7 @@ HIP_TEST_CASE(Unit_BuiltinAtomicsRTC_fminNonCoherentGlobalFlatMem) {
           "Memory model feature is only supported for gfx90a, Hence"
           "skipping the testcase for this GPU ") +
           std::to_string(device);
-      HIP_SKIP_TEST(skip_gfx_msg.c_str());
+      HipTest::HIP_SKIP_TEST(skip_gfx_msg.c_str());
     }
   }
 }

--- a/projects/hip-tests/catch/unit/deviceLib/deviceAllocation.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/deviceAllocation.cc
@@ -866,7 +866,8 @@ HIP_TEST_CASE(Unit_deviceAllocation_Malloc_PerThread_PrimitiveDataType) {
   constexpr size_t sizePerThread = 128;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
 
   SECTION("PerThread - char with malloc") {
@@ -1080,7 +1081,8 @@ HIP_TEST_CASE(Unit_deviceAllocation_ComplexDataType) {
   constexpr size_t sizePerThread = 64;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
 
   SECTION("Struct - malloc") {
@@ -1121,7 +1123,8 @@ HIP_TEST_CASE(Unit_deviceAllocation_CodeObjects) {
   constexpr size_t sizePerThread = 128;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
 
   SECTION("SingleCodeObj - malloc") {
@@ -1197,7 +1200,8 @@ HIP_TEST_CASE(Unit_deviceAllocation_Malloc_PerThread_Graph) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   // malloc()/free() tests
   SECTION("Test char datatype allocation with malloc") {
@@ -1229,7 +1233,8 @@ HIP_TEST_CASE(Unit_deviceAllocation_New_PerThread_Graph) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   // new/delete tests
   SECTION("Test char datatype allocation with new") {
@@ -1261,7 +1266,8 @@ HIP_TEST_CASE(Unit_deviceAllocation_DeviceFunc) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
 
   SECTION("Test device function allocation with malloc") {
@@ -1280,7 +1286,8 @@ HIP_TEST_CASE(Unit_deviceAllocation_VirtualFunction) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   int *outputVec_d{nullptr}, *outputVec_h{nullptr};
   constexpr size_t sizeBufferPerThread = 8;
@@ -1315,7 +1322,8 @@ HIP_TEST_CASE(Unit_deviceAllocation_SingKernels_MulThreads) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
 
   SECTION("Test single kernel multi-thread allocation with malloc") {
@@ -1362,7 +1370,8 @@ HIP_TEST_CASE(Unit_deviceAllocation_Malloc_MulCodeObj) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   REQUIRE(true == TestAlloc_Load_MultKernels(TEST_MALLOC_FREE, INT_MAX));
 }
@@ -1375,7 +1384,8 @@ HIP_TEST_CASE(Unit_deviceAllocation_New_MulCodeObj) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   REQUIRE(true == TestAlloc_Load_MultKernels(TEST_NEW_DELETE, INT_MAX));
 }
@@ -1389,7 +1399,8 @@ HIP_TEST_CASE(Unit_deviceAllocationFollowedByDeviceReset) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   REQUIRE(true == TestAllocInDeviceFunc(TEST_MALLOC_FREE));
   HIP_CHECK(hipDeviceReset());

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_fnuz.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_fnuz.cc
@@ -35,7 +35,8 @@ std::string get_arch_type() {
 #define FP8_FNUZ_SKIP_TEST                                                                         \
   std::string gfxName = get_arch_type();                                                           \
   if (!(ARCH_TYPE_GFX940(gfxName))) {                                                              \
-    HIP_SKIP_TEST("this test requires gfx942 architecture.");                                      \
+    HipTest::HIP_SKIP_TEST("this test requires gfx942 architecture.");                            \
+    return;                                                                                        \
   }
 
 #define __FP8_DEVICE__ __device__ static inline

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_ocp.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_ocp.cc
@@ -33,7 +33,8 @@ std::string arch_type() {
 #define FP8_OCP_SKIP_TEST                                                                          \
   std::string gfxName = arch_type();                                                               \
   if (!(ARCH_TYPE_GFX1200(gfxName))) {                                                             \
-    HIP_SKIP_TEST("this test requires GFX1200.");                                                  \
+    HipTest::HIP_SKIP_TEST("this test requires GFX1200.");                                \
+    return;                                                                                        \
   }
 
 #define __FP8_DEVICE__ __device__ static inline

--- a/projects/hip-tests/catch/unit/deviceLib/threadfence_system.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/threadfence_system.cc
@@ -42,7 +42,8 @@ HIP_TEST_CASE(Unit_threadfence_system) {
 
   volatile int* data = nullptr;
   if (hipHostMalloc(&data, sizeof(int), hipHostMallocCoherent) != hipSuccess) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCoherentHostAllocFailed);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCoherentHostAllocFailed);
+    return;
   }
 
   constexpr int init_data = 1000;
@@ -50,8 +51,9 @@ HIP_TEST_CASE(Unit_threadfence_system) {
 
   volatile int* flag = nullptr;
   if (hipHostMalloc(&flag, sizeof(int), hipHostMallocCoherent) != hipSuccess) {
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCoherentHostAllocFailed);
     HIP_CHECK(hipHostFree((void*)data));
-    HIP_SKIP_TEST(HipTest::SkipReason::kCoherentHostAllocFailed);
+    return;
   }
   *flag = 0;
 

--- a/projects/hip-tests/catch/unit/deviceLib/unsafeAtomicAddDevice.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/unsafeAtomicAddDevice.cc
@@ -115,6 +115,6 @@ HIP_TEST_CASE(Unit_unsafeAtomicAdd) {
     REQUIRE(fabs((res_f / 1000) - f_val) <= 0.2f);
     REQUIRE(fabs((res_d / 1000) - d_val) <= 0.2);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }

--- a/projects/hip-tests/catch/unit/deviceLib/unsafeAtomicAdd_RTC.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/unsafeAtomicAdd_RTC.cc
@@ -89,7 +89,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_CoherentRTCnounsafeatomicflag, float
     HIP_CHECK(hipModuleLoadData(&module, code.data()));
     HIP_CHECK(hipModuleGetFunction(&f_kernel, module, "AtomicCheck"));
     if (props.canMapHostMemory != 1) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       TestType *A_h, *result;
       TestType *A_d, *result_d;
@@ -121,7 +121,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_CoherentRTCnounsafeatomicflag, float
     }
     HIP_CHECK(hipModuleUnload(module));
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }
 
@@ -179,7 +179,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_CoherentRTCunsafeatomicflag, float, 
     HIP_CHECK(hipModuleGetFunction(&f_kernel, module, "AtomicCheck"));
 
     if (props.canMapHostMemory != 1) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       TestType *A_h, *result;
       TestType *A_d, *result_d;
@@ -211,7 +211,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_CoherentRTCunsafeatomicflag, float, 
     }
     HIP_CHECK(hipModuleUnload(module));
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }
 
@@ -266,7 +266,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_CoherentRTCwithoutflag, float, doubl
     HIP_CHECK(hipModuleGetFunction(&f_kernel, module, "AtomicCheck"));
 
     if (props.canMapHostMemory != 1) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       TestType *A_h, *result;
       TestType *A_d, *result_d;
@@ -298,7 +298,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_CoherentRTCwithoutflag, float, doubl
     }
     HIP_CHECK(hipModuleUnload(module));
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }
 
@@ -351,7 +351,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_NonCoherentRTCnounsafeatomicflag, fl
     HIP_CHECK(hipModuleLoadData(&module, code.data()));
     HIP_CHECK(hipModuleGetFunction(&f_kernel, module, "AtomicCheck"));
     if (props.canMapHostMemory != 1) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       TestType *A_h, *result;
       TestType *A_d, *result_d;
@@ -377,7 +377,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_NonCoherentRTCnounsafeatomicflag, fl
     }
     HIP_CHECK(hipModuleUnload(module));
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }
 
@@ -432,7 +432,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_NonCoherentRTCunsafeatomicflag, floa
     HIP_CHECK(hipModuleGetFunction(&f_kernel, module, "AtomicCheck"));
 
     if (props.canMapHostMemory != 1) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       TestType *A_h, *result;
       TestType *A_d, *result_d;
@@ -458,7 +458,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_NonCoherentRTCunsafeatomicflag, floa
     }
     HIP_CHECK(hipModuleUnload(module));
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }
 
@@ -513,7 +513,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_NonCoherentRTC, float, double) {
     HIP_CHECK(hipModuleGetFunction(&f_kernel, module, "AtomicCheck"));
 
     if (props.canMapHostMemory != 1) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
     } else {
       TestType *A_h, *result;
       TestType *A_d, *result_d;
@@ -539,6 +539,6 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_NonCoherentRTC, float, double) {
     }
     HIP_CHECK(hipModuleUnload(module));
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
   }
 }

--- a/projects/hip-tests/catch/unit/errorHandling/hipDynamicLogging.cc
+++ b/projects/hip-tests/catch/unit/errorHandling/hipDynamicLogging.cc
@@ -83,7 +83,8 @@ HIP_TEST_CASE(Unit_hipDynamicLogging_Positive_Basic) {
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
   if (numDevices <= 0) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    return;
   }
 
   REQUIRE(hipDynamicLoggingTest() == true);
@@ -106,7 +107,8 @@ HIP_TEST_CASE(Unit_hipDynamicLogging_Positive_MultipleEnableDisable) {
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 
   if (numDevices <= 0) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    return;
   }
 
   // Test multiple enable/disable cycles

--- a/projects/hip-tests/catch/unit/errorHandling/hipExtGetLastError.cc
+++ b/projects/hip-tests/catch/unit/errorHandling/hipExtGetLastError.cc
@@ -83,7 +83,8 @@ HIP_TEST_CASE(Unit_hipExtGetLastError_Positive_Threaded) {
 HIP_TEST_CASE(Unit_hipExtGetLastError_with_hipMemcpyPeerAsync) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   int can_access_peer = 0;

--- a/projects/hip-tests/catch/unit/errorHandling/hipGetLastError.cc
+++ b/projects/hip-tests/catch/unit/errorHandling/hipGetLastError.cc
@@ -84,7 +84,8 @@ HIP_TEST_CASE(Unit_hipGetLastError_Positive_Threaded) {
 HIP_TEST_CASE(Unit_hipGetLastError_with_hipMemcpyPeerAsync) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   int can_access_peer = 0;

--- a/projects/hip-tests/catch/unit/errorHandling/hipGetLastErrorOnAbort.cc
+++ b/projects/hip-tests/catch/unit/errorHandling/hipGetLastErrorOnAbort.cc
@@ -95,7 +95,8 @@ HIP_TEST_CASE(Unit_hipGetLastError_KernelFailure_TwoDevices) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   DISABLE_CORE_DUMPS();

--- a/projects/hip-tests/catch/unit/event/Unit_hipEventElapsedTime.cc
+++ b/projects/hip-tests/catch/unit/event/Unit_hipEventElapsedTime.cc
@@ -95,7 +95,8 @@ HIP_TEST_CASE(Unit_hipEventElapsedTime_DisableTiming) {
 HIP_TEST_CASE(Unit_hipEventElapsedTime_DifferentDevices) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   // create event on dev=0

--- a/projects/hip-tests/catch/unit/event/Unit_hipEventMGpuMThreads.cc
+++ b/projects/hip-tests/catch/unit/event/Unit_hipEventMGpuMThreads.cc
@@ -210,7 +210,7 @@ HIP_TEST_CASE(Unit_hipEventMGpuMThreads_2) {
   if (numDevices > 1) {
     testEventMGpuMThreads(numDevices);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 
@@ -234,7 +234,7 @@ HIP_TEST_CASE(Unit_hipEventMGpuMThreads_3) {
     fprintf(stderr, "Second round\n");
     testEventMGpuMThreads(numDevices);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 

--- a/projects/hip-tests/catch/unit/event/hipEventCreateWithFlags.cc
+++ b/projects/hip-tests/catch/unit/event/hipEventCreateWithFlags.cc
@@ -98,7 +98,8 @@ static void testMemCoherency(eSyncToTest test, eMemoryToTest mem, uint32_t flags
   HIP_CHECK(hipGetDeviceProperties(&prop, 0));
   // If the GPU is not large bar then exit the test
   if (prop.isLargeBar != 1) {
-    HIP_SKIP_TEST("large BAR (resizable BAR) is not supported on this device.");
+    HipTest::HIP_SKIP_TEST("large BAR (resizable BAR) is not supported on this device.");
+    return;
   }
   constexpr auto blocksPerCU = 6;
   unsigned grid_size = HipTest::setNumBlocks(blocksPerCU, block_size, buffer_size);

--- a/projects/hip-tests/catch/unit/executionControl/hipFuncSetAttribute.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipFuncSetAttribute.cc
@@ -206,7 +206,8 @@ HIP_TEST_CASE(Unit_hipFuncSetAttribute_Negative_Parameters) {
  */
 HIP_TEST_CASE(Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize_Not_Supported) {
 #if HT_NVIDIA
-  HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
+  return;
 #endif
 
   hipFuncAttributes old_attributes;
@@ -237,7 +238,8 @@ HIP_TEST_CASE(Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize_Not_S
  */
 HIP_TEST_CASE(Unit_hipFuncSetAttribute_Positive_PreferredSharedMemoryCarveout_Not_Supported) {
 #if HT_NVIDIA
-  HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
+  return;
 #endif
 
   hipFuncAttributes old_attributes;

--- a/projects/hip-tests/catch/unit/executionControl/hipFuncSetCacheConfig.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipFuncSetCacheConfig.cc
@@ -85,7 +85,8 @@ HIP_TEST_CASE(Unit_hipFuncSetCacheConfig_Negative_Parameters) {
  */
 HIP_TEST_CASE(Unit_hipFuncSetCacheConfig_Negative_Not_Supported) {
 #if HT_NVIDIA
-  HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
+  return;
 #endif
 
   HIP_CHECK_ERROR(hipFuncSetCacheConfig(reinterpret_cast<void*>(kernel), hipFuncCachePreferNone),

--- a/projects/hip-tests/catch/unit/executionControl/hipFuncSetSharedMemConfig.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipFuncSetSharedMemConfig.cc
@@ -85,7 +85,8 @@ HIP_TEST_CASE(Unit_hipFuncSetSharedMemConfig_Negative_Parameters) {
  */
 HIP_TEST_CASE(Unit_hipFuncSetSharedMemConfig_Negative_Not_Supported) {
 #if HT_NVIDIA
-  HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
+  return;
 #endif
 
   HIP_CHECK_ERROR(

--- a/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernel.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernel.cc
@@ -13,7 +13,8 @@
 
 HIP_TEST_CASE(Unit_hipLaunchCooperativeKernel_Positive_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   SECTION("Cooperative kernel with no arguments") {
@@ -39,7 +40,8 @@ HIP_TEST_CASE(Unit_hipLaunchCooperativeKernel_Positive_Basic) {
 
 HIP_TEST_CASE(Unit_hipLaunchCooperativeKernel_Positive_Parameters) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   SECTION("blockDim.x == maxBlockDimX") {
@@ -63,7 +65,8 @@ HIP_TEST_CASE(Unit_hipLaunchCooperativeKernel_Positive_Parameters) {
 
 HIP_TEST_CASE(Unit_hipLaunchCooperativeKernel_Negative_Parameters) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   SECTION("f == nullptr") {
@@ -161,7 +164,8 @@ HIP_TEST_CASE(Unit_hipLaunchCooperativeKernel_Negative_Parameters) {
 
 HIP_TEST_CASE(Unit_hipLaunchCooperativeKernel_Verify_Capture) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   hipStream_t stream;

--- a/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernelMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernelMultiDevice.cc
@@ -13,12 +13,14 @@
 
 HIP_TEST_CASE(Unit_hipLaunchCooperativeKernelMultiDevice_Positive_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   std::vector<hipLaunchParams> params_list(device_count);
@@ -47,12 +49,14 @@ HIP_TEST_CASE(Unit_hipLaunchCooperativeKernelMultiDevice_Positive_Basic) {
 
 HIP_TEST_CASE(Unit_hipLaunchCooperativeKernelMultiDevice_Negative_Parameters) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   std::vector<hipLaunchParams> params_list(device_count);
@@ -126,12 +130,14 @@ HIP_TEST_CASE(Unit_hipLaunchCooperativeKernelMultiDevice_Negative_Parameters) {
 
 HIP_TEST_CASE(Unit_hipLaunchCooperativeKernelMultiDevice_Negative_MultiKernelSameDevice) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   HIP_CHECK(hipSetDevice(0));

--- a/projects/hip-tests/catch/unit/gl_interop/gl_interop_common.hh
+++ b/projects/hip-tests/catch/unit/gl_interop/gl_interop_common.hh
@@ -74,24 +74,25 @@ public:
 };
 
 static std::once_flag glut_init_flag;
-static bool glut_init_failed = false;
 static void GlutError(const char *fmt, va_list ap)
 {
     // Print what error occurred
     fprintf(stderr, "GlutError:");
     vfprintf(stderr, fmt, ap);
     fprintf(stderr, "\n");
-    
-    glut_init_failed = true;
+
+    // Mark this test as skipped because this error could be
+    // due to system doesn't have display connected, e.g: Jenkins CI machine
+    HipTest::HIP_SKIP_TEST("GLUT initialization failed.");
+
+    glutExit();
+    exit(1);
 }
 
 class GLUTContextScopeGuard : public IContextScopeGuard {
  public:
   GLUTContextScopeGuard() {
     std::call_once(glut_init_flag, &GLUTContextScopeGuard::init);
-    if (glut_init_failed) {
-      HIP_SKIP_TEST("GLUT Init Failed");
-    }
     glut_window_ = glutCreateWindow("");
   }
 
@@ -114,7 +115,6 @@ class GLUTContextScopeGuard : public IContextScopeGuard {
     static int glut_argc = 1;
     glutInitErrorFunc(&GlutError);
     glutInit(&glut_argc, glut_argv.data());
-    if (glut_init_failed) return;
     glutInitDisplayMode(GLUT_RGB | GLUT_DOUBLE | GLUT_DEPTH);
     glutInitWindowSize(512, 512);
   }
@@ -207,6 +207,11 @@ class GLContextScopeGuard {
 
   GLContextScopeGuard() {
 
+    if(!HipTest::isImageSupported()) {
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+      exit(0);
+    }
+
     char* val = std::getenv(kEnvarName);
     std::string val_str = val == NULL ? "" : val;
 
@@ -229,8 +234,10 @@ class GLContextScopeGuard {
 #ifdef USE_GLEW
     GLenum err = glewInit();
     if (err != GLEW_OK) {
-      fprintf(stderr, "GLEW initialization failed: %s\n", glewGetErrorString(err));
-      HIP_SKIP_TEST(HipTest::SkipReason::kGlewInitFailed);
+      fprintf(stderr, "GLEW initialization failed: %s\n",
+              glewGetErrorString(err));
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGlewInitFailed);
+      exit(1);
     }
 #endif
   }

--- a/projects/hip-tests/catch/unit/gl_interop/hipGLContextSwitch.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGLContextSwitch.cc
@@ -89,9 +89,8 @@ class GLUTWindow {
     GLenum err = glewInit();
     if (err != GLEW_OK) {
       fprintf(stderr, "GLEW init failed: %s\n", glewGetErrorString(err));
-      glutDestroyWindow(window_id_);
-      window_id_ = 0;
-      HIP_SKIP_TEST(HipTest::SkipReason::kGlewInitFailed);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGlewInitFailed);
+      exit(1);
     }
 #endif
   }
@@ -260,7 +259,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_Basic) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    // Create first GL context
@@ -303,7 +303,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_SeparateContextSetups) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    // Create two contexts
@@ -364,7 +365,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_BackAndForth) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    GLUTWindow window1;
@@ -398,7 +400,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_RapidSwitching) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    GLUTWindow window1;
@@ -428,7 +431,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_Patterns) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    std::vector<std::unique_ptr<GLUTWindow>> windows;
@@ -492,7 +496,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_RegisterWithoutGetDevices) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    // First context - explicit initialization
@@ -540,7 +545,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_AllAPIsDetectSwitch) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    GLUTWindow window1;
@@ -607,7 +613,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
  */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_SequentialStableContext) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    GLUTWindow window;
@@ -687,7 +694,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
  */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_InterleavedWithSwitch) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    GLUTWindow window1;
@@ -732,7 +740,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
  */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_RapidMultiContextSwitching) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    std::vector<std::unique_ptr<GLUTWindow>> windows;
@@ -778,7 +787,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_SameContextRepeated) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    GLUTWindow window;
@@ -803,7 +813,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_ReturnToPreviousContext) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    GLUTWindow window1;
@@ -839,7 +850,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_ResourceContextAssociation) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    GLUTWindow window1;
@@ -895,7 +907,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_DataIntegrity) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    GLUTWindow window1;
@@ -964,7 +977,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_AlternatingDataOperations) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    GLUTWindow window1;
@@ -1044,7 +1058,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_TextureInterop) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    GLUTWindow window1;
@@ -1095,7 +1110,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_MixedResources) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    GLUTWindow window1;
@@ -1152,7 +1168,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_StreamOperations) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    GLUTWindow window1;
@@ -1207,7 +1224,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_MultipleStreams) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    GLUTWindow window1;
@@ -1268,7 +1286,8 @@ BufferInteropResult performBufferInteropCycle(unsigned int flags = hipGraphicsRe
  */
 HIP_TEST_CASE(Unit_hipGL_ContextSwitch_HighFrequencyStress) {
   if (!HipTest::isImageSupported()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+    return;
   }
 
   constexpr int kNumContexts = 3;
@@ -1300,7 +1319,8 @@ HIP_TEST_CASE(Unit_hipGL_ContextSwitch_HighFrequencyStress) {
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_ManyBuffersStress) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    GLUTWindow window1;
@@ -1371,7 +1391,8 @@ HIP_TEST_CASE(Unit_hipGL_ContextSwitch_HighFrequencyStress) {
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_LongRunningStress) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    GLUTWindow window1;
@@ -1418,7 +1439,8 @@ HIP_TEST_CASE(Unit_hipGL_ContextSwitch_HighFrequencyStress) {
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_RegistrationFlags) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    GLUTWindow window1;
@@ -1466,7 +1488,8 @@ HIP_TEST_CASE(Unit_hipGL_ContextSwitch_HighFrequencyStress) {
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_ContextDestruction) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    // Create and use first context
@@ -1496,7 +1519,8 @@ HIP_TEST_CASE(Unit_hipGL_ContextSwitch_HighFrequencyStress) {
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_MultipleDestructionCycles) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    for (int cycle = 0; cycle < kDefaultIterations; ++cycle) {
@@ -1521,7 +1545,8 @@ HIP_TEST_CASE(Unit_hipGL_ContextSwitch_HighFrequencyStress) {
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_DeviceListTypes) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    const int device_count = HipTest::getDeviceCount();
@@ -1558,7 +1583,8 @@ HIP_TEST_CASE(Unit_hipGL_ContextSwitch_HighFrequencyStress) {
   */
  HIP_TEST_CASE(Unit_hipGL_ContextSwitch_FirstOperationInitialization) {
    if (!HipTest::isImageSupported()) {
-     HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureImageUnsupported);
+     return;
    }
 
    GLUTWindow window;

--- a/projects/hip-tests/catch/unit/gl_interop/hipGLGetDevices.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGLGetDevices.cc
@@ -16,8 +16,6 @@ constexpr std::array<hipGLDeviceList, 3> kDeviceLists{
 }  // anonymous namespace
 
 HIP_TEST_CASE(Unit_hipGLGetDevices_Positive_Basic) {
-  CHECK_IMAGE_SUPPORT
-
   GLContextScopeGuard gl_context;
 
   const auto device_list = GENERATE(from_range(begin(kDeviceLists), end(kDeviceLists)));
@@ -40,8 +38,6 @@ HIP_TEST_CASE(Unit_hipGLGetDevices_Positive_Basic) {
 }
 
 HIP_TEST_CASE(Unit_hipGLGetDevices_Positive_Parameters) {
-  CHECK_IMAGE_SUPPORT
-  
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();
@@ -70,8 +66,6 @@ HIP_TEST_CASE(Unit_hipGLGetDevices_Positive_Parameters) {
 }
 
 HIP_TEST_CASE(Unit_hipGLGetDevices_Negative_Parameters) {
-  CHECK_IMAGE_SUPPORT
-
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();

--- a/projects/hip-tests/catch/unit/gl_interop/hipGraphicsGLRegisterBuffer.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGraphicsGLRegisterBuffer.cc
@@ -17,8 +17,6 @@ constexpr std::array<unsigned int, 3> kFlags{hipGraphicsRegisterFlagsNone,
 }  // anonymous namespace
 
 HIP_TEST_CASE(Unit_hipGraphicsGLRegisterBuffer_Positive_Basic) {
-  CHECK_IMAGE_SUPPORT
-
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();
@@ -42,8 +40,6 @@ HIP_TEST_CASE(Unit_hipGraphicsGLRegisterBuffer_Positive_Basic) {
 }
 
 HIP_TEST_CASE(Unit_hipGraphicsGLRegisterBuffer_Positive_Register_Twice) {
-  CHECK_IMAGE_SUPPORT
-
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();
@@ -67,8 +63,6 @@ HIP_TEST_CASE(Unit_hipGraphicsGLRegisterBuffer_Positive_Register_Twice) {
 }
 
 HIP_TEST_CASE(Unit_hipGraphicsGLRegisterBuffer_Negative_Parameters) {
-  CHECK_IMAGE_SUPPORT
-
   GLContextScopeGuard gl_context;
 
   GLBufferObject vbo;

--- a/projects/hip-tests/catch/unit/gl_interop/hipGraphicsGLRegisterImage.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGraphicsGLRegisterImage.cc
@@ -18,8 +18,6 @@ constexpr std::array<unsigned int, 5> kFlags{
 }  // anonymous namespace
 
 HIP_TEST_CASE(Unit_hipGraphicsGLRegisterImage_Positive_Basic) {
-  CHECK_IMAGE_SUPPORT
-
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();
@@ -43,8 +41,6 @@ HIP_TEST_CASE(Unit_hipGraphicsGLRegisterImage_Positive_Basic) {
 }
 
 HIP_TEST_CASE(Unit_hipGraphicsGLRegisterImage_Positive_Register_Twice) {
-  CHECK_IMAGE_SUPPORT
-
   GLContextScopeGuard gl_context;
   const int device_count = HipTest::getDeviceCount();
   unsigned int gl_device_count = 0;
@@ -69,8 +65,6 @@ HIP_TEST_CASE(Unit_hipGraphicsGLRegisterImage_Positive_Register_Twice) {
 }
 
 HIP_TEST_CASE(Unit_hipGraphicsGLRegisterImage_Negative_Parameters) {
-  CHECK_IMAGE_SUPPORT
-
   GLContextScopeGuard gl_context;
 
   GLImageObject tex;

--- a/projects/hip-tests/catch/unit/gl_interop/hipGraphicsMapResources.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGraphicsMapResources.cc
@@ -11,8 +11,6 @@
 #include "gl_interop_common.hh"
 
 HIP_TEST_CASE(Unit_hipGraphicsMapResources_Positive_Basic) {
-  CHECK_IMAGE_SUPPORT
-
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();
@@ -47,8 +45,6 @@ HIP_TEST_CASE(Unit_hipGraphicsMapResources_Positive_Basic) {
 }
 
 HIP_TEST_CASE(Unit_hipGraphicsMapResources_Negative_Parameters) {
-  CHECK_IMAGE_SUPPORT
-
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();

--- a/projects/hip-tests/catch/unit/gl_interop/hipGraphicsResourceGetMappedPointer.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGraphicsResourceGetMappedPointer.cc
@@ -11,8 +11,6 @@
 #include "gl_interop_common.hh"
 
 HIP_TEST_CASE(Unit_hipGraphicsResourceGetMappedPointer_Positive_Basic) {
-  CHECK_IMAGE_SUPPORT
-
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();
@@ -47,8 +45,6 @@ HIP_TEST_CASE(Unit_hipGraphicsResourceGetMappedPointer_Positive_Basic) {
 }
 
 HIP_TEST_CASE(Unit_hipGraphicsResourceGetMappedPointer_Null_Parameters) {
-  CHECK_IMAGE_SUPPORT
-
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();
@@ -97,8 +93,6 @@ HIP_TEST_CASE(Unit_hipGraphicsResourceGetMappedPointer_Null_Parameters) {
 }
 
 HIP_TEST_CASE(Unit_hipGraphicsResourceGetMappedPointer_Negative_Parameters) {
-  CHECK_IMAGE_SUPPORT
-
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();

--- a/projects/hip-tests/catch/unit/gl_interop/hipGraphicsSubResourceGetMappedArray.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGraphicsSubResourceGetMappedArray.cc
@@ -11,8 +11,6 @@
 #include "gl_interop_common.hh"
 
 HIP_TEST_CASE(Unit_hipGraphicsSubResourceGetMappedArray_Positive_Basic) {
-  CHECK_IMAGE_SUPPORT
-
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();
@@ -44,8 +42,6 @@ HIP_TEST_CASE(Unit_hipGraphicsSubResourceGetMappedArray_Positive_Basic) {
 }
 
 HIP_TEST_CASE(Unit_hipGraphicsSubResourceGetMappedArray_Negative_Parameters) {
-  CHECK_IMAGE_SUPPORT
-
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();

--- a/projects/hip-tests/catch/unit/gl_interop/hipGraphicsUnmapResources.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGraphicsUnmapResources.cc
@@ -11,8 +11,6 @@
 #include "gl_interop_common.hh"
 
 HIP_TEST_CASE(Unit_hipGraphicsUnmapResources_Negative_Parameters) {
-  CHECK_IMAGE_SUPPORT
-
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();

--- a/projects/hip-tests/catch/unit/gl_interop/hipGraphicsUnregisterResource.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGraphicsUnregisterResource.cc
@@ -11,8 +11,6 @@
 #include "gl_interop_common.hh"
 
 HIP_TEST_CASE(Unit_hipGraphicsUnregisterResource_Negative_Parameters) {
-  CHECK_IMAGE_SUPPORT
-
   GLContextScopeGuard gl_context;
 
   const int device_count = HipTest::getDeviceCount();

--- a/projects/hip-tests/catch/unit/graph/hipDeviceGetGraphMemAttribute.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDeviceGetGraphMemAttribute.cc
@@ -206,7 +206,10 @@ static void hipDeviceGetGraphMemAttribute_Functional_Test(unsigned deviceId = 0)
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
+    HipTest::HIP_SKIP_TEST(
+        "Runtime doesn't support Memory Pool."
+        " Skip the test case.");
+    return;
   }
 
   constexpr size_t Nbytes = 512 * 1024 * 1024;
@@ -299,7 +302,7 @@ HIP_TEST_CASE(Unit_hipDeviceGetGraphMemAttribute_Functional_Multi_Device) {
       hipDeviceGetGraphMemAttribute_Functional_Test(i);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
 }
 

--- a/projects/hip-tests/catch/unit/graph/hipDrvGraphAddMemcpyNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDrvGraphAddMemcpyNode.cc
@@ -365,7 +365,8 @@ HIP_TEST_CASE(Unit_hipDrvGraphAddMemcpyNode_MulitDevice) {
       hipDrvGraphAddMemcpyNode_test(device);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 #endif

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddChildGraphNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddChildGraphNode.cc
@@ -1085,7 +1085,8 @@ HIP_TEST_CASE(Unit_hipGraphAddChildGraphNode_CmplxNstGrph_MultGPU) {
   HIP_CHECK(hipGetDeviceCount(&devcount));
   // If only single GPU is detected then return
   if (devcount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   hipGraph_t** graph = new hipGraph_t*[devcount]();
   REQUIRE(graph != nullptr);

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemAllocNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemAllocNode.cc
@@ -454,7 +454,10 @@ HIP_TEST_CASE(Unit_hipGraphAddMemAllocNode_Functional_1) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
+    HipTest::HIP_SKIP_TEST(
+        "Runtime doesn't support Memory Pool."
+        " Skip the test case.");
+    return;
   }
 
   constexpr size_t N = 1024 * 1024;
@@ -561,7 +564,10 @@ HIP_TEST_CASE(Unit_hipGraphAddMemAllocNode_Functional_2) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
+    HipTest::HIP_SKIP_TEST(
+        "Runtime doesn't support Memory Pool."
+        " Skip the test case.");
+    return;
   }
 
   constexpr size_t Nbytes = 512 * 1024 * 1024;
@@ -627,7 +633,10 @@ HIP_TEST_CASE(Unit_hipGraphAddMemAllocNode_Functional_3) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
+    HipTest::HIP_SKIP_TEST(
+        "Runtime doesn't support Memory Pool."
+        " Skip the test case.");
+    return;
   }
 
   constexpr size_t Nbytes = 512 * 1024 * 1024;
@@ -698,7 +707,10 @@ HIP_TEST_CASE(Unit_hipGraphAddMemAllocNode_Functional_4) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
+    HipTest::HIP_SKIP_TEST(
+        "Runtime doesn't support Memory Pool."
+        " Skip the test case.");
+    return;
   }
 
   constexpr size_t Nbytes = 512 * 1024 * 1024;
@@ -784,7 +796,10 @@ HIP_TEST_CASE(Unit_hipGraphAddMemAllocNode_Argument_Check) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
+    HipTest::HIP_SKIP_TEST(
+        "Runtime doesn't support Memory Pool."
+        " Skip the test case.");
+    return;
   }
 
   constexpr size_t Nbytes = 512 * 1024 * 1024;
@@ -1001,7 +1016,10 @@ HIP_TEST_CASE(Unit_hipGraphAddMemAllocNode_Negative_Instanciate_Graph_Again) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
+    HipTest::HIP_SKIP_TEST(
+        "Runtime doesn't support Memory Pool."
+        " Skip the test case.");
+    return;
   }
 
   constexpr size_t Nbytes = 512 * 1024 * 1024;
@@ -1060,7 +1078,10 @@ HIP_TEST_CASE(Unit_hipGraphAddMemAllocNode_Negative_Free_Alloc_Memory_Again) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
+    HipTest::HIP_SKIP_TEST(
+        "Runtime doesn't support Memory Pool."
+        " Skip the test case.");
+    return;
   }
 
   constexpr size_t Nbytes = 512 * 1024 * 1024;
@@ -1122,7 +1143,10 @@ HIP_TEST_CASE(Unit_hipGraphAddMemAllocNode_Negative_With_Cloneed_Graph) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
+    HipTest::HIP_SKIP_TEST(
+        "Runtime doesn't support Memory Pool."
+        " Skip the test case.");
+    return;
   }
 
   constexpr size_t N = 512 * 1024 * 1024;

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemFreeNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemFreeNode.cc
@@ -191,7 +191,10 @@ HIP_TEST_CASE(Unit_hipGraphAddMemFreeNode_Functional) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST("Runtime doesn't support Memory Pool. Skip the test case.");
+    HipTest::HIP_SKIP_TEST(
+        "Runtime doesn't support Memory Pool."
+        " Skip the test case.");
+    return;
   }
 
   constexpr size_t Nbytes = 512 * 1024 * 1024;

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeFromSymbol_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeFromSymbol_old.cc
@@ -250,10 +250,11 @@ HIP_TEST_CASE(Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemoryPeerDevice) {
     if (canAccessPeer) {
       hipGraphAddMemcpyNodeFromSymbol_GlobalMemory(true, false);
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 
@@ -271,10 +272,11 @@ HIP_TEST_CASE(Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalConstMemoryPeerDevice) 
     if (canAccessPeer) {
       hipGraphAddMemcpyNodeFromSymbol_GlobalMemory(true, true);
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 #endif

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeToSymbol_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeToSymbol_old.cc
@@ -233,10 +233,11 @@ HIP_TEST_CASE(Unit_hipGraphAddMemcpyNodeToSymbol_GlobalMemoryPeerDevice) {
     if (canAccessPeer) {
       hipGraphAddMemcpyNodeToSymbol_GlobalMemory(true, false);
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 /*
@@ -253,10 +254,11 @@ HIP_TEST_CASE(Unit_hipGraphAddMemcpyNodeToSymbol_GlobalConstMemoryPeerDevice) {
     if (canAccessPeer) {
       hipGraphAddMemcpyNodeToSymbol_GlobalMemory(true, true);
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 #endif

--- a/projects/hip-tests/catch/unit/graph/hipGraphCloneComplx.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphCloneComplx.cc
@@ -1730,7 +1730,8 @@ HIP_TEST_CASE(Unit_hipGraphClone_multi_GPU_test) {
   HIP_CHECK(hipGetDeviceCount(&devcount));
   // If only single GPU is detected then return
   if (devcount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   for (int dev = 0; dev < devcount; dev++) {

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecEventRecordNodeSetEvent.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecEventRecordNodeSetEvent.cc
@@ -177,7 +177,8 @@ HIP_TEST_CASE(Unit_hipGraphExecEventRecordNodeSetEvent_VerifyEventNotChanged) {
 HIP_TEST_CASE(Unit_hipGraphExecEventRecordNodeSetEvent_Positive_DifferentDevices) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   hipGraphExec_t graphExec;
   hipStream_t streamForGraph;

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecUpdate.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecUpdate.cc
@@ -647,7 +647,8 @@ HIP_TEST_CASE(Unit_hipGraphExecUpdate_Negative_MultiDevice_Context_Changed) {
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 1, 0));
   }
   if (!peerAccess) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    return;
   }
   HIP_CHECK(hipSetDevice(0));
   int *A_d, *B_d, *C_d, *A_h, *B_h, *C_h;

--- a/projects/hip-tests/catch/unit/graph/hipGraphInstantiateWithFlags.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphInstantiateWithFlags.cc
@@ -264,10 +264,11 @@ HIP_TEST_CASE(Unit_hipGraphInstantiateWithFlags_DependencyGraphDeviceCtxtChg) {
     if (canAccessPeer) {
       GraphInstantiateWithFlags_DependencyGraph(true);
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 
@@ -285,10 +286,11 @@ HIP_TEST_CASE(Unit_hipGraphInstantiateWithFlags_StreamCapture) {
     if (canAccessPeer) {
       GraphInstantiateWithFlags_StreamCapture();
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 
@@ -306,10 +308,11 @@ HIP_TEST_CASE(Unit_hipGraphInstantiateWithFlags_StreamCaptureDeviceContextChg) {
     if (canAccessPeer) {
       GraphInstantiateWithFlags_StreamCapture(true);
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphLaunch_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphLaunch_old.cc
@@ -102,7 +102,7 @@ HIP_TEST_CASE(Unit_hipGraphLaunch_Functional_multidevice_test) {
       hipGraphLaunch_test();
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
 }
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphMemAllocNodeGetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMemAllocNodeGetParams.cc
@@ -131,7 +131,7 @@ HIP_TEST_CASE(Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_MultiDevice) 
       hipGraphMemAllocNodeGetParams_Functional(i);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
 }
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMultiDevice.cc
@@ -52,7 +52,8 @@ HIP_TEST_CASE(Unit_hipGraphMultiDevice) {
   int nGpus = 0;
   HIP_CHECK(hipGetDeviceCount(&nGpus));
   if (nGpus < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   hipStream_t streamdev1, streamdev2;
   hipEvent_t eventdev1, eventdev2;

--- a/projects/hip-tests/catch/unit/graph/hipGraphPerf.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphPerf.cc
@@ -490,7 +490,10 @@ static void checkGraphEventcontinuousKernelCallIn2Blocks(const unsigned int kNum
 
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_MemcpyKernelMixCall) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    HipTest::HIP_SKIP_TEST(
+        "Unable to turn on "
+        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    return;
   }
 
   constexpr int kNumIter1 = 25;
@@ -600,7 +603,10 @@ static void hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams(const hipStream_t
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    HipTest::HIP_SKIP_TEST(
+        "Unable to turn on "
+        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    return;
   }
 
   hipStream_t stream;
@@ -715,7 +721,10 @@ static void hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams_inLoop(const hipS
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams_inLoop) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    HipTest::HIP_SKIP_TEST(
+        "Unable to turn on "
+        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    return;
   }
 
   hipStream_t stream;
@@ -761,7 +770,10 @@ HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams_inLoop) {
 
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    HipTest::HIP_SKIP_TEST(
+        "Unable to turn on "
+        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    return;
   }
   constexpr int kNumNode = 1;
   unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, N);
@@ -931,7 +943,10 @@ static void hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams_inLoop(const hipS
 
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams_inLoop) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    HipTest::HIP_SKIP_TEST(
+        "Unable to turn on "
+        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    return;
   }
 
   hipStream_t stream;
@@ -1044,7 +1059,10 @@ static void hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams1D_inLoop(const hi
 
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams1D_inLoop) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    HipTest::HIP_SKIP_TEST(
+        "Unable to turn on "
+        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    return;
   }
 
   hipStream_t stream;
@@ -1149,7 +1167,10 @@ static void hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsFrmSymbol(const hi
 
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsFrmSymbol) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    HipTest::HIP_SKIP_TEST(
+        "Unable to turn on "
+        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    return;
   }
 
   hipStream_t stream;
@@ -1253,7 +1274,10 @@ static void hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsToSymbol(const hip
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsToSymbol) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    HipTest::HIP_SKIP_TEST(
+        "Unable to turn on "
+        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    return;
   }
 
   hipStream_t stream;
@@ -1403,7 +1427,10 @@ static void hipGraph_PerfCheck_hipGraphExecMemsetNodeSetParams(const hipStream_t
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecMemsetNodeSetParams) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    HipTest::HIP_SKIP_TEST(
+        "Unable to turn on "
+        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    return;
   }
 
   hipStream_t stream;
@@ -1833,7 +1860,10 @@ static void hipGraph_PerfCheck_hipGraphExecChildGraphNodeSetParams_mKernel(
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecChildGraphNodeSetParams) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    HipTest::HIP_SKIP_TEST(
+        "Unable to turn on "
+        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    return;
   }
 
   hipStream_t stream;
@@ -1977,7 +2007,10 @@ static void hipGraph_PerfCheck_hipGraphExecEventRecordNodeSetEvent(const hipStre
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecEventRecordNodeSetEvent) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    HipTest::HIP_SKIP_TEST(
+        "Unable to turn on "
+        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    return;
   }
 
   hipStream_t stream;
@@ -2161,7 +2194,10 @@ static void hipGraph_PerfCheck_hipGraphExecEventWaitNodeSetEvent(const hipStream
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecEventWaitNodeSetEvent) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    HipTest::HIP_SKIP_TEST(
+        "Unable to turn on "
+        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    return;
   }
 
   hipStream_t stream;
@@ -2312,7 +2348,10 @@ static void hipGraph_PerfCheck_hipGraphExecHostNodeSetParams(const hipStream_t& 
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecHostNodeSetParams) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    HipTest::HIP_SKIP_TEST(
+        "Unable to turn on "
+        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    return;
   }
 
   hipStream_t stream;
@@ -2432,7 +2471,10 @@ static void hipGraph_PerfCheck_hipGraphExecUpdate(const hipStream_t& stream) {
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecUpdate) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    HipTest::HIP_SKIP_TEST(
+        "Unable to turn on "
+        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    return;
   }
 
   hipStream_t stream;
@@ -2573,7 +2615,10 @@ static void hipGraph_PerfCheck_hipGraphExecUpdate_kernel_inLoop(const hipStream_
  */
 HIP_TEST_CASE(Unit_hipGraph_PerfCheck_hipGraphExecUpdate_kernel_inLoop) {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
-    HIP_SKIP_TEST("Unable to turn on DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    HipTest::HIP_SKIP_TEST(
+        "Unable to turn on "
+        "DEBUG_CLR_GRAPH_PACKET_CAPTURE, hence exit!");
+    return;
   }
 
   hipStream_t stream;

--- a/projects/hip-tests/catch/unit/graph/hipGraphUpload.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphUpload.cc
@@ -192,7 +192,7 @@ HIP_TEST_CASE(Unit_hipGraphUpload_Functional_multidevice_test) {
       }
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
   }
 }
 

--- a/projects/hip-tests/catch/unit/graph/hipSimpleGraphWithKernel.cc
+++ b/projects/hip-tests/catch/unit/graph/hipSimpleGraphWithKernel.cc
@@ -146,7 +146,8 @@ static void hipTestWithoutGraph() {
 #ifdef KERNEL_ARG_PREFETCH
 TEST_CASE("Unit_hipGraph_SimpleGraphWithKernel_kernel_arg_prefetch") {
   if (!HipTest::isKernelArgPrefetchSupported()) {
-    HIP_SKIP_TEST("Kernel arg prefetch is not supported on the device. Skipped.");
+    HipTest::HIP_SKIP_TEST("Kernel arg prefetch is not supported on the device. Skipped.");
+    return;
   }
 #else
 TEST_CASE("Unit_hipGraph_SimpleGraphWithKernel") {

--- a/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture.cc
@@ -1056,7 +1056,8 @@ HIP_TEST_CASE(Unit_hipStreamBeginCapture_Positive_MultiGPU) {
   HIP_CHECK(hipGetDeviceCount(&devcount));
   // If only single GPU is detected then return
   if (devcount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   hipStream_t* stream = reinterpret_cast<hipStream_t*>(malloc(devcount * sizeof(hipStream_t)));
   REQUIRE(stream != nullptr);

--- a/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture_old.cc
@@ -924,7 +924,8 @@ HIP_TEST_CASE(Unit_hipStreamBeginCapture_MultiGPU) {
   HIP_CHECK(hipGetDeviceCount(&devcount));
   // If only single GPU is detected then return
   if (devcount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   hipStream_t* stream = reinterpret_cast<hipStream_t*>(malloc(devcount * sizeof(hipStream_t)));
   REQUIRE(stream != nullptr);

--- a/projects/hip-tests/catch/unit/hip_specific/hip_check_VGPRs.cpp
+++ b/projects/hip-tests/catch/unit/hip_specific/hip_check_VGPRs.cpp
@@ -66,7 +66,7 @@ HIP_TEST_CASE(Unit_Device__hip_check_VGPRs) {
                                 hipDeviceAttributeMaxAvailableVgprsPerThread, device));
   if (maxAvailableVgprsPerThread > 1024) {
     // The test should work on all current devices as of writing.
-    HIP_SKIP_TEST(
+    HipTest::HIP_SKIP_TEST(
         "maxAvailableVgprsPerThread > 1024 is not supported in this test.");
   }
   HIP_CHECK(hipFuncGetAttributes(&attr, reinterpret_cast<void*>(test1024)));

--- a/projects/hip-tests/catch/unit/kernel/hipLaunchKernelEx.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipLaunchKernelEx.cc
@@ -127,7 +127,8 @@ __global__ void normalKernel(int* output, int totalThreads) {
  */
 HIP_TEST_CASE(Unit_hipLaunchKernelExC_NegetiveTsts) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
   int blockSize = 16;
   int totalThreads = 64;
@@ -196,7 +197,8 @@ HIP_TEST_CASE(Unit_hipLaunchKernelExC_NegetiveTsts) {
 
 HIP_TEST_CASE(Unit_hipLaunchKernelEx_NegetiveTsts) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
   int blockSize = 16;
   int totalThreads = 64;
@@ -318,7 +320,8 @@ bool runTest(const char* testName, const void* kernelFunc, int totalThreads, int
  */
 HIP_TEST_CASE(Unit_hipLaunchKernelEx_Functional) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
   std::string api_type = GENERATE("hipLaunchKernelEx", "hipLaunchKernelExC");
   if (api_type == "hipLaunchKernelEx") {
@@ -349,7 +352,8 @@ HIP_TEST_CASE(Unit_hipLaunchKernelEx_Functional) {
  */
 HIP_TEST_CASE(Unit_hipLaunchKernelEx_With_Different_Kernels) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   hipLaunchConfig_t config = {};
@@ -420,7 +424,8 @@ HIP_TEST_CASE(Unit_hipLaunchKernelEx_With_Different_Kernels) {
  */
 HIP_TEST_CASE(Unit_hipLaunchKernelEx_With_CooperativeKernelWithArgs) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   hipLaunchConfig_t config = {};
@@ -482,7 +487,8 @@ HIP_TEST_CASE(Unit_hipLaunchKernelEx_With_CooperativeKernelWithArgs) {
  */
 HIP_TEST_CASE(Unit_hipLaunchKernelEx_With_MaxBlockDims) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   hipLaunchConfig_t config = {};

--- a/projects/hip-tests/catch/unit/kernel/hipLaunchParmFunctor.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipLaunchParmFunctor.cc
@@ -411,7 +411,8 @@ void HipFunctorTests::TestForFunctorContainInStructObj(void) {
  */
 TEST_CASE("Unit_hipLaunchParmFunctor_kernel_arg_prefetch") {
   if (!HipTest::isKernelArgPrefetchSupported()) {
-    HIP_SKIP_TEST("Kernel arg prefetch is not supported on the device. Skipped.");
+    HipTest::HIP_SKIP_TEST("Kernel arg prefetch is not supported on the device. Skipped.");
+    return;
   }
 #else
 TEST_CASE("Unit_hipLaunchParmFunctor") {

--- a/projects/hip-tests/catch/unit/memory/hipArray3DCreate.cc
+++ b/projects/hip-tests/catch/unit/memory/hipArray3DCreate.cc
@@ -91,7 +91,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipArray3DCreate_MaxTexture, int, uint4, short, usho
 #else
   desc.Flags = GENERATE(0, hipArraySurfaceLoadStore);
   if (desc.Flags == hipArraySurfaceLoadStore) {
-    HIP_SKIP_TEST("tracked issue EXSWCPHIPT-58.");
+    HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-58.");
+    return;
   }
 #endif
   CAPTURE(desc.Flags);
@@ -324,7 +325,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipArray3DCreate_Negative_Non2DTextureGather, char, 
   CHECK_IMAGE_SUPPORT
 
 #if HT_AMD
-  HIP_SKIP_TEST(HipTest::SkipReason::kTextureGatherUnsupportedAmd);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureGatherUnsupportedAmd);
+  return;
 #endif
   using vec_info = vector_info<TestType>;
   DriverContext ctx;

--- a/projects/hip-tests/catch/unit/memory/hipArrayCommon.hh
+++ b/projects/hip-tests/catch/unit/memory/hipArrayCommon.hh
@@ -86,7 +86,8 @@ struct Sizes {
         return;
       }
       default: {
-        HIP_SKIP_TEST("array flag not supported.");
+        HipTest::HIP_SKIP_TEST("array flag not supported.");
+        return;
       }
     }
   }

--- a/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3DAsync_old.cc
@@ -307,7 +307,7 @@ void DrvMemcpy3DAsync<T>::HostDevice_DrvMemcpy3DAsync(bool device_context_change
   if (device_context_change) {
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 0, 1));
     if (!peerAccess) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
       skip_test = true;
     } else {
       HIP_CHECK(hipSetDevice(1));
@@ -381,7 +381,7 @@ void DrvMemcpy3DAsync<T>::HostArray_DrvMemcpy3DAsync(bool device_context_change)
   if (device_context_change) {
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 0, 1));
     if (!peerAccess) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
       skip_test = true;
     } else {
       HIP_CHECK(hipSetDevice(1));
@@ -454,7 +454,8 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy3DAsync_H2DDeviceContextChange) {
     DrvMemcpy3DAsync<float> memcpy3d(10, 10, 1, HIP_AD_FORMAT_FLOAT);
     memcpy3d.HostDevice_DrvMemcpy3DAsync(true);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 
@@ -479,7 +480,8 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy3DAsync_Host2ArrayDeviceContextChange) {
     DrvMemcpy3DAsync<float> memcpy3d(10, 10, 10, HIP_AD_FORMAT_FLOAT);
     memcpy3d.HostArray_DrvMemcpy3DAsync(true);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3D_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3D_old.cc
@@ -299,7 +299,7 @@ template <typename T> void DrvMemcpy3D<T>::HostDevice_DrvMemcpy3D(bool device_co
   if (device_context_change) {
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 0, 1));
     if (!peerAccess) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
       skip_test = true;
     } else {
       HIP_CHECK(hipSetDevice(1));
@@ -369,7 +369,7 @@ template <typename T> void DrvMemcpy3D<T>::HostArray_DrvMemcpy3D(bool device_con
   if (device_context_change) {
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 0, 1));
     if (!peerAccess) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
       skip_test = true;
     } else {
       HIP_CHECK(hipSetDevice(1));
@@ -520,7 +520,8 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy3D_H2DDeviceContextChange) {
     DrvMemcpy3D<float> memcpy3d(10, 10, 1, HIP_AD_FORMAT_FLOAT);
     memcpy3d.HostDevice_DrvMemcpy3D(true);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 
@@ -545,7 +546,8 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy3D_Host2ArrayDeviceContextChange) {
     DrvMemcpy3D<float> memcpy3d(10, 10, 1, HIP_AD_FORMAT_FLOAT);
     memcpy3d.HostArray_DrvMemcpy3D(true);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipExtMallocWithFlags.cc
+++ b/projects/hip-tests/catch/unit/memory/hipExtMallocWithFlags.cc
@@ -52,7 +52,8 @@ HIP_TEST_CASE(Unit_hipExtMallocWithFlags_Positive_Alignment) {
   const auto flag = GENERATE(hipDeviceMallocDefault, hipDeviceMallocFinegrained);
   if (flag == hipDeviceMallocFinegrained &&
       !DeviceAttributesSupport(0, hipDeviceAttributeFineGrainSupport)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+    return;
   }
   HIP_CHECK(hipExtMallocWithFlags(&ptr1, 1, flag));
   HIP_CHECK(hipExtMallocWithFlags(&ptr2, 10, flag));

--- a/projects/hip-tests/catch/unit/memory/hipFree.cc
+++ b/projects/hip-tests/catch/unit/memory/hipFree.cc
@@ -218,7 +218,8 @@ HIP_TEST_CASE(Unit_hipFreeDoubleHost) {
 
 #if HT_NVIDIA
 HIP_TEST_CASE(Unit_hipFreeDoubleArrayFree) {
-  HIP_SKIP_TEST("tracked issue EXSWCPHIPT-120.");
+  HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-120.");
+  return;
 
   size_t width = GENERATE(32, 512, 1024);
   size_t height = GENERATE(0, 32, 512, 1024);
@@ -235,7 +236,8 @@ HIP_TEST_CASE(Unit_hipFreeDoubleArrayFree) {
 }
 
 HIP_TEST_CASE(Unit_hipFreeDoubleArrayDestroy) {
-  HIP_SKIP_TEST("tracked issue EXSWCPHIPT-120.");
+  HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-120.");
+  return;
   using vec_info = vector_info<char>;
 
   size_t width = GENERATE(32, 512, 1024);

--- a/projects/hip-tests/catch/unit/memory/hipFreeArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipFreeArray.cc
@@ -43,7 +43,8 @@ HIP_TEST_CASE(Unit_hipFreeArray_NegativeArray) {
 
 HIP_TEST_CASE(Unit_hipFreeArray_DoubleFree) {
 #if HT_NVIDIA
-  HIP_SKIP_TEST("tracked issue EXSWCPHIPT-120.");
+  HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-120.");
+  return;
 #endif
 
   CHECK_IMAGE_SUPPORT

--- a/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
+++ b/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
@@ -5382,7 +5382,8 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisAddressRelated) {
  */
 HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisManagedMemory) {
   if (HmmAttrPrint() != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   void* hipMallocManaged_ptr = nullptr;
@@ -5675,7 +5676,8 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisStreamOrderedMemory) {
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
 
   if (mem_pool_support != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
 
   void* hipMallocAsync_ptr = nullptr;
@@ -6018,7 +6020,8 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisPeerToPeer) {
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
 
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   void* hipMemGetAddressRange_ptr = nullptr;
@@ -6049,7 +6052,8 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_MemoryApisPeerToPeer) {
   int canAccessPeer = 0;
   HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, deviceId, peerDeviceId));
   if (!canAccessPeer) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    return;
   }
 
   const int N = 16;

--- a/projects/hip-tests/catch/unit/memory/hipHostAlloc.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostAlloc.cc
@@ -175,7 +175,7 @@ HIP_TEST_CASE(Unit_hipHostAlloc_Basic) {
   HIP_CHECK(hipGetDevice(&device));
   HIP_CHECK(hipGetDeviceProperties(&prop, device));
   if (prop.canMapHostMemory != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
   } else {
     float *A_h, *B_h, *C_h;
     float *A_d, *B_d, *C_d;
@@ -320,7 +320,8 @@ HIP_TEST_CASE(Unit_hipHostAlloc_AllocateMoreThanTotalSystemMemory) {
   char* host_ptr = nullptr;
   const size_t total_ram_mb = HipTest::getTotalSystemMemoryInMB();
   if (total_ram_mb == 0) {
-    HIP_SKIP_TEST("total system memory could not be queried.");
+    HipTest::HIP_SKIP_TEST("total system memory could not be queried.");
+    return;
   }
 
   const size_t total_ram_bytes = total_ram_mb * 1024 * 1024;

--- a/projects/hip-tests/catch/unit/memory/hipHostGetDevicePointer.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostGetDevicePointer.cc
@@ -47,7 +47,8 @@ template <typename T> __global__ void set(T* ptr, T val) { *ptr = val; }
 
 HIP_TEST_CASE(Unit_hipHostGetDevicePointer_UseCase) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCanMapHostMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+    return;
   }
 
   int* hPtr{nullptr};
@@ -86,7 +87,8 @@ HIP_TEST_CASE(Unit_hipHostGetDevicePointer_UseCase) {
 
 HIP_TEST_CASE(Unit_hipHostGetDevicePointer_Capture) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCanMapHostMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+    return;
   }
 
   int* host_ptr = nullptr;

--- a/projects/hip-tests/catch/unit/memory/hipHostGetFlags.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostGetFlags.cc
@@ -85,7 +85,8 @@ HIP_TEST_CASE(Unit_hipHostGetFlags_flagCombos) {
 
   // Skip test if device does not support the property canMapHostMemory
   if (prop.canMapHostMemory != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+    return;
   } else {
     // Allocate using the generated flags combos
     INFO("Flag passed when allocating: 0x" << std::hex << FlagComp << "\n");
@@ -116,7 +117,8 @@ HIP_TEST_CASE(Unit_hipHostGetFlags_DifferentThreads) {
   HIP_CHECK(hipGetDevice(&device));
   HIP_CHECK(hipGetDeviceProperties(&prop, device));
   if (prop.canMapHostMemory != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+    return;
   } else {
     // Make sure we allocate before trying to get the flags
     std::thread malloc_thread(
@@ -144,7 +146,8 @@ HIP_TEST_CASE(Unit_hipHostGetFlags_InvalidArgs) {
 
   // Skip test if device does not support the property canMapHostMemory
   if (prop.canMapHostMemory != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+    return;
   } else {
     SECTION("Invalid flag ptr being passed to hipHostGetFlags") {
       // Use default flag

--- a/projects/hip-tests/catch/unit/memory/hipHostMalloc.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostMalloc.cc
@@ -95,7 +95,7 @@ HIP_TEST_CASE(Unit_hipHostMalloc_Basic) {
   HIP_CHECK(hipGetDevice(&device));
   HIP_CHECK(hipGetDeviceProperties(&prop, device));
   if (prop.canMapHostMemory != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
   } else {
     float *A_h, *B_h, *C_h;
     float *A_d, *B_d, *C_d;
@@ -191,7 +191,7 @@ HIP_TEST_CASE(Unit_hipHostMalloc_Coherent) {
 
     HIP_CHECK(hipFreeHost(A));
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCoherentHostAllocFailed);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCoherentHostAllocFailed);
   }
 }
 
@@ -221,7 +221,8 @@ HIP_TEST_CASE(Unit_hipHostMalloc_AllocateMoreThanTotalSystemMemory) {
   char* host_ptr = nullptr;
   const size_t total_ram_mb = HipTest::getTotalSystemMemoryInMB();
   if (total_ram_mb == 0) {
-    HIP_SKIP_TEST("total system memory could not be queried.");
+    HipTest::HIP_SKIP_TEST("total system memory could not be queried.");
+    return;
   }
 
   const size_t total_ram_bytes = total_ram_mb * 1024 * 1024;

--- a/projects/hip-tests/catch/unit/memory/hipHostMallocTests.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostMallocTests.cc
@@ -23,7 +23,7 @@ Testcase Scenarios :
  */
 HIP_TEST_CASE(Unit_hipHostMalloc_ArgValidation) {
 #if HT_NVIDIA
-  HIP_SKIP_TEST("host malloc test path pending debug.");
+  HipTest::HIP_SKIP_TEST("host malloc test path pending debug.");
 #endif
   constexpr size_t allocSize = 1000;
   char* ptr;

--- a/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
@@ -28,6 +28,16 @@ static constexpr auto LEN{1024};
 static constexpr auto LARGE_CHUNK_LEN{128 * LEN};
 static constexpr auto SMALL_CHUNK_LEN{8 * LEN};
 
+#if HT_AMD
+#define TEST_SKIP(arch)                                                                            \
+  if (std::string::npos == arch.find("xnack+")) {                                                  \
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);                                \
+    return;                                                                                        \
+  }
+#else
+#define TEST_SKIP(arch)
+#endif
+
 template <typename T> __global__ void SetVal(T* in, T val) {
   int i = threadIdx.x + blockIdx.x * blockDim.x;
   in[i] = val;
@@ -552,7 +562,9 @@ HIP_TEST_CASE(Unit_hipHostRegister_MemAdvise_SetGet) {
   hipDeviceProp_t prop;
   HIP_CHECK(hipGetDeviceProperties(&prop, 0));
   if (prop.concurrentManagedAccess == 0) {
-    HIP_SKIP_TEST("concurrent managed access is not supported for this test.");
+    HipTest::HIP_SKIP_TEST(
+        "concurrent managed access is not supported for this test.");
+    return;
   }
   int numDevices = HipTest::getDeviceCount();
   size_t sizeBytes{LEN * sizeof(uint8_t)};

--- a/projects/hip-tests/catch/unit/memory/hipHostUnregister.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostUnregister.cc
@@ -17,18 +17,22 @@ constexpr unsigned int allFlags = hipHostRegisterDefault |   // 0
     ;
 #endif
 
-inline void hipHostRegisterSupported() {
+inline bool hipHostRegisterSupported() {
 #if HT_NVIDIA
   // unable to query for cudaDevAttrHostRegisterSupported equivalent
-
-  HIP_SKIP_TEST("hipHostRegister is not supported on this device.");
+  HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-40.");
+  HipTest::HIP_SKIP_TEST("hipHostRegister is not supported on this device.");
+  return false;
+#else
+  return true;
 #endif
 }
 
 
 TEST_CASE("Unit_hipHostUnregister_MemoryNotAccessibleAfterUnregister") {
-  hipHostRegisterSupported();
-
+  if (!hipHostRegisterSupported()) {
+    return;
+  }
   // try all combinations of flags
   for (unsigned int flag = 0; flag <= allFlags; ++flag) {
 #if defined(_WIN32)
@@ -65,8 +69,9 @@ HIP_TEST_CASE(Unit_hipHostUnregister_NotRegisteredPointer) {
 }
 
 HIP_TEST_CASE(Unit_hipHostUnregister_AlreadyUnregisteredPointer) {
-  hipHostRegisterSupported();
-
+  if (!hipHostRegisterSupported()) {
+    return;
+  }
   // try all combinations of flags
   for (unsigned int flag = 0; flag <= allFlags; ++flag) {
 #if defined(_WIN32)

--- a/projects/hip-tests/catch/unit/memory/hipMalloc3DArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMalloc3DArray.cc
@@ -154,7 +154,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMalloc3DArray_MaxTexture, int, uint4, short, usho
   const unsigned int flag = GENERATE(hipArrayDefault, hipArraySurfaceLoadStore);
 #endif
   if (flag == hipArraySurfaceLoadStore) {
-    HIP_SKIP_TEST("tracked issue EXSWCPHIPT-58.");
+    HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-58.");
+    return;
   }
   CAPTURE(flag);
   const Sizes sizes(flag);
@@ -425,7 +426,8 @@ HIP_TEST_CASE(Unit_hipMalloc3DArray_Negative_NumericLimit) {
 HIP_TEMPLATE_TEST_CASE(Unit_hipMalloc3DArray_Negative_Non2DTextureGather, char, uchar2, short4,
                    float2, float4) {
 #if HT_AMD
-  HIP_SKIP_TEST(HipTest::SkipReason::kTextureGatherUnsupportedAmd);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureGatherUnsupportedAmd);
+  return;
 #endif
   hipArray_t array;
   const auto desc = hipCreateChannelDesc<TestType>();

--- a/projects/hip-tests/catch/unit/memory/hipMallocManaged.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocManaged.cc
@@ -70,7 +70,8 @@ HIP_TEST_CASE(Unit_hipMallocManaged_Basic) {
 HIP_TEST_CASE(Unit_hipMallocManaged_Advanced) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   float *A, *B, *C;

--- a/projects/hip-tests/catch/unit/memory/hipMallocManagedFlagsTst.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocManagedFlagsTst.cc
@@ -18,7 +18,8 @@ __global__ void MallcMangdFlgTst(int n, float* x, float* y) {
 HIP_TEST_CASE(Unit_hipMallocManaged_FlgParam) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   std::atomic<int> DataMismatch{0};
@@ -105,7 +106,8 @@ HIP_TEST_CASE(Unit_hipMallocManaged_FlgParam) {
 HIP_TEST_CASE(Unit_hipMallocManaged_AccessMultiStream) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   std::atomic<int> DataMismatch{0};

--- a/projects/hip-tests/catch/unit/memory/hipMallocManaged_MultiScenario.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocManaged_MultiScenario.cc
@@ -63,7 +63,8 @@ void HostKernelDouble(float* Hmm, float* hPtr, size_t n) {
 HIP_TEST_CASE(Unit_hipMallocManaged_HostDeviceConcurrent) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   float *Hmm = nullptr, *hPtr = nullptr, *dPtr = nullptr, *resPtr = nullptr;
@@ -99,7 +100,8 @@ HIP_TEST_CASE(Unit_hipMallocManaged_HostDeviceConcurrent) {
 HIP_TEST_CASE(Unit_hipMallocManaged_MultiChunkSingleDevice) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   std::atomic<int> DataMismatch{0};
@@ -150,7 +152,8 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MultiChunkSingleDevice) {
 HIP_TEST_CASE(Unit_hipMallocManaged_MultiChunkMultiDevice) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   std::atomic<int> DataMismatch{0};
@@ -158,7 +161,8 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MultiChunkMultiDevice) {
   int NumDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&NumDevices));
   if (NumDevices < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   unsigned int NUM_ELMS = (1024 * 1024);
   float *Ad[MAX_GPU], *Hmm = NULL, *Ah = new float[NUM_ELMS];
@@ -204,14 +208,16 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MultiChunkMultiDevice) {
 HIP_TEST_CASE(Unit_hipMallocManaged_OverSubscription) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
 #if HT_AMD
   int isPageableHMM = 0;
   HIP_CHECK(hipDeviceGetAttribute(&isPageableHMM, hipDeviceAttributePageableMemoryAccess, 0));
   if (!isPageableHMM) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
+    return;
   }
 #endif
 
@@ -287,7 +293,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMallocManaged_TwoPointers, int,
                    float, double) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   int NumDevices = 0;
@@ -327,13 +334,15 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMallocManaged_DeviceContextChange,
                    unsigned char, int, float, double) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   int NumDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&NumDevices));
   if (NumDevices < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   std::atomic<unsigned int> DataMismatch;

--- a/projects/hip-tests/catch/unit/memory/hipMallocMipmappedArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocMipmappedArray.cc
@@ -356,7 +356,8 @@ HIP_TEST_CASE(Unit_hipMallocMipmappedArray_Negative_NumericLimit) {
 HIP_TEMPLATE_TEST_CASE(Unit_hipMallocMipmappedArray_Negative_Non2DTextureGather, char, uchar2,
                    float2) {
 #if HT_AMD
-  HIP_SKIP_TEST(HipTest::SkipReason::kTextureGatherUnsupportedAmd);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kTextureGatherUnsupportedAmd);
+  return;
 #endif
   hipMipmappedArray_t array;
   unsigned int numLevels = 1;

--- a/projects/hip-tests/catch/unit/memory/hipMallocMngdMultiThread.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocMngdMultiThread.cc
@@ -285,7 +285,8 @@ static void AllocateHmmMemory(int flag, int device) {
 HIP_TEST_CASE(Unit_hipMallocManaged_MultiThread) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   IfTestPassed = true;
@@ -338,14 +339,16 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MultiThread) {
 HIP_TEST_CASE(Unit_hipMallocManaged_MGpuMThread) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   IfTestPassed = true;
   int Ngpus = 0;
   HIP_CHECK(hipGetDeviceCount(&Ngpus));
   if (Ngpus < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   int InitVal = 123, *Hmm1 = NULL, NumElms = 4096 * 4;
@@ -379,7 +382,8 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MGpuMThread) {
 HIP_TEST_CASE(Unit_hipMallocManaged_MultiKrnlComnHmm) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   IfTestPassed = true;
@@ -413,7 +417,8 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MultiKrnlComnHmm) {
 HIP_TEST_CASE(Unit_hipMallocManaged_MultiKrnlComnMalloc) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   IfTestPassed = true;
@@ -443,7 +448,8 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MultiKrnlComnMalloc) {
 HIP_TEST_CASE(Unit_hipMallocManaged_MultiThrdMultiStrm) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   IfTestPassed = true;
@@ -476,7 +482,8 @@ HIP_TEST_CASE(Unit_hipMallocManaged_MultiThrdMultiStrm) {
 HIP_TEST_CASE(Unit_hipMallocManaged_TwoKrnlsComnHmmMem) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   IfTestPassed = true;

--- a/projects/hip-tests/catch/unit/memory/hipMemAdvise.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAdvise.cc
@@ -53,7 +53,8 @@ std::vector<int> GetDevicesWithAdviseSupport() {
 HIP_TEST_CASE(Unit_hipMemAdvise_Set_Unset_Basic) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
   supported_devices.push_back(hipCpuDeviceId);
   const auto device = GENERATE_COPY(from_range(supported_devices));
@@ -82,7 +83,8 @@ HIP_TEST_CASE(Unit_hipMemAdvise_Set_Unset_Basic) {
 HIP_TEST_CASE(Unit_hipMemAdvise_No_Flag_Interference) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
   supported_devices.push_back(hipCpuDeviceId);
   const auto device = GENERATE_COPY(from_range(supported_devices));
@@ -109,7 +111,8 @@ HIP_TEST_CASE(Unit_hipMemAdvise_No_Flag_Interference) {
 HIP_TEST_CASE(Unit_hipMemAdvise_Rounding) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
   supported_devices.push_back(hipCpuDeviceId);
   const auto device = supported_devices.front();
@@ -140,7 +143,8 @@ HIP_TEST_CASE(Unit_hipMemAdvise_Rounding) {
 HIP_TEST_CASE(Unit_hipMemAdvise_Flags_Do_Not_Cause_Prefetch) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
   supported_devices.push_back(hipCpuDeviceId);
 
@@ -166,7 +170,8 @@ HIP_TEST_CASE(Unit_hipMemAdvise_Flags_Do_Not_Cause_Prefetch) {
 HIP_TEST_CASE(Unit_hipMemAdvise_Read_Write_After_Advise) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
   LinearAllocGuard<int> alloc(LinearAllocs::hipMallocManaged, kPageSize);
   constexpr size_t count = kPageSize / sizeof(*alloc.ptr());
@@ -210,7 +215,8 @@ HIP_TEST_CASE(Unit_hipMemAdvise_Read_Write_After_Advise) {
 HIP_TEST_CASE(Unit_hipMemAdvise_Prefetch_After_Advise) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
   supported_devices.push_back(hipCpuDeviceId);
   const auto advice = GENERATE(hipMemAdviseSetReadMostly, hipMemAdviseSetPreferredLocation
@@ -241,7 +247,8 @@ HIP_TEST_CASE(Unit_hipMemAdvise_Prefetch_After_Advise) {
 HIP_TEST_CASE(Unit_hipMemAdvise_AccessedBy_All_Devices) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
   // Disabling this hipCpuDeviceId scenario as it fails due to ROCr issue
   // Enable it once SWDEV-36994, SWDEV-392002 are fixed
@@ -260,7 +267,8 @@ HIP_TEST_CASE(Unit_hipMemAdvise_AccessedBy_All_Devices) {
 HIP_TEST_CASE(Unit_hipMemAdvise_Negative_Parameters) {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
   const auto device = supported_devices.front();
 

--- a/projects/hip-tests/catch/unit/memory/hipMemAdviseMmap.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAdviseMmap.cc
@@ -63,6 +63,6 @@ HIP_TEST_CASE(Unit_hipMemAdvise_MmapMem) {
     close(fd);
 #endif
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
   }
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemAdvise_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAdvise_old.cc
@@ -118,7 +118,8 @@ HIP_TEST_CASE(Unit_hipMemAdvise_TstAccessedByPeer) {
 
     HIP_CHECK(hipGetDeviceCount(&NumDevs));
     if (NumDevs < 2) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+      return;
     }
     HIP_CHECK(hipMallocManaged(&Hmm, MEM_SIZE, hipMemAttachGlobal));
     for (int i = 0; i < NumDevs; ++i) {
@@ -153,7 +154,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_TstAccessedByPeer) {
     HIP_CHECK(hipFree(Hmm));
     REQUIRE(IfTestPassed);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 #endif
@@ -183,7 +184,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_TstAccessedByFlg2) {
       HIP_CHECK(hipFree(Hmm));
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -222,7 +223,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_TstAccessedByFlg3) {
       HIP_CHECK(hipFree(Hmm));
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -267,7 +268,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_TstAccessedByFlg4) {
     HIP_CHECK(hipFree(Hmm));
     HIP_CHECK(hipStreamDestroy(strm));
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -317,13 +318,14 @@ HIP_TEST_CASE(Unit_hipMemAdvise_TstAlignedAllocMem) {
       HIP_CHECK(hipStreamDestroy(strm));
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
   }
 }
 
 HIP_TEST_CASE(Unit_hipMemAdvise_TstAlignedAllocMem_XNACK) {
   if (setenv("HSA_XNACK", "1", 1) != 0) {
-    HIP_SKIP_TEST("cannot set XNACK via environment.");
+    HipTest::HIP_SKIP_TEST("cannot set XNACK via environment.");
+    return;
   }
 
   hipDeviceProp_t prop;
@@ -336,7 +338,7 @@ HIP_TEST_CASE(Unit_hipMemAdvise_TstAlignedAllocMem_XNACK) {
     hip::SpawnProc proc("hipMemAdviseTstAlignedAllocMem", true);
     REQUIRE(proc.run() == 0);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kGpuXnackNotEnabled);
   }
 }
 #endif
@@ -353,7 +355,8 @@ HIP_TEST_CASE(Unit_hipMemAdvise_ReadMosltyMgpuTst) {
     int Ngpus = 0;
     HIP_CHECK(hipGetDeviceCount(&Ngpus));
     if (Ngpus < 2) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+      return;
     }
     int *Hmm = NULL, NumElms = (1024 * 1024), InitVal = 123;
     int *Hmm1 = NULL, DataMismatch = 0;
@@ -415,6 +418,6 @@ HIP_TEST_CASE(Unit_hipMemAdvise_ReadMosltyMgpuTst) {
     HIP_CHECK(hipFree(Hmm));
 
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemAdvise_v2.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAdvise_v2.cc
@@ -58,7 +58,8 @@ static std::vector<int> getSupportedDevices() {
 HIP_TEST_CASE(Unit_hipMemAdvise_v2_Device_Host) {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   HIP_CHECK(hipSetDevice(supportedDevices[0]));
@@ -144,10 +145,12 @@ HIP_TEST_CASE(Unit_hipMemAdvise_v2_Device_Host) {
 HIP_TEST_CASE(Unit_hipMemAdvise_v2_HostNuma_HostNumaCurrent) {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedNoConcurrentAccess);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedNoConcurrentAccess);
+    return;
   }
   if (numa_available() < 0) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kHostNumaUnavailable);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostNumaUnavailable);
+    return;
   }
 
   HIP_CHECK(hipSetDevice(supportedDevices[0]));
@@ -222,7 +225,8 @@ HIP_TEST_CASE(Unit_hipMemAdvise_v2_HostNuma_HostNumaCurrent) {
 HIP_TEST_CASE(Unit_hipMemAdvise_v2_Negative) {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   HIP_CHECK(hipSetDevice(supportedDevices[0]));

--- a/projects/hip-tests/catch/unit/memory/hipMemAllocHost.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAllocHost.cc
@@ -91,7 +91,8 @@ HIP_TEST_CASE(Unit_hipMemAllocHost_VerifyAccess) {
                                     device_index));
 
     if (!support_unified_adressing) {
-      HIP_SKIP_TEST("unified addressing is not supported.");
+      HipTest::HIP_SKIP_TEST("unified addressing is not supported.");
+      return;
     }
   }
 

--- a/projects/hip-tests/catch/unit/memory/hipMemCoherencyTst.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemCoherencyTst.cc
@@ -138,7 +138,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_CoherentTst) {
     HIP_CHECK(hipFree(Ptr));
     REQUIRE(YES_COHERENT);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 #endif
@@ -177,7 +177,7 @@ HIP_TEST_CASE(Unit_hipMallocManaged_CoherentTstWthAdvise) {
     HIP_CHECK(hipStreamDestroy(strm));
     REQUIRE(YES_COHERENT);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -218,10 +218,12 @@ HIP_TEST_CASE(Unit_hipExtMallocWithFlags_CoherentTst) {
   HIP_CHECK(hipDeviceGetAttribute(&managed, hipDeviceAttributeManagedMemory, 0));
   INFO("hipDeviceAttributeManagedMemory: " << managed);
   if (managed != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
   if (Pageable != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
+    return;
   }
 
   // Allocating hipExtMallocWithFlags() memory with flags

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolApi.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolApi.cc
@@ -34,7 +34,8 @@ HIP_TEST_CASE(Unit_hipMemPoolApi_Basic) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
 
   int numElements = 64 * 1024 * 1024;
@@ -90,7 +91,8 @@ HIP_TEST_CASE(Unit_hipMemPoolApi_BasicAlloc) {
 
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   unsigned int* notified = nullptr;
   HIP_CHECK(hipHostMalloc(&notified, sizeof(unsigned int)));
@@ -178,7 +180,8 @@ HIP_TEST_CASE(Unit_hipMemPoolApi_BasicTrim) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   unsigned int* notified = nullptr;
   HIP_CHECK(hipHostMalloc(&notified, sizeof(unsigned int)));
@@ -265,7 +268,8 @@ HIP_TEST_CASE(Unit_hipMemPoolApi_BasicReuse) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   unsigned int* notified = nullptr;
   HIP_CHECK(hipHostMalloc(&notified, sizeof(unsigned int)));
@@ -339,7 +343,8 @@ HIP_TEST_CASE(Unit_hipMemPoolApi_Opportunistic) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   unsigned int *notified1 = nullptr, *notified2 = nullptr;
   HIP_CHECK(hipHostMalloc(&notified1, sizeof(unsigned int)));
@@ -495,7 +500,8 @@ HIP_TEST_CASE(Unit_hipMemPoolApi_Default) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   unsigned int* notified = nullptr;
   HIP_CHECK(hipHostMalloc(&notified, sizeof(unsigned int)));

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolExportToShareableHandle.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolExportToShareableHandle.cc
@@ -462,12 +462,14 @@ HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_multiproc) {
   hipMemAllocationHandleType handleType;
 #if HT_WIN
   if (!(handleTypesSupported & hipMemHandleTypeWin32)) {
-    HIP_SKIP_TEST("Win32 handle type not supported. Skipping Test..");
+    HipTest::HIP_SKIP_TEST("Win32 handle type not supported. Skipping Test..");
+    return;
   }
   handleType = hipMemHandleTypeWin32;
 #else
   if (!(handleTypesSupported & hipMemHandleTypePosixFileDescriptor)) {
-    HIP_SKIP_TEST("POSIX FD handle type not supported. Skipping Test..");
+    HipTest::HIP_SKIP_TEST("POSIX FD handle type not supported. Skipping Test..");
+    return;
   }
   handleType = hipMemHandleTypePosixFileDescriptor;
 #endif
@@ -562,7 +564,8 @@ HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_multiproc) {
 HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_multiproc_child) {
   unsigned long parentPid = getParentProcessId();
   if (parentPid == 0) {
-    HIP_SKIP_TEST("Not launched by parent test. Skipping..");
+    HipTest::HIP_SKIP_TEST("Not launched by parent test. Skipping..");
+    return;
   }
   char shmName[64];
 #if HT_WIN
@@ -573,10 +576,10 @@ HIP_TEST_CASE(Unit_hipMemPoolExportToShareableHandle_multiproc_child) {
 
   SharedMemory shm;
   if (shm.open(shmName, sizeof(mempoolIpcShmStruct)) != 0) {
-    HIP_SKIP_TEST(
-        "Parent shared memory not found. "
-        "This test should only be invoked by "
-        "Unit_hipMemPoolExportToShareableHandle_multiproc. Skipping..");
+    HipTest::HIP_SKIP_TEST("Parent shared memory not found. "
+                            "This test should only be invoked by "
+                            "Unit_hipMemPoolExportToShareableHandle_multiproc. Skipping..");
+    return;
   }
   auto *shmData = shm.as<mempoolIpcShmStruct>();
 

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolMaxAlloc.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolMaxAlloc.cc
@@ -36,7 +36,8 @@ hipError_t Test() {
   HIP_CHECK_LT(hipMemGetInfo(&free, &total));
   if (free < 30_GB) {
     std::cout << "Free memory is too low: " << free / 1_MB << " MiB" << std::endl;
-    HIP_SKIP_TEST("test requires more than 30 GiB of free memory.");
+    HipTest::HIP_SKIP_TEST("test requires more than 30 GiB of free memory.");
+    return hipSuccess;
   }
 
   uint64_t threshold = std::numeric_limits<uint64_t>::max();

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolSetGetAccess.cc
@@ -88,7 +88,8 @@ int CheckP2PMemPoolSupport(int src_device, int dst_device) {
 HIP_TEST_CASE(Unit_hipMemPoolSetGetAccess_Positive_MultipleGPU) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   const auto src_device = GENERATE(range(0, HipTest::getDeviceCount()));
   const auto dst_device = GENERATE(range(0, HipTest::getDeviceCount()));
@@ -96,7 +97,8 @@ HIP_TEST_CASE(Unit_hipMemPoolSetGetAccess_Positive_MultipleGPU) {
 
   int mem_pool_support = CheckP2PMemPoolSupport(src_device, dst_device);
   if (!mem_pool_support) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
 
   const auto mempool_type = GENERATE(MemPools::dev_default, MemPools::created);
@@ -119,7 +121,8 @@ void MemPoolSetGetAccess_P2P(const MemPools mempool_type) {
 
   int mem_pool_support = CheckP2PMemPoolSupport(src_device, dst_device);
   if (!mem_pool_support) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
 
   int *alloc_mem1, *alloc_mem2;
@@ -200,7 +203,8 @@ void MemPoolSetGetAccess_P2P(const MemPools mempool_type) {
 HIP_TEST_CASE(Unit_hipMemPoolSetGetAccess_Positive_P2P) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   SECTION("Default MemPool") { MemPoolSetGetAccess_P2P(MemPools::dev_default); }

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolTrimTo.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolTrimTo.cc
@@ -210,7 +210,8 @@ HIP_TEST_CASE(Unit_hipMemPoolTrimTo_MGpuVaryingMinBytesToHold) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   for (int dev = 0; dev < numDevices; dev++) {
     checkMempoolSupported(dev) HIP_CHECK(hipSetDevice(dev));

--- a/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsync.cc
@@ -35,7 +35,8 @@ __global__ void MemPrefetchAsyncKernel(int* C_d, const int* A_d, size_t N) {
 HIP_TEST_CASE(Unit_hipMemPrefetchAsync_Basic_AllDevices) {
   const auto supported_devices = GetDevicesWithPrefetchSupport();
   if (supported_devices.empty()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   LinearAllocGuard<int> alloc1(LinearAllocs::hipMallocManaged, kPageSize);
@@ -64,7 +65,8 @@ HIP_TEST_CASE(Unit_hipMemPrefetchAsync_Basic_AllDevices) {
 HIP_TEST_CASE(Unit_hipMemPrefetchAsync_Sync_Behavior) {
   const auto supported_devices = GetDevicesWithPrefetchSupport();
   if (supported_devices.empty()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
   const auto device = supported_devices.front();
   const auto stream_type = GENERATE(Streams::nullstream, Streams::perThread, Streams::created);
@@ -80,7 +82,8 @@ HIP_TEST_CASE(Unit_hipMemPrefetchAsync_Sync_Behavior) {
 HIP_TEST_CASE(Unit_hipMemPrefetchAsync_Rounding_Behavior) {
   auto supported_devices = GetDevicesWithPrefetchSupport();
   if (supported_devices.empty()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
   const auto device = supported_devices.front();
   LinearAllocGuard<uint8_t> alloc(LinearAllocs::hipMallocManaged, 3 * kPageSize);
@@ -112,7 +115,8 @@ HIP_TEST_CASE(Unit_hipMemPrefetchAsync_Rounding_Behavior) {
 HIP_TEST_CASE(Unit_hipMemPrefetchAsync_Negative_Parameters) {
   auto supported_devices = GetDevicesWithPrefetchSupport();
   if (supported_devices.empty()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
   supported_devices.push_back(hipCpuDeviceId);
   const auto device = GENERATE_COPY(from_range(supported_devices));

--- a/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsyncExtTsts.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsyncExtTsts.cc
@@ -104,10 +104,10 @@ HIP_TEST_CASE(Unit_hipMemPrefetchAsyncAdviseFlgTst) {
       HIP_CHECK(hipFree(Hmm));
       REQUIRE(IfTestPassed);
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 
@@ -195,10 +195,10 @@ HIP_TEST_CASE(Unit_hipMemPrefetchAsyncAccsdByTst) {
       HIP_CHECK(hipStreamDestroy(strm));
       REQUIRE(IfTestPassed);
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 }
 
@@ -294,7 +294,7 @@ HIP_TEST_CASE(Unit_hipMemPrefetchAsyncNegativeTst) {
     REQUIRE(IfTestPassed);
 
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsync_v2.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsync_v2.cc
@@ -58,7 +58,8 @@ static std::vector<int> getSupportedDevices() {
 HIP_TEST_CASE(Unit_hipMemPrefetchAsync_v2_Device_Host) {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   HIP_CHECK(hipSetDevice(supportedDevices[0]));
@@ -169,10 +170,12 @@ HIP_TEST_CASE(Unit_hipMemPrefetchAsync_v2_Device_Host) {
 HIP_TEST_CASE(Unit_hipMemPrefetchAsync_v2_HostNuma_HostNumaCurrent) {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedNoConcurrentAccess);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedNoConcurrentAccess);
+    return;
   }
   if (numa_available() < 0) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kHostNumaUnavailable);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kHostNumaUnavailable);
+    return;
   }
 
   HIP_CHECK(hipSetDevice(supportedDevices[0]));
@@ -290,7 +293,8 @@ HIP_TEST_CASE(Unit_hipMemPrefetchAsync_v2_HostNuma_HostNumaCurrent) {
 HIP_TEST_CASE(Unit_hipMemPrefetchAsync_v2_Negative) {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   HIP_CHECK(hipSetDevice(supportedDevices[0]));

--- a/projects/hip-tests/catch/unit/memory/hipMemPrefetchBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPrefetchBatchAsync.cc
@@ -38,7 +38,8 @@ constexpr size_t kTestBufferBytes = kTestBufferElements * sizeof(int);
   int device_var = 0;                                                                              \
   HIP_CHECK(hipSetDevice(device_var));                                                             \
   if (!DeviceAttributesSupport(device_var, hipDeviceAttributeConcurrentManagedAccess)) {           \
-    HIP_SKIP_TEST("Device does not support concurrent managed access");                            \
+    HipTest::HIP_SKIP_TEST("Device does not support concurrent managed access");                   \
+    return;                                                                                        \
   }
 
 }  // namespace
@@ -574,7 +575,8 @@ TEST_CASE("Unit_hipMemPrefetchBatchAsync_MultiDevice") {
   HIP_CHECK(hipGetDeviceCount(&device_count));
 
   if (device_count < 2) {
-    HIP_SKIP_TEST("Multi-device test requires at least 2 GPUs");
+    HipTest::HIP_SKIP_TEST("Multi-device test requires at least 2 GPUs");
+    return;
   }
 
   std::vector<int> supported_devices;
@@ -585,7 +587,9 @@ TEST_CASE("Unit_hipMemPrefetchBatchAsync_MultiDevice") {
   }
 
   if (supported_devices.size() < 2) {
-    HIP_SKIP_TEST("Multi-device test requires at least 2 GPUs with concurrent managed access");
+    HipTest::HIP_SKIP_TEST(
+        "Multi-device test requires at least 2 GPUs with concurrent managed access");
+    return;
   }
 
   int device = supported_devices[0];

--- a/projects/hip-tests/catch/unit/memory/hipMemRangeGetAttribute.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemRangeGetAttribute.cc
@@ -11,7 +11,8 @@
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, kPageSize);
@@ -31,7 +32,8 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Basic) {
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Partial_Range) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, 2 * kPageSize);
@@ -52,7 +54,8 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Partial_Range) {
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, kPageSize);
@@ -72,7 +75,8 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Basic) {
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_CPU) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, kPageSize);
@@ -89,7 +93,8 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_CPU) {
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Partial_Range) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, 2 * kPageSize);
@@ -110,7 +115,8 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Partial_Ra
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, kPageSize);
@@ -130,7 +136,8 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Basic) 
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_CPU) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, kPageSize);
@@ -146,7 +153,8 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_CPU) {
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Partial_Range) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, 2 * kPageSize);
@@ -167,7 +175,8 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Partial
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, kPageSize);
@@ -197,7 +206,8 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Basic) {
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Partial_Range) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, 2 * kPageSize);
@@ -228,12 +238,14 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Partial_Range) {
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_AccessedBy_MultiDevice) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, kPageSize);
@@ -261,7 +273,8 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Positive_AccessedBy_MultiDevice) {
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_Negative_Parameters) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   int32_t data;

--- a/projects/hip-tests/catch/unit/memory/hipMemRangeGetAttribute_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemRangeGetAttribute_old.cc
@@ -48,7 +48,8 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_TstCountParam) {
     int isPageableHMM = 0;
     HIP_CHECK(hipDeviceGetAttribute(&isPageableHMM, hipDeviceAttributePageableMemoryAccess, 0));
     if (!isPageableHMM) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
+      return;
     }
 #endif
 
@@ -90,7 +91,7 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_TstCountParam) {
 
     REQUIRE(IfTestPassed);
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -143,7 +144,7 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_AccessedBy1) {
     }
     HIP_CHECK(hipFree(Hmm));
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -188,6 +189,6 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttribute_4) {
     HIP_CHECK(hipFree(Hmm));
     delete[] OutData;
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemRangeGetAttributes.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemRangeGetAttributes.cc
@@ -11,7 +11,8 @@
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttributes_Positive_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   LinearAllocGuard<void> allocation(LinearAllocs::hipMallocManaged, kPageSize);
@@ -48,7 +49,8 @@ HIP_TEST_CASE(Unit_hipMemRangeGetAttributes_Positive_Basic) {
 
 HIP_TEST_CASE(Unit_hipMemRangeGetAttributes_Negative_Parameters) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   constexpr size_t num_attributes = 4;

--- a/projects/hip-tests/catch/unit/memory/hipMemVmm.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemVmm.cc
@@ -29,7 +29,8 @@ HIP_TEST_CASE(Unit_hipMemVmm_Basic) {
   INFO("hipDeviceAttributeVirtualMemoryManagementSupported: " << vmm);
 
   if (vmm == 0) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);
+    return;
   }
 
   size_t granularity = 0;
@@ -86,7 +87,8 @@ HIP_TEST_CASE(Unit_hipMemVmm_Uncached) {
   INFO("hipDeviceAttributeVirtualMemoryManagementSupported: " << vmm);
 
   if (vmm == 0) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);
+    return;
   }
 
   size_t granularity = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync_old.cc
@@ -180,10 +180,11 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy2DAsync_multiDevice_StreamOnDiffDevice, int
       HIP_CHECK(hipFree(X_d));
       HIP_CHECK(hipStreamDestroy(stream));
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArrayAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArrayAsync_old.cc
@@ -60,10 +60,11 @@ HIP_TEST_CASE(Unit_hipMemcpy2DFromArrayAsync_multiDevicePinnedHostMem) {
       HIP_CHECK(hipStreamDestroy(stream));
       HipTest::freeArrays<float>(nullptr, nullptr, nullptr, A_h, nullptr, nullptr, false);
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 
@@ -114,10 +115,11 @@ HIP_TEST_CASE(Unit_hipMemcpy2DFromArrayAsync_multiDeviceContextChange) {
       HIP_CHECK(hipStreamDestroy(stream));
       HipTest::freeArrays<float>(nullptr, nullptr, nullptr, A_h, hData, nullptr, false);
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArray_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArray_old.cc
@@ -54,10 +54,11 @@ HIP_TEST_CASE(Unit_hipMemcpy2DFromArray_multiDevicePinnedMemPeerGpu) {
       HIP_CHECK(hipHostFree(E_h));
       HipTest::freeArrays<float>(nullptr, nullptr, nullptr, A_h, nullptr, nullptr, false);
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 
@@ -103,9 +104,10 @@ HIP_TEST_CASE(Unit_hipMemcpy2DFromArray_multiDeviceContextChange) {
       HIP_CHECK(hipFreeArray(A_d));
       HipTest::freeArrays<float>(nullptr, nullptr, nullptr, A_h, hData, nullptr, false);
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArrayAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArrayAsync_old.cc
@@ -63,10 +63,11 @@ HIP_TEST_CASE(Unit_hipMemcpy2DToArrayAsync_multiDevicePinnedHostMem) {
       HIP_CHECK(hipStreamDestroy(stream));
       HipTest::freeArrays<float>(nullptr, nullptr, nullptr, A_h, nullptr, nullptr, false);
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 
@@ -117,9 +118,10 @@ HIP_TEST_CASE(Unit_hipMemcpy2DToArrayAsync_multiDeviceDeviceContextChange) {
       HIP_CHECK(hipStreamDestroy(stream));
       HipTest::freeArrays<float>(nullptr, nullptr, nullptr, A_h, hData, nullptr, false);
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArray_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArray_old.cc
@@ -56,10 +56,11 @@ HIP_TEST_CASE(Unit_hipMemcpy2DToArray_multiDevicePinnedMemPeerGpu) {
       HIP_CHECK(hipHostFree(E_h));
       HipTest::freeArrays<float>(nullptr, nullptr, nullptr, A_h, nullptr, nullptr, false);
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 
@@ -105,9 +106,10 @@ HIP_TEST_CASE(Unit_hipMemcpy2DToArray_multiDeviceDeviceContextChange) {
       HIP_CHECK(hipFreeArray(A_d));
       HipTest::freeArrays<float>(nullptr, nullptr, nullptr, A_h, hData, nullptr, false);
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3DAsync_old.cc
@@ -166,7 +166,7 @@ template <typename T> void Memcpy3DAsync<T>::D2H_H2D_DeviceMem_OnDiffDevice() {
     // DeAllocating the Memory
     DeAllocateMemory();
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
 }
 
@@ -254,7 +254,7 @@ template <typename T> void Memcpy3DAsync<T>::D2D_DeviceMem_OnDiffDevice() {
     free(hOutputData);
     DeAllocateMemory();
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
 }
 
@@ -496,7 +496,7 @@ template <typename T> void Memcpy3DAsync<T>::D2D_SameDeviceMem_StreamDiffDevice(
     free(hOutputData);
     DeAllocateMemory();
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
 }
 
@@ -631,7 +631,8 @@ HIP_TEST_CASE(Unit_hipMemcpy3DAsync_multiDevice_Negative) {
     Memcpy3DAsync<int> memcpy3d(width, height, depth, hipChannelFormatKindSigned);
     memcpy3d.NegativeTests();
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 
@@ -656,7 +657,8 @@ HIP_TEST_CASE(Unit_hipMemcpy3DAsync_multiDevice_DiffStream) {
     Memcpy3DAsync<float> memcpy3dAsync(width, height, depth, hipChannelFormatKindFloat);
     memcpy3dAsync.D2D_SameDeviceMem_StreamDiffDevice();
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3DPeer.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3DPeer.cc
@@ -34,19 +34,22 @@ HIP_TEST_CASE(Unit_hipMemcpy3DPeer_BasicFunctional) {
   hipExtent extent = make_hipExtent(numW, numH, depth);
   const auto device_count = HipTest::getDeviceCount();
   if (device_count <= 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   const auto src_device = GENERATE_COPY(range(0, device_count));
   const auto dst_device = GENERATE_COPY(range(0, device_count));
   if (src_device == dst_device) {
     INFO("Src device: " << src_device << ", Dst device: " << dst_device);
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemcpyPeerSameSrcDstDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemcpyPeerSameSrcDstDevice);
+    return;
   }
   HIP_CHECK(hipSetDevice(src_device));
   int can_access_peer = 0;
   HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, src_device, dst_device));
   if (!can_access_peer) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    return;
   }
   // Array-1 Memory allocation
   hipChannelFormatDesc channelDesc_1 = hipCreateChannelDesc<char>();

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3DPeerAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3DPeerAsync.cc
@@ -37,19 +37,22 @@ HIP_TEST_CASE(Unit_hipMemcpy3DPeerAsync_BasicFunctional) {
   hipExtent extent = make_hipExtent(numW, numH, depth);
   const auto device_count = HipTest::getDeviceCount();
   if (device_count <= 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   const auto src_device = GENERATE_COPY(range(0, device_count));
   const auto dst_device = GENERATE_COPY(range(0, device_count));
   if (src_device == dst_device) {
     INFO("Src device: " << src_device << ", Dst device: " << dst_device);
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemcpyPeerSameSrcDstDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemcpyPeerSameSrcDstDevice);
+    return;
   }
   HIP_CHECK(hipSetDevice(src_device));
   int can_access_peer = 0;
   HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, src_device, dst_device));
   if (!can_access_peer) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    return;
   }
   // Array-1 Memory allocation
   hipChannelFormatDesc channelDesc_1 = hipCreateChannelDesc<char>();

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3D_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3D_old.cc
@@ -158,7 +158,7 @@ template <typename T> void Memcpy3D<T>::D2H_H2D_DeviceMem_OnDiffDevice() {
     free(hOutputData);
     DeAllocateMemory();
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
 }
 /*
@@ -238,7 +238,7 @@ template <typename T> void Memcpy3D<T>::D2D_DeviceMem_OnDiffDevice() {
     free(hOutputData);
     DeAllocateMemory();
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
   }
 }
 /*
@@ -522,7 +522,8 @@ HIP_TEST_CASE(Unit_hipMemcpy3D_multiDevice_Negative) {
     Memcpy3D<int> memcpy3d(width, height, depth, hipChannelFormatKindSigned);
     memcpy3d.NegativeTests();
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_derivatives.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_derivatives.cc
@@ -67,8 +67,10 @@ HIP_TEST_CASE(Unit_hipMemcpyHtoDAsync_Positive_Synchronization_Behavior) {
   // This behavior differs on NVIDIA and AMD, on AMD the hipMemcpy calls is synchronous with
   // respect to the host
 #if HT_AMD
-  HIP_SKIP_TEST(
-      "EXSWCPHIPT-127 - MemcpyAsync from host to device memory behavior differs on AMD and Nvidia");
+  HipTest::HIP_SKIP_TEST(
+      "EXSWCPHIPT-127 - MemcpyAsync from host to device memory behavior differs on AMD and "
+      "Nvidia");
+  return;
 #endif
   MemcpyHPinnedtoDSyncBehavior(
       [](void* dst, void* src, size_t count) {

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_old.cc
@@ -255,7 +255,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyAsync_PinnedRegMemWithKernelLaunch, int, fl
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   {
     // 1 refers to pinned Memory

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAtoA.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAtoA.cc
@@ -33,7 +33,8 @@
 
 HIP_TEST_CASE(Unit_hipMemcpyAtoA_Basic) {
 #if HT_NVIDIA
-  HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
+  return;
 #else
   HIP_CHECK(hipSetDevice(0));
   CHECK_IMAGE_SUPPORT

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAtoD.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAtoD.cc
@@ -31,7 +31,8 @@
  */
 HIP_TEST_CASE(Unit_hipMemcpyAtoD_Basic) {
 #if HT_NVIDIA
-  HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
+  return;
 #else
   HIP_CHECK(hipSetDevice(0));
   CHECK_IMAGE_SUPPORT

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAtoHAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAtoHAsync.cc
@@ -31,7 +31,8 @@
  */
 HIP_TEST_CASE(Unit_hipMemcpyAtoHAsync_Basic) {
 #if HT_NVIDIA
-  HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
+  return;
 #else
   HIP_CHECK(hipSetDevice(0));
   CHECK_IMAGE_SUPPORT

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAtoH_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAtoH_old.cc
@@ -39,7 +39,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyAtoH_multiDevice_PeerDeviceContext, char, i
     int peerAccess = 0;
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 1, 0));
     if (!peerAccess) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     } else {
       HIP_CHECK(hipSetDevice(0));
       hipArray_t A_d;
@@ -68,7 +68,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyAtoH_multiDevice_PeerDeviceContext, char, i
                                             false) == true);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 #endif

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyDtoD.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyDtoD.cc
@@ -34,14 +34,16 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyDtoD_Basic, int, float,
 
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   int canAccessPeer = 0;
   HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, 0, 1));
   HIP_CHECK(hipSetDevice(0));
   if (!canAccessPeer) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    return;
   }
   HIP_CHECK(hipDeviceEnablePeerAccess(1, 0));
   HipTest::initArrays<TestType>(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, NUM_ELM, false);

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyDtoDAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyDtoDAsync.cc
@@ -37,7 +37,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyDtoDAsync_Basic, int, float,
 
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   int canAccessPeer = 0;
@@ -47,7 +48,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyDtoDAsync_Basic, int, float,
     HIP_CHECK(hipDeviceEnablePeerAccess(1, 0));
   } else {
     INFO("Machine does not have P2P Capabilities");
-    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    return;
   }
   HipTest::initArrays<TestType>(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, NUM_ELM, false);
   HIP_CHECK(hipSetDevice(1));
@@ -104,13 +106,15 @@ HIP_TEST_CASE(Unit_hipMemcpyDtoDAsync_Capture) {
   int device_count = 0;
   HIP_CHECK(hipGetDeviceCount(&device_count));
   if (device_count <= 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   int peer_access = 0;
   HIP_CHECK(hipDeviceCanAccessPeer(&peer_access, 0, 1));
   if (!peer_access) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    return;
   }
 
   constexpr size_t kNumElements = NUM_ELM;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyHtoAAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyHtoAAsync.cc
@@ -93,7 +93,8 @@ HIP_TEST_CASE(Unit_hipMemcpyHtoAAsync_Negative) {
  */
 HIP_TEST_CASE(Unit_hipMemcpyHtoAAsync_BasicTstsWithDiffStreams) {
 #if HT_NVIDIA
-  HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
+  return;
 #else
   CHECK_IMAGE_SUPPORT
   HIP_CHECK(hipSetDevice(0));
@@ -154,7 +155,8 @@ HIP_TEST_CASE(Unit_hipMemcpyHtoAAsync_BasicTstsWithDiffStreams) {
  */
 HIP_TEST_CASE(Unit_hipMemcpyHtoAAsync_MultiDevice) {
 #if HT_NVIDIA
-  HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
+  return;
 #else
   CHECK_IMAGE_SUPPORT
   int devCount = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyHtoA_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyHtoA_old.cc
@@ -38,7 +38,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyHtoA_multiDevice_PeerDeviceContext, char, i
     int peerAccess = 0;
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 1, 0));
     if (!peerAccess) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     } else {
       HIP_CHECK(hipSetDevice(0));
       hipArray_t A_d;
@@ -69,7 +69,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyHtoA_multiDevice_PeerDeviceContext, char, i
                                             false) == true);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }
 #endif

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyParam2DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyParam2DAsync_old.cc
@@ -47,9 +47,10 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyParam2DAsync_multiDevice_StreamOnDiffDevice
     int peerAccess = 0;
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 1, 0));
     if (!peerAccess) {
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
       HIP_CHECK(hipFree(A_d));
       HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, A_h, nullptr, C_h, false);
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      return;
     }
     {
       TestType* E_d{nullptr};
@@ -93,6 +94,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyParam2DAsync_multiDevice_StreamOnDiffDevice
       HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, A_h, nullptr, C_h, false);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyPeer.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyPeer.cc
@@ -35,7 +35,8 @@
 HIP_TEST_CASE(Unit_hipMemcpyPeer_Positive_Default) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   const auto allocation_size = GENERATE(kPageSize / 2, kPageSize, kPageSize * 2);
@@ -101,7 +102,8 @@ HIP_TEST_CASE(Unit_hipMemcpyPeer_Positive_Synchronization_Behavior) {
 
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   int can_access_peer = 0;
@@ -146,7 +148,8 @@ HIP_TEST_CASE(Unit_hipMemcpyPeer_Positive_Synchronization_Behavior) {
 HIP_TEST_CASE(Unit_hipMemcpyPeer_Positive_ZeroSize) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   const auto allocation_size = kPageSize;
@@ -228,7 +231,8 @@ HIP_TEST_CASE(Unit_hipMemcpyPeer_Positive_ZeroSize) {
 HIP_TEST_CASE(Unit_hipMemcpyPeer_Negative_Parameters) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   int can_access_peer = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyPeerAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyPeerAsync.cc
@@ -35,7 +35,8 @@
 HIP_TEST_CASE(Unit_hipMemcpyPeerAsync_Positive_Default) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   const auto allocation_size = GENERATE(kPageSize / 2, kPageSize, kPageSize * 2);
@@ -105,7 +106,8 @@ HIP_TEST_CASE(Unit_hipMemcpyPeerAsync_Positive_Synchronization_Behavior) {
 
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   const StreamGuard stream_guard(Streams::created);
@@ -153,7 +155,8 @@ HIP_TEST_CASE(Unit_hipMemcpyPeerAsync_Positive_Synchronization_Behavior) {
 HIP_TEST_CASE(Unit_hipMemcpyPeerAsync_Positive_ZeroSize) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   const StreamGuard stream_guard(Streams::created);
@@ -237,7 +240,8 @@ HIP_TEST_CASE(Unit_hipMemcpyPeerAsync_Positive_ZeroSize) {
 HIP_TEST_CASE(Unit_hipMemcpyPeerAsync_Negative_Parameters) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   const StreamGuard stream_guard(Streams::created);
@@ -296,7 +300,8 @@ HIP_TEST_CASE(Unit_hipMemcpyPeerAsync_Negative_Parameters) {
 HIP_TEST_CASE(Unit_hipMemcpyPeerAsync_Capture) {
   const int device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   hipStream_t stream = nullptr;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyPeerAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyPeerAsync_old.cc
@@ -77,9 +77,10 @@ HIP_TEST_CASE(Unit_hipMemcpyPeerAsync_StreamOnDiffDevice) {
       HipTest::freeArrays<int>(X_d, Y_d, Z_d, nullptr, nullptr, nullptr, false);
       HIP_CHECK(hipStreamDestroy(stream));
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemcpySync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpySync.cc
@@ -163,8 +163,9 @@ static void runMemcpyTests(hipStream_t stream, bool async, allocType type, memTy
 
 HIP_TEST_CASE(Unit_hipMemcpySync) {
 #if HT_AMD  // To be removed when EXSWCPHIPT-127 is fixed
-  HIP_SKIP_TEST(
+  HipTest::HIP_SKIP_TEST(
       "tracked issue EXSWCPHIPT-127 (sync behaviour differs on AMD and NVIDIA).");
+  return;
 #endif
   allocType type = GENERATE(allocType::deviceMalloc, allocType::hostMalloc, allocType::hostRegisted,
                             allocType::devRegistered);
@@ -177,8 +178,9 @@ HIP_TEST_CASE(Unit_hipMemcpySync) {
 
 HIP_TEST_CASE(Unit_hipMemcpy2DSync) {
 #if HT_AMD
-  HIP_SKIP_TEST(
+  HipTest::HIP_SKIP_TEST(
       "tracked issue EXSWCPHIPT-127 (sync behaviour differs on AMD and NVIDIA).");
+  return;
 #endif
   allocType mallocType = GENERATE(allocType::deviceMalloc, allocType::hostMalloc,
                                   allocType::hostRegisted, allocType::devRegistered);
@@ -193,8 +195,9 @@ HIP_TEST_CASE(Unit_hipMemcpy2DSync) {
 
 HIP_TEST_CASE(Unit_hipMemcpy3DSync) {
 #if HT_AMD
-  HIP_SKIP_TEST(
+  HipTest::HIP_SKIP_TEST(
       "tracked issue EXSWCPHIPT-127 (sync behaviour differs on AMD and NVIDIA).");
+  return;
 #endif
   allocType mallocType = GENERATE(allocType::deviceMalloc, allocType::hostMalloc,
                                   allocType::hostRegisted, allocType::devRegistered);

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyWithStream_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyWithStream_old.cc
@@ -179,7 +179,8 @@ void TestOnMultiGPUwithOneStream(void) {
   HIP_CHECK(hipGetDeviceCount(&NumDevices));
   // If you have single GPU machine the return
   if (NumDevices <= 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, N);
   int *A_d[MaxGPUDevices], *B_d[MaxGPUDevices], *C_d[MaxGPUDevices];
@@ -257,7 +258,8 @@ void TestkindDtoD(void) {
   HIP_CHECK(hipGetDeviceCount(&NumDevices));
   // If you have single GPU machine the return
   if (NumDevices <= 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   int *A_d[MaxGPUDevices], *B_d[MaxGPUDevices], *C_d[MaxGPUDevices];
   int *A_h[MaxGPUDevices], *B_h[MaxGPUDevices], *C_h[MaxGPUDevices];
@@ -363,7 +365,8 @@ void TestkindDefaultForDtoD(void) {
   HIP_CHECK(hipGetDeviceCount(&NumDevices));
   // Test case will not run on single GPU setup.
   if (NumDevices <= 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   int *A_d[MaxGPUDevices], *B_d[MaxGPUDevices], *C_d[MaxGPUDevices];
   int *A_h[MaxGPUDevices], *B_h[MaxGPUDevices], *C_h[MaxGPUDevices];

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy_EdgeCases.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy_EdgeCases.cc
@@ -492,7 +492,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpy_PinnedRegMemWithKernelLaunch,
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   {
     // 1 refers to pinned Memory

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy_derivatives.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy_derivatives.cc
@@ -78,8 +78,9 @@ HIP_TEST_CASE(Unit_hipMemcpyDtoD_Positive_Synchronization_Behavior) {
   // This behavior differs on NVIDIA and AMD, on AMD the hipMemcpy calls is synchronous with
   // respect to the host
 #if HT_AMD
-  HIP_SKIP_TEST(
+  HipTest::HIP_SKIP_TEST(
       "EXSWCPHIPT-127 - Memcpy from device to device memory behavior differs on AMD and Nvidia");
+  return;
 #endif
   MemcpyDtoDSyncBehavior(
       [](void* dst, void* src, size_t count) {

--- a/projects/hip-tests/catch/unit/memory/hipMemsetAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetAsync.cc
@@ -104,7 +104,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemsetDASyncMulti, int8_t, int16_t, uint32_t) {
  */
 HIP_TEST_CASE(Unit_hipMemset2DASyncMulti) {
 #if HT_AMD
-  HIP_SKIP_TEST("tracked issue EXSWCPHIPT-127.");
+  HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-127.");
+  return;
 #endif
   allocType mallocType = GENERATE(allocType::deviceMalloc, allocType::hostMalloc,
                                   allocType::hostRegisted, allocType::devRegistered);
@@ -125,7 +126,8 @@ HIP_TEST_CASE(Unit_hipMemset2DASyncMulti) {
  */
 HIP_TEST_CASE(Unit_hipMemset3DASyncMulti) {
 #if HT_AMD
-  HIP_SKIP_TEST("tracked issue EXSWCPHIPT-127.");
+  HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-127.");
+  return;
 #endif
   allocType mallocType = GENERATE(allocType::deviceMalloc, allocType::hostMalloc,
                                   allocType::hostRegisted, allocType::devRegistered);

--- a/projects/hip-tests/catch/unit/memory/hipPointerGetAttribute.cc
+++ b/projects/hip-tests/catch/unit/memory/hipPointerGetAttribute.cc
@@ -37,7 +37,8 @@ behaviour
   hipDeviceAttribute_t attr = hipDeviceAttributeVirtualMemoryManagementSupported;                \
   HIP_CHECK(hipDeviceGetAttribute(&value, attr, device));                                        \
   if (value == 0) {                                                                              \
-    HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);                                         \
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);                                  \
+    return;                                                                                      \
   }                                                                                              \
 }
 
@@ -160,11 +161,12 @@ HIP_TEST_CASE(Unit_hipPointerGetAttribute_PeerGPU) {
                                        reinterpret_cast<hipDeviceptr_t>(A_d)));
       REQUIRE(data == 0);
     } else {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
     }
   } else {
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
     HIP_CHECK(hipFree(A_d));
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   HIP_CHECK(hipFree(A_d));
 }

--- a/projects/hip-tests/catch/unit/memory/hipSVMTestByteGranularity.cpp
+++ b/projects/hip-tests/catch/unit/memory/hipSVMTestByteGranularity.cpp
@@ -76,7 +76,8 @@ HIP_TEST_CASE(Unit_svm_byte_granularity) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   const int num_elements = 2048;
   int num_devices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipSVMTestFineGrainMemoryConsistency.cpp
+++ b/projects/hip-tests/catch/unit/memory/hipSVMTestFineGrainMemoryConsistency.cpp
@@ -235,7 +235,8 @@ HIP_TEST_CASE(Unit_svm_fine_grain_memory_consistency) {
     int pcieAtomic = 0;
     HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, id));
     if (!pcieAtomic) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+      return;
     }
   }
   const int num_elements = 2167;

--- a/projects/hip-tests/catch/unit/memory/hipSVMTestFineGrainSyncBuffers.cpp
+++ b/projects/hip-tests/catch/unit/memory/hipSVMTestFineGrainSyncBuffers.cpp
@@ -75,7 +75,8 @@ HIP_TEST_CASE(Unit_svm_fine_grain_sync_buffers) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   size_t num_pixels = 1024 * 1024 * 2;
   hipStream_t stream;

--- a/projects/hip-tests/catch/unit/memory/hipSVMTestSharedAddressSpaceFineGrain.cpp
+++ b/projects/hip-tests/catch/unit/memory/hipSVMTestSharedAddressSpaceFineGrain.cpp
@@ -166,7 +166,8 @@ HIP_TEST_CASE(Unit_svm_shared_address_space_fine_grain_buffers) {
     int pcieAtomic = 0;
     HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, id));
     if (!pcieAtomic) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+      return;
     }
   }
 
@@ -253,14 +254,16 @@ HIP_TEST_CASE(Unit_svm_shared_address_space_fine_grain_system) {
     int pcieAtomic = 0;
     HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, id));
     if (!pcieAtomic) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+      return;
     }
 
     int pageableAccess = 0;
     // This need xnack+ on MiXXX. If xnack is off on MiXXX, try ENV HSA_XNACK=1
     HIP_CHECK(hipDeviceGetAttribute(&pageableAccess, hipDeviceAttributePageableMemoryAccess, id));
     if (!pageableAccess) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
+      return;
     }
   }
 

--- a/projects/hip-tests/catch/unit/memory/hipStreamAttachMemAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipStreamAttachMemAsync.cc
@@ -12,7 +12,8 @@
 
 HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_Basic) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   StreamGuard stream(Streams::created);
@@ -25,11 +26,13 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_Basic) {
 
 HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_Pageable) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   if (!DeviceAttributesSupport(0, hipDeviceAttributePageableMemoryAccess)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPageableMemoryAccessUnsupported);
+    return;
   }
 
   StreamGuard stream(Streams::created);
@@ -44,7 +47,8 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_Pageable) {
 // device.
 HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_AttachGlobal) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   const auto device_count = HipTest::getDeviceCount();
@@ -88,11 +92,13 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_AttachGlobal) {
 // attribute cudaDevAttrConcurrentManagedAccess.
 HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_AttachHost) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   if (DeviceAttributesSupport(0, hipDeviceAttributeConcurrentManagedAccess)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedNoConcurrentAccess);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedNoConcurrentAccess);
+    return;
   }
 
   StreamGuard stream(Streams::created);
@@ -117,11 +123,13 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_AttachHost) {
 // guarantee that it will only access the memory on the device from stream.
 HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_AttachSingle) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   if (DeviceAttributesSupport(0, hipDeviceAttributeConcurrentManagedAccess)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedNoConcurrentAccess);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedNoConcurrentAccess);
+    return;
   }
 
   StreamGuard stream1(Streams::created);
@@ -152,7 +160,8 @@ HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Positive_AttachSingle) {
 
 HIP_TEST_CASE(Unit_hipStreamAttachMemAsync_Negative_Parameters) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   StreamGuard stream(Streams::created);

--- a/projects/hip-tests/catch/unit/memory/memcpy2d_tests_common.hh
+++ b/projects/hip-tests/catch/unit/memory/memcpy2d_tests_common.hh
@@ -61,7 +61,8 @@ void Memcpy2DDeviceToDeviceShell(F memcpy_func, const hipStream_t kernel_stream 
     int can_access_peer = 0;
     HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, src_device, dst_device));
     if (!can_access_peer) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+      return;
     }
   }
 

--- a/projects/hip-tests/catch/unit/memory/mempool_common.hh
+++ b/projects/hip-tests/catch/unit/memory/mempool_common.hh
@@ -19,19 +19,21 @@ namespace {
 constexpr auto wait_ms = 500;
 }  // anonymous namespace
 
-#define checkMempoolSupported(device) {                                                            \
-  int deviceSupportsMemoryPools = 0;                                                               \
-  HIP_CHECK(hipDeviceGetAttribute(&deviceSupportsMemoryPools,                                      \
-        hipDeviceAttributeMemoryPoolsSupported, device));                                          \
-  if (0 == deviceSupportsMemoryPools) {                                                            \
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);                                    \
-  }                                                                                                \
+#define checkMempoolSupported(device) {\
+  int deviceSupportsMemoryPools = 0;\
+  HIP_CHECK(hipDeviceGetAttribute(&deviceSupportsMemoryPools,\
+        hipDeviceAttributeMemoryPoolsSupported, device));\
+  if (0 == deviceSupportsMemoryPools) {\
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);\
+    return;\
+  }\
 }
 
-#define checkIfMultiDev(numOfDev) {                                                                \
-  if (numOfDev < 2) {                                                                              \
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);                                         \
-  }                                                                                                \
+#define checkIfMultiDev(numOfDev) {\
+  if (numOfDev < 2) {\
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);\
+    return;\
+  }\
 }
 
 template <typename T> __global__ void kernel_500ms(T* host_res, int clk_rate) {
@@ -84,7 +86,8 @@ template <typename F> void MallocMemPoolAsync_OneAlloc(F malloc_func, const MemP
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   unsigned int *notified = nullptr;
   HIP_CHECK(hipHostMalloc(&notified, sizeof(unsigned int)));
@@ -143,7 +146,8 @@ void MallocMemPoolAsync_TwoAllocs(F malloc_func, const MemPools mempool_type) {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   unsigned int *notified = nullptr;
   HIP_CHECK(hipHostMalloc(&notified, sizeof(unsigned int)));
@@ -222,7 +226,8 @@ template <typename F> void MallocMemPoolAsync_Reuse(F malloc_func, const MemPool
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMemoryPoolUnsupported);
+    return;
   }
   unsigned int *notified = nullptr;
   HIP_CHECK(hipHostMalloc(&notified, sizeof(unsigned int)));

--- a/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
+++ b/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
@@ -36,7 +36,8 @@ static constexpr auto kernel_name = "cooperativeKernelEx";
  */
 HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_NegTsts) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
   int totalThreads = 64;
   int blockSize = 16;
@@ -205,7 +206,8 @@ bool runTestDrvLaunch(const char* testName, std::string kernelFunc, int totalThr
  */
 HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_Functional) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
   REQUIRE(runTestDrvLaunch("hipDrvLaunchKernelEx", kernel_name, 64, 16, 2222) == true);
 }
@@ -228,7 +230,8 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_Functional) {
 HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_With_Different_Kernels) {
   CTX_CREATE();
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   hipModule_t module;
@@ -307,7 +310,8 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_With_Different_Kernels) {
 HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_With_CooperativeKernelWithArgs) {
   CTX_CREATE();
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   hipModule_t module;
@@ -382,7 +386,8 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_With_CooperativeKernelWithArgs) {
 HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_With_MaxBlockDims) {
   CTX_CREATE();
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   hipModule_t module;

--- a/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
+++ b/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
@@ -106,7 +106,8 @@ HIP_TEST_CASE(Unit_hipExtModuleLaunchKernel_NonUniformWorkGroup) {
   // first check if uniform_work_group_size = 1.
   const std::regex regexp("uniform_work_group_size\\s*:\\s*1");
   if (false == searchRegExpr(regexp, "copyKernel.s")) {
-    HIP_SKIP_TEST("test requires uniform work group size 1.");
+    HipTest::HIP_SKIP_TEST("test requires uniform work group size 1.");
+    return;
   }
   REQUIRE(true == searchRegExpr(regexp, "copyKernel.s"));
   auto isEven = GENERATE(0, 1);

--- a/projects/hip-tests/catch/unit/module/hipGetFuncBySymbol.cc
+++ b/projects/hip-tests/catch/unit/module/hipGetFuncBySymbol.cc
@@ -198,7 +198,8 @@ HIP_TEST_CASE(Unit_hipGetFuncBySymbol_MultiDev) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   hipFunction_t funcPointer;
@@ -313,7 +314,8 @@ HIP_TEST_CASE(Unit_hipGetFuncBySymbol_MultiDevMultiThread) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   ::std::vector< ::std::thread> threads;

--- a/projects/hip-tests/catch/unit/module/hipGetProcAddressModuleApis.cc
+++ b/projects/hip-tests/catch/unit/module/hipGetProcAddressModuleApis.cc
@@ -317,7 +317,8 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_ModuleApisLoadData) {
  */
 HIP_TEST_CASE(Unit_hipGetProcAddress_ModuleApisCooperativeKernels) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   HIP_CHECK(hipSetDevice(0));

--- a/projects/hip-tests/catch/unit/module/hipManagedKeywordBasic.cc
+++ b/projects/hip-tests/catch/unit/module/hipManagedKeywordBasic.cc
@@ -42,7 +42,8 @@ HIP_TEST_CASE(Unit_hipModuleGetGlobal_Functional) {
     int managed_memory = 0;
     HIPCHECK(hipDeviceGetAttribute(&managed_memory, hipDeviceAttributeManagedMemory, i));
     if (!managed_memory) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+      return;
     }
   }
   for (int i = 0; i < numDevices; i++) {

--- a/projects/hip-tests/catch/unit/module/hipModuleGetFunction.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleGetFunction.cc
@@ -60,7 +60,8 @@ HIP_TEST_CASE(Unit_hipModuleGetFunction_DiffDevice) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   auto mg = ModuleGuard::InitModule("get_function_module.code");

--- a/projects/hip-tests/catch/unit/module/hipModuleGetGlobal.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleGetGlobal.cc
@@ -137,7 +137,8 @@ HIP_TEST_CASE(Unit_hipModuleGetGlobal_DiffDevice) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   auto module = GetModule();
   HIP_CHECK(hipSetDevice(1));

--- a/projects/hip-tests/catch/unit/module/hipModuleLaunchCooperativeKernel.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleLaunchCooperativeKernel.cc
@@ -36,7 +36,8 @@
 HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernel_Positive_Basic) {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   SECTION("Cooperative kernel with no arguments") {
@@ -75,7 +76,8 @@ HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernel_Positive_Basic) {
 HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernel_Positive_Parameters) {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   hipFunction_t f = GetKernel(mg.module(), "NOPKernel");
@@ -110,7 +112,8 @@ HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernel_Positive_Parameters) {
 HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernel_Negative_Parameters) {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   hipFunction_t f = GetKernel(mg.module(), "NOPKernel");
@@ -207,7 +210,8 @@ HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernel_Negative_Parameters) {
  */
 HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernel_Verify_Capture) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");

--- a/projects/hip-tests/catch/unit/module/hipModuleLaunchCooperativeKernelMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleLaunchCooperativeKernelMultiDevice.cc
@@ -35,7 +35,8 @@
 HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernelMultiDevice_Positive_Basic) {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   const auto device_count = HipTest::getDeviceCount();
@@ -92,7 +93,8 @@ HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernelMultiDevice_Positive_Basic) {
 HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_Parameters) {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   const auto device_count = HipTest::getDeviceCount();
@@ -209,13 +211,15 @@ HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_Paramete
 HIP_TEST_CASE(Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_MultiKernelSameDevice) {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   int device_count;
   HIP_CHECK(hipGetDeviceCount(&device_count));
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   std::vector<hipFunctionLaunchParams> params_list(device_count);
   std::vector<hipModule_t> modules_list(device_count);

--- a/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSizeVariableSMemWithFlags.cc
+++ b/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSizeVariableSMemWithFlags.cc
@@ -101,7 +101,8 @@ HIP_TEST_CASE(Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_mgpu) {
   HIP_CHECK(hipGetDeviceCount(&devcount));
   // If only single GPU is detected then return
   if (devcount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   // Get current device property
   for (int dev = 0; dev < devcount; dev++) {

--- a/projects/hip-tests/catch/unit/p2p/hipDeviceGetP2PAttribute.cc
+++ b/projects/hip-tests/catch/unit/p2p/hipDeviceGetP2PAttribute.cc
@@ -49,12 +49,14 @@
 
 HIP_TEST_CASE(Unit_hipDeviceGetP2PAttribute_Basic) {
 #if HT_AMD
-  HIP_SKIP_TEST("tracked issue EXSWCPHIPT-119.");
+  HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-119.");
+  return;
 #else
 
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   hipDeviceP2PAttr attribute =
@@ -107,12 +109,14 @@ HIP_TEST_CASE(Unit_hipDeviceGetP2PAttribute_Basic) {
 
 HIP_TEST_CASE(Unit_hipDeviceGetP2PAttribute_Negative) {
 #if HT_AMD
-  HIP_SKIP_TEST("tracked issue EXSWCPHIPT-122.");
+  HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-122.");
+  return;
 #else
 
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   int value;

--- a/projects/hip-tests/catch/unit/p2p/hipP2pLinkTypeAndHopFunc.cc
+++ b/projects/hip-tests/catch/unit/p2p/hipP2pLinkTypeAndHopFunc.cc
@@ -295,7 +295,8 @@ HIP_TEST_CASE(Unit_hipP2pLinkTypeAndHopFunc) {
   bool TestPassed = true;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   SECTION("Test running for testhipInvalidDevice") {
     TestPassed = testhipInvalidDevice(numDevices);

--- a/projects/hip-tests/catch/unit/printf/hipPrintfAltForms.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfAltForms.cc
@@ -47,7 +47,8 @@ HIP_TEST_CASE(Unit_Printf_PrintfAltFormsTsts) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   std::string reference =
       std::string(R"here(042

--- a/projects/hip-tests/catch/unit/printf/hipPrintfBasic.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfBasic.cc
@@ -182,7 +182,8 @@ HIP_TEST_CASE(Unit_Printf_PrintfBasicTsts) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   uint num_blocks = 1;
   uint threads_per_block = 64;

--- a/projects/hip-tests/catch/unit/printf/hipPrintfManyDevices.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfManyDevices.cc
@@ -39,7 +39,8 @@ HIP_TEST_CASE(Unit_Printf_ManyDevicesTest) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   uint num_blocks = 14;
   uint threads_per_block = 250;

--- a/projects/hip-tests/catch/unit/printf/hipPrintfManyWaves.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfManyWaves.cc
@@ -226,7 +226,8 @@ HIP_TEST_CASE(Unit_Printf_PrintfManyWaves) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   uint num_blocks = 150;
   uint threads_per_block = 250;

--- a/projects/hip-tests/catch/unit/printf/hipPrintfStar.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfStar.cc
@@ -36,7 +36,8 @@ HIP_TEST_CASE(Unit_Printf_PrintfStar) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   std::string reference =
       std::string(R"here(              42

--- a/projects/hip-tests/catch/unit/printf/hipPrintfWidthPrecision.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfWidthPrecision.cc
@@ -46,7 +46,8 @@ HIP_TEST_CASE(Unit_Printf_PrintfWidthPrecision) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   std::string reference(R"here(              42
 00000042

--- a/projects/hip-tests/catch/unit/printf/printfFlags.cc
+++ b/projects/hip-tests/catch/unit/printf/printfFlags.cc
@@ -32,7 +32,8 @@ HIP_TEST_CASE(Unit_Printf_flags_Sanity_Positive) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   std::string reference =
       std::string(R"here(00000042

--- a/projects/hip-tests/catch/unit/printf/printfFlagsNonHost.cc
+++ b/projects/hip-tests/catch/unit/printf/printfFlagsNonHost.cc
@@ -33,7 +33,8 @@ HIP_TEST_CASE(Unit_Buffered_Printf_Flags) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   std::string reference =
       std::string(R"here(00000042

--- a/projects/hip-tests/catch/unit/printf/printfHost.cc
+++ b/projects/hip-tests/catch/unit/printf/printfHost.cc
@@ -31,7 +31,8 @@ HIP_TEST_CASE(Unit_Host_Printf) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   int *count{nullptr}, *count_d{nullptr};
   count = reinterpret_cast<int*>(malloc(sizeof(int)));

--- a/projects/hip-tests/catch/unit/printf/printfLength.cc
+++ b/projects/hip-tests/catch/unit/printf/printfLength.cc
@@ -31,7 +31,8 @@ HIP_TEST_CASE(Unit_Printf_length_Sanity_Positive) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
 #if HT_NVIDIA
   std::string reference(R"here(-42 -42

--- a/projects/hip-tests/catch/unit/printf/printfNonHost.cc
+++ b/projects/hip-tests/catch/unit/printf/printfNonHost.cc
@@ -57,7 +57,8 @@ HIP_TEST_CASE(Unit_NonHost_Printf_basic) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   int *count{nullptr}, *count_d{nullptr};
 
@@ -91,7 +92,8 @@ HIP_TEST_CASE(Unit_NonHost_Printf_loop) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   int *count{nullptr}, *count_d{nullptr};
   count = reinterpret_cast<int*>(malloc(ITER_COUNT * sizeof(int)));
@@ -132,7 +134,8 @@ HIP_TEST_CASE(Unit_NonHost_Printf_multiple_Threads) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   int *count{nullptr}, *count_d{nullptr};
   fprintf(stderr, "VALID_COUNT=%d, ITER_COUNT_FOR_THREAD=%d\n", VALID_COUNT, ITER_COUNT_FOR_THREAD);
@@ -176,7 +179,8 @@ HIP_TEST_CASE(Unit_NonHost_Printf_BufferAvailability) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   int *count{nullptr}, *count_d{nullptr};
 

--- a/projects/hip-tests/catch/unit/printf/printfSpecifiers.cc
+++ b/projects/hip-tests/catch/unit/printf/printfSpecifiers.cc
@@ -34,7 +34,8 @@ HIP_TEST_CASE(Unit_Printf_specifier_Sanity_Positive) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
 #if HT_NVIDIA
   std::string reference(R"here(xyzzy
@@ -139,7 +140,8 @@ HIP_TEST_CASE(Unit_Printf_Negative_Parameters_RTC) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
   hiprtcProgram program{};
 

--- a/projects/hip-tests/catch/unit/printf/printfSpecifiersNonHost.cc
+++ b/projects/hip-tests/catch/unit/printf/printfSpecifiersNonHost.cc
@@ -33,7 +33,8 @@ HIP_TEST_CASE(Unit_Buffered_Printf_Specifier) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
 #ifdef __HIP_PLATFORM_NVIDIA__
   std::string reference(R"here(xyzzy

--- a/projects/hip-tests/catch/unit/rtc/hipRTCDeviceMalloc.cc
+++ b/projects/hip-tests/catch/unit/rtc/hipRTCDeviceMalloc.cc
@@ -40,7 +40,8 @@ HIP_TEST_CASE(Unit_hiprtc_devicemalloc) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
+    return;
   }
 
   using namespace std;

--- a/projects/hip-tests/catch/unit/stream/hipLaunchHostFunc.cc
+++ b/projects/hip-tests/catch/unit/stream/hipLaunchHostFunc.cc
@@ -304,7 +304,8 @@ HIP_TEST_CASE(Unit_hipLaunchHostFunc_multidevice) {
   int num_devices;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   if (num_devices < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   usrDataS* usrDataptr = reinterpret_cast<usrDataS*>(malloc(sizeof(usrDataS)));
   REQUIRE(usrDataptr != nullptr);

--- a/projects/hip-tests/catch/unit/stream/hipMultiStream.cc
+++ b/projects/hip-tests/catch/unit/stream/hipMultiStream.cc
@@ -57,7 +57,8 @@ HIP_TEST_CASE(Unit_hipMultiStream_multimeDevice) {
   int nGpu = 0;
   HIP_CHECK(hipGetDeviceCount(&nGpu));
   if (nGpu < 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    return;
   }
   static int device = 0;
   HIP_CHECK(hipSetDevice(device));

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetCUMask.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetCUMask.cc
@@ -32,7 +32,8 @@ HIP_TEST_CASE(Unit_hipExtStreamGetCUMask_verifyDefaultAndCustomMask) {
   int nGpu = 0;
   HIP_CHECK(hipGetDeviceCount(&nGpu));
   if (nGpu < 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    return;
   }
 
   HIP_CHECK(hipSetDevice(0));

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetDevice.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetDevice.cc
@@ -178,7 +178,8 @@ HIP_TEST_CASE(Unit_hipStreamGetDevice_SetDiffDevice) {
   int device_count = 0;
   HIP_CHECK(hipGetDeviceCount(&device_count));
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   for (int i = 0; i < device_count; ++i) {
     HIP_CHECK(hipSetDevice(i));

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetId.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetId.cc
@@ -183,7 +183,8 @@ HIP_TEST_CASE(Unit_hipStreamGetId_MultiDevice) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   std::vector<unsigned long long> streamIds;

--- a/projects/hip-tests/catch/unit/stream/hipStreamLegacy_Ext.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamLegacy_Ext.cc
@@ -286,7 +286,8 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_MultiDevice) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   for (int deviceId = 0; deviceId < deviceCount; deviceId++) {
@@ -408,7 +409,8 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_MultiDeviceMultiOperation) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   int currentDevice = 0;
@@ -529,7 +531,8 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_TwoThreadsEachOneDiffOperation) {
   const unsigned int threadsSupported = std::thread::hardware_concurrency();
 
   if (threadsSupported < 2) {
-    HIP_SKIP_TEST("machine does not support two concurrent hardware threads.");
+    HipTest::HIP_SKIP_TEST("machine does not support two concurrent hardware threads.");
+    return;
   }
 
   int* hostArrSrc = new int[N];
@@ -580,7 +583,8 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_TwoDevicesEachOneDiffOperation) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   // Set arrays in device 0
@@ -664,7 +668,8 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_TwoThreadsInTwoDevicesEachOneDiffOperation) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   // Set arrays in device 0

--- a/projects/hip-tests/catch/unit/stream/hipStreamLegacy_compiler_options.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamLegacy_compiler_options.cc
@@ -99,7 +99,10 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_TwoThreadsDiffOperationWithSptCompOption) {
   const unsigned int threadsSupported = std::thread::hardware_concurrency();
 
   if (threadsSupported < 2) {
-    HIP_SKIP_TEST("Skipping due to machine doesn't support two concurrent threads");
+    HipTest::HIP_SKIP_TEST(
+        "Skipping due to machine does't "
+        "support two concurrent threads");
+    return;
   }
 
   int* hostArrSrc = new int[N];

--- a/projects/hip-tests/catch/unit/stream/hipStreamSynchronize.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamSynchronize.cc
@@ -88,7 +88,7 @@ HIP_TEST_CASE(Unit_hipStreamSynchronize_NullStreamSynchronization) {
  */
 HIP_TEST_CASE(Unit_hipStreamSynchronize_SynchronizeStreamAndQueryNullStream) {
 #if HT_AMD
-  HIP_SKIP_TEST("tracked issue EXSWCPHIPT-22.");
+  HipTest::HIP_SKIP_TEST("tracked issue EXSWCPHIPT-22.");
 #else
 
   hipStream_t stream1;

--- a/projects/hip-tests/catch/unit/stream/hipStreamValue.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamValue.cc
@@ -71,6 +71,7 @@ bool streamWaitValueSupported() {
     auto getAttributeError = hipDeviceGetAttribute(
         &waitValueSupport, hipDeviceAttributeCanUseStreamWaitValue, device_id);
     if (getAttributeError != hipSuccess) {
+      HipTest::HIP_SKIP_TEST("required stream attribute is not supported.");
       return false;
     }
     if (waitValueSupport == 1) return true;
@@ -236,7 +237,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipStreamValue_Write, (TestParams<uint32_t, PtrType:
                    (TestParams<uint64_t, PtrType::DevicePtrToHost>)) {
 #endif
   if (!streamWaitValueSupported()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+    return;
   }
 
   using UIntT = typename TestType::UIntType;
@@ -287,7 +289,8 @@ void syncAndCheckData(hipStream_t stream, UIntT* dataPtr, TestPtr signalPtr, siz
 template <typename TestType, bool isBlocking>
 void testWait(TEST_WAIT<typename TestType::UIntType> tc) {
   if (!streamWaitValueSupported()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+    return;
   }
   using UIntT = typename TestType::UIntType;
   constexpr auto ptrType = TestType::ptrType;
@@ -342,7 +345,8 @@ void testWait(TEST_WAIT<typename TestType::UIntType> tc) {
 // Combined blocking test case for both uint32_t and uint64_t
 HIP_TEMPLATE_TEST_CASE(Unit_hipStreamValue_Wait_Blocking, uint32_t, uint64_t) {
   if (!streamWaitValueSupported()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+    return;
   }
 
   using UIntT = TestType;
@@ -552,7 +556,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipStreamValue_Wait_Blocking, uint32_t, uint64_t) {
 // Negative Tests
 HIP_TEST_CASE(Unit_hipStreamValue_Negative_InvalidMemory) {
   if (!streamWaitValueSupported()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+    return;
   }
 
   hipStream_t stream{nullptr};
@@ -583,7 +588,8 @@ HIP_TEST_CASE(Unit_hipStreamValue_Negative_InvalidMemory) {
 // Merge the two similar negative tests
 HIP_TEMPLATE_TEST_CASE(Unit_hipStreamValue_Negative_StreamAndFlag, uint32_t, uint64_t) {
   if (!streamWaitValueSupported()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+    return;
   }
 
   SECTION("Invalid Stream handle") {
@@ -637,7 +643,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipStreamValue_Negative_StreamAndFlag, uint32_t, uin
 
 HIP_TEMPLATE_TEST_CASE(Unit_hipStreamWriteValue_Default, uint32_t, uint64_t) {
   if (!streamWaitValueSupported()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+    return;
   }
 
   hipStream_t stream{nullptr};
@@ -662,7 +669,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipStreamWriteValue_Default, uint32_t, uint64_t) {
 
 TEMPLATE_TEST_CASE("Unit_hipStreamWriteValue_Increment_Default", "", uint32_t, uint64_t) {
   if (!streamWaitValueSupported()) {
-    HIP_SKIP_TEST("hipStreamWriteValue not supported on this device.");
+    HipTest::HIP_SKIP_TEST("hipStreamWriteValue not supported on this device.");
+    return;
   }
 
   hipStream_t stream{nullptr};
@@ -687,7 +695,8 @@ TEMPLATE_TEST_CASE("Unit_hipStreamWriteValue_Increment_Default", "", uint32_t, u
 
 TEMPLATE_TEST_CASE("Unit_hipStreamWriteValue_Decrement_Default", "", uint32_t, uint64_t) {
   if (!streamWaitValueSupported()) {
-    HIP_SKIP_TEST("hipStreamWriteValue not supported on this device.");
+    HipTest::HIP_SKIP_TEST("hipStreamWriteValue not supported on this device.");
+    return;
   }
 
   hipStream_t stream{nullptr};
@@ -712,7 +721,8 @@ TEMPLATE_TEST_CASE("Unit_hipStreamWriteValue_Decrement_Default", "", uint32_t, u
 template <typename TestType>
 void testIncrementDecrementMultiStreamMultiDevice(uint32_t operationFlag) {
   if (!streamWaitValueSupported()) {
-    HIP_SKIP_TEST("hipStreamWriteValue not supported on this device.");
+    HipTest::HIP_SKIP_TEST("hipStreamWriteValue not supported on this device.");
+    return;
   }
 
   constexpr size_t streams_per_device = 2;
@@ -806,7 +816,8 @@ template <typename T> __global__ void add(T* a, T* b, T* c, size_t size) {
 
 HIP_TEMPLATE_TEST_CASE(Unit_hipStreamWaitValue_Default, uint32_t, uint64_t) {
   if (!streamWaitValueSupported()) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kStreamWaitValueUnsupported);
+    return;
   }
 
   auto size = GENERATE(as<size_t>{}, 100, 500, 1000);

--- a/projects/hip-tests/catch/unit/stream/hipStreamWithCUMask.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamWithCUMask.cc
@@ -169,7 +169,8 @@ HIP_TEST_CASE(Unit_hipExtStreamCreateWithCUMask_Functionality) {
   int nGpu = 0;
   HIP_CHECK(hipGetDeviceCount(&nGpu));
   if (nGpu < 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    return;
   }
 
   static int device = 0;

--- a/projects/hip-tests/catch/unit/streamperthread/hipGetProcAddressSptApis.cc
+++ b/projects/hip-tests/catch/unit/streamperthread/hipGetProcAddressSptApis.cc
@@ -2505,7 +2505,8 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_spt_LaunchCooperativeKernel) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, 0));
 
   if (!device_properties.cooperativeLaunch) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    return;
   }
 
   void* hipLaunchCooperativeKernel_spt_ptr = nullptr;

--- a/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThrdCompilerOptn.cc
+++ b/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThrdCompilerOptn.cc
@@ -274,7 +274,8 @@ void DefaultPT2_StrmWaitEvent() {
   int device;
   HIP_CHECK(hipGetDevice(&device));
   if (!DeviceAttributesSupport(device, hipDeviceAttributeManagedMemory)) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
 
   hipEvent_t evt;

--- a/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThrdTsts.cc
+++ b/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThrdTsts.cc
@@ -332,7 +332,7 @@ HIP_TEST_CASE(Unit_hipStreamPerThread_MangdMem) {
       REQUIRE(false);
     }
   } else {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
   }
 }
 
@@ -472,7 +472,7 @@ HIP_TEST_CASE(Unit_hipStreamPerThread_CoopLaunch) {
   HIPCHECK(hipGetDeviceProperties(&device_properties, 0));
   /* Test whether target device supports cooperative groups ****************/
   if (device_properties.cooperativeLaunch == 0) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kCooperativeLaunchUnsupported);
   } else {
     /* We will launch enough waves to fill up all of the GPU *****************/
     int warp_size = device_properties.warpSize;

--- a/projects/hip-tests/catch/unit/synchronization/cache_coherency_cpu_gpu.cc
+++ b/projects/hip-tests/catch/unit/synchronization/cache_coherency_cpu_gpu.cc
@@ -113,13 +113,15 @@ static bool cpu_to_gpu_coherency() {
 
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kNoGpuDevice);
+    return true;
   }
 
   SECTION("With device fine grained buffer") {
     HIP_CHECK(hipDeviceGetAttribute(&deviceFineGrain, hipDeviceAttributeFineGrainSupport, 0));
     if (deviceFineGrain == 0) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+      return true;
     }
     fprintf(stderr, "info: allocate device mem (%zu bytes) on device 0\n", Nbytes);
     HIP_CHECK(
@@ -243,7 +245,7 @@ static bool cpu_to_gpu_coherency() {
  */
 
 HIP_TEST_CASE(Unit_cache_coherency_cpu_gpu) {
+  bool passed = true;
   // Coherency between CPU and GPU sharing host and device memory.
-  bool result = cpu_to_gpu_coherency();
-  REQUIRE(result);
+  REQUIRE(passed == cpu_to_gpu_coherency());
 }

--- a/projects/hip-tests/catch/unit/synchronization/cache_coherency_gpu_gpu.cc
+++ b/projects/hip-tests/catch/unit/synchronization/cache_coherency_gpu_gpu.cc
@@ -99,16 +99,19 @@ static bool gpu_to_gpu_coherency() {
 
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < numTestDevices) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return true;
   }
   SECTION("With device fine grained buffer") {
     HIP_CHECK(hipDeviceGetAttribute(&deviceFineGrain, hipDeviceAttributeFineGrainSupport, 0));
     if (deviceFineGrain == 0) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+      return true;
     }
     HIP_CHECK(hipDeviceGetAttribute(&deviceFineGrain, hipDeviceAttributeFineGrainSupport, 1));
     if (deviceFineGrain == 0) {
-      HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFineGrainHwUnsupported);
+      return true;
     }
     HIP_CHECK(hipSetDevice(0));
     HIP_CHECK(hipDeviceEnablePeerAccess(1, 0));
@@ -270,7 +273,7 @@ static bool gpu_to_gpu_coherency() {
  */
 
 HIP_TEST_CASE(Unit_cache_coherency_gpu_gpu) {
+  bool passed = true;
   // Coherency between GPUs accessing local or remote FB.
-  bool result = gpu_to_gpu_coherency();
-  REQUIRE(result);
+  REQUIRE(passed == gpu_to_gpu_coherency());
 }

--- a/projects/hip-tests/catch/unit/texture/hipBindTextureToMipmappedArray.cc
+++ b/projects/hip-tests/catch/unit/texture/hipBindTextureToMipmappedArray.cc
@@ -136,7 +136,7 @@ HIP_TEST_CASE(Unit_hipTextureMipmapRef2D_Positive_Check) {
     }
   }
 #else
-  HIP_SKIP_TEST(HipTest::SkipReason::kMipmappedArraysUnsupported);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMipmappedArraysUnsupported);
 #endif
 }
 
@@ -196,7 +196,7 @@ HIP_TEST_CASE(Unit_hipTextureMipmapRef2D_Negative_Parameters) {
 
   HIP_CHECK(hipFreeMipmappedArray(mip_array_ptr));
 #else
-  HIP_SKIP_TEST(HipTest::SkipReason::kMipmappedArraysUnsupported);
+  HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kMipmappedArraysUnsupported);
 #endif
 }
 #endif

--- a/projects/hip-tests/catch/unit/texture/hipTextureObj1DCheckSRGBModes.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTextureObj1DCheckSRGBModes.cc
@@ -84,7 +84,9 @@ static void runTest(const int width, const float offsetX = 0) {
   if (ret == hipErrorInvalidValue && resType == hipResourceTypeLinear) {
     free(hData);
     HIP_CHECK(hipFree(hipBuff));
-    HIP_SKIP_TEST("sRGB is not supported for hipResourceTypeLinear on AMD devices.");
+    HipTest::HIP_SKIP_TEST(
+        "sRGB is not supported for hipResourceTypeLinear on AMD devices.");
+    return;
   }
 #endif
   HIP_CHECK(ret);

--- a/projects/hip-tests/catch/unit/texture/texCubemap.cc
+++ b/projects/hip-tests/catch/unit/texture/texCubemap.cc
@@ -35,7 +35,8 @@
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemap_Positive_ReadModeElementType, char, unsigned char, short,
                    unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
-  HIP_SKIP_TEST("texCubemap isn't supported.");
+  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
+  return;
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;
@@ -116,7 +117,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_texCubemap_Positive_ReadModeElementType, char, unsig
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemap_Positive_ReadModeNormalizedFloat, char, unsigned char,
                    short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
-  HIP_SKIP_TEST("texCubemap isn't supported.");
+  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
+  return;
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;

--- a/projects/hip-tests/catch/unit/texture/texCubemapGrad.cc
+++ b/projects/hip-tests/catch/unit/texture/texCubemapGrad.cc
@@ -35,7 +35,8 @@
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapGrad_Positive_ReadModeElementType, char, unsigned char,
                    short, unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
-  HIP_SKIP_TEST("texCubemap isn't supported.");
+  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
+  return;
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;
@@ -116,7 +117,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_texCubemapGrad_Positive_ReadModeElementType, char, u
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapGrad_Positive_ReadModeNormalizedFloat, char, unsigned char,
                    short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
-  HIP_SKIP_TEST("texCubemap isn't supported.");
+  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
+  return;
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;

--- a/projects/hip-tests/catch/unit/texture/texCubemapLayered.cc
+++ b/projects/hip-tests/catch/unit/texture/texCubemapLayered.cc
@@ -35,7 +35,8 @@
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLayered_Positive_ReadModeElementType, char, unsigned char,
                    short, unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
-  HIP_SKIP_TEST("texCubemap isn't supported.");
+  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
+  return;
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;
@@ -119,7 +120,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLayered_Positive_ReadModeElementType, char
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLayered_Positive_ReadModeNormalizedFloat, char,
                    unsigned char, short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
-  HIP_SKIP_TEST("texCubemap isn't supported.");
+  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
+  return;
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;

--- a/projects/hip-tests/catch/unit/texture/texCubemapLayeredGrad.cc
+++ b/projects/hip-tests/catch/unit/texture/texCubemapLayeredGrad.cc
@@ -35,7 +35,8 @@
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLayeredGrad_Positive_ReadModeElementType, char,
                    unsigned char, short, unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
-  HIP_SKIP_TEST("texCubemap isn't supported.");
+  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
+  return;
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;
@@ -120,7 +121,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLayeredGrad_Positive_ReadModeElementType, 
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLayeredGrad_Positive_ReadModeNormalizedFloat, char,
                    unsigned char, short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
-  HIP_SKIP_TEST("texCubemap isn't supported.");
+  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
+  return;
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;

--- a/projects/hip-tests/catch/unit/texture/texCubemapLayeredLod.cc
+++ b/projects/hip-tests/catch/unit/texture/texCubemapLayeredLod.cc
@@ -35,7 +35,8 @@
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLayeredLod_Positive_ReadModeElementType, char,
                    unsigned char, short, unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
-  HIP_SKIP_TEST("texCubemap isn't supported.");
+  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
+  return;
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;
@@ -120,7 +121,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLayeredLod_Positive_ReadModeElementType, c
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLayeredLod_Positive_ReadModeNormalizedFloat, char,
                    unsigned char, short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
-  HIP_SKIP_TEST("texCubemap isn't supported.");
+  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
+  return;
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;

--- a/projects/hip-tests/catch/unit/texture/texCubemapLod.cc
+++ b/projects/hip-tests/catch/unit/texture/texCubemapLod.cc
@@ -35,7 +35,8 @@
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLod_Positive_ReadModeElementType, char, unsigned char,
                    short, unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
-  HIP_SKIP_TEST("texCubemap isn't supported.");
+  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
+  return;
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;
@@ -116,7 +117,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLod_Positive_ReadModeElementType, char, un
 HIP_TEMPLATE_TEST_CASE(Unit_texCubemapLod_Positive_ReadModeNormalizedFloat, char, unsigned char,
                    short, unsigned short) {
   CHECK_IMAGE_SUPPORT;
-  HIP_SKIP_TEST("texCubemap isn't supported.");
+  HipTest::HIP_SKIP_TEST("texCubemap isn't supported.");
+  return;
   TextureTestParams<TestType> params = {};
   params.extent = make_hipExtent(2, 2, 6);
   params.num_subdivisions = 4;

--- a/projects/hip-tests/catch/unit/threadfence/__threadfence.cc
+++ b/projects/hip-tests/catch/unit/threadfence/__threadfence.cc
@@ -151,13 +151,15 @@ HIP_TEST_CASE(Unit___threadfence_Positive_Basic_Managed) {
 HIP_TEST_CASE(Unit___threadfence_Positive_Basic_Peer) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   int can_access_peer = 0;
   HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, 0, 1));
   if (!can_access_peer) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    return;
   }
 
   HIP_CHECK(hipSetDevice(0));

--- a/projects/hip-tests/catch/unit/threadfence/__threadfence_block.cc
+++ b/projects/hip-tests/catch/unit/threadfence/__threadfence_block.cc
@@ -151,13 +151,15 @@ HIP_TEST_CASE(Unit___threadfence_block_Positive_Basic_Managed) {
 HIP_TEST_CASE(Unit___threadfence_block_Positive_Basic_Peer) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   int can_access_peer = 0;
   HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, 0, 1));
   if (!can_access_peer) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    return;
   }
 
   HIP_CHECK(hipSetDevice(0));

--- a/projects/hip-tests/catch/unit/threadfence/__threadfence_system.cc
+++ b/projects/hip-tests/catch/unit/threadfence/__threadfence_system.cc
@@ -47,13 +47,15 @@ __global__ void ReadKernel(int* out, int* in) {
 HIP_TEST_CASE(Unit___threadfence_system_Positive_Basic_Peer) {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   int can_access_peer = 0;
   HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, 0, 1));
   if (!can_access_peer) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+    return;
   }
 
   HIP_CHECK(hipSetDevice(0));

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipGetProcAddressVmmApis.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipGetProcAddressVmmApis.cc
@@ -28,7 +28,8 @@ HIP_TEST_CASE(Unit_hipGetProcAddress_VMM) {
   int value = 0;
   HIP_CHECK(hipDeviceGetAttribute(&value, hipDeviceAttributeVirtualMemoryManagementSupported, 0));
   if (value == 0) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);
+    return;
   }
 
   hipDeviceProp_t devProp;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemGetHandleForAddressRange.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemGetHandleForAddressRange.cc
@@ -458,7 +458,8 @@ HIP_TEST_CASE(Unit_hipMemGetHandleForAddressRange_DeviceMemory_InAnotherDevice) 
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   constexpr int srcDeviceId = 0;
@@ -512,7 +513,8 @@ HIP_TEST_CASE(Unit_hipMemGetHandleForAddressRange_VM_InAnotherDevice) {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   constexpr int srcDeviceId = 0;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
@@ -281,7 +281,8 @@ void physicalMemoryReuse_MultiDev (hipMemAllocationProp prop) {
   int devicecount = 0;
   HIP_CHECK(hipGetDeviceCount(&devicecount));
   if (devicecount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   size_t granularity = 0;
   size_t buffer_size = N * sizeof(int);
@@ -453,7 +454,8 @@ void vMMMemoryReuse_MultiGPU (hipMemAllocationProp prop) {
   int deviceId = 0, devicecount = 0;
   HIP_CHECK(hipGetDeviceCount(&devicecount));
   if (devicecount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   size_t granularity = 0;
   size_t buffer_size = N * sizeof(int);

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
@@ -140,7 +140,8 @@ HIP_TEST_CASE(Unit_hipMemSetAccess_MultDevSetGet) {
   hipDevice_t device0, device1;
   HIP_CHECK(hipGetDeviceCount(&device_count));
   if (device_count < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
 
   HIP_CHECK(hipDeviceGet(&device0, deviceId));
@@ -331,7 +332,8 @@ HIP_TEST_CASE(Unit_hipMemSetAccess_FuncTstOnMultDev) {
   int deviceId = 0, devicecount = 0;
   HIP_CHECK(hipGetDeviceCount(&devicecount));
   if (devicecount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   for (deviceId = 0; deviceId < devicecount; deviceId++) {
     HIP_CHECK(hipSetDevice(deviceId));
@@ -612,7 +614,8 @@ HIP_TEST_CASE(Unit_hipMemSetAccess_Vmm2UnifiedMemCpy) {
   CTX_CREATE();
   auto managed = HmmAttrPrint();
   if (managed != 1) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kManagedMemoryUnsupported);
+    return;
   }
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
@@ -751,7 +754,8 @@ HIP_TEST_CASE(Unit_hipMemSetAccess_Vmm2PeerDevMemCpy) {
   int devicecount = 0;
   HIP_CHECK(hipGetDeviceCount(&devicecount));
   if (devicecount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   int deviceId = 0, value = 0;
   hipDevice_t device;
@@ -841,7 +845,8 @@ HIP_TEST_CASE(Unit_hipMemSetAccess_Vmm2PeerPeerMemCpy) {
   int devicecount = 0;
   HIP_CHECK(hipGetDeviceCount(&devicecount));
   if (devicecount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   int deviceId = 0, value = 0;
   hipDevice_t device;
@@ -1002,7 +1007,8 @@ HIP_TEST_CASE(Unit_hipMemSetAccess_Vmm2VMMInterDevMemCpy) {
   int devicecount = 0;
   HIP_CHECK(hipGetDeviceCount(&devicecount));
   if (devicecount < 2) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+    return;
   }
   int deviceId = 0, value = 0;
   hipDevice_t device;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hip_vmm_common.hh
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hip_vmm_common.hh
@@ -25,7 +25,8 @@
     hipDeviceAttribute_t attr = hipDeviceAttributeVirtualMemoryManagementSupported;                \
     HIP_CHECK(hipDeviceGetAttribute(&value, attr, device));                                        \
     if (value == 0) {                                                                              \
-      HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);                                         \
+      HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kVmmUnsupported);                     \
+      return;                                                                                      \
     }                                                                                              \
   }
 
@@ -35,7 +36,8 @@
     hipDeviceAttribute_t attr = hipDeviceAttributeDmaBufSupported;                                 \
     HIP_CHECK(hipDeviceGetAttribute(&value, attr, device));                                        \
     if (value == 0) {                                                                              \
-      HIP_SKIP_TEST("DMA-BUF is not supported for this test on this device.");                     \
+      HipTest::HIP_SKIP_TEST("DMA-BUF is not supported for this test on this device.");                  \
+      return;                                                                                      \
     }                                                                                              \
   }
 #ifdef __linux__

--- a/projects/hip-tests/catch/unit/warp/warp_all.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_all.cc
@@ -108,7 +108,8 @@ HIP_TEST_CASE(Unit_Warp_Vote_All_Positive_Basic) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.arch.hasWarpVote) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kWarpVoteUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kWarpVoteUnsupported);
+    return;
   }
 
   SECTION("Warp Vote All with specified active mask") { WarpAll().run(false); }

--- a/projects/hip-tests/catch/unit/warp/warp_any.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_any.cc
@@ -99,7 +99,8 @@ HIP_TEST_CASE(Unit_Warp_Vote_Any_Positive_Basic) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.arch.hasWarpVote) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kWarpVoteUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kWarpVoteUnsupported);
+    return;
   }
 
   SECTION("Warp Vote Any with specified active mask") { WarpAny().run(false); }

--- a/projects/hip-tests/catch/unit/warp/warp_ballot.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_ballot.cc
@@ -98,7 +98,8 @@ HIP_TEST_CASE(Unit_Warp_Ballot_Positive_Basic) {
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.arch.hasWarpBallot) {
-    HIP_SKIP_TEST("warp ballot is not supported on this device.");
+    HipTest::HIP_SKIP_TEST("warp ballot is not supported on this device.");
+    return;
   }
 
   SECTION("Warp Ballot with specified active mask") { WarpBallot().run(false); }

--- a/projects/hip-tests/catch/unit/warp/warp_shfl.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_shfl.cc
@@ -94,7 +94,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_Warp_Shfl_Positive_Basic, int, unsigned int, long, u
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.arch.hasWarpShuffle) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kWarpShuffleUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kWarpShuffleUnsupported);
+    return;
   }
 
   SECTION("Shfl with specified active mask and input values") { WarpShfl<TestType>().run(false); }

--- a/projects/hip-tests/catch/unit/warp/warp_shfl_down.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_shfl_down.cc
@@ -94,7 +94,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_Warp_Shfl_Down_Positive_Basic, int, unsigned int, lo
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.arch.hasWarpShuffle) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kWarpShuffleUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kWarpShuffleUnsupported);
+    return;
   }
 
   SECTION("Shfl Down with specified active mask and input values") {

--- a/projects/hip-tests/catch/unit/warp/warp_shfl_up.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_shfl_up.cc
@@ -93,7 +93,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_Warp_Shfl_Up_Positive_Basic, int, unsigned int, long
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.arch.hasWarpShuffle) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kWarpShuffleUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kWarpShuffleUnsupported);
+    return;
   }
 
   SECTION("Shfl Up with specified active mask and input values") {

--- a/projects/hip-tests/catch/unit/warp/warp_shfl_xor.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_shfl_xor.cc
@@ -100,7 +100,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_Warp_Shfl_XOR_Positive_Basic, int, unsigned int, lon
   HIP_CHECK(hipGetDeviceProperties(&device_properties, device));
 
   if (!device_properties.arch.hasWarpShuffle) {
-    HIP_SKIP_TEST(HipTest::SkipReason::kWarpShuffleUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kWarpShuffleUnsupported);
+    return;
   }
 
   SECTION("Shfl Xor with specified active mask and input values") {


### PR DESCRIPTION
Reverts ROCm/rocm-systems#4505

See https://github.com/ROCm/rocm-systems/issues/5915, this raced with https://github.com/ROCm/rocm-systems/pull/5575 and broke the build:
```
2026-05-08T13:02:48.3238393Z [hip-tests] /__w/TheRock/TheRock/rocm-systems/projects/hip-tests/catch/unit/event/Unit_hipEventIpc_shm_cleanup.cc:64:16: error: expected identifier
2026-05-08T13:02:48.3242073Z [hip-tests]    64 |       HipTest::HIP_SKIP_TEST("Device uses native IPC signals; /dev/shm cleanup not applicable");
2026-05-08T13:02:48.3242172Z [hip-tests]       |                ^
2026-05-08T13:02:48.3242752Z [hip-tests] /__w/TheRock/TheRock/rocm-systems/projects/hip-tests/catch/unit/event/Unit_hipEventIpc_shm_cleanup.cc:64:7: error: unexpected namespace name 'HipTest': expected expression
2026-05-08T13:02:48.3243063Z [hip-tests]    64 |       HipTest::HIP_SKIP_TEST("Device uses native IPC signals; /dev/shm cleanup not applicable");
2026-05-08T13:02:48.3243134Z [hip-tests]       |       ^
2026-05-08T13:02:48.3243616Z [hip-tests] /__w/TheRock/TheRock/rocm-systems/projects/hip-tests/catch/unit/event/Unit_hipEventIpc_shm_cleanup.cc:64:14: error: expected ';' after expression
2026-05-08T13:02:48.3243923Z [hip-tests]    64 |       HipTest::HIP_SKIP_TEST("Device uses native IPC signals; /dev/shm cleanup not applicable");
2026-05-08T13:02:48.3243996Z [hip-tests]       |              ^
2026-05-08T13:02:48.3244061Z [hip-tests]       |              ;
2026-05-08T13:02:48.3244417Z [hip-tests] 3 errors generated when compiling for gfx1010.
```