### PR TITLE
[rocprofiler-systems]: Wall Clock migration from timemory

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/CMakeLists.txt
@@ -10,6 +10,7 @@ set(trace_cache_sources
     ${CMAKE_CURRENT_LIST_DIR}/post_processor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rocpd_processor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/perfetto_processor.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wall_clock_scope_event_processor.cpp
 )
 
 set(trace_cache_headers

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/CMakeLists.txt
@@ -10,7 +10,7 @@ set(trace_cache_sources
     ${CMAKE_CURRENT_LIST_DIR}/post_processor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rocpd_processor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/perfetto_processor.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/wall_clock_scope_event_processor.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/profiled_event_processor.cpp
 )
 
 set(trace_cache_headers

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/data_types.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/data_types.hpp
@@ -19,7 +19,7 @@ namespace rocprofsys::trace_cache
 class metadata_registry;
 class rocpd_processor_t;
 class perfetto_processor_t;
-class wall_clock_scope_event_processor_t;
+class profiled_event_processor_t;
 }  // namespace rocprofsys::trace_cache
 
 namespace rocprofsys::trace_cache::data
@@ -82,9 +82,9 @@ struct processor_config_t
 
 struct processor_storage_t
 {
-    std::shared_ptr<rocpd_processor_t>                  rocpd_processor;
-    std::shared_ptr<perfetto_processor_t>               perfetto_processor;
-    std::shared_ptr<wall_clock_scope_event_processor_t> wall_clock_scope_processor;
+    std::shared_ptr<rocpd_processor_t>          rocpd_processor;
+    std::shared_ptr<perfetto_processor_t>       perfetto_processor;
+    std::shared_ptr<profiled_event_processor_t> profiled_event_processor;
 };
 
 using directory_files_t    = std::vector<std::string>;

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/data_types.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/data_types.hpp
@@ -19,6 +19,7 @@ namespace rocprofsys::trace_cache
 class metadata_registry;
 class rocpd_processor_t;
 class perfetto_processor_t;
+class wall_clock_scope_event_processor_t;
 }  // namespace rocprofsys::trace_cache
 
 namespace rocprofsys::trace_cache::data
@@ -81,8 +82,9 @@ struct processor_config_t
 
 struct processor_storage_t
 {
-    std::shared_ptr<rocpd_processor_t>    rocpd_processor;
-    std::shared_ptr<perfetto_processor_t> perfetto_processor;
+    std::shared_ptr<rocpd_processor_t>                  rocpd_processor;
+    std::shared_ptr<perfetto_processor_t>               perfetto_processor;
+    std::shared_ptr<wall_clock_scope_event_processor_t> wall_clock_scope_processor;
 };
 
 using directory_files_t    = std::vector<std::string>;

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
@@ -1448,4 +1448,8 @@ perfetto_processor_t::handle(const kfd_sample& _kfd)
     else
         LOG_WARNING("Unknown KFD category: {}", _category);
 }
+
+void
+perfetto_processor_t::handle(const wall_clock_scope_event_sample&)
+{}
 }  // namespace rocprofsys::trace_cache

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
@@ -1450,6 +1450,6 @@ perfetto_processor_t::handle(const kfd_sample& _kfd)
 }
 
 void
-perfetto_processor_t::handle(const wall_clock_scope_event_sample&)
+perfetto_processor_t::handle(const wall_clock_event_sample&)
 {}
 }  // namespace rocprofsys::trace_cache

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.hpp
@@ -51,7 +51,7 @@ public:
     void handle(const cpu_pmc_sample& sample);
     void handle(const backtrace_region_sample& sample);
     void handle(const kfd_sample& sample);
-    void handle(const wall_clock_scope_event_sample& sample);
+    void handle(const wall_clock_event_sample& sample);
 
 private:
     void       initialize_perfetto();

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.hpp
@@ -51,6 +51,7 @@ public:
     void handle(const cpu_pmc_sample& sample);
     void handle(const backtrace_region_sample& sample);
     void handle(const kfd_sample& sample);
+    void handle(const wall_clock_scope_event_sample& sample);
 
 private:
     void       initialize_perfetto();

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/post_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/post_processor.cpp
@@ -8,10 +8,10 @@
 #include "core/trace_cache/cacheable.hpp"
 #include "core/trace_cache/metadata_registry.hpp"
 #include "core/trace_cache/perfetto_processor.hpp"
+#include "core/trace_cache/profiled_event_processor.hpp"
 #include "core/trace_cache/rocpd_processor.hpp"
 #include "core/trace_cache/sample_processor.hpp"
 #include "core/trace_cache/storage_parser_alias.hpp"
-#include "core/trace_cache/wall_clock_scope_event_processor.hpp"
 #include "library/runtime.hpp"
 #include "logger/debug.hpp"
 
