### PR TITLE
rocr: Fix unguarded cast to GPUAgent

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/agent.h
@@ -332,7 +332,7 @@ class Agent : public Checked<0xF6BC25EB17E6F917> {
 
   /// @brief Returns the nearest CPU agent to this agent.
   ///
-  /// @retval pointer to the nearest CPU agent. If there is no CPU agent
+  /// @retval pointer to the nearest CPU agent
   virtual Agent* GetNearestCpuAgent() const = 0;
 
   // @brief Initialize secondary CUID for this agent.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/agent.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2025, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -329,6 +329,11 @@ class Agent : public Checked<0xF6BC25EB17E6F917> {
   // attribute.
   virtual hsa_status_t GetInfo(hsa_agent_info_t attribute,
                                void* value) const = 0;
+
+  /// @brief Returns the nearest CPU agent to this agent.
+  ///
+  /// @retval pointer to the nearest CPU agent. If there is no CPU agent
+  virtual Agent* GetNearestCpuAgent() const = 0;
 
   // @brief Initialize secondary CUID for this agent.
   virtual void InitDerivedCuid() = 0;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aie_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aie_agent.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2022-2023, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2022-2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -40,8 +40,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-// AMD specific HSA backend.
-
 #ifndef HSA_RUNTIME_CORE_INC_AMD_AIE_AGENT_H_
 #define HSA_RUNTIME_CORE_INC_AMD_AIE_AGENT_H_
 
@@ -64,6 +62,7 @@ public:
  hsa_status_t VisitRegion(bool include_peer,
                           hsa_status_t (*callback)(hsa_region_t region, void* data),
                           void* data) const override;
+
  hsa_status_t IterateRegion(hsa_status_t (*callback)(hsa_region_t region, void* data),
                             void* data) const override;
 
@@ -74,6 +73,8 @@ public:
                                    void* data) const override;
 
  hsa_status_t GetInfo(hsa_agent_info_t attribute, void* value) const override;
+
+ core::Agent* GetNearestCpuAgent() const override;
 
  void InitDerivedCuid() override;
 
@@ -96,11 +97,13 @@ public:
   /// @brief Getter for the AIE system deallocator.
   const std::function<void(void*)>& system_deallocator() const { return system_deallocator_; }
 
+  /// @brief Getter for the AIE node properties.
   const HsaNodeProperties& properties() const { return node_props_; }
 
 private:
   /// @brief Query the driver to get the region list owned by this agent.
   void InitRegionList();
+
   /// @brief Setup the memory allocators used by this agent.
   void InitAllocators();
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aie_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aie_agent.h
@@ -94,11 +94,11 @@ public:
    return system_allocator_;
  }
 
-  /// @brief Getter for the AIE system deallocator.
-  const std::function<void(void*)>& system_deallocator() const { return system_deallocator_; }
+ /// @brief Getter for the AIE system deallocator.
+ const std::function<void(void*)>& system_deallocator() const { return system_deallocator_; }
 
-  /// @brief Getter for the AIE node properties.
-  const HsaNodeProperties& properties() const { return node_props_; }
+ /// @brief Getter for the AIE node properties.
+ const HsaNodeProperties& properties() const { return node_props_; }
 
 private:
   /// @brief Query the driver to get the region list owned by this agent.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_cpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_cpu_agent.h
