### PR TITLE
[rocprofiler-compute] Disable gfx1151 dual-issue VALU counter collection

### DIFF
--- a/projects/rocprofiler-compute/docs/conceptual/rdna/system-speed-of-light.rst
+++ b/projects/rocprofiler-compute/docs/conceptual/rdna/system-speed-of-light.rst
@@ -46,9 +46,10 @@ packed FP16 from 256 to 512 FLOPs/CU/cycle.
 The aggregate ``VALU FLOPs`` row in this panel uses the FP32 single-issue FMA
 ceiling (128 FLOPs/CU/cycle) as the peak. A workload that issues VOPD heavily,
 or that runs packed FP16, can therefore report a percentage of peak above
-100%. To gauge how much of the throughput is coming from VOPD, inspect the
-``Instructions - Dual VALU (VOPD)`` row on the :doc:`wgp` panel, which counts
-``SQ_INSTS_DUAL_VALU_WAVE32``.
+100%. A dedicated WGP counter row for dual-issue VALU (VOPD) is currently
+disabled in rocprofiler-compute because the underlying SQ counter is not
+reliably collected; infer VOPD contribution from VALU FLOPs vs. peak and ISA
+when needed.
 
 Peak theoretical VALU rates
 ---------------------------

--- a/projects/rocprofiler-compute/docs/conceptual/rdna/system-speed-of-light.rst
+++ b/projects/rocprofiler-compute/docs/conceptual/rdna/system-speed-of-light.rst
@@ -46,10 +46,8 @@ packed FP16 from 256 to 512 FLOPs/CU/cycle.
 The aggregate ``VALU FLOPs`` row in this panel uses the FP32 single-issue FMA
 ceiling (128 FLOPs/CU/cycle) as the peak. A workload that issues VOPD heavily,
 or that runs packed FP16, can therefore report a percentage of peak above
-100%. A dedicated WGP counter row for dual-issue VALU (VOPD) is currently
-disabled in rocprofiler-compute because the underlying SQ counter is not
-reliably collected; infer VOPD contribution from VALU FLOPs vs. peak and ISA
-when needed.
+100%. Use VALU FLOPs against the ceilings below together with ISA-level VOPD
+pairing to reason about how much throughput is coming from dual-issue paths.
 
 Peak theoretical VALU rates
 ---------------------------

--- a/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
+++ b/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
@@ -288,7 +288,6 @@ Wave Instruction Mix:
   Instructions - Transcendental:
     rst: 'Transcendental VALU instructions (SQ_INSTS_VALU_TRANS) per normalization unit. These cover hardware approximations such as sin, cos, and log on the vector ALU.'
     unit: Count per Normalization Unit
-  # Instructions - Dual VALU (VOPD): disabled — dual-issue counter not exposed for collection.
   Instructions - VMEM:
     rst: 'Number of vector memory instructions executed, including global, buffer, and texture operations. High VMEM counts relative to VALU may indicate memory-bound workloads.'
     unit: Count per Normalization Unit

--- a/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
+++ b/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
@@ -288,9 +288,7 @@ Wave Instruction Mix:
   Instructions - Transcendental:
     rst: 'Transcendental VALU instructions (SQ_INSTS_VALU_TRANS) per normalization unit. These cover hardware approximations such as sin, cos, and log on the vector ALU.'
     unit: Count per Normalization Unit
-  Instructions - Dual VALU (VOPD):
-    rst: 'Dual-issue VALU instructions executed in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32) per normalization unit. The VOPD encoding pairs two independent VALU operations that issue in the same cycle.'
-    unit: Count per Normalization Unit
+  # Instructions - Dual VALU (VOPD): disabled — dual-issue counter not exposed for collection.
   Instructions - VMEM:
     rst: 'Number of vector memory instructions executed, including global, buffer, and texture operations. High VMEM counts relative to VALU may indicate memory-bound workloads.'
     unit: Count per Normalization Unit

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0700_workgroup_processor.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0700_workgroup_processor.yaml
@@ -154,12 +154,14 @@ Panel Config:
           min: MIN(SQ_INSTS_VALU_TRANS_sum / $denom)
           max: MAX(SQ_INSTS_VALU_TRANS_sum / $denom)
           unit: (Count + $normUnit)
