### PR TITLE
Add support for AqlProfil V2 API in Ctrl test. Remove "DeadCode"

### DIFF
--- a/projects/aqlprofile/test/CMakeLists.txt
+++ b/projects/aqlprofile/test/CMakeLists.txt
@@ -33,6 +33,19 @@ find_package(Clang REQUIRED CONFIG
              PATH_SUFFIXES "llvm/lib/cmake/clang")
 
 ## Building test executable
+if(NOT DEFINED AQLPROFILE_TARGET)
+    find_library(
+        AQLPROFILE_TARGET
+        REQUIRED
+        NAMES hsa-amd-aqlprofile64 hsa-amd-aqlprofile
+        HINTS /opt/rocm ${CMAKE_INSTALL_PREFIX}
+        PATHS /opt/rocm
+        PATH_SUFFIXES lib)
+    enable_testing()
+    include(CTest)
+endif()
+
+
 add_executable ( ${EXE_NAME} ${KERN_SRC} ${CTRL_SRC} ${UTIL_SRC} )
 target_include_directories ( ${EXE_NAME}
   PRIVATE
@@ -48,6 +61,7 @@ target_link_libraries( ${EXE_NAME}
       pthread
       aqlprofile::headers
       hsa-runtime64::hsa-runtime64
+      ${AQLPROFILE_TARGET}
       dl )
 install(TARGETS ${EXE_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME} COMPONENT tests)
 
@@ -71,6 +85,7 @@ list(LENGTH GPU_TARGETS list_count)
 if (${list_count} LESS_EQUAL 1)
   string(REPLACE " " ";" GPU_LIST "${GPU_TARGETS}")
   string(REPLACE "," ";" GPU_LIST "${GPU_TARGETS}")
+  message(STATUS "GPU_TARGETS is ${GPU_TARGETS}")
 else()
   set(GPU_LIST ${GPU_TARGETS})
 endif()

--- a/projects/aqlprofile/test/app/test.cpp
+++ b/projects/aqlprofile/test/app/test.cpp
@@ -35,6 +35,33 @@
 #include "pgen/test_pgen_sqtt.h"
 #include "simple_convolution/simple_convolution.h"
 
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+
+// Minimal host memory callbacks for aqlprofile_pmc_create_packets (see also integration/counter.cpp).
+hsa_status_t new_tests_mem_alloc(void** ptr, uint64_t size,
+                                 aqlprofile_buffer_desc_flags_t /*flags*/, void* /*userdata*/) {
+  *ptr = std::malloc(static_cast<size_t>(size));
+  return *ptr ? HSA_STATUS_SUCCESS : HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+}
+
+void new_tests_mem_dealloc(void* ptr, void* /*userdata*/) { std::free(ptr); }
+
+hsa_status_t new_tests_mem_copy(void* dst, const void* src, size_t size, void* /*userdata*/) {
+  if (size == 0) return HSA_STATUS_SUCCESS;
+  std::memcpy(dst, src, size);
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t new_tests_pmc_data_cb(aqlprofile_pmc_event_t /*event*/, uint64_t /*counter_id*/,
+                                   uint64_t /*counter_value*/, void* /*userdata*/) {
+  return HSA_STATUS_SUCCESS;
+}
+
+}  // namespace
+
 char** pmc_argv(unsigned argc, const hsa_ven_amd_aqlprofile_event_t* events) {
   const int argv_pmc_size = 32;
   static unsigned argc_pmc = 0;
@@ -67,6 +94,7 @@ int main(int argc, char* argv[]) {
   const bool scan_enable = (getenv("AQLPROFILE_SCAN") != NULL);
   const bool trace_enable = (getenv("AQLPROFILE_TRACE") != NULL);
   const bool spm_enable = (getenv("AQLPROFILE_SPM") != NULL);
+  const bool new_tests = (getenv("AQLPROFILE_NEW_TESTS") != NULL);
   int scan_step = 1;
   const char* step_env = getenv("AQLPROFILE_SCAN_STEP");
   if (step_env != NULL) {
@@ -92,6 +120,83 @@ int main(int argc, char* argv[]) {
 
   TestHsa::HsaInstantiate();
   const hsa_ven_amd_aqlprofile_event_t* events_arr;
+
+  if (new_tests) {
+    HsaRsrcFactory* rsrc = TestHsa::HsaInstantiate();
+    const AgentInfo* gpu = nullptr;
+    if (!rsrc || !rsrc->GetGpuAgentInfo(TestHsa::HsaAgentId(), &gpu) || gpu == nullptr) {
+      std::cerr << "AQLPROFILE_NEW_TESTS: GPU agent not available" << std::endl;
+      TestHsa::HsaShutdown();
+      return 1;
+    }
+
+    aqlprofile_agent_info_t agent_info{};
+    agent_info.agent_gfxip = gpu->gfxip;
+    agent_info.xcc_num = gpu->xcc_num;
+    agent_info.se_num = gpu->se_num;
+    agent_info.cu_num = gpu->cu_num;
+    agent_info.shader_arrays_per_se = gpu->shader_arrays_per_se;
+
+    // Skeleton exercises both registration entry points; a full integration typically uses one.
+    aqlprofile_agent_handle_t agent_v0{};
+    if (aqlprofile_register_agent(&agent_v0, &agent_info) != HSA_STATUS_SUCCESS) {
+      std::cerr << "AQLPROFILE_NEW_TESTS: aqlprofile_register_agent failed" << std::endl;
+      TestHsa::HsaShutdown();
+      return 1;
+    }
+
+    aqlprofile_agent_info_v1_t agent_info_v1{};
+    agent_info_v1.agent_gfxip = gpu->gfxip;
+    agent_info_v1.xcc_num = gpu->xcc_num;
+    agent_info_v1.se_num = gpu->se_num;
+    agent_info_v1.cu_num = gpu->cu_num;
+    agent_info_v1.shader_arrays_per_se = gpu->shader_arrays_per_se;
+    agent_info_v1.domain = gpu->domain;
+    agent_info_v1.location_id = gpu->bdf_id;
+
+    aqlprofile_agent_handle_t agent_v1{};
+    if (aqlprofile_register_agent_info(&agent_v1, &agent_info_v1, AQLPROFILE_AGENT_VERSION_V1) !=
+        HSA_STATUS_SUCCESS) {
+      std::cerr << "AQLPROFILE_NEW_TESTS: aqlprofile_register_agent_info failed" << std::endl;
+      TestHsa::HsaShutdown();
+      return 1;
+    }
+
+    aqlprofile_pmc_event_flags_t ev_flags{};
+    ev_flags.raw = 0;
+    aqlprofile_pmc_event_t events_v2[1] = {};
+    events_v2[0].block_index = 0;
+    events_v2[0].event_id = 2;
+    events_v2[0].flags = ev_flags;
+    events_v2[0].block_name = HSA_VEN_AMD_AQLPROFILE_BLOCK_NAME_SQ;
+
+    aqlprofile_pmc_profile_t profile{};
+    profile.agent = agent_v1;
+    profile.events = events_v2;
+    profile.event_count = 1;
+
+    aqlprofile_handle_t pmc_handle{};
+    aqlprofile_pmc_aql_packets_t packets{};
+    hsa_status_t st = aqlprofile_pmc_create_packets(&pmc_handle, &packets, profile,
+                                                    new_tests_mem_alloc, new_tests_mem_dealloc,
+                                                    new_tests_mem_copy, nullptr);
+    (void)agent_v0;
+
+    if (st == HSA_STATUS_SUCCESS) {
+      packets.start_packet.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC << HSA_PACKET_HEADER_TYPE;
+      packets.stop_packet.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC << HSA_PACKET_HEADER_TYPE;
+      packets.read_packet.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC << HSA_PACKET_HEADER_TYPE;
+      // TODO: enqueue start_packet, kernel dispatch, stop_packet, read_packet on TestHsa::GetQueue()
+      (void)aqlprofile_pmc_iterate_data(pmc_handle, new_tests_pmc_data_cb, nullptr);
+      aqlprofile_pmc_delete_packets(pmc_handle);
+    } else {
+      std::cerr << "AQLPROFILE_NEW_TESTS: aqlprofile_pmc_create_packets failed" << std::endl;
+    }
+
+    //TODO: Identify how to start simple convolution test here.
+    TestHsa::HsaShutdown();
+    return (st == HSA_STATUS_SUCCESS) ? 0 : 1;
+  }
 
   // Run simple convolution test
   if (pmc_enable) {

--- a/projects/aqlprofile/test/ctrl/run_kernel.h
+++ b/projects/aqlprofile/test/ctrl/run_kernel.h
@@ -35,19 +35,14 @@ bool RunKernel(int argc, char* argv[], int count = 1) {
   Kernel test_kernel;
   TestAql* test_hsa = new TestHsa(&test_kernel);
   TEST_ASSERT(test_hsa != NULL);
-  if (test_hsa == NULL) return false;
   TestAql* test_aql = new Test(test_hsa);
   TEST_ASSERT(test_aql != NULL);
-  if (test_aql == NULL) {
-    delete test_hsa;
-    return false;
-  }
+  
 
   // Initialization of Hsa Runtime
   ret_val = test_aql->Initialize(argc, argv);
   if (ret_val == false) {
     std::cerr << "Error in the test initialization" << std::endl;
-    // TEST_ASSERT(ret_val);
     delete test_aql;
     return false;
   }

--- a/projects/aqlprofile/test/ctrl/test_aql.h
+++ b/projects/aqlprofile/test/ctrl/test_aql.h
@@ -25,8 +25,6 @@
 #define TEST_CTRL_TEST_AQL_H_
 
 #include <hsa/hsa.h>
-#include <hsa/hsa_ven_amd_aqlprofile.h>
-
 #include "util/hsa_rsrc_factory.h"
 
 // Test AQL interface

--- a/projects/aqlprofile/test/integration/main.cpp
+++ b/projects/aqlprofile/test/integration/main.cpp
@@ -91,29 +91,26 @@ class HIPWorkload : public IWorkload
 public:
     HIPWorkload(AgentInfo& agent, const std::vector<std::string>& counters)
     {
-        col = std::make_unique<Collection>(agent, counters);
+        collection = std::make_unique<Collection>(agent, counters);
     }
     virtual ~HIPWorkload() {};
     virtual std::string_view name() = 0;
 
-    std::map<std::string, int64_t> collect(Queue& queue)
-    {
-        assert(col);
-        return col->iterate(queue, *this);
-    }
-
     void printcounters(Queue& queue)
     {
+        assert(collection);
+        std::map<std::string, int64_t> entries = collection->iterate(queue, *this);
         std::cout << "Name: " << name() << std::endl;
-        for (auto& [name, v] : collect(queue)) std::cout << " - " << name << ": " << v << std::endl;
+        for (auto& [name, v] : entries) {
+             std::cout << " - " << name << ": " << v << std::endl;
+        }
     }
 
-    std::unique_ptr<Collection> col{nullptr};
+    std::unique_ptr<Collection> collection{nullptr};
     hipMemory src{DATA_SIZE};
     hipMemory dst{DATA_SIZE};
     Stream stream{};
 };
-
 
 __global__ void copy_kernel(float* a, const float* b)
 {
@@ -370,11 +367,6 @@ auto io_counters(std::string_view gfxip)
         counters.push_back("TCC_EA0_RDREQ_DRAM_CREDIT_STALL");
     }
     return counters;
-}
-
-void printcounters(const std::map<std::string, int64_t>& map)
-{
-    for (auto& [name, v] : map) std::cout << " - " << name << ": " << v << std::endl;
 }
 
 int main()


### PR DESCRIPTION
## Motivation

We would like to replace the deprecated Aqlpfoile APIs with newer APIs from aqlprofile-sdk/aql_profile_v2.h
This is first step towards it. 
TODO: Need to invoke simple_convolution in the flow. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->


## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
