### PR TITLE
CE Coll: MPI test framework enhancements (logging, RAII guards, rank-aware diagnostics

### DIFF
--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -121,6 +121,11 @@ if(BUILD_TESTS)
   endif()
   list(APPEND RCCL_COMMON_COMPILE_DEFS __HIP_PLATFORM_AMD__)
 
+  # All test executables link against GTest; tell MPIHelpers.cpp so it can use
+  # GTest's current_test_info() rather than relying on __has_include (which only
+  # proves the header is installed, not that the target actually links the library).
+  list(APPEND RCCL_COMMON_COMPILE_DEFS RCCL_MPIHelpers_HAS_GTEST)
+
   # Common link libraries
   set(RCCL_COMMON_LINK_LIBS
     ${GTEST_BOTH_LIBRARIES}

--- a/projects/rccl/test/common/MPIEnvironment.cpp
+++ b/projects/rccl/test/common/MPIEnvironment.cpp
@@ -236,10 +236,13 @@ void MPIEnvironment::TearDown()
 
     if(barrier_result == MPI_SUCCESS)
     {
-        // Wait for barrier with a timeout (1 second)
+        // Wait for barrier with a timeout.
+        // 3 s: ncclCommDestroy is now explicitly called (and MPI-barrier'd) inside
+        // cleanupTestCommunicator before TearDown runs, so the only remaining rank
+        // skew here is log-file I/O (RCCL_MPI_LOG_ALL_RANKS) which is fast.
         int        flag             = 0;
         auto       timeout_start    = std::chrono::steady_clock::now();
-        const auto timeout_duration = std::chrono::seconds(1);
+        const auto timeout_duration = std::chrono::seconds(3);
 
         while(!flag)
         {

--- a/projects/rccl/test/common/MPIHelpers.cpp
+++ b/projects/rccl/test/common/MPIHelpers.cpp
@@ -23,13 +23,11 @@
     #include <sstream>
     #include <sys/stat.h>
     #include <unistd.h>
-    // GTest is available when building test binaries; standalone MPI binaries
-    // (benchmarks, performance tests) do not link against it.  __has_include
-    // lets us use GTest's current_test_info() when present and fall back to a
-    // pid-based log path when building without GTest.
-    #if __has_include(<gtest/gtest.h>)
+    // RCCL_MPIHelpers_HAS_GTEST is set by the build system (CMakeLists.txt) for
+    // targets that actually link against GTest, so this guard is guaranteed to
+    // match the link graph rather than relying on header presence alone.
+    #if defined(RCCL_MPIHelpers_HAS_GTEST)
         #include <gtest/gtest.h>
-        #define RCCL_MPIHelpers_HAS_GTEST 1
     #endif
 
     // resetNcclDebugFile() calls ncclResetDebugInit() via dlsym so that we
@@ -73,7 +71,8 @@ namespace
     //   1. RCCL_TEST_LOG_DIR env var — explicit override, useful in CI.
     //   2. Directory of the test binary (/proc/self/exe) — ties logs to the
     //      specific build that produced them; different builds never share logs.
-    //   3. /tmp — last-resort fallback if both above are unavailable.
+    //      Skipped if not writable (e.g. system-installed or read-only prefix).
+    //   3. /tmp — last-resort fallback.
     std::string getLogBaseDir()
     {
         const char* env = std::getenv("RCCL_TEST_LOG_DIR");
@@ -89,7 +88,9 @@ namespace
             if(slash)
             {
                 *slash = '\0';
-                return std::string{buf};
+                if(::access(buf, W_OK) == 0)
+                    return std::string{buf};
+                // Binary dir is not writable; fall through to /tmp.
             }
         }
 
@@ -621,45 +622,16 @@ TestLogAssertionContext::~TestLogAssertionContext()
     if(capture_nccl_ && !nccl_path_.empty())
     {
         // ---------------------------------------------------------------
-        // Prepend a one-line header to the log file so it is
-        // self-identifying regardless of whether the name is human-readable
-        // (GTest path) or opaque (pid-based standalone path).
-        //
-        // The header is written here (destructor) rather than in the
-        // constructor because NCCL opens the file with fopen("w") on its
-        // first lazy-init log call, which would truncate anything written
-        // earlier.  By writing in the destructor — after the communicator
-        // has already been torn down and fflush(nullptr) has drained NCCL's
-        // internal buffer — the file is complete and safe to rewrite.
+        // Decide whether this log will be kept or deleted BEFORE doing
+        // any file I/O: large NCCL_DEBUG=INFO logs on passing tests would
+        // otherwise add avoidable teardown I/O and rank skew if we read
+        // and rewrite a file we are about to delete.
         // ---------------------------------------------------------------
-        const std::string content = readTextFile(nccl_path_);
-        if(!content.empty())
-        {
-            std::ostringstream header;
-            header << "=== RCCL Test Log"
-                   << " | Test: "  << test_label_
-                   << " | Rank: "  << opts_.mpi_rank
-                   << " | PID: "   << ::getpid()
-                   << " ===\n";
-            const std::string hdr = header.str();
 
-            if(FILE* f = std::fopen(nccl_path_.c_str(), "w"))
-            {
-                std::fwrite(hdr.c_str(),     1, hdr.size(),     f);
-                std::fwrite(content.c_str(), 1, content.size(), f);
-                std::fclose(f);
-            }
-        }
-
-        // ---------------------------------------------------------------
-        // Keep the log when the test FAILED (so it is available
-        // for post-mortem inspection); delete it when the test PASSED to
-        // avoid accumulating noise in /tmp.
-        //
-        // Override: set RCCL_KEEP_TEST_LOGS=1 to keep ALL logs regardless
-        // of pass/fail — useful when stepping through a test run manually.
-        // ---------------------------------------------------------------
-        const bool keep_all = (std::getenv("RCCL_KEEP_TEST_LOGS") != nullptr);
+        // Treat RCCL_KEEP_TEST_LOGS=0 (or empty) as "don't keep"; any other
+        // non-empty value (typically "1") activates unconditional retention.
+        const char* keep_env = std::getenv("RCCL_KEEP_TEST_LOGS");
+        const bool  keep_all = keep_env && keep_env[0] != '\0' && keep_env[0] != '0';
 
         bool test_passed = false; // conservative default: keep when uncertain
 #if defined(RCCL_MPIHelpers_HAS_GTEST)
@@ -678,7 +650,42 @@ TestLogAssertionContext::~TestLogAssertionContext()
                   || (!auto_nccl_path_ && opts_.unlink_explicit_nccl_path));
 
         if(unlink_it)
+        {
             (void)::unlink(nccl_path_.c_str());
+        }
+        else
+        {
+            // ---------------------------------------------------------------
+            // Prepend a one-line header to the log file so it is
+            // self-identifying regardless of whether the name is human-readable
+            // (GTest path) or opaque (pid-based standalone path).
+            //
+            // The header is written here (destructor) rather than in the
+            // constructor because NCCL opens the file with fopen("w") on its
+            // first lazy-init log call, which would truncate anything written
+            // earlier.  By writing in the destructor — after the communicator
+            // has already been torn down and fflush(nullptr) has drained NCCL's
+            // internal buffer — the file is complete and safe to rewrite.
+            // ---------------------------------------------------------------
+            const std::string content = readTextFile(nccl_path_);
+            if(!content.empty())
+            {
+                std::ostringstream header;
+                header << "=== RCCL Test Log"
+                       << " | Test: "  << test_label_
+                       << " | Rank: "  << opts_.mpi_rank
+                       << " | PID: "   << ::getpid()
+                       << " ===\n";
+                const std::string hdr = header.str();
+
+                if(FILE* f = std::fopen(nccl_path_.c_str(), "w"))
+                {
+                    std::fwrite(hdr.c_str(),     1, hdr.size(),     f);
+                    std::fwrite(content.c_str(), 1, content.size(), f);
+                    std::fclose(f);
+                }
+            }
+        }
     }
 }
 

--- a/projects/rccl/test/common/MPIHelpers.cpp
+++ b/projects/rccl/test/common/MPIHelpers.cpp
@@ -10,9 +10,11 @@
 
     #include "MPITestCore.hpp"
     #include "MPIEnvironment.hpp"
+    #include <cctype>
     #include <cerrno>
     #include <cstdlib>
     #include <cstring>
+    #include <dlfcn.h>
     #include <fcntl.h>
     #include <fstream>
     #include <hip/hip_runtime.h>
@@ -21,6 +23,36 @@
     #include <sstream>
     #include <sys/stat.h>
     #include <unistd.h>
+    // GTest is available when building test binaries; standalone MPI binaries
+    // (benchmarks, performance tests) do not link against it.  __has_include
+    // lets us use GTest's current_test_info() when present and fall back to a
+    // pid-based log path when building without GTest.
+    #if __has_include(<gtest/gtest.h>)
+        #include <gtest/gtest.h>
+        #define RCCL_MPIHelpers_HAS_GTEST 1
+    #endif
+
+    // resetNcclDebugFile() calls ncclResetDebugInit() via dlsym so that we
+    // never reference the deprecated symbol by name at compile or link time.
+    //
+    // Why dlsym instead of a direct call:
+    //   - ncclResetDebugInit is marked __attribute__((deprecated)) in nccl.h,
+    //     so a direct call triggers -Wdeprecated-declarations and requires a
+    //     #pragma GCC diagnostic suppression.
+    //   - pncclResetDebugInit (the non-deprecated profiling wrapper) is NOT
+    //     exported from librccl.so, so it cannot be linked against directly.
+    //   - dlsym(RTLD_DEFAULT, ...) resolves the symbol from the already-loaded
+    //     librccl.so at runtime — no pragma, no link-time dependency.
+    //   - If RCCL removes the API in a future release the call becomes a no-op
+    //     (the static fn pointer stays null) rather than a link or build error.
+    static void resetNcclDebugFile()
+    {
+        using NcclResetFn = void (*)();
+        static NcclResetFn fn = reinterpret_cast<NcclResetFn>(
+            ::dlsym(RTLD_DEFAULT, "ncclResetDebugInit"));
+        if(fn)
+            fn();
+    }
 
 namespace MPIHelpers
 {
@@ -33,6 +65,82 @@ namespace
             return {};
         }
         return full.substr(static_cast<std::size_t>(off));
+    }
+
+    // Determine the base directory for per-rank and NCCL debug log files.
+    //
+    // Priority:
+    //   1. RCCL_TEST_LOG_DIR env var — explicit override, useful in CI.
+    //   2. Directory of the test binary (/proc/self/exe) — ties logs to the
+    //      specific build that produced them; different builds never share logs.
+    //   3. /tmp — last-resort fallback if both above are unavailable.
+    std::string getLogBaseDir()
+    {
+        const char* env = std::getenv("RCCL_TEST_LOG_DIR");
+        if(env && env[0] != '\0')
+            return env;
+
+        char buf[4096];
+        const ssize_t len = ::readlink("/proc/self/exe", buf, sizeof(buf) - 1);
+        if(len > 0)
+        {
+            buf[len]    = '\0';
+            char* slash = ::strrchr(buf, '/');
+            if(slash)
+            {
+                *slash = '\0';
+                return std::string{buf};
+            }
+        }
+
+        return "/tmp";
+    }
+
+    // Replace every character that is not alphanumeric, '.', or '-' with '_'
+    // so that test-suite and test-case names are safe to embed in a file path.
+    std::string sanitizeForFilename(const std::string& s)
+    {
+        std::string out;
+        out.reserve(s.size());
+        for(unsigned char c : s)
+        {
+            out += (std::isalnum(c) || c == '.' || c == '-') ? static_cast<char>(c) : '_';
+        }
+        return out;
+    }
+
+    // Build a per-test, per-rank NCCL debug log path.
+    //
+    // Pattern: <logdir>/rccl_<TestSuite>.<TestName>_rank<R>_pid<P>.log
+    // PID suffix ensures each process invocation gets a unique file so that
+    // stale files from a different user or a previous run never block fopen("w").
+    std::string makeTestNameLogPath(int rank)
+    {
+        const auto        pid     = std::to_string(::getpid());
+        const std::string logdir  = getLogBaseDir();
+#if defined(RCCL_MPIHelpers_HAS_GTEST)
+        std::string suite;
+        std::string test;
+
+        const ::testing::TestInfo* info
+            = ::testing::UnitTest::GetInstance()->current_test_info();
+        if(info)
+        {
+            if(info->test_suite_name())
+                suite = info->test_suite_name();
+            if(info->name())
+                test = info->name();
+        }
+
+        if(!suite.empty() && !test.empty())
+        {
+            return logdir + "/rccl_" + sanitizeForFilename(suite) + "."
+                   + sanitizeForFilename(test) + "_rank" + std::to_string(rank)
+                   + "_pid" + pid + ".log";
+        }
+#endif
+        return logdir + "/rccl_rank" + std::to_string(rank)
+               + "_pid" + pid + ".log";
     }
 } // namespace
 
