### PR TITLE
ROCR: Use userspace libdrm header path for amd_xdna_driver.cpp

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -52,7 +52,7 @@
 #include <string_view>
 #include <utility>
 
-#include <drm/drm.h>
+#include <libdrm/drm.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -52,8 +52,8 @@
 #include <string_view>
 #include <utility>
 
-#include <libdrm/drm.h>
 #include <fcntl.h>
+#include <libdrm/drm.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <unistd.h>


### PR DESCRIPTION
## Motivation

The SLES 15.6 ROCProfiler SDK CI fails while building ROCR with:

`fatal error: 'drm/drm.h' file not found`
This fixes the ROCR build on SLES without adding OS-specific include path assumptions.
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
