### PR TITLE
Add fallback to normal Submit if TimedSubmit fails

### DIFF
--- a/projects/clr/rocclr/device/pal/palubercapturemgr.cpp
+++ b/projects/clr/rocclr/device/pal/palubercapturemgr.cpp
@@ -319,6 +319,9 @@ Pal::Result UberTraceCaptureMgr::TimedQueueSubmit(Pal::IQueue* queue, uint64_t c
   Pal::Result result = Pal::Result::Success;
   if (IsQueueTimingActive()) {
     result = queue_timings_trace_source_->TimedSubmit(queue, submitInfo, timedSubmitInfo);
+    if (result != Pal::Result::Success) {
+      result = queue->Submit(submitInfo);
+    }
   } else {
     result = queue->Submit(submitInfo);
   }


### PR DESCRIPTION
## Motivation

Blender crashes when taking RGP capture

## Technical Details

When TimedSubmit fails we should fallback to normal Submit

## JIRA ID

ROCM-19854

## Test Plan

Check if taking RGP capture works well with blender

## Test Result

RGP capture is successfull

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
