### PR TITLE
[rocprofiler-sdk] Log lazy HIP stream registration at INFO in CI

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/stream.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/stream.cpp
@@ -147,8 +147,10 @@ get_stream_id(hipStream_t stream)
     // Stream ID already exists
     if(stream_id) return *stream_id;
 
-    ROCP_CI_LOG_IF(WARNING, !rocprofiler::registration::supports_attachment()) << fmt::format(
-        "Stream ID is not present in {} when attach feature is not being used", __FUNCTION__);
+    ROCP_INFO_IF(!rocprofiler::registration::supports_attachment())
+        << fmt::format("Stream ID is not present in {}, registering hipStream_t ({}) lazily",
+                       __FUNCTION__,
+                       sdk::utility::as_hex(static_cast<void*>(stream)));
     return add_stream(stream, false);
 }
 


### PR DESCRIPTION
When **attach mode is disabled**, HIP streams created before tracing starts may not yet be in the profiler’s internal map. The SDK already handles this by **registering those streams lazily** when they are first used.
Previously, that path logged a **WARNING**. In CI builds (`ROCPROFILER_CI`), warning-level CI logs are treated as **fatal**, so this expected behavior could **abort the process (SIGABRT)**—for example when using `ROCPROFSYS_SELECTED_REGIONS` with the `selective_region` sample.
This PR keeps the same lazy-registration behavior but logs at **INFO** with a clear message (including the stream pointer), so CI no longer fails on a normal catch-up registration path.
## Motivation

In `get_stream_id()`, when a `hipStream_t` is not yet in the stream map and attach mode is disabled, the SDK already registers the stream lazily via `add_stream(stream, false)`. That path is expected when profiling without the attach feature.

The previous log used `ROCP_CI_LOG_IF(WARNING, ...)`. In CI builds (`ROCPROFILER_CI` defined), `ROCP_CI_LOG_IF` is implemented as `ROCP_FATAL_IF` (see `logging.hpp`), so this condition could fail CI even though lazy registration is intentional and correct.

This change logs at INFO with a clearer message that lazy registration is occurring, including the stream pointer, without treating it as a CI failure.

## Technical Details

**File:** `projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/stream.cpp` — `get_stream_id()`

**Before:** `ROCP_CI_LOG_IF(WARNING, !supports_attachment())` with message implying a problem when attach is not used.

**After:** `ROCP_INFO_IF(!supports_attachment())` with message:
`Stream ID is not present in <fn>, registering hipStream_t (<hex>) lazily`

Behavior is unchanged: still calls `add_stream(stream, false)` when the stream ID is missing.

**Commit:** https://github.com/ROCm/rocm-systems/commit/691b7156487464b979f62175de981c57375564dd

## JIRA ID

Resolves AIPROFSYST-474

## Test Plan

- [ ] Build `rocprofiler-sdk` with CI defines enabled (`ROCPROFILER_CI=1`) and confirm the lazy-registration path no longer triggers a fatal via `ROCP_CI_LOG_IF`.
- [ ] Run existing rocprofiler-sdk CI / unit tests that exercise HIP stream profiling without attach mode.
- [ ] Manually verify (optional): run a small HIP workload with rocprofiler-sdk where a stream is first seen in `get_stream_id()` without attach; confirm INFO log appears and profiling completes successfully.

## Test Result

## Test Result

Tested on mi300x-2 with ROCm `/home/rpathania/therock-tarball/install_14May`,
branch `fix/sdk-stream-ci-lazy-registration` (661a56fec2), `build-ci` with `-DROCPROFILER_BUILD_CI=ON`:

- Build: PASSED (`ROCPROFILER_CI=1` confirmed in compile flags; new lazy-registration INFO string present in `librocprofiler-sdk.so`).
- `ctest -R hip-stream`: **8/8 PASSED** (13.08s) — hip-stream-display + hip-streams-per-thread execute + validation; no FATAL in logs.
- Manual `rocprofv3 --log-level info -- bin/hip-streams`: exit code 0, profiling completed successfully.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.