@@ -56,10 +56,9 @@ configure_processors(const std::shared_ptr<sample_processor_t>&       _coordinat
                      output_file_registry&                            _registry)
 {
     data::processor_storage_t storage;
-    storage.wall_clock_scope_processor =
-        std::make_shared<wall_clock_scope_event_processor_t>(_config->_pid,
-                                                             _config->_ppid, _registry);
-    _coordinator->add_handler(*storage.wall_clock_scope_processor);
+    storage.profiled_event_processor = std::make_shared<profiled_event_processor_t>(
+        _config->_pid, _config->_ppid, _registry);
+    _coordinator->add_handler(*storage.profiled_event_processor);
 
     if(_formats.is_rocpd_enabled())
     {

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/post_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/post_processor.cpp
@@ -4,12 +4,14 @@
 #include "core/trace_cache/post_processor.hpp"
 
 #include "core/agent_manager.hpp"
+#include "core/config.hpp"
 #include "core/trace_cache/cacheable.hpp"
 #include "core/trace_cache/metadata_registry.hpp"
 #include "core/trace_cache/perfetto_processor.hpp"
 #include "core/trace_cache/rocpd_processor.hpp"
 #include "core/trace_cache/sample_processor.hpp"
 #include "core/trace_cache/storage_parser_alias.hpp"
+#include "core/trace_cache/wall_clock_scope_event_processor.hpp"
 #include "library/runtime.hpp"
 #include "logger/debug.hpp"
 
@@ -54,6 +56,11 @@ configure_processors(const std::shared_ptr<sample_processor_t>&       _coordinat
                      output_file_registry&                            _registry)
 {
     data::processor_storage_t storage;
+    storage.wall_clock_scope_processor =
+        std::make_shared<wall_clock_scope_event_processor_t>(_config->_pid,
+                                                             _config->_ppid, _registry);
+    _coordinator->add_handler(*storage.wall_clock_scope_processor);
+
     if(_formats.is_rocpd_enabled())
     {
         storage.rocpd_processor = std::make_shared<rocpd_processor_t>(
@@ -120,6 +127,24 @@ post_processor::process(
         run_sequential(configs, formats.get_sequential_formats());
     if(formats.has_parallel_formats())
         run_multithreaded(configs, formats.get_parallel_formats());
+
+    if(!formats.has_sequential_formats() && !formats.has_parallel_formats())
+    {
+        // Instrumented wall-clock scope events are only emitted when profile mode
+        // (ROCPROFSYS_PROFILE / get_use_timemory) is on; skip an expensive buffer scan
+        // when profiling is disabled.
+        if(!config::get_use_timemory()) return;
+
+        // ROCpd and Perfetto are both off: we still must read buffered_storage.bin so
+        // processors that do not emit those formats (e.g. wall_clock_evt replay) run.
+        static const data::enabled_formats_t buffer_scan_formats{
+            std::vector<data::format_t>{
+                { data::format_kind::rocpd, true, false, "rocpd" },
+                { data::format_kind::perfetto, false, false, "perfetto" },
+            }
+        };
+        run_sequential(configs, buffer_scan_formats);
+    }
 }
 
 void

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/profiled_event_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/profiled_event_processor.cpp
@@ -8,8 +8,16 @@
 #include "library/runtime.hpp"
 
 #include <timemory/backends/dmp.hpp>
+#include <timemory/backends/process.hpp>
+#include <timemory/components/timing/wall_clock.hpp>
+#include <timemory/data/stream.hpp>
+#include <timemory/hash/types.hpp>
 #include <timemory/manager/manager.hpp>
+#include <timemory/math/compute.hpp>
+#include <timemory/operations/types/print.hpp>
+#include <timemory/operations/types/print_header.hpp>
 #include <timemory/settings.hpp>
+#include <timemory/storage/node.hpp>
 
 #include <nlohmann/json.hpp>
 
@@ -19,7 +27,6 @@
 #include <cstring>
 #include <fstream>
 #include <functional>
-#include <iomanip>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -52,8 +59,10 @@ struct out_node_t
     std::int32_t               depth     = -1;
     std::int64_t               thread_id = -1;
     std::string                name;
-    std::uint64_t              start_ns = 0;
-    std::uint64_t              end_ns   = 0;
+    std::uint64_t              exec_id        = 0;
+    std::uint64_t              parent_exec_id = 0;
+    std::uint64_t              start_ns       = 0;
+    std::uint64_t              end_ns         = 0;
     std::vector<std::uint32_t> children;
 };
 
@@ -68,11 +77,62 @@ format_prefix(int d, const std::string& name)
     return p;
 }
 
+/// Maps captured OS thread ids to timemory-style labels (\c 0, \c 1, …) for JSON/text
+/// prefixes. When \c collapse_threads is set, every scope uses label \c 0 like timemory.
+struct thread_label_ctx_t
+{
+    explicit thread_label_ctx_t(bool collapse_threads)
+    : collapse{ collapse_threads }
+    {}
+
+    std::int64_t label(std::int64_t sys_tid)
+    {
+        if(collapse) return 0;
+        auto it = sys_to_label.find(sys_tid);
+        if(it != sys_to_label.end()) return it->second;
+        const std::int64_t lbl = next_label++;
+        sys_to_label.emplace(sys_tid, lbl);
+        return lbl;
+    }
+
+    bool                                           collapse = false;
+    std::int64_t                                   next_label{ 0 };
+    std::unordered_map<std::int64_t, std::int64_t> sys_to_label;
+};
+
+/// Prefix string in timemory flat JSON (\c ranks[].graph), e.g. \c "|0>>> |_MPI_Init".
 std::string
-timemory_label_cell(std::int64_t tid, int depth, const std::string& name)
+timemory_json_prefix(std::int64_t display_tid, int depth, const std::string& name)
 {
     const std::string body = (depth <= 0) ? name : format_prefix(depth, name);
-    return std::string(" |") + std::to_string(tid) + ">>> " + body;
+    return std::string("|") + std::to_string(display_tid) + ">>> " + body;
+}
+
+tim::hash::hash_value_t
+node_name_hash(const std::string& name)
+{
+    return tim::get_hash_id(name);
+}
+
+/// Timemory flat JSON \c rolling_hash is the sum of region hashes along the parent chain.
+tim::hash::hash_value_t
+rolling_hash_for_node(const std::vector<out_node_t>& nodes, std::uint32_t id)
+{
+    tim::hash::hash_value_t rolling = node_name_hash(nodes.at(id).name);
+    for(std::uint32_t cur = nodes.at(id).parent; cur != 0; cur = nodes.at(cur).parent)
+        rolling += node_name_hash(nodes.at(cur).name);
+    return rolling;
+}
+
+std::string
+flat_graph_agg_key(const std::vector<out_node_t>& nodes, std::uint32_t id,
+                   thread_label_ctx_t& tlabels)
+{
+    const auto& n           = nodes.at(id);
+    const auto  display_tid = tlabels.label(n.thread_id);
+    return std::to_string(n.depth) + '\x1e' + std::to_string(node_name_hash(n.name)) +
+           '\x1e' + std::to_string(rolling_hash_for_node(nodes, id)) + '\x1e' +
+           timemory_json_prefix(display_tid, n.depth, n.name);
 }
 
 double
@@ -81,214 +141,251 @@ duration_sec(const out_node_t& n)
     return (n.end_ns > n.start_ns) ? (n.end_ns - n.start_ns) / 1.e9 : 0.0;
 }
 
-void
-dfs_graph(const std::vector<out_node_t>& nodes, std::uint32_t nid, nlohmann::json& graph)
+std::uint64_t
+duration_ns(const out_node_t& n)
 {
-    const auto& n = nodes.at(nid);
-    if(n.id != 0)
+    return (n.end_ns > n.start_ns) ? (n.end_ns - n.start_ns) : 0;
+}
+
+nlohmann::json
+wall_clock_entry_json(std::uint64_t accum_ns, std::int64_t laps)
+{
+    const double   sec = static_cast<double>(accum_ns) / 1.e9;
+    nlohmann::json entry;
+    entry["laps"]         = laps;
+    entry["value"]        = accum_ns;
+    entry["accum"]        = accum_ns;
+    entry["repr_data"]    = sec;
+    entry["repr_display"] = sec;
+    return entry;
+}
+
+nlohmann::json
+wall_clock_stats_json(const std::vector<double>& lap_secs)
+{
+    nlohmann::json stats;
+    if(lap_secs.empty())
     {
-        const double   sec = duration_sec(n);
-        nlohmann::json row;
-        row["prefix"]         = std::string{ ">>>  " } + format_prefix(n.depth, n.name);
-        row["depth"]          = n.depth;
-        row["hash"]           = 0;
-        row["rolling_hash"]   = 0;
-        row["entry"]          = nlohmann::json::object();
-        row["entry"]["laps"]  = 1;
-        row["entry"]["value"] = sec;
-        row["entry"]["accum_value"] = sec;
-        graph.push_back(std::move(row));
+        stats["sum"]    = 0.0;
+        stats["count"]  = 0;
+        stats["min"]    = 0.0;
+        stats["max"]    = 0.0;
+        stats["sqr"]    = 0.0;
+        stats["mean"]   = 0.0;
+        stats["stddev"] = 0.0;
+        return stats;
     }
-    for(auto cid : n.children)
-        dfs_graph(nodes, cid, graph);
-}
 
-void
-fill_inc_exc(const std::vector<out_node_t>& nodes, std::uint32_t id,
-             std::vector<double>& inclusive, std::vector<double>& exclusive)
-{
-    const auto&  n   = nodes.at(id);
-    const double inc = duration_sec(n);
-    double       ch  = 0.0;
-    for(auto cid : n.children)
+    double sum   = 0.0;
+    double sumsq = 0.0;
+    double minv  = lap_secs.front();
+    double maxv  = lap_secs.front();
+    for(double s : lap_secs)
     {
-        fill_inc_exc(nodes, cid, inclusive, exclusive);
-        ch += inclusive.at(cid);
+        sum += s;
+        sumsq += s * s;
+        minv = std::min(minv, s);
+        maxv = std::max(maxv, s);
     }
-    inclusive.at(id) = inc;
-    exclusive.at(id) = std::max(0.0, inc - ch);
+    const auto   count = static_cast<std::int64_t>(lap_secs.size());
+    const double mean  = sum / static_cast<double>(count);
+    const double var_p =
+        (count > 0) ? (sumsq / static_cast<double>(count) - mean * mean) : 0.0;
+    const double var = (var_p > 0.0) ? var_p : 0.0;
+
+    stats["sum"]    = sum;
+    stats["count"]  = count;
+    stats["min"]    = minv;
+    stats["max"]    = maxv;
+    stats["sqr"]    = sumsq;
+    stats["mean"]   = mean;
+    stats["stddev"] = std::sqrt(var);
+    return stats;
 }
 
-void
-compute_inc_exc_vectors(const std::vector<out_node_t>& nodes,
-                        std::vector<double>& inclusive, std::vector<double>& exclusive)
+struct flat_graph_agg_t
 {
-    inclusive.assign(nodes.size(), 0.0);
-    exclusive.assign(nodes.size(), 0.0);
-    fill_inc_exc(nodes, 0, inclusive, exclusive);
-}
-
-struct flat_row_t
-{
-    std::string  key;
-    std::int32_t depth     = 0;
-    double       inclusive = 0;
-    double       exclusive = 0;
+    std::string             prefix;
+    std::int32_t            depth    = 0;
+    tim::hash::hash_value_t hash     = 0;
+    tim::hash::hash_value_t rolling  = 0;
+    std::int64_t            laps     = 0;
+    std::uint64_t           accum_ns = 0;
+    std::vector<double>     lap_secs;
 };
 
 void
-collect_preorder(const std::vector<out_node_t>& nodes, std::uint32_t id,
-                 const std::vector<double>& inclusive,
-                 const std::vector<double>& exclusive, std::vector<flat_row_t>& out)
+collect_flat_graph_agg(const std::vector<out_node_t>& nodes, std::uint32_t id,
+                       std::unordered_map<std::string, flat_graph_agg_t>& agg,
+                       std::vector<std::string>& order, thread_label_ctx_t& tlabels)
 {
     if(id != 0)
     {
-        const auto& n = nodes.at(id);
-        out.push_back({ timemory_label_cell(n.thread_id, n.depth, n.name), n.depth,
-                        inclusive.at(id), exclusive.at(id) });
+        const auto& n   = nodes.at(id);
+        const auto  key = flat_graph_agg_key(nodes, id, tlabels);
+        auto&       a   = agg[key];
+        if(a.laps == 0)
+        {
+            order.push_back(key);
+            a.prefix  = timemory_json_prefix(tlabels.label(n.thread_id), n.depth, n.name);
+            a.depth   = n.depth;
+            a.hash    = node_name_hash(n.name);
+            a.rolling = rolling_hash_for_node(nodes, id);
+        }
+        const double sec = duration_sec(n);
+        ++a.laps;
+        a.accum_ns += duration_ns(n);
+        a.lap_secs.push_back(sec);
     }
     for(auto cid : nodes.at(id).children)
-        collect_preorder(nodes, cid, inclusive, exclusive, out);
+        collect_flat_graph_agg(nodes, cid, agg, order, tlabels);
 }
 
-struct agg_t
+std::vector<flat_graph_agg_t>
+build_flat_graph_aggregate(const std::vector<out_node_t>& nodes)
 {
-    std::int32_t depth    = 0;
-    std::int64_t count    = 0;
-    double       sum      = 0;
-    double       minv     = 0;
-    double       maxv     = 0;
-    double       sumsq    = 0;
-    double       sum_excl = 0;
-};
+    const bool collapse_threads =
+        tim::settings::instance() && tim::settings::instance()->get_collapse_threads();
+    thread_label_ctx_t tlabels{ collapse_threads };
 
-std::string
-center_text(const std::string& s, size_t w)
-{
-    if(s.size() >= w) return s.substr(0, w);
-    const size_t pad_l = (w - s.size()) / 2;
-    const size_t pad_r = w - pad_l - s.size();
-    return std::string(pad_l, ' ') + s + std::string(pad_r, ' ');
+    std::unordered_map<std::string, flat_graph_agg_t> agg;
+    std::vector<std::string>                          order;
+    collect_flat_graph_agg(nodes, 0, agg, order, tlabels);
+
+    std::vector<flat_graph_agg_t> rows;
+    rows.reserve(order.size());
+    for(const auto& key : order)
+        rows.push_back(agg.at(key));
+    return rows;
 }
 
-template <typename T>
-std::string
-right_field(const T& v, size_t w)
+nlohmann::json
+build_timemory_flat_graph(const std::vector<out_node_t>& nodes)
 {
-    std::ostringstream o;
-    o << std::right << std::setw(static_cast<int>(w)) << v;
-    return o.str();
-}
+    const auto rows = build_flat_graph_aggregate(nodes);
 
-std::string
-left_field(std::string s, size_t w)
-{
-    if(s.size() > w)
-        s.resize(w);
-    else if(s.size() < w)
-        s.append(w - s.size(), ' ');
-    return s;
-}
-
-std::string
-right_fixed(double v, size_t w, int prec)
-{
-    std::ostringstream o;
-    o << std::fixed << std::setprecision(prec) << std::right
-      << std::setw(static_cast<int>(w)) << v;
-    return o.str();
+    nlohmann::json graph = nlohmann::json::array();
+    for(const auto& a : rows)
+    {
+        nlohmann::json row;
+        row["hash"]         = a.hash;
+        row["prefix"]       = a.prefix;
+        row["depth"]        = a.depth;
+        row["entry"]        = wall_clock_entry_json(a.accum_ns, a.laps);
+        row["stats"]        = wall_clock_stats_json(a.lap_secs);
+        row["rolling_hash"] = a.rolling;
+        graph.push_back(std::move(row));
+    }
+    return graph;
 }
 
 void
 write_text(const std::vector<out_node_t>& nodes, std::ofstream& os)
 {
-    constexpr int inner_w = 149;
-    std::string   border  = "|";
-    border.append(static_cast<size_t>(inner_w), '-');
-    border += "|\n";
+    using wc_t            = tim::component::wall_clock;
+    using result_t        = tim::node::result<wc_t>;
+    using stats_t         = typename result_t::stats_type;
+    using get_return_type = decltype(std::declval<const wc_t>().get());
+    using compute_type    = tim::math::compute<get_return_type>;
 
-    os << border;
+    const auto rows = build_flat_graph_aggregate(nodes);
+    if(rows.empty()) return;
+
+    // print_header<> returns immediately when runtime_enabled is false (common after
+    // timemory_finalize), but print<> still writes rows and requires headers.
+    const bool saved_runtime = tim::trait::runtime_enabled<wc_t>::get();
+    tim::trait::runtime_enabled<wc_t>::set(true);
+
+    std::vector<result_t> storage;
+    storage.reserve(rows.size());
+    std::vector<result_t*> flattened;
+    flattened.reserve(rows.size());
+
+    std::int64_t max_depth = 0;
+    for(const auto& a : rows)
     {
-        const char* title = "REAL-CLOCK TIMER (I.E. WALL-CLOCK TIMER)";
-        const int   tl    = static_cast<int>(std::strlen(title));
-        const int   padl  = std::max(0, (inner_w - tl) / 2);
-        const int   padr  = std::max(0, inner_w - padl - tl);
-        os << '|' << std::string(static_cast<size_t>(padl), ' ') << title
-           << std::string(static_cast<size_t>(padr), ' ') << "|\n";
+        max_depth = std::max(max_depth, static_cast<std::int64_t>(a.depth));
+
+        stats_t stats{};
+        for(double sec : a.lap_secs)
+            stats += sec;
+
+        wc_t wc{};
+        wc.set_value(static_cast<wc_t::value_type>(a.accum_ns));
+        wc.set_accum(static_cast<wc_t::value_type>(a.accum_ns));
+        wc.set_laps(a.laps);
+
+        std::vector<tim::hash::hash_value_t> hierarchy{};
+        storage.emplace_back(a.hash, wc, std::string(" ") + a.prefix, a.depth, a.rolling,
+                             hierarchy, stats, 0, tim::process::get_id());
+        flattened.push_back(&storage.back());
     }
-    os << border;
 
-    constexpr int wl = 36;
-    os << '|' << center_text("LABEL", static_cast<size_t>(wl)) << '|'
-       << center_text("COUNT", 8) << '|' << center_text("DEPTH", 8) << '|'
-       << center_text("METRIC", 12) << '|' << center_text("UNITS", 8) << '|'
-       << center_text("SUM", 10) << '|' << center_text("MEAN", 10) << '|'
-       << center_text("MIN", 10) << '|' << center_text("MAX", 10) << '|'
-       << center_text("VAR", 10) << '|' << center_text("STDDEV", 10) << '|'
-       << center_text("% SELF", 8) << "|\n";
+    auto stream = std::make_shared<tim::utility::stream>(
+        '|', '-', wc_t::get_format_flags(), wc_t::get_width(), wc_t::get_precision());
 
-    os << "|" << std::string(36, '-') << "|" << std::string(8, '-') << "|"
-       << std::string(8, '-') << "|" << std::string(12, '-') << "|" << std::string(8, '-')
-       << "|" << std::string(10, '-') << "|" << std::string(10, '-') << "|"
-       << std::string(10, '-') << "|" << std::string(10, '-') << "|"
-       << std::string(10, '-') << "|" << std::string(10, '-') << "|"
-       << std::string(8, '-') << "|\n";
+    std::string banner = wc_t::description();
+    for(char& c : banner)
+        c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+    stream->set_banner(banner);
 
-    std::vector<double> inclusive;
-    std::vector<double> exclusive;
-    compute_inc_exc_vectors(nodes, inclusive, exclusive);
-
-    std::vector<flat_row_t> flat;
-    collect_preorder(nodes, 0, inclusive, exclusive, flat);
-
-    std::unordered_map<std::string, agg_t> agg;
-    std::vector<std::string>               order;
-    order.reserve(flat.size());
-    for(const auto& r : flat)
+    // Same flattened preorder walk and % SELF logic as
+    // tim::operation::finalize::print<wc_t>::write_stream.
+    bool header_done = false;
+    for(auto itr = flattened.begin(); itr != flattened.end(); ++itr)
     {
-        auto& a = agg[r.key];
-        if(a.count == 0)
+        auto& itr_obj    = (*itr)->data();
+        auto& itr_prefix = (*itr)->prefix();
+        auto& itr_depth  = (*itr)->depth();
+        auto  itr_laps   = itr_obj.get_laps();
+
+        if(itr_depth < 0 || itr_depth > max_depth) continue;
+
+        get_return_type exclusive_values{};
+        if(itr_depth < max_depth)
         {
-            order.push_back(r.key);
-            a.depth = r.depth;
-            a.minv = a.maxv = r.inclusive;
+            auto         eitr       = itr;
+            std::int64_t nexclusive = 0;
+            std::advance(eitr, 1);
+            exclusive_values = get_return_type{};
+            if(eitr != flattened.end())
+            {
+                auto eitr_depth = (*eitr)->depth();
+                while(eitr_depth != itr_depth)
+                {
+                    auto& eitr_obj = (*eitr)->data();
+                    if(eitr_depth == itr_depth + 1)
+                    {
+                        if(nexclusive == 0)
+                            exclusive_values = eitr_obj.get();
+                        else
+                            compute_type::plus(exclusive_values, eitr_obj.get());
+                        ++nexclusive;
+                    }
+                    ++eitr;
+                    if(eitr == flattened.end()) break;
+                    eitr_depth = (*eitr)->depth();
+                }
+            }
         }
-        else
+
+        const auto itr_self = compute_type::percent_diff(exclusive_values, itr_obj.get());
+        auto&      itr_stats = (*itr)->stats();
+
+        if(!header_done)
         {
-            a.minv = std::min(a.minv, r.inclusive);
-            a.maxv = std::max(a.maxv, r.inclusive);
+            tim::operation::print_header<wc_t>(itr_obj, *stream, itr_stats);
+            header_done = true;
         }
-        ++a.count;
-        a.sum += r.inclusive;
-        a.sumsq += r.inclusive * r.inclusive;
-        a.sum_excl += r.exclusive;
+
+        tim::operation::print<wc_t>(itr_obj, *stream, itr_prefix, itr_laps, itr_depth,
+                                    itr_self, itr_stats);
+        stream->add_row();
     }
 
-    for(const auto& key : order)
-    {
-        const auto&  a     = agg.at(key);
-        const double mean  = a.sum / static_cast<double>(a.count);
-        const double mean2 = mean * mean;
-        const double var_p =
-            (a.count > 0) ? (a.sumsq / static_cast<double>(a.count) - mean2) : 0.0;
-        const double var    = (var_p > 0) ? var_p : 0.0;
-        const double stddev = std::sqrt(var);
-        const double pct    = (a.sum > 1e-30) ? (100.0 * a.sum_excl / a.sum) : 0.0;
+    tim::trait::runtime_enabled<wc_t>::set(saved_runtime);
 
-        std::string lbl = key;
-        if(static_cast<int>(lbl.size()) > wl)
-            lbl = lbl.substr(0, static_cast<size_t>(wl - 3)) + "...";
-
-        os << '|' << left_field(lbl, static_cast<size_t>(wl)) << '|'
-           << right_field(a.count, 8) << '|' << right_field(a.depth, 8) << '|'
-           << center_text("wall_clock", 12) << '|' << center_text("sec", 8) << '|'
-           << right_fixed(a.sum, 10, 6) << '|' << right_fixed(mean, 10, 6) << '|'
-           << right_fixed(a.minv, 10, 6) << '|' << right_fixed(a.maxv, 10, 6) << '|'
-           << right_fixed(var, 10, 6) << '|' << right_fixed(stddev, 10, 6) << '|'
-           << right_fixed(pct, 8, 1) << "|\n";
-    }
-
-    os << border;
+    os << *stream << std::flush;
 }
 
 bool
@@ -297,22 +394,29 @@ replay_to_nodes(const std::vector<wall_clock_event_sample>& ev,
 {
     if(ev.empty()) return false;
 
+    auto legacy_replay_less = [](const wall_clock_event_sample& a,
+                                 const wall_clock_event_sample& b) {
+        if(a.steady_ns != b.steady_ns) return a.steady_ns < b.steady_ns;
+        if(a.thread_id != b.thread_id) return a.thread_id < b.thread_id;
+        if(a.exec_id != b.exec_id) return a.exec_id < b.exec_id;
+        return a.event_kind < b.event_kind;
+    };
+
     std::vector<wall_clock_event_sample> sorted = ev;
     std::sort(sorted.begin(), sorted.end(),
-              [](const wall_clock_event_sample& a, const wall_clock_event_sample& b) {
-                  if(a.steady_ns != b.steady_ns) return a.steady_ns < b.steady_ns;
-                  if(a.thread_id != b.thread_id) return a.thread_id < b.thread_id;
-                  if(a.exec_id != b.exec_id) return a.exec_id < b.exec_id;
-                  return a.event_kind < b.event_kind;
+              [&](const wall_clock_event_sample& a, const wall_clock_event_sample& b) {
+                  if(a.record_seq != b.record_seq) return a.record_seq < b.record_seq;
+                  return legacy_replay_less(a, b);
               });
 
-    std::uint64_t max_wall = 0;
-    for(const auto& s : sorted)
-        max_wall = std::max(max_wall, s.wall_ns);
+    std::uint64_t                                                 max_wall = 0;
+    std::unordered_map<std::uint64_t, slot_t>                     slots;
+    std::unordered_map<std::uint64_t, std::vector<std::uint64_t>> by_parent;
 
-    std::unordered_map<std::uint64_t, slot_t> slots;
     for(const auto& s : sorted)
     {
+        max_wall = std::max(max_wall, s.wall_ns);
+
         if(s.event_kind == static_cast<std::uint8_t>(wall_clock_scope_event_kind::enter))
         {
             slot_t sl;
@@ -325,6 +429,7 @@ replay_to_nodes(const std::vector<wall_clock_event_sample>& ev,
             sl.enter_steady_ns = s.steady_ns;
             sl.has_exit        = false;
             slots[s.exec_id]   = std::move(sl);
+            by_parent[s.parent_exec_id].push_back(s.exec_id);
         }
         else if(s.event_kind ==
                 static_cast<std::uint8_t>(wall_clock_scope_event_kind::exit))
@@ -347,31 +452,6 @@ replay_to_nodes(const std::vector<wall_clock_event_sample>& ev,
         }
     }
 
-    std::unordered_map<std::uint64_t, std::vector<std::uint64_t>> by_parent;
-    for(const auto& kv : slots)
-    {
-        by_parent[kv.second.parent_exec_id].push_back(kv.first);
-    }
-
-    for(auto& kv : by_parent)
-    {
-        auto& ch = kv.second;
-        // Sibling order: first ENTER time (steady clock), not inclusive duration.
-        // Sorting by duration reorders unrelated regions under the same parent (e.g.
-        // _pthread_barrier_wait before _launch_child) and still does not match timemory's
-        // graph sibling order for pthread_create → start_thread.
-        std::sort(ch.begin(), ch.end(), [&](std::uint64_t a, std::uint64_t b) {
-            const auto& sa = slots.at(a);
-            const auto& sb = slots.at(b);
-            if(sa.enter_steady_ns != sb.enter_steady_ns)
-                return sa.enter_steady_ns < sb.enter_steady_ns;
-            if(sa.enter_wall_ns != sb.enter_wall_ns)
-                return sa.enter_wall_ns < sb.enter_wall_ns;
-            if(sa.thread_id != sb.thread_id) return sa.thread_id < sb.thread_id;
-            return sa.exec_id < sb.exec_id;
-        });
-    }
-
     out_nodes.clear();
     out_node_t root{};
     root.id        = 0;
@@ -390,13 +470,15 @@ replay_to_nodes(const std::vector<wall_clock_event_sample>& ev,
 
         const auto nid = static_cast<std::uint32_t>(out_nodes.size());
         out_node_t n{};
-        n.id        = nid;
-        n.parent    = parent_out;
-        n.depth     = out_nodes.at(parent_out).depth + 1;
-        n.thread_id = static_cast<std::int64_t>(sl.thread_id);
-        n.name      = sl.name;
-        n.start_ns  = sl.enter_wall_ns;
-        n.end_ns    = sl.exit_wall_ns;
+        n.id             = nid;
+        n.parent         = parent_out;
+        n.depth          = out_nodes.at(parent_out).depth + 1;
+        n.thread_id      = static_cast<std::int64_t>(sl.thread_id);
+        n.name           = sl.name;
+        n.exec_id        = sl.exec_id;
+        n.parent_exec_id = sl.parent_exec_id;
+        n.start_ns       = sl.enter_wall_ns;
+        n.end_ns         = sl.exit_wall_ns;
         out_nodes.at(parent_out).children.push_back(nid);
         out_nodes.push_back(std::move(n));
 
@@ -462,22 +544,32 @@ profiled_event_processor_t::finalize_processing()
         settings::compose_output_filename(output_metric, "txt", path_cfg);
     if(json_path.empty() || txt_path.empty()) return;
 
+    nlohmann::json flat_graph = build_timemory_flat_graph(nodes);
+
+    // Match timemory \c wall_clock.json layout (key \c "wall_clock") for hatchet/tools.
+    // Output path remains \c wall_clock_evt-* via \p output_metric.
+    constexpr const char* json_component_key = "wall_clock";
+
     nlohmann::json root;
-    root["timemory"][output_metric]["properties"] = nlohmann::json::object();
-    root["timemory"][output_metric]["type"]       = output_metric;
-    root["timemory"][output_metric]["description"] =
-        "Wall-clock tree reconstructed offline from trace-cache scope events "
-        "(wall_clock_event)";
-    root["timemory"][output_metric]["unit_value"]        = 1.e9;
-    root["timemory"][output_metric]["unit_repr"]         = "sec";
-    root["timemory"][output_metric]["thread_scope_only"] = false;
-    root["timemory"][output_metric]["thread_count"] = tim::manager::get_thread_count();
-    root["timemory"][output_metric]["mpi_size"]     = dmp::size();
-    root["timemory"][output_metric]["ranks"]        = nlohmann::json::array();
+    auto&          wc       = root["timemory"][json_component_key];
+    wc["type"]              = "wall_clock";
+    wc["description"]       = "Real-clock timer (i.e. wall-clock timer)";
+    wc["unit_value"]        = 1000000000;
+    wc["unit_repr"]         = "sec";
+    wc["thread_scope_only"] = false;
+    wc["thread_count"]      = tim::manager::get_thread_count();
+    wc["mpi_size"]          = dmp::size();
+    wc["upcxx_size"]        = 1;
+    wc["process_count"]     = 1;
+    wc["num_ranks"]         = dmp::size();
+    wc["concurrency"]       = tim::manager::get_thread_count();
+    wc["ranks"]             = nlohmann::json::array();
+
     nlohmann::json rank_entry;
-    rank_entry["graph"] = nlohmann::json::array();
-    dfs_graph(nodes, 0, rank_entry["graph"]);
-    root["timemory"][output_metric]["ranks"].push_back(std::move(rank_entry));
+    rank_entry["rank"]       = dmp::rank();
+    rank_entry["graph_size"] = flat_graph.size();
+    rank_entry["graph"]      = std::move(flat_graph);
+    wc["ranks"].push_back(std::move(rank_entry));
 
     bool json_ok = false;
     bool txt_ok  = false;

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/profiled_event_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/profiled_event_processor.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
-#include "core/trace_cache/wall_clock_scope_event_processor.hpp"
+#include "core/trace_cache/profiled_event_processor.hpp"
 
 #include "core/config.hpp"
 #include "core/output_file_registry.hpp"
@@ -292,15 +292,14 @@ write_text(const std::vector<out_node_t>& nodes, std::ofstream& os)
 }
 
 bool
-replay_to_nodes(const std::vector<wall_clock_scope_event_sample>& ev,
-                std::vector<out_node_t>&                          out_nodes)
+replay_to_nodes(const std::vector<wall_clock_event_sample>& ev,
+                std::vector<out_node_t>&                    out_nodes)
 {
     if(ev.empty()) return false;
 
-    std::vector<wall_clock_scope_event_sample> sorted = ev;
+    std::vector<wall_clock_event_sample> sorted = ev;
     std::sort(sorted.begin(), sorted.end(),
-              [](const wall_clock_scope_event_sample& a,
-                 const wall_clock_scope_event_sample& b) {
+              [](const wall_clock_event_sample& a, const wall_clock_event_sample& b) {
                   if(a.steady_ns != b.steady_ns) return a.steady_ns < b.steady_ns;
                   if(a.thread_id != b.thread_id) return a.thread_id < b.thread_id;
                   if(a.exec_id != b.exec_id) return a.exec_id < b.exec_id;
@@ -421,8 +420,8 @@ replay_to_nodes(const std::vector<wall_clock_scope_event_sample>& ev,
 
 }  // namespace
 
-wall_clock_scope_event_processor_t::wall_clock_scope_event_processor_t(
-    int pid, int ppid, output_file_registry& registry)
+profiled_event_processor_t::profiled_event_processor_t(int pid, int ppid,
+                                                       output_file_registry& registry)
 : m_pid(pid)
 , m_ppid(ppid)
 , m_registry(registry)
@@ -432,13 +431,13 @@ wall_clock_scope_event_processor_t::wall_clock_scope_event_processor_t(
 }
 
 void
-wall_clock_scope_event_processor_t::prepare_for_processing()
+profiled_event_processor_t::prepare_for_processing()
 {
     m_events.clear();
 }
 
 void
-wall_clock_scope_event_processor_t::finalize_processing()
+profiled_event_processor_t::finalize_processing()
 {
     if(!config::get_use_timemory()) return;
     if(m_events.empty()) return;
@@ -468,7 +467,7 @@ wall_clock_scope_event_processor_t::finalize_processing()
     root["timemory"][output_metric]["type"]       = output_metric;
     root["timemory"][output_metric]["description"] =
         "Wall-clock tree reconstructed offline from trace-cache scope events "
-        "(wall_clock_scope_event)";
+        "(wall_clock_event)";
     root["timemory"][output_metric]["unit_value"]        = 1.e9;
     root["timemory"][output_metric]["unit_repr"]         = "sec";
     root["timemory"][output_metric]["thread_scope_only"] = false;
@@ -498,57 +497,57 @@ wall_clock_scope_event_processor_t::finalize_processing()
 }
 
 void
-wall_clock_scope_event_processor_t::handle(const wall_clock_scope_event_sample& s)
+profiled_event_processor_t::handle(const wall_clock_event_sample& s)
 {
     m_events.push_back(s);
 }
 
 void
-wall_clock_scope_event_processor_t::handle(const kernel_dispatch_sample&)
+profiled_event_processor_t::handle(const kernel_dispatch_sample&)
 {}
 
 void
-wall_clock_scope_event_processor_t::handle(const scratch_memory_sample&)
+profiled_event_processor_t::handle(const scratch_memory_sample&)
 {}
 
 void
-wall_clock_scope_event_processor_t::handle(const memory_copy_sample&)
+profiled_event_processor_t::handle(const memory_copy_sample&)
 {}
 
 void
-wall_clock_scope_event_processor_t::handle(const memory_allocate_sample&)
+profiled_event_processor_t::handle(const memory_allocate_sample&)
 {}
 
 void
-wall_clock_scope_event_processor_t::handle(const region_sample&)
+profiled_event_processor_t::handle(const region_sample&)
 {}
 
 void
-wall_clock_scope_event_processor_t::handle(const in_time_sample&)
+profiled_event_processor_t::handle(const in_time_sample&)
 {}
 
 void
-wall_clock_scope_event_processor_t::handle(const pmc_event_with_sample&)
+profiled_event_processor_t::handle(const pmc_event_with_sample&)
 {}
 
 void
-wall_clock_scope_event_processor_t::handle(const gpu_pmc_sample&)
+profiled_event_processor_t::handle(const gpu_pmc_sample&)
 {}
 
 void
-wall_clock_scope_event_processor_t::handle(const ainic_pmc_sample&)
+profiled_event_processor_t::handle(const ainic_pmc_sample&)
 {}
 
 void
-wall_clock_scope_event_processor_t::handle(const cpu_pmc_sample&)
+profiled_event_processor_t::handle(const cpu_pmc_sample&)
 {}
 
 void
-wall_clock_scope_event_processor_t::handle(const backtrace_region_sample&)
+profiled_event_processor_t::handle(const backtrace_region_sample&)
 {}
 
 void
-wall_clock_scope_event_processor_t::handle(const kfd_sample&)
+profiled_event_processor_t::handle(const kfd_sample&)
 {}
 
 }  // namespace rocprofsys::trace_cache

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/profiled_event_processor.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/profiled_event_processor.hpp
@@ -16,14 +16,13 @@ namespace rocprofsys
 namespace trace_cache
 {
 
-/// Collects \ref wall_clock_scope_event_sample during trace-cache replay and writes
+/// Collects \ref wall_clock_event_sample during trace-cache replay and writes
 /// \c wall_clock_evt.{json,txt} (offline reconstruction of the instrumented wall-clock
 /// tree).
-class wall_clock_scope_event_processor_t
-: public processor_t<wall_clock_scope_event_processor_t>
+class profiled_event_processor_t : public processor_t<profiled_event_processor_t>
 {
 public:
-    wall_clock_scope_event_processor_t(int pid, int ppid, output_file_registry& registry);
+    profiled_event_processor_t(int pid, int ppid, output_file_registry& registry);
 
     void prepare_for_processing();
     void finalize_processing();
@@ -40,13 +39,13 @@ public:
     void handle(const cpu_pmc_sample& sample);
     void handle(const backtrace_region_sample& sample);
     void handle(const kfd_sample& sample);
-    void handle(const wall_clock_scope_event_sample& sample);
+    void handle(const wall_clock_event_sample& sample);
 
 private:
-    int                                        m_pid;
-    int                                        m_ppid;
-    output_file_registry&                      m_registry;
-    std::vector<wall_clock_scope_event_sample> m_events;
+    int                                  m_pid;
+    int                                  m_ppid;
+    output_file_registry&                m_registry;
+    std::vector<wall_clock_event_sample> m_events;
 };
 
 }  // namespace trace_cache

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.cpp
@@ -710,6 +710,10 @@ rocpd_processor_t::handle(const kfd_sample& _kfd)
     }
 }
 
+void
+rocpd_processor_t::handle(const wall_clock_scope_event_sample&)
+{}
+
 rocpd_processor_t::rocpd_processor_t(const std::shared_ptr<metadata_registry>& md,
                                      const std::shared_ptr<agent_manager>&     agent_mngr,
                                      int pid, int ppid,

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.cpp
@@ -711,7 +711,7 @@ rocpd_processor_t::handle(const kfd_sample& _kfd)
 }
 
 void
-rocpd_processor_t::handle(const wall_clock_scope_event_sample&)
+rocpd_processor_t::handle(const wall_clock_event_sample&)
 {}
 
 rocpd_processor_t::rocpd_processor_t(const std::shared_ptr<metadata_registry>& md,

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.hpp
@@ -38,7 +38,7 @@ public:
     void handle(const cpu_pmc_sample& sample);
     void handle(const backtrace_region_sample& sample);
     void handle(const kfd_sample& sample);
-    void handle(const wall_clock_scope_event_sample& sample);
+    void handle(const wall_clock_event_sample& sample);
 
 private:
     using primary_key = size_t;

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_processor.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_processor.hpp
@@ -66,7 +66,7 @@ struct processor_t
 
     void handle(const kfd_sample& sample) { static_cast<T*>(this)->handle(sample); }
 
-    void handle(const wall_clock_scope_event_sample& sample)
+    void handle(const wall_clock_event_sample& sample)
     {
         static_cast<T*>(this)->handle(sample);
     }
@@ -96,8 +96,8 @@ struct processor_view_t
     using backtrace_region_fn_t = void (*)(void*,
                                            const backtrace_region_sample&) noexcept;
     using kfd_sample_fn_t       = void (*)(void*, const kfd_sample&) noexcept;
-    using wall_clock_scope_event_fn_t =
-        void (*)(void*, const wall_clock_scope_event_sample&) noexcept;
+    using wall_clock_event_fn_t = void (*)(void*,
+                                           const wall_clock_event_sample&) noexcept;
     using prepare_for_processing_fn_t = void (*)(void*) noexcept;
     using finalize_processing_fn_t    = void (*)(void*) noexcept;
 
@@ -117,7 +117,7 @@ struct processor_view_t
         cpu_pmc_sample_fn_t         handle_cpu_pmc_sample;
         backtrace_region_fn_t       handle_backtrace_region;
         kfd_sample_fn_t             handle_kfd_sample;
-        wall_clock_scope_event_fn_t handle_wall_clock_scope_event;
+        wall_clock_event_fn_t       handle_wall_clock_event;
         prepare_for_processing_fn_t prepare_for_processing;
         finalize_processing_fn_t    finalize_processing;
     };
@@ -197,10 +197,9 @@ struct processor_view_t
         m_vtable->handle_kfd_sample(m_object, sample);
     }
 
-    ROCPROFSYS_INLINE void handle(
-        const wall_clock_scope_event_sample& sample) const noexcept
+    ROCPROFSYS_INLINE void handle(const wall_clock_event_sample& sample) const noexcept
     {
-        m_vtable->handle_wall_clock_scope_event(m_object, sample);
+        m_vtable->handle_wall_clock_event(m_object, sample);
     }
 
     ROCPROFSYS_INLINE void prepare_for_processing() const noexcept
@@ -256,7 +255,7 @@ private:
             +[](void* obj, const kfd_sample& sample) noexcept {
                 static_cast<T*>(obj)->handle(sample);
             },
-            +[](void* obj, const wall_clock_scope_event_sample& sample) noexcept {
+            +[](void* obj, const wall_clock_event_sample& sample) noexcept {
                 static_cast<T*>(obj)->handle(sample);
             },
             +[](void* obj) noexcept { static_cast<T*>(obj)->prepare_for_processing(); },
@@ -347,7 +346,7 @@ struct sample_processor_t
                 handle_sample(static_cast<const kfd_sample&>(sample));
                 break;
             case type_identifier_t::wall_clock_scope_event:
-                handle_sample(static_cast<const wall_clock_scope_event_sample&>(sample));
+                handle_sample(static_cast<const wall_clock_event_sample&>(sample));
                 break;
             default: throw std::runtime_error("Unsupported sample type");
         }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_processor.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_processor.hpp
@@ -66,6 +66,11 @@ struct processor_t
 
     void handle(const kfd_sample& sample) { static_cast<T*>(this)->handle(sample); }
 
+    void handle(const wall_clock_scope_event_sample& sample)
+    {
+        static_cast<T*>(this)->handle(sample);
+    }
+
     void prepare_for_processing() { static_cast<T*>(this)->prepare_for_processing(); }
 
     void finalize_processing() { static_cast<T*>(this)->finalize_processing(); }
@@ -91,6 +96,8 @@ struct processor_view_t
     using backtrace_region_fn_t = void (*)(void*,
                                            const backtrace_region_sample&) noexcept;
     using kfd_sample_fn_t       = void (*)(void*, const kfd_sample&) noexcept;
+    using wall_clock_scope_event_fn_t =
+        void (*)(void*, const wall_clock_scope_event_sample&) noexcept;
     using prepare_for_processing_fn_t = void (*)(void*) noexcept;
     using finalize_processing_fn_t    = void (*)(void*) noexcept;
 
@@ -110,6 +117,7 @@ struct processor_view_t
         cpu_pmc_sample_fn_t         handle_cpu_pmc_sample;
         backtrace_region_fn_t       handle_backtrace_region;
         kfd_sample_fn_t             handle_kfd_sample;
+        wall_clock_scope_event_fn_t handle_wall_clock_scope_event;
         prepare_for_processing_fn_t prepare_for_processing;
         finalize_processing_fn_t    finalize_processing;
     };
@@ -189,6 +197,12 @@ struct processor_view_t
         m_vtable->handle_kfd_sample(m_object, sample);
     }
 
+    ROCPROFSYS_INLINE void handle(
+        const wall_clock_scope_event_sample& sample) const noexcept
+    {
+        m_vtable->handle_wall_clock_scope_event(m_object, sample);
+    }
+
     ROCPROFSYS_INLINE void prepare_for_processing() const noexcept
     {
         m_vtable->prepare_for_processing(m_object);
@@ -240,6 +254,9 @@ private:
                 static_cast<T*>(obj)->handle(sample);
             },
             +[](void* obj, const kfd_sample& sample) noexcept {
+                static_cast<T*>(obj)->handle(sample);
+            },
+            +[](void* obj, const wall_clock_scope_event_sample& sample) noexcept {
                 static_cast<T*>(obj)->handle(sample);
             },
             +[](void* obj) noexcept { static_cast<T*>(obj)->prepare_for_processing(); },
@@ -328,6 +345,9 @@ struct sample_processor_t
                 break;
             case type_identifier_t::kfd_sample:
                 handle_sample(static_cast<const kfd_sample&>(sample));
+                break;
+            case type_identifier_t::wall_clock_scope_event:
+                handle_sample(static_cast<const wall_clock_scope_event_sample&>(sample));
                 break;
             default: throw std::runtime_error("Unsupported sample type");
         }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
@@ -693,6 +693,9 @@ get_size(const backtrace_region_sample& item)
 /// ENTER/EXIT pair for one scope invocation. \c parent_exec_id / \c depth / \c name
 /// are meaningful on ENTER; on EXIT \c exec_id matches ENTER and other snapshot fields
 /// may be zero / empty.
+///
+/// \c record_seq is a global monotonic id assigned at emission time so offline replay
+/// can follow processing order (timemory-like semantics) without re-ordering by clocks.
 struct wall_clock_event_sample : cacheable_t
 {
     static constexpr type_identifier_t type_identifier =
@@ -703,7 +706,7 @@ struct wall_clock_event_sample : cacheable_t
                             std::uint64_t _thread_id, std::uint8_t _event_kind,
                             std::uint64_t _exec_id, std::uint64_t _parent_exec_id,
                             std::uint32_t _depth, std::uint64_t _correlation_id,
-                            std::string _name)
+                            std::uint64_t _record_seq, std::string _name)
     : steady_ns(_steady_ns)
     , wall_ns(_wall_ns)
     , thread_id(_thread_id)
@@ -712,6 +715,7 @@ struct wall_clock_event_sample : cacheable_t
     , parent_exec_id(_parent_exec_id)
     , depth(_depth)
     , correlation_id(_correlation_id)
+    , record_seq(_record_seq)
     , name(std::move(_name))
     {}
 
@@ -726,6 +730,8 @@ struct wall_clock_event_sample : cacheable_t
     std::uint64_t parent_exec_id = 0;
     std::uint32_t depth          = 0;
     std::uint64_t correlation_id = 0;
+    /// Global emission order (0 in legacy traces without this field).
+    std::uint64_t record_seq = 0;
     std::string   name;
 };
 
@@ -735,7 +741,8 @@ serialize(std::uint8_t* buffer, const wall_clock_event_sample& item)
 {
     utility::store_value(buffer, item.steady_ns, item.wall_ns, item.thread_id,
                          item.event_kind, item.exec_id, item.parent_exec_id, item.depth,
-                         item.correlation_id, std::string_view(item.name));
+                         item.correlation_id, item.record_seq,
+                         std::string_view(item.name));
 }
 
 template <>
