### PR TITLE
[AILITOOLS-256] Add GTest-style summary to unittest output

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -52,6 +52,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Exposed `amdsmi_get_afids_from_cper` in the Python package**.  
   - The CPER AFID API was implemented but missing from `py-interface/__init__.py`, making it unavailable to Python callers using `from amdsmi import ...`.
 
+- **Python unittest scripts now append a GTest-style summary after test output**.  
+  - All `*_test.py` and `unit_tests.py` scripts print a colored `[PASSED]`/`[SKIPPED]`/`[FAILED]` block after the standard unittest output. Colors are automatically suppressed when output is not a TTY (e.g. file redirection, CI log capture).
+
 - **Corrected the documented unit of `amdsmi_frequencies_t::frequency`**.  
   - The struct comment claimed frequencies were in MHz, but `amdsmi_get_clk_freq()` returns them in Hz. The comment now reads "List of frequencies in Hz".
   - Also removed the incorrect "in MHz" note from the `current` field, which is a frequency index, not a frequency value.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -4,6 +4,13 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ***All information listed below is for reference and subject to change.***
 
+## amd_smi_lib for ROCm 7.14.0
+
+### Changed
+
+- **Python unittest scripts now append a GTest-style summary after test output**.  
+  - All `*_test.py` and `unit_tests.py` scripts print a colored `[PASSED]`/`[SKIPPED]`/`[FAILED]` block after the standard unittest output. Colors are automatically suppressed when output is not a TTY (e.g. file redirection, CI log capture).
+
 ## amd_smi_lib for ROCm 7.13.0
 
 ### Changed

--- a/projects/amdsmi/tests/python_unittest/README.md
+++ b/projects/amdsmi/tests/python_unittest/README.md
@@ -623,7 +623,7 @@ Ran 31 tests in 0.592s
 
 OK
 
-[----------] 31 tests ran.
+[----------] 31 tests ran. (592 ms total)
 [  PASSED  ] 31 tests.
 ~~~
 
@@ -669,7 +669,7 @@ Ran 1 test in 0.453s
 
 OK
 
-[----------] 1 test ran.
+[----------] 1 test ran. (453 ms total)
 [  PASSED  ] 1 test.
 ~~~
 </details>
@@ -689,7 +689,7 @@ Ran 3 tests in 0.001s
 
 OK
 
-[----------] 3 tests ran.
+[----------] 3 tests ran. (1 ms total)
 [  PASSED  ] 3 tests.
 ```
 
@@ -752,7 +752,7 @@ Ran 4 tests in 0.466s
 
 OK
 
-[----------] 4 tests ran.
+[----------] 4 tests ran. (466 ms total)
 [  PASSED  ] 4 tests.
 ```
 

--- a/projects/amdsmi/tests/python_unittest/README.md
+++ b/projects/amdsmi/tests/python_unittest/README.md
@@ -622,6 +622,9 @@ ok
 Ran 31 tests in 0.592s
 
 OK
+
+[----------] 31 tests ran.
+[  PASSED  ] 31 tests.
 ~~~
 
 </details>
@@ -665,6 +668,9 @@ ok
 Ran 1 test in 0.453s
 
 OK
+
+[----------] 1 test ran.
+[  PASSED  ] 1 test.
 ~~~
 </details>
 
@@ -682,6 +688,9 @@ test_parse_bdf (__main__.TestAmdSmiPythonBDF) ... ok
 Ran 3 tests in 0.001s
 
 OK
+
+[----------] 3 tests ran.
+[  PASSED  ] 3 tests.
 ```
 
 ```shell
@@ -742,6 +751,9 @@ ok
 Ran 4 tests in 0.466s
 
 OK
+
+[----------] 4 tests ran.
+[  PASSED  ] 4 tests.
 ```
 
 ```shell

--- a/projects/amdsmi/tests/python_unittest/README.md
+++ b/projects/amdsmi/tests/python_unittest/README.md
@@ -622,7 +622,7 @@ Ran 31 tests in 0.592s
 
 OK
 
-[----------] 31 tests ran.
+[----------] 31 tests ran. (592 ms total)
 [  PASSED  ] 31 tests.
 ~~~
 
@@ -668,7 +668,7 @@ Ran 1 test in 0.453s
 
 OK
 
-[----------] 1 test ran.
+[----------] 1 test ran. (453 ms total)
 [  PASSED  ] 1 test.
 ~~~
 </details>
@@ -688,7 +688,7 @@ Ran 3 tests in 0.001s
 
 OK
 
