### PR TITLE
[rocprofiler-systems] Fix legacy Perfetto calling merging script when no output files are produced due to rank-based output filtering

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
@@ -265,8 +265,9 @@ post_process(tim::manager* _timemory_manager, bool& _perfetto_output_error,
         }
     }
 
-    // Merge the output files, if rank 0
-    if(dmp::rank() == 0)
+    // Merge the output files, if rank 0 and output is enabled for this rank
+    if(dmp::rank() == 0 &&
+       config::output_filtering::is_output_enabled_for_current_mpi_rank())
     {
         auto _output_folder = filepath::dirname(_filename);
         auto _script_path   = std::string{ "rocprof-sys-merge-output.sh" };


### PR DESCRIPTION
…filtered out

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

When using legacy Perfetto, and all output files are suppressed via rank-based output filtering, Perfetto merging script was still called on absent files, causing an error message. This PR fixes this behavior.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
Resolves AIPROFSYST-404

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Reproduction steps from AIPROFSYST-404 should not lead to merge script being called
- Existing automated tests should pass

## Test Result

<!-- Briefly summarize test outcomes. -->

- Reproduction steps from AIPROFSYST-404 do not call merge script - no merge script related error or other messages in console output is observed
- All existing automated tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
