### PR TITLE
AIRUNTIME-1986: Set KMT flag for Win32-KMT interop imports

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -912,7 +912,14 @@ bool Buffer::create(bool alloc_local) {
     auto ext_memory = interop->asExternalMemory();
     amd::GLObject* glObject = interop->asGLObject();
     if (ext_memory != nullptr) {
-      return interopMapBuffer(ext_memory->Handle()) == HSA_STATUS_SUCCESS;
+      // Win32-KMT handles need ROCR's KMT branch in libhsakmt; the default
+      // (no flag) takes the NT path and fails with STATUS_INVALID_HANDLE.
+      hsa_interop_map_flag_t map_flags = HSA_INTEROP_MAP_FLAG_NONE;
+      if (ext_memory->Type() == amd::ExternalMemory::HandleType::OpaqueWin32Kmt ||
+          ext_memory->Type() == amd::ExternalMemory::HandleType::D3D11ResourceKmt) {
+        map_flags = HSA_INTEROP_MAP_FLAG_KMT_HANDLE;
+      }
+      return interopMapBuffer(ext_memory->Handle(), map_flags) == HSA_STATUS_SUCCESS;
     } else if (glObject != nullptr) {
       return createInteropBuffer(GL_ARRAY_BUFFER, 0);
     }


### PR DESCRIPTION
## Motivation

`hipImportExternalMemory` failed with `hipErrorOutOfMemory` for Win32-KMT handle types because ROCR routed them through the NT path and returned `STATUS_INVALID_HANDLE`.

## Technical Details

Pass `HSA_INTEROP_MAP_FLAG_KMT_HANDLE` to `interopMapBuffer` for `OpaqueWin32Kmt` and `D3D11ResourceKmt` external memory types so ROCR takes its KMT branch in libhsakmt.

## JIRA ID

- AIRUNTIME-1986

## Test Plan

Run NVIDIA's `vulkanCudaSineWave` sample (HIP port from AIRUNTIME-1986) on Windows with `GPU_ENABLE_PAL=0` to force the ROCR backend.

## Test Result

Before fix: `hipImportExternalMemory` returned `hipErrorOutOfMemory`. After fix: sine wave renders cleanly and the render loop stays stable indefinitely. PAL backend (`GPU_ENABLE_PAL=1`) confirmed untouched as a regression control.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.