### PR TITLE
[rocprofiler-compute][bugfix] fix membw analysis

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -60,6 +60,8 @@ TOP_STATS_BUILD_IN_CONFIG: OrderedDict[int, dict[str, Any]] = OrderedDict([
     ),
 ])
 
+EXPERIMENTAL_PANEL_ID_MEMBW: int = 3000
+
 
 # ------------------------------------
 # Helper functions for join_prof()
@@ -69,6 +71,25 @@ TOP_STATS_BUILD_IN_CONFIG: OrderedDict[int, dict[str, Any]] = OrderedDict([
 def test_df_column_equality(df: pd.DataFrame) -> bool:
     """Test if all columns in dataframe are equal."""
     return df.eq(df.iloc[:, 0], axis=0).all(1).all()
+
+
+# ------------------------------------
+# Experimental panel filtering
+# ------------------------------------
+
+
+def _filter_experimental_panels(
+    panel_configs: OrderedDict[int, dict[str, Any]],
+    membw_analysis: bool,
+) -> OrderedDict[int, dict[str, Any]]:
+    """Remove experimental panels that require opt-in flags."""
+    if membw_analysis:
+        return panel_configs
+    return OrderedDict(
+        (pid, cfg)
+        for pid, cfg in panel_configs.items()
+        if pid != EXPERIMENTAL_PANEL_ID_MEMBW
+    )
 
 
 class OmniAnalyze_Base:
@@ -139,7 +160,10 @@ class OmniAnalyze_Base:
                         / arch
                     )
                 )
-            ac.panel_configs = load_panel_configs(arch_panel_config)
+            ac.panel_configs = _filter_experimental_panels(
+                load_panel_configs(arch_panel_config),
+                membw_analysis=self.get_args().membw_analysis,
+            )
 
         # TODO: filter_metrics should/might be one per arch
         parser.build_dfs(

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -60,8 +60,6 @@ TOP_STATS_BUILD_IN_CONFIG: OrderedDict[int, dict[str, Any]] = OrderedDict([
     ),
 ])
 
-EXPERIMENTAL_PANEL_ID_MEMBW: int = 3000
-
 
 # ------------------------------------
 # Helper functions for join_prof()
@@ -71,25 +69,6 @@ EXPERIMENTAL_PANEL_ID_MEMBW: int = 3000
 def test_df_column_equality(df: pd.DataFrame) -> bool:
     """Test if all columns in dataframe are equal."""
     return df.eq(df.iloc[:, 0], axis=0).all(1).all()
-
-
-# ------------------------------------
-# Experimental panel filtering
-# ------------------------------------
-
-
-def _filter_experimental_panels(
-    panel_configs: OrderedDict[int, dict[str, Any]],
-    membw_analysis: bool,
-) -> OrderedDict[int, dict[str, Any]]:
-    """Remove experimental panels that require opt-in flags."""
-    if membw_analysis:
-        return panel_configs
-    return OrderedDict(
-        (pid, cfg)
-        for pid, cfg in panel_configs.items()
-        if pid != EXPERIMENTAL_PANEL_ID_MEMBW
-    )
 
 
 class OmniAnalyze_Base:
@@ -160,10 +139,9 @@ class OmniAnalyze_Base:
                         / arch
                     )
                 )
-            ac.panel_configs = _filter_experimental_panels(
-                load_panel_configs(arch_panel_config),
-                membw_analysis=self.get_args().membw_analysis,
-            )
+            ac.panel_configs = load_panel_configs(arch_panel_config)
+            if not self.get_args().membw_analysis:
+                ac.panel_configs.pop(3000, None)
 
         # TODO: filter_metrics should/might be one per arch
         parser.build_dfs(

--- a/projects/rocprofiler-compute/src/rocprof_compute_tui/utils/tui_utils.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_tui/utils/tui_utils.py
@@ -148,9 +148,6 @@ def process_panels_to_dataframes(
     decimal_precision = getattr(args, "decimal", 2) if args else 2
 
     for panel_id, panel in arch_configs.panel_configs.items():
-        if panel_id == 3000 and not args.membw_analysis:
-            continue
-
         if panel_id in config.HIDDEN_SECTIONS:
             continue
 

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -943,11 +943,6 @@ def show_all(
     )
 
     for panel_id, panel in arch_configs.panel_configs.items():
-        # NOTE: Experimental Feature Toggle
-        # HARD GATE: Block 30 (panel 3000) requires membw_analysis flag
-        if panel_id == 3000 and not args.membw_analysis:
-            continue
-
         # Skip panels that don't support baseline comparison
         if len(args.path) > 1 and panel_id in config.HIDDEN_SECTIONS:
             continue

--- a/projects/rocprofiler-compute/tests/test_tui_components.py
+++ b/projects/rocprofiler-compute/tests/test_tui_components.py
@@ -369,7 +369,6 @@ class TestProcessPanelsToDataframes:
 
         mock_args = MagicMock()
         mock_args.decimal = 2
-        mock_args.membw_analysis = False
 
         mock_arch_configs = MagicMock()
         mock_arch_configs.panel_configs = {}
@@ -390,7 +389,6 @@ class TestProcessPanelsToDataframes:
 
         mock_args = MagicMock()
         mock_args.decimal = 2
-        mock_args.membw_analysis = False
 
         # Create panel config with hidden section ID
         hidden_id = list(config.HIDDEN_SECTIONS)[0] if config.HIDDEN_SECTIONS else 0


### PR DESCRIPTION
## Motivation

When running `rocprof-compute analyze` on a profiled gfx950 workload, the experimental memory bandwidth panel (block 30 / panel 3000, defined in `3000_mem_bw.yaml`) was being loaded and evaluated even without `--experimental --membw-analysis`.

The root cause: the panel was loaded unconditionally by `load_panel_configs()`, and only two downstream renderers (CLI in `tty.py` and TUI in `tui_utils.py`) had guards to skip it. The DB and web UI code paths had no such guards, so block 30 metrics leaked through in those modes.

## Technical Details

A single `pop()` call in `generate_configs()` (`analysis_base.py`) removes panel 3000 from `panel_configs` immediately 
after loading, before any downstream code sees it:
``` python
ac.panel_configs = load_panel_configs(arch_panel_config)
if not self.get_args().membw_analysis:
  ac.panel_configs.pop(3000, None)
```
This covers all analysis modes (CLI, DB, TUI, web UI) because they all go through generate_configs().

## JIRA ID

AIPROFCOMP-590

## Test Plan

- CLI mode without `--membw-analysis`: `rocprof-compute analyze -p <workload> -g` produces no `TA_ADDRESSER_STALLED_CYCLES` references
- CLI mode with `--experimental --membw-analysis`: same command shows 7 occurrences of `TA_ADDRESSER_STALLED_CYCLES`
- DB mode without flag: `--output-format db` produces database with 0 block-30 metrics
- DB mode with flag: same command produces 281 Memory Bandwidth Analysis metrics

## Test Result

- [x] CLI mode without `--membw-analysis`: `rocprof-compute analyze -p <workload> -g` produces no `TA_ADDRESSER_STALLED_CYCLES` references
- [x] CLI mode with `--experimental --membw-analysis`: same command shows 7 occurrences of `TA_ADDRESSER_STALLED_CYCLES`
- [x] DB mode without flag: `--output-format db` produces database with 0 block-30 metrics
- [x] DB mode with flag: same command produces 281 Memory Bandwidth Analysis metrics

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
