### PR TITLE
[AMD-SMI] Use clone instead of fork

### DIFF
--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_kfd_data_manager.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_kfd_data_manager.h
@@ -31,20 +31,20 @@
  * /sys/class/kfd/kfd/proc/<pid> when opening /dev/kfd. These persist until
  * process termination, blocking driver reloads and partition changes.
  *
- * This module uses fork-and-exit pattern: KFD operations run in short-lived
- * child processes that exit immediately, ensuring prompt cleanup.
+ * KFD operations run in short-lived child processes that exit immediately,
+ * ensuring prompt cleanup.
  *
  * CACHING:
  * --------
  * Batch queries support time-based caching with O(1) lookup by gpu_id.
- * On cache miss, a single fork refreshes data for ALL GPUs.
+ * On cache miss, a single child spawn refreshes data for ALL GPUs.
  * Cache is invalidated if any GPU query fails (full invalidation).
  *
  * TYPICAL TIMING (per query):
  * ---------------------------
  *   - Cache hit:             < 1 us (O(1) hash lookup)
- *   - Cache miss (fork):     200-800 us typical
- *     - Fork overhead:       100-300 us
+ *   - Cache miss (spawn):    200-800 us typical
+ *     - Spawn overhead:      100-300 us
  *     - IOCTL execution:     50-200 us
  *     - Cleanup verification: 10-50 us (stat-based polling)
  *
