### PR TITLE
[RCCL] Fix perf regression due to hipEventRecord

### DIFF
--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -1812,11 +1812,13 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
       NCCLCHECKGOTO(ncclStreamWaitStream(launchStream, deviceStream, comm->sharedRes->scratchEvent), result, failure);
     } else if (comm->lastStreamValid && comm->lastStream != launchStream) {
       // Stream changed from last call. The new launchStream has no implicit edge to the
-      // previous kernel's completion; install a direct event-based dependency on doneEvent
-      // (which the fast/slow path now records after every kernel launch). This bypasses
-      // deviceStream entirely so we don't depend on Finish-side advance to keep deviceStream
-      // fresh — the fast path skips that advance, which is why the deviceStream-mediated
-      // sync hangs in this scenario.
+      // previous kernel's completion; install a direct event-based dependency on doneEvent.
+      // Record lazily here on lastStream — HIP's per-stream FIFO guarantees the record
+      // sequences after the prior cuLaunchKernel — then wait on it from launchStream.
+      // Recording only on detected stream change (instead of after every ncclLaunchKernel)
+      // avoids a per-launch HIP runtime cost. Bypasses deviceStream, which the fast path
+      // leaves stale by skipping Finish-side advance.
+      CUDACHECKGOTO(hipEventRecord(comm->doneEvent, comm->lastStream), result, failure);
       CUDACHECKGOTO(hipStreamWaitEvent(launchStream, comm->doneEvent, 0), result, failure);
     }
 
@@ -1915,11 +1917,9 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
   if (planner->numStreams == 1 && !plan->persistent) {
     latency_profiler::collTraceRecordStartEvent(comm, launchStream, event.get());
     CUCHECKGOTO(cuLaunchKernel(fn, grid.x, grid.y, grid.z, block.x, block.y, block.z, smem, launchStream, nullptr, extra), ret, do_return);
-    // Record doneEvent so a future ncclLaunchPrepare on a different stream can wait on it.
-    // Cheap (one event record per fast-path launch) and load-bearing for stream-change correctness.
-    CUDACHECKGOTO(hipEventRecord(comm->doneEvent, launchStream), ret, do_return);
-    // Update bookkeeping only after both launch and event-record succeed, so a partial
-    // failure does not leave lastStreamValid asserting a doneEvent that was never recorded.
+    // doneEvent is recorded lazily by ncclLaunchPrepare on a detected stream change; no
+    // per-launch hipEventRecord is needed here. lastStream/lastStreamValid bookkeeping is
+    // still required so the next call's ncclLaunchPrepare can detect that change.
     comm->lastStream = launchStream;
     comm->lastStreamValid = true;
     latency_profiler::collTraceRecordEndEvent(comm, plan, launchStream, std::move(event));
@@ -2008,10 +2008,8 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
   latency_profiler::collTraceRecordStartEvent(comm, launchStream, event.get());
   CUCHECKGOTO(cuLaunchKernel(fn, grid.x, grid.y, grid.z, block.x, block.y, block.z, smem, launchStream, nullptr, extra), ret, do_return);
   latency_profiler::collTraceRecordEndEvent(comm, plan, launchStream, std::move(event));
-  // Mirror fast-path bookkeeping so the next ncclLaunchPrepare can detect stream-change
-  // and find a fresh doneEvent to wait on. Update only after the event-record succeeds
-  // so a partial failure does not leave lastStreamValid asserting an unrecorded event.
-  CUDACHECKGOTO(hipEventRecord(comm->doneEvent, launchStream), ret, do_return);
+  // Mirror fast-path bookkeeping so the next ncclLaunchPrepare can detect stream-change.
+  // doneEvent is recorded lazily by ncclLaunchPrepare in the stream-change branch.
   comm->lastStream = launchStream;
   comm->lastStreamValid = true;
 


### PR DESCRIPTION
## Motivation

PR #5800 added a `hipEventRecord(comm->doneEvent, launchStream)` after every `cuLaunchKernel` in both fast and slow paths of `ncclLaunchKernel` to fix a stream-change deadlock. The record costs ~2.5–3 μs of host-side HIP runtime per call and runs on every collective, even when no stream change ever happens.

## Technical Details

Move the `hipEventRecord` from `ncclLaunchKernel` into `ncclLaunchPrepare's` existing stream-change else if branch, recorded on `comm->lastStream` immediately before the `hipStreamWaitEvent` on `launchStream`.

## JIRA ID

AICOMRCCL-1048

## Test Plan

Validate against:
- Unit tests on CI
- Work loads for which the change was made -  ROCM-21756, ROCM-24157

## Test Result

- CI is green
- @thananon validated the fix on two PyTorch training workloads (ROCM-21756, ROCM-24157)
- Verified perf:

Before
<img width="1999" height="665" alt="image" src="https://github.com/user-attachments/assets/ad9d087a-44ae-4f01-b767-0d3c9e29a7fe" />

After
<img width="2001" height="668" alt="image" src="https://github.com/user-attachments/assets/93e7983e-8ad3-401c-9f7d-346dde120d97" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
