### PR TITLE
kmd_version and new pr_rocr_info macro for printing debug logs in release

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/dxg/librocdxg.h
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/librocdxg.h
@@ -217,6 +217,12 @@ extern hsakmtRuntime *dxg_runtime;
 	hsakmt_print(HSAKMT_DEBUG_LEVEL_INFO, fmt, ##__VA_ARGS__)
 #define pr_debug(fmt, ...) \
 	hsakmt_print(HSAKMT_DEBUG_LEVEL_DEBUG, fmt, ##__VA_ARGS__)
+#define pr_rocr_info(fmt, ...) \
+	do { \
+		if (HSAKMT_DEBUG_LEVEL_INFO <= dxg_runtime->hsakmt_debug_level) { \
+			hsakmt_print_common(stdout, fmt, ##__VA_ARGS__); \
+		} \
+	} while (false)
 #define pr_err_once(fmt, ...)                   \
 {                                               \
         static bool __print_once;               \

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -68,8 +68,9 @@ WDDMDevice::WDDMDevice(D3DKMT_HANDLE adapter, LUID adapter_luid, uint32_t node_i
   memset(&device_info_, 0, sizeof(device_info_));
 
   NTSTATUS ret = ParseDeviceInfo();
+  pr_rocr_info("kmd_version:%d\n", device_info_.kmd_version);
   device_info_.hwsInfo.hwsMask.aql_queue &= !dxg_runtime->use_pm4_;
-  pr_info("hwsInfo: aql_queue=%d computeHwsEnabled=%d use_pm4_override=%d\n",
+  pr_rocr_info("hwsInfo: aql_queue=%d computeHwsEnabled=%d use_pm4_override=%d\n",
            device_info_.hwsInfo.hwsMask.aql_queue,
            device_info_.hwsInfo.hwsMask.computeHwsEnabled,
            dxg_runtime->use_pm4_);

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -68,7 +68,7 @@ WDDMDevice::WDDMDevice(D3DKMT_HANDLE adapter, LUID adapter_luid, uint32_t node_i
   memset(&device_info_, 0, sizeof(device_info_));
 
   NTSTATUS ret = ParseDeviceInfo();
-  pr_rocr_info("kmd_version:%d\n", device_info_.kmd_version);
+  pr_rocr_info("kmd_version:%" PRIu32 "\n", device_info_.kmd_version);
   device_info_.hwsInfo.hwsMask.aql_queue &= !dxg_runtime->use_pm4_;
   pr_rocr_info("hwsInfo: aql_queue=%d computeHwsEnabled=%d use_pm4_override=%d\n",
            device_info_.hwsInfo.hwsMask.aql_queue,

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/queue.cpp
@@ -592,15 +592,15 @@ void ComputeQueue::RingDoorbell(uint64_t value) {
 
 hsa_status_t ComputeQueue::Init(void) {
   if (use_hws) {
-    pr_info("Scheduler: Microsoft Hardware Scheduler (HWS)\n");
+    pr_rocr_info("Scheduler: Microsoft Hardware Scheduler (HWS)\n");
   } else {
-    pr_info("Scheduler: AMD proprietary\n");
+    pr_rocr_info("Scheduler: AMD proprietary\n");
   }
 
   if (native_aql_)
-    pr_info("Submission type: AQL packet\n");
+    pr_rocr_info("Submission type: AQL packet\n");
   else
-    pr_info("Submission type: PM4 packet (AQL->PM4 translation)\n");
+    pr_rocr_info("Submission type: PM4 packet (AQL->PM4 translation)\n");
 
   hsa_status_t ret = use_hws ? HwsInit() : SwsInit();
   if (ret) {


### PR DESCRIPTION
Add kmd_version to the logs 
new pr_rocr_info macro that enables info-level logging in release builds without requiring debug configuration. Bypasses NDEBUG check while still respecting HSAKMT_DEBUG_LEVEL environment variable (requires level >= 6).
these few lines are useful for debugging rocr on windows issues

## Motivation
rocr backend needs specific AQL support, which is available in only newer base drivers. 
these logs help developers to debug faster

## Technical Details
Updated logging in device.cpp and queue.cpp to use pr_rocr_info for:
- Hardware scheduler info (AQL queue, compute HWS, PM4 override)
- Scheduler type (Microsoft HWS vs AMD proprietary)
- Submission type (AQL vs PM4 packet translation)
- KMD version

## JIRA ID
AIRUNTIME-2076

## Test Plan
normal windows build

## Test Result
normal windows build

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
