### PR TITLE
RCCL: RCCL_IB_P2P_DISABLE_CTS enabled by default

### DIFF
--- a/projects/rccl/ext-src/rocm_netib.patch
+++ b/projects/rccl/ext-src/rocm_netib.patch
@@ -51,7 +51,7 @@
 +
 +// AMD AINIC
 +RCCL_PARAM(CtsOffloadEnabled, "CTS_OFFLOAD_ENABLED", -1);
-+RCCL_PARAM(IbP2pDisableCts, "IB_P2P_DISABLE_CTS", 0);
++RCCL_PARAM(IbP2pDisableCts, "IB_P2P_DISABLE_CTS", 1);
 +
 +extern int64_t rcclParamAinicRoce();
 +

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -13,7 +13,7 @@ RCCL_PARAM(IbCastQpsPerP2p, "IB_QPS_PER_P2P", 0);
 extern int64_t ncclParamIbCastGdrFlushDisable();
 // AMD AINIC
 RCCL_PARAM(IbCastCtsOffloadEnabled, "CTS_OFFLOAD_ENABLED", -1);
-RCCL_PARAM(IbCastP2pDisableCts, "IB_P2P_DISABLE_CTS", 0);
+RCCL_PARAM(IbCastP2pDisableCts, "IB_P2P_DISABLE_CTS", 1);
 
 bool IbCastAinicRoce = 0;
 bool IbCastOffloadEnabled = 0;


### PR DESCRIPTION
## Motivation

RCCL_IB_P2P_DISABLE_CTS is set to 1 by default to enable P2P batching for AINIC with out-of-box settings.

## Technical Details

Changed RCCL_IB_P2P_DISABLE_CTS  default value.

## JIRA ID

N/A

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
