### PR TITLE
[rocprofiler-sdk] Replace std::getenv with direct environ reads for bash compatibility

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/aql_profile.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/aql_profile.cpp
@@ -27,6 +27,7 @@
 
 #include "lib/aqlprofile/core/logger.hpp"
 #include "lib/aqlprofile/core/pm4_factory.h"
+#include "lib/common/environment.hpp"
 #include "lib/aqlprofile/pm4/cmd_builder.h"
 #include "lib/aqlprofile/pm4/pmc_builder.h"
 #include "lib/aqlprofile/pm4/spm_builder.h"
@@ -182,16 +183,22 @@ bool                     Pm4Factory::concurrent_create_mode_ = false;
 bool                     Pm4Factory::spm_kfd_mode_           = false;
 Pm4Factory::mutex_t      Pm4Factory::mutex_;
 Pm4Factory::instances_t* Pm4Factory::instances_ = nullptr;
-bool                     read_api_enabled       = true;
+
+// Lazy initialization to avoid reading env in constructor context
+static bool
+is_read_api_enabled()
+{
+    static const bool enabled = []() {
+        auto value = rocprofiler::common::get_env("AQLPROFILE_READ_API", "1");
+        return std::atoi(value.c_str()) != 0;
+    }();
+    return enabled;
+}
 
 CONSTRUCTOR_API void
 constructor()
 {
-    const char* read_api_enabled_str = getenv("AQLPROFILE_READ_API");
-    if(read_api_enabled_str != nullptr)
-    {
-        if(atoi(read_api_enabled_str) == 0) read_api_enabled = false;
-    }
+    // Constructor intentionally empty - env reading deferred to first use
 }
 
 DESTRUCTOR_API void