-[----------] 3 tests ran.
+[----------] 3 tests ran. (1 ms total)
 [  PASSED  ] 3 tests.
 ```
 
@@ -751,7 +751,7 @@ Ran 4 tests in 0.466s
 
 OK
 
-[----------] 4 tests ran.
+[----------] 4 tests ran. (466 ms total)
 [  PASSED  ] 4 tests.
 ```
 

--- a/projects/amdsmi/tests/python_unittest/README.md
+++ b/projects/amdsmi/tests/python_unittest/README.md
@@ -621,6 +621,9 @@ ok
 Ran 31 tests in 0.592s
 
 OK
+
+[----------] 31 tests ran.
+[  PASSED  ] 31 tests.
 ~~~
 
 </details>
@@ -664,6 +667,9 @@ ok
 Ran 1 test in 0.453s
 
 OK
+
+[----------] 1 test ran.
+[  PASSED  ] 1 test.
 ~~~
 </details>
 
@@ -681,6 +687,9 @@ test_parse_bdf (__main__.TestAmdSmiPythonBDF) ... ok
 Ran 3 tests in 0.001s
 
 OK
+
+[----------] 3 tests ran.
+[  PASSED  ] 3 tests.
 ```
 
 ```shell
@@ -741,6 +750,9 @@ ok
 Ran 4 tests in 0.466s
 
 OK
+
+[----------] 4 tests ran.
+[  PASSED  ] 4 tests.
 ```
 
 ```shell

--- a/projects/amdsmi/tests/python_unittest/cli_unit_test.py
+++ b/projects/amdsmi/tests/python_unittest/cli_unit_test.py
@@ -1438,8 +1438,9 @@ if __name__ == "__main__":
     if verbose > common.VERBOSITY_QUIET:
         print("AMD SMI CLI Tests")
 
