### PR TITLE
[RCCL] MemManager: public Suspend/Resume API + group context

### DIFF
--- a/projects/rccl/src/group.cc
+++ b/projects/rccl/src/group.cc
@@ -286,6 +286,20 @@ ncclResult_t ncclCommGroupRegisterSymmetric(struct ncclAsyncJob* job_) {
     free(task);
   }
 
+  while (!ncclIntruQueueEmpty(&comm->suspendTaskQueue)) {
+    struct ncclMemManagerTask* task = ncclIntruQueueDequeue(&comm->suspendTaskQueue);
+    struct ncclComm* taskComm = task->comm;
+    free(task);
+    NCCLCHECKGOTO(ncclCommMemSuspend(taskComm), ret, fail);
+  }
+
+  while (!ncclIntruQueueEmpty(&comm->resumeTaskQueue)) {
+    struct ncclMemManagerTask* task = ncclIntruQueueDequeue(&comm->resumeTaskQueue);
+    struct ncclComm* taskComm = task->comm;
+    free(task);
+    NCCLCHECKGOTO(ncclCommMemResume(taskComm), ret, fail);
+  }
+
 exit:
   return ret;
 fail:

--- a/projects/rccl/src/include/alloc.h
+++ b/projects/rccl/src/include/alloc.h
@@ -509,6 +509,16 @@ static inline ncclResult_t ncclCuMemFree(void *ptr, struct ncclMemManager* manag
     INFO(NCCL_ALLOC, "ncclCuMemFree: Skipping free (process shutdown) pointer %p", ptr);
     return ncclSuccess;
   }
+
+  // RCCL: skip teardown when the comm is Suspended. Suspend has already
+  // released physical memory and unmapped the VA; ncclMemManagerDestroy
+  // takes care of cuMemAddressFree for every Released entry
+  if(manager != nullptr && __atomic_load_n(&manager->released, __ATOMIC_ACQUIRE))
+  {
+      INFO(NCCL_ALLOC, "ncclCuMemFree: comm suspended, leaving %p to ncclMemManagerDestroy", ptr);
+      return ncclSuccess;
+  }
+
   ncclResult_t result = ncclSuccess;
   size_t totalSize = 0;
   for (int segment = 0; segment < numSegments; segment++) {
@@ -730,6 +740,18 @@ ncclResult_t ncclCudaFree(T* ptr, struct ncclMemManager* manager, int numSegment
   if (rcclShutdownFlag().load(std::memory_order_acquire)) {
     INFO(NCCL_ALLOC, "ncclCudaFree: Skipping free (process shutdown) pointer %p", ptr);
     return ncclSuccess;
+  }
+
+  // RCCL: ncclCommDestroy may be invoked while the comm is in the Suspended
+  // state. Suspend has already done cuMemUnmap + cuMemRelease on every tracked
+  // entry, and ncclMemManagerDestroy reclaims the VA reservation for each
+  // Released entry.
+  if(manager != nullptr && __atomic_load_n(&manager->released, __ATOMIC_ACQUIRE))
+  {
+      INFO(NCCL_ALLOC,
+           "ncclCudaFree: comm suspended, leaving %p to ncclMemManagerDestroy",
+           (void*)ptr);
+      return ncclSuccess;
   }
 
   ncclResult_t result = ncclSuccess;

--- a/projects/rccl/src/include/api_trace.h
+++ b/projects/rccl/src/include/api_trace.h
@@ -31,7 +31,7 @@
 #define RCCL_API_TRACE_VERSION_MAJOR 0
 
 // should be increased every time new members are added to existing dispatch tables
-#define RCCL_API_TRACE_VERSION_PATCH 3
+#define RCCL_API_TRACE_VERSION_PATCH 4
 
 #if !defined(RCCL_EXTERN_C_INIT)
 #    ifdef __cplusplus
@@ -166,6 +166,12 @@ typedef ncclResult_t (*ncclCommWindowRegister_fn_t)(ncclComm_t comm, void* userP
 
 typedef ncclResult_t (*ncclCommWindowDeregister_fn_t)(ncclComm_t comm, ncclWindow_t win);
 
+typedef ncclResult_t (*ncclCommSuspend_fn_t)(ncclComm_t comm, int flags);
+
+typedef ncclResult_t (*ncclCommResume_fn_t)(ncclComm_t comm);
+
+typedef ncclResult_t (*ncclCommMemStats_fn_t)(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value);
+
 typedef struct rcclApiFuncTable
 {
     // ADD NEW FUNCTIONS AT BOTTOM ONLY
@@ -213,6 +219,9 @@ typedef struct rcclApiFuncTable
     ncclCommWindowDeregister_fn_t ncclCommWindowDeregister_fn;
     ncclAlltoAll_fn_t             ncclAlltoAll_fn;
     ncclAlltoAllv_fn_t            ncclAlltoAllv_fn;
+    ncclCommSuspend_fn_t          ncclCommSuspend_fn;
+    ncclCommResume_fn_t           ncclCommResume_fn;
+    ncclCommMemStats_fn_t         ncclCommMemStats_fn;
     // ADD NEW FUNCTIONS HERE ONLY
 } rcclApiFuncTable;
 

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -792,6 +792,8 @@ struct ncclComm {
   void* tempBuff;
 
   struct ncclMemManager* memManager;  // Memory manager
+  struct ncclIntruQueue<struct ncclMemManagerTask, &ncclMemManagerTask::next> suspendTaskQueue;
+  struct ncclIntruQueue<struct ncclMemManagerTask, &ncclMemManagerTask::next> resumeTaskQueue;
 
   uint64_t endMagic;
 };

--- a/projects/rccl/src/include/mem_manager.h
+++ b/projects/rccl/src/include/mem_manager.h
@@ -182,7 +182,11 @@ ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* pt
 
 ncclResult_t ncclCommMemSuspend(struct ncclComm* comm);
 ncclResult_t ncclCommMemResume(struct ncclComm* comm);
-ncclResult_t ncclCommMemStats(struct ncclComm* comm, ncclCommMemStat_t stat, uint64_t* value);
+
+// RCCL: Public API _impl entry points (dispatched from src/misc/api_trace.cc)
+ncclResult_t ncclCommSuspend_impl(ncclComm_t comm, int flags);
+ncclResult_t ncclCommResume_impl(ncclComm_t comm);
+ncclResult_t ncclCommMemStats_impl(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value);
 
 #ifdef __cplusplus
 }

--- a/projects/rccl/src/include/p2p.h
+++ b/projects/rccl/src/include/p2p.h
@@ -65,9 +65,9 @@ struct ncclIpcRegInfo {
   struct ncclIpcImpInfo impInfo;
 };
 
-ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int directMap, ncclIpcDesc *ipcDesc, void **ptr, struct ncclMemManager* manager = nullptr, ncclMemType_t memtype = ncclMemPersist);
+ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int directMap, ncclIpcDesc *ipcDesc, void **ptr, int peerRank = -1, struct ncclMemManager* manager = nullptr, ncclMemType_t memtype = ncclMemPersist);
 ncclResult_t ncclP2pFreeShareableBuffer(ncclIpcDesc *ipcDesc);
-ncclResult_t ncclP2pImportShareableBuffer(struct ncclComm *comm, int peer, size_t size, ncclIpcDesc *ipcDesc, void **devMemPtr);
+ncclResult_t ncclP2pImportShareableBuffer(struct ncclComm *comm, int peer, size_t size, ncclIpcDesc *ipcDesc, void **devMemPtr, void* ownerPtr = nullptr, ncclMemType_t memType = ncclMemPersist);
 ncclResult_t ncclIpcLocalRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize, int* peerRanks, int nPeers, ncclIpcRegType type, int* regBufFlag, uintptr_t* offsetOut, uintptr_t** peerRmtAddrsOut);
 ncclResult_t ncclIpcGraphRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize, int* peerRanks, int nPeers, ncclIpcRegType type, int* regBufFlag, uintptr_t* offsetOut, uintptr_t** peerRmtAddrsOut, void* cleanupQueuePtr, int* nCleanupQueueElts);
 

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -517,8 +517,15 @@ static ncclResult_t commFree(ncclComm_t comm) {
     }
   }
 
-  // Destroy dynamic memory manager only after all proxy threads have been joined
-  NCCLCHECK(ncclMemManagerDestroy(comm));
+  // Free any pending suspend/resume tasks
+  while (!ncclIntruQueueEmpty(&comm->suspendTaskQueue)) {
+    struct ncclMemManagerTask* task = ncclIntruQueueDequeue(&comm->suspendTaskQueue);
+    free(task);
+  }
+  while (!ncclIntruQueueEmpty(&comm->resumeTaskQueue)) {
+    struct ncclMemManagerTask* task = ncclIntruQueueDequeue(&comm->resumeTaskQueue);
+    free(task);
+  }
 
   if (comm->memPool) CUDACHECK(cudaMemPoolDestroy(comm->memPool));
 
@@ -616,6 +623,10 @@ skip_profiling:
     NCCLCHECK(dtor->fn(dtor));
     dtor = dtor->next;
   }
+
+  // RCCL: deferred from earlier in commFree. All ncclCudaFree callers have
+  // run by now, so it is safe to reclaim Released-entry VAs and free the manager.
+  NCCLCHECK(ncclMemManagerDestroy(comm));
 
   ncclMemoryStackDestruct(&comm->memScoped);
   ncclMemoryStackDestruct(&comm->memPermanent);
@@ -858,6 +869,8 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
   ncclIntruQueueMpscConstruct(&comm->callbackQueue);
   ncclIntruQueueConstruct(&comm->legacyRegCleanupQueue);
   ncclIntruQueueConstruct(&comm->ceInitTaskQueue);
+  ncclIntruQueueConstruct(&comm->suspendTaskQueue);
+  ncclIntruQueueConstruct(&comm->resumeTaskQueue);
 
   comm->regCache.pageSize = sysconf(_SC_PAGESIZE);
 

--- a/projects/rccl/src/mem_manager.cc
+++ b/projects/rccl/src/mem_manager.cc
@@ -928,13 +928,18 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
         // Use proxy to convert cuMem handle to FD
         int fd = -1;
 
+        // RCCL: use a local result so a successful conversion does not clobber
+        // a prior partial-failure ret set earlier in the loop
         // The handleData contains the cuMem handle - request FD conversion
-        ret = ncclProxyClientGetFdBlocking(comm, entry->desc.imported.ownerRank,
-                                           &matchedInfo->handleData, &fd);
-        if (ret != ncclSuccess || fd < 0) {
+        ncclResult_t fdRet =
+          ncclProxyClientGetFdBlocking(comm, entry->desc.imported.ownerRank,
+                                       &matchedInfo->handleData, &fd);
+        if (fdRet != ncclSuccess || fd < 0) {
           WARN("MemManager: Failed to get FD from rank %d for ptr=%p",
                entry->desc.imported.ownerRank, entry->ptr);
-          if (ret == ncclSuccess) ret = ncclSystemError;  // fd < 0 with success ret
+          if (ret == ncclSuccess) {
+            ret = (fdRet != ncclSuccess) ? fdRet : ncclSystemError;
+          }
           entry = entry->next;
           continue;
         }
@@ -1026,7 +1031,122 @@ fail:
   return ret;
 }
 
-ncclResult_t ncclCommMemStats(struct ncclComm* comm, ncclCommMemStat_t stat, uint64_t* value) {
+/*
+ * Public Communicator Suspend/Resume APIs
+ *
+ * Tasks are queued and drained in groupLaunch (group context) so that
+ * ncclGroupStart()/ncclGroupEnd() wrapping multi-comm Suspend/Resume becomes
+ * atomic. When called outside a group, ncclGroupStartInternal/EndInternal
+ * provides an implicit single-comm group that drains immediately.
+ */
+
+ncclResult_t ncclCommSuspend_impl(ncclComm_t comm, int flags) {
+  NCCL_NVTX3_FUNC_RANGE;
+
+  NCCLCHECK(CommCheck(comm, "ncclCommSuspend", "comm"));
+  NCCLCHECK(ncclCommEnsureReady(comm));
+
+  // RCCL: reject flags==0 and unknown bits before group barrier.
+  if (flags == 0 || (flags & ~NCCL_SUSPEND_MEM) != 0) {
+    WARN("ncclCommSuspend: invalid flags 0x%x (must be NCCL_SUSPEND_MEM)", flags);
+    return ncclInvalidArgument;
+  }
+
+  ncclResult_t ret = ncclSuccess;
+  int saveDev;
+  CUDACHECK(cudaGetDevice(&saveDev));
+  NCCLCHECK(ncclGroupStartInternal());
+  CUDACHECKGOTO(cudaSetDevice(comm->cudaDev), ret, fail);
+
+  if (flags & NCCL_SUSPEND_MEM) {
+    if (ncclParamMemManagerDisable()) {
+      WARN("MemManager: Suspend not supported, memory manager is disabled");
+      ret = ncclInvalidUsage;
+      goto fail;
+    }
+    if (comm->memManager && comm->memManager->refCount > 1) {
+      WARN("Memory suspend not supported with split_share communicators (refCount=%d)",
+           comm->memManager->refCount);
+      ret = ncclInvalidUsage;
+      goto fail;
+    }
+    // RCCL: reject double-Suspend. Queue-aware: pending Resume in
+    // resumeTaskQueue will flip released=0 during drain, so accept it.
+    if (comm->memManager &&
+        __atomic_load_n(&comm->memManager->released, __ATOMIC_ACQUIRE) &&
+        ncclIntruQueueEmpty(&comm->resumeTaskQueue)) {
+      WARN("ncclCommSuspend: rank %d already suspended", comm->rank);
+      ret = ncclInvalidUsage;
+      goto fail;
+    }
+    INFO(NCCL_INIT, "ncclCommSuspend: rank %d suspending memory", comm->rank);
+    struct ncclMemManagerTask* task;
+    NCCLCHECKGOTO(ncclCalloc(&task, 1), ret, fail);
+    task->comm = comm;
+    ncclIntruQueueEnqueue(&comm->suspendTaskQueue, task);
+    ncclGroupCommJoin(comm, ncclGroupTaskTypeSymRegister); // Reuse to avoid creating a new task type
+  }
+
+exit:
+  ncclGroupErrCheck(ret);
+  NCCLCHECK(ncclGroupEndInternal());
+  if (comm && !comm->config.blocking) { NCCLCHECK(ncclCommGetAsyncError(comm, &ret)); }
+  CUDACHECK(cudaSetDevice(saveDev));
+  return ret;
+fail:
+  goto exit;
+}
+
+ncclResult_t ncclCommResume_impl(ncclComm_t comm) {
+  NCCL_NVTX3_FUNC_RANGE;
+
+  NCCLCHECK(CommCheck(comm, "ncclCommResume", "comm"));
+  NCCLCHECK(ncclCommEnsureReady(comm));
+
+  ncclResult_t ret = ncclSuccess;
+  int saveDev;
+  CUDACHECK(cudaGetDevice(&saveDev));
+  NCCLCHECK(ncclGroupStartInternal());
+  CUDACHECKGOTO(cudaSetDevice(comm->cudaDev), ret, fail);
+
+  if (ncclParamMemManagerDisable()) {
+    WARN("MemManager: Resume not supported, memory manager is disabled");
+    ret = ncclInvalidUsage;
+    goto fail;
+  }
+  if (comm->memManager && comm->memManager->refCount > 1) {
+    WARN("Memory resume not supported with split_share communicators (refCount=%d)",
+         comm->memManager->refCount);
+    ret = ncclInvalidUsage;
+    goto fail;
+  }
+  // RCCL: reject Resume on active comm. Queue-aware: pending Suspend in
+  // suspendTaskQueue will flip released=1 during drain, so accept it.
+  if (comm->memManager &&
+      !__atomic_load_n(&comm->memManager->released, __ATOMIC_ACQUIRE) &&
+      ncclIntruQueueEmpty(&comm->suspendTaskQueue)) {
+    WARN("ncclCommResume: rank %d not suspended", comm->rank);
+    ret = ncclInvalidUsage;
+    goto fail;
+  }
+  INFO(NCCL_INIT, "ncclCommResume: rank %d resuming all resources", comm->rank);
+  struct ncclMemManagerTask* task;
+  NCCLCHECKGOTO(ncclCalloc(&task, 1), ret, fail);
+  task->comm = comm;
+  ncclIntruQueueEnqueue(&comm->resumeTaskQueue, task);
+  ncclGroupCommJoin(comm, ncclGroupTaskTypeSymRegister); // Reuse to avoid creating a new task type
+
+exit:
+  ncclGroupErrCheck(ret);
+  NCCLCHECK(ncclGroupEndInternal());
+  if (comm && !comm->config.blocking) { NCCLCHECK(ncclCommGetAsyncError(comm, &ret)); }
+  CUDACHECK(cudaSetDevice(saveDev));
+  return ret;
+fail:
+  goto exit;
+}
+
+ncclResult_t ncclCommMemStats_impl(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value) {
   NCCL_NVTX3_FUNC_RANGE;
 
   NCCLCHECK(CommCheck(comm, "ncclCommMemStats", "comm"));

--- a/projects/rccl/src/misc/api_trace.cc
+++ b/projects/rccl/src/misc/api_trace.cc
@@ -153,6 +153,15 @@ ncclResult_t
 ncclCommWindowDeregister_impl(ncclComm_t comm, ncclWindow_t win);
 
 ncclResult_t
+ncclCommSuspend_impl(ncclComm_t comm, int flags);
+
+ncclResult_t
+ncclCommResume_impl(ncclComm_t comm);
+
+ncclResult_t
+ncclCommMemStats_impl(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value);
+
+ncclResult_t
 ncclAllReduceWithBias_impl(const void* sendbuff, void* recvbuff, size_t count,
                    ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm,
                    cudaStream_t stream, const void* acc);
@@ -269,11 +278,14 @@ RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommWindowRegister_fn, 39);
 RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommWindowDeregister_fn, 40);
 RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclAlltoAll_fn, 41);
 RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclAlltoAllv_fn, 42);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommSuspend_fn, 43);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommResume_fn, 44);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommMemStats_fn, 45);
 // DO NOT REORDER, ADD NEW ITEMS HERE
 
 #undef RCCL_ASSERT_OFFSET
 
