### PR TITLE
test_runner: add CE suite support, gtest-style suite filtering, and docs

### DIFF
--- a/projects/rccl/tools/scripts/test_runner/README.md
+++ b/projects/rccl/tools/scripts/test_runner/README.md
@@ -15,7 +15,7 @@ This test runner provides a maintainable, extensible alternative to shell-based 
 - **Custom Library Support**: Use pre-built RCCL libraries from custom locations via environment variables
 - **Configurable Build System**: Customize CMake options, environment variables, and parallel jobs via config
 - **MPI Support**: Full support for multi-rank and multi-node tests
-- **Flexible Test Filtering**: Run all tests, specific test suites, or individual tests
+- **Flexible Test Filtering**: Both `--test-name` and `--suite-name` accept gtest-style glob patterns (`P2P*` = prefix, `*SHM*` = contains, `*:-NET*` = exclude; colon = OR; case-sensitive); filter by individual test name or by suite name
 - **Build Integration**: Automated RCCL building with CMake
 - **Code Coverage**: Integrated LLVM coverage report generation (HTML and text)
 - **Clean Output**: Automatic filtering of MPI verbose messages (enable with --verbose)
@@ -32,8 +32,20 @@ python test_runner.py --config my_tests.json
 # Run with verbose output
 python test_runner.py --config my_tests.json --verbose
 
-# Run specific test by name
+# Run a specific test by exact name
 python test_runner.py --config my_tests.json --test-name SHM_ComprehensiveWorkflow
+
+# Run all tests whose name starts with 'P2P' (glob prefix match)
+python test_runner.py --config my_tests.json --test-name "P2P_*"
+
+# Run multiple tests (colon-separated globs)
+python test_runner.py --config my_tests.json --test-name "P2P_*:SHM_Basic"
+
+# Run all suites whose name starts with 'P2P' (glob prefix match)
+python test_runner.py --config my_tests.json --suite-name "P2P*"
+
+# Run two specific suites by exact name (colon-separated)
+python test_runner.py --config my_tests.json --suite-name "P2P Tests - 2-Rank:P2P Tests - 4-Rank"
 ```
 
 ### Generate Coverage Report
@@ -96,6 +108,7 @@ The test runner supports the following environment variables to customize behavi
 | `RCCL_LIB_PATH` | Path to pre-built RCCL library directory (contains `librccl.so` and `test/` subdirectory). When set, the build step is automatically skipped. | `/path/to/rccl/build` |
 | `RCCL_BUILD_DIR` | Alternative name for `RCCL_LIB_PATH`. Either variable can be used. | `/path/to/rccl/build` |
 | `RCCL_TEST_MPI_HOSTFILE` | Path to MPI hostfile for multi-node tests. | `~/.mpi_hostfile` |
+| `RCCL_MPI_LOG_ALL_RANKS` | Set to `1` to capture stdout/stderr from every MPI rank into `rccl_test_rank_<N>.log` in the working directory (rank 0 is tee'd to console + file; ranks 1-N go to file only). Useful for debugging failures on non-zero ranks. | `RCCL_MPI_LOG_ALL_RANKS=1` |
 
 ### Configuration Path Variables
 
@@ -435,7 +448,8 @@ Required:
 Optional:
   -v, --verbose             Enable verbose output (shows build paths, commands, etc.)
   -o, --output DIR          Output directory for logs and reports
-  --test-name NAME          Run only specific test by name
+  --test-name GLOB[:GLOB…]  Run only tests matching any glob pattern; ':' = OR, '*' = wildcard, '-' prefix = exclude, case-sensitive (e.g. 'P2P_*' = all P2P tests; '*:-SHM*' = all except SHM)
+  --suite-name GLOB[:GLOB…] Run only suites matching any glob pattern; ':' = OR, '*' = wildcard, '-' prefix = exclude, case-sensitive (e.g. 'P2P*' = all P2P suites; '*:-NET*' = all except NET)
   --no-build                Skip build step and use existing build
   --skip-tests              Skip test execution (useful with --coverage-report)
   --coverage-report         Generate code coverage report (HTML + text)
@@ -490,10 +504,35 @@ When `--coverage-report` is specified, the runner generates:
 python test_runner.py --config test_config_sample.json --verbose
 ```
 
