### PR TITLE
[rccl-tests] Fix CSV header column misalignment in MPI builds

### DIFF
--- a/projects/rccl-tests/src/common.cu
+++ b/projects/rccl-tests/src/common.cu
@@ -222,7 +222,7 @@ void Reporter::writeFile() {
     _out << "numCycle,";
     _out << "collective,";
 #ifdef MPI_SUPPORT
-    _out << "ranks,rankspernode,gpusperrank,";
+    _out << "nodes,ranks,ranksPerNode,gpusPerRank,";
 #else
     _out << "gpus,";
 #endif


### PR DESCRIPTION
## Details

**Work item:** Internal.

**What were the changes?**
Fix the CSV header emitted by `Reporter::writeFile` so that, in `MPI_SUPPORT` builds, it includes the `nodes` column and uses the same field names/casing as the data rows and the JSON output.

**Why were the changes made?**
In `MPI_SUPPORT` builds the CSV header was missing the `nodes` column and used different casing (`rankspernode`, `gpusperrank`) than the values pushed by `Reporter::addResult` (`nodes`, `ranks`, `ranksPerNode`, `gpusPerRank`). The result is a CSV whose header has 13 columns but whose data rows have 14 fields — every column from `ranks` onward is shifted left by one, so any name-based parser silently misreads the data (not just a cosmetic miss).

Concrete example from a single-node, 8-rank, 1-GPU/rank `all_reduce_perf` run (so `nodes=1, ranks=8, ranksPerNode=8, gpusPerRank=1`):

Before (header has 13 columns, data has 14):

```
numCycle,collective,ranks,rankspernode,gpusperrank,size,type,redop,inplace,time,algbw,busbw,#wrong
0,"AllReduce",1,8,8,1,1048576,"float","sum",0,55.66,18.84,32.97,"0"
```

Parsed by header name, this would yield `ranks=1, rankspernode=8, gpusperrank=8, size=1, type=1048576, redop="float", inplace="sum", time=0, algbw=55.66, ...` — every field after `collective` is wrong.

After (header has 14 columns matching the data and the JSON keys):

```
numCycle,collective,nodes,ranks,ranksPerNode,gpusPerRank,size,type,redop,inplace,time,algbw,busbw,#wrong
0,"AllReduce",1,8,8,1,1048576,"float","sum",0,52.98,19.79,34.64,"0"
```

The non-MPI branch (`gpus`) and the JSON output were already correct and are unchanged.

**How was the outcome achieved?**
One-line change in `projects/rccl-tests/src/common.cu`, replacing the `MPI_SUPPORT` CSV header string with `"nodes,ranks,ranksPerNode,gpusPerRank,"` so it matches the order and casing of the keys that `Reporter::addResult` already pushes (and that the JSON writer already emits).

**Additional Documentation:**
Verified by rebuilding `all_reduce_perf` with `MPI=1` and rerunning the same single-node 8-rank repro. Header column count now matches data column count on every row (`awk -F,` confirms 14/14 alignment), and the decoded values match the expected `nodes=1, ranks=8, ranksPerNode=8, gpusPerRank=1`.

Made with [Cursor](https://cursor.com)