### PR TITLE
clr: Fix profiling for hipMemcpyBatchAsync

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/hip_profiler_ext.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/hip_profiler_ext.h
@@ -66,6 +66,7 @@ typedef enum {
   HIP_COPY_KIND_BUFFER_TO_IMAGE_EXT = 10, /**< Device buffer → device image (format conversion) */
   HIP_COPY_KIND_IMAGE_TO_BUFFER_EXT = 11, /**< Device image → device buffer (format conversion) */
   HIP_COPY_KIND_FILL_EXT            = 12, /**< Device buffer fill (pattern written by compute engine) */
+  HIP_COPY_KIND_BATCH_EXT           = 13, /**< Batched buffer copy (may mix D2D, P2P, H2D, D2H) */
 } HipCopyKindExt;
 
 /**
@@ -80,7 +81,8 @@ static inline int hipCopyKindIsSDMAExt(HipCopyKindExt kind) {
          kind == HIP_COPY_KIND_H2D_IMAGE_EXT ||
          kind == HIP_COPY_KIND_D2H_EXT       ||
          kind == HIP_COPY_KIND_D2H_RECT_EXT  ||
-         kind == HIP_COPY_KIND_D2H_IMAGE_EXT;
+         kind == HIP_COPY_KIND_D2H_IMAGE_EXT ||
+         kind == HIP_COPY_KIND_BATCH_EXT;
 }
 
 /**

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -2972,7 +2972,6 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
   std::vector<size_t> hostToHostIndices;
   std::vector<size_t> writeBufferIndices;
   std::vector<size_t> readBufferIndices;
-  std::vector<size_t> p2pIndices;
 
   for (size_t i = 0; i < count; ++i) {
     hip::MemcpyType type;
@@ -2988,6 +2987,7 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
     switch (type) {
       case hipCopyBuffer:
       case hipCopyBufferSDMA:
+      case hipCopyBufferP2P:
         bufferCopyIndices.push_back(i);
         break;
       case hipHostToHost:
@@ -2998,9 +2998,6 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
         break;
       case hipReadBuffer:
         readBufferIndices.push_back(i);
-        break;
-      case hipCopyBufferP2P:
-        p2pIndices.push_back(i);
         break;
     }
   }
@@ -3059,14 +3056,6 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
 
   // Handle read buffer (device to host) copies
   for (size_t idx : readBufferIndices) {
-    status = ihipMemcpy(dsts[idx], srcs[idx], sizes[idx], hipMemcpyDefault, stream, isAsync, true);
-    if (status != hipSuccess) {
-      return status;
-    }
-  }
-
-  // Handle P2P copies
-  for (size_t idx : p2pIndices) {
     status = ihipMemcpy(dsts[idx], srcs[idx], sizes[idx], hipMemcpyDefault, stream, isAsync, true);
     if (status != hipSuccess) {
       return status;

--- a/projects/clr/hipamd/src/profiler/hip_clr_profiler.cpp
+++ b/projects/clr/hipamd/src/profiler/hip_clr_profiler.cpp
@@ -285,6 +285,7 @@ static HipCopyKindExt ToCopyKindExt(uint32_t cl_kind) {
     case CL_COMMAND_COPY_BUFFER_TO_IMAGE:   return HIP_COPY_KIND_BUFFER_TO_IMAGE_EXT;
     case CL_COMMAND_COPY_IMAGE_TO_BUFFER:   return HIP_COPY_KIND_IMAGE_TO_BUFFER_EXT;
     case CL_COMMAND_FILL_BUFFER:            return HIP_COPY_KIND_FILL_EXT;
+    case ROCCLR_COMMAND_BATCH_COPY_BUFFER:  return HIP_COPY_KIND_BATCH_EXT;
     default:                                return HIP_COPY_KIND_UNKNOWN_EXT;
   }
 }
@@ -519,6 +520,7 @@ static const char* CopyKindName(uint32_t kind) {
     case HIP_COPY_KIND_BUFFER_TO_IMAGE_EXT: return "BufferToImage";
     case HIP_COPY_KIND_IMAGE_TO_BUFFER_EXT: return "ImageToBuffer";
     case HIP_COPY_KIND_FILL_EXT:            return "Fill";
+    case HIP_COPY_KIND_BATCH_EXT:           return "Batch_Copy";
     default:                                return "Unknown";
   }
 }
@@ -701,7 +703,7 @@ void WriteJsonTraceImpl(const char* filepath) {
       // emit_host_arrow: draw ph:s/ph:t dep arrow from CPU event to this GPU op.
       //   For graph launches only the first op gets the host arrow; subsequent nodes
       //   are connected via node→node graph arrows instead.
-      struct GpuOpInfo { uint64_t tid; double ts; bool has_ts; };
+      struct GpuOpInfo { uint64_t tid; double ts; double dur; bool has_ts; };
       auto emit_gpu_op = [&](const hipGpuActivityExt& gop, hipStream_t stream,
                              bool emit_host_arrow = true) -> GpuOpInfo {
         uint32_t op_idx  = gop.op < 3 ? gop.op : 3;
@@ -734,7 +736,7 @@ void WriteJsonTraceImpl(const char* filepath) {
         if (has_ts && emit_host_arrow)
           trace << ",\n{\"ph\":\"s\",\"id\":" << fid
                 << ",\"pid\":1024,\"tid\":" << rec.thread_id
-                << ",\"ts\":" << s_time << ",\"name\":\"dep\"}";
+                << ",\"ts\":" << (s_time + dur_us) << ",\"name\":\"dep\"}";
         // GPU X event.
         trace << ",\n{\"name\":\"" << gpu_name
               << "\",\"ph\":\"X\",\"pid\":" << gop.device_id
@@ -846,7 +848,7 @@ void WriteJsonTraceImpl(const char* filepath) {
         }
 
         device_gpu_tids[static_cast<int>(gop.device_id)].insert(gpu_tid);
-        return GpuOpInfo{gpu_tid, gpu_ts, has_ts};
+        return GpuOpInfo{gpu_tid, gpu_ts, gpu_dur, has_ts};
       };
 
       // Op-1 lives directly in rec.gpu; ops 2..N are in the spill linked list.
@@ -863,7 +865,7 @@ void WriteJsonTraceImpl(const char* filepath) {
             trace << ",\n{\"ph\":\"s\",\"id\":" << gfid
                   << ",\"pid\":" << rec.gpu.device_id
                   << ",\"tid\":" << prev.tid
-                  << ",\"ts\":" << prev.ts << ",\"name\":\"graph\",\"cat\":\"graph\"}";
+                  << ",\"ts\":" << (prev.ts + prev.dur) << ",\"name\":\"graph\",\"cat\":\"graph\"}";
             trace << ",\n{\"ph\":\"f\",\"bp\":\"e\",\"id\":" << gfid
                   << ",\"pid\":" << rec.gpu.device_id
                   << ",\"tid\":" << cur.tid
@@ -1612,14 +1614,14 @@ static void PfChunkCallback(const hipApiRecordExt* records, uint32_t count, uint
       cpu_anns.push_back({iid_stream, buf});
     }
 
-    // CPU→GPU outflow
-    std::vector<uint64_t> cpu_out;
     auto cfit = chunk_cpu_gpu_fid.find(rec.chunk_id);
-    if (cfit != chunk_cpu_gpu_fid.end()) cpu_out.push_back(cfit->second);
 
     uint64_t name_iid = g_pf_evt_iid.count(rec.api_name) ? g_pf_evt_iid[rec.api_name] : 0;
     EmitSliceSorted(sorted_pkts, cpu_uuid, ts_ns, dur_ns, rec.api_name,
-                    name_iid, cat_hip, cpu_anns, cpu_out, {});
+                    name_iid, cat_hip, cpu_anns, {}, {});
+    // CPU→GPU flow arrow sourced at CPU event END time (dispatch point)
+    if (cfit != chunk_cpu_gpu_fid.end())
+      EmitFlowEventSorted(sorted_pkts, cpu_uuid, ts_ns + dur_ns, cfit->second, true);
 
     if (rec.gpu.gpu_op_count == 0) continue;
 
@@ -2107,7 +2109,7 @@ void WriteProtoTraceImpl(const char* filepath) {
     for (auto& kv : g_kernel_names) intern_evt(kv.second);
   }
   // GPU copy: all possible CopyKindName values
-  for (int k = 0; k <= 12; ++k) intern_evt(CopyKindName(static_cast<uint32_t>(k)));
+  for (int k = 0; k <= 13; ++k) intern_evt(CopyKindName(static_cast<uint32_t>(k)));
   intern_evt("Barrier");
   // Memory alloc names: "0xADDR (SIZE unit)"
   for (auto& kv : alloc_map) {
@@ -2169,9 +2171,7 @@ void WriteProtoTraceImpl(const char* filepath) {
       uint64_t ts_ns    = rec.start_ns;
       uint64_t dur_ns   = (rec.end_ns > rec.start_ns) ? (rec.end_ns - rec.start_ns) : 1;
 
-      std::vector<uint64_t> cpu_out;
       auto cfit = cpu_gpu_flow.find(slot);
-      if (cfit != cpu_gpu_flow.end()) cpu_out.push_back(cfit->second);
 
       std::vector<std::pair<uint64_t,std::string>> cpu_anns;
       {
@@ -2195,7 +2195,10 @@ void WriteProtoTraceImpl(const char* filepath) {
         }
       }
       EmitSliceSorted(sorted_pkts, cpu_uuid, ts_ns, dur_ns, rec.api_name,
-                      intern_evt(rec.api_name), kCatHip, cpu_anns, cpu_out, {});
+                      intern_evt(rec.api_name), kCatHip, cpu_anns, {}, {});
+      // CPU→GPU flow arrow sourced at CPU event END time (dispatch point)
+      if (cfit != cpu_gpu_flow.end())
+        EmitFlowEventSorted(sorted_pkts, cpu_uuid, ts_ns + dur_ns, cfit->second, true);
 
       // GPU op slices
       auto ctoit = cpu_gpu_target_ord.find(slot);
@@ -2291,16 +2294,16 @@ void WriteProtoTraceImpl(const char* filepath) {
         auto gnif = graph_node_in_flows.find(slot * 1000 + op_ord);
         if (gnif != graph_node_in_flows.end()) in_flows_vec.push_back(gnif->second);
 
-        // Graph node→node: this op sends to next node
-        std::vector<uint64_t> out_flows_vec;
+        // Graph node→node: this op sends to next node (arrow from op END)
         auto gnof = graph_node_out_flows.find(slot * 1000 + op_ord);
-        if (gnof != graph_node_out_flows.end()) out_flows_vec.push_back(gnof->second);
 
         ++op_ord;
 
         uint64_t gpu_name_iid = intern_evt(gpu_name);
         EmitSliceSorted(sorted_pkts, gpu_uuid, g_ts, g_dur, gpu_name,
-                        gpu_name_iid, kCatGpu, gpu_anns, out_flows_vec, in_flows_vec);
+                        gpu_name_iid, kCatGpu, gpu_anns, {}, in_flows_vec);
+        if (gnof != graph_node_out_flows.end())
+          EmitFlowEventSorted(sorted_pkts, gpu_uuid, g_ts + g_dur, gnof->second, true);
       };
 
       if (rec.gpu.gpu_op_count > 0) {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -264,8 +264,9 @@ void Timestamp::checkGpuTime(ProfilingSignal* single_signal) {
         ExtractSignalTiming(sig, start, end, sdmaStart, sdmaEnd);
       }
 
-      if (command().GetBatchHead() == nullptr || command().profilingInfo().marker_ts_ ||
-          command().type() == CL_COMMAND_TASK) {
+      if (IsLogEnabled(amd::LOG_INFO, amd::LOG_TS) &&
+          (command().GetBatchHead() == nullptr || command().profilingInfo().marker_ts_ ||
+           command().type() == CL_COMMAND_TASK)) {
         uint64_t sig_start, sig_end;
         sig->GetCachedTiming(sig_start, sig_end);
         amd_signal_t* amdSignal = reinterpret_cast<amd_signal_t*>(sig->signal_.handle);
@@ -296,26 +297,37 @@ void Timestamp::checkGpuTime(ProfilingSignal* single_signal) {
       signals_.clear();
     }
 
-    // Update member timing variables from local accumulators
-    // When processing single signal, merge with existing timing
-    // When processing all signals, replace timing
+    // Aggregate timing based on command type
     if (end != 0 || sdmaEnd != 0) {
-      const bool merge_with_existing = (single_signal != nullptr);
-      uint64_t final_start = ((sdmaEnd != 0) ? sdmaStart : start) * ticksToTime_;
-      uint64_t final_end = ((sdmaEnd != 0) ? sdmaEnd : end) * ticksToTime_;
+      uint64_t final_start, final_end;
+      const auto cmd_type = command().type();
+
+      if (cmd_type == CL_COMMAND_COPY_BUFFER || cmd_type == CL_COMMAND_READ_BUFFER ||
+          cmd_type == CL_COMMAND_WRITE_BUFFER || cmd_type == CL_COMMAND_COPY_BUFFER_RECT ||
+          cmd_type == CL_COMMAND_READ_BUFFER_RECT || cmd_type == CL_COMMAND_WRITE_BUFFER_RECT) {
+        // Copy/Read/Write — prefer SDMA timing, fall back to compute
+        final_start = ((sdmaEnd != 0) ? sdmaStart : start) * ticksToTime_;
+        final_end = ((sdmaEnd != 0) ? sdmaEnd : end) * ticksToTime_;
+      } else {
+        // Batch copy and all other commands — min/max across all engines
+        final_start = std::min(sdmaEnd != 0 ? sdmaStart : start,
+                               end != 0 ? start : sdmaStart) * ticksToTime_;
+        final_end = std::max(sdmaEnd, end) * ticksToTime_;
+      }
+
       if (!accum_ena_) {
         start_ = final_start;
         accum_ena_ = true;
-      } else if (merge_with_existing) {
+      } else {
         start_ = std::min(start_, final_start);
       }
-      end_ = merge_with_existing ? std::max(end_, final_end) : final_end;
+      end_ = std::max(end_, final_end);
     }
   }
 }
 
 // ================================================================================================
-// Extract timing from a single signal
+// Extract timing from a single signal and update accumulators
 void Timestamp::ExtractSignalTiming(ProfilingSignal* signal,
                                     uint64_t& start, uint64_t& end,
                                     uint64_t& sdmaStart, uint64_t& sdmaEnd) {
@@ -2232,7 +2244,6 @@ void VirtualGPU::profilingBegin(amd::Command& command, bool sdmaProfiling) {
     timestamp_ = new Timestamp(this, command);
     command.data().emplace_back(timestamp_);
     timestamp_->start();
-
     // Enable SDMA profiling on the first access if profiling is set
     // Its not per command basis
     if (sdmaProfiling && !Barriers().GetSDMAProfiling()) {
@@ -3103,7 +3114,12 @@ void VirtualGPU::submitBatchCopyMemory(amd::BatchCopyMemoryCommand& cmd) {
   }
 
   // Synchronize the launch (compute) stream with SDMA engines.
+  // Reset active engine to Compute before the barrier — the barrier runs on the
+  // AQL compute queue, not an SDMA engine.  Without this, the barrier's profiling
+  // signal inherits an SDMA engine type, causing CacheTimingData to call
+  // hsa_amd_profiling_get_async_copy_time (wrong API) and corrupt the timestamps.
   if (result) {
+    Barriers().SetActiveEngine(HwQueueEngine::Compute);
     dispatchBarrierPacket(kNopPacketHeader);
   }
 

--- a/projects/clr/rocclr/platform/activity.cpp
+++ b/projects/clr/rocclr/platform/activity.cpp
@@ -94,6 +94,13 @@ void ReportActivity(const amd::Command& command) {
     case CL_COMMAND_FILL_BUFFER:
       record.bytes = linearSize(static_cast<const amd::FillMemoryCommand&>(command).size());
       break;
+    case ROCCLR_COMMAND_BATCH_COPY_BUFFER: {
+      const auto& ops = static_cast<const amd::BatchCopyMemoryCommand&>(command).copyOps();
+      size_t total = 0;
+      for (const auto& op : ops) total += op.size;
+      record.bytes = total;
+      break;
+    }
     default:
       break;
   }
@@ -162,6 +169,8 @@ const char* getOclCommandKindString(cl_command_type commandType) {
     CASE_STRING(CL_COMMAND_SVM_UNMAP, SvmUnmap);
     CASE_STRING(ROCCLR_COMMAND_STREAM_WAIT_VALUE, StreamWait);
     CASE_STRING(ROCCLR_COMMAND_STREAM_WRITE_VALUE, StreamWrite);
+    CASE_STRING(ROCCLR_COMMAND_BATCH_STREAM, BatchStreamOp);
+    CASE_STRING(ROCCLR_COMMAND_BATCH_COPY_BUFFER, BatchCopyBuffer);
     default:
       break;
   };

--- a/projects/clr/rocclr/platform/activity.hpp
+++ b/projects/clr/rocclr/platform/activity.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "top.hpp"
+#include "platform/command_utils.hpp"
 
 #include <atomic>
 #include <array>
@@ -37,6 +38,9 @@ constexpr OpId OperationId(cl_command_type commandType) {
   switch (commandType) {
     case CL_COMMAND_NDRANGE_KERNEL:
     case CL_COMMAND_TASK:
+    case ROCCLR_COMMAND_STREAM_WAIT_VALUE:
+    case ROCCLR_COMMAND_STREAM_WRITE_VALUE:
+    case ROCCLR_COMMAND_BATCH_STREAM:
       return OP_ID_DISPATCH;
     case CL_COMMAND_READ_BUFFER:
     case CL_COMMAND_READ_BUFFER_RECT:
@@ -51,6 +55,7 @@ constexpr OpId OperationId(cl_command_type commandType) {
     case CL_COMMAND_FILL_IMAGE:
     case CL_COMMAND_COPY_BUFFER_TO_IMAGE:
     case CL_COMMAND_COPY_IMAGE_TO_BUFFER:
+    case ROCCLR_COMMAND_BATCH_COPY_BUFFER:
       return OP_ID_COPY;
     case CL_COMMAND_MARKER:
       return OP_ID_BARRIER;

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -1173,7 +1173,7 @@ class BatchCopyMemoryCommand : public Command {
   virtual void submit(device::VirtualDevice& device) { device.submitBatchCopyMemory(*this); }
 
   //! Return the vector of copy operations
-  std::vector<BatchCopyOp>& copyOps() { return copyOps_; }
+  const std::vector<BatchCopyOp>& copyOps() const { return copyOps_; }
 
   //! Return the number of copy operations in the batch
   size_t count() const { return copyOps_.size(); }

--- a/projects/clr/rocclr/thread/monitor.hpp
+++ b/projects/clr/rocclr/thread/monitor.hpp
@@ -34,6 +34,13 @@ class Monitor {
   //! Release the lock and wake a single waiting thread if any.
   void unlock() { mutex_.unlock(); }
 
+  // GCC 12+ emits a false -Wstringop-overflow when it inlines atomic ops on
+  // class members through multiple call frames and loses size provenance.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+
   /*! \brief Give up the lock and go to sleep.
    *
    *  Calling wait() causes the current thread to go to sleep until
@@ -135,6 +142,10 @@ class Monitor {
       cv_.notify_all();
     }
   }
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
  private:
   std::mutex mutex_;


### PR DESCRIPTION
- Include P2P copies in batch command for unified profiling timestamps
- Add ROCCLR_COMMAND_BATCH_COPY_BUFFER to activity reporting and roctracer
- Add HIP_COPY_KIND_BATCH_EXT to profiler copy kind enum
- Fix timing aggregation in Timestamp::checkGpuTime to use command-type driven logic (SDMA-only for copy/read/write, min/max all for batch)
- Fix flow arrows in JSON/proto traces to originate at CPU event end time
- Reset active engine to Compute before barrier in batch copy dispatch

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
