### PR TITLE
fix(rocprofiler-sdk): Add fallback path when pandas is not found

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/__main__.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/__main__.py
@@ -236,12 +236,14 @@ Example usage:
     # query: subparser args
     process_query_reporter_args = []
     process_query_reporter_args.append(output_config.add_args(query_reporter))
+    process_query_reporter_args.append(output_config.add_generic_args(query_reporter))
     process_query_reporter_args.append(query.add_args(query_reporter))
     process_query_reporter_args.append(time_window.add_args(query_reporter))
 
     # summary: subparser args
     process_generate_summary_args = []
     process_generate_summary_args.append(output_config.add_args(generate_summary))
+    process_generate_summary_args.append(output_config.add_generic_args(generate_summary))
     process_generate_summary_args.append(summary.add_args(generate_summary))
     process_generate_summary_args.append(time_window.add_args(generate_summary))
 
@@ -355,7 +357,7 @@ Example usage:
         for pitr in process_generate_summary_args:
             summary_args.update(pitr(input, args))
 
-        summary.generate_all_summaries(input, **summary_args)
+        summary.execute(input, **summary_args)
 
     print("Done. Exiting...")
 

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/__main__.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/__main__.py
@@ -276,24 +276,17 @@ Example usage:
         for pitr in process_converter_args:
             all_args.update(pitr(input, args))
 
-        # setup the config args
-        config = (
-            output_config.output_config(**all_args)
-            if config is None
-            else config.update(**all_args)
-        )
-
         # process each requested output format
         format_handlers = {
-            "pftrace": pftrace.write_pftrace,
-            "csv": csv.write_csv,
-            "otf2": otf2.write_otf2,
+            "pftrace": pftrace.execute,
+            "csv": csv.execute,
+            "otf2": otf2.execute,
         }
 
         for out_format in args.output_format:
             if out_format in format_handlers:
                 print(f"Converting database(s) to {out_format} format:")
-                format_handlers[out_format](input, config)
+                format_handlers[out_format](input, **all_args)
             else:
                 print(f"Warning: Unsupported output format '{out_format}'")
 
@@ -338,7 +331,6 @@ Example usage:
 
         query.execute(
             input,
-            args,
             **query_args,
         )
 

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/__main__.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/__main__.py
@@ -126,10 +126,12 @@ Example usage:
 """
     input_help_string = "Input path and filename to one or more database(s). Wildcards accepted, as well as .rpdb folders"
 
+    rocpd_help_string = "Aggregate and/or analyze ROCm Profiling Data (rocpd). Provide rocpd .db files or .rpdb folders to generate reports, summaries, and other analyses."
+
     # Add the subparsers
     parser = argparse.ArgumentParser(
         prog="rocpd",
-        description="Aggregate and/or analyze ROCm Profiling Data (rocpd)",
+        description=rocpd_help_string,
         allow_abbrev=False,
     )
 

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/csv.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/csv.py
@@ -33,11 +33,7 @@ from . import libpyrocpd
 
 
 def write_sql_query_to_csv(
-    connection: RocpdImportData,
-    config,
-    query,
-    filename="",
-    postfix="trace",
+    connection: RocpdImportData, config, query, filename="", postfix="trace", **kwargs
 ) -> None:
     """Write the contents of a SQL query to a CSV file in the specified output path."""
 
@@ -58,13 +54,13 @@ def write_sql_query_to_csv(
         config.output_path, f"{file_prefix}{filename}{file_postfix}.csv"
     )
 
-    kwargs = {"title_columns": True}
+    kwargs["title_columns"] = True
     export_sqlite_query(
         connection, query, export_format="csv", export_path=export_path, **kwargs
     )
 
 
-def write_agent_info_csv(importData, config) -> None:
+def write_agent_info_csv(importData, config, **kwargs) -> None:
 
     # Define mapping of output column name to JSON key
     json_keys = [
@@ -192,7 +188,7 @@ def write_agent_info_csv(importData, config) -> None:
         FROM "rocpd_info_agent"
     """
 
-    write_sql_query_to_csv(importData, config, query, "agent_info", "")
+    write_sql_query_to_csv(importData, config, query, "agent_info", "", **kwargs)
 
 
 def build_agent_id_string(agent_index_value, prefix=""):
@@ -265,12 +261,12 @@ def get_kernel_csv_query(importData, config) -> str:
     """
 
 
-def write_kernel_csv(importData, config) -> None:
+def write_kernel_csv(importData, config, **kwargs) -> None:
     query = get_kernel_csv_query(importData, config)
-    write_sql_query_to_csv(importData, config, query, "kernel")
+    write_sql_query_to_csv(importData, config, query, "kernel", **kwargs)
 
 
-def write_memory_copy_csv(importData, config) -> None:
+def write_memory_copy_csv(importData, config, **kwargs) -> None:
 
     src_agent_id = build_agent_id_string(config.agent_index_value, "src")
     dst_agent_id = build_agent_id_string(config.agent_index_value, "dst")
@@ -299,10 +295,10 @@ def write_memory_copy_csv(importData, config) -> None:
         ORDER BY
             guid ASC, start ASC, end DESC
     """
-    write_sql_query_to_csv(importData, config, query, "memory_copy")
+    write_sql_query_to_csv(importData, config, query, "memory_copy", **kwargs)
 
 
-def write_graph_launch_csv(importData, config) -> None:
+def write_graph_launch_csv(importData, config, **kwargs) -> None:
 
     agent_id = build_agent_id_string(config.agent_index_value)
 
@@ -323,10 +319,10 @@ def write_graph_launch_csv(importData, config) -> None:
         ORDER BY
             guid ASC, start ASC, end DESC
     """
-    write_sql_query_to_csv(importData, config, query, "graph_launch")
+    write_sql_query_to_csv(importData, config, query, "graph_launch", **kwargs)
 
 
-def write_memory_allocation_csv(importData, config) -> None:
+def write_memory_allocation_csv(importData, config, **kwargs) -> None:
 
     agent_id = build_agent_id_string(config.agent_index_value)
 
@@ -362,10 +358,10 @@ def write_memory_allocation_csv(importData, config) -> None:
         ORDER BY
             guid ASC, start ASC, end DESC
     """
-    write_sql_query_to_csv(importData, config, query, "memory_allocation")
+    write_sql_query_to_csv(importData, config, query, "memory_allocation", **kwargs)
 
 
-def write_counters_csv(importData, config) -> None:
+def write_counters_csv(importData, config, **kwargs) -> None:
 
     agent_id = build_agent_id_string(config.agent_index_value)
 
@@ -405,10 +401,10 @@ def write_counters_csv(importData, config) -> None:
         ORDER BY
             guid ASC, start ASC, end DESC
     """
-    write_sql_query_to_csv(importData, config, query, "counter_collection")
+    write_sql_query_to_csv(importData, config, query, "counter_collection", **kwargs)
 
 
-def write_spm_counters_csv(importData, config) -> None:
+def write_spm_counters_csv(importData, config, **kwargs) -> None:
 
     agent_id = build_agent_id_string(config.agent_index_value)
 
@@ -447,10 +443,10 @@ def write_spm_counters_csv(importData, config) -> None:
         ORDER BY
             guid ASC, timestamp ASC
     """
-    write_sql_query_to_csv(importData, config, query, "spm_counter_collection")
+    write_sql_query_to_csv(importData, config, query, "spm_counter_collection", **kwargs)
 
 
-def write_scratch_memory_csv(importData, config) -> None:
+def write_scratch_memory_csv(importData, config, **kwargs) -> None:
 
     agent_id = build_agent_id_string(config.agent_index_value)
 
@@ -469,10 +465,10 @@ def write_scratch_memory_csv(importData, config) -> None:
         ORDER BY
             guid ASC, start ASC, end DESC
     """
-    write_sql_query_to_csv(importData, config, query, "scratch_memory")
+    write_sql_query_to_csv(importData, config, query, "scratch_memory", **kwargs)
 
 
-def write_region_csv(importData, config) -> None:
+def write_region_csv(importData, config, **kwargs) -> None:
 
     query = """
         SELECT
