### PR TITLE
[ROCM-21057] Fall back to pp_dpm_* sysfs when SMU power-gates clock domains

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -225,6 +225,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
     Several items were misaligned in the default output, and this change ensures a consistent left-aligned format across all fields.
   - *This change is purely cosmetic and does not affect any functionality.*
 
+- **Fixed `amd-smi static -C` reporting `N/A` for SYS/MEM/DF/SOC/DCEF clocks at idle on gfx1151-class APUs**.
+  - `get_frequencies()` in the rsmi backend no longer discards a parsed `pp_dpm_*` DPM table with `STATUS_UNEXPECTED_DATA` when the kernel omits the `*` current-level marker (which happens whenever the SMU power-gates the domain at idle). The supported frequency table is now returned and `current` is reported as `-1` (unknown) until the marker reappears, so `amdsmi_get_clk_freq()` and all callers see the table at idle as well as under load.
+
 ## amd_smi_lib for ROCm 7.12.0
 
 ### Added

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -136,7 +136,7 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - *This change is purely cosmetic and does not affect any functionality.*  
 
 - **Fixed `amd-smi static -C` reporting `N/A` for SYS/MEM/DF/SOC/DCEF clocks at idle on gfx1151-class APUs **.  
-  - Extended `amdsmi_get_clk_freq()` to fall back to the `pp_dpm_*` sysfs DPM tables when the firmware/`gpu_metrics` path returns no data (the SMU power-gates these domains at idle and `STATUS_UNEXPECTED_DATA` is returned). The supported frequency table is now reported at idle, and the current level is emitted whenever the kernel exposes the `*` marker. The existing VCLK/DCLK sysfs reader was extracted into a shared helper to back both paths and remove duplication.
+  - `get_frequencies()` in the rsmi backend no longer discards a parsed `pp_dpm_*` DPM table with `STATUS_UNEXPECTED_DATA` when the kernel omits the `*` current-level marker (which happens whenever the SMU power-gates the domain at idle). The supported frequency table is now returned and `current` is reported as `-1` (unknown) until the marker reappears, so `amdsmi_get_clk_freq()` and all callers see the table at idle as well as under load.
 
 ### Changed
 

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -135,6 +135,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
     Several items were misaligned in the default output, and this change ensures a consistent left-aligned format across all fields.
   - *This change is purely cosmetic and does not affect any functionality.*  
 
+- **Fixed `amd-smi static -C` reporting `N/A` for SYS/MEM/DF/SOC/DCEF clocks at idle on gfx1151-class APUs (ROCM-21057)**.  
+  - Extended `amdsmi_get_clk_freq()` to fall back to the `pp_dpm_*` sysfs DPM tables when the firmware/`gpu_metrics` path returns no data (the SMU power-gates these domains at idle and `STATUS_UNEXPECTED_DATA` is returned). The supported frequency table is now reported at idle, and the current level is emitted whenever the kernel exposes the `*` marker. The existing VCLK/DCLK sysfs reader was extracted into a shared helper to back both paths and remove duplication.
+
 ### Changed
 
 - **Package install no longer modifies the system-wide logrotate timer or cron schedule**.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -135,7 +135,7 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
     Several items were misaligned in the default output, and this change ensures a consistent left-aligned format across all fields.
   - *This change is purely cosmetic and does not affect any functionality.*  
 
-- **Fixed `amd-smi static -C` reporting `N/A` for SYS/MEM/DF/SOC/DCEF clocks at idle on gfx1151-class APUs (ROCM-21057)**.  
+- **Fixed `amd-smi static -C` reporting `N/A` for SYS/MEM/DF/SOC/DCEF clocks at idle on gfx1151-class APUs **.  
   - Extended `amdsmi_get_clk_freq()` to fall back to the `pp_dpm_*` sysfs DPM tables when the firmware/`gpu_metrics` path returns no data (the SMU power-gates these domains at idle and `STATUS_UNEXPECTED_DATA` is returned). The supported frequency table is now reported at idle, and the current level is emitted whenever the kernel exposes the `*` marker. The existing VCLK/DCLK sysfs reader was extracted into a shared helper to back both paths and remove duplication.
 
 ### Changed

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -1899,6 +1899,13 @@ class AMDSMICommands:
                             continue
                         freq_dict = {}
                         current_level = frequencies["current"]
+                        # The C library reports current = (uint32_t)-1 when the
+                        # kernel exposes the pp_dpm_* table without a '*'
+                        # current-level marker (e.g. SMU power-gated domains
+                        # on gfx1151 APUs at idle). Surface that as N/A so
+                        # the CLI doesn't show 4294967295 to users.
+                        if current_level == 0xFFFFFFFF:
+                            current_level = "N/A"
                         # Add current_level first for proper output ordering
                         freq_dict.update({"current_level": current_level})
                         # Add frequency_levels second

--- a/projects/amdsmi/amdsmi_cli/subcommands/metric.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/metric.py
@@ -717,14 +717,24 @@ class MetricCommands:
                     frequency_dict = amdsmi_interface.amdsmi_get_clk_freq(
                         args.gpu, amdsmi_interface.AmdSmiClkType.DF
                     )
-                    current_fclk_clock = frequency_dict["frequency"][frequency_dict["current"]]
+                    # The C library reports current = (uint32_t)-1 when the
+                    # kernel exposes pp_dpm_fclk without a '*' current-level
+                    # marker (e.g. SMU power-gated DF on gfx1151 APUs at idle).
+                    # Treat that as "no current frequency" so we don't index
+                    # out of range.
+                    current_fclk_index = frequency_dict["current"]
+                    if current_fclk_index == 0xFFFFFFFF or current_fclk_index >= len(
+                        frequency_dict["frequency"]
+                    ):
+                        raise IndexError("no current fclk level reported by kernel")
+                    current_fclk_clock = frequency_dict["frequency"][current_fclk_index]
                     current_fclk_clock = self.helpers.convert_SI_unit(
                         current_fclk_clock, self.helpers.SI_Unit.MICRO
                     )
                     clocks["fclk_0"]["clk"] = self.helpers.unit_format(
                         self.logger, current_fclk_clock, clock_unit
                     )
