### PR TITLE
[rocprofiler-compute] Port noise-clamp + dual-issue warnings into db_analysis

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -555,33 +555,19 @@ class db_analysis(OmniAnalyze_Base):
             return None
 
     @staticmethod
-    def calc_builtin_vars(
-        pmc_df: pd.DataFrame,
-        sys_info: dict,
-        emit_variance_warnings: bool = False,
-    ) -> pd.DataFrame:
+    def calc_builtin_vars(pmc_df: pd.DataFrame, sys_info: dict) -> pd.DataFrame:
         """Calculate built-in variables (numActiveCUs, kernelBusyCycles, etc.)"""
         # Calculate PER_XCD variables first
         for key, value in BUILD_IN_VARS.items():
             if "PER_XCD" in key:
                 sys_info[key] = db_analysis.evaluate(
-                    key,
-                    value,
-                    pmc_df,
-                    sys_info,
-                    parse=True,
-                    emit_variance_warnings=emit_variance_warnings,
+                    key, value, pmc_df, sys_info, parse=True
                 )
         # Variable dependent on PER_XCD variables
         for key, value in BUILD_IN_VARS.items():
             if "PER_XCD" not in key:
                 sys_info[key] = db_analysis.evaluate(
-                    key,
-                    value,
-                    pmc_df,
-                    sys_info,
-                    parse=True,
-                    emit_variance_warnings=emit_variance_warnings,
+                    key, value, pmc_df, sys_info, parse=True
                 )
         return pmc_df
 
@@ -593,9 +579,7 @@ class db_analysis(OmniAnalyze_Base):
         emit_variance_warnings: bool = False,
     ) -> pd.Series:
         # Calculate built-in variables
-        db_analysis.calc_builtin_vars(
-            pmc_df, sys_info, emit_variance_warnings=emit_variance_warnings
-        )
+        db_analysis.calc_builtin_vars(pmc_df, sys_info)
         # Evaluate expressions while printing warnings
         return expression_df.apply(
             lambda row: db_analysis.evaluate(
@@ -646,11 +630,7 @@ class db_analysis(OmniAnalyze_Base):
                 else pd.DataFrame()
             )
 
-            # Calculate workload-level metrics (aggregate across ALL dispatches).
-            # Variance-correction warnings and the aggregate noise-clamp summary
-            # are scoped to this pass: kernel-level evaluation runs the same
-            # expressions once per kernel and would multiply each warning by
-            # the kernel count.
+            # Variance warnings are emitted at workload-level, not per kernel.
             console_debug(f"Processing workload: {workload_path}")
             clear_noise_clamp_warnings()
             workload_values_data[workload_path] = expression_template.copy()

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -601,14 +601,9 @@ class db_analysis(OmniAnalyze_Base):
         arch_config: schema.ArchConfig,
     ) -> None:
         """Warn when VALU metrics exceed peak in the workload-level results."""
-        valu2_series = (
-            pmc_df[ValuDualIssueDetector.valu2_counter]
-            if ValuDualIssueDetector.valu2_counter in pmc_df.columns
-            else None
-        )
         detector = ValuDualIssueDetector(
             gpu_arch=sys_info.get("gpu_arch", ""),
-            valu2_series=valu2_series,
+            raw_pmc_df=pmc_df,
         )
 
         candidates: list[tuple[str, str, str]] = []
@@ -625,7 +620,7 @@ class db_analysis(OmniAnalyze_Base):
                 continue
             for metric_id, row in df.iterrows():
                 metric_name = row.get("Metric", "")
-                if metric_name in ValuDualIssueDetector.metrics:
+                if metric_name in ValuDualIssueDetector.candidate_metrics:
                     candidates.append((metric_id, metric_name, peak_col))
         if not candidates:
             return

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -14,7 +14,7 @@ import pandas as pd
 import utils.analysis_orm as orm
 from config import rocprof_compute_home
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
-from utils import utils_analysis
+from utils import schema, utils_analysis
 from utils.analysis_orm import Database
 from utils.file_io import process_pc_sampling_kernel_trace
 from utils.logger import (
@@ -36,6 +36,7 @@ from utils.metrics.aggregation import (
     to_std,
     to_sum,
 )
+from utils.metrics.common import ValuDualIssueDetector
 from utils.metrics.expression import CodeTransformer
 from utils.metrics.noise_clamper import (
     clear_noise_clamp_warnings,
@@ -592,6 +593,77 @@ class db_analysis(OmniAnalyze_Base):
             axis=1,
         )
 
+    @staticmethod
+    def validate_dual_issue_metrics(
+        pmc_df: pd.DataFrame,
+        sys_info: dict,
+        workload_values_df: pd.DataFrame,
+        arch_config: schema.ArchConfig,
+    ) -> None:
+        """Warn when VALU metrics exceed peak in the workload-level results.
+
+        Mirrors utils.metrics.evaluation_pipeline.validate_dual_issue_metrics
+        but adapted to the long-format (metric_id, value_name, value) shape
+        and flat per-workload pmc_df used by db_analysis.
+        """
+        valu2_series = (
+            pmc_df[ValuDualIssueDetector.VALU2_COUNTER]
+            if ValuDualIssueDetector.VALU2_COUNTER in pmc_df.columns
+            else None
+        )
+        detector = ValuDualIssueDetector(
+            gpu_arch=sys_info.get("gpu_arch", ""),
+            valu2_series=valu2_series,
+        )
+
+        candidates = db_analysis._resolve_dual_issue_candidates(arch_config)
+        if not candidates:
+            return
+
+        values_by_metric_id = {
+            metric_id: dict(zip(group["value_name"], group["value"]))
+            for metric_id, group in workload_values_df.groupby("metric_id")
+        }
+
+        for metric_id, metric_name, peak_col in candidates:
+            values = values_by_metric_id.get(metric_id)
+            if values is None:
+                continue
+            try:
+                value = float(values.get("Value", 0))
+                peak = float(values.get(peak_col, 0))
+            except (ValueError, TypeError):
+                continue
+            detector.check(metric_name, value, peak)
+
+    @staticmethod
+    def _resolve_dual_issue_candidates(
+        arch_config: schema.ArchConfig,
+    ) -> list[tuple[str, str, str]]:
+        """Walk arch_config metric_tables for VALU dual-issue candidate rows.
+
+        Returns (metric_id, metric_name, peak_col) for every row whose Metric
+        is a dual-issue candidate and whose source table carries both a Value
+        column and a Peak (Empirical) or Peak column.
+        """
+        candidates: list[tuple[str, str, str]] = []
+        for df_id, df in arch_config.dfs.items():
+            if arch_config.dfs_type.get(df_id) != "metric_table":
+                continue
+            if "Metric" not in df.columns or "Value" not in df.columns:
+                continue
+            if "Peak (Empirical)" in df.columns:
+                peak_col = "Peak (Empirical)"
+            elif "Peak" in df.columns:
+                peak_col = "Peak"
+            else:
+                continue
+            for metric_id, row in df.iterrows():
+                metric_name = row.get("Metric", "")
+                if metric_name in ValuDualIssueDetector.METRICS:
+                    candidates.append((metric_id, metric_name, peak_col))
+        return candidates
+
     def calc_expressions(
         self,
     ) -> tuple[dict[str, pd.DataFrame], dict[str, pd.DataFrame]]:
@@ -643,6 +715,12 @@ class db_analysis(OmniAnalyze_Base):
                 )
             )
             print_noise_clamp_summary()
+            db_analysis.validate_dual_issue_metrics(
+                pmc_df,
+                sys_info,
+                workload_values_data[workload_path],
+                self._arch_configs[sys_info["gpu_arch"]],
+            )
 
         if kernel_values_data or workload_values_data:
             console_debug("Calculated kernel-level and workload-level metric values")

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -37,7 +37,12 @@ from utils.metrics.aggregation import (
     to_sum,
 )
 from utils.metrics.expression import CodeTransformer
-from utils.metrics.noise_clamper import to_noise_clamp
+from utils.metrics.noise_clamper import (
+    clear_noise_clamp_warnings,
+    get_noise_clamp_warnings,
+    print_noise_clamp_summary,
+    to_noise_clamp,
+)
 from utils.parser import (
     PC_SAMPLING_NOT_ISSUE_PREFIX,
 )
@@ -472,6 +477,7 @@ class db_analysis(OmniAnalyze_Base):
         pmc_df: pd.DataFrame,
         sys_info: dict[str, Any],  # noqa ANN401
         parse: bool = False,
+        emit_variance_warnings: bool = False,
     ) -> Any:  # noqa ANN401
         if parse:
             value = re.sub(
@@ -493,6 +499,7 @@ class db_analysis(OmniAnalyze_Base):
                 value,
             )
         try:
+            prev_noise_clamp_count = get_noise_clamp_warnings()["count"]
             eval_result = eval(
                 compile(value, "<string>", "eval"),
                 {},  # no globals
@@ -536,35 +543,59 @@ class db_analysis(OmniAnalyze_Base):
                         "likely due to missing counter data."
                     )
                 return None
-            else:
-                return eval_result
+
+            if (
+                emit_variance_warnings
+                and get_noise_clamp_warnings()["count"] > prev_noise_clamp_count
+            ):
+                console_warning(f"Variance corrected for metric: {name}")
+            return eval_result
         except Exception as e:
             console_warning(f"Failed to evaluate expression for {name}: {value} - {e}")
             return None
 
     @staticmethod
-    def calc_builtin_vars(pmc_df: pd.DataFrame, sys_info: dict) -> pd.DataFrame:
+    def calc_builtin_vars(
+        pmc_df: pd.DataFrame,
+        sys_info: dict,
+        emit_variance_warnings: bool = False,
+    ) -> pd.DataFrame:
         """Calculate built-in variables (numActiveCUs, kernelBusyCycles, etc.)"""
         # Calculate PER_XCD variables first
         for key, value in BUILD_IN_VARS.items():
             if "PER_XCD" in key:
                 sys_info[key] = db_analysis.evaluate(
-                    key, value, pmc_df, sys_info, parse=True
+                    key,
+                    value,
+                    pmc_df,
+                    sys_info,
+                    parse=True,
+                    emit_variance_warnings=emit_variance_warnings,
                 )
         # Variable dependent on PER_XCD variables
         for key, value in BUILD_IN_VARS.items():
             if "PER_XCD" not in key:
                 sys_info[key] = db_analysis.evaluate(
-                    key, value, pmc_df, sys_info, parse=True
+                    key,
+                    value,
+                    pmc_df,
+                    sys_info,
+                    parse=True,
+                    emit_variance_warnings=emit_variance_warnings,
                 )
         return pmc_df
 
     @staticmethod
     def calc_dataframe_expressions(
-        pmc_df: pd.DataFrame, sys_info: dict, expression_df: pd.DataFrame
+        pmc_df: pd.DataFrame,
+        sys_info: dict,
+        expression_df: pd.DataFrame,
+        emit_variance_warnings: bool = False,
     ) -> pd.Series:
         # Calculate built-in variables
-        db_analysis.calc_builtin_vars(pmc_df, sys_info)
+        db_analysis.calc_builtin_vars(
+            pmc_df, sys_info, emit_variance_warnings=emit_variance_warnings
+        )
         # Evaluate expressions while printing warnings
         return expression_df.apply(
             lambda row: db_analysis.evaluate(
@@ -572,6 +603,7 @@ class db_analysis(OmniAnalyze_Base):
                 row["value"],
                 pmc_df,
                 sys_info,
+                emit_variance_warnings=emit_variance_warnings,
             ),
             axis=1,
         )
@@ -614,15 +646,23 @@ class db_analysis(OmniAnalyze_Base):
                 else pd.DataFrame()
             )
 
-            # Calculate workload-level metrics (aggregate across ALL dispatches)
+            # Calculate workload-level metrics (aggregate across ALL dispatches).
+            # Variance-correction warnings and the aggregate noise-clamp summary
+            # are scoped to this pass: kernel-level evaluation runs the same
+            # expressions once per kernel and would multiply each warning by
+            # the kernel count.
+            console_debug(f"Processing workload: {workload_path}")
+            clear_noise_clamp_warnings()
             workload_values_data[workload_path] = expression_template.copy()
             workload_values_data[workload_path]["value"] = (
                 db_analysis.calc_dataframe_expressions(
                     pmc_df,
                     sys_info.copy(),
                     workload_values_data[workload_path],
+                    emit_variance_warnings=True,
                 )
             )
+            print_noise_clamp_summary()
 
         if kernel_values_data or workload_values_data:
             console_debug("Calculated kernel-level and workload-level metric values")

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -600,15 +600,10 @@ class db_analysis(OmniAnalyze_Base):
         workload_values_df: pd.DataFrame,
         arch_config: schema.ArchConfig,
     ) -> None:
