### PR TITLE
[RCCL] [NOT FOR MERGE] net-ib: size IB inline buffer for multi-recv aggregation

### DIFF
--- a/projects/rccl/ext-src/rocm_netib.patch
+++ b/projects/rccl/ext-src/rocm_netib.patch
@@ -258,7 +258,7 @@
    qpInitAttr.cap.max_recv_wr = MAX_REQUESTS;
    qpInitAttr.cap.max_send_sge = 1;
    qpInitAttr.cap.max_recv_sge = 1;
--  qpInitAttr.cap.max_inline_data = ncclParamIbUseInline() ? sizeof(struct ncclIbSendFifo) : 0;
+-  qpInitAttr.cap.max_inline_data = ncclParamIbUseInline() ? NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifo) : 0;
 +  if (qpCtsOffload) {
 +    qpInitAttr.cap.max_inline_data = MAX_INLINE_DATA_SIZE;
 +  } else {

--- a/projects/rccl/src/transport/net_ib.cc
+++ b/projects/rccl/src/transport/net_ib.cc
@@ -1458,7 +1458,7 @@ ncclResult_t ncclIbCreateQp(uint8_t ib_port, struct ncclIbNetCommDevBase* base, 
   qpInitAttr.cap.max_recv_wr = MAX_REQUESTS;
   qpInitAttr.cap.max_send_sge = 1;
   qpInitAttr.cap.max_recv_sge = 1;
-  qpInitAttr.cap.max_inline_data = ncclParamIbUseInline() ? sizeof(struct ncclIbSendFifo) : 0;
+  qpInitAttr.cap.max_inline_data = ncclParamIbUseInline() ? NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifo) : 0;
   NCCLCHECK(wrap_ibv_create_qp(&qp->qp, base->pd, &qpInitAttr));
   struct ibv_qp_attr qpAttr;
   memset(&qpAttr, 0, sizeof(struct ibv_qp_attr));


### PR DESCRIPTION
## Motivation

ncclIbCreateQp reserved only one ncclIbSendFifo for max_inline_data, but the FIFO send path packs up to NCCL_NET_IB_MAX_RECVS slots into a single inline WR.

Bug surfaced after running latest version of net-ib test suite based on PR #5899.

## Technical Details

Multiply the reservation so all aggregated FIFO messages fit and the inline fast path is not silently dropped to DMA. Mirror the change in ext-src/rocm_netib.patch context line so the ROCm-variant build (generated via cmake/rocmIb.cmake) still applies cleanly.

## JIRA ID

AICOMNET-215

## Test Plan

See #5899, #5338

  - `rccl-UnitTestsMPI --gtest_filter=NetIbMPITest.*` on MI300X + Mellanox IB — full 2-rank and 4-rank sweep with the latest net-ib test suite from #5899.
  - Multi-recv aggregation tests (`MultiRecvAggregation`, `MultiRecv`, `MultiRecvShuffled`, `MultiRecvGPUShuffled`) — verify the inline path is not silently demoted.
  - ROCm plugin variant build — confirm `rocm_netib.patch` applies cleanly through `cmake/rocmIb.cmake`.

## Test Result

Pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
