### PR TITLE
[rocprofiler-compute] Fix stale gfx1151 panel hash in .config_hashes.json

### DIFF
--- a/projects/rocprofiler-compute/src/utils/.config_hashes.json
+++ b/projects/rocprofiler-compute/src/utils/.config_hashes.json
@@ -10,7 +10,7 @@
         "0400_roofline.yaml": "17b62eb17edee43abd833576a7c142a4",
         "0500_command_processor_cpc.yaml": "9de95259d153357dde907a7a410aa1a3",
         "0600_workgroup_manager_spi.yaml": "e0fb474a8a5e97cf26467578f7b5c316",
-        "0700_workgroup_processor.yaml": "1a4d1286cb2a55e55b3475c95258e309",
+        "0700_workgroup_processor.yaml": "a52ba91ec25dee5d1884b74a827513a2",
         "0900_l0_cache.yaml": "1cbfbc0badeed8ec0caa178faec2f231",
         "1100_l1_cache.yaml": "7403eeb9b47f69f73cf42eccb984cdf7",
         "1300_l2_cache.yaml": "dd34f4b6cbdbb8afbafa059b58ba9839",


### PR DESCRIPTION
## Motivation

The hash database at `src/utils/.config_hashes.json` records md5 fingerprints of every per-arch panel YAML and is enforced byte-for-byte by `tests/test_autogen_config.py::test_config_hashes_match_files`. Following the recent gfx1151 dual-issue VALU update, the entry for `gfx1151/0700_workgroup_processor.yaml` drifted from the on-disk YAML content, causing the hash-integrity test to fail and breaking the contributor guarantee that the YAML and the hash DB stay in lockstep. This change restores that guarantee without touching the panel YAML itself.

## Technical Details

This refreshes only the gfx1151 hash entries through the prescribed deterministic tool rather than editing the JSON by hand.

- Regenerated the gfx1151 entries via `python tools/config_management/hash_manager.py --update gfx1151 src/rocprof_compute_soc/analysis_configs src/utils/.config_hashes.json`, per the rule in `tools/config_management/README.md` that `.config_hashes.json` is machine-generated and must never be hand-edited.
- Net effect on the file is a one-line change for `0700_workgroup_processor.yaml`: `1a4d1286cb2a55e55b3475c95258e309` -> `a52ba91ec25dee5d1884b74a827513a2`. All other gfx1151 entries and all other arches remain bit-identical.

## JIRA ID

N/A

## Test Plan

Validation focuses on the failing hash-integrity test and a sanity check on the diff produced by the regenerator. The pytest run reproduces the original failure mode against the pre-fix state and confirms a clean pass after the hash refresh.

- [x] Re-run `pytest tests/test_autogen_config.py -v` against the patched hash DB and verify both `test_config_hashes_match_files` and `test_metric_description_hashes_match_files` pass.
- [x] Inspect `git diff src/utils/.config_hashes.json` to confirm the change is a single hash value flip with no incidental rewrites of unrelated arches.

## Test Result

-[x] Tests pass locally 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.