@@ -746,7 +753,7 @@ deserialize(std::uint8_t*& buffer)
     std::string_view        name_view;
     utility::parse_value(buffer, item.steady_ns, item.wall_ns, item.thread_id,
                          item.event_kind, item.exec_id, item.parent_exec_id, item.depth,
-                         item.correlation_id, name_view);
+                         item.correlation_id, item.record_seq, name_view);
     item.name = std::string(name_view);
     return item;
 }
@@ -757,7 +764,7 @@ get_size(const wall_clock_event_sample& item)
 {
     return utility::get_size(item.steady_ns, item.wall_ns, item.thread_id,
                              item.event_kind, item.exec_id, item.parent_exec_id,
-                             item.depth, item.correlation_id,
+                             item.depth, item.correlation_id, item.record_seq,
                              std::string_view(item.name));
 }
 

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
@@ -29,7 +29,16 @@ enum class type_identifier_t : std::uint32_t
     scratch_memory          = 0x0009,
     ainic_pmc_sample        = 0x000A,
     kfd_sample              = 0x000B,
-    fragmented_space        = 0xFFFF
+    /// Instrumented wall-clock scope ENTER/EXIT for offline tree reconstruction.
+    wall_clock_scope_event = 0x000C,
+    fragmented_space       = 0xFFFF
+};
+
+/// Values for \ref wall_clock_scope_event_sample::event_kind.
+enum class wall_clock_scope_event_kind : std::uint8_t
+{
+    enter = 0,
+    exit  = 1
 };
 
 struct kernel_dispatch_sample : cacheable_t
