### PR TITLE
Replace roc-obj with llvm-obj (#4880)

### DIFF
--- a/projects/hip/docs/understand/compilers.rst
+++ b/projects/hip/docs/understand/compilers.rst
@@ -157,7 +157,7 @@ In this syntax:
 * Specialized matrix instructions (``v_mfma_*``) invoke the :ref:`Matrix Core
   (MFMA) hardware units <mfma_units>`.
 
-Although AMDGPU assembly can be written by hand, this is uncommon. Developers typically inspect compiler‑generated assembly when optimizing kernels, diagnosing register pressure, or tuning memory‑access patterns
+While it is possible to write AMDGPU assembly by hand, this practice is rare. In most cases, developers review compiler‑generated assembly to optimize kernels, analyze register pressure, or refine memory‑access behavior.
 
 The ROCm disassembler (``llvm-objdump``) and ROCm profiler (``rocprofv3``)
 allow inspection of generated GFX ISA alongside high-level HIP or OpenMP source
@@ -243,20 +243,27 @@ The ROCm binary utilities are a collection of command-line tools for examining
 and manipulating GPU binaries produced by ``amdclang++`` or other ROCm build
 tools. These utilities allow developers to inspect, disassemble, and analyze
 AMDGPU code objects, the compiled GPU kernels embedded in host executables or
-distributed as standalone ``.hsaco`` files.
-
+distributed as standalone ``.hsaco`` files. Previous ROCm versions shipped with the ``roc-obj-ls``,
+``roc-obj-extract``, and ``roc-obj utilities``. These have been deprecated in favor of enhanced
+capabilities now available in standard LLVM object tools, such as ``llvm-objdump`` and
+``llvm-readobj``. For more information, see `llvm-objdump — LLVM’s object file dumper at
+<https://llvm.org/docs/CommandGuide/llvm-objdump.html>`__.
+ 
 The ``llvm-objdump`` utility provides multiple capabilities for analyzing GPU
 binaries. With the ``--offloading`` flag, it can list and extract information
 from the contents of ROCm binaries, including code object metadata, kernel
 symbols, target architectures (for example, ``gfx90a``, ``gfx1100``), and
 linkage details. It supports both standalone ``.hsaco`` files and "fat
-binaries" embedded within host executables. With the ``--triple=amdgcn`` flag,
-it can disassemble GPU kernels into human-readable AMDGPU ISA, allowing
-inspection of instruction sequences, register allocation, and control flow.
-These capabilities are essential for performance debugging, code verification,
-and low-level kernel analysis, for example, when tuning :ref:`MFMA
-<mfma_units>` instructions or checking compiler optimizations.
+binaries" stored as embedded objects within host executables. In current releases, the tool
+additionally extracts HIP fat‑binary bundle entries into standalone code object files. With the
+``--triple=amdgcn`` option, it can disassemble GPU kernels into readable AMDGPU ISA, allowing
+detailed examination of instruction streams, register usage, and control‑flow structure. Such
+capabilities are critical for performance tuning, correctness verification, and low‑level kernel
+analysis, including tasks such as optimizing :ref:`MFMA <mfma_units>` instructions or assessing
+compiler‑generated transformations.
 
+The ``llvm-readobj`` tool, used with the ``--offloading`` flag, provides a complete listing of HIP fat‑binary offload bundle entries, superseding the earlier ``roc-obj-ls`` utility.
+ 
 Together, these utilities provide developers with insight into how HIP C++ code
 is compiled, optimized, and mapped to GPU hardware. They complement profiling
 tools like ``rocprofv3`` by exposing the static structure of compiled GPU


### PR DESCRIPTION
## Motivation

Update HIP Compilers to include llvm-objdump utilities to replace roc-obj which has been removed (or will be soon).

---------

## Motivation

roc-obj is deprecated and replaced with llvm-obj
