### PR TITLE
rocpdsna: schema 4.0.0 — use inline BIGINT timestamps instead of rocpd_timestamp FK table

### DIFF
--- a/projects/rocpdsna/source/data_storage/backends/schema/4.0.0/data_views.sql
+++ b/projects/rocpdsna/source/data_storage/backends/schema/4.0.0/data_views.sql
@@ -202,9 +202,9 @@ SELECT
     T.nid,
     T.pid,
     T.tid,
-    DS.value AS `start`,
-    DE.value AS `end`,
-    (DE.value - DS.value) AS `duration`,
+    R."start",
+    R."end",
+    (R."end" - R."start") AS `duration`,
     R.event_id,
     R.track_id,
     E.stack_id,
@@ -218,11 +218,7 @@ FROM
     INNER JOIN `tracks` T ON T.id = R.track_id
     AND T.guid = R.guid
     INNER JOIN `rocpd_string` NS ON NS.id = R.name_id
-    AND NS.guid = R.guid
-    INNER JOIN `rocpd_timestamp` DS ON DS.id = R.start_id
-    AND DS.guid = R.guid
-    INNER JOIN `rocpd_timestamp` DE ON DE.id = R.end_id
-    AND DE.guid = R.guid;
+    AND NS.guid = R.guid;
 
 --
 -- Samples
@@ -236,7 +232,7 @@ SELECT
     T.nid,
     T.pid,
     T.tid,
-    DI.value AS `timestamp`,
+    S."timestamp",
     S.event_id,
     S.track_id,
     E.stack_id AS stack_id,
@@ -250,9 +246,7 @@ FROM
     INNER JOIN `events` E ON E.id = S.event_id
     AND E.guid = S.guid
     INNER JOIN `rocpd_string` NS ON NS.id = S.name_id
-    AND NS.guid = S.guid
-    INNER JOIN `rocpd_timestamp` DI ON DI.id = S.timestamp_id
-    AND DI.guid = S.guid;
+    AND NS.guid = S.guid;
 
 --
 -- Provides samples view with the same columns as regions view
@@ -317,9 +311,9 @@ SELECT
     T.queue_name AS `queue`,
     T.stream_id,
     T.stream_name AS `stream`,
-    DS.value AS `start`,
-    DE.value AS `end`,
-    (DE.value - DS.value) AS `duration`,
+    K."start",
+    K."end",
+    (K."end" - K."start") AS `duration`,
     K.event_id,
     K.track_id,
     -- OpenCL uses "grid" to mean number of work-items in a dimension
@@ -363,11 +357,7 @@ FROM
     INNER JOIN `rocpd_string` R ON R.id = K.region_name_id
     AND R.guid = K.guid
     INNER JOIN `rocpd_info_kernel_symbol` S ON S.id = K.kernel_id
-    AND S.guid = K.guid
-    INNER JOIN `rocpd_timestamp` DS ON DS.id = K.start_id
-    AND DS.guid = K.guid
-    INNER JOIN `rocpd_timestamp` DE ON DE.id = K.end_id
-    AND DE.guid = K.guid;
+    AND S.guid = K.guid;
 
 --
 -- Performance Monitoring Counters (PMC)
@@ -442,9 +432,9 @@ SELECT
     E.category,
     NS.string AS name,
     R.string AS region_name,
-    DS.value AS `start`,
-    DE.value AS `end`,
-    (DE.value - DS.value) AS `duration`,
+    M."start",
+    M."end",
+    (M."end" - M."start") AS `duration`,
     T.queue_id,
     T.queue_name,
     T.stream_id,
@@ -481,11 +471,7 @@ FROM
     INNER JOIN `rocpd_info_agent` dst_agent ON dst_agent.id = M.dst_agent_id
     AND dst_agent.guid = M.guid
     INNER JOIN `rocpd_info_agent` src_agent ON src_agent.id = M.src_agent_id
-    AND src_agent.guid = M.guid
-    INNER JOIN `rocpd_timestamp` DS ON DS.id = M.start_id
-    AND DS.guid = M.guid
-    INNER JOIN `rocpd_timestamp` DE ON DE.id = M.end_id
-    AND DE.guid = M.guid;
+    AND src_agent.guid = M.guid;
 
 --
 --
@@ -501,9 +487,9 @@ SELECT
     E.category,
     NS.string AS name,
     R.string AS region_name,
-    DS.value AS `start`,
-    DE.value AS `end`,
-    (DE.value - DS.value) AS `duration`,
+    M."start",
+    M."end",
+    (M."end" - M."start") AS `duration`,
     T.queue_id,
     T.queue_name,
     T.stream_id,
@@ -530,11 +516,7 @@ FROM
     INNER JOIN `rocpd_string` NS ON NS.id = M.name_id
     AND NS.guid = M.guid
     LEFT JOIN `rocpd_string` R ON R.id = M.region_name_id
