### PR TITLE
Inactivate leaked AQL queues in GpuAgent::ReleaseResources

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -570,6 +570,9 @@ class GpuAgent : public GpuAgentInt {
   /// @brief Get list of AQL queues for core dump filtering
   const std::vector<core::Queue*>& GetAqlQueues() const { return aql_queues_; }
 
+  /// @brief Stop tracking a queue
+  void RemoveAqlQueue(core::Queue* q);
+
  protected:
   // Sizes are in packets.
   const uint32_t minAqlSize_ = 0x40;     // 4KB min

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -411,6 +411,9 @@ void AqlQueue::Destroy() {
     agent_->GWSRelease();
     return;
   }
+  // Drop from agent's tracking list before deletion so
+  // GpuAgent::ReleaseResources() does not touch a destroyed queue.
+  agent_->RemoveAqlQueue(this);
   delete this;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1006,9 +1006,35 @@ void GpuAgent::PreloadBlits() {
   }
 }
 
+void GpuAgent::RemoveAqlQueue(core::Queue* q) {
+  auto it = std::find(aql_queues_.begin(), aql_queues_.end(), q);
+  if (it != aql_queues_.end()) aql_queues_.erase(it);
+}
+
 void GpuAgent::ReleaseResources() {
   if (this->Enabled()) {
     this->Disable();
+
+    aql_queues_.erase(
+        std::remove_if(aql_queues_.begin(), aql_queues_.end(),
+                       [this](core::Queue* q) {
+                         for (int i = 0; i < QueueCount; i++) {
+                           if (queues_[i] == q) return true;
+                         }
+                         return false;
+                       }),
+        aql_queues_.end());
+    if (!aql_queues_.empty()) {
+      debug_print("Warning: %zu AQL queue(s) leaked into hsa_shut_down on agent %p.\n",
+                  aql_queues_.size(), this);
+
+      for (auto iter : aql_queues_) {
+        auto aqlQueue = static_cast<AqlQueue*>(iter);
+        aqlQueue->Inactivate();
+        delete aqlQueue;
+      }
+      aql_queues_.clear();
+    }
 
     // Remove all shared hardware queues from pool
     queue_pool_.Cleanup();


### PR DESCRIPTION
User AQL queues may still be alive when hsa_shut_down() runs because the application (or higher-level runtime such as HIP CLR) skipped explicit hsa_queue_destroy on its non-pooled queues. On real hardware the kernel reaps them, but software KFD-thunk simulators are still polling queue memory when the driver unmaps the SVM aperture, which crashes the model thread.

Walk GpuAgent::aql_queues_ from ReleaseResources() and call AqlQueue::Inactivate() on each remaining queue so the KFD DESTROY_QUEUE ioctl is issued before driver teardown.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