@@ -679,6 +688,77 @@ get_size(const backtrace_region_sample& item)
         std::string_view(item.name), item.start_timestamp, item.end_timestamp,
         std::string_view(item.category), std::string_view(item.call_stack),
         std::string_view(item.line_info), std::string_view(item.extdata));
+}
+
+/// ENTER/EXIT pair for one scope invocation. \c parent_exec_id / \c depth / \c name
+/// are meaningful on ENTER; on EXIT \c exec_id matches ENTER and other snapshot fields
+/// may be zero / empty.
+struct wall_clock_scope_event_sample : cacheable_t
+{
+    static constexpr type_identifier_t type_identifier =
+        type_identifier_t::wall_clock_scope_event;
+
+    wall_clock_scope_event_sample() = default;
+    wall_clock_scope_event_sample(std::uint64_t _steady_ns, std::uint64_t _wall_ns,
+                                  std::uint64_t _thread_id, std::uint8_t _event_kind,
+                                  std::uint64_t _exec_id, std::uint64_t _parent_exec_id,
+                                  std::uint32_t _depth, std::uint64_t _correlation_id,
+                                  std::string _name)
+    : steady_ns(_steady_ns)
+    , wall_ns(_wall_ns)
+    , thread_id(_thread_id)
+    , event_kind(_event_kind)
+    , exec_id(_exec_id)
+    , parent_exec_id(_parent_exec_id)
+    , depth(_depth)
+    , correlation_id(_correlation_id)
+    , name(std::move(_name))
+    {}
+
+    /// Monotonic timestamp for deterministic global ordering (steady_clock).
+    std::uint64_t steady_ns = 0;
+    /// system_clock wall time in nanoseconds (duration = EXIT.wall - ENTER.wall).
+    std::uint64_t wall_ns   = 0;
+    std::uint64_t thread_id = 0;
+    /// 0 = ENTER, 1 = EXIT (see \c wall_clock_scope_event_kind).
+    std::uint8_t  event_kind     = 0;
+    std::uint64_t exec_id        = 0;
+    std::uint64_t parent_exec_id = 0;
+    std::uint32_t depth          = 0;
+    std::uint64_t correlation_id = 0;
+    std::string   name;
+};
+
+template <>
+inline void
+serialize(std::uint8_t* buffer, const wall_clock_scope_event_sample& item)
+{
+    utility::store_value(buffer, item.steady_ns, item.wall_ns, item.thread_id,
+                         item.event_kind, item.exec_id, item.parent_exec_id, item.depth,
+                         item.correlation_id, std::string_view(item.name));
+}
+
+template <>
+inline wall_clock_scope_event_sample
+deserialize(std::uint8_t*& buffer)
+{
+    wall_clock_scope_event_sample item;
+    std::string_view              name_view;
+    utility::parse_value(buffer, item.steady_ns, item.wall_ns, item.thread_id,
+                         item.event_kind, item.exec_id, item.parent_exec_id, item.depth,
+                         item.correlation_id, name_view);
+    item.name = std::string(name_view);
+    return item;
+}
+
+template <>
+inline size_t
+get_size(const wall_clock_scope_event_sample& item)
+{
+    return utility::get_size(item.steady_ns, item.wall_ns, item.thread_id,
+                             item.event_kind, item.exec_id, item.parent_exec_id,
+                             item.depth, item.correlation_id,
+                             std::string_view(item.name));
 }
 
 struct kfd_sample : cacheable_t

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
@@ -34,7 +34,7 @@ enum class type_identifier_t : std::uint32_t
     fragmented_space       = 0xFFFF
 };
 