-        """Warn when VALU metrics exceed peak in the workload-level results.
-
-        Mirrors utils.metrics.evaluation_pipeline.validate_dual_issue_metrics
-        but adapted to the long-format (metric_id, value_name, value) shape
-        and flat per-workload pmc_df used by db_analysis.
-        """
+        """Warn when VALU metrics exceed peak in the workload-level results."""
         valu2_series = (
-            pmc_df[ValuDualIssueDetector.VALU2_COUNTER]
-            if ValuDualIssueDetector.VALU2_COUNTER in pmc_df.columns
+            pmc_df[ValuDualIssueDetector.valu2_counter]
+            if ValuDualIssueDetector.valu2_counter in pmc_df.columns
             else None
         )
         detector = ValuDualIssueDetector(
@@ -616,7 +611,22 @@ class db_analysis(OmniAnalyze_Base):
             valu2_series=valu2_series,
         )
 
-        candidates = db_analysis._resolve_dual_issue_candidates(arch_config)
+        candidates: list[tuple[str, str, str]] = []
+        for df_id, df in arch_config.dfs.items():
+            if arch_config.dfs_type.get(df_id) != "metric_table":
+                continue
+            if "Metric" not in df.columns or "Value" not in df.columns:
+                continue
+            if "Peak (Empirical)" in df.columns:
+                peak_col = "Peak (Empirical)"
+            elif "Peak" in df.columns:
+                peak_col = "Peak"
+            else:
+                continue
+            for metric_id, row in df.iterrows():
+                metric_name = row.get("Metric", "")
+                if metric_name in ValuDualIssueDetector.metrics:
+                    candidates.append((metric_id, metric_name, peak_col))
         if not candidates:
             return
 
@@ -635,34 +645,6 @@ class db_analysis(OmniAnalyze_Base):
             except (ValueError, TypeError):
                 continue
             detector.check(metric_name, value, peak)