-                except (KeyError, amdsmi_exception.AmdSmiLibraryException) as e:
+                except (KeyError, IndexError, amdsmi_exception.AmdSmiLibraryException) as e:
                     logging.debug("Failed to get fclk info for gpu %s | %s", gpu_id, e)
 
                 # Populate SOCCLK clock value

--- a/projects/amdsmi/amdsmi_cli/subcommands/static.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/static.py
@@ -1225,6 +1225,13 @@ class StaticCommands:
                             continue
                         freq_dict = {}
                         current_level = frequencies["current"]
+                        # The C library reports current = (uint32_t)-1 when the
+                        # kernel exposes the pp_dpm_* table without a '*'
+                        # current-level marker (e.g. SMU power-gated domains
+                        # on gfx1151 APUs at idle). Surface that as N/A so
+                        # the CLI doesn't show 4294967295 to users.
+                        if current_level == 0xFFFFFFFF:
+                            current_level = "N/A"
                         # Add current_level first for proper output ordering
                         freq_dict.update({"current_level": current_level})
                         # Add frequency_levels second

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -1978,7 +1978,11 @@ typedef struct {
 typedef struct {
   bool has_deep_sleep;     //!< Deep Sleep frequency is only supported by some GPUs
   uint32_t num_supported;  //!< The number of supported frequencies
-  uint32_t current;        //!< The current frequency index
+  uint32_t current;        //!< The current frequency index. May be (uint32_t)-1
+                           //!< when the clock domain is power-gated / in sleep
+                           //!< mode and no current level is reported by the
+                           //!< kernel (e.g. SYS/MEM/DF/SOC/DCEF at idle on
+                           //!< some APUs).
   uint64_t frequency[AMDSMI_MAX_NUM_FREQUENCIES]; /**< List of frequencies in Hz. Only the first
                                                        num_supported frequencies are valid */
 } amdsmi_frequencies_t;

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -1913,7 +1913,11 @@ typedef struct {
 typedef struct {
   bool has_deep_sleep;     //!< Deep Sleep frequency is only supported by some GPUs
   uint32_t num_supported;  //!< The number of supported frequencies
-  uint32_t current;        //!< The current frequency index in MHz
+  uint32_t current;        //!< The current frequency index. May be (uint32_t)-1
+                           //!< when the clock domain is power-gated / in sleep
+                           //!< mode and no current level is reported by the
+                           //!< kernel (e.g. SYS/MEM/DF/SOC/DCEF at idle on
+                           //!< some APUs).
   uint64_t frequency[AMDSMI_MAX_NUM_FREQUENCIES]; /**< List of frequencies in MHz. Only the first
                                                        num_supported frequencies are valid */
 } amdsmi_frequencies_t;

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_utils.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_utils.h
@@ -279,4 +279,40 @@ std::string stringify_bdf(const amdsmi_bdf_t& bdf);
  *  @retval ::Tuple of domain, bus, device, function
  */
 std::tuple<uint64_t, uint64_t, uint64_t, uint64_t> parse_bdfid(uint64_t bdfid);
+
+/**
+ *  @brief Read a pp_dpm_* sysfs file and populate an amdsmi_frequencies_t.
+ *
+ *  @details Parses the kernel's per-domain DPM table (e.g. pp_dpm_vclk,
+ *  pp_dpm_dclk) for the given device. Lines look like:
+ *      0: 200Mhz
+ *      1: 400Mhz *
+ *      2: 800Mhz
+ *  The '*' marker is recorded into @p f->current.
+ *
+ *  @param[in]  device       Device whose render node sysfs is read.
+ *  @param[in]  pp_dpm_file  Basename of the sysfs file (e.g. "pp_dpm_vclk").
+ *  @param[out] f            Frequencies struct to populate.
+ *
+ *  @retval ::AMDSMI_STATUS_SUCCESS on success.
+ *          ::AMDSMI_STATUS_INVAL if @p f is null.
+ *          ::AMDSMI_STATUS_NOT_SUPPORTED if the sysfs file is missing or empty.
+ */
+amdsmi_status_t smi_amdgpu_read_clk_freq_from_pp_dpm(amd::smi::AMDSmiGPUDevice* device,
+                                                     const char* pp_dpm_file,
+                                                     amdsmi_frequencies_t* f);
+
+/**
+ *  @brief Map a VCLK/DCLK clock type to its pp_dpm_* sysfs filename.
+ *
+ *  rsmi does not expose these clock types via gpu_metrics, so amdsmi reads
+ *  them directly from sysfs.
+ *
+ *  @param[in] clk_type Clock type.
+ *
+ *  @retval Pointer to a static filename string, or nullptr for clock types
+ *          that are not VCLK0/VCLK1/DCLK0/DCLK1.
+ */
+const char* smi_amdgpu_pp_dpm_filename_for_clk_type(amdsmi_clk_type_t clk_type);
+
 #endif  // AMD_SMI_INCLUDE_AMD_SMI_UTILS_H_

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -1428,11 +1428,15 @@ static rsmi_status_t get_frequencies(amd::smi::DevInfoTypes type, rsmi_clk_type_
     }
   }
 
-  // Some older drivers will not have the current frequency set
-  // assert(f->current < f->num_supported);
+  // Some older drivers, and SMU power-gated domains on APUs (e.g. gfx1151
+  // SYS/DF/DCEF/SOC/MEM at idle), expose the supported DPM table in
+  // pp_dpm_* without flagging any level as current ('*' marker absent).
+  // Treat that as "current unknown" rather than discarding the parsed
+  // table: keep f->num_supported / f->frequency populated and signal
+  // "no current level" via f->current = -1 so callers can still report
+  // the frequency table.
   if (f->current >= f->num_supported) {
     f->current = -1;
-    return RSMI_STATUS_UNEXPECTED_DATA;
   }
 
   return RSMI_STATUS_SUCCESS;

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -1428,11 +1428,15 @@ static rsmi_status_t get_frequencies(amd::smi::DevInfoTypes type, rsmi_clk_type_
     }
   }
 
