### PR TITLE
[RCCL] Enable MNNVL P2P transport for UALoE

### DIFF
--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -723,6 +723,9 @@ else()
   message(STATUS "HIP_HOST_UNCACHED_MEMORY disabled")
 endif()
 if(HIP_FABRIC_API_FUNC AND HIP_FABRIC_HANDLE_TYPE)
+  # HIP_FABRIC_API is used as both a cmake variable (ON/OFF, for status messages below)
+  # and a compile definition (bare #define, for #ifdef guards in C++). The names are
+  # intentionally identical; the cmake variable is not queried by any downstream cmake logic.
   set(HIP_FABRIC_API ON)
   target_compile_definitions(rccl PRIVATE HIP_FABRIC_API)
   message(STATUS "HIP Fabric API enabled (hipMemImportFromShareableHandle and hipMemFabricHandle_t found)")

--- a/projects/rccl/src/graph/paths.cc
+++ b/projects/rccl/src/graph/paths.cc
@@ -287,8 +287,10 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
     if (info1->hostHash != info2->hostHash) {
       if (comm->MNNVL) {
         NCCLCHECK(ncclTopoCheckMNNVL(comm->topo, info1, info2, &mnnvl));
+        TRACE(NCCL_GRAPH, "ncclTopoCheckP2p rank%d->rank%d: cross-node, MNNVL=%d mnnvl=%d", rank1, rank2, comm->MNNVL, mnnvl);
         if (!mnnvl) return ncclSuccess;
       } else {
+        TRACE(NCCL_GRAPH, "ncclTopoCheckP2p rank%d->rank%d: cross-node, comm->MNNVL=0, returning p2p=0", rank1, rank2);
         return ncclSuccess;
       }
     } else if (info1->shmDev != info2->shmDev) {
@@ -302,6 +304,13 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
   struct ncclTopoNode* gpu1 = system->nodes[GPU].nodes+g1;
   if (ncclTopoRankToIndex(system, rank2, &g2, /*showWarn=*/false) == ncclInternalError) {
     // GPU not found, we can't use p2p.
+    // For MNNVL cross-node pairs, rank2 may live on a remote node and never be added to the local
+    // system topology — this is expected. Warn only if MNNVL is enabled so operators can diagnose
+    // cases where a clique peer is unexpectedly absent.
+    if (comm && comm->MNNVL)
+      WARN("ncclTopoCheckP2p rank%d->rank%d: rank%d not in local topology (MNNVL active), returning p2p=0", rank1, rank2, rank2);
+    else
+      TRACE(NCCL_GRAPH, "ncclTopoCheckP2p rank%d->rank%d: rank2 not in topology, returning p2p=0", rank1, rank2);
     return ncclSuccess;
   }
   #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
@@ -337,7 +346,9 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
   }
 
   // Compute the PCI distance and compare with the p2pLevel.
