### PR TITLE
[rocprofv3] Sglang Signal Handler Fix

### DIFF
--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -897,6 +897,16 @@ For attachment profiling of running processes:
 
     add_parser_bool_argument(
         advanced_options,
+        "--disable-wait-for-children",
+        help="""Disables waiting for child processes to exit before finalizing in the
+        rocprofv3 signal handler. When --disable-wait-for-children is set to true,
+        rocprofv3 will proceed directly to finalization upon receiving a signal without
+        waiting for child processes. Useful when child processes do not respond to
+        termination signals (e.g. torch inductor compile workers).""",
+    )
+
+    add_parser_bool_argument(
+        advanced_options,
         "--process-sync",
         help="""Enables the process synchronization in the rocprofv3 tool finalization stage.
         When --process-sync is set to true,
@@ -1955,6 +1965,9 @@ def run(app_args, args, **kwargs):
 
     if args.disable_signal_handlers is not None:
         update_env("ROCPROF_SIGNAL_HANDLERS", not args.disable_signal_handlers)
+
+    if args.disable_wait_for_children is not None:
+        update_env("ROCPROF_WAIT_FOR_CHILDREN", not args.disable_wait_for_children)
 
     if args.process_sync is not None:
         update_env("ROCPROF_PROCESS_SYNC", args.process_sync)

--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -907,6 +907,17 @@ For attachment profiling of running processes:
 
     add_parser_bool_argument(
         advanced_options,
+        "--skip-reraise",
+        help="""After rocprofv3 finalization, skip re-raising the signal when a chained
+        signal handler was invoked. Useful when profiling Python processes where the
+        chained handler (e.g. Python's SIGINT handler) is designed to return without
+        terminating the process. Without this flag, rocprofv3 re-raises the signal
+        after the chained handler returns, which kills the process before Python can
+        act on its pending KeyboardInterrupt.""",
+    )
+
+    add_parser_bool_argument(
+        advanced_options,
         "--process-sync",
         help="""Enables the process synchronization in the rocprofv3 tool finalization stage.
         When --process-sync is set to true,
@@ -1967,7 +1978,10 @@ def run(app_args, args, **kwargs):
         update_env("ROCPROF_SIGNAL_HANDLERS", not args.disable_signal_handlers)
 
     if args.disable_wait_for_children is not None:
-        update_env("ROCPROF_WAIT_FOR_CHILDREN", not args.disable_wait_for_children)
+        update_env("ROCPROF_DISABLE_WAIT_FOR_CHILDREN", args.disable_wait_for_children)
+
+    if args.skip_reraise is not None:
+        update_env("ROCPROF_SKIP_RERAISE", args.skip_reraise)
 
     if args.process_sync is not None:
         update_env("ROCPROF_PROCESS_SYNC", args.process_sync)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.hpp
@@ -137,6 +137,7 @@ struct config : output_config
     bool   advanced_thread_trace         = get_env("ROCPROF_ADVANCED_THREAD_TRACE", false);
     bool   att_serialize_all             = get_env("ROCPROF_ATT_PARAM_SERIALIZE_ALL", false);
     bool   enable_signal_handlers        = get_env("ROCPROF_SIGNAL_HANDLERS", true);
+    bool   enable_wait_for_children      = get_env("ROCPROF_WAIT_FOR_CHILDREN", true);
     bool   enable_process_sync           = get_env("ROCPROF_PROCESS_SYNC", false);
     bool   selected_regions              = get_env("ROCPROF_SELECTED_REGIONS", false);
     bool   selected_regions_ref_count    = get_env("ROCPROF_SELECTED_REGIONS_REF_COUNT", false);
@@ -296,6 +297,7 @@ config::save(ArchiveT& ar) const
     CFG_SERIALIZE_MEMBER(truncate);
     CFG_SERIALIZE_MEMBER(minimum_output_bytes);
     CFG_SERIALIZE_MEMBER(enable_signal_handlers);
+    CFG_SERIALIZE_MEMBER(enable_wait_for_children);
     CFG_SERIALIZE_MEMBER(enable_process_sync);
     CFG_SERIALIZE_MEMBER(selected_regions);
     CFG_SERIALIZE_MEMBER(selected_regions_ref_count);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.hpp
@@ -137,7 +137,8 @@ struct config : output_config
     bool   advanced_thread_trace         = get_env("ROCPROF_ADVANCED_THREAD_TRACE", false);
     bool   att_serialize_all             = get_env("ROCPROF_ATT_PARAM_SERIALIZE_ALL", false);
     bool   enable_signal_handlers        = get_env("ROCPROF_SIGNAL_HANDLERS", true);
-    bool   enable_wait_for_children      = get_env("ROCPROF_WAIT_FOR_CHILDREN", true);
+    bool   disable_wait_for_children     = get_env("ROCPROF_DISABLE_WAIT_FOR_CHILDREN", false);
+    bool   skip_reraise_after_chain      = get_env("ROCPROF_SKIP_RERAISE", false);
     bool   enable_process_sync           = get_env("ROCPROF_PROCESS_SYNC", false);
     bool   selected_regions              = get_env("ROCPROF_SELECTED_REGIONS", false);
     bool   selected_regions_ref_count    = get_env("ROCPROF_SELECTED_REGIONS_REF_COUNT", false);
@@ -297,7 +298,8 @@ config::save(ArchiveT& ar) const
     CFG_SERIALIZE_MEMBER(truncate);
     CFG_SERIALIZE_MEMBER(minimum_output_bytes);
     CFG_SERIALIZE_MEMBER(enable_signal_handlers);
-    CFG_SERIALIZE_MEMBER(enable_wait_for_children);
+    CFG_SERIALIZE_MEMBER(disable_wait_for_children);
+    CFG_SERIALIZE_MEMBER(skip_reraise_after_chain);
     CFG_SERIALIZE_MEMBER(enable_process_sync);
     CFG_SERIALIZE_MEMBER(selected_regions);
     CFG_SERIALIZE_MEMBER(selected_regions_ref_count);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -3497,19 +3497,32 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
         };
 
         auto _children = get_children();
-        ROCP_WARNING << fmt::format(
-            "[PPID={}][PID={}][TID={}][{}] rocprofv3 will wait for {} children to exit",
-            this_ppid,
-            this_pid,
-            this_tid,
-            this_func,
-            _children.size());
-
-        // wait for children
-        for(auto itr : _children)
+        if(tool::get_config().enable_wait_for_children)
         {
-            auto status = wait_pid(itr, WUNTRACED | WNOHANG);
-            if(status) diagnose_status(itr, status.value());
+            ROCP_WARNING << fmt::format(
+                "[PPID={}][PID={}][TID={}][{}] rocprofv3 will wait for {} children to exit",
+                this_ppid,
+                this_pid,
+                this_tid,
+                this_func,
+                _children.size());
+
+            for(auto itr : _children)
+            {
+                auto status = wait_pid(itr, WUNTRACED | WNOHANG);
+                if(status) diagnose_status(itr, status.value());
+            }
+        }
+        else
+        {
+            ROCP_INFO << fmt::format(
+                "[PPID={}][PID={}][TID={}][{}] rocprofv3 skipping wait for {} children "
+                "(ROCPROF_WAIT_FOR_CHILDREN=0)",
+                this_ppid,
+                this_pid,
+                this_tid,
+                this_func,
+                _children.size());
         }
 
         ROCP_WARNING << fmt::format(

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -3762,6 +3762,11 @@ rocprofv3_sigaction(int signum,
     if((act->sa_flags & SA_SIGINFO) == SA_SIGINFO &&
        act->sa_sigaction != &rocprofv3_error_signal_handler)
         get_chained_signals().at(signum) = chained_siginfo{signum, nullptr, *act};
+    // Also capture plain sa_handler (e.g. Python's SIGINT handler, which uses plain
+    // sa_handler without SA_SIGINFO). Without this, Python's handler would be silently
+    // discarded and the chained slot would stay empty. SIG_DFL/SIG_IGN are excluded
+    // because SIG_IGN is used by Python's multiprocessing spawn bootstrap and calling
+    // it as a function pointer would be undefined behavior.
     else if((act->sa_flags & SA_SIGINFO) != SA_SIGINFO && act->sa_handler &&
             act->sa_handler != SIG_DFL && act->sa_handler != SIG_IGN)
         get_chained_signals().at(signum) = chained_siginfo{signum, act->sa_handler, std::nullopt};

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -3481,6 +3481,7 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
                                 this_func,
                                 signo);
 
+    bool         chained_handler_invoked = false;
     static auto _once = std::once_flag{};
     std::call_once(_once, [&]() {
         auto get_children = [&this_pid]() {
@@ -3576,6 +3577,7 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
                         this_func,
                         signo);
                     _chained.action->sa_sigaction(signo, info, ucontext);
+                    chained_handler_invoked = true;
                 }
                 else if((_chained.action->sa_flags & SA_SIGINFO) != SA_SIGINFO &&
                         _chained.action->sa_handler &&
@@ -3590,6 +3592,7 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
                         this_func,
                         signo);
                     _chained.action->sa_handler(signo);
+                    chained_handler_invoked = true;
                 }
             }
             else
@@ -3605,6 +3608,7 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
                         this_func,
                         signo);
                     _chained.handler(signo);