-### Run Specific Test
+### Run Specific Tests or Suites
+
+Both `--test-name` and `--suite-name` accept gtest-style glob patterns:
+
+| Syntax | Meaning | Example |
+|--------|---------|---------|
+| `Name` | Exact match | `--test-name P2P_AllTests` |
+| `Name*` | Prefix match | `--test-name "P2P_*"` |
+| `*Name*` | Contains match | `--test-name "*AllReduce*"` |
+| `A:B` | A or B (OR) | `--test-name "P2P_*:SHM_Basic"` |
+| `-Name` | Exclude | `--test-name "*:-SHM*"` |
+
+Matching is against the `"name"` field (tests) or suite name (suites), and is case-sensitive.
 
 ```bash
+# Single test by exact name
 python test_runner.py --config test_config_sample.json --test-name P2P_AllTests
+
+# All tests whose name starts with 'P2P_'
+python test_runner.py --config test_config_sample.json --test-name "P2P_*"
+
+# All tests except SHM tests
+python test_runner.py --config test_config_sample.json --test-name "*:-SHM*"
+
+# All suites whose name starts with 'P2P' (glob prefix match)
+python test_runner.py --config test_config_sample.json --suite-name "P2P*"
+
+# Two specific suites matched by exact name (colon-separated)
+python test_runner.py --config test_config_sample.json --suite-name "P2P Tests - 2-Rank:P2P Tests - 4-Rank"
 ```
 
 ### Skip Build (Use Existing)
@@ -1090,7 +1129,7 @@ python test_runner.py --config test_config_sample.json --skip-tests --verbose
 1. Add test definition to appropriate configuration in JSON file
 2. Specify `is_gtest`, `description`, and required fields
 3. Test with dry run first: `--skip-tests --verbose`
-4. Run actual test: `--test-name YourTest --verbose`
+4. Run actual test: `--test-name YourTest --verbose` (exact name) or `--test-name "YourTest*" --verbose` (glob) or `--suite-name "My Suite" --verbose`
 
 ### Test Type Handling
 
@@ -1170,6 +1209,9 @@ These override the paths specified in the JSON configuration file:
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `RCCL_TEST_MPI_HOSTFILE` | Path to MPI hostfile for multi-node tests | `export RCCL_TEST_MPI_HOSTFILE=~/.mpi_hostfile` |
+| `RCCL_MPI_LOG_ALL_RANKS` | Set to `1` to redirect each MPI rank's stdout/stderr to `rccl_test_rank_<N>.log` (rank 0 is also tee'd to the console). Useful when debugging failures on non-zero ranks or when tests read per-rank log files for assertions. | `export RCCL_MPI_LOG_ALL_RANKS=1` |
+
+**Note**: `RCCL_TEST_MPI_HOSTFILE` falls back to `~/.mpi_hostfile` if not set.
 
 **Note**: Falls back to `~/.mpi_hostfile` if not set. For SLURM environments, hostfile is auto-generated from `SLURM_NODELIST`.
 

--- a/projects/rccl/tools/scripts/test_runner/README.md
+++ b/projects/rccl/tools/scripts/test_runner/README.md
@@ -32,7 +32,7 @@ python test_runner.py --config my_tests.json
 # Run with verbose output
 python test_runner.py --config my_tests.json --verbose
 
-# Run a specific test by exact name
+# Run a specific test by exact name (searches all enabled suites for a match)
 python test_runner.py --config my_tests.json --test-name SHM_ComprehensiveWorkflow
 
 # Run all tests whose name starts with 'P2P' (glob prefix match)
@@ -1211,9 +1211,7 @@ These override the paths specified in the JSON configuration file:
 | `RCCL_TEST_MPI_HOSTFILE` | Path to MPI hostfile for multi-node tests | `export RCCL_TEST_MPI_HOSTFILE=~/.mpi_hostfile` |
 | `RCCL_MPI_LOG_ALL_RANKS` | Set to `1` to redirect each MPI rank's stdout/stderr to `rccl_test_rank_<N>.log` (rank 0 is also tee'd to the console). Useful when debugging failures on non-zero ranks or when tests read per-rank log files for assertions. | `export RCCL_MPI_LOG_ALL_RANKS=1` |
 
