### PR TITLE
[clr] Fix hostcall listener thread crash with Asan

### DIFF
--- a/projects/clr/rocclr/os/os_posix.cpp
+++ b/projects/clr/rocclr/os/os_posix.cpp
@@ -374,6 +374,7 @@ bool Os::isThreadAlive(const Thread& thread) {
 static size_t tlsSize = 0;
 
 // Try to guess the size of TLS (plus some frames)
+__attribute__((no_sanitize("address"), noinline))
 void* guessTlsSizeThread(void* param) {
   address stackBase;
   address currentFrame;


### PR DESCRIPTION
When running with Asan, the heuristic guessTlsSize doesn't work because the stack might be in a different memory location. This change disables Asan for this function which makes sure that the thread stack base is in the right address to compute the TLS size using the heuristic.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
