### PR TITLE
[rocprofiler-systems] Add `rocprofsys_push_trace_with_args` and cache region arguments/perfetto annotations

### DIFF
--- a/projects/rocprofiler-systems/cmake/MacroUtilities.cmake
+++ b/projects/rocprofiler-systems/cmake/MacroUtilities.cmake
@@ -153,6 +153,7 @@ function(ROCPROFILER_SYSTEMS_STRIP_TARGET)
                     ${CMAKE_STRIP} -w --keep-symbol="rocprofsys_init"
                     --keep-symbol="rocprofsys_finalize"
                     --keep-symbol="rocprofsys_push_trace"
+                    --keep-symbol="rocprofsys_push_trace_with_args"
                     --keep-symbol="rocprofsys_pop_trace"
                     --keep-symbol="rocprofsys_push_region"
                     --keep-symbol="rocprofsys_pop_region"

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.cpp
@@ -37,6 +37,16 @@ module_function::update_width(const module_function& rhs)
     get_width()[2] = std::max<size_t>(get_width()[2], rhs.signature.get().length());
 }
 
+string_t
+module_function::get_source_object_name(procedure_t* func)
+{
+    if(!func) return {};
+    auto* module = func->getModule();
+    auto* object = (module) ? module->getObject() : nullptr;
+    auto  _name  = (object) ? object->name() : string_t{};
+    return _name;
+}
+
 module_function::module_function(module_t* mod, procedure_t* proc)
 : module{ mod }
 , function{ proc }
@@ -848,16 +858,27 @@ module_function::is_exit_trap_constrained() const
 
 std::pair<size_t, size_t>
 module_function::operator()(address_space_t* _addr_space, procedure_t* _entr_trace,
-                            procedure_t* _exit_trace) const
+                            procedure_t* _entr_trace_args, procedure_t* _exit_trace) const
 {
     std::pair<size_t, size_t> _count = { 0, 0 };
 
     if(!function || !module) return _count;
 
-    auto _name       = signature.get();
-    auto _trace_entr = rocprofsys_call_expr(_name.c_str());
+    auto _name          = signature.get();
+    auto _source_object = get_source_object_name(function);
+
+    // Arguments passed to rocprofsys_push_trace_with_args
+    // Pass in triples of name, value, enabled
+    auto _serialized_args = rocprofsys_get_serialized_args(
+        "source_object", _source_object, !_source_object.empty());
+
+    bool use_args_entr = (!_serialized_args.empty() && _entr_trace_args);
+
+    auto _trace_entr = (use_args_entr)
+                           ? rocprofsys_call_expr(_name.c_str(), _serialized_args)
+                           : rocprofsys_call_expr(_name.c_str());
     auto _trace_exit = rocprofsys_call_expr(_name.c_str());
-    auto _entr       = _trace_entr.get(_entr_trace);
+    auto _entr       = _trace_entr.get((use_args_entr) ? _entr_trace_args : _entr_trace);
     auto _exit       = _trace_exit.get(_exit_trace);
 
     if(insert_instr(_addr_space, function, _entr, BPatch_entry) &&
@@ -906,10 +927,12 @@ module_function::operator()(address_space_t* _addr_space, procedure_t* _entr_tra
                            "loop-exit-point-trap-instrumentation", _lname))
             continue;
 
-        auto _ltrace_entr = rocprofsys_call_expr(_lname.c_str());
+        auto _ltrace_entr = (use_args_entr)
+                                ? rocprofsys_call_expr(_lname.c_str(), _serialized_args)
+                                : rocprofsys_call_expr(_lname.c_str());
         auto _ltrace_exit = rocprofsys_call_expr(_lname.c_str());
-        auto _lentr       = _ltrace_entr.get(_entr_trace);
-        auto _lexit       = _ltrace_exit.get(_exit_trace);
+        auto _lentr = _ltrace_entr.get((use_args_entr) ? _entr_trace_args : _entr_trace);
+        auto _lexit = _ltrace_exit.get(_exit_trace);
 
         if(insert_instr(_addr_space, function, _lentr, BPatch_entry, flow_graph, itr,
                         instr_loop_traps) &&

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/module_function.hpp
@@ -27,6 +27,7 @@ struct module_function
     static void             reset_width();
     static void             update_width(const module_function& rhs);
     static void             write_header(std::ostream& os);
+    static string_t         get_source_object_name(procedure_t* func);
 
     module_function()                                      = default;
     module_function(const module_function&)                = default;
@@ -45,6 +46,7 @@ struct module_function
     // instrumentation
     std::pair<size_t, size_t> operator()(address_space_t* _addr_space,
                                          procedure_t*     _entr_trace,
+                                         procedure_t*     _entr_trace_args,
                                          procedure_t*     _exit_trace) const;
 
     // applies logic for all "is_*" and "can_*" checks below

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -1793,15 +1793,16 @@ main(int argc, char** argv)
 
     verbprintf(0, "Finding instrumentation functions...\n");
 
-    auto* init_func      = find_function(new_objects, "rocprofsys_init");
-    auto* fini_func      = find_function(new_objects, "rocprofsys_finalize");
-    auto* env_func       = find_function(new_objects, "rocprofsys_set_env");
-    auto* mpi_func       = find_function(new_objects, "rocprofsys_set_mpi");
-    auto* entr_trace     = find_function(new_objects, "rocprofsys_push_trace");
-    auto* exit_trace     = find_function(new_objects, "rocprofsys_pop_trace");
-    auto* reg_src_func   = find_function(new_objects, "rocprofsys_register_source");
-    auto* reg_cov_func   = find_function(new_objects, "rocprofsys_register_coverage");
-    auto* set_instr_func = find_function(new_objects, "rocprofsys_set_instrumented");
+    auto* init_func       = find_function(new_objects, "rocprofsys_init");
+    auto* fini_func       = find_function(new_objects, "rocprofsys_finalize");
+    auto* env_func        = find_function(new_objects, "rocprofsys_set_env");
+    auto* mpi_func        = find_function(new_objects, "rocprofsys_set_mpi");
+    auto* entr_trace      = find_function(new_objects, "rocprofsys_push_trace");
+    auto* entr_trace_args = find_function(new_objects, "rocprofsys_push_trace_with_args");
+    auto* exit_trace      = find_function(new_objects, "rocprofsys_pop_trace");
+    auto* reg_src_func    = find_function(new_objects, "rocprofsys_register_source");
+    auto* reg_cov_func    = find_function(new_objects, "rocprofsys_register_coverage");
+    auto* set_instr_func  = find_function(new_objects, "rocprofsys_set_instrumented");
 
     //----------------------------------------------------------------------------------//
     //
@@ -1931,6 +1932,10 @@ main(int argc, char** argv)
                       itr.second.c_str());
         }
     }
+    if(!entr_trace_args)
+        verbprintf(0, "Warning! could not find optional function :: "
+                      "'rocprofsys_push_trace_with_args'. Falling back to "
+                      "'rocprofsys_push_trace'\n");
 
     //----------------------------------------------------------------------------------//
     //
@@ -1976,12 +1981,18 @@ main(int argc, char** argv)
 
     if(main_func) main_sign.get();
 
-    auto main_call_args = rocprofsys_call_expr(main_sign.get());
-    auto init_call_args = rocprofsys_call_expr(instr_mode, binary_rewrite, "");
-    auto fini_call_args = rocprofsys_call_expr();
-    auto umpi_call_args = rocprofsys_call_expr(use_mpi, is_attached);
-    auto none_call_args = rocprofsys_call_expr();
-    auto set_instr_args = rocprofsys_call_expr(instr_mode_v_int);
+    auto main_source_object = module_function::get_source_object_name(main_func);
+    auto main_source_args   = rocprofsys_get_serialized_args(
+        "source_object", main_source_object, !main_source_object.empty());
+    auto main_has_source_object = (!main_source_args.empty() && entr_trace_args);
+    auto main_call_args         = (main_has_source_object)
+                                      ? rocprofsys_call_expr(main_sign.get(), main_source_args)
+                                      : rocprofsys_call_expr(main_sign.get());
+    auto init_call_args         = rocprofsys_call_expr(instr_mode, binary_rewrite, "");
+    auto fini_call_args         = rocprofsys_call_expr();
+    auto umpi_call_args         = rocprofsys_call_expr(use_mpi, is_attached);
+    auto none_call_args         = rocprofsys_call_expr();
+    auto set_instr_args         = rocprofsys_call_expr(instr_mode_v_int);
 
     verbprintf(2, "Done\n");
     verbprintf(2, "Getting call snippets... ");
