### PR TITLE
build(rocjitsu): Add emulation project mapping and build options in t…

### DIFF
--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -2,7 +2,8 @@
 This dictionary is used to map specific file directory changes to the corresponding build flag and tests
 """
 subtree_to_project_map = {
-    "emulation": "emulation",
+    "emulation/rocjistu": "emulation",
+    "emulation/mirage": "emulation",
     "projects/amdsmi": "core",
     "projects/aqlprofile": "profiler",
     "projects/clr": "runtimes",

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -2,7 +2,7 @@
 This dictionary is used to map specific file directory changes to the corresponding build flag and tests
 """
 subtree_to_project_map = {
-    "emulation/rocjistu": "emulation",
+    "emulation/rocjitsu": "emulation",
     "emulation/mirage": "emulation",
     "projects/amdsmi": "core",
     "projects/aqlprofile": "profiler",

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -2,6 +2,7 @@
 This dictionary is used to map specific file directory changes to the corresponding build flag and tests
 """
 subtree_to_project_map = {
+    "emulation": "emulation",
     "projects/amdsmi": "core",
     "projects/aqlprofile": "profiler",
     "projects/clr": "runtimes",
@@ -33,6 +34,10 @@ project_map = {
     "core": {
         "cmake_options": ["-DTHEROCK_ENABLE_CORE=ON", "-DTHEROCK_ENABLE_ALL=OFF"],
         "projects_to_test": "",  # will run sanity test to cover rocminfo and amdsmi
+    },
+    "emulation": {
+        "cmake_options": ["-DTHEROCK_ENABLE_ALL=OFF", "-DTHEROCK_ENABLE_EMULATION=ON"],
+        "projects_to_test": "",
     },
     "dc_tools": {
         "cmake_options": ["-DTHEROCK_ENABLE_ALL=OFF", "-DTHEROCK_ENABLE_DC_TOOLS=ON"],


### PR DESCRIPTION
## Motivation

Enable targeted TheRock CI for changes under emulation so those changes can build the emulation component without enabling the full project set.

## Technical Details

Updates therock_matrix.py to register emulation in `subtree_to_project_map` and add a matching `project_map` entry.

The new emulation CI configuration uses:

```text
-DTHEROCK_ENABLE_ALL=OFF
-DTHEROCK_ENABLE_EMULATION=ON
```

No Windows CI trigger path was added, so emulation follows the existing Linux-only behavior for subtrees that are not listed in `trigger_windows_ci_for_subtrees_paths`.

## JIRA ID

N/A

## Test Plan

Ran the focused TheRock CI matrix/configuration unit tests:

```bash
python3 .github/scripts/tests/therock_configure_ci_test.py
```

## Test Result

All focused tests passed:

```text
Ran 27 tests in 0.027s

OK
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.