### PR TITLE
Some GPUs require profile_standard for stable GPU counter collection.

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
@@ -41,12 +41,11 @@ namespace rocprofiler
 {
 namespace counters
 {
-CounterController::CounterController()
-{
-    // Pre-read metrics map file to catch faliures during initial setup.
-    rocprofiler::counters::loadMetrics();
-    rocprofiler::counters::check_installed_firmware_restrictions();
+constexpr auto drm_render_node_minor_offset = 128;
 
+void
+CounterController::check_power_performance_level()
+{
     // Check if power_dpm_force_performance_level is set to profile_standard
     // for GPU agents that support counter collection. gfx11+ (Navi3x) requires
     // profile_standard for stable counter collection; gfx10 and below do not.
@@ -79,14 +78,14 @@ CounterController::CounterController()
             continue;
         }
 
-        std::string perf_level;
+        std::string perf_level{};
         std::getline(perf_file, perf_level);
         if(perf_level.empty())
         {
             ROCP_WARNING << fmt::format(
                 "Could not get power_dpm_force_performance_level for Agent {} (card{}). "
                 "Set to one of 'profile_standard, low, high, manual' for stable counter "
-                "collection.",
+                "collection. You can try running rocm-smi.",
                 agent->node_id,
                 card_num);
         }
@@ -101,6 +100,13 @@ CounterController::CounterController()
                 perf_level);
         }
     }
+}
+
+CounterController::CounterController()
+{
+    // Pre-read metrics map file to catch faliures during initial setup.
+    rocprofiler::counters::loadMetrics();
+    rocprofiler::counters::check_installed_firmware_restrictions();
 }
 
 // Adds a counter collection profile to our global cache.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
@@ -22,6 +22,7 @@
 
 #include "lib/rocprofiler-sdk/counters/controller.hpp"
 #include "lib/common/environment.hpp"
+#include "lib/common/filesystem.hpp"
 #include "lib/common/logging.hpp"
 #include "lib/rocprofiler-sdk/agent.hpp"
 #include "lib/rocprofiler-sdk/buffer.hpp"
@@ -47,25 +48,54 @@ CounterController::CounterController()
     rocprofiler::counters::check_installed_firmware_restrictions();
 
     // Check if power_dpm_force_performance_level is set to profile_standard