@@ -210,9 +318,7 @@ std::optional<RankLogConfig> setupRankLogging(int rank)
 
         if(per_rank_logging_enabled)
         {
-            // Per-rank logging enabled: Redirect to log file
-            const auto log_filename
-                = std::string{"rccl_test_rank_"} + std::to_string(rank) + ".log";
+            const auto log_filename = getRankLogFilePath(rank);
 
             const auto log_fd = ::open(log_filename.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
 
@@ -269,9 +375,8 @@ std::optional<RankLogConfig> setupRankLogging(int rank)
     }
 
     // Create log file for rank 0
-    const auto log_filename = std::string{"rccl_test_rank_"} + std::to_string(rank) + ".log";
+    const auto log_filename = getRankLogFilePath(rank);
 
-    // Debug: Print to stderr BEFORE creating log file
     TEST_TRACE("Rank %d (rank 0 tee mode) opening log file: %s", rank, log_filename.c_str());
 
     const auto log_fd = ::open(log_filename.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
@@ -292,8 +397,8 @@ std::optional<RankLogConfig> setupRankLogging(int rank)
     // Print banner before redirection
     TEST_INFO("Per-Rank Logging ENABLED (RCCL_MPI_LOG_ALL_RANKS=1)");
     TEST_INFO("Rank 0     : Output to BOTH console AND %s", log_filename.c_str());
-    TEST_INFO("Ranks 1-N  : Output redirected to rccl_test_rank_<N>.log");
-    TEST_INFO("Location   : Log files created in current working directory");
+    TEST_INFO("Ranks 1-N  : Output redirected to per-rank log files");
+    TEST_INFO("Log dir    : %s  (override: RCCL_TEST_LOG_DIR)", getLogBaseDir().c_str());
 
     // Save original stdout/stderr for tee thread
     config.saved_stdout = FileDescriptor{::dup(STDOUT_FILENO)};
@@ -346,7 +451,8 @@ std::optional<RankLogConfig> setupRankLogging(int rank)
 
 std::string getRankLogFilePath(int rank)
 {
-    return std::string{"rccl_test_rank_"} + std::to_string(rank) + ".log";
+    return getLogBaseDir() + "/rccl_test_rank_" + std::to_string(rank)
+           + "_pid" + std::to_string(::getpid()) + ".log";
 }
 
 std::uintmax_t getFileSizeBytes(const std::string& path)
@@ -384,9 +490,13 @@ std::string readRankLogFile(int rank)
 TestLogAssertionOptions makeNcclDebugFileAssertionOptions(int mpi_rank)
 {
     TestLogAssertionOptions o;
-    o.mpi_rank                  = mpi_rank;
-    o.capture_nccl_debug_file   = true;
-    o.read_per_rank_stderr_log = false;
+    o.mpi_rank                        = mpi_rank;
+    o.capture_nccl_debug_file         = true;
+    o.read_per_rank_stderr_log        = false;
+    // Test-name-based paths are unique per test, so there is no truncation risk,
+    // auto-unlink log files on pass, keep on failure is implemented in the destructor.
+    // Set RCCL_KEEP_TEST_LOGS=1 to retain all logs unconditionally.
+    o.unlink_auto_generated_nccl_path = true;
     return o;
 }
 
@@ -415,12 +525,26 @@ TestLogAssertionContext::TestLogAssertionContext(const TestLogAssertionOptions& 
 {
     const int rank = opts.mpi_rank;
 
+    // Capture the test label for use in the log-file header (written in the
+    // destructor).  GTest tests get "Suite/TestName"; standalone binaries
+    // that don't link against GTest get "pid_<PID>" as a fallback so the
+    // log can still be correlated to the process that produced it.
+#if defined(RCCL_MPIHelpers_HAS_GTEST)
+    {
+        const ::testing::TestInfo* info
+            = ::testing::UnitTest::GetInstance()->current_test_info();
+        if(info && info->test_suite_name() && info->name())
+            test_label_ = std::string{info->test_suite_name()} + "/" + info->name();
+    }
+#endif
+    if(test_label_.empty())
+        test_label_ = std::string{"pid_"} + std::to_string(::getpid());
+
     if(capture_nccl_)
     {
         if(opts_.nccl_debug_file_path.empty())
         {
-            nccl_path_ = std::string{"/tmp/rccl_assert_nccl_rank_"} + std::to_string(rank) + "_pid_"
-                         + std::to_string(::getpid()) + ".log";
+            nccl_path_      = makeTestNameLogPath(rank);
             auto_nccl_path_ = true;
         }
         else
@@ -442,10 +566,23 @@ TestLogAssertionContext::TestLogAssertionContext(const TestLogAssertionOptions& 
         else
         {
             env_modified_ = true;
+            // Tell NCCL to close its current log file and re-read NCCL_DEBUG_FILE
+            // on the next log output.  Without this the global ncclDebugFile remains
+            // pointed at the previous test's (possibly already-unlinked) file handle.
+            resetNcclDebugFile();
         }
+
+        // Remove any log file left over from a previous test run (e.g. a
+        // skipped run that kept its log).  NCCL always opens the file with
+        // fopen("w") which truncates, so if we recorded the OLD file's size
+        // as nccl_start_offset_, readNcclDebugLog() would slice past all of
+        // the new content and return an empty string on every subsequent run.
+        (void)::unlink(nccl_path_.c_str());
 
         if(opts_.isolate_new_output)
         {
+            // File was just unlinked; getFileSizeBytes always returns 0 here.
+            // The assignment is kept for symmetry and clarity.
             nccl_start_offset_ = getFileSizeBytes(nccl_path_);
         }
     }
@@ -473,16 +610,75 @@ TestLogAssertionContext::~TestLogAssertionContext()
         {
             (void)::unsetenv("NCCL_DEBUG_FILE");
         }
+        // Flush all stdio streams (including NCCL's internal FILE* buffer) before
+        // reading the log file.  resetNcclDebugFile() arms the lazy close but does
+        // not flush or close the handle immediately; fflush(nullptr) ensures every
+        // pending byte has been written to disk before we read and rewrite the file.
+        std::fflush(nullptr);
+        resetNcclDebugFile();
     }
 
     if(capture_nccl_ && !nccl_path_.empty())
     {
-        const bool unlink_it = (auto_nccl_path_ && opts_.unlink_auto_generated_nccl_path)
-                               || (!auto_nccl_path_ && opts_.unlink_explicit_nccl_path);
-        if(unlink_it)
+        // ---------------------------------------------------------------
+        // Prepend a one-line header to the log file so it is
+        // self-identifying regardless of whether the name is human-readable
+        // (GTest path) or opaque (pid-based standalone path).
+        //
+        // The header is written here (destructor) rather than in the
+        // constructor because NCCL opens the file with fopen("w") on its
+        // first lazy-init log call, which would truncate anything written
+        // earlier.  By writing in the destructor — after the communicator
+        // has already been torn down and fflush(nullptr) has drained NCCL's
+        // internal buffer — the file is complete and safe to rewrite.
+        // ---------------------------------------------------------------
+        const std::string content = readTextFile(nccl_path_);
+        if(!content.empty())
         {
-            (void)::unlink(nccl_path_.c_str());
+            std::ostringstream header;
+            header << "=== RCCL Test Log"
+                   << " | Test: "  << test_label_
+                   << " | Rank: "  << opts_.mpi_rank
+                   << " | PID: "   << ::getpid()
+                   << " ===\n";
+            const std::string hdr = header.str();
+
+            if(FILE* f = std::fopen(nccl_path_.c_str(), "w"))
+            {
+                std::fwrite(hdr.c_str(),     1, hdr.size(),     f);
+                std::fwrite(content.c_str(), 1, content.size(), f);
+                std::fclose(f);
+            }
         }
+
+        // ---------------------------------------------------------------
+        // Keep the log when the test FAILED (so it is available
+        // for post-mortem inspection); delete it when the test PASSED to
+        // avoid accumulating noise in /tmp.
+        //
+        // Override: set RCCL_KEEP_TEST_LOGS=1 to keep ALL logs regardless
+        // of pass/fail — useful when stepping through a test run manually.
+        // ---------------------------------------------------------------
+        const bool keep_all = (std::getenv("RCCL_KEEP_TEST_LOGS") != nullptr);
+
+        bool test_passed = false; // conservative default: keep when uncertain
+#if defined(RCCL_MPIHelpers_HAS_GTEST)
+        {
+            const ::testing::TestInfo* info
+                = ::testing::UnitTest::GetInstance()->current_test_info();
+            if(info && info->result())
+                test_passed = info->result()->Passed();
+        }
+#endif
+
+        const bool unlink_it
+            = !keep_all
+              && test_passed
+              && ((auto_nccl_path_ && opts_.unlink_auto_generated_nccl_path)
+                  || (!auto_nccl_path_ && opts_.unlink_explicit_nccl_path));
+
+        if(unlink_it)
+            (void)::unlink(nccl_path_.c_str());
     }
 }
 
@@ -492,6 +688,11 @@ std::string TestLogAssertionContext::readNcclDebugLog() const
     {
         return {};
     }
+    // NCCL writes to a stdio FILE* with block-buffering.  Flush all open
+    // streams so that any bytes still sitting in the libc buffer (e.g.
+    // "Init CE" / "CE: rank" lines written during the most recent collective)
+    // are committed to disk before we read the file back.
+    std::fflush(nullptr);
     const std::string full = readTextFile(nccl_path_);
     return opts_.isolate_new_output ? sliceFromOffset(full, nccl_start_offset_) : full;
 }

--- a/projects/rccl/test/common/MPIHelpers.cpp
+++ b/projects/rccl/test/common/MPIHelpers.cpp
@@ -578,7 +578,11 @@ TestLogAssertionContext::TestLogAssertionContext(const TestLogAssertionOptions& 
         // fopen("w") which truncates, so if we recorded the OLD file's size
         // as nccl_start_offset_, readNcclDebugLog() would slice past all of
         // the new content and return an empty string on every subsequent run.
-        (void)::unlink(nccl_path_.c_str());
+        // Only unlink auto-generated paths; do not clobber a user-supplied file.
+        if(auto_nccl_path_)
+        {
+            (void)::unlink(nccl_path_.c_str());
+        }
 
         if(opts_.isolate_new_output)
         {

--- a/projects/rccl/test/common/MPIHelpers.hpp
+++ b/projects/rccl/test/common/MPIHelpers.hpp
@@ -20,6 +20,7 @@
 
 #include <array>
 #include <atomic>
+#include <cerrno>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -339,10 +340,21 @@ inline T getEnvParam(const char* name, T ncclDefault)
     static_assert(std::is_integral_v<T>, "getEnvParam: T must be an integer type");
     const char* v = std::getenv(name);
     if(!v || v[0] == '\0') return ncclDefault;
+
+    char* endptr = nullptr;
+    errno        = 0;
     if constexpr(std::is_unsigned_v<T>)
-        return static_cast<T>(std::strtoull(v, nullptr, 0));
+    {
+        const unsigned long long val = std::strtoull(v, &endptr, 0);
+        if(errno == ERANGE || endptr == v) return ncclDefault;
+        return static_cast<T>(val);
+    }
     else
-        return static_cast<T>(std::strtoll(v, nullptr, 0));
+    {
+        const long long val = std::strtoll(v, &endptr, 0);
+        if(errno == ERANGE || endptr == v) return ncclDefault;
+        return static_cast<T>(val);
+    }
 }
 
 /** RAII scoped set/restore of a single env var; restores (or unsets) on destruction.

--- a/projects/rccl/test/common/MPIHelpers.hpp
+++ b/projects/rccl/test/common/MPIHelpers.hpp
@@ -35,6 +35,19 @@
 namespace MPIHelpers
 {
 
+// Returns the MPI world rank as a string for diagnostic messages.
+// Probes OpenMPI, MPICH/PMIx, and SLURM env vars in order; returns "?" if none set.
+inline const char* getMpiRankStr()
+{
+    for(const char* var : {"OMPI_COMM_WORLD_RANK", "PMI_RANK", "PMIX_RANK", "SLURM_PROCID"})
+    {
+        const char* val = std::getenv(var);
+        if(val)
+            return val;
+    }
+    return "?";
+}
+
 /**
  * @struct MPIContext
  * @brief MPI environment context information

--- a/projects/rccl/test/common/MPIHelpers.hpp
+++ b/projects/rccl/test/common/MPIHelpers.hpp
@@ -21,6 +21,7 @@
 #include <array>
 #include <atomic>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <memory>
 #include <optional>
@@ -256,9 +257,10 @@ struct TestLogAssertionOptions
     int mpi_rank{0};
 
     bool capture_nccl_debug_file{false};
-    /** If capture_nccl_debug_file and empty, auto-path is:
-     *    GTest binary : /tmp/rccl_<Suite>.<Test>_rank<R>.log   (human-readable)
-     *    Standalone   : /tmp/rccl_nccl_rank<R>_pid<P>.log      (pid-based fallback)
+    /** If capture_nccl_debug_file and empty, auto-path is built from getLogBaseDir()
+     *  (priority: RCCL_TEST_LOG_DIR env var → binary directory → /tmp):
+     *    GTest binary : <logdir>/rccl_<Suite>.<Test>_rank<R>_pid<P>.log
+     *    Standalone   : <logdir>/rccl_rank<R>_pid<P>.log
      *  Path is derived from GTest current_test_info() at construction time. */
     std::string nccl_debug_file_path;
     /** When true, the log file is unlinked after a PASSING test.
@@ -326,18 +328,21 @@ TestLogAssertionOptions makeCombinedAssertionLogOptions(int mpi_rank);
 /**
  * @brief Return the effective value of a numeric NCCL env var (mirrors NCCL_PARAM semantics).
  * @param name        Env var name (e.g. "NCCL_CTA_POLICY").
- * @param ncclDefault NCCL compiled-in default (returned when the var is unset).
+ * @param ncclDefault NCCL compiled-in default (returned when the var is unset or empty).
+ *
+ * Mirrors ncclLoadParam behaviour: uses base 0 so that "0x10" parses as 16, "010" as 8, etc.
+ * An empty string is treated as unset (returns ncclDefault), consistent with RCCL's param code.
  */
 template<typename T>
 inline T getEnvParam(const char* name, T ncclDefault)
 {
     static_assert(std::is_integral_v<T>, "getEnvParam: T must be an integer type");
     const char* v = std::getenv(name);
-    if(!v) return ncclDefault;
+    if(!v || v[0] == '\0') return ncclDefault;
     if constexpr(std::is_unsigned_v<T>)
-        return static_cast<T>(std::strtoull(v, nullptr, 10));
+        return static_cast<T>(std::strtoull(v, nullptr, 0));
     else
-        return static_cast<T>(std::strtoll(v, nullptr, 10));
+        return static_cast<T>(std::strtoll(v, nullptr, 0));
 }
 
 /** RAII scoped set/restore of a single env var; restores (or unsets) on destruction.

--- a/projects/rccl/test/common/MPIHelpers.hpp
+++ b/projects/rccl/test/common/MPIHelpers.hpp
@@ -347,8 +347,7 @@ inline T getEnvParam(const char* name, T ncclDefault)
 
 /** RAII scoped set/restore of a single env var; restores (or unsets) on destruction.
  *
- *  If the variable was already set to a *different* value (e.g. by the test runner's
- *  suite/test env_variables config), a one-line warning is printed to stderr so the
+ *  Warns on stderr (via getMpiRankStr()) when overriding an existing value so the
  *  caller knows the in-test override is active.  The original value is always restored
  *  on destruction regardless of test outcome.
  */
@@ -367,18 +366,9 @@ struct MpiEnvGuard
             saved = prev;
             if(saved != v)
             {
-                // Avoid <mpi.h> dependency; try common MPI rank env vars.
-                const char* rankEnv = nullptr;
-                for(const char* var :
-                    {"OMPI_COMM_WORLD_RANK", "PMI_RANK", "PMIX_RANK", "SLURM_PROCID"})
-                {
-                    rankEnv = std::getenv(var);
-                    if(rankEnv)
-                        break;
-                }
                 fprintf(stderr,
                         "[MpiEnvGuard rank %s] overriding %s: '%s' -> '%s' (will restore on scope exit)\n",
-                        rankEnv ? rankEnv : "?", n, saved.c_str(), v);
+                        getMpiRankStr(), n, saved.c_str(), v);
             }
         }
         ::setenv(n, v, /*overwrite=*/1);

--- a/projects/rccl/test/common/MPIHelpers.hpp
+++ b/projects/rccl/test/common/MPIHelpers.hpp
@@ -26,6 +26,7 @@
 #include <optional>
 #include <string>
 #include <thread>
+#include <type_traits>
 
 /**
  * @namespace MPIHelpers
@@ -242,8 +243,14 @@ struct TestLogAssertionOptions
     int mpi_rank{0};
 
     bool capture_nccl_debug_file{false};
-    /** If capture_nccl_debug_file and empty, uses /tmp/rccl_assert_nccl_rank_<r>_pid_<p>.log */
+    /** If capture_nccl_debug_file and empty, auto-path is:
+     *    GTest binary : /tmp/rccl_<Suite>.<Test>_rank<R>.log   (human-readable)
+     *    Standalone   : /tmp/rccl_nccl_rank<R>_pid<P>.log      (pid-based fallback)
+     *  Path is derived from GTest current_test_info() at construction time. */
     std::string nccl_debug_file_path;
+    /** When true, the log file is unlinked after a PASSING test.
+     *  Failing tests always keep their log so it is available for post-mortem
+     *  inspection.  Set RCCL_KEEP_TEST_LOGS=1 to keep all logs regardless. */
     bool unlink_auto_generated_nccl_path{true};
     bool unlink_explicit_nccl_path{false};
 
@@ -283,6 +290,7 @@ public:
 private:
     TestLogAssertionOptions opts_;
     std::string             nccl_path_;
+    std::string             test_label_;           ///< "Suite/Test" or "pid_<P>" for standalone
     std::string             saved_nccl_debug_env_;
     bool                    saved_nccl_debug_present_{false};
     bool                    env_modified_{false};
@@ -301,6 +309,73 @@ TestLogAssertionOptions makePerRankStderrAssertionOptions(int mpi_rank);
 
 /** Both: NCCL debug file + per-rank stderr log (either read may contain the line) */
 TestLogAssertionOptions makeCombinedAssertionLogOptions(int mpi_rank);
+
+/**
+ * @brief Return the effective value of a numeric NCCL env var (mirrors NCCL_PARAM semantics).
+ * @param name        Env var name (e.g. "NCCL_CTA_POLICY").
+ * @param ncclDefault NCCL compiled-in default (returned when the var is unset).
+ */
+template<typename T>
+inline T getEnvParam(const char* name, T ncclDefault)
+{
+    static_assert(std::is_integral_v<T>, "getEnvParam: T must be an integer type");
+    const char* v = std::getenv(name);
+    if(!v) return ncclDefault;
+    if constexpr(std::is_unsigned_v<T>)
+        return static_cast<T>(std::strtoull(v, nullptr, 10));
+    else
+        return static_cast<T>(std::strtoll(v, nullptr, 10));
+}
+
+/** RAII scoped set/restore of a single env var; restores (or unsets) on destruction.
+ *
+ *  If the variable was already set to a *different* value (e.g. by the test runner's
+ *  suite/test env_variables config), a one-line warning is printed to stderr so the
+ *  caller knows the in-test override is active.  The original value is always restored
+ *  on destruction regardless of test outcome.
+ */
+struct MpiEnvGuard
+{
+    const char* name;
+    std::string saved;
+    bool        had{false};
+
+    MpiEnvGuard(const char* n, const char* v) : name(n)
+    {
+        const char* prev = std::getenv(n);
+        had              = (prev != nullptr);
+        if(had)
+        {
+            saved = prev;
+            if(saved != v)
+            {
+                // Avoid <mpi.h> dependency; try common MPI rank env vars.
+                const char* rankEnv = nullptr;
+                for(const char* var :
+                    {"OMPI_COMM_WORLD_RANK", "PMI_RANK", "PMIX_RANK", "SLURM_PROCID"})
+                {
+                    rankEnv = std::getenv(var);
+                    if(rankEnv)
+                        break;
+                }
+                fprintf(stderr,
+                        "[MpiEnvGuard rank %s] overriding %s: '%s' -> '%s' (will restore on scope exit)\n",
+                        rankEnv ? rankEnv : "?", n, saved.c_str(), v);
+            }
+        }
+        ::setenv(n, v, /*overwrite=*/1);
+    }
+    ~MpiEnvGuard()
+    {
+        if(had)
+            ::setenv(name, saved.c_str(), 1);
+        else
+            ::unsetenv(name);
+    }
+
+    MpiEnvGuard(const MpiEnvGuard&)            = delete;
+    MpiEnvGuard& operator=(const MpiEnvGuard&) = delete;
+};
 
 } // namespace MPIHelpers
 

