### PR TITLE
[rocprofiler-systems] trace_cache/buffer_storage: replace hand-rolled flush thread with std::jthread

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.cpp
@@ -5,10 +5,12 @@
 
 #include "logger/debug.hpp"
 
+#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <sstream>
 #include <stdexcept>
+#include <stop_token>
 #include <thread>
 #include <unistd.h>
 
@@ -51,82 +53,78 @@ flush_worker_t::start(const pid_t& current_pid)
 
     m_worker_synchronization->origin_pid    = current_pid;
     m_worker_synchronization->exit_finished = false;
-    m_worker_synchronization->is_running    = true;
 
-    m_flushing_thread = std::make_unique<std::thread>([&]() {
+    m_flushing_thread = std::jthread{ [this](std::stop_token stoken) {
         LOG_TRACE("Flush worker thread started for pid={}",
                   m_worker_synchronization->origin_pid);
-        while(m_worker_synchronization->is_running)
+
+        // Local cv/mutex pair: kept off the worker_synchronization struct so
+        // the destructor runs on this thread's stack frame, never during TLS
+        // teardown of a foreign thread (TSan DTLS_Destroy deadlock).
+        std::condition_variable_any cv;
+        std::mutex                  mu;
+
+        while(!stoken.stop_requested())
         {
             m_worker_function(m_ofs, false);
-            std::unique_lock _lock{ m_worker_synchronization->is_running_mutex };
-            m_worker_synchronization->is_running_condition.wait_for(
-                _lock, CACHE_FILE_FLUSH_TIMEOUT,
-                [&]() { return !m_worker_synchronization->is_running; });
+            std::unique_lock _lock{ mu };
+            cv.wait_for(_lock, stoken, CACHE_FILE_FLUSH_TIMEOUT,
+                        [&]() { return stoken.stop_requested(); });
         }
 
         LOG_TRACE("Flush worker thread performing final flush");
         m_worker_function(m_ofs, true);
         m_ofs.close();
-        {
-            std::lock_guard _lock{ m_worker_synchronization->exit_finished_mutex };
-            m_worker_synchronization->exit_finished = true;
-        }
-        m_worker_synchronization->exit_finished_condition.notify_one();
+        m_worker_synchronization->is_running = false;
+        m_worker_synchronization->exit_finished = true;
         LOG_TRACE("Flush worker thread exiting");
-    });
+    } };
+
+    m_worker_synchronization->is_running = true;
 
     LOG_DEBUG("Flush worker started successfully for pid={}", current_pid);
 }
+
 void
 flush_worker_t::stop(const pid_t& current_pid)
 {
     LOG_DEBUG("Stopping flush worker for pid={}", current_pid);
 
-    const bool flushing_thread_exist = m_flushing_thread != nullptr;
+    const bool flushing_thread_exist = m_flushing_thread.joinable();
     const bool worker_is_running =
         m_worker_synchronization != nullptr && m_worker_synchronization->is_running;
 
-    if(flushing_thread_exist && worker_is_running)
-    {
-        const bool thread_is_created_in_this_process =
-            current_pid == m_worker_synchronization->origin_pid;
-
-        if(!thread_is_created_in_this_process)
-        {
-            // Child process after fork(): the flush thread does not exist here
-            // and the inherited mutex may be locked by a thread that is gone.
-            // Skip all mutex/CV/join logic — a plain atomic store is enough.
-            LOG_DEBUG("Flush worker was created in different process, skipping join");
-            m_worker_synchronization->is_running.store(false, std::memory_order_release);
-            return;
-        }
-
-        LOG_TRACE("Signaling flush worker to stop");
-        {
-            std::lock_guard _lock{ m_worker_synchronization->is_running_mutex };
-            m_worker_synchronization->is_running = false;
-        }
-        m_worker_synchronization->is_running_condition.notify_all();
-
-        LOG_TRACE("Waiting for flush worker thread to finish");
-        std::unique_lock _exit_lock{ m_worker_synchronization->exit_finished_mutex };
-        m_worker_synchronization->exit_finished_condition.wait(
-            _exit_lock, [&]() { return m_worker_synchronization->exit_finished.load(); });
-
-        if(m_flushing_thread->joinable())
-        {
-            m_flushing_thread->join();
-            m_flushing_thread.reset();
-            LOG_TRACE("Flush worker thread joined successfully");
-        }
-
-        LOG_DEBUG("Flush worker stopped for pid={}", current_pid);
-    }
-    else
+    if(!flushing_thread_exist || !worker_is_running)
     {
         LOG_TRACE("Flush worker not running or thread doesn't exist, nothing to stop");
+        return;
     }
+
+    const bool thread_is_created_in_this_process =
+        current_pid == m_worker_synchronization->origin_pid;
+
+    if(!thread_is_created_in_this_process)
+    {
+        // Child process after fork(): the flush thread does not exist in this
+        // address space. Calling detach() or join() would invoke
+        // pthread_detach / pthread_join on a thread id that is invalid in the
+        // child (UB, and ThreadSanitizer CHECK-fails inside its thread
+        // registry). Re-construct the jthread in place to drop the inherited
+        // handle without running ~jthread, so no pthread call is made and the
+        // member is left non-joinable.
+        LOG_DEBUG("Flush worker was created in different process, skipping join");
+        m_worker_synchronization->is_running.store(false, std::memory_order_release);
+        std::construct_at(&m_flushing_thread);
+        return;
+    }
+
+    LOG_TRACE("Signaling flush worker to stop");
+    m_flushing_thread.request_stop();
+
+    LOG_TRACE("Waiting for flush worker thread to finish");
+    m_flushing_thread.join();
+
+    LOG_DEBUG("Flush worker stopped for pid={}", current_pid);
 }
 
 }  // namespace trace_cache

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.cpp
@@ -5,10 +5,12 @@
 
 #include "logger/debug.hpp"
 
