### PR TITLE
[rocprofv3] Modify midpoint interpolation to fix negative duration bug in pftrace

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
@@ -677,17 +677,18 @@ write_perfetto(
                             (*it)->end_timestamp     = mid;
                             (*next)->start_timestamp = mid;
 
-                            // The modified start may have pushed *next rightward in sort
-                            // order. Bubble the pointer forward to restore sorted order so
-                            // subsequent iterations see correct neighbors.
-                            auto bubble_it = next;
-                            while(std::next(bubble_it) != qitr.second.end() &&
-                                  (*bubble_it)->start_timestamp >
-                                      (*std::next(bubble_it))->start_timestamp)
-                            {
-                                std::iter_swap(bubble_it, std::next(bubble_it));
-                                ++bubble_it;
-                            }
+                            // The modified start may have pushed *next behind multiple later
+                            // records. Find the correct insertion point and rotate in one
+                            // shot so subsequent iterations see correct neighbors.
+                            auto insert_it =
+                                std::upper_bound(std::next(next),
+                                                 qitr.second.end(),
+                                                 (*next)->start_timestamp,
+                                                 [](rocprofiler_timestamp_t lhs, const auto* rhs) {
+                                                     return lhs < rhs->start_timestamp;
+                                                 });
+                            if(insert_it != std::next(next))
+                                std::rotate(next, std::next(next), insert_it);
                         }
 
                         if(demangled.find(name) == demangled.end())

--- a/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
@@ -676,6 +676,18 @@ write_perfetto(
                                 mid);
                             (*it)->end_timestamp     = mid;
                             (*next)->start_timestamp = mid;
+
+                            // The modified start may have pushed *next rightward in sort
+                            // order. Bubble the pointer forward to restore sorted order so
+                            // subsequent iterations see correct neighbors.
+                            auto bubble_it = next;
+                            while(std::next(bubble_it) != qitr.second.end() &&
+                                  (*bubble_it)->start_timestamp >
+                                      (*std::next(bubble_it))->start_timestamp)
+                            {
+                                std::iter_swap(bubble_it, std::next(bubble_it));
+                                ++bubble_it;
+                            }
                         }
 
                         if(demangled.find(name) == demangled.end())

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
@@ -732,6 +732,18 @@ write_perfetto(
 
                         current_it->end = new_current_end;
                         next_it->start  = new_next_start;
+
+                        // The modified start may have pushed next_sample_it's effective
+                        // midpoint rightward. Update the stored sort key and bubble the
+                        // element forward so subsequent iterations see correct order.
+                        next_sample_it->timestamp = (new_next_start + next_it->end) / 2;
+                        auto bubble_it            = next_sample_it;
+                        while(std::next(bubble_it) != group_data.end() &&
+                              bubble_it->timestamp > std::next(bubble_it)->timestamp)
+                        {
+                            std::iter_swap(bubble_it, std::next(bubble_it));
+                            ++bubble_it;
+                        }
                     }
                 }
             }

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
@@ -734,15 +734,21 @@ write_perfetto(
                         next_it->start  = new_next_start;
 
                         // The modified start may have pushed next_sample_it's effective
-                        // midpoint rightward. Update the stored sort key and bubble the
-                        // element forward so subsequent iterations see correct order.
+                        // midpoint rightward. Update the stored sort key and stably
+                        // reinsert the element so subsequent iterations see the correct
+                        // temporal order, including cases where it must move behind
+                        // multiple later slices.
                         next_sample_it->timestamp = (new_next_start + next_it->end) / 2;
-                        auto bubble_it            = next_sample_it;
-                        while(std::next(bubble_it) != group_data.end() &&
-                              bubble_it->timestamp > std::next(bubble_it)->timestamp)
+                        auto insert_it            = std::upper_bound(
+                            std::next(next_sample_it),
+                            group_data.end(),
+                            next_sample_it->timestamp,
+                            [](rocprofiler_timestamp_t lhs, const kernel_dispatch_data& rhs) {
+                                return lhs < rhs.timestamp;
+                            });
+                        if(insert_it != std::next(next_sample_it))
                         {
-                            std::iter_swap(bubble_it, std::next(bubble_it));
-                            ++bubble_it;
+                            std::rotate(next_sample_it, std::next(next_sample_it), insert_it);
                         }
                     }
                 }


### PR DESCRIPTION
## Motivation

The current implementation of midpoint interpolation in both the rocpd and direct perfetto generation has a bug where kernel duration can become negative. This bug occurs since modified timestamp slices are not "re-sorted", leading to negative timestamps in some rare instances.

## Technical Details

Added code where, after modifying the start timestamp of a time slice of a kernel, we check subsequent time slices. If the next time slices now have a start time before the new start timestamp of the modified kernel time slice, we swap positions of these new kernel slices until the kernels are sorted again.

Worst case, this "re-sort" is O(n), turning the midpoint interpolation as a whole to worst case O(n^2). That said, I believe that in most practical applications there will be very little kernel overlaps and we should expect little overhead with this addition. I can run some benchmarks if we want to be sure or can modify this PR if the worst case is a real concern.

## JIRA ID

ROCM-25326

## Test Plan


## Test Result

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