@@ -1990,7 +2001,8 @@ main(int argc, char** argv)
     auto fini_call      = fini_call_args.get(fini_func);
     auto umpi_call      = umpi_call_args.get(mpi_func);
     auto set_instr_call = set_instr_args.get(set_instr_func);
-    auto main_beg_call  = main_call_args.get(entr_trace);
+    auto main_beg_call =
+        main_call_args.get((main_has_source_object) ? entr_trace_args : entr_trace);
 
     verbprintf(2, "Done\n");
 
@@ -2247,7 +2259,7 @@ main(int argc, char** argv)
         for(const auto& itr : instrumented_module_functions)
         {
             if(itr.function == main_func) continue;
-            auto _count = itr(addr_space, entr_trace, exit_trace);
+            auto _count = itr(addr_space, entr_trace, entr_trace_args, exit_trace);
             _pass_info[itr.module_name].first += _count.first;
             _pass_info[itr.module_name].second += _count.second;
 
@@ -2330,22 +2342,22 @@ main(int argc, char** argv)
             verbprintf(
                 1,
                 "Using insertion set failed. Restarting with individual insertion...\n");
-            auto _execute_batch = [&addr_space, &entr_trace, &exit_trace](size_t _beg,
-                                                                          size_t _end) {
+            auto _execute_batch = [&addr_space, &entr_trace, &entr_trace_args,
+                                   &exit_trace](size_t _beg, size_t _end) {
                 verbprintf(1, "Instrumenting batch of functions [%lu, %lu)\n",
                            (unsigned long) _beg, (unsigned long) _end);
                 addr_space->beginInsertionSet();
                 auto itr = instrumented_module_functions.begin();
                 std::advance(itr, _beg);
                 for(size_t i = _beg; i < _end; ++i, ++itr)
-                    (*itr)(addr_space, entr_trace, exit_trace);
+                    (*itr)(addr_space, entr_trace, entr_trace_args, exit_trace);
                 bool _modified = true;
                 bool _success  = addr_space->finalizeInsertionSet(true, &_modified);
                 return _success;
             };
 
             auto execute_batch = [&_execute_batch, &addr_space, &entr_trace,
-                                  &exit_trace](size_t _beg) {
+                                  &entr_trace_args, &exit_trace](size_t _beg) {
                 if(!_execute_batch(_beg, _beg + batch_size))
                 {
                     verbprintf(1,
@@ -2357,7 +2369,7 @@ main(int argc, char** argv)
                     std::advance(itr, _beg);
                     for(size_t i = _beg; i < _beg + batch_size && itr != _end; ++i, ++itr)
                     {
-                        (*itr)(addr_space, entr_trace, exit_trace);
+                        (*itr)(addr_space, entr_trace, entr_trace_args, exit_trace);
                     }
                 }
                 return _beg + batch_size;

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "core/common_types.hpp"
+#include "core/demangler.hpp"
 #include "function_signature.hpp"
 #include "fwd.hpp"
 #include "info.hpp"
@@ -12,10 +14,13 @@
 #include <timemory/utility/filepath.hpp>
 #include <timemory/utility/join.hpp>
 
+#include <cstdint>
 #include <dlfcn.h>
 #include <string>
 #include <sys/stat.h>
+#include <type_traits>
 #include <unistd.h>
+#include <utility>
 
 //======================================================================================//
 
@@ -30,6 +35,113 @@ to_lower(string_t s)
     for(auto& itr : s)
         itr = tolower(itr);
     return s;
+}
+//
+//======================================================================================//
+//
+template <typename Tp>
+inline string_view_t
+rocprofsys_arg_name_view(Tp&& name)
+{
+    using raw_type   = std::remove_reference_t<Tp>;
+    using value_type = std::decay_t<Tp>;
+    static_assert(std::is_convertible<value_type, string_view_t>::value,
+                  "serialized argument names must be string-like");
+    if constexpr(std::is_pointer<raw_type>::value &&
+                 (std::is_same<value_type, const char*>::value ||
+                  std::is_same<value_type, char*>::value))
+    {
+        return (name) ? string_view_t{ name } : string_view_t{};
+    }
+    else
+    {
+        return string_view_t{ std::forward<Tp>(name) };
+    }
+}
+
+template <typename Tp>
+inline string_t
+rocprofsys_get_serialized_arg_type()
+{
+    using value_type = std::decay_t<Tp>;
+    if constexpr(std::is_same<value_type, string_t>::value ||
+                 std::is_same<value_type, string_view_t>::value ||
+                 std::is_same<value_type, const char*>::value ||
+                 std::is_same<value_type, char*>::value)
+    {
+        return "string";
+    }
+    else
+    {
+        return rocprofsys::utility::demangle<value_type>();
+    }
+}
+
+template <typename Tp>
+inline string_t
+rocprofsys_get_serialized_arg_value(Tp&& value)
+{
+    using raw_type   = std::remove_reference_t<Tp>;
+    using value_type = std::decay_t<Tp>;
+    if constexpr(std::is_pointer<raw_type>::value &&
+                 (std::is_same<value_type, const char*>::value ||
+                  std::is_same<value_type, char*>::value))
+    {
+        return (value) ? string_t{ value } : string_t{};
+    }
+
+    stringstream_t ss;
+    ss << std::forward<Tp>(value);
+    return ss.str();
+}
+
+template <typename NameT, typename ValueT, typename EnabledT, typename... TailT>
+inline size_t
+rocprofsys_append_serialized_args(string_t& out, size_t idx, NameT&& name, ValueT&& value,
+                                  EnabledT&& enabled, TailT&&... tail)
+{
+    static_assert(std::is_convertible<std::decay_t<EnabledT>, bool>::value,
+                  "serialized argument enable values must be bool-like");
+
+    auto next_idx = idx;
+    if(static_cast<bool>(enabled))
+    {
+        auto name_view = rocprofsys_arg_name_view(std::forward<NameT>(name));
+        if(!name_view.empty())
+        {
+            out += rocprofsys::get_args_string(
+                rocprofsys::function_args_t{ rocprofsys::argument_info{
+                    static_cast<std::uint32_t>(idx),
+                    rocprofsys_get_serialized_arg_type<ValueT>(), string_t{ name_view },
+                    rocprofsys_get_serialized_arg_value(std::forward<ValueT>(value)) } });
+            ++next_idx;
+        }
+    }
+
+    if constexpr(sizeof...(TailT) > 0)
+    {
+        return rocprofsys_append_serialized_args(out, next_idx,
+                                                 std::forward<TailT>(tail)...);
+    }
+    else
+    {
+        return next_idx;
+    }
+}
+
+// Builds a serialized string of arguments passed to rocprofsys_push_trace_with_args
+// Arguments are passed as name/value/enabled triples with the output format being:
+// <arg_number>;;<arg_type>;;<arg_name>;;<arg_value>;;
+template <typename... Args>
+inline string_t
+rocprofsys_get_serialized_args(Args&&... args)
+{
+    static_assert(sizeof...(Args) % 3 == 0,
+                  "serialized args must be passed as name/value/enabled triples");
+    string_t out;
+    if constexpr(sizeof...(Args) > 0)
+        rocprofsys_append_serialized_args(out, 0, std::forward<Args>(args)...);
+    return out;
 }
 //
 //======================================================================================//

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
@@ -685,8 +685,15 @@ extern "C"
         if(!dl::get_active()) return;
         if(dl::get_thread_enabled())
         {
-            ROCPROFSYS_DL_INVOKE(get_indirect().rocprofsys_push_trace_with_args_f, name,
-                                 serialized_args);
+            if(get_indirect().rocprofsys_push_trace_with_args_f)
+            {
+                ROCPROFSYS_DL_INVOKE(get_indirect().rocprofsys_push_trace_with_args_f,
+                                     name, serialized_args);
+            }
+            else
+            {
+                ROCPROFSYS_DL_INVOKE(get_indirect().rocprofsys_push_trace_f, name);
+            }
         }
         else
         {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
@@ -274,6 +274,8 @@ struct ROCPROFSYS_INTERNAL_API indirect
         ROCPROFSYS_DLSYM(rocprofsys_set_env_f, m_omnihandle, "rocprofsys_set_env");
         ROCPROFSYS_DLSYM(rocprofsys_set_mpi_f, m_omnihandle, "rocprofsys_set_mpi");
         ROCPROFSYS_DLSYM(rocprofsys_push_trace_f, m_omnihandle, "rocprofsys_push_trace");
+        ROCPROFSYS_DLSYM(rocprofsys_push_trace_with_args_f, m_omnihandle,
+                         "rocprofsys_push_trace_with_args");
         ROCPROFSYS_DLSYM(rocprofsys_pop_trace_f, m_omnihandle, "rocprofsys_pop_trace");
         ROCPROFSYS_DLSYM(rocprofsys_push_region_f, m_omnihandle,
                          "rocprofsys_push_region");
@@ -387,6 +389,7 @@ public:
                                          const char*)                          = nullptr;
     void (*rocprofsys_register_coverage_f)(const char*, const char*, size_t)   = nullptr;
     void (*rocprofsys_push_trace_f)(const char*)                               = nullptr;
+    void (*rocprofsys_push_trace_with_args_f)(const char*, const char*)        = nullptr;
     void (*rocprofsys_pop_trace_f)(const char*)                                = nullptr;
     int (*rocprofsys_push_region_f)(const char*)                               = nullptr;
     int (*rocprofsys_pop_region_f)(const char*)                                = nullptr;
@@ -670,6 +673,20 @@ extern "C"
         if(dl::get_thread_enabled())
         {
             ROCPROFSYS_DL_INVOKE(get_indirect().rocprofsys_push_trace_f, name);
+        }
+        else
+        {
+            ++dl::get_thread_count();
+        }
+    }
+
+    void rocprofsys_push_trace_with_args(const char* name, const char* serialized_args)
+    {
+        if(!dl::get_active()) return;
+        if(dl::get_thread_enabled())
+        {
+            ROCPROFSYS_DL_INVOKE(get_indirect().rocprofsys_push_trace_with_args_f, name,
+                                 serialized_args);
         }
         else
         {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl/dl.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl/dl.hpp
@@ -51,6 +51,8 @@ extern "C"
     void rocprofsys_set_mpi(bool use, bool attached) ROCPROFSYS_PUBLIC_API;
     void rocprofsys_set_instrumented(int) ROCPROFSYS_PUBLIC_API;
     void rocprofsys_push_trace(const char* name) ROCPROFSYS_PUBLIC_API;
+    void rocprofsys_push_trace_with_args(const char* name, const char* serialized_args)
+        ROCPROFSYS_PUBLIC_API;
     void rocprofsys_pop_trace(const char* name) ROCPROFSYS_PUBLIC_API;
     int  rocprofsys_push_region(const char*) ROCPROFSYS_PUBLIC_API;
     int  rocprofsys_pop_region(const char*) ROCPROFSYS_PUBLIC_API;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/main.c
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/main.c
@@ -65,6 +65,9 @@ extern void
 rocprofsys_push_trace(const char* name);
 
 extern void
+rocprofsys_push_trace_with_args(const char* name, const char* serialized_args);
+
+extern void
 rocprofsys_pop_trace(const char* name);
 
 extern void

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/api.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/api.cpp
@@ -14,6 +14,12 @@ rocprofsys_push_trace(const char* _name)
 }
 
 extern "C" void
+rocprofsys_push_trace_with_args(const char* _name, const char* _serialized_args)
+{
+    rocprofsys_push_trace_with_args_hidden(_name, _serialized_args);
+}
+
+extern "C" void
 rocprofsys_pop_trace(const char* _name)
 {
     rocprofsys_pop_trace_hidden(_name);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/api.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/api.hpp
@@ -37,6 +37,11 @@ extern "C"
     /// starts an instrumentation region
     void rocprofsys_push_trace(const char*) ROCPROFSYS_PUBLIC_API;
 
+    /// starts an instrumentation region that carries serialized arguments
+    /// serialized arguments are of the form:
+    /// <arg_number>;;<arg_type>;;<arg_name>;;<arg_value>;;
+    void rocprofsys_push_trace_with_args(const char*, const char*) ROCPROFSYS_PUBLIC_API;
+
     /// stops an instrumentation region
     void rocprofsys_pop_trace(const char*) ROCPROFSYS_PUBLIC_API;
 
@@ -85,6 +90,8 @@ extern "C"
     void rocprofsys_set_env_hidden(const char*, const char*) ROCPROFSYS_HIDDEN_API;
     void rocprofsys_set_mpi_hidden(bool, bool) ROCPROFSYS_HIDDEN_API;
     void rocprofsys_push_trace_hidden(const char*) ROCPROFSYS_HIDDEN_API;
+    void rocprofsys_push_trace_with_args_hidden(const char*,
+                                                const char*) ROCPROFSYS_HIDDEN_API;
     void rocprofsys_pop_trace_hidden(const char*) ROCPROFSYS_HIDDEN_API;
     void rocprofsys_flush_pending_region_cache_hidden() ROCPROFSYS_HIDDEN_API;
     void rocprofsys_push_region_hidden(const char*) ROCPROFSYS_HIDDEN_API;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -995,7 +995,8 @@ rocprofsys_finalize_hidden(void)
         }
     }
 
-    LOG_DEBUG("rocprofsys_push_trace :: called {}", _push_count);
+    LOG_DEBUG("rocprofsys_push_trace/rocprofsys_push_trace_with_args :: called {}",
+              _push_count);
     LOG_DEBUG("rocprofsys_pop_trace  :: called {}", _pop_count);
 
     tim::signals::enable_signal_detection({ tim::signals::sys_signal::Interrupt },
@@ -1274,7 +1275,8 @@ rocprofsys_finalize_hidden(void)
        !get_env<bool>("ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK", false, false))
     {
         throw std::runtime_error(fmt::format(
-            "rocprofsys_push_trace was called more times than "
+            "rocprofsys_push_trace/rocprofsys_push_trace_with_args was called more times "
+            "than "
             "rocprofsys_pop_trace. The inverse is fine but the current state "
             "means not every measurement was ended :: pushed: {} vs. popped: {}",
             _push_count, _pop_count));

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
@@ -36,22 +36,6 @@
 #include <type_traits>
 #include <utility>
 
-namespace
-{
-
-void
-cache_region(std::uint64_t thread_id, const std::string& name, std::uint64_t start_ts,
-             std::uint64_t end_ts, const std::string& category,
-             const std::string& args_str = {})
-{
-    constexpr size_t      NO_CORRELATION_ID = 0;
-    constexpr const char* CALLSTACK         = "{}";
-    rocprofsys::trace_cache::get_buffer_storage().store(
-        rocprofsys::trace_cache::region_sample{
-            thread_id, name.c_str(), NO_CORRELATION_ID, NO_CORRELATION_ID, start_ts,
-            end_ts, CALLSTACK, args_str.c_str(), category.c_str() });
-}
-
 struct entry_key
 {
     std::string name;
@@ -72,11 +56,27 @@ using timestamp_t = std::uint64_t;
 
 struct pending_cache_entry
 {
-    timestamp_t start_ts = 0;
-    std::string args     = {};
+    timestamp_t   start_ts  = 0;
+    std::string   args      = {};
+    std::uint32_t arg_count = 0;
 };
 
-thread_local std::map<entry_key, pending_cache_entry> map_name_to_cache_entry;
+inline thread_local std::map<entry_key, pending_cache_entry> map_name_to_cache_entry;
+
+namespace
+{
+void
+cache_region(std::uint64_t thread_id, const std::string& name, std::uint64_t start_ts,
+             std::uint64_t end_ts, const std::string& category,
+             const std::string& args_str = {})
+{
+    constexpr size_t      NO_CORRELATION_ID = 0;
+    constexpr const char* CALLSTACK         = "{}";
+    rocprofsys::trace_cache::get_buffer_storage().store(
+        rocprofsys::trace_cache::region_sample{
+            thread_id, name.c_str(), NO_CORRELATION_ID, NO_CORRELATION_ID, start_ts,
+            end_ts, CALLSTACK, args_str.c_str(), category.c_str() });
+}
 
 template <typename Tp>
 struct is_trace_cache_arg_name : std::is_convertible<std::decay_t<Tp>, std::string_view>
@@ -93,8 +93,6 @@ has_trace_cache_args(std::index_sequence<Idx...>)
     }
     else
     {
-        // TODO: perfetto annotations can also be passed, we cannot handle those here as
-        // of yet
         return ((Idx % 2 != 0 ||
                  is_trace_cache_arg_name<std::tuple_element_t<Idx, TupleT>>::value) &&
                 ...);
@@ -125,6 +123,7 @@ get_serialized_arg_value(Tp&& value)
     return ss.str();
 }
 
+// Append one trace-cache record "idx;;type;;name;;value;;" to args_str
 template <typename KeyT, typename ValueT>
 void
 append_serialized_arg(std::string& args_str, std::uint32_t idx, KeyT&& key,
@@ -137,6 +136,7 @@ append_serialized_arg(std::string& args_str, std::uint32_t idx, KeyT&& key,
                     get_serialized_arg_value(std::forward<ValueT>(value)), delimiter);
 }
 
+// Same record format, but type/value are pre-stringified by the caller
 void
 append_serialized_arg(std::string& args_str, std::uint32_t idx, std::string_view arg_type,
                       std::string_view key, std::string_view value)
@@ -144,6 +144,30 @@ append_serialized_arg(std::string& args_str, std::uint32_t idx, std::string_view
     const auto* delimiter = ";;";
     args_str += fmt::format("{}{}{}{}{}{}{}{}", idx, delimiter, arg_type, delimiter, key,
                             delimiter, value, delimiter);
+}
+
+std::uint32_t
+renumber_serialized_args(std::string& args_str, std::uint32_t next_idx)
+{
+    const auto delimiter = std::string_view{ ";;" };
+    size_t     start     = 0;
+    size_t     token_id  = 0;
+    auto       count     = std::uint32_t{ 0 };
+    auto       end       = args_str.find(delimiter, start);
+    while(end != std::string::npos)
+    {
+        if(token_id % 4 == 0)
+        {
+            auto replacement = fmt::format("{}", next_idx++);
+            args_str.replace(start, end - start, replacement);
+            end = start + replacement.size();
+            ++count;
+        }
+        start = end + delimiter.size();
+        ++token_id;
+        end = args_str.find(delimiter, start);
+    }
+    return count;
 }
 
 template <size_t Idx = 0, typename TupleT>
@@ -175,6 +199,8 @@ get_serialized_pointer_value(const void* value)
     return ss.str();
 }
 
+// Serialize a rocprofsys_annotation_t record to the trace-cache format
+// Returns true on success, false otherwise
 bool
 append_serialized_annotation_record_arg(std::string& args_str, std::uint32_t idx,
                                         const rocprofsys_annotation_t& annotation)
@@ -185,6 +211,9 @@ append_serialized_annotation_record_arg(std::string& args_str, std::uint32_t idx
     std::string arg_type  = {};
     std::string arg_value = {};
 
+    // annotation.type is a runtime enum tag naming a C type. Each case
+    // sets the type-label string written into the cache record and
+    // selects the matching compile-time reinterpret of annotation.value
     switch(annotation.type)
     {
         case ROCPROFSYS_VALUE_CSTR:
@@ -234,24 +263,15 @@ append_serialized_annotation_record_arg(std::string& args_str, std::uint32_t idx
         default: return false;
     }
 
+    // Append the record with the decoded information
     append_serialized_arg(args_str, idx, arg_type, annotation.name, arg_value);
     return true;
-}
-
-template <typename Tp>
-void
-append_serialized_annotation_arg(std::string& args_str, std::uint32_t& idx, Tp&& value)
-{
-    auto arg_name = fmt::format(
-        "arg{}-{}", idx, rocprofsys::utility::demangle<std::remove_reference_t<Tp>>());
-    append_serialized_arg(args_str, idx, arg_name, std::forward<Tp>(value));
-    ++idx;
 }
 
 // Serialize explicit argument pairs {"name", value}
 template <typename... Args>
 std::string
-get_serialized_args(Args&&... args)
+serialize_name_value_pairs(Args&&... args)
 {
     ROCPROFSYS_SCOPED_THREAD_STATE(ThreadState::Internal);
 
@@ -270,9 +290,9 @@ get_serialized_args(Args&&... args)
     }
 }
 
-// Serialize annotation records using their provided names and value types
-inline std::string
-get_serialized_annotation_args(rocprofsys_annotation_t* annotations,
+// Transforms rocprofsys_annotation_t records into the trace-cache format.
+std::string
+serialize_annotation_args(rocprofsys_annotation_t* annotations,
                                size_t                   annotation_count)
 {
     if(!annotations || annotation_count == 0) return {};
@@ -283,42 +303,71 @@ get_serialized_annotation_args(rocprofsys_annotation_t* annotations,
     std::uint32_t idx      = 0;
     for(size_t i = 0; i < annotation_count; ++i)
     {
+        // Attempt to append the record
         if(append_serialized_annotation_record_arg(args_str, idx, annotations[i])) ++idx;
     }
     return args_str;
 }
 
-// Serialize audit annotation values using generated argN-type names
+// Serializes gotcha audit arguments into the trace-cache format.
+// Names are synthesized as "arg{N}-{demangled-type}" to mirror add_perfetto_annotation
 template <typename... Args>
 std::string
-get_serialized_annotation_args(Args&&... args)
+serialize_annotation_args(Args&&... args)
 {
     ROCPROFSYS_SCOPED_THREAD_STATE(ThreadState::Internal);
 
     std::string   args_str = {};
     std::uint32_t idx      = 0;
     ROCPROFSYS_FOLD_EXPRESSION(
-        append_serialized_annotation_arg(args_str, idx, std::forward<Args>(args)));
+        (append_serialized_arg(
+             args_str, idx,
+             fmt::format("arg{}-{}", idx,
+                         rocprofsys::utility::demangle<std::remove_reference_t<Args>>()),
+             std::forward<Args>(args)),
+         ++idx));
+    return args_str;
+}
+
+// Outgoing audits pass at most one return value. This matches perfetto's single "return"
+// annotation.
+template <typename T>
+std::string
+serialize_return_arg(T&& value)
+{
+    ROCPROFSYS_SCOPED_THREAD_STATE(ThreadState::Internal);
+
+    std::string args_str = {};
+    append_serialized_arg(args_str, 0, "return", std::forward<T>(value));
     return args_str;
 }
 
 template <typename CategoryT>
 void
-cache_start(const char* name, std::string args_str = {})
+cache_start(const char* name, std::string args_str = {}, std::uint32_t arg_count = 0)
 {
     const auto start_ts =
         static_cast<timestamp_t>(rocprofsys::comp::wall_clock::record());
     entry_key key{ name, rocprofsys::trait::name<CategoryT>::value };
-    map_name_to_cache_entry[key] = pending_cache_entry{ start_ts, std::move(args_str) };
+    map_name_to_cache_entry[key] =
+        pending_cache_entry{ start_ts, std::move(args_str), arg_count };
 }
 
 template <typename CategoryT>
 void
-cache_args(const char* name, std::string args_str)
+append_cache_args(const char* name, std::string args_str)
 {
     auto key = entry_key{ name, rocprofsys::trait::name<CategoryT>::value };
     auto itr = map_name_to_cache_entry.find(key);
-    if(itr != map_name_to_cache_entry.end()) itr->second.args = std::move(args_str);
+    if(itr != map_name_to_cache_entry.end())
+    {
+        // If args were previously stored, the new ones must be renumbered to accomodate
+        auto appended_arg_count = renumber_serialized_args(args_str, itr->second.arg_count);
+
+        // Update the entry with the new args
+        itr->second.arg_count += appended_arg_count;
+        itr->second.args += std::move(args_str);
+    }
 }
 
 template <typename CategoryT>
@@ -442,7 +491,7 @@ struct category_region : comp::base<category_region<CategoryT>, void>
         return fmt::format("rocprofsys_{}_region", category_name);
     }
 
-    static void set_cache_args(std::string_view name, std::string serialized_args);
+    static void append_cache_args(std::string_view name, std::string serialized_args);
 
     template <typename... OptsT, typename... Args>
     static void start(std::string_view name, Args&&...);
@@ -521,7 +570,7 @@ category_region<CategoryT>::start(std::string_view name, Args&&... args)
     std::string _cache_args = {};
     if constexpr(_has_cache_args)
     {
-        _cache_args = get_serialized_args(args...);
+        _cache_args = serialize_name_value_pairs(args...);
     }
 
     auto _hash = tim::add_hash_id(name);
@@ -553,7 +602,9 @@ category_region<CategoryT>::start(std::string_view name, Args&&... args)
 
     if constexpr(_has_cache_args)
     {
-        cache_start<CategoryT>(name.data(), std::move(_cache_args));
+        constexpr auto _cache_arg_count =
+            static_cast<std::uint32_t>(sizeof...(Args) / 2);
+        cache_start<CategoryT>(name.data(), std::move(_cache_args), _cache_arg_count);
     }
     else
     {
@@ -563,8 +614,8 @@ category_region<CategoryT>::start(std::string_view name, Args&&... args)
 
 template <typename CategoryT>
 void
-category_region<CategoryT>::set_cache_args(std::string_view name,
-                                           std::string      serialized_args)
+category_region<CategoryT>::append_cache_args(std::string_view name,
+                                              std::string      serialized_args)
 {
     if(name.empty() || serialized_args.empty()) return;
 
@@ -572,7 +623,7 @@ category_region<CategoryT>::set_cache_args(std::string_view name,
 
     auto _hash = tim::add_hash_id(name);
     name       = tim::get_hash_identifier_fast(_hash);
-    cache_args<CategoryT>(name.data(), std::move(serialized_args));
+    ::append_cache_args<CategoryT>(name.data(), std::move(serialized_args));
 }
 
 template <typename CategoryT>
@@ -703,7 +754,7 @@ category_region<CategoryT>::audit(const gotcha_data_t& _data, audit::incoming,
 
     if constexpr(sizeof...(Args) > 0)
     {
-        set_cache_args(_data.tool_id.c_str(), get_serialized_annotation_args(_args...));
+        append_cache_args(_data.tool_id.c_str(), serialize_annotation_args(_args...));
     }
 }
 
@@ -713,6 +764,11 @@ void
 category_region<CategoryT>::audit(const gotcha_data_t& _data, audit::outgoing,
                                   Args&&... _args)
 {
+    if constexpr(sizeof...(Args) > 0)
+    {
+        append_cache_args(_data.tool_id.c_str(), serialize_return_arg(_args...));
+    }
+
     stop<OptsT...>(_data.tool_id.c_str(), [&](::perfetto::EventContext ctx) {
         if(config::get_perfetto_annotations())
             tracing::add_perfetto_annotation(
@@ -739,7 +795,7 @@ category_region<CategoryT>::audit(std::string_view _name, audit::incoming,
 
     if constexpr(sizeof...(Args) > 0)
     {
-        set_cache_args(_name.data(), get_serialized_annotation_args(_args...));
+        append_cache_args(_name.data(), serialize_annotation_args(_args...));
     }
 }
 
@@ -749,6 +805,11 @@ void
 category_region<CategoryT>::audit(std::string_view _name, audit::outgoing,
                                   Args&&... _args)
 {
+    if constexpr(sizeof...(Args) > 0)
+    {
+        append_cache_args(_name.data(), serialize_return_arg(_args...));
+    }
+
     stop<OptsT...>(_name.data(), [&](::perfetto::EventContext ctx) {
         if(config::get_perfetto_annotations())
             tracing::add_perfetto_annotation(

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
@@ -30,7 +30,10 @@
 
 #include <spdlog/fmt/ranges.h>
 
+#include <sstream>
+#include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 
 namespace
@@ -38,15 +41,15 @@ namespace
 
 void
 cache_region(std::uint64_t thread_id, const std::string& name, std::uint64_t start_ts,
-             std::uint64_t end_ts, const std::string& category)
+             std::uint64_t end_ts, const std::string& category,
+             const std::string& args_str = {})
 {
     constexpr size_t      NO_CORRELATION_ID = 0;
     constexpr const char* CALLSTACK         = "{}";
-    constexpr const char* ARGUMENTS         = "";
     rocprofsys::trace_cache::get_buffer_storage().store(
         rocprofsys::trace_cache::region_sample{
             thread_id, name.c_str(), NO_CORRELATION_ID, NO_CORRELATION_ID, start_ts,
-            end_ts, CALLSTACK, ARGUMENTS, category.c_str() });
+            end_ts, CALLSTACK, args_str.c_str(), category.c_str() });
 }
 
 struct entry_key
@@ -67,15 +70,121 @@ struct entry_key
 
 using timestamp_t = std::uint64_t;
 
-thread_local std::map<entry_key, timestamp_t> map_name_to_args;
+struct pending_cache_entry
+{
+    timestamp_t start_ts = 0;
+    std::string args     = {};
+};
 
-template <typename CategoryT, typename... Args>
+thread_local std::map<entry_key, pending_cache_entry> map_name_to_cache_entry;
+
+template <typename Tp>
+struct is_trace_cache_arg_name : std::is_convertible<std::decay_t<Tp>, std::string_view>
+{};
+
+template <typename TupleT, size_t... Idx>
+constexpr bool
+has_trace_cache_args(std::index_sequence<Idx...>)
+{
+    // Cannot be empty and must be grouped by "name", arg
+    if constexpr(sizeof...(Idx) == 0 || sizeof...(Idx) % 2 != 0)
+    {
+        return false;
+    }
+    else
+    {
+        // TODO: perfetto annotations can also be passed, we cannot handle those here as
+        // of yet
+        return ((Idx % 2 != 0 ||
+                 is_trace_cache_arg_name<std::tuple_element_t<Idx, TupleT>>::value) &&
+                ...);
+    }
+}
+
+template <typename Tp>
+std::string
+get_trace_cache_arg_type()
+{
+    using value_type = std::decay_t<Tp>;
+    if constexpr(std::is_convertible<value_type, std::string_view>::value)
+    {
+        return "string";
+    }
+    else
+    {
+        return rocprofsys::utility::demangle<value_type>();
+    }
+}
+
+template <typename Tp>
+std::string
+get_trace_cache_arg_value(Tp&& value)
+{
+    std::stringstream ss;
+    ss << std::forward<Tp>(value);
+    return ss.str();
+}
+
+template <typename KeyT, typename ValueT>
 void
-cache_start(const char* name)
+append_trace_cache_arg(std::string& args_str, std::uint32_t idx, KeyT&& key,
+                       ValueT&& value)
+{
+    const auto* delimiter = ";;";
+    args_str += fmt::format(
+        "{}{}{}{}{}{}{}{}", idx, delimiter, get_trace_cache_arg_type<ValueT>(), delimiter,
+        std::string_view{ std::forward<KeyT>(key) }, delimiter,
+        get_trace_cache_arg_value(std::forward<ValueT>(value)), delimiter);
+}
+
+template <size_t Idx = 0, typename TupleT>
+void
+append_trace_cache_args(std::string& args_str, TupleT&& args)
+{
+    if constexpr(Idx < std::tuple_size<std::remove_reference_t<TupleT>>::value)
+    {
+        append_trace_cache_arg(args_str, Idx / 2, std::get<Idx>(args),
+                               std::get<Idx + 1>(args));
+        append_trace_cache_args<Idx + 2>(args_str, std::forward<TupleT>(args));
+    }
+}
+
+template <typename... Args>
+std::string
+get_trace_cache_args_string(Args&&... args)
+{
+    using tuple_type = std::tuple<Args...>;
+    if constexpr(has_trace_cache_args<tuple_type>(
+                     std::make_index_sequence<sizeof...(Args)>{}))
+    {
+        auto        args_tuple = std::forward_as_tuple(args...);
+        std::string args_str;
+        append_trace_cache_args(args_str, args_tuple);
+        return args_str;
+    }
+    else
+    {
+        return {};
+    }
+}
+
+template <typename CategoryT>
+void
+cache_start(const char* name, std::string args_str = {})
 {
     const auto start_ts =
         static_cast<timestamp_t>(rocprofsys::comp::wall_clock::record());
-    map_name_to_args[{ name, rocprofsys::trait::name<CategoryT>::value }] = start_ts;
+    entry_key key{ name, rocprofsys::trait::name<CategoryT>::value };
+    map_name_to_cache_entry[key] = pending_cache_entry{ start_ts, std::move(args_str) };
+}
+
+template <typename CategoryT>
+void
+cache_args(const char* name, std::string args_str)
+{
+    auto key = entry_key{ name, rocprofsys::trait::name<CategoryT>::value };
+    auto itr = map_name_to_cache_entry.find(key);
+    if(itr != map_name_to_cache_entry.end()) itr->second.args = std::move(args_str);
 }
 
 template <typename CategoryT>
@@ -83,11 +192,12 @@ void
 cache_stop(const char* name)
 {
     entry_key key{ name, rocprofsys::trait::name<CategoryT>::value };
-    auto      x = map_name_to_args.find(key);
-    if(x != map_name_to_args.end())
+    auto      itr = map_name_to_cache_entry.find(key);
+    if(itr != map_name_to_cache_entry.end())
     {
-        auto timestamp = x->second;
-        map_name_to_args.erase(x);
+        auto timestamp = itr->second.start_ts;
+        auto args_str  = std::move(itr->second.args);
+        map_name_to_cache_entry.erase(itr);
 
         const auto end_ts =
             static_cast<timestamp_t>(rocprofsys::comp::wall_clock::record());
@@ -104,7 +214,7 @@ cache_stop(const char* name)
         }
 
         cache_region(thread_id, name, timestamp, end_ts,
-                     rocprofsys::trait::name<CategoryT>::value);
+                     rocprofsys::trait::name<CategoryT>::value, args_str);
     }
 }
 
@@ -126,11 +236,12 @@ flush_pending_cached_entries()
             { getppid(), getpid(), thread_id, UNKNOWN_TIME, UNKNOWN_TIME, "{}" });
     }
 
-    for(const auto& [key, start_ts] : map_name_to_args)
+    for(const auto& [key, entry] : map_name_to_cache_entry)
     {
-        cache_region(thread_id, key.name, start_ts, end_ts, key.category);
+        cache_region(thread_id, key.name, entry.start_ts, end_ts, key.category,
+                     entry.args);
     }
-    map_name_to_args.clear();
+    map_name_to_cache_entry.clear();
 }
 }  // namespace
 
@@ -196,6 +307,8 @@ struct category_region : comp::base<category_region<CategoryT>, void>
     {
         return fmt::format("rocprofsys_{}_region", category_name);
     }
+
+    static void set_cache_args(std::string_view name, std::string serialized_args);
 
     template <typename... OptsT, typename... Args>
     static void start(std::string_view name, Args&&...);
@@ -266,6 +379,17 @@ category_region<CategoryT>::start(std::string_view name, Args&&... args)
         ++tracing::push_count();
     }
 
+    // Allow cache_start to process arguments passed through args
+    // excluding perfetto annotations
+    constexpr bool _has_cache_args = has_trace_cache_args<std::tuple<Args...>>(
+        std::make_index_sequence<sizeof...(Args)>{});
+
+    std::string _cache_args = {};
+    if constexpr(_has_cache_args)
+    {
+        _cache_args = get_trace_cache_args_string(args...);
+    }
+
     auto _hash = tim::add_hash_id(name);
     name       = tim::get_hash_identifier_fast(_hash);
 
@@ -293,7 +417,26 @@ category_region<CategoryT>::start(std::string_view name, Args&&... args)
         }
     }
 
-    cache_start<CategoryT>(name.data());
+    if constexpr(_has_cache_args)
+    {
+        cache_start<CategoryT>(name.data(), std::move(_cache_args));
+    }
+    else
+    {
+        cache_start<CategoryT>(name.data());
+    }
+}
+
+template <typename CategoryT>
+void
+category_region<CategoryT>::set_cache_args(std::string_view name,
+                                           std::string      serialized_args)
+{
+    if(name.empty() || serialized_args.empty()) return;
+
+    auto _hash = tim::add_hash_id(name);
+    name       = tim::get_hash_identifier_fast(_hash);
+    cache_args<CategoryT>(name.data(), std::move(serialized_args));
 }
 
 template <typename CategoryT>

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
@@ -103,7 +103,7 @@ has_trace_cache_args(std::index_sequence<Idx...>)
 
 template <typename Tp>
 std::string
-get_trace_cache_arg_type()
+get_serialized_arg_type()
 {
     using value_type = std::decay_t<Tp>;
     if constexpr(std::is_convertible<value_type, std::string_view>::value)
@@ -118,7 +118,7 @@ get_trace_cache_arg_type()
 
 template <typename Tp>
 std::string
-get_trace_cache_arg_value(Tp&& value)
+get_serialized_arg_value(Tp&& value)
 {
     std::stringstream ss;
     ss << std::forward<Tp>(value);
@@ -127,31 +127,131 @@ get_trace_cache_arg_value(Tp&& value)
 
 template <typename KeyT, typename ValueT>
 void
-append_trace_cache_arg(std::string& args_str, std::uint32_t idx, KeyT&& key,
-                       ValueT&& value)
+append_serialized_arg(std::string& args_str, std::uint32_t idx, KeyT&& key,
+                      ValueT&& value)
 {
     const auto* delimiter = ";;";
-    args_str += fmt::format(
-        "{}{}{}{}{}{}{}{}", idx, delimiter, get_trace_cache_arg_type<ValueT>(), delimiter,
-        std::string_view{ std::forward<KeyT>(key) }, delimiter,
-        get_trace_cache_arg_value(std::forward<ValueT>(value)), delimiter);
+    args_str +=
+        fmt::format("{}{}{}{}{}{}{}{}", idx, delimiter, get_serialized_arg_type<ValueT>(),
+                    delimiter, std::string_view{ std::forward<KeyT>(key) }, delimiter,
+                    get_serialized_arg_value(std::forward<ValueT>(value)), delimiter);
+}
+
+void
+append_serialized_arg(std::string& args_str, std::uint32_t idx, std::string_view arg_type,
+                      std::string_view key, std::string_view value)
+{
+    const auto* delimiter = ";;";
+    args_str += fmt::format("{}{}{}{}{}{}{}{}", idx, delimiter, arg_type, delimiter, key,
+                            delimiter, value, delimiter);
 }
 
 template <size_t Idx = 0, typename TupleT>
 void
-append_trace_cache_args(std::string& args_str, TupleT&& args)
+append_serialized_args(std::string& args_str, TupleT&& args)
 {
     if constexpr(Idx < std::tuple_size<std::remove_reference_t<TupleT>>::value)
     {
-        append_trace_cache_arg(args_str, Idx / 2, std::get<Idx>(args),
-                               std::get<Idx + 1>(args));
-        append_trace_cache_args<Idx + 2>(args_str, std::forward<TupleT>(args));
+        append_serialized_arg(args_str, Idx / 2, std::get<Idx>(args),
+                              std::get<Idx + 1>(args));
+        append_serialized_args<Idx + 2>(args_str, std::forward<TupleT>(args));
     }
 }
 
+template <typename Tp>
+std::string
+get_serialized_annotation_value(const void* value)
+{
+    std::stringstream ss;
+    ss << *reinterpret_cast<const Tp*>(value);
+    return ss.str();
+}
+
+std::string
+get_serialized_pointer_value(const void* value)
+{
+    std::stringstream ss;
+    ss << value;
+    return ss.str();
+}
+
+bool
+append_serialized_annotation_record_arg(std::string& args_str, std::uint32_t idx,
+                                        const rocprofsys_annotation_t& annotation)
+{
+    if(!annotation.name || annotation.type == ROCPROFSYS_VALUE_NONE || !annotation.value)
+        return false;
+
+    std::string arg_type  = {};
+    std::string arg_value = {};
+
+    switch(annotation.type)
+    {
+        case ROCPROFSYS_VALUE_CSTR:
+            arg_type  = "string";
+            arg_value = reinterpret_cast<const char*>(annotation.value);
+            break;
+        case ROCPROFSYS_VALUE_SIZE_T:
+            arg_type  = "size_t";
+            arg_value = get_serialized_annotation_value<size_t>(annotation.value);
+            break;
+        case ROCPROFSYS_VALUE_INT16:
+            arg_type  = "std::int16_t";
+            arg_value = get_serialized_annotation_value<std::int16_t>(annotation.value);
+            break;
+        case ROCPROFSYS_VALUE_INT32:
+            arg_type  = "std::int32_t";
+            arg_value = get_serialized_annotation_value<std::int32_t>(annotation.value);
+            break;
+        case ROCPROFSYS_VALUE_INT64:
+            arg_type  = "std::int64_t";
+            arg_value = get_serialized_annotation_value<std::int64_t>(annotation.value);
+            break;
+        case ROCPROFSYS_VALUE_UINT16:
+            arg_type  = "std::uint16_t";
+            arg_value = get_serialized_annotation_value<std::uint16_t>(annotation.value);
+            break;
+        case ROCPROFSYS_VALUE_UINT32:
+            arg_type  = "std::uint32_t";
+            arg_value = get_serialized_annotation_value<std::uint32_t>(annotation.value);
+            break;
+        case ROCPROFSYS_VALUE_UINT64:
+            arg_type  = "std::uint64_t";
+            arg_value = get_serialized_annotation_value<std::uint64_t>(annotation.value);
+            break;
+        case ROCPROFSYS_VALUE_FLOAT32:
+            arg_type  = "float";
+            arg_value = get_serialized_annotation_value<float>(annotation.value);
+            break;
+        case ROCPROFSYS_VALUE_FLOAT64:
+            arg_type  = "double";
+            arg_value = get_serialized_annotation_value<double>(annotation.value);
+            break;
+        case ROCPROFSYS_VALUE_VOID_P:
+            arg_type  = "void*";
+            arg_value = get_serialized_pointer_value(annotation.value);
+            break;
+        default: return false;
+    }
+
+    append_serialized_arg(args_str, idx, arg_type, annotation.name, arg_value);
+    return true;
+}
+
+template <typename Tp>
+void
+append_serialized_annotation_arg(std::string& args_str, std::uint32_t& idx, Tp&& value)
+{
+    auto arg_name = fmt::format(
+        "arg{}-{}", idx, rocprofsys::utility::demangle<std::remove_reference_t<Tp>>());
+    append_serialized_arg(args_str, idx, arg_name, std::forward<Tp>(value));
+    ++idx;
+}
+
+// Serialize explicit argument pairs {"name", value}
 template <typename... Args>
 std::string
-get_trace_cache_args_string(Args&&... args)
+get_serialized_args(Args&&... args)
 {
     using tuple_type = std::tuple<Args...>;
     if constexpr(has_trace_cache_args<tuple_type>(
@@ -159,13 +259,41 @@ get_trace_cache_args_string(Args&&... args)
     {
         auto        args_tuple = std::forward_as_tuple(args...);
         std::string args_str;
-        append_trace_cache_args(args_str, args_tuple);
+        append_serialized_args(args_str, args_tuple);
         return args_str;
     }
     else
     {
         return {};
     }
+}
+
+// Serialize annotation records using their provided names and value types
+inline std::string
+get_serialized_annotation_args(rocprofsys_annotation_t* annotations,
+                               size_t                   annotation_count)
+{
+    if(!annotations || annotation_count == 0) return {};
+
+    std::string   args_str = {};
+    std::uint32_t idx      = 0;
+    for(size_t i = 0; i < annotation_count; ++i)
+    {
+        if(append_serialized_annotation_record_arg(args_str, idx, annotations[i])) ++idx;
+    }
+    return args_str;
+}
+
+// Serialize audit annotation values using generated argN-type names
+template <typename... Args>
+std::string
+get_serialized_annotation_args(Args&&... args)
+{
+    std::string   args_str = {};
+    std::uint32_t idx      = 0;
+    ROCPROFSYS_FOLD_EXPRESSION(
+        append_serialized_annotation_arg(args_str, idx, std::forward<Args>(args)));
+    return args_str;
 }
 
 template <typename CategoryT>
@@ -379,15 +507,15 @@ category_region<CategoryT>::start(std::string_view name, Args&&... args)
         ++tracing::push_count();
     }
 
-    // Allow cache_start to process arguments passed through args
-    // excluding perfetto annotations
+    // Only serialize name/value argument pairs. Perfetto annotation callbacks are handled
+    // separately by the tracing path
     constexpr bool _has_cache_args = has_trace_cache_args<std::tuple<Args...>>(
         std::make_index_sequence<sizeof...(Args)>{});
 
     std::string _cache_args = {};
     if constexpr(_has_cache_args)
     {
-        _cache_args = get_trace_cache_args_string(args...);
+        _cache_args = get_serialized_args(args...);
     }
 
     auto _hash = tim::add_hash_id(name);
@@ -564,6 +692,11 @@ category_region<CategoryT>::audit(const gotcha_data_t& _data, audit::incoming,
                 _args, _n++));
         }
     });
