### PR TITLE
[rccl] Add missing Revoke END/COMPLETE INFO logs to match NCCL

### DIFF
--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -3389,6 +3389,7 @@ static ncclResult_t commRevokeAsync(struct ncclAsyncJob* job_) {
 
 exit:
   (void) ncclCommSetAsyncError(comm, res);
+  INFO(NCCL_INIT, "CommRevokeAsync END comm %p result %d", comm, res);
   return res;
 }
 
@@ -3438,6 +3439,8 @@ exit:
   if (comm && !comm->config.blocking) {
     NCCLCHECK(ncclCommGetAsyncError(comm, &ret));
   }
+  INFO(NCCL_INIT, "comm %p rank %d nRanks %d cudaDev %d busId %lx - Revoke COMPLETE, result %d",
+       comm, comm->rank, comm->nRanks, comm->cudaDev, comm->busId, ret);
   return ret;
 fail:
   if (comm && !comm->config.blocking) (void) ncclCommSetAsyncError(comm, ret);


### PR DESCRIPTION
## Motivation

Align ncclCommRevoke logging with NCCL upstream:
- Add INFO log at commRevokeAsync exit (CommRevokeAsync END)
- Add INFO log at ncclCommRevoke_impl exit (Revoke COMPLETE)

Both use NCCL_INIT subsystem consistent with the existing Revoke START log. NCCL reference: commRevokeAsync/ncclCommRevoke in src/init.cc.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
