### PR TITLE
[ci] Adding new label for mi325 for rocm-systems `rocm-rel-7.2`

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -128,5 +128,5 @@ jobs:
     with:
       project_to_test: ${{ inputs.project_to_test }}
       amdgpu_families: "gfx94X-dcgpu"
-      test_runs_on: "linux-mi325-1gpu-ossci-rocm"
+      test_runs_on: "linux-gfx942-1gpu-ossci-rocm"
       platform: "linux"

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
+          ref: 6fab5d65a552483bcfa1f6ccaaabf699c8188c1e # 2025-11-06 commit
 
       - name: "Configuring CI options"
         env:


### PR DESCRIPTION
As requested, adding a hard-coded change to add the correct label for gfx942 pulled from here: https://github.com/ROCm/TheRock/blob/66232fa2673f970331d242db344285f6603b1ac3/build_tools/github_actions/amdgpu_family_matrix.py#L145

As of 2025-11-06, hiptests and rocprofiler-tests did not exist: https://github.com/ROCm/TheRock/tree/6fab5d65a552483bcfa1f6ccaaabf699c8188c1e/build_tools/github_actions/test_executable_scripts (thus the tests are skipped)