@@ -488,25 +484,25 @@ def write_region_csv(importData, config) -> None:
         ORDER BY
             guid ASC, start ASC, end DESC
     """
-    write_sql_query_to_csv(importData, config, query, "regions")
+    write_sql_query_to_csv(importData, config, query, "regions", **kwargs)
 
 
-def write_csv(importData, config):
+def write_csv(importData, config, **kwargs):
 
-    write_agent_info_csv(importData, config)
-    write_counters_csv(importData, config)
-    write_kernel_csv(importData, config)
-    write_memory_allocation_csv(importData, config)
-    write_memory_copy_csv(importData, config)
-    write_region_csv(importData, config)
-    write_scratch_memory_csv(importData, config)
+    write_agent_info_csv(importData, config, **kwargs)
+    write_counters_csv(importData, config, **kwargs)
+    write_kernel_csv(importData, config, **kwargs)
+    write_memory_allocation_csv(importData, config, **kwargs)
+    write_memory_copy_csv(importData, config, **kwargs)
+    write_region_csv(importData, config, **kwargs)
+    write_scratch_memory_csv(importData, config, **kwargs)
 
     # graph launch was not introduced until schema version 3.0.2
     if "graph_launch" in importData.supported_features:
-        write_graph_launch_csv(importData, config)
+        write_graph_launch_csv(importData, config, **kwargs)
 
     if "spm_counters" in importData.supported_features:
-        write_spm_counters_csv(importData, config)
+        write_spm_counters_csv(importData, config, **kwargs)
 
 
 def execute(input, config=None, **kwargs):
@@ -517,7 +513,7 @@ def execute(input, config=None, **kwargs):
         else config.update(**kwargs)
     )
 
-    write_csv(input, config)
+    write_csv(input, config, **kwargs)
 
 
 def add_args(parser):

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/libpyrocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/libpyrocpd.cpp
@@ -75,6 +75,9 @@ namespace py = ::pybind11;
 
 namespace rocpd
 {
+void
+rocpd_log_message(int level, std::string_view msg);
+
 template <typename Tp>
 auto
 read_impl(sqlite3* conn, std::string_view conditions)
@@ -191,6 +194,15 @@ struct jinja_variables
     py::str uuid = py::none{};
     py::str guid = py::none{};
 };
+
+enum log_level_t : int
+{
+    log_level_none    = ROCP_LOG_LEVEL_NONE,
+    log_level_error   = ROCP_LOG_LEVEL_ERROR,
+    log_level_warning = ROCP_LOG_LEVEL_WARNING,
+    log_level_info    = ROCP_LOG_LEVEL_INFO,
+    log_level_trace   = ROCP_LOG_LEVEL_TRACE,
+};
 }  // namespace rocpd
 
 PYBIND11_MODULE(libpyrocpd, pyrocpd)
@@ -218,6 +230,36 @@ PYBIND11_MODULE(libpyrocpd, pyrocpd)
             return tool::format_path(std::move(inp), tag);
         },
         "Resolve output keys in filepath");
+
+    // Bind logging functions
+    pyrocpd.def(
+        "rocpd_log_trace",
+        [](const std::string& msg) { rocpd::rocpd_log_message(ROCP_LOG_LEVEL_TRACE, msg); },
+        py::arg("msg"),
+        "Emit a TRACE log message");
+    pyrocpd.def(
+        "rocpd_log_info",
+        [](const std::string& msg) { rocpd::rocpd_log_message(ROCP_LOG_LEVEL_INFO, msg); },
+        py::arg("msg"),
+        "Emit an INFO log message");
+    pyrocpd.def(
+        "rocpd_log_warning",
+        [](const std::string& msg) { rocpd::rocpd_log_message(ROCP_LOG_LEVEL_WARNING, msg); },
+        py::arg("msg"),
+        "Emit a WARNING log message");
+    pyrocpd.def(
+        "rocpd_log_error",
+        [](const std::string& msg) { rocpd::rocpd_log_message(ROCP_LOG_LEVEL_ERROR, msg); },
+        py::arg("msg"),
+        "Emit an ERROR log message");
+    pyrocpd.def(
+        "rocpd_log",
+        [](rocpd::log_level_t level, const std::string& msg) {
+            rocpd::rocpd_log_message(static_cast<int>(level), msg);
+        },
+        py::arg("level"),
+        py::arg("msg"),
+        "Emit a log message at the given level (libpyrocpd.log_level enum or integer)");
 
     py::enum_<rocpd_sql_engine_t>(pyrocpd, "sql_engine", "Load schema engines")
         .value("sqlite3", ROCPD_SQL_ENGINE_SQLITE3);

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/otf2.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/otf2.py
@@ -106,14 +106,6 @@ def write_otf2(importData, config):
             "otf2 module not found. Please install it using 'pip install otf2' to convert to OTF2 format"
         ) from e
 
-    try:
-        import otf2
-        from otf2.enums import LocationType, LocationGroupType, RegionRole, Paradigm
-    except ImportError:
-        raise ImportError(
-            "otf2 module not found. Conversion to OTF2 format is not possible. Please install it using 'pip install otf2'\n"
-        )
-
     timer_resolution = 1_000_000_000
     trace_dir = getattr(config, "output_path", "./otf_traces")
     trace_file = f"{getattr(config, 'output_file', 'traces')}_results"

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/otf2.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/otf2.py
@@ -110,11 +110,9 @@ def write_otf2(importData, config):
         import otf2
         from otf2.enums import LocationType, LocationGroupType, RegionRole, Paradigm
     except ImportError:
-        print(
-            "otf2 module not found. Conversion to OTF2 format is not possible.\n"
-            "Please install it using 'pip install otf2'"
+        raise ImportError(
+            "otf2 module not found. Conversion to OTF2 format is not possible. Please install it using 'pip install otf2'\n"
         )
-        return
 
     timer_resolution = 1_000_000_000
     trace_dir = getattr(config, "output_path", "./otf_traces")

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/otf2.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/otf2.py
@@ -106,6 +106,16 @@ def write_otf2(importData, config):
             "otf2 module not found. Please install it using 'pip install otf2' to convert to OTF2 format"
         ) from e
 
+    try:
+        import otf2
+        from otf2.enums import LocationType, LocationGroupType, RegionRole, Paradigm
+    except ImportError:
+        print(
+            "otf2 module not found. Conversion to OTF2 format is not possible.\n"
+            "Please install it using 'pip install otf2'"
+        )
+        return
+
     timer_resolution = 1_000_000_000
     trace_dir = getattr(config, "output_path", "./otf_traces")
     trace_file = f"{getattr(config, 'output_file', 'traces')}_results"

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/output_config.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/output_config.py
@@ -153,9 +153,7 @@ def add_args(parser):
         for itr in valid_args:
             if hasattr(args, itr):
                 val = getattr(args, itr)
-                if itr == "output_format":
-                    ret[itr] = val
-                elif itr == "output_path" and val is not None:
+                if itr == "output_path" and val is not None:
                     ret[itr] = format_path(val)
                 elif val is not None:
                     ret[itr] = val

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/output_config.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/output_config.py
@@ -188,8 +188,18 @@ def add_generic_args(parser):
         default="relative",
     )
 
+    generic_options.add_argument(
+        "--export-backend",
+        choices=("auto", "pandas", "native"),
+        help="""Explicitly select export backend to use. Pandas is preferred if available (default: auto):
+        auto: attempts to use pandas and falls back to native if not available.
+        pandas: explicitly uses pandas for export.
+        native: only supports select formats (console, csv, html, json, md) where standard libraries are available.""",
+        nargs="+",
+    )
+
     def process_args(input, args):
-        valid_args = ["agent_index_value", "kernel_rename"]
+        valid_args = ["agent_index_value", "export_backend", "kernel_rename"]
         ret = {}
         for itr in valid_args:
             if hasattr(args, itr):

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
@@ -58,12 +58,14 @@ def export_sqlite_query(
     Returns the path to the exported file (or None if nothing was exported).
 
     Supported export_format values (case-insensitive):
-        - "csv"
-        - "html"
-        - "md"   (markdown)
-        - "pdf"
-        - "dashboard"   (templated HTML dashboard)
-        - "clipboard"
+        - "console"     (default; prints to stdout — no pandas required)
+        - "csv"         (no pandas required)
+        - "json"        (no pandas required)
+        - "html"        (no pandas required)
+        - "md"          (markdown — no pandas required)
+        - "pdf"         (requires pandas + reportlab)
+        - "dashboard"   (templated HTML dashboard — requires pandas + jinja2)
+        - "clipboard"   (requires pandas)
 
     If export_format == "dashboard", you may optionally pass a
     dashboard_template_path (a Jinja2 template file). If omitted,
@@ -71,9 +73,32 @@ def export_sqlite_query(
     """
 
     try:
-        import pandas as pd
-
         conn = conn.connection if isinstance(conn, RocpdImportData) else conn
+
+        try:
+            import pandas as pd
+
+            _pandas_available = True
+        except ImportError:
+            _pandas_available = False
+
+        normalized_format = export_format.lower() if export_format else None
+        _stdlib_formats = {None, "console", "csv", "json", "html", "md"}
+
+        if not _pandas_available:
+            if normalized_format in _stdlib_formats:
+                print(
+                    "Module 'pandas' not found. Install it with: pip install pandas. Using fallback path.\n"
+                )
+                return _export_without_pandas(
+                    conn, query, params, normalized_format, export_path, **kwargs
+                )
+            else:
+                print(
+                    f"Export format '{normalized_format}' requires pandas. "
+                    "Install it with: pip install pandas"
+                )
+                return None
 
         # 1) Run the query via pandas
         df = pd.read_sql_query(query, conn, params=params)
