### PR TITLE
Users/mahughes/isolated test coverage

### DIFF
--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -820,6 +820,11 @@ if(ENABLE_CODE_COVERAGE)
 
   target_link_options(rccl PRIVATE ${COVERAGE_SHARED_LINKER_FLAGS})
   target_link_options(rccl PRIVATE ${COVERAGE_EXE_LINKER_FLAGS})
+
+  # Expose explicit profile-flush wrappers so test harnesses that bypass
+  # atexit() handlers (e.g. ProcessIsolatedTestRunner using _exit()) can
+  # still flush librccl's private LLVM profile runtime instance.
+  target_sources(rccl PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/misc/coverage_flush.cc)
 elseif(BUILD_TESTS) # Enable default/hidden visibility based on build type and ROCM_VERSION
   if (ROCM_VERSION VERSION_GREATER_EQUAL "60400" AND CMAKE_BUILD_TYPE MATCHES "Debug")
     target_compile_options(rccl PRIVATE -fvisibility=default)

--- a/projects/rccl/src/misc/coverage_flush.cc
+++ b/projects/rccl/src/misc/coverage_flush.cc
@@ -1,0 +1,35 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Exported wrappers around the LLVM source-based coverage profile runtime,
+// compiled into librccl.so only when ENABLE_CODE_COVERAGE is on.
+//
+// Both librccl.so and the unit-test executables link libclang_rt.profile.a
+// statically, so each binary owns a *private* instance of the profile
+// runtime (with its own counters, its own __llvm_profile_write_file, and its
+// own filename buffer). The runtime's symbols are pulled in with hidden
+// visibility from the static archive, so the test binary cannot reach
+// librccl's writer via dlsym.
+//
+// To support the process-isolated test harness (which calls _exit() in the
+// child and therefore bypasses the runtime's atexit() handler), we expose
+// these explicit, default-visibility wrappers so the test side can flush
+// librccl's coverage data for each forked-and-_exited child process.
+
+extern "C" int  __llvm_profile_write_file(void);
+extern "C" void __llvm_profile_set_filename(const char* name);
+
+extern "C" __attribute__((visibility("default")))
+int rcclCoverageWriteFile(void)
+{
+    return __llvm_profile_write_file();
+}
+
+extern "C" __attribute__((visibility("default")))
+void rcclCoverageSetFilename(const char* name)
+{
+    __llvm_profile_set_filename(name);
+}

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -17,6 +17,9 @@ if(BUILD_TESTS)
   if (ENABLE_CODE_COVERAGE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
     set(HIPCC_COMPILE_FLAGS "${HIPCC_COMPILE_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
+    # Allow ProcessIsolatedTestRunner.cpp to call __llvm_profile_write_file()
+    # explicitly before _exit() so child-process coverage data is flushed.
+    add_compile_definitions(RCCL_TEST_CODE_COVERAGE=1)
   endif()
 
   find_package(hsa-runtime64 PATHS /opt/rocm )

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -453,14 +453,39 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
             std::string pattern    = (envPattern && *envPattern)
                                          ? envPattern
                                          : "default_%m.profraw";
+            // Ensure %p is present so each child gets its own file.
             if(pattern.find("%p") == std::string::npos)
             {
-                // Inject %p before the extension to keep child files unique.
                 auto dot = pattern.rfind('.');
                 if(dot == std::string::npos)
                     pattern += "_%p";
                 else
                     pattern.insert(dot, "_%p");
+            }
+            // The LLVM profile runtime caches getpid() at first init in the
+            // parent, so its own %p expansion would yield the parent PID in
+            // every child. Substitute %p ourselves with the child's real
+            // pid, leaving %m (binary signature) for the runtime to expand.
+            {
+                char            pidbuf[32];
+                std::snprintf(pidbuf, sizeof(pidbuf), "%d",
+                              static_cast<int>(getpid()));
+                std::string out;
+                out.reserve(pattern.size() + 16);
+                for(size_t i = 0; i < pattern.size();)
+                {
+                    if(i + 1 < pattern.size() && pattern[i] == '%'
+                       && pattern[i + 1] == 'p')
+                    {
+                        out.append(pidbuf);
+                        i += 2;
+                    }
+                    else
+                    {
+                        out.push_back(pattern[i++]);
+                    }
+                }
+                pattern.swap(out);
             }
             __llvm_profile_set_filename(pattern.c_str());
             if(libSet) libSet(pattern.c_str());

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -425,22 +425,45 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
         {
             redirectOutputToPipes(stdout_fd, stderr_fd);
 #if defined(RCCL_TEST_CODE_COVERAGE)
-            // The LLVM profile runtime resolves LLVM_PROFILE_FILE (and any %p
-            // patterns it contains) once, in the parent, before fork(). All
-            // children would otherwise inherit the same already-resolved path
-            // and overwrite each other's coverage data. Override the filename
-            // here so each child writes a unique .profraw based on its own PID.
+            // The LLVM profile runtime resolves LLVM_PROFILE_FILE (including
+            // any %p / %m patterns) once in the parent, before fork(), and
+            // caches the resolved path. Without intervention every child
+            // would inherit the parent's PID-substituted path and overwrite
+            // the same .profraw. Re-call __llvm_profile_set_filename() in
+            // the child with the original pattern so %p is re-resolved
+            // against the child PID. Force a %p into the pattern if the
+            // user didn't supply one, so children don't collide.
+            //
+            // librccl.so is statically linked against its own copy of the
+            // LLVM profile runtime (separate counters, separate writer,
+            // separate filename buffer). librccl exports
+            // rcclCoverageSetFilename / rcclCoverageWriteFile (built only
+            // when ENABLE_CODE_COVERAGE is on) which forward to its private
+            // runtime instance. Resolve them dynamically so the test binary
+            // doesn't need to declare them at link time. %m in the pattern
+            // (binary signature) keeps the two runtimes' files distinct.
+            using WriteFn = int (*)(void);
+            using SetFn   = void (*)(const char*);
+            auto libWrite = reinterpret_cast<WriteFn>(
+                dlsym(RTLD_DEFAULT, "rcclCoverageWriteFile"));
+            auto libSet = reinterpret_cast<SetFn>(
+                dlsym(RTLD_DEFAULT, "rcclCoverageSetFilename"));
+
+            const char* envPattern = std::getenv("LLVM_PROFILE_FILE");
+            std::string pattern    = (envPattern && *envPattern)
+                                         ? envPattern
+                                         : "default_%m.profraw";
+            if(pattern.find("%p") == std::string::npos)
             {
-                char            childProfile[512];
-                const char*     pattern = std::getenv("LLVM_PROFILE_FILE");
-                if(!pattern || !*pattern)
-                    pattern = "default_%m.profraw";
-                std::snprintf(
-                    childProfile, sizeof(childProfile), "rccl_isolated_%d_%s",
-                    static_cast<int>(getpid()), pattern
-                );
-                __llvm_profile_set_filename(childProfile);
+                // Inject %p before the extension to keep child files unique.
+                auto dot = pattern.rfind('.');
+                if(dot == std::string::npos)
+                    pattern += "_%p";
+                else
+                    pattern.insert(dot, "_%p");
             }
+            __llvm_profile_set_filename(pattern.c_str());
+            if(libSet) libSet(pattern.c_str());
 #endif
             int result = runTestInProcess(testConfig);
             // Flush LLVM source-based coverage data before _exit().
@@ -449,40 +472,8 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
             // writer registered by libclang_rt.profile, so without an
             // explicit flush no .profraw file is produced for this child.
 #if defined(RCCL_TEST_CODE_COVERAGE)
-            // Flush this binary's coverage data.
             __llvm_profile_write_file();
-            // librccl.so is statically linked against its own copy of the
-            // LLVM profile runtime, so the symbol above only flushes the
-            // test binary. librccl exports rcclCoverageSetFilename /
-            // rcclCoverageWriteFile (built only when ENABLE_CODE_COVERAGE
-            // is on) which forward to its private runtime instance.
-            // Resolve them dynamically so the test binary doesn't need to
-            // declare them at link time.
-            using WriteFn = int (*)(void);
-            using SetFn   = void (*)(const char*);
-            auto libWrite = reinterpret_cast<WriteFn>(
-                dlsym(RTLD_DEFAULT, "rcclCoverageWriteFile")
-            );
-            auto libSet = reinterpret_cast<SetFn>(
-                dlsym(RTLD_DEFAULT, "rcclCoverageSetFilename")
-            );
-            if(libSet)
-            {
-                char            libProfile[512];
-                const char*     pattern = std::getenv("LLVM_PROFILE_FILE");
-                if(!pattern || !*pattern)
-                    pattern = "default_%m.profraw";
-                std::snprintf(
-                    libProfile, sizeof(libProfile),
-                    "rccl_isolated_lib_%d_%s",
-                    static_cast<int>(getpid()), pattern
-                );
-                libSet(libProfile);
-            }
-            if(libWrite)
-            {
-                libWrite();
-            }
+            if(libWrite) libWrite();
 #endif
             // Use _exit() instead of exit() to avoid atexit handlers
             // This prevents GPU runtime cleanup issues after fork

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -19,6 +19,20 @@
 
 #include "ErrCode.hpp"
 
+// LLVM source-based code coverage profile writer.
+// When the binary is built with -fprofile-instr-generate, libclang_rt.profile
+// provides this symbol and a default atexit() handler that writes the
+// per-process .profraw file. Because we terminate child test processes with
+// _exit() (to skip atexit handlers that would otherwise tear down GPU runtime
+// state), that handler never fires and coverage data is lost. When coverage
+// is enabled at build time (RCCL_TEST_CODE_COVERAGE), declare the writer so
+// we can flush coverage explicitly before _exit().
+#if defined(RCCL_TEST_CODE_COVERAGE)
+#include <dlfcn.h>
+extern "C" int  __llvm_profile_write_file(void);
+extern "C" void __llvm_profile_set_filename(const char* name);
+#endif
+
 namespace RcclUnitTesting
 {
 
@@ -410,7 +424,66 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
         if(pid == 0)
         {
             redirectOutputToPipes(stdout_fd, stderr_fd);
+#if defined(RCCL_TEST_CODE_COVERAGE)
+            // The LLVM profile runtime resolves LLVM_PROFILE_FILE (and any %p
+            // patterns it contains) once, in the parent, before fork(). All
+            // children would otherwise inherit the same already-resolved path
+            // and overwrite each other's coverage data. Override the filename
+            // here so each child writes a unique .profraw based on its own PID.
+            {
+                char            childProfile[512];
+                const char*     pattern = std::getenv("LLVM_PROFILE_FILE");
+                if(!pattern || !*pattern)
+                    pattern = "default_%m.profraw";
+                std::snprintf(
+                    childProfile, sizeof(childProfile), "rccl_isolated_%d_%s",
+                    static_cast<int>(getpid()), pattern
+                );
+                __llvm_profile_set_filename(childProfile);
+            }
+#endif
             int result = runTestInProcess(testConfig);
+            // Flush LLVM source-based coverage data before _exit().
+            // _exit() skips atexit handlers (intentionally, to avoid GPU
+            // runtime teardown issues), but that also skips the profile
+            // writer registered by libclang_rt.profile, so without an
+            // explicit flush no .profraw file is produced for this child.
+#if defined(RCCL_TEST_CODE_COVERAGE)
+            // Flush this binary's coverage data.
+            __llvm_profile_write_file();
+            // librccl.so is statically linked against its own copy of the
+            // LLVM profile runtime, so the symbol above only flushes the
+            // test binary. librccl exports rcclCoverageSetFilename /
+            // rcclCoverageWriteFile (built only when ENABLE_CODE_COVERAGE
+            // is on) which forward to its private runtime instance.
+            // Resolve them dynamically so the test binary doesn't need to
+            // declare them at link time.
+            using WriteFn = int (*)(void);
+            using SetFn   = void (*)(const char*);
+            auto libWrite = reinterpret_cast<WriteFn>(
+                dlsym(RTLD_DEFAULT, "rcclCoverageWriteFile")
+            );
+            auto libSet = reinterpret_cast<SetFn>(
+                dlsym(RTLD_DEFAULT, "rcclCoverageSetFilename")
+            );
+            if(libSet)
+            {
+                char            libProfile[512];
+                const char*     pattern = std::getenv("LLVM_PROFILE_FILE");
+                if(!pattern || !*pattern)
+                    pattern = "default_%m.profraw";
+                std::snprintf(
+                    libProfile, sizeof(libProfile),
+                    "rccl_isolated_lib_%d_%s",
+                    static_cast<int>(getpid()), pattern
+                );
+                libSet(libProfile);
+            }
+            if(libWrite)
+            {
+                libWrite();
+            }
+#endif
             // Use _exit() instead of exit() to avoid atexit handlers
             // This prevents GPU runtime cleanup issues after fork
             _exit(result);

--- a/projects/rccl/tools/scripts/test_runner/configs/argcheck_tests.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/argcheck_tests.json
@@ -1,0 +1,43 @@
+{
+  "system_configurations": {
+    "name": "RCCL ArgCheckTests",
+    "description": "Run only ArgCheckTests.cpp unit tests"
+  },
+  "paths": {
+    "workdir": "${WORKDIR:-$PWD}",
+    "rocm_path": "${ROCM_PATH:-/opt/rocm}",
+    "mpi_path": "${MPI_PATH:-/opt/ompi}"
+  },
+  "env_variables": {
+    "HSA_NO_SCRATCH_RECLAIM": "1",
+    "NCCL_DEBUG": "WARN"
+  },
+  "build_configuration": {
+    "install_flags": ["--debug", "-t", "-l", "--enable-code-coverage", "--no_clean"],
+    "cmake_options": "-DBUILD_LOCAL_GPU_TARGET_ONLY=ON",
+    "parallel_jobs": 64,
+    "generator": "Unix Makefiles"
+  },
+  "test_configurations": {
+    "argcheck_tests": {
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsFixturesDebug",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 1,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": ""
+      },
+      "rerun_env_variables": {
+        "NCCL_DEBUG": "INFO"
+      },
+      "tests": [
+        {"name": "ArgCheckTest.All", "description": "All ArgCheckTests.cpp tests", "test_filter": "ArgCheckTest.*"}
+      ]
+    }
+  },
+  "test_suites": [
+    {"name": "ArgCheckTests", "config": "argcheck_tests", "enabled": true}
+  ]
+}

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -7,6 +7,7 @@ Test Executor Module
 Handles test execution, build processes, and result tracking
 """
 
+import glob
 import json
 import os
 import re
@@ -1264,11 +1265,11 @@ class TestExecutor:
             if self.args.verbose:
                 print(f"Found library: {librccl_so}")
 
-        # Add test binaries
+        # Add test binaries. Glob rather than maintain a hard-coded list so
+        # newly added rccl-UnitTests* executables are picked up automatically.
         test_dir = os.path.join(self.build_dir, "test")
-        for binary in ["rccl-UnitTestsFixtures", "rccl-UnitTestsFixturesDebug", "rccl-UnitTests", "rccl-UnitTestsMPI", "rccl-UnitTestsAltRsmi"]:
-            binary_path = os.path.join(test_dir, binary)
-            if os.path.isfile(binary_path):
+        for binary_path in sorted(glob.glob(os.path.join(test_dir, "rccl-UnitTests*"))):
+            if os.path.isfile(binary_path) and os.access(binary_path, os.X_OK):
                 object_files.extend(["--object", binary_path])
                 if self.args.verbose:
                     print(f"Found binary: {binary_path}")

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -1266,7 +1266,7 @@ class TestExecutor:
 
         # Add test binaries
         test_dir = os.path.join(self.build_dir, "test")
-        for binary in ["rccl-UnitTestsFixtures", "rccl-UnitTests", "rccl-UnitTestsMPI"]:
+        for binary in ["rccl-UnitTestsFixtures", "rccl-UnitTestsFixturesDebug", "rccl-UnitTests", "rccl-UnitTestsMPI", "rccl-UnitTestsAltRsmi"]:
             binary_path = os.path.join(test_dir, binary)
             if os.path.isfile(binary_path):
                 object_files.extend(["--object", binary_path])


### PR DESCRIPTION
## Motivation

I noticed that tests using the process isolation framework produced no coverage results. 

## Technical Details

This is an attempt to force `fork()`'ed tests to write out profiling information. This is preliminary, there may be better paths forward, but so far neither Opus nor I can find it. 

## JIRA ID

todo, create ticket

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Here is a minimal test_runner config, put it in `/tmp/argcheck_cov.json`: build debug + coverage, run all isolated ArgCheckTest.* tests (ArgCheckTests.cpp uses RUN_ISOLATED_TEST):
```json
{
  "system_configurations": {"name": "argcheck-cov", "description": "demo"},
  "paths": {
    "workdir": "${WORKDIR:-$PWD}",
    "rocm_path": "${ROCM_PATH:-/opt/rocm}",
    "mpi_path":  "${MPI_PATH:-/opt/ompi}"
  },
  "build_configuration": {
    "install_flags": ["--debug", "-t", "-l", "--enable-code-coverage", "--no_clean"],
    "cmake_options": "-DBUILD_LOCAL_GPU_TARGET_ONLY=ON",
    "parallel_jobs": 64,
    "generator": "Unix Makefiles"
  },
  "test_configurations": {
    "argcheck": {
      "is_gtest": true,
      "binary": "rccl-UnitTestsFixturesDebug",
      "num_ranks": 1, "num_nodes": 1, "num_gpus": 1, "timeout": 300,
      "tests": [
        {"name": "ArgCheckTest.All", "test_filter": "ArgCheckTest.*"}
      ]
    }
  },
  "test_suites": [{"name": "ArgCheckTests", "config": "argcheck", "enabled": true}]
}
```

### BEFORE: on `origin/develop` (reproduces the bug)

```bash
git checkout origin/develop
rm -rf build rccl_test_artifacts_*

python3 tools/scripts/test_runner/test_runner.py \
    --config /tmp/argcheck_cov.json \
    --skip-mpi-check --coverage-report 2>&1 | tail -5

# Count .profraw files: should be 2 (parent only — children's coverage lost)
echo "profraw files: $(find build -name '*.profraw' | wc -l)"

# Show that argcheck.cc functions report 0% coverage
REPORT=$(ls -dt rccl_test_artifacts_*/report | head -1)
grep -E "^(CudaPtrCheck|PtrCheck|ArgsCheck)\(" "$REPORT/function_coverage_report.txt"
```

Expected: `profraw files: 2`, and `CudaPtrCheck` / `PtrCheck` / `ArgsCheck` all show **0.00%**.


### AFTER: on this branch

```bash
git checkout users/mahughes/isolated-test-coverage
rm -rf build rccl_test_artifacts_*

python3 tools/scripts/test_runner/test_runner.py \
    --config /tmp/argcheck_cov.json \
    --skip-mpi-check --coverage-report 2>&1 | tail -5

# Should be ~50 (parent + ~24 child PIDs × 2 instrumented binaries)
echo "profraw files: $(find build -name '*.profraw' | wc -l)"

REPORT=$(ls -dt rccl_test_artifacts_*/report | head -1)
grep -E "^(CudaPtrCheck|PtrCheck|ArgsCheck)\(" "$REPORT/function_coverage_report.txt"
```

Expected: `profraw files: 50`, and `PtrCheck` 100%, `CudaPtrCheck` ~78%, `ArgsCheck` ~87% region coverage.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