@@ -269,7 +276,7 @@ hsa_ven_amd_aqlprofile_start(hsa_ven_amd_aqlprofile_profile_t* profile,
 
             // Generate read commands
             auto data_size = pmc_builder->Read(&commands, countersVec, profile->output_buffer.ptr);
-            if(!aql_profile::read_api_enabled) commands.Clear();
+            if(!aql_profile::is_read_api_enabled()) commands.Clear();
             cmd_buffer_mgr.SetRdSize(commands.Size());
 
             // Copy generated read commands
@@ -285,7 +292,7 @@ hsa_ven_amd_aqlprofile_start(hsa_ven_amd_aqlprofile_profile_t* profile,
             cmd_buffer_mgr.SetPreSize(commands.Size());
 
             // Generate stop commands
-            if(!aql_profile::read_api_enabled)
+            if(!aql_profile::is_read_api_enabled())
                 pmc_builder->Read(&commands, countersVec, profile->output_buffer.ptr);
             pmc_builder->Stop(&commands, countersVec);
 
@@ -404,8 +411,9 @@ hsa_ven_amd_aqlprofile_start(hsa_ven_amd_aqlprofile_profile_t* profile,
             }
             else
             {
-                const char* sz_sampling_rate = getenv("AQLPROFILE_SPM_SAMPLE_RATE");
-                if(sz_sampling_rate != nullptr) trace_config.sampleRate = atoi(sz_sampling_rate);
+                // Preserve original behavior: empty string calls atoi("") which returns 0
+                auto env_val = rocprofiler::common::get_env_optional("AQLPROFILE_SPM_SAMPLE_RATE");
+                if(env_val) trace_config.sampleRate = std::atoi(env_val->c_str());
 
                 pm4_builder::SpmBuilder* spm_builder = pm4_factory->GetSpmBuilder();
                 // Generate start commands
@@ -486,7 +494,7 @@ PUBLIC_API hsa_status_t
 hsa_ven_amd_aqlprofile_read(const hsa_ven_amd_aqlprofile_profile_t* profile,
                             aql_profile::packet_t*                  aql_read_packet)
 {
-    if(!aql_profile::read_api_enabled) return HSA_STATUS_ERROR;
+    if(!aql_profile::is_read_api_enabled()) return HSA_STATUS_ERROR;
     try
     {
         // Populate read aql packet

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/aql_profile.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/aql_profile.cpp
@@ -195,12 +195,6 @@ is_read_api_enabled()
     return enabled;
 }
 
-CONSTRUCTOR_API void
-constructor()
-{
-    // Constructor intentionally empty - env reading deferred to first use
-}
-
 DESTRUCTOR_API void
 destructor()
 {
@@ -1029,11 +1023,9 @@ hsa_ven_amd_aqlprofile_att_marker(hsa_ven_amd_aqlprofile_profile_t*           pr
 extern "C" BOOL WINAPI
 DllMain(HINSTANCE /*hinstDLL*/, DWORD fdwReason, LPVOID /*lpvReserved*/)
 {
-    switch(fdwReason)
+    if(fdwReason == DLL_PROCESS_DETACH)
     {
-        case DLL_PROCESS_ATTACH: aql_profile::constructor(); break;
-        case DLL_PROCESS_DETACH: aql_profile::destructor(); break;
-        default: break;
+        aql_profile::destructor();
     }
     return TRUE;
 }

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/aql_profile.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/aql_profile.cpp
@@ -405,7 +405,6 @@ hsa_ven_amd_aqlprofile_start(hsa_ven_amd_aqlprofile_profile_t* profile,
             }
             else
             {
-                // Preserve original behavior: empty string calls atoi("") which returns 0
                 auto env_val = rocprofiler::common::get_env_optional("AQLPROFILE_SPM_SAMPLE_RATE");
                 if(env_val) trace_config.sampleRate = std::atoi(env_val->c_str());
 

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/aql_profile.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/aql_profile.cpp
@@ -195,12 +195,6 @@ is_read_api_enabled()
     return enabled;
 }
 
-CONSTRUCTOR_API void
-constructor()
-{
-    // Constructor intentionally empty - env reading deferred to first use
-}
-
 DESTRUCTOR_API void
 destructor()
 {
@@ -984,11 +978,9 @@ hsa_ven_amd_aqlprofile_att_marker(hsa_ven_amd_aqlprofile_profile_t*           pr
 extern "C" BOOL WINAPI
 DllMain(HINSTANCE /*hinstDLL*/, DWORD fdwReason, LPVOID /*lpvReserved*/)
 {
-    switch(fdwReason)
+    if(fdwReason == DLL_PROCESS_DETACH)
     {
-        case DLL_PROCESS_ATTACH: aql_profile::constructor(); break;
-        case DLL_PROCESS_DETACH: aql_profile::destructor(); break;
-        default: break;
+        aql_profile::destructor();
     }
     return TRUE;
 }

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/pm4_factory.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/pm4_factory.h
@@ -38,6 +38,7 @@
 #include "lib/aqlprofile/core/aql_profile.hpp"
 #include "lib/aqlprofile/core/aql_profile_exception.h"
 #include "lib/aqlprofile/def/gpu_block_info.h"
+#include "lib/common/environment.hpp"
 #include "lib/aqlprofile/pm4/cmd_builder.h"
 #include "lib/aqlprofile/pm4/pmc_builder.h"
 #include "lib/aqlprofile/pm4/spm_builder.h"
@@ -331,8 +332,9 @@ Pm4Factory::Create(const AgentInfo* agent_info, gpu_id_t gpu_id, bool concurrent
     instances_t::iterator it  = ret.first;
 
     concurrent_create_mode_ = concurrent;
-    static bool spm_kfd     = getenv("ROCP_SPM_KFD_MODE") != nullptr;
-    spm_kfd_mode_           = spm_kfd;
+    // Check presence, not value (even empty string means "enabled")
+    static bool spm_kfd = rocprofiler::common::get_env_optional("ROCP_SPM_KFD_MODE").has_value();
+    spm_kfd_mode_       = spm_kfd;
 
     // Create a factory implementation for the GPU id
     if(ret.second)

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/pm4_factory.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/pm4_factory.h
@@ -38,6 +38,7 @@
 #include "lib/aqlprofile/core/aql_profile.hpp"
 #include "lib/aqlprofile/core/aql_profile_exception.h"
 #include "lib/aqlprofile/def/gpu_block_info.h"
+#include "lib/common/environment.hpp"
 #include "lib/aqlprofile/pm4/cmd_builder.h"
 #include "lib/aqlprofile/pm4/pmc_builder.h"
 #include "lib/aqlprofile/pm4/spm_builder.h"
@@ -326,8 +327,9 @@ Pm4Factory::Create(const AgentInfo* agent_info, gpu_id_t gpu_id, bool concurrent
     instances_t::iterator it  = ret.first;
 
     concurrent_create_mode_ = concurrent;
-    static bool spm_kfd     = getenv("ROCP_SPM_KFD_MODE") != nullptr;
-    spm_kfd_mode_           = spm_kfd;
+    // Check presence, not value (even empty string means "enabled")
+    static bool spm_kfd = rocprofiler::common::get_env_optional("ROCP_SPM_KFD_MODE").has_value();
+    spm_kfd_mode_       = spm_kfd;
 
     // Create a factory implementation for the GPU id
     if(ret.second)

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
@@ -11,6 +11,7 @@
 #include "lib/aqlprofile/core/logger.hpp"
 #include "lib/aqlprofile/core/pm4_factory.h"
 #include "lib/common/static_object.hpp"
+#include "lib/common/environment.hpp"
 
 #include <thread>
 #include <condition_variable>
@@ -177,8 +178,8 @@ is_virtualization_enabled()
 bool
 is_agent_supported_for_spm(const AgentInfo* agentInfo)
 {
-    const char* env_val = getenv("AQLPROFILE_SPM_OVERRIDE_AGENT_CHECK");
-    if(env_val && *env_val != '0' && *env_val != '\0') return true;
+    auto env_val = rocprofiler::common::get_env_optional("AQLPROFILE_SPM_OVERRIDE_AGENT_CHECK");
+    if(env_val && !env_val->empty() && env_val->front() != '0') return true;
 
     // if the device is gfx90a, then spm is not supported
     if(strncmp(agentInfo->gfxip, "gfx90a", 6) == 0)

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
@@ -178,6 +178,7 @@ is_virtualization_enabled()
 bool
 is_agent_supported_for_spm(const AgentInfo* agentInfo)
 {
+    // Check value, not just presence (must be non-empty and non-zero to override)
     auto env_val = rocprofiler::common::get_env_optional("AQLPROFILE_SPM_OVERRIDE_AGENT_CHECK");
     if(env_val && !env_val->empty() && env_val->front() != '0') return true;
 

--- a/projects/rocprofiler-sdk/source/lib/common/environment.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/environment.cpp
@@ -31,13 +31,14 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <optional>
 #include <string>
 #include <string_view>
 
-// Declare environ as extern at file scope
-extern "C" {
-extern char** environ;
-}
+// POSIX process environment table.
+// We intentionally read from environ directly instead of std::getenv()
+// because target applications (e.g. bash) may interpose getenv().
+extern "C" char** environ;
 
 namespace rocprofiler
 {
@@ -45,36 +46,37 @@ namespace common
 {
 namespace impl
 {
-namespace
-{
 // Safely read environment variable directly from environ array.
 // This avoids issues with bash's custom getenv() implementation which
 // breaks when setenv() is called before bash initializes its internal tables.
-// See: bash exports its own getenv() that uses hash tables, but when
-// libraries call setenv() in constructors, bash's tables are uninitialized.
-const char*
-safe_getenv(const char* name)
+//
+// THREAD SAFETY: This function is NOT thread-safe with respect to concurrent
+// setenv()/putenv()/unsetenv() calls.
+std::optional<std::string>
+get_env_direct(std::string_view name)
 {
-    if(!name || !environ) return nullptr;
+    if(name.empty() || !environ) return std::nullopt;
 
-    size_t name_len = std::strlen(name);
     for(char** env = environ; *env; ++env)
     {
-        if(std::strncmp(*env, name, name_len) == 0 && (*env)[name_len] == '=')
+        std::string_view entry{*env};
+        if(entry.size() > name.size() && entry.compare(0, name.size(), name) == 0 &&
+           entry[name.size()] == '=')
         {
-            return *env + name_len + 1;
+            // copy the value so callers do not retain pointers into environ.
+            return std::string{entry.substr(name.size() + 1)};
         }
     }
-    return nullptr;
+
+    return std::nullopt;
 }
-}  // namespace
 
 std::string
 get_env(std::string_view env_id, std::string_view _default)
 {
     if(env_id.empty()) return std::string{_default};
-    const char* env_var = safe_getenv(env_id.data());
-    if(env_var) return std::string{env_var};
+    auto env_var = get_env_direct(env_id);
+    if(env_var) return *env_var;
     return std::string{_default};
 }
 
@@ -88,26 +90,26 @@ bool
 get_env(std::string_view env_id, bool _default)
 {
     if(env_id.empty()) return _default;
-    const char* env_var = safe_getenv(env_id.data());
+    auto env_var = get_env_direct(env_id);
     if(env_var)
     {
-        if(std::string_view{env_var}.empty())
+        if(env_var->empty())
         {
             ROCP_FATAL << fmt::format("No boolean value provided for {}", env_id);
         }
 
-        if(std::string_view{env_var}.find_first_not_of("0123456789") == std::string_view::npos)
+        if(env_var->find_first_not_of("0123456789") == std::string_view::npos)
         {
-            return static_cast<bool>(std::stoi(env_var));
+            return static_cast<bool>(std::stoi(*env_var));
         }
 
-        // Create a mutable copy for tolower modification
-        std::string env_var_lower{env_var};
-        for(size_t i = 0; i < env_var_lower.length(); ++i)
-            env_var_lower[i] = tolower(env_var_lower[i]);
+        // Convert to lowercase in-place (cast to unsigned char to avoid UB)
+        for(size_t i = 0; i < env_var->length(); ++i)
+            (*env_var)[i] =
+                static_cast<char>(std::tolower(static_cast<unsigned char>((*env_var)[i])));
 
         for(const auto& itr : {"off", "false", "no", "n", "f", "0"})
-            if(env_var_lower == itr) return false;
+            if(*env_var == itr) return false;
 
         return true;
     }
@@ -126,7 +128,7 @@ get_env(std::string_view env_id,
         "change use of stol/stoul if instantiating for type larger than a 64-bit integer");
 
     if(env_id.empty()) return _default;
-    const char* env_var = safe_getenv(env_id.data());
+    auto env_var = get_env_direct(env_id);
     if(env_var)
     {
         try
@@ -135,18 +137,18 @@ get_env(std::string_view env_id,
             {
                 // use stol/stoul
                 if constexpr(std::is_signed<Tp>::value)
-                    return static_cast<Tp>(std::stol(env_var));
+                    return static_cast<Tp>(std::stol(*env_var));
                 else
-                    return static_cast<Tp>(std::stoul(env_var));
+                    return static_cast<Tp>(std::stoul(*env_var));
             }
             else if constexpr(std::is_floating_point<Tp>::value)
             {
-                return static_cast<Tp>(std::stod(env_var));
+                return static_cast<Tp>(std::stod(*env_var));
             }
         } catch(std::exception& _e)
         {
             ROCP_ERROR << "[rocprofiler][get_env] Exception thrown converting getenv(\"" << env_id
-                       << "\") = " << env_var << " to " << cxx_demangle(typeid(Tp).name())
+                       << "\") = " << *env_var << " to " << cxx_demangle(typeid(Tp).name())
                        << " :: " << _e.what() << ". Using default value of " << _default << "\n";
         }
         return _default;

--- a/projects/rocprofiler-sdk/source/lib/common/environment.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/environment.cpp
@@ -34,17 +34,46 @@
 #include <string>
 #include <string_view>
 
+// Declare environ as extern at file scope
+extern "C" {
+extern char** environ;
+}
+
 namespace rocprofiler
 {
 namespace common
 {
 namespace impl
 {
+namespace
+{
+// Safely read environment variable directly from environ array.
+// This avoids issues with bash's custom getenv() implementation which
+// breaks when setenv() is called before bash initializes its internal tables.
+// See: bash exports its own getenv() that uses hash tables, but when
+// libraries call setenv() in constructors, bash's tables are uninitialized.
+const char*
+safe_getenv(const char* name)
+{
+    if(!name || !environ) return nullptr;
+
+    size_t name_len = std::strlen(name);
+    for(char** env = environ; *env; ++env)
+    {
+        if(std::strncmp(*env, name, name_len) == 0 && (*env)[name_len] == '=')
+        {
+            return *env + name_len + 1;
+        }
+    }
+    return nullptr;
+}
+}  // namespace
+
 std::string
 get_env(std::string_view env_id, std::string_view _default)
 {
     if(env_id.empty()) return std::string{_default};
-    char* env_var = ::std::getenv(env_id.data());
+    const char* env_var = safe_getenv(env_id.data());
     if(env_var) return std::string{env_var};
     return std::string{_default};
 }
@@ -59,7 +88,7 @@ bool
 get_env(std::string_view env_id, bool _default)
 {
     if(env_id.empty()) return _default;
-    char* env_var = ::std::getenv(env_id.data());
+    const char* env_var = safe_getenv(env_id.data());
     if(env_var)
     {
         if(std::string_view{env_var}.empty())
@@ -72,11 +101,13 @@ get_env(std::string_view env_id, bool _default)
             return static_cast<bool>(std::stoi(env_var));
         }
 
-        for(size_t i = 0; i < std::string_view{env_var}.length(); ++i)
-            env_var[i] = tolower(env_var[i]);
+        // Create a mutable copy for tolower modification
+        std::string env_var_lower{env_var};
+        for(size_t i = 0; i < env_var_lower.length(); ++i)
+            env_var_lower[i] = tolower(env_var_lower[i]);
 
         for(const auto& itr : {"off", "false", "no", "n", "f", "0"})
-            if(std::string_view{env_var} == itr) return false;
+            if(env_var_lower == itr) return false;
 
         return true;
     }
@@ -95,7 +126,7 @@ get_env(std::string_view env_id,
         "change use of stol/stoul if instantiating for type larger than a 64-bit integer");
 
     if(env_id.empty()) return _default;
-    char* env_var = ::std::getenv(env_id.data());
+    const char* env_var = safe_getenv(env_id.data());
     if(env_var)
     {
         try

--- a/projects/rocprofiler-sdk/source/lib/common/environment.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/environment.cpp
@@ -35,11 +35,6 @@
 #include <string>
 #include <string_view>
 
-// POSIX process environment table.
-// We intentionally read from environ directly instead of std::getenv()
-// because target applications (e.g. bash) may interpose getenv().
-extern "C" char** environ;
-
 namespace rocprofiler
 {
 namespace common
@@ -50,8 +45,10 @@ namespace impl
 // This avoids issues with bash's custom getenv() implementation which
 // breaks when setenv() is called before bash initializes its internal tables.
 //
-// THREAD SAFETY: This function is NOT thread-safe with respect to concurrent
-// setenv()/putenv()/unsetenv() calls.
+// THREAD SAFETY: Reads are NOT safe against concurrent setenv()/putenv()/
+// unsetenv() from any thread, because glibc may reallocate the environ
+// array itself (not just mutate entries). Prefer reading at init time or
+// caching in a function-local static.
 std::optional<std::string>
 get_env_direct(std::string_view name)
 {
@@ -74,7 +71,6 @@ get_env_direct(std::string_view name)
 std::string
 get_env(std::string_view env_id, std::string_view _default)
 {
-    if(env_id.empty()) return std::string{_default};
     auto env_var = get_env_direct(env_id);
     if(env_var) return *env_var;
     return std::string{_default};
@@ -127,7 +123,6 @@ get_env(std::string_view env_id,
         sizeof(Tp) <= sizeof(uint64_t),
         "change use of stol/stoul if instantiating for type larger than a 64-bit integer");
 
-    if(env_id.empty()) return _default;
     auto env_var = get_env_direct(env_id);
     if(env_var)
     {

--- a/projects/rocprofiler-sdk/source/lib/common/environment.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/environment.cpp
@@ -151,6 +151,8 @@ get_env(std::string_view env_id,
     return _default;
 }
 
+// set_env uses standard ::setenv() (no wrapper needed).
+// Unlike getenv(), bash does not interpose setenv(), so it works correctly.
 int
 set_env(std::string_view env_id, bool value, int override)
 {

--- a/projects/rocprofiler-sdk/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/environment.hpp
@@ -86,7 +86,6 @@ set_env(std::string_view, Tp, int override = 0);
 inline std::optional<std::string>
 get_env_optional(std::string_view env_id)
 {
-    if(env_id.empty()) return std::nullopt;
     return impl::get_env_direct(env_id);
 }
 

--- a/projects/rocprofiler-sdk/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/environment.hpp
@@ -25,6 +25,7 @@
 #include "lib/common/logging.hpp"
 
 #include <unistd.h>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -37,6 +38,9 @@ namespace impl
 {
 struct sfinae
 {};
+
+// Exposed for presence checks - distinguishes "not set" from "set to empty"
+std::optional<std::string> get_env_direct(std::string_view);
 
 std::string get_env(std::string_view, std::string_view);
 
@@ -59,6 +63,33 @@ template <typename Tp>
 int
 set_env(std::string_view, Tp, int override = 0);
 }  // namespace impl
+
+// Get environment variable value, distinguishing "not set" from "set to empty".
+//
+// This is the lowest-level API for reading environment variables when you need
+// to distinguish between:
+//   - Variable not set:         returns std::nullopt
+//   - Variable set to "":       returns std::optional("")
+//   - Variable set to "value":  returns std::optional("value")
+//
+// Usage:
+//   auto val = get_env_optional("MY_VAR");
+//   if(!val) {
+//       // Not set
+//   } else if(val->empty()) {
+//       // Set to empty string
+//   } else {
+//       // Set with value: *val
+//   }
+//
+// To check presence: if(get_env_optional("MY_VAR").has_value()) { ... }
+// For most cases, use get_env(name, default) instead.
+inline std::optional<std::string>
+get_env_optional(std::string_view env_id)
+{
+    if(env_id.empty()) return std::nullopt;
+    return impl::get_env_direct(env_id);
+}
 
 template <typename Tp>
 inline auto
@@ -93,8 +124,7 @@ struct env_config
     {
         if(env_name.empty()) return -1;
         // overwrite < 0: only modify if variable already exists
-        // Use get_env wrapper which safely reads from environ
-        if(overwrite < 0 && get_env(env_name, "").empty())
+        if(overwrite < 0 && !get_env_optional(env_name).has_value())
             return 0;
         else if(_verbose)
         {

--- a/projects/rocprofiler-sdk/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/environment.hpp
@@ -93,7 +93,8 @@ struct env_config
     {
         if(env_name.empty()) return -1;
         // overwrite < 0: only modify if variable already exists
-        if(overwrite < 0 && ::std::getenv(env_name.c_str()) == nullptr)
+        // Use get_env wrapper which safely reads from environ
+        if(overwrite < 0 && get_env(env_name, "").empty())
             return 0;
         else if(_verbose)
         {

--- a/projects/rocprofiler-sdk/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/environment.hpp
@@ -39,7 +39,6 @@ namespace impl
 struct sfinae
 {};
 
-// Exposed for presence checks - distinguishes "not set" from "set to empty"
 std::optional<std::string> get_env_direct(std::string_view);
 
 std::string get_env(std::string_view, std::string_view);

--- a/projects/rocprofiler-sdk/source/lib/output/format_path.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/format_path.cpp
@@ -180,8 +180,7 @@ get_mpi_size()
     // Check if rocprofv3.py specified which env variable to use (to support subprocesses)
     if(auto size_var = common::get_env<std::string>(mpi_size_env_var_name, ""); !size_var.empty())
     {
-        auto* size_val = std::getenv(size_var.c_str());
-        if(size_val == nullptr)
+        if(!common::get_env_optional(size_var).has_value())
         {
             ROCP_FATAL << fmt::format("Environment variable {} is set to '{}', but '{}' is not "
                                       "set in the environment",
@@ -211,8 +210,7 @@ get_mpi_rank()
     // Check if rocprofv3.py specified which env variable to use (to support subprocesses)
     if(auto rank_var = common::get_env<std::string>(mpi_rank_env_var_name, ""); !rank_var.empty())
     {
-        auto* rank_val = std::getenv(rank_var.c_str());
-        if(rank_val == nullptr)
+        if(!common::get_env_optional(rank_var).has_value())
         {
             ROCP_FATAL << fmt::format("Environment variable {} is set to '{}', but '{}' is not "
                                       "set in the environment",

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/firmware_restrictions.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/firmware_restrictions.cpp
@@ -22,6 +22,7 @@
 
 #include "firmware_restrictions.hpp"
 
+#include "lib/common/environment.hpp"
 #include "lib/common/filesystem.hpp"
 #include "lib/common/logging.hpp"
 #include "lib/rocprofiler-sdk/agent.hpp"
@@ -64,10 +65,11 @@ findViaInstallPath(const std::string& filename)
 std::string
 findViaEnvironment(const std::string& filename)
 {
-    if(const char* metrics_path = nullptr; (metrics_path = getenv("ROCPROFILER_METRICS_PATH")))
+    auto metrics_path = common::get_env("ROCPROFILER_METRICS_PATH", "");
+    if(!metrics_path.empty())
     {
         ROCP_INFO << filename << " is being looked up via env variable ROCPROFILER_METRICS_PATH";
-        return common::filesystem::path{std::string{metrics_path}} / filename;
+        return common::filesystem::path{metrics_path} / filename;
     }
     // No environment variable, lookup via install path
     return findViaInstallPath(filename);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/firmware_restrictions.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/firmware_restrictions.cpp
@@ -65,11 +65,11 @@ findViaInstallPath(const std::string& filename)
 std::string
 findViaEnvironment(const std::string& filename)
 {
-    auto metrics_path = common::get_env("ROCPROFILER_METRICS_PATH", "");
-    if(!metrics_path.empty())
+    auto metrics_path = common::get_env_optional("ROCPROFILER_METRICS_PATH");
+    if(metrics_path)
     {
         ROCP_INFO << filename << " is being looked up via env variable ROCPROFILER_METRICS_PATH";
-        return common::filesystem::path{metrics_path} / filename;
+        return common::filesystem::path{*metrics_path} / filename;
     }
     // No environment variable, lookup via install path
     return findViaInstallPath(filename);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
@@ -286,11 +286,12 @@ locateMetricsFile(std::string_view name)
     auto metric_env_path = std::string{"not set"};
 
     // 1) Try env var
-    auto env = common::get_env("ROCPROFILER_METRICS_PATH", "");
-    if(!env.empty())
+    auto env = common::get_env_optional("ROCPROFILER_METRICS_PATH");
+    if(env)
     {
-        metric_env_path = env;
-        auto env_paths = sdk::parse::tokenize<std::vector<std::string>>(env, std::string_view{":"});
+        metric_env_path = *env;
+        auto env_paths =
+            sdk::parse::tokenize<std::vector<std::string>>(*env, std::string_view{":"});
         for(const auto& path : env_paths)
         {
             fs::path candidate = fs::path{path} / std::string{name};
@@ -300,7 +301,7 @@ locateMetricsFile(std::string_view name)
                 return candidate.string();
             }
         }
-        ROCP_INFO << name << " not found at ROCPROFILER_METRICS_PATH (" << env
+        ROCP_INFO << name << " not found at ROCPROFILER_METRICS_PATH (" << *env
                   << "). Falling back to install path.";
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
@@ -23,6 +23,7 @@
 #include "metrics.hpp"
 #include "id_decode.hpp"
 
+#include "lib/common/environment.hpp"
 #include "lib/common/filesystem.hpp"
 #include "lib/common/logging.hpp"
 #include "lib/common/static_object.hpp"
@@ -285,7 +286,8 @@ locateMetricsFile(std::string_view name)
     auto metric_env_path = std::string{"not set"};
 
     // 1) Try env var
-    if(const char* env = std::getenv("ROCPROFILER_METRICS_PATH"))
+    auto env = common::get_env("ROCPROFILER_METRICS_PATH", "");
+    if(!env.empty())
     {
         metric_env_path = env;
         auto env_paths = sdk::parse::tokenize<std::vector<std::string>>(env, std::string_view{":"});

--- a/projects/rocprofiler-sdk/source/lib/tests/common/environment.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/common/environment.cpp
@@ -25,6 +25,13 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+// POSIX process environment table
+extern "C" char** environ;
+
 namespace
 {
 bool _common_environment_test_init_logging = (rocprofiler::common::init_logging("TEST"), true);
@@ -157,4 +164,137 @@ TEST(common, environment_push_pop)
         EXPECT_EQ(get_env("ROCPROFILER_ENV_TEST_B", 0), 2) << fmt::format("iteration={}", i);
         EXPECT_EQ(get_env("ROCPROFILER_ENV_TEST_C", 0), 0) << fmt::format("iteration={}", i);
     }
+}
+
+// Unit test verifying that get_env() correctly reads environment variables.
+//
+// PURPOSE:
+// Validates that get_env() returns correct values for environment variables,
+// regardless of std::getenv() behavior or target application.
+//
+// CONTEXT:
+// Implementation reads from POSIX environ array directly (not std::getenv()) to avoid
+// dependency on application-specific getenv() implementations. Applications like bash
+// export custom getenv() that can fail when called before initialization.
+//
+// VALIDATES:
+// 1. get_env() returns correct values for variables that exist in environ
+// 2. type overloads (string, int, bool) return correct values
+TEST(common, environment_reads_directly_from_environ)
+{
+    using rocprofiler::common::get_env;
+
+    const char* test_var = "ROCPROFILER_BASH_REGRESSION_TEST";
+    const char* test_val = "regression_test_value_12345";
+
+    setenv(test_var, test_val, 1);
+
+    // Verify the variable exists in the actual environ array
+    bool        found_in_environ = false;
+    std::string environ_value;
+    size_t      test_var_len = std::strlen(test_var);
+
+    for(char** env = environ; *env; ++env)
+    {
+        if(std::strncmp(*env, test_var, test_var_len) == 0 && (*env)[test_var_len] == '=')
+        {
+            found_in_environ = true;
+            environ_value    = *env + test_var_len + 1;
+            break;
+        }
+    }
+
+    // The variable MUST exist in environ (this is the ground truth)
+    EXPECT_TRUE(found_in_environ)
+        << "Ground truth: Variable missing from environ after setenv() - setenv() failed?";
+    EXPECT_EQ(environ_value, test_val)
+        << "Ground truth: Variable in environ has wrong value - environ corrupted?";
+
+    // CRITICAL: get_env() must return the value we just verified exists in environ
+    // Failure could be: not reading environ, OR implementation bug, OR name parsing broken
+    EXPECT_EQ(get_env(test_var, "NOTFOUND"), test_val)
+        << "get_env() returned default 'NOTFOUND' instead of '" << test_val
+        << "' (which exists in environ)";
+
+    // Verify type overloads work (tests both environ access AND type conversion)
+    setenv("ROCPROFILER_BASH_REGRESSION_INT", "42", 1);
+    EXPECT_EQ(get_env("ROCPROFILER_BASH_REGRESSION_INT", 0), 42)
+        << "get_env<int>() returned default 0 instead of 42 for value '42'";
+
+    setenv("ROCPROFILER_BASH_REGRESSION_BOOL", "true", 1);
+    EXPECT_TRUE(get_env("ROCPROFILER_BASH_REGRESSION_BOOL", false))
+        << "get_env<bool>() returned false instead of true for value 'true'";
+
+    // Clean up
+    unsetenv(test_var);
+    unsetenv("ROCPROFILER_BASH_REGRESSION_INT");
+    unsetenv("ROCPROFILER_BASH_REGRESSION_BOOL");
+}
+
+// Unit test verifying get_env_optional() correctly distinguishes between
+// "not set" and "set to empty string".
+// This API was added in commit e36a8d128b to provide this distinction.
+TEST(common, environment_optional_distinguishes_unset_from_empty)
+{
+    using rocprofiler::common::get_env_optional;
+
+    const char* test_var = "ROCPROFILER_OPTIONAL_TEST";
+
+    // Test 1: Variable not set - should return std::nullopt
+    unsetenv(test_var);  // Ensure it's not set
+    auto result_unset = get_env_optional(test_var);
+    EXPECT_FALSE(result_unset.has_value()) << "Unset variable should return std::nullopt";
+
+    // Test 2: Variable with VALID NAME but EMPTY VALUE
+    // Scenario: export ROCPROFILER_OPTIONAL_TEST=""
+    // This should return std::optional("") because the variable EXISTS
+    setenv(test_var, "", 1);
+    auto result_empty = get_env_optional(test_var);
+    EXPECT_TRUE(result_empty.has_value())
+        << "Variable exists (even with empty value) should return optional with value";
+    EXPECT_TRUE(result_empty->empty()) << "Value should be empty string";
+    EXPECT_EQ(*result_empty, "") << "Dereferenced value should be empty string";
+
+    // Test 3: Variable set to non-empty value
+    setenv(test_var, "test_value", 1);
+    auto result_value = get_env_optional(test_var);
+    EXPECT_TRUE(result_value.has_value())
+        << "Variable with value should return optional with value";
+    EXPECT_FALSE(result_value->empty()) << "Value should not be empty";
+    EXPECT_EQ(*result_value, "test_value") << "Value should match what was set";
+
+    // Test 4: EMPTY VARIABLE NAME (invalid query)
+    // Scenario: get_env_optional("") - asking for value of a variable with NO NAME
+    // Should return std::nullopt because you can't query a variable with no name
+    auto result_empty_name = get_env_optional("");
+    EXPECT_FALSE(result_empty_name.has_value())
+        << "Empty variable name (invalid query) should return std::nullopt";
+
+    // Test 5: Verify it reads from environ directly (like get_env does)
+    // This ensures get_env_optional also bypasses custom getenv() implementations
+    const char* test_var2 = "ROCPROFILER_OPTIONAL_ENVIRON_TEST";
+    setenv(test_var2, "environ_value", 1);
+
+    // Verify it exists in environ array
+    bool   found_in_environ = false;
+    size_t test_var_len     = std::strlen(test_var2);
+    for(char** env = environ; *env; ++env)
+    {
+        if(std::strncmp(*env, test_var2, test_var_len) == 0 && (*env)[test_var_len] == '=')
+        {
+            found_in_environ = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found_in_environ) << "Variable should exist in environ";
+
+    // get_env_optional should read it directly from environ
+    auto environ_result = get_env_optional(test_var2);
+    EXPECT_TRUE(environ_result.has_value());
+    EXPECT_EQ(*environ_result, "environ_value")
+        << "get_env_optional() should read from environ directly";
+
+    // Clean up
+    unsetenv(test_var);
+    unsetenv(test_var2);
 }

--- a/projects/rocprofiler-sdk/source/lib/tests/common/environment.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/common/environment.cpp
@@ -29,9 +29,6 @@
 #include <cstring>
 #include <string>
 
-// POSIX process environment table
-extern "C" char** environ;
-
 namespace
 {
 bool _common_environment_test_init_logging = (rocprofiler::common::init_logging("TEST"), true);

--- a/projects/rocprofiler-sdk/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/CMakeLists.txt
@@ -89,6 +89,9 @@ add_subdirectory(rocjpeg)
 add_subdirectory(hip-host-tracing)
 add_subdirectory(code-object-multi-threaded)
 
+# environment variable tests
+add_subdirectory(environment)
+
 # rocpd validation tests
 add_subdirectory(rocpd)
 

--- a/projects/rocprofiler-sdk/tests/environment/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/environment/CMakeLists.txt
@@ -15,9 +15,9 @@ project(
 
 find_package(rocprofiler-sdk REQUIRED)
 
-  # Note: bash is invoked unconditionally (no find_program guard) because these
-  # tests are the regression coverage for the bash-specific getenv() bug —
-  # silently skipping them when bash is absent would hide the bug they exist to catch.
+# Note: bash is invoked unconditionally (no find_program guard) because these tests are
+# the regression coverage for the bash-specific getenv() bug — silently skipping them when
+# bash is absent would hide the bug they exist to catch.
 
 # Test 1: Invalid ROCPROFILER_METRICS_PATH with bash should show warning This verifies
 # that the environment variable is actually read (not ignored).

--- a/projects/rocprofiler-sdk/tests/environment/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/environment/CMakeLists.txt
@@ -15,8 +15,8 @@ project(
 
 find_package(rocprofiler-sdk REQUIRED)
 
-# Test 1: Invalid ROCPROFILER_METRICS_PATH with bash should show warning
-# This verifies that the environment variable is actually read (not ignored).
+# Test 1: Invalid ROCPROFILER_METRICS_PATH with bash should show warning This verifies
+# that the environment variable is actually read (not ignored).
 rocprofiler_add_integration_execute_test(
     environment-bash-invalid-path
     COMMAND $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES -- bash -c "exit 0"
@@ -29,8 +29,8 @@ rocprofiler_add_integration_execute_test(
         "Counter definitions file '/nonexistent/bash/test/path/config.yaml' does not exist"
     FIXTURES_SETUP environment-bash-invalid-path)
 
-# Test 2: Bash with path containing spaces
-# Validates that paths with special characters are handled correctly
+# Test 2: Bash with path containing spaces Validates that paths with special characters
+# are handled correctly
 rocprofiler_add_integration_execute_test(
     environment-bash-path-with-spaces
     COMMAND $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES -- bash -c "exit 0"
@@ -42,8 +42,8 @@ rocprofiler_add_integration_execute_test(
     PASS_REGULAR_EXPRESSION "Counter definitions file '/path/with spaces/metrics"
     FIXTURES_SETUP environment-bash-spaces)
 
-# Test 3: Multiple environment variables under bash
-# Validates that multiple ROCPROFILER_* env vars are all readable
+# Test 3: Multiple environment variables under bash Validates that multiple ROCPROFILER_*
+# env vars are all readable
 rocprofiler_add_integration_execute_test(
     environment-bash-multiple-vars
     COMMAND $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES -- bash -c "exit 0"
@@ -81,9 +81,9 @@ if(ZSH_EXECUTABLE)
         FIXTURES_SETUP environment-zsh-test)
 endif()
 
-# Test 6: Bash with inline script (mimics user wrapper scripts)
-# Real-world scenario: users often wrap profiling commands in bash -c
-# This test also validates normal operation (no spurious warnings)
+# Test 6: Bash with inline script (mimics user wrapper scripts) Real-world scenario: users
+# often wrap profiling commands in bash -c This test also validates normal operation (no
+# spurious warnings)
 rocprofiler_add_integration_execute_test(
     environment-bash-inline-script
     COMMAND

--- a/projects/rocprofiler-sdk/tests/environment/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/environment/CMakeLists.txt
@@ -1,0 +1,98 @@
+#
+# Environment variable tests
+#
+# Tests that environment variables are correctly read across different scenarios:
+# - bash as target (bypasses bash's custom getenv())
+# - Other shells and interpreters
+# - Various environment configurations
+#
+cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)
+
+project(
+    rocprofiler-sdk-tests-environment
+    LANGUAGES CXX
+    VERSION 0.0.0)
+
+find_package(rocprofiler-sdk REQUIRED)
+
+# Test 1: Invalid ROCPROFILER_METRICS_PATH with bash should show warning
+# This verifies that the environment variable is actually read (not ignored).
+rocprofiler_add_integration_execute_test(
+    environment-bash-invalid-path
+    COMMAND $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES -- bash -c "exit 0"
+    DEPENDS rocprofiler-sdk::rocprofv3
+    TIMEOUT 30
+    LABELS "integration-tests" "environment"
+    ENVIRONMENT "ROCPROFILER_METRICS_PATH=/nonexistent/bash/test/path"
+    # Expect warning about missing config file - proves env var was read
+    PASS_REGULAR_EXPRESSION
+        "Counter definitions file '/nonexistent/bash/test/path/config.yaml' does not exist"
+    FIXTURES_SETUP environment-bash-invalid-path)
+
+# Test 2: Bash with path containing spaces
+# Validates that paths with special characters are handled correctly
+rocprofiler_add_integration_execute_test(
+    environment-bash-path-with-spaces
+    COMMAND $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES -- bash -c "exit 0"
+    DEPENDS rocprofiler-sdk::rocprofv3
+    TIMEOUT 30
+    LABELS "integration-tests" "environment" "bash"
+    ENVIRONMENT "ROCPROFILER_METRICS_PATH=/path/with spaces/metrics"
+    # Should see the path with spaces in the error message
+    PASS_REGULAR_EXPRESSION "Counter definitions file '/path/with spaces/metrics"
+    FIXTURES_SETUP environment-bash-spaces)
+
+# Test 3: Multiple environment variables under bash
+# Validates that multiple ROCPROFILER_* env vars are all readable
+rocprofiler_add_integration_execute_test(
+    environment-bash-multiple-vars
+    COMMAND $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES -- bash -c "exit 0"
+    DEPENDS rocprofiler-sdk::rocprofv3
+    TIMEOUT 30
+    LABELS "integration-tests" "environment" "bash"
+    ENVIRONMENT "ROCPROFILER_METRICS_PATH=/test/path/one" "ROCPROFILER_LOG_LEVEL=trace"
+    # Should see both env vars being used
+    PASS_REGULAR_EXPRESSION "Counter definitions file '/test/path/one"
+    FIXTURES_SETUP environment-bash-multiple)
+
+# Test 4: Invalid ROCPROFILER_METRICS_PATH with sh should show warning
+rocprofiler_add_integration_execute_test(
+    environment-sh-invalid-path
+    COMMAND $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES -- sh -c "exit 0"
+    DEPENDS rocprofiler-sdk::rocprofv3
+    TIMEOUT 30
+    LABELS "integration-tests" "environment" "sh"
+    ENVIRONMENT "ROCPROFILER_METRICS_PATH=/nonexistent/sh/test"
+    PASS_REGULAR_EXPRESSION "Counter definitions file '/nonexistent/sh/test"
+    FIXTURES_SETUP environment-sh-test)
+
+# Test 5: Invalid ROCPROFILER_METRICS_PATH with zsh should show warning
+find_program(ZSH_EXECUTABLE zsh)
+if(ZSH_EXECUTABLE)
+    rocprofiler_add_integration_execute_test(
+        environment-zsh-invalid-path
+        COMMAND $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES --
+                ${ZSH_EXECUTABLE} -c "exit 0"
+        DEPENDS rocprofiler-sdk::rocprofv3
+        TIMEOUT 30
+        LABELS "integration-tests" "environment" "zsh"
+        ENVIRONMENT "ROCPROFILER_METRICS_PATH=/nonexistent/zsh/test"
+        PASS_REGULAR_EXPRESSION "Counter definitions file '/nonexistent/zsh/test"
+        FIXTURES_SETUP environment-zsh-test)
+endif()
+
+# Test 6: Bash with inline script (mimics user wrapper scripts)
+# Real-world scenario: users often wrap profiling commands in bash -c
+# This test also validates normal operation (no spurious warnings)
+rocprofiler_add_integration_execute_test(
+    environment-bash-inline-script
+    COMMAND
+        bash -c
+        "export ROCPROFILER_METRICS_PATH=/inline/test && \
+                     $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES -- bash -c 'exit 0'"
+    DEPENDS rocprofiler-sdk::rocprofv3
+    TIMEOUT 30
+    LABELS "integration-tests" "environment" "bash" "real-world"
+    # Should see the inline-set env var
+    PASS_REGULAR_EXPRESSION "Counter definitions file '/inline/test"
+    FIXTURES_SETUP environment-bash-inline)

--- a/projects/rocprofiler-sdk/tests/environment/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/environment/CMakeLists.txt
@@ -56,15 +56,19 @@ rocprofiler_add_integration_execute_test(
     FIXTURES_SETUP environment-bash-multiple)
 
 # Test 4: Invalid ROCPROFILER_METRICS_PATH with sh should show warning
-rocprofiler_add_integration_execute_test(
-    environment-sh-invalid-path
-    COMMAND $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES -- sh -c "exit 0"
-    DEPENDS rocprofiler-sdk::rocprofv3
-    TIMEOUT 30
-    LABELS "integration-tests" "environment" "sh"
-    ENVIRONMENT "ROCPROFILER_METRICS_PATH=/nonexistent/sh/test"
-    PASS_REGULAR_EXPRESSION "Counter definitions file '/nonexistent/sh/test"
-    FIXTURES_SETUP environment-sh-test)
+find_program(SH_EXECUTABLE sh)
+if(SH_EXECUTABLE)
+    rocprofiler_add_integration_execute_test(
+        environment-sh-invalid-path
+        COMMAND $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES --
+                ${SH_EXECUTABLE} -c "exit 0"
+        DEPENDS rocprofiler-sdk::rocprofv3
+        TIMEOUT 30
+        LABELS "integration-tests" "environment" "sh"
+        ENVIRONMENT "ROCPROFILER_METRICS_PATH=/nonexistent/sh/test"
+        PASS_REGULAR_EXPRESSION "Counter definitions file '/nonexistent/sh/test"
+        FIXTURES_SETUP environment-sh-test)
+endif()
 
 # Test 5: Invalid ROCPROFILER_METRICS_PATH with zsh should show warning
 find_program(ZSH_EXECUTABLE zsh)

--- a/projects/rocprofiler-sdk/tests/environment/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/environment/CMakeLists.txt
@@ -15,6 +15,10 @@ project(
 
 find_package(rocprofiler-sdk REQUIRED)
 
+  # Note: bash is invoked unconditionally (no find_program guard) because these
+  # tests are the regression coverage for the bash-specific getenv() bug —
+  # silently skipping them when bash is absent would hide the bug they exist to catch.
+
 # Test 1: Invalid ROCPROFILER_METRICS_PATH with bash should show warning This verifies
 # that the environment variable is actually read (not ignored).
 rocprofiler_add_integration_execute_test(


### PR DESCRIPTION
## Motivation

This PR addresses a bug affecting `rocprofv3` when the profiling target application is a bash command. 
The root cause is that bash exports its own `getenv()` function which fails when called before bash's internal environment tables are initialized. When `rocprofiler-sdk` calls `std::getenv()` during early initialization (via constructor functions), it invokes bash's custom `getenv()`, leading to incorrect behavior or crashes.

This PR resolves this issue by reading environment variables directly from the POSIX environ array.

## Technical Details

### Core Changes
Direct environ access (environment.cpp:41-71)

1. Added `get_env_direct()` function that reads directly from the POSIX `environ` array
2. Bypasses application-provided `getenv()` implementations (like bash's custom version)
3. Thread-safe with respect to reads, but not concurrent `setenv()/unsetenv()` calls

New `get_env_optional()` API (environment.hpp:66-91)

1. Distinguishes between "not set" (returns `std::nullopt`) and "set to empty string" (returns `std::optional("")`)

Updated all `std::getenv()` call sites to use safe environment functions:
1. aql_profile.cpp - AQL profile configuration
2. pm4_factory.h - SPM KFD mode detection
3. spm_v2.cpp - Agent override checks
4. format_path.cpp - MPI environment detection
5. firmware_restrictions.cpp - Metrics path lookup
6. metrics.cpp - Metrics path resolution

### Testing
Unit tests (tests/common/environment.cpp:168-298)

1. Validates `get_env()` reads from `environ` correctly
2. Validates `get_env_optional()` distinguishes unset vs empty string
3. Tests type conversion overloads (string, int, bool)

Integration tests (tests/environment/CMakeLists.txt)

1. Tests bash as target application (the primary regression scenario)
2. Tests other shells (sh, zsh)
3. Tests paths with spaces
4. Tests multiple environment variables
5. Tests inline bash scripts

## JIRA ID

ROCM-23799

## Test Plan

Unit tests validate core functionality:

1. `environment_reads_directly_from_environ`
2. `environment_optional_distinguishes_unset_from_empty`

Integration tests: 6 test cases covering bash, sh, zsh with various environment configurations


## Test Result

All new unit and integration tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
