### PR TITLE
rocclr: Prioritize local rocr-runtime headers over system paths

### DIFF
--- a/projects/clr/rocclr/cmake/ROCclrHSA.cmake
+++ b/projects/clr/rocclr/cmake/ROCclrHSA.cmake
@@ -43,15 +43,12 @@ else()
   if(UNIX)
     find_package(hsa-runtime64 1.11 REQUIRED CONFIG
       PATHS
-        ${ROCCLR_SRC_DIR}/../../rocr-runtime
-        ${CMAKE_CURRENT_BINARY_DIR}/../../rocr
         ${ROCM_PATH}
         ${ROCM_INSTALL_PATH}
       PATH_SUFFIXES
         cmake/hsa-runtime64
         lib/cmake/hsa-runtime64
-        lib64/cmake/hsa-runtime64
-      NO_DEFAULT_PATH)
+        lib64/cmake/hsa-runtime64)
   else()
     find_package(hsa-runtime64 1.11 REQUIRED CONFIG
       PATHS
@@ -69,21 +66,19 @@ else()
 
     # note: Temporarily for PAL backend build
     find_path(AMD_HSA_INCLUDE_DIR hsa.h
-      PATHS
-        ${ROCCLR_SRC_DIR}/../../rocr-runtime/runtime/hsa-runtime/inc
-        ${ROCCLR_SRC_DIR}/../../rocr-runtime/runtime/hsa-runtime
-        ${CMAKE_CURRENT_BINARY_DIR}/../../rocr/inc
-        ${CMAKE_CURRENT_BINARY_DIR}/../../rocr
-        ${CMAKE_CURRENT_BINARY_DIR}/../..
-        ${CMAKE_CURRENT_BINARY_DIR}/..
-        ${CMAKE_CURRENT_BINARY_DIR}
+      HINTS
         ${ROCM_PATH}
         ${ROCM_INSTALL_PATH}
+        ${CMAKE_CURRENT_BINARY_DIR}
+      PATHS
+        ${CMAKE_CURRENT_BINARY_DIR}/..
+        ${CMAKE_CURRENT_BINARY_DIR}/../..
+        ${CMAKE_CURRENT_BINARY_DIR}/../../rocr
+        ${ROCCLR_SRC_DIR}/../../rocr-runtime/runtime/hsa-runtime
       PATH_SUFFIXES
         include
         include/hsa
-        inc
-      NO_DEFAULT_PATH)
+        inc)
     message("Roc CLR: " ${ROCCLR_SRC_DIR} "; HSA headers:" ${AMD_HSA_INCLUDE_DIR})
     target_include_directories(rocclr PUBLIC ${AMD_HSA_INCLUDE_DIR})
     target_include_directories(rocclr PUBLIC ${AMD_HSA_INCLUDE_DIR}/..)

--- a/projects/clr/rocclr/cmake/ROCclrHSA.cmake
+++ b/projects/clr/rocclr/cmake/ROCclrHSA.cmake
@@ -4,19 +4,21 @@
 
 if (AMD_COMPUTE_WIN)
   find_path(AMD_HSA_INCLUDE_DIR hsa.h
-    HINTS
+    PATHS
+      ${ROCCLR_SRC_DIR}/../../rocr-runtime/runtime/hsa-runtime/inc
       ${ROCCLR_SRC_DIR}/../../rocr-runtime/runtime/hsa-runtime
+      ${CMAKE_CURRENT_BINARY_DIR}/../../rocr/inc
+      ${CMAKE_CURRENT_BINARY_DIR}/../../rocr
+      ${CMAKE_CURRENT_BINARY_DIR}/../..
+      ${CMAKE_CURRENT_BINARY_DIR}/..
+      ${CMAKE_CURRENT_BINARY_DIR}
       ${ROCM_PATH}
       ${ROCM_INSTALL_PATH}
-      ${CMAKE_CURRENT_BINARY_DIR}
-    PATHS
-      ${CMAKE_CURRENT_BINARY_DIR}/..
-      ${CMAKE_CURRENT_BINARY_DIR}/../..
-      ${CMAKE_CURRENT_BINARY_DIR}/../../rocr
     PATH_SUFFIXES
       include
       include/hsa
-      inc)
+      inc
+    NO_DEFAULT_PATH)
   message("Roc CLR: " ${ROCCLR_SRC_DIR} "; HSA headers:" ${AMD_HSA_INCLUDE_DIR})
   target_include_directories(rocclr PUBLIC ${AMD_HSA_INCLUDE_DIR})
   target_include_directories(rocclr PUBLIC ${AMD_HSA_INCLUDE_DIR}/..)
