### PR TITLE
[ROCm Systems Profiler] Duplicate index entry removed from documentation

### DIFF
--- a/projects/rocprofiler-systems/docs/index.rst
+++ b/projects/rocprofiler-systems/docs/index.rst
@@ -40,7 +40,6 @@ profiling, how it supports performance analysis, and how to leverage its capabil
       * :doc:`Instrumenting and rewriting a binary application <./how-to/instrumenting-rewriting-binary-application>`
       * :doc:`Performing causal profiling <./how-to/performing-causal-profiling>`
       * :doc:`Profiling Python scripts <./how-to/profiling-python-scripts>`
-      * :doc:`Communication runtime profiling <./how-to/communication-runtime-profiling>`
       * :doc:`Network performance profiling <./how-to/nic-profiling>`
       * :doc:`Communication runtime profiling <./how-to/communication-runtime-profiling>`
       * :doc:`VCN and JPEG sampling and tracing <./how-to/vcn-jpeg-sampling>`


### PR DESCRIPTION
## Motivation
This PR fixes the duplicate reference entry present in the ROCm Systems Profiler documentation index page. 
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

The changes was only made to the source .rst documentation file. No other technical changes made.
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
ROCM-24282

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
