### PR TITLE
[rccl] install nccl_device.h and nccl_device/ subtree

### DIFF
--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -579,6 +579,14 @@ rocm_install(FILES       ${PROJECT_BINARY_DIR}/include/rccl/rccl.h src/include/p
              DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rccl)
 rocm_install(FILES       src/include/api_trace.h
              DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rccl/amd_detail)
+## Install nccl_device.h plus the nccl_device/ subtree (see Makefile INCEXPORTS).
+## Required by downstream consumers (e.g. PyTorch's NCCL-backend symmetric memory)
+## that #include <nccl_device.h> to use the symmetric kernel device APIs.
+rocm_install(FILES       src/include/nccl_device.h
+             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rccl)
+rocm_install(DIRECTORY   src/include/nccl_device
+             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rccl
+             FILES_MATCHING PATTERN "*.h")
 ## Install tuner config directory for CSV-based tuner
 file(COPY tuner DESTINATION ${PROJECT_BINARY_DIR})
 rocm_install(DIRECTORY ${PROJECT_BINARY_DIR}/tuner DESTINATION ${CMAKE_INSTALL_DATADIR}/rccl)

--- a/projects/rccl/src/include/nccl_device/comm.h
+++ b/projects/rccl/src/include/nccl_device/comm.h
@@ -6,5 +6,5 @@
 
 #ifndef _NCCL_DEVICE_COMM_H_
 #define _NCCL_DEVICE_COMM_H_
-#include "core_tmp.h"
+#include "core.h"
 #endif

--- a/projects/rccl/src/include/nccl_device/core.h
+++ b/projects/rccl/src/include/nccl_device/core.h
@@ -6,7 +6,7 @@
 
 #ifndef _NCCL_DEVICE_CORE_H_
 #define _NCCL_DEVICE_CORE_H_
-#include <nccl.h>
+#include <rccl/rccl.h>
 #include "coop.h"
 #include "utility.h"
 

--- a/projects/rccl/src/include/nccl_device/impl/comm__types.h
+++ b/projects/rccl/src/include/nccl_device/impl/comm__types.h
@@ -6,7 +6,7 @@
 
 #ifndef _NCCL_DEVICE_COMM__TYPES_H_
 #define _NCCL_DEVICE_COMM__TYPES_H_
-#include "../comm_tmp.h"
+#include "../comm.h"
 #include "core__types.h"
 #include "mem_barrier__types.h"
 #include "ll_a2a__types.h"

--- a/projects/rccl/src/include/nccl_device/impl/core__types.h
+++ b/projects/rccl/src/include/nccl_device/impl/core__types.h
@@ -6,7 +6,7 @@
 
 #ifndef _NCCL_DEVICE_CORE__TYPES_H_
 #define _NCCL_DEVICE_CORE__TYPES_H_
-#include "../core_tmp.h"
+#include "../core.h"
 
 // nccl.h has: typedef ncclWindow_vidmem* ncclWindow_t;
 struct ncclWindow_vidmem {

--- a/projects/rccl/src/include/nccl_device/mem_barrier.h
+++ b/projects/rccl/src/include/nccl_device/mem_barrier.h
@@ -7,7 +7,7 @@
 #ifndef _NCCL_DEVICE_MEM_BARRIER_H_
 #define _NCCL_DEVICE_MEM_BARRIER_H_
 #include "impl/core__types.h"
-#include "core_tmp.h"
+#include "core.h"
 
 struct ncclLsaBarrierHandle;
 

--- a/projects/rccl/src/include/nccl_device/ptr.h
+++ b/projects/rccl/src/include/nccl_device/ptr.h
@@ -6,7 +6,7 @@
 
 #ifndef _NCCL_DEVICE_PTR_H_
 #define _NCCL_DEVICE_PTR_H_
-#include "core_tmp.h"
+#include "core.h"
 #include <stdint.h>
 
 #if __cplusplus


### PR DESCRIPTION
The legacy Makefile lists nccl_device.h plus the include/nccl_device/*.h and include/nccl_device/impl/*.h headers in INCEXPORTS, but the CMake install rules only ship rccl.h, nccl_net.h, and api_trace.h. 

See: https://github.com/ROCm/rccl/blob/57e58688f44c77076ad536ef1f6b68741fc6e694/src/Makefile#L10

As a result, downstream consumers built against /opt/rocm/include/rccl/* cannot #include <nccl_device.h>.

This blocks PyTorch's NCCL-backend symmetric memory implementation (NCCLSymmetricMemory.cu) from enabling NCCL_HAS_SYMMEM_DEVICE_SUPPORT on ROCM

 torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp gates the device-support code path on `#if !defined(USE_ROCM)` because the required header is not available downstream. With the header installed, that gate can be relaxed and torch.distributed._symmetric_memory's buffer_ptrs vector can be populated on ROCM

See: https://github.com/ROCm/pytorch/blob/5379cbe4a99daf7241eff5c7012da1b71221df9d/torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp#L14


Add a FILES rule for nccl_device.h and a DIRECTORY rule for the nccl_device/ subtree (filtered to *.h to skip README.md), mirroring the legacy Makefile's INCEXPORTS list.

## JIRA ID
Resolves AICOMRCCL-1051

