### PR TITLE
[rocprofiler-systems] Optimize git submodules download

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -65,44 +65,57 @@
 	path = projects/rocprofiler-systems/external/timemory
 	url = https://github.com/ROCm/timemory.git
 	branch = rocprofiler-systems
+	shallow = true
 [submodule "projects/rocprofiler-systems/external/perfetto"]
 	path = projects/rocprofiler-systems/external/perfetto
 	url = https://github.com/google/perfetto.git
+	shallow = true
 [submodule "projects/rocprofiler-systems/external/elfio"]
 	path = projects/rocprofiler-systems/external/elfio
 	url = https://github.com/jrmadsen/ELFIO.git
+	shallow = true
 [submodule "projects/rocprofiler-systems/external/dyninst"]
 	path = projects/rocprofiler-systems/external/dyninst
 	url = https://github.com/ROCm/dyninst.git
 	branch = dyninst_13
+	shallow = true
 [submodule "projects/rocprofiler-systems/external/kokkos"]
 	path = projects/rocprofiler-systems/examples/lulesh/external/kokkos
 	url = https://github.com/kokkos/kokkos.git
+	shallow = true
 [submodule "projects/rocprofiler-systems/external/papi"]
 	path = projects/rocprofiler-systems/external/papi
 	url = https://github.com/icl-utk-edu/papi.git
+	shallow = true
 [submodule "projects/rocprofiler-systems/external/pybind11"]
 	path = projects/rocprofiler-systems/external/pybind11
 	url = https://github.com/jrmadsen/pybind11.git
+	shallow = true
 [submodule "projects/rocprofiler-systems/external/sqlite"]
 	path = projects/rocprofiler-systems/external/sqlite
 	url = https://github.com/sqlite/sqlite.git
+	shallow = true
 [submodule "projects/rocprofiler-systems/examples/openmp/external/ompvv"]
 	path = projects/rocprofiler-systems/examples/openmp/external/ompvv
 	url = https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV.git
+	shallow = true
 [submodule "projects/rocprofiler-systems/external/googletest"]
 	path = projects/rocprofiler-systems/external/googletest
 	url = https://github.com/google/googletest.git
+	shallow = true
 [submodule "projects/rocprofiler-systems/external/filesystem"]
 	path = projects/rocprofiler-systems/external/filesystem
 	url = https://github.com/gulrak/filesystem.git
+	shallow = true
 [submodule "projects/rocprofiler-systems/external/spdlog"]
 	path = projects/rocprofiler-systems/external/spdlog
 	url = https://github.com/gabime/spdlog.git
 	tag = v1.16.0
+	shallow = true
 [submodule "projects/rocprofiler-systems/external/json"]
 	path = projects/rocprofiler-systems/external/json
 	url = https://github.com/nlohmann/json.git
+	shallow = true
 [submodule "projects/rocprofiler-compute/src/vendored/pyyaml"]
 	path = projects/rocprofiler-compute/src/vendored/pyyaml
 	url = https://github.com/yaml/pyyaml.git

--- a/projects/rocprofiler-systems/cmake/MacroUtilities.cmake
+++ b/projects/rocprofiler-systems/cmake/MacroUtilities.cmake
@@ -278,16 +278,60 @@ function(ROCPROFILER_SYSTEMS_CHECKOUT_GIT_SUBMODULE)
         set(_RECURSE "--recursive")
     endif()
 
+    # Shallow fetch: download only the pinned commit (--depth=1) instead of full
+    # history. Falls back to a full fetch if shallow fails (happens when the recorded
+    # SHA is not advertised by the remote, e.g. not a branch/tag tip and the server
+    # has not enabled uploadpack.allowReachableSHA1InWant).
+    option(
+        ROCPROFSYS_GIT_SHALLOW
+        "Use --depth=1 when fetching git submodules / external repos"
+        ON
+    )
+    set(_DEPTH "")
+    if(ROCPROFSYS_GIT_SHALLOW)
+        set(_DEPTH "--depth=1")
+    endif()
+
+    # Partial clone: skip blob history (--filter=blob:none); blobs fetched lazily on
+    # demand. Requires git >= 2.36 and remote with uploadpack.allowFilter=true (GitHub
+    # supports it). Falls back to non-filtered fetch if rejected. Combined with
+    # --depth=1 for minimal initial transfer.
+    option(
+        ROCPROFSYS_GIT_PARTIAL_CLONE
+        "Use --filter=blob:none when fetching git submodules / external repos"
+        ON
+    )
+    set(_FILTER "")
+    if(ROCPROFSYS_GIT_PARTIAL_CLONE)
+        set(_FILTER "--filter=blob:none")
+    endif()
+
     # if the module has not been checked out
     if(NOT _TEST_FILE_EXISTS AND _SUBMODULE_EXISTS)
-        # perform the checkout
+        # perform the checkout (shallow + partial first)
         execute_process(
             COMMAND
-                ${GIT_EXECUTABLE} submodule update --init ${_RECURSE}
+                ${GIT_EXECUTABLE} submodule update --init ${_DEPTH} ${_FILTER} ${_RECURSE}
                 ${CHECKOUT_ADDITIONAL_CMDS} ${CHECKOUT_RELATIVE_PATH}
             WORKING_DIRECTORY ${CHECKOUT_WORKING_DIRECTORY}
             RESULT_VARIABLE RET
         )
