### PR TITLE
[rocprofiler-sdk] Avoid error with OMPT when `early_fulfill` follows `task_complete`

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/ompt/ompt.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/ompt/ompt.cpp
@@ -174,7 +174,14 @@ ompt_task_schedule_callback(ompt_data_t*       prior_task_data,
     assert(pprior != nullptr);
     auto* state_prior = reinterpret_cast<ompt_task_save_state*>(pprior->ptr);
     if(state_prior == nullptr)
+    {
+        /* If early_fulfill is dispatched after task_complete,
+         * state_prior will be nullptr because task_complete deleted it.
+         * Return immediately to avoid failing on a valid trailing callback.
+         */
+        if(prior_task_status == ompt_task_early_fulfill) return;
         ROCP_FATAL << "state_prior == nullptr prior_task_status: " << prior_task_status << ".";
+    }
 
     auto* state_next   = pnext ? reinterpret_cast<ompt_task_save_state*>(pnext->ptr) : nullptr;
     auto* prior_corrid = context::get_latest_correlation_id();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/ompt/ompt.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/ompt/ompt.cpp
@@ -165,9 +165,12 @@ ompt_task_schedule_callback(ompt_data_t*       prior_task_data,
     corr_id->sub_ref_count();
 
     /* Warning: some tasks like early_fulfill may be scheduled
-     * out twice. The ordering between the early_fulfill and the complete
-     * (for example) is not specified. In this case the prior_task_state
-     * needs to be added to the early return if condition below.
+     * out twice. The ordering between early_fulfill and task_complete
+     * is not specified.
+     *
+     * If early_fulfill is dispatched after task_complete, state_prior
+     * will be nullptr because task_complete deleted it. Return immediately
+     * to avoid failing on a valid trailing callback.
      */
     auto* pprior = INTERNAL(prior_task_data);
     auto* pnext  = INTERNAL(next_task_data);
@@ -175,10 +178,6 @@ ompt_task_schedule_callback(ompt_data_t*       prior_task_data,
     auto* state_prior = reinterpret_cast<ompt_task_save_state*>(pprior->ptr);
     if(state_prior == nullptr)
     {
-        /* If early_fulfill is dispatched after task_complete,
-         * state_prior will be nullptr because task_complete deleted it.
-         * Return immediately to avoid failing on a valid trailing callback.
-         */
         if(prior_task_status == ompt_task_early_fulfill) return;
         ROCP_FATAL << "state_prior == nullptr prior_task_status: " << prior_task_status << ".";
     }


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

I was adding a fortran OpenMP test to `rocprofiler-systems` involving the OpenMP task construct. However, when profiling, it would fail with:
```
F0511 11:58:39.779112 1417307 ompt.cpp:183] state_prior == nullptr prior_task_status: 5.
*** Check failure stack trace: ***
```
Which was traced back to https://github.com/ROCm/rocm-systems/blob/develop/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/ompt/ompt.cpp#L177 added in PR #980 

Per the existing comment, `early_fulfill` may be scheduled after `task_complete` occurs. When `task_complete` occurs, it will delete `state_prior` and set it to `nullptr`. So when `early_fulfill` comes along afterwards, it has `state_prior = nullptr` and triggers the `ROCP_FATAL`. But having `early_fulfill` come after is a valid case, so we should not error out here and instead do an early return. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

If `early_fulfill` has `state_prior == nullptr`, do an early return instead of calling `ROCP_FATAL`. 

## JIRA ID

AIPROFSYST-458

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

The reproducer I was using (`reproducer.f90`):
```
program task_detach_repro
    use omp_lib
    integer(omp_event_handle_kind) :: event

    !$omp parallel num_threads(2)
    !$omp single
        !$omp task detach(event)
        !$omp end task

        !$omp task
            call sleep(1) ! Or some work that takes some time to complete
            call omp_fulfill_event(event)
        !$omp end task

        !$omp taskwait
    !$omp end single
    !$omp end parallel
end program
```
(Compiled with `amdflang -fopenmp`)
Without the change, it fails with the previously mentioned error.

## Test Result

<!-- Briefly summarize test outcomes. -->

With the change, `rocprofiler-systems` succeeds and the trace appears to be what I expect. 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.