### PR TITLE
[RCCL] Fix static build export failure when fmt is fetched via FetchContent

### DIFF
--- a/projects/rccl/CHANGELOG.md
+++ b/projects/rccl/CHANGELOG.md
@@ -23,6 +23,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 
 ### Resolved Issues
 * Fixed MSCCLPP_ENABLE_CLIP CMake build flag, which was not being properly honored.
+* Fixed static build (`BUILD_SHARED_LIBS=OFF`) failing with `install(EXPORT "rccl-targets" ...)` error when `fmt` is fetched via `FetchContent`. The `fmt-header-only` target is now scoped to the build interface and excluded from RCCL's exported usage requirements.
 
 ## Unreleased - RCCL 2.27.7 for ROCm 7.2.0
 

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -937,7 +937,11 @@ else()
 endif()
 target_link_libraries(rccl PRIVATE   dl)
 target_link_libraries(rccl PRIVATE   ${SMI_LIBRARIES})
-target_link_libraries(rccl PRIVATE fmt::fmt-header-only)
+# Wrap fmt in $<BUILD_INTERFACE:...> so it's only used while building rccl
+# and is omitted from the exported rccl-targets export set. Without this,
+# a FetchContent-built fmt-header-only target leaks into rccl's link
+# interface and breaks install(EXPORT) for static builds.
+target_link_libraries(rccl PRIVATE $<BUILD_INTERFACE:fmt::fmt-header-only>)
 if(ENABLE_ROCSHMEM)
   target_link_libraries(rccl PRIVATE ${ROCSHMEM_LIBRARY})
   target_link_libraries(rccl PRIVATE ${IBVERBS})


### PR DESCRIPTION
## Details

**Work item:** Internal

**What were the changes?**
Wrap the `fmt::fmt-header-only` link dependency of the `rccl` target in a `$<BUILD_INTERFACE:...>` generator expression so it does not leak into the exported `rccl-targets` export set.

**Why were the changes made?**
Static builds (`-DBUILD_SHARED_LIBS=OFF`) fail at CMake generate time on systems where `fmt` is not installed and RCCL falls back to `FetchContent_MakeAvailable(fmt)`:

```
-- fmt not found, fetching from source...
...
CMake Error: install(EXPORT "rccl-targets" ...) includes target "rccl"
which requires target "fmt-header-only" that is not in any export set.
CMake Generate step failed.
```

This blocks static-library builds, packaging, and consumer `find_package(rccl CONFIG)` flows on any environment without a system `fmt`.

**How was the outcome achieved?**
For static libraries, CMake propagates `PRIVATE` link dependencies into the consumer-facing `INTERFACE_LINK_LIBRARIES` (wrapped in `$<LINK_ONLY:...>`) because static libs don't link their dependencies into the archive — consumers must resolve them at their own link time. As a side effect, the `PRIVATE` link to `fmt::fmt-header-only` ends up in `rccl`'s exported usage requirements. With a system `fmt`, this is harmless (the consumer's `find_package(fmt)` re-creates the IMPORTED target). With a `FetchContent`-built `fmt`, the `fmt-header-only` target is not part of any export set, and `install(EXPORT)` validation aborts.

The fix wraps the link in `$<BUILD_INTERFACE:fmt::fmt-header-only>`, which evaluates to `fmt::fmt-header-only` while building `rccl` (preserving include dirs and compile defs from `fmt`'s header-only INTERFACE) and to the empty string in the install/export tree, so the exported `rccl-targets.cmake` no longer references `fmt-header-only`. The change is layout-symmetric for both the system-`fmt` and `FetchContent`-`fmt` paths and requires no change to consumers.

**Additional Documentation:**
Verified end-to-end on `gfx942` with ROCm 6.4.1 and CMake 3.28, with no system `fmt`:
- Configure + generate succeed (`-DBUILD_SHARED_LIBS=OFF -DCMAKE_DISABLE_FIND_PACKAGE_fmt=ON`)
- `librccl.a` and `rcclras` build cleanly
- `cmake --install` succeeds; installed `rccl-targets.cmake` contains no `fmt` references
- A minimal consumer using `find_package(rccl CONFIG)` configures successfully against the install tree

## Approval Checklist
- [x] CHANGELOG updated under `Unreleased - RCCL 2.28.3 for ROCm 7.11` → `Resolved Issues`.

Made with [Cursor](https://cursor.com)