### PR TITLE
[RCCL] [experimental] boostrap: lazy kernel init

### DIFF
--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -15,7 +15,7 @@
 #include <hip/hip_ext.h>
 #include "gdrwrap.h"
 #include "bootstrap.h"
-#include <cstring>
+#include <cstring> // std::memcpy
 #include "channel.h"
 #include "rocmwrap.h"
 #include "rccl_vars.h"
@@ -29,7 +29,6 @@
 #include "api_trace.h"
 #include "rccl_common.h"
 
-#include <cstring> // std::memcpy
 #include <cinttypes> // PRIx64
 #include <cassert>
 #include <cfloat> // FLT_MAX
@@ -104,7 +103,7 @@ RCCL_PARAM_DECLARE(LazyKernelInit);
 // owner thread we propagate the error to all waiters instead of leaving the
 // gate stuck at LAZY_INITIALIZING and hanging every subsequent launch on
 // the same device.
-enum LazyInitState : int {
+enum class LazyInitState : int {
   LAZY_UNINIT       = 0,
   LAZY_INITIALIZING = 1,
   LAZY_DONE         = 2,
@@ -113,8 +112,16 @@ enum LazyInitState : int {
 
 // Sized to MAX_ALLOC_TRACK_NGPU (currently 128) to cover the maximum
 // number of devices RCCL tracks elsewhere; the previous hardcoded 16
-// would silently skip lazy init for cudaDev >= 16.
-static std::atomic<int> g_rcclLazyKernelInitState[MAX_ALLOC_TRACK_NGPU] = {};
+// would silently skip lazy init for cudaDev >= 16. Default-initialised
+// state is LazyInitState::LAZY_UNINIT (== 0) per the enum definition above.
+static std::atomic<LazyInitState> g_rcclLazyKernelInitState[MAX_ALLOC_TRACK_NGPU] = {};
+// Side table for the failing ncclResult_t so waiters surface the same error
+// the owner saw (e.g. ncclUnhandledCudaError from a real init failure)
+// instead of a generic ncclSystemError that loses the first-cause context.
+// Owner writes this BEFORE publishing LAZY_FAILED on the gate; the release
+// on the gate store makes the value visible to any waiter that acquire-loads
+// LAZY_FAILED, so a plain relaxed load on the err table is sufficient.
+static std::atomic<int> g_rcclLazyKernelInitErr[MAX_ALLOC_TRACK_NGPU] = {};
 
 // Spin window for the lazy-init waiter before yielding the core. Mirrors the
 // short tight-spin pattern used in comm.h wait loops: a few µs covers the
@@ -2048,79 +2055,98 @@ NCCL_PARAM(MemSyncDomain, "MEM_SYNC_DOMAIN", cudaLaunchMemSyncDomainRemote);
 // Once-per-(process,device) lazy kernel init driven by ncclLaunchKernel.
 // Caller must ensure rcclParamLazyKernelInit() is set; cudaDev range is
 // validated eagerly in ncclCommInitRankFunc so this fast-path only does the
-// CAS-gate dance. The launch stream is checked against graph capture because
-// both ncclInitKernelsForDevice (cudaFuncSetAttribute) and applyKernelStackLimits
-// (cudaDeviceSetLimit) are not stream-capturable and would either corrupt the
-// captured graph or fail with a non-obvious error; users wanting graph capture
-// must perform a warmup launch outside the capture region.
+// CAS-gate dance.
+//
+// Stream capture is checked AFTER the would-be owner wins the
+// UNINIT->INITIALIZING CAS. If the owner is then found to be inside a
+// capture, it releases ownership back to LAZY_UNINIT (release) and returns
+// ncclInvalidUsage; any concurrent waiter sees that release as "owner
+// abandoned" and restarts from the top of the function to retry the CAS
+// itself. Tying the precondition to CAS ownership (rather than to a stale
+// pre-CAS load of s) closes the race where a thread observed LAZY_UNINIT
+// but did not actually become the owner.
+//
+// On real init failure the gate is poisoned to LAZY_FAILED and the failing
+// ncclResult_t is published in g_rcclLazyKernelInitErr so every waiter
+// returns the same first-cause code instead of a generic ncclSystemError.
 static ncclResult_t lazyKernelInitOnce(struct ncclComm* comm, cudaStream_t launchStream) {
   auto& gate = g_rcclLazyKernelInitState[comm->cudaDev];
-  int s = gate.load(std::memory_order_acquire);
-  if (__builtin_expect(s == LAZY_DONE, 1)) return ncclSuccess;
-  if (s == LAZY_FAILED) return ncclSystemError;
+  auto& errSlot = g_rcclLazyKernelInitErr[comm->cudaDev];
 
-  int expected = LAZY_UNINIT;
-  if (gate.compare_exchange_strong(expected, LAZY_INITIALIZING,
-                                   std::memory_order_acq_rel,
-                                   std::memory_order_acquire)) {
-    // Owner: bail out early if we are inside a cuda graph capture — neither
-    // cudaFuncSetAttribute nor cudaDeviceSetLimit can be safely captured.
-    cudaStreamCaptureStatus captureStatus = cudaStreamCaptureStatusNone;
-    cudaError_t cerr = cudaStreamIsCapturing(launchStream, &captureStatus);
-    if (cerr == cudaSuccess && captureStatus != cudaStreamCaptureStatusNone) {
-      gate.store(LAZY_FAILED, std::memory_order_release);
-      WARN("LazyKernelInit: dev %d first launch is inside a stream capture "
-           "(status=%d); cudaFuncSetAttribute/cudaDeviceSetLimit are not "
-           "graph-capturable. Perform a warmup ncclAllReduce outside "
-           "cudaStreamBeginCapture/cudaStreamEndCapture, or unset "
-           "RCCL_LAZY_KERNEL_INIT for capture workloads.",
-           comm->cudaDev, (int)captureStatus);
-      return ncclInvalidUsage;
+  for (;;) {
+    LazyInitState s = gate.load(std::memory_order_acquire);
+    if (__builtin_expect(s == LazyInitState::LAZY_DONE, 1)) return ncclSuccess;
+    if (s == LazyInitState::LAZY_FAILED) {
+      return (ncclResult_t)errSlot.load(std::memory_order_relaxed);
     }
+
+    if (s == LazyInitState::LAZY_UNINIT) {
+      LazyInitState expected = LazyInitState::LAZY_UNINIT;
+      if (gate.compare_exchange_strong(expected, LazyInitState::LAZY_INITIALIZING,
+                                       std::memory_order_acq_rel,
+                                       std::memory_order_acquire)) {
+        // Owner path. Precondition (stream capture) is checked here, not
+        // before the CAS, so threads that did not actually become the
+        // owner never observe a precondition-driven error.
+        cudaStreamCaptureStatus captureStatus = cudaStreamCaptureStatusNone;
+        cudaError_t cerr = cudaStreamIsCapturing(launchStream, &captureStatus);
+        if (cerr == cudaSuccess && captureStatus != cudaStreamCaptureStatusNone) {
+          gate.store(LazyInitState::LAZY_UNINIT, std::memory_order_release);
+          WARN("LazyKernelInit: dev %d first launch is inside a stream capture "
+               "(status=%d); cudaFuncSetAttribute/cudaDeviceSetLimit are not "
+               "graph-capturable. Perform a warmup ncclAllReduce outside "
+               "cudaStreamBeginCapture/cudaStreamEndCapture, or unset "
+               "RCCL_LAZY_KERNEL_INIT for capture workloads.",
+               comm->cudaDev, (int)captureStatus);
+          return ncclInvalidUsage;
+        }
+
+        uint64_t t0 = clockNano();
+        size_t maxLocalSizeBytes = 0;
+        ncclResult_t r = ncclInitKernelsForDevice(comm->cudaArch, comm->maxSharedMem, &maxLocalSizeBytes);
+        if (r == ncclSuccess) {
+          r = applyKernelStackLimits(comm->archName, maxLocalSizeBytes);
+        }
+        if (r != ncclSuccess) {
+          errSlot.store((int)r, std::memory_order_relaxed);
+          gate.store(LazyInitState::LAZY_FAILED, std::memory_order_release);
+          WARN("LazyKernelInit: init failed on dev %d: %d", comm->cudaDev, (int)r);
+          return r;
+        }
+        gate.store(LazyInitState::LAZY_DONE, std::memory_order_release);
+        INFO(NCCL_INIT | NCCL_BOOTSTRAP | NCCL_PROFILE,
+             "LazyKernelInit fired rank %d dev %d kernels_us %llu",
+             comm->rank, comm->cudaDev,
+             (unsigned long long)((clockNano() - t0) / 1000));
+        return ncclSuccess;
+      }
+      // CAS lost: somebody else owns the gate now, fall through to wait.
+    }
+
+    // Waiter: short spin then yield until DONE / FAILED / UNINIT (the last
+    // means the owner aborted the precondition and released the gate, in
+    // which case we retry the CAS from the top of the loop). Emit one WARN
+    // if the wait exceeds LAZY_INIT_WAITER_WARN_NS so a stuck owner does
+    // not appear as a silent hang in user logs.
     uint64_t t0 = clockNano();
-    size_t maxLocalSizeBytes = 0;
-    ncclResult_t r = ncclInitKernelsForDevice(comm->cudaArch, comm->maxSharedMem, &maxLocalSizeBytes);
-    if (r != ncclSuccess) {
-      gate.store(LAZY_FAILED, std::memory_order_release);
-      WARN("LazyKernelInit: ncclInitKernelsForDevice failed on dev %d: %d",
-           comm->cudaDev, (int)r);
-      return r;
+    bool warned = false;
+    LazyInitState w;
+    while ((w = gate.load(std::memory_order_acquire)) == LazyInitState::LAZY_INITIALIZING) {
+      uint64_t elapsed = clockNano() - t0;
+      if (elapsed >= LAZY_INIT_SPIN_NS) sched_yield();
+      if (!warned && elapsed >= LAZY_INIT_WAITER_WARN_NS) {
+        WARN("LazyKernelInit: rank %d dev %d still waiting for owner after %llus; "
+             "owner thread may be stuck in ncclInitKernelsForDevice "
+             "(HSA code-object load) or crashed before publishing the gate",
+             comm->rank, comm->cudaDev,
+             (unsigned long long)(elapsed / 1000000000ULL));
+        warned = true;
+      }
     }
-    r = applyKernelStackLimits(comm->archName, maxLocalSizeBytes);
-    if (r != ncclSuccess) {
-      gate.store(LAZY_FAILED, std::memory_order_release);
-      WARN("LazyKernelInit: applyKernelStackLimits failed on dev %d: %d",
-           comm->cudaDev, (int)r);
-      return r;
-    }
-    gate.store(LAZY_DONE, std::memory_order_release);
-    INFO(NCCL_INIT | NCCL_BOOTSTRAP | NCCL_PROFILE,
-         "LazyKernelInit fired rank %d dev %d kernels_us %llu",
-         comm->rank, comm->cudaDev,
-         (unsigned long long)((clockNano() - t0) / 1000));
-    return ncclSuccess;
+    if (w == LazyInitState::LAZY_DONE)   return ncclSuccess;
+    if (w == LazyInitState::LAZY_FAILED) return (ncclResult_t)errSlot.load(std::memory_order_relaxed);
+    // w == LAZY_UNINIT: owner aborted; retry the CAS ourselves.
   }
-
-  // Waiter: short spin then yield until LAZY_DONE / LAZY_FAILED. Emit one
-  // WARN if the wait exceeds LAZY_INIT_WAITER_WARN_NS so a stuck owner does
-  // not appear as a silent hang in user logs.
-  uint64_t t0 = clockNano();
-  bool warned = false;
-  int w;
-  while ((w = gate.load(std::memory_order_acquire)) != LAZY_DONE) {
-    if (w == LAZY_FAILED) return ncclSystemError;
-    uint64_t elapsed = clockNano() - t0;
-    if (elapsed >= LAZY_INIT_SPIN_NS) sched_yield();
-    if (!warned && elapsed >= LAZY_INIT_WAITER_WARN_NS) {
-      WARN("LazyKernelInit: rank %d dev %d still waiting for owner after %llus; "
-           "owner thread may be stuck in ncclInitKernelsForDevice "
-           "(HSA code-object load) or crashed before publishing the gate",
-           comm->rank, comm->cudaDev,
-           (unsigned long long)(elapsed / 1000000000ULL));
-      warned = true;
-    }
-  }
-  return ncclSuccess;
 }
 
 ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan) {

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -33,6 +33,7 @@
 #include <cinttypes> // PRIx64
 #include <cassert>
 #include <cfloat> // FLT_MAX
+#include <atomic> // std::atomic — lazy kernel init gate
 #include "latency_profiler/CollTraceFunc.h"
 
 #ifdef ENABLE_ROCSHMEM
@@ -94,6 +95,12 @@ constexpr int rcclShmemDynamicSize(int cudaArch = NCCL_CUDA_ARCH, int WarpSize =
 
 NCCL_PARAM(L1SharedMemoryCarveout, "L1_SHARED_MEMORY_CARVEOUT", 0);
 NCCL_PARAM(SymCeThreshold, "SYM_CE_THRESHOLD", 8*1024*1024);
+RCCL_PARAM_DECLARE(LazyKernelInit);
+
+// Per-process per-device gate for lazy kernel init.
+// 0 = uninitialized, 1 = initializing, 2 = done.
+// Sized for typical max GPUs per host; bumped above 8 for safety.
+static std::atomic<int> g_rcclLazyKernelInitState[16] = {};
 
 // Returns maximum kernel stack size of all CUDA kernels
 ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* maxStackSize) {
@@ -2014,6 +2021,28 @@ NCCL_PARAM(MemSyncDomain, "MEM_SYNC_DOMAIN", cudaLaunchMemSyncDomainRemote);
 
 ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan) {
   ncclResult_t ret = ncclSuccess;
+  // Lazy kernel init: if RCCL_LAZY_KERNEL_INIT=1, ncclInitKernelsForDevice was
+  // skipped during ncclCommInitRankFunc. Run it once-per-(process,device) here,
+  // before the first cuLaunchKernel that depends on those attributes.
+  if (rcclParamLazyKernelInit() && comm->cudaDev >= 0 &&
+      comm->cudaDev < (int)(sizeof(g_rcclLazyKernelInitState)/sizeof(g_rcclLazyKernelInitState[0]))) {
+    auto& gate = g_rcclLazyKernelInitState[comm->cudaDev];
+    int s = gate.load(std::memory_order_acquire);
+    if (__builtin_expect(s != 2, 0)) {
+      int expected = 0;
+      if (gate.compare_exchange_strong(expected, 1)) {
+        uint64_t t0 = clockNano();
+        NCCLCHECK(ncclInitKernelsForDevice(comm->cudaArch, comm->maxSharedMem, NULL));
+        gate.store(2, std::memory_order_release);
+        INFO(NCCL_INIT | NCCL_BOOTSTRAP | NCCL_PROFILE,
+             "LazyKernelInit fired rank %d dev %d kernels_us %llu",
+             comm->rank, comm->cudaDev,
+             (unsigned long long)((clockNano() - t0) / 1000));
+      } else {
+        while (gate.load(std::memory_order_acquire) != 2) { /* spin */ }
+      }
+    }
+  }
   struct ncclKernelPlanner* planner = &comm->planner;
   int nChannels = 0;
   for (int i = 0; i < MAXCHANNELS/64; i++)

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -34,6 +34,8 @@
 #include <cassert>
 #include <cfloat> // FLT_MAX
 #include <atomic> // std::atomic — lazy kernel init gate
+#include <sched.h> // sched_yield — lazy kernel init wait path
+#include "alloc.h" // MAX_ALLOC_TRACK_NGPU — sizing for per-device gate
 #include "latency_profiler/CollTraceFunc.h"
 
 #ifdef ENABLE_ROCSHMEM
@@ -98,9 +100,33 @@ NCCL_PARAM(SymCeThreshold, "SYM_CE_THRESHOLD", 8*1024*1024);
 RCCL_PARAM_DECLARE(LazyKernelInit);
 
 // Per-process per-device gate for lazy kernel init.
-// 0 = uninitialized, 1 = initializing, 2 = done.
-// Sized for typical max GPUs per host; bumped above 8 for safety.
-static std::atomic<int> g_rcclLazyKernelInitState[16] = {};
+// LAZY_FAILED is required so that if ncclInitKernelsForDevice fails on the
+// owner thread we propagate the error to all waiters instead of leaving the
+// gate stuck at LAZY_INITIALIZING and hanging every subsequent launch on
+// the same device.
+enum LazyInitState : int {
+  LAZY_UNINIT       = 0,
+  LAZY_INITIALIZING = 1,
+  LAZY_DONE         = 2,
+  LAZY_FAILED       = 3,
+};
+
+// Sized to MAX_ALLOC_TRACK_NGPU (currently 128) to cover the maximum
+// number of devices RCCL tracks elsewhere; the previous hardcoded 16
+// would silently skip lazy init for cudaDev >= 16.
+static std::atomic<int> g_rcclLazyKernelInitState[MAX_ALLOC_TRACK_NGPU] = {};
+
+// Spin window for the lazy-init waiter before yielding the core. Mirrors the
+// short tight-spin pattern used in comm.h wait loops: a few µs covers the
+// common case where the owner is already inside ncclInitKernelsForDevice and
+// about to publish LAZY_DONE, without burning the core for longer waits.
+static constexpr uint64_t LAZY_INIT_SPIN_NS = 5ULL * 1000ULL;
+// One-shot WARN threshold for the waiter. The owner runs ncclInitKernelsForDevice
+// + applyKernelStackLimits, which is typically <2s even on cold HSA code-object
+// load; anything past 30s indicates a stuck owner (deadlock, segfault before
+// the gate is published, or a misconfigured device) and the user should see
+// a clear log line rather than an opaque hang.
+static constexpr uint64_t LAZY_INIT_WAITER_WARN_NS = 30ULL * 1000ULL * 1000ULL * 1000ULL;
 
 // Returns maximum kernel stack size of all CUDA kernels
 ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* maxStackSize) {
@@ -2019,31 +2045,96 @@ ncclResult_t ncclLaunchKernelBefore_NoUncapturedCuda(struct ncclComm* comm, stru
 NCCL_PARAM(MemSyncDomain, "MEM_SYNC_DOMAIN", cudaLaunchMemSyncDomainRemote);
 #endif
 
-ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan) {
-  ncclResult_t ret = ncclSuccess;
-  // Lazy kernel init: if RCCL_LAZY_KERNEL_INIT=1, ncclInitKernelsForDevice was
-  // skipped during ncclCommInitRankFunc. Run it once-per-(process,device) here,
-  // before the first cuLaunchKernel that depends on those attributes.
-  if (rcclParamLazyKernelInit() && comm->cudaDev >= 0 &&
-      comm->cudaDev < (int)(sizeof(g_rcclLazyKernelInitState)/sizeof(g_rcclLazyKernelInitState[0]))) {
-    auto& gate = g_rcclLazyKernelInitState[comm->cudaDev];
-    int s = gate.load(std::memory_order_acquire);
-    if (__builtin_expect(s != 2, 0)) {
-      int expected = 0;
-      if (gate.compare_exchange_strong(expected, 1)) {
-        uint64_t t0 = clockNano();
-        NCCLCHECK(ncclInitKernelsForDevice(comm->cudaArch, comm->maxSharedMem, NULL));
-        gate.store(2, std::memory_order_release);
-        INFO(NCCL_INIT | NCCL_BOOTSTRAP | NCCL_PROFILE,
-             "LazyKernelInit fired rank %d dev %d kernels_us %llu",
-             comm->rank, comm->cudaDev,
-             (unsigned long long)((clockNano() - t0) / 1000));
-      } else {
-        while (gate.load(std::memory_order_acquire) != 2) { /* spin */ }
-      }
+// Once-per-(process,device) lazy kernel init driven by ncclLaunchKernel.
+// Caller must ensure rcclParamLazyKernelInit() is set; cudaDev range is
+// validated eagerly in ncclCommInitRankFunc so this fast-path only does the
+// CAS-gate dance. The launch stream is checked against graph capture because
+// both ncclInitKernelsForDevice (cudaFuncSetAttribute) and applyKernelStackLimits
+// (cudaDeviceSetLimit) are not stream-capturable and would either corrupt the
+// captured graph or fail with a non-obvious error; users wanting graph capture
+// must perform a warmup launch outside the capture region.
+static ncclResult_t lazyKernelInitOnce(struct ncclComm* comm, cudaStream_t launchStream) {
+  auto& gate = g_rcclLazyKernelInitState[comm->cudaDev];
+  int s = gate.load(std::memory_order_acquire);
+  if (__builtin_expect(s == LAZY_DONE, 1)) return ncclSuccess;
+  if (s == LAZY_FAILED) return ncclSystemError;
+
+  int expected = LAZY_UNINIT;
+  if (gate.compare_exchange_strong(expected, LAZY_INITIALIZING,
+                                   std::memory_order_acq_rel,
+                                   std::memory_order_acquire)) {
+    // Owner: bail out early if we are inside a cuda graph capture — neither
+    // cudaFuncSetAttribute nor cudaDeviceSetLimit can be safely captured.
+    cudaStreamCaptureStatus captureStatus = cudaStreamCaptureStatusNone;
+    cudaError_t cerr = cudaStreamIsCapturing(launchStream, &captureStatus);
+    if (cerr == cudaSuccess && captureStatus != cudaStreamCaptureStatusNone) {
+      gate.store(LAZY_FAILED, std::memory_order_release);
+      WARN("LazyKernelInit: dev %d first launch is inside a stream capture "
+           "(status=%d); cudaFuncSetAttribute/cudaDeviceSetLimit are not "
+           "graph-capturable. Perform a warmup ncclAllReduce outside "
+           "cudaStreamBeginCapture/cudaStreamEndCapture, or unset "
+           "RCCL_LAZY_KERNEL_INIT for capture workloads.",
+           comm->cudaDev, (int)captureStatus);
+      return ncclInvalidUsage;
+    }
+    uint64_t t0 = clockNano();
+    size_t maxLocalSizeBytes = 0;
+    ncclResult_t r = ncclInitKernelsForDevice(comm->cudaArch, comm->maxSharedMem, &maxLocalSizeBytes);
+    if (r != ncclSuccess) {
+      gate.store(LAZY_FAILED, std::memory_order_release);
+      WARN("LazyKernelInit: ncclInitKernelsForDevice failed on dev %d: %d",
+           comm->cudaDev, (int)r);
+      return r;
+    }
+    r = applyKernelStackLimits(comm->archName, maxLocalSizeBytes);
+    if (r != ncclSuccess) {
+      gate.store(LAZY_FAILED, std::memory_order_release);
+      WARN("LazyKernelInit: applyKernelStackLimits failed on dev %d: %d",
+           comm->cudaDev, (int)r);
+      return r;
+    }
+    gate.store(LAZY_DONE, std::memory_order_release);
+    INFO(NCCL_INIT | NCCL_BOOTSTRAP | NCCL_PROFILE,
+         "LazyKernelInit fired rank %d dev %d kernels_us %llu",
+         comm->rank, comm->cudaDev,
+         (unsigned long long)((clockNano() - t0) / 1000));
+    return ncclSuccess;
+  }
+
+  // Waiter: short spin then yield until LAZY_DONE / LAZY_FAILED. Emit one
+  // WARN if the wait exceeds LAZY_INIT_WAITER_WARN_NS so a stuck owner does
+  // not appear as a silent hang in user logs.
+  uint64_t t0 = clockNano();
+  bool warned = false;
+  int w;
+  while ((w = gate.load(std::memory_order_acquire)) != LAZY_DONE) {
+    if (w == LAZY_FAILED) return ncclSystemError;
+    uint64_t elapsed = clockNano() - t0;
+    if (elapsed >= LAZY_INIT_SPIN_NS) sched_yield();
+    if (!warned && elapsed >= LAZY_INIT_WAITER_WARN_NS) {
+      WARN("LazyKernelInit: rank %d dev %d still waiting for owner after %llus; "
+           "owner thread may be stuck in ncclInitKernelsForDevice "
+           "(HSA code-object load) or crashed before publishing the gate",
+           comm->rank, comm->cudaDev,
+           (unsigned long long)(elapsed / 1000000000ULL));
+      warned = true;
     }
   }
+  return ncclSuccess;
+}
+
+ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan) {
+  ncclResult_t ret = ncclSuccess;
   struct ncclKernelPlanner* planner = &comm->planner;
+  // Lazy kernel init: if RCCL_LAZY_KERNEL_INIT=1 (or the NCCL_ alias),
+  // ncclInitKernelsForDevice was skipped during ncclCommInitRankFunc.
+  // Run it once-per-(process,device) here, before the first cuLaunchKernel
+  // that depends on those attributes. cudaDev range is validated eagerly
+  // in ncclCommInitRankFunc when lazy mode is enabled, so we don't repeat
+  // the check on every launch.
+  if (rcclParamLazyKernelInit()) {
+    NCCLCHECK(lazyKernelInitOnce(comm, planner->streams->stream));
+  }
   int nChannels = 0;
   for (int i = 0; i < MAXCHANNELS/64; i++)
     nChannels += countOneBits(plan->channelMask.masks[i]);

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -15,7 +15,7 @@
 #include <hip/hip_ext.h>
 #include "gdrwrap.h"
 #include "bootstrap.h"
-#include <cstring>
+#include <cstring> // std::memcpy
 #include "channel.h"
 #include "rocmwrap.h"
 #include "rccl_vars.h"
@@ -29,7 +29,6 @@
 #include "api_trace.h"
 #include "rccl_common.h"
 
-#include <cstring> // std::memcpy
 #include <cinttypes> // PRIx64
 #include <cassert>
 #include <atomic> // std::atomic — lazy kernel init gate
@@ -102,7 +101,7 @@ RCCL_PARAM_DECLARE(LazyKernelInit);
 // owner thread we propagate the error to all waiters instead of leaving the
 // gate stuck at LAZY_INITIALIZING and hanging every subsequent launch on
 // the same device.
-enum LazyInitState : int {
+enum class LazyInitState : int {
   LAZY_UNINIT       = 0,
   LAZY_INITIALIZING = 1,
   LAZY_DONE         = 2,
@@ -111,8 +110,16 @@ enum LazyInitState : int {
 
 // Sized to MAX_ALLOC_TRACK_NGPU (currently 128) to cover the maximum
 // number of devices RCCL tracks elsewhere; the previous hardcoded 16
-// would silently skip lazy init for cudaDev >= 16.
-static std::atomic<int> g_rcclLazyKernelInitState[MAX_ALLOC_TRACK_NGPU] = {};
+// would silently skip lazy init for cudaDev >= 16. Default-initialised
+// state is LazyInitState::LAZY_UNINIT (== 0) per the enum definition above.
+static std::atomic<LazyInitState> g_rcclLazyKernelInitState[MAX_ALLOC_TRACK_NGPU] = {};
+// Side table for the failing ncclResult_t so waiters surface the same error
+// the owner saw (e.g. ncclUnhandledCudaError from a real init failure)
+// instead of a generic ncclSystemError that loses the first-cause context.
+// Owner writes this BEFORE publishing LAZY_FAILED on the gate; the release
+// on the gate store makes the value visible to any waiter that acquire-loads
+// LAZY_FAILED, so a plain relaxed load on the err table is sufficient.
+static std::atomic<int> g_rcclLazyKernelInitErr[MAX_ALLOC_TRACK_NGPU] = {};
 
 // Spin window for the lazy-init waiter before yielding the core. Mirrors the
 // short tight-spin pattern used in comm.h wait loops: a few µs covers the
@@ -1918,79 +1925,98 @@ NCCL_PARAM(MemSyncDomain, "MEM_SYNC_DOMAIN", cudaLaunchMemSyncDomainRemote);
 // Once-per-(process,device) lazy kernel init driven by ncclLaunchKernel.
 // Caller must ensure rcclParamLazyKernelInit() is set; cudaDev range is
 // validated eagerly in ncclCommInitRankFunc so this fast-path only does the
-// CAS-gate dance. The launch stream is checked against graph capture because
-// both ncclInitKernelsForDevice (cudaFuncSetAttribute) and applyKernelStackLimits
-// (cudaDeviceSetLimit) are not stream-capturable and would either corrupt the
-// captured graph or fail with a non-obvious error; users wanting graph capture
-// must perform a warmup launch outside the capture region.
+// CAS-gate dance.
+//
+// Stream capture is checked AFTER the would-be owner wins the
+// UNINIT->INITIALIZING CAS. If the owner is then found to be inside a
+// capture, it releases ownership back to LAZY_UNINIT (release) and returns
+// ncclInvalidUsage; any concurrent waiter sees that release as "owner
+// abandoned" and restarts from the top of the function to retry the CAS
+// itself. Tying the precondition to CAS ownership (rather than to a stale
+// pre-CAS load of s) closes the race where a thread observed LAZY_UNINIT
+// but did not actually become the owner.
+//
+// On real init failure the gate is poisoned to LAZY_FAILED and the failing
+// ncclResult_t is published in g_rcclLazyKernelInitErr so every waiter
+// returns the same first-cause code instead of a generic ncclSystemError.
 static ncclResult_t lazyKernelInitOnce(struct ncclComm* comm, cudaStream_t launchStream) {
   auto& gate = g_rcclLazyKernelInitState[comm->cudaDev];
-  int s = gate.load(std::memory_order_acquire);
-  if (__builtin_expect(s == LAZY_DONE, 1)) return ncclSuccess;
-  if (s == LAZY_FAILED) return ncclSystemError;
+  auto& errSlot = g_rcclLazyKernelInitErr[comm->cudaDev];
 
-  int expected = LAZY_UNINIT;
-  if (gate.compare_exchange_strong(expected, LAZY_INITIALIZING,
-                                   std::memory_order_acq_rel,
-                                   std::memory_order_acquire)) {
-    // Owner: bail out early if we are inside a cuda graph capture — neither
-    // cudaFuncSetAttribute nor cudaDeviceSetLimit can be safely captured.
-    cudaStreamCaptureStatus captureStatus = cudaStreamCaptureStatusNone;
-    cudaError_t cerr = cudaStreamIsCapturing(launchStream, &captureStatus);
-    if (cerr == cudaSuccess && captureStatus != cudaStreamCaptureStatusNone) {
-      gate.store(LAZY_FAILED, std::memory_order_release);
-      WARN("LazyKernelInit: dev %d first launch is inside a stream capture "
-           "(status=%d); cudaFuncSetAttribute/cudaDeviceSetLimit are not "
-           "graph-capturable. Perform a warmup ncclAllReduce outside "
-           "cudaStreamBeginCapture/cudaStreamEndCapture, or unset "
-           "RCCL_LAZY_KERNEL_INIT for capture workloads.",
-           comm->cudaDev, (int)captureStatus);
-      return ncclInvalidUsage;
+  for (;;) {
+    LazyInitState s = gate.load(std::memory_order_acquire);
+    if (__builtin_expect(s == LazyInitState::LAZY_DONE, 1)) return ncclSuccess;
+    if (s == LazyInitState::LAZY_FAILED) {
+      return (ncclResult_t)errSlot.load(std::memory_order_relaxed);
     }
+
+    if (s == LazyInitState::LAZY_UNINIT) {
+      LazyInitState expected = LazyInitState::LAZY_UNINIT;
+      if (gate.compare_exchange_strong(expected, LazyInitState::LAZY_INITIALIZING,
+                                       std::memory_order_acq_rel,
+                                       std::memory_order_acquire)) {
+        // Owner path. Precondition (stream capture) is checked here, not
+        // before the CAS, so threads that did not actually become the
+        // owner never observe a precondition-driven error.
+        cudaStreamCaptureStatus captureStatus = cudaStreamCaptureStatusNone;
+        cudaError_t cerr = cudaStreamIsCapturing(launchStream, &captureStatus);
+        if (cerr == cudaSuccess && captureStatus != cudaStreamCaptureStatusNone) {
+          gate.store(LazyInitState::LAZY_UNINIT, std::memory_order_release);
+          WARN("LazyKernelInit: dev %d first launch is inside a stream capture "
+               "(status=%d); cudaFuncSetAttribute/cudaDeviceSetLimit are not "
+               "graph-capturable. Perform a warmup ncclAllReduce outside "
+               "cudaStreamBeginCapture/cudaStreamEndCapture, or unset "
+               "RCCL_LAZY_KERNEL_INIT for capture workloads.",
+               comm->cudaDev, (int)captureStatus);
+          return ncclInvalidUsage;
+        }
+
+        uint64_t t0 = clockNano();
+        size_t maxLocalSizeBytes = 0;
+        ncclResult_t r = ncclInitKernelsForDevice(comm->cudaArch, comm->maxSharedMem, &maxLocalSizeBytes);
+        if (r == ncclSuccess) {
+          r = applyKernelStackLimits(comm->archName, maxLocalSizeBytes);
+        }
+        if (r != ncclSuccess) {
+          errSlot.store((int)r, std::memory_order_relaxed);
+          gate.store(LazyInitState::LAZY_FAILED, std::memory_order_release);
+          WARN("LazyKernelInit: init failed on dev %d: %d", comm->cudaDev, (int)r);
+          return r;
+        }
+        gate.store(LazyInitState::LAZY_DONE, std::memory_order_release);
+        INFO(NCCL_INIT | NCCL_BOOTSTRAP | NCCL_PROFILE,
+             "LazyKernelInit fired rank %d dev %d kernels_us %llu",
+             comm->rank, comm->cudaDev,
+             (unsigned long long)((clockNano() - t0) / 1000));
+        return ncclSuccess;
+      }
+      // CAS lost: somebody else owns the gate now, fall through to wait.
+    }
+
+    // Waiter: short spin then yield until DONE / FAILED / UNINIT (the last
+    // means the owner aborted the precondition and released the gate, in
+    // which case we retry the CAS from the top of the loop). Emit one WARN
+    // if the wait exceeds LAZY_INIT_WAITER_WARN_NS so a stuck owner does
+    // not appear as a silent hang in user logs.
     uint64_t t0 = clockNano();
-    size_t maxLocalSizeBytes = 0;
-    ncclResult_t r = ncclInitKernelsForDevice(comm->cudaArch, comm->maxSharedMem, &maxLocalSizeBytes);
-    if (r != ncclSuccess) {
-      gate.store(LAZY_FAILED, std::memory_order_release);
-      WARN("LazyKernelInit: ncclInitKernelsForDevice failed on dev %d: %d",
-           comm->cudaDev, (int)r);
-      return r;
+    bool warned = false;
+    LazyInitState w;
+    while ((w = gate.load(std::memory_order_acquire)) == LazyInitState::LAZY_INITIALIZING) {
+      uint64_t elapsed = clockNano() - t0;
+      if (elapsed >= LAZY_INIT_SPIN_NS) sched_yield();
+      if (!warned && elapsed >= LAZY_INIT_WAITER_WARN_NS) {
+        WARN("LazyKernelInit: rank %d dev %d still waiting for owner after %llus; "
+             "owner thread may be stuck in ncclInitKernelsForDevice "
+             "(HSA code-object load) or crashed before publishing the gate",
+             comm->rank, comm->cudaDev,
+             (unsigned long long)(elapsed / 1000000000ULL));
+        warned = true;
+      }
     }
-    r = applyKernelStackLimits(comm->archName, maxLocalSizeBytes);
-    if (r != ncclSuccess) {
-      gate.store(LAZY_FAILED, std::memory_order_release);
-      WARN("LazyKernelInit: applyKernelStackLimits failed on dev %d: %d",
-           comm->cudaDev, (int)r);
-      return r;
-    }
-    gate.store(LAZY_DONE, std::memory_order_release);
-    INFO(NCCL_INIT | NCCL_BOOTSTRAP | NCCL_PROFILE,
-         "LazyKernelInit fired rank %d dev %d kernels_us %llu",
-         comm->rank, comm->cudaDev,
-         (unsigned long long)((clockNano() - t0) / 1000));
-    return ncclSuccess;
+    if (w == LazyInitState::LAZY_DONE)   return ncclSuccess;
+    if (w == LazyInitState::LAZY_FAILED) return (ncclResult_t)errSlot.load(std::memory_order_relaxed);
+    // w == LAZY_UNINIT: owner aborted; retry the CAS ourselves.
   }
-
-  // Waiter: short spin then yield until LAZY_DONE / LAZY_FAILED. Emit one
-  // WARN if the wait exceeds LAZY_INIT_WAITER_WARN_NS so a stuck owner does
-  // not appear as a silent hang in user logs.
-  uint64_t t0 = clockNano();
-  bool warned = false;
-  int w;
-  while ((w = gate.load(std::memory_order_acquire)) != LAZY_DONE) {
-    if (w == LAZY_FAILED) return ncclSystemError;
-    uint64_t elapsed = clockNano() - t0;
-    if (elapsed >= LAZY_INIT_SPIN_NS) sched_yield();
-    if (!warned && elapsed >= LAZY_INIT_WAITER_WARN_NS) {
-      WARN("LazyKernelInit: rank %d dev %d still waiting for owner after %llus; "
-           "owner thread may be stuck in ncclInitKernelsForDevice "
-           "(HSA code-object load) or crashed before publishing the gate",
-           comm->rank, comm->cudaDev,
-           (unsigned long long)(elapsed / 1000000000ULL));
-      warned = true;
-    }
-  }
-  return ncclSuccess;
 }
 
 ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan) {

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -33,6 +33,8 @@
 #include <cinttypes> // PRIx64
 #include <cassert>
 #include <atomic> // std::atomic — lazy kernel init gate
+#include <sched.h> // sched_yield — lazy kernel init wait path
+#include "alloc.h" // MAX_ALLOC_TRACK_NGPU — sizing for per-device gate
 #include "latency_profiler/CollTraceFunc.h"
 
 #ifdef ENABLE_ROCSHMEM
@@ -96,9 +98,33 @@ NCCL_PARAM(L1SharedMemoryCarveout, "L1_SHARED_MEMORY_CARVEOUT", 0);
 RCCL_PARAM_DECLARE(LazyKernelInit);
 
 // Per-process per-device gate for lazy kernel init.
-// 0 = uninitialized, 1 = initializing, 2 = done.
-// Sized for typical max GPUs per host; bumped above 8 for safety.
-static std::atomic<int> g_rcclLazyKernelInitState[16] = {};
+// LAZY_FAILED is required so that if ncclInitKernelsForDevice fails on the
+// owner thread we propagate the error to all waiters instead of leaving the
+// gate stuck at LAZY_INITIALIZING and hanging every subsequent launch on
+// the same device.
+enum LazyInitState : int {
+  LAZY_UNINIT       = 0,
+  LAZY_INITIALIZING = 1,
+  LAZY_DONE         = 2,
+  LAZY_FAILED       = 3,
+};
+
+// Sized to MAX_ALLOC_TRACK_NGPU (currently 128) to cover the maximum
+// number of devices RCCL tracks elsewhere; the previous hardcoded 16
+// would silently skip lazy init for cudaDev >= 16.
+static std::atomic<int> g_rcclLazyKernelInitState[MAX_ALLOC_TRACK_NGPU] = {};
+
+// Spin window for the lazy-init waiter before yielding the core. Mirrors the
+// short tight-spin pattern used in comm.h wait loops: a few µs covers the
+// common case where the owner is already inside ncclInitKernelsForDevice and
+// about to publish LAZY_DONE, without burning the core for longer waits.
+static constexpr uint64_t LAZY_INIT_SPIN_NS = 5ULL * 1000ULL;
+// One-shot WARN threshold for the waiter. The owner runs ncclInitKernelsForDevice
+// + applyKernelStackLimits, which is typically <2s even on cold HSA code-object
+// load; anything past 30s indicates a stuck owner (deadlock, segfault before
+// the gate is published, or a misconfigured device) and the user should see
+// a clear log line rather than an opaque hang.
+static constexpr uint64_t LAZY_INIT_WAITER_WARN_NS = 30ULL * 1000ULL * 1000ULL * 1000ULL;
 
 // Returns maximum kernel stack size of all CUDA kernels
 ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* maxStackSize) {
@@ -1889,31 +1915,96 @@ ncclResult_t ncclLaunchKernelBefore_NoUncapturedCuda(struct ncclComm* comm, stru
 NCCL_PARAM(MemSyncDomain, "MEM_SYNC_DOMAIN", cudaLaunchMemSyncDomainRemote);
 #endif
 
-ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan) {
-  ncclResult_t ret = ncclSuccess;
-  // Lazy kernel init: if RCCL_LAZY_KERNEL_INIT=1, ncclInitKernelsForDevice was
-  // skipped during ncclCommInitRankFunc. Run it once-per-(process,device) here,
-  // before the first cuLaunchKernel that depends on those attributes.
-  if (rcclParamLazyKernelInit() && comm->cudaDev >= 0 &&
-      comm->cudaDev < (int)(sizeof(g_rcclLazyKernelInitState)/sizeof(g_rcclLazyKernelInitState[0]))) {
-    auto& gate = g_rcclLazyKernelInitState[comm->cudaDev];
-    int s = gate.load(std::memory_order_acquire);
-    if (__builtin_expect(s != 2, 0)) {
-      int expected = 0;
-      if (gate.compare_exchange_strong(expected, 1)) {
-        uint64_t t0 = clockNano();
-        NCCLCHECK(ncclInitKernelsForDevice(comm->cudaArch, comm->maxSharedMem, NULL));
-        gate.store(2, std::memory_order_release);
-        INFO(NCCL_INIT | NCCL_BOOTSTRAP | NCCL_PROFILE,
-             "LazyKernelInit fired rank %d dev %d kernels_us %llu",
-             comm->rank, comm->cudaDev,
-             (unsigned long long)((clockNano() - t0) / 1000));
-      } else {
-        while (gate.load(std::memory_order_acquire) != 2) { /* spin */ }
-      }
+// Once-per-(process,device) lazy kernel init driven by ncclLaunchKernel.
+// Caller must ensure rcclParamLazyKernelInit() is set; cudaDev range is
+// validated eagerly in ncclCommInitRankFunc so this fast-path only does the
+// CAS-gate dance. The launch stream is checked against graph capture because
+// both ncclInitKernelsForDevice (cudaFuncSetAttribute) and applyKernelStackLimits
+// (cudaDeviceSetLimit) are not stream-capturable and would either corrupt the
+// captured graph or fail with a non-obvious error; users wanting graph capture
+// must perform a warmup launch outside the capture region.
+static ncclResult_t lazyKernelInitOnce(struct ncclComm* comm, cudaStream_t launchStream) {
+  auto& gate = g_rcclLazyKernelInitState[comm->cudaDev];
+  int s = gate.load(std::memory_order_acquire);
+  if (__builtin_expect(s == LAZY_DONE, 1)) return ncclSuccess;
+  if (s == LAZY_FAILED) return ncclSystemError;
+
+  int expected = LAZY_UNINIT;
+  if (gate.compare_exchange_strong(expected, LAZY_INITIALIZING,
+                                   std::memory_order_acq_rel,
+                                   std::memory_order_acquire)) {
+    // Owner: bail out early if we are inside a cuda graph capture — neither
+    // cudaFuncSetAttribute nor cudaDeviceSetLimit can be safely captured.
+    cudaStreamCaptureStatus captureStatus = cudaStreamCaptureStatusNone;
+    cudaError_t cerr = cudaStreamIsCapturing(launchStream, &captureStatus);
+    if (cerr == cudaSuccess && captureStatus != cudaStreamCaptureStatusNone) {
+      gate.store(LAZY_FAILED, std::memory_order_release);
+      WARN("LazyKernelInit: dev %d first launch is inside a stream capture "
+           "(status=%d); cudaFuncSetAttribute/cudaDeviceSetLimit are not "
+           "graph-capturable. Perform a warmup ncclAllReduce outside "
+           "cudaStreamBeginCapture/cudaStreamEndCapture, or unset "
+           "RCCL_LAZY_KERNEL_INIT for capture workloads.",
+           comm->cudaDev, (int)captureStatus);
+      return ncclInvalidUsage;
+    }
+    uint64_t t0 = clockNano();
+    size_t maxLocalSizeBytes = 0;
+    ncclResult_t r = ncclInitKernelsForDevice(comm->cudaArch, comm->maxSharedMem, &maxLocalSizeBytes);
+    if (r != ncclSuccess) {
+      gate.store(LAZY_FAILED, std::memory_order_release);
+      WARN("LazyKernelInit: ncclInitKernelsForDevice failed on dev %d: %d",
+           comm->cudaDev, (int)r);
+      return r;
+    }
+    r = applyKernelStackLimits(comm->archName, maxLocalSizeBytes);
+    if (r != ncclSuccess) {
+      gate.store(LAZY_FAILED, std::memory_order_release);
+      WARN("LazyKernelInit: applyKernelStackLimits failed on dev %d: %d",
+           comm->cudaDev, (int)r);
+      return r;
+    }
+    gate.store(LAZY_DONE, std::memory_order_release);
+    INFO(NCCL_INIT | NCCL_BOOTSTRAP | NCCL_PROFILE,
+         "LazyKernelInit fired rank %d dev %d kernels_us %llu",
+         comm->rank, comm->cudaDev,
+         (unsigned long long)((clockNano() - t0) / 1000));
+    return ncclSuccess;
+  }
+
+  // Waiter: short spin then yield until LAZY_DONE / LAZY_FAILED. Emit one
+  // WARN if the wait exceeds LAZY_INIT_WAITER_WARN_NS so a stuck owner does
+  // not appear as a silent hang in user logs.
+  uint64_t t0 = clockNano();
+  bool warned = false;
+  int w;
+  while ((w = gate.load(std::memory_order_acquire)) != LAZY_DONE) {
+    if (w == LAZY_FAILED) return ncclSystemError;
+    uint64_t elapsed = clockNano() - t0;
+    if (elapsed >= LAZY_INIT_SPIN_NS) sched_yield();
+    if (!warned && elapsed >= LAZY_INIT_WAITER_WARN_NS) {
+      WARN("LazyKernelInit: rank %d dev %d still waiting for owner after %llus; "
+           "owner thread may be stuck in ncclInitKernelsForDevice "
+           "(HSA code-object load) or crashed before publishing the gate",
+           comm->rank, comm->cudaDev,
+           (unsigned long long)(elapsed / 1000000000ULL));
+      warned = true;
     }
   }
+  return ncclSuccess;
+}
+
+ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan) {
+  ncclResult_t ret = ncclSuccess;
   struct ncclKernelPlanner* planner = &comm->planner;
+  // Lazy kernel init: if RCCL_LAZY_KERNEL_INIT=1 (or the NCCL_ alias),
+  // ncclInitKernelsForDevice was skipped during ncclCommInitRankFunc.
+  // Run it once-per-(process,device) here, before the first cuLaunchKernel
+  // that depends on those attributes. cudaDev range is validated eagerly
+  // in ncclCommInitRankFunc when lazy mode is enabled, so we don't repeat
+  // the check on every launch.
+  if (rcclParamLazyKernelInit()) {
+    NCCLCHECK(lazyKernelInitOnce(comm, planner->streams->stream));
+  }
   int nChannels = 0;
   for (int i = 0; i < MAXCHANNELS/64; i++)
     nChannels += countOneBits(plan->channelMask.masks[i]);

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -32,6 +32,7 @@
 #include <cstring> // std::memcpy
 #include <cinttypes> // PRIx64
 #include <cassert>
+#include <atomic> // std::atomic — lazy kernel init gate
 #include "latency_profiler/CollTraceFunc.h"
 
 #ifdef ENABLE_ROCSHMEM
@@ -92,6 +93,12 @@ constexpr int rcclShmemDynamicSize(int cudaArch = NCCL_CUDA_ARCH, int WarpSize =
 }
 
 NCCL_PARAM(L1SharedMemoryCarveout, "L1_SHARED_MEMORY_CARVEOUT", 0);
+RCCL_PARAM_DECLARE(LazyKernelInit);
+
+// Per-process per-device gate for lazy kernel init.
+// 0 = uninitialized, 1 = initializing, 2 = done.
+// Sized for typical max GPUs per host; bumped above 8 for safety.
+static std::atomic<int> g_rcclLazyKernelInitState[16] = {};
 
 // Returns maximum kernel stack size of all CUDA kernels
 ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* maxStackSize) {
@@ -1884,6 +1891,28 @@ NCCL_PARAM(MemSyncDomain, "MEM_SYNC_DOMAIN", cudaLaunchMemSyncDomainRemote);
 
 ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan) {
   ncclResult_t ret = ncclSuccess;
+  // Lazy kernel init: if RCCL_LAZY_KERNEL_INIT=1, ncclInitKernelsForDevice was
+  // skipped during ncclCommInitRankFunc. Run it once-per-(process,device) here,
+  // before the first cuLaunchKernel that depends on those attributes.
+  if (rcclParamLazyKernelInit() && comm->cudaDev >= 0 &&
+      comm->cudaDev < (int)(sizeof(g_rcclLazyKernelInitState)/sizeof(g_rcclLazyKernelInitState[0]))) {
+    auto& gate = g_rcclLazyKernelInitState[comm->cudaDev];
+    int s = gate.load(std::memory_order_acquire);
+    if (__builtin_expect(s != 2, 0)) {
+      int expected = 0;
+      if (gate.compare_exchange_strong(expected, 1)) {
+        uint64_t t0 = clockNano();
+        NCCLCHECK(ncclInitKernelsForDevice(comm->cudaArch, comm->maxSharedMem, NULL));
+        gate.store(2, std::memory_order_release);
+        INFO(NCCL_INIT | NCCL_BOOTSTRAP | NCCL_PROFILE,
+             "LazyKernelInit fired rank %d dev %d kernels_us %llu",
+             comm->rank, comm->cudaDev,
+             (unsigned long long)((clockNano() - t0) / 1000));
+      } else {
+        while (gate.load(std::memory_order_acquire) != 2) { /* spin */ }
+      }
+    }
+  }
   struct ncclKernelPlanner* planner = &comm->planner;
   int nChannels = 0;
   for (int i = 0; i < MAXCHANNELS/64; i++)

--- a/projects/rccl/src/group.cc
+++ b/projects/rccl/src/group.cc
@@ -383,6 +383,12 @@ static ncclResult_t doLaunches(struct ncclComm* head) {
             CUDACHECKGOTO(cudaSetDevice(comm->cudaDev), result, failure);
             NCCLCHECKGOTO(ncclLaunchKernelBefore_NoUncapturedCuda(comm, plan), result, failure);
             if (plan->isCeColl) {
+              // CE collectives use copy-engine / DMA paths, not the compute
+              // kernels initialized by ncclInitKernelsForDevice. The lazy-init
+              // gate intentionally lives only in ncclLaunchKernel below: if a
+              // CE collective is the first launch on a (process, device), no
+              // lazy init runs (none is required), and any subsequent non-CE
+              // launch will still fire the gate normally.
               NCCLCHECKGOTO(ncclLaunchCeColl(comm, plan), result, failure);
             } else if (plan->isRma) {
               NCCLCHECKGOTO(ncclLaunchRma(comm, plan), result, failure);

--- a/projects/rccl/src/group.cc
+++ b/projects/rccl/src/group.cc
@@ -340,6 +340,12 @@ static ncclResult_t doLaunches(struct ncclComm* head) {
             CUDACHECKGOTO(cudaSetDevice(comm->cudaDev), result, failure);
             NCCLCHECKGOTO(ncclLaunchKernelBefore_NoUncapturedCuda(comm, plan), result, failure);
             if (plan->isCeColl) {
+              // CE collectives use copy-engine / DMA paths, not the compute
+              // kernels initialized by ncclInitKernelsForDevice. The lazy-init
+              // gate intentionally lives only in ncclLaunchKernel below: if a
+              // CE collective is the first launch on a (process, device), no
+              // lazy init runs (none is required), and any subsequent non-CE
+              // launch will still fire the gate normally.
               NCCLCHECKGOTO(ncclLaunchCeColl(comm, plan), result, failure);
             } else {
               NCCLCHECKGOTO(ncclLaunchKernel(comm, plan), result, failure);

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -634,6 +634,7 @@ struct ncclComm {
   ncclAffinity cpuAffinity; // CPU affinity of the GPU
   int WarpSize;
   int cudaArch; // matches __CUDA_ARCH__ of device
+  int maxSharedMem; // device max shared memory per block (opt-in); needed for lazy kernel init
 
   int cpuArch;   // architecture - As defined in src/include/graph.h, e.g. x86/arm/ppc/mixed
   int cpuVendor; // vendor - As defined in src/include/graph.h

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -552,6 +552,7 @@ struct ncclComm {
   cpu_set_t cpuAffinity; // CPU affinity of the GPU
   int WarpSize;
   int cudaArch; // matches __CUDA_ARCH__ of device
+  int maxSharedMem; // device max shared memory per block (opt-in); needed for lazy kernel init
 
   int cpuArch;   // architecture - As defined in src/include/graph.h, e.g. x86/arm/ppc/mixed
   int cpuVendor; // vendor - As defined in src/include/graph.h

--- a/projects/rccl/src/include/enqueue.h
+++ b/projects/rccl/src/include/enqueue.h
@@ -21,6 +21,12 @@
 void* rcclGetKernelIndex(int unroll, bool useCollTrace, struct ncclTaskColl* task = NULL);
 
 ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* maxStackSize);
+// Applies cudaLimitStackSize on the current device using maxLocalSizeBytes
+// returned by ncclInitKernelsForDevice. Shared between the eager init path
+// in ncclCommInitRankFunc and the lazy init path in ncclLaunchKernel. No
+// comm pointer is needed: the call is purely device-scoped and runs on the
+// current CUDA device (set by the caller via cudaSetDevice/launch context).
+ncclResult_t applyKernelStackLimits(const char* archName, size_t maxLocalSizeBytes);
 ncclResult_t ncclEnqueueCheck(struct ncclInfo* info);
 ncclResult_t ncclLaunchPrepare(struct ncclComm* comm);
 ncclResult_t ncclLaunchKernelBefore_NoUncapturedCuda(struct ncclComm* comm, struct ncclKernelPlan* plan);

--- a/projects/rccl/src/include/enqueue.h
+++ b/projects/rccl/src/include/enqueue.h
@@ -20,6 +20,12 @@
 void* rcclGetKernelIndex(int unroll, bool useCollTrace, struct ncclTaskColl* task = NULL);
 
 ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* maxStackSize);
+// Applies cudaLimitStackSize on the current device using maxLocalSizeBytes
+// returned by ncclInitKernelsForDevice. Shared between the eager init path
+// in ncclCommInitRankFunc and the lazy init path in ncclLaunchKernel. No
+// comm pointer is needed: the call is purely device-scoped and runs on the
+// current CUDA device (set by the caller via cudaSetDevice/launch context).
+ncclResult_t applyKernelStackLimits(const char* archName, size_t maxLocalSizeBytes);
 ncclResult_t ncclEnqueueCheck(struct ncclInfo* info);
 ncclResult_t ncclLaunchPrepare(struct ncclComm* comm);
 ncclResult_t ncclLaunchKernelBefore_NoUncapturedCuda(struct ncclComm* comm, struct ncclKernelPlan* plan);

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -192,7 +192,15 @@ RCCL_PARAM( InitChannels, "INIT_CHANNELS", -1) ;
 // Defer ncclInitKernelsForDevice from init to first ncclLaunchKernel.
 // On large-scale (32n+) the eager init triggers HSA code-object load (~1.2s);
 // deferring it amortizes that cost into the first collective launch.
-RCCL_PARAM(LazyKernelInit, "LAZY_KERNEL_INIT", 0);
+// Accepts both NCCL_LAZY_KERNEL_INIT and RCCL_LAZY_KERNEL_INIT (RCCL_ wins
+// when both are set).
+// NOTE: not compatible with cudaDeviceReset() between communicator lifetimes
+// in the same process. The per-device CAS gate (g_rcclLazyKernelInitState) is
+// process-static and survives a device reset, while the underlying HSA code
+// objects do not — subsequent launches would skip re-init and surface as
+// opaque HSA errors. Workflows that rely on cudaDeviceReset must keep
+// RCCL_LAZY_KERNEL_INIT unset (default).
+RCCL_PARAM_NCCL_ALIAS(LazyKernelInit, "LAZY_KERNEL_INIT", 0);
 
 // GDRCOPY support: Off by default
 NCCL_PARAM(GdrCopyEnable, "GDRCOPY_ENABLE", 0);
@@ -2370,6 +2378,30 @@ fail:
   goto exit;
 }
 
+// Apply cudaLimitStackSize for the current device using the maxLocalSize
+// reported by ncclInitKernelsForDevice. Shared between the eager init path
+// and the lazy init path (called from ncclLaunchKernel) so the same stack
+// configuration is applied regardless of when kernel init actually runs.
+ncclResult_t applyKernelStackLimits(const char* archName, size_t maxLocalSizeBytes) {
+#ifdef USE_INDIRECT_FUNCTION_CALL
+  if (ncclParamSetStackSize() == 1 && !IsArchMatch(archName,"gfx942") && !IsArchMatch(archName,"gfx950")) {
+    int64_t stackSize = rcclParamStackSizeOverride() ? rcclParamStackSizeOverride() : (int64_t)maxLocalSizeBytes;
+    if (stackSize == 0) {
+      stackSize = IsArchMatch(archName,"gfx906") ? 1024 : 512;
+    }
+    INFO(NCCL_INIT, "Setting cudaLimitStackSize to %zi maxLocalSizeBytes %zi", (ssize_t)stackSize, maxLocalSizeBytes);
+    CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, stackSize));
+  }
+#else
+  (void)archName;
+#endif
+  if (maxLocalSizeBytes > 0 && ncclParamSetStackSize() == 1) {
+    TRACE(NCCL_INIT, "Setting cudaLimitStackSize to %zu", maxLocalSizeBytes);
+    CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, maxLocalSizeBytes));
+  }
+  return ncclSuccess;
+}
+
 static ncclResult_t getParentRanks(int parentRanks, int parentRank, int* excludeRanksList, int excludeRanksCount, int* nRanksRet, int* myRankRet, int* parentRanksRet) {
   int count = 0, j = 0;
   for (int i = 0; i < parentRanks; i++) {
@@ -2402,10 +2434,6 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   int cuCount;
   hipDeviceProp_t devProp;
 
-  #ifdef USE_INDIRECT_FUNCTION_CALL
-  int64_t stackSize;
-  #endif
-
   timers[TIMER_INIT_TOTAL] = clockNano();
   CUDACHECKGOTO(cudaSetDevice(cudaDev), res, fail);
   CUDACHECKGOTO(cudaDeviceGetAttribute(&maxSharedMem, cudaDevAttrMaxSharedMemoryPerBlockOptin, cudaDev), res, fail);
@@ -2422,36 +2450,10 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     goto fail;
   }
 
-  comm->maxSharedMem = maxSharedMem; // saved for possible lazy kernel init
-  timers[TIMER_INIT_KERNELS] = clockNano();
-  if (rcclParamLazyKernelInit() == 0) {
-    NCCLCHECK(ncclInitKernelsForDevice(cudaArch, maxSharedMem, &maxLocalSizeBytes));
-    // Set the maximum kernel stack size of all kernels to avoid
-    // a CUDA memory reconfig on load (c.f. NVSHMEM issue)
-#ifdef USE_INDIRECT_FUNCTION_CALL
-    if (ncclParamSetStackSize() == 1 && !IsArchMatch(archName,"gfx942") && !IsArchMatch(archName,"gfx950")) {
-      stackSize = rcclParamStackSizeOverride() ? rcclParamStackSizeOverride() : maxLocalSizeBytes;
-      if (stackSize == 0) {
-        if (IsArchMatch(archName,"gfx906"))
-          stackSize = 1024;
-        else
-          stackSize = 512;
-      }
-      INFO(NCCL_INIT, "Setting cudaLimitStackSize to %zi maxLocalSizeBytes %zi", stackSize, maxLocalSizeBytes);
-      CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, stackSize));
-    }
-#endif
-    if (maxLocalSizeBytes > 0 && ncclParamSetStackSize() == 1) {
-      TRACE(NCCL_INIT, "Setting cudaLimitStackSize to %zu", maxLocalSizeBytes);
-      CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, maxLocalSizeBytes));
-    }
-  }
-  timers[TIMER_INIT_KERNELS] = clockNano() - timers[TIMER_INIT_KERNELS];
-  INFO(NCCL_INIT | NCCL_BOOTSTRAP | NCCL_PROFILE,
-       "PreBoot timings rank %d kernels_us %llu lazy %d",
-       job->myrank, (unsigned long long)(timers[TIMER_INIT_KERNELS] / 1000),
-       (int)rcclParamLazyKernelInit());
-
+  // NOTE: kernel init (eager or lazy) and comm->maxSharedMem assignment are
+  // deferred until after the parent/NOCOLOR exit so we do not deref a NULL
+  // comm for NCCL_SPLIT_NOCOLOR child jobs, and so the PreBoot INFO line
+  // below sees the populated job->myrank for split children.
   if (job->parent && !job->isGrow) {
     // SPLIT/SHRINK: use bootstrapSplit
     NCCLCHECKGOTO(ncclCalloc(&parentRanks, job->parent->nRanks), res, fail);
@@ -2509,10 +2511,34 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   }
   comm->cudaArch = cudaArch;
   comm->archName = archName;
+  comm->maxSharedMem = maxSharedMem; // saved for possible lazy kernel init
   comm->cuCount = cuCount;
   // [RCCL] Host mirrors of device side NCCL_LL128_LINEELEMS / NCCL_LL128_DATAELEMS
   comm->ll128LineElems = rcclLL128LineElemsFromArch(comm->archName);
   comm->ll128DataElems = rcclLL128DataElemsFromArch(comm->archName);
+
+  timers[TIMER_INIT_KERNELS] = clockNano();
+  if (rcclParamLazyKernelInit() == 0) {
+    NCCLCHECK(ncclInitKernelsForDevice(cudaArch, maxSharedMem, &maxLocalSizeBytes));
+    // Set the maximum kernel stack size of all kernels to avoid
+    // a CUDA memory reconfig on load (c.f. NVSHMEM issue).
+    NCCLCHECK(applyKernelStackLimits(archName, maxLocalSizeBytes));
+  } else {
+    // Lazy mode: validate that comm->cudaDev fits in the per-device CAS-gate
+    // table here, at init time, so a misconfigured device fails fast with a
+    // clear error instead of surfacing later on the first ncclLaunchKernel.
+    if (comm->cudaDev < 0 || comm->cudaDev >= MAX_ALLOC_TRACK_NGPU) {
+      WARN("LazyKernelInit: cudaDev %d out of range [0,%d); cannot lazily init kernels",
+           comm->cudaDev, MAX_ALLOC_TRACK_NGPU);
+      res = ncclInvalidUsage;
+      goto fail;
+    }
+  }
+  timers[TIMER_INIT_KERNELS] = clockNano() - timers[TIMER_INIT_KERNELS];
+  INFO(NCCL_INIT | NCCL_BOOTSTRAP | NCCL_PROFILE,
+       "PreBoot timings rank %d kernels_us %llu lazy %d",
+       job->myrank, (unsigned long long)(timers[TIMER_INIT_KERNELS] / 1000),
+       (int)rcclParamLazyKernelInit());
 
   NCCLCHECKGOTO(initTransportsRank(comm, job->parent, timers), res, fail);
 

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -189,6 +189,11 @@ RCCL_PARAM(Gfx9CheapFenceOff, "GFX9_CHEAP_FENCE_OFF", 0);
  */
 RCCL_PARAM( InitChannels, "INIT_CHANNELS", -1) ;
 
+// Defer ncclInitKernelsForDevice from init to first ncclLaunchKernel.
+// On large-scale (32n+) the eager init triggers HSA code-object load (~1.2s);
+// deferring it amortizes that cost into the first collective launch.
+RCCL_PARAM(LazyKernelInit, "LAZY_KERNEL_INIT", 0);
+
 // GDRCOPY support: Off by default
 NCCL_PARAM(GdrCopyEnable, "GDRCOPY_ENABLE", 0);
 
@@ -2417,28 +2422,35 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     goto fail;
   }
 
+  comm->maxSharedMem = maxSharedMem; // saved for possible lazy kernel init
   timers[TIMER_INIT_KERNELS] = clockNano();
-  NCCLCHECK(ncclInitKernelsForDevice(cudaArch, maxSharedMem, &maxLocalSizeBytes));
-  // Set the maximum kernel stack size of all kernels to avoid
-  // a CUDA memory reconfig on load (c.f. NVSHMEM issue)
+  if (rcclParamLazyKernelInit() == 0) {
+    NCCLCHECK(ncclInitKernelsForDevice(cudaArch, maxSharedMem, &maxLocalSizeBytes));
+    // Set the maximum kernel stack size of all kernels to avoid
+    // a CUDA memory reconfig on load (c.f. NVSHMEM issue)
 #ifdef USE_INDIRECT_FUNCTION_CALL
-  if (ncclParamSetStackSize() == 1 && !IsArchMatch(archName,"gfx942") && !IsArchMatch(archName,"gfx950")) {
-    stackSize = rcclParamStackSizeOverride() ? rcclParamStackSizeOverride() : maxLocalSizeBytes;
-    if (stackSize == 0) {
-      if (IsArchMatch(archName,"gfx906"))
-        stackSize = 1024;
-      else
-        stackSize = 512;
+    if (ncclParamSetStackSize() == 1 && !IsArchMatch(archName,"gfx942") && !IsArchMatch(archName,"gfx950")) {
+      stackSize = rcclParamStackSizeOverride() ? rcclParamStackSizeOverride() : maxLocalSizeBytes;
+      if (stackSize == 0) {
+        if (IsArchMatch(archName,"gfx906"))
+          stackSize = 1024;
+        else
+          stackSize = 512;
+      }
+      INFO(NCCL_INIT, "Setting cudaLimitStackSize to %zi maxLocalSizeBytes %zi", stackSize, maxLocalSizeBytes);
+      CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, stackSize));
     }
-    INFO(NCCL_INIT, "Setting cudaLimitStackSize to %zi maxLocalSizeBytes %zi", stackSize, maxLocalSizeBytes);
-    CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, stackSize));
-  }
 #endif
-  if (maxLocalSizeBytes > 0 && ncclParamSetStackSize() == 1) {
-    TRACE(NCCL_INIT, "Setting cudaLimitStackSize to %zu", maxLocalSizeBytes);
-    CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, maxLocalSizeBytes));
+    if (maxLocalSizeBytes > 0 && ncclParamSetStackSize() == 1) {
+      TRACE(NCCL_INIT, "Setting cudaLimitStackSize to %zu", maxLocalSizeBytes);
+      CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, maxLocalSizeBytes));
+    }
   }
   timers[TIMER_INIT_KERNELS] = clockNano() - timers[TIMER_INIT_KERNELS];
+  INFO(NCCL_INIT | NCCL_BOOTSTRAP | NCCL_PROFILE,
+       "PreBoot timings rank %d kernels_us %llu lazy %d",
+       job->myrank, (unsigned long long)(timers[TIMER_INIT_KERNELS] / 1000),
+       (int)rcclParamLazyKernelInit());
 
   if (job->parent && !job->isGrow) {
     // SPLIT/SHRINK: use bootstrapSplit

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -2386,11 +2386,17 @@ ncclResult_t applyKernelStackLimits(const char* archName, size_t maxLocalSizeByt
 #ifdef USE_INDIRECT_FUNCTION_CALL
   if (ncclParamSetStackSize() == 1 && !IsArchMatch(archName,"gfx942") && !IsArchMatch(archName,"gfx950")) {
     int64_t stackSize = rcclParamStackSizeOverride() ? rcclParamStackSizeOverride() : (int64_t)maxLocalSizeBytes;
+    if (stackSize < 0) {
+      // cudaDeviceSetLimit takes size_t -- a negative override would wrap to
+      // a huge value. Fall back to maxLocalSizeBytes and warn.
+      WARN("RCCL_STACK_SIZE_OVERRIDE=%zi is negative, falling back to maxLocalSizeBytes=%zu", (ssize_t)stackSize, maxLocalSizeBytes);
+      stackSize = (int64_t)maxLocalSizeBytes;
+    }
     if (stackSize == 0) {
       stackSize = IsArchMatch(archName,"gfx906") ? 1024 : 512;
     }
     INFO(NCCL_INIT, "Setting cudaLimitStackSize to %zi maxLocalSizeBytes %zu", (ssize_t)stackSize, maxLocalSizeBytes);
-    CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, stackSize));
+    CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, (size_t)stackSize));
     // This path already chose stackSize with RCCL_STACK_SIZE_OVERRIDE
     // taken into account (and falls back to maxLocalSizeBytes or an
     // arch-specific floor otherwise). The unconditional second

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -2389,8 +2389,15 @@ ncclResult_t applyKernelStackLimits(const char* archName, size_t maxLocalSizeByt
     if (stackSize == 0) {
       stackSize = IsArchMatch(archName,"gfx906") ? 1024 : 512;
     }
-    INFO(NCCL_INIT, "Setting cudaLimitStackSize to %zi maxLocalSizeBytes %zi", (ssize_t)stackSize, maxLocalSizeBytes);
+    INFO(NCCL_INIT, "Setting cudaLimitStackSize to %zi maxLocalSizeBytes %zu", (ssize_t)stackSize, maxLocalSizeBytes);
     CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, stackSize));
+    // This path already chose stackSize with RCCL_STACK_SIZE_OVERRIDE
+    // taken into account (and falls back to maxLocalSizeBytes or an
+    // arch-specific floor otherwise). The unconditional second
+    // cudaDeviceSetLimit below would overwrite the override with the
+    // raw maxLocalSizeBytes whenever maxLocalSizeBytes > 0, silently
+    // dropping the user's STACK_SIZE_OVERRIDE -- so we stop here.
+    return ncclSuccess;
   }
 #else
   (void)archName;

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -134,7 +134,15 @@ RCCL_PARAM( InitChannels, "INIT_CHANNELS", -1) ;
 // Defer ncclInitKernelsForDevice from init to first ncclLaunchKernel.
 // On large-scale (32n+) the eager init triggers HSA code-object load (~1.2s);
 // deferring it amortizes that cost into the first collective launch.
-RCCL_PARAM(LazyKernelInit, "LAZY_KERNEL_INIT", 0);
+// Accepts both NCCL_LAZY_KERNEL_INIT and RCCL_LAZY_KERNEL_INIT (RCCL_ wins
+// when both are set).
+// NOTE: not compatible with cudaDeviceReset() between communicator lifetimes
+// in the same process. The per-device CAS gate (g_rcclLazyKernelInitState) is
+// process-static and survives a device reset, while the underlying HSA code
+// objects do not — subsequent launches would skip re-init and surface as
+// opaque HSA errors. Workflows that rely on cudaDeviceReset must keep
+// RCCL_LAZY_KERNEL_INIT unset (default).
+RCCL_PARAM_NCCL_ALIAS(LazyKernelInit, "LAZY_KERNEL_INIT", 0);
 
 // GDRCOPY support: Off by default
 NCCL_PARAM(GdrCopyEnable, "GDRCOPY_ENABLE", 0);
@@ -2230,6 +2238,30 @@ fail:
   goto exit;
 }
 
+// Apply cudaLimitStackSize for the current device using the maxLocalSize
+// reported by ncclInitKernelsForDevice. Shared between the eager init path
+// and the lazy init path (called from ncclLaunchKernel) so the same stack
+// configuration is applied regardless of when kernel init actually runs.
+ncclResult_t applyKernelStackLimits(const char* archName, size_t maxLocalSizeBytes) {
+#ifdef USE_INDIRECT_FUNCTION_CALL
+  if (ncclParamSetStackSize() == 1 && !IsArchMatch(archName,"gfx942") && !IsArchMatch(archName,"gfx950")) {
+    int64_t stackSize = rcclParamStackSizeOverride() ? rcclParamStackSizeOverride() : (int64_t)maxLocalSizeBytes;
+    if (stackSize == 0) {
+      stackSize = IsArchMatch(archName,"gfx906") ? 1024 : 512;
+    }
+    INFO(NCCL_INIT, "Setting cudaLimitStackSize to %zi maxLocalSizeBytes %zi", (ssize_t)stackSize, maxLocalSizeBytes);
+    CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, stackSize));
+  }
+#else
+  (void)archName;
+#endif
+  if (maxLocalSizeBytes > 0 && ncclParamSetStackSize() == 1) {
+    TRACE(NCCL_INIT, "Setting cudaLimitStackSize to %zu", maxLocalSizeBytes);
+    CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, maxLocalSizeBytes));
+  }
+  return ncclSuccess;
+}
+
 static ncclResult_t getParentRanks(int parentRanks, int parentRank, int* excludeRanksList, int excludeRanksCount, int* nRanksRet, int* myRankRet, int* parentRanksRet) {
   int count = 0, j = 0;
   for (int i = 0; i < parentRanks; i++) {
@@ -2262,10 +2294,6 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   int cuCount;
   hipDeviceProp_t devProp;
 
-  #ifdef USE_INDIRECT_FUNCTION_CALL
-  int64_t stackSize;
-  #endif
-
   timers[TIMER_INIT_TOTAL] = clockNano();
   CUDACHECKGOTO(cudaSetDevice(cudaDev), res, fail);
   CUDACHECKGOTO(cudaDeviceGetAttribute(&maxSharedMem, cudaDevAttrMaxSharedMemoryPerBlockOptin, cudaDev), res, fail);
@@ -2282,36 +2310,10 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     goto fail;
   }
 
-  comm->maxSharedMem = maxSharedMem; // saved for possible lazy kernel init
-  timers[TIMER_INIT_KERNELS] = clockNano();
-  if (rcclParamLazyKernelInit() == 0) {
-    NCCLCHECK(ncclInitKernelsForDevice(cudaArch, maxSharedMem, &maxLocalSizeBytes));
-    // Set the maximum kernel stack size of all kernels to avoid
-    // a CUDA memory reconfig on load (c.f. NVSHMEM issue)
-#ifdef USE_INDIRECT_FUNCTION_CALL
-    if (ncclParamSetStackSize() == 1 && !IsArchMatch(archName,"gfx942") && !IsArchMatch(archName,"gfx950")) {
-      stackSize = rcclParamStackSizeOverride() ? rcclParamStackSizeOverride() : maxLocalSizeBytes;
-      if (stackSize == 0) {
-        if (IsArchMatch(archName,"gfx906"))
-          stackSize = 1024;
-        else
-          stackSize = 512;
-      }
-      INFO(NCCL_INIT, "Setting cudaLimitStackSize to %zi maxLocalSizeBytes %zi", stackSize, maxLocalSizeBytes);
-      CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, stackSize));
-    }
-#endif
-    if (maxLocalSizeBytes > 0 && ncclParamSetStackSize() == 1) {
-      TRACE(NCCL_INIT, "Setting cudaLimitStackSize to %zu", maxLocalSizeBytes);
-      CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, maxLocalSizeBytes));
-    }
-  }
-  timers[TIMER_INIT_KERNELS] = clockNano() - timers[TIMER_INIT_KERNELS];
-  INFO(NCCL_INIT | NCCL_BOOTSTRAP | NCCL_PROFILE,
-       "PreBoot timings rank %d kernels_us %llu lazy %d",
-       job->myrank, (unsigned long long)(timers[TIMER_INIT_KERNELS] / 1000),
-       (int)rcclParamLazyKernelInit());
-
+  // NOTE: kernel init (eager or lazy) and comm->maxSharedMem assignment are
+  // deferred until after the parent/NOCOLOR exit so we do not deref a NULL
+  // comm for NCCL_SPLIT_NOCOLOR child jobs, and so the PreBoot INFO line
+  // below sees the populated job->myrank for split children.
   if (job->parent) {
     NCCLCHECKGOTO(ncclCalloc(&parentRanks, job->parent->nRanks), res, fail);
     if (job->excludeRanksCount) {
@@ -2356,10 +2358,34 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   }
   comm->cudaArch = cudaArch;
   comm->archName = archName;
+  comm->maxSharedMem = maxSharedMem; // saved for possible lazy kernel init
   comm->cuCount = cuCount;
   // [RCCL] Host mirrors of device side NCCL_LL128_LINEELEMS / NCCL_LL128_DATAELEMS
   comm->ll128LineElems = rcclLL128LineElemsFromArch(comm->archName);
   comm->ll128DataElems = rcclLL128DataElemsFromArch(comm->archName);
+
+  timers[TIMER_INIT_KERNELS] = clockNano();
+  if (rcclParamLazyKernelInit() == 0) {
+    NCCLCHECK(ncclInitKernelsForDevice(cudaArch, maxSharedMem, &maxLocalSizeBytes));
+    // Set the maximum kernel stack size of all kernels to avoid
+    // a CUDA memory reconfig on load (c.f. NVSHMEM issue).
+    NCCLCHECK(applyKernelStackLimits(archName, maxLocalSizeBytes));
+  } else {
+    // Lazy mode: validate that comm->cudaDev fits in the per-device CAS-gate
+    // table here, at init time, so a misconfigured device fails fast with a
+    // clear error instead of surfacing later on the first ncclLaunchKernel.
+    if (comm->cudaDev < 0 || comm->cudaDev >= MAX_ALLOC_TRACK_NGPU) {
+      WARN("LazyKernelInit: cudaDev %d out of range [0,%d); cannot lazily init kernels",
+           comm->cudaDev, MAX_ALLOC_TRACK_NGPU);
+      res = ncclInvalidUsage;
+      goto fail;
+    }
+  }
+  timers[TIMER_INIT_KERNELS] = clockNano() - timers[TIMER_INIT_KERNELS];
+  INFO(NCCL_INIT | NCCL_BOOTSTRAP | NCCL_PROFILE,
+       "PreBoot timings rank %d kernels_us %llu lazy %d",
+       job->myrank, (unsigned long long)(timers[TIMER_INIT_KERNELS] / 1000),
+       (int)rcclParamLazyKernelInit());
 
   NCCLCHECKGOTO(initTransportsRank(comm, job->parent, timers), res, fail);
 

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -2249,8 +2249,15 @@ ncclResult_t applyKernelStackLimits(const char* archName, size_t maxLocalSizeByt
     if (stackSize == 0) {
       stackSize = IsArchMatch(archName,"gfx906") ? 1024 : 512;
     }
-    INFO(NCCL_INIT, "Setting cudaLimitStackSize to %zi maxLocalSizeBytes %zi", (ssize_t)stackSize, maxLocalSizeBytes);
+    INFO(NCCL_INIT, "Setting cudaLimitStackSize to %zi maxLocalSizeBytes %zu", (ssize_t)stackSize, maxLocalSizeBytes);
     CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, stackSize));