-/// Values for \ref wall_clock_scope_event_sample::event_kind.
+/// Values for \ref wall_clock_event_sample::event_kind.
 enum class wall_clock_scope_event_kind : std::uint8_t
 {
     enter = 0,
@@ -693,17 +693,17 @@ get_size(const backtrace_region_sample& item)
 /// ENTER/EXIT pair for one scope invocation. \c parent_exec_id / \c depth / \c name
 /// are meaningful on ENTER; on EXIT \c exec_id matches ENTER and other snapshot fields
 /// may be zero / empty.
-struct wall_clock_scope_event_sample : cacheable_t
+struct wall_clock_event_sample : cacheable_t
 {
     static constexpr type_identifier_t type_identifier =
         type_identifier_t::wall_clock_scope_event;
 
-    wall_clock_scope_event_sample() = default;
-    wall_clock_scope_event_sample(std::uint64_t _steady_ns, std::uint64_t _wall_ns,
-                                  std::uint64_t _thread_id, std::uint8_t _event_kind,
-                                  std::uint64_t _exec_id, std::uint64_t _parent_exec_id,
-                                  std::uint32_t _depth, std::uint64_t _correlation_id,
-                                  std::string _name)
+    wall_clock_event_sample() = default;
+    wall_clock_event_sample(std::uint64_t _steady_ns, std::uint64_t _wall_ns,
+                            std::uint64_t _thread_id, std::uint8_t _event_kind,
+                            std::uint64_t _exec_id, std::uint64_t _parent_exec_id,
+                            std::uint32_t _depth, std::uint64_t _correlation_id,
+                            std::string _name)
     : steady_ns(_steady_ns)
     , wall_ns(_wall_ns)
     , thread_id(_thread_id)
@@ -731,7 +731,7 @@ struct wall_clock_scope_event_sample : cacheable_t
 
 template <>
 inline void
-serialize(std::uint8_t* buffer, const wall_clock_scope_event_sample& item)
+serialize(std::uint8_t* buffer, const wall_clock_event_sample& item)
 {
     utility::store_value(buffer, item.steady_ns, item.wall_ns, item.thread_id,
                          item.event_kind, item.exec_id, item.parent_exec_id, item.depth,
@@ -739,11 +739,11 @@ serialize(std::uint8_t* buffer, const wall_clock_scope_event_sample& item)
 }
 
 template <>
-inline wall_clock_scope_event_sample
+inline wall_clock_event_sample
 deserialize(std::uint8_t*& buffer)
 {
-    wall_clock_scope_event_sample item;
-    std::string_view              name_view;
+    wall_clock_event_sample item;
+    std::string_view        name_view;
     utility::parse_value(buffer, item.steady_ns, item.wall_ns, item.thread_id,
                          item.event_kind, item.exec_id, item.parent_exec_id, item.depth,
                          item.correlation_id, name_view);
@@ -753,7 +753,7 @@ deserialize(std::uint8_t*& buffer)
 
 template <>
 inline size_t
-get_size(const wall_clock_scope_event_sample& item)
+get_size(const wall_clock_event_sample& item)
 {
     return utility::get_size(item.steady_ns, item.wall_ns, item.thread_id,
                              item.event_kind, item.exec_id, item.parent_exec_id,

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser_alias.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser_alias.hpp
@@ -16,6 +16,6 @@ using storage_parser_t = storage_parser<
     type_identifier_t, kernel_dispatch_sample, memory_copy_sample, memory_allocate_sample,
     region_sample, in_time_sample, pmc_event_with_sample, pmc::collectors::gpu::sample,
     pmc::collectors::nic::sample, pmc::collectors::cpu::sample, backtrace_region_sample,
-    scratch_memory_sample, kfd_sample, wall_clock_scope_event_sample>;
+    scratch_memory_sample, kfd_sample, wall_clock_event_sample>;
 
 }  // namespace rocprofsys::trace_cache

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser_alias.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser_alias.hpp
@@ -12,11 +12,10 @@
 namespace rocprofsys::trace_cache
 {
 
-using storage_parser_t =
-    storage_parser<type_identifier_t, kernel_dispatch_sample, memory_copy_sample,
-                   memory_allocate_sample, region_sample, in_time_sample,
-                   pmc_event_with_sample, pmc::collectors::gpu::sample,
-                   pmc::collectors::nic::sample, pmc::collectors::cpu::sample,
-                   backtrace_region_sample, scratch_memory_sample, kfd_sample>;
+using storage_parser_t = storage_parser<
+    type_identifier_t, kernel_dispatch_sample, memory_copy_sample, memory_allocate_sample,
+    region_sample, in_time_sample, pmc_event_with_sample, pmc::collectors::gpu::sample,
+    pmc::collectors::nic::sample, pmc::collectors::cpu::sample, backtrace_region_sample,
+    scratch_memory_sample, kfd_sample, wall_clock_scope_event_sample>;
 
 }  // namespace rocprofsys::trace_cache

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_sample_type.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_sample_type.cpp
@@ -659,13 +659,14 @@ TEST_F(sample_type_test, wall_clock_event_sample_default_constructor)
 {
     wall_clock_event_sample sample;
     EXPECT_EQ(sample.type_identifier, type_identifier_t::wall_clock_scope_event);
+    EXPECT_EQ(sample.record_seq, 0u);
 }
 
 TEST_F(sample_type_test, wall_clock_event_sample_serialize_roundtrip)
 {
     wall_clock_event_sample original(
         1001, 2002, 42, static_cast<std::uint8_t>(wall_clock_scope_event_kind::enter), 7,
-        3, 5, 99, "my_region");
+        3, 5, 99, 500, "my_region");
 
     serialize(buffer.data(), original);
 
@@ -681,5 +682,6 @@ TEST_F(sample_type_test, wall_clock_event_sample_serialize_roundtrip)
     EXPECT_EQ(deserialized.parent_exec_id, 3u);
     EXPECT_EQ(deserialized.depth, 5u);
     EXPECT_EQ(deserialized.correlation_id, 99u);
+    EXPECT_EQ(deserialized.record_seq, 500u);
     EXPECT_EQ(deserialized.name, "my_region");
 }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_sample_type.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_sample_type.cpp
@@ -476,6 +476,8 @@ TEST_F(sample_type_test, type_identifier_enum_values)
     EXPECT_EQ(static_cast<std::uint32_t>(type_identifier_t::cpu_pmc_sample), 0x0007);
     EXPECT_EQ(static_cast<std::uint32_t>(type_identifier_t::backtrace_region_sample),
               0x0008);
+    EXPECT_EQ(static_cast<std::uint32_t>(type_identifier_t::wall_clock_scope_event),
+              0x000C);
     EXPECT_EQ(static_cast<std::uint32_t>(type_identifier_t::fragmented_space), 0xFFFF);
 }
 
@@ -651,4 +653,33 @@ TEST_F(sample_type_test, kfd_sample_get_size)
     auto          deserialized = deserialize<kfd_sample>(buffer_ptr);
     EXPECT_EQ(deserialized.name, original.name);
     EXPECT_EQ(deserialized.category, original.category);
+}
+
+TEST_F(sample_type_test, wall_clock_scope_event_sample_default_constructor)
+{
+    wall_clock_scope_event_sample sample;
+    EXPECT_EQ(sample.type_identifier, type_identifier_t::wall_clock_scope_event);
+}
+
+TEST_F(sample_type_test, wall_clock_scope_event_sample_serialize_roundtrip)
+{
+    wall_clock_scope_event_sample original(
+        1001, 2002, 42, static_cast<std::uint8_t>(wall_clock_scope_event_kind::enter), 7,
+        3, 5, 99, "my_region");
+
+    serialize(buffer.data(), original);
+
+    std::uint8_t* buffer_ptr   = buffer.data();
+    auto          deserialized = deserialize<wall_clock_scope_event_sample>(buffer_ptr);
+
+    EXPECT_EQ(deserialized.steady_ns, 1001u);
+    EXPECT_EQ(deserialized.wall_ns, 2002u);
+    EXPECT_EQ(deserialized.thread_id, 42u);
+    EXPECT_EQ(deserialized.event_kind,
+              static_cast<std::uint8_t>(wall_clock_scope_event_kind::enter));
+    EXPECT_EQ(deserialized.exec_id, 7u);
+    EXPECT_EQ(deserialized.parent_exec_id, 3u);
+    EXPECT_EQ(deserialized.depth, 5u);
+    EXPECT_EQ(deserialized.correlation_id, 99u);
+    EXPECT_EQ(deserialized.name, "my_region");
 }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_sample_type.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/tests/test_sample_type.cpp
@@ -655,22 +655,22 @@ TEST_F(sample_type_test, kfd_sample_get_size)
     EXPECT_EQ(deserialized.category, original.category);
 }
 
-TEST_F(sample_type_test, wall_clock_scope_event_sample_default_constructor)
+TEST_F(sample_type_test, wall_clock_event_sample_default_constructor)
 {
-    wall_clock_scope_event_sample sample;
+    wall_clock_event_sample sample;
     EXPECT_EQ(sample.type_identifier, type_identifier_t::wall_clock_scope_event);
 }
 
-TEST_F(sample_type_test, wall_clock_scope_event_sample_serialize_roundtrip)
+TEST_F(sample_type_test, wall_clock_event_sample_serialize_roundtrip)
 {
-    wall_clock_scope_event_sample original(
+    wall_clock_event_sample original(
         1001, 2002, 42, static_cast<std::uint8_t>(wall_clock_scope_event_kind::enter), 7,
         3, 5, 99, "my_region");
 
     serialize(buffer.data(), original);
 
     std::uint8_t* buffer_ptr   = buffer.data();
-    auto          deserialized = deserialize<wall_clock_scope_event_sample>(buffer_ptr);
+    auto          deserialized = deserialize<wall_clock_event_sample>(buffer_ptr);
 
     EXPECT_EQ(deserialized.steady_ns, 1001u);
     EXPECT_EQ(deserialized.wall_ns, 2002u);

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/wall_clock_scope_event_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/wall_clock_scope_event_processor.cpp
@@ -1,0 +1,554 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "core/trace_cache/wall_clock_scope_event_processor.hpp"
+
+#include "core/config.hpp"
+#include "core/output_file_registry.hpp"
+#include "library/runtime.hpp"
+
+#include <timemory/backends/dmp.hpp>
+#include <timemory/manager/manager.hpp>
+#include <timemory/settings.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <functional>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace rocprofsys::trace_cache
+{
+namespace
+{
+
+constexpr const char* output_metric = "wall_clock_evt";
+
+struct slot_t
+{
+    std::uint64_t exec_id        = 0;
+    std::uint64_t parent_exec_id = 0;
+    std::uint64_t thread_id      = 0;
+    std::uint32_t depth          = 0;
+    std::string   name;
+    std::uint64_t enter_wall_ns   = 0;
+    std::uint64_t exit_wall_ns    = 0;
+    std::uint64_t enter_steady_ns = 0;
+    bool          has_exit        = false;
+};
+
+struct out_node_t
+{
+    std::uint32_t              id        = 0;
+    std::uint32_t              parent    = 0;
+    std::int32_t               depth     = -1;
+    std::int64_t               thread_id = -1;
+    std::string                name;
+    std::uint64_t              start_ns = 0;
+    std::uint64_t              end_ns   = 0;
+    std::vector<std::uint32_t> children;
+};
+
+std::string
+format_prefix(int d, const std::string& name)
+{
+    if(d <= 0) return name;
+    std::string p;
+    if(d > 1) p.append(std::string(static_cast<size_t>(d - 1) * 2, ' '));
+    p += "|_";
+    p += name;
+    return p;
+}
+
+std::string
+timemory_label_cell(std::int64_t tid, int depth, const std::string& name)
+{
+    const std::string body = (depth <= 0) ? name : format_prefix(depth, name);
+    return std::string(" |") + std::to_string(tid) + ">>> " + body;
+}
+
+double
+duration_sec(const out_node_t& n)
+{
+    return (n.end_ns > n.start_ns) ? (n.end_ns - n.start_ns) / 1.e9 : 0.0;
+}
+
+void
+dfs_graph(const std::vector<out_node_t>& nodes, std::uint32_t nid, nlohmann::json& graph)
+{
+    const auto& n = nodes.at(nid);
+    if(n.id != 0)
+    {
+        const double   sec = duration_sec(n);
+        nlohmann::json row;
+        row["prefix"]         = std::string{ ">>>  " } + format_prefix(n.depth, n.name);
+        row["depth"]          = n.depth;
+        row["hash"]           = 0;
+        row["rolling_hash"]   = 0;
+        row["entry"]          = nlohmann::json::object();
+        row["entry"]["laps"]  = 1;
+        row["entry"]["value"] = sec;
+        row["entry"]["accum_value"] = sec;
+        graph.push_back(std::move(row));
+    }
+    for(auto cid : n.children)
+        dfs_graph(nodes, cid, graph);
+}
+
+void
+fill_inc_exc(const std::vector<out_node_t>& nodes, std::uint32_t id,
+             std::vector<double>& inclusive, std::vector<double>& exclusive)
+{
+    const auto&  n   = nodes.at(id);
+    const double inc = duration_sec(n);
+    double       ch  = 0.0;
+    for(auto cid : n.children)
+    {
+        fill_inc_exc(nodes, cid, inclusive, exclusive);
+        ch += inclusive.at(cid);
+    }
+    inclusive.at(id) = inc;
+    exclusive.at(id) = std::max(0.0, inc - ch);
+}
+
+void
+compute_inc_exc_vectors(const std::vector<out_node_t>& nodes,
+                        std::vector<double>& inclusive, std::vector<double>& exclusive)
+{
+    inclusive.assign(nodes.size(), 0.0);
+    exclusive.assign(nodes.size(), 0.0);
+    fill_inc_exc(nodes, 0, inclusive, exclusive);
+}
+
+struct flat_row_t
+{
+    std::string  key;
+    std::int32_t depth     = 0;
+    double       inclusive = 0;
+    double       exclusive = 0;
+};
+
+void
+collect_preorder(const std::vector<out_node_t>& nodes, std::uint32_t id,
+                 const std::vector<double>& inclusive,
+                 const std::vector<double>& exclusive, std::vector<flat_row_t>& out)
+{
+    if(id != 0)
+    {
+        const auto& n = nodes.at(id);
+        out.push_back({ timemory_label_cell(n.thread_id, n.depth, n.name), n.depth,
+                        inclusive.at(id), exclusive.at(id) });
+    }
+    for(auto cid : nodes.at(id).children)
+        collect_preorder(nodes, cid, inclusive, exclusive, out);
+}
+
+struct agg_t
+{
+    std::int32_t depth    = 0;
+    std::int64_t count    = 0;
+    double       sum      = 0;
+    double       minv     = 0;
+    double       maxv     = 0;
+    double       sumsq    = 0;
+    double       sum_excl = 0;
+};
+
+std::string
+center_text(const std::string& s, size_t w)
+{
+    if(s.size() >= w) return s.substr(0, w);
+    const size_t pad_l = (w - s.size()) / 2;
+    const size_t pad_r = w - pad_l - s.size();
+    return std::string(pad_l, ' ') + s + std::string(pad_r, ' ');
+}
+
+template <typename T>
+std::string
+right_field(const T& v, size_t w)
+{
+    std::ostringstream o;
+    o << std::right << std::setw(static_cast<int>(w)) << v;
+    return o.str();
+}
+
+std::string
+left_field(std::string s, size_t w)
+{
+    if(s.size() > w)
+        s.resize(w);
+    else if(s.size() < w)
+        s.append(w - s.size(), ' ');
+    return s;
+}
+
+std::string
+right_fixed(double v, size_t w, int prec)
+{
+    std::ostringstream o;
+    o << std::fixed << std::setprecision(prec) << std::right
+      << std::setw(static_cast<int>(w)) << v;
+    return o.str();
+}
+
+void
+write_text(const std::vector<out_node_t>& nodes, std::ofstream& os)
+{
+    constexpr int inner_w = 149;
+    std::string   border  = "|";
+    border.append(static_cast<size_t>(inner_w), '-');
+    border += "|\n";
+
+    os << border;
+    {
+        const char* title = "REAL-CLOCK TIMER (I.E. WALL-CLOCK TIMER)";
+        const int   tl    = static_cast<int>(std::strlen(title));
+        const int   padl  = std::max(0, (inner_w - tl) / 2);
+        const int   padr  = std::max(0, inner_w - padl - tl);
+        os << '|' << std::string(static_cast<size_t>(padl), ' ') << title
+           << std::string(static_cast<size_t>(padr), ' ') << "|\n";
+    }
+    os << border;
+
+    constexpr int wl = 36;
+    os << '|' << center_text("LABEL", static_cast<size_t>(wl)) << '|'
+       << center_text("COUNT", 8) << '|' << center_text("DEPTH", 8) << '|'
+       << center_text("METRIC", 12) << '|' << center_text("UNITS", 8) << '|'
+       << center_text("SUM", 10) << '|' << center_text("MEAN", 10) << '|'
+       << center_text("MIN", 10) << '|' << center_text("MAX", 10) << '|'
+       << center_text("VAR", 10) << '|' << center_text("STDDEV", 10) << '|'
+       << center_text("% SELF", 8) << "|\n";
+
+    os << "|" << std::string(36, '-') << "|" << std::string(8, '-') << "|"
+       << std::string(8, '-') << "|" << std::string(12, '-') << "|" << std::string(8, '-')
+       << "|" << std::string(10, '-') << "|" << std::string(10, '-') << "|"
+       << std::string(10, '-') << "|" << std::string(10, '-') << "|"
+       << std::string(10, '-') << "|" << std::string(10, '-') << "|"
+       << std::string(8, '-') << "|\n";
+
+    std::vector<double> inclusive;
+    std::vector<double> exclusive;
+    compute_inc_exc_vectors(nodes, inclusive, exclusive);
+
+    std::vector<flat_row_t> flat;
+    collect_preorder(nodes, 0, inclusive, exclusive, flat);
+
+    std::unordered_map<std::string, agg_t> agg;
+    std::vector<std::string>               order;
+    order.reserve(flat.size());
+    for(const auto& r : flat)
+    {
+        auto& a = agg[r.key];
+        if(a.count == 0)
+        {
+            order.push_back(r.key);
+            a.depth = r.depth;
+            a.minv = a.maxv = r.inclusive;
+        }
+        else
+        {
+            a.minv = std::min(a.minv, r.inclusive);
+            a.maxv = std::max(a.maxv, r.inclusive);
+        }
+        ++a.count;
+        a.sum += r.inclusive;
+        a.sumsq += r.inclusive * r.inclusive;
+        a.sum_excl += r.exclusive;
+    }
+
+    for(const auto& key : order)
+    {
+        const auto&  a     = agg.at(key);
+        const double mean  = a.sum / static_cast<double>(a.count);
+        const double mean2 = mean * mean;
+        const double var_p =
+            (a.count > 0) ? (a.sumsq / static_cast<double>(a.count) - mean2) : 0.0;
+        const double var    = (var_p > 0) ? var_p : 0.0;
+        const double stddev = std::sqrt(var);
+        const double pct    = (a.sum > 1e-30) ? (100.0 * a.sum_excl / a.sum) : 0.0;
+
+        std::string lbl = key;
+        if(static_cast<int>(lbl.size()) > wl)
+            lbl = lbl.substr(0, static_cast<size_t>(wl - 3)) + "...";
+
+        os << '|' << left_field(lbl, static_cast<size_t>(wl)) << '|'
+           << right_field(a.count, 8) << '|' << right_field(a.depth, 8) << '|'
+           << center_text("wall_clock", 12) << '|' << center_text("sec", 8) << '|'
+           << right_fixed(a.sum, 10, 6) << '|' << right_fixed(mean, 10, 6) << '|'
+           << right_fixed(a.minv, 10, 6) << '|' << right_fixed(a.maxv, 10, 6) << '|'
+           << right_fixed(var, 10, 6) << '|' << right_fixed(stddev, 10, 6) << '|'
+           << right_fixed(pct, 8, 1) << "|\n";
+    }
+
+    os << border;
+}
+
+bool
+replay_to_nodes(const std::vector<wall_clock_scope_event_sample>& ev,
+                std::vector<out_node_t>&                          out_nodes)
+{
+    if(ev.empty()) return false;
+
+    std::vector<wall_clock_scope_event_sample> sorted = ev;
+    std::sort(sorted.begin(), sorted.end(),
+              [](const wall_clock_scope_event_sample& a,
+                 const wall_clock_scope_event_sample& b) {
+                  if(a.steady_ns != b.steady_ns) return a.steady_ns < b.steady_ns;
+                  if(a.thread_id != b.thread_id) return a.thread_id < b.thread_id;
+                  if(a.exec_id != b.exec_id) return a.exec_id < b.exec_id;
+                  return a.event_kind < b.event_kind;
+              });
+
+    std::uint64_t max_wall = 0;
+    for(const auto& s : sorted)
+        max_wall = std::max(max_wall, s.wall_ns);
+
+    std::unordered_map<std::uint64_t, slot_t> slots;
+    for(const auto& s : sorted)
+    {
+        if(s.event_kind == static_cast<std::uint8_t>(wall_clock_scope_event_kind::enter))
+        {
+            slot_t sl;
+            sl.exec_id         = s.exec_id;
+            sl.parent_exec_id  = s.parent_exec_id;
+            sl.thread_id       = s.thread_id;
+            sl.depth           = s.depth;
+            sl.name            = s.name;
+            sl.enter_wall_ns   = s.wall_ns;
+            sl.enter_steady_ns = s.steady_ns;
+            sl.has_exit        = false;
+            slots[s.exec_id]   = std::move(sl);
+        }
+        else if(s.event_kind ==
+                static_cast<std::uint8_t>(wall_clock_scope_event_kind::exit))
+        {
+            auto it = slots.find(s.exec_id);
+            if(it != slots.end())
+            {
+                it->second.exit_wall_ns = s.wall_ns;
+                it->second.has_exit     = true;
+            }
+        }
+    }
+
+    for(auto& kv : slots)
+    {
+        if(!kv.second.has_exit)
+        {
+            kv.second.exit_wall_ns = max_wall;
+            kv.second.has_exit     = true;
+        }
+    }
+
+    std::unordered_map<std::uint64_t, std::vector<std::uint64_t>> by_parent;
+    for(const auto& kv : slots)
+    {
+        by_parent[kv.second.parent_exec_id].push_back(kv.first);
+    }
+
+    for(auto& kv : by_parent)
+    {
+        auto& ch = kv.second;
+        // Sibling order: first ENTER time (steady clock), not inclusive duration.
+        // Sorting by duration reorders unrelated regions under the same parent (e.g.
+        // _pthread_barrier_wait before _launch_child) and still does not match timemory's
+        // graph sibling order for pthread_create → start_thread.
+        std::sort(ch.begin(), ch.end(), [&](std::uint64_t a, std::uint64_t b) {
+            const auto& sa = slots.at(a);
+            const auto& sb = slots.at(b);
+            if(sa.enter_steady_ns != sb.enter_steady_ns)
+                return sa.enter_steady_ns < sb.enter_steady_ns;
+            if(sa.enter_wall_ns != sb.enter_wall_ns)
+                return sa.enter_wall_ns < sb.enter_wall_ns;
+            if(sa.thread_id != sb.thread_id) return sa.thread_id < sb.thread_id;
+            return sa.exec_id < sb.exec_id;
+        });
+    }
+
+    out_nodes.clear();
+    out_node_t root{};
+    root.id        = 0;
+    root.parent    = 0;
+    root.depth     = -1;
+    root.thread_id = -1;
+    root.start_ns  = 0;
+    root.end_ns    = 0;
+    out_nodes.push_back(root);
+
+    std::function<void(std::uint64_t, std::uint32_t)> visit;
+    visit = [&](std::uint64_t exec_id, std::uint32_t parent_out) {
+        auto sit = slots.find(exec_id);
+        if(sit == slots.end()) return;
+        const slot_t& sl = sit->second;
+
+        const auto nid = static_cast<std::uint32_t>(out_nodes.size());
+        out_node_t n{};
+        n.id        = nid;
+        n.parent    = parent_out;
+        n.depth     = out_nodes.at(parent_out).depth + 1;
+        n.thread_id = static_cast<std::int64_t>(sl.thread_id);
+        n.name      = sl.name;
+        n.start_ns  = sl.enter_wall_ns;
+        n.end_ns    = sl.exit_wall_ns;
+        out_nodes.at(parent_out).children.push_back(nid);
+        out_nodes.push_back(std::move(n));
+
+        auto pit = by_parent.find(exec_id);
+        if(pit != by_parent.end())
+        {
+            for(auto ce : pit->second)
+                visit(ce, nid);
+        }
+    };
+
+    auto roots_it = by_parent.find(0);
+    if(roots_it != by_parent.end())
+    {
+        for(auto rid : roots_it->second)
+            visit(rid, 0);
+    }
+
+    return out_nodes.size() > 1;
+}
+
+}  // namespace
+
+wall_clock_scope_event_processor_t::wall_clock_scope_event_processor_t(
+    int pid, int ppid, output_file_registry& registry)
+: m_pid(pid)
+, m_ppid(ppid)
+, m_registry(registry)
+{
+    (void) m_pid;
+    (void) m_ppid;
+}
+
+void
+wall_clock_scope_event_processor_t::prepare_for_processing()
+{
+    m_events.clear();
+}
+
+void
+wall_clock_scope_event_processor_t::finalize_processing()
+{
+    if(!config::get_use_timemory()) return;
+    if(m_events.empty()) return;
+    if(!config::output_filtering::is_output_enabled_for_current_mpi_rank()) return;
+
+    // Trace-cache replay can run before tim::timemory_finalize(); timemory's
+    // file_output() flag is often still false here, while timemory wall_clock files are
+    // written after finalize when it becomes true. Do not gate on file_output() — use
+    // get_use_timemory() (already checked) and successful opens below.
+
+    std::vector<out_node_t> nodes;
+    if(!replay_to_nodes(m_events, nodes)) return;
+
+    auto path_cfg       = settings::compose_filename_config{};
+    path_cfg.use_suffix = config::get_use_pid();
+    path_cfg.suffix     = settings::default_process_suffix();
+    path_cfg.make_dir   = true;
+
+    const std::string json_path =
+        settings::compose_output_filename(output_metric, "json", path_cfg);
+    const std::string txt_path =
+        settings::compose_output_filename(output_metric, "txt", path_cfg);
+    if(json_path.empty() || txt_path.empty()) return;
+
+    nlohmann::json root;
+    root["timemory"][output_metric]["properties"] = nlohmann::json::object();
+    root["timemory"][output_metric]["type"]       = output_metric;
+    root["timemory"][output_metric]["description"] =
+        "Wall-clock tree reconstructed offline from trace-cache scope events "
+        "(wall_clock_scope_event)";
+    root["timemory"][output_metric]["unit_value"]        = 1.e9;
+    root["timemory"][output_metric]["unit_repr"]         = "sec";
+    root["timemory"][output_metric]["thread_scope_only"] = false;
+    root["timemory"][output_metric]["thread_count"] = tim::manager::get_thread_count();
+    root["timemory"][output_metric]["mpi_size"]     = dmp::size();
+    root["timemory"][output_metric]["ranks"]        = nlohmann::json::array();
+    nlohmann::json rank_entry;
+    rank_entry["graph"] = nlohmann::json::array();
+    dfs_graph(nodes, 0, rank_entry["graph"]);
+    root["timemory"][output_metric]["ranks"].push_back(std::move(rank_entry));
+
+    bool json_ok = false;
+    bool txt_ok  = false;
+    {
+        std::ofstream os{ json_path };
+        json_ok = static_cast<bool>(os);
+        if(json_ok) os << root.dump(4);
+    }
+    {
+        std::ofstream os{ txt_path };
+        txt_ok = static_cast<bool>(os);
+        if(txt_ok) write_text(nodes, os);
+    }
+
+    if(json_ok) m_registry.register_file(json_path, output_format::json, output_metric);
+    if(txt_ok) m_registry.register_file(txt_path, output_format::text, output_metric);
+}
+
+void
+wall_clock_scope_event_processor_t::handle(const wall_clock_scope_event_sample& s)
+{
+    m_events.push_back(s);
+}
+
+void
+wall_clock_scope_event_processor_t::handle(const kernel_dispatch_sample&)
+{}
+
+void
+wall_clock_scope_event_processor_t::handle(const scratch_memory_sample&)
+{}
+
+void
+wall_clock_scope_event_processor_t::handle(const memory_copy_sample&)
+{}
+
+void
+wall_clock_scope_event_processor_t::handle(const memory_allocate_sample&)
+{}
+
+void
+wall_clock_scope_event_processor_t::handle(const region_sample&)
+{}
+
+void
+wall_clock_scope_event_processor_t::handle(const in_time_sample&)
+{}
+
+void
+wall_clock_scope_event_processor_t::handle(const pmc_event_with_sample&)
+{}
+
+void
+wall_clock_scope_event_processor_t::handle(const gpu_pmc_sample&)
+{}
+
+void
+wall_clock_scope_event_processor_t::handle(const ainic_pmc_sample&)
+{}
+
+void
+wall_clock_scope_event_processor_t::handle(const cpu_pmc_sample&)
+{}
+
+void
+wall_clock_scope_event_processor_t::handle(const backtrace_region_sample&)
+{}
+
+void
+wall_clock_scope_event_processor_t::handle(const kfd_sample&)
+{}
+
+}  // namespace rocprofsys::trace_cache

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/wall_clock_scope_event_processor.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/wall_clock_scope_event_processor.hpp
@@ -2,26 +2,28 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
-#include "agent_manager.hpp"
-#include "core/node_info.hpp"
-#include "core/output_file_registry.hpp"
-#include "core/rocpd/data_processor.hpp"
-#include "core/trace_cache/metadata_registry.hpp"
-#include "core/trace_cache/sample_processor.hpp"
 
-#include "trace_cache/sample_type.hpp"
+#include "core/output_file_registry.hpp"
+#include "core/trace_cache/sample_processor.hpp"
+#include "core/trace_cache/sample_type.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
 
 namespace rocprofsys
 {
 namespace trace_cache
 {
 
-class rocpd_processor_t : public processor_t<rocpd_processor_t>
+/// Collects \ref wall_clock_scope_event_sample during trace-cache replay and writes
+/// \c wall_clock_evt.{json,txt} (offline reconstruction of the instrumented wall-clock
+/// tree).
+class wall_clock_scope_event_processor_t
+: public processor_t<wall_clock_scope_event_processor_t>
 {
 public:
-    rocpd_processor_t(const std::shared_ptr<metadata_registry>& metadata,
-                      const std::shared_ptr<agent_manager>& agent_mngr, int pid, int ppid,
-                      output_file_registry& output_registry);
+    wall_clock_scope_event_processor_t(int pid, int ppid, output_file_registry& registry);
 
     void prepare_for_processing();
     void finalize_processing();
@@ -41,17 +43,10 @@ public:
     void handle(const wall_clock_scope_event_sample& sample);
 
 private:
-    using primary_key = size_t;
-
-    void        post_process_metadata();
-    inline void insert_thread_id(info::thread& t_info, const node_info& n_info,
-                                 const info::process& process_info);
-
-    std::shared_ptr<metadata_registry>     m_metadata;
-    std::shared_ptr<agent_manager>         m_agent_manager;
-    std::shared_ptr<rocpd::data_processor> m_data_processor;
-    output_file_registry&                  m_output_registry;
-    std::string                            m_db_output_path;
+    int                                        m_pid;
+    int                                        m_ppid;
+    output_file_registry&                      m_registry;
+    std::vector<wall_clock_scope_event_sample> m_events;
 };
 
 }  // namespace trace_cache

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -53,6 +53,7 @@
 #include "library/thread_data.hpp"
 #include "library/thread_info.hpp"
 #include "library/tracing.hpp"
+#include "library/wall_clock_event_trace.hpp"
 #include "rocprofiler-systems/categories.h"  // in rocprof-sys-user
 
 #include <timemory/hash/types.hpp>
@@ -734,6 +735,7 @@ rocprofsys_init_tooling_hidden(void)
 
     if(get_use_timemory())
     {
+        rocprofsys::wall_clock_event_trace::session_reset();
         comp::user_global_bundle::global_init();
         std::set<int> _comps{};
         // convert string into set of enumerations
@@ -1171,24 +1173,10 @@ rocprofsys_finalize_hidden(void)
                                            _perfetto_output_error, _output_registry);
     }
 
-    {
-        auto& _manager = rocprofsys::trace_cache::cache_manager::get_instance();
-        _manager.shutdown();
-
-        rocprofsys::progress::bar_options _bar_opts;
-        _bar_opts.verbose = config::get_verbose();
-
-        rocprofsys::progress::tracker _tracker{ [_bar_opts](std::string   _label,
-                                                            std::uint64_t _total) {
-            auto                      _bar = std::make_shared<rocprofsys::progress::bar>(std::move(_label),
-                                                                                         _total, _bar_opts);
-            return rocprofsys::progress::progress_callback{ [_bar](std::uint64_t _delta) {
-                _bar->on_advance(_delta);
-            } };
-        } };
-
-        _manager.post_process_bulk(_output_registry, _tracker);
-    }
+    // Flush trace-cache ring buffer to /tmp before timemory finalization (same as prior
+    // shutdown placement; post_process_bulk is deferred until after finalize — see
+    // below).
+    rocprofsys::trace_cache::cache_manager::get_instance().shutdown();
 
     if(_timemory_manager && _timemory_manager != nullptr)
     {
@@ -1223,12 +1211,36 @@ rocprofsys_finalize_hidden(void)
             }
         }
 
-        LOG_DEBUG("Finalizing timemory...");
-        tim::timemory_finalize(_timemory_manager.get());
-
         auto _cfg       = settings::compose_filename_config{};
         _cfg.use_suffix = config::get_use_pid();
         _cfg.suffix     = settings::default_process_suffix();
+        // Ensure OUTPUT_PATH (e.g. time-stamped subdirectory) exists before any component
+        // writes files — matches timemory finalize behavior.
+        _cfg.make_dir = true;
+
+        LOG_DEBUG("Finalizing timemory...");
+        tim::timemory_finalize(_timemory_manager.get());
+
+        // Parse buffered_storage.bin after timemory finalize so OUTPUT_PATH / dated
+        // subdirectory / make_dir match timemory (wall_clock_evt used to compose empty
+        // paths when this ran earlier).
+        {
+            rocprofsys::progress::bar_options _bar_opts;
+            _bar_opts.verbose = config::get_verbose();
+
+            rocprofsys::progress::tracker _tracker{ [_bar_opts](std::string   _label,
+                                                                std::uint64_t _total) {
+                auto                      _bar = std::make_shared<rocprofsys::progress::bar>(
+                    std::move(_label), _total, _bar_opts);
+                return rocprofsys::progress::progress_callback{
+                    [_bar](std::uint64_t _delta) { _bar->on_advance(_delta); }
+                };
+            } };
+
+            rocprofsys::trace_cache::cache_manager::get_instance().post_process_bulk(
+                _output_registry, _tracker);
+        }
+
         _timemory_manager->write_metadata(settings::get_global_output_prefix(),
                                           "rocprofsys", _cfg);
 
@@ -1250,6 +1262,23 @@ rocprofsys_finalize_hidden(void)
                     output_format::json, _comp_name);
             }
         }
