### PR TITLE
[clr] fix the scope of this_cluster

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
@@ -1343,7 +1343,7 @@ struct bit_or {
  * separate WGP processor. Sizing, cluster size is in workgroups, workgroups size is in threads.
  */
 class cluster_group {
-  friend __device__ cluster_group this_cluster();
+  friend __CG_QUALIFIER__ cluster_group this_cluster();
 
   // Default constructor, hidden
   __CG_QUALIFIER__ cluster_group() {}
@@ -1413,7 +1413,7 @@ class cluster_group {
  *
  * \return cluster_group
  */
-__device__ cluster_group this_cluster() {
+__CG_QUALIFIER__ cluster_group this_cluster() {
   cluster_group cg;
   return cg;
 }


### PR DESCRIPTION
## Motivation

`this_cluster` is defined as `__device__` which causes issues when we have multiple translation units.

## Technical Details

It should have `__CG_QUALIFIER__` qualifier.

## JIRA ID

NA

## Test Plan

Orochi should work fine

## Test Result

Awaiting results

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
