### PR TITLE
[RCCL] Fix --rocshmem build with the device-linker pipeline

### DIFF
--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -47,6 +47,24 @@ set(DEVICE_BUILD_DIR "${PROJECT_BINARY_DIR}/device_build")
 set(SPECIALIZED_DIR  "${GEN_DIR}/specialized")
 
 # ---------------------------------------------------------------------------
+# rocSHMEM device bitcode integration
+#
+# rocSHMEM ships a per-arch device bitcode file (librocshmem_device_<arch>.bc)
+# that defines the device-side rocshmem_* implementations referenced by
+# RCCL's GDA AlltoAll kernels. Under -fgpu-rdc this bitcode is auto-linked
+# by the HIP toolchain when the host-side static archive (librocshmem.a) is
+# pulled in. The device-linker pipeline bypasses --hip-link entirely and
+# links per-arch device.elf files directly via ld.lld, so the bitcode must
+# be compiled to a per-arch relocatable object and added to that link step.
+# ---------------------------------------------------------------------------
+set(DL_ROCSHMEM_ENABLED FALSE)
+if(ENABLE_ROCSHMEM AND ROCSHMEM_LIBRARY)
+  get_filename_component(DL_ROCSHMEM_LIB_DIR "${ROCSHMEM_LIBRARY}" DIRECTORY)
+  set(DL_ROCSHMEM_ENABLED TRUE)
+  message(STATUS "Device Linker: rocSHMEM device bitcode dir = ${DL_ROCSHMEM_LIB_DIR}")
+endif()
+
+# ---------------------------------------------------------------------------
 # Parse GPU_TARGETS: strip target features, build offload-arch flag list
 # ---------------------------------------------------------------------------
 set(DL_GPU_TARGETS "")
@@ -243,6 +261,44 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
   target_link_libraries(${_dev_target} PRIVATE rccl_device_defs)
 
   add_dependencies(${_dev_target} hipify_all)
+  # Specialized kernels include <rocshmem/rocshmem.hpp> via device.h when
+  # ENABLE_ROCSHMEM is set, so rocSHMEM must finish installing its headers
+  # before any of these compiles start.
+  if(DL_ROCSHMEM_ENABLED AND TARGET rocshmem_ext)
+    add_dependencies(${_dev_target} rocshmem_ext)
+  endif()
+
+  # =========================================================================
+  # rocSHMEM device bitcode -> per-arch relocatable object
+  # =========================================================================
+  set(_rocshmem_dev_obj "")
+  if(DL_ROCSHMEM_ENABLED)
+    set(_rocshmem_dev_bc "${DL_ROCSHMEM_LIB_DIR}/librocshmem_device_${DL_GPU_TARGET}.bc")
+    set(_rocshmem_dev_obj "${DL_ARCH_DIR}/rocshmem_device.o")
+    # When rocSHMEM is built from source (ExternalProject), depend on the
+    # rocshmem_ext target so the .bc file exists before we compile it. When
+    # rocSHMEM is pre-built (ROCSHMEM_INSTALL_DIR), rocshmem_ext is not a
+    # target and the .bc file is expected to exist on disk — depend on the
+    # file path itself in that case.
+    if(TARGET rocshmem_ext)
+      set(_rocshmem_dev_bc_dep rocshmem_ext)
+    else()
+      set(_rocshmem_dev_bc_dep "${_rocshmem_dev_bc}")
+    endif()
+    add_custom_command(
+      OUTPUT  ${_rocshmem_dev_obj}
+      COMMAND ${DL_CLANG}
+        --target=amdgcn-amd-amdhsa
+        -mcpu=${DL_GPU_TARGET}
+        ${DL_HIP_COMPILER_FLAGS}
+        -w
+        -c -o ${_rocshmem_dev_obj}
+        ${_rocshmem_dev_bc}
+      DEPENDS ${_rocshmem_dev_bc_dep}
+      COMMENT "DL [${DL_GPU_TARGET}] compile rocSHMEM device bitcode -> .o"
+      VERBATIM
+    )
+  endif()
 
   # =========================================================================
   # Link step: driver --link mode produces device.elf
@@ -287,6 +343,16 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
   file(GENERATE OUTPUT "${_link_rsp}"
     CONTENT "$<JOIN:$<TARGET_OBJECTS:${_dev_target}>,\n>\n")
 
