### PR TITLE
test: fix typo requestedHandleTypes → requestedHandleType in MemManagerTests

### DIFF
--- a/projects/rccl/test/mem_manager/MemManagerTests.cpp
+++ b/projects/rccl/test/mem_manager/MemManagerTests.cpp
@@ -810,7 +810,7 @@ inline void AllocateVmmPosixFd(int dev, size_t requestedSize, VmmPosixAllocation
     prop.type                            = hipMemAllocationTypePinned;
     prop.location.type                   = hipMemLocationTypeDevice;
     prop.location.id                     = dev;
-    prop.requestedHandleTypes            = hipMemHandleTypePosixFileDescriptor;
+    prop.requestedHandleType             = hipMemHandleTypePosixFileDescriptor;
     prop.allocFlags.gpuDirectRDMACapable = 1;
 
     size_t granularity = 0;


### PR DESCRIPTION
## Summary
- `hipMemAllocationProp::requestedHandleType` is the correct singular field name as declared in `hip/hip_runtime_api.h` (line 1577).
- The plural `requestedHandleTypes` caused a compile error on the batch code-coverage CI run.

## Root cause
```
prop.requestedHandleTypes = hipMemHandleTypePosixFileDescriptor;
//   ^~~~~~~~~~~~~~~~~~~~
// error: no member named 'requestedHandleTypes'; did you mean 'requestedHandleType'?
```

## Fix
Removed the trailing `s` from `requestedHandleTypes` on line 813.

## Test plan
- [x] Batch code-coverage CI build passes (`MemManagerTests.cpp` compiles cleanly)