### PR TITLE
[rocprofiler-compute] Clean up gfx1151 dual-issue VALU follow-up

### DIFF
--- a/projects/rocprofiler-compute/docs/conceptual/rdna/system-speed-of-light.rst
+++ b/projects/rocprofiler-compute/docs/conceptual/rdna/system-speed-of-light.rst
@@ -85,8 +85,8 @@ per cycle, multiplied by instance count and clock). They are not anchored to a
 single public RDNA 3.5 table, so the percentage of peak reported for these
 rows is indicative rather than exact.
 
-For context, the memory hierarchy is GL0 (TCP), then GL1, then GL2, then
-system memory through GCEA.
+For context, the memory hierarchy is GL0 (TCP Cache), then GL1, then GL2, then
+system memory through GCEA and Data Fabric.
 
 .. Note::
    For AMD Instinct accelerators (CDNA-CDNA4), see

--- a/projects/rocprofiler-compute/docs/conceptual/rdna/system-speed-of-light.rst
+++ b/projects/rocprofiler-compute/docs/conceptual/rdna/system-speed-of-light.rst
@@ -14,57 +14,79 @@ shipped gfx1151 analysis configuration.
 metrics for how your workload is performing on the target GPU, so you can spot
 bottlenecks before diving into block-specific panels.
 
-VALU FLOPs rows use aggregate VALU instruction counters (they include FP16, FP32,
-and FP64). WMMA follows a separate ISA path and is not broken out in this panel.
+The VALU FLOPs rows use aggregate VALU instruction counters, which include FP16,
+FP32, and FP64 contributions together. WMMA instructions follow a separate ISA
+path and are not broken out in this panel.
 
 Wavefronts and FLOPs accounting
---------------------------------
+-------------------------------
 
-RDNA 3.5 supports both Wave32 (typical primary mode) and Wave64 wavefronts;
-wavefront size is fixed per kernel at compile time. The profiler's ``$wave_size``
-depends on the hardware architecture (i.e., ``rocminfo``), while the executing kernel
-may use a different size—treat peaks as an approximation when those differ. VALU FLOPs
-in this panel scale roughly as ``wave_size * SQ_INSTS_VALU_sum / time``.
+RDNA 3.5 supports both Wave32 (the typical primary mode) and Wave64 wavefronts.
+The wavefront size is fixed per kernel at compile time. The profiler reads
+``$wave_size`` from the hardware specs reported by ``rocminfo``, but a given
+kernel may have been compiled for the other size. When that happens, treat the
+peak rates here as approximations. The VALU FLOPs row in this panel scales as
+``wave_size * SQ_INSTS_VALU_sum / time``.
 
-Peak theoretical VALU rates (per CU, before multiplying by CU count and clock)
----------------------------------------------------------------------------------
+.. _rdna-dual-issue-valu:
 
-These ceilings explain how POP (% of peak) is anchored for FLOPs-oriented rows:
+Dual-issue VALU (VOPD)
+----------------------
 
