### PR TITLE
[GHA] Exempt draft PRs from being marked as stale

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -61,3 +61,6 @@ jobs:
 
           # Maximum number of operations per run (to avoid API rate limits)
           operations-per-run: 1000
+
+          # Draft PRs can stay for as long as necessary
+          exempt-draft-pr: true


### PR DESCRIPTION
## Motivation

Draft PRs are for showcasing work which is not under pressure to be merged soon. As such, they should be exempt from being pronounced as stale.

## Technical Details

See [docs](https://github.com/actions/stale#exempt-draft-pr)

## JIRA ID

N/A

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
