### PR TITLE
[rocprofiler-compute] Silently default unset/empty ROCPROF_* input env vars

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -41,7 +41,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Roofline panel L1/L2 bandwidth and arithmetic intensity on gfx942 and gfx950 now use the correct 128B cache line, matching the values reported in the Speed-of-Light and vL1D/L2 cache panels for the same run. Bandwidth values on these architectures are 2x and AI values are 0.5x compared to prior releases.
 
-* Fixed crash "ROCPROF_OUTPUT_PATH environment variable must be set" when profiling shell-script targets such as `rocprof-compute profile -o /tmp/out -- bash run.sh`. The collector library now snapshots `ROCPROF_*` variables from `extern char **environ`, bypassing user-defined `getenv()` symbols in LD_PRELOAD scenarios. The matching rocprofiler-sdk tool fix is tracked separately in ROCM-23799.
+* Fixed crash "ROCPROF_OUTPUT_PATH environment variable must be set" when profiling shell-script targets such as `rocprof-compute profile -o /tmp/out -- bash run.sh`. The collector library now snapshots `ROCPROF_*` variables from `extern char **environ`, bypassing user-defined `getenv()` symbols in LD_PRELOAD scenarios.
 
 * Fixed `inf` display for metrics with zero-denominator counters (e.g., L2-Fabric Write Latency when no write requests are issued). The metric evaluation path now catches `inf` scalar results and returns `"N/A"`, consistent with existing `NaN` handling.
 

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -41,7 +41,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Roofline panel L1/L2 bandwidth and arithmetic intensity on gfx942 and gfx950 now use the correct 128B cache line, matching the values reported in the Speed-of-Light and vL1D/L2 cache panels for the same run. Bandwidth values on these architectures are 2x and AI values are 0.5x compared to prior releases.
 
-* Fixed crash "ROCPROF_OUTPUT_PATH environment variable must be set" that aborted profiling when `ROCPROF_OUTPUT_PATH` was unset or empty (observed when profiling shell-script targets such as `rocprof-compute profile -o /tmp/out -- bash run.sh`). The collector now emits a warning and falls back to a documented default instead of aborting.
+* Fixed crash "ROCPROF_OUTPUT_PATH environment variable must be set" that aborted profiling when `ROCPROF_OUTPUT_PATH` was unset or empty (observed when profiling shell-script targets such as `rocprof-compute profile -o /tmp/out -- bash run.sh`). The collector now silently falls back to a documented default instead of aborting; debug builds emit a diagnostic noting the fallback.
 
 * Fixed `inf` display for metrics with zero-denominator counters (e.g., L2-Fabric Write Latency when no write requests are issued). The metric evaluation path now catches `inf` scalar results and returns `"N/A"`, consistent with existing `NaN` handling.
 

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -41,6 +41,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Roofline panel L1/L2 bandwidth and arithmetic intensity on gfx942 and gfx950 now use the correct 128B cache line, matching the values reported in the Speed-of-Light and vL1D/L2 cache panels for the same run. Bandwidth values on these architectures are 2x and AI values are 0.5x compared to prior releases.
 
+* Fixed crash "ROCPROF_OUTPUT_PATH environment variable must be set" when profiling shell-script targets such as `rocprof-compute profile -o /tmp/out -- bash run.sh`. The collector library now snapshots `ROCPROF_*` variables from `extern char **environ`, bypassing user-defined `getenv()` symbols in LD_PRELOAD scenarios. The matching rocprofiler-sdk tool fix is tracked separately in ROCM-23799.
+
 * Fixed `inf` display for metrics with zero-denominator counters (e.g., L2-Fabric Write Latency when no write requests are issued). The metric evaluation path now catches `inf` scalar results and returns `"N/A"`, consistent with existing `NaN` handling.
 
 * Kernels with missing counter data after iteration multiplexing imputation are now excluded from metrics calculations. A warning at analysis time lists the affected kernels. Their execution times remain visible in Top Stats.

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -41,7 +41,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Roofline panel L1/L2 bandwidth and arithmetic intensity on gfx942 and gfx950 now use the correct 128B cache line, matching the values reported in the Speed-of-Light and vL1D/L2 cache panels for the same run. Bandwidth values on these architectures are 2x and AI values are 0.5x compared to prior releases.
 
-* Fixed crash "ROCPROF_OUTPUT_PATH environment variable must be set" when profiling shell-script targets such as `rocprof-compute profile -o /tmp/out -- bash run.sh`. The collector library now snapshots `ROCPROF_*` variables from `extern char **environ`, bypassing user-defined `getenv()` symbols in LD_PRELOAD scenarios.
+* Fixed crash "ROCPROF_OUTPUT_PATH environment variable must be set" that aborted profiling when `ROCPROF_OUTPUT_PATH` was unset or empty (observed when profiling shell-script targets such as `rocprof-compute profile -o /tmp/out -- bash run.sh`). The collector now emits a warning and falls back to a documented default instead of aborting.
 
 * Fixed `inf` display for metrics with zero-denominator counters (e.g., L2-Fabric Write Latency when no write requests are issued). The metric evaluation path now catches `inf` scalar results and returns `"N/A"`, consistent with existing `NaN` handling.
 

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -41,7 +41,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Roofline panel L1/L2 bandwidth and arithmetic intensity on gfx942 and gfx950 now use the correct 128B cache line, matching the values reported in the Speed-of-Light and vL1D/L2 cache panels for the same run. Bandwidth values on these architectures are 2x and AI values are 0.5x compared to prior releases.
 
-* Fixed crash "ROCPROF_OUTPUT_PATH environment variable must be set" that aborted profiling when `ROCPROF_OUTPUT_PATH` was unset or empty (observed when profiling shell-script targets such as `rocprof-compute profile -o /tmp/out -- bash run.sh`). The collector now silently falls back to a documented default instead of aborting; debug builds emit a diagnostic noting the fallback.
+* Fixed crash "ROCPROF_OUTPUT_PATH environment variable must be set" that aborted profiling when `ROCPROF_OUTPUT_PATH` was unset or empty (observed when profiling shell-script targets such as `rocprof-compute profile -o /tmp/out -- bash run.sh`). The collector now silently falls back to a documented default instead of aborting.
 
 * Fixed `inf` display for metrics with zero-denominator counters (e.g., L2-Fabric Write Latency when no write requests are issued). The metric evaluation path now catches `inf` scalar results and returns `"N/A"`, consistent with existing `NaN` handling.
 

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -79,7 +79,9 @@ configure_file(
     @ONLY
 )
 
-set(CMAKE_BUILD_TYPE "Release")
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE)
+endif()
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "default install path" FORCE)
 endif()

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -79,9 +79,7 @@ configure_file(
     @ONLY
 )
 
-if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE)
-endif()
+set(CMAKE_BUILD_TYPE "Release")
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "default install path" FORCE)
 endif()

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/CMakeLists.txt
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(
     counters_writer.cpp
     sdk_callbacks.h
     sdk_callbacks.cpp
+    environ_cache.h
+    environ_cache.cpp
     input_parameters.h
     input_parameters.cpp
     sdk_wrapper.h

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/environ_cache.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/environ_cache.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#include "environ_cache.h"
+
+using namespace rocprofiler_compute_tool;
+
+extern "C" char** environ;
+
+namespace
+{
+constexpr std::string_view kRocprofPrefix{"ROCPROF_"};
+
+bool has_rocprof_prefix(std::string_view name)
+{
+    return name.size() >= kRocprofPrefix.size() &&
+           name.substr(0, kRocprofPrefix.size()) == kRocprofPrefix;
+}
+
+}  // namespace
+
+std::shared_ptr<const EnvironCache> EnvironCache::instance()
+{
+    static const std::shared_ptr<const EnvironCache> cache{new EnvironCache{environ}};
+    return cache;
+}
+
+EnvironCache::EnvironCache(char** envp)
+{
+    if (envp == nullptr)
+        return;
+
+    for (char** ep = envp; *ep != nullptr; ++ep)
+    {
+        const std::string_view entry{*ep};
+        const auto             separator = entry.find('=');
+        if (separator == std::string_view::npos)
+            continue;
+
+        const auto name = entry.substr(0, separator);
+        if (!has_rocprof_prefix(name))
+            continue;
+
+        m_values.emplace(std::string{name}, std::string{entry.substr(separator + 1)});
+    }
+}
+
+std::optional<std::string_view> EnvironCache::get(std::string_view name) const
+{
+    const auto value = m_values.find(std::string{name});
+    if (value != m_values.end())
+        return std::string_view{value->second};
+
+    return std::nullopt;
+}

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/environ_cache.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/environ_cache.cpp
@@ -12,8 +12,7 @@ constexpr std::string_view kRocprofPrefix{"ROCPROF_"};
 
 bool has_rocprof_prefix(std::string_view name)
 {
-    return name.size() >= kRocprofPrefix.size() &&
-           name.substr(0, kRocprofPrefix.size()) == kRocprofPrefix;
+    return name.size() >= kRocprofPrefix.size() && name.substr(0, kRocprofPrefix.size()) == kRocprofPrefix;
 }
 
 }  // namespace

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/environ_cache.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/environ_cache.h
@@ -1,0 +1,34 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace rocprofiler_compute_tool
+{
+// Snapshots all ROCPROF_* variables directly from the process environment block
+// at load time. Bypasses libc getenv() so LD_PRELOAD shims, such as shell-script
+// launchers, cannot intercept the lookup.
+class EnvironCache
+{
+public:
+    static std::shared_ptr<const EnvironCache> instance();
+
+    explicit EnvironCache(char** envp);
+    virtual ~EnvironCache() = default;
+
+    EnvironCache(const EnvironCache&)            = delete;
+    EnvironCache& operator=(const EnvironCache&) = delete;
+    EnvironCache(EnvironCache&&)                 = delete;
+    EnvironCache& operator=(EnvironCache&&)      = delete;
+
+    virtual std::optional<std::string_view> get(std::string_view name) const;
+
+private:
+    std::unordered_map<std::string, std::string> m_values;
+};
+}  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.cpp
@@ -2,31 +2,38 @@
 // SPDX-License-Identifier:  MIT
 #include "input_parameters.h"
 
-#include <stdlib.h>
+#include "environ_cache.h"
+
+#include <utility>
 
 using namespace rocprofiler_compute_tool;
 
