### PR TITLE
[rocprofiler-compute] Make pre-commit a superset of CI formatting

### DIFF
--- a/.github/workflows/rocprofiler-compute-formatting.yml
+++ b/.github/workflows/rocprofiler-compute-formatting.yml
@@ -20,118 +20,39 @@ on:
       - '!docs/**'
       - '!projects/*/docs/**'
 
+permissions:
+  contents: read
+
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # PRs: group by PR number so a new commit cancels in-flight runs.
+  # Pushes: group by SHA so postsubmit runs never cancel each other.
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
-  python:
-    runs-on: ubuntu-22.04
-
+  pre-commit:
+    runs-on: ubuntu-24.04
+    env:
+      # PRs diff against the base branch; pushes diff against the pre-push tip.
+      FROM_REF: ${{ github.event.pull_request.base.ref && format('origin/{0}', github.event.pull_request.base.ref) || github.event.before }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-      with:
-        sparse-checkout: projects/rocprofiler-compute
-    - name: Set up Python '3.x'
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      working-directory: projects/rocprofiler-compute
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install ruff==0.14.11
-        if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
-    - name: Run Ruff Linter and Import Sorter
-      run: |
-        ruff check . --fix
-    - name: Run Ruff Formatter
-      run: |
-        ruff format .
-    - name: Check for formatting/linting changes
-      run: |
-        git config --global user.name 'github-actions'
-        git config --global user.email 'github-actions@github.com'
-        git add -A .
-        if ! git diff --cached --quiet; then
-          echo "::error::Files were modified by ruff. Please run 'ruff check . --fix && ruff format .' locally and commit the changes."
-          git diff --cached --patch # Show the diff in the logs
-          exit 1
-        else
-          echo "Ruff found no issues or all issues were fixed and files are clean."
-        fi
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # required for --from-ref/--to-ref
 
-  cmake:
-    runs-on: ubuntu-22.04
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        sparse-checkout: projects/rocprofiler-compute
-    - name: Install dependencies
-      working-directory: projects/rocprofiler-compute
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y python3-pip
-        python3 -m pip install gersemi==0.22.1
-    - name: gersemi
-      working-directory: projects/rocprofiler-compute
-      run: |
-        set +e
-        gersemi -i $(find . -type f | egrep 'CMakeLists.txt|\.cmake$')
-        if [ $(git diff | wc -l) -gt 0 ]; then
-          echo -e "\nError! CMake code not formatted. Run gersemi...\n"
-          echo -e "\nFiles:\n"
-          git diff --name-only
-          echo -e "\nFull diff:\n"
-          git diff
-          exit 1
-        fi
+      - name: Install rocprofiler-compute Python dependencies
+        working-directory: projects/rocprofiler-compute
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
 
-  cxx:
-    runs-on: ubuntu-22.04
-
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        sparse-checkout: projects/rocprofiler-compute
-    - name: Install dependencies
-      working-directory: projects/rocprofiler-compute
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y python3-pip
-        python3 -m pip install clang-format==22.1.0
-    - name: clang-format
-      working-directory: projects/rocprofiler-compute
-      run: |
-        set +e
-        clang-format -i $(find src -type f | egrep '\.(h|hpp|hh|c|cc|cpp)(|\.in)$')
-        if [ $(git diff | wc -l) -gt 0 ]; then
-          echo -e "\nError! cxx code not formatted. Run clang-format...\n"
-          echo -e "\nFiles:\n"
-          git diff --name-only
-          echo -e "\nFull diff:\n"
-          git diff
-          exit 1
-        fi
-
-  python-bytecode:
-    runs-on: ubuntu-22.04
-
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        sparse-checkout: projects/rocprofiler-compute
-    - name: find-bytecode
-      working-directory: projects/rocprofiler-compute
-      run: |
-        set +e
-        FILES=$(find . -type f | egrep '__pycache__|\.pyc$')
-        if [ -n "${FILES}" ]; then
-          echo -e "\nError! Python bytecode included in commit\n"
-          echo -e "### FILES: ###"
-          echo -e "${FILES}"
-          echo -e "##############"
-          exit 1
-        fi
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        with:
+          # Use the rocprofiler-compute project pre-commit config and only check
+          # files changed in this push/PR.
+          extra_args: >-
+            --config projects/rocprofiler-compute/.pre-commit-config.yaml
+            --from-ref ${{ env.FROM_REF }}
+            --to-ref HEAD

--- a/.github/workflows/rocprofiler-compute-formatting.yml
+++ b/.github/workflows/rocprofiler-compute-formatting.yml
@@ -42,12 +42,6 @@ jobs:
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 
-      - name: Install rocprofiler-compute Python dependencies
-        working-directory: projects/rocprofiler-compute
-        run: |
-          python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
-
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           # Use the rocprofiler-compute project pre-commit config and only check

--- a/projects/rocprofiler-compute/.pre-commit-config.yaml
+++ b/projects/rocprofiler-compute/.pre-commit-config.yaml
@@ -18,6 +18,31 @@ repos:
         args: [--fix]
       - id: ruff-format
 
+  # CMake formatting (mirrors rocprofiler-compute-formatting.yml `cmake` job)
+  - repo: https://github.com/BlankSpruce/gersemi
+    rev: 0.22.1
+    hooks:
+      - id: gersemi
+        files: ^projects/rocprofiler-compute/.*(CMakeLists\.txt|\.cmake)$
+
+  # C/C++ formatting (mirrors rocprofiler-compute-formatting.yml `cxx` job)
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v22.1.0
+    hooks:
+      - id: clang-format
+        files: ^projects/rocprofiler-compute/src/.*\.(h|hpp|hh|c|cc|cpp)(\.in)?$
+
+  # Reject committed Python bytecode (mirrors `python-bytecode` job)
+  - repo: local
+    hooks:
+      - id: no-python-bytecode
+        name: Reject staged Python bytecode
+        entry: >-
+          bash -c 'printf "Error - Python bytecode staged for commit:\n";
+          printf "  %s\n" "$@"; exit 1' --
+        language: system
+        files: (^|/)(__pycache__/.*|.*\.pyc)$
+
   # Local hook: copyright header check
   - repo: local
     hooks:

--- a/projects/rocprofiler-compute/.pre-commit-config.yaml
+++ b/projects/rocprofiler-compute/.pre-commit-config.yaml
@@ -18,21 +18,21 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  # CMake formatting (mirrors rocprofiler-compute-formatting.yml `cmake` job)
+  # CMake formatting
   - repo: https://github.com/BlankSpruce/gersemi
     rev: 0.22.1
     hooks:
       - id: gersemi
         files: ^projects/rocprofiler-compute/.*(CMakeLists\.txt|\.cmake)$
 
-  # C/C++ formatting (mirrors rocprofiler-compute-formatting.yml `cxx` job)
+  # C/C++ formatting
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v22.1.0
     hooks:
       - id: clang-format
         files: ^projects/rocprofiler-compute/src/.*\.(h|hpp|hh|c|cc|cpp)(\.in)?$
 
-  # Reject committed Python bytecode (mirrors `python-bytecode` job)
+  # Reject committed Python bytecode
   - repo: local
     hooks:
       - id: no-python-bytecode

--- a/projects/rocprofiler-compute/.pre-commit-config.yaml
+++ b/projects/rocprofiler-compute/.pre-commit-config.yaml
@@ -48,10 +48,9 @@ repos:
     hooks:
       - id: copyright-header-check
         name: Copyright header check
-        entry: bash -lc 'cd projects/rocprofiler-compute && python3 tools/copyright_header_check.py'
-        language: system
+        entry: python projects/rocprofiler-compute/tools/copyright_header_check.py
+        language: python
         files: \.(py|hip|cpp)$
-        pass_filenames: false
         stages: [pre-commit]
 
   # Local hook: hash consistency check
@@ -59,7 +58,8 @@ repos:
     hooks:
       - id: hash-check
         name: Hash consistency check
-        entry: bash -lc 'cd projects/rocprofiler-compute && python3 src/utils/hash_checker.py'
-        language: system
+        entry: python projects/rocprofiler-compute/src/utils/hash_checker.py
+        language: python
+        additional_dependencies: [pyyaml==6.0.3]
         pass_filenames: false
         stages: [pre-commit]

--- a/projects/rocprofiler-compute/.pre-commit-config.yaml
+++ b/projects/rocprofiler-compute/.pre-commit-config.yaml
@@ -5,8 +5,11 @@ repos:
     rev: v6.0.0
     hooks:
       - id: check-yaml
+        files: ^projects/rocprofiler-compute/
       - id: end-of-file-fixer
+        files: ^projects/rocprofiler-compute/
       - id: trailing-whitespace
+        files: ^projects/rocprofiler-compute/
 
   # Python import sorting and formatting
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -16,7 +19,9 @@ repos:
     hooks:
       - id: ruff-check
         args: [--fix]
+        files: ^projects/rocprofiler-compute/
       - id: ruff-format
+        files: ^projects/rocprofiler-compute/
 
   # CMake formatting
   - repo: https://github.com/BlankSpruce/gersemi
@@ -41,7 +46,7 @@ repos:
           bash -c 'printf "Error - Python bytecode staged for commit:\n";
           printf "  %s\n" "$@"; exit 1' --
         language: system
-        files: (^|/)(__pycache__/.*|.*\.pyc)$
+        files: ^projects/rocprofiler-compute/.*(__pycache__/.*|\.pyc)$
 
   # Local hook: copyright header check
   - repo: local
@@ -50,7 +55,7 @@ repos:
         name: Copyright header check
         entry: python projects/rocprofiler-compute/tools/copyright_header_check.py
         language: python
-        files: \.(py|hip|cpp)$
+        files: ^projects/rocprofiler-compute/.*\.(py|hip|cpp)$
         stages: [pre-commit]
 
   # Local hook: hash consistency check
@@ -61,5 +66,6 @@ repos:
         entry: python projects/rocprofiler-compute/src/utils/hash_checker.py
         language: python
         additional_dependencies: [pyyaml==6.0.3]
+        files: ^projects/rocprofiler-compute/
         pass_filenames: false
         stages: [pre-commit]

--- a/projects/rocprofiler-compute/tests/test_pc_sampling.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling.py
@@ -48,6 +48,12 @@ def is_pc_sampling_not_supported(output):
     return "Given PC sampling configuration is not supported" in output
 
 
+def _skip_if_pc_sampling_unsupported(stdout, stderr, workload_dir):
+    if is_pc_sampling_not_supported(f"{stdout}\n{stderr}"):
+        test_utils.clean_output_dir(config["cleanup"], workload_dir)
+        pytest.skip("PC sampling is not supported")
+
+
 def skip_unsupported_pc_sampling_soc(is_stochastic=False):
     unsupported_socs = {"MI100", "STRIX_HALO"}
     if is_stochastic:
@@ -74,15 +80,19 @@ def test_pc_sampling_host_trap(binary_handler_profile_rocprof_compute):
 
     workload_dir = test_utils.get_output_dir()
 
-    _ = binary_handler_profile_rocprof_compute(
+    code, stdout, stderr = binary_handler_profile_rocprof_compute(
         config,
         workload_dir,
         options,
-        check_success=True,
+        check_success=False,
+        capture_output=True,
         roof=False,
         app_name="app_mat_mul_max",
     )
 
+    _skip_if_pc_sampling_unsupported(stdout, stderr, workload_dir)
+
+    assert code == 0
     file_dict = test_utils.check_non_pmc_files(workload_dir, num_devices, 1)
     assert sorted(list(file_dict.keys())) == sorted(PC_SAMPLING_HOST_TRAP_FILES)
 
@@ -116,10 +126,7 @@ def test_pc_sampling_stochastic(binary_handler_profile_rocprof_compute):
         app_name="app_mat_mul_max",
     )
 
-    output = f"{stdout}\n{stderr}"
-    if is_pc_sampling_not_supported(output):
-        test_utils.clean_output_dir(config["cleanup"], workload_dir)
-        pytest.skip("PC sampling is not supported")
+    _skip_if_pc_sampling_unsupported(stdout, stderr, workload_dir)
 
     assert code == 0
     file_dict = test_utils.check_non_pmc_files(workload_dir, num_devices, 1)
@@ -158,6 +165,8 @@ def test_multi_rank_pc_sampling_only(
         capture_output=True,
         check_success=False,
     )
+
+    _skip_if_pc_sampling_unsupported(stdout, stderr, workload_dir)
 
     output = stdout + stderr
     assert "Multi-rank application detected" not in output
@@ -198,6 +207,8 @@ def test_multi_rank_warning_pc_sampling_with_counters(
         check_success=False,
     )
 
+    _skip_if_pc_sampling_unsupported(stdout, stderr, workload_dir)
+
     output = stdout + stderr
     assert "Multi-rank application detected" in output
     assert "Application replay mode" in output
@@ -230,15 +241,19 @@ def test_pc_sampling_profile_then_analyze(
 
     workload_dir = test_utils.get_output_dir()
 
-    _ = binary_handler_profile_rocprof_compute(
+    code, stdout, stderr = binary_handler_profile_rocprof_compute(
         config,
         workload_dir,
         options,
-        check_success=True,
+        check_success=False,
+        capture_output=True,
         roof=False,
         app_name="app_mat_mul_max",
     )
 
+    _skip_if_pc_sampling_unsupported(stdout, stderr, workload_dir)
+
+    assert code == 0
     file_dict = test_utils.check_non_pmc_files(workload_dir, num_devices, 1)
     assert sorted(list(file_dict.keys())) == sorted(PC_SAMPLING_HOST_TRAP_FILES)
 
@@ -313,15 +328,19 @@ def test_pc_sampling_with_sol_block(binary_handler_profile_rocprof_compute):
 
     workload_dir = test_utils.get_output_dir()
 
-    _ = binary_handler_profile_rocprof_compute(
+    code, stdout, stderr = binary_handler_profile_rocprof_compute(
         config,
         workload_dir,
         options,
-        check_success=True,
+        check_success=False,
+        capture_output=True,
         roof=False,
         app_name="app_mat_mul_max",
     )
 
+    _skip_if_pc_sampling_unsupported(stdout, stderr, workload_dir)
+
+    assert code == 0
     file_dict = test_utils.check_csv_files(workload_dir, num_devices, 1)
     assert sorted(list(file_dict.keys())) == sorted(PC_SAMPLING_HOST_TRAP_FILES)
 

--- a/projects/rocprofiler-compute/tools/copyright_header_check.py
+++ b/projects/rocprofiler-compute/tools/copyright_header_check.py
@@ -6,6 +6,9 @@
 
 import subprocess
 import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
 
 EXPECTED_LINES = (
     "Copyright (c) Advanced Micro Devices, Inc.",
@@ -32,7 +35,7 @@ def _check_header(filepath, prefix):
         f"{prefix} {EXPECTED_LINES[1]}",
     ]
     try:
-        with open(filepath, encoding="utf-8", errors="replace") as f:
+        with open(REPO_ROOT / filepath, encoding="utf-8", errors="replace") as f:
             lines = [f.readline().rstrip("\n\r") for _ in range(3)]
     except OSError:
         return "  could not read file"

--- a/projects/rocprofiler-compute/tools/copyright_header_check.py
+++ b/projects/rocprofiler-compute/tools/copyright_header_check.py
@@ -19,8 +19,8 @@ COMMENT_PREFIXES = {
 }
 
 EXCLUDED_DIRS = (
-    "src/vendored/",
-    "docs/archive/",
+    "projects/rocprofiler-compute/src/vendored/",
+    "projects/rocprofiler-compute/docs/archive/",
 )
 
 EXCLUDED_FILES = ("__init__.py",)
@@ -53,31 +53,25 @@ def _check_header(filepath, prefix):
 
 
 def _get_staged_files():
-    prefix = subprocess.run(
-        ["git", "rev-parse", "--show-prefix"],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
     result = subprocess.run(
         ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"],
         capture_output=True,
         text=True,
         check=True,
     )
-    paths = []
-    for line in result.stdout.splitlines():
-        if prefix and line.startswith(prefix):
-            paths.append(line[len(prefix) :])
-        elif not prefix:
-            paths.append(line)
-    return paths
+    return result.stdout.splitlines()
+
+
+def _files_to_check():
+    if len(sys.argv) > 1:
+        return sys.argv[1:]
+    return _get_staged_files()
 
 
 def main():
     failures = []
 
-    for filepath in _get_staged_files():
+    for filepath in _files_to_check():
         if any(filepath.startswith(d) for d in EXCLUDED_DIRS):
             continue
         basename = filepath.rsplit("/", 1)[-1]


### PR DESCRIPTION
## Motivation

Make the project pre-commit config a strict superset of the
formatting CI workflow, then collapse the workflow to a single job
that runs pre-commit. If local hooks pass, CI passes.

## Technical Details

- Add gersemi 0.22.1, clang-format 22.1.0, and a staged-bytecode
  rejection hook to projects/rocprofiler-compute/.pre-commit-config.yaml,
  pinned to the same versions the CI workflow used.

- Replace the four jobs (python, cmake, cxx, python-bytecode) in
  rocprofiler-compute-formatting.yml with a single pre-commit job that
  runs pre-commit/action@v3.0.1 against the project config, scoped to
  changed files via --from-ref/--to-ref.

- Adopt rocm-libraries pre-commit workflow conventions (https://github.com/ROCm/rocm-libraries/blob/develop/.github/workflows/pre-commit.yml): SHA-pinned
  actions, permissions: contents: read, PR-vs-push concurrency
  grouping, fetch-depth: 0 for diff resolution.

- Self-contain Python deps for the local hooks (hash-check,
  copyright-header-check) via language: python and
  additional_dependencies, so CI no longer needs a separate pip
  install step. copyright-header-check reads file paths from
  pre-commit args, with a git-staged fallback for direct dev runs.

- Drive-by (unrelated, included to unblock CI on this PR): make the
  host_trap PC sampling tests skip on runners where rocprofiler-sdk
  reports agents do not support PC sampling, mirroring the existing
  dynamic skip in test_pc_sampling_stochastic.

## JIRA ID


## Test Plan

- Open this PR and watch the new pre-commit job run successfully
  against the changed files.

- Locally: pre-commit run --all-files --config
  projects/rocprofiler-compute/.pre-commit-config.yaml reports
  gersemi/clang-format clean on rocprofiler-compute sources.

## Test Result

Pending CI.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.