### PR TITLE
rocr: Replace repeated 'kAqlProfileLib' probes for each GPU

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -530,6 +530,8 @@ class Runtime {
   bool VirtualMemApiSupported() const { return virtual_mem_api_supported_; }
   bool XnackEnabled() const { return xnack_enabled_; }
   void XnackEnabled(bool enable) { xnack_enabled_ = enable; }
+  bool AqlProfileAvailable() const { return (aqlprofile_lib_ != nullptr); }
+  os::LibHandle AqlProfileLib() const { return aqlprofile_lib_; }
 
   Driver &AgentDriver(DriverType drv_type) {
     auto is_drv_type = [&](const std::unique_ptr<Driver> &d) {
@@ -968,6 +970,8 @@ class Runtime {
 
   bool virtual_mem_api_supported_;
   bool xnack_enabled_;
+
+  os::LibHandle aqlprofile_lib_;
 
   typedef void* ThunkHandle;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -2066,8 +2066,7 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
         setFlag(HSA_EXTENSION_AMD_PC_SAMPLING);
       }
 
-      if (os::LibHandle lib = os::LoadLib(kAqlProfileLib)) {
-        os::CloseLib(lib);
+      if (core::Runtime::runtime_singleton_->AqlProfileAvailable()) {
         setFlag(HSA_EXTENSION_AMD_AQLPROFILE);
       }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
@@ -498,9 +498,12 @@ hsa_status_t hsa_system_get_major_extension_table(uint16_t extension, uint16_t v
       return HSA_STATUS_ERROR;
     }
 
-    os::LibHandle lib = os::LoadLib(kAqlProfileLib);
+    // Use the cached aqlprofile library handle from Runtime instead of
+    // opening a new one.  The handle is loaded once during Runtime::Load()
+    // and closed in Runtime::Unload(), avoiding a dlopen handle leak.
+    os::LibHandle lib = core::Runtime::runtime_singleton_->AqlProfileLib();
     if (lib == NULL) {
-      debug_print("Loading '%s' failed\n", kAqlProfileLib);
+      debug_print("AQL profile library '%s' is unavailable.\n", kAqlProfileLib);
       return HSA_STATUS_ERROR;
     }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -761,8 +761,7 @@ hsa_status_t Runtime::GetSystemInfo(hsa_system_info_t attribute, void* value) {
         setFlag(HSA_EXTENSION_IMAGES);
       }
 
-      if (os::LibHandle lib = os::LoadLib(kAqlProfileLib)) {
-        os::CloseLib(lib);
+      if (aqlprofile_lib_ != nullptr) {
         setFlag(HSA_EXTENSION_AMD_AQLPROFILE);
       }
 
@@ -2372,6 +2371,7 @@ Runtime::Runtime()
       ipc_sock_server_thread_(nullptr) {
   virtual_mem_api_supported_ = false;
   ipc_dmabuf_supported_ = false;
+  aqlprofile_lib_ = nullptr;
   xnack_enabled_ = false;
   g_use_interrupt_wait = true;
   g_use_mwaitx = true;
@@ -2431,6 +2431,9 @@ hsa_status_t Runtime::Load() {
 
   loader_.reset(amd::hsa::loader::Loader::Create(&loader_context_));
 
+  // Probe aqlprofile availability once and cache the result
+  aqlprofile_lib_ = os::LoadLib(kAqlProfileLib);
+
   // Load extensions
   LoadExtensions();
 
@@ -2475,6 +2478,16 @@ void Runtime::Unload() {
 
   UnloadTools();
   UnloadExtensions();
+
+  // Close the aqlprofile probe handle. Skip the dlclose when
+  // running under Valgrind due to a Valgrind bug, see below:
+  // http://valgrind.org/docs/manual/faq.html#faq.unhelpful
+  if (aqlprofile_lib_ != nullptr) {
+    if (!flag_.running_valgrind()) {
+      os::CloseLib(aqlprofile_lib_);
+    }
+    aqlprofile_lib_ = nullptr;
+  }
 
   amd::hsa::loader::Loader::Destroy(loader_.get());
   loader_.reset();


### PR DESCRIPTION
Add one-time cached probe for AQL profile library availability and replace repeated probes in system and per-GPU queries.

## Motivation

The aqlprofile library (_libhsa-amd-aqlprofile64.so_) was probed via _dlopen_/_dlclose_ each time _HSA_AGENT_INFO_EXTENSIONS_ was queried, which happens once per visible GPU during HIP runtime init. The library's constructor allocates 152 bytes that are never freed on dlclose, resulting in 152 × N_GPUs bytes definitely lost (1,216 bytes on an 8-GPU system).

## Technical Details

Cache the _aqlprofile_ availability check in a single probe during `Runtime::Load()` and reuse the cached flag in both the system-level (_HSA_SYSTEM_INFO_EXTENSIONS_) and per-agent (_HSA_AGENT_INFO_EXTENSIONS_) query handlers. The library handle is intentionally kept open, so the constructor's allocation remains reachable rather than orphaned, consistent with the existing pattern in _hsa.cpp_. We close it in `Unload()` when not running with Valgrind.