### PR TITLE
Add shader batch copy

### DIFF
--- a/projects/clr/rocclr/device/blitcl.cpp
+++ b/projects/clr/rocclr/device/blitcl.cpp
@@ -140,26 +140,21 @@ const char* BlitLinearSourceCode = BLIT_KERNELS(
       ulong aligned_element_count;
       uint aligned_element_size;
       uint trailing_byte_count;
-      uint workgroup_count;
     } CopyBufferBatchDescriptor;
 
     __kernel void __amd_rocclr_copyBufferBatch(
         __global const CopyBufferBatchDescriptor *descriptors,
-        uint workgroup_size) {
+        uint workgroup_size,
+        uint copy_stride) {
       uint work_item_id = __builtin_amdgcn_workitem_id_x();
       uint group_ordinal = __builtin_amdgcn_workgroup_id_x();
       uint descriptor_index = __builtin_amdgcn_workgroup_id_y();
 
       CopyBufferBatchDescriptor descriptor = descriptors[descriptor_index];
-      if (group_ordinal >= descriptor.workgroup_count) {
-        return;
-      }
-
       __global uchar *source = (__global uchar *)descriptor.source_address;
       __global uchar *destination =
           (__global uchar *)descriptor.destination_address;
       ulong copy_index = ((ulong)group_ordinal * workgroup_size) + work_item_id;
-      uint copy_stride = descriptor.workgroup_count * workgroup_size;
 
       if (descriptor.aligned_element_size == sizeof(ulong2)) {
         __global ulong2 *source_data = (__global ulong2 *)(source);

--- a/projects/clr/rocclr/device/blitcl.cpp
+++ b/projects/clr/rocclr/device/blitcl.cpp
@@ -134,6 +134,59 @@ const char* BlitLinearSourceCode = BLIT_KERNELS(
       }
     }
 
+    typedef struct CopyBufferBatchDescriptor {
+      ulong source_address;
+      ulong destination_address;
+      ulong aligned_element_count;
+      uint aligned_element_size;
+      uint trailing_byte_count;
+      uint workgroup_count;
+    } CopyBufferBatchDescriptor;
+
+    __kernel void __amd_rocclr_copyBufferBatch(
+        __global const CopyBufferBatchDescriptor *descriptors,
+        uint workgroup_size) {
+      uint work_item_id = __builtin_amdgcn_workitem_id_x();
+      uint group_ordinal = __builtin_amdgcn_workgroup_id_x();
+      uint descriptor_index = __builtin_amdgcn_workgroup_id_y();
+
+      CopyBufferBatchDescriptor descriptor = descriptors[descriptor_index];
+      if (group_ordinal >= descriptor.workgroup_count) {
+        return;
+      }
+
+      __global uchar *source = (__global uchar *)descriptor.source_address;
+      __global uchar *destination =
+          (__global uchar *)descriptor.destination_address;
+      ulong copy_index = ((ulong)group_ordinal * workgroup_size) + work_item_id;
+      uint copy_stride = descriptor.workgroup_count * workgroup_size;
+
+      if (descriptor.aligned_element_size == sizeof(ulong2)) {
+        __global ulong2 *source_data = (__global ulong2 *)(source);
+        __global ulong2 *destination_data = (__global ulong2 *)(destination);
+        while (copy_index < descriptor.aligned_element_count) {
+          destination_data[copy_index] = source_data[copy_index];
+          copy_index += copy_stride;
+        }
+      } else {
+        __global uint *source_data = (__global uint *)(source);
+        __global uint *destination_data = (__global uint *)(destination);
+        while (copy_index < descriptor.aligned_element_count) {
+          destination_data[copy_index] = source_data[copy_index];
+          copy_index += copy_stride;
+        }
+      }
+      if ((descriptor.trailing_byte_count != 0) && (group_ordinal == 0) &&
+          (work_item_id == 0)) {
+        ulong tail_start =
+            descriptor.aligned_element_count * descriptor.aligned_element_size;
+        ulong tail_end = tail_start + descriptor.trailing_byte_count;
+        for (ulong i = tail_start; i < tail_end; ++i) {
+          destination[i] = source[i];
+        }
+      }
+    }
+
     __kernel void __amd_rocclr_copyBufferAligned(__global uint* src, __global uint* dst,
                                                  ulong srcOrigin, ulong dstOrigin, ulong size,
                                                  uint alignment) {

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2601,15 +2601,15 @@ struct CopyBufferBatchDescriptor {
 };
 
 // ================================================================================================
-bool KernelBlitManager::shaderCopyBufferBatch(
+bool KernelBlitManager::ShaderCopyBufferBatch(
     const std::vector<amd::BatchCopyOp> &copy_operations,
     bool attach_signal) const {
   std::scoped_lock transfer_operations_lock(lockXferOps_);
 
   constexpr uint32_t kMaxAlignment = 2 * sizeof(uint64_t);
   constexpr uint32_t kLocalWorkSize = 512;
-  const uint32_t max_workgroups_per_copy =
-      std::max<uint32_t>(dev().settings().limit_blit_wg_ / copy_operations.size(), 1);
+  const uint32_t max_workgroups_per_copy = std::max<uint32_t>(
+      dev().settings().limit_blit_wg_ / copy_operations.size(), 1);
   const size_t descriptor_bytes =
       copy_operations.size() * sizeof(CopyBufferBatchDescriptor);
   void *descriptor_buffer = gpu().allocKernArg(descriptor_bytes, kCBAlignment);
@@ -2642,8 +2642,8 @@ bool KernelBlitManager::shaderCopyBufferBatch(
         std::max(max_aligned_element_count, aligned_element_count);
 
     descriptors[descriptor_index++] = {
-        source_address,        destination_address, aligned_element_count,
-        aligned_element_size,  trailing_byte_count};
+        source_address, destination_address, aligned_element_count,
+        aligned_element_size, trailing_byte_count};
   }
 
   uint32_t workgroup_count = static_cast<uint32_t>(
@@ -2748,20 +2748,22 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
       gpu().Barriers().AddExternalSignal(priorSignal);
     }
 
-    bool attachSignal = false;
-    for (const auto& op : d2dCopyOps) {
-      attachSignal |= !op.metadata.isAsync_;
+    bool attach_signal = false;
+    for (const auto &op : d2dCopyOps) {
+      attach_signal |= !op.metadata.isAsync_;
     }
 
-    std::map<size_t, std::vector<amd::BatchCopyOp>, std::greater<size_t>> d2dCopyOpsBySize;
-    for (const auto& op : d2dCopyOps) {
-      d2dCopyOpsBySize[op.size].push_back(op);
+    std::map<size_t, std::vector<amd::BatchCopyOp>, std::greater<size_t>>
+        d2d_copy_ops_by_size;
+    for (const auto &op : d2dCopyOps) {
+      d2d_copy_ops_by_size[op.size].push_back(op);
     }
 
-    for (const auto& copyOpsBySizeEntry : d2dCopyOpsBySize) {
-      const auto& copyOpsBySize = copyOpsBySizeEntry.second;
-      if (!shaderCopyBufferBatch(copyOpsBySize, attachSignal)) {
-        LogError("KernelBlitManager::shaderCopyBufferBatch: Intra-device batch copy failed!");
+    for (const auto &copy_ops_by_size_entry : d2d_copy_ops_by_size) {
+      const auto &copy_ops_by_size = copy_ops_by_size_entry.second;
+      if (!ShaderCopyBufferBatch(copy_ops_by_size, attach_signal)) {
+        LogError("KernelBlitManager::ShaderCopyBufferBatch: Intra-device batch "
+                 "copy failed!");
         return false;
       }
     }

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2592,6 +2592,89 @@ bool KernelBlitManager::shaderCopyBuffer(address dst, address src, const amd::Co
   return result;
 }
 
+struct CopyBufferBatchDescriptor {
+  uint64_t source_address;
+  uint64_t destination_address;
+  uint64_t aligned_element_count;
+  uint32_t aligned_element_size;
+  uint32_t trailing_byte_count;
+  uint32_t workgroup_count;
+};
+
+// ================================================================================================
+bool KernelBlitManager::shaderCopyBufferBatch(
+    const std::vector<amd::BatchCopyOp> &copy_operations,
+    bool attach_signal) const {
+  std::scoped_lock transfer_operations_lock(lockXferOps_);
+
+  constexpr uint32_t kMaxAlignment = 2 * sizeof(uint64_t);
+  constexpr uint32_t kLocalWorkSize = 512;
+  const uint32_t max_workgroups_per_copy =
+      std::max<uint32_t>(dev().settings().limit_blit_wg_ / copy_operations.size(), 1);
+  const size_t descriptor_bytes =
+      copy_operations.size() * sizeof(CopyBufferBatchDescriptor);
+  void *descriptor_buffer = gpu().allocKernArg(descriptor_bytes, kCBAlignment);
+  CopyBufferBatchDescriptor *descriptors =
+      static_cast<CopyBufferBatchDescriptor *>(descriptor_buffer);
+  size_t descriptor_index = 0;
+  uint32_t max_workgroups_used = 1;
+
+  for (const auto &copy_operation : copy_operations) {
+    device::Memory *source_device_memory =
+        copy_operation.srcMemory->getDeviceMemory(
+            *copy_operation.srcMemory->getContext().devices()[0]);
+    device::Memory *destination_device_memory =
+        copy_operation.dstMemory->getDeviceMemory(
+            *copy_operation.dstMemory->getContext().devices()[0]);
+
+    const uint64_t source_address =
+        source_device_memory->virtualAddress() + copy_operation.srcOffset;
+    const uint64_t destination_address =
+        destination_device_memory->virtualAddress() + copy_operation.dstOffset;
+    const bool addresses_aligned = ((source_address % kMaxAlignment) == 0) &&
+                                   ((destination_address % kMaxAlignment) == 0);
+    const uint32_t aligned_element_size =
+        (addresses_aligned) ? kMaxAlignment : sizeof(uint32_t);
+    const uint64_t aligned_element_count =
+        copy_operation.size / aligned_element_size;
+    const uint32_t trailing_byte_count =
+        copy_operation.size % aligned_element_size;
+
+    uint32_t workgroup_count = static_cast<uint32_t>(
+        std::min<uint64_t>(max_workgroups_per_copy,
+                           amd::alignUp(aligned_element_count,
+                                        static_cast<uint64_t>(kLocalWorkSize)) /
+                               kLocalWorkSize));
+    workgroup_count = std::max<uint32_t>(workgroup_count, 1);
+    max_workgroups_used = std::max(max_workgroups_used, workgroup_count);
+
+    descriptors[descriptor_index++] = {
+        source_address,        destination_address, aligned_element_count,
+        aligned_element_size,  trailing_byte_count, workgroup_count};
+  }
+
+  amd::Kernel *const kernel = kernels_[BlitCopyBufferBatch];
+  constexpr bool kDirectVa = true;
+  setArgument(kernel, 0, sizeof(cl_mem), descriptor_buffer, 0, nullptr,
+              kDirectVa);
+
+  setArgument(kernel, 1, sizeof(kLocalWorkSize), &kLocalWorkSize);
+
+  size_t global_work_size[2] = {static_cast<size_t>(max_workgroups_used) *
+                                    kLocalWorkSize,
+                                copy_operations.size()};
+  size_t local_work_size[2] = {kLocalWorkSize, 1};
+  amd::NDRangeContainer nd_range(2, nullptr, global_work_size, local_work_size);
+
+  address parameters = captureArguments(kernel);
+  bool submit_result =
+      gpu().submitKernelInternal(nd_range, *kernel, parameters, nullptr, 0,
+                                 nullptr, nullptr, attach_signal);
+  releaseArguments(parameters);
+
+  return submit_result;
+}
+
 // ================================================================================================
 bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& copyOps) const {
   if (copyOps.empty()) {
@@ -2610,6 +2693,8 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
   // Partition into intra-device (kernel blit) and inter-device (DMA batch) groups.
   std::vector<amd::BatchCopyOp> d2dCopyOps;
   std::vector<amd::BatchCopyOp> p2pCopyOps;
+  d2dCopyOps.reserve(copyOps.size());
+  p2pCopyOps.reserve(copyOps.size());
 
   for (const auto& op : copyOps) {
     device::Memory* srcDevMem = op.srcMemory->getDeviceMemory(
@@ -2622,9 +2707,18 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
       return false;
     }
 
-    // Resolve real agents for partition decision (handles IPC shared memory)
+    // Normal same-device allocations do not need the heavier agent-resolution path.
     const Memory& srcMem = gpuMem(*srcDevMem);
     const Memory& dstMem = gpuMem(*dstDevMem);
+    const bool isLocalD2D = (&srcMem.dev() == &dstMem.dev()) && !op.srcMemory->ipcShared() &&
+                            !op.dstMemory->ipcShared() && !op.srcMemory->vmmImported() &&
+                            !op.dstMemory->vmmImported() && !op.metadata.preferCE_;
+    if (isLocalD2D) {
+      d2dCopyOps.push_back(op);
+      continue;
+    }
+
+    // Resolve real agents for IPC/VMM and remote resources.
     address srcAddr = reinterpret_cast<address>(srcMem.getDeviceMemory()) + op.srcOffset;
     address dstAddr = reinterpret_cast<address>(dstMem.getDeviceMemory()) + op.dstOffset;
 
@@ -2665,29 +2759,30 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
       gpu().Barriers().AddExternalSignal(priorSignal);
     }
 
+    bool attachSignal = false;
     for (const auto& op : d2dCopyOps) {
-      device::Memory* srcDevMem = op.srcMemory->getDeviceMemory(
-          *op.srcMemory->getContext().devices()[0]);
-      device::Memory* dstDevMem = op.dstMemory->getDeviceMemory(
-          *op.dstMemory->getContext().devices()[0]);
+      attachSignal |= !op.metadata.isAsync_;
+    }
 
-      amd::Coord3D srcOrigin(op.srcOffset);
-      amd::Coord3D dstOrigin(op.dstOffset);
-      amd::Coord3D size(op.size);
+    std::map<size_t, std::vector<amd::BatchCopyOp>, std::greater<size_t>> d2dCopyOpsBySize;
+    for (const auto& op : d2dCopyOps) {
+      d2dCopyOpsBySize[op.size].push_back(op);
+    }
 
-      if (!copyBuffer(*srcDevMem, *dstDevMem, srcOrigin, dstOrigin, size,
-                      false, op.metadata)) {
-        LogError("KernelBlitManager::copyBufferBatch: Intra-device copy failed!");
+    for (const auto& copyOpsBySizeEntry : d2dCopyOpsBySize) {
+      const auto& copyOpsBySize = copyOpsBySizeEntry.second;
+      if (!shaderCopyBufferBatch(copyOpsBySize, attachSignal)) {
+        LogError("KernelBlitManager::shaderCopyBufferBatch: Intra-device batch copy failed!");
         return false;
       }
+    }
 
-      // Track non-Compute intra signals as external so the final barrier
-      // synchronizes the compute stream with them.
-      // Compute signals are implicitly ordered on the same AQL queue.
-      ProfilingSignal* sig = gpu().Barriers().GetLastSignal();
-      if (sig != nullptr && sig->engine_ != HwQueueEngine::Compute) {
-        gpu().Barriers().AddExternalSignal(sig);
-      }
+    // Track non-Compute intra signals as external so the final barrier
+    // synchronizes the compute stream with them.
+    // Compute signals are implicitly ordered on the same AQL queue.
+    ProfilingSignal* sig = gpu().Barriers().GetLastSignal();
+    if (sig != nullptr && sig->engine_ != HwQueueEngine::Compute) {
+      gpu().Barriers().AddExternalSignal(sig);
     }
   }
 

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2592,6 +2592,7 @@ bool KernelBlitManager::shaderCopyBuffer(address dst, address src, const amd::Co
   return result;
 }
 
+// This layout must match the struct in blitcl.cpp
 struct CopyBufferBatchDescriptor {
   uint64_t source_address;
   uint64_t destination_address;
@@ -2602,8 +2603,7 @@ struct CopyBufferBatchDescriptor {
 
 // ================================================================================================
 bool KernelBlitManager::ShaderCopyBufferBatch(
-    const std::vector<amd::BatchCopyOp> &copy_operations,
-    bool attach_signal) const {
+    const std::vector<amd::BatchCopyOp> &copy_operations) const {
   std::scoped_lock transfer_operations_lock(lockXferOps_);
 
   constexpr uint32_t kMaxAlignment = 2 * sizeof(uint64_t);
@@ -2617,6 +2617,8 @@ bool KernelBlitManager::ShaderCopyBufferBatch(
       static_cast<CopyBufferBatchDescriptor *>(descriptor_buffer);
   size_t descriptor_index = 0;
   uint64_t max_aligned_element_count = 0;
+  bool needs_system_scope = false;
+  bool attach_signal = false;
 
   for (const auto &copy_operation : copy_operations) {
     device::Memory *source_device_memory =
@@ -2630,6 +2632,12 @@ bool KernelBlitManager::ShaderCopyBufferBatch(
         source_device_memory->virtualAddress() + copy_operation.srcOffset;
     const uint64_t destination_address =
         destination_device_memory->virtualAddress() + copy_operation.dstOffset;
+    const bool source_svm_atomics =
+        (source_device_memory->owner()->getMemFlags() & CL_MEM_SVM_ATOMICS) != 0;
+    needs_system_scope |=
+        (!source_svm_atomics && source_device_memory->isHostMemDirectAccess()) ||
+        !copy_operation.metadata.isAsync_;
+    attach_signal |= !copy_operation.metadata.isAsync_;
     const bool addresses_aligned = ((source_address % kMaxAlignment) == 0) &&
                                    ((destination_address % kMaxAlignment) == 0);
     const uint32_t aligned_element_size =
@@ -2667,6 +2675,9 @@ bool KernelBlitManager::ShaderCopyBufferBatch(
   amd::NDRangeContainer nd_range(2, nullptr, global_work_size, local_work_size);
 
   address parameters = captureArguments(kernel);
+  if (needs_system_scope) {
+    gpu().addSystemScope();
+  }
   bool submit_result =
       gpu().submitKernelInternal(nd_range, *kernel, parameters, nullptr, 0,
                                  nullptr, nullptr, attach_signal);
@@ -2748,11 +2759,6 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
       gpu().Barriers().AddExternalSignal(priorSignal);
     }
 
-    bool attach_signal = false;
-    for (const auto &op : d2dCopyOps) {
-      attach_signal |= !op.metadata.isAsync_;
-    }
-
     std::map<size_t, std::vector<amd::BatchCopyOp>, std::greater<size_t>>
         d2d_copy_ops_by_size;
     for (const auto &op : d2dCopyOps) {
@@ -2761,7 +2767,7 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
 
     for (const auto &copy_ops_by_size_entry : d2d_copy_ops_by_size) {
       const auto &copy_ops_by_size = copy_ops_by_size_entry.second;
-      if (!ShaderCopyBufferBatch(copy_ops_by_size, attach_signal)) {
+      if (!ShaderCopyBufferBatch(copy_ops_by_size)) {
         LogError("KernelBlitManager::ShaderCopyBufferBatch: Intra-device batch "
                  "copy failed!");
         return false;

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2598,7 +2598,6 @@ struct CopyBufferBatchDescriptor {
   uint64_t aligned_element_count;
   uint32_t aligned_element_size;
   uint32_t trailing_byte_count;
-  uint32_t workgroup_count;
 };
 
 // ================================================================================================
@@ -2617,7 +2616,7 @@ bool KernelBlitManager::shaderCopyBufferBatch(
   CopyBufferBatchDescriptor *descriptors =
       static_cast<CopyBufferBatchDescriptor *>(descriptor_buffer);
   size_t descriptor_index = 0;
-  uint32_t max_workgroups_used = 1;
+  uint64_t max_aligned_element_count = 0;
 
   for (const auto &copy_operation : copy_operations) {
     device::Memory *source_device_memory =
@@ -2639,19 +2638,21 @@ bool KernelBlitManager::shaderCopyBufferBatch(
         copy_operation.size / aligned_element_size;
     const uint32_t trailing_byte_count =
         copy_operation.size % aligned_element_size;
-
-    uint32_t workgroup_count = static_cast<uint32_t>(
-        std::min<uint64_t>(max_workgroups_per_copy,
-                           amd::alignUp(aligned_element_count,
-                                        static_cast<uint64_t>(kLocalWorkSize)) /
-                               kLocalWorkSize));
-    workgroup_count = std::max<uint32_t>(workgroup_count, 1);
-    max_workgroups_used = std::max(max_workgroups_used, workgroup_count);
+    max_aligned_element_count =
+        std::max(max_aligned_element_count, aligned_element_count);
 
     descriptors[descriptor_index++] = {
         source_address,        destination_address, aligned_element_count,
-        aligned_element_size,  trailing_byte_count, workgroup_count};
+        aligned_element_size,  trailing_byte_count};
   }
+
+  uint32_t workgroup_count = static_cast<uint32_t>(
+      std::min<uint64_t>(max_workgroups_per_copy,
+                         amd::alignUp(max_aligned_element_count,
+                                      static_cast<uint64_t>(kLocalWorkSize)) /
+                             kLocalWorkSize));
+  workgroup_count = std::max<uint32_t>(workgroup_count, 1);
+  const uint32_t copy_stride = workgroup_count * kLocalWorkSize;
 
   amd::Kernel *const kernel = kernels_[BlitCopyBufferBatch];
   constexpr bool kDirectVa = true;
@@ -2659,10 +2660,9 @@ bool KernelBlitManager::shaderCopyBufferBatch(
               kDirectVa);
 
   setArgument(kernel, 1, sizeof(kLocalWorkSize), &kLocalWorkSize);
+  setArgument(kernel, 2, sizeof(copy_stride), &copy_stride);
 
-  size_t global_work_size[2] = {static_cast<size_t>(max_workgroups_used) *
-                                    kLocalWorkSize,
-                                copy_operations.size()};
+  size_t global_work_size[2] = {copy_stride, copy_operations.size()};
   size_t local_work_size[2] = {kLocalWorkSize, 1};
   amd::NDRangeContainer nd_range(2, nullptr, global_work_size, local_work_size);
 

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2693,8 +2693,6 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
   // Partition into intra-device (kernel blit) and inter-device (DMA batch) groups.
   std::vector<amd::BatchCopyOp> d2dCopyOps;
   std::vector<amd::BatchCopyOp> p2pCopyOps;
-  d2dCopyOps.reserve(copyOps.size());
-  p2pCopyOps.reserve(copyOps.size());
 
   for (const auto& op : copyOps) {
     device::Memory* srcDevMem = op.srcMemory->getDeviceMemory(
@@ -2707,18 +2705,9 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
       return false;
     }
 
-    // Normal same-device allocations do not need the heavier agent-resolution path.
+    // Resolve real agents for partition decision (handles IPC shared memory)
     const Memory& srcMem = gpuMem(*srcDevMem);
     const Memory& dstMem = gpuMem(*dstDevMem);
-    const bool isLocalD2D = (&srcMem.dev() == &dstMem.dev()) && !op.srcMemory->ipcShared() &&
-                            !op.dstMemory->ipcShared() && !op.srcMemory->vmmImported() &&
-                            !op.dstMemory->vmmImported() && !op.metadata.preferCE_;
-    if (isLocalD2D) {
-      d2dCopyOps.push_back(op);
-      continue;
-    }
-
-    // Resolve real agents for IPC/VMM and remote resources.
     address srcAddr = reinterpret_cast<address>(srcMem.getDeviceMemory()) + op.srcOffset;
     address dstAddr = reinterpret_cast<address>(dstMem.getDeviceMemory()) + op.dstOffset;
 

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -308,6 +308,7 @@ class KernelBlitManager : public DmaBlitManager {
     BatchMemOp,
     StreamOpsIncrement,
     StreamOpsDecrement,
+    BlitCopyBufferBatch,
     BlitLinearTotal,
     FillImage = BlitLinearTotal,
     BlitCopyImage,
@@ -603,6 +604,10 @@ class KernelBlitManager : public DmaBlitManager {
                         const uint32_t blitWg, amd::CopyMetadata copyMetadata,
                         bool attachSignal = false) const;
 
+  //! Copies a batch of buffers using a single/multiple shader dispatch
+  bool shaderCopyBufferBatch(const std::vector<amd::BatchCopyOp> &copy_ops,
+                             bool attach_signal = false) const;
+
   //! Atomically updates a memory location (i.e. writes, increments or decrements the memory).
   bool streamOpsUpdate(uint blitType, device::Memory& memory, uint64_t value, size_t offset,
                        size_t sizeBytes) const;
@@ -627,6 +632,7 @@ static const char* BlitName[KernelBlitManager::BlitTotal] = {
     "__amd_rocclr_scheduler",          "__amd_rocclr_gwsInit",
     "__amd_rocclr_initHeap",           "__amd_rocclr_batchMemOp",
     "__amd_rocclr_streamOpsIncrement", "__amd_rocclr_streamOpsDecrement",
+    "__amd_rocclr_copyBufferBatch",
     "__amd_rocclr_fillImage",          "__amd_rocclr_copyImage",
     "__amd_rocclr_copyImage1DA",       "__amd_rocclr_copyImageToBuffer",
     "__amd_rocclr_copyBufferToImage"};

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -605,8 +605,7 @@ class KernelBlitManager : public DmaBlitManager {
                         bool attachSignal = false) const;
 
   //! Copies a batch of buffers using a single/multiple shader dispatch
-  bool ShaderCopyBufferBatch(const std::vector<amd::BatchCopyOp>& copy_ops,
-                             bool attach_signal = false) const;
+  bool ShaderCopyBufferBatch(const std::vector<amd::BatchCopyOp>& copy_ops) const;
 
   //! Atomically updates a memory location (i.e. writes, increments or decrements the memory).
   bool streamOpsUpdate(uint blitType, device::Memory& memory, uint64_t value, size_t offset,

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -605,7 +605,7 @@ class KernelBlitManager : public DmaBlitManager {
                         bool attachSignal = false) const;
 
   //! Copies a batch of buffers using a single/multiple shader dispatch
-  bool shaderCopyBufferBatch(const std::vector<amd::BatchCopyOp> &copy_ops,
+  bool ShaderCopyBufferBatch(const std::vector<amd::BatchCopyOp>& copy_ops,
                              bool attach_signal = false) const;
 
   //! Atomically updates a memory location (i.e. writes, increments or decrements the memory).

--- a/projects/hip-tests/catch/config/configs/performance.yaml
+++ b/projects/hip-tests/catch/config/configs/performance.yaml
@@ -37,6 +37,8 @@ performance:
   Performance_hipMemcpyHtoA:
     <<: *level_2
     tags: [image]
+  Performance_hipMemcpyBatchAsync_D2D_OptimizedPath_Aligned: *level_2
+  Performance_hipMemcpyBatchAsync_D2D_OptimizedPath_4ByteOffset: *level_2
   Performance_hipMemcpyDtoD_PeerAccessEnabled: *level_2
   Performance_hipMemcpyDtoD_PeerAccessDisabled: *level_2
   Performance_hipMemcpyDtoDAsync_PeerAccessEnabled: *level_2

--- a/projects/hip-tests/catch/include/performance_common.hh
+++ b/projects/hip-tests/catch/include/performance_common.hh
@@ -32,13 +32,13 @@ typedef __int32 ssize_t;
 #endif  // !_WIN64
 #endif  /*_WIN32*/
 
-static double GetGigabytesPerSecond(size_t bytes, float time_ms) {
+inline double GetGigabytesPerSecond(size_t bytes, float time_ms) {
   constexpr double kBytesPerGigabyte = 1'000'000'000.0;
   return (static_cast<double>(bytes) / kBytesPerGigabyte) /
          (static_cast<double>(time_ms) / 1000.0);
 }
 
-static std::string FormatGigabytesPerSecond(size_t bytes, float time_ms) {
+inline std::string FormatGigabytesPerSecond(size_t bytes, float time_ms) {
   std::ostringstream out;
   out << std::fixed << std::setprecision(2)
       << GetGigabytesPerSecond(bytes, time_ms);

--- a/projects/hip-tests/catch/include/performance_common.hh
+++ b/projects/hip-tests/catch/include/performance_common.hh
@@ -8,8 +8,11 @@
 
 #include <algorithm>
 #include <chrono>
+#include <iomanip>
 #include <memory>
 #include <numeric>
+#include <sstream>
+#include <string>
 #include <type_traits>
 #include <vector>
 
@@ -28,6 +31,19 @@ typedef __int64 ssize_t;
 typedef __int32 ssize_t;
 #endif  // !_WIN64
 #endif  /*_WIN32*/
+
+static double GetGigabytesPerSecond(size_t bytes, float time_ms) {
+  constexpr double kBytesPerGigabyte = 1'000'000'000.0;
+  return (static_cast<double>(bytes) / kBytesPerGigabyte) /
+         (static_cast<double>(time_ms) / 1000.0);
+}
+
+static std::string FormatGigabytesPerSecond(size_t bytes, float time_ms) {
+  std::ostringstream out;
+  out << std::fixed << std::setprecision(2)
+      << GetGigabytesPerSecond(bytes, time_ms);
+  return out.str();
+}
 
 class Timer {
  public:
@@ -119,6 +135,8 @@ template <typename Derived> class Benchmark {
   using ModifierSignature = std::function<float(float)>;
   void RegisterModifier(const ModifierSignature& modifier) { modifier_ = modifier; }
 
+  void RegisterBandwidth(size_t bytes) { bandwidth_bytes_ = bytes; }
+
   template <typename... Args> std::tuple<float, float, float, float> Run(Args&&... args) {
     AddSectionName(std::to_string(iterations_));
     AddSectionName(std::to_string(warmups_));
@@ -184,6 +202,7 @@ template <typename Derived> class Benchmark {
   ssize_t current_;
   bool display_output_;
   bool progress_bar_;
+  size_t bandwidth_bytes_ = 0;
 
   ModifierSignature modifier_;
 
@@ -200,9 +219,14 @@ template <typename Derived> class Benchmark {
 
   void PrintStats(float mean, float deviation, float best, float worst) {
     if (!display_output_) return;
-    Print("Average time: " + std::to_string(mean) + " ms, Standard deviation: " +
-          std::to_string(deviation) + " ms, Fastest: " + std::to_string(best) +
-          " ms, Slowest: " + std::to_string(worst) + " ms\n");
+    std::string stats = "Average time: " + std::to_string(mean) +
+                        " ms, Standard deviation: " + std::to_string(deviation) +
+                        " ms, Fastest: " + std::to_string(best) +
+                        " ms, Slowest: " + std::to_string(worst) + " ms";
+    if (bandwidth_bytes_ != 0) {
+      stats += ", Bandwidth: " + FormatGigabytesPerSecond(bandwidth_bytes_, mean) + " GB/s";
+    }
+    Print(stats + "\n");
   }
 };
 

--- a/projects/hip-tests/catch/performance/memcpy/CMakeLists.txt
+++ b/projects/hip-tests/catch/performance/memcpy/CMakeLists.txt
@@ -8,6 +8,7 @@ set(TEST_SRC
     hipMemcpyWithStream.cc
     hipMemcpyAtoH.cc
     hipMemcpyHtoA.cc
+    hipMemcpyBatchAsync.cc
     hipMemcpyDtoD.cc
     hipMemcpyDtoDAsync.cc
     hipMemcpyDtoH.cc

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyBatchAsync.cc
@@ -8,8 +8,6 @@
 
 #include <array>
 #include <cstdint>
-#include <iomanip>
-#include <iostream>
 #include <string>
 #include <vector>
 
@@ -35,26 +33,6 @@ std::string GetSizeSectionName(size_t size) {
 
 size_t AlignUp(size_t value, size_t alignment) {
   return ((value + alignment - 1) / alignment) * alignment;
-}
-
-double GetGbPerSecond(size_t bytes, float time_ms) {
-  constexpr double kBytesPerGb = 1'000'000'000.0;
-  return (static_cast<double>(bytes) / kBytesPerGb) /
-         (static_cast<double>(time_ms) / 1000.0);
-}
-
-void PrintBandwidthStats(size_t bytes, float mean_ms, float best_ms,
-                         float worst_ms) {
-  const auto flags = std::cout.flags();
-  const auto precision = std::cout.precision();
-
-  std::cout << std::fixed << std::setprecision(2)
-            << "Bandwidth: Average: " << GetGbPerSecond(bytes, mean_ms)
-            << " GB/s, Best: " << GetGbPerSecond(bytes, best_ms)
-            << " GB/s, Worst: " << GetGbPerSecond(bytes, worst_ms) << " GB/s\n";
-
-  std::cout.flags(flags);
-  std::cout.precision(precision);
 }
 
 class MemcpyBatchAsyncDtoDBenchmark
@@ -93,6 +71,7 @@ void RunBenchmark(size_t copy_size, size_t offset) {
   benchmark.AddSectionName(GetSizeSectionName(copy_size));
   benchmark.AddSectionName(offset == 0 ? "aligned" : "4-byte offset");
   benchmark.AddSectionName(std::to_string(kBatchCount) + " copies");
+  benchmark.RegisterBandwidth(copy_size * kBatchCount);
 
   constexpr size_t kAllocationAlignment = 256;
   const size_t stride = AlignUp(copy_size + offset, kAllocationAlignment);
@@ -116,11 +95,8 @@ void RunBenchmark(size_t copy_size, size_t offset) {
   }
 
   const StreamGuard stream_guard(Streams::created);
-  const auto [mean_ms, deviation_ms, best_ms, worst_ms] =
-      benchmark.Run(dsts.data(), srcs.data(), sizes.data(), sizes.size(),
-                    stream_guard.stream());
-  (void)deviation_ms;
-  PrintBandwidthStats(copy_size * kBatchCount, mean_ms, best_ms, worst_ms);
+  benchmark.Run(dsts.data(), srcs.data(), sizes.data(), sizes.size(),
+                stream_guard.stream());
 
   for (size_t i = 0; i < kBatchCount; ++i) {
     ValidateCopy(dsts[i], copy_size);
@@ -135,11 +111,11 @@ void RunBenchmark(size_t copy_size, size_t offset) {
 /**
  * Test Description
  * ------------------------
- *  - Executes `hipMemcpyBatchAsync` with a same-device D2D batch so the ROCclr
- * optimized intra-device batch path is selected:
- *    -# Copy sizes: 4 KB, 256 KB, 1 MB, 4 MB, 16 MB, 256 MB
- *    -# Batch shape: four D2D copies of the same size
- *    -# Allocation type: hipMalloc source and destination buffers on one device
+ *  - Executes `hipMemcpyBatchAsync` with 64 same-device D2D copies:
+ *    -# Copy sizes: 4 KB, 64 KB, 128 KB, 256 KB, 1 MB, 4 MB,
+ *       16 MB, 64 MB, 128 MB, 256 MB, 1024 MB
+ *    -# Source and destination allocation type: hipMalloc on the current device
+ *    -# Source and destination pointers are 256-byte aligned
  * Test source
  * ------------------------
  *  - performance/memcpy/hipMemcpyBatchAsync.cc
@@ -157,9 +133,13 @@ HIP_TEST_CASE(Performance_hipMemcpyBatchAsync_D2D_OptimizedPath_Aligned) {
 /**
  * Test Description
  * ------------------------
- *  - Executes `hipMemcpyBatchAsync` with same-device D2D copies whose source
- * and destination pointers are 4-byte aligned but not 16-byte aligned. Test
- * source
+ *  - Executes `hipMemcpyBatchAsync` with 64 same-device D2D copies:
+ *    -# Copy sizes: 4 KB, 64 KB, 128 KB, 256 KB, 1 MB, 4 MB,
+ *       16 MB, 64 MB, 128 MB, 256 MB, 1024 MB
+ *    -# Source and destination allocation type: hipMalloc on the current device
+ *    -# Source and destination pointers are offset by 4 bytes from a
+ *       256-byte-aligned stride
+ * Test source
  * ------------------------
  *  - performance/memcpy/hipMemcpyBatchAsync.cc
  * Test requirements

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyBatchAsync.cc
@@ -111,7 +111,7 @@ void RunBenchmark(size_t copy_size, size_t offset) {
 /**
  * Test Description
  * ------------------------
- *  - Executes `hipMemcpyBatchAsync` with 64 same-device D2D copies:
+ *  - Executes `hipMemcpyBatchAsync` with kBatchCount same-device D2D copies:
  *    -# Copy sizes: 4 KB, 64 KB, 128 KB, 256 KB, 1 MB, 4 MB,
  *       16 MB, 64 MB, 128 MB, 256 MB, 1024 MB
  *    -# Source and destination allocation type: hipMalloc on the current device
@@ -133,7 +133,7 @@ HIP_TEST_CASE(Performance_hipMemcpyBatchAsync_D2D_OptimizedPath_Aligned) {
 /**
  * Test Description
  * ------------------------
- *  - Executes `hipMemcpyBatchAsync` with 64 same-device D2D copies:
+ *  - Executes `hipMemcpyBatchAsync` with kBatchCount same-device D2D copies:
  *    -# Copy sizes: 4 KB, 64 KB, 128 KB, 256 KB, 1 MB, 4 MB,
  *       16 MB, 64 MB, 128 MB, 256 MB, 1024 MB
  *    -# Source and destination allocation type: hipMalloc on the current device

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyBatchAsync.cc
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "memcpy_performance_common.hh"
+
+#include <array>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+/**
+ * @addtogroup memcpy memcpy
+ * @{
+ * @ingroup PerformanceTest
+ */
+
+#if HT_AMD
+
+namespace {
+
+constexpr size_t kBatchCount = 64;
+constexpr unsigned char kPattern = 0x5a;
+
+std::string GetSizeSectionName(size_t size) {
+  if (size < 1_MB) {
+    return std::to_string(size / 1_KB) + " KB";
+  }
+  return std::to_string(size / 1_MB) + " MB";
+}
+
+size_t AlignUp(size_t value, size_t alignment) {
+  return ((value + alignment - 1) / alignment) * alignment;
+}
+
+double GetGbPerSecond(size_t bytes, float timeMs) {
+  constexpr double kBytesPerGb = 1'000'000'000.0;
+  return (static_cast<double>(bytes) / kBytesPerGb) /
+         (static_cast<double>(timeMs) / 1000.0);
+}
+
+void PrintBandwidthStats(size_t bytes, float meanMs, float bestMs,
+                         float worstMs) {
+  const auto flags = std::cout.flags();
+  const auto precision = std::cout.precision();
+
+  std::cout << std::fixed << std::setprecision(2)
+            << "Bandwidth: Average: " << GetGbPerSecond(bytes, meanMs)
+            << " GB/s, Best: " << GetGbPerSecond(bytes, bestMs)
+            << " GB/s, Worst: " << GetGbPerSecond(bytes, worstMs) << " GB/s\n";
+
+  std::cout.flags(flags);
+  std::cout.precision(precision);
+}
+
+class MemcpyBatchAsyncDtoDBenchmark
+    : public Benchmark<MemcpyBatchAsyncDtoDBenchmark> {
+public:
+  void operator()(void **dsts, void **srcs, size_t *sizes, size_t count,
+                  const hipStream_t &stream) {
+    constexpr size_t numAttrs = 0;
+    size_t attrsIdxs[1] = {0};
+    size_t failIdx = 0;
+
+    TIMED_SECTION_STREAM(kTimerTypeCpu, stream) {
+      HIP_CHECK(hipMemcpyBatchAsync(dsts, srcs, sizes, count, nullptr,
+                                    attrsIdxs, numAttrs, &failIdx, stream));
+    }
+  }
+};
+
+void ValidateCopy(void *dst, size_t size) {
+  std::array<unsigned char, 16> prefix = {};
+  unsigned char suffix = 0;
+
+  HIP_CHECK(
+      hipMemcpy(prefix.data(), dst, prefix.size(), hipMemcpyDeviceToHost));
+  HIP_CHECK(hipMemcpy(&suffix, static_cast<unsigned char *>(dst) + size - 1,
+                      sizeof(suffix), hipMemcpyDeviceToHost));
+
+  for (const auto value : prefix) {
+    REQUIRE(value == kPattern);
+  }
+  REQUIRE(suffix == kPattern);
+}
+
+void RunBenchmark(size_t copySize, size_t offset) {
+  MemcpyBatchAsyncDtoDBenchmark benchmark;
+  benchmark.AddSectionName(GetSizeSectionName(copySize));
+  benchmark.AddSectionName(offset == 0 ? "aligned" : "4-byte offset");
+  benchmark.AddSectionName(std::to_string(kBatchCount) + " copies");
+
+  constexpr size_t kAllocationAlignment = 256;
+  const size_t stride = AlignUp(copySize + offset, kAllocationAlignment);
+  const size_t allocationSize = stride * kBatchCount;
+
+  void *srcAllocation = nullptr;
+  void *dstAllocation = nullptr;
+  HIP_CHECK(hipMalloc(&srcAllocation, allocationSize));
+  HIP_CHECK(hipMalloc(&dstAllocation, allocationSize));
+  HIP_CHECK(hipMemset(srcAllocation, kPattern, allocationSize));
+  HIP_CHECK(hipMemset(dstAllocation, 0, allocationSize));
+
+  std::vector<void *> srcs(kBatchCount);
+  std::vector<void *> dsts(kBatchCount);
+  std::vector<size_t> sizes(kBatchCount, copySize);
+  for (size_t i = 0; i < kBatchCount; ++i) {
+    srcs[i] =
+        static_cast<unsigned char *>(srcAllocation) + (i * stride) + offset;
+    dsts[i] =
+        static_cast<unsigned char *>(dstAllocation) + (i * stride) + offset;
+  }
+
+  const StreamGuard streamGuard(Streams::created);
+  const auto [meanMs, deviationMs, bestMs, worstMs] =
+      benchmark.Run(dsts.data(), srcs.data(), sizes.data(), sizes.size(),
+                    streamGuard.stream());
+  (void)deviationMs;
+  PrintBandwidthStats(copySize * kBatchCount, meanMs, bestMs, worstMs);
+
+  for (size_t i = 0; i < kBatchCount; ++i) {
+    ValidateCopy(dsts[i], copySize);
+  }
+
+  HIP_CHECK(hipFree(srcAllocation));
+  HIP_CHECK(hipFree(dstAllocation));
+}
+
+} // namespace
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Executes `hipMemcpyBatchAsync` with a same-device D2D batch so the ROCclr
+ * optimized intra-device batch path is selected:
+ *    -# Copy sizes: 4 KB, 256 KB, 1 MB, 4 MB, 16 MB, 256 MB
+ *    -# Batch shape: four D2D copies of the same size
+ *    -# Allocation type: hipMalloc source and destination buffers on one device
+ * Test source
+ * ------------------------
+ *  - performance/memcpy/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - AMD
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Performance_hipMemcpyBatchAsync_D2D_OptimizedPath_Aligned) {
+  const auto copySize = GENERATE(4_KB, 64_KB, 128_KB, 256_KB, 1_MB, 4_MB, 16_MB,
+                                 64_MB, 128_MB, 256_MB, 1024_MB);
+  RunBenchmark(copySize, 0);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Executes `hipMemcpyBatchAsync` with same-device D2D copies whose source
+ * and destination pointers are 4-byte aligned but not 16-byte aligned. Test
+ * source
+ * ------------------------
+ *  - performance/memcpy/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - AMD
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Performance_hipMemcpyBatchAsync_D2D_OptimizedPath_4ByteOffset) {
+  const auto copySize = GENERATE(4_KB, 64_KB, 128_KB, 256_KB, 1_MB, 4_MB, 16_MB,
+                                 64_MB, 128_MB, 256_MB, 1024_MB);
+  RunBenchmark(copySize, sizeof(uint32_t));
+}
+
+#endif
+
+/**
+ * End doxygen group memcpy.
+ * @}
+ */

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyBatchAsync.cc
@@ -37,21 +37,21 @@ size_t AlignUp(size_t value, size_t alignment) {
   return ((value + alignment - 1) / alignment) * alignment;
 }
 
-double GetGbPerSecond(size_t bytes, float timeMs) {
+double GetGbPerSecond(size_t bytes, float time_ms) {
   constexpr double kBytesPerGb = 1'000'000'000.0;
   return (static_cast<double>(bytes) / kBytesPerGb) /
-         (static_cast<double>(timeMs) / 1000.0);
+         (static_cast<double>(time_ms) / 1000.0);
 }
 
-void PrintBandwidthStats(size_t bytes, float meanMs, float bestMs,
-                         float worstMs) {
+void PrintBandwidthStats(size_t bytes, float mean_ms, float best_ms,
+                         float worst_ms) {
   const auto flags = std::cout.flags();
   const auto precision = std::cout.precision();
 
   std::cout << std::fixed << std::setprecision(2)
-            << "Bandwidth: Average: " << GetGbPerSecond(bytes, meanMs)
-            << " GB/s, Best: " << GetGbPerSecond(bytes, bestMs)
-            << " GB/s, Worst: " << GetGbPerSecond(bytes, worstMs) << " GB/s\n";
+            << "Bandwidth: Average: " << GetGbPerSecond(bytes, mean_ms)
+            << " GB/s, Best: " << GetGbPerSecond(bytes, best_ms)
+            << " GB/s, Worst: " << GetGbPerSecond(bytes, worst_ms) << " GB/s\n";
 
   std::cout.flags(flags);
   std::cout.precision(precision);
@@ -62,13 +62,13 @@ class MemcpyBatchAsyncDtoDBenchmark
 public:
   void operator()(void **dsts, void **srcs, size_t *sizes, size_t count,
                   const hipStream_t &stream) {
-    constexpr size_t numAttrs = 0;
-    size_t attrsIdxs[1] = {0};
-    size_t failIdx = 0;
+    constexpr size_t kNumAttrs = 0;
+    size_t attrs_idxs[1] = {0};
+    size_t fail_idx = 0;
 
     TIMED_SECTION_STREAM(kTimerTypeCpu, stream) {
       HIP_CHECK(hipMemcpyBatchAsync(dsts, srcs, sizes, count, nullptr,
-                                    attrsIdxs, numAttrs, &failIdx, stream));
+                                    attrs_idxs, kNumAttrs, &fail_idx, stream));
     }
   }
 };
@@ -88,46 +88,46 @@ void ValidateCopy(void *dst, size_t size) {
   REQUIRE(suffix == kPattern);
 }
 
-void RunBenchmark(size_t copySize, size_t offset) {
+void RunBenchmark(size_t copy_size, size_t offset) {
   MemcpyBatchAsyncDtoDBenchmark benchmark;
-  benchmark.AddSectionName(GetSizeSectionName(copySize));
+  benchmark.AddSectionName(GetSizeSectionName(copy_size));
   benchmark.AddSectionName(offset == 0 ? "aligned" : "4-byte offset");
   benchmark.AddSectionName(std::to_string(kBatchCount) + " copies");
 
   constexpr size_t kAllocationAlignment = 256;
-  const size_t stride = AlignUp(copySize + offset, kAllocationAlignment);
-  const size_t allocationSize = stride * kBatchCount;
+  const size_t stride = AlignUp(copy_size + offset, kAllocationAlignment);
+  const size_t allocation_size = stride * kBatchCount;
 
-  void *srcAllocation = nullptr;
-  void *dstAllocation = nullptr;
-  HIP_CHECK(hipMalloc(&srcAllocation, allocationSize));
-  HIP_CHECK(hipMalloc(&dstAllocation, allocationSize));
-  HIP_CHECK(hipMemset(srcAllocation, kPattern, allocationSize));
-  HIP_CHECK(hipMemset(dstAllocation, 0, allocationSize));
+  void *src_allocation = nullptr;
+  void *dst_allocation = nullptr;
+  HIP_CHECK(hipMalloc(&src_allocation, allocation_size));
+  HIP_CHECK(hipMalloc(&dst_allocation, allocation_size));
+  HIP_CHECK(hipMemset(src_allocation, kPattern, allocation_size));
+  HIP_CHECK(hipMemset(dst_allocation, 0, allocation_size));
 
   std::vector<void *> srcs(kBatchCount);
   std::vector<void *> dsts(kBatchCount);
-  std::vector<size_t> sizes(kBatchCount, copySize);
+  std::vector<size_t> sizes(kBatchCount, copy_size);
   for (size_t i = 0; i < kBatchCount; ++i) {
     srcs[i] =
-        static_cast<unsigned char *>(srcAllocation) + (i * stride) + offset;
+        static_cast<unsigned char *>(src_allocation) + (i * stride) + offset;
     dsts[i] =
-        static_cast<unsigned char *>(dstAllocation) + (i * stride) + offset;
+        static_cast<unsigned char *>(dst_allocation) + (i * stride) + offset;
   }
 
-  const StreamGuard streamGuard(Streams::created);
-  const auto [meanMs, deviationMs, bestMs, worstMs] =
+  const StreamGuard stream_guard(Streams::created);
+  const auto [mean_ms, deviation_ms, best_ms, worst_ms] =
       benchmark.Run(dsts.data(), srcs.data(), sizes.data(), sizes.size(),
-                    streamGuard.stream());
-  (void)deviationMs;
-  PrintBandwidthStats(copySize * kBatchCount, meanMs, bestMs, worstMs);
+                    stream_guard.stream());
+  (void)deviation_ms;
+  PrintBandwidthStats(copy_size * kBatchCount, mean_ms, best_ms, worst_ms);
 
   for (size_t i = 0; i < kBatchCount; ++i) {
-    ValidateCopy(dsts[i], copySize);
+    ValidateCopy(dsts[i], copy_size);
   }
 
-  HIP_CHECK(hipFree(srcAllocation));
-  HIP_CHECK(hipFree(dstAllocation));
+  HIP_CHECK(hipFree(src_allocation));
+  HIP_CHECK(hipFree(dst_allocation));
 }
 
 } // namespace
@@ -149,9 +149,9 @@ void RunBenchmark(size_t copySize, size_t offset) {
  *  - HIP_VERSION >= 7.1
  */
 HIP_TEST_CASE(Performance_hipMemcpyBatchAsync_D2D_OptimizedPath_Aligned) {
-  const auto copySize = GENERATE(4_KB, 64_KB, 128_KB, 256_KB, 1_MB, 4_MB, 16_MB,
-                                 64_MB, 128_MB, 256_MB, 1024_MB);
-  RunBenchmark(copySize, 0);
+  const auto copy_size = GENERATE(4_KB, 64_KB, 128_KB, 256_KB, 1_MB, 4_MB,
+                                  16_MB, 64_MB, 128_MB, 256_MB, 1024_MB);
+  RunBenchmark(copy_size, 0);
 }
 
 /**
@@ -168,9 +168,9 @@ HIP_TEST_CASE(Performance_hipMemcpyBatchAsync_D2D_OptimizedPath_Aligned) {
  *  - HIP_VERSION >= 7.1
  */
 HIP_TEST_CASE(Performance_hipMemcpyBatchAsync_D2D_OptimizedPath_4ByteOffset) {
-  const auto copySize = GENERATE(4_KB, 64_KB, 128_KB, 256_KB, 1_MB, 4_MB, 16_MB,
-                                 64_MB, 128_MB, 256_MB, 1024_MB);
-  RunBenchmark(copySize, sizeof(uint32_t));
+  const auto copy_size = GENERATE(4_KB, 64_KB, 128_KB, 256_KB, 1_MB, 4_MB,
+                                  16_MB, 64_MB, 128_MB, 256_MB, 1024_MB);
+  RunBenchmark(copy_size, sizeof(uint32_t));
 }
 
 #endif

--- a/projects/hip-tests/catch/performance/memcpy/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/performance/memcpy/hipMemcpyBatchAsync.cc
@@ -21,7 +21,7 @@
 
 namespace {
 
-constexpr size_t kBatchCount = 64;
+constexpr size_t kBatchCount = 8;
 constexpr unsigned char kPattern = 0x5a;
 
 std::string GetSizeSectionName(size_t size) {


### PR DESCRIPTION
## Motivation

`hipMemcpyBatchAsync` currently enqueues one kernel per copy operation, which is not optimal from a performance standpoint. Ideally, all copy operations should be executed using a single kernel or grouped into a small number of kernel dispatches.

## Technical Details

Copy operations are now grouped and dispatched based on their size. All copy operations with the same size are dispatched through a single kernel.


## JIRA ID

/

## Test Plan

- Run hipMemcpyBatchAsync performance tests and verify whether the modifications improve bandwidth.

## Test Result

- Bandwidth improved in all test-cases.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
