### PR TITLE
[rocdbgapi] Replace utils::narrow with static_cast to avoid fatal error while saving the core

### DIFF
--- a/projects/rocdbgapi/src/os_driver_kfd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kfd.cpp
@@ -1957,7 +1957,7 @@ kfd_driver_t::xfer_global_memory_partial (global_address_t address, void *read,
   if (address > std::numeric_limits<off_t>::max ())
     return AMD_DBGAPI_STATUS_ERROR_MEMORY_ACCESS;
 
-  auto offset = utils::narrow<off_t> (address);
+  auto offset = static_cast<off_t> (address);
   ssize_t ret = read != nullptr
                   ? pread (*m_proc_mem_fd, read, *size, offset)
                   : pwrite (*m_proc_mem_fd, write, *size, offset);


### PR DESCRIPTION
ROCdbgapi can report a fatal error and print the stack while encountering a negative kernel space address of 0xffffffffff600000 while dumping the core. This is a cosmetic issue and doesn't break anything. The fix will prevent the error from occurring.