-    // for all GPU agents. Navi3x requires profile_standard for stable counter collection.
-    for(const auto* agent : agent::get_agents()) {
-        if(!agent || agent->type != ROCPROFILER_AGENT_TYPE_GPU) continue;
+    // for GPU agents that support counter collection. gfx11+ (Navi3x) requires
+    // profile_standard for stable counter collection; gfx10 and below do not.
+    constexpr auto gfx_version_major_scale   = 10000;
+    constexpr auto gfx_version_component_mod = 100;
+    constexpr auto min_gfx_major_power_check = 11;
 
-        auto card_num = agent->drm_render_minor - 128;
-        auto perf_path = fmt::format(
-            "/sys/class/drm/card{}/device/power_dpm_force_performance_level", card_num);
+    for(const auto* agent : agent::get_agents())
+    {
+        if(!agent || agent->type != ROCPROFILER_AGENT_TYPE_GPU ||
+           agent::get_agent_cache(agent) == nullptr)
+            continue;
 
-        std::ifstream perf_file(perf_path);
-        if(!perf_file.is_open()) continue;
+        auto gfx_major =
+            (agent->gfx_target_version / gfx_version_major_scale) % gfx_version_component_mod;
+        if(gfx_major < min_gfx_major_power_check) continue;
+
+        auto card_num  = agent->drm_render_minor - drm_render_node_minor_offset;
+        auto perf_path = common::filesystem::path{"/sys/class/drm"} /
+                         fmt::format("card{}", card_num) / "device" /
+                         "power_dpm_force_performance_level";
+
+        if(!common::filesystem::exists(perf_path)) continue;
+        std::ifstream perf_file(perf_path.string());
+        if(!perf_file.is_open())
+        {
+            ROCP_WARNING << fmt::format(
+                "Could not open path {} to get power_dpm_force_performance_level. ",
+                perf_path.string());
+            continue;
+        }
 
         std::string perf_level;
         std::getline(perf_file, perf_level);
-
-        if(!perf_level.empty() && perf_level != "profile_standard")
+        if(perf_level.empty())
+        {
+            ROCP_WARNING << fmt::format(
+                "Could not get power_dpm_force_performance_level for Agent {} (card{}). "
+                "Set to one of 'profile_standard, low, high, manual' for stable counter "
+                "collection.",
+                agent->node_id,
+                card_num);
+        }
+        else if(perf_level == "auto")
         {
             ROCP_WARNING << fmt::format(
                 "Agent {} (card{}) power_dpm_force_performance_level is '{}'. "
-                "Set to 'profile_standard' for stable counter collection.",
+                "Set to one of 'profile_standard, low, high, manual' for stable counter "
+                "collection.",
                 agent->node_id,
                 card_num,
                 perf_level);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
@@ -22,6 +22,7 @@
 
 #include "lib/rocprofiler-sdk/counters/controller.hpp"
 #include "lib/common/environment.hpp"
+#include "lib/common/logging.hpp"
 #include "lib/rocprofiler-sdk/agent.hpp"
 #include "lib/rocprofiler-sdk/buffer.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
@@ -33,6 +34,8 @@
 #include <rocprofiler-sdk/dispatch_counting_service.h>
 #include <rocprofiler-sdk/fwd.h>
 
+#include <fstream>
+
 namespace rocprofiler
 {
 namespace counters
@@ -42,6 +45,32 @@ CounterController::CounterController()
     // Pre-read metrics map file to catch faliures during initial setup.
     rocprofiler::counters::loadMetrics();
     rocprofiler::counters::check_installed_firmware_restrictions();
+
+    // Check if power_dpm_force_performance_level is set to profile_standard
+    // for all GPU agents. Navi3x requires profile_standard for stable counter collection.
+    for(const auto* agent : agent::get_agents()) {
+        if(!agent || agent->type != ROCPROFILER_AGENT_TYPE_GPU) continue;
+
+        auto card_num = agent->drm_render_minor - 128;
+        auto perf_path = fmt::format(
+            "/sys/class/drm/card{}/device/power_dpm_force_performance_level", card_num);
+
+        std::ifstream perf_file(perf_path);
+        if(!perf_file.is_open()) continue;
+
+        std::string perf_level;
+        std::getline(perf_file, perf_level);
+
+        if(!perf_level.empty() && perf_level != "profile_standard")
+        {
+            ROCP_WARNING << fmt::format(
+                "Agent {} (card{}) power_dpm_force_performance_level is '{}'. "
+                "Set to 'profile_standard' for stable counter collection.",
+                agent->node_id,
+                card_num,
+                perf_level);
+        }
+    }
 }
 
 // Adds a counter collection profile to our global cache.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.hpp
@@ -38,6 +38,8 @@ namespace rocprofiler
 {
 namespace counters
 {
+// DRM render node minors start at 128; subtract to get the card index.
+inline constexpr auto drm_render_node_minor_offset = 128;
 // Stores counter profiling information such as the agent
 // to collect counters on, the metrics to collect, the hw
 // counters needed to evaluate the metrics, and the ASTs.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.hpp
@@ -94,7 +94,7 @@ public:
         rocprofiler_agent_id_t                   agent_id,
         rocprofiler_device_counting_service_cb_t cb,
         void*                                    user_data);
-    void check_power_performance_level();
+    static void check_power_performance_level();
 
 private:
     common::Synchronized<std::unordered_map<uint64_t, std::shared_ptr<counter_config>>> _configs;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.hpp
@@ -39,7 +39,6 @@ namespace rocprofiler
 namespace counters
 {
 // DRM render node minors start at 128; subtract to get the card index.
-inline constexpr auto drm_render_node_minor_offset = 128;
 // Stores counter profiling information such as the agent
 // to collect counters on, the metrics to collect, the hw
 // counters needed to evaluate the metrics, and the ASTs.
@@ -95,6 +94,7 @@ public:
         rocprofiler_agent_id_t                   agent_id,
         rocprofiler_device_counting_service_cb_t cb,
         void*                                    user_data);
+    void check_power_performance_level();
 
 private:
     common::Synchronized<std::unordered_map<uint64_t, std::shared_ptr<counter_config>>> _configs;


### PR DESCRIPTION
Make sure power_dpm_force_performance_level is set to profile_standard instead of auto, before collecting values.

## Motivation

Navi3x/Navi4X requires a stable power state for counter collection. This PR warns user if the state is not set before collecting counters. 
 
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
ROCM-8724

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
Tests already fail if the power state is not set. We are only adding a user friendly warning here. 

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
