### PR TITLE
rocrtst: Add ROCRTST_ASAN check and add reference count tests

### DIFF
--- a/projects/rocr-runtime/rocrtst/common/base_rocr_utils.cc
+++ b/projects/rocr-runtime/rocrtst/common/base_rocr_utils.cc
@@ -112,11 +112,16 @@ hsa_status_t CommonCleanUp(BaseRocR* test) {
   RET_IF_HSA_UTILS_ERR(err);
 
   // Ensure that HSA is actually closed.
+#ifndef ROCRTST_ASAN
+  // Under ASan, the sanitizer's hsa_init interceptor holds an extra reference
+  // count, so the runtime is still alive here.  Skip this check to avoid
+  // tearing down the runtime while ASan still expects it to be available.
   hsa_status_t check = hsa_shut_down();
   if (check != HSA_STATUS_ERROR_NOT_INITIALIZED) {
     EXPECT_EQ(HSA_STATUS_ERROR_NOT_INITIALIZED, check) << "hsa_init reference count was too high.";
     return HSA_STATUS_ERROR;
   }
+#endif
 
   std::string intr_val;
 

--- a/projects/rocr-runtime/rocrtst/suites/functional/concurrent_init.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/concurrent_init.cc
@@ -160,7 +160,11 @@ void ConcurrentInitTest::TestConcurrentInit(void) {
     ASSERT_EQ(HSA_STATUS_SUCCESS, err) << "An hsa_init was missed.";
   }
 
+#ifndef ROCRTST_ASAN
+  // Under ASan, the sanitizer's hsa_init interceptor holds an extra reference
+  // count, so the runtime is still alive here.  Skip this verification.
   hsa_status_t err = hsa_shut_down();
   ASSERT_EQ(HSA_STATUS_ERROR_NOT_INITIALIZED, err) << "hsa_init reference count was too high.";
+#endif
 }
 #undef RET_IF_HSA_ERR

--- a/projects/rocr-runtime/rocrtst/suites/functional/concurrent_init_shutdown.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/concurrent_init_shutdown.cc
@@ -161,7 +161,11 @@ void ConcurrentInitShutdownTest::TestConcurrentInitShutdown(void) {
   }
 
   // Check that HSA refcount is exact.
+#ifndef ROCRTST_ASAN
+  // Under ASan, the sanitizer's hsa_init interceptor holds an extra reference
+  // count, so the runtime is still alive here.  Skip this verification.
   hsa_status_t err = hsa_shut_down();
   ASSERT_EQ(HSA_STATUS_ERROR_NOT_INITIALIZED, err) << "hsa_init reference count was too high.";
+#endif
 }
 #undef RET_IF_HSA_ERR

--- a/projects/rocr-runtime/rocrtst/suites/functional/reference_count.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/reference_count.cc
@@ -72,7 +72,14 @@
 #include "gtest/gtest.h"
 #include "hsa/hsa.h"
 
+#ifdef ROCRTST_ASAN
+// Under ASan, each hsa_init consumes significantly more memory due to
+// sanitizer book-keeping.  Reduce the iteration count to avoid
+// HSA_STATUS_ERROR_OUT_OF_RESOURCES.
+static const int NumOfTimes = 100;
+#else
 static const int NumOfTimes = 1000;  // No of times the hsa runtime will be initialized
+#endif
 static const double MaxRefCount = 2147483649;  // Setting to max value to test to INIT_MAX+2 as defined in hsa runtime
 
 #define RET_IF_HSA_ERR(err) { \
@@ -163,6 +170,13 @@ void ReferenceCountTest::TestReferenceCount(void) {
 }
 
 void ReferenceCountTest::TestMaxReferenceCount(void) {
+#ifdef ROCRTST_ASAN
+  // Under ASan the 2-billion+ hsa_init loop exhausts resources quickly
+  // due to the sanitizer's memory overhead.  Skip this test.
+  std::cout << "Skipping Max_Reference_Count under ASan (OOM possible)." << std::endl;
+  return;
+#endif
+
   hsa_status_t status;
   // Initialize hsa runtime to maximum allowed  times
   for (int i = 0; i < MaxRefCount; ++i) {


### PR DESCRIPTION
Guard the affected assertions with `#ifndef ROCRTST_ASAN` so they are skipped when building with sanitizers.

ASan intercepts `hsa_init()` at startup and holds its own reference count for the process lifetime.  This extra `refcount` causes several test assertions to fail because they expect `hsa_shut_down()` to return HSA_STATUS_ERROR_NOT_INITIALIZED after balancing all calls.

Also, reduce `TestReferenceCount` iterations from 1000 to 100 (each `hsa_init` carries heavier sanitizer book-keeping), and skip `TestMaxReferenceCount` entirely (2B+ iterations exhaust memory).