### PR TITLE
[RCCL] Fix build failure with ENABLE_ROCSHMEM=ON (ROCM-24149)

### DIFF
--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -243,6 +243,11 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
   target_link_libraries(${_dev_target} PRIVATE rccl_device_defs)
 
   add_dependencies(${_dev_target} hipify_all)
+  if(ENABLE_ROCSHMEM AND TARGET rocshmem_static)
+    # rocSHMEM headers land in ext/rocshmem/include only after ExternalProject
+    # completes; ensure they are installed before device kernels start compiling.
+    add_dependencies(${_dev_target} rocshmem_static)
+  endif()
 
   # =========================================================================
   # Link step: driver --link mode produces device.elf
@@ -287,6 +292,23 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
   file(GENERATE OUTPUT "${_link_rsp}"
     CONTENT "$<JOIN:$<TARGET_OBJECTS:${_dev_target}>,\n>\n")
 
+  # When rocSHMEM is enabled, pass the per-arch device bitcode to the driver.
+  # rocSHMEM device API symbols have hidden visibility and must be statically
+  # present in the device ELF — they cannot be imported from a shared library.
+  set(_rocshmem_bitcode_arg "")
+  set(_rocshmem_link_depends "")
+  if(ENABLE_ROCSHMEM AND ROCSHMEM_INSTALL_DIR)
+    set(_rocshmem_bc "${ROCSHMEM_INSTALL_DIR}/lib/librocshmem_device_${DL_GPU_TARGET}.bc")
+    set(_rocshmem_bitcode_arg "--rocshmem-bitcode=${_rocshmem_bc}")
+    # Do NOT add _rocshmem_bc to DEPENDS: rocSHMEM only supports a subset of
+    # GPU_TARGETS (e.g. gfx90a, gfx942, gfx950) and the bitcode files don't
+    # exist at cmake configure time (ExternalProject).  The Python driver checks
+    # existence at build time and skips silently for unsupported arches.
+    if(TARGET rocshmem_static)
+      list(APPEND _rocshmem_link_depends rocshmem_static)
+    endif()
+  endif()
+
   add_custom_command(
     OUTPUT  ${ARCH_DEVICE_ELF}
     COMMAND ${CMAKE_RCCLDEV_COMPILER}
@@ -295,13 +317,14 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
       --clang=${DL_CLANG}
       ${DL_HIP_COMPILER_FLAGS}
       --dispatcher=${HIPIFY_DIR}/src/device/common.cu.cpp
+      ${_rocshmem_bitcode_arg}
       ${_link_def_flags}
       ${_link_inc_flags}
       ${DL_OPT_FLAGS}
       -std=c++17
       -o ${ARCH_DEVICE_ELF}
       @${_link_rsp}
-    DEPENDS ${_dev_target} ${HIPIFY_DIR}/src/device/common.cu.cpp
+    DEPENDS ${_dev_target} ${HIPIFY_DIR}/src/device/common.cu.cpp ${_rocshmem_link_depends}
     COMMENT "DL [${DL_GPU_TARGET}] link: device.elf"
     VERBATIM
     COMMAND_EXPAND_LISTS

--- a/projects/rccl/cmake/ROCSHMEM.cmake
+++ b/projects/rccl/cmake/ROCSHMEM.cmake
@@ -81,6 +81,7 @@ function(add_rocshmem_targets)
             ${CMAKE_COMMAND} -E chdir build ${CMAKE_MAKE_PROGRAM} install
     )
 
+    set(ROCSHMEM_INSTALL_DIR  "${ROCSHMEM_INSTALL_DIR}"          PARENT_SCOPE)
     set(ROCSHMEM_INCLUDE_DIR "${ROCSHMEM_INSTALL_DIR}/include" PARENT_SCOPE)
     set(ROCSHMEM_LIBRARY     "${ROCSHMEM_INSTALL_DIR}/lib/librocshmem.a" PARENT_SCOPE)
 

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -958,6 +958,23 @@ target_link_libraries(rccl PRIVATE $<BUILD_INTERFACE:fmt::fmt-header-only>)
 if(ENABLE_ROCSHMEM)
   target_link_libraries(rccl PRIVATE ${ROCSHMEM_LIBRARY})
   target_link_libraries(rccl PRIVATE ${IBVERBS})
