### PR TITLE
[hip-tests] disable enforcing of adding a yaml config entry in the build step

### DIFF
--- a/projects/hip-tests/catch/config/check_config.py
+++ b/projects/hip-tests/catch/config/check_config.py
@@ -5,7 +5,7 @@
 import argparse
 import sys
 
-from common import iter_group_configs
+from common import iter_group_configs, ERROR, RESET
 
 
 def parse_args():
@@ -34,11 +34,11 @@ def main():
 
     if missing:
         print(
-            "ERROR: The following test cases are missing a 'level' in their YAML config:",
+            f"[check_config] {ERROR}ERROR: The following test cases are missing a 'level' in their YAML config:{RESET}",
             file=sys.stderr,
         )
         for entry in missing:
-            print(entry, file=sys.stderr)
+            print(f"[check_config] {ERROR}{entry}{RESET}", file=sys.stderr)
         sys.exit(1)
 
 

--- a/projects/hip-tests/catch/config/check_sources.py
+++ b/projects/hip-tests/catch/config/check_sources.py
@@ -7,10 +7,9 @@ import os
 import re
 import sys
 
-from common import NON_UNIT_GROUPS, iter_group_configs
+from common import NON_UNIT_GROUPS, iter_group_configs, WARNING, RESET
 
 CPP_EXTENSIONS = (".cc", ".cpp", ".cxx", ".c++", ".C", ".cp", ".CPP")
-
 
 def find_source_test_cases(source_root, group, is_unit):
     if is_unit:
@@ -26,7 +25,8 @@ def find_source_test_cases(source_root, group, is_unit):
     # A commented-out HIP_TEST_CASE will still be detected as a source test
     # and flagged as missing if it has no YAML entry.
     pattern = re.compile(
-        r'(?:HIP_TEST_CASE|HIP_TEMPLATE_TEST_CASE)\(\s*(\w+)\s*[,)]'
+        r'\b(?:HIP_TEST_CASE|HIP_TEMPLATE_TEST_CASE|TEST_CASE|TEMPLATE_TEST_CASE)'
+        r'\(\s*(?:"([^"]*)"|(\w+))\s*[,)]'
     )
     for root, _, files in os.walk(source_dir):
         for filename in files:
@@ -36,7 +36,7 @@ def find_source_test_cases(source_root, group, is_unit):
             with open(filepath, errors="replace") as f:
                 content = f.read()
             for match in pattern.finditer(content):
-                test_names.add(match.group(1))
+                test_names.add(match.group(1) or match.group(2))
 
     return test_names
 
@@ -79,12 +79,11 @@ def main():
 
     if missing:
         print(
-            "ERROR: The following Catch2 test cases have no entry in their YAML config:",
+            f"[check_sources] {WARNING}WARNING: The following Catch2 test cases have no entry in their YAML config:{RESET}",
             file=sys.stderr,
         )
         for entry in missing:
