### PR TITLE
[RCCL] AllGather: align Direct path with AlltoAll 

### DIFF
--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -88,22 +88,30 @@ const char* ncclProtoToString(int proto) {
 NCCL_API(ncclResult_t, ncclAllGather, const void* sendbuff, void* recvbuff, size_t sendcount,
     ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream);
 
+// Direct AllGather: posts Send/Recv to every peer (including self) for every
+// rank using the same iteration order on all ranks. Mirrors the AlltoAll
+// scheduling path so that, when RCCL_P2P_BATCH_ENABLE=1, all ranks emit the
+// same sequence of (sendRank, recvRank) rounds and therefore the same fused
+// ncclDevWorkBatch composition.
+//
+// We deliberately keep this minimal:
+//   - No (rank + r) % nRanks rotation: all ranks visit peers in order 0..N-1.
+//   - No in-place self-peer skip: send/recv to self is always posted; the
+//     device kernel handles isCopy = (sendRank == self) as a local memcpy
+//     (see device/sendrecv.h).
+//   - Posting is delegated to taskAppend() via a single ncclEnqueueCheck
+//     call. taskAppend() then loops once and calls p2pTaskAppend directly,
+//     the same way ncclAlltoAll does, avoiding the per-peer ncclSend/ncclRecv
+//     overhead (ArgsCheck, Recorder, profiler events, group start/end
+//     internal) that previously made cross-rank batch composition fragile at
+//     scale.
 static ncclResult_t rcclDirectAllGather(const void* sendbuff, void* recvbuff, size_t sendcount,
-    ncclDataType_t datatype, int in_place, ncclComm_t comm, cudaStream_t stream) {
-  int nRanks = comm->nRanks;
-  int rank = comm->rank;
-  size_t rankOffset = sendcount * ncclTypeSize(datatype);
-
-  NCCLCHECK(ncclGroupStart());
-  for (int r = 0; r < nRanks; r++) {
-    int peer = (rank + r) % nRanks;
-    if (peer == rank && in_place) continue;
-    NCCLCHECK(ncclSend(((char*)sendbuff), sendcount, datatype, peer, comm, stream));
-    NCCLCHECK(ncclRecv(((char*)recvbuff) + peer * rankOffset, sendcount, datatype, peer, comm, stream));
-  }
-  NCCLCHECK(ncclGroupEnd());
-
-  return ncclSuccess;
+    ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream) {
+  struct ncclInfo info = { ncclFuncAllGather, "AllGather",
+    sendbuff, recvbuff, sendcount, datatype, ncclSum, 0, comm, stream,
+    ALLGATHER_CHUNKSTEPS, ALLGATHER_SLICESTEPS, nullptr };
+  info.useDirect = true;
+  return ncclEnqueueCheck(&info);
 }
 
 RCCL_PARAM(HierarchicalAllGather, "HIERARCHICAL_ALLGATHER", 0);
@@ -144,7 +152,7 @@ static ncclResult_t ncclHierarchicalAllGather_Impl(const void* sendbuff, void* r
   size_t interMsgSize = sendcount * nNodes * typeSize;
   if (rcclUseAllGatherDirect(interComm, interMsgSize)) {
     // Use direct allgather
-    NCCLCHECK(rcclDirectAllGather(interSendBuff, recvbuff, sendcount, datatype, 0, interComm, stream));
+    NCCLCHECK(rcclDirectAllGather(interSendBuff, recvbuff, sendcount, datatype, interComm, stream));
   } else {
     struct ncclInfo infoInterAG = { ncclFuncAllGather, "HierarchicalAllGather-Inter",
       interSendBuff, recvbuff, sendcount, datatype, ncclSum, 0, interComm, stream,
@@ -157,7 +165,7 @@ static ncclResult_t ncclHierarchicalAllGather_Impl(const void* sendbuff, void* r
   size_t intraMsgSize = intraSendCount * typeSize * localRanks;
   if (rcclUseAllGatherDirect(intraComm, intraMsgSize)) {
     // Use direct allgather
-    NCCLCHECK(rcclDirectAllGather(recvbuff, tempBuffer, intraSendCount, datatype, 0, intraComm, stream));
+    NCCLCHECK(rcclDirectAllGather(recvbuff, tempBuffer, intraSendCount, datatype, intraComm, stream));
   } else {
     struct ncclInfo infoIntraAG = { ncclFuncAllGather, "HierarchicalAllGather-Intra",
       recvbuff, tempBuffer, intraSendCount, datatype, ncclSum, 0, intraComm, stream,
@@ -193,9 +201,6 @@ ncclResult_t ncclAllGather_impl(const void* sendbuff, void* recvbuff, size_t sen
     sendbuff, recvbuff, sendcount, datatype, ncclSum, 0, comm, stream, /* Args */
     chunkSteps, sliceSteps, nullptr };
   int nRanks, rank;
-  int in_place = 0;
-  const void* srcBuf;
-  void* dstBuf;
   NCCLCHECK(ncclCommCount(comm, &nRanks));
   NCCLCHECK(ncclCommUserRank(comm, &rank));
   size_t msgSize = sendcount * ncclTypeSize(datatype) * nRanks;
@@ -207,22 +212,15 @@ ncclResult_t ncclAllGather_impl(const void* sendbuff, void* recvbuff, size_t sen
   }
 
   if (rcclUseAllGatherDirect(comm, msgSize) && ncclGroupDepth == 0) {
-     INFO(NCCL_INIT, "RCCL DIRECT ALLGATHER count = %zu, msgSize = %zu, comm = %p, stream = %p, rank = %d, sendbuff = %p, recvbuff = %p",
-		     sendcount, msgSize, comm, stream, rank, sendbuff, recvbuff);
-     // use direct allgather (only when not in a group; in-group use Ring so ncclGroupSimulateEnd gets estimatedTime)
-     if (sendcount == 0) return ncclSuccess;
-     size_t rankOffset = sendcount * ncclTypeSize(datatype);
-     if (sendbuff == (((char*)recvbuff) + rank * rankOffset)) {
-        srcBuf = ((char*)recvbuff) + rank * rankOffset;
-        dstBuf = recvbuff;
-        in_place = 1;
-     } else {
-        srcBuf = sendbuff;
-        dstBuf = recvbuff;
-     }
-
-    NCCLCHECK(rcclDirectAllGather(srcBuf, dstBuf, sendcount, datatype, in_place, comm, stream));
-    return ncclSuccess;
+    INFO(NCCL_INIT, "RCCL DIRECT ALLGATHER count = %zu, msgSize = %zu, comm = %p, stream = %p, rank = %d, sendbuff = %p, recvbuff = %p",
+        sendcount, msgSize, comm, stream, rank, sendbuff, recvbuff);
+    // Use direct allgather (only when not in a group; in-group use Ring so
+    // ncclGroupSimulateEnd gets estimatedTime).
+    if (sendcount == 0) return ncclSuccess;
+    // Mark the info so taskAppend posts this as A2A-style per-peer Send/Recv
+    // P2P tasks (no peer rotation, no in-place self skip).
+    info.useDirect = true;
+    return ncclEnqueueCheck(&info);
   } else {
      // use ring allgather
      return ncclEnqueueCheck(&info);

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -3146,6 +3146,24 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
             NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncSend, collAPI, (void*)((char*)info->sendbuff+r*info->count*ncclTypeSize(info->datatype)), info->count, info->datatype, r));
             NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncRecv, collAPI, (void*)((char*)info->recvbuff+r*info->count*ncclTypeSize(info->datatype)), info->count, info->datatype, r));
           }
+        } else if (info->coll == ncclFuncAllGather && info->useDirect) {
+          // Direct AllGather: post per-peer Send/Recv P2P tasks the same way
+          // ncclFuncAlltoAll does above. Differences vs A2A:
+          //   - sendbuff is NOT offset per peer (every peer receives this
+          //     rank's full contribution).
+          //   - recvbuff is offset by r * count * sizeof(T) (each peer's
+          //     contribution lands in its slot of the gather buffer).
+          // Identical to A2A in all other respects: iteration order is
+          // 0..nRanks-1 on every rank (no (rank+r)%nRanks rotation), and
+          // the self peer (r == rank) is always posted (no in-place skip).
+          // Posting self via p2pTaskAppend is correct because the device
+          // kernel handles isCopy = (sendRank == self) as a local memcpy
+          // (see device/sendrecv.h's RunWorkBatch<ncclFuncSendRecv,...>).
+          size_t rankOffset = info->count * ncclTypeSize(info->datatype);
+          for (int r=0; r<comm->nRanks; r++) {
+            NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncSend, collAPI, (void*)info->sendbuff, info->count, info->datatype, r));
+            NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncRecv, collAPI, (void*)((char*)info->recvbuff + r*rankOffset), info->count, info->datatype, r));
+          }
         } else if (info->coll == ncclFuncGather){
           size_t offset = 0;
           NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncSend, collAPI, (void*)info->sendbuff, info->count, info->datatype, info->root));

