### PR TITLE
clr/rocr: Route batch copies through shader blits; support H2D multi-entry batch

### DIFF
--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -2907,7 +2907,8 @@ static amd::CopyMetadata buildCopyMetadataFromAttrs(hipMemcpyAttributes* attrs, 
   // Map flags
   unsigned int flags = attrs[attrIdx].flags;
   if (flags & hipMemcpyFlagExtPreferCE) {
-    metadata.preferCE_ = 1;
+    // CE means Copy Engine here, so keep these copies on SDMA instead of shader blits.
+    metadata.copyEnginePreference_ = amd::CopyMetadata::CopyEnginePreference::SDMA;
   }
   if (flags & hipMemcpyFlagExtOpSwap) {
     metadata.copyOpType_ = amd::CopyMetadata::kCopyOpSwap;

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2602,6 +2602,37 @@ struct CopyBufferBatchDescriptor {
 };
 
 // ================================================================================================
+bool KernelBlitManager::useShaderCopyBufferPath(const Memory& srcMemory, const Memory& dstMemory,
+                                                size_t size, amd::CopyMetadata copyMetadata,
+                                                bool* useLimitedP2pBlitWg) const {
+  bool isP2pOrIpc = (&srcMemory.dev() != &dstMemory.dev()) ||
+                    srcMemory.owner()->ipcShared() || dstMemory.owner()->ipcShared() ||
+                    srcMemory.owner()->vmmImported() || dstMemory.owner()->vmmImported();
+  const bool smallP2pOrIpc = isP2pOrIpc && size <= dev().settings().sdma_p2p_threshold_;
+  if (useLimitedP2pBlitWg != nullptr) {
+    *useLimitedP2pBlitWg = smallP2pOrIpc;
+  }
+
+  // Use the shader path for small P2P/IPC transfers, otherwise keep large P2P/IPC on SDMA.
+  if (smallP2pOrIpc) {
+    isP2pOrIpc = false;
+  }
+
+  bool isSdmaPreference =
+      copyMetadata.copyEnginePreference_ == amd::CopyMetadata::CopyEnginePreference::SDMA;
+  bool isBlitPreference =
+      copyMetadata.copyEnginePreference_ == amd::CopyMetadata::CopyEnginePreference::BLIT;
+  bool neitherMemoryIsHostDirectAccess =
+      !srcMemory.isHostMemDirectAccess() && !dstMemory.isHostMemDirectAccess();
+  bool smallSizeWithNonSdmaPreference =
+      size <= dev().settings().sdmaCopyThreshold_ && !isSdmaPreference;
+  bool nonP2PIpcOrDirectAccess =
+      !isP2pOrIpc && neitherMemoryIsHostDirectAccess && !isSdmaPreference;
+
+  return smallSizeWithNonSdmaPreference || nonP2PIpcOrDirectAccess || isBlitPreference;
+}
+
+// ================================================================================================
 bool KernelBlitManager::ShaderCopyBufferBatch(
     const std::vector<amd::BatchCopyOp> &copy_operations) const {
   std::scoped_lock transfer_operations_lock(lockXferOps_);
@@ -2716,17 +2747,14 @@ bool KernelBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& cop
       return false;
     }
 
-    // Resolve real agents for partition decision (handles IPC shared memory)
     const Memory& srcMem = gpuMem(*srcDevMem);
     const Memory& dstMem = gpuMem(*dstDevMem);
-    address srcAddr = reinterpret_cast<address>(srcMem.getDeviceMemory()) + op.srcOffset;
-    address dstAddr = reinterpret_cast<address>(dstMem.getDeviceMemory()) + op.dstOffset;
+    bool isLinearCopyOp = op.metadata.copyOpType_ == amd::CopyMetadata::kCopyOpLinear;
+    // ShaderCopyBufferBatch only describes linear copies; route swap/other ops through DMA.
+    bool useShaderCopyPath =
+        isLinearCopyOp && useShaderCopyBufferPath(srcMem, dstMem, op.size, op.metadata);
 
-    hsa_agent_t srcAgent;
-    hsa_agent_t dstAgent;
-    resolveAgents(srcMem, dstMem, srcAddr, dstAddr, srcAgent, dstAgent);
-
-    if (srcAgent.handle == dstAgent.handle && !op.metadata.preferCE_) {
+    if (useShaderCopyPath) {
       d2dCopyOps.push_back(op);
     } else {
       p2pCopyOps.push_back(op);
@@ -2807,39 +2835,17 @@ bool KernelBlitManager::copyBuffer(device::Memory& srcMemory, device::Memory& ds
   bool result = false;
   uint32_t blitWg = dev().settings().limit_blit_wg_;
 
-  bool isP2pOrIpc = (&gpuMem(srcMemory).dev() != &gpuMem(dstMemory).dev()) ||
-                    srcMemory.owner()->ipcShared() || dstMemory.owner()->ipcShared() ||
-                    srcMemory.owner()->vmmImported() || dstMemory.owner()->vmmImported();
-
-  // Use SDMA for large P2P/IPC transfers, shader for small ones
-  if (isP2pOrIpc && sizeIn[0] <= dev().settings().sdma_p2p_threshold_) {
+  const Memory& srcRocMemory = gpuMem(srcMemory);
+  const Memory& dstRocMemory = gpuMem(dstMemory);
+  bool useLimitedP2pBlitWg = false;
+  const bool useShaderCopyBuffer =
+      useShaderCopyBufferPath(srcRocMemory, dstRocMemory, sizeIn[0], copyMetadata,
+                              &useLimitedP2pBlitWg);
+  const bool useShaderCopyPath = setup_.disableHwlCopyBuffer_ || useShaderCopyBuffer;
+  if (useLimitedP2pBlitWg) {
     constexpr uint32_t kLimitWgForKernelP2p = 16;
     blitWg = kLimitWgForKernelP2p;
-    isP2pOrIpc = false;
   }
-
-  // Determine if we should use shader copy path based on various conditions
-  bool hwlCopyDisabled = setup_.disableHwlCopyBuffer_;
-
-  // Check copy engine preferences
-  bool isSdmaPreference =
-      copyMetadata.copyEnginePreference_ == amd::CopyMetadata::CopyEnginePreference::SDMA;
-  bool isBlitPreference =
-      copyMetadata.copyEnginePreference_ == amd::CopyMetadata::CopyEnginePreference::BLIT;
-
-  // Check memory access patterns
-  bool neitherMemoryIsHostDirectAccess =
-      !srcMemory.isHostMemDirectAccess() && !dstMemory.isHostMemDirectAccess();
-
-  // Determine shader copy path conditions
-  bool smallSizeWithNonSdmaPreference =
-      sizeIn[0] <= dev().settings().sdmaCopyThreshold_ && !isSdmaPreference;
-
-  bool nonP2PIpcOrDirectAccess =
-      !isP2pOrIpc && neitherMemoryIsHostDirectAccess && !isSdmaPreference;
-
-  const bool useShaderCopyPath = hwlCopyDisabled || smallSizeWithNonSdmaPreference ||
-                                 nonP2PIpcOrDirectAccess || isBlitPreference;
 
   if (!useShaderCopyPath) {
     if (amd::IS_HIP) {

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -604,6 +604,11 @@ class KernelBlitManager : public DmaBlitManager {
                         const uint32_t blitWg, amd::CopyMetadata copyMetadata,
                         bool attachSignal = false) const;
 
+  //! Returns true if a linear buffer copy should use the shader path.
+  bool useShaderCopyBufferPath(const Memory& srcMemory, const Memory& dstMemory, size_t size,
+                               amd::CopyMetadata copyMetadata,
+                               bool* useLimitedP2pBlitWg = nullptr) const;
+
   //! Copies a batch of buffers using a single/multiple shader dispatch
   bool ShaderCopyBufferBatch(const std::vector<amd::BatchCopyOp>& copy_ops) const;
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -3118,12 +3118,10 @@ void VirtualGPU::submitBatchCopyMemory(amd::BatchCopyMemoryCommand& cmd) {
   }
 
   // Synchronize the launch (compute) stream with SDMA engines.
-  // Reset active engine to Compute before the barrier — the barrier runs on the
-  // AQL compute queue, not an SDMA engine.  Without this, the barrier's profiling
-  // signal inherits an SDMA engine type, causing CacheTimingData to call
-  // hsa_amd_profiling_get_async_copy_time (wrong API) and corrupt the timestamps.
+  // WaitingSignal(Compute) inside dispatchBarrierPacket detects the engine switch
+  // from SDMA→Compute, collects the SDMA completion signal as a barrier dependency,
+  // and updates engine_ to Compute before ActiveSignal tags the profiling signal.
   if (result) {
-    Barriers().SetActiveEngine(HwQueueEngine::Compute);
     dispatchBarrierPacket(kNopPacketHeader);
   }
 

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -282,9 +282,8 @@ union CopyMetadata {
     uint32_t isAsync_ : 1;
     uint32_t copyEnginePreference_ : 2;
     uint32_t srcAccessOrder_ : 2;       //!< Source access ordering for batch copies
-    uint32_t preferCE_ : 1;             //!< Prefer compute engine over SDMA
     uint32_t copyOpType_ : 3;           //!< Operation type (CopyOpType)
-    uint32_t reserved_ : 23;            //!< Reserved for future use
+    uint32_t reserved_ : 24;            //!< Reserved for future use
   };
   uint32_t flags_;
   CopyMetadata() : flags_(0) {}
@@ -292,7 +291,6 @@ union CopyMetadata {
       : isAsync_(isAsync),
         copyEnginePreference_(copyEnginePreference),
         srcAccessOrder_(kSrcAccessOrderStream),
-        preferCE_(0),
         copyOpType_(kCopyOpLinear),
         reserved_(0) {}
   CopyMetadata(bool isAsync, CopyEnginePreference copyEnginePreference,
@@ -300,7 +298,6 @@ union CopyMetadata {
       : isAsync_(isAsync),
         copyEnginePreference_(copyEnginePreference),
         srcAccessOrder_(srcAccessOrder),
-        preferCE_(0),
         copyOpType_(kCopyOpLinear),
         reserved_(0) {}
 };

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_sdma.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_sdma.h
@@ -81,15 +81,13 @@ class BlitSdmaBase : public core::Blit {
       std::vector<core::Signal*>& dep_signals,
       core::Signal& out_signal) = 0;
 
-  /// @brief Submit back-to-back linear copy commands for all destinations from a
-  /// shared source in a single SDMA ring submission (linearB2BCopy path).
-  /// Unlike broadcast, each destination gets one or more standard
-  /// SDMA_PKT_COPY_LINEAR packets (chunked when size exceeds the per-packet
-  /// limit); the compactness comes from batching all of them into one
-  /// SubmitCommand call.
+  /// @brief Pack N linear copy packets back-to-back in a single SDMA ring
+  /// submission (linearB2BCopy path).  Each entry i copies srcs[i] -> dsts[i]
+  /// of sizes[i] bytes.  For the broadcast case (same src/size for all dsts),
+  /// the caller simply fills srcs and sizes with repeated values.
   virtual hsa_status_t SubmitLinearCopyB2BCommand(
-      const std::vector<void*>& dsts, const void* src, size_t size,
-      std::vector<core::Signal*>& dep_signals,
+      const std::vector<void*>& dsts, const std::vector<const void*>& srcs,
+      const std::vector<size_t>& sizes, std::vector<core::Signal*>& dep_signals,
       core::Signal& out_signal) = 0;
 
   virtual bool BroadcastSupported() const = 0;
@@ -209,8 +207,8 @@ template <bool useGCR, bool scopeFields> class BlitSdma : public BlitSdmaBase {
       core::Signal& out_signal) override;
 
   hsa_status_t SubmitLinearCopyB2BCommand(
-      const std::vector<void*>& dsts, const void* src, size_t size,
-      std::vector<core::Signal*>& dep_signals,
+      const std::vector<void*>& dsts, const std::vector<const void*>& srcs,
+      const std::vector<size_t>& sizes, std::vector<core::Signal*>& dep_signals,
       core::Signal& out_signal) override;
 
   /// @brief Submit a linear fill command to the queue buffer

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -1475,32 +1475,33 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyBroadcastCommand(
 
 template <bool useGCR, bool scopeFields>
 hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyB2BCommand(
-    const std::vector<void*>& dsts, const void* src, size_t size,
-    std::vector<core::Signal*>& dep_signals,
+    const std::vector<void*>& dsts, const std::vector<const void*>& srcs,
+    const std::vector<size_t>& sizes, std::vector<core::Signal*>& dep_signals,
     core::Signal& out_signal) {
 
-  if (dsts.empty() || size == 0) {
+  const size_t num_entries = srcs.size();
+  if (num_entries == 0 || dsts.size() != num_entries || sizes.size() != num_entries) {
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }
 
   const size_t max_copy_size = max_single_linear_copy_size_ ? max_single_linear_copy_size_
                                                              : kMaxSingleCopySize;
-  const uint32_t num_chunks = static_cast<uint32_t>((size + max_copy_size - 1) / max_copy_size);
 
-  // One set of linear copy packets per destination, all packed back-to-back.
-  const size_t per_dst_bytes =
-      static_cast<size_t>(num_chunks) * static_cast<size_t>(linear_copy_command_size_);
-  const size_t total_cmd_size = dsts.size() * per_dst_bytes;
-
-  std::vector<char> cmd_buf(total_cmd_size);  // BuildCopyCommand memsets each packet
-  char* cmd_ptr = cmd_buf.data();
-
-  for (void* dst : dsts) {
-    BuildCopyCommand(cmd_ptr, num_chunks, dst, src, size);
-    cmd_ptr += per_dst_bytes;
+  std::vector<uint32_t> chunks(num_entries);
+  size_t total_cmd_size = 0;
+  uint64_t total_bytes_moved = 0;
+  for (size_t i = 0; i < num_entries; i++) {
+    chunks[i] = static_cast<uint32_t>((sizes[i] + max_copy_size - 1) / max_copy_size);
+    total_cmd_size += static_cast<size_t>(chunks[i]) * linear_copy_command_size_;
+    total_bytes_moved += sizes[i];
   }
 
-  const uint64_t total_bytes_moved = static_cast<uint64_t>(size) * dsts.size();
+  std::vector<char> cmd_buf(total_cmd_size);
+  char* cmd_ptr = cmd_buf.data();
+  for (size_t i = 0; i < num_entries; i++) {
+    BuildCopyCommand(cmd_ptr, chunks[i], dsts[i], srcs[i], sizes[i]);
+    cmd_ptr += static_cast<size_t>(chunks[i]) * linear_copy_command_size_;
+  }
 
   std::vector<core::Signal*> no_gang;
   return SubmitCommand(cmd_buf.data(), total_cmd_size, total_bytes_moved,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1705,7 +1705,7 @@ hsa_status_t GpuAgent::DmaCopyBroadcast(
   core::Signal& out_signal = *out_signal_obj;
 
   const uint16_t num_entries = op.num_entries;
-  constexpr size_t kBroadcastMaxSize = 1024 * 1024;
+  constexpr size_t kBroadcastMaxSize = 256 * 1024;
 
   // Try HW broadcast/multicast.
   {
@@ -1716,15 +1716,16 @@ hsa_status_t GpuAgent::DmaCopyBroadcast(
     if (blit->isSDMA()) {
       BlitSdmaBase* sdma_blit = static_cast<BlitSdmaBase*>((*blit).get());
 
-      // linearB2BCopy outperforms HW broadcast for per-copy sizes >= 16KB
+      // linearB2BCopy for per-copy sizes in [16KB, 256KB].
+      // Above 256KB the fan-out path parallelises across engines.
       // HSA_SDMA_LINEAR_B2B: 1=force B2B, 0=force broadcast, unset=auto threshold.
       constexpr size_t kLinearB2BMinSize = 16 * 1024;
       const auto b2b_flag = core::Runtime::runtime_singleton_->flag().sdma_linear_b2b();
       const bool use_linear_b2b = (b2b_flag == Flag::SDMA_ENABLE) ||
           (b2b_flag == Flag::SDMA_DEFAULT && op.size >= kLinearB2BMinSize &&
-           !sdma_blit->IsGfx1250());
+           op.size <= kBroadcastMaxSize);
 
-      if (use_linear_b2b) {
+      if (use_linear_b2b && !sdma_blit->IsGfx1250()) {
         if (profiling_enabled())
           out_signal.async_copy_agent(core::Agent::Convert(this->public_handle()));
 
@@ -1735,12 +1736,13 @@ hsa_status_t GpuAgent::DmaCopyBroadcast(
                  dep_signals.empty() ? 0 : core::Signal::Convert(dep_signals[0]).handle,
                  out_signal_obj->signal_);
         std::vector<void*> dsts(op.dst_list, op.dst_list + num_entries);
+        std::vector<const void*> srcs(num_entries, op.src);
+        std::vector<size_t> sizes(num_entries, op.size);
         return sdma_blit->SubmitLinearCopyB2BCommand(
-            dsts, op.src, op.size, dep_signals, out_signal);
+            dsts, srcs, sizes, dep_signals, out_signal);
       }
 
-      if (sdma_blit->BroadcastSupported() &&
-          (sdma_blit->IsGfx1250() || op.size < kBroadcastMaxSize)) {
+      if (sdma_blit->BroadcastSupported() && op.size < kLinearB2BMinSize) {
         if (profiling_enabled())
           out_signal.async_copy_agent(core::Agent::Convert(this->public_handle()));
 
@@ -1774,8 +1776,61 @@ hsa_status_t GpuAgent::DmaCopyMulti(
   core::Signal* out_signal_obj = core::Signal::Convert(op.completion_signal);
   core::Signal& out_signal = *out_signal_obj;
 
+  const uint16_t num_entries = op.num_entries;
+  constexpr size_t kLinearB2BMaxSize = 256 * 1024;
+  constexpr size_t kLinearB2BMinSize = 16 * 1024;
+
+  // Try linearB2B: pack all entries as back-to-back SDMA linear copy packets in
+  // one ring submission to avoid fan-out signal overhead.  Use the same size
+  // thresholds as DmaCopyBroadcast: per-entry size in [16KB, 1MB) unless the
+  // flag forces B2B on.  For large entries the fan-out path parallelises across
+  // engines and is faster.
+  {
+    SetCopyRequestRefCount(true);
+    MAKE_SCOPE_GUARD([&]() { SetCopyRequestRefCount(false); });
+
+    lazy_ptr<core::Blit>& blit = GetBlitObject(BlitHostToDev);
+    if (blit->isSDMA()) {
+      BlitSdmaBase* sdma_blit = static_cast<BlitSdmaBase*>((*blit).get());
+
+      const auto b2b_flag = core::Runtime::runtime_singleton_->flag().sdma_linear_b2b();
+
+      // Check that every entry qualifies for B2B.
+      bool all_qualify = true;
+      for (uint16_t i = 0; i < num_entries; i++) {
+        const size_t sz = op.size_list[i];
+        const bool qualifies =
+            (b2b_flag == Flag::SDMA_ENABLE) ||
+            (b2b_flag == Flag::SDMA_DEFAULT && sz >= kLinearB2BMinSize &&
+             sz <= kLinearB2BMaxSize);
+        if (!qualifies) {
+          all_qualify = false;
+          break;
+        }
+      }
+
+      if (all_qualify) {
+        if (profiling_enabled())
+          out_signal.async_copy_agent(core::Agent::Convert(this->public_handle()));
+
+        std::vector<void*> dsts(op.dst_list, op.dst_list + num_entries);
+        std::vector<const void*> srcs(op.src_list, op.src_list + num_entries);
+        std::vector<size_t> sizes(op.size_list, op.size_list + num_entries);
+
+        LogPrint(HSA_AMD_LOG_FLAG_SDMA,
+                 "SDMA multiB2BCopy using engine %02u, num_entries=%u, "
+                 "dep_signal=0x%zx, completion_signal=0x%zx",
+                 BlitHostToDev, num_entries,
+                 dep_signals.empty() ? 0 : core::Signal::Convert(dep_signals[0]).handle,
+                 out_signal_obj->signal_);
+        return sdma_blit->SubmitLinearCopyB2BCommand(dsts, srcs, sizes,
+                                                     dep_signals, out_signal);
+      }
+    }
+  }
+
   return DmaCopyFanOutOp(HSA_AMD_MEMORY_COPY_OP_LINEAR, out_signal, dep_signals,
-                         op.num_entries, const_cast<const void* const*>(op.src_list),
+                         num_entries, const_cast<const void* const*>(op.src_list),
                          op.dst_list, op.dst_agent_list, op.size_list);
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -437,13 +437,16 @@ hsa_status_t hsa_amd_memory_async_batch_copy(const hsa_amd_memory_copy_op_t* cop
         // Multi-linear: arrays of src/dst/size, one signal for all entries.
         if (op.src_list == nullptr || op.dst_list == nullptr ||
             op.dst_agent_list == nullptr || op.size_list == nullptr ||
-            op.num_entries > 1024 || op.reserved0 != 0)
+            op.num_entries > 65536 || op.reserved0 != 0)
           return HSA_STATUS_ERROR_INVALID_ARGUMENT;
         for (uint32_t d = 0; d < op.num_entries; ++d) {
           IS_BAD_PTR(op.src_list[d]);
           IS_BAD_PTR(op.dst_list[d]);
           core::Agent* da = core::Agent::Convert(op.dst_agent_list[d]);
           IS_VALID(da);
+          if (src_agent->device_type() != core::Agent::DeviceType::kAmdGpuDevice &&
+              da->device_type() != core::Agent::DeviceType::kAmdGpuDevice)
+            return HSA_STATUS_ERROR_INVALID_AGENT;
           if (op.size_list[d] == 0)
             return HSA_STATUS_ERROR_INVALID_ARGUMENT;
         }
@@ -467,7 +470,7 @@ hsa_status_t hsa_amd_memory_async_batch_copy(const hsa_amd_memory_copy_op_t* cop
       break;
     case HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST:
       if (op.dst_list == nullptr || op.dst_agent_list == nullptr ||
-          op.num_entries == 0 || op.num_entries > 1024 || op.unused_size != 0)
+          op.num_entries == 0 || op.num_entries > 65536 || op.unused_size != 0)
         return HSA_STATUS_ERROR_INVALID_ARGUMENT;
       for (uint32_t d = 0; d < op.num_entries; ++d) {
         IS_BAD_PTR(op.dst_list[d]);
@@ -479,7 +482,7 @@ hsa_status_t hsa_amd_memory_async_batch_copy(const hsa_amd_memory_copy_op_t* cop
       if (op.num_entries > 0) {
         if (op.src_list == nullptr || op.dst_list == nullptr ||
             op.dst_agent_list == nullptr || op.size_list == nullptr ||
-            op.num_entries > 1024 || op.reserved0 != 0)
+            op.num_entries > 65536 || op.reserved0 != 0)
           return HSA_STATUS_ERROR_INVALID_ARGUMENT;
         for (uint32_t d = 0; d < op.num_entries; ++d) {
           IS_BAD_PTR(op.src_list[d]);
@@ -514,11 +517,18 @@ hsa_status_t hsa_amd_memory_async_batch_copy(const hsa_amd_memory_copy_op_t* cop
 
     if (has_work) {
       core::Agent* copy_agent = nullptr;
-      if (op.type == HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST ||
-          (is_multi && op.type != HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP)) {
+      if (op.type == HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST) {
         if (src_agent->device_type() != core::Agent::DeviceType::kAmdGpuDevice)
           return HSA_STATUS_ERROR_INVALID_AGENT;
         copy_agent = src_agent;
+      } else if (is_multi && op.type != HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP) {
+        if (src_agent->device_type() == core::Agent::DeviceType::kAmdGpuDevice) {
+          // D2D or D2H: use src GPU as the copy engine.
+          copy_agent = src_agent;
+        } else {
+          // H2D: every destination was validated as a GPU; route through the first one.
+          copy_agent = core::Agent::Convert(op.dst_agent_list[0]);
+        }
       } else if (op.type == HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP && is_multi) {
         // Swap: pick the GPU agent, same as DmaCopy does.
         // Multi-entry swap has no single dst_agent, use dst_agent_list[0].

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -2212,18 +2212,18 @@ typedef enum {
  *
  * LINEAR (multi-copy when num_entries > 0, one signal for all entries):
  *   src_list         -- caller-owned array of num_entries source pointers
- *   src_agent        -- common source agent (must be GPU)
+ *   src_agent        -- common source agent (GPU or CPU); if CPU, all dst_agent_list entries must be GPU
  *   dst_list         -- caller-owned array of num_entries destination pointers
  *   dst_agent_list   -- caller-owned array of num_entries destination agents
  *   size_list        -- caller-owned array of num_entries copy sizes in bytes
- *   num_entries         -- number of entries (>= 1, <= 1024)
+ *   num_entries         -- number of entries (>= 1, <= 65536)
  *
  * LINEAR_BROADCAST (single source -> multiple destinations):
  *   src, src_agent    -- source pointer and agent (must be GPU)
  *   dst_list          -- caller-owned array of num_entries destination pointers
  *   dst_agent_list    -- caller-owned array of num_entries destination agents
  *   size              -- copy size in bytes (same for every destination)
- *   num_entries          -- number of entries in dst_list / dst_agent_list (>= 1, <= 1024)
+ *   num_entries          -- number of entries in dst_list / dst_agent_list (>= 1, <= 65536)
  *
  * LINEAR_SWAP (exchange contents of two buffers, multi-entry when num_entries > 0):
  *   src_list         -- caller-owned array of num_entries source pointers
@@ -2231,7 +2231,7 @@ typedef enum {
  *   dst_list         -- caller-owned array of num_entries destination pointers
  *   dst_agent_list   -- caller-owned array of num_entries destination agents
  *   size_list        -- caller-owned array of num_entries swap sizes in bytes
- *   num_entries      -- number of entries (>= 1, <= 1024)
+ *   num_entries      -- number of entries (>= 1, <= 65536)
  *
  * LINEAR_SWAP (single, when num_entries == 0):
  *   src, src_agent  -- first buffer pointer and agent (modified in place)


### PR DESCRIPTION
CLR changes:
- Add inline KernelBlitManager::useShaderCopyBufferPath() to share
  routing logic between single and batch linear buffer copies. Small
  copies and BLIT-preferred copies take the shader path; SDMA-preferred,
  P2P, IPC, and host-direct-access copies stay on the DMA engine.
- Remove the redundant preferCE_ bitfield from CopyMetadata; CE
  preference is now expressed solely via copyEnginePreference_.
- hipMemcpyFlagExtPreferCE sets copyEnginePreference to SDMA directly.

ROCr changes:
- Relax hsa_amd_memory_async_batch_copy agent validation for multi-entry
  LINEAR ops: when src_agent is a CPU (H2D), select the first GPU
  destination as the copy engine instead of rejecting with
  HSA_STATUS_ERROR_INVALID_AGENT. GPU src_agent (D2D/D2H) continues to
  use src_agent as the copy engine.
- Update hsa_ext_amd.h doc to reflect that src_agent may be a CPU agent
  for H2D multi-entry batch copies.
- Extend linearB2B (back-to-back SDMA copy packing) to multi-entry batch
  copies via SubmitLinearCopyMultiB2BCommand, eliminating per-copy signal
  overhead for mid-size transfers.
- Introduce kBroadcastMaxSize (256 KB per entry) as the upper threshold
  for linearB2B; copies larger than this fall through to the fan-out path
  which spreads work across multiple SDMA engines for better bandwidth.
- Add HSA_SDMA_LINEAR_B2B environment variable (enable/disable/default)
  to control linearB2B path selection for debugging and tuning.
- Routing logic: sizes < 16 KB use single-engine copy, 16 KB - 256 KB
  use linearB2B (single submission, no signal overhead), > 256 KB use
  fan-out (multi-engine parallelism).


## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

catch/performance/memcpy/hipMemcpyBatchAsync.cc
It tests all these sizes
4 KB, 64 KB, 128 KB, 256 KB, 1 MB, 4 MB, 16 MB, 64 MB, 128 MB, 256 MB, 1024 MB

## Test Result
With RCCL benchmark https://github.com/ROCm/sdma-collective
Performance (8-GPU all-gather batch, vs develop pre-linearB2B):
- 128 KB - 4 MB: 13-55% faster (linearB2B eliminates signal overhead)
- 8 MB+: equivalent (both use fan-out)
- No regressions at any size

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