-
-    @staticmethod
-    def _resolve_dual_issue_candidates(
-        arch_config: schema.ArchConfig,
-    ) -> list[tuple[str, str, str]]:
-        """Walk arch_config metric_tables for VALU dual-issue candidate rows.
-
-        Returns (metric_id, metric_name, peak_col) for every row whose Metric
-        is a dual-issue candidate and whose source table carries both a Value
-        column and a Peak (Empirical) or Peak column.
-        """
-        candidates: list[tuple[str, str, str]] = []
-        for df_id, df in arch_config.dfs.items():
-            if arch_config.dfs_type.get(df_id) != "metric_table":
-                continue
-            if "Metric" not in df.columns or "Value" not in df.columns:
-                continue
-            if "Peak (Empirical)" in df.columns:
-                peak_col = "Peak (Empirical)"
-            elif "Peak" in df.columns:
-                peak_col = "Peak"
-            else:
-                continue
-            for metric_id, row in df.iterrows():
-                metric_name = row.get("Metric", "")
-                if metric_name in ValuDualIssueDetector.METRICS:
-                    candidates.append((metric_id, metric_name, peak_col))
-        return candidates
 
     def calc_expressions(
         self,

--- a/projects/rocprofiler-compute/src/utils/metrics/common.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/common.py
@@ -39,12 +39,15 @@ class ValuDualIssueDetector:
         self._dual_issue_confirmed = self._compute_dual_issue_confirmed(valu2_series)
 
     def check(self, metric_name: str, value: float, peak: float) -> None:
-        """Emit a dual-issue warning if metric is a candidate and value > peak."""
+        """Emit dual-issue warning above peak; counter-issue warning above 2x peak."""
         if metric_name not in self.metrics:
             return
         if not (peak > 0 and value > peak):
             return
-        console_warning(self._build_warning(metric_name))
+        if value > 2 * peak:
+            console_warning(self._build_counter_issue_warning(metric_name))
+        else:
+            console_warning(self._build_warning(metric_name))
 
     def _compute_dual_issue_confirmed(
         self,
@@ -55,6 +58,17 @@ class ValuDualIssueDetector:
         if valu2_series is None:
             return False
         return float(valu2_series.sum()) > 0
+
+    def _build_counter_issue_warning(self, metric_name: str) -> str:
+        if metric_name in self.valu_utilization_metrics:
+            return (
+                "VALU Utilization exceeds twice the theoretical peak, "
+                "indicating an issue in raw performance counters."
+            )
+        return (
+            "VALU FLOPs exceeds twice the theoretical peak, "
+            "indicating an issue in raw performance counters."
+        )
 
     def _build_warning(self, metric_name: str) -> str:
         if metric_name in self.valu_utilization_metrics:

--- a/projects/rocprofiler-compute/src/utils/metrics/common.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/common.py
@@ -1,9 +1,9 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
-"""Shared metric-evaluation helpers used by both eval_pipeline and db_analysis."""
+"""Shared metric-evaluation helpers used by evaluation_pipeline and analysis_db."""
 
-from __future__ import annotations
+from typing import Optional
 
 import pandas as pd
 
@@ -11,22 +11,19 @@ from utils.logger import console_warning
 
 
 class ValuDualIssueDetector:
-    """Detects VALU metrics exceeding theoretical peak due to dual-issue.
+    """Per-workload detector for VALU metrics exceeding theoretical peak.
 
-    Configured per workload with the workload's gpu_arch and an optional
-    SQ_ACTIVE_INST_VALU2 counter Series. Each call to check() evaluates a
-    (metric_name, value, peak) triple and emits a console_warning if the
-    value exceeds peak and the metric is one of the dual-issue candidates.
-    For gfx950, a non-zero SQ_ACTIVE_INST_VALU2 sum confirms dual-issue
-    activity and is appended to the warning.
+    - Configured with gpu_arch and an optional SQ_ACTIVE_INST_VALU2 series.
+    - check() emits the dual-issue console_warning when a candidate metric's
+      value exceeds peak; on gfx950 a non-zero VALU2 counter is appended.
     """
 
-    VALU_UTILIZATION_METRICS = ("VALU Utilization",)
-    VALU_FLOPS_METRICS = ("VALU FLOPs (F64)",)
-    METRICS = VALU_UTILIZATION_METRICS + VALU_FLOPS_METRICS
-    VALU2_COUNTER = "SQ_ACTIVE_INST_VALU2"
-    GFX950 = "gfx950"
-    FAQ_URL = (
+    valu_utilization_metrics = ("VALU Utilization",)
+    valu_flops_metrics = ("VALU FLOPs (F64)",)
+    metrics = valu_utilization_metrics + valu_flops_metrics
+    valu2_counter = "SQ_ACTIVE_INST_VALU2"
+    gfx950 = "gfx950"
+    faq_url = (
         "https://rocm.docs.amd.com/projects/"
         "rocprofiler-compute/en/latest/reference/"
         "faq.html#why-does-valu-utilization-exceed-"
@@ -36,14 +33,14 @@ class ValuDualIssueDetector:
     def __init__(
         self,
         gpu_arch: str,
-        valu2_series: pd.Series | None = None,
+        valu2_series: Optional[pd.Series] = None,
     ) -> None:
         self._gpu_arch = gpu_arch
         self._dual_issue_confirmed = self._compute_dual_issue_confirmed(valu2_series)
 
     def check(self, metric_name: str, value: float, peak: float) -> None:
         """Emit a dual-issue warning if metric is a candidate and value > peak."""
-        if metric_name not in self.METRICS:
+        if metric_name not in self.metrics:
             return
         if not (peak > 0 and value > peak):
             return
@@ -51,28 +48,28 @@ class ValuDualIssueDetector:
 
     def _compute_dual_issue_confirmed(
         self,
-        valu2_series: pd.Series | None,
+        valu2_series: Optional[pd.Series],
     ) -> bool:
-        if self._gpu_arch != self.GFX950:
+        if self._gpu_arch != self.gfx950:
             return False
         if valu2_series is None:
             return False
         return float(valu2_series.sum()) > 0
 
     def _build_warning(self, metric_name: str) -> str:
-        if metric_name in self.VALU_UTILIZATION_METRICS:
+        if metric_name in self.valu_utilization_metrics:
             msg = (
                 "VALU Utilization can go up to 200% "
                 "because CU can dual-issue instructions. "
-                f"See {self.FAQ_URL} for more information."
+                f"See {self.faq_url} for more information."
             )
         else:
             msg = (
                 "VALU FLOPs can exceed the peak value "
                 "because these instructions can be "
                 "dual-issued in specific circumstances. "
-                f"See {self.FAQ_URL} for more information."
+                f"See {self.faq_url} for more information."
             )
-        if self._gpu_arch == self.GFX950 and self._dual_issue_confirmed:
+        if self._gpu_arch == self.gfx950 and self._dual_issue_confirmed:
             msg += " (Dual-issue activity detected via SQ_ACTIVE_INST_VALU2 counter)"
         return msg

--- a/projects/rocprofiler-compute/src/utils/metrics/common.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/common.py
@@ -1,0 +1,78 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+"""Shared metric-evaluation helpers used by both eval_pipeline and db_analysis."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from utils.logger import console_warning
+
+
+class ValuDualIssueDetector:
+    """Detects VALU metrics exceeding theoretical peak due to dual-issue.
+
+    Configured per workload with the workload's gpu_arch and an optional
+    SQ_ACTIVE_INST_VALU2 counter Series. Each call to check() evaluates a
+    (metric_name, value, peak) triple and emits a console_warning if the
+    value exceeds peak and the metric is one of the dual-issue candidates.
+    For gfx950, a non-zero SQ_ACTIVE_INST_VALU2 sum confirms dual-issue
+    activity and is appended to the warning.
+    """
+
+    VALU_UTILIZATION_METRICS = ("VALU Utilization",)
+    VALU_FLOPS_METRICS = ("VALU FLOPs (F64)",)
+    METRICS = VALU_UTILIZATION_METRICS + VALU_FLOPS_METRICS
+    VALU2_COUNTER = "SQ_ACTIVE_INST_VALU2"
+    GFX950 = "gfx950"
+    FAQ_URL = (
+        "https://rocm.docs.amd.com/projects/"
+        "rocprofiler-compute/en/latest/reference/"
+        "faq.html#why-does-valu-utilization-exceed-"
+        "the-theoretical-peak"
+    )
+
+    def __init__(
+        self,
+        gpu_arch: str,
+        valu2_series: pd.Series | None = None,
+    ) -> None:
+        self._gpu_arch = gpu_arch
+        self._dual_issue_confirmed = self._compute_dual_issue_confirmed(valu2_series)
+
+    def check(self, metric_name: str, value: float, peak: float) -> None:
+        """Emit a dual-issue warning if metric is a candidate and value > peak."""
+        if metric_name not in self.METRICS:
+            return
+        if not (peak > 0 and value > peak):
+            return
+        console_warning(self._build_warning(metric_name))
+
+    def _compute_dual_issue_confirmed(
+        self,
+        valu2_series: pd.Series | None,
+    ) -> bool:
+        if self._gpu_arch != self.GFX950:
+            return False
+        if valu2_series is None:
+            return False
+        return float(valu2_series.sum()) > 0
+
+    def _build_warning(self, metric_name: str) -> str:
+        if metric_name in self.VALU_UTILIZATION_METRICS:
+            msg = (
+                "VALU Utilization can go up to 200% "
+                "because CU can dual-issue instructions. "
+                f"See {self.FAQ_URL} for more information."
+            )
+        else:
+            msg = (
+                "VALU FLOPs can exceed the peak value "
+                "because these instructions can be "
+                "dual-issued in specific circumstances. "
+                f"See {self.FAQ_URL} for more information."
+            )
+        if self._gpu_arch == self.GFX950 and self._dual_issue_confirmed:
+            msg += " (Dual-issue activity detected via SQ_ACTIVE_INST_VALU2 counter)"
+        return msg

--- a/projects/rocprofiler-compute/src/utils/metrics/common.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/common.py
@@ -3,8 +3,6 @@
 
 """Shared metric-evaluation helpers used by evaluation_pipeline and analysis_db."""
 
-from typing import Optional
-
 import pandas as pd
 
 from utils.logger import console_warning
@@ -13,16 +11,13 @@ from utils.logger import console_warning
 class ValuDualIssueDetector:
     """Per-workload detector for VALU metrics exceeding theoretical peak.
 
-    - Configured with gpu_arch and an optional SQ_ACTIVE_INST_VALU2 series.
-    - check() emits the dual-issue console_warning when a candidate metric's
-      value exceeds peak; on gfx950 a non-zero VALU2 counter is appended.
+    - check() emits a dual-issue warning above peak and a counter-issue
+      warning above 2x peak on any arch.
+    - On gfx950 a non-zero SQ_ACTIVE_INST_VALU2 sum suffixes the dual-issue
+      message with hardware confirmation.
     """
 
-    valu_utilization_metrics = ("VALU Utilization",)
-    valu_flops_metrics = ("VALU FLOPs (F64)",)
-    metrics = valu_utilization_metrics + valu_flops_metrics
-    valu2_counter = "SQ_ACTIVE_INST_VALU2"
-    gfx950 = "gfx950"
+    candidate_metrics = {"VALU Utilization", "VALU FLOPs (F64)"}
     faq_url = (
         "https://rocm.docs.amd.com/projects/"
         "rocprofiler-compute/en/latest/reference/"
@@ -30,17 +25,16 @@ class ValuDualIssueDetector:
         "the-theoretical-peak"
     )
 
-    def __init__(
-        self,
-        gpu_arch: str,
-        valu2_series: Optional[pd.Series] = None,
-    ) -> None:
-        self._gpu_arch = gpu_arch
-        self._dual_issue_confirmed = self._compute_dual_issue_confirmed(valu2_series)
+    def __init__(self, gpu_arch: str, raw_pmc_df: pd.DataFrame) -> None:
+        self._dual_issue_confirmed = (
+            gpu_arch == "gfx950"
+            and "SQ_ACTIVE_INST_VALU2" in raw_pmc_df.columns
+            and float(raw_pmc_df["SQ_ACTIVE_INST_VALU2"].sum()) > 0
+        )
 
     def check(self, metric_name: str, value: float, peak: float) -> None:
         """Emit dual-issue warning above peak; counter-issue warning above 2x peak."""
-        if metric_name not in self.metrics:
+        if metric_name not in self.candidate_metrics:
             return
         if not (peak > 0 and value > peak):
             return
@@ -49,18 +43,8 @@ class ValuDualIssueDetector:
         else:
             console_warning(self._build_warning(metric_name))
 
-    def _compute_dual_issue_confirmed(
-        self,
-        valu2_series: Optional[pd.Series],
-    ) -> bool:
-        if self._gpu_arch != self.gfx950:
-            return False
-        if valu2_series is None:
-            return False
-        return float(valu2_series.sum()) > 0
-
     def _build_counter_issue_warning(self, metric_name: str) -> str:
-        if metric_name in self.valu_utilization_metrics:
+        if metric_name == "VALU Utilization":
             return (
                 "VALU Utilization exceeds twice the theoretical peak, "
                 "indicating an issue in raw performance counters."
@@ -71,7 +55,7 @@ class ValuDualIssueDetector:
         )
 
     def _build_warning(self, metric_name: str) -> str:
-        if metric_name in self.valu_utilization_metrics:
+        if metric_name == "VALU Utilization":
             msg = (
                 "VALU Utilization can go up to 200% "
                 "because CU can dual-issue instructions. "
@@ -84,6 +68,6 @@ class ValuDualIssueDetector:
                 "dual-issued in specific circumstances. "
                 f"See {self.faq_url} for more information."
             )
-        if self._gpu_arch == self.gfx950 and self._dual_issue_confirmed:
+        if self._dual_issue_confirmed:
             msg += " (Dual-issue activity detected via SQ_ACTIVE_INST_VALU2 counter)"
         return msg

--- a/projects/rocprofiler-compute/src/utils/metrics/evaluation_pipeline.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/evaluation_pipeline.py
@@ -237,19 +237,12 @@ def validate_dual_issue_metrics(
     sys_info: pd.Series,
     raw_pmc_df: pd.DataFrame,
 ) -> None:
-    """
-    Check if VALU Utilization or VALU FLOPs metrics exceed theoretical peak.
-    Warns about dual-issue behavior.
-    For MI350 (gfx950), additionally verify SQ_ACTIVE_INST_VALU2 counter.
-    """
-    valu2_series = None
-    if isinstance(raw_pmc_df, dict):
-        pmc_perf = raw_pmc_df.get("pmc_perf")
-        if (
-            pmc_perf is not None
-            and ValuDualIssueDetector.valu2_counter in pmc_perf.columns
-        ):
-            valu2_series = pmc_perf[ValuDualIssueDetector.valu2_counter]
+    """Warn when VALU metrics exceed peak in the eval_metric results."""
+    valu2_series = (
+        raw_pmc_df[ValuDualIssueDetector.valu2_counter]
+        if ValuDualIssueDetector.valu2_counter in raw_pmc_df.columns
+        else None
+    )
     detector = ValuDualIssueDetector(
         gpu_arch=sys_info.get("gpu_arch", ""),
         valu2_series=valu2_series,

--- a/projects/rocprofiler-compute/src/utils/metrics/evaluation_pipeline.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/evaluation_pipeline.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 
 from utils.logger import console_error, console_warning, demarcate
+from utils.metrics.common import ValuDualIssueDetector
 from utils.metrics.debug_row_tracker import DebugRowTracker, debug_row_tracker
 from utils.metrics.expression import build_eval_string
 from utils.metrics.metric_evaluator import MetricEvaluator
@@ -241,11 +242,10 @@ def validate_dual_issue_metrics(
     Warns about dual-issue behavior.
     For MI350 (gfx950), additionally verify SQ_ACTIVE_INST_VALU2 counter.
     """
-    gpu_arch = sys_info.get("gpu_arch", "")
-
-    # Metrics to check for dual-issue warnings
-    valu_utilization_metrics = ["VALU Utilization"]
-    valu_flops_metrics = ["VALU FLOPs (F64)"]
+    detector = ValuDualIssueDetector(
+        gpu_arch=sys_info.get("gpu_arch", ""),
+        valu2_series=_resolve_valu2_series(raw_pmc_df),
+    )
 
     for df_id, df in dfs.items():
         if dfs_type[df_id] != "metric_table":
@@ -262,53 +262,28 @@ def validate_dual_issue_metrics(
         for _, row in df.iterrows():
             metric_name = row.get("Metric", "")
 
-            if metric_name not in valu_utilization_metrics + valu_flops_metrics:
+            if metric_name not in ValuDualIssueDetector.METRICS:
                 continue
 
             try:
                 value = float(row.get("Value", 0))
                 peak = float(row.get(peak_col, 0))
-
-                if peak > 0 and value > peak:
-                    dual_issue_confirmed = False
-                    if (
-                        gpu_arch == "gfx950"
-                        and "SQ_ACTIVE_INST_VALU2" in raw_pmc_df.columns
-                    ):
-                        valu2_sum = raw_pmc_df["SQ_ACTIVE_INST_VALU2"].sum()
-                        if valu2_sum > 0:
-                            dual_issue_confirmed = True
-
-                    # Determine warning message based on metric type
-                    faq_url = (
-                        "https://rocm.docs.amd.com/projects/"
-                        "rocprofiler-compute/en/latest/reference/"
-                        "faq.html#why-does-valu-utilization-exceed-"
-                        "the-theoretical-peak"
-                    )
-
-                    if metric_name in valu_utilization_metrics:
-                        warning_msg = (
-                            "VALU Utilization can go up to 200% "
-                            "because CU can dual-issue instructions. "
-                            f"See {faq_url} for more information."
-                        )
-                    else:  # VALU FLOPs metrics
-                        warning_msg = (
-                            "VALU FLOPs can exceed the peak value "
-                            "because these instructions can be "
-                            "dual-issued in specific circumstances. "
-                            f"See {faq_url} for more information."
-                        )
-
-                    if gpu_arch == "gfx950" and dual_issue_confirmed:
-                        warning_msg += (
-                            " (Dual-issue activity detected "
-                            "via SQ_ACTIVE_INST_VALU2 counter)"
-                        )
-
-                    console_warning(warning_msg)
-
             except (ValueError, TypeError):
                 # Skip if the value or peak cannot be converted to a float
                 continue
+
+            detector.check(metric_name, value, peak)
+
+
+def _resolve_valu2_series(
+    raw_pmc_df: pd.DataFrame | dict,
+) -> pd.Series | None:
+    """Pull the SQ_ACTIVE_INST_VALU2 column from raw PMC data, or None if absent."""
+    if not isinstance(raw_pmc_df, dict):
+        return None
+    pmc_perf = raw_pmc_df.get("pmc_perf")
+    if pmc_perf is None:
+        return None
+    if ValuDualIssueDetector.VALU2_COUNTER not in pmc_perf.columns:
+        return None
+    return pmc_perf[ValuDualIssueDetector.VALU2_COUNTER]

--- a/projects/rocprofiler-compute/src/utils/metrics/evaluation_pipeline.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/evaluation_pipeline.py
@@ -238,14 +238,9 @@ def validate_dual_issue_metrics(
     raw_pmc_df: pd.DataFrame,
 ) -> None:
     """Warn when VALU metrics exceed peak in the eval_metric results."""
-    valu2_series = (
-        raw_pmc_df[ValuDualIssueDetector.valu2_counter]
-        if ValuDualIssueDetector.valu2_counter in raw_pmc_df.columns
-        else None
-    )
     detector = ValuDualIssueDetector(
         gpu_arch=sys_info.get("gpu_arch", ""),
-        valu2_series=valu2_series,
+        raw_pmc_df=raw_pmc_df,
     )
 
     for df_id, df in dfs.items():
@@ -253,24 +248,21 @@ def validate_dual_issue_metrics(
             continue
         if "Metric" not in df.columns or "Value" not in df.columns:
             continue
-
-        has_peak_column = "Peak (Empirical)" in df.columns or "Peak" in df.columns
-        peak_col = "Peak (Empirical)" if "Peak (Empirical)" in df.columns else "Peak"
-
-        if not has_peak_column:
+        if "Peak (Empirical)" in df.columns:
+            peak_col = "Peak (Empirical)"
+        elif "Peak" in df.columns:
+            peak_col = "Peak"
+        else:
             continue
 
         for _, row in df.iterrows():
             metric_name = row.get("Metric", "")
-
-            if metric_name not in ValuDualIssueDetector.metrics:
+            if metric_name not in ValuDualIssueDetector.candidate_metrics:
                 continue
-
             try:
                 value = float(row.get("Value", 0))
                 peak = float(row.get(peak_col, 0))
             except (ValueError, TypeError):
-                # Skip if the value or peak cannot be converted to a float
+                # DB cells may be non-numeric (e.g. "N/A"); skip those.
                 continue
-
             detector.check(metric_name, value, peak)

--- a/projects/rocprofiler-compute/src/utils/metrics/evaluation_pipeline.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/evaluation_pipeline.py
@@ -242,9 +242,17 @@ def validate_dual_issue_metrics(
     Warns about dual-issue behavior.
     For MI350 (gfx950), additionally verify SQ_ACTIVE_INST_VALU2 counter.
     """
+    valu2_series = None
+    if isinstance(raw_pmc_df, dict):
+        pmc_perf = raw_pmc_df.get("pmc_perf")
+        if (
+            pmc_perf is not None
+            and ValuDualIssueDetector.valu2_counter in pmc_perf.columns
+        ):
+            valu2_series = pmc_perf[ValuDualIssueDetector.valu2_counter]
     detector = ValuDualIssueDetector(
         gpu_arch=sys_info.get("gpu_arch", ""),
-        valu2_series=_resolve_valu2_series(raw_pmc_df),
+        valu2_series=valu2_series,
     )
 
     for df_id, df in dfs.items():
@@ -262,7 +270,7 @@ def validate_dual_issue_metrics(
         for _, row in df.iterrows():
             metric_name = row.get("Metric", "")
 
-            if metric_name not in ValuDualIssueDetector.METRICS:
+            if metric_name not in ValuDualIssueDetector.metrics:
                 continue
 
             try:
@@ -273,17 +281,3 @@ def validate_dual_issue_metrics(
                 continue
 
             detector.check(metric_name, value, peak)
-
-
-def _resolve_valu2_series(
-    raw_pmc_df: pd.DataFrame | dict,
-) -> pd.Series | None:
-    """Pull the SQ_ACTIVE_INST_VALU2 column from raw PMC data, or None if absent."""
-    if not isinstance(raw_pmc_df, dict):
-        return None
-    pmc_perf = raw_pmc_df.get("pmc_perf")
-    if pmc_perf is None:
-        return None
-    if ValuDualIssueDetector.VALU2_COUNTER not in pmc_perf.columns:
-        return None
-    return pmc_perf[ValuDualIssueDetector.VALU2_COUNTER]

--- a/projects/rocprofiler-compute/tests/test_analysis_db.py
+++ b/projects/rocprofiler-compute/tests/test_analysis_db.py
@@ -510,7 +510,7 @@ def test_validate_dual_issue_metrics_appends_valu2_suffix_on_gfx950():
         "value": [150.0, 100.0],
     })
     pmc_df = pd.DataFrame({
-        ValuDualIssueDetector.VALU2_COUNTER: [1, 2, 3],
+        ValuDualIssueDetector.valu2_counter: [1, 2, 3],
     })
 
     with patch("utils.metrics.common.console_warning") as console_warning_mock:

--- a/projects/rocprofiler-compute/tests/test_analysis_db.py
+++ b/projects/rocprofiler-compute/tests/test_analysis_db.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 
 from rocprof_compute_analyze.analysis_db import db_analysis
+from utils.metrics.common import ValuDualIssueDetector
 from utils.metrics.noise_clamper import (
     clear_noise_clamp_warnings,
     get_noise_clamp_warnings,
@@ -337,13 +338,14 @@ def test_calc_expressions_noise_clamp():
         "value_name": ["clamped"],
         "value": [noise_clamp_expression],
     })
-    sys_info_df = pd.DataFrame([{"placeholder": 1}])
+    sys_info_df = pd.DataFrame([{"placeholder": 1, "gpu_arch": "gfx942"}])
 
     analyzer = db_analysis(MagicMock(), {})
     analyzer._pmc_df_per_workload = {workload_path: pmc_df}
     analyzer._metric_expression_data_per_workload = {workload_path: expression_template}
     analyzer._roofline_ceilings_per_workload = {workload_path: {}}
     analyzer._runs = {workload_path: MagicMock(sys_info=sys_info_df)}
+    analyzer._arch_configs = MagicMock()
 
     # Direct evaluate kwarg behavior.
     clear_noise_clamp_warnings()
@@ -394,6 +396,7 @@ def test_calc_expressions_noise_clamp():
         patch(
             "rocprof_compute_analyze.analysis_db.print_noise_clamp_summary"
         ) as print_noise_clamp_summary_mock,
+        patch.object(db_analysis, "validate_dual_issue_metrics"),
     ):
         analyzer.calc_expressions()
 
@@ -406,3 +409,139 @@ def test_calc_expressions_noise_clamp():
     assert "1.1 - clamped" in variance_warning_calls[0].args[0]
     print_noise_clamp_summary_mock.assert_called_once()
     assert get_noise_clamp_warnings()["count"] >= 1
+
+
+# =============================================================================
+# Dual-issue VALU validation tests
+# =============================================================================
+
+
+def _make_dual_issue_arch_config(metric_name: str, peak_col: str = "Peak"):
+    """Build an arch_config stub with a metric_table carrying one VALU row."""
+    metric_df = pd.DataFrame(
+        {
+            "Metric": [metric_name],
+            "Value": ["unused_expression"],
+            peak_col: ["unused_peak_expression"],
+        },
+        index=pd.Index(["1.1"], name="Metric_ID"),
+    )
+    arch_config = MagicMock()
+    arch_config.dfs = {201: metric_df}
+    arch_config.dfs_type = {201: "metric_table"}
+    return arch_config
+
+
+def test_validate_dual_issue_metrics_emits_warning_above_peak():
+    """Long-format VALU Utilization above peak triggers the dual-issue warning."""
+    arch_config = _make_dual_issue_arch_config("VALU Utilization")
+    workload_values_df = pd.DataFrame({
+        "metric_id": ["1.1", "1.1"],
+        "value_name": ["Value", "Peak"],
+        "value": [150.0, 100.0],
+    })
+    pmc_df = pd.DataFrame({"GRBM_GUI_ACTIVE": [1000]})
+
+    with patch("utils.metrics.common.console_warning") as console_warning_mock:
+        db_analysis.validate_dual_issue_metrics(
+            pmc_df,
+            {"gpu_arch": "gfx942"},
+            workload_values_df,
+            arch_config,
+        )
+
+    console_warning_mock.assert_called_once()
+    msg = console_warning_mock.call_args.args[0]
+    assert "VALU Utilization can go up to 200%" in msg
+
+
+def test_validate_dual_issue_metrics_silent_below_peak():
+    """Below-peak VALU Utilization stays silent."""
+    arch_config = _make_dual_issue_arch_config("VALU Utilization")
+    workload_values_df = pd.DataFrame({
+        "metric_id": ["1.1", "1.1"],
+        "value_name": ["Value", "Peak"],
+        "value": [80.0, 100.0],
+    })
+    pmc_df = pd.DataFrame({"GRBM_GUI_ACTIVE": [1000]})
+
+    with patch("utils.metrics.common.console_warning") as console_warning_mock:
+        db_analysis.validate_dual_issue_metrics(
+            pmc_df,
+            {"gpu_arch": "gfx942"},
+            workload_values_df,
+            arch_config,
+        )
+
+    console_warning_mock.assert_not_called()
+
+
+def test_validate_dual_issue_metrics_uses_peak_empirical_fallback():
+    """Peak (Empirical) column is preferred over Peak when both are absent."""
+    arch_config = _make_dual_issue_arch_config(
+        "VALU FLOPs (F64)", peak_col="Peak (Empirical)"
+    )
+    workload_values_df = pd.DataFrame({
+        "metric_id": ["1.1", "1.1"],
+        "value_name": ["Value", "Peak (Empirical)"],
+        "value": [600.0, 400.0],
+    })
+    pmc_df = pd.DataFrame({"GRBM_GUI_ACTIVE": [1000]})
+
+    with patch("utils.metrics.common.console_warning") as console_warning_mock:
+        db_analysis.validate_dual_issue_metrics(
+            pmc_df,
+            {"gpu_arch": "gfx942"},
+            workload_values_df,
+            arch_config,
+        )
+
+    console_warning_mock.assert_called_once()
+    msg = console_warning_mock.call_args.args[0]
+    assert "VALU FLOPs can exceed the peak value" in msg
+
+
+def test_validate_dual_issue_metrics_appends_valu2_suffix_on_gfx950():
+    """gfx950 with non-zero SQ_ACTIVE_INST_VALU2 appends the confirmation."""
+    arch_config = _make_dual_issue_arch_config("VALU Utilization")
+    workload_values_df = pd.DataFrame({
+        "metric_id": ["1.1", "1.1"],
+        "value_name": ["Value", "Peak"],
+        "value": [150.0, 100.0],
+    })
+    pmc_df = pd.DataFrame({
+        ValuDualIssueDetector.VALU2_COUNTER: [1, 2, 3],
+    })
+
+    with patch("utils.metrics.common.console_warning") as console_warning_mock:
+        db_analysis.validate_dual_issue_metrics(
+            pmc_df,
+            {"gpu_arch": "gfx950"},
+            workload_values_df,
+            arch_config,
+        )
+
+    msg = console_warning_mock.call_args.args[0]
+    assert "Dual-issue activity detected via SQ_ACTIVE_INST_VALU2 counter" in msg
+
+
+def test_validate_dual_issue_metrics_skips_non_metric_table_dfs():
+    """dfs entries whose dfs_type is not metric_table are ignored."""
+    arch_config = _make_dual_issue_arch_config("VALU Utilization")
+    arch_config.dfs_type = {201: "raw_csv_table"}
+    workload_values_df = pd.DataFrame({
+        "metric_id": ["1.1", "1.1"],
+        "value_name": ["Value", "Peak"],
+        "value": [150.0, 100.0],
+    })
+    pmc_df = pd.DataFrame({"GRBM_GUI_ACTIVE": [1000]})
+
+    with patch("utils.metrics.common.console_warning") as console_warning_mock:
+        db_analysis.validate_dual_issue_metrics(
+            pmc_df,
+            {"gpu_arch": "gfx942"},
+            workload_values_df,
+            arch_config,
+        )
+
+    console_warning_mock.assert_not_called()

--- a/projects/rocprofiler-compute/tests/test_analysis_db.py
+++ b/projects/rocprofiler-compute/tests/test_analysis_db.py
@@ -358,9 +358,9 @@ def test_calc_expressions_noise_clamp():
             emit_variance_warnings=True,
         )
         variance_warning_calls = [
-            c
-            for c in console_warning_mock.call_args_list
-            if "Variance corrected for metric: direct_test" in c.args[0]
+            warning_call
+            for warning_call in console_warning_mock.call_args_list
+            if "Variance corrected for metric: direct_test" in warning_call.args[0]
         ]
         assert len(variance_warning_calls) == 1
         assert get_noise_clamp_warnings()["count"] >= 1
@@ -378,9 +378,9 @@ def test_calc_expressions_noise_clamp():
         )
         assert get_noise_clamp_warnings()["count"] >= 1
         variance_warning_calls = [
-            c
-            for c in console_warning_mock.call_args_list
-            if "Variance corrected for metric:" in c.args[0]
+            warning_call
+            for warning_call in console_warning_mock.call_args_list
+            if "Variance corrected for metric:" in warning_call.args[0]
         ]
         assert variance_warning_calls == []
 
