### PR TITLE
[rocprofiler-compute] Silence divide-by-zero warnings in metric eval

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -4,6 +4,7 @@
 import ast
 import json
 import re
+import warnings
 from pathlib import Path
 from typing import Any, Callable, Optional, Union
 
@@ -501,27 +502,32 @@ class db_analysis(OmniAnalyze_Base):
             )
         try:
             prev_noise_clamp_count = get_noise_clamp_warnings()["count"]
-            eval_result = eval(
-                compile(value, "<string>", "eval"),
-                {},  # no globals
-                {
-                    # only locals
-                    "pmc_df": pmc_df,
-                    "sys_info": sys_info,
-                    "to_avg": to_avg,
-                    "to_concat": to_concat,
-                    "to_int": to_int,
-                    "to_max": to_max,
-                    "to_median": to_median,
-                    "to_min": to_min,
-                    "to_mod": to_mod,
-                    "to_quantile": to_quantile,
-                    "to_round": to_round,
-                    "to_std": to_std,
-                    "to_sum": to_sum,
-                    "to_noise_clamp": to_noise_clamp,
-                },
-            )
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always", RuntimeWarning)
+                eval_result = eval(
+                    compile(value, "<string>", "eval"),
+                    {},  # no globals
+                    {
+                        # only locals
+                        "pmc_df": pmc_df,
+                        "sys_info": sys_info,
+                        "to_avg": to_avg,
+                        "to_concat": to_concat,
+                        "to_int": to_int,
+                        "to_max": to_max,
+                        "to_median": to_median,
+                        "to_min": to_min,
+                        "to_mod": to_mod,
+                        "to_quantile": to_quantile,
+                        "to_round": to_round,
+                        "to_std": to_std,
+                        "to_sum": to_sum,
+                        "to_noise_clamp": to_noise_clamp,
+                    },
+                )
+            # RuntimeWarnings (e.g. divide-by-zero) are surfaced only under --verbose
+            for w in caught:
+                console_debug(f"RuntimeWarning evaluating {name}: {w.message}")
 
             # eval_result can be None if expression has None explicitly specified
             # Do not give warning for this case and simply return None
@@ -537,8 +543,8 @@ class db_analysis(OmniAnalyze_Base):
 
             if is_scalar_na:
                 # Only warn if expression doesn't have "None" as an explicit fallback
-                # Expressions with .where(..., None) are expected to return NA
-                if "None" not in value:
+                # and no RuntimeWarning was emitted (e.g. divide-by-zero)
+                if "None" not in value and not caught:
                     console_warning(
                         f"Could not evaluate expression for {name}: {value} - "
                         "likely due to missing counter data."

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -527,24 +527,32 @@ class db_analysis(OmniAnalyze_Base):
                 )
             # RuntimeWarnings (e.g. divide-by-zero) are surfaced only under --verbose
             for w in caught:
-                console_debug(f"RuntimeWarning evaluating {name}: {w.message}")
+                console_debug(
+                    f"RuntimeWarning evaluating {name}: {value} - {w.message}"
+                )
 
             # eval_result can be None if expression has None explicitly specified
             # Do not give warning for this case and simply return None
             if eval_result is None:
                 return None
 
-            # Only return None for scalar NA values (NaN, pd.NA)
+            # Only return None for scalar NA values (NaN, pd.NA, +/-inf).
             # For vectors/Series, return as-is to preserve shape for downstream
             # operations. Note: pd.NA is not detected as scalar by np.isscalar()
             is_scalar_na = eval_result is pd.NA or (
-                np.isscalar(eval_result) and pd.isna(eval_result)
+                np.isscalar(eval_result)
+                and (pd.isna(eval_result) or np.isinf(eval_result))
             )
 
             if is_scalar_na:
-                # Only warn if expression doesn't have "None" as an explicit fallback
-                # and no RuntimeWarning was emitted (e.g. divide-by-zero)
-                if "None" not in value and not caught:
+                # Skip warning when None is explicit or a RuntimeWarning
+                # already explained the NA
+                if "None" in value:
+                    console_debug(
+                        f"Expression for {name}: {value} evaluated to "
+                        "None - explicitly specified."
+                    )
+                elif not caught:
                     console_warning(
                         f"Could not evaluate expression for {name}: {value} - "
                         "likely due to missing counter data."

--- a/projects/rocprofiler-compute/src/utils/metrics/metric_evaluator.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/metric_evaluator.py
@@ -89,17 +89,16 @@ class MetricEvaluator:
                     and (pd.isna(eval_result) or np.isinf(eval_result))
                 )
             ):