-static_assert(sizeof(rcclApiFuncTable) == compute_table_size(43),
+static_assert(sizeof(rcclApiFuncTable) == compute_table_size(46),
               "Update table major/step version and add a new offset assertion if this "
               "fails to compile");
 
@@ -326,7 +338,10 @@ RcclGetFunctionTable_impl()
                                                &ncclCommWindowRegister_impl,
                                                &ncclCommWindowDeregister_impl,
                                                &ncclAlltoAll_impl,
-                                               &ncclAlltoAllv_impl
+                                               &ncclAlltoAllv_impl,
+                                               &ncclCommSuspend_impl,
+                                               &ncclCommResume_impl,
+                                               &ncclCommMemStats_impl
                                                // DO NOT REORDER, ADD NEW ITEMS HERE
                                              };
 
@@ -480,6 +495,13 @@ NCCL_API(ncclResult_t, ncclCommWindowRegister, ncclComm_t comm, void* buff, size
          ncclWindow_t* win, int winFlags);
 
 NCCL_API(ncclResult_t, ncclCommWindowDeregister, ncclComm_t comm, ncclWindow_t win);
+
+NCCL_API(ncclResult_t, ncclCommSuspend, ncclComm_t comm, int flags);
+
+NCCL_API(ncclResult_t, ncclCommResume, ncclComm_t comm);
+
+NCCL_API(ncclResult_t, ncclCommMemStats, ncclComm_t comm, ncclCommMemStat_t stat,
+         uint64_t* value);
 
 ncclResult_t
 ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcount,
@@ -787,4 +809,22 @@ ncclResult_t
 ncclCommWindowDeregister(ncclComm_t comm, ncclWindow_t win)
 {
     return ::rccl::RcclGetFunctionTable()->ncclCommWindowDeregister_fn(comm, win);
+}
+
+ncclResult_t
+ncclCommSuspend(ncclComm_t comm, int flags)
+{
+    return ::rccl::RcclGetFunctionTable()->ncclCommSuspend_fn(comm, flags);
+}
+
+ncclResult_t
+ncclCommResume(ncclComm_t comm)
+{
+    return ::rccl::RcclGetFunctionTable()->ncclCommResume_fn(comm);
+}
+
+ncclResult_t
+ncclCommMemStats(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value)
+{
+    return ::rccl::RcclGetFunctionTable()->ncclCommMemStats_fn(comm, stat, value);
 }

--- a/projects/rccl/src/nccl.h.in
+++ b/projects/rccl/src/nccl.h.in
@@ -25,6 +25,7 @@
 #define RCCL_GATHER_SCATTER 1
 #define RCCL_ALLTOALLV 1
 #define RCCL_ALLREDUCE_WITH_BIAS 1
+#define RCCL_SUSPEND_RESUME 1
 
 #ifdef __cplusplus
 extern "C" {
@@ -372,13 +373,6 @@ ncclResult_t  ncclCommGetAsyncError(ncclComm_t comm, ncclResult_t *asyncError);
 /*! @cond       include_hidden */
 ncclResult_t pncclCommGetAsyncError(ncclComm_t comm, ncclResult_t *asyncError);
 /*! @endcond */
-
-typedef enum {
-  ncclStatGpuMemSuspend      = 0,  // Allocated GPU memory that can be suspended (bytes)
-  ncclStatGpuMemSuspended    = 1,   // GPU memory suspended? (0=active, 1=suspended)
-  ncclStatGpuMemPersist      = 2,  // Allocated GPU memory that cannot be suspended (bytes)
-  ncclStatGpuMemTotal        = 3  // Total allocated GPU memory tracked by NCCL (bytes)
-} ncclCommMemStat_t;
 /*! @} */
 
 /*! @defgroup   rccl_api_comminfo Communicator Information
@@ -429,6 +423,53 @@ ncclResult_t pncclCommRegister(const ncclComm_t comm, void* buff, size_t size, v
 ncclResult_t  ncclCommDeregister(const ncclComm_t comm, void* handle);
 /*! @cond       include_hidden */
 ncclResult_t pncclCommDeregister(const ncclComm_t comm, void* handle);
+/*! @endcond */
+
+/* Communicator suspend flags */
+#define NCCL_SUSPEND_MEM 0x01 // Suspend memory (release dynamic allocations)
+
+/*
+ * ncclCommSuspend
+ *
+ * Suspend communicator operations to free resources.
+ * The communicator cannot be used while suspended.
+ *
+ * flags: NCCL_SUSPEND_MEM - Release dynamic GPU memory allocations
+ */
+ncclResult_t  ncclCommSuspend(ncclComm_t comm, int flags);
+/*! @cond       include_hidden */
+ncclResult_t pncclCommSuspend(ncclComm_t comm, int flags);
+/*! @endcond */
+
+/*
+ * ncclCommResume
+ *
+ * Resume all previously suspended communicator resources.
+ */
+ncclResult_t  ncclCommResume(ncclComm_t comm);
+/*! @cond       include_hidden */
+ncclResult_t pncclCommResume(ncclComm_t comm);
+/*! @endcond */
+
+/* Communicator memory statistics */
+typedef enum {
+  ncclStatGpuMemSuspend      = 0,  // Allocated GPU memory that can be suspended (bytes)
+  ncclStatGpuMemSuspended    = 1,  // GPU memory suspended? (0=active, 1=suspended)
+  ncclStatGpuMemPersist      = 2,  // Allocated GPU memory that cannot be suspended (bytes)
+  ncclStatGpuMemTotal        = 3   // Total allocated GPU memory tracked by NCCL (bytes)
+} ncclCommMemStat_t;
+
+/*
+ * ncclCommMemStats
+ *
+ * Query communicator memory statistics.
+ *
+ * stat: One of ncclCommMemStat_t values
+ * value: Output pointer to receive the memory statistic value
+ */
+ncclResult_t  ncclCommMemStats(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value);
+/*! @cond       include_hidden */
+ncclResult_t pncclCommMemStats(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value);
 /*! @endcond */
 
 /* Register memory window  */

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -643,20 +643,24 @@ static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* conne
     if (!map->sameProcess) NCCLCHECK(netMapShm(comm, &send->proxyConn, map->mems + NCCL_NET_MAP_HOSTMEM));
     if (map->mems[NCCL_NET_MAP_DEVMEM].size) {
       map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr = NULL;
+      // NET transport import: No ownerVA available, mark as Persist (do not release)
       NCCLCHECK(ncclP2pImportShareableBuffer(comm, send->proxyConn.rank,
                                             map->mems[NCCL_NET_MAP_DEVMEM].size,
                                             &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,
-                                            (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr));
+                                            (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr,
+                                            nullptr, ncclMemPersist));
       map->mems[NCCL_NET_MAP_DEVMEM].cpuPtr = NULL;
     }
     if (map->mems[NCCL_NET_MAP_SHARED_DEVMEM].size) {
       void** sharedDevMemPtr = comm->proxyState->sharedDevMems + send->proxyConn.tpLocalRank;
       if (*sharedDevMemPtr == NULL) {
         map->mems[NCCL_NET_MAP_SHARED_DEVMEM].gpuPtr = NULL;
+        // NET transport shared import: No ownerVA, mark as Persist (do not release)
         NCCLCHECK(ncclP2pImportShareableBuffer(comm, send->proxyConn.rank,
                                               map->mems[NCCL_NET_MAP_SHARED_DEVMEM].size,
                                               &map->mems[NCCL_NET_MAP_SHARED_DEVMEM].ipcDesc,
-                                              sharedDevMemPtr));
+                                              sharedDevMemPtr,
+                                              nullptr, ncclMemPersist));
       }
       map->mems[NCCL_NET_MAP_SHARED_DEVMEM].gpuPtr = (char*)(*sharedDevMemPtr);
       map->mems[NCCL_NET_MAP_SHARED_DEVMEM].cpuPtr = NULL;