--- a/projects/rccl/test/common/MPITestCore.cpp
+++ b/projects/rccl/test/common/MPITestCore.cpp
@@ -12,6 +12,8 @@
 #include <string>
 
 // Import commonly used guards into local scope
+using RCCLTestGuards::makeCommAutoGuard;
+using RCCLTestGuards::makeStreamAutoGuard;
 using RCCLTestGuards::makeScopeGuard;
 
 // Detect the number of unique nodes
@@ -363,46 +365,21 @@ ncclResult_t MPITestCore::cleanupTestCommunicator()
         return ncclSuccess; // Already cleaned up or never created
     }
 
-    int world_rank = MPIEnvironment::world_rank;
-
     MPI_Barrier(MPI_COMM_WORLD);
 
-    // RAII guard: Ensure test_comm_ is destroyed even if stream cleanup fails
-    auto comm_guard = makeScopeGuard(
-        [this, world_rank]()
-        {
-            if(test_comm_)
-            {
-                ncclResult_t result = ncclCommDestroy(test_comm_);
-                if(result != ncclSuccess)
-                {
-                    TEST_WARN("Rank %d: ncclCommDestroy failed during cleanup: %s",
-                              world_rank,
-                              ncclGetErrorString(result));
-                }
-                test_comm_ = nullptr;
-            }
-        });
-
-    // RAII guard: Ensure test_stream_ is destroyed
-    auto stream_guard = makeScopeGuard(
-        [this, world_rank]()
-        {
-            if(test_stream_)
-            {
-                hipError_t hip_result = hipStreamDestroy(test_stream_);
-                if(hip_result != hipSuccess)
-                {
-                    TEST_WARN("Rank %d: hipStreamDestroy failed during cleanup: %s",
-                              world_rank,
-                              hipGetErrorString(hip_result));
-                }
-                test_stream_ = nullptr;
-            }
-        });
-
-    // Guards will automatically clean up when going out of scope
-    // Even if an exception were thrown (though we don't use exceptions)
+    // Nested scope: guards fire at }, which is BEFORE the post-cleanup barrier.
+    // This guarantees ncclCommDestroy completes on every rank before any rank
+    // enters the next test's createTestCommunicator.  This matters when the
+    // binary is run directly (mpirun ./rccl-UnitTestsMPI); the test runner
+    // avoids the scenario entirely by spawning one mpirun per test.
+    {
+        // Declare comm_guard first so it is destroyed last (LIFO):
+        // stream is destroyed first, then comm — matching creation order.
+        auto comm_guard   = makeCommAutoGuard(test_comm_);
+        test_comm_        = nullptr;
+        auto stream_guard = makeStreamAutoGuard(test_stream_);
+        test_stream_      = nullptr;
+    } // stream_guard fires, then comm_guard fires — both before MPI_Barrier
 
     MPI_Barrier(MPI_COMM_WORLD);
 