-                # Skip warning when None is explicit, or a RuntimeWarning already
-                # explained the NA (e.g. divide-by-zero)
-                if "None" not in expr and not caught:
+                # Skip warning when None is explicit or a RuntimeWarning
+                # already explained the NA
+                if "None" in expr:
+                    console_debug(
+                        f"Expression '{expr}' evaluated to None - explicitly specified."
+                    )
+                elif not caught:
                     console_warning(
                         f"Could not evaluate expression '{expr}' - likely "
                         "due to missing counter data."
-                    )
-                else:
-                    console_debug(
-                        f"Expression '{expr}' evaluated to None - likely "
-                        "explicitly specified."
                     )
                 return "N/A"
             else:

--- a/projects/rocprofiler-compute/src/utils/metrics/metric_evaluator.py
+++ b/projects/rocprofiler-compute/src/utils/metrics/metric_evaluator.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 import numpy as np
@@ -65,11 +66,16 @@ class MetricEvaluator:
                 "to_noise_clamp": to_noise_clamp,
             })
 
-            eval_result = eval(
-                compile(expr, "<string>", "eval"),
-                {},
-                local_expr_context,
-            )
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always", RuntimeWarning)
+                eval_result = eval(
+                    compile(expr, "<string>", "eval"),
+                    {},
+                    local_expr_context,
+                )
+            # RuntimeWarnings (e.g. divide-by-zero) are surfaced only under --verbose
+            for w in caught:
+                console_debug(f"RuntimeWarning evaluating '{expr}': {w.message}")
 
             # Only return "N/A" for scalar NA values
             # For vectors/Series, return as-is to preserve shape for
@@ -83,8 +89,9 @@ class MetricEvaluator:
                     and (pd.isna(eval_result) or np.isinf(eval_result))
                 )
             ):