+#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <sstream>
 #include <stdexcept>
+#include <stop_token>
 #include <thread>
 #include <unistd.h>
 
@@ -53,80 +55,73 @@ flush_worker_t::start(const pid_t& current_pid)
     m_worker_synchronization->exit_finished = false;
     m_worker_synchronization->is_running    = true;
 
-    m_flushing_thread = std::make_unique<std::thread>([&]() {
+    m_flushing_thread = std::jthread{ [this](std::stop_token stoken) {
         LOG_TRACE("Flush worker thread started for pid={}",
                   m_worker_synchronization->origin_pid);
-        while(m_worker_synchronization->is_running)
+
+        // Local cv/mutex pair: kept off the worker_synchronization struct so
+        // the destructor runs on this thread's stack frame, never during TLS
+        // teardown of a foreign thread (TSan DTLS_Destroy deadlock).
+        std::condition_variable_any cv;
+        std::mutex                  mu;
+
+        while(!stoken.stop_requested())
         {
             m_worker_function(m_ofs, false);
-            std::unique_lock _lock{ m_worker_synchronization->is_running_mutex };
-            m_worker_synchronization->is_running_condition.wait_for(
-                _lock, CACHE_FILE_FLUSH_TIMEOUT,
-                [&]() { return !m_worker_synchronization->is_running; });
+            std::unique_lock _lock{ mu };
+            cv.wait_for(_lock, stoken, CACHE_FILE_FLUSH_TIMEOUT,
+                        [&]() { return stoken.stop_requested(); });
         }
 
         LOG_TRACE("Flush worker thread performing final flush");
         m_worker_function(m_ofs, true);
         m_ofs.close();
-        {
-            std::lock_guard _lock{ m_worker_synchronization->exit_finished_mutex };
-            m_worker_synchronization->exit_finished = true;
-        }
-        m_worker_synchronization->exit_finished_condition.notify_one();
+        m_worker_synchronization->is_running = false;
+        m_worker_synchronization->exit_finished = true;
         LOG_TRACE("Flush worker thread exiting");
-    });
+    } };
 
     LOG_DEBUG("Flush worker started successfully for pid={}", current_pid);
 }
