### PR TITLE
rocr: Make Agent::VisitRegion a virtual function

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/agent.h
@@ -251,6 +251,21 @@ class Agent : public Checked<0xF6BC25EB17E6F917> {
     return HSA_STATUS_ERROR;
   }
 
+  /// @brief Invoke the user provided callback for each region accessible by
+  /// this agent.
+  ///
+  /// @param[in] include_peer If true, the callback will be also invoked on
+  /// each peer memory region accessible by this agent. If false, only invoke
+  /// the callback on memory region owned by this agent.
+  /// @param[in] callback User provided callback function.
+  /// @param[in] data User provided pointer as input for @p callback.
+  ///
+  /// @retval ::HSA_STATUS_SUCCESS if the callback function for each traversed
+  /// region returns ::HSA_STATUS_SUCCESS.
+  virtual hsa_status_t VisitRegion(bool include_peer,
+                                   hsa_status_t (*callback)(hsa_region_t region, void* data),
+                                   void* data) const = 0;
+
   // @brief Invoke the user provided callback for each region accessible by
   // this agent.
   //

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aie_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aie_agent.h
@@ -51,6 +51,7 @@
 namespace rocr {
 namespace AMD {
 
+/// @brief Class to represent an AIE device.
 class AieAgent : public core::Agent {
 public:
  /// @brief AIE agent constructor.
@@ -62,7 +63,7 @@ public:
 
  hsa_status_t VisitRegion(bool include_peer,
                           hsa_status_t (*callback)(hsa_region_t region, void* data),
-                          void* data) const;
+                          void* data) const override;
  hsa_status_t IterateRegion(hsa_status_t (*callback)(hsa_region_t region, void* data),
                             void* data) const override;
 
@@ -74,7 +75,6 @@ public:
 
  hsa_status_t GetInfo(hsa_agent_info_t attribute, void* value) const override;
 
- // @brief Override from core::Agent.
  void InitDerivedCuid() override;
 
  hsa_status_t QueueCreate(size_t size, hsa_queue_type32_t queue_type, uint64_t flags,
@@ -83,7 +83,6 @@ public:
                           bool metadata_queue,
                           core::Queue** queue) override;
 
- /// @brief Override from core::Agent.
  const std::vector<const core::Isa*>& supported_isas() const override { return supported_isas_; }
 
  const std::vector<std::shared_ptr<const core::MemoryRegion>>& regions() const override { return regions_; }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_cpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_cpu_agent.h
@@ -70,21 +70,10 @@ class CpuAgent : public core::Agent {
   // @brief CpuAgent destructor.
   ~CpuAgent();
 
-  // @brief Invoke the user provided callback for each region accessible by
-  // this agent.
-  //
-  // @param [in] include_peer If true, the callback will be also invoked on each
-  // peer memory region accessible by this agent. If false, only invoke the
-  // callback on memory region owned by this agent.
-  // @param [in] callback User provided callback function.
-  // @param [in] data User provided pointer as input for @p callback.
-  //
-  // @retval ::HSA_STATUS_SUCCESS if the callback function for each traversed
-  // region returns ::HSA_STATUS_SUCCESS.
+  // @brief Override from core::Agent.
   hsa_status_t VisitRegion(bool include_peer,
-                           hsa_status_t (*callback)(hsa_region_t region,
-                                                    void* data),
-                           void* data) const;
+                           hsa_status_t (*callback)(hsa_region_t region, void* data),
+                           void* data) const override;
 
   // @brief Override from core::Agent.
   hsa_status_t IterateRegion(hsa_status_t (*callback)(hsa_region_t region,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -93,22 +93,6 @@ class GpuAgentInt : public core::Agent {
 
    virtual void ReleaseResources() = 0;
 
-   // @brief Invoke the user provided callback for each region accessible by
-   // this agent.
-   //
-   // @param [in] include_peer If true, the callback will be also invoked on
-   // each peer memory region accessible by this agent. If false, only invoke
-   // the callback on memory region owned by this agent.
-   // @param [in] callback User provided callback function.
-   // @param [in] data User provided pointer as input for @p callback.
-   //
-   // @retval ::HSA_STATUS_SUCCESS if the callback function for each traversed
-   // region returns ::HSA_STATUS_SUCCESS.
-   virtual hsa_status_t
-   VisitRegion(bool include_peer,
-               hsa_status_t (*callback)(hsa_region_t region, void *data),
-               void *data) const = 0;
-
    // @brief Carve scratch memory for main from scratch pool.
    //
    // @param [in,out] scratch Structure to be populated with the carved memory
@@ -786,7 +770,7 @@ class GpuAgent : public GpuAgentInt {
   // @brief Initialize scratch handler thresholds
   void InitAsyncScratchThresholds();
 
-  // @brief Initialize Secondary CUID for GPU device that 
+  // @brief Initialize Secondary CUID for GPU device that
   // this agent is running on.
   void InitDerivedCuid() override;
 


### PR DESCRIPTION
## Motivation

All agents implement `core::Agent::VisitRegion` but it was only virtual in a subclass.

## Technical Details

Make `core::Agent::VisitRegion` a pure virtual function.

## JIRA ID

NA

## Test Plan

./rocrtst64

## Test Result

Success.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
