### PR TITLE
[AMD-SMI] Update rust wrapper and fix ProcessorTypeT

### DIFF
--- a/projects/amdsmi/rust-interface/src/amdsmi.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi.rs
@@ -32,7 +32,7 @@ use std::ptr::null_mut;
 ///
 /// # Arguments
 ///
-/// * `init_flags` - Use a [`ProcessorTypeT`] for initialization flags.
+/// * `init_flags` - Use a [`AmdsmiInitFlagsT`] for initialization flags.
 ///
 /// # Returns
 ///
@@ -280,7 +280,7 @@ pub fn amdsmi_get_processor_handles(
 ///
 /// # Returns
 ///
-/// * `AmdsmiResult<ProcessorTypeT>` - Returns `Ok(ProcessorTypeT)` containing the [`ProcessorTypeT`] if successful, or an error if it fails.
+/// * `AmdsmiResult<AmdsmiProcessorTypeT>` - Returns `Ok(AmdsmiProcessorTypeT)` containing the [`AmdsmiProcessorTypeT`] if successful, or an error if it fails.
 ///
 /// # Example
 ///
@@ -310,8 +310,8 @@ pub fn amdsmi_get_processor_handles(
 /// This function will return the error in [`AmdsmiStatusT`] if the underlying `amdsmi_wrapper::amdsmi_get_processor_type` call fails.
 pub fn amdsmi_get_processor_type(
     processor_handle: AmdsmiProcessorHandle,
-) -> AmdsmiResult<ProcessorTypeT> {
-    let mut processor_type = ProcessorTypeT::AmdsmiProcessorTypeUnknown;
+) -> AmdsmiResult<AmdsmiProcessorTypeT> {
+    let mut processor_type = AmdsmiProcessorTypeT::AmdsmiProcessorTypeUnknown;
     call_unsafe!(amdsmi_wrapper::amdsmi_get_processor_type(
         processor_handle,
         &mut processor_type

--- a/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
@@ -123,6 +123,10 @@ pub const AMDSMI_MAX_NUM_JPEG: u32 = 32;
 pub const AMDSMI_MAX_NUM_JPEG_ENG_V1: u32 = 40;
 pub const AMDSMI_MAX_NUM_XCC: u32 = 8;
 pub const AMDSMI_MAX_NUM_XCP: u32 = 8;
+pub const AMDSMI_APU_MAX_CORES: u32 = 16;
+pub const AMDSMI_APU_V24_CORES: u32 = 8;
+pub const AMDSMI_APU_MAX_L3: u32 = 2;
+pub const AMDSMI_APU_MAX_IPU: u32 = 8;
 pub const AMDSMI_MAX_VF_COUNT: u32 = 32;
 pub const AMDSMI_MAX_DRIVER_NUM: u32 = 2;
 pub const AMDSMI_DFC_FW_NUMBER_OF_ENTRIES: u32 = 9;
@@ -132,6 +136,11 @@ pub const AMDSMI_MAX_UUID_ELEMENTS: u32 = 16;
 pub const AMDSMI_MAX_TA_WHITE_LIST_ELEMENTS: u32 = 8;
 pub const AMDSMI_MAX_ERR_RECORDS: u32 = 10;
 pub const AMDSMI_MAX_PROFILE_COUNT: u32 = 16;
+pub const AMDSMI_MAX_NUM_HBM_STACKS: u32 = 12;
+pub const AMDSMI_MAX_NUM_AID: u32 = 2;
+pub const AMDSMI_MAX_NUM_MID: u32 = 2;
+pub const AMDSMI_MAX_NUM_CLKS_PER_AID: u32 = 2;
+pub const AMDSMI_MAX_NUM_CLKS_PER_MID: u32 = 2;
 pub const AMDSMI_TIME_FORMAT: &[u8; 20] = b"%02d:%02d:%02d.%03d\0";
 pub const AMDSMI_DATE_FORMAT: &[u8; 35] = b"%04d-%02d-%02d:%02d:%02d:%02d.%03d\0";
 pub const AMDSMI_LIB_VERSION_MAJOR: u32 = 26;
@@ -147,7 +156,23 @@ pub const AMDSMI_MAX_NUM_PM_POLICIES: u32 = 32;
 pub const AMDSMI_MAX_NIC_PORTS: u32 = 32;
 pub const AMDSMI_MAX_NIC_RDMA_DEV: u32 = 32;
 pub const AMDSMI_MAX_NIC_FW: u32 = 16;
+pub const AMDSMI_FABRIC_LABEL_MAX_LENGTH: u32 = 32;
 pub const AMDSMI_MAX_CARVEOUT_OPTIONS: u32 = 16;
+pub type __time_t = ::std::os::raw::c_long;
+pub type __syscall_slong_t = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timespec {
+    pub tv_sec: __time_t,
+    pub tv_nsec: __syscall_slong_t,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of timespec"][::std::mem::size_of::<timespec>() - 16usize];
+    ["Alignment of timespec"][::std::mem::align_of::<timespec>() - 8usize];
+    ["Offset of field: timespec::tv_sec"][::std::mem::offset_of!(timespec, tv_sec) - 0usize];
+    ["Offset of field: timespec::tv_nsec"][::std::mem::offset_of!(timespec, tv_nsec) - 8usize];
+};
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum AmdsmiInitFlagsT {
@@ -178,7 +203,7 @@ pub type AmdsmiSocketHandle = *mut ::std::os::raw::c_void;
 pub type AmdsmiNodeHandle = *mut ::std::os::raw::c_void;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum ProcessorTypeT {
+pub enum AmdsmiProcessorTypeT {
     AmdsmiProcessorTypeUnknown = 0,
     AmdsmiProcessorTypeAmdGpu = 1,
     AmdsmiProcessorTypeAmdCpu = 2,
@@ -321,6 +346,10 @@ impl AmdsmiTemperatureTypeT {
         AmdsmiTemperatureTypeT::AmdsmiTemperatureTypeGpuboardVrFirst;
 }
 impl AmdsmiTemperatureTypeT {
+    pub const AmdsmiTemperatureTypeGpuboardLast: AmdsmiTemperatureTypeT =
+        AmdsmiTemperatureTypeT::AmdsmiTemperatureTypeGpuboardVddan075;
+}
+impl AmdsmiTemperatureTypeT {
     pub const AmdsmiTemperatureTypeBaseboardUbbFpga: AmdsmiTemperatureTypeT =
         AmdsmiTemperatureTypeT::AmdsmiTemperatureTypeBaseboardFirst;
 }
@@ -359,6 +388,19 @@ pub enum AmdsmiTemperatureTypeT {
     AmdsmiTemperatureTypeGpuboardVddcr11HbmD = 160,
     AmdsmiTemperatureTypeGpuboardVddUsr = 161,
     AmdsmiTemperatureTypeGpuboardVddio11E32 = 162,
+    AmdsmiTemperatureTypeGpuboardVddio04HbmB = 163,
+    AmdsmiTemperatureTypeGpuboardVddio04HbmD = 164,
+    AmdsmiTemperatureTypeGpuboardVddcr075HbmB = 165,
+    AmdsmiTemperatureTypeGpuboardVddcr075HbmD = 166,
+    AmdsmiTemperatureTypeGpuboardVddio11GtaA = 167,
+    AmdsmiTemperatureTypeGpuboardVddio11GtaC = 168,
+    AmdsmiTemperatureTypeGpuboardVddan075GtaA = 169,
+    AmdsmiTemperatureTypeGpuboardVddan075GtaC = 170,
+    AmdsmiTemperatureTypeGpuboardVddcr075Ucie = 171,
+    AmdsmiTemperatureTypeGpuboardVddio065Ucieaa = 172,
+    AmdsmiTemperatureTypeGpuboardVddio065UcieamA = 173,
+    AmdsmiTemperatureTypeGpuboardVddio065UcieamC = 174,
+    AmdsmiTemperatureTypeGpuboardVddan075 = 175,
     AmdsmiTemperatureTypeGpuboardVrLast = 199,
     AmdsmiTemperatureTypeBaseboardFirst = 200,
     AmdsmiTemperatureTypeBaseboardUbbFront = 201,
@@ -1191,11 +1233,11 @@ pub struct AmdsmiAsicInfoT {
     pub target_graphics_version: u64,
     pub subsystem_id: u32,
     pub flags: u64,
-    pub reserved: [u32; 19usize],
+    pub reserved: [u32; 18usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of AmdsmiAsicInfoT"][::std::mem::size_of::<AmdsmiAsicInfoT>() - 904usize];
+    ["Size of AmdsmiAsicInfoT"][::std::mem::size_of::<AmdsmiAsicInfoT>() - 896usize];
     ["Alignment of AmdsmiAsicInfoT"][::std::mem::align_of::<AmdsmiAsicInfoT>() - 8usize];
     ["Offset of field: AmdsmiAsicInfoT::market_name"]
         [::std::mem::offset_of!(AmdsmiAsicInfoT, market_name) - 0usize];
@@ -1839,6 +1881,106 @@ const _: () = {
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct AmdsmiProcGpuEntryT {
+    pub gpu_index: u32,
+    pub mem: u64,
+    pub engine_usage: AmdsmiProcGpuEntryTBindgenTy1,
+    pub memory_usage: AmdsmiProcGpuEntryTBindgenTy2,
+    pub cu_occupancy: u32,
+    pub evicted_time: u32,
+    pub sdma_usage: u64,
+    pub reserved: [u32; 8usize],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiProcGpuEntryTBindgenTy1 {
+    pub gfx: u64,
+    pub enc: u64,
+    pub reserved: [u32; 12usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiProcGpuEntryTBindgenTy1"]
+        [::std::mem::size_of::<AmdsmiProcGpuEntryTBindgenTy1>() - 64usize];
+    ["Alignment of AmdsmiProcGpuEntryTBindgenTy1"]
+        [::std::mem::align_of::<AmdsmiProcGpuEntryTBindgenTy1>() - 8usize];
+    ["Offset of field: AmdsmiProcGpuEntryTBindgenTy1::gfx"]
+        [::std::mem::offset_of!(AmdsmiProcGpuEntryTBindgenTy1, gfx) - 0usize];
+    ["Offset of field: AmdsmiProcGpuEntryTBindgenTy1::enc"]
+        [::std::mem::offset_of!(AmdsmiProcGpuEntryTBindgenTy1, enc) - 8usize];
+    ["Offset of field: AmdsmiProcGpuEntryTBindgenTy1::reserved"]
+        [::std::mem::offset_of!(AmdsmiProcGpuEntryTBindgenTy1, reserved) - 16usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiProcGpuEntryTBindgenTy2 {
+    pub gtt_mem: u64,
+    pub cpu_mem: u64,
+    pub vram_mem: u64,
+    pub reserved: [u32; 10usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiProcGpuEntryTBindgenTy2"]
+        [::std::mem::size_of::<AmdsmiProcGpuEntryTBindgenTy2>() - 64usize];
+    ["Alignment of AmdsmiProcGpuEntryTBindgenTy2"]
+        [::std::mem::align_of::<AmdsmiProcGpuEntryTBindgenTy2>() - 8usize];
+    ["Offset of field: AmdsmiProcGpuEntryTBindgenTy2::gtt_mem"]
+        [::std::mem::offset_of!(AmdsmiProcGpuEntryTBindgenTy2, gtt_mem) - 0usize];
+    ["Offset of field: AmdsmiProcGpuEntryTBindgenTy2::cpu_mem"]
+        [::std::mem::offset_of!(AmdsmiProcGpuEntryTBindgenTy2, cpu_mem) - 8usize];
+    ["Offset of field: AmdsmiProcGpuEntryTBindgenTy2::vram_mem"]
+        [::std::mem::offset_of!(AmdsmiProcGpuEntryTBindgenTy2, vram_mem) - 16usize];
+    ["Offset of field: AmdsmiProcGpuEntryTBindgenTy2::reserved"]
+        [::std::mem::offset_of!(AmdsmiProcGpuEntryTBindgenTy2, reserved) - 24usize];
+};
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiProcGpuEntryT"][::std::mem::size_of::<AmdsmiProcGpuEntryT>() - 192usize];
+    ["Alignment of AmdsmiProcGpuEntryT"][::std::mem::align_of::<AmdsmiProcGpuEntryT>() - 8usize];
+    ["Offset of field: AmdsmiProcGpuEntryT::gpu_index"]
+        [::std::mem::offset_of!(AmdsmiProcGpuEntryT, gpu_index) - 0usize];
+    ["Offset of field: AmdsmiProcGpuEntryT::mem"]
+        [::std::mem::offset_of!(AmdsmiProcGpuEntryT, mem) - 8usize];
+    ["Offset of field: AmdsmiProcGpuEntryT::engine_usage"]
+        [::std::mem::offset_of!(AmdsmiProcGpuEntryT, engine_usage) - 16usize];
+    ["Offset of field: AmdsmiProcGpuEntryT::memory_usage"]
+        [::std::mem::offset_of!(AmdsmiProcGpuEntryT, memory_usage) - 80usize];
+    ["Offset of field: AmdsmiProcGpuEntryT::cu_occupancy"]
+        [::std::mem::offset_of!(AmdsmiProcGpuEntryT, cu_occupancy) - 144usize];
+    ["Offset of field: AmdsmiProcGpuEntryT::evicted_time"]
+        [::std::mem::offset_of!(AmdsmiProcGpuEntryT, evicted_time) - 148usize];
+    ["Offset of field: AmdsmiProcGpuEntryT::sdma_usage"]
+        [::std::mem::offset_of!(AmdsmiProcGpuEntryT, sdma_usage) - 152usize];
+    ["Offset of field: AmdsmiProcGpuEntryT::reserved"]
+        [::std::mem::offset_of!(AmdsmiProcGpuEntryT, reserved) - 160usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiProcInfoByPidT {
+    pub pid: AmdsmiProcessHandleT,
+    pub name: [::std::os::raw::c_char; 256usize],
+    pub container_name: [::std::os::raw::c_char; 256usize],
+    pub num_gpus: u32,
+    pub gpus: [AmdsmiProcGpuEntryT; 32usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiProcInfoByPidT"][::std::mem::size_of::<AmdsmiProcInfoByPidT>() - 6664usize];
+    ["Alignment of AmdsmiProcInfoByPidT"][::std::mem::align_of::<AmdsmiProcInfoByPidT>() - 8usize];
+    ["Offset of field: AmdsmiProcInfoByPidT::pid"]
+        [::std::mem::offset_of!(AmdsmiProcInfoByPidT, pid) - 0usize];
+    ["Offset of field: AmdsmiProcInfoByPidT::name"]
+        [::std::mem::offset_of!(AmdsmiProcInfoByPidT, name) - 4usize];
+    ["Offset of field: AmdsmiProcInfoByPidT::container_name"]
+        [::std::mem::offset_of!(AmdsmiProcInfoByPidT, container_name) - 260usize];
+    ["Offset of field: AmdsmiProcInfoByPidT::num_gpus"]
+        [::std::mem::offset_of!(AmdsmiProcInfoByPidT, num_gpus) - 516usize];
+    ["Offset of field: AmdsmiProcInfoByPidT::gpus"]
+        [::std::mem::offset_of!(AmdsmiProcInfoByPidT, gpus) - 520usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct AmdsmiP2pCapabilityT {
     pub is_iolink_coherent: u8,
     pub is_iolink_atomics_32bit: u8,
@@ -2460,28 +2602,34 @@ const _: () = {
 pub struct AmdsmiOdVoltFreqDataT {
     pub curr_sclk_range: AmdsmiRangeT,
     pub curr_mclk_range: AmdsmiRangeT,
+    pub curr_fclk_range: AmdsmiRangeT,
     pub sclk_freq_limits: AmdsmiRangeT,
     pub mclk_freq_limits: AmdsmiRangeT,
+    pub fclk_freq_limits: AmdsmiRangeT,
     pub curve: AmdsmiOdVoltCurveT,
     pub num_regions: u32,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of AmdsmiOdVoltFreqDataT"][::std::mem::size_of::<AmdsmiOdVoltFreqDataT>() - 184usize];
+    ["Size of AmdsmiOdVoltFreqDataT"][::std::mem::size_of::<AmdsmiOdVoltFreqDataT>() - 248usize];
     ["Alignment of AmdsmiOdVoltFreqDataT"]
         [::std::mem::align_of::<AmdsmiOdVoltFreqDataT>() - 8usize];
     ["Offset of field: AmdsmiOdVoltFreqDataT::curr_sclk_range"]
         [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, curr_sclk_range) - 0usize];
     ["Offset of field: AmdsmiOdVoltFreqDataT::curr_mclk_range"]
         [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, curr_mclk_range) - 32usize];
+    ["Offset of field: AmdsmiOdVoltFreqDataT::curr_fclk_range"]
+        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, curr_fclk_range) - 64usize];
     ["Offset of field: AmdsmiOdVoltFreqDataT::sclk_freq_limits"]
-        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, sclk_freq_limits) - 64usize];
+        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, sclk_freq_limits) - 96usize];
     ["Offset of field: AmdsmiOdVoltFreqDataT::mclk_freq_limits"]
-        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, mclk_freq_limits) - 96usize];
+        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, mclk_freq_limits) - 128usize];
+    ["Offset of field: AmdsmiOdVoltFreqDataT::fclk_freq_limits"]
+        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, fclk_freq_limits) - 160usize];
     ["Offset of field: AmdsmiOdVoltFreqDataT::curve"]
-        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, curve) - 128usize];
+        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, curve) - 192usize];
     ["Offset of field: AmdsmiOdVoltFreqDataT::num_regions"]
-        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, num_regions) - 176usize];
+        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, num_regions) - 240usize];
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2514,10 +2662,11 @@ pub struct AmdsmiGpuXcpMetricsT {
     pub gfx_below_host_limit_thm_acc: [u64; 8usize],
     pub gfx_low_utilization_acc: [u64; 8usize],
     pub gfx_below_host_limit_total_acc: [u64; 8usize],
+    pub temperature_xcd: [u16; 8usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of AmdsmiGpuXcpMetricsT"][::std::mem::size_of::<AmdsmiGpuXcpMetricsT>() - 504usize];
+    ["Size of AmdsmiGpuXcpMetricsT"][::std::mem::size_of::<AmdsmiGpuXcpMetricsT>() - 520usize];
     ["Alignment of AmdsmiGpuXcpMetricsT"][::std::mem::align_of::<AmdsmiGpuXcpMetricsT>() - 8usize];
     ["Offset of field: AmdsmiGpuXcpMetricsT::gfx_busy_inst"]
         [::std::mem::offset_of!(AmdsmiGpuXcpMetricsT, gfx_busy_inst) - 0usize];
@@ -2537,6 +2686,215 @@ const _: () = {
         [::std::mem::offset_of!(AmdsmiGpuXcpMetricsT, gfx_low_utilization_acc) - 376usize];
     ["Offset of field: AmdsmiGpuXcpMetricsT::gfx_below_host_limit_total_acc"]
         [::std::mem::offset_of!(AmdsmiGpuXcpMetricsT, gfx_below_host_limit_total_acc) - 440usize];
+    ["Offset of field: AmdsmiGpuXcpMetricsT::temperature_xcd"]
+        [::std::mem::offset_of!(AmdsmiGpuXcpMetricsT, temperature_xcd) - 504usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiApuMetricsT {
+    pub temperature_gfx: u16,
+    pub temperature_soc: u16,
+    pub temperature_core: [u16; 16usize],
+    pub temperature_l3: [u16; 2usize],
+    pub temperature_skin: u16,
+    pub average_gfx_activity: u16,
+    pub average_mm_activity: u16,
+    pub average_vcn_activity: u16,
+    pub average_ipu_activity: [u16; 8usize],
+    pub average_core_c0_activity: [u16; 16usize],
+    pub average_dram_reads: u16,
+    pub average_dram_writes: u16,
+    pub average_ipu_reads: u16,
+    pub average_ipu_writes: u16,
+    pub average_socket_power: u32,
+    pub average_cpu_power: u16,
+    pub average_soc_power: u16,
+    pub average_gfx_power: u32,
+    pub average_core_power: [u16; 16usize],
+    pub average_ipu_power: u16,
+    pub average_apu_power: u32,
+    pub average_dgpu_power: u32,
+    pub average_all_core_power: u32,
+    pub average_sys_power: u16,
+    pub stapm_power_limit: u16,
+    pub current_stapm_power_limit: u16,
+    pub average_gfxclk_frequency: u16,
+    pub average_socclk_frequency: u16,
+    pub average_uclk_frequency: u16,
+    pub average_fclk_frequency: u16,
+    pub average_vclk_frequency: u16,
+    pub average_dclk_frequency: u16,
+    pub average_vpeclk_frequency: u16,
+    pub average_ipuclk_frequency: u16,
+    pub average_mpipu_frequency: u16,
+    pub current_gfxclk: u16,
+    pub current_socclk: u16,
+    pub current_uclk: u16,
+    pub current_fclk: u16,
+    pub current_vclk: u16,
+    pub current_dclk: u16,
+    pub current_coreclk: [u16; 16usize],
+    pub current_l3clk: [u16; 2usize],
+    pub current_core_maxfreq: u16,
+    pub current_gfx_maxfreq: u16,
+    pub throttle_status: u32,
+    pub indep_throttle_status: u64,
+    pub throttle_residency_prochot: u32,
+    pub throttle_residency_spl: u32,
+    pub throttle_residency_fppt: u32,
+    pub throttle_residency_sppt: u32,
+    pub throttle_residency_thm_core: u32,
+    pub throttle_residency_thm_gfx: u32,
+    pub throttle_residency_thm_soc: u32,
+    pub fan_pwm: u16,
+    pub average_temperature_gfx: u16,
+    pub average_temperature_soc: u16,
+    pub average_temperature_core: [u16; 16usize],
+    pub average_temperature_l3: [u16; 2usize],
+    pub average_cpu_voltage: u16,
+    pub average_soc_voltage: u16,
+    pub average_gfx_voltage: u16,
+    pub average_cpu_current: u16,
+    pub average_soc_current: u16,
+    pub average_gfx_current: u16,
+    pub time_filter_alphavalue: u32,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiApuMetricsT"][::std::mem::size_of::<AmdsmiApuMetricsT>() - 344usize];
+    ["Alignment of AmdsmiApuMetricsT"][::std::mem::align_of::<AmdsmiApuMetricsT>() - 8usize];
+    ["Offset of field: AmdsmiApuMetricsT::temperature_gfx"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, temperature_gfx) - 0usize];
+    ["Offset of field: AmdsmiApuMetricsT::temperature_soc"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, temperature_soc) - 2usize];
+    ["Offset of field: AmdsmiApuMetricsT::temperature_core"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, temperature_core) - 4usize];
+    ["Offset of field: AmdsmiApuMetricsT::temperature_l3"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, temperature_l3) - 36usize];
+    ["Offset of field: AmdsmiApuMetricsT::temperature_skin"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, temperature_skin) - 40usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_gfx_activity"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_gfx_activity) - 42usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_mm_activity"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_mm_activity) - 44usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_vcn_activity"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_vcn_activity) - 46usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_ipu_activity"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_ipu_activity) - 48usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_core_c0_activity"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_core_c0_activity) - 64usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_dram_reads"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_dram_reads) - 96usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_dram_writes"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_dram_writes) - 98usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_ipu_reads"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_ipu_reads) - 100usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_ipu_writes"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_ipu_writes) - 102usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_socket_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_socket_power) - 104usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_cpu_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_cpu_power) - 108usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_soc_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_soc_power) - 110usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_gfx_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_gfx_power) - 112usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_core_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_core_power) - 116usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_ipu_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_ipu_power) - 148usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_apu_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_apu_power) - 152usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_dgpu_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_dgpu_power) - 156usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_all_core_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_all_core_power) - 160usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_sys_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_sys_power) - 164usize];
+    ["Offset of field: AmdsmiApuMetricsT::stapm_power_limit"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, stapm_power_limit) - 166usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_stapm_power_limit"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_stapm_power_limit) - 168usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_gfxclk_frequency"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_gfxclk_frequency) - 170usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_socclk_frequency"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_socclk_frequency) - 172usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_uclk_frequency"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_uclk_frequency) - 174usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_fclk_frequency"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_fclk_frequency) - 176usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_vclk_frequency"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_vclk_frequency) - 178usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_dclk_frequency"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_dclk_frequency) - 180usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_vpeclk_frequency"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_vpeclk_frequency) - 182usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_ipuclk_frequency"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_ipuclk_frequency) - 184usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_mpipu_frequency"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_mpipu_frequency) - 186usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_gfxclk"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_gfxclk) - 188usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_socclk"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_socclk) - 190usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_uclk"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_uclk) - 192usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_fclk"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_fclk) - 194usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_vclk"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_vclk) - 196usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_dclk"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_dclk) - 198usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_coreclk"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_coreclk) - 200usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_l3clk"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_l3clk) - 232usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_core_maxfreq"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_core_maxfreq) - 236usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_gfx_maxfreq"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_gfx_maxfreq) - 238usize];
+    ["Offset of field: AmdsmiApuMetricsT::throttle_status"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, throttle_status) - 240usize];
+    ["Offset of field: AmdsmiApuMetricsT::indep_throttle_status"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, indep_throttle_status) - 248usize];
+    ["Offset of field: AmdsmiApuMetricsT::throttle_residency_prochot"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, throttle_residency_prochot) - 256usize];
+    ["Offset of field: AmdsmiApuMetricsT::throttle_residency_spl"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, throttle_residency_spl) - 260usize];
+    ["Offset of field: AmdsmiApuMetricsT::throttle_residency_fppt"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, throttle_residency_fppt) - 264usize];
+    ["Offset of field: AmdsmiApuMetricsT::throttle_residency_sppt"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, throttle_residency_sppt) - 268usize];
+    ["Offset of field: AmdsmiApuMetricsT::throttle_residency_thm_core"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, throttle_residency_thm_core) - 272usize];
+    ["Offset of field: AmdsmiApuMetricsT::throttle_residency_thm_gfx"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, throttle_residency_thm_gfx) - 276usize];
+    ["Offset of field: AmdsmiApuMetricsT::throttle_residency_thm_soc"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, throttle_residency_thm_soc) - 280usize];
+    ["Offset of field: AmdsmiApuMetricsT::fan_pwm"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, fan_pwm) - 284usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_temperature_gfx"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_temperature_gfx) - 286usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_temperature_soc"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_temperature_soc) - 288usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_temperature_core"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_temperature_core) - 290usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_temperature_l3"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_temperature_l3) - 322usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_cpu_voltage"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_cpu_voltage) - 326usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_soc_voltage"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_soc_voltage) - 328usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_gfx_voltage"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_gfx_voltage) - 330usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_cpu_current"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_cpu_current) - 332usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_soc_current"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_soc_current) - 334usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_gfx_current"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_gfx_current) - 336usize];
+    ["Offset of field: AmdsmiApuMetricsT::time_filter_alphavalue"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, time_filter_alphavalue) - 340usize];
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2610,10 +2968,16 @@ pub struct AmdsmiGpuMetricsT {
     pub pcie_lc_perf_other_end_recovery: u32,
     pub vram_max_bandwidth: u64,
     pub xgmi_link_status: [u16; 8usize],
+    pub temperature_hbm_stacks: [u16; 12usize],
+    pub temperature_mid: [u16; 2usize],
+    pub temperature_aid: [u16; 2usize],
+    pub current_uclk_aid: [u16; 2usize],
+    pub current_socclks_mid: [u16; 2usize],
+    pub apu_metrics: *mut AmdsmiApuMetricsT,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of AmdsmiGpuMetricsT"][::std::mem::size_of::<AmdsmiGpuMetricsT>() - 4544usize];
+    ["Size of AmdsmiGpuMetricsT"][::std::mem::size_of::<AmdsmiGpuMetricsT>() - 4720usize];
     ["Alignment of AmdsmiGpuMetricsT"][::std::mem::align_of::<AmdsmiGpuMetricsT>() - 8usize];
     ["Offset of field: AmdsmiGpuMetricsT::common_header"]
         [::std::mem::offset_of!(AmdsmiGpuMetricsT, common_header) - 0usize];
@@ -2748,11 +3112,23 @@ const _: () = {
     ["Offset of field: AmdsmiGpuMetricsT::xcp_stats"]
         [::std::mem::offset_of!(AmdsmiGpuMetricsT, xcp_stats) - 480usize];
     ["Offset of field: AmdsmiGpuMetricsT::pcie_lc_perf_other_end_recovery"]
-        [::std::mem::offset_of!(AmdsmiGpuMetricsT, pcie_lc_perf_other_end_recovery) - 4512usize];
+        [::std::mem::offset_of!(AmdsmiGpuMetricsT, pcie_lc_perf_other_end_recovery) - 4640usize];
     ["Offset of field: AmdsmiGpuMetricsT::vram_max_bandwidth"]
-        [::std::mem::offset_of!(AmdsmiGpuMetricsT, vram_max_bandwidth) - 4520usize];
+        [::std::mem::offset_of!(AmdsmiGpuMetricsT, vram_max_bandwidth) - 4648usize];
     ["Offset of field: AmdsmiGpuMetricsT::xgmi_link_status"]
-        [::std::mem::offset_of!(AmdsmiGpuMetricsT, xgmi_link_status) - 4528usize];
+        [::std::mem::offset_of!(AmdsmiGpuMetricsT, xgmi_link_status) - 4656usize];
+    ["Offset of field: AmdsmiGpuMetricsT::temperature_hbm_stacks"]
+        [::std::mem::offset_of!(AmdsmiGpuMetricsT, temperature_hbm_stacks) - 4672usize];
+    ["Offset of field: AmdsmiGpuMetricsT::temperature_mid"]
+        [::std::mem::offset_of!(AmdsmiGpuMetricsT, temperature_mid) - 4696usize];
+    ["Offset of field: AmdsmiGpuMetricsT::temperature_aid"]
+        [::std::mem::offset_of!(AmdsmiGpuMetricsT, temperature_aid) - 4700usize];
+    ["Offset of field: AmdsmiGpuMetricsT::current_uclk_aid"]
+        [::std::mem::offset_of!(AmdsmiGpuMetricsT, current_uclk_aid) - 4704usize];
+    ["Offset of field: AmdsmiGpuMetricsT::current_socclks_mid"]
+        [::std::mem::offset_of!(AmdsmiGpuMetricsT, current_socclks_mid) - 4708usize];
+    ["Offset of field: AmdsmiGpuMetricsT::apu_metrics"]
+        [::std::mem::offset_of!(AmdsmiGpuMetricsT, apu_metrics) - 4712usize];
 };
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -3367,7 +3743,31 @@ extern "C" {
 extern "C" {
     pub fn amdsmi_get_processor_type(
         processor_handle: AmdsmiProcessorHandle,
-        processor_type: *mut ProcessorTypeT,
+        processor_type: *mut AmdsmiProcessorTypeT,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_get_processor_info(
+        processor_handle: AmdsmiProcessorHandle,
+        len: usize,
+        name: *mut ::std::os::raw::c_char,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_get_processor_count_from_handles(
+        processor_handles: *mut AmdsmiProcessorHandle,
+        processor_count: *mut u32,
+        nr_cpusockets: *mut u32,
+        nr_cpucores: *mut u32,
+        nr_gpus: *mut u32,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_get_processor_handles_by_type(
+        socket_handle: AmdsmiSocketHandle,
+        processor_type: AmdsmiProcessorTypeT,
+        processor_handles: *mut AmdsmiProcessorHandle,
+        processor_count: *mut u32,
     ) -> AmdsmiStatusT;
 }
 extern "C" {
@@ -3851,6 +4251,272 @@ extern "C" {
 }
 extern "C" {
     pub fn amdsmi_clean_gpu_local_data(processor_handle: AmdsmiProcessorHandle) -> AmdsmiStatusT;
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum AmdsmiFabricTelemetryCategoryT {
+    AmdsmiFabricTelemetryCategoryUnknown = 4294967295,
+    AmdsmiFabricTelemetryCategoryUaloe = 0,
+    AmdsmiFabricTelemetryCategorySwitch = 1,
+    AmdsmiFabricTelemetryCategoryCrypto = 2,
+    AmdsmiFabricTelemetryCategoryPfc = 3,
+    AmdsmiFabricTelemetryCategoryNetport = 4,
+    AmdsmiFabricTelemetryCategoryDerivedUaloe = 5,
+    AmdsmiFabricTelemetryCategoryDerivedNetport = 6,
+    AmdsmiFabricTelemetryCategoryMax = 7,
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum AmdsmiFabricTelemetryCategoryMaskT {
+    AmdsmiFabricTelemetryCategoryMaskUaloe = 1,
+    AmdsmiFabricTelemetryCategoryMaskSwitch = 2,
+    AmdsmiFabricTelemetryCategoryMaskCrypto = 4,
+    AmdsmiFabricTelemetryCategoryMaskPfc = 8,
+    AmdsmiFabricTelemetryCategoryMaskNetport = 16,
+    AmdsmiFabricTelemetryCategoryMaskDerivedUaloe = 32,
+    AmdsmiFabricTelemetryCategoryMaskDerivedNetport = 64,
+    AmdsmiFabricTelemetryCategoryMaskAllKnown = 127,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricTelemetryItemT {
+    pub id: u64,
+    pub value: u64,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricTelemetryItemT"]
+        [::std::mem::size_of::<AmdsmiFabricTelemetryItemT>() - 16usize];
+    ["Alignment of AmdsmiFabricTelemetryItemT"]
+        [::std::mem::align_of::<AmdsmiFabricTelemetryItemT>() - 8usize];
+    ["Offset of field: AmdsmiFabricTelemetryItemT::id"]
+        [::std::mem::offset_of!(AmdsmiFabricTelemetryItemT, id) - 0usize];
+    ["Offset of field: AmdsmiFabricTelemetryItemT::value"]
+        [::std::mem::offset_of!(AmdsmiFabricTelemetryItemT, value) - 8usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricLabelT {
+    pub text: [::std::os::raw::c_char; 32usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricLabelT"][::std::mem::size_of::<AmdsmiFabricLabelT>() - 32usize];
+    ["Alignment of AmdsmiFabricLabelT"][::std::mem::align_of::<AmdsmiFabricLabelT>() - 1usize];
+    ["Offset of field: AmdsmiFabricLabelT::text"]
+        [::std::mem::offset_of!(AmdsmiFabricLabelT, text) - 0usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricTelemetryInstanceT {
+    pub name: AmdsmiFabricLabelT,
+    pub logical_idx: ::std::os::raw::c_uint,
+    pub item_count: ::std::os::raw::c_uint,
+    pub items: *mut AmdsmiFabricTelemetryItemT,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricTelemetryInstanceT"]
+        [::std::mem::size_of::<AmdsmiFabricTelemetryInstanceT>() - 48usize];
+    ["Alignment of AmdsmiFabricTelemetryInstanceT"]
+        [::std::mem::align_of::<AmdsmiFabricTelemetryInstanceT>() - 8usize];
+    ["Offset of field: AmdsmiFabricTelemetryInstanceT::name"]
+        [::std::mem::offset_of!(AmdsmiFabricTelemetryInstanceT, name) - 0usize];
+    ["Offset of field: AmdsmiFabricTelemetryInstanceT::logical_idx"]
+        [::std::mem::offset_of!(AmdsmiFabricTelemetryInstanceT, logical_idx) - 32usize];
+    ["Offset of field: AmdsmiFabricTelemetryInstanceT::item_count"]
+        [::std::mem::offset_of!(AmdsmiFabricTelemetryInstanceT, item_count) - 36usize];
+    ["Offset of field: AmdsmiFabricTelemetryInstanceT::items"]
+        [::std::mem::offset_of!(AmdsmiFabricTelemetryInstanceT, items) - 40usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricTelemetryDatasetT {
+    pub category: AmdsmiFabricTelemetryCategoryT,
+    pub generation_count: u64,
+    pub timestamp: timespec,
+    pub instance_count: ::std::os::raw::c_uint,
+    pub instances: *mut AmdsmiFabricTelemetryInstanceT,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricTelemetryDatasetT"]
+        [::std::mem::size_of::<AmdsmiFabricTelemetryDatasetT>() - 48usize];
+    ["Alignment of AmdsmiFabricTelemetryDatasetT"]
+        [::std::mem::align_of::<AmdsmiFabricTelemetryDatasetT>() - 8usize];
+    ["Offset of field: AmdsmiFabricTelemetryDatasetT::category"]
+        [::std::mem::offset_of!(AmdsmiFabricTelemetryDatasetT, category) - 0usize];
+    ["Offset of field: AmdsmiFabricTelemetryDatasetT::generation_count"]
+        [::std::mem::offset_of!(AmdsmiFabricTelemetryDatasetT, generation_count) - 8usize];
+    ["Offset of field: AmdsmiFabricTelemetryDatasetT::timestamp"]
+        [::std::mem::offset_of!(AmdsmiFabricTelemetryDatasetT, timestamp) - 16usize];
+    ["Offset of field: AmdsmiFabricTelemetryDatasetT::instance_count"]
+        [::std::mem::offset_of!(AmdsmiFabricTelemetryDatasetT, instance_count) - 32usize];
+    ["Offset of field: AmdsmiFabricTelemetryDatasetT::instances"]
+        [::std::mem::offset_of!(AmdsmiFabricTelemetryDatasetT, instances) - 40usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricTelemetryT {
+    pub datasets: [*mut AmdsmiFabricTelemetryDatasetT; 7usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricTelemetryT"][::std::mem::size_of::<AmdsmiFabricTelemetryT>() - 56usize];
+    ["Alignment of AmdsmiFabricTelemetryT"]
+        [::std::mem::align_of::<AmdsmiFabricTelemetryT>() - 8usize];
+    ["Offset of field: AmdsmiFabricTelemetryT::datasets"]
+        [::std::mem::offset_of!(AmdsmiFabricTelemetryT, datasets) - 0usize];
+};
+extern "C" {
+    pub fn amdsmi_alloc_fabric_telemetry(
+        processor_handle: AmdsmiProcessorHandle,
+        category_mask: u32,
+        telemetry: *mut *mut AmdsmiFabricTelemetryT,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_get_fabric_telemetry_data(
+        processor_handle: AmdsmiProcessorHandle,
+        telemetry: *mut AmdsmiFabricTelemetryT,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_fabric_telem_id_to_string(telem_id: u64) -> *const ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn amdsmi_free_fabric_telemetry(
+        processor_handle: AmdsmiProcessorHandle,
+        telemetry: *mut AmdsmiFabricTelemetryT,
+    ) -> AmdsmiStatusT;
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum AmdsmiFabricSizeConstantsT {
+    AmdsmiFabricActiveAcceleratorsBitmapSize = 32,
+    AmdsmiFabricMaxLocalGpus = 8,
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum AmdsmiFabricTypeT {
+    AmdsmiFabricTypeUaloe = 0,
+    AmdsmiFabricTypeUallink = 1,
+    AmdsmiFabricTypeUnknown = 2,
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum AmdsmiFabricNpaAddressModeT {
+    AmdsmiFabricNpaAddressModeSourceAliasing = 0,
+    AmdsmiFabricNpaAddressModeSourceIdentification = 1,
+    AmdsmiFabricNpaAddressModeUnknown = 2,
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum AmdsmiFabricAcceleratorVpodStateT {
+    AmdsmiFabricAcceleratorVpodStateUnconfigured = 0,
+    AmdsmiFabricAcceleratorVpodStateConfigured = 1,
+    AmdsmiFabricAcceleratorVpodStateReady = 2,
+    AmdsmiFabricAcceleratorVpodStateActive = 3,
+    AmdsmiFabricAcceleratorVpodStateError = 4,
+    AmdsmiFabricAcceleratorVpodStateUnknown = 5,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiFabricInfoV1T {
+    pub accelerator_id: u32,
+    pub fabric_type: AmdsmiFabricTypeT,
+    pub bandwidth: u32,
+    pub latency: u32,
+    pub ppod_id: [u8; 16usize],
+    pub ppod_size: u32,
+    pub vpod_id: u32,
+    pub vpod_size: u32,
+    pub vpod_active_accelerators: [u32; 32usize],
+    pub local_accelerators: [u32; 8usize],
+    pub addr_mode: AmdsmiFabricNpaAddressModeT,
+    pub accel_state: AmdsmiFabricAcceleratorVpodStateT,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricInfoV1T"][::std::mem::size_of::<AmdsmiFabricInfoV1T>() - 212usize];
+    ["Alignment of AmdsmiFabricInfoV1T"][::std::mem::align_of::<AmdsmiFabricInfoV1T>() - 4usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::accelerator_id"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, accelerator_id) - 0usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::fabric_type"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, fabric_type) - 4usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::bandwidth"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, bandwidth) - 8usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::latency"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, latency) - 12usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::ppod_id"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, ppod_id) - 16usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::ppod_size"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, ppod_size) - 32usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::vpod_id"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, vpod_id) - 36usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::vpod_size"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, vpod_size) - 40usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::vpod_active_accelerators"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, vpod_active_accelerators) - 44usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::local_accelerators"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, local_accelerators) - 172usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::addr_mode"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, addr_mode) - 204usize];
+    ["Offset of field: AmdsmiFabricInfoV1T::accel_state"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoV1T, accel_state) - 208usize];
+};
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct AmdsmiFabricInfoVerT {
+    pub version: u32,
+    pub fabric_version: AmdsmiFabricInfoVerTFabricInfo,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union AmdsmiFabricInfoVerTFabricInfo {
+    pub v1: AmdsmiFabricInfoV1T,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricInfoVerTFabricInfo"]
+        [::std::mem::size_of::<AmdsmiFabricInfoVerTFabricInfo>() - 212usize];
+    ["Alignment of AmdsmiFabricInfoVerTFabricInfo"]
+        [::std::mem::align_of::<AmdsmiFabricInfoVerTFabricInfo>() - 4usize];
+    ["Offset of field: AmdsmiFabricInfoVerTFabricInfo::v1"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoVerTFabricInfo, v1) - 0usize];
+};
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricInfoVerT"][::std::mem::size_of::<AmdsmiFabricInfoVerT>() - 216usize];
+    ["Alignment of AmdsmiFabricInfoVerT"][::std::mem::align_of::<AmdsmiFabricInfoVerT>() - 4usize];
+    ["Offset of field: AmdsmiFabricInfoVerT::version"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoVerT, version) - 0usize];
+    ["Offset of field: AmdsmiFabricInfoVerT::fabric_version"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoVerT, fabric_version) - 4usize];
+};
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct AmdsmiFabricInfoT {
+    pub bdf: AmdsmiBdfT,
+    pub fabric_info: AmdsmiFabricInfoVerT,
+    pub reserved: [u32; 15usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiFabricInfoT"][::std::mem::size_of::<AmdsmiFabricInfoT>() - 288usize];
+    ["Alignment of AmdsmiFabricInfoT"][::std::mem::align_of::<AmdsmiFabricInfoT>() - 8usize];
+    ["Offset of field: AmdsmiFabricInfoT::bdf"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoT, bdf) - 0usize];
+    ["Offset of field: AmdsmiFabricInfoT::fabric_info"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoT, fabric_info) - 8usize];
+    ["Offset of field: AmdsmiFabricInfoT::reserved"]
+        [::std::mem::offset_of!(AmdsmiFabricInfoT, reserved) - 224usize];
+};
+extern "C" {
+    pub fn amdsmi_get_gpu_fabric_info(
+        processor_handle: AmdsmiProcessorHandle,
+        info: *mut AmdsmiFabricInfoT,
+    ) -> AmdsmiStatusT;
 }
 extern "C" {
     pub fn amdsmi_get_lib_version(version: *mut AmdsmiVersionT) -> AmdsmiStatusT;
@@ -4443,6 +5109,14 @@ extern "C" {
         processor_handle: AmdsmiProcessorHandle,
         max_processes: *mut u32,
         list: *mut AmdsmiProcInfoT,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_get_gpu_process_list_by_pid(
+        processor_handles: *mut AmdsmiProcessorHandle,
+        num_processors: u32,
+        procs: *mut AmdsmiProcInfoByPidT,
+        max_processes: *mut u32,
     ) -> AmdsmiStatusT;
 }
 extern "C" {

--- a/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
@@ -123,6 +123,10 @@ pub const AMDSMI_MAX_NUM_JPEG: u32 = 32;
 pub const AMDSMI_MAX_NUM_JPEG_ENG_V1: u32 = 40;
 pub const AMDSMI_MAX_NUM_XCC: u32 = 8;
 pub const AMDSMI_MAX_NUM_XCP: u32 = 8;
+pub const AMDSMI_APU_MAX_CORES: u32 = 16;
+pub const AMDSMI_APU_V24_CORES: u32 = 8;
+pub const AMDSMI_APU_MAX_L3: u32 = 2;
+pub const AMDSMI_APU_MAX_IPU: u32 = 8;
 pub const AMDSMI_MAX_VF_COUNT: u32 = 32;
 pub const AMDSMI_MAX_DRIVER_NUM: u32 = 2;
 pub const AMDSMI_DFC_FW_NUMBER_OF_ENTRIES: u32 = 9;
@@ -132,6 +136,11 @@ pub const AMDSMI_MAX_UUID_ELEMENTS: u32 = 16;
 pub const AMDSMI_MAX_TA_WHITE_LIST_ELEMENTS: u32 = 8;
 pub const AMDSMI_MAX_ERR_RECORDS: u32 = 10;
 pub const AMDSMI_MAX_PROFILE_COUNT: u32 = 16;
+pub const AMDSMI_MAX_NUM_HBM_STACKS: u32 = 12;
+pub const AMDSMI_MAX_NUM_AID: u32 = 2;
+pub const AMDSMI_MAX_NUM_MID: u32 = 2;
+pub const AMDSMI_MAX_NUM_CLKS_PER_AID: u32 = 2;
+pub const AMDSMI_MAX_NUM_CLKS_PER_MID: u32 = 2;
 pub const AMDSMI_TIME_FORMAT: &[u8; 20] = b"%02d:%02d:%02d.%03d\0";
 pub const AMDSMI_DATE_FORMAT: &[u8; 35] = b"%04d-%02d-%02d:%02d:%02d:%02d.%03d\0";
 pub const AMDSMI_LIB_VERSION_MAJOR: u32 = 26;
@@ -178,7 +187,7 @@ pub type AmdsmiSocketHandle = *mut ::std::os::raw::c_void;
 pub type AmdsmiNodeHandle = *mut ::std::os::raw::c_void;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum ProcessorTypeT {
+pub enum AmdsmiProcessorTypeT {
     AmdsmiProcessorTypeUnknown = 0,
     AmdsmiProcessorTypeAmdGpu = 1,
     AmdsmiProcessorTypeAmdCpu = 2,
@@ -1191,11 +1200,11 @@ pub struct AmdsmiAsicInfoT {
     pub target_graphics_version: u64,
     pub subsystem_id: u32,
     pub flags: u64,
-    pub reserved: [u32; 19usize],
+    pub reserved: [u32; 18usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of AmdsmiAsicInfoT"][::std::mem::size_of::<AmdsmiAsicInfoT>() - 904usize];
+    ["Size of AmdsmiAsicInfoT"][::std::mem::size_of::<AmdsmiAsicInfoT>() - 896usize];
     ["Alignment of AmdsmiAsicInfoT"][::std::mem::align_of::<AmdsmiAsicInfoT>() - 8usize];
     ["Offset of field: AmdsmiAsicInfoT::market_name"]
         [::std::mem::offset_of!(AmdsmiAsicInfoT, market_name) - 0usize];
@@ -2460,28 +2469,34 @@ const _: () = {
 pub struct AmdsmiOdVoltFreqDataT {
     pub curr_sclk_range: AmdsmiRangeT,
     pub curr_mclk_range: AmdsmiRangeT,
+    pub curr_fclk_range: AmdsmiRangeT,
     pub sclk_freq_limits: AmdsmiRangeT,
     pub mclk_freq_limits: AmdsmiRangeT,
+    pub fclk_freq_limits: AmdsmiRangeT,
     pub curve: AmdsmiOdVoltCurveT,
     pub num_regions: u32,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of AmdsmiOdVoltFreqDataT"][::std::mem::size_of::<AmdsmiOdVoltFreqDataT>() - 184usize];
+    ["Size of AmdsmiOdVoltFreqDataT"][::std::mem::size_of::<AmdsmiOdVoltFreqDataT>() - 248usize];
     ["Alignment of AmdsmiOdVoltFreqDataT"]
         [::std::mem::align_of::<AmdsmiOdVoltFreqDataT>() - 8usize];
     ["Offset of field: AmdsmiOdVoltFreqDataT::curr_sclk_range"]
         [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, curr_sclk_range) - 0usize];
     ["Offset of field: AmdsmiOdVoltFreqDataT::curr_mclk_range"]
         [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, curr_mclk_range) - 32usize];
+    ["Offset of field: AmdsmiOdVoltFreqDataT::curr_fclk_range"]
+        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, curr_fclk_range) - 64usize];
     ["Offset of field: AmdsmiOdVoltFreqDataT::sclk_freq_limits"]
-        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, sclk_freq_limits) - 64usize];
+        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, sclk_freq_limits) - 96usize];
     ["Offset of field: AmdsmiOdVoltFreqDataT::mclk_freq_limits"]
-        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, mclk_freq_limits) - 96usize];
+        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, mclk_freq_limits) - 128usize];
+    ["Offset of field: AmdsmiOdVoltFreqDataT::fclk_freq_limits"]
+        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, fclk_freq_limits) - 160usize];
     ["Offset of field: AmdsmiOdVoltFreqDataT::curve"]
-        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, curve) - 128usize];
+        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, curve) - 192usize];
     ["Offset of field: AmdsmiOdVoltFreqDataT::num_regions"]
-        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, num_regions) - 176usize];
+        [::std::mem::offset_of!(AmdsmiOdVoltFreqDataT, num_regions) - 240usize];
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2514,10 +2529,11 @@ pub struct AmdsmiGpuXcpMetricsT {
     pub gfx_below_host_limit_thm_acc: [u64; 8usize],
     pub gfx_low_utilization_acc: [u64; 8usize],
     pub gfx_below_host_limit_total_acc: [u64; 8usize],
+    pub temperature_xcd: [u16; 8usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of AmdsmiGpuXcpMetricsT"][::std::mem::size_of::<AmdsmiGpuXcpMetricsT>() - 504usize];
+    ["Size of AmdsmiGpuXcpMetricsT"][::std::mem::size_of::<AmdsmiGpuXcpMetricsT>() - 520usize];
     ["Alignment of AmdsmiGpuXcpMetricsT"][::std::mem::align_of::<AmdsmiGpuXcpMetricsT>() - 8usize];
     ["Offset of field: AmdsmiGpuXcpMetricsT::gfx_busy_inst"]
         [::std::mem::offset_of!(AmdsmiGpuXcpMetricsT, gfx_busy_inst) - 0usize];
@@ -2537,6 +2553,215 @@ const _: () = {
         [::std::mem::offset_of!(AmdsmiGpuXcpMetricsT, gfx_low_utilization_acc) - 376usize];
     ["Offset of field: AmdsmiGpuXcpMetricsT::gfx_below_host_limit_total_acc"]
         [::std::mem::offset_of!(AmdsmiGpuXcpMetricsT, gfx_below_host_limit_total_acc) - 440usize];
+    ["Offset of field: AmdsmiGpuXcpMetricsT::temperature_xcd"]
+        [::std::mem::offset_of!(AmdsmiGpuXcpMetricsT, temperature_xcd) - 504usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiApuMetricsT {
+    pub temperature_gfx: u16,
+    pub temperature_soc: u16,
+    pub temperature_core: [u16; 16usize],
+    pub temperature_l3: [u16; 2usize],
+    pub temperature_skin: u16,
+    pub average_gfx_activity: u16,
+    pub average_mm_activity: u16,
+    pub average_vcn_activity: u16,
+    pub average_ipu_activity: [u16; 8usize],
+    pub average_core_c0_activity: [u16; 16usize],
+    pub average_dram_reads: u16,
+    pub average_dram_writes: u16,
+    pub average_ipu_reads: u16,
+    pub average_ipu_writes: u16,
+    pub average_socket_power: u32,
+    pub average_cpu_power: u16,
+    pub average_soc_power: u16,
+    pub average_gfx_power: u32,
+    pub average_core_power: [u16; 16usize],
+    pub average_ipu_power: u16,
+    pub average_apu_power: u32,
+    pub average_dgpu_power: u32,
+    pub average_all_core_power: u32,
+    pub average_sys_power: u16,
+    pub stapm_power_limit: u16,
+    pub current_stapm_power_limit: u16,
+    pub average_gfxclk_frequency: u16,
+    pub average_socclk_frequency: u16,
+    pub average_uclk_frequency: u16,
+    pub average_fclk_frequency: u16,
+    pub average_vclk_frequency: u16,
+    pub average_dclk_frequency: u16,
+    pub average_vpeclk_frequency: u16,
+    pub average_ipuclk_frequency: u16,
+    pub average_mpipu_frequency: u16,
+    pub current_gfxclk: u16,
+    pub current_socclk: u16,
+    pub current_uclk: u16,
+    pub current_fclk: u16,
+    pub current_vclk: u16,
+    pub current_dclk: u16,
+    pub current_coreclk: [u16; 16usize],
+    pub current_l3clk: [u16; 2usize],
+    pub current_core_maxfreq: u16,
+    pub current_gfx_maxfreq: u16,
+    pub throttle_status: u32,
+    pub indep_throttle_status: u64,
+    pub throttle_residency_prochot: u32,
+    pub throttle_residency_spl: u32,
+    pub throttle_residency_fppt: u32,
+    pub throttle_residency_sppt: u32,
+    pub throttle_residency_thm_core: u32,
+    pub throttle_residency_thm_gfx: u32,
+    pub throttle_residency_thm_soc: u32,
+    pub fan_pwm: u16,
+    pub average_temperature_gfx: u16,
+    pub average_temperature_soc: u16,
+    pub average_temperature_core: [u16; 16usize],
+    pub average_temperature_l3: [u16; 2usize],
+    pub average_cpu_voltage: u16,
+    pub average_soc_voltage: u16,
+    pub average_gfx_voltage: u16,
+    pub average_cpu_current: u16,
+    pub average_soc_current: u16,
+    pub average_gfx_current: u16,
+    pub time_filter_alphavalue: u32,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiApuMetricsT"][::std::mem::size_of::<AmdsmiApuMetricsT>() - 344usize];
+    ["Alignment of AmdsmiApuMetricsT"][::std::mem::align_of::<AmdsmiApuMetricsT>() - 8usize];
+    ["Offset of field: AmdsmiApuMetricsT::temperature_gfx"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, temperature_gfx) - 0usize];
+    ["Offset of field: AmdsmiApuMetricsT::temperature_soc"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, temperature_soc) - 2usize];
+    ["Offset of field: AmdsmiApuMetricsT::temperature_core"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, temperature_core) - 4usize];
+    ["Offset of field: AmdsmiApuMetricsT::temperature_l3"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, temperature_l3) - 36usize];
+    ["Offset of field: AmdsmiApuMetricsT::temperature_skin"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, temperature_skin) - 40usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_gfx_activity"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_gfx_activity) - 42usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_mm_activity"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_mm_activity) - 44usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_vcn_activity"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_vcn_activity) - 46usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_ipu_activity"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_ipu_activity) - 48usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_core_c0_activity"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_core_c0_activity) - 64usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_dram_reads"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_dram_reads) - 96usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_dram_writes"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_dram_writes) - 98usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_ipu_reads"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_ipu_reads) - 100usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_ipu_writes"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_ipu_writes) - 102usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_socket_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_socket_power) - 104usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_cpu_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_cpu_power) - 108usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_soc_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_soc_power) - 110usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_gfx_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_gfx_power) - 112usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_core_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_core_power) - 116usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_ipu_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_ipu_power) - 148usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_apu_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_apu_power) - 152usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_dgpu_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_dgpu_power) - 156usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_all_core_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_all_core_power) - 160usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_sys_power"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_sys_power) - 164usize];
+    ["Offset of field: AmdsmiApuMetricsT::stapm_power_limit"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, stapm_power_limit) - 166usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_stapm_power_limit"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_stapm_power_limit) - 168usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_gfxclk_frequency"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_gfxclk_frequency) - 170usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_socclk_frequency"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_socclk_frequency) - 172usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_uclk_frequency"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_uclk_frequency) - 174usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_fclk_frequency"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_fclk_frequency) - 176usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_vclk_frequency"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_vclk_frequency) - 178usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_dclk_frequency"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_dclk_frequency) - 180usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_vpeclk_frequency"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_vpeclk_frequency) - 182usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_ipuclk_frequency"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_ipuclk_frequency) - 184usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_mpipu_frequency"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_mpipu_frequency) - 186usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_gfxclk"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_gfxclk) - 188usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_socclk"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_socclk) - 190usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_uclk"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_uclk) - 192usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_fclk"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_fclk) - 194usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_vclk"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_vclk) - 196usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_dclk"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_dclk) - 198usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_coreclk"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_coreclk) - 200usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_l3clk"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_l3clk) - 232usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_core_maxfreq"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_core_maxfreq) - 236usize];
+    ["Offset of field: AmdsmiApuMetricsT::current_gfx_maxfreq"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, current_gfx_maxfreq) - 238usize];
+    ["Offset of field: AmdsmiApuMetricsT::throttle_status"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, throttle_status) - 240usize];
+    ["Offset of field: AmdsmiApuMetricsT::indep_throttle_status"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, indep_throttle_status) - 248usize];
+    ["Offset of field: AmdsmiApuMetricsT::throttle_residency_prochot"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, throttle_residency_prochot) - 256usize];
+    ["Offset of field: AmdsmiApuMetricsT::throttle_residency_spl"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, throttle_residency_spl) - 260usize];
+    ["Offset of field: AmdsmiApuMetricsT::throttle_residency_fppt"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, throttle_residency_fppt) - 264usize];
+    ["Offset of field: AmdsmiApuMetricsT::throttle_residency_sppt"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, throttle_residency_sppt) - 268usize];
+    ["Offset of field: AmdsmiApuMetricsT::throttle_residency_thm_core"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, throttle_residency_thm_core) - 272usize];
+    ["Offset of field: AmdsmiApuMetricsT::throttle_residency_thm_gfx"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, throttle_residency_thm_gfx) - 276usize];
+    ["Offset of field: AmdsmiApuMetricsT::throttle_residency_thm_soc"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, throttle_residency_thm_soc) - 280usize];
+    ["Offset of field: AmdsmiApuMetricsT::fan_pwm"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, fan_pwm) - 284usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_temperature_gfx"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_temperature_gfx) - 286usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_temperature_soc"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_temperature_soc) - 288usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_temperature_core"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_temperature_core) - 290usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_temperature_l3"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_temperature_l3) - 322usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_cpu_voltage"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_cpu_voltage) - 326usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_soc_voltage"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_soc_voltage) - 328usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_gfx_voltage"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_gfx_voltage) - 330usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_cpu_current"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_cpu_current) - 332usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_soc_current"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_soc_current) - 334usize];
+    ["Offset of field: AmdsmiApuMetricsT::average_gfx_current"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, average_gfx_current) - 336usize];
+    ["Offset of field: AmdsmiApuMetricsT::time_filter_alphavalue"]
+        [::std::mem::offset_of!(AmdsmiApuMetricsT, time_filter_alphavalue) - 340usize];
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2610,10 +2835,16 @@ pub struct AmdsmiGpuMetricsT {
     pub pcie_lc_perf_other_end_recovery: u32,
     pub vram_max_bandwidth: u64,
     pub xgmi_link_status: [u16; 8usize],
+    pub temperature_hbm_stacks: [u16; 12usize],
+    pub temperature_mid: [u16; 2usize],
+    pub temperature_aid: [u16; 2usize],
+    pub current_uclk_aid: [u16; 2usize],
+    pub current_socclks_mid: [u16; 2usize],
+    pub apu_metrics: *mut AmdsmiApuMetricsT,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of AmdsmiGpuMetricsT"][::std::mem::size_of::<AmdsmiGpuMetricsT>() - 4544usize];
+    ["Size of AmdsmiGpuMetricsT"][::std::mem::size_of::<AmdsmiGpuMetricsT>() - 4720usize];
     ["Alignment of AmdsmiGpuMetricsT"][::std::mem::align_of::<AmdsmiGpuMetricsT>() - 8usize];
     ["Offset of field: AmdsmiGpuMetricsT::common_header"]
         [::std::mem::offset_of!(AmdsmiGpuMetricsT, common_header) - 0usize];
@@ -2748,11 +2979,23 @@ const _: () = {
     ["Offset of field: AmdsmiGpuMetricsT::xcp_stats"]
         [::std::mem::offset_of!(AmdsmiGpuMetricsT, xcp_stats) - 480usize];
     ["Offset of field: AmdsmiGpuMetricsT::pcie_lc_perf_other_end_recovery"]
-        [::std::mem::offset_of!(AmdsmiGpuMetricsT, pcie_lc_perf_other_end_recovery) - 4512usize];
+        [::std::mem::offset_of!(AmdsmiGpuMetricsT, pcie_lc_perf_other_end_recovery) - 4640usize];
     ["Offset of field: AmdsmiGpuMetricsT::vram_max_bandwidth"]
-        [::std::mem::offset_of!(AmdsmiGpuMetricsT, vram_max_bandwidth) - 4520usize];
+        [::std::mem::offset_of!(AmdsmiGpuMetricsT, vram_max_bandwidth) - 4648usize];
     ["Offset of field: AmdsmiGpuMetricsT::xgmi_link_status"]
-        [::std::mem::offset_of!(AmdsmiGpuMetricsT, xgmi_link_status) - 4528usize];
+        [::std::mem::offset_of!(AmdsmiGpuMetricsT, xgmi_link_status) - 4656usize];
+    ["Offset of field: AmdsmiGpuMetricsT::temperature_hbm_stacks"]
+        [::std::mem::offset_of!(AmdsmiGpuMetricsT, temperature_hbm_stacks) - 4672usize];
+    ["Offset of field: AmdsmiGpuMetricsT::temperature_mid"]
+        [::std::mem::offset_of!(AmdsmiGpuMetricsT, temperature_mid) - 4696usize];
+    ["Offset of field: AmdsmiGpuMetricsT::temperature_aid"]
+        [::std::mem::offset_of!(AmdsmiGpuMetricsT, temperature_aid) - 4700usize];
+    ["Offset of field: AmdsmiGpuMetricsT::current_uclk_aid"]
+        [::std::mem::offset_of!(AmdsmiGpuMetricsT, current_uclk_aid) - 4704usize];
+    ["Offset of field: AmdsmiGpuMetricsT::current_socclks_mid"]
+        [::std::mem::offset_of!(AmdsmiGpuMetricsT, current_socclks_mid) - 4708usize];
+    ["Offset of field: AmdsmiGpuMetricsT::apu_metrics"]
+        [::std::mem::offset_of!(AmdsmiGpuMetricsT, apu_metrics) - 4712usize];
 };
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -3367,7 +3610,31 @@ extern "C" {
 extern "C" {
     pub fn amdsmi_get_processor_type(
         processor_handle: AmdsmiProcessorHandle,
-        processor_type: *mut ProcessorTypeT,
+        processor_type: *mut AmdsmiProcessorTypeT,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_get_processor_info(
+        processor_handle: AmdsmiProcessorHandle,
+        len: usize,
+        name: *mut ::std::os::raw::c_char,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_get_processor_count_from_handles(
+        processor_handles: *mut AmdsmiProcessorHandle,
+        processor_count: *mut u32,
+        nr_cpusockets: *mut u32,
+        nr_cpucores: *mut u32,
+        nr_gpus: *mut u32,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_get_processor_handles_by_type(
+        socket_handle: AmdsmiSocketHandle,
+        processor_type: AmdsmiProcessorTypeT,
+        processor_handles: *mut AmdsmiProcessorHandle,
+        processor_count: *mut u32,
     ) -> AmdsmiStatusT;
 }
 extern "C" {

--- a/projects/amdsmi/rust-interface/src/utils.rs
+++ b/projects/amdsmi/rust-interface/src/utils.rs
@@ -30,7 +30,7 @@ pub use crate::amdsmi_wrapper::{
     AmdsmiInitFlagsT, AmdsmiLinkTypeT, AmdsmiMemoryPartitionTypeT, AmdsmiMemoryTypeT,
     AmdsmiPowerProfilePresetMasksT, AmdsmiRasErrStateT, AmdsmiStatusT,
     AmdsmiTemperatureMetricT, AmdsmiTemperatureTypeT, AmdsmiUtilizationCounterTypeT,
-    AmdsmiVoltageMetricT, AmdsmiVoltageTypeT, AmdsmiXgmiStatusT, ProcessorTypeT, AmdsmiAcceleratorPartitionTypeT
+    AmdsmiVoltageMetricT, AmdsmiVoltageTypeT, AmdsmiXgmiStatusT, AmdsmiProcessorTypeT, AmdsmiAcceleratorPartitionTypeT
 };
 
 // Re-export all the struct type

--- a/projects/amdsmi/tools/generator.py
+++ b/projects/amdsmi/tools/generator.py
@@ -391,6 +391,10 @@ amdsmi_free_name_value_pairs.argtypes = [ctypes.POINTER(None)]"""
                     new_line = new_line.replace(str_replace, str_with)
                     output_file_array[index] = new_line
 
+        # trim last newline - avoids pre-commit hook error
+        if output_file_array[-1] == "":
+            output_file_array = output_file_array[:-1]
+
         write_file(output_file, output_file_array)
 
 


### PR DESCRIPTION
## Motivation

Rust wrapper got out of date, to the point where wrapper updater script wasn't enough.
Had to fix `ProcessorTypeT -> AmdsmiProcessorTypeT`.