+
+    if constexpr(sizeof...(Args) > 0)
+    {
+        set_cache_args(_data.tool_id.c_str(), get_serialized_annotation_args(_args...));
+    }
 }
 
 template <typename CategoryT>
@@ -595,6 +728,11 @@ category_region<CategoryT>::audit(std::string_view _name, audit::incoming,
                 _args, _n++));
         }
     });
+
+    if constexpr(sizeof...(Args) > 0)
+    {
+        set_cache_args(_name.data(), get_serialized_annotation_args(_args...));
+    }
 }
 
 template <typename CategoryT>

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
@@ -253,6 +253,8 @@ template <typename... Args>
 std::string
 get_serialized_args(Args&&... args)
 {
+    ROCPROFSYS_SCOPED_THREAD_STATE(ThreadState::Internal);
+
     using tuple_type = std::tuple<Args...>;
     if constexpr(has_trace_cache_args<tuple_type>(
                      std::make_index_sequence<sizeof...(Args)>{}))
@@ -275,6 +277,8 @@ get_serialized_annotation_args(rocprofsys_annotation_t* annotations,
 {
     if(!annotations || annotation_count == 0) return {};
 
+    ROCPROFSYS_SCOPED_THREAD_STATE(ThreadState::Internal);
+
     std::string   args_str = {};
     std::uint32_t idx      = 0;
     for(size_t i = 0; i < annotation_count; ++i)
@@ -289,6 +293,8 @@ template <typename... Args>
 std::string
 get_serialized_annotation_args(Args&&... args)
 {
+    ROCPROFSYS_SCOPED_THREAD_STATE(ThreadState::Internal);
+
     std::string   args_str = {};
     std::uint32_t idx      = 0;
     ROCPROFSYS_FOLD_EXPRESSION(
@@ -562,6 +568,8 @@ category_region<CategoryT>::set_cache_args(std::string_view name,
 {
     if(name.empty() || serialized_args.empty()) return;
 
+    ROCPROFSYS_SCOPED_THREAD_STATE(ThreadState::Internal);
+
     auto _hash = tim::add_hash_id(name);
     name       = tim::get_hash_identifier_fast(_hash);
     cache_args<CategoryT>(name.data(), std::move(serialized_args));
@@ -695,7 +703,6 @@ category_region<CategoryT>::audit(const gotcha_data_t& _data, audit::incoming,
 
     if constexpr(sizeof...(Args) > 0)
     {
-        ROCPROFSYS_SCOPED_THREAD_STATE(ThreadState::Internal);
         set_cache_args(_data.tool_id.c_str(), get_serialized_annotation_args(_args...));
     }
 }
@@ -732,7 +739,6 @@ category_region<CategoryT>::audit(std::string_view _name, audit::incoming,
 
     if constexpr(sizeof...(Args) > 0)
     {
-        ROCPROFSYS_SCOPED_THREAD_STATE(ThreadState::Internal);
         set_cache_args(_name.data(), get_serialized_annotation_args(_args...));
     }
 }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
@@ -695,6 +695,7 @@ category_region<CategoryT>::audit(const gotcha_data_t& _data, audit::incoming,
 
     if constexpr(sizeof...(Args) > 0)
     {
+        ROCPROFSYS_SCOPED_THREAD_STATE(ThreadState::Internal);
         set_cache_args(_data.tool_id.c_str(), get_serialized_annotation_args(_args...));
     }
 }
@@ -731,6 +732,7 @@ category_region<CategoryT>::audit(std::string_view _name, audit::incoming,
 
     if constexpr(sizeof...(Args) > 0)
     {
+        ROCPROFSYS_SCOPED_THREAD_STATE(ThreadState::Internal);
         set_cache_args(_name.data(), get_serialized_annotation_args(_args...));
     }
 }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/regions.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/regions.cpp
@@ -43,8 +43,8 @@ invoke_category_region_start(rocprofsys_category_t _category, const char* name,
                         tracing::add_perfetto_annotation(ctx, _annotations[i]);
                 }
             });
-        component::category_region<category_type>::set_cache_args(
-            name, get_serialized_annotation_args(_annotations, _annotation_count));
+        component::category_region<category_type>::append_cache_args(
+            name, serialize_annotation_args(_annotations, _annotation_count));
     }
     else
     {
@@ -106,7 +106,7 @@ rocprofsys_push_trace_with_args_hidden(const char* name, const char* serialized_
 {
     rocprofsys::component::category_region<rocprofsys::category::host>::start(name);
     if(!serialized_args) return;
-    rocprofsys::component::category_region<rocprofsys::category::host>::set_cache_args(
+    rocprofsys::component::category_region<rocprofsys::category::host>::append_cache_args(
         name, serialized_args);
 }
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/regions.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/regions.cpp
@@ -100,6 +100,15 @@ rocprofsys_push_trace_hidden(const char* name)
 }
 
 extern "C" void
+rocprofsys_push_trace_with_args_hidden(const char* name, const char* serialized_args)
+{
+    rocprofsys::component::category_region<rocprofsys::category::host>::start(name);
+    if(!serialized_args) return;
+    rocprofsys::component::category_region<rocprofsys::category::host>::set_cache_args(
+        name, serialized_args);
+}
+
+extern "C" void
 rocprofsys_pop_trace_hidden(const char* name)
 {
     rocprofsys::component::category_region<rocprofsys::category::host>::stop(name);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/regions.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/regions.cpp
@@ -43,6 +43,8 @@ invoke_category_region_start(rocprofsys_category_t _category, const char* name,
                         tracing::add_perfetto_annotation(ctx, _annotations[i]);
                 }
             });
+        component::category_region<category_type>::set_cache_args(
+            name, get_serialized_annotation_args(_annotations, _annotation_count));
     }
     else
     {


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Currently, with `runtime-instrument`, it is difficult for a user with limited knowledge to know where certain traces come from. Do they come from their binaries, or do they originate from some shared library that was pulled in?

Consider this function found in any old LLVM OpenMP host program that splits work across multiple threads:
<img width="1677" height="299" alt="image" src="https://github.com/user-attachments/assets/60b3a2c2-8248-411e-a578-07cbbaa9e6b8" />

Tell me, where does `__kmp_allocate_thread()` come from? The answer is `libomp.so`, which is not obvious when looking at the above image. This PR aims to fix this.

**ALSO**

`ROCPROFSYS_TRACE_LEGACY` encodes some information that is missing from debug args when trace cache is used.
I'll make an attempt to ensure that perfetto annotations are stored in the trace cache as well.

(See **perfetto annotations** section in **Manual Testing with Perfetto**)

## Technical Details

For a trace with args, prefer calling `rocprofsys_push_trace_with_args(...)`. It is then popped using `rocprof_sys_pop_trace`.

<!-- Explain the changes along with any relevant GitHub links. -->
 - Added `rocprofsys_push_trace_with_args`
 - Added `rocprofsys_get_serialized_args` which takes in a triples of `name, val, enabled` and transforms it into the `<arg_number>;;<arg_type>;;<arg_name>;;<arg_value>;;` form.
 - Allow `cache_region` to store `args` instead of hard coding `ARGUMENTS = ""`.
   - If `category_region<CategoryT>::start()` is called with `Args... args` being tuples of `"name", val`, then these are serialized for `cache_region`
   - When `rocprofsys_push_trace_with_args` is used, it also calls `set_cache_args` on top of the usual `start` (see `library.cpp`).
 - Allow perfetto annotations to be stored in cache as well. Note that `audit` calls require `ROCPROFSYS_SCOPED_THREAD_STATE(ThreadState::Internal)` as setting the cache does tool internal work which will end up calling `pthread` locks, which is dangerous inside the `pthread_gotcha` (without this, `pthreads` tests would all deadlock).
 - Move `entry_key` and `pending_cache_entry` outside of the anonymous namespace. Anonymous-namespace symbols in a header have internal linkage, so each TU had its own `map_name_to_cache_entry`. Linker deduplicated `category_region<>` member functions could then insert into one TU's map and look up in another's, silently dropping cache entries. Lifting them to file scope with `inline thread_local` makes the storage single and shared.

**Notes**:
 - `rocprofsys_push_trace_with_args` only works with the `trace_cache`. It will not work with `ROCPROFSYS_TRACE_LEGACY`.
 - Perfetto annotations are now stored in trace cache as well. Everything is serialized to the `<arg_number>;;<arg_type>;;<arg_name>;;<arg_value>;;` form.
 - `rocprofsys_push_trace_with_args` is optional to find. If it does not find it, fallback to using `rocprofsys_push_trace`.
 - Depending on the amount of information from dyninst we want to show in the traces, we could also show:
   - instruction count
   - source line information
   - address location
   - etc.. 

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

AIPROFSYST-460

## Manual Testing with Perfetto

<!-- Explain any relevant testing done to verify this PR. -->

### rocprofsys_push_trace_with_args

Before, one would see for some `numa_alloc` (library function): 
<img width="831" height="156" alt="image" src="https://github.com/user-attachments/assets/5c43efca-751d-41ec-81db-11c224fc8bf6" />

But now we can see that `source_object` that it originates from (`libnuma.so.1.1.0`): 
<img width="823" height="160" alt="image" src="https://github.com/user-attachments/assets/3950208e-d285-42e3-9d65-419ba09f695e" />

### arguments

As a bonus, if a caller calls `category_region<CategoryT>::start` with `Args` following the `"name", val` format, it is also processed by the `trace_cache`. For example, `numa_alloc` now shows the `alloc` size:

Before:
<img width="811" height="132" alt="image" src="https://github.com/user-attachments/assets/d81e3605-96c8-4c16-b130-bb2b501739a9" />

After (notice in `debug`, we see the `size`):
<img width="813" height="156" alt="image" src="https://github.com/user-attachments/assets/fc002b6c-65a3-4032-af5b-94a65cf8e1de" />

### perfetto annotations

One could also consider the case of `pthread_create`:
<img width="823" height="244" alt="image" src="https://github.com/user-attachments/assets/8a3396c5-b55a-4cc5-abff-4bc4cb636b5f" />

With `ROCPROFSYS_TRACE_LEGACY`, it would show:
<img width="817" height="211" alt="image" src="https://github.com/user-attachments/assets/7ed38fab-1de5-40af-885a-d4bdc7f26259" />

And now with these changes, we have:
<img width="820" height="222" alt="image" src="https://github.com/user-attachments/assets/c3c9fdf1-8aaf-4bee-a0a8-cbebb31e4ba8" />

## Manual Testing with ROCPD

All of these are done with the `user-api` binary.

### rocprofsys_push_trace_with_args
We see the `source_object` as expected:

<img width="763" height="153" alt="image" src="https://github.com/user-attachments/assets/9d9bab85-40cf-42fc-bc1d-dab60f59d72d" />

A `source_object` with the same name of the binary means that it originates from said binary. This is how dyninst does it.

### arguments

Consider again `numa_alloc`. We can see the `size` now:

<img width="775" height="162" alt="image" src="https://github.com/user-attachments/assets/cecba686-4f5b-4b6f-a196-6951445f76be" />


### annotations

`pthread_create` is as expected:
<img width="755" height="196" alt="image" src="https://github.com/user-attachments/assets/7fb43e9a-e63a-4b4e-9d49-8cd7c8b50e84" />


<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