-        # Instructions - Dual VALU (VOPD): disabled — SQ_INSTS_DUAL_VALU_WAVE32 /
-        # SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 not collected (see sdk_config reserved
-        # lowercase counter sq_insts_dual_valu_wave32).
-        #   avg: SUM(SQ_INSTS_DUAL_VALU_WAVE32_sum) / SUM($denom)
-        #   min: MIN(SQ_INSTS_DUAL_VALU_WAVE32_sum / $denom)
-        #   max: MAX(SQ_INSTS_DUAL_VALU_WAVE32_sum / $denom)
+        # Instructions - Dual VALU (VOPD): row omitted (SQ_INSTS_DUAL_VALU_WAVE32 unreliable). When
+        # restoring, uncomment below, switch to SUM(SQ_INSTS_DUAL_VALU_WAVE32_sum)/… per sdk_config,
+        # and sync tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml,
+        # docs/data/metrics/gfx1151_metrics.yaml, and SoL prose if needed. Lowercase tokens in the
+        # snippet avoid PMC expansion if pasted verbatim; replace with SQ_* before enabling.
+        #   avg: SUM(sq_insts_dual_valu_wave32_sum) / SUM($denom)
+        #   min: MIN(sq_insts_dual_valu_wave32_sum / $denom)
+        #   max: MAX(sq_insts_dual_valu_wave32_sum / $denom)
         #   unit: (Count + $normUnit)
         Instructions - VMEM:
           avg: SUM(SQ_INSTS_TEX_sum) / SUM($denom)
@@ -346,7 +348,6 @@ Panel Config:
       Transcendental VALU instructions (SQ_INSTS_VALU_TRANS) per normalization unit.
       These cover hardware approximations such as sin, cos, and log on the vector
       ALU.
-    # Instructions - Dual VALU (VOPD): disabled with dual-issue counter (see sdk_config).
     Instructions - VMEM: >-
       Number of vector memory instructions executed, including global, buffer, and
       texture operations. High VMEM counts relative to VALU may indicate memory-bound

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0700_workgroup_processor.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0700_workgroup_processor.yaml
@@ -154,8 +154,8 @@ Panel Config:
           min: MIN(SQ_INSTS_VALU_TRANS_sum / $denom)
           max: MAX(SQ_INSTS_VALU_TRANS_sum / $denom)
           unit: (Count + $normUnit)
-        # Instructions - Dual VALU (VOPD): row omitted (SQ_INSTS_DUAL_VALU_WAVE32 unreliable). When
-        # restoring, uncomment below, switch to SUM(SQ_INSTS_DUAL_VALU_WAVE32_sum)/… per sdk_config,
+        # Instructions - Dual VALU (VOPD): row omitted (sq_insts_dual_valu_wave32 unreliable). When
+        # restoring, uncomment below, switch to SUM(sq_insts_dual_valu_wave32_sum)/… per sdk_config,
         # and sync tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml,
         # docs/data/metrics/gfx1151_metrics.yaml, and SoL prose if needed. Lowercase tokens in the
         # snippet avoid PMC expansion if pasted verbatim; replace with SQ_* before enabling.

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0700_workgroup_processor.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0700_workgroup_processor.yaml
@@ -154,11 +154,13 @@ Panel Config:
           min: MIN(SQ_INSTS_VALU_TRANS_sum / $denom)
           max: MAX(SQ_INSTS_VALU_TRANS_sum / $denom)
           unit: (Count + $normUnit)