-    AND R.guid = M.guid
-    INNER JOIN `rocpd_timestamp` DS ON DS.id = M.start_id
-    AND DS.guid = M.guid
-    INNER JOIN `rocpd_timestamp` DE ON DE.id = M.end_id
-    AND DE.guid = M.guid;
+    AND R.guid = M.guid;
 
 --
 -- PMC events specific to kernels

--- a/projects/rocpdsna/source/data_storage/backends/schema/4.0.0/rocpd_indexes.sql
+++ b/projects/rocpdsna/source/data_storage/backends/schema/4.0.0/rocpd_indexes.sql
@@ -14,9 +14,6 @@ CREATE INDEX `rocpd_info_process{{uuid}}_pid_idx` ON `rocpd_info_process{{uuid}}
 CREATE INDEX `rocpd_info_thread{{uuid}}_tid_idx` ON `rocpd_info_thread{{uuid}}` ("tid");
 CREATE INDEX `rocpd_info_process{{uuid}}_guid_pid_idx` ON `rocpd_info_process{{uuid}}` ("guid", "pid");
 CREATE INDEX `rocpd_info_thread{{uuid}}_guid_tid_idx` ON `rocpd_info_thread{{uuid}}` ("guid", "tid");
-CREATE INDEX `rocpd_timestamp{{uuid}}_value_idx` ON `rocpd_timestamp{{uuid}}` ("value");
-CREATE INDEX `rocpd_timestamp{{uuid}}_track_id_idx` ON `rocpd_timestamp{{uuid}}` ("track_id");
-
 -- CREATE INDEX `rocpd_kernel_dispatch{{uuid}}_guid_pid_tid_idx` ON `rocpd_kernel_dispatch{{uuid}}` ("guid", "pid", "tid");
 CREATE INDEX `rocpd_memory_copy{{uuid}}_guid_pid_tid_idx` ON `rocpd_memory_copy{{uuid}}` ("guid", "pid", "tid");
 -- CREATE INDEX `rocpd_memory_allocate{{uuid}}_guid_pid_tid_idx` ON `rocpd_memory_allocate{{uuid}}` ("guid", "pid", "tid");

--- a/projects/rocpdsna/source/data_storage/backends/schema/4.0.0/rocpd_tables.sql
+++ b/projects/rocpdsna/source/data_storage/backends/schema/4.0.0/rocpd_tables.sql
@@ -269,21 +269,6 @@ CREATE TABLE IF NOT EXISTS
         FOREIGN KEY (name_id) REFERENCES `rocpd_string{{uuid}}` (id) ON UPDATE CASCADE
     );
 
--- Stores all the timestamps
-CREATE TABLE IF NOT EXISTS
-    `rocpd_timestamp{{uuid}}` (
-        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
-        "value" BIGINT NOT NULL,
-        "phase" INTEGER CHECK ("phase" IN (0, 1, 2)),
-        -- Phases:
-        --      0 = none/instantaneous
-        --      1 = start/enter/load
-        --      2 = end/exit/unload
-        "track_id" INTEGER, -- set to NULL if this timestamp is associated with more than one track (not recommended)
-        FOREIGN KEY (track_id) REFERENCES `rocpd_track{{uuid}}` (id) ON UPDATE CASCADE
-    );
-
 -- Storage for a region, instant, and counter
 CREATE TABLE IF NOT EXISTS
     `rocpd_event{{uuid}}` (
@@ -358,14 +343,12 @@ CREATE TABLE IF NOT EXISTS
         "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
         "track_id" INTEGER NOT NULL,
         "name_id" INTEGER NOT NULL,
-        "start_id" INTEGER NOT NULL,
-        "end_id" INTEGER NOT NULL,
+        "start" BIGINT NOT NULL,
+        "end" BIGINT NOT NULL,
         "event_id" INTEGER,
         "extdata" JSONB DEFAULT "{}" NOT NULL,
         FOREIGN KEY (track_id) REFERENCES `rocpd_track{{uuid}}` (id) ON UPDATE CASCADE,
         FOREIGN KEY (name_id) REFERENCES `rocpd_string{{uuid}}` (id) ON UPDATE CASCADE,
-        FOREIGN KEY (start_id) REFERENCES `rocpd_timestamp{{uuid}}` (id) ON UPDATE CASCADE,
-        FOREIGN KEY (end_id) REFERENCES `rocpd_timestamp{{uuid}}` (id) ON UPDATE CASCADE,
         FOREIGN KEY (event_id) REFERENCES `rocpd_event{{uuid}}` (id) ON UPDATE CASCADE
     );
 
@@ -376,12 +359,11 @@ CREATE TABLE IF NOT EXISTS
         "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
         "track_id" INTEGER NOT NULL,
         "name_id" INTEGER NOT NULL,
-        "timestamp_id" INTEGER NOT NULL,
+        "timestamp" BIGINT NOT NULL,
         "event_id" INTEGER,
         "extdata" JSONB DEFAULT "{}" NOT NULL,
         FOREIGN KEY (track_id) REFERENCES `rocpd_track{{uuid}}` (id) ON UPDATE CASCADE,
         FOREIGN KEY (name_id) REFERENCES `rocpd_string{{uuid}}` (id) ON UPDATE CASCADE,
-        FOREIGN KEY (timestamp_id) REFERENCES `rocpd_timestamp{{uuid}}` (id) ON UPDATE CASCADE,
         FOREIGN KEY (event_id) REFERENCES `rocpd_event{{uuid}}` (id) ON UPDATE CASCADE
     );
 
@@ -392,8 +374,8 @@ CREATE TABLE IF NOT EXISTS
         "track_id" INTEGER NOT NULL,
         "kernel_id" INTEGER NOT NULL,
         "dispatch_id" INTEGER NOT NULL,
-        "start_id" INTEGER NOT NULL,
-        "end_id" INTEGER NOT NULL,
+        "start" BIGINT NOT NULL,
+        "end" BIGINT NOT NULL,
         "private_segment_size" INTEGER,
         "group_segment_size" INTEGER,
         "workgroup_size_x" INTEGER NOT NULL,
@@ -407,8 +389,6 @@ CREATE TABLE IF NOT EXISTS
         "extdata" JSONB DEFAULT "{}" NOT NULL,
         FOREIGN KEY (track_id) REFERENCES `rocpd_track{{uuid}}` (id) ON UPDATE CASCADE,
         FOREIGN KEY (kernel_id) REFERENCES `rocpd_info_kernel_symbol{{uuid}}` (id) ON UPDATE CASCADE,
-        FOREIGN KEY (start_id) REFERENCES `rocpd_timestamp{{uuid}}` (id) ON UPDATE CASCADE,
-        FOREIGN KEY (end_id) REFERENCES `rocpd_timestamp{{uuid}}` (id) ON UPDATE CASCADE,
         FOREIGN KEY (region_name_id) REFERENCES `rocpd_string{{uuid}}` (id) ON UPDATE CASCADE,
         FOREIGN KEY (event_id) REFERENCES `rocpd_event{{uuid}}` (id) ON UPDATE CASCADE
     );
@@ -418,8 +398,8 @@ CREATE TABLE IF NOT EXISTS
         "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
         "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
         "track_id" INTEGER NOT NULL,
-        "start_id" INTEGER NOT NULL,
-        "end_id" INTEGER NOT NULL,
+        "start" BIGINT NOT NULL,
+        "end" BIGINT NOT NULL,
         "name_id" INTEGER NOT NULL,
         "dst_agent_id" INTEGER,
         "dst_address" INTEGER,
@@ -430,8 +410,6 @@ CREATE TABLE IF NOT EXISTS
         "event_id" INTEGER,
         "extdata" JSONB DEFAULT "{}" NOT NULL,
         FOREIGN KEY (track_id) REFERENCES `rocpd_track{{uuid}}` (id) ON UPDATE CASCADE,
-        FOREIGN KEY (start_id) REFERENCES `rocpd_timestamp{{uuid}}` (id) ON UPDATE CASCADE,
-        FOREIGN KEY (end_id) REFERENCES `rocpd_timestamp{{uuid}}` (id) ON UPDATE CASCADE,
         FOREIGN KEY (name_id) REFERENCES `rocpd_string{{uuid}}` (id) ON UPDATE CASCADE,
         FOREIGN KEY (dst_agent_id) REFERENCES `rocpd_info_agent{{uuid}}` (id) ON UPDATE CASCADE,
         FOREIGN KEY (src_agent_id) REFERENCES `rocpd_info_agent{{uuid}}` (id) ON UPDATE CASCADE,
@@ -447,8 +425,8 @@ CREATE TABLE IF NOT EXISTS
         "track_id" INTEGER NOT NULL,
         "type" TEXT CHECK ("type" IN ('ALLOC', 'FREE', 'REALLOC', 'RECLAIM')),
         "level" TEXT CHECK ("level" IN ('REAL', 'VIRTUAL', 'SCRATCH')),
-        "start_id" INTEGER NOT NULL,
-        "end_id" INTEGER NOT NULL,
+        "start" BIGINT NOT NULL,
+        "end" BIGINT NOT NULL,
         "name_id" INTEGER NOT NULL,
         "address" INTEGER,
         "size" INTEGER NOT NULL,
@@ -456,8 +434,6 @@ CREATE TABLE IF NOT EXISTS
         "event_id" INTEGER,
         "extdata" JSONB DEFAULT "{}" NOT NULL,
         FOREIGN KEY (track_id) REFERENCES `rocpd_track{{uuid}}` (id) ON UPDATE CASCADE,
-        FOREIGN KEY (start_id) REFERENCES `rocpd_timestamp{{uuid}}` (id) ON UPDATE CASCADE,
-        FOREIGN KEY (end_id) REFERENCES `rocpd_timestamp{{uuid}}` (id) ON UPDATE CASCADE,
         FOREIGN KEY (name_id) REFERENCES `rocpd_string{{uuid}}` (id) ON UPDATE CASCADE,
         FOREIGN KEY (region_name_id) REFERENCES `rocpd_string{{uuid}}` (id) ON UPDATE CASCADE,
         FOREIGN KEY (event_id) REFERENCES `rocpd_event{{uuid}}` (id) ON UPDATE CASCADE

--- a/projects/rocpdsna/source/data_storage/schema_v4/insert_statements.hpp
+++ b/projects/rocpdsna/source/data_storage/schema_v4/insert_statements.hpp
@@ -50,7 +50,6 @@ struct insert_statements
         initialize_kernel_symbol_info_statement();
         initialize_code_object_info_statement();
         initialize_track_info_statement();
-        initialize_timestamp_statement();
         initialize_category_info_statement();
         initialize_address_range_info_statement();
         initialize_source_code_info_statement();
@@ -211,13 +210,6 @@ struct insert_statements
                     std::optional<integer_foreign_key_t>,  // name_id
                     std::string_view>;                     // extdata
 
-    // NEW in v4: rocpd_timestamp table
-    using timestamp_statement_func_t =
-        statement_t<integer_primary_key_t,                  // id
-                    uint64_t,                               // value
-                    std::optional<int>,                     // phase
-                    std::optional<integer_foreign_key_t>>;  // track_id
-
     // NEW in v4: rocpd_info_category table
     using category_info_statement_func_t = statement_t<integer_primary_key_t,  // id
                                                        std::string_view,       // name
@@ -296,33 +288,33 @@ struct insert_statements
                     double,                                // value
                     std::string_view>;                     // extdata
 
-    // v4: region uses track_id, start_id, end_id
+    // v4: region uses track_id, inline start/end timestamps
     using region_statement_func_t =
         statement_t<integer_primary_key_t,                 // id
                     integer_foreign_key_t,                 // track_id
                     integer_foreign_key_t,                 // name_id
-                    integer_foreign_key_t,                 // start_id
-                    integer_foreign_key_t,                 // end_id
+                    uint64_t,                              // start
+                    uint64_t,                              // end
                     std::optional<integer_foreign_key_t>,  // event_id
                     std::string_view>;                     // extdata
 
-    // v4: sample uses name_id, timestamp_id
+    // v4: sample uses name_id, inline timestamp
     using sample_statement_func_t =
         statement_t<integer_primary_key_t,                 // id
                     integer_foreign_key_t,                 // track_id
                     integer_foreign_key_t,                 // name_id
-                    integer_foreign_key_t,                 // timestamp_id
+                    uint64_t,                              // timestamp
                     std::optional<integer_foreign_key_t>,  // event_id
                     std::string_view>;                     // extdata
 
-    // v4: kernel_dispatch uses track_id, start_id, end_id
+    // v4: kernel_dispatch uses track_id, inline start/end timestamps
     using kernel_dispatch_statement_func_t =
         statement_t<integer_primary_key_t,                 // id
                     integer_foreign_key_t,                 // track_id
                     integer_foreign_key_t,                 // kernel_id
                     size_t,                                // dispatch_id
-                    integer_foreign_key_t,                 // start_id
-                    integer_foreign_key_t,                 // end_id
+                    uint64_t,                              // start
+                    uint64_t,                              // end
                     std::optional<size_t>,                 // private_segment_size
                     std::optional<size_t>,                 // group_segment_size
                     size_t,                                // workgroup_size_x
@@ -335,12 +327,12 @@ struct insert_statements
                     std::optional<integer_foreign_key_t>,  // event_id
                     std::string_view>;                     // extdata
 
-    // v4: memory_copy uses track_id, start_id, end_id
+    // v4: memory_copy uses track_id, inline start/end timestamps
     using memory_copy_statement_func_t =
         statement_t<integer_primary_key_t,                 // id
                     integer_foreign_key_t,                 // track_id
-                    integer_foreign_key_t,                 // start_id
-                    integer_foreign_key_t,                 // end_id
+                    uint64_t,                              // start
+                    uint64_t,                              // end
                     integer_foreign_key_t,                 // name_id
                     std::optional<integer_foreign_key_t>,  // dst_agent_id
                     std::optional<size_t>,                 // dst_address
@@ -351,14 +343,14 @@ struct insert_statements
                     std::optional<integer_foreign_key_t>,  // event_id
                     std::string_view>;                     // extdata
 
-    // v4: memory_allocate uses track_id, start_id, end_id, name_id
+    // v4: memory_allocate uses track_id, inline start/end timestamps, name_id
     using memory_alloc_statement_func_t =
         statement_t<integer_primary_key_t,                 // id
                     integer_foreign_key_t,                 // track_id
                     std::optional<std::string_view>,       // type
                     std::optional<std::string_view>,       // level
-                    integer_foreign_key_t,                 // start_id
-                    integer_foreign_key_t,                 // end_id
+                    uint64_t,                              // start
+                    uint64_t,                              // end
                     integer_foreign_key_t,                 // name_id
                     std::optional<size_t>,                 // address
                     size_t,                                // size
@@ -422,11 +414,6 @@ public:
     [[nodiscard]] const track_info_statement_func_t& track_info_statement() const
     {
         return m_track_info_statement;
-    }
-
-    [[nodiscard]] const timestamp_statement_func_t& timestamp_statement() const
-    {
-        return m_timestamp_statement;
     }
 
     [[nodiscard]] const category_info_statement_func_t& category_info_statement() const
@@ -750,18 +737,6 @@ private:
         create_statement(m_track_info_statement, query);
     }
 
-    // NEW in v4: rocpd_timestamp
-    void initialize_timestamp_statement()
-    {
-        rocpdsna::queries::insert::table_insert_query query_builder;
-        auto                                          query =
-            query_builder.set_table_name(fmt::format("rocpd_timestamp_{}", m_uuid))
-                .set_columns("id", "value", "phase", "track_id")
-                .set_values('?', '?', '?', '?')
-                .get_query_string();
-        create_statement(m_timestamp_statement, query);
-    }
-
     // NEW in v4: rocpd_info_category
     void initialize_category_info_statement()
     {
@@ -894,37 +869,33 @@ private:
         create_statement(m_pmc_event_statement, query);
     }
 
-    // v4: region uses track_id, start_id, end_id
+    // v4: region uses track_id, inline start/end timestamps
     void initialize_region_statement()
     {
         rocpdsna::queries::insert::table_insert_query query_builder;
-        auto query = query_builder.set_table_name(fmt::format("rocpd_region_{}", m_uuid))
-                         .set_columns("id",
-                                      "track_id",
-                                      "name_id",
-                                      "start_id",
-                                      "end_id",
-                                      "event_id",
-                                      "extdata")
-                         .set_values('?', '?', '?', '?', '?', '?', '?')
-                         .get_query_string();
+        auto                                          query =
+            query_builder.set_table_name(fmt::format("rocpd_region_{}", m_uuid))
+                .set_columns(
+                    "id", "track_id", "name_id", "start", "end", "event_id", "extdata")
+                .set_values('?', '?', '?', '?', '?', '?', '?')
+                .get_query_string();
         create_statement(m_region_statement, query);
     }
 
-    // v4: sample uses name_id, timestamp_id
+    // v4: sample uses name_id, inline timestamp
     void initialize_sample_statement()
     {
         rocpdsna::queries::insert::table_insert_query query_builder;
         auto                                          query =
             query_builder.set_table_name(fmt::format("rocpd_sample_{}", m_uuid))
                 .set_columns(
-                    "id", "track_id", "name_id", "timestamp_id", "event_id", "extdata")
+                    "id", "track_id", "name_id", "timestamp", "event_id", "extdata")
                 .set_values('?', '?', '?', '?', '?', '?')
                 .get_query_string();
         create_statement(m_sample_statement, query);
     }
 
-    // v4: kernel_dispatch uses track_id, start_id, end_id
+    // v4: kernel_dispatch uses track_id, inline start/end timestamps
     void initialize_kernel_dispatch_statement()
     {
         rocpdsna::queries::insert::table_insert_query query_builder;
@@ -934,8 +905,8 @@ private:
                              "track_id",
                              "kernel_id",
                              "dispatch_id",
-                             "start_id",
-                             "end_id",
+                             "start",
+                             "end",
                              "private_segment_size",
                              "group_segment_size",
                              "workgroup_size_x",
@@ -968,7 +939,7 @@ private:
         create_statement(m_kernel_dispatch_statement, query);
     }
 
-    // v4: memory_copy uses track_id, start_id, end_id
+    // v4: memory_copy uses track_id, inline start/end timestamps
     void initialize_memory_copy_statement()
     {
         rocpdsna::queries::insert::table_insert_query query_builder;
@@ -976,8 +947,8 @@ private:
             query_builder.set_table_name(fmt::format("rocpd_memory_copy_{}", m_uuid))
                 .set_columns("id",
                              "track_id",
-                             "start_id",
-                             "end_id",
+                             "start",
+                             "end",
                              "name_id",
                              "dst_agent_id",
                              "dst_address",
@@ -993,7 +964,7 @@ private:
         create_statement(m_memory_copy_statement, query);
     }
 
-    // v4: memory_allocate uses track_id, start_id, end_id, name_id
+    // v4: memory_allocate uses track_id, inline start/end timestamps, name_id
     void initialize_memory_alloc_statement()
     {
         rocpdsna::queries::insert::table_insert_query query_builder;
@@ -1003,8 +974,8 @@ private:
                              "track_id",
                              "type",
                              "level",
-                             "start_id",
-                             "end_id",
+                             "start",
+                             "end",
                              "name_id",
                              "address",
                              "size",
@@ -1030,7 +1001,6 @@ private:
     kernel_symbol_info_statement_func_t m_kernel_symbol_info_statement;
     code_object_info_statement_func_t   m_code_object_info_statement;
     track_info_statement_func_t         m_track_info_statement;
-    timestamp_statement_func_t          m_timestamp_statement;
     category_info_statement_func_t      m_category_info_statement;
     address_range_info_statement_func_t m_address_range_info_statement;
     source_code_info_statement_func_t   m_source_code_info_statement;

--- a/projects/rocpdsna/source/writers/schema_v4/common_insert_operations.hpp
+++ b/projects/rocpdsna/source/writers/schema_v4/common_insert_operations.hpp
@@ -32,8 +32,7 @@ namespace rocpdsna
  * - Region/dispatch/memory: Uses track_id + timestamp IDs instead of nid/pid/tid + direct
  * timestamps
  * - Sample: Uses name_id + timestamp_id
- * - New operations: insert_timestamp(), insert_call_stack(), insert_line_info(),
- * insert_category()
+ * - New operations: insert_call_stack(), insert_line_info(), insert_category()
  */
 template <>
 class common_insert_operations<data_storage::schema_v4_tag>
@@ -119,24 +118,6 @@ public:
     }
 
     /**
-     * @brief Insert timestamp into rocpd_timestamp table
-     *
-     * @param value The timestamp value
-     * @param phase Optional phase indicator (0 = none/instantaneous, 1 =
-     * start/enter/load, 2 = end/exit/unload)
-     * @param track_id Optional track ID reference
-     * @return Primary key of the inserted timestamp
-     */
-    primary_key_t insert_timestamp(uint64_t                     value,
-                                   std::optional<int>           phase    = std::nullopt,
-                                   std::optional<primary_key_t> track_id = std::nullopt)
-    {
-        const auto pk = m_ctx->key_providers->timestamp_data().get_primary_key_value();
-        m_stmts->timestamp_statement()(pk, value, phase, track_id);
-        return pk;
-    }
-
-    /**
      * @brief Ensure category is registered and return its primary key
      *
      * Uses the category_info registry (similar to how v3 uses string_info for categories)
@@ -197,15 +178,11 @@ public:
             m_ctx->registry->string_info().get_primary_key_value_for_entity(
                 std::string(track_name_view));
 
-        // Insert timestamp and get ID
-        // Phase 0 = none/instantaneous for sample timestamps
-        const auto timestamp_id = insert_timestamp(sample_data.timestamp, 0, track_pk);
-
         const auto pk = m_ctx->key_providers->sample_data().get_primary_key_value();
 
-        // v4 sample: id, track_id, name_id, timestamp_id, event_id, extdata
+        // v4 sample: id, track_id, name_id, timestamp, event_id, extdata
         m_stmts->sample_statement()(
-            pk, track_pk, name_pk, timestamp_id, event_pk, sample_data.extdata);
+            pk, track_pk, name_pk, sample_data.timestamp, event_pk, sample_data.extdata);
     }
 
     void insert_arg(const writer_types::arg_data_t& arg_data, primary_key_t event_id)

--- a/projects/rocpdsna/source/writers/schema_v4/kernel_dispatch_writer.hpp
+++ b/projects/rocpdsna/source/writers/schema_v4/kernel_dispatch_writer.hpp
@@ -24,7 +24,7 @@ namespace rocpdsna
  *
  * Key differences from schema_v3:
  * - Uses track_id instead of nid/pid/tid/agent_id/queue_id/stream_id columns
- * - Uses start_id/end_id (references rocpd_timestamp) instead of direct timestamps
+ * - Uses inline start/end BIGINT timestamps instead of FK references to rocpd_timestamp
  * - Uses region_name_id instead of name
  */
 template <>
@@ -62,13 +62,6 @@ public:
         // Get track_id from trace environment
         const auto track_pk = m_common_ops->resolve_track_id(trace_env);
 
-        // Insert timestamps and get their IDs
-        // Phase: 1 = start/enter/load, 2 = end/exit/unload (per SQL CHECK constraint)
-        const auto start_id =
-            m_common_ops->insert_timestamp(data.start_timestamp, 1, track_pk);
-        const auto end_id =
-            m_common_ops->insert_timestamp(data.end_timestamp, 2, track_pk);
-
         // Get region_name_id if name is provided
         std::optional<primary_key_t> region_name_pk =
             data.name.has_value()
@@ -87,7 +80,7 @@ public:
         const auto pk =
             m_ctx->key_providers->kernel_dispatch_data().get_primary_key_value();
 
-        // v4 kernel_dispatch: id, track_id, kernel_id, dispatch_id, start_id, end_id,
+        // v4 kernel_dispatch: id, track_id, kernel_id, dispatch_id, start, end,
         //                     private_segment_size, group_segment_size,
         //                     workgroup_size_x/y/z, grid_size_x/y/z,
         //                     region_name_id, event_id, extdata
@@ -95,8 +88,8 @@ public:
                                              track_pk,
                                              data.kernel_symbol_id,
                                              data.dispatch_id,
-                                             start_id,
-                                             end_id,
+                                             data.start_timestamp,
+                                             data.end_timestamp,
                                              data.private_segment_size,
                                              data.group_segment_size,
                                              data.workgroup_size_x,

--- a/projects/rocpdsna/source/writers/schema_v4/memory_alloc_writer.hpp
+++ b/projects/rocpdsna/source/writers/schema_v4/memory_alloc_writer.hpp
@@ -28,7 +28,7 @@ namespace rocpdsna
  *
  * Key differences from schema_v3:
  * - Uses track_id instead of nid/pid/tid columns
- * - Uses start_id/end_id (references rocpd_timestamp) instead of direct timestamps
+ * - Uses inline start/end BIGINT timestamps instead of FK references to rocpd_timestamp
  * - Uses name_id, region_name_id for string references
  */
 template <>
@@ -93,13 +93,6 @@ public:
         // Get track_id from trace environment
         const auto track_pk = m_common_ops->resolve_track_id(trace_env);
 
-        // Insert timestamps and get their IDs
-        // Phase: 1 = start/enter/load, 2 = end/exit/unload (per SQL CHECK constraint)
-        const auto start_id =
-            m_common_ops->insert_timestamp(data.start_timestamp, 1, track_pk);
-        const auto end_id =
-            m_common_ops->insert_timestamp(data.end_timestamp, 2, track_pk);
-
         // name_id is required: prefer user-provided name, fall back to type, then generic
         std::string_view name_str = data.name.has_value()
                                         ? data.name.value()
@@ -125,14 +118,14 @@ public:
 
         const auto pk = m_ctx->key_providers->memory_alloc_data().get_primary_key_value();
 
-        // v4 memory_allocate: id, track_id, type, level, start_id, end_id, name_id,
+        // v4 memory_allocate: id, track_id, type, level, start, end, name_id,
         //                     address, size, region_name_id, event_id, extdata
         m_stmts->memory_alloc_statement()(pk,
                                           track_pk,
                                           data.type,
                                           data.level,
-                                          start_id,
-                                          end_id,
+                                          data.start_timestamp,
+                                          data.end_timestamp,
                                           name_pk,
                                           data.address,
                                           data.size,

--- a/projects/rocpdsna/source/writers/schema_v4/memory_copy_writer.hpp
+++ b/projects/rocpdsna/source/writers/schema_v4/memory_copy_writer.hpp
@@ -24,7 +24,7 @@ namespace rocpdsna
  *
  * Key differences from schema_v3:
  * - Uses track_id instead of nid/pid/tid columns
- * - Uses start_id/end_id (references rocpd_timestamp) instead of direct timestamps
+ * - Uses inline start/end BIGINT timestamps instead of FK references to rocpd_timestamp
  * - Uses name_id, region_name_id for string references
  */
 template <>
@@ -62,13 +62,6 @@ public:
         // Get track_id from trace environment
         const auto track_pk = m_common_ops->resolve_track_id(trace_env);
 
-        // Insert timestamps and get their IDs
-        // Phase: 1 = start/enter/load, 2 = end/exit/unload (per SQL CHECK constraint)
-        const auto start_id =
-            m_common_ops->insert_timestamp(data.start_timestamp, 1, track_pk);
-        const auto end_id =
-            m_common_ops->insert_timestamp(data.end_timestamp, 2, track_pk);
-
         // Get name_id
         const auto name_pk =
             m_ctx->registry->string_info().get_primary_key_value_for_entity(
@@ -97,13 +90,13 @@ public:
 
         const auto pk = m_ctx->key_providers->memory_copy_data().get_primary_key_value();
 
-        // v4 memory_copy: id, track_id, start_id, end_id, name_id,
+        // v4 memory_copy: id, track_id, start, end, name_id,
         //                 dst_agent_id, dst_address, src_agent_id, src_address,
         //                 size, region_name_id, event_id, extdata
         m_stmts->memory_copy_statement()(pk,
                                          track_pk,
-                                         start_id,
-                                         end_id,
+                                         data.start_timestamp,
+                                         data.end_timestamp,
                                          name_pk,
                                          dst_agent_pk,
                                          data.dst_address,

--- a/projects/rocpdsna/source/writers/schema_v4/region_writer.hpp
+++ b/projects/rocpdsna/source/writers/schema_v4/region_writer.hpp
@@ -25,7 +25,7 @@ namespace rocpdsna
  *
  * Key differences from schema_v3:
  * - Uses track_id instead of nid/pid/tid columns
- * - Uses start_id/end_id (references rocpd_timestamp) instead of direct start/end BIGINT
+ * - Uses inline start/end BIGINT timestamps instead of FK references to rocpd_timestamp
  * - Uses name_id instead of direct name reference
  */
 template <>
@@ -69,14 +69,7 @@ public:
         // 4. Get track_id from trace environment
         const auto track_pk = m_common_ops->resolve_track_id(trace_env);
 
-        // 5. Insert timestamps and get their IDs (v4 uses rocpd_timestamp table)
-        // Phase: 1 = start/enter/load, 2 = end/exit/unload (per SQL CHECK constraint)
-        const auto start_id =
-            m_common_ops->insert_timestamp(data.start_timestamp, 1, track_pk);
-        const auto end_id =
-            m_common_ops->insert_timestamp(data.end_timestamp, 2, track_pk);
-
-        // 6. Insert event data and get event_id
+        // 5. Insert event data and get event_id
         std::optional<primary_key_t> event_pk = std::nullopt;
         if(data.event.has_value())
         {
@@ -84,12 +77,17 @@ public:
                 data.event.value(), trace_env.node_id, trace_env.process_id);
         }
 
-        // 7. Insert region data and get region_id
+        // 6. Insert region data and get region_id
         const auto pk = m_ctx->key_providers->region_data().get_primary_key_value();
 
-        // v4 region: id, track_id, name_id, start_id, end_id, event_id, extdata
-        m_stmts->region_statement()(
-            pk, track_pk, name_pk, start_id, end_id, event_pk, data.extdata);
+        // v4 region: id, track_id, name_id, start, end, event_id, extdata
+        m_stmts->region_statement()(pk,
+                                    track_pk,
+                                    name_pk,
+                                    data.start_timestamp,
+                                    data.end_timestamp,
+                                    event_pk,
+                                    data.extdata);
 
         if(event_pk.has_value())
         {


### PR DESCRIPTION
## Summary

This PR modifies the schema 4.0.0 SQL files and schema_v4 C++ writers in PR #5347 to use
inline `BIGINT` timestamps (`start`, `end`) instead of FK references to a separate
`rocpd_timestamp` table.

### Changes

**SQL schema (`schema/4.0.0/`)**
- `rocpd_tables.sql` — removed `rocpd_timestamp` table; replaced `start_id`/`end_id` INTEGER FK
  columns with `start`/`end` BIGINT on `rocpd_region`, `rocpd_kernel_dispatch`,
  `rocpd_memory_copy`, `rocpd_memory_allocate`; replaced `timestamp_id` FK with `timestamp`
  BIGINT on `rocpd_sample`; removed FK constraints referencing `rocpd_timestamp`
- `rocpd_indexes.sql` — removed two indexes on `rocpd_timestamp`
  (`rocpd_timestamp_value_idx`, `rocpd_timestamp_guid_value_idx`)
- `data_views.sql` — removed all `rocpd_timestamp` JOINs from `regions`, `kernels`,
  `memory_copies`, `memory_allocations`, `samples` views; reads `start`/`end`/`timestamp`
  directly from inline columns

**C++ writers (`source/`)**
- `insert_statements.hpp` — removed timestamp INSERT; updated INSERT statements to bind
  `start`/`end`/`timestamp` BIGINT directly
- `writers/schema_v4/common_insert_operations.hpp` — removed `insert_timestamp()` helper
- `writers/schema_v4/region_writer.hpp` — direct BIGINT bind for start/end
- `writers/schema_v4/kernel_dispatch_writer.hpp` — direct BIGINT bind for start/end
- `writers/schema_v4/memory_copy_writer.hpp` — direct BIGINT bind for start/end
- `writers/schema_v4/memory_alloc_writer.hpp` — direct BIGINT bind for start/end

### Motivation

The `rocpd_timestamp` FK indirection adds write overhead (two inserts per event instead of one)
and complicates reads (every view requires a JOIN). Storing timestamps inline as BIGINT is
simpler, faster, and consistent with how other integer fields are handled in the schema.

### Test results

358 tests pass. 183 pre-existing failures (unrelated `rocpd_info_node` column bug in PR #5347
base) are unchanged — zero new failures introduced.