### PR TITLE
[rocprofiler-compute] Add pre-commit hook for scanning secrets

### DIFF
--- a/projects/rocprofiler-compute/.pre-commit-config.yaml
+++ b/projects/rocprofiler-compute/.pre-commit-config.yaml
@@ -11,6 +11,17 @@ repos:
       - id: trailing-whitespace
         files: ^projects/rocprofiler-compute/
 
+  # Block committed secrets
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args:
+          - --baseline
+          - projects/rocprofiler-compute/.secrets.baseline
+        files: ^projects/rocprofiler-compute/
+        exclude: ^projects/rocprofiler-compute/\.secrets\.baseline$
+
   # Python import sorting and formatting
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version. Check https://github.com/astral-sh/ruff-pre-commit#version-compatibility

--- a/projects/rocprofiler-compute/.secrets.baseline
+++ b/projects/rocprofiler-compute/.secrets.baseline
@@ -1,0 +1,884 @@
+{
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "min_level": 2,
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "generated_at": "2026-05-18T18:37:21Z",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "limit": 3.0,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": "",
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "projects/rocprofiler-compute/docs/archive/docs-1.x/installation.md": [
+      {
+        "filename": "projects/rocprofiler-compute/docs/archive/docs-1.x/installation.md",
+        "hashed_secret": "d7683e52af93b105a44fcef5bd668a77fafd49f9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 213,
+        "type": "Basic Auth Credentials"
+      }
+    ],
+    "projects/rocprofiler-compute/docs/archive/docs-2.x/installation.md": [
+      {
+        "filename": "projects/rocprofiler-compute/docs/archive/docs-2.x/installation.md",
+        "hashed_secret": "d7683e52af93b105a44fcef5bd668a77fafd49f9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 238,
+        "type": "Basic Auth Credentials"
+      }
+    ],
+    "projects/rocprofiler-compute/src/utils/.config_hashes.json": [
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "a0cab203efc1e39249803f6be365d6d22a606c40",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "e06c5c79889a1307520e52628fb5f06c89972c06",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "253fcacd99e21c34e085b963979726ed5dd7f82e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 8,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "add5bb85d5d0ff736d75303a599ecb0914453e38",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 9,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "235344247f04ea91db21c43b51d898685b16116c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 10,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "1950bf4f9c0f340a5868c2b2bec0182e053ab4c9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 11,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "229afceefd96bf3d653afe6d99e1f05adccc42bd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "a81400bb12beaffd8c9c18bd136a1fad7962cdef",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 13,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "038c5ae87a77b724aa7cafce2c4b50a59edd79ce",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 14,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "e91bd17dceef5faa5b1d22541cbe49cd70e27621",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 15,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "e6d62b52bcbd05f8da266587fe494b8f450f257f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 16,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "94c4d4196eba1c399a05880446582cbe48974a9e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 17,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "d92f7ccb510722fec35c839f710bfc054cae94f3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "0bcffe58cdae32ca20ce51e24496278beb6e7d16",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "2c24d935ae02527bb7a3ce9aa531e6e413f257e1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "f3311f183240c4956c94c6a77015c6c7db283594",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "4fa609f19b99cee76d058a487872254bb4a0f557",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "48135d48de8432975e8213e818042cc48d6dd222",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "26b78dc6084c02055b0b68de9b3c8e0824b40cc4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "24a06f208bb1bf7f0b38bd37f66853b8ab5d13a1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "1dd61eb9bac5c7e78ec0d6da4493ddfc4c09d9c3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "cd952d4df024665679c87c04c4c93ffb5c42d046",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "c8a2fc3fdb303dd86a171923f68bf07d04dc14d8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 32,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "f2fed70bf1c5f071be9c42ef52e402950144c6a0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 33,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "2f1b3b7ea50865b2f694aca150ae7abb114564b8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 34,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "6ad43a8ddf85c9765e3afa7856ecdd249db93427",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 35,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "378e2e80949a9da47d9301453a70a859f28395c4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 36,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "4fff3e520f056e85b9cb7ccf14004ed78db5ad4d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 37,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "3181292ef5c1f2ec0f1f0063d8701ba6b2c34a77",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 38,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "db39b989a691c4be706e99810e26a5db18cc968f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 39,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "f7640d82458f0e029638a0b5a5852d4b81607e8b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 40,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "c0da28a0d130695c9f3b4dcd3e9e644bcc110b35",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 41,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "1e9a9d4d0c1032a0e80ed57d03d748465ca67bdd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 45,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "cb2c072728f2ef5eb04a9320e95be2c394b18235",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 49,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "5c0b5f926a886b6d428cd84c8b9ceaffe7f7e556",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 50,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "46b37b72f52f6285f0f142b09cad687e8366450f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 51,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "db26e5755a00c0df01b116f5dd86de2f4ba7d340",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 55,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "08ea362a1da7028928443125c5f1a45fe4a90377",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 56,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "aa9756126882f06dea5f10763046831e4149d082",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 60,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "dfb0fc269aa98aa7c947b14320adfba975f7fa5c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 62,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "12224c4d27e7794dfde618baedf03aed48e7fd20",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 63,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "428e3c8d7efe287b471600ad3762feb6cd9f92be",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 68,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "cff94424adcde950a1cb723f236f367884bd7e64",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 72,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "33112a26afaf03459bd4a2eec381256ab39ce483",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 73,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "05a2db83b37bab5de50048fa7222ef14a3c0575e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 74,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "75438e20b161cd3aa4b650339ce4adbfe10c67b0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 78,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "3c7a67f0a866e3b10d125f975878ee80b223502a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 79,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "0039a114824d326ce0812cff1c3c90c5be336a32",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 83,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "1ce8abf46e7392b72b930dfd57936223a18be9e9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 84,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "dc100aeee95987fc4cf330595bf2740509691583",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 85,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "4d5425bfa82df81681a6f4b89d4648b6fac3ce2f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 86,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "4a3ef145680f9d74e4911625a1f0d90f86bf7a88",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 91,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "b07814ecbbc8c2d74d36246031327bb66e111ac6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 95,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "f2dc032462c0d9f3dfc2f53a0bbad566cf473a86",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 97,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "3c6b83c72765daf5100d80cf7e6b790772ab4c2f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 108,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "e0515e5ea7f13d6e362813b52985c4a3f4924e34",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 114,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "c4dd6b7420547e299699c8257f41cc30a578da13",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 119,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "0d1232565cceae959725db2d83043be7bc5d06ff",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 120,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "0f12375f686b349efee3f27bfa0c656842bbb005",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 125,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "a4a3c3fad62863c354d4346dcb3bff03b8e2cca8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 129,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "e762ff2ee67302255b1aa88a1fda123b53a43446",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 131,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "bea8c3e4f258891e2bd07e58e0e8953b8278c484",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 141,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "d6ac88499f908ce66fe4d53089a49a87388e3175",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 142,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "a8cb4551a4844e771af1beab0095185fbc919bef",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 143,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "2de8a763a5e626ee131c41d81296c39f202f4347",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 144,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "6bd00a9c48586a1f49dcbd389988c86a6b24e52b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 145,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "53d98b5c40c905c54c3dd367e4806f8a8528eb5c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 146,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "5283a8fba2cec103be3cb4651c07169f63afd034",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 147,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "5103b795cf8a7e06f0783de175e1e2f559c60959",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 148,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "adc8bac429f068e53804c0663960771cee2f1d31",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 149,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "f9cf9ee9dc3c9f8839058794724e737fff111c45",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 151,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "6eb9d7b1ccdf70535ca0e836c44419e027459d43",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 152,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "e0c560c759eeec303154d7c01fed0a1ce34a4697",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 153,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "27d2b9e85eab498a62362eab962e996a864f383d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 154,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "e4df0ba45d52819f1a67aaa5cc1aacfe5df0483a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 155,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/src/utils/.config_hashes.json",
+        "hashed_secret": "d4a859cddefe39e2c29fb16b303fb95fc3394662",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 157,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "projects/rocprofiler-compute/tests/test_analyze_commands.py": [
+      {
+        "filename": "projects/rocprofiler-compute/tests/test_analyze_commands.py",
+        "hashed_secret": "810cc15b4c2739d50aca61b28f777c9225261998",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1962,
+        "type": "Base64 High Entropy String"
+      }
+    ],
+    "projects/rocprofiler-compute/tests/test_analyze_workloads.py": [
+      {
+        "filename": "projects/rocprofiler-compute/tests/test_analyze_workloads.py",
+        "hashed_secret": "b09c5ca0c98f9ed0be8d39bbdd1e9850ea526fc9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 44,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/tests/test_analyze_workloads.py",
+        "hashed_secret": "40fd9869361d4a45629ae985bdf24de0d307073c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 100,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/tests/test_analyze_workloads.py",
+        "hashed_secret": "c2c273caf51678910f6fe833e254541d6efb3a87",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 292,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/tests/test_analyze_workloads.py",
+        "hashed_secret": "f78585677a3de295de80a3164aae4b8c1858cf87",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 322,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/tests/test_analyze_workloads.py",
+        "hashed_secret": "7ee437091be9baf49305b73fa74bd9df4126c6d8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 760,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/tests/test_analyze_workloads.py",
+        "hashed_secret": "f3cdc985486f79781b18c90fbe86026175ed7ab3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1109,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/tests/test_analyze_workloads.py",
+        "hashed_secret": "0162fd796dbc5926d553f4e33c7588ab4fe1d71a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1339,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/tests/test_analyze_workloads.py",
+        "hashed_secret": "af1a457ffda63402a12b273de9d3212f70de7a24",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1371,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/tests/test_analyze_workloads.py",
+        "hashed_secret": "41f7976023e8aee8a4ba7c8c77d45d20f2c5e96f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1416,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/tests/test_analyze_workloads.py",
+        "hashed_secret": "779a2440ed89fda5866dd7a79f791330c2513d92",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1750,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/tests/test_analyze_workloads.py",
+        "hashed_secret": "5cf962d876023822ea935f333f5d868d4f1761a8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1767,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/tests/test_analyze_workloads.py",
+        "hashed_secret": "f9a5f0c47fe5e109fb832d5a5d2714122eb48328",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1784,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "filename": "projects/rocprofiler-compute/tests/test_analyze_workloads.py",
+        "hashed_secret": "2ee48aeca58cade073c06380695b6b66eca0f639",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1801,
+        "type": "Base64 High Entropy String"
+      }
+    ],
+    "projects/rocprofiler-compute/tests/workloads/vcopy_iteration_multiplexing/MI350/profiling_config.yaml": [
+      {
+        "filename": "projects/rocprofiler-compute/tests/workloads/vcopy_iteration_multiplexing/MI350/profiling_config.yaml",
+        "hashed_secret": "fbd28e7b93374e5f61ea489673efb01b25eb3e89",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Base64 High Entropy String"
+      }
+    ]
+  },
+  "version": "1.5.0"
+}


### PR DESCRIPTION
## Motivation

Add detect-secrets coverage for rocprofiler-compute to keep credentials and host-specific session data out of committed files.

Depends on PR #6246 ([rocprofiler-compute] Remove env-var dump from PC sampling log fixture), which must merge first so the new hook does not flag the leaked secret in `tests/workloads/vcopy_pc_sampling_only/MI300A_A1/log.txt`.

## Technical Details

- Add a rocprofiler-compute pre-commit configuration entry for `detect-secrets` v1.5.0 with `--baseline projects/rocprofiler-compute/.secrets.baseline`.
- Exclude the baseline file itself from the hook to avoid self-referential failures.
- Add the `.secrets.baseline` snapshot of existing rocprofiler-compute findings.

## JIRA ID

N/A

## Test Plan

- [x] Run `detect-secrets-hook --baseline .secrets.baseline` over rocprofiler-compute paths.
- [x] Validate that `.secrets.baseline` parses as JSON.

## Test Result

`detect-secrets-hook` exits successfully against tracked rocprofiler-compute files with the supplied baseline, and `.secrets.baseline` parses as valid JSON.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.