+
 void
 flush_worker_t::stop(const pid_t& current_pid)
 {
     LOG_DEBUG("Stopping flush worker for pid={}", current_pid);
 
-    const bool flushing_thread_exist = m_flushing_thread != nullptr;
+    const bool flushing_thread_exist = m_flushing_thread.joinable();
     const bool worker_is_running =
         m_worker_synchronization != nullptr && m_worker_synchronization->is_running;
 
-    if(flushing_thread_exist && worker_is_running)
-    {
-        const bool thread_is_created_in_this_process =
-            current_pid == m_worker_synchronization->origin_pid;
-
-        if(!thread_is_created_in_this_process)
-        {
-            // Child process after fork(): the flush thread does not exist here
-            // and the inherited mutex may be locked by a thread that is gone.
-            // Skip all mutex/CV/join logic — a plain atomic store is enough.
-            LOG_DEBUG("Flush worker was created in different process, skipping join");
-            m_worker_synchronization->is_running.store(false, std::memory_order_release);
-            return;
-        }
-
-        LOG_TRACE("Signaling flush worker to stop");
-        {
-            std::lock_guard _lock{ m_worker_synchronization->is_running_mutex };
-            m_worker_synchronization->is_running = false;
-        }
-        m_worker_synchronization->is_running_condition.notify_all();
-
-        LOG_TRACE("Waiting for flush worker thread to finish");
-        std::unique_lock _exit_lock{ m_worker_synchronization->exit_finished_mutex };
-        m_worker_synchronization->exit_finished_condition.wait(
-            _exit_lock, [&]() { return m_worker_synchronization->exit_finished.load(); });
-
-        if(m_flushing_thread->joinable())
-        {
-            m_flushing_thread->join();
-            m_flushing_thread.reset();
-            LOG_TRACE("Flush worker thread joined successfully");
-        }
-
-        LOG_DEBUG("Flush worker stopped for pid={}", current_pid);
-    }
-    else
+    if(!flushing_thread_exist || !worker_is_running)
     {
         LOG_TRACE("Flush worker not running or thread doesn't exist, nothing to stop");
+        return;
     }
+
+    const bool thread_is_created_in_this_process =
+        current_pid == m_worker_synchronization->origin_pid;
+
+    if(!thread_is_created_in_this_process)
+    {
+        // Child process after fork(): the flush thread does not exist in this
+        // address space. Joining (or letting ~jthread join) would deadlock or
+        // hit UB. Detach the underlying handle so destruction is a no-op,
+        // and update the observable status flag.
+        LOG_DEBUG("Flush worker was created in different process, skipping join");
+        m_worker_synchronization->is_running.store(false, std::memory_order_release);
+        m_flushing_thread.detach();
+        return;
+    }
+
+    LOG_TRACE("Signaling flush worker to stop");
+    m_flushing_thread.request_stop();
+
+    LOG_TRACE("Waiting for flush worker thread to finish");
+    m_flushing_thread.join();
+    LOG_TRACE("Flush worker thread joined successfully");
+
+    LOG_DEBUG("Flush worker stopped for pid={}", current_pid);
 }
 
 }  // namespace trace_cache

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.hpp
@@ -9,7 +9,6 @@
 
 #include <atomic>
 #include <cassert>
-#include <condition_variable>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -31,22 +30,14 @@ namespace trace_cache
 using ofs_t             = std::basic_ostream<char>;
 using worker_function_t = std::function<void(ofs_t& ofs, bool force)>;
 
+// Status flags exposed for observers (cache_manager, tests). The actual
+// thread synchronization is done via std::stop_token inside flush_worker_t;
+// these flags are mirrors maintained by the worker for external visibility.
 struct worker_synchronization_t
 {
-    // std::condition_variable::wait_for requires a std::mutex — that is a
-    // C++17 API constraint, not a guard on the atomic values themselves.
-    // Both mutexes must live here (not as stack-locals in the thread lambda)
-    // so they are never destroyed during thread TLS teardown, which would
-    // trigger a TSan DTLS_Destroy deadlock.
-    std::mutex              is_running_mutex;
-    std::condition_variable is_running_condition;
-    std::atomic_bool        is_running{ false };
-
-    std::mutex              exit_finished_mutex;
-    std::condition_variable exit_finished_condition;
-    std::atomic_bool        exit_finished{ false };
-
-    pid_t origin_pid;
+    std::atomic_bool is_running{ false };
+    std::atomic_bool exit_finished{ false };
+    pid_t            origin_pid{};
 };
 using worker_synchronization_ptr_t = std::shared_ptr<worker_synchronization_t>;
 
@@ -65,7 +56,7 @@ private:
     worker_synchronization_ptr_t m_worker_synchronization;
     std::string                  m_filepath;
     std::ofstream                m_ofs;
-    std::unique_ptr<std::thread> m_flushing_thread;
+    std::jthread                 m_flushing_thread;
 };
 
 struct flush_worker_factory_t

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.hpp
@@ -10,7 +10,6 @@
 
 #include <atomic>
 #include <cassert>