+    }
+    else
+    {
+        rocprofsys::progress::bar_options _bar_opts;
+        _bar_opts.verbose = config::get_verbose();
+
+        rocprofsys::progress::tracker _tracker{ [_bar_opts](std::string   _label,
+                                                            std::uint64_t _total) {
+            auto                      _bar = std::make_shared<rocprofsys::progress::bar>(std::move(_label),
+                                                                                         _total, _bar_opts);
+            return rocprofsys::progress::progress_callback{ [_bar](std::uint64_t _delta) {
+                _bar->on_advance(_delta);
+            } };
+        } };
+
+        rocprofsys::trace_cache::cache_manager::get_instance().post_process_bulk(
+            _output_registry, _tracker);
     }
 
     _output_registry.print_summary();

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 set(library_sources
     ${CMAKE_CURRENT_LIST_DIR}/coverage.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/wall_clock_event_trace.cpp
     ${CMAKE_CURRENT_LIST_DIR}/kokkosp.cpp
     ${CMAKE_CURRENT_LIST_DIR}/perf.cpp
     ${CMAKE_CURRENT_LIST_DIR}/process_sampler.cpp
@@ -15,6 +16,7 @@ set(library_sources
 
 set(library_headers
     ${CMAKE_CURRENT_LIST_DIR}/coverage.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/wall_clock_event_trace.hpp
     ${CMAKE_CURRENT_LIST_DIR}/process_sampler.hpp
     ${CMAKE_CURRENT_LIST_DIR}/perf.hpp
     ${CMAKE_CURRENT_LIST_DIR}/rocm.hpp

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
@@ -284,7 +284,7 @@ category_region<CategoryT>::start(std::string_view name, Args&&... args)
         if(get_use_timemory())
         {
             tracing::push_timemory(CategoryT{}, name, std::forward<Args>(args)...);
-            wall_clock_event_trace::push_region(tim::threading::get_id(),
+            wall_clock_event_trace::push_region(tim::threading::get_sys_tid(),
                                                 std::string{ name });
         }
     }
@@ -349,8 +349,11 @@ category_region<CategoryT>::stop(std::string_view name, Args&&... args)
         {
             if(get_use_timemory())
             {
+                auto _wc_hash = tim::add_hash_id(name);
+                auto _wc_name = tim::get_hash_identifier_fast(_wc_hash);
                 tracing::pop_timemory(CategoryT{}, name, std::forward<Args>(args)...);
-                wall_clock_event_trace::pop_region(tim::threading::get_id(), name);
+                wall_clock_event_trace::pop_region(tim::threading::get_sys_tid(),
+                                                   _wc_name);
             }
         }
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
@@ -15,6 +15,7 @@
 #include "library/thread_info.hpp"
 #include "library/tracing.hpp"
 #include "library/tracing/annotation.hpp"
+#include "library/wall_clock_event_trace.hpp"
 #include <cstdint>
 
 #include <map>
@@ -23,6 +24,7 @@
 #include <timemory/hash/types.hpp>
 #include <timemory/mpl/concepts.hpp>
 #include <timemory/mpl/types.hpp>
+#include <timemory/process/threading.hpp>
 #include <timemory/utility/types.hpp>
 #include <tuple>
 
@@ -282,6 +284,8 @@ category_region<CategoryT>::start(std::string_view name, Args&&... args)
         if(get_use_timemory())
         {
             tracing::push_timemory(CategoryT{}, name, std::forward<Args>(args)...);
+            wall_clock_event_trace::push_region(tim::threading::get_id(),
+                                                std::string{ name });
         }
     }
 
@@ -346,6 +350,7 @@ category_region<CategoryT>::stop(std::string_view name, Args&&... args)
             if(get_use_timemory())
             {
                 tracing::pop_timemory(CategoryT{}, name, std::forward<Args>(args)...);
+                wall_clock_event_trace::pop_region(tim::threading::get_id(), name);
             }
         }
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
@@ -21,6 +21,7 @@
 #include <timemory/components/timing/wall_clock.hpp>
 #include <timemory/hash/types.hpp>
 #include <timemory/mpl/types.hpp>
+#include <timemory/process/threading.hpp>
 #include <timemory/sampling/allocator.hpp>
 #include <timemory/units.hpp>
 #include <timemory/utility/types.hpp>
@@ -66,7 +67,7 @@ auto  bundles_dtor  = scope::destructor{ []() {
 template <typename... Args>
 inline void
 start_bundle(bundle_t& _bundle, std::int64_t _tid,
-             std::optional<std::int64_t> _start_thread_parent_tid, Args&&... _args)
+             std::optional<std::int64_t> _wall_clock_parent_os_tid, Args&&... _args)
 {
     if(!get_use_timemory() && !get_use_perfetto()) return;
     LOG_TRACE("Starting bundle '{}' in thread {}...", _bundle.key(), _tid);
@@ -90,12 +91,13 @@ start_bundle(bundle_t& _bundle, std::int64_t _tid,
         const std::string _key = _bundle.key();
         if(_key == "pthread_create")
         {
-            wall_clock_event_trace::push_pthread_create(_tid, _key);
+            wall_clock_event_trace::push_pthread_create(tim::threading::get_sys_tid(),
+                                                        _key);
         }
-        else if(_key == "start_thread" && _start_thread_parent_tid)
+        else if(_key == "start_thread" && _wall_clock_parent_os_tid)
         {
-            wall_clock_event_trace::push_start_thread(*_start_thread_parent_tid, _tid,
-                                                      _key);
+            wall_clock_event_trace::push_start_thread(
+                *_wall_clock_parent_os_tid, tim::threading::get_sys_tid(), _key);
         }
     }
 }
@@ -127,11 +129,12 @@ stop_bundle(bundle_t& _bundle, std::int64_t _tid, Args&&... _args)
         const std::string _key = _bundle.key();
         if(_key == "pthread_create")
         {
-            wall_clock_event_trace::pop_pthread_create(_tid, _key);
+            wall_clock_event_trace::pop_pthread_create(tim::threading::get_sys_tid(),
+                                                       _key);
         }
         else if(_key == "start_thread")
         {
-            wall_clock_event_trace::pop_start_thread(_tid, _key);
+            wall_clock_event_trace::pop_start_thread(tim::threading::get_sys_tid(), _key);
         }
     }
     if constexpr(sizeof...(Args) > 0)
@@ -264,7 +267,10 @@ pthread_create_gotcha::wrapper::operator()() const
             _bundle = bundles->emplace(_tid, std::make_shared<bundle_t>("start_thread"))
                           .first->second;
         }
-        if(_bundle) start_bundle(*_bundle, _tid, m_config.parent_tid);
+        if(_bundle)
+            start_bundle(*_bundle, _tid,
+                         std::optional<std::int64_t>{ m_config.parent_sys_tid },
+                         audit::incoming{});
         get_cpu_cid_stack(_tid, m_config.parent_tid);
         if(m_config.enable_causal)
         {
@@ -653,8 +659,10 @@ pthread_create_gotcha::operator()(pthread_t* thread, const pthread_attr_t* attr,
     set_thread_state(ThreadState::Disabled);
     auto _blocked = get_sampling_signals();
     auto _promise = (_active) ? std::make_shared<std::promise<void>>() : promise_t{};
-    auto _config =
-        wrapper_config{ _enable_causal, _enable_sampling, _offset, _tid, _promise };
+    auto _config  = wrapper_config{
+        _enable_causal, _enable_sampling, _offset, _tid, tim::threading::get_sys_tid(),
+        _promise
+    };
     auto* _wrap = new wrapper{ func, arg, _config };
     set_thread_state(ThreadState::Internal);
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
@@ -13,6 +13,7 @@
 #include "library/thread_data.hpp"
 #include "library/thread_info.hpp"
 #include "library/tracing.hpp"
+#include "library/wall_clock_event_trace.hpp"
 #include <cstdint>
 
 #include <timemory/backends/threading.hpp>
@@ -28,6 +29,7 @@
 
 #include <csignal>
 #include <dlfcn.h>
+#include <optional>
 #include <ostream>
 #include <pthread.h>
 #include <string_view>
@@ -63,7 +65,8 @@ auto  bundles_dtor  = scope::destructor{ []() {
 
 template <typename... Args>
 inline void
-start_bundle(bundle_t& _bundle, std::int64_t _tid, Args&&... _args)
+start_bundle(bundle_t& _bundle, std::int64_t _tid,
+             std::optional<std::int64_t> _start_thread_parent_tid, Args&&... _args)
 {
     if(!get_use_timemory() && !get_use_perfetto()) return;
     LOG_TRACE("Starting bundle '{}' in thread {}...", _bundle.key(), _tid);
@@ -84,6 +87,16 @@ start_bundle(bundle_t& _bundle, std::int64_t _tid, Args&&... _args)
     {
         _bundle.push(_tid);
         _bundle.start();
+        const std::string _key = _bundle.key();
+        if(_key == "pthread_create")
+        {
+            wall_clock_event_trace::push_pthread_create(_tid, _key);
+        }
+        else if(_key == "start_thread" && _start_thread_parent_tid)
+        {
+            wall_clock_event_trace::push_start_thread(*_start_thread_parent_tid, _tid,
+                                                      _key);
+        }
     }
 }
 
@@ -110,6 +123,16 @@ stop_bundle(bundle_t& _bundle, std::int64_t _tid, Args&&... _args)
         _bundle.stop();
         // exclude popping wall-clock
         _bundle.pop(_tid);
+
+        const std::string _key = _bundle.key();
+        if(_key == "pthread_create")
+        {
+            wall_clock_event_trace::pop_pthread_create(_tid, _key);
+        }
+        else if(_key == "start_thread")
+        {
+            wall_clock_event_trace::pop_start_thread(_tid, _key);
+        }
     }
     if constexpr(sizeof...(Args) > 0)
     {
@@ -241,7 +264,7 @@ pthread_create_gotcha::wrapper::operator()() const
             _bundle = bundles->emplace(_tid, std::make_shared<bundle_t>("start_thread"))
                           .first->second;
         }
-        if(_bundle) start_bundle(*_bundle, _tid);
+        if(_bundle) start_bundle(*_bundle, _tid, m_config.parent_tid);
         get_cpu_cid_stack(_tid, m_config.parent_tid);
         if(m_config.enable_causal)
         {
@@ -645,8 +668,8 @@ pthread_create_gotcha::operator()(pthread_t* thread, const pthread_attr_t* attr,
     if(_use_bundle)
     {
         _bundle = bundle_t{ "pthread_create" };
-        start_bundle(*_bundle, _info->index_data->sequent_value, audit::incoming{},
-                     thread, attr, func, arg);
+        start_bundle(*_bundle, _info->index_data->sequent_value, std::nullopt,
+                     audit::incoming{}, thread, attr, func, arg);
     }
 
     // threads must process their delays before creating a new thread

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.hpp
@@ -31,8 +31,10 @@ struct pthread_create_gotcha : tim::component::base<pthread_create_gotcha, void>
         bool         enable_causal   = false;
         bool         enable_sampling = false;
         bool         offset          = false;
-        std::int64_t parent_tid      = 0;
-        promise_t    promise         = {};
+        std::int64_t parent_tid      = 0;  ///< \c InternalTID for \c thread_info, etc.
+        /// Parent OS thread id for \c wall_clock_event_trace pthread linkage only.
+        std::int64_t parent_sys_tid = 0;
+        promise_t    promise        = {};
     };
 
     struct wrapper

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -28,6 +28,7 @@
 #include "library/rocprofiler-sdk/trace_control.hpp"
 #include "library/thread_info.hpp"
 #include "library/tracing.hpp"
+#include "library/wall_clock_event_trace.hpp"
 #include "rocprofiler-sdk.hpp"
 #include "rocprofiler-sdk/roctx_client.hpp"
 
@@ -175,6 +176,23 @@ ompt_get_unified_name(const rocprofiler_callback_tracing_record_t& record)
 }
 
 #endif
+
+std::int64_t
+rocprofiler_trace_thread_id(rocprofiler_thread_id_t rtid)
+{
+    const auto& tinfo = thread_info::get(rtid, SystemTID);
+    if(!tinfo || !tinfo->index_data) return 0;
+    return tinfo->index_data->sequent_value;
+}
+
+void
+wall_clock_trace_buffered_interval(std::int64_t tid, const std::string& name,
+                                   std::uint64_t beg_ns, std::uint64_t end_ns)
+{
+    if(!config::get_use_timemory()) return;
+    wall_clock_event_trace::push_region_ts(tid, name, beg_ns, beg_ns);
+    wall_clock_event_trace::pop_region_ts(tid, name, end_ns, end_ns);
+}
 
 auto&
 get_stream_stack()
@@ -697,13 +715,16 @@ template <typename CategoryT>
 void
 tool_tracing_callback_start(CategoryT, rocprofiler_callback_tracing_record_t record,
                             rocprofiler_user_data_t* /*user_data*/,
-                            rocprofiler_timestamp_t /*ts*/)
+                            rocprofiler_timestamp_t ts)
 {
     auto _name = tool_data->callback_tracing_info.at(record.kind, record.operation);
 
     if(get_use_timemory())
     {
         tracing::push_timemory(CategoryT{}, _name);
+        const auto          tid = rocprofiler_trace_thread_id(record.thread_id);
+        const std::uint64_t tns = static_cast<std::uint64_t>(ts);
+        wall_clock_event_trace::push_region_ts(tid, std::string{ _name }, tns, tns);
     }
 }
 
@@ -721,6 +742,9 @@ tool_tracing_callback_stop(
     if(get_use_timemory())
     {
         tracing::pop_timemory(CategoryT{}, _name);
+        const auto          tid = rocprofiler_trace_thread_id(record.thread_id);
+        const std::uint64_t ens = static_cast<std::uint64_t>(ts);
+        wall_clock_event_trace::pop_region_ts(tid, _name, ens, ens);
     }
 
     if(get_use_perfetto())
@@ -1194,6 +1218,9 @@ ompt_tracing_callback_start(rocprofiler_callback_tracing_record_t record,
     if(get_use_timemory())
     {
         tracing::push_timemory(category::rocm_ompt_api{}, _name);
+        const auto          tid = rocprofiler_trace_thread_id(record.thread_id);
+        const std::uint64_t tns = static_cast<std::uint64_t>(ts);
+        wall_clock_event_trace::push_region_ts(tid, std::string{ _name }, tns, tns);
     }
 
     if(get_use_perfetto())
@@ -1239,6 +1266,9 @@ ompt_tracing_callback_stop(
     if(get_use_timemory())
     {
         tracing::pop_timemory(category::rocm_ompt_api{}, _name);
+        const auto          tid = rocprofiler_trace_thread_id(record.thread_id);
+        const std::uint64_t ens = static_cast<std::uint64_t>(ts);
+        wall_clock_event_trace::pop_region_ts(tid, _name, ens, ens);
     }
 
     if(get_use_perfetto())
@@ -1744,16 +1774,21 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
                 if(get_use_timemory())
                 {
                     const auto& _tinfo = thread_info::get(record->thread_id, SystemTID);
-                    auto        _tid   = _tinfo->index_data->sequent_value;
+                    if(_tinfo && _tinfo->index_data)
+                    {
+                        auto _tid = _tinfo->index_data->sequent_value;
 
-                    auto _bundle = kernel_dispatch_bundle_t{ _name };
+                        auto _bundle = kernel_dispatch_bundle_t{ _name };
 
-                    _bundle.push(_tid).start().stop();
-                    _bundle.get([_beg_ns, _end_ns](tim::component::wall_clock* _wc) {
-                        _wc->set_value(_end_ns - _beg_ns);
-                        _wc->set_accum(_end_ns - _beg_ns);
-                    });
-                    _bundle.pop();
+                        _bundle.push(_tid).start().stop();
+                        _bundle.get([_beg_ns, _end_ns](tim::component::wall_clock* _wc) {
+                            _wc->set_value(_end_ns - _beg_ns);
+                            _wc->set_accum(_end_ns - _beg_ns);
+                        });
+                        _bundle.pop();
+
+                        wall_clock_trace_buffered_interval(_tid, _name, _beg_ns, _end_ns);
+                    }
                 }
 
                 if(get_use_perfetto())
@@ -1876,6 +1911,9 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
                         _wc->set_accum(_end_ns - _beg_ns);
                     });
                     _bundle.pop();
+
+                    wall_clock_trace_buffered_interval(
+                        thread_id_sequent, std::string{ _name }, _beg_ns, _end_ns);
                 }
 
                 if(get_use_perfetto())
@@ -1986,16 +2024,22 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
                 if(get_use_timemory())
                 {
                     const auto& _tinfo = thread_info::get(record->thread_id, SystemTID);
-                    auto        _tid   = _tinfo->index_data->sequent_value;
+                    if(_tinfo && _tinfo->index_data)
+                    {
+                        auto _tid = _tinfo->index_data->sequent_value;
 
-                    auto _bundle = kernel_dispatch_bundle_t{ _name };
+                        auto _bundle = kernel_dispatch_bundle_t{ _name };
 
-                    _bundle.push(_tid).start().stop();
-                    _bundle.get([_beg_ns, _end_ns](tim::component::wall_clock* _wc) {
-                        _wc->set_value(_end_ns - _beg_ns);
-                        _wc->set_accum(_end_ns - _beg_ns);
-                    });
-                    _bundle.pop();
+                        _bundle.push(_tid).start().stop();
+                        _bundle.get([_beg_ns, _end_ns](tim::component::wall_clock* _wc) {
+                            _wc->set_value(_end_ns - _beg_ns);
+                            _wc->set_accum(_end_ns - _beg_ns);
+                        });
+                        _bundle.pop();
+
+                        wall_clock_trace_buffered_interval(_tid, std::string{ _name },
+                                                           _beg_ns, _end_ns);
+                    }
                 }
 
                 if(get_use_perfetto())
@@ -2064,6 +2108,20 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
                     cache_category<category::rocm_memory_allocate>();
                     cache_add_thread_info(record->thread_id);
                     cache_memory_allocation(record, _stream_id);
+                }
+
+                if(get_use_timemory())
+                {
+                    const auto& _tinfo = thread_info::get(record->thread_id, SystemTID);
+                    if(_tinfo && _tinfo->index_data)
+                    {
+                        auto _label = std::string{ tool_data->buffered_tracing_info.at(
+                            ROCPROFILER_BUFFER_TRACING_MEMORY_ALLOCATION,
+                            record->operation) };
+                        wall_clock_trace_buffered_interval(
+                            _tinfo->index_data->sequent_value, _label,
+                            record->start_timestamp, record->end_timestamp);
+                    }
                 }
             }
 #endif

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -34,6 +34,7 @@
 
 #include <timemory/components/timing/wall_clock.hpp>
 #include <timemory/hash/types.hpp>