@@ -41,12 +43,15 @@ else()
   if(UNIX)
     find_package(hsa-runtime64 1.11 REQUIRED CONFIG
       PATHS
+        ${ROCCLR_SRC_DIR}/../../rocr-runtime
+        ${CMAKE_CURRENT_BINARY_DIR}/../../rocr
         ${ROCM_PATH}
         ${ROCM_INSTALL_PATH}
       PATH_SUFFIXES
         cmake/hsa-runtime64
         lib/cmake/hsa-runtime64
-        lib64/cmake/hsa-runtime64)
+        lib64/cmake/hsa-runtime64
+      NO_DEFAULT_PATH)
   else()
     find_package(hsa-runtime64 1.11 REQUIRED CONFIG
       PATHS
@@ -64,19 +69,21 @@ else()
 
     # note: Temporarily for PAL backend build
     find_path(AMD_HSA_INCLUDE_DIR hsa.h
-      HINTS
+      PATHS
+        ${ROCCLR_SRC_DIR}/../../rocr-runtime/runtime/hsa-runtime/inc
+        ${ROCCLR_SRC_DIR}/../../rocr-runtime/runtime/hsa-runtime
+        ${CMAKE_CURRENT_BINARY_DIR}/../../rocr/inc
+        ${CMAKE_CURRENT_BINARY_DIR}/../../rocr
+        ${CMAKE_CURRENT_BINARY_DIR}/../..
+        ${CMAKE_CURRENT_BINARY_DIR}/..
+        ${CMAKE_CURRENT_BINARY_DIR}
         ${ROCM_PATH}
         ${ROCM_INSTALL_PATH}
-        ${CMAKE_CURRENT_BINARY_DIR}
-      PATHS
-        ${CMAKE_CURRENT_BINARY_DIR}/..
-        ${CMAKE_CURRENT_BINARY_DIR}/../..
-        ${CMAKE_CURRENT_BINARY_DIR}/../../rocr
-        ${ROCCLR_SRC_DIR}/../../rocr-runtime/runtime/hsa-runtime
       PATH_SUFFIXES
         include
         include/hsa
-        inc)
+        inc
+      NO_DEFAULT_PATH)
     message("Roc CLR: " ${ROCCLR_SRC_DIR} "; HSA headers:" ${AMD_HSA_INCLUDE_DIR})
     target_include_directories(rocclr PUBLIC ${AMD_HSA_INCLUDE_DIR})
     target_include_directories(rocclr PUBLIC ${AMD_HSA_INCLUDE_DIR}/..)


### PR DESCRIPTION
Fixes build errors where CMake finds outdated HSA headers in system paths instead of the local rocr-runtime

Changes applied to windows builds using ROCclrHSA.cmake:
- Reorder find_path/find_package to search local rocr-runtime first
- Add NO_DEFAULT_PATH to prevent system path searches
- Covers Windows (AMD_COMPUTE_WIN)

## Motivation
when building hip, the headers and libs should be obtained locally first then at the system level. 
User can have multiple rocms installed at system level. During hip build, user expects the local rocr/hsa to be picked first

## Technical Details
changing the search order of rocr headers and libs, so the expected Libs/headers are picked for the hip build

## JIRA ID
NA

## Test Plan
Rock build passes and local hip build passes

## Test Result
Rock build passes and local hip build passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
