### PR TITLE
[rocjitsu] Fix v_bfe_u32/v_bfe_i32 codegen regression

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
@@ -1278,11 +1278,12 @@ _INLINE_TERNARY_OPS: dict[str, str] = {
     'mad_i24': '[&]() {{ auto a = static_cast<int32_t>({0} << 8) >> 8;'
                ' auto b = static_cast<int32_t>({1} << 8) >> 8;'
                ' return static_cast<uint32_t>(a * b + static_cast<int32_t>({2})); }}()',
-    'bfe_u': '[&]() {{ auto src={0}; auto off_w={1}; (void){2};'
-             ' uint32_t off = off_w & 31u; uint32_t w = (off_w >> 16) & 0x7Fu;'
-             ' return w == 0 ? 0u : (src >> off) & ((1u << w) - 1u); }}()',
-    'bfe_i': '[&]() -> uint32_t {{ auto src=static_cast<int32_t>({0}); auto off_w={1}; (void){2};'
-             ' uint32_t off = off_w & 31u; uint32_t w = (off_w >> 16) & 0x7Fu;'
+    'bfe_u': '[&]() {{ uint32_t src={0}; uint32_t off={1} & 31u; uint32_t w={2} & 31u;'
+             ' if (w == 0) return 0u;'
+             ' uint32_t mask = (w >= 32) ? ~0u : ((1u << w) - 1u);'
+             ' return (src >> off) & mask; }}()',
+    'bfe_i': '[&]() -> uint32_t {{ int32_t src=static_cast<int32_t>({0});'
+             ' uint32_t off={1} & 31u; uint32_t w={2} & 31u;'
              ' if (w == 0) return 0u; int32_t val = (src >> off) & ((1 << w) - 1);'
              ' if (val & (1 << (w-1))) val |= -(1 << w);'
              ' return static_cast<uint32_t>(val); }}()',

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
@@ -4030,12 +4030,13 @@ void VBfeU32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     vdst.write_lane(wf, lane, [&]() {
-      auto src = src0.read_lane(wf, lane);
-      auto off_w = src1.read_lane(wf, lane);
-      (void)src2.read_lane(wf, lane);
-      uint32_t off = off_w & 31u;
-      uint32_t w = (off_w >> 16) & 0x7Fu;
-      return w == 0 ? 0u : (src >> off) & ((1u << w) - 1u);
+      uint32_t src = src0.read_lane(wf, lane);
+      uint32_t off = src1.read_lane(wf, lane) & 31u;
+      uint32_t w = src2.read_lane(wf, lane) & 31u;
+      if (w == 0)
+        return 0u;
+      uint32_t mask = (w >= 32) ? ~0u : ((1u << w) - 1u);
+      return (src >> off) & mask;
     }());
   }
 }
