### PR TITLE
Hipfile: Provide fallback definitions for symbols missing on older version of Linux

### DIFF
--- a/.github/workflows/hipfile-build.yml
+++ b/.github/workflows/hipfile-build.yml
@@ -13,7 +13,7 @@ env:
   AIS_MOUNT_PATH: /mnt/ais/ext4
   AIS_PKG_MGR: >-
     ${{
-      inputs.platform == 'rocky' && 'dnf' ||
+      startsWith(inputs.platform, 'rocky') && 'dnf' ||
       inputs.platform == 'suse' && 'zypper' ||
       inputs.platform == 'ubuntu' && 'apt'
     }}

--- a/.github/workflows/hipfile-ci-system.yml
+++ b/.github/workflows/hipfile-ci-system.yml
@@ -12,7 +12,7 @@ env:
   AIS_PKG_INSTALL_CMD: >-
     ${{
       case(
-        inputs.platform == 'rocky', 'dnf install -y',
+        startsWith(inputs.platform, 'rocky'), 'dnf install -y',
         inputs.platform == 'suse', 'zypper install -y --allow-unsigned-rpm',
         inputs.platform == 'ubuntu', 'apt update; apt install -y',
         ''
@@ -20,7 +20,7 @@ env:
     }}
   AIS_PKG_MGR: >-
     ${{
-      inputs.platform == 'rocky' && 'dnf' ||
+      startsWith(inputs.platform, 'rocky') && 'dnf' ||
       inputs.platform == 'suse' && 'zypper' ||
       inputs.platform == 'ubuntu' && 'apt'
     }}
@@ -225,7 +225,7 @@ jobs:
 #      FIO_RUNTIME_PKG_FILENAME: >-
 #        ${{
 #          case(
-#            inputs.platform == 'rocky', needs.build_FIO.outputs.fio_pkg_fedora_filename,
+#            startsWith(inputs.platform, 'rocky'), needs.build_FIO.outputs.fio_pkg_fedora_filename,
 #            inputs.platform == 'suse', needs.build_FIO.outputs.fio_pkg_suse_filename,
 #            inputs.platform == 'ubuntu', needs.build_FIO.outputs.fio_pkg_debian_filename,
 #            ''
@@ -234,7 +234,7 @@ jobs:
 #      FIO_HIPFILE_ENGINE_PKG_FILENAME: >-
 #        ${{
 #          case(
-#            inputs.platform == 'rocky', needs.build_FIO.outputs.fio_pkg_fedora_hipfile_engine_filename,
+#            startsWith(inputs.platform, 'rocky'), needs.build_FIO.outputs.fio_pkg_fedora_hipfile_engine_filename,
 #            ''
 #          )
 #        }}
@@ -269,7 +269,7 @@ jobs:
 #          artifact-ids: >-
 #            ${{
 #              case(
-#                inputs.platform == 'rocky',
+#                startsWith(inputs.platform, 'rocky'),
 #                format(
 #                  '{0},{1}',
 #                  needs.build_FIO.outputs.fio_pkg_fedora_artifact_id,
@@ -339,7 +339,7 @@ jobs:
 #            "${AIS_CONTAINER_NAME}:/root"
 #          ${{
 #            case(
-#              inputs.platform == 'rocky',
+#              startsWith(inputs.platform, 'rocky'),
 #                'docker cp \
 #                  "${GITHUB_WORKSPACE}/${FIO_HIPFILE_ENGINE_PKG_FILENAME}" \
 #                  "${AIS_CONTAINER_NAME}:/root"
@@ -359,7 +359,7 @@ jobs:
 #                  '{0} {1}',
 #                  env.AIS_PKG_INSTALL_CMD,
 #                  case(
-#                    inputs.platform == 'rocky',
+#                    startsWith(inputs.platform, 'rocky'),
 #                      format('./{0} ./{1}', env.FIO_RUNTIME_PKG_FILENAME, env.FIO_HIPFILE_ENGINE_PKG_FILENAME),
 #                    format('./{0}', env.FIO_RUNTIME_PKG_FILENAME)
 #                  )

--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -32,6 +32,7 @@ jobs:
       matrix:
         supported_platforms:
           - rocky
+          - rocky8
           - suse
           - ubuntu
         rocm_versions:

--- a/.github/workflows/hipfile-ci.yml
+++ b/.github/workflows/hipfile-ci.yml
@@ -64,7 +64,7 @@ jobs:
 
   build_and_test_cxx20:
     # cancelled() needed. Otherwise success() implicitly added and fails if build_AIS_CI_image skipped.
-    if: ${{ !cancelled() && needs.build_AIS_CI_image.outputs.ci_image_build_satisfied == 'true' }}
+    if: ${{ !cancelled() && needs.build_AIS_CI_image.outputs.ci_image_build_satisfied == 'true' && inputs.platform != 'rocky8' }}
     needs: [AIS_CI_Pre-check, build_AIS_CI_image]
     uses: ./.github/workflows/hipfile-build.yml
     with:

--- a/.github/workflows/hipfile-image-update.yml
+++ b/.github/workflows/hipfile-image-update.yml
@@ -45,6 +45,7 @@ jobs:
       matrix:
         supported_platforms:
           - rocky
+          - rocky8
           - suse
           - ubuntu
         rocm_versions:

--- a/projects/hipfile/src/amd_detail/hipfile-stats.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile-stats.cpp
@@ -24,6 +24,12 @@ hipFileStatsCreateContext(hipFileStatsContext_t **context, int targetPid)
     try {
         *context = reinterpret_cast<hipFileStatsContext_t *>(new StatsClient{targetPid});
     }
+    catch (const std::system_error &e) {
+        *context = nullptr;
+        if (e.code().value() == ENOSYS)
+            return hipFileStatsTargetProcessNotAccessible;
+        return hipFileStatsTargetProcessNotFound;
+    }
     catch (...) {
         *context = nullptr;
         return hipFileStatsTargetProcessNotFound;

--- a/projects/hipfile/src/amd_detail/stats.cpp
+++ b/projects/hipfile/src/amd_detail/stats.cpp
@@ -97,6 +97,12 @@ populateSocketAddr(sockaddr_un &addr, pid_t pid) noexcept
 }
 
 namespace hipFile {
+
+// This flag is not defined on kernels before 5.1
+#ifndef F_SEAL_FUTURE_WRITE
+#define F_SEAL_FUTURE_WRITE 0x0010
+#endif
+
 StatsContainer::StatsContainer()
     : m_fd{FileDescriptor::make_managed(Context<Sys>::get()->memfd_create("AISSTATS", MFD_ALLOW_SEALING))},
       m_stats{nullptr}
@@ -107,6 +113,12 @@ StatsContainer::StatsContainer()
         Context<Sys>::get()->mmap(nullptr, sizeof(Stats), PROT_READ | PROT_WRITE, MAP_SHARED, m_fd.get(), 0);
     try {
         Context<Sys>::get()->fcntl(m_fd.get(), F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_FUTURE_WRITE);
+    }
+    catch (const std::system_error &e) {
+        Context<Sys>::get()->munmap(shm, sizeof(Stats));
+        if (e.code().value() == EINVAL)
+            return;
+        throw;
     }
     catch (...) {
         Context<Sys>::get()->munmap(shm, sizeof(Stats));
@@ -128,7 +140,8 @@ StatsContainer::~StatsContainer()
 StatsServer::StatsServer()
     : m_efd{FileDescriptor::make_managed(Context<Sys>::get()->eventfd(0, 0))}, m_stats{}
 {
-    m_thread = std::thread(&StatsServer::threadFn, this);
+    if (m_stats.getStats())
+        m_thread = std::thread(&StatsServer::threadFn, this);
 }
 
 StatsServer::~StatsServer()

--- a/projects/hipfile/src/amd_detail/sys.cpp
+++ b/projects/hipfile/src/amd_detail/sys.cpp
@@ -136,6 +136,15 @@ Sys::eventfd(unsigned int initval, int flags) const
     return throwOn(-1, ::eventfd(initval, flags));
 }
 
+// This syscall is not defined on kernels before 5.3
+#ifndef SYS_pidfd_open
+#if defined(__linux__) && defined(__x86_64__)
+#define SYS_pidfd_open 434
+#else
+#error "SYS_pidfd_open is unavailable on this architecture/libc; no safe fallback is defined."
+#endif
+#endif
+
 int
 Sys::pidfd_open(pid_t pid, unsigned int flags) const
 {

--- a/projects/hipfile/test/amd_detail/CMakeLists.txt
+++ b/projects/hipfile/test/amd_detail/CMakeLists.txt
@@ -5,6 +5,7 @@
 include(AISAddExecutable)
 include(AISUseGTest)
 find_package(Boost COMPONENTS program_options REQUIRED)
+find_package(Threads REQUIRED)
 
 set(SHARED_SOURCE_FILES
     "${HIPFILE_TEST_COMMON_PATH}/magic-word.cpp"
@@ -69,6 +70,9 @@ ais_add_test_executable(
     SRCS "state_mt.cpp"
     SYSINCLS ${HIPFILE_AMD_SOURCE_PATH} ${HIPFILE_INCLUDE_PATH}
 )
+
+target_link_libraries(state_mt PRIVATE Threads::Threads)
+
 add_test(
     NAME state_mt_test
     COMMAND gdb --batch --quiet -ex run -ex "thread apply all bt full" --return-child-result --args $<TARGET_FILE:state_mt>
@@ -81,6 +85,9 @@ ais_add_test_executable(
     SRCS "batch/batch_mt.cpp"
     SYSINCLS ${HIPFILE_AMD_SOURCE_PATH} ${HIPFILE_INCLUDE_PATH}
 )
+
+target_link_libraries(batch_mt PRIVATE Threads::Threads)
+
 add_test(
     NAME batch_mt_test
     COMMAND gdb --batch --quiet -ex run -ex "thread apply all bt full" --return-child-result --args $<TARGET_FILE:batch_mt>

--- a/projects/hipfile/test/amd_detail/hipfile-stats.cpp
+++ b/projects/hipfile/test/amd_detail/hipfile-stats.cpp
@@ -46,6 +46,16 @@ TEST_F(HipFileStatsApi, CreateContextInvalidTarget)
     EXPECT_EQ(context, nullptr);
 }
 
+TEST_F(HipFileStatsApi, CreateContextNoSYS_pidfd_open)
+{
+    StrictMock<MSys> msys{};
+    EXPECT_CALL(msys, pidfd_open)
+        .WillOnce(testing::Throw(std::system_error(ENOSYS, std::generic_category())));
+    hipFileStatsContext_t *context;
+    EXPECT_EQ(hipFileStatsCreateContext(&context, 1234), hipFileStatsTargetProcessNotAccessible);
+    EXPECT_EQ(context, nullptr);
+}
+
 TEST_F(HipFileStatsApi, ConnectToTargetProcessInvalidArgument)
 {
     EXPECT_EQ(hipFileStatsConnectToTargetProcess(nullptr), hipFileStatsInvalidArgument);

--- a/projects/hipfile/test/amd_detail/stats.cpp
+++ b/projects/hipfile/test/amd_detail/stats.cpp
@@ -103,6 +103,21 @@ TEST_F(HipFileStats, StatsContainer)
     ASSERT_EQ(10, sc.getFd());
 }
 
+TEST_F(HipFileStats, StatsContainerNoF_SEAL_FUTURE_WRITE)
+{
+    StrictMock<MSys>           msys{};
+    StrictMock<MConfiguration> mcfg{};
+    EXPECT_CALL(msys, memfd_create).WillOnce(testing::Return(10));
+    EXPECT_CALL(mcfg, statsLevel()).WillOnce(testing::Return(1));
+    EXPECT_CALL(msys, ftruncate);
+    EXPECT_CALL(msys, mmap).WillOnce(testing::Return(nullptr));
+    EXPECT_CALL(msys, fcntl).WillOnce(testing::Throw(std::system_error(EINVAL, std::generic_category())));
+    EXPECT_CALL(msys, munmap).Times(1);
+    EXPECT_CALL(msys, close).Times(1);
+    StatsContainer sc{};
+    ASSERT_EQ(nullptr, sc.getStats());
+}
+
 TEST_F(HipFileStats, GenerateReportV1)
 {
     Stats              stats{};

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky8
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky8
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
-ARG ROCKY_MAJOR_VERSION=9
-ARG ROCKY_VERSION=${ROCKY_MAJOR_VERSION}.6
+ARG ROCKY_MAJOR_VERSION=8
+ARG ROCKY_VERSION=${ROCKY_MAJOR_VERSION}.10
 FROM rockylinux/rockylinux:${ROCKY_VERSION}-minimal
 LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
 # Brings ROCKY_VERSION in-scope
@@ -21,7 +21,7 @@ ARG ROCM_PKG_REPO_OVERRIDE
 RUN microdnf install -y \
         dnf \
         epel-release && \
-    dnf config-manager --set-enabled crb
+    /usr/bin/crb enable
 
 # Setup AMD/ROCm Repositories (using AMD RHEL repo)
 # Method 1: Using amdgpu_install.rpm - buggy

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky8
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_rocky8
@@ -1,0 +1,120 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+ARG ROCKY_MAJOR_VERSION=9
+ARG ROCKY_VERSION=${ROCKY_MAJOR_VERSION}.6
+FROM rockylinux/rockylinux:${ROCKY_VERSION}-minimal
+LABEL org.opencontainers.image.source=https://github.com/ROCm/hipFile
+# Brings ROCKY_VERSION in-scope
+ARG ROCKY_MAJOR_VERSION
+ARG ROCKY_VERSION
+ARG ROCM_VERSION=7.2.2
+
+# If the target ROCm Version on the package repository is non-standard, you can forcibly
+# set the ROCm version used in the package repo URL.
+# Ex. Package 7.0_alpha installs 7.0.0
+ARG ROCM_PKG_REPO_OVERRIDE
+
+# Update repo and install program dependencies.
+# microdnf is too stripped down, install full dnf.
+RUN microdnf install -y \
+        dnf \
+        epel-release && \
+    dnf config-manager --set-enabled crb
+
+# Setup AMD/ROCm Repositories (using AMD RHEL repo)
+# Method 1: Using amdgpu_install.rpm - buggy
+# The ROCm repo works in mysterious ways in that someone visiting from
+# a browser can download a certain version, but a utility like curl will
+# not be allowed to download it. Sometimes we may need to just forcibly
+# specify the version to make this work...
+# ARG AMDGPU_INSTALL="amdgpu-install-6.4.60402-1.el9.noarch.rpm"
+# RUN : "${AMDGPU_INSTALL:=$( \
+#         curl -s https://repo.radeon.com/amdgpu-install/latest/rhel/${ROCKY_VERSION}/ | \
+#         grep -oP '(?<=href=")[^"]+' | \
+#         grep amdgpu-install)}" && \
+#     echo "AMDGPU_INSTALL is: ${AMDGPU_INSTALL}" && \
+#     curl https://repo.radeon.com/amdgpu-install/latest/rhel/${ROCKY_VERSION}/${AMDGPU_INSTALL} \
+#         -o amdgpu_install.rpm && \
+#     dnf install -y ./amdgpu_install.rpm
+# Method 2: Manually create repo file.
+
+# ROCM_PKG_REPO_VERSION normalizes the ROCm version used in the package repo URL.
+# If the PATCH component is 0, the PATCH of the version is dropped. Otherwise no
+# modification is made.
+RUN ROCM_PKG_REPO_VERSION="$(echo ${ROCM_PKG_REPO_OVERRIDE:-$ROCM_VERSION} | sed -E 's|([^.]+\.[^.]+)\.0$|\1|')"; \
+    cat <<EOF > /etc/yum.repos.d/rocm.repo
+[ROCm-${ROCM_VERSION}]
+name=ROCm${ROCM_VERSION}
+baseurl=https://repo.radeon.com/rocm/el${ROCKY_MAJOR_VERSION}/${ROCM_PKG_REPO_VERSION}/main
+enabled=1
+priority=50
+gpgcheck=1
+gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+EOF
+
+# Development Dependencies
+# clang version == 19
+# llvm-dev == llvm-devel
+# Defaults to gcc11. On 9.6 gcc14 seems to be present.
+#   Use gcc13 to match Ubuntu24.
+RUN dnf makecache && \
+    dnf install -y \
+        boost-devel \
+        clang \
+        cmake \
+        doxygen \
+        gcc-toolset-13 \
+        gdb \
+        git \
+        hip-devel \
+        libmount-devel \
+        llvm-devel \
+        rpm-build
+
+# Configure system linker for ROCm
+RUN cat <<EOF > /etc/ld.so.conf.d/rocm.conf
+/opt/rocm/lib
+/opt/rocm/lib64
+EOF
+RUN ldconfig
+
+# Install a minimal CUDA SDK
+# HIP depends on the ROCm libraries being installed.
+# This means we are unable to have a separate CUDA+HIP image
+# without ROCm.
+RUN curl https://developer.download.nvidia.com/compute/cuda/repos/rhel${ROCKY_MAJOR_VERSION}/x86_64/cuda-rhel${ROCKY_MAJOR_VERSION}.repo \
+        -o /etc/yum.repos.d/cuda-rhel${ROCKY_MAJOR_VERSION}.repo && \
+    dnf makecache
+
+# https://gitlab.com/nvidia/container-images/cuda/blob/master/dist/12.6.1/ubuntu2404/devel/Dockerfile
+# Attempt a "minimal" CUDA Dev install.
+# libcufile-dev-X.Y == libcufile-devel-X.Y
+# libnvidia-compute-570-server == nvidia-driver-cuda + kmod-nvidia-open-dkms
+RUN dnf module enable -y nvidia-driver:570-open && \
+    dnf install -y \
+        cuda-minimal-build-12-9 \
+        kmod-nvidia-open-dkms \
+        libcufile-devel-12-9 \
+        nvidia-driver-cuda
+
+# Add ROCm and CUDA bin directories to the path
+ENV PATH=/usr/local/cuda/bin:/opt/rocm/bin:${PATH}
+
+# Environment Build Arg for ROCm
+ENV ROCM_VERSION="${ROCM_VERSION}"
+
+# .rc and .profile files are not automatically read on non-login,
+# non-interactive shells. Tell Bash to read a minimal .profile
+# when a shell of any type is opened.
+# Uncomment to prefer newer version of GCC.
+# RUN echo 'source /opt/rh/gcc-toolset-13/enable' >> ~/.bashrc
+RUN echo 'source ~/.bashrc' >> ~/.bash_profile
+ENV BASH_ENV="~/.bashrc"
+
+# AIS Code Repository Mount Point
+VOLUME /mnt/ais
+
+# Generic Mount point for container to access AIS-capable storage.
+VOLUME /mnt/ais-fs


### PR DESCRIPTION
## Motivation
Hipfile's stats collection uses several features that were added in kernel versions 5.1 and 5.3. RHEL 8 is currently a supported distribution and ships with kernel version 4.18. Stats collection is disabled on kernels older than 5.3 to resolve this issue.

## Technical Details

- Added a fallback definition for SYS_pidfd_open in sys.cpp.
- Added unit test for hipFileStatsCreateContext where syscall doesn't exist.
- Added a fallback definition for F_SEAL_FUTURE_WRITE in stats.cpp
- Added unit test for StatsContainer where flag doesn't exist.

## JIRA ID

no jira

## Test Plan

## Test Result

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