-    runner = unittest.TextTestRunner(
+    runner = common.GTestSummaryRunner(
         stream=sys.stderr, verbosity=common.make_runner_verbosity(verbose)
     )
+
     unittest.main(testRunner=runner)
     sys.exit(0)

--- a/projects/amdsmi/tests/python_unittest/cli_unit_test.py
+++ b/projects/amdsmi/tests/python_unittest/cli_unit_test.py
@@ -1416,6 +1416,6 @@ if __name__ == "__main__":
         print("Please relaunch with elevated privileges.\n")
         sys.exit(1)
 
-    runner = common.GTestSummaryRunner(verbosity=verbose)
+    runner = common.GTestSummaryRunner(verbosity=common.make_runner_verbosity(verbose))
     unittest.main(testRunner=runner)
     sys.exit(0)

--- a/projects/amdsmi/tests/python_unittest/cli_unit_test.py
+++ b/projects/amdsmi/tests/python_unittest/cli_unit_test.py
@@ -1416,6 +1416,6 @@ if __name__ == "__main__":
         print("Please relaunch with elevated privileges.\n")
         sys.exit(1)
 
-    runner = unittest.TextTestRunner(verbosity=verbose)
+    runner = common.GTestSummaryRunner(verbosity=verbose)
     unittest.main(testRunner=runner)
     sys.exit(0)

--- a/projects/amdsmi/tests/python_unittest/common.py
+++ b/projects/amdsmi/tests/python_unittest/common.py
@@ -305,14 +305,24 @@ class GTestSummaryRunner(unittest.TextTestRunner):
         """Return the GTest-format label for *test*.
 
         ``TestCase.id()`` is the public API for a test's full dotted name
-        (e.g. ``"__main__.ClassName.method_name"``).  We keep only the last
-        two components so the label matches GTest's ``ClassName.method_name``
-        format and does not expose the Python module path.
+        (e.g. ``"__main__.ClassName.method_name"``).  When the id starts with
+        the standard ``__main__.`` prefix we strip it, yielding
+        ``ClassName.method_name`` without risking label collisions between
+        tests from different modules that share a class name.
         """
-        return ".".join(test.id().split(".")[-2:])
+        test_id = test.id()
+        if test_id.startswith("__main__."):
+            return test_id[len("__main__.") :]
+        return test_id
 
     def _color(self, code, text):
-        """Wrap *text* in *code* only when the output stream is a real TTY."""
+        """Wrap *text* in *code* only when colors are appropriate.
+
+        Colors are suppressed when the ``NO_COLOR`` environment variable is set
+        (https://no-color.org/) or when the output stream is not a real TTY.
+        """
+        if os.environ.get("NO_COLOR"):
+            return text
         underlying = getattr(self.stream, "stream", self.stream)
         if hasattr(underlying, "isatty") and underlying.isatty():
             return f"{code}{text}{self._RESET}"
@@ -356,6 +366,13 @@ class GTestSummaryRunner(unittest.TextTestRunner):
                 stream.writeln(self._color(self._RED, f"[  FAILED  ] {self._test_label(t)}"))
             for t, _ in result.errors:
                 stream.writeln(self._color(self._RED, f"[  FAILED  ] {self._test_label(t)}"))
+            # unexpectedSuccesses items are bare TestCase instances (not (test, traceback) tuples).
+            for t in getattr(result, "unexpectedSuccesses", []):
+                stream.writeln(
+                    self._color(
+                        self._RED, f"[  FAILED  ] {self._test_label(t)} (unexpected success)"
+                    )
+                )
         if skipped:
             stream.writeln(
                 self._color(

--- a/projects/amdsmi/tests/python_unittest/common.py
+++ b/projects/amdsmi/tests/python_unittest/common.py
@@ -26,6 +26,7 @@ import json
 import os
 import pathlib
 import sys
+import time
 
 import unittest
 
@@ -329,11 +330,13 @@ class GTestSummaryRunner(unittest.TextTestRunner):
         return text
 
     def run(self, test):
+        start = time.perf_counter()
         result = super().run(test)
-        self._print_gtest_summary(result)
+        elapsed_ms = round((time.perf_counter() - start) * 1000)
+        self._print_gtest_summary(result, elapsed_ms)
         return result
 
-    def _print_gtest_summary(self, result):
+    def _print_gtest_summary(self, result, elapsed_ms):
         """Write the GTest-style pass/skip/fail block to *self.stream*."""
         stream = self.stream  # unittest._WritelnDecorator, supports .writeln()
         skipped = len(result.skipped)
@@ -348,7 +351,7 @@ class GTestSummaryRunner(unittest.TextTestRunner):
         stream.writeln(
             self._color(
                 self._CYAN,
-                f"[----------] {result.testsRun} test{self._plural(result.testsRun)} ran.",
+                f"[----------] {result.testsRun} test{self._plural(result.testsRun)} ran. ({elapsed_ms} ms total)",
             )
         )
         stream.writeln(

--- a/projects/amdsmi/tests/python_unittest/common.py
+++ b/projects/amdsmi/tests/python_unittest/common.py
@@ -261,6 +261,97 @@ def expand_glob_k_arg(caller_globals):
         break
 
 
+class GTestSummaryRunner(unittest.TextTestRunner):
+    """TextTestRunner that appends a GTest-style pass/skip/fail summary.
+
+    After the standard unittest output, prints a colored block like::
+
+        [----------] 40 tests ran.
+        [  PASSED  ] 39 tests.
+        [  SKIPPED ] 1 test, listed below:
+        [  SKIPPED ] TestClass.test_method_name
+
+    Colors mirror GTest: green = PASSED, yellow = SKIPPED, red = FAILED,
+    cyan = separator.  Colors are suppressed when the stream is not a TTY.
+    """
+
+    # ANSI color codes match GTest's scheme:
+    #   cyan   = separator line ([----------])
+    #   green  = PASSED
+    #   yellow = SKIPPED
+    #   red    = FAILED
+    # Colors are automatically suppressed when the output stream is not a TTY
+    # (e.g. when piped to a file or CI log capture), so file-based runners such
+    # as those in perf_tests.py will never receive ANSI escape codes in their logs.
+    _CYAN = "\033[36m"
+    _GREEN = "\033[32m"
+    _YELLOW = "\033[33m"
+    _RED = "\033[31m"
+    _RESET = "\033[0m"
+
+    def _color(self, code, text):
+        """Wrap *text* in *code* only when the output stream is a real TTY."""
+        underlying = getattr(self.stream, "stream", self.stream)
+        if hasattr(underlying, "isatty") and underlying.isatty():
+            return f"{code}{text}{self._RESET}"
+        return text
+
+    def run(self, test):
+        result = super().run(test)
+        self._print_gtest_summary(result)
+        return result
+
+    def _print_gtest_summary(self, result):
+        stream = self.stream  # unittest._WritelnDecorator, supports .writeln()
+        skipped = len(result.skipped)
+        failures = len(result.failures) + len(result.errors)
+        passed = result.testsRun - skipped - failures
+
+        stream.writeln()
+        stream.writeln(
+            self._color(
+                self._CYAN,
+                f"[----------] {result.testsRun} test{'s' if result.testsRun != 1 else ''} ran.",
+            )
+        )
+        stream.writeln(
+            self._color(self._GREEN, f"[  PASSED  ] {passed} test{'s' if passed != 1 else ''}.")
+        )
+        if failures:
+            stream.writeln(
+                self._color(
+                    self._RED,
+                    f"[  FAILED  ] {failures} test{'s' if failures != 1 else ''}, listed below:",
+                )
+            )
+            for t, _ in result.failures:
+                stream.writeln(
+                    self._color(
+                        self._RED, f"[  FAILED  ] {t.__class__.__name__}.{t._testMethodName}"
+                    )
+                )
+            for t, _ in result.errors:
+                stream.writeln(
+                    self._color(
+                        self._RED, f"[  FAILED  ] {t.__class__.__name__}.{t._testMethodName}"
+                    )
+                )
+        if skipped:
+            stream.writeln(
+                self._color(
+                    self._YELLOW,
+                    f"[  SKIPPED ] {skipped} test{'s' if skipped != 1 else ''}, listed below:",
+                )
+            )
+            for t, _ in result.skipped:
+                stream.writeln(
+                    self._color(
+                        self._YELLOW, f"[  SKIPPED ] {t.__class__.__name__}.{t._testMethodName}"
+                    )
+                )
+        stream.writeln()
+
+
 def has_gpu_od_interface(bdf):
     """Check if a GPU has the gpu_od sysfs interface.
 

--- a/projects/amdsmi/tests/python_unittest/common.py
+++ b/projects/amdsmi/tests/python_unittest/common.py
@@ -271,23 +271,45 @@ class GTestSummaryRunner(unittest.TextTestRunner):
         [  SKIPPED ] 1 test, listed below:
         [  SKIPPED ] TestClass.test_method_name
 
-    Colors mirror GTest: green = PASSED, yellow = SKIPPED, red = FAILED,
-    cyan = separator.  Colors are suppressed when the stream is not a TTY.
+    Color scheme mirrors GTest:
+        cyan   = separator line ([----------])
+        green  = PASSED
+        yellow = SKIPPED
+        red    = FAILED
+
+    Colors are automatically suppressed when the output stream is not a TTY
+    (e.g. when piped to a file or CI log capture), so file-based runners such
+    as those in perf_tests.py will never receive ANSI escape codes in their logs.
+
+    Example::
+
+        runner = common.GTestSummaryRunner(verbosity=common.make_runner_verbosity(verbose))
+        unittest.main(testRunner=runner)
+
+        # To redirect output to stderr (e.g. when stdout is used for data):
+        runner = common.GTestSummaryRunner(stream=sys.stderr, verbosity=common.make_runner_verbosity(verbose))
     """
 
-    # ANSI color codes match GTest's scheme:
-    #   cyan   = separator line ([----------])
-    #   green  = PASSED
-    #   yellow = SKIPPED
-    #   red    = FAILED
-    # Colors are automatically suppressed when the output stream is not a TTY
-    # (e.g. when piped to a file or CI log capture), so file-based runners such
-    # as those in perf_tests.py will never receive ANSI escape codes in their logs.
     _CYAN = "\033[36m"
     _GREEN = "\033[32m"
     _YELLOW = "\033[33m"
     _RED = "\033[31m"
     _RESET = "\033[0m"
+
+    @staticmethod
+    def _plural(n):
+        return "s" if n != 1 else ""
+
+    @staticmethod
+    def _test_label(test):
+        """Return the GTest-format label for *test*.
+
+        ``TestCase.id()`` is the public API for a test's full dotted name
+        (e.g. ``"__main__.ClassName.method_name"``).  We keep only the last
+        two components so the label matches GTest's ``ClassName.method_name``
+        format and does not expose the Python module path.
+        """
+        return ".".join(test.id().split(".")[-2:])
 
     def _color(self, code, text):
         """Wrap *text* in *code* only when the output stream is a real TTY."""
@@ -302,53 +324,47 @@ class GTestSummaryRunner(unittest.TextTestRunner):
         return result
 
     def _print_gtest_summary(self, result):
+        """Write the GTest-style pass/skip/fail block to *self.stream*."""
         stream = self.stream  # unittest._WritelnDecorator, supports .writeln()
         skipped = len(result.skipped)
-        failures = len(result.failures) + len(result.errors)
+        # unexpectedSuccesses are tests marked @expectedFailure that passed instead.
+        # They cause wasSuccessful() to return False, so count them as failures so
+        # the summary accurately reflects the overall run status.
+        unexpectedSuccesses = len(getattr(result, "unexpectedSuccesses", []))
+        failures = len(result.failures) + len(result.errors) + unexpectedSuccesses
         passed = result.testsRun - skipped - failures
 
         stream.writeln()
         stream.writeln(
             self._color(
                 self._CYAN,
-                f"[----------] {result.testsRun} test{'s' if result.testsRun != 1 else ''} ran.",
+                f"[----------] {result.testsRun} test{self._plural(result.testsRun)} ran.",
             )
         )
         stream.writeln(
-            self._color(self._GREEN, f"[  PASSED  ] {passed} test{'s' if passed != 1 else ''}.")
+            self._color(self._GREEN, f"[  PASSED  ] {passed} test{self._plural(passed)}.")
         )
+
         if failures:
             stream.writeln(
                 self._color(
                     self._RED,
-                    f"[  FAILED  ] {failures} test{'s' if failures != 1 else ''}, listed below:",
+                    f"[  FAILED  ] {failures} test{self._plural(failures)}, listed below:",
                 )
             )
             for t, _ in result.failures:
-                stream.writeln(
-                    self._color(
-                        self._RED, f"[  FAILED  ] {t.__class__.__name__}.{t._testMethodName}"
-                    )
-                )
+                stream.writeln(self._color(self._RED, f"[  FAILED  ] {self._test_label(t)}"))
             for t, _ in result.errors:
-                stream.writeln(
-                    self._color(
-                        self._RED, f"[  FAILED  ] {t.__class__.__name__}.{t._testMethodName}"
-                    )
-                )
+                stream.writeln(self._color(self._RED, f"[  FAILED  ] {self._test_label(t)}"))
         if skipped:
             stream.writeln(
                 self._color(
                     self._YELLOW,
-                    f"[  SKIPPED ] {skipped} test{'s' if skipped != 1 else ''}, listed below:",
+                    f"[  SKIPPED ] {skipped} test{self._plural(skipped)}, listed below:",
                 )
             )
             for t, _ in result.skipped:
-                stream.writeln(
-                    self._color(
-                        self._YELLOW, f"[  SKIPPED ] {t.__class__.__name__}.{t._testMethodName}"
-                    )
-                )
+                stream.writeln(self._color(self._YELLOW, f"[  SKIPPED ] {self._test_label(t)}"))
         stream.writeln()
 
 

--- a/projects/amdsmi/tests/python_unittest/common.py
+++ b/projects/amdsmi/tests/python_unittest/common.py
@@ -182,14 +182,24 @@ class GTestSummaryRunner(unittest.TextTestRunner):
         """Return the GTest-format label for *test*.
 
         ``TestCase.id()`` is the public API for a test's full dotted name
-        (e.g. ``"__main__.ClassName.method_name"``).  We keep only the last
-        two components so the label matches GTest's ``ClassName.method_name``
-        format and does not expose the Python module path.
+        (e.g. ``"__main__.ClassName.method_name"``).  When the id starts with
+        the standard ``__main__.`` prefix we strip it, yielding
+        ``ClassName.method_name`` without risking label collisions between
+        tests from different modules that share a class name.
         """
-        return ".".join(test.id().split(".")[-2:])
+        test_id = test.id()
+        if test_id.startswith("__main__."):
+            return test_id[len("__main__.") :]
+        return test_id
 
     def _color(self, code, text):
-        """Wrap *text* in *code* only when the output stream is a real TTY."""
+        """Wrap *text* in *code* only when colors are appropriate.
+
+        Colors are suppressed when the ``NO_COLOR`` environment variable is set
+        (https://no-color.org/) or when the output stream is not a real TTY.
+        """
+        if os.environ.get("NO_COLOR"):
+            return text
         underlying = getattr(self.stream, "stream", self.stream)
         if hasattr(underlying, "isatty") and underlying.isatty():
             return f"{code}{text}{self._RESET}"
@@ -233,6 +243,13 @@ class GTestSummaryRunner(unittest.TextTestRunner):
                 stream.writeln(self._color(self._RED, f"[  FAILED  ] {self._test_label(t)}"))
             for t, _ in result.errors:
                 stream.writeln(self._color(self._RED, f"[  FAILED  ] {self._test_label(t)}"))
+            # unexpectedSuccesses items are bare TestCase instances (not (test, traceback) tuples).
+            for t in getattr(result, "unexpectedSuccesses", []):
+                stream.writeln(
+                    self._color(
+                        self._RED, f"[  FAILED  ] {self._test_label(t)} (unexpected success)"
+                    )
+                )
         if skipped:
             stream.writeln(
                 self._color(

--- a/projects/amdsmi/tests/python_unittest/common.py
+++ b/projects/amdsmi/tests/python_unittest/common.py
@@ -24,6 +24,7 @@ import json
 import os
 import pathlib
 import sys
+import time
 
 import unittest
 
@@ -206,11 +207,13 @@ class GTestSummaryRunner(unittest.TextTestRunner):
         return text
 
     def run(self, test):
+        start = time.perf_counter()
         result = super().run(test)
-        self._print_gtest_summary(result)
+        elapsed_ms = round((time.perf_counter() - start) * 1000)
+        self._print_gtest_summary(result, elapsed_ms)
         return result
 
-    def _print_gtest_summary(self, result):
+    def _print_gtest_summary(self, result, elapsed_ms):
         """Write the GTest-style pass/skip/fail block to *self.stream*."""
         stream = self.stream  # unittest._WritelnDecorator, supports .writeln()
         skipped = len(result.skipped)
@@ -225,7 +228,7 @@ class GTestSummaryRunner(unittest.TextTestRunner):
         stream.writeln(
             self._color(
                 self._CYAN,
-                f"[----------] {result.testsRun} test{self._plural(result.testsRun)} ran.",
+                f"[----------] {result.testsRun} test{self._plural(result.testsRun)} ran. ({elapsed_ms} ms total)",
             )
         )
         stream.writeln(

--- a/projects/amdsmi/tests/python_unittest/common.py
+++ b/projects/amdsmi/tests/python_unittest/common.py
@@ -138,6 +138,97 @@ def expand_glob_k_arg(caller_globals):
         break
 
 
+class GTestSummaryRunner(unittest.TextTestRunner):
+    """TextTestRunner that appends a GTest-style pass/skip/fail summary.
+
+    After the standard unittest output, prints a colored block like::
+
+        [----------] 40 tests ran.
+        [  PASSED  ] 39 tests.
+        [  SKIPPED ] 1 test, listed below:
+        [  SKIPPED ] TestClass.test_method_name
+
+    Colors mirror GTest: green = PASSED, yellow = SKIPPED, red = FAILED,
+    cyan = separator.  Colors are suppressed when the stream is not a TTY.
+    """
+
+    # ANSI color codes match GTest's scheme:
+    #   cyan   = separator line ([----------])
+    #   green  = PASSED
+    #   yellow = SKIPPED
+    #   red    = FAILED
+    # Colors are automatically suppressed when the output stream is not a TTY
+    # (e.g. when piped to a file or CI log capture), so file-based runners such
+    # as those in perf_tests.py will never receive ANSI escape codes in their logs.
+    _CYAN = "\033[36m"
+    _GREEN = "\033[32m"
+    _YELLOW = "\033[33m"
+    _RED = "\033[31m"
+    _RESET = "\033[0m"
+
+    def _color(self, code, text):
+        """Wrap *text* in *code* only when the output stream is a real TTY."""
+        underlying = getattr(self.stream, "stream", self.stream)
+        if hasattr(underlying, "isatty") and underlying.isatty():
+            return f"{code}{text}{self._RESET}"
+        return text
+
+    def run(self, test):
+        result = super().run(test)
+        self._print_gtest_summary(result)
+        return result
+
+    def _print_gtest_summary(self, result):
+        stream = self.stream  # unittest._WritelnDecorator, supports .writeln()
+        skipped = len(result.skipped)
+        failures = len(result.failures) + len(result.errors)
+        passed = result.testsRun - skipped - failures
+
+        stream.writeln()
+        stream.writeln(
+            self._color(
+                self._CYAN,
+                f"[----------] {result.testsRun} test{'s' if result.testsRun != 1 else ''} ran.",
+            )
+        )
+        stream.writeln(
+            self._color(self._GREEN, f"[  PASSED  ] {passed} test{'s' if passed != 1 else ''}.")
+        )
+        if failures:
+            stream.writeln(
+                self._color(
+                    self._RED,
+                    f"[  FAILED  ] {failures} test{'s' if failures != 1 else ''}, listed below:",
+                )
+            )
+            for t, _ in result.failures:
+                stream.writeln(
+                    self._color(
+                        self._RED, f"[  FAILED  ] {t.__class__.__name__}.{t._testMethodName}"
+                    )
+                )
+            for t, _ in result.errors:
+                stream.writeln(
+                    self._color(
+                        self._RED, f"[  FAILED  ] {t.__class__.__name__}.{t._testMethodName}"
+                    )
+                )
+        if skipped:
+            stream.writeln(
+                self._color(
+                    self._YELLOW,
+                    f"[  SKIPPED ] {skipped} test{'s' if skipped != 1 else ''}, listed below:",
+                )
+            )
+            for t, _ in result.skipped:
+                stream.writeln(
+                    self._color(
+                        self._YELLOW, f"[  SKIPPED ] {t.__class__.__name__}.{t._testMethodName}"
+                    )
+                )
+        stream.writeln()
+
+
 def has_gpu_od_interface(bdf):
     """Check if a GPU has the gpu_od sysfs interface.
 

--- a/projects/amdsmi/tests/python_unittest/common.py
+++ b/projects/amdsmi/tests/python_unittest/common.py
@@ -148,23 +148,45 @@ class GTestSummaryRunner(unittest.TextTestRunner):
         [  SKIPPED ] 1 test, listed below:
         [  SKIPPED ] TestClass.test_method_name
 
-    Colors mirror GTest: green = PASSED, yellow = SKIPPED, red = FAILED,
-    cyan = separator.  Colors are suppressed when the stream is not a TTY.
+    Color scheme mirrors GTest:
+        cyan   = separator line ([----------])
+        green  = PASSED
+        yellow = SKIPPED
+        red    = FAILED
+
+    Colors are automatically suppressed when the output stream is not a TTY
+    (e.g. when piped to a file or CI log capture), so file-based runners such
+    as those in perf_tests.py will never receive ANSI escape codes in their logs.
+
+    Example::
+
+        runner = common.GTestSummaryRunner(verbosity=common.make_runner_verbosity(verbose))
+        unittest.main(testRunner=runner)
+
+        # To redirect output to stderr (e.g. when stdout is used for data):
+        runner = common.GTestSummaryRunner(stream=sys.stderr, verbosity=common.make_runner_verbosity(verbose))
     """
 
-    # ANSI color codes match GTest's scheme:
-    #   cyan   = separator line ([----------])
-    #   green  = PASSED
-    #   yellow = SKIPPED
-    #   red    = FAILED
-    # Colors are automatically suppressed when the output stream is not a TTY
-    # (e.g. when piped to a file or CI log capture), so file-based runners such
-    # as those in perf_tests.py will never receive ANSI escape codes in their logs.
     _CYAN = "\033[36m"
     _GREEN = "\033[32m"
     _YELLOW = "\033[33m"
     _RED = "\033[31m"
     _RESET = "\033[0m"
+
+    @staticmethod
+    def _plural(n):
+        return "s" if n != 1 else ""
+
+    @staticmethod
+    def _test_label(test):
+        """Return the GTest-format label for *test*.
+
+        ``TestCase.id()`` is the public API for a test's full dotted name
+        (e.g. ``"__main__.ClassName.method_name"``).  We keep only the last
+        two components so the label matches GTest's ``ClassName.method_name``
+        format and does not expose the Python module path.
+        """
+        return ".".join(test.id().split(".")[-2:])
 
     def _color(self, code, text):
         """Wrap *text* in *code* only when the output stream is a real TTY."""
@@ -179,53 +201,47 @@ class GTestSummaryRunner(unittest.TextTestRunner):
         return result
 
     def _print_gtest_summary(self, result):
+        """Write the GTest-style pass/skip/fail block to *self.stream*."""
         stream = self.stream  # unittest._WritelnDecorator, supports .writeln()
         skipped = len(result.skipped)
-        failures = len(result.failures) + len(result.errors)
+        # unexpectedSuccesses are tests marked @expectedFailure that passed instead.
+        # They cause wasSuccessful() to return False, so count them as failures so
+        # the summary accurately reflects the overall run status.
+        unexpectedSuccesses = len(getattr(result, "unexpectedSuccesses", []))
+        failures = len(result.failures) + len(result.errors) + unexpectedSuccesses
         passed = result.testsRun - skipped - failures
 
         stream.writeln()
         stream.writeln(
             self._color(
                 self._CYAN,
-                f"[----------] {result.testsRun} test{'s' if result.testsRun != 1 else ''} ran.",
+                f"[----------] {result.testsRun} test{self._plural(result.testsRun)} ran.",
             )
         )
         stream.writeln(
-            self._color(self._GREEN, f"[  PASSED  ] {passed} test{'s' if passed != 1 else ''}.")
+            self._color(self._GREEN, f"[  PASSED  ] {passed} test{self._plural(passed)}.")
         )
+
         if failures:
             stream.writeln(
                 self._color(
                     self._RED,
-                    f"[  FAILED  ] {failures} test{'s' if failures != 1 else ''}, listed below:",
+                    f"[  FAILED  ] {failures} test{self._plural(failures)}, listed below:",
                 )
             )
             for t, _ in result.failures:
-                stream.writeln(
-                    self._color(
-                        self._RED, f"[  FAILED  ] {t.__class__.__name__}.{t._testMethodName}"
-                    )
-                )
+                stream.writeln(self._color(self._RED, f"[  FAILED  ] {self._test_label(t)}"))
             for t, _ in result.errors:
-                stream.writeln(
-                    self._color(
-                        self._RED, f"[  FAILED  ] {t.__class__.__name__}.{t._testMethodName}"
-                    )
-                )
+                stream.writeln(self._color(self._RED, f"[  FAILED  ] {self._test_label(t)}"))
         if skipped:
             stream.writeln(
                 self._color(
                     self._YELLOW,
-                    f"[  SKIPPED ] {skipped} test{'s' if skipped != 1 else ''}, listed below:",
+                    f"[  SKIPPED ] {skipped} test{self._plural(skipped)}, listed below:",
                 )
             )
             for t, _ in result.skipped:
-                stream.writeln(
-                    self._color(
-                        self._YELLOW, f"[  SKIPPED ] {t.__class__.__name__}.{t._testMethodName}"
-                    )
-                )
+                stream.writeln(self._color(self._YELLOW, f"[  SKIPPED ] {self._test_label(t)}"))
         stream.writeln()
 
 

--- a/projects/amdsmi/tests/python_unittest/integration_test.py
+++ b/projects/amdsmi/tests/python_unittest/integration_test.py
@@ -1604,7 +1604,7 @@ if __name__ == "__main__":
     #       self.assertEqual(e.get_error_code(), amdsmi.AmdSmiStatus.AMDSMI_STATUS_NOT_SUPPORTED)
     # ---------------------------------------------------------------------------
 
-    runner = unittest.TextTestRunner(
+    runner = common.GTestSummaryRunner(
         stream=sys.stderr, verbosity=common.make_runner_verbosity(verbose)
     )
 

--- a/projects/amdsmi/tests/python_unittest/integration_test.py
+++ b/projects/amdsmi/tests/python_unittest/integration_test.py
@@ -1612,7 +1612,7 @@ if __name__ == "__main__":
     #       self.assertEqual(e.get_error_code(), amdsmi.AmdSmiStatus.AMDSMI_STATUS_NOT_SUPPORTED)
     # ---------------------------------------------------------------------------
 
-    runner = unittest.TextTestRunner(verbosity=common.make_runner_verbosity(verbose))
+    runner = common.GTestSummaryRunner(verbosity=common.make_runner_verbosity(verbose))
 
     common.expand_glob_k_arg(globals())
     unittest.main(testRunner=runner)

--- a/projects/amdsmi/tests/python_unittest/unit_tests.py
+++ b/projects/amdsmi/tests/python_unittest/unit_tests.py
@@ -1809,7 +1809,7 @@ if __name__ == "__main__":
     #       self.assertEqual(e.get_error_code(), amdsmi.AmdSmiStatus.AMDSMI_STATUS_NOT_SUPPORTED)
     # ---------------------------------------------------------------------------
 
-    runner = unittest.TextTestRunner(
+    runner = common.GTestSummaryRunner(
         stream=sys.stderr, verbosity=common.make_runner_verbosity(verbose)
     )
     common.expand_glob_k_arg(globals())

--- a/projects/amdsmi/tests/python_unittest/unit_tests.py
+++ b/projects/amdsmi/tests/python_unittest/unit_tests.py
@@ -1817,7 +1817,7 @@ if __name__ == "__main__":
     #       self.assertEqual(e.get_error_code(), amdsmi.AmdSmiStatus.AMDSMI_STATUS_NOT_SUPPORTED)
     # ---------------------------------------------------------------------------
 
-    runner = unittest.TextTestRunner(
+    runner = common.GTestSummaryRunner(
         stream=sys.stderr, verbosity=common.make_runner_verbosity(verbose)
     )
     common.expand_glob_k_arg(globals())


### PR DESCRIPTION
Add GTestSummaryRunner to common.py — a TextTestRunner subclass that
appends a GTest-style summary block after the standard unittest output:

    [----------] 40 tests ran.
    [  PASSED  ] 39 tests.
    [  SKIPPED ] 1 test, listed below:
    [  SKIPPED ] TestClass.test_method_name

Colors match GTest's scheme (cyan separator, green PASSED, yellow
SKIPPED, red FAILED) and are automatically suppressed when the output
stream is not a TTY, so CI log capture and file-based runners like those
in perf_tests.py are unaffected.

Switch unit_tests.py, integration_test.py, and cli_unit_test.py to use
GTestSummaryRunner in place of unittest.TextTestRunner.

Signed-off-by: Charis Poag <charis.poag@amd.com>
Assisted-by: GitHub Copilot:claude-sonnet-4-6


-------
### Gtest Example Output:
<img width="776" height="232" alt="image" src="https://github.com/user-attachments/assets/58324ec6-1458-40a2-8f73-66258616cd8b" />


### Updated Python Unittest Output:
<img width="1229" height="773" alt="image" src="https://github.com/user-attachments/assets/5614f139-ecce-4510-9c63-722ec996fdf7" />

