### PR TITLE
[aqlprofile] Fix SPM state map lifetime to avoid dlclose leak

### DIFF
--- a/projects/aqlprofile/src/core/spm_v2.cpp
+++ b/projects/aqlprofile/src/core/spm_v2.cpp
@@ -246,10 +246,10 @@ private:
     std::map<aqlprofile_handle_t, std::unique_ptr<ManagerThread>> threads{};
 };
 
-SpmStateMap& spm_state_map()
+SpmStateMap* spm_state_map()
 {
-    static SpmStateMap map;
-    return map;
+    static SpmStateMap* instance = new SpmStateMap{};
+    return instance;
 }
 
 hsa_status_t _internal_aqlprofile_spm_create_packets(
@@ -289,7 +289,7 @@ hsa_status_t _internal_aqlprofile_spm_create_packets(
     handle->handle = memory->GetHandler();
     out_desc->data = memory->GetOutputBuf();
     out_desc->size = SPM_DESC_SIZE;
-    spm_state_map().insert(*handle, s);
+    spm_state_map()->insert(*handle, s);
 
     {
         aql_profile::Pm4Factory* pm4_factory = nullptr;
@@ -379,7 +379,7 @@ PUBLIC_API hsa_status_t aqlprofile_spm_start(
     aqlprofile_spm_data_callback_t data_cb,
     void*                          userdata
 ) {
-    auto s = aqlprofile::spm::spm_state_map().query(handle);
+    auto s = aqlprofile::spm::spm_state_map()->query(handle);
     if (!s) return HSA_STATUS_ERROR_NOT_INITIALIZED;
 
     // The first page of output_buffer is reserved for SpmBufferDesc
@@ -413,7 +413,7 @@ PUBLIC_API hsa_status_t aqlprofile_spm_start(
         auto manager = std::make_unique<ManagerThread>(s, data_cb, userdata);
 
         CHECKHSA(manager->status, return manager->status);
-        aqlprofile::spm::spm_state_map().setthread(handle, std::move(manager));
+        aqlprofile::spm::spm_state_map()->setthread(handle, std::move(manager));
     }
     catch(...) { return HSA_STATUS_ERROR; }
     return HSA_STATUS_SUCCESS;
@@ -421,13 +421,13 @@ PUBLIC_API hsa_status_t aqlprofile_spm_start(
 
 PUBLIC_API hsa_status_t aqlprofile_spm_stop(aqlprofile_handle_t handle)
 {
-    bool b = aqlprofile::spm::spm_state_map().setthread(handle, nullptr);
+    bool b = aqlprofile::spm::spm_state_map()->setthread(handle, nullptr);
     return b ? HSA_STATUS_SUCCESS : HSA_STATUS_ERROR_NOT_INITIALIZED;
 }
 
 PUBLIC_API void aqlprofile_spm_delete_packets(aqlprofile_handle_t handle)
 {
-    aqlprofile::spm::spm_state_map().remove(handle);
+    aqlprofile::spm::spm_state_map()->remove(handle);
 }
 
 struct consumer_thread_handle_t

--- a/projects/aqlprofile/src/core/spm_v2.cpp
+++ b/projects/aqlprofile/src/core/spm_v2.cpp
@@ -246,7 +246,11 @@ private:
     std::map<aqlprofile_handle_t, std::unique_ptr<ManagerThread>> threads{};
 };
 
-auto* spm_state_map = new SpmStateMap{};
+SpmStateMap& spm_state_map()
+{
+    static SpmStateMap map;
+    return map;
+}
 
 hsa_status_t _internal_aqlprofile_spm_create_packets(
     aqlprofile_handle_t*                 handle,
@@ -285,7 +289,7 @@ hsa_status_t _internal_aqlprofile_spm_create_packets(
     handle->handle = memory->GetHandler();
     out_desc->data = memory->GetOutputBuf();
     out_desc->size = SPM_DESC_SIZE;
-    spm_state_map->insert(*handle, s);
+    spm_state_map().insert(*handle, s);
 
     {
         aql_profile::Pm4Factory* pm4_factory = nullptr;
@@ -375,7 +379,7 @@ PUBLIC_API hsa_status_t aqlprofile_spm_start(
     aqlprofile_spm_data_callback_t data_cb,
     void*                          userdata
 ) {
-    auto s = aqlprofile::spm::spm_state_map->query(handle);
+    auto s = aqlprofile::spm::spm_state_map().query(handle);
     if (!s) return HSA_STATUS_ERROR_NOT_INITIALIZED;
 
     // The first page of output_buffer is reserved for SpmBufferDesc
@@ -409,7 +413,7 @@ PUBLIC_API hsa_status_t aqlprofile_spm_start(
         auto manager = std::make_unique<ManagerThread>(s, data_cb, userdata);
 
         CHECKHSA(manager->status, return manager->status);
-        aqlprofile::spm::spm_state_map->setthread(handle, std::move(manager));
+        aqlprofile::spm::spm_state_map().setthread(handle, std::move(manager));
     }
     catch(...) { return HSA_STATUS_ERROR; }
     return HSA_STATUS_SUCCESS;
@@ -417,13 +421,13 @@ PUBLIC_API hsa_status_t aqlprofile_spm_start(
 
 PUBLIC_API hsa_status_t aqlprofile_spm_stop(aqlprofile_handle_t handle)
 {
-    bool b = aqlprofile::spm::spm_state_map->setthread(handle, nullptr);
+    bool b = aqlprofile::spm::spm_state_map().setthread(handle, nullptr);
     return b ? HSA_STATUS_SUCCESS : HSA_STATUS_ERROR_NOT_INITIALIZED;
 }
 
 PUBLIC_API void aqlprofile_spm_delete_packets(aqlprofile_handle_t handle)
 {
-    aqlprofile::spm::spm_state_map->remove(handle);
+    aqlprofile::spm::spm_state_map().remove(handle);
 }
 
 struct consumer_thread_handle_t

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
@@ -10,6 +10,7 @@
 
 #include "lib/aqlprofile/core/logger.hpp"
 #include "lib/aqlprofile/core/pm4_factory.h"
+#include "lib/common/static_object.hpp"
 
 #include <thread>
 #include <condition_variable>
@@ -276,7 +277,13 @@ private:
     std::map<aqlprofile_handle_t, std::unique_ptr<ManagerThread>> threads{};
 };
 
-auto* spm_state_map = new SpmStateMap{};
+// Lazy-init via rocprofiler::common::static_object; destroyed in destroy_static_objects() at exit.
+SpmStateMap*
+spm_state_map()
+{
+    static auto*& _v = rocprofiler::common::static_object<SpmStateMap>::construct();
+    return _v;
+}
 
 hsa_status_t
 _internal_aqlprofile_spm_create_packets(aqlprofile_handle_t*          handle,
@@ -325,7 +332,7 @@ _internal_aqlprofile_spm_create_packets(aqlprofile_handle_t*          handle,
     handle->handle = memory->GetHandler();
     out_desc->data = memory->GetOutputBuf();
     out_desc->size = SPM_DESC_SIZE;
-    spm_state_map->insert(*handle, s);
+    spm_state_map()->insert(*handle, s);
 
     {
         aql_profile::Pm4Factory* pm4_factory = nullptr;
@@ -424,7 +431,7 @@ aqlprofile_spm_start(aqlprofile_handle_t            handle,
                      aqlprofile_spm_data_callback_t data_cb,
                      void*                          userdata)
 {
-    auto s = aqlprofile::spm::spm_state_map->query(handle);
+    auto s = aqlprofile::spm::spm_state_map()->query(handle);
     if(!s) return HSA_STATUS_ERROR_NOT_INITIALIZED;
 
     // The first page of output_buffer is reserved for SpmBufferDesc
@@ -459,7 +466,7 @@ aqlprofile_spm_start(aqlprofile_handle_t            handle,
         auto manager = std::make_unique<ManagerThread>(s, data_cb, userdata);
 
         CHECKHSA(manager->status, return manager->status);
-        aqlprofile::spm::spm_state_map->setthread(handle, std::move(manager));
+        aqlprofile::spm::spm_state_map()->setthread(handle, std::move(manager));
     } catch(...)
     {
         return HSA_STATUS_ERROR;
@@ -470,14 +477,14 @@ aqlprofile_spm_start(aqlprofile_handle_t            handle,
 PUBLIC_API hsa_status_t
 aqlprofile_spm_stop(aqlprofile_handle_t handle)
 {
-    bool b = aqlprofile::spm::spm_state_map->setthread(handle, nullptr);
+    bool b = aqlprofile::spm::spm_state_map()->setthread(handle, nullptr);
     return b ? HSA_STATUS_SUCCESS : HSA_STATUS_ERROR_NOT_INITIALIZED;
 }
 
 PUBLIC_API void
 aqlprofile_spm_delete_packets(aqlprofile_handle_t handle)
 {
-    aqlprofile::spm::spm_state_map->remove(handle);
+    aqlprofile::spm::spm_state_map()->remove(handle);
 }
 
 struct consumer_thread_handle_t


### PR DESCRIPTION
## Motivation

LeakSanitizer reports a 152-byte leak when clang-built aqlprofile is dlopen/dlclose'd because the SPM state map was heap-allocated and never released.

## Technical Details

Replace the leaked raw-pointer singleton with a function-local static SpmStateMap accessor and update call sites to use the owned instance.

## JIRA ID

ROCM-24382

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
