### PR TITLE
[RCCL]: add CTS cache overflow reproducer test (CtsDepthStress)

### DIFF
--- a/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
@@ -1418,23 +1418,14 @@ TEST_F(NetIbMPITest, MultiRecvShuffled) {
     // connGuard closes comms on scope exit
 }
 
-// CTS Cache Overflow Stress Test
-//
-// Creates N P2P connections with D outstanding recv requests each and
-// monitors per-device InfiniBand hw_counters for CTS retransmits and
-// ACK timeouts. With RCCL_IB_P2P_DISABLE_CTS=0 the AINIC CTS match
-// table overflows around ~256 entries and the test hangs in the drain
-// phase; with RCCL_IB_P2P_DISABLE_CTS=1 the test passes cleanly.
-//
-// Tunables (env vars):
-//   CTS_NUM_CONNS  - number of P2P connections (default 32)
-//   CTS_QP_DEPTH   - outstanding recvs per connection (default 256)
-//   CTS_SNAP_EVERY - sample hw_counters every K connections (default 1)
+// CTS cache overflow stress test. N P2P connections x D outstanding recvs.
+// Env: CTS_NUM_CONNS (32), CTS_QP_DEPTH (256), CTS_SNAP_EVERY (1).
+// With RCCL_IB_P2P_DISABLE_CTS=0 the AINIC CTS table overflows ~256 entries
+// and the drain times out; with =1 it passes. Requires exactly 2 ranks.
 TEST_F(NetIbMPITest, CtsDepthStress) {
-    ASSERT_TRUE(validateTestPrerequisites(kMinProcessesForMPI,
-                                         MPITestConstants::kNoProcessLimit,
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit))
-        << "Need at least " << kMinProcessesForMPI << " MPI ranks";
+        << "Test requires exactly " << kExactTwoProcesses << " MPI processes";
 
     net_ = &rocmNetIb;
     ASSERT_EQ(InitNetIb(), ncclSuccess);
@@ -1446,9 +1437,17 @@ TEST_F(NetIbMPITest, CtsDepthStress) {
     const int rank        = MPIEnvironment::world_rank;
     const int kMaxRetries = 10000000;
 
-    const int numConns  = []{ auto* e = getenv("CTS_NUM_CONNS");  return e ? atoi(e) : 32;  }();
-    const int qpDepth   = []{ auto* e = getenv("CTS_QP_DEPTH");   return e ? atoi(e) : 256; }();
-    const int snapEvery = []{ auto* e = getenv("CTS_SNAP_EVERY"); return e ? atoi(e) : 1;   }();
+    auto envInt = [](const char* name, int dflt) {
+        const char* e = getenv(name);
+        return e ? atoi(e) : dflt;
+    };
+    const int numConns  = envInt("CTS_NUM_CONNS",  32);
+    const int qpDepth   = envInt("CTS_QP_DEPTH",   256);
+    const int snapEvery = envInt("CTS_SNAP_EVERY", 1);
+    ASSERT_GT(numConns,  0) << "CTS_NUM_CONNS must be > 0";
+    ASSERT_GT(qpDepth,   0) << "CTS_QP_DEPTH must be > 0";
+    ASSERT_GT(snapEvery, 0) << "CTS_SNAP_EVERY must be > 0";
+
     const int totalEntries = numConns * qpDepth;
     const size_t bufSize   = 4096;
     const int    baseTag   = 100;
@@ -1461,7 +1460,9 @@ TEST_F(NetIbMPITest, CtsDepthStress) {
               << "  ndev=" << ndev
               << "\n" << std::flush;
 
+    // Self-cleaning so ASSERT_* mid-fill doesn't leak comms / MRs / bufs.
     struct Conn {
+        ncclNet_t* net = nullptr;
         void* sendComm   = nullptr;
         void* recvComm   = nullptr;
         void* listenComm = nullptr;
@@ -1469,23 +1470,40 @@ TEST_F(NetIbMPITest, CtsDepthStress) {
         std::vector<void*> recvMhandles;
         std::vector<void*> recvBufs;
         std::vector<void*> recvRequests;
-    };
 
-    ncclNet_ctxt_t devCtxt = {};
+        Conn() = default;
+        Conn(const Conn&) = delete;
+        Conn& operator=(const Conn&) = delete;
+
+        ~Conn() {
+            if (!net) return;
+            for (size_t d = 0; d < recvMhandles.size(); d++) {
+                if (recvMhandles[d] && recvComm) net->deregMr(recvComm, recvMhandles[d]);
+            }
+            for (auto* b : recvBufs) if (b) free(b);
+            if (sendMhandle && sendComm) net->deregMr(sendComm, sendMhandle);
+            if (recvComm)   net->closeRecv(recvComm);
+            if (sendComm)   net->closeSend(sendComm);
+            if (listenComm) net->closeListen(listenComm);
+        }
+    };
 
     using namespace NetIbCts;
     CounterMap snapInit = takeSnapshot();
     std::cout << "[Rank " << rank << "] snapshot: Init\n" << std::flush;
 
-    std::vector<Conn> conns(numConns);
+    std::vector<std::unique_ptr<Conn>> conns(numConns);
+    for (int i = 0; i < numConns; i++) {
+        conns[i] = std::make_unique<Conn>();
+        conns[i]->net = net_;
+    }
 
     if (rank == 0) {
         std::vector<ncclNetHandle_t> handles(numConns);
         std::cout << "[Rank 0] listen() x " << numConns << "...\n" << std::flush;
         for (int i = 0; i < numConns; i++) {
-            devCtxt.chId = i % 32;
             ASSERT_EQ(net_->listen(initCtx_, i % ndev, &handles[i],
-                                   &conns[i].listenComm), ncclSuccess)
+                                   &conns[i]->listenComm), ncclSuccess)
                 << "listen failed conn=" << i;
             ASSERT_EQ(rcclRocmNetP2pPolicy(&handles[i], 1), ncclSuccess);
             MPI_Send(&handles[i], sizeof(ncclNetHandle_t), MPI_BYTE,
@@ -1494,25 +1512,25 @@ TEST_F(NetIbMPITest, CtsDepthStress) {
 
         std::cout << "[Rank 0] accept() x " << numConns << "...\n" << std::flush;
         for (int i = 0; i < numConns; i++) {
-            devCtxt.chId = i % 32;
-            int retries  = 0;
-            while (!conns[i].recvComm) {
-                net_->accept(conns[i].listenComm, &conns[i].recvComm,
-                             (ncclNetDeviceHandle_t**)&devCtxt);
+            int retries = 0;
+            while (!conns[i]->recvComm) {
+                ASSERT_EQ(net_->accept(conns[i]->listenComm,
+                                       &conns[i]->recvComm, nullptr),
+                          ncclSuccess) << "accept failed conn=" << i;
                 ++retries;
                 if (retries % 1000 == 0) usleep(100);
                 ASSERT_LT(retries, kMaxRetries) << "accept timeout conn=" << i;
             }
-            conns[i].recvBufs.resize(qpDepth);
-            conns[i].recvMhandles.resize(qpDepth, nullptr);
-            conns[i].recvRequests.resize(qpDepth, nullptr);
+            conns[i]->recvBufs.resize(qpDepth);
+            conns[i]->recvMhandles.resize(qpDepth, nullptr);
+            conns[i]->recvRequests.resize(qpDepth, nullptr);
             for (int d = 0; d < qpDepth; d++) {
-                conns[i].recvBufs[d] = malloc(bufSize);
-                ASSERT_NE(conns[i].recvBufs[d], nullptr);
-                ASSERT_EQ(RegisterMemory(conns[i].recvComm,
-                                         conns[i].recvBufs[d], bufSize,
+                conns[i]->recvBufs[d] = malloc(bufSize);
+                ASSERT_NE(conns[i]->recvBufs[d], nullptr);
+                ASSERT_EQ(RegisterMemory(conns[i]->recvComm,
+                                         conns[i]->recvBufs[d], bufSize,
                                          NCCL_PTR_HOST,
-                                         &conns[i].recvMhandles[d]), ncclSuccess)
+                                         &conns[i]->recvMhandles[d]), ncclSuccess)
                     << "regMr failed conn=" << i << " depth=" << d;
             }
         }
@@ -1520,9 +1538,10 @@ TEST_F(NetIbMPITest, CtsDepthStress) {
 
         MPI_Barrier(MPI_COMM_WORLD);
 
-        // Posting all recvs fills the CTS match table; sample after each
-        // connection batch so we can spot the overflow as soon as it occurs.
-        CounterMap snapPrev = takeSnapshot();
+        // snapBeforePostRecv: fixed baseline for the final delta.
+        // snapStep: advances each sample so prints are per-window.
+        CounterMap snapBeforePostRecv = takeSnapshot();
+        CounterMap snapStep           = snapBeforePostRecv;
         std::cout << "[Rank 0] snapshot: BeforePostRecv\n"
                   << "[Rank 0] filling " << numConns << " x " << qpDepth
                   << " = " << totalEntries << " CTS entries...\n" << std::flush;
@@ -1532,34 +1551,36 @@ TEST_F(NetIbMPITest, CtsDepthStress) {
 
         for (int i = 0; i < numConns; i++) {
             for (int d = 0; d < qpDepth; d++) {
-                void*  rb[1]  = {conns[i].recvBufs[d]};
+                void*  rb[1]  = {conns[i]->recvBufs[d]};
                 size_t rs[1]  = {bufSize};
                 int    rt[1]  = {baseTag + i * qpDepth + d};
-                void*  rh[1]  = {conns[i].recvMhandles[d]};
-                ASSERT_EQ(PostRecv(conns[i].recvComm, 1, rb, rs, rt, rh,
-                                   &conns[i].recvRequests[d]), ncclSuccess)
+                void*  rh[1]  = {conns[i]->recvMhandles[d]};
+                ASSERT_EQ(PostRecv(conns[i]->recvComm, 1, rb, rs, rt, rh,
+                                   &conns[i]->recvRequests[d]), ncclSuccess)
                     << "PostRecv failed conn=" << i << " depth=" << d;
-                ASSERT_NE(conns[i].recvRequests[d], nullptr);
+                ASSERT_NE(conns[i]->recvRequests[d], nullptr);
             }
 
             if ((i + 1) % snapEvery == 0) {
                 CounterMap snapNow = takeSnapshot();
-                printSummary(rank, "filling", i + 1, qpDepth, snapPrev, snapNow);
-                auto s = calcSummary(snapPrev, snapNow);
+                printSummary(rank, "filling step", i + 1, qpDepth, snapStep, snapNow);
+                auto s = calcSummary(snapStep, snapNow);
                 if ((s.retx_pkts > 0 || s.ack_timeout > 0) && !overflowDetected) {
                     overflowDetected = true;
                     overflowAtConn   = i + 1;
                     printDelta(rank, "BeforePostRecv", "OverflowPoint",
-                               snapPrev, snapNow);
+                               snapBeforePostRecv, snapNow);
                 }
+                snapStep = std::move(snapNow);
             }
         }
 
         CounterMap snapAfterRecv = takeSnapshot();
         std::cout << "\n[Rank 0] snapshot: AfterPostRecv\n" << std::flush;
-        printDelta(rank, "BeforePostRecv", "AfterPostRecv", snapPrev, snapAfterRecv);
+        printDelta(rank, "BeforePostRecv", "AfterPostRecv",
+                   snapBeforePostRecv, snapAfterRecv);
         printSummary(rank, "FINAL after all PostRecv", numConns, qpDepth,
-                     snapPrev, snapAfterRecv);
+                     snapBeforePostRecv, snapAfterRecv);
 
         if (!overflowDetected)
             std::cout << "[Rank 0] No overflow at " << totalEntries
@@ -1570,21 +1591,20 @@ TEST_F(NetIbMPITest, CtsDepthStress) {
                       << " (~" << overflowAtConn * qpDepth << " entries)\n"
                       << std::flush;
 
-        // Both ranks always proceed to drain. If overflow was detected above,
-        // WaitForCompletion will hang here -- that is the expected observable
-        // behavior of the CTS cache overflow.
+        // On overflow, WaitForCompletion times out and we report the partial
+        // completion count -- that's the observable CTS-overflow signature.
         MPI_Barrier(MPI_COMM_WORLD);
 
         std::cout << "[Rank 0] draining " << numConns << " connections"
-                  << (overflowDetected ? " (OVERFLOW - expect hang)" : "")
+                  << (overflowDetected ? " (OVERFLOW - expect drain timeout)" : "")
                   << "...\n" << std::flush;
 
         int totalCompleted = 0;
         for (int i = 0; i < numConns; i++) {
             for (int d = 0; d < qpDepth; d++) {
                 int sizes[1] = {0};
-                if (WaitForCompletion(conns[i].recvRequests[d], sizes, 30000)
-                        != ncclSuccess) {
+                if (WaitForCompletion(conns[i]->recvRequests[d], sizes,
+                                      kLargeTransferTimeoutMs) != ncclSuccess) {
                     std::cout << "[Rank 0] TIMEOUT conn=" << i
                               << " depth=" << d
                               << " total_completed=" << totalCompleted << "\n"
@@ -1613,40 +1633,29 @@ TEST_F(NetIbMPITest, CtsDepthStress) {
         EXPECT_EQ(totalCompleted, totalEntries);
 
         MPI_Barrier(MPI_COMM_WORLD);
-        std::cout << "[Rank 0] cleanup...\n" << std::flush;
-        for (int i = 0; i < numConns; i++) {
-            for (int d = 0; d < qpDepth; d++) {
-                if (conns[i].recvMhandles[d])
-                    DeregisterMemory(conns[i].recvComm, conns[i].recvMhandles[d]);
-                if (conns[i].recvBufs[d]) free(conns[i].recvBufs[d]);
-            }
-            if (conns[i].recvComm)   CloseRecvComm(conns[i].recvComm);
-            if (conns[i].listenComm) CloseListenComm(conns[i].listenComm);
-        }
-        std::cout << "[Rank 0] cleanup done\n" << std::flush;
 
     } else {
-        // Rank 1: sender side
-        void* sendBuf = malloc(bufSize);
+        HostBufferAutoGuard sendBufGuard(malloc(bufSize));
+        void* const sendBuf = sendBufGuard.get();
         ASSERT_NE(sendBuf, nullptr);
         memset(sendBuf, 0xab, bufSize);
 
         std::cout << "[Rank 1] connect() x " << numConns << "...\n" << std::flush;
         for (int i = 0; i < numConns; i++) {
-            devCtxt.chId = i % 32;
             ncclNetHandle_t handle;
             MPI_Recv(&handle, sizeof(ncclNetHandle_t), MPI_BYTE,
                      0, i, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
             int retries = 0;
-            while (!conns[i].sendComm) {
-                net_->connect(initCtx_, i % ndev, &handle, &conns[i].sendComm,
-                              (ncclNetDeviceHandle_t**)&devCtxt);
+            while (!conns[i]->sendComm) {
+                ASSERT_EQ(net_->connect(initCtx_, i % ndev, &handle,
+                                        &conns[i]->sendComm, nullptr),
+                          ncclSuccess) << "connect failed conn=" << i;
                 ++retries;
                 if (retries % 1000 == 0) usleep(100);
                 ASSERT_LT(retries, kMaxRetries) << "connect timeout conn=" << i;
             }
-            ASSERT_EQ(RegisterMemory(conns[i].sendComm, sendBuf, bufSize,
-                                     NCCL_PTR_HOST, &conns[i].sendMhandle), ncclSuccess)
+            ASSERT_EQ(RegisterMemory(conns[i]->sendComm, sendBuf, bufSize,
+                                     NCCL_PTR_HOST, &conns[i]->sendMhandle), ncclSuccess)
                 << "regMr failed conn=" << i;
         }
         std::cout << "[Rank 1] all " << numConns << " connections up\n" << std::flush;
@@ -1659,15 +1668,16 @@ TEST_F(NetIbMPITest, CtsDepthStress) {
             std::vector<void*> sendRequests(qpDepth, nullptr);
             for (int d = 0; d < qpDepth; d++) {
                 int sendTag = baseTag + i * qpDepth + d;
-                PostSendWithRetry(conns[i].sendComm, sendBuf, bufSize,
-                                  sendTag, conns[i].sendMhandle,
+                PostSendWithRetry(conns[i]->sendComm, sendBuf, bufSize,
+                                  sendTag, conns[i]->sendMhandle,
                                   &sendRequests[d]);
                 ASSERT_NE(sendRequests[d], nullptr)
                     << "null send request conn=" << i << " depth=" << d;
             }
             for (int d = 0; d < qpDepth; d++) {
                 int sizes[1] = {0};
-                if (WaitForCompletion(sendRequests[d], sizes, 30000) != ncclSuccess) {
+                if (WaitForCompletion(sendRequests[d], sizes,
+                                      kLargeTransferTimeoutMs) != ncclSuccess) {
                     std::cout << "[Rank 1] TIMEOUT conn=" << i
                               << " depth=" << d
                               << " total_completed=" << totalCompleted << "\n"
@@ -1683,12 +1693,6 @@ TEST_F(NetIbMPITest, CtsDepthStress) {
         EXPECT_EQ(totalCompleted, totalEntries);
 
         MPI_Barrier(MPI_COMM_WORLD);
-        for (int i = 0; i < numConns; i++) {
-            if (conns[i].sendMhandle)
-                DeregisterMemory(conns[i].sendComm, conns[i].sendMhandle);
-            if (conns[i].sendComm) CloseSendComm(conns[i].sendComm);
-        }
-        free(sendBuf);
     }
 
     MPI_Barrier(MPI_COMM_WORLD);

--- a/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/GeneralTests.cpp
@@ -1418,4 +1418,280 @@ TEST_F(NetIbMPITest, MultiRecvShuffled) {
     // connGuard closes comms on scope exit
 }
 
+// CTS Cache Overflow Stress Test
+//
+// Creates N P2P connections with D outstanding recv requests each and
+// monitors per-device InfiniBand hw_counters for CTS retransmits and
+// ACK timeouts. With RCCL_IB_P2P_DISABLE_CTS=0 the AINIC CTS match
+// table overflows around ~256 entries and the test hangs in the drain
+// phase; with RCCL_IB_P2P_DISABLE_CTS=1 the test passes cleanly.
+//
+// Tunables (env vars):
+//   CTS_NUM_CONNS  - number of P2P connections (default 32)
+//   CTS_QP_DEPTH   - outstanding recvs per connection (default 256)
+//   CTS_SNAP_EVERY - sample hw_counters every K connections (default 1)
+TEST_F(NetIbMPITest, CtsDepthStress) {
+    ASSERT_TRUE(validateTestPrerequisites(kMinProcessesForMPI,
+                                         MPITestConstants::kNoProcessLimit,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Need at least " << kMinProcessesForMPI << " MPI ranks";
+
+    net_ = &rocmNetIb;
+    ASSERT_EQ(InitNetIb(), ncclSuccess);
+
+    int ndev = 0;
+    ASSERT_EQ(GetDeviceCount(&ndev), ncclSuccess);
+    ASSERT_GT(ndev, 0);
+
+    const int rank        = MPIEnvironment::world_rank;
+    const int kMaxRetries = 10000000;
+
+    const int numConns  = []{ auto* e = getenv("CTS_NUM_CONNS");  return e ? atoi(e) : 32;  }();
+    const int qpDepth   = []{ auto* e = getenv("CTS_QP_DEPTH");   return e ? atoi(e) : 256; }();
+    const int snapEvery = []{ auto* e = getenv("CTS_SNAP_EVERY"); return e ? atoi(e) : 1;   }();
+    const int totalEntries = numConns * qpDepth;
+    const size_t bufSize   = 4096;
+    const int    baseTag   = 100;
+
+    std::cout << "[Rank " << rank << "] CtsDepthStress:"
+              << "  numConns=" << numConns
+              << "  qpDepth=" << qpDepth
+              << "  totalCtsEntries=" << totalEntries
+              << "  snapEvery=" << snapEvery
+              << "  ndev=" << ndev
+              << "\n" << std::flush;
+
+    struct Conn {
+        void* sendComm   = nullptr;
+        void* recvComm   = nullptr;
+        void* listenComm = nullptr;
+        void* sendMhandle = nullptr;
+        std::vector<void*> recvMhandles;
+        std::vector<void*> recvBufs;
+        std::vector<void*> recvRequests;
+    };
+
+    ncclNet_ctxt_t devCtxt = {};
+
+    using namespace NetIbCts;
+    CounterMap snapInit = takeSnapshot();
+    std::cout << "[Rank " << rank << "] snapshot: Init\n" << std::flush;
+
+    std::vector<Conn> conns(numConns);
+
+    if (rank == 0) {
+        std::vector<ncclNetHandle_t> handles(numConns);
+        std::cout << "[Rank 0] listen() x " << numConns << "...\n" << std::flush;
+        for (int i = 0; i < numConns; i++) {
+            devCtxt.chId = i % 32;
+            ASSERT_EQ(net_->listen(initCtx_, i % ndev, &handles[i],
+                                   &conns[i].listenComm), ncclSuccess)
+                << "listen failed conn=" << i;
+            ASSERT_EQ(rcclRocmNetP2pPolicy(&handles[i], 1), ncclSuccess);
+            MPI_Send(&handles[i], sizeof(ncclNetHandle_t), MPI_BYTE,
+                     1, i, MPI_COMM_WORLD);
+        }
+
+        std::cout << "[Rank 0] accept() x " << numConns << "...\n" << std::flush;
+        for (int i = 0; i < numConns; i++) {
+            devCtxt.chId = i % 32;
+            int retries  = 0;
+            while (!conns[i].recvComm) {
+                net_->accept(conns[i].listenComm, &conns[i].recvComm,
+                             (ncclNetDeviceHandle_t**)&devCtxt);
+                ++retries;
+                if (retries % 1000 == 0) usleep(100);
+                ASSERT_LT(retries, kMaxRetries) << "accept timeout conn=" << i;
+            }
+            conns[i].recvBufs.resize(qpDepth);
+            conns[i].recvMhandles.resize(qpDepth, nullptr);
+            conns[i].recvRequests.resize(qpDepth, nullptr);
+            for (int d = 0; d < qpDepth; d++) {
+                conns[i].recvBufs[d] = malloc(bufSize);
+                ASSERT_NE(conns[i].recvBufs[d], nullptr);
+                ASSERT_EQ(RegisterMemory(conns[i].recvComm,
+                                         conns[i].recvBufs[d], bufSize,
+                                         NCCL_PTR_HOST,
+                                         &conns[i].recvMhandles[d]), ncclSuccess)
+                    << "regMr failed conn=" << i << " depth=" << d;
+            }
+        }
+        std::cout << "[Rank 0] all " << numConns << " connections up\n" << std::flush;
+
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        // Posting all recvs fills the CTS match table; sample after each
+        // connection batch so we can spot the overflow as soon as it occurs.
+        CounterMap snapPrev = takeSnapshot();
+        std::cout << "[Rank 0] snapshot: BeforePostRecv\n"
+                  << "[Rank 0] filling " << numConns << " x " << qpDepth
+                  << " = " << totalEntries << " CTS entries...\n" << std::flush;
+
+        bool overflowDetected = false;
+        int  overflowAtConn   = -1;
+
+        for (int i = 0; i < numConns; i++) {
+            for (int d = 0; d < qpDepth; d++) {
+                void*  rb[1]  = {conns[i].recvBufs[d]};
+                size_t rs[1]  = {bufSize};
+                int    rt[1]  = {baseTag + i * qpDepth + d};
+                void*  rh[1]  = {conns[i].recvMhandles[d]};
+                ASSERT_EQ(PostRecv(conns[i].recvComm, 1, rb, rs, rt, rh,
+                                   &conns[i].recvRequests[d]), ncclSuccess)
+                    << "PostRecv failed conn=" << i << " depth=" << d;
+                ASSERT_NE(conns[i].recvRequests[d], nullptr);
+            }
+
+            if ((i + 1) % snapEvery == 0) {
+                CounterMap snapNow = takeSnapshot();
+                printSummary(rank, "filling", i + 1, qpDepth, snapPrev, snapNow);
+                auto s = calcSummary(snapPrev, snapNow);
+                if ((s.retx_pkts > 0 || s.ack_timeout > 0) && !overflowDetected) {
+                    overflowDetected = true;
+                    overflowAtConn   = i + 1;
+                    printDelta(rank, "BeforePostRecv", "OverflowPoint",
+                               snapPrev, snapNow);
+                }
+            }
+        }
+
+        CounterMap snapAfterRecv = takeSnapshot();
+        std::cout << "\n[Rank 0] snapshot: AfterPostRecv\n" << std::flush;
+        printDelta(rank, "BeforePostRecv", "AfterPostRecv", snapPrev, snapAfterRecv);
+        printSummary(rank, "FINAL after all PostRecv", numConns, qpDepth,
+                     snapPrev, snapAfterRecv);
+
+        if (!overflowDetected)
+            std::cout << "[Rank 0] No overflow at " << totalEntries
+                      << " entries. Try CTS_NUM_CONNS=" << numConns * 2 << "\n"
+                      << std::flush;
+        else
+            std::cout << "[Rank 0] Overflow confirmed at conn=" << overflowAtConn
+                      << " (~" << overflowAtConn * qpDepth << " entries)\n"
+                      << std::flush;
+
+        // Both ranks always proceed to drain. If overflow was detected above,
+        // WaitForCompletion will hang here -- that is the expected observable
+        // behavior of the CTS cache overflow.
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        std::cout << "[Rank 0] draining " << numConns << " connections"
+                  << (overflowDetected ? " (OVERFLOW - expect hang)" : "")
+                  << "...\n" << std::flush;
+
+        int totalCompleted = 0;
+        for (int i = 0; i < numConns; i++) {
+            for (int d = 0; d < qpDepth; d++) {
+                int sizes[1] = {0};
+                if (WaitForCompletion(conns[i].recvRequests[d], sizes, 30000)
+                        != ncclSuccess) {
+                    std::cout << "[Rank 0] TIMEOUT conn=" << i
+                              << " depth=" << d
+                              << " total_completed=" << totalCompleted << "\n"
+                              << std::flush;
+                    goto drain_done;
+                }
+                totalCompleted++;
+            }
+            if ((i + 1) % 8 == 0)
+                std::cout << "[Rank 0] drained " << (i+1) << "/" << numConns
+                          << " (" << totalCompleted << " completions)\n"
+                          << std::flush;
+        }
+        drain_done:
+        std::cout << "[Rank 0] " << totalCompleted << "/" << totalEntries
+                  << " completions done\n" << std::flush;
+
+        CounterMap snapAfterBurst = takeSnapshot();
+        std::cout << "[Rank 0] snapshot: AfterBurst\n" << std::flush;
+        printDelta(rank, "AfterPostRecv", "AfterBurst", snapAfterRecv, snapAfterBurst);
+        printSummary(rank, "AfterBurst delta", numConns, qpDepth,
+                     snapAfterRecv, snapAfterBurst);
+        printDelta(rank, "Init", "Full run", snapInit, snapAfterBurst);
+        printSummary(rank, "Full run", numConns, qpDepth, snapInit, snapAfterBurst);
+
+        EXPECT_EQ(totalCompleted, totalEntries);
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        std::cout << "[Rank 0] cleanup...\n" << std::flush;
+        for (int i = 0; i < numConns; i++) {
+            for (int d = 0; d < qpDepth; d++) {
+                if (conns[i].recvMhandles[d])
+                    DeregisterMemory(conns[i].recvComm, conns[i].recvMhandles[d]);
+                if (conns[i].recvBufs[d]) free(conns[i].recvBufs[d]);
+            }
+            if (conns[i].recvComm)   CloseRecvComm(conns[i].recvComm);
+            if (conns[i].listenComm) CloseListenComm(conns[i].listenComm);
+        }
+        std::cout << "[Rank 0] cleanup done\n" << std::flush;
+
+    } else {
+        // Rank 1: sender side
+        void* sendBuf = malloc(bufSize);
+        ASSERT_NE(sendBuf, nullptr);
+        memset(sendBuf, 0xab, bufSize);
+
+        std::cout << "[Rank 1] connect() x " << numConns << "...\n" << std::flush;
+        for (int i = 0; i < numConns; i++) {
+            devCtxt.chId = i % 32;
+            ncclNetHandle_t handle;
+            MPI_Recv(&handle, sizeof(ncclNetHandle_t), MPI_BYTE,
+                     0, i, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            int retries = 0;
+            while (!conns[i].sendComm) {
+                net_->connect(initCtx_, i % ndev, &handle, &conns[i].sendComm,
+                              (ncclNetDeviceHandle_t**)&devCtxt);
+                ++retries;
+                if (retries % 1000 == 0) usleep(100);
+                ASSERT_LT(retries, kMaxRetries) << "connect timeout conn=" << i;
+            }
+            ASSERT_EQ(RegisterMemory(conns[i].sendComm, sendBuf, bufSize,
+                                     NCCL_PTR_HOST, &conns[i].sendMhandle), ncclSuccess)
+                << "regMr failed conn=" << i;
+        }
+        std::cout << "[Rank 1] all " << numConns << " connections up\n" << std::flush;
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        int totalCompleted = 0;
+        for (int i = 0; i < numConns; i++) {
+            std::vector<void*> sendRequests(qpDepth, nullptr);
+            for (int d = 0; d < qpDepth; d++) {
+                int sendTag = baseTag + i * qpDepth + d;
+                PostSendWithRetry(conns[i].sendComm, sendBuf, bufSize,
+                                  sendTag, conns[i].sendMhandle,
+                                  &sendRequests[d]);
+                ASSERT_NE(sendRequests[d], nullptr)
+                    << "null send request conn=" << i << " depth=" << d;
+            }
+            for (int d = 0; d < qpDepth; d++) {
+                int sizes[1] = {0};
+                if (WaitForCompletion(sendRequests[d], sizes, 30000) != ncclSuccess) {
+                    std::cout << "[Rank 1] TIMEOUT conn=" << i
+                              << " depth=" << d
+                              << " total_completed=" << totalCompleted << "\n"
+                              << std::flush;
+                    goto sender_drain_done;
+                }
+                totalCompleted++;
+            }
+        }
+        sender_drain_done:
+        std::cout << "[Rank 1] " << totalCompleted << "/" << totalEntries
+                  << " sends completed\n" << std::flush;
+        EXPECT_EQ(totalCompleted, totalEntries);
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        for (int i = 0; i < numConns; i++) {
+            if (conns[i].sendMhandle)
+                DeregisterMemory(conns[i].sendComm, conns[i].sendMhandle);
+            if (conns[i].sendComm) CloseSendComm(conns[i].sendComm);
+        }
+        free(sendBuf);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
 #endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -17,6 +17,7 @@
 #include "HostBufferHelpers.hpp"
 #include "nccl.h"
 #include "net.h"
+#include "plugin/nccl_net.h"
 #include <vector>
 #include <memory>
 #include <cstring>
@@ -24,6 +25,14 @@
 #include <cstdio>
 #include <cstdlib>
 #include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <string>
+#include <dirent.h>
+#include <unistd.h>
 
 #ifdef MPI_TESTS_ENABLED
 
@@ -595,6 +604,162 @@ protected:
         }
     }
 };
+
+// ============================================================================
+// CTS hw_counters helpers (for CtsDepthStress and friends)
+//
+// Read per-IB-device InfiniBand hw_counters from
+// /sys/class/infiniband/<dev>/ports/1/hw_counters and compute deltas for
+// CTS-relevant counters (cts_pkts, cts_retx, cts_ack_timeout, ...).
+// ============================================================================
+namespace NetIbCts {
+
+using CounterMap = std::map<std::string, long long>;
+
+inline const std::vector<std::string>& kCtsKeywords() {
+    static const std::vector<std::string> v = {
+        "cts_pkts", "cts_bytes",
+        "cts_retx",          // retransmit = overflow signal
+        "cts_ack_timeout",   // ACK timeout = overflow signal
+        "cts_miss", "cts_cache", "cts_match",
+        "nak", "rdma_ccl",
+    };
+    return v;
+}
+
+inline bool isCtsRelevant(const std::string& name) {
+    std::string lower = name;
+    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+    for (const auto& kw : kCtsKeywords())
+        if (lower.find(kw) != std::string::npos) return true;
+    return false;
+}
+
+inline CounterMap readHwCounters(const std::string& ibdev) {
+    CounterMap result;
+    const std::string base =
+        "/sys/class/infiniband/" + ibdev + "/ports/1/hw_counters";
+    DIR* dir = opendir(base.c_str());
+    if (!dir) return result;
+    struct dirent* ent;
+    while ((ent = readdir(dir)) != nullptr) {
+        if (ent->d_name[0] == '.') continue;
+        std::ifstream f(base + "/" + ent->d_name);
+        long long val = 0;
+        if (f >> val)
+            result[ibdev + "/" + ent->d_name] = val;
+    }
+    closedir(dir);
+    return result;
+}
+
+inline std::vector<std::string> listIbDevices() {
+    std::vector<std::string> devs;
+    DIR* dir = opendir("/sys/class/infiniband");
+    if (!dir) return devs;
+    struct dirent* ent;
+    while ((ent = readdir(dir)) != nullptr)
+        if (ent->d_name[0] != '.') devs.push_back(ent->d_name);
+    closedir(dir);
+    std::sort(devs.begin(), devs.end());
+    return devs;
+}
+
+inline CounterMap takeSnapshot() {
+    CounterMap snap;
+    for (const auto& dev : listIbDevices()) {
+        auto m = readHwCounters(dev);
+        snap.insert(m.begin(), m.end());
+    }
+    return snap;
+}
+
+inline void printDelta(int rank,
+                       const std::string& fromLabel,
+                       const std::string& toLabel,
+                       const CounterMap& before,
+                       const CounterMap& after) {
+    struct Row { std::string name; long long vb, va, delta; };
+    std::vector<Row> rows;
+    for (const auto& kv : after) {
+        if (!isCtsRelevant(kv.first)) continue;
+        long long vb = 0;
+        auto it = before.find(kv.first);
+        if (it != before.end()) vb = it->second;
+        long long delta = kv.second - vb;
+        if (delta != 0)
+            rows.push_back({kv.first, vb, kv.second, delta});
+    }
+
+    const int wName = 55, wVal = 12, wDelta = 12;
+    std::cout << "\n[Rank " << rank << "] "
+              << fromLabel << " -> " << toLabel << "\n";
+    if (rows.empty()) {
+        std::cout << "  (no CTS-relevant changes)\n" << std::flush;
+        return;
+    }
+    std::cout << "  " << std::left  << std::setw(wName)  << "counter"
+              <<         std::right << std::setw(wVal)   << "before"
+              <<         std::right << std::setw(wVal)   << "after"
+              <<         std::right << std::setw(wDelta) << "delta"
+              << "\n  " << std::string(wName + wVal + wVal + wDelta, '-') << "\n";
+    for (const auto& r : rows)
+        std::cout << "  " << std::left  << std::setw(wName)  << r.name
+                  <<         std::right << std::setw(wVal)   << r.vb
+                  <<         std::right << std::setw(wVal)   << r.va
+                  <<         std::right << std::setw(wDelta) << ("+" + std::to_string(r.delta))
+                  << "\n";
+    std::cout << std::flush;
+}
+
+struct SnapSummary {
+    long long pkts        = 0;
+    long long bytes       = 0;
+    long long retx_pkts   = 0;  // cts_retx_pkts   - overflow signal
+    long long ack_timeout = 0;  // cts_ack_timeout - overflow signal
+};
+
+inline SnapSummary calcSummary(const CounterMap& before, const CounterMap& after) {
+    SnapSummary s;
+    for (const auto& kv : after) {
+        auto it = before.find(kv.first);
+        long long d = kv.second - (it != before.end() ? it->second : 0LL);
+        if (d == 0) continue;
+        const std::string& n = kv.first;
+        if (n.find("cts_retx_pkts")    != std::string::npos) s.retx_pkts   += d;
+        if (n.find("cts_ack_timeout")  != std::string::npos) s.ack_timeout += d;
+        if (n.find("cts_pkts")         != std::string::npos &&
+            n.find("retx")             == std::string::npos) s.pkts        += d;
+        if (n.find("cts_bytes")        != std::string::npos &&
+            n.find("retx")             == std::string::npos) s.bytes       += d;
+    }
+    return s;
+}
+
+inline void printSummary(int rank,
+                         const std::string& label,
+                         int connsDone,
+                         int qpDepth,
+                         const CounterMap& before,
+                         const CounterMap& after) {
+    auto s = calcSummary(before, after);
+    long long bpp = s.pkts > 0 ? s.bytes / s.pkts : 0;
+
+    std::cout << "[Rank " << rank << "]"
+              << "  conns=" << std::setw(4) << connsDone
+              << "  entries=" << std::setw(6) << (connsDone * qpDepth)
+              << "  cts_pkts=" << std::setw(6) << s.pkts
+              << "  bytes/pkt=" << bpp
+              << "  retx=" << s.retx_pkts
+              << "  ack_timeout=" << s.ack_timeout;
+    if (s.retx_pkts > 0 || s.ack_timeout > 0) {
+        std::cout << "  <<< OVERFLOW at ~"
+                  << connsDone * qpDepth << " entries >>>";
+    }
+    std::cout << "  [" << label << "]\n" << std::flush;
+}
+
+}  // namespace NetIbCts
 
 #endif /* MPI_TESTS_ENABLED */
 

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -606,11 +606,9 @@ protected:
 };
 
 // ============================================================================
-// CTS hw_counters helpers (for CtsDepthStress and friends)
-//
-// Read per-IB-device InfiniBand hw_counters from
-// /sys/class/infiniband/<dev>/ports/1/hw_counters and compute deltas for
-// CTS-relevant counters (cts_pkts, cts_retx, cts_ack_timeout, ...).
+// CTS hw_counters helpers (for CtsDepthStress and friends).
+// Snapshots /sys/class/infiniband/<dev>/ports/<N>/hw_counters/ and the
+// device-level /sys/class/infiniband/<dev>/hw_counters/ for CTS deltas.
 // ============================================================================
 namespace NetIbCts {
 
@@ -628,41 +626,56 @@ inline const std::vector<std::string>& kCtsKeywords() {
 }
 
 inline bool isCtsRelevant(const std::string& name) {
-    std::string lower = name;
-    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+    std::string lower(name.size(), '\0');
+    std::transform(name.begin(), name.end(), lower.begin(),
+                   [](char c) { return static_cast<char>(
+                       std::tolower(static_cast<unsigned char>(c))); });
     for (const auto& kw : kCtsKeywords())
         if (lower.find(kw) != std::string::npos) return true;
     return false;
 }
 
-inline CounterMap readHwCounters(const std::string& ibdev) {
-    CounterMap result;
-    const std::string base =
-        "/sys/class/infiniband/" + ibdev + "/ports/1/hw_counters";
-    DIR* dir = opendir(base.c_str());
-    if (!dir) return result;
+inline void readCountersDir(const std::string& dir,
+                            const std::string& keyPrefix,
+                            CounterMap& out) {
+    DIR* d = opendir(dir.c_str());
+    if (!d) return;
     struct dirent* ent;
-    while ((ent = readdir(dir)) != nullptr) {
+    while ((ent = readdir(d)) != nullptr) {
         if (ent->d_name[0] == '.') continue;
-        std::ifstream f(base + "/" + ent->d_name);
+        std::ifstream f(dir + "/" + ent->d_name);
         long long val = 0;
         if (f >> val)
-            result[ibdev + "/" + ent->d_name] = val;
+            out[keyPrefix + "/" + ent->d_name] = val;
     }
-    closedir(dir);
+    closedir(d);
+}
+
+inline std::vector<std::string> listDirEntries(const std::string& dir) {
+    std::vector<std::string> entries;
+    DIR* d = opendir(dir.c_str());
+    if (!d) return entries;
+    struct dirent* ent;
+    while ((ent = readdir(d)) != nullptr)
+        if (ent->d_name[0] != '.') entries.push_back(ent->d_name);
+    closedir(d);
+    std::sort(entries.begin(), entries.end());
+    return entries;
+}
+
+inline CounterMap readHwCounters(const std::string& ibdev) {
+    CounterMap result;
+    const std::string devBase = "/sys/class/infiniband/" + ibdev;
+    for (const auto& portName : listDirEntries(devBase + "/ports")) {
+        readCountersDir(devBase + "/ports/" + portName + "/hw_counters",
+                        ibdev + "/port" + portName, result);
+    }
+    readCountersDir(devBase + "/hw_counters", ibdev + "/dev", result);
     return result;
 }
 
 inline std::vector<std::string> listIbDevices() {
-    std::vector<std::string> devs;
-    DIR* dir = opendir("/sys/class/infiniband");
-    if (!dir) return devs;
-    struct dirent* ent;
-    while ((ent = readdir(dir)) != nullptr)
-        if (ent->d_name[0] != '.') devs.push_back(ent->d_name);
-    closedir(dir);
-    std::sort(devs.begin(), devs.end());
-    return devs;
+    return listDirEntries("/sys/class/infiniband");
 }
 
 inline CounterMap takeSnapshot() {
@@ -672,6 +685,10 @@ inline CounterMap takeSnapshot() {
         snap.insert(m.begin(), m.end());
     }
     return snap;
+}
+
+inline std::string formatSignedDelta(long long delta) {
+    return (delta >= 0 ? "+" : "") + std::to_string(delta);
 }
 
 inline void printDelta(int rank,
@@ -707,7 +724,7 @@ inline void printDelta(int rank,
         std::cout << "  " << std::left  << std::setw(wName)  << r.name
                   <<         std::right << std::setw(wVal)   << r.vb
                   <<         std::right << std::setw(wVal)   << r.va
-                  <<         std::right << std::setw(wDelta) << ("+" + std::to_string(r.delta))
+                  <<         std::right << std::setw(wDelta) << formatSignedDelta(r.delta)
                   << "\n";
     std::cout << std::flush;
 }

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -310,6 +310,24 @@
         }
       ]
     },
+    "net_ib_cts_stress": {
+      "extends": "net_ib_base",
+      "timeout": 600,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "RCCL_IB_P2P_DISABLE_CTS": "1",
+        "CTS_NUM_CONNS":  "16",
+        "CTS_QP_DEPTH":   "256",
+        "CTS_SNAP_EVERY": "4"
+      },
+      "tests": [
+        {
+          "name": "NetIB_CtsDepthStress",
+          "description": "Stress CTS match-table depth (16 P2P conns x 256 outstanding recvs) and sample hw_counters; with RCCL_IB_P2P_DISABLE_CTS=1 the workaround should keep retx/ack_timeout at 0",
+          "test_filter": "NetIbMPITest.CtsDepthStress"
+        }
+      ]
+    },
     "unit_tests_fixtures": {
       "is_gtest": true,
       "binary": "rccl-UnitTestsFixtures",
@@ -962,6 +980,12 @@
       "name": "NET IB - MultiRecv",
       "description": "irecv(n>1) multi-slot batching tests",
       "config": "net_ib_multirecv",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - CTS Depth Stress",
+      "description": "CTS match-table depth stress / overflow reproducer (AINIC); fully under RCCL_IB_P2P_DISABLE_CTS=1 workaround so passes cleanly on healthy stacks",
+      "config": "net_ib_cts_stress",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -368,6 +368,25 @@
       ]
     },
 
+    "net_ib_cts_stress": {
+      "extends": "net_ib_base",
+      "timeout": 600,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "RCCL_IB_P2P_DISABLE_CTS": "1",
+        "CTS_NUM_CONNS":  "16",
+        "CTS_QP_DEPTH":   "256",
+        "CTS_SNAP_EVERY": "4"
+      },
+      "tests": [
+        {
+          "name": "NetIB_CtsDepthStress",
+          "description": "Stress CTS match-table depth (16 P2P conns x 256 outstanding recvs) and sample hw_counters; with RCCL_IB_P2P_DISABLE_CTS=1 the workaround should keep retx/ack_timeout at 0",
+          "test_filter": "NetIbMPITest.CtsDepthStress"
+        }
+      ]
+    },
+
     "cast_base": {
       "extends": "net_ib_base",
       "env_variables": {
@@ -661,6 +680,12 @@
       "name": "NET IB - MultiRecv",
       "description": "irecv(n>1) multi-slot batching tests",
       "config": "net_ib_multirecv",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - CTS Depth Stress",
+      "description": "CTS match-table depth stress / overflow reproducer (AINIC); fully under RCCL_IB_P2P_DISABLE_CTS=1 workaround so passes cleanly on healthy stacks",
+      "config": "net_ib_cts_stress",
       "enabled": true
     },
     {


### PR DESCRIPTION
## Motivation

RCCL's NET IB transport on AINIC uses a per-connection CTS (Clear-To-Send)
match table to track outstanding receives. When the receiver posts many
outstanding `irecv` requests across a number of P2P connections, that table
can overflow, surfacing as `cts_retx` retransmits / `cts_ack_timeout` spikes
in the device `hw_counters` and an eventual hang in the drain phase.

This PR adds a reproducer test, `CtsDepthStress`, that drives the receiver
into this regime and continuously samples per-device `hw_counters`, so the
overflow point can be observed in CI/dev runs and we have a regression hook
for the upcoming `RCCL_IB_P2P_DISABLE_CTS` / per-connection CTS offload
work.

The test:
- creates `CTS_NUM_CONNS` P2P connections (default 32) with `CTS_QP_DEPTH`
  outstanding recvs each (default 256) — by default 8192 CTS entries in
  flight;
- snapshots `/sys/class/infiniband/<dev>/ports/1/hw_counters` after every
  `CTS_SNAP_EVERY` connections (default 1);
- prints per-step deltas for CTS-relevant counters and an explicit
  `<<< OVERFLOW at ~N entries >>>` marker when `cts_retx_pkts` /
  `cts_ack_timeout` start incrementing;
- always proceeds to the drain phase: with `RCCL_IB_P2P_DISABLE_CTS=0` the
  drain hangs around ~256 entries on AINIC (the observable overflow); with
  `RCCL_IB_P2P_DISABLE_CTS=1` the test passes cleanly.

All `hw_counters` helpers (`CounterMap`, `takeSnapshot`, `printDelta`,
`calcSummary`, `printSummary`, `SnapSummary`) live in the shared
`NetIbMPITestBase.hpp` under the `NetIbCts` namespace so other suites
(`NicFusionTests`, `CastTests`) can reuse them.

## JIRA ID

Resolves AICOMNET-171

## Test Plan


## Test Result


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.