-* FP32 FMA, single-issue: 128 FLOPs/CU/cycle — two SIMD32 lanes per CU
-  (``$simd_per_cu``), Wave32 (``$wave_size`` 32), times two for FMA.
-* FP32 VOPD dual-issue: 256 FLOPs/CU/cycle (paired dual-VALU ops such as
-  ``V_DUAL_ADD_F32`` / ``V_DUAL_MUL_F32``).
-* FP16 packed FMA, single-issue: 256 FLOPs/CU/cycle (packed half-rate vs FP32).
-* FP16 packed VOPD dual-issue: 512 FLOPs/CU/cycle (dual-issue packed half ops).
-* FP64 FMA: 4 FLOPs/CU/cycle — 1/32 of the FP32 single-issue FMA rate on RDNA.
-* Mixed FP32 single-issue plus FP16 packed dual-issue (illustrative ceiling):
+RDNA 3 and RDNA 3.5 add a dual-issue path to the VALU. A pair of independent
+VALU operations can be encoded into a single instruction and issued together in
+the same cycle. The RDNA ISA refers to this encoding as **VOPD**. Hardware
+accepts the pairing only when register, opcode, and operand constraints are
+satisfied, and the compiler emits VOPD when those constraints hold.
+
+When dual-issue runs successfully, peak VALU throughput per CU per cycle
+doubles relative to single-issue: FP32 from 128 to 256 FLOPs/CU/cycle, and
+packed FP16 from 256 to 512 FLOPs/CU/cycle.
+
+The aggregate ``VALU FLOPs`` row in this panel uses the FP32 single-issue FMA
+ceiling (128 FLOPs/CU/cycle) as the peak. A workload that issues VOPD heavily,
+or that runs packed FP16, can therefore report a percentage of peak above
+100%. To gauge how much of the throughput is coming from VOPD, inspect the
+``Instructions - Dual VALU (VOPD)`` row on the :doc:`wgp` panel, which counts
+``SQ_INSTS_DUAL_VALU_WAVE32``.
+
+Peak theoretical VALU rates
+---------------------------
+
+The values below are per CU, before multiplying by the CU count and the shader
+clock. They anchor the percentage of peak reported for the FLOPs related rows.
+
+* FP32 FMA, single-issue: 128 FLOPs/CU/cycle. Two SIMD32 lanes per CU
+  (``$simd_per_cu``), Wave32 (``$wave_size`` 32), multiplied by two for FMA.
+* FP32 VOPD dual-issue: 256 FLOPs/CU/cycle. Paired dual-VALU instructions such
+  as ``V_DUAL_ADD_F32`` and ``V_DUAL_MUL_F32``.
+* FP16 packed FMA, single-issue: 256 FLOPs/CU/cycle. Packed FP16 runs at twice
+  the FP32 rate.
+* FP16 packed VOPD dual-issue: 512 FLOPs/CU/cycle. Dual-issue packed FP16
+  pairings.
+* FP64 FMA: 4 FLOPs/CU/cycle. RDNA 3.5 runs FP64 FMA at 1/32 of the FP32
+  single-issue FMA rate.
+* Mixed FP32 single-issue with FP16 packed dual-issue (illustrative ceiling):
   about 384 FLOPs/CU/cycle combined (128 + 256).
 
 Scaling and clocks
 ------------------
 
-``$cu_per_gpu`` is the total CU count from system info, not WGP count. On RDNA 3.5,
-each WGP pairs two CUs, so CU count is approximately twice the WGP count; peak
-FLOPs scale with CUs. ``$max_sclk`` is the shader/engine clock in MHz from profiler
-system specs.
+``$cu_per_gpu`` is the total Compute Unit count from system info, not the WGP
+count. On RDNA 3.5 each WGP pairs two CUs, so the CU count is about twice the
+WGP count, and peak FLOPs scale with the CU count. ``$max_sclk`` is the shader
+engine clock in MHz from system info.
 
-Bandwidth and cache POP rows
-----------------------------
+Bandwidth and cache rows
+------------------------
 
-TCP, GL1, GL2, and SQC throughput POP values use heuristic ceilings (bytes per
-cycle * instance count * clock). They are not tied to a single public RDNA 3.5 table—
-treat Pct of Peak as indicative, not exact.
+The throughput rows for TCP, GL1, GL2, and SQC use heuristic ceilings (bytes
+per cycle, multiplied by instance count and clock). They are not anchored to a
+single public RDNA 3.5 table, so the percentage of peak reported for these
+rows is indicative rather than exact.
 
-Memory hierarchy (for context): GL0 (TCP) → GL1 → GL2 → system memory (GCEA).
-
-.. tip::
-
-   If Pct of Peak for VALU FLOPs goes above 100%, the assumed peak likely underestimates
-   achievable throughput—for example when the kernel uses VOPD dual-issue or heavy packed
-   FP16 instead of the single-issue FP32 FMA baseline. Inspect the ``Instructions - Dual VALU (VOPD)``
-   metric on the :doc:`wgp` panel (counter ``SQ_INSTS_DUAL_VALU_WAVE32``) to gauge dual-issue
-   activity and interpret POP accordingly.
+For context, the memory hierarchy is GL0 (TCP), then GL1, then GL2, then
+system memory through GCEA.
 
 .. Note::
    For AMD Instinct accelerators (CDNA-CDNA4), see

--- a/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
+++ b/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
@@ -9,7 +9,7 @@ System Speed-of-Light:
     rst: 'Instructions executed per cycle, measuring overall instruction throughput efficiency. Higher IPC indicates better utilization of the shader pipeline. Low IPC may indicate stalls due to memory latency, register dependencies, or insufficient wavefront occupancy to hide latencies.'
     unit: Instr/cycle
   Wavefront Occupancy:
-    rst: 'Average number of wavefronts resident on the GPU during kernel execution. Higher occupancy provides more opportunities to hide memory latency through wavefront switching. However, maximum occupancy is not always optimal-excessive register or LDS usage per wavefront may limit occupancy.'
+    rst: 'Average number of wavefronts resident on the GPU during kernel execution. Higher occupancy provides more opportunities to hide memory latency through wavefront switching. However, maximum occupancy is not always optimal; excessive register or LDS usage per wavefront may limit occupancy.'
     unit: Wavefronts
   GL2 Cache Hit Rate:
     rst: 'Percentage of GL2 cache requests that are serviced from cache without accessing system memory. Higher hit rates reduce memory bandwidth pressure and improve performance. Low hit rates may indicate poor data locality or working sets that exceed cache capacity.'

--- a/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
+++ b/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
@@ -9,7 +9,7 @@ System Speed-of-Light:
     rst: 'Instructions executed per cycle, measuring overall instruction throughput efficiency. Higher IPC indicates better utilization of the shader pipeline. Low IPC may indicate stalls due to memory latency, register dependencies, or insufficient wavefront occupancy to hide latencies.'
     unit: Instr/cycle
   Wavefront Occupancy:
-    rst: 'Average number of wavefronts resident on the GPU during kernel execution. Higher occupancy provides more opportunities to hide memory latency through wavefront switching. However, maximum occupancy is not always optimal; excessive register or LDS usage per wavefront may limit occupancy.'
+    rst: 'Average number of wavefronts resident on the GPU during kernel execution. Higher occupancy provides more opportunities to hide memory latency through wavefront switching. However, maximum occupancy is not always optimal. Excessive register or LDS usage per wavefront may limit occupancy.'
     unit: Wavefronts
   GL2 Cache Hit Rate:
     rst: 'Percentage of GL2 cache requests that are serviced from cache without accessing system memory. Higher hit rates reduce memory bandwidth pressure and improve performance. Low hit rates may indicate poor data locality or working sets that exceed cache capacity.'

--- a/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
+++ b/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
@@ -9,7 +9,7 @@ System Speed-of-Light:
     rst: 'Instructions executed per cycle, measuring overall instruction throughput efficiency. Higher IPC indicates better utilization of the shader pipeline. Low IPC may indicate stalls due to memory latency, register dependencies, or insufficient wavefront occupancy to hide latencies.'
     unit: Instr/cycle
   Wavefront Occupancy:
-    rst: 'Average number of wavefronts resident on the GPU during kernel execution. Higher occupancy provides more opportunities to hide memory latency through wavefront switching. However, maximum occupancy is not always optimal—excessive register or LDS usage per wavefront may limit occupancy.'
+    rst: 'Average number of wavefronts resident on the GPU during kernel execution. Higher occupancy provides more opportunities to hide memory latency through wavefront switching. However, maximum occupancy is not always optimal-excessive register or LDS usage per wavefront may limit occupancy.'
     unit: Wavefronts
   GL2 Cache Hit Rate:
     rst: 'Percentage of GL2 cache requests that are serviced from cache without accessing system memory. Higher hit rates reduce memory bandwidth pressure and improve performance. Low hit rates may indicate poor data locality or working sets that exceed cache capacity.'
@@ -274,7 +274,7 @@ Wave Instruction Mix:
     rst: 'Total number of instructions executed across all wavefronts. This provides an overall measure of computational work. Compare with specific instruction types to understand the workload characteristics.'
     unit: Count per Normalization Unit
   Instructions - Internal:
-    rst: 'Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit — bookkeeping or non-user-visible work attributed to the scheduler.'
+    rst: 'Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit. These represent bookkeeping or non-user-visible work issued by the SQ.'
     unit: Count per Normalization Unit
   Instructions - VALU:
     rst: 'Number of Vector ALU instructions executed. VALU handles arithmetic and logic operations across all work-items in a wavefront. High VALU counts indicate compute-intensive kernels.'
@@ -286,10 +286,10 @@ Wave Instruction Mix:
     rst: 'Number of scalar memory instructions executed. SMEM loads constant and uniform data through the scalar cache. High counts may indicate heavy use of constant buffers or kernel arguments.'
     unit: Count per Normalization Unit
   Instructions - Transcendental:
-    rst: 'Transcendental VALU instructions (SQ_INSTS_VALU_TRANS), per normalization unit — e.g. sin/cos/log approximations on the vector ALU.'
+    rst: 'Transcendental VALU instructions (SQ_INSTS_VALU_TRANS) per normalization unit. These cover hardware approximations such as sin, cos, and log on the vector ALU.'
     unit: Count per Normalization Unit
   Instructions - Dual VALU (VOPD):
-    rst: 'Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum), per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip interface); emulated counter.'
+    rst: 'Dual-issue VALU instructions executed in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32) per normalization unit. The VOPD encoding pairs two independent VALU operations that issue in the same cycle.'
     unit: Count per Normalization Unit
   Instructions - VMEM:
     rst: 'Number of vector memory instructions executed, including global, buffer, and texture operations. High VMEM counts relative to VALU may indicate memory-bound workloads.'

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0200_system_speed_of_light.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0200_system_speed_of_light.yaml
@@ -167,8 +167,8 @@ Panel Config:
     Wavefront Occupancy: >-
       Average number of wavefronts resident on the GPU during kernel execution. Higher
       occupancy provides more opportunities to hide memory latency through wavefront
-      switching. However, maximum occupancy is not always optimal-excessive register or
-      LDS usage per wavefront may limit occupancy.
+      switching. However, maximum occupancy is not always optimal. Excessive register
+      or LDS usage per wavefront may limit occupancy.
     GL2 Cache Hit Rate: >-
       Percentage of GL2 cache requests that are serviced from cache without accessing
       system memory. Higher hit rates reduce memory bandwidth pressure and improve

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0700_workgroup_processor.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0700_workgroup_processor.yaml
@@ -326,8 +326,8 @@ Panel Config:
       overall measure of computational work. Compare with specific instruction types
       to understand the workload characteristics.
     Instructions - Internal: >-
-      Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit — bookkeeping
-      or non-user-visible work attributed to the scheduler.
+      Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit. These
+      represent bookkeeping or non-user-visible work issued by the SQ.
     Instructions - VALU: >-
       Number of Vector ALU instructions executed. VALU handles arithmetic and logic
       operations across all work-items in a wavefront. High VALU counts indicate
@@ -341,12 +341,13 @@ Panel Config:
       data through the scalar cache. High counts may indicate heavy use of constant
       buffers or kernel arguments.
     Instructions - Transcendental: >-
-      Transcendental VALU instructions (SQ_INSTS_VALU_TRANS), per normalization unit —
-      e.g. sin/cos/log approximations on the vector ALU.
+      Transcendental VALU instructions (SQ_INSTS_VALU_TRANS) per normalization unit.
+      These cover hardware approximations such as sin, cos, and log on the vector
+      ALU.
     Instructions - Dual VALU (VOPD): >-
-      Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum),
-      per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip
-      interface); emulated counter.
+      Dual-issue VALU instructions executed in wave32 mode
+      (SQ_INSTS_DUAL_VALU_WAVE32) per normalization unit. The VOPD encoding pairs
+      two independent VALU operations that issue in the same cycle.
     Instructions - VMEM: >-
       Number of vector memory instructions executed, including global, buffer, and
       texture operations. High VMEM counts relative to VALU may indicate memory-bound

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/sdk_config.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/sdk_config.yaml
@@ -2552,8 +2552,7 @@ rocprofiler-sdk:
       block: SQ
       event: 173
   - name: SQ_INSTS_DUAL_VALU_WAVE32
-    description: >-
-      Number of dual VALU (VOPD) instructions issued in wave32 mode. {emulated} Matches SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 in Strix2 chip interface public RAI.
+    description: The number of dual-issue VALU (VOPD) instructions issued in Wave32 mode.
     properties: []
     definitions:
     - architectures:
@@ -4052,7 +4051,7 @@ rocprofiler-sdk:
       - gfx1152
       expression: reduce(SQ_INSTS_WAVE32_LDS_PARAM_LOAD,sum)
   - name: SQ_INSTS_DUAL_VALU_WAVE32_sum
-    description: sum of SQ INSTS DUAL VALU WAVE32.
+    description: ''
     properties: []
     definitions:
     - architectures:

--- a/projects/rocprofiler-compute/src/utils/.config_hashes.json
+++ b/projects/rocprofiler-compute/src/utils/.config_hashes.json
@@ -5,7 +5,7 @@
       "files": {
         "0000_top_stats.yaml": "e20b23bcf3d5d5f4d1fb30cb171850f3",
         "0100_system_info.yaml": "5bee16deca4a0b880af47a002fa7bab9",
-        "0200_system_speed_of_light.yaml": "1a4ee76f5773cb8687762d1e7f82e43a",
+        "0200_system_speed_of_light.yaml": "8a3b9c67a01ce54f7f3c62436a63c02f",
         "0300_memory_chart.yaml": "3ea467a5cdd48bd7a20ec0c94304e7a9",
         "0400_roofline.yaml": "17b62eb17edee43abd833576a7c142a4",
         "0500_command_processor_cpc.yaml": "9de95259d153357dde907a7a410aa1a3",

--- a/projects/rocprofiler-compute/src/utils/.config_hashes.json
+++ b/projects/rocprofiler-compute/src/utils/.config_hashes.json
@@ -10,7 +10,7 @@
         "0400_roofline.yaml": "17b62eb17edee43abd833576a7c142a4",
         "0500_command_processor_cpc.yaml": "9de95259d153357dde907a7a410aa1a3",
         "0600_workgroup_manager_spi.yaml": "e0fb474a8a5e97cf26467578f7b5c316",
-        "0700_workgroup_processor.yaml": "a52ba91ec25dee5d1884b74a827513a2",
+        "0700_workgroup_processor.yaml": "40dd2cfd8753fcc3ad0d543327594d93",
         "0900_l0_cache.yaml": "1cbfbc0badeed8ec0caa178faec2f231",
         "1100_l1_cache.yaml": "7403eeb9b47f69f73cf42eccb984cdf7",
         "1300_l2_cache.yaml": "dd34f4b6cbdbb8afbafa059b58ba9839",

--- a/projects/rocprofiler-compute/tests/test_autogen_config.py
+++ b/projects/rocprofiler-compute/tests/test_autogen_config.py
@@ -10,7 +10,6 @@ import pytest
 
 HASH_DB = Path(common.SRC) / "utils/.config_hashes.json"
 ANALYSIS_CONFIGS = Path(common.SRC) / "rocprof_compute_soc/analysis_configs"
-REPO_ROOT = Path(common.ROOT)
 
 
 def md5(path: Path) -> str:
@@ -91,32 +90,3 @@ def test_config_hashes_match_files() -> None:
 
     if failures:
         pytest.fail("Hash consistency failures:\n\n" + "\n".join(failures))
-
-
-def test_metric_description_hashes_match_files() -> None:
-    """Tracked metric-description artifacts (per-arch YAML + generated docs)."""
-    assert HASH_DB.exists(), f"Missing hash DB: {HASH_DB}"
-
-    with HASH_DB.open() as f:
-        data = json.load(f)
-
-    tracked = data.get("metric_descriptions") or {}
-    if not tracked:
-        return
-
-    failures: list[str] = []
-    for rel_path, expected_hash in tracked.items():
-        artifact_path = REPO_ROOT / rel_path
-        if not artifact_path.exists():
-            failures.append(f"Missing metric description file: {artifact_path}")
-            continue
-        actual_hash = md5(artifact_path)
-        if actual_hash != expected_hash:
-            failures.append(
-                f"Metric description hash mismatch: {artifact_path}\n"
-                f"  expected: {expected_hash}\n"
-                f"  actual:   {actual_hash}"
-            )
-
-    if failures:
-        pytest.fail("Metric description hash failures:\n\n" + "\n".join(failures))

--- a/projects/rocprofiler-compute/tools/config_management/README.md
+++ b/projects/rocprofiler-compute/tools/config_management/README.md
@@ -300,17 +300,10 @@ python tools/config_management/metric_description_manager.py --sync-all src/rocp
 python tools/config_management/metric_description_manager.py --generate-docs
 ```
 
-To regenerate **only selected** docs metrics (for example gfx1151 without rewriting CDNA YAMLs):
+To regenerate the docs YAML for a single architecture without rewriting the others (for example, gfx1151 only):
 
 ```bash
 python tools/config_management/metric_description_manager.py --generate-docs --docs-arch gfx1151
 ```
 
-Then refresh **MD5 entries** under `metric_descriptions` in `src/utils/.config_hashes.json` for:
-
-- `tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml`
-- `docs/data/metrics/gfx1151_metrics.yaml`
-
-(`tests/test_autogen_config.py::test_metric_description_hashes_match_files` enforces these when present.)
-
-**RST enhancement:** Edit per-arch YAMLs directly. Framework preserves manual edits (detects when `rst != plain`).
+**Manual RST edits:** Edit per-arch YAMLs directly. The framework preserves an edit when its `rst` differs from `plain`.

--- a/projects/rocprofiler-compute/tools/config_management/hash_manager.py
+++ b/projects/rocprofiler-compute/tools/config_management/hash_manager.py
@@ -72,6 +72,7 @@ def save_hash_db(hash_file: Path, data: dict) -> None:
     hash_path.parent.mkdir(parents=True, exist_ok=True)
     with open(hash_path, "w") as f:
         json.dump(data, f, indent=2, sort_keys=True)
+        f.write("\n")
 
 
 def detect_changes(configs_dir: Path, hash_file: Path) -> dict:

--- a/projects/rocprofiler-compute/tools/config_management/metric_description_manager.py
+++ b/projects/rocprofiler-compute/tools/config_management/metric_description_manager.py
@@ -557,7 +557,7 @@ def main() -> int:
     parser.add_argument(
         "--sync-arch",
         metavar="ARCH",
-        help="Sync descriptions for specific architecture",
+        help="Sync descriptions for a single architecture",
     )
     parser.add_argument(
         "--sync-all",
@@ -567,7 +567,7 @@ def main() -> int:
     parser.add_argument(
         "--validate",
         metavar="ARCH",
-        help="Validate descriptions for specific architecture",
+        help="Validate descriptions for a single architecture",
     )
     parser.add_argument(
         "--generate-docs",
@@ -580,28 +580,44 @@ def main() -> int:
         metavar="ARCH",
         dest="docs_archs",
         help=(
-            "With --generate-docs, only emit docs for these architectures "
-            "(repeatable). Default: all per-arch *_metrics_description.yaml files."
+            "Restrict --generate-docs to one or more architectures "
+            "(repeatable). Defaults to every per-arch description file."
         ),
     )
     parser.add_argument(
-        "configs_dir", nargs="?", help="Path to analysis_configs directory"
+        "configs_dir", nargs="?", help="Path to the analysis_configs directory"
     )
     parser.add_argument(
         "--per-arch-output",
         default="tools/per_arch_metric_definitions",
-        help="Output directory for per-arch files",
+        help="Output directory for the per-arch description YAMLs",
     )
     parser.add_argument(
         "--docs-output-dir",
         default="docs/data/metrics",
-        help="Output directory for per-arch docs files",
+        help="Output directory for the generated docs YAMLs",
     )
 
     args = parser.parse_args()
 
+    if args.docs_archs and not args.generate_docs:
+        print("Error: --docs-arch requires --generate-docs")
+        return 1
+
     if args.generate_docs:
-        target_archs = args.docs_archs if args.docs_archs else None
+        available_archs = set(resolved_docs_target_archs(args.per_arch_output))
+        if args.docs_archs:
+            unknown = sorted(set(args.docs_archs) - available_archs)
+            if unknown:
+                print(
+                    "Error: --docs-arch values are not in the docs target set "
+                    f"(available: {', '.join(sorted(available_archs))}): "
+                    f"{', '.join(unknown)}"
+                )
+                return 1
+            target_archs = args.docs_archs
+        else:
+            target_archs = None
         ok = generate_docs_from_per_arch(
             args.per_arch_output, args.docs_output_dir, target_archs
         )

--- a/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml
+++ b/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml
@@ -12,8 +12,8 @@ System Speed-of-Light:
     rst: Instructions executed per cycle, measuring overall instruction throughput efficiency. Higher IPC indicates better utilization of the shader pipeline. Low IPC may indicate stalls due to memory latency, register dependencies, or insufficient wavefront occupancy to hide latencies.
     unit: Instr/cycle
   Wavefront Occupancy:
-    plain: Average number of wavefronts resident on the GPU during kernel execution. Higher occupancy provides more opportunities to hide memory latency through wavefront switching. However, maximum occupancy is not always optimal—excessive register or LDS usage per wavefront may limit occupancy.
-    rst: Average number of wavefronts resident on the GPU during kernel execution. Higher occupancy provides more opportunities to hide memory latency through wavefront switching. However, maximum occupancy is not always optimal—excessive register or LDS usage per wavefront may limit occupancy.
+    plain: Average number of wavefronts resident on the GPU during kernel execution. Higher occupancy provides more opportunities to hide memory latency through wavefront switching. However, maximum occupancy is not always optimal-excessive register or LDS usage per wavefront may limit occupancy.
+    rst: Average number of wavefronts resident on the GPU during kernel execution. Higher occupancy provides more opportunities to hide memory latency through wavefront switching. However, maximum occupancy is not always optimal-excessive register or LDS usage per wavefront may limit occupancy.
     unit: Wavefronts
   GL2 Cache Hit Rate:
     plain: Percentage of GL2 cache requests that are serviced from cache without accessing system memory. Higher hit rates reduce memory bandwidth pressure and improve performance. Low hit rates may indicate poor data locality or working sets that exceed cache capacity.
@@ -359,8 +359,8 @@ Wave Instruction Mix:
     rst: Total number of instructions executed across all wavefronts. This provides an overall measure of computational work. Compare with specific instruction types to understand the workload characteristics.
     unit: Count per Normalization Unit
   Instructions - Internal:
-    plain: Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit — bookkeeping or non-user-visible work attributed to the scheduler.
-    rst: Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit — bookkeeping or non-user-visible work attributed to the scheduler.
+    plain: Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit. These represent bookkeeping or non-user-visible work issued by the SQ.
+    rst: Internal SQ instructions (SQ_INSTS_INTERNAL) per normalization unit. These represent bookkeeping or non-user-visible work issued by the SQ.
     unit: Count per Normalization Unit
   Instructions - VALU:
     plain: Number of Vector ALU instructions executed. VALU handles arithmetic and logic operations across all work-items in a wavefront. High VALU counts indicate compute-intensive kernels.
@@ -375,12 +375,12 @@ Wave Instruction Mix:
     rst: Number of scalar memory instructions executed. SMEM loads constant and uniform data through the scalar cache. High counts may indicate heavy use of constant buffers or kernel arguments.
     unit: Count per Normalization Unit
   Instructions - Transcendental:
-    plain: Transcendental VALU instructions (SQ_INSTS_VALU_TRANS), per normalization unit — e.g. sin/cos/log approximations on the vector ALU.
-    rst: Transcendental VALU instructions (SQ_INSTS_VALU_TRANS), per normalization unit — e.g. sin/cos/log approximations on the vector ALU.
+    plain: Transcendental VALU instructions (SQ_INSTS_VALU_TRANS) per normalization unit. These cover hardware approximations such as sin, cos, and log on the vector ALU.
+    rst: Transcendental VALU instructions (SQ_INSTS_VALU_TRANS) per normalization unit. These cover hardware approximations such as sin, cos, and log on the vector ALU.
     unit: Count per Normalization Unit
   Instructions - Dual VALU (VOPD):
-    plain: Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum), per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip interface); emulated counter.
-    rst: Dual-issue VALU (VOPD) instructions issued in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32_sum), per normalization unit. Hardware perf select SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 (Strix2 chip interface); emulated counter.
+    plain: Dual-issue VALU instructions executed in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32) per normalization unit. The VOPD encoding pairs two independent VALU operations that issue in the same cycle.
+    rst: Dual-issue VALU instructions executed in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32) per normalization unit. The VOPD encoding pairs two independent VALU operations that issue in the same cycle.
     unit: Count per Normalization Unit
   Instructions - VMEM:
     plain: Number of vector memory instructions executed, including global, buffer, and texture operations. High VMEM counts relative to VALU may indicate memory-bound workloads.

--- a/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml
+++ b/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml
@@ -12,8 +12,8 @@ System Speed-of-Light:
     rst: Instructions executed per cycle, measuring overall instruction throughput efficiency. Higher IPC indicates better utilization of the shader pipeline. Low IPC may indicate stalls due to memory latency, register dependencies, or insufficient wavefront occupancy to hide latencies.
     unit: Instr/cycle
   Wavefront Occupancy:
-    plain: Average number of wavefronts resident on the GPU during kernel execution. Higher occupancy provides more opportunities to hide memory latency through wavefront switching. However, maximum occupancy is not always optimal-excessive register or LDS usage per wavefront may limit occupancy.
-    rst: Average number of wavefronts resident on the GPU during kernel execution. Higher occupancy provides more opportunities to hide memory latency through wavefront switching. However, maximum occupancy is not always optimal-excessive register or LDS usage per wavefront may limit occupancy.
+    plain: Average number of wavefronts resident on the GPU during kernel execution. Higher occupancy provides more opportunities to hide memory latency through wavefront switching. However, maximum occupancy is not always optimal. Excessive register or LDS usage per wavefront may limit occupancy.
+    rst: Average number of wavefronts resident on the GPU during kernel execution. Higher occupancy provides more opportunities to hide memory latency through wavefront switching. However, maximum occupancy is not always optimal. Excessive register or LDS usage per wavefront may limit occupancy.
     unit: Wavefronts
   GL2 Cache Hit Rate:
     plain: Percentage of GL2 cache requests that are serviced from cache without accessing system memory. Higher hit rates reduce memory bandwidth pressure and improve performance. Low hit rates may indicate poor data locality or working sets that exceed cache capacity.


### PR DESCRIPTION
## Motivation

Follow-up to #5872. Several flaws were merged into the 7.14 dev branch; this PR fixes them in place rather than reverting.

Bugfix: the hash database now ends with a trailing newline (pre-commit enforces this), and the recorded hash for `0700_workgroup_processor.yaml` is corrected to match the actual file.

## Technical Details

- `docs/conceptual/rdna/system-speed-of-light.rst`: rewrite the new prose without em dashes, fix underline lengths, qualify the FP64 ratio to RDNA 3.5, promote the dual-issue `tip` into a `Dual-issue VALU (VOPD)` section with stable label `_rdna-dual-issue-valu:`, and introduce VOPD with a one-paragraph explanation before its first use.

- `src/rocprof_compute_soc/analysis_configs/gfx1151/0700_workgroup_processor.yaml`: clean up `Instructions - Internal`, `Instructions - Transcendental`, and `Instructions - Dual VALU (VOPD)` descriptions in the panel YAML (the source of truth). The framework propagates the new text to the per-arch YAML and docs YAML.

- `src/rocprof_compute_soc/profile_configs/sdk_config.yaml`: tighten `SQ_INSTS_DUAL_VALU_WAVE32` and its `_sum` entries; drop internal jargon ("Strix2 chip interface", "emulated counter").

- `tools/config_management/metric_description_manager.py`: harden `--docs-arch` (validate archs against `resolved_docs_target_archs()`, reject unknown/excluded names with a non-zero exit, reject `--docs-arch` without `--generate-docs`). Grammar pass on argparse help.

- `tools/config_management/hash_manager.py`: `save_hash_db` now writes a trailing newline so output matches the project's pre-commit expectation.

- `tools/config_management/README.md`: grammar pass on the `Metric Descriptions` section.

- `tests/test_autogen_config.py`: drop `test_metric_description_hashes_match_files`. It was added in #5872 but no `metric_descriptions` entries were ever populated to enforce.

- `src/utils/.config_hashes.json`: regenerated via `hash_manager --update gfx1151`. The recorded hash for `0700_workgroup_processor.yaml` now matches the actual file.

Side-effect noted while regenerating: the PR-merged `docs/data/metrics/gfx1151_metrics.yaml` had `Internal` / `Transcendental` rows dangling at the bottom of `Wave Instruction Mix` because the "align with counter order" commit (#5872 commit `c95e91b9`) only updated the panel and per-arch YAMLs. Re-running `--sync-arch gfx1151` and `--generate-docs --docs-arch gfx1151` propagates the panel order into the docs YAML.

## JIRA ID

## Test Plan

- `pytest projects/rocprofiler-compute/tests/test_autogen_config.py`
- `python tools/config_management/metric_description_manager.py --sync-arch gfx1151 src/rocprof_compute_soc/analysis_configs && python tools/config_management/metric_description_manager.py --generate-docs --docs-arch gfx1151` — confirm no diff
- Build the Sphinx docs and inspect the new `Dual-issue VALU (VOPD)` section under `RDNA System Speed-of-Light`

## Test Result

Passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.