-                # Do not give warning if None is explicitly specified in expression
-                if "None" not in expr:
+                # Skip warning when None is explicit, or a RuntimeWarning already
+                # explained the NA (e.g. divide-by-zero)
+                if "None" not in expr and not caught:
                     console_warning(
                         f"Could not evaluate expression '{expr}' - likely "
                         "due to missing counter data."

--- a/projects/rocprofiler-compute/tests/test_analysis_db.py
+++ b/projects/rocprofiler-compute/tests/test_analysis_db.py
@@ -208,6 +208,50 @@ def test_evaluate_with_none_in_formula_does_not_nullify_valid_result():
     assert result == 10
 
 
+def test_evaluate_divide_by_zero_silenced_and_logged_at_debug():
+    """
+    Divide-by-zero (x/0 -> inf, 0/0 -> NaN) emits a numpy RuntimeWarning
+    that is captured and logged via console_debug. The misleading
+    "missing counter data" console_warning must not fire.
+    """
+    pmc_df = pd.DataFrame({"Counter1": [10, 20, 30]})
+    sys_info = {}
+
+    cases = [
+        # x/0 yields scalar inf; evaluate() returns it as-is
+        ("to_sum(raw_pmc_df['Counter1']) / 0", float("inf")),
+        # 0/0 yields scalar NaN; evaluate() returns None
+        ("(to_sum(raw_pmc_df['Counter1']) * 0) / 0", None),
+    ]
+
+    for expr, expected in cases:
+        with (
+            patch(
+                "rocprof_compute_analyze.analysis_db.console_warning"
+            ) as mock_warning,
+            patch("rocprof_compute_analyze.analysis_db.console_debug") as mock_debug,
+        ):
+            result = db_analysis.evaluate(
+                "test_metric",
+                expr,
+                pmc_df,
+                sys_info,
+                parse=False,
+            )
+
+        if expected is None:
+            assert result is None, f"Expected None for '{expr}', got {result}"
+        else:
+            assert result == expected, f"Expected {expected} for '{expr}', got {result}"
+
+        mock_warning.assert_not_called()
+        debug_msgs = [str(call) for call in mock_debug.call_args_list]
+        assert any("RuntimeWarning" in m for m in debug_msgs), (
+            f"Expected RuntimeWarning in console_debug output for '{expr}', "
+            f"got {debug_msgs}"
+        )
+
+
 # =============================================================================
 # db_analysis.calc_builtin_vars() tests
 # =============================================================================

--- a/projects/rocprofiler-compute/tests/test_analysis_db.py
+++ b/projects/rocprofiler-compute/tests/test_analysis_db.py
@@ -218,13 +218,13 @@ def test_evaluate_divide_by_zero_silenced_and_logged_at_debug():
     sys_info = {}
 
     cases = [
-        # x/0 yields scalar inf; evaluate() returns it as-is
-        ("to_sum(raw_pmc_df['Counter1']) / 0", float("inf")),
-        # 0/0 yields scalar NaN; evaluate() returns None
-        ("(to_sum(raw_pmc_df['Counter1']) * 0) / 0", None),
+        # x/0 yields scalar inf; evaluate() collapses to None
+        "to_sum(raw_pmc_df['Counter1']) / 0",
+        # 0/0 yields scalar NaN; evaluate() collapses to None
+        "(to_sum(raw_pmc_df['Counter1']) * 0) / 0",
     ]
 
-    for expr, expected in cases:
+    for expr in cases:
         with (
             patch(
                 "rocprof_compute_analyze.analysis_db.console_warning"
@@ -239,10 +239,7 @@ def test_evaluate_divide_by_zero_silenced_and_logged_at_debug():
                 parse=False,
             )
 
-        if expected is None:
-            assert result is None, f"Expected None for '{expr}', got {result}"
-        else:
-            assert result == expected, f"Expected {expected} for '{expr}', got {result}"
+        assert result is None, f"Expected None for '{expr}', got {result}"
 
         mock_warning.assert_not_called()
         debug_msgs = [str(call) for call in mock_debug.call_args_list]

--- a/projects/rocprofiler-compute/tests/test_metric_utils.py
+++ b/projects/rocprofiler-compute/tests/test_metric_utils.py
@@ -699,6 +699,45 @@ class TestMetricEvaluator:
             f"SUM([100,200]) / 5 should be 60.0, got {result}"
         )
 
+    def test_eval_expression_divide_by_zero_silenced_and_logged_at_debug(self):
+        """
+        Divide-by-zero (x/0 -> inf, 0/0 -> NaN) emits a numpy RuntimeWarning
+        that is captured and logged via console_debug. The misleading
+        "missing counter data" console_warning must not fire; the function
+        still returns 'N/A' for both cases.
+        """
+        cases = [
+            # x/0 -> inf, taken by the np.isinf branch
+            (
+                {"NUMERATOR": [100.0, 200.0], "DENOMINATOR": [0.0, 0.0]},
+                "SUM(NUMERATOR) / SUM(DENOMINATOR)",
+            ),
+            # 0/0 -> NaN
+            (
+                {"NUMERATOR": [0.0, 0.0], "DENOMINATOR": [0.0, 0.0]},
+                "SUM(NUMERATOR) / SUM(DENOMINATOR)",
+            ),
+        ]
+
+        for columns, equation in cases:
+            evaluator = self._make_evaluator(columns)
+            eval_str = self._to_eval_str(equation)
+            with (
+                patch("utils.metrics.metric_evaluator.console_warning") as mock_warning,
+                patch("utils.metrics.metric_evaluator.console_debug") as mock_debug,
+            ):
+                result = evaluator.eval_expression(eval_str)
+
+            assert result == "N/A", (
+                f"Expected 'N/A' for '{equation}' with {columns}, got {result}"
+            )
+            mock_warning.assert_not_called()
+            debug_msgs = [str(call) for call in mock_debug.call_args_list]
+            assert any("RuntimeWarning" in m for m in debug_msgs), (
+                f"Expected RuntimeWarning in console_debug output for "
+                f"'{equation}', got {debug_msgs}"
+            )
+
     def test_eval_expression_aggregates_past_partial_zeros_in_denominator(self):
         """SUM aggregates past zero entries in the denominator without erroring."""
         evaluator = self._make_evaluator({


### PR DESCRIPTION
## Motivation

When evaluating metric expressions in `analysis_db.py` and `metric_evaluator.py`,
pandas/numpy emit `RuntimeWarning: invalid value encountered in scalar divide`
on a zero denominator and return scalar NaN. The current code surfaces a
misleading `console_warning` claiming "missing counter data" even when the
data is present and the result is legitimately N/A.

## Technical Details

- Wrap `eval()` in `warnings.catch_warnings(record=True)` so the raw
  `<string>:2: RuntimeWarning` no longer leaks to stderr.
- Log captured RuntimeWarnings via `console_debug` so they remain visible
  under `--verbose` for diagnostics.
- Skip the "missing counter data" warning when a RuntimeWarning already
  explains the scalar NA (e.g. divide-by-zero on a valid zero denominator).
- Add unit tests covering both `x/0` and `0/0` in `test_analysis_db.py` and
  `test_metric_utils.py::TestMetricEvaluator`.

## JIRA ID

AIPROFCOMP-609

## Test Plan

- Run `rocprof-compute analyze` on a workload that produces a zero
  denominator in one of the metric expressions and confirm no
  `<string>:2: RuntimeWarning` and no `Could not evaluate expression...`
  warnings appear on stderr.
- Re-run with `-v` and confirm the RuntimeWarning is now logged at debug
  level with the expression name.
- Confirm existing "missing counter data" warnings still fire for real
  missing-counter cases (no RuntimeWarning emitted).
- `pytest tests/test_analysis_db.py tests/test_metric_utils.py::TestMetricEvaluator`

## Test Result

- Pass: 28/28 in `tests/test_analysis_db.py` and `TestMetricEvaluator`,
  including the two new `*_divide_by_zero_silenced_and_logged_at_debug`
  tests.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.