-            print(entry, file=sys.stderr)
-        sys.exit(1)
+            print(f"[check_sources] {WARNING}{entry}{RESET}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/projects/hip-tests/catch/config/common.py
+++ b/projects/hip-tests/catch/config/common.py
@@ -16,6 +16,10 @@ NON_UNIT_GROUPS = [
     "TypeQualifiers",
 ]
 
+WARNING = "\033[0;33m"
+ERROR = "\033[0;31m"
+RESET = "\033[0m"
+
 
 def parse_size_string(size_str):
     """Convert size string (1K, 1M, 1G) to bytes.
@@ -63,14 +67,18 @@ def load_config(file_path, definitions_text):
 
 
 def iter_group_configs(configs_path):
-    """Yield (group, config) pairs for all unit and non-unit config files.
+    """Yield (group, cases) pairs for all unit and non-unit config files.
 
     Iterates unit configs first (sorted alphabetically), then non-unit groups
-    in the order defined by NON_UNIT_GROUPS.
+    in the order defined by NON_UNIT_GROUPS. Empty case entries (YAML keys
+    with no value) are yielded as empty dicts rather than ``None``.
     """
     definitions_path = os.path.join(configs_path, "definitions.yaml")
     with open(definitions_path) as file:
         definitions_text = file.read()
+
+    def _normalize(cases):
+        return {name: (cfg or {}) for name, cfg in (cases or {}).items()}
 
     unit_config_dir = os.path.join(configs_path, "unit")
     for config_file in sorted(glob.glob(os.path.join(unit_config_dir, "*.yaml"))):
@@ -78,9 +86,9 @@ def iter_group_configs(configs_path):
         group = os.path.splitext(os.path.basename(config_file))[0]
         if group not in config:
             continue
-        yield group, config[group]
+        yield group, _normalize(config[group])
 
     for group in NON_UNIT_GROUPS:
         config_file = os.path.join(configs_path, f"{group}.yaml")
         config = load_config(config_file, definitions_text)
-        yield group, config[group]
+        yield group, _normalize(config[group])

--- a/projects/hip-tests/catch/config/common.py
+++ b/projects/hip-tests/catch/config/common.py
@@ -4,6 +4,7 @@
 
 import glob
 import os
+import sys
 
 import yaml
 
@@ -16,9 +17,10 @@ NON_UNIT_GROUPS = [
     "TypeQualifiers",
 ]
 
-WARNING = "\033[0;33m"
-ERROR = "\033[0;31m"
-RESET = "\033[0m"
+_use_color = sys.stderr.isatty() and not os.environ.get("NO_COLOR")
+WARNING = "\033[0;33m" if _use_color else ""
+ERROR = "\033[0;31m" if _use_color else ""
+RESET = "\033[0m" if _use_color else ""
 
 
 def parse_size_string(size_str):

--- a/projects/hip-tests/catch/config/common.py
+++ b/projects/hip-tests/catch/config/common.py
@@ -17,6 +17,10 @@ NON_UNIT_GROUPS = [
     "TypeQualifiers",
 ]
 
+WARNING = "\033[0;33m"
+ERROR = "\033[0;31m"
+RESET = "\033[0m"
+
 
 def parse_size_string(size_str):
     """Convert size string (1K, 1M, 1G) to bytes.
@@ -64,14 +68,18 @@ def load_config(file_path, definitions_text):
 
 
 def iter_group_configs(configs_path):
-    """Yield (group, config) pairs for all unit and non-unit config files.
+    """Yield (group, cases) pairs for all unit and non-unit config files.
 
     Iterates unit configs first (sorted alphabetically), then non-unit groups
-    in the order defined by NON_UNIT_GROUPS.
+    in the order defined by NON_UNIT_GROUPS. Empty case entries (YAML keys
+    with no value) are yielded as empty dicts rather than ``None``.
     """
     definitions_path = os.path.join(configs_path, "definitions.yaml")
     with open(definitions_path) as file:
         definitions_text = file.read()
+
+    def _normalize(cases):
+        return {name: (cfg or {}) for name, cfg in (cases or {}).items()}
 
     unit_config_dir = os.path.join(configs_path, "unit")
     for config_file in sorted(glob.glob(os.path.join(unit_config_dir, "*.yaml"))):
@@ -79,9 +87,9 @@ def iter_group_configs(configs_path):
         group = os.path.splitext(os.path.basename(config_file))[0]
         if group not in config:
             continue
-        yield group, config[group]
+        yield group, _normalize(config[group])
 
     for group in NON_UNIT_GROUPS:
         config_file = os.path.join(configs_path, f"{group}.yaml")
         config = load_config(config_file, definitions_text)
-        yield group, config[group]
+        yield group, _normalize(config[group])


### PR DESCRIPTION
## Motivation

It is quite annoying and counter-productive to enforce failing a local build if a test entry is not added to the yaml configurations. Instead, print a warning

## Technical Details

-

## JIRA ID

-

## Test Plan

Ensure build passes. All tests pass

## Test Result

Local build passed, local tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.