+#include <timemory/process/threading.hpp>
 #include <timemory/unwind/processed_entry.hpp>
 #include <timemory/variadic/lightweight_tuple.hpp>
 #include <type_traits>
@@ -177,21 +178,14 @@ ompt_get_unified_name(const rocprofiler_callback_tracing_record_t& record)
 
 #endif
 
-std::int64_t
-rocprofiler_trace_thread_id(rocprofiler_thread_id_t rtid)
-{
-    const auto& tinfo = thread_info::get(rtid, SystemTID);
-    if(!tinfo || !tinfo->index_data) return 0;
-    return tinfo->index_data->sequent_value;
-}
-
 void
 wall_clock_trace_buffered_interval(std::int64_t tid, const std::string& name,
-                                   std::uint64_t beg_ns, std::uint64_t end_ns)
+                                   std::uint64_t beg_ns, std::uint64_t end_ns,
+                                   std::uint64_t rocprofiler_ancestor_internal)
 {
     if(!config::get_use_timemory()) return;
-    wall_clock_event_trace::push_region_ts(tid, name, beg_ns, beg_ns);
-    wall_clock_event_trace::pop_region_ts(tid, name, end_ns, end_ns);
+    wall_clock_event_trace::emit_buffered_wall_clock_interval(
+        tid, name, beg_ns, end_ns, rocprofiler_ancestor_internal);
 }
 
 auto&
@@ -722,9 +716,12 @@ tool_tracing_callback_start(CategoryT, rocprofiler_callback_tracing_record_t rec
     if(get_use_timemory())
     {
         tracing::push_timemory(CategoryT{}, _name);
-        const auto          tid = rocprofiler_trace_thread_id(record.thread_id);
+        const auto          tid = tim::threading::get_sys_tid();
         const std::uint64_t tns = static_cast<std::uint64_t>(ts);
-        wall_clock_event_trace::push_region_ts(tid, std::string{ _name }, tns, tns);
+        const std::uint64_t corr_internal =
+            static_cast<std::uint64_t>(record.correlation_id.internal);
+        wall_clock_event_trace::push_region_ts(tid, std::string{ _name }, tns, tns,
+                                               corr_internal);
     }
 }
 
@@ -742,9 +739,11 @@ tool_tracing_callback_stop(
     if(get_use_timemory())
     {
         tracing::pop_timemory(CategoryT{}, _name);
-        const auto          tid = rocprofiler_trace_thread_id(record.thread_id);
+        const auto          tid = tim::threading::get_sys_tid();
         const std::uint64_t ens = static_cast<std::uint64_t>(ts);
-        wall_clock_event_trace::pop_region_ts(tid, _name, ens, ens);
+        const std::uint64_t corr_internal =
+            static_cast<std::uint64_t>(record.correlation_id.internal);
+        wall_clock_event_trace::pop_region_ts(tid, _name, ens, ens, corr_internal);
     }
 
     if(get_use_perfetto())
@@ -1218,9 +1217,12 @@ ompt_tracing_callback_start(rocprofiler_callback_tracing_record_t record,
     if(get_use_timemory())
     {
         tracing::push_timemory(category::rocm_ompt_api{}, _name);
-        const auto          tid = rocprofiler_trace_thread_id(record.thread_id);
+        const auto          tid = tim::threading::get_sys_tid();
         const std::uint64_t tns = static_cast<std::uint64_t>(ts);
-        wall_clock_event_trace::push_region_ts(tid, std::string{ _name }, tns, tns);
+        const std::uint64_t corr_internal =
+            static_cast<std::uint64_t>(record.correlation_id.internal);
+        wall_clock_event_trace::push_region_ts(tid, std::string{ _name }, tns, tns,
+                                               corr_internal);
     }
 
     if(get_use_perfetto())
@@ -1266,9 +1268,11 @@ ompt_tracing_callback_stop(
     if(get_use_timemory())
     {
         tracing::pop_timemory(category::rocm_ompt_api{}, _name);
-        const auto          tid = rocprofiler_trace_thread_id(record.thread_id);
+        const auto          tid = tim::threading::get_sys_tid();
         const std::uint64_t ens = static_cast<std::uint64_t>(ts);
-        wall_clock_event_trace::pop_region_ts(tid, _name, ens, ens);
+        const std::uint64_t corr_internal =
+            static_cast<std::uint64_t>(record.correlation_id.internal);
+        wall_clock_event_trace::pop_region_ts(tid, _name, ens, ens, corr_internal);
     }
 
     if(get_use_perfetto())
@@ -1787,7 +1791,9 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
                         });
                         _bundle.pop();
 
-                        wall_clock_trace_buffered_interval(_tid, _name, _beg_ns, _end_ns);
+                        wall_clock_trace_buffered_interval(
+                            _tinfo->index_data->system_value, _name, _beg_ns, _end_ns,
+                            get_parent_stack_id(record->correlation_id));
                     }
                 }
 
@@ -1913,7 +1919,8 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
                     _bundle.pop();
 
                     wall_clock_trace_buffered_interval(
-                        thread_id_sequent, std::string{ _name }, _beg_ns, _end_ns);
+                        t_info->index_data->system_value, std::string{ _name }, _beg_ns,
+                        _end_ns, get_parent_stack_id(record->correlation_id));
                 }
 
                 if(get_use_perfetto())
@@ -2037,8 +2044,10 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
                         });
                         _bundle.pop();
 
-                        wall_clock_trace_buffered_interval(_tid, std::string{ _name },
-                                                           _beg_ns, _end_ns);
+                        wall_clock_trace_buffered_interval(
+                            _tinfo->index_data->system_value, std::string{ _name },
+                            _beg_ns, _end_ns,
+                            get_parent_stack_id(record->correlation_id));
                     }
                 }
 
@@ -2119,8 +2128,9 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
                             ROCPROFILER_BUFFER_TRACING_MEMORY_ALLOCATION,
                             record->operation) };
                         wall_clock_trace_buffered_interval(
-                            _tinfo->index_data->sequent_value, _label,
-                            record->start_timestamp, record->end_timestamp);
+                            _tinfo->index_data->system_value, _label,
+                            record->start_timestamp, record->end_timestamp,
+                            get_parent_stack_id(record->correlation_id));
                     }
                 }
             }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/wall_clock_event_trace.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/wall_clock_event_trace.cpp
@@ -1,0 +1,233 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "library/wall_clock_event_trace.hpp"
+
+#include "core/config.hpp"
+#include "core/trace_cache/cache_manager.hpp"
+#include "core/trace_cache/sample_type.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace rocprofsys
+{
+namespace wall_clock_event_trace
+{
+namespace
+{
+struct frame_t
+{
+    std::uint64_t exec_id = 0;
+    std::string   name;
+};
+
+struct state_t
+{
+    std::mutex                                             mtx;
+    std::atomic<std::uint64_t>                             next_exec_id{ 1 };
+    std::unordered_map<std::int64_t, std::vector<frame_t>> stacks;
+    std::unordered_map<std::int64_t, std::uint64_t>        open_pthread_create;
+
+    void reset()
+    {
+        std::scoped_lock<std::mutex> lk{ mtx };
+        next_exec_id.store(1, std::memory_order_relaxed);
+        stacks.clear();
+        open_pthread_create.clear();
+    }
+
+    static std::pair<std::uint64_t, std::uint64_t> now_steady_wall_ns()
+    {
+        const auto sn = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                            std::chrono::steady_clock::now().time_since_epoch())
+                            .count();
+        const auto wn = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                            std::chrono::system_clock::now().time_since_epoch())
+                            .count();
+        return { static_cast<std::uint64_t>(sn), static_cast<std::uint64_t>(wn) };
+    }
+
+    void emit(std::uint64_t steady_ns, std::uint64_t wall_ns, std::uint64_t thread_id_u,
+              trace_cache::wall_clock_scope_event_kind kind, std::uint64_t exec_id,
+              std::uint64_t parent_exec_id, std::uint32_t depth,
+              std::uint64_t correlation_id, std::string name)
+    {
+        trace_cache::get_buffer_storage().store(
+            trace_cache::wall_clock_scope_event_sample{
+                steady_ns, wall_ns, thread_id_u, static_cast<std::uint8_t>(kind), exec_id,
+                parent_exec_id, depth, correlation_id, std::move(name) });
+    }
+};
+
+state_t&
+get_state()
+{
+    static state_t* s = new state_t{};
+    return *s;
+}
+}  // namespace
+
+void
+session_reset()
+{
+    get_state().reset();
+}
+
+void
+push_region(std::int64_t thread_id, const std::string& name)
+{
+    if(!config::get_use_timemory()) return;
+
+    auto&                        st = get_state();
+    const auto                   tw = state_t::now_steady_wall_ns();
+    std::scoped_lock<std::mutex> lk{ st.mtx };
+
+    const std::uint64_t parent_exec = [&]() -> std::uint64_t {
+        auto it = st.stacks.find(thread_id);
+        if(it == st.stacks.end() || it->second.empty()) return 0;
+        return it->second.back().exec_id;
+    }();
+
+    const std::uint32_t depth = [&]() -> std::uint32_t {
+        auto it = st.stacks.find(thread_id);
+        if(it == st.stacks.end()) return 0;
+        return static_cast<std::uint32_t>(it->second.size());
+    }();
+
+    const std::uint64_t exec_id = st.next_exec_id.fetch_add(1, std::memory_order_relaxed);
+    st.emit(tw.first, tw.second, static_cast<std::uint64_t>(thread_id),
+            trace_cache::wall_clock_scope_event_kind::enter, exec_id, parent_exec, depth,
+            0, name);
+    st.stacks[thread_id].push_back(frame_t{ exec_id, name });
+}
+
+void
+pop_region(std::int64_t thread_id, std::string_view name)
+{
+    if(!config::get_use_timemory()) return;
+
+    auto&                        st = get_state();
+    const auto                   tw = state_t::now_steady_wall_ns();
+    std::scoped_lock<std::mutex> lk{ st.mtx };
+
+    auto it = st.stacks.find(thread_id);
+    if(it == st.stacks.end() || it->second.empty()) return;
+
+    if(it->second.back().name != name) return;
+
+    const std::uint64_t exec_id = it->second.back().exec_id;
+    st.emit(tw.first, tw.second, static_cast<std::uint64_t>(thread_id),
+            trace_cache::wall_clock_scope_event_kind::exit, exec_id, 0, 0, 0,
+            std::string{});
+    it->second.pop_back();
+}
+
+void
+push_pthread_create(std::int64_t parent_thread_id, const std::string& name)
+{
+    if(!config::get_use_timemory()) return;
+
+    auto&                        st = get_state();
+    const auto                   tw = state_t::now_steady_wall_ns();
+    std::scoped_lock<std::mutex> lk{ st.mtx };
+
+    const std::uint64_t parent_exec = [&]() -> std::uint64_t {
+        auto ps_it = st.stacks.find(parent_thread_id);
+        if(ps_it == st.stacks.end() || ps_it->second.empty()) return 0;
+        return ps_it->second.back().exec_id;
+    }();
+
+    const std::uint32_t depth = [&]() -> std::uint32_t {
+        auto ps_it = st.stacks.find(parent_thread_id);
+        if(ps_it == st.stacks.end()) return 0;
+        return static_cast<std::uint32_t>(ps_it->second.size());
+    }();
+
+    const std::uint64_t exec_id = st.next_exec_id.fetch_add(1, std::memory_order_relaxed);
+    st.emit(tw.first, tw.second, static_cast<std::uint64_t>(parent_thread_id),
+            trace_cache::wall_clock_scope_event_kind::enter, exec_id, parent_exec, depth,
+            0, name);
+    st.stacks[parent_thread_id].push_back(frame_t{ exec_id, name });
+    st.open_pthread_create[parent_thread_id] = exec_id;
+}
+
+void
+pop_pthread_create(std::int64_t parent_thread_id, std::string_view name)
+{
+    if(!config::get_use_timemory()) return;
+
+    auto&                        st = get_state();
+    const auto                   tw = state_t::now_steady_wall_ns();
+    std::scoped_lock<std::mutex> lk{ st.mtx };
+
+    st.open_pthread_create.erase(parent_thread_id);
+
+    auto ps_it = st.stacks.find(parent_thread_id);
+    if(ps_it == st.stacks.end() || ps_it->second.empty()) return;
+
+    if(ps_it->second.back().name != name) return;
+
+    const std::uint64_t exec_id = ps_it->second.back().exec_id;
+    st.emit(tw.first, tw.second, static_cast<std::uint64_t>(parent_thread_id),
+            trace_cache::wall_clock_scope_event_kind::exit, exec_id, 0, 0, 0,
+            std::string{});
+    ps_it->second.pop_back();
+}
+
+void
+push_start_thread(std::int64_t parent_thread_id, std::int64_t child_thread_id,
+                  const std::string& name)
+{
+    if(!config::get_use_timemory()) return;
+
+    auto&                        st = get_state();
+    const auto                   tw = state_t::now_steady_wall_ns();
+    std::scoped_lock<std::mutex> lk{ st.mtx };
+
+    std::uint64_t parent_exec = 0;
+    auto          pit         = st.open_pthread_create.find(parent_thread_id);
+    if(pit != st.open_pthread_create.end()) parent_exec = pit->second;
+
+    const std::uint32_t depth = [&]() -> std::uint32_t {
+        auto cs_it = st.stacks.find(child_thread_id);
+        if(cs_it == st.stacks.end()) return 0;
+        return static_cast<std::uint32_t>(cs_it->second.size());
+    }();
+
+    const std::uint64_t exec_id = st.next_exec_id.fetch_add(1, std::memory_order_relaxed);
+    const std::uint64_t corr    = static_cast<std::uint64_t>(parent_thread_id);
+    st.emit(tw.first, tw.second, static_cast<std::uint64_t>(child_thread_id),
+            trace_cache::wall_clock_scope_event_kind::enter, exec_id, parent_exec, depth,
+            corr, name);
+    st.stacks[child_thread_id].push_back(frame_t{ exec_id, name });
+}
+
+void
+pop_start_thread(std::int64_t child_thread_id, std::string_view name)
+{
+    if(!config::get_use_timemory()) return;
+
+    auto&                        st = get_state();
+    const auto                   tw = state_t::now_steady_wall_ns();
+    std::scoped_lock<std::mutex> lk{ st.mtx };
+
+    auto cs_it = st.stacks.find(child_thread_id);
+    if(cs_it == st.stacks.end() || cs_it->second.empty()) return;
+
+    if(cs_it->second.back().name != name) return;
+
+    const std::uint64_t exec_id = cs_it->second.back().exec_id;
+    st.emit(tw.first, tw.second, static_cast<std::uint64_t>(child_thread_id),
+            trace_cache::wall_clock_scope_event_kind::exit, exec_id, 0, 0, 0,
+            std::string{});
+    cs_it->second.pop_back();
+}
+
+}  // namespace wall_clock_event_trace
+}  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/wall_clock_event_trace.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/wall_clock_event_trace.cpp
@@ -7,11 +7,14 @@
 #include "core/trace_cache/cache_manager.hpp"
 #include "core/trace_cache/sample_type.hpp"
 
