### PR TITLE
rocr: ring doorbell when there is a signal attached for completion

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1302,7 +1302,7 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
   // skipping the doorbell will not wake up the AQL worker thread
   uint32_t skip_limit = DEBUG_CLR_DOORBELL_SKIP;
   bool ring_doorbell = IS_LINUX || dev().IsPm4Emulation() || blocking ||
-                       (skippedDispatches_ >= skip_limit);
+                       (skippedDispatches_ >= skip_limit) || attach_signal;
   if (ring_doorbell) {
     Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, index);
     skippedDispatches_ = 0;


### PR DESCRIPTION
## Motivation
Currently only rings doorbell for core logic signals (attach_signal). Profiling signals do not ring doorbell immediately.

## Technical Details
door bell is never rung for batch optimization. This PR rings the door bell if a signal is attached for competition. 
For profiling continue to add to the skipped count

## JIRA ID
SWDEV-590677

## Test Plan
Ensure hiptests dont hang with AQL path on windows

## Test Result
Ensure hiptests dont hang with AQL path on windows

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
