### PR TITLE
rocr/aie: AIE queue metadata to support KMQ

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -240,6 +240,11 @@ static hsa_status_t xdna_ioctl(int fd, unsigned long request, void* arg) {
   }
 }
 
+/// @brief Metadata for a Kernel Mode Queue (KMQ).
+struct KmqQueueMetadata {
+  uint32_t hw_ctx_handle;
+};
+
 /**
  * @brief Flushes the CPU cache for the packet's arguments.
  *
@@ -612,9 +617,24 @@ hsa_status_t XdnaDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint
                                      HSA::hsa_amd_queue_priority_internal_t priority, uint32_t sdma_engine_id,
                                      void* queue_addr, uint64_t queue_size_bytes, uint64_t queue_metadata_size_bytes,
                                      HsaEvent* event, HsaQueueResource& queue_resource) const {
-  if (queue_resource.QueueId != AMDXDNA_INVALID_CTX_HANDLE) {
-    return HSA_STATUS_ERROR;
-  }
+  // Driver doesn't support user-mode queues.
+  return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
+}
+
+hsa_status_t XdnaDriver::UpdateQueue(HSA_QUEUEID queue_id, uint32_t queue_pct,
+                                     HSA::hsa_amd_queue_priority_internal_t priority,
+                                     void* queue_addr, uint64_t queue_size, HsaEvent* event) const {
+  // Driver doesn't support queue updates.
+  return HSA_STATUS_ERROR_INVALID_QUEUE;
+}
+
+hsa_status_t XdnaDriver::DestroyQueue(HSA_QUEUEID queue_id) const {
+  // Driver doesn't support user-mode queues.
+  return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
+}
+
+hsa_status_t XdnaDriver::CreateKernelModeQueue(size_t queue_size, void** metadata) const {
+  auto queue_metadata = std::make_unique<KmqQueueMetadata>();
 
   // Create QoS information. Currently we do not leverage this information.
   amdxdna_qos_info qos_info = {};
@@ -648,29 +668,22 @@ hsa_status_t XdnaDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint
     return err;
   }
 
-  queue_resource.QueueId = static_cast<HSA_QUEUEID>(create_hwctx_args.handle);
+  queue_metadata->hw_ctx_handle = create_hwctx_args.handle;
+  *metadata = queue_metadata.release();
 
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::DestroyQueue(HSA_QUEUEID queue_id) const {
-  auto hw_ctx_handle = static_cast<uint32_t>(queue_id);
-  if (hw_ctx_handle == AMDXDNA_INVALID_CTX_HANDLE) {
+hsa_status_t XdnaDriver::DestroyKernelModeQueue(void* metadata) const {
+  std::unique_ptr<KmqQueueMetadata> queue_metadata;
+  queue_metadata.reset(static_cast<KmqQueueMetadata*>(metadata));
+
+  if (queue_metadata->hw_ctx_handle == AMDXDNA_INVALID_CTX_HANDLE) {
     return HSA_STATUS_ERROR_INVALID_QUEUE;
   }
 
-  // Drop PDI cache.
-  const_cast<std::unordered_map<HSA_QUEUEID, PDICache>&>(queue_pdi_map_).erase(queue_id);
-
   // Destroy hardware context associated with the queue.
-  return DestroyHwCtx(fd_, hw_ctx_handle);
-}
-
-hsa_status_t XdnaDriver::UpdateQueue(HSA_QUEUEID queue_id, uint32_t queue_pct,
-                                     HSA::hsa_amd_queue_priority_internal_t priority, void* queue_addr,
-                                     uint64_t queue_size, HsaEvent* event) const {
-  // AIE doesn't support queue updates.
-  return HSA_STATUS_ERROR_INVALID_QUEUE;
+  return DestroyHwCtx(fd_, queue_metadata->hw_ctx_handle);
 }
 
 hsa_status_t XdnaDriver::SetQueueCUMask(HSA_QUEUEID queue_id, uint32_t cu_mask_count,
@@ -921,9 +934,10 @@ hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) {
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
-                                        uint64_t first_pkt_idx, uint64_t num_pkts,
-                                        uint32_t num_core_tiles) {
+hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, void* kmq_metadata, uint64_t first_pkt_idx,
+                                        uint64_t num_pkts, uint32_t num_core_tiles) {
+  auto queue_metadata = static_cast<KmqQueueMetadata*>(kmq_metadata);
+
   // Instruction and arguments BOs (performance hint: up to 3 argument BOs per packet).
   std::vector<uint32_t> bo_handles;
   bo_handles.reserve(num_pkts * 4);
@@ -941,7 +955,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
   // PDI cache to avoid reconfiguration. If the cache is empty or updated, a new hardware context
   // will be created for the queue.
   PDICache pdi_cache;
-  auto pdi_cache_it = queue_pdi_map_.find(queue_id);
+  auto pdi_cache_it = queue_pdi_map_.find(queue_metadata->hw_ctx_handle);
   if (pdi_cache_it != queue_pdi_map_.end()) {
     pdi_cache = pdi_cache_it->second;
   }
@@ -1037,12 +1051,12 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
     if (pdi_cache_it != queue_pdi_map_.end()) {
       queue_pdi_map_.erase(pdi_cache_it);
     }
-    hsa_status_t status = ConfigHwCtx(pdi_cache, queue_id, num_core_tiles);
+    hsa_status_t status = ConfigHwCtx(pdi_cache, queue_metadata, num_core_tiles);
     if (status != HSA_STATUS_SUCCESS) {
       assert(false && "Failed to configure hardware context for queue.");
       return status;
     }
-    queue_pdi_map_.emplace(queue_id, pdi_cache);
+    queue_pdi_map_.emplace(queue_metadata->hw_ctx_handle, pdi_cache);
   }
 
   // Remove duplicate BOs, since the driver reports an error if the same BO is provided multiple
@@ -1057,19 +1071,17 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
     FlushArguments(pkt);
   }
 
-  auto hw_ctx_handle = static_cast<uint32_t>(queue_id);
-
   if (num_pkts == 1) {
     // Single packet: submit the per-kernel cmd BO directly, no chain wrapper.
     uint64_t seq = 0;
-    hsa_status_t status =
-        SubmitCommand(fd_, cmd_bo_handles[0].handle, bo_handles, hw_ctx_handle, seq);
+    hsa_status_t status = SubmitCommand(fd_, cmd_bo_handles[0].handle, bo_handles,
+                                        queue_metadata->hw_ctx_handle, seq);
     if (status != HSA_STATUS_SUCCESS) {
       assert(false && "Failed to submit command.");
       return status;
     }
     status = WaitCommand(fd_, static_cast<ert_start_kernel_cmd*>(cmd_bo_handles[0].vaddr),
-                         hw_ctx_handle, seq);
+                         queue_metadata->hw_ctx_handle, seq);
     if (status != HSA_STATUS_SUCCESS) {
       assert(false && "Failed waiting for command.");
       return status;
@@ -1100,13 +1112,14 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id,
 
     // Execute all commands in the command chain.
     uint64_t seq = 0;
-    status = SubmitCommand(fd_, cmd_bo_handle.handle, bo_handles, hw_ctx_handle, seq);
+    status =
+        SubmitCommand(fd_, cmd_bo_handle.handle, bo_handles, queue_metadata->hw_ctx_handle, seq);
     if (status != HSA_STATUS_SUCCESS) {
       assert(false && "Failed to submit command chain.");
       return status;
     }
     status = WaitCommand(fd_, static_cast<ert_start_kernel_cmd*>(cmd_bo_handle.vaddr),
-                         hw_ctx_handle, seq);
+                         queue_metadata->hw_ctx_handle, seq);
     if (status != HSA_STATUS_SUCCESS) {
       assert(false && "Failed waiting for command chain.");
       return status;
@@ -1218,8 +1231,10 @@ XdnaDriver::BOHandle XdnaDriver::FindBOHandle(void* mem) const {
   return it->second;
 }
 
-hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, HSA_QUEUEID& queue_id,
+hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, void* kmq_metadata,
                                      uint32_t num_core_tiles) const {
+  auto queue_metadata = static_cast<KmqQueueMetadata*>(kmq_metadata);
+
   const size_t config_cu_param_size =
       sizeof(amdxdna_hwctx_param_config_cu) + pdi_bo_handles.size() * sizeof(amdxdna_cu_config);
 
@@ -1238,17 +1253,15 @@ hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, HSA_QUEUEID
     xdna_config_cu_param->cu_configs[i].cu_func = default_cu_func;
   }
 
-  auto hw_ctx_handle = static_cast<uint32_t>(queue_id);
-
   // Destroy the hardware context
   // Note: we can do this because we have forced synchronization between command chains. If we move
   // to a more asynchronous model, we will need to figure out how hardware context destruction works
   // while applications are running.
-  hsa_status_t err = DestroyHwCtx(fd_, hw_ctx_handle);
+  hsa_status_t err = DestroyHwCtx(fd_, queue_metadata->hw_ctx_handle);
   if (err != HSA_STATUS_SUCCESS) {
     return err;
   }
-  queue_id = AMDXDNA_INVALID_CTX_HANDLE;
+  queue_metadata->hw_ctx_handle = AMDXDNA_INVALID_CTX_HANDLE;
 
   // Create the new hardware context
   // Currently we do not leverage QoS information.
@@ -1274,7 +1287,7 @@ hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, HSA_QUEUEID
     return err;
   }
 
-  queue_id = create_hwctx_args.handle;
+  queue_metadata->hw_ctx_handle = create_hwctx_args.handle;
 
   return HSA_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -395,7 +395,7 @@ static hsa_status_t WaitCommand(int fd, ert_start_kernel_cmd* cmd, uint32_t hw_c
     timeline_wait.points = reinterpret_cast<uintptr_t>(&seq);
     timeline_wait.count_handles = 1;
     timeline_wait.timeout_nsec = INT64_MAX;
-    timeline_wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL;
+    timeline_wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL | DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT;
     hsa_status_t err = xdna_ioctl(fd, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &timeline_wait);
     if (err != HSA_STATUS_SUCCESS) {
       return err;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -292,8 +292,8 @@ class PDICache {
 };
 
 /// @brief Metadata for a Kernel Mode Queue (KMQ).
-struct KmqQueueMetadata {
-  uint32_t hw_ctx_handle;
+struct KmqMetadata {
+  uint32_t hw_ctx_handle = AMDXDNA_INVALID_CTX_HANDLE;
   uint32_t syncobj_handle = 0;
   PDICache pdi_cache;
 };
@@ -326,6 +326,73 @@ static hsa_status_t DestroyHwCtx(int fd, uint32_t hw_ctx_handle) {
   amdxdna_drm_destroy_hwctx args = {};
   args.handle = hw_ctx_handle;
   return xdna_ioctl(fd, DRM_IOCTL_AMDXDNA_DESTROY_HWCTX, &args);
+}
+
+/// @brief Creates and configures a hardware context for the KMQ, and updates the KMQ metadata.
+///
+/// @param[in] fd driver file descriptor
+/// @param[in] num_core_tiles number of core tiles to configure the hardware context with
+/// @param[in,out] kmq_metadata KMQ metadata to update with the hardware context handle and syncobj
+/// handle
+static hsa_status_t CreateHwCtx(int fd, uint32_t num_core_tiles, KmqMetadata* kmq_metadata) {
+  // Create the new hardware context; we do not leverage QoS information
+  amdxdna_qos_info qos_info = {};
+  amdxdna_drm_create_hwctx create_hwctx_args = {};
+  create_hwctx_args.qos_p = reinterpret_cast<uintptr_t>(&qos_info);
+  create_hwctx_args.max_opc = 0x800;
+  create_hwctx_args.num_tiles = num_core_tiles;
+  hsa_status_t err = xdna_ioctl(fd, DRM_IOCTL_AMDXDNA_CREATE_HWCTX, &create_hwctx_args);
+  if (err != HSA_STATUS_SUCCESS) {
+    assert(false && "Failed to create hardware context for KMQ");
+    return err;
+  }
+
+  // Create hardware context configuration
+  const size_t num_cus = kmq_metadata->pdi_cache.empty() ? 1 : kmq_metadata->pdi_cache.size();
+  const size_t config_cu_param_size =
+      sizeof(amdxdna_hwctx_param_config_cu) + num_cus * sizeof(amdxdna_cu_config);
+
+  auto* xdna_config_cu_param =
+      static_cast<amdxdna_hwctx_param_config_cu*>(malloc(config_cu_param_size));
+  if (xdna_config_cu_param == nullptr) {
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
+  MAKE_SCOPE_GUARD([xdna_config_cu_param] { free(xdna_config_cu_param); });
+  memset(xdna_config_cu_param, 0, config_cu_param_size);
+
+  if (!kmq_metadata->pdi_cache.empty()) {
+    xdna_config_cu_param->num_cus = kmq_metadata->pdi_cache.size();
+    for (size_t i = 0; i < kmq_metadata->pdi_cache.size(); i++) {
+      xdna_config_cu_param->cu_configs[i].cu_bo = kmq_metadata->pdi_cache[i];
+      xdna_config_cu_param->cu_configs[i].cu_func = default_cu_func;
+    }
+  } else {
+    // If the PDI cache is empty, it means we have not allocated any CU configuration BOs yet. Still
+    // need to configure the hardware context with at least 1 CU, so we set the cu_bo of the first
+    // CU config to 0, which is an invalid BO handle but indicates to the driver that we want to use
+    // the default CU configuration.
+    xdna_config_cu_param->num_cus = 1;
+    xdna_config_cu_param->cu_configs[0].cu_bo = 0;
+    xdna_config_cu_param->cu_configs[0].cu_func = default_cu_func;
+  }
+
+  // Configure the new hardware context
+  amdxdna_drm_config_hwctx config_hw_ctx_args = {};
+  config_hw_ctx_args.handle = create_hwctx_args.handle;
+  config_hw_ctx_args.param_type = DRM_AMDXDNA_HWCTX_CONFIG_CU;
+  config_hw_ctx_args.param_val = reinterpret_cast<uint64_t>(xdna_config_cu_param);
+  config_hw_ctx_args.param_val_size = static_cast<uint32_t>(config_cu_param_size);
+  err = xdna_ioctl(fd, DRM_IOCTL_AMDXDNA_CONFIG_HWCTX, &config_hw_ctx_args);
+  if (err != HSA_STATUS_SUCCESS) {
+    DestroyHwCtx(fd, create_hwctx_args.handle);
+    assert(false && "Failed to configure hardware context for KMQ");
+    return err;
+  }
+
+  kmq_metadata->hw_ctx_handle = create_hwctx_args.handle;
+  kmq_metadata->syncobj_handle = create_hwctx_args.syncobj_handle;
+
+  return HSA_STATUS_SUCCESS;
 }
 
 /**
@@ -701,59 +768,36 @@ hsa_status_t XdnaDriver::DestroyQueue(HSA_QUEUEID queue_id) const {
   return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
 }
 
-hsa_status_t XdnaDriver::CreateKernelModeQueue(size_t queue_size, void** metadata) const {
-  auto queue_metadata = std::make_unique<KmqQueueMetadata>();
-
-  // Create QoS information. Currently we do not leverage this information.
-  amdxdna_qos_info qos_info = {};
-  amdxdna_drm_create_hwctx create_hwctx_args = {};
-  create_hwctx_args.qos_p = reinterpret_cast<uintptr_t>(&qos_info);
-  create_hwctx_args.max_opc = 0x800;
-  create_hwctx_args.num_tiles = 1;  // dummy context; use 1 core
-  hsa_status_t err = xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_HWCTX, &create_hwctx_args);
+hsa_status_t XdnaDriver::CreateKernelModeQueue(size_t queue_size, void** queue_metadata) const {
+  auto kmq_metadata = std::make_unique<KmqMetadata>();
+  const uint32_t num_core_tiles = 1;
+  hsa_status_t err = CreateHwCtx(fd_, num_core_tiles, kmq_metadata.get());
   if (err != HSA_STATUS_SUCCESS) {
     return err;
   }
-
-  // Create hardware context for the queue.
-  constexpr size_t cu_config_size =
-      sizeof(amdxdna_hwctx_param_config_cu) + sizeof(amdxdna_cu_config);
-  alignas(amdxdna_hwctx_param_config_cu) std::byte cu_config_buffer[cu_config_size];
-  memset(cu_config_buffer, 0, cu_config_size);
-  auto* cu_config = reinterpret_cast<amdxdna_hwctx_param_config_cu*>(cu_config_buffer);
-  cu_config->num_cus = 1;
-  cu_config->cu_configs[0].cu_bo = 0;
-  cu_config->cu_configs[0].cu_func = default_cu_func;
-
-  amdxdna_drm_config_hwctx config_ctx{};
-  config_ctx.handle = create_hwctx_args.handle;
-  config_ctx.param_type = DRM_AMDXDNA_HWCTX_CONFIG_CU;
-  config_ctx.param_val = reinterpret_cast<uint64_t>(cu_config);
-  config_ctx.param_val_size = static_cast<uint32_t>(cu_config_size);
-  err = xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CONFIG_HWCTX, &config_ctx);
-  if (err != HSA_STATUS_SUCCESS) {
-    DestroyHwCtx(fd_, create_hwctx_args.handle);
-    return err;
-  }
-
-  queue_metadata->hw_ctx_handle = create_hwctx_args.handle;
-  queue_metadata->syncobj_handle = create_hwctx_args.syncobj_handle;
-
-  *metadata = queue_metadata.release();
-
+  *queue_metadata = kmq_metadata.release();
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::DestroyKernelModeQueue(void* metadata) const {
-  std::unique_ptr<KmqQueueMetadata> queue_metadata;
-  queue_metadata.reset(static_cast<KmqQueueMetadata*>(metadata));
-
-  if (queue_metadata->hw_ctx_handle == AMDXDNA_INVALID_CTX_HANDLE) {
+hsa_status_t XdnaDriver::DestroyKernelModeQueue(void* queue_metadata) const {
+  if (queue_metadata == nullptr ||
+      (static_cast<KmqMetadata*>(queue_metadata)->hw_ctx_handle == AMDXDNA_INVALID_CTX_HANDLE)) {
     return HSA_STATUS_ERROR_INVALID_QUEUE;
   }
 
+  // Create a unique_ptr to ensure cleanup.
+  std::unique_ptr<KmqMetadata> kmq_metadata;
+  kmq_metadata.reset(static_cast<KmqMetadata*>(queue_metadata));
+
   // Destroy hardware context associated with the queue.
-  return DestroyHwCtx(fd_, queue_metadata->hw_ctx_handle);
+  hsa_status_t err = DestroyHwCtx(fd_, kmq_metadata->hw_ctx_handle);
+  if (err != HSA_STATUS_SUCCESS) {
+    return err;
+  }
+  kmq_metadata->hw_ctx_handle = AMDXDNA_INVALID_CTX_HANDLE;
+  kmq_metadata->syncobj_handle = 0;
+
+  return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t XdnaDriver::SetQueueCUMask(HSA_QUEUEID queue_id, uint32_t cu_mask_count,
@@ -1004,9 +1048,10 @@ hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) con
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, void* kmq_metadata, uint64_t first_pkt_idx,
-                                        uint64_t num_pkts, uint32_t num_core_tiles) {
-  auto queue_metadata = static_cast<KmqQueueMetadata*>(kmq_metadata);
+hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, void* queue_metadata,
+                                        uint64_t first_pkt_idx, uint64_t num_pkts,
+                                        uint32_t num_core_tiles) {
+  auto kmq_metadata = static_cast<KmqMetadata*>(queue_metadata);
 
   // Instruction and arguments BOs (performance hint: up to 3 argument BOs per packet).
   std::vector<uint32_t> bo_handles;
@@ -1038,10 +1083,10 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, void* kmq_metadata, uint
     if (!pdi_bo_handle.IsValid()) {
       return HSA_STATUS_ERROR_INVALID_ALLOCATION;
     }
-    auto cached_pdi_index = queue_metadata->pdi_cache.GetIndex(pdi_bo_handle.handle);
+    auto cached_pdi_index = kmq_metadata->pdi_cache.GetIndex(pdi_bo_handle.handle);
     if (cached_pdi_index == PDICache::NotFound) {
       FlushCpuCache(pdi_bo_handle.vaddr, 0, pdi_bo_handle.size);
-      hsa_status_t err = queue_metadata->pdi_cache.SetNext(pdi_bo_handle.handle, cached_pdi_index);
+      hsa_status_t err = kmq_metadata->pdi_cache.SetNext(pdi_bo_handle.handle, cached_pdi_index);
       if (err != HSA_STATUS_SUCCESS) {
         assert(false && "Failed to set PDI in cache.");
         return err;
@@ -1110,9 +1155,22 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, void* kmq_metadata, uint
     }
   }
 
-  // Reconfigure hardware context and update cache entry if a PDI was added to the cache.
+  // Reconfigure hardware context.
   if (reconfigure_queue) {
-    hsa_status_t err = ConfigHwCtx(queue_metadata, num_core_tiles);
+    // Destroy the existing hardware context.
+    // Note: we can do this because we have forced synchronization between command chains. If we
+    // move to a more asynchronous model, we will need to figure out how hardware context
+    // destruction works while applications are running.
+    hsa_status_t err = DestroyHwCtx(fd_, kmq_metadata->hw_ctx_handle);
+    if (err != HSA_STATUS_SUCCESS) {
+      assert(false && "Failed to destroy hardware context for queue.");
+      return err;
+    }
+    kmq_metadata->hw_ctx_handle = AMDXDNA_INVALID_CTX_HANDLE;
+    kmq_metadata->syncobj_handle = 0;
+
+    // Create a new hardware context.
+    err = CreateHwCtx(fd_, num_core_tiles, kmq_metadata);
     if (err != HSA_STATUS_SUCCESS) {
       assert(false && "Failed to configure hardware context for queue.");
       return err;
@@ -1134,14 +1192,14 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, void* kmq_metadata, uint
   if (num_pkts == 1) {
     // Single packet: submit the per-kernel cmd BO directly, no chain wrapper.
     uint64_t seq = 0;
-    hsa_status_t status = SubmitCommand(fd_, cmd_bo_handles[0].handle, bo_handles,
-                                        queue_metadata->hw_ctx_handle, seq);
+    hsa_status_t status =
+        SubmitCommand(fd_, cmd_bo_handles[0].handle, bo_handles, kmq_metadata->hw_ctx_handle, seq);
     if (status != HSA_STATUS_SUCCESS) {
       assert(false && "Failed to submit command.");
       return status;
     }
     status = WaitCommand(fd_, static_cast<ert_start_kernel_cmd*>(cmd_bo_handles[0].vaddr),
-                         queue_metadata->hw_ctx_handle, queue_metadata->syncobj_handle, seq);
+                         kmq_metadata->hw_ctx_handle, kmq_metadata->syncobj_handle, seq);
     if (status != HSA_STATUS_SUCCESS) {
       assert(false && "Failed waiting for command.");
       return status;
@@ -1172,14 +1230,13 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, void* kmq_metadata, uint
 
     // Execute all commands in the command chain.
     uint64_t seq = 0;
-    status =
-        SubmitCommand(fd_, cmd_bo_handle.handle, bo_handles, queue_metadata->hw_ctx_handle, seq);
+    status = SubmitCommand(fd_, cmd_bo_handle.handle, bo_handles, kmq_metadata->hw_ctx_handle, seq);
     if (status != HSA_STATUS_SUCCESS) {
       assert(false && "Failed to submit command chain.");
       return status;
     }
     status = WaitCommand(fd_, static_cast<ert_start_kernel_cmd*>(cmd_bo_handle.vaddr),
-                         queue_metadata->hw_ctx_handle, queue_metadata->syncobj_handle, seq);
+                         kmq_metadata->hw_ctx_handle, kmq_metadata->syncobj_handle, seq);
     if (status != HSA_STATUS_SUCCESS) {
       assert(false && "Failed waiting for command chain.");
       return status;
@@ -1289,68 +1346,6 @@ XdnaDriver::BOHandle XdnaDriver::FindBOHandle(void* mem) const {
   }
 
   return it->second;
-}
-
-hsa_status_t XdnaDriver::ConfigHwCtx(void* kmq_metadata, uint32_t num_core_tiles) const {
-  auto queue_metadata = static_cast<KmqQueueMetadata*>(kmq_metadata);
-
-  const size_t config_cu_param_size = sizeof(amdxdna_hwctx_param_config_cu) +
-      queue_metadata->pdi_cache.size() * sizeof(amdxdna_cu_config);
-
-  auto* xdna_config_cu_param =
-      static_cast<amdxdna_hwctx_param_config_cu*>(malloc(config_cu_param_size));
-  if (xdna_config_cu_param == nullptr) {
-    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
-  }
-  MAKE_SCOPE_GUARD([xdna_config_cu_param] { free(xdna_config_cu_param); });
-  memset(xdna_config_cu_param, 0, config_cu_param_size);
-
-  xdna_config_cu_param->num_cus = queue_metadata->pdi_cache.size();
-
-  for (size_t i = 0; i < queue_metadata->pdi_cache.size(); i++) {
-    xdna_config_cu_param->cu_configs[i].cu_bo = queue_metadata->pdi_cache[i];
-    xdna_config_cu_param->cu_configs[i].cu_func = default_cu_func;
-  }
-
-  // Destroy the hardware context
-  // Note: we can do this because we have forced synchronization between command chains. If we move
-  // to a more asynchronous model, we will need to figure out how hardware context destruction works
-  // while applications are running.
-  hsa_status_t err = DestroyHwCtx(fd_, queue_metadata->hw_ctx_handle);
-  if (err != HSA_STATUS_SUCCESS) {
-    return err;
-  }
-  queue_metadata->hw_ctx_handle = AMDXDNA_INVALID_CTX_HANDLE;
-  queue_metadata->syncobj_handle = 0;
-
-  // Create the new hardware context
-  // Currently we do not leverage QoS information.
-  amdxdna_qos_info qos_info = {};
-  amdxdna_drm_create_hwctx create_hwctx_args = {};
-  create_hwctx_args.qos_p = reinterpret_cast<uintptr_t>(&qos_info);
-  create_hwctx_args.max_opc = 0x800;
-  create_hwctx_args.num_tiles = num_core_tiles;
-  err = xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CREATE_HWCTX, &create_hwctx_args);
-  if (err != HSA_STATUS_SUCCESS) {
-    return err;
-  }
-
-  // Configure the new hardware context
-  amdxdna_drm_config_hwctx config_hw_ctx_args = {};
-  config_hw_ctx_args.handle = create_hwctx_args.handle;
-  config_hw_ctx_args.param_type = DRM_AMDXDNA_HWCTX_CONFIG_CU;
-  config_hw_ctx_args.param_val = reinterpret_cast<uint64_t>(xdna_config_cu_param);
-  config_hw_ctx_args.param_val_size = static_cast<uint32_t>(config_cu_param_size);
-  err = xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_CONFIG_HWCTX, &config_hw_ctx_args);
-  if (err != HSA_STATUS_SUCCESS) {
-    DestroyHwCtx(fd_, create_hwctx_args.handle);
-    return err;
-  }
-
-  queue_metadata->hw_ctx_handle = create_hwctx_args.handle;
-  queue_metadata->syncobj_handle = create_hwctx_args.syncobj_handle;
-
-  return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t XdnaDriver::SetTrapHandler(uint32_t node_id, const void* base, uint64_t base_size,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -240,9 +240,60 @@ static hsa_status_t xdna_ioctl(int fd, unsigned long request, void* arg) {
   }
 }
 
+/// @brief Per hardware context PDI cache.
+class PDICache {
+ private:
+  /// @brief CU mask size.
+  constexpr static size_t cu_mask_size = sizeof(uint32_t) * CHAR_BIT;
+
+ public:
+  using size_type = uint32_t;
+
+ private:
+  std::array<uint32_t, cu_mask_size> entries = {};
+  size_type entry_count = 0;
+
+ public:
+  /// @brief Sentinel value for entries not found.
+  constexpr static size_type NotFound = cu_mask_size;
+
+  /// @brief Returns if the cache is empty.
+  constexpr bool empty() const { return entry_count == 0; }
+
+  /// @brief Returns the size of the cache.
+  constexpr size_type size() const { return entry_count; }
+
+  /// @brief Returns the index of the BO handle if it is the cache, otherwise @ref NotFound.
+  ///
+  /// This function does a linear search because the mask is small (32 elements).
+  size_type GetIndex(uint32_t pdi_handle) const {
+    for (size_type i = 0; i < entry_count; ++i) {
+      if (entries[i] == pdi_handle) {
+        return i;
+      }
+    }
+    return NotFound;
+  }
+
+  /// @brief Sets the next cache entry.
+  hsa_status_t SetNext(uint32_t pdi_bo_handle, size_type& index) {
+    if (entry_count == entries.size()) {
+      // cache is full
+      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+    }
+
+    index = entry_count++;
+    entries[index] = pdi_bo_handle;
+    return HSA_STATUS_SUCCESS;
+  }
+
+  constexpr uint32_t operator[](size_type index) const { return entries[index]; }
+};
+
 /// @brief Metadata for a Kernel Mode Queue (KMQ).
 struct KmqQueueMetadata {
   uint32_t hw_ctx_handle;
+  PDICache pdi_cache;
 };
 
 /**
@@ -952,14 +1003,8 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, void* kmq_metadata, uint
     }
   });
 
-  // PDI cache to avoid reconfiguration. If the cache is empty or updated, a new hardware context
-  // will be created for the queue.
-  PDICache pdi_cache;
-  auto pdi_cache_it = queue_pdi_map_.find(queue_metadata->hw_ctx_handle);
-  if (pdi_cache_it != queue_pdi_map_.end()) {
-    pdi_cache = pdi_cache_it->second;
-  }
-  bool reconfigure_queue = pdi_cache.empty();
+  // Flag to reconfigure the hardware context because of a new PDI.
+  bool reconfigure_queue = false;
 
   // Process all packets in a single command chain.
   auto* queue = static_cast<hsa_amd_aie_kernel_dispatch_packet_t*>(q.base_address);
@@ -974,13 +1019,13 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, void* kmq_metadata, uint
     if (!pdi_bo_handle.IsValid()) {
       return HSA_STATUS_ERROR_INVALID_ALLOCATION;
     }
-    auto cached_pdi_index = pdi_cache.GetIndex(pdi_bo_handle.handle);
+    auto cached_pdi_index = queue_metadata->pdi_cache.GetIndex(pdi_bo_handle.handle);
     if (cached_pdi_index == PDICache::NotFound) {
       FlushCpuCache(pdi_bo_handle.vaddr, 0, pdi_bo_handle.size);
-      hsa_status_t status = pdi_cache.SetNext(pdi_bo_handle, cached_pdi_index);
-      if (status != HSA_STATUS_SUCCESS) {
+      hsa_status_t err = queue_metadata->pdi_cache.SetNext(pdi_bo_handle.handle, cached_pdi_index);
+      if (err != HSA_STATUS_SUCCESS) {
         assert(false && "Failed to set PDI in cache.");
-        return status;
+        return err;
       }
       reconfigure_queue = true;
     }
@@ -1016,10 +1061,10 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, void* kmq_metadata, uint
     const uint32_t cmd_data_bytesize = cmd_dwords * sizeof(uint32_t);
     const uint32_t cmd_bytesize = sizeof(ert_start_kernel_cmd) + cmd_data_bytesize;
     BOHandle cmd_bo_handle;
-    hsa_status_t status = CreateCmdBO(cmd_bytesize, cmd_bo_handle);
-    if (status != HSA_STATUS_SUCCESS) {
+    hsa_status_t err = CreateCmdBO(cmd_bytesize, cmd_bo_handle);
+    if (err != HSA_STATUS_SUCCESS) {
       assert(false && "Failed to create command BO.");
-      return status;
+      return err;
     }
     cmd_bo_handles.push_back(cmd_bo_handle);
 
@@ -1048,15 +1093,11 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, void* kmq_metadata, uint
 
   // Reconfigure hardware context and update cache entry if a PDI was added to the cache.
   if (reconfigure_queue) {
-    if (pdi_cache_it != queue_pdi_map_.end()) {
-      queue_pdi_map_.erase(pdi_cache_it);
-    }
-    hsa_status_t status = ConfigHwCtx(pdi_cache, queue_metadata, num_core_tiles);
-    if (status != HSA_STATUS_SUCCESS) {
+    hsa_status_t err = ConfigHwCtx(queue_metadata, num_core_tiles);
+    if (err != HSA_STATUS_SUCCESS) {
       assert(false && "Failed to configure hardware context for queue.");
-      return status;
+      return err;
     }
-    queue_pdi_map_.emplace(queue_metadata->hw_ctx_handle, pdi_cache);
   }
 
   // Remove duplicate BOs, since the driver reports an error if the same BO is provided multiple
@@ -1231,12 +1272,11 @@ XdnaDriver::BOHandle XdnaDriver::FindBOHandle(void* mem) const {
   return it->second;
 }
 
-hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, void* kmq_metadata,
-                                     uint32_t num_core_tiles) const {
+hsa_status_t XdnaDriver::ConfigHwCtx(void* kmq_metadata, uint32_t num_core_tiles) const {
   auto queue_metadata = static_cast<KmqQueueMetadata*>(kmq_metadata);
 
-  const size_t config_cu_param_size =
-      sizeof(amdxdna_hwctx_param_config_cu) + pdi_bo_handles.size() * sizeof(amdxdna_cu_config);
+  const size_t config_cu_param_size = sizeof(amdxdna_hwctx_param_config_cu) +
+      queue_metadata->pdi_cache.size() * sizeof(amdxdna_cu_config);
 
   auto* xdna_config_cu_param =
       static_cast<amdxdna_hwctx_param_config_cu*>(malloc(config_cu_param_size));
@@ -1246,10 +1286,10 @@ hsa_status_t XdnaDriver::ConfigHwCtx(const PDICache& pdi_bo_handles, void* kmq_m
   MAKE_SCOPE_GUARD([xdna_config_cu_param] { free(xdna_config_cu_param); });
   memset(xdna_config_cu_param, 0, config_cu_param_size);
 
-  xdna_config_cu_param->num_cus = pdi_bo_handles.size();
+  xdna_config_cu_param->num_cus = queue_metadata->pdi_cache.size();
 
-  for (size_t i = 0; i < pdi_bo_handles.size(); i++) {
-    xdna_config_cu_param->cu_configs[i].cu_bo = pdi_bo_handles[i].handle;
+  for (size_t i = 0; i < queue_metadata->pdi_cache.size(); i++) {
+    xdna_config_cu_param->cu_configs[i].cu_bo = queue_metadata->pdi_cache[i];
     xdna_config_cu_param->cu_configs[i].cu_func = default_cu_func;
   }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -42,20 +42,21 @@
 
 #include "core/inc/amd_xdna_driver.h"
 
-#include <cerrno>
-#include <fcntl.h>
-#include <sys/ioctl.h>
-#include <sys/mman.h>
-#include <unistd.h>
-
 #include <array>
 #include <cassert>
+#include <cerrno>
 #include <fstream>
 #include <map>
 #include <memory>
 #include <string>
 #include <string_view>
 #include <utility>
+
+#include <drm/drm.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <unistd.h>
 
 #include "inc/hsa_ext_amd_aie.h"
 #include "core/inc/amd_memory_region.h"
@@ -293,6 +294,7 @@ class PDICache {
 /// @brief Metadata for a Kernel Mode Queue (KMQ).
 struct KmqQueueMetadata {
   uint32_t hw_ctx_handle;
+  uint32_t syncobj_handle = 0;
   PDICache pdi_cache;
 };
 
@@ -362,10 +364,11 @@ static hsa_status_t SubmitCommand(int fd, uint32_t cmd_bo_handle,
  * @param[in] fd driver file descriptor
  * @param[in] cmd command to wait for
  * @param[in] hw_ctx_handle hardware context handle
+ * @param[in] syncobj_handle DRM syncobj handle for timeline wait
  * @param[in] seq sequence number of the command
  */
 static hsa_status_t WaitCommand(int fd, ert_start_kernel_cmd* cmd, uint32_t hw_ctx_handle,
-                                uint64_t seq) {
+                                uint32_t syncobj_handle, uint64_t seq) {
   assert(hw_ctx_handle != AMDXDNA_INVALID_CTX_HANDLE);
 
   // Check command status before waiting to avoid unnecessary ioctl if the command has already
@@ -385,14 +388,28 @@ static hsa_status_t WaitCommand(int fd, ert_start_kernel_cmd* cmd, uint32_t hw_c
       return HSA_STATUS_ERROR;
   }
 
-  // Wait for command completion.
-  amdxdna_drm_wait_cmd wait_cmd = {};
-  wait_cmd.hwctx = hw_ctx_handle;
-  wait_cmd.timeout = 0;  // no timeout, wait until the command finishes
-  wait_cmd.seq = seq;
-  hsa_status_t err = xdna_ioctl(fd, DRM_IOCTL_AMDXDNA_WAIT_CMD, &wait_cmd);
-  if (err != HSA_STATUS_SUCCESS) {
-    return err;
+  // Prefer DRM syncobj timeline wait when available.
+  if (syncobj_handle != 0) {
+    drm_syncobj_timeline_wait timeline_wait = {};
+    timeline_wait.handles = reinterpret_cast<uintptr_t>(&syncobj_handle);
+    timeline_wait.points = reinterpret_cast<uintptr_t>(&seq);
+    timeline_wait.count_handles = 1;
+    timeline_wait.timeout_nsec = INT64_MAX;
+    timeline_wait.flags = DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL;
+    hsa_status_t err = xdna_ioctl(fd, DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT, &timeline_wait);
+    if (err != HSA_STATUS_SUCCESS) {
+      return err;
+    }
+  } else {
+    // Fallback: XDNA-specific wait.
+    amdxdna_drm_wait_cmd wait_cmd = {};
+    wait_cmd.hwctx = hw_ctx_handle;
+    wait_cmd.timeout = 0;  // no timeout, wait until the command finishes
+    wait_cmd.seq = seq;
+    hsa_status_t err = xdna_ioctl(fd, DRM_IOCTL_AMDXDNA_WAIT_CMD, &wait_cmd);
+    if (err != HSA_STATUS_SUCCESS) {
+      return err;
+    }
   }
 
   // Check if command failed.
@@ -720,6 +737,8 @@ hsa_status_t XdnaDriver::CreateKernelModeQueue(size_t queue_size, void** metadat
   }
 
   queue_metadata->hw_ctx_handle = create_hwctx_args.handle;
+  queue_metadata->syncobj_handle = create_hwctx_args.syncobj_handle;
+
   *metadata = queue_metadata.release();
 
   return HSA_STATUS_SUCCESS;
@@ -947,7 +966,7 @@ hsa_status_t XdnaDriver::FreeDeviceHeap() {
   return err;
 }
 
-hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) {
+hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) const {
   amdxdna_drm_create_bo create_cmd_bo = {};
   create_cmd_bo.type = AMDXDNA_BO_CMD;
   create_cmd_bo.size = size;
@@ -1122,7 +1141,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, void* kmq_metadata, uint
       return status;
     }
     status = WaitCommand(fd_, static_cast<ert_start_kernel_cmd*>(cmd_bo_handles[0].vaddr),
-                         queue_metadata->hw_ctx_handle, seq);
+                         queue_metadata->hw_ctx_handle, queue_metadata->syncobj_handle, seq);
     if (status != HSA_STATUS_SUCCESS) {
       assert(false && "Failed waiting for command.");
       return status;
@@ -1160,7 +1179,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, void* kmq_metadata, uint
       return status;
     }
     status = WaitCommand(fd_, static_cast<ert_start_kernel_cmd*>(cmd_bo_handle.vaddr),
-                         queue_metadata->hw_ctx_handle, seq);
+                         queue_metadata->hw_ctx_handle, queue_metadata->syncobj_handle, seq);
     if (status != HSA_STATUS_SUCCESS) {
       assert(false && "Failed waiting for command chain.");
       return status;
@@ -1211,7 +1230,7 @@ hsa_status_t XdnaDriver::IsModelEnabled(bool* enable) const {
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::DestroyBOHandle(BOHandle& bo_handle) {
+hsa_status_t XdnaDriver::DestroyBOHandle(BOHandle& bo_handle) const {
   if (!bo_handle.IsValid()) {
     return HSA_STATUS_SUCCESS;
   }
@@ -1302,6 +1321,7 @@ hsa_status_t XdnaDriver::ConfigHwCtx(void* kmq_metadata, uint32_t num_core_tiles
     return err;
   }
   queue_metadata->hw_ctx_handle = AMDXDNA_INVALID_CTX_HANDLE;
+  queue_metadata->syncobj_handle = 0;
 
   // Create the new hardware context
   // Currently we do not leverage QoS information.
@@ -1328,6 +1348,7 @@ hsa_status_t XdnaDriver::ConfigHwCtx(void* kmq_metadata, uint32_t num_core_tiles
   }
 
   queue_metadata->hw_ctx_handle = create_hwctx_args.handle;
+  queue_metadata->syncobj_handle = create_hwctx_args.syncobj_handle;
 
   return HSA_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -335,8 +335,11 @@ static hsa_status_t DestroyHwCtx(int fd, uint32_t hw_ctx_handle) {
 /// @param[in,out] kmq_metadata KMQ metadata to update with the hardware context handle and syncobj
 /// handle
 static hsa_status_t CreateHwCtx(int fd, uint32_t num_core_tiles, KmqMetadata* kmq_metadata) {
-  // Create the new hardware context; we do not leverage QoS information
+  // Create QoS information; we don't leverage any external Qos hints.
   amdxdna_qos_info qos_info = {};
+  qos_info.user_start_col = USER_START_COL_NOT_REQUESTED;
+
+  // Create the new hardware context.
   amdxdna_drm_create_hwctx create_hwctx_args = {};
   create_hwctx_args.qos_p = reinterpret_cast<uintptr_t>(&qos_info);
   create_hwctx_args.max_opc = 0x800;
@@ -347,7 +350,7 @@ static hsa_status_t CreateHwCtx(int fd, uint32_t num_core_tiles, KmqMetadata* km
     return err;
   }
 
-  // Create hardware context configuration
+  // Create hardware context configuration.
   const size_t num_cus = kmq_metadata->pdi_cache.empty() ? 1 : kmq_metadata->pdi_cache.size();
   const size_t config_cu_param_size =
       sizeof(amdxdna_hwctx_param_config_cu) + num_cus * sizeof(amdxdna_cu_config);
@@ -377,7 +380,7 @@ static hsa_status_t CreateHwCtx(int fd, uint32_t num_core_tiles, KmqMetadata* km
     xdna_config_cu_param->cu_configs[0].cu_func = default_cu_func;
   }
 
-  // Configure the new hardware context
+  // Configure the new hardware context.
   amdxdna_drm_config_hwctx config_hw_ctx_args = {};
   config_hw_ctx_args.handle = create_hwctx_args.handle;
   config_hw_ctx_args.param_type = DRM_AMDXDNA_HWCTX_CONFIG_CU;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -355,6 +355,7 @@ static hsa_status_t CreateHwCtx(int fd, uint32_t num_core_tiles, KmqMetadata* km
   auto* xdna_config_cu_param =
       static_cast<amdxdna_hwctx_param_config_cu*>(malloc(config_cu_param_size));
   if (xdna_config_cu_param == nullptr) {
+    DestroyHwCtx(fd, create_hwctx_args.handle);
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
   MAKE_SCOPE_GUARD([xdna_config_cu_param] { free(xdna_config_cu_param); });

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aie_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aie_aql_queue.h
@@ -110,11 +110,12 @@ class AieAqlQueue : public core::Queue,
     return rtti_id_;
   }
 
-  HSA_QUEUEID queue_id_ = INVALID_QUEUEID;
   /// @brief Queue size in bytes.
   uint32_t queue_size_bytes_ = 0;
   /// @brief Base of the queue's ring buffer storage.
   void* ring_buf_ = nullptr;
+  /// @brief Kernel Mode Queue (KMQ) metadata associated with this queue.
+  void* kmq_metadata_ = nullptr;
   /// @brief Indicates if queue is active.
   std::atomic<bool> active_ = false;
 };

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -188,7 +188,7 @@ public:
   /// @note This function will unmap the virtual address and close the BO, even if the former fails.
   ///
   /// @param[in,out] bo_handle BO handle to destroy.
-  hsa_status_t DestroyBOHandle(BOHandle& bo_handle);
+  hsa_status_t DestroyBOHandle(BOHandle& bo_handle) const;
 
   /// @brief Returns the BO associated with the address.
   ///
@@ -214,7 +214,7 @@ public:
   ///
   /// @param[in] size size of memory to allocate
   /// @param[out] bo_info allocated BO
-  hsa_status_t CreateCmdBO(uint32_t size, BOHandle& bo_info);
+  hsa_status_t CreateCmdBO(uint32_t size, BOHandle& bo_info) const;
 
   std::map<void*, BOHandle> vmem_addr_mappings;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -124,6 +124,10 @@ public:
 
   /// @brief Destroy the Kernel Mode Queue (KMQ) metadata.
   ///
+  /// @note This function will also destroy the hardware context associated with the KMQ. Even if
+  /// that fails, the metadata is still considered destroyed and the function will return the error
+  /// from destroying the hardware context.
+  ///
   /// @param[in] queue_metadata KMQ metadata to be destroyed
   hsa_status_t DestroyKernelModeQueue(void* queue_metadata) const;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -119,13 +119,13 @@ public:
   /// dispatch queue.
   ///
   /// @param[in] queue_size size of the dispatch queue in number of packets
-  /// @param[out] metadata KMQ metadata created for the dispatch queue
-  hsa_status_t CreateKernelModeQueue(size_t queue_size, void** metadata) const;
+  /// @param[out] queue_metadata KMQ metadata created for the dispatch queue
+  hsa_status_t CreateKernelModeQueue(size_t queue_size, void** queue_metadata) const;
 
   /// @brief Destroy the Kernel Mode Queue (KMQ) metadata.
   ///
-  /// @param[in] metadata KMQ metadata to be destroyed
-  hsa_status_t DestroyKernelModeQueue(void* metadata) const;
+  /// @param[in] queue_metadata KMQ metadata to be destroyed
+  hsa_status_t DestroyKernelModeQueue(void* queue_metadata) const;
 
   hsa_status_t SetQueueCUMask(HSA_QUEUEID queue_id, uint32_t cu_mask_count,
                               uint32_t* queue_cu_mask) const override;
@@ -150,12 +150,12 @@ public:
   /// @note The packets are contiguous in index but not necessarily contiguous in memory.
   ///
   /// @param[in] q queue with packets
-  /// @param[in,out] kmq_metadata Kernel Mode Queue (KMQ) metadata. It will be updated if the driver
-  /// needs to create a new hardware context.
+  /// @param[in,out] queue_metadata Kernel Mode Queue (KMQ) metadata. It will be updated if the
+  /// driver needs to create a new hardware context.
   /// @param[in] first_pkt_idx index of the first packet in the queue
   /// @param[in] num_pkts number of packets in the queue to be submitted. Must be greater than 0.
   /// @param[in] num_core_tiles number of core tiles in the AIE device
-  hsa_status_t SubmitCmdChain(hsa_queue_t& q, void* kmq_metadata, uint64_t first_pkt_idx,
+  hsa_status_t SubmitCmdChain(hsa_queue_t& q, void* queue_metadata, uint64_t first_pkt_idx,
                               uint64_t num_pkts, uint32_t num_core_tiles);
 
   hsa_status_t SPMAcquire(uint32_t preferred_node_id) const override;
@@ -194,12 +194,6 @@ public:
   ///
   /// @param[in] mem virtual address to query.
   BOHandle FindBOHandle(void* mem) const;
-
-  /// @brief Creates a new hardware context.
-  ///
-  /// @param[in,out] kmq_metadata Kernel Mode Queue (KMQ) metadata
-  /// @param[in] num_core_tiles number of core tiles in the AIE device
-  hsa_status_t ConfigHwCtx(void* kmq_metadata, uint32_t num_core_tiles) const;
 
   /// @brief Queries the driver version and updates internal state.
   hsa_status_t QueryDriverVersion();

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -47,7 +47,6 @@
 #include <climits>
 #include <map>
 #include <memory>
-#include <unordered_map>
 
 #include "core/inc/amd_aie_agent.h"
 #include "core/inc/driver.h"
@@ -77,57 +76,6 @@ class XdnaDriver final : public core::Driver {
     constexpr BOHandle(void* vaddr, uint32_t handle, size_t size)
         : vaddr{vaddr}, handle{handle}, size{size} {}
     constexpr bool IsValid() const { return handle != 0; }
-  };
-
-
-  /// @brief Per hardware context PDI cache.
-  class PDICache {
-   private:
-    /// @brief CU mask size.
-    constexpr static size_t cu_mask_size = sizeof(uint32_t) * CHAR_BIT;
-
-   public:
-    using size_type = uint32_t;
-
-   private:
-    std::array<BOHandle, cu_mask_size> entries = {};
-    size_type entry_count = 0;
-
-   public:
-    /// @brief Sentinel value for entries not found.
-    constexpr static size_type NotFound = cu_mask_size;
-
-    /// @brief Returns if the cache is empty.
-    constexpr bool empty() const { return entry_count == 0; }
-
-    /// @brief Returns the size of the cache.
-    constexpr size_type size() const { return entry_count; }
-
-    /// @brief Returns the index of the BO handle if it is the cache, otherwise @ref NotFound.
-    ///
-    /// This function does a linear search because the mask is small (32 elements).
-    size_type GetIndex(uint32_t pdi_handle) const {
-      for (size_type i = 0; i < entry_count; ++i) {
-        if (entries[i].handle == pdi_handle) {
-          return i;
-        }
-      }
-      return NotFound;
-    }
-
-    /// @brief Sets the next cache entry.
-    hsa_status_t SetNext(const BOHandle& pdi_bo_handle, size_type& index) {
-      if (entry_count == entries.size()) {
-        // cache is full
-        return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
-      }
-
-      index = entry_count++;
-      entries[index] = pdi_bo_handle;
-      return HSA_STATUS_SUCCESS;
-    }
-
-    constexpr const BOHandle& operator[](size_type index) const { return entries[index]; }
   };
 
 public:
@@ -167,7 +115,8 @@ public:
                            void* queue_addr, uint64_t queue_size, HsaEvent* event) const override;
   hsa_status_t DestroyQueue(HSA_QUEUEID queue_id) const override;
 
-  /// @brief Create Kernel Mode Queue (KMQ) metadata to dispatch packets in a user-mode access agent dispatch queue.
+  /// @brief Create Kernel Mode Queue (KMQ) metadata to dispatch packets in a user-mode access agent
+  /// dispatch queue.
   ///
   /// @param[in] queue_size size of the dispatch queue in number of packets
   /// @param[out] metadata KMQ metadata created for the dispatch queue
@@ -248,11 +197,9 @@ public:
 
   /// @brief Creates a new hardware context.
   ///
-  /// @param[in] pdi_bo_handles PDI BO handles to use for the new hardware context.
   /// @param[in,out] kmq_metadata Kernel Mode Queue (KMQ) metadata
   /// @param[in] num_core_tiles number of core tiles in the AIE device
-  hsa_status_t ConfigHwCtx(const PDICache& pdi_bo_handles, void* kmq_metadata,
-                           uint32_t num_core_tiles) const;
+  hsa_status_t ConfigHwCtx(void* kmq_metadata, uint32_t num_core_tiles) const;
 
   /// @brief Queries the driver version and updates internal state.
   hsa_status_t QueryDriverVersion();
@@ -270,9 +217,6 @@ public:
   hsa_status_t CreateCmdBO(uint32_t size, BOHandle& bo_info);
 
   std::map<void*, BOHandle> vmem_addr_mappings;
-
-  /// @brief Queue to PDI cache map.
-  std::unordered_map<HSA_QUEUEID, PDICache> queue_pdi_map_;
 
   /// @brief Virtual address range allocated for the device heap.
   ///

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -166,6 +166,18 @@ public:
   hsa_status_t UpdateQueue(HSA_QUEUEID queue_id, uint32_t queue_pct, HSA::hsa_amd_queue_priority_internal_t priority,
                            void* queue_addr, uint64_t queue_size, HsaEvent* event) const override;
   hsa_status_t DestroyQueue(HSA_QUEUEID queue_id) const override;
+
+  /// @brief Create Kernel Mode Queue (KMQ) metadata to dispatch packets in a user-mode access agent dispatch queue.
+  ///
+  /// @param[in] queue_size size of the dispatch queue in number of packets
+  /// @param[out] metadata KMQ metadata created for the dispatch queue
+  hsa_status_t CreateKernelModeQueue(size_t queue_size, void** metadata) const;
+
+  /// @brief Destroy the Kernel Mode Queue (KMQ) metadata.
+  ///
+  /// @param[in] metadata KMQ metadata to be destroyed
+  hsa_status_t DestroyKernelModeQueue(void* metadata) const;
+
   hsa_status_t SetQueueCUMask(HSA_QUEUEID queue_id, uint32_t cu_mask_count,
                               uint32_t* queue_cu_mask) const override;
   hsa_status_t AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_gws,
@@ -184,17 +196,17 @@ public:
                                      uint64_t* drm_fd_offset) override;
   hsa_status_t DestroyShareableHandle(core::ShareableHandle* handle) override;
 
-  /// @brief Submits a chain of command packets to the driver for execution.
+  /// @brief Submits packets to the driver for execution.
   ///
   /// @note The packets are contiguous in index but not necessarily contiguous in memory.
   ///
-  /// @param[in] q AIE KMQ queue with queued packets
-  /// @param[in,out] queue_id queue ID. It will be updated if the driver needs to create a new
-  /// hardware context for this command chain.
+  /// @param[in] q queue with packets
+  /// @param[in,out] kmq_metadata Kernel Mode Queue (KMQ) metadata. It will be updated if the driver
+  /// needs to create a new hardware context.
   /// @param[in] first_pkt_idx index of the first packet in the queue
-  /// @param[in] num_pkts number of packets in the queue to be submitted
+  /// @param[in] num_pkts number of packets in the queue to be submitted. Must be greater than 0.
   /// @param[in] num_core_tiles number of core tiles in the AIE device
-  hsa_status_t SubmitCmdChain(hsa_queue_t& q, HSA_QUEUEID& queue_id, uint64_t first_pkt_idx,
+  hsa_status_t SubmitCmdChain(hsa_queue_t& q, void* kmq_metadata, uint64_t first_pkt_idx,
                               uint64_t num_pkts, uint32_t num_core_tiles);
 
   hsa_status_t SPMAcquire(uint32_t preferred_node_id) const override;
@@ -234,13 +246,12 @@ public:
   /// @param[in] mem virtual address to query.
   BOHandle FindBOHandle(void* mem) const;
 
-  /// @brief Creates a new hardware context with the given PDI BO handles.
+  /// @brief Creates a new hardware context.
   ///
   /// @param[in] pdi_bo_handles PDI BO handles to use for the new hardware context.
-  /// @param[in,out] queue_id queue ID. It will be updated if the driver needs to create a new
-  /// hardware context for this command chain.
+  /// @param[in,out] kmq_metadata Kernel Mode Queue (KMQ) metadata
   /// @param[in] num_core_tiles number of core tiles in the AIE device
-  hsa_status_t ConfigHwCtx(const PDICache& pdi_bo_handles, HSA_QUEUEID& queue_id,
+  hsa_status_t ConfigHwCtx(const PDICache& pdi_bo_handles, void* kmq_metadata,
                            uint32_t num_core_tiles) const;
 
   /// @brief Queries the driver version and updates internal state.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2023-2025, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2023-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -158,7 +158,6 @@ public:
   /// if @p type is one of the SDMA queue types.
   /// @param[in] queue_addr Address of the queue's ring buffer.
   /// @param[in] queue_size_bytes Size of the queue's ring buffer in bytes.
-  /// @param[in] queue_metadata_addr Address of the queue's metadata ring buffer.
   /// @param[in] queue_metadata_size_bytes Size of the queue's metadata ring buffer in bytes.
   /// @param[in] event HsaEvent for event-driven callbacks.
   /// @param[out] queue_resource Queue resource information populated by the driver.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -92,14 +92,11 @@ AieAqlQueue::AieAqlQueue(core::SharedQueue* shared_queue, AieAgent* agent, size_
   signal_.kind = AMD_SIGNAL_KIND_DOORBELL;
   signal_.queue_ptr = &amd_queue_;
 
-  HsaQueueResource queue_resource = {};
-  hsa_status_t status = agent->driver().CreateQueue(
-      node_id, HSA_QUEUE_COMPUTE_AQL, 0, rocr::HSA::HSA_AMD_QUEUE_PRIORITY_NORMAL, 0, nullptr,
-      queue_size_bytes_, 0, nullptr, queue_resource);
-  if (status != HSA_STATUS_SUCCESS) {
-    throw hsa_exception(status, "Failed to create a hardware context for an AIE queue.");
+  auto& driver = static_cast<XdnaDriver&>(agent->driver());
+  hsa_status_t err = driver.CreateKernelModeQueue(req_size_pkts, &kmq_metadata_);
+  if (err != HSA_STATUS_SUCCESS) {
+    throw hsa_exception(err, "Failed to create KMQ metadata for the AIE queue.");
   }
-  queue_id_ = queue_resource.QueueId;
 
   active_ = true;
 
@@ -120,7 +117,8 @@ AieAqlQueue::~AieAqlQueue() {
 hsa_status_t AieAqlQueue::Inactivate() {
   bool active = active_.exchange(false, std::memory_order_relaxed);
   if (active) {
-    auto err = GetAgent()->driver().DestroyQueue(queue_id_);
+    auto& driver = static_cast<XdnaDriver&>(GetAgent()->driver());
+    hsa_status_t err = driver.DestroyKernelModeQueue(kmq_metadata_);
     assert(err == HSA_STATUS_SUCCESS && "Destroy queue failed.");
     (void)err;
     atomic::Fence(std::memory_order_acquire);
@@ -220,10 +218,10 @@ void AieAqlQueue::SubmitPackets() {
   }
 
   const auto num_pkts = last_pkt_idx - first_pkt_idx;
-  hsa_status_t status = driver.SubmitCmdChain(amd_queue_.hsa_queue, queue_id_, first_pkt_idx,
-                                              num_pkts, agent.properties().NumNeuralCores);
-  if (status != HSA_STATUS_SUCCESS) {
-    throw hsa_exception(status, "Could not submit packets");
+  hsa_status_t err = driver.SubmitCmdChain(amd_queue_.hsa_queue, kmq_metadata_, first_pkt_idx,
+                                           num_pkts, agent.properties().NumNeuralCores);
+  if (err != HSA_STATUS_SUCCESS) {
+    throw hsa_exception(err, "Could not submit packets");
   }
 
   atomic::Store(&amd_queue_.read_dispatch_id, last_pkt_idx, std::memory_order_release);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -104,7 +104,9 @@ AieAqlQueue::AieAqlQueue(core::SharedQueue* shared_queue, AieAgent* agent, size_
 }
 
 AieAqlQueue::~AieAqlQueue() {
-  AieAqlQueue::Inactivate();
+  auto err = AieAqlQueue::Inactivate();
+  assert(err == HSA_STATUS_SUCCESS && "Destroy queue failed.");
+  (void)err;
   if (ring_buf_) {
     auto& agent = static_cast<AieAgent&>(*GetAgent());
     agent.system_deallocator()(ring_buf_);
@@ -116,14 +118,15 @@ AieAqlQueue::~AieAqlQueue() {
 
 hsa_status_t AieAqlQueue::Inactivate() {
   bool active = active_.exchange(false, std::memory_order_relaxed);
-  if (active) {
-    auto& driver = static_cast<XdnaDriver&>(GetAgent()->driver());
-    hsa_status_t err = driver.DestroyKernelModeQueue(kmq_metadata_);
-    assert(err == HSA_STATUS_SUCCESS && "Destroy queue failed.");
-    (void)err;
-    atomic::Fence(std::memory_order_acquire);
+  if (!active) {
+    return HSA_STATUS_SUCCESS;
   }
-  return HSA_STATUS_SUCCESS;
+
+  auto& driver = static_cast<XdnaDriver&>(GetAgent()->driver());
+  hsa_status_t err = driver.DestroyKernelModeQueue(kmq_metadata_);
+  kmq_metadata_ = nullptr;
+  atomic::Fence(std::memory_order_acquire);
+  return err;
 }
 
 hsa_status_t AieAqlQueue::SetPriority(HSA::hsa_amd_queue_priority_internal_t priority) {


### PR DESCRIPTION
## Motivation

AIE queues for aie2 / aie2p are using the xdna-driver Kernel-Mode Queue (KMQ). While we offer AQL-like queue interface, internally the packets are transformed to packets for xdna-driver ioctl calls.

There's some metadata that are required for that translation which are associated with the queue that were previously associated with the `XdnaDriver` and indexed with the queue ID.

This PR associates that metadata directly with the queue as an opaque object.

## Technical Details

This PR creates an opaque metadata object associated with the AIE queue to help with the translation from AQL packets to ioctl xdna-driver calls.

The metadata structure (KMQMetadata) now contains:
1. `hwctx_handle`: the hardware context (i.e., KMQ handle)
2. `syncobj_handle`: a handle to the syncobj associated with the KMQ
3. `PDICache`: datastructure to create command BO cu masks

Additional changes:
1. `PDICache` now only holds BO handles, not vaddr or size.
2. `syncobj` timeline is used for synchronization if found, otherwise it falls to the xdna-driver WAIT_CMD
3. `CreateHwCtx` is used now in both queue creation and queue reconfiguration.

## JIRA ID

NA

## Test Plan

Tests from https://github.com/ROCm/rocm-systems/tree/users/ypapadop-amd/aie-tests/projects/rocr-runtime/rocrtst/suites/aie

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
