### PR TITLE
rocprofiler-sdk: fix cmake warnings

### DIFF
--- a/projects/rocprofiler-sdk/cmake/rocprofiler_config_interfaces.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_config_interfaces.cmake
@@ -201,7 +201,7 @@ target_link_libraries(rocprofiler-sdk-ptl INTERFACE PTL::ptl-static)
 #
 # ----------------------------------------------------------------------------------------#
 
-find_package(LibElf)
+find_package(LibElf QUIET)
 if(LibElf_FOUND)
     target_link_libraries(rocprofiler-sdk-elf INTERFACE elf::elf)
 else()

--- a/projects/rocprofiler-sdk/tests/common/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/common/CMakeLists.txt
@@ -322,10 +322,7 @@ function(rocprofiler_add_integration_execute_test NAME)
     if(DEFINED arg_COMMAND AND NOT DEFINED arg_DEPENDS)
         message(SEND_ERROR "COMMAND signature without DEPENDS specified")
 
-    elseif(
-        DEFINED arg_COMMAND
-        AND DEFINED arg_DEPENDS
-        AND TARGET ${arg_DEPENDS})
+    elseif(DEFINED arg_COMMAND AND DEFINED arg_DEPENDS)
 
         add_test(NAME "${arg_NAME}" COMMAND ${arg_COMMAND})
 


### PR DESCRIPTION
- Fixes warning when libelf is found instead of LibElf
- Fixes warning from rocdecode and rocjpeg tests when they are added without the DEPENDS target existing

## Motivation

Fixes some cmake warnings that were annoying

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
