### PR TITLE
[rocjitsu] Updated default formatting targets

### DIFF
--- a/emulation/rocjitsu/scripts/clang_format.sh
+++ b/emulation/rocjitsu/scripts/clang_format.sh
@@ -23,7 +23,7 @@ fi
 
 # Default directories if none provided.
 if [ $# -eq 0 ]; then
-  set -- "$PROJECT_ROOT/lib" "$PROJECT_ROOT/tests" "$PROJECT_ROOT/tools"
+  set -- "$PROJECT_ROOT/lib" "$PROJECT_ROOT/tests"
 fi
 
 # Find all .cpp and .h files under the given directories.


### PR DESCRIPTION

## Motivation

`clang_format.sh` has default directories for the script. This included the tools directory which was removed in commit 4c199d3 (PR #6029). This commit removes that directory from the defaults.

## Test Plan

Run the script without passing any parameters.

## Test Result

It runs normally.

## Submission Checklist

- [X ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