--- a/projects/rccl/src/include/info.h
+++ b/projects/rccl/src/include/info.h
@@ -34,6 +34,10 @@ struct ncclInfo {
   // Optional per-operation metadata for rocSHMEM collectives.
   size_t* sizes;
 #endif
+  // When true and coll == ncclFuncAllGather, taskAppend posts the AG as an
+  // A2A-style fan of per-peer Send/Recv P2P tasks (Direct AllGather path)
+  // instead of routing through collTaskAppend (ring/PAT/etc.).
+  bool useDirect;
 };
 
 #endif

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -430,11 +430,6 @@ bool rcclUseAllGatherDirect(struct ncclComm* comm, size_t& msgSize) {
     return false;
   }
 
-  if (comm->nNodes > 32) {
-    INFO(NCCL_INIT, "RCCL DIRECT ALLGATHER disabled when using more than 32 nodes.");
-    return false;
-  }
-
   // Check if user explicitly set threshold
   static int userThresholdInput = -2;
   if (userThresholdInput == -2) {


### PR DESCRIPTION
  1. rcclDirectAllGather rotated peers with (rank + r) % nRanks, so every rank populated planner queues, profiler events, and Recorder state in a different order. AlltoAll iterates 0..N-1 identically on every rank.

  2. The in-place check (peer == rank && in_place) dropped the self-pair on some ranks. The detection sendbuff == recvbuff + rank*offset is per-rank; at scale, ranks could disagree on in_place and emit different fused ncclDevWorkBatch shapes -- the exact condition scheduleP2pTasksToPlan flags as "causing hangs". AlltoAll never skips the self pair; the device kernel handles it via isCopy = (sendRank == self).

  3. The loop posted via ncclSend / ncclRecv wrapped in ncclGroupStart / End. Each call paid the full ncclEnqueueCheck tax (ArgsCheck, Recorder::record, INFO / TRACE_CALL, profiler API events, internal group depth toggles) -- 2*nRanks times per AG. AlltoAll posts all per-peer tasks via p2pTaskAppend from inside a single taskAppend() call.

This change makes Direct AllGather use the same path:

  * Add bool useDirect to ncclInfo (aggregate-init defaults to false everywhere it isn't set).
  * ncclAllGather_impl no longer detects in-place. When the Direct path is chosen, it sets info.useDirect = true and calls ncclEnqueueCheck once.
  * rcclDirectAllGather (still used by Hierarchical AllGather) is now a thin wrapper that does the same: build ncclInfo with useDirect = true and call ncclEnqueueCheck.
  * taskAppend gains a branch mirroring the ncclFuncAlltoAll case: for info->coll == ncclFuncAllGather && info->useDirect, loop r in [0, nRanks) and call p2pTaskAppend for Send (sendbuff) and Recv (recvbuff + r * count * sizeof(T)). No rotation, no in-place skip.
  * Drop the "comm->nNodes > 32" guard in rcclUseAllGatherDirect so the path is actually exercised at the scales we now support.

The existing in-place fast-path in scheduleP2pTasksToPlan (skip self when send->buff == recv->buff and batching is off) is preserved, so behavior with RCCL_P2P_BATCH_ENABLE=0 is unchanged.

Tested manually at 37 and 48 nodes with RCCL_P2P_BATCH_ENABLE=1.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
