### PR TITLE
[rccl-tests] Restore buffer allocation in parallel-init mode

### DIFF
--- a/projects/rccl-tests/src/common.cu
+++ b/projects/rccl-tests/src/common.cu
@@ -1963,6 +1963,13 @@ testResult_t run() {
   for (int i=0; i<nGpus*nThreads; i++) {
     gpus[i] = ((gpu0 != -1 ? gpu0 : localRank*nThreads*nGpus) + i)%numDevices;
     CUDACHECK(cudaSetDevice(gpus[i]));
+    if (parallel_init) {
+      if (test_bias) {
+        TESTCHECK(AllocateBuffs(sendbuffs.data()+i, sendBytes, recvbuffs.data()+i, recvBytes, expected.data()+i, (size_t)maxBytes, bias.data()+i));
+      } else {
+        TESTCHECK(AllocateBuffs(sendbuffs.data()+i, sendBytes, recvbuffs.data()+i, recvBytes, expected.data()+i, (size_t)maxBytes, NULL));
+      }
+    }
     if (streamnull) {
       streams[i] = NULL;
     }


### PR DESCRIPTION
## Summary

Parallel-init mode (`-p 1`) crashes on the first collective with `HIP illegal memory access` at `rccl/src/enqueue.cc:1918` — the kernel dereferences NULL `sendbuff`/`recvbuff`.

The OOM fix in #3588 removed the unconditional `AllocateBuffs` loop in `run()` to stop double-allocation in the non-parallel path. That loop was also the *only* allocation site for `parallel_init==1`, so `-p 1` has been running with default-NULL buffers since.

Restore the same loop body, gated on `if (parallel_init)`. The non-parallel path still allocates inside `if (!parallel_init)` at line 2009, so no double-allocation is reintroduced.

## Test plan

Validated on develop @ 96f84c9488 / MI355X (gfx950) / ROCm 7.0.2.1.

- [x] `all_reduce_perf -b 8 -e 8 -f 2 -g {2..8} -p 1 -c 0` — all PASS (was: HIP illegal memory access on every config)
- [x] `all_reduce_perf -b 8 -e 1G -f 2 -g 8` non-parallel sweep — PASS, no OOM regression
- [x] 5/5 stability iterations at `-g 8 -p 1`

## Refs

AICOMRCCL-839; regression introduced in #3588.