--- a/projects/rccl/test/common/MPITestFramework.md
+++ b/projects/rccl/test/common/MPITestFramework.md
@@ -449,21 +449,32 @@ RCCL_MPI_LOG_ALL_RANKS=1 mpirun -np 4 ./rccl-UnitTestsMPI
 
 ### Log Files
 
-When enabled, log files are created for all ranks in the **current working directory**:
+When enabled, log files are named `rccl_test_rank_<N>_pid<PID>.log` and placed in a directory
+chosen by the following priority:
+
+1. **`RCCL_TEST_LOG_DIR`** env var — explicit override, useful in CI pipelines
+2. **Directory of the test binary** (`/proc/self/exe`) — logs land alongside the binary,
+   automatically tied to the exact build; different builds never share logs
+3. **`/tmp`** — last-resort fallback if both above are unavailable
 
 ```
-rccl_test_rank_0.log  (contains rank 0 output - also displayed on console)
-rccl_test_rank_1.log  (contains all rank 1 output)
-rccl_test_rank_2.log  (contains all rank 2 output)
-rccl_test_rank_3.log  (contains all rank 3 output)
+<binary_dir>/rccl_test_rank_0_pid<PID>.log  (rank 0 — also displayed on console)
+<binary_dir>/rccl_test_rank_1_pid<PID>.log  (rank 1)
+<binary_dir>/rccl_test_rank_2_pid<PID>.log  (rank 2)
+<binary_dir>/rccl_test_rank_3_pid<PID>.log  (rank 3)
+```
+
+**Overriding the log directory:**
+```bash
+export RCCL_TEST_LOG_DIR=/path/to/ci/artifacts
+mpirun -np 4 -x RCCL_MPI_LOG_ALL_RANKS=1 ./rccl-UnitTestsMPI
 ```
 
 **Important Notes:**
 - **Rank 0**: Output goes to BOTH console (for interactive monitoring) AND log file (for later analysis)
 - **Rank 1-N**: Output goes only to log files
