### PR TITLE
[rocprofiler-systems] Trim leading space from PMC counter names

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/counters.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/counters.cpp
@@ -152,7 +152,7 @@ counter_storage::counter_storage(const client_data* _tool_data, std::uint64_t _d
 
     {
         constexpr auto _unit = ::perfetto::CounterTrack::Unit::UNIT_COUNT;
-        track_name           = fmt::format(" GPU {} [{}]", _metric_name, device_id);
+        track_name           = fmt::format("GPU {} [{}]", _metric_name, device_id);
         track                = std::make_unique<counter_track_type>(
             ::perfetto::StaticString(track_name.c_str()));
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Remove leading whitespace from the counter name. This was affecting queries to the database.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
The `pmc_info` table stored rocprofiler-sdk counter names with a stray leading space (e.g. " GPU SQ_WAVES [0]" instead of "GPU SQ_WAVES [0]").

The space was introduced when the construction of `track_name` was refactored from
`JOIN(" ", "GPU", _metric_name, "[N]")` to
`fmt::format(" GPU {} [{}]", ...)`. The JOIN form only interleaved spaces between fields, so the new format string gained an unintended literal leading space, which then propagated through `metadata_initialize_counters_pmc` into `rocpd_info_pmc.name` / `.symbol` and through `metadata_initialize_counter_track` into the track metadata.

Drop the leading space from the format string so the value matches the pre-refactor behavior.

End-2-End tests will be added here - https://github.com/ROCm/rocm-systems/pull/6146

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFSYST-471

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- `rocprof-sys-sample -PT --use-rocpd=true -G SQ_WAVES -- ./transpose`
- Open database
- `SELECT name FROM pmc_info where name like "%SQ_WAVES%"`
- Confirm that leading whitespace is removed.

## Test Result

<!-- Briefly summarize test outcomes. -->
There is no longer a leading space.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
