### PR TITLE
[clr] fix vmm access violation

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -798,6 +798,7 @@ class Graph {
                                                    dev_info.virtualMemAllocGranularityRecommended_);
     if (ptr == nullptr) {
       LogError("Failed to reserve Virtual Address");
+      return nullptr;
     }
 
     // Set Access to read write for all devices.

--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -2446,7 +2446,10 @@ void* Device::virtualAlloc(void* addr, size_t size, size_t alignment) {
   constexpr bool kParent = true;
   constexpr bool kForceAlloc = true;
   amd::Memory* mem = CreateVirtualBuffer(context(), addr, size, -1, -1, kParent, kForceAlloc);
-  assert(mem != nullptr);
+  if (mem == nullptr) {
+    LogPrintfError("CreateVirtualBuffer failed(addr=%p, size=%zu)\n", addr, size);
+    return nullptr;
+  }
   return mem->getSvmPtr();
 }
 

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -2413,7 +2413,8 @@ void* Device::virtualAlloc(void* req_addr, size_t size, size_t alignment) {
   constexpr bool kParent = true;
   amd::Memory* mem = CreateVirtualBuffer(context(), vptr, size, -1, -1, kParent);
   if (mem == nullptr) {
-    LogPrintfError("Cannot create Virtual Buffer for vptr: %p of size: %u", vptr, size);
+    LogPrintfError("Cannot create Virtual Buffer for vptr: %p of size: %zu", vptr, size);
+    return nullptr;
   }
 
   return mem->getSvmPtr();

--- a/projects/clr/rocclr/platform/vmheap.cpp
+++ b/projects/clr/rocclr/platform/vmheap.cpp
@@ -17,6 +17,10 @@ namespace amd {
 address VmHeap::ReserveAddressRange(address start, size_t size, size_t alignment) {
   // Reserve a virtual address range on the device
   void* ptr = device_->virtualAlloc(start, size, alignment);
+  if (ptr == nullptr) {
+    LogPrintfError("virtualAlloc failed(start=%p, size=%zu)\n", start, size);
+    return nullptr;
+  }
   // Save base memory object to accelerate access in the future
   base_memory_ = MemObjMap::FindVirtualMemObj(ptr);
   return reinterpret_cast<address>(ptr);


### PR DESCRIPTION
## Motivation

I got an `OSError: exception: access violation reading 0x00000000000000E0` while using comfy-aimdo in `hipMemAddressReserve` (same as https://github.com/Comfy-Org/comfy-aimdo/issues/45).

This PR does not solve the root cause, but with this fix, it exposes the same issue `RuntimeError: VRAM reservation failed` as CUDA user: https://github.com/Comfy-Org/comfy-aimdo/issues/49.

## Technical Details

Four changes to propagate VMM allocation failure instead of crashing:

- `hip_graph_internal.hpp`: Added `return nullptr` after `LogError` when virtual address reservation fails, preventing fall-through to null-pointer dereference.
- `paldevice.cpp`: Replaced `assert(mem != nullptr)` with a proper null check + error log + `return nullptr` in `Device::virtualAlloc()`. The assert is a no-op in Release builds, masking the failure.
- `rocdevice.cpp`: Added `return nullptr` after the existing `LogPrintfError` in `Device::virtualAlloc()`, and fixed the format specifier from %u to %zu for size_t.
- `vmheap.cpp`: Added null check for `virtualAlloc` return value in `VmHeap::ReserveAddressRange()` with error log + early return.


## Test Plan

Built `amdhip64_7.dll` according to [clr Windows build guide](https://github.com/ROCm/rocm-systems/tree/develop/projects/clr#windows) and tested on my local machine.
```
pytorch version: 2.11.0+rocm7.13.0a20260511
AMD arch: gfx1201
ROCm version: (7, 13)
```

## Test Result

Got real issue `RuntimeError: VRAM reservation failed` as same as CUDA.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