-**Note**: `RCCL_TEST_MPI_HOSTFILE` falls back to `~/.mpi_hostfile` if not set.
-
-**Note**: Falls back to `~/.mpi_hostfile` if not set. For SLURM environments, hostfile is auto-generated from `SLURM_NODELIST`.
+**Note**: `RCCL_TEST_MPI_HOSTFILE` falls back to `~/.mpi_hostfile` if not set. For SLURM environments, hostfile is auto-generated from `SLURM_NODELIST`.
 
 ### Test-Specific Variables
 

--- a/projects/rccl/tools/scripts/test_runner/lib/__init__.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/__init__.py
@@ -5,7 +5,7 @@ Provides modules for test configuration, parsing, and execution
 
 from .test_config import TestConfigProcessor
 from .test_parser import ArgumentParserInterface, parse_test_output
-from .test_executor import TestExecutor, ExitCode, TestResult
+from .test_executor import TestExecutor, ExitCode, TestResult, glob_filter_matches
 
 __all__ = [
     'TestConfigProcessor',
@@ -13,7 +13,8 @@ __all__ = [
     'parse_test_output',
     'TestExecutor',
     'ExitCode',
-    'TestResult'
+    'TestResult',
+    'glob_filter_matches',
 ]
 
 __version__ = '1.0.0'

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -811,10 +811,14 @@ class TestExecutor:
 
         # Build command based on test type
         if num_ranks == 1:
-            # Non-MPI test - prepend environment variables to the command
+            # Non-MPI test - prepend environment variables to the command.
+            # LD_LIBRARY_PATH is already merged with correct priority order above,
+            # so skip it in the merged_env loop and use the final env value instead.
             env_prefix = ""
             for key, value in merged_env.items():
-                env_prefix += f"{key}={value} "
+                if key != 'LD_LIBRARY_PATH':
+                    env_prefix += f"{key}={value} "
+            env_prefix += f"LD_LIBRARY_PATH={env['LD_LIBRARY_PATH']} "
 
             if is_gtest:
                 # GTest-based test - use --gtest_filter syntax

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -772,16 +772,23 @@ class TestExecutor:
 
         # Build LD_LIBRARY_PATH.  Priority order (highest → lowest):
         #   1. build_dir          – always first so the test-built librccl.so wins
-        #   2. caller environment – LD_LIBRARY_PATH already set in the shell lets
+        #   2. test JSON value    – per-test custom lib dir (e.g. a backport HIP stack)
+        #   3. caller environment – LD_LIBRARY_PATH already set in the shell lets
         #                           users point at a custom libamdhip64.so.7 without
         #                           any special variable:
         #                             LD_LIBRARY_PATH=/path/to/hip python3 test_runner.py ...
-        #   3. {rocm_path}/lib    – default ROCm/HIP fallback
-        #   4. mpi_path/lib       – MPI runtime
+        #   4. {rocm_path}/lib    – default ROCm/HIP fallback
+        #   5. mpi_path/lib       – MPI runtime
+        #
+        # LD_LIBRARY_PATH from the JSON config is consumed here (not in the
+        # merged_env loop below) so that build_dir always stays first.
         mpi_path  = self.paths.get("mpi_path", "")
         rocm_path = self.paths.get("rocm_path", "/opt/rocm")
 
         ld_library_path_parts = [self.build_dir]
+        test_ld = merged_env.get('LD_LIBRARY_PATH')
+        if test_ld:
+            ld_library_path_parts.append(str(test_ld))
         if env.get('LD_LIBRARY_PATH'):
             ld_library_path_parts.append(env['LD_LIBRARY_PATH'])
         ld_library_path_parts.append(os.path.join(rocm_path, "lib"))
@@ -797,15 +804,9 @@ class TestExecutor:
         if self.args.coverage_report:
             env['LLVM_PROFILE_FILE'] = "rccl_tests_%p_%m.profraw"
 
-        # Add test-specific env vars.
-        # LD_LIBRARY_PATH is treated specially: a value coming from the JSON
-        # config is prepended to the already-constructed path so that the
-        # user-supplied directory wins over the {rocm_path}/lib default without
-        # losing build_dir (which must always remain first for librccl.so).
+        # Add test-specific env vars.  LD_LIBRARY_PATH is already merged above.
         for key, value in merged_env.items():
-            if key == 'LD_LIBRARY_PATH' and env.get('LD_LIBRARY_PATH'):
-                env[key] = str(value) + ":" + env['LD_LIBRARY_PATH']
-            else:
+            if key != 'LD_LIBRARY_PATH':
                 env[key] = str(value)
 
         # Build command based on test type

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -25,6 +25,36 @@ from pathlib import Path
 sys.stdout.reconfigure(line_buffering=True)
 
 
+def glob_filter_matches(name: str, pattern_str: str) -> bool:
+    """Return True if *name* matches the gtest-style glob filter *pattern_str*.
+
+    Syntax (same as GTest's --gtest_filter):
+      *     matches any substring
+      ?     matches any single character
+      :     separates patterns (OR)
+      -     prefix on a token negates it (exclude)
+
+    Matching is anchored to the full name and is case-sensitive.
+
+    Examples:
+      glob_filter_matches("P2P_AllTests", "P2P_*")          → True
+      glob_filter_matches("SHM_Basic",    "P2P_*")          → False
+      glob_filter_matches("P2P_AllTests", "*:-P2P*")        → False  (excluded)
+      glob_filter_matches("SHM_Basic",    "P2P_*:SHM_*")   → True   (OR)
+    """
+    def _to_re(pat: str) -> re.Pattern:
+        escaped = re.sub(r'([.+^${}()|\\])', r'\\\1', pat)
+        return re.compile('^' + escaped.replace('*', '.*').replace('?', '.') + '$')
+
+    pos, neg = [], []
+    for token in pattern_str.split(':'):
+        (neg if token.startswith('-') else pos).append(_to_re(token.lstrip('-')))
+
+    if neg and any(p.match(name) for p in neg):
+        return False
+    return (not pos) or any(p.match(name) for p in pos)
+
+
 class ExitCode(IntEnum):
     """Exit codes for processes"""
     EXIT_SUCCESS = 0
@@ -740,13 +770,23 @@ class TestExecutor:
         # Setup environment
         env = os.environ.copy()
 
-        # Build LD_LIBRARY_PATH with build dir and MPI lib (if available)
-        mpi_path = self.paths.get("mpi_path", "")
+        # Build LD_LIBRARY_PATH.  Priority order (highest → lowest):
+        #   1. build_dir          – always first so the test-built librccl.so wins
+        #   2. caller environment – LD_LIBRARY_PATH already set in the shell lets
+        #                           users point at a custom libamdhip64.so.7 without
+        #                           any special variable:
+        #                             LD_LIBRARY_PATH=/path/to/hip python3 test_runner.py ...
+        #   3. {rocm_path}/lib    – default ROCm/HIP fallback
+        #   4. mpi_path/lib       – MPI runtime
+        mpi_path  = self.paths.get("mpi_path", "")
+        rocm_path = self.paths.get("rocm_path", "/opt/rocm")
+
         ld_library_path_parts = [self.build_dir]
+        if env.get('LD_LIBRARY_PATH'):
+            ld_library_path_parts.append(env['LD_LIBRARY_PATH'])
+        ld_library_path_parts.append(os.path.join(rocm_path, "lib"))
         if mpi_path:
             ld_library_path_parts.append(os.path.join(mpi_path, "lib"))
-        if env.get('LD_LIBRARY_PATH'):
-            ld_library_path_parts.append(env.get('LD_LIBRARY_PATH'))
         env['LD_LIBRARY_PATH'] = ":".join(ld_library_path_parts)
 
         # Set LLVM_PROFILE_FILE for code coverage (prevents default.profraw
@@ -757,9 +797,16 @@ class TestExecutor:
         if self.args.coverage_report:
             env['LLVM_PROFILE_FILE'] = "rccl_tests_%p_%m.profraw"
 
-        # Add test-specific env vars
+        # Add test-specific env vars.
+        # LD_LIBRARY_PATH is treated specially: a value coming from the JSON
+        # config is prepended to the already-constructed path so that the
+        # user-supplied directory wins over the {rocm_path}/lib default without
+        # losing build_dir (which must always remain first for librccl.so).
         for key, value in merged_env.items():
-            env[key] = str(value)
+            if key == 'LD_LIBRARY_PATH' and env.get('LD_LIBRARY_PATH'):
+                env[key] = str(value) + ":" + env['LD_LIBRARY_PATH']
+            else:
+                env[key] = str(value)
 
         # Build command based on test type
         if num_ranks == 1:
@@ -983,9 +1030,9 @@ class TestExecutor:
                     print(f"\nStopping test suite execution due to rerun failure (--stop-on-rerun-failure)")
                 break
 
-            # Filter by test name if specified
+            # Filter by test name if specified (gtest-style glob; see glob_filter_matches).
             test_name = test.get("name")
-            if self.args.test_name and test_name != self.args.test_name:
+            if self.args.test_name and not glob_filter_matches(test_name, self.args.test_name):
                 skipped_count += 1
                 continue
 

--- a/projects/rccl/tools/scripts/test_runner/lib/test_parser.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_parser.py
@@ -23,8 +23,17 @@ Examples:
   # Run all tests from config
   %(prog)s -c test_config.json
 
-  # Run specific test
-  %(prog)s -c test_config.json --test-name NET_AllTests_2Nodes_ETH
+  # Run a specific individual test by exact name
+  %(prog)s -c test_config.json --test-name CE_AllGather_2Ranks
+
+  # Run multiple individual tests (colon-separated)
+  %(prog)s -c test_config.json --test-name CE_AllGather_2Ranks:CE_AlltoAll_2Ranks
+
+  # Run all suites whose name contains 'CE Tests'
+  %(prog)s -c test_config.json --suite-name "CE Tests"
+
+  # Run two specific suites by substring (colon-separated)
+  %(prog)s -c test_config.json --suite-name "CE Tests - 2-Rank:CE Tests - 4-Rank"
 
   # Run with verbose output
   %(prog)s -c test_config.json -v
@@ -64,7 +73,12 @@ Examples:
         self.parser.add_argument(
             '--test-name',
             type=str,
-            help="Run only specific test by name"
+            help="Run only tests matching any glob pattern; ':' = OR, '*' = wildcard, '-' prefix = exclude, case-sensitive (e.g. 'P2P_*' = all P2P tests; '*:-SHM*' = all except SHM)"
+        )
+        self.parser.add_argument(
+            '--suite-name',
+            type=str,
+            help="gtest-style glob filter on suite names: ':' = OR, '*' = wildcard, '-' prefix = exclude, case-sensitive (e.g. 'CE*' runs all CE suites; '*:-NET*' runs all except NET)"
         )
         self.parser.add_argument(
             '--no-build',
@@ -140,7 +154,8 @@ Examples:
             print(f"Config file:       {args.config}")
             print(f"Verbose mode:      {args.verbose}")
             print(f"Output dir:        {args.output if args.output else 'auto-generated'}")
-            print(f"Test name filter:  {args.test_name if args.test_name else 'all tests'}")
+            print(f"Test name filter:  {args.test_name if args.test_name else 'all (glob)'}")
+            print(f"Suite name filter: {args.suite_name if args.suite_name else 'all suites'}")
             print(f"No build:          {args.no_build}")
             print(f"Skip tests:        {args.skip_tests}")
             print(f"Coverage report:   {args.coverage_report}")

--- a/projects/rccl/tools/scripts/test_runner/test_runner.py
+++ b/projects/rccl/tools/scripts/test_runner/test_runner.py
@@ -11,7 +11,7 @@ import logging
 
 from lib.test_parser import ArgumentParserInterface
 from lib.test_config import TestConfigProcessor
-from lib.test_executor import TestExecutor
+from lib.test_executor import TestExecutor, glob_filter_matches
 
 # Configure logging
 logging.basicConfig(
@@ -81,22 +81,29 @@ def main():
                 print()
                 print(f"Found {len(test_suites)} test suite(s)")
 
-            # Print skip messages for disabled test suites upfront
+            # Print skip messages for disabled or filtered-out test suites upfront.
+            # --suite-name uses gtest-style glob filtering (see glob_filter_matches).
             print()
             for suite in test_suites:
                 suite_name = suite["suite_details"]["name"]
                 enabled = suite["suite_details"].get("enabled", True)
                 if not enabled:
                     print(f"SKIP: Test suite '{suite_name}' is disabled")
+                elif args.suite_name and not glob_filter_matches(suite_name, args.suite_name):
+                    print(f"SKIP: Test suite '{suite_name}' (does not match --suite-name '{args.suite_name}')")
 
-            # Run only enabled test suites
+            # Run only enabled (and name-matched) test suites
             # Note: Reruns happen immediately within run_test_suite() if --rerun-failed is set
             all_results = []
             for suite in test_suites:
+                suite_name = suite["suite_details"]["name"]
                 enabled = suite["suite_details"].get("enabled", True)
-                if enabled:
-                    results = executor.run_test_suite(suite)
-                    all_results.extend(results)
+                if not enabled:
+                    continue
+                if args.suite_name and not glob_filter_matches(suite_name, args.suite_name):
+                    continue
+                results = executor.run_test_suite(suite)
+                all_results.extend(results)
 
             # Print summary once at the end
             executor.print_summary()

--- a/projects/rccl/tools/scripts/test_runner/test_runner.py
+++ b/projects/rccl/tools/scripts/test_runner/test_runner.py
@@ -94,7 +94,6 @@ def main():
 
             # Run only enabled (and name-matched) test suites
             # Note: Reruns happen immediately within run_test_suite() if --rerun-failed is set
-            all_results = []
             for suite in test_suites:
                 suite_name = suite["suite_details"]["name"]
                 enabled = suite["suite_details"].get("enabled", True)
@@ -102,8 +101,7 @@ def main():
                     continue
                 if args.suite_name and not glob_filter_matches(suite_name, args.suite_name):
                     continue
-                results = executor.run_test_suite(suite)
-                all_results.extend(results)
+                executor.run_test_suite(suite)
 
             # Print summary once at the end
             executor.print_summary()


### PR DESCRIPTION
## Motivation

- The test runner's --suite-name used brittle substring matching, making it hard to target specific suites or exclude groups; --test-name had no filtering at all, forcing users to run entire suites.
- A shared, well-tested glob utility and accurate README documentation reduce maintenance cost and improve usability for anyone running or extending the test suite.

## Technical Details

- Replaced --suite-name substring match in test_runner.py with gtest-style glob filtering (* wildcard, ? single-char, : OR, - prefix negation), identical to --gtest_filter syntax.
- Added the same glob filtering to --test-name in test_executor.py, and extracted the shared logic into a single glob_filter_matches(name, pattern) utility exported from lib/__init__.py.
- Updated lib/test_parser.py help text and README.md to accurately document glob syntax, LD_LIBRARY_PATH priority, and RCCL_MPI_LOG_ALL_RANKS per-rank logging.

## JIRA ID

AICOMRCCL-971

## Test Plan

- Ran glob_filter_matches unit smoke tests covering wildcard, negation, OR, exact-match, and no-match cases across all 5 config files (401 tests, 70 suites).
- Verified --suite-name and --test-name glob behavior against real suite/test names from ci-precheckin.json, mi300x_mellanox_ib.json, net_ib_transport.json, rccl_perf_tests.json, and test_config_sample.json.

## Test Result

- All 7 glob smoke-test cases passed with correct match counts (*Reduce* → 108, Broadcast* → 16, *:-*Perf* → 393, etc.).
No regressions: configs with enabled: false suites are still correctly skipped regardless of filter.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
