### PR TITLE
Fix device enqueue in OCL for AQL path

### DIFF
--- a/projects/clr/opencl/tests/ocltst/module/runtime/OCLDynamic.cpp
+++ b/projects/clr/opencl/tests/ocltst/module/runtime/OCLDynamic.cpp
@@ -182,7 +182,7 @@ void OCLDynamic::run(void) {
 
   for (unsigned int i = 0; i < TotalElements; ++i) {
     if (host[i] != 0) {
-      printf("Bad value: a[%d] = %d\n", i, hostArray[i]);
+      printf("Bad value: a[%d] = %d\n", i, host[i]);
       CHECK_RESULT(true, "Incorrect result for dependency!\n");
     }
   }

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -76,6 +76,8 @@ bool roc::Device::isHsaInitialized_ = false;
 std::vector<hsa_agent_t> roc::Device::gpu_agents_;
 std::vector<AgentInfo> roc::Device::cpu_agents_;
 
+std::atomic<bool> Device::skipHsaShutdown_{false};
+
 address Device::mg_sync_ = nullptr;
 
 bool NullDevice::create(const amd::Isa& isa) {
@@ -222,17 +224,25 @@ Device::~Device() {
   delete xferQueue_;
   xferQueue_ = nullptr;
 
-  for (auto& it : queuePool_) {
-    for (auto qIter = it.begin(); qIter != it.end();) {
-      hsa_queue_t* queue = qIter->first;
-      auto& qInfo = qIter->second;
-      ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE, "Deleting hardware queue %p with refCount 0",
-              queue->base_address);
-      qIter = it.erase(qIter);
-      Hsa::queue_destroy(queue);
+#if defined(_WIN32)
+  if (hasSchedulerQueue_.load(std::memory_order_acquire) > 0) {
+    skipHsaShutdown_.store(true, std::memory_order_release);
+    queuePool_.clear();
+  } else
+#endif  // _WIN32
+  {
+    for (auto& it : queuePool_) {
+      for (auto qIter = it.begin(); qIter != it.end();) {
+        hsa_queue_t* queue = qIter->first;
+        auto& qInfo = qIter->second;
+        ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE, "Deleting hardware queue %p with refCount 0",
+                queue->base_address);
+        qIter = it.erase(qIter);
+        Hsa::queue_destroy(queue);
+      }
     }
+    queuePool_.clear();
   }
-  queuePool_.clear();
 
   delete blitProgram_;
 
@@ -350,6 +360,9 @@ hsa_status_t Device::loaderQueryHostAddress(const void* device, const void** hos
 
 // ================================================================================================
 bool Device::init() {
+#if defined(_WIN32)
+  skipHsaShutdown_.store(false, std::memory_order_release);
+#endif
   if (!Hsa::LoadLib()) {
     LogPrintfWarning("Failed to load rocr library!");
     return false;
@@ -532,6 +545,11 @@ extern const char* SchedulerSourceCode;
 
 void Device::tearDown() {
   NullDevice::tearDown();
+#if defined(_WIN32)
+  if (skipHsaShutdown_.load(std::memory_order_acquire)) {
+    return;
+  }
+#endif  // _WIN32
   Hsa::shut_down();
 }
 

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -774,6 +774,12 @@ class Device : public NullDevice {
   friend void callbackQueue(hsa_status_t status, hsa_queue_t* queue, void* data);
 
  public:
+
+  //! Count of schedulerQueue_ instances per device
+  //! Windows AQL device-enqueue path.
+  std::atomic<uint32_t> hasSchedulerQueue_{0};
+  static std::atomic<bool> skipHsaShutdown_;
+
   std::atomic<uint> numOfVgpus_;  //!< Virtual gpu unique index
 
   //! Returns the valid SDMA engine bitmask for the given operation type.

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1928,7 +1928,33 @@ VirtualGPU::~VirtualGPU() {
 
   delete blitMgr_;
 
-  if (tracking_created_) {
+  bool skip_fence_barrier = false;
+  if (nullptr != schedulerQueue_) {
+#if defined(_WIN32)
+    if (isSchedulerQueueThreadRunning()) {
+      schedulerQueueThreadRunning_.store(false, std::memory_order_release);
+      {
+        std::lock_guard<std::mutex> lock(scheduler_mutex_);
+        pendingSchedulerEvents_.clear();
+        scheduler_cv_.notify_one();
+      }
+      if (schedulerQueueThread_.joinable()) {
+        schedulerQueueThread_.join();
+      }
+    }
+    if (!dev().IsPm4Emulation()) {
+      roc_device_.hasSchedulerQueue_.fetch_add(1, std::memory_order_release);
+      skip_fence_barrier = true;
+    } else {
+      Hsa::queue_destroy(schedulerQueue_);
+    }
+#else
+    Hsa::queue_destroy(schedulerQueue_);
+#endif  // _WIN32
+    schedulerQueue_ = nullptr;
+  }
+
+  if (tracking_created_ && !skip_fence_barrier) {
     std::scoped_lock l(execution());
     // Dedicated queues keep their HW queue, never acquire from pool
     if (!dedicated_queue_ && gpu_queue_ == nullptr) {
@@ -1951,23 +1977,6 @@ VirtualGPU::~VirtualGPU() {
   }
 
   delete printfdbg_;
-
-  if (nullptr != schedulerQueue_) {
-#if defined(_WIN32)
-    // Stop the monitor thread before destroying the queue
-    if (isSchedulerQueueThreadRunning()) {
-      schedulerQueueThreadRunning_.store(false, std::memory_order_relaxed);
-      {
-        std::lock_guard<std::mutex> lock(scheduler_mutex_);
-        scheduler_cv_.notify_one();
-      }
-      if (schedulerQueueThread_.joinable()) {
-        schedulerQueueThread_.join();
-      }
-    }
-#endif  // _WIN32
-    Hsa::queue_destroy(schedulerQueue_);
-  }
 
   if (nullptr != virtualQueue_) {
     virtualQueue_->release();


### PR DESCRIPTION
## Motivation

Fixes the OCL tests using device enqueue with ROCr backend on AQL path

## Technical Details

Clears the pending event signals during the destructor. Also, terminates the scheduler thread on the host prior to releasing the resources of signals.

## JIRA ID

AIRUNTIME-277

## Test Plan

Verify with the OCL device enqueue tests

## Test Result

PASS

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
