### PR TITLE
AIRUNTIME-2209: Fix APU non-local memory accounting

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/impl/wddm/device.h
+++ b/projects/rocr-runtime/libhsakmt/include/impl/wddm/device.h
@@ -88,8 +88,16 @@ enum class SegmentKind {
 struct SegmentInfo {
   uint32_t segment_id;
   SegmentKind kind;
+  // Raw segment flags — kind collapses aperture+system_memory into kAperture,
+  // so preserve the source bits to identify non-local-heap segments later.
+  bool is_aperture;
+  bool is_system_memory;
 
-  SegmentInfo() : segment_id(0), kind(SegmentKind::kUnknown) {}
+  SegmentInfo()
+      : segment_id(0),
+        kind(SegmentKind::kUnknown),
+        is_aperture(false),
+        is_system_memory(false) {}
 };
 
 class WDDMDevice {

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -152,6 +152,8 @@ bool WDDMDevice::QuerySegmentInfo()
 
     SegmentInfo info;
     info.segment_id = i;
+    info.is_aperture = !!seg.Aperture;
+    info.is_system_memory = !!seg.SegmentProperties.SystemMemory;
 
     if (seg.Aperture) {
       info.kind = SegmentKind::kAperture;
@@ -239,19 +241,41 @@ hsa_status_t WDDMDevice::VramAvail(uint64_t* available_bytes) {
 
     *available_bytes = LocalHeapSize() - usedVis - usedInv;
   } else {
-    // APU - NonLocal memory
-    if (!FindSegmentId(SegmentKind::kSystemMemory, &segmentId))
+    // APU: the shared-system-memory budget is exposed as aperture segments
+    // with the SystemMemory bit set (collapsed to kAperture above), so
+    // FindSegmentId(kSystemMemory) always missed. Sum BytesResident across
+    // every aperture+system_memory segment for the residency footprint.
+    const uint64_t budget = NonLocalHeapSize();
+    if (budget == 0) {
+      // No budget from WKMI — bail rather than underflow VramAvail.
       return HSA_STATUS_ERROR;
+    }
 
-    memset(&stats, 0, sizeof(D3DKMT_QUERYSTATISTICS));
-    stats.Type = D3DKMT_QUERYSTATISTICS_SEGMENT;
-    stats.AdapterLuid = adapter_luid_;
-    stats.QuerySegment.SegmentId = segmentId;
-    ret = DXCORE_CALL(D3DKMTQueryStatistics(&stats));
-    if (ret == 0)
-      usedNonLocal = stats.QueryResult.SegmentInformation.BytesResident;
+    bool found_any = false;
+    for (const auto& seg_info : segment_infos_) {
+      if (!seg_info.is_aperture || !seg_info.is_system_memory) {
+        continue;
+      }
+      found_any = true;
 
-    *available_bytes = NonLocalHeapSize() - usedNonLocal;
+      memset(&stats, 0, sizeof(D3DKMT_QUERYSTATISTICS));
+      stats.Type = D3DKMT_QUERYSTATISTICS_SEGMENT;
+      stats.AdapterLuid = adapter_luid_;
+      stats.QuerySegment.SegmentId = seg_info.segment_id;
+      ret = DXCORE_CALL(D3DKMTQueryStatistics(&stats));
+      if (ret != 0) {
+        continue;
+      }
+      usedNonLocal += stats.QueryResult.SegmentInformation.BytesResident;
+    }
+
+    if (!found_any) {
+      return HSA_STATUS_ERROR;
+    }
+
+    // Virtual apertures can double-count residency — saturate at zero
+    // instead of underflowing.
+    *available_bytes = (usedNonLocal >= budget) ? 0 : (budget - usedNonLocal);
   }
 
   return HSA_STATUS_SUCCESS;


### PR DESCRIPTION
## Motivation

On APU/iGPU, `hsaKmtAvailableMemory` failed with `HSA_STATUS_ERROR` (or returned a wrong value) because `WDDMDevice::QuerySegmentInfo` collapses aperture+system-memory segments into `kAperture`, causing the legacy `FindSegmentId(kSystemMemory, ...)` lookup in `VramAvail` to always miss.

## Technical Details

- Preserve raw `is_aperture` and `is_system_memory` bits on `SegmentInfo` since `kind` collapses both into `kAperture`.
- Rewrite the APU branch of `VramAvail` to sum `BytesResident` across every aperture+system-memory segment and subtract from `NonLocalHeapSize()` (populated by WKMI via `KMTQAITYPE_GETSEGMENTSIZE::SharedSystemMemorySize`).
- Saturate at zero when overlapping virtual apertures over-count, and return `HSA_STATUS_ERROR` if the budget is zero or no matching segment exists.

## JIRA ID

- AIRUNTIME-2209

## Test Plan

Run `hipInfo.exe` on a Windows iGPU.

## Test Result

`hipMemGetInfo` succeeds and reports valid values.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