@@ -398,9 +398,9 @@ def test_calc_expressions_noise_clamp():
         analyzer.calc_expressions()
 
     variance_warning_calls = [
-        c
-        for c in console_warning_mock.call_args_list
-        if "Variance corrected for metric:" in c.args[0]
+        warning_call
+        for warning_call in console_warning_mock.call_args_list
+        if "Variance corrected for metric:" in warning_call.args[0]
     ]
     assert len(variance_warning_calls) == 1
     assert "1.1 - clamped" in variance_warning_calls[0].args[0]

--- a/projects/rocprofiler-compute/tests/test_analysis_db.py
+++ b/projects/rocprofiler-compute/tests/test_analysis_db.py
@@ -475,7 +475,7 @@ def test_validate_dual_issue_metrics_silent_below_peak():
 
 
 def test_validate_dual_issue_metrics_uses_peak_empirical_fallback():
-    """Peak (Empirical) column is preferred over Peak when both are absent."""
+    """Peak (Empirical) wins when present; falls back to Peak otherwise."""
     arch_config = _make_dual_issue_arch_config(
         "VALU FLOPs (F64)", peak_col="Peak (Empirical)"
     )

--- a/projects/rocprofiler-compute/tests/test_analysis_db.py
+++ b/projects/rocprofiler-compute/tests/test_analysis_db.py
@@ -3,6 +3,7 @@
 
 """Unit tests for analysis_db.py static methods."""
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
@@ -299,3 +300,120 @@ def test_calc_dataframe_expressions_with_builtin_vars():
     assert result.iloc[0] == 51
     # None from evaluate becomes NaN in pandas Series
     assert pd.isna(result.iloc[1])