-const char* EnvInputParameters::get_output_path()
+EnvInputParameters::EnvInputParameters(std::shared_ptr<const EnvironCache> environ)
+    : m_environ{std::move(environ)}
 {
-    return getenv("ROCPROF_OUTPUT_PATH");
 }
 
-const char* EnvInputParameters::get_requested_counters()
+std::optional<std::string_view> EnvInputParameters::get_output_path()
 {
-    return getenv("ROCPROF_COUNTERS");
+    return m_environ->get("ROCPROF_OUTPUT_PATH");
 }
 
-const char* EnvInputParameters::get_iteration_multiplexing_mode()
+std::optional<std::string_view> EnvInputParameters::get_requested_counters()
 {
-    return getenv("ROCPROF_ITERATION_MULTIPLEXING");
+    return m_environ->get("ROCPROF_COUNTERS");
 }
 
-const char* EnvInputParameters::get_kernel_filter_include_regex()
+std::optional<std::string_view> EnvInputParameters::get_iteration_multiplexing_mode()
 {
-    return getenv("ROCPROF_KERNEL_FILTER_INCLUDE_REGEX");
+    return m_environ->get("ROCPROF_ITERATION_MULTIPLEXING");
 }
 
-const char* EnvInputParameters::get_kernel_filter_range()
+std::optional<std::string_view> EnvInputParameters::get_kernel_filter_include_regex()
 {
-    return getenv("ROCPROF_KERNEL_FILTER_RANGE");
+    return m_environ->get("ROCPROF_KERNEL_FILTER_INCLUDE_REGEX");
+}
+
+std::optional<std::string_view> EnvInputParameters::get_kernel_filter_range()
+{
+    return m_environ->get("ROCPROF_KERNEL_FILTER_RANGE");
 }

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.cpp
@@ -21,9 +21,11 @@ std::string_view EnvInputParameters::get_or_warn(std::string_view env_var_name,
     if (v && !v->empty())
         return *v;
 
+#ifndef NDEBUG
     const auto reason = v ? std::string_view{"empty"} : std::string_view{"unset"};
-    std::clog << "\033[33m[rocprofiler-compute] WARNING: " << env_var_name << " is " << reason
-              << "; defaulting to \"" << default_value << "\"\033[0m" << std::endl;
+    std::clog << "[rocprofiler-compute] DEBUG: " << env_var_name << " is " << reason
+              << "; defaulting to \"" << default_value << "\"" << std::endl;
+#endif
     return default_value;
 }
 

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.cpp
@@ -4,6 +4,7 @@
 
 #include "environ_cache.h"
 
+#include <iostream>
 #include <utility>
 
 using namespace rocprofiler_compute_tool;
