### PR TITLE
Disable hostcalls and reset transfer queue on device reset

### DIFF
--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -135,6 +135,21 @@ void Device::AddSafeStream(Stream* event_stream, Stream* wait_stream) {
 
 // ================================================================================================
 void Device::Reset() {
+  auto* dev = devices()[0];
+
+  flags_ = hipDeviceScheduleSpin;
+
+  // Destroy all user streams first so their GPU work completes (including the Windows
+  // VirtualGPU barrier flush in ~VirtualGPU) before any backing memory is freed.
+  destroyAllStreams();
+
+  // null_stream_ is excluded from destroyAllStreams(),
+  // Destroy it explicitly so it is recreated fresh after reset.
+  if (null_stream_ != nullptr) {
+    hip::Stream::Destroy(null_stream_);
+    null_stream_ = nullptr;
+  }
+
   {
     std::scoped_lock lock(lock_);
     auto pools_to_delete = std::exchange(mem_pools_, {});
@@ -143,12 +158,16 @@ void Device::Reset() {
       delete pool;
     }
   }
-  flags_ = hipDeviceScheduleSpin;
-  destroyAllStreams();
+
+  // Recreate the internal transfer queue so it starts fresh after reset.
+  // Must happen after pools and streams are torn down (PAL resource destructors
+  // call through xferQueue), but before Purge (ROCR svmFree of hostcallBuffer
+  // happens in ~VirtualGPU).
+  dev->recreateXferQueue();
 
   // Clear hostcall allocations to avoid ~Device() accessing freed Memory objects later.
-  auto* dev = devices()[0];
   dev->ClearHostcallMemories();
+
   amd::MemObjMap::Purge(dev);
   Create();
 }

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1910,6 +1910,8 @@ class Device : public RuntimeObject {
    */
   bool customHostAllocator() const { return settings().customHostAllocator_ == 1; }
 
+  virtual void recreateXferQueue() {}
+
   /**
    * @copydoc amd::Context::hostAlloc
    */

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1905,6 +1905,8 @@ class Device : public RuntimeObject {
    */
   bool customHostAllocator() const { return settings().customHostAllocator_ == 1; }
 
+  virtual void recreateXferQueue() {}
+
   /**
    * @copydoc amd::Context::hostAlloc
    */

--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -2826,4 +2826,21 @@ amd::Memory* Device::ImportShareableVMMHandle(void* osHandle) {
   return amd_mem_obj;
 }
 
+void Device::recreateXferQueue() {
+  delete xferQueue_;
+  xferQueue_ = nullptr;
+
+  // PAL's xferQueue() is a bare getter with no lazy re-creation, so recreate explicitly.
+  // Finalize() was already called during initializeHeapResources() and must not be called
+  // again, but creating a new VirtualGPU is safe at this point.
+  xferQueue_ = new VirtualGPU(*this);
+  if (!(xferQueue_ && xferQueue_->create(false))) {
+    delete xferQueue_;
+    xferQueue_ = nullptr;
+    LogError("Couldn't recreate the device transfer manager after reset!");
+    return;
+  }
+  xferQueue_->enableSyncedBlit();
+}
+
 }  // namespace amd::pal

--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -2830,6 +2830,14 @@ void Device::recreateXferQueue() {
   delete xferQueue_;
   xferQueue_ = nullptr;
 
+  // If the heap has never been initialized (e.g. hipDeviceReset called before any queue or
+  // memory operation), Finalize() has not been called yet and creating a VirtualGPU would
+  // use an uninitialized PAL device. Skip recreation here; xferQueue_ will be created lazily
+  // by the next caller that goes through initializeHeapResources().
+  if (!heapInitComplete_) {
+    return;
+  }
+
   // PAL's xferQueue() is a bare getter with no lazy re-creation, so recreate explicitly.
   // Finalize() was already called during initializeHeapResources() and must not be called
   // again, but creating a new VirtualGPU is safe at this point.

--- a/projects/clr/rocclr/device/pal/paldevice.hpp
+++ b/projects/clr/rocclr/device/pal/paldevice.hpp
@@ -526,6 +526,8 @@ class Device : public NullDevice {
 
   VirtualGPU* xferQueue() const { return xferQueue_; }
 
+  void recreateXferQueue() override;
+
   //! Retrieves the internal format from the OCL format
   Pal::ChNumFormat getPalFormat(const amd::Image::Format& format,  //! OCL image format
                                 Pal::ChannelMapping* channel) const;

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -4160,6 +4160,14 @@ void callbackQueue(hsa_status_t status, hsa_queue_t* queue, void* data) {
   }
 }
 
+void Device::recreateXferQueue() {
+  delete xferQueue_;
+  xferQueue_ = nullptr;
+  // xferQueue() is a lazy accessor: it will recreate xferQueue_ on the next call.
+  // Do not eagerly recreate here — creating an HSA queue inside the hipDeviceReset
+  // call chain (where rocprofiler is already in a callback) causes reentrancy issues
+  // in rocprofiler's queue controller.
+}
 // ================================================================================================
 #if defined(__clang__)
 #if __has_feature(address_sanitizer)

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -4161,8 +4161,10 @@ void callbackQueue(hsa_status_t status, hsa_queue_t* queue, void* data) {
 }
 
 void Device::recreateXferQueue() {
-  delete xferQueue_;
-  xferQueue_ = nullptr;
+  if (xferQueue_) {
+    xferQueue_->release();
+    xferQueue_ = nullptr;
+  }
   // xferQueue() is a lazy accessor: it will recreate xferQueue_ on the next call.
   // Do not eagerly recreate here — creating an HSA queue inside the hipDeviceReset
   // call chain (where rocprofiler is already in a callback) causes reentrancy issues

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -4100,8 +4100,10 @@ void callbackQueue(hsa_status_t status, hsa_queue_t* queue, void* data) {
 }
 
 void Device::recreateXferQueue() {
-  delete xferQueue_;
-  xferQueue_ = nullptr;
+  if (xferQueue_) {
+    xferQueue_->release();
+    xferQueue_ = nullptr;
+  }
   // xferQueue() is a lazy accessor: it will recreate xferQueue_ on the next call.
   // Do not eagerly recreate here — creating an HSA queue inside the hipDeviceReset
   // call chain (where rocprofiler is already in a callback) causes reentrancy issues

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -4099,6 +4099,14 @@ void callbackQueue(hsa_status_t status, hsa_queue_t* queue, void* data) {
   }
 }
 
+void Device::recreateXferQueue() {
+  delete xferQueue_;
+  xferQueue_ = nullptr;
+  // xferQueue() is a lazy accessor: it will recreate xferQueue_ on the next call.
+  // Do not eagerly recreate here — creating an HSA queue inside the hipDeviceReset
+  // call chain (where rocprofiler is already in a callback) causes reentrancy issues
+  // in rocprofiler's queue controller.
+}
 // ================================================================================================
 #if defined(__clang__)
 #if __has_feature(address_sanitizer)

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -375,6 +375,8 @@ class Device : public NullDevice {
 
   void checkAtomicSupport();  //!< Check the support for pcie atomics
 
+  void recreateXferQueue() override;
+
   //! Destructor for the physical HSA device
   virtual ~Device();
 

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -370,6 +370,8 @@ class Device : public NullDevice {
 
   void checkAtomicSupport();  //!< Check the support for pcie atomics
 
+  void recreateXferQueue() override;
+
   //! Destructor for the physical HSA device
   virtual ~Device();
 

--- a/projects/hip-tests/catch/config/configs/unit/device.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/device.yaml
@@ -284,6 +284,12 @@ device:
     # (nvidia_windows) Disabling tests which no longer behave the same on nvidia platform
     disabled: [amd_wsl, nvidia_windows]
     tags: [synchronization]
+  Unit_hipDeviceReset_Positive_BeforeHeapInit:
+    <<: *level_2
+    tags: [synchronization]
+  Unit_hipDeviceReset_Positive_XferQueueRecreation:
+    <<: *level_2
+    tags: [synchronization]
   Unit_hipDeviceSetMemPool_Positive_Basic:
     <<: *level_2
     tags: [config]

--- a/projects/hip-tests/catch/config/configs/unit/device.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/device.yaml
@@ -281,6 +281,12 @@ device:
     # (nvidia_windows) Disabling tests which no longer behave the same on nvidia platform
     disabled: [amd_wsl, nvidia_windows]
     tags: [synchronization]
+  Unit_hipDeviceReset_Positive_BeforeHeapInit:
+    <<: *level_2
+    tags: [synchronization]
+  Unit_hipDeviceReset_Positive_XferQueueRecreation:
+    <<: *level_2
+    tags: [synchronization]
   Unit_hipDeviceSetMemPool_Positive_Basic:
     <<: *level_2
     tags: [config]

--- a/projects/hip-tests/catch/unit/device/hipDeviceReset.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceReset.cc
@@ -145,6 +145,81 @@ HIP_TEST_CASE(Unit_hipDeviceReset_Positive_Threaded) {
 }
 
 /**
+ * Test Description
+ * ------------------------
+ *  - Validates that hipDeviceReset succeeds when called immediately after
+ *    hipSetDevice, before any queue or memory operation has initialized
+ *    heap resources. This exercises the early-reset path where the internal
+ *    transfer queue has never been created.
+ * Test source
+ * ------------------------
+ *  - unit/device/hipDeviceReset.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.13
+ */
+HIP_TEST_CASE(Unit_hipDeviceReset_Positive_BeforeHeapInit) {
+  const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
+  HIP_CHECK(hipSetDevice(device));
+  INFO("Current device is: " << device);
+
+  // Reset immediately — no malloc, stream, or kernel before this point.
+  // Heap resources (and the internal transfer queue) have never been initialized.
+  HIP_CHECK(hipDeviceReset());
+
+  // Verify the device is fully usable after the early reset.
+  void* ptr = nullptr;
+  HIP_CHECK(hipMalloc(&ptr, 1024));
+  HIP_CHECK(hipMemset(ptr, 0, 1024));
+  HIP_CHECK(hipDeviceSynchronize());
+  HIP_CHECK(hipFree(ptr));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Validates that the device is fully usable after a reset that follows
+ *    real work. Specifically, allocates memory and performs a memcpy after
+ *    the reset to exercise the lazy re-creation of the internal transfer
+ *    queue (xferQueue_).
+ * Test source
+ * ------------------------
+ *  - unit/device/hipDeviceReset.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.13
+ */
+HIP_TEST_CASE(Unit_hipDeviceReset_Positive_XferQueueRecreation) {
+  const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
+  HIP_CHECK(hipSetDevice(device));
+  INFO("Current device is: " << device);
+
+  // Do real work first to ensure heap resources and the transfer queue are initialized.
+  void* ptr = nullptr;
+  HIP_CHECK(hipMalloc(&ptr, 1024));
+  HIP_CHECK(hipMemset(ptr, 0xAB, 1024));
+  HIP_CHECK(hipDeviceSynchronize());
+  HIP_CHECK(hipFree(ptr));
+
+  HIP_CHECK(hipDeviceReset());
+
+  // After reset, xferQueue_ is null and must be lazily recreated on the
+  // next transfer operation. Perform a copy to trigger that path.
+  constexpr size_t kSize = 1024;
+  void* dev_ptr = nullptr;
+  HIP_CHECK(hipMalloc(&dev_ptr, kSize));
+
+  std::vector<uint8_t> host_src(kSize, 0xCD);
+  std::vector<uint8_t> host_dst(kSize, 0);
+
+  HIP_CHECK(hipMemcpy(dev_ptr, host_src.data(), kSize, hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(host_dst.data(), dev_ptr, kSize, hipMemcpyDeviceToHost));
+  HIP_CHECK(hipFree(dev_ptr));
+
+  CHECK(host_dst == host_src);
+}
+
+/**
  * End doxygen group DeviceTest.
  * @}
  */


### PR DESCRIPTION
## Motivation
hipDeviceReset() did not properly tear down and reinitialize internal device state, causing crashes and hangs when the device was reused after reset.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Streams are now destroyed before memory pools so VirtualGPU destructors complete their GPU work before memory is freed. null_stream_ is explicitly destroyed so it is recreated fresh on next use. The internal transfer queue is destroyed and recreated on both ROCR and PAL paths via the new recreateXferQueue()
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
AIRUNTIME-2064
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
PSDB should pass without impacting any of the downstream projects
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Waiting for CI
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.