### PR TITLE
[rocprofiler-compute] Fix CMake warnings in native tool runtime compile

### DIFF
--- a/projects/rocprofiler-compute/src/lib/CMakeLists.txt
+++ b/projects/rocprofiler-compute/src/lib/CMakeLists.txt
@@ -1,3 +1,6 @@
+cmake_minimum_required(VERSION 3.21)
+project(rocprofiler-compute-tool LANGUAGES CXX)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/CMakeLists.txt
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/CMakeLists.txt
@@ -20,14 +20,15 @@ target_link_libraries(
 
 set_target_properties(
     ${target}
-    PROPERTIES INSTALL_RPATH "$ORIGIN/../../../${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}"
+    PROPERTIES
+        INSTALL_RPATH "$ORIGIN/../../../${CMAKE_INSTALL_LIBDIR}/${CMAKE_PROJECT_NAME}"
 )
 
 if(INSTALL_TESTS)
     install(
         TARGETS ${target}
         RUNTIME
-            DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}/tests
+            DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${CMAKE_PROJECT_NAME}/tests
             COMPONENT tests
     )
 endif()

--- a/projects/rocprofiler-compute/src/utils/native_tool_finder.py
+++ b/projects/rocprofiler-compute/src/utils/native_tool_finder.py
@@ -63,26 +63,26 @@ class NativeToolFinder:
         return self.__find_file_by_glob_pattern(self.root_path, pattern)
 
     def _generate_cmake(self, src_path: Path) -> None:
-        build_command = (
-            "cmake "
-            + f"-S {src_path}/{self.sources_dir_name} "
-            + f"-B {src_path}/{self.sources_dir_name}/{self.sources_build_subdir_name}"
-        )
-        console_log(f"Building native tool using command: {build_command}")
-        self.__execute_command(build_command)
-
-    def _build_cmake(self, src_path: Path) -> None:
         generate_command = (
-            "cmake --build "
-            + f"{src_path}/{self.sources_dir_name}/{self.sources_build_subdir_name} "
-            + "--parallel"
+            "cmake "
+            f"-S {src_path}/{self.sources_dir_name} "
+            f"-B {src_path}/{self.sources_dir_name}/{self.sources_build_subdir_name}"
         )
         console_log(f"Generating native tool project using command: {generate_command}")
         self.__execute_command(generate_command)
 
+    def _build_cmake(self, src_path: Path) -> None:
+        build_command = (
+            "cmake --build "
+            f"{src_path}/{self.sources_dir_name}/{self.sources_build_subdir_name} "
+            "--parallel"
+        )
+        console_log(f"Building native tool using command: {build_command}")
+        self.__execute_command(build_command)
+
     def __execute_command(self, command: str) -> None:
-        success, output = capture_subprocess_output(shlex.split(command))
-        console_debug(f"Build output: {output}")
+        # Output is logged when enable_logging=False is not provided
+        success, _ = capture_subprocess_output(shlex.split(command))
         if not success:
             msg = f"Failed to execute command: {command}"
             raise RuntimeError(msg)


### PR DESCRIPTION
## Motivation

Profile mode runtime-compiles the native tool and emits CMake dev warnings on every run. Fix the warnings cleanly instead of using -Wno-dev.

## Technical Details

- src/lib/CMakeLists.txt: add cmake_minimum_required(VERSION 3.21) and project(rocprofiler-compute-tool LANGUAGES CXX).

- src/lib/rocprofiler_compute_tool/tests/CMakeLists.txt: PROJECT_NAME to CMAKE_PROJECT_NAME so root install path stays lib/rocprofiler-compute/.

- Bugfix: src/utils/native_tool_finder.py had generate_command and build_command variable names and log strings swapped.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

- Root build: rm -rf build install && cmake -B build -D CMAKE_INSTALL_PREFIX=install -D ENABLE_TESTS=ON -D INSTALL_TESTS=ON -D ENABLE_COVERAGE=ON -S . && cmake --build build --target install --parallel 8

- Verify install/lib/ has rocprofiler-compute/librocprofiler-compute-tool.so and no rocprofiler-compute-tool/ folder.

- Profile mode: src/rocprof-compute profile --name memcopy -b 2 --verbose -- tests/memcopy. Confirm no CMake dev warnings.

## Test Result

Root build and install clean, layout unchanged. Profile-mode runtime compile has no dev warnings.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.