@@ -13,27 +14,40 @@ EnvInputParameters::EnvInputParameters(std::shared_ptr<const EnvironCache> envir
 {
 }
 
-std::optional<std::string_view> EnvInputParameters::get_output_path()
+std::string_view EnvInputParameters::get_or_warn(std::string_view env_var_name,
+                                                 std::string_view default_value)
 {
-    return m_environ->get("ROCPROF_OUTPUT_PATH");
+    const auto v = m_environ->get(env_var_name);
+    if (v && !v->empty())
+        return *v;
+
+    const auto reason = v ? std::string_view{"empty"} : std::string_view{"unset"};
+    std::clog << "\033[33m[rocprofiler-compute] WARNING: " << env_var_name << " is " << reason
+              << "; defaulting to \"" << default_value << "\"\033[0m" << std::endl;
+    return default_value;
 }
 
-std::optional<std::string_view> EnvInputParameters::get_requested_counters()
+std::string_view EnvInputParameters::get_output_path()
 {
-    return m_environ->get("ROCPROF_COUNTERS");
+    return get_or_warn("ROCPROF_OUTPUT_PATH", kDefaultOutputPath);
 }
 
-std::optional<std::string_view> EnvInputParameters::get_iteration_multiplexing_mode()
+std::string_view EnvInputParameters::get_requested_counters()
 {
-    return m_environ->get("ROCPROF_ITERATION_MULTIPLEXING");
+    return get_or_warn("ROCPROF_COUNTERS", kDefaultRequestedCounters);
 }
 
-std::optional<std::string_view> EnvInputParameters::get_kernel_filter_include_regex()
+std::string_view EnvInputParameters::get_iteration_multiplexing_mode()
 {
-    return m_environ->get("ROCPROF_KERNEL_FILTER_INCLUDE_REGEX");
+    return get_or_warn("ROCPROF_ITERATION_MULTIPLEXING", kDefaultIterationMultiplexingMode);
 }
 
-std::optional<std::string_view> EnvInputParameters::get_kernel_filter_range()
+std::string_view EnvInputParameters::get_kernel_filter_include_regex()
 {
-    return m_environ->get("ROCPROF_KERNEL_FILTER_RANGE");
+    return get_or_warn("ROCPROF_KERNEL_FILTER_INCLUDE_REGEX", kDefaultKernelFilterIncludeRegex);
+}
+
+std::string_view EnvInputParameters::get_kernel_filter_range()
+{
+    return get_or_warn("ROCPROF_KERNEL_FILTER_RANGE", kDefaultKernelFilterRange);
 }

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.cpp
@@ -13,8 +13,7 @@ EnvInputParameters::EnvInputParameters(std::shared_ptr<const EnvironCache> envir
 {
 }
 
-std::string_view EnvInputParameters::get(std::string_view env_var_name,
-                                         std::string_view default_value)
+std::string_view EnvInputParameters::get(std::string_view env_var_name, std::string_view default_value)
 {
     const auto v = m_environ->get(env_var_name);
     if (v && !v->empty())

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.cpp
@@ -4,7 +4,6 @@
 
 #include "environ_cache.h"
 
-#include <iostream>
 #include <utility>
 
 using namespace rocprofiler_compute_tool;
@@ -14,42 +13,36 @@ EnvInputParameters::EnvInputParameters(std::shared_ptr<const EnvironCache> envir
 {
 }
 
-std::string_view EnvInputParameters::get_or_warn(std::string_view env_var_name,
-                                                 std::string_view default_value)
+std::string_view EnvInputParameters::get(std::string_view env_var_name,
+                                         std::string_view default_value)
 {
     const auto v = m_environ->get(env_var_name);
     if (v && !v->empty())
         return *v;
-
-#ifndef NDEBUG
-    const auto reason = v ? std::string_view{"empty"} : std::string_view{"unset"};
-    std::clog << "[rocprofiler-compute] DEBUG: " << env_var_name << " is " << reason
-              << "; defaulting to \"" << default_value << "\"" << std::endl;
-#endif
     return default_value;
 }
 
 std::string_view EnvInputParameters::get_output_path()
 {
-    return get_or_warn("ROCPROF_OUTPUT_PATH", kDefaultOutputPath);
+    return get("ROCPROF_OUTPUT_PATH", kDefaultOutputPath);
 }
 
 std::string_view EnvInputParameters::get_requested_counters()
 {
-    return get_or_warn("ROCPROF_COUNTERS", kDefaultRequestedCounters);
+    return get("ROCPROF_COUNTERS", kDefaultRequestedCounters);
 }
 
 std::string_view EnvInputParameters::get_iteration_multiplexing_mode()
 {
-    return get_or_warn("ROCPROF_ITERATION_MULTIPLEXING", kDefaultIterationMultiplexingMode);
+    return get("ROCPROF_ITERATION_MULTIPLEXING", kDefaultIterationMultiplexingMode);
 }
 
 std::string_view EnvInputParameters::get_kernel_filter_include_regex()
 {
-    return get_or_warn("ROCPROF_KERNEL_FILTER_INCLUDE_REGEX", kDefaultKernelFilterIncludeRegex);
+    return get("ROCPROF_KERNEL_FILTER_INCLUDE_REGEX", kDefaultKernelFilterIncludeRegex);
 }
 
 std::string_view EnvInputParameters::get_kernel_filter_range()
 {
-    return get_or_warn("ROCPROF_KERNEL_FILTER_RANGE", kDefaultKernelFilterRange);
+    return get("ROCPROF_KERNEL_FILTER_RANGE", kDefaultKernelFilterRange);
 }

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.h
@@ -24,12 +24,6 @@ public:
 class EnvInputParameters : public InputParameters
 {
 public:
-    static constexpr std::string_view kDefaultOutputPath{"./workloads/"};
-    static constexpr std::string_view kDefaultRequestedCounters{""};
-    static constexpr std::string_view kDefaultIterationMultiplexingMode{""};
-    static constexpr std::string_view kDefaultKernelFilterIncludeRegex{""};
-    static constexpr std::string_view kDefaultKernelFilterRange{""};
-
     static std::string_view get_default_output_path() { return kDefaultOutputPath; }
 
     static std::string_view get_default_requested_counters() { return kDefaultRequestedCounters; }
@@ -54,6 +48,12 @@ public:
     std::string_view get_kernel_filter_range() override;
 
 private:
+    static constexpr std::string_view kDefaultOutputPath{"./"};
+    static constexpr std::string_view kDefaultRequestedCounters{""};
+    static constexpr std::string_view kDefaultIterationMultiplexingMode{""};
+    static constexpr std::string_view kDefaultKernelFilterIncludeRegex{""};
+    static constexpr std::string_view kDefaultKernelFilterRange{""};
+
     std::string_view get_or_warn(std::string_view env_var_name, std::string_view default_value);
 
     std::shared_ptr<const EnvironCache> m_environ;

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.h
@@ -25,6 +25,24 @@ public:
 class EnvInputParameters : public InputParameters
 {
 public:
+    static constexpr std::string_view kDefaultOutputPath{"./workloads/"};
+    static constexpr std::string_view kDefaultRequestedCounters{""};
+    static constexpr std::string_view kDefaultIterationMultiplexingMode{""};
+    static constexpr std::string_view kDefaultKernelFilterIncludeRegex{""};
+    static constexpr std::string_view kDefaultKernelFilterRange{""};
+
+    static std::string_view get_default_output_path() { return kDefaultOutputPath; }
+    static std::string_view get_default_requested_counters() { return kDefaultRequestedCounters; }
+    static std::string_view get_default_iteration_multiplexing_mode()
+    {
+        return kDefaultIterationMultiplexingMode;
+    }
+    static std::string_view get_default_kernel_filter_include_regex()
+    {
+        return kDefaultKernelFilterIncludeRegex;
+    }
+    static std::string_view get_default_kernel_filter_range() { return kDefaultKernelFilterRange; }
+
     explicit EnvInputParameters(std::shared_ptr<const EnvironCache> environ = EnvironCache::instance());
     std::optional<std::string_view> get_output_path() override;
     std::optional<std::string_view> get_requested_counters() override;

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.h
@@ -2,25 +2,37 @@
 // SPDX-License-Identifier:  MIT
 #pragma once
 
+#include "environ_cache.h"
+
+#include <memory>
+#include <optional>
+#include <string_view>
+
 namespace rocprofiler_compute_tool
 {
 class InputParameters
 {
 public:
-    virtual const char* get_output_path()                 = 0;
-    virtual const char* get_requested_counters()          = 0;
-    virtual const char* get_iteration_multiplexing_mode() = 0;
-    virtual const char* get_kernel_filter_include_regex() = 0;
-    virtual const char* get_kernel_filter_range()         = 0;
+    virtual ~InputParameters() = default;
+
+    virtual std::optional<std::string_view> get_output_path()                 = 0;
+    virtual std::optional<std::string_view> get_requested_counters()          = 0;
+    virtual std::optional<std::string_view> get_iteration_multiplexing_mode() = 0;
+    virtual std::optional<std::string_view> get_kernel_filter_include_regex() = 0;
+    virtual std::optional<std::string_view> get_kernel_filter_range()         = 0;
 };
 
 class EnvInputParameters : public InputParameters
 {
 public:
-    const char* get_output_path() override;
-    const char* get_requested_counters() override;
-    const char* get_iteration_multiplexing_mode() override;
-    const char* get_kernel_filter_include_regex() override;
-    const char* get_kernel_filter_range() override;
+    explicit EnvInputParameters(std::shared_ptr<const EnvironCache> environ = EnvironCache::instance());
+    std::optional<std::string_view> get_output_path() override;
+    std::optional<std::string_view> get_requested_counters() override;
+    std::optional<std::string_view> get_iteration_multiplexing_mode() override;
+    std::optional<std::string_view> get_kernel_filter_include_regex() override;
+    std::optional<std::string_view> get_kernel_filter_range() override;
+
+private:
+    std::shared_ptr<const EnvironCache> m_environ;
 };
 }  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.h
@@ -24,21 +24,11 @@ public:
 class EnvInputParameters : public InputParameters
 {
 public:
-    static std::string_view get_default_output_path() { return kDefaultOutputPath; }
-
-    static std::string_view get_default_requested_counters() { return kDefaultRequestedCounters; }
-
-    static std::string_view get_default_iteration_multiplexing_mode()
-    {
-        return kDefaultIterationMultiplexingMode;
-    }
-
-    static std::string_view get_default_kernel_filter_include_regex()
-    {
-        return kDefaultKernelFilterIncludeRegex;
-    }
-
-    static std::string_view get_default_kernel_filter_range() { return kDefaultKernelFilterRange; }
+    static constexpr std::string_view kDefaultOutputPath{"./"};
+    static constexpr std::string_view kDefaultRequestedCounters{""};
+    static constexpr std::string_view kDefaultIterationMultiplexingMode{""};
+    static constexpr std::string_view kDefaultKernelFilterIncludeRegex{""};
+    static constexpr std::string_view kDefaultKernelFilterRange{""};
 
     explicit EnvInputParameters(std::shared_ptr<const EnvironCache> environ = EnvironCache::instance());
     std::string_view get_output_path() override;
@@ -48,13 +38,7 @@ public:
     std::string_view get_kernel_filter_range() override;
 
 private:
-    static constexpr std::string_view kDefaultOutputPath{"./"};
-    static constexpr std::string_view kDefaultRequestedCounters{""};
-    static constexpr std::string_view kDefaultIterationMultiplexingMode{""};
-    static constexpr std::string_view kDefaultKernelFilterIncludeRegex{""};
-    static constexpr std::string_view kDefaultKernelFilterRange{""};
-
-    std::string_view get_or_warn(std::string_view env_var_name, std::string_view default_value);
+    std::string_view get(std::string_view env_var_name, std::string_view default_value);
 
     std::shared_ptr<const EnvironCache> m_environ;
 };

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.h
@@ -5,7 +5,6 @@
 #include "environ_cache.h"
 
 #include <memory>
-#include <optional>
 #include <string_view>
 
 namespace rocprofiler_compute_tool
@@ -15,11 +14,11 @@ class InputParameters
 public:
     virtual ~InputParameters() = default;
 
-    virtual std::optional<std::string_view> get_output_path()                 = 0;
-    virtual std::optional<std::string_view> get_requested_counters()          = 0;
-    virtual std::optional<std::string_view> get_iteration_multiplexing_mode() = 0;
-    virtual std::optional<std::string_view> get_kernel_filter_include_regex() = 0;
-    virtual std::optional<std::string_view> get_kernel_filter_range()         = 0;
+    virtual std::string_view get_output_path()                 = 0;
+    virtual std::string_view get_requested_counters()          = 0;
+    virtual std::string_view get_iteration_multiplexing_mode() = 0;
+    virtual std::string_view get_kernel_filter_include_regex() = 0;
+    virtual std::string_view get_kernel_filter_range()         = 0;
 };
 
 class EnvInputParameters : public InputParameters
@@ -48,13 +47,15 @@ public:
     static std::string_view get_default_kernel_filter_range() { return kDefaultKernelFilterRange; }
 
     explicit EnvInputParameters(std::shared_ptr<const EnvironCache> environ = EnvironCache::instance());
-    std::optional<std::string_view> get_output_path() override;
-    std::optional<std::string_view> get_requested_counters() override;
-    std::optional<std::string_view> get_iteration_multiplexing_mode() override;
-    std::optional<std::string_view> get_kernel_filter_include_regex() override;
-    std::optional<std::string_view> get_kernel_filter_range() override;
+    std::string_view get_output_path() override;
+    std::string_view get_requested_counters() override;
+    std::string_view get_iteration_multiplexing_mode() override;
+    std::string_view get_kernel_filter_include_regex() override;
+    std::string_view get_kernel_filter_range() override;
 
 private:
+    std::string_view get_or_warn(std::string_view env_var_name, std::string_view default_value);
+
     std::shared_ptr<const EnvironCache> m_environ;
 };
 }  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.h
@@ -32,15 +32,19 @@ public:
     static constexpr std::string_view kDefaultKernelFilterRange{""};
 
     static std::string_view get_default_output_path() { return kDefaultOutputPath; }
+
     static std::string_view get_default_requested_counters() { return kDefaultRequestedCounters; }
+
     static std::string_view get_default_iteration_multiplexing_mode()
     {
         return kDefaultIterationMultiplexingMode;
     }
+
     static std::string_view get_default_kernel_filter_include_regex()
     {
         return kDefaultKernelFilterIncludeRegex;
     }
+
     static std::string_view get_default_kernel_filter_range() { return kDefaultKernelFilterRange; }
 
     explicit EnvInputParameters(std::shared_ptr<const EnvironCache> environ = EnvironCache::instance());

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
@@ -150,10 +150,6 @@ void tool_fini(void* user_data)
 
 static std::string generate_output_filename(std::string_view output_path)
 {
-    if (output_path.empty())
-    {
-        throw std::runtime_error("Output path is empty");
-    }
     std::string filename{output_path};
     if (filename.back() != '/')
         filename += '/';
@@ -166,8 +162,16 @@ std::unique_ptr<tool_data_t> create_tool_data(rocprofiler_client_id_t* /*id*/)
 {
     auto tool_data = std::make_unique<tool_data_t>();
 
-    tool_data->output_filename = generate_output_filename(
-        g_input_parameters->get_output_path().value_or(std::string_view{}));
+    auto output_path = g_input_parameters->get_output_path();
+    if (!output_path || output_path->empty())
+    {
+        auto reason = !output_path ? std::string_view{"unset"} : std::string_view{"empty"};
+        output_path = EnvInputParameters::get_default_output_path();
+        std::clog << "\033[33m[rocprofiler-compute] [" << __FUNCTION__
+                  << "] WARNING: ROCPROF_OUTPUT_PATH is " << reason << "; defaulting to \""
+                  << *output_path << "\"\033[0m" << std::endl;
+    }
+    tool_data->output_filename = generate_output_filename(*output_path);
 
     // ROCPROF_COUNTERS env. var. is a string like "pmc: counter1 counter2 ..."
     if (const auto v = g_input_parameters->get_requested_counters())

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
@@ -166,8 +166,8 @@ std::unique_ptr<tool_data_t> create_tool_data(rocprofiler_client_id_t* /*id*/)
 {
     auto tool_data = std::make_unique<tool_data_t>();
 
-    tool_data->output_filename =
-        generate_output_filename(g_input_parameters->get_output_path().value_or(std::string_view{}));
+    tool_data->output_filename = generate_output_filename(
+        g_input_parameters->get_output_path().value_or(std::string_view{}));
 
     // ROCPROF_COUNTERS env. var. is a string like "pmc: counter1 counter2 ..."
     if (const auto v = g_input_parameters->get_requested_counters())

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
@@ -162,66 +162,53 @@ std::unique_ptr<tool_data_t> create_tool_data(rocprofiler_client_id_t* /*id*/)
 {
     auto tool_data = std::make_unique<tool_data_t>();
 
-    auto output_path = g_input_parameters->get_output_path();
-    if (!output_path || output_path->empty())
-    {
-        auto reason = !output_path ? std::string_view{"unset"} : std::string_view{"empty"};
-        output_path = EnvInputParameters::get_default_output_path();
-        std::clog << "\033[33m[rocprofiler-compute] [" << __FUNCTION__
-                  << "] WARNING: ROCPROF_OUTPUT_PATH is " << reason << "; defaulting to \""
-                  << *output_path << "\"\033[0m" << std::endl;
-    }
-    tool_data->output_filename = generate_output_filename(*output_path);
+    tool_data->output_filename = generate_output_filename(g_input_parameters->get_output_path());
 
     // ROCPROF_COUNTERS env. var. is a string like "pmc: counter1 counter2 ..."
-    if (const auto v = g_input_parameters->get_requested_counters())
-        tool_data->requested_counters = std::string{*v};
+    tool_data->requested_counters = std::string{g_input_parameters->get_requested_counters()};
 
-    if (const auto v = g_input_parameters->get_iteration_multiplexing_mode())
-        tool_data->iteration_multiplexing_mode = iteration_multiplexing_mode(*v);
+    tool_data->iteration_multiplexing_mode = iteration_multiplexing_mode(
+        g_input_parameters->get_iteration_multiplexing_mode());
 
     // ROCPROF_KERNEL_FILTER_INCLUDE_REGEX env. var. is a regex string like
     // kernel_name_1|kernel_name_2|... Used to collect counters only for kernels
     // with names matching the regex
-    if (const auto v = g_input_parameters->get_kernel_filter_include_regex())
-        tool_data->kernel_filter_include_regex = std::string{*v};
+    tool_data->kernel_filter_include_regex = std::string{
+        g_input_parameters->get_kernel_filter_include_regex()};
 
     // ROCPROF_KERNEL_FILTER_RANGE env. var. is a string like "[4,7-9,...]"
-    if (const auto v = g_input_parameters->get_kernel_filter_range())
+    std::string v_str{g_input_parameters->get_kernel_filter_range()};
+    // Remove square brackets at the ends if present
+    if (!v_str.empty() && v_str.front() == '[')
+        v_str.erase(0, 1);
+    if (!v_str.empty() && v_str.back() == ']')
+        v_str.pop_back();
+    // Parse the range string into vector of pairs
+    std::istringstream ss{v_str};
+    for (std::string token; std::getline(ss, token, ',');)
     {
-        // Remove square brackets at the ends if present
-        std::string v_str{*v};
-        if (!v_str.empty() && v_str.front() == '[')
-            v_str.erase(0, 1);
-        if (!v_str.empty() && v_str.back() == ']')
-            v_str.pop_back();
-        // Parse the range string into vector of pairs
-        std::istringstream ss{v_str};
-        for (std::string token; std::getline(ss, token, ',');)
+        size_t dash_pos = token.find('-');
+        try
         {
-            size_t dash_pos = token.find('-');
-            try
+            if (dash_pos == std::string::npos)
             {
-                if (dash_pos == std::string::npos)
-                {
-                    // single number
-                    uint64_t num = std::stoull(token);
-                    tool_data->kernel_filter_ranges.emplace_back(num, num);
-                }
-                else
-                {
-                    // range of numbers
-                    uint64_t start = std::stoull(token.substr(0, dash_pos));
-                    uint64_t end   = std::stoull(token.substr(dash_pos + 1));
-                    tool_data->kernel_filter_ranges.emplace_back(start, end);
-                }
+                // single number
+                uint64_t num = std::stoull(token);
+                tool_data->kernel_filter_ranges.emplace_back(num, num);
             }
-            catch (const std::invalid_argument&)
+            else
             {
-                std::cerr << "[rocprofiler-compute] [" << __FUNCTION__
-                          << "] ERROR: Invalid entry in ROCPROF_KERNEL_FILTER_RANGE: " << token
-                          << std::endl;
+                // range of numbers
+                uint64_t start = std::stoull(token.substr(0, dash_pos));
+                uint64_t end   = std::stoull(token.substr(dash_pos + 1));
+                tool_data->kernel_filter_ranges.emplace_back(start, end);
             }
+        }
+        catch (const std::invalid_argument&)
+        {
+            std::cerr << "[rocprofiler-compute] [" << __FUNCTION__
+                      << "] ERROR: Invalid entry in ROCPROF_KERNEL_FILTER_RANGE: " << token
+                      << std::endl;
         }
     }
 

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <string_view>
 
 using namespace rocprofiler_compute_tool;
 
@@ -50,7 +51,7 @@ static rocprofiler_context_id_t& get_client_ctx()
     return ctx;
 }
 
-iteration_multiplexing_mode_t iteration_multiplexing_mode(const std::string& mode)
+iteration_multiplexing_mode_t iteration_multiplexing_mode(std::string_view mode)
 {
     if (mode == "kernel")
         return iteration_multiplexing_mode_t::KERNEL;
@@ -147,13 +148,13 @@ void tool_fini(void* user_data)
 
 }  // namespace rocprofiler_compute_tool
 
-static std::string generate_output_filename(const char* output_path)
+static std::string generate_output_filename(std::string_view output_path)
 {
-    if (!output_path || !*output_path)
+    if (output_path.empty())
     {
         throw std::runtime_error("Output path is empty");
     }
-    std::string filename = output_path;
+    std::string filename{output_path};
     if (filename.back() != '/')
         filename += '/';
 
@@ -165,33 +166,33 @@ std::unique_ptr<tool_data_t> create_tool_data(rocprofiler_client_id_t* /*id*/)
 {
     auto tool_data = std::make_unique<tool_data_t>();
 
-    tool_data->output_filename = generate_output_filename(g_input_parameters->get_output_path());
+    tool_data->output_filename =
+        generate_output_filename(g_input_parameters->get_output_path().value_or(std::string_view{}));
 
     // ROCPROF_COUNTERS env. var. is a string like "pmc: counter1 counter2 ..."
-    if (const char* v = g_input_parameters->get_requested_counters())
-        tool_data->requested_counters = v;
+    if (const auto v = g_input_parameters->get_requested_counters())
+        tool_data->requested_counters = std::string{*v};
 
-    if (const char* v = g_input_parameters->get_iteration_multiplexing_mode())
-        tool_data->iteration_multiplexing_mode = iteration_multiplexing_mode(v);
+    if (const auto v = g_input_parameters->get_iteration_multiplexing_mode())
+        tool_data->iteration_multiplexing_mode = iteration_multiplexing_mode(*v);
 
     // ROCPROF_KERNEL_FILTER_INCLUDE_REGEX env. var. is a regex string like
     // kernel_name_1|kernel_name_2|... Used to collect counters only for kernels
     // with names matching the regex
-    if (const char* v = g_input_parameters->get_kernel_filter_include_regex())
-        tool_data->kernel_filter_include_regex = v;
+    if (const auto v = g_input_parameters->get_kernel_filter_include_regex())
+        tool_data->kernel_filter_include_regex = std::string{*v};
 
     // ROCPROF_KERNEL_FILTER_RANGE env. var. is a string like "[4,7-9,...]"
-    if (const char* v = g_input_parameters->get_kernel_filter_range())
+    if (const auto v = g_input_parameters->get_kernel_filter_range())
     {
         // Remove square brackets at the ends if present
-        std::string v_str = v;
+        std::string v_str{*v};
         if (!v_str.empty() && v_str.front() == '[')
             v_str.erase(0, 1);
         if (!v_str.empty() && v_str.back() == ']')
             v_str.pop_back();
-        v = v_str.c_str();
         // Parse the range string into vector of pairs
-        std::istringstream ss(v);
+        std::istringstream ss{v_str};
         for (std::string token; std::getline(ss, token, ',');)
         {
             size_t dash_pos = token.find('-');

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.h
@@ -8,11 +8,17 @@
 #include <rocprofiler-sdk/registration.h>
 
 #include <memory>
+#include <string_view>
 
 rocprofiler_tool_configure_result_t* rocprofiler_configure(uint32_t                 version,
                                                            const char*              runtime_version,
                                                            uint32_t                 priority,
                                                            rocprofiler_client_id_t* id);
+
+namespace rocprofiler_compute_tool
+{
+iteration_multiplexing_mode_t iteration_multiplexing_mode(std::string_view mode);
+}  // namespace rocprofiler_compute_tool
 
 namespace rocprofiler_compute_tool::test_knobs
 {

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/CMakeLists.txt
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/CMakeLists.txt
@@ -8,6 +8,8 @@ add_executable(
     test_rocprofiler_compute_tool.cpp
     test_sdk_callbacks.h
     test_sdk_callbacks.cpp
+    test_environ_cache.h
+    test_environ_cache.cpp
     mocks.h
     mocks.cpp
     main.cpp

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
@@ -8,53 +8,75 @@
 
 std::optional<std::string_view> MockInputParameters::get_output_path()
 {
+    if (!m_output_path_set) return std::nullopt;
     return std::string_view{m_output_path};
 }
 
 std::optional<std::string_view> MockInputParameters::get_requested_counters()
 {
+    if (!m_requested_counters_set) return std::nullopt;
     return std::string_view{m_requested_counters};
 }
 
 std::optional<std::string_view> MockInputParameters::get_iteration_multiplexing_mode()
 {
+    if (!m_iteration_multiplexing_mode_set) return std::nullopt;
     return std::string_view{m_iteration_multiplexing_mode};
 }
 
 std::optional<std::string_view> MockInputParameters::get_kernel_filter_include_regex()
 {
+    if (!m_kernel_filter_include_regex_set) return std::nullopt;
     return std::string_view{m_kernel_filter_include_regex};
 }
 
 std::optional<std::string_view> MockInputParameters::get_kernel_filter_range()
 {
+    if (!m_kernel_filter_range_set) return std::nullopt;
     return std::string_view{m_kernel_filter_range};
 }
 
 void MockInputParameters::set_output_path(const std::string& output_path)
 {
-    m_output_path = output_path;
+    m_output_path     = output_path;
+    m_output_path_set = true;
 }
 
 void MockInputParameters::set_requested_counters(const std::string& counters)
 {
-    m_requested_counters = counters;
+    m_requested_counters     = counters;
+    m_requested_counters_set = true;
 }
 
 void MockInputParameters::set_iteration_multiplexing_mode(const std::string& mode)
 {
-    m_iteration_multiplexing_mode = mode;
+    m_iteration_multiplexing_mode     = mode;
+    m_iteration_multiplexing_mode_set = true;
 }
 
 void MockInputParameters::set_kernel_filter_include_regex(const std::string& regex)
 {
-    m_kernel_filter_include_regex = regex;
+    m_kernel_filter_include_regex     = regex;
+    m_kernel_filter_include_regex_set = true;
 }
 
 void MockInputParameters::set_kernel_filter_range(const std::string& range)
 {
-    m_kernel_filter_range = range;
+    m_kernel_filter_range     = range;
+    m_kernel_filter_range_set = true;
 }
+
+void MockInputParameters::unset_output_path() { m_output_path_set = false; }
+void MockInputParameters::unset_requested_counters() { m_requested_counters_set = false; }
+void MockInputParameters::unset_iteration_multiplexing_mode()
+{
+    m_iteration_multiplexing_mode_set = false;
+}
+void MockInputParameters::unset_kernel_filter_include_regex()
+{
+    m_kernel_filter_include_regex_set = false;
+}
+void MockInputParameters::unset_kernel_filter_range() { m_kernel_filter_range_set = false; }
 
 /////////////////////////////////////////////////////////////////////////
 // MockSdkWrapper

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
@@ -9,35 +9,35 @@
 std::string_view MockInputParameters::get_output_path()
 {
     if (!m_output_path_set || m_output_path.empty())
-        return rocprofiler_compute_tool::EnvInputParameters::get_default_output_path();
+        return rocprofiler_compute_tool::EnvInputParameters::kDefaultOutputPath;
     return std::string_view{m_output_path};
 }
 
 std::string_view MockInputParameters::get_requested_counters()
 {
     if (!m_requested_counters_set || m_requested_counters.empty())
-        return rocprofiler_compute_tool::EnvInputParameters::get_default_requested_counters();
+        return rocprofiler_compute_tool::EnvInputParameters::kDefaultRequestedCounters;
     return std::string_view{m_requested_counters};
 }
 
 std::string_view MockInputParameters::get_iteration_multiplexing_mode()
 {
     if (!m_iteration_multiplexing_mode_set || m_iteration_multiplexing_mode.empty())
-        return rocprofiler_compute_tool::EnvInputParameters::get_default_iteration_multiplexing_mode();
+        return rocprofiler_compute_tool::EnvInputParameters::kDefaultIterationMultiplexingMode;
     return std::string_view{m_iteration_multiplexing_mode};
 }
 
 std::string_view MockInputParameters::get_kernel_filter_include_regex()
 {
     if (!m_kernel_filter_include_regex_set || m_kernel_filter_include_regex.empty())
-        return rocprofiler_compute_tool::EnvInputParameters::get_default_kernel_filter_include_regex();
+        return rocprofiler_compute_tool::EnvInputParameters::kDefaultKernelFilterIncludeRegex;
     return std::string_view{m_kernel_filter_include_regex};
 }
 
 std::string_view MockInputParameters::get_kernel_filter_range()
 {
     if (!m_kernel_filter_range_set || m_kernel_filter_range.empty())
-        return rocprofiler_compute_tool::EnvInputParameters::get_default_kernel_filter_range();
+        return rocprofiler_compute_tool::EnvInputParameters::kDefaultKernelFilterRange;
     return std::string_view{m_kernel_filter_range};
 }
 

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
@@ -6,38 +6,38 @@
 
 #include <utility>
 
-std::optional<std::string_view> MockInputParameters::get_output_path()
+std::string_view MockInputParameters::get_output_path()
 {
-    if (!m_output_path_set)
-        return std::nullopt;
+    if (!m_output_path_set || m_output_path.empty())
+        return rocprofiler_compute_tool::EnvInputParameters::get_default_output_path();
     return std::string_view{m_output_path};
 }
 
-std::optional<std::string_view> MockInputParameters::get_requested_counters()
+std::string_view MockInputParameters::get_requested_counters()
 {
-    if (!m_requested_counters_set)
-        return std::nullopt;
+    if (!m_requested_counters_set || m_requested_counters.empty())
+        return rocprofiler_compute_tool::EnvInputParameters::get_default_requested_counters();
     return std::string_view{m_requested_counters};
 }
 
-std::optional<std::string_view> MockInputParameters::get_iteration_multiplexing_mode()
+std::string_view MockInputParameters::get_iteration_multiplexing_mode()
 {
-    if (!m_iteration_multiplexing_mode_set)
-        return std::nullopt;
+    if (!m_iteration_multiplexing_mode_set || m_iteration_multiplexing_mode.empty())
+        return rocprofiler_compute_tool::EnvInputParameters::get_default_iteration_multiplexing_mode();
     return std::string_view{m_iteration_multiplexing_mode};
 }
 
-std::optional<std::string_view> MockInputParameters::get_kernel_filter_include_regex()
+std::string_view MockInputParameters::get_kernel_filter_include_regex()
 {
-    if (!m_kernel_filter_include_regex_set)
-        return std::nullopt;
+    if (!m_kernel_filter_include_regex_set || m_kernel_filter_include_regex.empty())
+        return rocprofiler_compute_tool::EnvInputParameters::get_default_kernel_filter_include_regex();
     return std::string_view{m_kernel_filter_include_regex};
 }
 
-std::optional<std::string_view> MockInputParameters::get_kernel_filter_range()
+std::string_view MockInputParameters::get_kernel_filter_range()
 {
-    if (!m_kernel_filter_range_set)
-        return std::nullopt;
+    if (!m_kernel_filter_range_set || m_kernel_filter_range.empty())
+        return rocprofiler_compute_tool::EnvInputParameters::get_default_kernel_filter_range();
     return std::string_view{m_kernel_filter_range};
 }
 

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
@@ -8,31 +8,36 @@
 
 std::optional<std::string_view> MockInputParameters::get_output_path()
 {
-    if (!m_output_path_set) return std::nullopt;
+    if (!m_output_path_set)
+        return std::nullopt;
     return std::string_view{m_output_path};
 }
 
 std::optional<std::string_view> MockInputParameters::get_requested_counters()
 {
-    if (!m_requested_counters_set) return std::nullopt;
+    if (!m_requested_counters_set)
+        return std::nullopt;
     return std::string_view{m_requested_counters};
 }
 
 std::optional<std::string_view> MockInputParameters::get_iteration_multiplexing_mode()
 {
-    if (!m_iteration_multiplexing_mode_set) return std::nullopt;
+    if (!m_iteration_multiplexing_mode_set)
+        return std::nullopt;
     return std::string_view{m_iteration_multiplexing_mode};
 }
 
 std::optional<std::string_view> MockInputParameters::get_kernel_filter_include_regex()
 {
-    if (!m_kernel_filter_include_regex_set) return std::nullopt;
+    if (!m_kernel_filter_include_regex_set)
+        return std::nullopt;
     return std::string_view{m_kernel_filter_include_regex};
 }
 
 std::optional<std::string_view> MockInputParameters::get_kernel_filter_range()
 {
-    if (!m_kernel_filter_range_set) return std::nullopt;
+    if (!m_kernel_filter_range_set)
+        return std::nullopt;
     return std::string_view{m_kernel_filter_range};
 }
 
@@ -66,17 +71,30 @@ void MockInputParameters::set_kernel_filter_range(const std::string& range)
     m_kernel_filter_range_set = true;
 }
 
-void MockInputParameters::unset_output_path() { m_output_path_set = false; }
-void MockInputParameters::unset_requested_counters() { m_requested_counters_set = false; }
+void MockInputParameters::unset_output_path()
+{
+    m_output_path_set = false;
+}
+
+void MockInputParameters::unset_requested_counters()
+{
+    m_requested_counters_set = false;
+}
+
 void MockInputParameters::unset_iteration_multiplexing_mode()
 {
     m_iteration_multiplexing_mode_set = false;
 }
+
 void MockInputParameters::unset_kernel_filter_include_regex()
 {
     m_kernel_filter_include_regex_set = false;
 }
-void MockInputParameters::unset_kernel_filter_range() { m_kernel_filter_range_set = false; }
+
+void MockInputParameters::unset_kernel_filter_range()
+{
+    m_kernel_filter_range_set = false;
+}
 
 /////////////////////////////////////////////////////////////////////////
 // MockSdkWrapper

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
@@ -4,29 +4,31 @@
 
 #include "gsl_assert.h"
 
-const char* MockInputParameters::get_output_path()
+#include <utility>
+
+std::optional<std::string_view> MockInputParameters::get_output_path()
 {
-    return m_output_path.c_str();
+    return std::string_view{m_output_path};
 }
 
-const char* MockInputParameters::get_requested_counters()
+std::optional<std::string_view> MockInputParameters::get_requested_counters()
 {
-    return m_requested_counters.c_str();
+    return std::string_view{m_requested_counters};
 }
 
-const char* MockInputParameters::get_iteration_multiplexing_mode()
+std::optional<std::string_view> MockInputParameters::get_iteration_multiplexing_mode()
 {
-    return m_iteration_multiplexing_mode.c_str();
+    return std::string_view{m_iteration_multiplexing_mode};
 }
 
-const char* MockInputParameters::get_kernel_filter_include_regex()
+std::optional<std::string_view> MockInputParameters::get_kernel_filter_include_regex()
 {
-    return m_kernel_filter_include_regex.c_str();
+    return std::string_view{m_kernel_filter_include_regex};
 }
 
-const char* MockInputParameters::get_kernel_filter_range()
+std::optional<std::string_view> MockInputParameters::get_kernel_filter_range()
 {
-    return m_kernel_filter_range.c_str();
+    return std::string_view{m_kernel_filter_range};
 }
 
 void MockInputParameters::set_output_path(const std::string& output_path)

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
@@ -8,14 +8,18 @@
 
 #include <gmock/gmock.h>
 
+#include <optional>
+#include <string>
+#include <string_view>
+
 class MockInputParameters : public rocprofiler_compute_tool::InputParameters
 {
 public:
-    const char* get_output_path() override;
-    const char* get_requested_counters() override;
-    const char* get_iteration_multiplexing_mode() override;
-    const char* get_kernel_filter_include_regex() override;
-    const char* get_kernel_filter_range() override;
+    std::optional<std::string_view> get_output_path() override;
+    std::optional<std::string_view> get_requested_counters() override;
+    std::optional<std::string_view> get_iteration_multiplexing_mode() override;
+    std::optional<std::string_view> get_kernel_filter_include_regex() override;
+    std::optional<std::string_view> get_kernel_filter_range() override;
 
     void set_output_path(const std::string& output_path);
     void set_requested_counters(const std::string& counters);

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
@@ -27,6 +27,12 @@ public:
     void set_kernel_filter_include_regex(const std::string& regex);
     void set_kernel_filter_range(const std::string& range);
 
+    void unset_output_path();
+    void unset_requested_counters();
+    void unset_iteration_multiplexing_mode();
+    void unset_kernel_filter_include_regex();
+    void unset_kernel_filter_range();
+
 private:
     const char* m_non_empty_str               = "non empty string";
     std::string m_output_path                 = m_non_empty_str;
@@ -34,6 +40,12 @@ private:
     std::string m_iteration_multiplexing_mode = m_non_empty_str;
     std::string m_kernel_filter_include_regex = m_non_empty_str;
     std::string m_kernel_filter_range         = m_non_empty_str;
+
+    bool m_output_path_set                 = true;
+    bool m_requested_counters_set          = true;
+    bool m_iteration_multiplexing_mode_set = true;
+    bool m_kernel_filter_include_regex_set = true;
+    bool m_kernel_filter_range_set         = true;
 };
 
 class MockSdkWrapper : public rocprofiler_compute_tool::SdkWrapper

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
@@ -8,18 +8,17 @@
 
 #include <gmock/gmock.h>
 
-#include <optional>
 #include <string>
 #include <string_view>
 
 class MockInputParameters : public rocprofiler_compute_tool::InputParameters
 {
 public:
-    std::optional<std::string_view> get_output_path() override;
-    std::optional<std::string_view> get_requested_counters() override;
-    std::optional<std::string_view> get_iteration_multiplexing_mode() override;
-    std::optional<std::string_view> get_kernel_filter_include_regex() override;
-    std::optional<std::string_view> get_kernel_filter_range() override;
+    std::string_view get_output_path() override;
+    std::string_view get_requested_counters() override;
+    std::string_view get_iteration_multiplexing_mode() override;
+    std::string_view get_kernel_filter_include_regex() override;
+    std::string_view get_kernel_filter_range() override;
 
     void set_output_path(const std::string& output_path);
     void set_requested_counters(const std::string& counters);

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_environ_cache.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_environ_cache.cpp
@@ -25,7 +25,7 @@ TEST_F(TestEnvironCache, Instance_ReturnsSameSingleton_AcrossCalls)
 
 TEST_F(TestEnvironCache, RocprofKeyInEnviron_ReturnsValue)
 {
-    Envp envp{{"ROCPROF_OUTPUT_PATH=/tmp/x"}};
+    Envp         envp{{"ROCPROF_OUTPUT_PATH=/tmp/x"}};
     EnvironCache cache{envp.data()};
     EXPECT_EQ(cache.get("ROCPROF_OUTPUT_PATH"),
               std::optional<std::string_view>{std::string_view{"/tmp/x"}});
@@ -33,40 +33,39 @@ TEST_F(TestEnvironCache, RocprofKeyInEnviron_ReturnsValue)
 
 TEST_F(TestEnvironCache, MissingRocprofKey_ReturnsNullopt)
 {
-    Envp envp{{}};
+    Envp         envp{{}};
     EnvironCache cache{envp.data()};
     EXPECT_EQ(cache.get("ROCPROF_OUTPUT_PATH"), std::nullopt);
 }
 
 TEST_F(TestEnvironCache, NonRocprofKeyInEnviron_NotCaptured)
 {
-    Envp envp{{"FOO=bar"}};
+    Envp         envp{{"FOO=bar"}};
     EnvironCache cache{envp.data()};
     EXPECT_EQ(cache.get("FOO"), std::nullopt);
 }
 
 TEST_F(TestEnvironCache, EmptyValueRocprofKey_ReturnsEmptyView)
 {
-    Envp envp{{"ROCPROF_OUTPUT_PATH="}};
+    Envp         envp{{"ROCPROF_OUTPUT_PATH="}};
     EnvironCache cache{envp.data()};
-    EXPECT_EQ(cache.get("ROCPROF_OUTPUT_PATH"),
-              std::optional<std::string_view>{std::string_view{}});
+    EXPECT_EQ(cache.get("ROCPROF_OUTPUT_PATH"), std::optional<std::string_view>{std::string_view{}});
 }
 
 TEST_F(TestEnvironCache, PrefixOnlyMatchInEnviron_ReturnsNullopt)
 {
-    Envp envp{{"ROCPROF_OUTPUT_PATH_EXTRA=junk"}};
+    Envp         envp{{"ROCPROF_OUTPUT_PATH_EXTRA=junk"}};
     EnvironCache cache{envp.data()};
     EXPECT_EQ(cache.get("ROCPROF_OUTPUT_PATH"), std::nullopt);
 }
 
 TEST_F(TestEnvironCache, MultipleRocprofKeys_AllCaptured)
 {
-    Envp envp{{"ROCPROF_OUTPUT_PATH=/tmp/p",
-               "ROCPROF_COUNTERS=SQ_WAVES",
-               "ROCPROF_ITERATION_MULTIPLEXING=kernel",
-               "ROCPROF_KERNEL_FILTER_INCLUDE_REGEX=.*conv.*",
-               "ROCPROF_KERNEL_FILTER_RANGE=1-5"}};
+    Envp         envp{{"ROCPROF_OUTPUT_PATH=/tmp/p",
+                       "ROCPROF_COUNTERS=SQ_WAVES",
+                       "ROCPROF_ITERATION_MULTIPLEXING=kernel",
+                       "ROCPROF_KERNEL_FILTER_INCLUDE_REGEX=.*conv.*",
+                       "ROCPROF_KERNEL_FILTER_RANGE=1-5"}};
     EnvironCache cache{envp.data()};
     EXPECT_EQ(cache.get("ROCPROF_OUTPUT_PATH"),
               std::optional<std::string_view>{std::string_view{"/tmp/p"}});
@@ -82,8 +81,7 @@ TEST_F(TestEnvironCache, MultipleRocprofKeys_AllCaptured)
 
 TEST_F(TestEnvironCache, DuplicateEnvironEntries_FirstWins)
 {
-    Envp envp{{"ROCPROF_OUTPUT_PATH=/tmp/first",
-               "ROCPROF_OUTPUT_PATH=/tmp/second"}};
+    Envp         envp{{"ROCPROF_OUTPUT_PATH=/tmp/first", "ROCPROF_OUTPUT_PATH=/tmp/second"}};
     EnvironCache cache{envp.data()};
     EXPECT_EQ(cache.get("ROCPROF_OUTPUT_PATH"),
               std::optional<std::string_view>{std::string_view{"/tmp/first"}});
@@ -91,11 +89,11 @@ TEST_F(TestEnvironCache, DuplicateEnvironEntries_FirstWins)
 
 TEST_F(TestEnvironCache, EnvInputParametersInjectedCache_ReturnsInjectedValues)
 {
-    Envp envp{{"ROCPROF_OUTPUT_PATH=/tmp/injected",
-               "ROCPROF_COUNTERS=SQ_WAVES",
-               "ROCPROF_ITERATION_MULTIPLEXING=kernel",
-               "ROCPROF_KERNEL_FILTER_INCLUDE_REGEX=.*gemm.*",
-               "ROCPROF_KERNEL_FILTER_RANGE=3-7"}};
+    Envp               envp{{"ROCPROF_OUTPUT_PATH=/tmp/injected",
+                             "ROCPROF_COUNTERS=SQ_WAVES",
+                             "ROCPROF_ITERATION_MULTIPLEXING=kernel",
+                             "ROCPROF_KERNEL_FILTER_INCLUDE_REGEX=.*gemm.*",
+                             "ROCPROF_KERNEL_FILTER_RANGE=3-7"}};
     EnvInputParameters input_parameters{std::make_shared<EnvironCache>(envp.data())};
 
     EXPECT_EQ(input_parameters.get_output_path(),

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_environ_cache.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_environ_cache.cpp
@@ -1,0 +1,111 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#include "test_environ_cache.h"
+
+#include "environ_cache.h"
+#include "input_parameters.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <optional>
+#include <string_view>
+
+using namespace rocprofiler_compute_tool;
+
+TEST_F(TestEnvironCache, Instance_ReturnsSameSingleton_AcrossCalls)
+{
+    const auto first  = EnvironCache::instance();
+    const auto second = EnvironCache::instance();
+
+    // Both calls must return the same instance; the singleton is constructed
+    // once at load time.
+    EXPECT_EQ(first.get(), second.get());
+}
+
+TEST_F(TestEnvironCache, RocprofKeyInEnviron_ReturnsValue)
+{
+    Envp envp{{"ROCPROF_OUTPUT_PATH=/tmp/x"}};
+    EnvironCache cache{envp.data()};
+    EXPECT_EQ(cache.get("ROCPROF_OUTPUT_PATH"),
+              std::optional<std::string_view>{std::string_view{"/tmp/x"}});
+}
+
+TEST_F(TestEnvironCache, MissingRocprofKey_ReturnsNullopt)
+{
+    Envp envp{{}};
+    EnvironCache cache{envp.data()};
+    EXPECT_EQ(cache.get("ROCPROF_OUTPUT_PATH"), std::nullopt);
+}
+
+TEST_F(TestEnvironCache, NonRocprofKeyInEnviron_NotCaptured)
+{
+    Envp envp{{"FOO=bar"}};
+    EnvironCache cache{envp.data()};
+    EXPECT_EQ(cache.get("FOO"), std::nullopt);
+}
+
+TEST_F(TestEnvironCache, EmptyValueRocprofKey_ReturnsEmptyView)
+{
+    Envp envp{{"ROCPROF_OUTPUT_PATH="}};
+    EnvironCache cache{envp.data()};
+    EXPECT_EQ(cache.get("ROCPROF_OUTPUT_PATH"),
+              std::optional<std::string_view>{std::string_view{}});
+}
+
+TEST_F(TestEnvironCache, PrefixOnlyMatchInEnviron_ReturnsNullopt)
+{
+    Envp envp{{"ROCPROF_OUTPUT_PATH_EXTRA=junk"}};
+    EnvironCache cache{envp.data()};
+    EXPECT_EQ(cache.get("ROCPROF_OUTPUT_PATH"), std::nullopt);
+}
+
+TEST_F(TestEnvironCache, MultipleRocprofKeys_AllCaptured)
+{
+    Envp envp{{"ROCPROF_OUTPUT_PATH=/tmp/p",
+               "ROCPROF_COUNTERS=SQ_WAVES",
+               "ROCPROF_ITERATION_MULTIPLEXING=kernel",
+               "ROCPROF_KERNEL_FILTER_INCLUDE_REGEX=.*conv.*",
+               "ROCPROF_KERNEL_FILTER_RANGE=1-5"}};
+    EnvironCache cache{envp.data()};
+    EXPECT_EQ(cache.get("ROCPROF_OUTPUT_PATH"),
+              std::optional<std::string_view>{std::string_view{"/tmp/p"}});
+    EXPECT_EQ(cache.get("ROCPROF_COUNTERS"),
+              std::optional<std::string_view>{std::string_view{"SQ_WAVES"}});
+    EXPECT_EQ(cache.get("ROCPROF_ITERATION_MULTIPLEXING"),
+              std::optional<std::string_view>{std::string_view{"kernel"}});
+    EXPECT_EQ(cache.get("ROCPROF_KERNEL_FILTER_INCLUDE_REGEX"),
+              std::optional<std::string_view>{std::string_view{".*conv.*"}});
+    EXPECT_EQ(cache.get("ROCPROF_KERNEL_FILTER_RANGE"),
+              std::optional<std::string_view>{std::string_view{"1-5"}});
+}
+
+TEST_F(TestEnvironCache, DuplicateEnvironEntries_FirstWins)
+{
+    Envp envp{{"ROCPROF_OUTPUT_PATH=/tmp/first",
+               "ROCPROF_OUTPUT_PATH=/tmp/second"}};
+    EnvironCache cache{envp.data()};
+    EXPECT_EQ(cache.get("ROCPROF_OUTPUT_PATH"),
+              std::optional<std::string_view>{std::string_view{"/tmp/first"}});
+}
+
+TEST_F(TestEnvironCache, EnvInputParametersInjectedCache_ReturnsInjectedValues)
+{
+    Envp envp{{"ROCPROF_OUTPUT_PATH=/tmp/injected",
+               "ROCPROF_COUNTERS=SQ_WAVES",
+               "ROCPROF_ITERATION_MULTIPLEXING=kernel",
+               "ROCPROF_KERNEL_FILTER_INCLUDE_REGEX=.*gemm.*",
+               "ROCPROF_KERNEL_FILTER_RANGE=3-7"}};
+    EnvInputParameters input_parameters{std::make_shared<EnvironCache>(envp.data())};
+
+    EXPECT_EQ(input_parameters.get_output_path(),
+              std::optional<std::string_view>{std::string_view{"/tmp/injected"}});
+    EXPECT_EQ(input_parameters.get_requested_counters(),
+              std::optional<std::string_view>{std::string_view{"SQ_WAVES"}});
+    EXPECT_EQ(input_parameters.get_iteration_multiplexing_mode(),
+              std::optional<std::string_view>{std::string_view{"kernel"}});
+    EXPECT_EQ(input_parameters.get_kernel_filter_include_regex(),
+              std::optional<std::string_view>{std::string_view{".*gemm.*"}});
+    EXPECT_EQ(input_parameters.get_kernel_filter_range(),
+              std::optional<std::string_view>{std::string_view{"3-7"}});
+}

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_environ_cache.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_environ_cache.cpp
@@ -96,14 +96,9 @@ TEST_F(TestEnvironCache, EnvInputParametersInjectedCache_ReturnsInjectedValues)
                              "ROCPROF_KERNEL_FILTER_RANGE=3-7"}};
     EnvInputParameters input_parameters{std::make_shared<EnvironCache>(envp.data())};
 
-    EXPECT_EQ(input_parameters.get_output_path(),
-              std::optional<std::string_view>{std::string_view{"/tmp/injected"}});
-    EXPECT_EQ(input_parameters.get_requested_counters(),
-              std::optional<std::string_view>{std::string_view{"SQ_WAVES"}});
-    EXPECT_EQ(input_parameters.get_iteration_multiplexing_mode(),
-              std::optional<std::string_view>{std::string_view{"kernel"}});
-    EXPECT_EQ(input_parameters.get_kernel_filter_include_regex(),
-              std::optional<std::string_view>{std::string_view{".*gemm.*"}});
-    EXPECT_EQ(input_parameters.get_kernel_filter_range(),
-              std::optional<std::string_view>{std::string_view{"3-7"}});
+    EXPECT_EQ(input_parameters.get_output_path(), std::string_view{"/tmp/injected"});
+    EXPECT_EQ(input_parameters.get_requested_counters(), std::string_view{"SQ_WAVES"});
+    EXPECT_EQ(input_parameters.get_iteration_multiplexing_mode(), std::string_view{"kernel"});
+    EXPECT_EQ(input_parameters.get_kernel_filter_include_regex(), std::string_view{".*gemm.*"});
+    EXPECT_EQ(input_parameters.get_kernel_filter_range(), std::string_view{"3-7"});
 }

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_environ_cache.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_environ_cache.h
@@ -1,0 +1,45 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+class TestEnvironCache : public ::testing::Test
+{
+protected:
+    // Owns the storage backing a NULL-terminated char** envp.
+    // Non-copyable and non-movable: tests must declare it as a named local
+    // so the validity scope of data() is explicit.
+    class Envp
+    {
+    public:
+        explicit Envp(const std::vector<std::string>& entries)
+        {
+            m_owned.reserve(entries.size());
+            m_pointers.reserve(entries.size() + 1);
+
+            for (const auto& entry : entries)
+            {
+                m_owned.emplace_back(entry.begin(), entry.end());
+                m_owned.back().push_back('\0');
+                m_pointers.push_back(m_owned.back().data());
+            }
+
+            m_pointers.push_back(nullptr);
+        }
+
+        Envp(const Envp&)            = delete;
+        Envp& operator=(const Envp&) = delete;
+        Envp(Envp&&)                 = delete;
+        Envp& operator=(Envp&&)      = delete;
+
+        char** data() { return m_pointers.data(); }
+
+    private:
+        std::vector<std::vector<char>> m_owned;
+        std::vector<char*>             m_pointers;
+    };
+};

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
@@ -45,6 +45,53 @@ TEST_F(TestRocprofilerComputeTool, ProvidedEmptyKernelFilterRange_DoesntThrow)
     EXPECT_NO_THROW(rocprofiler_configure(1, "", 1, &m_client_id));
 }
 
+TEST_F(TestRocprofilerComputeTool, ProvidedUnsetOutputPath_UsesDefault)
+{
+    m_input_parameters->unset_output_path();
+    EXPECT_NO_THROW(rocprofiler_configure(1, "", 1, &m_client_id));
+    const auto cfg       = rocprofiler_configure(1, "", 1, &m_client_id);
+    const auto tool_data = get_tool_data(cfg);
+    EXPECT_TRUE(tool_data->output_filename.find(EnvInputParameters::get_default_output_path()) !=
+                std::string::npos);
+    EXPECT_TRUE(tool_data->output_filename.find(
+                    std::to_string(getpid()) + "_native_counter_collection.csv") != std::string::npos);
+}
+
+TEST_F(TestRocprofilerComputeTool, ProvidedUnsetRequestedCounters_UsesDefault)
+{
+    m_input_parameters->unset_requested_counters();
+    const auto cfg       = rocprofiler_configure(1, "", 1, &m_client_id);
+    const auto tool_data = get_tool_data(cfg);
+    EXPECT_EQ(tool_data->requested_counters, EnvInputParameters::get_default_requested_counters());
+}
+
+TEST_F(TestRocprofilerComputeTool, ProvidedUnsetIterationMultiplexingMode_UsesDefault)
+{
+    m_input_parameters->unset_iteration_multiplexing_mode();
+    const auto cfg       = rocprofiler_configure(1, "", 1, &m_client_id);
+    const auto tool_data = get_tool_data(cfg);
+    EXPECT_EQ(tool_data->iteration_multiplexing_mode,
+              iteration_multiplexing_mode(EnvInputParameters::get_default_iteration_multiplexing_mode()));
+}
+
+TEST_F(TestRocprofilerComputeTool, ProvidedUnsetKernelFilterIncludeRegex_UsesDefault)
+{
+    m_input_parameters->unset_kernel_filter_include_regex();
+    const auto cfg       = rocprofiler_configure(1, "", 1, &m_client_id);
+    const auto tool_data = get_tool_data(cfg);
+    EXPECT_EQ(tool_data->kernel_filter_include_regex,
+              EnvInputParameters::get_default_kernel_filter_include_regex());
+}
+
+TEST_F(TestRocprofilerComputeTool, ProvidedUnsetKernelFilterRange_UsesDefault)
+{
+    m_input_parameters->unset_kernel_filter_range();
+    const auto cfg       = rocprofiler_configure(1, "", 1, &m_client_id);
+    const auto tool_data = get_tool_data(cfg);
+    EXPECT_TRUE(EnvInputParameters::get_default_kernel_filter_range().empty());
+    EXPECT_TRUE(tool_data->kernel_filter_ranges.empty());
+}
+
 TEST_F(TestRocprofilerComputeTool, ProvidedNonEmptyOutputPath_ReturnsItExtended)
 {
     const auto cfg       = rocprofiler_configure(1, "", 1, &m_client_id);

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
@@ -43,7 +43,7 @@ TEST_F(TestRocprofilerComputeTool, ProvidedNonEmptyOutputPath_ReturnsItExtended)
 {
     const auto cfg       = rocprofiler_configure(1, "", 1, &m_client_id);
     const auto tool_data = get_tool_data(cfg);
-    EXPECT_TRUE(tool_data->output_filename.find(m_input_parameters->get_output_path()) !=
+    EXPECT_TRUE(tool_data->output_filename.find(*m_input_parameters->get_output_path()) !=
                 std::string::npos);
     EXPECT_TRUE(tool_data->output_filename.find(
                     std::to_string(getpid()) + "_native_counter_collection.csv") != std::string::npos);
@@ -53,7 +53,7 @@ TEST_F(TestRocprofilerComputeTool, ProvidedRequestedCounters_ReturnsIt)
 {
     const auto cfg       = rocprofiler_configure(1, "", 1, &m_client_id);
     const auto tool_data = get_tool_data(cfg);
-    EXPECT_EQ(tool_data->requested_counters, m_input_parameters->get_requested_counters());
+    EXPECT_EQ(tool_data->requested_counters, *m_input_parameters->get_requested_counters());
 }
 
 TEST_F(TestRocprofilerComputeTool, ProvidedIncorrectIterationMultiplexingMode_ReturnsDisabled)
@@ -85,7 +85,7 @@ TEST_F(TestRocprofilerComputeTool, ProvidedKernelFilterIncludeRegex_ReturnsIt)
     const auto cfg       = rocprofiler_configure(1, "", 1, &m_client_id);
     const auto tool_data = get_tool_data(cfg);
     EXPECT_EQ(tool_data->kernel_filter_include_regex,
-              m_input_parameters->get_kernel_filter_include_regex());
+              *m_input_parameters->get_kernel_filter_include_regex());
 }
 
 TEST_F(TestRocprofilerComputeTool, ProvidedIncorrectKernelFilterRange_ReturnsEmpty)

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
@@ -96,7 +96,7 @@ TEST_F(TestRocprofilerComputeTool, ProvidedNonEmptyOutputPath_ReturnsItExtended)
 {
     const auto cfg       = rocprofiler_configure(1, "", 1, &m_client_id);
     const auto tool_data = get_tool_data(cfg);
-    EXPECT_TRUE(tool_data->output_filename.find(*m_input_parameters->get_output_path()) !=
+    EXPECT_TRUE(tool_data->output_filename.find(m_input_parameters->get_output_path()) !=
                 std::string::npos);
     EXPECT_TRUE(tool_data->output_filename.find(
                     std::to_string(getpid()) + "_native_counter_collection.csv") != std::string::npos);
@@ -106,7 +106,7 @@ TEST_F(TestRocprofilerComputeTool, ProvidedRequestedCounters_ReturnsIt)
 {
     const auto cfg       = rocprofiler_configure(1, "", 1, &m_client_id);
     const auto tool_data = get_tool_data(cfg);
-    EXPECT_EQ(tool_data->requested_counters, *m_input_parameters->get_requested_counters());
+    EXPECT_EQ(tool_data->requested_counters, m_input_parameters->get_requested_counters());
 }
 
 TEST_F(TestRocprofilerComputeTool, ProvidedIncorrectIterationMultiplexingMode_ReturnsDisabled)
@@ -138,7 +138,7 @@ TEST_F(TestRocprofilerComputeTool, ProvidedKernelFilterIncludeRegex_ReturnsIt)
     const auto cfg       = rocprofiler_configure(1, "", 1, &m_client_id);
     const auto tool_data = get_tool_data(cfg);
     EXPECT_EQ(tool_data->kernel_filter_include_regex,
-              *m_input_parameters->get_kernel_filter_include_regex());
+              m_input_parameters->get_kernel_filter_include_regex());
 }
 
 TEST_F(TestRocprofilerComputeTool, ProvidedIncorrectKernelFilterRange_ReturnsEmpty)

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
@@ -9,10 +9,16 @@
 
 using namespace rocprofiler_compute_tool;
 
-TEST_F(TestRocprofilerComputeTool, ProvidedEmptyOutputPath_Throws)
+TEST_F(TestRocprofilerComputeTool, ProvidedEmptyOutputPath_UsesDefault)
 {
     m_input_parameters->set_output_path("");
-    EXPECT_THROW(rocprofiler_configure(1, "", 1, &m_client_id), std::runtime_error);
+    EXPECT_NO_THROW(rocprofiler_configure(1, "", 1, &m_client_id));
+    const auto cfg       = rocprofiler_configure(1, "", 1, &m_client_id);
+    const auto tool_data = get_tool_data(cfg);
+    EXPECT_TRUE(tool_data->output_filename.find(EnvInputParameters::get_default_output_path()) !=
+                std::string::npos);
+    EXPECT_TRUE(tool_data->output_filename.find(
+                    std::to_string(getpid()) + "_native_counter_collection.csv") != std::string::npos);
 }
 
 TEST_F(TestRocprofilerComputeTool, ProvidedNoRequestedCounters_Throws)

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
@@ -15,7 +15,7 @@ TEST_F(TestRocprofilerComputeTool, ProvidedEmptyOutputPath_UsesDefault)
     EXPECT_NO_THROW(rocprofiler_configure(1, "", 1, &m_client_id));
     const auto cfg       = rocprofiler_configure(1, "", 1, &m_client_id);
     const auto tool_data = get_tool_data(cfg);
-    EXPECT_TRUE(tool_data->output_filename.find(EnvInputParameters::get_default_output_path()) !=
+    EXPECT_TRUE(tool_data->output_filename.find(EnvInputParameters::kDefaultOutputPath) !=
                 std::string::npos);
     EXPECT_TRUE(tool_data->output_filename.find(
                     std::to_string(getpid()) + "_native_counter_collection.csv") != std::string::npos);
@@ -51,7 +51,7 @@ TEST_F(TestRocprofilerComputeTool, ProvidedUnsetOutputPath_UsesDefault)
     EXPECT_NO_THROW(rocprofiler_configure(1, "", 1, &m_client_id));
     const auto cfg       = rocprofiler_configure(1, "", 1, &m_client_id);
     const auto tool_data = get_tool_data(cfg);
-    EXPECT_TRUE(tool_data->output_filename.find(EnvInputParameters::get_default_output_path()) !=
+    EXPECT_TRUE(tool_data->output_filename.find(EnvInputParameters::kDefaultOutputPath) !=
                 std::string::npos);
     EXPECT_TRUE(tool_data->output_filename.find(
                     std::to_string(getpid()) + "_native_counter_collection.csv") != std::string::npos);
@@ -62,7 +62,7 @@ TEST_F(TestRocprofilerComputeTool, ProvidedUnsetRequestedCounters_UsesDefault)
     m_input_parameters->unset_requested_counters();
     const auto cfg       = rocprofiler_configure(1, "", 1, &m_client_id);
     const auto tool_data = get_tool_data(cfg);
-    EXPECT_EQ(tool_data->requested_counters, EnvInputParameters::get_default_requested_counters());
+    EXPECT_EQ(tool_data->requested_counters, EnvInputParameters::kDefaultRequestedCounters);
 }
 
 TEST_F(TestRocprofilerComputeTool, ProvidedUnsetIterationMultiplexingMode_UsesDefault)
@@ -71,7 +71,7 @@ TEST_F(TestRocprofilerComputeTool, ProvidedUnsetIterationMultiplexingMode_UsesDe
     const auto cfg       = rocprofiler_configure(1, "", 1, &m_client_id);
     const auto tool_data = get_tool_data(cfg);
     EXPECT_EQ(tool_data->iteration_multiplexing_mode,
-              iteration_multiplexing_mode(EnvInputParameters::get_default_iteration_multiplexing_mode()));
+              iteration_multiplexing_mode(EnvInputParameters::kDefaultIterationMultiplexingMode));
 }
 
 TEST_F(TestRocprofilerComputeTool, ProvidedUnsetKernelFilterIncludeRegex_UsesDefault)
@@ -80,7 +80,7 @@ TEST_F(TestRocprofilerComputeTool, ProvidedUnsetKernelFilterIncludeRegex_UsesDef
     const auto cfg       = rocprofiler_configure(1, "", 1, &m_client_id);
     const auto tool_data = get_tool_data(cfg);
     EXPECT_EQ(tool_data->kernel_filter_include_regex,
-              EnvInputParameters::get_default_kernel_filter_include_regex());
+              EnvInputParameters::kDefaultKernelFilterIncludeRegex);
 }
 
 TEST_F(TestRocprofilerComputeTool, ProvidedUnsetKernelFilterRange_UsesDefault)
@@ -88,7 +88,7 @@ TEST_F(TestRocprofilerComputeTool, ProvidedUnsetKernelFilterRange_UsesDefault)
     m_input_parameters->unset_kernel_filter_range();
     const auto cfg       = rocprofiler_configure(1, "", 1, &m_client_id);
     const auto tool_data = get_tool_data(cfg);
-    EXPECT_TRUE(EnvInputParameters::get_default_kernel_filter_range().empty());
+    EXPECT_TRUE(EnvInputParameters::kDefaultKernelFilterRange.empty());
     EXPECT_TRUE(tool_data->kernel_filter_ranges.empty());
 }
 


### PR DESCRIPTION
## Motivation

When `ROCPROF_OUTPUT_PATH` was unset or empty, the collector aborted profiling. That is too aggressive — the tool should fall back to a documented default so profiling proceeds, matching how the rocprofiler-SDK tool behaves. The same silent-default policy is extended to the other `ROCPROF_*` input vars for consistency. In the same spirit of hardening env-var handling, the collector reads `ROCPROF_*` variables directly from `extern char **environ` at startup so lookups are not affected by `LD_PRELOAD` shims that override libc `getenv`.

## Technical Details

- `EnvInputParameters` centralizes the unset/empty → default policy in a `get(env_var, default)` helper. When a `ROCPROF_*` var is unset or empty, the getter returns the documented default. Covers `ROCPROF_OUTPUT_PATH` (defaults to `./`), `ROCPROF_COUNTERS`, `ROCPROF_ITERATION_MULTIPLEXING`, `ROCPROF_KERNEL_FILTER_INCLUDE_REGEX`, and `ROCPROF_KERNEL_FILTER_RANGE`. Defaults are exposed as `public static constexpr` `kDefault*` constants on `EnvInputParameters` so callers and tests reference a single canonical spelling.
- New `environ_cache.{h,cpp}` walks `extern char **environ` once at startup and stores every `ROCPROF_*` name/value pair, so lookups do not go through libc `getenv` and are unaffected by `LD_PRELOAD` shims that intercept it.
- `MockInputParameters` mirrors the production contract.
- Tests: new `TestEnvironCache` suite (singleton identity, prefix matching, missing/empty keys, multi-key capture, DI into `EnvInputParameters`); five `ProvidedUnset*_UsesDefault` cases in `test_rocprofiler_compute_tool` exercise the silent-default path per env var.
- `CHANGELOG.md` records the fix under Resolved issues.

## JIRA ID

ROCM-21212

## Test Plan

- [x] Run `test_rocprofiler_compute_tool` — exercises the new `TestEnvironCache` suite and the five `ProvidedUnset*_UsesDefault` cases.
- [x] Reproduce the original shell-script failure (`rocprof-compute profile -o /tmp/out -- bash run.sh`) against a build with a `getenv`-overriding shim; confirm the collector no longer aborts.

## Test Result

- [x] 52/52 cases in `test_rocprofiler_compute_tool` pass, including the new `TestEnvironCache` suite and the `ProvidedUnset*_UsesDefault` cases.
- [x] Shell-script profiling repro completes end-to-end with the expected output files; collector no longer aborts.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