@@ -71,7 +71,7 @@ namespace amd::smi::kfd {
 
 /// Configuration for KFD Data Manager timing and behavior
 struct KFDManagerConfig {
-  /// Use legacy direct ioctl instead of fork pattern (default: false)
+  /// Use legacy direct ioctl instead of spawning a child (default: false)
   /// Set AMDSMI_KFD_USE_ORIG_VRAM=1 to enable
   bool use_original_vram_fcn = false;
 
@@ -123,7 +123,7 @@ KFDManagerConfig GetCurrentConfig();
 
 /// Batch query with caching - O(1) cache lookup by gpu_id
 /// If target's cache is valid, returns immediately
-/// Otherwise, refreshes cache for ALL gpu_ids in one fork
+/// Otherwise, refreshes cache for ALL gpu_ids in one child spawn
 [[nodiscard]] QueryResult ExecuteBatchQueryCached(OpType op, const std::vector<uint32_t>& gpu_ids,
                                                   uint32_t target_gpu_id);
 

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd_data_manager.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd_data_manager.cc
@@ -26,10 +26,12 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <poll.h>
+#include <sched.h>
 #include <signal.h>
 #include <sys/inotify.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -71,9 +73,9 @@ using KfdProcSnapshot = std::set<std::string>;
 //=============================================================================
 // PID Namespace Detection for Container Support
 //=============================================================================
-// In containers with PID namespace isolation, fork() returns container-local
-// PIDs but KFD uses host PIDs. We detect containers and use baseline
-// comparison to find our child's host PID entry.
+// In containers with PID namespace isolation, the kernel returns
+// container-local PIDs but KFD uses host PIDs. We detect containers and
+// use baseline comparison to find our child's host PID entry.
 //
 // Shared namespace (baremetal/VM): Direct PID lookup
 // Isolated namespace (container):  Baseline diff to find new entry
@@ -428,9 +430,7 @@ bool IsInPidNamespace() {
     close(fd);
   }
 
-  // Note: Cannot log here - we're in forked child, must use only
-  // async-signal-safe functions. Write failure will cause parent
-  // to detect short read and report EIO.
+  // In child: AS-safe only, no logging. Short write -> parent sees EIO.
   static_cast<void>(write(write_fd, &result, sizeof(result)));
   close(write_fd);
   _exit(result.status ? 1 : 0);
@@ -449,9 +449,7 @@ bool IsInPidNamespace() {
       payload.results[i] = {gpu_ids[i], err, 0};
     }
     payload.count = limit;
-    // Note: Cannot log here - we're in forked child, must use only
-    // async-signal-safe functions. Write failure will cause parent
-    // to detect short read and report EIO.
+    // In child: AS-safe only, no logging. Short write -> parent sees EIO.
     static_cast<void>(write(write_fd, &payload, sizeof(payload)));
     close(write_fd);
     _exit(1);
@@ -481,9 +479,7 @@ bool IsInPidNamespace() {
   }
 
   close(fd);
-  // Note: Cannot log here - we're in forked child, must use only
-  // async-signal-safe functions. Write failure will cause parent
-  // to detect short read and report EIO.
+  // In child: AS-safe only, no logging. Short write -> parent sees EIO.
   static_cast<void>(write(write_fd, &payload, sizeof(payload)));
   close(write_fd);
   _exit(0);
@@ -508,15 +504,22 @@ void EnsureInitialized() {
   }
 }
 
-// Common fork/exec/wait logic to reduce code duplication
-struct ForkResult {
+// SIGCHLD-only clone() = fork() semantics without glibc's pthread_atfork
+// dispatch, avoiding recursion when callers invoke AMD-SMI from their own
+// atfork chain (ROCM-24163). No CLONE_VM/CLONE_VFORK: separate address space,
+// so none of vfork's shared-stack hazards apply.
+pid_t SpawnChild() {
+  return static_cast<pid_t>(syscall(SYS_clone, SIGCHLD, nullptr, nullptr, nullptr, 0));
+}
+
+struct SpawnResult {
   int err_code = 0;
   BatchIpcPayload payload{};
   bool success = false;
 };
 
-ForkResult ExecuteBatchFork(OpType op, const std::vector<uint32_t>& gpu_ids) {
-  ForkResult result;
+SpawnResult ExecuteBatchSpawn(OpType op, const std::vector<uint32_t>& gpu_ids) {
+  SpawnResult result;
 
   if (gpu_ids.empty()) {
     result.err_code = EINVAL;
@@ -524,9 +527,9 @@ ForkResult ExecuteBatchFork(OpType op, const std::vector<uint32_t>& gpu_ids) {
   }
 
   bool in_container = IsInPidNamespace();
-  KfdProcSnapshot pre_fork_snapshot;
+  KfdProcSnapshot pre_spawn_snapshot;
   if (in_container) {
-    pre_fork_snapshot = CaptureKfdProcEntries();
+    pre_spawn_snapshot = CaptureKfdProcEntries();
   }
 
   int pipe_fds[2];
@@ -538,13 +541,13 @@ ForkResult ExecuteBatchFork(OpType op, const std::vector<uint32_t>& gpu_ids) {
     return result;
   }
 
-  pid_t child_pid = fork();
+  pid_t child_pid = SpawnChild();
   if (child_pid < 0) {
     result.err_code = errno;
     close(pipe_fds[0]);
     close(pipe_fds[1]);
     std::ostringstream ss;
-    ss << __PRETTY_FUNCTION__ << " | fork failed: " << strerror(errno);
+    ss << __PRETTY_FUNCTION__ << " | clone failed: " << strerror(errno);
     LOG_ERROR(ss);
     return result;
   }
@@ -592,7 +595,7 @@ ForkResult ExecuteBatchFork(OpType op, const std::vector<uint32_t>& gpu_ids) {
     // KNOWN RACE: Another process could create a KFD entry between our
     // snapshot and detection, causing us to wait for the wrong entry.
     // This is mitigated by:
-    //   1. Narrow window (snapshot taken immediately before fork)
+    //   1. Narrow window (snapshot taken immediately before spawn)
     //   2. Bounded wait (max_cleanup_wait_ms timeout)
     //   3. Kernel cleanup (child's entry disappears when child exits)
     // Worst case: we timeout waiting for wrong entry, but our child's
@@ -600,7 +603,7 @@ ForkResult ExecuteBatchFork(OpType op, const std::vector<uint32_t>& gpu_ids) {
     if (KfdProcEntryExists(direct_entry)) {
       WaitForEntryRemoval(direct_entry, poll_ms);
     } else {
-      std::string new_entry = DetectNewKfdProcEntry(pre_fork_snapshot);
+      std::string new_entry = DetectNewKfdProcEntry(pre_spawn_snapshot);
       if (!new_entry.empty()) {
         std::ostringstream ss;
         ss << __PRETTY_FUNCTION__ << " | Container PID translation: " << child_pid << " -> "
@@ -668,9 +671,9 @@ QueryResult ExecuteIsolatedQuery(OpType op, uint32_t gpu_id) {
   EnsureInitialized();
 
   bool in_container = IsInPidNamespace();
-  KfdProcSnapshot pre_fork_snapshot;
+  KfdProcSnapshot pre_spawn_snapshot;
   if (in_container) {
-    pre_fork_snapshot = CaptureKfdProcEntries();
+    pre_spawn_snapshot = CaptureKfdProcEntries();
   }
 
   int pipe_fds[2];
@@ -681,12 +684,12 @@ QueryResult ExecuteIsolatedQuery(OpType op, uint32_t gpu_id) {
     return out;
   }
 
-  pid_t child_pid = fork();
+  pid_t child_pid = SpawnChild();
   if (child_pid < 0) {
     out.err_code = errno;
     close(pipe_fds[0]);
     close(pipe_fds[1]);
-    ss << __PRETTY_FUNCTION__ << " | fork failed: " << strerror(errno);
+    ss << __PRETTY_FUNCTION__ << " | clone failed: " << strerror(errno);
     LOG_ERROR(ss);
     return out;
   }
@@ -732,7 +735,7 @@ QueryResult ExecuteIsolatedQuery(OpType op, uint32_t gpu_id) {
     // KNOWN RACE: Another process could create a KFD entry between our
     // snapshot and detection, causing us to wait for the wrong entry.
     // This is mitigated by:
-    //   1. Narrow window (snapshot taken immediately before fork)
+    //   1. Narrow window (snapshot taken immediately before spawn)
     //   2. Bounded wait (max_cleanup_wait_ms timeout)
     //   3. Kernel cleanup (child's entry disappears when child exits)
     // Worst case: we timeout waiting for wrong entry, but our child's
@@ -740,7 +743,7 @@ QueryResult ExecuteIsolatedQuery(OpType op, uint32_t gpu_id) {
     if (KfdProcEntryExists(direct_entry)) {
       WaitForEntryRemoval(direct_entry, poll_ms);
     } else {
-      std::string new_entry = DetectNewKfdProcEntry(pre_fork_snapshot);
+      std::string new_entry = DetectNewKfdProcEntry(pre_spawn_snapshot);
       if (!new_entry.empty()) {
         ss << __PRETTY_FUNCTION__ << " | Container PID translation: " << child_pid << " -> "
            << new_entry;
@@ -775,10 +778,10 @@ QueryResult ExecuteBatchQueryCached(OpType op, const std::vector<uint32_t>& gpu_
   }
 
   // TODO(optimization): Consider adding a "single-flight" / "coalescing"
-  // pattern. This avoids redundant forks when multiple threads have
-  // concurrent cache misses.
+  // pattern. This avoids redundant child spawns when multiple threads
+  // have concurrent cache misses.
   //
-  // Current behavior: both threads fork (safe but slightly inefficient).
+  // Current behavior: both threads spawn (safe but slightly inefficient).
   // Search: "singleflight pattern", "request coalescing", "call coalescing C++"
   //         or "deduplicate concurrent requests" folly Singleton
   //
@@ -786,24 +789,24 @@ QueryResult ExecuteBatchQueryCached(OpType op, const std::vector<uint32_t>& gpu_
   // "folly Singleton" or "folly futures coalescing"
   // or "C++ promise shared future" (to see  underlying mechanism)
 
-  // Cache miss - execute batch fork for all GPUs
-  auto fork_result = ExecuteBatchFork(op, gpu_ids);
+  // Cache miss - spawn batch child for all GPUs
+  auto spawn_result = ExecuteBatchSpawn(op, gpu_ids);
 
-  // On fork/pipe failure, purge cache (system state unreliable)
-  if (!fork_result.success) {
+  // On spawn/pipe failure, purge cache (system state unreliable)
+  if (!spawn_result.success) {
     std::ostringstream ss;
-    ss << __PRETTY_FUNCTION__ << " | Fork failed (err=" << fork_result.err_code
+    ss << __PRETTY_FUNCTION__ << " | Spawn failed (err=" << spawn_result.err_code
        << "), purging cache for op=" << static_cast<uint32_t>(op);
     LOG_WARN(ss);
     GetGlobalCache().Purge(op, -1);
-    return QueryResult{fork_result.err_code, 0};
+    return QueryResult{spawn_result.err_code, 0};
   }
 
   // Store results and find target in single pass
-  auto store_result = GetGlobalCache().StoreBatch(op, fork_result.payload, target_gpu_id);
+  auto store_result = GetGlobalCache().StoreBatch(op, spawn_result.payload, target_gpu_id);
 
   std::ostringstream ss;
-  ss << __PRETTY_FUNCTION__ << " | Refreshed " << fork_result.payload.count
+  ss << __PRETTY_FUNCTION__ << " | Refreshed " << spawn_result.payload.count
      << " GPUs, target_found=" << store_result.target_found
      << ", cache_updated=" << (store_result.success ? "yes" : "no (error)");
   LOG_DEBUG(ss);

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd_data_manager.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd_data_manager.cc
@@ -26,10 +26,12 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <poll.h>
+#include <sched.h>
 #include <signal.h>
 #include <sys/inotify.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -71,9 +73,9 @@ using KfdProcSnapshot = std::set<std::string>;
 //=============================================================================
 // PID Namespace Detection for Container Support
 //=============================================================================
-// In containers with PID namespace isolation, fork() returns container-local
-// PIDs but KFD uses host PIDs. We detect containers and use baseline
-// comparison to find our child's host PID entry.
+// In containers with PID namespace isolation, the kernel returns
+// container-local PIDs but KFD uses host PIDs. We detect containers and
+// use baseline comparison to find our child's host PID entry.
 //
 // Shared namespace (baremetal/VM): Direct PID lookup
 // Isolated namespace (container):  Baseline diff to find new entry
@@ -428,9 +430,7 @@ bool IsInPidNamespace() {
     close(fd);
   }
 
-  // Note: Cannot log here - we're in forked child, must use only
-  // async-signal-safe functions. Write failure will cause parent
-  // to detect short read and report EIO.
+  // In child: AS-safe only, no logging. Short write -> parent sees EIO.
   static_cast<void>(write(write_fd, &result, sizeof(result)));
   close(write_fd);
   _exit(result.status ? 1 : 0);
@@ -449,9 +449,7 @@ bool IsInPidNamespace() {
       payload.results[i] = {gpu_ids[i], err, 0};
     }
     payload.count = limit;
-    // Note: Cannot log here - we're in forked child, must use only
-    // async-signal-safe functions. Write failure will cause parent
-    // to detect short read and report EIO.
+    // In child: AS-safe only, no logging. Short write -> parent sees EIO.
     static_cast<void>(write(write_fd, &payload, sizeof(payload)));
     close(write_fd);
     _exit(1);
@@ -481,9 +479,7 @@ bool IsInPidNamespace() {
   }
 
   close(fd);
-  // Note: Cannot log here - we're in forked child, must use only
-  // async-signal-safe functions. Write failure will cause parent
-  // to detect short read and report EIO.
+  // In child: AS-safe only, no logging. Short write -> parent sees EIO.
   static_cast<void>(write(write_fd, &payload, sizeof(payload)));
   close(write_fd);
   _exit(0);
@@ -508,15 +504,23 @@ void EnsureInitialized() {
   }
 }
 
-// Common fork/exec/wait logic to reduce code duplication
-struct ForkResult {
+// Raw clone bypasses glibc's pthread_atfork dispatch (which fork() runs),
+// avoiding recursion when callers invoke AMD-SMI from inside their own
+// atfork chain (ROCM-24163). CLONE_VM | CLONE_VFORK = vfork(2) semantics:
+// child must use only async-signal-safe calls and terminate with _exit.
+pid_t SpawnChild() {
+  return static_cast<pid_t>(
+      syscall(SYS_clone, CLONE_VM | CLONE_VFORK | SIGCHLD, nullptr, nullptr, nullptr, 0));
+}
+
+struct SpawnResult {
   int err_code = 0;
   BatchIpcPayload payload{};
   bool success = false;
 };
 
-ForkResult ExecuteBatchFork(OpType op, const std::vector<uint32_t>& gpu_ids) {
-  ForkResult result;
+SpawnResult ExecuteBatchSpawn(OpType op, const std::vector<uint32_t>& gpu_ids) {
+  SpawnResult result;
 
   if (gpu_ids.empty()) {
     result.err_code = EINVAL;
@@ -524,9 +528,9 @@ ForkResult ExecuteBatchFork(OpType op, const std::vector<uint32_t>& gpu_ids) {
   }
 
   bool in_container = IsInPidNamespace();
-  KfdProcSnapshot pre_fork_snapshot;
+  KfdProcSnapshot pre_spawn_snapshot;
   if (in_container) {
-    pre_fork_snapshot = CaptureKfdProcEntries();
+    pre_spawn_snapshot = CaptureKfdProcEntries();
   }
 
   int pipe_fds[2];
@@ -538,13 +542,13 @@ ForkResult ExecuteBatchFork(OpType op, const std::vector<uint32_t>& gpu_ids) {
     return result;
   }
 
-  pid_t child_pid = fork();
+  pid_t child_pid = SpawnChild();
   if (child_pid < 0) {
     result.err_code = errno;
     close(pipe_fds[0]);
     close(pipe_fds[1]);
     std::ostringstream ss;
-    ss << __PRETTY_FUNCTION__ << " | fork failed: " << strerror(errno);
+    ss << __PRETTY_FUNCTION__ << " | clone failed: " << strerror(errno);
     LOG_ERROR(ss);
     return result;
   }
@@ -592,7 +596,7 @@ ForkResult ExecuteBatchFork(OpType op, const std::vector<uint32_t>& gpu_ids) {
     // KNOWN RACE: Another process could create a KFD entry between our
     // snapshot and detection, causing us to wait for the wrong entry.
     // This is mitigated by:
-    //   1. Narrow window (snapshot taken immediately before fork)
+    //   1. Narrow window (snapshot taken immediately before spawn)
     //   2. Bounded wait (max_cleanup_wait_ms timeout)
     //   3. Kernel cleanup (child's entry disappears when child exits)
     // Worst case: we timeout waiting for wrong entry, but our child's
@@ -600,7 +604,7 @@ ForkResult ExecuteBatchFork(OpType op, const std::vector<uint32_t>& gpu_ids) {
     if (KfdProcEntryExists(direct_entry)) {
       WaitForEntryRemoval(direct_entry, poll_ms);
     } else {
-      std::string new_entry = DetectNewKfdProcEntry(pre_fork_snapshot);
+      std::string new_entry = DetectNewKfdProcEntry(pre_spawn_snapshot);
       if (!new_entry.empty()) {
         std::ostringstream ss;
         ss << __PRETTY_FUNCTION__ << " | Container PID translation: " << child_pid << " -> "
@@ -668,9 +672,9 @@ QueryResult ExecuteIsolatedQuery(OpType op, uint32_t gpu_id) {
   EnsureInitialized();
 
   bool in_container = IsInPidNamespace();
-  KfdProcSnapshot pre_fork_snapshot;
+  KfdProcSnapshot pre_spawn_snapshot;
   if (in_container) {
-    pre_fork_snapshot = CaptureKfdProcEntries();
+    pre_spawn_snapshot = CaptureKfdProcEntries();
   }
 
   int pipe_fds[2];
@@ -681,12 +685,12 @@ QueryResult ExecuteIsolatedQuery(OpType op, uint32_t gpu_id) {
     return out;
   }
 
-  pid_t child_pid = fork();
+  pid_t child_pid = SpawnChild();
   if (child_pid < 0) {
     out.err_code = errno;
     close(pipe_fds[0]);
     close(pipe_fds[1]);
-    ss << __PRETTY_FUNCTION__ << " | fork failed: " << strerror(errno);
+    ss << __PRETTY_FUNCTION__ << " | clone failed: " << strerror(errno);
     LOG_ERROR(ss);
     return out;
   }
@@ -732,7 +736,7 @@ QueryResult ExecuteIsolatedQuery(OpType op, uint32_t gpu_id) {
     // KNOWN RACE: Another process could create a KFD entry between our
     // snapshot and detection, causing us to wait for the wrong entry.
     // This is mitigated by:
-    //   1. Narrow window (snapshot taken immediately before fork)
+    //   1. Narrow window (snapshot taken immediately before spawn)
     //   2. Bounded wait (max_cleanup_wait_ms timeout)
     //   3. Kernel cleanup (child's entry disappears when child exits)
     // Worst case: we timeout waiting for wrong entry, but our child's
@@ -740,7 +744,7 @@ QueryResult ExecuteIsolatedQuery(OpType op, uint32_t gpu_id) {
     if (KfdProcEntryExists(direct_entry)) {
       WaitForEntryRemoval(direct_entry, poll_ms);
     } else {
-      std::string new_entry = DetectNewKfdProcEntry(pre_fork_snapshot);
+      std::string new_entry = DetectNewKfdProcEntry(pre_spawn_snapshot);
       if (!new_entry.empty()) {
         ss << __PRETTY_FUNCTION__ << " | Container PID translation: " << child_pid << " -> "
            << new_entry;
@@ -775,10 +779,10 @@ QueryResult ExecuteBatchQueryCached(OpType op, const std::vector<uint32_t>& gpu_
   }
 
   // TODO(optimization): Consider adding a "single-flight" / "coalescing"
-  // pattern. This avoids redundant forks when multiple threads have
-  // concurrent cache misses.
+  // pattern. This avoids redundant child spawns when multiple threads
+  // have concurrent cache misses.
   //
-  // Current behavior: both threads fork (safe but slightly inefficient).
+  // Current behavior: both threads spawn (safe but slightly inefficient).
   // Search: "singleflight pattern", "request coalescing", "call coalescing C++"
   //         or "deduplicate concurrent requests" folly Singleton
   //
@@ -786,24 +790,24 @@ QueryResult ExecuteBatchQueryCached(OpType op, const std::vector<uint32_t>& gpu_
   // "folly Singleton" or "folly futures coalescing"
   // or "C++ promise shared future" (to see  underlying mechanism)
 
-  // Cache miss - execute batch fork for all GPUs
-  auto fork_result = ExecuteBatchFork(op, gpu_ids);
+  // Cache miss - spawn batch child for all GPUs
+  auto spawn_result = ExecuteBatchSpawn(op, gpu_ids);
 
-  // On fork/pipe failure, purge cache (system state unreliable)
-  if (!fork_result.success) {
+  // On spawn/pipe failure, purge cache (system state unreliable)
+  if (!spawn_result.success) {
     std::ostringstream ss;
-    ss << __PRETTY_FUNCTION__ << " | Fork failed (err=" << fork_result.err_code
+    ss << __PRETTY_FUNCTION__ << " | Spawn failed (err=" << spawn_result.err_code
        << "), purging cache for op=" << static_cast<uint32_t>(op);
     LOG_WARN(ss);
     GetGlobalCache().Purge(op, -1);
-    return QueryResult{fork_result.err_code, 0};
+    return QueryResult{spawn_result.err_code, 0};
   }
 
   // Store results and find target in single pass
-  auto store_result = GetGlobalCache().StoreBatch(op, fork_result.payload, target_gpu_id);
+  auto store_result = GetGlobalCache().StoreBatch(op, spawn_result.payload, target_gpu_id);
 
   std::ostringstream ss;
-  ss << __PRETTY_FUNCTION__ << " | Refreshed " << fork_result.payload.count
+  ss << __PRETTY_FUNCTION__ << " | Refreshed " << spawn_result.payload.count
      << " GPUs, target_found=" << store_result.target_found
      << ", cache_updated=" << (store_result.success ? "yes" : "no (error)");
   LOG_DEBUG(ss);

--- a/projects/amdsmi/tests/amd_smi_test/functional/kfd_atfork_read.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/kfd_atfork_read.cc
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include "kfd_atfork_read.h"
+
+#include <gtest/gtest.h>
+#include <pthread.h>
+
+#include <atomic>
+#include <cstdint>
+#include <iostream>
+
+#include "../test_common.h"
+#include "rocm_smi/rocm_smi_kfd_data_manager.h"
+
+namespace {
+// pthread_atfork callbacks take no arguments, so the counter is file-scoped.
+std::atomic<int> g_atfork_calls{0};
+void CountAtfork() { ++g_atfork_calls; }
+}  // namespace
+
+TestKfdAtforkRead::TestKfdAtforkRead() : TestBase() {
+  set_title("KFD atfork Bypass Test");
+  set_description(
+      "Verifies the KFD VRAM helper spawns its short-lived child with clone() "
+      "rather than fork(), so a caller's pthread_atfork handlers are not "
+      "triggered (ROCM-24163). The helper is invoked directly because the "
+      "public getter only reaches it as a sysfs fallback.");
+}
+
+TestKfdAtforkRead::~TestKfdAtforkRead(void) {}
+
+void TestKfdAtforkRead::SetUp(void) { TestBase::SetUp(); }
+
+void TestKfdAtforkRead::DisplayTestInfo(void) { TestBase::DisplayTestInfo(); }
+
+void TestKfdAtforkRead::DisplayResults(void) const { TestBase::DisplayResults(); }
+
+void TestKfdAtforkRead::Close() { TestBase::Close(); }
+
+void TestKfdAtforkRead::Run(void) {
+  TestBase::Run();
+  PRINT_VERBOSITY();
+  if (setup_failed_) {
+    std::cout << "** SetUp Failed for this test. Skipping.**" << std::endl;
+    return;
+  }
+
+  // Register once; atfork handlers persist process-wide.
+  static const int reg = pthread_atfork(CountAtfork, CountAtfork, CountAtfork);
+  ASSERT_EQ(reg, 0);
+
+  // ExecuteIsolatedQuery always spawns a child, so the gpu_id need not be valid
+  // for the spawn (and thus the atfork check) to be exercised.
+  for (uint32_t i = 0; i < num_monitor_devs(); ++i) {
+    PrintDeviceHeader(processor_handles_[i]);
+
+    g_atfork_calls = 0;  // measure only this spawn's effect
+    uint64_t available = 0;
+    (void)amd::smi::kfd::QueryAvailableVram(i, &available);
+
+    EXPECT_EQ(g_atfork_calls.load(), 0)
+        << "KFD VRAM helper fired pthread_atfork handlers on gpu=" << i
+        << " (expected clone(), got fork())";
+  }
+}

--- a/projects/amdsmi/tests/amd_smi_test/functional/kfd_atfork_read.h
+++ b/projects/amdsmi/tests/amd_smi_test/functional/kfd_atfork_read.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TESTS_AMD_SMI_TEST_FUNCTIONAL_KFD_ATFORK_READ_H_
+#define TESTS_AMD_SMI_TEST_FUNCTIONAL_KFD_ATFORK_READ_H_
+
+#include "../test_base.h"
+
+// Verifies that querying GPU memory usage does not trigger a caller's
+// pthread_atfork handlers. The KFD VRAM helper spawns a short-lived child via
+// clone() rather than fork() specifically to bypass glibc's atfork dispatch,
+// which can recurse/deadlock when AMD-SMI is called from an atfork chain
+// (ROCM-24163). A regression to fork() would fire the handlers below.
+class TestKfdAtforkRead : public TestBase {
+ public:
+  TestKfdAtforkRead();
+
+  virtual ~TestKfdAtforkRead();
+
+  virtual void SetUp();
+
+  virtual void Run();
+
+  virtual void Close();
+
+  virtual void DisplayResults() const;
+
+  virtual void DisplayTestInfo(void);
+};
+
+#endif  // TESTS_AMD_SMI_TEST_FUNCTIONAL_KFD_ATFORK_READ_H_

--- a/projects/amdsmi/tests/amd_smi_test/main.cc
+++ b/projects/amdsmi/tests/amd_smi_test/main.cc
@@ -38,6 +38,7 @@
 #include "functional/gpu_partition_metrics_read.h"
 #include "functional/hw_topology_read.h"
 #include "functional/id_info_read.h"
+#include "functional/kfd_atfork_read.h"
 #include "functional/mem_page_info_read.h"
 #include "functional/mem_util_read.h"
 #include "functional/memory_read_write.h"
@@ -223,6 +224,11 @@ TEST(amdsmitstReadOnly, TestErrCntRead) {
 
 TEST(amdsmitstReadOnly, TestMemUtilRead) {
   TestMemUtilRead tst;
+  RunGenericTest(&tst);
+}
+
+TEST(amdsmitstReadOnly, TestKfdAtforkRead) {
+  TestKfdAtforkRead tst;
   RunGenericTest(&tst);
 }
 


### PR DESCRIPTION
Some programs register their own pthread_atfork handlers, which gets triggered when amdsmi forks. It's surprising that amdsmi forks when we call a getter `amdsmi_get_gpu_memory_usage`

Use clone to bypass the issue entirely.

Consumer side fix <https://github.com/ROCm/rocm-systems/pull/5590>

## JIRA ID

Resolves ROCM-24163

## Test Plan

Run `ctest -R "preset*|domain*" --output-on-failure` on a machine that triggers this path.
i.e. MI300A

## Test Result

TODO
