### PR TITLE
libhsakmt: openclose: set error status on CREATE_PROCESS ioctl failure

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/openclose.c
+++ b/projects/rocr-runtime/libhsakmt/src/openclose.c
@@ -37,6 +37,7 @@
 #include <sys/ioctl.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <errno.h>
 #include <strings.h>
 #include "fmm.h"
 #include <dlfcn.h>
@@ -333,6 +334,10 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtOpenSecondaryKFDCtx(HsaKFDContext **pCtx)
 	} else {
 		struct kfd_ioctl_create_process_args args = {};
 		if (hsakmt_ioctl(kfd_fd, AMDKFD_IOC_CREATE_PROCESS, &args)) {
+			if (errno == EINVAL || errno == ENOTTY)
+				result = HSAKMT_STATUS_NOT_SUPPORTED;
+			else
+				result = HSAKMT_STATUS_ERROR;
 			goto create_process_failed;
 		} else {
 			new_ctx = calloc(1, sizeof(HsaKFDContext));


### PR DESCRIPTION
The ioctl failure path in hsaKmtOpenSecondaryKFDCtx() was missing an error status assignment, causing the function to return SUCCESS even when the ioctl failed. Set result to HSAKMT_STATUS_NOT_SUPPORTED for EINVAL/ENOTTY (kernel does not support the ioctl) and HSAKMT_STATUS_ERROR for other failures.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