+    // This path already chose stackSize with RCCL_STACK_SIZE_OVERRIDE
+    // taken into account (and falls back to maxLocalSizeBytes or an
+    // arch-specific floor otherwise). The unconditional second
+    // cudaDeviceSetLimit below would overwrite the override with the
+    // raw maxLocalSizeBytes whenever maxLocalSizeBytes > 0, silently
+    // dropping the user's STACK_SIZE_OVERRIDE -- so we stop here.
+    return ncclSuccess;
   }
 #else
   (void)archName;

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -131,6 +131,11 @@ RCCL_PARAM(Gfx9CheapFenceOff, "GFX9_CHEAP_FENCE_OFF", 0);
  */
 RCCL_PARAM( InitChannels, "INIT_CHANNELS", -1) ;
 
+// Defer ncclInitKernelsForDevice from init to first ncclLaunchKernel.
+// On large-scale (32n+) the eager init triggers HSA code-object load (~1.2s);
+// deferring it amortizes that cost into the first collective launch.
+RCCL_PARAM(LazyKernelInit, "LAZY_KERNEL_INIT", 0);
+
 // GDRCOPY support: Off by default
 NCCL_PARAM(GdrCopyEnable, "GDRCOPY_ENABLE", 0);
 
@@ -2277,28 +2282,35 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     goto fail;
   }
 
