### PR TITLE
[rocprofiler-sdk] Optimize PM4 read and offload completion callback to a dedicated consumer thread

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx9_cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx9_cmd_builder.h
@@ -314,7 +314,19 @@ public:
                                         const uint32_t* dst_addr,
                                         uint32_t        dw_mask)
     {
+        if(dw_mask == 0x3 && src_reg_addr_hi == src_reg_addr_lo + 1 &&
+           (reinterpret_cast<std::uintptr_t>(dst_addr) % 8) == 0)
+        {
+            BuildCopyRegDataPacket(cmdbuf,
+                                   src_reg_addr_lo,
+                                   dst_addr,
+                                   PACKET3_COPY_DATA__COUNT_SEL__64_BITS_OF_DATA,
+                                   false);
+            return 2;
+        }
+
         uint32_t read_counter = 0;
+
         if(dw_mask & 0x1)
         {
             BuildCopyRegDataPacket(cmdbuf,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/CMakeLists.txt
@@ -20,6 +20,7 @@ set(ROCPROFILER_LIB_COUNTERS_HEADERS
     sample_processing.hpp
     controller.hpp
     device_counting.hpp
+    sample_consumer.hpp
     ioctl.hpp
     firmware_restrictions.hpp)
 target_sources(rocprofiler-sdk-object-library PRIVATE ${ROCPROFILER_LIB_COUNTERS_SOURCES}

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
@@ -160,6 +160,8 @@ start_context(const context::context* ctx)
 
     if(!already_enabled)
     {
+        callback_thread_start();
+
         for(auto& cb : ctx->dispatch_counter_collection->callbacks)
         {
             using external_corr_id_map_t = tracing::external_correlation_id_map_t;
@@ -216,6 +218,8 @@ stop_context(const context::context* ctx)
     });
 
     if(controller) controller->disable_serialization();
+
+    callback_thread_stop();
 }
 
 rocprofiler_status_t

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/sample_consumer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/sample_consumer.hpp
@@ -73,18 +73,19 @@ public:
 
     void add(DataType&& params)
     {
-        std::unique_lock<std::mutex> lk(mut);
-
-        if(read_ptr + buffer.size() <= write_ptr || !valid)
+        bool selfconsume = true;
         {
-            // If not possible to use consumer thread, process with this thread
-            consume_fn(std::move(params));
-            return;
+            auto lk = std::unique_lock{mut};
+            if(valid && read_ptr + buffer.size() > write_ptr)
+            {
+                buffer.at(write_ptr.fetch_add(1) % buffer.size()) = std::move(params);
+                selfconsume                                       = false;
+            }
         }
-
-        buffer.at(write_ptr % buffer.size()) = std::move(params);
-        write_ptr.fetch_add(1);
-        cv.notify_all();
+        if(selfconsume)
+            consume_fn(std::move(params));
+        else
+            cv.notify_all();
     }
 
 protected:
@@ -92,11 +93,10 @@ protected:
     {
         while(true)
         {
-            while(read_ptr == write_ptr)
             {
-                std::unique_lock<std::mutex> lk(mut);
+                auto lk = std::unique_lock{mut};
                 cv.wait(lk, [&] { return read_ptr != write_ptr || !valid; });
-                if(!valid && read_ptr == write_ptr)
+                if(read_ptr == write_ptr)
                 {
                     exited.store(true);
                     cv.notify_all();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/sample_consumer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/sample_consumer.hpp
@@ -1,0 +1,125 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "lib/rocprofiler-sdk/counters/sample_processing.hpp"
+#include "lib/rocprofiler-sdk/internal_threading.hpp"
+
+#include <array>
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <utility>
+
+namespace rocprofiler
+{
+namespace counters
+{
+template <typename DataType>
+class consumer_thread_t
+{
+    static constexpr size_t SIZE = 128;
+    using consume_func_t         = std::function<void(DataType&&)>;
+
+public:
+    consumer_thread_t(consume_func_t func) { this->consume_fn = std::move(func); }
+    virtual ~consumer_thread_t() { exit(); }
+
+    void start()
+    {
+        std::unique_lock<std::mutex> lk(mut);
+
+        if(valid.exchange(true)) return;
+        exited.store(false);
+
+        internal_threading::notify_pre_internal_thread_create(ROCPROFILER_LIBRARY);
+        consumer = std::thread{&consumer_thread_t::consumer_loop, this};
+        internal_threading::notify_post_internal_thread_create(ROCPROFILER_LIBRARY);
+    }
+
+    void exit()
+    {
+        std::unique_lock<std::mutex> lk(mut);
+
+        valid.store(false);
+        cv.notify_all();
+
+        if(!exited) cv.wait(lk, [&] { return exited.load(); });
+        if(consumer.joinable()) consumer.join();
+    }
+
+    void add(DataType&& params)
+    {
+        std::unique_lock<std::mutex> lk(mut);
+
+        if(read_ptr + buffer.size() <= write_ptr || !valid)
+        {
+            // If not possible to use consumer thread, process with this thread
+            consume_fn(std::move(params));
+            return;
+        }
+
+        buffer.at(write_ptr % buffer.size()) = std::move(params);
+        write_ptr.fetch_add(1);
+        cv.notify_all();
+    }
+
+protected:
+    void consumer_loop()
+    {
+        while(true)
+        {
+            while(read_ptr == write_ptr)
+            {
+                std::unique_lock<std::mutex> lk(mut);
+                cv.wait(lk, [&] { return read_ptr != write_ptr || !valid; });
+                if(!valid && read_ptr == write_ptr)
+                {
+                    exited.store(true);
+                    cv.notify_all();
+                    return;
+                }
+            }
+
+            auto retrieved = std::move(buffer.at(read_ptr % buffer.size()));
+            read_ptr.fetch_add(1);
+            consume_fn(std::move(retrieved));
+        }
+    }
+
+    consume_func_t             consume_fn;
+    std::atomic<bool>          valid{false};
+    std::atomic<bool>          exited{true};
+    std::mutex                 mut;
+    std::atomic<size_t>        write_ptr{0};
+    std::atomic<size_t>        read_ptr{0};
+    std::array<DataType, SIZE> buffer;
+    std::thread                consumer;
+    std::condition_variable    cv;
+};
+
+}  // namespace counters
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/sample_processing.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/sample_processing.cpp
@@ -30,6 +30,7 @@
 #include "lib/rocprofiler-sdk/buffer.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
 #include "lib/rocprofiler-sdk/counters/core.hpp"
+#include "lib/rocprofiler-sdk/counters/sample_consumer.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
 #include "lib/rocprofiler-sdk/kernel_dispatch/profiling_time.hpp"
 
@@ -46,11 +47,15 @@ get_buffer_mut()
     return *CHECK_NOTNULL(mut);
 }
 
+namespace
+{
 /**
- * Callback called by HSA interceptor when the kernel has completed processing.
+ * Synchronous body of the completion callback. Invoked on the dedicated
+ * consumer thread (or, as a fallback, on the producer thread when the
+ * ring-buffer is full / the consumer is not running).
  */
 void
-process_callback_data(completed_cb_params_t&& params)
+process_completed_cb(completed_cb_params_t&& params)
 {
     auto&       info          = params.info;
     auto&       session       = *params.session;
@@ -152,6 +157,39 @@ process_callback_data(completed_cb_params_t&& params)
                                   info->record_callback_args);
         }
     }
+}
+
+using callback_consumer_t = consumer_thread_t<completed_cb_params_t>;
+
+callback_consumer_t&
+callback_thread_get()
+{
+    static auto*& _v = common::static_object<callback_consumer_t>::construct(&process_completed_cb);
+    return *CHECK_NOTNULL(_v);
+}
+}  // namespace
+
+void
+callback_thread_start()
+{
+    callback_thread_get().start();
+}
+
+void
+callback_thread_stop()
+{
+    callback_thread_get().exit();
+}
+
+/**
+ * Callback called by HSA interceptor when the kernel has completed processing.
+ * Hands the work off to the dedicated consumer thread so that the HSA async
+ * signal handler returns quickly.
+ */
+void
+process_callback_data(completed_cb_params_t&& params)
+{
+    callback_thread_get().add(std::move(params));
 }
 }  // namespace counters
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/sample_processing.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/sample_processing.hpp
@@ -42,6 +42,12 @@ struct completed_cb_params_t
 };
 
 void
+callback_thread_start();
+
+void
+callback_thread_stop();
+
+void
 process_callback_data(completed_cb_params_t&& params);
 }  // namespace counters
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt
@@ -104,3 +104,25 @@ rocprofiler_add_unit_test(
         device_counting_service_test.sync_sq_waves_verify_non_intercept
         device_counting_service_test.raw_sq_waves_verify
         device_counting_service_test.sync_grbm_verify)
+
+set(ROCPROFILER_LIB_CONSUMER_TEST_SOURCES consumer_test.cpp)
+
+add_executable(consumer-test)
+target_sources(consumer-test PRIVATE ${ROCPROFILER_LIB_CONSUMER_TEST_SOURCES})
+
+target_link_libraries(
+    consumer-test
+    PRIVATE rocprofiler-sdk::rocprofiler-sdk-hsa-runtime
+            rocprofiler-sdk::rocprofiler-sdk-hip
+            rocprofiler-sdk::rocprofiler-sdk-common-library
+            rocprofiler-sdk::rocprofiler-sdk-static-library
+            GTest::gtest
+            GTest::gtest_main)
+
+gtest_add_tests(
+    TARGET consumer-test
+    SOURCES ${ROCPROFILER_LIB_CONSUMER_TEST_SOURCES}
+    TEST_LIST consumer-tests_TESTS
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+set_tests_properties(${consumer-tests_TESTS} PROPERTIES TIMEOUT 45 LABELS "unittests")

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/consumer_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/consumer_test.cpp
@@ -1,0 +1,195 @@
+// MIT License
+//
+// Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <future>
+#include <mutex>
+#include <thread>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+
+#include "lib/rocprofiler-sdk/counters/sample_consumer.hpp"
+
+namespace rocprofiler
+{
+namespace counters
+{
+constexpr size_t NUM_THREADS  = 5;
+constexpr size_t NUM_ELEMENTS = 1ul << 17;
+using result_array_t          = std::array<std::atomic<size_t>, NUM_ELEMENTS>;
+using result_array_ptr_t      = std::shared_ptr<result_array_t>;
+
+struct DummyData
+{
+    size_t             index;
+    size_t             increment;
+    result_array_ptr_t array;
+};
+
+using consumer_t = consumer_thread_t<DummyData>;
+
+void
+consume_fn(DummyData&& data)
+{
+    data.array->at(data.index).fetch_add(data.increment);
+}
+
+TEST(consumer, nothread)
+{
+    auto array = std::make_shared<result_array_t>();
+
+    consumer_t consumer(consume_fn);
+    consumer.add(DummyData{1, 1, array});
+
+    EXPECT_EQ(array->at(0).load(), 0);
+    EXPECT_EQ(array->at(1).load(), 1);
+}
+
+TEST(consumer, singlethread)
+{
+    auto array = std::make_shared<result_array_t>();
+
+    {
+        consumer_t consumer(consume_fn);
+        consumer.start();
+
+        for(size_t i = 0; i < NUM_ELEMENTS; i++)
+            consumer.add(DummyData{i, 1, array});
+    }
+
+    for(auto& var : *array)
+        EXPECT_EQ(var.load(), 1);
+}
+
+TEST(consumer, multithreaded)
+{
+    auto       array = std::make_shared<result_array_t>();
+    consumer_t consumer(consume_fn);
+
+    auto produce_fn = [&](size_t tid) {
+        for(size_t i = 0; i < NUM_ELEMENTS; i++)
+            consumer.add(DummyData{i, tid, array});
+    };
+
+    {
+        std::vector<std::future<void>> threads{};
+        for(size_t i = 0; i < NUM_THREADS; i++)
+            threads.push_back(std::async(std::launch::async, produce_fn, i + 1));
+
+        consumer.start();
+    }
+
+    consumer.exit();
+
+    size_t expected = NUM_THREADS * (NUM_THREADS + 1) / 2;
+
+    for(auto& var : *array)
+        EXPECT_EQ(var.load(), expected);
+}
+
+// Verifies that a single consumer instance survives multiple
+// start()/exit() cycles. Each cycle adds 1 to every slot, so after
+// CYCLES iterations every slot must equal CYCLES. Exercises the
+// drain-on-exit logic (the `exited` flag + cv wait) followed by a
+// fresh start() that re-arms it.
+TEST(consumer, restart)
+{
+    auto array = std::make_shared<result_array_t>();
+
+    consumer_t    consumer(consume_fn);
+    constexpr int CYCLES = 3;
+
+    for(int cycle = 0; cycle < CYCLES; ++cycle)
+    {
+        consumer.start();
+        for(size_t i = 0; i < NUM_ELEMENTS; ++i)
+            consumer.add(DummyData{i, 1, array});
+        consumer.exit();
+    }
+
+    for(auto& var : *array)
+        EXPECT_EQ(var.load(), static_cast<size_t>(CYCLES));
+}
+
+// Verifies that calling add() after exit() does not lose work: the
+// item must be processed synchronously on the calling thread via the
+// fallback path (`!valid` clause in add()).
+TEST(consumer, add_after_exit)
+{
+    auto array = std::make_shared<result_array_t>();
+
+    consumer_t consumer(consume_fn);
+    consumer.start();
+    consumer.exit();
+
+    consumer.add(DummyData{42, 7, array});
+
+    EXPECT_EQ(array->at(42).load(), 7u);
+    EXPECT_EQ(array->at(0).load(), 0u);
+}
+
+// Verifies the synchronous fallback when the ring buffer overflows.
+// Throttles the consumer so the producer outpaces it; asserts that
+// (a) every item is processed exactly once and (b) at least some
+// items took the fallback path (consumed on the producer thread).
+TEST(consumer, buffer_full_fallback)
+{
+    auto                array = std::make_shared<result_array_t>();
+    std::atomic<size_t> fallback_count{0};
+    std::atomic<size_t> processed{0};
+    constexpr size_t    SLOW_FIRST_N = 256;
+
+    const auto producer_tid = std::this_thread::get_id();
+
+    auto slow_consume = [&, producer_tid](DummyData&& data) {
+        if(std::this_thread::get_id() == producer_tid) fallback_count.fetch_add(1);
+
+        if(processed.fetch_add(1) < SLOW_FIRST_N)
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+        data.array->at(data.index).fetch_add(data.increment);
+    };
+
+    consumer_thread_t<DummyData> consumer(slow_consume);
+    consumer.start();
+
+    for(size_t i = 0; i < NUM_ELEMENTS; ++i)
+        consumer.add(DummyData{i, 1, array});
+
+    consumer.exit();
+
+    for(auto& var : *array)
+        EXPECT_EQ(var.load(), 1u);
+
+    EXPECT_GT(fallback_count.load(), 0u);
+}
+
+}  // namespace counters
+}  // namespace rocprofiler


### PR DESCRIPTION
## Motivation
Optimize PM4 read. Move the synchronous body of the counter-collection completion callback off of the HSA async signal handler thread and onto a dedicated consumer thread, so the signal handler returns quickly, and the next dispatch's completion is no longer queued behind per-dispatch counter post-processing on the shared signal-handler thread.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
ROCM-23806
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
A new gtest consumer-test was added with 6 tests covering the consumer thread:

consumer.nothread — add() before start() falls back to synchronous consumption.
consumer.singlethread — single producer × ~131k items, all consumed exactly once.
consumer.multithreaded — 5 concurrent producers × ~131k items each, all consumed exactly once.
consumer.restart — start()/exit() cycle survives multiple iterations.
consumer.add_after_exit — items added after exit() are processed synchronously and not lost.
consumer.buffer_full_fallback — slow consume_fn forces ring-buffer overflow, verifies every item is processed and at least some items take the fallback path.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
All tests passed.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