-  // Some older drivers will not have the current frequency set
-  // assert(f->current < f->num_supported);
+  // Some older drivers, and SMU power-gated domains on APUs (e.g. gfx1151
+  // SYS/DF/DCEF/SOC/MEM at idle), expose the supported DPM table in
+  // pp_dpm_* without flagging any level as current ('*' marker absent).
+  // Treat that as "current unknown" rather than discarding the parsed
+  // table: keep f->num_supported / f->frequency populated and signal
+  // "no current level" via f->current = -1 so callers can still report
+  // the frequency table.
   if (f->current >= f->num_supported) {
     f->current = -1;
-    return RSMI_STATUS_UNEXPECTED_DATA;
   }
 
   return RSMI_STATUS_SUCCESS;
@@ -2262,7 +2266,7 @@ rsmi_status_t rsmi_dev_process_isolation_set(uint32_t dv_ind, uint32_t pisolate)
 
   // To set the values,need to specify the setting for all of the partitions
   // For two partition
-  // echo "1 0"  | sudo tee  /sys/class/drm/cardX/device/enforce_isolation
+  // echo "1 0"  | sudo tee Â /sys/class/drm/cardX/device/enforce_isolation
   uint32_t partition_id = 0;
   rsmi_dev_partition_id_get(dv_ind, &partition_id);
   std::string str_val;
