### PR TITLE
[AMD-SMI] Fix Python tests: test_gpu_fan_speed & test_set

### DIFF
--- a/projects/amdsmi/tests/python_unittest/common.py
+++ b/projects/amdsmi/tests/python_unittest/common.py
@@ -38,25 +38,6 @@ try:
 except ImportError as e:
     raise ImportError(f'Could not import the "amdsmi" module from "{amdsmi_path}"') from e
 
-# TODO(amdsmi_team): Refactor to create an amdsmi_get_gpu_fan_speed_range() API
-#                    amdsmi_get_gpu_fan_speed_range(
-#                                           amdsmi_processor_handle processor_handle,
-#                                           uint32_t sensor_ind,
-#                                           amdsmi_range_t* fan_speed_range)
-# and begin deprecation of amdsmi_get_gpu_fan_speed_max(). This will allow us
-# to remove the dependency on amdsmi_helpers from this common module.
-# Exposing non-public SYSFS API interfaces in the CLI (and in general)
-# is a bad design pattern and needs to be addressed in the future.
-amdsmi_cli_path = os.path.normpath(os.path.join(amdsmi_path, "..", "..", "libexec", "amdsmi_cli"))
-if amdsmi_cli_path not in sys.path:
-    sys.path.insert(0, amdsmi_cli_path)
-try:
-    import amdsmi_helpers  # type: ignore
-except ImportError as e:
-    raise ImportError(
-        f'Could not import the "amdsmi_helpers" module from "{amdsmi_cli_path}"'
-    ) from e
-
 #################################################
 # Module level functions, not part of the class #
 #################################################
@@ -160,7 +141,8 @@ def expand_glob_k_arg(caller_globals):
 def has_gpu_od_interface(bdf):
     """Check if a GPU has the gpu_od sysfs interface.
 
-    This is a wrapper around AMDSMIHelpers.detect_gpu_od() for test convenience.
+    Delegates to amdsmi_helpers.AMDSMIHelpers.detect_gpu_od(). Requires the
+    AMD-SMI CLI to be installed (amdsmi_helpers is imported on first call).
 
     Args:
         bdf: PCI Bus/Device/Function string (e.g. '0000:26:00.0')
@@ -168,6 +150,31 @@ def has_gpu_od_interface(bdf):
     Returns:
         bool: True if gpu_od directory exists for this GPU
     """
+    # TODO(amdsmi_team): Refactor to create an amdsmi_get_gpu_fan_speed_range() API
+    #                    amdsmi_get_gpu_fan_speed_range(
+    #                                           amdsmi_processor_handle processor_handle,
+    #                                           uint32_t sensor_ind,
+    #                                           amdsmi_range_t* fan_speed_range)
+    # and begin deprecation of amdsmi_get_gpu_fan_speed_max(). This will allow us
+    # to remove the dependency on amdsmi_helpers from this common module.
+    # Exposing non-public SYSFS API interfaces in the CLI (and in general)
+    # is a bad design pattern and needs to be addressed in the future.
+    amdsmi_cli_path = os.path.normpath(
+        os.path.join(amdsmi_path, "..", "..", "libexec", "amdsmi_cli")
+    )
+    if not os.path.exists(amdsmi_cli_path):
+        raise FileNotFoundError(
+            f'amdsmi_cli path "{amdsmi_cli_path}" does not exist. '
+            f"Ensure the AMD-SMI CLI is installed, or set AMDSMI_PATH correctly."
+        )
+    if amdsmi_cli_path not in sys.path:
+        sys.path.append(amdsmi_cli_path)
+    try:
+        import amdsmi_helpers  # type: ignore
+    except ImportError as e:
+        raise ImportError(
+            f'Could not import the "amdsmi_helpers" module from "{amdsmi_cli_path}"'
+        ) from e
     has_gpu_od, _ = amdsmi_helpers.AMDSMIHelpers.detect_gpu_od(bdf)
     return has_gpu_od
 

--- a/projects/amdsmi/tests/python_unittest/common.py
+++ b/projects/amdsmi/tests/python_unittest/common.py
@@ -38,6 +38,25 @@ try:
 except ImportError as e:
     raise ImportError(f'Could not import the "amdsmi" module from "{amdsmi_path}"') from e
 
+# TODO(amdsmi_team): Refactor to create an amdsmi_get_gpu_fan_speed_range() API
+#                    amdsmi_get_gpu_fan_speed_range(
+#                                           amdsmi_processor_handle processor_handle,
+#                                           uint32_t sensor_ind,
+#                                           amdsmi_range_t* fan_speed_range)
+# and begin deprecation of amdsmi_get_gpu_fan_speed_max(). This will allow us
+# to remove the dependency on amdsmi_helpers from this common module.
+# Exposing non-public SYSFS API interfaces in the CLI (and in general)
+# is a bad design pattern and needs to be addressed in the future.
+amdsmi_cli_path = os.path.normpath(os.path.join(amdsmi_path, "..", "..", "libexec", "amdsmi_cli"))
+if amdsmi_cli_path not in sys.path:
+    sys.path.insert(0, amdsmi_cli_path)
+try:
+    import amdsmi_helpers  # type: ignore
+except ImportError as e:
+    raise ImportError(
+        f'Could not import the "amdsmi_helpers" module from "{amdsmi_cli_path}"'
+    ) from e
+
 #################################################
 # Module level functions, not part of the class #
 #################################################
@@ -149,14 +168,7 @@ def has_gpu_od_interface(bdf):
     Returns:
         bool: True if gpu_od directory exists for this GPU
     """
-    # Add amdsmi_cli to path for import
-    cli_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "..", "amdsmi_cli")
-    if cli_path not in sys.path:
-        sys.path.insert(0, cli_path)
-
-    from amdsmi_helpers import AMDSMIHelpers
-
-    has_gpu_od, _ = AMDSMIHelpers.detect_gpu_od(bdf)
+    has_gpu_od, _ = amdsmi_helpers.AMDSMIHelpers.detect_gpu_od(bdf)
     return has_gpu_od
 
 


### PR DESCRIPTION
Move amdsmi_helpers to a module-level import (PEP 8), deriving its
path from amdsmi_path rather than a broken __file__-relative path.
Replace the deferred from-import inside has_gpu_od_interface() with
a direct amdsmi_helpers.AMDSMIHelpers.detect_gpu_od() call.

Add a TODO to track removing this CLI sysfs dependency via a proper
amdsmi_get_gpu_fan_speed_range() API.

Fixes: ModuleNotFoundError: No module named 'amdsmi_helpers'