@@ -156,6 +181,85 @@ def export_sqlite_query(
     except Exception as e:
         print(f"Error: {e}")
         return None
+
+
+def _export_without_pandas(conn, query, params, export_format, export_path, **kwargs):
+    """
+    Execute a SQLite query and export results using only the standard library.
+    Handles: console, csv, json, html, md.
+    """
+    import csv as _csv
+    import json
+    import html as _html
+
+    cursor = conn.cursor()
+    cursor.execute(query, params if params else ())
+    rows = cursor.fetchall()
+    col_names_raw = [desc[0] for desc in cursor.description] if cursor.description else []
+
+    if not rows:
+        sys.stderr.write(f"No results found for query: {query}\n")
+        sys.stderr.flush()
+        return None
+
+    if export_format in (None, "console"):
+        str_rows = [[str(v) for v in row] for row in rows]
+        col_widths = [len(c) for c in col_names_raw]
+        for row in str_rows:
+            for i, v in enumerate(row):
+                col_widths[i] = max(col_widths[i], len(v))
+        header = "  ".join(c.ljust(col_widths[i]) for i, c in enumerate(col_names_raw))
+        print(header)
+        for row in str_rows:
+            print("  ".join(v.ljust(col_widths[i]) for i, v in enumerate(row)))
+        return None
+
+    ext = export_format
+    export_path = export_path or f"query_output.{ext}"
+    if not export_path.endswith(f".{ext}"):
+        export_path = f"{export_path}.{ext}"
+    export_path = os.path.abspath(libpyrocpd.format_path(export_path, "rocpd"))
+    os.makedirs(os.path.dirname(export_path), exist_ok=True)
+
+    if export_format == "csv":
+        title_columns = kwargs.get("title_columns", True)
+        col_names = (
+            [c.title() for c in col_names_raw] if title_columns else col_names_raw[:]
+        )
+        with open(export_path, "w", newline="") as f:
+            writer = _csv.writer(f, quoting=_csv.QUOTE_NONNUMERIC)
+            writer.writerow(col_names)
+            writer.writerows(rows)
+
+    elif export_format == "json":
+        records = [dict(zip(col_names_raw, row)) for row in rows]
+        with open(export_path, "w", encoding="utf-8") as f:
+            json.dump(records, f, indent=2, default=str)
+            f.write("\n")
+
+    elif export_format == "html":
+        lines = ['<table border="1" class="dataframe">', "  <thead>", "    <tr>"]
+        for col in col_names_raw:
+            lines.append(f"      <th>{_html.escape(str(col))}</th>")
+        lines += ["    </tr>", "  </thead>", "  <tbody>"]
+        for row in rows:
+            lines.append("    <tr>")
+            for v in row:
+                lines.append(f"      <td>{_html.escape(str(v))}</td>")
+            lines.append("    </tr>")
+        lines += ["  </tbody>", "</table>"]
+        with open(export_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+
+    elif export_format == "md":
+        with open(export_path, "w", encoding="utf-8") as f:
+            f.write("| " + " | ".join(col_names_raw) + " |\n")
+            f.write("|" + "|".join("---" for _ in col_names_raw) + "|\n")
+            for row in rows:
+                f.write("| " + " | ".join(str(v) for v in row) + " |\n")
+
+    print(f"Exported to: {export_path}\n")
+    return export_path
 
 
 def _df_to_markdown_fallback(df, path: str):

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
@@ -87,17 +87,19 @@ def export_sqlite_query(
 
         if not _pandas_available:
             if normalized_format in _stdlib_formats:
-                print(
+                sys.stderr.write(
                     "Module 'pandas' not found. Install it with: pip install pandas. Using fallback path.\n"
                 )
+                sys.stderr.flush()
                 return _export_without_pandas(
                     conn, query, params, normalized_format, export_path, **kwargs
                 )
             else:
-                print(
+                sys.stderr.write(
                     f"Export format '{normalized_format}' requires pandas. "
-                    "Install it with: pip install pandas"
+                    "Install it with: pip install pandas\n"
                 )
+                sys.stderr.flush()
                 return None
 
         # 1) Run the query via pandas
@@ -108,17 +110,16 @@ def export_sqlite_query(
             sys.stderr.flush()
             return None
 
-        if export_format == "console" or export_format is None:
+        if normalized_format in (None, "console"):
             # 2) Print to console
             print(df.to_string(index=False))
             return None
 
-        elif export_format == "clipboard":
+        elif normalized_format == "clipboard":
             df.to_clipboard(excel=False)
             return None
 
-        export_format = export_format.lower()
-        ext = export_format
+        ext = normalized_format
         export_path = export_path or f"query_output.{ext}"
         if not export_path.endswith(f".{ext}"):
             export_path = f"{export_path}.{ext}"
@@ -132,7 +133,7 @@ def export_sqlite_query(
                 ofs.flush()
 
         # 3) Export based on format
-        if export_format == "csv":
+        if normalized_format == "csv":
             import csv
 
             cols = [f"{itr}" for itr in df.columns.tolist()]
@@ -149,10 +150,10 @@ def export_sqlite_query(
                 quoting=csv.QUOTE_NONNUMERIC,
             )
 
-        elif export_format == "html":
+        elif normalized_format == "html":
             write_export(df.to_html(index=False))
 
-        elif export_format == "md":
+        elif normalized_format == "md":
             # pandas 1.0+ has to_markdown
             try:
                 write_export(df.to_markdown(index=False))
@@ -160,19 +161,19 @@ def export_sqlite_query(
                 # fallback: manually write markdown table
                 _df_to_markdown_fallback(df, export_path)
 
-        elif export_format == "pdf":
+        elif normalized_format == "pdf":
             _export_df_to_pdf(df, export_path)
 
-        elif export_format == "dashboard":
+        elif normalized_format == "dashboard":
             _export_dashboard(
                 df, export_path=export_path, template_path=dashboard_template_path
             )
 
-        elif export_format == "json":
+        elif normalized_format == "json":
             df.to_json(export_path, index=False, indent=2, orient="records")
 
         else:
-            print(f"Unsupported export format: {export_format}")
+            print(f"Unsupported export format: {normalized_format}")
             return None
 
         print(f"Exported to: {export_path}\n")
@@ -226,7 +227,7 @@ def _export_without_pandas(conn, query, params, export_format, export_path, **kw
         col_names = (
             [c.title() for c in col_names_raw] if title_columns else col_names_raw[:]
         )
-        with open(export_path, "w", newline="") as f:
+        with open(export_path, "w", newline="", encoding="utf-8") as f:
             writer = _csv.writer(f, quoting=_csv.QUOTE_NONNUMERIC)
             writer.writerow(col_names)
             writer.writerows(rows)

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
@@ -79,7 +79,9 @@ def export_sqlite_query(
             import pandas as pd
 
             _pandas_available = True
-        except ImportError:
+        except ModuleNotFoundError as e:
+            if e.name != "pandas":
+                raise e
             _pandas_available = False
 
         normalized_format = export_format.lower() if export_format else None

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
@@ -76,8 +76,8 @@ def export_sqlite_query(
 
         _pandas_available = True
     except ModuleNotFoundError as e:
-            if e.name != "pandas":
-                raise e
+        if e.name != "pandas":
+            raise e
         _pandas_available = False
 
     try:
@@ -618,13 +618,33 @@ def add_args(parser):
     )
 
     def process_args(input, args):
+        valid_args = [
+            "query",
+            "script",
+            "format",
+            "email_to",
+            "email_from",
+            "email_subject",
+            "smtp_server",
+            "smtp_port",
+            "smtp_user",
+            "smtp_password",
+            "zip_attachments",
+            "inline_preview",
+            "template_path",
+        ]
         ret = {}
+        for itr in valid_args:
+            if hasattr(args, itr):
+                val = getattr(args, itr)
+                if val is not None:
+                    ret[itr] = val
         return ret
 
     return process_args
 
 
-def execute(input, args, config=None, **kwargs):
+def execute(input, config=None, **kwargs):
 
     config = (
         output_config.output_config(**kwargs)
@@ -632,20 +652,20 @@ def execute(input, args, config=None, **kwargs):
         else config.update(**kwargs)
     )
 
-    if args.script:
+    if kwargs.get("script", None):
         # read script and execute statements
-        with open(args.script, "r") as ifs:
+        with open(kwargs.get("script", None), "r") as ifs:
             for itr in ifs.read().split(";"):
                 input.execute(f"{itr}")
 
     # Prepare parameters for export
-    query = args.query
+    query = kwargs.pop("query", None)
     db = input
-    export_format = args.format
+    export_format = kwargs.pop("format", None)
     export_path = os.path.join(config.output_path, config.output_file)
 
     # Dashboard-only extra
-    dashboard_template = kwargs.get("template_path", None)
+    dashboard_template = kwargs.pop("template_path", None)
 
     # 1) Run and export
     exported_file = export_sqlite_query(
@@ -659,25 +679,25 @@ def execute(input, args, config=None, **kwargs):
     )
 
     # 2) If --email-to was provided and we have a file, send it
-    if args.email_to:
-        if not args.email_from:
+    if kwargs.get("email_to", None):
+        if not kwargs.get("email_from", None):
             raise ValueError("--email-from is required when --email-to is used.")
         if not exported_file:
             print("No file was exported; skipping email.")
             return
 
-        recipients = [addr.strip() for addr in args.email_to.split(",")]
+        recipients = [addr.strip() for addr in kwargs.get("email_to", None).split(",")]
         send_report_email(
             file_paths=[exported_file],
             to=recipients,
-            sender=args.email_from,
-            subject=args.email_subject,
-            inline_preview=args.inline_preview,
-            smtp_server=args.smtp_server,
-            smtp_port=args.smtp_port,
-            smtp_user=args.smtp_user,
-            smtp_password=args.smtp_password,
-            zip_attachments=args.zip_attachments,
+            sender=kwargs.get("email_from", None),
+            subject=kwargs.get("email_subject", None),
+            inline_preview=kwargs.get("inline_preview", None),
+            smtp_server=kwargs.get("smtp_server", None),
+            smtp_port=kwargs.get("smtp_port", None),
+            smtp_user=kwargs.get("smtp_user", None),
+            smtp_password=kwargs.get("smtp_password", None),
+            zip_attachments=kwargs.get("zip_attachments", None),
         )
 
 
@@ -725,7 +745,6 @@ def main(argv=None):
 
     execute(
         input,
-        args,
         **all_args,
     )
 

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
@@ -320,6 +320,8 @@ def _export_without_pandas(conn, query, params, export_format, export_path, **kw
     elif export_format == "md":
 
         def _fmt_val_md(v):
+            import math
+            
             if v is None or (isinstance(v, float) and math.isnan(v)):
                 return "nan"
             if isinstance(v, float):

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
@@ -254,6 +254,23 @@ def _export_without_pandas(conn, query, params, export_format, export_path, **kw
     import csv as _csv
     import json
     import html as _html
+    import math
+
+    # Determine format per column: scientific if any float in the column >= 1e6
+    def _col_fmt(col_vals):
+        floats = [v for v in col_vals if isinstance(v, float) and not math.isnan(v)]
+        if floats and max(abs(v) for v in floats) >= 1e6:
+            return "{:.6e}"
+        return "{:.6f}"
+
+    def _fmt_val(v, fmt):
+        if v is None:
+            return "NaN"
+        if isinstance(v, float):
+            if math.isnan(v):
+                return "NaN"
+            return fmt.format(v)
+        return str(v)
 
     libpyrocpd.rocpd_log_info(
         f"Running query via stdlib for export format: {export_format}"
@@ -268,8 +285,12 @@ def _export_without_pandas(conn, query, params, export_format, export_path, **kw
         sys.stderr.flush()
         return None
 
+    col_fmts = [_col_fmt([row[ci] for row in rows]) for ci in range(len(col_names_raw))]
+
     if export_format in (None, "console"):
-        str_rows = [[str(v) for v in row] for row in rows]
+        str_rows = [
+            [_fmt_val(v, col_fmts[ci]) for ci, v in enumerate(row)] for row in rows
+        ]
         col_widths = [len(c) for c in col_names_raw]
         for row in str_rows:
             for i, v in enumerate(row):
@@ -293,7 +314,7 @@ def _export_without_pandas(conn, query, params, export_format, export_path, **kw
             [c.title() for c in col_names_raw] if title_columns else col_names_raw[:]
         )
         with open(export_path, "w", newline="", encoding="utf-8") as f:
-            writer = _csv.writer(f, quoting=_csv.QUOTE_NONNUMERIC)
+            writer = _csv.writer(f, quoting=_csv.QUOTE_NONNUMERIC, lineterminator="\n")
             writer.writerow(col_names)
             writer.writerows(rows)
 
@@ -310,8 +331,8 @@ def _export_without_pandas(conn, query, params, export_format, export_path, **kw
         lines += ["    </tr>", "  </thead>", "  <tbody>"]
         for row in rows:
             lines.append("    <tr>")
-            for v in row:
-                lines.append(f"      <td>{_html.escape(str(v))}</td>")
+            for ci, v in enumerate(row):
+                lines.append(f"      <td>{_html.escape(_fmt_val(v, col_fmts[ci]))}</td>")
             lines.append("    </tr>")
         lines += ["  </tbody>", "</table>"]
         with open(export_path, "w", encoding="utf-8") as f:
@@ -322,7 +343,11 @@ def _export_without_pandas(conn, query, params, export_format, export_path, **kw
             f.write("| " + " | ".join(col_names_raw) + " |\n")
             f.write("|" + "|".join("---" for _ in col_names_raw) + "|\n")
             for row in rows:
-                f.write("| " + " | ".join(str(v) for v in row) + " |\n")
+                f.write(
+                    "| "
+                    + " | ".join(_fmt_val(v, col_fmts[ci]) for ci, v in enumerate(row))
+                    + " |\n"
+                )
 
     print(f"Exported to: {export_path}\n")
     return export_path

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
@@ -72,7 +72,7 @@ def export_sqlite_query(
     a built-in default template is used.
     """
     try:
-        import pandas as pd
+        import pandas  # noqa: F401
 
         _pandas_available = True
     except ModuleNotFoundError as e:
@@ -254,23 +254,6 @@ def _export_without_pandas(conn, query, params, export_format, export_path, **kw
     import csv as _csv
     import json
     import html as _html
-    import math
-
-    # Determine format per column: scientific if any float in the column >= 1e6
-    def _col_fmt(col_vals):
-        floats = [v for v in col_vals if isinstance(v, float) and not math.isnan(v)]
-        if floats and max(abs(v) for v in floats) >= 1e6:
-            return "{:.6e}"
-        return "{:.6f}"
-
-    def _fmt_val(v, fmt):
-        if v is None:
-            return "NaN"
-        if isinstance(v, float):
-            if math.isnan(v):
-                return "NaN"
-            return fmt.format(v)
-        return str(v)
 
     libpyrocpd.rocpd_log_info(
         f"Running query via stdlib for export format: {export_format}"
@@ -285,12 +268,8 @@ def _export_without_pandas(conn, query, params, export_format, export_path, **kw
         sys.stderr.flush()
         return None
 
-    col_fmts = [_col_fmt([row[ci] for row in rows]) for ci in range(len(col_names_raw))]
-
     if export_format in (None, "console"):
-        str_rows = [
-            [_fmt_val(v, col_fmts[ci]) for ci, v in enumerate(row)] for row in rows
-        ]
+        str_rows = [[str(v) for v in row] for row in rows]
         col_widths = [len(c) for c in col_names_raw]
         for row in str_rows:
             for i, v in enumerate(row):
@@ -314,7 +293,7 @@ def _export_without_pandas(conn, query, params, export_format, export_path, **kw
             [c.title() for c in col_names_raw] if title_columns else col_names_raw[:]
         )
         with open(export_path, "w", newline="", encoding="utf-8") as f:
-            writer = _csv.writer(f, quoting=_csv.QUOTE_NONNUMERIC, lineterminator="\n")
+            writer = _csv.writer(f, quoting=_csv.QUOTE_NONNUMERIC)
             writer.writerow(col_names)
             writer.writerows(rows)
 
@@ -331,8 +310,8 @@ def _export_without_pandas(conn, query, params, export_format, export_path, **kw
         lines += ["    </tr>", "  </thead>", "  <tbody>"]
         for row in rows:
             lines.append("    <tr>")
-            for ci, v in enumerate(row):
-                lines.append(f"      <td>{_html.escape(_fmt_val(v, col_fmts[ci]))}</td>")
+            for v in row:
+                lines.append(f"      <td>{_html.escape(str(v))}</td>")
             lines.append("    </tr>")
         lines += ["  </tbody>", "</table>"]
         with open(export_path, "w", encoding="utf-8") as f:
@@ -343,11 +322,7 @@ def _export_without_pandas(conn, query, params, export_format, export_path, **kw
             f.write("| " + " | ".join(col_names_raw) + " |\n")
             f.write("|" + "|".join("---" for _ in col_names_raw) + "|\n")
             for row in rows:
-                f.write(
-                    "| "
-                    + " | ".join(_fmt_val(v, col_fmts[ci]) for ci, v in enumerate(row))
-                    + " |\n"
-                )
+                f.write("| " + " | ".join(str(v) for v in row) + " |\n")
 
     print(f"Exported to: {export_path}\n")
     return export_path

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
@@ -88,19 +88,16 @@ def export_sqlite_query(
 
         if not _pandas_available:
             if normalized_format in _stdlib_formats:
-                sys.stderr.write(
+                libpyrocpd.rocpd_log_warning(
                     "Module 'pandas' not found. Install it with: pip install pandas. Using fallback path.\n"
                 )
-                sys.stderr.flush()
                 return _export_without_pandas(
                     conn, query, params, normalized_format, export_path, **kwargs
                 )
             else:
-                sys.stderr.write(
-                    f"Export format '{normalized_format}' requires pandas. "
-                    "Install it with: pip install pandas\n"
+                libpyrocpd.rocpd_log_error(
+                    f"Export format '{normalized_format}' requires pandas. Install it with: pip install pandas\n"
                 )
-                sys.stderr.flush()
                 return None
 
         # 1) Run the query via pandas

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
@@ -86,17 +86,19 @@ def export_sqlite_query(
 
         if not _pandas_available:
             if normalized_format in _stdlib_formats:
-                print(
+                sys.stderr.write(
                     "Module 'pandas' not found. Install it with: pip install pandas. Using fallback path.\n"
                 )
+                sys.stderr.flush()
                 return _export_without_pandas(
                     conn, query, params, normalized_format, export_path, **kwargs
                 )
             else:
-                print(
+                sys.stderr.write(
                     f"Export format '{normalized_format}' requires pandas. "
-                    "Install it with: pip install pandas"
+                    "Install it with: pip install pandas\n"
                 )
+                sys.stderr.flush()
                 return None
 
         # 1) Run the query via pandas
@@ -107,17 +109,16 @@ def export_sqlite_query(
             sys.stderr.flush()
             return None
 
-        if export_format == "console" or export_format is None:
+        if normalized_format in (None, "console"):
             # 2) Print to console
             print(df.to_string(index=False))
             return None
 
-        elif export_format == "clipboard":
+        elif normalized_format == "clipboard":
             df.to_clipboard(excel=False)
             return None
 
-        export_format = export_format.lower()
-        ext = export_format
+        ext = normalized_format
         export_path = export_path or f"query_output.{ext}"
         if not export_path.endswith(f".{ext}"):
             export_path = f"{export_path}.{ext}"
@@ -131,7 +132,7 @@ def export_sqlite_query(
                 ofs.flush()
 
         # 3) Export based on format
-        if export_format == "csv":
+        if normalized_format == "csv":
             import csv
 
             cols = [f"{itr}" for itr in df.columns.tolist()]
@@ -148,10 +149,10 @@ def export_sqlite_query(
                 quoting=csv.QUOTE_NONNUMERIC,
             )
 
-        elif export_format == "html":
+        elif normalized_format == "html":
             write_export(df.to_html(index=False))
 
-        elif export_format == "md":
+        elif normalized_format == "md":
             # pandas 1.0+ has to_markdown
             try:
                 write_export(df.to_markdown(index=False))
@@ -159,19 +160,19 @@ def export_sqlite_query(
                 # fallback: manually write markdown table
                 _df_to_markdown_fallback(df, export_path)
 
-        elif export_format == "pdf":
+        elif normalized_format == "pdf":
             _export_df_to_pdf(df, export_path)
 
-        elif export_format == "dashboard":
+        elif normalized_format == "dashboard":
             _export_dashboard(
                 df, export_path=export_path, template_path=dashboard_template_path
             )
 
-        elif export_format == "json":
+        elif normalized_format == "json":
             df.to_json(export_path, index=False, indent=2, orient="records")
 
         else:
-            print(f"Unsupported export format: {export_format}")
+            print(f"Unsupported export format: {normalized_format}")
             return None
 
         print(f"Exported to: {export_path}\n")
@@ -225,7 +226,7 @@ def _export_without_pandas(conn, query, params, export_format, export_path, **kw
         col_names = (
             [c.title() for c in col_names_raw] if title_columns else col_names_raw[:]
         )
-        with open(export_path, "w", newline="") as f:
+        with open(export_path, "w", newline="", encoding="utf-8") as f:
             writer = _csv.writer(f, quoting=_csv.QUOTE_NONNUMERIC)
             writer.writerow(col_names)
             writer.writerows(rows)

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
@@ -220,12 +220,12 @@ def _export_with_pandas(
         write_export(df.to_html(index=False))
 
     elif export_format == "md":
-        # pandas 1.0+ has to_markdown
         try:
             write_export(df.to_markdown(index=False))
         except AttributeError:
-            # fallback: manually write markdown table
-            _df_to_markdown_fallback(df, export_path)
+            return _export_without_pandas(
+                conn, query, params, "md", export_path, **kwargs
+            )
 
     elif export_format == "pdf":
         _export_df_to_pdf(df, export_path)
@@ -274,10 +274,10 @@ def _export_without_pandas(conn, query, params, export_format, export_path, **kw
         for row in str_rows:
             for i, v in enumerate(row):
                 col_widths[i] = max(col_widths[i], len(v))
-        header = "  ".join(c.ljust(col_widths[i]) for i, c in enumerate(col_names_raw))
+        header = "  ".join(c.rjust(col_widths[i]) for i, c in enumerate(col_names_raw))
         print(header)
         for row in str_rows:
-            print("  ".join(v.ljust(col_widths[i]) for i, v in enumerate(row)))
+            print("  ".join(v.rjust(col_widths[i]) for i, v in enumerate(row)))
         return None
 
     ext = export_format
@@ -318,30 +318,103 @@ def _export_without_pandas(conn, query, params, export_format, export_path, **kw
             f.write("\n".join(lines) + "\n")
 
     elif export_format == "md":
+
+        def _fmt_val_md(v):
+            if v is None or (isinstance(v, float) and math.isnan(v)):
+                return "nan"
+            if isinstance(v, float):
+                return f"{v:.6g}"
+            return str(v)
+
+        def _split_decimal(s):
+            """Split a formatted value at its first '.'; return (int_part, frac_part)."""
+            dot = s.find(".")
+            if dot == -1:
+                return s, ""
+            return s[:dot], s[dot:]
+
+        # Detect column types (numeric = all non-None values are int or float)
+        col_numeric = [
+            all(isinstance(row[ci], (int, float)) or row[ci] is None for row in rows)
+            for ci in range(len(col_names_raw))
+        ]
+
+        # Format all cell values
+        str_rows = [
+            [_fmt_val_md(row[ci]) for ci in range(len(col_names_raw))] for row in rows
+        ]
+
+        # Compute per-column layout parameters
+        # For numeric: decimal-point alignment (padded_w = max(header+2, max_int+max_frac))
+        # For strings: simple left-align (padded_w = max(header, max_data))
+        col_padded_w = []
+        col_eff_int = []  # effective max integer-part width (after header expansion)
+        col_max_frac = []
+
+        for ci, header in enumerate(col_names_raw):
+            if col_numeric[ci]:
+                splits = [_split_decimal(r[ci]) for r in str_rows]
+                max_int = max(len(ip) for ip, fp in splits)
+                max_frac = max(len(fp) for ip, fp in splits)
+                data_w = max_int + max_frac
+                padded_w = max(len(header) + 2, data_w)
+                col_padded_w.append(padded_w)
+                col_eff_int.append(padded_w - max_frac)
+                col_max_frac.append(max_frac)
+            else:
+                max_data = max(len(r[ci]) for r in str_rows)
+                padded_w = max(len(header), max_data)
+                col_padded_w.append(padded_w)
+                col_eff_int.append(padded_w)
+                col_max_frac.append(0)
+
+        def _pad_cell(s, ci):
+            if col_numeric[ci]:
+                ip, fp = _split_decimal(s)
+                return (
+                    " " * (col_eff_int[ci] - len(ip))
+                    + ip
+                    + fp
+                    + " " * (col_max_frac[ci] - len(fp))
+                )
+            return s.ljust(col_padded_w[ci])
+
         with open(export_path, "w", encoding="utf-8") as f:
-            f.write("| " + " | ".join(col_names_raw) + " |\n")
-            f.write("|" + "|".join("---" for _ in col_names_raw) + "|\n")
-            for row in rows:
-                f.write("| " + " | ".join(str(v) for v in row) + " |\n")
+            # Header row: numeric → right-aligned, string → left-aligned
+            f.write(
+                "| "
+                + " | ".join(
+                    (
+                        col_names_raw[ci].rjust(col_padded_w[ci])
+                        if col_numeric[ci]
+                        else col_names_raw[ci].ljust(col_padded_w[ci])
+                    )
+                    for ci in range(len(col_names_raw))
+                )
+                + " |\n"
+            )
+            # Separator: width = col_padded_w + 2 (to match the `| cell |` spacing)
+            sep_parts = [
+                (
+                    ("-" * (col_padded_w[ci] + 1) + ":")
+                    if col_numeric[ci]
+                    else (":" + "-" * (col_padded_w[ci] + 1))
+                )
+                for ci in range(len(col_names_raw))
+            ]
+            f.write("|" + "|".join(sep_parts) + "|\n")
+            # Data rows
+            for row in str_rows:
+                f.write(
+                    "| "
+                    + " | ".join(
+                        _pad_cell(row[ci], ci) for ci in range(len(col_names_raw))
+                    )
+                    + " |\n"
+                )
 
     print(f"Exported to: {export_path}\n")
     return export_path
-
-
-def _df_to_markdown_fallback(df, path: str):
-    """
-    Simple fallback if pandas.DataFrame.to_markdown(...) is unavailable.
-    """
-    headers = list(df.columns)
-    with open(path, "w", encoding="utf-8") as f:
-        # Header row
-        f.write("| " + " | ".join(headers) + " |\n")
-        # Separator
-        f.write("|" + "|".join("---" for _ in headers) + "|\n")
-        # Data rows
-        for row in df.itertuples(index=False):
-            line = "| " + " | ".join(str(v) for v in row) + " |\n"
-            f.write(line)
 
 
 def _export_df_to_pdf(df, path: str):

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
@@ -86,100 +86,164 @@ def export_sqlite_query(
         normalized_format = export_format.lower() if export_format else None
         _stdlib_formats = {None, "console", "csv", "json", "html", "md"}
 
-        if not _pandas_available:
-            if normalized_format in _stdlib_formats:
-                libpyrocpd.rocpd_log_warning(
-                    "Module 'pandas' not found. Install it with: pip install pandas. Using fallback path.\n"
-                )
-                return _export_without_pandas(
-                    conn, query, params, normalized_format, export_path, **kwargs
-                )
+        # parse backend here
+        export_backend = kwargs.get("export_backend", "auto")
+
+        if not isinstance(export_backend, list):
+            export_backend = [export_backend]
+
+        for backend_itr in export_backend:
+            if backend_itr == "pandas":
+                libpyrocpd.rocpd_log_info(f"User requested pandas backend for export")
+                if _pandas_available:
+                    return _export_with_pandas(
+                        conn,
+                        query,
+                        params,
+                        export_format,
+                        export_path,
+                        dashboard_template_path=dashboard_template_path,
+                        **kwargs,
+                    )
+                else:
+                    libpyrocpd.rocpd_log_warning(
+                        "Module 'pandas' not found but user requested pandas backend. Doing nothing.\n"
+                    )
+
+            elif backend_itr == "native":
+                libpyrocpd.rocpd_log_info(f"User requested native backend for export")
+                if normalized_format in _stdlib_formats:
+                    return _export_without_pandas(
+                        conn, query, params, normalized_format, export_path, **kwargs
+                    )
+                else:
+                    libpyrocpd.rocpd_log_error(
+                        f"Export format '{normalized_format}' requires pandas. User requested native backend. Doing nothing.\n"
+                    )
             else:
-                libpyrocpd.rocpd_log_error(
-                    f"Export format '{normalized_format}' requires pandas. Install it with: pip install pandas\n"
-                )
-                return None
-
-        # 1) Run the query via pandas
-        df = pd.read_sql_query(query, conn, params=params)
-
-        if df.empty:
-            sys.stderr.write(f"No results found for query: {query}\n")
-            sys.stderr.flush()
-            return None
-
-        if normalized_format in (None, "console"):
-            # 2) Print to console
-            print(df.to_string(index=False))
-            return None
-
-        elif normalized_format == "clipboard":
-            df.to_clipboard(excel=False)
-            return None
-
-        ext = normalized_format
-        export_path = export_path or f"query_output.{ext}"
-        if not export_path.endswith(f".{ext}"):
-            export_path = f"{export_path}.{ext}"
-        export_path = os.path.abspath(libpyrocpd.format_path(export_path, "rocpd"))
-
-        os.makedirs(os.path.dirname(export_path), exist_ok=True)
-
-        def write_export(content):
-            with open(export_path, "w") as ofs:
-                ofs.write(f"{content}\n")
-                ofs.flush()
-
-        # 3) Export based on format
-        if normalized_format == "csv":
-            import csv
-
-            cols = [f"{itr}" for itr in df.columns.tolist()]
-            col_names = (
-                [f"{itr}".title() for itr in cols]
-                if kwargs.get("title_columns", True)
-                else cols[:]
-            )
-            df.to_csv(
-                export_path,
-                index=False,
-                columns=cols,
-                header=col_names,
-                quoting=csv.QUOTE_NONNUMERIC,
-            )
-
-        elif normalized_format == "html":
-            write_export(df.to_html(index=False))
-
-        elif normalized_format == "md":
-            # pandas 1.0+ has to_markdown
-            try:
-                write_export(df.to_markdown(index=False))
-            except AttributeError:
-                # fallback: manually write markdown table
-                _df_to_markdown_fallback(df, export_path)
-
-        elif normalized_format == "pdf":
-            _export_df_to_pdf(df, export_path)
-
-        elif normalized_format == "dashboard":
-            _export_dashboard(
-                df, export_path=export_path, template_path=dashboard_template_path
-            )
-
-        elif normalized_format == "json":
-            df.to_json(export_path, index=False, indent=2, orient="records")
-
-        else:
-            print(f"Unsupported export format: {normalized_format}")
-            return None
-
-        print(f"Exported to: {export_path}\n")
-        return export_path
+                # automatically try pandas if available
+                if _pandas_available:
+                    return _export_with_pandas(
+                        conn,
+                        query,
+                        params,
+                        export_format,
+                        export_path,
+                        dashboard_template_path=dashboard_template_path,
+                        **kwargs,
+                    )
+                else:
+                    if normalized_format in _stdlib_formats:
+                        libpyrocpd.rocpd_log_warning(
+                            "Module 'pandas' not found. Install it with: pip install pandas. Using fallback path.\n"
+                        )
+                        return _export_without_pandas(
+                            conn, query, params, normalized_format, export_path, **kwargs
+                        )
+                    else:
+                        libpyrocpd.rocpd_log_error(
+                            f"Export format '{normalized_format}' requires pandas. Install it with: pip install pandas\n"
+                        )
 
     except Exception as e:
         print(f"Error: {e}")
         return None
+
+
+def _export_with_pandas(
+    conn,
+    query,
+    params,
+    export_format,
+    export_path,
+    dashboard_template_path=None,
+    **kwargs,
+):
+    """
+    Execute a SQLite query and export results using pandas.
+    Handles: console, clipboard, csv, html, md, pdf, dashboard, json.
+    """
+    import pandas as pd
+
+    libpyrocpd.rocpd_log_info(
+        f"Running query via pandas for export format: {export_format}"
+    )
+    # 1) Run the query via pandas
+    df = pd.read_sql_query(query, conn, params=params)
+
+    if df.empty:
+        sys.stderr.write(f"No results found for query: {query}\n")
+        sys.stderr.flush()
+        return None
+
+    if export_format in (None, "console"):
+        # 2) Print to console
+        print(df.to_string(index=False))
+        return None
+
+    elif export_format == "clipboard":
+        df.to_clipboard(excel=False)
+        return None
+
+    ext = export_format
+    export_path = export_path or f"query_output.{ext}"
+    if not export_path.endswith(f".{ext}"):
+        export_path = f"{export_path}.{ext}"
+    export_path = os.path.abspath(libpyrocpd.format_path(export_path, "rocpd"))
+
+    os.makedirs(os.path.dirname(export_path), exist_ok=True)
+
+    def write_export(content):
+        with open(export_path, "w") as ofs:
+            ofs.write(f"{content}\n")
+            ofs.flush()
+
+    # 3) Export based on format
+    if export_format == "csv":
+        import csv
+
+        cols = [f"{itr}" for itr in df.columns.tolist()]
+        col_names = (
+            [f"{itr}".title() for itr in cols]
+            if kwargs.get("title_columns", True)
+            else cols[:]
+        )
+        df.to_csv(
+            export_path,
+            index=False,
+            columns=cols,
+            header=col_names,
+            quoting=csv.QUOTE_NONNUMERIC,
+        )
+
+    elif export_format == "html":
+        write_export(df.to_html(index=False))
+
+    elif export_format == "md":
+        # pandas 1.0+ has to_markdown
+        try:
+            write_export(df.to_markdown(index=False))
+        except AttributeError:
+            # fallback: manually write markdown table
+            _df_to_markdown_fallback(df, export_path)
+
+    elif export_format == "pdf":
+        _export_df_to_pdf(df, export_path)
+
+    elif export_format == "dashboard":
+        _export_dashboard(
+            df, export_path=export_path, template_path=dashboard_template_path
+        )
+
+    elif export_format == "json":
+        df.to_json(export_path, index=False, indent=2, orient="records")
+
+    else:
+        print(f"Unsupported export format: {export_format}")
+        return None
+
+    print(f"Exported to: {export_path}\n")
+    return export_path
 
 
 def _export_without_pandas(conn, query, params, export_format, export_path, **kwargs):
@@ -191,6 +255,9 @@ def _export_without_pandas(conn, query, params, export_format, export_path, **kw
     import json
     import html as _html
 
+    libpyrocpd.rocpd_log_info(
+        f"Running query via stdlib for export format: {export_format}"
+    )
     cursor = conn.cursor()
     cursor.execute(query, params if params else ())
     rows = cursor.fetchall()
@@ -588,6 +655,7 @@ def execute(input, args, config=None, **kwargs):
         export_format=export_format,
         export_path=export_path,
         dashboard_template_path=dashboard_template,
+        **kwargs,
     )
 
     # 2) If --email-to was provided and we have a file, send it

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
@@ -94,7 +94,7 @@ def export_sqlite_query(
 
         for backend_itr in export_backend:
             if backend_itr == "pandas":
-                libpyrocpd.rocpd_log_info(f"User requested pandas backend for export")
+                libpyrocpd.rocpd_log_info("User requested pandas backend for export")
                 if _pandas_available:
                     return _export_with_pandas(
                         conn,
@@ -111,7 +111,7 @@ def export_sqlite_query(
                     )
 
             elif backend_itr == "native":
-                libpyrocpd.rocpd_log_info(f"User requested native backend for export")
+                libpyrocpd.rocpd_log_info("User requested native backend for export")
                 if normalized_format in _stdlib_formats:
                     return _export_without_pandas(
                         conn, query, params, normalized_format, export_path, **kwargs
@@ -321,7 +321,7 @@ def _export_without_pandas(conn, query, params, export_format, export_path, **kw
 
         def _fmt_val_md(v):
             import math
-            
+
             if v is None or (isinstance(v, float) and math.isnan(v)):
                 return "nan"
             if isinstance(v, float):

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
@@ -58,12 +58,14 @@ def export_sqlite_query(
     Returns the path to the exported file (or None if nothing was exported).
 
     Supported export_format values (case-insensitive):
-        - "csv"
-        - "html"
-        - "md"   (markdown)
-        - "pdf"
-        - "dashboard"   (templated HTML dashboard)
-        - "clipboard"
+        - "console"     (default; prints to stdout — no pandas required)
+        - "csv"         (no pandas required)
+        - "json"        (no pandas required)
+        - "html"        (no pandas required)
+        - "md"          (markdown — no pandas required)
+        - "pdf"         (requires pandas + reportlab)
+        - "dashboard"   (templated HTML dashboard — requires pandas + jinja2)
+        - "clipboard"   (requires pandas)
 
     If export_format == "dashboard", you may optionally pass a
     dashboard_template_path (a Jinja2 template file). If omitted,
@@ -71,13 +73,31 @@ def export_sqlite_query(
     """
     try:
         import pandas as pd
+
+        _pandas_available = True
     except ImportError as e:
-        raise ImportError(
-            "pandas module not found. Please install it using 'pip install pandas' to export to other formats"
-        ) from e
+        _pandas_available = False
 
     try:
         conn = conn.connection if isinstance(conn, RocpdImportData) else conn
+
+        normalized_format = export_format.lower() if export_format else None
+        _stdlib_formats = {None, "console", "csv", "json", "html", "md"}
+
+        if not _pandas_available:
+            if normalized_format in _stdlib_formats:
+                print(
+                    "Module 'pandas' not found. Install it with: pip install pandas. Using fallback path.\n"
+                )
+                return _export_without_pandas(
+                    conn, query, params, normalized_format, export_path, **kwargs
+                )
+            else:
+                print(
+                    f"Export format '{normalized_format}' requires pandas. "
+                    "Install it with: pip install pandas"
+                )
+                return None
 
         # 1) Run the query via pandas
         df = pd.read_sql_query(query, conn, params=params)
@@ -160,6 +180,85 @@ def export_sqlite_query(
     except Exception as e:
         print(f"Error: {e}")
         return None
+
+
+def _export_without_pandas(conn, query, params, export_format, export_path, **kwargs):
+    """
+    Execute a SQLite query and export results using only the standard library.
+    Handles: console, csv, json, html, md.
+    """
+    import csv as _csv
+    import json
+    import html as _html
+
+    cursor = conn.cursor()
+    cursor.execute(query, params if params else ())
+    rows = cursor.fetchall()
+    col_names_raw = [desc[0] for desc in cursor.description] if cursor.description else []
+
+    if not rows:
+        sys.stderr.write(f"No results found for query: {query}\n")
+        sys.stderr.flush()
+        return None
+
+    if export_format in (None, "console"):
+        str_rows = [[str(v) for v in row] for row in rows]
+        col_widths = [len(c) for c in col_names_raw]
+        for row in str_rows:
+            for i, v in enumerate(row):
+                col_widths[i] = max(col_widths[i], len(v))
+        header = "  ".join(c.ljust(col_widths[i]) for i, c in enumerate(col_names_raw))
+        print(header)
+        for row in str_rows:
+            print("  ".join(v.ljust(col_widths[i]) for i, v in enumerate(row)))
+        return None
+
+    ext = export_format
+    export_path = export_path or f"query_output.{ext}"
+    if not export_path.endswith(f".{ext}"):
+        export_path = f"{export_path}.{ext}"
+    export_path = os.path.abspath(libpyrocpd.format_path(export_path, "rocpd"))
+    os.makedirs(os.path.dirname(export_path), exist_ok=True)
+
+    if export_format == "csv":
+        title_columns = kwargs.get("title_columns", True)
+        col_names = (
+            [c.title() for c in col_names_raw] if title_columns else col_names_raw[:]
+        )
+        with open(export_path, "w", newline="") as f:
+            writer = _csv.writer(f, quoting=_csv.QUOTE_NONNUMERIC)
+            writer.writerow(col_names)
+            writer.writerows(rows)
+
+    elif export_format == "json":
+        records = [dict(zip(col_names_raw, row)) for row in rows]
+        with open(export_path, "w", encoding="utf-8") as f:
+            json.dump(records, f, indent=2, default=str)
+            f.write("\n")
+
+    elif export_format == "html":
+        lines = ['<table border="1" class="dataframe">', "  <thead>", "    <tr>"]
+        for col in col_names_raw:
+            lines.append(f"      <th>{_html.escape(str(col))}</th>")
+        lines += ["    </tr>", "  </thead>", "  <tbody>"]
+        for row in rows:
+            lines.append("    <tr>")
+            for v in row:
+                lines.append(f"      <td>{_html.escape(str(v))}</td>")
+            lines.append("    </tr>")
+        lines += ["  </tbody>", "</table>"]
+        with open(export_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+
+    elif export_format == "md":
+        with open(export_path, "w", encoding="utf-8") as f:
+            f.write("| " + " | ".join(col_names_raw) + " |\n")
+            f.write("|" + "|".join("---" for _ in col_names_raw) + "|\n")
+            for row in rows:
+                f.write("| " + " | ".join(str(v) for v in row) + " |\n")
+
+    print(f"Exported to: {export_path}\n")
+    return export_path
 
 
 def _df_to_markdown_fallback(df, path: str):

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/query.py
@@ -75,7 +75,9 @@ def export_sqlite_query(
         import pandas as pd
 
         _pandas_available = True
-    except ImportError as e:
+    except ModuleNotFoundError as e:
+            if e.name != "pandas":
+                raise e
         _pandas_available = False
 
     try:

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
@@ -100,6 +100,7 @@ def export_query(
     output_format,
     query_name,
     query,
+    **kwargs,
 ) -> None:
     """Write the contents of a SQL query to an output format."""
 
@@ -125,7 +126,11 @@ def export_query(
     # call query module to export.  query will append the extension
     export_path = os.path.join(output_path, output_filename)
     export_sqlite_query(
-        connection, query, export_format=output_format, export_path=export_path
+        connection,
+        query,
+        export_format=output_format,
+        export_path=export_path,
+        **kwargs,
     )
 
 
@@ -505,8 +510,8 @@ def generate_all_summaries(connection: RocpdImportData, **kwargs: Any) -> None:
 
     domain_summary = kwargs.get("domain_summary", False)
     by_rank = kwargs.get("summary_by_rank", False)
-    output_file = kwargs.get("output_file", "")
-    output_path = kwargs.get("output_path", "./rocpd-output-data")
+    output_file = kwargs.pop("output_file", "")
+    output_path = kwargs.pop("output_path", "./rocpd-output-data")
     region_categories = kwargs.get("region_categories", None)
     output_format = kwargs.get("format", "console")
     mangled_kernels = kwargs.get("mangled_kernels", False)
@@ -572,7 +577,13 @@ def generate_all_summaries(connection: RocpdImportData, **kwargs: Any) -> None:
     # Export all summary queries
     for query_name, query in summary_queries.items():
         export_query(
-            connection, output_path, output_file, output_format, query_name, query
+            connection,
+            output_path,
+            output_file,
+            output_format,
+            query_name,
+            query,
+            **kwargs,
         )
 
 
@@ -671,6 +682,7 @@ def main(argv=None) -> int:
     )
 
     process_outcfg_args = output_config.add_args(parser)
+    process_generic_args = output_config.add_generic_args(parser)
     process_summary_args = add_args(parser)
     process_time_window_args = time_window.add_args(parser)
 
@@ -681,10 +693,11 @@ def main(argv=None) -> int:
     )
 
     summary_args = process_summary_args(input, args)
+    generic_args = process_generic_args(input, args)
     io_args = process_outcfg_args(input, args)
     process_time_window_args(input, args)
 
-    all_args = {**summary_args, **io_args}
+    all_args = {**summary_args, **io_args, **generic_args}
 
     execute(
         input,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocpd/rocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocpd/rocpd.cpp
@@ -80,6 +80,20 @@ get_status_string(rocpd_status_t status, std::index_sequence<Idx, Tail...>)
 }
 }  // namespace
 
+// make this visible to python bindings, used with ROCPD_LOG_LEVEL env variable
+ROCPD_PUBLIC_API void
+rocpd_log_message(int level, std::string_view msg)
+{
+    switch(level)
+    {
+        case ROCP_LOG_LEVEL_TRACE: ROCP_TRACE << msg; break;
+        case ROCP_LOG_LEVEL_INFO: ROCP_INFO << msg; break;
+        case ROCP_LOG_LEVEL_WARNING: ROCP_WARNING << msg; break;
+        case ROCP_LOG_LEVEL_ERROR: ROCP_ERROR << msg; break;
+        default: ROCP_ERROR << msg; break;
+    }
+}
+
 // force initialization of logging on library load
 bool _rocpd_init_logging = (rocprofiler::common::init_logging("ROCPD"), true);
 }  // namespace rocpd

--- a/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/CMakeLists.txt
@@ -549,5 +549,53 @@ foreach(_fmt console csv json html md)
         LABELS "integration-tests;rocpd"
         ENVIRONMENT "${rocprofv3-rocpd-env}"
         FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
+        FIXTURES_SETUP rocprofv3-test-rocpd-no-pandas
         FIXTURES_REQUIRED rocprofv3-test-rocpd-merge-generation-using-package)
 endforeach()
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-rocpd-summary-native-csv
+    COMMAND
+        ${Python3_EXECUTABLE} -m rocpd summary -i
+        ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data/out_results.db --format csv
+        --export-backend native -d
+        ${CMAKE_CURRENT_BINARY_DIR}/rocpd-output-data/out_native
+    DEPENDS rocprofiler-sdk::rocprofv3
+    TIMEOUT 60
+    LABELS "integration-tests;rocpd"
+    ENVIRONMENT "${rocprofv3-rocpd-env}"
+    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
+    FIXTURES_SETUP rocprofv3-test-rocpd-no-pandas-csv-generated
+    FIXTURES_REQUIRED rocprofv3-test-rocpd-no-pandas)
+
+# Validate csv data matches between native and pandas output
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-rocpd-csv-compare-validation
+    TEST_PATHS
+    COPY conftest.py validate.py
+    CONFIG pytest.ini
+    BUNDLE_TESTS
+    ARGS validate.py::test_compare_csv_files
+         --csv-compare-file1
+         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-output-data/summary/out_hip_summary.csv
+         --csv-compare-file2
+         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-output-data/out_native/out_hip_summary.csv
+    TIMEOUT 60
+    LABELS "integration-tests;rocpd;kernel-name"
+    FIXTURES_REQUIRED rocprofv3-test-rocpd-no-pandas-csv-generated)
+
+# Validate csv output files match between native and pandas output
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-rocpd-csv-output-compare-validation
+    TEST_PATHS
+    COPY conftest.py validate.py
+    CONFIG pytest.ini
+    BUNDLE_TESTS
+    ARGS validate.py::test_compare_csv_output_files
+         --csv-output-file1
+         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-output-data/summary/out_hip_summary.csv
+         --csv-output-file2
+         ${CMAKE_CURRENT_BINARY_DIR}/rocpd-output-data/out_native/out_hip_summary.csv
+    TIMEOUT 60
+    LABELS "integration-tests;rocpd;kernel-name"
+    FIXTURES_REQUIRED rocprofv3-test-rocpd-no-pandas-csv-generated)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/CMakeLists.txt
@@ -529,3 +529,25 @@ rocprofiler_add_integration_execute_test(
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     DISABLED "${MULTIPROC_IS_DISABLED}"
     FIXTURES_REQUIRED rocprofv3-test-rocpd-merge-generation-using-package-multiproc)
+
+#########################################################################################
+#
+# Query SQL string without pandas (stdlib-only fallback path)
+#
+#########################################################################################
+
+foreach(_fmt console csv json html md)
+    rocprofiler_add_integration_execute_test(
+        rocprofv3-test-rocpd-query-no-pandas-${_fmt}
+        COMMAND
+            ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_rocpd_no_pandas.py
+            query -i ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data/merged_db.db --query
+            "SELECT id, type FROM rocpd_info_agent LIMIT 10;" --format ${_fmt} -d
+            ${CMAKE_CURRENT_BINARY_DIR}/rocpd-output-data/query-no-pandas
+        DEPENDS rocprofiler-sdk::rocprofv3
+        TIMEOUT 60
+        LABELS "integration-tests;rocpd"
+        ENVIRONMENT "${rocprofv3-rocpd-env}"
+        FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
+        FIXTURES_REQUIRED rocprofv3-test-rocpd-merge-generation-using-package)
+endforeach()

--- a/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/CMakeLists.txt
@@ -478,3 +478,25 @@ rocprofiler_add_integration_execute_test(
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
     DISABLED "${MULTIPROC_IS_DISABLED}"
     FIXTURES_REQUIRED rocprofv3-test-rocpd-merge-generation-using-package-multiproc)
+
+#########################################################################################
+#
+# Query SQL string without pandas (stdlib-only fallback path)
+#
+#########################################################################################
+
+foreach(_fmt console csv json html md)
+    rocprofiler_add_integration_execute_test(
+        rocprofv3-test-rocpd-query-no-pandas-${_fmt}
+        COMMAND
+            ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_rocpd_no_pandas.py
+            query -i ${CMAKE_CURRENT_BINARY_DIR}/rocpd-input-data/merged_db.db --query
+            "SELECT id, type FROM rocpd_info_agent LIMIT 10;" --format ${_fmt} -d
+            ${CMAKE_CURRENT_BINARY_DIR}/rocpd-output-data/query-no-pandas
+        DEPENDS rocprofiler-sdk::rocprofv3
+        TIMEOUT 60
+        LABELS "integration-tests;rocpd"
+        ENVIRONMENT "${rocprofv3-rocpd-env}"
+        FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
+        FIXTURES_REQUIRED rocprofv3-test-rocpd-merge-generation-using-package)
+endforeach()

--- a/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/conftest.py
@@ -106,6 +106,26 @@ def pytest_addoption(parser):
         action="store",
         help="Path to mangled kernels summary CSV file.",
     )
+    parser.addoption(
+        "--csv-compare-file1",
+        action="store",
+        help="Path to first CSV file for comparison.",
+    )
+    parser.addoption(
+        "--csv-compare-file2",
+        action="store",
+        help="Path to second CSV file for comparison.",
+    )
+    parser.addoption(
+        "--csv-output-file1",
+        action="store",
+        help="Path to first CSV output file for text-formatting comparison.",
+    )
+    parser.addoption(
+        "--csv-output-file2",
+        action="store",
+        help="Path to second CSV output file for text-formatting comparison.",
+    )
 
     pd.set_option("display.width", 2000)
     # increase debug display of pandas dataframes
@@ -207,9 +227,9 @@ def summary_data(request):
     return domains
 
 
-# Helper function for CSV file fixtures
+# Helper functions for CSV file fixtures
 def _get_csv_files(request, option):
-    """Get and validate CSV files from pytest option"""
+    """Get and validate a list of CSV file paths from a pytest option."""
     csv_files = request.config.getoption(option)
 
     if not csv_files:
@@ -220,6 +240,79 @@ def _get_csv_files(request, option):
         pytest.fail(f"{option} contains missing files: {missing}")
 
     return csv_files
+
+
+def _load_csv(request, option):
+    """Load a single CSV file from a pytest option and return a pandas DataFrame."""
+    filename = request.config.getoption(option)
+    if not filename:
+        pytest.skip(f"{option} not provided")
+    if not os.path.exists(filename):
+        pytest.fail(f"{option} file not found: {filename}")
+    return pd.read_csv(filename)
+
+
+def _detect_quoting(raw_line: str) -> list:
+    """Return a list of booleans indicating whether each CSV field was quoted.
+
+    Uses a minimal state machine so that commas inside quoted fields are not
+    mistaken for field separators.  Handles doubled-quote escaping ("").
+    """
+    quoted = []
+    i = 0
+    n = len(raw_line)
+    while i <= n:
+        if i == n:
+            # trailing empty field after a final comma
+            break
+        if raw_line[i] == '"':
+            quoted.append(True)
+            i += 1  # skip opening quote
+            while i < n:
+                if raw_line[i] == '"':
+                    i += 1
+                    if i < n and raw_line[i] == '"':  # escaped "" inside field
+                        i += 1
+                    else:
+                        break  # closing quote
+                else:
+                    i += 1
+            # advance past any whitespace + comma separator
+            while i < n and raw_line[i] != ",":
+                i += 1
+            i += 1  # skip the comma (or step past end)
+        else:
+            quoted.append(False)
+            while i < n and raw_line[i] != ",":
+                i += 1
+            i += 1  # skip the comma
+    return quoted
+
+
+def _load_csv_raw(request, option):
+    """Load a single CSV file as raw (headers, rows, quoting) without type conversion.
+
+    Returns a tuple of:
+      headers         -- list of column name strings (quotes stripped by csv.reader)
+      rows            -- list of data rows, each a list of raw cell strings
+      header_quoting  -- list[bool] whether each header cell was quoted
+      row_quoting     -- list[list[bool]] quoting mask for every data row
+    """
+    filename = request.config.getoption(option)
+    if not filename:
+        pytest.skip(f"{option} not provided")
+    if not os.path.exists(filename):
+        pytest.fail(f"{option} file not found: {filename}")
+    with open(filename, "r", newline="") as f:
+        raw_lines = [line.rstrip("\r\n") for line in f]
+    raw_lines = [line for line in raw_lines if line.strip()]
+    if not raw_lines:
+        pytest.fail(f"{option} file is empty: {filename}")
+
+    parsed_rows = [next(csv.reader([line])) for line in raw_lines]
+    quoting_mask = [_detect_quoting(line) for line in raw_lines]
+
+    return parsed_rows[0], parsed_rows[1:], quoting_mask[0], quoting_mask[1:]
 
 
 # Fixtures for region category summary tests
@@ -249,33 +342,41 @@ def summary_none_csv_files(request):
 
 @pytest.fixture
 def csv_kernels_truncated(request):
-    """Load truncated kernels summary CSV file"""
-    filename = request.config.getoption("--csv-input-truncated")
-    if not filename:
-        pytest.skip("--csv-input-truncated not provided")
-    if not os.path.exists(filename):
-        raise FileExistsError(f"{filename} does not exist")
-    return pd.read_csv(filename)
+    """Load truncated kernels summary CSV file."""
+    return _load_csv(request, "--csv-input-truncated")
 
 
 @pytest.fixture
 def csv_kernels_full(request):
-    """Load full kernels summary CSV file from --csv-input-summary option"""
-    filename = request.config.getoption("--csv-input-summary")
-    if not filename:
-        pytest.skip("--csv-input-summary not provided")
-    if not os.path.exists(filename):
-        raise FileExistsError(f"{filename} does not exist")
-
-    return pd.read_csv(filename)
+    """Load full kernels summary CSV file."""
+    return _load_csv(request, "--csv-input-summary")
 
 
 @pytest.fixture
 def csv_kernels_mangled(request):
-    """Load mangled kernels summary CSV file"""
-    filename = request.config.getoption("--csv-input-mangled")
-    if not filename:
-        pytest.skip("--csv-input-mangled not provided")
-    if not os.path.exists(filename):
-        raise FileExistsError(f"{filename} does not exist")
-    return pd.read_csv(filename)
+    """Load mangled kernels summary CSV file."""
+    return _load_csv(request, "--csv-input-mangled")
+
+
+@pytest.fixture
+def csv_compare_1(request):
+    """Load first CSV file for comparison as a DataFrame."""
+    return _load_csv(request, "--csv-compare-file1")
+
+
+@pytest.fixture
+def csv_compare_2(request):
+    """Load second CSV file for comparison as a DataFrame."""
+    return _load_csv(request, "--csv-compare-file2")
+
+
+@pytest.fixture
+def csv_output_1(request):
+    """Load first CSV output file as raw (headers, rows) for text-formatting comparison."""
+    return _load_csv_raw(request, "--csv-output-file1")
+
+
+@pytest.fixture
+def csv_output_2(request):
+    """Load second CSV output file as raw (headers, rows) for text-formatting comparison."""
+    return _load_csv_raw(request, "--csv-output-file2")

--- a/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/test_rocpd_no_pandas.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/test_rocpd_no_pandas.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+###############################################################################
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+###############################################################################
+"""
+Test driver: verify export_sqlite_query produces correct output for the five
+stdlib-only formats (console, csv, json, html, md) when pandas is unavailable.
+
+Pandas is blocked by inserting a None sentinel into sys.modules before any
+rocpd code is imported. Any lazy 'import pandas' inside the library will then
+raise ImportError, exercising the fallback path in export_sqlite_query.
+"""
+
+import sys
+import os
+import argparse
+
+# Block pandas before any rocpd submodule is imported so every lazy
+# 'import pandas' inside the library raises ImportError.
+sys.modules["pandas"] = None  # type: ignore[assignment]
+
+import rocpd
+import rocpd.__main__
+
+
+def main():
+    # Pass thru all args to the rocpd module
+    rocpd.__main__.main(sys.argv[1:])
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/test_rocpd_no_pandas.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/test_rocpd_no_pandas.py
@@ -23,17 +23,10 @@
 # THE SOFTWARE.
 ###############################################################################
 """
-Test driver: verify export_sqlite_query produces correct output for the five
-stdlib-only formats (console, csv, json, html, md) when pandas is unavailable.
-
-Pandas is blocked by inserting a None sentinel into sys.modules before any
-rocpd code is imported. Any lazy 'import pandas' inside the library will then
-raise ImportError, exercising the fallback path in export_sqlite_query.
+Wrapper script to test rocpd without pandas.
 """
 
 import sys
-import os
-import argparse
 
 # Block pandas before any rocpd submodule is imported so every lazy
 # 'import pandas' inside the library raises ImportError.

--- a/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/validate.py
@@ -387,6 +387,134 @@ def test_summary_mangled_kernels(csv_kernels_mangled, csv_kernels_full, json_dat
     _verify_names_match_json(csv_kernels_mangled, json_data, "mangled")
 
 
+#########################################################################################
+#
+# ROCPD CSV comparison Validation
+#
+#########################################################################################
+
+
+def test_compare_csv_files(csv_compare_1, csv_compare_2):
+    """
+    Test that two CSV files are identical using pandas.
+    """
+    # compare the headers
+    assert csv_compare_1.columns.equals(
+        csv_compare_2.columns
+    ), "CSV files have different headers"
+    # compare the data
+    for col in csv_compare_1.columns:
+        assert csv_compare_1[col].equals(
+            csv_compare_2[col]
+        ), f"CSV files have different data in column {col}"
+
+
+def _decimal_places(value: str):
+    """Return the number of decimal places in a numeric string, or None if not numeric.
+
+    The exponent shifts the decimal point, so it is factored into the result.
+    For example: "1.23e+1" -> 1, "1.23e-1" -> 3, "1.23e+10" -> 0.
+    """
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        float(value)
+    except ValueError:
+        return None
+
+    # Strip the exponent and record its value (e.g. "1.23e+10" -> exponent=10).
+    exponent = 0
+    exp_pos = value.lower().find("e")
+    if exp_pos != -1:
+        try:
+            exponent = int(value[exp_pos + 1 :])
+        except ValueError:
+            pass
+        value = value[:exp_pos]
+
+    dot_pos = value.find(".")
+    frac_len = 0 if dot_pos == -1 else len(value[dot_pos + 1 :])
+
+    # A positive exponent shifts digits left (fewer decimals); negative shifts right (more).
+    return max(0, frac_len - exponent)
+
+
+def test_compare_csv_output_files(csv_output_1, csv_output_2):
+    """
+    Compare two CSV output files for consistent text formatting.
+
+    Verifies:
+    - Header text matches exactly (column names and order)
+    - Number of columns is the same
+    - Number of data rows is the same
+    - Each header cell has the same quoting (present vs absent) in both files
+    - Each data cell has the same quoting in both files
+    - Each numeric cell has the same number of decimal places as its counterpart
+    - Each numeric cell has the same value as its counterpart
+    - Each non-numeric cell has the same string value as its counterpart
+    """
+    headers1, rows1, hquote1, rquote1 = csv_output_1
+    headers2, rows2, hquote2, rquote2 = csv_output_2
+
+    assert len(headers1) == len(headers2), (
+        f"Column count differs: file1={len(headers1)}, file2={len(headers2)}\n"
+        f"  file1 headers: {headers1}\n"
+        f"  file2 headers: {headers2}"
+    )
+
+    assert (
+        headers1 == headers2
+    ), f"CSV headers differ:\n  file1: {headers1}\n  file2: {headers2}"
+
+    # Check header quoting consistency
+    for col_idx, (q1, q2) in enumerate(zip(hquote1, hquote2)):
+        assert q1 == q2, (
+            f"Header quoting differs for column '{headers1[col_idx]}': "
+            f"file1={'quoted' if q1 else 'unquoted'}, "
+            f"file2={'quoted' if q2 else 'unquoted'}"
+        )
+
+    assert len(rows1) == len(
+        rows2
+    ), f"Row count differs: file1={len(rows1)}, file2={len(rows2)}"
+
+    for row_idx, (row1, row2, qrow1, qrow2) in enumerate(
+        zip(rows1, rows2, rquote1, rquote2)
+    ):
+        assert len(row1) == len(row2), (
+            f"Column count differs at data row {row_idx + 1}: "
+            f"file1={len(row1)}, file2={len(row2)}"
+        )
+        for col_idx, (val1, val2, q1, q2) in enumerate(zip(row1, row2, qrow1, qrow2)):
+            assert q1 == q2, (
+                f"Cell quoting differs at row {row_idx + 1}, "
+                f"column '{headers1[col_idx]}': "
+                f"file1='{val1}' ({'quoted' if q1 else 'unquoted'}), "
+                f"file2='{val2}' ({'quoted' if q2 else 'unquoted'})"
+            )
+            dec1 = _decimal_places(val1)
+            dec2 = _decimal_places(val2)
+            if dec1 is not None and dec2 is not None:
+                assert dec1 == dec2, (
+                    f"Decimal precision differs at row {row_idx + 1}, "
+                    f"column '{headers1[col_idx]}': "
+                    f"file1='{val1}' ({dec1} decimal(s)), "
+                    f"file2='{val2}' ({dec2} decimal(s))"
+                )
+                assert float(val1) == float(val2), (
+                    f"Numeric value differs at row {row_idx + 1}, "
+                    f"column '{headers1[col_idx]}': "
+                    f"file1='{val1}', file2='{val2}'"
+                )
+            else:
+                assert val1 == val2, (
+                    f"Cell value differs at row {row_idx + 1}, "
+                    f"column '{headers1[col_idx]}': "
+                    f"file1='{val1}', file2='{val2}'"
+                )
+
+
 if __name__ == "__main__":
     exit_code = pytest.main(["-x", __file__] + sys.argv[1:])
     sys.exit(exit_code)


### PR DESCRIPTION
## Motivation

The previous code path relied on pandas module to output to console, csv, and many other output formats.  However, some users complained that they did not want to install pandas. This PR addresses use-case when pandas is not found, we can output using fallback path with some standard modules instead.

## Technical Details

Supports console, csv, html, json and md only. All other output formats require non-standard modules

## JIRA ID

JIRA ID: ROCPDSNA-64

## Test Plan

Added no-pandas tests to generate these output formats, and to exercise these fall-back code paths, to ensure they are working.  Not necessarily to check for data validity.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
