### PR TITLE
[hipGraph] Pre-allocate graph signal pool at instantiate; live-dispatch reset kernel

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -981,6 +981,23 @@ bool GraphExec::isGraphExecValid(GraphExec* pGraphExec) {
 }
 
 // ================================================================================================
+void GraphExec::DestroyPersistentPool() {
+  if (persistent_pool_ != nullptr && persistent_pool_device_ != nullptr) {
+    persistent_pool_device_->DestroyGraphSignalPool(persistent_pool_);
+    persistent_pool_ = nullptr;
+    sync_plan_.segment_hw_events.clear();
+  }
+  if (reset_signal_ != nullptr) {
+    if (reset_signal_->signal_.handle != 0) {
+      amd::roc::Hsa::signal_destroy(reset_signal_->signal_);
+      reset_signal_->signal_.handle = 0;  // prevent double-destroy in ~ProfilingSignal
+    }
+    delete reset_signal_;
+    reset_signal_ = nullptr;
+  }
+}
+
+// ================================================================================================
 hipError_t GraphExec::CreateStreams(uint32_t num_streams, int devId) {
   std::scoped_lock lock(graphExecStreamCreateLock_);
 
@@ -1023,6 +1040,7 @@ hipError_t GraphExec::CreateStreams(uint32_t num_streams, int devId) {
                                   hipStreamNonBlocking);
 
     if (!stream->Create()) {
+      fprintf(stderr, "[DIAG] CreateStreams: stream->Create() failed i=%u devId=%d\n", i, devId); fflush(stderr);
       ClPrint(amd::LOG_ERROR, amd::LOG_CODE, "[hipGraph] Failed to create stream %u for device %d",
               i, devId);
       hip::Stream::Destroy(stream);
@@ -1184,6 +1202,17 @@ hipError_t GraphExec::Init() {
             "[hipGraph] Init: %zu device(s), %u total stream(s) (per-device cap: %u)",
             max_streams_dev_.size(), total_streams, DEBUG_HIP_FORCE_GRAPH_QUEUES);
 
+    // Ensure each device's blit program is initialized before creating parallel streams.
+    // CreateStreams creates VirtualGPUs which need blitProgram_ to be non-null; calling
+    // xferQueue() here initializes it as a side effect if not already done.
+    for (auto const& [dev_id, num_streams] : max_streams_dev_) {
+      if (num_streams > 0) {
+        auto* rocDev = static_cast<amd::roc::Device*>(g_devices[dev_id]->devices()[0]);
+        if (rocDev->blitProgram() == nullptr) {
+          rocDev->xferQueue();  // initializes blitProgram_ as a side effect
+        }
+      }
+    }
     // Create parallel streams for each device based on the capped requirements.
     for (auto const& [dev_id, num_streams] : max_streams_dev_) {
       if (num_streams > 0) {
@@ -1481,131 +1510,84 @@ hipError_t GraphExec::CaptureAndFormPacketsForGraph() {
   auto* device =
       static_cast<amd::roc::Device*>(g_devices[instantiateDeviceId_]->devices()[0]);
 
-  // 1. Create the persistent signal pool (num_hw_events segment signals +
-  //    1 extra slot for reset_signal_) and populate sync_plan_.segment_hw_events.
-  //    gpu_count = num_hw_events + 1 so Acquire() for reset_signal_ doesn't grow.
-  if (sync_plan_.num_hw_events > 0 || true) {  // always create pool for reset kernel
-    const size_t gpu_count =
-        static_cast<size_t>(sync_plan_.num_hw_events) + 1;  // +1 for reset_signal_
+  // 1. Create the persistent signal pool (one slot per segment that needs a
+  //    completion signal).  Always create it when there are parallel streams so
+  //    the reset kernel has a pool to write through; the pool is also used for
+  //    the dep-signal barriers prepended to non-stream-0 segments.
+  {
+    const size_t hw_count = static_cast<size_t>(sync_plan_.num_hw_events);
     persistent_pool_ =
-        device->CreateGraphSignalPool(gpu_count,
-                                      static_cast<size_t>(sync_plan_.num_hw_events),
-                                      sync_plan_.segment_hw_events);
+        device->CreateGraphSignalPool(hw_count, hw_count, sync_plan_.segment_hw_events);
     if (persistent_pool_ == nullptr) {
       ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
-              "[hipGraph] CaptureAndFormPacketsForGraph: failed to create signal pool");
+              "[hipGraph] CaptureAndFormPacketsForGraph: CreateGraphSignalPool failed");
       return hipErrorOutOfMemory;
     }
     persistent_pool_device_ = device;
 
-    // 2. Acquire dedicated reset signal (the +1 slot pre-allocated above).
-    reset_signal_ =
-        static_cast<amd::roc::ProfilingSignal*>(persistent_pool_->Acquire());
-    if (reset_signal_ == nullptr) {
+    // 2. Allocate a CPU+GPU-accessible HSA signal used as a guard for
+    //    dep_signal[0] in non-stream-0 barriers.  Its handle is stored here
+    //    only to drive the logic in step 3 below; the actual per-launch
+    //    completion signal comes from the runtime's Barriers() pool.
+    reset_signal_ = new amd::roc::ProfilingSignal();
+    if (amd::roc::Hsa::signal_create(0, 0, nullptr, &reset_signal_->signal_) !=
+        HSA_STATUS_SUCCESS) {
       ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
-              "[hipGraph] CaptureAndFormPacketsForGraph: failed to acquire reset signal");
+              "[hipGraph] CaptureAndFormPacketsForGraph: hsa_signal_create failed");
+      delete reset_signal_;
+      reset_signal_ = nullptr;
       return hipErrorOutOfMemory;
     }
-    // reset_signal_ starts at 0; CPU will store 1 before each launch.
-    amd::roc::Hsa::signal_silent_store_relaxed(reset_signal_->signal_, 0);
   }
 
-  // 3. Capture the reset kernel AQL packet for stream-0.
-  //    The packet is produced by resetContSignalBuffer in capture mode:
-  //    kernargs are stored in the graph kernarg pool (via captureCmd),
-  //    and the 64-byte packet is pushed to captureCmd.gpuPackets_.
-  //    completion_signal is left zero here; it is patched below.
-  // std::vector<uint8_t*> resetPktVec;
-  // if (persistent_pool_ != nullptr && reset_signal_ != nullptr) {
-  //   GraphCaptureCommand captureCmd;
-  //   const std::string* capturedKernelName = nullptr;
-  //   captureCmd.setPktCapturingState(true, &resetPktVec, GetKernelArgManager(),
-  //                                   &capturedKernelName);
-  //   if (!device->CaptureResetKernelPacket(persistent_pool_, &captureCmd)) {
-  //     ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
-  //             "[hipGraph] CaptureAndFormPacketsForGraph: reset kernel capture failed");
-  //     // Non-fatal: fall back to not having pre-baked reset. Pool and signals
-  //     // are still valid; EnqueueSegmentedGraph will handle the fallback.
-  //     resetPktVec.clear();
-  //   }
-  // }
-
-  // 4. Find the stream-0 root segment (level 0, stream_id == 0) to prepend
-  //    the reset kernel packet to.  Also prepend reset-wait barriers to every
-  //    non-stream-0 root segment so they block until the reset kernel retires.
-  int stream0_root_seg_id = -1;
-  // if (!resetPktVec.empty() && reset_signal_ != nullptr) {
-  //   // Locate the first level-0 segment assigned to stream_id == 0.
-  //   auto lvl0_it = segments_per_level_.find(0);
-  //   if (lvl0_it != segments_per_level_.end()) {
-  //     for (int sid : lvl0_it->second) {
-  //       if (sid >= 0 && sid < static_cast<int>(segments_.size()) &&
-  //           segments_[sid].stream_id == 0) {
-  //         stream0_root_seg_id = sid;
-  //         break;
-  //       }
-  //     }
-  //   }
-
-    // Prepend reset kernel packet to stream-0's first batch.
-    // if (stream0_root_seg_id >= 0) {
-    //   auto it = segmentBatches_.find(stream0_root_seg_id);
-    //   if (it != segmentBatches_.end()) {
-    //     auto& firstBatch = it->second.packet_batches[0];
-    //     firstBatch.dispatchPackets.insert(firstBatch.dispatchPackets.begin(),
-    //                                       resetPktVec[0]);
-    //     static const std::string* const kBarrierKernelNamePtr = nullptr;
-    //     firstBatch.dispatchKernelNames.insert(
-    //         firstBatch.dispatchKernelNames.begin(), kBarrierKernelNamePtr);
-    //     // Adjust existing node range start indices to account for the prepended packet.
-    //     for (auto& nodeRange : firstBatch.nodeRanges) {
-    //       nodeRange.startIndex += 1;
-    //     }
-    //   }
-    // }
-
-  // 5. Prepend a reset-wait barrier (dep_signal[0] = reset_signal_->signal_)
-  //    to the first batch of every non-stream-0 segment so it blocks until
-  //    the live-dispatched reset kernel retires.  dep_signals survive
-  //    rebuildFlatBuffer (only completion_signal at offset 56 is zeroed).
+  // 3. Prepend a dep-signal barrier-and packet to the first batch of every
+  //    non-stream-0 segment.  dep_signal[0].handle is left as 0 here and
+  //    patched at each hipGraphLaunch with the reset kernel's per-launch
+  //    completion signal via nonstream0_dep_signal_ptrs.
   if (reset_signal_ != nullptr) {
     for (auto& [seg_id, segBatch] : segmentBatches_) {
       if (seg_id < 0 || seg_id >= static_cast<int>(segments_.size())) continue;
-      if (segments_[seg_id].stream_id == 0) continue;  // stream-0: natural ordering
+      if (segments_[seg_id].stream_id == 0) continue;
 
       if (segBatch.packet_batches.empty()) {
         segBatch.packet_batches.emplace_back();
       }
       auto& firstBatch = segBatch.packet_batches[0];
 
-      uint8_t* rwb = device->CreateBarrierPacket();
-      auto* pkt = reinterpret_cast<hsa_barrier_and_packet_t*>(rwb);
-      pkt->dep_signal[0] = reset_signal_->signal_;  // survives flat copy
-      sync_plan_.barrier_packets.push_back(rwb);
-
-      firstBatch.dispatchPackets.insert(firstBatch.dispatchPackets.begin(), rwb);
-      static const std::string* const kBarrierNameNull = nullptr;
-      firstBatch.dispatchKernelNames.insert(
-          firstBatch.dispatchKernelNames.begin(), kBarrierNameNull);
+      uint8_t* barrier = device->CreateBarrierPacket();
+      sync_plan_.barrier_packets.push_back(barrier);
+      firstBatch.dispatchPackets.insert(firstBatch.dispatchPackets.begin(), barrier);
+      firstBatch.dispatchKernelNames.insert(firstBatch.dispatchKernelNames.begin(), nullptr);
       for (auto& nodeRange : firstBatch.nodeRanges) {
         nodeRange.startIndex += 1;
       }
     }
   }
 
-  // -----------------------------------------------------------------------
-  // Build flat buffers now that all dispatchPackets are final.
-  // Also build pktToFlat so patch_list flat_packet pointers can be resolved.
-  // -----------------------------------------------------------------------
+  // Build flat buffers now that all dispatchPackets are final, and build
+  // pktToFlat so patch_list flat_packet pointers can be resolved.
+  // For non-stream-0 first batches, also record a pointer to dep_signal[0].handle
+  // (byte offset 8 of the first/barrier packet) so it can be patched at launch.
+  static constexpr size_t kDepSig0HandleOffset = 8;  // offset of dep_signal[0].handle in AQL packet
   std::unordered_map<const uint8_t*, uint8_t*> pktToFlat;
   for (auto& [seg_id, segBatch] : segmentBatches_) {
-    for (auto& batch : segBatch.packet_batches) {
-      if (!batch.dispatchPackets.empty()) {
-        batch.rebuildFlatBuffer();
-        for (size_t i = 0; i < batch.dispatchPackets.size(); ++i) {
-          pktToFlat[batch.dispatchPackets[i]] =
-              batch.flatPacketData.data() + i * PacketBatch::kAqlPktSize;
-        }
+    for (size_t bIdx = 0; bIdx < segBatch.packet_batches.size(); ++bIdx) {
+      auto& batch = segBatch.packet_batches[bIdx];
+      if (batch.dispatchPackets.empty()) continue;
+
+      batch.rebuildFlatBuffer();
+      for (size_t i = 0; i < batch.dispatchPackets.size(); ++i) {
+        pktToFlat[batch.dispatchPackets[i]] =
+            batch.flatPacketData.data() + i * PacketBatch::kAqlPktSize;
+      }
+
+      // Record the dep_signal[0].handle pointer for the barrier prepended to each
+      // non-stream-0 segment's first batch (step 3 above).
+      if (bIdx == 0 && reset_signal_ != nullptr &&
+          seg_id >= 0 && seg_id < static_cast<int>(segments_.size()) &&
+          segments_[seg_id].stream_id != 0) {
+        sync_plan_.nonstream0_dep_signal_ptrs.push_back(
+            reinterpret_cast<uint64_t*>(batch.flatPacketData.data() + kDepSig0HandleOffset));
       }
     }
   }
@@ -1618,38 +1600,19 @@ hipError_t GraphExec::CaptureAndFormPacketsForGraph() {
     }
   }
 
-  // 6. Patch reset kernel's completion_signal in the flat buffer.
-  //    rebuildFlatBuffer zeroed offset 56; write reset_signal_->signal_ there.
-  // static constexpr size_t kSigOff = 56;
-  // if (!resetPktVec.empty() && stream0_root_seg_id >= 0 && reset_signal_ != nullptr) {
-  //   auto it = segmentBatches_.find(stream0_root_seg_id);
-  //   if (it != segmentBatches_.end() && !it->second.packet_batches.empty()) {
-  //     auto& flat = it->second.packet_batches[0].flatPacketData;
-  //     if (flat.size() >= kSigOff + sizeof(hsa_signal_t)) {
-  //       memcpy(flat.data() + kSigOff, &reset_signal_->signal_, sizeof(hsa_signal_t));
-  //     }
-  //   }
-  // }
-
-  // 7. Bake completion signals for all segments that need them (ApplyHwEventPatches
+  // 5. Bake completion signals for all segments that need them (ApplyHwEventPatches
   //    uses dense seg_to_hw_event indices into sync_plan_.segment_hw_events).
   if (!sync_plan_.patch_list.empty()) {
     device->ApplyHwEventPatches(sync_plan_.patch_list, sync_plan_.segment_hw_events);
   }
 
-  // Diagnostic: pool and reset signal state at instantiate time.
-  ClPrint(amd::LOG_INFO, amd::LOG_CODE,
-          "[hipGraph] instantiate: pool=%p reset_sig=0x%zx "
-          "num_hw=%d stream0_seg=%d",
+  ClPrint(amd::LOG_DEBUG, amd::LOG_CODE,
+          "[hipGraph] instantiate: pool=%p reset_sig=0x%zx num_hw_events=%d "
+          "nonstream0_barriers=%zu",
           (void*)persistent_pool_,
           reset_signal_ ? reset_signal_->signal_.handle : 0UL,
-          sync_plan_.num_hw_events, stream0_root_seg_id);
-  if (persistent_pool_) {
-    ClPrint(amd::LOG_INFO, amd::LOG_CODE,
-            "[hipGraph] pool: cont_buf=0x%zx cont_cnt=%u",
-            reinterpret_cast<uintptr_t>(persistent_pool_->ContBuffer()),
-            persistent_pool_->ContBufferCount());
-  }
+          sync_plan_.num_hw_events,
+          sync_plan_.nonstream0_dep_signal_ptrs.size());
 
   return status;
 }
@@ -1678,6 +1641,7 @@ hipError_t GraphExec::CaptureAQLPackets() {
 
     const size_t totalPoolSize = kernArgSize + kKernArgChunkSize;
     if (!kernArgManager_->AllocGraphKernargPool(totalPoolSize, g_devices[deviceId]->devices()[0])) {
+      fprintf(stderr, "[DIAG] AllocGraphKernargPool failed size=%zu devId=%d\n", totalPoolSize, deviceId); fflush(stderr);
       ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
               "[hipGraph] Failed to allocate kernel argument pool of size %zu for device %d",
               totalPoolSize, deviceId);
@@ -1904,66 +1868,6 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
     *out_status = hipSuccess;
   }
 
-  // Pool and signals are pre-allocated and pre-patched at instantiate time
-  // (CaptureAndFormPacketsForGraph).  EnqueueSegmentedGraph:
-  //   1. Re-arms reset_signal_ to 1 (CPU store).
-  //   2. Dispatches the reset kernel live on launch_stream to write 1 into
-  //      every pool signal via the GPU (signals are GPU-only; CPU cannot).
-  //   3. Captures the reset kernel's completion signal and enqueues an
-  //      ordering Marker on every internal stream that waits on it — this
-  //      prevents internal-stream dep-barriers from firing on stale 0 values
-  //      from the previous launch before the current reset completes.
-  //   4. Dispatches the pre-built flat packets for every segment.
-  //   5. Synchronizes leaf parallel streams back to launch_stream.
-
-  // Re-arm reset_signal_ (CPU store) before the GPU reset kernel runs.
-  if (reset_signal_ != nullptr) {
-    amd::roc::Hsa::signal_store_relaxed(reset_signal_->signal_, 1);
-  }
-
-  // Live-dispatch reset kernel on launch_stream.
-  void* gpu_reset_hw_event = nullptr;
-  if (persistent_pool_ != nullptr) {
-    auto* roc_device =
-        static_cast<amd::roc::Device*>(g_devices[instantiateDeviceId_]->devices()[0]);
-    bool did_gpu_reset = false;
-    if (!roc_device->ResetGraphSignalPool(launch_stream->vdev(), persistent_pool_,
-                                          false, &did_gpu_reset)) {
-      ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
-              "[hipGraph] EnqueueSegmentedGraph: ResetGraphSignalPool failed");
-      if (out_status != nullptr) *out_status = hipErrorUnknown;
-      return nullptr;
-    }
-    if (did_gpu_reset) {
-      // Pull the reset kernel's completion signal so ordering markers on
-      // internal streams can wait on it before executing their first barrier.
-      auto* gpu = static_cast<amd::roc::VirtualGPU*>(launch_stream->vdev());
-      gpu_reset_hw_event = gpu->Barriers().GetLastSignal();
-    }
-    ClPrint(amd::LOG_INFO, amd::LOG_CODE,
-            "[hipGraph] launch: live reset dispatched (gpu=%d) pool cont_buf=0x%zx cnt=%u",
-            (int)did_gpu_reset,
-            reinterpret_cast<uintptr_t>(persistent_pool_->ContBuffer()),
-            persistent_pool_->ContBufferCount());
-  }
-
-  // Enqueue one ordering Marker per internal stream so that each stream's
-  // dep-barrier does not see stale 0 values from the prior launch.  The
-  // Marker waits on the reset kernel's completion signal; once the reset
-  // retires all pool signals are back at 1 and the dep-barriers are safe.
-  // if (gpu_reset_hw_event != nullptr) {
-  //   for (auto* s : streams) {
-  //     if (s == launch_stream) continue;
-  //     auto* marker = new amd::Marker(*s, kMarkerDisableFlush, {});
-  //     if (marker != nullptr) {
-  //       marker->addDepHwEvent(gpu_reset_hw_event);
-  //       marker->enqueue();
-  //       marker->release();
-  //     }
-  //   }
-  // }
-
-  // Resolve a segment's assigned hip::Stream* from its pre-computed stream_id.
   auto resolveSegmentStream = [&](const Segment& seg) -> hip::Stream* {
     if (!streams.empty()) {
       return streams[static_cast<size_t>(seg.stream_id) % streams.size()];
@@ -1973,18 +1877,34 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
 
   // Single AccumulateCommand anchors all segment dispatches.
   auto* graph_accumulate = new amd::AccumulateCommand(*launch_stream, {}, nullptr);
-  // graph_accumulate->SetGraphSignalPool(persistent_pool_);
 
-  // Dispatch pre-built flat packets level by level.
+  // Dispatch the reset kernel on launch_stream before any parallel segment.
+  // The per-launch completion signal it fires is patched into dep_signal[0] of
+  // every non-stream-0 segment's leading barrier-and packet, ensuring those
+  // segments block until the pool is reset (race-free across launches).
+  if (persistent_pool_ != nullptr && !sync_plan_.nonstream0_dep_signal_ptrs.empty()) {
+    auto* rocDev = static_cast<amd::roc::Device*>(launch_stream->GetDevice()->devices()[0]);
+    rocDev->ResetGraphSignalPool(launch_stream->vdev(), persistent_pool_,
+                                 /*prev_done=*/false, /*out_did_gpu_reset=*/nullptr);
+
+    auto* lastSig = static_cast<amd::roc::VirtualGPU*>(launch_stream->vdev())
+                        ->Barriers().GetLastSignal();
+    const hsa_signal_t reset_done = (lastSig != nullptr) ? lastSig->signal_
+                                                          : hsa_signal_t{0};
+    for (uint64_t* dep_ptr : sync_plan_.nonstream0_dep_signal_ptrs) {
+      *dep_ptr = reset_done.handle;
+    }
+    ClPrint(amd::LOG_DEBUG, amd::LOG_CODE,
+            "[hipGraph] reset kernel dispatched, completion_sig=0x%zx", reset_done.handle);
+  }
+
   for (int level = 0; level <= max_dependency_level_; ++level) {
     auto level_it = segments_per_level_.find(level);
     if (level_it == segments_per_level_.end()) continue;
 
     for (int segment_id : level_it->second) {
       const auto& segment = segments_[segment_id];
-      hip::Stream* current_stream = resolveSegmentStream(segment);
-
-      status = EnqueueSegment(segment, current_stream, graph_accumulate);
+      status = EnqueueSegment(segment, resolveSegmentStream(segment), graph_accumulate);
       if (status != hipSuccess) {
         graph_accumulate->release();
         if (out_status != nullptr) *out_status = status;

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -41,6 +41,14 @@ const char* GetGraphNodeTypeString(uint32_t op) {
 };
 }  // namespace
 
+// Minimal concrete amd::Command subclass used only for AQL packet capture at
+// instantiate time — never submitted to a real hardware queue.
+// setPktCapturingState() must be called before this command is used.
+struct GraphCaptureCommand : amd::Command {
+  GraphCaptureCommand() : amd::Command(0) {}
+  void submit(device::VirtualDevice&) override {}
+};
+
 namespace hip {
 
 int GraphNode::nextID = 0;
@@ -437,8 +445,24 @@ void GraphExec::BuildSyncPlan() {
   sync_plan_.patch_list.clear();
   sync_plan_.barrier_packets.clear();
   sync_plan_.leaf_segment_ids.clear();
+  sync_plan_.segment_hw_events.clear();
 
   auto* device = g_devices[instantiateDeviceId_]->devices()[0];
+
+  // Build sparse seg→hw_event mapping: only segments with needs_completion_signal
+  // get a completion signal. Dense indices (0 .. num_hw_events-1) allow the
+  // signal vector to be sized exactly right at instantiate time.
+  sync_plan_.seg_to_hw_event.assign(segments_.size(), -1);
+  {
+    int hw_idx = 0;
+    for (const auto& seg : segments_) {
+      if (seg.needs_completion_signal) {
+        sync_plan_.seg_to_hw_event[seg.id] = hw_idx++;
+      }
+    }
+    sync_plan_.num_hw_events = hw_idx;
+  }
+  graph_signal_count_ = static_cast<size_t>(sync_plan_.num_hw_events);
 
   // Barrier packets are sentinel-marked with nullptr in dispatchKernelNames so that
   // activity.cpp can distinguish them from kernel/blit dispatch packets (which use "" or a
@@ -494,7 +518,8 @@ void GraphExec::BuildSyncPlan() {
       if (use_ext_dep) {
         uint8_t* first_dispatch = firstBatch.dispatchPackets[0];
         sync_plan_.patch_list.push_back(
-            {first_dispatch, nullptr, barrier_dep_indices[0],
+            {first_dispatch, nullptr,
+             sync_plan_.seg_to_hw_event[barrier_dep_indices[0]],
              amd::Device::HwEventPatch::kExtDispatchDepSignal});
       } else {
         int barrier_count = (num_deps + 4) / 5;
@@ -507,7 +532,9 @@ void GraphExec::BuildSyncPlan() {
           int end_dep = std::min(start_dep + 5, num_deps);
           for (int d = start_dep; d < end_dep; ++d) {
             sync_plan_.patch_list.push_back(
-                {barrier_pkt, nullptr, barrier_dep_indices[d], d - start_dep});
+                {barrier_pkt, nullptr,
+                 sync_plan_.seg_to_hw_event[barrier_dep_indices[d]],
+                 d - start_dep});
           }
 
           firstBatch.dispatchPackets.insert(firstBatch.dispatchPackets.begin(), barrier_pkt);
@@ -527,31 +554,24 @@ void GraphExec::BuildSyncPlan() {
         !segment.nodes.empty() && !segBatch.node_capture_status.back();
 
     auto& lastBatch = segBatch.packet_batches.back();
-    if (last_node_uncaptured) {
-      uint8_t* completion_barrier = device->CreateBarrierPacket();
-      sync_plan_.barrier_packets.push_back(completion_barrier);
 
-      lastBatch.dispatchPackets.push_back(completion_barrier);
-      lastBatch.dispatchKernelNames.push_back(kBarrierKernelNamePtr);
+    // Only emit a completion barrier for segments that actually need a HW event
+    // (needs_completion_signal == true). Same-stream-only segments are serialized
+    // by AQL queue order; no explicit signal is required.
+    if (segment.needs_completion_signal) {
+      const int hw_idx = sync_plan_.seg_to_hw_event[segment.id];
 
-      sync_plan_.patch_list.push_back(
-          {completion_barrier, nullptr, segment.id,
-           amd::Device::HwEventPatch::kCompletionSignal});
-    } else if (!lastBatch.dispatchPackets.empty()) {
-      // All nodes are capturable — append a real completion barrier packet so that
-      // ApplyHwEventPatches patches the barrier's completion signal, not the last
-      // kernel dispatch's. Patching the last kernel dispatch directly causes
-      // dispatchAqlPacketBatchFlat to see a pre-patched non-zero signal and skip
-      // profiling setup (reserved2 / isPacketDispatch_) for that kernel.
-      uint8_t* completion_barrier = device->CreateBarrierPacket();
-      sync_plan_.barrier_packets.push_back(completion_barrier);
+      if (last_node_uncaptured || !lastBatch.dispatchPackets.empty()) {
+        uint8_t* completion_barrier = device->CreateBarrierPacket();
+        sync_plan_.barrier_packets.push_back(completion_barrier);
 
-      lastBatch.dispatchPackets.push_back(completion_barrier);
-      lastBatch.dispatchKernelNames.push_back(kBarrierKernelNamePtr);
+        lastBatch.dispatchPackets.push_back(completion_barrier);
+        lastBatch.dispatchKernelNames.push_back(kBarrierKernelNamePtr);
 
-      sync_plan_.patch_list.push_back(
-          {completion_barrier, nullptr, segment.id,
-           amd::Device::HwEventPatch::kCompletionSignal});
+        sync_plan_.patch_list.push_back(
+            {completion_barrier, nullptr, hw_idx,
+             amd::Device::HwEventPatch::kCompletionSignal});
+      }
     }
 
     if (segment.segment_ids_edges.empty()) {
@@ -559,10 +579,6 @@ void GraphExec::BuildSyncPlan() {
     }
 
   }
-
-  // Seed GPU-only signal count with known minimum (SyncPlan HW events)
-  // so even the first launch pre-allocates these instead of growing on demand.
-  graph_signal_count_ = sync_plan_.num_segments;
 }
 
 // ================================================================================================
@@ -1196,6 +1212,9 @@ hipError_t GraphExec::Init() {
 //! Chunk size to add to kern arg pool
 constexpr uint32_t kKernArgChunkSize = 128 * Ki;
 // ================================================================================================
+// Conservative upper bound for the reset kernel (3 args: ptr/uint32/uint64, 8-byte aligned).
+static constexpr size_t kResetKernelKernargSize = 64;
+
 void GraphExec::GetKernelArgSizeForGraph(std::unordered_map<int, size_t>& kernArgSizeForGraph) {
   // Calculate the kernel argument size required for all graph kernel nodes
   // when GPU packet capture is enabled
@@ -1226,6 +1245,11 @@ void GraphExec::GetKernelArgSizeForGraph(std::unordered_map<int, size_t>& kernAr
           kernArgSizeForGraph[node->dev_id_] += node->GetKerArgSize();
         }
       }
+    }
+
+    // Account for the reset kernel captured once at instantiate time.
+    if (instantiateDeviceId_ >= 0) {
+      kernArgSizeForGraph[instantiateDeviceId_] += kResetKernelKernargSize;
     }
   }
 }
@@ -1451,10 +1475,128 @@ hipError_t GraphExec::CaptureAndFormPacketsForGraph() {
   // prepends barrier packets and generates the patch list
   BuildSyncPlan();
 
-  // Build flat buffers once now that all dispatchPackets are finalized
-  // (capture populated them, BuildSyncPlan may have prepended/appended barriers).
-  // Also build a map from dispatchPacket pointer -> flat buffer pointer so
-  // ApplyHwEventPatches can patch flatPacketData directly at launch time.
+  // -----------------------------------------------------------------------
+  // Instantiate-time signal pool, reset kernel capture, and barrier baking
+  // -----------------------------------------------------------------------
+  auto* device =
+      static_cast<amd::roc::Device*>(g_devices[instantiateDeviceId_]->devices()[0]);
+
+  // 1. Create the persistent signal pool (num_hw_events segment signals +
+  //    1 extra slot for reset_signal_) and populate sync_plan_.segment_hw_events.
+  //    gpu_count = num_hw_events + 1 so Acquire() for reset_signal_ doesn't grow.
+  if (sync_plan_.num_hw_events > 0 || true) {  // always create pool for reset kernel
+    const size_t gpu_count =
+        static_cast<size_t>(sync_plan_.num_hw_events) + 1;  // +1 for reset_signal_
+    persistent_pool_ =
+        device->CreateGraphSignalPool(gpu_count,
+                                      static_cast<size_t>(sync_plan_.num_hw_events),
+                                      sync_plan_.segment_hw_events);
+    if (persistent_pool_ == nullptr) {
+      ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+              "[hipGraph] CaptureAndFormPacketsForGraph: failed to create signal pool");
+      return hipErrorOutOfMemory;
+    }
+    persistent_pool_device_ = device;
+
+    // 2. Acquire dedicated reset signal (the +1 slot pre-allocated above).
+    reset_signal_ =
+        static_cast<amd::roc::ProfilingSignal*>(persistent_pool_->Acquire());
+    if (reset_signal_ == nullptr) {
+      ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+              "[hipGraph] CaptureAndFormPacketsForGraph: failed to acquire reset signal");
+      return hipErrorOutOfMemory;
+    }
+    // reset_signal_ starts at 0; CPU will store 1 before each launch.
+    amd::roc::Hsa::signal_silent_store_relaxed(reset_signal_->signal_, 0);
+  }
+
+  // 3. Capture the reset kernel AQL packet for stream-0.
+  //    The packet is produced by resetContSignalBuffer in capture mode:
+  //    kernargs are stored in the graph kernarg pool (via captureCmd),
+  //    and the 64-byte packet is pushed to captureCmd.gpuPackets_.
+  //    completion_signal is left zero here; it is patched below.
+  // std::vector<uint8_t*> resetPktVec;
+  // if (persistent_pool_ != nullptr && reset_signal_ != nullptr) {
+  //   GraphCaptureCommand captureCmd;
+  //   const std::string* capturedKernelName = nullptr;
+  //   captureCmd.setPktCapturingState(true, &resetPktVec, GetKernelArgManager(),
+  //                                   &capturedKernelName);
+  //   if (!device->CaptureResetKernelPacket(persistent_pool_, &captureCmd)) {
+  //     ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+  //             "[hipGraph] CaptureAndFormPacketsForGraph: reset kernel capture failed");
+  //     // Non-fatal: fall back to not having pre-baked reset. Pool and signals
+  //     // are still valid; EnqueueSegmentedGraph will handle the fallback.
+  //     resetPktVec.clear();
+  //   }
+  // }
+
+  // 4. Find the stream-0 root segment (level 0, stream_id == 0) to prepend
+  //    the reset kernel packet to.  Also prepend reset-wait barriers to every
+  //    non-stream-0 root segment so they block until the reset kernel retires.
+  int stream0_root_seg_id = -1;
+  // if (!resetPktVec.empty() && reset_signal_ != nullptr) {
+  //   // Locate the first level-0 segment assigned to stream_id == 0.
+  //   auto lvl0_it = segments_per_level_.find(0);
+  //   if (lvl0_it != segments_per_level_.end()) {
+  //     for (int sid : lvl0_it->second) {
+  //       if (sid >= 0 && sid < static_cast<int>(segments_.size()) &&
+  //           segments_[sid].stream_id == 0) {
+  //         stream0_root_seg_id = sid;
+  //         break;
+  //       }
+  //     }
+  //   }
+
+    // Prepend reset kernel packet to stream-0's first batch.
+    // if (stream0_root_seg_id >= 0) {
+    //   auto it = segmentBatches_.find(stream0_root_seg_id);
+    //   if (it != segmentBatches_.end()) {
+    //     auto& firstBatch = it->second.packet_batches[0];
+    //     firstBatch.dispatchPackets.insert(firstBatch.dispatchPackets.begin(),
+    //                                       resetPktVec[0]);
+    //     static const std::string* const kBarrierKernelNamePtr = nullptr;
+    //     firstBatch.dispatchKernelNames.insert(
+    //         firstBatch.dispatchKernelNames.begin(), kBarrierKernelNamePtr);
+    //     // Adjust existing node range start indices to account for the prepended packet.
+    //     for (auto& nodeRange : firstBatch.nodeRanges) {
+    //       nodeRange.startIndex += 1;
+    //     }
+    //   }
+    // }
+
+  // 5. Prepend a reset-wait barrier (dep_signal[0] = reset_signal_->signal_)
+  //    to the first batch of every non-stream-0 segment so it blocks until
+  //    the live-dispatched reset kernel retires.  dep_signals survive
+  //    rebuildFlatBuffer (only completion_signal at offset 56 is zeroed).
+  if (reset_signal_ != nullptr) {
+    for (auto& [seg_id, segBatch] : segmentBatches_) {
+      if (seg_id < 0 || seg_id >= static_cast<int>(segments_.size())) continue;
+      if (segments_[seg_id].stream_id == 0) continue;  // stream-0: natural ordering
+
+      if (segBatch.packet_batches.empty()) {
+        segBatch.packet_batches.emplace_back();
+      }
+      auto& firstBatch = segBatch.packet_batches[0];
+
+      uint8_t* rwb = device->CreateBarrierPacket();
+      auto* pkt = reinterpret_cast<hsa_barrier_and_packet_t*>(rwb);
+      pkt->dep_signal[0] = reset_signal_->signal_;  // survives flat copy
+      sync_plan_.barrier_packets.push_back(rwb);
+
+      firstBatch.dispatchPackets.insert(firstBatch.dispatchPackets.begin(), rwb);
+      static const std::string* const kBarrierNameNull = nullptr;
+      firstBatch.dispatchKernelNames.insert(
+          firstBatch.dispatchKernelNames.begin(), kBarrierNameNull);
+      for (auto& nodeRange : firstBatch.nodeRanges) {
+        nodeRange.startIndex += 1;
+      }
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Build flat buffers now that all dispatchPackets are final.
+  // Also build pktToFlat so patch_list flat_packet pointers can be resolved.
+  // -----------------------------------------------------------------------
   std::unordered_map<const uint8_t*, uint8_t*> pktToFlat;
   for (auto& [seg_id, segBatch] : segmentBatches_) {
     for (auto& batch : segBatch.packet_batches) {
@@ -1468,12 +1610,45 @@ hipError_t GraphExec::CaptureAndFormPacketsForGraph() {
     }
   }
 
-  // Resolve flat_packet pointers for all HwEventPatches
+  // Resolve flat_packet pointers for all HwEventPatches (completion + dep barriers).
   for (auto& patch : sync_plan_.patch_list) {
     auto it = pktToFlat.find(patch.packet);
     if (it != pktToFlat.end()) {
       patch.flat_packet = it->second;
     }
+  }
+
+  // 6. Patch reset kernel's completion_signal in the flat buffer.
+  //    rebuildFlatBuffer zeroed offset 56; write reset_signal_->signal_ there.
+  // static constexpr size_t kSigOff = 56;
+  // if (!resetPktVec.empty() && stream0_root_seg_id >= 0 && reset_signal_ != nullptr) {
+  //   auto it = segmentBatches_.find(stream0_root_seg_id);
+  //   if (it != segmentBatches_.end() && !it->second.packet_batches.empty()) {
+  //     auto& flat = it->second.packet_batches[0].flatPacketData;
+  //     if (flat.size() >= kSigOff + sizeof(hsa_signal_t)) {
+  //       memcpy(flat.data() + kSigOff, &reset_signal_->signal_, sizeof(hsa_signal_t));
+  //     }
+  //   }
+  // }
+
+  // 7. Bake completion signals for all segments that need them (ApplyHwEventPatches
+  //    uses dense seg_to_hw_event indices into sync_plan_.segment_hw_events).
+  if (!sync_plan_.patch_list.empty()) {
+    device->ApplyHwEventPatches(sync_plan_.patch_list, sync_plan_.segment_hw_events);
+  }
+
+  // Diagnostic: pool and reset signal state at instantiate time.
+  ClPrint(amd::LOG_INFO, amd::LOG_CODE,
+          "[hipGraph] instantiate: pool=%p reset_sig=0x%zx "
+          "num_hw=%d stream0_seg=%d",
+          (void*)persistent_pool_,
+          reset_signal_ ? reset_signal_->signal_.handle : 0UL,
+          sync_plan_.num_hw_events, stream0_root_seg_id);
+  if (persistent_pool_) {
+    ClPrint(amd::LOG_INFO, amd::LOG_CODE,
+            "[hipGraph] pool: cont_buf=0x%zx cont_cnt=%u",
+            reinterpret_cast<uintptr_t>(persistent_pool_->ContBuffer()),
+            persistent_pool_->ContBufferCount());
   }
 
   return status;
@@ -1729,103 +1904,66 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
     *out_status = hipSuccess;
   }
 
-  auto* device = g_devices[launch_stream->DeviceId()]->devices()[0];
+  // Pool and signals are pre-allocated and pre-patched at instantiate time
+  // (CaptureAndFormPacketsForGraph).  EnqueueSegmentedGraph:
+  //   1. Re-arms reset_signal_ to 1 (CPU store).
+  //   2. Dispatches the reset kernel live on launch_stream to write 1 into
+  //      every pool signal via the GPU (signals are GPU-only; CPU cannot).
+  //   3. Captures the reset kernel's completion signal and enqueues an
+  //      ordering Marker on every internal stream that waits on it — this
+  //      prevents internal-stream dep-barriers from firing on stale 0 values
+  //      from the previous launch before the current reset completes.
+  //   4. Dispatches the pre-built flat packets for every segment.
+  //   5. Synchronizes leaf parallel streams back to launch_stream.
 
-  // Persistent pool model:
-  //   - Pool is owned by GraphExec, allocated lazily on first launch.
-  //   - At each launch, decide reset path by inspecting prev_leaf_signals_
-  //     (the GPU-only signals that the previous launch's leaf segments
-  //     completed into). All-zero ⇒ previous launch fully drained ⇒ CPU
-  //     fast reset. Otherwise ⇒ GPU reset (kernel dispatched on launch_stream
-  //     so existing level-0 wait markers naturally serialize segment kernels
-  //     after the reset).
-  //   - AccumulateCommand never owns the pool; it carries only a non-owning
-  //     reference so segments can pull GPU-only signals from it.
-  std::vector<void*> segment_hw_events;
-  amd::roc::GraphSignalPool* launch_pool = nullptr;
-
-  // When the GPU-reset path is taken, this holds the reset kernel's
-  // completion signal (a ProfilingSignal*). Parallel-stream level-0
-  // dispatches must wait on it so they don't read stale signal values
-  // before the reset kernel has retired. Same-queue ordering covers the
-  // launch_stream itself.
-  void* gpu_reset_hw_event = nullptr;
-  bool did_gpu_reset = false;
-
-  if (persistent_pool_ != nullptr) {
-    // Reuse path. Decide CPU vs GPU reset based on prev_leaf_signals_ status.
-    bool prev_done = true;
-    for (auto* ps : prev_leaf_signals_) {
-      if (ps != nullptr && amd::roc::Hsa::signal_load_relaxed(ps->signal_) != 0) {
-        prev_done = false;
-        break;
-      }
-    }
-    if (!device->ResetGraphSignalPool(launch_stream->vdev(), persistent_pool_,
-                                      /*prev_done=*/prev_done, &did_gpu_reset)) {
-      // Reset failed (allocation/dispatch error). Drop and re-allocate.
-      DestroyPersistentPool();
-    } else {
-      if (did_gpu_reset) {
-        // The reset kernel was dispatched with attach_signal=true on
-        // launch_stream's queue; pull its completion signal back here so
-        // parallel-stream dispatches at level 0 can wait on it.
-        auto* gpu = static_cast<amd::roc::VirtualGPU*>(launch_stream->vdev());
-        gpu_reset_hw_event = gpu->Barriers().GetLastSignal();
-      }
-      launch_pool = persistent_pool_;
-      segment_hw_events.assign(sync_plan_.num_segments, nullptr);
-      bool acquire_ok = true;
-      for (int i = 0; i < sync_plan_.num_segments; ++i) {
-        segment_hw_events[i] = launch_pool->Acquire();
-        if (segment_hw_events[i] == nullptr) {
-          acquire_ok = false;
-          break;
-        }
-      }
-      if (!acquire_ok) {
-        DestroyPersistentPool();
-        launch_pool = nullptr;
-        segment_hw_events.clear();
-      } else {
-        launch_pool->ResetLastAcquired();
-      }
-    }
+  // Re-arm reset_signal_ (CPU store) before the GPU reset kernel runs.
+  if (reset_signal_ != nullptr) {
+    amd::roc::Hsa::signal_store_relaxed(reset_signal_->signal_, 1);
   }
 
-  if (launch_pool == nullptr) {
-    // First launch (or fallback). Allocate a fresh pool sized to the cached
-    // GPU-only signal count plus one slot per segment.
-    launch_pool = device->CreateGraphSignalPool(
-        graph_signal_count_,
-        static_cast<size_t>(sync_plan_.num_segments), segment_hw_events);
-    if (launch_pool == nullptr) {
-      if (out_status != nullptr) *out_status = hipErrorOutOfMemory;
+  // Live-dispatch reset kernel on launch_stream.
+  void* gpu_reset_hw_event = nullptr;
+  if (persistent_pool_ != nullptr) {
+    auto* roc_device =
+        static_cast<amd::roc::Device*>(g_devices[instantiateDeviceId_]->devices()[0]);
+    bool did_gpu_reset = false;
+    if (!roc_device->ResetGraphSignalPool(launch_stream->vdev(), persistent_pool_,
+                                          false, &did_gpu_reset)) {
+      ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+              "[hipGraph] EnqueueSegmentedGraph: ResetGraphSignalPool failed");
+      if (out_status != nullptr) *out_status = hipErrorUnknown;
       return nullptr;
     }
-    persistent_pool_ = launch_pool;
-    persistent_pool_device_ = device;
-  }
-
-  // Apply pre-computed patches — writes HW events directly into flatPacketData
-  if (!sync_plan_.patch_list.empty()) {
-    device->ApplyHwEventPatches(sync_plan_.patch_list, segment_hw_events);
-  }
-
-  // Snapshot leaf hw_events for the next launch's reset decision. Done up
-  // front because segment_hw_events may be reordered/consumed by the dispatch
-  // path below.
-  prev_leaf_signals_.clear();
-  prev_leaf_signals_.reserve(sync_plan_.leaf_segment_ids.size());
-  for (int seg_id : sync_plan_.leaf_segment_ids) {
-    if (seg_id >= 0 && seg_id < static_cast<int>(segment_hw_events.size())) {
-      prev_leaf_signals_.push_back(
-          static_cast<amd::roc::ProfilingSignal*>(segment_hw_events[seg_id]));
+    if (did_gpu_reset) {
+      // Pull the reset kernel's completion signal so ordering markers on
+      // internal streams can wait on it before executing their first barrier.
+      auto* gpu = static_cast<amd::roc::VirtualGPU*>(launch_stream->vdev());
+      gpu_reset_hw_event = gpu->Barriers().GetLastSignal();
     }
+    ClPrint(amd::LOG_INFO, amd::LOG_CODE,
+            "[hipGraph] launch: live reset dispatched (gpu=%d) pool cont_buf=0x%zx cnt=%u",
+            (int)did_gpu_reset,
+            reinterpret_cast<uintptr_t>(persistent_pool_->ContBuffer()),
+            persistent_pool_->ContBufferCount());
   }
+
+  // Enqueue one ordering Marker per internal stream so that each stream's
+  // dep-barrier does not see stale 0 values from the prior launch.  The
+  // Marker waits on the reset kernel's completion signal; once the reset
+  // retires all pool signals are back at 1 and the dep-barriers are safe.
+  // if (gpu_reset_hw_event != nullptr) {
+  //   for (auto* s : streams) {
+  //     if (s == launch_stream) continue;
+  //     auto* marker = new amd::Marker(*s, kMarkerDisableFlush, {});
+  //     if (marker != nullptr) {
+  //       marker->addDepHwEvent(gpu_reset_hw_event);
+  //       marker->enqueue();
+  //       marker->release();
+  //     }
+  //   }
+  // }
 
   // Resolve a segment's assigned hip::Stream* from its pre-computed stream_id.
-  // streams is the collision-handled streams_ vector built by UpdateStreams.
   auto resolveSegmentStream = [&](const Segment& seg) -> hip::Stream* {
     if (!streams.empty()) {
       return streams[static_cast<size_t>(seg.stream_id) % streams.size()];
@@ -1833,95 +1971,40 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
     return launch_stream;
   };
 
-  // Single AccumulateCommand on launch_stream serves as the dispatch anchor
-  // for all segments across all streams. It carries ONLY a non-owning
-  // reference to the persistent pool — no recycle callback, no ownership
-  // transfer. ~AccumulateCommand will not touch the pool.
+  // Single AccumulateCommand anchors all segment dispatches.
   auto* graph_accumulate = new amd::AccumulateCommand(*launch_stream, {}, nullptr);
-  // graph_accumulate->SetGraphSignalPool(launch_pool);
+  // graph_accumulate->SetGraphSignalPool(persistent_pool_);
 
-  // GPU-reset: enqueue one ordering marker on every internal stream before any
-  // segment dispatches. The reset kernel ran on launch_stream so its completion
-  // already implies all prior launch_stream work is done. Every internal stream
-  // must wait — all pool signals may be stale until the reset kernel retires.
-  if (gpu_reset_hw_event != nullptr) {
-    for (auto* s : streams) {
-      if (s == launch_stream) continue;
-      auto* marker = new amd::Marker(*s, kMarkerDisableFlush, {});
-      if (marker != nullptr) {
-        marker->addDepHwEvent(gpu_reset_hw_event);
-        marker->enqueue();
-        marker->release();
-      }
-    }
-  }
-
-  // Process segments level by level
+  // Dispatch pre-built flat packets level by level.
   for (int level = 0; level <= max_dependency_level_; ++level) {
     auto level_it = segments_per_level_.find(level);
-    if (level_it == segments_per_level_.end()) {
-      continue;
-    }
+    if (level_it == segments_per_level_.end()) continue;
 
-    const auto& segments_at_level = level_it->second;
-
-    // CPU-reset, level 0 only: root nodes have no AQL barrier predecessors so
-    // any internal stream that receives one must wait for prior launch_stream
-    // work. Only enqueue a marker per stream — if all roots land on
-    // launch_stream, no markers are enqueued at all.
-    if (did_gpu_reset == false && gpu_reset_hw_event == nullptr && level == 0) {
-      amd::Command* launch_last_cmd = launch_stream->getLastQueuedCommand(true);
-      if (launch_last_cmd != nullptr) {
-        amd::Command::EventWaitList launch_wait_list;
-        launch_wait_list.push_back(launch_last_cmd);
-
-        for (int segment_id : segments_at_level) {
-          hip::Stream* seg_stream = resolveSegmentStream(segments_[segment_id]);
-          if (seg_stream != launch_stream) {
-            auto marker = new amd::Marker(*seg_stream, kMarkerDisableFlush, launch_wait_list);
-            if (marker != nullptr) {
-              marker->enqueue();
-              marker->release();
-            }
-          }
-        }
-        launch_last_cmd->release();
-      }
-    }
-
-    // Dispatch each segment — barriers are in the batch, signals are patched
-    for (int segment_id : segments_at_level) {
+    for (int segment_id : level_it->second) {
       const auto& segment = segments_[segment_id];
       hip::Stream* current_stream = resolveSegmentStream(segment);
 
       status = EnqueueSegment(segment, current_stream, graph_accumulate);
-
       if (status != hipSuccess) {
         graph_accumulate->release();
-        if (out_status != nullptr) {
-          *out_status = status;
-        }
+        if (out_status != nullptr) *out_status = status;
         return nullptr;
       }
     }
   }
 
-  // Synchronize parallel streams back to the launch stream via leaf HW events
-  // if (IsLeafNodeSyncRequired()) {
-    for (int seg_id : sync_plan_.leaf_segment_ids) {
-      if (seg_id >= 0 && seg_id < static_cast<int>(segments_.size())) {
-        hip::Stream* seg_stream = resolveSegmentStream(segments_[seg_id]);
-        if (seg_stream != launch_stream) {
-          graph_accumulate->addDepHwEvent(segment_hw_events[seg_id]);
+  // Synchronize parallel leaf streams back to launch_stream using the stable
+  // pre-allocated signals from sync_plan_.segment_hw_events (dense indices).
+  for (int seg_id : sync_plan_.leaf_segment_ids) {
+    if (seg_id >= 0 && seg_id < static_cast<int>(segments_.size())) {
+      hip::Stream* seg_stream = resolveSegmentStream(segments_[seg_id]);
+      if (seg_stream != launch_stream) {
+        int hw_idx = sync_plan_.seg_to_hw_event[seg_id];
+        if (hw_idx >= 0 && hw_idx < static_cast<int>(sync_plan_.segment_hw_events.size())) {
+          graph_accumulate->addDepHwEvent(sync_plan_.segment_hw_events[hw_idx]);
         }
       }
     }
-  // }
-
-  // Cache GPU-only signal count for future launches (first launch or if count grew)
-  size_t used = device->GetGraphSignalPoolUsedCount(launch_pool);
-  if (used > graph_signal_count_) {
-    graph_signal_count_ = used;
   }
 
   graph_accumulate->enqueue();

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -431,6 +431,7 @@ void GraphExec::BuildSyncPlan() {
   sync_plan_.patch_list.clear();
   sync_plan_.barrier_packets.clear();
   sync_plan_.leaf_segment_ids.clear();
+  graph_irq_signal_count_ = 0;
 
   auto* device = g_devices[instantiateDeviceId_]->devices()[0];
 
@@ -551,7 +552,19 @@ void GraphExec::BuildSyncPlan() {
     if (segment.segment_ids_edges.empty()) {
       sync_plan_.leaf_segment_ids.push_back(segment.id);
     }
+
+    // Count interrupt signals needed for non-captured host nodes in this segment.
+    for (size_t i = 0; i < segment.nodes.size(); ++i) {
+      if (!segBatch.node_capture_status[i] &&
+          segment.nodes[i]->GetType() == hipGraphNodeTypeHost) {
+        graph_irq_signal_count_ += 2;
+      }
+    }
   }
+
+  // Seed GPU-only signal count with known minimum (SyncPlan HW events)
+  // so even the first launch pre-allocates these instead of growing on demand.
+  graph_signal_count_ = sync_plan_.num_segments;
 }
 
 // ================================================================================================
@@ -1720,19 +1733,19 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
 
   auto* device = g_devices[launch_stream->DeviceId()]->devices()[0];
 
-  // Allocate HW events for all segments
+  // Create per-launch graph signal pool: pre-allocates GPU-only and IRQ signals,
+  // acquires one hw-event per segment, and resets GetLastAcquired() so it only
+  // tracks actual dispatches. All pool method calls are encapsulated in the factory.
   std::vector<void*> segment_hw_events;
-  if (sync_plan_.num_segments > 0) {
-    if (!device->CreateHwEvents(sync_plan_.num_segments, segment_hw_events)) {
-      if (out_status != nullptr) {
-        *out_status = hipErrorOutOfMemory;
-      }
-      return nullptr;
-    }
+  auto* launch_pool = device->CreateGraphSignalPool(
+      graph_signal_count_, graph_irq_signal_count_,
+      static_cast<size_t>(sync_plan_.num_segments), segment_hw_events);
+  if (launch_pool == nullptr) {
+    if (out_status != nullptr) *out_status = hipErrorOutOfMemory;
+    return nullptr;
   }
 
-  // Apply pre-computed patches -- writes HW events directly into flatPacketData
-  // via the flat_packet pointers resolved at instantiate time, so no rebuild needed.
+  // Apply pre-computed patches — writes HW events directly into flatPacketData
   if (!sync_plan_.patch_list.empty()) {
     device->ApplyHwEventPatches(sync_plan_.patch_list, segment_hw_events);
   }
@@ -1746,18 +1759,13 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
     return launch_stream;
   };
 
-  // Single AccumulateCommand on launch_stream manages all HW event lifetimes
+  // Single AccumulateCommand on launch_stream manages graph pool lifetime
   // and serves as the dispatch anchor for all segments across all streams.
+  // Note: SetOwnedGraphSignalPool transfers ownership — on error paths below,
+  // graph_accumulate->release() deletes the pool via ~AccumulateCommand.
   auto* graph_accumulate = new amd::AccumulateCommand(*launch_stream, {}, nullptr);
-
-  // Register HW events with graph_accumulate for lifetime tracking.
-  // addHwEvent does not retain — ownership transfers from CreateHwEvents
-  // to graph_accumulate. ~AccumulateCommand releases them after graph completion.
-  for (auto& hw_event : segment_hw_events) {
-    if (hw_event != nullptr) {
-      graph_accumulate->addHwEvent(hw_event, device);
-    }
-  }
+  graph_accumulate->SetGraphSignalPool(launch_pool);
+  graph_accumulate->SetOwnedGraphSignalPool(launch_pool);
 
   // Process segments level by level
   for (int level = 0; level <= max_dependency_level_; ++level) {
@@ -1769,13 +1777,13 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
     const auto& segments_at_level = level_it->second;
 
     if (level == 0) {
-      // Synchronize internal streams with launch stream's last command if available
+      // Synchronize internal streams with launch stream's last command if available.
+      // These wait markers use runtime pool signals (no graph pool) for boundary sync.
       amd::Command* launch_last_cmd = launch_stream->getLastQueuedCommand(true);
       if (launch_last_cmd != nullptr) {
         amd::Command::EventWaitList launch_wait_list;
         launch_wait_list.push_back(launch_last_cmd);
 
-        // For each segment at level 0, if it's on a different stream, add a wait marker
         for (int segment_id : segments_at_level) {
           hip::Stream* seg_stream = resolveSegmentStream(segments_[segment_id]);
           if (seg_stream != launch_stream) {
@@ -1790,7 +1798,7 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
       }
     }
 
-    // Dispatch each segment -- barriers are in the batch, signals are patched
+    // Dispatch each segment — barriers are in the batch, signals are patched
     for (int segment_id : segments_at_level) {
       const auto& segment = segments_[segment_id];
       hip::Stream* current_stream = resolveSegmentStream(segment);
@@ -1807,10 +1815,7 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
     }
   }
 
-  // Synchronize parallel streams back to the launch stream.
-  // Each leaf segment already has a completion HW event signal patched onto its
-  // last packet. Add those HW events as dependencies on graph_accumulate so
-  // the runtime emits barrier packets when it is enqueued on the launch stream.
+  // Synchronize parallel streams back to the launch stream via leaf HW events
   if (IsLeafNodeSyncRequired()) {
     for (int seg_id : sync_plan_.leaf_segment_ids) {
       if (seg_id >= 0 && seg_id < static_cast<int>(segments_.size())) {
@@ -1820,6 +1825,12 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
         }
       }
     }
+  }
+
+  // Cache GPU-only signal count for future launches (first launch or if count grew)
+  size_t used = device->GetGraphSignalPoolUsedCount(launch_pool);
+  if (used > graph_signal_count_) {
+    graph_signal_count_ = used;
   }
 
   graph_accumulate->enqueue();
@@ -1845,8 +1856,11 @@ hipError_t GraphExec::EnqueueSegment(const Segment& segment, hip::Stream* stream
 
   size_t batchIndex = 0;
 
-  // Lambda to dispatch the current batch at batchIndex
-  auto dispatchCurrentBatch = [&]() -> hipError_t {
+  // Lambda to dispatch the current batch at batchIndex.
+  // attach_signal: when true, places a completion signal on the last packet so a
+  // subsequent non-captured node (e.g. SDMA) can wait on it directly via
+  // WaitingSignal, avoiding an extra barrier packet in the AQL queue.
+  auto dispatchCurrentBatch = [&](bool attach_signal = false) -> hipError_t {
     if (!segBatch || batchIndex >= segBatch->packet_batches.size()) {
       return hipSuccess;
     }
@@ -1873,7 +1887,7 @@ hipError_t GraphExec::EnqueueSegment(const Segment& segment, hip::Stream* stream
 
     if (!flatData->empty()) {
       bool batchStatus = stream->vdev()->dispatchAqlPacketBatchFlat(
-          *flatData, *flatHdrs, accumulate, false, kernelNamesToDispatch, true);
+          *flatData, *flatHdrs, accumulate, attach_signal, kernelNamesToDispatch, true);
       if (!batchStatus) {
         return hipErrorUnknown;
       }
@@ -1928,8 +1942,6 @@ hipError_t GraphExec::EnqueueSegment(const Segment& segment, hip::Stream* stream
 
   // Process all nodes in this segment
   for (size_t i = 0; i < segment.nodes.size(); ++i) {
-    auto& node = segment.nodes[i];
-
     if (segBatch && i < segBatch->node_capture_status.size() &&
         segBatch->node_capture_status[i]) {
       // Node was successfully captured - dispatch its batch
@@ -1944,36 +1956,36 @@ hipError_t GraphExec::EnqueueSegment(const Segment& segment, hip::Stream* stream
         // Skip all consecutive captured nodes that belong to this batch
         i += packetBatch.nodeRanges.size() - 1;
 
-        status = dispatchCurrentBatch();
+        // Check if an uncaptured SDMA node (memcpy/memset) follows this batch.
+        // If so, attach a signal to the last packet so the SDMA engine can wait
+        // on it directly via WaitingSignal, avoiding an extra barrier packet.
+        bool sdma_follows = false;
+        size_t next = i + 1;
+        if (next < segment.nodes.size() &&
+            next < segBatch->node_capture_status.size() &&
+            !segBatch->node_capture_status[next]) {
+          sdma_follows = (segment.nodes[next]->GetType() == hipGraphNodeTypeMemcpy);
+        }
+        if (sdma_follows) {
+          stream->vdev()->addSystemScope();
+        }
+        status = dispatchCurrentBatch(sdma_follows);
         if (status != hipSuccess) return status;
       }
     } else {
-      // Node doesn't support capture - execute individually.
-      // Flat dispatch bypasses the Barriers() tracker (ActiveSignal is skipped).
-      // Enqueue Markers before and after the non-captured node to:
-      //   Before: resync the Barriers() tracker so releaseGpuMemoryFence/WaitCurrent
-      //           can track queue progress for the node's internal operations.
-      //   After:  ensure the node's commands (e.g. host node blocking callbacks) are
-      //           fully flushed to the HW queue before the next flat batch is
-      //           dispatched, which writes directly to the HW queue.
-      auto pre_marker = new amd::Marker(*stream, kMarkerDisableFlush, {});
-      if (pre_marker != nullptr) {
-        pre_marker->enqueue();
-        pre_marker->release();
-      }
+      // Non-captured nodes execute through the normal command pipeline.
+      auto& uncaptured_node = segment.nodes[i];
       if (DEBUG_HIP_GRAPH_DOT_PRINT) {
-        node->stream_id_ = stream->GetStreamId();
-        node->hw_queue_id_ = stream->getQueueID();
+        uncaptured_node->stream_id_ = stream->GetStreamId();
+        uncaptured_node->hw_queue_id_ = stream->getQueueID();
       }
-      node->SetStream(stream);
-      status = node->CreateCommand(node->GetQueue());
+      uncaptured_node->SetStream(stream);
+      status = uncaptured_node->CreateCommand(uncaptured_node->GetQueue());
       if (status != hipSuccess) return status;
-      node->EnqueueCommands(stream);
-      auto post_marker = new amd::Marker(*stream, kMarkerDisableFlush, {});
-      if (post_marker != nullptr) {
-        post_marker->enqueue();
-        post_marker->release();
+      if (accumulate->graphSignalPool() != nullptr) {
+        uncaptured_node->SetGraphSignalPoolOnCommands(accumulate->graphSignalPool());
       }
+      uncaptured_node->EnqueueCommands(stream);
     }
   }
 

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -6,6 +6,12 @@
 
 #include "hip_graph_internal.hpp"
 
+// Full definition of amd::roc::GraphSignalPool — needed for direct method
+// calls (TryAcquireCachedPool / Acquire / TotalSignalCount / etc.) below.
+// device.hpp only forward-declares it.
+#include "device/rocm/rocdevice.hpp"
+#include "device/rocm/rocrctx.hpp"
+
 #define CASE_STRING(X, C)                                                                          \
   case X:                                                                                          \
     case_string = #C;                                                                              \
@@ -431,7 +437,6 @@ void GraphExec::BuildSyncPlan() {
   sync_plan_.patch_list.clear();
   sync_plan_.barrier_packets.clear();
   sync_plan_.leaf_segment_ids.clear();
-  graph_irq_signal_count_ = 0;
 
   auto* device = g_devices[instantiateDeviceId_]->devices()[0];
 
@@ -553,13 +558,6 @@ void GraphExec::BuildSyncPlan() {
       sync_plan_.leaf_segment_ids.push_back(segment.id);
     }
 
-    // Count interrupt signals needed for non-captured host nodes in this segment.
-    for (size_t i = 0; i < segment.nodes.size(); ++i) {
-      if (!segBatch.node_capture_status[i] &&
-          segment.nodes[i]->GetType() == hipGraphNodeTypeHost) {
-        graph_irq_signal_count_ += 2;
-      }
-    }
   }
 
   // Seed GPU-only signal count with known minimum (SyncPlan HW events)
@@ -1733,21 +1731,97 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
 
   auto* device = g_devices[launch_stream->DeviceId()]->devices()[0];
 
-  // Create per-launch graph signal pool: pre-allocates GPU-only and IRQ signals,
-  // acquires one hw-event per segment, and resets GetLastAcquired() so it only
-  // tracks actual dispatches. All pool method calls are encapsulated in the factory.
+  // Persistent pool model:
+  //   - Pool is owned by GraphExec, allocated lazily on first launch.
+  //   - At each launch, decide reset path by inspecting prev_leaf_signals_
+  //     (the GPU-only signals that the previous launch's leaf segments
+  //     completed into). All-zero ⇒ previous launch fully drained ⇒ CPU
+  //     fast reset. Otherwise ⇒ GPU reset (kernel dispatched on launch_stream
+  //     so existing level-0 wait markers naturally serialize segment kernels
+  //     after the reset).
+  //   - AccumulateCommand never owns the pool; it carries only a non-owning
+  //     reference so segments can pull GPU-only signals from it.
   std::vector<void*> segment_hw_events;
-  auto* launch_pool = device->CreateGraphSignalPool(
-      graph_signal_count_, graph_irq_signal_count_,
-      static_cast<size_t>(sync_plan_.num_segments), segment_hw_events);
+  amd::roc::GraphSignalPool* launch_pool = nullptr;
+
+  // When the GPU-reset path is taken, this holds the reset kernel's
+  // completion signal (a ProfilingSignal*). Parallel-stream level-0
+  // dispatches must wait on it so they don't read stale signal values
+  // before the reset kernel has retired. Same-queue ordering covers the
+  // launch_stream itself.
+  void* gpu_reset_hw_event = nullptr;
+  bool did_gpu_reset = false;
+
+  if (persistent_pool_ != nullptr) {
+    // Reuse path. Decide CPU vs GPU reset based on prev_leaf_signals_ status.
+    bool prev_done = true;
+    for (auto* ps : prev_leaf_signals_) {
+      if (ps != nullptr && amd::roc::Hsa::signal_load_relaxed(ps->signal_) != 0) {
+        prev_done = false;
+        break;
+      }
+    }
+    if (!device->ResetGraphSignalPool(launch_stream->vdev(), persistent_pool_,
+                                      /*prev_done=*/prev_done, &did_gpu_reset)) {
+      // Reset failed (allocation/dispatch error). Drop and re-allocate.
+      DestroyPersistentPool();
+    } else {
+      if (did_gpu_reset) {
+        // The reset kernel was dispatched with attach_signal=true on
+        // launch_stream's queue; pull its completion signal back here so
+        // parallel-stream dispatches at level 0 can wait on it.
+        auto* gpu = static_cast<amd::roc::VirtualGPU*>(launch_stream->vdev());
+        gpu_reset_hw_event = gpu->Barriers().GetLastSignal();
+      }
+      launch_pool = persistent_pool_;
+      segment_hw_events.assign(sync_plan_.num_segments, nullptr);
+      bool acquire_ok = true;
+      for (int i = 0; i < sync_plan_.num_segments; ++i) {
+        segment_hw_events[i] = launch_pool->Acquire();
+        if (segment_hw_events[i] == nullptr) {
+          acquire_ok = false;
+          break;
+        }
+      }
+      if (!acquire_ok) {
+        DestroyPersistentPool();
+        launch_pool = nullptr;
+        segment_hw_events.clear();
+      } else {
+        launch_pool->ResetLastAcquired();
+      }
+    }
+  }
+
   if (launch_pool == nullptr) {
-    if (out_status != nullptr) *out_status = hipErrorOutOfMemory;
-    return nullptr;
+    // First launch (or fallback). Allocate a fresh pool sized to the cached
+    // GPU-only signal count plus one slot per segment.
+    launch_pool = device->CreateGraphSignalPool(
+        graph_signal_count_,
+        static_cast<size_t>(sync_plan_.num_segments), segment_hw_events);
+    if (launch_pool == nullptr) {
+      if (out_status != nullptr) *out_status = hipErrorOutOfMemory;
+      return nullptr;
+    }
+    persistent_pool_ = launch_pool;
+    persistent_pool_device_ = device;
   }
 
   // Apply pre-computed patches — writes HW events directly into flatPacketData
   if (!sync_plan_.patch_list.empty()) {
     device->ApplyHwEventPatches(sync_plan_.patch_list, segment_hw_events);
+  }
+
+  // Snapshot leaf hw_events for the next launch's reset decision. Done up
+  // front because segment_hw_events may be reordered/consumed by the dispatch
+  // path below.
+  prev_leaf_signals_.clear();
+  prev_leaf_signals_.reserve(sync_plan_.leaf_segment_ids.size());
+  for (int seg_id : sync_plan_.leaf_segment_ids) {
+    if (seg_id >= 0 && seg_id < static_cast<int>(segment_hw_events.size())) {
+      prev_leaf_signals_.push_back(
+          static_cast<amd::roc::ProfilingSignal*>(segment_hw_events[seg_id]));
+    }
   }
 
   // Resolve a segment's assigned hip::Stream* from its pre-computed stream_id.
@@ -1759,13 +1833,28 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
     return launch_stream;
   };
 
-  // Single AccumulateCommand on launch_stream manages graph pool lifetime
-  // and serves as the dispatch anchor for all segments across all streams.
-  // Note: SetOwnedGraphSignalPool transfers ownership — on error paths below,
-  // graph_accumulate->release() deletes the pool via ~AccumulateCommand.
+  // Single AccumulateCommand on launch_stream serves as the dispatch anchor
+  // for all segments across all streams. It carries ONLY a non-owning
+  // reference to the persistent pool — no recycle callback, no ownership
+  // transfer. ~AccumulateCommand will not touch the pool.
   auto* graph_accumulate = new amd::AccumulateCommand(*launch_stream, {}, nullptr);
-  graph_accumulate->SetGraphSignalPool(launch_pool);
-  graph_accumulate->SetOwnedGraphSignalPool(launch_pool);
+  // graph_accumulate->SetGraphSignalPool(launch_pool);
+
+  // GPU-reset: enqueue one ordering marker on every internal stream before any
+  // segment dispatches. The reset kernel ran on launch_stream so its completion
+  // already implies all prior launch_stream work is done. Every internal stream
+  // must wait — all pool signals may be stale until the reset kernel retires.
+  if (gpu_reset_hw_event != nullptr) {
+    for (auto* s : streams) {
+      if (s == launch_stream) continue;
+      auto* marker = new amd::Marker(*s, kMarkerDisableFlush, {});
+      if (marker != nullptr) {
+        marker->addDepHwEvent(gpu_reset_hw_event);
+        marker->enqueue();
+        marker->release();
+      }
+    }
+  }
 
   // Process segments level by level
   for (int level = 0; level <= max_dependency_level_; ++level) {
@@ -1776,9 +1865,11 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
 
     const auto& segments_at_level = level_it->second;
 
-    if (level == 0) {
-      // Synchronize internal streams with launch stream's last command if available.
-      // These wait markers use runtime pool signals (no graph pool) for boundary sync.
+    // CPU-reset, level 0 only: root nodes have no AQL barrier predecessors so
+    // any internal stream that receives one must wait for prior launch_stream
+    // work. Only enqueue a marker per stream — if all roots land on
+    // launch_stream, no markers are enqueued at all.
+    if (did_gpu_reset == false && gpu_reset_hw_event == nullptr && level == 0) {
       amd::Command* launch_last_cmd = launch_stream->getLastQueuedCommand(true);
       if (launch_last_cmd != nullptr) {
         amd::Command::EventWaitList launch_wait_list;
@@ -1787,7 +1878,7 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
         for (int segment_id : segments_at_level) {
           hip::Stream* seg_stream = resolveSegmentStream(segments_[segment_id]);
           if (seg_stream != launch_stream) {
-            auto marker = new amd::Marker(*seg_stream, true, launch_wait_list);
+            auto marker = new amd::Marker(*seg_stream, kMarkerDisableFlush, launch_wait_list);
             if (marker != nullptr) {
               marker->enqueue();
               marker->release();
@@ -1816,7 +1907,7 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
   }
 
   // Synchronize parallel streams back to the launch stream via leaf HW events
-  if (IsLeafNodeSyncRequired()) {
+  // if (IsLeafNodeSyncRequired()) {
     for (int seg_id : sync_plan_.leaf_segment_ids) {
       if (seg_id >= 0 && seg_id < static_cast<int>(segments_.size())) {
         hip::Stream* seg_stream = resolveSegmentStream(segments_[seg_id]);
@@ -1825,7 +1916,7 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
         }
       }
     }
-  }
+  // }
 
   // Cache GPU-only signal count for future launches (first launch or if count grew)
   size_t used = device->GetGraphSignalPoolUsedCount(launch_pool);

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -6,9 +6,11 @@
 
 #pragma once
 #include <algorithm>
+#include <chrono>
 #include <queue>
 #include <stack>
 #include <iostream>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -243,6 +245,9 @@ class GraphNode : public hipGraphNodeDOTAttribute {
                                   std::vector<uint8_t*>* batchPackets = nullptr,
                                   std::vector<const std::string*>* batchKernelNames = nullptr) {
     auto capture_stream = hip::getNullStream(g_devices[dev_id_]->devices()[0]->context(), false);
+    if (capture_stream == nullptr) {
+      return hipErrorInvalidDevice;
+    }
     hipError_t status = CreateCommand(capture_stream);
     if (status != hipSuccess) {
       return status;
@@ -1122,21 +1127,22 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
   std::unordered_map<int, SegmentBatch> segmentBatches_;
 
   struct SyncPlan {
-    int num_segments = 0;   // total segment count (used for bounds checks)
-    int num_hw_events = 0;  // HW event slots to allocate (one per ncs=true segment)
+    int num_segments  = 0;  //!< total segment count (bounds check reference)
+    int num_hw_events = 0;  //!< HW event slots allocated (one per leaf parallel segment)
 
-    // Dense index into segment_hw_events for each segment.
-    // seg_to_hw_event[seg_id] == -1  ->  no completion signal emitted.
-    // seg_to_hw_event[seg_id] >= 0  ->  index into the compact hw_events vector.
-    std::vector<int> seg_to_hw_event;
-
-    // Stable ProfilingSignal* per HW event, allocated at instantiate time.
-    // Size == num_hw_events; indexed by seg_to_hw_event[seg_id].
+    //! seg_to_hw_event[seg_id]: -1 = no completion signal; >= 0 = index into segment_hw_events.
+    std::vector<int>   seg_to_hw_event;
+    //! Stable ProfilingSignal* per HW event slot; indexed via seg_to_hw_event.
     std::vector<void*> segment_hw_events;
 
     std::vector<amd::Device::HwEventPatch> patch_list;
-    std::vector<uint8_t*> barrier_packets;
-    std::vector<int> leaf_segment_ids;
+    std::vector<uint8_t*>                  barrier_packets;
+    std::vector<int>                       leaf_segment_ids;
+
+    //! Pointers to dep_signal[0].handle (AQL byte offset 8) in the flat buffer of
+    //! each non-stream-0 segment's first packet.  Patched at every hipGraphLaunch
+    //! with the reset kernel's per-launch completion signal handle.
+    std::vector<uint64_t*> nonstream0_dep_signal_ptrs;
 
     ~SyncPlan() {
       for (auto* p : barrier_packets) { delete[] p; }
@@ -1157,22 +1163,14 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
   amd::Device* persistent_pool_device_ = nullptr;  //!< Device that owns persistent_pool_
 
   //! Dedicated completion signal for the pre-baked reset kernel.
-  //! CPU re-arms to 1 before each launch; GPU reset kernel drives it to 0.
-  //! Internal-stream reset-wait barriers (pre-baked in flat buffers) block on it.
-  //! Owned by persistent_pool_ — never freed here.
+  //! Non-null when graph has parallel (non-stream-0) segments; guards the
+  //! dep-signal barrier prepend in CaptureAndFormPacketsForGraph.
+  //! Freed in DestroyPersistentPool.
   amd::roc::ProfilingSignal* reset_signal_ = nullptr;
 
-  //! Drop persistent_pool_ in ~GraphExec. Caller must have already finished
-  //! every parallel stream so no in-flight AQL packet still references its
-  //! signals.
-  void DestroyPersistentPool() {
-    if (persistent_pool_ != nullptr && persistent_pool_device_ != nullptr) {
-      persistent_pool_device_->DestroyGraphSignalPool(persistent_pool_);
-      persistent_pool_ = nullptr;
-      reset_signal_ = nullptr;        // owned by pool, not freed here
-      sync_plan_.segment_hw_events.clear();
-    }
-  }
+  //! Release persistent_pool_ and reset_signal_.  Must be called only after
+  //! all in-flight launches have retired (no AQL packets still reference them).
+  void DestroyPersistentPool();
 };
 
 class ChildGraphNode : public GraphNode, public GraphExec {

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1130,6 +1130,10 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
     // seg_to_hw_event[seg_id] >= 0  ->  index into the compact hw_events vector.
     std::vector<int> seg_to_hw_event;
 
+    // Stable ProfilingSignal* per HW event, allocated at instantiate time.
+    // Size == num_hw_events; indexed by seg_to_hw_event[seg_id].
+    std::vector<void*> segment_hw_events;
+
     std::vector<amd::Device::HwEventPatch> patch_list;
     std::vector<uint8_t*> barrier_packets;
     std::vector<int> leaf_segment_ids;
@@ -1144,22 +1148,19 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
   void BuildSyncPlan();
 
   //! Cached signal counts for graph signal pool pre-allocation
-  size_t graph_signal_count_ = 0;      //!< GPU-only signals, cached after first launch
+  size_t graph_signal_count_ = 0;      //!< GPU-only signals (= num_hw_events after BuildSyncPlan)
 
-  //! Persistent signal pool owned by this GraphExec and reused across launches.
-  //! Allocated lazily on the first call to EnqueueSegmentedGraph and destroyed
-  //! in ~GraphExec (after all parallel streams have finished). AccumulateCommand
-  //! holds only a non-owning reference to this pool — there is no ownership
-  //! transfer or recycle callback.
+  //! Persistent signal pool owned by this GraphExec, allocated at instantiate time
+  //! in CaptureAndFormPacketsForGraph and destroyed in ~GraphExec.
+  //! AccumulateCommand holds only a non-owning reference.
   amd::roc::GraphSignalPool* persistent_pool_ = nullptr;
   amd::Device* persistent_pool_device_ = nullptr;  //!< Device that owns persistent_pool_
 
-  //! Probe signals from the previous launch's leaf segments. Each one is a
-  //! GPU-only signal from persistent_pool_ that reaches 0 when its leaf
-  //! segment's completion barrier fires; the previous launch is fully done
-  //! iff every entry is at 0. Read at the next launch to decide CPU-fast-reset
-  //! vs GPU-reset. Pointers live inside persistent_pool_ — never released here.
-  std::vector<amd::roc::ProfilingSignal*> prev_leaf_signals_;
+  //! Dedicated completion signal for the pre-baked reset kernel.
+  //! CPU re-arms to 1 before each launch; GPU reset kernel drives it to 0.
+  //! Internal-stream reset-wait barriers (pre-baked in flat buffers) block on it.
+  //! Owned by persistent_pool_ — never freed here.
+  amd::roc::ProfilingSignal* reset_signal_ = nullptr;
 
   //! Drop persistent_pool_ in ~GraphExec. Caller must have already finished
   //! every parallel stream so no in-flight AQL packet still references its
@@ -1168,7 +1169,8 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
     if (persistent_pool_ != nullptr && persistent_pool_device_ != nullptr) {
       persistent_pool_device_->DestroyGraphSignalPool(persistent_pool_);
       persistent_pool_ = nullptr;
-      prev_leaf_signals_.clear();
+      reset_signal_ = nullptr;        // owned by pool, not freed here
+      sync_plan_.segment_hw_events.clear();
     }
   }
 };

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -291,6 +291,12 @@ class GraphNode : public hipGraphNodeDOTAttribute {
   int GetID() const { return id_; }
   /// Returns command for graph node
   virtual std::vector<amd::Command*>& GetCommands() { return commands_; }
+  /// Propagate graph signal pool to all commands owned by this node
+  void SetGraphSignalPoolOnCommands(amd::roc::GraphSignalPool* pool) {
+    for (auto& cmd : commands_) {
+      if (cmd != nullptr) cmd->SetGraphSignalPool(pool);
+    }
+  }
   /// Returns graph node type
   hipGraphNodeType GetType() const { return type_; }
   /// Clone graph node
@@ -1125,6 +1131,10 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
   SyncPlan sync_plan_;
 
   void BuildSyncPlan();
+
+  //! Cached signal counts for graph signal pool pre-allocation
+  size_t graph_signal_count_ = 0;      //!< GPU-only signals, cached after first launch
+  size_t graph_irq_signal_count_ = 0;  //!< Interrupt signals, determined at instantiation
 };
 
 class ChildGraphNode : public GraphNode, public GraphExec {

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -21,6 +21,11 @@
 #include "hip_mempool_impl.hpp"
 #include "hip_vm.hpp"
 
+namespace amd { namespace roc {
+  struct GraphSignalPool;
+  struct ProfilingSignal;
+}}
+
 typedef struct ihipExtKernelEvents {
   hipEvent_t startEvent_;
   hipEvent_t stopEvent_;
@@ -977,6 +982,12 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
       }
     }
 
+    // Destroy persistent pool. All parallel streams were finished above, so
+    // every signal owned by the pool is settled and no in-flight AQL packet
+    // still references it. Any IRQ signal used by an AccumulateCommand came
+    // from the runtime pool, not this one.
+    DestroyPersistentPool();
+
     segmentBatches_.clear();
   }
 
@@ -1134,7 +1145,32 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
 
   //! Cached signal counts for graph signal pool pre-allocation
   size_t graph_signal_count_ = 0;      //!< GPU-only signals, cached after first launch
-  size_t graph_irq_signal_count_ = 0;  //!< Interrupt signals, determined at instantiation
+
+  //! Persistent signal pool owned by this GraphExec and reused across launches.
+  //! Allocated lazily on the first call to EnqueueSegmentedGraph and destroyed
+  //! in ~GraphExec (after all parallel streams have finished). AccumulateCommand
+  //! holds only a non-owning reference to this pool — there is no ownership
+  //! transfer or recycle callback.
+  amd::roc::GraphSignalPool* persistent_pool_ = nullptr;
+  amd::Device* persistent_pool_device_ = nullptr;  //!< Device that owns persistent_pool_
+
+  //! Probe signals from the previous launch's leaf segments. Each one is a
+  //! GPU-only signal from persistent_pool_ that reaches 0 when its leaf
+  //! segment's completion barrier fires; the previous launch is fully done
+  //! iff every entry is at 0. Read at the next launch to decide CPU-fast-reset
+  //! vs GPU-reset. Pointers live inside persistent_pool_ — never released here.
+  std::vector<amd::roc::ProfilingSignal*> prev_leaf_signals_;
+
+  //! Drop persistent_pool_ in ~GraphExec. Caller must have already finished
+  //! every parallel stream so no in-flight AQL packet still references its
+  //! signals.
+  void DestroyPersistentPool() {
+    if (persistent_pool_ != nullptr && persistent_pool_device_ != nullptr) {
+      persistent_pool_device_->DestroyGraphSignalPool(persistent_pool_);
+      persistent_pool_ = nullptr;
+      prev_leaf_signals_.clear();
+    }
+  }
 };
 
 class ChildGraphNode : public GraphNode, public GraphExec {

--- a/projects/clr/rocclr/device/blitcl.cpp
+++ b/projects/clr/rocclr/device/blitcl.cpp
@@ -197,6 +197,22 @@ const char* HipExtraSourceCode = BLIT_KERNELS(
       }
     }
 
+    // Faster variant for pools that carry a persistent contiguous VA buffer
+    // (GraphSignalPool::ContBuffer()).  The caller passes the stable device
+    // pointer populated once at pool-creation time; no per-launch host-to-
+    // device copy of the address array is needed.  The kernel body is
+    // identical to __amd_rocclr_resetGraphSignals — the performance benefit
+    // comes entirely from eliminating the CPU-side CollectValuePtrs() scan
+    // and the memcpy into a transient kernarg slot on the dispatch path.
+    __kernel void __amd_rocclr_resetContSignalBuffer(__global ulong* valueAddrs, uint count,
+                                                     ulong resetValue) {
+      uint i = (uint)get_global_id(0);
+      if (i < count) {
+        __global ulong* p = (__global ulong*)(valueAddrs[i]);
+        *p = resetValue;
+      }
+    }
+
     __kernel void __amd_rocclr_gwsInit(uint value) { __builtin_amdgcn_ds_gws_init(value, 0); });
 
 const char* HipExtraSourceCodeNoGWS = BLIT_KERNELS(
@@ -229,6 +245,16 @@ const char* HipExtraSourceCodeNoGWS = BLIT_KERNELS(
     // no-GWS variant for parity.
     __kernel void __amd_rocclr_resetGraphSignals(__global ulong* valueAddrs, uint count,
                                                  ulong resetValue) {
+      uint i = (uint)get_global_id(0);
+      if (i < count) {
+        __global ulong* p = (__global ulong*)(valueAddrs[i]);
+        *p = resetValue;
+      }
+    }
+
+    // See HipExtraSourceCode for the rationale; no-GWS parity copy.
+    __kernel void __amd_rocclr_resetContSignalBuffer(__global ulong* valueAddrs, uint count,
+                                                     ulong resetValue) {
       uint i = (uint)get_global_id(0);
       if (i < count) {
         __global ulong* p = (__global ulong*)(valueAddrs[i]);

--- a/projects/clr/rocclr/device/blitcl.cpp
+++ b/projects/clr/rocclr/device/blitcl.cpp
@@ -180,6 +180,23 @@ const char* HipExtraSourceCode = BLIT_KERNELS(
       __ockl_dm_init_v1(heap_to_initialize, initial_blocks, heap_size, number_of_initial_blocks);
     }
 
+    // Resets graph-pool amd_signal_t.value fields back to a given value
+    // (default 1) so the pool can be recycled for the next launch.
+    // `valueAddrs` is a flat array of raw 64-bit device addresses (one per
+    // signal); each work-item casts an entry to a __global ulong* and performs
+    // a plain 64-bit store. Each address is written by exactly one work-item
+    // (no intra-kernel race), and the AQL packet's scope_release at kernel
+    // completion makes the writes visible to host signal-wait hardware before
+    // the next iteration's AQL barrier acquires them.
+    __kernel void __amd_rocclr_resetGraphSignals(__global ulong* valueAddrs, uint count,
+                                                 ulong resetValue) {
+      uint i = (uint)get_global_id(0);
+      if (i < count) {
+        __global ulong* p = (__global ulong*)(valueAddrs[i]);
+        *p = resetValue;
+      }
+    }
+
     __kernel void __amd_rocclr_gwsInit(uint value) { __builtin_amdgcn_ds_gws_init(value, 0); });
 
 const char* HipExtraSourceCodeNoGWS = BLIT_KERNELS(
@@ -206,6 +223,17 @@ const char* HipExtraSourceCodeNoGWS = BLIT_KERNELS(
     __kernel void __amd_rocclr_initHeap(ulong heap_to_initialize, ulong initial_blocks,
                                         uint heap_size, uint number_of_initial_blocks) {
       __ockl_dm_init_v1(heap_to_initialize, initial_blocks, heap_size, number_of_initial_blocks);
+    }
+
+    // See HipExtraSourceCode for the rationale; same kernel emitted in the
+    // no-GWS variant for parity.
+    __kernel void __amd_rocclr_resetGraphSignals(__global ulong* valueAddrs, uint count,
+                                                 ulong resetValue) {
+      uint i = (uint)get_global_id(0);
+      if (i < count) {
+        __global ulong* p = (__global ulong*)(valueAddrs[i]);
+        *p = resetValue;
+      }
     });
 
 const char* BlitImageSourceCode = BLIT_KERNELS(

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -43,6 +43,7 @@
 #include <shared_mutex>
 
 namespace amd {
+namespace roc { struct GraphSignalPool; }
 class Command;
 class CommandQueue;
 class ReadMemoryCommand;
@@ -1354,6 +1355,8 @@ class VirtualDevice : public amd::ReferenceCountedObject {
 
   //! Returns fence state of the VirtualGPU
   virtual bool isFenceDirty() const = 0;
+  //! Insert a system scope on the next dispatch
+  virtual void addSystemScope() {}
   //! Init hidden heap for device memory allocations
   virtual void HiddenHeapInit() = 0;
 
@@ -2128,6 +2131,19 @@ class Device : public RuntimeObject {
   virtual uint8_t* CreateBarrierPacket() const { return nullptr; }
   virtual void ApplyHwEventPatches(const std::vector<HwEventPatch>& patches,
                                    const std::vector<void*>& hw_events) const {}
+
+  // Creates a fully-initialised per-launch graph signal pool.
+  // Allocates gpu_count GPU-only signals and irq_count interrupt signals,
+  // then acquires segment_count hw-event slots into hw_events and resets
+  // the last-acquired pointer so GetLastAcquired() only tracks dispatches.
+  // Returns nullptr (and leaves hw_events empty) on allocation failure.
+  virtual roc::GraphSignalPool* CreateGraphSignalPool(
+      size_t gpu_count, size_t irq_count,
+      size_t segment_count, std::vector<void*>& hw_events) const { return nullptr; }
+
+  // Returns the number of GPU-only signals consumed from the pool so far.
+  // Used by the graph executor to cache the count for the next launch.
+  virtual size_t GetGraphSignalPoolUsedCount(roc::GraphSignalPool* pool) const { return 0; }
 
   virtual const bool isFineGrainSupported() const {
     return (info().svmCapabilities_ & CL_DEVICE_SVM_ATOMICS) != 0 ? true : false;

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -2133,17 +2133,44 @@ class Device : public RuntimeObject {
                                    const std::vector<void*>& hw_events) const {}
 
   // Creates a fully-initialised per-launch graph signal pool.
-  // Allocates gpu_count GPU-only signals and irq_count interrupt signals,
-  // then acquires segment_count hw-event slots into hw_events and resets
-  // the last-acquired pointer so GetLastAcquired() only tracks dispatches.
+  // Allocates gpu_count GPU-only signals, then acquires segment_count
+  // hw-event slots into hw_events and resets the last-acquired pointer so
+  // GetLastAcquired() only tracks dispatches. IRQ/handler-bearing signals
+  // are NOT owned by the graph pool — they come from the runtime pool.
   // Returns nullptr (and leaves hw_events empty) on allocation failure.
   virtual roc::GraphSignalPool* CreateGraphSignalPool(
-      size_t gpu_count, size_t irq_count,
+      size_t gpu_count,
       size_t segment_count, std::vector<void*>& hw_events) const { return nullptr; }
 
   // Returns the number of GPU-only signals consumed from the pool so far.
   // Used by the graph executor to cache the count for the next launch.
   virtual size_t GetGraphSignalPoolUsedCount(roc::GraphSignalPool* pool) const { return 0; }
+
+  // Destroys a graph signal pool created by CreateGraphSignalPool.
+  // Required because GraphSignalPool is only forward-declared in platform/
+  // headers; calling `delete pool;` from generic code would not invoke
+  // ~GraphSignalPool (delete-on-incomplete-type is undefined behaviour and
+  // in practice silently skips the destructor). Routing through this virtual
+  // ensures the destructor in rocdevice.cpp is actually called.
+  virtual void DestroyGraphSignalPool(roc::GraphSignalPool* pool) const {}
+
+  // Reset a previously-used graph signal pool so it can be reused for the
+  // next launch on `vdev`. When `prev_done` is true the caller has already
+  // verified (via the previous launch's leaf signals) that every GPU-only
+  // signal has settled, so we take the CPU fast path. Otherwise dispatches
+  // the __amd_rocclr_resetGraphSignals kernel on `vdev`'s queue with a
+  // completion signal attached; caller pulls it back via
+  // `vdev->Barriers().GetLastSignal()` and serializes parallel-stream
+  // dispatches behind it. `out_did_gpu_reset` (optional) is set to true iff
+  // the GPU kernel was actually dispatched (i.e. caller should read the
+  // last signal). Returns true on success.
+  virtual bool ResetGraphSignalPool(device::VirtualDevice* vdev,
+                                    roc::GraphSignalPool* pool,
+                                    bool prev_done,
+                                    bool* out_did_gpu_reset = nullptr) const {
+    if (out_did_gpu_reset != nullptr) *out_did_gpu_reset = false;
+    return false;
+  }
 
   virtual const bool isFineGrainSupported() const {
     return (info().svmCapabilities_ & CL_DEVICE_SVM_ATOMICS) != 0 ? true : false;

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -3245,7 +3245,9 @@ bool KernelBlitManager::resetContSignalBuffer(uint64_t* deviceVaBuf, uint32_t co
   amd::Command* saved_cmd = gpu().command();
   gpu().SetCommand(override_cmd);
 
-  constexpr bool kAttachSignal = true;
+  // Don't attach a runtime-pool signal in capture mode — the caller patches
+  // completion_signal directly into the captured AQL packet after capture.
+  constexpr bool kAttachSignal = false;
   bool result = gpu().submitKernelInternal(ndrange, *kernels_[blitType], parameters,
                                            /*event_handle=*/nullptr,
                                            /*sharedMemBytes=*/0,
@@ -3256,6 +3258,17 @@ bool KernelBlitManager::resetContSignalBuffer(uint64_t* deviceVaBuf, uint32_t co
   gpu().SetCommand(saved_cmd);
   releaseArguments(parameters);
   return result;
+}
+
+// ================================================================================================
+size_t KernelBlitManager::ResetContKernargSize() const {
+  const auto* gpuKernel = kernels_[ResetContSignalBuffer]->getDeviceKernel(gpu().dev());
+  return gpuKernel->KernargSegmentByteSize();
+}
+
+size_t KernelBlitManager::ResetContKernargAlignment() const {
+  const auto* gpuKernel = kernels_[ResetContSignalBuffer]->getDeviceKernel(gpu().dev());
+  return gpuKernel->KernargSegmentAlignment();
 }
 
 // ================================================================================================

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -3195,7 +3195,8 @@ bool KernelBlitManager::resetGraphSignals(const std::vector<uint64_t*>& valuePtr
 // for the rationale behind holding execution() + lockXferOps_ together and
 // using AcquireQueueWithPreferenceLocked().
 bool KernelBlitManager::resetContSignalBuffer(uint64_t* deviceVaBuf, uint32_t count,
-                                              uint64_t resetValue) const {
+                                              uint64_t resetValue,
+                                              amd::Command* override_cmd) const {
   if (deviceVaBuf == nullptr || count == 0) return true;
 
   // Mirror the lock order of resetGraphSignals: execution() → lockXferOps_.
@@ -3237,10 +3238,12 @@ bool KernelBlitManager::resetContSignalBuffer(uint64_t* deviceVaBuf, uint32_t co
 
   address parameters = captureArguments(kernels_[blitType]);
 
-  // Clear command_ to force the runtime-pool signal path inside
-  // submitKernelInternal — same reasoning as resetGraphSignals.
+  // For normal dispatch: clear command_ to force the runtime-pool signal path.
+  // For capture mode: set override_cmd so submitKernelInternal sees
+  //   getPktCapturingState()==true, routes kernargs to the graph pool, and
+  //   stores the 64-byte AQL packet in override_cmd->gpuPackets_.
   amd::Command* saved_cmd = gpu().command();
-  gpu().SetCommand(nullptr);
+  gpu().SetCommand(override_cmd);
 
   constexpr bool kAttachSignal = true;
   bool result = gpu().submitKernelInternal(ndrange, *kernels_[blitType], parameters,

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -3084,6 +3084,102 @@ bool KernelBlitManager::batchMemOps(const void* paramArray, size_t paramSize,
 }
 
 // ================================================================================================
+// Dispatches __amd_rocclr_resetGraphSignals to atomically write resetValue
+// into amd_signal_t.value of every signal whose pointer is in valuePtrs.
+//
+// Pass attach_signal=true so submitKernelInternal acquires a completion
+// signal from the runtime pool and attaches it to the kernel's AQL packet.
+// The caller can then read it back via gpu->Barriers().GetLastSignal() and
+// use it to serialize parallel-stream dispatches behind the reset
+// (cross-queue ordering).
+//
+// Threading caveat: this is called from the user thread inside hipGraphLaunch
+// and bypasses the worker-thread queue management, which can race with
+// HsaAmdSignalHandler::ReleaseHwQueue. The handler thread calls
+// VirtualGPU::ReleaseHwQueue() and opportunistically takes execution() via
+// try_lock(). If we let it succeed while we are mid-setup here (setArgument,
+// captureArguments, etc.), it nulls gpu_queue_ before submitKernelInternal's
+// packet writes, causing a crash. To prevent that we hold execution()
+// continuously across the queue-check, the setup phase, and the packet
+// dispatch inside submitKernelInternal. submitKernelInternal does NOT take
+// execution() itself — its callers are expected to hold it (see callsites in
+// rocvirtual.cpp), so no recursive-lock deadlock occurs here. We use
+// AcquireQueueWithPreferenceLocked() rather than AcquireQueueWithPreference()
+// for the same reason: the latter would re-enter execution() (std::mutex is
+// non-recursive).
+bool KernelBlitManager::resetGraphSignals(const std::vector<uint64_t*>& valuePtrs,
+                                          uint64_t resetValue) const {
+  if (valuePtrs.empty()) return true;
+
+  // Lock order is execution() -> lockXferOps_ everywhere else in the
+  // codebase (e.g. submitCopyMemory takes execution() then calls into
+  // KernelBlitManager which takes lockXferOps_). Match that order here to
+  // avoid an inverse-order deadlock with concurrent blits on the same VGPU.
+  std::scoped_lock execLock(gpu().execution());
+  std::scoped_lock k(lockXferOps_);
+
+  if (gpu().gpu_queue() == nullptr) {
+    gpu().AcquireQueueWithPreferenceLocked();
+    if (gpu().gpu_queue() == nullptr) {
+      return false;
+    }
+  }
+
+  uint blitType = ResetGraphSignals;
+  const uint32_t count = static_cast<uint32_t>(valuePtrs.size());
+
+  constexpr bool kDirectVa = true;
+  const size_t arr_size = static_cast<size_t>(count) * sizeof(uint64_t*);
+  void* constBuf = gpu().allocKernArg(arr_size, kCBAlignment);
+  if (constBuf == nullptr) return false;
+  memcpy(constBuf, valuePtrs.data(), arr_size);
+
+  setArgument(kernels_[blitType], 0, sizeof(cl_mem), constBuf, 0, nullptr, kDirectVa);
+  setArgument(kernels_[blitType], 1, sizeof(uint32_t), &count);
+  setArgument(kernels_[blitType], 2, sizeof(uint64_t), &resetValue);
+
+  size_t globalWorkOffset[1] = {0};
+  size_t localWorkSize[1] = {std::min<size_t>(64, count)};
+  const size_t global = ((count + localWorkSize[0] - 1) / localWorkSize[0]) * localWorkSize[0];
+  size_t globalWorkSize[1] = {global};
+
+  amd::NDRangeContainer ndrange(1, globalWorkOffset, globalWorkSize, localWorkSize);
+
+  address parameters = captureArguments(kernels_[blitType]);
+  // submitKernelInternal does NOT clear gpu().command() when vcmd==nullptr,
+  // so any leftover command pointer from a previous dispatch (e.g. the prior
+  // launch's AccumulateCommand whose graphSignalPool() is non-null) would
+  // make HwQueueTracker::ActiveSignal route this kernel's completion signal
+  // through the graph pool. That is wrong here: the reset kernel writes 1
+  // to every value field in the graph pool, including the one we just
+  // allocated for ourselves — race against subsequent graph segment
+  // dispatches that re-acquire the same slot. Force the runtime-pool path
+  // by temporarily clearing command_.
+  amd::Command* saved_cmd = gpu().command();
+  gpu().SetCommand(nullptr);
+
+  constexpr bool kAttachSignal = true;
+
+  // Promote the next AQL dispatch (this reset kernel) to SYSTEM-scope
+  // acquire/release fences. The kernel writes resetValue into graph signal
+  // pool slots consumed by subsequent graph dispatches and host wait paths;
+  // AGENT-scope release can leave those writes invisible outside this
+  // agent's coherence domain.
+  // gpu().addSystemScope();
+
+  bool result = gpu().submitKernelInternal(ndrange, *kernels_[blitType], parameters,
+                                           /*event_handle=*/nullptr,
+                                           /*sharedMemBytes=*/0,
+                                           /*vcmd=*/nullptr,
+                                           /*aql_packet=*/nullptr,
+                                           kAttachSignal);
+
+  gpu().SetCommand(saved_cmd);
+  releaseArguments(parameters);
+  return result;
+}
+
+// ================================================================================================
 bool KernelBlitManager::initHeap(device::Memory* heap_to_initialize, device::Memory* initial_blocks,
                                  uint heap_size, uint number_of_initial_blocks) const {
   bool result;

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -3180,6 +3180,82 @@ bool KernelBlitManager::resetGraphSignals(const std::vector<uint64_t*>& valuePtr
 }
 
 // ================================================================================================
+// Dispatches __amd_rocclr_resetContSignalBuffer to write resetValue into
+// every amd_signal_t.value field referenced by the pool's contiguous VA
+// buffer.  Unlike resetGraphSignals(), this path skips the per-launch
+// CollectValuePtrs() CPU scan and the memcpy of the pointer array into a
+// transient kernarg slot — the caller passes the stable device VA that was
+// populated once at pool-creation / pool-growth time.
+//
+// deviceVaBuf must be a GPU-readable array of `count` uint64_t entries where
+// entry i holds the device VA of amd_signal_t.value for pool signal i.
+//
+// The function is called from the user thread inside hipGraphLaunch (same
+// threading context as resetGraphSignals); see that function's header comment
+// for the rationale behind holding execution() + lockXferOps_ together and
+// using AcquireQueueWithPreferenceLocked().
+bool KernelBlitManager::resetContSignalBuffer(uint64_t* deviceVaBuf, uint32_t count,
+                                              uint64_t resetValue) const {
+  if (deviceVaBuf == nullptr || count == 0) return true;
+
+  // Mirror the lock order of resetGraphSignals: execution() → lockXferOps_.
+  std::scoped_lock execLock(gpu().execution());
+  std::scoped_lock k(lockXferOps_);
+
+  if (gpu().gpu_queue() == nullptr) {
+    gpu().AcquireQueueWithPreferenceLocked();
+    if (gpu().gpu_queue() == nullptr) {
+      return false;
+    }
+  }
+
+  uint blitType = ResetContSignalBuffer;
+
+  // Pass the stable device VA directly as an immediate pointer argument —
+  // no per-launch kernarg allocation or memcpy required.
+  //
+  // IMPORTANT: must cast deviceVaBuf to void* (not &deviceVaBuf).
+  // setArgument with kDirectVa=true does:
+  //   LP64_SWITCH(u32,u64) = reinterpret_cast<uintptr_t>(value)
+  // so it stores the numeric VALUE of the pointer as the kernel arg VA.
+  // Passing &deviceVaBuf (a pointer-to-pointer, i.e. a stack address) would
+  // make the GPU read from the stack — causing error 700.
+  // This matches how resetGraphSignals passes `constBuf` (already a void*).
+  constexpr bool kDirectVa = true;
+  setArgument(kernels_[blitType], 0, sizeof(cl_mem),
+              reinterpret_cast<void*>(deviceVaBuf), 0, nullptr, kDirectVa);
+  setArgument(kernels_[blitType], 1, sizeof(uint32_t), &count);
+  setArgument(kernels_[blitType], 2, sizeof(uint64_t), &resetValue);
+
+  size_t globalWorkOffset[1] = {0};
+  size_t localWorkSize[1] = {std::min<size_t>(64, static_cast<size_t>(count))};
+  const size_t global =
+      ((static_cast<size_t>(count) + localWorkSize[0] - 1) / localWorkSize[0]) * localWorkSize[0];
+  size_t globalWorkSize[1] = {global};
+
+  amd::NDRangeContainer ndrange(1, globalWorkOffset, globalWorkSize, localWorkSize);
+
+  address parameters = captureArguments(kernels_[blitType]);
+
+  // Clear command_ to force the runtime-pool signal path inside
+  // submitKernelInternal — same reasoning as resetGraphSignals.
+  amd::Command* saved_cmd = gpu().command();
+  gpu().SetCommand(nullptr);
+
+  constexpr bool kAttachSignal = true;
+  bool result = gpu().submitKernelInternal(ndrange, *kernels_[blitType], parameters,
+                                           /*event_handle=*/nullptr,
+                                           /*sharedMemBytes=*/0,
+                                           /*vcmd=*/nullptr,
+                                           /*aql_packet=*/nullptr,
+                                           kAttachSignal);
+
+  gpu().SetCommand(saved_cmd);
+  releaseArguments(parameters);
+  return result;
+}
+
+// ================================================================================================
 bool KernelBlitManager::initHeap(device::Memory* heap_to_initialize, device::Memory* initial_blocks,
                                  uint heap_size, uint number_of_initial_blocks) const {
   bool result;

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -559,8 +559,13 @@ class KernelBlitManager : public DmaBlitManager {
   //! kernarg slot that resetGraphSignals() requires.
   //! Like resetGraphSignals(), dispatches with attach_signal=true so the
   //! caller can read back the completion signal via GetLastSignal().
+  //! Normal path: dispatch the reset kernel on the GPU immediately.
+  //! Capture path: pass override_cmd with getPktCapturingState()==true so
+  //! submitKernelInternal routes kernargs to the graph pool and stores the
+  //! 64-byte AQL packet in override_cmd->gpuPackets_ without hardware dispatch.
   bool resetContSignalBuffer(uint64_t* deviceVaBuf, uint32_t count,
-                             uint64_t resetValue = 1) const;
+                             uint64_t resetValue = 1,
+                             amd::Command* override_cmd = nullptr) const;
 
   virtual std::recursive_mutex* lockXfer() const { return &lockXferOps_; }
 

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -309,6 +309,7 @@ class KernelBlitManager : public DmaBlitManager {
     StreamOpsIncrement,
     StreamOpsDecrement,
     ResetGraphSignals,
+    ResetContSignalBuffer,
     BlitLinearTotal,
     FillImage = BlitLinearTotal,
     BlitCopyImage,
@@ -549,6 +550,18 @@ class KernelBlitManager : public DmaBlitManager {
   bool resetGraphSignals(const std::vector<uint64_t*>& valuePtrs,
                          uint64_t resetValue = 1) const;
 
+  //! Faster variant of resetGraphSignals for pools that carry a persistent
+  //! contiguous device-accessible VA buffer (GraphSignalPool::ContBuffer()).
+  //! deviceVaBuf must be a GPU-readable array of exactly `count` uint64_t
+  //! entries, where entry i holds the device VA of amd_signal_t.value for
+  //! signal i in the pool.  Passing the pre-built device buffer avoids the
+  //! per-launch CollectValuePtrs() CPU scan and memcpy into a transient
+  //! kernarg slot that resetGraphSignals() requires.
+  //! Like resetGraphSignals(), dispatches with attach_signal=true so the
+  //! caller can read back the completion signal via GetLastSignal().
+  bool resetContSignalBuffer(uint64_t* deviceVaBuf, uint32_t count,
+                             uint64_t resetValue = 1) const;
+
   virtual std::recursive_mutex* lockXfer() const { return &lockXferOps_; }
 
   virtual bool initHeap(device::Memory* heap_to_initialize, device::Memory* initial_blocks,
@@ -639,7 +652,7 @@ static const char* BlitName[KernelBlitManager::BlitTotal] = {
     "__amd_rocclr_scheduler",          "__amd_rocclr_gwsInit",
     "__amd_rocclr_initHeap",           "__amd_rocclr_batchMemOp",
     "__amd_rocclr_streamOpsIncrement", "__amd_rocclr_streamOpsDecrement",
-    "__amd_rocclr_resetGraphSignals",
+    "__amd_rocclr_resetGraphSignals",  "__amd_rocclr_resetContSignalBuffer",
     "__amd_rocclr_fillImage",          "__amd_rocclr_copyImage",
     "__amd_rocclr_copyImage1DA",       "__amd_rocclr_copyImageToBuffer",
     "__amd_rocclr_copyBufferToImage"};

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -567,6 +567,12 @@ class KernelBlitManager : public DmaBlitManager {
                              uint64_t resetValue = 1,
                              amd::Command* override_cmd = nullptr) const;
 
+  //! Returns the kernarg segment size (bytes) for the resetContSignalBuffer
+  //! kernel.  Used by CaptureResetKernelPacket to pre-allocate a stable
+  //! kernarg buffer that bypasses the graph kernarg manager.
+  size_t ResetContKernargSize() const;
+  size_t ResetContKernargAlignment() const;
+
   virtual std::recursive_mutex* lockXfer() const { return &lockXferOps_; }
 
   virtual bool initHeap(device::Memory* heap_to_initialize, device::Memory* initial_blocks,

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -308,6 +308,7 @@ class KernelBlitManager : public DmaBlitManager {
     BatchMemOp,
     StreamOpsIncrement,
     StreamOpsDecrement,
+    ResetGraphSignals,
     BlitLinearTotal,
     FillImage = BlitLinearTotal,
     BlitCopyImage,
@@ -537,6 +538,17 @@ class KernelBlitManager : public DmaBlitManager {
   //! Batch memory ops- Submits batch of streamWaits and streamWrite operations.
   virtual bool batchMemOps(const void* paramArray, size_t paramSize, uint32_t count) const;
 
+  //! Reset graph-pool signal value fields back to a given value (default 1).
+  //! Dispatches a small compute kernel on this VirtualGPU's queue with
+  //! attach_signal=true, so submitKernelInternal acquires a real signal and
+  //! attaches it as the AQL packet's completion_signal. The caller can then
+  //! read that signal back via `gpu_queue->Barriers().GetLastSignal()` and
+  //! use it to serialize parallel-stream dispatches behind the reset.
+  //! valuePtrs holds raw device pointers to amd_signal_t.value of each
+  //! signal owned by the pool.
+  bool resetGraphSignals(const std::vector<uint64_t*>& valuePtrs,
+                         uint64_t resetValue = 1) const;
+
   virtual std::recursive_mutex* lockXfer() const { return &lockXferOps_; }
 
   virtual bool initHeap(device::Memory* heap_to_initialize, device::Memory* initial_blocks,
@@ -627,6 +639,7 @@ static const char* BlitName[KernelBlitManager::BlitTotal] = {
     "__amd_rocclr_scheduler",          "__amd_rocclr_gwsInit",
     "__amd_rocclr_initHeap",           "__amd_rocclr_batchMemOp",
     "__amd_rocclr_streamOpsIncrement", "__amd_rocclr_streamOpsDecrement",
+    "__amd_rocclr_resetGraphSignals",
     "__amd_rocclr_fillImage",          "__amd_rocclr_copyImage",
     "__amd_rocclr_copyImage1DA",       "__amd_rocclr_copyImageToBuffer",
     "__amd_rocclr_copyBufferToImage"};

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3712,19 +3712,6 @@ bool GraphSignalPool::Allocate(size_t count) {
   }
   capacity_.store(signals_.size(), std::memory_order_release);
   next_idx_.store(0);
-  irq_next_idx_.store(0);
-  return true;
-}
-
-bool GraphSignalPool::AllocateIrq(size_t count, bool system_scope) {
-  irq_signals_.reserve(count);
-  for (size_t i = irq_signals_.size(); i < count; ++i) {
-    auto* ps = AllocateOneSignal(true, system_scope);
-    if (ps == nullptr) return false;
-    irq_signals_.push_back(ps);
-  }
-  irq_capacity_.store(irq_signals_.size(), std::memory_order_release);
-  irq_next_idx_.store(0);
   return true;
 }
 
@@ -3740,20 +3727,100 @@ ProfilingSignal* GraphSignalPool::GrowAndAcquire(size_t idx) {
   return signals_[idx];
 }
 
-ProfilingSignal* GraphSignalPool::GrowAndAcquireIrq(size_t idx, bool system_scope) {
+// ================================================================================================
+// IRQ acquire with re-arm-on-acquire semantics. See header for invariants.
+// Single critical section: scan + silent_store happen under lock_ so two
+// concurrent acquires in the same launch can't both grab the same slot.
+//
+// Reuse criterion: flags_.done_ == true. This flag is set inside the async
+// handler chain (HsaAmdSignalHandler → updateCommandsState → process_signal,
+// which writes signal->flags_.done_ = true once the timestamps have been
+// drained). Checking the signal *value* alone is NOT safe: the GPU may have
+// already written 0 while the HSA worker has not yet invoked the registered
+// handler. Re-arming the value to init_val in that window causes the worker
+// to re-read value == init_val on the LT-init_val condition check and skip
+// the pending handler, so the previous launch's batch never gets drained
+// and the next sync/wait on it hangs.
+// ================================================================================================
+ProfilingSignal* GraphSignalPool::AcquireIrq(bool system_scope, hsa_signal_value_t init_val) {
   amd::ScopedLock sl(lock_);
-  if (idx < irq_signals_.size()) return irq_signals_[idx];
-  while (irq_signals_.size() <= idx) {
-    auto* ps = AllocateOneSignal(true, system_scope);
-    if (ps == nullptr) return nullptr;
-    irq_signals_.push_back(ps);
-  }
-  irq_capacity_.store(irq_signals_.size(), std::memory_order_release);
-  return irq_signals_[idx];
+  // Always allocate a fresh IRQ signal; never reuse an existing one. Each
+  // AC barrier needs a dedicated completion signal with its own async handler
+  // registration. Reusing a signal — even after flags_.done_ is set — risks
+  // a race with HSA's serial async handler dispatcher.
+  auto* ps = AllocateOneSignal(true, system_scope);
+  if (ps == nullptr) return nullptr;
+  Hsa::signal_silent_store_relaxed(ps->signal_, init_val);
+  ps->flags_.done_ = false;
+  ps->ResetCachedTiming();
+  irq_signals_.push_back(ps);
+  last_acquired_ = ps;
+  return ps;
 }
 
+// ================================================================================================
+// Pool reuse helpers — see header for contract.
+// ================================================================================================
+//
+// IRQ signals are managed via re-arm-on-acquire (see AcquireIrq). They are
+// NOT swept here: each AcquireIrq() scans for a *handler-completed* IRQ
+// (flags_.done_ == true, set by the handler chain after it has drained the
+// batch) and silently re-arms it, falling back to allocating a fresh one
+// when nothing is reusable. Sweeping IRQ signal values to 1 in bulk here
+// would mask still-pending handlers and cause the classic "silently re-
+// store 1 before HSA worker observes 0 → handler never fires" hang.
+// ================================================================================================
+bool GraphSignalPool::TryCpuReset() {
+  for (auto* ps : signals_) {
+    if (Hsa::signal_load_relaxed(ps->signal_) != 0) {
+      return false;
+    }
+  }
+
+  // Silent store ⇒ no events triggered.
+  for (auto* ps : signals_) {
+    Hsa::signal_silent_store_relaxed(ps->signal_, kInitSignalValueOne);
+    ps->flags_.done_ = false;
+    ps->ResetCachedTiming();
+  }
+
+  ResetCountersForReuse();
+  return true;
+}
+
+// ================================================================================================
+void GraphSignalPool::ResetCountersForReuse() {
+  next_idx_.store(0, std::memory_order_release);
+  last_acquired_ = nullptr;
+
+  // Clear cached timing so a stale value from the previous launch can never
+  // bleed into the next one. The GPU-reset path skips CacheTimingData reset
+  // since the kernel only touches the value byte. IRQ signals are excluded;
+  // their done_/timing state is reset inside AcquireIrq when re-armed.
+  for (auto* ps : signals_) {
+    ps->flags_.done_ = false;
+    ps->ResetCachedTiming();
+  }
+}
+
+// ================================================================================================
+void GraphSignalPool::CollectValuePtrs(std::vector<uint64_t*>& out) const {
+  // GPU-only signals only. IRQ signals are excluded — see TryCpuReset note.
+  amd::ScopedLock sl(lock_);
+  out.reserve(out.size() + signals_.size());
+  for (auto* ps : signals_) {
+    auto* amd_sig = reinterpret_cast<amd_signal_t*>(ps->signal_.handle);
+    auto* val_ptr = reinterpret_cast<uint64_t*>(const_cast<int64_t*>(&amd_sig->value));
+    out.push_back(val_ptr);
+  }
+}
+
+// ================================================================================================
 GraphSignalPool::~GraphSignalPool() {
   for (auto* ps : signals_) { ps->release(); }
+  // Safe to release IRQ signals here: ~GraphSignalPool only runs after
+  // ~GraphExec finished every parallel stream, which guarantees all async
+  // handlers attached to IRQ signals have already fired.
   for (auto* ps : irq_signals_) { ps->release(); }
 }
 
@@ -3774,8 +3841,7 @@ uint8_t* Device::CreateBarrierPacket() const {
 
 // ================================================================================================
 GraphSignalPool* Device::CreateGraphSignalPool(
-    size_t gpu_count, size_t irq_count,
-    size_t segment_count, std::vector<void*>& hw_events) const {
+    size_t gpu_count, size_t segment_count, std::vector<void*>& hw_events) const {
   // Clear upfront so every failure path honours the contract: caller sees an
   // empty hw_events whenever nullptr is returned, regardless of what was passed in.
   hw_events.clear();
@@ -3783,10 +3849,6 @@ GraphSignalPool* Device::CreateGraphSignalPool(
   auto* pool = new GraphSignalPool();
 
   if (gpu_count > 0 && !pool->Allocate(gpu_count)) {
-    delete pool;
-    return nullptr;
-  }
-  if (irq_count > 0 && !pool->AllocateIrq(irq_count, true)) {
     delete pool;
     return nullptr;
   }
@@ -3809,6 +3871,63 @@ GraphSignalPool* Device::CreateGraphSignalPool(
 // ================================================================================================
 size_t Device::GetGraphSignalPoolUsedCount(GraphSignalPool* pool) const {
   return pool ? pool->UsedCount() : 0;
+}
+
+// ================================================================================================
+// Out-of-line deleter so ~GraphSignalPool is actually invoked from generic
+// platform/ code (which only sees a forward declaration of GraphSignalPool).
+void Device::DestroyGraphSignalPool(GraphSignalPool* pool) const {
+  delete pool;
+}
+
+// ================================================================================================
+// Hybrid CPU/GPU reset for pool reuse:
+//   1. Try CPU-side reset — succeeds when every signal is already at 0
+//      (previous launch fully drained). This is the common steady-state
+//      case and avoids any GPU work at all.
+//   2. Otherwise dispatch the __amd_rocclr_resetGraphSignals kernel on
+//      vdev's queue. The kernel is naturally serialized behind any prior
+//      dispatches via AQL packet ordering, so the reset completes before
+//      the next graph segment is enqueued.
+bool Device::ResetGraphSignalPool(device::VirtualDevice* vdev, GraphSignalPool* pool,
+                                  bool prev_done, bool* out_did_gpu_reset) const {
+  if (out_did_gpu_reset != nullptr) *out_did_gpu_reset = false;
+
+  if (pool == nullptr) return false;
+
+  // CPU fast path: the caller has already verified every leaf signal is at
+  // 0, so every GPU-only signal in the pool is guaranteed to be settled.
+  // TryCpuReset is just a sanity loop + silent-store-1 + counter wind-back.
+  if (prev_done) {
+    if (pool->TryCpuReset()) {
+      return true;
+    }
+    // Race: leaves were 0 a moment ago but a still-pending non-leaf signal
+    // hasn't drained yet. Fall through to GPU reset.
+  }
+
+  // GPU reset path. Used when the previous launch is still in flight at
+  // this enqueue time (overlapping launches). Dispatched on launch_stream's
+  // queue with attach_signal=true; caller pulls the completion signal back
+  // via vdev->Barriers().GetLastSignal() and uses it as a dep for the
+  // level-0 wait markers on parallel internal streams.
+  if (vdev == nullptr) return false;
+
+  std::vector<uint64_t*> value_ptrs;
+  pool->CollectValuePtrs(value_ptrs);
+  if (value_ptrs.empty()) {
+    pool->ResetCountersForReuse();
+    return true;
+  }
+
+  auto& blit = static_cast<KernelBlitManager&>(vdev->blitMgr());
+  if (!blit.resetGraphSignals(value_ptrs, /*resetValue=*/kInitSignalValueOne)) {
+    return false;
+  }
+
+  if (out_did_gpu_reset != nullptr) *out_did_gpu_reset = true;
+  pool->ResetCountersForReuse();
+  return true;
 }
 
 // ================================================================================================

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3685,6 +3685,79 @@ void Device::DestroyHwEvent(void* hw_event) const {
 }
 
 // ================================================================================================
+// GraphSignalPool implementation
+// ================================================================================================
+ProfilingSignal* GraphSignalPool::AllocateOneSignal(bool interrupt, bool system_scope) {
+  auto* ps = new ProfilingSignal();
+  hsa_status_t status;
+  if (interrupt && system_scope) {
+    status = Hsa::signal_create(1, 0, nullptr, &ps->signal_);
+  } else {
+    status = Hsa::signal_create(1, 0, nullptr, HSA_AMD_SIGNAL_AMD_GPU_ONLY, &ps->signal_);
+  }
+  if (status != HSA_STATUS_SUCCESS) {
+    delete ps;
+    return nullptr;
+  }
+  ps->flags_.interrupt_ = interrupt;
+  return ps;
+}
+
+bool GraphSignalPool::Allocate(size_t count) {
+  signals_.reserve(count);
+  for (size_t i = signals_.size(); i < count; ++i) {
+    auto* ps = AllocateOneSignal(false, false);
+    if (ps == nullptr) return false;
+    signals_.push_back(ps);
+  }
+  capacity_.store(signals_.size(), std::memory_order_release);
+  next_idx_.store(0);
+  irq_next_idx_.store(0);
+  return true;
+}
+
+bool GraphSignalPool::AllocateIrq(size_t count, bool system_scope) {
+  irq_signals_.reserve(count);
+  for (size_t i = irq_signals_.size(); i < count; ++i) {
+    auto* ps = AllocateOneSignal(true, system_scope);
+    if (ps == nullptr) return false;
+    irq_signals_.push_back(ps);
+  }
+  irq_capacity_.store(irq_signals_.size(), std::memory_order_release);
+  irq_next_idx_.store(0);
+  return true;
+}
+
+ProfilingSignal* GraphSignalPool::GrowAndAcquire(size_t idx) {
+  amd::ScopedLock sl(lock_);
+  if (idx < signals_.size()) return signals_[idx];
+  while (signals_.size() <= idx) {
+    auto* ps = AllocateOneSignal(false, false);
+    if (ps == nullptr) return nullptr;
+    signals_.push_back(ps);
+  }
+  capacity_.store(signals_.size(), std::memory_order_release);
+  return signals_[idx];
+}
+
+ProfilingSignal* GraphSignalPool::GrowAndAcquireIrq(size_t idx, bool system_scope) {
+  amd::ScopedLock sl(lock_);
+  if (idx < irq_signals_.size()) return irq_signals_[idx];
+  while (irq_signals_.size() <= idx) {
+    auto* ps = AllocateOneSignal(true, system_scope);
+    if (ps == nullptr) return nullptr;
+    irq_signals_.push_back(ps);
+  }
+  irq_capacity_.store(irq_signals_.size(), std::memory_order_release);
+  return irq_signals_[idx];
+}
+
+GraphSignalPool::~GraphSignalPool() {
+  for (auto* ps : signals_) { ps->release(); }
+  for (auto* ps : irq_signals_) { ps->release(); }
+}
+
+// ================================================================================================
 uint8_t* Device::CreateBarrierPacket() const {
   static constexpr uint16_t kBarrierNopHeader =
       (HSA_PACKET_TYPE_BARRIER_AND << HSA_PACKET_HEADER_TYPE) |
@@ -3697,6 +3770,45 @@ uint8_t* Device::CreateBarrierPacket() const {
   auto* pkt = reinterpret_cast<hsa_barrier_and_packet_t*>(raw);
   pkt->header = kBarrierNopHeader;
   return raw;
+}
+
+// ================================================================================================
+GraphSignalPool* Device::CreateGraphSignalPool(
+    size_t gpu_count, size_t irq_count,
+    size_t segment_count, std::vector<void*>& hw_events) const {
+  // Clear upfront so every failure path honours the contract: caller sees an
+  // empty hw_events whenever nullptr is returned, regardless of what was passed in.
+  hw_events.clear();
+
+  auto* pool = new GraphSignalPool();
+
+  if (gpu_count > 0 && !pool->Allocate(gpu_count)) {
+    delete pool;
+    return nullptr;
+  }
+  if (irq_count > 0 && !pool->AllocateIrq(irq_count, true)) {
+    delete pool;
+    return nullptr;
+  }
+
+  hw_events.resize(segment_count, nullptr);
+  for (size_t i = 0; i < segment_count; ++i) {
+    hw_events[i] = pool->Acquire();
+    if (hw_events[i] == nullptr) {
+      delete pool;
+      hw_events.clear();
+      return nullptr;
+    }
+  }
+
+  // Pre-allocation is done; reset so GetLastAcquired() only reflects GPU dispatches.
+  pool->ResetLastAcquired();
+  return pool;
+}
+
+// ================================================================================================
+size_t Device::GetGraphSignalPoolUsedCount(GraphSignalPool* pool) const {
+  return pool ? pool->UsedCount() : 0;
 }
 
 // ================================================================================================

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -4037,6 +4037,26 @@ bool Device::ResetGraphSignalPool(device::VirtualDevice* vdev, GraphSignalPool* 
 }
 
 // ================================================================================================
+// Capture the reset-kernel AQL packet (with kernargs in the graph pool) at
+// instantiate time so it can be prepended to stream-0's flat buffer.
+// captureCmd must already have setPktCapturingState(true, ...) called before
+// this function is invoked.  On success captureCmd->gpuPackets_[0] holds the
+// 64-byte dispatch packet; completion_signal is left zero — the caller writes
+// reset_signal_->signal_ at flat-buffer offset 56 after rebuildFlatBuffer.
+bool Device::CaptureResetKernelPacket(GraphSignalPool* pool, amd::Command* captureCmd) const {
+  if (pool == nullptr || captureCmd == nullptr) return false;
+
+  uint64_t* cont_buf = pool->ContBuffer();
+  uint32_t  cont_cnt = pool->ContBufferCount();
+  if (cont_buf == nullptr || cont_cnt == 0) return false;
+
+  auto& blit = static_cast<KernelBlitManager&>(xferQueue()->blitMgr());
+  return blit.resetContSignalBuffer(cont_buf, cont_cnt,
+                                    /*resetValue=*/kInitSignalValueOne,
+                                    captureCmd);
+}
+
+// ================================================================================================
 void Device::ApplyHwEventPatches(const std::vector<HwEventPatch>& patches,
                                  const std::vector<void*>& hw_events) const {
   for (const auto& patch : patches) {

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3890,6 +3890,7 @@ GraphSignalPool::~GraphSignalPool() {
     Hsa::memory_pool_free(cont_buffer_);
     cont_buffer_ = nullptr;
   }
+
 }
 
 // ================================================================================================
@@ -4037,12 +4038,14 @@ bool Device::ResetGraphSignalPool(device::VirtualDevice* vdev, GraphSignalPool* 
 }
 
 // ================================================================================================
-// Capture the reset-kernel AQL packet (with kernargs in the graph pool) at
-// instantiate time so it can be prepended to stream-0's flat buffer.
+// Capture the reset-kernel AQL packet at instantiate time.
 // captureCmd must already have setPktCapturingState(true, ...) called before
 // this function is invoked.  On success captureCmd->gpuPackets_[0] holds the
 // 64-byte dispatch packet; completion_signal is left zero — the caller writes
 // reset_signal_->signal_ at flat-buffer offset 56 after rebuildFlatBuffer.
+//
+// Kernargs are allocated from the graph's pre-sized kernarg pool via AllocKernArg.
+// GetKernelArgSizeForGraph reserves kResetKernelKernargSize bytes for this kernel.
 bool Device::CaptureResetKernelPacket(GraphSignalPool* pool, amd::Command* captureCmd) const {
   if (pool == nullptr || captureCmd == nullptr) return false;
 
@@ -4051,6 +4054,7 @@ bool Device::CaptureResetKernelPacket(GraphSignalPool* pool, amd::Command* captu
   if (cont_buf == nullptr || cont_cnt == 0) return false;
 
   auto& blit = static_cast<KernelBlitManager&>(xferQueue()->blitMgr());
+
   return blit.resetContSignalBuffer(cont_buf, cont_cnt,
                                     /*resetValue=*/kInitSignalValueOne,
                                     captureCmd);

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3703,6 +3703,46 @@ ProfilingSignal* GraphSignalPool::AllocateOneSignal(bool interrupt, bool system_
   return ps;
 }
 
+bool GraphSignalPool::GrowContBuffer(size_t new_cap) {
+  if (alloc_pool_.handle == 0 || new_cap == 0) return false;
+
+  void* raw = nullptr;
+  hsa_status_t st = Hsa::memory_pool_allocate(alloc_pool_,
+                        new_cap * sizeof(uint64_t), /*flags=*/0, &raw);
+  if (st != HSA_STATUS_SUCCESS || raw == nullptr) return false;
+
+  // Grant both GPU (read during reset kernel) and CPU (write during pool
+  // init/growth) access to this coarse-grained VRAM allocation — mirrors the
+  // hsa_amd_agents_allow_access pattern from the contiguous-signal POC.
+  if (gpu_agent_.handle != 0 && cpu_agent_.handle != 0) {
+    hsa_agent_t agents[2] = {gpu_agent_, cpu_agent_};
+    st = Hsa::agents_allow_access(2, agents, nullptr, raw);
+    if (st != HSA_STATUS_SUCCESS) {
+      Hsa::memory_pool_free(raw);
+      return false;
+    }
+  }
+
+  auto* new_buf = reinterpret_cast<uint64_t*>(raw);
+
+  // Copy existing valid entries before releasing the old buffer.
+  if (cont_buffer_ != nullptr && cont_buffer_cap_ > 0) {
+    memcpy(new_buf, cont_buffer_, cont_buffer_cap_ * sizeof(uint64_t));
+    Hsa::memory_pool_free(cont_buffer_);
+  }
+
+  cont_buffer_ = new_buf;
+  cont_buffer_cap_ = new_cap;
+  return true;
+}
+
+void GraphSignalPool::PatchContBufferEntry(size_t idx) {
+  if (cont_buffer_ == nullptr || idx >= cont_buffer_cap_) return;
+  auto* amd_sig = reinterpret_cast<amd_signal_t*>(signals_[idx]->signal_.handle);
+  cont_buffer_[idx] = reinterpret_cast<uint64_t>(
+      const_cast<int64_t*>(&amd_sig->value));
+}
+
 bool GraphSignalPool::Allocate(size_t count) {
   signals_.reserve(count);
   for (size_t i = signals_.size(); i < count; ++i) {
@@ -3712,6 +3752,16 @@ bool GraphSignalPool::Allocate(size_t count) {
   }
   capacity_.store(signals_.size(), std::memory_order_release);
   next_idx_.store(0);
+
+  // Build the contiguous device-accessible value-pointer buffer.
+  // One-time cost: populated here and updated lazily in GrowAndAcquire.
+  // Falls back to CollectValuePtrs() if allocation fails or pool unavailable.
+  if (alloc_pool_.handle != 0 && GrowContBuffer(signals_.size())) {
+    for (size_t i = 0; i < signals_.size(); ++i) {
+      PatchContBufferEntry(i);
+    }
+  }
+
   return true;
 }
 
@@ -3724,6 +3774,18 @@ ProfilingSignal* GraphSignalPool::GrowAndAcquire(size_t idx) {
     signals_.push_back(ps);
   }
   capacity_.store(signals_.size(), std::memory_order_release);
+
+  // Extend the contiguous VA buffer to cover the newly added signals.
+  // GrowContBuffer copies existing entries, so only new slots need patching.
+  if (alloc_pool_.handle != 0 && signals_.size() > cont_buffer_cap_) {
+    size_t old_cap = cont_buffer_cap_;
+    if (GrowContBuffer(signals_.size())) {
+      for (size_t i = old_cap; i < signals_.size(); ++i) {
+        PatchContBufferEntry(i);
+      }
+    }
+  }
+
   return signals_[idx];
 }
 
@@ -3822,6 +3884,12 @@ GraphSignalPool::~GraphSignalPool() {
   // ~GraphExec finished every parallel stream, which guarantees all async
   // handlers attached to IRQ signals have already fired.
   for (auto* ps : irq_signals_) { ps->release(); }
+
+  // Release the contiguous VA buffer if it was allocated.
+  if (cont_buffer_ != nullptr) {
+    Hsa::memory_pool_free(cont_buffer_);
+    cont_buffer_ = nullptr;
+  }
 }
 
 // ================================================================================================
@@ -3847,6 +3915,19 @@ GraphSignalPool* Device::CreateGraphSignalPool(
   hw_events.clear();
 
   auto* pool = new GraphSignalPool();
+
+  // Wire up the coarse-grained VRAM pool for the contiguous VA buffer.
+  // We use gpuvm_segment_ (GPU coarse VRAM) — same pool the POC uses as
+  // g_gpu_coarse.  We then call hsa_amd_agents_allow_access(CPU+GPU) inside
+  // GrowContBuffer so the CPU can write pointer values at init time and the
+  // GPU reset kernel can read them.  Fine-grained segment is NOT used here:
+  // fine-grained memory can be slower for GPU reads on some topologies.
+  // If gpuvm_segment_ is unavailable the cont_buffer_ path is skipped and
+  // the caller falls back to CollectValuePtrs().
+  if (gpuvm_segment_.handle != 0) {
+    pool->SetAllocPool(gpuvm_segment_);
+    pool->SetAgents(bkendDevice_, cpu_agent_info_->agent);
+  }
 
   if (gpu_count > 0 && !pool->Allocate(gpu_count)) {
     delete pool;
@@ -3885,10 +3966,17 @@ void Device::DestroyGraphSignalPool(GraphSignalPool* pool) const {
 //   1. Try CPU-side reset — succeeds when every signal is already at 0
 //      (previous launch fully drained). This is the common steady-state
 //      case and avoids any GPU work at all.
-//   2. Otherwise dispatch the __amd_rocclr_resetGraphSignals kernel on
-//      vdev's queue. The kernel is naturally serialized behind any prior
-//      dispatches via AQL packet ordering, so the reset completes before
-//      the next graph segment is enqueued.
+//   2. Otherwise dispatch a GPU-side reset kernel on vdev's queue.
+//      Two dispatch paths are available:
+//      a) __amd_rocclr_resetContSignalBuffer  — preferred when the pool has
+//         a persistent contiguous VA buffer (cont_buffer_).  Passes the
+//         stable device pointer directly; avoids the per-launch
+//         CollectValuePtrs() scan and memcpy into a transient kernarg slot.
+//      b) __amd_rocclr_resetGraphSignals  — fallback when cont_buffer_ is
+//         unavailable (fine-grained segment absent or allocation failed).
+//      Both kernels are naturally serialized behind prior dispatches via AQL
+//      packet ordering, so the reset completes before the next graph segment
+//      is enqueued.
 bool Device::ResetGraphSignalPool(device::VirtualDevice* vdev, GraphSignalPool* pool,
                                   bool prev_done, bool* out_did_gpu_reset) const {
   if (out_did_gpu_reset != nullptr) *out_did_gpu_reset = false;
@@ -3913,6 +4001,25 @@ bool Device::ResetGraphSignalPool(device::VirtualDevice* vdev, GraphSignalPool* 
   // level-0 wait markers on parallel internal streams.
   if (vdev == nullptr) return false;
 
+  auto& blit = static_cast<KernelBlitManager&>(vdev->blitMgr());
+
+  // Preferred path: persistent contiguous VA buffer — no per-launch memcpy.
+  // Controlled by GPU_GRAPH_CONT_SIGNAL_RESET (default true). Set to 0 to
+  // force the legacy CollectValuePtrs + resetGraphSignals path instead.
+  uint64_t* cont_buf = pool->ContBuffer();
+  uint32_t  cont_cnt = pool->ContBufferCount();
+  if (GPU_GRAPH_CONT_SIGNAL_RESET && cont_buf != nullptr && cont_cnt > 0) {
+    if (!blit.resetContSignalBuffer(cont_buf, cont_cnt,
+                                    /*resetValue=*/kInitSignalValueOne)) {
+      return false;
+    }
+    if (out_did_gpu_reset != nullptr) *out_did_gpu_reset = true;
+    pool->ResetCountersForReuse();
+    return true;
+  }
+
+  // Legacy path (or forced via GPU_GRAPH_CONT_SIGNAL_RESET=0): assemble the
+  // value-pointer list on the CPU and copy to a transient kernarg slot.
   std::vector<uint64_t*> value_ptrs;
   pool->CollectValuePtrs(value_ptrs);
   if (value_ptrs.empty()) {
@@ -3920,7 +4027,6 @@ bool Device::ResetGraphSignalPool(device::VirtualDevice* vdev, GraphSignalPool* 
     return true;
   }
 
-  auto& blit = static_cast<KernelBlitManager&>(vdev->blitMgr());
   if (!blit.resetGraphSignals(value_ptrs, /*resetValue=*/kInitSignalValueOne)) {
     return false;
   }

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -114,6 +114,63 @@ class ProfilingSignal : public amd::ReferenceCountedObject {
   }
 };
 
+//! Graph-owned signal pool for per-launch signal allocation.
+//! Avoids runtime signal pool stalls (WaitCurrent/WaitNext) during graph execution.
+//! Two sub-pools: GPU-only signals (fast) and interrupt-capable signals (for host callbacks).
+struct GraphSignalPool {
+  ProfilingSignal* Acquire() {
+    size_t idx = next_idx_.fetch_add(1, std::memory_order_relaxed);
+    ProfilingSignal* ps;
+    if (idx < capacity_.load(std::memory_order_acquire)) {
+      ps = signals_[idx];
+    } else {
+      ps = GrowAndAcquire(idx);
+    }
+    if (ps) last_acquired_ = ps;
+    return ps;
+  }
+
+  ProfilingSignal* AcquireIrq(bool system_scope) {
+    size_t idx = irq_next_idx_.fetch_add(1, std::memory_order_relaxed);
+    ProfilingSignal* ps;
+    if (idx < irq_capacity_.load(std::memory_order_acquire)) {
+      ps = irq_signals_[idx];
+    } else {
+      ps = GrowAndAcquireIrq(idx, system_scope);
+    }
+    if (ps) last_acquired_ = ps;
+    return ps;
+  }
+
+  //! Returns the most recently acquired signal from a GPU dispatch (not pre-allocation)
+  ProfilingSignal* GetLastAcquired() const { return last_acquired_; }
+
+  //! Reset after pre-allocation so GetLastAcquired only reflects actual GPU dispatches
+  void ResetLastAcquired() { last_acquired_ = nullptr; }
+
+  bool Allocate(size_t count);
+  bool AllocateIrq(size_t count, bool system_scope);
+
+  size_t UsedCount() const { return next_idx_.load(std::memory_order_relaxed); }
+  size_t UsedIrqCount() const { return irq_next_idx_.load(std::memory_order_relaxed); }
+
+  ~GraphSignalPool();
+
+ private:
+  std::vector<ProfilingSignal*> signals_;       //!< GPU-only signals
+  std::atomic<size_t> capacity_{0};             //!< Current GPU-only signal count (atomic to avoid race with growth)
+  std::atomic<size_t> next_idx_{0};             //!< Next GPU-only signal index
+  std::vector<ProfilingSignal*> irq_signals_;   //!< Interrupt-capable signals
+  std::atomic<size_t> irq_capacity_{0};         //!< Current interrupt signal count
+  std::atomic<size_t> irq_next_idx_{0};         //!< Next interrupt signal index
+  ProfilingSignal* last_acquired_ = nullptr;    //!< Most recently acquired signal
+  amd::Monitor lock_;                           //!< Protects growth of both vectors
+
+  static ProfilingSignal* AllocateOneSignal(bool interrupt, bool system_scope);
+  ProfilingSignal* GrowAndAcquire(size_t idx);
+  ProfilingSignal* GrowAndAcquireIrq(size_t idx, bool system_scope);
+};
+
 class Sampler : public device::Sampler {
  public:
   //! Constructor
@@ -488,6 +545,10 @@ class Device : public NullDevice {
   virtual uint8_t* CreateBarrierPacket() const override;
   virtual void ApplyHwEventPatches(const std::vector<HwEventPatch>& patches,
                                    const std::vector<void*>& hw_events) const override;
+  virtual GraphSignalPool* CreateGraphSignalPool(
+      size_t gpu_count, size_t irq_count,
+      size_t segment_count, std::vector<void*>& hw_events) const override;
+  virtual size_t GetGraphSignalPoolUsedCount(GraphSignalPool* pool) const override;
   virtual bool CreateUserEvent(amd::UserEvent* event) const override;
   virtual void SetUserEvent(amd::UserEvent* event) const override;
 

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -197,6 +197,31 @@ struct GraphSignalPool {
   //! re-arm-on-acquire and would race with the async-handler thread otherwise.
   void CollectValuePtrs(std::vector<uint64_t*>& out) const;
 
+  //! Set the HSA memory pool used to allocate the contiguous VA buffer.
+  //! Must be called once (with a valid coarse-grained VRAM pool handle)
+  //! before Allocate(). If never called, or if allocation fails,
+  //! ContBuffer() returns nullptr and the caller falls back to
+  //! CollectValuePtrs().
+  void SetAllocPool(hsa_amd_memory_pool_t pool) { alloc_pool_ = pool; }
+
+  //! Set the GPU and CPU HSA agents needed by GrowContBuffer() to grant
+  //! both GPU (read/write) and CPU (write-for-init) access to the
+  //! coarse-grained VRAM allocation via hsa_amd_agents_allow_access.
+  //! Must be called before Allocate().
+  void SetAgents(hsa_agent_t gpu_agent, hsa_agent_t cpu_agent) {
+    gpu_agent_ = gpu_agent;
+    cpu_agent_ = cpu_agent;
+  }
+
+  //! Returns the persistent device-accessible buffer that holds the device VA
+  //! of amd_signal_t.value for every GPU-only signal, laid out contiguously.
+  //! Populated once at Allocate()/GrowAndAcquire() time; valid until
+  //! ~GraphSignalPool. Returns nullptr when unavailable.
+  uint64_t* ContBuffer() const { return cont_buffer_; }
+
+  //! Number of valid entries in ContBuffer() — equals signals_.size().
+  uint32_t ContBufferCount() const { return static_cast<uint32_t>(signals_.size()); }
+
   ~GraphSignalPool();
 
  private:
@@ -207,8 +232,30 @@ struct GraphSignalPool {
   ProfilingSignal* last_acquired_ = nullptr;    //!< Most recently acquired signal
   mutable amd::Monitor lock_;                   //!< Protects growth of signals_ and IRQ scan/grow
 
+  //! Persistent contiguous device-accessible buffer.
+  //! Each entry i holds the device VA of amd_signal_t.value for signals_[i].
+  //! Allocated from GPU coarse-grained VRAM (gpuvm_segment_) with CPU+GPU
+  //! access granted via hsa_amd_agents_allow_access so that:
+  //!   - CPU can populate entries at pool creation / growth time
+  //!   - GPU reset kernel can read the pointer values and write to them
+  //! Null when alloc_pool_ is unavailable or allocation failed.
+  hsa_amd_memory_pool_t alloc_pool_{};          //!< GPU coarse-grained pool for cont_buffer_
+  hsa_agent_t           gpu_agent_{};           //!< GPU HSA agent — needed for allow_access
+  hsa_agent_t           cpu_agent_{};           //!< CPU HSA agent — needed for allow_access
+  uint64_t*             cont_buffer_ = nullptr; //!< Contiguous device VA array of signal value ptrs
+  size_t                cont_buffer_cap_ = 0;   //!< Allocated capacity of cont_buffer_ in entries
+
   static ProfilingSignal* AllocateOneSignal(bool interrupt, bool system_scope);
   ProfilingSignal* GrowAndAcquire(size_t idx);
+
+  //! (Re-)allocate cont_buffer_ to hold at least new_cap entries.
+  //! Copies existing entries [0, old_cap) before freeing the old buffer.
+  //! Returns true on success; leaves cont_buffer_ unchanged on failure.
+  bool GrowContBuffer(size_t new_cap);
+
+  //! Write the device VA of signals_[idx].value into cont_buffer_[idx].
+  //! No-op when cont_buffer_ is null.
+  void PatchContBufferEntry(size_t idx);
 };
 
 class Sampler : public device::Sampler {

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -644,6 +644,13 @@ class Device : public NullDevice {
   virtual bool CreateUserEvent(amd::UserEvent* event) const override;
   virtual void SetUserEvent(amd::UserEvent* event) const override;
 
+  //! Capture the reset kernel AQL packet at instantiate time without hardware
+  //! dispatch. captureCmd must have setPktCapturingState(true, ...) already
+  //! called; on return captureCmd->gpuPackets_[0] holds the 64-byte packet
+  //! with kernarg_address pointing into the graph kernarg pool and
+  //! completion_signal left as zero (caller patches it after rebuildFlatBuffer).
+  bool CaptureResetKernelPacket(GraphSignalPool* pool, amd::Command* captureCmd) const;
+
   //! Allocate host memory in terms of numa policy set by user
   void* hostNumaAlloc(size_t size, size_t alignment, MemorySegment mem_seg) const;
 

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -116,7 +116,23 @@ class ProfilingSignal : public amd::ReferenceCountedObject {
 
 //! Graph-owned signal pool for per-launch signal allocation.
 //! Avoids runtime signal pool stalls (WaitCurrent/WaitNext) during graph execution.
-//! Two sub-pools: GPU-only signals (fast) and interrupt-capable signals (for host callbacks).
+//!
+//! Two sub-pools:
+//!   - GPU-only signals: pre-allocated up to graph_signal_count_; recycled
+//!     between launches via TryCpuReset/GPU-side reset (entire sub-pool is
+//!     re-armed at once when the previous launch is fully drained).
+//!   - IRQ signals: pulled on-demand via AcquireIrq with re-arm-on-acquire
+//!     semantics. Each AcquireIrq() scans the IRQ vector for a signal whose
+//!     handler has already fully retired (flags_.done_ == true — set inside
+//!     HsaAmdSignalHandler's drain path, not implied by value==0), silent-
+//!     stores init_val and returns it. Only allocates a fresh IRQ signal
+//!     when nothing is reusable (launches overlap in flight). Sub-pool
+//!     size therefore stays bounded by max-concurrent-in-flight launches
+//!     × IRQs-per-launch.
+//!
+//! The pool is owned by GraphExec (persistent across launches) and is
+//! destroyed in ~GraphExec after every parallel stream has finished — at
+//! which point all async handlers attached to any IRQ signal have fired.
 struct GraphSignalPool {
   ProfilingSignal* Acquire() {
     size_t idx = next_idx_.fetch_add(1, std::memory_order_relaxed);
@@ -130,17 +146,12 @@ struct GraphSignalPool {
     return ps;
   }
 
-  ProfilingSignal* AcquireIrq(bool system_scope) {
-    size_t idx = irq_next_idx_.fetch_add(1, std::memory_order_relaxed);
-    ProfilingSignal* ps;
-    if (idx < irq_capacity_.load(std::memory_order_acquire)) {
-      ps = irq_signals_[idx];
-    } else {
-      ps = GrowAndAcquireIrq(idx, system_scope);
-    }
-    if (ps) last_acquired_ = ps;
-    return ps;
-  }
+  //! Acquire an IRQ-capable signal and atomically re-arm it to init_val.
+  //! Scans irq_signals_ under lock_ for a signal with flags_.done_ == true
+  //! (handler has fully retired — see rocdevice.cpp::AcquireIrq for why a
+  //! value==0 check is insufficient); if found, silent-stores init_val and
+  //! returns it. Otherwise allocates a fresh signal and appends it.
+  ProfilingSignal* AcquireIrq(bool system_scope, hsa_signal_value_t init_val);
 
   //! Returns the most recently acquired signal from a GPU dispatch (not pre-allocation)
   ProfilingSignal* GetLastAcquired() const { return last_acquired_; }
@@ -149,10 +160,42 @@ struct GraphSignalPool {
   void ResetLastAcquired() { last_acquired_ = nullptr; }
 
   bool Allocate(size_t count);
-  bool AllocateIrq(size_t count, bool system_scope);
 
   size_t UsedCount() const { return next_idx_.load(std::memory_order_relaxed); }
-  size_t UsedIrqCount() const { return irq_next_idx_.load(std::memory_order_relaxed); }
+
+  //! Current size of the IRQ sub-pool. Used by diagnostics — there is no
+  //! "used IRQ count" because IRQ signals are scanned/re-armed on Acquire,
+  //! not bumped via a counter.
+  size_t IrqCapacity() const {
+    amd::ScopedLock sl(lock_);
+    return irq_signals_.size();
+  }
+
+  //! Total number of signals currently owned by the pool (both sub-pools).
+  size_t TotalSignalCount() const {
+    amd::ScopedLock sl(lock_);
+    return signals_.size() + irq_signals_.size();
+  }
+
+  //! Try to reset the GPU-only sub-pool entirely on the CPU. Returns true if
+  //! every GPU-only signal is already at 0 (previous launch's GPU work fully
+  //! drained): all GPU-only signal values are silently stored back to 1 and
+  //! the acquire counter is wound back to 0. Returns false if any GPU-only
+  //! signal is still busy, in which case the caller must dispatch a GPU-side
+  //! reset before the next launch. IRQ signals are NOT touched here — they
+  //! are re-armed individually on each AcquireIrq.
+  bool TryCpuReset();
+
+  //! Wind GPU-only acquire counter back to 0 and clear last_acquired_. Used
+  //! by the caller after dispatching a GPU-side reset (the GPU kernel only
+  //! resets the signal value bytes; the host-side bookkeeping is reset here).
+  void ResetCountersForReuse();
+
+  //! Append device-visible pointers to amd_signal_t.value for every GPU-only
+  //! signal into out. Used by the GPU reset kernel; pointers are stable for
+  //! the pool's lifetime. IRQ signals are excluded — they're handled by
+  //! re-arm-on-acquire and would race with the async-handler thread otherwise.
+  void CollectValuePtrs(std::vector<uint64_t*>& out) const;
 
   ~GraphSignalPool();
 
@@ -160,15 +203,12 @@ struct GraphSignalPool {
   std::vector<ProfilingSignal*> signals_;       //!< GPU-only signals
   std::atomic<size_t> capacity_{0};             //!< Current GPU-only signal count (atomic to avoid race with growth)
   std::atomic<size_t> next_idx_{0};             //!< Next GPU-only signal index
-  std::vector<ProfilingSignal*> irq_signals_;   //!< Interrupt-capable signals
-  std::atomic<size_t> irq_capacity_{0};         //!< Current interrupt signal count
-  std::atomic<size_t> irq_next_idx_{0};         //!< Next interrupt signal index
+  std::vector<ProfilingSignal*> irq_signals_;   //!< IRQ-capable signals (re-armed on acquire)
   ProfilingSignal* last_acquired_ = nullptr;    //!< Most recently acquired signal
-  amd::Monitor lock_;                           //!< Protects growth of both vectors
+  mutable amd::Monitor lock_;                   //!< Protects growth of signals_ and IRQ scan/grow
 
   static ProfilingSignal* AllocateOneSignal(bool interrupt, bool system_scope);
   ProfilingSignal* GrowAndAcquire(size_t idx);
-  ProfilingSignal* GrowAndAcquireIrq(size_t idx, bool system_scope);
 };
 
 class Sampler : public device::Sampler {
@@ -546,9 +586,14 @@ class Device : public NullDevice {
   virtual void ApplyHwEventPatches(const std::vector<HwEventPatch>& patches,
                                    const std::vector<void*>& hw_events) const override;
   virtual GraphSignalPool* CreateGraphSignalPool(
-      size_t gpu_count, size_t irq_count,
+      size_t gpu_count,
       size_t segment_count, std::vector<void*>& hw_events) const override;
   virtual size_t GetGraphSignalPoolUsedCount(GraphSignalPool* pool) const override;
+  virtual void DestroyGraphSignalPool(GraphSignalPool* pool) const override;
+  virtual bool ResetGraphSignalPool(device::VirtualDevice* vdev,
+                                    GraphSignalPool* pool,
+                                    bool prev_done,
+                                    bool* out_did_gpu_reset = nullptr) const override;
   virtual bool CreateUserEvent(amd::UserEvent* event) const override;
   virtual void SetUserEvent(amd::UserEvent* event) const override;
 

--- a/projects/clr/rocclr/device/rocm/rocrctx.hpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.hpp
@@ -10,19 +10,19 @@
 #include "top.hpp"
 
 #if defined(ROCR_DYN_DLL) || defined(ROCR_STATIC_OPEN)
-#include "hsa.h"
-#include "hsa_ext_image.h"
-#include "hsa_ext_amd.h"
-#include "amd_hsa_signal.h"
-#include "hsa_ven_amd_loader.h"
-#include "hsa_ven_amd_aqlprofile.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa_ext_image.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa_ext_amd.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/amd_hsa_signal.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa_ven_amd_loader.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa_ven_amd_aqlprofile.h"
 #else
-#include "hsa/hsa.h"
-#include "hsa/hsa_ext_image.h"
-#include "hsa/hsa_ext_amd.h"
-#include "hsa/amd_hsa_signal.h"
-#include "hsa/hsa_ven_amd_loader.h"
-#include "hsa/hsa_ven_amd_aqlprofile.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/hsa.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/hsa_ext_image.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/hsa_ext_amd.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/amd_hsa_signal.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/hsa_ven_amd_loader.h"
+#include "/home/amd/anusha_latest_clr/rocm-systems/projects/rocr-runtime/build/install/include/hsa/hsa_ven_amd_aqlprofile.h"
 #endif
 
 namespace amd {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1210,12 +1210,6 @@ void VirtualGPU::AcquireQueueWithPreference() {
 }
 
 // ================================================================================================
-void VirtualGPU::AcquireQueueWithPreference() {
-  std::scoped_lock lock(execution());
-  AcquireQueueWithPreferenceLocked();
-}
-
-// ================================================================================================
 bool VirtualGPU::ReacquireQueueExcluding(const std::unordered_set<uint64_t>& excluded_ids) {
   std::scoped_lock lock(execution());
   if (gpu_queue_ != nullptr) {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -567,6 +567,89 @@ bool VirtualGPU::HwQueueTracker::Create() {
 hsa_signal_t VirtualGPU::HwQueueTracker::ActiveSignal(hsa_signal_value_t init_val, Timestamp* ts,
                                                       bool attach_signal) {
   amd::Command* cmd = gpu_.command();
+
+  // Graph signal pool fast path: skip WaitCurrent/WaitNext, use graph-owned signals.
+  // No fallback to runtime pool — graph pool grows on demand.
+  if (cmd != nullptr && cmd->graphSignalPool() != nullptr) {
+    if (!attach_signal) {
+      if (cmd->HwEvent() != nullptr) {
+        reinterpret_cast<ProfilingSignal*>(cmd->HwEvent())->release();
+      }
+      cmd->SetHwEvent(nullptr);
+      return hsa_signal_t{0};
+    }
+
+    auto* pool = cmd->graphSignalPool();
+
+    bool enqueHandler = false;
+    if (ts != nullptr) {
+      enqueHandler =
+          (ts->command().Callback() != nullptr || ts->command().GetBatchHead() != nullptr) &&
+          !ts->command().CpuWaitRequested();
+    }
+    bool use_irq = enqueHandler || (IS_WINDOWS && gpu_.ForceIrq());
+    use_irq |= !gpu_.dev().ActiveWait();
+
+    ProfilingSignal* ps;
+    if (use_irq) {
+      const Settings& settings = gpu_.dev().settings();
+      ps = pool->AcquireIrq(settings.system_scope_signal_);
+    } else {
+      ps = pool->Acquire();
+    }
+
+    if (ps == nullptr) {
+      LogError("GraphSignalPool: failed to allocate signal");
+      if (cmd->HwEvent() != nullptr) {
+        reinterpret_cast<ProfilingSignal*>(cmd->HwEvent())->release();
+      }
+      cmd->SetHwEvent(nullptr);
+      return hsa_signal_t{0};
+    }
+
+    Hsa::signal_silent_store_relaxed(ps->signal_, init_val);
+    ps->flags_.done_ = false;
+    ps->engine_ = engine_;
+    ps->flags_.isPacketDispatch_ = false;
+    ps->ResetCachedTiming();
+
+    if (cmd->HwEvent() != nullptr) {
+      reinterpret_cast<ProfilingSignal*>(cmd->HwEvent())->release();
+    }
+    cmd->SetHwEvent(ps);
+    ps->retain();
+
+    if (ts != nullptr) {
+      ts->retain();
+      ps->ts_ = ts;
+      ts->AddProfilingSignal(ps);
+
+      if (enqueHandler) {
+        uint32_t handler_init = kInitSignalValueOne;
+        if (ts->command().Callback() != nullptr) {
+          bool blocking = ts->command().Callback()->blocking_;
+          ts->SetCallbackSignal(ps->signal_, blocking);
+          if (blocking) {
+            Hsa::signal_add_relaxed(ps->signal_, 1);
+            handler_init += 1;
+          }
+        }
+        gpu_.QueuedAsyncHandlers()++;
+        ts->gpu()->retain();
+        hsa_status_t result = Hsa::signal_async_handler(
+            ps->signal_, HSA_SIGNAL_CONDITION_LT, handler_init, &HsaAmdSignalHandler, ts);
+        if (HSA_STATUS_SUCCESS != result) {
+          gpu_.QueuedAsyncHandlers()--;
+          ts->gpu()->release();
+          LogError("hsa_amd_signal_async_handler() failed in graph pool path");
+        }
+      }
+    }
+    return ps->signal_;
+  }
+
+  // --- Normal runtime pool path ---
+
   // If no signal is needed, decrement the refcount and clear the hw_event of current command
   if (!attach_signal) {
     if (nullptr != cmd) {
@@ -740,15 +823,16 @@ std::vector<hsa_signal_t>& VirtualGPU::HwQueueTracker::WaitingSignal(HwQueueEngi
   if (explicit_wait) {
     bool skip_internal_signal = false;
 
+    ProfilingSignal* last_signal = GetLastSignal();
     for (uint32_t i = 0; i < external_signals_.size(); ++i) {
       // If external signal matches internal one, then skip it
-      if (external_signals_[i]->signal_.handle == signal_list_[current_id_]->signal_.handle) {
+      if (external_signals_[i]->signal_.handle == last_signal->signal_.handle) {
         skip_internal_signal = true;
       }
     }
     // Add the oldest signal into the tracking for a wait
     if (!skip_internal_signal) {
-      external_signals_.push_back(signal_list_[current_id_]);
+      external_signals_.push_back(last_signal);
     }
   }
 
@@ -806,13 +890,25 @@ bool VirtualGPU::HwQueueTracker::CpuWaitForSignal(ProfilingSignal* signal) {
 }
 
 // ================================================================================================
+ProfilingSignal* VirtualGPU::HwQueueTracker::GetLastSignal() const {
+  auto* cmd = gpu_.command();
+  if (cmd != nullptr && cmd->graphSignalPool() != nullptr) {
+    auto* last = cmd->graphSignalPool()->GetLastAcquired();
+    if (last != nullptr) return last;
+  }
+  return signal_list_[current_id_];
+}
+
+// ================================================================================================
 bool VirtualGPU::HwQueueTracker::WaitCurrent() {
-  ProfilingSignal* signal = signal_list_[current_id_];
+  ProfilingSignal* signal = GetLastSignal();
   return CpuWaitForSignal(signal);
 }
 
 // ================================================================================================
 void VirtualGPU::HwQueueTracker::WaitNext() {
+  auto* cmd = gpu_.command();
+  if (cmd != nullptr && cmd->graphSignalPool() != nullptr) return;
   size_t next = (current_id_ + 1) % signal_list_.size();
   ProfilingSignal* signal = signal_list_[next];
   // Only wait, there is no need to save timestamp for the next signal
@@ -822,6 +918,14 @@ void VirtualGPU::HwQueueTracker::WaitNext() {
 
 // ================================================================================================
 void VirtualGPU::HwQueueTracker::ResetCurrentSignal() {
+  auto* cmd = gpu_.command();
+  if (cmd != nullptr && cmd->graphSignalPool() != nullptr) {
+    auto* last = cmd->graphSignalPool()->GetLastAcquired();
+    if (last != nullptr) {
+      Hsa::signal_silent_store_relaxed(last->signal_, 0);
+    }
+    return;
+  }
   // Reset the signal and return
   Hsa::signal_silent_store_relaxed(signal_list_[current_id_]->signal_, 0);
   // Fallback to the previous signal
@@ -1517,8 +1621,16 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
              (thisChunk - firstCount) * kPacketSize);
     }
 
-    // Per-packet fixups: profiling signals and kernel-name printing.
-    if (timestamp_ != nullptr || IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2)) {
+    // Attach signal to the last packet when requested (before per-packet logging).
+    auto* lastSlotPtr = reinterpret_cast<hsa_kernel_dispatch_packet_t*>(
+        queueBase + ((startIndex + chunkEnd - 1) & queueMask) * kPacketSize);
+    if (isLastChunk && (attach_signal || blocking) && timestamp_ == nullptr) {
+      lastSlotPtr->completion_signal = Barriers().ActiveSignal();
+    }
+
+    // Per-packet fixups: profiling signals, kernel-name printing, and barrier logging.
+    if (timestamp_ != nullptr || IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2) ||
+        IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) {
       for (size_t i = chunkStart; i < chunkEnd; ++i) {
         const uint64_t slotIdx = (startIndex + i) & queueMask;
         auto* slot = reinterpret_cast<hsa_kernel_dispatch_packet_t*>(
@@ -1527,8 +1639,6 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
         const uint8_t pktType =
             extractAqlBits(hdr, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE);
         if (timestamp_ != nullptr) {
-          // When pre_patched, skip any slot whose completion_signal was already
-          // written by ApplyHwEventPatches (non-zero means pre-patched).
           bool has_prepatched_signal = pre_patched && (slot->completion_signal.handle != 0);
           if (!has_prepatched_signal) {
             slot->completion_signal =
@@ -1566,14 +1676,27 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
                   slot->kernel_object, slot->kernarg_address,
                   slot->completion_signal, slot->reserved2,
                   Hsa::queue_load_read_index_scacquire(gpu_queue_), slotIdx);
+        } else if (pktType == HSA_PACKET_TYPE_BARRIER_AND) {
+          auto* bpkt = reinterpret_cast<hsa_barrier_and_packet_t*>(slot);
+          ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL,
+                  "SWq=0x%zx, HWq=0x%zx, id=%d, Graph Barrier-AND Header = "
+                  "0x%x (type=%d, barrier=%d, acquire=%d, release=%d), "
+                  "dep_signal=[0x%zx, 0x%zx, 0x%zx, 0x%zx, 0x%zx], "
+                  "completion_signal=0x%zx, rptr=%u, wptr=%u",
+                  gpu_queue_, gpu_queue_->base_address, gpu_queue_->id, hdr, pktType,
+                  extractAqlBits(hdr, HSA_PACKET_HEADER_BARRIER,
+                                 HSA_PACKET_HEADER_WIDTH_BARRIER),
+                  extractAqlBits(hdr, HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE,
+                                 HSA_PACKET_HEADER_WIDTH_SCACQUIRE_FENCE_SCOPE),
+                  extractAqlBits(hdr, HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE,
+                                 HSA_PACKET_HEADER_WIDTH_SCRELEASE_FENCE_SCOPE),
+                  bpkt->dep_signal[0].handle, bpkt->dep_signal[1].handle,
+                  bpkt->dep_signal[2].handle, bpkt->dep_signal[3].handle,
+                  bpkt->dep_signal[4].handle,
+                  bpkt->completion_signal.handle,
+                  Hsa::queue_load_read_index_scacquire(gpu_queue_), slotIdx);
         }
       }
-    }
-
-    auto* lastSlotPtr = reinterpret_cast<hsa_kernel_dispatch_packet_t*>(
-        queueBase + ((startIndex + chunkEnd - 1) & queueMask) * kPacketSize);
-    if (isLastChunk && (attach_signal || blocking) && timestamp_ == nullptr) {
-      lastSlotPtr->completion_signal = Barriers().ActiveSignal();
     }
 
     // Write valid headers and ring the doorbell for this chunk.

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1577,17 +1577,11 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
 
   uint8_t* queueBase = static_cast<uint8_t*>(gpu_queue_->base_address);
 
-  // Reserve ALL slots with a single wptr bump, then submit in kPeriod-sized chunks.
-  // Per-chunk: yield if the queue is full (handles graphs larger than the queue), then
-  // memcpy + per-packet fixups + headers + doorbell.  For graphs that fit in the queue
-  // the yield never fires.
-  uint64_t startIndex = Hsa::queue_add_write_index_screlease(gpu_queue_, numPackets);
+  // Reserve all slots upfront with a single atomic bump.
+  uint64_t globalStart = Hsa::queue_add_write_index_screlease(gpu_queue_, numPackets);
   setFenceDirty(true);
 
   // Update cached fence state from the last packet's release scope.
-  // Clear fence dirty if the last packet has system-scope release, matching
-  // the single-dispatch path in dispatchGenericAqlPacket (set dirty on reserve,
-  // then conditionally clear if system scope).
   auto expected_fence_state =
       extractAqlBits(lastHeader, HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE,
                      HSA_PACKET_HEADER_WIDTH_SCRELEASE_FENCE_SCOPE);
@@ -1598,16 +1592,17 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
 
   const size_t kPeriod = DEBUG_HIP_GRAPH_BATCH_SIZE;
   auto* first_loc = reinterpret_cast<uint32_t*>(
-      queueBase + (startIndex & queueMask) * kPacketSize);
+      queueBase + (globalStart & queueMask) * kPacketSize);
 
   for (size_t chunkStart = 0; chunkStart < numPackets; ) {
     const size_t chunkEnd  = std::min(chunkStart + kPeriod, numPackets);
     const size_t thisChunk = chunkEnd - chunkStart;
     const bool isFirstChunk = (chunkStart == 0);
     const bool isLastChunk  = (chunkEnd == numPackets);
+    const uint64_t startIndex = globalStart;
 
     // Yield until this chunk's physical slots are free.
-    while (((startIndex + chunkEnd - 1) - Hsa::queue_load_read_index_scacquire(gpu_queue_)) >=
+    while (((globalStart + chunkEnd - 1) - Hsa::queue_load_read_index_scacquire(gpu_queue_)) >=
            sw_queue_size) {
       amd::Os::yield();
     }
@@ -1724,8 +1719,9 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
 
   hasPendingDispatch_ = true;
 
+  const uint64_t lastSlotIdx = globalStart + numPackets - 1;
   auto* finalLastSlot = reinterpret_cast<hsa_kernel_dispatch_packet_t*>(
-      queueBase + ((startIndex + numPackets - 1) & queueMask) * kPacketSize);
+      queueBase + (lastSlotIdx & queueMask) * kPacketSize);
 
   // Skip the pending dispatch only when both conditions are met: a completion
   // signal tracks the last packet and the fence is already clean (system scope).
@@ -1733,7 +1729,7 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
     hasPendingDispatch_ = false;
   }
 
-  TrackQueueProgress(*finalLastSlot, startIndex + numPackets - 1, pre_patched);
+  TrackQueueProgress(*finalLastSlot, lastSlotIdx, pre_patched);
 
   if (blocking) {
     LogInfo("Running serialized as blocking is requested");
@@ -2116,9 +2112,10 @@ bool VirtualGPU::create() {
   void* md_rb = nullptr;
   SetGpuQueue(roc_device_.acquireQueue(queue_size, cooperative_, cuMask_, priority_, false,
                                        dedicated_queue_, nullptr, nullptr, &md_rb), md_rb);
-  if (!gpu_queue_) return false;
+  if (!gpu_queue_) { fprintf(stderr, "[DIAG] VirtualGPU::create: acquireQueue failed\n"); fflush(stderr); return false; }
 
   if (!managed_kernarg_buffer_.Create(Device::MemorySegment::kKernArg)) {
+    fprintf(stderr, "[DIAG] VirtualGPU::create: managed_kernarg_buffer_ failed\n"); fflush(stderr);
     LogError("Couldn't allocate arguments/signals for the queue");
     return false;
   }
@@ -2126,6 +2123,7 @@ bool VirtualGPU::create() {
   device::BlitManager::Setup blitSetup;
   blitMgr_ = new KernelBlitManager(*this, blitSetup);
   if ((nullptr == blitMgr_) || !blitMgr_->create(roc_device_)) {
+    fprintf(stderr, "[DIAG] VirtualGPU::create: BlitManager failed\n"); fflush(stderr);
     LogError("Could not create BlitManager!");
     return false;
   }
@@ -2152,6 +2150,7 @@ bool VirtualGPU::create() {
   // Allocate signal tracker for ROCr copy queue
   tracking_created_ = Barriers().Create();
   if (!tracking_created_) {
+    fprintf(stderr, "[DIAG] VirtualGPU::create: Barriers().Create() failed\n"); fflush(stderr);
     LogError("Could not create signal for copy queue!");
     return false;
   }

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -38,6 +38,7 @@
 #endif
 #endif
 
+
 /**
  * HSA image object size in bytes (see HSA spec)
  */
@@ -378,10 +379,6 @@ bool HsaAmdSignalHandler(hsa_signal_value_t value, void* arg) {
   // Update the batch, since signal is complete
   gpu->updateCommandsState(ts->command().GetBatchHead());
 
-  // Opportunistically try to release the HW queue if it's now idle
-  // This helps reclaim queues in async workloads without explicit sync
-  gpu->ReleaseHwQueue();
-
   // Reset API callback signal. It will release AQL queue and start commands processing
   if (callback_signal.handle != 0 && isBlocking) {
     Hsa::signal_subtract_relaxed(callback_signal, 1);
@@ -569,7 +566,11 @@ hsa_signal_t VirtualGPU::HwQueueTracker::ActiveSignal(hsa_signal_value_t init_va
   amd::Command* cmd = gpu_.command();
 
   // Graph signal pool fast path: skip WaitCurrent/WaitNext, use graph-owned signals.
-  // No fallback to runtime pool — graph pool grows on demand.
+  // No fallback to runtime pool — graph pool grows on demand. IRQ signals come
+  // from the pool's IRQ sub-pool (AcquireIrq), which uses re-arm-on-acquire
+  // semantics: scans for a signal whose handler has already fired (value==0),
+  // silently re-arms it to init_val and returns it; only allocates a fresh one
+  // when nothing is reusable (i.e., when launches overlap).
   if (cmd != nullptr && cmd->graphSignalPool() != nullptr) {
     if (!attach_signal) {
       if (cmd->HwEvent() != nullptr) {
@@ -593,9 +594,14 @@ hsa_signal_t VirtualGPU::HwQueueTracker::ActiveSignal(hsa_signal_value_t init_va
     ProfilingSignal* ps;
     if (use_irq) {
       const Settings& settings = gpu_.dev().settings();
-      ps = pool->AcquireIrq(settings.system_scope_signal_);
+      ps = pool->AcquireIrq(settings.system_scope_signal_, init_val);
     } else {
       ps = pool->Acquire();
+      if (ps != nullptr) {
+        Hsa::signal_silent_store_relaxed(ps->signal_, init_val);
+        ps->flags_.done_ = false;
+        ps->ResetCachedTiming();
+      }
     }
 
     if (ps == nullptr) {
@@ -607,11 +613,8 @@ hsa_signal_t VirtualGPU::HwQueueTracker::ActiveSignal(hsa_signal_value_t init_va
       return hsa_signal_t{0};
     }
 
-    Hsa::signal_silent_store_relaxed(ps->signal_, init_val);
-    ps->flags_.done_ = false;
     ps->engine_ = engine_;
     ps->flags_.isPacketDispatch_ = false;
-    ps->ResetCachedTiming();
 
     if (cmd->HwEvent() != nullptr) {
       reinterpret_cast<ProfilingSignal*>(cmd->HwEvent())->release();
@@ -1204,6 +1207,12 @@ void VirtualGPU::AcquireQueueWithPreference() {
     SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, last_hwq_, nullptr, &md_rb), md_rb);
     last_hwq_ = nullptr;
   }
+}
+
+// ================================================================================================
+void VirtualGPU::AcquireQueueWithPreference() {
+  std::scoped_lock lock(execution());
+  AcquireQueueWithPreferenceLocked();
 }
 
 // ================================================================================================

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -503,6 +503,11 @@ class VirtualGPU : public device::VirtualDevice {
   //! Acquire a HW queue using the preferred hint, then clear the hint
   void AcquireQueueWithPreference() override;
 
+  //! Same as AcquireQueueWithPreference() but assumes execution() is already held by the caller.
+  //! Use this when the caller needs to keep execution() locked across the acquire to prevent the
+  //! async signal handler thread from racing in and releasing the queue.
+  void AcquireQueueWithPreferenceLocked();
+
   //! Pin the HW queue so ReleaseHwQueue() becomes a no-op (used by graph internal streams)
   void PinQueue() override { queue_pinned_ = true; }
   //! Unpin the HW queue, allowing ReleaseHwQueue() to release it again
@@ -545,6 +550,12 @@ class VirtualGPU : public device::VirtualDevice {
 
   Timestamp* timestamp() const { return timestamp_; }
   amd::Command* command() const { return command_; }
+  //! Override the currently-tracked command. Used by callers (e.g. graph-pool
+  //! signal reset) that dispatch a blit kernel outside any host command and
+  //! want HwQueueTracker::ActiveSignal() to take the runtime-pool path
+  //! (graph pool requires command_ to carry a graphSignalPool reference).
+  //! Caller is responsible for save/restore of the prior command pointer.
+  void SetCommand(amd::Command* cmd) { command_ = cmd; }
 
   void* allocKernArg(size_t size, size_t alignment);
   bool isFenceDirty() const { return fence_dirty_.load(std::memory_order_acquire); }

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -287,7 +287,7 @@ class VirtualGPU : public device::VirtualDevice {
     void AddExternalSignal(ProfilingSignal* signal) { external_signals_.push_back(signal); }
 
     //! Get the last active signal on the queue
-    ProfilingSignal* GetLastSignal() const { return signal_list_[current_id_]; }
+    ProfilingSignal* GetLastSignal() const;
 
     //! Clear external signals
     void ClearExternalSignals() { external_signals_.clear(); }
@@ -535,7 +535,7 @@ class VirtualGPU : public device::VirtualDevice {
 
   void hasPendingDispatch() { hasPendingDispatch_ = true; }
   bool IsPendingDispatch() const { return (hasPendingDispatch_) ? true : false; }
-  void addSystemScope() {
+  void addSystemScope() override {
     addSystemScope_ = true;
     fence_state_ = amd::Device::CacheState::kCacheStateInvalid;
   }

--- a/projects/clr/rocclr/platform/command.cpp
+++ b/projects/clr/rocclr/platform/command.cpp
@@ -63,13 +63,19 @@ Event::~Event() {
 
 // ================================================================================================
 AccumulateCommand::~AccumulateCommand() {
-  // Release all retained HW events per device
-  for (auto& device_events_pair : hw_events_) {
-    Device* dev = device_events_pair.first;
-    if (dev != nullptr) {
-      for (void* hw_event : device_events_pair.second) {
-        if (hw_event != nullptr) {
-          dev->ReleaseGlobalSignal(hw_event);
+  if (owned_graph_signal_pool_ != nullptr) {
+    // Graph pool owns all signals (SyncPlan HW events + ActiveSignal signals).
+    // Skip per-device HW event release — pool destructor handles everything.
+    delete owned_graph_signal_pool_;
+  } else {
+    // Non-graph path: release HW events per device as before
+    for (auto& device_events_pair : hw_events_) {
+      Device* dev = device_events_pair.first;
+      if (dev != nullptr) {
+        for (void* hw_event : device_events_pair.second) {
+          if (hw_event != nullptr) {
+            dev->ReleaseGlobalSignal(hw_event);
+          }
         }
       }
     }

--- a/projects/clr/rocclr/platform/command.cpp
+++ b/projects/clr/rocclr/platform/command.cpp
@@ -63,19 +63,20 @@ Event::~Event() {
 
 // ================================================================================================
 AccumulateCommand::~AccumulateCommand() {
-  if (owned_graph_signal_pool_ != nullptr) {
-    // Graph pool owns all signals (SyncPlan HW events + ActiveSignal signals).
-    // Skip per-device HW event release — pool destructor handles everything.
-    delete owned_graph_signal_pool_;
-  } else {
-    // Non-graph path: release HW events per device as before
-    for (auto& device_events_pair : hw_events_) {
-      Device* dev = device_events_pair.first;
-      if (dev != nullptr) {
-        for (void* hw_event : device_events_pair.second) {
-          if (hw_event != nullptr) {
-            dev->ReleaseGlobalSignal(hw_event);
-          }
+  // The graph signal pool (if any) is owned by GraphExec, not by us. Just
+  // release any per-device HW events we accumulated for non-graph commands.
+  // For graph commands those HW events live inside the persistent pool and
+  // must NOT be released individually here — they get released en masse when
+  // GraphExec destroys the pool.
+  if (graphSignalPool() != nullptr) {
+    return;
+  }
+  for (auto& device_events_pair : hw_events_) {
+    Device* dev = device_events_pair.first;
+    if (dev != nullptr) {
+      for (void* hw_event : device_events_pair.second) {
+        if (hw_event != nullptr) {
+          dev->ReleaseGlobalSignal(hw_event);
         }
       }
     }

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -42,6 +42,7 @@ namespace amd {
 class Command;
 class HostQueue;
 union ComputeCommand;
+namespace roc { struct GraphSignalPool; }
 
 /*! \brief Encapsulates the status of a command.
  *
@@ -310,6 +311,7 @@ class Command : public Event {
   GraphKernelArgManager* graphKernArgMgr_ = nullptr;  //!< KernelMgr for graph
   address kernArgOffset_ = nullptr;  //!< KernelArg buffer to used when graph capturing is enabled
   const std::string** capturedKernelName_ = nullptr;  //!< Kernel under capture
+  roc::GraphSignalPool* graph_signal_pool_ = nullptr;  //!< Graph-owned signal pool for this command
  protected:
   bool cpu_wait_ = false;  //!< If true, then the command was issued for CPU/GPU sync
 
@@ -459,6 +461,11 @@ class Command : public Event {
 
   //! Check if this command(should be a marker) requires CPU wait
   bool CpuWaitRequested() const { return cpu_wait_; }
+
+  //! Set graph signal pool for graph-owned signal allocation
+  void SetGraphSignalPool(roc::GraphSignalPool* pool) { graph_signal_pool_ = pool; }
+  //! Get graph signal pool (nullptr for non-graph commands)
+  roc::GraphSignalPool* graphSignalPool() const { return graph_signal_pool_; }
 };
 
 class UserEvent : public Command {
@@ -1502,6 +1509,8 @@ class AccumulateCommand : public Command {
   std::vector<std::pair<uint64_t, uint64_t>> tsList_;
   //! HW events that need to be released when this command is destroyed
   std::unordered_map<Device*, std::vector<void*>> hw_events_;
+  //! Graph signal pool owned by this command (deleted after GPU completion)
+  roc::GraphSignalPool* owned_graph_signal_pool_ = nullptr;
 
  public:
   //! Create a new Marker
@@ -1524,6 +1533,9 @@ class AccumulateCommand : public Command {
       }
     }
   }
+
+  //! Transfer ownership of graph signal pool for cleanup after GPU completion
+  void SetOwnedGraphSignalPool(roc::GraphSignalPool* pool) { owned_graph_signal_pool_ = pool; }
 
   //! Add kernel name to the list if available
   void addKernelName(const std::string* kernelName) { kernelNames_.push_back(kernelName); }

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -309,7 +309,6 @@ class Command : public Event {
   bool packetCapturing_ = false;       //!< Flag to enable/disable graph gpu packet capture
   std::vector<uint8_t*>* gpuPackets_;  //!< GPU packets captured when graph capturing is enabled
   GraphKernelArgManager* graphKernArgMgr_ = nullptr;  //!< KernelMgr for graph
-  address kernArgOffset_ = nullptr;  //!< KernelArg buffer to used when graph capturing is enabled
   const std::string** capturedKernelName_ = nullptr;  //!< Kernel under capture
   roc::GraphSignalPool* graph_signal_pool_ = nullptr;  //!< Graph-owned signal pool for this command
  protected:

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -1509,8 +1509,12 @@ class AccumulateCommand : public Command {
   std::vector<std::pair<uint64_t, uint64_t>> tsList_;
   //! HW events that need to be released when this command is destroyed
   std::unordered_map<Device*, std::vector<void*>> hw_events_;
-  //! Graph signal pool owned by this command (deleted after GPU completion)
-  roc::GraphSignalPool* owned_graph_signal_pool_ = nullptr;
+  //
+  // NOTE: AccumulateCommand does NOT own the graph signal pool. The pool is
+  // owned by GraphExec (persistent across launches). AccumulateCommand only
+  // carries a non-owning reference (via Command::graphSignalPool_) so that
+  // segments dispatched on parallel streams can pull GPU-only signals from
+  // the same pool. ~AccumulateCommand therefore does not touch the pool.
 
  public:
   //! Create a new Marker
@@ -1533,9 +1537,6 @@ class AccumulateCommand : public Command {
       }
     }
   }
-
-  //! Transfer ownership of graph signal pool for cleanup after GPU completion
-  void SetOwnedGraphSignalPool(roc::GraphSignalPool* pool) { owned_graph_signal_pool_ = pool; }
 
   //! Add kernel name to the list if available
   void addKernelName(const std::string* kernelName) { kernelNames_.push_back(kernelName); }

--- a/projects/clr/rocclr/platform/commandqueue.hpp
+++ b/projects/clr/rocclr/platform/commandqueue.hpp
@@ -176,7 +176,7 @@ class HostQueue : public CommandQueue {
       }
     }
 
-    void Release() const { virtualDevice_->release(); }
+    void Release() const { if (virtualDevice_ != nullptr) virtualDevice_->release(); }
 
     //! Get virtual device for the current thread
     device::VirtualDevice* vdev() const { return virtualDevice_; }

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -271,7 +271,12 @@ release(bool, DEBUG_CLR_DISABLE_IMAGE, false,                                 \
 release(bool, DEBUG_CLR_ENABLE_PREFETCH_METADATA, true,                       \
         "Enable metadata prefetch for some Aql packets")                      \
 release(uint, DEBUG_CLR_DOORBELL_SKIP, 16,                                    \
-        "Number of consecutive dispatches that may skip the doorbell flush.")
+        "Number of consecutive dispatches that may skip the doorbell flush.")  \
+release(bool, GPU_GRAPH_CONT_SIGNAL_RESET, true,                               \
+        "Use the persistent contiguous VA buffer for graph GPU-side signal "   \
+        "reset (true = __amd_rocclr_resetContSignalBuffer, skips per-launch "  \
+        "CollectValuePtrs + memcpy; false = legacy __amd_rocclr_resetGraph"    \
+        "Signals with a freshly assembled pointer list each launch)")
  
 
 namespace amd {


### PR DESCRIPTION
## Summary

Moves `GraphSignalPool` creation, segment completion-signal allocation, and reset-wait barrier baking out of the per-launch hot path into `hipGraphExec` instantiation. The reset kernel is live-dispatched on the launch stream at each `hipGraphLaunch`, and an ordering `Marker` per internal stream waits on its completion signal so no internal-stream barrier can fire on stale signal values from a prior launch.

## Commits (on top of develop)

1. **Revert "Revert \"[hipGraph] Add graph signal pool ...\""** - restores the graph signal pool infrastructure that was reverted in #5951 (originally #5333).
2. **[clr] Add GPU reset kernel for graph signal pool reuse** - introduces the `__amd_rocclr_resetContSignalBuffer` kernel and `ResetGraphSignalPool` to reset GPU-only signal values from the device.
3. **[clr] Add persistent contiguous signal buffer for GPU-side graph signal reset** - adds the device-accessible `cont_buffer_` holding `&amd_signal_t.value` addresses, plus `PatchContBufferEntry` / `AllocateOneSignal` and `CreateBarrierPacket` / `ApplyHwEventPatches` helpers backing the new instantiate-time path.
4. **[clr][hipGraph] Pre-allocate signal pool at instantiate; live-dispatch reset kernel** - the main change:
   - `CaptureAndFormPacketsForGraph` creates the `GraphSignalPool`, acquires `reset_signal_`, populates `sync_plan_.segment_hw_events`, pre-bakes reset-wait barriers on the first batch of every non-stream-0 segment, and patches HW event signals into all AQL packets via `ApplyHwEventPatches`.
   - `EnqueueSegmentedGraph` re-arms `reset_signal_`, live-dispatches the reset kernel on the launch stream via `ResetGraphSignalPool`, captures the completion signal via `Barriers().GetLastSignal()`, and enqueues an ordering `Marker` on every internal stream so dep-barriers don't fire on stale 0 values from the previous launch.

## Why live-dispatch instead of pre-baked reset packet?

A pre-baked reset packet captured at instantiate time picks up hidden kernarg fields (HiddenQueuePtr / HiddenPrivateBase / HiddenSharedBase) from the *transfer queue's* `VirtualGPU` context. Dispatching that packet on the launch stream's queue later produced GPU hangs due to mismatched queue context. Live-dispatch on the launch stream avoids this entirely.

## Test plan

- [ ] `graph_bench --topology straight` - smoke test.
- [ ] `graph_bench --topology full2` / `full4` - independent chains.
- [ ] `graph_bench --topology paths2` - cross-stream join (the previous deadlock case).
- [ ] `graph_bench --sweep` - all topologies, including warmup loop (10 launches w/o sync).
- [ ] hip-tests `hipGraph*` suite.
- [ ] Performance comparison vs. previous per-launch pool allocation path.

## Notes

- Force-pushed onto fresh `develop` (which now contains PR #4778 "stream assignment at instantiate"). The new 4-commit history sits cleanly on top with no merge artifacts.

Made with [Cursor](https://cursor.com)