@@ -2321,7 +2325,7 @@ rsmi_status_t rsmi_dev_gpu_run_cleaner_shader(uint32_t dv_ind) {
   GET_DEV_FROM_INDX
 
   // To reset you need to provide the partition id
-  // echo "0" | sudo tee  /sys/class/drm/cardX/device/run_cleaner_shader
+  // echo "0" | sudo tee Â /sys/class/drm/cardX/device/run_cleaner_shader
   uint32_t partition_id = 0;
   rsmi_dev_partition_id_get(dv_ind, &partition_id);
   std::string value = std::to_string(partition_id);
@@ -3293,7 +3297,7 @@ rsmi_status_t rsmi_dev_temp_metric_get(uint32_t dv_ind, uint32_t sensor_type,
   uint16_t val_ui16;
   GET_DEV_FROM_INDX
   // DEVICE_MUTEX moved before the HBM/gpuboard early-return paths so that
-  // all code paths — including the HBM temperature block — hold the lock.
+  // all code paths â€” including the HBM temperature block â€” hold the lock.
   // Previously the mutex was acquired after those blocks, leaving them unprotected.
   DEVICE_MUTEX
 

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -2266,7 +2266,7 @@ rsmi_status_t rsmi_dev_process_isolation_set(uint32_t dv_ind, uint32_t pisolate)
 
   // To set the values,need to specify the setting for all of the partitions
   // For two partition
-  // echo "1 0"  | sudo tee /sys/class/drm/cardX/device/enforce_isolation
+  // echo "1 0"  | sudo tee  /sys/class/drm/cardX/device/enforce_isolation
   uint32_t partition_id = 0;
   rsmi_dev_partition_id_get(dv_ind, &partition_id);
   std::string str_val;
@@ -2325,7 +2325,7 @@ rsmi_status_t rsmi_dev_gpu_run_cleaner_shader(uint32_t dv_ind) {
   GET_DEV_FROM_INDX
 
   // To reset you need to provide the partition id
-  // echo "0" | sudo tee /sys/class/drm/cardX/device/run_cleaner_shader
+  // echo "0" | sudo tee  /sys/class/drm/cardX/device/run_cleaner_shader
   uint32_t partition_id = 0;
   rsmi_dev_partition_id_get(dv_ind, &partition_id);
   std::string value = std::to_string(partition_id);

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -2266,7 +2266,7 @@ rsmi_status_t rsmi_dev_process_isolation_set(uint32_t dv_ind, uint32_t pisolate)
 
   // To set the values,need to specify the setting for all of the partitions
   // For two partition
-  // echo "1 0"  | sudo tee Â /sys/class/drm/cardX/device/enforce_isolation
+  // echo "1 0"  | sudo tee /sys/class/drm/cardX/device/enforce_isolation
   uint32_t partition_id = 0;
   rsmi_dev_partition_id_get(dv_ind, &partition_id);
   std::string str_val;
@@ -2325,7 +2325,7 @@ rsmi_status_t rsmi_dev_gpu_run_cleaner_shader(uint32_t dv_ind) {
   GET_DEV_FROM_INDX
 
   // To reset you need to provide the partition id
-  // echo "0" | sudo tee Â /sys/class/drm/cardX/device/run_cleaner_shader
+  // echo "0" | sudo tee /sys/class/drm/cardX/device/run_cleaner_shader
   uint32_t partition_id = 0;
   rsmi_dev_partition_id_get(dv_ind, &partition_id);
   std::string value = std::to_string(partition_id);
@@ -3297,7 +3297,7 @@ rsmi_status_t rsmi_dev_temp_metric_get(uint32_t dv_ind, uint32_t sensor_type,
   uint16_t val_ui16;
   GET_DEV_FROM_INDX
   // DEVICE_MUTEX moved before the HBM/gpuboard early-return paths so that
-  // all code paths â€” including the HBM temperature block â€” hold the lock.
+  // all code paths — including the HBM temperature block — hold the lock.
   // Previously the mutex was acquired after those blocks, leaving them unprotected.
   DEVICE_MUTEX
 

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -4116,122 +4116,21 @@ amdsmi_status_t amdsmi_get_gpu_pci_bandwidth(amdsmi_processor_handle processor_h
                       reinterpret_cast<rsmi_pcie_bandwidth_t*>(bandwidth));
 }
 
-// TODO(bliu): other frequencies in amdsmi_clk_type_t
 amdsmi_status_t amdsmi_get_clk_freq(amdsmi_processor_handle processor_handle,
                                     amdsmi_clk_type_t clk_type, amdsmi_frequencies_t* f) {
   AMDSMI_CHECK_INIT();
   // nullptr api supported
 
-  // Read VCLK/DCLK from sysfs pp_dpm files instead of gpu_metrics
+  // VCLK/DCLK have no rsmi/gpu_metrics path; read directly from pp_dpm_* sysfs.
   if (clk_type == AMDSMI_CLK_TYPE_VCLK0 || clk_type == AMDSMI_CLK_TYPE_VCLK1 ||
       clk_type == AMDSMI_CLK_TYPE_DCLK0 || clk_type == AMDSMI_CLK_TYPE_DCLK1) {
-    // Get the GPU device to access renderD number
     amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
     amdsmi_status_t status = get_gpu_device_from_handle(processor_handle, &gpu_device);
     if (status != AMDSMI_STATUS_SUCCESS) {
       return status;
     }
-
-    // Get renderD number for this GPU
-    uint32_t drm_render = gpu_device->get_drm_render_minor();
-
-    // Determine the sysfs file name based on clock type
-    const char* pp_dpm_file = nullptr;
-    if (clk_type == AMDSMI_CLK_TYPE_VCLK0) {
-      pp_dpm_file = "pp_dpm_vclk";
-    } else if (clk_type == AMDSMI_CLK_TYPE_VCLK1) {
-      pp_dpm_file = "pp_dpm_vclk1";
-    } else if (clk_type == AMDSMI_CLK_TYPE_DCLK0) {
-      pp_dpm_file = "pp_dpm_dclk";
-    } else if (clk_type == AMDSMI_CLK_TYPE_DCLK1) {
-      pp_dpm_file = "pp_dpm_dclk1";
-    }
-
-    // Construct the sysfs path: /sys/class/drm/renderD<num>/device/pp_dpm_*
-    std::string sysfs_path =
-        "/sys/class/drm/renderD" + std::to_string(drm_render) + "/device/" + pp_dpm_file;
-
-    // Check if the file exists
-    std::ifstream file(sysfs_path);
-    if (!file.good()) {
-      // File doesn't exist, fallback to gpu_metrics for backward compatibility
-      // or return not supported
-      return AMDSMI_STATUS_NOT_SUPPORTED;
-    }
-
-    // Parse the pp_dpm file
-    // Format example:
-    // 0: 200Mhz
-    // 1: 400Mhz *
-    // 2: 800Mhz
-    if (f == nullptr) {
-      return AMDSMI_STATUS_INVAL;
-    }
-
-    f->num_supported = 0;
-    f->current = 0;
-    f->has_deep_sleep = 0;
-
-    std::string line;
-    uint32_t level_index = 0;
-
-    while (std::getline(file, line) && level_index < AMDSMI_MAX_NUM_FREQUENCIES) {
-      // Parse line format: "0: 200Mhz" or "1: 400Mhz *"
-      size_t colon_pos = line.find(':');
-      if (colon_pos == std::string::npos) {
-        continue;
-      }
-
-      // Extract level number
-      std::string level_str = line.substr(0, colon_pos);
-      level_str.erase(0, level_str.find_first_not_of(" \t"));
-      level_str.erase(level_str.find_last_not_of(" \t") + 1);
-
-      // Extract frequency value
-      std::string freq_str = line.substr(colon_pos + 1);
-
-      // Check if this is the current level (marked with *)
-      bool is_current = (freq_str.find('*') != std::string::npos);
-      if (is_current) {
-        f->current = level_index;
-      }
-
-      // Remove asterisk and spaces
-      freq_str.erase(std::remove(freq_str.begin(), freq_str.end(), '*'), freq_str.end());
-      freq_str.erase(0, freq_str.find_first_not_of(" \t"));
-      freq_str.erase(freq_str.find_last_not_of(" \t") + 1);
-
-      // Parse frequency value (e.g., "200Mhz" or "200 Mhz")
-      uint64_t freq_value = 0;
-      char unit = 'M';  // Default to MHz
-
-      size_t unit_pos = freq_str.find_first_not_of("0123456789 ");
-      if (unit_pos != std::string::npos) {
-        std::string value_str = freq_str.substr(0, unit_pos);
-        value_str.erase(std::remove(value_str.begin(), value_str.end(), ' '), value_str.end());
-
-        try {
-          freq_value = std::stoull(value_str);
-        } catch (...) {
-          continue;  // Skip invalid lines
-        }
-
-        // Extract unit (M for MHz, G for GHz, etc.)
-        std::string unit_str = freq_str.substr(unit_pos);
-        if (!unit_str.empty()) {
-          unit = static_cast<char>(std::toupper(static_cast<unsigned char>(unit_str[0])));
-        }
-      }
-
-      // Convert to Hz based on unit
-      f->frequency[level_index] = freq_value * amd::smi::get_multiplier_from_char(unit);
-      level_index++;
-    }
-
-    f->num_supported = level_index;
-    file.close();
-
-    return (f->num_supported > 0) ? AMDSMI_STATUS_SUCCESS : AMDSMI_STATUS_NOT_SUPPORTED;
+    return smi_amdgpu_read_clk_freq_from_pp_dpm(
+        gpu_device, smi_amdgpu_pp_dpm_filename_for_clk_type(clk_type), f);
   }
 
   return rsmi_wrapper(rsmi_dev_gpu_clk_freq_get, processor_handle, 0,

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -4165,127 +4165,142 @@ amdsmi_status_t amdsmi_get_gpu_pci_bandwidth(amdsmi_processor_handle processor_h
                       reinterpret_cast<rsmi_pcie_bandwidth_t*>(bandwidth));
 }
 
-// TODO(bliu): other frequencies in amdsmi_clk_type_t
+// Read a pp_dpm_* sysfs file and populate amdsmi_frequencies_t.
+// Format example:
+//   0: 200Mhz
+//   1: 400Mhz *
+//   2: 800Mhz
+// Returns AMDSMI_STATUS_NOT_SUPPORTED if the file does not exist or is empty
+// (e.g. SMU power-gates the domain at idle and the kernel exposes an empty
+// file).
+static amdsmi_status_t read_clk_freq_from_pp_dpm(amdsmi_processor_handle processor_handle,
+                                                 const char* pp_dpm_file,
+                                                 amdsmi_frequencies_t* f) {
+  if (f == nullptr) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
+  amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
+  amdsmi_status_t status = get_gpu_device_from_handle(processor_handle, &gpu_device);
+  if (status != AMDSMI_STATUS_SUCCESS) {
+    return status;
+  }
+
+  uint32_t drm_render = gpu_device->get_drm_render_minor();
+  std::string sysfs_path =
+      "/sys/class/drm/renderD" + std::to_string(drm_render) + "/device/" + pp_dpm_file;
+
+  std::ifstream file(sysfs_path);
+  if (!file.good()) {
+    return AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+
+  f->num_supported = 0;
+  f->current = 0;
+  f->has_deep_sleep = 0;
+
+  std::string line;
+  uint32_t level_index = 0;
+
+  while (std::getline(file, line) && level_index < AMDSMI_MAX_NUM_FREQUENCIES) {
+    // Parse line format: "0: 200Mhz" or "1: 400Mhz *"
+    size_t colon_pos = line.find(':');
+    if (colon_pos == std::string::npos) {
+      continue;
+    }
+
+    std::string freq_str = line.substr(colon_pos + 1);
+
+    // Check if this is the current level (marked with *)
+    bool is_current = (freq_str.find('*') != std::string::npos);
+    if (is_current) {
+      f->current = level_index;
+    }
+
+    // Remove asterisk and surrounding whitespace
+    freq_str.erase(std::remove(freq_str.begin(), freq_str.end(), '*'), freq_str.end());
+    freq_str.erase(0, freq_str.find_first_not_of(" \t"));
+    size_t end = freq_str.find_last_not_of(" \t");
+    if (end != std::string::npos) {
+      freq_str.erase(end + 1);
+    }
+
+    // Parse "200Mhz" / "200 Mhz" / "200MHz"
+    uint64_t freq_value = 0;
+    char unit = 'M';  // Default to MHz
+
+    size_t unit_pos = freq_str.find_first_not_of("0123456789 ");
+    if (unit_pos != std::string::npos) {
+      std::string value_str = freq_str.substr(0, unit_pos);
+      value_str.erase(std::remove(value_str.begin(), value_str.end(), ' '), value_str.end());
+      try {
+        freq_value = std::stoull(value_str);
+      } catch (...) {
+        continue;  // Skip invalid lines
+      }
+      std::string unit_str = freq_str.substr(unit_pos);
+      if (!unit_str.empty()) {
+        unit = static_cast<char>(std::toupper(static_cast<unsigned char>(unit_str[0])));
+      }
+    }
+
+    f->frequency[level_index] = freq_value * amd::smi::get_multiplier_from_char(unit);
+    level_index++;
+  }
+
+  f->num_supported = level_index;
+  return (f->num_supported > 0) ? AMDSMI_STATUS_SUCCESS : AMDSMI_STATUS_NOT_SUPPORTED;
+}
+
+// Map an amdsmi_clk_type_t to its corresponding pp_dpm_* sysfs filename, or
+// nullptr if no sysfs file is defined for that clock type.
+static const char* pp_dpm_filename_for_clk_type(amdsmi_clk_type_t clk_type) {
+  switch (clk_type) {
+    case AMDSMI_CLK_TYPE_SYS:   return "pp_dpm_sclk";
+    case AMDSMI_CLK_TYPE_DF:    return "pp_dpm_fclk";
+    case AMDSMI_CLK_TYPE_DCEF:  return "pp_dpm_dcefclk";
+    case AMDSMI_CLK_TYPE_SOC:   return "pp_dpm_socclk";
+    case AMDSMI_CLK_TYPE_MEM:   return "pp_dpm_mclk";
+    case AMDSMI_CLK_TYPE_VCLK0: return "pp_dpm_vclk";
+    case AMDSMI_CLK_TYPE_VCLK1: return "pp_dpm_vclk1";
+    case AMDSMI_CLK_TYPE_DCLK0: return "pp_dpm_dclk";
+    case AMDSMI_CLK_TYPE_DCLK1: return "pp_dpm_dclk1";
+    default:                    return nullptr;
+  }
+}
+
 amdsmi_status_t amdsmi_get_clk_freq(amdsmi_processor_handle processor_handle,
                                     amdsmi_clk_type_t clk_type, amdsmi_frequencies_t* f) {
   AMDSMI_CHECK_INIT();
   // nullptr api supported
 
-  // Read VCLK/DCLK from sysfs pp_dpm files instead of gpu_metrics
+  // VCLK/DCLK have no rsmi/gpu_metrics path; read directly from pp_dpm_* sysfs.
   if (clk_type == AMDSMI_CLK_TYPE_VCLK0 || clk_type == AMDSMI_CLK_TYPE_VCLK1 ||
       clk_type == AMDSMI_CLK_TYPE_DCLK0 || clk_type == AMDSMI_CLK_TYPE_DCLK1) {
-    // Get the GPU device to access renderD number
-    amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
-    amdsmi_status_t status = get_gpu_device_from_handle(processor_handle, &gpu_device);
-    if (status != AMDSMI_STATUS_SUCCESS) {
-      return status;
-    }
-
-    // Get renderD number for this GPU
-    uint32_t drm_render = gpu_device->get_drm_render_minor();
-
-    // Determine the sysfs file name based on clock type
-    const char* pp_dpm_file = nullptr;
-    if (clk_type == AMDSMI_CLK_TYPE_VCLK0) {
-      pp_dpm_file = "pp_dpm_vclk";
-    } else if (clk_type == AMDSMI_CLK_TYPE_VCLK1) {
-      pp_dpm_file = "pp_dpm_vclk1";
-    } else if (clk_type == AMDSMI_CLK_TYPE_DCLK0) {
-      pp_dpm_file = "pp_dpm_dclk";
-    } else if (clk_type == AMDSMI_CLK_TYPE_DCLK1) {
-      pp_dpm_file = "pp_dpm_dclk1";
-    }
-
-    // Construct the sysfs path: /sys/class/drm/renderD<num>/device/pp_dpm_*
-    std::string sysfs_path =
-        "/sys/class/drm/renderD" + std::to_string(drm_render) + "/device/" + pp_dpm_file;
-
-    // Check if the file exists
-    std::ifstream file(sysfs_path);
-    if (!file.good()) {
-      // File doesn't exist, fallback to gpu_metrics for backward compatibility
-      // or return not supported
-      return AMDSMI_STATUS_NOT_SUPPORTED;
-    }
-
-    // Parse the pp_dpm file
-    // Format example:
-    // 0: 200Mhz
-    // 1: 400Mhz *
-    // 2: 800Mhz
-    if (f == nullptr) {
-      return AMDSMI_STATUS_INVAL;
-    }
-
-    f->num_supported = 0;
-    f->current = 0;
-    f->has_deep_sleep = 0;
-
-    std::string line;
-    uint32_t level_index = 0;
-
-    while (std::getline(file, line) && level_index < AMDSMI_MAX_NUM_FREQUENCIES) {
-      // Parse line format: "0: 200Mhz" or "1: 400Mhz *"
-      size_t colon_pos = line.find(':');
-      if (colon_pos == std::string::npos) {
-        continue;
-      }
-
-      // Extract level number
-      std::string level_str = line.substr(0, colon_pos);
-      level_str.erase(0, level_str.find_first_not_of(" \t"));
-      level_str.erase(level_str.find_last_not_of(" \t") + 1);
-
-      // Extract frequency value
-      std::string freq_str = line.substr(colon_pos + 1);
-
-      // Check if this is the current level (marked with *)
-      bool is_current = (freq_str.find('*') != std::string::npos);
-      if (is_current) {
-        f->current = level_index;
-      }
-
-      // Remove asterisk and spaces
-      freq_str.erase(std::remove(freq_str.begin(), freq_str.end(), '*'), freq_str.end());
-      freq_str.erase(0, freq_str.find_first_not_of(" \t"));
-      freq_str.erase(freq_str.find_last_not_of(" \t") + 1);
-
-      // Parse frequency value (e.g., "200Mhz" or "200 Mhz")
-      uint64_t freq_value = 0;
-      char unit = 'M';  // Default to MHz
-
-      size_t unit_pos = freq_str.find_first_not_of("0123456789 ");
-      if (unit_pos != std::string::npos) {
-        std::string value_str = freq_str.substr(0, unit_pos);
-        value_str.erase(std::remove(value_str.begin(), value_str.end(), ' '), value_str.end());
-
-        try {
-          freq_value = std::stoull(value_str);
-        } catch (...) {
-          continue;  // Skip invalid lines
-        }
-
-        // Extract unit (M for MHz, G for GHz, etc.)
-        std::string unit_str = freq_str.substr(unit_pos);
-        if (!unit_str.empty()) {
-          unit = static_cast<char>(std::toupper(static_cast<unsigned char>(unit_str[0])));
-        }
-      }
-
-      // Convert to Hz based on unit
-      f->frequency[level_index] = freq_value * amd::smi::get_multiplier_from_char(unit);
-      level_index++;
-    }
-
-    f->num_supported = level_index;
-    file.close();
-
-    return (f->num_supported > 0) ? AMDSMI_STATUS_SUCCESS : AMDSMI_STATUS_NOT_SUPPORTED;
+    return read_clk_freq_from_pp_dpm(processor_handle,
+                                     pp_dpm_filename_for_clk_type(clk_type), f);
   }
 
-  return rsmi_wrapper(rsmi_dev_gpu_clk_freq_get, processor_handle, 0,
-                      static_cast<rsmi_clk_type_t>(clk_type),
-                      reinterpret_cast<rsmi_frequencies_t*>(f));
+  amdsmi_status_t status = rsmi_wrapper(rsmi_dev_gpu_clk_freq_get, processor_handle, 0,
+                                        static_cast<rsmi_clk_type_t>(clk_type),
+                                        reinterpret_cast<rsmi_frequencies_t*>(f));
+
+  // ROCM-21057: on gfx1151-class APUs the SMU power-gates SYS/DF/DCEF/SOC/MEM
+  // at idle and rsmi/gpu_metrics returns no data. The pp_dpm_* sysfs files
+  // always expose the supported DPM table (the '*' current-level marker is
+  // dropped while the domain is gated). Fall back to sysfs when the firmware
+  // path returns no usable data.
+  if (f != nullptr && (status != AMDSMI_STATUS_SUCCESS || f->num_supported == 0)) {
+    const char* pp_dpm_file = pp_dpm_filename_for_clk_type(clk_type);
+    if (pp_dpm_file != nullptr) {
+      amdsmi_status_t sysfs_status = read_clk_freq_from_pp_dpm(processor_handle, pp_dpm_file, f);
+      if (sysfs_status == AMDSMI_STATUS_SUCCESS) {
+        return AMDSMI_STATUS_SUCCESS;
+      }
+    }
+  }
+
+  return status;
 }
 
 amdsmi_status_t amdsmi_set_clk_freq(amdsmi_processor_handle processor_handle,

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -4171,8 +4171,6 @@ amdsmi_status_t amdsmi_get_gpu_pci_bandwidth(amdsmi_processor_handle processor_h
 //   1: 400Mhz *
 //   2: 800Mhz
 // Returns AMDSMI_STATUS_NOT_SUPPORTED if the file does not exist or is empty
-// (e.g. SMU power-gates the domain at idle and the kernel exposes an empty
-// file).
 static amdsmi_status_t read_clk_freq_from_pp_dpm(amdsmi_processor_handle processor_handle,
                                                  const char* pp_dpm_file,
                                                  amdsmi_frequencies_t* f) {
@@ -4285,7 +4283,7 @@ amdsmi_status_t amdsmi_get_clk_freq(amdsmi_processor_handle processor_handle,
                                         static_cast<rsmi_clk_type_t>(clk_type),
                                         reinterpret_cast<rsmi_frequencies_t*>(f));
 
-  // ROCM-21057: on gfx1151-class APUs the SMU power-gates SYS/DF/DCEF/SOC/MEM
+  // on gfx1151-class APUs the SMU power-gates SYS/DF/DCEF/SOC/MEM
   // at idle and rsmi/gpu_metrics returns no data. The pp_dpm_* sysfs files
   // always expose the supported DPM table (the '*' current-level marker is
   // dropped while the domain is gated). Fall back to sysfs when the firmware

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -4172,8 +4172,7 @@ amdsmi_status_t amdsmi_get_gpu_pci_bandwidth(amdsmi_processor_handle processor_h
 //   2: 800Mhz
 // Returns AMDSMI_STATUS_NOT_SUPPORTED if the file does not exist or is empty
 static amdsmi_status_t read_clk_freq_from_pp_dpm(amdsmi_processor_handle processor_handle,
-                                                 const char* pp_dpm_file,
-                                                 amdsmi_frequencies_t* f) {
+                                                 const char* pp_dpm_file, amdsmi_frequencies_t* f) {
   if (f == nullptr) {
     return AMDSMI_STATUS_INVAL;
   }
@@ -4254,16 +4253,26 @@ static amdsmi_status_t read_clk_freq_from_pp_dpm(amdsmi_processor_handle process
 // nullptr if no sysfs file is defined for that clock type.
 static const char* pp_dpm_filename_for_clk_type(amdsmi_clk_type_t clk_type) {
   switch (clk_type) {
-    case AMDSMI_CLK_TYPE_SYS:   return "pp_dpm_sclk";
-    case AMDSMI_CLK_TYPE_DF:    return "pp_dpm_fclk";
-    case AMDSMI_CLK_TYPE_DCEF:  return "pp_dpm_dcefclk";
-    case AMDSMI_CLK_TYPE_SOC:   return "pp_dpm_socclk";
-    case AMDSMI_CLK_TYPE_MEM:   return "pp_dpm_mclk";
-    case AMDSMI_CLK_TYPE_VCLK0: return "pp_dpm_vclk";
-    case AMDSMI_CLK_TYPE_VCLK1: return "pp_dpm_vclk1";
-    case AMDSMI_CLK_TYPE_DCLK0: return "pp_dpm_dclk";
-    case AMDSMI_CLK_TYPE_DCLK1: return "pp_dpm_dclk1";
-    default:                    return nullptr;
+    case AMDSMI_CLK_TYPE_SYS:
+      return "pp_dpm_sclk";
+    case AMDSMI_CLK_TYPE_DF:
+      return "pp_dpm_fclk";
+    case AMDSMI_CLK_TYPE_DCEF:
+      return "pp_dpm_dcefclk";
+    case AMDSMI_CLK_TYPE_SOC:
+      return "pp_dpm_socclk";
+    case AMDSMI_CLK_TYPE_MEM:
+      return "pp_dpm_mclk";
+    case AMDSMI_CLK_TYPE_VCLK0:
+      return "pp_dpm_vclk";
+    case AMDSMI_CLK_TYPE_VCLK1:
+      return "pp_dpm_vclk1";
+    case AMDSMI_CLK_TYPE_DCLK0:
+      return "pp_dpm_dclk";
+    case AMDSMI_CLK_TYPE_DCLK1:
+      return "pp_dpm_dclk1";
+    default:
+      return nullptr;
   }
 }
 
@@ -4275,8 +4284,7 @@ amdsmi_status_t amdsmi_get_clk_freq(amdsmi_processor_handle processor_handle,
   // VCLK/DCLK have no rsmi/gpu_metrics path; read directly from pp_dpm_* sysfs.
   if (clk_type == AMDSMI_CLK_TYPE_VCLK0 || clk_type == AMDSMI_CLK_TYPE_VCLK1 ||
       clk_type == AMDSMI_CLK_TYPE_DCLK0 || clk_type == AMDSMI_CLK_TYPE_DCLK1) {
-    return read_clk_freq_from_pp_dpm(processor_handle,
-                                     pp_dpm_filename_for_clk_type(clk_type), f);
+    return read_clk_freq_from_pp_dpm(processor_handle, pp_dpm_filename_for_clk_type(clk_type), f);
   }
 
   amdsmi_status_t status = rsmi_wrapper(rsmi_dev_gpu_clk_freq_get, processor_handle, 0,

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -4249,20 +4249,11 @@ static amdsmi_status_t read_clk_freq_from_pp_dpm(amdsmi_processor_handle process
   return (f->num_supported > 0) ? AMDSMI_STATUS_SUCCESS : AMDSMI_STATUS_NOT_SUPPORTED;
 }
 
-// Map an amdsmi_clk_type_t to its corresponding pp_dpm_* sysfs filename, or
-// nullptr if no sysfs file is defined for that clock type.
+// Map a VCLK/DCLK clock type to its pp_dpm_* sysfs filename. rsmi does not
+// support these clock types via gpu_metrics, so amdsmi reads them directly
+// from sysfs. Returns nullptr for any other clock type.
 static const char* pp_dpm_filename_for_clk_type(amdsmi_clk_type_t clk_type) {
   switch (clk_type) {
-    case AMDSMI_CLK_TYPE_SYS:
-      return "pp_dpm_sclk";
-    case AMDSMI_CLK_TYPE_DF:
-      return "pp_dpm_fclk";
-    case AMDSMI_CLK_TYPE_DCEF:
-      return "pp_dpm_dcefclk";
-    case AMDSMI_CLK_TYPE_SOC:
-      return "pp_dpm_socclk";
-    case AMDSMI_CLK_TYPE_MEM:
-      return "pp_dpm_mclk";
     case AMDSMI_CLK_TYPE_VCLK0:
       return "pp_dpm_vclk";
     case AMDSMI_CLK_TYPE_VCLK1:
@@ -4287,26 +4278,9 @@ amdsmi_status_t amdsmi_get_clk_freq(amdsmi_processor_handle processor_handle,
     return read_clk_freq_from_pp_dpm(processor_handle, pp_dpm_filename_for_clk_type(clk_type), f);
   }
 
-  amdsmi_status_t status = rsmi_wrapper(rsmi_dev_gpu_clk_freq_get, processor_handle, 0,
-                                        static_cast<rsmi_clk_type_t>(clk_type),
-                                        reinterpret_cast<rsmi_frequencies_t*>(f));
-
-  // on gfx1151-class APUs the SMU power-gates SYS/DF/DCEF/SOC/MEM
-  // at idle and rsmi/gpu_metrics returns no data. The pp_dpm_* sysfs files
-  // always expose the supported DPM table (the '*' current-level marker is
-  // dropped while the domain is gated). Fall back to sysfs when the firmware
-  // path returns no usable data.
-  if (f != nullptr && (status != AMDSMI_STATUS_SUCCESS || f->num_supported == 0)) {
-    const char* pp_dpm_file = pp_dpm_filename_for_clk_type(clk_type);
-    if (pp_dpm_file != nullptr) {
-      amdsmi_status_t sysfs_status = read_clk_freq_from_pp_dpm(processor_handle, pp_dpm_file, f);
-      if (sysfs_status == AMDSMI_STATUS_SUCCESS) {
-        return AMDSMI_STATUS_SUCCESS;
-      }
-    }
-  }
-
-  return status;
+  return rsmi_wrapper(rsmi_dev_gpu_clk_freq_get, processor_handle, 0,
+                      static_cast<rsmi_clk_type_t>(clk_type),
+                      reinterpret_cast<rsmi_frequencies_t*>(f));
 }
 
 amdsmi_status_t amdsmi_set_clk_freq(amdsmi_processor_handle processor_handle,

--- a/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
@@ -1322,3 +1322,91 @@ std::tuple<uint64_t, uint64_t, uint64_t, uint64_t> parse_bdfid(uint64_t bdfid) {
   uint64_t function = bdfid & 0x7;
   return std::tuple<uint64_t, uint64_t, uint64_t, uint64_t>(domain, bus, device_id, function);
 }
+
+amdsmi_status_t smi_amdgpu_read_clk_freq_from_pp_dpm(amd::smi::AMDSmiGPUDevice* device,
+                                                     const char* pp_dpm_file,
+                                                     amdsmi_frequencies_t* f) {
+  if (f == nullptr || device == nullptr || pp_dpm_file == nullptr) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
+  uint32_t drm_render = device->get_drm_render_minor();
+  std::string sysfs_path =
+      "/sys/class/drm/renderD" + std::to_string(drm_render) + "/device/" + pp_dpm_file;
+
+  std::ifstream file(sysfs_path);
+  if (!file.good()) {
+    return AMDSMI_STATUS_NOT_SUPPORTED;
+  }
+
+  f->num_supported = 0;
+  f->current = 0;
+  f->has_deep_sleep = 0;
+
+  std::string line;
+  uint32_t level_index = 0;
+
+  while (std::getline(file, line) && level_index < AMDSMI_MAX_NUM_FREQUENCIES) {
+    // Parse line format: "0: 200Mhz" or "1: 400Mhz *"
+    size_t colon_pos = line.find(':');
+    if (colon_pos == std::string::npos) {
+      continue;
+    }
+
+    std::string freq_str = line.substr(colon_pos + 1);
+
+    // Check if this is the current level (marked with *)
+    bool is_current = (freq_str.find('*') != std::string::npos);
+    if (is_current) {
+      f->current = level_index;
+    }
+
+    // Remove asterisk and surrounding whitespace
+    freq_str.erase(std::remove(freq_str.begin(), freq_str.end(), '*'), freq_str.end());
+    freq_str.erase(0, freq_str.find_first_not_of(" \t"));
+    size_t end = freq_str.find_last_not_of(" \t");
+    if (end != std::string::npos) {
+      freq_str.erase(end + 1);
+    }
+
+    // Parse "200Mhz" / "200 Mhz" / "200MHz"
+    uint64_t freq_value = 0;
+    char unit = 'M';  // Default to MHz
+
+    size_t unit_pos = freq_str.find_first_not_of("0123456789 ");
+    if (unit_pos != std::string::npos) {
+      std::string value_str = freq_str.substr(0, unit_pos);
+      value_str.erase(std::remove(value_str.begin(), value_str.end(), ' '), value_str.end());
+      try {
+        freq_value = std::stoull(value_str);
+      } catch (...) {
+        continue;  // Skip invalid lines
+      }
+      std::string unit_str = freq_str.substr(unit_pos);
+      if (!unit_str.empty()) {
+        unit = static_cast<char>(std::toupper(static_cast<unsigned char>(unit_str[0])));
+      }
+    }
+
+    f->frequency[level_index] = freq_value * amd::smi::get_multiplier_from_char(unit);
+    level_index++;
+  }
+
+  f->num_supported = level_index;
+  return (f->num_supported > 0) ? AMDSMI_STATUS_SUCCESS : AMDSMI_STATUS_NOT_SUPPORTED;
+}
+
+const char* smi_amdgpu_pp_dpm_filename_for_clk_type(amdsmi_clk_type_t clk_type) {
+  switch (clk_type) {
+    case AMDSMI_CLK_TYPE_VCLK0:
+      return "pp_dpm_vclk";
+    case AMDSMI_CLK_TYPE_VCLK1:
+      return "pp_dpm_vclk1";
+    case AMDSMI_CLK_TYPE_DCLK0:
+      return "pp_dpm_dclk";
+    case AMDSMI_CLK_TYPE_DCLK1:
+      return "pp_dpm_dclk1";
+    default:
+      return nullptr;
+  }
+}


### PR DESCRIPTION

## Motivation

On gfx1151, amd-smi static -C shows MEM/DF/SOC/DCEF/VCLK/DCLK as N/A at idle because the SMU power-gates those domains, so the kernel's pp_dpm_* table has no * current-level marker and the rsmi parser was discarding the whole table as STATUS_UNEXPECTED_DATA. This PR keeps the supported DPM frequency table visible at idle as well.

## Technical Details

Fixed get_frequencies() in the rsmi backend to stop returning UNEXPECTED_DATA when no * marker is present: the parsed num_supported / frequency[] are kept and current is set to (uint32_t)-1 (documented in amdsmi_frequencies_t). VCLK/DCLK still have no rsmi/gpu_metrics path, so the existing inline pp_dpm reader was moved out of public amd_smi.cc into internal amd_smi_utils.{h,cc}. CLI translates the sentinel to N/A and guards the fclk index in metric --clock. Output schema is unchanged.

## JIRA ID

ROCM-21057

## Test Plan

Built from source on gfx1151 and ran amd-smi static -C and amd-smi metric --clock at idle, during a HIP busy_kernel workload, and post-workload; cross-validated CURRENT_LEVEL against * markers in /sys/class/drm/renderD*/device/pp_dpm_*. Also re-ran amd-smi list / monitor / metric -u to check for regressions.

## Test Result

Idle now shows full FREQUENCY_LEVELS for MEM/DF/SOC with CURRENT_LEVEL: N/A while the domain is gated; under load CURRENT_LEVEL appears and exactly matches the sysfs * marker; post-load it drops back. metric --clock no longer crashes on idle fclk. DCEF/VCLK/DCLK remain N/A only when the sysfs file is absent or empty. No regressions in other amd-smi subcommands.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