+  # librocshmem.a is compiled with -fgpu-rdc (relocatable device code).
+  # The __hip_gpubin_handle_* symbols referenced by __hip_module_ctor in the
+  # librocshmem.a objects are only defined by the RDC device-link step.
+  # --hip-link tells amdclang++ to perform that step as part of the final
+  # librccl.so link; -fgpu-rdc marks the link as RDC-mode.  --offload-arch
+  # flags use RCCL's GPU_TARGETS (stripped of feature suffixes like :xnack-)
+  # so the device-link covers every arch RCCL is built for.
+  # RCCL's own device code (already embedded in device_build/common.o by the
+  # custom device-linker pipeline) is NOT compiled with -fgpu-rdc and is
+  # therefore unaffected by this device-link step.
+  set(_rocshmem_offload_arch_flags "")
+  foreach(_gpu_raw ${GPU_TARGETS})
+    string(REGEX REPLACE ":.*" "" _gpu "${_gpu_raw}")
+    list(APPEND _rocshmem_offload_arch_flags "--offload-arch=${_gpu}")
+  endforeach()
+  list(REMOVE_DUPLICATES _rocshmem_offload_arch_flags)
+  target_link_options(rccl PRIVATE -fgpu-rdc --hip-link ${_rocshmem_offload_arch_flags})
 endif()
 
 ## Set RCCL link options

--- a/projects/rccl/tools/rccl-device-compile
+++ b/projects/rccl/tools/rccl-device-compile
@@ -17,7 +17,8 @@ Link mode (--link):
     2. Compiles dispatcher source to assembly
     3. Patches dispatcher with aggregated resources
     4. Assembles patched dispatcher
-    5. Links all objects + dispatcher into device.elf via ld.lld
+    5. Optionally compiles --rocshmem-bitcode=<path>.bc to a device object
+    6. Links all objects + dispatcher (+ optional rocSHMEM object) into device.elf via ld.lld
 
 Tool discovery:
     amdclang++, ld.lld are found relative to --clang=<path> or by searching
@@ -544,6 +545,7 @@ def do_link(args, forwarded_flags):
     output = args.output
     dispatcher = args.dispatcher
     keep_temps = args.keep_temps
+    rocshmem_bitcode = getattr(args, 'rocshmem_bitcode', None)
 
     if not dispatcher:
         raise SystemExit("ERROR: --link requires --dispatcher=<source>")
@@ -571,13 +573,17 @@ def do_link(args, forwarded_flags):
         disp_asm = os.path.join(output_dir, f'dispatcher_{arch}.s')
         disp_patched = os.path.join(output_dir, f'dispatcher_{arch}_patched.s')
         disp_obj = os.path.join(output_dir, f'dispatcher_{arch}.o')
+        rocshmem_obj = os.path.join(output_dir, f'rocshmem_device_{arch}.o') if rocshmem_bitcode else None
         cleanup = []
     else:
         tmpdir = tempfile.mkdtemp(prefix='rccl-dl-')
         disp_asm = os.path.join(tmpdir, 'dispatcher.s')
         disp_patched = os.path.join(tmpdir, 'dispatcher_patched.s')
         disp_obj = os.path.join(tmpdir, 'dispatcher.o')
+        rocshmem_obj = os.path.join(tmpdir, 'rocshmem_device.o') if rocshmem_bitcode else None
         cleanup = [disp_asm, disp_patched, disp_obj, tmpdir]
+        if rocshmem_obj:
+            cleanup.insert(-1, rocshmem_obj)  # remove before rmdir
 
     try:
         # Step 2: Compile dispatcher to assembly
@@ -609,13 +615,35 @@ def do_link(args, forwarded_flags):
         ]
         run(disp_assemble_cmd, f"assemble dispatcher for {arch}")
 
-        # Step 5: Link all objects + dispatcher into device.elf
+        # Step 5: Compile rocSHMEM device bitcode to an amdgcn object (if provided).
+        # rocSHMEM device API symbols (rocshmem::*_wg, rocshmem_n_pes, …) have
+        # hidden visibility and cannot be imported from a shared lib — they must
+        # be statically present in the device ELF.  The bitcode path is supplied
+        # by CMake via --rocshmem-bitcode when ENABLE_ROCSHMEM is on.
+        if rocshmem_bitcode:
+            if not os.path.exists(rocshmem_bitcode):
+                print(f"  rocSHMEM: no device bitcode for {arch} ({rocshmem_bitcode}), skipping",
+                      file=sys.stderr)
+                rocshmem_obj = None
+            else:
+                bc_compile_cmd = [
+                    clang,
+                    '-target', 'amdgcn-amd-amdhsa',
+                    f'-mcpu={arch}',
+                    '-c', '-x', 'ir',
+                    '-o', rocshmem_obj, rocshmem_bitcode,
+                ]
+                run(bc_compile_cmd, f"compile rocSHMEM device bitcode for {arch}")
+
+        # Step 6: Link all objects + dispatcher into device.elf
         # Use a response file for potentially long object lists
         rsp_path = os.path.join(output_dir, f'link_{arch}.rsp')
         with open(rsp_path, 'w') as f:
             f.write(disp_obj + '\n')
             for obj in objects:
                 f.write(obj + '\n')
