### PR TITLE
[clr] Fix GraphSignalPool leak in ~AccumulateCommand

### DIFF
--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -2145,6 +2145,14 @@ class Device : public RuntimeObject {
   // Used by the graph executor to cache the count for the next launch.
   virtual size_t GetGraphSignalPoolUsedCount(roc::GraphSignalPool* pool) const { return 0; }
 
+  // Destroys a graph signal pool created by CreateGraphSignalPool.
+  // Required because GraphSignalPool is only forward-declared in platform/
+  // headers; calling `delete pool;` from generic code would not invoke
+  // ~GraphSignalPool (delete-on-incomplete-type is undefined behaviour and
+  // in practice silently skips the destructor). Routing through this virtual
+  // ensures the destructor in rocdevice.cpp is actually called.
+  virtual void DestroyGraphSignalPool(roc::GraphSignalPool* pool) const {}
+
   virtual const bool isFineGrainSupported() const {
     return (info().svmCapabilities_ & CL_DEVICE_SVM_ATOMICS) != 0 ? true : false;
   }

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3727,6 +3727,13 @@ size_t Device::GetGraphSignalPoolUsedCount(GraphSignalPool* pool) const {
 }
 
 // ================================================================================================
+// Out-of-line deleter so ~GraphSignalPool is actually invoked from generic
+// platform/ code (which only sees a forward declaration of GraphSignalPool).
+void Device::DestroyGraphSignalPool(GraphSignalPool* pool) const {
+  delete pool;
+}
+
+// ================================================================================================
 void Device::ApplyHwEventPatches(const std::vector<HwEventPatch>& patches,
                                  const std::vector<void*>& hw_events) const {
   for (const auto& patch : patches) {

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -549,6 +549,7 @@ class Device : public NullDevice {
       size_t gpu_count, size_t irq_count,
       size_t segment_count, std::vector<void*>& hw_events) const override;
   virtual size_t GetGraphSignalPoolUsedCount(GraphSignalPool* pool) const override;
+  virtual void DestroyGraphSignalPool(GraphSignalPool* pool) const override;
   virtual bool CreateUserEvent(amd::UserEvent* event) const override;
   virtual void SetUserEvent(amd::UserEvent* event) const override;
 

--- a/projects/clr/rocclr/platform/command.cpp
+++ b/projects/clr/rocclr/platform/command.cpp
@@ -66,7 +66,14 @@ AccumulateCommand::~AccumulateCommand() {
   if (owned_graph_signal_pool_ != nullptr) {
     // Graph pool owns all signals (SyncPlan HW events + ActiveSignal signals).
     // Skip per-device HW event release — pool destructor handles everything.
-    delete owned_graph_signal_pool_;
+    // Route through the device's virtual deleter so ~GraphSignalPool actually
+    // runs: a plain `delete owned_graph_signal_pool_;` here would only see
+    // the forward declaration of roc::GraphSignalPool and silently skip the
+    // destructor (delete-on-incomplete-type, which is UB and leaks every
+    // ProfilingSignal/HSA signal handle owned by the pool).
+    if (device_ != nullptr) {
+      device_->DestroyGraphSignalPool(owned_graph_signal_pool_);
+    }
   } else {
     // Non-graph path: release HW events per device as before
     for (auto& device_events_pair : hw_events_) {


### PR DESCRIPTION
`~AccumulateCommand::~AccumulateCommand()` does
`delete owned_graph_signal_pool_;` while only a forward declaration of `roc::GraphSignalPool` is visible in `platform/command.hpp`. Deleting through an incomplete type is undefined behaviour; in practice the compiler emits only `operator delete(void*)` on the raw memory and silently skips `~GraphSignalPool`. The pool's `signals_` and `irq_signals_` vectors of `ProfilingSignal*` are therefore never released, leaking every `ProfilingSignal` (and the underlying `hsa_signal_t` handle) owned by the pool — once per graph launch.

Verified via disassembly of the destructor: the call site emits `R_X86_64_PLT32 operator delete(void*)` directly, with no reference to `amd::roc::GraphSignalPool::~GraphSignalPool()`.

Fix: add a virtual `Device::DestroyGraphSignalPool(roc::GraphSignalPool*)` on the base `device::Device` (no-op default) with the real implementation in `rocdevice.cpp` where the destructor is in scope. `~AccumulateCommand` now routes the delete through `device_->DestroyGraphSignalPool(...)`, which properly invokes `~GraphSignalPool` and releases the owned profiling signals. This mirrors the existing pattern used for `CreateGraphSignalPool` / `GetGraphSignalPoolUsedCount` and avoids pulling rocm-specific headers into generic `platform/` code.

After fix: indirect virtual call dispatches to
`roc::Device::DestroyGraphSignalPool`, which calls `delete pool;` with the full type visible, the destructor runs, and every ProfilingSignal in the pool is released.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
