### PR TITLE
ROCr: Add a runtime interface to configure RAS poison-consumption SIGBUS

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/drm/amdgpu_drm.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/drm/amdgpu_drm.h
@@ -54,6 +54,7 @@ extern "C" {
 #define DRM_AMDGPU_VM			0x13
 #define DRM_AMDGPU_FENCE_TO_HANDLE	0x14
 #define DRM_AMDGPU_SCHED		0x15
+#define DRM_AMDGPU_USER_OPTIONS	0x1A
 
 /* hybrid specific ioctls */
 #define DRM_AMDGPU_SEM			0x5b
@@ -75,6 +76,7 @@ extern "C" {
 #define DRM_IOCTL_AMDGPU_VM		DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_VM, union drm_amdgpu_vm)
 #define DRM_IOCTL_AMDGPU_FENCE_TO_HANDLE DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_FENCE_TO_HANDLE, union drm_amdgpu_fence_to_handle)
 #define DRM_IOCTL_AMDGPU_SCHED		DRM_IOW(DRM_COMMAND_BASE + DRM_AMDGPU_SCHED, union drm_amdgpu_sched)
+#define DRM_IOCTL_AMDGPU_USER_OPTIONS	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_USER_OPTIONS, struct drm_amdgpu_user_options)
 /* hybrid specific ioctls */
 #define DRM_IOCTL_AMDGPU_SEM		DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_SEM, union drm_amdgpu_sem)
 #define DRM_IOCTL_AMDGPU_GEM_DGMA	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_DGMA, struct drm_amdgpu_gem_dgma)
@@ -397,6 +399,20 @@ struct drm_amdgpu_sched_in {
 union drm_amdgpu_sched {
 	struct drm_amdgpu_sched_in in;
 };
+
+struct drm_amdgpu_user_options {
+	__u32 op;
+	union {
+		struct {
+			__u16 value;
+			__u16 _pad;
+		} kfd_sigbus_delay;
+		__u32 _pad;
+	};
+};
+
+#define AMDGPU_USER_OPTIONS_OP_KFD_SIGBUS_DELAY 0
+#define AMDGPU_USER_OPTIONS_KFD_SIGBUS_DELAY_DISABLED  0xFFFFFFFFu
 
 /*
  * This is not a reliable API and you should expect it to fail for any

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -789,6 +789,11 @@ class Runtime {
   // @brief Binds Error handlers to this node.
   void BindErrorHandlers();
 
+  // @brief Forward HSA_RAS_POISON_SIGBUS_DELAY_MS to amdgpu/KFD via
+  //        DRM_IOCTL_AMDGPU_USER_OPTIONS for each GPU agent. No-op if the
+  //        flag is unset or the host kernel does not support the option.
+  void ConfigureRasSigbusDelay();
+
   // @brief Acquire snapshot of system event handlers.
   // Returns a copy to avoid holding a lock during callbacks.
   std::vector<std::pair<AMD::callback_t<hsa_amd_system_event_callback_t>, void*>>

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -50,6 +50,7 @@
 #include <link.h>
 #include <dlfcn.h>
 #include <amdgpu_drm.h>
+#include <sys/ioctl.h>
 #include <sys/mman.h>
 #endif
 
@@ -2087,6 +2088,47 @@ void Runtime::BindErrorHandlers() {
                         HwExceptionHandler, reinterpret_cast<void*>(hw_exception_signal_.get()));
 }
 
+
+// Forward declarations for RAS poison SIGBUS delay configuration
+static int (*fn_amdgpu_device_get_fd)(HsaAMDGPUDeviceHandle device_handle) = NULL;
+int fn_amdgpu_device_get_fd_nosupport(HsaAMDGPUDeviceHandle device_handle);
+
+void Runtime::ConfigureRasSigbusDelay() {
+  if (!flag_.ras_poison_sigbus_delay_set()) return;
+
+#if defined(__linux__)
+  if (fn_amdgpu_device_get_fd == nullptr ||
+      fn_amdgpu_device_get_fd == &fn_amdgpu_device_get_fd_nosupport) {
+    debug_warning(
+        "HSA_RAS_POISON_SIGBUS_DELAY_MS set but amdgpu_device_get_fd is "
+        "unavailable; option ignored");
+    return;
+  }
+
+  const uint32_t value = flag_.ras_poison_sigbus_delay_ms();
+  for (core::Agent* agent : gpu_agents_) {
+    AMD::GpuAgent* gpu = static_cast<AMD::GpuAgent*>(agent);
+    amdgpu_device_handle ldrm_dev = gpu->libDrmDev();
+    if (ldrm_dev == nullptr) continue;
+
+    int fd = fn_amdgpu_device_get_fd(ldrm_dev);
+    if (fd < 0) continue;
+
+    struct drm_amdgpu_user_options args = {};
+    args.op = AMDGPU_USER_OPTIONS_OP_KFD_SIGBUS_DELAY;
+    args.kfd_sigbus_delay.value = value;
+    if (ioctl(fd, DRM_IOCTL_AMDGPU_USER_OPTIONS, &args) != 0) {
+      // Kernel may be older than the patch; not fatal.
+      debug_warning(
+          "DRM_IOCTL_AMDGPU_USER_OPTIONS(KFD_SIGBUS_DELAY) failed; "
+          "host kernel may not support the RAS-poison opt-in.");
+      // Don't keep retrying for the rest of the agents on the same kernel.
+      return;
+    }
+  }
+#endif
+}
+
 bool Runtime::HwExceptionHandler(hsa_signal_value_t val, void* arg) {
   core::InterruptSignal* hw_exception_signal = reinterpret_cast<core::InterruptSignal*>(arg);
 
@@ -2450,6 +2492,10 @@ hsa_status_t Runtime::Load() {
   // Initialize libdrm helper function
   CheckVirtualMemApiSupport();
 
+  // Configure per-process RAS poison-consume SIGBUS opt-in (requires the
+  // amdgpu_device_get_fd helper resolved by CheckVirtualMemApiSupport).
+  ConfigureRasSigbusDelay();
+
   // Initialize IPC support mode
   InitIPCDmaBufSupport();
 
@@ -2607,9 +2653,6 @@ static std::vector<std::string> parse_tool_names(std::string tool_names) {
   if (name != "") names.push_back(name);
   return names;
 }
-
-
-static int (*fn_amdgpu_device_get_fd)(HsaAMDGPUDeviceHandle device_handle) = NULL;
 
 int fn_amdgpu_device_get_fd_nosupport(HsaAMDGPUDeviceHandle device_handle) {
   fprintf(stderr, "amdgpu_device_get_fd not available. Please update version of libdrm");

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -87,6 +87,24 @@ class Flag {
     var = os::GetEnvVar("HSA_ENABLE_QUEUE_FAULT_MESSAGE");
     enable_queue_fault_message_ = (var == "0") ? false : true;
 
+    // RAS poison-consumption SIGBUS opt-in (forwarded to the amdgpu KFD driver
+    // via DRM_IOCTL_AMDGPU_USER_OPTIONS).  Lets the registered system-event
+    // handler observe the poison-consumed event before (or instead of) the
+    // process being killed by SIGBUS.
+    //   unset / empty       - do not call ioctl, kernel default (immediate SIGBUS)
+    //   "off" / "disable"   - suppress SIGBUS entirely (0xFFFFFFFF)
+    //   numeric value (ms)  - safety timeout: deliver SIGBUS after N ms if the
+    //                         app does not handle the error in time
+    var = os::GetEnvVar("HSA_RAS_POISON_SIGBUS_DELAY_MS");
+    ras_poison_sigbus_delay_set_ = !var.empty();
+    if (!ras_poison_sigbus_delay_set_) {
+      ras_poison_sigbus_delay_ms_ = 0;
+    } else if (var == "off" || var == "disable" || var == "disabled") {
+      ras_poison_sigbus_delay_ms_ = 0xFFFFFFFFu;
+    } else {
+      ras_poison_sigbus_delay_ms_ = static_cast<uint32_t>(strtoul(var.c_str(), nullptr, 0));
+    }
+
     var = os::GetEnvVar("HSA_ENABLE_INTERRUPT");
     enable_interrupt_ = (var == "0") ? false : true;
 
@@ -343,6 +361,10 @@ class Flag {
 
   bool enable_queue_fault_message() const { return enable_queue_fault_message_; }
 
+  bool ras_poison_sigbus_delay_set() const { return ras_poison_sigbus_delay_set_; }
+
+  uint32_t ras_poison_sigbus_delay_ms() const { return ras_poison_sigbus_delay_ms_; }
+
   bool enable_interrupt() const { return enable_interrupt_; }
 
   bool enable_sdma_hdp_flush() const { return enable_sdma_hdp_flush_; }
@@ -516,6 +538,8 @@ class Flag {
   bool running_valgrind_;
   bool sdma_wait_idle_;
   bool enable_queue_fault_message_;
+  bool ras_poison_sigbus_delay_set_ = false;
+  uint32_t ras_poison_sigbus_delay_ms_ = 0;
   bool report_tool_load_failures_;
   bool report_tool_register_failures_ = false;
   bool disable_tool_register_ = false;


### PR DESCRIPTION
This change introduces parsing of the
HSA_RAS_POISON_SIGBUS_DELAY_MS environment variable and forwards the configured value to the kernel through DRM_IOCTL_AMDGPU_USER_OPTIONS for each GPU agent during runtime initialization.

Supported modes:
- unset/empty: leave kernel default behavior unchanged
- off/disable/disabled: suppress SIGBUS delivery
- numeric value: delay SIGBUS delivery by the specified timeout in ms

This enables applications to observe poison-consumed events via the registered system-event handler before an immediate SIGBUS terminates the process, or to apply a safety timeout before SIGBUS is delivered.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