+  comm->maxSharedMem = maxSharedMem; // saved for possible lazy kernel init
   timers[TIMER_INIT_KERNELS] = clockNano();
-  NCCLCHECK(ncclInitKernelsForDevice(cudaArch, maxSharedMem, &maxLocalSizeBytes));
-  // Set the maximum kernel stack size of all kernels to avoid
-  // a CUDA memory reconfig on load (c.f. NVSHMEM issue)
+  if (rcclParamLazyKernelInit() == 0) {
+    NCCLCHECK(ncclInitKernelsForDevice(cudaArch, maxSharedMem, &maxLocalSizeBytes));
+    // Set the maximum kernel stack size of all kernels to avoid
+    // a CUDA memory reconfig on load (c.f. NVSHMEM issue)
 #ifdef USE_INDIRECT_FUNCTION_CALL
-  if (ncclParamSetStackSize() == 1 && !IsArchMatch(archName,"gfx942") && !IsArchMatch(archName,"gfx950")) {
-    stackSize = rcclParamStackSizeOverride() ? rcclParamStackSizeOverride() : maxLocalSizeBytes;
-    if (stackSize == 0) {
-      if (IsArchMatch(archName,"gfx906"))
-        stackSize = 1024;
-      else
-        stackSize = 512;
+    if (ncclParamSetStackSize() == 1 && !IsArchMatch(archName,"gfx942") && !IsArchMatch(archName,"gfx950")) {
+      stackSize = rcclParamStackSizeOverride() ? rcclParamStackSizeOverride() : maxLocalSizeBytes;
+      if (stackSize == 0) {
+        if (IsArchMatch(archName,"gfx906"))
+          stackSize = 1024;
+        else
+          stackSize = 512;
+      }
+      INFO(NCCL_INIT, "Setting cudaLimitStackSize to %zi maxLocalSizeBytes %zi", stackSize, maxLocalSizeBytes);
+      CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, stackSize));
     }
-    INFO(NCCL_INIT, "Setting cudaLimitStackSize to %zi maxLocalSizeBytes %zi", stackSize, maxLocalSizeBytes);
-    CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, stackSize));
-  }
 #endif