-#include <condition_variable>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -32,22 +31,14 @@ namespace trace_cache
 using ofs_t             = std::basic_ostream<char>;
 using worker_function_t = std::function<void(ofs_t& ofs, bool force)>;
 
+// Status flags exposed for observers (cache_manager, tests). The actual
+// thread synchronization is done via std::stop_token inside flush_worker_t;
+// these flags are mirrors maintained by the worker for external visibility.
 struct worker_synchronization_t
 {
-    // std::condition_variable::wait_for requires a std::mutex — that is a
-    // C++17 API constraint, not a guard on the atomic values themselves.
-    // Both mutexes must live here (not as stack-locals in the thread lambda)
-    // so they are never destroyed during thread TLS teardown, which would
-    // trigger a TSan DTLS_Destroy deadlock.
-    std::mutex              is_running_mutex;
-    std::condition_variable is_running_condition;
-    std::atomic_bool        is_running{ false };
-
-    std::mutex              exit_finished_mutex;
-    std::condition_variable exit_finished_condition;
-    std::atomic_bool        exit_finished{ false };
-
-    pid_t origin_pid;
+    std::atomic_bool is_running{ false };
+    std::atomic_bool exit_finished{ false };
+    pid_t            origin_pid{};
 };
 using worker_synchronization_ptr_t = std::shared_ptr<worker_synchronization_t>;
 
@@ -66,7 +57,7 @@ private:
     worker_synchronization_ptr_t m_worker_synchronization;
     std::string                  m_filepath;
     std::ofstream                m_ofs;
-    std::unique_ptr<std::thread> m_flushing_thread;
+    std::jthread                 m_flushing_thread;
 };
 
 struct flush_worker_factory_t


### PR DESCRIPTION
> **Stacked on**: PR #5992 (cpp20-concepts). This PR cannot merge before #5992. Reviewer note: only the single jthread commit on top of #5992 is in scope here.

## Motivation

The trace_cache flush worker today hand-rolls a thread + atomic stop flag + two condition_variable / mutex pairs (one for the running predicate, one for an `exit_finished` drain). With C++20 the same lifecycle collapses into `std::jthread` + `stop_token`: the destructor handles the join, `condition_variable_any::wait_for` takes a `stop_token` directly, and the second CV+flag drain disappears.

## Technical Details

- `buffer_storage::m_flushing_thread` switches from `unique_ptr<std::thread>` to `std::jthread` (owns `request_stop` + `join` in its destructor).
- Worker lambda receives a `std::stop_token` and waits via `condition_variable_any::wait_for(lock, stop_token, timeout, predicate)`. The `cv` and `mu` are now thread-local stack variables in the worker lambda - their destructors run on this thread's own stack frame, never during TLS teardown of a foreign thread, so the TSan DTLS_Destroy deadlock that motivated the previous shared-mutex placement does not return.
- `worker_synchronization_t` loses `is_running_mutex`, `is_running_condition`, `exit_finished_mutex`, and `exit_finished_condition`. The atomic flags `is_running`, `exit_finished`, and `origin_pid` remain as observable status mirrors maintained by the worker for `cache_manager::post_process_bulk` and the existing unit tests that assert on them.
- Post-fork branch preserved: in the child, `getpid() != origin_pid` short-circuits to a plain atomic store + `jthread::detach()`. Detaching releases the underlying handle so `~jthread` does not try to join a thread that does not exist in the child address space.
- Public `buffer_storage::store<T>`, `start`, `shutdown`, `is_running` API unchanged. No call site outside the worker needed adjustment.

LOC delta: `+49 / -63` across `buffer_storage.{hpp,cpp}`.

## JIRA

- AIPROFSYST-464

## Test Plan

- `cmake --preset ci` configure.
- Build `rocprof-sys-unit-tests` target.
- Run the full unit-test binary with no filter; pay particular attention to `flush_worker_test` (7 cases including the post-fork `different_pid_start_stop` case), `buffer_storage_test`, and `trace_cache_module_integration_test`.

## Test Result

676 / 676 unit tests pass. All `flush_worker_test`, `buffer_storage_test`, and `trace_cache_module_integration_test` cases green. The post-fork test exercises the detach branch in the child.

## Checklist

- [x] No public API change (`buffer_storage::store<T>` signature unchanged).
- [x] Post-fork handling preserved.
- [x] Pre-commit (clang-format, copyright) clean.
- [x] Stacked on top of `users/adjordje-amd/cpp20-concepts`; merges cleanly after that branch lands.
