### PR TITLE
[clr] Load file-backed code objects via hsa_ven_amd_loader from_file_…

### DIFF
--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -41,7 +41,7 @@ kpack_cache_t getHipKpackCache() {
 #endif
 
 FatBinaryInfo::FatBinaryInfo(const char* fname, const void* image)
-    : foffset_(0), image_(image), image_mapped_(false), uri_(std::string()) {
+    : foffset_(0), image_(image), image_size_(0), image_mapped_(false), uri_(std::string()) {
   if (fname != nullptr) {
     fname_ = std::string(fname);
   } else {
@@ -81,20 +81,14 @@ FatBinaryInfo::~FatBinaryInfo() {
 }
 
 void FatBinaryInfo::ReleaseImageAndFile() {
-  // Release image_ and ufd_
-  if (ufd_) {
-    if (image_mapped_ && !amd::Os::MemoryUnmapFile(image_, ufd_->fsize_)) {
+  if (image_mapped_) {
+    if (!amd::Os::MemoryUnmapFile(image_, image_size_)) {
       guarantee(false, "Cannot unmap the file");
     }
-
-    if (!PlatformState::Instance().CloseUniqueFileHandle(ufd_)) {
-      guarantee(false, "Cannot close file for fdesc: %d", ufd_->fdesc_);
-    }
-
-    ufd_ = nullptr;
     image_ = nullptr;
-    uri_ = std::string();
+    image_size_ = 0;
     image_mapped_ = false;
+    uri_ = std::string();
   }
 }
 
@@ -403,29 +397,33 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
     return hipErrorInvalidValue;
   }
 
+  // The source-file fd, when one is opened. AddDevProgram dups it for each
+  // file-backed handoff; the original is closed on every exit from this
+  // function so the open-fd burden does not grow with the number of loaded
+  // modules.
+  amd::Os::FileDesc fdesc = amd::Os::FDescInit();
+  auto fdesc_guard = std::shared_ptr<void>(nullptr, [&fdesc](void*) {
+    if (fdesc != amd::Os::FDescInit()) amd::Os::CloseFileHandle(fdesc);
+  });
+
   if (image_ != nullptr) {
     if (!amd::Os::FindFileNameFromAddress(image_, &fname_, &foffset_)) {
       fname_ = std::string("");
       foffset_ = 0;
     }
   } else {
-    ufd_ = PlatformState::Instance().GetUniqueFileHandle(fname_.c_str());
-    if (ufd_ == nullptr) {
+    size_t fsize = 0;
+    if (!amd::Os::GetFileHandle(fname_.c_str(), &fdesc, &fsize)) {
       return hipErrorFileNotFound;
     }
-
-    // If the file name exists but the file size is 0, the something wrong with the file or its path
-    if (ufd_->fsize_ == 0) {
+    if (fsize == 0) {
       return hipErrorInvalidImage;
     }
-
-    // If image_ is nullptr, then file path is passed via hipMod* APIs, so map the file.
-    if (!amd::Os::MemoryMapFileDesc(ufd_->fdesc_, ufd_->fsize_, foffset_, &image_)) {
+    if (!amd::Os::MemoryMapFileDesc(fdesc, fsize, foffset_, &image_)) {
       LogError("Cannot map the file descriptor");
-      PlatformState::Instance().CloseUniqueFileHandle(ufd_);
       return hipErrorInvalidValue;
     }
-
+    image_size_ = fsize;
     image_mapped_ = true;
   }
   guarantee(image_ != nullptr, "Image cannot be nullptr, file:%s did not map for some reason",
@@ -440,7 +438,8 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
       // Load the binary directly
       auto elf_size = amd::Elf::getElfSize(image_);
       for (auto* device : devices) {
-        if (hipSuccess != AddDevProgram(device, image_, elf_size, 0)) return hipErrorInvalidImage;
+        if (hipSuccess != AddDevProgram(device, image_, elf_size, fdesc))
+          return hipErrorInvalidImage;
       }
       return hipSuccess;  // We are done since it was already ELF
     } else {
@@ -494,12 +493,14 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
 
       // If the size is not 0, that means we found the native isa code object
       if (native_co != code_obj_map.end() && !HIP_FORCE_SPIRV_CODEOBJECT) {
-        hip_status = AddDevProgram(device, native_co->second.first, native_co->second.second, 0);
+        hip_status =
+            AddDevProgram(device, native_co->second.first, native_co->second.second, fdesc);
         if (hip_status != hipSuccess) {
           break;
         }
       } else if (generic_co != code_obj_map.end() && !HIP_FORCE_SPIRV_CODEOBJECT) {
-        hip_status = AddDevProgram(device, generic_co->second.first, generic_co->second.second, 0);
+        hip_status =
+            AddDevProgram(device, generic_co->second.first, generic_co->second.second, fdesc);
         if (hip_status != hipSuccess) {
           break;
         }
@@ -632,7 +633,7 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
           break;
         }
 
-        hip_status = AddDevProgram(device, co, co_size, 0);
+        hip_status = AddDevProgram(device, co, co_size, fdesc);
         if (hip_status != hipSuccess) {
           break;
         }
@@ -710,9 +711,11 @@ hipError_t FatBinaryInfo::ExtractKpackBinary(const std::vector<hip::Device*>& de
     return hipErrorInvalidImage;
   }
 
-  // Add code object to all devices
+  // Add code object to all devices. The kpack buffer isn't backed by a file
+  // on disk, so no fd is passed.
   for (auto device : devices) {
-    hipError_t hip_err = AddDevProgram(device, code_object, code_object_size, 0);
+    hipError_t hip_err =
+        AddDevProgram(device, code_object, code_object_size, amd::Os::FDescInit());
     if (hip_err != hipSuccess) {
       kpack_free_code_object(code_object);
       return hip_err;
@@ -727,7 +730,7 @@ hipError_t FatBinaryInfo::ExtractKpackBinary(const std::vector<hip::Device*>& de
 }
 
 hipError_t FatBinaryInfo::AddDevProgram(hip::Device* device, const void* binary_image,
-                                        size_t binary_size, size_t binary_offset) {
+                                        size_t binary_size, amd::Os::FileDesc fdesc) {
   int devID = device->deviceId();
   amd::Context* ctx = device->asContext();
   amd::Program* program = new amd::Program(*ctx);
@@ -735,10 +738,28 @@ hipError_t FatBinaryInfo::AddDevProgram(hip::Device* device, const void* binary_
   if (program == nullptr) {
     return hipErrorOutOfMemory;
   }
+
+  // The binary is file-backed (sub-region of image_) only when:
+  //   - the caller passed an open fd for the source file,
+  //   - the FatBinaryInfo did mmap that file as image_, and
+  //   - the binary is not one of the freshly allocated buffers (compressed
+  //     bundle, SPIRV->native, kpack) tracked in code_obj_allocations_.
+  // In that case we dup the fd so the downstream setKernels owns and closes
+  // its own copy.
+  amd::Os::FileDesc out_fdesc = amd::Os::FDescInit();
+  size_t out_foffset = 0;
+  const bool is_file_backed = fdesc != amd::Os::FDescInit() && image_mapped_ &&
+                              code_obj_allocations_.count(binary_image) == 0;
+  if (is_file_backed) {
+    out_fdesc = amd::Os::DupFileHandle(fdesc);
+    out_foffset = static_cast<size_t>(reinterpret_cast<const char*>(binary_image) -
+                                      reinterpret_cast<const char*>(image_));
+  }
+
   if (CL_SUCCESS !=
       program->addDeviceProgram(*ctx->devices()[0], binary_image, binary_size, false, nullptr,
-                                nullptr, (ufd_ != nullptr ? ufd_->fdesc_ : amd::Os::FDescInit()),
-                                binary_offset, uri_)) {
+                                nullptr, out_fdesc, out_foffset, uri_)) {
+    if (out_fdesc != amd::Os::FDescInit()) amd::Os::CloseFileHandle(out_fdesc);
     return hipErrorInvalidKernelFile;
   }
   return hipSuccess;

--- a/projects/clr/hipamd/src/hip_fatbin.hpp
+++ b/projects/clr/hipamd/src/hip_fatbin.hpp
@@ -14,9 +14,6 @@
 
 #include <optional>
 
-// Forward declaration for Unique FD
-struct UniqueFD;
-
 namespace hip {
 
 // Fat Binary Info
@@ -37,7 +34,7 @@ class FatBinaryInfo {
   hipError_t ExtractFatBinaryUsingCOMGR(const std::vector<hip::Device*>& devices);
   hipError_t ExtractKpackBinary(const std::vector<hip::Device*>& devices);
   hipError_t AddDevProgram(hip::Device* device, const void* binary_image, size_t binary_size,
-                           size_t binary_offset);
+                           amd::Os::FileDesc fdesc);
   hipError_t BuildProgram(const int device_id);
 
   // Device Id bounds check
@@ -73,8 +70,10 @@ class FatBinaryInfo {
   std::string fname_;  //!< File name
   size_t foffset_;     //!< File Offset where the fat binary is present.
 
-  // Even when file is passed image will be mmapped till ~desctructor.
+  // When loaded from a file, image_ is the mmap address; fd is closed once
+  // ExtractFatBinaryUsingCOMGR has dup'd it for every per-device handoff.
   const void* image_;  //!< Image
+  size_t image_size_;  //!< Mapped image size (only valid when image_mapped_ is true)
   bool image_mapped_;  //!< flag to detect if image is mapped
 
   // Only used for FBs where image is directly passed
@@ -85,7 +84,6 @@ class FatBinaryInfo {
 
   std::vector<amd::Program*> dev_programs_;  //!< Program info per Device
 
-  std::shared_ptr<UniqueFD> ufd_;                         //!< Unique file descriptor
   std::recursive_mutex fb_lock_;                          //!< Lock for the fat binary access
   std::unordered_set<const void*> code_obj_allocations_;  //!< Track allocations for code objects
 };

--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -1214,41 +1214,6 @@ void PlatformState::PopExec(ihipExec_t& exec) {
 }
 
 // ================================================================================================
-std::shared_ptr<UniqueFD> PlatformState::GetUniqueFileHandle(const std::string& file_path) {
-  std::scoped_lock lock(ufd_lock_);
-
-  auto it = ufd_map_.find(file_path);
-  if (it != ufd_map_.end()) {
-    return it->second;
-  }
-
-  // Get the file desc and file size from amd::Os API
-  amd::Os::FileDesc fdesc;
-  size_t fsize = 0;
-  if (!amd::Os::GetFileHandle(file_path.c_str(), &fdesc, &fsize)) {
-    return nullptr;
-  }
-  
-  auto ufd = std::make_shared<UniqueFD>(file_path, fdesc, fsize);
-  ufd_map_.emplace(file_path, ufd);
-  return ufd;
-}
-
-// ================================================================================================
-bool PlatformState::CloseUniqueFileHandle(const std::shared_ptr<UniqueFD>& ufd) {
-  std::scoped_lock lock(ufd_lock_);
-
-  // if use_count is 2, then there is 1 entry in the map and the current entry is the last close.
-  if (ufd.use_count() == 2) {
-    ufd_map_.erase(ufd->fpath_);
-    if (!amd::Os::CloseFileHandle(ufd->fdesc_)) {
-      return false;
-    }
-  }
-  return true;
-}
-
-// ================================================================================================
 void* PlatformState::GetDynamicLibraryHandle() {
   std::scoped_lock lock(lock_);
 

--- a/projects/clr/hipamd/src/hip_platform.hpp
+++ b/projects/clr/hipamd/src/hip_platform.hpp
@@ -18,16 +18,6 @@ hipError_t ihipOccupancyMaxActiveBlocksPerMultiprocessor(
     hipFunction_t func, int inputBlockSize, size_t dynamicSMemSize, bool bCalcPotentialBlkSz);
 }  // namespace hip_impl
 
-// Unique file descriptor class
-struct UniqueFD {
-  UniqueFD(const std::string& fpath, amd::Os::FileDesc fdesc, size_t fsize)
-      : fpath_(fpath), fdesc_(fdesc), fsize_(fsize) {}
-
-  const std::string fpath_;        //!< File path of this unique file
-  const amd::Os::FileDesc fdesc_;  //!< File Descriptor
-  const size_t fsize_;             //!< File Size
-};
-
 namespace hip {
 class PlatformState {
  public:
@@ -66,9 +56,6 @@ class PlatformState {
   void ConfigureCall(dim3 gridDim, dim3 blockDim, size_t sharedMem, hipStream_t stream);
   void PopExec(ihipExec_t& exec);
 
-  std::shared_ptr<UniqueFD> GetUniqueFileHandle(const std::string& file_path);
-  bool CloseUniqueFileHandle(const std::shared_ptr<UniqueFD>& ufd);
-
   // Logging lock accessor
   std::recursive_mutex& GetLogLock() { return lg_lock_; }
 
@@ -105,7 +92,6 @@ class PlatformState {
   ~PlatformState() {}
 
   std::recursive_mutex lock_;       //!< Guards PlatformState globals
-  std::recursive_mutex ufd_lock_;   //!< Unique FD Store Lock
   std::recursive_mutex lg_lock_;    //!< Lock for logging operations
   static PlatformState* platform_;  //!< Singleton instance
 
@@ -115,8 +101,6 @@ class PlatformState {
   bool initialized_{false};         //!< Platform initialization state
   //! Texture reference map: texRef -> (module, name)
   std::unordered_map<textureReference*, std::pair<hipModule_t, std::string>> texRef_map_;
-  //! Unique File Descriptor Map
-  std::unordered_map<std::string, std::shared_ptr<UniqueFD>> ufd_map_;
   void* dynamicLibraryHandle_{nullptr};  //!< Handle to dynamic library
   //! Library function map: kernel -> library
   std::unordered_map<hipKernel_t, hipLibrary_t> library_functions_;

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -350,7 +350,7 @@ hsa_status_t Device::iterateAgentCallback(hsa_agent_t agent, void* data) {
   return stat;
 }
 
-hsa_ven_amd_loader_1_00_pfn_t Device::amd_loader_ext_table = {nullptr};
+hsa_ven_amd_loader_1_03_pfn_t Device::amd_loader_ext_table = {nullptr};
 
 hsa_status_t Device::loaderQueryHostAddress(const void* device, const void** host) {
   return amd_loader_ext_table.hsa_ven_amd_loader_query_host_address

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -351,6 +351,11 @@ class Device : public NullDevice {
   static hsa_status_t iterateCpuMemoryPoolCallback(hsa_amd_memory_pool_t region, void* data);
   static hsa_status_t loaderQueryHostAddress(const void* device, const void** host);
 
+  //! Returns the AMD HSA loader extension function table.
+  static const hsa_ven_amd_loader_1_03_pfn_t& loaderExtensionTable() {
+    return amd_loader_ext_table;
+  }
+
   static bool loadHsaModules();
 
   hsa_agent_t getBackendDevice() const { return bkendDevice_; }
@@ -639,7 +644,7 @@ class Device : public NullDevice {
                            int numa_id = kDefaultNumaNode) const;
   static constexpr hsa_signal_value_t InitSignalValue = 1;
 
-  static hsa_ven_amd_loader_1_00_pfn_t amd_loader_ext_table;
+  static hsa_ven_amd_loader_1_03_pfn_t amd_loader_ext_table;
 
   std::recursive_mutex* mapCacheOps_;    //!< Lock to serialise cache for the map resources
   std::vector<amd::Memory*>* mapCache_;  //!< Map cache info structure

--- a/projects/clr/rocclr/device/rocm/rocprogram.cpp
+++ b/projects/clr/rocclr/device/rocm/rocprogram.cpp
@@ -239,7 +239,6 @@ bool Program::setKernels(void* binary, size_t binSize, amd::Os::FileDesc fdesc,
     return false;
   }
 
-#if !defined(_WIN32)
   // If we received a file descriptor, hand the code object's file region to
   // rocr via the vendor extension so it can mmap it itself (and resolve the
   // URI directly from the fd). Fall back to from_memory when the fd is
@@ -250,9 +249,7 @@ bool Program::setKernels(void* binary, size_t binSize, amd::Os::FileDesc fdesc,
           .hsa_ven_amd_loader_code_object_reader_create_from_file_with_offset_size;
   if (fdesc != amd::Os::FDescInit() && create_from_file != nullptr) {
     status = create_from_file(fdesc, foffset, binSize, &hsaCodeObjectReader_);
-  } else
-#endif // !defined(_WIN32)
-  {
+  } else {
     status = Hsa::code_object_reader_create_from_memory(binary, binSize, &hsaCodeObjectReader_);
   }
   if (fdesc != amd::Os::FDescInit()) {

--- a/projects/clr/rocclr/device/rocm/rocprogram.cpp
+++ b/projects/clr/rocclr/device/rocm/rocprogram.cpp
@@ -239,10 +239,25 @@ bool Program::setKernels(void* binary, size_t binSize, amd::Os::FileDesc fdesc,
     return false;
   }
 
-  // Load the code object, either with file descriptor and offset
-  // or binary image and binary size with URI
-  // or binary image and binary size
-  status = Hsa::code_object_reader_create_from_memory(binary, binSize, &hsaCodeObjectReader_);
+#if !defined(_WIN32)
+  // If we received a file descriptor, hand the code object's file region to
+  // rocr via the vendor extension so it can mmap it itself (and resolve the
+  // URI directly from the fd). Fall back to from_memory when the fd is
+  // invalid or the vendor extension isn't available in the linked rocr.
+  // The fd is owned by setKernels in all cases: closed before returning.
+  auto* create_from_file =
+      Device::loaderExtensionTable()
+          .hsa_ven_amd_loader_code_object_reader_create_from_file_with_offset_size;
+  if (fdesc != amd::Os::FDescInit() && create_from_file != nullptr) {
+    status = create_from_file(fdesc, foffset, binSize, &hsaCodeObjectReader_);
+  } else
+#endif // !defined(_WIN32)
+  {
+    status = Hsa::code_object_reader_create_from_memory(binary, binSize, &hsaCodeObjectReader_);
+  }
+  if (fdesc != amd::Os::FDescInit()) {
+    amd::Os::CloseFileHandle(fdesc);
+  }
   if (status != HSA_STATUS_SUCCESS) {
     buildLog_ += "Error: AMD HSA Code Object Reader create failed: ";
     buildLog_ += hsa_strerror(status);

--- a/projects/clr/rocclr/os/os.hpp
+++ b/projects/clr/rocclr/os/os.hpp
@@ -49,6 +49,8 @@ class Os : AllStatic {
 
   // Closes the file Handle
   static bool CloseFileHandle(FileDesc fdesc);
+  // Duplicates the file Handle. Returns FDescInit() on failure.
+  static FileDesc DupFileHandle(FileDesc fdesc);
   // Given a valid file name, returns file descriptor and file size
   static bool GetFileHandle(const char* fname, FileDesc* fd_ptr, size_t* sz_ptr);
 

--- a/projects/clr/rocclr/os/os_posix.cpp
+++ b/projects/clr/rocclr/os/os_posix.cpp
@@ -849,6 +849,10 @@ bool Os::CloseFileHandle(FileDesc fdesc) {
   return true;
 }
 
+amd::Os::FileDesc Os::DupFileHandle(FileDesc fdesc) {
+  return dup(fdesc);
+}
+
 bool Os::GetFileHandle(const char* fname, FileDesc* fd_ptr, size_t* sz_ptr) {
   if ((fd_ptr == nullptr) || (sz_ptr == nullptr)) {
     return false;

--- a/projects/clr/rocclr/os/os_win32.cpp
+++ b/projects/clr/rocclr/os/os_win32.cpp
@@ -561,6 +561,15 @@ bool Os::CloseFileHandle(FileDesc fdesc) {
   return true;
 }
 
+amd::Os::FileDesc Os::DupFileHandle(FileDesc fdesc) {
+  HANDLE out = nullptr;
+  if (!DuplicateHandle(GetCurrentProcess(), fdesc, GetCurrentProcess(), &out, 0, FALSE,
+                       DUPLICATE_SAME_ACCESS)) {
+    return FDescInit();
+  }
+  return out;
+}
+
 bool Os::GetFileHandle(const char* fname, FileDesc* fd_ptr, size_t* sz_ptr) {
   if ((fd_ptr == nullptr) || (sz_ptr == nullptr)) {
     return false;

--- a/projects/hip-tests/catch/config/configs/unit/module.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/module.yaml
@@ -159,6 +159,10 @@ module:
     # Below tests tests fail in PSDB
     disabled: [nvidia_windows]
     tags: [load]
+  Unit_hipModuleLoad_Positive_NoFdLeak:
+    <<: *level_2
+    disabled: [windows, nvidia_windows]
+    tags: [load]
   Unit_hipFuncSetSharedMemConfig_functional:
     <<: *level_2
     tags: [function]

--- a/projects/hip-tests/catch/unit/module/hipModuleLoad.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleLoad.cc
@@ -7,6 +7,61 @@
 #include <hip_test_common.hh>
 #include <hip/hip_runtime_api.h>
 
+#if defined(__linux__)
+#include <cstdlib>
+#include <dirent.h>
+
+static int CountOpenFds() {
+  DIR* d = opendir("/proc/self/fd");
+  REQUIRE(d != nullptr);
+  int dir_fd = dirfd(d);
+  int count = 0;
+  while (struct dirent* ent = readdir(d)) {
+    if (ent->d_name[0] == '.') continue;
+    int fd = atoi(ent->d_name);
+    if (fd == dir_fd) continue;
+    ++count;
+  }
+  closedir(d);
+  return count;
+}
+
+HIP_TEST_CASE(Unit_hipModuleLoad_Positive_NoFdLeak) {
+  HIP_CHECK(hipFree(nullptr));
+
+  {
+    hipModule_t warmup = nullptr;
+    HIP_CHECK(hipModuleLoad(&warmup, "empty_module.code"));
+    HIP_CHECK(hipModuleUnload(warmup));
+  }
+
+  const int baseline = CountOpenFds();
+
+  {
+    hipModule_t module = nullptr;
+    HIP_CHECK(hipModuleLoad(&module, "empty_module.code"));
+    REQUIRE(module != nullptr);
+    const int after_load = CountOpenFds();
+    INFO("Open FDs before load: " << baseline
+         << ", after load (before unload): " << after_load);
+    REQUIRE(after_load == baseline);
+    HIP_CHECK(hipModuleUnload(module));
+  }
+
+  constexpr int kIterations = 32;
+  for (int i = 0; i < kIterations; ++i) {
+    hipModule_t module = nullptr;
+    HIP_CHECK(hipModuleLoad(&module, "empty_module.code"));
+    REQUIRE(module != nullptr);
+    HIP_CHECK(hipModuleUnload(module));
+  }
+  const int after_cycles = CountOpenFds();
+  INFO("Open FDs before: " << baseline << ", after " << kIterations
+       << " load/unload cycles: " << after_cycles);
+  REQUIRE(after_cycles == baseline);
+}
+#endif
+
 HIP_TEST_CASE(Unit_hipModuleLoad_Positive_Basic) {
   HIP_CHECK(hipFree(nullptr));
   hipModule_t module = nullptr;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_hsa_loader.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_hsa_loader.hpp
@@ -151,6 +151,14 @@ struct CodeObjectReaderImpl final {
   size_t code_object_size{0};
   std::string uri{};
   bool is_mmap{false};
+#if defined(_WIN32) || defined(_WIN64)
+  // Bookkeeping for MapViewOfFile-backed mappings (file-backed code objects on
+  // Windows). map_base is the unadjusted pointer returned by MapViewOfFile and
+  // map_handle is the file-mapping HANDLE from CreateFileMappingW. Stored as
+  // void* so this header stays free of windows.h.
+  void *map_base{nullptr};
+  void *map_handle{nullptr};
+#endif
 };
 
 //===----------------------------------------------------------------------===//

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_hsa_loader.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_hsa_loader.cpp
@@ -50,6 +50,9 @@
 #include <linux/limits.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#elif defined(_WIN32) || defined(_WIN64)
+#include <windows.h>
+#include <cstdint>
 #else
 #include <cstdint>
 #endif
@@ -74,6 +77,39 @@ uintptr_t PAGE_SIZE_MASK{
   };
 #endif
 
+#if defined(_WIN32) || defined(_WIN64)
+// Convert a Win32 wide-character path into the UTF-8, forward-slash form used
+// in file:// URIs. Strips the \\?\ and \\?\UNC\ prefixes that
+// GetFinalPathNameByHandleW / GetMappedFileNameW may emit, and prepends a
+// leading '/' so the result composes into file:///C:/path/... (RFC 8089).
+// Returns an empty string on conversion failure.
+std::string NormalizeWindowsPathToUtf8(std::wstring wpath) {
+  if (wpath.compare(0, 8, L"\\\\?\\UNC\\") == 0) {
+    wpath = L"\\\\" + wpath.substr(8);  // \\?\UNC\srv\share -> \\srv\share
+  } else if (wpath.compare(0, 4, L"\\\\?\\") == 0) {
+    wpath.erase(0, 4);                  // \\?\C:\... -> C:\...
+  }
+
+  int u8len = WideCharToMultiByte(CP_UTF8, 0, wpath.data(),
+                                  static_cast<int>(wpath.size()),
+                                  nullptr, 0, nullptr, nullptr);
+  if (u8len <= 0) {
+    return {};
+  }
+  std::string path(static_cast<size_t>(u8len), '\0');
+  WideCharToMultiByte(CP_UTF8, 0, wpath.data(), static_cast<int>(wpath.size()),
+                      path.data(), u8len, nullptr, nullptr);
+
+  for (auto& c : path) {
+    if (c == '\\') c = '/';
+  }
+  if (!path.empty() && path.front() != '/') {
+    path.insert(path.begin(), '/');
+  }
+  return path;
+}
+#endif
+
 std::string EncodePathname(const char *file_path) {
   std::ostringstream ss;
   unsigned char c;
@@ -83,7 +119,8 @@ std::string EncodePathname(const char *file_path) {
 
   while ((c = *file_path++) != '\0') {
     if (isalnum(c) || c == '/' || c == '-' ||
-        c == '_' || c == '.' || c == '~') {
+        c == '_' || c == '.' || c == '~' ||
+	c == ':') {
       ss << c;
     } else {
       ss << std::uppercase;
@@ -105,7 +142,82 @@ std::string GetUriFromMemoryAddress(const void *memory, size_t size) {
 }
 
 std::string GetUriFromMemoryInExecutableFile(const void *memory, size_t size) {
-#if !defined(_WIN32) && !defined(_WIN64)
+#if defined(_WIN32) || defined(_WIN64)
+  // Find the loaded module (EXE or DLL) whose image contains `memory`.
+  // GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT avoids ref-counting the
+  // module so we don't have to FreeLibrary it.
+  HMODULE hModule = nullptr;
+  if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                              GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                          reinterpret_cast<LPCWSTR>(memory), &hModule) ||
+      hModule == nullptr) {
+    return GetUriFromMemoryAddress(memory, size);
+  }
+
+  // Walk the PE headers of the mapped image to translate the memory address
+  // into a file offset. hModule == ImageBase, so:
+  //   RVA          = memory - hModule
+  //   file_offset  = RVA - section.VirtualAddress + section.PointerToRawData
+  // for the section that covers the RVA.
+  auto* base = reinterpret_cast<const BYTE*>(hModule);
+  auto* dos = reinterpret_cast<const IMAGE_DOS_HEADER*>(base);
+  if (dos->e_magic != IMAGE_DOS_SIGNATURE) {
+    return GetUriFromMemoryAddress(memory, size);
+  }
+  auto* nt = reinterpret_cast<const IMAGE_NT_HEADERS*>(base + dos->e_lfanew);
+  if (nt->Signature != IMAGE_NT_SIGNATURE) {
+    return GetUriFromMemoryAddress(memory, size);
+  }
+  uintptr_t rva = reinterpret_cast<const BYTE*>(memory) - base;
+  const IMAGE_SECTION_HEADER* sections = IMAGE_FIRST_SECTION(nt);
+
+  size_t file_offset = 0;
+  bool found = false;
+  for (WORD i = 0; i < nt->FileHeader.NumberOfSections; ++i) {
+    const auto& s = sections[i];
+    DWORD vsize = s.Misc.VirtualSize ? s.Misc.VirtualSize : s.SizeOfRawData;
+    if (rva >= s.VirtualAddress && rva < s.VirtualAddress + vsize) {
+      // Sections with no backing on disk (e.g. .bss) can't yield a file URI.
+      if (s.PointerToRawData == 0) break;
+      file_offset = rva - s.VirtualAddress + s.PointerToRawData;
+      found = true;
+      break;
+    }
+  }
+  if (!found) {
+    return GetUriFromMemoryAddress(memory, size);
+  }
+
+  // Resolve the module's on-disk path. Grow the buffer if MAX_PATH overflows
+  // (long paths or DLLs loaded via \\?\ prefixed names).
+  std::wstring wpath(MAX_PATH, L'\0');
+  for (;;) {
+    DWORD n = GetModuleFileNameW(hModule, wpath.data(),
+                                 static_cast<DWORD>(wpath.size()));
+    if (n == 0) {
+      return GetUriFromMemoryAddress(memory, size);
+    }
+    if (n < wpath.size()) {
+      wpath.resize(n);
+      break;
+    }
+    if (wpath.size() >= 32768) {
+      return GetUriFromMemoryAddress(memory, size);
+    }
+    wpath.resize(wpath.size() * 2);
+  }
+
+  std::string path = NormalizeWindowsPathToUtf8(std::move(wpath));
+  if (path.empty()) {
+    return GetUriFromMemoryAddress(memory, size);
+  }
+
+  std::ostringstream uri_stream;
+  uri_stream << EncodePathname(path.c_str())
+             << "#offset=" << file_offset
+             << "&size=" << size;
+  return uri_stream.str();
+#else
   uintptr_t address = reinterpret_cast<uintptr_t>(memory);
   struct callback_data_s {
     ElfW(Addr) address;
@@ -232,9 +344,32 @@ std::string GetUriFromMemoryInMmapedFile(const void *memory, size_t size) {
   return GetUriFromMemoryAddress(memory, size);
 }
 
-std::string GetUriFromFile(int file_descriptor, size_t offset, size_t size,
+std::string GetUriFromFile(hsa_file_t file_descriptor, size_t offset, size_t size,
     bool is_complete_file, const void *memory) {
-#if !defined(_WIN32) && !defined(_WIN64)
+  std::string path;
+
+#if defined(_WIN32) || defined(_WIN64)
+  // Resolve the HANDLE to a filesystem path via GetFinalPathNameByHandleW.
+  // First call sizes the buffer (return value includes the terminating NUL
+  // when the supplied buffer is too small).
+  DWORD wlen = GetFinalPathNameByHandleW(file_descriptor, nullptr, 0,
+                                         FILE_NAME_NORMALIZED | VOLUME_NAME_DOS);
+  if (wlen == 0) {
+    return GetUriFromMemoryAddress(memory, size);
+  }
+  std::wstring wpath(wlen, L'\0');
+  DWORD got = GetFinalPathNameByHandleW(file_descriptor, wpath.data(), wlen,
+                                        FILE_NAME_NORMALIZED | VOLUME_NAME_DOS);
+  if (got == 0 || got >= wlen) {
+    return GetUriFromMemoryAddress(memory, size);
+  }
+  wpath.resize(got);  // drop the trailing NUL from std::wstring length
+
+  path = NormalizeWindowsPathToUtf8(std::move(wpath));
+  if (path.empty()) {
+    return GetUriFromMemoryAddress(memory, size);
+  }
+#else
   std::ostringstream proc_fd_path;
   proc_fd_path << "/proc/self/fd/" << file_descriptor;
 
@@ -244,21 +379,19 @@ std::string GetUriFromFile(int file_descriptor, size_t offset, size_t size,
   if (readlink(proc_fd_path.str().c_str(), uri_file_path, PATH_MAX) == -1) {
     return GetUriFromMemoryAddress(memory, size);
   }
-
   if (uri_file_path[0] == '\0') {
     return GetUriFromMemoryAddress(memory, size);
   }
+  path = uri_file_path;
+#endif
 
   std::ostringstream uri_stream;
-  uri_stream << EncodePathname(uri_file_path);
+  uri_stream << EncodePathname(path.c_str());
   if (!is_complete_file) {
     uri_stream << "#offset=" << offset;
     uri_stream << "&size=" << size;
   }
   return uri_stream.str();
-#else
-  return GetUriFromMemoryAddress(memory, size);
-#endif  // !defined(_WIN32) && !defined(_WIN64)
 }
 
 }  // namespace
@@ -277,7 +410,8 @@ CodeObjectReaderImpl::~CodeObjectReaderImpl() {
     size_t adjusted_size = code_object_size + (address - adjusted_address);
     munmap(reinterpret_cast<void *>(adjusted_address), adjusted_size);
 #else
-    delete [] code_object_memory;
+    if (map_base) UnmapViewOfFile(map_base);
+    if (map_handle) CloseHandle(static_cast<HANDLE>(map_handle));
 #endif  // !defined(_WIN32) && !defined(_WIN64)
   }
 }
@@ -288,6 +422,7 @@ hsa_status_t CodeObjectReaderImpl::SetFile(
     size_t _code_object_size) {
   assert(!code_object_memory && "Code object reader wrapper is already set");
 
+#if !defined(_WIN32) && !defined(_WIN64)
   if (_code_object_file_descriptor == -1) {
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }
@@ -304,7 +439,6 @@ hsa_status_t CodeObjectReaderImpl::SetFile(
   }
   bool is_complete_file = _code_object_offset == 0 && _code_object_size == file_size;
 
-#if !defined(_WIN32) && !defined(_WIN64)
   off_t adjusted_offset = _code_object_offset & PAGE_SIZE_MASK;
   size_t adjusted_size = _code_object_size + (_code_object_offset - adjusted_offset);
   void *memory = mmap(nullptr, adjusted_size, PROT_READ, MAP_PRIVATE,
@@ -316,12 +450,61 @@ hsa_status_t CodeObjectReaderImpl::SetFile(
                         (_code_object_offset & ~PAGE_SIZE_MASK);
   code_object_size = _code_object_size;
   is_mmap = true;
-#else
-  //@todo May need an implementation in Windows
-#endif  // !defined(_WIN32) && !defined(_WIN64)
 
   uri = GetUriFromFile(_code_object_file_descriptor, _code_object_offset,
                         _code_object_size, is_complete_file, code_object_memory);
+#else
+  if (_code_object_file_descriptor == INVALID_HANDLE_VALUE ||
+      _code_object_file_descriptor == nullptr) {
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+
+  LARGE_INTEGER file_size_li;
+  if (!GetFileSizeEx(_code_object_file_descriptor, &file_size_li)) {
+    return HSA_STATUS_ERROR_INVALID_FILE;
+  }
+  uint64_t file_size = static_cast<uint64_t>(file_size_li.QuadPart);
+  if (file_size <= _code_object_offset) {
+    return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
+  }
+  if (_code_object_size == 0) {
+    _code_object_size = static_cast<size_t>(file_size - _code_object_offset);
+  }
+  bool is_complete_file = _code_object_offset == 0 && _code_object_size == file_size;
+
+  // MapViewOfFile requires the file offset to be aligned to the system
+  // allocation granularity (typically 64 KiB on Windows), not page size.
+  SYSTEM_INFO si;
+  GetSystemInfo(&si);
+  uint64_t granularity = si.dwAllocationGranularity;
+  uint64_t aligned_offset = _code_object_offset & ~(granularity - 1);
+  size_t slop = static_cast<size_t>(_code_object_offset - aligned_offset);
+  size_t adjusted_size = _code_object_size + slop;
+
+  HANDLE mapping = CreateFileMappingW(_code_object_file_descriptor, nullptr,
+                                      PAGE_READONLY, 0, 0, nullptr);
+  if (mapping == nullptr) {
+    return HSA_STATUS_ERROR_INVALID_FILE;
+  }
+
+  void *base = MapViewOfFile(mapping, FILE_MAP_READ,
+                             static_cast<DWORD>(aligned_offset >> 32),
+                             static_cast<DWORD>(aligned_offset & 0xFFFFFFFFu),
+                             adjusted_size);
+  if (base == nullptr) {
+    CloseHandle(mapping);
+    return HSA_STATUS_ERROR_INVALID_FILE;
+  }
+
+  map_base = base;
+  map_handle = mapping;
+  code_object_memory = reinterpret_cast<unsigned char*>(base) + slop;
+  code_object_size = _code_object_size;
+  is_mmap = true;
+
+  uri = GetUriFromFile(_code_object_file_descriptor, _code_object_offset,
+                       _code_object_size, is_complete_file, code_object_memory);
+#endif  // !defined(_WIN32) && !defined(_WIN64)
 
   return HSA_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa.h
@@ -336,9 +336,15 @@ typedef enum {
 } hsa_access_permission_t;
 
 /**
- * @brief POSIX file descriptor.
+ * @brief OS file handle. A POSIX file descriptor on Unix-like systems, a Win32
+ * HANDLE (as returned by CreateFile) on Windows. Declared as void* on Windows
+ * to avoid pulling windows.h into the public header.
  */
+#if defined(_WIN32) || defined(_WIN64)
+typedef void* hsa_file_t;
+#else
 typedef int hsa_file_t;
+#endif
 
 /** @} **/
 


### PR DESCRIPTION
…with_offset_size

Have amd::roc::Program::setKernels hand rocr the file descriptor + offset/size for file-backed code objects via the AMD loader vendor extension, instead of always going through hsa_code_object_reader_create_from_memory. rocr now mmaps the per-ISA region itself and resolves the URI from the fd directly (single readlink on /proc/self/fd/N), avoiding the /proc/self/maps walk that the in-memory path triggers.

hipamd: localize the source-file fd to FatBinaryInfo::ExtractFatBinaryUsingCOMGR so it is closed before that function returns rather than held for the lifetime of the module. AddDevProgram dups the fd only for binaries that are actually sub-regions of the mmap'd image (raw ELF and uncompressed-bundle per-ISA slices), discriminating against fresh buffers (compressed-bundle items, SPIRV translations, kpack) via code_obj_allocations_. Each dup flows through addDeviceProgram -> ClBinary::fdesc_ -> setKernels, which closes it.

rocclr: upgrade Device::amd_loader_ext_table to hsa_ven_amd_loader_1_03_pfn_t and add a public loaderExtensionTable() accessor; falls back to from_memory when the older 1.00 rocr is loaded and leaves the new entry null.

PlatformState's UniqueFD dedup cache existed only to keep the fd alive for the module lifetime and is removed.