-  if (maxLocalSizeBytes > 0 && ncclParamSetStackSize() == 1) {
-    TRACE(NCCL_INIT, "Setting cudaLimitStackSize to %zu", maxLocalSizeBytes);
-    CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, maxLocalSizeBytes));
+    if (maxLocalSizeBytes > 0 && ncclParamSetStackSize() == 1) {
+      TRACE(NCCL_INIT, "Setting cudaLimitStackSize to %zu", maxLocalSizeBytes);
+      CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, maxLocalSizeBytes));
+    }
   }
   timers[TIMER_INIT_KERNELS] = clockNano() - timers[TIMER_INIT_KERNELS];
+  INFO(NCCL_INIT | NCCL_BOOTSTRAP | NCCL_PROFILE,
+       "PreBoot timings rank %d kernels_us %llu lazy %d",
+       job->myrank, (unsigned long long)(timers[TIMER_INIT_KERNELS] / 1000),
+       (int)rcclParamLazyKernelInit());
 
   if (job->parent) {
     NCCLCHECKGOTO(ncclCalloc(&parentRanks, job->parent->nRanks), res, fail);

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -215,6 +215,7 @@ if(BUILD_TESTS)
 
     set(TEST_FIXTURE_SOURCE_FILES
       BitOpsTests.cpp
+      LazyInitGateTests.cpp
       MiscTests.cpp
       RomeTopoConsensusTests.cpp
       EnqueueCountTests.cpp

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -205,6 +205,7 @@ if(BUILD_TESTS)
 
     set(TEST_FIXTURE_SOURCE_FILES
       BitOpsTests.cpp
+      LazyInitGateTests.cpp
       MiscTests.cpp
       RomeTopoConsensusTests.cpp
       EnqueueCountTests.cpp

--- a/projects/rccl/test/LazyInitGateTests.cpp
+++ b/projects/rccl/test/LazyInitGateTests.cpp
@@ -64,12 +64,17 @@ enum class LazyInitState : int {
 //   Return false to abort ownership: the gate is released back to
 //   LAZY_UNINIT and the caller returns err_out. Threads that did not win
 //   the CAS never invoke it -- that's the property we pin.
+// waiterReachedWaitLoop - optional instrumentation hook. When non-null, a
+//   thread that did NOT win the CAS sets it to 1 on entering the spin
+//   wait. Lets multi-thread tests deterministically synchronize on "the
+//   waiter is parked" without resorting to sleep_for-based handshakes.
 static ncclResult_t testGateRun(
     std::atomic<LazyInitState>& gate,
     std::atomic<int>& errSlot,
     std::function<ncclResult_t()> initFn,
     std::function<bool(ncclResult_t&)> ownerPrecondition =
-        [](ncclResult_t&){ return true; }) {
+        [](ncclResult_t&){ return true; },
+    std::atomic<int>* waiterReachedWaitLoop = nullptr) {
   for (;;) {
     LazyInitState s = gate.load(std::memory_order_acquire);
     if (s == LazyInitState::LAZY_DONE) return ncclSuccess;
@@ -99,6 +104,9 @@ static ncclResult_t testGateRun(
     }
 
     LazyInitState w;
+    if (waiterReachedWaitLoop) {
+      waiterReachedWaitLoop->store(1, std::memory_order_release);
+    }
     while ((w = gate.load(std::memory_order_acquire)) == LazyInitState::LAZY_INITIALIZING) {
       sched_yield();
     }
@@ -278,6 +286,7 @@ TEST(LazyInitGateTests, MultiThread_OwnerAborts_WaiterRetriesAndSucceeds) {
   std::atomic<int> initCalls{0};
   std::atomic<int> ownerEnteredPrecondition{0};
   std::atomic<int> releaseOwner{0};
+  std::atomic<int> retrierInWaitLoop{0};
 
   std::thread owner([&]{
     ncclResult_t r = testGateRun(gate, err,
@@ -301,12 +310,16 @@ TEST(LazyInitGateTests, MultiThread_OwnerAborts_WaiterRetriesAndSucceeds) {
   // LAZY_UNINIT release, retry the CAS itself, run init, and succeed.
   std::thread retrier([&]{
     ncclResult_t r = testGateRun(gate, err,
-        [&]{ initCalls.fetch_add(1); return ncclSuccess; });
+        [&]{ initCalls.fetch_add(1); return ncclSuccess; },
+        [](ncclResult_t&){ return true; },
+        &retrierInWaitLoop);
     EXPECT_EQ(r, ncclSuccess) << "waiter must retry CAS on owner-abort and succeed";
   });
 
-  // Let the second thread reach the waiter loop, then unblock the owner.
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  // Deterministically wait until the retrier is actually parked in the
+  // wait loop, then unblock the owner. Avoids relying on sleep_for, which
+  // is flaky under CI load.
+  while (retrierInWaitLoop.load(std::memory_order_acquire) == 0) sched_yield();
   releaseOwner.store(1, std::memory_order_release);
 
   owner.join();

--- a/projects/rccl/test/LazyInitGateTests.cpp
+++ b/projects/rccl/test/LazyInitGateTests.cpp
@@ -1,0 +1,211 @@
+/*************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ * SPDX-License-Identifier: MIT
+ *
+ * Regression coverage for the lazy kernel-init CAS gate that lives in
+ * src/enqueue.cc::lazyKernelInitOnce. We cannot link the production helper
+ * directly (it pulls in HIP runtime + the rest of enqueue.cc), so this test
+ * mirrors the gate's state machine and memory ordering inline in
+ * testGateRun() below. If the production gate's contract changes, this
+ * mirror MUST be updated in lockstep -- otherwise these tests still pass
+ * while the real code drifts away from the spec they pin.
+ *
+ * Contract under test (must match src/enqueue.cc::lazyKernelInitOnce):
+ *   - Per-(process,device) std::atomic<int> gate with four states:
+ *       LAZY_UNINIT (0), LAZY_INITIALIZING (1), LAZY_DONE (2), LAZY_FAILED (3).
+ *   - Exactly one caller wins the UNINIT->INITIALIZING CAS and runs initFn();
+ *     all other callers wait until LAZY_DONE / LAZY_FAILED is observed.
+ *   - LAZY_FAILED is REQUIRED so that an owner failure propagates to every
+ *     waiter as ncclSystemError instead of leaving the gate stuck at
+ *     LAZY_INITIALIZING and hanging every subsequent launch on that device.
+ *   - LAZY_DONE / LAZY_FAILED short-circuit fresh callers without doing the
+ *     CAS again (this is the common-case fast path after first launch).
+ ************************************************************************/
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <thread>
+#include <vector>
+
+#include <sched.h>
+
+#include <gtest/gtest.h>
+#include <rccl/rccl.h>
+
+namespace RcclUnitTesting {
+namespace {
+
+enum LazyInitState : int {
+  LAZY_UNINIT       = 0,
+  LAZY_INITIALIZING = 1,
+  LAZY_DONE         = 2,
+  LAZY_FAILED       = 3,
+};
+
+// Inline mirror of src/enqueue.cc::lazyKernelInitOnce minus the HIP-specific
+// pieces (stream-capture check, INFO/WARN logging, clockNano). Behaviorally
+// identical for the CAS race and failure-propagation contract this file
+// pins. initFn is the test-supplied stand-in for ncclInitKernelsForDevice.
+static ncclResult_t testGateRun(std::atomic<int>& gate,
+                                std::function<ncclResult_t()> initFn) {
+  int s = gate.load(std::memory_order_acquire);
+  if (s == LAZY_DONE)   return ncclSuccess;
+  if (s == LAZY_FAILED) return ncclSystemError;
+
+  int expected = LAZY_UNINIT;
+  if (gate.compare_exchange_strong(expected, LAZY_INITIALIZING,
+                                   std::memory_order_acq_rel,
+                                   std::memory_order_acquire)) {
+    ncclResult_t r = initFn();
+    gate.store(r == ncclSuccess ? LAZY_DONE : LAZY_FAILED,
+               std::memory_order_release);
+    return r;
+  }
+
+  int w;
+  while ((w = gate.load(std::memory_order_acquire)) != LAZY_DONE) {
+    if (w == LAZY_FAILED) return ncclSystemError;
+    sched_yield();
+  }
+  return ncclSuccess;
+}
+
+} // namespace
+
+// Single-threaded happy path: UNINIT -> INITIALIZING -> DONE, initFn fires
+// exactly once, gate ends in LAZY_DONE.
+TEST(LazyInitGateTests, SingleThread_HappyPath_RunsInitOnce) {
+  std::atomic<int> gate{LAZY_UNINIT};
+  int calls = 0;
+  ncclResult_t r = testGateRun(gate, [&]{ ++calls; return ncclSuccess; });
+  EXPECT_EQ(r, ncclSuccess);
+  EXPECT_EQ(calls, 1);
+  EXPECT_EQ(gate.load(), LAZY_DONE);
+}
+
+// Re-entry after success must NOT run initFn again -- this is the steady-state
+// fast path that fires on every launch past the first.
+TEST(LazyInitGateTests, AlreadyDone_IsFastPath_NoReinit) {
+  std::atomic<int> gate{LAZY_DONE};
+  int calls = 0;
+  ncclResult_t r = testGateRun(gate, [&]{ ++calls; return ncclSuccess; });
+  EXPECT_EQ(r, ncclSuccess);
+  EXPECT_EQ(calls, 0);
+  EXPECT_EQ(gate.load(), LAZY_DONE);
+}
+
+// Once the gate has been poisoned (owner failed), every later caller must get
+// ncclSystemError WITHOUT re-running initFn. This is the contract that keeps
+// a misconfigured device from hanging every subsequent launch.
+TEST(LazyInitGateTests, AlreadyFailed_IsFastPath_NoReinit) {
+  std::atomic<int> gate{LAZY_FAILED};
+  int calls = 0;
+  ncclResult_t r = testGateRun(gate, [&]{ ++calls; return ncclSuccess; });
+  EXPECT_EQ(r, ncclSystemError);
+  EXPECT_EQ(calls, 0);
+  EXPECT_EQ(gate.load(), LAZY_FAILED);
+}
+
+// Owner failure must publish LAZY_FAILED and surface initFn's exact error.
+TEST(LazyInitGateTests, OwnerFailure_PoisonsGate_PropagatesError) {
+  std::atomic<int> gate{LAZY_UNINIT};
+  int calls = 0;
+  ncclResult_t r = testGateRun(gate, [&]{
+    ++calls;
+    return ncclInternalError;
+  });
+  EXPECT_EQ(r, ncclInternalError);
+  EXPECT_EQ(calls, 1);
+  EXPECT_EQ(gate.load(), LAZY_FAILED);
+
+  // A second caller must not retry the failed init -- it gets the cached
+  // failure mapped to ncclSystemError (the gate has no room to store the
+  // exact error, by design).
+  ncclResult_t r2 = testGateRun(gate, [&]{ ++calls; return ncclSuccess; });
+  EXPECT_EQ(r2, ncclSystemError);
+  EXPECT_EQ(calls, 1);
+}
+
+// The headline race: N threads hit a fresh gate in parallel; exactly one
+// must win the CAS and run initFn, and every thread must return ncclSuccess.
+// We hold initFn artificially long (10ms) so contenders are still racing on
+// the gate when the owner publishes LAZY_DONE -- this exercises the waiter
+// path, not just the steady-state fast path.
+TEST(LazyInitGateTests, MultiThread_OnlyOneOwnerRunsInit_AllSucceed) {
+  constexpr int kThreads = 16;
+  std::atomic<int> gate{LAZY_UNINIT};
+  std::atomic<int> initCalls{0};
+  std::atomic<int> startGate{0};
+  std::vector<ncclResult_t> results(kThreads, ncclInternalError);
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back([&, i]{
+      while (startGate.load(std::memory_order_acquire) == 0) sched_yield();
+      results[i] = testGateRun(gate, [&]{
+        initCalls.fetch_add(1, std::memory_order_relaxed);
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        return ncclSuccess;
+      });
+    });
+  }
+
+  startGate.store(1, std::memory_order_release);
+  for (auto& t : threads) t.join();
+
+  EXPECT_EQ(initCalls.load(), 1) << "initFn must fire exactly once across all racing threads";
+  EXPECT_EQ(gate.load(), LAZY_DONE);
+  for (int i = 0; i < kThreads; ++i) {
+    EXPECT_EQ(results[i], ncclSuccess) << "thread " << i << " saw a non-success result";
+  }
+}
+
+// Same multi-thread race, but the owner FAILS. Every waiter must observe
+// LAZY_FAILED and return ncclSystemError -- no waiter may hang and no waiter
+// may silently re-run initFn after the failure is published.
+TEST(LazyInitGateTests, MultiThread_OwnerFails_AllWaitersGetSystemError) {
+  constexpr int kThreads = 16;
+  std::atomic<int> gate{LAZY_UNINIT};
+  std::atomic<int> initCalls{0};
+  std::atomic<int> startGate{0};
+  std::vector<ncclResult_t> results(kThreads, ncclInternalError);
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back([&, i]{
+      while (startGate.load(std::memory_order_acquire) == 0) sched_yield();
+      results[i] = testGateRun(gate, [&]{
+        initCalls.fetch_add(1, std::memory_order_relaxed);
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        return ncclUnhandledCudaError;
+      });
+    });
+  }
+
+  startGate.store(1, std::memory_order_release);
+  for (auto& t : threads) t.join();
+
+  EXPECT_EQ(initCalls.load(), 1) << "initFn must fire exactly once even when it fails";
+  EXPECT_EQ(gate.load(), LAZY_FAILED);
+
+  // Exactly one thread saw the owner's raw error code; every other thread
+  // is a waiter and must see the cached ncclSystemError.
+  int ownerCount  = 0;
+  int waiterCount = 0;
+  for (int i = 0; i < kThreads; ++i) {
+    if (results[i] == ncclUnhandledCudaError) {
+      ++ownerCount;
+    } else {
+      EXPECT_EQ(results[i], ncclSystemError) << "thread " << i << " saw an unexpected result";
+      ++waiterCount;
+    }
+  }
+  EXPECT_EQ(ownerCount,  1);
+  EXPECT_EQ(waiterCount, kThreads - 1);
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/LazyInitGateTests.cpp
+++ b/projects/rccl/test/LazyInitGateTests.cpp
@@ -15,11 +15,19 @@
  *       LAZY_UNINIT (0), LAZY_INITIALIZING (1), LAZY_DONE (2), LAZY_FAILED (3).
  *   - Exactly one caller wins the UNINIT->INITIALIZING CAS and runs initFn();
  *     all other callers wait until LAZY_DONE / LAZY_FAILED is observed.
- *   - LAZY_FAILED is REQUIRED so that an owner failure propagates to every
- *     waiter as ncclSystemError instead of leaving the gate stuck at
- *     LAZY_INITIALIZING and hanging every subsequent launch on that device.
- *   - LAZY_DONE / LAZY_FAILED short-circuit fresh callers without doing the
- *     CAS again (this is the common-case fast path after first launch).
+ *   - On owner failure, the owner first writes the failing ncclResult_t to a
+ *     per-device err side-table and THEN publishes LAZY_FAILED on the gate
+ *     (release). Waiters acquire-load LAZY_FAILED and return the same code,
+ *     so every rank sees the first-cause error instead of a generic
+ *     ncclSystemError.
+ *   - DONE / FAILED short-circuit fresh callers without re-running initFn
+ *     (this is the common-case fast path after first launch).
+ *   - A would-be owner that cannot legally run init right now (in production:
+ *     inside a stream capture) is detected AFTER winning the CAS. It then
+ *     releases ownership back to LAZY_UNINIT and returns the precondition
+ *     error. Any concurrent waiter sees that release and retries the CAS
+ *     itself, so a legal caller still completes init. Threads that never
+ *     became the owner never observe a precondition-driven error.
  ************************************************************************/
 
 #include <atomic>
@@ -37,7 +45,7 @@
 namespace RcclUnitTesting {
 namespace {
 
-enum LazyInitState : int {
+enum class LazyInitState : int {
   LAZY_UNINIT       = 0,
   LAZY_INITIALIZING = 1,
   LAZY_DONE         = 2,
@@ -45,31 +53,59 @@ enum LazyInitState : int {
 };
 
 // Inline mirror of src/enqueue.cc::lazyKernelInitOnce minus the HIP-specific
-// pieces (stream-capture check, INFO/WARN logging, clockNano). Behaviorally
-// identical for the CAS race and failure-propagation contract this file
-// pins. initFn is the test-supplied stand-in for ncclInitKernelsForDevice.
-static ncclResult_t testGateRun(std::atomic<int>& gate,
-                                std::function<ncclResult_t()> initFn) {
-  int s = gate.load(std::memory_order_acquire);
-  if (s == LAZY_DONE)   return ncclSuccess;
-  if (s == LAZY_FAILED) return ncclSystemError;
+// pieces (INFO/WARN logging, clockNano). Behaviorally identical for the CAS
+// race, owner/waiter handoff, post-CAS precondition with owner-abort retry,
+// and failure propagation this file pins.
+//
+// initFn  - test-supplied stand-in for ncclInitKernelsForDevice.
+// errSlot - mirror of g_rcclLazyKernelInitErr.
+// ownerPrecondition(err_out) - mirror of the stream-capture check; the
+//   thread invokes it ONLY AFTER it has won the UNINIT->INITIALIZING CAS.
+//   Return false to abort ownership: the gate is released back to
+//   LAZY_UNINIT and the caller returns err_out. Threads that did not win
+//   the CAS never invoke it -- that's the property we pin.
+static ncclResult_t testGateRun(
+    std::atomic<LazyInitState>& gate,
+    std::atomic<int>& errSlot,
+    std::function<ncclResult_t()> initFn,
+    std::function<bool(ncclResult_t&)> ownerPrecondition =
+        [](ncclResult_t&){ return true; }) {
+  for (;;) {
+    LazyInitState s = gate.load(std::memory_order_acquire);
+    if (s == LazyInitState::LAZY_DONE) return ncclSuccess;
+    if (s == LazyInitState::LAZY_FAILED) {
+      return (ncclResult_t)errSlot.load(std::memory_order_relaxed);
+    }
 
-  int expected = LAZY_UNINIT;
-  if (gate.compare_exchange_strong(expected, LAZY_INITIALIZING,
-                                   std::memory_order_acq_rel,
-                                   std::memory_order_acquire)) {
-    ncclResult_t r = initFn();
-    gate.store(r == ncclSuccess ? LAZY_DONE : LAZY_FAILED,
-               std::memory_order_release);
-    return r;
-  }
+    if (s == LazyInitState::LAZY_UNINIT) {
+      LazyInitState expected = LazyInitState::LAZY_UNINIT;
+      if (gate.compare_exchange_strong(expected, LazyInitState::LAZY_INITIALIZING,
+                                       std::memory_order_acq_rel,
+                                       std::memory_order_acquire)) {
+        ncclResult_t pre = ncclSuccess;
+        if (!ownerPrecondition(pre)) {
+          gate.store(LazyInitState::LAZY_UNINIT, std::memory_order_release);
+          return pre;
+        }
+        ncclResult_t r = initFn();
+        if (r != ncclSuccess) {
+          errSlot.store((int)r, std::memory_order_relaxed);
+          gate.store(LazyInitState::LAZY_FAILED, std::memory_order_release);
+          return r;
+        }
+        gate.store(LazyInitState::LAZY_DONE, std::memory_order_release);
+        return ncclSuccess;
+      }
+    }
 
-  int w;
-  while ((w = gate.load(std::memory_order_acquire)) != LAZY_DONE) {
-    if (w == LAZY_FAILED) return ncclSystemError;
-    sched_yield();
+    LazyInitState w;
+    while ((w = gate.load(std::memory_order_acquire)) == LazyInitState::LAZY_INITIALIZING) {
+      sched_yield();
+    }
+    if (w == LazyInitState::LAZY_DONE)   return ncclSuccess;
+    if (w == LazyInitState::LAZY_FAILED) return (ncclResult_t)errSlot.load(std::memory_order_relaxed);
+    // w == LAZY_UNINIT: owner aborted, retry the CAS ourselves.
   }
-  return ncclSuccess;
 }
 
 } // namespace
@@ -77,54 +113,60 @@ static ncclResult_t testGateRun(std::atomic<int>& gate,
 // Single-threaded happy path: UNINIT -> INITIALIZING -> DONE, initFn fires
 // exactly once, gate ends in LAZY_DONE.
 TEST(LazyInitGateTests, SingleThread_HappyPath_RunsInitOnce) {
-  std::atomic<int> gate{LAZY_UNINIT};
+  std::atomic<LazyInitState> gate{LazyInitState::LAZY_UNINIT};
+  std::atomic<int> err{(int)ncclSuccess};
   int calls = 0;
-  ncclResult_t r = testGateRun(gate, [&]{ ++calls; return ncclSuccess; });
+  ncclResult_t r = testGateRun(gate, err, [&]{ ++calls; return ncclSuccess; });
   EXPECT_EQ(r, ncclSuccess);
   EXPECT_EQ(calls, 1);
-  EXPECT_EQ(gate.load(), LAZY_DONE);
+  EXPECT_EQ(gate.load(), LazyInitState::LAZY_DONE);
 }
 
 // Re-entry after success must NOT run initFn again -- this is the steady-state
 // fast path that fires on every launch past the first.
 TEST(LazyInitGateTests, AlreadyDone_IsFastPath_NoReinit) {
-  std::atomic<int> gate{LAZY_DONE};
+  std::atomic<LazyInitState> gate{LazyInitState::LAZY_DONE};
+  std::atomic<int> err{(int)ncclSuccess};
   int calls = 0;
-  ncclResult_t r = testGateRun(gate, [&]{ ++calls; return ncclSuccess; });
+  ncclResult_t r = testGateRun(gate, err, [&]{ ++calls; return ncclSuccess; });
   EXPECT_EQ(r, ncclSuccess);
   EXPECT_EQ(calls, 0);
-  EXPECT_EQ(gate.load(), LAZY_DONE);
+  EXPECT_EQ(gate.load(), LazyInitState::LAZY_DONE);
 }
 
-// Once the gate has been poisoned (owner failed), every later caller must get
-// ncclSystemError WITHOUT re-running initFn. This is the contract that keeps
-// a misconfigured device from hanging every subsequent launch.
+// Once the gate has been poisoned (owner failed), every later caller must
+// receive the owner's exact ncclResult_t WITHOUT re-running initFn. This is
+// the contract that keeps a misconfigured device from hanging every
+// subsequent launch and from losing the first-cause error code.
 TEST(LazyInitGateTests, AlreadyFailed_IsFastPath_NoReinit) {
-  std::atomic<int> gate{LAZY_FAILED};
+  std::atomic<LazyInitState> gate{LazyInitState::LAZY_FAILED};
+  std::atomic<int> err{(int)ncclUnhandledCudaError};
   int calls = 0;
-  ncclResult_t r = testGateRun(gate, [&]{ ++calls; return ncclSuccess; });
-  EXPECT_EQ(r, ncclSystemError);
+  ncclResult_t r = testGateRun(gate, err, [&]{ ++calls; return ncclSuccess; });
+  EXPECT_EQ(r, ncclUnhandledCudaError);
   EXPECT_EQ(calls, 0);
-  EXPECT_EQ(gate.load(), LAZY_FAILED);
+  EXPECT_EQ(gate.load(), LazyInitState::LAZY_FAILED);
 }
 
-// Owner failure must publish LAZY_FAILED and surface initFn's exact error.
+// Owner failure must publish LAZY_FAILED, store the failing code in errSlot,
+// and surface initFn's exact error to the owner and any later caller.
 TEST(LazyInitGateTests, OwnerFailure_PoisonsGate_PropagatesError) {
-  std::atomic<int> gate{LAZY_UNINIT};
+  std::atomic<LazyInitState> gate{LazyInitState::LAZY_UNINIT};
+  std::atomic<int> err{(int)ncclSuccess};
   int calls = 0;
-  ncclResult_t r = testGateRun(gate, [&]{
+  ncclResult_t r = testGateRun(gate, err, [&]{
     ++calls;
     return ncclInternalError;
   });
   EXPECT_EQ(r, ncclInternalError);
   EXPECT_EQ(calls, 1);
-  EXPECT_EQ(gate.load(), LAZY_FAILED);
+  EXPECT_EQ(gate.load(), LazyInitState::LAZY_FAILED);
+  EXPECT_EQ((ncclResult_t)err.load(), ncclInternalError);
 
   // A second caller must not retry the failed init -- it gets the cached
-  // failure mapped to ncclSystemError (the gate has no room to store the
-  // exact error, by design).
-  ncclResult_t r2 = testGateRun(gate, [&]{ ++calls; return ncclSuccess; });
-  EXPECT_EQ(r2, ncclSystemError);
+  // first-cause code from the err side-table.
+  ncclResult_t r2 = testGateRun(gate, err, [&]{ ++calls; return ncclSuccess; });
+  EXPECT_EQ(r2, ncclInternalError);
   EXPECT_EQ(calls, 1);
 }
 
@@ -135,7 +177,8 @@ TEST(LazyInitGateTests, OwnerFailure_PoisonsGate_PropagatesError) {
 // path, not just the steady-state fast path.
 TEST(LazyInitGateTests, MultiThread_OnlyOneOwnerRunsInit_AllSucceed) {
   constexpr int kThreads = 16;
-  std::atomic<int> gate{LAZY_UNINIT};
+  std::atomic<LazyInitState> gate{LazyInitState::LAZY_UNINIT};
+  std::atomic<int> err{(int)ncclSuccess};
   std::atomic<int> initCalls{0};
   std::atomic<int> startGate{0};
   std::vector<ncclResult_t> results(kThreads, ncclInternalError);
@@ -145,7 +188,7 @@ TEST(LazyInitGateTests, MultiThread_OnlyOneOwnerRunsInit_AllSucceed) {
   for (int i = 0; i < kThreads; ++i) {
     threads.emplace_back([&, i]{
       while (startGate.load(std::memory_order_acquire) == 0) sched_yield();
-      results[i] = testGateRun(gate, [&]{
+      results[i] = testGateRun(gate, err, [&]{
         initCalls.fetch_add(1, std::memory_order_relaxed);
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
         return ncclSuccess;
@@ -157,18 +200,20 @@ TEST(LazyInitGateTests, MultiThread_OnlyOneOwnerRunsInit_AllSucceed) {
   for (auto& t : threads) t.join();
 
   EXPECT_EQ(initCalls.load(), 1) << "initFn must fire exactly once across all racing threads";
-  EXPECT_EQ(gate.load(), LAZY_DONE);
+  EXPECT_EQ(gate.load(), LazyInitState::LAZY_DONE);
   for (int i = 0; i < kThreads; ++i) {
     EXPECT_EQ(results[i], ncclSuccess) << "thread " << i << " saw a non-success result";
   }
 }
 
-// Same multi-thread race, but the owner FAILS. Every waiter must observe
-// LAZY_FAILED and return ncclSystemError -- no waiter may hang and no waiter
-// may silently re-run initFn after the failure is published.
-TEST(LazyInitGateTests, MultiThread_OwnerFails_AllWaitersGetSystemError) {
+// Same multi-thread race, but the owner FAILS. Every thread (owner and
+// waiters) must return the SAME ncclResult_t the owner produced -- no
+// generic ncclSystemError, no hangs, no silent re-run of initFn.
+TEST(LazyInitGateTests, MultiThread_OwnerFails_AllThreadsGetSameError) {
   constexpr int kThreads = 16;
-  std::atomic<int> gate{LAZY_UNINIT};
+  constexpr ncclResult_t kOwnerErr = ncclUnhandledCudaError;
+  std::atomic<LazyInitState> gate{LazyInitState::LAZY_UNINIT};
+  std::atomic<int> err{(int)ncclSuccess};
   std::atomic<int> initCalls{0};
   std::atomic<int> startGate{0};
   std::vector<ncclResult_t> results(kThreads, ncclInternalError);
@@ -178,10 +223,10 @@ TEST(LazyInitGateTests, MultiThread_OwnerFails_AllWaitersGetSystemError) {
   for (int i = 0; i < kThreads; ++i) {
     threads.emplace_back([&, i]{
       while (startGate.load(std::memory_order_acquire) == 0) sched_yield();
-      results[i] = testGateRun(gate, [&]{
+      results[i] = testGateRun(gate, err, [&]{
         initCalls.fetch_add(1, std::memory_order_relaxed);
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        return ncclUnhandledCudaError;
+        return kOwnerErr;
       });
     });
   }
@@ -190,22 +235,85 @@ TEST(LazyInitGateTests, MultiThread_OwnerFails_AllWaitersGetSystemError) {
   for (auto& t : threads) t.join();
 
   EXPECT_EQ(initCalls.load(), 1) << "initFn must fire exactly once even when it fails";
-  EXPECT_EQ(gate.load(), LAZY_FAILED);
-
-  // Exactly one thread saw the owner's raw error code; every other thread
-  // is a waiter and must see the cached ncclSystemError.
-  int ownerCount  = 0;
-  int waiterCount = 0;
+  EXPECT_EQ(gate.load(), LazyInitState::LAZY_FAILED);
+  EXPECT_EQ((ncclResult_t)err.load(), kOwnerErr);
   for (int i = 0; i < kThreads; ++i) {
-    if (results[i] == ncclUnhandledCudaError) {
-      ++ownerCount;
-    } else {
-      EXPECT_EQ(results[i], ncclSystemError) << "thread " << i << " saw an unexpected result";
-      ++waiterCount;
-    }
+    EXPECT_EQ(results[i], kOwnerErr) << "thread " << i << " did not receive the owner's first-cause error";
   }
-  EXPECT_EQ(ownerCount,  1);
-  EXPECT_EQ(waiterCount, kThreads - 1);
+}
+
+// Post-CAS precondition (in production: stream capture) must not poison
+// the gate on failure. A later caller for whom the precondition holds wins
+// a fresh CAS, runs init, and succeeds -- proving the precondition path is
+// retryable.
+TEST(LazyInitGateTests, OwnerPrecondition_FailsRetryable_NoGatePoison) {
+  std::atomic<LazyInitState> gate{LazyInitState::LAZY_UNINIT};
+  std::atomic<int> err{(int)ncclSuccess};
+  int calls = 0;
+
+  ncclResult_t r1 = testGateRun(gate, err,
+      [&]{ ++calls; return ncclSuccess; },
+      [](ncclResult_t& out){ out = ncclInvalidUsage; return false; });
+  EXPECT_EQ(r1, ncclInvalidUsage);
+  EXPECT_EQ(calls, 0);
+  EXPECT_EQ(gate.load(), LazyInitState::LAZY_UNINIT)
+      << "owner-abort must release the gate back to LAZY_UNINIT for retry";
+
+  ncclResult_t r2 = testGateRun(gate, err,
+      [&]{ ++calls; return ncclSuccess; });
+  EXPECT_EQ(r2, ncclSuccess);
+  EXPECT_EQ(calls, 1);
+  EXPECT_EQ(gate.load(), LazyInitState::LAZY_DONE);
+}
+
+// Owner aborts the precondition WHILE a second thread is already in the
+// waiter loop. The waiter must observe the LAZY_UNINIT release, retry the
+// CAS itself, run init, and return ncclSuccess. This pins the "waiter
+// retries on owner abort" branch -- a hang or a generic error here would
+// mean the state machine cannot recover from a legitimately-failing
+// precondition without dropping concurrent callers.
+TEST(LazyInitGateTests, MultiThread_OwnerAborts_WaiterRetriesAndSucceeds) {
+  std::atomic<LazyInitState> gate{LazyInitState::LAZY_UNINIT};
+  std::atomic<int> err{(int)ncclSuccess};
+  std::atomic<int> initCalls{0};
+  std::atomic<int> ownerEnteredPrecondition{0};
+  std::atomic<int> releaseOwner{0};
+
+  std::thread owner([&]{
+    ncclResult_t r = testGateRun(gate, err,
+        [&]{ initCalls.fetch_add(1); return ncclSuccess; },
+        [&](ncclResult_t& out){
+          // Park inside the precondition long enough for the second thread
+          // to enter the waiter loop with s == LAZY_INITIALIZING. Then
+          // abort -- this releases the gate back to LAZY_UNINIT.
+          ownerEnteredPrecondition.store(1, std::memory_order_release);
+          while (releaseOwner.load(std::memory_order_acquire) == 0) sched_yield();
+          out = ncclInvalidUsage;
+          return false;
+        });
+    EXPECT_EQ(r, ncclInvalidUsage);
+  });
+
+  while (ownerEnteredPrecondition.load(std::memory_order_acquire) == 0) sched_yield();
+
+  // Second thread: precondition passes, but it arrives while the first
+  // thread already owns the gate. It must wait, observe the owner's
+  // LAZY_UNINIT release, retry the CAS itself, run init, and succeed.
+  std::thread retrier([&]{
+    ncclResult_t r = testGateRun(gate, err,
+        [&]{ initCalls.fetch_add(1); return ncclSuccess; });
+    EXPECT_EQ(r, ncclSuccess) << "waiter must retry CAS on owner-abort and succeed";
+  });
+
+  // Let the second thread reach the waiter loop, then unblock the owner.
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  releaseOwner.store(1, std::memory_order_release);
+
+  owner.join();
+  retrier.join();
+
+  EXPECT_EQ(initCalls.load(), 1) << "init must fire exactly once across owner+retrier";
+  EXPECT_EQ(gate.load(), LazyInitState::LAZY_DONE);
 }
 
 } // namespace RcclUnitTesting

--- a/projects/rccl/test/ParamTests.cpp
+++ b/projects/rccl/test/ParamTests.cpp
@@ -6,6 +6,10 @@
 #include <rccl/rccl.h>
 #include "common/ProcessIsolatedTestRunner.hpp"
 
+// Forward-declare rcclParamLazyKernelInit() in the global namespace so the
+// regression test below can call into the same symbol that init.cc defines.
+RCCL_PARAM_DECLARE(LazyKernelInit);
+
 namespace RcclUnitTesting {
 TEST(ParamTests, initEnv_ParseValidConfFile) {
   // Skip the test if NCCL_CONF_FILE is not set
@@ -54,5 +58,51 @@ TEST(ParamTests, ncclLoadParam_InvalidParam) {
           ASSERT_EQ(cache, defaultVal); // Cache should be set to default value
       }
   );
+}
+
+// Regression test for the lazy kernel-init env-var alias: the original PR
+// declared the param with RCCL_PARAM, which only honored RCCL_LAZY_KERNEL_INIT
+// even though the commit message advertised NCCL_LAZY_KERNEL_INIT as well.
+// The fix switches to RCCL_PARAM_NCCL_ALIAS; this test pins that contract.
+TEST(ParamTests, LazyKernelInit_NcclAlias_IsRead) {
+  // ncclLoadParam reads via getenv; since rcclParamLazyKernelInit caches its
+  // result in a function-local static, we run inside an isolated subprocess
+  // so each variant gets a clean cache.
+  RUN_ISOLATED_TEST(
+      "LazyKernelInit_NcclAlias_OnlyNcclSet",
+      []()
+      {
+          unsetenv("RCCL_LAZY_KERNEL_INIT");
+          setenv("NCCL_LAZY_KERNEL_INIT", "1", 1);
+          ASSERT_EQ(rcclParamLazyKernelInit(), 1);
+          unsetenv("NCCL_LAZY_KERNEL_INIT");
+      });
+  RUN_ISOLATED_TEST(
+      "LazyKernelInit_NcclAlias_OnlyRcclSet",
+      []()
+      {
+          unsetenv("NCCL_LAZY_KERNEL_INIT");
+          setenv("RCCL_LAZY_KERNEL_INIT", "1", 1);
+          ASSERT_EQ(rcclParamLazyKernelInit(), 1);
+          unsetenv("RCCL_LAZY_KERNEL_INIT");
+      });
+  RUN_ISOLATED_TEST(
+      "LazyKernelInit_NcclAlias_RcclWinsOverNccl",
+      []()
+      {
+          setenv("RCCL_LAZY_KERNEL_INIT", "0", 1);
+          setenv("NCCL_LAZY_KERNEL_INIT", "1", 1);
+          ASSERT_EQ(rcclParamLazyKernelInit(), 0);
+          unsetenv("RCCL_LAZY_KERNEL_INIT");
+          unsetenv("NCCL_LAZY_KERNEL_INIT");
+      });
+  RUN_ISOLATED_TEST(
+      "LazyKernelInit_NcclAlias_DefaultIsZero",
+      []()
+      {
+          unsetenv("RCCL_LAZY_KERNEL_INIT");
+          unsetenv("NCCL_LAZY_KERNEL_INIT");
+          ASSERT_EQ(rcclParamLazyKernelInit(), 0);
+      });
 }
 } // namespace RcclUnitTesting

--- a/projects/rccl/test/ParamTests.cpp
+++ b/projects/rccl/test/ParamTests.cpp
@@ -6,6 +6,10 @@
 #include <rccl/rccl.h>
 #include "common/ProcessIsolatedTestRunner.hpp"
 
+// Forward-declare rcclParamLazyKernelInit() in the global namespace so the
+// regression test below can call into the same symbol that init.cc defines.
+RCCL_PARAM_DECLARE(LazyKernelInit);
+
 namespace RcclUnitTesting {
 TEST(ParamTests, initEnv_ParseValidConfFile) {
   // Skip the test if NCCL_CONF_FILE is not set
@@ -53,5 +57,51 @@ TEST(ParamTests, ncclLoadParam_InvalidParam) {
           ASSERT_EQ(cache, defaultVal); // Cache should be set to default value
       }
   );
+}
+
+// Regression test for the lazy kernel-init env-var alias: the original PR
+// declared the param with RCCL_PARAM, which only honored RCCL_LAZY_KERNEL_INIT
+// even though the commit message advertised NCCL_LAZY_KERNEL_INIT as well.
+// The fix switches to RCCL_PARAM_NCCL_ALIAS; this test pins that contract.
+TEST(ParamTests, LazyKernelInit_NcclAlias_IsRead) {
+  // ncclLoadParam reads via getenv; since rcclParamLazyKernelInit caches its
+  // result in a function-local static, we run inside an isolated subprocess
+  // so each variant gets a clean cache.
+  RUN_ISOLATED_TEST(
+      "LazyKernelInit_NcclAlias_OnlyNcclSet",
+      []()
+      {
+          unsetenv("RCCL_LAZY_KERNEL_INIT");
+          setenv("NCCL_LAZY_KERNEL_INIT", "1", 1);
+          ASSERT_EQ(rcclParamLazyKernelInit(), 1);
+          unsetenv("NCCL_LAZY_KERNEL_INIT");
+      });
+  RUN_ISOLATED_TEST(
+      "LazyKernelInit_NcclAlias_OnlyRcclSet",
+      []()
+      {
+          unsetenv("NCCL_LAZY_KERNEL_INIT");
+          setenv("RCCL_LAZY_KERNEL_INIT", "1", 1);
+          ASSERT_EQ(rcclParamLazyKernelInit(), 1);
+          unsetenv("RCCL_LAZY_KERNEL_INIT");
+      });
+  RUN_ISOLATED_TEST(
+      "LazyKernelInit_NcclAlias_RcclWinsOverNccl",
+      []()
+      {
+          setenv("RCCL_LAZY_KERNEL_INIT", "0", 1);
+          setenv("NCCL_LAZY_KERNEL_INIT", "1", 1);
+          ASSERT_EQ(rcclParamLazyKernelInit(), 0);
+          unsetenv("RCCL_LAZY_KERNEL_INIT");
+          unsetenv("NCCL_LAZY_KERNEL_INIT");
+      });
+  RUN_ISOLATED_TEST(
+      "LazyKernelInit_NcclAlias_DefaultIsZero",
+      []()
+      {
+          unsetenv("RCCL_LAZY_KERNEL_INIT");
+          unsetenv("NCCL_LAZY_KERNEL_INIT");
+          ASSERT_EQ(rcclParamLazyKernelInit(), 0);
+      });
 }
 } // namespace RcclUnitTesting


### PR DESCRIPTION
## Motivation

Add RCCL_LAZY_KERNEL_INIT=1 to defer ncclInitKernelsForDevice from ncclCommInitRankFunc to the first ncclLaunchKernel of the (process, device) pair, guarded by a per-device atomic CAS gate.

## Technical Details

On large-scale (32n+) the eager init triggers HSA code-object load on three RCCL kernels (~400 ms each), inflating per-rank PreBoot time to ~1.26 s mean / ~1.40 s p99 and jittering ranks enough to provoke 5-second straggler timeouts in bootstrap recv_from_root. Deferring those queries collapses PreBoot kernels_us to ~2 us and eliminates the straggler tail (1.9% of baseline ranks vs 0% lazy in a 32n x 4 cfg sweep). The cost moves into the first collective launch, which already pays kernel-launch overhead.

Disabled by default; opt in with NCCL_LAZY_KERNEL_INIT=1 or RCCL_LAZY_KERNEL_INIT=1. PreBoot INFO line is extended with 'lazy %d' to make the mode visible in logs.

## JIRA ID

AICOMNET-227

## Test Plan

Largescale validation

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