-        Instructions - Dual VALU (VOPD):
-          avg: SUM(SQ_INSTS_DUAL_VALU_WAVE32_sum) / SUM($denom)
-          min: MIN(SQ_INSTS_DUAL_VALU_WAVE32_sum / $denom)
-          max: MAX(SQ_INSTS_DUAL_VALU_WAVE32_sum / $denom)
-          unit: (Count + $normUnit)
+        # Instructions - Dual VALU (VOPD): disabled — SQ_INSTS_DUAL_VALU_WAVE32 /
+        # SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 not collected (see sdk_config reserved
+        # lowercase counter sq_insts_dual_valu_wave32).
+        #   avg: SUM(SQ_INSTS_DUAL_VALU_WAVE32_sum) / SUM($denom)
+        #   min: MIN(SQ_INSTS_DUAL_VALU_WAVE32_sum / $denom)
+        #   max: MAX(SQ_INSTS_DUAL_VALU_WAVE32_sum / $denom)
+        #   unit: (Count + $normUnit)
         Instructions - VMEM:
           avg: SUM(SQ_INSTS_TEX_sum) / SUM($denom)
           min: MIN(SQ_INSTS_TEX_sum / $denom)
@@ -344,10 +346,7 @@ Panel Config:
       Transcendental VALU instructions (SQ_INSTS_VALU_TRANS) per normalization unit.
       These cover hardware approximations such as sin, cos, and log on the vector
       ALU.
-    Instructions - Dual VALU (VOPD): >-
-      Dual-issue VALU instructions executed in wave32 mode
-      (SQ_INSTS_DUAL_VALU_WAVE32) per normalization unit. The VOPD encoding pairs
-      two independent VALU operations that issue in the same cycle.
+    # Instructions - Dual VALU (VOPD): disabled with dual-issue counter (see sdk_config).
     Instructions - VMEM: >-
       Number of vector memory instructions executed, including global, buffer, and
       texture operations. High VMEM counts relative to VALU may indicate memory-bound

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/sdk_config.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/sdk_config.yaml
@@ -2551,13 +2551,8 @@ rocprofiler-sdk:
       - gfx1152
       block: SQ
       event: 173
-  # Lowercase name: rocprofiler-compute only collects all-uppercase tokens from
-  # panel formulas (see gen_counter_list); keeps definition for reference without
-  # auto-selecting this counter for PMC when gfx1151 metrics are expanded.
-  - name: sq_insts_dual_valu_wave32
-    description: >-
-      Reserved (not collected). Maps to SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 / SQ
-      event 178 on gfx1151; hardware path currently unreliable—use when validated.
+  - name: SQ_INSTS_DUAL_VALU_WAVE32
+    description: The number of dual-issue VALU (VOPD) instructions issued in Wave32 mode.
     properties: []
     definitions:
     - architectures:
@@ -4055,13 +4050,13 @@ rocprofiler-sdk:
       - gfx1151
       - gfx1152
       expression: reduce(SQ_INSTS_WAVE32_LDS_PARAM_LOAD,sum)
-  - name: sq_insts_dual_valu_wave32_sum
+  - name: SQ_INSTS_DUAL_VALU_WAVE32_sum
     description: ''
     properties: []
     definitions:
     - architectures:
       - gfx1151
-      expression: reduce(sq_insts_dual_valu_wave32,sum)
+      expression: reduce(SQ_INSTS_DUAL_VALU_WAVE32,sum)
   - name: SQ_ITEMS_sum
     description: ''
     properties: []

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/sdk_config.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/sdk_config.yaml
@@ -2551,8 +2551,13 @@ rocprofiler-sdk:
       - gfx1152
       block: SQ
       event: 173
-  - name: SQ_INSTS_DUAL_VALU_WAVE32
-    description: The number of dual-issue VALU (VOPD) instructions issued in Wave32 mode.
+  # Lowercase name: rocprofiler-compute only collects all-uppercase tokens from
+  # panel formulas (see gen_counter_list); keeps definition for reference without
+  # auto-selecting this counter for PMC when gfx1151 metrics are expanded.
+  - name: sq_insts_dual_valu_wave32
+    description: >-
+      Reserved (not collected). Maps to SQ_PERF_SEL_INSTS_DUAL_VALU_WAVE32 / SQ
+      event 178 on gfx1151; hardware path currently unreliable—use when validated.
     properties: []
     definitions:
     - architectures:
@@ -4050,13 +4055,13 @@ rocprofiler-sdk:
       - gfx1151
       - gfx1152
       expression: reduce(SQ_INSTS_WAVE32_LDS_PARAM_LOAD,sum)
-  - name: SQ_INSTS_DUAL_VALU_WAVE32_sum
+  - name: sq_insts_dual_valu_wave32_sum
     description: ''
     properties: []
     definitions:
     - architectures:
       - gfx1151
-      expression: reduce(SQ_INSTS_DUAL_VALU_WAVE32,sum)
+      expression: reduce(sq_insts_dual_valu_wave32,sum)
   - name: SQ_ITEMS_sum
     description: ''
     properties: []

--- a/projects/rocprofiler-compute/src/utils/.config_hashes.json
+++ b/projects/rocprofiler-compute/src/utils/.config_hashes.json
@@ -10,7 +10,7 @@
         "0400_roofline.yaml": "17b62eb17edee43abd833576a7c142a4",
         "0500_command_processor_cpc.yaml": "9de95259d153357dde907a7a410aa1a3",
         "0600_workgroup_manager_spi.yaml": "e0fb474a8a5e97cf26467578f7b5c316",
-        "0700_workgroup_processor.yaml": "64769ca02ce42ca3db7c07124974a4fe",
+        "0700_workgroup_processor.yaml": "aeb45598ecdb03f1f186da2128fe606b",
         "0900_l0_cache.yaml": "1cbfbc0badeed8ec0caa178faec2f231",
         "1100_l1_cache.yaml": "7403eeb9b47f69f73cf42eccb984cdf7",
         "1300_l2_cache.yaml": "dd34f4b6cbdbb8afbafa059b58ba9839",

--- a/projects/rocprofiler-compute/src/utils/.config_hashes.json
+++ b/projects/rocprofiler-compute/src/utils/.config_hashes.json
@@ -10,7 +10,7 @@
         "0400_roofline.yaml": "17b62eb17edee43abd833576a7c142a4",
         "0500_command_processor_cpc.yaml": "9de95259d153357dde907a7a410aa1a3",
         "0600_workgroup_manager_spi.yaml": "e0fb474a8a5e97cf26467578f7b5c316",
-        "0700_workgroup_processor.yaml": "aeb45598ecdb03f1f186da2128fe606b",
+        "0700_workgroup_processor.yaml": "2e4b9dcea407fdebba15c08b9b4f312c",
         "0900_l0_cache.yaml": "1cbfbc0badeed8ec0caa178faec2f231",
         "1100_l1_cache.yaml": "7403eeb9b47f69f73cf42eccb984cdf7",
         "1300_l2_cache.yaml": "dd34f4b6cbdbb8afbafa059b58ba9839",

--- a/projects/rocprofiler-compute/src/utils/.config_hashes.json
+++ b/projects/rocprofiler-compute/src/utils/.config_hashes.json
@@ -10,7 +10,7 @@
         "0400_roofline.yaml": "17b62eb17edee43abd833576a7c142a4",
         "0500_command_processor_cpc.yaml": "9de95259d153357dde907a7a410aa1a3",
         "0600_workgroup_manager_spi.yaml": "e0fb474a8a5e97cf26467578f7b5c316",
-        "0700_workgroup_processor.yaml": "40dd2cfd8753fcc3ad0d543327594d93",
+        "0700_workgroup_processor.yaml": "64769ca02ce42ca3db7c07124974a4fe",
         "0900_l0_cache.yaml": "1cbfbc0badeed8ec0caa178faec2f231",
         "1100_l1_cache.yaml": "7403eeb9b47f69f73cf42eccb984cdf7",
         "1300_l2_cache.yaml": "dd34f4b6cbdbb8afbafa059b58ba9839",