@@ -834,7 +838,7 @@ static ncclResult_t sharedNetBuffersInit(struct ncclProxyState* proxyState, int 
 
   if (cuda && state->cudaBuff == NULL) {
     if (sameProcess == 0 || ncclCuMemEnable()) {
-      NCCLCHECK(ncclP2pAllocateShareableBuffer(state->size, 0, &state->ipcDesc, (void**)&state->cudaBuff, proxyState->memManager, ncclMemPersist));
+      NCCLCHECK(ncclP2pAllocateShareableBuffer(state->size, 0, &state->ipcDesc, (void**)&state->cudaBuff, /*peerRank=*/-1, proxyState->memManager, ncclMemPersist));
     } else {
 #if defined(HIP_UNCACHED_MEMORY)
 #if defined(HIP_CONTIGUOUS_MEMORY)
@@ -1157,7 +1161,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
       if (!map->sameProcess || ncclCuMemEnable()) {
         ALIGN_SIZE(map->mems[NCCL_NET_MAP_DEVMEM].size, CUDA_IPC_MIN);
         NCCLCHECK(ncclP2pAllocateShareableBuffer(map->mems[NCCL_NET_MAP_DEVMEM].size, 0, &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,
-                                                (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, proxyState->memManager, ncclMemPersist));
+                                                (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, /*peerRank=*/-1, proxyState->memManager, ncclMemPersist));
 #if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
         // Get DMA-BUF fd for cuMem VMM allocations via cuMemGetHandleForAddressRange.
         // Required even when DMA-BUF is globally disabled: ibv_reg_mr on cuMem RDMA
@@ -1383,7 +1387,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
     if (resources->shared == 0) {
       if (ncclCuMemEnable()) {
         NCCLCHECK(ncclP2pAllocateShareableBuffer(map->mems[NCCL_NET_MAP_DEVMEM].size, 0, &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,
-                                                (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, proxyState->memManager, ncclMemPersist));
+                                                (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, /*peerRank=*/-1, proxyState->memManager, ncclMemPersist));
 #if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
         // Get DMA-BUF fd for cuMem VMM allocations. Required even when DMA-BUF is
         // globally disabled to avoid ibv_reg_mr on VMM memory.

--- a/projects/rccl/src/transport/p2p.cc
+++ b/projects/rccl/src/transport/p2p.cc
@@ -29,6 +29,7 @@ struct ncclP2pBuff {
 struct ncclP2pRequest {
   size_t size;
   int refcount;
+  int peerRank;
 };
 
 struct p2pConnectInfo {
@@ -223,7 +224,7 @@ ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph
   } while (0)
 
 // cuMem API support
-ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int refcount, ncclIpcDesc *ipcDesc, void **ptr, struct ncclMemManager* manager, ncclMemType_t memtype) {
+ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int refcount, ncclIpcDesc *ipcDesc, void **ptr, int peerRank, struct ncclMemManager* manager, ncclMemType_t memtype) {
   if (ncclCuMemEnable()) {
 #if ROCM_VERSION >= 70000
     CUmemAllocationHandleType type = ncclCuMemHandleType;
@@ -231,6 +232,9 @@ ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int refcount, ncclIpcDe
     // cuMem API support
     CUmemGenericAllocationHandle handle;
     NCCLCHECK(ncclCuMemAlloc(ptr, &handle, type, size, manager, memtype));
+    if (manager != nullptr && peerRank >= 0 && memtype != ncclMemPersist) {
+      NCCLCHECK(ncclDynMemMarkExportToPeer(manager, *ptr, peerRank));
+    }
     if (type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
       // Return the native cuMem handle for later Export/Import via UDS
       memcpy(&ipcDesc->cuDesc.data, &handle, sizeof(handle));
@@ -267,7 +271,7 @@ ncclResult_t ncclP2pFreeShareableBuffer(ncclIpcDesc *ipcDesc) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclP2pImportShareableBuffer(struct ncclComm *comm, int peer, size_t size, ncclIpcDesc *ipcDesc, void **devMemPtr) {
+ncclResult_t ncclP2pImportShareableBuffer(struct ncclComm *comm, int peer, size_t size, ncclIpcDesc *ipcDesc, void **devMemPtr, void* ownerPtr, ncclMemType_t memType) {
   if (ncclCuMemEnable()) {
 #if ROCM_VERSION >= 70000
     // cuMem API support
@@ -316,6 +320,10 @@ ncclResult_t ncclP2pImportShareableBuffer(struct ncclComm *comm, int peer, size_
     TRACE(NCCL_P2P, "Set Access for %p size %zu on dev %d", (void*)dptr, size, accessDesc.location.id);
 
     *devMemPtr = (void *)dptr;
+
+    // Track imported buffer
+    NCCLCHECK(ncclMemTrackImportFromPeer(comm->memManager, (void*)dptr, size, handle, type, memType,
+                                         peer, comm->peerInfo[peer].cudaDev, ownerPtr));
 #else
     return ncclInternalError;
 #endif
@@ -366,6 +374,12 @@ static ncclResult_t p2pMap(struct ncclComm *comm, struct ncclProxyConnector* pro
         NCCLCHECK(ncclCuMemAllocAddr(devMem, &p2pBuff->ipcDesc.memHandle, p2pBuff->size));
         CUCHECK(cuMemRelease(p2pBuff->ipcDesc.memHandle));
         *ipcPtr = *devMem;
+
+        // Track as imported peer memory for dynamic memory management.
+        // Pass handle=0 since we already released the reference above; suspend shouldn't release again.
+        NCCLCHECK(ncclMemTrackImportFromPeer(comm->memManager, *devMem, p2pBuff->size,
+                                             0, ncclCuMemHandleType, ncclMemOffload,
+                                             peerInfo->rank, peerInfo->cudaDev, p2pBuff->directPtr));
 #endif
       } else {
         *devMem = p2pBuff->directPtr;
@@ -377,7 +391,8 @@ static ncclResult_t p2pMap(struct ncclComm *comm, struct ncclProxyConnector* pro
     }
   } else {
     // Different PID
-    NCCLCHECK(ncclP2pImportShareableBuffer(comm, peerInfo->rank, p2pBuff->size, &p2pBuff->ipcDesc, devMem));
+    // Pass p2pBuff->directPtr as ownerPtr for P2P handle exchange during restore
+    NCCLCHECK(ncclP2pImportShareableBuffer(comm, peerInfo->rank, p2pBuff->size, &p2pBuff->ipcDesc, devMem, p2pBuff->directPtr, ncclMemOffload));
     *ipcPtr = *devMem;
   }
   return ncclSuccess;
@@ -449,6 +464,7 @@ ncclResult_t p2pSendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
   memset(&req, '\0', sizeof(req));
   req.size = sendSize;
   req.refcount = 0;
+  req.peerRank = peerInfo->rank;  // Track which peer will import this buffer
   if (P2P_SAME_PID((comm->peerInfo + info->rank), peerInfo) && (comm->peerInfo[info->rank].cudaDev != peerInfo->cudaDev)) req.refcount++;
   if (P2P_SAME_PID((comm->peerInfo + info->rank), myInfo) && (comm->peerInfo[info->rank].cudaDev != myInfo->cudaDev)) req.refcount++;
   NCCLCHECK(ncclProxyConnect(comm, TRANSPORT_P2P, 1, info->rank, &send->proxyConn));
@@ -509,6 +525,7 @@ ncclResult_t p2pRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
   memset(&req, '\0', sizeof(req));
   req.size = recvSize;
   req.refcount = 0;
+  req.peerRank = peerInfo->rank;  // Track which peer will import this buffer
   if (P2P_SAME_PID((comm->peerInfo + info->rank), peerInfo) && (comm->peerInfo[info->rank].cudaDev != peerInfo->cudaDev)) req.refcount++;
   if (P2P_SAME_PID((comm->peerInfo + info->rank), myInfo) && (comm->peerInfo[info->rank].cudaDev != myInfo->cudaDev)) req.refcount++;
   NCCLCHECK(ncclProxyConnect(comm, TRANSPORT_P2P, 0, info->rank, &recv->proxyConn));
@@ -689,7 +706,7 @@ static ncclResult_t p2pSendProxySetup(struct ncclProxyConnection* connection, st
     int size = req->size;
     if (respSize != sizeof(struct ncclP2pBuff)) return ncclInternalError;
     struct ncclP2pBuff* p2pBuff = (struct ncclP2pBuff*)respBuff;
-    NCCLCHECK(ncclP2pAllocateShareableBuffer(size, req->refcount, &p2pBuff->ipcDesc, &p2pBuff->directPtr, proxyState->memManager, ncclMemOffload));
+    NCCLCHECK(ncclP2pAllocateShareableBuffer(size, req->refcount, &p2pBuff->ipcDesc, &p2pBuff->directPtr, req->peerRank, proxyState->memManager, ncclMemOffload));
     p2pBuff->size = size;
     if (ncclCuMemEnable()) {
       // cuMem API support
@@ -711,7 +728,7 @@ static ncclResult_t p2pRecvProxySetup(struct ncclProxyConnection* connection, st
   int size = req->size;
   if (respSize != sizeof(struct ncclP2pBuff)) return ncclInternalError;
   struct ncclP2pBuff* p2pBuff = (struct ncclP2pBuff*)respBuff;
-  NCCLCHECK(ncclP2pAllocateShareableBuffer(size, req->refcount, &p2pBuff->ipcDesc, &p2pBuff->directPtr, proxyState->memManager, ncclMemOffload));
+  NCCLCHECK(ncclP2pAllocateShareableBuffer(size, req->refcount, &p2pBuff->ipcDesc, &p2pBuff->directPtr, req->peerRank, proxyState->memManager, ncclMemOffload));
   p2pBuff->size = size;
   if (ncclCuMemEnable()) {
     // cuMem API support

--- a/projects/rccl/test/mem_manager/MemManagerTests.cpp
+++ b/projects/rccl/test/mem_manager/MemManagerTests.cpp
@@ -39,6 +39,70 @@ hipMemGenericAllocationHandle_t fakeHandle()
 }
 
 void* fakePtr(uintptr_t i) { return reinterpret_cast<void*>(kFakePtrBase + i); }
+
+// --- MemManagerAllocator helpers -------------------------------------------
+// Mirrors the contract of ncclMemTrackInternal:
+//  - ncclMemPersist:                  counter-only update, no linked-list entry.
+//  - ncclMemScratch / ncclMemOffload: linked-list entry created + counter update.
+
+inline bool memTypeCreatesEntry(ncclMemType_t mt)
+{
+    return mt != ncclMemPersist;
+}
+
+inline size_t totalCounter(const ncclMemManager* m, ncclMemType_t mt)
+{
+    switch(mt) {
+    case ncclMemPersist: return m->totalPersist;
+    case ncclMemScratch: return m->totalScratch;
+    case ncclMemOffload: return m->totalOffload;
+    }
+    return 0;
+}
+
+inline const char* memTypeName(ncclMemType_t mt)
+{
+    switch(mt) {
+    case ncclMemPersist: return "Persist";
+    case ncclMemScratch: return "Scratch";
+    case ncclMemOffload: return "Offload";
+    }
+    return "?";
+}
+
+// Verify manager state right after a single track op for `mt` of `size` bytes
+// targeting `ptr`. Cross-counters (other memTypes) must stay at zero.
+inline void expectTrackedOnce(const ncclMemManager* m, void* ptr, size_t size,
+                              ncclMemType_t mt)
+{
+    SCOPED_TRACE(memTypeName(mt));
+    EXPECT_GE(totalCounter(m, mt), size);
+    for(ncclMemType_t other : {ncclMemPersist, ncclMemScratch, ncclMemOffload}) {
+        if(other != mt) {
+            EXPECT_EQ(totalCounter(m, other), 0u)
+                << "cross-counter for " << memTypeName(other) << " should be zero";
+        }
+    }
+    if(memTypeCreatesEntry(mt)) {
+        EXPECT_EQ(m->numEntries, 1);
+        ASSERT_NE(m->entries, nullptr);
+        EXPECT_EQ(m->entries->ptr, ptr);
+        EXPECT_EQ(m->entries->memType, mt);
+        EXPECT_GE(m->entries->size, size);
+    } else {
+        EXPECT_EQ(m->numEntries, 0);
+        EXPECT_EQ(m->entries, nullptr);
+    }
+}
+
+// Verify the manager is fully drained for `mt` (counter and entries).
+inline void expectFullyUntracked(const ncclMemManager* m, ncclMemType_t mt)
+{
+    SCOPED_TRACE(memTypeName(mt));
+    EXPECT_EQ(totalCounter(m, mt), 0u);
+    EXPECT_EQ(m->numEntries, 0);
+    EXPECT_EQ(m->entries, nullptr);
+}
 } // namespace
 
 // Pure-state fixture: no HIP init, no real allocations. Suitable for fast logic
@@ -1276,9 +1340,16 @@ TEST_F(MemManagerStatsTest, SuspendedFlag_FlipsWithReleased)
 // ncclCudaMalloc/Free and ncclCudaCallocAsync/Free keep ncclMemManager
 // bookkeeping consistent end-to-end. Real HIP allocations require process
 // isolation (RUN_ISOLATED_TEST).
+//
+// Per-type cases follow the manager's contract 
+//  - ncclMemPersist:                  counter-only update; no linked-list entry.
+//  - ncclMemScratch / ncclMemOffload: linked-list entry created + counter update.
+//
 // VMM-dependent tests gate on ncclCuMemEnable() — the same RCCL helper used
 // throughout src/ to honor NCCL_CUMEM_ENABLE plus runtime CuMem support.
 // ---------------------------------------------------------------------------
+
+// ---- ncclCuMemAlloc round-trip --------------------------------------------
 
 TEST(MemManagerAllocator, CuMemAlloc_Persist_TracksAndUntracks)
 {
@@ -1300,26 +1371,19 @@ TEST(MemManagerAllocator, CuMemAlloc_Persist_TracksAndUntracks)
                   ncclSuccess);
         ASSERT_NE(ptr, nullptr);
 
-        EXPECT_EQ(comm->memManager->numEntries, 1);
-        ASSERT_NE(comm->memManager->entries, nullptr);
-        EXPECT_EQ(comm->memManager->entries->ptr, ptr);
-        EXPECT_EQ(comm->memManager->entries->memType, ncclMemPersist);
-        EXPECT_GE(comm->memManager->totalPersist, kSize);
-        const size_t recordedSize = comm->memManager->entries->size;
+        expectTrackedOnce(comm->memManager, ptr, kSize, ncclMemPersist);
 
         ASSERT_EQ(ncclCuMemFree(ptr, comm->memManager), ncclSuccess);
-        EXPECT_EQ(comm->memManager->numEntries, 0);
-        EXPECT_EQ(comm->memManager->totalPersist, 0u);
-        EXPECT_GT(recordedSize, 0u);
+        expectFullyUntracked(comm->memManager, ncclMemPersist);
 
         ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
         delete comm;
     });
 }
 
-TEST(MemManagerAllocator, CuMemAlloc_Scratch_AccountedSeparately)
+TEST(MemManagerAllocator, CuMemAlloc_Scratch_TracksAndUntracks)
 {
-    RUN_ISOLATED_TEST("MemManagerAllocator_CuMemAlloc_Scratch_AccountedSeparately", []() {
+    RUN_ISOLATED_TEST("MemManagerAllocator_CuMemAlloc_Scratch_TracksAndUntracks", []() {
         if(!ncclCuMemEnable()) {
             GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 or VMM unsupported by runtime";
         }
@@ -1329,27 +1393,56 @@ TEST(MemManagerAllocator, CuMemAlloc_Scratch_AccountedSeparately)
         comm->cudaDev  = 0;
         ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
 
-        constexpr size_t                kSize = 2u << 20;
+        constexpr size_t                kSize = 2u << 20; // 2 MiB
         void*                           ptr   = nullptr;
         hipMemGenericAllocationHandle_t handle{};
         ASSERT_EQ(ncclCuMemAlloc(&ptr, &handle, hipMemHandleTypePosixFileDescriptor,
                                  kSize, comm->memManager, ncclMemScratch),
                   ncclSuccess);
+        ASSERT_NE(ptr, nullptr);
 
-        EXPECT_EQ(comm->memManager->numEntries, 1);
-        EXPECT_EQ(comm->memManager->entries->memType, ncclMemScratch);
-        EXPECT_GE(comm->memManager->totalScratch, kSize);
-        EXPECT_EQ(comm->memManager->totalPersist, 0u);
-        EXPECT_EQ(comm->memManager->totalOffload, 0u);
+        expectTrackedOnce(comm->memManager, ptr, kSize, ncclMemScratch);
 
         ASSERT_EQ(ncclCuMemFree(ptr, comm->memManager), ncclSuccess);
-        EXPECT_EQ(comm->memManager->totalScratch, 0u);
+        expectFullyUntracked(comm->memManager, ncclMemScratch);
 
         ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
         delete comm;
     });
 }
 
+TEST(MemManagerAllocator, CuMemAlloc_Offload_TracksAndUntracks)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_CuMemAlloc_Offload_TracksAndUntracks", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 or VMM unsupported by runtime";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        constexpr size_t                kSize = 2u << 20; // 2 MiB
+        void*                           ptr   = nullptr;
+        hipMemGenericAllocationHandle_t handle{};
+        ASSERT_EQ(ncclCuMemAlloc(&ptr, &handle, hipMemHandleTypePosixFileDescriptor,
+                                 kSize, comm->memManager, ncclMemOffload),
+                  ncclSuccess);
+        ASSERT_NE(ptr, nullptr);
+
+        expectTrackedOnce(comm->memManager, ptr, kSize, ncclMemOffload);
+
+        ASSERT_EQ(ncclCuMemFree(ptr, comm->memManager), ncclSuccess);
+        expectFullyUntracked(comm->memManager, ncclMemOffload);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+// Single test: the null-manager early-return in ncclMemTrack is independent of
+// memType (validated in pure-state tests), so one allocator-level case suffices.
 TEST(MemManagerAllocator, CuMemAlloc_NullManager_NoTracking)
 {
     RUN_ISOLATED_TEST("MemManagerAllocator_CuMemAlloc_NullManager_NoTracking", []() {
@@ -1369,6 +1462,8 @@ TEST(MemManagerAllocator, CuMemAlloc_NullManager_NoTracking)
                   ncclSuccess);
         EXPECT_EQ(comm->memManager->numEntries, 0);
         EXPECT_EQ(comm->memManager->totalPersist, 0u);
+        EXPECT_EQ(comm->memManager->totalScratch, 0u);
+        EXPECT_EQ(comm->memManager->totalOffload, 0u);
 
         ASSERT_EQ(ncclCuMemFree(ptr, /*manager=*/nullptr), ncclSuccess);
         EXPECT_EQ(comm->memManager->numEntries, 0);
@@ -1378,9 +1473,11 @@ TEST(MemManagerAllocator, CuMemAlloc_NullManager_NoTracking)
     });
 }
 
-TEST(MemManagerAllocator, CuMemAlloc_MultipleEntries_AllTracked)
+// ---- ncclCuMemAlloc with N entries ----------------------------------------
+
+TEST(MemManagerAllocator, CuMemAlloc_Persist_MultipleEntries)
 {
-    RUN_ISOLATED_TEST("MemManagerAllocator_CuMemAlloc_MultipleEntries_AllTracked", []() {
+    RUN_ISOLATED_TEST("MemManagerAllocator_CuMemAlloc_Persist_MultipleEntries", []() {
         if(!ncclCuMemEnable()) {
             GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 or VMM unsupported by runtime";
         }
@@ -1401,23 +1498,104 @@ TEST(MemManagerAllocator, CuMemAlloc_MultipleEntries_AllTracked)
                                      comm->memManager, ncclMemPersist),
                       ncclSuccess);
         }
-        EXPECT_EQ(comm->memManager->numEntries, kN);
+        // Persist: counter-only, no linked-list entries grown.
+        EXPECT_EQ(comm->memManager->numEntries, 0);
+        EXPECT_EQ(comm->memManager->entries, nullptr);
         EXPECT_GE(comm->memManager->totalPersist, kN * kSize);
+        EXPECT_EQ(comm->memManager->totalScratch, 0u);
+        EXPECT_EQ(comm->memManager->totalOffload, 0u);
 
         for(int i = 0; i < kN; ++i) {
             ASSERT_EQ(ncclCuMemFree(ptrs[i], comm->memManager), ncclSuccess);
         }
-        EXPECT_EQ(comm->memManager->numEntries, 0);
-        EXPECT_EQ(comm->memManager->totalPersist, 0u);
+        expectFullyUntracked(comm->memManager, ncclMemPersist);
 
         ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
         delete comm;
     });
 }
 
-TEST(MemManagerAllocator, CudaCalloc_DispatchesToCuMem_AndTracks)
+TEST(MemManagerAllocator, CuMemAlloc_Scratch_MultipleEntries)
 {
-    RUN_ISOLATED_TEST("MemManagerAllocator_CudaCalloc_Tracks", []() {
+    RUN_ISOLATED_TEST("MemManagerAllocator_CuMemAlloc_Scratch_MultipleEntries", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 or VMM unsupported by runtime";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        constexpr int                   kN          = 4;
+        constexpr size_t                kSize       = 256u << 10;
+        void*                           ptrs[kN]    = {};
+        hipMemGenericAllocationHandle_t handles[kN] = {};
+
+        for(int i = 0; i < kN; ++i) {
+            ASSERT_EQ(ncclCuMemAlloc(&ptrs[i], &handles[i],
+                                     hipMemHandleTypePosixFileDescriptor, kSize,
+                                     comm->memManager, ncclMemScratch),
+                      ncclSuccess);
+        }
+        EXPECT_EQ(comm->memManager->numEntries, kN);
+        EXPECT_GE(comm->memManager->totalScratch, kN * kSize);
+        EXPECT_EQ(comm->memManager->totalPersist, 0u);
+        EXPECT_EQ(comm->memManager->totalOffload, 0u);
+
+        for(int i = 0; i < kN; ++i) {
+            ASSERT_EQ(ncclCuMemFree(ptrs[i], comm->memManager), ncclSuccess);
+        }
+        expectFullyUntracked(comm->memManager, ncclMemScratch);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+TEST(MemManagerAllocator, CuMemAlloc_Offload_MultipleEntries)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_CuMemAlloc_Offload_MultipleEntries", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 or VMM unsupported by runtime";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        constexpr int                   kN          = 4;
+        constexpr size_t                kSize       = 256u << 10;
+        void*                           ptrs[kN]    = {};
+        hipMemGenericAllocationHandle_t handles[kN] = {};
+
+        for(int i = 0; i < kN; ++i) {
+            ASSERT_EQ(ncclCuMemAlloc(&ptrs[i], &handles[i],
+                                     hipMemHandleTypePosixFileDescriptor, kSize,
+                                     comm->memManager, ncclMemOffload),
+                      ncclSuccess);
+        }
+        EXPECT_EQ(comm->memManager->numEntries, kN);
+        EXPECT_GE(comm->memManager->totalOffload, kN * kSize);
+        EXPECT_EQ(comm->memManager->totalPersist, 0u);
+        EXPECT_EQ(comm->memManager->totalScratch, 0u);
+
+        for(int i = 0; i < kN; ++i) {
+            ASSERT_EQ(ncclCuMemFree(ptrs[i], comm->memManager), ncclSuccess);
+        }
+        expectFullyUntracked(comm->memManager, ncclMemOffload);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+// ---- ncclCudaCalloc dispatch ----------------------------------------------
+
+TEST(MemManagerAllocator, CudaCalloc_Persist_DispatchesToCuMem)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_CudaCalloc_Persist_DispatchesToCuMem", []() {
         if(!ncclCuMemEnable()) {
             GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 - ncclCudaCalloc bypasses manager";
         }
@@ -1433,20 +1611,77 @@ TEST(MemManagerAllocator, CudaCalloc_DispatchesToCuMem_AndTracks)
                   ncclSuccess);
         ASSERT_NE(ptr, nullptr);
 
-        EXPECT_EQ(comm->memManager->numEntries, 1);
-        EXPECT_GE(comm->memManager->totalPersist, kElems * sizeof(int));
+        expectTrackedOnce(comm->memManager, ptr, kElems * sizeof(int), ncclMemPersist);
 
         ASSERT_EQ(ncclCudaFree(ptr, comm->memManager), ncclSuccess);
-        EXPECT_EQ(comm->memManager->numEntries, 0);
+        expectFullyUntracked(comm->memManager, ncclMemPersist);
 
         ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
         delete comm;
     });
 }
 
-TEST(MemManagerAllocator, CudaMalloc_DispatchesToCuMem_AndTracks)
+TEST(MemManagerAllocator, CudaCalloc_Scratch_DispatchesToCuMem)
 {
-    RUN_ISOLATED_TEST("MemManagerAllocator_CudaMalloc_Tracks", []() {
+    RUN_ISOLATED_TEST("MemManagerAllocator_CudaCalloc_Scratch_DispatchesToCuMem", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 - ncclCudaCalloc bypasses manager";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        constexpr size_t kElems = 1024;
+        int*             ptr    = nullptr;
+        ASSERT_EQ(ncclCudaCalloc(&ptr, kElems, comm->memManager, ncclMemScratch),
+                  ncclSuccess);
+        ASSERT_NE(ptr, nullptr);
+
+        expectTrackedOnce(comm->memManager, ptr, kElems * sizeof(int), ncclMemScratch);
+
+        ASSERT_EQ(ncclCudaFree(ptr, comm->memManager), ncclSuccess);
+        expectFullyUntracked(comm->memManager, ncclMemScratch);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+TEST(MemManagerAllocator, CudaCalloc_Offload_DispatchesToCuMem)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_CudaCalloc_Offload_DispatchesToCuMem", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 - ncclCudaCalloc bypasses manager";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        constexpr size_t kElems = 1024;
+        int*             ptr    = nullptr;
+        ASSERT_EQ(ncclCudaCalloc(&ptr, kElems, comm->memManager, ncclMemOffload),
+                  ncclSuccess);
+        ASSERT_NE(ptr, nullptr);
+
+        expectTrackedOnce(comm->memManager, ptr, kElems * sizeof(int), ncclMemOffload);
+
+        ASSERT_EQ(ncclCudaFree(ptr, comm->memManager), ncclSuccess);
+        expectFullyUntracked(comm->memManager, ncclMemOffload);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+// ---- ncclCudaMalloc dispatch ----------------------------------------------
+
+TEST(MemManagerAllocator, CudaMalloc_Persist_DispatchesToCuMem)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_CudaMalloc_Persist_DispatchesToCuMem", []() {
         if(!ncclCuMemEnable()) {
             GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 - ncclCudaMalloc bypasses manager";
         }
@@ -1456,25 +1691,83 @@ TEST(MemManagerAllocator, CudaMalloc_DispatchesToCuMem_AndTracks)
         comm->cudaDev  = 0;
         ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
 
-        constexpr size_t kBytes = 64 << 10; // 64 KiB
+        constexpr size_t kBytes = 64u << 10; // 64 KiB
         char*            ptr    = nullptr;
-        ASSERT_EQ(ncclCudaMalloc(&ptr, kBytes, comm->memManager, ncclMemScratch),
+        ASSERT_EQ(ncclCudaMalloc(&ptr, kBytes, comm->memManager, ncclMemPersist),
                   ncclSuccess);
+        ASSERT_NE(ptr, nullptr);
 
-        EXPECT_EQ(comm->memManager->numEntries, 1);
-        EXPECT_EQ(comm->memManager->entries->memType, ncclMemScratch);
+        expectTrackedOnce(comm->memManager, ptr, kBytes, ncclMemPersist);
 
         ASSERT_EQ(ncclCudaFree(ptr, comm->memManager), ncclSuccess);
-        EXPECT_EQ(comm->memManager->numEntries, 0);
+        expectFullyUntracked(comm->memManager, ncclMemPersist);
 
         ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
         delete comm;
     });
 }
 
-TEST(MemManagerAllocator, CudaCallocAsync_DispatchesToCuMem_AndTracks)
+TEST(MemManagerAllocator, CudaMalloc_Scratch_DispatchesToCuMem)
 {
-    RUN_ISOLATED_TEST("MemManagerAllocator_CudaCallocAsync_Tracks", []() {
+    RUN_ISOLATED_TEST("MemManagerAllocator_CudaMalloc_Scratch_DispatchesToCuMem", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 - ncclCudaMalloc bypasses manager";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        constexpr size_t kBytes = 64u << 10;
+        char*            ptr    = nullptr;
+        ASSERT_EQ(ncclCudaMalloc(&ptr, kBytes, comm->memManager, ncclMemScratch),
+                  ncclSuccess);
+        ASSERT_NE(ptr, nullptr);
+
+        expectTrackedOnce(comm->memManager, ptr, kBytes, ncclMemScratch);
+
+        ASSERT_EQ(ncclCudaFree(ptr, comm->memManager), ncclSuccess);
+        expectFullyUntracked(comm->memManager, ncclMemScratch);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+TEST(MemManagerAllocator, CudaMalloc_Offload_DispatchesToCuMem)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_CudaMalloc_Offload_DispatchesToCuMem", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 - ncclCudaMalloc bypasses manager";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        constexpr size_t kBytes = 64u << 10;
+        char*            ptr    = nullptr;
+        ASSERT_EQ(ncclCudaMalloc(&ptr, kBytes, comm->memManager, ncclMemOffload),
+                  ncclSuccess);
+        ASSERT_NE(ptr, nullptr);
+
+        expectTrackedOnce(comm->memManager, ptr, kBytes, ncclMemOffload);
+
+        ASSERT_EQ(ncclCudaFree(ptr, comm->memManager), ncclSuccess);
+        expectFullyUntracked(comm->memManager, ncclMemOffload);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+// ---- ncclCudaCallocAsync dispatch -----------------------------------------
+
+TEST(MemManagerAllocator, CudaCallocAsync_Persist_DispatchesToCuMem)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_CudaCallocAsync_Persist_DispatchesToCuMem", []() {
         if(!ncclCuMemEnable()) {
             GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 - ncclCudaCallocAsync bypasses manager";
         }
@@ -1493,12 +1786,13 @@ TEST(MemManagerAllocator, CudaCallocAsync_DispatchesToCuMem_AndTracks)
                                       ncclMemPersist),
                   ncclSuccess);
         ASSERT_EQ(hipStreamSynchronize(stream), hipSuccess);
+        ASSERT_NE(ptr, nullptr);
 
-        EXPECT_EQ(comm->memManager->numEntries, 1);
-        EXPECT_GE(comm->memManager->totalPersist, kElems * sizeof(uint64_t));
+        expectTrackedOnce(comm->memManager, ptr, kElems * sizeof(uint64_t),
+                          ncclMemPersist);
 
         ASSERT_EQ(ncclCudaFree(ptr, comm->memManager), ncclSuccess);
-        EXPECT_EQ(comm->memManager->numEntries, 0);
+        expectFullyUntracked(comm->memManager, ncclMemPersist);
 
         ASSERT_EQ(hipStreamDestroy(stream), hipSuccess);
         ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
@@ -1506,6 +1800,80 @@ TEST(MemManagerAllocator, CudaCallocAsync_DispatchesToCuMem_AndTracks)
     });
 }
 
+TEST(MemManagerAllocator, CudaCallocAsync_Scratch_DispatchesToCuMem)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_CudaCallocAsync_Scratch_DispatchesToCuMem", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 - ncclCudaCallocAsync bypasses manager";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        hipStream_t stream;
+        ASSERT_EQ(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking), hipSuccess);
+
+        constexpr size_t kElems = 256;
+        uint64_t*        ptr    = nullptr;
+        ASSERT_EQ(ncclCudaCallocAsync(&ptr, kElems, stream, comm->memManager,
+                                      ncclMemScratch),
+                  ncclSuccess);
+        ASSERT_EQ(hipStreamSynchronize(stream), hipSuccess);
+        ASSERT_NE(ptr, nullptr);
+
+        expectTrackedOnce(comm->memManager, ptr, kElems * sizeof(uint64_t),
+                          ncclMemScratch);
+
+        ASSERT_EQ(ncclCudaFree(ptr, comm->memManager), ncclSuccess);
+        expectFullyUntracked(comm->memManager, ncclMemScratch);
+
+        ASSERT_EQ(hipStreamDestroy(stream), hipSuccess);
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+TEST(MemManagerAllocator, CudaCallocAsync_Offload_DispatchesToCuMem)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_CudaCallocAsync_Offload_DispatchesToCuMem", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 - ncclCudaCallocAsync bypasses manager";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        hipStream_t stream;
+        ASSERT_EQ(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking), hipSuccess);
+
+        constexpr size_t kElems = 256;
+        uint64_t*        ptr    = nullptr;
+        ASSERT_EQ(ncclCudaCallocAsync(&ptr, kElems, stream, comm->memManager,
+                                      ncclMemOffload),
+                  ncclSuccess);
+        ASSERT_EQ(hipStreamSynchronize(stream), hipSuccess);
+        ASSERT_NE(ptr, nullptr);
+
+        expectTrackedOnce(comm->memManager, ptr, kElems * sizeof(uint64_t),
+                          ncclMemOffload);
+
+        ASSERT_EQ(ncclCudaFree(ptr, comm->memManager), ncclSuccess);
+        expectFullyUntracked(comm->memManager, ncclMemOffload);
+
+        ASSERT_EQ(hipStreamDestroy(stream), hipSuccess);
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+// ---- Cross-type interaction (single test) ---------------------------------
+
+// Allocates one buffer of each memType. Only Scratch+Offload create linked-list
+// entries, so numEntries == 2; total* counters move per-type independently.
 TEST(MemManagerAllocator, MixedMemTypes_BookkeepingIndependent)
 {
     RUN_ISOLATED_TEST("MemManagerAllocator_MixedMemTypes_BookkeepingIndependent", []() {
@@ -1536,7 +1904,8 @@ TEST(MemManagerAllocator, MixedMemTypes_BookkeepingIndependent)
                                  kSize, comm->memManager, ncclMemOffload),
                   ncclSuccess);
 
-        EXPECT_EQ(comm->memManager->numEntries, 3);
+        // Persist does not create an entry; Scratch+Offload do.
+        EXPECT_EQ(comm->memManager->numEntries, 2);
         EXPECT_GE(comm->memManager->totalPersist, kSize);
         EXPECT_GE(comm->memManager->totalScratch, kSize);
         EXPECT_GE(comm->memManager->totalOffload, kSize);
@@ -1545,11 +1914,12 @@ TEST(MemManagerAllocator, MixedMemTypes_BookkeepingIndependent)
         EXPECT_EQ(comm->memManager->totalScratch, 0u);
         EXPECT_GE(comm->memManager->totalPersist, kSize); // unaffected
         EXPECT_GE(comm->memManager->totalOffload, kSize); // unaffected
-        EXPECT_EQ(comm->memManager->numEntries, 2);
+        EXPECT_EQ(comm->memManager->numEntries, 1);
 
         ASSERT_EQ(ncclCuMemFree(pPer, comm->memManager), ncclSuccess);
         ASSERT_EQ(ncclCuMemFree(pOff, comm->memManager), ncclSuccess);
         EXPECT_EQ(comm->memManager->numEntries, 0);
+        EXPECT_EQ(comm->memManager->entries, nullptr);
         EXPECT_EQ(comm->memManager->totalPersist, 0u);
         EXPECT_EQ(comm->memManager->totalOffload, 0u);
 
@@ -1558,9 +1928,11 @@ TEST(MemManagerAllocator, MixedMemTypes_BookkeepingIndependent)
     });
 }
 
-TEST(MemManagerAllocator, AllocTrackerAndManager_AreIndependent)
+// ---- allocTracker independence per memType --------------------------------
+
+TEST(MemManagerAllocator, AllocTrackerAndManager_Persist_AreIndependent)
 {
-    RUN_ISOLATED_TEST("MemManagerAllocator_AllocTrackerAndManager_AreIndependent", []() {
+    RUN_ISOLATED_TEST("MemManagerAllocator_AllocTrackerAndManager_Persist_AreIndependent", []() {
         if(!ncclCuMemEnable()) {
             GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 or VMM unsupported by runtime";
         }
@@ -1586,13 +1958,95 @@ TEST(MemManagerAllocator, AllocTrackerAndManager_AreIndependent)
                   allocBefore);
         EXPECT_GT(__atomic_load_n(&allocTracker[0].totalAllocSize, __ATOMIC_RELAXED),
                   allocSizeBefore);
-        EXPECT_EQ(comm->memManager->numEntries, 1);
+        expectTrackedOnce(comm->memManager, ptr, kSize, ncclMemPersist);
 
         ASSERT_EQ(ncclCuMemFree(ptr, comm->memManager), ncclSuccess);
 
         EXPECT_EQ(__atomic_load_n(&allocTracker[0].totalAlloc, __ATOMIC_RELAXED),
                   allocBefore);
-        EXPECT_EQ(comm->memManager->numEntries, 0);
+        expectFullyUntracked(comm->memManager, ncclMemPersist);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+TEST(MemManagerAllocator, AllocTrackerAndManager_Scratch_AreIndependent)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_AllocTrackerAndManager_Scratch_AreIndependent", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 or VMM unsupported by runtime";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        const uint64_t allocBefore     = __atomic_load_n(
+            &allocTracker[0].totalAlloc, __ATOMIC_RELAXED);
+        const uint64_t allocSizeBefore = __atomic_load_n(
+            &allocTracker[0].totalAllocSize, __ATOMIC_RELAXED);
+
+        constexpr size_t                kSize = 1u << 20;
+        void*                           ptr   = nullptr;
+        hipMemGenericAllocationHandle_t handle{};
+        ASSERT_EQ(ncclCuMemAlloc(&ptr, &handle, hipMemHandleTypePosixFileDescriptor,
+                                 kSize, comm->memManager, ncclMemScratch),
+                  ncclSuccess);
+
+        EXPECT_GT(__atomic_load_n(&allocTracker[0].totalAlloc, __ATOMIC_RELAXED),
+                  allocBefore);
+        EXPECT_GT(__atomic_load_n(&allocTracker[0].totalAllocSize, __ATOMIC_RELAXED),
+                  allocSizeBefore);
+        expectTrackedOnce(comm->memManager, ptr, kSize, ncclMemScratch);
+
+        ASSERT_EQ(ncclCuMemFree(ptr, comm->memManager), ncclSuccess);
+
+        EXPECT_EQ(__atomic_load_n(&allocTracker[0].totalAlloc, __ATOMIC_RELAXED),
+                  allocBefore);
+        expectFullyUntracked(comm->memManager, ncclMemScratch);
+
+        ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
+        delete comm;
+    });
+}
+
+TEST(MemManagerAllocator, AllocTrackerAndManager_Offload_AreIndependent)
+{
+    RUN_ISOLATED_TEST("MemManagerAllocator_AllocTrackerAndManager_Offload_AreIndependent", []() {
+        if(!ncclCuMemEnable()) {
+            GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 or VMM unsupported by runtime";
+        }
+        ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+        ncclComm* comm = new ncclComm();
+        comm->cudaDev  = 0;
+        ASSERT_EQ(ncclMemManagerInit(comm), ncclSuccess);
+
+        const uint64_t allocBefore     = __atomic_load_n(
+            &allocTracker[0].totalAlloc, __ATOMIC_RELAXED);
+        const uint64_t allocSizeBefore = __atomic_load_n(
+            &allocTracker[0].totalAllocSize, __ATOMIC_RELAXED);
+
+        constexpr size_t                kSize = 1u << 20;
+        void*                           ptr   = nullptr;
+        hipMemGenericAllocationHandle_t handle{};
+        ASSERT_EQ(ncclCuMemAlloc(&ptr, &handle, hipMemHandleTypePosixFileDescriptor,
+                                 kSize, comm->memManager, ncclMemOffload),
+                  ncclSuccess);
+
+        EXPECT_GT(__atomic_load_n(&allocTracker[0].totalAlloc, __ATOMIC_RELAXED),
+                  allocBefore);
+        EXPECT_GT(__atomic_load_n(&allocTracker[0].totalAllocSize, __ATOMIC_RELAXED),
+                  allocSizeBefore);
+        expectTrackedOnce(comm->memManager, ptr, kSize, ncclMemOffload);
+
+        ASSERT_EQ(ncclCuMemFree(ptr, comm->memManager), ncclSuccess);
+
+        EXPECT_EQ(__atomic_load_n(&allocTracker[0].totalAlloc, __ATOMIC_RELAXED),
+                  allocBefore);
+        expectFullyUntracked(comm->memManager, ncclMemOffload);
 
         ASSERT_EQ(ncclMemManagerDestroy(comm), ncclSuccess);
         delete comm;

--- a/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp
+++ b/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp
@@ -6,7 +6,9 @@
 
 /**
  * @file SuspendResumeMPITests.cpp
- * @brief Multi-process tests for ncclCommMemSuspend / ncclCommMemResume / ncclCommMemStats.
+ * @brief Multi-process tests for the suspend/resume feature -- both the
+ *        internal ncclCommMemSuspend/Resume/Stats path and the public
+ *        ncclCommSuspend/Resume/MemStats API.
  *
  * The single-process unit-test suite in `test/mem_manager/MemManagerTests.cpp`
  * covers all early-return error paths, `ncclCommMemStats`, and the manager
@@ -33,30 +35,39 @@
  * not the allocator. If the runtime really lacks raw VMM, hipMemCreate fails
  * with an explicit HIP error code instead of a misleading version skip.
  *
- * Two suites:
+ * Suites:
  *   - MemManagerAnyRanks - each rank runs the same local Suspend/Resume
  *     scenario in lockstep. The cross-rank bootstrapBarrier inside
  *     ncclCommMemSuspend / ncclCommMemResume keeps all ranks in sync, so
  *     every test in this suite passes on any np >= 1.
  *   - MemManagerTwoRank   - peer-coupled scenarios that need exactly 2 ranks
  *     (rank 0 exporter, rank 1 importer).
+ *   - SuspendResumeBasic / MemStats / CollectiveIntegrity / Lifecycle / Group
+ *     / ArgValidation / MemStatsValidation - public API tests for
+ *     ncclCommSuspend / ncclCommResume / ncclCommMemStats. Need np >= 2.
  *
  * Run (a single mpirun -np 2 invocation runs the entire file):
- *   mpirun -np 2 ./rccl-UnitTestsMPI --gtest_filter='MemManager*'
+ *   mpirun -np 2 ./rccl-UnitTestsMPI --gtest_filter='MemManager*:SuspendResume*'
  *
- * Or, if you want to focus on one suite:
+ * Or, if you want to focus on one group of suites:
  *   mpirun -np 1 ./rccl-UnitTestsMPI --gtest_filter='MemManagerAnyRanks.*'
  *   mpirun -np 2 ./rccl-UnitTestsMPI --gtest_filter='MemManagerTwoRank.*'
+ *   mpirun -np 2 ./rccl-UnitTestsMPI --gtest_filter='SuspendResume*'
  */
 
+#include "DeviceBufferHelpers.hpp"
 #include "MPITestBase.hpp"
+#include "ResourceGuards.hpp"
 #include "TestChecks.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <iomanip>
+#include <mutex>
 #include <string>
+#include <thread>
 #include <unistd.h>
 #include <vector>
 
@@ -68,6 +79,8 @@
 #include "proxy.h"
 
 using namespace MPITestConstants;
+using namespace RCCLTestGuards;
+using namespace RCCLTestHelpers;
 
 // ---------------------------------------------------------------------------
 // VMM helpers
@@ -155,14 +168,21 @@ void reserveVaOnly(int dev, size_t requestedSize, VmmAlloc* out)
     out->handle = 0;
 }
 
-// Tear down whatever Resume / the test left mapped at out->pdev. Safe whether
-// the entry is in the Active state (mapped) or Released state (unmapped) -
-// hipMemUnmap returns an error on a reserved-but-unmapped VA which we ignore.
+// Mirrors ncclCuMemFree: recover the live handle from the VA (cached
+// a->handle is stale after Suspend/Resume). Retain bumps refcount by 1, so
+// release twice. Reserved-but-unmapped VA falls through to AddressFree.
 void releaseVmm(VmmAlloc* a)
 {
     if (a == nullptr || a->pdev == 0) return;
-    (void)hipMemUnmap(a->pdev, a->size);
-    if (a->handle != 0) (void)hipMemRelease(a->handle);
+
+    hipMemGenericAllocationHandle_t live = 0;
+    if (hipMemRetainAllocationHandle(&live, a->ptr) == hipSuccess) {
+        (void)hipMemRelease(live);
+        (void)hipMemUnmap(a->pdev, a->size);
+        (void)hipMemRelease(live);
+    } else {
+        (void)hipMemUnmap(a->pdev, a->size);
+    }
     (void)hipMemAddressFree(a->pdev, a->size);
     a->pdev   = 0;
     a->handle = 0;
@@ -196,23 +216,60 @@ void verifyCanaryReadback(void* ptr, size_t size, uint8_t pattern, const std::st
                     << " not preserved";
 }
 
-// Cleanup pattern shared by every test that does Track + later Untrack on a
-// VMM entry that may have gone through Suspend/Resume:
-//   - Resume installs a NEW handle into entry->handle (the original one we
-//     created via hipMemCreate is long gone after Suspend's hipMemRelease).
-//   - ncclMemUntrack drops the linked-list entry but does NOT unmap or release
-//     anything HIP-side.
-// So we snapshot the live handle out of the entry FIRST, then Untrack, then
-// releaseVmm() with that handle.
+// ncclMemUntrack + releaseVmm. Mirrors the ncclCudaFree pattern.
 void untrackAndRelease(struct ncclComm* comm, void* ptr, VmmAlloc* a)
 {
-    ncclMemManager* mgr = comm->memManager;
-    ASSERT_NE(mgr, nullptr);
-    ncclDynMemEntry* entry = mgr->entries;
-    while (entry != nullptr && entry->ptr != ptr) entry = entry->next;
-    if (entry != nullptr) a->handle = entry->handle;
-    ASSERT_EQ(ncclMemUntrack(mgr, ptr, a->size), ncclSuccess);
+    ASSERT_NE(comm, nullptr);
+    ASSERT_NE(comm->memManager, nullptr);
+    ASSERT_EQ(ncclMemUntrack(comm->memManager, ptr, a->size), ncclSuccess);
     releaseVmm(a);
+}
+
+// Snapshot of manager state taken before the test adds its own entries.
+// With NCCL_CUMEM_ENABLE=1 a freshly created comm already tracks internal
+// RCCL allocations (proxy P2P buffers, channel buffers etc.), so absolute
+// counters/sizes can't be asserted directly - tests must check deltas.
+struct MgrBaseline
+{
+    int      numEntries     = 0;
+    uint64_t cpuBackupUsage = 0;
+    uint64_t total          = 0;
+    uint64_t persist        = 0;
+    uint64_t suspendBytes   = 0;
+};
+
+MgrBaseline captureBaseline(struct ncclComm* comm)
+{
+    MgrBaseline b{};
+    EXPECT_NE(comm, nullptr);
+    EXPECT_NE(comm->memManager, nullptr);
+    b.numEntries     = comm->memManager->numEntries;
+    b.cpuBackupUsage = comm->memManager->cpuBackupUsage;
+    EXPECT_EQ(ncclCommMemStats(comm, ncclStatGpuMemTotal,   &b.total),        ncclSuccess);
+    EXPECT_EQ(ncclCommMemStats(comm, ncclStatGpuMemPersist, &b.persist),      ncclSuccess);
+    EXPECT_EQ(ncclCommMemStats(comm, ncclStatGpuMemSuspend, &b.suspendBytes), ncclSuccess);
+    return b;
+}
+
+// Run one Suspend/Resume cycle to learn how much CPU backup the comm's
+// internal Offload entries consume - tests with their own Offload Track must
+// add their size on top of this baseline when checking cpuBackupUsage.
+uint64_t captureInternalOffloadCpuBackup(struct ncclComm* comm)
+{
+    EXPECT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
+    uint64_t v = comm->memManager->cpuBackupUsage;
+    EXPECT_EQ(ncclCommMemResume(comm), ncclSuccess);
+    return v;
+}
+
+// Find the entry tracking `ptr`. With internals tracked it's no longer
+// guaranteed to be at manager->entries[0].
+ncclDynMemEntry* findEntryByPtr(struct ncclComm* comm, void* ptr)
+{
+    for (auto* e = comm->memManager->entries; e != nullptr; e = e->next) {
+        if (e->ptr == ptr) return e;
+    }
+    return nullptr;
 }
 
 // ---------------------------------------------------------------------------
@@ -356,6 +413,8 @@ TEST_F(MemManagerAnyRanks, SuspendResume_LocalOffload_DataPreserved)
     ncclComm_t comm = getActiveCommunicator();
     ASSERT_NE(comm->memManager, nullptr);
 
+    const uint64_t internalOffload = captureInternalOffloadCpuBackup(comm);
+
     VmmAlloc a{};
     allocateVmmPosixFd(comm->cudaDev, 64 * 1024, &a);
 
@@ -363,19 +422,17 @@ TEST_F(MemManagerAnyRanks, SuspendResume_LocalOffload_DataPreserved)
                            hipMemHandleTypePosixFileDescriptor, ncclMemOffload),
               ncclSuccess);
 
-    // Pre-fill device buffer with a recognisable pattern so we can verify that
-    // Suspend's D2H copy and Resume's H2D restore round-trip the bytes.
     std::vector<uint8_t> pattern(a.size);
     for (size_t i = 0; i < a.size; i++) pattern[i] = static_cast<uint8_t>(i * 31u);
     ASSERT_EQ(hipMemcpy(a.ptr, pattern.data(), a.size, hipMemcpyHostToDevice), hipSuccess);
 
     ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
 
-    ncclDynMemEntry* entry = comm->memManager->entries;
+    ncclDynMemEntry* entry = findEntryByPtr(comm, a.ptr);
     ASSERT_NE(entry, nullptr);
     EXPECT_EQ(entry->state, ncclDynMemStateReleased);
     EXPECT_NE(entry->cpuBackup, nullptr);
-    EXPECT_EQ(comm->memManager->cpuBackupUsage, a.size);
+    EXPECT_EQ(comm->memManager->cpuBackupUsage, internalOffload + a.size);
 
     ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
     EXPECT_EQ(entry->state, ncclDynMemStateActive);
@@ -386,14 +443,15 @@ TEST_F(MemManagerAnyRanks, SuspendResume_LocalOffload_DataPreserved)
     ASSERT_EQ(hipMemcpy(roundtrip.data(), a.ptr, a.size, hipMemcpyDeviceToHost), hipSuccess);
     EXPECT_EQ(std::memcmp(roundtrip.data(), pattern.data(), a.size), 0);
 
-    ASSERT_EQ(ncclMemUntrack(comm->memManager, a.ptr, a.size), ncclSuccess);
-    releaseVmm(&a);
+    untrackAndRelease(comm, a.ptr, &a);
 }
 
 TEST_F(MemManagerAnyRanks, SuspendResume_PersistUntouched)
 {
     ncclComm_t comm = getActiveCommunicator();
     ASSERT_NE(comm->memManager, nullptr);
+
+    const MgrBaseline base = captureBaseline(comm);
 
     constexpr size_t persistSize = 8192;
     void* persistPtr             = reinterpret_cast<void*>(0xDEADBEEF00ULL);
@@ -404,13 +462,13 @@ TEST_F(MemManagerAnyRanks, SuspendResume_PersistUntouched)
 
     uint64_t persistBefore = 0;
     ASSERT_EQ(ncclCommMemStats(comm, ncclStatGpuMemPersist, &persistBefore), ncclSuccess);
-    EXPECT_EQ(persistBefore, persistSize);
+    EXPECT_EQ(persistBefore - base.persist, persistSize);
 
     ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
 
     uint64_t persistAfter = 0;
     ASSERT_EQ(ncclCommMemStats(comm, ncclStatGpuMemPersist, &persistAfter), ncclSuccess);
-    EXPECT_EQ(persistAfter, persistSize);
+    EXPECT_EQ(persistAfter - base.persist, persistSize);
 
     uint64_t suspended = 0;
     ASSERT_EQ(ncclCommMemStats(comm, ncclStatGpuMemSuspended, &suspended), ncclSuccess);
@@ -662,25 +720,26 @@ TEST_F(MemManagerTwoRank, SuspendResume_PeerExportImport_RoundtripCanary)
 // Stress / coverage tests for AnyRanks (np >= 1)
 // ===========================================================================
 
-// A: empty manager - no entries tracked, but Suspend/Resume must still drive
-// all the bootstrap barriers and toggle the released flag. Catches a corner
-// case where Pass 1 / Pass 2 / Step 1 / Step 4 loops crash on a null entries
-// pointer (manager->entries == nullptr from start).
+// A: no user-tracked entries. Suspend/Resume must drive the bootstrap barriers
+// + flip released without inventing or losing entries. Pre-CUMEM the manager
+// was always empty here; with NCCL_CUMEM_ENABLE=1 internal entries exist, so
+// we check that the entry count and cpuBackup are preserved across the cycle.
 TEST_F(MemManagerAnyRanks, EmptyManager_SuspendResume_NoOp)
 {
     ncclComm_t comm = getActiveCommunicator();
     ASSERT_NE(comm->memManager, nullptr);
-    ASSERT_EQ(comm->memManager->entries, nullptr);
-    ASSERT_EQ(comm->memManager->numEntries, 0);
+    const MgrBaseline base = captureBaseline(comm);
 
     ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
     EXPECT_EQ(comm->memManager->released, 1);
-    EXPECT_EQ(comm->memManager->entries, nullptr) << "Suspend must not invent entries";
+    EXPECT_EQ(comm->memManager->numEntries, base.numEntries)
+        << "Suspend must not invent or lose entries";
 
     ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
     EXPECT_EQ(comm->memManager->released, 0);
-    EXPECT_EQ(comm->memManager->entries, nullptr) << "Resume must not invent entries";
-    EXPECT_EQ(comm->memManager->cpuBackupUsage, 0u);
+    EXPECT_EQ(comm->memManager->numEntries, base.numEntries)
+        << "Resume must not invent or lose entries";
+    EXPECT_EQ(comm->memManager->cpuBackupUsage, base.cpuBackupUsage);
 }
 
 // B: Persist + Scratch + Offload tracked together. Suspend / Resume releases
@@ -694,6 +753,8 @@ TEST_F(MemManagerAnyRanks, MixedMemTypes_StatsConsistent)
 {
     ncclComm_t comm = getActiveCommunicator();
     ASSERT_NE(comm->memManager, nullptr);
+
+    const MgrBaseline base = captureBaseline(comm);
 
     constexpr size_t  kPersistReq  = 8 * 1024;
     constexpr size_t  kScratchReq  = 256 * 1024;
@@ -728,42 +789,39 @@ TEST_F(MemManagerAnyRanks, MixedMemTypes_StatsConsistent)
         return v;
     };
 
-    const uint64_t expectedTotal   = persistVmm.size + scratchVmm.size + offloadVmm.size;
-    const uint64_t expectedPersist = persistVmm.size;
-    const uint64_t expectedDynamic = scratchVmm.size + offloadVmm.size;
+    const uint64_t deltaTotal   = persistVmm.size + scratchVmm.size + offloadVmm.size;
+    const uint64_t deltaPersist = persistVmm.size;
+    const uint64_t deltaDynamic = scratchVmm.size + offloadVmm.size;
 
-    EXPECT_EQ(readStat(ncclStatGpuMemTotal),     expectedTotal);
-    EXPECT_EQ(readStat(ncclStatGpuMemPersist),   expectedPersist);
-    EXPECT_EQ(readStat(ncclStatGpuMemSuspend),   expectedDynamic);
+    EXPECT_EQ(readStat(ncclStatGpuMemTotal)   - base.total,        deltaTotal);
+    EXPECT_EQ(readStat(ncclStatGpuMemPersist) - base.persist,      deltaPersist);
+    EXPECT_EQ(readStat(ncclStatGpuMemSuspend) - base.suspendBytes, deltaDynamic);
     EXPECT_EQ(readStat(ncclStatGpuMemSuspended), 0u);
 
     ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
 
-    // Tracked sizes don't change across Suspend - the entries are still in the
-    // linked list, just with state == Released. Persist counter is independent.
-    EXPECT_EQ(readStat(ncclStatGpuMemTotal),     expectedTotal);
-    EXPECT_EQ(readStat(ncclStatGpuMemPersist),   expectedPersist);
-    EXPECT_EQ(readStat(ncclStatGpuMemSuspend),   expectedDynamic);
+    EXPECT_EQ(readStat(ncclStatGpuMemTotal)   - base.total,        deltaTotal);
+    EXPECT_EQ(readStat(ncclStatGpuMemPersist) - base.persist,      deltaPersist);
+    EXPECT_EQ(readStat(ncclStatGpuMemSuspend) - base.suspendBytes, deltaDynamic);
     EXPECT_EQ(readStat(ncclStatGpuMemSuspended), 1u);
 
     ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
-    EXPECT_EQ(readStat(ncclStatGpuMemTotal),     expectedTotal);
-    EXPECT_EQ(readStat(ncclStatGpuMemPersist),   expectedPersist);
-    EXPECT_EQ(readStat(ncclStatGpuMemSuspend),   expectedDynamic);
+    EXPECT_EQ(readStat(ncclStatGpuMemTotal)   - base.total,        deltaTotal);
+    EXPECT_EQ(readStat(ncclStatGpuMemPersist) - base.persist,      deltaPersist);
+    EXPECT_EQ(readStat(ncclStatGpuMemSuspend) - base.suspendBytes, deltaDynamic);
     EXPECT_EQ(readStat(ncclStatGpuMemSuspended), 0u);
 
-    // Persist physical memory must still be readable with its canary intact.
     verifyCanaryReadback(persistVmm.ptr, persistVmm.size, kPersistByte,
                          "persist after Suspend/Resume");
 
     untrackAndRelease(comm, scratchVmm.ptr, &scratchVmm);
     untrackAndRelease(comm, offloadVmm.ptr, &offloadVmm);
-    // Persist isn't in the linked list - Untrack only adjusts the counter.
     ASSERT_EQ(ncclMemUntrack(comm->memManager, persistVmm.ptr, persistVmm.size),
               ncclSuccess);
     releaseVmm(&persistVmm);
 
-    EXPECT_EQ(readStat(ncclStatGpuMemTotal), 0u);
+    EXPECT_EQ(readStat(ncclStatGpuMemTotal),   base.total);
+    EXPECT_EQ(readStat(ncclStatGpuMemPersist), base.persist);
 }
 
 // C: multiple Suspend/Resume cycles on the same Offload buffer. Verifies that
@@ -773,6 +831,8 @@ TEST_F(MemManagerAnyRanks, MultipleSuspendResumeCycles_DataPreserved)
 {
     ncclComm_t comm = getActiveCommunicator();
     ASSERT_NE(comm->memManager, nullptr);
+
+    const uint64_t internalOffload = captureInternalOffloadCpuBackup(comm);
 
     constexpr size_t  kSize    = 64 * 1024;
     constexpr int     kCycles  = 5;
@@ -795,12 +855,12 @@ TEST_F(MemManagerAnyRanks, MultipleSuspendResumeCycles_DataPreserved)
         SCOPED_TRACE("cycle=" + std::to_string(cycle));
 
         ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
-        EXPECT_EQ(comm->memManager->cpuBackupUsage, a.size)
-            << "Suspend must allocate exactly one CPU backup";
+        EXPECT_EQ(comm->memManager->cpuBackupUsage, internalOffload + a.size)
+            << "Suspend must allocate one CPU backup per Offload entry";
 
         ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
         EXPECT_EQ(comm->memManager->cpuBackupUsage, 0u)
-            << "Resume must free the CPU backup after restore";
+            << "Resume must free every CPU backup after restore";
 
         std::vector<uint8_t> readback(a.size, 0u);
         ASSERT_EQ(hipMemcpy(readback.data(), a.ptr, a.size, hipMemcpyDeviceToHost),
@@ -820,16 +880,18 @@ TEST_F(MemManagerAnyRanks, Suspend_LargeNumberOfEntries_AllRestored)
     ncclComm_t comm = getActiveCommunicator();
     ASSERT_NE(comm->memManager, nullptr);
 
+    const MgrBaseline base            = captureBaseline(comm);
+    const uint64_t    internalOffload = captureInternalOffloadCpuBackup(comm);
+
     constexpr int kNumEntries = 32;
     constexpr int kNumOffload = 8;  // first kNumOffload are Offload, rest are Scratch
 
     std::vector<VmmAlloc> entries(kNumEntries);
     std::vector<uint8_t>  canaries(kNumEntries);
-    uint64_t              expectedDynamicBytes = 0;
-    uint64_t              expectedOffloadBytes = 0;
+    uint64_t              testDynamicBytes = 0;
+    uint64_t              testOffloadBytes = 0;
 
     for (int i = 0; i < kNumEntries; ++i) {
-        // Mix sizes from 4 KiB to ~256 KiB - granularity rounding still applies.
         size_t requested = (4 * 1024) + (i * 8 * 1024);
         allocateVmmPosixFd(comm->cudaDev, requested, &entries[i]);
 
@@ -842,21 +904,19 @@ TEST_F(MemManagerAnyRanks, Suspend_LargeNumberOfEntries_AllRestored)
                                entries[i].handle,
                                hipMemHandleTypePosixFileDescriptor, type),
                   ncclSuccess);
-        expectedDynamicBytes += entries[i].size;
-        if (isOffload) expectedOffloadBytes += entries[i].size;
+        testDynamicBytes += entries[i].size;
+        if (isOffload) testOffloadBytes += entries[i].size;
     }
     ASSERT_EQ(hipDeviceSynchronize(), hipSuccess);
-    EXPECT_EQ(comm->memManager->numEntries, kNumEntries);
+    EXPECT_EQ(comm->memManager->numEntries - base.numEntries, kNumEntries);
 
     ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
-    EXPECT_EQ(comm->memManager->cpuBackupUsage, expectedOffloadBytes)
-        << "CPU backup pool must equal sum of Offload sizes";
+    EXPECT_EQ(comm->memManager->cpuBackupUsage, internalOffload + testOffloadBytes)
+        << "CPU backup pool must equal sum of all Offload sizes (internal + test)";
 
     ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
     EXPECT_EQ(comm->memManager->cpuBackupUsage, 0u);
 
-    // Every Offload entry must come back with its canary preserved. Scratch
-    // entries lose data by design - just check the VA is mapped + writable.
     for (int i = 0; i < kNumEntries; ++i) {
         SCOPED_TRACE("entry=" + std::to_string(i));
         if (i < kNumOffload) {
@@ -872,10 +932,10 @@ TEST_F(MemManagerAnyRanks, Suspend_LargeNumberOfEntries_AllRestored)
         EXPECT_EQ(ncclCommMemStats(comm, s, &v), ncclSuccess);
         return v;
     };
-    EXPECT_EQ(readStat(ncclStatGpuMemSuspend), expectedDynamicBytes);
+    EXPECT_EQ(readStat(ncclStatGpuMemSuspend) - base.suspendBytes, testDynamicBytes);
 
     for (auto& e : entries) untrackAndRelease(comm, e.ptr, &e);
-    EXPECT_EQ(comm->memManager->numEntries, 0);
+    EXPECT_EQ(comm->memManager->numEntries, base.numEntries);
 }
 
 // E: Persist physical memory must survive Suspend/Resume completely untouched
@@ -886,6 +946,9 @@ TEST_F(MemManagerAnyRanks, Persist_PhysicalMemoryUntouched)
 {
     ncclComm_t comm = getActiveCommunicator();
     ASSERT_NE(comm->memManager, nullptr);
+
+    const MgrBaseline base            = captureBaseline(comm);
+    const uint64_t    internalOffload = captureInternalOffloadCpuBackup(comm);
 
     constexpr size_t  kSize   = 32 * 1024;
     constexpr uint8_t kCanary = 0xE7;
@@ -900,14 +963,13 @@ TEST_F(MemManagerAnyRanks, Persist_PhysicalMemoryUntouched)
                            ncclMemPersist),
               ncclSuccess);
 
-    EXPECT_EQ(comm->memManager->numEntries, 0)
+    EXPECT_EQ(comm->memManager->numEntries, base.numEntries)
         << "Persist must not enter the linked list (only counter)";
 
     ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
-    EXPECT_EQ(comm->memManager->cpuBackupUsage, 0u)
-        << "Persist must NOT be CPU-backed up";
+    EXPECT_EQ(comm->memManager->cpuBackupUsage, internalOffload)
+        << "Persist must NOT contribute to CPU backup pool";
 
-    // VA must still be live - manager skipped it, so handle/map are untouched.
     verifyCanaryReadback(persistVmm.ptr, persistVmm.size, kCanary, "persist mid-suspend");
 
     ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
@@ -974,10 +1036,15 @@ TEST_F(MemManagerTwoRank, Multiple_PeerEntries_RoundtripCanary)
     ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
     ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
 
+    // Look up each test-owned import explicitly. With NCCL_CUMEM_ENABLE=1 the
+    // manager also tracks ~64 internal peer-imports from src/transport/p2p.cc
+    // (P2P proxy setup), so we cannot count by `isImportedFromPeer` alone.
     int activeCount = 0;
-    for (auto* e = comm->memManager->entries; e != nullptr; e = e->next) {
-        EXPECT_EQ(e->state, ncclDynMemStateActive);
+    for (int i = 0; i < kNumBuffers; ++i) {
+        auto* e = findEntryByPtr(comm, imports[i].ptr);
+        ASSERT_NE(e, nullptr) << "Import #" << i << " missing from manager";
         EXPECT_TRUE(e->isImportedFromPeer);
+        EXPECT_EQ(e->state, ncclDynMemStateActive);
         ++activeCount;
     }
     EXPECT_EQ(activeCount, kNumBuffers);
@@ -1001,11 +1068,11 @@ TEST_F(MemManagerTwoRank, Bidirectional_PeerExchange_RoundtripCanary)
     int rank = comm->rank;
     int peer = 1 - rank;
 
+    const MgrBaseline base = captureBaseline(comm);
+
     constexpr size_t kSize       = 64 * 1024;
     const     uint8_t myCanary   = (rank == 0) ? 0xD1 : 0xD2;
     const     uint8_t peerCanary = (rank == 0) ? 0xD2 : 0xD1;
-    // One tag per sender so the two bootstrapSends can race in flight without
-    // collision at the bootstrap layer.
     const int myExportTag   = 0xC0FFEE0 + rank;
     const int peerExportTag = 0xC0FFEE0 + peer;
 
@@ -1014,9 +1081,6 @@ TEST_F(MemManagerTwoRank, Bidirectional_PeerExchange_RoundtripCanary)
     ASSERT_EQ(hipMemset(myExport.ptr, myCanary, myExport.size), hipSuccess);
     ASSERT_EQ(hipDeviceSynchronize(), hipSuccess);
 
-    // Send my export's metadata BEFORE the recv to avoid deadlock - both ranks
-    // do the same so each side's bootstrapSend buffers up at the bootstrap
-    // layer until the matching bootstrapRecv fires.
     exportAndShipMeta(comm, myExport, peer, ncclMemOffload, myExportTag);
 
     VmmAlloc peerImport{};
@@ -1024,8 +1088,8 @@ TEST_F(MemManagerTwoRank, Bidirectional_PeerExchange_RoundtripCanary)
     verifyCanaryReadback(peerImport.ptr, peerImport.size, peerCanary,
                          "primary import of peer's buffer");
 
-    EXPECT_EQ(comm->memManager->numEntries, 2)
-        << "Each rank should now own 1 local + 1 imported entry";
+    EXPECT_EQ(comm->memManager->numEntries - base.numEntries, 2)
+        << "Each rank should add 1 local + 1 imported entry on top of baseline";
 
     ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
     ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
@@ -1037,11 +1101,9 @@ TEST_F(MemManagerTwoRank, Bidirectional_PeerExchange_RoundtripCanary)
     untrackAndRelease(comm, peerImport.ptr, &peerImport);
 }
 
-// H: rank 0 exports 2 buffers, but rank 1 only does a real import for the
-// FIRST one - the second is a synthetic stale import that points at a fake
-// ownerPtr (nothing actually exported with that VA). Resume Step 4 must
-// successfully match buffer #0 (positive branch) AND skip-with-WARN buffer
-// #1 (negative branch), in the SAME matching-loop pass.
+// Rank 1 has 1 real peer-import + 1 stale (fake ownerPtr). Per RCCL divergence
+// (mem_manager.cc:905), Step 4 partial-success: real -> Active, stale stays
+// Released, ncclCommMemResume returns ncclSystemError.
 TEST_F(MemManagerTwoRank, PartialPeerImport_MixedMatch)
 {
     ncclComm_t comm = getActiveCommunicator();
@@ -1093,16 +1155,24 @@ TEST_F(MemManagerTwoRank, PartialPeerImport_MixedMatch)
     }
 
     ASSERT_EQ(ncclCommMemSuspend(comm), ncclSuccess);
-    ASSERT_EQ(ncclCommMemResume(comm), ncclSuccess);
+    // Per RCCL divergence: stale's no-match -> ncclSystemError. Real import is
+    // still re-imported successfully in the same pass (partial-success).
+    EXPECT_EQ(ncclCommMemResume(comm), ncclSystemError)
+        << "Stale no-match peer-import must surface ncclSystemError";
+    EXPECT_EQ(comm->memManager->released, 1)
+        << "Partial-failure must leave manager in suspended state";
 
-    int activeCount   = 0;
-    int releasedCount = 0;
-    for (auto* e = comm->memManager->entries; e != nullptr; e = e->next) {
-        if      (e->state == ncclDynMemStateActive)   ++activeCount;
-        else if (e->state == ncclDynMemStateReleased) ++releasedCount;
-    }
-    EXPECT_EQ(activeCount,   1) << "Resume must match-and-restore exactly the real import";
-    EXPECT_EQ(releasedCount, 1) << "Stale entry must remain Released (no-match WARN branch)";
+    // Look up the two test-owned entries explicitly. With NCCL_CUMEM_ENABLE=1
+    // the manager also tracks ~64 internal peer-imports (proxy P2P from
+    // src/transport/p2p.cc:325,380) so we cannot count by isImportedFromPeer.
+    auto* realEntry  = findEntryByPtr(comm, realImport.ptr);
+    auto* staleEntry = findEntryByPtr(comm, stale.ptr);
+    ASSERT_NE(realEntry,  nullptr);
+    ASSERT_NE(staleEntry, nullptr);
+    EXPECT_EQ(realEntry->state,  ncclDynMemStateActive)
+        << "Real import must be re-imported despite stale's failure";
+    EXPECT_EQ(staleEntry->state, ncclDynMemStateReleased)
+        << "Stale entry must stay Released (no-match branch)";
 
     verifyCanaryReadback(realImport.ptr, realImport.size, kCanary,
                          "real import survived mixed-match Resume");
@@ -1110,6 +1180,690 @@ TEST_F(MemManagerTwoRank, PartialPeerImport_MixedMatch)
     ASSERT_EQ(ncclMemUntrack(comm->memManager, stale.ptr, stale.size), ncclSuccess);
     releaseVmm(&stale);
     untrackAndRelease(comm, realImport.ptr, &realImport);
+}
+
+// ============================================================================
+// Public API tests (ncclCommSuspend / ncclCommResume / ncclCommMemStats).
+//
+// The internal ncclCommMemSuspend/Resume/Stats path is exercised in detail by
+// the MemManagerAnyRanks / MemManagerTwoRank suites above (peer export/import
+// canary, manager state machine, etc). The suites below target the public API:
+//
+//  - ncclCommSuspend(comm, NCCL_SUSPEND_MEM)
+//  - ncclCommResume(comm)
+//  - ncclCommMemStats(comm, stat, &value)
+//
+// Coverage matrix:
+//
+//  Happy paths
+//    - SuspendResumeBasic.BasicCycle              one Suspend -> Resume round-trip
+//    - SuspendResumeBasic.MultipleCycles          5 back-to-back cycles
+//    - SuspendResumeBasic.BarrierSync             rank 0 sleeps before suspend;
+//                                                 every rank should observe the
+//                                                 cross-rank bootstrap barrier
+//    - SuspendResumeMemStats.BeforeAndAfter       ncclStatGpuMem* across the
+//                                                 active/suspended/resumed
+//                                                 transitions
+//    - SuspendResumeMemStats.Conservation         total + suspended bytes is
+//                                                 conserved across a Suspend
+//    - SuspendResumeCollectiveIntegrity.AllReduceAfterResume
+//                                                 AllReduce produces correct
+//                                                 result after Suspend/Resume
+//    - SuspendResumeCollectiveIntegrity.AllReduceTwoCycles
+//                                                 same after multiple cycles
+//    - SuspendResumeCollectiveIntegrity.AllReduceP2pAutoMark
+//                                                 verifies that p2p collectives
+//                                                 auto-mark exported buffers via
+//                                                 ncclDynMemMarkExportToPeer
+//                                                 (Bucket 1)
+//    - SuspendResumeLifecycle.DestroyWhileSuspended
+//                                                 ncclCommDestroy succeeds on a
+//                                                 still-suspended comm (drains
+//                                                 pending tasks + manager
+//                                                 destruction frees released VAs)
+//    - SuspendResumeGroup.AtomicSuspend           ncclGroupStart() + Suspend +
+//                                                 ncclGroupEnd() drains the
+//                                                 pending suspend task
+//    - SuspendResumeGroup.AtomicResume            same for Resume
+//    - SuspendResumeGroup.MixedSuspendResume      Suspend + Resume in the same
+//                                                 group leaves the comm active
+//
+//  Argument validation (no bootstrap barrier reached, so individual ranks can
+//  fail without deadlocking peers)
+//    - SuspendResumeArgValidation.ZeroFlags       Suspend(comm, 0) is rejected
+//    - SuspendResumeArgValidation.UnknownFlagsRejected  bogus high bits rejected
+//    - SuspendResumeArgValidation.DoubleSuspend   Suspend twice -> 2nd rejected
+//    - SuspendResumeArgValidation.ResumeWhenActive Resume on active comm rejected
+//    - SuspendResumeArgValidation.DoubleResume    Resume twice -> 2nd rejected
+//    - SuspendResumeMemStatsValidation.NullValuePtr  NULL output pointer rejected
+//    - SuspendResumeMemStatsValidation.UnknownStat   bogus enum value rejected
+// ============================================================================
+
+namespace SuspendResumeTestConfig
+{
+constexpr int    kMinRanks        = 2;     // multi-rank tests need >= 2
+constexpr size_t kAllReduceCount  = 1024;  // 4 KiB float buffer
+constexpr float  kEpsilon         = 1e-3f;
+constexpr int    kMultiCycleCount = 5;
+constexpr int    kBarrierSleepMs  = 200;   // rank-0 stagger time
+} // namespace SuspendResumeTestConfig
+
+using namespace SuspendResumeTestConfig;
+
+/**
+ * @class SuspendResumePublicAPITestBase
+ * @brief Shared fixture for all public-API suspend/resume MPI tests.
+ *
+ * Wraps MPITestBase and adds a convenience accessor for ncclCommMemStats and
+ * a self-checking AllReduce helper.
+ */
+class SuspendResumePublicAPITestBase : public MPITestBase
+{
+protected:
+    // Read one ncclCommMemStat as uint64_t. Fails the test on any non-success
+    // return so callers can use the value directly.
+    uint64_t readStat(ncclComm_t comm, ncclCommMemStat_t stat)
+    {
+        uint64_t v = ~uint64_t{0};
+        ncclResult_t r = ncclCommMemStats(comm, stat, &v);
+        EXPECT_EQ(r, ncclSuccess) << "ncclCommMemStats failed for stat " << (int)stat;
+        return v;
+    }
+
+    // Run an AllReduce with float-sum and verify each element equals
+    // sum(1..nranks) = nranks * (nranks + 1) / 2. Returns true on success.
+    bool runAllReduceAndVerify(ncclComm_t comm, hipStream_t stream)
+    {
+        const size_t n     = kAllReduceCount;
+        const int    rank  = MPIEnvironment::world_rank;
+        const int    nrnks = MPIEnvironment::world_size;
+
+        void* sendbuf = nullptr;
+        void* recvbuf = nullptr;
+        if (hipMalloc(&sendbuf, n * sizeof(float)) != hipSuccess) return false;
+        if (hipMalloc(&recvbuf, n * sizeof(float)) != hipSuccess)
+        {
+            (void)hipFree(sendbuf);
+            return false;
+        }
+        auto sendGuard = makeDeviceBufferAutoGuard(sendbuf);
+        auto recvGuard = makeDeviceBufferAutoGuard(recvbuf);
+
+        if (initializeBufferWithPattern<float>(
+                sendbuf, n,
+                [rank](size_t) { return static_cast<float>(rank + 1); }) != hipSuccess)
+            return false;
+        if (zeroInitializeBuffer<float>(recvbuf, n) != hipSuccess) return false;
+
+        if (ncclAllReduce(sendbuf, recvbuf, n, ncclFloat32, ncclSum, comm, stream)
+            != ncclSuccess)
+            return false;
+        if (hipStreamSynchronize(stream) != hipSuccess) return false;
+
+        const float expected = static_cast<float>(nrnks * (nrnks + 1) / 2);
+        return verifyBufferData<float>(
+            recvbuf, n,
+            [expected](size_t) { return expected; },
+            0,
+            static_cast<double>(kEpsilon * expected));
+    }
+};
+
+// ----------------------------------------------------------------------------
+// 1. Basic happy-path tests
+// ----------------------------------------------------------------------------
+
+class SuspendResumeBasic : public SuspendResumePublicAPITestBase {};
+
+TEST_F(SuspendResumeBasic, BasicCycle)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended))
+        << "Newly initialized comm must report not-suspended";
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    EXPECT_EQ(1u, readStat(comm, ncclStatGpuMemSuspended))
+        << "After Suspend, ncclStatGpuMemSuspended must be 1";
+
+    // ncclStatGpuMemSuspend == totalScratch + totalOffload of *tracked* entries
+    // With NCCL_CUMEM_ENABLE=0 the comm's internal allocations are not
+    // VMM-backed so the count is legitimately zero; with CUMEM=1 it is > 0.
+    uint64_t suspBytes = readStat(comm, ncclStatGpuMemSuspend);
+    TEST_INFO("Rank %d ncclStatGpuMemSuspend after Suspend = %llu bytes",
+              MPIEnvironment::world_rank, (unsigned long long)suspBytes);
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+    EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended))
+        << "After Resume, ncclStatGpuMemSuspended must be 0";
+}
+
+TEST_F(SuspendResumeBasic, MultipleCycles)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    for (int i = 0; i < kMultiCycleCount; ++i)
+    {
+        TEST_INFO("Cycle %d: Suspend", i);
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+        EXPECT_EQ(1u, readStat(comm, ncclStatGpuMemSuspended)) << "cycle " << i;
+
+        TEST_INFO("Cycle %d: Resume", i);
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+        EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended)) << "cycle " << i;
+    }
+}
+
+TEST_F(SuspendResumeBasic, BarrierSync)
+{
+    // Rank 0 stages a deliberate delay before calling Suspend. Without the
+    // bootstrapBarrier inside ncclCommMemSuspend, the other ranks would return
+    // immediately and the elapsed time on those ranks would be much smaller
+    // than rank 0's. With the barrier wired up correctly, every rank must
+    // observe at least kBarrierSleepMs of elapsed wall-clock between the
+    // (cross-rank) start of the call and its return.
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    auto t0 = std::chrono::steady_clock::now();
+
+    if (MPIEnvironment::world_rank == 0)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(kBarrierSleepMs));
+    }
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    auto t1 = std::chrono::steady_clock::now();
+
+    auto elapsed_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
+
+    // Generous slack: this is a synchronization assertion, not a microbenchmark.
+    // Without a barrier, non-zero ranks would typically observe < 10 ms.
+    EXPECT_GE(elapsed_ms, kBarrierSleepMs / 2)
+        << "Rank " << MPIEnvironment::world_rank
+        << ": Suspend returned in " << elapsed_ms
+        << " ms (rank 0 staged a " << kBarrierSleepMs
+        << " ms delay; expected the barrier to hold every rank)";
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+}
+
+// ----------------------------------------------------------------------------
+// 2. Memory-statistics correctness
+// ----------------------------------------------------------------------------
+
+class SuspendResumeMemStats : public SuspendResumePublicAPITestBase {};
+
+TEST_F(SuspendResumeMemStats, BeforeAndAfter)
+{
+    // ncclCommMemStats reads per-type counters on the memory manager.
+    // The counters cover *tracked* allocations only. With NCCL_CUMEM_ENABLE=0
+    // RCCL skips tracking on most internal allocations so all counters
+    // legitimately read zero; the suspended boolean still toggles. With
+    // CUMEM=1, counters are non-zero and persist across the suspend boundary
+    // (Suspend doesn't change totalScratch/totalOffload -- it only flips
+    // released).
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    uint64_t totalActive = readStat(comm, ncclStatGpuMemTotal);
+    uint64_t suspActive  = readStat(comm, ncclStatGpuMemSuspend);
+    uint64_t persActive  = readStat(comm, ncclStatGpuMemPersist);
+    uint64_t isSusActive = readStat(comm, ncclStatGpuMemSuspended);
+    EXPECT_EQ(isSusActive, 0u) << "fresh comm must not be suspended";
+    EXPECT_EQ(totalActive, persActive + suspActive)
+        << "Total = persist + (scratch+offload) invariant";
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+
+    uint64_t totalSusp = readStat(comm, ncclStatGpuMemTotal);
+    uint64_t suspSusp  = readStat(comm, ncclStatGpuMemSuspend);
+    uint64_t isSusSusp = readStat(comm, ncclStatGpuMemSuspended);
+    EXPECT_EQ(isSusSusp, 1u) << "after Suspend, suspended boolean must be 1";
+    EXPECT_EQ(totalSusp, totalActive)
+        << "Suspend does not change tracked byte counters (mirrors NCCL)";
+    EXPECT_EQ(suspSusp, suspActive)
+        << "Suspend does not change scratch/offload byte counters";
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+
+    uint64_t totalResumed = readStat(comm, ncclStatGpuMemTotal);
+    uint64_t isSusResumed = readStat(comm, ncclStatGpuMemSuspended);
+    EXPECT_EQ(isSusResumed, 0u);
+    EXPECT_EQ(totalResumed, totalActive)
+        << "Resume does not change tracked byte counters either";
+
+    TEST_INFO("rank %d: total=%llu persist=%llu suspendable=%llu "
+              "[scratch+offload] (CUMEM gates whether non-zero)",
+              MPIEnvironment::world_rank,
+              (unsigned long long)totalActive,
+              (unsigned long long)persActive,
+              (unsigned long long)suspActive);
+}
+
+TEST_F(SuspendResumeMemStats, Conservation)
+{
+    // ncclCommMemStats reports per-type byte counters; Suspend doesn't move
+    // bytes between persist / scratch / offload buckets, it only flips the
+    // released boolean. So Total = Persist + (Scratch+Offload) holds in every
+    // state, and Total/Persist/Suspend are constant across a Suspend->Resume
+    // round-trip. (CPU backup memory used by ncclMemOffload entries is tracked
+    // separately on manager->cpuBackupUsage and not part of the public stats.)
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    uint64_t totalA = readStat(comm, ncclStatGpuMemTotal);
+    uint64_t persA  = readStat(comm, ncclStatGpuMemPersist);
+    uint64_t suspA  = readStat(comm, ncclStatGpuMemSuspend);
+    EXPECT_EQ(totalA, persA + suspA);
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    uint64_t totalS = readStat(comm, ncclStatGpuMemTotal);
+    uint64_t persS  = readStat(comm, ncclStatGpuMemPersist);
+    uint64_t suspS  = readStat(comm, ncclStatGpuMemSuspend);
+    EXPECT_EQ(totalS, totalA);
+    EXPECT_EQ(persS,  persA);
+    EXPECT_EQ(suspS,  suspA);
+    EXPECT_EQ(totalS, persS + suspS);
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+
+    uint64_t totalR = readStat(comm, ncclStatGpuMemTotal);
+    EXPECT_EQ(totalR, totalA);
+}
+
+// ----------------------------------------------------------------------------
+// 3. Collective integrity across a suspend/resume cycle
+// ----------------------------------------------------------------------------
+
+class SuspendResumeCollectiveIntegrity : public SuspendResumePublicAPITestBase {};
+
+TEST_F(SuspendResumeCollectiveIntegrity, AllReduceAfterResume)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t  comm   = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+
+    EXPECT_TRUE(runAllReduceAndVerify(comm, stream))
+        << "AllReduce baseline failed before any Suspend";
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+
+    EXPECT_TRUE(runAllReduceAndVerify(comm, stream))
+        << "AllReduce produced wrong values after Suspend/Resume cycle";
+}
+
+TEST_F(SuspendResumeCollectiveIntegrity, AllReduceTwoCycles)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t  comm   = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+
+    EXPECT_TRUE(runAllReduceAndVerify(comm, stream)) << "baseline AllReduce";
+
+    for (int i = 0; i < 2; ++i)
+    {
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+
+        EXPECT_TRUE(runAllReduceAndVerify(comm, stream))
+            << "AllReduce wrong after cycle " << i;
+    }
+}
+
+// Regression: ncclP2pImportShareableBuffer (and the intra-PID different-GPU
+// branch in p2pMap) must call ncclMemTrackImportFromPeer so the importer side
+// of every cuMem-backed proxy buffer is visible to ncclMemManager. Without
+// this wiring Resume Step 4 has nothing to re-import: after Suspend the owner
+// rebuilds its physical pages, but the importer's local VA stays mapped to
+// the OLD physical pages, owner/importer drift apart, and the next collective
+// hangs in hipStreamSynchronize waiting on flags that never converge across
+// the diverged buffers.
+//
+// We catch the bug structurally instead of as a hang:
+//   1. Force p2p proxy connections via a warm-up AllReduce.
+//   2. Walk manager->entries and require >= 1 entry with isImportedFromPeer
+//      and a non-zero live handle. Pre-fix this set is empty under CUMEM=1;
+//      post-fix every cross-PID p2p connection adds one.
+//   3. Suspend/Resume and verify that those imported entries return Active
+//      with rebuilt (still non-zero) handles and a non-stale ownerPtr.
+TEST_F(SuspendResumeCollectiveIntegrity, P2pPeerImports_TrackedAndRebuilt)
+{
+    // Peer-import tracking lives on the cuMem path (ncclP2pImportShareableBuffer
+    // calls ncclMemTrackImportFromPeer). Under NCCL_CUMEM_ENABLE=0 RCCL falls
+    // back to legacy cudaIpcOpenMemHandle/cudaIpcCloseMemHandle which is not
+    // managed by Suspend/Resume, so this regression check is meaningless there.
+    if (!ncclCuMemEnable()) {
+        GTEST_SKIP() << "NCCL_CUMEM_ENABLE=0 — peer-import tracking is cuMem-only";
+    }
+
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t  comm   = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+
+    ASSERT_NE(comm->memManager, nullptr);
+
+    EXPECT_TRUE(runAllReduceAndVerify(comm, stream))
+        << "warm-up AllReduce must succeed before peer-import inspection";
+
+    auto countPeerImports = [&](int* nActive, int* nReleased) {
+        *nActive = *nReleased = 0;
+        std::lock_guard<std::mutex> lk(comm->memManager->lock);
+        for (auto* e = comm->memManager->entries; e != nullptr; e = e->next) {
+            if (!e->isImportedFromPeer) continue;
+            if (e->state == ncclDynMemStateActive)        (*nActive)++;
+            else if (e->state == ncclDynMemStateReleased) (*nReleased)++;
+        }
+    };
+
+    int activeBefore = 0, releasedBefore = 0;
+    countPeerImports(&activeBefore, &releasedBefore);
+    EXPECT_EQ(releasedBefore, 0)
+        << "no entry should be Released while comm is unsuspended";
+    EXPECT_GT(activeBefore, 0)
+        << "ncclP2pImportShareableBuffer must register every cross-PID p2p "
+           "import via ncclMemTrackImportFromPeer (regression: 0 imports "
+           "tracked => Resume Step 4 is a no-op => post-Resume collectives "
+           "hang on stale peer mappings)";
+
+    if (activeBefore == 0) return;
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+
+    int activeMid = 0, releasedMid = 0;
+    countPeerImports(&activeMid, &releasedMid);
+    EXPECT_EQ(activeMid, 0)
+        << "Suspend must move every peer-imported entry to Released";
+    EXPECT_EQ(releasedMid, activeBefore)
+        << "Suspend must Release exactly the entries that were Active before";
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+
+    int activeAfter = 0, releasedAfter = 0;
+    countPeerImports(&activeAfter, &releasedAfter);
+    EXPECT_EQ(releasedAfter, 0)
+        << "Resume must rebuild every peer-imported entry";
+    EXPECT_EQ(activeAfter, activeBefore)
+        << "Resume must restore the same number of peer-imported entries";
+
+    {
+        std::lock_guard<std::mutex> lk(comm->memManager->lock);
+        for (auto* e = comm->memManager->entries; e != nullptr; e = e->next) {
+            if (!e->isImportedFromPeer) continue;
+            EXPECT_NE(e->ptr, nullptr) << "imported VA must be preserved";
+            EXPECT_NE(e->desc.imported.ownerPtr, nullptr)
+                << "ownerPtr must survive Suspend/Resume so Step 4 can match";
+            // handle == 0 is legal for the intra-PID different-GPU branch
+            // (handle pre-released by p2pMap), so we don't assert non-zero
+            // here. The cross-PID branch will have a fresh non-zero handle.
+        }
+    }
+
+    EXPECT_TRUE(runAllReduceAndVerify(comm, stream))
+        << "post-Resume AllReduce must complete (no hang on stale imports)";
+}
+
+TEST_F(SuspendResumeCollectiveIntegrity, AllReduceP2pAutoMark)
+{
+    // Bucket 1 invariant: p2pSendProxySetup / p2pRecvProxySetup pass req->peerRank
+    // into ncclP2pAllocateShareableBuffer, which in turn calls
+    // ncclDynMemMarkExportToPeer on every cuMem-allocated proxy buffer. After
+    // Suspend, the manager's Step 3 in ncclCommMemResume re-exports those
+    // buffers to the same peer using the recorded peerRank, so the post-Resume
+    // AllReduce can rebuild peer mappings without manual MarkExport calls.
+    //
+    // This test exercises the full path end-to-end: an AllReduce that uses the
+    // p2p transport must continue to work after a full Suspend/Resume cycle.
+    // If peerRank is lost this test still passes when CUMEM=0
+    // (no peer marking happens at all) but exposes the regression
+    // as a SIGSEGV during Resume Step 4 with CUMEM=1 + nRanks >= 2.
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t  comm   = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+
+    // Warm-up AllReduce so the p2p proxy buffers are actually allocated and
+    // marked for export before we suspend.
+    EXPECT_TRUE(runAllReduceAndVerify(comm, stream)) << "warm-up AllReduce";
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+
+    EXPECT_TRUE(runAllReduceAndVerify(comm, stream))
+        << "AllReduce broken after Suspend/Resume - peer-export marking "
+           "regression?";
+}
+
+// ----------------------------------------------------------------------------
+// 4. Lifecycle: destroy while suspended
+// ----------------------------------------------------------------------------
+
+class SuspendResumeLifecycle : public SuspendResumePublicAPITestBase
+{
+protected:
+    // We tear down our own comm in this test rather than relying on the base
+    // class, so that we drive ncclCommDestroy from a suspended state.
+    void TearDown() override
+    {
+        // Skip MPITestBase::TearDown's cleanupTestCommunicator since the test
+        // already destroyed it.
+        test_comm_   = nullptr;
+        test_stream_ = nullptr;
+    }
+};
+
+TEST_F(SuspendResumeLifecycle, DestroyWhileSuspended)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t  comm   = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    EXPECT_EQ(1u, readStat(comm, ncclStatGpuMemSuspended));
+
+    // Tear the comm down without resuming. commFree drains pending suspend/resume
+    // tasks and ncclMemManagerDestroy reclaims VAs of Released entries, so the
+    // destructor walk must not SIGSEGV.
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommDestroy(comm));
+    test_comm_ = nullptr;
+    if (stream != nullptr)
+    {
+        (void)hipStreamDestroy(stream);
+        test_stream_ = nullptr;
+    }
+}
+
+// ----------------------------------------------------------------------------
+// 5. Group context (Bucket 3): Suspend/Resume inside ncclGroupStart/End
+// ----------------------------------------------------------------------------
+
+class SuspendResumeGroup : public SuspendResumePublicAPITestBase {};
+
+TEST_F(SuspendResumeGroup, AtomicSuspend)
+{
+    // ncclCommSuspend always wraps the body in
+    // ncclGroupStartInternal/EndInternal, so a user-level
+    // ncclGroupStart/Suspend/ncclGroupEnd nesting must still drain the pending
+    // suspend task and leave the comm in the suspended state.
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclGroupStart());
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    ASSERT_MPI_EQ(ncclSuccess, ncclGroupEnd());
+
+    EXPECT_EQ(1u, readStat(comm, ncclStatGpuMemSuspended))
+        << "Suspend inside a group must drain in groupLaunch";
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+    EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended));
+}
+
+TEST_F(SuspendResumeGroup, AtomicResume)
+{
+    // Same as AtomicSuspend but for Resume.
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    EXPECT_EQ(1u, readStat(comm, ncclStatGpuMemSuspended));
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclGroupStart());
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+    ASSERT_MPI_EQ(ncclSuccess, ncclGroupEnd());
+
+    EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended))
+        << "Resume inside a group must drain in groupLaunch";
+}
+
+TEST_F(SuspendResumeGroup, MixedSuspendResume)
+{
+    // Suspend + Resume in the same group: groupLaunch drains suspendTaskQueue
+    // first, then resumeTaskQueue, so the net effect is "active" again.
+    // The RCCL pre-check in ncclCommResume_impl accepts this case because at
+    // the moment Resume is called there is still a Suspend task pending in
+    // suspendTaskQueue (i.e. the comm is "going to be suspended" — not
+    // currently active in the sense of the validation).
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended));
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclGroupStart());
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+    ASSERT_MPI_EQ(ncclSuccess, ncclGroupEnd());
+
+    EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended))
+        << "After Suspend+Resume in the same group, comm must be active";
+}
+
+// ----------------------------------------------------------------------------
+// 6. Argument validation / corner cases
+//
+// Each of these returns from inside ncclCommSuspend/Resume/MemStats BEFORE the
+// bootstrapBarrier is reached, so individual ranks failing the call do not
+// leave their peers blocked on a barrier.
+// ----------------------------------------------------------------------------
+
+class SuspendResumeArgValidation : public SuspendResumePublicAPITestBase {};
+
+TEST_F(SuspendResumeArgValidation, ZeroFlags)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    ASSERT_MPI_EQ(ncclInvalidArgument, ncclCommSuspend(comm, 0));
+
+    EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended))
+        << "rejected Suspend should not transition the comm";
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+}
+
+TEST_F(SuspendResumeArgValidation, UnknownFlagsRejected)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    ASSERT_MPI_EQ(ncclInvalidArgument, ncclCommSuspend(comm, 0xffff));
+    ASSERT_MPI_EQ(ncclInvalidArgument,
+                  ncclCommSuspend(comm, NCCL_SUSPEND_MEM | 0x80));
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+}
+
+TEST_F(SuspendResumeArgValidation, DoubleSuspend)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+
+    // Second suspend rejects on every rank before reaching the barrier
+    // (state check sees comm->memManager->released==1).
+    ASSERT_MPI_EQ(ncclInvalidUsage, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+    EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended));
+}
+
+TEST_F(SuspendResumeArgValidation, ResumeWhenActive)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    // Resume on an already-active comm rejects before any barrier.
+    ASSERT_MPI_EQ(ncclInvalidUsage, ncclCommResume(comm));
+
+    EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended))
+        << "rejected Resume should not transition the comm";
+}
+
+TEST_F(SuspendResumeArgValidation, DoubleResume)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommSuspend(comm, NCCL_SUSPEND_MEM));
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommResume(comm));
+
+    // Second resume rejects: comm is no longer suspended.
+    ASSERT_MPI_EQ(ncclInvalidUsage, ncclCommResume(comm));
+
+    EXPECT_EQ(0u, readStat(comm, ncclStatGpuMemSuspended));
+}
+
+// ----- ncclCommMemStats validation --------------------------------------
+
+class SuspendResumeMemStatsValidation : public SuspendResumePublicAPITestBase {};
+
+TEST_F(SuspendResumeMemStatsValidation, NullValuePtr)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    EXPECT_EQ(ncclInvalidArgument,
+              ncclCommMemStats(comm, ncclStatGpuMemTotal, nullptr));
+    EXPECT_EQ(ncclInvalidArgument,
+              ncclCommMemStats(comm, ncclStatGpuMemSuspend, nullptr));
+}
+
+TEST_F(SuspendResumeMemStatsValidation, UnknownStat)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinRanks)) << "Need >= 2 ranks";
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t comm = getActiveCommunicator();
+
+    uint64_t v = 0;
+    EXPECT_EQ(ncclInvalidArgument,
+              ncclCommMemStats(comm, static_cast<ncclCommMemStat_t>(999), &v));
+    EXPECT_EQ(ncclInvalidArgument,
+              ncclCommMemStats(comm, static_cast<ncclCommMemStat_t>(-1), &v));
 }
 
 #endif // MPI_TESTS_ENABLED


### PR DESCRIPTION
- Bucket 1: track peerRank in ncclP2pRequest and call ncclDynMemMarkExportToPeer on every cuMem-allocated p2p proxy buffer so Resume Step 3 can re-export to the recorded peer.
- Bucket 2: expose ncclCommSuspend / ncclCommResume / ncclCommMemStats via api_trace dispatch (RCCL_API_TRACE_VERSION_PATCH 3 -> 4); add NCCL_SUSPEND_MEM and ncclCommMemStat_t to public nccl.h.
- Bucket 3: per-comm ncclMemManagerTask suspend/resume task queues + drain in groupLaunch so Suspend/Resume can be wrapped in ncclGroupStart/ncclGroupEnd (atomic across multi-comm groups).
- Tests: 13 new public-API tests (Basic / MemStats / CollectiveIntegrity / Lifecycle / Group / ArgValidation / MemStatsValidation) merged into the existing SuspendResumeMPITests.cpp.