+#include <timemory/process/threading.hpp>
+
 #include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -31,15 +34,21 @@ struct state_t
 {
     std::mutex                                             mtx;
     std::atomic<std::uint64_t>                             next_exec_id{ 1 };
+    std::atomic<std::uint64_t>                             next_record_seq{ 1 };
     std::unordered_map<std::int64_t, std::vector<frame_t>> stacks;
     std::unordered_map<std::int64_t, std::uint64_t>        open_pthread_create;
+    /// ROCprofiler \c correlation_id::internal for an open callback scope -> wall_clock
+    /// \c exec_id (used to parent buffered GPU samples under the submitting API region).
+    std::unordered_map<std::uint64_t, std::uint64_t> open_correlation_exec;
 
     void reset()
     {
         std::scoped_lock<std::mutex> lk{ mtx };
         next_exec_id.store(1, std::memory_order_relaxed);
+        next_record_seq.store(1, std::memory_order_relaxed);
         stacks.clear();
         open_pthread_create.clear();
+        open_correlation_exec.clear();
     }
 
     static std::pair<std::uint64_t, std::uint64_t> now_steady_wall_ns()
@@ -58,9 +67,10 @@ struct state_t
               std::uint64_t parent_exec_id, std::uint32_t depth,
               std::uint64_t correlation_id, std::string name)
     {
+        const std::uint64_t rs = next_record_seq.fetch_add(1, std::memory_order_relaxed);
         trace_cache::get_buffer_storage().store(trace_cache::wall_clock_event_sample{
             steady_ns, wall_ns, thread_id_u, static_cast<std::uint8_t>(kind), exec_id,
-            parent_exec_id, depth, correlation_id, std::move(name) });
+            parent_exec_id, depth, correlation_id, rs, std::move(name) });
     }
 };
 
@@ -76,6 +86,12 @@ void
 session_reset()
 {
     get_state().reset();
+}
+
+std::int64_t
+stack_thread_id()
+{
+    return tim::threading::get_sys_tid();
 }
 
 void
@@ -129,7 +145,7 @@ pop_region(std::int64_t thread_id, std::string_view name)
 
 void
 push_region_ts(std::int64_t thread_id, const std::string& name, std::uint64_t steady_ns,
-               std::uint64_t wall_ns)
+               std::uint64_t wall_ns, std::uint64_t rocprofiler_correlation_internal)
 {
     if(!config::get_use_timemory()) return;
 
@@ -153,11 +169,13 @@ push_region_ts(std::int64_t thread_id, const std::string& name, std::uint64_t st
             trace_cache::wall_clock_scope_event_kind::enter, exec_id, parent_exec, depth,
             0, name);
     st.stacks[thread_id].push_back(frame_t{ exec_id, name });
+    if(rocprofiler_correlation_internal != 0)
+        st.open_correlation_exec[rocprofiler_correlation_internal] = exec_id;
 }
 
 void
 pop_region_ts(std::int64_t thread_id, std::string_view name, std::uint64_t steady_ns,
-              std::uint64_t wall_ns)
+              std::uint64_t wall_ns, std::uint64_t rocprofiler_correlation_internal)
 {
     if(!config::get_use_timemory()) return;
 
@@ -174,6 +192,46 @@ pop_region_ts(std::int64_t thread_id, std::string_view name, std::uint64_t stead
             trace_cache::wall_clock_scope_event_kind::exit, exec_id, 0, 0, 0,
             std::string{});
     it->second.pop_back();
+    if(rocprofiler_correlation_internal != 0)
+        st.open_correlation_exec.erase(rocprofiler_correlation_internal);
+}
+
+void
+emit_buffered_wall_clock_interval(std::int64_t thread_id, const std::string& name,
+                                  std::uint64_t beg_ns, std::uint64_t end_ns,
+                                  std::uint64_t rocprofiler_ancestor_internal)
+{
+    if(!config::get_use_timemory()) return;
+
+    auto&                        st = get_state();
+    std::scoped_lock<std::mutex> lk{ st.mtx };
+
+    std::uint64_t parent_exec = 0;
+    if(rocprofiler_ancestor_internal != 0)
+    {
+        auto pit = st.open_correlation_exec.find(rocprofiler_ancestor_internal);
+        if(pit != st.open_correlation_exec.end()) parent_exec = pit->second;
+    }
+    if(parent_exec == 0)
+    {
+        auto sit = st.stacks.find(thread_id);
+        if(sit != st.stacks.end() && !sit->second.empty())
+            parent_exec = sit->second.back().exec_id;
+    }
+
+    const std::uint32_t depth = [&]() -> std::uint32_t {
+        auto sit = st.stacks.find(thread_id);
+        if(sit == st.stacks.end()) return 0;
+        return static_cast<std::uint32_t>(sit->second.size());
+    }();
+
+    const std::uint64_t exec_id = st.next_exec_id.fetch_add(1, std::memory_order_relaxed);
+    st.emit(beg_ns, beg_ns, static_cast<std::uint64_t>(thread_id),
+            trace_cache::wall_clock_scope_event_kind::enter, exec_id, parent_exec, depth,
+            0, name);
+    st.emit(end_ns, end_ns, static_cast<std::uint64_t>(thread_id),
+            trace_cache::wall_clock_scope_event_kind::exit, exec_id, 0, 0, 0,
+            std::string{});
 }
 
 void

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/wall_clock_event_trace.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/wall_clock_event_trace.cpp
@@ -58,10 +58,9 @@ struct state_t
               std::uint64_t parent_exec_id, std::uint32_t depth,
               std::uint64_t correlation_id, std::string name)
     {
-        trace_cache::get_buffer_storage().store(
-            trace_cache::wall_clock_scope_event_sample{
-                steady_ns, wall_ns, thread_id_u, static_cast<std::uint8_t>(kind), exec_id,
-                parent_exec_id, depth, correlation_id, std::move(name) });
+        trace_cache::get_buffer_storage().store(trace_cache::wall_clock_event_sample{
+            steady_ns, wall_ns, thread_id_u, static_cast<std::uint8_t>(kind), exec_id,
+            parent_exec_id, depth, correlation_id, std::move(name) });
     }
 };
 
@@ -123,6 +122,55 @@ pop_region(std::int64_t thread_id, std::string_view name)
 
     const std::uint64_t exec_id = it->second.back().exec_id;
     st.emit(tw.first, tw.second, static_cast<std::uint64_t>(thread_id),
+            trace_cache::wall_clock_scope_event_kind::exit, exec_id, 0, 0, 0,
+            std::string{});
+    it->second.pop_back();
+}
+
+void
+push_region_ts(std::int64_t thread_id, const std::string& name, std::uint64_t steady_ns,
+               std::uint64_t wall_ns)
+{
+    if(!config::get_use_timemory()) return;
+
+    auto&                        st = get_state();
+    std::scoped_lock<std::mutex> lk{ st.mtx };
+
+    const std::uint64_t parent_exec = [&]() -> std::uint64_t {
+        auto it = st.stacks.find(thread_id);
+        if(it == st.stacks.end() || it->second.empty()) return 0;
+        return it->second.back().exec_id;
+    }();
+
+    const std::uint32_t depth = [&]() -> std::uint32_t {
+        auto it = st.stacks.find(thread_id);
+        if(it == st.stacks.end()) return 0;
+        return static_cast<std::uint32_t>(it->second.size());
+    }();
+
+    const std::uint64_t exec_id = st.next_exec_id.fetch_add(1, std::memory_order_relaxed);
+    st.emit(steady_ns, wall_ns, static_cast<std::uint64_t>(thread_id),
+            trace_cache::wall_clock_scope_event_kind::enter, exec_id, parent_exec, depth,
+            0, name);
+    st.stacks[thread_id].push_back(frame_t{ exec_id, name });
+}
+
+void
+pop_region_ts(std::int64_t thread_id, std::string_view name, std::uint64_t steady_ns,
+              std::uint64_t wall_ns)
+{
+    if(!config::get_use_timemory()) return;
+
+    auto&                        st = get_state();
+    std::scoped_lock<std::mutex> lk{ st.mtx };
+
+    auto it = st.stacks.find(thread_id);
+    if(it == st.stacks.end() || it->second.empty()) return;
+
+    if(it->second.back().name != name) return;
+
+    const std::uint64_t exec_id = it->second.back().exec_id;
+    st.emit(steady_ns, wall_ns, static_cast<std::uint64_t>(thread_id),
             trace_cache::wall_clock_scope_event_kind::exit, exec_id, 0, 0, 0,
             std::string{});
     it->second.pop_back();

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/wall_clock_event_trace.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/wall_clock_event_trace.hpp
@@ -14,6 +14,11 @@ namespace wall_clock_event_trace
 void
 session_reset();
 
+/// OS thread id for wall-clock host stacks (matches \c tim::threading::get_sys_tid()).
+/// Kept for ABI compatibility with object files that still reference this symbol.
+std::int64_t
+stack_thread_id();
+
 void
 push_region(std::int64_t thread_id, const std::string& name);
 void
@@ -22,12 +27,23 @@ pop_region(std::int64_t thread_id, std::string_view name);
 /// ENTER/EXIT timestamps supplied by caller (e.g. \c rocprofiler_timestamp_t values from
 /// ROCprofiler callbacks or buffer records). Both steady and wall fields use the same
 /// nanosecond value so replay ordering and inclusive duration match the profiler domain.
+/// When \p rocprofiler_correlation_internal is non-zero, it must match
+/// \c rocprofiler_correlation_id_t::internal for this scope so buffered GPU activity can
+/// attach under the correct parent via the ancestor correlation id.
 void
 push_region_ts(std::int64_t thread_id, const std::string& name, std::uint64_t steady_ns,
-               std::uint64_t wall_ns);
+               std::uint64_t wall_ns, std::uint64_t rocprofiler_correlation_internal = 0);
 void
 pop_region_ts(std::int64_t thread_id, std::string_view name, std::uint64_t steady_ns,
-              std::uint64_t wall_ns);
+              std::uint64_t wall_ns, std::uint64_t rocprofiler_correlation_internal = 0);
+
+/// Synthetic ENTER/EXIT for buffered GPU intervals without touching the host stack.
+/// Parent is resolved from \p rocprofiler_ancestor_internal when that id is registered
+/// from a callback scope; otherwise the current stack top is used (flush-time parent).
+void
+emit_buffered_wall_clock_interval(std::int64_t thread_id, const std::string& name,
+                                  std::uint64_t beg_ns, std::uint64_t end_ns,
+                                  std::uint64_t rocprofiler_ancestor_internal = 0);
 
 void
 push_pthread_create(std::int64_t parent_thread_id, const std::string& name);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/wall_clock_event_trace.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/wall_clock_event_trace.hpp
@@ -1,0 +1,33 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace rocprofsys
+{
+namespace wall_clock_event_trace
+{
+void
+session_reset();
+
+void
+push_region(std::int64_t thread_id, const std::string& name);
+void
+pop_region(std::int64_t thread_id, std::string_view name);
+
+void
+push_pthread_create(std::int64_t parent_thread_id, const std::string& name);
+void
+pop_pthread_create(std::int64_t parent_thread_id, std::string_view name);
+
+void
+push_start_thread(std::int64_t parent_thread_id, std::int64_t child_thread_id,
+                  const std::string& name);
+void
+pop_start_thread(std::int64_t child_thread_id, std::string_view name);
+}  // namespace wall_clock_event_trace
+}  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/wall_clock_event_trace.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/wall_clock_event_trace.hpp
@@ -19,6 +19,16 @@ push_region(std::int64_t thread_id, const std::string& name);
 void
 pop_region(std::int64_t thread_id, std::string_view name);
 
+/// ENTER/EXIT timestamps supplied by caller (e.g. \c rocprofiler_timestamp_t values from
+/// ROCprofiler callbacks or buffer records). Both steady and wall fields use the same
+/// nanosecond value so replay ordering and inclusive duration match the profiler domain.
+void
+push_region_ts(std::int64_t thread_id, const std::string& name, std::uint64_t steady_ns,
+               std::uint64_t wall_ns);
+void
+pop_region_ts(std::int64_t thread_id, std::string_view name, std::uint64_t steady_ns,
+              std::uint64_t wall_ns);
+
 void
 push_pthread_create(std::int64_t parent_thread_id, const std::string& name);
 void


### PR DESCRIPTION
## Motivation

Move the wall clock generation logic to trace cache from timemory to rely on a single trace-buffer path for all the outputs including all profile data output.

## Technical Details

Trace-cache sample type and plumbing
 - Adds a new buffered sample type `wall_clock_scope_event_sample` (with `wall_clock_scope_event_kind` enter/exit) in sample_type.hpp, wires it through data_types.hpp, storage_parser_alias.hpp, and extends test_sample_type.cpp for serialization/layout coverage.
 - Extends the sequential sample visitor (sample_processor.hpp) so coordinators dispatch handle(wall_clock_scope_event_sample); Perfetto and ROCpd processors get matching no-op overloads so the type is accepted everywhere the visitor pattern is used.

Runtime: scope events into the trace buffer
- Introduces wall_clock_event_trace.{hpp,cpp}: on the same timemory-gated paths as existing instrumentation, records ENTER/EXIT pairs into trace_cache::get_buffer_storage() with steady + wall timestamps, exec_id / parent_exec_id, depth, thread id, and region name. Maintains per-thread stacks and open_pthread_create so start_thread nests under the parent’s open pthread_create.
- Hooks category_region.hpp (normal regions) and pthread_create_gotcha.cpp (pthread_create / start_thread) to call the new emitter; library.cpp calls wall_clock_event_trace::session_reset() when timemory profiling is enabled.

Offline: replay buffer → wall_clock_evt artifacts
- Adds `wall_clock_scope_event_processor` : reads collected `wall_clock_scope_event_sample` events, sorts them for deterministic replay, pairs ENTER/EXIT into slots, builds a parent/child tree (roots under parent_exec_id == 0), computes inclusive/exclusive wall time (with non-negative exclusive - when child wall sums exceed the parent interval), flattens in preorder, aggregates rows by timemory-style LABEL keys, and writes timemory-shaped JSON plus a timemory-style ASCII table under the metric basename wall_clock_evt, registering paths on output_file_registry.
- post_processor.cpp: constructs and registers wall_clock_scope_event_processor_t on the coordinator for every post-process run. If both ROCpd and Perfetto sequential/parallel formats are disabled, adds a buffer-only sequential pass (guarded by config::get_use_timemory()) so buffered_storage.bin is still parsed and wall_clock_evt can be produced

## JIRA ID


## Test Plan


## Test Result


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
