### PR TITLE
Route same-GPU D2D swap copies through the SDMA path

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2848,14 +2848,14 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
       // Swap ops cannot fall back to shader copy (it only does one-directional
       // copy, not a bidirectional swap). Fail the entire batch if any swap op
       // was in the SDMA batch that failed.
-      bool has_swap = false;
+      bool hasSwap = false;
       for (const auto& op : p2pCopyOps) {
         if (op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpSwap) {
-          has_swap = true;
+          hasSwap = true;
           break;
         }
       }
-      if (has_swap) {
+      if (hasSwap) {
         LogError("KernelBlitManager::copyBufferBatch: SDMA batch with swap ops failed");
         return false;
       }

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2845,6 +2845,20 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
   if (!p2pCopyOps.empty()) {
     // Always pass prior wait events to maintain stream ordering for the batch.
     if (!hsaCopyBatch(p2pCopyOps, &priorWaitEvents, &batchSignals)) {
+      // Swap ops cannot fall back to shader copy (it only does one-directional
+      // copy, not a bidirectional swap). Fail the entire batch if any swap op
+      // was in the SDMA batch that failed.
+      bool has_swap = false;
+      for (const auto& op : p2pCopyOps) {
+        if (op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpSwap) {
+          has_swap = true;
+          break;
+        }
+      }
+      if (has_swap) {
+        LogError("KernelBlitManager::copyBufferBatch: SDMA batch with swap ops failed");
+        return false;
+      }
       LogWarning(
           "KernelBlitManager::copyBufferBatch: Batch copy failed, falling back to copyBuffer");
       d2dCopyOps.insert(d2dCopyOps.end(), p2pCopyOps.begin(), p2pCopyOps.end());

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2746,14 +2746,14 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
       // Swap ops cannot fall back to shader copy (it only does one-directional
       // copy, not a bidirectional swap). Fail the entire batch if any swap op
       // was in the SDMA batch that failed.
-      bool has_swap = false;
+      bool hasSwap = false;
       for (const auto& op : p2pCopyOps) {
         if (op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpSwap) {
-          has_swap = true;
+          hasSwap = true;
           break;
         }
       }
-      if (has_swap) {
+      if (hasSwap) {
         LogError("KernelBlitManager::copyBufferBatch: SDMA batch with swap ops failed");
         return false;
       }

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2726,7 +2726,10 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
     hsa_agent_t dstAgent;
     resolveAgents(srcMem, dstMem, srcAddr, dstAddr, srcAgent, dstAgent);
 
-    if (srcAgent.handle == dstAgent.handle && !op.metadata.preferCE_) {
+    // Swap ops must use the SDMA batch path even for same-GPU D2D,
+    // because the shader copy path cannot perform a bidirectional swap.
+    if (srcAgent.handle == dstAgent.handle && !op.metadata.preferCE_
+        && op.metadata.copyOpType_ != amd::CopyMetadata::kCopyOpSwap) {
       d2dCopyOps.push_back(op);
     } else {
       p2pCopyOps.push_back(op);
@@ -2740,6 +2743,20 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
   if (!p2pCopyOps.empty()) {
     // Always pass prior wait events to maintain stream ordering for the batch.
     if (!hsaCopyBatch(p2pCopyOps, &priorWaitEvents, &batchSignals)) {
+      // Swap ops cannot fall back to shader copy (it only does one-directional
+      // copy, not a bidirectional swap). Fail the entire batch if any swap op
+      // was in the SDMA batch that failed.
+      bool has_swap = false;
+      for (const auto& op : p2pCopyOps) {
+        if (op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpSwap) {
+          has_swap = true;
+          break;
+        }
+      }
+      if (has_swap) {
+        LogError("KernelBlitManager::copyBufferBatch: SDMA batch with swap ops failed");
+        return false;
+      }
       LogWarning(
           "KernelBlitManager::copyBufferBatch: Batch copy failed, falling back to copyBuffer");
       d2dCopyOps.insert(d2dCopyOps.end(), p2pCopyOps.begin(), p2pCopyOps.end());

--- a/projects/clr/rocclr/device/rocm/rocsettings.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.cpp
@@ -145,7 +145,8 @@ bool Settings::create(bool fullProfile, const amd::Isa& isa, bool enableXNACK, b
     queue_pipe_dist_ = dynamic_queues_ >= 1;
   }
 
-  if (gfxipMajor == 9 && gfxipMinor >= 4) {
+  if ((gfxipMajor == 9 && gfxipMinor >= 4) ||
+      (gfxipMajor == 12 && gfxipMinor >= 5)) {
     sdma_swap_supported_ = true;
   }
 

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -804,6 +804,7 @@ memory:
   Unit_hipMemcpyBatchAsync_H2D_Functional: *level_2
   Unit_hipMemcpyBatchAsync_D2H_Functional: *level_2
   Unit_hipMemcpyBatchAsync_H2H_Functional: *level_2
+  Unit_hipMemcpyBatchAsync_swap_cp: *level_2
   Unit_hipMemcpyBatchAsync_NegativeTsts:
     <<: *level_2
     tags: [transfer]

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -736,6 +736,7 @@ memory:
   Unit_hipMemcpyBatchAsync_H2D_Functional: *level_2
   Unit_hipMemcpyBatchAsync_D2H_Functional: *level_2
   Unit_hipMemcpyBatchAsync_H2H_Functional: *level_2
+  Unit_hipMemcpyBatchAsync_swap_cp: *level_2
   Unit_hipMemcpyBatchAsync_NegativeTsts:
     <<: *level_2
     tags: [transfer]

--- a/projects/hip-tests/catch/include/hip_test_common.hh
+++ b/projects/hip-tests/catch/include/hip_test_common.hh
@@ -578,6 +578,8 @@ inline constexpr char const kNotEnoughFreeGpuMemory[] =
 inline constexpr char const kNotEnoughFreeHostMemory[] =
     "not enough free host memory";
 inline constexpr char const kRequiresLinux[] = "this test requires Linux.";
+inline constexpr char const kSdmaSwapUnsupported[] =
+    "SDMA swap is not supported on this device.";
 }  // namespace SkipReason
 
 /**

--- a/projects/hip-tests/catch/include/hip_test_common.hh
+++ b/projects/hip-tests/catch/include/hip_test_common.hh
@@ -560,6 +560,8 @@ inline constexpr char const kNotEnoughFreeGpuMemory[] =
 inline constexpr char const kNotEnoughFreeHostMemory[] =
     "not enough free host memory";
 inline constexpr char const kRequiresLinux[] = "this test requires Linux.";
+inline constexpr char const kSdmaSwapUnsupported[] =
+    "SDMA swap is not supported on this device.";
 }  // namespace SkipReason
 
 /**

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -340,7 +340,7 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_swap_cp) {
     HIP_CHECK(hipStreamDestroy(stream));
     HIP_CHECK(hipFree(d_a));
     HIP_CHECK(hipFree(d_b));
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kSdmaSwapUnsupported);
+    HIP_SKIP_TEST(HipTest::SkipReason::kSdmaSwapUnsupported);
   }
   HIP_CHECK(err);
   HIP_CHECK(hipStreamSynchronize(stream));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -334,8 +334,15 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_swap_cp) {
   attr.srcAccessOrder = hipMemcpySrcAccessOrderStream;
 
   size_t failIdx = 0;
-  HIP_CHECK(hipMemcpyBatchAsync(dsts, srcs, sizes, 1, &attr, attrsIdxs, 1,
-                                &failIdx, stream));
+  hipError_t err = hipMemcpyBatchAsync(dsts, srcs, sizes, 1, &attr, attrsIdxs, 1,
+                                       &failIdx, stream);
+  if (err == hipErrorNotSupported) {
+    HIP_CHECK(hipStreamDestroy(stream));
+    HIP_CHECK(hipFree(d_a));
+    HIP_CHECK(hipFree(d_b));
+    HIP_SKIP_TEST(HipTest::SkipReason::kSdmaSwapUnsupported);
+  }
+  HIP_CHECK(err);
   HIP_CHECK(hipStreamSynchronize(stream));
 
   // Read back and verify swap

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -340,7 +340,7 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_swap_cp) {
     HIP_CHECK(hipStreamDestroy(stream));
     HIP_CHECK(hipFree(d_a));
     HIP_CHECK(hipFree(d_b));
-    HIP_SKIP_TEST(HipTest::SkipReason::kSdmaSwapUnsupported);
+    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kSdmaSwapUnsupported);
   }
   HIP_CHECK(err);
   HIP_CHECK(hipStreamSynchronize(stream));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -289,6 +289,70 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyBatchAsync_H2H_Functional, char, int,
   // Clean up
   HIP_CHECK(hipStreamDestroy(stream));
 }
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verify hipMemcpyBatchAsync with hipMemcpyFlagExtOpSwap exchanges the
+ *   contents of two device buffers.
+ * 1. Allocate two device buffers and fill with distinct values.
+ * 2. Issue hipMemcpyBatchAsync with swap attribute.
+ * 3. Read back both buffers and verify values are exchanged.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_swap_cp) {
+  constexpr size_t kNumElements = 4096;
+  constexpr size_t kSizeBytes = kNumElements * sizeof(int);
+  constexpr int kValA = 42;
+  constexpr int kValB = 99;
+
+  // Allocate device buffers
+  void* d_a = nullptr;
+  void* d_b = nullptr;
+  HIP_CHECK(hipMalloc(&d_a, kSizeBytes));
+  HIP_CHECK(hipMalloc(&d_b, kSizeBytes));
+
+  // Fill with distinct values
+  std::vector<int> hostA(kNumElements, kValA);
+  std::vector<int> hostB(kNumElements, kValB);
+  HIP_CHECK(hipMemcpy(d_a, hostA.data(), kSizeBytes, hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(d_b, hostB.data(), kSizeBytes, hipMemcpyHostToDevice));
+
+  // Set up batch swap: dst=d_a, src=d_b with swap flag
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  void* dsts[] = {d_a};
+  void* srcs[] = {d_b};
+  size_t sizes[] = {kSizeBytes};
+  size_t attrsIdxs[] = {0};
+
+  hipMemcpyAttributes attr{};
+  attr.flags = hipMemcpyFlagExtOpSwap;
+  attr.srcAccessOrder = hipMemcpySrcAccessOrderStream;
+
+  size_t failIdx = 0;
+  HIP_CHECK(hipMemcpyBatchAsync(dsts, srcs, sizes, 1, &attr, attrsIdxs, 1,
+                                &failIdx, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  // Read back and verify swap
+  std::vector<int> resultA(kNumElements);
+  std::vector<int> resultB(kNumElements);
+  HIP_CHECK(hipMemcpy(resultA.data(), d_a, kSizeBytes, hipMemcpyDeviceToHost));
+  HIP_CHECK(hipMemcpy(resultB.data(), d_b, kSizeBytes, hipMemcpyDeviceToHost));
+
+  for (size_t i = 0; i < kNumElements; i++) {
+    REQUIRE(resultA[i] == kValB);
+    REQUIRE(resultB[i] == kValA);
+  }
+
+  HIP_CHECK(hipFree(d_a));
+  HIP_CHECK(hipFree(d_b));
+  HIP_CHECK(hipStreamDestroy(stream));
+}
 #endif
 /**
  * Test Description


### PR DESCRIPTION
## Motivation
Swap ops must use the SDMA batch path even for same-GPU D2D,
because the shader copy path cannot perform a bidirectional swap.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
Added new test case Unit_hipMemcpyBatchAsync_swap_cp
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
