### PR TITLE
[RCCL] mem manager: use requestedHandleType (singular) for HIP compat

### DIFF
--- a/projects/rccl/src/mem_manager.cc
+++ b/projects/rccl/src/mem_manager.cc
@@ -652,7 +652,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
 #endif
     prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
     prop.location.id = entry->cudaDev;
-    prop.requestedHandleTypes = entry->handleType;
+    prop.requestedHandleType = entry->handleType;
 #if defined(__HIP_PLATFORM_AMD__)
     prop.allocFlags.gpuDirectRDMACapable = 1;
 #endif


### PR DESCRIPTION
## Motivation

Older HIP headers expose only requestedHandleType (singular) in hipMemAllocationProp; newer headers also alias requestedHandleTypes via a union. Use the singular form so the debug build compiles on both header versions.

Fixes hipify build error in mem_manager.cc:656 introduced by c158245ad9 ([RCCL] MemResume: mirror ncclCuMemAlloc CUmemAllocationProp init).

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

AICOMNET-223

## Test Result

  | HIP version | Field | Result |
  |---|---|---|
  | HIP 6.4.1 (CI) | `requestedHandleTypes` | ❌ same error as CI |
  | HIP 6.4.1 (CI) | `requestedHandleType` (fix) | ✅ compiles clean |
  | HIP 7.x (local k13-09) | `requestedHandleTypes` | ✅ works (via union) |
  | HIP 7.x (local k13-09) | `requestedHandleType` (fix) | ✅ works |

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