@@ -91,6 +91,8 @@ class CpuAgent : public core::Agent {
   // @brief Override from core::Agent.
   hsa_status_t GetInfo(hsa_agent_info_t attribute, void* value) const override;
 
+  core::Agent* GetNearestCpuAgent() const override { return const_cast<CpuAgent*>(this); }
+
   // @brief Override from core::Agent.
   void InitDerivedCuid() override;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -383,7 +383,7 @@ class GpuAgent : public GpuAgentInt {
 
   hsa_status_t Preload(uint64_t flags);
 
-  core::Agent* GetNearestCpuAgent(void) const;
+  core::Agent* GetNearestCpuAgent() const override;
 
   void RegisterGangPeer(core::Agent& gang_peer, unsigned int bandwidth_factor) override;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
@@ -248,6 +248,9 @@ hsa_status_t AieAgent::GetInfo(hsa_agent_info_t attribute, void *value) const {
       assert(regions_.size() != 0 && "No device local memory found!");
       *static_cast<bool*>(value) = true;
       break;
+    case HSA_AMD_AGENT_INFO_NEAREST_CPU:
+      *static_cast<hsa_agent_t*>(value) = GetNearestCpuAgent()->public_handle();
+      break;
     case HSA_AMD_AGENT_INFO_MEMORY_PROPERTIES:
       std::memset(value, 0, sizeof(uint8_t) * 8);
       break;
@@ -260,6 +263,12 @@ hsa_status_t AieAgent::GetInfo(hsa_agent_info_t attribute, void *value) const {
   }
 
   return HSA_STATUS_SUCCESS;
+}
+
+core::Agent* AieAgent::GetNearestCpuAgent() const {
+  // AIE agents are currently associated with the first CPU agent.
+  assert(!core::Runtime::runtime_singleton_->cpu_agents().empty());
+  return core::Runtime::runtime_singleton_->cpu_agents()[0];
 }
 
 hsa_status_t AieAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type, uint64_t flags,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -3528,7 +3528,7 @@ hsa_status_t Runtime::SvmBatchDiscard(void** ptrs, size_t* sizes, uint32_t count
     attr.type = HSA_SVM_ATTR_PREFERRED_LOC;
     attr.value = 0;
 
-    AMD::CpuAgent* cpu = nullptr;
+    Agent* cpu_agent = nullptr;
     HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtSVMGetAttr(base, len, 1, &attr));
 
     if (status == HSAKMT_STATUS_SUCCESS &&
@@ -3540,15 +3540,15 @@ hsa_status_t Runtime::SvmBatchDiscard(void** ptrs, size_t* sizes, uint32_t count
         op->target_cpus.push_back(UINT32_MAX);
         continue;
       } else {
-        cpu = static_cast<AMD::CpuAgent*>(agent->GetNearestCpuAgent());
+        cpu_agent = agent->GetNearestCpuAgent();
       }
     }
 
-    if (!cpu) {
+    if (!cpu_agent) {
       // Fallback to use first available CPU agent when nearest fails
-      cpu = static_cast<AMD::CpuAgent*>(cpu_agents_[0]);
+      cpu_agent = cpu_agents_[0];
     }
-    op->target_cpus.push_back(cpu->node_id());
+    op->target_cpus.push_back(cpu_agent->node_id());
   }
 
   // Dependancy signals already at 0 need not be monitored.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -1397,7 +1397,7 @@ hsa_status_t Runtime::IPCCreate(void* ptr, size_t len, hsa_amd_ipc_memory_t* han
   // deferred export will not run into this problem.
   int dmabuf_fd;
   uint64_t dmabufOffset;
-  
+
   auto err = hsaKmtExportDMABufHandle(ptr, len, &dmabuf_fd, &dmabufOffset);
   assert(dmabufOffset/pageSize == fragOffset && "DMA Buf inconsistent with pointer offset.");
   if (err != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
@@ -3539,9 +3539,8 @@ hsa_status_t Runtime::SvmBatchDiscard(void** ptrs, size_t* sizes, uint32_t count
         // Already on a CPU agent; skip prefetch for this region
         op->target_cpus.push_back(UINT32_MAX);
         continue;
-      } else if (agent->device_type() == core::Agent::kAmdGpuDevice) {
-        AMD::GpuAgent* gpu = static_cast<AMD::GpuAgent*>(agent);
-        cpu = static_cast<AMD::CpuAgent*>(gpu->GetNearestCpuAgent());
+      } else {
+        cpu = static_cast<AMD::CpuAgent*>(agent->GetNearestCpuAgent());
       }
     }
 
@@ -3717,7 +3716,7 @@ hsa_status_t Runtime::VMemoryAddressReserve(void** va, size_t size, uint64_t add
   }
 
   reserved_address_map_[addr] = AddressHandle(addr, size, true);
-  *va = addr; 
+  *va = addr;
   return HSA_STATUS_SUCCESS;
 }
 
@@ -3936,7 +3935,7 @@ Runtime::MappedHandleAllowedAgent::MappedHandleAllowedAgent(
         *targetAgent, &driver_handle, ShareType::DMABUF_FD,
         &memHandle->driver_handle.dmabuf_fd);
   }
-  if (status != HSA_STATUS_SUCCESS) 
+  if (status != HSA_STATUS_SUCCESS)
     throw AMD::hsa_exception(status, "Failed to import memory");
 }
 
@@ -4013,7 +4012,7 @@ Runtime::MappedHandle::MappedHandle(MemoryHandle *mem_handle, AddressHandle *add
      * to look up the VA when sharing this BO to a third party driver. We only
      * need this in the process that owns this memory allocation.
      */
-    auto cpu_agent = static_cast<AMD::GpuAgent*>(agentOwner())->GetNearestCpuAgent();
+    auto cpu_agent = agentOwner()->GetNearestCpuAgent();
     auto agentPermsIt = allowed_agents.emplace(std::piecewise_construct,
                         std::forward_as_tuple(cpu_agent),
                         std::forward_as_tuple(this, cpu_agent, va,


### PR DESCRIPTION
## Motivation

`MappedHandle::agentOwner()` may not be a `GpuAgent` leading to an incorrect cast.

## Technical Details

Make `GetNearestCpuAgent()` a virtual function and remove the cast.

## JIRA ID

NA

## Test Plan

./rocrtst64

## Test Result

Successs

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
