### PR TITLE
[rocprofiler-systems] bump elfutils to 0.195

### DIFF
--- a/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
@@ -209,8 +209,10 @@ else()
         BUILD_IN_SOURCE 1
         ${_eu_patch_args}
         CONFIGURE_COMMAND
-            ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3
-            CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=-fPIC\ -O3
+            ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER}
+            CFLAGS=-fPIC\ -O3\ -Wno-error=maybe-uninitialized
+            CXX=${CMAKE_CXX_COMPILER}
+            CXXFLAGS=-fPIC\ -O3\ -Wno-error=maybe-uninitialized
             [=[LDFLAGS=-Wl,-rpath='$$ORIGIN']=] <SOURCE_DIR>/configure
             --enable-install-elfh --prefix=${_eu_root} --disable-libdebuginfod
             --disable-debuginfod --enable-thread-safety --disable-nls

--- a/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
@@ -210,10 +210,9 @@ else()
         ${_eu_patch_args}
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER}
-            CFLAGS=-fPIC\ -O3\ -Wno-error=maybe-uninitialized
-            CXX=${CMAKE_CXX_COMPILER}
+            CFLAGS=-fPIC\ -O3\ -Wno-error=maybe-uninitialized CXX=${CMAKE_CXX_COMPILER}
             CXXFLAGS=-fPIC\ -O3\ -Wno-error=maybe-uninitialized
-            [=[LDFLAGS=-Wl,-rpath='$$ORIGIN']=] <SOURCE_DIR>/configure
+            [=[LDFLAGS=-Wl,-rpath='$$ORIGIN' -pthread]=] <SOURCE_DIR>/configure
             --enable-install-elfh --prefix=${_eu_root} --disable-libdebuginfod
             --disable-debuginfod --enable-thread-safety --disable-nls
             ${ElfUtils_CONFIG_OPTIONS} --libdir=${_eu_root}/lib

--- a/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
@@ -135,7 +135,7 @@ else()
     # If we didn't find a suitable version on the system, then download one from the web
     rocprofiler_systems_add_cache_option(
         ELFUTILS_DOWNLOAD_VERSION "Version of elfutils to download and install" STRING
-        "0.194"
+        "0.195"
     )
     set(ELFUTILS_DOWNLOAD_VERSION ${ElfUtils_DOWNLOAD_VERSION})
 

--- a/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
@@ -45,7 +45,7 @@ endif()
 
 # Minimum acceptable version of elfutils NB: We need >=0.178 because libdw isn't
 # thread-safe before then
-set(_min_version 0.178)
+set(_min_version 0.195)
 
 set(ElfUtils_MIN_VERSION
     ${_min_version}
@@ -135,7 +135,7 @@ else()
     # If we didn't find a suitable version on the system, then download one from the web
     rocprofiler_systems_add_cache_option(
         ELFUTILS_DOWNLOAD_VERSION "Version of elfutils to download and install" STRING
-        "0.188"
+        "0.195"
     )
     set(ELFUTILS_DOWNLOAD_VERSION ${ElfUtils_DOWNLOAD_VERSION})
 

--- a/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
@@ -45,7 +45,7 @@ endif()
 
 # Minimum acceptable version of elfutils NB: We need >=0.178 because libdw isn't
 # thread-safe before then
-set(_min_version 0.195)
+set(_min_version 0.178)
 
 set(ElfUtils_MIN_VERSION
     ${_min_version}

--- a/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
+++ b/projects/rocprofiler-systems/cmake/DyninstElfUtils.cmake
@@ -135,7 +135,7 @@ else()
     # If we didn't find a suitable version on the system, then download one from the web
     rocprofiler_systems_add_cache_option(
         ELFUTILS_DOWNLOAD_VERSION "Version of elfutils to download and install" STRING
-        "0.195"
+        "0.194"
     )
     set(ELFUTILS_DOWNLOAD_VERSION ${ElfUtils_DOWNLOAD_VERSION})
 


### PR DESCRIPTION
## Motivation

The purpose of this PR is to bump `elfutils` to latest version 0.195

## Technical Details

In file libdw/dwarf_cu_dwp_section_info.c, variables `offset` and `size` are seen by GCC 11 as uninitialized, which blocks the build. `-Wno-error=maybe-uninitialized` solves this.

`-pthread` flag is added to solve `undefined reference to symbol 'pthread_join@@GLIBC_2.2.5'` linking error.

## JIRA ID

AIPROFSYST-405

## Test Plan

- Existing ctests should pass
- Confirming with build logs that new version of ElfUtils is used. 

## Test Result

All existing tests pass

```
  -- [rocprofiler-systems] Attempting to build elfutils(0.195) as external project
  -- [rocprofiler-systems] ElfUtils includes: $<BUILD_INTERFACE:/__w/rocm-systems/rocm-systems/projects/rocprofiler-systems/build/external/elfutils/include>
  -- [rocprofiler-systems] ElfUtils library dirs: $<BUILD_INTERFACE:/__w/rocm-systems/rocm-systems/projects/rocprofiler-systems/build/external/elfutils/lib>
  -- [rocprofiler-systems] ElfUtils libraries: $<BUILD_INTERFACE:/__w/rocm-systems/rocm-systems/projects/rocprofiler-systems/build/external/elfutils/lib/libdw.so>;$<BUILD_INTERFACE:/__w/rocm-systems/rocm-systems/projects/rocprofiler-systems/build/external/elfutils/lib/libelf.so>
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
