### PR TITLE
rocrtst: Strip GPU feature suffixes from TARGET_DEVICES

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/test_common/CMakeLists.txt
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/CMakeLists.txt
@@ -27,7 +27,7 @@
 #   4) Run "make"
 #
 
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.12.0)
 
 # Set Name for Samples Project
 #
@@ -336,6 +336,12 @@ if(NOT DEFINED TARGET_DEVICES OR TARGET_DEVICES STREQUAL "")
   endif()
 endif()
 
+# Strip feature suffixes (e.g., ":xnack+", ":sramecc+") from TARGET_DEVICES.
+# rocrtst compiles kernels with bare -mcpu (producing xnack=any code objects)
+# and LocateKernelFile() searches by bare HSA_AGENT_INFO_NAME.
+list(TRANSFORM TARGET_DEVICES REPLACE ":.*$" "")
+list(REMOVE_DUPLICATES TARGET_DEVICES)
+
 # Build type configuration
 string(TOLOWER "${ROCRTST_BLD_TYPE}" tmp)
 if("${tmp}" STREQUAL release)
@@ -467,12 +473,10 @@ function(build_kernel S_NAME TARG_DEV)
   set(KERNEL_DIR ${PROJECT_BINARY_DIR}/${TARG_DEV})
   set(SNAME_KERNEL "${S_NAME}_kernels.hsaco")
 
-  set(TARG_NAME "${S_NAME}_hsaco.${TARG_DEV}")
   set(HSACO_TARG_LIST ${HSACO_TARG_LIST} "${KERNEL_DIR}/${SNAME_KERNEL}" PARENT_SCOPE)
   string(SUBSTRING ${TARG_DEV} 3 -1 gfxNum)
-  string(REGEX REPLACE ":.*$" "" gfxNum "${gfxNum}")  # strip xnack+/xnack- and other suffixes
   separate_arguments(CLANG_ARG_LIST UNIX_COMMAND
-   "-D ROCRTST_GPU=0x${gfxNum} -x cl -target amdgcn-amd-amdhsa -include ${OPENCL_INC_DIR}/opencl-c.h -mcpu=${TARG_DEV} ${BITCODE_ARGS} -cl-std=CL${OPENCL_VER} -mcode-object-version=4 ${CL_FILE_LIST} -o ${KERNEL_DIR}/${SNAME_KERNEL}")
+    "-D ROCRTST_GPU=0x${gfxNum} -x cl -target amdgcn-amd-amdhsa -include ${OPENCL_INC_DIR}/opencl-c.h -mcpu=${TARG_DEV} ${BITCODE_ARGS} -cl-std=CL${OPENCL_VER} -mcode-object-version=4 ${CL_FILE_LIST} -o ${KERNEL_DIR}/${SNAME_KERNEL}")
   add_custom_command(OUTPUT "${KERNEL_DIR}/${SNAME_KERNEL}" COMMAND ${CLANG} ${CLANG_ARG_LIST} DEPENDS ${CL_FILE_LIST} ${CLANG} COMMENT "BUILDING ${KERNEL_DIR}/${SNAME_KERNEL}" VERBATIM)
 endfunction(build_kernel)
 
@@ -488,11 +492,10 @@ function(build_kernel_kernarg_preload S_NAME TARG_DEV)
   set(KERNEL_DIR ${PROJECT_BINARY_DIR}/${TARG_DEV})
   set(SNAME_KERNEL "${S_NAME}_kernels_argpreload.hsaco")
 
-  set(TARG_NAME "${S_NAME}_hsaco.${TARG_DEV}")
   set(HSACO_TARG_LIST ${HSACO_TARG_LIST} "${KERNEL_DIR}/${SNAME_KERNEL}" PARENT_SCOPE)
   string(SUBSTRING ${TARG_DEV} 3 -1 gfxNum)
   separate_arguments(CLANG_ARG_LIST UNIX_COMMAND
-  "-D ROCRTST_GPU=0x${gfxNum} -x cl -target amdgcn-amd-amdhsa -include ${OPENCL_INC_DIR}/opencl-c.h -mcpu=${TARG_DEV} ${BITCODE_ARGS} -cl-std=CL${OPENCL_VER} -mcode-object-version=4 -mllvm -amdgpu-kernarg-preload-count=16 ${CL_FILE_LIST} -o ${KERNEL_DIR}/${SNAME_KERNEL}")
+    "-D ROCRTST_GPU=0x${gfxNum} -x cl -target amdgcn-amd-amdhsa -include ${OPENCL_INC_DIR}/opencl-c.h -mcpu=${TARG_DEV} ${BITCODE_ARGS} -cl-std=CL${OPENCL_VER} -mcode-object-version=4 -mllvm -amdgpu-kernarg-preload-count=16 ${CL_FILE_LIST} -o ${KERNEL_DIR}/${SNAME_KERNEL}")
   add_custom_command(OUTPUT "${KERNEL_DIR}/${SNAME_KERNEL}" COMMAND ${CLANG} ${CLANG_ARG_LIST} DEPENDS ${CL_FILE_LIST} ${CLANG} COMMENT "BUILDING ${KERNEL_DIR}/${SNAME_KERNEL}" VERBATIM)
 endfunction(build_kernel_kernarg_preload)
 


### PR DESCRIPTION
Normalize TARGET_DEVICES immediately after it's set by stripping feature suffixes and deduplicating. This produces _xnack=any_ code objects (compatible with any agent ISA) and correct directory names, without requiring changes in any downstream build functions.

When GPU_TARGETS contains feature suffixes (e.g., "gfx942:xnack+"), the kernel build creates directories and code objects that are incompatible with the runtime's `LocateKernelFile()` lookup (which uses the bare HSA_AGENT_INFO_NAME like "gfx942") and fails to load.

Bump `cmake_minimum_required` to 3.12 for `list(TRANSFORM)`.

JIRA: [ROCM-24733](https://amd-hub.atlassian.net/browse/ROCM-24733)

[ROCM-24733]: https://amd-hub.atlassian.net/browse/ROCM-24733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