+
+        # retry without --depth=1 / --filter if shallow or partial fetch failed
+        # (pinned SHA may not be reachable; remote may reject filter)
+        if(RET GREATER 0 AND (ROCPROFSYS_GIT_SHALLOW OR ROCPROFSYS_GIT_PARTIAL_CLONE))
+            message(
+                STATUS
+                "Optimized fetch of '${CHECKOUT_RELATIVE_PATH}' failed; retrying full fetch"
+            )
+            execute_process(
+                COMMAND
+                    ${GIT_EXECUTABLE} submodule update --init ${_RECURSE}
+                    ${CHECKOUT_ADDITIONAL_CMDS} ${CHECKOUT_RELATIVE_PATH}
+                WORKING_DIRECTORY ${CHECKOUT_WORKING_DIRECTORY}
+                RESULT_VARIABLE RET
+            )
+        endif()
 
         # check the return code
         if(RET GREATER 0)
@@ -313,22 +357,50 @@ function(ROCPROFILER_SYSTEMS_CHECKOUT_GIT_SUBMODULE)
             execute_process(COMMAND ${CMAKE_COMMAND} -E remove_directory ${_DIR})
         endif()
 
-        # perform the checkout
+        # perform the checkout (shallow + partial first)
         execute_process(
             COMMAND
-                ${GIT_EXECUTABLE} clone -b ${CHECKOUT_REPO_BRANCH}
+                ${GIT_EXECUTABLE} clone ${_DEPTH} ${_FILTER} -b ${CHECKOUT_REPO_BRANCH}
                 ${CHECKOUT_ADDITIONAL_CMDS} ${CHECKOUT_REPO_URL} ${CHECKOUT_RELATIVE_PATH}
             WORKING_DIRECTORY ${CHECKOUT_WORKING_DIRECTORY}
             RESULT_VARIABLE RET
         )
 
-        # perform the submodule update
+        # retry without --depth=1 / --filter if optimized clone failed
+        if(RET GREATER 0 AND (ROCPROFSYS_GIT_SHALLOW OR ROCPROFSYS_GIT_PARTIAL_CLONE))
+            message(
+                STATUS
+                "Optimized clone of '${CHECKOUT_REPO_URL}' failed; retrying full clone"
+            )
+            if(EXISTS "${_DIR}")
+                execute_process(COMMAND ${CMAKE_COMMAND} -E remove_directory ${_DIR})
+            endif()
+            execute_process(
+                COMMAND
+                    ${GIT_EXECUTABLE} clone -b ${CHECKOUT_REPO_BRANCH}
+                    ${CHECKOUT_ADDITIONAL_CMDS} ${CHECKOUT_REPO_URL}
+                    ${CHECKOUT_RELATIVE_PATH}
+                WORKING_DIRECTORY ${CHECKOUT_WORKING_DIRECTORY}
+                RESULT_VARIABLE RET
+            )
+        endif()
+
+        # perform the submodule update (shallow + partial first)
         if(CHECKOUT_RECURSIVE AND EXISTS "${_DIR}" AND IS_DIRECTORY "${_DIR}")
             execute_process(
-                COMMAND ${GIT_EXECUTABLE} submodule update --init ${_RECURSE}
+                COMMAND
+                    ${GIT_EXECUTABLE} submodule update --init ${_DEPTH} ${_FILTER}
+                    ${_RECURSE}
                 WORKING_DIRECTORY ${_DIR}
                 RESULT_VARIABLE RET
             )
+            if(RET GREATER 0 AND (ROCPROFSYS_GIT_SHALLOW OR ROCPROFSYS_GIT_PARTIAL_CLONE))
+                execute_process(
+                    COMMAND ${GIT_EXECUTABLE} submodule update --init ${_RECURSE}
+                    WORKING_DIRECTORY ${_DIR}
+                    RESULT_VARIABLE RET
+                )
+            endif()
         endif()
 
         # check the return code


### PR DESCRIPTION
## Motivation

Fetching git submodules transfers full repository history by default, which is unnecessary for builds and slows down CI and developer checkout times. rocprofiler-systems has 13 external submodules (timemory, perfetto, dyninst, PAPI, pybind11, sqlite, googletest, spdlog, etc.) that together represent a significant amount of data to clone on every fresh workspace.

## Technical Details

Two complementary optimizations are applied, both enabled by default and each individually togglable via CMake options:

**1. Shallow submodule fetch (`ROCPROFSYS_GIT_SHALLOW`, default `ON`)**
- Adds `shallow = true` to all 13 rocprofiler-systems submodule entries in `.gitmodules`.
- Passes `--depth=1` to `git submodule update --init` and `git clone` inside `ROCPROFILER_SYSTEMS_CHECKOUT_GIT_SUBMODULE`, downloading only the pinned commit instead of full history.

**2. Partial clone / blob filter (`ROCPROFSYS_GIT_PARTIAL_CLONE`, default `ON`)**
- Passes `--filter=blob:none` so blobs are fetched lazily on demand rather than eagerly upfront. Requires git ≥ 2.36 and a remote that supports `uploadpack.allowFilter` (GitHub does).

**Fallback on failure**
Both optimizations are applied together on the first attempt. If the fetch fails (e.g. the pinned SHA is not a branch/tag tip and the server does not advertise it, or the remote rejects the filter), the function automatically retries with a plain full fetch. This keeps the build correct on all remotes while still benefiting from the optimization on the common path.

The fallback is applied to all three git operations performed by the helper: `submodule update --init`, `git clone`, and the recursive `submodule update` inside a freshly cloned external repo.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFSYST-461

## Test Plan

- [x] Clean build with default settings (`ROCPROFSYS_GIT_SHALLOW=ON`, `ROCPROFSYS_GIT_PARTIAL_CLONE=ON`) — all submodules initialize correctly.
- [x] Build with both options `OFF` — full fetch path exercised, no regressions.
- [x] Verify fallback path: disable `uploadpack.allowFilter` on a local mirror and confirm the build retries and succeeds.
- [x] CI green on the PR branch.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.