+            if rocshmem_obj:
+                f.write(rocshmem_obj + '\n')
 
         link_cmd = [
             lld, '-shared',
@@ -672,6 +700,11 @@ def parse_compiler_flags(argv):
         elif arg == '--dispatcher' and i + 1 < len(argv):
             our_args.extend([arg, argv[i + 1]])
             i += 1
+        elif arg.startswith('--rocshmem-bitcode='):
+            our_args.append(arg)
+        elif arg == '--rocshmem-bitcode' and i + 1 < len(argv):
+            our_args.extend([arg, argv[i + 1]])
+            i += 1
         elif arg == '-o' and i + 1 < len(argv):
             our_args.extend(['-o', argv[i + 1]])
             i += 1
@@ -717,6 +750,7 @@ def main():
     parser.add_argument('--arch', required=False)
     parser.add_argument('--clang', default=None)
     parser.add_argument('--dispatcher', default=None)
+    parser.add_argument('--rocshmem-bitcode', default=None, dest='rocshmem_bitcode')
     parser.add_argument('-o', '--output', required=False)
     parser.add_argument('--keep-temps', action='store_true')
     parser.add_argument('--version', action='store_true')


### PR DESCRIPTION
## Summary

Fixes three bugs that caused RCCL to fail to build when `ENABLE_ROCSHMEM=ON` (or `--rocshmem` passed to `install.sh`).

**Bug 1 — device linker never included rocSHMEM device bitcode** (`tools/rccl-device-compile`)

The `--link` driver had no way to include rocSHMEM device-side bitcode in the per-arch `device.elf`. rocSHMEM device API symbols (`rocshmem::rocshmem_n_pes`, `rocshmem::rocshmem_char_alltoall_wg`, etc.) carry hidden visibility and cannot be imported from a shared library — they must be statically linked into every device ELF that references them.

Fix: add `--rocshmem-bitcode=<path>` arg. When supplied and the file exists for the arch, the `.bc` is compiled to an amdgcn object and appended to the `ld.lld` RSP. Arches not supported by rocSHMEM (e.g. gfx906, gfx1030) skip silently.

**Bug 2 — cmake DEPENDS on a file that doesn't exist at configure time** (`cmake/DeviceLinker.cmake`)

The bitcode path was added to cmake `DEPENDS`, causing make to fail with `No rule to make target 'librocshmem_device_gfx906.bc'` for arches rocSHMEM doesn't support. rocSHMEM is also built via `ExternalProject_Add`, so no bitcode files exist at cmake configure time.

Fix: remove the bitcode file from cmake `DEPENDS`; the `rocshmem_static` target dependency ensures ordering. The Python driver checks file existence at build time. Also adds `add_dependencies(rccl_device_<arch> rocshmem_static)` so headers are installed before device kernels start compiling.

**Bug 3 — `__hip_gpubin_handle_*` undefined in host link** (`src/CMakeLists.txt`)

`librocshmem.a` is compiled with `-fgpu-rdc` (relocatable device code). Its objects reference `__hip_gpubin_handle_*` symbols that are only defined by the HIP RDC device-link step, which RCCL's final host link was not triggering.

Fix: add `-fgpu-rdc --hip-link --offload-arch=<each GPU_TARGET>` to `rccl`'s link options when `ENABLE_ROCSHMEM` is on, triggering the RDC device-link step as part of the `librccl.so` link. RCCL's own device code (already embedded in `device_build/common.o` by the custom device-linker pipeline) is not compiled with `-fgpu-rdc` and is unaffected.

**Bonus — `ROCSHMEM_INSTALL_DIR` not propagated to parent scope** (`cmake/ROCSHMEM.cmake`)

`ROCSHMEM_INSTALL_DIR` was not set with `PARENT_SCOPE` after the ExternalProject path, so `DeviceLinker.cmake` could not use it to construct the per-arch bitcode paths.

## Test plan

- [ ] `./install.sh -l --rocshmem -j $(nproc)` completes with exit 0 and produces `librccl.so`
- [ ] Normal build without `--rocshmem` (`./install.sh -l`) is unaffected
- [ ] Arches not supported by rocSHMEM (gfx906, gfx908, gfx1030, etc.) produce a skip message rather than a build failure