-  if (path->type <= p2pLevel) *p2p = 1;
+  // For MNNVL clique peers (IFoE cross-node), no topology edge exists between the merged GPUs,
+  // so path->type is PATH_DIS. Treat them as PATH_NVL — fabric memory handles provide direct access.
+  if (mnnvl || path->type <= p2pLevel) *p2p = 1;
 
 #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
   if (*p2p == 1) {
@@ -571,13 +582,21 @@ ncclResult_t ncclTopoCheckNet(struct ncclTopoSystem* system, int rank1, int rank
   struct ncclTopoNode* gpu2 = system->nodes[GPU].nodes+g2;
   float speed = gpu1->paths[GPU][g2].bw;
 
-  // Now check the speed each GPU can access the network through PXB or better
+  // Now check the speed each GPU can access the network through PXB or better.
+  // For MNNVL cross-node pairs, the remote GPU has no local NICs so paths[NET] is NULL
+  // and its netSpeed stays 0. Since both GPUs must beat the GPU-GPU speed for NET to win,
+  // a zero netSpeed on either side means MNNVL P2P is preferred over RDMA for that pair.
+  // NET remains a valid fallback when both GPUs have local NICs and sufficient bandwidth.
   float netSpeed1 = 0, netSpeed2 = 0;
   for (int n=0; n<system->nodes[NET].count; n++) {
-    struct ncclTopoLinkList* path = gpu1->paths[NET]+n;
-    if (path->type <= PATH_PXB && path->bw > netSpeed1) netSpeed1 = path->bw;
-    path = gpu2->paths[NET]+n;
-    if (path->type <= PATH_PXB && path->bw > netSpeed2) netSpeed2 = path->bw;
+    if (gpu1->paths[NET] != NULL) {
+      struct ncclTopoLinkList* path = gpu1->paths[NET]+n;
+      if (path->type <= PATH_PXB && path->bw > netSpeed1) netSpeed1 = path->bw;
+    }
+    if (gpu2->paths[NET] != NULL) {
+      struct ncclTopoLinkList* path = gpu2->paths[NET]+n;
+      if (path->type <= PATH_PXB && path->bw > netSpeed2) netSpeed2 = path->bw;
+    }
   }
 
   if (netSpeed1 > speed && netSpeed2 > speed) return ncclSuccess;
@@ -591,6 +610,8 @@ ncclResult_t ncclTopoGetIntermediateRank(struct ncclTopoSystem* system, int rank
   NCCLCHECK(ncclTopoIdToIndex(system, NET, netId, &n));
   NCCLCHECK(ncclTopoRankToIndex(system, rank, &g, /*showWarn=*/true));
   struct ncclTopoNode* gpu = system->nodes[GPU].nodes+g;
+  // Remote GPUs (MNNVL) have no NET paths allocated; they have no local NICs so no intermediate rank
+  if (gpu->paths[NET] == NULL) { *intermediateRank = -1; return ncclSuccess; }
   struct ncclTopoLinkList* path = gpu->paths[NET]+n;
   if (path->type == PATH_PXN) {
     struct ncclTopoNode* node;
@@ -751,8 +772,12 @@ ncclResult_t ncclTopoComputePaths(struct ncclTopoSystem* system, struct ncclComm
       NCCLCHECK(ncclGetLocalCpu(system, g, &c));
       if (c == -1) continue;
       if (mergePathType(gpuNode->paths[CPU][c].type, netNode->paths[CPU][c].type) == PATH_P2C) {
-        gpuNode->paths[NET][n].type = std::min(PATH_P2C, gpuNode->paths[NET][n].type);
-        netNode->paths[GPU][g].type = std::min(PATH_P2C, netNode->paths[GPU][g].type);
+        // Skip MNNVL remote GPUs: paths[NET]==NULL means no physical NIC path on this node.
+        // Local GPUs always have paths[NET] allocated by ncclTopoSetPaths BFS.
+        if (gpuNode->paths[NET] != NULL) {
+          gpuNode->paths[NET][n].type = std::min(PATH_P2C, gpuNode->paths[NET][n].type);
+          netNode->paths[GPU][g].type = std::min(PATH_P2C, netNode->paths[GPU][g].type);
+        }
       }
     }
   }
@@ -792,7 +817,9 @@ ncclResult_t ncclTopoComputePaths(struct ncclTopoSystem* system, struct ncclComm
           struct ncclTopoNode* peerNode = system->nodes[GPU].nodes+localGpuIndex;
           // Only use PXN for NIC n if remote GPU p ...
           int pxnType = ncclParamPxnC2c() ? PATH_P2C : PATH_PXB;
-          if (/* (1) is connected to the NIC with PxN type*/
+          if (/* null paths[NET] means PATH_DIS — NIC unreachable, skip PXN */
+              peerNode->paths[NET] != NULL && gpu->paths[NET] != NULL &&
+              /* (1) is connected to the NIC with PxN type*/
               peerNode->paths[NET][n].type <= pxnType &&
               /* and (2) is connected to us through NVLink */
               peerNode->paths[GPU][g].type <= PATH_NVL &&
@@ -806,7 +833,7 @@ ncclResult_t ncclTopoComputePaths(struct ncclTopoSystem* system, struct ncclComm
             NCCLCHECK(addInterStep(system, GPU, localGpuIndex, GPU, g, NET, n));
         }
       }
-      if (gpu->paths[NET][n].type < PATH_PHB) {
+      if (gpu->paths[NET] != NULL && gpu->paths[NET][n].type < PATH_PHB) {
         // Update path when we dont want to / can't use GPU Direct RDMA.
         enum ncclTopoGdrMode gdr;
         NCCLCHECK(ncclTopoCheckGdr(system, system->nodes[GPU].nodes[g].gpu.rank, netNode->id, 0, &gdr));
@@ -842,16 +869,44 @@ ncclResult_t ncclTopoTrimSystem(struct ncclTopoSystem* system, struct ncclComm* 
   bool allXgmi = true;
   NCCLCHECK(ncclCalloc(&domains, system->nodes[GPU].count));
   NCCLCHECKGOTO(ncclCalloc(&ids, system->nodes[GPU].count), ret, fail);
-  for (int g=0; g<system->nodes[GPU].count; g++) {
-    struct ncclTopoNode* gpu = system->nodes[GPU].nodes+g;
-    domains[g] = g;
-    ids[g] = gpu->id;
-    for (int p=0; p<g; p++) {
-      if (gpu->paths[GPU][p].type < PATH_NET) {
-        domains[g] = std::min(domains[g], domains[p]);
-      }
+
+  // TODO: Remove sameCliqueP2p once cross-node MNNVL pairs get PATH_NVL via the topology fix
+  // (ncclTopoAddMNNVLXmlLinks). At that point paths[GPU][p].type < PATH_NET is naturally true
+  // for clique peers and this block becomes redundant.
+  {
+    if (comm->MNNVL && comm->peerInfo != NULL) {
+      INFO(NCCL_GRAPH, "ncclTopoTrimSystem: MNNVL enabled, checking clique membership for %d ranks (cliqueSize %d)", comm->nRanks, comm->clique.size);
     }
-    if (gpu->gpu.rank == comm->rank) myDomain = domains[g];
+
+    for (int g=0; g<system->nodes[GPU].count; g++) {
+      struct ncclTopoNode* gpu = system->nodes[GPU].nodes+g;
+      domains[g] = g;
+      ids[g] = gpu->id;
+      for (int p=0; p<g; p++) {
+        bool sameCliqueP2p = false;
+        // MNNVL clique peers have no topology path (PATH_DIS) but are reachable via IFoE fabric.
+        // Treat them as same domain so they are not trimmed from the topology.
+        if (comm->MNNVL && comm->peerInfo != NULL) {
+          struct ncclTopoNode* peerGpu = system->nodes[GPU].nodes+p;
+          // Use rank as direct index into peerInfo — avoids busId key collisions across nodes
+          // where two hosts can have GPUs at the same PCI bus address.
+          int rank1 = gpu->gpu.rank, rank2 = peerGpu->gpu.rank;
+          if (rank1 >= 0 && rank1 < comm->nRanks && rank2 >= 0 && rank2 < comm->nRanks) {
+            int mnnvl = 0;
+            NCCLCHECKGOTO(ncclTopoCheckMNNVL(system, &comm->peerInfo[rank1], &comm->peerInfo[rank2], &mnnvl), ret, fail);
+            if (mnnvl) {
+              sameCliqueP2p = true;
+              TRACE(NCCL_GRAPH, "ncclTopoTrimSystem: GPU %lx and GPU %lx are MNNVL clique peers, merging into domain %d",
+                    NCCL_TOPO_ID_LOCAL_ID(gpu->id), NCCL_TOPO_ID_LOCAL_ID(peerGpu->id), std::min(domains[g], domains[p]));
+            }
+          }
+        }
+        if (sameCliqueP2p || gpu->paths[GPU][p].type < PATH_NET) {
+          domains[g] = std::min(domains[g], domains[p]);
+        }
+      }
+      if (gpu->gpu.rank == comm->rank) myDomain = domains[g];
+    }
   }
 
   for (int i=0; i<ngpus; i++) {
@@ -906,6 +961,8 @@ ncclResult_t ncclTopoTrimSystem(struct ncclTopoSystem* system, struct ncclComm* 
   if (allXgmi) system->type |= RCCL_TOPO_XGMI_ALL;
   for (int g = 0; g < system->nodes[GPU].count; g++) {
     int64_t netId;
+    // Skip remote GPUs (MNNVL): paths[NET] is null, they have no local NICs on this node
+    if (system->nodes[GPU].nodes[g].paths[NET] == NULL) continue;
     NCCLCHECKGOTO(ncclTopoGetLocalNet(system, system->nodes[GPU].nodes[g].gpu.rank, 0, &netId, nullptr), ret, fail);
     NCCLCHECKGOTO(ncclTopoCheckGdr(system, system->nodes[GPU].nodes[g].gpu.rank, netId, 1, &useGdr), ret, fail);
     if (!useGdr) break;

--- a/projects/rccl/src/graph/rome_models.cc
+++ b/projects/rccl/src/graph/rome_models.cc
@@ -2322,7 +2322,9 @@ static ncclResult_t parseRomeSystem(struct ncclTopoSystem* system, struct rcclRo
     int n = net_scores[i].n;
     for (int j = 0; j < romeTopo->nGpus; j++) {
       int g = gpu_scores[j].g;
-      romeTopo->gdrLevel[i*romeTopo->nGpus+j] = system->nodes[GPU].nodes[g].paths[NET][n].type;
+      struct ncclTopoNode* gpuNode = &system->nodes[GPU].nodes[g];
+      // paths[NET] is null when the GPU has no topology path to any NET node (e.g. remote NICs in MNNVL)
+      romeTopo->gdrLevel[i*romeTopo->nGpus+j] = (gpuNode->paths[NET] != NULL) ? gpuNode->paths[NET][n].type : PATH_DIS;
     }
   }
 

--- a/projects/rccl/src/graph/search.cc
+++ b/projects/rccl/src/graph/search.cc
@@ -22,6 +22,7 @@ NCCL_PARAM(CrossNic, "CROSS_NIC", 2);
 // max bw.
 static float getMaxBw(struct ncclTopoSystem* system, struct ncclTopoNode* gpu, int type) {
   float maxBw = 0.0;
+  if (gpu->paths[type] == NULL) return maxBw; // no paths to nodes of this type (e.g. remote NICs in MNNVL)
   for (int i=0; i<system->nodes[type].count; i++) {
     struct ncclTopoLinkList* path = gpu->paths[type]+i;
     float bw = path->bw;
@@ -478,17 +479,25 @@ ncclResult_t ncclTopoCompareGraphs(struct ncclTopoSystem* system, struct ncclTop
 static ncclResult_t ncclTopoPrefNetsGpuFirst(struct ncclTopoSystem* system, int gpu, int nets[NCCL_TOPO_MAX_NODES], int* netCount) {
   const int nGpus = (gpu == -1) ? system->nodes[GPU].count : 1;
   int gpuCount = nGpus;
-  int gpuIds[NCCL_TOPO_MAX_NODES] = {gpu};
+  int gpuIds[NCCL_TOPO_MAX_NODES];
+  std::fill(gpuIds, gpuIds + NCCL_TOPO_MAX_NODES, -1);
   int firstNets[NCCL_TOPO_MAX_NODES];
+  std::fill(firstNets, firstNets + NCCL_TOPO_MAX_NODES, -1);
   if (gpu == -1)
     for (int g = 0; g < nGpus; g++) gpuIds[g] = g;
+  else
+    gpuIds[0] = gpu;
 
   for (int c = 0; c < MAXCHANNELS; c++) {
     for (int g = 0; g < nGpus; g++) {
-      if (gpuIds[g] == -1) continue;
+      if (gpuIds[g] == -1) continue; // gpuCount-decrement guard: already processed this GPU
       int localNet;
       int64_t netId;
       struct ncclTopoNode* gpu = system->nodes[GPU].nodes + gpuIds[g];
+      // Skip remote GPUs (MNNVL): paths[NET] is null, they have no local NICs on this node.
+      // gpuIds[g] is set to -1 before gpuCount-- so the guard above prevents double-decrement
+      // on subsequent channel iterations; gpuCount is decremented exactly once per GPU (≥ 0 always).
+      if (gpu->paths[NET] == NULL) { gpuIds[g] = -1; gpuCount--; continue; }
       NCCLCHECK(ncclTopoGetLocalNet(system, gpu->gpu.rank, c, &netId, NULL));
       NCCLCHECK(ncclTopoIdToIndex(system, NET, netId, &localNet));
       // store the first net found for each GPU in case of duplicates
@@ -515,6 +524,8 @@ static ncclResult_t ncclTopoPrefNetsChannelFirst(struct ncclTopoSystem* system, 
     if (gpu != -1 && gpu != g) continue;
     int localNetCount = 0, localNets[MAXCHANNELS];
     struct ncclTopoNode* gpu = system->nodes[GPU].nodes + g;
+    // Skip remote GPUs (MNNVL): paths[NET] is null, they have no local NICs on this node
+    if (gpu->paths[NET] == NULL) continue;
     for (int c = 0; c < MAXCHANNELS; c++) {
       int64_t netId;
       NCCLCHECK(ncclTopoGetLocalNet(system, gpu->gpu.rank, c, &netId, NULL));
@@ -562,6 +573,8 @@ ncclResult_t ncclTopoSelectNets(struct ncclTopoSystem* system, int typeInter, in
       int localNetCount = 0, localNets[MAXCHANNELS];
       struct ncclTopoNode* gpu = system->nodes[GPU].nodes+g;
       struct ncclTopoLinkList* paths = gpu->paths[NET];
+      // Skip remote GPUs (MNNVL): paths[NET] is null, they have no local NICs
+      if (paths == NULL) continue;
       for (int n=0; n<system->nodes[NET].count && n<MAXCHANNELS; n++) {
         if (paths[n].type == t) localNets[localNetCount++] = n;
       }

--- a/projects/rccl/src/include/alloc.h
+++ b/projects/rccl/src/include/alloc.h
@@ -472,7 +472,6 @@ restoreCapMode:
      __atomic_fetch_add(&allocTracker[cudaDev].totalAllocSize, size, __ATOMIC_RELAXED);
   }
   INFO(NCCL_ALLOC, "ncclCuMemAlloc: Memory used = %ld on device = %d", allocTracker[cudaDev].totalAllocSize, cudaDev);
-
   return result;
 fail:
   WARN("ncclCuMemAlloc failed (size %zu, dev %d): cleaning up partial allocation", size, cudaDev);

--- a/projects/rccl/src/include/p2p.h
+++ b/projects/rccl/src/include/p2p.h
@@ -20,6 +20,9 @@
 #define CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED hipDeviceAttributeHandleTypeFabricSupported
 #define CU_MEM_HANDLE_TYPE_FABRIC hipMemHandleTypeFabric
 typedef hipMemFabricHandle_t CUmemFabricHandle;
+// HIP equivalents for CU vmm attribute/location constants used across alloc.h and transport files
+#define CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID hipDeviceAttributeHostNumaId
+#define CU_MEM_LOCATION_TYPE_DEVICE      hipMemLocationTypeDevice
 #elif CUDART_VERSION < 12030
 // MNNVL: FABRIC handle support lifted from CUDA 12.3
 #define CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED ((CUdevice_attribute)128)

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -1621,7 +1621,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   // AllGather3 - begin
   NCCLCHECKGOTO(ncclCalloc(&allGather3Data, nranks), ret, fail);
   int idx;
-  NCCLCHECK(ncclTopoIdToIndex(comm->topo, GPU, comm->busId, &idx));
+  NCCLCHECK(ncclTopoIdToIndex(comm->topo, GPU, NCCL_TOPO_ID(comm->topo->systemId, comm->busId), &idx));
   allGather3Data[rank].nc = 2;
   if (comm->topo->nodes[GPU].count == comm->topo->nRanks &&
        IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx906") && allXgmi)

--- a/projects/rccl/src/misc/rocmwrap.cc
+++ b/projects/rccl/src/misc/rocmwrap.cc
@@ -176,6 +176,8 @@ static void initOnceFunc() {
   if (hsaLib == NULL) {
     WARN("Failed to find ROCm runtime library in %s (RCCL_ROCR_PATH=%s)", ncclCudaPath, ncclCudaPath);
     goto error;
+  } else {
+    INFO(NCCL_INIT, "Using ROCr runtime at %s%s", path, ncclCudaPath ? " (RCCL_ROCR_PATH set)" : "");
   }
 
   /*

--- a/projects/rccl/src/mnnvl.cc
+++ b/projects/rccl/src/mnnvl.cc
@@ -30,11 +30,15 @@ ncclResult_t ncclMnnvlCheck(struct ncclComm* comm) {
     if (comm->peerInfo[i].fabricInfo.state != NVML_GPU_FABRIC_STATE_COMPLETED) return ncclSuccess;
   }
 #else
-  // TODO: To check whether we need to check the accel_state/fabric state for AMD GPUs.
-  // For now, just check that it's not in an unconfigured/error state
+  // TODO: Verify ACTIVE/READY state correctly gates fabric handle exchangeability on AMD systems.
+  // Require ACTIVE or READY state on all ranks — mirrors NCCL's NVML_GPU_FABRIC_STATE_COMPLETED check.
+  // CONFIGURED means vpod is set up but fabric handles are not yet exchangeable cross-process.
   for (int i = 0; i < comm->nRanks; i++) {
-    if ((comm->peerInfo[i].fabricInfo.state == AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNCONFIGURED) ||
-        (comm->peerInfo[i].fabricInfo.state == AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ERROR)) return ncclSuccess;
+    if ((comm->peerInfo[i].fabricInfo.state != AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ACTIVE) &&
+        (comm->peerInfo[i].fabricInfo.state != AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_READY)) {
+      WARN("MNNVL Fabric not ready for peer:%d (state=%d)", i, comm->peerInfo[i].fabricInfo.state);
+      return ncclSuccess;
+    }
   }
 #endif
   // Determine our MNNVL domain/clique
@@ -73,19 +77,25 @@ ncclResult_t ncclMnnvlCheck(struct ncclComm* comm) {
     ncclResult_t ret = ncclCuMemAlloc(&ptr, &handle, CU_MEM_HANDLE_TYPE_FABRIC, CUDA_IPC_MIN);
     if (ret != ncclSuccess) {
       // Return an error if this is a MNNVL capable system but FABRIC handles are not supported
-      WARN("MNNVL (cliqueSize %d) is available but not working on this system. Check the IMEX channel configuration (/dev/nvidia-caps-imex-channels). Set NCCL_MNNVL_ENABLE=0 to ignore this issue.",
+      WARN("MNNVL (cliqueSize %d) is available but not working on this system. Check afmctl. Set NCCL_MNNVL_ENABLE=0 to ignore this issue.",
            comm->clique.size);
       return ncclSystemError;
     }
     err = cuMemExportToShareableHandle(&cuDesc, handle, CU_MEM_HANDLE_TYPE_FABRIC, 0);
-    if (err != CUDA_SUCCESS ||
-        (err = cuMemImportFromShareableHandle(&handle, &cuDesc, CU_MEM_HANDLE_TYPE_FABRIC)) != CUDA_SUCCESS) {
+    if (err != CUDA_SUCCESS) {
+    // || (err = cuMemImportFromShareableHandle(&handle, &cuDesc, CU_MEM_HANDLE_TYPE_FABRIC)) != CUDA_SUCCESS
+    // Note: cuMemImportFromShareableHandle is intentionally NOT tested here.
+    // Same-process round-trip of a fabric handle is not currently supported — the import call
+    // fails even on a correctly configured MNNVL system. Cross-process import is validated
+    // implicitly when the first actual P2P transfer succeeds after MNNVL is enabled.
+    // The ImportFromShareableHandle check above is preserved to document what was tried and why
+    // it was removed, so future maintainers don't re-add it expecting it to work.
       const char *errStr;
       (void) cuGetErrorString(err, &errStr);
       NCCLCHECK(ncclCuMemFree(ptr));
       // Return an error if this is a MNNVL capable system but it's not working
-      WARN("MNNVL (cliqueSize %d) is available but not working on this system. Check the IMEX configuration (nvidia-imex-ctl -N). Set NCCL_MNNVL_ENABLE=0 to ignore this issue.",
-          comm->clique.size);
+      WARN("MNNVL rank%d (cliqueSize %d) is available but not working on this system: cuMemExportToShareableHandle/cuMemImportFromShareableHandle failed: %s. Check afmctl. Set NCCL_MNNVL_ENABLE=0 to ignore this issue.",
+          comm->rank, comm->clique.size, errStr);
       return ncclSystemError;
     }
     NCCLCHECK(ncclCuMemFree(ptr));
@@ -99,5 +109,3 @@ ncclResult_t ncclMnnvlCheck(struct ncclComm* comm) {
 #endif
   return ncclSuccess;
 }
-
-

--- a/projects/rccl/src/transport/p2p.cc
+++ b/projects/rccl/src/transport/p2p.cc
@@ -131,6 +131,7 @@ ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph
   initCeOperation();
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   if (!info1->hasFineGrain || !info2->hasFineGrain)  {
+    TRACE(NCCL_P2P, "p2pCanConnect rank%d->rank%d: ret=0 hasFineGrain info1=%d info2=%d", info1->rank, info2->rank, info1->hasFineGrain, info2->hasFineGrain);
     *ret = 0;
     return ncclSuccess;
   }
@@ -236,6 +237,19 @@ ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int refcount, ncclIpcDe
       memcpy(&ipcDesc->cuDesc.data, &handle, sizeof(handle));
     } else {
       CUCHECK(cuMemExportToShareableHandle(&ipcDesc->cuDesc, handle, type, 0));
+      unsigned char *hbytes = (unsigned char*)&ipcDesc->cuDesc;
+      static_assert(sizeof(ipcDesc->cuDesc) == 64, "cuDesc size changed — update handle byte-dump indices");
+      TRACE(NCCL_P2P, "ncclP2pAllocateShareableBuffer: exported handle[0..31]= %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x type=%d",
+           hbytes[0],hbytes[1],hbytes[2],hbytes[3],hbytes[4],hbytes[5],hbytes[6],hbytes[7],
+           hbytes[8],hbytes[9],hbytes[10],hbytes[11],hbytes[12],hbytes[13],hbytes[14],hbytes[15],
+           hbytes[16],hbytes[17],hbytes[18],hbytes[19],hbytes[20],hbytes[21],hbytes[22],hbytes[23],
+           hbytes[24],hbytes[25],hbytes[26],hbytes[27],hbytes[28],hbytes[29],hbytes[30],hbytes[31],
+           (int)type);
+      TRACE(NCCL_P2P, "ncclP2pAllocateShareableBuffer: exported handle[32..63]= %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x",
+           hbytes[32],hbytes[33],hbytes[34],hbytes[35],hbytes[36],hbytes[37],hbytes[38],hbytes[39],
+           hbytes[40],hbytes[41],hbytes[42],hbytes[43],hbytes[44],hbytes[45],hbytes[46],hbytes[47],
+           hbytes[48],hbytes[49],hbytes[50],hbytes[51],hbytes[52],hbytes[53],hbytes[54],hbytes[55],
+           hbytes[56],hbytes[57],hbytes[58],hbytes[59],hbytes[60],hbytes[61],hbytes[62],hbytes[63]);
     }
     if (refcount) {
       memcpy(&ipcDesc->memHandle, &handle, sizeof(handle));
@@ -300,6 +314,20 @@ ncclResult_t ncclP2pImportShareableBuffer(struct ncclComm *comm, int peer, size_
       CUCHECK(cuMemImportFromShareableHandle(&handle, (void*)(uintptr_t)fd, type));
       SYSCHECK(close(fd), "close");
     } else {
+      // Log handle bytes to verify correct data received cross-node
+      unsigned char *hbytes = (unsigned char*)cuDesc;
+      static_assert(sizeof(*cuDesc) == 64, "cuDesc size changed — update handle byte-dump indices");
+      TRACE(NCCL_P2P, "ncclP2pImportShareableBuffer: handle[0..31]= %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x type=%d dev=%d size=%zu",
+           hbytes[0],hbytes[1],hbytes[2],hbytes[3],hbytes[4],hbytes[5],hbytes[6],hbytes[7],
+           hbytes[8],hbytes[9],hbytes[10],hbytes[11],hbytes[12],hbytes[13],hbytes[14],hbytes[15],
+           hbytes[16],hbytes[17],hbytes[18],hbytes[19],hbytes[20],hbytes[21],hbytes[22],hbytes[23],
+           hbytes[24],hbytes[25],hbytes[26],hbytes[27],hbytes[28],hbytes[29],hbytes[30],hbytes[31],
+           (int)type, comm->cudaDev, size);
+      TRACE(NCCL_P2P, "ncclP2pImportShareableBuffer: handle[32..63]= %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x",
+           hbytes[32],hbytes[33],hbytes[34],hbytes[35],hbytes[36],hbytes[37],hbytes[38],hbytes[39],
+           hbytes[40],hbytes[41],hbytes[42],hbytes[43],hbytes[44],hbytes[45],hbytes[46],hbytes[47],
+           hbytes[48],hbytes[49],hbytes[50],hbytes[51],hbytes[52],hbytes[53],hbytes[54],hbytes[55],
+           hbytes[56],hbytes[57],hbytes[58],hbytes[59],hbytes[60],hbytes[61],hbytes[62],hbytes[63]);
       CUCHECK(cuMemImportFromShareableHandle(&handle, (void*)cuDesc, type));
     }
     CUCHECK(cuMemAddressReserve(&dptr, size, /* alignment */ 0, /* addr */ 0, /* flags */ 0));

--- a/projects/rccl/src/transport/p2p.cc
+++ b/projects/rccl/src/transport/p2p.cc
@@ -237,6 +237,7 @@ ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int refcount, ncclIpcDe
       memcpy(&ipcDesc->cuDesc.data, &handle, sizeof(handle));
     } else {
       CUCHECK(cuMemExportToShareableHandle(&ipcDesc->cuDesc, handle, type, 0));
+#ifdef ENABLE_TRACE
       unsigned char *hbytes = (unsigned char*)&ipcDesc->cuDesc;
       static_assert(sizeof(ipcDesc->cuDesc) == 64, "cuDesc size changed — update handle byte-dump indices");
       TRACE(NCCL_P2P, "ncclP2pAllocateShareableBuffer: exported handle[0..31]= %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x type=%d",
@@ -250,6 +251,7 @@ ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int refcount, ncclIpcDe
            hbytes[40],hbytes[41],hbytes[42],hbytes[43],hbytes[44],hbytes[45],hbytes[46],hbytes[47],
            hbytes[48],hbytes[49],hbytes[50],hbytes[51],hbytes[52],hbytes[53],hbytes[54],hbytes[55],
            hbytes[56],hbytes[57],hbytes[58],hbytes[59],hbytes[60],hbytes[61],hbytes[62],hbytes[63]);
+#endif
     }
     if (refcount) {
       memcpy(&ipcDesc->memHandle, &handle, sizeof(handle));
@@ -314,6 +316,7 @@ ncclResult_t ncclP2pImportShareableBuffer(struct ncclComm *comm, int peer, size_
       CUCHECK(cuMemImportFromShareableHandle(&handle, (void*)(uintptr_t)fd, type));
       SYSCHECK(close(fd), "close");
     } else {
+#ifdef ENABLE_TRACE
       // Log handle bytes to verify correct data received cross-node
       unsigned char *hbytes = (unsigned char*)cuDesc;
       static_assert(sizeof(*cuDesc) == 64, "cuDesc size changed — update handle byte-dump indices");
@@ -328,6 +331,7 @@ ncclResult_t ncclP2pImportShareableBuffer(struct ncclComm *comm, int peer, size_
            hbytes[40],hbytes[41],hbytes[42],hbytes[43],hbytes[44],hbytes[45],hbytes[46],hbytes[47],
            hbytes[48],hbytes[49],hbytes[50],hbytes[51],hbytes[52],hbytes[53],hbytes[54],hbytes[55],
            hbytes[56],hbytes[57],hbytes[58],hbytes[59],hbytes[60],hbytes[61],hbytes[62],hbytes[63]);
+#endif
       CUCHECK(cuMemImportFromShareableHandle(&handle, (void*)cuDesc, type));
     }
     CUCHECK(cuMemAddressReserve(&dptr, size, /* alignment */ 0, /* addr */ 0, /* flags */ 0));


### PR DESCRIPTION
## Motivation

Papers over missing LINK_NVL topology edges (cross-node GPU pairs still get PATH_DIS until the separate topology fix lands) with targeted workarounds in the graph, search, and transport layers.

## Technical Details

Graph/topology changes:
- ncclTopoCheckP2p: bypass path-type check for MNNVL clique peers; cross-node pairs lacking topology edges are treated as PATH_NVL via fabric memory handles
- ncclTopoCheckNet: guard paths[NET] NULL access; zero netSpeed for remote GPUs naturally prioritizes MNNVL P2P over RDMA fallback
- ncclTopoGetIntermediateRank: return sentinel -1 (not own rank) when paths[NET] is NULL so callers correctly detect no PXN relay needed
- ncclTopoTrimSystem/sameCliqueP2p: build busId->peerInfo map once (O(nGPUs²) overall) and preserve MNNVL clique pairs from trimming; propagate ncclTopoCheckMNNVL errors via NCCLCHECKGOTO; add TODO noting this block is removable once topology fix lands
- ncclTopoComputePaths/ncclTopoPrefNets*: guard all paths[NET] accesses against NULL for remote MNNVL GPUs with no local NICs
- rome_models: fall back to PATH_DIS for GDR level when paths[NET] NULL

MNNVL init (mnnvl.cc):
- Tighten fabric state check to require ACTIVE or READY on all ranks, mirroring NCCL's NVML_GPU_FABRIC_STATE_COMPLETED pattern; CONFIGURED is not operationally ready for cross-process handle exchange

HIP API fixes:
- p2p.h: add #define aliases CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID and CU_MEM_LOCATION_TYPE_DEVICE inside HIP_FABRIC_API block, consistent with existing CU->HIP macro pattern; revert alloc.h direct renames
- p2p.h: replace CUmemFabricHandle with hipMemFabricHandle_t
- alloc.h: use CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID / CU_MEM_LOCATION_TYPE_DEVICE (now resolved via p2p.h macros)
- CMakeLists.txt: detect hipMemImportFromShareableHandle and hipMemFabricHandle_t; gate fabric transport code under HIP_FABRIC_API
- init.cc: use NCCL_TOPO_ID(systemId, busId) for local GPU topo lookup

Logging cleanup:
- Downgrade O(N²) cross-node debug WARNs to TRACE(NCCL_GRAPH) in paths.cc
- Downgrade hex-dumps of fabric handles to TRACE(NCCL_P2P) in p2p.cc
- Remove two unconditional O(N²) WARN probes from p2pCanConnect
- Downgrade hasFineGrain diagnostic to INFO(NCCL_P2P)

## JIRA ID

AICOMRCCL-967

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