+  # Extra positional inputs to the link step (currently: rocSHMEM device .o).
+  # These are appended after the response file so they're treated as positional
+  # object inputs by rccl-device-compile --link.
+  set(_link_extra_objs "")
+  set(_link_extra_deps "")
+  if(_rocshmem_dev_obj)
+    list(APPEND _link_extra_objs ${_rocshmem_dev_obj})
+    list(APPEND _link_extra_deps ${_rocshmem_dev_obj})
+  endif()
+
   add_custom_command(
     OUTPUT  ${ARCH_DEVICE_ELF}
     COMMAND ${CMAKE_RCCLDEV_COMPILER}
@@ -301,7 +367,8 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
       -std=c++17
       -o ${ARCH_DEVICE_ELF}
       @${_link_rsp}
-    DEPENDS ${_dev_target} ${HIPIFY_DIR}/src/device/common.cu.cpp
+      ${_link_extra_objs}
+    DEPENDS ${_dev_target} ${HIPIFY_DIR}/src/device/common.cu.cpp ${_link_extra_deps}
     COMMENT "DL [${DL_GPU_TARGET}] link: device.elf"
     VERBATIM
     COMMAND_EXPAND_LISTS
@@ -529,6 +596,13 @@ add_custom_target(device_linker_build ALL
   DEPENDS ${COMMON_FAT_OBJ} ${ONERANK_FAT_OBJ} ${COLLECTIVES_FAT_OBJ} ${SYM_FAT_OBJS}
 )
 add_dependencies(device_linker_build hipify_all)
+# common.cu.cpp / collectives.cc / sym kernels also see device.h, which pulls
+# in <rocshmem/rocshmem.hpp> when ENABLE_ROCSHMEM is set. Without an explicit
+# ordering dependency, these custom-command compilations race the rocSHMEM
+# external project install step and fail with "rocshmem/rocshmem.hpp not found".
+if(DL_ROCSHMEM_ENABLED AND TARGET rocshmem_ext)
+  add_dependencies(device_linker_build rocshmem_ext)
+endif()
 
 set(DEVICE_LINKER_OBJECTS
   ${COMMON_FAT_OBJ}

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -926,6 +926,29 @@ if (ROCTX_ENABLE)
 endif()
 if(NOT ENABLE_DEVICE_LINKER)
   target_link_libraries(rccl PRIVATE   -fgpu-rdc)             # Required when linking relocatable device code
+elseif(ENABLE_ROCSHMEM)
+  # The device-linker pipeline normally avoids -fgpu-rdc because rccl's own
+  # device code is pre-built into fat objects (common.o / onerank.o / ...).
+  # However librocshmem.a is compiled with -fgpu-rdc and its host-side objects
+  # reference __hip_gpubin_handle_<hash> symbols that are only emitted by
+  # clang's --hip-link pass. Force the HIP link action so those symbols are
+  # resolved against rocSHMEM's device IR while leaving the already-bundled
+  # rccl fat objects untouched.
+  target_link_options(rccl PRIVATE --hip-link -fgpu-rdc)
+  # Build a deduplicated list of base GPU targets (strip :xnack-/:xnack+
+  # suffixes) and emit one --offload-arch per unique arch. rocSHMEM's device
+  # bitcode files are keyed on the bare arch name; emitting the xnack-flavored
+  # variant twice would just add the same --offload-arch=gfx<N> twice to the
+  # link line.
+  set(_dl_rocshmem_archs "")
+  foreach(_arch IN LISTS GPU_TARGETS)
+    string(REGEX REPLACE ":.*" "" _arch_clean "${_arch}")
+    list(APPEND _dl_rocshmem_archs "${_arch_clean}")
+  endforeach()
+  list(REMOVE_DUPLICATES _dl_rocshmem_archs)
+  foreach(_arch IN LISTS _dl_rocshmem_archs)
+    target_link_options(rccl PRIVATE --offload-arch=${_arch})
+  endforeach()
 endif()
 target_link_libraries(rccl PRIVATE   Threads::Threads)
 target_link_libraries(rccl INTERFACE hip::host)


### PR DESCRIPTION
## Motivation

Enable the default RCCL build to work cleanly with `--rocshmem`. Today `./install.sh --rocshmem` only succeeds when paired with `--no-device-linker`; this PR extends the default device-linker pipeline so it integrates rocSHMEM out of the box, matching the behavior of the legacy path.

## Technical Details

The device-linker pipeline links each per-arch `device.elf` directly via `ld.lld` rather than going through `--hip-link`, so a few additional integration points are needed when rocSHMEM is in the picture:

- The GDA AlltoAll kernels under `src/device/alltoall_gda.h` and `alltoallv_gda.h` reference device-side rocSHMEM entry points (`rocshmem::rocshmem_n_pes()`, `rocshmem::rocshmem_char_alltoall_wg(...)`, etc.) that live in `librocshmem_device_<arch>.bc`. That bitcode needs to be folded into each per-arch `device.elf`.
- Specialized kernel TUs, `common.cu.cpp`, `collectives.cc`, and the symmetric kernel TUs all see `<rocshmem/rocshmem.hpp>` via `device.h` under `ENABLE_ROCSHMEM`, so they need an explicit ordering edge against the rocSHMEM `ExternalProject` install step.
- `librocshmem.a` is built with `-fgpu-rdc`, so its host-side objects reference `__hip_gpubin_handle_<hash>` symbols that are emitted by clang's `--hip-link` pass; the final librccl.so link needs to opt into that pass so those symbols are resolved against rocSHMEM's device IR.

Changes, both gated on `ENABLE_ROCSHMEM`:

- `projects/rccl/cmake/DeviceLinker.cmake`
  - Derives `DL_ROCSHMEM_LIB_DIR` from `ROCSHMEM_LIBRARY`.
  - Per GPU target, compiles `librocshmem_device_<arch>.bc` into a per-arch `rocshmem_device.o` (`--target=amdgcn-amd-amdhsa -mcpu=<arch>`) and appends it as a positional input to `rccl-device-compile --link`, so it lands in that arch's `device.elf`.
  - Adds build-order edges: `add_dependencies(rccl_device_<arch> rocshmem_ext)` and `add_dependencies(device_linker_build rocshmem_ext)`. The bitcode-compile custom command depends on `rocshmem_ext` when it's a target, and falls back to depending on the `.bc` file path when rocSHMEM is supplied pre-built via `ROCSHMEM_INSTALL_DIR`.

- `projects/rccl/src/CMakeLists.txt`
  - When `ENABLE_DEVICE_LINKER AND ENABLE_ROCSHMEM`, adds `--hip-link -fgpu-rdc --offload-arch=<each>` to rccl's `LINK_OPTIONS` via `target_link_options`. Clang runs the HIP link action over rocSHMEM's `-fgpu-rdc` objects; the already-bundled rccl fat objects (`common.o` / `onerank.o` / `collectives.o` / `sym_*.o`) pass through untouched. Base arches are de-duplicated so the ASAN `:xnack+` expansion doesn't emit `--offload-arch=gfx942` twice.

Both edits are no-ops when `ENABLE_ROCSHMEM=OFF` (the default RCCL build) and when `ENABLE_DEVICE_LINKER=OFF` (the legacy `-fgpu-rdc` path, which is preserved as-is).

## JIRA ID

<!-- Add the appropriate AICOMRCCL / SWDEV ID here. -->

## Test Plan

Each scenario was tested as a clean rebuild (`rm -rf build/release` first) with the standard rocSHMEM env:

```
export LD_LIBRARY_PATH=/path/to/ucx/lib:/path/to/ompi/lib:/opt/rocm/lib
export PATH=/path/to/ucx/bin:/path/to/ompi/bin:$PATH
```

- `./install.sh -l` — default build, no rocSHMEM, device linker on. Confirms the patch is inert in the most common configuration.
- `./install.sh -l --rocshmem` — rocSHMEM with the default device-linker pipeline; the configuration this PR enables.
- `./install.sh -l --rocshmem --no-device-linker` — legacy `-fgpu-rdc` path; confirms no regression.
- Symbol audit on the resulting `librccl.so`: no undefined `rocshmem::*` and no undefined `__hip_gpubin_handle_*`.
- Fatbin audit via `llvm-objdump --offload-fatbin librccl.so`: confirms both the rccl device kernels and the rocSHMEM device IR are bundled for the target arch.
- Generated `device.elf` make rule inspection for the `--rocshmem`-off case to confirm the rule is byte-identical to pre-patch (no spurious empty trailing args).

## Test Result

- `./install.sh -l`: build succeeds, librccl.so is 13 MB, 0 occurrences of `--hip-link` or `-fgpu-rdc` in `src/CMakeFiles/rccl.dir/link.txt`, `device.elf` make rule ends with `@.../link_objects.rsp` (no trailing args).
- `./install.sh -l --rocshmem`: build succeeds, librccl.so is 15 MB, 2195 `rocshmem`-prefixed symbols defined, zero undefined `rocshmem::*` or `__hip_gpubin_handle_*` symbols, `device_build/-gfx942/rocshmem_device.o` produced, embedded fatbin contains both `librccl.so.0.hipv4-amdgcn-amd-amdhsa--gfx942` (rccl kernels via the device linker) and `librccl.so.1.hipv4-amdgcn-amd-amdhsa--gfx942` (rocSHMEM device IR registered via `--hip-link`).
- `./install.sh -l --rocshmem --no-device-linker`: legacy path still builds cleanly — unchanged.
- `rcclras` binary builds in all three cases.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.