### PR TITLE
[rocdbgapi] kmd_driver_t: forward process_exited error from escape call

### DIFF
--- a/projects/rocdbgapi/src/os_driver_kmd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kmd.cpp
@@ -2135,6 +2135,8 @@ kmd_driver_t::xfer_global_memory_partial (global_address_t address, void *read,
         return status;
       else if (status == AMD_DBGAPI_STATUS_ERROR_MEMORY_UNAVAILABLE)
         return status;
+      else if (status == AMD_DBGAPI_STATUS_ERROR_PROCESS_EXITED)
+        return status;
     }
 
   /* The memory could not be accessed using any of the known agents, this must
@@ -2294,6 +2296,8 @@ kmd_driver_t::xfer_agent_memory_partial (os_agent_id_t agent_id,
     }
   else if (status == STATUS_RETRY)
     return AMD_DBGAPI_STATUS_ERROR_MEMORY_UNAVAILABLE;
+  else if (status == STATUS_DRIVER_PROCESS_TERMINATED)
+    return AMD_DBGAPI_STATUS_ERROR_PROCESS_EXITED;
 
   return AMD_DBGAPI_STATUS_ERROR_MEMORY_ACCESS;
 


### PR DESCRIPTION
## Motivation

This commit makes kmd_driver_t::xfer_agent_memory (and its caller kmd_driver_t::xfer_global_memory) forward the DRIVER_PROCESS_EXITED error code when received, instead of silently dropping them and returning AMD_DBGAPI_STATUS_ERROR_MEMORY_ACCESS on escape call failure.

## Technical Details

This fixes errors when detaching the dbgapi from an already killed inferior: in process_t::detach, a total cache write_back is performed. If the inferior process was already killed, this would result in a fatal_error. The write_back now silently completes as expected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