-- **Location**: Log files are created in the directory where you execute the test command
-- For multi-node runs, each node creates logs in its local working directory
-- Ensure you have write permissions in the execution directory
+- **PID suffix**: Ensures each `mpirun` invocation gets unique files; stale files from a previous run are never silently overwritten
+- For multi-node runs, each node writes logs to its local resolution of the log directory
 
 **Banner Display:**
 The per-rank logging banner is displayed using `TEST_INFO` macros, which means:
@@ -522,9 +533,9 @@ NCCL_DEBUG=INFO mpirun -np 2 ./rccl-UnitTestsMPI --gtest_filter="P2PTest.DataTra
 
 # You'll see a banner message at startup (with NCCL_DEBUG=INFO):
 # [0] TEST INFO Per-Rank Logging ENABLED (RCCL_MPI_LOG_ALL_RANKS=1)
-# [0] TEST INFO Rank 0     : Output to BOTH console AND rccl_test_rank_0.log
-# [0] TEST INFO Ranks 1-N  : Output redirected to rccl_test_rank_<N>.log
-# [0] TEST INFO Location   : Log files created in current working directory
+# [0] TEST INFO Rank 0     : Output to BOTH console AND <binary_dir>/rccl_test_rank_0_pid<PID>.log
+# [0] TEST INFO Ranks 1-N  : Output redirected to per-rank log files
+# [0] TEST INFO Log dir    : <binary_dir>  (override: RCCL_TEST_LOG_DIR)
 
 # Without NCCL_DEBUG (minimal output):
 export RCCL_MPI_LOG_ALL_RANKS=1
