### PR TITLE
[AMD-SMI] Guidance for BDF output on partitioned GPUs

### DIFF
--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -372,6 +372,16 @@ Where:
 * `<device>` is 2 hex digits long from 00-1F interval
 * `<function>` is 1 hex digit long from 0-7 interval
 
+> [!NOTE]
+> In some devices, the partition ID may be stored in the function bits
+> BDFID[2:0] instead of BDFID[31:28].
+
+> [!NOTE]
+> For MI series devices, the function bits are only used to store the 
+> partition ID, but this modified BDF is internal to the ROCm stack. 
+> To the OS, partitions share the same BDF as the unpartitioned device and
+> have function bits = 0, which can be verified through lspci.
+
 Exceptions that can be thrown by `amdsmi_get_gpu_device_bdf` function:
 
 * `AmdSmiParameterException`
@@ -2255,11 +2265,21 @@ BDFID = ((DOMAIN & 0xffffffff) << 32) | ((BUS & 0xff) << 8) |
 
 | Name     | Field   |
 ---------- | ------- |
-| Domain   | [64:32] |
+| Domain   | [63:32] |
 | Reserved | [31:16] |
 | Bus      | [15: 8] |
 | Device   | [ 7: 3] |
 | Function | [ 2: 0] |
+
+> [!NOTE]
+> In some devices, the partition ID may be stored in the function bits
+> BDFID[2:0] instead of BDFID[31:28].
+
+> [!NOTE]
+> For MI series devices, the function bits are only used to store the 
+> partition ID, but this modified BDF is internal to the ROCm stack. 
+> To the OS, partitions share the same BDF as the unpartitioned device and
+> have function bits = 0, which can be verified through lspci.
 
 Exceptions that can be thrown by `amdsmi_get_gpu_bdf_id` function:
 

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -3697,7 +3697,7 @@ amdsmi_status_t amdsmi_get_gpu_pci_bandwidth(amdsmi_processor_handle processor_h
  *
  *  @platform{gpu_bm_linux}
  *
- *  @details Give a processor handle @p processor_handle and a pointer to a uint64_t @p
+ *  @details Given a processor handle @p processor_handle and a pointer to a uint64_t @p
  *  bdfid, this function will write the Bus/Device/Function PCI identifier
  *  (BDFID) associated with device @p processor_handle to the value pointed to by
  *  @p bdfid.
@@ -3716,6 +3716,14 @@ amdsmi_status_t amdsmi_get_gpu_pci_bandwidth(amdsmi_processor_handle processor_h
  *  | Bus          | [15: 8] | "location id"    | (LOCATION & 0xFF00)          |
  *  | Device       | [ 7: 3] | "location id"    | (LOCATION & 0xF8)            |
  *  | Function     | [ 2: 0] | "location id"    | (LOCATION & 0x7)             |
+ *
+ *  Note: In some devices, the partition ID may be stored in the function bits
+ *  BDFID[2:0] instead of BDFID[31:28].
+ *
+ *  Note: For MI series devices, the function bits are only used to store the
+ *  partition ID, but this modified BDF is internal to the ROCm stack.
+ *  To the OS, partitions share the same BDF as the unpartitioned device and
+ *  have function bits = 0, which can be verified through lspci.
  *
  *  @param[in] processor_handle a processor handle
  *


### PR DESCRIPTION
Resolves https://github.com/ROCm/rocm-systems/issues/5805. This documentation was previously added to the `rocm-smi` docs with https://github.com/ROCm/rocm_smi_lib/commit/67a0de4279c16dfa50b3c6bb0b2d99b571ccc2c0 but wasn't added to the matching APIs in `amd-smi`.