### PR TITLE
rocr: Allow all agents to call hsa_amd_vmem_get_access

### DIFF
--- a/projects/rocr-runtime/rocrtst/common/common.cc
+++ b/projects/rocr-runtime/rocrtst/common/common.cc
@@ -201,8 +201,6 @@ hsa_status_t IterateCPUAgents(hsa_agent_t agent, void *data) {
   return status;
 }
 
-
-
 // Find GPU Agents
 hsa_status_t IterateGPUAgents(hsa_agent_t agent, void *data) {
   hsa_status_t status;
@@ -216,6 +214,23 @@ hsa_status_t IterateGPUAgents(hsa_agent_t agent, void *data) {
   RET_IF_HSA_COMMON_ERR(status);
   if (HSA_STATUS_SUCCESS == status && HSA_DEVICE_TYPE_GPU == device_type) {
     gpus->push_back(agent);
+  }
+  return status;
+}
+
+// Find AIE Agents
+hsa_status_t IterateAIEAgents(hsa_agent_t agent, void* data) {
+  hsa_status_t status;
+  assert(data != nullptr);
+  if (data == nullptr) {
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+  std::vector<hsa_agent_t>* aies = static_cast<std::vector<hsa_agent_t>*>(data);
+  hsa_device_type_t device_type;
+  status = hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &device_type);
+  RET_IF_HSA_COMMON_ERR(status);
+  if (HSA_STATUS_SUCCESS == status && HSA_DEVICE_TYPE_AIE == device_type) {
+    aies->push_back(agent);
   }
   return status;
 }

--- a/projects/rocr-runtime/rocrtst/common/common.h
+++ b/projects/rocr-runtime/rocrtst/common/common.h
@@ -187,6 +187,15 @@ hsa_status_t IterateCPUAgents(hsa_agent_t agent, void *data);
 /// \returns HSA_STATUS_SUCCESS if no errors are encountered.
 hsa_status_t IterateGPUAgents(hsa_agent_t agent, void *data);
 
+/// If the provided agent is associated with an AIE, return that agent through
+/// output parameter. This function is meant to be the call-back function used
+/// with hsa_iterate_agents to find  all the AIE agents.
+/// \param[in] agent Agent to evaluate if AIE
+/// \param[out] data If agent is associated with an AIE, this pointer will point
+///  to the agent upon return
+/// \returns HSA_STATUS_SUCCESS if no errors are encountered.
+hsa_status_t IterateAIEAgents(hsa_agent_t agent, void* data);
+
 /// Find a GLOBAL memory pool. By this, we mean not a kernel args pool.
 /// This function is meant to be the call-back function used
 /// with hsa_amd_agent_iterate_memory_pools.

--- a/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
@@ -137,6 +137,7 @@ void VirtMemoryTestBasic::TestCreateDestroy(hsa_agent_t agent, hsa_amd_memory_po
   hsa_amd_pointer_info_t ptrInfo = {};
   uint32_t num_agents_accessible = 0;
   std::vector<hsa_agent_t> gpus;
+  std::vector<hsa_agent_t> aies;
   rocrtst::pool_info_t pool_i;
   hsa_device_type_t ag_type;
   char ag_name[64];
@@ -155,6 +156,7 @@ void VirtMemoryTestBasic::TestCreateDestroy(hsa_agent_t agent, hsa_amd_memory_po
   const size_t sizeof_addrRange = 20 * granule_size;
 
   ASSERT_SUCCESS(hsa_iterate_agents(rocrtst::IterateGPUAgents, &gpus));
+  ASSERT_SUCCESS(hsa_iterate_agents(rocrtst::IterateAIEAgents, &aies));
   ASSERT_SUCCESS(hsa_amd_vmem_address_reserve(&addrRange, sizeof_addrRange, 0, 0));
   ASSERT_SUCCESS(hsa_amd_vmem_address_reserve(&addrRangeUnmapped, sizeof_addrRangeUnmapped, 0, 0));
 
@@ -228,6 +230,14 @@ void VirtMemoryTestBasic::TestCreateDestroy(hsa_agent_t agent, hsa_amd_memory_po
     ASSERT_EQ(perm, HSA_ACCESS_PERMISSION_NONE);
   }
 
+  // Access to each AIE should be None
+  for (auto aieIt = aies.begin(); aieIt != aies.end(); ++aieIt) {
+    hsa_access_permission_t perm = HSA_ACCESS_PERMISSION_RW;
+
+    ASSERT_SUCCESS(hsa_amd_vmem_get_access(addrRange, &perm, *aieIt));
+    ASSERT_EQ(perm, HSA_ACCESS_PERMISSION_NONE);
+  }
+
   /* Set RO Access to all GPUs */
   {
     int descIndex = 0;
@@ -238,20 +248,41 @@ void VirtMemoryTestBasic::TestCreateDestroy(hsa_agent_t agent, hsa_amd_memory_po
     ASSERT_SUCCESS(hsa_amd_vmem_set_access(addrRange, 10 * granule_size, desc, gpus.size()));
   }
 
+  /* Set RO Access to all AIEs */
+  if (!aies.empty()) {
+    int descIndex = 0;
+    hsa_amd_memory_access_desc_t desc[aies.size()];
+    for (auto aieIt = aies.begin(); aieIt != aies.end(); ++aieIt) {
+      desc[descIndex++] = {HSA_ACCESS_PERMISSION_RO, *aieIt};
+    }
+    ASSERT_SUCCESS(hsa_amd_vmem_set_access(addrRange, 10 * granule_size, desc, aies.size()));
+  }
+
   /* Verity pointer info accessible agents on mapped addresses */
   ptrInfo.size = sizeof(ptrInfo);
   ASSERT_SUCCESS(hsa_amd_pointer_info(addrRange, &ptrInfo, &malloc, &num_agents_accessible,
                                       &agents_accessible));
   ASSERT_EQ(ptrInfo.type, HSA_EXT_POINTER_TYPE_HSA_VMEM);
   ASSERT_EQ(ptrInfo.sizeInBytes, sizeof_mem_handle);  // size matches memory handle
-  ASSERT_EQ(num_agents_accessible, gpus.size());
+  ASSERT_EQ(num_agents_accessible, gpus.size() + aies.size());
   ASSERT_NE(agents_accessible, nullptr);
 
   /* Verify agents_accessible is valid */
   for (auto gpuIt = gpus.begin(); gpuIt != gpus.end(); ++gpuIt) {
     bool found = false;
-    for (auto i = 0; i < gpus.size(); i++) {
+    for (auto i = 0; i < num_agents_accessible; i++) {
       if (agents_accessible[i].handle == (*gpuIt).handle) {
+        found = true;
+        break;
+      }
+    }
+    ASSERT_EQ(found, true);
+  }
+
+  for (auto aieIt = aies.begin(); aieIt != aies.end(); ++aieIt) {
+    bool found = false;
+    for (auto i = 0; i < num_agents_accessible; i++) {
+      if (agents_accessible[i].handle == (*aieIt).handle) {
         found = true;
         break;
       }
@@ -269,6 +300,17 @@ void VirtMemoryTestBasic::TestCreateDestroy(hsa_agent_t agent, hsa_amd_memory_po
 
     /* addrRangeUnmapped was never mapped, so this is an invalid mapping */
     err = hsa_amd_vmem_get_access(addrRangeUnmapped, &perm, *gpuIt);
+    ASSERT_EQ(err, HSA_STATUS_ERROR_INVALID_ALLOCATION);
+  }
+
+  for (auto aieIt = aies.begin(); aieIt != aies.end(); ++aieIt) {
+    hsa_access_permission_t perm = HSA_ACCESS_PERMISSION_NONE;
+
+    ASSERT_SUCCESS(hsa_amd_vmem_get_access(addrRange, &perm, *aieIt));
+    ASSERT_EQ(perm, HSA_ACCESS_PERMISSION_RO);
+
+    /* addrRangeUnmapped was never mapped, so this is an invalid mapping */
+    err = hsa_amd_vmem_get_access(addrRangeUnmapped, &perm, *aieIt);
     ASSERT_EQ(err, HSA_STATUS_ERROR_INVALID_ALLOCATION);
   }
 
@@ -1188,10 +1230,10 @@ void VirtMemoryTestBasic::MemoryAccountingTest(hsa_agent_t agent, hsa_amd_memory
   ptr_info.size = sizeof(ptr_info);
   ASSERT_SUCCESS(hsa_amd_pointer_info(reserved_addr, &ptr_info, nullptr, nullptr, nullptr));
   ASSERT_SUCCESS(hsa_amd_vmem_handle_create(pool, allocation_size, MEMORY_TYPE_NONE, 0, &mem_handle));
- 
+
   ASSERT_SUCCESS(hsa_agent_get_info(agent, (hsa_agent_info_t)HSA_AMD_AGENT_INFO_MEMORY_AVAIL, &amount_current));
   ASSERT_NEAR(amount_begin - amount_current, allocation_size, 4096);
-  
+
   ASSERT_SUCCESS(hsa_amd_vmem_map(reserved_addr, allocation_size, 0, mem_handle, 0));
 
   hsa_amd_memory_access_desc_t access_desc = {HSA_ACCESS_PERMISSION_RW, agent};
@@ -1377,7 +1419,7 @@ void VirtMemoryTestBasic::TestVirtAddressAlias(hsa_agent_t cpuAgent, hsa_agent_t
 
   // Setup kernel args to write to addr1
   kernArgs->a = host_data;
-  kernArgs->b = dummy_data;  // dummy buffer kernel writes to 
+  kernArgs->b = dummy_data;  // dummy buffer kernel writes to
   kernArgs->c = reinterpret_cast<int*>(addr1);
 
   // Create and dispatch AQL packet for addr1

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -4236,8 +4236,7 @@ hsa_status_t Runtime::VMemoryGetAccess(const void* va, hsa_access_permission_t* 
   if (!mappedHandleFound) return HSA_STATUS_ERROR_INVALID_ALLOCATION;
 
   Agent* agent = Agent::Convert(agent_handle);
-  if (agent == NULL || !agent->IsValid() || agent->device_type() != core::Agent::kAmdGpuDevice)
-    return HSA_STATUS_ERROR_INVALID_AGENT;
+  if (agent == NULL || !agent->IsValid()) return HSA_STATUS_ERROR_INVALID_AGENT;
 
   auto agentPermsIt = mappedHandleIt->second.allowed_agents.find(agent);
   if (agentPermsIt != mappedHandleIt->second.allowed_agents.end()) {


### PR DESCRIPTION
## Motivation

Calling `hsa_amd_vmem_get_access` from non-GPU agents was returning HSA_STATUS_ERROR_INVALID_AGENT although you can set / unset permissions for them.

## Technical Details

Remove the check if the agent is a GPU agent.

## JIRA ID

NA

## Test Plan

Ran AIE example code that does `hsa_amd_vmem_set_access()` followed by `hsa_amd_vmem_get_access()`

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