+                    chained_handler_invoked = true;
                 }
             }
         }
@@ -3612,7 +3616,7 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
 
     // below is for testing purposes. re-raising the signal causes CTest to ignore WILL_FAIL ON
     if(signal_handler_exit) ::quick_exit(signo);
-    ::raise(signo);
+    if(!chained_handler_invoked) ::raise(signo);
 }
 
 int
@@ -3758,6 +3762,9 @@ rocprofv3_sigaction(int signum,
     if((act->sa_flags & SA_SIGINFO) == SA_SIGINFO &&
        act->sa_sigaction != &rocprofv3_error_signal_handler)
         get_chained_signals().at(signum) = chained_siginfo{signum, nullptr, *act};
+    else if((act->sa_flags & SA_SIGINFO) != SA_SIGINFO && act->sa_handler &&
+            act->sa_handler != SIG_DFL && act->sa_handler != SIG_IGN)
+        get_chained_signals().at(signum) = chained_siginfo{signum, act->sa_handler, std::nullopt};
 
     struct sigaction _upd_act = *act;
     _upd_act.sa_flags |= (SA_SIGINFO | SA_RESETHAND | SA_NOCLDSTOP);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -3481,8 +3481,8 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
                                 this_func,
                                 signo);
 
-    bool         chained_handler_invoked = false;
-    static auto _once = std::once_flag{};
+    bool        chained_handler_invoked = false;
+    static auto _once                   = std::once_flag{};
     std::call_once(_once, [&]() {
         auto get_children = [&this_pid]() {
             auto fname    = fmt::format("/proc/{}/task/{}/children", this_pid, this_pid);
@@ -3498,7 +3498,7 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
         };
 
         auto _children = get_children();
-        if(tool::get_config().enable_wait_for_children)
+        if(!tool::get_config().disable_wait_for_children)
         {
             ROCP_WARNING << fmt::format(
                 "[PPID={}][PID={}][TID={}][{}] rocprofv3 will wait for {} children to exit",
@@ -3518,7 +3518,7 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
         {
             ROCP_INFO << fmt::format(
                 "[PPID={}][PID={}][TID={}][{}] rocprofv3 skipping wait for {} children "
-                "(ROCPROF_WAIT_FOR_CHILDREN=0)",
+                "(ROCPROF_DISABLE_WAIT_FOR_CHILDREN=1)",
                 this_ppid,
                 this_pid,
                 this_tid,
@@ -3616,7 +3616,7 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
 
     // below is for testing purposes. re-raising the signal causes CTest to ignore WILL_FAIL ON
     if(signal_handler_exit) ::quick_exit(signo);
-    if(!chained_handler_invoked) ::raise(signo);
+    if(!chained_handler_invoked || !tool::get_config().skip_reraise_after_chain) ::raise(signo);
 }
 
 int


### PR DESCRIPTION
## Motivation

There is a currently a hang when shutting down sglang servers when the rocprofv3 tool is attached. This change works together with a separate sglang code to have the rocprofv3 tool write output files and exit after a shutdown period.

## Technical Details

The hang is due to sglang spawning torch compiler processes as children of it's scheduling/worker processes. Unfortunately, these torch compiler processes do not respond to the SIGINT signal when the user attempts to shut down the sglang server with Ctrl^C. As it stands, the sglang processes enter the signal handler, waits for the torch compiler processes to exit before proceeding, the torch compiler processes do not exit since they do not respond to the SIGINT signal, and all sglang processes are stuck until the user hits Ctrl^C again and kills all the sglang processes, resulting in no output being written. Disabling signal handlers also did not work to resolve this since the main sglang would kill all processes immediately during shutdown leaving no time for rocprofv3 to output any files. Adding a shutdown timeout and disabling signal handlers would not work since rocprofv3 do not begin exiting without the signal handlers; the processes wait without writing any output until the shutdown timeout ends and then are killed.

To fix this hang, I created a PR for sglang where we add a shutdown timeout to sglang. This gives the rocprofv3 tool sufficient time to output all requested files before termination. Then there are three major changes to signal handling on the rocprofv3 tool side.

 1. Add `disable-wait-for-children` flag. This allows rocprofv3 to start writing the output files after receiving the SIGINT signal without waiting for the torch compiler processes to exit. 
 2. Add fix to save python SIGINT handler
 3. Add chained signal handler flag and option to skip ::raise() with `--skip-reraise`. This is a consequence of skipping the children wait (change 1) and python's code. With default behavior, the raise immediately kills the sglang process without hitting the `finally` block and hitting the shutdown timeout. With the new flag, we let the the Python exception handler run, hitting the timeout code I added in the PR.

I'm not exactly enthusiastic about this PR, so please let me know if anyone has any alternative ideas to handle this

## JIRA ID

Resolves AIPROFSDK-786

## Test Plan

Ran workload described in ticket and confirmed output is generated.

## Test Result

Output was generated in ticket workload

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