--- a/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml
+++ b/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml
@@ -378,10 +378,6 @@ Wave Instruction Mix:
     plain: Transcendental VALU instructions (SQ_INSTS_VALU_TRANS) per normalization unit. These cover hardware approximations such as sin, cos, and log on the vector ALU.
     rst: Transcendental VALU instructions (SQ_INSTS_VALU_TRANS) per normalization unit. These cover hardware approximations such as sin, cos, and log on the vector ALU.
     unit: Count per Normalization Unit
-  # Instructions - Dual VALU (VOPD): panel row disabled; dual-issue SQ counter not collected.
-  # plain: (disabled)
-  # rst: (disabled)
-  # unit: Count per Normalization Unit
   Instructions - VMEM:
     plain: Number of vector memory instructions executed, including global, buffer, and texture operations. High VMEM counts relative to VALU may indicate memory-bound workloads.
     rst: Number of vector memory instructions executed, including global, buffer, and texture operations. High VMEM counts relative to VALU may indicate memory-bound workloads.

--- a/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml
+++ b/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml
@@ -378,10 +378,10 @@ Wave Instruction Mix:
     plain: Transcendental VALU instructions (SQ_INSTS_VALU_TRANS) per normalization unit. These cover hardware approximations such as sin, cos, and log on the vector ALU.
     rst: Transcendental VALU instructions (SQ_INSTS_VALU_TRANS) per normalization unit. These cover hardware approximations such as sin, cos, and log on the vector ALU.
     unit: Count per Normalization Unit
-  Instructions - Dual VALU (VOPD):
-    plain: Dual-issue VALU instructions executed in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32) per normalization unit. The VOPD encoding pairs two independent VALU operations that issue in the same cycle.
-    rst: Dual-issue VALU instructions executed in wave32 mode (SQ_INSTS_DUAL_VALU_WAVE32) per normalization unit. The VOPD encoding pairs two independent VALU operations that issue in the same cycle.
-    unit: Count per Normalization Unit
+  # Instructions - Dual VALU (VOPD): panel row disabled; dual-issue SQ counter not collected.
+  # plain: (disabled)
+  # rst: (disabled)
+  # unit: Count per Normalization Unit
   Instructions - VMEM:
     plain: Number of vector memory instructions executed, including global, buffer, and texture operations. High VMEM counts relative to VALU may indicate memory-bound workloads.
     rst: Number of vector memory instructions executed, including global, buffer, and texture operations. High VMEM counts relative to VALU may indicate memory-bound workloads.


### PR DESCRIPTION
## Motivation

The gfx1151 SQ dual-issue VALU (VOPD) wave32 counter is not reliable for end-to-end collection on current stacks. This change stops rocprofiler-compute from requesting it via panel-derived PMC lists while keeping a reserved definition for future use.

Bugfix: avoids broken or misleading WGP "Dual VALU (VOPD)" metrics until the hardware/SDK path is validated.

## Technical Details

- `sdk_config.yaml`: rename counters to lowercase `sq_insts_dual_valu_wave32` / `_sum` and document as reserved; `gen_counter_list` only collects all-uppercase identifiers from panel formulas, so these are not auto-selected for PMC.
- `gfx1151/0700_workgroup_processor.yaml`: comment out the Wave Instruction Mix row and the matching `metrics_description` entry; refresh `src/utils/.config_hashes.json`.
- `tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml` and `docs/data/metrics/gfx1151_metrics.yaml`: align with the disabled panel row.
- `docs/conceptual/rdna/system-speed-of-light.rst`: remove the pointer to the removed WGP row; note the counter row is disabled and suggest inferring VOPD from VALU FLOPs vs. peak / ISA when needed.

## JIRA ID


## Test Plan

- `pytest projects/rocprofiler-compute/tests/test_autogen_config.py::test_config_hashes_match_files`
- Profile or analyze a gfx1151 workload and confirm PMC plans do not include the former `SQ_INSTS_DUAL_VALU_WAVE32` counter name.

## Test Result

- `pytest projects/rocprofiler-compute/tests/test_autogen_config.py::test_config_hashes_match_files` — passed locally before push.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
