### PR TITLE
CE Coll: Add MPI tests for CE collectives

### DIFF
--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -477,26 +477,57 @@ add_custom_command(
 # collectives.cc: contains a __global__ kernel launch (hierarchicalAGShuffle)
 # so it needs full HIP compilation, not --offload-host-only.
 # ===========================================================================
+# Dependency tracking note (CMake >= 3.20 vs < 3.20):
+# add_custom_command only rebuilds when files listed in DEPENDS change.  It
+# does NOT automatically track transitive headers (e.g. ce_coll.h), so a
+# struct layout change in a header would not invalidate collectives.o.
+# CMake 3.20 DEPFILE support fixes this by reading the compiler-generated .d
+# file; on older CMake the workaround is: touch hipify/src/collectives.cc.
+# ===========================================================================
 set(COLLECTIVES_FAT_OBJ "${DEVICE_BUILD_DIR}/collectives.o")
 
-add_custom_command(
-  OUTPUT  ${COLLECTIVES_FAT_OBJ}
-  COMMAND ${DL_CLANG}
-    -x hip ${DL_OFFLOAD_ARCH_FLAGS}
-    ${DL_HIP_COMPILER_FLAGS}
-    -DRCCL_DEVICE_LINKER
-    ${_link_def_flags}
-    ${_host_inc_flags}
-    ${DL_OPT_FLAGS}
-    -std=c++17
-    -fPIC
-    -w
-    -c -o ${COLLECTIVES_FAT_OBJ}
-    ${HIPIFY_DIR}/src/collectives.cc
-  DEPENDS ${HIPIFY_DIR}/src/collectives.cc
-  COMMENT "DL compile: collectives.cc (has __global__ kernel)"
-  VERBATIM
-)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.20")
+  set(COLLECTIVES_DEPFILE "${DEVICE_BUILD_DIR}/collectives.d")
+  add_custom_command(
+    OUTPUT  ${COLLECTIVES_FAT_OBJ}
+    COMMAND ${DL_CLANG}
+      -x hip ${DL_OFFLOAD_ARCH_FLAGS}
+      ${DL_HIP_COMPILER_FLAGS}
+      -DRCCL_DEVICE_LINKER
+      ${_link_def_flags}
+      ${_host_inc_flags}
+      ${DL_OPT_FLAGS}
+      -std=c++17
+      -fPIC
+      -w
+      -MD -MF ${COLLECTIVES_DEPFILE}
+      -c -o ${COLLECTIVES_FAT_OBJ}
+      ${HIPIFY_DIR}/src/collectives.cc
+    DEPENDS ${HIPIFY_DIR}/src/collectives.cc
+    DEPFILE ${COLLECTIVES_DEPFILE}
+    COMMENT "DL compile: collectives.cc (has __global__ kernel, header-tracking via DEPFILE)"
+    VERBATIM
+  )
+else()
+  add_custom_command(
+    OUTPUT  ${COLLECTIVES_FAT_OBJ}
+    COMMAND ${DL_CLANG}
+      -x hip ${DL_OFFLOAD_ARCH_FLAGS}
+      ${DL_HIP_COMPILER_FLAGS}
+      -DRCCL_DEVICE_LINKER
+      ${_link_def_flags}
+      ${_host_inc_flags}
+      ${DL_OPT_FLAGS}
+      -std=c++17
+      -fPIC
+      -w
+      -c -o ${COLLECTIVES_FAT_OBJ}
+      ${HIPIFY_DIR}/src/collectives.cc
+    DEPENDS ${HIPIFY_DIR}/src/collectives.cc
+    COMMENT "DL compile: collectives.cc (has __global__ kernel)"
+    VERBATIM
+  )
+endif()
 
 # ===========================================================================
 # dda_all_reduce_ipc.cu.cpp: contains device kernels and kernel launches.

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -94,6 +94,7 @@ set(SRC_FILES
   include/bitops.h
   include/bootstrap.h
   include/ce_coll.h
+  include/ce_fault_inject.h
   include/channel.h
   include/checks.h
   include/collectives.h

--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -13,6 +13,17 @@
 #include "alloc.h"
 #include "ce_fault_inject.h"
 
+#ifdef ENABLE_FAULT_INJECTION
+// Common fault check helper
+static ncclResult_t ceFaultCheck(struct ncclComm* comm, uint32_t bit, const char* fnName) {
+  if (comm->ceColl.ceFaults & bit) {
+    WARN("CE: fault injection: %s returning ncclSystemError (rank %d)", fnName, comm->rank);
+    return ncclSystemError;
+  }
+  return ncclSuccess;
+}
+#endif
+
 RCCL_PARAM(CeMultiStreams, "CE_MULTI_STREAMS", 0);
 // Static constant for graph synchronization
 static const uint32_t GRAPH_SYNC_VALUE = 1;
@@ -35,10 +46,7 @@ ncclResult_t ncclCeInit(struct ncclComm* comm) {
   ncclResult_t ret = ncclSuccess;
 
 #ifdef ENABLE_FAULT_INJECTION
-  if (comm->ceColl.ceFaults & CE_FAULT_INIT) {
-    WARN("CE: fault injection: ncclCeInit returning ncclSystemError (rank %d)", comm->rank);
-    return ncclSystemError;
-  }
+  NCCLCHECK(ceFaultCheck(comm, CE_FAULT_INIT, "ncclCeInit"));
 #endif
 
   uint8_t* ceDevBase = nullptr;
@@ -192,10 +200,7 @@ ncclResult_t ncclPrepUCSync(struct ncclComm* comm, bool isComplete,
   ncclResult_t ret = ncclSuccess;
 
 #ifdef ENABLE_FAULT_INJECTION
-  if (comm->ceColl.ceFaults & CE_FAULT_SYNC_PREP) {
-    WARN("CE: fault injection: ncclPrepUCSync returning ncclSystemError (rank %d)", comm->rank);
-    return ncclSystemError;
-  }
+  NCCLCHECK(ceFaultCheck(comm, CE_FAULT_SYNC_PREP, "ncclPrepUCSync"));
 #endif
 
   uint32_t* readyPtrs    = (uint32_t*)comm->ceColl.baseUCSymReadyPtr;
@@ -331,10 +336,7 @@ ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeBatchOpsPa
   ncclResult_t ret = ncclSuccess;
 
 #ifdef ENABLE_FAULT_INJECTION
-  if (comm->ceColl.ceFaults & CE_FAULT_LAUNCH_OP) {
-    WARN("CE: fault injection: ncclCeLaunchBatchOps returning ncclSystemError (rank %d)", comm->rank);
-    return ncclSystemError;
-  }
+  NCCLCHECK(ceFaultCheck(comm, CE_FAULT_LAUNCH_OP, "ncclCeLaunchBatchOps"));
 #endif
 
   // Check if there are any operations to perform

--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -135,6 +135,10 @@ bool ncclCeImplemented(ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_
   if (ncclCudaDriverVersion(&driverVersion) != ncclSuccess) return false;
 
   // CE is supported in ROCm 7.12+ and the 7.0.2.x range [7.0.2.2, 7.0.3.0).
+  // hipDriverGetVersion() encodes as MAJOR*10000000 + MINOR*100000 + PATCH*1000 + BUILD;
+  //   ROCm 7.12.0   → 71200000
+  //   ROCm 7.0.2.2  → 70051831  (lower bound of the 7.0.2.x backport range)
+  //   ROCm 7.0.3.0  → 70060000  (exclusive upper bound)
   if (driverVersion >= 71200000 || (driverVersion >= 70051831 && driverVersion < 70060000)) {
     switch (coll) {
     case ncclFuncAllGather:

--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -11,6 +11,7 @@
 #include "rocmwrap.h"
 #include "ce_coll.h"
 #include "alloc.h"
+#include "ce_fault_inject.h"
 
 RCCL_PARAM(CeMultiStreams, "CE_MULTI_STREAMS", 0);
 // Static constant for graph synchronization
@@ -32,6 +33,13 @@ static void ceDestroyCopyStreams(struct ncclComm* comm, int nPairs) {
 
 ncclResult_t ncclCeInit(struct ncclComm* comm) {
   ncclResult_t ret = ncclSuccess;
+
+#ifdef ENABLE_FAULT_INJECTION
+  if (comm->ceColl.ceFaults & CE_FAULT_INIT) {
+    WARN("CE: fault injection: ncclCeInit returning ncclSystemError (rank %d)", comm->rank);
+    return ncclSystemError;
+  }
+#endif
 
   uint8_t* ceDevBase = nullptr;
   size_t ceDevBaseSize = alignUp(comm->nRanks*sizeof(uint32_t), 16) * 2;
@@ -118,9 +126,8 @@ bool ncclCeImplemented(ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_
   int driverVersion;
   if (ncclCudaDriverVersion(&driverVersion) != ncclSuccess) return false;
 
-  // CE is supported in ROCm 7.12 and later
-  // hipDriverGetVersion() returns 71200000 for ROCm 7.12
-  if (driverVersion >= 71200000) {
+  // CE is supported in ROCm 7.12+ and the 7.0.2.x range [7.0.2.2, 7.0.3.0).
+  if (driverVersion >= 71200000 || (driverVersion >= 70051831 && driverVersion < 70060000)) {
     switch (coll) {
     case ncclFuncAllGather:
     case ncclFuncAlltoAll:
@@ -183,6 +190,13 @@ ncclResult_t ncclPrepUCSync(struct ncclComm* comm, bool isComplete,
                                hipStreamBatchMemOpParams* batchParams,
                                size_t* opIdx) {
   ncclResult_t ret = ncclSuccess;
+
+#ifdef ENABLE_FAULT_INJECTION
+  if (comm->ceColl.ceFaults & CE_FAULT_SYNC_PREP) {
+    WARN("CE: fault injection: ncclPrepUCSync returning ncclSystemError (rank %d)", comm->rank);
+    return ncclSystemError;
+  }
+#endif
 
   uint32_t* readyPtrs    = (uint32_t*)comm->ceColl.baseUCSymReadyPtr;
   uint32_t* completePtrs = (uint32_t*)comm->ceColl.baseUCSymComplPtr;
@@ -284,7 +298,7 @@ ncclResult_t ncclCeInitBatchOpsParams(struct ncclCeBatchOpsParams* params, int n
   params->sizes = nullptr;
   params->numOps = 0;
   params->intraBatchSync = false;
-#if ROCM_VERSION >= 71200
+#if CE_BATCH_API_SUPPORTED
   params->attrs = nullptr;
   params->attrIdxs = nullptr;
   params->numAttrs = 0;
@@ -293,7 +307,7 @@ ncclResult_t ncclCeInitBatchOpsParams(struct ncclCeBatchOpsParams* params, int n
   NCCLCHECKGOTO(ncclCalloc(&params->srcs, nRanks), ret, fail);
   NCCLCHECKGOTO(ncclCalloc(&params->dsts, nRanks), ret, fail);
   NCCLCHECKGOTO(ncclCalloc(&params->sizes, nRanks), ret, fail);
-#if ROCM_VERSION >= 71200
+#if CE_BATCH_API_SUPPORTED
   NCCLCHECKGOTO(ncclCalloc(&params->attrs, nRanks), ret, fail);
   NCCLCHECKGOTO(ncclCalloc(&params->attrIdxs, nRanks), ret, fail);
 #endif
@@ -307,7 +321,7 @@ void ncclCeFreeBatchOpsParams(struct ncclCeBatchOpsParams* params) {
   if (params->srcs) free(params->srcs);
   if (params->dsts) free(params->dsts);
   if (params->sizes) free(params->sizes);
-#if ROCM_VERSION >= 71200
+#if CE_BATCH_API_SUPPORTED
   if (params->attrs) free(params->attrs);
   if (params->attrIdxs) free(params->attrIdxs);
 #endif
@@ -315,6 +329,13 @@ void ncclCeFreeBatchOpsParams(struct ncclCeBatchOpsParams* params) {
 
 ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeBatchOpsParams* params, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
+
+#ifdef ENABLE_FAULT_INJECTION
+  if (comm->ceColl.ceFaults & CE_FAULT_LAUNCH_OP) {
+    WARN("CE: fault injection: ncclCeLaunchBatchOps returning ncclSystemError (rank %d)", comm->rank);
+    return ncclSystemError;
+  }
+#endif
 
   // Check if there are any operations to perform
   if (params->numOps == 0) {
@@ -345,13 +366,19 @@ ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeBatchOpsPa
   }
   //--------------No graph capture--------------
   else {
-    // driverVersion is reported as 71200000 for ROCm 7.12 when using hipDriverGetVersion().
-    if (ROCM_VERSION >= 71200 && driverVersion >= 71200000) {
-#if ROCM_VERSION >= 71200
-    // For ROCm 7.12+, use batch memory copy for better performance
+    // driverVersion is reported as ~71200000 for ROCm 7.12 and values in
+    // [70051831, 70060000) for ROCm 7.0.2.x backport builds.
+    if (CE_BATCH_API_SUPPORTED &&
+        (driverVersion >= 71200000 || (driverVersion >= 70051831 && driverVersion < 70060000))) {
+#if CE_BATCH_API_SUPPORTED
     params->attrs[0] = {};
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+    params->attrs[0].srcAccessOrder = hipMemcpySrcAccessOrderStream;
+    params->attrs[0].flags = hipMemcpyFlagPreferOverlapWithCompute;
+#else
     params->attrs[0].srcAccessOrder = cudaMemcpySrcAccessOrderStream;
     params->attrs[0].flags = cudaMemcpyFlagPreferOverlapWithCompute;
+#endif
     params->attrIdxs[0] = 0;
     params->numAttrs = 1;
 
@@ -360,8 +387,12 @@ ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeBatchOpsPa
       int batchSize = comm->ceColl.intraBatchSyncFreq;
       for (int i = 0; i < params->numOps; i += batchSize) {
         int currentBatchSize = (i + batchSize <= params->numOps) ? batchSize : params->numOps - i;
-        INFO(NCCL_COLL, "CE: rank %d -> Batch path with intraBatchSync (cudaMemcpyBatchAsync, intraBatchSync), numOps=%zu, batchSize=%d", comm->rank, params->numOps, currentBatchSize);
+        INFO(NCCL_COLL, "CE: rank %d -> Batch path with intraBatchSync (hipMemcpyBatchAsync, intraBatchSync), numOps=%zu, batchSize=%d", comm->rank, params->numOps, currentBatchSize);
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+        CUDACHECKGOTO(hipMemcpyBatchAsync(
+#else
         CUDACHECKGOTO(cudaMemcpyBatchAsync(
+#endif
           (void**)&params->dsts[i], (void**)&params->srcs[i], &params->sizes[i], currentBatchSize,
           params->attrs, params->attrIdxs, params->numAttrs, nullptr, stream), ret, fail);
         // Sync after each batch
@@ -371,8 +402,12 @@ ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeBatchOpsPa
       }
     } else {
       // Use single batch for all operations
-      INFO(NCCL_COLL, "CE: rank %d -> Batch path without intraBatchSync (cudaMemcpyBatchAsync), numOps=%zu", comm->rank, params->numOps);
+      INFO(NCCL_COLL, "CE: rank %d -> Batch path without intraBatchSync (hipMemcpyBatchAsync), numOps=%zu", comm->rank, params->numOps);
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+      CUDACHECKGOTO(hipMemcpyBatchAsync(
+#else
       CUDACHECKGOTO(cudaMemcpyBatchAsync(
+#endif
         (void**)params->dsts, (void**)params->srcs, params->sizes, params->numOps,
         params->attrs, params->attrIdxs, params->numAttrs, nullptr, stream), ret, fail);
     }

--- a/projects/rccl/src/include/ce_coll.h
+++ b/projects/rccl/src/include/ce_coll.h
@@ -16,6 +16,10 @@
 #define NCCL_CE_SYNC_OPS_PER_RANK_UC 3
 #define RCCL_CE_NUM_COPY_STREAMS 8
 
+// hipMemcpyBatchAsync is available in ROCm 7.12+ and was backported to 7.0.2.x.
+// ROCM_VERSION encodes as (MAJOR*10000 + MINOR*100 + PATCH), so 7.0.2 → 70002.
+#define CE_BATCH_API_SUPPORTED (ROCM_VERSION >= 71200 || ROCM_VERSION == 70002)
+
 struct ncclCeColl {
   uint8_t* baseUCSymReadyPtr;
   uint8_t* baseUCSymComplPtr;
@@ -29,6 +33,9 @@ struct ncclCeColl {
   int nCopyStreams;
   cudaStream_t copyStreams[RCCL_CE_NUM_COPY_STREAMS];
   cudaEvent_t copyEvents[RCCL_CE_NUM_COPY_STREAMS];
+#ifdef ENABLE_FAULT_INJECTION
+  uint32_t ceFaults;  // bitmask of CE_FAULT_* bits; see ce_fault_inject.h
+#endif
 };
 
 struct ncclCeInitTask {
@@ -53,8 +60,8 @@ struct ncclCeBatchOpsParams {
   size_t* sizes;
   size_t numOps;
   bool intraBatchSync;
-#if ROCM_VERSION >= 71200
-  cudaMemcpyAttributes* attrs;
+#if CE_BATCH_API_SUPPORTED
+  hipMemcpyAttributes* attrs;
   size_t* attrIdxs;
   size_t numAttrs;
 #endif

--- a/projects/rccl/src/include/ce_fault_inject.h
+++ b/projects/rccl/src/include/ce_fault_inject.h
@@ -1,0 +1,87 @@
+/*************************************************************************
+ * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+/**
+ * @file ce_fault_inject.h
+ * @brief Test-only fault injection API for CE (Copy-Engine) collectives.
+ *
+ * This header is compiled in only when ENABLE_FAULT_INJECTION is defined
+ * (test builds).  Production builds pay zero overhead.
+ *
+ * Usage pattern (mirrors net_ib_fault_inject.h):
+ *
+ *   // arm a fault before calling the code under test
+ *   ncclCeFaultSet(comm, CE_FAULT_LAUNCH_OP);
+ *   ncclResult_t r = ncclCeLaunchBatchOps(comm, &params, stream);
+ *   EXPECT_EQ(r, ncclSystemError);
+ *   ncclCeFaultClear(comm);
+ *
+ *   // verify normal operation resumes
+ *   r = ncclCeLaunchBatchOps(comm, &params, stream);
+ *   EXPECT_EQ(r, ncclSuccess);
+ */
+
+#ifndef NCCL_CE_FAULT_INJECT_H_
+#define NCCL_CE_FAULT_INJECT_H_
+
+#ifdef ENABLE_FAULT_INJECTION
+
+#include "nccl.h"
+
+// ---------------------------------------------------------------------------
+// Fault bits – OR them together when arming multiple faults at once.
+// ---------------------------------------------------------------------------
+
+/** Force ncclCeInit() to return ncclSystemError. */
+#define CE_FAULT_INIT        0x01U
+
+/** Force ncclPrepUCSync() to return ncclSystemError. */
+#define CE_FAULT_SYNC_PREP   0x02U
+
+/** Force ncclCeLaunchBatchOps() to return ncclSystemError. */
+#define CE_FAULT_LAUNCH_OP   0x04U
+
+// ---------------------------------------------------------------------------
+// Public API (implemented as inline helpers that touch comm->ceColl.ceFaults)
+// ---------------------------------------------------------------------------
+
+struct ncclComm;
+
+/** Arm one or more fault bits on @p comm. */
+static inline ncclResult_t ncclCeFaultSet(struct ncclComm* comm, uint32_t bits);
+
+/** Clear all CE fault bits on @p comm. */
+static inline ncclResult_t ncclCeFaultClear(struct ncclComm* comm);
+
+/** Return the current fault bitmask on @p comm. */
+static inline uint32_t ncclCeFaultGet(struct ncclComm* comm);
+
+// ---------------------------------------------------------------------------
+// Inline implementations – included only here so callers need not link
+// against a separate translation unit.
+// ---------------------------------------------------------------------------
+
+#include "comm.h"   // ncclComm definition
+
+static inline ncclResult_t ncclCeFaultSet(struct ncclComm* comm, uint32_t bits) {
+  if (comm == nullptr) return ncclInvalidArgument;
+  comm->ceColl.ceFaults |= bits;
+  return ncclSuccess;
+}
+
+static inline ncclResult_t ncclCeFaultClear(struct ncclComm* comm) {
+  if (comm == nullptr) return ncclInvalidArgument;
+  comm->ceColl.ceFaults = 0;
+  return ncclSuccess;
+}
+
+static inline uint32_t ncclCeFaultGet(struct ncclComm* comm) {
+  if (comm == nullptr) return 0;
+  return comm->ceColl.ceFaults;
+}
+
+#endif /* ENABLE_FAULT_INJECTION */
+#endif /* NCCL_CE_FAULT_INJECT_H_ */

--- a/projects/rccl/src/include/ce_fault_inject.h
+++ b/projects/rccl/src/include/ce_fault_inject.h
@@ -45,26 +45,12 @@
 #define CE_FAULT_LAUNCH_OP   0x04U
 
 // ---------------------------------------------------------------------------
-// Public API (implemented as inline helpers that touch comm->ceColl.ceFaults)
+// Inline implementations – ncclComm is defined in comm.h, ncclResult_t in nccl.h.
+// All three functions are defined here so callers need not link against a
+// separate translation unit.
 // ---------------------------------------------------------------------------
 
-struct ncclComm;
-
-/** Arm one or more fault bits on @p comm. */
-static inline ncclResult_t ncclCeFaultSet(struct ncclComm* comm, uint32_t bits);
-
-/** Clear all CE fault bits on @p comm. */
-static inline ncclResult_t ncclCeFaultClear(struct ncclComm* comm);
-
-/** Return the current fault bitmask on @p comm. */
-static inline uint32_t ncclCeFaultGet(struct ncclComm* comm);
-
-// ---------------------------------------------------------------------------
-// Inline implementations – included only here so callers need not link
-// against a separate translation unit.
-// ---------------------------------------------------------------------------
-
-#include "comm.h"   // ncclComm definition
+#include "comm.h"   // ncclComm definition (transitively includes nccl.h)
 
 static inline ncclResult_t ncclCeFaultSet(struct ncclComm* comm, uint32_t bits) {
   if (comm == nullptr) return ncclInvalidArgument;

--- a/projects/rccl/src/misc/rocmwrap.cc
+++ b/projects/rccl/src/misc/rocmwrap.cc
@@ -97,8 +97,14 @@ error:
 }
 
 int ncclCuMemEnable() {
+#if HIP_VERSION < 71260540
+  if (ncclParamCuMemEnable() > 0)
+    WARN("NCCL_CUMEM_ENABLE=1 is set but cuMem VMM APIs require ROCm 7.0 or later (HIP_VERSION=%d); disabling cuMem", HIP_VERSION);
+  return 0;
+#else
   int param = ncclParamCuMemEnable();
   return param >= 0 ? param : (param == -2 && ncclCuMemSupported);
+#endif
 }
 
 static int ncclCumemHostEnable = -1;

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -303,6 +303,8 @@ if(BUILD_TESTS)
       RegistrationMPITests.cpp
       mem_manager/SuspendResumeMPITests.cpp
       RevokeMPITests.cpp
+      ce/CeMPITests.cpp
+      ce/CeInternalMPITests.cpp
     )
 
     add_executable(rccl-UnitTestsMPI ${MPI_TEST_SOURCE_FILES})

--- a/projects/rccl/test/ce/CeInternalMPITests.cpp
+++ b/projects/rccl/test/ce/CeInternalMPITests.cpp
@@ -10,6 +10,7 @@
 #include "CeTestHelpers.hpp"
 #include "DeviceBufferHelpers.hpp"
 #include "MPITestBase.hpp"
+#include "ResourceGuards.hpp"
 #include "SymmetricBufferHelpers.hpp"
 #include "rccl/rccl.h"
 
@@ -158,6 +159,7 @@ TEST_F(CeInternalMPITest, IndependentCeStatePerComm)
     ncclComm_t comm2 = nullptr;
     ASSERT_EQ(ncclSuccess,
               ncclCommInitRank(&comm2, nRanks, uid, ceComm->rank));
+    RCCLTestGuards::NcclCommAutoGuard comm2Guard(comm2);
 
     auto* ceComm2 = static_cast<ncclComm*>(comm2);
 
@@ -172,13 +174,15 @@ TEST_F(CeInternalMPITest, IndependentCeStatePerComm)
     ASSERT_EQ(ncclSuccess,
               ncclAllGather(s2.ptr, r2.ptr, kElem, ncclFloat32, comm2,
                             getActiveStream()));
+    // hipStreamSynchronize has no timeout; a CE hang here means CE dispatch failed.
+    // The test runner's --timeout option provides the external deadline.
     ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
 
+    // White-box check: baseUCSymReadyPtr is set by ncclCeInit and is the most direct
+    // indicator that CE initialized on comm2.  Log-based detection would require
+    // capturing per-rank stderr across MPI processes, which is unavailable here.
     if(ceComm2->ceColl.baseUCSymReadyPtr == nullptr)
-    {
-        ncclCommDestroy(comm2);
         GTEST_SKIP() << "CE not available on comm2";
-    }
 
     EXPECT_NE(ceComm->ceColl.baseUCSymReadyPtr,
               ceComm2->ceColl.baseUCSymReadyPtr)
@@ -188,7 +192,10 @@ TEST_F(CeInternalMPITest, IndependentCeStatePerComm)
 
     const uint32_t seqBefore = ceComm->ceColl.ceSeqNum;
 
-    for(int i = 0; i < 3; ++i)
+    // Run 3 collectives on comm2 to advance its CE sequence number by several steps;
+    // any count > 1 is sufficient to detect a ceSeqNum cross-contamination into comm1.
+    constexpr int kAdvanceIters = 3;
+    for(int i = 0; i < kAdvanceIters; ++i)
     {
         ASSERT_EQ(ncclSuccess,
                   ncclAllGather(s2.ptr, r2.ptr, kElem, ncclFloat32, comm2,
@@ -223,8 +230,7 @@ TEST_F(CeInternalMPITest, IndependentCeStatePerComm)
                     0, 1e-5, &errIdx, &errExp, &errAct))
         << "Data corruption in comm1 AllGather after comm2 state was advanced"
         << " at idx=" << errIdx << " expected=" << errExp << " got=" << errAct;
-
-    ncclCommDestroy(comm2);
+    // comm2Guard auto-destroys comm2 on scope exit.
 }
 
 // INIT-05: ncclCeFinalize with no further collectives after SetUp warmup must succeed and zero pointers.
@@ -365,27 +371,35 @@ TEST_F(CeInternalMPITest, LaunchEmptyBatchSucceeds)
 //            succeeds and the data is correctly transferred.
 TEST_F(CeInternalMPITest, LaunchFourOpsSucceeds)
 {
+    using namespace RCCLTestGuards;
     constexpr int    kOps   = 4;
     constexpr size_t kBytes = kOps * sizeof(float); // allocation size per src/dst buffer
 
-    std::vector<float*> src(kOps, nullptr), dst(kOps, nullptr);
+    // DeviceBufferAutoGuard ensures hipFree is called on all paths, including early ASSERT exits.
+    std::vector<DeviceBufferAutoGuard> srcGuards(kOps), dstGuards(kOps);
     for(int i = 0; i < kOps; ++i)
     {
-        ASSERT_EQ(hipMalloc(&src[i], kBytes), hipSuccess);
-        ASSERT_EQ(hipMalloc(&dst[i], kBytes), hipSuccess);
+        void* p = nullptr;
+        ASSERT_EQ(hipMalloc(&p, kBytes), hipSuccess);
+        srcGuards[i].set(p);
+        p = nullptr;
+        ASSERT_EQ(hipMalloc(&p, kBytes), hipSuccess);
+        dstGuards[i].set(p);
+
         float pattern = static_cast<float>(i + 1);
-        ASSERT_EQ(hipMemset(src[i], 0, kBytes), hipSuccess);
-        ASSERT_EQ(hipMemcpy(src[i], &pattern, sizeof(float), hipMemcpyHostToDevice),
+        ASSERT_EQ(hipMemset(srcGuards[i].get(), 0, kBytes), hipSuccess);
+        ASSERT_EQ(hipMemcpy(srcGuards[i].get(), &pattern, sizeof(float), hipMemcpyHostToDevice),
                   hipSuccess);
     }
 
     ncclCeBatchOpsParams params{};
     ASSERT_EQ(ncclCeInitBatchOpsParams(&params, kOps), ncclSuccess);
+    SCOPE_EXIT(ncclCeFreeBatchOpsParams(&params));
 
     for(int i = 0; i < kOps; ++i)
     {
-        params.srcs[i] = src[i];
-        params.dsts[i] = dst[i];
+        params.srcs[i]  = static_cast<float*>(srcGuards[i].get());
+        params.dsts[i]  = static_cast<float*>(dstGuards[i].get());
         params.sizes[i] = sizeof(float);
     }
     params.numOps = kOps;
@@ -396,16 +410,11 @@ TEST_F(CeInternalMPITest, LaunchFourOpsSucceeds)
     for(int i = 0; i < kOps; ++i)
     {
         float result = 0.0f;
-        ASSERT_EQ(hipMemcpy(&result, dst[i], sizeof(float), hipMemcpyDeviceToHost), hipSuccess);
+        ASSERT_EQ(hipMemcpy(&result, dstGuards[i].get(), sizeof(float), hipMemcpyDeviceToHost),
+                  hipSuccess);
         EXPECT_FLOAT_EQ(result, static_cast<float>(i + 1)) << "op " << i;
     }
-
-    ncclCeFreeBatchOpsParams(&params);
-    for(int i = 0; i < kOps; ++i)
-    {
-        hipFree(src[i]);
-        hipFree(dst[i]);
-    }
+    // srcGuards, dstGuards, and params freed automatically on scope exit.
 }
 
 // ===========================================================================
@@ -477,20 +486,27 @@ TEST_F(CeFaultInjTest, SyncPrepErrorPropagates)
 //           After clearing, the same call must succeed.
 TEST_F(CeFaultInjTest, LaunchBatchOpsErrorPropagates)
 {
-    constexpr int   kOps  = 2;
+    using namespace RCCLTestGuards;
+    constexpr int    kOps  = 2;
     constexpr size_t kBytes = sizeof(float);
 
-    float* src = nullptr;
-    float* dst = nullptr;
-    ASSERT_EQ(hipMalloc(&src, kBytes), hipSuccess);
-    ASSERT_EQ(hipMalloc(&dst, kBytes), hipSuccess);
+    // DeviceBufferAutoGuard ensures hipFree is called on all paths, including early ASSERT exits.
+    void* srcPtr = nullptr;
+    ASSERT_EQ(hipMalloc(&srcPtr, kBytes), hipSuccess);
+    DeviceBufferAutoGuard srcGuard(srcPtr);
+
+    void* dstPtr = nullptr;
+    ASSERT_EQ(hipMalloc(&dstPtr, kBytes), hipSuccess);
+    DeviceBufferAutoGuard dstGuard(dstPtr);
 
     ncclCeBatchOpsParams params{};
     ASSERT_EQ(ncclCeInitBatchOpsParams(&params, kOps), ncclSuccess);
+    SCOPE_EXIT(ncclCeFreeBatchOpsParams(&params));
+
     for(int i = 0; i < kOps; ++i)
     {
-        params.srcs[i]  = src;
-        params.dsts[i]  = dst;
+        params.srcs[i]  = static_cast<float*>(srcPtr);
+        params.dsts[i]  = static_cast<float*>(dstPtr);
         params.sizes[i] = kBytes;
     }
     params.numOps = kOps;
@@ -505,10 +521,7 @@ TEST_F(CeFaultInjTest, LaunchBatchOpsErrorPropagates)
               ncclSuccess)
         << "Expected ncclSuccess after fault cleared";
     EXPECT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
-
-    ncclCeFreeBatchOpsParams(&params);
-    hipFree(src);
-    hipFree(dst);
+    // srcGuard, dstGuard, and params freed automatically on scope exit.
 }
 
 // FAULT-03: CE_FAULT_INIT makes ncclCeInit return ncclSystemError and leaves

--- a/projects/rccl/test/ce/CeInternalMPITests.cpp
+++ b/projects/rccl/test/ce/CeInternalMPITests.cpp
@@ -301,6 +301,10 @@ TEST_F(CeInternalMPITest, PrepUCSyncNoSelfTargetedOp)
 
     auto [batch, opIdx] = callPrepUCSync();
 
+    // baseUCSymReadyPtr points into a VMM-backed symmetric (host-accessible)
+    // allocation created by ncclCeInit via ncclSymBufAlloc.  Address arithmetic
+    // on the host-side pointer is valid for comparison with batch op addresses,
+    // which are also expressed as host-visible hipDeviceptr_t values.
     uint32_t*      readyPtrs = reinterpret_cast<uint32_t*>(ceComm->ceColl.baseUCSymReadyPtr);
     hipDeviceptr_t selfReady = reinterpret_cast<hipDeviceptr_t>(&readyPtrs[rank]);
     int selfTargets = 0;
@@ -320,8 +324,10 @@ TEST_F(CeInternalMPITest, SeqNumWrap)
     requireMinRanks(2);
     ceComm->ceColl.ceSeqNum = UINT32_MAX - 1;
 
-    { auto [b, i] = callPrepUCSync(); EXPECT_EQ(ceComm->ceColl.ceSeqNum, UINT32_MAX); }
-    { auto [b, i] = callPrepUCSync(); EXPECT_EQ(ceComm->ceColl.ceSeqNum, 0u) << "wrap from UINT32_MAX to 0"; }
+    callPrepUCSync();
+    EXPECT_EQ(ceComm->ceColl.ceSeqNum, UINT32_MAX);
+    callPrepUCSync();
+    EXPECT_EQ(ceComm->ceColl.ceSeqNum, 0u) << "wrap from UINT32_MAX to 0";
 }
 
 // SYNC-05: ceSeqNum wraps correctly through the full AllGather dispatch path (not only PrepUCSync).

--- a/projects/rccl/test/ce/CeInternalMPITests.cpp
+++ b/projects/rccl/test/ce/CeInternalMPITests.cpp
@@ -43,6 +43,12 @@ class CeInternalMPITest : public MPITestBase
 protected:
     ncclComm* ceComm = nullptr;
 
+    // RAII guards: set NCCL_DEBUG=INFO and NCCL_DEBUG_SUBSYS=ALL before communicator
+    // creation so that CE init/dispatch log lines are always available for diagnostics,
+    // regardless of the external environment.  Mirrors the pattern in CeMPITest.
+    std::unique_ptr<MPIHelpers::MpiEnvGuard> debugGuard_;
+    std::unique_ptr<MPIHelpers::MpiEnvGuard> debugSubsysGuard_;
+
     void SetUp() override
     {
         MPITestBase::SetUp();
@@ -50,6 +56,10 @@ protected:
         if(!isCeDispatchConfigured())
             GTEST_SKIP() << "CE requires ROCm >= 7.12 or 7.0.2.x, "
                             "NCCL_CTA_POLICY=2, NCCL_LOCAL_REGISTER=0, NCCL_CUMEM_ENABLE=1";
+
+        // Set debug env vars before ncclCommInitRank so the communicator picks them up.
+        debugGuard_       = std::make_unique<MPIHelpers::MpiEnvGuard>("NCCL_DEBUG",        "INFO");
+        debugSubsysGuard_ = std::make_unique<MPIHelpers::MpiEnvGuard>("NCCL_DEBUG_SUBSYS", "ALL");
 
         ASSERT_EQ(createTestCommunicator(), ncclSuccess)
             << "ncclCommInitRank failed";
@@ -73,6 +83,8 @@ protected:
                   ncclSuccess);
         ASSERT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
 
+        // White-box check: baseUCSymReadyPtr is ncclCeInit's primary output — it is
+        // the definition of "CE initialized".
         if(ceComm->ceColl.baseUCSymReadyPtr == nullptr)
             GTEST_SKIP() << "CE not available on this system (ncclCeInit was not triggered)";
     }
@@ -80,7 +92,11 @@ protected:
     void TearDown() override
     {
         ceComm = nullptr;
+        // Destroy communicator before releasing the debug guards so any final
+        // NCCL log lines from comm teardown still go to the debug output.
         MPITestBase::TearDown();
+        debugSubsysGuard_.reset();
+        debugGuard_.reset();
     }
 
     // Batch buffer for ncclPrepUCSync: capacity = NCCL_CE_SYNC_OPS_PER_RANK_UC * nRanks.
@@ -178,9 +194,8 @@ TEST_F(CeInternalMPITest, IndependentCeStatePerComm)
     // The test runner's --timeout option provides the external deadline.
     ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
 
-    // White-box check: baseUCSymReadyPtr is set by ncclCeInit and is the most direct
-    // indicator that CE initialized on comm2.  Log-based detection would require
-    // capturing per-rank stderr across MPI processes, which is unavailable here.
+    // White-box check: baseUCSymReadyPtr is ncclCeInit's primary output — it is
+    // the definition of "CE initialized on this comm".
     if(ceComm2->ceColl.baseUCSymReadyPtr == nullptr)
         GTEST_SKIP() << "CE not available on comm2";
 

--- a/projects/rccl/test/ce/CeInternalMPITests.cpp
+++ b/projects/rccl/test/ce/CeInternalMPITests.cpp
@@ -1,0 +1,564 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// White-box tests for CE internal functions (ncclCeInit, ncclPrepUCSync,
+// ncclCeLaunchBatchOps, ncclCeImplemented). Requires Debug build.
+
+#include "CeTestHelpers.hpp"
+#include "DeviceBufferHelpers.hpp"
+#include "MPITestBase.hpp"
+#include "SymmetricBufferHelpers.hpp"
+#include "rccl/rccl.h"
+
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <comm.h>
+#include <ce_coll.h>
+
+#include <cstdint>
+#include <vector>
+
+#ifdef MPI_TESTS_ENABLED
+
+using namespace MPITestConstants;
+
+// Internal CE helpers not in ce_coll.h; accessible in Debug builds (-fvisibility=hidden not applied).
+ncclResult_t ncclPrepUCSync(struct ncclComm* comm, bool isComplete,
+                            hipStreamBatchMemOpParams* batchParams,
+                            size_t* opIdx);
+
+ncclResult_t ncclCeInitBatchOpsParams(struct ncclCeBatchOpsParams* params, int nRanks);
+void         ncclCeFreeBatchOpsParams(struct ncclCeBatchOpsParams* params);
+ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm,
+                                  struct ncclCeBatchOpsParams* params,
+                                  hipStream_t stream);
+
+// Fixture: skip if no CE driver; create comm; warmup AllGather → ncclCeInit; TearDown destroys comm.
+class CeInternalMPITest : public MPITestBase
+{
+protected:
+    ncclComm* ceComm = nullptr;
+
+    void SetUp() override
+    {
+        MPITestBase::SetUp();
+
+        if(!isCeDispatchConfigured())
+            GTEST_SKIP() << "CE requires ROCm >= 7.12 or 7.0.2.x, "
+                            "NCCL_CTA_POLICY=2, NCCL_LOCAL_REGISTER=0, NCCL_CUMEM_ENABLE=1";
+
+        ASSERT_EQ(createTestCommunicator(), ncclSuccess)
+            << "ncclCommInitRank failed";
+
+        ceComm = static_cast<ncclComm*>(getActiveCommunicator());
+        ASSERT_NE(ceComm, nullptr);
+
+        // Warmup AllGather triggers ncclCeInit via group.cc (NCCL_CTA_POLICY=2).
+        // SymBuf (VMM-backed) satisfies ncclDevrFindWindow for ceCollTaskAppend.
+        constexpr size_t kElem = 4;
+        RCCLTestHelpers::SymBuf sendSym, recvSym;
+        ASSERT_EQ(RCCLTestHelpers::ncclSymBufAlloc(
+                      getActiveCommunicator(), kElem * sizeof(float), sendSym),
+                  ncclSuccess) << "ncclSymBufAlloc for sendBuf failed (cuMem enabled?)";
+        ASSERT_EQ(RCCLTestHelpers::ncclSymBufAlloc(
+                      getActiveCommunicator(), kElem * ceComm->nRanks * sizeof(float), recvSym),
+                  ncclSuccess) << "ncclSymBufAlloc for recvBuf failed";
+
+        ASSERT_EQ(ncclAllGather(sendSym.ptr, recvSym.ptr, kElem, ncclFloat32,
+                                getActiveCommunicator(), getActiveStream()),
+                  ncclSuccess);
+        ASSERT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
+
+        if(ceComm->ceColl.baseUCSymReadyPtr == nullptr)
+            GTEST_SKIP() << "CE not available on this system (ncclCeInit was not triggered)";
+    }
+
+    void TearDown() override
+    {
+        ceComm = nullptr;
+        MPITestBase::TearDown();
+    }
+
+    // Batch buffer for ncclPrepUCSync: capacity = NCCL_CE_SYNC_OPS_PER_RANK_UC * nRanks.
+    std::vector<hipStreamBatchMemOpParams> makePrepSyncBatch() const
+    {
+        size_t batchSize = NCCL_CE_SYNC_OPS_PER_RANK_UC * ceComm->nRanks;
+        return std::vector<hipStreamBatchMemOpParams>(batchSize);
+    }
+
+    // Skip if fewer than n ranks.
+    void requireMinRanks(int n)
+    {
+        if(ceComm->nRanks < n)
+            GTEST_SKIP() << "Need >= " << n << " MPI ranks";
+    }
+
+    // Allocate a batch, call ncclPrepUCSync once, and return both for inspection.
+    struct PrepSyncResult
+    {
+        std::vector<hipStreamBatchMemOpParams> batch;
+        size_t opIdx = 0;
+    };
+
+    PrepSyncResult callPrepUCSync(bool isComplete = false)
+    {
+        PrepSyncResult res;
+        res.batch = makePrepSyncBatch();
+        EXPECT_EQ(ncclPrepUCSync(ceComm, isComplete, res.batch.data(), &res.opIdx),
+                  ncclSuccess);
+        return res;
+    }
+};
+
+// ===========================================================================
+// CeInternal_Init – CE init / finalize lifecycle
+// ===========================================================================
+
+// INIT-01: After ncclCeInit, the sync-window pointers are non-null.
+TEST_F(CeInternalMPITest, InitSetsWindowPointers)
+{
+    EXPECT_NE(ceComm->ceColl.baseUCSymReadyPtr, nullptr);
+    EXPECT_NE(ceComm->ceColl.baseUCSymComplPtr, nullptr);
+    EXPECT_NE(ceComm->ceColl.ceSyncWin, nullptr);
+}
+
+// INIT-02: ncclCeFinalize sets sync-window pointers back to null.
+TEST_F(CeInternalMPITest, FiniNullsPointers)
+{
+    ASSERT_NE(ceComm->ceColl.baseUCSymReadyPtr, nullptr);
+    ASSERT_EQ(ncclCeFinalize(ceComm), ncclSuccess);
+    EXPECT_EQ(ceComm->ceColl.baseUCSymReadyPtr, nullptr);
+    EXPECT_EQ(ceComm->ceColl.baseUCSymComplPtr, nullptr);
+    EXPECT_EQ(ceComm->ceColl.ceSyncWin, nullptr);
+}
+
+// INIT-03: Calling ncclCeFinalize twice is safe (idempotent).
+TEST_F(CeInternalMPITest, DoubleFiniIsSafe)
+{
+    EXPECT_EQ(ncclCeFinalize(ceComm), ncclSuccess);
+    EXPECT_EQ(ncclCeFinalize(ceComm), ncclSuccess);
+    EXPECT_EQ(ceComm->ceColl.baseUCSymReadyPtr, nullptr);
+}
+
+// INIT-04: Two comms have independent CE state; advancing one must not affect the other.
+TEST_F(CeInternalMPITest, IndependentCeStatePerComm)
+{
+    requireMinRanks(2);
+    const int nRanks = ceComm->nRanks;
+
+    // Create a second communicator spanning the same ranks.
+    ncclUniqueId uid{};
+    if(ceComm->rank == 0)
+        ASSERT_EQ(ncclSuccess, ncclGetUniqueId(&uid));
+    MPI_Bcast(&uid, sizeof(uid), MPI_BYTE, 0, MPI_COMM_WORLD);
+
+    ncclComm_t comm2 = nullptr;
+    ASSERT_EQ(ncclSuccess,
+              ncclCommInitRank(&comm2, nRanks, uid, ceComm->rank));
+
+    auto* ceComm2 = static_cast<ncclComm*>(comm2);
+
+    // Trigger CE init on comm2 via a warmup AllGather.
+    constexpr size_t kElem = 4;
+    RCCLTestHelpers::SymBuf s2, r2;
+    ASSERT_EQ(ncclSuccess,
+              RCCLTestHelpers::ncclSymBufAlloc(comm2, kElem * sizeof(float), s2));
+    ASSERT_EQ(ncclSuccess,
+              RCCLTestHelpers::ncclSymBufAlloc(
+                  comm2, kElem * static_cast<size_t>(nRanks) * sizeof(float), r2));
+    ASSERT_EQ(ncclSuccess,
+              ncclAllGather(s2.ptr, r2.ptr, kElem, ncclFloat32, comm2,
+                            getActiveStream()));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+    if(ceComm2->ceColl.baseUCSymReadyPtr == nullptr)
+    {
+        ncclCommDestroy(comm2);
+        GTEST_SKIP() << "CE not available on comm2";
+    }
+
+    EXPECT_NE(ceComm->ceColl.baseUCSymReadyPtr,
+              ceComm2->ceColl.baseUCSymReadyPtr)
+        << "Both comms share the same ready-pointer allocation (CE state not isolated)";
+    EXPECT_NE(ceComm->ceColl.ceSyncWin, ceComm2->ceColl.ceSyncWin)
+        << "Both comms share the same sync window";
+
+    const uint32_t seqBefore = ceComm->ceColl.ceSeqNum;
+
+    for(int i = 0; i < 3; ++i)
+    {
+        ASSERT_EQ(ncclSuccess,
+                  ncclAllGather(s2.ptr, r2.ptr, kElem, ncclFloat32, comm2,
+                                getActiveStream()));
+        ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+    }
+
+    EXPECT_EQ(seqBefore, ceComm->ceColl.ceSeqNum)
+        << "Advancing comm2's CE state leaked into comm1";
+
+    RCCLTestHelpers::SymBuf s1, r1;
+    ASSERT_EQ(ncclSuccess,
+              RCCLTestHelpers::ncclSymBufAlloc(
+                  getActiveCommunicator(), kElem * sizeof(float), s1));
+    ASSERT_EQ(ncclSuccess,
+              RCCLTestHelpers::ncclSymBufAlloc(
+                  getActiveCommunicator(),
+                  kElem * static_cast<size_t>(nRanks) * sizeof(float), r1));
+
+    const int rank = ceComm->rank;
+    ASSERT_EQ(hipSuccess, ceFillRankScalarFloat(s1.ptr, kElem, rank));
+
+    ASSERT_EQ(ncclSuccess,
+              ncclAllGather(s1.ptr, r1.ptr, kElem, ncclFloat32,
+                            getActiveCommunicator(), getActiveStream()));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+    size_t errIdx; float errExp, errAct;
+    EXPECT_TRUE(RCCLTestHelpers::verifyBufferData<float>(
+                    r1.ptr, kElem * nRanks,
+                    [kElem](size_t i) { return static_cast<float>(i / kElem + 1); },
+                    0, 1e-5, &errIdx, &errExp, &errAct))
+        << "Data corruption in comm1 AllGather after comm2 state was advanced"
+        << " at idx=" << errIdx << " expected=" << errExp << " got=" << errAct;
+
+    ncclCommDestroy(comm2);
+}
+
+// INIT-05: ncclCeFinalize with no further collectives after SetUp warmup must succeed and zero pointers.
+TEST_F(CeInternalMPITest, FiniAfterZeroCollectives)
+{
+    ASSERT_NE(ceComm->ceColl.baseUCSymReadyPtr, nullptr)
+        << "Precondition: CE must be initialized by fixture SetUp";
+
+    EXPECT_EQ(ncclCeFinalize(ceComm), ncclSuccess)
+        << "ncclCeFinalize should succeed with no collectives outstanding";
+
+    EXPECT_EQ(ceComm->ceColl.baseUCSymReadyPtr, nullptr);
+    EXPECT_EQ(ceComm->ceColl.baseUCSymComplPtr, nullptr);
+    EXPECT_EQ(ceComm->ceColl.ceSyncWin,         nullptr);
+}
+
+// ===========================================================================
+// CeInternal_Sync – ncclPrepUCSync op-count and self-target checks
+// ===========================================================================
+
+// SYNC-01: ncclPrepUCSync increments ceSeqNum on each call.
+TEST_F(CeInternalMPITest, PrepUCSyncIncrementsCeSeqNum)
+{
+    constexpr int kCallCount = 10; // number of ncclPrepUCSync calls to verify monotonic increment
+    auto batch = makePrepSyncBatch();
+    uint32_t initialSeq = ceComm->ceColl.ceSeqNum;
+    for(int n = 1; n <= kCallCount; ++n)
+    {
+        size_t opIdx = 0;
+        ASSERT_EQ(ncclPrepUCSync(ceComm, false, batch.data(), &opIdx), ncclSuccess)
+            << "call " << n;
+        EXPECT_EQ(ceComm->ceColl.ceSeqNum, initialSeq + static_cast<uint32_t>(n))
+            << "ceSeqNum should increment by 1 per call, call " << n << "/" << kCallCount;
+    }
+}
+
+// SYNC-02: ncclPrepUCSync produces exactly 2*(nRanks-1) ops (one WRITE +
+//          one WAIT per remote rank).
+TEST_F(CeInternalMPITest, PrepUCSyncOpCount)
+{
+    requireMinRanks(2);
+    const int nRanks = ceComm->nRanks;
+    auto [batch, opIdx] = callPrepUCSync();
+    EXPECT_EQ(opIdx, static_cast<size_t>(2 * (nRanks - 1)))
+        << "expected 2*(nRanks-1) ops for nRanks=" << nRanks;
+}
+
+// SYNC-03: No WRITE_VALUE op targets the local rank's own ready slot.
+TEST_F(CeInternalMPITest, PrepUCSyncNoSelfTargetedOp)
+{
+    requireMinRanks(2);
+    const int rank = ceComm->rank;
+
+    auto [batch, opIdx] = callPrepUCSync();
+
+    uint32_t*      readyPtrs = reinterpret_cast<uint32_t*>(ceComm->ceColl.baseUCSymReadyPtr);
+    hipDeviceptr_t selfReady = reinterpret_cast<hipDeviceptr_t>(&readyPtrs[rank]);
+    int selfTargets = 0;
+    for(size_t i = 0; i < opIdx; ++i)
+    {
+        if(batch[i].operation == hipStreamMemOpWriteValue32 &&
+           batch[i].writeValue.address == selfReady)
+            ++selfTargets;
+    }
+    EXPECT_EQ(selfTargets, 0)
+        << "A WRITE_VALUE op targeted rank " << rank << "'s own ready slot";
+}
+
+// SYNC-04: ceSeqNum wraps correctly from UINT32_MAX → 0.
+TEST_F(CeInternalMPITest, SeqNumWrap)
+{
+    requireMinRanks(2);
+    ceComm->ceColl.ceSeqNum = UINT32_MAX - 1;
+
+    { auto [b, i] = callPrepUCSync(); EXPECT_EQ(ceComm->ceColl.ceSeqNum, UINT32_MAX); }
+    { auto [b, i] = callPrepUCSync(); EXPECT_EQ(ceComm->ceColl.ceSeqNum, 0u) << "wrap from UINT32_MAX to 0"; }
+}
+
+// SYNC-05: ceSeqNum wraps correctly through the full AllGather dispatch path (not only PrepUCSync).
+TEST_F(CeInternalMPITest, SeqNumWrapAroundCollective)
+{
+    requireMinRanks(2);
+    const int nRanks = ceComm->nRanks;
+
+    constexpr size_t kCount = 256;
+
+    RCCLTestHelpers::SymBuf sendSym, recvSym;
+    ASSERT_EQ(ncclSuccess,
+              RCCLTestHelpers::ncclSymBufAlloc(
+                  getActiveCommunicator(), kCount * sizeof(float), sendSym));
+    ASSERT_EQ(ncclSuccess,
+              RCCLTestHelpers::ncclSymBufAlloc(
+                  getActiveCommunicator(),
+                  kCount * static_cast<size_t>(nRanks) * sizeof(float), recvSym));
+
+    const int rank = ceComm->rank;
+    ASSERT_EQ(hipSuccess, ceFillRankScalarFloat(sendSym.ptr, kCount, rank));
+
+    ceComm->ceColl.ceSeqNum = UINT32_MAX - 1;
+
+    constexpr int kWrapIters = 2; // iter 0: seqNum wraps to UINT32_MAX; iter 1: wraps to 0
+    for(int iter = 0; iter < kWrapIters; ++iter)
+    {
+        ASSERT_EQ(ncclSuccess,
+                  ncclAllGather(sendSym.ptr, recvSym.ptr, kCount, ncclFloat32,
+                                getActiveCommunicator(), getActiveStream()))
+            << "ncclAllGather failed at wrap iteration " << iter;
+        ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()))
+            << "hipStreamSynchronize failed at wrap iteration " << iter;
+
+        // Verify block pattern: recvbuf[r*kCount + i] == float(r+1).
+        size_t errIdx; float errExp, errAct;
+        if(!RCCLTestHelpers::verifyBufferData<float>(
+               recvSym.ptr, kCount * nRanks,
+               [kCount](size_t i) { return static_cast<float>(i / kCount + 1); },
+               0, 1e-5, &errIdx, &errExp, &errAct))
+        {
+            ADD_FAILURE() << "Data corruption at wrap iter=" << iter
+                          << " idx=" << errIdx
+                          << " expected=" << errExp << " got=" << errAct;
+        }
+    }
+}
+
+// ===========================================================================
+// CeInternal_Launch – ncclCeLaunchBatchOps with zero and real ops
+// ===========================================================================
+
+// LAUNCH-01: Launching an empty batch (numOps == 0) succeeds.
+TEST_F(CeInternalMPITest, LaunchEmptyBatchSucceeds)
+{
+    ncclCeBatchOpsParams params{};
+    EXPECT_EQ(ncclCeLaunchBatchOps(ceComm, &params, getActiveStream()), ncclSuccess);
+    EXPECT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
+}
+
+// LAUNCH-02: Launching 4 device-to-device copy ops via ncclCeLaunchBatchOps
+//            succeeds and the data is correctly transferred.
+TEST_F(CeInternalMPITest, LaunchFourOpsSucceeds)
+{
+    constexpr int    kOps   = 4;
+    constexpr size_t kBytes = kOps * sizeof(float); // allocation size per src/dst buffer
+
+    std::vector<float*> src(kOps, nullptr), dst(kOps, nullptr);
+    for(int i = 0; i < kOps; ++i)
+    {
+        ASSERT_EQ(hipMalloc(&src[i], kBytes), hipSuccess);
+        ASSERT_EQ(hipMalloc(&dst[i], kBytes), hipSuccess);
+        float pattern = static_cast<float>(i + 1);
+        ASSERT_EQ(hipMemset(src[i], 0, kBytes), hipSuccess);
+        ASSERT_EQ(hipMemcpy(src[i], &pattern, sizeof(float), hipMemcpyHostToDevice),
+                  hipSuccess);
+    }
+
+    ncclCeBatchOpsParams params{};
+    ASSERT_EQ(ncclCeInitBatchOpsParams(&params, kOps), ncclSuccess);
+
+    for(int i = 0; i < kOps; ++i)
+    {
+        params.srcs[i] = src[i];
+        params.dsts[i] = dst[i];
+        params.sizes[i] = sizeof(float);
+    }
+    params.numOps = kOps;
+
+    EXPECT_EQ(ncclCeLaunchBatchOps(ceComm, &params, getActiveStream()), ncclSuccess);
+    ASSERT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
+
+    for(int i = 0; i < kOps; ++i)
+    {
+        float result = 0.0f;
+        ASSERT_EQ(hipMemcpy(&result, dst[i], sizeof(float), hipMemcpyDeviceToHost), hipSuccess);
+        EXPECT_FLOAT_EQ(result, static_cast<float>(i + 1)) << "op " << i;
+    }
+
+    ncclCeFreeBatchOpsParams(&params);
+    for(int i = 0; i < kOps; ++i)
+    {
+        hipFree(src[i]);
+        hipFree(dst[i]);
+    }
+}
+
+// ===========================================================================
+// CeInternal_Neg – ncclCeImplemented logic (no CE hardware required)
+// ===========================================================================
+
+// NEG-01: ncclCeImplemented returns false for collectives CE does not handle.
+TEST(CeInternalNeg, CeImplementedReturnsFalseForUnsupported)
+{
+    EXPECT_FALSE(ncclCeImplemented(ncclFuncAllReduce,    ncclDevSum, ncclFloat32));
+    EXPECT_FALSE(ncclCeImplemented(ncclFuncBroadcast,    ncclDevSum, ncclFloat32));
+    EXPECT_FALSE(ncclCeImplemented(ncclFuncReduceScatter, ncclDevSum, ncclFloat32));
+}
+
+// NEG-02: On ROCm 7.12+ or 7.0.2.x, ncclCeImplemented returns true for
+//         the four supported CE collectives.
+TEST(CeInternalNeg, CeImplementedReturnsTrueOnSupportedDriver)
+{
+    if(!isCeDriverSupported())
+        GTEST_SKIP() << "CE not supported on this driver (need >= 7.12 or 7.0.2.x)";
+
+    EXPECT_TRUE(ncclCeImplemented(ncclFuncAllGather, ncclDevSum, ncclFloat32));
+    EXPECT_TRUE(ncclCeImplemented(ncclFuncAlltoAll,  ncclDevSum, ncclFloat32));
+    EXPECT_TRUE(ncclCeImplemented(ncclFuncScatter,   ncclDevSum, ncclFloat32));
+    EXPECT_TRUE(ncclCeImplemented(ncclFuncGather,    ncclDevSum, ncclFloat32));
+}
+
+// ===========================================================================
+// CeInternal_FaultInj – fault injection (ENABLE_FAULT_INJECTION only)
+// Build: cmake -DENABLE_FAULT_INJECTION=ON; Run: --gtest_filter=CeInternalFaultInj*
+// ===========================================================================
+
+#ifdef ENABLE_FAULT_INJECTION
+#include "ce_fault_inject.h"
+
+// Inherits CeInternalMPITest; clears all CE faults in TearDown.
+class CeFaultInjTest : public CeInternalMPITest
+{
+protected:
+    void TearDown() override
+    {
+        if(ceComm != nullptr)
+            ncclCeFaultClear(ceComm);
+        CeInternalMPITest::TearDown();
+    }
+};
+
+// FAULT-01: CE_FAULT_SYNC_PREP makes ncclPrepUCSync return ncclSystemError.
+//           After clearing, the same call must succeed.
+TEST_F(CeFaultInjTest, SyncPrepErrorPropagates)
+{
+    requireMinRanks(2);
+    auto   batch = makePrepSyncBatch();
+    size_t opIdx = 0;
+
+    ASSERT_EQ(ncclCeFaultSet(ceComm, CE_FAULT_SYNC_PREP), ncclSuccess);
+    EXPECT_EQ(ncclPrepUCSync(ceComm, false, batch.data(), &opIdx),
+              ncclSystemError)
+        << "Expected ncclSystemError when CE_FAULT_SYNC_PREP is armed";
+
+    ASSERT_EQ(ncclCeFaultClear(ceComm), ncclSuccess);
+    opIdx = 0;
+    EXPECT_EQ(ncclPrepUCSync(ceComm, false, batch.data(), &opIdx), ncclSuccess)
+        << "Expected ncclSuccess after fault cleared";
+}
+
+// FAULT-02: CE_FAULT_LAUNCH_OP makes ncclCeLaunchBatchOps return
+//           ncclSystemError even for a non-empty batch.
+//           After clearing, the same call must succeed.
+TEST_F(CeFaultInjTest, LaunchBatchOpsErrorPropagates)
+{
+    constexpr int   kOps  = 2;
+    constexpr size_t kBytes = sizeof(float);
+
+    float* src = nullptr;
+    float* dst = nullptr;
+    ASSERT_EQ(hipMalloc(&src, kBytes), hipSuccess);
+    ASSERT_EQ(hipMalloc(&dst, kBytes), hipSuccess);
+
+    ncclCeBatchOpsParams params{};
+    ASSERT_EQ(ncclCeInitBatchOpsParams(&params, kOps), ncclSuccess);
+    for(int i = 0; i < kOps; ++i)
+    {
+        params.srcs[i]  = src;
+        params.dsts[i]  = dst;
+        params.sizes[i] = kBytes;
+    }
+    params.numOps = kOps;
+
+    ASSERT_EQ(ncclCeFaultSet(ceComm, CE_FAULT_LAUNCH_OP), ncclSuccess);
+    EXPECT_EQ(ncclCeLaunchBatchOps(ceComm, &params, getActiveStream()),
+              ncclSystemError)
+        << "Expected ncclSystemError when CE_FAULT_LAUNCH_OP is armed";
+
+    ASSERT_EQ(ncclCeFaultClear(ceComm), ncclSuccess);
+    EXPECT_EQ(ncclCeLaunchBatchOps(ceComm, &params, getActiveStream()),
+              ncclSuccess)
+        << "Expected ncclSuccess after fault cleared";
+    EXPECT_EQ(hipStreamSynchronize(getActiveStream()), hipSuccess);
+
+    ncclCeFreeBatchOpsParams(&params);
+    hipFree(src);
+    hipFree(dst);
+}
+
+// FAULT-03: CE_FAULT_INIT makes ncclCeInit return ncclSystemError and leaves
+//           CE un-initialized (baseUCSymReadyPtr remains null after the call).
+TEST_F(CeFaultInjTest, InitErrorPreventsSetup)
+{
+    ASSERT_EQ(ncclCeFinalize(ceComm), ncclSuccess);
+    ASSERT_EQ(ceComm->ceColl.baseUCSymReadyPtr, nullptr);
+
+    ASSERT_EQ(ncclCeFaultSet(ceComm, CE_FAULT_INIT), ncclSuccess);
+    EXPECT_EQ(ncclCeInit(ceComm), ncclSystemError)
+        << "Expected ncclSystemError when CE_FAULT_INIT is armed";
+    EXPECT_EQ(ceComm->ceColl.baseUCSymReadyPtr, nullptr)
+        << "Failed init must not set baseUCSymReadyPtr";
+
+    ASSERT_EQ(ncclCeFaultClear(ceComm), ncclSuccess);
+    EXPECT_EQ(ncclCeInit(ceComm), ncclSuccess)
+        << "Expected ncclSuccess after fault cleared";
+    EXPECT_NE(ceComm->ceColl.baseUCSymReadyPtr, nullptr)
+        << "Successful re-init should set baseUCSymReadyPtr";
+}
+
+// FAULT-04: Multiple faults can be armed simultaneously; each targeted
+//           function returns ncclSystemError; ncclCeFaultClear restores all.
+TEST_F(CeFaultInjTest, MultipleFaultsArmedAndCleared)
+{
+    requireMinRanks(2);
+
+    ASSERT_EQ(ncclCeFaultSet(ceComm, CE_FAULT_SYNC_PREP | CE_FAULT_LAUNCH_OP),
+              ncclSuccess);
+    EXPECT_EQ(ncclCeFaultGet(ceComm), CE_FAULT_SYNC_PREP | CE_FAULT_LAUNCH_OP)
+        << "Both fault bits should be visible via ncclCeFaultGet";
+
+    auto   batch = makePrepSyncBatch();
+    size_t opIdx = 0;
+    EXPECT_EQ(ncclPrepUCSync(ceComm, false, batch.data(), &opIdx),
+              ncclSystemError);
+
+    ncclCeBatchOpsParams emptyParams{};
+    emptyParams.numOps = 1; // non-zero to bypass the early-out
+    EXPECT_EQ(ncclCeLaunchBatchOps(ceComm, &emptyParams, getActiveStream()),
+              ncclSystemError);
+
+    ASSERT_EQ(ncclCeFaultClear(ceComm), ncclSuccess);
+    EXPECT_EQ(ncclCeFaultGet(ceComm), 0u) << "All faults should be cleared";
+
+    opIdx = 0;
+    EXPECT_EQ(ncclPrepUCSync(ceComm, false, batch.data(), &opIdx), ncclSuccess);
+}
+
+#endif // ENABLE_FAULT_INJECTION
+
+#endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/ce/CeMPITests.cpp
+++ b/projects/rccl/test/ce/CeMPITests.cpp
@@ -1,0 +1,656 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// End-to-end MPI tests for CE collectives via the public RCCL API (AllGather, AlltoAll, Scatter, Gather, Fallback, Stress).
+
+#include "CeTestHelpers.hpp"
+#include "DeviceBufferHelpers.hpp"
+#include "MPIHelpers.hpp"
+#include "MPITestBase.hpp"
+#include "SymmetricBufferHelpers.hpp"
+#include "TestChecks.hpp"
+#include "rccl/rccl.h"
+
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <string>
+
+#ifdef MPI_TESTS_ENABLED
+
+using namespace MPITestConstants;
+using namespace RCCLTestHelpers;
+
+namespace CeMPITestConstants
+{
+constexpr size_t kSmallCount      = 4096;   // elements per rank for fast tests
+constexpr size_t kMediumCount     = 65536;  // elements per rank for larger tests
+constexpr int    kMinRanks2       = 2;
+constexpr int    kMinRanks4       = 4;
+constexpr int    kMinRanks8       = 8;
+constexpr int    kStressIters     = 20;     // back-to-back iterations for stress test
+constexpr int    kInterleavedIters = 10;    // iterations for CE+SM interleaved stress test
+} // namespace CeMPITestConstants
+
+using namespace CeMPITestConstants;
+
+// Base fixture for all CE MPI tests; captures NCCL INFO per rank for log-marker assertions.
+// Tests always run: on CE-capable systems they assert the CE path; on others they assert
+// the SM fallback path.  isCeExpected() is the single gate for which assertion to make.
+class CeMPITest : public MPITestBase
+{
+protected:
+    std::unique_ptr<MPIHelpers::MpiEnvGuard>             debugGuard_;
+    std::unique_ptr<MPIHelpers::MpiEnvGuard>             debugSubsysGuard_;
+    std::unique_ptr<MPIHelpers::TestLogAssertionContext> logCtx_;
+
+    void SetUp() override
+    {
+        MPITestBase::SetUp();
+        // Log capture is always enabled so that assertCEPathTaken / assertCEPathNotTaken
+        // can inspect the NCCL debug output regardless of whether CE is active.
+        debugGuard_       = std::make_unique<MPIHelpers::MpiEnvGuard>("NCCL_DEBUG",        "INFO");
+        debugSubsysGuard_ = std::make_unique<MPIHelpers::MpiEnvGuard>("NCCL_DEBUG_SUBSYS", "ALL");
+        logCtx_ = std::make_unique<MPIHelpers::TestLogAssertionContext>(
+            MPIHelpers::makeCombinedAssertionLogOptions(getTestMpiRank()));
+    }
+
+    void TearDown() override
+    {
+        // Destroy communicator before logCtx_ so its log lines flush to the debug file first.
+        MPITestBase::TearDown();
+
+        logCtx_.reset();
+        debugSubsysGuard_.reset();
+        debugGuard_.reset();
+    }
+
+    // Returns true when all CE prerequisites are met (driver + env vars).
+    // Delegates to isCeDispatchConfigured() in CeTestHelpers.hpp — the single
+    // source of truth shared with CeInternalMPITests.cpp.
+    bool isCeExpected() const { return isCeDispatchConfigured(); }
+
+    // CE log markers: "Init CE" = CE initialised; "CE: rank" = CE path taken for a collective.
+    enum class CeLogStatus { Taken, InitOnlyNoOp, NotInitialized };
+
+    static CeLogStatus checkCeLog(const std::string& log)
+    {
+        if(log.find("Init CE") == std::string::npos)
+            return CeLogStatus::NotInitialized;
+        if(log.find("CE: rank") != std::string::npos)
+            return CeLogStatus::Taken;
+        return CeLogStatus::InitOnlyNoOp;
+    }
+
+    // Merge debug file + per-rank stderr (covers ncclDebugInit race on first test).
+    std::string readAllLogs() const
+    {
+        return logCtx_->readNcclDebugLog() + logCtx_->readPerRankStderrLog();
+    }
+
+    // Assert the CE dispatch path was taken, or — when CE is not expected on this
+    // system/configuration — assert the SM fallback path and print an info line.
+    void assertCEPathTaken(const char* context)
+    {
+        const std::string log    = readAllLogs();
+        CeLogStatus       status = checkCeLog(log);
+
+        if(isCeExpected())
+        {
+            EXPECT_EQ(status, CeLogStatus::Taken)
+                << context
+                << ": \"CE: rank\" absent from NCCL log"
+                   " (NCCL_CTA_POLICY=2 set but CE dispatch path was not taken)";
+            if(status == CeLogStatus::Taken)
+                TEST_INFO("%s: assertion passed — CE dispatch path taken", context);
+        }
+        else
+        {
+            EXPECT_EQ(log.find("CE: rank"), std::string::npos)
+                << context
+                << ": \"CE: rank\" found in NCCL log but CE was not expected"
+                   " (driver or env-var prerequisites not met)";
+            TEST_INFO("%s: assertion passed — SM fallback path (CE not available/configured)",
+                      context);
+        }
+    }
+
+    // Root-only variant: only root emits "CE: rank" (non-root has numOps=0 in Scatter/Gather).
+    void assertCEPathTakenOnRoot(int rootRank, int myRank, const char* context)
+    {
+        const std::string log    = readAllLogs();
+        CeLogStatus       status = checkCeLog(log);
+
+        if(isCeExpected())
+        {
+            if(myRank == rootRank)
+            {
+                EXPECT_EQ(status, CeLogStatus::Taken)
+                    << context
+                    << ": \"CE: rank\" absent from NCCL log on root rank " << myRank
+                    << " (NCCL_CTA_POLICY=2 set but CE dispatch path was not taken)";
+                if(status == CeLogStatus::Taken)
+                    TEST_INFO("%s: assertion passed — root rank %d CE dispatch path taken",
+                              context, myRank);
+            }
+            else
+            {
+                TEST_INFO("%s: rank %d non-root — no CE ops expected (correct)", context, myRank);
+            }
+        }
+        else
+        {
+            EXPECT_EQ(log.find("CE: rank"), std::string::npos)
+                << context
+                << ": \"CE: rank\" found in NCCL log but CE was not expected";
+            TEST_INFO("%s: rank %d assertion passed — SM fallback path (CE not available/configured)",
+                      context, myRank);
+        }
+    }
+
+    // Assert CE was explicitly NOT taken.  Prints an info line in all cases.
+    void assertCEPathNotTaken(const char* context)
+    {
+        const std::string log = readAllLogs();
+        EXPECT_EQ(log.find("CE: rank"), std::string::npos)
+            << context << ": \"CE: rank\" found in NCCL log but was not expected";
+        TEST_INFO("%s: assertion passed — CE path not taken (expected for this test)", context);
+    }
+
+    // Assert the specific CE batch path sub-variant that was (or was not) taken.
+    //
+    // When CE is expected:
+    //   withIntraBatchSync=true  → asserts "Batch path with intraBatchSync"
+    //   withIntraBatchSync=false → asserts "Batch path without intraBatchSync"
+    // When CE is not expected the check is skipped (SM fallback emits neither line).
+    //
+    // Call after assertCEPathTaken() so the "CE: rank" assertion already passed.
+    void assertCEBatchPath(bool withIntraBatchSync, const char* context)
+    {
+        if(!isCeExpected())
+            return;
+
+        const std::string needle = withIntraBatchSync
+                                       ? "Batch path with intraBatchSync"
+                                       : "Batch path without intraBatchSync";
+        const std::string log = readAllLogs();
+        EXPECT_NE(log.find(needle), std::string::npos)
+            << context << ": expected \"" << needle << "\" not found in NCCL log";
+        TEST_INFO("%s: batch path assertion passed — %s", context, needle.c_str());
+    }
+
+    // Root-only variant: only the root rank emits the batch path log line
+    // (non-root ranks have numOps=0 for Scatter/Gather and emit nothing).
+    void assertCEBatchPathOnRoot(bool withIntraBatchSync,
+                                 int rootRank, int myRank,
+                                 const char* context)
+    {
+        if(!isCeExpected() || myRank != rootRank)
+            return;
+        assertCEBatchPath(withIntraBatchSync, context);
+    }
+
+    // Data helpers: fill/verify with float(rank+1) per-rank or block-index pattern.
+    // Thin fixture wrappers; the underlying logic lives in CeTestHelpers.hpp so that
+    // CeInternalMPITests.cpp can call the same helpers without going through this fixture.
+
+    void fillRankScalar(void* buf, size_t nElem, int rank)
+    {
+        ASSERT_EQ(hipSuccess, ceFillRankScalarFloat(buf, nElem, rank));
+    }
+
+    void fillBlockPattern(void* buf, size_t totalElem, size_t elemsPerBlock)
+    {
+        ASSERT_EQ(
+            hipSuccess,
+            initializeBufferWithPattern<float>(buf, totalElem, [elemsPerBlock](size_t i) {
+                return static_cast<float>(i / elemsPerBlock + 1);
+            }));
+    }
+
+    bool verifyBlockPattern(const void* buf, size_t totalElem, size_t elemsPerBlock)
+    {
+        return ceVerifyBlockPatternFloat(buf, totalElem, elemsPerBlock);
+    }
+
+    bool verifyRankScalar(const void* buf, size_t nElem, int rank)
+    {
+        return verifyBufferData<float>(buf, nElem,
+                                       [rank](size_t) { return static_cast<float>(rank + 1); });
+    }
+
+    // Symmetric buffer wrapper bound to the active communicator; call after createTestCommunicator().
+    using SymBuf = RCCLTestHelpers::SymBuf;
+
+    ncclResult_t allocSymBuf(size_t bytes, SymBuf& sb)
+    {
+        return RCCLTestHelpers::ncclSymBufAlloc(getActiveCommunicator(), bytes, sb);
+    }
+};
+
+// ===========================================================================
+// CeMPI_AllGather – ncclAllGather CE correctness + log verification
+// ===========================================================================
+
+class CeMPI_AllGather : public CeMPITest
+{
+protected:
+    void runAllGather(int minRanks, size_t count, const char* testId)
+    {
+        if(!validateTestPrerequisites(minRanks))
+            GTEST_SKIP() << "Need >= " << minRanks << " MPI ranks";
+
+        ASSERT_EQ(ncclSuccess, createTestCommunicator());
+
+        int rank{}, nRanks{};
+        ncclCommUserRank(getActiveCommunicator(), &rank);
+        ncclCommCount(getActiveCommunicator(), &nRanks);
+
+        SymBuf sendSym, recvSym;
+        ASSERT_EQ(ncclSuccess, allocSymBuf(count * sizeof(float), sendSym));
+        ASSERT_EQ(ncclSuccess, allocSymBuf(count * nRanks * sizeof(float), recvSym));
+
+        fillRankScalar(sendSym.ptr, count, rank);
+
+        ASSERT_EQ(ncclSuccess,
+                  ncclAllGather(sendSym.ptr, recvSym.ptr, count, ncclFloat32,
+                                getActiveCommunicator(), getActiveStream()));
+        ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+        ASSERT_TRUE(verifyBlockPattern(recvSym.ptr, count * nRanks, count))
+            << "Rank " << rank << ": AllGather data verification failed";
+
+        assertCEPathTaken(testId);
+        // numOps = nRanks (one copy per rank including self); chunkBytes = count * sizeof(float)
+        assertCEBatchPath(ceExpectIntraBatchSync(nRanks, count * sizeof(float)), testId);
+    }
+};
+
+// CE-MPI-AG-01: 2 ranks, small buffers.
+TEST_F(CeMPI_AllGather, TwoRanks)    { runAllGather(kMinRanks2, kSmallCount,  "CeMPI_AllGather/TwoRanks"); }
+// CE-MPI-AG-02: 4 ranks, medium buffers.
+TEST_F(CeMPI_AllGather, FourRanks)   { runAllGather(kMinRanks4, kMediumCount, "CeMPI_AllGather/FourRanks"); }
+// CE-MPI-AG-03: 8 ranks (default production topology), medium buffers.
+TEST_F(CeMPI_AllGather, EightRanks)  { runAllGather(kMinRanks8, kMediumCount, "CeMPI_AllGather/EightRanks"); }
+// CE-MPI-AG-04: Edge case — single element per rank.
+TEST_F(CeMPI_AllGather, SingleElement) { runAllGather(kMinRanks2, 1,          "CeMPI_AllGather/SingleElement"); }
+
+// ===========================================================================
+// CeMPI_AlltoAll – ncclAlltoAll CE correctness + log verification
+// ===========================================================================
+
+class CeMPI_AlltoAll : public CeMPITest
+{
+protected:
+    // count is per-rank-per-destination; total send/recv buffer = count * nRanks.
+    void runAlltoAll(int minRanks, size_t count, const char* testId)
+    {
+        if(!validateTestPrerequisites(minRanks))
+            GTEST_SKIP() << "Need >= " << minRanks << " MPI ranks";
+
+        ASSERT_EQ(ncclSuccess, createTestCommunicator());
+
+        int rank{}, nRanks{};
+        ncclCommUserRank(getActiveCommunicator(), &rank);
+        ncclCommCount(getActiveCommunicator(), &nRanks);
+
+        const size_t totalElem = count * static_cast<size_t>(nRanks);
+
+        SymBuf sendSym, recvSym;
+        ASSERT_EQ(ncclSuccess, allocSymBuf(totalElem * sizeof(float), sendSym));
+        ASSERT_EQ(ncclSuccess, allocSymBuf(totalElem * sizeof(float), recvSym));
+
+        fillRankScalar(sendSym.ptr, totalElem, rank);
+
+        ASSERT_EQ(ncclSuccess,
+                  ncclAlltoAll(sendSym.ptr, recvSym.ptr, count, ncclFloat32,
+                               getActiveCommunicator(), getActiveStream()));
+        ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+        ASSERT_TRUE(verifyBlockPattern(recvSym.ptr, totalElem, count))
+            << "Rank " << rank << ": AlltoAll data verification failed";
+
+        assertCEPathTaken(testId);
+        // numOps = nRanks (one per destination rank); chunkBytes = count * sizeof(float)
+        assertCEBatchPath(ceExpectIntraBatchSync(nRanks, count * sizeof(float)), testId);
+    }
+};
+
+// CE-MPI-A2A-01: 2 ranks, small buffers.
+TEST_F(CeMPI_AlltoAll, TwoRanks)   { runAlltoAll(kMinRanks2, kSmallCount,  "CeMPI_AlltoAll/TwoRanks"); }
+// CE-MPI-A2A-02: 4 ranks, medium buffers.
+TEST_F(CeMPI_AlltoAll, FourRanks)  { runAlltoAll(kMinRanks4, kMediumCount, "CeMPI_AlltoAll/FourRanks"); }
+// CE-MPI-A2A-03: 8 ranks (default production topology), medium buffers.
+TEST_F(CeMPI_AlltoAll, EightRanks) { runAlltoAll(kMinRanks8, kMediumCount, "CeMPI_AlltoAll/EightRanks"); }
+// CE-MPI-A2A-04: Odd rank count (3) — non-power-of-two op layout vs 2/4/8 ranks.
+TEST_F(CeMPI_AlltoAll, ThreeRanks) { runAlltoAll(3,          kSmallCount,  "CeMPI_AlltoAll/ThreeRanks"); }
+
+// ===========================================================================
+// CeMPI_Scatter – ncclScatter CE correctness + log verification
+// ===========================================================================
+
+class CeMPI_Scatter : public CeMPITest
+{
+protected:
+    // Root sends block r to rank r; non-root send bufs are registered but ignored.
+    void runScatter(int minRanks, size_t count, int root, const char* testId)
+    {
+        if(!validateTestPrerequisites(minRanks))
+            GTEST_SKIP() << "Need >= " << minRanks << " MPI ranks";
+
+        ASSERT_EQ(ncclSuccess, createTestCommunicator());
+
+        int rank{}, nRanks{};
+        ncclCommUserRank(getActiveCommunicator(), &rank);
+        ncclCommCount(getActiveCommunicator(), &nRanks);
+
+        SymBuf sendSym, recvSym;
+        ASSERT_EQ(ncclSuccess,
+                  allocSymBuf(count * static_cast<size_t>(nRanks) * sizeof(float), sendSym));
+        ASSERT_EQ(ncclSuccess, allocSymBuf(count * sizeof(float), recvSym));
+
+        if(rank == root)
+            fillBlockPattern(sendSym.ptr, count * static_cast<size_t>(nRanks), count);
+
+        ASSERT_EQ(ncclSuccess,
+                  ncclScatter(sendSym.ptr, recvSym.ptr, count, ncclFloat32, root,
+                              getActiveCommunicator(), getActiveStream()));
+        ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+        ASSERT_TRUE(verifyRankScalar(recvSym.ptr, count, rank))
+            << "Rank " << rank << ": Scatter data verification failed";
+
+        assertCEPathTakenOnRoot(root, rank, testId);
+        // Root sends nRanks chunks; chunkBytes = count * sizeof(float)
+        assertCEBatchPathOnRoot(ceExpectIntraBatchSync(nRanks, count * sizeof(float)),
+                                root, rank, testId);
+    }
+};
+
+// CE-MPI-SCT-01: 4 ranks, root = 0.
+TEST_F(CeMPI_Scatter, FourRanksRoot0)  { runScatter(kMinRanks4, kSmallCount, 0, "CeMPI_Scatter/FourRanksRoot0"); }
+// CE-MPI-SCT-02: 4 ranks, non-zero root (root = 1).
+TEST_F(CeMPI_Scatter, FourRanksRoot1)  { runScatter(kMinRanks4, kSmallCount, 1, "CeMPI_Scatter/FourRanksRoot1"); }
+// CE-MPI-SCT-03: 8 ranks (default production topology), root = 0.
+TEST_F(CeMPI_Scatter, EightRanksRoot0) { runScatter(kMinRanks8, kSmallCount, 0, "CeMPI_Scatter/EightRanksRoot0"); }
+
+// ===========================================================================
+// CeMPI_Gather – ncclGather CE correctness + log verification
+// ===========================================================================
+
+class CeMPI_Gather : public CeMPITest
+{
+protected:
+    // All ranks send; root gathers into block-pattern recvbuf; non-root recv bufs registered.
+    void runGather(int minRanks, size_t count, int root, const char* testId)
+    {
+        if(!validateTestPrerequisites(minRanks))
+            GTEST_SKIP() << "Need >= " << minRanks << " MPI ranks";
+
+        ASSERT_EQ(ncclSuccess, createTestCommunicator());
+
+        int rank{}, nRanks{};
+        ncclCommUserRank(getActiveCommunicator(), &rank);
+        ncclCommCount(getActiveCommunicator(), &nRanks);
+
+        SymBuf sendSym, recvSym;
+        ASSERT_EQ(ncclSuccess, allocSymBuf(count * sizeof(float), sendSym));
+        ASSERT_EQ(ncclSuccess,
+                  allocSymBuf(count * static_cast<size_t>(nRanks) * sizeof(float), recvSym));
+
+        fillRankScalar(sendSym.ptr, count, rank);
+
+        ASSERT_EQ(ncclSuccess,
+                  ncclGather(sendSym.ptr, recvSym.ptr, count, ncclFloat32, root,
+                             getActiveCommunicator(), getActiveStream()));
+        ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+        if(rank == root)
+        {
+            ASSERT_TRUE(verifyBlockPattern(recvSym.ptr, count * static_cast<size_t>(nRanks), count))
+                << "Rank " << rank << " (root): Gather data verification failed";
+        }
+
+        assertCEPathTakenOnRoot(root, rank, testId);
+        // Root receives nRanks chunks; chunkBytes = count * sizeof(float)
+        assertCEBatchPathOnRoot(ceExpectIntraBatchSync(nRanks, count * sizeof(float)),
+                                root, rank, testId);
+    }
+};
+
+// CE-MPI-GTH-01: 4 ranks, root = 0.
+TEST_F(CeMPI_Gather, FourRanksRoot0)  { runGather(kMinRanks4, kSmallCount, 0, "CeMPI_Gather/FourRanksRoot0"); }
+// CE-MPI-GTH-02: 4 ranks, non-zero root (root = 1).
+TEST_F(CeMPI_Gather, FourRanksRoot1)  { runGather(kMinRanks4, kSmallCount, 1, "CeMPI_Gather/FourRanksRoot1"); }
+// CE-MPI-GTH-03: 8 ranks (default production topology), root = 0.
+TEST_F(CeMPI_Gather, EightRanksRoot0) { runGather(kMinRanks8, kSmallCount, 0, "CeMPI_Gather/EightRanksRoot0"); }
+
+// ===========================================================================
+// CeMPI_Fallback – CE not taken for AllReduce; SM path when CE env is off
+// ===========================================================================
+
+class CeMPI_Fallback : public CeMPITest
+{};
+
+// CE-MPI-FALLBACK-01: AllReduce never uses CE (not a CE collective).
+// Plain hipMalloc avoids the symmetric-SM kernel path (absent with GENERATE_SYM_KERNELS=OFF).
+TEST_F(CeMPI_Fallback, AllReduceNeverUsesCE)
+{
+    if(!validateTestPrerequisites(kMinRanks2))
+        GTEST_SKIP() << "Need >= 2 MPI ranks";
+
+    ASSERT_EQ(ncclSuccess, createTestCommunicator());
+
+    int rank{}, nRanks{};
+    ncclCommUserRank(getActiveCommunicator(), &rank);
+    ncclCommCount(getActiveCommunicator(), &nRanks);
+
+    const size_t count = kSmallCount;
+    const size_t bytes = count * sizeof(float);
+
+    void* sendBuf = nullptr;
+    void* recvBuf = nullptr;
+    ASSERT_EQ(hipSuccess, hipMalloc(&sendBuf, bytes));
+    ASSERT_EQ(hipSuccess, hipMalloc(&recvBuf, bytes));
+
+    fillRankScalar(sendBuf, count, rank);
+
+    ASSERT_EQ(ncclSuccess,
+              ncclAllReduce(sendBuf, recvBuf, count, ncclFloat32, ncclSum,
+                            getActiveCommunicator(), getActiveStream()));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+    const float expected = static_cast<float>(nRanks * (nRanks + 1) / 2);
+    ASSERT_TRUE(verifyBufferData<float>(recvBuf, count,
+                                        [expected](size_t) { return expected; }))
+        << "Rank " << rank << ": AllReduce data verification failed";
+
+    hipFree(sendBuf);
+    hipFree(recvBuf);
+
+    assertCEPathNotTaken("CeMPI_Fallback/AllReduceNeverUsesCE");
+}
+
+// CE-MPI-FALLBACK-02: AllGather with plain hipMalloc (no symmetric window) falls back to SM.
+// NCCL_CTA_POLICY is process-cached; bypassing CE via unregistered buffers is the correct approach.
+TEST_F(CeMPI_Fallback, AllGatherFallbackToSMWhenCEDisabled)
+{
+    if(!validateTestPrerequisites(kMinRanks2))
+        GTEST_SKIP() << "Need >= 2 MPI ranks";
+
+    ASSERT_EQ(ncclSuccess, createTestCommunicator());
+
+    int rank{}, nRanks{};
+    ncclCommUserRank(getActiveCommunicator(), &rank);
+    ncclCommCount(getActiveCommunicator(), &nRanks);
+
+    const size_t count = kSmallCount;
+    const size_t bytes = count * sizeof(float);
+
+    // Plain hipMalloc: ncclDevrFindWindow returns NULL → CE dispatch condition false.
+    void* sendBuf = nullptr;
+    void* recvBuf = nullptr;
+    ASSERT_EQ(hipSuccess, hipMalloc(&sendBuf, bytes));
+    ASSERT_EQ(hipSuccess, hipMalloc(&recvBuf, bytes * static_cast<size_t>(nRanks)));
+
+    fillRankScalar(sendBuf, count, rank);
+
+    ASSERT_EQ(ncclSuccess,
+              ncclAllGather(sendBuf, recvBuf, count, ncclFloat32,
+                            getActiveCommunicator(), getActiveStream()));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+    ASSERT_TRUE(verifyBlockPattern(recvBuf, count * static_cast<size_t>(nRanks), count))
+        << "Rank " << rank << ": AllGather (SM path) data verification failed";
+
+    hipFree(sendBuf);
+    hipFree(recvBuf);
+
+    assertCEPathNotTaken("CeMPI_Fallback/AllGatherFallbackToSMWhenCEDisabled");
+}
+
+// CE-MPI-FALLBACK-03: Only send registered; recvWin == NULL → CE dispatch skipped, SM ring used.
+TEST_F(CeMPI_Fallback, AllGatherRecvNotRegisteredFallsBackToSM)
+{
+    if(!validateTestPrerequisites(kMinRanks2))
+        GTEST_SKIP() << "Need >= 2 MPI ranks";
+
+    ASSERT_EQ(ncclSuccess, createTestCommunicator());
+
+    int rank{}, nRanks{};
+    ncclCommUserRank(getActiveCommunicator(), &rank);
+    ncclCommCount(getActiveCommunicator(), &nRanks);
+
+    const size_t count = kSmallCount;
+    const size_t bytes = count * sizeof(float);
+
+    // Send is a symmetric window; recv is plain hipMalloc → CE condition fails.
+    SymBuf sendSym;
+    ASSERT_EQ(ncclSuccess, allocSymBuf(bytes, sendSym));
+
+    void* recvBuf = nullptr;
+    ASSERT_EQ(hipSuccess, hipMalloc(&recvBuf, bytes * static_cast<size_t>(nRanks)));
+
+    fillRankScalar(sendSym.ptr, count, rank);
+
+    ASSERT_EQ(ncclSuccess,
+              ncclAllGather(sendSym.ptr, recvBuf, count, ncclFloat32,
+                            getActiveCommunicator(), getActiveStream()));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+    ASSERT_TRUE(verifyBlockPattern(recvBuf, count * static_cast<size_t>(nRanks), count))
+        << "Rank " << rank << ": AllGather (partial-reg SM fallback) data verification failed";
+
+    hipFree(recvBuf);
+
+    assertCEPathNotTaken("CeMPI_Fallback/AllGatherRecvNotRegisteredFallsBackToSM");
+}
+
+// ===========================================================================
+// CeMPI_Stress – back-to-back repetitions stress test
+// ===========================================================================
+
+class CeMPI_Stress : public CeMPITest
+{};
+
+// CE-MPI-STRESS-01: 20 consecutive AllGather calls; validates ceSeqNum never desyncs.
+TEST_F(CeMPI_Stress, AllGatherBackToBack20x)
+{
+    if(!validateTestPrerequisites(kMinRanks2))
+        GTEST_SKIP() << "Need >= 2 MPI ranks";
+
+    ASSERT_EQ(ncclSuccess, createTestCommunicator());
+
+    int rank{}, nRanks{};
+    ncclCommUserRank(getActiveCommunicator(), &rank);
+    ncclCommCount(getActiveCommunicator(), &nRanks);
+
+    const size_t count = kSmallCount;
+
+    SymBuf sendSym, recvSym;
+    ASSERT_EQ(ncclSuccess, allocSymBuf(count * sizeof(float), sendSym));
+    ASSERT_EQ(ncclSuccess, allocSymBuf(count * nRanks * sizeof(float), recvSym));
+    void* sendBuf = sendSym.ptr;
+    void* recvBuf = recvSym.ptr;
+
+    fillRankScalar(sendBuf, count, rank);
+
+    for(int iter = 0; iter < kStressIters; ++iter)
+    {
+        ASSERT_EQ(ncclSuccess,
+                  ncclAllGather(sendBuf, recvBuf, count, ncclFloat32,
+                                getActiveCommunicator(), getActiveStream()))
+            << "Iteration " << iter << " failed";
+        ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()))
+            << "Stream sync failed at iteration " << iter;
+
+        ASSERT_TRUE(verifyBlockPattern(recvBuf, count * nRanks, count))
+            << "Rank " << rank << ": AllGather data wrong at iteration " << iter;
+    }
+
+    assertCEPathTaken("CeMPI_Stress/AllGatherBackToBack20x");
+}
+
+// CE-MPI-STRESS-02: Interleave CE AllGather and SM AllReduce on same comm.
+// Validates that CE DMA work and SM kernel work ordered on the same comm do
+// not corrupt each other's state.
+TEST_F(CeMPI_Stress, InterleavedCEAllGatherAndSMAllReduce)
+{
+    if(!validateTestPrerequisites(kMinRanks2))
+        GTEST_SKIP() << "Need >= 2 MPI ranks";
+
+    ASSERT_EQ(ncclSuccess, createTestCommunicator());
+
+    int rank{}, nRanks{};
+    ncclCommUserRank(getActiveCommunicator(), &rank);
+    ncclCommCount(getActiveCommunicator(), &nRanks);
+
+    const size_t count = kSmallCount;
+
+    SymBuf agSendSym, agRecvSym;
+    ASSERT_EQ(ncclSuccess, allocSymBuf(count * sizeof(float), agSendSym));
+    ASSERT_EQ(ncclSuccess, allocSymBuf(count * nRanks * sizeof(float), agRecvSym));
+    void* agSend = agSendSym.ptr;
+    void* agRecv = agRecvSym.ptr;
+
+    // AllReduce uses plain hipMalloc; symmetric buffers would route to a sym-SM kernel
+    // absent with GENERATE_SYM_KERNELS=OFF → ncclUnhandledCudaError.
+    void* arSend = nullptr;
+    void* arRecv = nullptr;
+    ASSERT_EQ(hipSuccess, hipMalloc(&arSend, count * sizeof(float)));
+    ASSERT_EQ(hipSuccess, hipMalloc(&arRecv, count * sizeof(float)));
+
+    fillRankScalar(agSend, count, rank);
+    fillRankScalar(arSend, count, rank);
+
+    const float arExpected = static_cast<float>(nRanks * (nRanks + 1) / 2);
+
+    for(int iter = 0; iter < kInterleavedIters; ++iter)
+    {
+        ASSERT_EQ(ncclSuccess,
+                  ncclAllGather(agSend, agRecv, count, ncclFloat32,
+                                getActiveCommunicator(), getActiveStream()))
+            << "AllGather iter " << iter;
+        ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+        ASSERT_TRUE(verifyBlockPattern(agRecv, count * nRanks, count))
+            << "AllGather data wrong at iter " << iter;
+
+        ASSERT_EQ(ncclSuccess,
+                  ncclAllReduce(arSend, arRecv, count, ncclFloat32, ncclSum,
+                                getActiveCommunicator(), getActiveStream()))
+            << "AllReduce iter " << iter;
+        ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+        ASSERT_TRUE(verifyBufferData<float>(arRecv, count,
+                                            [arExpected](size_t) { return arExpected; }))
+            << "AllReduce data wrong at iter " << iter;
+    }
+
+    hipFree(arSend);
+    hipFree(arRecv);
+
+    assertCEPathTaken("CeMPI_Stress/InterleavedCEAllGatherAndSMAllReduce");
+}
+
+#endif // MPI_TESTS_ENABLED

--- a/projects/rccl/test/ce/CeMPITests.cpp
+++ b/projects/rccl/test/ce/CeMPITests.cpp
@@ -10,6 +10,7 @@
 #include "DeviceBufferHelpers.hpp"
 #include "MPIHelpers.hpp"
 #include "MPITestBase.hpp"
+#include "ResourceGuards.hpp"
 #include "SymmetricBufferHelpers.hpp"
 #include "TestChecks.hpp"
 #include "rccl/rccl.h"
@@ -438,6 +439,7 @@ class CeMPI_Fallback : public CeMPITest
 // Plain hipMalloc avoids the symmetric-SM kernel path (absent with GENERATE_SYM_KERNELS=OFF).
 TEST_F(CeMPI_Fallback, AllReduceNeverUsesCE)
 {
+    using namespace RCCLTestGuards;
     if(!validateTestPrerequisites(kMinRanks2))
         GTEST_SKIP() << "Need >= 2 MPI ranks";
 
@@ -450,10 +452,15 @@ TEST_F(CeMPI_Fallback, AllReduceNeverUsesCE)
     const size_t count = kSmallCount;
     const size_t bytes = count * sizeof(float);
 
+    // Plain hipMalloc (not symmetric) is intentional: avoids the sym-SM kernel path.
+    // DeviceBufferAutoGuard ensures hipFree on all exit paths including early ASSERTs.
     void* sendBuf = nullptr;
-    void* recvBuf = nullptr;
     ASSERT_EQ(hipSuccess, hipMalloc(&sendBuf, bytes));
+    DeviceBufferAutoGuard sendGuard(sendBuf);
+
+    void* recvBuf = nullptr;
     ASSERT_EQ(hipSuccess, hipMalloc(&recvBuf, bytes));
+    DeviceBufferAutoGuard recvGuard(recvBuf);
 
     fillRankScalar(sendBuf, count, rank);
 
@@ -467,9 +474,6 @@ TEST_F(CeMPI_Fallback, AllReduceNeverUsesCE)
                                         [expected](size_t) { return expected; }))
         << "Rank " << rank << ": AllReduce data verification failed";
 
-    hipFree(sendBuf);
-    hipFree(recvBuf);
-
     assertCEPathNotTaken("CeMPI_Fallback/AllReduceNeverUsesCE");
 }
 
@@ -477,6 +481,7 @@ TEST_F(CeMPI_Fallback, AllReduceNeverUsesCE)
 // NCCL_CTA_POLICY is process-cached; bypassing CE via unregistered buffers is the correct approach.
 TEST_F(CeMPI_Fallback, AllGatherFallbackToSMWhenCEDisabled)
 {
+    using namespace RCCLTestGuards;
     if(!validateTestPrerequisites(kMinRanks2))
         GTEST_SKIP() << "Need >= 2 MPI ranks";
 
@@ -489,11 +494,15 @@ TEST_F(CeMPI_Fallback, AllGatherFallbackToSMWhenCEDisabled)
     const size_t count = kSmallCount;
     const size_t bytes = count * sizeof(float);
 
-    // Plain hipMalloc: ncclDevrFindWindow returns NULL → CE dispatch condition false.
+    // Plain hipMalloc (not symmetric) is intentional: ncclDevrFindWindow returns NULL
+    // → CE dispatch condition false.  Guards ensure cleanup on all exit paths.
     void* sendBuf = nullptr;
-    void* recvBuf = nullptr;
     ASSERT_EQ(hipSuccess, hipMalloc(&sendBuf, bytes));
+    DeviceBufferAutoGuard sendGuard(sendBuf);
+
+    void* recvBuf = nullptr;
     ASSERT_EQ(hipSuccess, hipMalloc(&recvBuf, bytes * static_cast<size_t>(nRanks)));
+    DeviceBufferAutoGuard recvGuard(recvBuf);
 
     fillRankScalar(sendBuf, count, rank);
 
@@ -505,15 +514,13 @@ TEST_F(CeMPI_Fallback, AllGatherFallbackToSMWhenCEDisabled)
     ASSERT_TRUE(verifyBlockPattern(recvBuf, count * static_cast<size_t>(nRanks), count))
         << "Rank " << rank << ": AllGather (SM path) data verification failed";
 
-    hipFree(sendBuf);
-    hipFree(recvBuf);
-
     assertCEPathNotTaken("CeMPI_Fallback/AllGatherFallbackToSMWhenCEDisabled");
 }
 
 // CE-MPI-FALLBACK-03: Only send registered; recvWin == NULL → CE dispatch skipped, SM ring used.
 TEST_F(CeMPI_Fallback, AllGatherRecvNotRegisteredFallsBackToSM)
 {
+    using namespace RCCLTestGuards;
     if(!validateTestPrerequisites(kMinRanks2))
         GTEST_SKIP() << "Need >= 2 MPI ranks";
 
@@ -526,12 +533,13 @@ TEST_F(CeMPI_Fallback, AllGatherRecvNotRegisteredFallsBackToSM)
     const size_t count = kSmallCount;
     const size_t bytes = count * sizeof(float);
 
-    // Send is a symmetric window; recv is plain hipMalloc → CE condition fails.
+    // Send is a symmetric window; recv is plain hipMalloc (intentional) → CE condition fails.
     SymBuf sendSym;
     ASSERT_EQ(ncclSuccess, allocSymBuf(bytes, sendSym));
 
     void* recvBuf = nullptr;
     ASSERT_EQ(hipSuccess, hipMalloc(&recvBuf, bytes * static_cast<size_t>(nRanks)));
+    DeviceBufferAutoGuard recvGuard(recvBuf);
 
     fillRankScalar(sendSym.ptr, count, rank);
 
@@ -542,8 +550,6 @@ TEST_F(CeMPI_Fallback, AllGatherRecvNotRegisteredFallsBackToSM)
 
     ASSERT_TRUE(verifyBlockPattern(recvBuf, count * static_cast<size_t>(nRanks), count))
         << "Rank " << rank << ": AllGather (partial-reg SM fallback) data verification failed";
-
-    hipFree(recvBuf);
 
     assertCEPathNotTaken("CeMPI_Fallback/AllGatherRecvNotRegisteredFallsBackToSM");
 }
@@ -615,12 +621,16 @@ TEST_F(CeMPI_Stress, InterleavedCEAllGatherAndSMAllReduce)
     void* agSend = agSendSym.ptr;
     void* agRecv = agRecvSym.ptr;
 
-    // AllReduce uses plain hipMalloc; symmetric buffers would route to a sym-SM kernel
-    // absent with GENERATE_SYM_KERNELS=OFF → ncclUnhandledCudaError.
+    // AllReduce uses plain hipMalloc (intentional): symmetric buffers would route to a
+    // sym-SM kernel absent with GENERATE_SYM_KERNELS=OFF → ncclUnhandledCudaError.
+    // DeviceBufferAutoGuard ensures cleanup on all exit paths.
     void* arSend = nullptr;
-    void* arRecv = nullptr;
     ASSERT_EQ(hipSuccess, hipMalloc(&arSend, count * sizeof(float)));
+    RCCLTestGuards::DeviceBufferAutoGuard arSendGuard(arSend);
+
+    void* arRecv = nullptr;
     ASSERT_EQ(hipSuccess, hipMalloc(&arRecv, count * sizeof(float)));
+    RCCLTestGuards::DeviceBufferAutoGuard arRecvGuard(arRecv);
 
     fillRankScalar(agSend, count, rank);
     fillRankScalar(arSend, count, rank);
@@ -646,9 +656,6 @@ TEST_F(CeMPI_Stress, InterleavedCEAllGatherAndSMAllReduce)
                                             [arExpected](size_t) { return arExpected; }))
             << "AllReduce data wrong at iter " << iter;
     }
-
-    hipFree(arSend);
-    hipFree(arRecv);
 
     assertCEPathTaken("CeMPI_Stress/InterleavedCEAllGatherAndSMAllReduce");
 }

--- a/projects/rccl/test/ce/CeTestHelpers.hpp
+++ b/projects/rccl/test/ce/CeTestHelpers.hpp
@@ -1,0 +1,95 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Shared CE test utilities – include in CeMPITests.cpp and CeInternalMPITests.cpp.
+
+#ifndef CE_TEST_HELPERS_HPP
+#define CE_TEST_HELPERS_HPP
+
+#ifdef MPI_TESTS_ENABLED
+
+#include "DeviceBufferHelpers.hpp"
+#include "MPIHelpers.hpp"
+
+// Driver-version check
+// Returns true when the HIP driver supports CE: ROCm ≥ 7.12 or the 7.0.2.x
+// backport range [7.0.2.2, 7.0.3.0).
+inline bool isCeDriverSupported()
+{
+    int driverVer = 0;
+    if(hipDriverGetVersion(&driverVer) != hipSuccess)
+        return false;
+    return (driverVer >= 71200000) ||
+           (driverVer >= 70051831 && driverVer < 70060000);
+}
+
+// Full CE dispatch gate
+
+// Returns true when all four prerequisites for CE dispatch are satisfied:
+//   1. Driver version supports CE (ROCm ≥ 7.12 or 7.0.2.2).
+//   2. NCCL_CTA_POLICY=2     (CE dispatch mode).
+//   3. NCCL_LOCAL_REGISTER=0  (explicit buffer registration only).
+//   4. NCCL_CUMEM_ENABLE=1    (VMM-backed symmetric memory; default is 0).
+//      Without this, comm->symmetricSupport is false and CE is never dispatched.
+//
+// Use this single check wherever a test needs to decide between asserting the
+// CE path or the SM fallback path.
+inline bool isCeDispatchConfigured()
+{
+    // Required values
+    constexpr int kCtaPolicyCE     = 2; // NCCL_CTA_POLICY=2      → CE dispatch
+    constexpr int kLocalRegisterCE = 0; // NCCL_LOCAL_REGISTER=0  → explicit registration
+    constexpr int kCuMemEnable     = 1; // NCCL_CUMEM_ENABLE=1    → symmetric VMM memory
+    // NCCL compiled-in defaults (returned when the env var is unset)
+    constexpr int kCtaPolicyDefault     = 0; // SM path
+    constexpr int kLocalRegisterDefault = 1; // implicit registration enabled
+    constexpr int kCuMemEnableDefault   = 0; // VMM/symmetric memory disabled
+    return isCeDriverSupported() &&
+           MPIHelpers::getEnvParam("NCCL_CTA_POLICY",    kCtaPolicyDefault)     == kCtaPolicyCE &&
+           MPIHelpers::getEnvParam("NCCL_LOCAL_REGISTER", kLocalRegisterDefault) == kLocalRegisterCE &&
+           MPIHelpers::getEnvParam("NCCL_CUMEM_ENABLE",   kCuMemEnableDefault)   == kCuMemEnable;
+}
+
+// Batch path prediction helpers
+
+// Mirrors the thresholds from ce_coll.cc (CE_COLL_INTRA_BATCH_SYNC_FREQ /
+// CE_COLL_INTRA_BATCH_SYNC_MSG_THRESHOLD).  Kept here so the source file does
+// not need to expose internal constants via its header.
+static constexpr uint32_t kCeIntraBatchSyncFreq          = 8;
+static constexpr uint64_t kCeIntraBatchSyncMsgThreshold  = 512ULL * 1024 * 1024;
+
+// Returns true when the CE batch path will use intraBatchSync, given the
+// actual numOps and chunkBytes for a collective.  Mirrors the condition in
+// ncclCeLaunchBatchOps() so tests can assert the correct path sub-variant.
+inline bool ceExpectIntraBatchSync(size_t numOps, size_t chunkBytes)
+{
+    return numOps > kCeIntraBatchSyncFreq &&
+           chunkBytes * numOps >= kCeIntraBatchSyncMsgThreshold;
+}
+
+// Shared buffer helpers
+
+// Fill buf[0..nElem) with float(rank + 1) on the GPU.
+// Returns hipSuccess on success; caller should ASSERT_EQ on the result.
+inline hipError_t ceFillRankScalarFloat(void* buf, size_t nElem, int rank)
+{
+    return RCCLTestHelpers::initializeBufferWithPattern<float>(
+        buf, nElem, [rank](size_t) { return static_cast<float>(rank + 1); });
+}
+
+// Verify AllGather / AlltoAll output: element at index i must equal
+// float(i / elemsPerRank + 1), i.e. each rank's block contains float(rank+1).
+// Returns true when all elements match.
+inline bool ceVerifyBlockPatternFloat(const void* buf, size_t totalElem, size_t elemsPerRank)
+{
+    return RCCLTestHelpers::verifyBufferData<float>(
+        buf, totalElem,
+        [elemsPerRank](size_t i) { return static_cast<float>(i / elemsPerRank + 1); });
+}
+
+#endif // MPI_TESTS_ENABLED
+
+#endif // CE_TEST_HELPERS_HPP

--- a/projects/rccl/test/common/MPIHelpers.cpp
+++ b/projects/rccl/test/common/MPIHelpers.cpp
@@ -483,6 +483,8 @@ std::string readTextFile(const std::string& path)
 
 std::string readRankLogFile(int rank)
 {
+    if(!isPerRankLoggingEnabled())
+        return {};
     std::fflush(stdout);
     std::fflush(stderr);
     return readTextFile(getRankLogFilePath(rank));
@@ -710,7 +712,7 @@ std::string TestLogAssertionContext::readNcclDebugLog() const
 
 std::string TestLogAssertionContext::readPerRankStderrLog() const
 {
-    if(!read_per_rank_)
+    if(!read_per_rank_ || !isPerRankLoggingEnabled())
     {
         return {};
     }

--- a/projects/rccl/test/common/MPIHelpers.hpp
+++ b/projects/rccl/test/common/MPIHelpers.hpp
@@ -378,9 +378,14 @@ struct MpiEnvGuard
             saved = prev;
             if(saved != v)
             {
+#ifdef RCCL_TEST_CHECKS_HPP
+                TEST_INFO("MpiEnvGuard overriding %s: '%s' -> '%s' (will restore on scope exit)",
+                          n, saved.c_str(), v);
+#else
                 fprintf(stderr,
                         "[MpiEnvGuard rank %s] overriding %s: '%s' -> '%s' (will restore on scope exit)\n",
                         getMpiRankStr(), n, saved.c_str(), v);
+#endif
             }
         }
         ::setenv(n, v, /*overwrite=*/1);

--- a/projects/rccl/test/common/SymmetricBufferHelpers.hpp
+++ b/projects/rccl/test/common/SymmetricBufferHelpers.hpp
@@ -1,0 +1,162 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef SYMMETRIC_BUFFER_HELPERS_HPP
+#define SYMMETRIC_BUFFER_HELPERS_HPP
+
+#include "nccl.h"
+#include <cstddef>
+
+/**
+ * @file SymmetricBufferHelpers.hpp
+ * @brief RAII helpers for ncclMemAlloc + ncclCommWindowRegister lifecycle.
+ *
+ * Provides reusable utilities for allocating cuMem VMM-backed buffers and
+ * registering them as NCCL symmetric windows.  This combination is required
+ * for RCCL features that dispatch through the CE (Copy-Engine) collective
+ * path: ceCollTaskAppend in enqueue.cc only triggers CE when
+ * ncclDevrFindWindow returns non-NULL sendWin and recvWin, which requires
+ * the buffers to be registered with NCCL_WIN_COLL_SYMMETRIC.
+ *
+ * Allocation and registration pattern (mirrors rccl-tests/src/common.cu):
+ *   1. ncclMemAlloc(&ptr, bytes)
+ *        – allocates cuMem/VMM-backed device memory (requires ncclCuMemEnable() == 1)
+ *   2. ncclCommWindowRegister(comm, ptr, bytes, &win, NCCL_WIN_COLL_SYMMETRIC)
+ *        – registers the buffer in the symmetric window table so that
+ *          ncclDevrFindWindow can locate it during collective dispatch
+ *   3. collective call (CE dispatch proceeds with non-NULL sendWin/recvWin)
+ *   4. ncclCommWindowDeregister(comm, win) + ncclMemFree(ptr) on cleanup
+ *
+ * Prerequisites:
+ *   - ncclCuMemEnable() must return 1 (ROCm >= 7.12 or 7.0.2.x with the
+ *     CUMEM_DRIVER_CAPABLE backport; controlled by NCCL_CUMEM_ENABLE env var)
+ *   - comm->symmetricSupport must be true (hardware supports VMM RDMA)
+ *
+ * If either prerequisite is absent, ncclMemAlloc falls back to hipMalloc and
+ * ncclCommWindowRegister fails (cuMemGetAddressRange only works on VMM memory).
+ * Callers should treat a non-ncclSuccess return from ncclSymBufAlloc as a
+ * test-skip condition rather than a hard failure.
+ *
+ * NOTE: All functions and types live in namespace RCCLTestHelpers to match
+ *       DeviceBufferHelpers.hpp and HostBufferHelpers.hpp conventions.
+ */
+
+namespace RCCLTestHelpers
+{
+
+// ============================================================================
+// SymBuf – RAII owner of one ncclMemAlloc + ncclCommWindowRegister pair
+// ============================================================================
+
+/**
+ * @brief RAII wrapper that owns a cuMem-allocated device buffer registered as
+ *        a NCCL symmetric window.
+ *
+ * Lifetime rules:
+ *   - Construct with default constructor; populate via ncclSymBufAlloc().
+ *   - Destructor calls ncclCommWindowDeregister then ncclMemFree automatically.
+ *   - Non-copyable; move-constructible for container storage.
+ *
+ * Usage:
+ * @code
+ * RCCLTestHelpers::SymBuf sendBuf;
+ * ASSERT_EQ(ncclSuccess, RCCLTestHelpers::ncclSymBufAlloc(comm, bytes, sendBuf));
+ * // use sendBuf.ptr as the device pointer ...
+ * // sendBuf auto-destructs at end of scope
+ * @endcode
+ */
+struct SymBuf
+{
+    void*        ptr  = nullptr; ///< cuMem-allocated device pointer
+    ncclWindow_t win  = nullptr; ///< symmetric window handle
+    ncclComm_t   comm = nullptr; ///< owning communicator (not ref-counted)
+
+    SymBuf()                         = default;
+    SymBuf(const SymBuf&)            = delete;
+    SymBuf& operator=(const SymBuf&) = delete;
+
+    SymBuf(SymBuf&& o) noexcept : ptr(o.ptr), win(o.win), comm(o.comm)
+    {
+        o.ptr = nullptr;
+        o.win = nullptr;
+        o.comm = nullptr;
+    }
+
+    ~SymBuf()
+    {
+        release();
+    }
+
+    /**
+     * @brief Explicitly release the window and buffer before end of scope.
+     *        Safe to call multiple times (idempotent after first call).
+     */
+    void release()
+    {
+        if(win && comm)
+        {
+            ncclCommWindowDeregister(comm, win);
+            win = nullptr;
+        }
+        if(ptr)
+        {
+            ncclMemFree(ptr);
+            ptr = nullptr;
+        }
+        comm = nullptr;
+    }
+
+    /// @return true if the buffer has been successfully allocated and registered.
+    bool valid() const { return ptr != nullptr && win != nullptr; }
+};
+
+// ============================================================================
+// ncclSymBufAlloc – allocate + register in one call
+// ============================================================================
+
+/**
+ * @brief Allocate a cuMem VMM buffer and register it as a symmetric window.
+ *
+ * Combines ncclMemAlloc + ncclCommWindowRegister(NCCL_WIN_COLL_SYMMETRIC) into
+ * a single call.  On any failure the SymBuf is left in a clean empty state and
+ * any partially acquired resources are released before returning.
+ *
+ * Returns ncclSuccess on success.  Typical non-success results:
+ *   - ncclInternalError / ncclSystemError if cuMem is not enabled or VMM RDMA
+ *     is unsupported on this hardware — treat as a test-skip condition.
+ *   - ncclInvalidArgument if bytes == 0 or comm is null.
+ *
+ * @param comm   NCCL communicator that owns the window registration.
+ * @param bytes  Allocation size in bytes.
+ * @param[out] sb SymBuf to populate.  Must be in the default-constructed state.
+ * @return ncclResult_t
+ */
+inline ncclResult_t ncclSymBufAlloc(ncclComm_t comm, size_t bytes, SymBuf& sb)
+{
+    sb.comm = comm;
+
+    ncclResult_t ret = ncclMemAlloc(&sb.ptr, bytes);
+    if(ret != ncclSuccess)
+    {
+        sb.ptr  = nullptr;
+        sb.comm = nullptr;
+        return ret;
+    }
+
+    ret = ncclCommWindowRegister(comm, sb.ptr, bytes, &sb.win, NCCL_WIN_COLL_SYMMETRIC);
+    if(ret != ncclSuccess)
+    {
+        ncclMemFree(sb.ptr);
+        sb.ptr  = nullptr;
+        sb.win  = nullptr;
+        sb.comm = nullptr;
+    }
+    return ret;
+}
+
+} // namespace RCCLTestHelpers
+
+#endif // SYMMETRIC_BUFFER_HELPERS_HPP

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1285,6 +1285,217 @@
           "test_filter": "RevokeMPITest.RepeatedRevokeShrinkCycles_ResourceCleanup"
         }
       ]
+    },
+
+    "ce_base": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_nodes": 1,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "NCCL_DEBUG_SUBSYS": "INIT,COLL",
+        "RCCL_MPI_LOG_ALL_RANKS": "1",
+        "NCCL_CTA_POLICY": "2",
+        "NCCL_LOCAL_REGISTER": "0",
+        "NCCL_CUMEM_ENABLE": "1"
+      }
+    },
+
+    "ce_2rank": {
+      "extends": "ce_base",
+      "num_ranks": 2,
+      "num_gpus": 2,
+      "timeout": 120,
+      "tests": [
+        {
+          "name": "CE_AllGather_2Ranks",
+          "description": "AllGather CE correctness and 'Init CE' log marker (2 ranks)",
+          "test_filter": "CeMPI_AllGather.TwoRanks"
+        },
+        {
+          "name": "CE_AllGather_SingleElement",
+          "description": "AllGather edge case: single element per rank",
+          "test_filter": "CeMPI_AllGather.SingleElement"
+        },
+        {
+          "name": "CE_AlltoAll_2Ranks",
+          "description": "AlltoAll CE correctness and 'Init CE' log marker (2 ranks)",
+          "test_filter": "CeMPI_AlltoAll.TwoRanks"
+        },
+        {
+          "name": "CE_Fallback_AllReduce",
+          "description": "AllReduce must NOT take CE path; verifies SM fallback",
+          "test_filter": "CeMPI_Fallback.AllReduceNeverUsesCE"
+        },
+        {
+          "name": "CE_Fallback_AllGatherUnregistered",
+          "description": "AllGather with plain hipMalloc (no symmetric window) falls back to SM",
+          "test_filter": "CeMPI_Fallback.AllGatherFallbackToSMWhenCEDisabled"
+        },
+        {
+          "name": "CE_Fallback_RecvNotRegistered",
+          "description": "AllGather with only send registered; missing recvWin forces SM fallback",
+          "test_filter": "CeMPI_Fallback.AllGatherRecvNotRegisteredFallsBackToSM"
+        },
+        {
+          "name": "CE_Stress_BackToBack",
+          "description": "20 consecutive AllGather calls; validates ceSeqNum never desyncs",
+          "test_filter": "CeMPI_Stress.AllGatherBackToBack20x",
+          "timeout": 300
+        },
+        {
+          "name": "CE_Stress_Interleaved",
+          "description": "Interleaved CE AllGather and SM AllReduce on same comm; validates no state corruption",
+          "test_filter": "CeMPI_Stress.InterleavedCEAllGatherAndSMAllReduce",
+          "timeout": 300
+        }
+      ]
+    },
+
+    "ce_3rank": {
+      "extends": "ce_base",
+      "num_ranks": 3,
+      "num_gpus": 3,
+      "timeout": 120,
+      "tests": [
+        {
+          "name": "CE_AlltoAll_3Ranks",
+          "description": "AlltoAll CE correctness with odd (non-power-of-two) rank count",
+          "test_filter": "CeMPI_AlltoAll.ThreeRanks"
+        }
+      ]
+    },
+
+    "ce_4rank": {
+      "extends": "ce_base",
+      "num_ranks": 4,
+      "num_gpus": 4,
+      "timeout": 180,
+      "tests": [
+        {
+          "name": "CE_AllGather_4Ranks",
+          "description": "AllGather CE correctness and 'Init CE' log marker (4 ranks)",
+          "test_filter": "CeMPI_AllGather.FourRanks"
+        },
+        {
+          "name": "CE_AlltoAll_4Ranks",
+          "description": "AlltoAll CE correctness and 'Init CE' log marker (4 ranks)",
+          "test_filter": "CeMPI_AlltoAll.FourRanks"
+        },
+        {
+          "name": "CE_Scatter_4Ranks_Root0",
+          "description": "Scatter CE correctness, root=0 (4 ranks)",
+          "test_filter": "CeMPI_Scatter.FourRanksRoot0"
+        },
+        {
+          "name": "CE_Scatter_4Ranks_Root1",
+          "description": "Scatter CE correctness, non-zero root=1 (4 ranks)",
+          "test_filter": "CeMPI_Scatter.FourRanksRoot1"
+        },
+        {
+          "name": "CE_Gather_4Ranks_Root0",
+          "description": "Gather CE correctness, root=0 (4 ranks)",
+          "test_filter": "CeMPI_Gather.FourRanksRoot0"
+        },
+        {
+          "name": "CE_Gather_4Ranks_Root1",
+          "description": "Gather CE correctness, non-zero root=1 (4 ranks)",
+          "test_filter": "CeMPI_Gather.FourRanksRoot1"
+        }
+      ]
+    },
+
+    "ce_8rank": {
+      "extends": "ce_base",
+      "num_ranks": 8,
+      "num_gpus": 8,
+      "timeout": 240,
+      "tests": [
+        {
+          "name": "CE_AllGather_8Ranks",
+          "description": "AllGather CE correctness — default production topology (8 ranks)",
+          "test_filter": "CeMPI_AllGather.EightRanks"
+        },
+        {
+          "name": "CE_AlltoAll_8Ranks",
+          "description": "AlltoAll CE correctness — default production topology (8 ranks)",
+          "test_filter": "CeMPI_AlltoAll.EightRanks"
+        },
+        {
+          "name": "CE_Scatter_8Ranks",
+          "description": "Scatter CE correctness, root=0 — default production topology (8 ranks)",
+          "test_filter": "CeMPI_Scatter.EightRanksRoot0"
+        },
+        {
+          "name": "CE_Gather_8Ranks",
+          "description": "Gather CE correctness, root=0 — default production topology (8 ranks)",
+          "test_filter": "CeMPI_Gather.EightRanksRoot0"
+        }
+      ]
+    },
+
+    "ce_internal": {
+      "extends": "ce_base",
+      "num_ranks": 2,
+      "num_gpus": 2,
+      "timeout": 120,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "NCCL_DEBUG_SUBSYS": "INIT,COLL",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "CE_Internal_Init",
+          "description": "ncclCeInit lifecycle: allocates sync window; ncclCeFinalize tears it down; double-fini is safe; independent state per comm",
+          "test_filter": "CeInternalMPITest.InitSetsWindowPointers:CeInternalMPITest.FiniNullsPointers:CeInternalMPITest.DoubleFiniIsSafe:CeInternalMPITest.IndependentCeStatePerComm:CeInternalMPITest.FiniAfterZeroCollectives"
+        },
+        {
+          "name": "CE_Internal_Sync",
+          "description": "ncclPrepUCSync: ceSeqNum increments, correct op-count, no self-target ops, wrap-around via direct call and via collective",
+          "test_filter": "CeInternalMPITest.PrepUCSync*:CeInternalMPITest.SeqNum*"
+        },
+        {
+          "name": "CE_Internal_Launch",
+          "description": "ncclCeLaunchBatchOps: empty batch succeeds; 4-op batch transfers data correctly",
+          "test_filter": "CeInternalMPITest.Launch*"
+        },
+        {
+          "name": "CE_Internal_Neg",
+          "description": "ncclCeImplemented returns false for non-CE collectives; true on supported driver",
+          "test_filter": "CeInternalNeg.*"
+        }
+      ]
+    },
+
+    "ce_fault_injection": {
+      "extends": "ce_base",
+      "num_ranks": 2,
+      "num_gpus": 2,
+      "timeout": 120,
+      "tests": [
+        {
+          "name": "CE_FaultInj_SyncPrepError",
+          "description": "CE_FAULT_SYNC_PREP: ncclPrepUCSync returns ncclSystemError; clears and resumes correctly",
+          "test_filter": "CeFaultInjTest.SyncPrepErrorPropagates"
+        },
+        {
+          "name": "CE_FaultInj_LaunchOpError",
+          "description": "CE_FAULT_LAUNCH_OP: ncclCeLaunchBatchOps returns ncclSystemError; clears and resumes correctly",
+          "test_filter": "CeFaultInjTest.LaunchBatchOpsErrorPropagates"
+        },
+        {
+          "name": "CE_FaultInj_InitError",
+          "description": "CE_FAULT_INIT: ncclCeInit returns ncclSystemError; leaves baseUCSymReadyPtr null",
+          "test_filter": "CeFaultInjTest.InitErrorPreventsSetup"
+        },
+        {
+          "name": "CE_FaultInj_MultipleFaults",
+          "description": "Multiple CE_FAULT_* bits simultaneously; all target functions return ncclSystemError; ncclCeFaultClear restores all",
+          "test_filter": "CeFaultInjTest.MultipleFaultsArmedAndCleared"
+        }
+      ]
     }
   },
   "test_suites": [
@@ -1514,6 +1725,42 @@
       "name": "Revoke MPI Tests - Multi-Node (4-rank, 2-node)",
       "description": "ncclCommRevoke multi-node scenarios: asymmetric shrink across nodes (ring-only topology after revoke) and repeated revoke/shrink generations to verify no leaked resources",
       "config": "revoke_mpi_tests_multinode",
+      "enabled": true
+    },
+    {
+      "name": "CE Tests - 2-Rank (AllGather, AlltoAll, Fallback, Stress)",
+      "description": "CE collective tests on 2 GPUs/ranks: correctness, log-marker verification, SM fallback, and stress. Skips automatically on unsupported driver version.",
+      "config": "ce_2rank",
+      "enabled": true
+    },
+    {
+      "name": "CE Tests - 3-Rank (AlltoAll odd topology)",
+      "description": "CE AlltoAll with a non-power-of-two rank count. Skips automatically on unsupported driver version.",
+      "config": "ce_3rank",
+      "enabled": true
+    },
+    {
+      "name": "CE Tests - 4-Rank (AllGather, AlltoAll, Scatter, Gather)",
+      "description": "CE collective tests on 4 GPUs/ranks including non-zero root variants. Skips automatically on unsupported driver version.",
+      "config": "ce_4rank",
+      "enabled": true
+    },
+    {
+      "name": "CE Tests - 8-Rank (AllGather, AlltoAll, Scatter, Gather)",
+      "description": "CE collective tests on 8 GPUs/ranks — default production topology. Skips automatically on unsupported driver version.",
+      "config": "ce_8rank",
+      "enabled": true
+    },
+    {
+      "name": "CE Internal Tests (white-box, Debug build only)",
+      "description": "White-box CE internal function tests (ncclCeInit, ncclPrepUCSync, ncclCeLaunchBatchOps). Requires Debug build for symbol visibility. Skips on unsupported driver version.",
+      "config": "ce_internal",
+      "enabled": true
+    },
+    {
+      "name": "CE Fault Injection Tests",
+      "description": "Per-function error injection for CE code paths (ENABLE_FAULT_INJECTION build). Verifies ncclSystemError propagation and recovery for Init, SyncPrep, and LaunchOp faults.",
+      "config": "ce_fault_injection",
       "enabled": true
     }
   ]


### PR DESCRIPTION
Motivation

The CE (Copy-Engine) collective path (`NCCL_CTA_POLICY=2`) lacked any automated test coverage. This PR adds a complete test suite — end-to-end MPI correctness tests, white-box internal unit tests, and fault injection tests — to catch regressions in CE dispatch, synchronization, and error handling across ROCm versions that support CE (`7.12+` and the `7.0.2.x` backport range).

### Technical Details
**New test files**
- `test/ce/CeMPITests.cpp` — 19 end-to-end MPI tests covering the full CE collective API:
    - _AllGather_: 2/4/8-rank correctness + single-element edge case
    - _AlltoAll_: 2/3/4/8-rank correctness
    - _Scatter / Gather_: 4/8-rank with zero and non-zero root
    - _Fallback_: asserts SM path is taken for AllReduce, unregistered buffers, and when CE env vars are absent
    - _Stress_: 20× back-to-back AllGather and interleaved CE+SM collective calls
    - All CE tests assert the specific batch sub-path taken (`"Batch path with/without intraBatchSync"`) in addition to the CE dispatch marker.
        
- `test/ce/CeInternalMPITests.cpp` — 18 white-box tests against internal CE APIs (`ncclCeInit`, `ncclPrepUCSync`, `ncclCeLaunchBatchOps`):
    - _Init_: window pointer setup, double-finalize safety, per-communicator state isolation
    - _Sync_: sequence number increment, op count, no self-targeted ops, wrap-around
    - _Launch_: empty batch, 4-op batch
    - _Negative_: `ncclCeImplemented` returns correct values for unsupported collectives and driver versions
    - _Fault injection_: `CE_FAULT_INIT`, `CE_FAULT_SYNC_PREP`, `CE_FAULT_LAUNCH_OP` bitmask tests via `ENABLE_FAULT_INJECTION`

- `test/ce/CeTestHelpers.hpp` — shared helpers: `isCeDriverSupported()`, `isCeDispatchConfigured()`, `ceExpectIntraBatchSync()`, buffer fill/verify utilities.

**Source changes**

- `src/ce_coll.cc` / `src/include/ce_coll.h` — added `ENABLE_FAULT_INJECTION` hooks (`CE_FAULT_INIT`, `CE_FAULT_SYNC_PREP`, `CE_FAULT_LAUNCH_OP`); added `CE_BATCH_API_SUPPORTED` compile-time macro for `hipMemcpyBatchAsync` availability (ROCm ≥ 7.12 or `7.0.2.x` backport); guarded `hipMemcpyBatchAsync` vs `cudaMemcpyBatchAsync` with `__HIP_PLATFORM_AMD__`; runtime driver version check for the batch path uses `[70051831, 70060000)` to capture `7.0.2.x` backport builds.
- `cmake/DeviceLinker.cmake` — added CMake 3.20 `DEPFILE` support for `collectives.cc` so that header changes (e.g. `ce_coll.h`) correctly invalidate the device object without requiring a manual `touch`.
- `test/CMakeLists.txt` / `src/CMakeLists.txt` — wired `rccl-UnitTestsMPI-CE` targets and propagated `ENABLE_FAULT_INJECTION` compile flag.

**Test runner config**
- `tools/scripts/test_runner/configs/mi300x_mellanox_ib.json` — added CE test suites with the required environment variables (`NCCL_CTA_POLICY=2`, `NCCL_LOCAL_REGISTER=0`, `NCCL_CUMEM_ENABLE=1`).

### JIRA ID

AICOMRCCL-971

### Test Plan

- Built `rccl-UnitTestsMPI` with `ENABLE_FAULT_INJECTION=ON` inside the `rccl-mn` Docker container on MI300X.
- Ran all 37 CE MPI tests individually via `mpirun` (as the test runner would) with CE enabled (`NCCL_CTA_POLICY=2 NCCL_LOCAL_REGISTER=0 NCCL_CUMEM_ENABLE=1`).
- Verified CE path and batch sub-path assertions pass for all collectives.
- Verified fallback tests correctly assert the SM path when CE is not configured.

## Test Result

Test Result

37/37 tests pass on MI300X (ROCm 7.0.2.2, single-node, 8 GPUs).


Suite | Tests | Result
-- | -- | --
CeMPI_AllGather | 4 | PASS
CeMPI_AlltoAll | 4 | PASS
CeMPI_Scatter | 3 | PASS
CeMPI_Gather | 3 | PASS
CeMPI_Fallback | 3 | PASS
CeMPI_Stress | 2 | PASS
CeInternalMPITest | 12 | PASS
CeInternalNeg | 2 | PASS
CeFaultInjTest | 4 | PASS

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
