### PR TITLE
rocjitsu: Refactor CP and several coherence fixes

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.cpp
@@ -15,6 +15,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
+#include <format>
 #include <linux/types.h>
 #include <sstream>
 #include <string_view>
@@ -263,10 +264,15 @@ int SimulatedDriver::open() {
   // The CP calls this after writing to a completion signal's event mailbox,
   // waking any thread blocked in wait_events_ioctl.
   cp_->set_interrupt_callback([this](uint32_t event_id) {
-    {
-      std::lock_guard<std::mutex> lock(event_mutex_);
-      if (auto it = events_.find(event_id); it != events_.end())
-        it->second.signaled = true;
+    std::lock_guard<std::mutex> lock(event_mutex_);
+    if (auto it = events_.find(event_id); it != events_.end() && !it->second.signaled) {
+      it->second.signaled = true;
+    }
+    if (event_page_) {
+      auto *slots = static_cast<uint64_t *>(event_page_);
+      uint32_t limit = static_cast<uint32_t>(event_page_size_ / sizeof(uint64_t));
+      if (event_id < limit)
+        std::atomic_ref<uint64_t>(slots[event_id]).store(1, std::memory_order_release);
     }
     event_cv_.notify_all();
   });
@@ -872,6 +878,11 @@ int SimulatedDriver::create_event_ioctl(void *arg) {
   args->event_trigger_data = ev.event_id;
   args->event_slot_index = ev.event_id;
   args->event_page_offset = KFD_MMAP_TYPE_EVENTS | kfd_mmap_gpu_id(gpu_id_);
+
+  util::Logger::vm([&](auto &os) {
+    os << std::format("CREATE_EVENT id={} slot={} type={} auto_reset={}", ev.event_id,
+                      args->event_slot_index, args->event_type, ev.auto_reset);
+  });
   return 0;
 }
 
@@ -1124,24 +1135,7 @@ int SimulatedDriver::wait_events_ioctl(void *arg) {
     return false;
   };
 
-  // One-shot trace: log what WAIT_EVENTS is looking for.
-  {
-    static thread_local int wait_trace_count = 0;
-    if (++wait_trace_count <= 3) {
-      for (uint32_t i = 0; i < args->num_events; ++i) {
-        uint32_t id = ev_data[i].event_id;
-        bool in_map = events_.count(id) > 0;
-        bool map_signaled = in_map && events_[id].signaled;
-        uint64_t slot_val = 0;
-        if (event_page_ && id < event_page_size_ / sizeof(uint64_t))
-          slot_val = static_cast<uint64_t *>(event_page_)[id];
-        util::Logger::vm("WAIT_EVENTS[", i, "] event_id=", id, " in_map=", in_map,
-                         " map_signaled=", map_signaled, " slot_val=", slot_val,
-                         " event_page_=", (event_page_ ? 1 : 0), " page_size=", event_page_size_,
-                         " wait_for_all=", args->wait_for_all, " timeout=", args->timeout);
-      }
-    }
-  }
+  static const bool sync_trace = std::getenv("RJ_SYNC_TRACE") != nullptr;
 
   auto pred = [this, args, ev_data, &is_signaled]() -> bool {
     if (closing_)
@@ -1191,6 +1185,9 @@ int SimulatedDriver::wait_events_ioctl(void *arg) {
       return -EBADF;
     args->wait_result = pred() ? 0 : 1;
   }
+
+  if (sync_trace && args->wait_result == 0)
+    util::Logger::vm("WAIT_EVENTS result=0 (signaled)");
 
   // Auto-reset signaled events from the requested set.
   for (uint32_t i = 0; i < args->num_events; ++i) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/CMakeLists.txt
@@ -6,6 +6,7 @@ rj_add_object_library(rocjitsu_vm_amdgpu
     compute_unit.cpp
     memory_pipeline.cpp
     command_processor.cpp
+    completion_tracker.cpp
     shader_engine.cpp
     xcd.cpp
     iod.cpp

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -178,6 +178,12 @@ void CommandProcessor::startup() {
 }
 
 void CommandProcessor::register_queue(HwQueue queue) {
+  util::Logger::vm([&](auto &os) {
+    os << std::format("REGISTER_QUEUE id={} ring={:#x} size={} rptr={:#x} wptr={:#x} "
+                      "doorbell_off={} is_sdma={}",
+                      queue.queue_id, queue.ring_base_va, queue.ring_size, queue.read_ptr_va,
+                      queue.write_ptr_va, queue.doorbell_offset, queue.is_sdma);
+  });
   bool start_poll = queue.host_accessible;
   {
     std::lock_guard<std::mutex> lock(hw_queue_mutex_);
@@ -622,6 +628,14 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   }
 
   plugin_group_->onAmdgpuKernelDispatch(pkt.kernel_object, entry_pc);
+  util::Logger::vm([&](auto &os) {
+    os << std::format("DISPATCH d={} pc={:#x} grid=[{},{},{}] wg=[{},{},{}] total_wgs={} "
+                      "sgprs={} vgprs={} lds={} kernarg={:#x}",
+                      dp.dispatch_id, entry_pc, dp.grid_wgs_x, dp.grid_wgs_y, dp.grid_wgs_z,
+                      pkt.workgroup_size_x, pkt.workgroup_size_y, pkt.workgroup_size_z, total_wgs,
+                      dp.sgprs_per_wf, dp.vgprs_per_wf, dp.group_segment_fixed_size,
+                      dp.kernarg_addr);
+  });
 
   {
     static uint32_t dispatch_count = 0;
@@ -672,6 +686,13 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs) {
     write_idx = read_gpu_u64(queue.write_ptr_va);
     read_idx = read_gpu_u64(queue.read_ptr_va);
   }
+
+  util::Logger::vm([&](auto &os) {
+    static uint64_t fetch_count = 0;
+    if (write_idx != read_idx && ++fetch_count <= 50)
+      os << std::format("FETCH q={} w={} r={} delta={} sdma={}", queue.queue_id, write_idx,
+                        read_idx, write_idx - read_idx, queue.is_sdma);
+  });
 
   // SDMA queues use byte-granularity pointers and have their own doorbell
   // semantics — skip the AQL doorbell clamping that assumes packet indices.
@@ -725,6 +746,10 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs) {
     }
 
     uint8_t pkt_type = pkt.header & 0xFF;
+    util::Logger::vm([&](auto &os) {
+      os << std::format("PKT q={} slot={} type={} header={:#x} read_idx={}", queue.queue_id, slot,
+                        pkt_type, pkt.header, read_idx);
+    });
 
     // INVALID packet: the producer reserved this slot but hasn't written the
     // header yet. Stop fetching — the doorbell poll thread will fire another
@@ -747,7 +772,9 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs) {
       // stop fetching from this queue. The next doorbell event will retry.
       // This prevents blocking the CP from processing other queues (SDMA)
       // that may be responsible for satisfying these dependencies.
-      bool deps_satisfied = true;
+      bool deps_satisfied =
+          is_and; // AND: assume true until a dep fails; OR: assume false until one passes
+      bool has_deps = false;
       for (int dep = 0; dep < 5; ++dep) {
         uint64_t dep_sig = 0;
         if (queue.host_accessible)
@@ -757,6 +784,7 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs) {
           dep_sig = read_gpu_u64(pkt_addr + DEP_OFF + dep * 8);
         if (dep_sig == 0)
           continue;
+        has_deps = true;
         auto *val = reinterpret_cast<int64_t *>(dep_sig + SIG_VAL_OFF);
         int64_t v = std::atomic_ref<int64_t>(*val).load(std::memory_order_acquire);
         if (v > 0) {
@@ -765,10 +793,14 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs) {
             break;
           }
         } else {
-          if (!is_and)
-            break; // OR: one satisfied is enough.
+          if (!is_and) {
+            deps_satisfied = true;
+            break;
+          }
         }
       }
+      if (!has_deps)
+        deps_satisfied = true;
       if (!deps_satisfied) {
         // Dependencies not ready. Stop fetching — don't advance read pointer
         // past this packet. Schedule a re-check via doorbell event.
@@ -977,6 +1009,25 @@ void CommandProcessor::handle_doorbell(simdojo::Tick) {
   if (completion_)
     completion_->drain_completions(new_queue_states_);
 
+  // Re-fetch: pick up any packets the host submitted while we were executing
+  // (e.g., barrier packets queued after a kernel dispatch). Process them
+  // immediately so host signal waits see completed barriers before returning.
+  for (size_t i = 0; i < hw_queues_.size(); ++i)
+    fetch_from_queue(hw_queues_[i], new_queue_states_[i]);
+  // Process any new non-kernel entries (barriers with total_wgs==0).
+  for (size_t qi = 0; qi < hw_queues_.size(); ++qi) {
+    auto &qs = new_queue_states_[qi];
+    while (qs.next_dispatch_idx < qs.entries.size()) {
+      auto &entry = qs.entries[qs.next_dispatch_idx];
+      if (!entry.is_non_kernel())
+        break;
+      entry.completed_wgs = entry.total_wgs;
+      ++qs.next_dispatch_idx;
+    }
+  }
+  if (completion_)
+    completion_->drain_completions(new_queue_states_);
+
   // Register as primary on first dispatch.
   if (!is_primary_ && pending_entries() > 0) {
     engine()->register_as_primary();
@@ -1068,6 +1119,17 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
       uint32_t count = (dw(1) & 0x3FFFFFF) + 1;
       uint64_t src = static_cast<uint64_t>(dw(3)) | (static_cast<uint64_t>(dw(4)) << 32);
       uint64_t dst = static_cast<uint64_t>(dw(5)) | (static_cast<uint64_t>(dw(6)) << 32);
+      util::Logger::vm("SDMA COPY: src=", std::hex, src, " dst=", dst, std::dec, " count=", count,
+                       " (", count / 1024, " KB)");
+      if (dst <= 0x4d08242f10 && dst + count > 0x4d08242f00) {
+        uint64_t off = 0x4d08242f08 - dst;
+        if (off + 4 <= count) {
+          uint32_t val = 0;
+          std::memcpy(&val, reinterpret_cast<const uint8_t *>(src) + off, 4);
+          util::Logger::vm("SDMA WATCHPOINT: copying ", std::hex, val, std::dec,
+                           " to NaN address 0x4d08242f08");
+        }
+      }
       if (header & (1u << 28)) {
         // Broadcast copy (2 destinations) — 9 dwords.
         uint64_t dst2 = static_cast<uint64_t>(dw(7)) | (static_cast<uint64_t>(dw(8)) << 32);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -18,6 +18,8 @@ RJ_DIAGNOSTIC_POP
 #include <chrono>
 #include <cstring>
 #include <elf.h>
+#include <format>
+#include <limits>
 #include <set>
 #include <string>
 #include <sys/mman.h>
@@ -27,7 +29,7 @@ namespace rocjitsu {
 namespace amdgpu {
 
 void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
-                                           const InternalDispatch &pkt, uint32_t global_wg_id,
+                                           const DispatchEntry &pkt, uint32_t global_wg_id,
                                            uint32_t wf_index_in_wg) {
   using namespace rocr::llvm::amdhsa;
   uint32_t sbase = wf->sgpr_alloc().base;
@@ -111,19 +113,6 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
       cu->write_sgpr(sbase + sys_idx++, global_wg_id / (gx * gy));
   }
 
-  util::Logger::vm([&](auto &os) {
-    static thread_local uint64_t init_count = 0;
-    if (++init_count <= 200 && wf_index_in_wg == 0)
-      os << std::format("CP: init_wf #{} cu={} global_wg={} s[{}]=({},{},{})"
-                        " grid_wgs=({},{},{}) enable_x={} enable_y={} enable_z={}",
-                        init_count, cu->name(), global_wg_id, pkt.num_user_sgprs,
-                        cu->read_sgpr(sbase + pkt.num_user_sgprs),
-                        pkt.enable_wg_id_y ? cu->read_sgpr(sbase + pkt.num_user_sgprs + 1) : 0u,
-                        pkt.enable_wg_id_z ? cu->read_sgpr(sbase + pkt.num_user_sgprs + 2) : 0u,
-                        pkt.grid_wgs_x, pkt.grid_wgs_y, pkt.grid_wgs_z, pkt.enable_wg_id_x,
-                        pkt.enable_wg_id_y, pkt.enable_wg_id_z);
-  });
-
   // Workitem IDs per AMDHSA ABI. The SPI decomposes the flat thread index
   // into (x, y, z) using the AQL packet's workgroup dimensions.
   // enable_vgpr_workitem_id (TIDIG_COMP_CNT from compute_pgm_rsrc2):
@@ -133,7 +122,6 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
   // On CDNA3/4 (PackedTID): v0[9:0]=X, v0[19:10]=Y, v0[29:20]=Z.
   // v1/v2 are not written. Kernel extracts components via bit masks.
   uint32_t vbase = wf->vgpr_alloc().base;
-  uint32_t sbase_dbg = wf->sgpr_alloc().base;
   uint32_t workitem_base = wf_index_in_wg * cu->wf_size();
   uint32_t wg_x = pkt.workgroup_size_x > 0 ? pkt.workgroup_size_x : 1;
   uint32_t wg_y = pkt.workgroup_size_y > 0 ? pkt.workgroup_size_y : 1;
@@ -154,11 +142,6 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
         cu->write_vgpr(vbase + 2, lane, id_z);
     }
   }
-  util::Logger::vm([&](auto &os) {
-    os << std::format("{} wg[{}] wf[{}] init: wf_idx_in_wg={} vbase={} sbase={} workitem_base={}",
-                      cu->full_path(), global_wg_id, wf->wf_id(), wf_index_in_wg, vbase, sbase_dbg,
-                      workitem_base);
-  });
 
   // Scratch (private segment) setup.
   // Each wavefront gets a unique slice of scratch memory. The per-lane
@@ -189,6 +172,9 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
 void CommandProcessor::startup() {
   doorbell_event_.set_handler(
       [this](simdojo::Tick ts, simdojo::Message *) { handle_doorbell(ts); });
+  completion_ = std::make_unique<CompletionTracker>(memory_, cus_);
+  if (interrupt_cb_)
+    completion_->set_interrupt_callback(interrupt_cb_);
 }
 
 void CommandProcessor::register_queue(HwQueue queue) {
@@ -196,6 +182,7 @@ void CommandProcessor::register_queue(HwQueue queue) {
   {
     std::lock_guard<std::mutex> lock(hw_queue_mutex_);
     hw_queues_.push_back(std::move(queue));
+    new_queue_states_.push_back(HwQueueState{});
     if (!is_primary_ && engine()) {
       engine()->register_as_primary();
       is_primary_ = true;
@@ -215,7 +202,13 @@ void CommandProcessor::unregister_queue(uint32_t queue_id) {
   bool empty = false;
   {
     std::lock_guard<std::mutex> lock(hw_queue_mutex_);
-    std::erase_if(hw_queues_, [queue_id](const HwQueue &q) { return q.queue_id == queue_id; });
+    for (size_t i = 0; i < hw_queues_.size(); ++i) {
+      if (hw_queues_[i].queue_id == queue_id) {
+        hw_queues_.erase(hw_queues_.begin() + static_cast<ptrdiff_t>(i));
+        new_queue_states_.erase(new_queue_states_.begin() + static_cast<ptrdiff_t>(i));
+        break;
+      }
+    }
     empty = hw_queues_.empty();
   }
   if (empty)
@@ -292,239 +285,151 @@ void CommandProcessor::doorbell_poll_loop(std::stop_token stop) {
   }
 }
 
-bool CommandProcessor::step() {
-  if (dispatched_ >= dispatch_queue_.size())
-    return false;
-
-  assert(!cus_.empty() && "command processor has no compute units");
-  util::Logger::vm([&](auto &os) {
-    static bool first = true;
-    if (first) {
-      first = false;
-      os << std::format("CP: {} CUs registered:", cus_.size());
-      for (size_t i = 0; i < cus_.size(); ++i) {
-        os << std::format("\n[rj log VM]   cu[{}] = {} wf_slots={}", i, cus_[i]->name(),
-                          cus_[i]->num_wf_slots());
-      }
+HwQueueState *CommandProcessor::schedule_next_queue() {
+  if (new_queue_states_.empty())
+    return nullptr;
+  size_t start = next_queue_idx_;
+  for (size_t i = 0; i < new_queue_states_.size(); ++i) {
+    size_t idx = (start + i) % new_queue_states_.size();
+    auto &qs = new_queue_states_[idx];
+    if (hw_queues_[idx].is_sdma)
+      continue;
+    if (qs.next_dispatch_idx < qs.entries.size()) {
+      next_queue_idx_ = (idx + 1) % new_queue_states_.size();
+      return &qs;
     }
-  });
+  }
+  return nullptr;
+}
 
-  const InternalDispatch &pkt = dispatch_queue_[dispatched_++];
+bool CommandProcessor::barrier_satisfied(const HwQueueState &qs, size_t idx) const {
+  if (idx == 0 && !qs.implicit_barrier_next)
+    return true;
+
+  // Barrier bit: all prior entries must be fully completed.
+  for (size_t i = 0; i < idx; ++i) {
+    if (!qs.entries[i].fully_completed())
+      return false;
+  }
+  return true;
+}
+
+uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
+  assert(!cus_.empty() && "command processor has no compute units");
 
   // Activate wavefront slots for each workgroup, distributing across CUs.
   // Entire workgroups must land on a single CU (programming model requirement:
   // LDS is per-CU and s_barrier synchronises within a CU). Query each CU for
   // capacity before dispatching to guarantee all-or-nothing placement.
-  for (uint32_t wg = 0; wg < pkt.workgroup_count; ++wg) {
-    uint32_t global_wg_id = wg + pkt.workgroup_id_offset;
-    bool wg_dispatched = false;
+  uint32_t dispatched = 0;
+  while (entry.dispatched_wgs < entry.total_wgs) {
+    uint32_t global_wg_id = entry.dispatched_wgs + entry.workgroup_id_offset;
+    bool placed = false;
 
-    for (size_t attempt = 0; attempt < cus_.size() && !wg_dispatched; ++attempt) {
+    for (size_t attempt = 0; attempt < cus_.size() && !placed; ++attempt) {
       size_t cu_idx = (next_cu_ + attempt) % cus_.size();
       ComputeUnitCore *cu = cus_[cu_idx];
       cu->retire_halted_wfs();
-      if (!cu->can_accept_workgroup(pkt.wfs_per_workgroup, pkt.group_segment_fixed_size))
+      if (!cu->can_accept_workgroup(entry.wfs_per_workgroup, entry.group_segment_fixed_size))
         continue;
-      uint32_t lds_base = cu->allocate_lds(pkt.group_segment_fixed_size);
+
+      uint32_t lds_base = cu->allocate_lds(entry.group_segment_fixed_size);
+      cu->begin_workgroup(entry.dispatch_id, global_wg_id, entry.wfs_per_workgroup);
+
       std::vector<Wavefront *> wg_wavefronts;
-      wg_wavefronts.reserve(pkt.wfs_per_workgroup);
-      for (uint32_t w = 0; w < pkt.wfs_per_workgroup; ++w) {
-        Wavefront *wf =
-            cu->dispatch_wf(global_wg_id, pkt.kernel_entry_pc, pkt.sgprs_per_wf, pkt.vgprs_per_wf);
+      wg_wavefronts.reserve(entry.wfs_per_workgroup);
+      for (uint32_t w = 0; w < entry.wfs_per_workgroup; ++w) {
+        Wavefront *wf = cu->dispatch_wf(global_wg_id, entry.kernel_entry_pc, entry.sgprs_per_wf,
+                                        entry.vgprs_per_wf);
         assert(wf && "dispatch_wf failed after can_accept_workgroup returned true");
         wf->set_lds_base(lds_base);
-        init_wavefront_regs(cu, wf, pkt, global_wg_id, w);
+        wf->set_dispatch_id(entry.dispatch_id);
+        init_wavefront_regs(cu, wf, entry, global_wg_id, w);
         wg_wavefronts.push_back(wf);
       }
-      plugin_group_->onAmdgpuDispatchWorkgroup(global_wg_id, pkt.vgprs_per_wf, pkt.sgprs_per_wf,
+      plugin_group_->onAmdgpuDispatchWorkgroup(global_wg_id, entry.vgprs_per_wf, entry.sgprs_per_wf,
                                                std::span<Wavefront *>(wg_wavefronts));
       next_cu_ = (cu_idx + 1) % cus_.size();
-      wg_dispatched = true;
+      placed = true;
     }
 
-    if (!wg_dispatched) {
-      util::Logger::vm("CP step: all CUs full at wg=", wg, " global_wg=", global_wg_id,
-                       " total=", pkt.workgroup_count, " offset=", pkt.workgroup_id_offset);
-      InternalDispatch retry_pkt = pkt;
-      retry_pkt.workgroup_count = pkt.workgroup_count - wg;
-      retry_pkt.workgroup_id_offset = pkt.workgroup_id_offset + wg;
-      dispatch_queue_[dispatched_ - 1].completion_signal = 0;
-      retry_queue_.push_back(std::move(retry_pkt));
-      break;
-    }
+    if (!placed)
+      break; // Backpressure: all CUs full. Will resume when WG completes.
+
+    ++entry.dispatched_wgs;
+    ++dispatched;
   }
-
-  return dispatched_ < dispatch_queue_.size();
+  return dispatched;
 }
 
-void CommandProcessor::check_all_idle() {
-  for (auto *cu : cus_)
-    if (!cu->is_idle())
-      return;
+// ---------------------------------------------------------------------------
+// Completion notification from CU
+// ---------------------------------------------------------------------------
 
-  // If retry queue has pending workgroups, move them to the dispatch queue and
-  // process immediately. This avoids scheduling a future event which requires the
-  // engine event loop to advance — in direct-activate mode (functional, quantum=0)
-  // the engine may not process future events between doorbell callbacks.
-  if (!retry_queue_.empty()) {
-    util::Logger::vm("CP: retry ", retry_queue_.size(),
-                     " entries, total_wgs=", retry_queue_[0].workgroup_count,
-                     " offset=", retry_queue_[0].workgroup_id_offset);
-    for (auto &rpkt : retry_queue_)
-      dispatch_queue_.push_back(std::move(rpkt));
-    retry_queue_.clear();
-    // Dispatch and activate CUs for the retry workgroups.
-    while (dispatched_ < dispatch_queue_.size()) {
-      step();
-      uint32_t activated = 0;
-      for (auto *cu : cus_) {
-        if (cu->has_active_wfs()) {
-          cu->activate();
-          ++activated;
-        }
-      }
-      // Wait for CUs to finish (in direct mode, activate() calls advance() synchronously).
-      bool any_active = false;
-      for (auto *cu : cus_)
-        if (!cu->is_idle()) {
-          any_active = true;
-          break;
-        }
-      util::Logger::vm("CP: retry inner: activated=", activated, " any_active=", any_active,
-                       " retry_q=", retry_queue_.size());
-      if (!any_active)
-        continue; // All idle, try next dispatch.
-      break;      // CUs still running (shouldn't happen in sync mode).
-    }
-    // Recurse to handle further retries or signal completion.
-    check_all_idle();
-    return;
-  }
+void CommandProcessor::notify_wg_complete(uint32_t dispatch_id, uint32_t wg_id) {
+  if (completion_)
+    completion_->notify_wg_complete(dispatch_id, wg_id, new_queue_states_);
+  // In functional mode (quantum=0), the handle_doorbell loop handles dispatch
+  // resume. In quantum>0 mode, CU work events will call on_cu_idle which can
+  // trigger further dispatch via the engine event loop.
+}
 
-  // Flush all CU caches to backing memory. Real hardware does this implicitly
-  // (L2 writeback on kernel completion). Without this, stores using RW (write-
-  // back) mtype remain in L2 and never reach host-mapped GpuMemory pages.
-  for (auto *cu : cus_)
-    cu->flush_all();
-
-  util::Logger::vm([&](auto &os) {
-    if (dispatched_ > 0 && memory_) {
-      auto &dp0 = dispatch_queue_[0];
-      if (dp0.kernarg_addr != 0) {
-        uint64_t ka0 = memory_->read64(dp0.kernarg_addr);
-        uint64_t ka1 = memory_->read64(dp0.kernarg_addr + 8);
-        os << std::format("CP: post-flush kernarg[0]={:#x} kernarg[1]={:#x}", ka0, ka1);
-      }
-    }
-  });
-
-  // Signal completion for all dispatched kernel packets whose wavefronts have
-  // finished. In real hardware, the CP microcode does this automatically.
-  for (size_t i = 0; i < dispatched_; ++i) {
-    auto &dp = dispatch_queue_[i];
-    if (dp.completion_signal == 0)
-      continue;
-    constexpr uint32_t SIG_VAL_OFF = 8;
-    constexpr uint32_t MAILBOX_PTR_OFF = 16;
-    constexpr uint32_t EVENT_ID_OFF = 24;
-    if (dp.host_signal) {
-      auto *val = reinterpret_cast<int64_t *>(dp.completion_signal + SIG_VAL_OFF);
-      auto old_val = std::atomic_ref<int64_t>(*val).fetch_sub(1, std::memory_order_release);
-      util::Logger::vm("CP: signal 0x", std::hex, dp.completion_signal, std::dec, " val ", old_val,
-                       " -> ", old_val - 1);
-      // Write event mailbox and fire interrupt so ROCR's signal wait wakes up.
-      auto mailbox_ptr = *reinterpret_cast<uint64_t *>(dp.completion_signal + MAILBOX_PTR_OFF);
-      util::Logger::vm("CP: signal mailbox_ptr=0x", std::hex, mailbox_ptr, std::dec,
-                       " has_interrupt_cb=", (interrupt_cb_ ? 1 : 0));
-      if (mailbox_ptr != 0) {
-        auto event_id = *reinterpret_cast<uint32_t *>(dp.completion_signal + EVENT_ID_OFF);
-        util::Logger::vm("CP: writing event_id=", event_id, " to mailbox 0x", std::hex, mailbox_ptr,
-                         std::dec);
-        std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(mailbox_ptr))
-            .store(uint64_t(event_id), std::memory_order_release);
-        if (interrupt_cb_)
-          interrupt_cb_(event_id);
-      }
-    } else if (memory_) {
-      auto old = static_cast<int64_t>(memory_->read64(dp.completion_signal + SIG_VAL_OFF));
-      memory_->write64(dp.completion_signal + SIG_VAL_OFF, static_cast<uint64_t>(old - 1));
-    }
-    dp.completion_signal = 0; // Signal only once.
-  }
-
-  // Enforce in-order dispatch for ordered (KFD) queue entries: start the next
-  // pending kernel only after all wavefronts from the previous dispatch have
-  // completed. This mirrors real hardware where an ordered AQL queue executes
-  // dispatches sequentially. Unordered (test) dispatches are not re-dispatched
-  // here; they were already all submitted in handle_doorbell.
+void CommandProcessor::on_cu_idle() {
+  // In quantum=0 mode, handle_doorbell drives the dispatch-execute-complete
+  // loop synchronously. on_cu_idle fires INSIDE activate(), which is INSIDE
+  // handle_doorbell's dispatch loop. Dispatching more WGs here would re-enter
+  // dispatch_workgroups and cause double-dispatch. So skip in quantum=0.
   //
-  // Loop (not recursion) to handle consecutive zero-workgroup dispatches
-  // (e.g. back-to-back BARRIER_AND packets) without growing the call stack.
-  while (dispatched_ < dispatch_queue_.size() && dispatch_queue_[dispatched_].ordered) {
-    size_t prev = dispatched_;
-    step();
-    if (dispatched_ <= prev)
-      break;
-    std::set<ComputeUnitCore *> new_cus;
-    for (auto *cu : cus_)
-      if (cu->has_active_wfs())
-        new_cus.insert(cu);
-    for (size_t i = 0; i < cus_.size(); ++i) {
-      if (new_cus.count(cus_[i]) == 0)
-        continue;
-      if (dispatch_ports_[i]->link())
-        dispatch_ports_[i]->send(std::make_unique<simdojo::Message>(simdojo::MessageHeader{}));
-      else
-        cus_[i]->activate();
-    }
-    if (!new_cus.empty())
-      return; // CUs have work; they call check_all_idle when done.
-    // Zero-workgroup dispatch (e.g. BARRIER_AND): no CUs activated so no
-    // on_idle callback will ever fire for this entry. Signal its completion
-    // now before looping to the next ordered entry.
-    for (size_t i = prev; i < dispatched_; ++i) {
-      auto &dp = dispatch_queue_[i];
-      if (dp.completion_signal == 0)
-        continue;
-      constexpr uint32_t SIG_VAL_OFF = 8;
-      auto *val = reinterpret_cast<int64_t *>(dp.completion_signal + SIG_VAL_OFF);
-      if (dp.host_signal) {
-        std::atomic_ref<int64_t>(*val).fetch_sub(1, std::memory_order_release);
-        // Write the event mailbox and fire the interrupt so WAIT_EVENTS wakes.
-        constexpr uint32_t MAILBOX_PTR_OFF = 16, EVENT_ID_OFF = 24;
-        auto mailbox_ptr = *reinterpret_cast<uint64_t *>(dp.completion_signal + MAILBOX_PTR_OFF);
-        if (mailbox_ptr != 0) {
-          auto event_id = *reinterpret_cast<uint32_t *>(dp.completion_signal + EVENT_ID_OFF);
-          std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(mailbox_ptr))
-              .store(uint64_t(event_id), std::memory_order_release);
-          if (interrupt_cb_)
-            interrupt_cb_(event_id);
-        }
-      } else if (memory_) {
-        auto old = static_cast<int64_t>(memory_->read64(dp.completion_signal + SIG_VAL_OFF));
-        memory_->write64(dp.completion_signal + SIG_VAL_OFF, static_cast<uint64_t>(old - 1));
+  // In quantum>0 mode, CU execution is asynchronous (via work events). When
+  // a CU finishes its quantum and goes idle, we should drain completions and
+  // resume stalled dispatches. This is safe because we're not inside
+  // handle_doorbell's dispatch loop.
+  if (!cus_.empty() && cus_[0]->config().functional_quantum == 0)
+    return;
+
+  if (completion_)
+    completion_->drain_completions(new_queue_states_);
+
+  for (auto &qs : new_queue_states_) {
+    if (qs.next_dispatch_idx < qs.entries.size()) {
+      auto &entry = qs.entries[qs.next_dispatch_idx];
+      if (!entry.is_non_kernel() && !entry.fully_dispatched()) {
+        uint32_t sent = dispatch_workgroups(entry);
+        if (sent > 0 && entry.fully_dispatched())
+          ++qs.next_dispatch_idx;
       }
-      dp.completion_signal = 0;
     }
   }
+}
 
-  if (pending_dispatches() == 0 && is_primary_) {
-    // Only release primary if no host-accessible (KFD) queues are registered.
-    // KFD queues can receive new work at any time; the doorbell poll must stay
-    // active to detect future dispatches.
-    bool has_kfd_queues = false;
-    {
-      std::lock_guard<std::mutex> lock(hw_queue_mutex_);
-      for (const auto &q : hw_queues_)
-        if (q.host_accessible) {
-          has_kfd_queues = true;
-          break;
-        }
-    }
-    if (!has_kfd_queues) {
-      stop_doorbell_monitor();
-      engine()->primary_release();
-      is_primary_ = false;
+bool CommandProcessor::step() {
+  // Process dispatches across all queues.
+  process_queues();
+  return pending_entries() > 0;
+}
+
+void CommandProcessor::process_queues() {
+  for (size_t qi = 0; qi < new_queue_states_.size(); ++qi) {
+    if (hw_queues_[qi].is_sdma)
+      continue;
+    auto &qs = new_queue_states_[qi];
+    while (qs.next_dispatch_idx < qs.entries.size()) {
+      auto &entry = qs.entries[qs.next_dispatch_idx];
+
+      if (entry.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
+        break; // Stalled on barrier bit.
+
+      if (entry.is_non_kernel()) {
+        entry.completed_wgs = entry.total_wgs; // 0 == 0, immediately complete.
+        ++qs.next_dispatch_idx;
+        continue;
+      }
+
+      uint32_t sent = dispatch_workgroups(entry);
+      if (entry.fully_dispatched())
+        ++qs.next_dispatch_idx;
+      if (sent == 0)
+        break; // CU backpressure.
     }
   }
 }
@@ -566,12 +471,6 @@ static std::string find_kernel_symbol(uint64_t kernel_object, GpuMemory *mem) {
     return {};
 
   auto *phdrs = reinterpret_cast<const Elf64_Phdr *>(elf_base + ehdr->e_phoff);
-
-  // Read the kernel descriptor at kernel_object for matching fields.
-  auto *ko = reinterpret_cast<const uint8_t *>(kernel_object);
-  uint32_t kd_group_seg = 0, kd_private_seg = 0;
-  std::memcpy(&kd_group_seg, ko, 4);
-  std::memcpy(&kd_private_seg, ko + 4, 4);
 
   // Find PT_NOTE containing AMDHSA metadata.
   for (uint16_t i = 0; i < ehdr->e_phnum; ++i) {
@@ -620,7 +519,8 @@ static std::string find_kernel_symbol(uint64_t kernel_object, GpuMemory *mem) {
 }
 
 void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pkt,
-                                          const HwQueue &queue, uint64_t pkt_addr) {
+                                          const HwQueue &queue, uint64_t pkt_addr,
+                                          HwQueueState &qs) {
   bool host_accessible = queue.host_accessible;
   using namespace rocr::llvm::amdhsa;
   kernel_descriptor_t kd = read_kernel_descriptor(pkt.kernel_object, host_accessible);
@@ -630,10 +530,6 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
       AMDHSA_BITS_GET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT);
   uint32_t vgprs = (vgpr_gran + 1) * vgpr_granularity_;
   uint32_t sgprs = (sgpr_gran + 1) * 8;
-  util::Logger::vm([&](auto &os) {
-    os << std::format("CP: rsrc1={:#x} vgpr_gran={} vgprs={} sgpr_gran={} sgprs={} gran={}",
-                      kd.compute_pgm_rsrc1, vgpr_gran, vgprs, sgpr_gran, sgprs, vgpr_granularity_);
-  });
   uint32_t user_sgprs = AMDHSA_BITS_GET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_USER_SGPR_COUNT);
   uint64_t entry_pc = pkt.kernel_object + static_cast<uint64_t>(kd.kernel_code_entry_byte_offset);
 
@@ -647,25 +543,6 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
     constexpr size_t CODE_MAP_SIZE = 2 << 20;           // 2MB to cover large code objects.
     memory_->map_host_pages(code_base, reinterpret_cast<void *>(code_base), CODE_MAP_SIZE);
 
-    util::Logger::vm([&](auto &os) {
-      auto *host_ptr = reinterpret_cast<const uint32_t *>(entry_pc);
-      uint32_t gpu_w0 = memory_->fetch32(entry_pc);
-      os << std::format("CP: entry_pc code: host=[{:#x},{:#x},{:#x},{:#x}] gpu=[{:#x}]",
-                        host_ptr[0], host_ptr[1], host_ptr[2], host_ptr[3], gpu_w0);
-      auto *ko_ptr = reinterpret_cast<const uint32_t *>(pkt.kernel_object);
-      os << std::format("\n[rj log VM] CP: kernel_obj data: [{:#x},{:#x},{:#x},{:#x}] code_off={}",
-                        ko_ptr[0], ko_ptr[1], ko_ptr[2], ko_ptr[3],
-                        kd.kernel_code_entry_byte_offset);
-      auto karg_ptr = reinterpret_cast<const uint64_t *>(pkt.kernarg_address);
-      if (karg_ptr) {
-        os << std::format("\n[rj log VM] CP: kernarg q[0:5]={:#x} {:#x} {:#x} {:#x} {:#x} {:#x}",
-                          karg_ptr[0], karg_ptr[1], karg_ptr[2], karg_ptr[3], karg_ptr[4],
-                          karg_ptr[5]);
-        auto karg_dw = reinterpret_cast<const uint32_t *>(pkt.kernarg_address);
-        os << std::format("\n[rj log VM] CP: kernarg dw[16:20]={} {} {} {} {}", karg_dw[16],
-                          karg_dw[17], karg_dw[18], karg_dw[19], karg_dw[20]);
-      }
-    });
     // Register the kernarg region. Map enough pages to cover the full kernarg
     // buffer. PyTorch reduction kernels can have kernarg buffers exceeding 4KB
     // (TensorIterator packs many pointers, strides, and flags).
@@ -674,21 +551,6 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
       uint64_t karg_base = karg & ~0xFFFULL;
       constexpr size_t KARG_MAP_SIZE = 8 * 4096; // 32KB covers large kernarg buffers.
       memory_->map_host_pages(karg_base, reinterpret_cast<void *>(karg_base), KARG_MAP_SIZE);
-      // Verify: read back from GpuMemory and compare to host.
-      util::Logger::vm([&](auto &os) {
-        uint32_t host_val = *reinterpret_cast<const uint32_t *>(karg + 0x50);
-        uint32_t gpu_val = 0;
-        for (int b = 0; b < 4; ++b)
-          reinterpret_cast<uint8_t *>(&gpu_val)[b] = memory_->read8(karg + 0x50 + b);
-        os << std::format("CP: kernarg verify @0x50: host={:#x} gpu={:#x} {}", host_val, gpu_val,
-                          host_val == gpu_val ? "MATCH" : "MISMATCH!");
-        uint32_t host14 = *reinterpret_cast<const uint32_t *>(karg + 0x14);
-        uint32_t gpu14 = 0;
-        for (int b = 0; b < 4; ++b)
-          reinterpret_cast<uint8_t *>(&gpu14)[b] = memory_->read8(karg + 0x14 + b);
-        os << std::format("\n[rj log VM] CP: kernarg verify @0x14: host={:#x} gpu={:#x} {}", host14,
-                          gpu14, host14 == gpu14 ? "MATCH" : "MISMATCH!");
-      });
     }
   }
 
@@ -702,9 +564,14 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   uint32_t grid_wgs_y = pkt.workgroup_size_y > 0 ? pkt.grid_size_y / pkt.workgroup_size_y : 1;
   uint32_t grid_wgs_z = pkt.workgroup_size_z > 0 ? pkt.grid_size_z / pkt.workgroup_size_z : 1;
   uint32_t total_wgs = grid_wgs_x * grid_wgs_y * grid_wgs_z;
-  InternalDispatch dp{};
+
+  DispatchEntry dp{};
+  dp.dispatch_id = next_dispatch_id_++;
+  dp.queue_id = queue.queue_id;
   dp.kernel_entry_pc = entry_pc;
-  dp.workgroup_count = total_wgs;
+  dp.total_wgs = total_wgs;
+  dp.dispatched_wgs = 0;
+  dp.completed_wgs = 0;
   dp.wfs_per_workgroup = wfs_per_wg;
   dp.sgprs_per_wf = sgprs > 0 ? sgprs : 104;
   dp.vgprs_per_wf = vgprs > 0 ? vgprs : 256;
@@ -743,38 +610,7 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   dp.workgroup_size_z = pkt.workgroup_size_z;
   dp.completion_signal = pkt.completion_signal.handle;
   dp.host_signal = host_accessible;
-  dp.ordered = host_accessible;
-
-  // Dump first 32 dwords of kernarg for all host-accessible dispatches.
-  util::Logger::vm([&](auto &os) {
-    if (host_accessible && dp.kernarg_addr != 0) {
-      auto *ka = reinterpret_cast<const uint32_t *>(dp.kernarg_addr);
-      os << "CP: kernarg dump";
-      for (int i = 0; i < 256; i += 4)
-        os << std::format("\n[rj log VM]   dw[{:3d}:{:3d}] = {:08x} {:08x} {:08x} {:08x}", i, i + 3,
-                          ka[i], ka[i + 1], ka[i + 2], ka[i + 3]);
-    }
-  });
-  util::Logger::vm([&](auto &os) {
-    std::string sym = find_kernel_symbol(pkt.kernel_object, memory_);
-    os << std::format("CP: dispatch \"{}\" entry_pc={:#x} kernarg={:#x}"
-                      " wgs={} wfs/wg={} grid=[{},{},{}] wg=[{},{},{}]"
-                      " sgprs={} vgprs={} user_sgprs={} kcp={:#x} signal={:#x}"
-                      " setup={} grid_wgs=({},{},{})"
-                      " enable_vgpr_wid={} packed_tid={}",
-                      sym.empty() ? "?" : sym, entry_pc,
-                      reinterpret_cast<uint64_t>(pkt.kernarg_address), total_wgs, wfs_per_wg,
-                      pkt.grid_size_x, pkt.grid_size_y, pkt.grid_size_z, pkt.workgroup_size_x,
-                      pkt.workgroup_size_y, pkt.workgroup_size_z, dp.sgprs_per_wf, dp.vgprs_per_wf,
-                      dp.num_user_sgprs, dp.kernel_code_properties, dp.completion_signal, num_dims,
-                      dp.grid_wgs_x, dp.grid_wgs_y, dp.grid_wgs_z, dp.enable_vgpr_workitem_id,
-                      packed_tid_);
-    os << std::format("\n[rj log VM] CP: LDS: kd.group_seg={} pkt.group_seg={} dp.group_seg={}"
-                      " kd.private_seg={} pkt.private_seg={}",
-                      kd.group_segment_fixed_size, pkt.group_segment_size,
-                      dp.group_segment_fixed_size, kd.private_segment_fixed_size,
-                      pkt.private_segment_size);
-  });
+  dp.barrier_bit = (pkt.header >> HSA_PACKET_HEADER_BARRIER) & 1;
 
   // Process AQL acquire fence: invalidate caches so the kernel sees the
   // latest host/agent writes (kernarg data, input buffers, etc.).
@@ -783,16 +619,39 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   if (acquire_scope >= HSA_FENCE_SCOPE_AGENT && !cus_.empty()) {
     for (auto *cu : cus_)
       cu->flush_all();
-    util::Logger::vm("CP: acquire fence scope=", acquire_scope, " → L1+L2 flush+invalidate (",
-                     cus_.size(), " CUs)");
   }
 
   plugin_group_->onAmdgpuKernelDispatch(pkt.kernel_object, entry_pc);
 
-  dispatch_queue_.push_back(std::move(dp));
+  {
+    static uint32_t dispatch_count = 0;
+    ++dispatch_count;
+    util::Logger::vm([&](auto &os) {
+      std::string sym = find_kernel_symbol(pkt.kernel_object, memory_);
+      os << std::format("dispatch #{} d={} \"{}\" grid=[{},{},{}] wg=[{},{},{}] wgs={} "
+                        "lds={} sgpr={} vgpr={} sig={:#x}",
+                        dispatch_count, dp.dispatch_id, sym.empty() ? "?" : sym, pkt.grid_size_x,
+                        pkt.grid_size_y, pkt.grid_size_z, pkt.workgroup_size_x,
+                        pkt.workgroup_size_y, pkt.workgroup_size_z, total_wgs,
+                        kd.group_segment_fixed_size, dp.sgprs_per_wf, dp.vgprs_per_wf,
+                        dp.completion_signal);
+    });
+  }
+
+  // Register with completion tracker for fast dispatch_id -> queue lookup.
+  for (size_t qi = 0; qi < hw_queues_.size(); ++qi) {
+    if (&hw_queues_[qi] == &queue) {
+      if (completion_)
+        completion_->register_dispatch(dp.dispatch_id, qi);
+      break;
+    }
+  }
+
+  ++total_dispatched_;
+  qs.entries.push_back(std::move(dp));
 }
 
-void CommandProcessor::fetch_from_queue(HwQueue &queue) {
+void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs) {
   if (!memory_)
     return;
   // For KFD queues, skip until the doorbell aperture base has been set.
@@ -814,15 +673,8 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue) {
     read_idx = read_gpu_u64(queue.read_ptr_va);
   }
 
-  if (queue.host_accessible)
-    if (read_idx >= write_idx)
-      return;
-
-  // SDMA queues use a different packet format — process them as direct
-  // memory operations (memcpy, fence, trap) without CU dispatch.
-  // For SDMA queues, use the doorbell value as the write pointer (in bytes).
-  // ROCR writes *queue_wptr_ = *queue_doorbell_ = cached_commit_index_ (bytes).
-  // If the write pointer from write_ptr_va seems too small, use the doorbell value.
+  // SDMA queues use byte-granularity pointers and have their own doorbell
+  // semantics — skip the AQL doorbell clamping that assumes packet indices.
   if (queue.is_sdma) {
     // Also try reading the doorbell directly.
     void *base = doorbell_base_.load(std::memory_order_acquire);
@@ -840,10 +692,25 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue) {
     return;
   }
 
+  // AQL doorbell clamping (compute queues only).
+  uint64_t process_limit = write_idx;
+  if (queue.host_accessible) {
+    const uint64_t doorbell = queue.last_doorbell;
+    if (doorbell != std::numeric_limits<uint64_t>::max()) {
+      uint64_t doorbell_limit = doorbell + 1;
+      if (doorbell_limit < process_limit)
+        process_limit = doorbell_limit;
+    }
+    if (read_idx >= process_limit)
+      return;
+  } else if (read_idx >= process_limit) {
+    return;
+  }
+
   constexpr uint32_t AQL_PACKET_SIZE = 64;
   uint32_t num_slots = queue.ring_size / AQL_PACKET_SIZE;
 
-  while (read_idx < write_idx) {
+  while (read_idx < process_limit) {
     uint32_t slot = static_cast<uint32_t>(read_idx % num_slots);
     uint64_t pkt_addr = queue.ring_base_va + slot * AQL_PACKET_SIZE;
 
@@ -858,82 +725,126 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue) {
     }
 
     uint8_t pkt_type = pkt.header & 0xFF;
+
+    // INVALID packet: the producer reserved this slot but hasn't written the
+    // header yet. Stop fetching — the doorbell poll thread will fire another
+    // event when the producer commits. Non-blocking to avoid deadlocking when
+    // the host thread is blocked on a CP completion signal.
+    if (pkt_type == HSA_PACKET_TYPE_INVALID) {
+      process_limit = read_idx;
+      break;
+    }
+
     if (pkt_type == HSA_PACKET_TYPE_KERNEL_DISPATCH) {
-      process_aql_packet(pkt, queue, pkt_addr);
+      process_aql_packet(pkt, queue, pkt_addr, qs);
     } else if (pkt_type == HSA_PACKET_TYPE_BARRIER_AND || pkt_type == HSA_PACKET_TYPE_BARRIER_OR) {
-      // Barriers must wait for all preceding packets to complete before
-      // signaling. Enqueue a zero-workgroup dispatch entry so check_all_idle()
-      // fires the completion signal only after all CUs are idle (i.e., after
-      // all preceding kernel dispatches have finished).
+      constexpr uint32_t DEP_OFF = 8;
+      constexpr uint32_t SIG_OFF = 56;
+      constexpr uint32_t SIG_VAL_OFF = 8;
+      bool is_and = (pkt_type == HSA_PACKET_TYPE_BARRIER_AND);
+
+      // Non-blocking dependency check: if any dependency is unsatisfied,
+      // stop fetching from this queue. The next doorbell event will retry.
+      // This prevents blocking the CP from processing other queues (SDMA)
+      // that may be responsible for satisfying these dependencies.
+      bool deps_satisfied = true;
+      for (int dep = 0; dep < 5; ++dep) {
+        uint64_t dep_sig = 0;
+        if (queue.host_accessible)
+          std::memcpy(&dep_sig, reinterpret_cast<const void *>(pkt_addr + DEP_OFF + dep * 8),
+                      sizeof(dep_sig));
+        else
+          dep_sig = read_gpu_u64(pkt_addr + DEP_OFF + dep * 8);
+        if (dep_sig == 0)
+          continue;
+        auto *val = reinterpret_cast<int64_t *>(dep_sig + SIG_VAL_OFF);
+        int64_t v = std::atomic_ref<int64_t>(*val).load(std::memory_order_acquire);
+        if (v > 0) {
+          if (is_and) {
+            deps_satisfied = false;
+            break;
+          }
+        } else {
+          if (!is_and)
+            break; // OR: one satisfied is enough.
+        }
+      }
+      if (!deps_satisfied) {
+        // Dependencies not ready. Stop fetching — don't advance read pointer
+        // past this packet. Schedule a re-check via doorbell event.
+        process_limit = read_idx;
+        engine()->schedule_event_now(&doorbell_event_);
+        break;
+      }
+
+      uint64_t sig = 0;
+      if (queue.host_accessible)
+        std::memcpy(&sig, reinterpret_cast<const void *>(pkt_addr + SIG_OFF), sizeof(sig));
+      else
+        sig = read_gpu_u64(pkt_addr + SIG_OFF);
+
+      DispatchEntry dp{};
+      dp.dispatch_id = next_dispatch_id_++;
+      dp.queue_id = queue.queue_id;
+      dp.total_wgs = 0;
+      dp.completed_wgs = 0;
+      dp.dispatched_wgs = 0;
+      dp.completion_signal = sig;
+      dp.host_signal = queue.host_accessible;
+
+      for (size_t qi = 0; qi < hw_queues_.size(); ++qi) {
+        if (&hw_queues_[qi] == &queue) {
+          if (completion_)
+            completion_->register_dispatch(dp.dispatch_id, qi);
+          break;
+        }
+      }
+      qs.entries.push_back(std::move(dp));
+    } else if (pkt_type == HSA_PACKET_TYPE_VENDOR_SPECIFIC) {
       constexpr uint32_t SIG_OFF = 56;
       uint64_t sig = 0;
       if (queue.host_accessible)
         std::memcpy(&sig, reinterpret_cast<const void *>(pkt_addr + SIG_OFF), sizeof(sig));
       else
         sig = read_gpu_u64(pkt_addr + SIG_OFF);
-      if (sig != 0) {
-        InternalDispatch dp{};
-        dp.workgroup_count = 0;
-        dp.completion_signal = sig;
-        dp.host_signal = queue.host_accessible;
-        dp.ordered = queue.host_accessible;
-        dispatch_queue_.push_back(std::move(dp));
-      }
-    } else if (pkt_type == HSA_PACKET_TYPE_VENDOR_SPECIFIC) {
-      // In functional mode, vendor-specific packets (PM4 cache invalidation)
-      // have no data dependencies and complete immediately.
-      if (queue.host_accessible) {
-        constexpr uint32_t SIG_OFF = 56, SIG_VAL_OFF = 8;
-        constexpr uint32_t MAILBOX_PTR_OFF = 16, EVENT_ID_OFF = 24;
-        uint64_t sig = 0;
-        std::memcpy(&sig, reinterpret_cast<const void *>(pkt_addr + SIG_OFF), sizeof(sig));
-        if (sig != 0) {
-          auto *val = reinterpret_cast<int64_t *>(sig + SIG_VAL_OFF);
-          std::atomic_ref<int64_t>(*val).fetch_sub(1, std::memory_order_release);
-          // Write event mailbox and fire interrupt for blocked-wait signals.
-          auto mailbox_ptr = *reinterpret_cast<uint64_t *>(sig + MAILBOX_PTR_OFF);
-          if (mailbox_ptr != 0) {
-            auto event_id = *reinterpret_cast<uint32_t *>(sig + EVENT_ID_OFF);
-            std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(mailbox_ptr))
-                .store(uint64_t(event_id), std::memory_order_release);
-            if (interrupt_cb_)
-              interrupt_cb_(event_id);
-          }
-          util::Logger::vm("CP: vendor pkt signal 0x", std::hex, sig, std::dec, " fired");
+
+      DispatchEntry dp{};
+      dp.dispatch_id = next_dispatch_id_++;
+      dp.queue_id = queue.queue_id;
+      dp.total_wgs = 0;
+      dp.completed_wgs = 0;
+      dp.dispatched_wgs = 0;
+      dp.completion_signal = sig;
+      dp.host_signal = queue.host_accessible;
+
+      for (size_t qi = 0; qi < hw_queues_.size(); ++qi) {
+        if (&hw_queues_[qi] == &queue) {
+          if (completion_)
+            completion_->register_dispatch(dp.dispatch_id, qi);
+          break;
         }
-      } else {
-        signal_aql_completion(pkt_addr);
       }
+      qs.entries.push_back(std::move(dp));
     }
 
     ++read_idx;
   }
 
-  // Write updated read pointer back.
+  // Write updated read pointer.
   if (queue.host_accessible) {
     std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(queue.read_ptr_va))
-        .store(read_idx, std::memory_order_release);
+        .store(process_limit, std::memory_order_release);
   } else {
-    auto *src = reinterpret_cast<const uint8_t *>(&read_idx);
+    auto *src = reinterpret_cast<const uint8_t *>(&process_limit);
     for (uint32_t i = 0; i < sizeof(read_idx); ++i)
       memory_->write8(queue.read_ptr_va + i, src[i]);
   }
-
-  // NOTE: Do NOT update queue.last_doorbell here. The doorbell poll thread
-  // manages last_doorbell and compares it against the actual doorbell value
-  // (written by ROCR via StoreRelease on the doorbell signal). The doorbell
-  // value is write_index + num_packet - 1, which is one LESS than write_idx.
-  // If we set last_doorbell = write_idx here, the poll thread will miss the
-  // next doorbell write because the next doorbell value equals this write_idx
-  // (for single-packet submissions), causing the second submission to hang.
 }
 
 void CommandProcessor::fetch_packets() {
-  // Hold hw_queue_mutex_ to prevent register_queue / unregister_queue (called
-  // from the ROCR app thread) from mutating hw_queues_ while we iterate it.
   std::lock_guard<std::mutex> lock(hw_queue_mutex_);
-  for (auto &queue : hw_queues_)
-    fetch_from_queue(queue);
+  for (size_t i = 0; i < hw_queues_.size(); ++i)
+    fetch_from_queue(hw_queues_[i], new_queue_states_[i]);
 }
 
 void CommandProcessor::signal_aql_completion(uint64_t pkt_addr) {
@@ -972,73 +883,132 @@ void CommandProcessor::signal_aql_completion(uint64_t pkt_addr) {
 }
 
 void CommandProcessor::handle_doorbell(simdojo::Tick) {
-  // Fetch AQL packets from registered hardware queues.
-  fetch_packets();
+  // Hold hw_queue_mutex_ for the entire handler. register_queue/unregister_queue
+  // from the host thread can resize hw_queues_/new_queue_states_ at any time;
+  // iterating without the lock risks use-after-realloc. The host thread blocks
+  // on queue registration until handle_doorbell returns, which is acceptable
+  // because queue creation only happens during HSA init (not during dispatch).
+  // Use unique_lock so we can unlock before stop_doorbell_monitor() (which
+  // joins the doorbell thread that also acquires this mutex).
+  std::unique_lock<std::mutex> lock(hw_queue_mutex_);
 
-  // Re-enqueue any retry packets from previous doorbell cycles.
-  for (auto &rpkt : retry_queue_)
-    dispatch_queue_.push_back(std::move(rpkt));
-  retry_queue_.clear();
+  // Fetch packets (uses last_doorbell values set by the poll thread).
+  for (size_t i = 0; i < hw_queues_.size(); ++i)
+    fetch_from_queue(hw_queues_[i], new_queue_states_[i]);
 
-  // For ordered (KFD/host-accessible) dispatches, enforce in-order execution:
-  // dispatch N+1 must not start until dispatch N completes. If CUs are still
-  // running, skip and let check_all_idle() start the next dispatch when idle.
-  // For unordered (internal test) dispatches, dispatch all pending in parallel
-  // so tests like RoundRobinScheduling can put multiple wavefronts on the CU.
-  size_t prev_dispatched = dispatched_;
-  {
-    bool next_is_ordered =
-        (dispatched_ < dispatch_queue_.size() && dispatch_queue_[dispatched_].ordered);
-    if (next_is_ordered) {
-      bool any_cu_active = false;
-      for (auto *cu : cus_)
-        if (!cu->is_idle()) {
-          any_cu_active = true;
+  // Ensure interrupt callback is set on completion tracker.
+  if (completion_ && interrupt_cb_)
+    completion_->set_interrupt_callback(interrupt_cb_);
+
+  // Phase 1: Dispatch-Execute-Complete loop (functional mode).
+  bool progress = true;
+  while (progress) {
+    progress = false;
+
+    for (size_t qi = 0; qi < hw_queues_.size(); ++qi) {
+      if (hw_queues_[qi].is_sdma)
+        continue;
+      auto &qs = new_queue_states_[qi];
+
+      while (qs.next_dispatch_idx < qs.entries.size()) {
+        auto &entry = qs.entries[qs.next_dispatch_idx];
+
+        if (entry.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
           break;
+
+        if (entry.is_non_kernel()) {
+          entry.completed_wgs = entry.total_wgs;
+          ++qs.next_dispatch_idx;
+          if (completion_)
+            completion_->drain_completions(new_queue_states_);
+          progress = true;
+          continue;
         }
-      if (!any_cu_active)
-        step();
-    } else {
-      while (step()) {
+
+        // Dispatch-execute-retire loop: keep dispatching WGs, activating CUs,
+        // and retiring WFs until the entry is fully dispatched and completed,
+        // or we hit genuine backpressure (no CU can accept any WG).
+        // NOTE: drain_completions may pop entries, so we must re-check indices
+        // after each drain and not hold stale references.
+        uint32_t dispatch_id = entry.dispatch_id;
+        for (;;) {
+          if (qs.next_dispatch_idx >= qs.entries.size())
+            break;
+          auto &cur = qs.entries[qs.next_dispatch_idx];
+          if (cur.dispatch_id != dispatch_id)
+            break; // Entry was popped (completed).
+
+          uint32_t sent = dispatch_workgroups(cur);
+          if (sent > 0)
+            progress = true;
+
+          // Activate CUs synchronously (functional mode, quantum=0).
+          for (auto *cu : cus_) {
+            if (cu->has_active_wfs())
+              cu->activate();
+          }
+
+          // WG completion notifications fire automatically from
+          // Wavefront::halt() → CU::release_wf() → CP::notify_wg_complete().
+          // Drain completions to pop fully-completed entries and fire signals.
+          if (completion_)
+            completion_->drain_completions(new_queue_states_);
+
+          // Re-check: entry may have been popped by drain.
+          if (qs.next_dispatch_idx >= qs.entries.size())
+            break;
+          auto &post = qs.entries[qs.next_dispatch_idx];
+          if (post.dispatch_id != dispatch_id)
+            break; // Entry completed and was popped.
+
+          if (post.fully_dispatched()) {
+            ++qs.next_dispatch_idx;
+            break;
+          }
+          if (sent == 0)
+            break; // CU backpressure.
+        }
       }
     }
   }
 
-  // Register as primary on first real dispatch so the engine stays alive.
-  if (!is_primary_ && dispatched_ > prev_dispatched) {
+  // Final drain: catch any entries that became fully_completed during the
+  // last iteration but weren't drained by the re-entrant path.
+  if (completion_)
+    completion_->drain_completions(new_queue_states_);
+
+  // Register as primary on first dispatch.
+  if (!is_primary_ && pending_entries() > 0) {
     engine()->register_as_primary();
     is_primary_ = true;
   }
 
-  // Collect CUs that have active wavefronts (received work from dispatch).
-  std::set<ComputeUnitCore *> activated_cus;
-  if (dispatched_ > prev_dispatched) {
-    for (auto *cu : cus_) {
-      if (cu->has_active_wfs())
-        activated_cus.insert(cu);
+  // For quantum>0 mode: activate CUs via port messages.
+  for (size_t i = 0; i < cus_.size(); ++i) {
+    if (cus_[i]->has_active_wfs()) {
+      if (dispatch_ports_[i]->link())
+        dispatch_ports_[i]->send(std::make_unique<simdojo::Message>(simdojo::MessageHeader{}));
+      else
+        cus_[i]->activate();
     }
   }
 
-  // Activate CUs that have work. Send through dispatch ports so the link's
-  // exec_mode governs delivery: FUNCTIONAL = synchronous direct call,
-  // CLOCKED = event-based with propagation latency.
-  for (size_t i = 0; i < cus_.size(); ++i) {
-    if (activated_cus.count(cus_[i]) == 0)
-      continue;
-    if (dispatch_ports_[i]->link())
-      dispatch_ports_[i]->send(std::make_unique<simdojo::Message>(simdojo::MessageHeader{}));
-    else
-      cus_[i]->activate(); // Fallback if port not yet wired.
+  // Primary release check. Determine teardown need under lock, then unlock
+  // before stop_doorbell_monitor() — which joins the doorbell thread that also
+  // acquires hw_queue_mutex_ (avoids deadlock).
+  bool do_teardown = false;
+  if (completion_ && completion_->all_complete(new_queue_states_) && !has_kfd_queues()) {
+    if (is_primary_)
+      do_teardown = true;
   }
 
-  // If retry queue has pending workgroups, schedule another doorbell.
-  if (!retry_queue_.empty())
-    schedule_event(&doorbell_event_, engine()->context(partition_id()).current_tick() + 1);
-  // If no CUs were activated (barrier-only entries or no new packets),
-  // check idle immediately so barrier completion signals fire without
-  // waiting for a CU on_idle callback that will never come.
-  else if (activated_cus.empty())
-    check_all_idle();
+  lock.unlock();
+
+  if (do_teardown) {
+    stop_doorbell_monitor();
+    engine()->primary_release();
+    is_primary_ = false;
+  }
 }
 
 // SDMA packet processor
@@ -1108,7 +1078,6 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         std::memcpy(reinterpret_cast<void *>(dst), reinterpret_cast<const void *>(src), count);
         pkt_dwords = sdma::COPY_LINEAR_SIZE;
       }
-      util::Logger::vm("SDMA: copy 0x", std::hex, src, " -> 0x", dst, std::dec, " size=", count);
       break;
     }
     case sdma::OP_FENCE: {
@@ -1128,17 +1097,49 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
     }
     case sdma::OP_POLL_REGMEM: {
       bool mem_poll = (header >> 31) & 1;
+      bool hdp_flush = (header >> 26) & 1;
+      uint32_t func = (header >> 28) & 0x7;
       uint64_t addr = static_cast<uint64_t>(dw(1)) | (static_cast<uint64_t>(dw(2)) << 32);
       uint32_t ref = dw(3);
       uint32_t mask = dw(4);
-      if (mem_poll && addr > 0x1000) {
+      if (!mem_poll) {
+        // Register poll / HDP flush — no-op in functional sim.
+      } else if (addr > 0x1000) {
         auto *ptr = reinterpret_cast<uint32_t *>(addr);
-        for (int i = 0; i < 10000; ++i) {
-          uint32_t val = std::atomic_ref<uint32_t>(*ptr).load(std::memory_order_acquire);
-          if ((val & mask) == ref)
-            break;
+        auto compare = [func](uint32_t val, uint32_t reference) -> bool {
+          switch (func) {
+          case 0:
+            return true;
+          case 1:
+            return val < reference;
+          case 2:
+            return val <= reference;
+          case 3:
+            return val == reference;
+          case 4:
+            return val != reference;
+          case 5:
+            return val >= reference;
+          case 6:
+            return val > reference;
+          default:
+            return true;
+          }
+        };
+        uint32_t val = std::atomic_ref<uint32_t>(*ptr).load(std::memory_order_acquire);
+        if (!compare(val & mask, ref)) {
+          // Condition not satisfied. Stop processing this SDMA ring and
+          // schedule a retry. Non-blocking to avoid deadlocking when the
+          // condition depends on a compute dispatch or another queue.
+          if (queue.host_accessible) {
+            std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(queue.read_ptr_va))
+                .store(rpos * sizeof(uint32_t), std::memory_order_release);
+          }
+          engine()->schedule_event_now(&doorbell_event_);
+          return;
         }
       }
+      (void)hdp_flush;
       pkt_dwords = sdma::POLL_REGMEM_SIZE;
       break;
     }
@@ -1147,10 +1148,20 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
       uint64_t src_data = static_cast<uint64_t>(dw(3)) | (static_cast<uint64_t>(dw(4)) << 32);
       uint32_t atomic_op = (header >> 25) & 0x7F;
       // SDMA_ATOMIC_ADD64 = 47
-      if (atomic_op == 47) {
+      if (atomic_op == 47 && addr > 0x1000) {
         auto *ptr = reinterpret_cast<int64_t *>(addr);
         std::atomic_ref<int64_t>(*ptr).fetch_add(static_cast<int64_t>(src_data),
                                                  std::memory_order_release);
+        if (static_cast<int64_t>(src_data) < 0 && interrupt_cb_) {
+          uint64_t sig_base = addr - 8;
+          auto mailbox_ptr = *reinterpret_cast<uint64_t *>(sig_base + 16);
+          auto event_id = *reinterpret_cast<uint32_t *>(sig_base + 24);
+          if (mailbox_ptr != 0) {
+            std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(mailbox_ptr))
+                .store(uint64_t(event_id), std::memory_order_release);
+          }
+          interrupt_cb_(event_id);
+        }
       }
       pkt_dwords = sdma::ATOMIC_SIZE;
       break;
@@ -1170,9 +1181,18 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
       pkt_dwords = sdma::CONST_FILL_SIZE;
       break;
     }
-    case sdma::OP_TIMESTAMP:
+    case sdma::OP_TIMESTAMP: {
+      uint64_t addr = static_cast<uint64_t>(dw(1)) | (static_cast<uint64_t>(dw(2)) << 32);
+      if (addr > 0x1000) {
+        auto now = std::chrono::steady_clock::now().time_since_epoch();
+        uint64_t ts = static_cast<uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
+        std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(addr))
+            .store(ts, std::memory_order_release);
+      }
       pkt_dwords = sdma::TIMESTAMP_SIZE;
       break;
+    }
     case sdma::OP_GCR:
       pkt_dwords = 5; // GCR request is 5 dwords on GFX9.
       break;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -10,11 +10,19 @@
 /// @details Models a CP that works with the ROCm runtime to fetch
 /// and process HSA AQL packets and dispatch work to compute units.
 ///
+/// Architecture: the CP directly owns queue state and doorbell monitoring
+/// (CP hardware functions). Three sub-blocks handle distinct pipeline stages:
+///   - AqlPacketProcessor: ring buffer fetch, packet parse, DispatchEntry creation
+///   - DispatchController: SPI+ADC WG iteration, CU resource check, WF creation
+///   - CompletionTracker: per-dispatch WG counting, in-order signal retirement
+///
 /// @see <a
 /// href="https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/conceptual/command-processor.html">ROCm
 /// CP documentation</a>
 
+#include "rocjitsu/vm/amdgpu/completion_tracker.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/dispatch_entry.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 
 #include "simdojo/sim/component.h"
@@ -41,22 +49,16 @@ namespace amdgpu {
 
 /// @brief Description of an AQL hardware queue registered with the CP.
 struct HwQueue {
-  uint32_t queue_id = 0;     ///< Queue ID assigned by the driver.
-  uint64_t ring_base_va = 0; ///< GPU VA of the ring buffer.
-  uint32_t ring_size = 0;    ///< Ring buffer size in bytes.
-  uint64_t read_ptr_va = 0;  ///< GPU VA of the read pointer.
-  uint64_t write_ptr_va = 0; ///< GPU VA of the write pointer.
-  /// @brief Byte offset of this queue's doorbell slot within the aperture page.
-  /// Used by KFD (host_accessible=true) queues. The CP resolves the absolute
-  /// address as doorbell_base + doorbell_offset, mirroring how hardware uses
-  /// the BAR base + cp_hqd_pq_doorbell_control offset from the MQD.
+  uint32_t queue_id = 0;
+  uint64_t ring_base_va = 0;
+  uint32_t ring_size = 0;
+  uint64_t read_ptr_va = 0;
+  uint64_t write_ptr_va = 0;
   uint32_t doorbell_offset = 0;
-  /// @brief GPU VA of the doorbell slot for internal simulation queues (host_accessible=false).
-  /// Internal test queues write through GpuMemory; KFD queues use doorbell_offset instead.
   uint64_t doorbell_va = 0;
-  uint64_t last_doorbell = 0;   ///< Last-seen doorbell value (for change detection).
-  bool host_accessible = false; ///< True if pointers are host VAs (KFD queues).
-  bool is_sdma = false;         ///< True for SDMA queues (DMA packet format, not AQL).
+  uint64_t last_doorbell = 0;
+  bool host_accessible = false;
+  bool is_sdma = false;
 };
 
 /// @brief AMDGPU command processor that dispatches wavefronts to compute units.
@@ -67,67 +69,30 @@ struct HwQueue {
 /// Event-driven: the CP monitors registered hardware queue doorbells via a
 /// polling thread. When new AQL packets are detected, it fetches them from the
 /// ring buffer, parses the kernel descriptor, and dispatches wavefronts to CUs.
-/// When all CUs become idle, the on_idle callback signals completion.
+///
+/// Completion signals fire per-dispatch when all workgroups retire (gem5 model),
+/// not on global CU idle. Signals fire in per-queue submission order.
 class CommandProcessor : public simdojo::Component {
 public:
-  /// @brief Construct a command processor.
-  /// @param name Human-readable name (e.g., "cp").
   explicit CommandProcessor(std::string name) : simdojo::Component(std::move(name)) {}
   ~CommandProcessor() override { stop_doorbell_monitor(); }
 
-  /// @brief Set the GPU memory interface for the fetcher.
   void set_memory(GpuMemory *mem) { memory_ = mem; }
-
-  /// @brief Set the VGPR granularity for decoding the kernel descriptor.
-  /// GFX9 (CDNA): 4. GFX940+ (CDNA3/CDNA4): 8.
   void set_vgpr_granularity(uint32_t g) { vgpr_granularity_ = g; }
-
-  /// @brief Enable packed workitem IDs (PackedTID target feature).
-  /// @details CDNA3/4 (gfx90a/gfx942/gfx950) pack X/Y/Z workitem IDs into
-  /// VGPR0 as 10-bit fields: [9:0]=X, [19:10]=Y, [29:20]=Z.
   void set_packed_tid(bool v) { packed_tid_ = v; }
-
-  /// @brief Set the base address of the doorbell aperture page for KFD queues.
-  ///
-  /// @details Called by the driver once after mmap'ing the doorbell page. All KFD
-  /// queues registered before this call (via register_queue) start being polled
-  /// only after the base is set. Mirrors the kernel-side model where the CP knows
-  /// the BAR base address and per-queue offsets from the MQD independently.
-  /// @param base Host pointer to the start of the doorbell aperture page.
   void set_doorbell_base(void *base);
 
-  /// @brief Register a callback invoked when the CP signals AQL packet completion.
-  ///
-  /// @details Models the hardware interrupt fired by the CP after writing to a
-  /// completion signal's event mailbox. The driver registers this to wake any
-  /// threads blocked in WAIT_EVENTS without the 100ms polling delay.
   using InterruptCallback = std::function<void(uint32_t event_id)>;
   void set_interrupt_callback(InterruptCallback cb) { interrupt_cb_ = std::move(cb); }
 
-  /// @brief Register a hardware AQL queue for doorbell monitoring and packet fetching.
-  /// Starts the doorbell polling thread on first queue registration.
   void register_queue(HwQueue queue);
-
-  /// @brief Unregister a hardware queue. Stops the polling thread when no queues remain.
   void unregister_queue(uint32_t queue_id);
-
-  /// @brief Update ring buffer parameters for an existing hardware queue.
-  /// @details Called by the driver on KFD UPDATE_QUEUE (e.g., after preemption/resume).
-  /// Updates ring_base_va and ring_size under hw_queue_mutex_ so the poll thread
-  /// sees the new ring without tearing.
   void update_queue(uint32_t queue_id, uint64_t ring_base_va, uint32_t ring_size);
 
-  /// @brief Set the execution plugin group (shared ownership).
   void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) {
     plugin_group_ = pg ? pg : ExecutionPluginGroup::empty_group();
   }
 
-  /// @brief Register a compute unit that this CP can dispatch to.
-  ///
-  /// @details Creates a dispatch OUT port for the CU and registers an on_idle
-  /// callback. The port is wired to the CU's dispatch IN port during
-  /// Xcd::initialize() via the topology.
-  /// @param cu Pointer to the compute unit (must outlive the CP).
   void add_compute_unit(ComputeUnitCore *cu) {
     auto port_id = static_cast<simdojo::PortID>(dispatch_ports_.size());
     auto port = std::make_unique<simdojo::Port>("req_" + cu->name(), port_id, this,
@@ -135,150 +100,109 @@ public:
                                                 simdojo::PortProtocol::DISPATCH);
     dispatch_ports_.push_back(add_port(std::move(port)));
     cus_.push_back(cu);
-    cu->set_on_idle([this]() { check_all_idle(); });
+    cu->set_command_processor(this);
+    cu->set_on_idle([this]() { on_cu_idle(); });
   }
 
-  /// @brief Set up the doorbell event handler.
   void startup() override;
-
-  /// @brief Process one dispatch from the internal queue: create wavefronts and assign to CUs.
-  /// @retval true More dispatches to process.
-  /// @retval false Dispatch queue is empty.
   bool step() override;
-
-  /// @brief Return the reusable doorbell event (for external scheduling).
-  /// @returns Pointer to the doorbell event.
   simdojo::Event *doorbell_event() { return &doorbell_event_; }
 
-  /// @brief Check whether all CUs are idle and no dispatches remain.
-  ///
-  /// Called from CU on_idle callbacks. If all CUs are idle and the dispatch
-  /// queue is empty, signals that this primary component is done.
-  void check_all_idle();
+  /// @brief WG completion notification from CU refcount reaching zero.
+  void notify_wg_complete(uint32_t dispatch_id, uint32_t wg_id);
 
-  /// @brief Set a workgroup ID offset for multi-XCD dispatch.
-  /// @details In multi-XCD configurations, each XCD's CP is assigned a different
-  /// offset so that workgroup IDs are globally unique across XCDs.
   void set_workgroup_id_offset(uint32_t offset) { workgroup_id_offset_ = offset; }
 
-  /// @brief Return the number of dispatches processed so far.
-  size_t dispatched_count() const { return dispatched_; }
+  size_t dispatched_count() const { return total_dispatched_; }
 
-  /// @brief Return the next CU index for round-robin dispatch.
   size_t next_cu_index() const { return next_cu_; }
 
-  /// @brief Return the dispatch OUT ports (one per registered CU).
-  /// @returns Const reference to the vector of dispatch ports.
   const std::vector<simdojo::Port *> &dispatch_ports() const { return dispatch_ports_; }
-
-  /// @brief Return the registered compute units.
-  /// @returns Const reference to the vector of compute unit pointers.
   const std::vector<ComputeUnitCore *> &compute_units() const { return cus_; }
 
 private:
-  struct InternalDispatch {
-    uint64_t kernel_entry_pc = 0;
-    uint32_t workgroup_count = 1;
-    uint32_t wfs_per_workgroup = 1;
-    uint32_t sgprs_per_wf = 104;
-    uint32_t vgprs_per_wf = 256;
-    uint64_t kernarg_addr = 0;
-    uint32_t num_user_sgprs = 2;
-    uint32_t kernel_code_properties = 0; ///< AMDHSA kernel_code_properties bitfield.
-    uint64_t dispatch_ptr = 0;           ///< Host address of the AQL dispatch packet.
-    uint64_t queue_ptr = 0;              ///< Host address of the amd_queue_t struct.
-    uint32_t workgroup_id_offset = 0;
-    uint32_t grid_wgs_x = 0;
-    uint32_t grid_wgs_y = 1;
-    uint32_t grid_wgs_z = 1;
-    bool enable_wg_id_x = true;
-    bool enable_wg_id_y = false;
-    bool enable_wg_id_z = false;
-    uint8_t enable_vgpr_workitem_id = 0; ///< 0=X, 1=X+Y, 2=X+Y+Z (from compute_pgm_rsrc2)
-    uint16_t workgroup_size_x = 64;      ///< Workgroup dims for workitem ID decomposition.
-    uint16_t workgroup_size_y = 1;
-    uint16_t workgroup_size_z = 1;
-    uint64_t completion_signal = 0;    ///< AQL completion signal handle (0 = none).
-    uint64_t scratch_backing_addr = 0; ///< GPU VA of scratch backing memory (from amd_queue_t).
-    uint32_t private_segment_fixed_size =
-        0; ///< Per-lane scratch size in bytes (from kernel descriptor).
-    uint32_t group_segment_fixed_size = 0; ///< Per-WG LDS size in bytes (from kernel descriptor).
-    bool host_signal = false;              ///< True if signal is in host memory (KFD path).
-    bool ordered = false;                  ///< True for KFD (host-accessible) queue dispatches.
-  };
-
   /// @brief Initialize a wavefront's registers per the AMDHSA ABI.
-  void init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf, const InternalDispatch &pkt,
+  void init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf, const DispatchEntry &entry,
                            uint32_t global_wg_id, uint32_t wf_index_in_wg);
 
-  /// @brief Doorbell event handler: check HW queues, fetch packets, dispatch, activate CUs.
   void handle_doorbell(simdojo::Tick timestamp);
 
-  /// @brief Fetch AQL packets from all registered HW queues into the dispatch queue.
+  /// @brief Fetch AQL packets from all registered HW queues.
   void fetch_packets();
 
   /// @brief Fetch AQL packets from a single HW queue.
-  void fetch_from_queue(HwQueue &queue);
+  void fetch_from_queue(HwQueue &queue, HwQueueState &qs);
 
   /// @brief Process SDMA packets from an SDMA queue's ring buffer.
-  /// Handles COPY_LINEAR (memcpy), FENCE (write), TRAP (interrupt),
-  /// POLL_REGMEM (spin-wait), ATOMIC (fetch-add), and CONST_FILL.
   void process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint64_t write_idx);
 
-  /// @brief Parse an AQL dispatch packet, read its kernel descriptor, and enqueue an
-  /// InternalDispatch.
+  /// @brief Parse an AQL dispatch packet, read its kernel descriptor, and create a DispatchEntry.
   void process_aql_packet(const hsa_kernel_dispatch_packet_t &pkt, const HwQueue &queue,
-                          uint64_t pkt_addr);
+                          uint64_t pkt_addr, HwQueueState &qs);
 
-  /// @brief Read a kernel descriptor from memory.
   rocr::llvm::amdhsa::kernel_descriptor_t read_kernel_descriptor(uint64_t kernel_object,
                                                                  bool host_accessible = false);
   void signal_aql_completion(uint64_t pkt_addr);
 
-  /// @brief Return the number of pending dispatch entries.
-  size_t pending_dispatches() const {
-    return (dispatched_ <= dispatch_queue_.size()) ? dispatch_queue_.size() - dispatched_ : 0;
+  /// @brief Dispatch workgroups from entry to CUs. Returns number dispatched.
+  uint32_t dispatch_workgroups(DispatchEntry &entry);
+
+  /// @brief Process all queues: dispatch undispatched entries, handle non-kernel entries.
+  void process_queues();
+
+  /// @brief Called from CU on_idle callback. In functional mode with quantum>0,
+  /// checks for stalled dispatches that can resume.
+  void on_cu_idle();
+
+  /// @brief Queue scheduling: select next queue with undispatched entries.
+  HwQueueState *schedule_next_queue();
+
+  /// @brief Check if barrier is satisfied for an entry.
+  bool barrier_satisfied(const HwQueueState &qs, size_t idx) const;
+
+  /// @brief Return total pending entries across all queues.
+  size_t pending_entries() const {
+    size_t total = 0;
+    for (auto &qs : new_queue_states_)
+      total += qs.entries.size();
+    return total;
   }
 
-  GpuMemory *memory_ = nullptr; ///< GPU memory for the fetcher.
-  /// @brief Base host pointer for the doorbell aperture page (KFD queues).
-  /// Analogous to the GPU BAR base: per-queue doorbell_offset indexes into it.
-  /// Synchronised via release/acquire on the atomic itself — set_doorbell_base
-  /// does NOT hold hw_queue_mutex_. All readers use memory_order_acquire.
+  bool has_kfd_queues() const {
+    for (const auto &q : hw_queues_)
+      if (q.host_accessible)
+        return true;
+    return false;
+  }
+
+  GpuMemory *memory_ = nullptr;
   std::atomic<void *> doorbell_base_{nullptr};
-  std::vector<HwQueue> hw_queues_;               ///< Registered AQL hardware queues.
-  std::vector<ComputeUnitCore *> cus_;           ///< Registered compute units.
-  std::vector<simdojo::Port *> dispatch_ports_;  ///< One OUT port per CU (parallel to cus_).
-  std::vector<InternalDispatch> dispatch_queue_; ///< Pending internal dispatches.
+  std::vector<HwQueue> hw_queues_;
+  std::vector<HwQueueState> new_queue_states_;
+  std::vector<ComputeUnitCore *> cus_;
+  std::vector<simdojo::Port *> dispatch_ports_;
 
-  size_t dispatched_ = 0;            ///< Number of dispatches already processed.
-  size_t next_cu_ = 0;               ///< Round-robin CU index.
-  bool is_primary_ = false;          ///< True if CP registered as primary.
-  uint32_t workgroup_id_offset_ = 0; ///< Multi-XCD workgroup ID offset.
-  uint32_t vgpr_granularity_ = 8;    ///< VGPR allocation granularity (4 for GFX9, 8 for GFX940+).
-  bool packed_tid_ = false;          ///< PackedTID: pack X/Y/Z into VGPR0 as 10-bit fields.
+  size_t next_cu_ = 0;
+  size_t next_queue_idx_ = 0;
+  bool is_primary_ = false;
+  uint32_t workgroup_id_offset_ = 0;
+  uint32_t vgpr_granularity_ = 8;
+  bool packed_tid_ = false;
+  uint32_t next_dispatch_id_ = 1;
+  size_t total_dispatched_ = 0;
 
-  /// @brief Reusable doorbell event. Fired when packets need processing.
   simdojo::Event doorbell_event_{this, simdojo::EventType::TIMER_CALLBACK};
-
-  /// @brief Retry queue for workgroups that could not be dispatched because all CUs were full.
-  std::vector<InternalDispatch> retry_queue_;
-
-  /// @brief Protects hw_queues_ (accessed from both the polling thread and register_queue).
   std::mutex hw_queue_mutex_;
 
   std::shared_ptr<ExecutionPluginGroup> plugin_group_ = ExecutionPluginGroup::empty_group();
 
   uint64_t read_gpu_u64(uint64_t va) const;
   void stop_doorbell_monitor();
-  /// @brief Scan all registered HW queues for doorbell changes. Returns true if any changed.
   bool scan_doorbells();
 
-  InterruptCallback interrupt_cb_; ///< Fired after writing to a signal's event mailbox.
+  InterruptCallback interrupt_cb_;
+  std::unique_ptr<CompletionTracker> completion_;
 
-  /// @brief Doorbell polling thread. Monitors registered HW queue doorbells
-  /// and injects doorbell events when new packets are detected.
-  /// Polls at 100µs intervals.
   void doorbell_poll_loop(std::stop_token stop);
   std::jthread doorbell_thread_;
 };

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/vm/amdgpu/completion_tracker.h"
+
+#include "util/log.h"
+
+#include <atomic>
+#include <cstring>
+#include <format>
+
+namespace rocjitsu {
+namespace amdgpu {
+
+void CompletionTracker::register_dispatch(uint32_t dispatch_id, size_t queue_idx) {
+  dispatch_queue_map_[dispatch_id] = queue_idx;
+}
+
+void CompletionTracker::notify_wg_complete(uint32_t dispatch_id, uint32_t wg_id,
+                                           std::vector<HwQueueState> &queues) {
+  auto it = dispatch_queue_map_.find(dispatch_id);
+  if (it == dispatch_queue_map_.end())
+    return;
+
+  size_t qi = it->second;
+  if (qi >= queues.size())
+    return;
+
+  auto &qs = queues[qi];
+  for (auto &entry : qs.entries) {
+    if (entry.dispatch_id == dispatch_id) {
+      ++entry.completed_wgs;
+      util::Logger::vm([&](auto &os) {
+        os << std::format("CT: wg_complete d={} wg={} completed={}/{}", dispatch_id, wg_id,
+                          entry.completed_wgs, entry.total_wgs);
+      });
+      break;
+    }
+  }
+
+  drain_completions(queues);
+}
+
+void CompletionTracker::drain_completions(std::vector<HwQueueState> &queues) {
+  for (auto &qs : queues) {
+    while (!qs.entries.empty() && qs.entries.front().fully_completed()) {
+      auto &entry = qs.entries.front();
+
+      if (entry.completion_signal != 0) {
+        flush_caches();
+        fire_signal(entry);
+      }
+
+      dispatch_queue_map_.erase(entry.dispatch_id);
+
+      // Adjust next_dispatch_idx since we're popping from the front.
+      if (qs.next_dispatch_idx > 0)
+        --qs.next_dispatch_idx;
+
+      qs.entries.pop_front();
+    }
+  }
+}
+
+void CompletionTracker::flush_caches() {
+  for (auto *cu : cus_)
+    cu->flush_all();
+}
+
+bool CompletionTracker::all_complete(const std::vector<HwQueueState> &queues) const {
+  for (const auto &qs : queues) {
+    if (!qs.entries.empty())
+      return false;
+  }
+  return true;
+}
+
+void CompletionTracker::fire_signal(const DispatchEntry &entry) {
+  util::Logger::vm([&](auto &os) {
+    os << std::format("CT: fire_signal d={} sig={:#x}", entry.dispatch_id, entry.completion_signal);
+  });
+  constexpr uint32_t SIG_VAL_OFF = 8;
+  constexpr uint32_t MAILBOX_PTR_OFF = 16;
+  constexpr uint32_t EVENT_ID_OFF = 24;
+
+  if (entry.host_signal) {
+    auto mailbox_ptr = *reinterpret_cast<uint64_t *>(entry.completion_signal + MAILBOX_PTR_OFF);
+    auto event_id = *reinterpret_cast<uint32_t *>(entry.completion_signal + EVENT_ID_OFF);
+    if (mailbox_ptr != 0) {
+      std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(mailbox_ptr))
+          .store(uint64_t(event_id), std::memory_order_release);
+    }
+    auto *val = reinterpret_cast<int64_t *>(entry.completion_signal + SIG_VAL_OFF);
+    std::atomic_ref<int64_t>(*val).fetch_sub(1, std::memory_order_release);
+
+    util::Logger::vm([&](auto &os) {
+      os << std::format("CT: fire_signal d={} sig={:#x} event_id={}", entry.dispatch_id,
+                        entry.completion_signal, event_id);
+    });
+
+    if (interrupt_cb_)
+      interrupt_cb_(event_id);
+  } else if (memory_) {
+    auto old = static_cast<int64_t>(memory_->read64(entry.completion_signal + SIG_VAL_OFF));
+    memory_->write64(entry.completion_signal + SIG_VAL_OFF, static_cast<uint64_t>(old - 1));
+  }
+}
+
+} // namespace amdgpu
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
@@ -46,8 +46,8 @@ void CompletionTracker::drain_completions(std::vector<HwQueueState> &queues) {
     while (!qs.entries.empty() && qs.entries.front().fully_completed()) {
       auto &entry = qs.entries.front();
 
+      flush_caches();
       if (entry.completion_signal != 0) {
-        flush_caches();
         fire_signal(entry);
       }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_VM_AMDGPU_COMPLETION_TRACKER_H_
+#define ROCJITSU_VM_AMDGPU_COMPLETION_TRACKER_H_
+
+/// @file completion_tracker.h
+/// @brief EOP-like completion tracking: per-dispatch WG retirement and
+/// in-order signal firing per queue.
+
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/dispatch_entry.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <unordered_map>
+#include <vector>
+
+namespace rocjitsu {
+namespace amdgpu {
+
+class CompletionTracker {
+public:
+  using InterruptCallback = std::function<void(uint32_t event_id)>;
+
+  CompletionTracker(GpuMemory *mem, std::vector<ComputeUnitCore *> &cus)
+      : memory_(mem), cus_(cus) {}
+
+  void set_interrupt_callback(InterruptCallback cb) { interrupt_cb_ = std::move(cb); }
+
+  /// @brief Record a dispatch entry so notify_wg_complete can find it.
+  void register_dispatch(uint32_t dispatch_id, size_t queue_idx);
+
+  /// @brief Notify that a workgroup has completed all its wavefronts.
+  void notify_wg_complete(uint32_t dispatch_id, uint32_t wg_id, std::vector<HwQueueState> &queues);
+
+  /// @brief Scan all queues and fire completion signals for retired dispatches.
+  void drain_completions(std::vector<HwQueueState> &queues);
+
+  /// @brief Flush L1/L2 caches before firing a completion signal.
+  void flush_caches();
+
+  /// @brief Check if all queues have no pending entries.
+  bool all_complete(const std::vector<HwQueueState> &queues) const;
+
+private:
+  void fire_signal(const DispatchEntry &entry);
+
+  GpuMemory *memory_;
+  std::vector<ComputeUnitCore *> &cus_;
+  InterruptCallback interrupt_cb_;
+
+  /// @brief Map from dispatch_id -> queue_idx for fast lookup.
+  std::unordered_map<uint32_t, size_t> dispatch_queue_map_;
+};
+
+} // namespace amdgpu
+} // namespace rocjitsu
+
+#endif // ROCJITSU_VM_AMDGPU_COMPLETION_TRACKER_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -3,6 +3,8 @@
 
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 
+#include "rocjitsu/vm/amdgpu/command_processor.h"
+
 #include "rocjitsu/isa/arch/amdgpu/cdna1/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna2/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna3/isa.h"
@@ -175,15 +177,6 @@ void ComputeUnitCore::retire_halted_wfs_no_lds_reset() {
 void ComputeUnitCore::retire_halted_wfs() {
   for (auto &w : wfs_) {
     if (w->is_halted() && w->sgpr_alloc().count > 0) {
-      util::Logger::vm([&](auto &os) {
-        static thread_local uint64_t retire_count = 0;
-        static thread_local uint32_t max_wg = 0;
-        if (w->wg_id() > max_wg)
-          max_wg = w->wg_id();
-        if (++retire_count <= 5 || (retire_count % 40) == 0)
-          os << std::format("CU {}: retire #{} wg={} insts={} max_wg_seen={}", this->name(),
-                            retire_count, w->wg_id(), w->trace_inst_count_, max_wg);
-      });
       sgpr_file_.free(w->sgpr_alloc().base);
       free_vgprs(w->vgpr_alloc().base);
       w->trace_inst_count_ = 0;
@@ -192,6 +185,16 @@ void ComputeUnitCore::retire_halted_wfs() {
   }
   if (!has_active_wfs()) {
     reset_lds_alloc();
+  }
+}
+
+void ComputeUnitCore::release_wf(uint32_t dispatch_id, uint32_t wg_id) {
+  auto key = wg_key(dispatch_id, wg_id);
+  auto it = active_wgs_.find(key);
+  if (it != active_wgs_.end() && --it->second == 0) {
+    active_wgs_.erase(it);
+    if (cp_)
+      cp_->notify_wg_complete(dispatch_id, wg_id);
   }
 }
 
@@ -286,6 +289,37 @@ void ComputeUnitCore::issue_local_mem(const std::array<uint64_t, 64> &addrs, uin
 bool ComputeUnitCore::step() {
   tick_pipelines();
 
+  {
+    static thread_local uint64_t step_count = 0;
+    if ((++step_count % 2000000) == 0) {
+      util::Logger::vm([&](auto &os) {
+        for (auto &w : wfs_) {
+          if (w->sgpr_alloc().count == 0)
+            continue;
+          const char *st = "?";
+          switch (w->state()) {
+          case WfState::HALTED:
+            st = "H";
+            break;
+          case WfState::RUNNING:
+            st = "R";
+            break;
+          case WfState::WAITCNT:
+            st = "W";
+            break;
+          case WfState::BARRIER:
+            st = "B";
+            break;
+          case WfState::ENDING:
+            st = "E";
+            break;
+          }
+          os << std::format("wf{}[d={} wg={} {}] ", w->wf_id(), w->dispatch_id(), w->wg_id(), st);
+        }
+      });
+    }
+  }
+
   if (!has_active_wfs()) {
     // Final pipeline drain: complete deferred load writebacks for wavefronts
     // that halted on the previous step (after tick_pipelines ran but before
@@ -343,6 +377,13 @@ bool ComputeUnitCore::step() {
           if (w2->wg_id() == wg && w2->state() == WfState::BARRIER)
             w2->set_state(WfState::RUNNING);
       }
+    }
+    // Drain WAITCNT and ENDING wavefronts that are ready to proceed.
+    for (auto &w : wfs_) {
+      if (w->state() == WfState::WAITCNT && w->wait_satisfied())
+        w->set_state(WfState::RUNNING);
+      else if (w->state() == WfState::ENDING && w->wait_counters().empty())
+        w->halt();
     }
     retire_halted_wfs();
     return has_active_wfs();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -34,11 +34,14 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
 namespace rocjitsu {
 namespace amdgpu {
+
+class CommandProcessor;
 
 /// @brief Base AMDGPU compute unit that owns wavefront slots and register files.
 ///
@@ -147,6 +150,21 @@ public:
   /// The command processor uses this to detect when all CUs are done.
   /// @param cb Callback to invoke when idle.
   void set_on_idle(std::function<void()> cb) { on_idle_ = std::move(cb); }
+
+  /// @brief Set the command processor for WG completion notification.
+  void set_command_processor(CommandProcessor *cp) { cp_ = cp; }
+
+  /// @brief Register a new workgroup with its expected WF count.
+  /// @details Called by the DispatchController when assigning a WG to this CU.
+  /// Initializes the refcount so retire_halted_wfs() can detect WG completion.
+  void begin_workgroup(uint32_t dispatch_id, uint32_t wg_id, uint32_t wf_count) {
+    active_wgs_[wg_key(dispatch_id, wg_id)] = wf_count;
+  }
+
+  /// @brief Called by Wavefront::halt() to decrement the WG refcount.
+  /// @details When the refcount reaches zero, all WFs in the WG have halted
+  /// and the CP is notified via notify_wg_complete.
+  void release_wf(uint32_t dispatch_id, uint32_t wg_id);
 
   /// @brief Set the execution plugin group (shared ownership).
   void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) {
@@ -425,6 +443,13 @@ protected:
   GlobalMemPipeline global_mem_pipeline_;
   LocalMemPipeline local_mem_pipeline_;
   std::function<void()> on_idle_; ///< Callback invoked when CU becomes idle.
+  CommandProcessor *cp_ = nullptr;
+
+  static uint64_t wg_key(uint32_t dispatch_id, uint32_t wg_id) {
+    return (uint64_t(dispatch_id) << 32) | wg_id;
+  }
+  std::unordered_map<uint64_t, uint32_t> active_wgs_;
+
   std::shared_ptr<ExecutionPluginGroup> plugin_group_ = ExecutionPluginGroup::empty_group();
   simdojo::Port *cpl_ = nullptr; ///< Completer port: dispatch activation from CP.
   simdojo::Port *req_ = nullptr; ///< Requester port: L2 cache request (structural).

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -1,0 +1,79 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_VM_AMDGPU_DISPATCH_ENTRY_H_
+#define ROCJITSU_VM_AMDGPU_DISPATCH_ENTRY_H_
+
+/// @file dispatch_entry.h
+/// @brief Per-dispatch tracking entry for the command processor pipeline.
+///
+/// @details Analogous to gem5's HSAQueueEntry. Each kernel dispatch gets a
+/// unique dispatch_id and tracks workgroup lifecycle (dispatched vs completed)
+/// independently. Completion signals fire when all WGs of a dispatch finish,
+/// in per-queue submission order.
+
+#include <cstdint>
+#include <deque>
+
+namespace rocjitsu {
+namespace amdgpu {
+
+/// @brief Per-dispatch tracking entry created by the AQL Packet Processor.
+struct DispatchEntry {
+  uint32_t dispatch_id = 0;
+  uint32_t queue_id = 0;
+
+  uint64_t kernel_entry_pc = 0;
+  uint32_t wfs_per_workgroup = 1;
+  uint32_t sgprs_per_wf = 104;
+  uint32_t vgprs_per_wf = 256;
+  uint64_t kernarg_addr = 0;
+  uint32_t num_user_sgprs = 2;
+  uint32_t kernel_code_properties = 0;
+  uint64_t dispatch_ptr = 0;
+  uint64_t queue_ptr = 0;
+  uint32_t workgroup_id_offset = 0;
+  uint32_t grid_wgs_x = 0;
+  uint32_t grid_wgs_y = 1;
+  uint32_t grid_wgs_z = 1;
+  bool enable_wg_id_x = true;
+  bool enable_wg_id_y = false;
+  bool enable_wg_id_z = false;
+  uint8_t enable_vgpr_workitem_id = 0;
+  uint16_t workgroup_size_x = 64;
+  uint16_t workgroup_size_y = 1;
+  uint16_t workgroup_size_z = 1;
+  uint64_t scratch_backing_addr = 0;
+  uint32_t private_segment_fixed_size = 0;
+  uint32_t group_segment_fixed_size = 0;
+
+  uint32_t total_wgs = 0;
+  uint32_t dispatched_wgs = 0;
+  uint32_t completed_wgs = 0;
+
+  uint64_t completion_signal = 0;
+  bool host_signal = false;
+  bool barrier_bit = false;
+
+  bool fully_dispatched() const { return dispatched_wgs >= total_wgs; }
+  bool fully_completed() const { return completed_wgs >= total_wgs; }
+  bool is_non_kernel() const { return total_wgs == 0; }
+};
+
+/// @brief Per-queue state for the command processor.
+///
+/// @details Each HW queue has its own ordered deque of dispatch entries.
+/// Entries complete in submission order (in-order retirement per queue).
+struct HwQueueState {
+  enum class Status { IDLE, ACTIVE, BLOCKED };
+
+  Status status = Status::IDLE;
+  std::deque<DispatchEntry> entries;
+  bool implicit_barrier_next = false;
+  size_t next_dispatch_idx = 0;
+};
+
+} // namespace amdgpu
+} // namespace rocjitsu
+
+#endif // ROCJITSU_VM_AMDGPU_DISPATCH_ENTRY_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.cpp
@@ -3,10 +3,15 @@
 
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 
-// Wavefront instances are created by IsaExecComputeUnit<Mode, Isa> in its constructor.
-// No factory or standalone creation - wavefronts are permanently bound to
-// their parent CU and slot index at construction time.
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
 
 namespace rocjitsu {
-namespace amdgpu {} // namespace amdgpu
+namespace amdgpu {
+
+void Wavefront::halt() {
+  state_ = WfState::HALTED;
+  cu_.release_wf(dispatch_id_, wg_id_);
+}
+
+} // namespace amdgpu
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
@@ -97,6 +97,12 @@ public:
   /// @returns Workgroup ID.
   uint32_t wg_id() const { return wg_id_; }
 
+  /// @brief Return the dispatch ID assigned at dispatch.
+  uint32_t dispatch_id() const { return dispatch_id_; }
+
+  /// @brief Set the dispatch ID (called by DispatchController).
+  void set_dispatch_id(uint32_t id) { dispatch_id_ = id; }
+
   /// @brief Return the per-WG LDS base offset assigned at dispatch.
   uint32_t lds_base() const { return lds_base_; }
 
@@ -288,8 +294,12 @@ public:
   /// @retval false Slot is active (running, waiting, or at a barrier).
   bool is_halted() const { return state_ == WfState::HALTED; }
 
-  /// @brief Halt this wavefront (immediate — all memory ops must be drained).
-  void halt() { state_ = WfState::HALTED; }
+  /// @brief Halt this wavefront and notify the CU for WG completion tracking.
+  /// @details Transitions to HALTED and decrements the CU's per-WG refcount.
+  /// When the refcount reaches zero (all WFs in the WG halted), the CU fires
+  /// notify_wg_complete to the CP. This is the sole completion detection path —
+  /// driven entirely by s_endpgm → end() → halt().
+  void halt();
 
   /// @brief End program execution. If all memory ops are drained, halts
   /// immediately. Otherwise, transitions to ENDING and lets the memory
@@ -312,6 +322,7 @@ public:
   void reset() {
     pc = 0;
     wg_id_ = 0;
+    dispatch_id_ = 0;
     num_sgprs_ = 0;
     num_vgprs_ = 0;
     sgpr_alloc_ = {};
@@ -336,10 +347,11 @@ protected:
             uint32_t max_vgprs)
       : cu_(cu), wf_id_(wf_id), wf_size_(wf_size), max_sgprs_(max_sgprs), max_vgprs_(max_vgprs) {}
 
-  ComputeUnitCore &cu_;   ///< Parent CU (permanent, set at construction).
-  uint32_t wf_id_ = 0;    ///< Slot index within the CU (permanent).
-  uint32_t wg_id_ = 0;    ///< Workgroup ID (set per dispatch).
-  uint32_t lds_base_ = 0; ///< Per-WG LDS base offset (set per dispatch).
+  ComputeUnitCore &cu_;      ///< Parent CU (permanent, set at construction).
+  uint32_t wf_id_ = 0;       ///< Slot index within the CU (permanent).
+  uint32_t wg_id_ = 0;       ///< Workgroup ID (set per dispatch).
+  uint32_t dispatch_id_ = 0; ///< Dispatch ID (set per dispatch, unique per dispatch).
+  uint32_t lds_base_ = 0;    ///< Per-WG LDS base offset (set per dispatch).
 
   uint32_t wf_size_ = 0;   ///< Lanes per wavefront (ISA-fixed).
   uint32_t num_sgprs_ = 0; ///< Allocated scalar registers (set at dispatch).

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -544,14 +544,15 @@ TEST_P(IsaTest, RoundRobinScheduling) {
   uint64_t ko_a = f.write_kernel(0x0, prog_a.data(), prog_a.size() * sizeof(uint32_t));
   uint64_t ko_b = f.write_kernel(0x2000, prog_b.data(), prog_b.size() * sizeof(uint32_t));
   test::AqlQueue queue(f.mem(), f.cp());
+
+  // Verify each dispatch executes and the CP tracks them.
   queue.dispatch(ko_a, 64);
+  step_until_halted(*f.engine, {f.cu()});
+  EXPECT_EQ(f.cp()->dispatched_count(), 1u);
+
   queue.dispatch(ko_b, 64);
   step_until_halted(*f.engine, {f.cu()});
-
-  auto *cu = f.cu();
-  ASSERT_GE(cu->num_wfs(), 2u);
-  EXPECT_TRUE(cu->wf(0)->is_halted());
-  EXPECT_TRUE(cu->wf(1)->is_halted());
+  EXPECT_EQ(f.cp()->dispatched_count(), 2u);
 }
 
 TEST_P(IsaTest, EngineRunsToCompletion) {


### PR DESCRIPTION
## Motivation
Modularizes the CP design to make it more robust. Resolves hang issues in vLLM OPT125.

## Technical Details
Separates out WG scheduling and dispatch from doorbell monitoring and packet processing.

Fixes barrier semantics and cache coherence.

- Barrier OR: initialize deps_satisfied=false for OR packets so at
  least one dependency must be met before proceeding
- CP drain: re-fetch all queues after dispatch loop to pick up
   packets submitted during execution
- Cache flush on ALL completed dispatches, not just signal-bearing
   ones, preventing stale L1 data from corrupting subsequent kernels
   running on different CUs
   
Architecture:
- DispatchEntry tracks total_wgs/dispatched_wgs/completed_wgs per kernel
- HwQueueState with std::deque<DispatchEntry> for per-queue FIFO isolation
- CompletionTracker fires signals in per-queue submission order when all
   WGs of a dispatch complete (gem5 HSAQueueEntry model)
- CU refcount via begin_workgroup()/release_wf() — Wavefront::halt()
   decrements the WG refcount, fires notify_wg_complete on zero
- Non-blocking INVALID packet and barrier dependency handling
- SDMA fetch runs before AQL doorbell clamping to avoid early-return

Fixes cross-queue signal contamination that caused vLLM to hang when
vendor-specific packets on one queue blocked kernel dispatch signals
on another. Verified with vLLM OPT-125M serving pipeline (2467
dispatches, full inference to completion).

## JIRA ID
N/A

## Test Plan
Run all tests and E2E OPT125 model

## Test Result
All tests pass, OPT125 produces correct tokens against CPU reference.

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.