### PR TITLE
[rocshmem] non contiguous parent teams with IPC backend

### DIFF
--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -131,6 +131,7 @@ declare -A TEST_NUMBERS=(
   ["teamctxsharedinfra"]="95"
   ["quiet_on_stream"]="96"
   ["sync_all_on_stream"]="97"
+  ["teamctxsubsetparentinfra"]="98"
 )
 
 ExecTest() {
@@ -612,6 +613,8 @@ TestOther() {
   ExecTest  "teamctxoddeveninfra" 5       1            1
   ExecTest  "teamctxsharedinfra"  2       1            1
   ExecTest  "teamctxsharedinfra"  5       1            1
+  ExecTest  "teamctxsubsetparentinfra" 4  1            1
+  ExecTest  "teamctxsubsetparentinfra" 5  1            1
   unset ROCSHMEM_MAX_NUM_CONTEXTS
 
   ExecTest  "shmemptr"         2       1            1         8

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -477,22 +477,23 @@ void GDABackend::Alltoall_char_inplace (char *inoutbuf, size_t num_bytes, rocshm
 
 //TODO: factorize somewhere else, maybe backend_bc?
 void GDABackend::Allreduce_char_BAND (char* inbuf, char *outbuf, size_t num_bytes,
-                                      Team *team) {
+                                      const TeamInfo& new_team_info_wrt_world,
+                                      int num_pes, int my_pe_in_new_team) {
 
   // Implement an Allreduce outside of MPI. This is specialized for the scenario
   // required for the team creation, i.e. assuming bytes and using BAND operation.
   // Implementation uses an Allgather operation followed a local reduction.
-
-  GDATeam *team_obj = reinterpret_cast<GDATeam *>(team);
-  int num_pes = team_obj->num_pes;
-  std::vector<int> pes_in_world;
+  // Note: Only PEs in the new team call this function.
 
   char *tmp_buffer = new char[num_pes * num_bytes];
   std::memset(tmp_buffer, 0, num_pes * num_bytes);
-  std::memcpy(&tmp_buffer[my_pe * num_bytes], inbuf, num_bytes);
+  std::memcpy(&tmp_buffer[my_pe_in_new_team * num_bytes], inbuf, num_bytes);
 
+  // Build a vector of world ranks for the new team
+  std::vector<int> pes_in_world;
+  pes_in_world.reserve(num_pes);
   for (int i = 0; i < num_pes; i++) {
-    pes_in_world.push_back(team_obj->get_pe_in_world(i));
+    pes_in_world.push_back(new_team_info_wrt_world.pe_start + i * new_team_info_wrt_world.stride);
   }
   backend_bootstr->groupAllGather(tmp_buffer, num_bytes, pes_in_world);
 
@@ -510,17 +511,18 @@ void GDABackend::create_new_team([[maybe_unused]] Team *parent_team,
                                 const TeamInfo& team_info_wrt_parent,
                                 const TeamInfo& team_info_wrt_world,
                                 int num_pes, int my_pe_in_new_team,
-                                MPI_Comm team_comm,
+                                MPI_Comm new_team_comm,
                                 rocshmem_team_t *new_team) {
   /**
    * Read the bit mask and find out a common index into
    * the pool of available work arrays.
    */
-  if (team_comm != MPI_COMM_NULL) {
+  if (new_team_comm != MPI_COMM_NULL) {
     NET_CHECK(mpilib_ftable_.Allreduce(team_pool_bitmask_, team_reduced_bitmask_, team_bitmask_size_,
-                            MPI_CHAR, MPI_BAND, team_comm));
+                            MPI_CHAR, MPI_BAND, new_team_comm));
   } else {
-    Allreduce_char_BAND (team_pool_bitmask_, team_reduced_bitmask_, team_bitmask_size_, parent_team);
+    Allreduce_char_BAND (team_pool_bitmask_, team_reduced_bitmask_, team_bitmask_size_,
+                         team_info_wrt_world, num_pes, my_pe_in_new_team);
   }
 
   /* Pick the least significant non-zero bit (logical layout) in the reduced
@@ -545,7 +547,7 @@ void GDABackend::create_new_team([[maybe_unused]] Team *parent_team,
   CHECK_HIP(hipMalloc(&new_team_obj, sizeof(GDATeam)));
   new (new_team_obj)
       GDATeam(this, team_info_wrt_parent, team_info_wrt_world, num_pes,
-                my_pe_in_new_team, team_comm, common_index);
+                my_pe_in_new_team, new_team_comm, common_index);
 
   *new_team = get_external_team(new_team_obj);
 }

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -490,12 +490,12 @@ void GDABackend::Allreduce_char_BAND (char* inbuf, char *outbuf, size_t num_byte
   std::memcpy(&tmp_buffer[my_pe_in_new_team * num_bytes], inbuf, num_bytes);
 
   // Build a vector of world ranks for the new team
-  std::vector<int> pes_in_world;
-  pes_in_world.reserve(num_pes);
+  std::vector<int> world_ranks;
+  world_ranks.reserve(num_pes);
   for (int i = 0; i < num_pes; i++) {
-    pes_in_world.push_back(new_team_info_wrt_world.pe_start + i * new_team_info_wrt_world.stride);
+    world_ranks.push_back(new_team_info_wrt_world.pe_start + i * new_team_info_wrt_world.stride);
   }
-  backend_bootstr->groupAllGather(tmp_buffer, num_bytes, pes_in_world);
+  backend_bootstr->groupAllGather(tmp_buffer, num_bytes, world_ranks);
 
   for (size_t i = 0; i < num_bytes; i++) {
     outbuf[i] = tmp_buffer[i];

--- a/projects/rocshmem/src/gda/backend_gda.hpp
+++ b/projects/rocshmem/src/gda/backend_gda.hpp
@@ -259,7 +259,7 @@ class GDABackend : public Backend {
   void create_new_team(Team *parent_team,
                        const TeamInfo& team_info_wrt_parent,
                        const TeamInfo& team_info_wrt_world, int num_pes,
-                       int my_pe_in_new_team, MPI_Comm team_comm,
+                       int my_pe_in_new_team, MPI_Comm new_team_comm,
                        rocshmem_team_t *new_team) override;
 
   /**
@@ -588,7 +588,9 @@ class GDABackend : public Backend {
   /**
    * @brief rte allreduce for teams
    */
-  void Allreduce_char_BAND (char* inbuf, char *outbuf, size_t num_bytes, Team *team);
+  void Allreduce_char_BAND (char* inbuf, char *outbuf, size_t num_bytes,
+                            const TeamInfo& new_team_info_wrt_world,
+                            int num_pes, int my_pe_in_new_team);
 
   /**
    * @brief rte barrier for initialization

--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -23,6 +23,7 @@
  *****************************************************************************/
 
 #include <cstring>
+#include <vector>
 
 #include <hip/hip_runtime.h>
 #include <cstdlib>
@@ -263,10 +264,20 @@ void IPCBackend::Allreduce_char_BAND (char* inbuf, char *outbuf, size_t num_byte
   std::memset(tmp_buffer, 0, num_pes * num_bytes);
   std::memcpy (&tmp_buffer[my_pe * num_bytes], inbuf, num_bytes);
 
-  if (num_pes == backend_bootstr->getNranks() ) {
+  TeamInfo *tinfo = team_obj->tinfo_wrt_world;
+
+  // Fast path: team is TEAM_WORLD (all PEs in identity order)
+  if (num_pes == backend_bootstr->getNranks() &&
+      tinfo->pe_start == 0 && tinfo->stride == 1) {
     backend_bootstr->allGather(tmp_buffer, num_bytes);
   } else {
-    LOG_ERROR_ABORT("create_new_team: non-mpi version only supports parent_teams that contain all processes");
+    // Build a vector of world ranks for this team using team_info_wrt_world
+    std::vector<int> world_ranks;
+    world_ranks.reserve(num_pes);
+    for (int i = 0; i < num_pes; i++) {
+      world_ranks.push_back(tinfo->pe_start + i * tinfo->stride);
+    }
+    backend_bootstr->groupAllGather(tmp_buffer, num_bytes, world_ranks);
   }
 
   for (size_t i = 0; i < num_bytes; i++) {

--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -250,32 +250,28 @@ void IPCBackend::team_destroy(rocshmem_team_t team) {
 }
 
 void IPCBackend::Allreduce_char_BAND (char* inbuf, char *outbuf, size_t num_bytes,
-                                      Team *team) {
+                                      const TeamInfo& new_team_info_wrt_world,
+                                      int num_pes, int my_pe_in_new_team) {
 
   // Implement an Allreduce outside of MPI. This is specialized for the scenario
   // required for the team creation, i.e. assuming bytes and using BAND operation.
   // Implementation uses an Allgather operation followed a local reduction.
-
-  IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
-  int num_pes = team_obj->num_pes;
-  int my_pe = team_obj->my_pe;
+  // Note: Only PEs in the new team call this function.
 
   char *tmp_buffer = new char[num_pes * num_bytes];
   std::memset(tmp_buffer, 0, num_pes * num_bytes);
-  std::memcpy (&tmp_buffer[my_pe * num_bytes], inbuf, num_bytes);
+  std::memcpy (&tmp_buffer[my_pe_in_new_team * num_bytes], inbuf, num_bytes);
 
-  TeamInfo *tinfo = team_obj->tinfo_wrt_world;
-
-  // Fast path: team is TEAM_WORLD (all PEs in identity order)
+  // Fast path: new team is TEAM_WORLD (all PEs in identity order)
   if (num_pes == backend_bootstr->getNranks() &&
-      tinfo->pe_start == 0 && tinfo->stride == 1) {
+      new_team_info_wrt_world.pe_start == 0 && new_team_info_wrt_world.stride == 1) {
     backend_bootstr->allGather(tmp_buffer, num_bytes);
   } else {
-    // Build a vector of world ranks for this team using team_info_wrt_world
+    // Build a vector of world ranks for the new team
     std::vector<int> world_ranks;
     world_ranks.reserve(num_pes);
     for (int i = 0; i < num_pes; i++) {
-      world_ranks.push_back(tinfo->pe_start + i * tinfo->stride);
+      world_ranks.push_back(new_team_info_wrt_world.pe_start + i * new_team_info_wrt_world.stride);
     }
     backend_bootstr->groupAllGather(tmp_buffer, num_bytes, world_ranks);
   }
@@ -294,17 +290,18 @@ void IPCBackend::create_new_team([[maybe_unused]] Team *parent_team,
                                 const TeamInfo& team_info_wrt_parent,
                                 const TeamInfo& team_info_wrt_world,
                                 int num_pes, int my_pe_in_new_team,
-                                MPI_Comm team_comm,
+                                MPI_Comm new_team_comm,
                                 rocshmem_team_t *new_team) {
   /**
    * Read the bit mask and find out a common index into
    * the pool of available work arrays.
    */
-  if (team_comm != MPI_COMM_NULL) {
+  if (new_team_comm != MPI_COMM_NULL) {
     NET_CHECK(mpilib_ftable_.Allreduce(team_pool_bitmask_, team_reduced_bitmask_, team_bitmask_size_,
-                                       MPI_CHAR, MPI_BAND, team_comm));
+                                       MPI_CHAR, MPI_BAND, new_team_comm));
   } else {
-    Allreduce_char_BAND (team_pool_bitmask_, team_reduced_bitmask_, team_bitmask_size_, parent_team);
+    Allreduce_char_BAND (team_pool_bitmask_, team_reduced_bitmask_, team_bitmask_size_,
+                         team_info_wrt_world, num_pes, my_pe_in_new_team);
   }
 
   /* Pick the least significant non-zero bit (logical layout) in the reduced
@@ -328,7 +325,7 @@ void IPCBackend::create_new_team([[maybe_unused]] Team *parent_team,
   CHECK_HIP(hipMalloc(&new_team_obj, sizeof(IPCTeam)));
   new (new_team_obj)
       IPCTeam(this, team_info_wrt_parent, team_info_wrt_world, num_pes,
-                my_pe_in_new_team, team_comm, common_index);
+                my_pe_in_new_team, new_team_comm, common_index);
 
   *new_team = get_external_team(new_team_obj);
 }

--- a/projects/rocshmem/src/ipc/backend_ipc.hpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.hpp
@@ -100,7 +100,7 @@ class IPCBackend : public Backend {
   void create_new_team(Team *parent_team,
                        const TeamInfo& team_info_wrt_parent,
                        const TeamInfo& team_info_wrt_world, int num_pes,
-                       int my_pe_in_new_team, MPI_Comm team_comm,
+                       int my_pe_in_new_team, MPI_Comm new_team_comm,
                        rocshmem_team_t *new_team) override;
 
   /**
@@ -307,7 +307,9 @@ class IPCBackend : public Backend {
   /**
    * @brief
    */
-  void Allreduce_char_BAND (char* inbuf, char *outbuf, size_t num_bytes, Team *team);
+  void Allreduce_char_BAND (char* inbuf, char *outbuf, size_t num_bytes,
+                            const TeamInfo& new_team_info_wrt_world,
+                            int num_pes, int my_pe_in_new_team);
 
 };
 

--- a/projects/rocshmem/src/reverse_offload/backend_ro.cpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.cpp
@@ -276,11 +276,11 @@ void ROBackend::create_new_team(Team *parent_team,
                                 const TeamInfo& team_info_wrt_parent,
                                 const TeamInfo& team_info_wrt_world,
                                 int num_pes, int my_pe_in_new_team,
-                                MPI_Comm team_comm,
+                                MPI_Comm new_team_comm,
                                 rocshmem_team_t *new_team) {
   transport_->createNewTeam(this, parent_team, team_info_wrt_parent,
                             team_info_wrt_world, num_pes, my_pe_in_new_team,
-                            team_comm, new_team);
+                            new_team_comm, new_team);
 }
 
 void ROBackend::ctx_create(int64_t options, void **ctx) {

--- a/projects/rocshmem/src/reverse_offload/backend_ro.hpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.hpp
@@ -96,7 +96,7 @@ class ROBackend : public Backend {
   void create_new_team(Team *parent_team,
                        const TeamInfo& team_info_wrt_parent,
                        const TeamInfo& team_info_wrt_world, int num_pes,
-                       int my_pe_in_new_team, MPI_Comm team_comm,
+                       int my_pe_in_new_team, MPI_Comm new_team_comm,
                        rocshmem_team_t *new_team) override;
 
   /**

--- a/projects/rocshmem/src/reverse_offload/mpi_transport.cpp
+++ b/projects/rocshmem/src/reverse_offload/mpi_transport.cpp
@@ -254,14 +254,14 @@ void MPITransport::createNewTeam(ROBackend *backend, [[maybe_unused]] Team *pare
                                    const TeamInfo& team_info_wrt_parent,
                                    const TeamInfo& team_info_wrt_world,
                                    int num_pes, int my_pe_in_new_team,
-                                   MPI_Comm team_comm,
+                                   MPI_Comm new_team_comm,
                                    rocshmem_team_t *new_team) {
   ROTeam *new_team_obj{nullptr};
 
   CHECK_HIP(hipMalloc(&new_team_obj, sizeof(ROTeam)));
 
   new (new_team_obj) ROTeam(backend, team_info_wrt_parent, team_info_wrt_world,
-                            num_pes, my_pe_in_new_team, team_comm);
+                            num_pes, my_pe_in_new_team, new_team_comm);
 
   *new_team = get_external_team(new_team_obj);
 }

--- a/projects/rocshmem/src/reverse_offload/mpi_transport.hpp
+++ b/projects/rocshmem/src/reverse_offload/mpi_transport.hpp
@@ -51,7 +51,7 @@ public:
   void createNewTeam(ROBackend *backend, Team *parent_team,
                      const TeamInfo& team_info_wrt_parent,
                      const TeamInfo& team_info_wrt_world, int num_pes,
-                     int my_pe_in_new_team, MPI_Comm team_comm,
+                     int my_pe_in_new_team, MPI_Comm new_team_comm,
                      rocshmem_team_t *new_team) override;
 
   void barrier(int contextId, volatile char *status, bool blocking,

--- a/projects/rocshmem/src/reverse_offload/transport.hpp
+++ b/projects/rocshmem/src/reverse_offload/transport.hpp
@@ -48,7 +48,7 @@ class Transport {
   virtual void createNewTeam(ROBackend *backend_handle, Team *parent_team,
                              const TeamInfo& team_info_wrt_parent,
                              const TeamInfo& team_info_wrt_world, int num_pes,
-                             int my_pe_in_new_team, MPI_Comm team_comm,
+                             int my_pe_in_new_team, MPI_Comm new_team_comm,
                              rocshmem_team_t *new_team) = 0;
 
   virtual void barrier(int wg_id, volatile char *status, bool blocking,

--- a/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.cpp
@@ -334,6 +334,7 @@ void TeamCtxInfraTester::postLaunchKernel() {
   if (_splitType == ROCSHMEM_TEST_TEAM_SUBSET_PARENT &&
       subset_parent_team != ROCSHMEM_TEAM_INVALID) {
     rocshmem_team_destroy(subset_parent_team);
+    subset_parent_team = ROCSHMEM_TEAM_INVALID;
   }
 }
 

--- a/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.cpp
@@ -261,7 +261,8 @@ void TeamCtxInfraTester::preLaunchKernel() {
     _expected_pe = rocshmem_team_my_pe(ROCSHMEM_TEAM_SHARED);
     _expected_n_pes = rocshmem_team_n_pes(ROCSHMEM_TEAM_SHARED);
   } else if (_splitType == ROCSHMEM_TEST_TEAM_SUBSET_PARENT) {
-    // First create a subset parent team (odd-numbered PEs only)
+    // First create a subset parent team via parity-based partition:
+    // even PEs create team {0,2,4,...}, odd PEs create team {1,3,5,...}
     int start_pe = (my_pe % 2) == 0 ? 0 : 1;
     int num_pes = n_pes / 2;
     if (((n_pes % 2) != 0) && ((my_pe % 2) == 0))
@@ -275,7 +276,7 @@ void TeamCtxInfraTester::preLaunchKernel() {
       abort();
     }
 
-    // Now split this subset team into two halves
+    // Now split this subset parent team into two halves
     int subset_n_pes = rocshmem_team_n_pes(subset_parent_team);
     int subset_my_pe = rocshmem_team_my_pe(subset_parent_team);
     int mid_pe = subset_n_pes / 2;

--- a/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.cpp
@@ -260,6 +260,44 @@ void TeamCtxInfraTester::preLaunchKernel() {
     team_world_dup[0] = ROCSHMEM_TEAM_SHARED;
     _expected_pe = rocshmem_team_my_pe(ROCSHMEM_TEAM_SHARED);
     _expected_n_pes = rocshmem_team_n_pes(ROCSHMEM_TEAM_SHARED);
+  } else if (_splitType == ROCSHMEM_TEST_TEAM_SUBSET_PARENT) {
+    // First create a subset parent team (odd-numbered PEs only)
+    int start_pe = (my_pe % 2) == 0 ? 0 : 1;
+    int num_pes = n_pes / 2;
+    if (((n_pes % 2) != 0) && ((my_pe % 2) == 0))
+      num_pes++;
+
+    rocshmem_team_split_strided(_parentTeam, start_pe, 2, num_pes, nullptr, 0,
+                                &subset_parent_team);
+
+    if (subset_parent_team == ROCSHMEM_TEAM_INVALID) {
+      printf("ROCSHMEM_TEST_TEAM_SUBSET_PARENT: Failed to create subset parent team!\n");
+      abort();
+    }
+
+    // Now split this subset team into two halves
+    int subset_n_pes = rocshmem_team_n_pes(subset_parent_team);
+    int subset_my_pe = rocshmem_team_my_pe(subset_parent_team);
+    int mid_pe = subset_n_pes / 2;
+    int subset_start_pe  = subset_my_pe < mid_pe ? 0 : mid_pe;
+    int subset_end_pe = subset_my_pe < mid_pe ? (mid_pe - 1) : (subset_n_pes - 1);
+    int subset_num_pes = subset_end_pe - subset_start_pe + 1;
+    int new_pe =  subset_my_pe < mid_pe ? subset_my_pe : (subset_my_pe - subset_start_pe);
+
+    rocshmem_team_split_strided(subset_parent_team, subset_start_pe, 1, subset_num_pes, nullptr, 0,
+                                &team_world_dup[0]);
+    _expected_pe = rocshmem_team_my_pe(team_world_dup[0]);
+    _expected_n_pes = rocshmem_team_n_pes(team_world_dup[0]);
+
+    if (_expected_n_pes != subset_num_pes) {
+      printf("ROCSHMEM_TEST_TEAM_SUBSET_PARENT: n_pes %d expected: %d\n", _expected_n_pes, subset_num_pes);
+      abort();
+    }
+
+    if (_expected_pe != new_pe) {
+      printf("ROCSHMEM_TEST_TEAM_SUBSET_PARENT: my_pe %d expected: %d\n", _expected_pe, new_pe);
+      abort();
+    }
   }
 }
 
@@ -277,7 +315,8 @@ void TeamCtxInfraTester::launchKernel(dim3 gridSize, dim3 blockSize, [[maybe_unu
   } else if (_splitType == ROCSHMEM_TEST_TEAM_SINGLE ||
              _splitType == ROCSHMEM_TEST_TEAM_BLOCK  ||
              _splitType == ROCSHMEM_TEST_TEAM_ODDEVEN ||
-             _splitType == ROCSHMEM_TEST_TEAM_SHARED ) {
+             _splitType == ROCSHMEM_TEST_TEAM_SHARED ||
+             _splitType == ROCSHMEM_TEST_TEAM_SUBSET_PARENT ) {
     hipLaunchKernelGGL(TeamCtxInfraSimpleTest, gridSize, blockSize, shared_bytes,
                        stream, _shmem_context, team_world_dup[0], _expected_pe, _expected_n_pes);
   }
@@ -289,6 +328,12 @@ void TeamCtxInfraTester::postLaunchKernel() {
   int teams_to_destroy = _splitType == ROCSHMEM_TEST_TEAM_DUP ? num_teams : 1;
   for (int team_i = 0; team_i < teams_to_destroy; team_i++) {
     rocshmem_team_destroy(team_world_dup[team_i]);
+  }
+
+  // Destroy the subset parent team if it was created
+  if (_splitType == ROCSHMEM_TEST_TEAM_SUBSET_PARENT &&
+      subset_parent_team != ROCSHMEM_TEAM_INVALID) {
+    rocshmem_team_destroy(subset_parent_team);
   }
 }
 

--- a/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.hpp
@@ -62,6 +62,7 @@ class TeamCtxInfraTester : public Tester {
    */
   int num_teams = 40;
   rocshmem::rocshmem_team_t *team_world_dup = nullptr;
+  rocshmem::rocshmem_team_t subset_parent_team = rocshmem::ROCSHMEM_TEAM_INVALID;
   bool _skip_shared = false;
 };
 

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -236,6 +236,11 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
       args.team_type = ROCSHMEM_TEST_TEAM_SHARED;
       testers.push_back(new TeamCtxInfraTester(args));
       break;
+    case TeamCtxSubsetParentInfraTestType:
+      test_name = "Team Ctx Infra Subset Parent test";
+      args.team_type = ROCSHMEM_TEST_TEAM_SUBSET_PARENT;
+      testers.push_back(new TeamCtxInfraTester(args));
+      break;
     case TeamCtxGetTestType:
       test_name = "Blocking Team Ctx Gets";
       testers.push_back(new TeamCtxPrimitiveTester(args));
@@ -713,7 +718,8 @@ void Tester::execute() {
         _type != TeamCtxInfraSingleTestType &&
         _type != TeamCtxInfraBlockTestType  &&
         _type != TeamCtxInfraOddEvenTestType &&
-        _type != TeamCtxSharedInfraTestType ) {
+        _type != TeamCtxSharedInfraTestType &&
+        _type != TeamCtxSubsetParentInfraTestType ) {
       print(size);
     }
   }
@@ -736,6 +742,7 @@ bool Tester::peLaunchesKernel() {
     case TeamCtxInfraBlockTestType:
     case TeamCtxInfraOddEvenTestType:
     case TeamCtxSharedInfraTestType:
+    case TeamCtxSubsetParentInfraTestType:
     case TeamAllToAllTestType:
     case TeamAllToAllvTestType:
     case TeamFCollectTestType:

--- a/projects/rocshmem/tests/functional_tests/tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/tester.hpp
@@ -139,7 +139,8 @@
   X(LibraryInfo,               94)  \
   X(TeamCtxSharedInfra,        95)  \
   X(QuietOnStream,             96)  \
-  X(SyncAllOnStream,           97)
+  X(SyncAllOnStream,           97)  \
+  X(TeamCtxSubsetParentInfra,  98)
 
 #define _ROCSHMEM_ENUM_ENTRY(name, val) name##TestType = val,
 enum TestType {

--- a/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
@@ -210,6 +210,7 @@ TesterArguments::TesterArguments(int argc, char *argv[]) {
     case TeamCtxInfraSingleTestType:
     case TeamCtxInfraBlockTestType:
     case TeamCtxInfraOddEvenTestType:
+    case TeamCtxSubsetParentInfraTestType:
       max_msg_size = min_msg_size;
       break;
     case PutNBIMRTestType:
@@ -286,6 +287,7 @@ void TesterArguments::get_arguments() {
     case TeamWGBarrierTestType:
     case TeamCtxInfraBlockTestType:
     case TeamCtxInfraOddEvenTestType:
+    case TeamCtxSubsetParentInfraTestType:
     // On-stream tests - support any number of PEs
     case TeamAlltoallmemOnStreamTestType:
     case BarrierAllOnStreamTestType:

--- a/projects/rocshmem/tests/functional_tests/tester_arguments.hpp
+++ b/projects/rocshmem/tests/functional_tests/tester_arguments.hpp
@@ -38,6 +38,7 @@ enum TeamSplitType {
   ROCSHMEM_TEST_TEAM_BLOCK,      // split parent into two halves
   ROCSHMEM_TEST_TEAM_ODDEVEN,    // odd-even splitting
   ROCSHMEM_TEST_TEAM_SHARED,     // predefined ROCSHMEM_TEAM_SHARED
+  ROCSHMEM_TEST_TEAM_SUBSET_PARENT, // split a subset parent team (not TEAM_WORLD)
 };
 
 enum UserBufType {


### PR DESCRIPTION
## Motivation

The IPC backend in rocshmem did not support the scenario where created a team from a parent team that did not have a full set of PEs of TEAM_WORLD. This commit fixes this issue, and also adds some tests to the functional tests suite to evaluate this feature.

## Technical Details


## JIRA ID

AIROCSHMEM-134

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
