### PR TITLE
rccl: fix bf16 header conflict in CollCommon.h on ROCm 6.x

### DIFF
--- a/projects/rccl/src/include/algorithms/CollCommon.h
+++ b/projects/rccl/src/include/algorithms/CollCommon.h
@@ -13,11 +13,14 @@
 #include <type_traits>
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIP_PLATFORM_HCC__)
-#include <hip/hip_bfloat16.h>
+// Do NOT include <hip/hip_bfloat16.h> (the old header).  It defines
+// _HIP_BFLOAT16_H_ which conflicts with the RCCL bf16 workaround in
+// device.h on ROCm 6.x, causing a hard #error regardless of include order.
+// amd_hip_bf16.h already provides __hip_bfloat16 without touching those macros.
 #include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
 #include <hip/amd_detail/amd_hip_bf16.h>
-using bf16 = hip_bfloat16;
+using bf16 = __hip_bfloat16;
 #else
 #include <cuda.h>
 #include <cuda_bf16.h>


### PR DESCRIPTION
## Motivation

```
hsa-runtime64 found @  /opt/rocm/lib/cmake/hsa-runtime64 
/projects/math-ci/slurm-batch-submitter-1/workspace/_batch-codecoverage_rccl_PR-6024/run1/rccl/projects/rccl/build/debug/hipify/src/include/device.h:26:6: error: "RCCL is not using the correct hip_bf16.h file. Please make sure that the correct header is included!"
   26 |     #error "RCCL is not using the correct hip_bf16.h file. Please make sure that the correct header is included!"
      |      ^
1 error generated when compiling for gfx942.
make[2]: *** [src/CMakeFiles/device_linker_build.dir/build.make:85: device_build/dda_all_reduce_ipc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:357: src/CMakeFiles/device_linker_build.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```

## Technical Details

CollCommon.h included <hip/hip_bfloat16.h> (the old header) which defines _HIP_BFLOAT16_H_.  device.h uses this macro as a guard: on ROCm 6.x, if _HIP_BFLOAT16_H_ is already set when device.h is processed it triggers a hard #error, regardless of include order.

The old header was only needed to name the type 'hip_bfloat16' for 'using bf16 = hip_bfloat16'.  amd_hip_bf16.h (already included on the next line) provides __hip_bfloat16 without touching the guard macros, so it is safe to include in any order relative to device.h.

Fix:
- Remove #include <hip/hip_bfloat16.h>
- Change 'using bf16 = hip_bfloat16' to 'using bf16 = __hip_bfloat16'

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

CI build

## Test Result

CI build should pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
