### PR TITLE
fix(rccl/tests): correct requestedHandleType typo in mem_manager test files

### DIFF
--- a/projects/rccl/test/mem_manager/MemManagerTests.cpp
+++ b/projects/rccl/test/mem_manager/MemManagerTests.cpp
@@ -797,7 +797,7 @@ struct VmmPosixAllocation
 // Allocates a chunk of device memory via the HIP VMM API with a POSIX-fd
 // shareable handle. Mirrors the prop layout of ncclCuMemAlloc:
 //   - Pinned + Device location
-//   - requestedHandleTypes = POSIX_FILE_DESCRIPTOR
+//   - requestedHandleType = POSIX_FILE_DESCRIPTOR
 //   - allocFlags.gpuDirectRDMACapable = 1 (ROCM-2550 workaround; without it
 //     hipMemMap can SIGSEGV on AMD)
 // `requestedSize` is rounded up to the minimum granularity reported by HIP.
@@ -810,7 +810,7 @@ inline void AllocateVmmPosixFd(int dev, size_t requestedSize, VmmPosixAllocation
     prop.type                            = hipMemAllocationTypePinned;
     prop.location.type                   = hipMemLocationTypeDevice;
     prop.location.id                     = dev;
-    prop.requestedHandleTypes            = hipMemHandleTypePosixFileDescriptor;
+    prop.requestedHandleType             = hipMemHandleTypePosixFileDescriptor;
     prop.allocFlags.gpuDirectRDMACapable = 1;
 
     size_t granularity = 0;

--- a/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp
+++ b/projects/rccl/test/mem_manager/SuspendResumeMPITests.cpp
@@ -97,7 +97,7 @@ void allocateVmmPosixFd(int dev, size_t requestedSize, VmmAlloc* out)
     prop.type                            = hipMemAllocationTypePinned;
     prop.location.type                   = hipMemLocationTypeDevice;
     prop.location.id                     = dev;
-    prop.requestedHandleTypes            = hipMemHandleTypePosixFileDescriptor;
+    prop.requestedHandleType             = hipMemHandleTypePosixFileDescriptor;
     prop.allocFlags.gpuDirectRDMACapable = 1;
 
     size_t granularity = 0;
@@ -137,7 +137,7 @@ void reserveVaOnly(int dev, size_t requestedSize, VmmAlloc* out)
     prop.type                            = hipMemAllocationTypePinned;
     prop.location.type                   = hipMemLocationTypeDevice;
     prop.location.id                     = dev;
-    prop.requestedHandleTypes            = hipMemHandleTypePosixFileDescriptor;
+    prop.requestedHandleType             = hipMemHandleTypePosixFileDescriptor;
     prop.allocFlags.gpuDirectRDMACapable = 1;
 
     size_t granularity = 0;


### PR DESCRIPTION
## Summary

`hipMemAllocationProp` declares the handle-type field as `requestedHandleType` (singular), as seen in `/opt/rocm/include/hip/hip_runtime_api.h:1577`. The test files were using the pluralised name `requestedHandleTypes`, which does not exist on the HIP struct and caused a build error in CI:

```
SuspendResumeMPITests.cpp:100:10: error: no member named 'requestedHandleTypes' in 'hipMemAllocationProp'; did you mean 'requestedHandleType'?
SuspendResumeMPITests.cpp:140:10: error: no member named 'requestedHandleTypes' in 'hipMemAllocationProp'; did you mean 'requestedHandleType'?
```

## Changes

| File | Lines | Fix |
|------|-------|-----|
| `test/mem_manager/SuspendResumeMPITests.cpp` | 100, 140 | `requestedHandleTypes` → `requestedHandleType` |
| `test/mem_manager/MemManagerTests.cpp` | 800 (comment), 813 | `requestedHandleTypes` → `requestedHandleType` |

All other occurrences of `requestedHandleTypes` in the codebase (`allocator.cc`, `alloc.h`, `cudawrap.cc`, `rocmwrap.cc`, `nvls.cc`, `p2p.cc`, `shm.cc`) are on `CUmemAllocationProp` (CUDA type), where the **plural** field name is correct and were left unchanged.

## Test plan

- [x] Debug build for `gfx942` with `--debug -t --enable-mpi-tests` completed with zero errors
- [x] Both `test/CMakeFiles/rccl-UnitTestsFixturesDebug.dir/mem_manager/MemManagerTests.cpp.o` and `test/CMakeFiles/rccl-UnitTestsMPI.dir/mem_manager/SuspendResumeMPITests.cpp.o` compiled cleanly
- [x] All test targets linked successfully: `rccl-UnitTests`, `rccl-UnitTestsFixturesDebug`, `rccl-UnitTestsMPI`