@@ -4060,11 +4061,9 @@ void VBfeI32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     vdst.write_lane(wf, lane, [&]() -> uint32_t {
-      auto src = static_cast<int32_t>(static_cast<int32_t>(src0.read_lane(wf, lane)));
-      auto off_w = static_cast<int32_t>(src1.read_lane(wf, lane));
-      (void)static_cast<int32_t>(src2.read_lane(wf, lane));
-      uint32_t off = off_w & 31u;
-      uint32_t w = (off_w >> 16) & 0x7Fu;
+      int32_t src = static_cast<int32_t>(static_cast<int32_t>(src0.read_lane(wf, lane)));
+      uint32_t off = static_cast<int32_t>(src1.read_lane(wf, lane)) & 31u;
+      uint32_t w = static_cast<int32_t>(src2.read_lane(wf, lane)) & 31u;
       if (w == 0)
         return 0u;
       int32_t val = (src >> off) & ((1 << w) - 1);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -2570,11 +2570,9 @@ inline void execute_v_bfe_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane(wf, lane, [&]() -> uint32_t {
-      auto src = static_cast<int32_t>(static_cast<int32_t>(inst.src0.read_lane(wf, lane)));
-      auto off_w = static_cast<int32_t>(inst.src1.read_lane(wf, lane));
-      (void)static_cast<int32_t>(inst.src2.read_lane(wf, lane));
-      uint32_t off = off_w & 31u;
-      uint32_t w = (off_w >> 16) & 0x7Fu;
+      int32_t src = static_cast<int32_t>(static_cast<int32_t>(inst.src0.read_lane(wf, lane)));
+      uint32_t off = static_cast<int32_t>(inst.src1.read_lane(wf, lane)) & 31u;
+      uint32_t w = static_cast<int32_t>(inst.src2.read_lane(wf, lane)) & 31u;
       if (w == 0)
         return 0u;
       int32_t val = (src >> off) & ((1 << w) - 1);
@@ -2592,12 +2590,13 @@ inline void execute_v_bfe_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane(wf, lane, [&]() {
-      auto src = inst.src0.read_lane(wf, lane);
-      auto off_w = inst.src1.read_lane(wf, lane);
-      (void)inst.src2.read_lane(wf, lane);
-      uint32_t off = off_w & 31u;
-      uint32_t w = (off_w >> 16) & 0x7Fu;
-      return w == 0 ? 0u : (src >> off) & ((1u << w) - 1u);
+      uint32_t src = inst.src0.read_lane(wf, lane);
+      uint32_t off = inst.src1.read_lane(wf, lane) & 31u;
+      uint32_t w = inst.src2.read_lane(wf, lane) & 31u;
+      if (w == 0)
+        return 0u;
+      uint32_t mask = (w >= 32) ? ~0u : ((1u << w) - 1u);
+      return (src >> off) & mask;
     }());
   }
 }

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -311,6 +311,9 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
         message(STATUS "rocBLAS GEMM test disabled (librocblas not found)")
     endif()
 
+    rj_add_hip_test(hip_bfe_2d_test)
+    rj_add_hip_test_case(hip_bfe_2d_test "BfeRegressionTest.ThreadIdxY")
+
     message(STATUS "HIP tests enabled (found ${HIPCC_EXECUTABLE})")
 else()
     message(STATUS "HIP tests disabled (hipcc or libhsa-runtime64 not found)")

--- a/emulation/rocjitsu/tests/hip_bfe_2d_test.cpp
+++ b/emulation/rocjitsu/tests/hip_bfe_2d_test.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// Regression test for v_bfe_u32 (vector bit-field extract).
+// A 2D HIP grid uses v_bfe_u32 to extract threadIdx.y from the packed
+// thread-ID register. If v_bfe_u32 is broken, threadIdx.y is always 0
+// and only half the output is written.
+
+#include <hip/hip_runtime.h>
+#include <unistd.h>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  int rc = RUN_ALL_TESTS();
+  (void)hipDeviceReset();
+  _exit(rc);
+}
+
+#define HIP_ASSERT(call)                                                                           \
+  do {                                                                                             \
+    hipError_t err = (call);                                                                       \
+    ASSERT_EQ(err, hipSuccess) << "HIP error: " << hipGetErrorString(err);                         \
+  } while (0)
+
+__global__ void write_thread_y(int *out) { out[threadIdx.y] = threadIdx.y; }
+
+TEST(BfeRegressionTest, ThreadIdxY) {
+  constexpr int N = 4;
+
+  int *d_out = nullptr;
+  HIP_ASSERT(hipMalloc(&d_out, N * sizeof(int)));
+  HIP_ASSERT(hipMemset(d_out, -1, N * sizeof(int)));
+
+  dim3 block(1, N);
+  dim3 grid(1, 1);
+  write_thread_y<<<grid, block>>>(d_out);
+  HIP_ASSERT(hipDeviceSynchronize());
+
+  std::vector<int> h(N);
+  HIP_ASSERT(hipMemcpy(h.data(), d_out, N * sizeof(int), hipMemcpyDeviceToHost));
+
+  for (int i = 0; i < N; ++i)
+    EXPECT_EQ(h[i], i);
+
+  (void)hipFree(d_out);
+}


### PR DESCRIPTION
Commit https://github.com/ROCm/rocm-systems/commit/2063c2bd387ba9bbe47cd8c7f8227a6a20dd9971 ("rocjitsu: Refactor AMDISA codegen (https://github.com/ROCm/rocm-systems/pull/5942)") introduced
a regression in the vector bit-field extract (v_bfe_u32 / v_bfe_i32) code
generation. The codegen templates in sema_lower.py incorrectly packed
offset and width from a single source operand (src1), matching the scalar
s_bfe encoding, but the vector v_bfe instructions take offset and width as
separate src1/src2 operands. src2 was read and discarded with (void).

This caused v_bfe_u32 to always return 0 when width was passed as a
separate operand (the common case), breaking any kernel using 2D or 3D
thread blocks — threadIdx.y extraction via `v_bfe_u32 v1, v0, 10, 10`
always yielded 0.

Fix:
- sema_lower.py: Fix 'bfe_u' and 'bfe_i' templates to read offset from
  {1} (src1) and width from {2} (src2) as separate operands.
- Regenerated C++ output via:
    python3 -m amdisa --multi ... --gen-isas --isa-output ...
    bash scripts/clang_format.sh
  Only execute_shared.h and rdna4/vop3.cpp differ after regen + format.

Test:
- Add hip_bfe_2d_test.cpp: launches a 2D HIP grid (dim3 block(1,4),
  dim3 grid(1,1)) and verifies all threadIdx.y values are correct.
  Fails without the fix, passes with it.
