### PR TITLE
[DCGPUSDV-4011] Fix for "sudo amd-smi ras --cper --json" command not returning valid json format

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -12263,9 +12263,17 @@ class AMDSMICommands:
 
             print()
 
+        is_json = self.logger.is_json_format()
         while True:
+            all_json_rows = []
             for idx, device_handle in enumerate(args.gpu):
-                self.helpers.ras_cper(args, device_handle, self.logger, idx)
+                rows = self.helpers.ras_cper(
+                    args, device_handle, self.logger, idx, emit_json=not is_json
+                )
+                all_json_rows.extend(rows)
+            if is_json and all_json_rows:
+                self.logger.multiple_device_output = all_json_rows
+                self.logger.print_output(multiple_device_enabled=True)
             if not args.follow:
                 break
             time.sleep(1)


### PR DESCRIPTION
Motivation
Fix amd-smi ras --cper --json outputting separate JSON arrays per GPU instead of a single unified array. Also fix --follow mode printing empty [] every second when no new entries exist.

Technical Details
Modified the ras_cper call loop in [amdsmi_commands.py](vscode-file://vscode-app/c:/Users/yalmusaf/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html). When JSON format is active, per-GPU JSON emission is suppressed (emit_json=False), rows are collected from all GPUs, and a single consolidated JSON array is printed. Empty iterations in --follow mode are skipped.

JIRA ID
[https://ontrack-internal.amd.com/browse/DCGPUSDV-4010](vscode-file://vscode-app/c:/Users/yalmusaf/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Test Plan
Manual verification with sudo amd-smi ras --cper --json (multi-GPU) and sudo amd-smi ras --cper --follow --json.

Test Result
Single unified JSON array output across all GPUs; no empty [] output during --follow idle periods.

<img width="326" height="477" alt="image" src="https://github.com/user-attachments/assets/b584115f-6b36-41be-b418-41fb6e3d8b0f" />

<img width="327" height="491" alt="image" src="https://github.com/user-attachments/assets/7610e656-5a74-42ca-823f-4ce2d543298f" />

<img width="325" height="128" alt="image" src="https://github.com/user-attachments/assets/7cb31528-0b22-433d-a071-529efc327701" />


Submission Checklist
 Pre-commit passes
 Single commit, signed-off
