### PR TITLE
[rocdecode] - propagate rocm_sysdeps/lib DT_RPATH to consumers on TheRock

### DIFF
--- a/projects/rocdecode/cmake_modules/rocdecode-config.cmake.in
+++ b/projects/rocdecode/cmake_modules/rocdecode-config.cmake.in
@@ -25,6 +25,14 @@ set_and_check(@PROJECT_NAME@_LIBRARIES "@PACKAGE_LIB_INSTALL_DIR@/lib@PROJECT_NA
 if(NOT TARGET @PROJECT_NAME@::@PROJECT_NAME@)
   add_library(@PROJECT_NAME@::@PROJECT_NAME@ INTERFACE IMPORTED)
   set_target_properties(@PROJECT_NAME@::@PROJECT_NAME@ PROPERTIES INTERFACE_LINK_LIBRARIES ${@PROJECT_NAME@_LIBRARY})
+  # When installed via TheRock, propagate DT_RPATH for rocm_sysdeps/lib to all consumers.
+  # Some system libraries carries a transitive dependency on libva.so.2 and DT_RPATH
+  # in the executable is inherited by all loaded libraries (unlike DT_RUNPATH), ensuring
+  # these system libraries resolves libva.so.2 from TheRock instead of the system installation.
+  if(EXISTS "${PACKAGE_PREFIX_DIR}/lib/rocm_sysdeps/lib")
+    set_target_properties(@PROJECT_NAME@::@PROJECT_NAME@ PROPERTIES
+      INTERFACE_LINK_OPTIONS "-Wl,--disable-new-dtags,-rpath,${PACKAGE_PREFIX_DIR}/lib/rocm_sysdeps/lib")
+  endif()
 endif ()
 
 include(FindPackageHandleStandardArgs)

--- a/projects/rocdecode/cmake_modules/rocdecode-config.cmake.in
+++ b/projects/rocdecode/cmake_modules/rocdecode-config.cmake.in
@@ -25,15 +25,18 @@ set_and_check(@PROJECT_NAME@_LIBRARIES "@PACKAGE_LIB_INSTALL_DIR@/lib@PROJECT_NA
 if(NOT TARGET @PROJECT_NAME@::@PROJECT_NAME@)
   add_library(@PROJECT_NAME@::@PROJECT_NAME@ INTERFACE IMPORTED)
   set_target_properties(@PROJECT_NAME@::@PROJECT_NAME@ PROPERTIES INTERFACE_LINK_LIBRARIES ${@PROJECT_NAME@_LIBRARY})
-  # When installed via TheRock, propagate DT_RPATH for rocm_sysdeps/lib to all consumers.
-  # Some system libraries carries a transitive dependency on libva.so.2 and DT_RPATH
-  # in the executable is inherited by all loaded libraries (unlike DT_RUNPATH), ensuring
-  # these system libraries resolves libva.so.2 from TheRock instead of the system installation.
-  if(EXISTS "${PACKAGE_PREFIX_DIR}/lib/rocm_sysdeps/lib")
-    set_target_properties(@PROJECT_NAME@::@PROJECT_NAME@ PROPERTIES
-      INTERFACE_LINK_OPTIONS "-Wl,--disable-new-dtags,-rpath,${PACKAGE_PREFIX_DIR}/lib/rocm_sysdeps/lib")
-  endif()
 endif ()
+
+# When installed via TheRock, propagate DT_RPATH for rocm_sysdeps/lib to all consumers.
+# Some system libraries carry a transitive dependency on libva.so.2 and DT_RPATH
+# in the executable is inherited by all loaded libraries (unlike DT_RUNPATH), ensuring
+# these system libraries resolve libva.so.2 from TheRock instead of the system installation.
+# Applied unconditionally after target creation (whether by rocdecode-targets.cmake or the
+# fallback above) so it is not skipped when the exported targets file creates the target.
+if(EXISTS "${PACKAGE_PREFIX_DIR}/lib/rocm_sysdeps/lib" AND UNIX)
+  set_property(TARGET @PROJECT_NAME@::@PROJECT_NAME@ APPEND PROPERTY
+    INTERFACE_LINK_OPTIONS "-Wl,--disable-new-dtags,-rpath,${PACKAGE_PREFIX_DIR}/lib/rocm_sysdeps/lib")
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(


### PR DESCRIPTION
## Motivation

This PR addresses a libva initialization error encountered by applications (e.g., videoDecode) that utilize FFMPEG.

## Technical Details

The `rocdecode-config` now propagates the `rocm_sysdeps/lib` DT_RPATH to consumers on TheRock.

When `rocdecode` is installed via TheRock, system libraries such as FFMPEG create a transitive dependency on `libva.so.2`. Since DT_RUNPATH (the CMake default) is not inherited by transitive dependencies, the `libavcodec` library resolves `libva.so.2` from the system installation instead of TheRock. This results in a mismatch between the VA-API version and the driver path at runtime.

To resolve this issue, we added `INTERFACE_LINK_OPTIONS` to the `rocdecode::rocdecode` imported target. This modification embeds the DT_RPATH (using `--disable-new-dtags`) that points to `rocm_sysdeps/lib` in every consumer executable. This way, the DT_RPATH in the executable is inherited by all transitively loaded libraries, ensuring that `libva.so.2` resolves to TheRock's version, regardless of the link order.


## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