+
+
+# =============================================================================
+# Noise-clamp warning + summary tests
+# =============================================================================
+
+
+def test_calc_expressions_noise_clamp():
+    """Variance warning fires only on workload-level pass; summary per workload.
+
+    Covers three things in one test:
+    1. db_analysis.evaluate(emit_variance_warnings=True) emits a per-metric
+       'Variance corrected for metric: ...' console_warning when to_noise_clamp
+       advances the global counter; the same call with the kwarg False stays
+       silent.
+    2. db_analysis.calc_expressions emits the warning exactly once per
+       workload (workload-level pass) even though the kernel-level pass
+       evaluates the same noise-clamping expression for every kernel.
+    3. print_noise_clamp_summary is called exactly once per workload.
+    """
+    from utils.metrics.noise_clamper import (
+        clear_noise_clamp_warnings,
+        get_noise_clamp_warnings,
+    )
+
+    workload_path = "/fake/workload"
+    # Two distinct kernels so the kernel-level groupby produces two groups.
+    # Without the kwarg gate the unguarded code would emit three warnings
+    # (two kernel + one workload); with the gate exactly one fires.
+    pmc_df = pd.DataFrame({
+        "Kernel_Name": ["kernel_a", "kernel_a", "kernel_b", "kernel_b"],
+        "DIFF": [-100.0, -100.0, -100.0, -100.0],
+        "REF": [1000.0, 1000.0, 1000.0, 1000.0],
+    })
+    expression_template = pd.DataFrame({
+        "metric_id": ["1.1"],
+        "value_name": ["clamped"],
+        "value": [
+            "to_noise_clamp("
+            "to_min(raw_pmc_df['pmc_perf']['DIFF']), "
+            "to_max(raw_pmc_df['pmc_perf']['REF']))"
+        ],
+    })
+    sys_info_df = pd.DataFrame([{"placeholder": 1}])
+
+    instance = object.__new__(db_analysis)
+    instance._pmc_df_per_workload = {workload_path: pmc_df}
+    instance._metric_expression_data_per_workload = {workload_path: expression_template}
+    instance._roofline_ceilings_per_workload = {workload_path: {}}
+    instance._runs = {workload_path: SimpleNamespace(sys_info=sys_info_df)}
+
+    # --- 1. Direct evaluate() kwarg behavior ---------------------------------
+    clear_noise_clamp_warnings()
+    with patch("rocprof_compute_analyze.analysis_db.console_warning") as mock_warning:
+        db_analysis.evaluate(
+            "direct_test",
+            "to_noise_clamp("
+            "to_min(raw_pmc_df['pmc_perf']['DIFF']), "
+            "to_max(raw_pmc_df['pmc_perf']['REF']))",
+            pmc_df,
+            {},
+            emit_variance_warnings=True,
+        )
+        emitted_with_kwarg = [
+            c
+            for c in mock_warning.call_args_list
+            if "Variance corrected for metric: direct_test" in c.args[0]
+        ]
+        assert len(emitted_with_kwarg) == 1
+        assert get_noise_clamp_warnings()["count"] >= 1
+
+    clear_noise_clamp_warnings()
+    with patch(
+        "rocprof_compute_analyze.analysis_db.console_warning"
+    ) as mock_warning_off:
+        db_analysis.evaluate(
+            "direct_test_off",
+            "to_noise_clamp("
+            "to_min(raw_pmc_df['pmc_perf']['DIFF']), "
+            "to_max(raw_pmc_df['pmc_perf']['REF']))",
+            pmc_df,
+            {},
+            emit_variance_warnings=False,
+        )
+        assert get_noise_clamp_warnings()["count"] >= 1
+        emitted_without_kwarg = [
+            c
+            for c in mock_warning_off.call_args_list
+            if "Variance corrected for metric:" in c.args[0]
+        ]
+        assert emitted_without_kwarg == []
+
+    # --- 2 & 3. calc_expressions per-workload bracket ------------------------
+    clear_noise_clamp_warnings()
+    with (
+        patch("rocprof_compute_analyze.analysis_db.BUILD_IN_VARS", {}),
+        patch(
+            "rocprof_compute_analyze.analysis_db.console_warning"
+        ) as mock_console_warning,
+        patch(
+            "rocprof_compute_analyze.analysis_db.print_noise_clamp_summary"
+        ) as mock_print_summary,
+    ):
+        instance.calc_expressions()
+
+    variance_calls = [
+        c
+        for c in mock_console_warning.call_args_list
+        if "Variance corrected for metric:" in c.args[0]
+    ]
+    # Exactly one variance warning per workload (kernel-level pass is silent).
+    assert len(variance_calls) == 1
+    assert "1.1 - clamped" in variance_calls[0].args[0]
+    mock_print_summary.assert_called_once()
+    # Counter reflects only the workload-level pass (kernel-level counts were
+    # cleared by the bracket before workload-level evaluation).
+    assert get_noise_clamp_warnings()["count"] >= 1

--- a/projects/rocprofiler-compute/tests/test_analysis_db.py
+++ b/projects/rocprofiler-compute/tests/test_analysis_db.py
@@ -321,9 +321,7 @@ def test_calc_expressions_noise_clamp():
     """
     workload_path = "/fake/workload"
     noise_clamp_expression = (
-        "to_noise_clamp("
-        "to_min(raw_pmc_df['pmc_perf']['DIFF']), "
-        "to_max(raw_pmc_df['pmc_perf']['REF']))"
+        "to_noise_clamp(to_min(raw_pmc_df['DIFF']), to_max(raw_pmc_df['REF']))"
     )
     # Two distinct kernels so groupby yields two kernel-level evaluate calls
     # in addition to one workload-level call. Without the kwarg gate the

--- a/projects/rocprofiler-compute/tests/test_analysis_db.py
+++ b/projects/rocprofiler-compute/tests/test_analysis_db.py
@@ -3,13 +3,16 @@
 
 """Unit tests for analysis_db.py static methods."""
 
-from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
 
 from rocprof_compute_analyze.analysis_db import db_analysis
+from utils.metrics.noise_clamper import (
+    clear_noise_clamp_warnings,
+    get_noise_clamp_warnings,
+)
 
 # =============================================================================
 # db_analysis.evaluate() tests
@@ -308,112 +311,98 @@ def test_calc_dataframe_expressions_with_builtin_vars():
 
 
 def test_calc_expressions_noise_clamp():
-    """Variance warning fires only on workload-level pass; summary per workload.
+    """Variance warnings fire only at workload level, summary once per workload.
 
-    Covers three things in one test:
-    1. db_analysis.evaluate(emit_variance_warnings=True) emits a per-metric
-       'Variance corrected for metric: ...' console_warning when to_noise_clamp
-       advances the global counter; the same call with the kwarg False stays
-       silent.
-    2. db_analysis.calc_expressions emits the warning exactly once per
-       workload (workload-level pass) even though the kernel-level pass
-       evaluates the same noise-clamping expression for every kernel.
-    3. print_noise_clamp_summary is called exactly once per workload.
+    - evaluate(emit_variance_warnings=True) emits the per-metric warning when
+      to_noise_clamp advances the global counter; the False kwarg stays silent.
+    - calc_expressions emits exactly one variance warning per workload
+      (kernel-level pass is silent) and calls print_noise_clamp_summary once.
     """
-    from utils.metrics.noise_clamper import (
-        clear_noise_clamp_warnings,
-        get_noise_clamp_warnings,
-    )
-
     workload_path = "/fake/workload"
-    # Two distinct kernels so the kernel-level groupby produces two groups.
-    # Without the kwarg gate the unguarded code would emit three warnings
-    # (two kernel + one workload); with the gate exactly one fires.
+    noise_clamp_expression = (
+        "to_noise_clamp("
+        "to_min(raw_pmc_df['pmc_perf']['DIFF']), "
+        "to_max(raw_pmc_df['pmc_perf']['REF']))"
+    )
+    # Two distinct kernels so groupby yields two kernel-level evaluate calls
+    # in addition to one workload-level call. Without the kwarg gate the
+    # unguarded code would emit three warnings; with the gate, exactly one.
     pmc_df = pd.DataFrame({
-        "Kernel_Name": ["kernel_a", "kernel_a", "kernel_b", "kernel_b"],
-        "DIFF": [-100.0, -100.0, -100.0, -100.0],
-        "REF": [1000.0, 1000.0, 1000.0, 1000.0],
+        "Kernel_Name": ["kernel_a", "kernel_b"],
+        "DIFF": [-100.0, -100.0],
+        "REF": [1000.0, 1000.0],
     })
     expression_template = pd.DataFrame({
         "metric_id": ["1.1"],
         "value_name": ["clamped"],
-        "value": [
-            "to_noise_clamp("
-            "to_min(raw_pmc_df['pmc_perf']['DIFF']), "
-            "to_max(raw_pmc_df['pmc_perf']['REF']))"
-        ],
+        "value": [noise_clamp_expression],
     })
     sys_info_df = pd.DataFrame([{"placeholder": 1}])
 
-    instance = object.__new__(db_analysis)
-    instance._pmc_df_per_workload = {workload_path: pmc_df}
-    instance._metric_expression_data_per_workload = {workload_path: expression_template}
-    instance._roofline_ceilings_per_workload = {workload_path: {}}
-    instance._runs = {workload_path: SimpleNamespace(sys_info=sys_info_df)}
+    analyzer = db_analysis(MagicMock(), {})
+    analyzer._pmc_df_per_workload = {workload_path: pmc_df}
+    analyzer._metric_expression_data_per_workload = {workload_path: expression_template}
+    analyzer._roofline_ceilings_per_workload = {workload_path: {}}
+    analyzer._runs = {workload_path: MagicMock(sys_info=sys_info_df)}
 
-    # --- 1. Direct evaluate() kwarg behavior ---------------------------------
+    # Direct evaluate kwarg behavior.
     clear_noise_clamp_warnings()
-    with patch("rocprof_compute_analyze.analysis_db.console_warning") as mock_warning:
+    with patch(
+        "rocprof_compute_analyze.analysis_db.console_warning"
+    ) as console_warning_mock:
         db_analysis.evaluate(
             "direct_test",
-            "to_noise_clamp("
-            "to_min(raw_pmc_df['pmc_perf']['DIFF']), "
-            "to_max(raw_pmc_df['pmc_perf']['REF']))",
+            noise_clamp_expression,
             pmc_df,
             {},
             emit_variance_warnings=True,
         )
-        emitted_with_kwarg = [
+        variance_warning_calls = [
             c
-            for c in mock_warning.call_args_list
+            for c in console_warning_mock.call_args_list
             if "Variance corrected for metric: direct_test" in c.args[0]
         ]
-        assert len(emitted_with_kwarg) == 1
+        assert len(variance_warning_calls) == 1
         assert get_noise_clamp_warnings()["count"] >= 1
 
     clear_noise_clamp_warnings()
     with patch(
         "rocprof_compute_analyze.analysis_db.console_warning"
-    ) as mock_warning_off:
+    ) as console_warning_mock:
         db_analysis.evaluate(
             "direct_test_off",
-            "to_noise_clamp("
-            "to_min(raw_pmc_df['pmc_perf']['DIFF']), "
-            "to_max(raw_pmc_df['pmc_perf']['REF']))",
+            noise_clamp_expression,
             pmc_df,
             {},
             emit_variance_warnings=False,
         )
         assert get_noise_clamp_warnings()["count"] >= 1
-        emitted_without_kwarg = [
+        variance_warning_calls = [
             c
-            for c in mock_warning_off.call_args_list
+            for c in console_warning_mock.call_args_list
             if "Variance corrected for metric:" in c.args[0]
         ]
-        assert emitted_without_kwarg == []
+        assert variance_warning_calls == []
 
-    # --- 2 & 3. calc_expressions per-workload bracket ------------------------
+    # calc_expressions per-workload bracket.
     clear_noise_clamp_warnings()
     with (
         patch("rocprof_compute_analyze.analysis_db.BUILD_IN_VARS", {}),
         patch(
             "rocprof_compute_analyze.analysis_db.console_warning"
-        ) as mock_console_warning,
+        ) as console_warning_mock,
         patch(
             "rocprof_compute_analyze.analysis_db.print_noise_clamp_summary"
-        ) as mock_print_summary,
+        ) as print_noise_clamp_summary_mock,
     ):
-        instance.calc_expressions()
+        analyzer.calc_expressions()
 