@@ -1544,6 +1555,12 @@ Two types of guards are provided:
 
 1. **`AutoGuard<T, auto DeleterFunc>`** - Modern C++17 guard using function pointers (for simple cleanup)
 2. **`ResourceGuard<T, Deleter>`** - Functor-based guard (for complex stateful cleanup)
+
+The built-in wrapper functions (`ncclCommDestroyWrapper`, `hipStreamDestroyWrapper`) include the
+MPI rank in any failure warning. The rank is resolved via `getMpiRankStr()`, which probes
+`OMPI_COMM_WORLD_RANK`, `PMI_RANK` (MPICH), `PMIX_RANK`, and `SLURM_PROCID` in that order,
+so rank-tagged warnings appear correctly under OpenMPI, MPICH, and SLURM without requiring
+`<mpi.h>` in the guard header.
 
 ### AutoGuard - Simple Cleanup
 

--- a/projects/rccl/test/common/ResourceGuards.hpp
+++ b/projects/rccl/test/common/ResourceGuards.hpp
@@ -324,6 +324,19 @@ struct NcclRegHandleDeleter
     }
 };
 
+// Returns the MPI world rank as a string for diagnostic messages.
+// Tries OpenMPI, MPICH/PMIx, and SLURM env vars in order.
+inline const char* getMpiRankStr()
+{
+    for(const char* var : {"OMPI_COMM_WORLD_RANK", "PMI_RANK", "PMIX_RANK", "SLURM_PROCID"})
+    {
+        const char* val = std::getenv(var);
+        if(val)
+            return val;
+    }
+    return "?";
+}
+
 // Wrapper functions for AutoGuard (void-returning cleanup functions)
 inline void hipFreeWrapper(void* ptr)
 {
@@ -348,7 +361,8 @@ inline void hipStreamDestroyWrapper(hipStream_t stream)
         if(err != hipSuccess)
         {
             fprintf(stderr,
-                    "WARNING: hipStreamDestroy failed in destructor: %s (stream=%p)\n",
+                    "WARNING: rank %s: hipStreamDestroy failed: %s (stream=%p)\n",
+                    getMpiRankStr(),
                     hipGetErrorString(err),
                     static_cast<void*>(stream));
         }
@@ -378,7 +392,8 @@ inline void ncclCommDestroyWrapper(ncclComm_t comm)
         if(result != ncclSuccess)
         {
             fprintf(stderr,
-                    "WARNING: ncclCommDestroy failed in destructor: %s (comm=%p)\n",
+                    "WARNING: rank %s: ncclCommDestroy failed: %s (comm=%p)\n",
+                    getMpiRankStr(),
                     ncclGetErrorString(result),
                     static_cast<void*>(comm));
         }


### PR DESCRIPTION
## Motivation

The RCCL MPI test framework needed several reliability and usability improvements to support robust multi-rank testing: per-rank log files were written to /tmp with no build association, teardown races caused spurious MPI_Abort failures, communicator cleanup was not barrier-synchronized before the next test could start, and guard failure messages lacked rank context, making failures hard to attribute in multi-rank runs.

## Technical Details

#### Per-rank log file management (MPIHelpers.cpp, MPIHelpers.hpp)
- Added getLogBaseDir() with priority: RCCL_TEST_LOG_DIR env var → directory of the test binary (/proc/self/exe) → /tmp. Logs are now tied to the build that produced them.
- TestLogAssertionContext calls ncclResetDebugInit() via dlsym to avoid the -Wdeprecated-declarations warning and a direct link dependency, while still resetting NCCL debug state between tests.
- MpiEnvGuard now warns on stderr when overriding an existing env var; rank detection probes OMPI_COMM_WORLD_RANK, PMI_RANK, PMIX_RANK, and SLURM_PROCID for OpenMPI / MPICH / SLURM compatibility without a <mpi.h> dependency.

#### Cleanup ordering fix (MPITestCore.cpp)
- Refactored cleanupTestCommunicator() to use makeCommAutoGuard / makeStreamAutoGuard in a nested scope that fires before the final MPI_Barrier. This prevents RDMA pool exhaustion when multiple tests are run sequentially in a single mpirun invocation by ensuring all VMM allocations are released on every rank before the next test's communicator creation.

#### Teardown timeout (MPIEnvironment.cpp)
- Increased the non-blocking barrier timeout in MPIEnvironment::TearDown from 1 s to 3 s. With communicator destruction now barrier-synchronized in cleanupTestCommunicator, the remaining skew is log-file I/O only, making 3 s sufficient to prevent false MPI_Abort on slow nodes.

#### Rank-aware RAII guard diagnostics (ResourceGuards.hpp)
- Added getMpiRankStr() helper (no <mpi.h>) that probes multiple MPI rank env vars. Updated ncclCommDestroyWrapper and hipStreamDestroyWrapper to include the MPI rank in failure warning messages.

#### Documentation (MPITestFramework.md)
- Updated "Log Files" section to document RCCL_TEST_LOG_DIR / binary-dir / /tmp priority and the RCCL_MPI_LOG_ALL_RANKS interaction.
- Updated "RAII Resource Guards" section to document the rank-aware wrappers and getMpiRankStr().

## JIRA ID

AICOMRCCL-971

## Test Plan

- Built rccl-UnitTestsMPI with both OpenMPI and confirmed clean compilation with no new warnings.
- Ran the full CE collective MPI test suite (AllGather, AlltoAll, Scatter, Gather, Fallback — 19 tests across 2/4/8 ranks) via individual mpirun invocations and verified all pass with RCCL_MPI_LOG_ALL_RANKS=1.
- Verified log files are created in the test binary directory and that passing tests auto-unlink their log files.
- Ran NET IB tests to confirm framework changes are non-breaking for non-CE test paths.

## Test Result

All CE MPI tests pass. No regressions observed in the existing MPI test suite.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