-    variance_calls = [
+    variance_warning_calls = [
         c
-        for c in mock_console_warning.call_args_list
+        for c in console_warning_mock.call_args_list
         if "Variance corrected for metric:" in c.args[0]
     ]
-    # Exactly one variance warning per workload (kernel-level pass is silent).
-    assert len(variance_calls) == 1
-    assert "1.1 - clamped" in variance_calls[0].args[0]
-    mock_print_summary.assert_called_once()
-    # Counter reflects only the workload-level pass (kernel-level counts were
-    # cleared by the bracket before workload-level evaluation).
+    assert len(variance_warning_calls) == 1
+    assert "1.1 - clamped" in variance_warning_calls[0].args[0]
+    print_noise_clamp_summary_mock.assert_called_once()
     assert get_noise_clamp_warnings()["count"] >= 1

--- a/projects/rocprofiler-compute/tests/test_analysis_db.py
+++ b/projects/rocprofiler-compute/tests/test_analysis_db.py
@@ -9,11 +9,27 @@ import numpy as np
 import pandas as pd
 
 from rocprof_compute_analyze.analysis_db import db_analysis
-from utils.metrics.common import ValuDualIssueDetector
 from utils.metrics.noise_clamper import (
     clear_noise_clamp_warnings,
     get_noise_clamp_warnings,
 )
+
+
+def make_dual_issue_arch_config(metric_name: str, peak_col: str = "Peak"):
+    """Build an arch_config stub with a metric_table carrying one VALU row."""
+    metric_df = pd.DataFrame(
+        {
+            "Metric": [metric_name],
+            "Value": ["unused_expression"],
+            peak_col: ["unused_peak_expression"],
+        },
+        index=pd.Index(["1.1"], name="Metric_ID"),
+    )
+    arch_config = MagicMock()
+    arch_config.dfs = {201: metric_df}
+    arch_config.dfs_type = {201: "metric_table"}
+    return arch_config
+
 
 # =============================================================================
 # db_analysis.evaluate() tests
@@ -414,25 +430,9 @@ def test_calc_expressions_noise_clamp():
 # =============================================================================
 
 
-def _make_dual_issue_arch_config(metric_name: str, peak_col: str = "Peak"):
-    """Build an arch_config stub with a metric_table carrying one VALU row."""
-    metric_df = pd.DataFrame(
-        {
-            "Metric": [metric_name],
-            "Value": ["unused_expression"],
-            peak_col: ["unused_peak_expression"],
-        },
-        index=pd.Index(["1.1"], name="Metric_ID"),
-    )
-    arch_config = MagicMock()
-    arch_config.dfs = {201: metric_df}
-    arch_config.dfs_type = {201: "metric_table"}
-    return arch_config
-
-
 def test_validate_dual_issue_metrics_emits_warning_above_peak():
     """Long-format VALU Utilization above peak triggers the dual-issue warning."""
-    arch_config = _make_dual_issue_arch_config("VALU Utilization")
+    arch_config = make_dual_issue_arch_config("VALU Utilization")
     workload_values_df = pd.DataFrame({
         "metric_id": ["1.1", "1.1"],
         "value_name": ["Value", "Peak"],
@@ -455,7 +455,7 @@ def test_validate_dual_issue_metrics_emits_warning_above_peak():
 
 def test_validate_dual_issue_metrics_silent_below_peak():
     """Below-peak VALU Utilization stays silent."""
-    arch_config = _make_dual_issue_arch_config("VALU Utilization")
+    arch_config = make_dual_issue_arch_config("VALU Utilization")
     workload_values_df = pd.DataFrame({
         "metric_id": ["1.1", "1.1"],
         "value_name": ["Value", "Peak"],
@@ -476,7 +476,7 @@ def test_validate_dual_issue_metrics_silent_below_peak():
 
 def test_validate_dual_issue_metrics_uses_peak_empirical_fallback():
     """Peak (Empirical) wins when present; falls back to Peak otherwise."""
-    arch_config = _make_dual_issue_arch_config(
+    arch_config = make_dual_issue_arch_config(
         "VALU FLOPs (F64)", peak_col="Peak (Empirical)"
     )
     workload_values_df = pd.DataFrame({
@@ -501,15 +501,13 @@ def test_validate_dual_issue_metrics_uses_peak_empirical_fallback():
 
 def test_validate_dual_issue_metrics_appends_valu2_suffix_on_gfx950():
     """gfx950 with non-zero SQ_ACTIVE_INST_VALU2 appends the confirmation."""
-    arch_config = _make_dual_issue_arch_config("VALU Utilization")
+    arch_config = make_dual_issue_arch_config("VALU Utilization")
     workload_values_df = pd.DataFrame({
         "metric_id": ["1.1", "1.1"],
         "value_name": ["Value", "Peak"],
         "value": [150.0, 100.0],
     })
-    pmc_df = pd.DataFrame({
-        ValuDualIssueDetector.valu2_counter: [1, 2, 3],
-    })
+    pmc_df = pd.DataFrame({"SQ_ACTIVE_INST_VALU2": [1, 2, 3]})
 
     with patch("utils.metrics.common.console_warning") as console_warning_mock:
         db_analysis.validate_dual_issue_metrics(
@@ -525,7 +523,7 @@ def test_validate_dual_issue_metrics_appends_valu2_suffix_on_gfx950():
 
 def test_validate_dual_issue_metrics_skips_non_metric_table_dfs():
     """dfs entries whose dfs_type is not metric_table are ignored."""
-    arch_config = _make_dual_issue_arch_config("VALU Utilization")
+    arch_config = make_dual_issue_arch_config("VALU Utilization")
     arch_config.dfs_type = {201: "raw_csv_table"}
     workload_values_df = pd.DataFrame({
         "metric_id": ["1.1", "1.1"],

--- a/projects/rocprofiler-compute/tests/test_metric_utils.py
+++ b/projects/rocprofiler-compute/tests/test_metric_utils.py
@@ -448,7 +448,7 @@ class TestEvaluationPipeline:
         assert "Test Metric" in variance_calls[0].args[0]
         mock_print_summary.assert_called_once()
 
-    def _make_dual_issue_dfs(
+    def make_dual_issue_dfs(
         self, metric_name: str, value: float, peak: float, peak_col: str = "Peak"
     ):
         """Build the (dfs, dfs_type) fixture used by dual-issue tests."""
@@ -461,7 +461,7 @@ class TestEvaluationPipeline:
 
     def test_validate_dual_issue_metrics_emits_valu_utilization_warning(self):
         """VALU Utilization above peak triggers the dual-issue warning."""
-        dfs, dfs_type = self._make_dual_issue_dfs(
+        dfs, dfs_type = self.make_dual_issue_dfs(
             "VALU Utilization", value=150.0, peak=100.0
         )
         sys_info = pd.Series({"gpu_arch": "gfx942"})
@@ -478,7 +478,7 @@ class TestEvaluationPipeline:
 
     def test_validate_dual_issue_metrics_emits_valu_flops_warning(self):
         """VALU FLOPs (F64) above peak triggers the FLOPs-flavored warning."""
-        dfs, dfs_type = self._make_dual_issue_dfs(
+        dfs, dfs_type = self.make_dual_issue_dfs(
             "VALU FLOPs (F64)", value=600.0, peak=400.0
         )
         sys_info = pd.Series({"gpu_arch": "gfx942"})
@@ -493,7 +493,7 @@ class TestEvaluationPipeline:
 
     def test_validate_dual_issue_metrics_silent_below_peak(self):
         """Below-peak VALU Utilization stays silent."""
-        dfs, dfs_type = self._make_dual_issue_dfs(
+        dfs, dfs_type = self.make_dual_issue_dfs(
             "VALU Utilization", value=80.0, peak=100.0
         )
         sys_info = pd.Series({"gpu_arch": "gfx942"})
@@ -507,7 +507,7 @@ class TestEvaluationPipeline:
 
     def test_validate_dual_issue_metrics_appends_valu2_suffix_on_gfx950(self):
         """gfx950 with non-zero SQ_ACTIVE_INST_VALU2 appends the confirmation."""
-        dfs, dfs_type = self._make_dual_issue_dfs(
+        dfs, dfs_type = self.make_dual_issue_dfs(
             "VALU Utilization", value=150.0, peak=100.0
         )
         sys_info = pd.Series({"gpu_arch": "gfx950"})
@@ -521,7 +521,7 @@ class TestEvaluationPipeline:
 
     def test_validate_dual_issue_metrics_uses_peak_empirical_fallback(self):
         """Peak (Empirical) column is used when present alongside Value."""
-        dfs, dfs_type = self._make_dual_issue_dfs(
+        dfs, dfs_type = self.make_dual_issue_dfs(
             "VALU Utilization",
             value=150.0,
             peak=100.0,

--- a/projects/rocprofiler-compute/tests/test_metric_utils.py
+++ b/projects/rocprofiler-compute/tests/test_metric_utils.py
@@ -408,18 +408,16 @@ class TestEvaluationPipeline:
             metric_fields={
                 "Value": (
                     "to_noise_clamp("
-                    "to_min(raw_pmc_df['pmc_perf']['DIFF']), "
-                    "to_max(raw_pmc_df['pmc_perf']['REF']))"
+                    "to_min(raw_pmc_df['DIFF']), "
+                    "to_max(raw_pmc_df['REF']))"
                 ),
             }
         )
-        raw_pmc_df = {
-            "pmc_perf": pd.DataFrame({
-                "GRBM_GUI_ACTIVE": [1000],
-                "DIFF": [-100.0],
-                "REF": [1000.0],
-            })
-        }
+        raw_pmc_df = pd.DataFrame({
+            "GRBM_GUI_ACTIVE": [1000],
+            "DIFF": [-100.0],
+            "REF": [1000.0],
+        })
 
         clear_noise_clamp_warnings()
         with (
@@ -438,7 +436,6 @@ class TestEvaluationPipeline:
                 pd.DataFrame(),
                 raw_pmc_df,
                 debug=False,
-                config={},
             )
 
         assert get_noise_clamp_warnings()["count"] >= 1
@@ -470,7 +467,9 @@ class TestEvaluationPipeline:
         sys_info = pd.Series({"gpu_arch": "gfx942"})
 
         with patch("utils.metrics.common.console_warning") as mock_warning:
-            validate_dual_issue_metrics(dfs, dfs_type, sys_info, raw_pmc_df={})
+            validate_dual_issue_metrics(
+                dfs, dfs_type, sys_info, raw_pmc_df=pd.DataFrame()
+            )
 
         mock_warning.assert_called_once()
         msg = mock_warning.call_args.args[0]
@@ -485,7 +484,9 @@ class TestEvaluationPipeline:
         sys_info = pd.Series({"gpu_arch": "gfx942"})
 
         with patch("utils.metrics.common.console_warning") as mock_warning:
-            validate_dual_issue_metrics(dfs, dfs_type, sys_info, raw_pmc_df={})
+            validate_dual_issue_metrics(
+                dfs, dfs_type, sys_info, raw_pmc_df=pd.DataFrame()
+            )
 
         msg = mock_warning.call_args.args[0]
         assert "VALU FLOPs can exceed the peak value" in msg
@@ -498,7 +499,9 @@ class TestEvaluationPipeline:
         sys_info = pd.Series({"gpu_arch": "gfx942"})
 
         with patch("utils.metrics.common.console_warning") as mock_warning:
-            validate_dual_issue_metrics(dfs, dfs_type, sys_info, raw_pmc_df={})
+            validate_dual_issue_metrics(
+                dfs, dfs_type, sys_info, raw_pmc_df=pd.DataFrame()
+            )
 
         mock_warning.assert_not_called()
 
@@ -508,9 +511,7 @@ class TestEvaluationPipeline:
             "VALU Utilization", value=150.0, peak=100.0
         )
         sys_info = pd.Series({"gpu_arch": "gfx950"})
-        raw_pmc_df = {
-            "pmc_perf": pd.DataFrame({"SQ_ACTIVE_INST_VALU2": [1, 2, 3]}),
-        }
+        raw_pmc_df = pd.DataFrame({"SQ_ACTIVE_INST_VALU2": [1, 2, 3]})
 
         with patch("utils.metrics.common.console_warning") as mock_warning:
             validate_dual_issue_metrics(dfs, dfs_type, sys_info, raw_pmc_df)
@@ -529,7 +530,9 @@ class TestEvaluationPipeline:
         sys_info = pd.Series({"gpu_arch": "gfx942"})
 
         with patch("utils.metrics.common.console_warning") as mock_warning:
-            validate_dual_issue_metrics(dfs, dfs_type, sys_info, raw_pmc_df={})
+            validate_dual_issue_metrics(
+                dfs, dfs_type, sys_info, raw_pmc_df=pd.DataFrame()
+            )
 
         mock_warning.assert_called_once()
         msg = mock_warning.call_args.args[0]

--- a/projects/rocprofiler-compute/tests/test_metric_utils.py
+++ b/projects/rocprofiler-compute/tests/test_metric_utils.py
@@ -21,7 +21,10 @@ from utils.metrics.aggregation import (
     to_round,
     to_std,
 )
-from utils.metrics.evaluation_pipeline import eval_metric
+from utils.metrics.evaluation_pipeline import (
+    eval_metric,
+    validate_dual_issue_metrics,
+)
 from utils.metrics.expression import (
     CodeTransformer,
     build_eval_string,
@@ -447,6 +450,90 @@ class TestEvaluationPipeline:
         assert len(variance_calls) == 1
         assert "Test Metric" in variance_calls[0].args[0]
         mock_print_summary.assert_called_once()
+
+    def _make_dual_issue_dfs(
+        self, metric_name: str, value: float, peak: float, peak_col: str = "Peak"
+    ):
+        """Build the (dfs, dfs_type) fixture used by dual-issue tests."""
+        df = pd.DataFrame({
+            "Metric": [metric_name],
+            "Value": [value],
+            peak_col: [peak],
+        })
+        return {1: df}, {1: "metric_table"}
+
+    def test_validate_dual_issue_metrics_emits_valu_utilization_warning(self):
+        """VALU Utilization above peak triggers the dual-issue warning."""
+        dfs, dfs_type = self._make_dual_issue_dfs(
+            "VALU Utilization", value=150.0, peak=100.0
+        )
+        sys_info = pd.Series({"gpu_arch": "gfx942"})
+
+        with patch("utils.metrics.common.console_warning") as mock_warning:
+            validate_dual_issue_metrics(dfs, dfs_type, sys_info, raw_pmc_df={})
+
+        mock_warning.assert_called_once()
+        msg = mock_warning.call_args.args[0]
+        assert "VALU Utilization can go up to 200%" in msg
+        assert "SQ_ACTIVE_INST_VALU2" not in msg
+
+    def test_validate_dual_issue_metrics_emits_valu_flops_warning(self):
+        """VALU FLOPs (F64) above peak triggers the FLOPs-flavored warning."""
+        dfs, dfs_type = self._make_dual_issue_dfs(
+            "VALU FLOPs (F64)", value=600.0, peak=400.0
+        )
+        sys_info = pd.Series({"gpu_arch": "gfx942"})
+
+        with patch("utils.metrics.common.console_warning") as mock_warning:
+            validate_dual_issue_metrics(dfs, dfs_type, sys_info, raw_pmc_df={})
+
+        msg = mock_warning.call_args.args[0]
+        assert "VALU FLOPs can exceed the peak value" in msg
+
+    def test_validate_dual_issue_metrics_silent_below_peak(self):
+        """Below-peak VALU Utilization stays silent."""
+        dfs, dfs_type = self._make_dual_issue_dfs(
+            "VALU Utilization", value=80.0, peak=100.0
+        )
+        sys_info = pd.Series({"gpu_arch": "gfx942"})
+
+        with patch("utils.metrics.common.console_warning") as mock_warning:
+            validate_dual_issue_metrics(dfs, dfs_type, sys_info, raw_pmc_df={})
+
+        mock_warning.assert_not_called()
+
+    def test_validate_dual_issue_metrics_appends_valu2_suffix_on_gfx950(self):
+        """gfx950 with non-zero SQ_ACTIVE_INST_VALU2 appends the confirmation."""
+        dfs, dfs_type = self._make_dual_issue_dfs(
+            "VALU Utilization", value=150.0, peak=100.0
+        )
+        sys_info = pd.Series({"gpu_arch": "gfx950"})
+        raw_pmc_df = {
+            "pmc_perf": pd.DataFrame({"SQ_ACTIVE_INST_VALU2": [1, 2, 3]}),
+        }
+
+        with patch("utils.metrics.common.console_warning") as mock_warning:
+            validate_dual_issue_metrics(dfs, dfs_type, sys_info, raw_pmc_df)
+
+        msg = mock_warning.call_args.args[0]
+        assert "Dual-issue activity detected via SQ_ACTIVE_INST_VALU2 counter" in msg
+
+    def test_validate_dual_issue_metrics_uses_peak_empirical_fallback(self):
+        """Peak (Empirical) column is used when present alongside Value."""
+        dfs, dfs_type = self._make_dual_issue_dfs(
+            "VALU Utilization",
+            value=150.0,
+            peak=100.0,
+            peak_col="Peak (Empirical)",
+        )
+        sys_info = pd.Series({"gpu_arch": "gfx942"})
+
+        with patch("utils.metrics.common.console_warning") as mock_warning:
+            validate_dual_issue_metrics(dfs, dfs_type, sys_info, raw_pmc_df={})
+
+        mock_warning.assert_called_once()
+        msg = mock_warning.call_args.args[0]
+        assert "VALU Utilization can go up to 200%" in msg
 
 
 # =============================================================================

--- a/projects/rocprofiler-compute/tests/test_metric_utils.py
+++ b/projects/rocprofiler-compute/tests/test_metric_utils.py
@@ -30,6 +30,10 @@ from utils.metrics.expression import (
     update_normal_unit_string,
 )
 from utils.metrics.metric_evaluator import MetricEvaluator
+from utils.metrics.noise_clamper import (
+    clear_noise_clamp_warnings,
+    get_noise_clamp_warnings,
+)
 from utils.utils_common import calc_builtin_var
 
 # =============================================================================
@@ -395,14 +399,9 @@ class TestEvaluationPipeline:
 
     def test_eval_metric_noise_clamp(self):
         """eval_metric emits per-metric variance warning + summary on clamp."""
-        from utils.metrics.noise_clamper import (
-            clear_noise_clamp_warnings,
-            get_noise_clamp_warnings,
-        )
-
         # Negative DIFF over a positive REF crosses the 1% threshold and bumps
         # the noise-clamp counter when to_noise_clamp evaluates the expression.
-        metric_df, dfs, dfs_type, sys_info, _ = self._build_eval_metric_inputs(
+        _, dfs, dfs_type, sys_info, _ = self._build_eval_metric_inputs(
             metric_fields={
                 "Value": (
                     "to_noise_clamp("

--- a/projects/rocprofiler-compute/tests/test_metric_utils.py
+++ b/projects/rocprofiler-compute/tests/test_metric_utils.py
@@ -393,6 +393,62 @@ class TestEvaluationPipeline:
             )
         assert metric_df.loc["1.1.0", "Average"] == ""
 
+    def test_eval_metric_noise_clamp(self):
+        """eval_metric emits per-metric variance warning + summary on clamp."""
+        from utils.metrics.noise_clamper import (
+            clear_noise_clamp_warnings,
+            get_noise_clamp_warnings,
+        )
+
+        # Negative DIFF over a positive REF crosses the 1% threshold and bumps
+        # the noise-clamp counter when to_noise_clamp evaluates the expression.
+        metric_df, dfs, dfs_type, sys_info, _ = self._build_eval_metric_inputs(
+            metric_fields={
+                "Value": (
+                    "to_noise_clamp("
+                    "to_min(raw_pmc_df['pmc_perf']['DIFF']), "
+                    "to_max(raw_pmc_df['pmc_perf']['REF']))"
+                ),
+            }
+        )
+        raw_pmc_df = {
+            "pmc_perf": pd.DataFrame({
+                "GRBM_GUI_ACTIVE": [1000],
+                "DIFF": [-100.0],
+                "REF": [1000.0],
+            })
+        }
+
+        clear_noise_clamp_warnings()
+        with (
+            patch("utils.metrics.evaluation_pipeline.BUILD_IN_VARS", {}),
+            patch(
+                "utils.metrics.evaluation_pipeline.console_warning"
+            ) as mock_console_warning,
+            patch(
+                "utils.metrics.evaluation_pipeline.print_noise_clamp_summary"
+            ) as mock_print_summary,
+        ):
+            eval_metric(
+                dfs,
+                dfs_type,
+                sys_info,
+                pd.DataFrame(),
+                raw_pmc_df,
+                debug=False,
+                config={},
+            )
+
+        assert get_noise_clamp_warnings()["count"] >= 1
+        variance_calls = [
+            call_args
+            for call_args in mock_console_warning.call_args_list
+            if "Variance corrected for metric:" in call_args.args[0]
+        ]
+        assert len(variance_calls) == 1
+        assert "Test Metric" in variance_calls[0].args[0]
+        mock_print_summary.assert_called_once()
+
 
 # =============================================================================
 # Tests for utils.metrics.metric_evaluator

--- a/projects/rocprofiler-compute/tests/test_metrics_common.py
+++ b/projects/rocprofiler-compute/tests/test_metrics_common.py
@@ -1,0 +1,99 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+"""Unit tests for utils.metrics.common."""
+
+from unittest.mock import patch
+
+import pandas as pd
+
+from utils.metrics.common import ValuDualIssueDetector
+
+
+class TestValuDualIssueDetector:
+    """Tests for utils.metrics.common.ValuDualIssueDetector."""
+
+    def test_check_skips_non_candidate_metric(self):
+        """Non-VALU metric names never trigger a warning, even when over peak."""
+        detector = ValuDualIssueDetector(gpu_arch="gfx942")
+        with patch("utils.metrics.common.console_warning") as console_warning_mock:
+            detector.check("IPC", value=10.0, peak=5.0)
+        console_warning_mock.assert_not_called()
+
+    def test_check_skips_when_value_below_peak(self):
+        """Candidate metric does not warn when value is within peak."""
+        detector = ValuDualIssueDetector(gpu_arch="gfx942")
+        with patch("utils.metrics.common.console_warning") as console_warning_mock:
+            detector.check("VALU Utilization", value=80.0, peak=100.0)
+        console_warning_mock.assert_not_called()
+
+    def test_check_skips_when_peak_not_positive(self):
+        """A non-positive peak is treated as missing and never warns."""
+        detector = ValuDualIssueDetector(gpu_arch="gfx942")
+        with patch("utils.metrics.common.console_warning") as console_warning_mock:
+            detector.check("VALU Utilization", value=10.0, peak=0.0)
+            detector.check("VALU Utilization", value=10.0, peak=-1.0)
+        console_warning_mock.assert_not_called()
+
+    def test_check_emits_valu_utilization_warning_above_peak(self):
+        """VALU Utilization above peak emits the dual-issue warning."""
+        detector = ValuDualIssueDetector(gpu_arch="gfx942")
+        with patch("utils.metrics.common.console_warning") as console_warning_mock:
+            detector.check("VALU Utilization", value=150.0, peak=100.0)
+        console_warning_mock.assert_called_once()
+        msg = console_warning_mock.call_args.args[0]
+        assert "VALU Utilization can go up to 200%" in msg
+        assert ValuDualIssueDetector.FAQ_URL in msg
+        assert "SQ_ACTIVE_INST_VALU2" not in msg
+
+    def test_check_emits_valu_flops_warning_above_peak(self):
+        """VALU FLOPs (F64) above peak emits the FLOPs-flavored warning."""
+        detector = ValuDualIssueDetector(gpu_arch="gfx942")
+        with patch("utils.metrics.common.console_warning") as console_warning_mock:
+            detector.check("VALU FLOPs (F64)", value=600.0, peak=400.0)
+        console_warning_mock.assert_called_once()
+        msg = console_warning_mock.call_args.args[0]
+        assert "VALU FLOPs can exceed the peak value" in msg
+        assert ValuDualIssueDetector.FAQ_URL in msg
+        assert "SQ_ACTIVE_INST_VALU2" not in msg
+
+    def test_check_appends_valu2_suffix_on_gfx950(self):
+        """gfx950 with non-zero SQ_ACTIVE_INST_VALU2 appends the confirmation."""
+        detector = ValuDualIssueDetector(
+            gpu_arch="gfx950",
+            valu2_series=pd.Series([0, 1, 2]),
+        )
+        with patch("utils.metrics.common.console_warning") as console_warning_mock:
+            detector.check("VALU Utilization", value=150.0, peak=100.0)
+        msg = console_warning_mock.call_args.args[0]
+        assert "Dual-issue activity detected via SQ_ACTIVE_INST_VALU2 counter" in msg
+
+    def test_check_omits_valu2_suffix_when_counter_sum_zero(self):
+        """gfx950 with all-zero SQ_ACTIVE_INST_VALU2 omits the confirmation."""
+        detector = ValuDualIssueDetector(
+            gpu_arch="gfx950",
+            valu2_series=pd.Series([0, 0, 0]),
+        )
+        with patch("utils.metrics.common.console_warning") as console_warning_mock:
+            detector.check("VALU Utilization", value=150.0, peak=100.0)
+        msg = console_warning_mock.call_args.args[0]
+        assert "SQ_ACTIVE_INST_VALU2" not in msg
+
+    def test_check_omits_valu2_suffix_when_counter_absent(self):
+        """gfx950 without the SQ_ACTIVE_INST_VALU2 series omits the confirmation."""
+        detector = ValuDualIssueDetector(gpu_arch="gfx950", valu2_series=None)
+        with patch("utils.metrics.common.console_warning") as console_warning_mock:
+            detector.check("VALU Utilization", value=150.0, peak=100.0)
+        msg = console_warning_mock.call_args.args[0]
+        assert "SQ_ACTIVE_INST_VALU2" not in msg
+
+    def test_check_ignores_valu2_on_non_gfx950(self):
+        """Non-gfx950 archs never append the SQ_ACTIVE_INST_VALU2 suffix."""
+        detector = ValuDualIssueDetector(
+            gpu_arch="gfx942",
+            valu2_series=pd.Series([1, 2, 3]),
+        )
+        with patch("utils.metrics.common.console_warning") as console_warning_mock:
+            detector.check("VALU Utilization", value=150.0, peak=100.0)
+        msg = console_warning_mock.call_args.args[0]
+        assert "SQ_ACTIVE_INST_VALU2" not in msg

--- a/projects/rocprofiler-compute/tests/test_metrics_common.py
+++ b/projects/rocprofiler-compute/tests/test_metrics_common.py
@@ -43,7 +43,7 @@ class TestValuDualIssueDetector:
         console_warning_mock.assert_called_once()
         msg = console_warning_mock.call_args.args[0]
         assert "VALU Utilization can go up to 200%" in msg
-        assert ValuDualIssueDetector.FAQ_URL in msg
+        assert ValuDualIssueDetector.faq_url in msg
         assert "SQ_ACTIVE_INST_VALU2" not in msg
 
     def test_check_emits_valu_flops_warning_above_peak(self):
@@ -54,7 +54,7 @@ class TestValuDualIssueDetector:
         console_warning_mock.assert_called_once()
         msg = console_warning_mock.call_args.args[0]
         assert "VALU FLOPs can exceed the peak value" in msg
-        assert ValuDualIssueDetector.FAQ_URL in msg
+        assert ValuDualIssueDetector.faq_url in msg
         assert "SQ_ACTIVE_INST_VALU2" not in msg
 
     def test_check_appends_valu2_suffix_on_gfx950(self):

--- a/projects/rocprofiler-compute/tests/test_metrics_common.py
+++ b/projects/rocprofiler-compute/tests/test_metrics_common.py
@@ -87,6 +87,35 @@ class TestValuDualIssueDetector:
         msg = console_warning_mock.call_args.args[0]
         assert "SQ_ACTIVE_INST_VALU2" not in msg
 
+    def test_check_emits_counter_issue_warning_above_2x_peak(self):
+        """VALU Utilization above 2x peak emits the counter-issue warning."""
+        detector = ValuDualIssueDetector(gpu_arch="gfx942")
+        with patch("utils.metrics.common.console_warning") as console_warning_mock:
+            detector.check("VALU Utilization", value=250.0, peak=100.0)
+        msg = console_warning_mock.call_args.args[0]
+        assert "exceeds twice the theoretical peak" in msg
+        assert "raw performance counters" in msg
+        assert "can go up to 200%" not in msg
+        assert ValuDualIssueDetector.faq_url not in msg
+
+    def test_check_emits_dual_issue_warning_at_exactly_2x_peak(self):
+        """value == 2 * peak stays in the dual-issue tier (not counter-issue)."""
+        detector = ValuDualIssueDetector(gpu_arch="gfx942")
+        with patch("utils.metrics.common.console_warning") as console_warning_mock:
+            detector.check("VALU Utilization", value=200.0, peak=100.0)
+        msg = console_warning_mock.call_args.args[0]
+        assert "VALU Utilization can go up to 200%" in msg
+        assert "exceeds twice" not in msg
+
+    def test_check_counter_issue_warning_for_valu_flops(self):
+        """VALU FLOPs above 2x peak emits the FLOPs-flavored counter-issue warning."""
+        detector = ValuDualIssueDetector(gpu_arch="gfx942")
+        with patch("utils.metrics.common.console_warning") as console_warning_mock:
+            detector.check("VALU FLOPs (F64)", value=1000.0, peak=400.0)
+        msg = console_warning_mock.call_args.args[0]
+        assert "VALU FLOPs exceeds twice the theoretical peak" in msg
+        assert "raw performance counters" in msg
+
     def test_check_ignores_valu2_on_non_gfx950(self):
         """Non-gfx950 archs never append the SQ_ACTIVE_INST_VALU2 suffix."""
         detector = ValuDualIssueDetector(

--- a/projects/rocprofiler-compute/tests/test_metrics_common.py
+++ b/projects/rocprofiler-compute/tests/test_metrics_common.py
@@ -15,29 +15,29 @@ class TestValuDualIssueDetector:
 
     def test_check_skips_non_candidate_metric(self):
         """Non-VALU metric names never trigger a warning, even when over peak."""
-        detector = ValuDualIssueDetector(gpu_arch="gfx942")
+        detector = ValuDualIssueDetector(gpu_arch="gfx942", raw_pmc_df=pd.DataFrame())
         with patch("utils.metrics.common.console_warning") as console_warning_mock:
             detector.check("IPC", value=10.0, peak=5.0)
         console_warning_mock.assert_not_called()
 
     def test_check_skips_when_value_below_peak(self):
         """Candidate metric does not warn when value is within peak."""
-        detector = ValuDualIssueDetector(gpu_arch="gfx942")
+        detector = ValuDualIssueDetector(gpu_arch="gfx942", raw_pmc_df=pd.DataFrame())
         with patch("utils.metrics.common.console_warning") as console_warning_mock:
             detector.check("VALU Utilization", value=80.0, peak=100.0)
         console_warning_mock.assert_not_called()
 
     def test_check_skips_when_peak_not_positive(self):
         """A non-positive peak is treated as missing and never warns."""
-        detector = ValuDualIssueDetector(gpu_arch="gfx942")
+        detector = ValuDualIssueDetector(gpu_arch="gfx942", raw_pmc_df=pd.DataFrame())
         with patch("utils.metrics.common.console_warning") as console_warning_mock:
             detector.check("VALU Utilization", value=10.0, peak=0.0)
             detector.check("VALU Utilization", value=10.0, peak=-1.0)
         console_warning_mock.assert_not_called()
 
     def test_check_emits_valu_utilization_warning_above_peak(self):
-        """VALU Utilization above peak emits the dual-issue warning."""
-        detector = ValuDualIssueDetector(gpu_arch="gfx942")
+        """VALU Utilization above peak emits the dual-issue warning on any arch."""
+        detector = ValuDualIssueDetector(gpu_arch="gfx942", raw_pmc_df=pd.DataFrame())
         with patch("utils.metrics.common.console_warning") as console_warning_mock:
             detector.check("VALU Utilization", value=150.0, peak=100.0)
         console_warning_mock.assert_called_once()
@@ -48,7 +48,7 @@ class TestValuDualIssueDetector:
 
     def test_check_emits_valu_flops_warning_above_peak(self):
         """VALU FLOPs (F64) above peak emits the FLOPs-flavored warning."""
-        detector = ValuDualIssueDetector(gpu_arch="gfx942")
+        detector = ValuDualIssueDetector(gpu_arch="gfx942", raw_pmc_df=pd.DataFrame())
         with patch("utils.metrics.common.console_warning") as console_warning_mock:
             detector.check("VALU FLOPs (F64)", value=600.0, peak=400.0)
         console_warning_mock.assert_called_once()
@@ -59,10 +59,8 @@ class TestValuDualIssueDetector:
 
     def test_check_appends_valu2_suffix_on_gfx950(self):
         """gfx950 with non-zero SQ_ACTIVE_INST_VALU2 appends the confirmation."""
-        detector = ValuDualIssueDetector(
-            gpu_arch="gfx950",
-            valu2_series=pd.Series([0, 1, 2]),
-        )
+        raw_pmc_df = pd.DataFrame({"SQ_ACTIVE_INST_VALU2": [0, 1, 2]})
+        detector = ValuDualIssueDetector(gpu_arch="gfx950", raw_pmc_df=raw_pmc_df)
         with patch("utils.metrics.common.console_warning") as console_warning_mock:
             detector.check("VALU Utilization", value=150.0, peak=100.0)
         msg = console_warning_mock.call_args.args[0]
@@ -70,18 +68,25 @@ class TestValuDualIssueDetector:
 
     def test_check_omits_valu2_suffix_when_counter_sum_zero(self):
         """gfx950 with all-zero SQ_ACTIVE_INST_VALU2 omits the confirmation."""
-        detector = ValuDualIssueDetector(
-            gpu_arch="gfx950",
-            valu2_series=pd.Series([0, 0, 0]),
-        )
+        raw_pmc_df = pd.DataFrame({"SQ_ACTIVE_INST_VALU2": [0, 0, 0]})
+        detector = ValuDualIssueDetector(gpu_arch="gfx950", raw_pmc_df=raw_pmc_df)
         with patch("utils.metrics.common.console_warning") as console_warning_mock:
             detector.check("VALU Utilization", value=150.0, peak=100.0)
         msg = console_warning_mock.call_args.args[0]
         assert "SQ_ACTIVE_INST_VALU2" not in msg
 
     def test_check_omits_valu2_suffix_when_counter_absent(self):
-        """gfx950 without the SQ_ACTIVE_INST_VALU2 series omits the confirmation."""
-        detector = ValuDualIssueDetector(gpu_arch="gfx950", valu2_series=None)
+        """gfx950 without SQ_ACTIVE_INST_VALU2 column omits the confirmation."""
+        detector = ValuDualIssueDetector(gpu_arch="gfx950", raw_pmc_df=pd.DataFrame())
+        with patch("utils.metrics.common.console_warning") as console_warning_mock:
+            detector.check("VALU Utilization", value=150.0, peak=100.0)
+        msg = console_warning_mock.call_args.args[0]
+        assert "SQ_ACTIVE_INST_VALU2" not in msg
+
+    def test_check_omits_valu2_suffix_on_non_gfx950(self):
+        """Non-gfx950 archs never append the SQ_ACTIVE_INST_VALU2 suffix."""
+        raw_pmc_df = pd.DataFrame({"SQ_ACTIVE_INST_VALU2": [1, 2, 3]})
+        detector = ValuDualIssueDetector(gpu_arch="gfx942", raw_pmc_df=raw_pmc_df)
         with patch("utils.metrics.common.console_warning") as console_warning_mock:
             detector.check("VALU Utilization", value=150.0, peak=100.0)
         msg = console_warning_mock.call_args.args[0]
@@ -89,7 +94,7 @@ class TestValuDualIssueDetector:
 
     def test_check_emits_counter_issue_warning_above_2x_peak(self):
         """VALU Utilization above 2x peak emits the counter-issue warning."""
-        detector = ValuDualIssueDetector(gpu_arch="gfx942")
+        detector = ValuDualIssueDetector(gpu_arch="gfx942", raw_pmc_df=pd.DataFrame())
         with patch("utils.metrics.common.console_warning") as console_warning_mock:
             detector.check("VALU Utilization", value=250.0, peak=100.0)
         msg = console_warning_mock.call_args.args[0]
@@ -100,7 +105,7 @@ class TestValuDualIssueDetector:
 
     def test_check_emits_dual_issue_warning_at_exactly_2x_peak(self):
         """value == 2 * peak stays in the dual-issue tier (not counter-issue)."""
-        detector = ValuDualIssueDetector(gpu_arch="gfx942")
+        detector = ValuDualIssueDetector(gpu_arch="gfx942", raw_pmc_df=pd.DataFrame())
         with patch("utils.metrics.common.console_warning") as console_warning_mock:
             detector.check("VALU Utilization", value=200.0, peak=100.0)
         msg = console_warning_mock.call_args.args[0]
@@ -109,20 +114,9 @@ class TestValuDualIssueDetector:
 
     def test_check_counter_issue_warning_for_valu_flops(self):
         """VALU FLOPs above 2x peak emits the FLOPs-flavored counter-issue warning."""
-        detector = ValuDualIssueDetector(gpu_arch="gfx942")
+        detector = ValuDualIssueDetector(gpu_arch="gfx942", raw_pmc_df=pd.DataFrame())
         with patch("utils.metrics.common.console_warning") as console_warning_mock:
             detector.check("VALU FLOPs (F64)", value=1000.0, peak=400.0)
         msg = console_warning_mock.call_args.args[0]
         assert "VALU FLOPs exceeds twice the theoretical peak" in msg
         assert "raw performance counters" in msg
-
-    def test_check_ignores_valu2_on_non_gfx950(self):
-        """Non-gfx950 archs never append the SQ_ACTIVE_INST_VALU2 suffix."""
-        detector = ValuDualIssueDetector(
-            gpu_arch="gfx942",
-            valu2_series=pd.Series([1, 2, 3]),
-        )
-        with patch("utils.metrics.common.console_warning") as console_warning_mock:
-            detector.check("VALU Utilization", value=150.0, peak=100.0)
-        msg = console_warning_mock.call_args.args[0]
-        assert "SQ_ACTIVE_INST_VALU2" not in msg


### PR DESCRIPTION
## Motivation

Surface noise-clamping and VALU dual-issue warnings in the analysis-DB
run with the same per-workload scoping the eval_pipeline path already
emits, so noisy counter data and over-peak VALU metrics are visible
regardless of which analysis path is used.

## Technical Details

- Noise-clamp: thread `emit_variance_warnings` through `evaluate` and `calc_dataframe_expressions`; bracket the workload pass with `clear_noise_clamp_warnings()` / `print_noise_clamp_summary()`. Kernel pass stays silent.

- Dual-issue: new `ValuDualIssueDetector` in `utils/metrics/common.py` owns the candidate set, gfx950 `SQ_ACTIVE_INST_VALU2` confirmation, and warning text.

- `evaluation_pipeline.validate_dual_issue_metrics` becomes a thin adapter over the detector. Behavior preserved.

- New `db_analysis.validate_dual_issue_metrics` runs after `print_noise_clamp_summary()` in `calc_expressions`, scoped per workload.

- Tests: new `tests/test_metrics_common.py` for the detector; per-adapter coverage added in `tests/test_metric_utils.py` and `tests/test_analysis_db.py` for both noise-clamp and dual-issue paths.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

- Run `db_analysis` on a workload whose PMC counters trigger `to_noise_clamp` and verify per-metric warnings + per-workload summary appear.

- Run `db_analysis` on a workload whose VALU Utilization or VALU FLOPs (F64) exceed peak and verify the dual-issue FAQ warning appears once per workload; on gfx950 verify the SQ_ACTIVE_INST_VALU2 confirmation suffix when the counter sum is non-zero.

- Run on a clean workload and verify no variance, summary, or dual-issue warnings.

## Test Result

Pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.